### PR TITLE
Modify log to add ngx.var.uri in request object

### DIFF
--- a/kong/plugins/log-serializers/basic.lua
+++ b/kong/plugins/log-serializers/basic.lua
@@ -12,11 +12,12 @@ function _M.serialize(ngx)
       consumer_id = ngx.ctx.authenticated_credential.consumer_id
     }
   end
-  
+
   return {
     request = {
-      uri = ngx.var.request_uri,
-      request_uri = ngx.var.scheme .. "://" .. ngx.var.host .. ":" .. ngx.var.server_port .. ngx.var.request_uri,
+      request_uri = ngx.var.request_uri,
+      upstream_uri = ngx.var.upstream_uri,
+      request_url = ngx.var.scheme .. "://" .. ngx.var.host .. ":" .. ngx.var.server_port .. ngx.var.request_uri,
       querystring = ngx.req.get_uri_args(), -- parameters, as a table
       method = ngx.req.get_method(), -- http method
       headers = ngx.req.get_headers(),
@@ -31,7 +32,7 @@ function _M.serialize(ngx)
     latencies = {
       kong = (ngx.ctx.KONG_ACCESS_TIME or 0) +
              (ngx.ctx.KONG_RECEIVE_TIME or 0) +
-             (ngx.ctx.KONG_REWRITE_TIME or 0) + 
+             (ngx.ctx.KONG_REWRITE_TIME or 0) +
              (ngx.ctx.KONG_BALANCER_TIME or 0),
       proxy = ngx.ctx.KONG_WAITING_TIME or -1,
       request = ngx.var.request_time * 1000

--- a/spec/01-unit/012-log_serializer_spec.lua
+++ b/spec/01-unit/012-log_serializer_spec.lua
@@ -8,7 +8,7 @@ describe("Log Serializer", function()
       ctx = {
         balancer_address = {
           tries = {
-            { 
+            {
               ip = "127.0.0.1",
               port = 8000,
             },
@@ -17,6 +17,7 @@ describe("Log Serializer", function()
       },
       var = {
         request_uri = "/request_uri",
+        upstream_uri = "/upstream_uri",
         scheme = "http",
         host = "test.com",
         server_port = 80,
@@ -57,9 +58,10 @@ describe("Log Serializer", function()
       assert.same({"header1", "header2"}, res.request.headers)
       assert.equal("POST", res.request.method)
       assert.same({"arg1", "arg2"}, res.request.querystring)
-      assert.equal("http://test.com:80/request_uri", res.request.request_uri)
+      assert.equal("http://test.com:80/request_uri", res.request.request_url)
+      assert.equal("/upstream_uri", res.request.upstream_uri)
       assert.equal(200, res.request.size)
-      assert.equal("/request_uri", res.request.uri)
+      assert.equal("/request_uri", res.request.request_uri)
 
       -- Response
       assert.is_table(res.response)
@@ -97,7 +99,7 @@ describe("Log Serializer", function()
     end)
 
     it("serializes the Authenticated Entity object", function()
-      ngx.ctx.authenticated_credential = {id = "somecred", 
+      ngx.ctx.authenticated_credential = {id = "somecred",
                                           consumer_id = "user1"}
 
       local res = basic.serialize(ngx)


### PR DESCRIPTION
### Summary

`ngx.var.request_uri` is the original uri and is not updated if the uri is changed using `ngx.set_uri(newUri)`. Instead, `ngx.var.uri` reflects the new uri. Added a new field to reflect the modified uri.

### Full changelog

* Use the same name as the Nginx variables in request object of logs
* Rename `request_uri` to `request_url`
* New unit test

### Issues resolved

Fix #2441 
