### PR TITLE
add extend points in nginx/kong conf templates

### DIFF
--- a/kong/templates/nginx.lua
+++ b/kong/templates/nginx.lua
@@ -21,5 +21,6 @@ events {
 
 http {
     include 'nginx-kong.conf';
+    include 'conf.d/nginx_*.conf';
 }
 ]]

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -150,6 +150,8 @@ server {
             kong.handle_error()
         }
     }
+
+    include 'conf.d/kong_*.conf';
 }
 
 server {
@@ -190,5 +192,7 @@ server {
     location /robots.txt {
         return 200 'User-agent: *\nDisallow: /';
     }
+
+    include 'conf.d/admin_*.conf';
 }
 ]]


### PR DESCRIPTION
### Summary

Add three extendsion points in nginx configuration template so that user can put their extend configuration in their own directory instead of update the template file in system library.

### Full changelog

* kong/templates/nginx.lua
* kong/templates/nginx_kong.lua

