### PR TITLE
added LDAPS support in auth-ldap plugin

### DIFF
--- a/kong/plugins/ldap-auth/access.lua
+++ b/kong/plugins/ldap-auth/access.lua
@@ -45,6 +45,14 @@ local function ldap_authenticate(given_username, given_password, conf)
     return nil, err, responses.status_codes.HTTP_INTERNAL_SERVER_ERROR
   end
 
+  if conf.ldaps then
+    local _, err = sock:sslhandshake(true, conf.ldap_host, conf.verify_ldap_host)
+    if err ~= nil then
+      return false, "failed to do SSL handshake with "..conf.ldap_host..":"..tostring(conf.ldap_port)..": ".. err
+    end
+  end
+
+
   if conf.start_tls then
     local success, err = ldap.start_tls(sock)
     if not success then

--- a/kong/plugins/ldap-auth/schema.lua
+++ b/kong/plugins/ldap-auth/schema.lua
@@ -1,4 +1,5 @@
 local utils = require "kong.tools.utils"
+local Errors = require "kong.dao.errors"
 
 local function check_user(anonymous)
   if anonymous == "" or utils.is_valid_uuid(anonymous) then
@@ -14,6 +15,7 @@ return {
     ldap_host = {required = true, type = "string"},
     ldap_port = {required = true, type = "number"},
     start_tls = {required = true, type = "boolean", default = false},
+    ldaps = {required = true, type = "boolean", default = false},
     verify_ldap_host = {required = true, type = "boolean", default = false},
     base_dn = {required = true, type = "string"},
     attribute = {required = true, type = "string"},
@@ -22,5 +24,13 @@ return {
     timeout = {type = "number", default = 10000},
     keepalive = {type = "number", default = 60000},
     anonymous = {type = "string", default = "", func = check_user},
-  }
+  },
+  self_check = function(schema, plugin_t, dao, is_update)
+    if plugin_t.ldaps and plugin_t.start_tls then
+       return false, Errors.schema "LDAPS and StartTLS cannot be enabled simultaneously. You need to enable only one of the two."
+    end
+    return true
+  end
 }
+
+

--- a/spec/03-plugins/21-ldap-auth/02-schema_spec.lua
+++ b/spec/03-plugins/21-ldap-auth/02-schema_spec.lua
@@ -1,0 +1,14 @@
+local validate_entity = require("kong.dao.schemas_validation").validate_entity
+local ldap_auth_schema = require "kong.plugins.ldap-auth.schema"
+
+describe("Plugin: ldap-auth (schema)", function()
+  describe("errors", function()
+    it("requires ldaps and start_tls to be mutually exclusive", function()
+      local ok, errors, err = validate_entity({ldap_host = "none", ldap_port = "389", ldaps = true, start_tls = true, base_dn="ou=users", attribute="cn"}, ldap_auth_schema)
+      assert.False(ok)
+      assert.equal("LDAPS and StartTLS cannot be enabled simultaneously. You need to enable only one of the two.", tostring(err))
+    end)
+  end)
+end)
+
+


### PR DESCRIPTION

### Summary

This PR adds an option for LDAPS support (ie LDAP over SSL) to the ldap connection.  This addresses the request for LDAPS in issue (https://github.com/Mashape/kong/issues/1393)

### Full changelog

* Added boolean configuration schema option for LDAPS in ldap-auth plugin
* Added connection code to handle the new configuration option
* ...

### Issues resolved

Addresses the feature requests buried in #1393 
