### PR TITLE
Make OAuth 2.0 redirect URIs regexes.

### DIFF
--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -165,9 +165,10 @@ local function authorize(conf)
 
       if not allowed_redirect_uris then
         response_params = {[ERROR] = "invalid_client", error_description = "Invalid client authentication" }
+
       else
-        -- Since default redirect URIs are now patterns, it's not safe to use them directly before the
-        -- comparison below  as before. Instead, if one is not supplied, just use the one registered with
+        -- Since default redirect URIs are now patterns, it's not safe to use them directly in the
+        -- comparison below. Instead, if one is not supplied, just use the one registered with
         -- the application. In either case, we should try to remove the start/end of string characters.
         -- This is pretty hacky, perhaps a "default redirect URI" option should be provided instead.
         redirect_uri = parameters[REDIRECT_URI]
@@ -178,6 +179,7 @@ local function authorize(conf)
             -- redirect_uri used in this case is the first one registered with the application
             redirect_uri = string.gsub(allowed_redirect_uris[1],"[%^%$]","")
           end
+
         else
           redirect_uri = string.gsub(allowed_redirect_uris[1],"[%^%$]","")
         end
@@ -286,7 +288,6 @@ local function issue_token(conf)
   if not is_https then
     response_params = {[ERROR] = "access_denied", error_description = err or "You must use HTTPS"}
   else
-    
     local grant_type = parameters[GRANT_TYPE]
     if not (grant_type == GRANT_AUTHORIZATION_CODE or
             grant_type == GRANT_REFRESH_TOKEN or
@@ -305,7 +306,6 @@ local function issue_token(conf)
         invalid_client_properties = { status = 401, www_authenticate = "Basic realm=\"OAuth2.0\""}
       end
     else
-      
       -- Since default redirect URIs are now patterns, it's not safe to use them directly before the
       -- comparison below  as before. Instead, if one is not supplied, don't do the comparison
       local redirect_uri = parameters[REDIRECT_URI]

--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -166,12 +166,20 @@ local function authorize(conf)
       if not allowed_redirect_uris then
         response_params = {[ERROR] = "invalid_client", error_description = "Invalid client authentication" }
       else
-        redirect_uri = parameters[REDIRECT_URI] and parameters[REDIRECT_URI] or allowed_redirect_uris[1]
+        -- Since default redirect URIs are now patterns, it's not safe to use them directly before the
+        -- comparison below  as before. Instead, if one is not supplied, just use the one registered with
+        -- the application. In either case, we should try to remove the start/end of string characters.
+        -- This is pretty hacky, perhaps a "default redirect URI" option should be provided instead.
+        redirect_uri = parameters[REDIRECT_URI]
 
-        if not utils.table_contains(allowed_redirect_uris, redirect_uri) then
-          response_params = {[ERROR] = "invalid_request", error_description = "Invalid " .. REDIRECT_URI .. " that does not match with any redirect_uri created with the application" }
-          -- redirect_uri used in this case is the first one registered with the application
-          redirect_uri = allowed_redirect_uris[1]
+        if redirect_uri then
+          if not utils.table_contains_regex(allowed_redirect_uris, redirect_uri) then
+            response_params = {[ERROR] = "invalid_request", error_description = "Invalid " .. REDIRECT_URI .. " that does not match with any redirect_uri created with the application" }
+            -- redirect_uri used in this case is the first one registered with the application
+            redirect_uri = string.gsub(allowed_redirect_uris[1],"[%^%$]","")
+          end
+        else
+          redirect_uri = string.gsub(allowed_redirect_uris[1],"[%^%$]","")
         end
       end
 
@@ -297,7 +305,7 @@ local function issue_token(conf)
       end
     else
       local redirect_uri = parameters[REDIRECT_URI] and parameters[REDIRECT_URI] or allowed_redirect_uris[1]
-      if not utils.table_contains(allowed_redirect_uris, redirect_uri) then
+      if not utils.table_contains_regex(allowed_redirect_uris, redirect_uri) then
         response_params = {[ERROR] = "invalid_request", error_description = "Invalid " .. REDIRECT_URI .. " that does not match with any redirect_uri created with the application" }
       end
     end

--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -286,6 +286,7 @@ local function issue_token(conf)
   if not is_https then
     response_params = {[ERROR] = "access_denied", error_description = err or "You must use HTTPS"}
   else
+    
     local grant_type = parameters[GRANT_TYPE]
     if not (grant_type == GRANT_AUTHORIZATION_CODE or
             grant_type == GRANT_REFRESH_TOKEN or
@@ -304,8 +305,11 @@ local function issue_token(conf)
         invalid_client_properties = { status = 401, www_authenticate = "Basic realm=\"OAuth2.0\""}
       end
     else
-      local redirect_uri = parameters[REDIRECT_URI] and parameters[REDIRECT_URI] or allowed_redirect_uris[1]
-      if not utils.table_contains_regex(allowed_redirect_uris, redirect_uri) then
+      
+      -- Since default redirect URIs are now patterns, it's not safe to use them directly before the
+      -- comparison below  as before. Instead, if one is not supplied, don't do the comparison
+      local redirect_uri = parameters[REDIRECT_URI]
+      if redirect_uri and not utils.table_contains_regex(allowed_redirect_uris, redirect_uri) then
         response_params = {[ERROR] = "invalid_request", error_description = "Invalid " .. REDIRECT_URI .. " that does not match with any redirect_uri created with the application" }
       end
     end

--- a/kong/plugins/oauth2/daos.lua
+++ b/kong/plugins/oauth2/daos.lua
@@ -1,5 +1,4 @@
 local utils = require "kong.tools.utils"
-local url = require "socket.url"
 
 local function validate_uris(v, t, column)
   if v then

--- a/kong/plugins/oauth2/daos.lua
+++ b/kong/plugins/oauth2/daos.lua
@@ -7,11 +7,7 @@ local function validate_uris(v, t, column)
       return false, "at least one URI is required"
     end
     for _, uri in ipairs(v) do
-      local parsed_uri = url.parse(uri)
-      if not (parsed_uri and parsed_uri.host and parsed_uri.scheme) then
-        return false, "cannot parse '" .. uri .. "'"
-      end
-      if parsed_uri.fragment ~= nil then
+      if string.find(uri, '#') ~= nil then
         return false, "fragment not allowed in '" .. uri .. "'"
       end
     end

--- a/kong/plugins/oauth2/migrations/cassandra.lua
+++ b/kong/plugins/oauth2/migrations/cassandra.lua
@@ -189,5 +189,29 @@ return {
       end
     end,
     down = function(_, _, dao) end  -- not implemented
+  },
+  {
+    name = "2017-7-27-convert_redirect_uri_to_pattern",
+    up = function(_, _, factory)
+      local schema = factory.oauth2_credentials.schema
+
+      local rows, err = factory.oauth2_credentials.db:find_all("oauth2_credentials", nil, schema)
+      if err then
+        return err
+      end
+
+      for _, row in ipairs(rows) do
+        local converted = {}
+        for _, uri in ipairs(row.redirect_uri) do
+          converted[_] = "^" .. uri .. "$"
+        end
+
+        local _, err = factory.oauth2_credentials.db:update("oauth2_credentials", schema, nil, {id = row.id}, {redirect_uri = converted})
+        if err then
+          return err
+        end
+      end
+    end,
+    down = function(_, _, dao) end  -- not implemented
   }
 }

--- a/kong/plugins/oauth2/migrations/postgres.lua
+++ b/kong/plugins/oauth2/migrations/postgres.lua
@@ -213,10 +213,11 @@ return {
         return err
       end
 
-      for _, row in ipairs(rows) do
+      for i = 1, #rows do
         local converted = {}
-        for _, uri in ipairs(row.redirect_uri) do
-          converted[_] = "^" .. uri .. "$"
+        local row = rows[i]
+        for j = 1, #row.redirect_uri do
+          converted[j] = "^" .. row.redirect_uri[j] .. "$"
         end
 
         local _, err = factory.oauth2_credentials.db:update("oauth2_credentials", schema, nil, {id = row.id}, {redirect_uri = converted})

--- a/kong/plugins/oauth2/migrations/postgres.lua
+++ b/kong/plugins/oauth2/migrations/postgres.lua
@@ -202,5 +202,29 @@ return {
       end
     end,
     down = function(_, _, dao) end  -- not implemented
+  },
+  {
+    name = "2017-7-27-convert_redirect_uri_to_pattern",
+    up = function(_, _, factory)
+      local schema = factory.oauth2_credentials.schema
+
+      local rows, err = factory.oauth2_credentials.db:find_all("oauth2_credentials", nil, schema)
+      if err then
+        return err
+      end
+
+      for _, row in ipairs(rows) do
+        local converted = {}
+        for _, uri in ipairs(row.redirect_uri) do
+          converted[_] = "^" .. uri .. "$"
+        end
+
+        local _, err = factory.oauth2_credentials.db:update("oauth2_credentials", schema, nil, {id = row.id}, {redirect_uri = converted})
+        if err then
+          return err
+        end
+      end
+    end,
+    down = function(_, _, dao) end  -- not implemented
   }
 }

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -372,6 +372,21 @@ function _M.table_contains(arr, val)
   return false
 end
 
+--- Check if any regex in a table matches a value
+-- @param arr The table to use
+-- @param pat The value to check
+-- @return Returns `true` if the table contains a regex matching the value, `false` otherwise
+function _M.table_contains_regex(arr, val)
+  if arr then
+    for _, p in pairs(arr) do
+      if ngx.re.match(val, p) then
+        return true
+      end
+    end
+  end
+  return false
+end
+
 --- Checks if a table is an array and not an associative array.
 -- *** NOTE *** string-keys containing integers are considered valid array entries!
 -- @param t The table to check

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -378,8 +378,8 @@ end
 -- @return Returns `true` if the table contains a regex matching the value, `false` otherwise
 function _M.table_contains_regex(arr, val)
   if arr then
-    for _, p in pairs(arr) do
-      if ngx.re.match(val, p) then
+    for i = 1,  #arr do
+      if re_find(val, arr[i], "jo") then
         return true
       end
     end

--- a/spec/03-plugins/26-oauth2/02-api_spec.lua
+++ b/spec/03-plugins/26-oauth2/02-api_spec.lua
@@ -120,21 +120,6 @@ describe("Plugin: oauth (API)", function()
             path = "/consumers/bob/oauth2",
             body = {
               name = "Test APP",
-              redirect_uri = "not-valid"
-            },
-            headers = {
-              ["Content-Type"] = "application/json"
-            }
-          })
-          local body = assert.res_status(400, res)
-          local json = cjson.decode(body)
-          assert.same({ redirect_uri = "cannot parse 'not-valid'" }, json)
-
-          local res = assert(admin_client:send {
-            method = "POST",
-            path = "/consumers/bob/oauth2",
-            body = {
-              name = "Test APP",
               redirect_uri = "http://test.com/#with-fragment"
             },
             headers = {
@@ -144,21 +129,6 @@ describe("Plugin: oauth (API)", function()
           local body = assert.res_status(400, res)
           local json = cjson.decode(body)
           assert.same({ redirect_uri = "fragment not allowed in 'http://test.com/#with-fragment'" }, json)
-
-          local res = assert(admin_client:send {
-            method = "POST",
-            path = "/consumers/bob/oauth2",
-            body = {
-              name = "Test APP",
-              redirect_uri = {"http://valid.com", "not-valid"}
-            },
-            headers = {
-              ["Content-Type"] = "application/json"
-            }
-          })
-          local body = assert.res_status(400, res)
-          local json = cjson.decode(body)
-          assert.same({ redirect_uri = "cannot parse 'not-valid'" }, json)
 
           local res = assert(admin_client:send {
             method = "POST",
@@ -342,7 +312,7 @@ describe("Plugin: oauth (API)", function()
             method = "PATCH",
             path = "/consumers/bob/oauth2/" .. credential.id,
             body = {
-              redirect_uri = "not-valid"
+              redirect_uri = "http://one.com/#fragment"
             },
             headers = {
               ["Content-Type"] = "application/json"
@@ -350,7 +320,7 @@ describe("Plugin: oauth (API)", function()
           })
           local body = assert.res_status(400, res)
           local json = cjson.decode(body)
-          assert.same({ redirect_uri = "cannot parse 'not-valid'" }, json)
+          assert.same({ redirect_uri = "fragment not allowed in 'http://one.com/#fragment'" }, json)
         end)
       end)
     end)

--- a/spec/03-plugins/26-oauth2/03-access_spec.lua
+++ b/spec/03-plugins/26-oauth2/03-access_spec.lua
@@ -106,9 +106,9 @@ describe("Plugin: oauth2 (access)", function()
       consumer_id = consumer.id
     })
     assert(helpers.dao.oauth2_credentials:insert {
-      client_id = "clientidwpattern",
+      client_id = "clientwpattern",
       client_secret = "secretforpattern",
-      redirect_uri = {"^http://one.com/one/$", "^http://two.com/two/.*$"},
+      redirect_uri = {'^http://one.com/one$', '^http://two.com/two/.*$'},
       name = "testapp3",
       consumer_id = consumer.id
     })
@@ -1166,7 +1166,7 @@ describe("Plugin: oauth2 (access)", function()
             client_secret="secret456",
             scope = "email",
             grant_type = "client_credentials",
-            redirect_uri = "http://two.com/two/hello"
+            redirect_uri = "http://two.com/hello"
           },
           headers = {
             ["Host"] = "oauth2_4.com",


### PR DESCRIPTION
### Summary
This addresses https://github.com/Mashape/kong/issues/1397 by making the redirect URIs a regex. This is necessary for any application that allows a user to login on arbitrary pages within the application. While this could be handled by saving that information in the app locally, that creates additional development overhead and complexity. I'm hoping this change doesn't qualify as breaking, although it's not a simple bugfix and _does_ change behavior. If so, I can rebase off of next instead.

### Full Changelog
- Add `table_contains_regex` that mirrors old `table_contains` and use it when checking if the supplied redirect URI is valid for a given client. This method simply uses `ngx.re.match` instead of a simple equality check.
- Add migrations to prepend all redirect URIs with '^' and append '$' to ensure that existing exact match behavior is preserved on upgrade.
- If no redirect URI is specified, the first entry in the list is still used but the '^' and '$' characters are removed. This is hacky, feedback is appreciated.
- Add related tests.

### Issues resolved

Fix #1397
