### PR TITLE
fix(statsd) deal with nil ctx.api on 404

### DIFF
--- a/kong/plugins/statsd/handler.lua
+++ b/kong/plugins/statsd/handler.lua
@@ -62,7 +62,11 @@ local function log(premature, conf, message)
     return
   end
   
-  local api_name = string_gsub(message.api.name, "%.", "_")
+  local api_name = "UNKNOWN_API"
+  if message.api ~= nil then
+    api_name = string_gsub(message.api.name, "%.", "_")
+  end
+
   for _, metric in pairs(conf.metrics) do
     local gauge = gauges[metric]
     if gauge ~= nil then


### PR DESCRIPTION
### Summary

Fix statsd plugin, which crashes on 404 requests with:

```
2017/08/02 11:55:05 [error] 109#0: *46932 lua entry thread aborted: runtime error: /usr/local/share/lua/5.1/kong/plugins/statsd/handler.lua:63: attempt to index field 'api' (a nil value)
stack traceback:
coroutine 0:
	/usr/local/share/lua/5.1/kong/plugins/statsd/handler.lua: in function </usr/local/share/lua/5.1/kong/plugins/statsd/handler.lua:54>, context: ngx.timer, client: 10.20.1.1, server: 0.0.0.0:8000
2017/08/02 11:55:05 [error] 109#0: *46936 lua entry thread aborted: runtime error: /usr/local/share/lua/5.1/kong/plugins/statsd/handler.lua:63: attempt to index field 'api' (a nil value)
```

### Full changelog

* dereference `message.api` only if it is not nil
