### PR TITLE
feat(aws-lambda) Lambda authentication via EC2 IAM roles

### DIFF
--- a/kong-0.14.1-0.rockspec
+++ b/kong-0.14.1-0.rockspec
@@ -324,6 +324,7 @@ build = {
     ["kong.plugins.aws-lambda.handler"] = "kong/plugins/aws-lambda/handler.lua",
     ["kong.plugins.aws-lambda.schema"] = "kong/plugins/aws-lambda/schema.lua",
     ["kong.plugins.aws-lambda.v4"] = "kong/plugins/aws-lambda/v4.lua",
+    ["kong.plugins.aws-lambda.iam-role-credentials"] = "kong/plugins/aws-lambda/iam-role-credentials.lua",
 
     ["kong.plugins.request-termination.handler"] = "kong/plugins/request-termination/handler.lua",
     ["kong.plugins.request-termination.schema"] = "kong/plugins/request-termination/schema.lua",

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -203,7 +203,11 @@ function AWSLambdaHandler:access(conf)
   }
 
   if conf.use_ec2_iam_role then
-    local iam_role_credentials = get_credentials_from_iam_role()
+    local iam_role_credentials, err = get_credentials_from_iam_role()
+    if not iam_role_credentials then
+      return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+    end
+
     opts.access_key = iam_role_credentials.access_key
     opts.secret_key = iam_role_credentials.secret_key
     opts.headers["X-Amz-Security-Token"] = iam_role_credentials.session_token

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -206,7 +206,8 @@ function AWSLambdaHandler:access(conf)
     local iam_role_credentials = get_credentials_from_iam_role()
     opts.access_key = iam_role_credentials.access_key
     opts.secret_key = iam_role_credentials.secret_key
-    opts.headers['X-Amz-Security-Token'] = iam_role_credentials.session_token
+    opts.headers["X-Amz-Security-Token"] = iam_role_credentials.session_token
+
   else
     opts.access_key = conf.aws_key
     opts.secret_key = conf.aws_secret

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -10,8 +10,6 @@ local http = require "resty.http"
 local cjson = require "cjson.safe"
 local public_utils = require "kong.tools.public"
 local fetch_iam_credentials_from_metadata_service = require "kong.plugins.aws-lambda.iam-role-credentials"
-local singletons = require "kong.singletons"
-
 
 local tostring             = tostring
 local tonumber             = tonumber

--- a/kong/plugins/aws-lambda/iam-role-credentials.lua
+++ b/kong/plugins/aws-lambda/iam-role-credentials.lua
@@ -1,23 +1,16 @@
-local http = require 'resty.http'
-local json = require 'cjson'
-local cache = require "kong.tools.database_cache"
+local http  = require 'resty.http'
+local json  = require 'cjson'
+local cache = require 'kong.tools.database_cache'
 
 local CACHE_IAM_INSTANCE_CREDS_DURATION = 60 -- seconds to cache credentials from metadata service
-    
-local function get_iam_credentials_cache_key()
-  return "plugin.aws-lambda-iam-role.iam_role_temp_creds"
-end
-
+local IAM_CREDENTIALS_CACHE_KEY = "plugin.aws-lambda.iam_role_temp_creds"
 
 local function fetch_iam_credentials_from_metadata_service(metadata_service_host, metadata_service_port)
-    metadata_service_host = metadata_service_host or '169.254.169.254'
-    metadata_service_port = metadata_service_port or 80
- 
     local client = http.new()
     local ok, err = client:connect(metadata_service_host, metadata_service_port) 
     
     if not ok then
-      ngx.log(ngx.ERR, "Could not connect to metadata service: " .. err)
+      ngx.log(ngx.ERR, "[aws-lambda] Could not connect to metadata service: ", err)
       return nil, err
     end
     
@@ -27,23 +20,24 @@ local function fetch_iam_credentials_from_metadata_service(metadata_service_host
     }
      
     if not role_name_request_res or role_name_request_res == "" then
-          ngx.log(ngx.ERR, "Could not fetch role name from metadata service: ".. err)
+          ngx.log(ngx.ERR, "[aws-lambda] Could not fetch role name from metadata service: ", err)
         return nil, err
     end 
      
     if role_name_request_res.status ~= 200 then
-      return nil, "[aws-lambda] Fetching role name from metadata service returned status code ".. role_name_request_res.status  .. 
-                   "with body " .. role_name_request_res.body
+      return nil, "[aws-lambda] Fetching role name from metadata service returned status code "..
+                  role_name_request_res.status  .. "with body " .. role_name_request_res.body
     end
            
     local iam_role_name = role_name_request_res:read_body() 
     
-    ngx.log(ngx.INFO, "[aws-lambda] IAM role '" .. iam_role_name .. "' is available through metadata service, fetching IAM credentials")
+    ngx.log(ngx.DEBUG, "[aws-lambda] IAM role '" .. iam_role_name ..
+                       "' is available through metadata service, fetching IAM credentials")
     
     local ok, err = client:connect(metadata_service_host, metadata_service_port) 
     
     if not ok then
-      ngx.log(ngx.ERR, "Could not connect to metadata service: " .. err)
+      ngx.log(ngx.ERR, "Could not connect to metadata service: ", err)
       return nil, err
     end
     
@@ -66,20 +60,23 @@ local function fetch_iam_credentials_from_metadata_service(metadata_service_host
     end
 
     local iam_security_token_data = json.decode(iam_security_token_request:read_body())
-    
-    ngx.log(ngx.INFO, "[aws-lambda] Received temporary IAM credential from metadata service for role '" ..
-                       iam_role_name .. "' with session token " .. iam_security_token_data['Token'])
-  
+
+    ngx.log(ngx.DEBUG, "[aws-lambda] Received temporary IAM credential from metadata service for role '" ..
+                       iam_role_name .. "' with session token " .. iam_security_token_data.Token)
+
     return {
-        access_key = iam_security_token_data['AccessKeyId'],
-        secret_key = iam_security_token_data['SecretAccessKey'],
-        session_token = iam_security_token_data['Token']
+        access_key = iam_security_token_data.AccessKeyId,
+        secret_key = iam_security_token_data.SecretAccessKey,
+        session_token = iam_security_token_data.Token
     }
 end
 
-local function get_iam_credentials_from_instance_profile()
-    local iam_profile_credentials, err = cache.get_or_set(get_iam_credentials_cache_key(), CACHE_IAM_INSTANCE_CREDS_DURATION,
-                                       fetch_iam_credentials_from_metadata_service)
+local function get_iam_credentials_from_instance_profile(metadata_service_host, metadata_service_port)
+    metadata_service_host = metadata_service_host or '169.254.169.254'
+    metadata_service_port = metadata_service_port or 80
+
+    local iam_profile_credentials, err = cache.get_or_set(IAM_CREDENTIALS_CACHE_KEY, CACHE_IAM_INSTANCE_CREDS_DURATION,
+                                       fetch_iam_credentials_from_metadata_service, metadata_service_host, metadata_service_port)
     if not iam_profile_credentials then
       ngx.log(ngx.ERR, err)
       return ngx.exit(ngx.ERROR)

--- a/kong/plugins/aws-lambda/iam-role-credentials.lua
+++ b/kong/plugins/aws-lambda/iam-role-credentials.lua
@@ -52,8 +52,8 @@ local function fetch_iam_credentials_from_metadata_service(metadata_service_host
     end
     
     if iam_security_token_request.status == 404 then
-        return nil, '[aws-lambda] Unable to request IAM credentials for role' .. iam_role_name ..
-                    ' Request returned status code ' .. iam_security_token_request.status
+        return nil, "[aws-lambda] Unable to request IAM credentials for role" .. iam_role_name ..
+                    " Request returned status code " .. iam_security_token_request.status
     end
 
     if iam_security_token_request.status ~= 200 then
@@ -73,7 +73,7 @@ local function fetch_iam_credentials_from_metadata_service(metadata_service_host
 end
 
 local function get_iam_credentials_from_instance_profile(metadata_service_host, metadata_service_port)
-    metadata_service_host = metadata_service_host or '169.254.169.254'
+    metadata_service_host = metadata_service_host or "169.254.169.254"
     metadata_service_port = metadata_service_port or 80
 
     return cache.get_or_set(IAM_CREDENTIALS_CACHE_KEY, CACHE_IAM_INSTANCE_CREDS_DURATION,

--- a/kong/plugins/aws-lambda/iam-role-credentials.lua
+++ b/kong/plugins/aws-lambda/iam-role-credentials.lua
@@ -1,0 +1,91 @@
+local http = require 'resty.http'
+local json = require 'cjson'
+local cache = require "kong.tools.database_cache"
+
+local CACHE_IAM_INSTANCE_CREDS_DURATION = 60 -- seconds to cache credentials from metadata service
+    
+local function get_iam_credentials_cache_key()
+  return "plugin.aws-lambda-iam-role.iam_role_temp_creds"
+end
+
+
+local function fetch_iam_credentials_from_metadata_service(metadata_service_host, metadata_service_port)
+    metadata_service_host = metadata_service_host or '169.254.169.254'
+    metadata_service_port = metadata_service_port or 80
+ 
+    local client = http.new()
+    local ok, err = client:connect(metadata_service_host, metadata_service_port) 
+    
+    if not ok then
+      ngx.log(ngx.ERR, "Could not connect to metadata service: " .. err)
+      return nil, err
+    end
+    
+    local role_name_request_res, err = client:request {
+      method = "GET",
+      path = "/latest/meta-data/iam/security-credentials/"
+    }
+     
+    if not role_name_request_res or role_name_request_res == "" then
+          ngx.log(ngx.ERR, "Could not fetch role name from metadata service: ".. err)
+        return nil, err
+    end 
+     
+    if role_name_request_res.status ~= 200 then
+      return nil, "[aws-lambda] Fetching role name from metadata service returned status code ".. role_name_request_res.status  .. 
+                   "with body " .. role_name_request_res.body
+    end
+           
+    local iam_role_name = role_name_request_res:read_body() 
+    
+    ngx.log(ngx.INFO, "[aws-lambda] IAM role '" .. iam_role_name .. "' is available through metadata service, fetching IAM credentials")
+    
+    local ok, err = client:connect(metadata_service_host, metadata_service_port) 
+    
+    if not ok then
+      ngx.log(ngx.ERR, "Could not connect to metadata service: " .. err)
+      return nil, err
+    end
+    
+    local iam_security_token_request, err = client:request {
+      method = "GET",
+      path = "/latest/meta-data/iam/security-credentials/" .. iam_role_name
+    }    
+    
+    if not iam_security_token_request then
+        return nil, err
+    end
+    
+    if iam_security_token_request.status == 404 then
+        return nil, '[aws-lambda] Unable to request IAM credentials for role' .. iam_role_name ..
+                    ' Request returned status code ' .. iam_security_token_request.status
+    end
+
+    if iam_security_token_request.status ~= 200 then
+        return nil, iam_security_token_request:read_body()
+    end
+
+    local iam_security_token_data = json.decode(iam_security_token_request:read_body())
+    
+    ngx.log(ngx.INFO, "[aws-lambda] Received temporary IAM credential from metadata service for role '" ..
+                       iam_role_name .. "' with session token " .. iam_security_token_data['Token'])
+  
+    return {
+        access_key = iam_security_token_data['AccessKeyId'],
+        secret_key = iam_security_token_data['SecretAccessKey'],
+        session_token = iam_security_token_data['Token']
+    }
+end
+
+local function get_iam_credentials_from_instance_profile()
+    local iam_profile_credentials, err = cache.get_or_set(get_iam_credentials_cache_key(), CACHE_IAM_INSTANCE_CREDS_DURATION,
+                                       fetch_iam_credentials_from_metadata_service)
+    if not iam_profile_credentials then
+      ngx.log(ngx.ERR, err)
+      return ngx.exit(ngx.ERROR)
+    end
+
+  return iam_profile_credentials
+end
+
+return get_iam_credentials_from_instance_profile

--- a/kong/plugins/aws-lambda/iam-role-credentials.lua
+++ b/kong/plugins/aws-lambda/iam-role-credentials.lua
@@ -6,78 +6,78 @@ local CACHE_IAM_INSTANCE_CREDS_DURATION = 60 -- seconds to cache credentials fro
 local IAM_CREDENTIALS_CACHE_KEY = "plugin.aws-lambda.iam_role_temp_creds"
 
 local function fetch_iam_credentials_from_metadata_service(metadata_service_host, metadata_service_port)
-    local client = http.new()
-    client:set_timeout(500)
+  local client = http.new()
+  client:set_timeout(500)
 
-    local ok, err = client:connect(metadata_service_host, metadata_service_port)
-    
-    if not ok then
-      ngx.log(ngx.ERR, "[aws-lambda] Could not connect to metadata service: ", err)
-      return nil, err
-    end
-    
-    local role_name_request_res, err = client:request {
-      method = "GET",
-      path = "/latest/meta-data/iam/security-credentials/",
-    }
-     
-    if not role_name_request_res or role_name_request_res == "" then
-          ngx.log(ngx.ERR, "[aws-lambda] Could not fetch role name from metadata service: ", err)
-        return nil, err
-    end 
-     
-    if role_name_request_res.status ~= 200 then
-      return nil, "[aws-lambda] Fetching role name from metadata service returned status code " ..
-                  role_name_request_res.status  .. "with body " .. role_name_request_res.body
-    end
-           
-    local iam_role_name = role_name_request_res:read_body() 
-    
-    ngx.log(ngx.DEBUG, "[aws-lambda] Found IAM role on instance with name: ", iam_role_name)
-    
-    local ok, err = client:connect(metadata_service_host, metadata_service_port) 
-    
-    if not ok then
-      ngx.log(ngx.ERR, "Could not connect to metadata service: ", err)
-      return nil, err
-    end
-    
-    local iam_security_token_request, err = client:request {
-      method = "GET",
-      path = "/latest/meta-data/iam/security-credentials/" .. iam_role_name,
-    }    
-    
-    if not iam_security_token_request then
-        return nil, err
-    end
-    
-    if iam_security_token_request.status == 404 then
-        return nil, "[aws-lambda] Unable to request IAM credentials for role" .. iam_role_name ..
-                    " Request returned status code " .. iam_security_token_request.status
-    end
+  local ok, err = client:connect(metadata_service_host, metadata_service_port)
 
-    if iam_security_token_request.status ~= 200 then
-        return nil, iam_security_token_request:read_body()
-    end
+  if not ok then
+    ngx.log(ngx.ERR, "[aws-lambda] Could not connect to metadata service: ", err)
+    return nil, err
+  end
 
-    local iam_security_token_data = json.decode(iam_security_token_request:read_body())
+  local role_name_request_res, err = client:request {
+    method = "GET",
+    path   = "/latest/meta-data/iam/security-credentials/",
+  }
 
-    ngx.log(ngx.DEBUG, "[aws-lambda] Received temporary IAM credential from metadata service for role '",
-                       iam_role_name, "' with session token: ", iam_security_token_data.Token)
+  if not role_name_request_res or role_name_request_res == "" then
+    ngx.log(ngx.ERR, "[aws-lambda] Could not fetch role name from metadata service: ", err)
+    return nil, err
+  end
 
-    return {
-        access_key    = iam_security_token_data.AccessKeyId,
-        secret_key    = iam_security_token_data.SecretAccessKey,
-        session_token = iam_security_token_data.Token,
-    }
+  if role_name_request_res.status ~= 200 then
+    return nil, "[aws-lambda] Fetching role name from metadata service returned status code " ..
+                role_name_request_res.status .. "with body " .. role_name_request_res.body
+  end
+
+  local iam_role_name = role_name_request_res:read_body()
+
+  ngx.log(ngx.DEBUG, "[aws-lambda] Found IAM role on instance with name: ", iam_role_name)
+
+  local ok, err = client:connect(metadata_service_host, metadata_service_port)
+
+  if not ok then
+    ngx.log(ngx.ERR, "Could not connect to metadata service: ", err)
+    return nil, err
+  end
+
+  local iam_security_token_request, err = client:request {
+    method = "GET",
+    path   = "/latest/meta-data/iam/security-credentials/" .. iam_role_name,
+  }
+
+  if not iam_security_token_request then
+    return nil, err
+  end
+
+  if iam_security_token_request.status == 404 then
+    return nil, "[aws-lambda] Unable to request IAM credentials for role" .. iam_role_name ..
+                " Request returned status code " .. iam_security_token_request.status
+  end
+
+  if iam_security_token_request.status ~= 200 then
+    return nil, iam_security_token_request:read_body()
+  end
+
+  local iam_security_token_data = json.decode(iam_security_token_request:read_body())
+
+  ngx.log(ngx.DEBUG, "[aws-lambda] Received temporary IAM credential from metadata service for role '",
+                     iam_role_name, "' with session token: ", iam_security_token_data.Token)
+
+  return {
+    access_key    = iam_security_token_data.AccessKeyId,
+    secret_key    = iam_security_token_data.SecretAccessKey,
+    session_token = iam_security_token_data.Token,
+  }
 end
 
 local function get_iam_credentials_from_instance_profile(metadata_service_host, metadata_service_port)
-    metadata_service_host = metadata_service_host or "169.254.169.254"
-    metadata_service_port = metadata_service_port or 80
+  metadata_service_host = metadata_service_host or "169.254.169.254"
+  metadata_service_port = metadata_service_port or 80
 
-    return cache.get_or_set(IAM_CREDENTIALS_CACHE_KEY, CACHE_IAM_INSTANCE_CREDS_DURATION,
-                            fetch_iam_credentials_from_metadata_service, metadata_service_host, metadata_service_port)
+  return cache.get_or_set(IAM_CREDENTIALS_CACHE_KEY, CACHE_IAM_INSTANCE_CREDS_DURATION,
+                          fetch_iam_credentials_from_metadata_service, metadata_service_host, metadata_service_port)
 end
 
 return get_iam_credentials_from_instance_profile

--- a/kong/plugins/aws-lambda/iam-role-credentials.lua
+++ b/kong/plugins/aws-lambda/iam-role-credentials.lua
@@ -77,7 +77,7 @@ local function get_iam_credentials_from_instance_profile(metadata_service_host, 
     metadata_service_port = metadata_service_port or 80
 
     return cache.get_or_set(IAM_CREDENTIALS_CACHE_KEY, CACHE_IAM_INSTANCE_CREDS_DURATION,
-                                       fetch_iam_credentials_from_metadata_service, metadata_service_host, metadata_service_port)
+                            fetch_iam_credentials_from_metadata_service, metadata_service_host, metadata_service_port)
 end
 
 return get_iam_credentials_from_instance_profile

--- a/kong/plugins/aws-lambda/iam-role-credentials.lua
+++ b/kong/plugins/aws-lambda/iam-role-credentials.lua
@@ -2,12 +2,16 @@ local http  = require "resty.http"
 local json  = require "cjson"
 local cache = require "kong.tools.database_cache"
 
-local CACHE_IAM_INSTANCE_CREDS_DURATION = 60 -- seconds to cache credentials from metadata service
+local DEFAULT_CACHE_IAM_INSTANCE_CREDS_DURATION = 60 -- seconds to cache credentials from metadata service
+local DEFAULT_METADATA_SERVICE_PORT = 80
+local DEFAULT_METADATA_SERVICE_HOST = "169.254.169.254"
+local DEFAULT_METADATA_SERVICE_REQUEST_TIMEOUT = 5000
 local IAM_CREDENTIALS_CACHE_KEY = "plugin.aws-lambda.iam_role_temp_creds"
 
-local function fetch_iam_credentials_from_metadata_service(metadata_service_host, metadata_service_port)
+local function fetch_iam_credentials_from_metadata_service(metadata_service_host, metadata_service_port,
+                                                           metadata_service_request_timeout)
   local client = http.new()
-  client:set_timeout(500)
+  client:set_timeout(metadata_service_request_timeout)
 
   local ok, err = client:connect(metadata_service_host, metadata_service_port)
 
@@ -72,12 +76,16 @@ local function fetch_iam_credentials_from_metadata_service(metadata_service_host
   }
 end
 
-local function get_iam_credentials_from_instance_profile(metadata_service_host, metadata_service_port)
-  metadata_service_host = metadata_service_host or "169.254.169.254"
-  metadata_service_port = metadata_service_port or 80
+local function get_iam_credentials_from_instance_profile(metadata_service_host, metadata_service_port,
+                                                         metadata_service_request_timeout, credentials_cache_ttl)
+  metadata_service_host = metadata_service_host or DEFAULT_METADATA_SERVICE_HOST
+  metadata_service_port = metadata_service_port or DEFAULT_METADATA_SERVICE_PORT
+  metadata_service_request_timeout = metadata_service_request_timeout or DEFAULT_METADATA_SERVICE_REQUEST_TIMEOUT
+  credentials_cache_ttl = credentials_cache_ttl or DEFAULT_CACHE_IAM_INSTANCE_CREDS_DURATION
 
-  return cache.get_or_set(IAM_CREDENTIALS_CACHE_KEY, CACHE_IAM_INSTANCE_CREDS_DURATION,
-                          fetch_iam_credentials_from_metadata_service, metadata_service_host, metadata_service_port)
+  return cache.get_or_set(IAM_CREDENTIALS_CACHE_KEY, credentials_cache_ttl,
+                          fetch_iam_credentials_from_metadata_service, metadata_service_host, metadata_service_port,
+                          metadata_service_request_timeout)
 end
 
 return get_iam_credentials_from_instance_profile

--- a/kong/plugins/aws-lambda/schema.lua
+++ b/kong/plugins/aws-lambda/schema.lua
@@ -108,7 +108,7 @@ return {
   self_check =  function(schema, plugin_t, dao, is_update)
     if not plugin_t.use_ec2_iam_role or plugin_t.use_ec2_iam_role == false then
       -- if iam_profile is not set, aws_key and aws_secret are required
-      if not plugin_t.aws_key or not plugin_t.aws_secret then
+      if not plugin_t.aws_key or plugin_t.aws_key == "" or not plugin_t.aws_secret or plugin_t.aws_secret == "" then
         return false, Errors.schema "You need to set aws_key and aws_secret or need to use EC2 IAM roles"
       end
       return true

--- a/kong/plugins/aws-lambda/schema.lua
+++ b/kong/plugins/aws-lambda/schema.lua
@@ -106,7 +106,7 @@ return {
     },
   },
   self_check =  function(schema, plugin_t, dao, is_update)
-    if not plugin_t.use_ec2_iam_role or plugin_t.use_ec2_iam_role == false then
+    if not plugin_t.use_ec2_iam_role then
       -- if iam_profile is not set, aws_key and aws_secret are required
       if not plugin_t.aws_key or plugin_t.aws_key == "" or not plugin_t.aws_secret or plugin_t.aws_secret == "" then
         return false, Errors.schema "You need to set aws_key and aws_secret or need to use EC2 IAM roles"

--- a/kong/plugins/aws-lambda/schema.lua
+++ b/kong/plugins/aws-lambda/schema.lua
@@ -105,7 +105,7 @@ return {
       type="boolean",
     },
   },
-  self_check =  function(schema, plugin_t, dao, is_update)
+  self_check = function(schema, plugin_t, dao, is_update)
     if not plugin_t.use_ec2_iam_role then
       -- if iam_profile is not set, aws_key and aws_secret are required
       if not plugin_t.aws_key or plugin_t.aws_key == "" or not plugin_t.aws_secret or plugin_t.aws_secret == "" then

--- a/kong/plugins/aws-lambda/schema.lua
+++ b/kong/plugins/aws-lambda/schema.lua
@@ -1,3 +1,5 @@
+local Errors = require "kong.dao.errors"
+
 local function check_status(status)
   if status and (status < 100 or status > 999) then
     return false, "unhandled_status must be within 100 - 999."
@@ -20,11 +22,9 @@ return {
     },
     aws_key = {
       type = "string",
-      required = true,
     },
     aws_secret = {
       type = "string",
-      required = true,
     },
     aws_region = {
       type = "string",
@@ -101,5 +101,18 @@ return {
       type = "boolean",
       default = false,
     },
+    use_ec2_iam_role = {
+      type="boolean",
+    },
   },
+  self_check =  function(schema, plugin_t, dao, is_update)
+    if not plugin_t["use_ec2_iam_role"] or plugin_t["use_ec2_iam_role"] == false then
+      -- if iam_profile is not set, aws_key and aws_secret are required
+      if not plugin_t["aws_key"] or not plugin_t["aws_secret"] then
+        return false, Errors.schema "You need to set aws_key and aws_secret or need to use EC2 IAM roles"
+      end
+      return true
+    end
+    return true
+  end
 }

--- a/kong/plugins/aws-lambda/schema.lua
+++ b/kong/plugins/aws-lambda/schema.lua
@@ -106,9 +106,9 @@ return {
     },
   },
   self_check =  function(schema, plugin_t, dao, is_update)
-    if not plugin_t["use_ec2_iam_role"] or plugin_t["use_ec2_iam_role"] == false then
+    if not plugin_t.use_ec2_iam_role or plugin_t.use_ec2_iam_role == false then
       -- if iam_profile is not set, aws_key and aws_secret are required
-      if not plugin_t["aws_key"] or not plugin_t["aws_secret"] then
+      if not plugin_t.aws_key or not plugin_t.aws_secret then
         return false, Errors.schema "You need to set aws_key and aws_secret or need to use EC2 IAM roles"
       end
       return true

--- a/spec/03-plugins/23-aws-lambda/02-schema_spec.lua
+++ b/spec/03-plugins/23-aws-lambda/02-schema_spec.lua
@@ -19,11 +19,6 @@ describe("Plugin: AWS Lambda (schema)", function()
     port             = 443,
   }
 
-  local DEFAULTS_IAM_ROLE_AUTH = {
-    function_name = DEFAULTS.function_name,
-    aws_region = DEFAULTS.aws_region
-  }
-
   it("accepts nil Unhandled Response Status Code", function()
     local entity = utils.table_merge(DEFAULTS, { unhandled_status = nil })
     local ok, err = validate_entity(entity, aws_lambda_schema)
@@ -53,28 +48,37 @@ describe("Plugin: AWS Lambda (schema)", function()
   end)
 
   it("errors with no aws_key and use_ec2_iam_role set to false", function()
-    local entity = utils.table_merge(DEFAULTS_IAM_ROLE_AUTH, { aws_key = "" })
+    local entity = utils.table_merge(DEFAULTS, { aws_key = "" })
     local ok, err, self_err = validate_entity(entity, aws_lambda_schema)
+    assert.is_nil(err)
     assert.equal("You need to set aws_key and aws_secret or need to use EC2 IAM roles", self_err.message)
     assert.False(ok)
   end)
 
   it("errors with empty aws_secret and use_ec2_iam_role set to false", function()
-    local entity = utils.table_merge(DEFAULTS_IAM_ROLE_AUTH, { aws_secret = "" })
+    local entity = utils.table_merge(DEFAULTS, { aws_secret = "" })
     local ok, err, self_err = validate_entity(entity, aws_lambda_schema)
+    assert.is_nil(err)
     assert.equal("You need to set aws_key and aws_secret or need to use EC2 IAM roles", self_err.message)
     assert.False(ok)
   end)
 
   it("errors with empty aws_secret or aws_key and use_ec2_iam_role set to false", function()
-    local ok, err, self_err = validate_entity(DEFAULTS_IAM_ROLE_AUTH, aws_lambda_schema)
+    local entity = utils.table_merge(DEFAULTS, {})
+    entity.aws_key = nil
+    entity.aws_secret = nil
+    local ok, err, self_err = validate_entity(entity, aws_lambda_schema)
+    assert.is_nil(err)
     assert.equal("You need to set aws_key and aws_secret or need to use EC2 IAM roles", self_err.message)
     assert.False(ok)
   end)
 
   it("ok if aws_key or aws_secret is missing but use_ec2_iam_role is set to true", function()
-    local entity = utils.table_merge(DEFAULTS_IAM_ROLE_AUTH, { use_ec2_iam_role = true })
-    local ok, err= validate_entity(entity, aws_lambda_schema)
+    local entity = utils.table_merge(DEFAULTS, { use_ec2_iam_role = true })
+    entity.aws_key = nil
+    entity.aws_secret = nil
+    local ok, err = validate_entity(entity, aws_lambda_schema)
+    assert.is_nil(err)
     assert.True(ok)
   end)
 

--- a/spec/03-plugins/23-aws-lambda/02-schema_spec.lua
+++ b/spec/03-plugins/23-aws-lambda/02-schema_spec.lua
@@ -19,6 +19,11 @@ describe("Plugin: AWS Lambda (schema)", function()
     port             = 443,
   }
 
+  local DEFAULTS_IAM_ROLE_AUTH = {
+    function_name = DEFAULTS.function_name,
+    aws_region = DEFAULTS.aws_region
+  }
+
   it("accepts nil Unhandled Response Status Code", function()
     local entity = utils.table_merge(DEFAULTS, { unhandled_status = nil })
     local ok, err = validate_entity(entity, aws_lambda_schema)
@@ -46,4 +51,31 @@ describe("Plugin: AWS Lambda (schema)", function()
     assert.equal("unhandled_status must be within 100 - 999.", err.unhandled_status)
     assert.False(ok)
   end)
+
+  it("errors with no aws_key and use_ec2_iam_role set to false", function()
+    local entity = utils.table_merge(DEFAULTS_IAM_ROLE_AUTH, { aws_key = "" })
+    local ok, err, self_err = validate_entity(entity, aws_lambda_schema)
+    assert.equal("You need to set aws_key and aws_secret or need to use EC2 IAM roles", self_err.message)
+    assert.False(ok)
+  end)
+
+  it("errors with empty aws_secret and use_ec2_iam_role set to false", function()
+    local entity = utils.table_merge(DEFAULTS_IAM_ROLE_AUTH, { aws_secret = "" })
+    local ok, err, self_err = validate_entity(entity, aws_lambda_schema)
+    assert.equal("You need to set aws_key and aws_secret or need to use EC2 IAM roles", self_err.message)
+    assert.False(ok)
+  end)
+
+  it("errors with empty aws_secret or aws_key and use_ec2_iam_role set to false", function()
+    local ok, err, self_err = validate_entity(DEFAULTS_IAM_ROLE_AUTH, aws_lambda_schema)
+    assert.equal("You need to set aws_key and aws_secret or need to use EC2 IAM roles", self_err.message)
+    assert.False(ok)
+  end)
+
+  it("ok if aws_key or aws_secret is missing but use_ec2_iam_role is set to true", function()
+    local entity = utils.table_merge(DEFAULTS_IAM_ROLE_AUTH, { use_ec2_iam_role = true })
+    local ok, err= validate_entity(entity, aws_lambda_schema)
+    assert.True(ok)
+  end)
+
 end)

--- a/spec/03-plugins/23-aws-lambda/03-get-iam-role-credentials_spec.lua
+++ b/spec/03-plugins/23-aws-lambda/03-get-iam-role-credentials_spec.lua
@@ -13,9 +13,18 @@ describe("Plugin: aws-lambda", function()
     end)
 
     describe("IAM Metadata service", function()
-        it("should fetch credentials from metadata service", function()
-            local iam_role_credentials = get_credentials_from_iam_role('127.0.0.1', 9999)
+        it("should return error if metadata service is not running on provided endpoint", function()
+            local iam_role_credentials, err = get_credentials_from_iam_role('192.0.2.0', 1234)
 
+            assert.is_nil(iam_role_credentials)
+            assert.is_not_nil(err)
+            assert.equal("timeout", err)
+        end)
+
+        it("should fetch credentials from metadata service", function()
+            local iam_role_credentials, err = get_credentials_from_iam_role('127.0.0.1', 9999)
+
+            assert.is_nil(err)
             assert.equal("test_iam_access_key_id", iam_role_credentials.access_key)
             assert.equal("test_iam_secret_access_key", iam_role_credentials.secret_key)
             assert.equal("test_session_token", iam_role_credentials.session_token)

--- a/spec/03-plugins/23-aws-lambda/03-get-iam-role-credentials_spec.lua
+++ b/spec/03-plugins/23-aws-lambda/03-get-iam-role-credentials_spec.lua
@@ -21,7 +21,7 @@ describe("Plugin: AWS Lambda (metadata service credentials)", function()
   end)
 
   it("should fetch credentials from metadata service", function()
-    local iam_role_credentials, err = get_credentials_from_iam_role('127.0.0.1', 55555, 200, 0)
+    local iam_role_credentials, err = get_credentials_from_iam_role('127.0.0.1', 15555, 200, 0)
 
     assert.is_nil(err)
     assert.equal("test_iam_access_key_id", iam_role_credentials.access_key)

--- a/spec/03-plugins/23-aws-lambda/03-get-iam-role-credentials_spec.lua
+++ b/spec/03-plugins/23-aws-lambda/03-get-iam-role-credentials_spec.lua
@@ -1,33 +1,31 @@
 local helpers = require "spec.helpers"
 local get_credentials_from_iam_role = require "kong.plugins.aws-lambda.iam-role-credentials"
 
-describe("Plugin: aws-lambda", function()
-    setup(function()
-        assert(helpers.start_kong{
-            nginx_conf = "spec/fixtures/custom_nginx.template",
-        })
-    end)
+describe("Plugin: AWS Lambda (metadata service credentials)", function()
+  setup(function()
+    assert(helpers.start_kong {
+      nginx_conf = "spec/fixtures/custom_nginx.template",
+    })
+  end)
 
-    teardown(function()
-        helpers.stop_kong()
-    end)
+  teardown(function()
+    helpers.stop_kong()
+  end)
 
-    describe("IAM Metadata service", function()
-        it("should return error if metadata service is not running on provided endpoint", function()
-            local iam_role_credentials, err = get_credentials_from_iam_role('192.0.2.0', 1234)
+  it("should return error if metadata service is not running on provided endpoint", function()
+    local iam_role_credentials, err = get_credentials_from_iam_role('192.0.2.0', 1234)
 
-            assert.is_nil(iam_role_credentials)
-            assert.is_not_nil(err)
-            assert.equal("timeout", err)
-        end)
+    assert.is_nil(iam_role_credentials)
+    assert.is_not_nil(err)
+    assert.equal("timeout", err)
+  end)
 
-        it("should fetch credentials from metadata service", function()
-            local iam_role_credentials, err = get_credentials_from_iam_role('127.0.0.1', 9999)
+  it("should fetch credentials from metadata service", function()
+    local iam_role_credentials, err = get_credentials_from_iam_role('127.0.0.1', 9999)
 
-            assert.is_nil(err)
-            assert.equal("test_iam_access_key_id", iam_role_credentials.access_key)
-            assert.equal("test_iam_secret_access_key", iam_role_credentials.secret_key)
-            assert.equal("test_session_token", iam_role_credentials.session_token)
-        end)
-    end)
+    assert.is_nil(err)
+    assert.equal("test_iam_access_key_id", iam_role_credentials.access_key)
+    assert.equal("test_iam_secret_access_key", iam_role_credentials.secret_key)
+    assert.equal("test_session_token", iam_role_credentials.session_token)
+  end)
 end)

--- a/spec/03-plugins/23-aws-lambda/03-get-iam-role-credentials_spec.lua
+++ b/spec/03-plugins/23-aws-lambda/03-get-iam-role-credentials_spec.lua
@@ -21,7 +21,7 @@ describe("Plugin: AWS Lambda (metadata service credentials)", function()
   end)
 
   it("should fetch credentials from metadata service", function()
-    local iam_role_credentials, err = get_credentials_from_iam_role('127.0.0.1', 9999, 200, 0)
+    local iam_role_credentials, err = get_credentials_from_iam_role('127.0.0.1', 55555, 200, 0)
 
     assert.is_nil(err)
     assert.equal("test_iam_access_key_id", iam_role_credentials.access_key)

--- a/spec/03-plugins/23-aws-lambda/03-get-iam-role-credentials_spec.lua
+++ b/spec/03-plugins/23-aws-lambda/03-get-iam-role-credentials_spec.lua
@@ -13,7 +13,7 @@ describe("Plugin: AWS Lambda (metadata service credentials)", function()
   end)
 
   it("should return error if metadata service is not running on provided endpoint", function()
-    local iam_role_credentials, err = get_credentials_from_iam_role('192.0.2.0', 1234)
+    local iam_role_credentials, err = get_credentials_from_iam_role('192.0.2.0', 1234, 200, 0)
 
     assert.is_nil(iam_role_credentials)
     assert.is_not_nil(err)
@@ -21,7 +21,7 @@ describe("Plugin: AWS Lambda (metadata service credentials)", function()
   end)
 
   it("should fetch credentials from metadata service", function()
-    local iam_role_credentials, err = get_credentials_from_iam_role('127.0.0.1', 9999)
+    local iam_role_credentials, err = get_credentials_from_iam_role('127.0.0.1', 9999, 200, 0)
 
     assert.is_nil(err)
     assert.equal("test_iam_access_key_id", iam_role_credentials.access_key)

--- a/spec/03-plugins/23-aws-lambda/03-get-iam-role-credentials_spec.lua
+++ b/spec/03-plugins/23-aws-lambda/03-get-iam-role-credentials_spec.lua
@@ -1,0 +1,24 @@
+local helpers = require "spec.helpers"
+local get_credentials_from_iam_role = require "kong.plugins.aws-lambda.iam-role-credentials"
+
+describe("Plugin: aws-lambda", function()
+    setup(function()
+        assert(helpers.start_kong{
+            nginx_conf = "spec/fixtures/custom_nginx.template",
+        })
+    end)
+
+    teardown(function()
+        helpers.stop_kong()
+    end)
+
+    describe("IAM Metadata service", function()
+        it("should fetch credentials from metadata service", function()
+            local iam_role_credentials = get_credentials_from_iam_role('127.0.0.1', 9999)
+
+            assert.equal("test_iam_access_key_id", iam_role_credentials.access_key)
+            assert.equal("test_iam_secret_access_key", iam_role_credentials.secret_key)
+            assert.equal("test_session_token", iam_role_credentials.session_token)
+        end)
+    end)
+end)

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -443,7 +443,7 @@ http {
                     AccessKeyId = "test_iam_access_key_id",
                     SecretAccessKey ="test_iam_secret_access_key",
                     Token = "test_session_token"
-                 }
+                }
                 local IAM_ROLE_TEMPORARY_CREDS_TXT = require("cjson").encode(IAM_ROLE_TEMPORARY_CREDS)
 
                 ngx.status = 200

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -423,5 +423,35 @@ http {
                 end
             }
         }
+
+        location = "/latest/meta-data/iam/security-credentials/" {
+            content_by_lua_block {
+                local IAM_ROLE_NAME = 'testrole'
+                ngx.header["Content-Length"] = #IAM_ROLE_NAME
+                ngx.header["Content-Type"] = "text/plain"
+                ngx.status = 200
+                ngx.say(IAM_ROLE_NAME)
+                ngx.exit(0)
+            }
+        }
+
+        location = "/latest/meta-data/iam/security-credentials/testrole" {
+            content_by_lua_block {
+                local IAM_ROLE_TEMPORARY_CREDS = {
+                    Code = "Success",
+                    Type = "AWS-HMAC",
+                    AccessKeyId = "test_iam_access_key_id",
+                    SecretAccessKey ="test_iam_secret_access_key",
+                    Token = "test_session_token"
+                 }
+                local IAM_ROLE_TEMPORARY_CREDS_TXT = require("cjson").encode(IAM_ROLE_TEMPORARY_CREDS)
+
+                ngx.status = 200
+                ngx.header["Content-Length"] = #IAM_ROLE_TEMPORARY_CREDS_TXT
+                ngx.header["Content-Type"] = "text/plain"
+                ngx.say(IAM_ROLE_TEMPORARY_CREDS_TXT)
+                ngx.exit(0)
+           }
+        }
     }
 }


### PR DESCRIPTION
### Summary
Adds support for querying temporary credentials from EC2 metadata service instead of fetching long-lived key-pairs from the database.

The credentials are fetched from the EC2 metadata service and are cached for 60 seconds. I assume that many users are running kong on EC2 instances. For these users this is the recommended way to authenticate requests for AWS services as key-rotation and credential provisioning are managed by AWS.

For further details refer to the [AWS documentation about EC2 roles](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html)

### Full changelog

* Added `kong.plugins.aws-lambda.iam-role-credentials` for  fetching and caching temporary credentials from the metadata service (default 169.254.169.254 port 80) 
* Added plugins config flag `use_ec2_iam_role` to `kong.plugins.aws-lambda.schema` and declared `aws_key` and `aws_secret` as optional
* Added `self_check` function to check whether either `use_ec2_iam_role` is set  to true or both aws_key and aws_secret as configured
* Added if branch in `kong.plugins.aws-lambda.handler` to either fetch credentials from the metadata service or use credentials stored in database
