### PR TITLE
feat(jwt) add oauth2 token to ngx.ctx

### DIFF
--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -488,7 +488,7 @@ local function set_consumer(consumer, credential, token)
     ngx_set_header("x-authenticated-scope", token.scope)
     ngx_set_header("x-authenticated-userid", token.authenticated_userid)
     ngx.ctx.authenticated_credential = credential
-    ngx.ctx.authenticated_token = token
+    ngx.ctx.authenticated_oauth2_token = token
     ngx_set_header(constants.HEADERS.ANONYMOUS, nil) -- in case of auth plugins concatenation
   else
     ngx_set_header(constants.HEADERS.ANONYMOUS, true)

--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -488,6 +488,7 @@ local function set_consumer(consumer, credential, token)
     ngx_set_header("x-authenticated-scope", token.scope)
     ngx_set_header("x-authenticated-userid", token.authenticated_userid)
     ngx.ctx.authenticated_credential = credential
+    ngx.ctx.authenticated_token = token
     ngx_set_header(constants.HEADERS.ANONYMOUS, nil) -- in case of auth plugins concatenation
   else
     ngx_set_header(constants.HEADERS.ANONYMOUS, true)


### PR DESCRIPTION
### Summary

Store the Access Token in the context so other plugins can have access to it without reparsing it and without breaking "hide credentials".

### Full changelog

* Store the access token in the context along with the credential.