### PR TITLE
feat(balancer) implement consistent hashing

### DIFF
--- a/kong/core/balancer.lua
+++ b/kong/core/balancer.lua
@@ -4,6 +4,8 @@ local singletons = require "kong.singletons"
 local dns_client = require "resty.dns.client"  -- due to startup/require order, cannot use the one from 'singletons' here
 local ring_balancer = require "resty.dns.balancer"
 
+local table_concat = table.concat
+local crc32 = ngx.crc32_short
 local toip = dns_client.toip
 local log = ngx.log
 
@@ -146,7 +148,7 @@ end
 
 -- looks up a balancer for the target.
 -- @param target the table with the target details
--- @return balancer if found, or `false` if not found, or nil+error on error
+-- @return balancer+upstream if found, `false` if not found, or nil+error on error
 local get_balancer = function(target)
   -- NOTE: only called upon first lookup, so `cache_only` limitations do not apply here
   local hostname = target.host
@@ -233,9 +235,52 @@ local get_balancer = function(target)
     end
   end
 
-  return balancer
+  return balancer, upstream
 end
 
+
+-- Calculates hash-value.
+-- Will only be called once per request, on first try.
+-- @param upstream the upstream enity
+-- @return integer value or nil if there is no hash to calculate
+local create_hash = function(upstream)
+  local hash_on = upstream.hash_on
+  if hash_on == "none" or hash_on == nil then
+    return nil -- exit fast
+  end
+
+  local ctx = ngx.ctx
+  local identifier
+
+  for i = 1,2 do
+
+    if hash_on == "consumer" then
+      -- consumer, fallback to credential
+      identifier = (ctx.authenticated_consumer or EMPTY_T).id or
+                   (ctx.authenticated_credential or EMPTY_T).id
+
+    elseif hash_on == "ip" then
+      identifier = ngx.var.remote_addr
+
+    elseif hash_on == "header" then
+      identifier = ngx.req.get_headers()[upstream["hash_header" .. i]]
+      if type(indentifier) == "table" then
+        identifier = table_concat(identifier)
+      end
+    end
+
+    if identifier then
+      return crc32(identifier)
+    else
+      -- we missed the first, so now try the fallback
+      hash_on = upstream.hash_fallback
+      if hash_on == "none" or hash_on == nil then
+        return nil
+      end
+    end
+  end
+  -- nothing found, leave without a hash  
+end
 
 --===========================================================
 -- Main entry point when resolving
@@ -260,7 +305,7 @@ local function execute(target)
   -- when tries == 0 it runs before the `balancer` context (in the `access` context),
   -- when tries >= 2 then it performs a retry in the `balancer` context
   local dns_cache_only = target.try_count ~= 0
-  local balancer
+  local balancer, upstream, hash_value
 
   if dns_cache_only then
     -- retry, so balancer is already set if there was one
@@ -269,20 +314,30 @@ local function execute(target)
   else
     local err
     -- first try, so try and find a matching balancer/upstream object
-    balancer, err = get_balancer(target)
-    if err then -- check on err, `nil` without `err` means we do dns resolution
+    balancer, upstream = get_balancer(target)
+    if balancer == nil then -- `false` means no balancer, `nil` is error
       return nil, err
     end
 
-    -- store for retries
-    target.balancer = balancer
+    if balancer then
+      -- store for retries
+      target.balancer = balancer
+      
+      -- calculate hash-value
+      -- only add it if it doesn't exist, in case a plugin inserted one
+      hash_value = target.hash_value
+      if not hash_value then
+        hash_value = create_hash(upstream)
+        target.hash_value = hash_value
+      end
+    end
   end
 
   if balancer then
     -- have to invoke the ring-balancer
-    local hashValue = nil  -- TODO: implement, nil does simple round-robin
-
-    local ip, port, hostname = balancer:getPeer(hashValue, nil, dns_cache_only)
+    local ip, port, hostname = balancer:getPeer(hash_value,
+                                                target.try_count,
+                                                dns_cache_only)
     if not ip then
       if port == "No peers are available" then
         -- in this case a "503 service unavailable", others will be a 500.
@@ -297,6 +352,7 @@ local function execute(target)
     target.ip = ip
     target.port = port
     target.hostname = hostname
+    target.hash_value = hash_value
     return true
   end
 

--- a/kong/core/balancer.lua
+++ b/kong/core/balancer.lua
@@ -269,7 +269,7 @@ local create_hash = function(upstream)
 
     elseif hash_on == "header" then
       identifier = ngx.req.get_headers()[upstream[header_field_names[i]]]
-      if type(indentifier) == "table" then
+      if type(identifier) == "table" then
         identifier = table_concat(identifier)
       end
     end
@@ -387,4 +387,5 @@ return {
   _load_upstreams_dict_into_memory = load_upstreams_dict_into_memory,
   _load_upstream_into_memory = load_upstream_into_memory,
   _load_targets_into_memory = load_targets_into_memory,
+  _create_hash = create_hash,
 }

--- a/kong/core/balancer.lua
+++ b/kong/core/balancer.lua
@@ -317,11 +317,10 @@ local function execute(target)
     balancer = target.balancer
 
   else
-    local err
     -- first try, so try and find a matching balancer/upstream object
     balancer, upstream = get_balancer(target)
     if balancer == nil then -- `false` means no balancer, `nil` is error
-      return nil, err
+      return nil, upstream
     end
 
     if balancer then

--- a/kong/core/handler.lua
+++ b/kong/core/handler.lua
@@ -312,6 +312,7 @@ return {
         -- ip                = nil,            -- final target IP address
         -- balancer          = nil,            -- the balancer object, in case of a balancer
         -- hostname          = nil,            -- the hostname belonging to the final target IP
+        -- hash_value        = nil,            -- balancer hash (integer)
       }
 
       ctx.api              = api

--- a/kong/dao/migrations/cassandra.lua
+++ b/kong/dao/migrations/cassandra.lua
@@ -481,4 +481,43 @@ return {
     ]],
     down = function(_, _, dao) end  -- not implemented
   },
+  {
+    name = "2017-10-27-134100_consistent_hashing_1",
+    up = [[
+      ALTER TABLE upstreams ADD hash_on text;
+      ALTER TABLE upstreams ADD hash_fallback text;
+      ALTER TABLE upstreams ADD hash_on_header text;
+      ALTER TABLE upstreams ADD hash_fallback_header text;
+    ]],
+    down = [[
+      ALTER TABLE upstreams DROP hash_on;
+      ALTER TABLE upstreams DROP hash_fallback;
+      ALTER TABLE upstreams DROP hash_on_header;
+      ALTER TABLE upstreams DROP hash_fallback_header;
+    ]]
+  },
+  {
+    name = "2017-10-27-134100_consistent_hashing_2",
+    up = function(_, _, dao)
+      local rows, err = dao.db:query([[
+        SELECT * FROM upstreams;
+      ]])
+      if err then
+        return err
+      end
+
+      for _, row in ipairs(rows) do
+        if not row.hash_on or not row.hash_fallback then
+          row.hash_on = "none"
+          row.hash_fallback = "none"
+--          row.created_at = nil
+          local _, err = dao.upstreams:update(row, { id = row.id })
+          if err then
+            return err
+          end
+        end
+      end
+    end,
+    down = function(_, _, dao) end  -- n.a. since the columns will be dropped
+  },
 }

--- a/kong/dao/schemas/upstreams.lua
+++ b/kong/dao/schemas/upstreams.lua
@@ -90,6 +90,11 @@ return {
       end
     end
 
+    if (config.hash_on == "header" and not config.hash_on_header) or
+       (config.hash_fallback == "header" and not config.hash_fallback_header) then
+      return false, Errors.schema("Hashing on 'header', but no header name provided")
+    end
+
     if config.hash_on == "none" then
       if config.hash_fallback ~= "none" then
         return false, Errors.schema("Cannot set fallback if primary 'hash_on' is not set")

--- a/kong/dao/schemas/upstreams.lua
+++ b/kong/dao/schemas/upstreams.lua
@@ -90,22 +90,32 @@ return {
       end
     end
 
-    if (config.hash_on == "header" and not config.hash_on_header) or
-       (config.hash_fallback == "header" and not config.hash_fallback_header) then
-      return false, Errors.schema("Hashing on 'header', but no header name provided")
+    if (config.hash_on == "header"
+        and not config.hash_on_header) or
+       (config.hash_fallback == "header"
+        and not config.hash_fallback_header) then
+      return false, Errors.schema("Hashing on 'header', " ..
+                                  "but no header name provided")
     end
 
     if config.hash_on == "none" then
       if config.hash_fallback ~= "none" then
-        return false, Errors.schema("Cannot set fallback if primary 'hash_on' is not set")
+        return false, Errors.schema("Cannot set fallback if primary " ..
+                                    "'hash_on' is not set")
       end
+
     else
       if config.hash_on == config.hash_fallback then
         if config.hash_on ~= "header" then
-          return false, Errors.schema("Cannot set fallback and primary hash to the same value")
+          return false, Errors.schema("Cannot set fallback and primary " ..
+                                      "hashes to the same value")
+
         else
-          if config.hash_on_header:upper() == config.hash_fallback_header:upper() then
-            return false, Errors.schema("Cannot set fallback and primary hash to the same value")
+          local upper_hash_on = config.hash_on_header:upper()
+          local upper_hash_fallback = config.hash_fallback_header:upper()
+          if upper_hash_on == upper_hash_fallback then
+            return false, Errors.schema("Cannot set fallback and primary "..
+                                        "hashes to the same value")
           end
         end
       end

--- a/kong/dao/schemas/upstreams.lua
+++ b/kong/dao/schemas/upstreams.lua
@@ -51,12 +51,10 @@ return {
     hash_on_header = {
       -- header name, if `hash_on == "header"`
       type = "string",
-      default = "",
     },
     hash_fallback_header = {
       -- header name, if `hash_fallback == "header"`
       type = "string",
-      default = "",
     },
     slots = {
       -- the number of slots in the loadbalancer algorithm
@@ -78,14 +76,14 @@ return {
       return false, Errors.schema("Invalid name; no port allowed")
     end
 
-    if config.hash_on_header ~= "" then
+    if config.hash_on_header then
       local ok, err = utils.validate_header_name(config.hash_on_header)
       if not ok then
         return false, Errors.schema("Header: " .. err)
       end
     end
 
-    if config.hash_fallback_header ~= "" then
+    if config.hash_fallback_header then
       local ok, err = utils.validate_header_name(config.hash_fallback_header)
       if not ok then
         return false, Errors.schema("Header: " .. err)

--- a/kong/dao/schemas/upstreams.lua
+++ b/kong/dao/schemas/upstreams.lua
@@ -96,7 +96,13 @@ return {
       end
     else
       if config.hash_on == config.hash_fallback then
-        return false, Errors.schema("Cannot set fallback and primary hash to the same value")
+        if config.hash_on ~= "header" then
+          return false, Errors.schema("Cannot set fallback and primary hash to the same value")
+        else
+          if config.hash_on_header:upper() == config.hash_fallback_header:upper() then
+            return false, Errors.schema("Cannot set fallback and primary hash to the same value")
+          end
+        end
       end
     end
 

--- a/kong/dao/schemas/upstreams.lua
+++ b/kong/dao/schemas/upstreams.lua
@@ -48,12 +48,12 @@ return {
         "header",
       },
     },
-    hash_header1 = {
+    hash_on_header = {
       -- header name, if `hash_on == "header"`
       type = "string",
       default = "",
     },
-    hash_header2 = {
+    hash_fallback_header = {
       -- header name, if `hash_fallback == "header"`
       type = "string",
       default = "",
@@ -78,15 +78,15 @@ return {
       return false, Errors.schema("Invalid name; no port allowed")
     end
 
-    if config.hash_header1 ~= "" then
-      local ok, err = utils.validate_header_name(config.hash_header1)
+    if config.hash_on_header ~= "" then
+      local ok, err = utils.validate_header_name(config.hash_on_header)
       if not ok then
         return false, Errors.schema("Header: " .. err)
       end
     end
 
-    if config.hash_header2 ~= "" then
-      local ok, err = utils.validate_header_name(config.hash_header2)
+    if config.hash_fallback_header ~= "" then
+      local ok, err = utils.validate_header_name(config.hash_fallback_header)
       if not ok then
         return false, Errors.schema("Header: " .. err)
       end

--- a/spec/01-unit/011-balancer_spec.lua
+++ b/spec/01-unit/011-balancer_spec.lua
@@ -115,6 +115,7 @@ describe("Balancer", function()
 
   describe("creating hash values", function()
     local headers
+    local backup
     before_each(function()
       headers = setmetatable({}, {
           __newindex = function(self, key, value)
@@ -124,14 +125,15 @@ describe("Balancer", function()
             return rawget(self, key:upper())
           end,
       })
+      backup = { ngx.req, ngx.var, ngx.ctx }
       ngx.req = { get_headers = function() return headers end }
       ngx.var = {}
       ngx.ctx = {}
     end)
     after_each(function()
-      ngx.req = nil
-      ngx.var = nil
-      ngx.ctx = nil
+      ngx.req = backup[1]
+      ngx.var = backup[2]
+      ngx.ctx = backup[3]
     end)
     it("none", function()
       local hash = balancer._create_hash({

--- a/spec/01-unit/011-balancer_spec.lua
+++ b/spec/01-unit/011-balancer_spec.lua
@@ -2,7 +2,8 @@ describe("Balancer", function()
   local singletons, balancer
   local UPSTREAMS_FIXTURES
   local TARGETS_FIXTURES
-  --local uuid = require("kong.tools.utils").uuid
+  local crc32 = ngx.crc32_short
+  local uuid = require("kong.tools.utils").uuid
 
   
   setup(function()
@@ -111,4 +112,115 @@ describe("Balancer", function()
       assert(targets[4].id == "a1")
     end)
   end)
+
+  describe("creating hash values", function()
+    local headers
+    before_each(function()
+      headers = setmetatable({}, {
+          __newindex = function(self, key, value)
+            rawset(self, key:upper(), value)
+          end,
+          __index = function(self, key)
+            return rawget(self, key:upper())
+          end,
+      })
+      ngx.req = { get_headers = function() return headers end }
+      ngx.var = {}
+      ngx.ctx = {}
+    end)
+    after_each(function()
+      ngx.req = nil
+      ngx.var = nil
+      ngx.ctx = nil
+    end)
+    it("none", function()
+      local hash = balancer._create_hash({
+          hash_on = "none",
+      })
+      assert.is_nil(hash)
+    end)
+    it("consumer", function()
+      local value = uuid()
+      ngx.ctx.authenticated_consumer = { id = value }
+      local hash = balancer._create_hash({
+          hash_on = "consumer",
+      })
+      assert.are.same(crc32(value), hash)
+    end)
+    it("ip", function()
+      local value = "1.2.3.4"
+      ngx.var.remote_addr = value
+      local hash = balancer._create_hash({
+          hash_on = "ip",
+      })
+      assert.are.same(crc32(value), hash)
+    end)
+    it("header", function()
+      local value = "some header value"
+      headers.HeaderName = value
+      local hash = balancer._create_hash({
+          hash_on = "header",
+          hash_on_header = "HeaderName",
+      })
+      assert.are.same(crc32(value), hash)
+    end)
+    it("multi-header", function()
+      local value = { "some header value", "another value" }
+      headers.HeaderName = value
+      local hash = balancer._create_hash({
+          hash_on = "header",
+          hash_on_header = "HeaderName",
+      })
+      assert.are.same(crc32(table.concat(value)), hash)
+    end)
+    describe("fallback", function()
+      it("none", function()
+        local hash = balancer._create_hash({
+            hash_on = "consumer",
+            hash_fallback = "none",
+        })
+        assert.is_nil(hash)
+      end)
+      it("consumer", function()
+        local value = uuid()
+        ngx.ctx.authenticated_consumer = { id = value }
+        local hash = balancer._create_hash({
+            hash_on = "header",
+            hash_on_header = "non-existing",
+            hash_fallback = "consumer",
+        })
+        assert.are.same(crc32(value), hash)
+      end)
+      it("ip", function()
+        local value = "1.2.3.4"
+        ngx.var.remote_addr = value
+        local hash = balancer._create_hash({
+            hash_on = "consumer",
+            hash_fallback = "ip",
+        })
+        assert.are.same(crc32(value), hash)
+      end)
+      it("header", function()
+        local value = "some header value"
+        headers.HeaderName = value
+        local hash = balancer._create_hash({
+            hash_on = "consumer",
+            hash_fallback = "header",
+            hash_fallback_header = "HeaderName",
+        })
+        assert.are.same(crc32(value), hash)
+      end)
+      it("multi-header", function()
+        local value = { "some header value", "another value" }
+        headers.HeaderName = value
+        local hash = balancer._create_hash({
+            hash_on = "consumer",
+            hash_fallback = "header",
+            hash_fallback_header = "HeaderName",
+        })
+        assert.are.same(crc32(table.concat(value)), hash)
+      end)
+    end)
+  end)
+
 end)

--- a/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
@@ -55,9 +55,13 @@ describe("Admin API: #" .. kong_config.database, function()
           assert.is_number(json.created_at)
           assert.is_string(json.id)
           assert.are.equal(slots_default, json.slots)
+          assert.are.equal("none", json.hash_on)
+          assert.are.equal("none", json.hash_fallback)
+          assert.is_nil(json.hash_on_header)
+          assert.is_nil(json.hash_fallback_header)
         end
       end)
-      it_content_types("creates an upstream without defaults with application/json", function(content_type)
+      it_content_types("creates an upstream without defaults", function(content_type)
         return function()
           local res = assert(client:send {
             method = "POST",
@@ -65,6 +69,10 @@ describe("Admin API: #" .. kong_config.database, function()
             body = {
               name = "my.upstream",
               slots = 10,
+              hash_on = "consumer",
+              hash_fallback = "ip",
+              hash_on_header = "HeaderName",
+              hash_fallback_header = "HeaderFallback",
             },
             headers = {["Content-Type"] = content_type}
           })
@@ -74,6 +82,37 @@ describe("Admin API: #" .. kong_config.database, function()
           assert.is_number(json.created_at)
           assert.is_string(json.id)
           assert.are.equal(10, json.slots)
+          assert.are.equal("consumer", json.hash_on)
+          assert.are.equal("ip", json.hash_fallback)
+          assert.are.equal("HeaderName", json.hash_on_header)
+          assert.are.equal("HeaderFallback", json.hash_fallback_header)
+        end
+      end)
+      it_content_types("creates an upstream with 2 header hashes", function(content_type)
+        return function()
+          local res = assert(client:send {
+            method = "POST",
+            path = "/upstreams",
+            body = {
+              name = "my.upstream",
+              slots = 10,
+              hash_on = "header",
+              hash_fallback = "header",
+              hash_on_header = "HeaderName1",
+              hash_fallback_header = "HeaderName2",
+            },
+            headers = {["Content-Type"] = content_type}
+          })
+          assert.response(res).has.status(201)
+          local json = assert.response(res).has.jsonbody()
+          assert.equal("my.upstream", json.name)
+          assert.is_number(json.created_at)
+          assert.is_string(json.id)
+          assert.are.equal(10, json.slots)
+          assert.are.equal("header", json.hash_on)
+          assert.are.equal("header", json.hash_fallback)
+          assert.are.equal("HeaderName1", json.hash_on_header)
+          assert.are.equal("HeaderName2", json.hash_fallback_header)
         end
       end)
       it_content_types("creates an upstream with " .. slots_max .. " slots", function(content_type)
@@ -133,6 +172,7 @@ describe("Admin API: #" .. kong_config.database, function()
             body = assert.res_status(400, res)
             local json = cjson.decode(body)
             assert.same({ message = "Invalid name; must be a valid hostname" }, json)
+
             -- Invalid slots parameter
             res = assert(client:send {
               method = "POST",
@@ -146,6 +186,100 @@ describe("Admin API: #" .. kong_config.database, function()
             body = assert.res_status(400, res)
             local json = cjson.decode(body)
             assert.same({ message = "number of slots must be between 10 and 65536" }, json)
+
+            -- Invalid hash_on entries
+            res = assert(client:send {
+              method = "POST",
+              path = "/upstreams",
+              body = {
+                name = "my.upstream",
+                hash_on = "something that is invalid",
+              },
+              headers = {["Content-Type"] = content_type}
+            })
+            body = assert.res_status(400, res)
+            local json = cjson.decode(body)
+            assert.same({ hash_on = '"something that is invalid" is not allowed. Allowed values are: "none", "consumer", "ip", "header"' }, json)
+
+            -- Invalid hash_fallback entries
+            res = assert(client:send {
+              method = "POST",
+              path = "/upstreams",
+              body = {
+                name = "my.upstream",
+                hash_on = "consumer",
+                hash_fallback = "something that is invalid",
+              },
+              headers = {["Content-Type"] = content_type}
+            })
+            body = assert.res_status(400, res)
+            local json = cjson.decode(body)
+            assert.same({ hash_fallback = '"something that is invalid" is not allowed. Allowed values are: "none", "consumer", "ip", "header"' }, json)
+
+            -- same hash entries
+            res = assert(client:send {
+              method = "POST",
+              path = "/upstreams",
+              body = {
+                name = "my.upstream",
+                hash_on = "consumer",
+                hash_fallback = "consumer",
+              },
+              headers = {["Content-Type"] = content_type}
+            })
+            body = assert.res_status(400, res)
+            local json = cjson.decode(body)
+            assert.same({ message = "Cannot set fallback and primary hash to the same value" }, json)
+
+            -- Invalid header
+            res = assert(client:send {
+              method = "POST",
+              path = "/upstreams",
+              body = {
+                name = "my.upstream",
+                hash_on = "header",
+                hash_fallback = "consumer",
+                hash_on_header = "not a <> valid <> header name",
+              },
+              headers = {["Content-Type"] = content_type}
+            })
+            body = assert.res_status(400, res)
+            local json = cjson.decode(body)
+            assert.same({ message = "Header: bad header name 'not a <> valid <> header name', allowed characters are A-Z, a-z, 0-9, '_', and '-'" }, json)
+
+            -- Invalid header
+            res = assert(client:send {
+              method = "POST",
+              path = "/upstreams",
+              body = {
+                name = "my.upstream",
+                hash_on = "consumer",
+                hash_fallback = "header",
+                hash_fallback_header = "not a <> valid <> header name",
+              },
+              headers = {["Content-Type"] = content_type}
+            })
+            body = assert.res_status(400, res)
+            local json = cjson.decode(body)
+            assert.same({ message = "Header: bad header name 'not a <> valid <> header name', allowed characters are A-Z, a-z, 0-9, '_', and '-'" }, json)
+
+            -- Same headers
+            res = assert(client:send {
+              method = "POST",
+              path = "/upstreams",
+              body = {
+                name = "my.upstream",
+                hash_on = "header",
+                hash_fallback = "header",
+                hash_on_header = "headername",
+                hash_fallback_header = "HeaderName",  --> validate case insensitivity
+              },
+              headers = {["Content-Type"] = content_type}
+            })
+            body = assert.res_status(400, res)
+            local json = cjson.decode(body)
+            assert.same({ message = "Cannot set fallback and primary hash to the same value" }, json)
+
           end
         end)
         it_content_types("returns 409 on conflict", function(content_type)

--- a/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
@@ -280,6 +280,38 @@ describe("Admin API: #" .. kong_config.database, function()
             local json = cjson.decode(body)
             assert.same({ message = "Cannot set fallback and primary hash to the same value" }, json)
 
+            -- No headername provided
+            res = assert(client:send {
+              method = "POST",
+              path = "/upstreams",
+              body = {
+                name = "my.upstream",
+                hash_on = "header",
+                hash_fallback = "header",
+                hash_on_header = nil,  -- not given
+                hash_fallback_header = "HeaderName",
+              },
+              headers = {["Content-Type"] = content_type}
+            })
+            body = assert.res_status(400, res)
+            local json = cjson.decode(body)
+            assert.same({ message = "Hashing on 'header', but no header name provided" }, json)
+
+            -- No fallback headername provided
+            res = assert(client:send {
+              method = "POST",
+              path = "/upstreams",
+              body = {
+                name = "my.upstream",
+                hash_on = "consumer",
+                hash_fallback = "header",
+              },
+              headers = {["Content-Type"] = content_type}
+            })
+            body = assert.res_status(400, res)
+            local json = cjson.decode(body)
+            assert.same({ message = "Hashing on 'header', but no header name provided" }, json)
+
           end
         end)
         it_content_types("returns 409 on conflict", function(content_type)

--- a/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
@@ -229,7 +229,7 @@ describe("Admin API: #" .. kong_config.database, function()
             })
             body = assert.res_status(400, res)
             local json = cjson.decode(body)
-            assert.same({ message = "Cannot set fallback and primary hash to the same value" }, json)
+            assert.same({ message = "Cannot set fallback and primary hashes to the same value" }, json)
 
             -- Invalid header
             res = assert(client:send {
@@ -278,7 +278,7 @@ describe("Admin API: #" .. kong_config.database, function()
             })
             body = assert.res_status(400, res)
             local json = cjson.decode(body)
-            assert.same({ message = "Cannot set fallback and primary hash to the same value" }, json)
+            assert.same({ message = "Cannot set fallback and primary hashes to the same value" }, json)
 
             -- No headername provided
             res = assert(client:send {

--- a/spec/02-integration/05-proxy/09-balancer_spec.lua
+++ b/spec/02-integration/05-proxy/09-balancer_spec.lua
@@ -10,10 +10,10 @@ local TEST_LOG = false    -- extra verbose logging of test server
 -- modified http-server. Accepts (sequentially) a number of incoming
 -- connections, and returns the number of succesful ones.
 -- Also features a timeout setting.
-local function http_server(timeout, count, port, ...)
+local function http_server(timeout, count, port, no_timeout)
   local threads = require "llthreads2.ex"
   local thread = threads.new({
-    function(timeout, count, port, TEST_LOG)
+    function(timeout, count, port, no_timeout, TEST_LOG)
 
       local function test_log(...)
         if not TEST_LOG then
@@ -44,7 +44,11 @@ local function http_server(timeout, count, port, ...)
         if err == "timeout" then
           if socket.gettime() > expire then
             server:close()
-            error("timeout")
+            if no_timeout then
+              return success
+            else
+              error("timeout")
+            end
           end
         elseif not client then
           server:close()
@@ -83,9 +87,9 @@ local function http_server(timeout, count, port, ...)
       test_log("test http server on port ", port, " closed")
       return success
     end
-  }, timeout, count, port, TEST_LOG)
+  }, timeout, count, port, no_timeout, TEST_LOG)
 
-  local server = thread:start(...)
+  local server = thread:start()
   ngx.sleep(0.2)  -- attempt to make sure server is started for failing CI tests
   return server
 end
@@ -112,28 +116,52 @@ dao_helpers.for_each_dao(function(kong_config)
     end)
 
     describe("Balancing", function()
-      local client, api_client, upstream, target1, target2
+      local client, api_client, upstream1, upstream2, target1, target2
 
       before_each(function()
         helpers.run_migrations()
+        -- insert an api with round-robin balancer
         assert(helpers.dao.apis:insert {
           name = "balancer.test",
           hosts = { "balancer.test" },
           upstream_url = "http://service.xyz.v1/path",
         })
-        upstream = assert(helpers.dao.upstreams:insert {
+        upstream1 = assert(helpers.dao.upstreams:insert {
           name = "service.xyz.v1",
           slots = 10,
         })
         target1 = assert(helpers.dao.targets:insert {
           target = "127.0.0.1:" .. PORT,
           weight = 10,
-          upstream_id = upstream.id,
+          upstream_id = upstream1.id,
         })
         target2 = assert(helpers.dao.targets:insert {
           target = "127.0.0.1:" .. (PORT+1),
           weight = 10,
-          upstream_id = upstream.id,
+          upstream_id = upstream1.id,
+        })
+
+        -- insert an api with round-robin balancer
+        assert(helpers.dao.apis:insert {
+          name = "hashing.test",
+          hosts = { "hashing.test" },
+          upstream_url = "http://service.hashing.v1/path",
+        })
+        upstream2 = assert(helpers.dao.upstreams:insert {
+          name = "service.hashing.v1",
+          slots = 10,
+          hash_on = "header",
+          hash_on_header = "hashme",
+        })
+        target1 = assert(helpers.dao.targets:insert {
+          target = "127.0.0.1:" .. PORT+2,
+          weight = 10,
+          upstream_id = upstream2.id,
+        })
+        target2 = assert(helpers.dao.targets:insert {
+          target = "127.0.0.1:" .. (PORT+3),
+          weight = 10,
+          upstream_id = upstream2.id,
         })
 
         -- insert additional api + upstream with no targets
@@ -162,7 +190,7 @@ dao_helpers.for_each_dao(function(kong_config)
 
       it("over multiple targets", function()
         local timeout = 10
-        local requests = upstream.slots * 2 -- go round the balancer twice
+        local requests = upstream1.slots * 2 -- go round the balancer twice
 
         -- setup target servers
         local server1 = http_server(timeout, requests/2, PORT)
@@ -188,9 +216,40 @@ dao_helpers.for_each_dao(function(kong_config)
         assert.are.equal(requests/2, count1)
         assert.are.equal(requests/2, count2)
       end)
+      it("over multiple targets, with hashing", function()
+        local timeout = 5
+        local requests = upstream2.slots * 2 -- go round the balancer twice
+
+        -- setup target servers
+        local server1 = http_server(timeout, requests, PORT+2, true)
+        local server2 = http_server(timeout, requests, PORT+3, true)
+
+        -- Go hit them with our test requests
+        for _ = 1, requests do
+          local res = assert(client:send {
+            method = "GET",
+            path = "/",
+            headers = {
+              ["Host"] = "hashing.test",
+              ["hashme"] = "just a value", 
+            }
+          })
+          assert.response(res).has.status(200)
+        end
+
+        -- collect server results; hitcount
+        -- one should get all the hits, the other 0, and hence a timeout
+        local _, count1 = server1:join()
+        local _, count2 = server2:join()
+
+        -- verify, print a warning about the timeout error
+        assert(count1 == 0 or count1 == requests, "counts should either get a timeout-error or ALL hits")
+        assert(count2 == 0 or count2 == requests, "counts should either get a timeout-error or ALL hits")
+        assert(count1 + count2 == requests)
+      end)
       it("adding a target", function()
         local timeout = 10
-        local requests = upstream.slots * 2 -- go round the balancer twice
+        local requests = upstream1.slots * 2 -- go round the balancer twice
 
         -- setup target servers
         local server1 = http_server(timeout, requests/2, PORT)
@@ -219,7 +278,7 @@ dao_helpers.for_each_dao(function(kong_config)
         -- add a new target 3
         local res = assert(api_client:send {
           method = "POST",
-          path = "/upstreams/" .. upstream.name .. "/targets",
+          path = "/upstreams/" .. upstream1.name .. "/targets",
           headers = {
             ["Content-Type"] = "application/json"
           },
@@ -262,7 +321,7 @@ dao_helpers.for_each_dao(function(kong_config)
       end)
       it("removing a target", function()
         local timeout = 10
-        local requests = upstream.slots * 2 -- go round the balancer twice
+        local requests = upstream1.slots * 2 -- go round the balancer twice
 
         -- setup target servers
         local server1 = http_server(timeout, requests/2, PORT)
@@ -291,7 +350,7 @@ dao_helpers.for_each_dao(function(kong_config)
         -- modify weight for target 2, set to 0
         local res = assert(api_client:send {
           method = "POST",
-          path = "/upstreams/" .. upstream.name .. "/targets",
+          path = "/upstreams/" .. upstream1.name .. "/targets",
           headers = {
             ["Content-Type"] = "application/json"
           },
@@ -328,7 +387,7 @@ dao_helpers.for_each_dao(function(kong_config)
       end)
       it("modifying target weight", function()
         local timeout = 10
-        local requests = upstream.slots * 2 -- go round the balancer twice
+        local requests = upstream1.slots * 2 -- go round the balancer twice
 
         -- setup target servers
         local server1 = http_server(timeout, requests/2, PORT)
@@ -397,7 +456,7 @@ dao_helpers.for_each_dao(function(kong_config)
       end)
       it("failure due to targets all 0 weight", function()
         local timeout = 10
-        local requests = upstream.slots * 2 -- go round the balancer twice
+        local requests = upstream1.slots * 2 -- go round the balancer twice
 
         -- setup target servers
         local server1 = http_server(timeout, requests/2, PORT)
@@ -426,7 +485,7 @@ dao_helpers.for_each_dao(function(kong_config)
         -- modify weight for both targets, set to 0
         local res = assert(api_client:send {
           method = "POST",
-          path = "/upstreams/" .. upstream.name .. "/targets",
+          path = "/upstreams/" .. upstream1.name .. "/targets",
           headers = {
             ["Content-Type"] = "application/json"
           },
@@ -439,7 +498,7 @@ dao_helpers.for_each_dao(function(kong_config)
 
         res = assert(api_client:send {
           method = "POST",
-          path = "/upstreams/" .. upstream.name .. "/targets",
+          path = "/upstreams/" .. upstream1.name .. "/targets",
           headers = {
             ["Content-Type"] = "application/json"
           },

--- a/spec/02-integration/05-proxy/09-balancer_spec.lua
+++ b/spec/02-integration/05-proxy/09-balancer_spec.lua
@@ -153,12 +153,12 @@ dao_helpers.for_each_dao(function(kong_config)
           hash_on = "header",
           hash_on_header = "hashme",
         })
-        target1 = assert(helpers.dao.targets:insert {
+        assert(helpers.dao.targets:insert {
           target = "127.0.0.1:" .. PORT+2,
           weight = 10,
           upstream_id = upstream2.id,
         })
-        target2 = assert(helpers.dao.targets:insert {
+        assert(helpers.dao.targets:insert {
           target = "127.0.0.1:" .. (PORT+3),
           weight = 10,
           upstream_id = upstream2.id,

--- a/spec/02-integration/05-proxy/09-balancer_spec.lua
+++ b/spec/02-integration/05-proxy/09-balancer_spec.lua
@@ -141,7 +141,7 @@ dao_helpers.for_each_dao(function(kong_config)
           upstream_id = upstream1.id,
         })
 
-        -- insert an api with round-robin balancer
+        -- insert an api with consistent-hashing balancer
         assert(helpers.dao.apis:insert {
           name = "hashing.test",
           hosts = { "hashing.test" },


### PR DESCRIPTION
One can define 2 keys to hash on, if the first key returns `nil`, the fallback is used (for example if a header is not present). The options for the keys are:

1. `none`:  do not use a hash, just do (weighted) round-robin. This is the default.
1. `consumer`: use the `consumer_id`, or if not found the `credential_id`. (later is for external auth like `oauth2` or `ldap`)
1. `ip`: use the originating ip address
1. `header`: use the header specified in the additional header option. If there are multiple headers by this name, then all entries are used (concatenated)

The hash value is created from the resulting string-value, and is calculated as a numerical `crc32`.
