### PR TITLE
Updating router to consider the upstream uri

### DIFF
--- a/kong/core/router.lua
+++ b/kong/core/router.lua
@@ -821,9 +821,11 @@ function _M.new(apis)
 
   function self.exec(ngx)
     local method      = ngx.req.get_method()
-    local request_uri = ngx.var.request_uri
-    local uri         = request_uri
-
+    local request_uri = ngx.var.upstream_uri
+	    if(request_uri == nil or request_uri == '') then
+        request_uri = ngx.var.request_uri
+      end
+    local uri = request_uri
     do
       local idx = find(uri, "?", 2, true)
       if idx then


### PR DESCRIPTION

NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Mashape/kong/blob/master/CONTRIBUTING.md#contributing



This fix changes the router to consider the upstream uri once the uri is edited this will allow plugins to modify the uri in runtime and allow users to write plugins with runtime url manipulation


