### PR TITLE
feat(key-auth) add endpoint to list all key-auths

### DIFF
--- a/kong/plugins/key-auth/api.lua
+++ b/kong/plugins/key-auth/api.lua
@@ -53,12 +53,12 @@ return {
       crud.delete(self.keyauth_credential, dao_factory.keyauth_credentials)
     end
   },
-  ["/key-auth/"] = {
+  ["/key-auths/"] = {
     GET = function(self, dao_factory)
       crud.paginated_set(self, dao_factory.keyauth_credentials)
     end
   },
-  ["/key-auth/:credential_key_or_id/consumer"] = {
+  ["/key-auths/:credential_key_or_id/consumer"] = {
     before = function(self, dao_factory, helpers)
       local credentials, err = crud.find_by_id_or_field(
         dao_factory.keyauth_credentials,

--- a/kong/plugins/key-auth/api.lua
+++ b/kong/plugins/key-auth/api.lua
@@ -52,5 +52,34 @@ return {
     DELETE = function(self, dao_factory)
       crud.delete(self.keyauth_credential, dao_factory.keyauth_credentials)
     end
+  },
+  ["/key-auth/"] = {
+    GET = function(self, dao_factory)
+      crud.paginated_set(self, dao_factory.keyauth_credentials)
+    end
+  },
+  ["/key-auth/:credential_key_or_id/consumer"] = {
+    before = function(self, dao_factory, helpers)
+      local credentials, err = crud.find_by_id_or_field(
+        dao_factory.keyauth_credentials,
+        {},
+        self.params.credential_key_or_id,
+        "key"
+      )
+
+      if err then
+        return helpers.yield_error(err)
+      elseif next(credentials) == nil then
+        return helpers.responses.send_HTTP_NOT_FOUND()
+      end
+
+      self.params.credential_key_or_id = nil
+      self.params.username_or_id = credentials[1].consumer_id
+      crud.find_consumer_by_username_or_id(self, dao_factory, helpers)
+    end,
+
+    GET = function(self, dao_factory,helpers)
+      return helpers.responses.send_HTTP_OK(self.consumer)
+    end
   }
 }

--- a/spec/03-plugins/10-key-auth/01-api_spec.lua
+++ b/spec/03-plugins/10-key-auth/01-api_spec.lua
@@ -333,7 +333,7 @@ describe("Plugin: key-auth (API)", function()
       it("retrieve all the key-auths", function()
         local res = assert(admin_client:send {
           method = "GET",
-          path = "/key-auth/"
+          path = "/key-auths/"
         })
         local body = assert.res_status(200, res)
         local json = cjson.decode(body)
@@ -344,7 +344,7 @@ describe("Plugin: key-auth (API)", function()
       it("retrieve all the key-auths", function()
         local res = assert(admin_client:send {
           method = "GET",
-          path = "/key-auth"
+          path = "/key-auths"
         })
         local body = assert.res_status(200, res)
         local json = cjson.decode(body)
@@ -355,7 +355,7 @@ describe("Plugin: key-auth (API)", function()
       it("retrieve key-auths for a consumer_id", function()
         local res = assert(admin_client:send {
           method = "GET",
-          path = "/key-auth?consumer_id=" .. consumer.id
+          path = "/key-auths?consumer_id=" .. consumer.id
         })
         local body = assert.res_status(200, res)
         local json = cjson.decode(body)
@@ -366,7 +366,7 @@ describe("Plugin: key-auth (API)", function()
       it("return empty for a non-existing consumer_id", function()
         local res = assert(admin_client:send {
           method = "GET",
-          path = "/key-auth?consumer_id=" .. utils.uuid(),
+          path = "/key-auths?consumer_id=" .. utils.uuid(),
         })
         local body = assert.res_status(200, res)
         local json = cjson.decode(body)
@@ -376,7 +376,7 @@ describe("Plugin: key-auth (API)", function()
       end)
     end)
   end)
-  describe("/key-auth/:credential_key_or_id/consumer", function()
+  describe("/key-auths/:credential_key_or_id/consumer", function()
     describe("GET", function()
       local credential
       setup(function()
@@ -388,7 +388,7 @@ describe("Plugin: key-auth (API)", function()
       it("retrieve consumer from a key id", function()
         local res = assert(admin_client:send {
           method = "GET",
-          path = "/key-auth/" .. credential.id .. "/consumer"
+          path = "/key-auths/" .. credential.id .. "/consumer"
         })
         local body = assert.res_status(200, res)
         local json = cjson.decode(body)
@@ -397,7 +397,7 @@ describe("Plugin: key-auth (API)", function()
       it("retrieve a Consumer from a credential's key", function()
         local res = assert(admin_client:send {
           method = "GET",
-          path = "/key-auth/" .. credential.key .. "/consumer"
+          path = "/key-auths/" .. credential.key .. "/consumer"
         })
         local body = assert.res_status(200, res)
         local json = cjson.decode(body)
@@ -406,14 +406,14 @@ describe("Plugin: key-auth (API)", function()
       it("returns 404 for a random non-existing id", function()
         local res = assert(admin_client:send {
           method = "GET",
-          path = "/key-auth/" .. utils.uuid()  .. "/consumer"
+          path = "/key-auths/" .. utils.uuid()  .. "/consumer"
         })
         assert.res_status(404, res)
       end)
       it("returns 404 for a random non-existing key", function()
         local res = assert(admin_client:send {
           method = "GET",
-          path = "/key-auth/" .. utils.random_string()  .. "/consumer"
+          path = "/key-auths/" .. utils.random_string()  .. "/consumer"
         })
         assert.res_status(404, res)
       end)


### PR DESCRIPTION
### Summary

Adding an endpoint to list all the keys of all consumers.
This is an initial commit to get better feedback from the community.

- The endpoint could be changed to something else.
- Grouping of multiple keys belonging to the same consumer is something I'm considering
- A similar thing could be done for the ACL plugin.

Tests are missing right now.

### Full changelog

* Implement an endpoint GET /plugins/key-auth/consumers to list all the consumers with their key(s).
