### PR TITLE
perf(*-rate-limiting) optimize redis pipelining

### DIFF
--- a/kong/plugins/rate-limiting/policies/init.lua
+++ b/kong/plugins/rate-limiting/policies/init.lua
@@ -99,6 +99,9 @@ return {
         end
       end
 
+      local keys = {}
+      local expirations = {}
+      local idx = 0
       local periods = timestamp.get_timestamps(current_timestamp)
       for period, period_date in pairs(periods) do
         if limits[period] then
@@ -109,20 +112,27 @@ return {
             return nil, err
           end
 
-          red:init_pipeline((not exists or exists == 0) and 2 or 1)
-          red:incrby(cache_key, value)
+          idx = idx + 1
+          keys[idx] = cache_key
           if not exists or exists == 0 then
-            red:expire(cache_key, EXPIRATIONS[period])
-          end
-
-          local _, err = red:commit_pipeline()
-          if err then
-            ngx_log(ngx.ERR, "failed to commit pipeline in Redis: ", err)
-            return nil, err
+            expirations[idx] = EXPIRATIONS[period]
           end
         end
       end
 
+      red:init_pipeline()
+      for i = 1, idx do
+        red:incrby(keys[i], value)
+        if expirations[i] then
+          red:expire(keys[i], expirations[i])
+        end
+      end
+
+      local _, err = red:commit_pipeline()
+      if err then
+        ngx_log(ngx.ERR, "failed to commit pipeline in Redis: ", err)
+        return nil, err
+      end
       local ok, err = red:set_keepalive(10000, 100)
       if not ok then
         ngx_log(ngx.ERR, "failed to set Redis keepalive: ", err)


### PR DESCRIPTION
### Summary

Redis policy for rate-limiting and response rate-limiting plugins uses redis pipelining feature but start and commit multiple pipelines instead of using a single one.

I messed up in a force push on my forked repo, this is same as #2932 

Sorry for the confusion.

### Full changelog

* Optimize redis storage policy for rate limiting plugin by using a single pipeline
* Optimize redis storage policy for response rate limiting plugin by using a single pipeline