### PR TITLE
Ability to use "Authorization: WhaTeVer base64(username:password)"

### DIFF
--- a/kong/plugins/ldap-auth/access.lua
+++ b/kong/plugins/ldap-auth/access.lua
@@ -18,10 +18,16 @@ local PROXY_AUTHORIZATION = "proxy-authorization"
 
 local _M = {}
 
-local function retrieve_credentials(authorization_header_value)
+local function case_insensitive(pattern)
+  return pattern:gsub("(.)", function(letter)
+    return string.format("[%s%s]", letter:lower(), letter:upper())
+  end)
+end
+
+local function retrieve_credentials(authorization_header_value, conf)
   local username, password
   if authorization_header_value then
-    local cred = match(authorization_header_value, "%s*[ldap|LDAP]%s+(.*)")
+    local cred = match(authorization_header_value, "%s*" .. case_insensitive(conf.header_type) .. "%s+(.*)")
 
     if cred ~= nil then
       local decoded_cred = decode_base64(cred)
@@ -82,7 +88,7 @@ local function load_credential(given_username, given_password, conf)
 end
 
 local function authenticate(conf, given_credentials)
-  local given_username, given_password = retrieve_credentials(given_credentials)
+  local given_username, given_password = retrieve_credentials(given_credentials, conf)
   if given_username == nil then
     return false
   end

--- a/kong/plugins/ldap-auth/access.lua
+++ b/kong/plugins/ldap-auth/access.lua
@@ -4,6 +4,9 @@ local singletons = require "kong.singletons"
 local ldap = require "kong.plugins.ldap-auth.ldap"
 
 local match = string.match
+local lower = string.lower
+local find = string.find
+local sub = string.sub
 local ngx_log = ngx.log
 local request = ngx.req
 local ngx_error = ngx.ERR
@@ -18,18 +21,12 @@ local PROXY_AUTHORIZATION = "proxy-authorization"
 
 local _M = {}
 
-local function case_insensitive(pattern)
-  return pattern:gsub("(.)", function(letter)
-    return string.format("[%s%s]", letter:lower(), letter:upper())
-  end)
-end
-
 local function retrieve_credentials(authorization_header_value, conf)
   local username, password
   if authorization_header_value then
-    local cred = match(authorization_header_value, "%s*" .. case_insensitive(conf.header_type) .. "%s+(.*)")
-
-    if cred ~= nil then
+    local s, e = find(lower(authorization_header_value), "%s*" .. lower(conf.header_type) .. "%s+")
+    if s == 1 then
+      local cred = sub(authorization_header_value, e + 1)
       local decoded_cred = decode_base64(cred)
       username, password = match(decoded_cred, "(.+):(.+)")
     end

--- a/kong/plugins/ldap-auth/schema.lua
+++ b/kong/plugins/ldap-auth/schema.lua
@@ -22,5 +22,6 @@ return {
     timeout = {type = "number", default = 10000},
     keepalive = {type = "number", default = 60000},
     anonymous = {type = "string", default = "", func = check_user},
+    header_type = {type = "string", default = "ldap"},
   }
 }


### PR DESCRIPTION
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Mashape/kong/blob/master/CONTRIBUTING.md#contributing

### Summary

Ability to use `Authorization: WhaTeVer base64(username:password)` has a authorization header for the ldap-auth plugin.

In particular, when not using the basic-auth plugin, using `Authorization: Basic base64(username:password)` instead of "Authorization: LDAP base64(username:password)` will allow you to use any client (web browser, curl) without having to fool around the headers manually.

### Full changelog

* The ldap-auth plugin can now use any `Authorization type` you want, such as `Authorization: LDAP base64(username:password)`, `Authorization: Basic base64(username:password)`, `Authorization: WhaTeVer base64(username:password)`. This can be set through the new `config.header_type` configuration option for the ldap-auth plugin. Its default value is `ldap` 
