### PR TITLE
allow JWT token to be sent as a cookie

### DIFF
--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -35,7 +35,7 @@ local function retrieve_token(request, conf)
     end
   end
   
-  authorization_header = request.get_headers()["authorization"]
+  local authorization_header = request.get_headers()["authorization"]
   if authorization_header then
     local iterator, iter_err = ngx_re_gmatch(authorization_header, "\\s*[Bb]earer\\s+(.+)")
     if not iterator then

--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -6,6 +6,7 @@ local jwt_decoder = require "kong.plugins.jwt.jwt_parser"
 local string_format = string.format
 local ngx_re_gmatch = ngx.re.gmatch
 
+local ngx_var = ngx.var
 local ngx_set_header = ngx.req.set_header
 local get_method = ngx.req.get_method
 
@@ -14,7 +15,8 @@ local JwtHandler = BasePlugin:extend()
 JwtHandler.PRIORITY = 1005
 
 --- Retrieve a JWT in a request.
--- Checks for the JWT in URI parameters, then for a JWT token in a cookie names and then the `Authorization` header.
+-- Checks for the JWT in URI parameters, then for a JWT token in cookies
+-- and finally in the `Authorization` header.
 -- @param request ngx request object
 -- @param conf Plugin configuration
 -- @return token JWT token contained in request (can be a table) or nil
@@ -29,9 +31,9 @@ local function retrieve_token(request, conf)
   end
 
   for _, v in ipairs(conf.cookie_names) do
-    local jwt_cookie = ngx.unescape_uri(ngx.var["cookie_" .. v])
+    local jwt_cookie = ngx_var["cookie_" .. v]
     if jwt_cookie and jwt_cookie ~= "" then
-      return jwt_cookie, nil
+      return jwt_cookie
     end
   end
   

--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -6,7 +6,6 @@ local jwt_decoder = require "kong.plugins.jwt.jwt_parser"
 local string_format = string.format
 local ngx_re_gmatch = ngx.re.gmatch
 
-local ngx_var = ngx.var
 local ngx_set_header = ngx.req.set_header
 local get_method = ngx.req.get_method
 
@@ -31,7 +30,7 @@ local function retrieve_token(request, conf)
   end
 
   for _, v in ipairs(conf.cookie_names) do
-    local jwt_cookie = ngx_var["cookie_" .. v]
+    local jwt_cookie = ngx.var["cookie_" .. v]
     if jwt_cookie and jwt_cookie ~= "" then
       return jwt_cookie
     end

--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -29,8 +29,9 @@ local function retrieve_token(request, conf)
     end
   end
 
+  local ngx_var = ngx.var
   for _, v in ipairs(conf.cookie_names) do
-    local jwt_cookie = ngx.var["cookie_" .. v]
+    local jwt_cookie = ngx_var["cookie_" .. v]
     if jwt_cookie and jwt_cookie ~= "" then
       return jwt_cookie
     end

--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -14,7 +14,7 @@ local JwtHandler = BasePlugin:extend()
 JwtHandler.PRIORITY = 1005
 
 --- Retrieve a JWT in a request.
--- Checks for the JWT in URI parameters, then in the `Authorization` header.
+-- Checks for the JWT in URI parameters, then for a JWT token in a cookie names and then the `Authorization` header.
 -- @param request ngx request object
 -- @param conf Plugin configuration
 -- @return token JWT token contained in request (can be a table) or nil
@@ -28,7 +28,14 @@ local function retrieve_token(request, conf)
     end
   end
 
-  local authorization_header = request.get_headers()["authorization"]
+  for _, v in ipairs(conf.cookie_names) do
+    local jwt_cookie = ngx.unescape_uri(ngx.var["cookie_" .. v])
+    if jwt_cookie and jwt_cookie ~= "" then
+      return jwt_cookie, nil
+    end
+  end
+  
+  authorization_header = request.get_headers()["authorization"]
   if authorization_header then
     local iterator, iter_err = ngx_re_gmatch(authorization_header, "\\s*[Bb]earer\\s+(.+)")
     if not iterator then

--- a/kong/plugins/jwt/migrations/cassandra.lua
+++ b/kong/plugins/jwt/migrations/cassandra.lua
@@ -50,4 +50,22 @@ return {
     end,
     down = function(_, _, dao) end  -- not implemented
   },
+  {
+    name = "2017-10-25-211200_jwt-cookie_names-default",
+    up = function(_, _, dao)
+      for ok, config, update in plugin_config_iterator(dao, "jwt") do
+        if not ok then
+          return config
+        end
+        if config.cookie_names == nil then
+          config.cookie_names = {}
+          local _, err = update(config)
+          if err then
+            return err
+          end
+        end
+      end
+    end,
+    down = function(_, _, dao) end  -- not implemented
+  },
 }

--- a/kong/plugins/jwt/migrations/postgres.lua
+++ b/kong/plugins/jwt/migrations/postgres.lua
@@ -68,4 +68,22 @@ return {
     end,
     down = function(_, _, dao) end  -- not implemented
   },
+  {
+    name = "2017-10-25-211200_jwt-cookie_names-default",
+    up = function(_, _, dao)
+      for ok, config, update in plugin_config_iterator(dao, "jwt") do
+        if not ok then
+          return config
+        end
+        if config.cookie_names == nil then
+          config.cookie_names = {}
+          local _, err = update(config)
+          if err then
+            return err
+          end
+        end
+      end
+    end,
+    down = function(_, _, dao) end  -- not implemented
+  },
 }

--- a/kong/plugins/jwt/schema.lua
+++ b/kong/plugins/jwt/schema.lua
@@ -12,6 +12,7 @@ return {
   no_consumer = true,
   fields = {
     uri_param_names = {type = "array", default = {"jwt"}},
+    cookie_names = {type = "array", default = {}},
     key_claim_name = {type = "string", default = "iss"},
     secret_is_base64 = {type = "boolean", default = false},
     claims_to_verify = {type = "array", enum = {"exp", "nbf"}},

--- a/spec/03-plugins/17-jwt/03-access_spec.lua
+++ b/spec/03-plugins/17-jwt/03-access_spec.lua
@@ -281,7 +281,7 @@ describe("Plugin: jwt (access)", function()
       })
       assert.res_status(200, res)
     end)
-    it("finds the JWT if given in cookie crumble", function()
+    it("returns 200 the JWT is found in the cookie crumble", function()
       PAYLOAD.iss = jwt_secret.key
       local jwt = jwt_encoder.encode(PAYLOAD, jwt_secret.secret)
       local res = assert(proxy_client:send {
@@ -294,7 +294,7 @@ describe("Plugin: jwt (access)", function()
       })
       assert.res_status(200, res)
     end)
-    it("finds the JWT if given in cookie silly", function()
+    it("returns 200 if the JWT is found in the cookie silly", function()
       PAYLOAD.iss = jwt_secret.key
       local jwt = jwt_encoder.encode(PAYLOAD, jwt_secret.secret)
       local res = assert(proxy_client:send {
@@ -307,9 +307,9 @@ describe("Plugin: jwt (access)", function()
       })
       assert.res_status(200, res)
     end)
-    it("reports a 401 if the JWT in cookie is corrupt", function()
+    it("reports a 401 if the JWT in the cookie is corrupt", function()
       PAYLOAD.iss = jwt_secret.key
-      local jwt = 'no-way-this-works' .. jwt_encoder.encode(PAYLOAD, jwt_secret.secret)
+      local jwt = "no-way-this-works" .. jwt_encoder.encode(PAYLOAD, jwt_secret.secret)
       local res = assert(proxy_client:send {
         method  = "GET",
         path    = "/request",
@@ -321,7 +321,7 @@ describe("Plugin: jwt (access)", function()
       local body = assert.res_status(401, res)
       assert.equal([[{"message":"Bad token; invalid JSON"}]], body)
     end)
-    it("no cookie with JWT token, defaults to 'Authorization'", function()
+    it("reports a 200 without cookies but with a JWT token in the Authorization header", function()
       PAYLOAD.iss = jwt_secret.key
       local jwt = jwt_encoder.encode(PAYLOAD, jwt_secret.secret)
       local res = assert(proxy_client:send {
@@ -333,6 +333,16 @@ describe("Plugin: jwt (access)", function()
         }
       })
       assert.res_status(200, res)
+    end)
+    it("returns 401 if no JWT tokens are found in cookies or Authorization header", function()
+      local res = assert(proxy_client:send {
+        method  = "GET",
+        path    = "/request",
+        headers = {
+          ["Host"] = "jwt9.com",
+        }
+      })
+      assert.res_status(401, res)
     end)
     it("finds the JWT if given in a custom URL parameter", function()
       PAYLOAD.iss = jwt_secret.key

--- a/spec/03-plugins/17-jwt/03-access_spec.lua
+++ b/spec/03-plugins/17-jwt/03-access_spec.lua
@@ -307,6 +307,21 @@ describe("Plugin: jwt (access)", function()
       })
       assert.res_status(200, res)
     end)
+    it("returns 403 if the JWT found in the cookie does not match a credential", function()
+      PAYLOAD.iss = 'incorrect-issuer'
+      local jwt = jwt_encoder.encode(PAYLOAD, jwt_secret.secret)
+      local res = assert(proxy_client:send {
+        method  = "GET",
+        path    = "/request",
+        headers = {
+          ["Host"] = "jwt9.com",
+          ["Cookie"] = "silly=" .. jwt .. "; path=/;domain=.jwt9.com"
+        }
+      })
+      local body = assert.res_status(403, res)
+      local json = cjson.decode(body)
+      assert.same({ message = "No credentials found for given 'iss'" }, json)
+    end)
     it("reports a 401 if the JWT in the cookie is corrupt", function()
       PAYLOAD.iss = jwt_secret.key
       local jwt = "no-way-this-works" .. jwt_encoder.encode(PAYLOAD, jwt_secret.secret)

--- a/spec/03-plugins/17-jwt/03-access_spec.lua
+++ b/spec/03-plugins/17-jwt/03-access_spec.lua
@@ -310,7 +310,6 @@ describe("Plugin: jwt (access)", function()
     it("no cookie with JWT token, defaults to 'Authorization'", function()
       PAYLOAD.iss = jwt_secret.key
       local jwt = jwt_encoder.encode(PAYLOAD, jwt_secret.secret)
-      local jwt = jwt_encoder.encode(PAYLOAD, jwt_secret.secret)
       local res = assert(proxy_client:send {
         method  = "GET",
         path    = "/request",
@@ -319,7 +318,7 @@ describe("Plugin: jwt (access)", function()
           ["Authorization"] = "Bearer " .. jwt,
         }
       })
-      local body = assert.res_status(200, res)
+      assert.res_status(200, res)
     end)
     it("finds the JWT if given in a custom URL parameter", function()
       PAYLOAD.iss = jwt_secret.key

--- a/spec/03-plugins/17-jwt/03-access_spec.lua
+++ b/spec/03-plugins/17-jwt/03-access_spec.lua
@@ -307,6 +307,20 @@ describe("Plugin: jwt (access)", function()
       })
       assert.res_status(200, res)
     end)
+    it("reports a 401 if the JWT in cookie is corrupt", function()
+      PAYLOAD.iss = jwt_secret.key
+      local jwt = 'no-way-this-works' .. jwt_encoder.encode(PAYLOAD, jwt_secret.secret)
+      local res = assert(proxy_client:send {
+        method  = "GET",
+        path    = "/request",
+        headers = {
+          ["Host"] = "jwt9.com",
+          ["Cookie"] = "silly=" .. jwt .. "; path=/;domain=.jwt9.com"
+        }
+      })
+      local body = assert.res_status(401, res)
+      assert.equal([[{"message":"Bad token; invalid JSON"}]], body)
+    end)
     it("no cookie with JWT token, defaults to 'Authorization'", function()
       PAYLOAD.iss = jwt_secret.key
       local jwt = jwt_encoder.encode(PAYLOAD, jwt_secret.secret)


### PR DESCRIPTION
### Summary

Added support for passing the JWT in a cookie. When one or more 'cookie_names' are specified, the plugin will try to retrieve the jwt from the specified cookies in order. 

There are a number of pull requests open which seem to be aborted. I will take it on me to get it done.

### Full changelog

* When the jwt plugin is configured with the property 'cookie_names', the plugin will
attempt to retrieve  the jwt token from one of the named cookies.

### Issues resolved
#2911 
#2894
#2363
