### PR TITLE
chore(*) bump lua-resty-http

### DIFF
--- a/kong-0.11.0-0.rockspec
+++ b/kong-0.11.0-0.rockspec
@@ -14,7 +14,7 @@ dependencies = {
   "luasec == 0.6",
   "luasocket == 3.0-rc1",
   "penlight == 1.5.4",
-  "lua-resty-http == 0.08",
+  "lua-resty-http == 0.10",
   "lua-resty-jit-uuid == 0.0.5",
   "multipart == 0.5",
   "version == 0.2",


### PR DESCRIPTION
### Summary

Bump to a version that does not include a breaking change.

### Full changelog

* Bump `lua-resty-http` dependency to `0.10`