### PR TITLE
fix(ldap) stricter test of header_type

### DIFF
--- a/kong-0.11.0-0.rockspec
+++ b/kong-0.11.0-0.rockspec
@@ -245,6 +245,8 @@ build = {
     ["kong.plugins.hmac-auth.api"] = "kong/plugins/hmac-auth/api.lua",
     ["kong.plugins.hmac-auth.daos"] = "kong/plugins/hmac-auth/daos.lua",
 
+    ["kong.plugins.ldap-auth.migrations.cassandra"] = "kong/plugins/ldap-auth/migrations/cassandra.lua",
+    ["kong.plugins.ldap-auth.migrations.postgres"] = "kong/plugins/ldap-auth/migrations/postgres.lua",
     ["kong.plugins.ldap-auth.handler"] = "kong/plugins/ldap-auth/handler.lua",
     ["kong.plugins.ldap-auth.access"] = "kong/plugins/ldap-auth/access.lua",
     ["kong.plugins.ldap-auth.schema"] = "kong/plugins/ldap-auth/schema.lua",

--- a/kong/plugins/ldap-auth/access.lua
+++ b/kong/plugins/ldap-auth/access.lua
@@ -24,7 +24,7 @@ local _M = {}
 local function retrieve_credentials(authorization_header_value, conf)
   local username, password
   if authorization_header_value then
-    local s, e = find(lower(authorization_header_value), "%s*" .. lower(conf.header_type) .. "%s+")
+    local s, e = find(lower(authorization_header_value), "^%s*" .. lower(conf.header_type) .. "%s+")
     if s == 1 then
       local cred = sub(authorization_header_value, e + 1)
       local decoded_cred = decode_base64(cred)

--- a/kong/plugins/ldap-auth/migrations/cassandra.lua
+++ b/kong/plugins/ldap-auth/migrations/cassandra.lua
@@ -1,0 +1,23 @@
+local plugin_config_iterator = require("kong.dao.migrations.helpers").plugin_config_iterator
+local schema = require("kong.plugins.ldap-auth.schema")
+
+return {
+  {
+    name = "2017-10-23-150900_header_type_default",
+    up = function(_, _, dao)
+      for ok, config, update in plugin_config_iterator(dao, "ldap-auth") do
+        if not ok then
+          return config
+        end
+        if config.header_type == nil then
+          config.header_type = schema.fields.header_type.default
+          local _, err = update(config)
+          if err then
+            return err
+          end
+        end
+      end
+    end,
+    down = function(_, _, dao) end  -- not implemented
+  },
+}

--- a/kong/plugins/ldap-auth/migrations/postgres.lua
+++ b/kong/plugins/ldap-auth/migrations/postgres.lua
@@ -1,0 +1,23 @@
+local plugin_config_iterator = require("kong.dao.migrations.helpers").plugin_config_iterator
+local schema = require("kong.plugins.ldap-auth.schema")
+
+return {
+  {
+    name = "2017-10-23-150900_header_type_default",
+    up = function(_, _, dao)
+      for ok, config, update in plugin_config_iterator(dao, "ldap-auth") do
+        if not ok then
+          return config
+        end
+        if config.header_type == nil then
+          config.header_type = schema.fields.header_type.default
+          local _, err = update(config)
+          if err then
+            return err
+          end
+        end
+      end
+    end,
+    down = function(_, _, dao) end  -- not implemented
+  },
+}

--- a/spec/03-plugins/21-ldap-auth/01-access_spec.lua
+++ b/spec/03-plugins/21-ldap-auth/01-access_spec.lua
@@ -172,6 +172,19 @@ describe("Plugin: ldap-auth (access)", function()
     })
     assert.response(r).has.status(200)
   end)
+  it("fails if credential type is invalid in post request", function()
+    local r = assert(client:send {
+      method = "POST",
+      path = "/request",
+      body = {},
+      headers = {
+        host = "ldap.com",
+        authorization = "invalidldap " .. ngx.encode_base64("einstein:password"),
+        ["content-type"] = "application/x-www-form-urlencoded",
+      }
+    })
+    assert.response(r).has.status(403)
+  end)
   it("passes if credential is valid and starts with space in post request", function()
     local r = assert(client:send {
       method = "POST",


### PR DESCRIPTION
A companion PR to #2963: adds a stricter test of `header_type`, plus tests for the functionality introduced by that PR and a regression test for the previously-existing bug uncovered by that PR.