### PR TITLE
feat(jwt) add jwt token to ngx.ctx

### DIFF
--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -80,13 +80,14 @@ local function load_consumer(consumer_id, anonymous)
   return result
 end
 
-local function set_consumer(consumer, jwt_secret)
+local function set_consumer(consumer, jwt_secret, token)
   ngx_set_header(constants.HEADERS.CONSUMER_ID, consumer.id)
   ngx_set_header(constants.HEADERS.CONSUMER_CUSTOM_ID, consumer.custom_id)
   ngx_set_header(constants.HEADERS.CONSUMER_USERNAME, consumer.username)
   ngx.ctx.authenticated_consumer = consumer
   if jwt_secret then
     ngx.ctx.authenticated_credential = jwt_secret
+    ngx.ctx.authenticated_jwt_token = token
     ngx_set_header(constants.HEADERS.ANONYMOUS, nil) -- in case of auth plugins concatenation
   else
     ngx_set_header(constants.HEADERS.ANONYMOUS, true)
@@ -177,8 +178,7 @@ local function do_authentication(conf)
     return false, {status = 403, message = string_format("Could not find consumer for '%s=%s'", conf.key_claim_name, jwt_secret_key)}
   end
 
-  set_consumer(consumer, jwt_secret)
-  ngx.ctx.jwt_token = token
+  set_consumer(consumer, jwt_secret, token)
 
   return true
 end
@@ -209,7 +209,7 @@ function JwtHandler:access(conf)
       if err then
         return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
       end
-      set_consumer(consumer, nil)
+      set_consumer(consumer, nil, nil)
     else
       return responses.send(err.status, err.message)
     end

--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -178,6 +178,7 @@ local function do_authentication(conf)
   end
 
   set_consumer(consumer, jwt_secret)
+  ngx.ctx.jwt_token = token
 
   return true
 end

--- a/spec/fixtures/custom_plugins/kong/plugins/ctx-checker/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/ctx-checker/handler.lua
@@ -1,0 +1,27 @@
+local BasePlugin = require "kong.plugins.base_plugin"
+
+
+local CtxCheckerHandler = BasePlugin:extend()
+
+
+CtxCheckerHandler.PRIORITY = 1000
+
+
+function CtxCheckerHandler:new()
+  CtxCheckerHandler.super.new(self, "ctx checker")
+end
+
+
+function CtxCheckerHandler:access(conf)
+  CtxCheckerHandler.super.access(self)
+
+  if conf.ctx_field then
+    if ngx.ctx[conf.ctx_field] then
+      ngx.req.set_header("Ctx-Checker-Plugin-Field", ngx.ctx[conf.ctx_field])
+    end
+  end
+
+end
+
+
+return CtxCheckerHandler

--- a/spec/fixtures/custom_plugins/kong/plugins/ctx-checker/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/ctx-checker/schema.lua
@@ -1,0 +1,5 @@
+return {
+  fields = {
+    ctx_field = { type = "string" },
+  }
+}


### PR DESCRIPTION
### Summary

In this way subsequent plugins can do things with the token
(specific payload validation, check for revocation, etc..) without
having to obtain it from the request.