### PR TITLE
fixed internal error with invalid hmac-auth authorization header

### DIFF
--- a/kong/plugins/hmac-auth/access.lua
+++ b/kong/plugins/hmac-auth/access.lua
@@ -73,8 +73,10 @@ local function validate_params(params, conf)
   -- check enforced headers are present
   if conf.enforce_headers and #conf.enforce_headers >= 1 then
     local enforced_header_set = list_as_set(conf.enforce_headers)
-    for _, header in ipairs(params.hmac_headers) do
-      enforced_header_set[header] = nil
+    if params.hmac_headers then
+      for _, header in ipairs(params.hmac_headers) do
+        enforced_header_set[header] = nil
+      end
     end
     for _, header in ipairs(conf.enforce_headers) do
       if enforced_header_set[header] then

--- a/spec/03-plugins/20-hmac-auth/03-access_spec.lua
+++ b/spec/03-plugins/20-hmac-auth/03-access_spec.lua
@@ -1160,6 +1160,21 @@ describe("Plugin: hmac-auth (access)", function()
       assert.res_status(403, res)
     end)
 
+    it("should return a 403 with an invalid authorization header", function()
+      local date = os.date("!%a, %d %b %Y %H:%M:%S GMT")
+      local res = assert(client:send {
+        method  = "GET",
+        path    = "/request",
+        body    = {},
+        headers = {
+          ["HOST"]                = "hmacauth6.com",
+          date                    = date,
+          ["proxy-authorization"] = "this is no hmac token at all is it?",
+        },
+      })
+      assert.res_status(403, res)
+    end)
+
     it("should pass with hmac-sha1", function()
       local date = os.date("!%a, %d %b %Y %H:%M:%S GMT")
       local encodedSignature = ngx.encode_base64(


### PR DESCRIPTION
### Summary

When an invalid hmac-auth header is sent by the client, kong generates an internal server error when enforce_headers are configured. The code did not check whether any headers were actually parsed.

### Issues resolved

Fix #2951