### PR TITLE
feat(basic-auth) add endpoint to list all basic-auths

### DIFF
--- a/kong/plugins/basic-auth/api.lua
+++ b/kong/plugins/basic-auth/api.lua
@@ -52,5 +52,34 @@ return {
     DELETE = function(self, dao_factory)
       crud.delete(self.basicauth_credential, dao_factory.basicauth_credentials)
     end
+  },
+  ["/basic-auths/"] = {
+    GET = function(self, dao_factory)
+      crud.paginated_set(self, dao_factory.basicauth_credentials)
+    end
+  },
+  ["/basic-auths/:credential_username_or_id/consumer"] = {
+    before = function(self, dao_factory, helpers)
+      local credentials, err = crud.find_by_id_or_field(
+        dao_factory.basicauth_credentials,
+        nil,
+        self.params.credential_username_or_id,
+        "username"
+      )
+
+      self.params.credential_username_or_id = nil
+      if err then
+        return helpers.yield_error(err)
+      elseif next(credentials) == nil then
+        return helpers.responses.send_HTTP_NOT_FOUND()
+      end
+
+      self.params.username_or_id = credentials[1].consumer_id
+      crud.find_consumer_by_username_or_id(self, dao_factory, helpers)
+    end,
+
+    GET = function(self, dao_factory,helpers)
+      return helpers.responses.send_HTTP_OK(self.consumer)
+    end
   }
 }

--- a/spec/03-plugins/11-basic-auth/02-api_spec.lua
+++ b/spec/03-plugins/11-basic-auth/02-api_spec.lua
@@ -1,5 +1,6 @@
 local cjson = require "cjson"
 local helpers = require "spec.helpers"
+local utils = require "kong.tools.utils"
 
 describe("Plugin: basic-auth (API)", function()
   local consumer, admin_client
@@ -298,6 +299,137 @@ describe("Plugin: basic-auth (API)", function()
           })
           assert.res_status(404, res)
         end)
+      end)
+    end)
+  end)
+  describe("/basic-auths", function()
+    local consumer2
+    describe("GET", function()
+      setup(function()
+        helpers.dao:truncate_table("basicauth_credentials")
+        assert(helpers.dao.basicauth_credentials:insert {
+          consumer_id = consumer.id,
+          username = "bob"
+        })
+        consumer2 = assert(helpers.dao.consumers:insert {
+          username = "bob-the-buidler"
+        })
+        assert(helpers.dao.basicauth_credentials:insert {
+          consumer_id = consumer2.id,
+          username = "bob-the-buidler"
+        })
+      end)
+      it("retrieves all the basic-auths with trailing slash", function()
+        local res = assert(admin_client:send {
+          method = "GET",
+          path = "/basic-auths/"
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.is_table(json.data)
+        assert.equal(2, #json.data)
+        assert.equal(2, json.total)
+      end)
+      it("retrieves all the basic-auths without trailing slash", function()
+        local res = assert(admin_client:send {
+          method = "GET",
+          path = "/basic-auths"
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.is_table(json.data)
+        assert.equal(2, #json.data)
+        assert.equal(2, json.total)
+      end)
+      it("paginates through the basic-auths", function()
+        local res = assert(admin_client:send {
+          method = "GET",
+          path = "/basic-auths?size=1",
+        })
+        local body = assert.res_status(200, res)
+        local json_1 = cjson.decode(body)
+        assert.is_table(json_1.data)
+        assert.equal(1, #json_1.data)
+        assert.equal(2, json_1.total)
+
+        res = assert(admin_client:send {
+          method = "GET",
+          path = "/basic-auths?size=1&offset=" .. json_1.offset,
+        })
+        body = assert.res_status(200, res)
+        local json_2 = cjson.decode(body)
+        assert.is_table(json_2.data)
+        assert.equal(1, #json_2.data)
+        assert.equal(2, json_2.total)
+
+        assert.not_same(json_1.data, json_2.data)
+        assert.is_nil(json_2.offset) -- last page
+      end)
+      it("retrieve basic-auths for a consumer_id", function()
+        local res = assert(admin_client:send {
+          method = "GET",
+          path = "/basic-auths?consumer_id=" .. consumer.id
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.is_table(json.data)
+        assert.equal(1, #json.data)
+        assert.equal(1, json.total)
+      end)
+      it("return empty for a non-existing consumer_id", function()
+        local res = assert(admin_client:send {
+          method = "GET",
+          path = "/basic-auths?consumer_id=" .. utils.uuid(),
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.is_table(json.data)
+        assert.equal(0, #json.data)
+        assert.equal(0, json.total)
+      end)
+    end)
+  end)
+  describe("/basic-auths/:credential_username_or_id/consumer", function()
+    describe("GET", function()
+      local credential
+      setup(function()
+        helpers.dao:truncate_table("basicauth_credentials")
+        credential = assert(helpers.dao.basicauth_credentials:insert {
+          consumer_id = consumer.id,
+          username = "bob"
+        })
+      end)
+      it("retrieve consumer from a basic-auth id", function()
+        local res = assert(admin_client:send {
+          method = "GET",
+          path = "/basic-auths/" .. credential.id .. "/consumer"
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.same(consumer,json)
+      end)
+      it("retrieve consumer from a basic-auth username", function()
+        local res = assert(admin_client:send {
+          method = "GET",
+          path = "/basic-auths/" .. credential.username .. "/consumer"
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.same(consumer,json)
+      end)
+      it("returns 404 for a random non-existing basic-auth id", function()
+        local res = assert(admin_client:send {
+          method = "GET",
+          path = "/basic-auths/" .. utils.uuid()  .. "/consumer"
+        })
+        assert.res_status(404, res)
+      end)
+      it("returns 404 for a random non-existing basic-auth username", function()
+        local res = assert(admin_client:send {
+          method = "GET",
+          path = "/basic-auths/" .. utils.random_string()  .. "/consumer"
+        })
+        assert.res_status(404, res)
       end)
     end)
   end)


### PR DESCRIPTION
### Summary

Adding endpoints:
- `GET /basic-auth` : lists all the basic-auths present in kong
- `GET /basic-auth/:credential_id/consumer` : retrieve a consumer form a credential ID
### Full changelog

* `GET /basic-auth` : lists all the basic-auths present in kong
* `GET /basic-auth/:credential_id/consumer` : retrieve a consumer form a credential ID
* Add related tests

This is similar to #2955 and #2371