### PR TITLE
fix(admin) return empty array for enabled_in_cluster property

### DIFF
--- a/kong/api/routes/kong.lua
+++ b/kong/api/routes/kong.lua
@@ -1,6 +1,7 @@
 local utils = require "kong.tools.utils"
 local singletons = require "kong.singletons"
 local conf_loader = require "kong.conf_loader"
+local cjson = require "cjson"
 
 local sub = string.sub
 local find = string.find
@@ -16,6 +17,7 @@ return {
   ["/"] = {
     GET = function(self, dao, helpers)
       local distinct_plugins = {}
+      setmetatable(distinct_plugins, cjson.empty_array_mt)      
       local prng_seeds = {}
 
       do

--- a/spec/02-integration/04-admin_api/01-kong_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/01-kong_routes_spec.lua
@@ -65,6 +65,14 @@ describe("Admin API - Kong routes", function()
       local json = cjson.decode(body)
       assert.is_table(json.configuration)
     end)
+    it("enabled_in_cluster property is an array", function()
+      local res = assert(client:send {
+        method = "GET",
+        path = "/"
+      })
+      local body = assert.res_status(200, res)
+      assert(string.match(body, '"enabled_in_cluster":%[]'))
+    end)
     it("obfuscates sensitive settings from the configuration", function()
       local res = assert(client:send {
         method = "GET",


### PR DESCRIPTION
### Summary

Fix admin API `GET /` enabled_in_cluster property to return an empty array when applicable

### Issues resolved

Fix #2982 
