### PR TITLE
fix(cluster) do not inadvertently log error messages

### DIFF
--- a/kong/core/handler.lua
+++ b/kong/core/handler.lua
@@ -127,15 +127,15 @@ return {
                                              data.operation)
 
         -- crud:apis
-        local ok, err = worker_events.post_local("crud", entity_channel, data)
-        if not ok then
+        local _, err = worker_events.post_local("crud", entity_channel, data)
+        if err then
           log(ngx.ERR, "[events] could not broadcast crud event: ", err)
           return
         end
 
         -- crud:apis:create
-        ok, err = worker_events.post_local("crud", entity_operation_channel, data)
-        if not ok then
+        _, err = worker_events.post_local("crud", entity_operation_channel, data)
+        if err then
           log(ngx.ERR, "[events] could not broadcast crud event: ", err)
           return
         end

--- a/kong/dao/dao.lua
+++ b/kong/dao/dao.lua
@@ -146,12 +146,12 @@ function DAO:insert(tbl, options)
   local res, err = self.db:insert(self.table, self.schema, model, self.constraints, options)
   if not err and not options.quiet then
     if self.events then
-      local ok, err = self.events.post_local("dao:crud", "create", {
+      local _, err = self.events.post_local("dao:crud", "create", {
         schema    = self.schema,
         operation = "create",
         entity    = res,
       })
-      if not ok then
+      if err then
         ngx.log(ngx.ERR, "could not propagate CRUD operation: ", err)
       end
     end
@@ -325,13 +325,13 @@ function DAO:update(tbl, filter_keys, options)
   elseif res then
     if not options.quiet then
       if self.events then
-        local ok, err = self.events.post_local("dao:crud", "update", {
+        local _, err = self.events.post_local("dao:crud", "update", {
           schema     = self.schema,
           operation  = "update",
           entity     = res,
           old_entity = old,
         })
-        if not ok then
+        if err then
           ngx.log(ngx.ERR, "could not propagate CRUD operation: ", err)
         end
       end
@@ -382,12 +382,12 @@ function DAO:delete(tbl, options)
   local row, err = self.db:delete(self.table, self.schema, primary_keys, self.constraints)
   if not err and row ~= nil and not options.quiet then
     if self.events then
-      local ok, err = self.events.post_local("dao:crud", "delete", {
+      local _, err = self.events.post_local("dao:crud", "delete", {
         schema    = self.schema,
         operation = "delete",
         entity    = row,
       })
-      if not ok then
+      if err then
         ngx.log(ngx.ERR, "could not propagate CRUD operation: ", err)
       end
     end
@@ -396,12 +396,12 @@ function DAO:delete(tbl, options)
     for k, v in pairs(associated_entites) do
       for _, entity in ipairs(v.entities) do
         if self.events then
-          local ok, err = self.events.post_local("dao:crud", "delete", {
+          local _, err = self.events.post_local("dao:crud", "delete", {
             schema    = v.schema,
             operation = "delete",
             entity    = entity,
           })
-          if not ok then
+          if err then
             ngx.log(ngx.ERR, "could not propagate CRUD operation: ", err)
           end
         end


### PR DESCRIPTION
The `post_local` API of the worker-events library can return `false,
nil` when polling is skipped because we are posting from an event
handler, effectively nullifying the purpose of the first return value of
`post_local`.

My suggestion to lua-resty-worker-events would be to replace the
following line in `post_local`:

    return _M.poll()

with a wrapper:

    local ok, err = _M.poll()
    if err then
        return nil, err
    end

    return true -- the event *was* posted

In the meantime, this commit changes the return values check to rely on
`err ~= nil`, thus avoiding such inadvertent error messages to show up.

Fix #2872