### PR TITLE
feat(jwt) add endpoint to list all JWTs

### DIFF
--- a/kong/plugins/jwt/api.lua
+++ b/kong/plugins/jwt/api.lua
@@ -20,7 +20,7 @@ return {
     end
   },
 
-  ["/consumers/:username_or_id/jwt/:credential_key_or_id"] = {
+  ["/consumers/:username_or_id/jwt/:jwt_key_or_id"] = {
     before = function(self, dao_factory, helpers)
       crud.find_consumer_by_username_or_id(self, dao_factory, helpers)
       self.params.consumer_id = self.consumer.id
@@ -28,7 +28,7 @@ return {
       local credentials, err = crud.find_by_id_or_field(
         dao_factory.jwt_secrets,
         { consumer_id = self.params.consumer_id },
-        self.params.credential_key_or_id,
+        self.params.jwt_key_or_id,
         "key"
       )
 
@@ -37,7 +37,7 @@ return {
       elseif next(credentials) == nil then
         return helpers.responses.send_HTTP_NOT_FOUND()
       end
-      self.params.credential_key_or_id = nil
+      self.params.jwt_key_or_id = nil
 
       self.jwt_secret = credentials[1]
     end,

--- a/spec/03-plugins/17-jwt/02-api_spec.lua
+++ b/spec/03-plugins/17-jwt/02-api_spec.lua
@@ -1,5 +1,6 @@
 local helpers = require "spec.helpers"
 local cjson = require "cjson"
+local utils = require "kong.tools.utils"
 
 local jwt_secrets = helpers.dao.jwt_secrets
 local fixtures = require "spec.03-plugins.17-jwt.fixtures"
@@ -308,6 +309,134 @@ describe("Plugin: jwt (API)", function()
           headers = {
             ["Content-Type"] = "application/json"
           }
+        })
+        assert.res_status(404, res)
+      end)
+    end)
+  end)
+  describe("/jwts", function()
+    local consumer2
+    describe("GET", function()
+      setup(function()
+        helpers.dao:truncate_table("jwt_secrets")
+        assert(helpers.dao.jwt_secrets:insert {
+          consumer_id = consumer.id,
+        })
+        consumer2 = assert(helpers.dao.consumers:insert {
+          username = "bob-the-buidler"
+        })
+        assert(helpers.dao.jwt_secrets:insert {
+          consumer_id = consumer2.id,
+        })
+      end)
+      it("retrieves all the jwts with trailing slash", function()
+        local res = assert(admin_client:send {
+          method = "GET",
+          path = "/jwts/"
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.is_table(json.data)
+        assert.equal(2, #json.data)
+        assert.equal(2, json.total)
+      end)
+      it("retrieves all the jwts without trailing slash", function()
+        local res = assert(admin_client:send {
+          method = "GET",
+          path = "/jwts"
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.is_table(json.data)
+        assert.equal(2, #json.data)
+        assert.equal(2, json.total)
+      end)
+      it("paginates through the jwts", function()
+        local res = assert(admin_client:send {
+          method = "GET",
+          path = "/jwts?size=1",
+        })
+        local body = assert.res_status(200, res)
+        local json_1 = cjson.decode(body)
+        assert.is_table(json_1.data)
+        assert.equal(1, #json_1.data)
+        assert.equal(2, json_1.total)
+
+        res = assert(admin_client:send {
+          method = "GET",
+          path = "/jwts?size=1&offset=" .. json_1.offset,
+        })
+        body = assert.res_status(200, res)
+        local json_2 = cjson.decode(body)
+        assert.is_table(json_2.data)
+        assert.equal(1, #json_2.data)
+        assert.equal(2, json_2.total)
+
+        assert.not_same(json_1.data, json_2.data)
+        assert.is_nil(json_2.offset) -- last page
+      end)
+      it("retrieve jwts for a consumer_id", function()
+        local res = assert(admin_client:send {
+          method = "GET",
+          path = "/jwts?consumer_id=" .. consumer.id
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.is_table(json.data)
+        assert.equal(1, #json.data)
+        assert.equal(1, json.total)
+      end)
+      it("return empty for a non-existing consumer_id", function()
+        local res = assert(admin_client:send {
+          method = "GET",
+          path = "/jwts?consumer_id=" .. utils.uuid(),
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.is_table(json.data)
+        assert.equal(0, #json.data)
+        assert.equal(0, json.total)
+      end)
+    end)
+  end)
+  describe("/jwts/:jwt_key_or_id/consumer", function()
+    describe("GET", function()
+      local credential
+      setup(function()
+        helpers.dao:truncate_table("jwt_secrets")
+        credential = assert(helpers.dao.jwt_secrets:insert {
+          consumer_id = consumer.id
+        })
+      end)
+      it("retrieve consumer from a JWT id", function()
+        local res = assert(admin_client:send {
+          method = "GET",
+          path = "/jwts/" .. credential.id .. "/consumer"
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.same(consumer,json)
+      end)
+      it("retrieve consumer from a JWT key", function()
+        local res = assert(admin_client:send {
+          method = "GET",
+          path = "/jwts/" .. credential.key .. "/consumer"
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.same(consumer,json)
+      end)
+      it("returns 404 for a random non-existing JWT id", function()
+        local res = assert(admin_client:send {
+          method = "GET",
+          path = "/jwts/" .. utils.uuid()  .. "/consumer"
+        })
+        assert.res_status(404, res)
+      end)
+      it("returns 404 for a random non-existing JWT key", function()
+        local res = assert(admin_client:send {
+          method = "GET",
+          path = "/jwts/" .. utils.random_string()  .. "/consumer"
         })
         assert.res_status(404, res)
       end)


### PR DESCRIPTION
* `/jwts/` to paginate through all jwt credentials
* `/jwts/:jwt_key_or_id/consumer` to retrieve the Consumer
associated with a credential

Similar to #2998 #2955 