### PR TITLE
fix(admin) return HTTP 404 on PUT with non-existing PK

### DIFF
--- a/kong/api/crud_helpers.lua
+++ b/kong/api/crud_helpers.lua
@@ -245,6 +245,10 @@ function _M.put(params, dao_collection, post_process)
     -- If entity body has primary key, deal with update
     new_entity, err = dao_collection:update(params, params, {full = true})
     if not err then
+      if not new_entity then
+        return responses.send_HTTP_NOT_FOUND()
+      end
+
       return responses.send_HTTP_OK(post_process_row(new_entity, post_process))
     end
   end


### PR DESCRIPTION
Background
----------

Due to unfortunate legacy design decisions, our HTTP PUT handlers behave
in the following way as of today:

1. if the payload does not have the entity's primary key values,
   we attempt an insert()
2. if the payload has primary key values, we attempt an update()

Issue
-----

While acknowledging this isn't the appropriate/desired behavior for a
PUT handler, #2774 has raised the following concern:

> When a PUT payload contains an non-existing primary key (attempt to
create an entity), the endpoint responds HTTP 200 OK, but the entity is
not created, and the response body is empty.

Root cause & resolution
-----------------------

This was due to a mis-usage of the `dao:update()` API.

While this change will **not** allow #2774 to work the way it is
expected of it to work, this will help alleviate confusion by at least
returning the appropriate HTTP status code, at least in the way our
Admin API implements PUT handlers...

Appendix
--------

In the future, and as we are working towards a new model comprised of a
new Admin API, we promise ourselves to implement a more appropriate
behavior for PUT endpoints.

Fix #2774