### PR TITLE
feat(hmac-auth) add 2 endpoints to interact with hmac-auth credentials

### DIFF
--- a/kong/plugins/hmac-auth/api.lua
+++ b/kong/plugins/hmac-auth/api.lua
@@ -53,5 +53,34 @@ return{
     DELETE = function(self, dao_factory)
       crud.delete(self.hmacauth_credential, dao_factory.hmacauth_credentials)
     end
+  },
+  ["/hmac-auths/"] = {
+    GET = function(self, dao_factory)
+      crud.paginated_set(self, dao_factory.hmacauth_credentials)
+    end
+  },
+  ["/hmac-auths/:hmac_username_or_id/consumer"] = {
+    before = function(self, dao_factory, helpers)
+      local credentials, err = crud.find_by_id_or_field(
+        dao_factory.hmacauth_credentials,
+        {},
+        self.params.hmac_username_or_id,
+        "username"
+      )
+
+      if err then
+        return helpers.yield_error(err)
+      elseif next(credentials) == nil then
+        return helpers.responses.send_HTTP_NOT_FOUND()
+      end
+
+      self.params.hmac_username_or_id = nil
+      self.params.username_or_id = credentials[1].consumer_id
+      crud.find_consumer_by_username_or_id(self, dao_factory, helpers)
+    end,
+
+    GET = function(self, dao_factory,helpers)
+      return helpers.responses.send_HTTP_OK(self.consumer)
+    end
   }
 }

--- a/kong/plugins/hmac-auth/api.lua
+++ b/kong/plugins/hmac-auth/api.lua
@@ -20,7 +20,7 @@ return{
     end
   },
 
-  ["/consumers/:username_or_id/hmac-auth/:credential_username_or_id"]  = {
+  ["/consumers/:username_or_id/hmac-auth/:hmac_username_or_id"]  = {
     before = function(self, dao_factory, helpers)
       crud.find_consumer_by_username_or_id(self, dao_factory, helpers)
       self.params.consumer_id = self.consumer.id
@@ -28,7 +28,7 @@ return{
       local credentials, err = crud.find_by_id_or_field(
         dao_factory.hmacauth_credentials,
         { consumer_id = self.params.consumer_id },
-        self.params.credential_username_or_id,
+        self.params.hmac_username_or_id,
         "username"
       )
 
@@ -37,7 +37,7 @@ return{
       elseif next(credentials) == nil then
         return helpers.responses.send_HTTP_NOT_FOUND()
       end
-      self.params.credential_username_or_id = nil
+      self.params.hmac_username_or_id = nil
 
       self.hmacauth_credential = credentials[1]
     end,


### PR DESCRIPTION
* `/hmac-auths/` to paginate through all hmac-auth credentials
* `/hmac-auths/:credential_key_or_id/consumer` to retrieve the Consumer
associated with a credential