### PR TITLE
chore(*) fix workarounds for lua_cjson empty array handling

### DIFF
--- a/kong/api/crud_helpers.lua
+++ b/kong/api/crud_helpers.lua
@@ -163,21 +163,11 @@ function _M.paginated_set(self, dao_collection, post_process)
     })
   end
 
-  local data
+  local data = setmetatable(rows, cjson.empty_array_mt)
 
-  if #rows == 0 then
-    -- FIXME: remove and stick to previous `empty_array_mt` metatable
-    -- assignment once https://github.com/openresty/lua-cjson/pull/16
-    -- is included in the OpenResty release we use.
-    data = cjson.empty_array
-
-  else
-    data = rows
-
-    if type(post_process) == "function" then
-      for i, row in ipairs(rows) do
-        data[i] = post_process(row)
-      end
+  if type(post_process) == "function" then
+    for i, row in ipairs(rows) do
+      data[i] = post_process(row)
     end
   end
 

--- a/kong/api/routes/certificates.lua
+++ b/kong/api/routes/certificates.lua
@@ -90,13 +90,6 @@ return {
         for j = 1, #rows do
           table.insert(ssl_certificates[i].snis, rows[j].name)
         end
-
-        -- FIXME: remove and stick to previous `empty_array_mt` metatable
-        -- assignment once https://github.com/openresty/lua-cjson/pull/16
-        -- is included in the OpenResty release we use.
-        if #ssl_certificates[i].snis == 0 then
-          ssl_certificates[i].snis = cjson.empty_array
-        end
       end
 
       return helpers.responses.send_HTTP_OK({
@@ -163,13 +156,6 @@ return {
 
       for i = 1, #rows do
         table.insert(row.snis, rows[i].name)
-      end
-
-      -- FIXME: remove and stick to previous `empty_array_mt` metatable
-      -- assignment once https://github.com/openresty/lua-cjson/pull/16
-      -- is included in the OpenResty release we use.
-      if #row.snis == 0 then
-        row.snis = cjson.empty_array
       end
 
       return helpers.responses.send_HTTP_OK(row)

--- a/kong/api/routes/upstreams.lua
+++ b/kong/api/routes/upstreams.lua
@@ -164,14 +164,6 @@ return {
         end
       end
 
-      -- FIXME: remove and stick to previous `empty_array_mt` metatable
-      -- assignment once https://github.com/openresty/lua-cjson/pull/16
-      -- is included in the OpenResty release we use.
-      if #active == 0 then
-        active = cjson.empty_array
-      end
-
-
       -- for now lets not worry about rolling our own pagination
       -- we also end up returning a "backwards" list of targets because
       -- of how we sorted- do we care?

--- a/kong/plugins/galileo/alf.lua
+++ b/kong/plugins/galileo/alf.lua
@@ -70,13 +70,6 @@ local function hash_to_array(t)
     end
   end
 
-  -- FIXME: temporary workardound
-  -- remove once https://github.com/openresty/lua-cjson/pull/16
-  -- is included in a formal OpenResty release.
-  if #arr == 0 then
-    return cjson.empty_array
-  end
-
   return arr
 end
 

--- a/spec/03-plugins/09-galileo/01-alf_spec.lua
+++ b/spec/03-plugins/09-galileo/01-alf_spec.lua
@@ -26,17 +26,6 @@ local alf_serializer = require "kong.plugins.galileo.alf"
 -- input sets to the serializer.
 local function reload_alf_serializer()
   package.loaded["kong.plugins.galileo.alf"] = nil
-
-  -- FIXME: temporary double-loading of the cjson module
-  -- for the encoding JSON as empty array tests in the
-  -- serialize() suite.
-  -- remove once https://github.com/openresty/lua-cjson/pull/16
-  -- is included in a formal OpenResty release.
-  package.loaded["cjson"] = nil
-  package.loaded["cjson.safe"] = nil
-  require "cjson.safe"
-  require "cjson"
-
   alf_serializer = require "kong.plugins.galileo.alf"
 end
 
@@ -516,12 +505,6 @@ describe("ALF serializer", function()
   end) -- add_entry()
 
   describe("serialize()", function()
-    -- FIXME: temporary double-loading of the cjson module
-    -- for the encoding JSON as empty array tests in the
-    -- serialize() suite.
-    -- remove once https://github.com/openresty/lua-cjson/pull/16
-    -- is included in a formal OpenResty release.
-    reload_alf_serializer()
 
     local cjson = require "cjson.safe"
     it("returns a JSON encoded ALF object", function()


### PR DESCRIPTION
### Summary

Since https://github.com/openresty/lua-cjson/pull/16 has been merged quite a while back and we use Openresty 1.11.2.4, we can safely remove some workarounds.