### PR TITLE
fix(basic-auth) accept passwords containing ':'

### DIFF
--- a/kong/plugins/basic-auth/access.lua
+++ b/kong/plugins/basic-auth/access.lua
@@ -39,7 +39,7 @@ local function retrieve_credentials(request, header_name, conf)
     if m and m[1] then
       local decoded_basic = ngx.decode_base64(m[1])
       if decoded_basic then
-        local basic_parts = utils.split(decoded_basic, ":")
+        local basic_parts = utils.split(decoded_basic, ":", 2)
         username = basic_parts[1]
         password = basic_parts[2]
       end
@@ -77,7 +77,7 @@ local function load_credential_from_db(username)
   if not username then
     return
   end
-  
+
   local credential_cache_key = singletons.dao.basicauth_credentials:cache_key(username)
   local credential, err      = singletons.cache:get(credential_cache_key, nil,
                                                     load_credential_into_memory,
@@ -111,7 +111,7 @@ local function set_consumer(consumer, credential)
   else
     ngx_set_header(constants.HEADERS.ANONYMOUS, true)
   end
-  
+
 end
 
 local function do_authentication(conf)
@@ -156,7 +156,7 @@ end
 function _M.execute(conf)
 
   if ngx.ctx.authenticated_credential and conf.anonymous ~= "" then
-    -- we're already authenticated, and we're configured for using anonymous, 
+    -- we're already authenticated, and we're configured for using anonymous,
     -- hence we're in a logical OR between auth methods and we're already done.
     return
   end

--- a/kong/plugins/basic-auth/access.lua
+++ b/kong/plugins/basic-auth/access.lua
@@ -1,4 +1,3 @@
-local utils = require "kong.tools.utils"
 local crypto = require "kong.plugins.basic-auth.crypto"
 local singletons = require "kong.singletons"
 local constants = require "kong.constants"
@@ -6,6 +5,7 @@ local responses = require "kong.tools.responses"
 
 local ngx_set_header = ngx.req.set_header
 local ngx_get_headers = ngx.req.get_headers
+local ngx_re_match = ngx.re.match
 
 local realm = 'Basic realm="' .. _KONG._NAME .. '"'
 
@@ -39,9 +39,17 @@ local function retrieve_credentials(request, header_name, conf)
     if m and m[1] then
       local decoded_basic = ngx.decode_base64(m[1])
       if decoded_basic then
-        local basic_parts = utils.split(decoded_basic, ":", 2)
-        username = basic_parts[1]
-        password = basic_parts[2]
+        local basic_parts, err = ngx_re_match(decoded_basic, "([^:]+):(.+)", "oj")
+        if basic_parts then
+          username = basic_parts[1]
+          password = basic_parts[2]
+        else
+          if err then
+            ngx.log(ngx.ERR, err)
+            return
+          end
+          ngx.log(ngx.ERR, "basic auth header has unrecognized format")
+        end
       end
     end
   end

--- a/spec/03-plugins/11-basic-auth/03-access_spec.lua
+++ b/spec/03-plugins/11-basic-auth/03-access_spec.lua
@@ -49,6 +49,11 @@ describe("Plugin: basic-auth (access)", function()
       password    = "password123",
       consumer_id = consumer.id,
     })
+    assert(helpers.dao.basicauth_credentials:insert {
+      username    = "user321",
+      password    = "password:123",
+      consumer_id = consumer.id,
+    })
 
     local api3 = assert(helpers.dao.apis:insert {
       name         = "api-3",
@@ -195,6 +200,19 @@ describe("Plugin: basic-auth (access)", function()
         path = "/request",
         headers = {
           ["Authorization"] = "Basic dXNlcjEyMzpwYXNzd29yZDEyMw==",
+          ["Host"] = "basic-auth1.com"
+        }
+      })
+      local body = cjson.decode(assert.res_status(200, res))
+      assert.equal('bob', body.headers["x-consumer-username"])
+    end)
+
+    it("authenticates with password including ':'", function()
+      local res = assert(client:send {
+        method = "GET",
+        path = "/request",
+        headers = {
+          ["Authorization"] = "Basic dXNlcjMyMTpwYXNzd29yZDoxMjM=",
           ["Host"] = "basic-auth1.com"
         }
       })


### PR DESCRIPTION
### Summary

When a password contains one or more ':' characters, the password is
truncated up to the first ':' character. This is due to an error
while splitting the user:password string.

### Full changelog

* Modify split in basic-auth/access
* Add test to check a password with ':' is accepted

### Issues resolved

Fix #2986
