### PR TITLE
feat(key-auth) duplicate key-auth to key-auths endpoint

### DIFF
--- a/kong/plugins/key-auth/api.lua
+++ b/kong/plugins/key-auth/api.lua
@@ -1,7 +1,7 @@
 local crud = require "kong.api.crud_helpers"
 
 return {
-  ["/consumers/:username_or_id/key-auth/"] = {
+  ["/consumers/:username_or_id/key-auth(s)/"] = {
     before = function(self, dao_factory, helpers)
       crud.find_consumer_by_username_or_id(self, dao_factory, helpers)
       self.params.consumer_id = self.consumer.id
@@ -19,7 +19,7 @@ return {
       crud.post(self.params, dao_factory.keyauth_credentials)
     end
   },
-  ["/consumers/:username_or_id/key-auth/:credential_key_or_id"] = {
+  ["/consumers/:username_or_id/key-auth(s)/:credential_key_or_id"] = {
     before = function(self, dao_factory, helpers)
       crud.find_consumer_by_username_or_id(self, dao_factory, helpers)
       self.params.consumer_id = self.consumer.id


### PR DESCRIPTION
### Summary

We currently have the following two endpoints:
```
GET /consumers/:username_or_id/key-auth/
GET /consumers/:username_or_id/key-auth/:credential_key_or_id
```

While these are OK, I regularly trip and try to use the following plural and more correct RESTful URIs:
```
GET /consumers/:username_or_id/key-auths/
GET /consumers/:username_or_id/key-auths/:credential_key_or_id
```

This PR adds support for the plural form and keeps the older ones to maintain compatibility.

If it's just me, then we close this PR.
But if this is what we would like (others) to use then I can polish it up.

**TODO**
- Test cases
- Update Documentation