### PR TITLE
fix(conf-loader) add format check for `admin_listen_ssl` string

### DIFF
--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -485,6 +485,7 @@ local function load(path, custom_conf)
     local proxy_ssl_ip, proxy_ssl_port = string.match(conf.proxy_listen_ssl, ip_port_pat)
 
     if not admin_port then return nil, "admin_listen must be of form 'address:port'"
+    elseif not admin_ssl_port then return nil, "admin_listen_ssl must be of form 'address:port'"
     elseif not proxy_port then return nil, "proxy_listen must be of form 'address:port'"
     elseif not proxy_ssl_port then return nil, "proxy_listen_ssl must be of form 'address:port'" end
     conf.admin_ip = admin_ip

--- a/spec/01-unit/002-conf_loader_spec.lua
+++ b/spec/01-unit/002-conf_loader_spec.lua
@@ -234,6 +234,12 @@ describe("Configuration loader", function()
       assert.equal("admin_listen must be of form 'address:port'", err)
 
       conf, err = conf_loader(nil, {
+        admin_listen_ssl = "127.0.0.1"
+      })
+      assert.is_nil(conf)
+      assert.equal("admin_listen_ssl must be of form 'address:port'", err)
+
+      conf, err = conf_loader(nil, {
         proxy_listen = "127.0.0.1"
       })
       assert.is_nil(conf)


### PR DESCRIPTION
### Summary

Adds a listen address check in `conf_loader.lua` for the `admin_listen_ssl` configuration string to enhance error reporting when a Kong node is misconfigured.