### PR TITLE
tests(plugins) wait for UDP server threads to start

### DIFF
--- a/spec/03-plugins/06-statsd/01-log_spec.lua
+++ b/spec/03-plugins/06-statsd/01-log_spec.lua
@@ -299,6 +299,7 @@ describe("Plugin: statsd (log)", function()
         end
       }, UDP_PORT)
       thread:start()
+      ngx.sleep(0.1)
 
       local response = assert(client:send {
         method = "GET",
@@ -345,6 +346,7 @@ describe("Plugin: statsd (log)", function()
         end
       }, UDP_PORT)
       thread:start()
+      ngx.sleep(0.1)
 
       local response = assert(client:send {
         method = "GET",
@@ -405,6 +407,8 @@ describe("Plugin: statsd (log)", function()
         end
       }, UDP_PORT)
       thread:start()
+      ngx.sleep(0.1)
+
       local response = assert(client:send {
         method = "GET",
         path = "/request",
@@ -528,6 +532,8 @@ describe("Plugin: statsd (log)", function()
         end
       }, UDP_PORT)
       thread:start()
+      ngx.sleep(0.1)
+
       local response = assert(client:send {
         method = "GET",
         path = "/request?apikey=kong",

--- a/spec/03-plugins/08-datadog/01-log_spec.lua
+++ b/spec/03-plugins/08-datadog/01-log_spec.lua
@@ -137,6 +137,7 @@ describe("Plugin: datadog (log)", function()
       end
     })
     thread:start()
+    ngx.sleep(0.1)
 
     local res = assert(client:send {
       method = "GET",
@@ -183,6 +184,7 @@ describe("Plugin: datadog (log)", function()
       end
     })
     thread:start()
+    ngx.sleep(0.1)
 
     local res = assert(client:send {
       method = "GET",
@@ -230,6 +232,7 @@ describe("Plugin: datadog (log)", function()
       end
     })
     thread:start()
+    ngx.sleep(0.1)
 
     local res = assert(client:send {
       method = "GET",
@@ -265,6 +268,7 @@ describe("Plugin: datadog (log)", function()
       end
     })
     thread:start()
+    ngx.sleep(0.1)
 
     local res = assert(client:send {
       method = "GET",
@@ -297,6 +301,7 @@ describe("Plugin: datadog (log)", function()
       end
     })
     thread:start()
+    ngx.sleep(0.1)
 
     local res = assert(client:send {
       method = "GET",


### PR DESCRIPTION
This is a band-aid solution to the remaining class of
ephemeral failures happening in our CI. Most threads that
spawn a UDP server use `helper:udp_server` which does
sleep. A few ones run customized servers, and those were
lacking the sleep.

The most proper solution would be to implement an initialization
handshake (and to refactor the tests touched by this patch to
avoid the repetition that proliferated this bug), but this is
the least-invasive patch to address the problem, submitted in
hopes that it can be applied quickly to address the CI issues.
We will revisit this issue properly when we review the test suite
as a whole in the future.

NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

### Summary

SUMMARY_GOES_HERE

### Full changelog

* [Implement ...]
* [Add related tests]
* ...

### Issues resolved

Fix #XXX
