### PR TITLE
feat(acls) add admin endpoints to interact with acls

### DIFF
--- a/kong/plugins/acl/api.lua
+++ b/kong/plugins/acl/api.lua
@@ -53,5 +53,31 @@ return {
     DELETE = function(self, dao_factory)
       crud.delete(self.acl, dao_factory.acls)
     end
+  },
+  ["/acls"] = {
+    GET = function(self, dao_factory)
+      crud.paginated_set(self, dao_factory.acls)
+    end
+  },
+  ["/acls/:acl_id/consumer"] = {
+    before = function(self, dao_factory, helpers)
+      local filter_keys = {
+       id = self.params.acl_id
+      }
+
+      local acls, err = dao_factory.acls:find_all(filter_keys)
+      if err then
+        return helpers.yield_error(err)
+      elseif next(acls) == nil then
+        return helpers.responses.send_HTTP_NOT_FOUND()
+      end
+
+      self.params.username_or_id = acls[1].consumer_id
+      crud.find_consumer_by_username_or_id(self, dao_factory, helpers)
+    end,
+
+    GET = function(self, dao_factory, helpers)
+      return helpers.responses.send_HTTP_OK(self.consumer)
+    end
   }
 }

--- a/spec/03-plugins/19-acl/01-api_spec.lua
+++ b/spec/03-plugins/19-acl/01-api_spec.lua
@@ -1,5 +1,6 @@
 local cjson = require "cjson"
 local helpers = require "spec.helpers"
+local utils = require "kong.tools.utils"
 
 describe("Plugin: acl (API)", function()
   local consumer, admin_client
@@ -60,7 +61,7 @@ describe("Plugin: acl (API)", function()
     end)
 
     describe("PUT", function()
-      it("creates a basic-auth credential", function()
+      it("updates an ACL's groupname", function()
         local res = assert(admin_client:send {
           method = "PUT",
           path = "/consumers/bob/acls",
@@ -265,6 +266,163 @@ describe("Plugin: acl (API)", function()
           })
           assert.res_status(404, res)
         end)
+      end)
+    end)
+  end)
+  
+  describe("/acls", function()
+    local consumer2
+
+    describe("GET", function()
+      setup(function()
+        helpers.dao:truncate_table("acls")
+
+        for i = 1, 3 do
+          assert(helpers.dao.acls:insert {
+            group = "group" .. i,
+            consumer_id = consumer.id
+          })
+        end
+
+        consumer2 = assert(helpers.dao.consumers:insert {
+          username = "bob-the-buidler"
+        })
+
+        for i = 1, 3 do
+          assert(helpers.dao.acls:insert {
+            group = "group" .. i,
+            consumer_id = consumer2.id
+          })
+        end
+      end)
+
+      it("retrieves all the acls with trailing slash", function()
+        local res = assert(admin_client:send {
+          method = "GET",
+          path = "/acls/",
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.is_table(json.data)
+        assert.equal(6, #json.data)
+        assert.equal(6, json.total)
+      end)
+      it("retrieves all the acls without trailing slash", function()
+        local res = assert(admin_client:send {
+          method = "GET",
+          path = "/acls",
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.is_table(json.data)
+        assert.equal(6, #json.data)
+        assert.equal(6, json.total)
+      end)
+      it("paginates through the acls", function()
+        local res = assert(admin_client:send {
+          method = "GET",
+          path = "/acls?size=3",
+        })
+        local body = assert.res_status(200, res)
+        local json_1 = cjson.decode(body)
+        assert.is_table(json_1.data)
+        assert.equal(3, #json_1.data)
+        assert.equal(6, json_1.total)
+
+        res = assert(admin_client:send {
+          method = "GET",
+          path = "/acls",
+          query = {
+            size = 3,
+            offset = json_1.offset,
+          }
+        })
+        body = assert.res_status(200, res)
+        local json_2 = cjson.decode(body)
+        assert.is_table(json_2.data)
+        assert.equal(3, #json_2.data)
+        assert.equal(6, json_2.total)
+
+        assert.not_same(json_1.data, json_2.data)
+        -- Disabled: on Cassandra, the last page still returns a
+        -- next_page token, and thus, an offset proprty in the
+        -- response of the Admin API.
+        --assert.is_nil(json_2.offset) -- last page
+
+      end)
+      it("retrieves acls for a consumer_id", function()
+        local res = assert(admin_client:send {
+          method = "GET",
+          path = "/acls?consumer_id=" .. consumer.id
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.is_table(json.data)
+        assert.equal(3, #json.data)
+        assert.equal(3, json.total)
+      end)
+      it("return empty for a non-existing consumer_id", function()
+        local res = assert(admin_client:send {
+          method = "GET",
+          path = "/acls?consumer_id=" .. utils.uuid(),
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.is_table(json.data)
+        assert.equal(0, #json.data)
+        assert.equal(0, json.total)
+      end)
+      it("retrieves acls belong to a specific group", function()
+        local res = assert(admin_client:send {
+          method = "GET",
+          path = "/acls?group=" .. "group1"
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.is_table(json.data)
+        assert.equal(2, #json.data)
+        assert.equal(2, json.total)
+      end)
+      it("return empty for a non-existing group", function()
+        local res = assert(admin_client:send {
+          method = "GET",
+          path = "/acls?group=" .. "foo-group",
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.is_table(json.data)
+        assert.equal(0, #json.data)
+        assert.equal(0, json.total)
+      end)
+    end)
+  end)
+
+  describe("/acls/:acl_id/consumer", function()
+    describe("GET", function()
+      local credential
+
+      setup(function()
+        helpers.dao:truncate_table("acls")
+        credential = assert(helpers.dao.acls:insert {
+          group = "foo-group",
+          consumer_id = consumer.id
+        })
+      end)
+      it("retrieve Consumer from an acl's id", function()
+        local res = assert(admin_client:send {
+          method = "GET",
+          path = "/acls/" .. credential.id .. "/consumer"
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.same(consumer, json)
+      end)
+      it("returns 404 for a random non-existing id", function()
+        local res = assert(admin_client:send {
+          method = "GET",
+          path = "/acls/" .. utils.uuid()  .. "/consumer"
+        })
+        assert.res_status(404, res)
       end)
     end)
   end)


### PR DESCRIPTION
* `/acls/` to paginate through all acls for all consumers
* `/acls/:acl_id/consumer` to retrieve the Consumer associated with an acl

### Issues resolved

Fix #2188 
Close #2371 
