### PR TITLE
style(contributing) drop assignment alignment rule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -597,19 +597,6 @@ local max_len = 100
 local MAX_LEN = 100
 ```
 
-When assigning several variables on consecutive lines, **do** align their
-assignment operator:
-
-```lua
--- bad
-local str = "world"
-local my_value = "hello"
-
--- good
-local str      = "world"
-local my_value = "hello"
-```
-
 [Back to code style TOC](#table-of-contents---code-style)
 
 
@@ -639,23 +626,6 @@ local t = {foo="hello",bar="world"}
 
 -- good
 local t = { foo = "hello", bar = "world" }
-```
-
-When using the constructor syntax on multiple lines, **do** align the
-assignments:
-
-```lua
--- bad
-local t = {
-  some_key = "hello",
-  some_other_key = "world",
-}
-
--- good
-local t = {
-  some_key       = "hello",
-  some_other_key = "world",
-}
 ```
 
 [Back to code style TOC](#table-of-contents---code-style)


### PR DESCRIPTION
This PR proposes dropping the requirement to always align assignments for variables and table constructors. This will reduce `diff` noise caused by a variable change affecting a number of unrelated lines of code around it. This does not imply that judicious use of alignment of semantically-related concepts is now forbidden (we already use it successfully in the codebase for things other than assignments), it's just no longer a style requirement for every single table constructor and group of assignments.