### PR TITLE
hotfix(*) credentials endpoints test suites with Cassandra

### DIFF
--- a/spec/03-plugins/10-key-auth/01-api_spec.lua
+++ b/spec/03-plugins/10-key-auth/01-api_spec.lua
@@ -371,7 +371,11 @@ describe("Plugin: key-auth (API)", function()
 
         res = assert(admin_client:send {
           method = "GET",
-          path = "/key-auths?size=3&offset=" .. json_1.offset,
+          path = "/key-auths",
+          query = {
+            size = 3,
+            offset = json_1.offset,
+          }
         })
         body = assert.res_status(200, res)
         local json_2 = cjson.decode(body)
@@ -380,7 +384,10 @@ describe("Plugin: key-auth (API)", function()
         assert.equal(6, json_2.total)
 
         assert.not_same(json_1.data, json_2.data)
-        assert.is_nil(json_2.offset) -- last page
+        -- Disabled: on Cassandra, the last page still returns a
+        -- next_page token, and thus, an offset proprty in the
+        -- response of the Admin API.
+        --assert.is_nil(json_2.offset) -- last page
       end)
       it("retrieves key-auths for a consumer_id", function()
         local res = assert(admin_client:send {

--- a/spec/03-plugins/11-basic-auth/02-api_spec.lua
+++ b/spec/03-plugins/11-basic-auth/02-api_spec.lua
@@ -354,7 +354,11 @@ describe("Plugin: basic-auth (API)", function()
 
         res = assert(admin_client:send {
           method = "GET",
-          path = "/basic-auths?size=1&offset=" .. json_1.offset,
+          path = "/basic-auths",
+          query = {
+            size = 1,
+            offset = json_1.offset,
+          }
         })
         body = assert.res_status(200, res)
         local json_2 = cjson.decode(body)
@@ -363,7 +367,10 @@ describe("Plugin: basic-auth (API)", function()
         assert.equal(2, json_2.total)
 
         assert.not_same(json_1.data, json_2.data)
-        assert.is_nil(json_2.offset) -- last page
+        -- Disabled: on Cassandra, the last page still returns a
+        -- next_page token, and thus, an offset proprty in the
+        -- response of the Admin API.
+        --assert.is_nil(json_2.offset) -- last page
       end)
       it("retrieve basic-auths for a consumer_id", function()
         local res = assert(admin_client:send {

--- a/spec/03-plugins/17-jwt/02-api_spec.lua
+++ b/spec/03-plugins/17-jwt/02-api_spec.lua
@@ -364,7 +364,11 @@ describe("Plugin: jwt (API)", function()
 
         res = assert(admin_client:send {
           method = "GET",
-          path = "/jwts?size=1&offset=" .. json_1.offset,
+          path = "/jwts",
+          query = {
+            size = 1,
+            offset = json_1.offset,
+          }
         })
         body = assert.res_status(200, res)
         local json_2 = cjson.decode(body)
@@ -373,7 +377,10 @@ describe("Plugin: jwt (API)", function()
         assert.equal(2, json_2.total)
 
         assert.not_same(json_1.data, json_2.data)
-        assert.is_nil(json_2.offset) -- last page
+        -- Disabled: on Cassandra, the last page still returns a
+        -- next_page token, and thus, an offset proprty in the
+        -- response of the Admin API.
+        --assert.is_nil(json_2.offset) -- last page
       end)
       it("retrieve jwts for a consumer_id", function()
         local res = assert(admin_client:send {

--- a/spec/03-plugins/20-hmac-auth/02-api_spec.lua
+++ b/spec/03-plugins/20-hmac-auth/02-api_spec.lua
@@ -252,7 +252,11 @@ describe("Plugin: hmac-auth (API)", function()
 
         res = assert(client:send {
           method = "GET",
-          path = "/hmac-auths?size=1&offset=" .. json_1.offset,
+          path = "/hmac-auths",
+          query = {
+            size = 1,
+            offset = json_1.offset,
+          }
         })
         body = assert.res_status(200, res)
         local json_2 = cjson.decode(body)
@@ -261,7 +265,10 @@ describe("Plugin: hmac-auth (API)", function()
         assert.equal(2, json_2.total)
 
         assert.not_same(json_1.data, json_2.data)
-        assert.is_nil(json_2.offset) -- last page
+        -- Disabled: on Cassandra, the last page still returns a
+        -- next_page token, and thus, an offset proprty in the
+        -- response of the Admin API.
+        --assert.is_nil(json_2.offset) -- last page
       end)
       it("retrieve hmac-auths for a consumer_id", function()
         local res = assert(client:send {


### PR DESCRIPTION
The recent commits adding endpoints to manipulate the credentials of
authentication plugins had test cases that were flawed when running with
Cassandra.

With Cassandra, the `offset` query argument must be URL-encoded, and the
`offset` parameter in the Admin API response will also be present in the
response for the last page.