### PR TITLE
release: 0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 - [Planned](#planned)
     - [0.12.0](#0120---tbd)
 - [Scheduled](#scheduled)
-    - [0.11.2](#0112---estimated-20171129)
 - [Released](#released)
+    - [0.11.2](#0112---20171129)
     - [0.11.1](#0111---20171024)
     - [0.10.4](#0104---20171024)
     - [0.11.0](#0110---20170816)
@@ -35,7 +35,16 @@ This release will mainly focus around two new major features:
 This section describes upcoming releases that have a release date, along with
 a detailed changeset of their content.
 
-## [0.11.2] - Estimated 2017/11/29
+*No scheduled releases yet.*
+
+[Back to TOC](#table-of-contents)
+
+# Released
+
+This section describes publicly available releases and a detailed changeset of
+their content.
+
+## [0.11.2] - 2017/11/29
 
 ### Added
 
@@ -65,6 +74,12 @@ a detailed changeset of their content.
     - `/hmac-auths/` to paginate through all hmac-auth credentials.
     - `/hmac-auths/:hmac_username_or_id/consumer` to retrieve the Consumer
       associated with a credential.
+- acl: New endpoints to manipulate ACLs.
+  Thanks [@hbagdi](https://github.com/hbagdi) for the contribution.
+  [#3039](https://github.com/Kong/kong/pull/3039)
+    - `/acls/` to paginate through all ACLs.
+    - `/acls/:acl_id/consumer` to retrieve the Consumer
+      associated with an ACL.
 
 ### Fixed
 
@@ -104,13 +119,6 @@ a detailed changeset of their content.
   [#2956](https://github.com/Kong/kong/pull/2956)
 - Improve the performance of the response-transformer plugin.
   [#2977](https://github.com/Kong/kong/pull/2977)
-
-[Back to TOC](#table-of-contents)
-
-# Released
-
-This section describes publicly available releases and a detailed changeset of
-their content.
 
 ## [0.11.1] - 2017/10/24
 
@@ -1965,7 +1973,7 @@ First version running with Cassandra.
 [Back to TOC](#table-of-contents)
 
 [0.12.0]: https://github.com/Kong/kong/compare/0.11.1...next
-[0.11.2]: https://github.com/Kong/kong/compare/0.11.1...master
+[0.11.2]: https://github.com/Kong/kong/compare/0.11.1...0.11.2
 [0.11.1]: https://github.com/Kong/kong/compare/0.11.0...0.11.1
 [0.10.4]: https://github.com/Kong/kong/compare/0.10.3...0.10.4
 [0.11.0]: https://github.com/Kong/kong/compare/0.10.3...0.11.0

--- a/kong-0.11.2-0.rockspec
+++ b/kong-0.11.2-0.rockspec
@@ -1,9 +1,9 @@
 package = "kong"
-version = "0.11.1-0"
+version = "0.11.2-0"
 supported_platforms = {"linux", "macosx"}
 source = {
   url = "git://github.com/Kong/kong",
-  tag = "0.11.1"
+  tag = "0.11.2"
 }
 description = {
   summary = "Kong is a scalable and customizable API Management Layer built on top of Nginx.",

--- a/kong/meta.lua
+++ b/kong/meta.lua
@@ -1,7 +1,7 @@
 local version = setmetatable({
   major = 0,
   minor = 11,
-  patch = 1,
+  patch = 2,
   --suffix = ""
 }, {
   __tostring = function(t)


### PR DESCRIPTION
**Formal PR for Kong 0.11.2 - request for reviews!**

* Full list of commits since 0.11.1: https://github.com/Kong/kong/compare/0.11.1...release/0.11.2
* Changelog (formatted): https://github.com/Kong/kong/blob/4b609928da7263819640ea139989a8d34840b7f0/CHANGELOG.md#0112---20171129
* Docs PR: https://github.com/Kong/getkong.org/pull/554

Things to look for:
* Is the changelog complete?
* Changelog typos
* Double checking for the absence of breaking changes in the commits
* If enough time, double checking/testing the new features/fixes

**This officially closes the merging window for 0.11.2 as of today, 2017/11/27.**