### PR TITLE
chore(deps) bump lua-multipart version from 0.5.1 to 0.5.4

### DIFF
--- a/kong-0.12.1-0.rockspec
+++ b/kong-0.12.1-0.rockspec
@@ -16,7 +16,7 @@ dependencies = {
   "penlight == 1.5.4",
   "lua-resty-http == 0.08",
   "lua-resty-jit-uuid == 0.0.7",
-  "multipart == 0.5.1",
+  "multipart == 0.5.4",
   "version == 0.2",
   "kong-lapis == 1.6.0.1",
   "lua-cassandra == 1.2.3",


### PR DESCRIPTION
### Summary

Bump lua-multipart version from 0.5.1 to 0.5.4.

### Issues resolved

Fix #3024 
Fix #2981
Fix #2851
Fix https://github.com/Kong/lua-multipart/issues/12