### PR TITLE
fix(cli) handle race condition in changing env perms

### DIFF
--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -48,6 +48,7 @@ const char *ERR_reason_error_string(unsigned long e);
 
 int open(const char * filename, int flags, int mode);
 size_t read(int fd, void *buf, size_t count);
+int write(int fd, const void *ptr, int numbytes);
 int close(int fd);
 char *strerror(int errnum);
 ]]


### PR DESCRIPTION
### Summary

Handle a potential vulnerability in how we secured the Kong env file. Previously we chmod'd the file after writing the contents via penlight's wrapper of the Lua io lib, which in turn uses stdio. This allowed for a miniscule window in which the file contents could be read (fopen() creates files with 0666 octal permissions, as modified by the processes's umask).

The new behavior is to leverage the open() libc wrapper directly via FFI, which allows us to create the file with appropriate permissions from the outset.

### Full changelog

* Open, write, and close the `.kong_env` file via libc wrappers around open/write/read syscalls (via FFI)