### PR TITLE
fix(tools) avoid passing a nil value to `cjson.decode`

### DIFF
--- a/kong/tools/public.lua
+++ b/kong/tools/public.lua
@@ -53,6 +53,10 @@ do
 
     [MIME_TYPES.json] = function()
       local raw_body  = ngx_req_get_body_data()
+      if not raw_body then
+        return {}, raw_body
+      end
+
       local args, err = cjson.decode(raw_body)
       if err then
         ngx_log(ERR, "could not decode JSON body args: ", err)


### PR DESCRIPTION
we would have a 1 line error on stderr when passing `nil` to `cjson.decode`.