### PR TITLE
fix(cli) fix log to forceful shutdown

### DIFF
--- a/kong/cmd/quit.lua
+++ b/kong/cmd/quit.lua
@@ -32,6 +32,8 @@ local function execute(args)
   if running then
     log.verbose("nginx is still running at %s, forcing shutdown", conf.prefix)
     assert(nginx_signals.stop(conf))
+    log("Timeout, Kong stopped forcefully")
+    return
   end
 
   log("Kong stopped (gracefully)")


### PR DESCRIPTION
The cli QUIT command would even on a forceful exit still print a 'graceful' message.
