### PR TITLE
fix(tools) avoid passing a nil value to `cjson.decode` and `multipart`

### DIFF
--- a/kong/tools/public.lua
+++ b/kong/tools/public.lua
@@ -53,6 +53,11 @@ do
 
     [MIME_TYPES.json] = function()
       local raw_body  = ngx_req_get_body_data()
+      if not raw_body then
+        ngx_log(ERR, "could not read request body")
+        return {}, raw_body
+      end
+
       local args, err = cjson.decode(raw_body)
       if err then
         ngx_log(ERR, "could not decode JSON body args: ", err)

--- a/kong/tools/public.lua
+++ b/kong/tools/public.lua
@@ -46,7 +46,12 @@ do
   local MIME_DECODERS = {
     [MIME_TYPES.multipart] = function(content_type)
       local raw_body = ngx_req_get_body_data()
-      local args     = multipart(raw_body, content_type):get_all()
+      if not raw_body then
+        ngx_log(ERR, "could not read request body (ngx.req.get_body_data() returned: nil)")
+        return {}, raw_body
+      end
+
+      local args = multipart(raw_body, content_type):get_all()
 
       return args, raw_body
     end,
@@ -54,7 +59,7 @@ do
     [MIME_TYPES.json] = function()
       local raw_body  = ngx_req_get_body_data()
       if not raw_body then
-        ngx_log(ERR, "could not read request body")
+        ngx_log(ERR, "could not read request body (ngx.req.get_body_data() returned: nil)")
         return {}, raw_body
       end
 


### PR DESCRIPTION
we would have a 1 line error on stderr when passing nil to cjson.decode.

be opened against master, not next
move from #3059 