### PR TITLE
fix(oauth2) ensuring that the request indeed has a payload

### DIFF
--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -92,10 +92,16 @@ local function get_redirect_uri(client_id)
 end
 
 local function retrieve_parameters()
-  ngx.req.read_body()
-
   -- OAuth2 parameters could be in both the querystring or body
-  return utils.table_merge(ngx.req.get_uri_args(), public_utils.get_body_args())
+  local uri_args = ngx.req.get_uri_args()
+  local method   = ngx.req.get_method()
+  if method == "POST" or method == "PUT" or method == "PATCH" then
+    ngx.req.read_body()
+    local body_args = public_utils.get_body_args()
+    return utils.table_merge(uri_args, body_args)
+  end
+
+  return uri_args
 end
 
 local function retrieve_scopes(parameters, conf)

--- a/spec/03-plugins/26-oauth2/03-access_spec.lua
+++ b/spec/03-plugins/26-oauth2/03-access_spec.lua
@@ -1709,11 +1709,43 @@ describe("Plugin: oauth2 (access)", function()
       local json = cjson.decode(body)
       assert.same({ error_description = "The access token is invalid or has expired", error = "invalid_token" }, json)
     end)
-    it("works when a correct access_token is being sent in a form body", function()
+    it("works when a correct access_token is being sent in a form body (POST)", function()
       local token = provision_token()
 
       local res = assert(proxy_ssl_client:send {
         method = "POST",
+        path = "/request",
+        body = {
+          access_token = token.access_token
+        },
+        headers = {
+          ["Host"] = "oauth2.com",
+          ["Content-Type"] = "application/json"
+        }
+      })
+      assert.res_status(200, res)
+    end)
+    it("works when a correct access_token is being sent in a form body (PUT)", function()
+      local token = provision_token()
+
+      local res = assert(proxy_ssl_client:send {
+        method = "PUT",
+        path = "/request",
+        body = {
+          access_token = token.access_token
+        },
+        headers = {
+          ["Host"] = "oauth2.com",
+          ["Content-Type"] = "application/json"
+        }
+      })
+      assert.res_status(200, res)
+    end)
+    it("works when a correct access_token is being sent in a form body (PATCH)", function()
+      local token = provision_token()
+
+      local res = assert(proxy_ssl_client:send {
+        method = "PATCH",
         path = "/request",
         body = {
           access_token = token.access_token


### PR DESCRIPTION
### Summary
there should be no reason to call ngx.req.read_body() or
public_utils.get_body_args() for requests that do not have a payload.

### Issues resolved
Fix #3055