### PR TITLE
fix(test) bypass existing environment variables

### DIFF
--- a/spec/01-unit/002-conf_loader_spec.lua
+++ b/spec/01-unit/002-conf_loader_spec.lua
@@ -85,6 +85,12 @@ describe("Configuration loader", function()
     assert.equal(8443, conf.proxy_ssl_port)
   end)
   it("attaches prefix paths", function()
+    -- patch os.getenv to not have existing environment variables interfere
+    local _getenv = os.getenv
+    os.getenv = function() end  -- luacheck: ignore
+    finally(function()
+        os.getenv = _getenv     -- luacheck: ignore
+      end)
     local conf = assert(conf_loader())
     assert.equal("/usr/local/kong/pids/nginx.pid", conf.nginx_pid)
     assert.equal("/usr/local/kong/logs/error.log", conf.nginx_err_logs)
@@ -144,6 +150,12 @@ describe("Configuration loader", function()
 
   describe("inferences", function()
     it("infer booleans (on/off/true/false strings)", function()
+      -- patch os.getenv to not have existing environment variables interfere
+      local _getenv = os.getenv
+      os.getenv = function() end  -- luacheck: ignore
+      finally(function()
+          os.getenv = _getenv     -- luacheck: ignore
+        end)
       local conf = assert(conf_loader())
       assert.equal("on", conf.nginx_daemon)
       assert.equal(30, conf.lua_socket_pool_size)

--- a/spec/01-unit/003-prefix_handler_spec.lua
+++ b/spec/01-unit/003-prefix_handler_spec.lua
@@ -380,11 +380,23 @@ describe("NGINX conf compiler", function()
       assert.truthy(exists(tmp_config.nginx_admin_acc_logs))
     end)
     it("dumps Kong conf", function()
+      -- patch os.getenv to not have existing environment variables interfere
+      local _getenv = os.getenv
+      os.getenv = function() end  -- luacheck: ignore
+      finally(function()
+          os.getenv = _getenv     -- luacheck: ignore
+        end)
       assert(prefix_handler.prepare_prefix(tmp_config))
       local in_prefix_kong_conf = assert(conf_loader(tmp_config.kong_env))
       assert.same(tmp_config, in_prefix_kong_conf)
     end)
     it("dump Kong conf (custom conf)", function()
+      -- patch os.getenv to not have existing environment variables interfere
+      local _getenv = os.getenv
+      os.getenv = function() end  -- luacheck: ignore
+      finally(function()
+          os.getenv = _getenv     -- luacheck: ignore
+        end)
       local conf = assert(conf_loader(nil, {
         pg_database = "foobar",
         prefix = tmp_config.prefix


### PR DESCRIPTION
Some existing environment variables would interfere with test results if set. This change mocks the environment such that the tests run clean.
