### PR TITLE
fix(tests) use KONG_TEST_* variables only in tests

### DIFF
--- a/bin/busted
+++ b/bin/busted
@@ -1,5 +1,32 @@
 #!/usr/bin/env resty
 
+if not os.getenv("KONG_BUSTED_RESPAWNED") then
+  local script = {}
+  local tests = {}
+  for line in io.popen("set"):lines() do
+    local ktvar, val = line:match("^KONG_TEST_([^=]*)=(.*)")
+    if ktvar then
+      table.insert(tests, "export KONG_" .. ktvar .. "=" ..val)
+    end
+    local var = line:match("^(KONG_[^=]*)")
+    if var then
+      table.insert(script, "unset " .. var)
+    end
+  end
+  for _, a in ipairs(tests) do
+    table.insert(script, a)
+  end
+  local cmd = { "exec" }
+  for i = 0, #arg do
+    table.insert(cmd, "'"..arg[i].."'")
+  end
+  table.insert(script, "export KONG_BUSTED_RESPAWNED=1")
+  table.insert(script, "export KONG_ANONYMOUS_REPORTS=off")
+  table.insert(script, table.concat(cmd, " "))
+print(table.concat(script, "; "))
+  return os.execute(table.concat(script, "; "))
+end
+
 require "luarocks.loader"
 
 require("kong.core.globalpatches")({

--- a/bin/busted
+++ b/bin/busted
@@ -1,29 +1,32 @@
 #!/usr/bin/env resty
 
 if not os.getenv("KONG_BUSTED_RESPAWNED") then
+  -- initial run, so go update the environment
   local script = {}
-  local tests = {}
   for line in io.popen("set"):lines() do
     local ktvar, val = line:match("^KONG_TEST_([^=]*)=(.*)")
     if ktvar then
-      table.insert(tests, "export KONG_" .. ktvar .. "=" ..val)
+      -- reinserted KONG_TEST_xxx as KONG_xxx; append
+      table.insert(script, "export KONG_" .. ktvar .. "=" ..val)
     end
+
     local var = line:match("^(KONG_[^=]*)")
     if var then
-      table.insert(script, "unset " .. var)
+      -- remove existing KONG_xxx and KONG_TEST_xxx variables; prepend
+      table.insert(script, 1, "unset " .. var)
     end
   end
-  for _, a in ipairs(tests) do
-    table.insert(script, a)
-  end
+  -- add cli recursion detection
+  table.insert(script, "export KONG_BUSTED_RESPAWNED=1")
+
+  -- rebuild the invoked commandline
   local cmd = { "exec" }
   for i = 0, #arg do
     table.insert(cmd, "'"..arg[i].."'")
   end
-  table.insert(script, "export KONG_BUSTED_RESPAWNED=1")
-  table.insert(script, "export KONG_ANONYMOUS_REPORTS=off")
   table.insert(script, table.concat(cmd, " "))
-print(table.concat(script, "; "))
+
+  -- recurse cli command, with proper variables (un)set for clean testing
   return os.execute(table.concat(script, "; "))
 end
 


### PR DESCRIPTION
An alternative approach to solving the issue raised in PR #3066.

Bypass existing `KONG_*` environment variables when running Busted, replacing their values with `KONG_TEST_*` equivalents.