### PR TITLE
fix(plugins-iter) properly catch errors from the cache callback

### DIFF
--- a/kong/core/plugins_iterator.lua
+++ b/kong/core/plugins_iterator.lua
@@ -12,7 +12,7 @@ local function load_plugin_into_memory(api_id, consumer_id, plugin_name)
     name = plugin_name
   }
   if err then
-    return nil, err
+    error(err)
   end
 
   if #rows > 0 then
@@ -22,8 +22,8 @@ local function load_plugin_into_memory(api_id, consumer_id, plugin_name)
       end
     end
   end
-  -- insert a cached value to not trigger too many DB queries.
-  return {null = true}  -- works because: `.enabled == nil`
+
+  return nil
 end
 
 --- Load the configuration for a plugin entry in the DB.


### PR DESCRIPTION
mlcache does not catch errors coming out from a cache callback via the
traditional second return argument (yet). It only catches Lua errors
thrown by `error()`. This fixes a silent failure when such errors
happen in the plugins iterator, causing the HTTP 500 response to not be
sent.

Additionally, we take advantage of mlcache's native miss cache to remove
the need for a nil sentinel when our plugin query is a miss.