### PR TITLE
chore(*) trim all trailing whitespaces

### DIFF
--- a/kong/dao/migrations/cassandra.lua
+++ b/kong/dao/migrations/cassandra.lua
@@ -352,7 +352,7 @@ return {
         end
 
         for i = 1, #rows do
-          if rows[i].options and 
+          if rows[i].options and
              rows[i].options.target == "request_host" or
              rows[i].options.target == "request_path" then
 

--- a/kong/dao/migrations/postgres.lua
+++ b/kong/dao/migrations/postgres.lua
@@ -273,12 +273,12 @@ return {
         set[#set + 1] = fmt("upstream_url = '%s'", upstream_url)
 
         if row.request_host and row.request_host ~= "" then
-          set[#set + 1] = fmt("hosts = '%s'", 
+          set[#set + 1] = fmt("hosts = '%s'",
                               cjson.encode({ row.request_host }))
         end
 
         if row.request_path and row.request_path ~= "" then
-          set[#set + 1] = fmt("uris = '%s'", 
+          set[#set + 1] = fmt("uris = '%s'",
                               cjson.encode({ row.request_path }))
         end
 

--- a/kong/dao/schemas/targets.lua
+++ b/kong/dao/schemas/targets.lua
@@ -15,14 +15,14 @@ return {
   primary_key = {"id"},
   fields = {
     id = {
-      type = "id", 
-      dao_insert_value = true, 
+      type = "id",
+      dao_insert_value = true,
       required = true,
     },
     created_at = {
-      type = "timestamp", 
-      immutable = true, 
-      dao_insert_value = true, 
+      type = "timestamp",
+      immutable = true,
+      dao_insert_value = true,
       required = true,
     },
     upstream_id = {
@@ -42,7 +42,7 @@ return {
     },
   },
   self_check = function(schema, config, dao, is_updating)
-    
+
     -- check weight
     if config.weight < WEIGHT_MIN or config.weight > WEIGHT_MAX then
       return false, Errors.schema(WEIGHT_MSG)

--- a/kong/dao/schemas/upstreams.lua
+++ b/kong/dao/schemas/upstreams.lua
@@ -10,20 +10,20 @@ return {
   primary_key = {"id"},
   fields = {
     id = {
-      type = "id", 
-      dao_insert_value = true, 
+      type = "id",
+      dao_insert_value = true,
       required = true,
     },
     created_at = {
-      type = "timestamp", 
-      immutable = true, 
-      dao_insert_value = true, 
+      type = "timestamp",
+      immutable = true,
+      dao_insert_value = true,
       required = true,
     },
     name = {
       -- name is a hostname like name that can be referenced in an `upstream_url` field
-      type = "string", 
-      unique = true, 
+      type = "string",
+      unique = true,
       required = true,
     },
     slots = {
@@ -40,7 +40,7 @@ return {
     }
   },
   self_check = function(schema, config, dao, is_updating)
-    
+
     -- check the name
     local p = utils.normalize_ip(config.name)
     if not p then
@@ -52,12 +52,12 @@ return {
     if p.port then
       return false, Errors.schema("Invalid name; no port allowed")
     end
-    
+
     -- check the slots number
     if config.slots < SLOTS_MIN or config.slots > SLOTS_MAX then
       return false, Errors.schema(SLOTS_MSG)
     end
-    
+
     -- check the order array
     local order = config.orderlist
     if #order == config.slots then
@@ -92,14 +92,14 @@ return {
       local t = {}
       for i = 1, config.slots do
         t[i] = {
-          id = i, 
+          id = i,
           order = math.random(1, config.slots),
         }
       end
 
-      -- sort the array (we don't check for -accidental- duplicates as the 
+      -- sort the array (we don't check for -accidental- duplicates as the
       -- id field is used for the order and that one is always unique)
-      table.sort(t, function(a,b) 
+      table.sort(t, function(a,b)
         return a.order < b.order
       end)
 
@@ -107,7 +107,7 @@ return {
       for i, v in ipairs(t) do
         t[i] = v.id
       end
-      
+
       config.orderlist = t
     end
 

--- a/kong/plugins/aws-lambda/v4.lua
+++ b/kong/plugins/aws-lambda/v4.lua
@@ -33,7 +33,7 @@ local function percent_encode(char)
 end
 
 local function urldecode(str)
-  return (str:gsub("%%(%x%x)", function(c) 
+  return (str:gsub("%%(%x%x)", function(c)
     return string.char(tonumber(c, 16))
   end))
 end

--- a/kong/plugins/basic-auth/schema.lua
+++ b/kong/plugins/basic-auth/schema.lua
@@ -4,7 +4,7 @@ local function check_user(anonymous)
   if anonymous == "" or utils.is_valid_uuid(anonymous) then
     return true
   end
-  
+
   return false, "the anonymous user must be empty or a valid uuid"
 end
 

--- a/kong/plugins/datadog/handler.lua
+++ b/kong/plugins/datadog/handler.lua
@@ -138,7 +138,7 @@ end
 
 function DatadogHandler:log(conf)
   DatadogHandler.super.log(self)
-  
+
   -- unmatched apis are nil
   if not ngx.ctx.api then
     return

--- a/kong/plugins/galileo/alf.lua
+++ b/kong/plugins/galileo/alf.lua
@@ -73,7 +73,7 @@ local function hash_to_array(t)
   return arr
 end
 
--- Calculate an approximation of header size (it doesn't calculate white 
+-- Calculate an approximation of header size (it doesn't calculate white
 -- space that may be sorrounding values, other than that it's accurate)
 local function calculate_headers_size(request_line, headers)
   local size = 0
@@ -197,7 +197,7 @@ function _M:add_entry(_ngx, req_body_str, resp_body_str)
       queryString = hash_to_array(req_get_uri_args()),
       headers = hash_to_array(request_headers),
       headersSize = calculate_headers_size(
-                      fmt("%s %s %s", method, var.request_uri, http_version), 
+                      fmt("%s %s %s", method, var.request_uri, http_version),
                       request_headers),
       postData = post_data,
       bodyCaptured = req_has_body,

--- a/kong/plugins/jwt/asn_sequence.lua
+++ b/kong/plugins/jwt/asn_sequence.lua
@@ -109,7 +109,7 @@ end
 
 -- @param input (string) 32 characters, format to be validated before calling
 function _M.resign_integer(input)
-  if type(input) ~= "string" then 
+  if type(input) ~= "string" then
     error("Argument #1 must be string", 2)
   end
   if string_byte(input) > 0x7F then

--- a/kong/plugins/jwt/schema.lua
+++ b/kong/plugins/jwt/schema.lua
@@ -4,7 +4,7 @@ local function check_user(anonymous)
   if anonymous == "" or utils.is_valid_uuid(anonymous) then
     return true
   end
-  
+
   return false, "the anonymous user must be empty or a valid uuid"
 end
 

--- a/kong/plugins/key-auth/handler.lua
+++ b/kong/plugins/key-auth/handler.lua
@@ -165,7 +165,7 @@ function KeyAuthHandler:access(conf)
     -- in the datastore
     return
   end
- 
+
   if ngx.ctx.authenticated_credential and conf.anonymous ~= "" then
     -- we're already authenticated, and we're configured for using anonymous,
     -- hence we're in a logical OR between auth methods and we're already done.

--- a/kong/plugins/ldap-auth/access.lua
+++ b/kong/plugins/ldap-auth/access.lua
@@ -111,7 +111,7 @@ local function load_consumer(consumer_id, anonymous)
 end
 
 local function set_consumer(consumer, credential)
-  
+
   if consumer then
     -- this can only be the Anonymous user in this case
     ngx_set_header(constants.HEADERS.CONSUMER_ID, consumer.id)
@@ -121,11 +121,11 @@ local function set_consumer(consumer, credential)
     ngx.ctx.authenticated_consumer = consumer
     return
   end
-  
+
   -- here we have been authenticated by ldap
   ngx_set_header(constants.HEADERS.CREDENTIAL_USERNAME, credential.username)
   ngx.ctx.authenticated_credential = credential
-  
+
   -- in case of auth plugins concatenation, remove remnants of anonymous
   ngx.ctx.authenticated_consumer = nil
   ngx_set_header(constants.HEADERS.ANONYMOUS, nil)
@@ -169,7 +169,7 @@ end
 function _M.execute(conf)
 
   if ngx.ctx.authenticated_credential and conf.anonymous ~= "" then
-    -- we're already authenticated, and we're configured for using anonymous, 
+    -- we're already authenticated, and we're configured for using anonymous,
     -- hence we're in a logical OR between auth methods and we're already done.
     return
   end

--- a/kong/plugins/ldap-auth/schema.lua
+++ b/kong/plugins/ldap-auth/schema.lua
@@ -4,7 +4,7 @@ local function check_user(anonymous)
   if anonymous == "" or utils.is_valid_uuid(anonymous) then
     return true
   end
-  
+
   return false, "the anonymous user must be empty or a valid uuid"
 end
 

--- a/kong/plugins/log-serializers/basic.lua
+++ b/kong/plugins/log-serializers/basic.lua
@@ -12,7 +12,7 @@ function _M.serialize(ngx)
       consumer_id = ngx.ctx.authenticated_credential.consumer_id
     }
   end
-  
+
   return {
     request = {
       uri = ngx.var.request_uri,
@@ -31,7 +31,7 @@ function _M.serialize(ngx)
     latencies = {
       kong = (ngx.ctx.KONG_ACCESS_TIME or 0) +
              (ngx.ctx.KONG_RECEIVE_TIME or 0) +
-             (ngx.ctx.KONG_REWRITE_TIME or 0) + 
+             (ngx.ctx.KONG_REWRITE_TIME or 0) +
              (ngx.ctx.KONG_BALANCER_TIME or 0),
       proxy = ngx.ctx.KONG_WAITING_TIME or -1,
       request = ngx.var.request_time * 1000

--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -463,7 +463,7 @@ local function load_consumer_into_memory(consumer_id, anonymous)
   end
   return result
 end
-  
+
 local function set_consumer(consumer, credential, token)
   ngx_set_header(constants.HEADERS.CONSUMER_ID, consumer.id)
   ngx_set_header(constants.HEADERS.CONSUMER_CUSTOM_ID, consumer.custom_id)
@@ -477,7 +477,7 @@ local function set_consumer(consumer, credential, token)
   else
     ngx_set_header(constants.HEADERS.ANONYMOUS, true)
   end
-  
+
 end
 
 local function do_authentication(conf)
@@ -530,7 +530,7 @@ end
 function _M.execute(conf)
 
   if ngx.ctx.authenticated_credential and conf.anonymous ~= "" then
-    -- we're already authenticated, and we're configured for using anonymous, 
+    -- we're already authenticated, and we're configured for using anonymous,
     -- hence we're in a logical OR between auth methods and we're already done.
     return
   end

--- a/kong/plugins/oauth2/migrations/cassandra.lua
+++ b/kong/plugins/oauth2/migrations/cassandra.lua
@@ -141,7 +141,7 @@ return {
       if err then
         return err
       end
-      
+
       for _, row in ipairs(rows) do
         row.config.global_credentials = true
 

--- a/kong/plugins/oauth2/schema.lua
+++ b/kong/plugins/oauth2/schema.lua
@@ -5,7 +5,7 @@ local function check_user(anonymous)
   if anonymous == "" or utils.is_valid_uuid(anonymous) then
     return true
   end
-  
+
   return false, "the anonymous user must be empty or a valid uuid"
 end
 

--- a/kong/plugins/request-termination/schema.lua
+++ b/kong/plugins/request-termination/schema.lua
@@ -13,7 +13,7 @@ return {
         return false, Errors.schema("status_code must be between 100 .. 599")
       end
     end
-    
+
     if plugin_t.message then
       if plugin_t.content_type or plugin_t.body then
         return false, Errors.schema("message cannot be used with content_type or body")
@@ -23,7 +23,7 @@ return {
         return false, Errors.schema("content_type requires a body")
       end
     end
-    
+
     return true
   end
 }

--- a/kong/plugins/response-ratelimiting/log.lua
+++ b/kong/plugins/response-ratelimiting/log.lua
@@ -7,7 +7,7 @@ local function log(premature, conf, api_id, identifier, current_timestamp, incre
   if premature then
     return
   end
-  
+
   -- Increment metrics for all periods if the request goes through
   for k, v in pairs(usage) do
     if increments[k] and increments[k] ~= 0 then

--- a/kong/plugins/response-transformer/body_transformer.lua
+++ b/kong/plugins/response-transformer/body_transformer.lua
@@ -23,14 +23,14 @@ end
 
 local function append_value(current_value, value)
   local current_value_type = type(current_value)
- 
+
   if current_value_type  == "string" then
     return {current_value, value}
   elseif current_value_type  == "table" then
     table_insert(current_value, value)
-    return current_value  
+    return current_value
   else
-    return {value} 
+    return {value}
   end
 end
 
@@ -46,8 +46,8 @@ local function iter(config_array)
     if current_value == "" then
       current_value = nil
     end
- 
-    return i, current_name, current_value  
+
+    return i, current_name, current_value
   end, config_array, 0
 end
 
@@ -60,12 +60,12 @@ function _M.transform_json_body(conf, buffered_data)
   if json_body == nil then
     return
   end
-  
+
   -- remove key:value to body
   for _, name in iter(conf.remove.json) do
     json_body[name] = nil
   end
-  
+
   -- replace key:value to body
   for _, name, value in iter(conf.replace.json) do
     local v = cjson_encode(value)
@@ -77,8 +77,8 @@ function _M.transform_json_body(conf, buffered_data)
       json_body[name] = v
     end
   end
-  
-  -- add new key:value to body    
+
+  -- add new key:value to body
   for _, name, value in iter(conf.add.json) do
     local v = cjson_encode(value)
     if sub(v, 1, 1) == [["]] and sub(v, -1, -1) == [["]] then
@@ -89,8 +89,8 @@ function _M.transform_json_body(conf, buffered_data)
       json_body[name] = v
     end
   end
-  
-  -- append new key:value or value to existing key    
+
+  -- append new key:value or value to existing key
   for _, name, value in iter(conf.append.json) do
     local v = cjson_encode(value)
     if sub(v, 1, 1) == [["]] and sub(v, -1, -1) == [["]] then
@@ -99,8 +99,8 @@ function _M.transform_json_body(conf, buffered_data)
     v = gsub(v, [[\/]], [[/]]) -- To prevent having double encoded slashes
     json_body[name] = append_value(json_body[name],v)
   end
-  
-  return cjson_encode(json_body) 
+
+  return cjson_encode(json_body)
 end
 
 return _M

--- a/kong/plugins/response-transformer/header_transformer.lua
+++ b/kong/plugins/response-transformer/header_transformer.lua
@@ -18,8 +18,8 @@ local function iter(config_array)
     if header_to_test_value == "" then
       header_to_test_value = nil
     end
-    
-    return i, header_to_test_name, header_to_test_value  
+
+    return i, header_to_test_name, header_to_test_value
   end, config_array, 0
 end
 
@@ -30,9 +30,9 @@ local function append_value(current_value, value)
     return {current_value, value}
   elseif current_value_type == "table" then
     insert(current_value, value)
-    return current_value  
+    return current_value
   else
-    return {value} 
+    return {value}
   end
 end
 
@@ -51,7 +51,7 @@ _M.is_body_transform_set = is_body_transform_set
 ---
 --   # Example:
 --   ngx.headers = header_filter.transform_headers(conf, ngx.headers)
--- We run transformations in following order: remove, replace, add, append. 
+-- We run transformations in following order: remove, replace, add, append.
 -- @param[type=table] conf Plugin configuration.
 -- @param[type=table] ngx_headers Table of headers, that should be `ngx.headers`
 -- @return table A table containing the new headers.
@@ -60,26 +60,26 @@ function _M.transform_headers(conf, ngx_headers)
   for _, header_name, header_value in iter(conf.remove.headers) do
       ngx_headers[header_name] = nil
   end
-  
+
   -- replace headers
   for _, header_name, header_value in iter(conf.replace.headers) do
     if ngx_headers[header_name] ~= nil then
       ngx_headers[header_name] = header_value
     end
   end
-  
+
   -- add headers
   for _, header_name, header_value in iter(conf.add.headers) do
     if ngx_headers[header_name] == nil then
       ngx_headers[header_name] = header_value
     end
   end
-  
+
   -- append headers
   for _, header_name, header_value in iter(conf.append.headers) do
     ngx_headers[header_name] = append_value(ngx_headers[header_name], header_value)
   end
-  
+
   -- Removing the content-length header because the body is going to change
   if is_body_transform_set(conf) and is_json_body(ngx_headers["content-type"]) then
     ngx_headers["content-length"] = nil

--- a/kong/plugins/response-transformer/schema.lua
+++ b/kong/plugins/response-transformer/schema.lua
@@ -3,7 +3,7 @@ local find = string.find
 local function check_for_value(value)
   for i, entry in ipairs(value) do
     local ok = find(entry, ":")
-    if not ok then 
+    if not ok then
       return false, "key '" .. entry .. "' has no value"
     end
   end
@@ -13,7 +13,7 @@ end
 return {
   fields = {
     -- add: Add a value (to response headers or response JSON body) only if the key does not already exist.
-    remove = { 
+    remove = {
       type = "table",
       schema = {
         fields = {
@@ -40,8 +40,8 @@ return {
         }
       }
     },
-    append = { 
-      type = "table", 
+    append = {
+      type = "table",
       schema = {
         fields = {
           json = {type = "array", default = {}, func = check_for_value},

--- a/kong/tools/dns.lua
+++ b/kong/tools/dns.lua
@@ -5,13 +5,13 @@ local dns_client
 -- @param conf (table) Kong configuration
 -- @return the initialized `resty.dns.client` module, or an error
 local setup_client = function(conf)
-  if not dns_client then 
+  if not dns_client then
     dns_client = require "resty.dns.client"
   end
 
   conf = conf or {}
   local servers = {}
-  
+
   -- servers must be reformatted as name/port sub-arrays
   if conf.dns_resolver then
     for i, server in ipairs(conf.dns_resolver) do
@@ -19,7 +19,7 @@ local setup_client = function(conf)
       servers[i] = { s.host, s.port or 53 }   -- inserting port if omitted
     end
   end
-    
+
   local opts = {
     hosts = conf.dns_hostsfile,
     resolvConf = nil,                -- defaults to system resolv.conf
@@ -33,7 +33,7 @@ local setup_client = function(conf)
     order = conf.dns_order,          -- order of trying record types
     noSynchronisation = conf.dns_no_sync,
   }
-  
+
   assert(dns_client.init(opts))
 
   return dns_client

--- a/kong/tools/timestamp.lua
+++ b/kong/tools/timestamp.lua
@@ -22,14 +22,14 @@ local function get_utc_ms()
   return tz_time() * 1000
 end
 
--- setup a validation value, any value above this is assumed to be in MS 
+-- setup a validation value, any value above this is assumed to be in MS
 -- instead of S (a year value beyond the year 20000), it assumes current times
 -- as in 2016 and later.
 local ms_check = tt(20000 , 1 , 1 , 0 , 0 , 0):timestamp()
 
 -- Returns a time-table.
 -- @param now (optional) time to generate the time-table from. If omitted
--- current utc will be used. It can be specified either in seconds or 
+-- current utc will be used. It can be specified either in seconds or
 -- milliseconds, it will be converted automatically.
 local function get_timetable(now)
   local timestamp = now and now or get_utc()
@@ -45,13 +45,13 @@ end
 local function get_timestamps(now)
   local timetable = get_timetable(now)
   local stamps = {}
-  
+
   timetable.sec = math_floor(timetable.sec)   -- reduce to second precision
   stamps.second = timetable:timestamp() * 1000
 
   timetable.sec = 0
   stamps.minute = timetable:timestamp() * 1000
-  
+
   timetable.min = 0
   stamps.hour = timetable:timestamp() * 1000
 

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -541,13 +541,13 @@ _M.normalize_ipv4 = function(address)
      c > 255 or d < 0 or d > 255 then
     return nil, "invalid ipv4 address: " .. address
   end
-  if port then 
-    port = tonumber(port) 
+  if port then
+    port = tonumber(port)
     if port > 65535 then
       return nil, "invalid port number"
     end
   end
-  
+
   return fmt("%d.%d.%d.%d",a,b,c,d), port
 end
 
@@ -562,7 +562,7 @@ _M.normalize_ipv6 = function(address)
   if check then
     check = check:sub(2, -2)  -- drop the brackets
     -- we have ipv6 in brackets, now get port if we got something left
-    if port then 
+    if port then
       port = port:match("^:(%d-)$")
       if not port then
         return nil, "invalid ipv6 address"
@@ -672,7 +672,7 @@ end
 -- local addr, err = format_ip(check_hostname("//bad .. name\\"))    --> nil, "invalid hostname: ... "
 _M.format_host = function(p1, p2)
   local t = type(p1)
-  if t == "nil" then 
+  if t == "nil" then
     return p1, p2   -- just pass through any errors passed in
   end
   local host, port, typ

--- a/spec/01-unit/005-timestamp_spec.lua
+++ b/spec/01-unit/005-timestamp_spec.lua
@@ -7,7 +7,7 @@ describe("Timestamp", function()
     for _ in pairs(t) do s = s + 1 end
     return s
   end
-  
+
   it("should get UTC time", function()
     assert.truthy(timestamp.get_utc())
     assert.are.same(13, #tostring(timestamp.get_utc()))

--- a/spec/01-unit/009-responses_spec.lua
+++ b/spec/01-unit/009-responses_spec.lua
@@ -61,7 +61,7 @@ describe("Response helpers", function()
   it("calls `ngx.log` if and only if a 500 status code was given", function()
     responses.send_HTTP_BAD_REQUEST()
     assert.stub(ngx.log).was_not_called()
-    
+
     responses.send_HTTP_BAD_REQUEST("error")
     assert.stub(ngx.log).was_not_called()
 

--- a/spec/01-unit/011-balancer_spec.lua
+++ b/spec/01-unit/011-balancer_spec.lua
@@ -4,7 +4,7 @@ describe("Balancer", function()
   local TARGETS_FIXTURES
   --local uuid = require("kong.tools.utils").uuid
 
-  
+
   setup(function()
     balancer = require "kong.core.balancer"
     singletons = require "kong.singletons"
@@ -21,7 +21,7 @@ describe("Balancer", function()
       {id = "c", name = "gelato",  slots = 20, orderlist = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20} },
       {id = "d", name = "galileo", slots = 20, orderlist = {20,19,18,17,16,15,14,13,12,11,10,9,8,7,6,5,4,3,2,1} },
     }
-    
+
     singletons.dao.targets = {
       find_all = function(self, match_on)
         local ret = {}

--- a/spec/01-unit/012-log_serializer_spec.lua
+++ b/spec/01-unit/012-log_serializer_spec.lua
@@ -8,7 +8,7 @@ describe("Log Serializer", function()
       ctx = {
         balancer_address = {
           tries = {
-            { 
+            {
               ip = "127.0.0.1",
               port = 8000,
             },
@@ -97,7 +97,7 @@ describe("Log Serializer", function()
     end)
 
     it("serializes the Authenticated Entity object", function()
-      ngx.ctx.authenticated_credential = {id = "somecred", 
+      ngx.ctx.authenticated_credential = {id = "somecred",
                                           consumer_id = "user1"}
 
       local res = basic.serialize(ngx)

--- a/spec/02-integration/03-dao/04-constraints_spec.lua
+++ b/spec/02-integration/03-dao/04-constraints_spec.lua
@@ -68,7 +68,7 @@ helpers.for_each_dao(function(kong_config)
             anonymous = "",
             key_in_body = false,
           }, plugin.config)
-      end)		
+      end)
       describe("unique per API/Consumer", function()
         it("API/Plugin", function()
           plugin_fixture.api_id = api_fixture.id

--- a/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
@@ -229,7 +229,7 @@ if content_type == "application/x-www-form-urlencoded" then return end
               body = {
                 name = "my.upstream",
                 slots = 10,
-                orderlist = { 1,2,3,4,5,1,2,3,4,5 }, 
+                orderlist = { 1,2,3,4,5,1,2,3,4,5 },
               },
               headers = {["Content-Type"] = content_type}
             })


### PR DESCRIPTION
The best way to avoid white-spaces diff in the future is to get rid of them at once, and configure our editors to trim them automatically.