### PR TITLE
hotfix(tests) ensure bin/busted works on some platforms

### DIFF
--- a/bin/busted
+++ b/bin/busted
@@ -1,5 +1,20 @@
 #!/usr/bin/env resty
 
+do
+  local lines = getmetatable(io.output()).lines
+
+  getmetatable(io.output()).lines = function(self, ...)
+    local iter = lines(self, ...)
+
+    return function()
+      local ok, ret = pcall(iter)
+      if ok then
+        return ret
+      end
+    end
+  end
+end
+
 if not os.getenv("KONG_BUSTED_RESPAWNED") then
   -- initial run, so go update the environment
   local script = {}


### PR DESCRIPTION
A regression introduced by 67473d2 and #3075: the underlying `io.popen`
read syscall can easily be interrupted by the `SIGCHLD` signal returned
from the invoked shell (handled by NGINX, underlying the resty-cli)
interpreter.

This issue is discussed in several places:

* openresty/resty-cli#35
* luarocks/luarocks#732

An easy workaround for it is the fix proposed in one of the above
issues, in which we simply call our iterator in protected mode and
ignore the resulting Lua error from the uncaught `EINTR` error.