### PR TITLE
feat(reports) send database_version and redis_version

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -120,7 +120,13 @@ local function load_plugins(kong_conf, dao)
   -- add reports plugin if not disabled
   if kong_conf.anonymous_reports then
     local reports = require "kong.core.reports"
+
+    local db_infos = dao:infos()
+    reports.add_ping_value("database", kong_conf.database)
+    reports.add_ping_value("database_version", db_infos.version)
+
     reports.toggle(true)
+
     sorted_plugins[#sorted_plugins+1] = {
       name = "reports",
       handler = reports,

--- a/spec/01-unit/01-db/02-cassandra_spec.lua
+++ b/spec/01-unit/01-db/02-cassandra_spec.lua
@@ -11,6 +11,16 @@ describe("cassandra_db", function()
     end)
   end)
 
+  describe("extract_major_minor()", function()
+    it("extract major and minor version digits", function()
+      assert.equal("3.7", cassandra_db.extract_major_minor("3.7"))
+      assert.equal("3.7", cassandra_db.extract_major_minor("3.7.12"))
+      assert.equal("2.1", cassandra_db.extract_major_minor("2.1.14"))
+      assert.equal("2.10", cassandra_db.extract_major_minor("2.10"))
+      assert.equal("10.0", cassandra_db.extract_major_minor("10.0"))
+    end)
+  end)
+
   describe("cluster_release_version()", function()
     it("extracts major release_version from available peers", function()
       local release_version = assert(cassandra_db.cluster_release_version {
@@ -27,7 +37,10 @@ describe("cassandra_db", function()
           release_version = "3.1.2",
         }
       })
-      assert.equal(3, release_version)
+      assert.same({
+        major       = "3",
+        major_minor = "3.7",
+      }, release_version)
 
       local release_version = assert(cassandra_db.cluster_release_version {
         {
@@ -43,7 +56,10 @@ describe("cassandra_db", function()
           release_version = "2.2.4",
         }
       })
-      assert.equal(2, release_version)
+      assert.same({
+        major       = "2",
+        major_minor = "2.14",
+      }, release_version)
     end)
     it("errors with different major versions", function()
       local release_version, err = cassandra_db.cluster_release_version {

--- a/spec/01-unit/01-db/03-postgres_spec.lua
+++ b/spec/01-unit/01-db/03-postgres_spec.lua
@@ -1,0 +1,16 @@
+local postgres_db = require "kong.dao.db.postgres"
+
+
+describe("postgres_db", function()
+  describe("extract_major_minor()", function()
+    it("extract major and minor version digits", function()
+      assert.equal("9.4", postgres_db.extract_major_minor("9.4.11"))
+      assert.equal("9.4", postgres_db.extract_major_minor("9.4"))
+      assert.equal("9.5", postgres_db.extract_major_minor("9.5.6"))
+      assert.equal("9.6", postgres_db.extract_major_minor("9.6.10"))
+      assert.equal("9.10", postgres_db.extract_major_minor("9.10"))
+      assert.equal("10.0", postgres_db.extract_major_minor("10.0.1"))
+      assert.equal("10.0", postgres_db.extract_major_minor("10.0"))
+    end)
+  end)
+end)

--- a/spec/02-integration/03-dao/01-factory_spec.lua
+++ b/spec/02-integration/03-dao/01-factory_spec.lua
@@ -19,4 +19,38 @@ helpers.for_each_dao(function(kong_conf)
       assert.equal(factory.daos.plugins, factory.plugins)
     end)
   end)
+
+  describe(":init() + :infos()", function()
+    it("returns DB info + 'unknown' for version if missing", function()
+      local factory = assert(Factory.new(kong_conf))
+      local info = factory:infos()
+
+      if kong_conf.database == "postgres" then
+        assert.same({
+          desc = "database",
+          name = kong_conf.pg_database,
+          version = "unknown",
+        }, info)
+
+      elseif kong_conf.database == "cassandra" then
+        assert.same({
+          desc = "keyspace",
+          name = kong_conf.cassandra_keyspace,
+          version = "unknown",
+        }, info)
+
+      else
+        error("unknown database")
+      end
+    end)
+
+    it("returns DB version if :init() called", function()
+      local factory = assert(Factory.new(kong_conf))
+      assert(factory:init())
+
+      local info = factory:infos()
+      assert.is_string(info.version)
+      assert.not_equal("unknown", info.version)
+    end)
+  end)
 end)


### PR DESCRIPTION
In order to offer better support for the different versions of each
database Kong is compatible with, we need to be able to make decisions
based on field usage data.

This commit adds the Cassandra/PostgreSQL/Redis version as part of the
PING signal, when `anonymous_reports` is enabled. We only retrieve the
first two digits of the version number to avoid high cardinality values
as much as possible, and to stay concise in our UDP packet.

We introduce tests for the version retrieval of both datastores
(PostgreSQL and Cassandra).

Unfortunately, there exist no tests for the reports `ping` signal, and
the `redis_version` retrieval is even more cumbersome to test. Those
have been tested manually for now (yuck).

NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

### Summary

SUMMARY_GOES_HERE

### Full changelog

* [Implement ...]
* [Add related tests]
* ...

### Issues resolved

Fix #XXX
