### PR TITLE
feat(reports) abstract redis version tracking

### DIFF
--- a/kong/plugins/response-ratelimiting/policies/init.lua
+++ b/kong/plugins/response-ratelimiting/policies/init.lua
@@ -2,6 +2,7 @@ local singletons = require "kong.singletons"
 local timestamp = require "kong.tools.timestamp"
 local redis = require "resty.redis"
 local policy_cluster = require "kong.plugins.response-ratelimiting.policies.cluster"
+local reports = require "kong.core.reports"
 local ngx_log = ngx.log
 local shm = ngx.shared.kong_cache
 
@@ -163,6 +164,8 @@ return {
           return nil, err
         end
       end
+
+      reports.retrieve_redis_version(red)
 
       local periods = timestamp.get_timestamps(current_timestamp)
       local cache_key = get_local_key(api_id, identifier, periods[period], name, period)

--- a/spec/01-unit/013-reports_spec.lua
+++ b/spec/01-unit/013-reports_spec.lua
@@ -42,4 +42,97 @@ describe("reports", function()
       assert.equal("timeout", err)
     end)
   end)
+
+  describe("retrieve_redis_version()", function()
+    before_each(function()
+      package.loaded["kong.core.reports"] = nil
+      reports = require "kong.core.reports"
+      reports.toggle(true)
+    end)
+
+    it("does not query Redis if not enabled", function()
+      reports.toggle(false)
+
+      local red_mock = {
+        info = function() end,
+      }
+
+      local s = spy.on(red_mock, "info")
+
+      reports.retrieve_redis_version(red_mock)
+      assert.spy(s).was_not_called()
+    end)
+
+    it("queries Redis if enabled", function()
+      local red_mock = {
+        info = function()
+          return "redis_version:2.4.5\r\nredis_git_sha1:e09e31b1"
+        end,
+      }
+
+      local s = spy.on(red_mock, "info")
+
+      reports.retrieve_redis_version(red_mock)
+      assert.spy(s).was_called_with(red_mock, "server")
+    end)
+
+    it("queries Redis only once", function()
+      local red_mock = {
+        info = function()
+          return "redis_version:2.4.5\r\nredis_git_sha1:e09e31b1"
+        end,
+      }
+
+      local s = spy.on(red_mock, "info")
+
+      reports.retrieve_redis_version(red_mock)
+      reports.retrieve_redis_version(red_mock)
+      reports.retrieve_redis_version(red_mock)
+      assert.spy(s).was_called(1)
+    end)
+
+    it("retrieves major.minor version", function()
+      local red_mock = {
+        info = function()
+          return "redis_version:2.4.5\r\nredis_git_sha1:e09e31b1"
+        end,
+      }
+
+      reports.retrieve_redis_version(red_mock)
+      assert.equal("2.4", reports.get_ping_value("redis_version"))
+    end)
+
+    it("retrieves 'unknown' when the version could not be retrieved (1/3)", function()
+      local red_mock = {
+        info = function()
+          return nil
+        end,
+      }
+
+      reports.retrieve_redis_version(red_mock)
+      assert.equal("unknown", reports.get_ping_value("redis_version"))
+    end)
+
+    it("retrieves 'unknown' when the version could not be retrieved (2/3)", function()
+      local red_mock = {
+        info = function()
+          return ngx.null
+        end,
+      }
+
+      reports.retrieve_redis_version(red_mock)
+      assert.equal("unknown", reports.get_ping_value("redis_version"))
+    end)
+
+    it("retrieves 'unknown' when the version could not be retrieved (3/3)", function()
+      local red_mock = {
+        info = function()
+          return "hello world"
+        end,
+      }
+
+      reports.retrieve_redis_version(red_mock)
+      assert.equal("unknown", reports.get_ping_value("redis_version"))
+    end)
+  end)
 end)


### PR DESCRIPTION
* Moved the Redis version tracking so it can be used in
  response-ratelimiting, and any other plugin that may use Redis.
* Moved the tracking point from `increment` to `usage` to enable
  tracking in scenarios when all clients have already reached their
  limit.
* Unit tests for reports Redis tracking.
* We require the `kong.core.reports` module at the module level
  regardless of the value of `anonymous_reports`, since it is already
  done in the `core/handler.lua` module for now anyway.