### PR TITLE
feat(rate-limiting) add support for redis cluster

### DIFF
--- a/kong-0.11.2-0.rockspec
+++ b/kong-0.11.2-0.rockspec
@@ -179,6 +179,7 @@ build = {
     ["kong.plugins.rate-limiting.daos"] = "kong/plugins/rate-limiting/daos.lua",
     ["kong.plugins.rate-limiting.policies"] = "kong/plugins/rate-limiting/policies/init.lua",
     ["kong.plugins.rate-limiting.policies.cluster"] = "kong/plugins/rate-limiting/policies/cluster.lua",
+    ["kong.plugins.rate-limiting.policies.redis-cluster"] = "kong/plugins/rate-limiting/policies/redis-cluster.lua",
 
     ["kong.plugins.response-ratelimiting.migrations.cassandra"] = "kong/plugins/response-ratelimiting/migrations/cassandra.lua",
     ["kong.plugins.response-ratelimiting.migrations.postgres"] = "kong/plugins/response-ratelimiting/migrations/postgres.lua",

--- a/kong/plugins/rate-limiting/policies/init.lua
+++ b/kong/plugins/rate-limiting/policies/init.lua
@@ -2,6 +2,7 @@ local singletons = require "kong.singletons"
 local timestamp = require "kong.tools.timestamp"
 local redis = require "resty.redis"
 local policy_cluster = require "kong.plugins.rate-limiting.policies.cluster"
+local policy_redis_cluster = require "kong.plugins.rate-limiting.policies.redis-cluster"
 local reports = require "kong.core.reports"
 local ngx_log = ngx.log
 local shm = ngx.shared.kong_cache
@@ -187,5 +188,9 @@ return {
 
       return current_metric or 0
     end
+  },
+  ["redis-cluster"] = {
+    increment = policy_redis_cluster.increment,
+    usage = policy_redis_cluster.usage
   }
 }

--- a/kong/plugins/rate-limiting/policies/redis-cluster.lua
+++ b/kong/plugins/rate-limiting/policies/redis-cluster.lua
@@ -1,0 +1,136 @@
+local timestamp = require "kong.tools.timestamp"
+-- TODO add this to dependency BLOCKER (need to publish https://github.com/steve0511/resty-redis-cluster on luarocks)
+local redis_cluster = require "rediscluster" 
+local ngx_log = ngx.log
+local pairs = pairs
+
+-- TODO duplicate logic between redis single node and cluster; 
+local get_local_key = function(api_id, identifier, period_date, name)
+  return string.format("redis-ratelimit:%s:%s:%s:%s", api_id, identifier, period_date, name)
+end
+
+local EXPIRATIONS = {
+  second = 1,
+  minute = 60,
+  hour = 3600,
+  day = 86400,
+  month = 2592000,
+  year = 31536000,
+}
+
+local servers_cache = {}
+local servers_cache_init = false
+
+-- generate configuration for rediscluster from the conf(conf is from the configuration of the plugin)
+local rc_config_from_conf = function(conf)
+  local rc_config = {}
+  rc_config.name = conf.redis_cluster_name
+
+  -- TODO add override: if configuration is specified in plugin then use that
+  -- if cache hit then set and return
+  if servers_cache_init then
+    rc_config.serv_list = servers_cache
+    return rc_config
+  end
+
+local hosts_string = os.getenv("KONG_REDIS_CLUSTER_HOSTS")
+local ports_string = os.getenv("KONG_REDIS_CLUSTER_PORTS")
+if not hosts_string or not ports_string then
+    return nil, error("Enviornment variables for redis configuration are not set.")
+end
+local i = 0
+for host in string.gmatch(hosts_string, '([^,]+)') do
+    i = i+1
+    conf.redis_hosts[i] = host
+end
+i = 0
+for port in string.gmatch(ports_string, '([^,]+)') do
+    i = i+1
+    conf.redis_ports[i] = port
+end
+  --add redis nodes
+  local servers = {}
+  local count = 1
+  for index, _ in pairs(conf.redis_hosts) do
+			servers[#servers + 1 ] = {ip = conf.redis_hosts[count], port = conf.redis_ports[count] }
+      count = count + 1
+  end 
+  -- set cache 
+  servers_cache = servers
+  servers_cache_init = true
+  rc_config.serv_list = servers
+  rc_config.connection_timout = conf.redis_timeout
+  return rc_config
+end
+
+return {
+  increment = function(conf, limits, api_id, identifier, current_timestamp, value)
+
+    local rc_conf, err = rc_config_from_conf(conf)
+    if err then
+      return nil, err
+    end
+
+    local redis_cluster, err = redis_cluster:new(rc_conf)
+    if err then
+      ngx_log(ngx.ERR,"Failed to instantiate a rediscluster")
+      return nil, err
+    end
+
+    local periods = timestamp.get_timestamps(current_timestamp)
+
+    for period, period_date in pairs(periods) do
+      if limits[period] then
+        local cache_key = get_local_key(api_id, identifier, period_date, period)
+        local exists, err = redis_cluster:exists(cache_key)
+        if err then
+          ngx_log(ngx.ERR, "failed to query Redis: ", err)
+          return nil, err
+        end
+        --TODO(Harry) pull the single pipeline fix from master here
+        redis_cluster:init_pipeline()
+        redis_cluster:incrby(cache_key, value)
+        if not exists or exists == 0 then
+          redis_cluster:expire(cache_key, EXPIRATIONS[period])
+        end
+
+        local _, err = redis_cluster:commit_pipeline()
+        
+        if err then
+          ngx_log(ngx.ERR, "failed to commit pipeline in Redis: ", err)
+          return nil, err
+        end
+      end
+    end
+    return true
+  end,
+
+  usage = function(conf, api_id, identifier, current_timestamp, name)
+    local rc_conf,err = rc_config_from_conf(conf)
+
+    if err then
+      return nil, err
+    end
+
+    local redis_cluster, err = redis_cluster:new(rc_conf)
+
+    if err then
+      ngx_log(ngx.ERR,"Failed to instantiate a rediscluster")
+      return nil, err
+    end
+
+    local periods = timestamp.get_timestamps(current_timestamp)
+    local cache_key = get_local_key(api_id, identifier, periods[name], name)
+    local current_metric, err = redis_cluster:get(cache_key)
+
+    if err then
+      return nil, err
+    end
+
+    if current_metric == ngx.null then
+      current_metric = nil
+    end
+
+    return current_metric or 0
+  end
+}


### PR DESCRIPTION
This PR is an introductory one and to get a conversation started regarding redis-cluster storage support for counters in *-rate-limiting plugins (and other plugins in the wild).

I doubt anyone is using a single instance redis with Kong CE for production purpose since there is no failover model. Hence, I believe this feature would be really useful to a broad audience for whom gateway performance is a critical.

This feature adds a dependency on another luarocks module: https://github.com/steve0511/resty-redis-cluster. If the community is ready to accept this feature then I'm offering help to work with the author of resty-redis-cluster to get the module into luarocks repository so that we can include it as a direct dependency here. I've tested that the module in question here works for this particular use case.
I currently include the resty-redis-cluster module in the plugin itself, which though not ideal, works for my purpose.
I'm open to thoughts/suggestions of avoiding an additional dependency.

An additional proposal with this PR is to allow redis connection details to be supplied using environment variables or a property rather than specifying those with plugin configuration.
Putting `host:port` info is a deployment and runtime configuration rather than an entity specific detail. I'm assuming here that such a feature was always on the backlog and no one has picked it up yet. I'm open to better ways of dealing with this problem. In any case, putting these details in DB does not sound very good in my opinion.

To not break things, we can have an override via plugin configuration feature, where by default, connection details are read from environment variables, but the setting can be overridden using plugin configuration using Admin API.

I can share benchmarks if needed later on. The performance is very similar to a single instance Redis storage.

**Code in the PR as is will not work right now.**

## Blockers
- [ ] Publish https://github.com/steve0511/resty-redis-cluster to luarocks repo
- [ ] Include the above dependency in Kong's rockspec file
- [ ] Test cases
- [ ] Refactor redis policies into a single file (to remove the duplicate code)
- [ ] Solve TODOs in code
- [ ] Support for Redis connection details using environment variables
## TODO
- Documentation