### PR TITLE
fix(*) invert tcp-log and request-termination priority

### DIFF
--- a/kong/plugins/request-termination/handler.lua
+++ b/kong/plugins/request-termination/handler.lua
@@ -6,7 +6,7 @@ local server_header = meta._NAME .. "/" .. meta._VERSION
 
 local RequestTerminationHandler = BasePlugin:extend()
 
-RequestTerminationHandler.PRIORITY = 7
+RequestTerminationHandler.PRIORITY = 2
 RequestTerminationHandler.VERSION = "0.1.0"
 
 function RequestTerminationHandler:new()

--- a/kong/plugins/tcp-log/handler.lua
+++ b/kong/plugins/tcp-log/handler.lua
@@ -4,7 +4,7 @@ local cjson = require "cjson"
 
 local TcpLogHandler = BasePlugin:extend()
 
-TcpLogHandler.PRIORITY = 2
+TcpLogHandler.PRIORITY = 7
 TcpLogHandler.VERSION = "0.1.0"
 
 local function log(premature, conf, message)

--- a/spec/01-unit/014-plugins_order_spec.lua
+++ b/spec/01-unit/014-plugins_order_spec.lua
@@ -66,12 +66,12 @@ describe("Plugins", function()
       "datadog",
       "file-log",
       "udp-log",
-      "request-termination",
+      "tcp-log",
       "loggly",
       "runscope",
       "syslog",
       "galileo",
-      "tcp-log",
+      "request-termination",
       "correlation-id",
     }
 


### PR DESCRIPTION
### Summary

Work done in #3079 highlighted that tcp-log executed with a lower priority than request-termination. While this functionally has not presented a significant problem, this commit cleans up the prioritization of these plugins to a more sane definition. This has the added benefit of not requiring the request-termination define its own delayed callback function once #3079 is merged.

### Full changelog

* Swap the priority definitions of the `tcp-log` and `request-termination` plugins
* Update the plugins order unit spec to reflect that `tcp-log` is prioritized accordingly