### PR TITLE
feat(tcp-log) TLS handshake support for TCP logs

### DIFF
--- a/kong-0.11.2-0.rockspec
+++ b/kong-0.11.2-0.rockspec
@@ -151,6 +151,8 @@ build = {
 
     ["kong.plugins.tcp-log.handler"] = "kong/plugins/tcp-log/handler.lua",
     ["kong.plugins.tcp-log.schema"] = "kong/plugins/tcp-log/schema.lua",
+    ["kong.plugins.tcp-log.migrations.cassandra"] = "kong/plugins/tcp-log/migrations/cassandra.lua",
+    ["kong.plugins.tcp-log.migrations.postgres"] = "kong/plugins/tcp-log/migrations/postgres.lua",
 
     ["kong.plugins.udp-log.handler"] = "kong/plugins/udp-log/handler.lua",
     ["kong.plugins.udp-log.schema"] = "kong/plugins/udp-log/schema.lua",

--- a/kong/plugins/tcp-log/handler.lua
+++ b/kong/plugins/tcp-log/handler.lua
@@ -27,6 +27,15 @@ local function log(premature, conf, message)
     return
   end
 
+  if conf.tls then
+    ok, err = sock:sslhandshake(true, conf.tls_sni, false)
+    if not ok then
+      ngx.log(ngx.ERR, "[tcp-log] failed to perform TLS handshake to ",
+                       host, ":", port, ": ", err)
+      return
+    end
+  end
+
   ok, err = sock:send(cjson.encode(message) .. "\r\n")
   if not ok then
     ngx.log(ngx.ERR, "[tcp-log] failed to send data to " .. host .. ":" .. tostring(port) .. ": ", err)

--- a/kong/plugins/tcp-log/migrations/cassandra.lua
+++ b/kong/plugins/tcp-log/migrations/cassandra.lua
@@ -1,0 +1,22 @@
+local plugin_config_iterator = require("kong.dao.migrations.helpers").plugin_config_iterator
+
+
+return {
+  {
+    name = "2017-12-13-120000_tcp-log_tls",
+    up = function(_, _, dao)
+      for ok, config, update in plugin_config_iterator(dao, "tcp-log") do
+        if not ok then
+          return config
+        end
+				config.tls = false
+				local ok, err = update(config)
+				if not ok then
+					return err
+				end
+      end
+    end,
+    down = function(_, _, dao) end  -- not implemented
+  },
+}
+

--- a/kong/plugins/tcp-log/migrations/postgres.lua
+++ b/kong/plugins/tcp-log/migrations/postgres.lua
@@ -1,0 +1,22 @@
+local plugin_config_iterator = require("kong.dao.migrations.helpers").plugin_config_iterator
+
+
+return {
+  {
+    name = "2017-12-13-120000_tcp-log_tls",
+    up = function(_, _, dao)
+      for ok, config, update in plugin_config_iterator(dao, "tcp-log") do
+        if not ok then
+          return config
+        end
+				config.tls = false
+				local ok, err = update(config)
+				if not ok then
+					return err
+				end
+      end
+    end,
+    down = function(_, _, dao) end  -- not implemented
+  },
+}
+

--- a/kong/plugins/tcp-log/schema.lua
+++ b/kong/plugins/tcp-log/schema.lua
@@ -3,6 +3,8 @@ return {
     host = { required = true, type = "string" },
     port = { required = true, type = "number" },
     timeout = { default = 10000, type = "number" },
-    keepalive = { default = 60000, type = "number" }
+    keepalive = { default = 60000, type = "number" },
+    tls = { default = false, type = "boolean" },
+    tls_sni = { type = "string" },
   }
 }

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -308,11 +308,13 @@ end
 -- (single read).
 -- @name tcp_server
 -- @param `port`    The port where the server will be listening to
+-- @param `opts     A table of options defining the server's behavior
 -- @return `thread` A thread object
-local function tcp_server(port, ...)
+local function tcp_server(port, opts, ...)
   local threads = require "llthreads2.ex"
+  opts = opts or {}
   local thread = threads.new({
-    function(port)
+    function(port, opts)
       local socket = require "socket"
       local server = assert(socket.tcp())
       server:settimeout(10)
@@ -320,13 +322,27 @@ local function tcp_server(port, ...)
       assert(server:bind("*", port))
       assert(server:listen())
       local client = assert(server:accept())
+
+      if opts.tls then
+        local ssl = require "ssl"
+        local params = {
+          mode = "server",
+          protocol = "any",
+          key = "spec/fixtures/kong_spec.key",
+          certificate = "spec/fixtures/kong_spec.crt",
+        }
+
+        client = ssl.wrap(client, params)
+        client:dohandshake()
+      end
+
       local line = assert(client:receive())
       client:send(line .. "\n")
       client:close()
       server:close()
       return line
     end
-  }, port)
+  }, port, opts)
 
   return thread:start(...)
 end


### PR DESCRIPTION
### Summary

Support TLS connections for remote TCP servers in the `tcp-log` plugin.

### Full changelog

* Add two new config options to `tcp-log`: `tls`, a boolean indicating whether to perform a TLS handshake against the remote server, and `tls_sni`, and optional string defining the SNI hostname to send in the handshake.
* Attempt to perform a TLS handshake when `tls` is true.
* Add support for TLS connections in the mock `tcp_server` helpers construct.
