### PR TITLE
ldap_auth add bind+search feature

### DIFF
--- a/kong/plugins/ldap-auth/access.lua
+++ b/kong/plugins/ldap-auth/access.lua
@@ -86,6 +86,11 @@ local function ldap_authenticate(given_username, given_password, conf)
           local hash = decode_base64(value.userPassword:sub(6))
           local digest = openssl_digest.new("sha1"):final(given_password)
           is_authenticated = digest == hash
+        elseif value.userPassword:match("^%{[Ss][Ss][Hh][Aa]%}") then
+          local hash = decode_base64(value.userPassword:sub(7))
+          local salt = hash:sub(21)
+          local digest = openssl_digest.new("sha1"):update(given_password):final(salt) .. salt
+          is_authenticated = digest == hash
         end
       end
     end

--- a/kong/plugins/ldap-auth/asn1.lua
+++ b/kong/plugins/ldap-auth/asn1.lua
@@ -195,6 +195,37 @@ _M.ASN1Encoder = {
     return bpack('XAA' , '30', self.encodeLength(#seqData), seqData)
   end,
 
+  encodeEnum = function(self, data)
+    local ival = self.encodeInt(data)
+    local len = self.encodeLength(#ival)
+    return bpack('cAA', 10, len, ival)
+  end,
+
+  encodeTag = function(self, class, constructed, tagn, data)
+    local o1
+    if class == "universal" then
+      o1 = 0
+    elseif class == "application" then
+      o1 = 0x40
+    elseif class == "context" then
+      o1 = 0x80
+    elseif class == "private" then
+      o1 = 0xC0
+    else
+      error("invalid")
+    end
+    if constructed then
+      o1 = o1 + 0x20
+    end
+    if tagn < 0x20 then
+      o1 = o1 + tagn
+    else
+      error("NYI")
+    end
+
+    return bpack('cAA', o1, self.encodeLength(#data), data)
+  end,
+
   encode = function(self, val)
     local vtype = type(val)
 

--- a/kong/plugins/ldap-auth/ldap.lua
+++ b/kong/plugins/ldap-auth/ldap.lua
@@ -29,7 +29,7 @@ local function encodeLDAPOp(encoder, appno, isConstructed, data)
   return encoder:encode({ _ldaptype = string_format("%X", asn1_type), data })
 end
 
-local function claculate_payload_length(encStr, pos, socket)
+local function calculate_payload_length(encStr, pos, socket)
   local elen
   pos, elen = bunpack(encStr, 'C', pos)
   if elen > 128 then
@@ -62,7 +62,7 @@ function _M.bind_request(socket, username, password)
   ldapMessageId = ldapMessageId +1
   socket:send(packet)
   packet = socket:receive(2)
-  _, packet_len = claculate_payload_length(packet, 2, socket)
+  _, packet_len = calculate_payload_length(packet, 2, socket)
 
   packet = socket:receive(packet_len)
   pos, response.messageID = decoder:decode(packet, 1)
@@ -114,7 +114,7 @@ function _M.start_tls(socket)
   packet = encoder:encodeSeq(ldapMsg)
   socket:send(packet)
   packet = socket:receive(2)
-  _, packet_len = claculate_payload_length(packet, 2, socket)
+  _, packet_len = calculate_payload_length(packet, 2, socket)
 
   packet = socket:receive(packet_len)
   pos, response.messageID = decoder:decode(packet, 1)

--- a/kong/plugins/ldap-auth/schema.lua
+++ b/kong/plugins/ldap-auth/schema.lua
@@ -12,7 +12,9 @@ return {
   no_consumer = true,
   fields = {
     ldap_host = {required = true, type = "string"},
+    ldap_password = {type = "string"},
     ldap_port = {type = "number", default = 389},
+    bind_dn = {type = "string"},
     start_tls = {required = true, type = "boolean", default = false},
     verify_ldap_host = {required = true, type = "boolean", default = false},
     base_dn = {required = true, type = "string"},

--- a/kong/plugins/ldap-auth/schema.lua
+++ b/kong/plugins/ldap-auth/schema.lua
@@ -12,7 +12,7 @@ return {
   no_consumer = true,
   fields = {
     ldap_host = {required = true, type = "string"},
-    ldap_port = {required = true, type = "number"},
+    ldap_port = {type = "number", default = 389},
     start_tls = {required = true, type = "boolean", default = false},
     verify_ldap_host = {required = true, type = "boolean", default = false},
     base_dn = {required = true, type = "string"},


### PR DESCRIPTION
Closes #1821

I would have loved to have used lua-ldap, but that would require either lua-ldap to support passing own socket (possible) and yielding (less possible); *or* https://github.com/openresty/lua-nginx-module/pull/450 to submit lua-ldap's fd to the nginx main loop.

Instead I've extended the internal asn1 decoder/encoder with some extra features and added the new function `ldap.search_request`.
This is then used from the ldap-auth access phase: if `bind_dn` is set in config we do a search for a user matching the provided `attribute` and retrive the `userPassword` field.
This PR supports crypt, sha1 and salted-sha1 hashes from rfc 2307 (though marked as "experimental", these are the forms widely used).