### PR TITLE
fix(makefile) proper OPENSSL_DIR defaults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,14 @@
+OS := $(shell uname)
+
 DEV_ROCKS = "busted 2.0.rc12" "luacheck 0.20.0" "lua-llthreads2 0.1.4"
 BUSTED_ARGS ?= -v
 TEST_CMD ?= bin/busted $(BUSTED_ARGS)
+
+ifeq ($(OS), Darwin)
 OPENSSL_DIR ?= /usr/local/opt/openssl
+else
+OPENSSL_DIR ?= /usr
+endif
 
 .PHONY: install dev lint test test-integration test-plugins test-all
 


### PR DESCRIPTION
### Summary

Detect the default OPENSSL_DIR include path based on the OS. The variable can still be explicitly overridden. This fixes a regression introduced by 54691fb.

This default definition for non-Darwin environments primarily targets Debian-based distros, benefiting the `kong-vagrant` environment.

### Full changelog

* Define the `OPENSSL_DIR` default directive accordingly based on OS.