### PR TITLE
feat(healthchecks) add active and passive health checks

### DIFF
--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-export BUSTED_ARGS="-o gtest -v --exclude-tags=flaky"
+export BUSTED_ARGS="-o gtest -v --exclude-tags=flaky,ipv6"
 export TEST_CMD="bin/busted $BUSTED_ARGS"
 
 createuser --createdb kong

--- a/kong-0.11.2-0.rockspec
+++ b/kong-0.11.2-0.rockspec
@@ -27,9 +27,10 @@ dependencies = {
   "luaossl == 20171028",
   "luasyslog == 1.0.0",
   "lua_pack == 1.0.5",
-  "lua-resty-dns-client == 0.6.2",
-  "lua-resty-worker-events == 0.3.0",
+  "lua-resty-dns-client == 0.6.3",
+  "lua-resty-worker-events == 0.3.1",
   "lua-resty-mediador == 0.1.2",
+  "lua-resty-healthcheck == 0.2.0",
 }
 build = {
   type = "builtin",

--- a/kong-0.11.2-0.rockspec
+++ b/kong-0.11.2-0.rockspec
@@ -27,7 +27,7 @@ dependencies = {
   "luaossl == 20171028",
   "luasyslog == 1.0.0",
   "lua_pack == 1.0.5",
-  "lua-resty-dns-client == 0.6.3",
+  "lua-resty-dns-client == 1.0.0",
   "lua-resty-worker-events == 0.3.1",
   "lua-resty-mediador == 0.1.2",
   "lua-resty-healthcheck == 0.2.0",

--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -72,5 +72,6 @@ return {
     "kong_cache",
     "kong_process_events",
     "kong_cluster_events",
+    "kong_healthchecks",
   },
 }

--- a/kong/core/balancer.lua
+++ b/kong/core/balancer.lua
@@ -714,6 +714,29 @@ end
 
 
 --------------------------------------------------------------------------------
+-- Update health status and broadcast to workers
+-- @param upstream a table with upstream data
+-- @param ip target IP
+-- @param port target port
+-- @param is_healthy boolean: true if healthy, false if unhealthy
+-- @return true if posting event was successful, nil+error otherwise
+local function post_health(upstream, ip, port, is_healthy)
+
+  local balancer = balancers[upstream.name]
+  if not balancer then
+    return nil, "Upstream " .. tostring(upstream.name) .. " has no balancer"
+  end
+
+  local healthchecker = healthcheckers[balancer]
+  if not healthchecker then
+    return nil, "no healthchecker found for " .. tostring(upstream.name)
+  end
+
+  return healthchecker:set_target_status(ip, port, is_healthy)
+end
+
+
+--------------------------------------------------------------------------------
 -- for unit-testing purposes only
 local function _get_healthchecker(balancer)
   return healthcheckers[balancer]
@@ -734,6 +757,7 @@ return {
   on_upstream_event = on_upstream_event,
   get_upstream_by_name = get_upstream_by_name,
   get_all_upstreams = get_all_upstreams,
+  post_health = post_health,
 
   -- ones below are exported for test purposes only
   _create_balancer = create_balancer,

--- a/kong/core/balancer.lua
+++ b/kong/core/balancer.lua
@@ -1,126 +1,145 @@
 local pl_tablex = require "pl.tablex"
-local responses = require "kong.tools.responses"
 local singletons = require "kong.singletons"
-local dns_client = require "resty.dns.client"  -- due to startup/require order, cannot use the one from 'singletons' here
-local ring_balancer = require "resty.dns.balancer"
+
+-- due to startup/require order, cannot use the ones from 'singletons' here
+local dns_client = require "resty.dns.client"
 
 local table_concat = table.concat
 local crc32 = ngx.crc32_short
 local toip = dns_client.toip
 local log = ngx.log
 
-local ERROR = ngx.ERR
+local ERR   = ngx.ERR
+local WARN  = ngx.WARN
 local DEBUG = ngx.DEBUG
 local EMPTY_T = pl_tablex.readonly {}
 
---===========================================================
--- Ring-balancer based resolution
---===========================================================
-local balancers = {}  -- table holding our balancer objects, indexed by upstream name
+-- for unit-testing purposes only
+local _load_upstreams_dict_into_memory
+local _load_upstream_into_memory
+local _load_targets_into_memory
 
--- caching logic;
--- we retain 3 entities:
--- 1) list of upstreams: to be invalidated on any upstream change
--- 2) individual upstreams: to be invalidated on individual basis
--- 3) target history for an upstream, invalidated when:
+
+--==============================================================================
+-- Ring-balancer based resolution
+--==============================================================================
+
+
+-- table holding our balancer objects, indexed by upstream name
+local balancers = {}
+
+
+-- objects whose lifetimes are bound to that of a balancer
+local healthcheckers = setmetatable({}, { __mode = "k" })
+local healthchecker_callbacks = setmetatable({}, { __mode = "k" })
+local target_histories = setmetatable({}, { __mode = "k" })
+
+
+-- Caching logic
+--
+-- We retain 3 entities in singletons.cache:
+--
+-- 1) `"balancer:upstreams"` - a list of upstreams
+--    to be invalidated on any upstream change
+-- 2) `"balancer:upstreams:" .. id` - individual upstreams
+--    to be invalidated on individual basis
+-- 3) `"balancer:targets:" .. id`
+--    target history for an upstream, invalidated:
 --    a) along with the upstream it belongs to
 --    b) upon any target change for the upstream (can only add entries)
+--
 -- Distinction between 1 and 2 makes it possible to invalidate individual
 -- upstreams, instead of all at once forcing to rebuild all balancers
 
--- Implements a simple dictionary with all upstream-ids indexed
--- by their name.
-local function load_upstreams_dict_into_memory()
-  log(DEBUG, "fetching all upstreams")
-  local upstreams, err = singletons.dao.upstreams:find_all()
-  if err then
-    return nil, err
-  end
 
-  -- build a dictionary, indexed by the upstream name
-  local upstreams_dict = {}
-  for _, up in ipairs(upstreams) do
-    upstreams_dict[up.name] = up.id
-  end
-
-  -- check whether any of our existing balancers has been deleted
-  for upstream_name in pairs(balancers) do
-    if not upstreams_dict[upstream_name] then
-      -- this one was deleted, so also clear the balancer object
-      balancers[upstream_name] = nil
+local function stop_healthchecker(balancer)
+  local healthchecker = healthcheckers[balancer]
+  if healthchecker then
+    local ok, err = healthchecker:clear()
+    if not ok then
+      log(ERR, "[healthchecks] error clearing healthcheck data: ", err)
     end
+    healthchecker:stop()
   end
-
-  return upstreams_dict
+  healthcheckers[balancer] = nil
 end
 
--- delete a balancer object from our internal cache
-local function invalidate_balancer(upstream_name)
-  balancers[upstream_name] = nil
+
+local get_upstream_by_id
+do
+  ------------------------------------------------------------------------------
+  -- Loads a single upstream entity.
+  -- @param upstream_id string
+  -- @return the upstream table, or nil+error
+  local function load_upstream_into_memory(upstream_id)
+    log(DEBUG, "fetching upstream: ", tostring(upstream_id))
+
+    local upstream, err = singletons.dao.upstreams:find_all {id = upstream_id}
+    if not upstream then
+      return nil, err
+    end
+
+    return upstream[1]  -- searched by id, so only 1 row in the returned set
+  end
+  _load_upstream_into_memory = load_upstream_into_memory
+
+  get_upstream_by_id = function(upstream_id)
+    local upstream_cache_key = "balancer:upstreams:" .. upstream_id
+    return singletons.cache:get(upstream_cache_key, nil,
+                                load_upstream_into_memory, upstream_id)
+  end
 end
 
--- loads a single upstream entity
-local function load_upstream_into_memory(upstream_id)
-  log(DEBUG, "fetching upstream: ", tostring(upstream_id))
 
-  local upstream, err = singletons.dao.upstreams:find_all {id = upstream_id}
-  if not upstream then
-    return nil, err
+local fetch_target_history
+do
+  ------------------------------------------------------------------------------
+  -- Loads the target history from the DAO.
+  -- @param upstream_id Upstream uuid for which to load the target history
+  -- @return The target history array, with target entity tables.
+  local function load_targets_into_memory(upstream_id)
+    log(DEBUG, "fetching targets for upstream: ",tostring(upstream_id))
+
+    local target_history, err = singletons.dao.targets:find_all {upstream_id = upstream_id}
+    if not target_history then
+      return nil, err
+    end
+
+    -- perform some raw data updates
+    for _, target in ipairs(target_history) do
+      -- split `target` field into `name` and `port`
+      local port
+      target.name, port = string.match(target.target, "^(.-):(%d+)$")
+      target.port = tonumber(port)
+
+      -- need exact order, so create sort-key by created-time and uuid
+      target.order = target.created_at .. ":" .. target.id
+    end
+
+    table.sort(target_history, function(a,b)
+      return a.order < b.order
+    end)
+
+    return target_history
   end
+  _load_targets_into_memory = load_targets_into_memory
 
-  return upstream[1]  -- searched by id, so only 1 row in the returned set
+
+  ------------------------------------------------------------------------------
+  -- Fetch target history, from cache or the DAO.
+  -- @param upstream The upstream entity object
+  -- @return The target history array, with target entity tables.
+  fetch_target_history = function(upstream)
+    local targets_cache_key = "balancer:targets:" .. upstream.id
+    return singletons.cache:get(targets_cache_key, nil,
+                                load_targets_into_memory, upstream.id)
+  end
 end
 
--- finds and returns an upstream entity. This functions covers
--- caching, invalidation, db access, et al.
--- @return upstream table, or `false` if not found, or nil+error
-local function get_upstream(upstream_name)
-  local upstreams_dict, err = singletons.cache:get("balancer:upstreams", nil,
-                                                   load_upstreams_dict_into_memory)
-  if err then
-    return nil, err
-  end
 
-  local upstream_id = upstreams_dict[upstream_name]
-  if not upstream_id then
-    return false -- no upstream by this name
-  end
-
-  local upstream_cache_key = "balancer:upstreams:" .. upstream_id
-  return singletons.cache:get(upstream_cache_key, nil,
-                              load_upstream_into_memory, upstream_id)
-end
-
--- loads the target history for an upstream
--- @param upstream_id Upstream uuid for which to load the target history
-local function load_targets_into_memory(upstream_id)
-  log(DEBUG, "fetching targets for upstream: ",tostring(upstream_id))
-
-  local target_history, err = singletons.dao.targets:find_all {upstream_id = upstream_id}
-  if err then
-    return nil, err
-  end
-
-  -- perform some raw data updates
-  for _, target in ipairs(target_history) do
-    -- split `target` field into `name` and `port`
-    local port
-    target.name, port = string.match(target.target, "^(.-):(%d+)$")
-    target.port = tonumber(port)
-
-    -- need exact order, so create sort-key by created-time and uuid
-    target.order = target.created_at .. ":" .. target.id
-  end
-
-  table.sort(target_history, function(a,b)
-    return a.order < b.order
-  end)
-
-  return target_history
-end
-
--- applies the history of lb transactions from index `start` forward
--- @param rb ring-balancer object
+--------------------------------------------------------------------------------
+-- Applies the history of lb transactions from index `start` forward.
+-- @param rb ring balancer object
 -- @param history list of targets/transactions to be applied
 -- @param start the index where to start in the `history` parameter
 -- @return true
@@ -135,7 +154,7 @@ local function apply_history(rb, history, start)
       assert(rb:removeHost(target.name, target.port))
     end
 
-    rb.__targets_history[i] = {
+    target_histories[rb][i] = {
       name = target.name,
       port = target.port,
       weight = target.weight,
@@ -146,96 +165,388 @@ local function apply_history(rb, history, start)
   return true
 end
 
--- looks up a balancer for the target.
--- @param target the table with the target details
--- @return balancer+upstream if found, `false` if not found, or nil+error on error
-local get_balancer = function(target)
-  -- NOTE: only called upon first lookup, so `cache_only` limitations do not apply here
-  local hostname = target.host
 
-  -- first go and find the upstream object, from cache or the db
-  local upstream, err = get_upstream(hostname)
+local function populate_healthchecker(hc, balancer)
+  for weight, addr, host in balancer:addressIter() do
+    if weight > 0 then
+      local ipaddr = addr.ip
+      local port = addr.port
+      local hostname = host.hostname
+      local ok, err = hc:add_target(ipaddr, port, hostname)
+      if ok then
+        -- Get existing health status which may have been initialized
+        -- with data from another worker, and apply to the new balancer.
+        local tgt_status = hc:get_target_status(ipaddr, port)
+        balancer:setPeerStatus(tgt_status, ipaddr, port, hostname)
 
-  if upstream == false then
-    return false                -- no upstream by this name
+      else
+        log(ERR, "[healthchecks] failed adding target: ", err)
+      end
+    end
+  end
+end
+
+
+local create_balancer
+do
+  local ring_balancer = require "resty.dns.balancer"
+
+  local create_healthchecker
+  do
+    local healthcheck -- delay initialization
+
+    ------------------------------------------------------------------------------
+    -- Callback function that informs the healthchecker when targets are added
+    -- or removed to a balancer.
+    -- @param balancer the ring balancer object that triggers this callback.
+    -- @param action "added" or "removed"
+    -- @param ip string
+    -- @param port number
+    -- @param hostname string
+    local function ring_balancer_callback(balancer, action, ip, port, hostname)
+      local healthchecker = healthcheckers[balancer]
+      if action == "added" then
+        local ok, err = healthchecker:add_target(ip, port, hostname)
+        if not ok then
+          log(ERR, "[healthchecks] failed adding a target: ", err)
+        end
+
+      elseif action == "removed" then
+        local ok, err = healthchecker:remove_target(ip, port)
+        if not ok then
+          log(ERR, "[healthchecks] failed adding a target: ", err)
+        end
+
+      else
+        log(WARN, "[healthchecks] unknown status from balancer: ",
+                  tostring(action))
+      end
+    end
+
+    -- @param healthchecker The healthchecker object
+    -- @param balancer The balancer object
+    local function attach_healthchecker_to_balancer(healthchecker, balancer)
+      local hc_callback = function(tgt, event)
+        local ok, err = true, nil
+        if event == healthchecker.events.healthy then
+          ok, err = balancer:setPeerStatus(true, tgt.ip, tgt.port, tgt.hostname)
+        elseif event == healthchecker.events.unhealthy then
+          ok, err = balancer:setPeerStatus(false, tgt.ip, tgt.port, tgt.hostname)
+        end
+        if not ok then
+          log(ERR, "[healthchecks] failed setting peer status: ", err)
+        end
+      end
+
+      -- Register event using a weak-reference in worker-events,
+      -- and attach lifetime of callback to that of the balancer.
+      singletons.worker_events.register_weak(hc_callback, healthchecker.EVENT_SOURCE)
+      healthchecker_callbacks[balancer] = hc_callback
+
+      -- The lifetime of the healthchecker is based on that of the balancer.
+      healthcheckers[balancer] = healthchecker
+
+      balancer.report_http_status = function(ip, port, status)
+        local ok, err = healthchecker:report_http_status(ip, port, status,
+                                                         "passive")
+        if not ok then
+          log(ERR, "[healthchecks] failed reporting status: ", err)
+        end
+      end
+
+      balancer.report_tcp_failure = function(ip, port)
+        local ok, err = healthchecker:report_tcp_failure(ip, port, nil,
+                                                         "passive")
+        if not ok then
+          log(ERR, "[healthchecks] failed reporting status: ", err)
+        end
+      end
+    end
+
+    ----------------------------------------------------------------------------
+    -- Create a healthchecker object.
+    -- @param upstream An upstream entity table.
+    create_healthchecker = function(balancer, upstream)
+      if not healthcheck then
+        healthcheck = require("resty.healthcheck") -- delayed initialization
+      end
+      local healthchecker, err = healthcheck.new({
+        name = upstream.name,
+        shm_name = "kong_healthchecks",
+        checks = upstream.healthchecks,
+      })
+      if not healthchecker then
+        log(ERR, "[healthchecks] error creating health checker: ", err)
+        return nil, err
+      end
+
+      populate_healthchecker(healthchecker, balancer)
+
+      attach_healthchecker_to_balancer(healthchecker, balancer)
+
+      -- only enable the callback after the target history has been replayed.
+      balancer:setCallback(ring_balancer_callback)
+    end
   end
 
-  if err then
-    return nil, err             -- there was an error
-  end
+  ------------------------------------------------------------------------------
+  -- @return The new balancer object, or nil+error
+  create_balancer = function(upstream, history, start)
+    local balancer, err = ring_balancer.new({
+        wheelSize = upstream.slots,
+        order = upstream.orderlist,
+        dns = dns_client,
+      })
+    if not balancer then
+      return nil, err
+    end
 
-  -- we've got the upstream, now fetch its targets, from cache or the db
-  local targets_cache_key    = "balancer:targets:" .. upstream.id
-  local targets_history, err = singletons.cache:get(targets_cache_key, nil,
-                                                    load_targets_into_memory,
-                                                    upstream.id)
+    target_histories[balancer] = {}
+
+    if not history then
+      history, err = fetch_target_history(upstream)
+      if not history then
+        return nil, err
+      end
+      start = 1
+    end
+
+    apply_history(balancer, history, start)
+
+    create_healthchecker(balancer, upstream)
+
+    -- only make the new balancer available for other requests after it
+    -- is fully set up.
+    balancers[upstream.name] = balancer
+
+    return balancer
+  end
+end
+
+
+--------------------------------------------------------------------------------
+-- Compare the target history of the upstream with that of the
+-- current balancer object, updating or recreating the balancer if necessary.
+-- @param upstream The upstream entity object
+-- @param balancer The ring balancer object
+-- @return true if all went well, or nil + error in case of failures.
+local function check_target_history(upstream, balancer)
+  -- Fetch the upstream's targets, from cache or the db
+  local new_history, err = fetch_target_history(upstream)
   if err then
     return nil, err
   end
 
-  local balancer = balancers[upstream.name]
-  if not balancer then
-    -- no balancer yet (or invalidated) so create a new one
-    balancer, err = ring_balancer.new({
-        wheelSize = upstream.slots,
-        dns = dns_client,
-      })
-
-    if not balancer then
-      return balancer, err
-    end
-
-    -- NOTE: we're inserting a foreign entity in the balancer, to keep track of
-    -- target-history changes!
-    balancer.__targets_history = {}
-    balancers[upstream.name] = balancer
-  end
+  local old_history = target_histories[balancer]
 
   -- check history state
-  -- NOTE: in the code below variables are similarly named, but the
-  -- ones with `__`-prefixed, are the ones on the `balancer` object, and the
-  -- regular ones are the ones we just fetched and are comparing against.
-  local __size = #balancer.__targets_history
-  local size = #targets_history
+  local old_size = #old_history
+  local new_size = #new_history
 
-  if __size ~= size or
-    (balancer.__targets_history[__size] or EMPTY_T).order ~=
-    (targets_history[size] or EMPTY_T).order then
-    -- last entries in history don't match, so we must do some updates.
+  if old_size == new_size and
+    (old_history[old_size] or EMPTY_T).order ==
+    (new_history[new_size] or EMPTY_T).order then
+    -- No history update is necessary in the balancer object.
+    return true
+  end
 
-    -- compare balancer history with db-loaded history
-    local last_equal_index = 0  -- last index where history is the same
-    for i, entry in ipairs(balancer.__targets_history) do
-      if entry.order ~= (targets_history[i] or EMPTY_T).order then
-        last_equal_index = i - 1
-        break
-      end
+  -- last entries in history don't match, so we must do some updates.
+
+  -- compare balancer history with db-loaded history
+  local last_equal_index = 0  -- last index where history is the same
+  for i, entry in ipairs(old_history) do
+    if entry.order ~= (new_history[i] or EMPTY_T).order then
+      last_equal_index = i - 1
+      break
+    end
+  end
+
+  if last_equal_index == old_size then
+    -- history is the same, so we only need to add new entries
+    apply_history(balancer, new_history, last_equal_index + 1)
+    return true
+  end
+
+  -- history not the same.
+  -- TODO: ideally we would undo the last ones until we're equal again
+  -- and can replay changes, but not supported by ring-balancer yet.
+  -- for now; create a new balancer from scratch
+
+  stop_healthchecker(balancer)
+
+  local new_balancer, err = create_balancer(upstream, new_history, 1)
+  if not new_balancer then
+    return nil, err
+  end
+
+  return true
+end
+
+
+local get_all_upstreams
+do
+  ------------------------------------------------------------------------------
+  -- Implements a simple dictionary with all upstream-ids indexed
+  -- by their name.
+  -- @return The upstreams dictionary, a map with upstream names as string keys
+  -- and upstream entity tables as values, or nil+error
+  local function load_upstreams_dict_into_memory()
+    log(DEBUG, "fetching all upstreams")
+    local upstreams, err = singletons.dao.upstreams:find_all()
+    if err then
+      return nil, err
     end
 
-    if last_equal_index == __size then
-      -- history is the same, so we only need to add new entries
-      apply_history(balancer, targets_history, last_equal_index + 1)
+    -- build a dictionary, indexed by the upstream name
+    local upstreams_dict = {}
+    for _, up in ipairs(upstreams) do
+      upstreams_dict[up.name] = up.id
+    end
 
+    return upstreams_dict
+  end
+  _load_upstreams_dict_into_memory = load_upstreams_dict_into_memory
+
+
+  ------------------------------------------------------------------------------
+  -- Finds and returns an upstream entity. This function covers
+  -- caching, invalidation, db access, et al.
+  -- @param upstream_name string.
+  -- @return upstream table, or `false` if not found, or nil+error
+  get_all_upstreams = function()
+    local upstreams_dict, err = singletons.cache:get("balancer:upstreams", nil,
+                                                load_upstreams_dict_into_memory)
+    if err then
+      return nil, err
+    end
+
+    return upstreams_dict
+  end
+end
+
+
+------------------------------------------------------------------------------
+-- Finds and returns an upstream entity. This function covers
+-- caching, invalidation, db access, et al.
+-- @param upstream_name string.
+-- @return upstream table, or `false` if not found, or nil+error
+local function get_upstream_by_name(upstream_name)
+  local upstreams_dict, err = get_all_upstreams()
+  if err then
+    return nil, err
+  end
+
+  local upstream_id = upstreams_dict[upstream_name]
+  if not upstream_id then
+    return false -- no upstream by this name
+  end
+
+  return get_upstream_by_id(upstream_id)
+end
+
+
+-- looks up a balancer for the target.
+-- @param target the table with the target details
+-- @param no_create (optional) if true, do not attempt to create
+-- (for thorough testing purposes)
+-- @return balancer if found, `false` if not found, or nil+error on error
+local function get_balancer(target, no_create)
+  -- NOTE: only called upon first lookup, so `cache_only` limitations
+  -- do not apply here
+  local hostname = target.host
+
+  -- first go and find the upstream object, from cache or the db
+  local upstream, err = get_upstream_by_name(hostname)
+  if upstream == false then
+    return false -- no upstream by this name
+  end
+  if err then
+    return nil, err -- there was an error
+  end
+
+  local balancer = balancers[upstream.name]
+  if not balancer then
+    if no_create then
+      return nil, "balancer not found"
     else
-      -- history not the same.
-      -- TODO: ideally we would undo the last ones until we're equal again
-      -- and can replay changes, but not supported by ring-balancer yet.
-      -- for now; create a new balancer from scratch
-      balancer, err = ring_balancer.new({
-          wheelSize = upstream.slots,
-          dns = dns_client,
-        })
-      if not balancer then
-        return balancer, err
-      end
-
-      balancer.__targets_history = {}
-      balancers[upstream.name] = balancer  -- overwrite our existing one
-      apply_history(balancer, targets_history, 1)
+      log(ERR, "balancer not found for ", upstream.name, ", will create it")
+      return create_balancer(upstream)
     end
   end
 
   return balancer, upstream
+end
+
+
+--==============================================================================
+-- Event Callbacks
+--==============================================================================
+
+
+--------------------------------------------------------------------------------
+-- Called on any changes to a target.
+-- @param operation "create", "update" or "delete"
+-- @param upstream Target table with `upstream_id` field
+local function on_target_event(operation, target)
+  local upstream_id = target.upstream_id
+
+  singletons.cache:invalidate_local("balancer:targets:" .. upstream_id)
+
+  local upstream = get_upstream_by_id(upstream_id)
+  if not upstream then
+    log(ERR, "target ", operation, ": upstream not found for ", upstream_id)
+    return
+  end
+
+  local balancer = balancers[upstream.name]
+  if not balancer then
+    log(ERR, "target ", operation, ": balancer not found for ", upstream.name)
+    return
+  end
+
+  local ok, err = check_target_history(upstream, balancer)
+  if not ok then
+    log(ERR, "failed checking target history for ", upstream.name, ":  ", err)
+  end
+end
+
+
+--------------------------------------------------------------------------------
+-- Called on any changes to an upstream.
+-- @param operation "create", "update" or "delete"
+-- @param upstream Upstream table with `id` and `name` fields
+local function on_upstream_event(operation, upstream)
+
+  if operation == "create" then
+    local _, err = create_balancer(upstream)
+    if err then
+      log(ERR, "failed creating balancer for ", upstream.name, ": ", err)
+    end
+
+  elseif operation == "delete" or operation == "update" then
+
+    if operation == "delete" then
+      singletons.cache:invalidate_local("balancer:upstreams")
+    end
+    singletons.cache:invalidate_local("balancer:upstreams:" .. upstream.id)
+    singletons.cache:invalidate_local("balancer:targets:"   .. upstream.id)
+
+    local balancer = balancers[upstream.name]
+    if balancer then
+      stop_healthchecker(balancer)
+    end
+
+    if operation == "delete" then
+      balancers[upstream.name] = nil
+    else
+      local _, err = create_balancer(upstream)
+      if err then
+        log(ERR, "failed recreating balancer for ", upstream.name, ": ", err)
+      end
+    end
+
+  end
+
 end
 
 
@@ -281,21 +592,56 @@ local create_hash = function(upstream)
       return nil
     end
   end
-  -- nothing found, leave without a hash  
+  -- nothing found, leave without a hash
 end
 
---===========================================================
--- Main entry point when resolving
---===========================================================
 
+--==============================================================================
+-- Initialize balancers
+--==============================================================================
+
+
+local function init()
+  local upstreams, err = get_all_upstreams()
+  if not upstreams then
+    log(ngx.STDERR, "failed loading initial list of upstreams: ", err)
+    return
+  end
+
+  local oks, errs = 0, 0
+  for name, id in pairs(upstreams) do
+    local upstream = get_upstream_by_id(id)
+    local ok, err = create_balancer(upstream)
+    if ok ~= nil then
+      oks = oks + 1
+    else
+      log(ngx.STDERR, "failed creating balancer for ", name, ": ", err)
+      errs = errs + 1
+    end
+  end
+  log(DEBUG, "initialized ", oks, " balancer(s), ", errs, " error(s)")
+end
+
+
+--==============================================================================
+-- Main entry point when resolving
+--==============================================================================
+
+
+--------------------------------------------------------------------------------
 -- Resolves the target structure in-place (fields `ip`, `port`, and `hostname`).
 --
 -- If the hostname matches an 'upstream' pool, then it must be balanced in that
--- pool, in this case any port number provided will be ignored, as the pool provides it.
+-- pool, in this case any port number provided will be ignored, as the pool
+-- provides it.
 --
--- @param target the data structure as defined in `core.access.before` where it is created
--- @return true on success, nil+error otherwise
+-- @param target the data structure as defined in `core.access.before` where
+-- it is created.
+-- @param silent Do not produce body data (to be used in OpenResty contexts
+-- which do not support sending it)
+-- @return true on success, nil+error message+status code otherwise
 local function execute(target)
+
   if target.type ~= "name" then
     -- it's an ip address (v4 or v6), so nothing we can do...
     target.ip = target.host
@@ -304,8 +650,10 @@ local function execute(target)
     return true
   end
 
-  -- when tries == 0 it runs before the `balancer` context (in the `access` context),
-  -- when tries >= 2 then it performs a retry in the `balancer` context
+  -- when tries == 0,
+  --   it runs before the `balancer` context (in the `access` context),
+  -- when tries >= 2,
+  --   then it performs a retry in the `balancer` context
   local dns_cache_only = target.try_count ~= 0
   local balancer, upstream, hash_value
 
@@ -317,13 +665,13 @@ local function execute(target)
     -- first try, so try and find a matching balancer/upstream object
     balancer, upstream = get_balancer(target)
     if balancer == nil then -- `false` means no balancer, `nil` is error
-      return nil, upstream
+      return nil, upstream, 500
     end
 
     if balancer then
       -- store for retries
       target.balancer = balancer
-      
+
       -- calculate hash-value
       -- only add it if it doesn't exist, in case a plugin inserted one
       hash_value = target.hash_value
@@ -334,54 +682,66 @@ local function execute(target)
     end
   end
 
+  local ip, port, hostname
   if balancer then
     -- have to invoke the ring-balancer
-    local ip, port, hostname = balancer:getPeer(hash_value,
-                                                target.try_count,
-                                                dns_cache_only)
-    if not ip then
-      if port == "No peers are available" then
-        -- in this case a "503 service unavailable", others will be a 500.
-        log(ERROR, "failure to get a peer from the ring-balancer '",
-                   target.host, "': ", port)
-        return responses.send(503)
-      end
-
-      return nil, port -- some other error
+    ip, port, hostname = balancer:getPeer(hash_value,
+                                          target.try_count,
+                                          dns_cache_only)
+    if not ip and port == "No peers are available" then
+      return nil, "failure to get a peer from the ring-balancer", 503
     end
-
-    target.ip = ip
-    target.port = port
-    target.hostname = hostname
     target.hash_value = hash_value
-    return true
+
+  else
+    -- have to do a regular DNS lookup
+    ip, port = toip(target.host, target.port, dns_cache_only)
+    hostname = target.host
+    if not ip and port == "dns server error: 3 name error" then
+      return nil, "name resolution failed", 503
+    end
   end
 
-  -- have to do a regular DNS lookup
-  local ip, port = toip(target.host, target.port, dns_cache_only)
   if not ip then
-    if port == "dns server error: 3 name error" then
-      -- in this case a "503 service unavailable", others will be a 500.
-      log(ERROR, "name resolution failed for '", tostring(target.host),
-                 "': ", port)
-      return responses.send(503)
-    end
-    return nil, port
+    return nil, port, 500
   end
 
   target.ip = ip
   target.port = port
-  target.hostname = target.host
+  target.hostname = hostname
   return true
 end
 
-return {
-  execute = execute,
-  invalidate_balancer = invalidate_balancer,
 
-  -- ones below are exported for test purposes
-  _load_upstreams_dict_into_memory = load_upstreams_dict_into_memory,
-  _load_upstream_into_memory = load_upstream_into_memory,
-  _load_targets_into_memory = load_targets_into_memory,
+--------------------------------------------------------------------------------
+-- for unit-testing purposes only
+local function _get_healthchecker(balancer)
+  return healthcheckers[balancer]
+end
+
+
+--------------------------------------------------------------------------------
+-- for unit-testing purposes only
+local function _get_target_history(balancer)
+  return target_histories[balancer]
+end
+
+
+return {
+  init = init,
+  execute = execute,
+  on_target_event = on_target_event,
+  on_upstream_event = on_upstream_event,
+  get_upstream_by_name = get_upstream_by_name,
+  get_all_upstreams = get_all_upstreams,
+
+  -- ones below are exported for test purposes only
+  _create_balancer = create_balancer,
+  _get_balancer = get_balancer,
+  _get_healthchecker = _get_healthchecker,
+  _get_target_history = _get_target_history,
+  _load_upstreams_dict_into_memory = _load_upstreams_dict_into_memory,
+  _load_upstream_into_memory = _load_upstream_into_memory,
+  _load_targets_into_memory = _load_targets_into_memory,
   _create_hash = create_hash,
 }

--- a/kong/core/handler.lua
+++ b/kong/core/handler.lua
@@ -85,6 +85,12 @@ return {
       local cluster_events = singletons.cluster_events
 
 
+      -- initialize balancers
+
+
+      balancer.init()
+
+
       -- events dispatcher
 
 
@@ -184,56 +190,107 @@ return {
       end, "crud", "ssl_certificates")
 
 
-      -- targets invalidations
+      -- target updates
 
 
+      -- worker_events local handler: event received from DAO
       worker_events.register(function(data)
-        log(DEBUG, "[events] Target updated, invalidating target in balancer")
+        local operation = data.operation
         local target = data.entity
-
-        cache:invalidate("balancer:targets:" .. target.upstream_id)
+        -- => to worker_events node handler
+        local ok, err = worker_events.post("balancer", "targets", {
+          operation = data.operation,
+          entity = data.entity,
+        })
+        if not ok then
+          log(ERR, "failed broadcasting target ",
+              operation, " to workers: ", err)
+        end
+        -- => to cluster_events handler
+        local key = fmt("%s:%s", operation, target.upstream_id)
+        ok, err = cluster_events:broadcast("balancer:targets", key)
+        if not ok then
+          log(ERR, "failed broadcasting target ", operation, " to cluster: ", err)
+        end
       end, "crud", "targets")
 
 
-      -- balancer invalidations
-
-
+      -- worker_events node handler
       worker_events.register(function(data)
-        log(DEBUG, "[events] Upstream updated, invalidating balancer")
-        local upstream = data.entity
+        local operation = data.operation
+        local target = data.entity
 
-        local ok, err = worker_events.post("balancer", "invalidate", upstream)
+        -- => to balancer update
+        balancer.on_target_event(operation, target)
+      end, "balancer", "targets")
+
+
+      -- cluster_events handler
+      cluster_events:subscribe("balancer:targets", function(data)
+        local operation, key = unpack(utils.split(data, ":"))
+        -- => to worker_events node handler
+        local ok, err = worker_events.post("balancer", "targets", {
+          operation = operation,
+          entity = {
+            upstream_id = key,
+          }
+        })
         if not ok then
-          log(ERR, "failed broadcasting balancer invalidation to workers: ", err)
+          log(ERR, "failed broadcasting target ", operation, " to workers: ", err)
         end
+      end)
 
-        local data = fmt("%s:%s", upstream.id, upstream.name)
-        local ok, err = cluster_events:broadcast("balancer:invalidate", data)
+
+      -- upstream updates
+
+
+      -- worker_events local handler: event received from DAO
+      worker_events.register(function(data)
+        local operation = data.operation
+        local upstream = data.entity
+        -- => to worker_events node handler
+        local ok, err = worker_events.post("balancer", "upstreams", {
+          operation = data.operation,
+          entity = data.entity,
+        })
         if not ok then
-          log(ERR, "failed broadcasting balancer invalidation to cluster: ", err)
+          log(ERR, "failed broadcasting upstream ",
+              operation, " to workers: ", err)
+        end
+        -- => to cluster_events handler
+        local key = fmt("%s:%s:%s", operation, upstream.id, upstream.name)
+        ok, err = cluster_events:broadcast("balancer:upstreams", key)
+        if not ok then
+          log(ERR, "failed broadcasting upstream ", operation, " to cluster: ", err)
         end
       end, "crud", "upstreams")
 
 
-      worker_events.register(function(upstream)
-        cache:invalidate_local("balancer:upstreams")
-        cache:invalidate_local("balancer:upstreams:" .. upstream.id)
-        cache:invalidate_local("balancer:targets:"   .. upstream.id)
-        balancer.invalidate_balancer(upstream.name)
-      end, "balancer", "invalidate")
+      -- worker_events node handler
+      worker_events.register(function(data)
+        local operation = data.operation
+        local upstream = data.entity
+
+        -- => to balancer update
+        balancer.on_upstream_event(operation, upstream)
+      end, "balancer", "upstreams")
 
 
-      cluster_events:subscribe("balancer:invalidate", function(data)
-        local upstream_id, upstream_name = unpack(utils.split(data, ":"))
-
-        local ok, err = worker_events.post("balancer", "invalidate", {
-          id   = upstream_id,
-          name = upstream_name,
+      cluster_events:subscribe("balancer:upstreams", function(data)
+        local operation, id, name = unpack(utils.split(data, ":"))
+        -- => to worker_events node handler
+        local ok, err = worker_events.post("balancer", "upstreams", {
+          operation = operation,
+          entity = {
+            id = id,
+            name = name,
+          }
         })
         if not ok then
-          log(ERR, "failed broadcasting balancer invalidation to workers: ", err)
+          log(ERR, "failed broadcasting upstream ", operation, " to workers: ", err)
         end
       end)
+
     end
   },
   certificate = {
@@ -389,12 +446,14 @@ return {
         end
       end
 
-      local ok, err = balancer.execute(ctx.balancer_address)
+      local ok, err, errcode = balancer.execute(ctx.balancer_address)
       if not ok then
-        return responses.send_HTTP_INTERNAL_SERVER_ERROR(
-                          "failed the initial dns/balancer resolve for '" ..
-                          ctx.balancer_address.host .. "' with: "         ..
-                          tostring(err))
+        if errcode == 500 then
+          err = "failed the initial dns/balancer resolve for '" ..
+                ctx.balancer_address.host .. "' with: "         ..
+                tostring(err)
+        end
+        return responses.send(errcode, err)
       end
 
       do
@@ -489,6 +548,12 @@ return {
   log = {
     after = function(ctx)
       reports.log()
+      local addr = ctx.balancer_address
+
+      -- Report HTTP status for health checks
+      if addr and addr.balancer and addr.ip then
+        addr.balancer.report_http_status(addr.ip, addr.port, ngx.status)
+      end
     end
   }
 }

--- a/kong/core/handler.lua
+++ b/kong/core/handler.lua
@@ -241,6 +241,18 @@ return {
       end)
 
 
+      -- manual health updates
+      cluster_events:subscribe("balancer:post_health", function(data)
+        local ip, port, health, name = data:match("([^|]+)|([^|]+)|([^|]+)|(.*)")
+        port = tonumber(port)
+        local upstream = { name = name }
+        local ok, err = balancer.post_health(upstream, ip, port, health == "1")
+        if not ok then
+          log(ERR, "failed posting health of ", name, " to workers: ", err)
+        end
+      end)
+
+
       -- upstream updates
 
 

--- a/kong/core/handler.lua
+++ b/kong/core/handler.lua
@@ -550,9 +550,12 @@ return {
       reports.log()
       local addr = ctx.balancer_address
 
-      -- Report HTTP status for health checks
-      if addr and addr.balancer and addr.ip then
-        addr.balancer.report_http_status(addr.ip, addr.port, ngx.status)
+      -- If response was produced by an upstream (ie, not by a Kong plugin)
+      if ctx.KONG_PROXIED == true then
+        -- Report HTTP status for health checks
+        if addr and addr.balancer and addr.ip then
+          addr.balancer.report_http_status(addr.ip, addr.port, ngx.status)
+        end
       end
     end
   }

--- a/kong/dao/migrations/cassandra.lua
+++ b/kong/dao/migrations/cassandra.lua
@@ -520,4 +520,40 @@ return {
     end,
     down = function(_, _, dao) end  -- n.a. since the columns will be dropped
   },
+  {
+    name = "2017-11-07-192000_upstream_healthchecks",
+    up = [[
+      ALTER TABLE upstreams ADD healthchecks text;
+    ]],
+    down = [[
+      ALTER TABLE upstreams DROP healthchecks;
+    ]]
+  },
+  {
+    name = "2017-11-07-192100_upstream_healthchecks_2",
+    up = function(_, _, dao)
+      local rows, err = dao.db:query([[
+        SELECT * FROM upstreams;
+      ]])
+      if err then
+        return err
+      end
+
+      local upstreams = require("kong.dao.schemas.upstreams")
+      local default = upstreams.fields.healthchecks.default
+
+      for _, row in ipairs(rows) do
+        if not row.healthchecks then
+
+          local _, err = dao.upstreams:update({
+            healthchecks = default,
+          }, { id = row.id })
+          if err then
+            return err
+          end
+        end
+      end
+    end,
+    down = function(_, _, dao) end
+  },
 }

--- a/kong/dao/migrations/postgres.lua
+++ b/kong/dao/migrations/postgres.lua
@@ -581,4 +581,46 @@ return {
     end,
     down = function(_, _, dao) end  -- n.a. since the columns will be dropped
   },
+  {
+    name = "2017-11-07-192000_upstream_healthchecks",
+    up = [[
+      DO $$
+      BEGIN
+          ALTER TABLE upstreams ADD COLUMN healthchecks json;
+      EXCEPTION WHEN duplicate_column THEN
+          -- Do nothing, accept existing state
+      END$$;
+
+    ]],
+    down = [[
+      ALTER TABLE upstreams DROP COLUMN IF EXISTS healthchecks;
+    ]]
+  },
+  {
+    name = "2017-11-07-192100_upstream_healthchecks_2",
+    up = function(_, _, dao)
+      local rows, err = dao.db:query([[
+        SELECT * FROM upstreams;
+      ]])
+      if err then
+        return err
+      end
+
+      local upstreams = require("kong.dao.schemas.upstreams")
+      local default = upstreams.fields.healthchecks.default
+
+      for _, row in ipairs(rows) do
+        if not row.healthchecks then
+
+          local _, err = dao.upstreams:update({
+            healthchecks = default,
+          }, { id = row.id })
+          if err then
+            return err
+          end
+        end
+      end
+    end,
+    down = function(_, _, dao) end
+  },
 }

--- a/kong/dao/schemas/upstreams.lua
+++ b/kong/dao/schemas/upstreams.lua
@@ -65,15 +65,17 @@ return {
   self_check = function(schema, config, dao, is_updating)
 
     -- check the name
-    local p = utils.normalize_ip(config.name)
-    if not p then
-      return false, Errors.schema("Invalid name; must be a valid hostname")
-    end
-    if p.type ~= "name" then
-      return false, Errors.schema("Invalid name; no ip addresses allowed")
-    end
-    if p.port then
-      return false, Errors.schema("Invalid name; no port allowed")
+    if config.name then
+      local p = utils.normalize_ip(config.name)
+      if not p then
+        return false, Errors.schema("Invalid name; must be a valid hostname")
+      end
+      if p.type ~= "name" then
+        return false, Errors.schema("Invalid name; no ip addresses allowed")
+      end
+      if p.port then
+        return false, Errors.schema("Invalid name; no port allowed")
+      end
     end
 
     if config.hash_on_header then
@@ -98,32 +100,36 @@ return {
                                   "but no header name provided")
     end
 
-    if config.hash_on == "none" then
-      if config.hash_fallback ~= "none" then
-        return false, Errors.schema("Cannot set fallback if primary " ..
-                                    "'hash_on' is not set")
-      end
+    if config.hash_on and config.hash_fallback then
+      if config.hash_on == "none" then
+        if config.hash_fallback ~= "none" then
+          return false, Errors.schema("Cannot set fallback if primary " ..
+                                      "'hash_on' is not set")
+        end
 
-    else
-      if config.hash_on == config.hash_fallback then
-        if config.hash_on ~= "header" then
-          return false, Errors.schema("Cannot set fallback and primary " ..
-                                      "hashes to the same value")
-
-        else
-          local upper_hash_on = config.hash_on_header:upper()
-          local upper_hash_fallback = config.hash_fallback_header:upper()
-          if upper_hash_on == upper_hash_fallback then
-            return false, Errors.schema("Cannot set fallback and primary "..
+      else
+        if config.hash_on == config.hash_fallback then
+          if config.hash_on ~= "header" then
+            return false, Errors.schema("Cannot set fallback and primary " ..
                                         "hashes to the same value")
+
+          else
+            local upper_hash_on = config.hash_on_header:upper()
+            local upper_hash_fallback = config.hash_fallback_header:upper()
+            if upper_hash_on == upper_hash_fallback then
+              return false, Errors.schema("Cannot set fallback and primary "..
+                                          "hashes to the same value")
+            end
           end
         end
       end
     end
 
-    -- check the slots number
-    if config.slots < SLOTS_MIN or config.slots > SLOTS_MAX then
-      return false, Errors.schema(SLOTS_MSG)
+    if config.slots then
+      -- check the slots number
+      if config.slots < SLOTS_MIN or config.slots > SLOTS_MAX then
+        return false, Errors.schema(SLOTS_MSG)
+      end
     end
 
     return true

--- a/kong/dao/schemas/upstreams.lua
+++ b/kong/dao/schemas/upstreams.lua
@@ -1,9 +1,127 @@
 local Errors = require "kong.dao.errors"
 local utils = require "kong.tools.utils"
+local match = string.match
+local sub = string.sub
 
 local DEFAULT_SLOTS = 100
 local SLOTS_MIN, SLOTS_MAX = 10, 2^16
 local SLOTS_MSG = "number of slots must be between " .. SLOTS_MIN .. " and " .. SLOTS_MAX
+
+
+local function check_nonnegative(arg)
+  if arg < 0 then
+    return false, "must be greater than or equal to 0"
+  end
+end
+
+
+local function check_positive_int(t)
+  if t < 1 or t > 2^31 - 1 or math.floor(t) ~= t then
+    return false, "must be an integer between 1 and " .. 2^31 - 1
+  end
+
+  return true
+end
+
+
+local function check_http_path(arg)
+  if match(arg, "^%s*$") then
+    return false, "path is empty"
+  end
+  if sub(arg, 1, 1) ~= "/" then
+    return false, "must be prefixed with slash"
+  end
+  return true
+end
+
+
+local function check_http_statuses(arg)
+  for _, s in ipairs(arg) do
+    if type(s) ~= "number" then
+      return false, "array element is not a number"
+    end
+
+    if math.floor(s) ~= s then
+      return false, "must be an integer"
+    end
+
+    -- Accept any three-digit status code,
+    -- applying Postel's law in case of nonstandard HTTP codes
+    if s < 100 or s > 999 then
+      return false, "invalid status code '" .. s ..
+                    "': must be between 100 and 999"
+    end
+  end
+  return true
+end
+
+
+-- same fields as lua-resty-healthcheck library
+local healthchecks_defaults = {
+  active = {
+    timeout = 1,
+    concurrency = 10,
+    http_path = "/",
+    healthy = {
+      interval = 0, -- 0 = disabled by default
+      http_statuses = { 200, 302 },
+      successes = 2,
+    },
+    unhealthy = {
+      interval = 0, -- 0 = disabled by default
+      http_statuses = { 429, 404,
+                        500, 501, 502, 503, 504, 505 },
+      tcp_failures = 2,
+      timeouts = 3,
+      http_failures = 5,
+    },
+  },
+  passive = {
+    healthy = {
+      http_statuses = { 200, 201, 202, 203, 204, 205, 206, 207, 208, 226,
+                        300, 301, 302, 303, 304, 305, 306, 307, 308 },
+      successes = 5,
+    },
+    unhealthy = {
+      http_statuses = { 429, 500, 503 },
+      tcp_failures = 2,
+      timeouts = 7,
+      http_failures = 5,
+    },
+  },
+}
+
+
+local funcs = {
+  timeout = check_nonnegative,
+  concurrency = check_positive_int,
+  interval = check_nonnegative,
+  successes = check_positive_int,
+  tcp_failures = check_positive_int,
+  timeouts = check_positive_int,
+  http_failures = check_positive_int,
+  http_path = check_http_path,
+  http_statuses = check_http_statuses,
+}
+
+
+local function gen_schema(tbl)
+  local ret = {}
+  for k, v in pairs(tbl) do
+    if type(v) == "number" or type(v) == "string" then
+      ret[k] = { type = type(v), default = v, func = funcs[k] }
+
+    elseif type(v) == "table" then
+      if v[1] then
+        ret[k] = { type = "array", default = v, func = funcs[k] }
+      else
+        ret[k] = { type = "table", schema = gen_schema(v), default = v }
+      end
+    end
+  end
+  return { fields = ret }
+end
+
 
 return {
   table = "upstreams",
@@ -60,6 +178,11 @@ return {
       -- the number of slots in the loadbalancer algorithm
       type = "number",
       default = DEFAULT_SLOTS,
+    },
+    healthchecks = {
+      type = "table",
+      schema = gen_schema(healthchecks_defaults),
+      default = healthchecks_defaults,
     },
   },
   self_check = function(schema, config, dao, is_updating)

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -32,6 +32,7 @@ lua_shared_dict kong                5m;
 lua_shared_dict kong_cache          ${{MEM_CACHE_SIZE}};
 lua_shared_dict kong_process_events 5m;
 lua_shared_dict kong_cluster_events 5m;
+lua_shared_dict kong_healthchecks   5m;
 > if database == "cassandra" then
 lua_shared_dict kong_cassandra      5m;
 > end

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -425,6 +425,28 @@ function _M.shallow_copy(orig)
   return copy
 end
 
+--- Merges two tables recursively
+-- For each subtable in t1 and t2, an equivalent (but different) table will
+-- be created in the resulting merge. If t1 and t2 have a subtable with in the
+-- same key k, res[k] will be a deep merge of both subtables.
+-- Metatables are not taken into account.
+-- Keys are copied by reference (if tables are used as keys they will not be
+-- duplicated)
+-- @param t1 one of the tables to merge
+-- @param t2 one of the tables to merge
+-- @return Returns a table representing a deep merge of the new table
+function _M.deep_merge(t1, t2)
+  local res = _M.deep_copy(t1)
+  for k, v in pairs(t2) do
+    if type(v) == "table" and type(res[k]) == "table" then
+      res[k] = _M.deep_merge(res[k], v)
+    else
+      res[k] = _M.deep_copy(v) -- returns v when it is not a table
+    end
+  end
+  return res
+end
+
 local err_list_mt = {}
 
 --- Concatenates lists into a new table.

--- a/spec/02-integration/05-proxy/09-balancer_spec.lua
+++ b/spec/02-integration/05-proxy/09-balancer_spec.lua
@@ -3,8 +3,6 @@
 
 local helpers = require "spec.helpers"
 local dao_helpers = require "spec.02-integration.03-dao.helpers"
-local localhost = "127.0.0.1"
-local ipv = "ipv4"
 local PORT = 21000
 local utils = require "kong.tools.utils"
 local cjson = require "cjson"
@@ -284,6 +282,15 @@ local function client_requests(n, headers)
   end
   return oks, fails, last_status
 end
+
+
+local localhosts = {
+  ipv4 = "127.0.0.1",
+  ipv6 = "0000:0000:0000:0000:0000:0000:0000:0001",
+}
+
+
+for ipv, localhost in pairs(localhosts) do
 
 
 dao_helpers.for_each_dao(function(kong_config)
@@ -1142,3 +1149,5 @@ dao_helpers.for_each_dao(function(kong_config)
   end)
 
 end) -- for 'database type'
+
+end

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -45,6 +45,7 @@ http {
     lua_shared_dict kong_cache          ${{MEM_CACHE_SIZE}};
     lua_shared_dict kong_process_events 5m;
     lua_shared_dict kong_cluster_events 5m;
+    lua_shared_dict kong_healthchecks   5m;
 > if database == "cassandra" then
     lua_shared_dict kong_cassandra      5m;
 > end


### PR DESCRIPTION
### Summary

Adds support for health checks in Kong. 

Health checkers can perform _active health checks_, periodically pinging a configurable upstream URL and checking for the HTTP status code, TCP errors and timeouts, and also _passive health checks_, checking these same signals on ongoing traffic, allowing for _circuit breaker_ functionality.

Major kudos to @Tieske for his work on [lua-resty-dns-client](https://github.com/kong/lua-resty-dns-client) and our joint work on [lua-resty-healthcheck](https://github.com/kong/lua-resty-healthcheck) (on which this is based), and to @thibaultcha for his reviews while this PR was in the making.

### Full changelog

* Overhaul of the update flow for ring-balancer objects of upstream entities: instead of checking and updating balancer objects on-demand based on client requests, the module now keeps these objects updated based on CRUD updates of the underlying entities
* Attaches a health checker object to each balancer object
* Adds the `healthchecks` configuration field for the `upstreams` entity
* Adds support for active health checks
* Adds support for passive health checks
* Adds endpoints for manually setting the health status: `/upstream/:id/targets/:target/healthy` and `/upstream/:id/targets/:target/unhealthy`
* Adds a dependency on [lua-resty-healthcheck](https://github.com/kong/lua-resty-healthcheck), which provides the backend functionality for health checks
* Bumps the dependency versions for [lua-resty-worker-events](https://github.com/kong/lua-resty-worker-events) and [lua-resty-worker-events](https://github.com/kong/lua-resty-dns-client)
* Adds related unit and integration tests for all functionality listed above

### Issues resolved

Fix Kong/kong#112
Fix Kong/kong#154