### PR TITLE
hotfix(log-serializer) avoid redundant `request.request_*` properties

### DIFF
--- a/kong/plugins/log-serializers/basic.lua
+++ b/kong/plugins/log-serializers/basic.lua
@@ -15,14 +15,14 @@ function _M.serialize(ngx)
 
   return {
     request = {
-      request_uri = ngx.var.request_uri,
-      upstream_uri = ngx.var.upstream_uri,
-      request_url = ngx.var.scheme .. "://" .. ngx.var.host .. ":" .. ngx.var.server_port .. ngx.var.request_uri,
+      uri = ngx.var.request_uri,
+      url = ngx.var.scheme .. "://" .. ngx.var.host .. ":" .. ngx.var.server_port .. ngx.var.request_uri,
       querystring = ngx.req.get_uri_args(), -- parameters, as a table
       method = ngx.req.get_method(), -- http method
       headers = ngx.req.get_headers(),
       size = ngx.var.request_length
     },
+    upstream_uri = ngx.var.upstream_uri,
     response = {
       status = ngx.status,
       headers = ngx.resp.get_headers(),

--- a/spec/01-unit/012-log_serializer_spec.lua
+++ b/spec/01-unit/012-log_serializer_spec.lua
@@ -58,10 +58,10 @@ describe("Log Serializer", function()
       assert.same({"header1", "header2"}, res.request.headers)
       assert.equal("POST", res.request.method)
       assert.same({"arg1", "arg2"}, res.request.querystring)
-      assert.equal("http://test.com:80/request_uri", res.request.request_url)
-      assert.equal("/upstream_uri", res.request.upstream_uri)
+      assert.equal("http://test.com:80/request_uri", res.request.url)
+      assert.equal("/upstream_uri", res.upstream_uri)
       assert.equal(200, res.request.size)
-      assert.equal("/request_uri", res.request.request_uri)
+      assert.equal("/request_uri", res.request.uri)
 
       -- Response
       assert.is_table(res.response)


### PR DESCRIPTION
Reflecting back on #2445, the chosen names feel very redundant when
accessed from a queryable interface. The same way, `upstream_uri` seems
to have been wrongly added under the `request` scope, where it doesn't
belong.

This solution has the benefit of being less breaking as well. (Only one
field gets renamed).