### PR TITLE
chore(deps) bump lua-resty-jit-uuid to 0.0.7

### DIFF
--- a/kong-0.11.2-0.rockspec
+++ b/kong-0.11.2-0.rockspec
@@ -15,7 +15,7 @@ dependencies = {
   "luasocket == 3.0-rc1",
   "penlight == 1.5.4",
   "lua-resty-http == 0.08",
-  "lua-resty-jit-uuid == 0.0.5",
+  "lua-resty-jit-uuid == 0.0.7",
   "multipart == 0.5.1",
   "version == 0.2",
   "kong-lapis == 1.6.0.1",


### PR DESCRIPTION
There are no changes for UUID v4 generation between 0.0.5 and 0.0.7, but
the 0.0.7 bump allows anyone to generate v3/v5 UUIDs.

See: https://github.com/thibaultcha/lua-resty-jit-uuid/compare/0.0.5...0.0.7