### PR TITLE
chore(travis) bump OpenSSL and LuaRocks versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ addons:
 
 env:
   global:
-    - LUAROCKS=2.4.2
-    - OPENSSL=1.0.2l
+    - LUAROCKS=2.4.3
+    - OPENSSL=1.0.2n
     - CASSANDRA=2.2.8
     - OPENRESTY_BASE=1.11.2.4
     - OPENRESTY_LATEST=1.11.2.4


### PR DESCRIPTION
When merging next into master, we will also bump our OpenResty versions.