### PR TITLE
feat(reports) execute defined ping values as functions

### DIFF
--- a/kong/core/reports.lua
+++ b/kong/core/reports.lua
@@ -81,6 +81,9 @@ local function send_report(signal_type, t, host, port)
         end
 
         v = json
+
+      elseif type(v) == "function" then
+        v = v()
       end
 
       mutable_idx = mutable_idx + 1

--- a/spec/01-unit/013-reports_spec.lua
+++ b/spec/01-unit/013-reports_spec.lua
@@ -46,6 +46,11 @@ describe("reports", function()
   end)
 
   describe("retrieve_redis_version()", function()
+    setup(function()
+      _G.ngx = ngx
+      _G.ngx.log = function() return end
+    end)
+
     before_each(function()
       package.loaded["kong.core.reports"] = nil
       reports = require "kong.core.reports"

--- a/spec/01-unit/013-reports_spec.lua
+++ b/spec/01-unit/013-reports_spec.lua
@@ -12,7 +12,8 @@ describe("reports", function()
 
       reports.send("stub", {
         hello = "world",
-        foo = "bar"
+        foo = "bar",
+        baz = function() return "bat" end,
       }, "127.0.0.1", 8189)
 
       local ok, res = thread:join()
@@ -26,6 +27,7 @@ describe("reports", function()
       assert.matches("foo=bar", res, nil, true)
       assert.matches("hello=world", res, nil, true)
       assert.matches("signal=stub", res, nil, true)
+      assert.matches("baz=bat", res, nil, true)
     end)
     it("doesn't send if not enabled", function()
       reports.toggle(false)


### PR DESCRIPTION
### Summary

This allows ping keys to be redefined every time send_report is
called.

### Full changelog

* Execute the value of `_ping_infos` members as function when defined as a function.