### PR TITLE
hotfix(migrations) check major C* version against new field

### DIFF
--- a/kong/dao/migrations/cassandra.lua
+++ b/kong/dao/migrations/cassandra.lua
@@ -319,7 +319,7 @@ return {
     up = function(db, kong_config)
       local keyspace_name = kong_config.cassandra_keyspace
 
-      if db.release_version < 3 then
+      if db.major_version_n < 3 then
         local rows, err = db:query([[
           SELECT *
           FROM system.schema_columns

--- a/spec/02-integration/03-dao/01-factory_spec.lua
+++ b/spec/02-integration/03-dao/01-factory_spec.lua
@@ -52,5 +52,14 @@ helpers.for_each_dao(function(kong_conf)
       assert.is_string(info.version)
       assert.not_equal("unknown", info.version)
     end)
+
+    if kong_conf.database == "cassandra" then
+      it("[cassandra] sets the 'major_version_n' field on the DB", function()
+        local factory = assert(Factory.new(kong_conf))
+        assert(factory:init())
+
+        assert.is_number(factory.db.major_version_n)
+      end)
+    end
   end)
 end)


### PR DESCRIPTION
Regression introduced by #3085.

This highlights the dangers of using the DAO in our migrations. While
each migration should be frozen in time and always considered valid given
its parents have previously run, using our DAO in the migrations
introduces a time factor as the DAO undergoes changes over time that
might make previously written migrations suddenly become invalid
(sometimes in worst cases than this, if the schema of entities has
changed).