### PR TITLE
Handle 400 Request Header Or Cookie Too Large (494)

### DIFF
--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -63,7 +63,7 @@ upstream kong_upstream {
 server {
     server_name kong;
     listen ${{PROXY_LISTEN}}${{PROXY_PROTOCOL}};
-    error_page 400 404 408 411 412 413 414 417 /kong_error_handler;
+    error_page 400 404 408 411 412 413 414 417 494 /kong_error_handler;
     error_page 500 502 503 504 /kong_error_handler;
 
     access_log ${{PROXY_ACCESS_LOG}};


### PR DESCRIPTION
### Summary

Handle HTTP 494 with `/kong_error_handler`.

This recently came up in a security audit, we were leaking nginx error pages when sending an oversized header. (which also led us to include `server_tokens off;`, perhaps Kong should include this by default, too)

Can easily be triggered by eg. configuring `key-auth` and sending a large header value.

Upon inspection of the nginx source (https://github.com/nginx/nginx/blob/master/src/http/ngx_http_special_response.c#L244), I noticed that an `400 Request Header Or Cookie Too Large` was merely an internal alias of HTTP `494`, which is nginx-specific.

The block at https://github.com/nginx/nginx/blob/master/src/http/ngx_http_special_response.c#L394 revealed more of these corner cases:

```
    ngx_string(ngx_http_error_494_page), /* 494, request header too large */
    ngx_string(ngx_http_error_495_page), /* 495, https certificate error */
    ngx_string(ngx_http_error_496_page), /* 496, https no certificate */
    ngx_string(ngx_http_error_497_page), /* 497, http to https */
    ngx_string(ngx_http_error_404_page), /* 498, canceled */
    ngx_null_string, /* 499, client has closed connection */
```

Would you be interested in handling all of these with `/kong_error_handler`, perhaps? I'd have to investigate how to trigger them (except 499..).

### Full changelog

* Add HTTP code `494` to errors handled by `/kong_error_handler`