### PR TITLE
hotfix(healthchecks) make circuit-breaker functionality off by default

### DIFF
--- a/kong-0.12.0rc1-0.rockspec
+++ b/kong-0.12.0rc1-0.rockspec
@@ -30,7 +30,7 @@ dependencies = {
   "lua-resty-dns-client == 1.0.0",
   "lua-resty-worker-events == 0.3.1",
   "lua-resty-mediador == 0.1.2",
-  "lua-resty-healthcheck == 0.2.0",
+  "lua-resty-healthcheck == 0.3.0",
 }
 build = {
   type = "builtin",

--- a/kong/dao/schemas/upstreams.lua
+++ b/kong/dao/schemas/upstreams.lua
@@ -63,30 +63,30 @@ local healthchecks_defaults = {
     concurrency = 10,
     http_path = "/",
     healthy = {
-      interval = 0, -- 0 = disabled by default
+      interval = 0,  -- 0 = probing disabled by default
       http_statuses = { 200, 302 },
-      successes = 2,
+      successes = 0, -- 0 = disabled by default
     },
     unhealthy = {
-      interval = 0, -- 0 = disabled by default
+      interval = 0, -- 0 = probing disabled by default
       http_statuses = { 429, 404,
                         500, 501, 502, 503, 504, 505 },
-      tcp_failures = 2,
-      timeouts = 3,
-      http_failures = 5,
+      tcp_failures = 0,  -- 0 = disabled by default
+      timeouts = 0,      -- 0 = disabled by default
+      http_failures = 0, -- 0 = disabled by default
     },
   },
   passive = {
     healthy = {
       http_statuses = { 200, 201, 202, 203, 204, 205, 206, 207, 208, 226,
                         300, 301, 302, 303, 304, 305, 306, 307, 308 },
-      successes = 5,
+      successes = 0,
     },
     unhealthy = {
       http_statuses = { 429, 500, 503 },
-      tcp_failures = 2,
-      timeouts = 7,
-      http_failures = 5,
+      tcp_failures = 0,  -- 0 = circuit-breaker disabled by default
+      timeouts = 0,      -- 0 = circuit-breaker disabled by default
+      http_failures = 0, -- 0 = circuit-breaker disabled by default
     },
   },
 }


### PR DESCRIPTION
To avoid unexpected behaviors for users, this makes the circuit-breaker functionality of passive healthchecks disabled by default. Users need to opt-in by supplying threshold values to enable the cut-off of targets based on analysis of ongoing traffic.

This commit requires functionality introduced in lua-resty-healthcheck 0.3.0 (version bump included in this PR).