### PR TITLE
hotfix(balancer) invalidate cache when creating upstreams

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -36,6 +36,144 @@ starts new workers, which take over from old workers before those old workers
 are terminated. In this way, Kong will serve new requests via the new
 configuration, without dropping existing in-flight connections.
 
+## Upgrade to `0.12.x`
+
+As it is the case most of the time, this new major version of Kong comes with
+a few **database migrations**, some breaking changes, databases deprecation
+notices, and minor updates to the NGINX configuration template.
+
+This document will only highlight the breaking changes that you need to be
+aware of, and describe a recommended upgrade path. We recommend that you
+consult the full [0.12.0
+Changelog](https://github.com/Kong/kong/blob/master/CHANGELOG.md) for a
+complete list of changes and new features.
+
+See below the breaking changes section for a detailed list of steps recommended
+to **run migrations** and upgrade from a previous version of Kong.
+
+#### Breaking changes
+
+#### Configuration
+
+- Several updates were made to the NGINX configuration template. If you are
+  using a custom template, you **must** apply those modifications. See below
+  for a list of changes to apply.
+
+##### Core
+
+- The required OpenResty version has been bumped to 1.11.2.5. If you
+  are installing Kong from one of our distribution packages, you are not
+  affected by this change.
+- As Kong now executes subsequent plugins when a request is being
+  short-circuited (e.g. HTTP 401 responses from auth plugins), plugins that
+  run in the header or body filter phases will be run upon such responses
+  from the access phase. It is possible that some of these plugins (e.g. your
+  custom plugins) now run in scenarios where they were not previously expected
+  to run.
+
+##### Admin API
+
+- By default, the Admin API now only listens on the local interface.
+  We consider this change to be an improvement in the default security policy
+  of Kong. If you are already using Kong, and your Admin API still binds to all
+  interfaces, consider updating it as well. You can do so by updating the
+  `admin_listen` configuration value, like so: `admin_listen = 127.0.0.1:8001`.
+
+  :red_circle: **Note to Docker users**: Beware of this change as you may have
+  to ensure that your Admin API is reachable via the host's interface.
+  You can use the `-e KONG_ADMIN_LISTEN` argument when provisioning your
+  container(s) to update this value; for example,
+  `-e KONG_ADMIN_LISTEN=0.0.0.0:8001`.
+
+- The `/upstreams/:upstream_name_or_id/targets/` has been updated to not show
+  the full list of Targets anymore, but only the ones that are currently
+  active in the load balancer. To retrieve the full history of Targets, you can
+  now query `/upstreams/:upstream_name_or_id/targets/all`. The
+  `/upstreams/:upstream_name_or_id/targets/active` endpoint has been removed.
+- The `orderlist` property of Upstreams has been removed.
+
+##### CLI
+
+- The `$ kong compile` command which was deprecated in 0.11.0 has been removed.
+
+##### Plugins
+
+- In logging plugins, the `request.request_uri` field has been renamed to
+  `request.url`.
+
+#### Deprecations
+
+##### Databases
+
+- Starting with Kong 0.12.0, we have updated our databases support policy.
+    - Support for PostgreSQL 9.4 has been deprecated. We recommend using
+      PostgreSQL 9.5 or above.
+    - Support for Cassandra 2.0 has been deprecated. We recommend using
+      Cassandra 2.1 or above.
+    - Support for Redis versions 3.1 or below has been deprecated. We
+      recommend using Redis 3.2 or above.
+
+---
+
+If you use a custom NGINX configuration template from Kong 0.11, before
+attempting to run any 0.12 node, make sure to apply the following change to
+your template:
+
+```diff
+diff --git a/kong/templates/nginx_kong.lua b/kong/templates/nginx_kong.lua
+index 5ab65ca3..8a6abd64 100644
+--- a/kong/templates/nginx_kong.lua
++++ b/kong/templates/nginx_kong.lua
+@@ -32,6 +32,7 @@ lua_shared_dict kong                5m;
+ lua_shared_dict kong_cache          ${{MEM_CACHE_SIZE}};
+ lua_shared_dict kong_process_events 5m;
+ lua_shared_dict kong_cluster_events 5m;
++lua_shared_dict kong_healthchecks   5m;
+ > if database == "cassandra" then
+ lua_shared_dict kong_cassandra      5m;
+ > end
+```
+
+---
+
+You can now start migrating your cluster from `0.11.x` to `0.12`. If you are
+doing this upgrade "in-place", against the datastore of a running 0.11 cluster,
+then for a short period of time, your database schema won't be fully compatible
+with your 0.11 nodes anymore. This is why we suggest either performing this
+upgrade when your 0.11 cluster is warm and most entities are cached, or against
+a new database, if you can migrate your data. If you wish to temporarily make
+your APIs unavailable, you can leverage the
+[request-termination](https://getkong.org/plugins/request-termination/) plugin.
+
+The path to upgrade a 0.11 datastore is identical to the one of previous major
+releases:
+
+1. If you are planning on upgrading Kong while 0.11 nodes are running against
+   the same datastore, make sure those nodes are warm enough (they should have
+   most of your entities cached already), or temporarily disable your APIs.
+2. Provision a 0.12 node and configure it as you wish (environment variables/
+   configuration file). Make sure to point this new 0.12 node to your current
+   datastore.
+3. **Without starting the 0.12 node**, run the 0.12 migrations against your
+   current datastore:
+
+```
+$ kong migrations up [-c kong.conf]
+```
+
+As usual, this step should be executed from a **single node**.
+
+4. You can now provision a fresh 0.12 cluster pointing to your migrated
+   datastore and start your 0.12 nodes.
+5. Gradually switch your traffic from the 0.11 cluster to the new 0.12 cluster.
+   Remember, once your database is migrated, your 0.11 nodes will rely on
+   their cache and not on the underlying database. Your traffic should switch
+   to the new cluster as quickly as possible.
+6. Once your traffic is fully migrated to the 0.12 cluster, decommission
+   your 0.11 cluster.
+
+You have now successfully upgraded your cluster to run 0.12 nodes exclusively.
+
 ## Upgrade to `0.11.x`
 
 Along with the usual database migrations shipped with our major releases, this

--- a/kong-0.12.0rc1-0.rockspec
+++ b/kong-0.12.0rc1-0.rockspec
@@ -1,9 +1,9 @@
 package = "kong"
-version = "0.11.2-0"
+version = "0.12.0rc1-0"
 supported_platforms = {"linux", "macosx"}
 source = {
   url = "git://github.com/Kong/kong",
-  tag = "0.11.2"
+  tag = "0.12.0rc1"
 }
 description = {
   summary = "Kong is a scalable and customizable API Management Layer built on top of Nginx.",

--- a/kong/core/balancer.lua
+++ b/kong/core/balancer.lua
@@ -528,9 +528,7 @@ local function on_upstream_event(operation, upstream)
 
   elseif operation == "delete" or operation == "update" then
 
-    if operation == "delete" then
-      singletons.cache:invalidate_local("balancer:upstreams")
-    end
+    singletons.cache:invalidate_local("balancer:upstreams")
     singletons.cache:invalidate_local("balancer:upstreams:" .. upstream.id)
     singletons.cache:invalidate_local("balancer:targets:"   .. upstream.id)
 

--- a/kong/core/balancer.lua
+++ b/kong/core/balancer.lua
@@ -518,6 +518,9 @@ end
 local function on_upstream_event(operation, upstream)
 
   if operation == "create" then
+
+    singletons.cache:invalidate_local("balancer:upstreams")
+
     local _, err = create_balancer(upstream)
     if err then
       log(ERR, "failed creating balancer for ", upstream.name, ": ", err)

--- a/kong/core/balancer.lua
+++ b/kong/core/balancer.lua
@@ -317,7 +317,7 @@ do
 
     -- only make the new balancer available for other requests after it
     -- is fully set up.
-    balancers[upstream.name] = balancer
+    balancers[upstream.id] = balancer
 
     return balancer
   end
@@ -464,7 +464,7 @@ local function get_balancer(target, no_create)
     return nil, err -- there was an error
   end
 
-  local balancer = balancers[upstream.name]
+  local balancer = balancers[upstream.id]
   if not balancer then
     if no_create then
       return nil, "balancer not found"
@@ -498,7 +498,7 @@ local function on_target_event(operation, target)
     return
   end
 
-  local balancer = balancers[upstream.name]
+  local balancer = balancers[upstream.id]
   if not balancer then
     log(ERR, "target ", operation, ": balancer not found for ", upstream.name)
     return
@@ -532,13 +532,13 @@ local function on_upstream_event(operation, upstream)
     singletons.cache:invalidate_local("balancer:upstreams:" .. upstream.id)
     singletons.cache:invalidate_local("balancer:targets:"   .. upstream.id)
 
-    local balancer = balancers[upstream.name]
+    local balancer = balancers[upstream.id]
     if balancer then
       stop_healthchecker(balancer)
     end
 
     if operation == "delete" then
-      balancers[upstream.name] = nil
+      balancers[upstream.id] = nil
     else
       local _, err = create_balancer(upstream)
       if err then
@@ -723,7 +723,7 @@ end
 -- @return true if posting event was successful, nil+error otherwise
 local function post_health(upstream, ip, port, is_healthy)
 
-  local balancer = balancers[upstream.name]
+  local balancer = balancers[upstream.id]
   if not balancer then
     return nil, "Upstream " .. tostring(upstream.name) .. " has no balancer"
   end

--- a/kong/dao/schemas/upstreams.lua
+++ b/kong/dao/schemas/upstreams.lua
@@ -24,6 +24,21 @@ local function check_positive_int(t)
 end
 
 
+local function check_positive_int_or_zero(t)
+  if t == 0 then
+    return true
+  end
+
+  local ok = check_positive_int(t)
+  if not ok then
+    return false, "must be 0 (disabled), or an integer between 1 and "
+                  .. 2 ^31 - 1
+  end
+
+  return true
+end
+
+
 local function check_http_path(arg)
   if match(arg, "^%s*$") then
     return false, "path is empty"
@@ -96,10 +111,10 @@ local funcs = {
   timeout = check_nonnegative,
   concurrency = check_positive_int,
   interval = check_nonnegative,
-  successes = check_positive_int,
-  tcp_failures = check_positive_int,
-  timeouts = check_positive_int,
-  http_failures = check_positive_int,
+  successes = check_positive_int_or_zero,
+  tcp_failures = check_positive_int_or_zero,
+  timeouts = check_positive_int_or_zero,
+  http_failures = check_positive_int_or_zero,
   http_path = check_http_path,
   http_statuses = check_http_statuses,
 }

--- a/kong/meta.lua
+++ b/kong/meta.lua
@@ -1,8 +1,8 @@
 local version = setmetatable({
   major = 0,
-  minor = 11,
-  patch = 2,
-  --suffix = ""
+  minor = 12,
+  patch = 0,
+  suffix = "rc1"
 }, {
   __tostring = function(t)
     return string.format("%d.%d.%d%s", t.major, t.minor, t.patch,

--- a/spec/02-integration/05-proxy/09-balancer_spec.lua
+++ b/spec/02-integration/05-proxy/09-balancer_spec.lua
@@ -133,6 +133,7 @@ local function http_server(timeout, host, port, counts, test_log)
       test_log("test http server on port ", port, " started")
 
       local healthy = true
+      local n_checks = 0
 
       local ok_responses, fail_responses = 0, 0
       local total_reqs = 0
@@ -192,6 +193,7 @@ local function http_server(timeout, host, port, counts, test_log)
               client:send("HTTP/1.1 500 Internal Server Error\r\nConnection: close\r\n\r\n")
             end
             client:close()
+            n_checks = n_checks + 1
 
           elseif lines[1]:match("/healthy") then
             healthy = true
@@ -242,7 +244,7 @@ local function http_server(timeout, host, port, counts, test_log)
       end
       server:close()
       test_log("test http server on port ", port, " closed")
-      return ok_responses, fail_responses
+      return ok_responses, fail_responses, n_checks
     end
   }, timeout, host, port, counts, test_log or TEST_LOG)
 
@@ -425,6 +427,75 @@ dao_helpers.for_each_dao(function(kong_config)
         local _, server2_oks, server2_fails = server2:join()
         assert.same({1, 0}, { server1_oks, server1_fails })
         assert.same({1, 0}, { server2_oks, server2_fails })
+      end)
+
+      it("do not leave a stale healthchecker when renamed", function()
+        local healthcheck_interval = 0.1
+        -- create an upstream
+        assert.same(201, api_send("POST", "/upstreams", {
+          name = "test_upstr", slots = 10,
+          healthchecks = healthchecks_config {
+            active = {
+              http_path = "/status",
+              healthy = {
+                interval = healthcheck_interval,
+                successes = 1,
+              },
+              unhealthy = {
+                interval = healthcheck_interval,
+                http_failures = 1,
+              },
+            }
+          }
+        }))
+        assert.same(201, api_send("POST", "/upstreams/test_upstr/targets", {
+          target = utils.format_host(localhost, 2000),
+        }))
+        assert.same(201, api_send("POST", "/apis", {
+          name = "test_api",
+          hosts = "test_upstr.com",
+          upstream_url = "http://test_upstr",
+        }))
+
+        -- start server
+        local server1 = http_server(10, localhost, 2000, { 1 })
+
+        -- rename upstream
+        assert.same(200, api_send("PATCH", "/upstreams/test_upstr", {
+          name = "test_upstr_2",
+        }))
+
+        -- reconfigure healthchecks
+        assert.same(200, api_send("PATCH", "/upstreams/test_upstr_2", {
+          healthchecks = {
+            active = {
+              http_path = "/status",
+              healthy = {
+                interval = 0,
+                successes = 1,
+              },
+              unhealthy = {
+                interval = 0,
+                http_failures = 1,
+              },
+            }
+          }
+        }))
+
+        -- give time for healthchecker to (not!) run
+        ngx.sleep(healthcheck_interval * 5)
+
+        assert.same(200, api_send("PATCH", "/apis/test_api", {
+          upstream_url = "http://test_upstr_2",
+        }))
+
+        -- a single request to upstream just to make server shutdown
+        client_requests(1, { ["Host"] = "test_upstr.com" })
+
+        -- collect results
+        local _, server1_oks, server1_fails, hcs = server1:join()
+        assert.same({1, 0}, { server1_oks, server1_fails })
+        assert.truthy(hcs < 2)
       end)
 
     end)


### PR DESCRIPTION
Make sure that cache for the overall list of upstreams is invalidated when an individual upstream is created.

Includes a regression test.