### PR TITLE
feat(admin) add latency headers in Admin API responses

### DIFF
--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -40,6 +40,7 @@ return {
   HEADERS = {
     HOST_OVERRIDE = "X-Host-Override",
     PROXY_LATENCY = "X-Kong-Proxy-Latency",
+    KONG_RESPONSE_LATENCY = "X-Kong-Latency",
     UPSTREAM_LATENCY = "X-Kong-Upstream-Latency",
     CONSUMER_ID = "X-Consumer-ID",
     CONSUMER_CUSTOM_ID = "X-Consumer-Custom-ID",

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -177,7 +177,11 @@ server {
     location / {
         default_type application/json;
         content_by_lua_block {
-            kong.serve_admin_api()
+            kong.admin_api.serve()
+        }
+
+        header_filter_by_lua_block {
+            kong.admin_api.header_filter()
         }
     }
 

--- a/spec/02-integration/04-admin_api/01-kong_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/01-kong_routes_spec.lua
@@ -1,6 +1,7 @@
 local helpers = require "spec.helpers"
 local cjson = require "cjson"
 
+local constants = require "kong.constants"
 local DAOFactory = require "kong.dao.factory"
 
 local dao_helpers = require "spec.02-integration.03-dao.helpers"
@@ -41,6 +42,14 @@ describe("Admin API - Kong routes", function()
       assert.res_status(200, res)
       assert.equal(string.format("%s/%s", meta._NAME, meta._VERSION), res.headers.server)
       assert.is_nil(res.headers.via) -- Via is only set for proxied requests
+    end)
+    it("response has " .. constants.HEADERS.KONG_RESPONSE_LATENCY .. " header", function()
+      local res = assert(client:send {
+        method = "GET",
+        path = "/"
+      })
+      assert.res_status(200, res)
+      assert(res.headers[constants.HEADERS.KONG_RESPONSE_LATENCY])
     end)
     it("returns 405 on invalid method", function()
       local methods = {"POST", "PUT", "DELETE", "PATCH", "GEEEET"}


### PR DESCRIPTION
### Summary
Responses from Admin API now include a latency header,
which represents the time taken by Kong to respond to the
Admin request in milliseconds.

### Breaking change

* Nginx template for Kong
A `header_filter_by_lua_block` has been added to admin endpoint
to inject the latency header.

### Issues resolved

Fix #2855 
