### PR TITLE
fix(reports) support functions as values in ping reports

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -36,6 +36,144 @@ starts new workers, which take over from old workers before those old workers
 are terminated. In this way, Kong will serve new requests via the new
 configuration, without dropping existing in-flight connections.
 
+## Upgrade to `0.12.x`
+
+As it is the case most of the time, this new major version of Kong comes with
+a few **database migrations**, some breaking changes, databases deprecation
+notices, and minor updates to the NGINX configuration template.
+
+This document will only highlight the breaking changes that you need to be
+aware of, and describe a recommended upgrade path. We recommend that you
+consult the full [0.12.0
+Changelog](https://github.com/Kong/kong/blob/master/CHANGELOG.md) for a
+complete list of changes and new features.
+
+See below the breaking changes section for a detailed list of steps recommended
+to **run migrations** and upgrade from a previous version of Kong.
+
+#### Breaking changes
+
+#### Configuration
+
+- Several updates were made to the NGINX configuration template. If you are
+  using a custom template, you **must** apply those modifications. See below
+  for a list of changes to apply.
+
+##### Core
+
+- The required OpenResty version has been bumped to 1.11.2.5. If you
+  are installing Kong from one of our distribution packages, you are not
+  affected by this change.
+- As Kong now executes subsequent plugins when a request is being
+  short-circuited (e.g. HTTP 401 responses from auth plugins), plugins that
+  run in the header or body filter phases will be run upon such responses
+  from the access phase. It is possible that some of these plugins (e.g. your
+  custom plugins) now run in scenarios where they were not previously expected
+  to run.
+
+##### Admin API
+
+- By default, the Admin API now only listens on the local interface.
+  We consider this change to be an improvement in the default security policy
+  of Kong. If you are already using Kong, and your Admin API still binds to all
+  interfaces, consider updating it as well. You can do so by updating the
+  `admin_listen` configuration value, like so: `admin_listen = 127.0.0.1:8001`.
+
+  :red_circle: **Note to Docker users**: Beware of this change as you may have
+  to ensure that your Admin API is reachable via the host's interface.
+  You can use the `-e KONG_ADMIN_LISTEN` argument when provisioning your
+  container(s) to update this value; for example,
+  `-e KONG_ADMIN_LISTEN=0.0.0.0:8001`.
+
+- The `/upstreams/:upstream_name_or_id/targets/` has been updated to not show
+  the full list of Targets anymore, but only the ones that are currently
+  active in the load balancer. To retrieve the full history of Targets, you can
+  now query `/upstreams/:upstream_name_or_id/targets/all`. The
+  `/upstreams/:upstream_name_or_id/targets/active` endpoint has been removed.
+- The `orderlist` property of Upstreams has been removed.
+
+##### CLI
+
+- The `$ kong compile` command which was deprecated in 0.11.0 has been removed.
+
+##### Plugins
+
+- In logging plugins, the `request.request_uri` field has been renamed to
+  `request.url`.
+
+#### Deprecations
+
+##### Databases
+
+- Starting with Kong 0.12.0, we have updated our databases support policy.
+    - Support for PostgreSQL 9.4 has been deprecated. We recommend using
+      PostgreSQL 9.5 or above.
+    - Support for Cassandra 2.0 has been deprecated. We recommend using
+      Cassandra 2.1 or above.
+    - Support for Redis versions 3.1 or below has been deprecated. We
+      recommend using Redis 3.2 or above.
+
+---
+
+If you use a custom NGINX configuration template from Kong 0.11, before
+attempting to run any 0.12 node, make sure to apply the following change to
+your template:
+
+```diff
+diff --git a/kong/templates/nginx_kong.lua b/kong/templates/nginx_kong.lua
+index 5ab65ca3..8a6abd64 100644
+--- a/kong/templates/nginx_kong.lua
++++ b/kong/templates/nginx_kong.lua
+@@ -32,6 +32,7 @@ lua_shared_dict kong                5m;
+ lua_shared_dict kong_cache          ${{MEM_CACHE_SIZE}};
+ lua_shared_dict kong_process_events 5m;
+ lua_shared_dict kong_cluster_events 5m;
++lua_shared_dict kong_healthchecks   5m;
+ > if database == "cassandra" then
+ lua_shared_dict kong_cassandra      5m;
+ > end
+```
+
+---
+
+You can now start migrating your cluster from `0.11.x` to `0.12`. If you are
+doing this upgrade "in-place", against the datastore of a running 0.11 cluster,
+then for a short period of time, your database schema won't be fully compatible
+with your 0.11 nodes anymore. This is why we suggest either performing this
+upgrade when your 0.11 cluster is warm and most entities are cached, or against
+a new database, if you can migrate your data. If you wish to temporarily make
+your APIs unavailable, you can leverage the
+[request-termination](https://getkong.org/plugins/request-termination/) plugin.
+
+The path to upgrade a 0.11 datastore is identical to the one of previous major
+releases:
+
+1. If you are planning on upgrading Kong while 0.11 nodes are running against
+   the same datastore, make sure those nodes are warm enough (they should have
+   most of your entities cached already), or temporarily disable your APIs.
+2. Provision a 0.12 node and configure it as you wish (environment variables/
+   configuration file). Make sure to point this new 0.12 node to your current
+   datastore.
+3. **Without starting the 0.12 node**, run the 0.12 migrations against your
+   current datastore:
+
+```
+$ kong migrations up [-c kong.conf]
+```
+
+As usual, this step should be executed from a **single node**.
+
+4. You can now provision a fresh 0.12 cluster pointing to your migrated
+   datastore and start your 0.12 nodes.
+5. Gradually switch your traffic from the 0.11 cluster to the new 0.12 cluster.
+   Remember, once your database is migrated, your 0.11 nodes will rely on
+   their cache and not on the underlying database. Your traffic should switch
+   to the new cluster as quickly as possible.
+6. Once your traffic is fully migrated to the 0.12 cluster, decommission
+   your 0.11 cluster.
+
+You have now successfully upgraded your cluster to run 0.12 nodes exclusively.
+
 ## Upgrade to `0.11.x`
 
 Along with the usual database migrations shipped with our major releases, this

--- a/kong-0.12.0rc1-0.rockspec
+++ b/kong-0.12.0rc1-0.rockspec
@@ -1,9 +1,9 @@
 package = "kong"
-version = "0.11.2-0"
+version = "0.12.0rc1-0"
 supported_platforms = {"linux", "macosx"}
 source = {
   url = "git://github.com/Kong/kong",
-  tag = "0.11.2"
+  tag = "0.12.0rc1"
 }
 description = {
   summary = "Kong is a scalable and customizable API Management Layer built on top of Nginx.",

--- a/kong/core/reports.lua
+++ b/kong/core/reports.lua
@@ -74,6 +74,10 @@ local function send_report(signal_type, t, host, port)
 
   for k, v in pairs(t) do
     if k == "unique_id" or (k ~= "created_at" and sub(k, -2) ~= "id") then
+      if type(v) == "function" then
+        v = v()
+      end
+		
       if type(v) == "table" then
         local json, err = cjson.encode(v)
         if err then
@@ -81,9 +85,6 @@ local function send_report(signal_type, t, host, port)
         end
 
         v = json
-
-      elseif type(v) == "function" then
-        v = v()
       end
 
       mutable_idx = mutable_idx + 1

--- a/kong/dao/schemas/upstreams.lua
+++ b/kong/dao/schemas/upstreams.lua
@@ -24,6 +24,21 @@ local function check_positive_int(t)
 end
 
 
+local function check_positive_int_or_zero(t)
+  if t == 0 then
+    return true
+  end
+
+  local ok = check_positive_int(t)
+  if not ok then
+    return false, "must be 0 (disabled), or an integer between 1 and "
+                  .. 2 ^31 - 1
+  end
+
+  return true
+end
+
+
 local function check_http_path(arg)
   if match(arg, "^%s*$") then
     return false, "path is empty"
@@ -96,10 +111,10 @@ local funcs = {
   timeout = check_nonnegative,
   concurrency = check_positive_int,
   interval = check_nonnegative,
-  successes = check_positive_int,
-  tcp_failures = check_positive_int,
-  timeouts = check_positive_int,
-  http_failures = check_positive_int,
+  successes = check_positive_int_or_zero,
+  tcp_failures = check_positive_int_or_zero,
+  timeouts = check_positive_int_or_zero,
+  http_failures = check_positive_int_or_zero,
   http_path = check_http_path,
   http_statuses = check_http_statuses,
 }

--- a/kong/meta.lua
+++ b/kong/meta.lua
@@ -1,8 +1,8 @@
 local version = setmetatable({
   major = 0,
-  minor = 11,
-  patch = 2,
-  --suffix = ""
+  minor = 12,
+  patch = 0,
+  suffix = "rc1"
 }, {
   __tostring = function(t)
     return string.format("%d.%d.%d%s", t.major, t.minor, t.patch,

--- a/spec/01-unit/013-reports_spec.lua
+++ b/spec/01-unit/013-reports_spec.lua
@@ -14,6 +14,8 @@ describe("reports", function()
         hello = "world",
         foo = "bar",
         baz = function() return "bat" end,
+        foobar = function() return { foo = "bar" } end,
+        bazbat = { baz = "bat" },
       }, "127.0.0.1", 8189)
 
       local ok, res = thread:join()
@@ -28,6 +30,8 @@ describe("reports", function()
       assert.matches("hello=world", res, nil, true)
       assert.matches("signal=stub", res, nil, true)
       assert.matches("baz=bat", res, nil, true)
+      assert.matches("foobar=" .. cjson.encode({ foo = "bar" }), res, nil, true)
+      assert.matches("bazbat=" .. cjson.encode({ baz = "bat" }), res, nil, true)
     end)
     it("doesn't send if not enabled", function()
       reports.toggle(false)

--- a/spec/01-unit/013-reports_spec.lua
+++ b/spec/01-unit/013-reports_spec.lua
@@ -1,6 +1,8 @@
 local meta = require "kong.meta"
 local helpers = require "spec.helpers"
 local reports = require "kong.core.reports"
+local cjson = require "cjson.safe"
+
 
 describe("reports", function()
   describe("send()", function()


### PR DESCRIPTION
If a ping value is a function, execute the function and then evaluate the value. 
This allows functions to return tables that will be JSON-encoded before being
added to the ping message.
