### PR TITLE
hotfix(*) exit from plugins on error

### DIFF
--- a/kong/plugins/basic-auth/access.lua
+++ b/kong/plugins/basic-auth/access.lua
@@ -137,12 +137,18 @@ local function do_authentication(conf)
   local given_username, given_password = retrieve_credentials(ngx.req, "proxy-authorization", conf)
   if given_username then
     credential = load_credential_from_db(given_username)
+    if not credential then
+      return
+    end
   end
 
   -- Try with the authorization header
   if not credential then
     given_username, given_password = retrieve_credentials(ngx.req, "authorization", conf)
     credential = load_credential_from_db(given_username)
+    if not credential then
+      return
+    end
   end
 
   if not credential or not validate_credentials(credential, given_password) then
@@ -172,8 +178,8 @@ function _M.execute(conf)
     return
   end
 
-  local ok, err = do_authentication(conf)
-  if not ok then
+  local _, err = do_authentication(conf)
+  if err then
     if conf.anonymous ~= "" then
       -- get anonymous user
       local consumer_cache_key = singletons.dao.consumers:cache_key(conf.anonymous)

--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -197,8 +197,8 @@ function JwtHandler:access(conf)
     return
   end
 
-  local ok, err = do_authentication(conf)
-  if not ok then
+  local _, err = do_authentication(conf)
+  if err then
     if conf.anonymous ~= "" then
       -- get anonymous user
       local consumer_cache_key = singletons.dao.consumers:cache_key(conf.anonymous)

--- a/kong/plugins/key-auth/handler.lua
+++ b/kong/plugins/key-auth/handler.lua
@@ -168,8 +168,8 @@ function KeyAuthHandler:access(conf)
     return
   end
 
-  local ok, err = do_authentication(conf)
-  if not ok then
+  local _, err = do_authentication(conf)
+  if err then
     if conf.anonymous ~= "" then
       -- get anonymous user
       local consumer_cache_key = singletons.dao.consumers:cache_key(conf.anonymous)
@@ -177,7 +177,7 @@ function KeyAuthHandler:access(conf)
                                                  load_consumer,
                                                  conf.anonymous, true)
       if err then
-        responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+        return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
       end
       set_consumer(consumer, nil)
     else


### PR DESCRIPTION
One of the consequences of c6bde1a24065f1ce5fdfea268d3b7a3a08945272 is
that the `responses` module does not make plugin exit the access phase
anymore. This has the unfortunate consequence that plugins were
originally built with the assumption that calling this module upon an
error would short-circuit its execution. Today, we are left with a few
leftover corner-cases from this assumption we broke:

1. plugins calling `responses.send_*` MUST do so in conjunction with the
`return` instruction.
2. plugins calling `responses.send_*` from a function that is higher in
the stack call than `access()` (that is, called by `access()` or by one
of its callees) must make `access()` aware that a response has been
buffered and that the plugin should short-circuit without executing any
further instructions.

This commit takes care of two cases of 1., and a few cases of 2.,
originally spotted by @nateslo for the key-auth plugin.

This is a less-than-ideal fix, consequence of an already established
hacky approach taken by c6bde1a24065f1ce5fdfea268d3b7a3a08945272.
Ideally, our future plugins runloop will provide hardened rules around
their execution and possible short-circuiting.