### PR TITLE
fix(schema) do not run further tests when type is invalid

### DIFF
--- a/kong/dao/schemas_validation.lua
+++ b/kong/dao/schemas_validation.lua
@@ -147,6 +147,7 @@ function _M.validate_entity(tbl, schema, options)
           if not is_valid_type and POSSIBLE_TYPES[v.type] then
             errors = utils.add_error(errors, error_prefix .. column,
                     string.format("%s is not %s %s", column, v.type == "array" and "an" or "a", v.type))
+            goto continue
           end
         end
 
@@ -258,6 +259,8 @@ function _M.validate_entity(tbl, schema, options)
             end
           end
         end
+
+        ::continue::
       end
 
       -- Check for unexpected fields in the entity

--- a/spec/01-unit/006-schema_validation_spec.lua
+++ b/spec/01-unit/006-schema_validation_spec.lua
@@ -157,6 +157,15 @@ describe("Schemas", function()
       assert.falsy(err)
     end)
 
+    it("should not crash when an array has invalid contents (regression for #3144)", function()
+      local values = { enum_array = 5 }
+
+      local valid, err = validate_entity(values, schema)
+      assert.falsy(valid)
+      assert.truthy(err)
+      assert.are.same("enum_array is not an array", err.enum_array)
+    end)
+
     it("should return error when an invalid boolean value is passed", function()
       local values = {string = "test", boolean_val = "ciao"}
 


### PR DESCRIPTION
### Summary

When the schema validator detects that an field is not of the correct type, do not try to run further tests on it (such as trying to iterate a value that is not an array, which produced a crash).

### Issues resolved

Fixes #3144 
