### PR TITLE
hotfix(runloop) make delayed response short-circuit plugin

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -370,7 +370,7 @@ function Kong.access()
 
   for plugin, plugin_conf in plugins_iterator(singletons.loaded_plugins, true) do
     if not ctx.delayed_response then
-      plugin.handler:access(plugin_conf)
+      coroutine.wrap(plugin.handler.access)(plugin.handler, plugin_conf)
     end
   end
 

--- a/kong/tools/responses.lua
+++ b/kong/tools/responses.lua
@@ -113,7 +113,7 @@ local function send_response(status_code)
         headers = headers,
       }
 
-      return
+      coroutine.yield()
     end
 
     if status_code == _M.status_codes.HTTP_INTERNAL_SERVER_ERROR then

--- a/spec/fixtures/custom_plugins/kong/plugins/dummy/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/dummy/handler.lua
@@ -1,4 +1,5 @@
 local BasePlugin = require "kong.plugins.base_plugin"
+local responses = require "kong.tools.responses"
 
 
 local DummyHandler = BasePlugin:extend()
@@ -14,6 +15,12 @@ end
 
 function DummyHandler:access()
   DummyHandler.super.access(self)
+
+  if ngx.req.get_uri_args()["send_error"] then
+    responses.send_HTTP_NOT_FOUND()
+  end
+
+  ngx.header["Dummy-Plugin-Access-Header"] = "dummy"
 end
 
 


### PR DESCRIPTION
Prior to c6bde1a, the `responses.send` method was effectively an "abort" function, causing a plugin phase to stop executing. With the delayed execution of the actual response sending, this feature of `responses.send` was removed, breaking expectations of plugins which assumed that a function would stop running if a response was sent with `responses.send`. This PR restores the original behavior of aborting the ongoing phase of the plugin, while still retaining the benefits of c6bde1a, meaning that further phases and plugins still run.

This issue was originally spotted by @nateslo for the key-auth plugin, and the precise issue was mapped out by @thibaultcha and originally described in PR #3413.