### PR TITLE
Admin API: Return 404 on call to GET /certificates/uuid

### DIFF
--- a/kong/api/routes/certificates.lua
+++ b/kong/api/routes/certificates.lua
@@ -279,7 +279,9 @@ return {
         return helpers.yield_error(err)
       end
 
-      assert(row, "no SSL certificate for given SNI")
+      if not row then
+        return helpers.responses.send_HTTP_NOT_FOUND()
+      end
 
       -- add list of other SNIs for this certificate
 

--- a/spec/02-integration/04-admin_api/06-certificates_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/06-certificates_routes_spec.lua
@@ -659,6 +659,28 @@ describe("Admin API: #" .. kong_config.database, function()
       end)
     end)
 
+    describe("GET", function()
+      it("returns 404 for a random non-existing uuid", function()
+        local res  = assert(client:send {
+          method   = "GET",
+          path     = "/certificates/" .. utils.uuid(),
+        })
+
+        assert.res_status(404, res)
+      end)
+    end)
+
+    describe("GET", function()
+      it("returns 404 for a random non-existing SNI", function()
+        local res  = assert(client:send {
+          method   = "GET",
+          path     = "/certificates/doesntexist.com",
+        })
+
+        assert.res_status(404, res)
+      end)
+    end)
+
     describe("PATCH", function()
       local cert_foo
       local cert_bar


### PR DESCRIPTION
When querying the Admin API for a specific certificate using a UUID that doesn't exist the result returned is a 500 status code.

This patch returns a 404 instead.
