### PR TITLE
hotfix(migrations) fix broken upstream migrations

### DIFF
--- a/kong/dao/migrations/cassandra.lua
+++ b/kong/dao/migrations/cassandra.lua
@@ -482,6 +482,15 @@ return {
     down = function(_, _, dao) end  -- not implemented
   },
   {
+    name = "2017-11-07-192000_upstream_healthchecks",
+    up = [[
+      ALTER TABLE upstreams ADD healthchecks text;
+    ]],
+    down = [[
+      ALTER TABLE upstreams DROP healthchecks;
+    ]]
+  },
+  {
     name = "2017-10-27-134100_consistent_hashing_1",
     up = [[
       ALTER TABLE upstreams ADD hash_on text;
@@ -494,39 +503,6 @@ return {
       ALTER TABLE upstreams DROP hash_fallback;
       ALTER TABLE upstreams DROP hash_on_header;
       ALTER TABLE upstreams DROP hash_fallback_header;
-    ]]
-  },
-  {
-    name = "2017-10-27-134100_consistent_hashing_2",
-    up = function(_, _, dao)
-      local rows, err = dao.db:query([[
-        SELECT * FROM upstreams;
-      ]])
-      if err then
-        return err
-      end
-
-      for _, row in ipairs(rows) do
-        if not row.hash_on or not row.hash_fallback then
-          row.hash_on = "none"
-          row.hash_fallback = "none"
---          row.created_at = nil
-          local _, err = dao.upstreams:update(row, { id = row.id })
-          if err then
-            return err
-          end
-        end
-      end
-    end,
-    down = function(_, _, dao) end  -- n.a. since the columns will be dropped
-  },
-  {
-    name = "2017-11-07-192000_upstream_healthchecks",
-    up = [[
-      ALTER TABLE upstreams ADD healthchecks text;
-    ]],
-    down = [[
-      ALTER TABLE upstreams DROP healthchecks;
     ]]
   },
   {
@@ -555,5 +531,27 @@ return {
       end
     end,
     down = function(_, _, dao) end
+  },
+  {
+    name = "2017-10-27-134100_consistent_hashing_2",
+    up = function(_, _, dao)
+      local rows, err = dao.upstreams:find_all()
+      if err then
+        return err
+      end
+
+      for _, row in ipairs(rows) do
+        if not row.hash_on or not row.hash_fallback then
+          row.hash_on = "none"
+          row.hash_fallback = "none"
+--          row.created_at = nil
+          local _, err = dao.upstreams:update(row, { id = row.id })
+          if err then
+            return err
+          end
+        end
+      end
+    end,
+    down = function(_, _, dao) end  -- n.a. since the columns will be dropped
   },
 }

--- a/kong/dao/migrations/postgres.lua
+++ b/kong/dao/migrations/postgres.lua
@@ -543,45 +543,6 @@ return {
     ]]
   },
   {
-    name = "2017-10-27-134100_consistent_hashing_1",
-    up = [[
-      ALTER TABLE upstreams ADD hash_on text;
-      ALTER TABLE upstreams ADD hash_fallback text;
-      ALTER TABLE upstreams ADD hash_on_header text;
-      ALTER TABLE upstreams ADD hash_fallback_header text;
-    ]],
-    down = [[
-      ALTER TABLE upstreams DROP COLUMN IF EXISTS hash_on;
-      ALTER TABLE upstreams DROP COLUMN IF EXISTS hash_fallback;
-      ALTER TABLE upstreams DROP COLUMN IF EXISTS hash_on_header;
-      ALTER TABLE upstreams DROP COLUMN IF EXISTS hash_fallback_header;
-    ]]
-  },
-  {
-    name = "2017-10-27-134100_consistent_hashing_2",
-    up = function(_, _, dao)
-      local rows, err = dao.db:query([[
-        SELECT * FROM upstreams;
-      ]])
-      if err then
-        return err
-      end
-
-      for _, row in ipairs(rows) do
-        if not row.hash_on or not row.hash_fallback then
-          row.hash_on = "none"
-          row.hash_fallback = "none"
-          row.created_at = nil
-          local _, err = dao.upstreams:update(row, { id = row.id })
-          if err then
-            return err
-          end
-        end
-      end
-    end,
-    down = function(_, _, dao) end  -- n.a. since the columns will be dropped
-  },
-  {
     name = "2017-11-07-192000_upstream_healthchecks",
     up = [[
       DO $$
@@ -594,6 +555,21 @@ return {
     ]],
     down = [[
       ALTER TABLE upstreams DROP COLUMN IF EXISTS healthchecks;
+    ]]
+  },
+  {
+    name = "2017-10-27-134100_consistent_hashing_1",
+    up = [[
+      ALTER TABLE upstreams ADD hash_on text;
+      ALTER TABLE upstreams ADD hash_fallback text;
+      ALTER TABLE upstreams ADD hash_on_header text;
+      ALTER TABLE upstreams ADD hash_fallback_header text;
+    ]],
+    down = [[
+      ALTER TABLE upstreams DROP COLUMN IF EXISTS hash_on;
+      ALTER TABLE upstreams DROP COLUMN IF EXISTS hash_fallback;
+      ALTER TABLE upstreams DROP COLUMN IF EXISTS hash_on_header;
+      ALTER TABLE upstreams DROP COLUMN IF EXISTS hash_fallback_header;
     ]]
   },
   {
@@ -622,5 +598,29 @@ return {
       end
     end,
     down = function(_, _, dao) end
+  },
+  {
+    name = "2017-10-27-134100_consistent_hashing_2",
+    up = function(_, _, dao)
+      local rows, err = dao.db:query([[
+        SELECT * FROM upstreams;
+      ]])
+      if err then
+        return err
+      end
+
+      for _, row in ipairs(rows) do
+        if not row.hash_on or not row.hash_fallback then
+          row.hash_on = "none"
+          row.hash_fallback = "none"
+          row.created_at = nil
+          local _, err = dao.upstreams:update(row, { id = row.id })
+          if err then
+            return err
+          end
+        end
+      end
+    end,
+    down = function(_, _, dao) end  -- n.a. since the columns will be dropped
   },
 }


### PR DESCRIPTION
### Summary

There exists two problems with the behavior of upstream object
migrations introduced in the 0.12.0 release:

- First, the DDL migrations to add both healthcheck and hashing
column definitions were required before executing function-level
migrations to fill in default object data. This is a result of the
current DAO implementation that requires that all Lua-schema definitions
exist as column definitions in the underlying data store, even if the
DAO update call does not reference the column in question.
- Second, the functional definitions load each row directly by a
directly underlying DB call (as opposed to a DAO find_all()); this
resulted in "table" schema types being represented as literal JSON
strings, isntead of Lua table types, by the C* driver. The Postgres
implementation does not suffer this as the underlying reprentation of
table data in Postgres-backed schemas is Postgres' JSON type; this is
automagically deserialized to a Lua table upon retrieval. As the C*
implementation offers no such behind-the-scenes transformation, a
direct load of rows containing "table" schemas results in an
incompatable data type when iterating over the returned rows. The
fix in the commit is to use the abstract DAO to load upstream rows
when leveraging C*.

### Issues resolved

Fixes #3156.