### PR TITLE
feat(chore) provide commandline options for 'resty' when testing

### DIFF
--- a/bin/busted
+++ b/bin/busted
@@ -1,5 +1,7 @@
 #!/usr/bin/env resty
 
+local DEFAULT_RESTY_FLAGS="-c 65000"
+
 do
   local lines = getmetatable(io.output()).lines
 
@@ -34,10 +36,18 @@ if not os.getenv("KONG_BUSTED_RESPAWNED") then
   -- add cli recursion detection
   table.insert(script, "export KONG_BUSTED_RESPAWNED=1")
 
-  -- rebuild the invoked commandline
+  -- rebuild the invoked commandline, while inserting extra resty-flags
+  local resty_flags = DEFAULT_RESTY_FLAGS
   local cmd = { "exec" }
-  for i = 0, #arg do
-    table.insert(cmd, "'"..arg[i].."'")
+  for i = -1, #arg do
+    if arg[i]:sub(1,12) == "RESTY_FLAGS=" then
+      resty_flags = arg[i]:sub(13,-1)
+    else
+      table.insert(cmd, "'" .. arg[i] .. "'")
+    end
+  end
+  if resty_flags then
+    table.insert(cmd, 3, resty_flags)
   end
   table.insert(script, table.concat(cmd, " "))
 


### PR DESCRIPTION
This allows to pass a setting on the 'bin/busted' commandline that sets flags on the underlying 'resty' executable running the environment. The flag is named `RESTY_FLAGS` and can be used like this:
```
bin/busted -v RESTY_FLAGS="-c 2 -I /lua/lib/?.lua" -o gtest 
```
which will then effectively execute:
```
resty -c 2 -I /lua/lib/?.lua bin/busted -v -o gtest 
```

The default flags will be "-c 65000" to remove the dreaded "xxx worker_connections are not enough" error message while running the test suite.
