### PR TITLE
Update the Resty connection limit when testing

### DIFF
--- a/bin/busted
+++ b/bin/busted
@@ -1,6 +1,6 @@
 #!/usr/bin/env resty
 
-local DEFAULT_RESTY_FLAGS="-c 65000"
+local DEFAULT_RESTY_FLAGS="-c 4096"
 
 do
   local lines = getmetatable(io.output()).lines


### PR DESCRIPTION
The current limit of 60000 gives warnings and is beyond the supposed hard limit of 4096. Hence reducing the default.