### PR TITLE
chore(tests) remove extraneous stdout/stderr output

### DIFF
--- a/spec/01-unit/011-balancer_spec.lua
+++ b/spec/01-unit/011-balancer_spec.lua
@@ -6,7 +6,14 @@ describe("Balancer", function()
   local uuid = require("kong.tools.utils").uuid
 
 
+  teardown(function()
+    ngx.log:revert()
+  end)
+
+
   setup(function()
+    stub(ngx, "log")
+
     balancer = require "kong.core.balancer"
     singletons = require "kong.singletons"
     singletons.worker_events = require "resty.worker.events"

--- a/spec/01-unit/013-reports_spec.lua
+++ b/spec/01-unit/013-reports_spec.lua
@@ -55,8 +55,11 @@ describe("reports", function()
 
   describe("retrieve_redis_version()", function()
     setup(function()
-      _G.ngx = ngx
-      _G.ngx.log = function() return end
+      stub(ngx, "log")
+    end)
+
+    teardown(function()
+      ngx.log:revert()
     end)
 
     before_each(function()

--- a/spec/02-integration/05-proxy/09-balancer_spec.lua
+++ b/spec/02-integration/05-proxy/09-balancer_spec.lua
@@ -1076,8 +1076,8 @@ dao_helpers.for_each_dao(function(kong_config)
         local requests = upstream2.slots * 2 -- go round the balancer twice
 
         -- setup target servers
-        local server1 = http_server(timeout, localhost, PORT + 2, { requests }, true)
-        local server2 = http_server(timeout, localhost, PORT + 3, { requests }, true)
+        local server1 = http_server(timeout, localhost, PORT + 2, { requests })
+        local server2 = http_server(timeout, localhost, PORT + 3, { requests })
 
         -- Go hit them with our test requests
         local oks = client_requests(requests, {


### PR DESCRIPTION
### Summary

Remove a few calls that write unneeded debug/log data. This just cleans up the test output.

### Full changelog

* Remove a missed `test_log` param from a balancer integration test
* Neuter `ngx.log` in a balancer unit test where `lua-resty-dns-client` wrote a `WARN` level entry
* Update the neutered `ngx.log` in the `reports` unit test to follow the same pattern as implemented here.