### PR TITLE
fix(deps) remove Kong before installing on `make dev`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,9 @@ endif
 install:
 	@luarocks make OPENSSL_DIR=$(OPENSSL_DIR) CRYPTO_DIR=$(OPENSSL_DIR)
 
-dev: install
+dev:
+	@luarocks remove kong
+	@luarocks make OPENSSL_DIR=$(OPENSSL_DIR) CRYPTO_DIR=$(OPENSSL_DIR)
 	@for rock in $(DEV_ROCKS) ; do \
 	  if luarocks list --porcelain $$rock | grep -q "installed" ; then \
 	    echo $$rock already installed, skipping ; \


### PR DESCRIPTION
when updating dependencies without updating the rock versioning, old versions will not be removed. By explicitly removing the old version this is ensured.

Typical example when installing current `next` on top of `0.12.1`:
```
lua-resty-jit-uuid 0.0.7-1 is now installed in /usr/local (license: MIT)

Checking stability of dependencies in the absence of
lua-resty-jit-uuid 0.0.5-1...

Will not remove lua-resty-jit-uuid 0.0.5-1.
Removing it would break dependencies for:
kong 0.12.1-0
```

after the fix

```
lua-resty-jit-uuid 0.0.7-1 is now installed in /usr/local (license: MIT)

Checking stability of dependencies in the absence of
lua-resty-jit-uuid 0.0.5-1...

Removing lua-resty-jit-uuid 0.0.5-1...
Removal successful.
```
