### PR TITLE
fix (acl) allow acl record update with same group

### DIFF
--- a/kong/plugins/acl/daos.lua
+++ b/kong/plugins/acl/daos.lua
@@ -4,7 +4,7 @@ local function check_unique(group, acl)
   -- If dao required to make this work in integration tests when adding fixtures
   if singletons.dao and acl.consumer_id and group then
     local res, err = singletons.dao.acls:find_all {consumer_id = acl.consumer_id, group = group}
-    if not err and #res > 0 then
+    if not err and #res > 0 and res[1].id ~= acl.id then
       return false, "ACL group already exist for this consumer"
     elseif not err then
       return true


### PR DESCRIPTION
PUT requests should work such that multiple identical PUT requests
to the same resource should yield the same result. This is important
for the automated management of resources. Previously, identical PUT
requests subsequent an initial successful request to /consumers/:id/acls
would return a 400 response due to a supposed duplicate group name.
While changing the group of an existing resource should be prohibited
in cases where the new group name matches that of another acl for the
same consumer, the same group name for the same resource should be
allowed to allow for idempotence. This commit applies that fix.

* Do not reject PUT and PATCH requests when group is set to the
  same value as the value of group on the resource being udpated
* Add several integration tests for the new functionality

Fix #3183
