### PR TITLE
check for nil value of KONG_HEADER_FILTER_STARTED_AT

### DIFF
--- a/kong/core/handler.lua
+++ b/kong/core/handler.lua
@@ -553,7 +553,7 @@ return {
         -- time spent receiving the response (header_filter + body_filter)
         -- we could uyse $upstream_response_time but we need to distinguish the waiting time
         -- from the receiving time in our logging plugins (especially ALF serializer).
-        ctx.KONG_RECEIVE_TIME = get_now() - ctx.KONG_HEADER_FILTER_STARTED_AT
+        ctx.KONG_RECEIVE_TIME = ctx.KONG_HEADER_FILTER_STARTED_AT and get_now() - ctx.KONG_HEADER_FILTER_STARTED_AT or get_now()
       end
     end
   },

--- a/kong/core/handler.lua
+++ b/kong/core/handler.lua
@@ -553,7 +553,7 @@ return {
         -- time spent receiving the response (header_filter + body_filter)
         -- we could uyse $upstream_response_time but we need to distinguish the waiting time
         -- from the receiving time in our logging plugins (especially ALF serializer).
-        ctx.KONG_RECEIVE_TIME = ctx.KONG_HEADER_FILTER_STARTED_AT and get_now() - ctx.KONG_HEADER_FILTER_STARTED_AT or get_now()
+        ctx.KONG_RECEIVE_TIME = ctx.KONG_HEADER_FILTER_STARTED_AT and get_now() - ctx.KONG_HEADER_FILTER_STARTED_AT or 0
       end
     end
   },


### PR DESCRIPTION

### Summary

Avoiding an error that occurs when `ctx.KONG_HEADER_FILTER_STARTED_AT` is `nil`.
> attempt to perform arithmetic on field 'KONG_HEADER_FILTER_STARTED_AT' (a nil value)

 This happens sometimes. See [example issue](https://github.com/Kong/kong/issues/1042).
