### PR TITLE
feat(cli) add --yes flag to 'kong migrations'

### DIFF
--- a/kong/cmd/migrations.lua
+++ b/kong/cmd/migrations.lua
@@ -46,7 +46,9 @@ local function execute(args)
           db_infos.desc, db_infos.name)
     end
   elseif args.command == "reset" then
-    if confirm("Are you sure? This operation is irreversible.") then
+    if args.yes
+      or confirm("Are you sure? This operation is irreversible.")
+    then
       dao:drop_schema()
       log("Schema successfully reset")
     else
@@ -67,6 +69,7 @@ The available commands are:
 
 Options:
  -c,--conf        (optional string) configuration file
+ -y,--yes         assume "yes" to prompts and run non-interactively
 ]]
 
 return {

--- a/spec/02-integration/02-cmd/10-migrations_spec.lua
+++ b/spec/02-integration/02-cmd/10-migrations_spec.lua
@@ -1,0 +1,80 @@
+local helpers = require "spec.helpers"
+local pl_utils = require "pl.utils"
+
+
+local dao = helpers.dao -- postgreSQL DAO (faster to test this command)
+
+
+describe("kong migrations", function()
+  describe("reset", function()
+    before_each(function()
+      assert(dao:run_migrations())
+    end)
+
+    teardown(function()
+      dao:drop_schema()
+    end)
+
+    it("runs interactively by default", function()
+      local answers = {
+        "y",
+        "Y",
+        "yes",
+        "YES",
+      }
+
+      for _, answer in ipairs(answers) do
+        local cmd = string.format(helpers.unindent [[
+          echo %s | %s migrations reset
+        ]], answer, helpers.bin_path)
+
+        local ok, _, stdout, stderr = pl_utils.executeex(cmd)
+        assert.is_true(ok)
+        assert.equal("", stderr)
+        assert.matches("Are you sure? This operation is irreversible. [Y/n]",
+                       stdout, nil, true)
+        assert.matches("Schema successfully reset", stdout, nil, true)
+        assert(dao:run_migrations())
+      end
+    end)
+
+    it("cancels when ran interactively", function()
+      local answers = {
+        "n",
+        "N",
+        "no",
+        "NO",
+      }
+
+      for _, answer in ipairs(answers) do
+        local cmd = string.format(helpers.unindent [[
+          echo %s | %s migrations reset
+        ]], answer, helpers.bin_path)
+        local ok, _, stdout, stderr = pl_utils.executeex(cmd)
+        assert.is_true(ok)
+        assert.equal("", stderr)
+        assert.matches("Are you sure? This operation is irreversible. [Y/n]",
+                       stdout, nil, true)
+        assert.matches("Canceled", stdout, nil, true)
+      end
+    end)
+
+    it("runs non-interactively with --yes", function()
+      local ok, stderr, stdout = helpers.kong_exec("migrations reset --yes")
+      assert.is_true(ok)
+      assert.is_equal("", stderr)
+      assert.not_matches("Are you sure? This operation is irreversible. [Y/n]",
+                         stdout, nil, true)
+      assert.matches("Schema successfully reset", stdout, nil, true)
+    end)
+
+    it("runs non-interactively with -y", function()
+      local ok, stderr, stdout = helpers.kong_exec("migrations reset -y")
+      assert.is_true(ok)
+      assert.is_equal("", stderr)
+      assert.not_matches("Are you sure? This operation is irreversible. [Y/n]",
+                         stdout, nil, true)
+      assert.matches("Schema successfully reset", stdout, nil, true)
+    end)
+  end)
+end)


### PR DESCRIPTION
This -y|--yes flag allows for 'kong migrations' to run
non-interactively, and answer "yes" to all prompt questions, such as
"Are you sure?" from the 'reset' sub-command.