### PR TITLE
chore(makefile) ignore luarocks remove failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ install:
 	@luarocks make OPENSSL_DIR=$(OPENSSL_DIR) CRYPTO_DIR=$(OPENSSL_DIR)
 
 dev:
-	@luarocks remove kong
+	-@luarocks remove kong
 	@luarocks make OPENSSL_DIR=$(OPENSSL_DIR) CRYPTO_DIR=$(OPENSSL_DIR)
 	@for rock in $(DEV_ROCKS) ; do \
 	  if luarocks list --porcelain $$rock | grep -q "installed" ; then \


### PR DESCRIPTION
Oftentimes, this command will fail because Kong is not installed. We now
avoid having to call make with the -k option as a workaround.

This is a regression introduced by 04f967b.