### PR TITLE
Bumping to lua-resty-http 0.12

### DIFF
--- a/kong-0.12.1-0.rockspec
+++ b/kong-0.12.1-0.rockspec
@@ -14,7 +14,7 @@ dependencies = {
   "luasec == 0.6",
   "luasocket == 3.0-rc1",
   "penlight == 1.5.4",
-  "lua-resty-http == 0.08",
+  "lua-resty-http == 0.12",
   "lua-resty-jit-uuid == 0.0.7",
   "multipart == 0.5.4",
   "version == 0.2",


### PR DESCRIPTION
### Summary

This PR addresses https://discuss.konghq.com/t/bumping-to-more-recent-version-of-lua-resty-http/480 by upgrading the version of lua-resty-http to 0.12 (latest available version)

### Full changelog

* Well, the only location I found referencing the `lua-rest-http` version is in the `kong-0.12.1-0.rockspec` ... but I don't know if directly updating this file is the right way to do. Pardon me if this is not !

### Issues resolved

https://discuss.konghq.com/t/bumping-to-more-recent-version-of-lua-resty-http/480
