### PR TITLE
added certificate and key to pgmoon options

### DIFF
--- a/kong/dao/db/postgres.lua
+++ b/kong/dao/db/postgres.lua
@@ -54,7 +54,9 @@ function _M.new(kong_config)
     database = kong_config.pg_database,
     ssl = kong_config.pg_ssl,
     ssl_verify = kong_config.pg_ssl_verify,
-    cafile = kong_config.lua_ssl_trusted_certificate
+    cafile = kong_config.lua_ssl_trusted_certificate,
+    cert = kong_config.admin_ssl_cert_default,
+    key = kong_config.admin_ssl_cert_key
   }
 
   return self


### PR DESCRIPTION
### Summary

Added options to connect to a postgresql configured to authenticate by users' certificate instead of user:password.

### Full changelog

* Add certificate and key to pgpool connection options.

