### PR TITLE
fix(oauth2) send 400 on invalid scope string

### DIFF
--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -116,6 +116,11 @@ end
 local function retrieve_scopes(parameters, conf)
   local scope = parameters[SCOPE]
   local scopes = {}
+
+  if scope and type(scope) ~= "string" then
+      return false, {[ERROR] = "invalid_scope", error_description = "scope must be a string"}
+  end
+
   if conf.scopes and scope then
     for v in scope:gmatch("%S+") do
       if not utils.table_contains(conf.scopes, v) then

--- a/spec/03-plugins/26-oauth2/03-access_spec.lua
+++ b/spec/03-plugins/26-oauth2/03-access_spec.lua
@@ -1317,6 +1317,27 @@ describe("Plugin: oauth2 (access)", function()
         local json = cjson.decode(body)
         assert.same({ error = "unsupported_grant_type", error_description = "Invalid grant_type" }, json)
       end)
+      it("returns an error when scope property is an array", function()
+        local res = assert(proxy_ssl_client:send {
+          method = "POST",
+          path = "/oauth2/token",
+          body = {
+            provision_key = "provision123",
+            authenticated_userid = "id123",
+            client_id = "clientid123",
+            client_secret="secret123",
+            scope = {"email"},
+            grant_type = "password"
+          },
+          headers = {
+            ["Host"] = "oauth2_5.com",
+            ["Content-Type"] = "application/json"
+          }
+        })
+        local body = assert.res_status(400, res)
+        local json = cjson.decode(body)
+        assert.same({ error = "invalid_scope", error_description = "scope must be a string" }, json)
+      end)
       it("fails when no provision key is being sent", function()
         local res = assert(proxy_ssl_client:send {
           method = "POST",


### PR DESCRIPTION
### Summary

If you create an oauth2 token, and pass a scope as something other than a
string, you get a 500 error. This updates the retrieve_scopes
method to perform a type check and return a 400 if it isn't a
string

### Full changelog

* return 400 when an invalid scope string is given

### Issues resolved

Fix #3205 