### PR TITLE
fix(balancer) unregister healthchecker callback immediately

### DIFF
--- a/kong/core/balancer.lua
+++ b/kong/core/balancer.lua
@@ -60,6 +60,8 @@ local function stop_healthchecker(balancer)
       log(ERR, "[healthchecks] error clearing healthcheck data: ", err)
     end
     healthchecker:stop()
+    local hc_callback = healthchecker_callbacks[balancer]
+    singletons.worker_events.unregister(hc_callback, healthchecker.EVENT_SOURCE)
   end
   healthcheckers[balancer] = nil
 end


### PR DESCRIPTION
When a healthchecker is stopped, unregister its callback immediately, instead of waiting for the garbage collector to kick in and automatically reclaim it (as per the behavior of `register_weak`).

This does not modify the logic of health checks, but prevents bogus error messages from appearing in the error logs.

Thanks to @aledbf for the report!
