### PR TITLE
fix(key-auth) properly re-encode request body

### DIFF
--- a/kong/plugins/key-auth/handler.lua
+++ b/kong/plugins/key-auth/handler.lua
@@ -3,6 +3,8 @@ local constants = require "kong.constants"
 local singletons = require "kong.singletons"
 local public_tools = require "kong.tools.public"
 local BasePlugin = require "kong.plugins.base_plugin"
+local multipart = require "multipart"
+local cjson = require "cjson"
 
 local ngx_set_header = ngx.req.set_header
 local ngx_get_headers = ngx.req.get_headers
@@ -62,6 +64,35 @@ local function set_consumer(consumer, credential)
 
 end
 
+
+local hide_body_credentials
+do
+  local MIME_TYPES = public_tools.req_mime_types
+
+
+  hide_body_credentials = {
+    [MIME_TYPES.form_url_encoded] = function(key, body)
+      body[key] = nil
+      return ngx_encode_args(body)
+    end,
+
+    [MIME_TYPES.json] = function(key, body)
+      body[key] = nil
+      return cjson.encode(body)
+    end,
+
+    [MIME_TYPES.multipart] = function(key, _, raw_body)
+      -- im not a fan of recreating the lua-multipart object here,
+      -- but the current Kong API doesn't provide us the original
+      -- metatable, so our hands are tied here
+      local m_body = multipart(raw_body, ngx.var.content_type)
+      m_body:delete(key)
+      return m_body:tostring()
+    end,
+  }
+end
+
+
 local function do_authentication(conf)
   if type(conf.key_names) ~= "table" then
     ngx.log(ngx.ERR, "[key-auth] no conf.key_names set, aborting plugin execution")
@@ -71,12 +102,17 @@ local function do_authentication(conf)
   local key
   local headers = ngx_get_headers()
   local uri_args = get_uri_args()
-  local body_data
+  local body_data, raw_body, req_mime
 
   -- read in the body if we want to examine POST args
   if conf.key_in_body then
     ngx_req_read_body()
-    body_data = public_tools.get_body_args()
+    local err
+    body_data, err, raw_body, req_mime = public_tools.get_body_info()
+
+    if err then
+      return false, { status = 400, message = "Cannot process request body" }
+    end
   end
 
   -- search in headers & querystring
@@ -101,8 +137,24 @@ local function do_authentication(conf)
         clear_header(name)
 
         if conf.key_in_body then
-          body_data[name] = nil
-          ngx_req_set_body_data(ngx_encode_args(body_data))
+          if not hide_body_credentials[req_mime] then
+            -- the request was indeed well formed but could not be processed
+            -- the status '422' might be a good candidate here, but it's part
+            -- of the WebDAV extension, so it doesn't seem appropriate here
+            -- and a 5xx status seems inappropriate as well- the server (plugin)
+            -- configuration is not incorrect. it's up to the client to present
+            -- the appropriate body encoding, given the server configuration
+            -- this places an onus of responsibility on the server operator to
+            -- properly document the acceptable body encodings when
+            -- 'hide_credentials' and 'key_in_body' are both set
+            return false, { status = 400, message = "Cannot process request body" }
+          end
+
+          ngx_req_set_body_data(hide_body_credentials[req_mime](
+            name,
+            body_data,
+            raw_body
+          ))
         end
       end
       break


### PR DESCRIPTION
### Summary

When both key_in_body and hide_credentials are set, we previously re-encoded the request body as a form/url-encoded entity, regardless of the request content type (and without changing the content type
header!). This commit refactors the key_in_body behavior to be a bit more robust and handle request types that the existing Kong API can decode/encode via the 'get_body_info' public function.

This PR is to be accompanied by a getkong.org PR that explicitly documents this behavior, and notifies Kong administrators that the simultaneous use of `hide_credentials` and `key_in_body` is limited to a given set of request body types.

### Full changelog

* Hide `key-auth` credentials sent in the request body, and re-encode the body`, when the `hide_credentials` and `key_in_body` plugin values are set, for `application/json`, `multipart/form-data`, and `application/www-form-urlencoded` request bodies.
* Bail with a `BAD_REQUEST` status when the client sends a request with an unsupported body type, when both `hide_credentials` and `key_in_body` are set.
* Expand the `key-auth` plugin access tests to cover this new behavior.

### Issues resolved

Fix #3108.
