### PR TITLE
Fix/routing without Host header

### DIFF
--- a/kong/core/router.lua
+++ b/kong/core/router.lua
@@ -831,7 +831,7 @@ function _M.new(apis)
       end
     end
 
-    local req_host = ngx.var.http_host
+    local req_host = ngx.var.http_host or ""
 
     local match_t = find_api(method, uri, req_host, ngx)
     if not match_t then

--- a/spec/01-unit/010-router_spec.lua
+++ b/spec/01-unit/010-router_spec.lua
@@ -100,6 +100,13 @@ describe("Router", function()
       assert.same(use_case[3], match_t.api)
     end)
 
+    it("[uri]", function()
+      -- uri + empty host
+      local match_t = router.select("GET", "/my-api", "")
+      assert.truthy(match_t)
+      assert.same(use_case[3], match_t.api)
+    end)
+
     it("[method]", function()
       -- method
       local match_t = router.select("TRACE", "/", "domain.org")

--- a/spec/01-unit/010-router_spec.lua
+++ b/spec/01-unit/010-router_spec.lua
@@ -100,7 +100,7 @@ describe("Router", function()
       assert.same(use_case[3], match_t.api)
     end)
 
-    it("[uri]", function()
+    it("[uri + empty host]", function()
       -- uri + empty host
       local match_t = router.select("GET", "/my-api", "")
       assert.truthy(match_t)

--- a/spec/02-integration/05-proxy/01-router_spec.lua
+++ b/spec/02-integration/05-proxy/01-router_spec.lua
@@ -151,6 +151,18 @@ describe("Router", function()
         assert.matches("kong-api-name: api-1", string.lower(remainder),
                        nil, true)
       end)
+
+      it("HTTP/1.1 rejected with 400 from NGINX", function()
+        local sock = ngx.socket.tcp()
+        finally(function() sock:close() end)
+        assert(sock:connect(helpers.test_conf.proxy_ip,
+                            helpers.test_conf.proxy_port))
+        local req = "GET /get HTTP/1.1\r\nKong-Debug: 1\r\n\r\n"
+        assert(sock:send(req))
+        local line = assert(sock:receive("*l"))
+        local status = tonumber(string.sub(line, 10, 12))
+        assert.equal(400, status)
+      end)
     end)
 
     describe("API with a path component in its upstream_url", function()

--- a/spec/02-integration/05-proxy/01-router_spec.lua
+++ b/spec/02-integration/05-proxy/01-router_spec.lua
@@ -134,24 +134,23 @@ describe("Router", function()
       assert.equal("api-1", res.headers["kong-api-name"])
     end)
 
-    it("routes by method-only if no Host header present", function()
-      -- a very limited HTTP client for sending requests without Host
-      -- based on the source of https://github.com/pintsized/lua-resty-http
-      local sock = ngx.socket.tcp()
-      finally(function() sock:close() end)
-      local ok, err = sock:connect(helpers.test_conf.proxy_ip,
-        helpers.test_conf.proxy_port)
-      assert(ok, err)
-      local req = "GET /get HTTP/1.0\r\nKong-Debug: 1\r\n\r\n"
-      sock:send(req)
-      local line, err = sock:receive("*l")
-      assert(line, err)
-      local status = tonumber(string.sub(line, 10, 12))
-      assert.equal(status, 200)
-      local remainder, err = sock:receive("*a")
-      assert(remainder, err)
-      assert(string.find(string.lower(remainder),
-        "kong-api-name: api-1", 1, true))
+    describe("requests without Host header", function()
+      it("HTTP/1.0 routes by method-only if no Host header present", function()
+        -- a very limited HTTP client for sending requests without Host
+        -- based on the source of https://github.com/pintsized/lua-resty-http
+        local sock = ngx.socket.tcp()
+        finally(function() sock:close() end)
+        assert(sock:connect(helpers.test_conf.proxy_ip,
+                            helpers.test_conf.proxy_port))
+        local req = "GET /get HTTP/1.0\r\nKong-Debug: 1\r\n\r\n"
+        assert(sock:send(req))
+        local line = assert(sock:receive("*l"))
+        local status = tonumber(string.sub(line, 10, 12))
+        assert.equal(200, status)
+        local remainder = assert(sock:receive("*a"))
+        assert.matches("kong-api-name: api-1", string.lower(remainder),
+                       nil, true)
+      end)
     end)
 
     describe("API with a path component in its upstream_url", function()


### PR DESCRIPTION
### Summary

Allows Kong to accept HTTP/1.0 requests that do not contain a Host header

### Full changelog

* If no Host header present, match against APIs defined by method or URI
* Test that a request with a matching method or URI can be matched without Host

### Issues resolved

Fix #3171
