### PR TITLE
refactor(core) expose API to obtain node_id

### DIFF
--- a/kong/api/routes/kong.lua
+++ b/kong/api/routes/kong.lua
@@ -1,5 +1,6 @@
 local utils = require "kong.tools.utils"
 local singletons = require "kong.singletons"
+local public = require "kong.tools.public"
 local conf_loader = require "kong.conf_loader"
 local cjson = require "cjson"
 
@@ -52,10 +53,16 @@ return {
         end
       end
 
+      local node_id, err = public.get_node_id()
+      if node_id == nil then
+        ngx.log(ngx.ERR, "could not get node id: ", err)
+      end
+
       return helpers.responses.send_HTTP_OK {
         tagline = tagline,
         version = version,
         hostname = utils.get_hostname(),
+        node_id = node_id,
         timers = {
           running = ngx.timer.running_count(),
           pending = ngx.timer.pending_count()

--- a/kong/cluster_events.lua
+++ b/kong/cluster_events.lua
@@ -1,4 +1,4 @@
-local utils = require "kong.tools.utils"
+local public = require "kong.tools.public"
 
 
 local ngx_debug = ngx.config.debug
@@ -13,7 +13,6 @@ local ngx_now   = ngx.now
 local timer_at  = ngx.timer.at
 
 
-local NODE_ID_KEY            = "cluster_events:id"
 local POLL_INTERVAL_LOCK_KEY = "cluster_events:poll_interval"
 local POLL_RUNNING_LOCK_KEY  = "cluster_events:poll_running"
 local CURRENT_AT_KEY         = "cluster_events:at"
@@ -122,18 +121,9 @@ function _M.new(opts)
 
   -- set node id (uuid)
 
-  ok, err = self.shm:safe_add(NODE_ID_KEY, utils.uuid())
-  if not ok and err ~= "exists" then
-    return nil, "failed to set 'node_id' in shm: " .. err
-  end
-
-  self.node_id, err = self.shm:get(NODE_ID_KEY)
-  if err then
-    return nil, "failed to get 'node_id' in shm: " .. err
-  end
-
+  self.node_id, err = public.get_node_id()
   if not self.node_id then
-    return nil, "no 'node_id' set in shm"
+    return nil, err
   end
 
   if ngx_debug and opts.node_id then

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -142,6 +142,7 @@ local function load_plugins(kong_conf, dao)
   return sorted_plugins
 end
 
+
 -- Kong public context handlers.
 -- @section kong_handlers
 

--- a/spec/02-integration/04-admin_api/01-kong_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/01-kong_routes_spec.lua
@@ -5,6 +5,8 @@ local DAOFactory = require "kong.dao.factory"
 
 local dao_helpers = require "spec.02-integration.03-dao.helpers"
 
+local UUID_PATTERN = "%x%x%x%x%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%x%x%x%x%x%x%x%x"
+
 describe("Admin API - Kong routes", function()
   describe("/", function()
     local meta = require "kong.meta"
@@ -32,6 +34,15 @@ describe("Admin API - Kong routes", function()
       local json = cjson.decode(body)
       assert.equal(meta._VERSION, json.version)
       assert.equal("Welcome to kong", json.tagline)
+    end)
+    it("returns a UUID as the node_id", function()
+      local res = assert(client:send {
+        method = "GET",
+        path = "/"
+      })
+      local body = assert.res_status(200, res)
+      local json = cjson.decode(body)
+      assert.matches(UUID_PATTERN, json.node_id)
     end)
     it("response has the correct Server header", function()
       local res = assert(client:send {


### PR DESCRIPTION
Move the unique identifier of the Kong node from the `kong.cluster_events` module into an internal value, accessible via `kong.tools.public.get_node_id()`.

This way, the same unique identifier can be used for different features that need it, such as cluster events and identifying per-node data in health check reporting.