### PR TITLE
tests(balancer) improve stability of active healthcheck tests

### DIFF
--- a/spec/02-integration/05-proxy/09-balancer_spec.lua
+++ b/spec/02-integration/05-proxy/09-balancer_spec.lua
@@ -145,27 +145,23 @@ local function http_server(timeout, host, port, counts, test_log)
       while n_reqs < total_reqs do
         local client, err
         client, err = server:accept()
-        if err == "timeout" then
-          if socket.gettime() > expire then
-            server:close()
-            break
-          end
+        if socket.gettime() > expire then
+          server:close()
+          break
 
         elseif not client then
-          server:close()
-          error(err)
+          if err ~= "timeout" then
+            server:close()
+            error(err)
+          end
 
         else
           local lines = {}
           local line, err
           while #lines < 7 do
             line, err = client:receive()
-            if err then
+            if err or #line == 0 then
               break
-
-            elseif #line == 0 then
-              break
-
             else
               table.insert(lines, line)
             end


### PR DESCRIPTION
This PR contains two commits that perform separate improvements for the stability of active healthcheck tests in our suite:

* **launch test server before starting active healthchecks** - When launching test `http_server` instances in the balancer tests, do so before enabling active healthchecks, to ensure that we get the expected results (and no failed checks before the server starts).
* **make sure http_server always times out** - Active healthchecks produce a constant flow of requests to the server, causing it to never timeout (in case of failed tests where the number of requests received does not match the list of requests expected). This turns the `timeout` argument into a hard limit for the execution time of the `http_server` itself.