### PR TITLE
feat(basic-auth-empty-password) allow empty password

### DIFF
--- a/kong/plugins/basic-auth/access.lua
+++ b/kong/plugins/basic-auth/access.lua
@@ -40,7 +40,7 @@ local function retrieve_credentials(request, header_name, conf)
       local decoded_basic = ngx.decode_base64(m[1])
       if decoded_basic then
         local basic_parts, err = ngx_re_match(decoded_basic,
-                                              "([^:]+):(.+)", "oj")
+                                              "([^:]+):(.*)", "oj")
         if err then
           ngx.log(ngx.ERR, err)
           return

--- a/spec/03-plugins/11-basic-auth/03-access_spec.lua
+++ b/spec/03-plugins/11-basic-auth/03-access_spec.lua
@@ -44,7 +44,7 @@ describe("Plugin: basic-auth (access)", function()
       password    = "kong",
       consumer_id = consumer.id,
     })
-     assert(helpers.dao.basicauth_credentials:insert {
+    assert(helpers.dao.basicauth_credentials:insert {
       username    = "user123",
       password    = "password123",
       consumer_id = consumer.id,
@@ -52,6 +52,11 @@ describe("Plugin: basic-auth (access)", function()
     assert(helpers.dao.basicauth_credentials:insert {
       username    = "user321",
       password    = "password:123",
+      consumer_id = consumer.id,
+    })
+    assert(helpers.dao.basicauth_credentials:insert {
+      username    = "user-with-empty-password",
+      password    = "",
       consumer_id = consumer.id,
     })
 
@@ -213,6 +218,19 @@ describe("Plugin: basic-auth (access)", function()
         path = "/request",
         headers = {
           ["Authorization"] = "Basic dXNlcjMyMTpwYXNzd29yZDoxMjM=",
+          ["Host"] = "basic-auth1.com"
+        }
+      })
+      local body = cjson.decode(assert.res_status(200, res))
+      assert.equal("bob", body.headers["x-consumer-username"])
+    end)
+
+    it("authenticates with empty password", function()
+      local res = assert(client:send {
+        method = "GET",
+        path = "/request",
+        headers = {
+          ["Authorization"] = "Basic dXNlci13aXRoLWVtcHR5LXBhc3N3b3JkOgo=",
           ["Host"] = "basic-auth1.com"
         }
       })


### PR DESCRIPTION
### Summary

Story: I'm trying to migrate our current API to kong, and we have to support basic-auth with empty passwords, thus I opened this pr.

I think this is not a breaking change, and it's based on the `master` branch instead of the `next` branch.

Related to empty password basic auth

- https://svn.reviewboard.kde.org/r/1601/
- https://tools.ietf.org/html/rfc7617 (it didn't mention that password should be not empty)

### Full changelog

* Add empty password support for basic-auth

