### PR TITLE
feat(api) add /services/{service}/plugins and /routes/{route}/plugins

### DIFF
--- a/kong/api/endpoints.lua
+++ b/kong/api/endpoints.lua
@@ -443,7 +443,7 @@ local function generate_endpoints(schema, endpoints, prefix)
 end
 
 
-local Endpoints = {}
+local Endpoints = { handle_error = handle_error }
 
 
 function Endpoints.new(schema, endpoints, prefix)

--- a/kong/api/routes/routes.lua
+++ b/kong/api/routes/routes.lua
@@ -1,4 +1,14 @@
 local api_helpers = require "kong.api.api_helpers"
+local singletons  = require "kong.singletons"
+local responses   = require "kong.tools.responses"
+local endpoints   = require "kong.api.endpoints"
+local reports     = require "kong.core.reports"
+local utils       = require "kong.tools.utils"
+local crud        = require "kong.api.crud_helpers"
+
+
+local tostring    = tostring
+local type        = type
 
 
 return {
@@ -7,5 +17,63 @@ return {
       api_helpers.resolve_url_params(self)
       return parent()
     end,
+  },
+
+  ["/routes/:routes/plugins"] = {
+    on_error = function(self)
+      local err = self.errors[1]
+
+      if type(err) ~= "table" then
+        return responses.send_HTTP_INTERNAL_SERVER_ERROR(tostring(err))
+      end
+
+      if err.db then
+        return responses.send_HTTP_INTERNAL_SERVER_ERROR(err.message)
+      end
+
+      if err.unique then
+        return responses.send_HTTP_CONFLICT(err.tbl)
+      end
+
+      if err.foreign then
+        return responses.send_HTTP_NOT_FOUND(err.tbl)
+      end
+
+      return responses.send_HTTP_BAD_REQUEST(err.tbl or err.message)
+    end,
+
+    before = function(self, db, helpers)
+      local id = self.params.routes
+
+      local parent_entity, _, err_t = db.routes:select({ id = id })
+      if err_t then
+        return endpoints.handle_error(err_t)
+      end
+
+      if not parent_entity then
+        return helpers.responses.send_HTTP_NOT_FOUND()
+      end
+
+      self.params.routes   = nil
+      self.params.route_id = parent_entity.id
+    end,
+
+    GET = function(self)
+      crud.paginated_set(self, singletons.dao.plugins)
+    end,
+
+    POST = function(self)
+      crud.post(self.params, singletons.dao.plugins,
+        function(data)
+          local r_data = utils.deep_copy(data)
+          r_data.config = nil
+          reports.send("api", r_data)
+        end
+      )
+    end,
+
+    PUT = function(self)
+      crud.put(self.params, singletons.dao.plugins)
+    end
   },
 }

--- a/kong/api/routes/services.lua
+++ b/kong/api/routes/services.lua
@@ -1,4 +1,14 @@
 local api_helpers = require "kong.api.api_helpers"
+local singletons  = require "kong.singletons"
+local responses   = require "kong.tools.responses"
+local endpoints   = require "kong.api.endpoints"
+local reports     = require "kong.core.reports"
+local utils       = require "kong.tools.utils"
+local crud        = require "kong.api.crud_helpers"
+
+
+local tostring    = tostring
+local type        = type
 
 
 return {
@@ -14,5 +24,70 @@ return {
       api_helpers.resolve_url_params(self)
       return parent()
     end,
+  },
+
+  ["/services/:services/plugins"] = {
+    on_error = function(self)
+      local err = self.errors[1]
+
+      if type(err) ~= "table" then
+        return responses.send_HTTP_INTERNAL_SERVER_ERROR(tostring(err))
+      end
+
+      if err.db then
+        return responses.send_HTTP_INTERNAL_SERVER_ERROR(err.message)
+      end
+
+      if err.unique then
+        return responses.send_HTTP_CONFLICT(err.tbl)
+      end
+
+      if err.foreign then
+        return responses.send_HTTP_NOT_FOUND(err.tbl)
+      end
+
+      return responses.send_HTTP_BAD_REQUEST(err.tbl or err.message)
+    end,
+
+    before = function(self, db, helpers)
+      local id = self.params.services
+
+      local parent_entity, _, err_t
+      if not utils.is_valid_uuid(id) then
+        parent_entity, _, err_t = db.services:select_by_name(id)
+
+      else
+        parent_entity, _, err_t = db.services:select({ id = id })
+      end
+
+      if err_t then
+        return endpoints.handle_error(err_t)
+      end
+
+      if not parent_entity then
+        return helpers.responses.send_HTTP_NOT_FOUND()
+      end
+
+      self.params.services   = nil
+      self.params.service_id = parent_entity.id
+    end,
+
+    GET = function(self)
+      crud.paginated_set(self, singletons.dao.plugins)
+    end,
+
+    POST = function(self)
+      crud.post(self.params, singletons.dao.plugins,
+        function(data)
+          local r_data = utils.deep_copy(data)
+          r_data.config = nil
+          reports.send("api", r_data)
+        end
+      )
+    end,
+
+    PUT = function(self)
+      crud.put(self.params, singletons.dao.plugins)
+    end
   },
 }

--- a/spec/02-integration/04-admin_api/20-routes_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/20-routes_routes_spec.lua
@@ -19,10 +19,11 @@ for _, strategy in helpers.each_strategy("postgres") do
   describe("Admin API #" .. strategy, function()
     local bp
     local db
+    local dao
     local client
 
     setup(function()
-      bp, db = helpers.get_db_utils(strategy)
+      bp, db, dao = helpers.get_db_utils(strategy)
     end)
 
     teardown(function()
@@ -634,6 +635,307 @@ for _, strategy in helpers.each_strategy("postgres") do
               local res = client:delete("/routes/" .. utils.uuid() .. "/service")
               assert.res_status(404, res)
             end)
+          end)
+        end)
+      end)
+
+      describe("/routes/{route}/plugins", function()
+        local service
+        local route
+
+        before_each(function()
+          service = bp.services:insert {
+            name     = "my-service",
+            protocol = "http",
+            host     = "my-service.com",
+          }
+
+          route = bp.routes:insert {
+            hosts    = { "my-route.com" },
+            service  = service
+          }
+        end)
+
+        describe("POST", function()
+          it_content_types("creates a plugin config on a Route", function(content_type)
+            return function()
+              local res = assert(client:send {
+                method = "POST",
+                path = "/routes/" .. route.id .. "/plugins",
+                body = {
+                  name = "key-auth",
+                  ["config.key_names"] = "apikey,key"
+                },
+                headers = { ["Content-Type"] = content_type }
+              })
+              local body = assert.res_status(201, res)
+              local json = cjson.decode(body)
+              assert.equal("key-auth", json.name)
+              assert.same({ "apikey", "key" }, json.config.key_names)
+            end
+          end)
+
+          describe("errors", function()
+            it_content_types("handles invalid input", function(content_type)
+              return function()
+                local res = assert(client:send {
+                  method = "POST",
+                  path = "/routes/" .. route.id .. "/plugins",
+                  body = {},
+                  headers = { ["Content-Type"] = content_type }
+                })
+                local body = assert.res_status(400, res)
+                local json = cjson.decode(body)
+                assert.same({ name = "name is required" }, json)
+              end
+            end)
+
+            it_content_types("returns 409 on conflict (same plugin name)", function(content_type)
+              return function()
+                -- insert initial plugin
+                local res = assert(client:send {
+                  method = "POST",
+                  path = "/routes/" .. route.id .. "/plugins",
+                  body = {
+                    name = "basic-auth",
+                  },
+                  headers = {["Content-Type"] = content_type}
+                })
+                assert.response(res).has.status(201)
+                assert.response(res).has.jsonbody()
+
+                -- do it again, to provoke the error
+                local res = assert(client:send {
+                  method = "POST",
+                  path = "/routes/" .. route.id .. "/plugins",
+                  body = {
+                    name = "basic-auth",
+                  },
+                  headers = { ["Content-Type"] = content_type }
+                })
+                assert.response(res).has.status(409)
+                local json = assert.response(res).has.jsonbody()
+                assert.same({ name = "already exists with value 'basic-auth'"}, json)
+              end
+            end)
+
+            it_content_types("returns 409 on id conflict (same plugin id)", function(content_type)
+              return function()
+                -- insert initial plugin
+                local res = assert(client:send {
+                  method = "POST",
+                  path = "/routes/"..route.id.."/plugins",
+                  body = {
+                    name = "basic-auth",
+                  },
+                  headers = {["Content-Type"] = content_type}
+                })
+                local body = assert.res_status(201, res)
+                local plugin = cjson.decode(body)
+
+                -- do it again, to provoke the error
+                local conflict_res = assert(client:send {
+                  method = "POST",
+                  path = "/routes/" .. route.id .. "/plugins",
+                  body = {
+                    name = "key-auth",
+                    id = plugin.id,
+                  },
+                  headers = { ["Content-Type"] = content_type }
+                })
+                local conflict_body = assert.res_status(409, conflict_res)
+                local json = cjson.decode(conflict_body)
+                assert.same({ id = "already exists with value '" .. plugin.id .. "'"}, json)
+              end
+            end)
+          end)
+        end)
+
+        describe("PUT", function()
+          it_content_types("creates if not exists", function(content_type)
+            return function()
+              local res = assert(client:send {
+                method = "PUT",
+                path = "/routes/" .. route.id .. "/plugins",
+                body = {
+                  name = "key-auth",
+                  ["config.key_names"] = "apikey,key",
+                  created_at = 1461276890000
+                },
+                headers = { ["Content-Type"] = content_type }
+              })
+              local body = assert.res_status(201, res)
+              local json = cjson.decode(body)
+              assert.equal("key-auth", json.name)
+              assert.same({ "apikey", "key" }, json.config.key_names)
+            end
+          end)
+
+          it_content_types("replaces if exists", function(content_type)
+            return function()
+              local res = assert(client:send {
+                method = "PUT",
+                path = "/routes/" .. route.id .. "/plugins",
+                body = {
+                  name = "key-auth",
+                  ["config.key_names"] = "apikey,key",
+                  created_at = 1461276890000
+                },
+                headers = { ["Content-Type"] = content_type }
+              })
+              local body = assert.res_status(201, res)
+              local json = cjson.decode(body)
+
+              res = assert(client:send {
+                method = "PUT",
+                path = "/routes/" .. route.id .. "/plugins",
+                body = {
+                  id = json.id,
+                  name = "key-auth",
+                  ["config.key_names"] = "key",
+                  created_at = 1461276890000
+                },
+                headers = { ["Content-Type"] = content_type }
+              })
+              body = assert.res_status(200, res)
+              json = cjson.decode(body)
+              assert.equal("key-auth", json.name)
+              assert.same({ "key" }, json.config.key_names)
+            end
+          end)
+
+          it_content_types("perfers default values when replacing", function(content_type)
+            return function()
+              local plugin = assert(dao.plugins:insert {
+                name = "key-auth",
+                route_id = route.id,
+                config = {hide_credentials = true}
+              })
+              assert.True(plugin.config.hide_credentials)
+              assert.same({"apikey"}, plugin.config.key_names)
+
+              local res = assert(client:send {
+                method = "PUT",
+                path = "/routes/" .. route.id .. "/plugins",
+                body = {
+                  id = plugin.id,
+                  name = "key-auth",
+                  ["config.key_names"] = "apikey,key",
+                  created_at = 1461276890000
+                },
+                headers = { ["Content-Type"] = content_type }
+              })
+              local body = assert.res_status(200, res)
+              local json = cjson.decode(body)
+              assert.False(json.config.hide_credentials) -- not true anymore
+
+              plugin = assert(dao.plugins:find {
+                id = plugin.id,
+                name = plugin.name
+              })
+              assert.False(plugin.config.hide_credentials)
+              assert.same({"apikey", "key"}, plugin.config.key_names)
+            end
+          end)
+
+          it_content_types("overrides a plugin previous config if partial", function(content_type)
+            return function()
+              local plugin = assert(dao.plugins:insert {
+                name = "key-auth",
+                route_id = route.id
+              })
+              assert.same({ "apikey" }, plugin.config.key_names)
+
+              local res = assert(client:send {
+                method = "PUT",
+                path = "/routes/" .. route.id .. "/plugins",
+                body = {
+                  id = plugin.id,
+                  name = "key-auth",
+                  ["config.key_names"] = "apikey,key",
+                  created_at = 1461276890000
+                },
+                headers = { ["Content-Type"] = content_type }
+              })
+              local body = assert.res_status(200, res)
+              local json = cjson.decode(body)
+              assert.same({ "apikey", "key" }, json.config.key_names)
+            end
+          end)
+
+          it_content_types("updates the enabled property", function(content_type)
+            return function()
+              local plugin = assert(dao.plugins:insert {
+                name = "key-auth",
+                route_id = route.id
+              })
+              assert.True(plugin.enabled)
+
+              local res = assert(client:send {
+                method = "PUT",
+                path = "/routes/" .. route.id .. "/plugins",
+                body = {
+                  id = plugin.id,
+                  name = "key-auth",
+                  enabled = false,
+                  created_at = 1461276890000
+                },
+                headers = { ["Content-Type"] = content_type }
+              })
+              local body = assert.res_status(200, res)
+              local json = cjson.decode(body)
+              assert.False(json.enabled)
+
+              plugin = assert(dao.plugins:find {
+                id = plugin.id,
+                name = plugin.name
+              })
+              assert.False(plugin.enabled)
+            end
+          end)
+
+          describe("errors", function()
+            it_content_types("handles invalid input", function(content_type)
+              return function()
+                local res = assert(client:send {
+                  method = "PUT",
+                  path = "/routes/" .. route.id .. "/plugins",
+                  body = {},
+                  headers = { ["Content-Type"] = content_type }
+                })
+                local body = assert.res_status(400, res)
+                local json = cjson.decode(body)
+                assert.same({ name = "name is required" }, json)
+              end
+            end)
+          end)
+        end)
+
+        describe("GET", function()
+          it("retrieves the first page", function()
+            assert(dao.plugins:insert {
+              name = "key-auth",
+              route_id = route.id
+            })
+            local res = assert(client:send {
+              method = "GET",
+              path = "/routes/" .. route.id .. "/plugins"
+            })
+            local body = assert.res_status(200, res)
+            local json = cjson.decode(body)
+            assert.equal(1, #json.data)
+          end)
+
+          it("ignores an invalid body", function()
+            local res = assert(client:send {
+              method = "GET",
+              path = "/routes/" .. route.id .. "/plugins",
+              body = "this fails if decoded as json",
+              headers = {
+                ["Content-Type"] = "application/json",
+              }
+            })
+            assert.res_status(200, res)
           end)
         end)
       end)


### PR DESCRIPTION
### Summary

Adds two new Admin API endpoints:

- `/services/{service}/plugins`
- `/routes/{route}/plugins`

These endpoints support `GET`, `PUT`, and `POST` just like `/apis/{api}/plugins` does.

It is under new-model (routes and services) but uses old model on `/plugins` because plugins are still in old model. It doesn't add `/routes/{route}/plugins/{id}` (unlike `/apis({api}/plugins/{id}` because you can always just use `/plugins/{id}`.