### PR TITLE
fix(plugins) urldecode path fragments which accept spaces

### DIFF
--- a/kong/plugins/aws-lambda/v4.lua
+++ b/kong/plugins/aws-lambda/v4.lua
@@ -32,12 +32,6 @@ local function percent_encode(char)
   return string.format("%%%02X", string.byte(char))
 end
 
-local function urldecode(str)
-  return (str:gsub("%%(%x%x)", function(c)
-    return string.char(tonumber(c, 16))
-  end))
-end
-
 local function canonicalise_path(path)
   local segments = {}
   for segment in path:gmatch("/([^/]*)") do
@@ -47,7 +41,8 @@ local function canonicalise_path(path)
       -- intentionally discards components at top level
       segments[#segments] = nil
     else
-      segments[#segments+1] = urldecode(segment):gsub("[^%w%-%._~]", percent_encode)
+      segments[#segments+1] = ngx.unescape_uri(segment):gsub("[^%w%-%._~]",
+                                                             percent_encode)
     end
   end
   local len = #segments
@@ -67,8 +62,8 @@ end
 local function canonicalise_query_string(query)
   local q = {}
   for key, val in query:gmatch("([^&=]+)=?([^&]*)") do
-    key = urldecode(key):gsub("[^%w%-%._~]", percent_encode)
-    val = urldecode(val):gsub("[^%w%-%._~]", percent_encode)
+    key = ngx.unescape_uri(key):gsub("[^%w%-%._~]", percent_encode)
+    val = ngx.unescape_uri(val):gsub("[^%w%-%._~]", percent_encode)
     q[#q+1] = key .. "=" .. val
   end
   table.sort(q)

--- a/kong/plugins/basic-auth/api.lua
+++ b/kong/plugins/basic-auth/api.lua
@@ -27,7 +27,7 @@ return {
       local credentials, err = crud.find_by_id_or_field(
         dao_factory.basicauth_credentials,
         { consumer_id = self.params.consumer_id },
-        self.params.credential_username_or_id,
+        ngx.unescape_uri(self.params.credential_username_or_id),
         "username"
       )
 
@@ -63,7 +63,7 @@ return {
       local credentials, err = crud.find_by_id_or_field(
         dao_factory.basicauth_credentials,
         nil,
-        self.params.credential_username_or_id,
+        ngx.unescape_uri(self.params.credential_username_or_id),
         "username"
       )
 

--- a/kong/plugins/hmac-auth/api.lua
+++ b/kong/plugins/hmac-auth/api.lua
@@ -28,7 +28,7 @@ return{
       local credentials, err = crud.find_by_id_or_field(
         dao_factory.hmacauth_credentials,
         { consumer_id = self.params.consumer_id },
-        self.params.hmac_username_or_id,
+        ngx.unescape_uri(self.params.hmac_username_or_id),
         "username"
       )
 
@@ -64,7 +64,7 @@ return{
       local credentials, err = crud.find_by_id_or_field(
         dao_factory.hmacauth_credentials,
         {},
-        self.params.hmac_username_or_id,
+        ngx.unescape_uri(self.params.hmac_username_or_id),
         "username"
       )
 

--- a/kong/plugins/jwt/api.lua
+++ b/kong/plugins/jwt/api.lua
@@ -28,7 +28,7 @@ return {
       local credentials, err = crud.find_by_id_or_field(
         dao_factory.jwt_secrets,
         { consumer_id = self.params.consumer_id },
-        self.params.jwt_key_or_id,
+        ngx.unescape_uri(self.params.jwt_key_or_id),
         "key"
       )
 
@@ -64,7 +64,7 @@ return {
       local credentials, err = crud.find_by_id_or_field(
         dao_factory.jwt_secrets,
         nil,
-        self.params.jwt_key_or_id,
+        ngx.unescape_uri(self.params.jwt_key_or_id),
         "key"
       )
 

--- a/kong/plugins/key-auth/api.lua
+++ b/kong/plugins/key-auth/api.lua
@@ -27,7 +27,7 @@ return {
       local credentials, err = crud.find_by_id_or_field(
         dao_factory.keyauth_credentials,
         { consumer_id = self.params.consumer_id },
-        self.params.credential_key_or_id,
+        ngx.unescape_uri(self.params.credential_key_or_id),
         "key"
       )
 
@@ -63,7 +63,7 @@ return {
       local credentials, err = crud.find_by_id_or_field(
         dao_factory.keyauth_credentials,
         {},
-        self.params.credential_key_or_id,
+        ngx.unescape_uri(self.params.credential_key_or_id),
         "key"
       )
 

--- a/kong/plugins/oauth2/api.lua
+++ b/kong/plugins/oauth2/api.lua
@@ -80,7 +80,7 @@ return {
       local credentials, err = crud.find_by_id_or_field(
         dao_factory.oauth2_credentials,
         { consumer_id = self.params.consumer_id },
-        self.params.clientid_or_id,
+        ngx.unescape_uri(self.params.clientid_or_id),
         "client_id"
       )
 

--- a/spec/03-plugins/10-key-auth/01-api_spec.lua
+++ b/spec/03-plugins/10-key-auth/01-api_spec.lua
@@ -149,10 +149,15 @@ describe("Plugin: key-auth (API)", function()
 
   describe("/consumers/:consumer/key-auth/:id", function()
     local credential
+    -- Contains all reserved characters from RFC 3986
+    local key = "Some Key :/?#[]@!$&'()*+,;="
+    local url_key = "Some%20Key%20%3a%2f%3f%23%5b%5d%40%21%24%26%27%28%29%2a%2b%2c%3b%3d"
+
     before_each(function()
       helpers.dao:truncate_table("keyauth_credentials")
       credential = assert(helpers.dao.keyauth_credentials:insert {
-        consumer_id = consumer.id
+        consumer_id = consumer.id,
+        key = key,
       })
     end)
     describe("GET", function()
@@ -164,11 +169,12 @@ describe("Plugin: key-auth (API)", function()
         local body = assert.res_status(200, res)
         local json = cjson.decode(body)
         assert.equal(credential.id, json.id)
+        assert.equal(key, json.key)
       end)
       it("retrieves key-auth credential by key", function()
         local res = assert(admin_client:send {
           method = "GET",
-          path = "/consumers/bob/key-auth/" .. credential.key
+          path = "/consumers/bob/key-auth/" .. url_key
         })
         local body = assert.res_status(200, res)
         local json = cjson.decode(body)
@@ -212,7 +218,7 @@ describe("Plugin: key-auth (API)", function()
       it("updates a credential by key", function()
         local res = assert(admin_client:send {
           method = "PATCH",
-          path = "/consumers/bob/key-auth/" .. credential.key,
+          path = "/consumers/bob/key-auth/" .. url_key,
           body = {
             key = "4321UPD"
           },
@@ -417,11 +423,15 @@ describe("Plugin: key-auth (API)", function()
   describe("/key-auths/:credential_key_or_id/consumer", function()
     describe("GET", function()
       local credential
+      -- Contains all reserved characters from RFC 3986
+      local my_plugin_key = "Some Key :/?#[]@!$&'()*+,;="
+      local my_url_key = "Some%20Key%20%3a%2f%3f%23%5b%5d%40%21%24%26%27%28%29%2a%2b%2c%3b%3d"
 
       setup(function()
         helpers.dao:truncate_table("keyauth_credentials")
         credential = assert(helpers.dao.keyauth_credentials:insert {
-          consumer_id = consumer.id
+          consumer_id = consumer.id,
+          key = my_plugin_key,
         })
       end)
 
@@ -437,7 +447,7 @@ describe("Plugin: key-auth (API)", function()
       it("retrieve a Consumer from a credential's key", function()
         local res = assert(admin_client:send {
           method = "GET",
-          path = "/key-auths/" .. credential.key .. "/consumer"
+          path = "/key-auths/" .. my_url_key .. "/consumer"
         })
         local body = assert.res_status(200, res)
         local json = cjson.decode(body)

--- a/spec/03-plugins/10-key-auth/01-api_spec.lua
+++ b/spec/03-plugins/10-key-auth/01-api_spec.lua
@@ -153,11 +153,19 @@ describe("Plugin: key-auth (API)", function()
     local key = "Some Key :/?#[]@!$&'()*+,;="
     local url_key = "Some%20Key%20%3a%2f%3f%23%5b%5d%40%21%24%26%27%28%29%2a%2b%2c%3b%3d"
 
+    -- Test for a simpler key that doesn't trigger URL encodings
+    local simple_credential
+    local simple_key = "foo"
+
     before_each(function()
       helpers.dao:truncate_table("keyauth_credentials")
       credential = assert(helpers.dao.keyauth_credentials:insert {
         consumer_id = consumer.id,
         key = key,
+      })
+      simple_credential = assert(helpers.dao.keyauth_credentials:insert {
+        consumer_id = consumer.id,
+        key = simple_key,
       })
     end)
     describe("GET", function()
@@ -179,6 +187,15 @@ describe("Plugin: key-auth (API)", function()
         local body = assert.res_status(200, res)
         local json = cjson.decode(body)
         assert.equal(credential.id, json.id)
+      end)
+      it("retrieves key-auth credential by key (simple)", function()
+        local res = assert(admin_client:send {
+          method = "GET",
+          path = "/consumers/bob/key-auth/" .. simple_key
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.equal(simple_credential.id, json.id)
       end)
       it("retrieves credential by id only if the credential belongs to the specified consumer", function()
         assert(helpers.dao.consumers:insert {

--- a/spec/03-plugins/11-basic-auth/02-api_spec.lua
+++ b/spec/03-plugins/11-basic-auth/02-api_spec.lua
@@ -4,6 +4,9 @@ local utils = require "kong.tools.utils"
 
 describe("Plugin: basic-auth (API)", function()
   local consumer, admin_client
+  -- Contains all reserved characters from RFC 3986
+  local plugin_username = "spongebob squarepants :/?#[]@!$&'()*+,;="
+  local url_username = "spongebob%20squarepants%20%3a%2f%3f%23%5b%5d%40%21%24%26%27%28%29%2a%2b%2c%3b%3d"
   setup(function()
     helpers.run_migrations()
 
@@ -31,7 +34,7 @@ describe("Plugin: basic-auth (API)", function()
           method = "POST",
           path = "/consumers/bob/basic-auth",
           body = {
-            username = "bob",
+            username = plugin_username,
             password = "kong"
           },
           headers = {
@@ -41,14 +44,14 @@ describe("Plugin: basic-auth (API)", function()
         local body = assert.res_status(201, res)
         local json = cjson.decode(body)
         assert.equal(consumer.id, json.consumer_id)
-        assert.equal("bob", json.username)
+        assert.equal(plugin_username, json.username)
       end)
       it("encrypts the password", function()
         local res = assert(admin_client:send {
           method = "POST",
           path = "/consumers/bob/basic-auth",
           body = {
-            username = "bob",
+            username = plugin_username,
             password = "kong"
           },
           headers = {
@@ -86,7 +89,7 @@ describe("Plugin: basic-auth (API)", function()
             method = "POST",
             path = "/consumers/bob/basic-auth",
             body = {
-              username = "bob",
+              username = plugin_username,
               password = "kong"
             },
             headers = {
@@ -100,7 +103,7 @@ describe("Plugin: basic-auth (API)", function()
             method = "POST",
             path = "/consumers/bob/basic-auth",
             body = {
-              username = "bob",
+              username = plugin_username,
               password = "kong"
             },
             headers = {
@@ -118,7 +121,7 @@ describe("Plugin: basic-auth (API)", function()
           method = "PUT",
           path = "/consumers/bob/basic-auth",
           body = {
-            username = "bob",
+            username = plugin_username,
             password = "kong"
           },
           headers = {
@@ -128,7 +131,7 @@ describe("Plugin: basic-auth (API)", function()
         local body = assert.res_status(201, res)
         local json = cjson.decode(body)
         assert.equal(consumer.id, json.consumer_id)
-        assert.equal("bob", json.username)
+        assert.equal(plugin_username, json.username)
       end)
       describe("errors", function()
         it("returns bad request", function()
@@ -179,7 +182,7 @@ describe("Plugin: basic-auth (API)", function()
     before_each(function()
       helpers.dao:truncate_table("basicauth_credentials")
       credential = assert(helpers.dao.basicauth_credentials:insert {
-        username = "bob",
+        username = plugin_username,
         password = "kong",
         consumer_id = consumer.id
       })
@@ -197,7 +200,7 @@ describe("Plugin: basic-auth (API)", function()
       it("retrieves basic-auth credential by username", function()
         local res = assert(admin_client:send {
           method = "GET",
-          path = "/consumers/bob/basic-auth/" .. credential.username
+          path = "/consumers/bob/basic-auth/" .. url_username
         })
         local body = assert.res_status(200, res)
         local json = cjson.decode(body)
@@ -245,7 +248,7 @@ describe("Plugin: basic-auth (API)", function()
 
         local res = assert(admin_client:send {
           method = "PATCH",
-          path = "/consumers/bob/basic-auth/" .. credential.username,
+          path = "/consumers/bob/basic-auth/" .. url_username,
           body = {
             password = "upd4321"
           },
@@ -309,7 +312,7 @@ describe("Plugin: basic-auth (API)", function()
         helpers.dao:truncate_table("basicauth_credentials")
         assert(helpers.dao.basicauth_credentials:insert {
           consumer_id = consumer.id,
-          username = "bob"
+          username = plugin_username
         })
         consumer2 = assert(helpers.dao.consumers:insert {
           username = "bob-the-buidler"
@@ -403,7 +406,7 @@ describe("Plugin: basic-auth (API)", function()
         helpers.dao:truncate_table("basicauth_credentials")
         credential = assert(helpers.dao.basicauth_credentials:insert {
           consumer_id = consumer.id,
-          username = "bob"
+          username = plugin_username,
         })
       end)
       it("retrieve consumer from a basic-auth id", function()
@@ -418,7 +421,7 @@ describe("Plugin: basic-auth (API)", function()
       it("retrieve consumer from a basic-auth username", function()
         local res = assert(admin_client:send {
           method = "GET",
-          path = "/basic-auths/" .. credential.username .. "/consumer"
+          path = "/basic-auths/" .. url_username .. "/consumer"
         })
         local body = assert.res_status(200, res)
         local json = cjson.decode(body)

--- a/spec/03-plugins/17-jwt/02-api_spec.lua
+++ b/spec/03-plugins/17-jwt/02-api_spec.lua
@@ -234,10 +234,18 @@ describe("Plugin: jwt (API)", function()
     local my_plugin_key = "Some Key :/?#[]@!$&'()*+,;="
     local my_url_key = "Some%20Key%20%3a%2f%3f%23%5b%5d%40%21%24%26%27%28%29%2a%2b%2c%3b%3d"
 
+    -- Test for a simpler key that doesn't trigger encodings as well
+    local my_simple_jwt
+    local simple_key = "foo"
+
     setup(function()
       my_jwt = assert(jwt_secrets:insert {
         consumer_id = consumer.id,
         key = my_plugin_key,
+      })
+      my_simple_jwt = assert(jwt_secrets:insert {
+        consumer_id = consumer.id,
+        key = simple_key,
       })
     end)
     teardown(function()
@@ -259,6 +267,15 @@ describe("Plugin: jwt (API)", function()
         local body = assert.res_status(200, res)
         jwt_secret = cjson.decode(body)
         assert.equal(my_plugin_key, jwt_secret.key)
+      end)
+      it("retrieves by key (simple)", function()
+        local res = assert(admin_client:send {
+          method = "GET",
+          path = "/consumers/bob/jwt/" .. simple_key,
+        })
+        local body = assert.res_status(200, res)
+        jwt_secret = cjson.decode(body)
+        assert.equal(my_simple_jwt.key, jwt_secret.key)
       end)
     end)
 

--- a/spec/03-plugins/17-jwt/02-api_spec.lua
+++ b/spec/03-plugins/17-jwt/02-api_spec.lua
@@ -7,6 +7,8 @@ local fixtures = require "spec.03-plugins.17-jwt.fixtures"
 
 describe("Plugin: jwt (API)", function()
   local admin_client, consumer, jwt_secret
+  local plugin_key = "spongebob squarepants"
+  local url_key = "spongebob%20squarepants"
   setup(function()
     helpers.run_migrations()
 
@@ -54,7 +56,7 @@ describe("Plugin: jwt (API)", function()
           method = "POST",
           path = "/consumers/bob/jwt/",
           body = {
-            key = "bob2",
+            key = plugin_key,
             secret = "tooshort"
           },
           headers = {
@@ -62,7 +64,7 @@ describe("Plugin: jwt (API)", function()
           }
         })
         local body = cjson.decode(assert.res_status(201, res))
-        assert.equal("bob2", body.key)
+        assert.equal(plugin_key, body.key)
         assert.equal("tooshort", body.secret)
         jwt2 = body
       end)
@@ -112,7 +114,7 @@ describe("Plugin: jwt (API)", function()
           method = "POST",
           path = "/consumers/bob/jwt/",
           body = {
-            key = "bob3",
+            key = plugin_key .." 3",
             algorithm = "RS256",
             rsa_public_key = rsa_public_key
           },
@@ -122,7 +124,7 @@ describe("Plugin: jwt (API)", function()
         })
         assert.response(res).has.status(201)
         local json = assert.response(res).has.jsonbody()
-        assert.equal("bob3", json.key)
+        assert.equal(plugin_key .. " 3", json.key)
       end)
       it("accepts a valid public key for RS256 when posted as json", function()
         local rsa_public_key = fixtures.rs256_public_key
@@ -131,7 +133,7 @@ describe("Plugin: jwt (API)", function()
           method = "POST",
           path = "/consumers/bob/jwt/",
           body = {
-            key = "bob4",
+            key = plugin_key .. " 4",
             algorithm = "RS256",
             rsa_public_key = rsa_public_key
           },
@@ -141,14 +143,14 @@ describe("Plugin: jwt (API)", function()
         })
         assert.response(res).has.status(201)
         local json = assert.response(res).has.jsonbody()
-        assert.equal("bob4", json.key)
+        assert.equal(plugin_key .. " 4", json.key)
       end)
       it("fails with missing `rsa_public_key` parameter for RS256 algorithms", function ()
         local res = assert(admin_client:send {
           method = "POST",
           path = "/consumers/bob/jwt/",
           body = {
-            key = "bob5",
+            key = plugin_key .. " 5",
             algorithm = "RS256"
           },
           headers = {
@@ -164,7 +166,7 @@ describe("Plugin: jwt (API)", function()
           method = "POST",
           path = "/consumers/bob/jwt/",
           body = {
-            key = "bob5",
+            key = plugin_key .. " 6",
             algorithm = "RS256",
             rsa_public_key = "test",
           },
@@ -181,7 +183,7 @@ describe("Plugin: jwt (API)", function()
           method = "POST",
           path = "/consumers/bob/jwt/",
           body = {
-            key = "bob5",
+            key = plugin_key .. " 7",
             algorithm = "HS256",
           },
           headers = {
@@ -227,20 +229,36 @@ describe("Plugin: jwt (API)", function()
   end)
 
   describe("/consumers/:consumer/jwt/:id", function()
+    local my_jwt
+    -- Contains all reserved characters from RFC 3986
+    local my_plugin_key = "Some Key :/?#[]@!$&'()*+,;="
+    local my_url_key = "Some%20Key%20%3a%2f%3f%23%5b%5d%40%21%24%26%27%28%29%2a%2b%2c%3b%3d"
+
+    setup(function()
+      my_jwt = assert(jwt_secrets:insert {
+        consumer_id = consumer.id,
+        key = my_plugin_key,
+      })
+    end)
+    teardown(function()
+      jwt_secrets:delete(my_jwt)
+    end)
     describe("GET", function()
       it("retrieves by id", function()
         local res = assert(admin_client:send {
           method = "GET",
-          path = "/consumers/bob/jwt/" .. jwt_secret.id,
+          path = "/consumers/bob/jwt/" .. my_jwt.id,
         })
         assert.res_status(200, res)
       end)
       it("retrieves by key", function()
         local res = assert(admin_client:send {
           method = "GET",
-          path = "/consumers/bob/jwt/" .. jwt_secret.key,
+          path = "/consumers/bob/jwt/" .. my_url_key,
         })
-        assert.res_status(200, res)
+        local body = assert.res_status(200, res)
+        jwt_secret = cjson.decode(body)
+        assert.equal(my_plugin_key, jwt_secret.key)
       end)
     end)
 
@@ -248,10 +266,10 @@ describe("Plugin: jwt (API)", function()
       it("updates a credential by id", function()
         local res = assert(admin_client:send {
           method = "PATCH",
-          path = "/consumers/bob/jwt/" .. jwt_secret.id,
+          path = "/consumers/bob/jwt/" .. my_jwt.id,
           body = {
-            key = "alice",
-            secret = "newsecret"
+            key = "new key",
+            secret = "new secret"
           },
           headers = {
             ["Content-Type"] = "application/json"
@@ -259,15 +277,18 @@ describe("Plugin: jwt (API)", function()
         })
         local body = assert.res_status(200, res)
         jwt_secret = cjson.decode(body)
-        assert.equal("newsecret", jwt_secret.secret)
+        assert.equal("new key", jwt_secret.key)
+        assert.equal("new secret", jwt_secret.secret)
+        my_plugin_key = "new key"
+        my_url_key = "new%20key"
       end)
       it("updates a credential by key", function()
         local res = assert(admin_client:send {
           method = "PATCH",
-          path = "/consumers/bob/jwt/" .. jwt_secret.key,
+          path = "/consumers/bob/jwt/" .. my_url_key,
           body = {
             key = "alice",
-            secret = "newsecret2"
+            secret = "new secret 2"
           },
           headers = {
             ["Content-Type"] = "application/json"
@@ -275,7 +296,8 @@ describe("Plugin: jwt (API)", function()
         })
         local body = assert.res_status(200, res)
         jwt_secret = cjson.decode(body)
-        assert.equal("newsecret2", jwt_secret.secret)
+        assert.equal("new secret 2", jwt_secret.secret)
+        my_url_key = "new%20secret%202"
       end)
     end)
 
@@ -284,6 +306,17 @@ describe("Plugin: jwt (API)", function()
         local res = assert(admin_client:send {
           method = "DELETE",
           path = "/consumers/bob/jwt/" .. jwt_secret.id,
+          body = {},
+          headers = {
+            ["Content-Type"] = "application/json"
+          }
+        })
+        assert.res_status(204, res)
+      end)
+      it("deletes a credential by key", function()
+        local res = assert(admin_client:send {
+          method = "DELETE",
+          path = "/consumers/bob/jwt/" .. url_key,
           body = {},
           headers = {
             ["Content-Type"] = "application/json"
@@ -409,10 +442,14 @@ describe("Plugin: jwt (API)", function()
   describe("/jwts/:jwt_key_or_id/consumer", function()
     describe("GET", function()
       local credential
+      -- Contains all reserved characters from RFC 3986
+      local key = "Some Key :/?#[]@!$&'()*+,;="
+      local url_key = "Some%20Key%20%3a%2f%3f%23%5b%5d%40%21%24%26%27%28%29%2a%2b%2c%3b%3d"
       setup(function()
         helpers.dao:truncate_table("jwt_secrets")
         credential = assert(helpers.dao.jwt_secrets:insert {
-          consumer_id = consumer.id
+          consumer_id = consumer.id,
+          key = key,
         })
       end)
       it("retrieve consumer from a JWT id", function()
@@ -427,7 +464,7 @@ describe("Plugin: jwt (API)", function()
       it("retrieve consumer from a JWT key", function()
         local res = assert(admin_client:send {
           method = "GET",
-          path = "/jwts/" .. credential.key .. "/consumer"
+          path = "/jwts/" .. url_key .. "/consumer"
         })
         local body = assert.res_status(200, res)
         local json = cjson.decode(body)

--- a/spec/03-plugins/26-oauth2/02-api_spec.lua
+++ b/spec/03-plugins/26-oauth2/02-api_spec.lua
@@ -242,12 +242,17 @@ describe("Plugin: oauth (API)", function()
 
   describe("/consumers/:consumer/oauth2/:id", function()
     local credential
+    -- Contains all reserved characters from RFC 3986
+    local plugin_client_id = "Some Key :/?#[]@!$&'()*+,;="
+    local url_client_id = "Some%20Key%20%3a%2f%3f%23%5b%5d%40%21%24%26%27%28%29%2a%2b%2c%3b%3d"
+
     before_each(function()
       helpers.dao:truncate_table("oauth2_credentials")
       credential = assert(helpers.dao.oauth2_credentials:insert {
         name         = "test app",
         redirect_uri = helpers.mock_upstream_ssl_url,
         consumer_id  = consumer.id,
+        client_id    = plugin_client_id,
       })
     end)
     describe("GET", function()
@@ -263,7 +268,7 @@ describe("Plugin: oauth (API)", function()
       it("retrieves oauth2 credential by client id", function()
         local res = assert(admin_client:send {
           method = "GET",
-          path = "/consumers/bob/oauth2/" .. credential.client_id
+          path = "/consumers/bob/oauth2/" .. url_client_id
         })
         local body = assert.res_status(200, res)
         local json = cjson.decode(body)
@@ -289,13 +294,13 @@ describe("Plugin: oauth (API)", function()
       it("retrieves credential by clientid only if the credential belongs to the specified consumer", function()
         local res = assert(admin_client:send {
           method = "GET",
-          path = "/consumers/bob/oauth2/" .. credential.client_id
+          path = "/consumers/bob/oauth2/" .. url_client_id
         })
         assert.res_status(200, res)
 
         res = assert(admin_client:send {
           method = "GET",
-          path = "/consumers/alice/oauth2/" .. credential.client_id
+          path = "/consumers/alice/oauth2/" .. url_client_id
         })
         assert.res_status(404, res)
       end)
@@ -324,7 +329,7 @@ describe("Plugin: oauth (API)", function()
 
         local res = assert(admin_client:send {
           method = "PATCH",
-          path = "/consumers/bob/oauth2/" .. credential.client_id,
+          path = "/consumers/bob/oauth2/" .. url_client_id,
           body = {
             name = "4321UDP"
           },

--- a/spec/03-plugins/26-oauth2/02-api_spec.lua
+++ b/spec/03-plugins/26-oauth2/02-api_spec.lua
@@ -242,12 +242,23 @@ describe("Plugin: oauth (API)", function()
 
   describe("/consumers/:consumer/oauth2/:id", function()
     local credential
+    local simple_credential
+    local simple_client_id = "foo"
+
     -- Contains all reserved characters from RFC 3986
     local plugin_client_id = "Some Key :/?#[]@!$&'()*+,;="
     local url_client_id = "Some%20Key%20%3a%2f%3f%23%5b%5d%40%21%24%26%27%28%29%2a%2b%2c%3b%3d"
 
     before_each(function()
       helpers.dao:truncate_table("oauth2_credentials")
+
+      simple_credential = assert(helpers.dao.oauth2_credentials:insert {
+        name         = "test app",
+        redirect_uri = helpers.mock_upstream_ssl_url,
+        consumer_id  = consumer.id,
+        client_id    = simple_client_id,
+      })
+
       credential = assert(helpers.dao.oauth2_credentials:insert {
         name         = "test app",
         redirect_uri = helpers.mock_upstream_ssl_url,
@@ -264,6 +275,15 @@ describe("Plugin: oauth (API)", function()
         local body = assert.res_status(200, res)
         local json = cjson.decode(body)
         assert.equal(credential.id, json.id)
+      end)
+      it("retrieves oauth2 credential by client id (simple)", function()
+        local res = assert(admin_client:send {
+          method = "GET",
+          path = "/consumers/bob/oauth2/" .. simple_client_id
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.equal(simple_credential.id, json.id)
       end)
       it("retrieves oauth2 credential by client id", function()
         local res = assert(admin_client:send {


### PR DESCRIPTION
In some plugins (basic-auth, hmac-auth, jwt, key-auth, oauth2) we have path fragments which represent plugin fields that may contain spaces in their definitions. For example, if a username for basic-auth contains a space, for example, then it is reasonable to perform this request:

```
http ":8001/consumers/bob/basic-auth/John Doe/"
```

which, due to URL-encoding, results in a request to
http://localhost:8001/consumers/bob/basic-auth/John%20Doe/ --
we are currently returning 404 for those queries.

This patch performs URL-decoding on those path fragments, using `ngx.unescape_uri`.

It also modifies the test suites for these plugins using values with spaces for the relevant fields, and using the URL-encoded version of these fields when querying the Admin API.

Fixes #3247.
