### PR TITLE
release: 0.13.0rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Table of Contents
 
 - [Scheduled](#scheduled)
-    - [0.13.0](#0130)
     - [0.12.2](#0122)
 - [Released](#released)
+    - [0.13.0rc1](#0130rc1)
     - [0.12.1](#0121---20180118)
     - [0.12.0](#0120---20180116)
     - [0.11.2](#0112---20171129)
@@ -21,33 +21,140 @@
 This section describes upcoming releases that have a release date, along with
 a detailed changeset of their content.
 
-## [0.13.0]
+*No scheduled releases yet.*
 
-**RC release date (target)**: February 28th 2018
-**Stable release date (target)**: March 14th 2018
+# Released
 
-The contents of this release are still fluctuating. New additions will
-certainly be made before the closing of the merging window.
+This section describes publicly available releases and a detailed changeset of
+their content.
+
+## [0.13.0rc1]
+
+- **rc1 release date**: February 28th 2018
+- **Stable release date (target)**: March 14th 2018
+
+This release introduces two new core entities that will improve the way you
+configure Kong: **Routes** & **Services**. Those entities replace the "API"
+entity and simplify the setup of non-naive use-cases by providing better
+separation of concerns and allowing for plugins to be applied to specific
+**endpoints**.
+
+As usual, major version upgrades require database migrations and changes to
+the NGINX configuration file (if you customized the default template).
+Please take a few minutes to read the [0.13 Upgrade
+Path](https://github.com/Kong/kong/blob/master/UPGRADE.md#upgrade-to-013x) for
+more details regarding breaking changes and migrations before planning to
+upgrade your Kong cluster.
+
+### Breaking Changes
+
+##### Dependencies
+
+- Support for Cassandra 2.1 was deprecated in 0.12.0, and has been dropped
+  starting with 0.13.0.
+
+##### Configuration
+
+- :warning: The `proxy_listen` and `admin_listen` configuration values have a
+  new syntax.  This syntax is more aligned with that of NGINX and is more
+  powerful while also simpler.  As a result, the following configuration values
+  have been removed because superfluous: `ssl`, `admin_ssl`, `http2`,
+  `admin_http2`, `proxy_listen_ssl`, and `admin_listen_ssl`.
+  [#3147](https://github.com/Kong/kong/pull/3147)
+
+##### Plugins
+
+- :warning: galileo: As part of the Galileo deprecation path, the galileo
+  plugin is not enabled by default anymore, although still bundled with 0.13.
+  Users are advised to stop using the plugin, but for the time being can keep
+  enabling it by adding it to the `custom_plugin` configuration value.
+  [#3233](https://github.com/Kong/kong/pull/3233)
+- :warning: rate-limiting (Cassandra): The default migration for including
+  Routes and Services in plugins will remove and re-create the Cassandra
+  rate-limiting counters table. This means that users that were rate-limited
+  because of excessive API consumption will be able to consume the API until
+  they reach their limit again. There is no such data deletion in PosgreSQL.
+  [def201f](https://github.com/Kong/kong/commit/def201f566ccf2dd9b670e2f38e401a0450b1cb5)
+
+### Changed
+
+##### Dependencies
+
+- The Openresty version shipped with our default packages has been bumped to
+  `1.13.6.1`. The 0.13.0 release should still be compatible with the OpenResty
+  `1.11.2.x` series for the time being.
+- Bumped [lua-resty-dns-client](https://github.com/Kong/lua-resty-dns-client)
+  to `2.0.0`.
+  [#3220](https://github.com/Kong/kong/pull/3220)
+- Bumped [lua-resty-http](https://github.com/pintsized/lua-resty-http) to
+  `0.12`.
+  [#3196](https://github.com/Kong/kong/pull/3196)
+- Bumped [lua-multipart](https://github.com/Kong/lua-multipart) to `0.5.4`.
+  [#3154](https://github.com/Kong/kong/pull/3054)
 
 ### Added
 
-- :fireworks: This release introduces two new entities: **Routes**
-  and **Services**.
-  Those entities will provide a better separation of concerns than the "API"
-  entity offers. Routes will define rules for matching a client's request (e.g.
-  method, host, path...), and Services will represent upstream services (or
-  backends) that Kong should proxy those requests to.
-  Plugins can also be added to both Routes and Services, enabling use-cases
-  to apply plugins more granularly (e.g. per endpoint).
+##### Configuration
+
+- :fireworks: Support for **control-plane** and **data-plane** modes. The new
+  new syntax of `proxy_listen` and `admin_listen` supports `off`, which
+  disables either one of those interfaces. It is now simpler than ever to
+  make a Kong node "Proxy only" (data-plane) or "Admin only" (control-plane).
+  [#3147](https://github.com/Kong/kong/pull/3147)
+
+##### Core
+
+- :fireworks: This release introduces two new entities: **Routes** and
+  **Services**. Those entities will provide a better separation of concerns
+  than the "API" entity offers. Routes will define rules for matching a
+  client's request (e.g., method, host, path...), and Services will represent
+  upstream services (or backends) that Kong should proxy those requests to.
+  Plugins can also be added to both Routes and Services, enabling use-cases to
+  apply plugins more granularly (e.g., per endpoint).
   Following this addition, the API entity and related Admin API endpoints are
   now deprecated. This release is backwards-compatible with the previous model
   and all of your currently defined APIs and matching rules are still
-  supported.
+  supported, although we advise users to migrate to Routes and Services as soon
+  as possible.
+  [#3224](https://github.com/Kong/kong/pull/3224)
 
-Additionally, this release will also include all the changes listed under the
-[0.12.2](#0122) release.
+##### Admin API
+
+- :fireworks: New endpoints: `/routes` and `/services` to interact with the new
+  core entities. More specific endpoints are also available such as
+  `/services/{service id or name}/routes`,
+  `/services/{service id or name}/plugins`, and `/routes/{route id}/plugins`.
+  [#3224](https://github.com/Kong/kong/pull/3224)
+- :fireworks: Our new endpoints (listed above) provide much better responses
+  with regards to producing responses for incomplete entities, errors, etc...
+  In the future, existing endpoints will gradually be moved to using this new
+  Admin API content producer.
+  [#3224](https://github.com/Kong/kong/pull/3224)
+- :fireworks: Improved argument parsing in form-urlencoded requests to the new
+  endpoints as well.
+  Kong now expects the following syntaxes for representing
+  arrays: `hosts[]=a.com&hosts[]=b.com`, `hosts[1]=a.com&hosts[2]=b.com`, which
+  avoid comma-separated arrays and related issues that can arise.
+  In the future, existing endpoints will gradually be moved to using this new
+  Admin API content parser.
+  [#3224](https://github.com/Kong/kong/pull/3224)
+
+##### Plugins
+
+- jwt: `ngx.ctx.authenticated_jwt_token` is available for other plugins to use.
+  [#2988](https://github.com/Kong/kong/pull/2988)
+- statsd: The fields `host`, `port` and `metrics` are no longer marked as
+  "required", since they have a default value.
+  [#3209](https://github.com/Kong/kong/pull/3209)
 
 [Back to TOC](#table-of-contents)
+
+### Fixes
+
+##### Admin API
+
+- Fix several issues with application/multipart MIME type parsing of payloads.
+  [#3054](https://github.com/Kong/kong/pull/3054)
 
 ## [0.12.2]
 
@@ -75,11 +182,6 @@ certainly be made before the closing of the merging window.
   [#3148](https://github.com/Kong/kong/pull/3148)
 
 [Back to TOC](#table-of-contents)
-
-# Released
-
-This section describes publicly available releases and a detailed changeset of
-their content.
 
 ## [0.12.1] - 2018/01/18
 
@@ -2226,6 +2328,7 @@ First version running with Cassandra.
 
 [Back to TOC](#table-of-contents)
 
+[0.13.0rc1]: https://github.com/Kong/kong/compare/0.12.2...0.13.0rc1
 [0.12.1]: https://github.com/Kong/kong/compare/0.12.0...0.12.1
 [0.12.0]: https://github.com/Kong/kong/compare/0.11.2...0.12.0
 [0.11.2]: https://github.com/Kong/kong/compare/0.11.1...0.11.2

--- a/kong-0.13.0rc1-0.rockspec
+++ b/kong-0.13.0rc1-0.rockspec
@@ -1,9 +1,9 @@
 package = "kong"
-version = "0.12.1-0"
+version = "0.13.0rc1-0"
 supported_platforms = {"linux", "macosx"}
 source = {
   url = "git://github.com/Kong/kong",
-  tag = "0.12.1"
+  tag = "0.13.0rc1"
 }
 description = {
   summary = "Kong is a scalable and customizable API Management Layer built on top of Nginx.",

--- a/kong/meta.lua
+++ b/kong/meta.lua
@@ -1,8 +1,8 @@
 local version = setmetatable({
   major = 0,
-  minor = 12,
-  patch = 1,
-  --suffix = ""
+  minor = 13,
+  patch = 0,
+  suffix = "rc1"
 }, {
   __tostring = function(t)
     return string.format("%d.%d.%d%s", t.major, t.minor, t.patch,


### PR DESCRIPTION
**Formal PR for Kong 0.13.0rc1 - request for reviews!**

* Full list of commits since 0.12.1: https://github.com/Kong/kong/compare/0.12.1...release/0.13.0
* Docs PR: https://github.com/Kong/getkong.org/pull/583

**This officially closes the merging window for 0.13.0rc1 as of today, 2018/02/23.**