### PR TITLE
fix(core) on_error accepts strings and numbers

### DIFF
--- a/kong/api/init.lua
+++ b/kong/api/init.lua
@@ -53,9 +53,8 @@ local function on_error(self)
     else
       return responses.send_HTTP_BAD_REQUEST(err.tbl or err.message)
     end
-  else
-    return responses.send_HTTP_BAD_REQUEST(tostring(err))
   end
+  return responses.send_HTTP_BAD_REQUEST(tostring(err))
 end
 
 

--- a/kong/api/init.lua
+++ b/kong/api/init.lua
@@ -54,7 +54,7 @@ local function on_error(self)
       return responses.send_HTTP_BAD_REQUEST(err.tbl or err.message)
     end
   end
-  return responses.send_HTTP_BAD_REQUEST(tostring(err))
+  return responses.send_HTTP_BAD_REQUEST(err)
 end
 
 

--- a/kong/api/init.lua
+++ b/kong/api/init.lua
@@ -53,6 +53,8 @@ local function on_error(self)
     else
       return responses.send_HTTP_BAD_REQUEST(err.tbl or err.message)
     end
+  else
+    return responses.send_HTTP_BAD_REQUEST(tostring(err))
   end
 end
 


### PR DESCRIPTION
Not defaulting to Lapis error page when parameter is not a table.

### Full changelog

* on_error accept non table parameters  
