### PR TITLE
fix(plugin) checks for deprecated plugins

### DIFF
--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -33,9 +33,19 @@ for i = 1, #plugins do
   plugin_map[plugins[i]] = true
 end
 
+local deprecated_plugins = {
+  "galileo",
+}
+
+local deprecated_plugin_map = {}
+for _, plugin in ipairs(deprecated_plugins) do
+  deprecated_plugin_map[plugin] = true
+end
+
 return {
   PLUGINS_AVAILABLE = plugin_map,
   -- non-standard headers, specific to Kong
+  DEPRECATED_PLUGINS = deprecated_plugin_map,
   HEADERS = {
     HOST_OVERRIDE = "X-Host-Override",
     PROXY_LATENCY = "X-Kong-Proxy-Latency",

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -26,12 +26,11 @@
 
 require "luarocks.loader"
 require "resty.core"
+local constants = require "kong.constants"
 
 do
   -- let's ensure the required shared dictionaries are
   -- declared via lua_shared_dict in the Nginx conf
-
-  local constants = require "kong.constants"
 
   for _, dict in ipairs(constants.DICTS) do
     if not ngx.shared[dict] then
@@ -97,8 +96,8 @@ local function load_plugins(kong_conf, dao)
 
   -- load installed plugins
   for plugin in pairs(kong_conf.plugins) do
-    if plugin == "galileo" then
-      ngx_log(ngx.WARN, "the 'galileo' plugin has been deprecated")
+    if constants.DEPRECATED_PLUGINS[plugin] then
+      ngx.log(ngx.WARN, "plugin '", plugin, "' has been deprecated")
     end
 
     local ok, handler = utils.load_module_if_exists("kong.plugins." .. plugin .. ".handler")

--- a/spec-old-api/02-integration/04-admin_api/02-apis_routes_spec.lua
+++ b/spec-old-api/02-integration/04-admin_api/02-apis_routes_spec.lua
@@ -1228,7 +1228,7 @@ describe("Admin API #" .. kong_config.database, function()
               })
               local body = assert.res_status(400, res)
               local json = cjson.decode(body)
-              assert.same({ config = "Plugin \"foo\" not found" }, json)
+              assert.same({ config = "plugin 'foo' not enabled; add it to the 'custom_plugins' configuration property" }, json)
             end
           end)
         end)

--- a/spec-old-api/02-integration/04-admin_api/03-consumers_routes_spec.lua
+++ b/spec-old-api/02-integration/04-admin_api/03-consumers_routes_spec.lua
@@ -1095,7 +1095,7 @@ describe("Admin API", function()
             })
             local body = assert.res_status(400, res)
             local json = cjson.decode(body)
-            assert.same({ config = "Plugin \"foo\" not found" }, json)
+            assert.same({ config = "plugin 'foo' not enabled; add it to the 'custom_plugins' configuration property" }, json)
           end
         end)
       end)

--- a/spec/02-integration/04-admin_api/02-apis_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/02-apis_routes_spec.lua
@@ -1211,7 +1211,7 @@ pending("Admin API #" .. kong_config.database, function()
               })
               local body = assert.res_status(400, res)
               local json = cjson.decode(body)
-              assert.same({ config = "Plugin \"foo\" not found" }, json)
+              assert.same({ config = "plugin 'foo' not enabled; add it to the 'custom_plugins' configuration property" }, json)
             end
           end)
         end)

--- a/spec/02-integration/04-admin_api/03-consumers_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/03-consumers_routes_spec.lua
@@ -1102,7 +1102,7 @@ describe("Admin API", function()
             })
             local body = assert.res_status(400, res)
             local json = cjson.decode(body)
-            assert.same({ config = "Plugin \"foo\" not found" }, json)
+            assert.same({ config = "plugin 'foo' not enabled; add it to the 'custom_plugins' configuration property" }, json)
           end
         end)
       end)

--- a/spec/02-integration/04-admin_api/23-deprecated_plugin_spec.lua
+++ b/spec/02-integration/04-admin_api/23-deprecated_plugin_spec.lua
@@ -1,0 +1,65 @@
+local helpers = require "spec.helpers"
+local cjson = require "cjson"
+
+describe("Deprecated plugin API" , function()
+  local client
+
+  describe("deprecated not enabled plugins" , function()
+    setup(function()
+      assert(helpers.dao:run_migrations())
+      assert(helpers.start_kong())
+      client = helpers.admin_client()
+    end)
+    teardown(function()
+      if client then
+        client:close()
+      end
+      helpers.stop_kong()
+    end)
+
+    describe("POST" , function()
+      it("returns 400 on non enabled plugin" , function()
+        local res = assert(client:send {
+          method = "POST",
+          path = "/plugins/",
+          body = {
+            name = "admin-api-post-process"
+          },
+          headers = { ["Content-Type"] = "application/json" }
+        })
+        local body = assert.res_status(400 , res)
+        local json = cjson.decode(body)
+        assert.is_equal("plugin 'admin-api-post-process' not enabled; add it to the 'custom_plugins' configuration property", json.config)
+      end)
+    end)
+  end)
+
+  describe("deprecated enabled plugins" , function()
+    setup(function()
+      assert(helpers.start_kong({
+        custom_plugins = "admin-api-post-process"
+      }))
+      client = helpers.admin_client()
+    end)
+    teardown(function()
+      if client then
+        client:close()
+      end
+      helpers.stop_kong()
+    end)
+
+    describe("GET" , function()
+      it("returns 201 for enabled plugin" , function()
+        local res = assert(client:send {
+          method = "POST",
+          path = "/plugins/",
+          body = {
+            name = "admin-api-post-process"
+          },
+          headers = { ["Content-Type"] = "application/json" }
+        })
+        assert.res_status(201 , res)
+      end)
+    end)
+  end)
+end)


### PR DESCRIPTION
### Summary

Currently user can use a plugin which is installed but not enabled, which can be confusing because next time user restart Kong, it will fail as plugin is not enabled.  So this change is to prevent that behavior. Now user would explicitly need to enable the plugin as a custom plugin to use it.

### Full changelog

- added additional schema checks to prevent installed plugin to be applied
  to an api if it's not enabled.
- added a list of deprecated plugins in Constants.lua
- log warning when using deprecated plugin
- added relevent tests
