### PR TITLE
refactor add LOG_FORMAT option

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -29,6 +29,9 @@
                                  # Each Kong process must have a separate
                                  # working directory.
 
+#log_format = combined           # Default nginx log format.
+                                 # KONG_LOG_FORMAT env variable
+
 #log_level = notice              # Log level of the Nginx server. Logs are
                                  # found at <prefix>/logs/error.log
 # Note: See http://nginx.org/en/docs/ngx_core_module.html#error_log for a list

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -29,9 +29,6 @@
                                  # Each Kong process must have a separate
                                  # working directory.
 
-#log_format = combined           # Default nginx log format.
-                                 # KONG_LOG_FORMAT env variable
-
 #log_level = notice              # Log level of the Nginx server. Logs are
                                  # found at <prefix>/logs/error.log
 # Note: See http://nginx.org/en/docs/ngx_core_module.html#error_log for a list

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -46,6 +46,8 @@
                                           # adjusted by the `log_level`
                                           # directive.
 
+#proxy_custom_log_format                  # Custom log format for nginx access log
+
 #admin_access_log = logs/admin_access.log # Path for Admin API request access
                                           # logs. Set this value to `off` to
                                           # disable logging Admin API requests.
@@ -57,6 +59,8 @@
                                           # logs. Granularity of these logs is
                                           # adjusted by the `log_level`
                                           # directive.
+
+#admin_custom_log_format                  # Custom log format for nginx admin log
 
 #custom_plugins =                # Comma-separated list of additional plugins
                                  # this node should load.

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -3,8 +3,10 @@ prefix = /usr/local/kong/
 log_level = notice
 proxy_access_log = logs/access.log
 proxy_error_log = logs/error.log
+proxy_log_format = combined
 admin_access_log = logs/admin_access.log
 admin_error_log = logs/error.log
+admin_log_format = combined
 custom_plugins = NONE
 anonymous_reports = on
 

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -65,7 +65,11 @@ server {
     error_page 400 404 408 411 412 413 414 417 /kong_error_handler;
     error_page 500 502 503 504 /kong_error_handler;
 
-    access_log ${{PROXY_ACCESS_LOG}};
+> if proxy_custom_log_format then
+    ${{PROXY_CUSTOM_LOG_FORMAT}}
+> end
+
+    access_log ${{PROXY_ACCESS_LOG}} ${{PROXY_LOG_FORMAT}};
     error_log ${{PROXY_ERROR_LOG}} ${{LOG_LEVEL}};
 
     client_body_buffer_size ${{CLIENT_BODY_BUFFER_SIZE}};
@@ -154,7 +158,11 @@ server {
     server_name kong_admin;
     listen ${{ADMIN_LISTEN}};
 
-    access_log ${{ADMIN_ACCESS_LOG}};
+> if admin_custom_log_format then
+    ${{ADMIN_CUSTOM_LOG_FORMAT}}
+> end
+
+    access_log ${{ADMIN_ACCESS_LOG}} ${{ADMIN_LOG_FORMAT}};
     error_log ${{ADMIN_ERROR_LOG}} ${{LOG_LEVEL}};
 
     client_max_body_size 10m;

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -65,7 +65,7 @@ server {
     error_page 400 404 408 411 412 413 414 417 /kong_error_handler;
     error_page 500 502 503 504 /kong_error_handler;
 
-    access_log ${{PROXY_ACCESS_LOG}} ${{LOG_FORMAT}};
+    access_log ${{PROXY_ACCESS_LOG}};
     error_log ${{PROXY_ERROR_LOG}} ${{LOG_LEVEL}};
 
     client_body_buffer_size ${{CLIENT_BODY_BUFFER_SIZE}};
@@ -154,7 +154,7 @@ server {
     server_name kong_admin;
     listen ${{ADMIN_LISTEN}};
 
-    access_log ${{ADMIN_ACCESS_LOG}} ${{LOG_FORMAT}};
+    access_log ${{ADMIN_ACCESS_LOG}};
     error_log ${{ADMIN_ERROR_LOG}} ${{LOG_LEVEL}};
 
     client_max_body_size 10m;

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -65,7 +65,7 @@ server {
     error_page 400 404 408 411 412 413 414 417 /kong_error_handler;
     error_page 500 502 503 504 /kong_error_handler;
 
-    access_log ${{PROXY_ACCESS_LOG}};
+    access_log ${{PROXY_ACCESS_LOG}} ${{LOG_FORMAT}};
     error_log ${{PROXY_ERROR_LOG}} ${{LOG_LEVEL}};
 
     client_body_buffer_size ${{CLIENT_BODY_BUFFER_SIZE}};
@@ -154,7 +154,7 @@ server {
     server_name kong_admin;
     listen ${{ADMIN_LISTEN}};
 
-    access_log ${{ADMIN_ACCESS_LOG}};
+    access_log ${{ADMIN_ACCESS_LOG}} ${{LOG_FORMAT}};
     error_log ${{ADMIN_ERROR_LOG}} ${{LOG_LEVEL}};
 
     client_max_body_size 10m;


### PR DESCRIPTION
### Summary

According to this [https://getkong.org/docs/0.12.x/configuration/#custom-nginx-configuration-embedding-kong](document) there are two ways of using custom template:
* tune global nginx configuration
* inline `nginx_kong.lua` in global

First method is pretty cool and easy. And it doesn't break in case of change in `nginx_kong.lua`. So it's a pretty solid way to add functionality. Second method involves more maintenance as every update we have to check what was changed in templates, backport the changes into our custom template and try to re-build image (yes we run docker).

Desired way of defining log format for nginx:
```
http {
     # custome configuration goes here:
     map $upstream_response_time $temprt {
       default $upstream_response_time;
       ""      0;
     }
     log_format json '{ "@timestamp": "$time_iso8601", '
                        '"remote_addr": "$remote_addr", '
                        '"body_bytes_sent": "$body_bytes_sent", '
                        '"status": $status, '
                        '"request": "$request", '
                        '"url": "$uri", '
                        '"request_method": "$request_method", '
                        '"response_time": $temprt, '
                        '"http_referrer": "$http_referer", '
                        '"http_user_agent": "$http_user_agent" }';
     
     access_log ${{PROXY_ACCESS_LOG}} json;
     # include default Kong Nginx config
     include 'nginx-kong.conf';
}
```

But in current situation we need to inline whole `nginx_kong.lua` in order to append `access_log...`  with `json` in the end.

### Full changelog

* Add LOG_FORMAT option to `nginx_kong.lua` template
* Add log_forma option to `kong.conf.default`