### PR TITLE
fix(core) remove a memory leak introduced in the DB caching

### DIFF
--- a/kong/cache.lua
+++ b/kong/cache.lua
@@ -32,30 +32,6 @@ local function log(lvl, ...)
 end
 
 
--- Temporary fix to convert soft callback errors into hard ones.
--- FIXME: use upstream mlcache lib instead of local copy
-local soft_to_hard
-do
-  local s2h_cache = setmetatable({}, { __mode = "k" })
-
-  local function create_wrapper(key, cb)
-    s2h_cache[key] = function(...)
-      local result, err = cb(...)
-      if err then
-        error(err)
-      end
-      return result
-    end
-    return s2h_cache[key]
-  end
-
-
-  soft_to_hard = function(key, cb)
-    return s2h_cache[key] or create_wrapper(key, cb)
-  end
-end
-
-
 local _M = {}
 local mt = { __index = _M }
 
@@ -131,7 +107,7 @@ function _M:get(key, opts, cb, ...)
 
   --log(DEBUG, "get from key: ", key)
 
-  local v, err = self.mlcache:get(key, opts, soft_to_hard(key, cb), ...)
+  local v, err = self.mlcache:get(key, opts, cb, ...)
   if err then
     return nil, "failed to get from node cache: " .. err
   end

--- a/kong/cache.lua
+++ b/kong/cache.lua
@@ -37,21 +37,21 @@ end
 local soft_to_hard
 do
   local s2h_cache = setmetatable({}, { __mode = "k" })
-  
-  local function create_wrapper(cb)
-    s2h_cache[cb] = function(...)
+
+  local function create_wrapper(key, cb)
+    s2h_cache[key] = function(...)
       local result, err = cb(...)
       if err then
         error(err)
       end
       return result
     end
-    return s2h_cache[cb]
+    return s2h_cache[key]
   end
 
 
-  soft_to_hard = function(cb)
-    return s2h_cache[cb] or create_wrapper(cb)
+  soft_to_hard = function(key, cb)
+    return s2h_cache[key] or create_wrapper(key, cb)
   end
 end
 
@@ -131,7 +131,7 @@ function _M:get(key, opts, cb, ...)
 
   --log(DEBUG, "get from key: ", key)
 
-  local v, err = self.mlcache:get(key, opts, soft_to_hard(cb), ...)
+  local v, err = self.mlcache:get(key, opts, soft_to_hard(key, cb), ...)
   if err then
     return nil, "failed to get from node cache: " .. err
   end

--- a/kong/core/handler.lua
+++ b/kong/core/handler.lua
@@ -325,7 +325,7 @@ return {
 
       local version, err = singletons.cache:get("router:version", {
         ttl = 0
-      }, function() return utils.uuid() end)
+      }, utils.uuid)
       if err then
         log(ngx.CRIT, "could not ensure router is up to date: ", err)
 

--- a/kong/mlcache.lua
+++ b/kong/mlcache.lua
@@ -407,12 +407,19 @@ function _M:get(key, opts, cb, ...)
 
     -- still not in shm, we are responsible for running the callback
 
-    local ok, err = pcall(cb, ...)
-    if not ok then
-        return unlock_and_ret(lock, nil, "callback threw an error: " .. err)
+    local pok, perr, err = pcall(cb, ...)
+    if not pok then
+        return unlock_and_ret(lock, nil, "callback threw an error: " .. perr)
     end
 
-    local value, err = shmlru_set(self, key, err, ttl, neg_ttl)
+    data = perr
+
+    if err then
+        -- callback returned data + err
+        return unlock_and_ret(lock, data, err)
+    end
+
+    local value, err = shmlru_set(self, key, data, ttl, neg_ttl)
     if err then
         return unlock_and_ret(lock, nil, err)
     end


### PR DESCRIPTION
This fixes a regression introduced in de6390e34c5301aa4c965d52f08e00ab81f91efa and released in 0.12.2 and 0.13.0rc1. It was reported in #3277 and investigated by @hishamhm and myself.

This PR takes a conservative approach at fixing the underlying issues: we introduce 3 commits from less to most disruptive, in an attempt to release a safe 0.12.3 hotfix:

- avoid generated-on-the-fly cache callback closure in the router cache
- use a different caching key for `soft_to_hard_error` wrapping closure that does not prevent the underlying callback from being GC'ed.
- backport an upstream mlcache feature to get rid of the (temporary) `soft_to_hard_error` wrapper workaround altogether (https://github.com/thibaultcha/lua-resty-mlcache/commit/4fdfbb976a9b4cda0f277ffc71294a14481a9c4d)