### PR TITLE
[next] tests(*) improve timeouts and refactor duplication in udp/tcp tests

### DIFF
--- a/spec-old-api/03-plugins/06-statsd/01-log_spec.lua
+++ b/spec-old-api/03-plugins/06-statsd/01-log_spec.lua
@@ -281,25 +281,7 @@ describe("Plugin: statsd (log)", function()
 
   describe("metrics", function()
     it("logs over UDP with default metrics", function()
-      local threads = require "llthreads2.ex"
-
-      local thread = threads.new({
-        function(port)
-          local socket = require "socket"
-          local server = assert(socket.udp())
-          server:settimeout(1)
-          server:setoption("reuseaddr", true)
-          server:setsockname("127.0.0.1", port)
-          local metrics = {}
-          for i = 1, 12 do
-            metrics[#metrics+1] = server:receive()
-          end
-          server:close()
-          return metrics
-        end
-      }, UDP_PORT)
-      thread:start()
-      ngx.sleep(0.1)
+      local thread = helpers.udp_server(UDP_PORT, 12)
 
       local response = assert(client:send {
         method = "GET",
@@ -328,25 +310,7 @@ describe("Plugin: statsd (log)", function()
                       metrics)
     end)
     it("logs over UDP with default metrics and new prefix", function()
-      local threads = require "llthreads2.ex"
-
-      local thread = threads.new({
-        function(port)
-          local socket = require "socket"
-          local server = assert(socket.udp())
-          server:settimeout(1)
-          server:setoption("reuseaddr", true)
-          server:setsockname("127.0.0.1", port)
-          local metrics = {}
-          for i = 1, 12 do
-            metrics[#metrics+1] = server:receive()
-          end
-          server:close()
-          return metrics
-        end
-      }, UDP_PORT)
-      thread:start()
-      ngx.sleep(0.1)
+      local thread = helpers.udp_server(UDP_PORT, 12)
 
       local response = assert(client:send {
         method = "GET",
@@ -389,25 +353,7 @@ describe("Plugin: statsd (log)", function()
       assert.equal("kong.stastd5.request.count:1|c", res)
     end)
     it("status_count", function()
-      local threads = require "llthreads2.ex"
-
-      local thread = threads.new({
-        function(port)
-          local socket = require "socket"
-          local server = assert(socket.udp())
-          server:settimeout(1)
-          server:setoption("reuseaddr", true)
-          server:setsockname("127.0.0.1", port)
-          local metrics = {}
-          for i = 1, 2 do
-            metrics[#metrics+1] = server:receive()
-          end
-          server:close()
-          return metrics
-        end
-      }, UDP_PORT)
-      thread:start()
-      ngx.sleep(0.1)
+      local thread = helpers.udp_server(UDP_PORT, 2)
 
       local response = assert(client:send {
         method = "GET",
@@ -514,25 +460,7 @@ describe("Plugin: statsd (log)", function()
       assert.matches("kong.stastd9.user.uniques:robert|s", res)
     end)
     it("status_count_per_user", function()
-      local threads = require "llthreads2.ex"
-
-      local thread = threads.new({
-        function(port)
-          local socket = require "socket"
-          local server = assert(socket.udp())
-          server:settimeout(1)
-          server:setoption("reuseaddr", true)
-          server:setsockname("127.0.0.1", port)
-          local metrics = {}
-          for i = 1, 2 do
-            metrics[#metrics+1] = server:receive()
-          end
-          server:close()
-          return metrics
-        end
-      }, UDP_PORT)
-      thread:start()
-      ngx.sleep(0.1)
+      local thread = helpers.udp_server(UDP_PORT, 2)
 
       local response = assert(client:send {
         method = "GET",

--- a/spec-old-api/03-plugins/08-datadog/01-log_spec.lua
+++ b/spec-old-api/03-plugins/08-datadog/01-log_spec.lua
@@ -1,5 +1,4 @@
 local helpers = require "spec.helpers"
-local threads = require "llthreads2.ex"
 local pl_file = require "pl.file"
 
 describe("Plugin: datadog (log)", function()
@@ -121,23 +120,7 @@ describe("Plugin: datadog (log)", function()
   end)
 
   it("logs metrics over UDP", function()
-    local thread = threads.new({
-      function()
-        local socket = require "socket"
-        local server = assert(socket.udp())
-        server:settimeout(1)
-        server:setoption("reuseaddr", true)
-        server:setsockname("127.0.0.1", 9999)
-        local gauges = {}
-        for _ = 1, 12 do
-          gauges[#gauges+1] = server:receive()
-        end
-        server:close()
-        return gauges
-      end
-    })
-    thread:start()
-    ngx.sleep(0.1)
+    local thread = helpers.udp_server(9999, 12)
 
     local res = assert(client:send {
       method = "GET",
@@ -168,23 +151,7 @@ describe("Plugin: datadog (log)", function()
   end)
 
   it("logs metrics over UDP with custome prefix", function()
-    local thread = threads.new({
-      function()
-        local socket = require "socket"
-        local server = assert(socket.udp())
-        server:settimeout(1)
-        server:setoption("reuseaddr", true)
-        server:setsockname("127.0.0.1", 9999)
-        local gauges = {}
-        for _ = 1, 12 do
-          gauges[#gauges+1] = server:receive()
-        end
-        server:close()
-        return gauges
-      end
-    })
-    thread:start()
-    ngx.sleep(0.1)
+    local thread = helpers.udp_server(9999, 12)
 
     local res = assert(client:send {
       method = "GET",
@@ -216,23 +183,7 @@ describe("Plugin: datadog (log)", function()
   end)
 
   it("logs only given metrics", function()
-    local thread = threads.new({
-      function()
-        local socket = require "socket"
-        local server = assert(socket.udp())
-        server:settimeout(1)
-        server:setoption("reuseaddr", true)
-        server:setsockname("127.0.0.1", 9999)
-        local gauges = {}
-        for _ = 1, 3 do
-          gauges[#gauges+1] = server:receive()
-        end
-        server:close()
-        return gauges
-      end
-    })
-    thread:start()
-    ngx.sleep(0.1)
+    local thread = helpers.udp_server(9999, 3)
 
     local res = assert(client:send {
       method = "GET",
@@ -252,23 +203,7 @@ describe("Plugin: datadog (log)", function()
   end)
 
   it("logs metrics with tags", function()
-    local thread = threads.new({
-      function()
-        local socket = require "socket"
-        local server = assert(socket.udp())
-        server:settimeout(1)
-        server:setoption("reuseaddr", true)
-        server:setsockname("127.0.0.1", 9999)
-        local gauges = {}
-        for _ = 1, 4 do
-          gauges[#gauges+1] = server:receive()
-        end
-        server:close()
-        return gauges
-      end
-    })
-    thread:start()
-    ngx.sleep(0.1)
+    local thread = helpers.udp_server(9999, 4)
 
     local res = assert(client:send {
       method = "GET",
@@ -288,20 +223,7 @@ describe("Plugin: datadog (log)", function()
   end)
 
   it("should not return a runtime error (regression)", function()
-    local thread = threads.new({
-      function()
-        local socket = require "socket"
-        local server = assert(socket.udp())
-        server:settimeout(1)
-        server:setoption("reuseaddr", true)
-        server:setsockname("127.0.0.1", 9999)
-        local gauge = server:receive()
-        server:close()
-        return gauge
-      end
-    })
-    thread:start()
-    ngx.sleep(0.1)
+    helpers.udp_server(9999, 1, 1)
 
     local res = assert(client:send {
       method = "GET",

--- a/spec/01-unit/013-reports_spec.lua
+++ b/spec/01-unit/013-reports_spec.lua
@@ -40,7 +40,7 @@ describe("reports", function()
     it("doesn't send if not enabled", function()
       reports.toggle(false)
 
-      local thread = helpers.udp_server(8189)
+      local thread = helpers.udp_server(8189, 1, 0.1)
 
       reports.send({
         foo = "bar"

--- a/spec/03-plugins/06-statsd/01-log_spec.lua
+++ b/spec/03-plugins/06-statsd/01-log_spec.lua
@@ -247,24 +247,7 @@ for _, strategy in helpers.each_strategy() do
 
     describe("metrics", function()
       it("logs over UDP with default metrics", function()
-        local threads = require "llthreads2.ex"
-
-        local thread = threads.new({
-          function(port)
-            local socket = require "socket"
-            local server = assert(socket.udp())
-            server:settimeout(1)
-            server:setoption("reuseaddr", true)
-            server:setsockname("127.0.0.1", port)
-            local metrics = {}
-            for i = 1, 12 do
-              metrics[#metrics+1] = server:receive()
-            end
-            server:close()
-            return metrics
-          end
-        }, UDP_PORT)
-        thread:start()
+        local thread = helpers.udp_server(UDP_PORT, 12)
 
         local response = assert(proxy_client:send {
           method  = "GET",
@@ -293,24 +276,8 @@ for _, strategy in helpers.each_strategy() do
                         metrics)
       end)
       it("logs over UDP with default metrics and new prefix", function()
-        local threads = require "llthreads2.ex"
 
-        local thread = threads.new({
-          function(port)
-            local socket = require "socket"
-            local server = assert(socket.udp())
-            server:settimeout(1)
-            server:setoption("reuseaddr", true)
-            server:setsockname("127.0.0.1", port)
-            local metrics = {}
-            for i = 1, 12 do
-              metrics[#metrics+1] = server:receive()
-            end
-            server:close()
-            return metrics
-          end
-        }, UDP_PORT)
-        thread:start()
+        local thread = helpers.udp_server(UDP_PORT, 12)
 
         local response = assert(proxy_client:send {
           method  = "GET",
@@ -353,24 +320,8 @@ for _, strategy in helpers.each_strategy() do
         assert.equal("kong.statsd5.request.count:1|c", res)
       end)
       it("status_count", function()
-        local threads = require "llthreads2.ex"
+        local thread = helpers.udp_server(UDP_PORT, 2)
 
-        local thread = threads.new({
-          function(port)
-            local socket = require "socket"
-            local server = assert(socket.udp())
-            server:settimeout(1)
-            server:setoption("reuseaddr", true)
-            server:setsockname("127.0.0.1", port)
-            local metrics = {}
-            for i = 1, 2 do
-              metrics[#metrics+1] = server:receive()
-            end
-            server:close()
-            return metrics
-          end
-        }, UDP_PORT)
-        thread:start()
         local response = assert(proxy_client:send {
           method  = "GET",
           path    = "/request",
@@ -476,24 +427,7 @@ for _, strategy in helpers.each_strategy() do
         assert.matches("kong.statsd9.user.uniques:robert|s", res)
       end)
       it("status_count_per_user", function()
-        local threads = require "llthreads2.ex"
-
-        local thread = threads.new({
-          function(port)
-            local socket = require "socket"
-            local server = assert(socket.udp())
-            server:settimeout(1)
-            server:setoption("reuseaddr", true)
-            server:setsockname("127.0.0.1", port)
-            local metrics = {}
-            for i = 1, 2 do
-              metrics[#metrics+1] = server:receive()
-            end
-            server:close()
-            return metrics
-          end
-        }, UDP_PORT)
-        thread:start()
+        local thread = helpers.udp_server(UDP_PORT, 2)
         local response = assert(proxy_client:send {
           method  = "GET",
           path    = "/request?apikey=kong",

--- a/spec/03-plugins/08-datadog/01-log_spec.lua
+++ b/spec/03-plugins/08-datadog/01-log_spec.lua
@@ -1,5 +1,4 @@
 local helpers = require "spec.helpers"
-local threads = require "llthreads2.ex"
 local pl_file = require "pl.file"
 
 
@@ -135,23 +134,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     it("logs metrics over UDP", function()
-      local thread = threads.new({
-        function()
-          local socket = require "socket"
-          local server = assert(socket.udp())
-          server:settimeout(1)
-          server:setoption("reuseaddr", true)
-          server:setsockname("127.0.0.1", 9999)
-          local gauges = {}
-          for _ = 1, 12 do
-            gauges[#gauges+1] = server:receive()
-          end
-          server:close()
-          return gauges
-        end
-      })
-      thread:start()
-      ngx.sleep(0.1)
+      local thread = helpers.udp_server(9999, 12)
 
       local res = assert(proxy_client:send {
         method  = "GET",
@@ -182,23 +165,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     it("logs metrics over UDP with custom prefix", function()
-      local thread = threads.new({
-        function()
-          local socket = require "socket"
-          local server = assert(socket.udp())
-          server:settimeout(1)
-          server:setoption("reuseaddr", true)
-          server:setsockname("127.0.0.1", 9999)
-          local gauges = {}
-          for _ = 1, 12 do
-            gauges[#gauges+1] = server:receive()
-          end
-          server:close()
-          return gauges
-        end
-      })
-      thread:start()
-      ngx.sleep(0.1)
+      local thread = helpers.udp_server(9999, 12)
 
       local res = assert(proxy_client:send {
         method  = "GET",
@@ -230,23 +197,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     it("logs only given metrics", function()
-      local thread = threads.new({
-        function()
-          local socket = require "socket"
-          local server = assert(socket.udp())
-          server:settimeout(1)
-          server:setoption("reuseaddr", true)
-          server:setsockname("127.0.0.1", 9999)
-          local gauges = {}
-          for _ = 1, 3 do
-            gauges[#gauges+1] = server:receive()
-          end
-          server:close()
-          return gauges
-        end
-      })
-      thread:start()
-      ngx.sleep(0.1)
+      local thread = helpers.udp_server(9999, 3)
 
       local res = assert(proxy_client:send {
         method  = "GET",
@@ -266,23 +217,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     it("logs metrics with tags", function()
-      local thread = threads.new({
-        function()
-          local socket = require "socket"
-          local server = assert(socket.udp())
-          server:settimeout(1)
-          server:setoption("reuseaddr", true)
-          server:setsockname("127.0.0.1", 9999)
-          local gauges = {}
-          for _ = 1, 4 do
-            gauges[#gauges+1] = server:receive()
-          end
-          server:close()
-          return gauges
-        end
-      })
-      thread:start()
-      ngx.sleep(0.1)
+      local thread = helpers.udp_server(9999, 4)
 
       local res = assert(proxy_client:send {
         method  = "GET",
@@ -302,20 +237,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     it("should not return a runtime error (regression)", function()
-      local thread = threads.new({
-        function()
-          local socket = require "socket"
-          local server = assert(socket.udp())
-          server:settimeout(1)
-          server:setoption("reuseaddr", true)
-          server:setsockname("127.0.0.1", 9999)
-          local gauge = server:receive()
-          server:close()
-          return gauge
-        end
-      })
-      thread:start()
-      ngx.sleep(0.1)
+      helpers.udp_server(9999, 1, 1)
 
       local res = assert(proxy_client:send {
         method  = "GET",

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -436,7 +436,7 @@ local function tcp_server(port, opts, ...)
     function(port, opts)
       local socket = require "socket"
       local server = assert(socket.tcp())
-      server:settimeout(10)
+      server:settimeout(360)
       assert(server:setoption('reuseaddr', true))
       assert(server:bind("*", port))
       assert(server:listen())
@@ -519,26 +519,57 @@ end
 -- Accepts a single connection, reading once and then closes
 -- @name udp_server
 -- @param `port`    The port where the server will be listening to
+-- @param `n`       The number of packets that will be received
+-- @param `timeout` Timeout per read
 -- @return `thread` A thread object
-local function udp_server(port)
+local function udp_server(port, n, timeout)
   local threads = require "llthreads2.ex"
 
   local thread = threads.new({
-    function(port)
+    function(port, n, timeout)
       local socket = require "socket"
       local server = assert(socket.udp())
-      server:settimeout(5)
+      server:settimeout(timeout or 360)
       server:setoption("reuseaddr", true)
       server:setsockname("127.0.0.1", port)
-      local data, err = server:receive()
+      local err
+      local data = {}
+      local handshake_done = false
+      local i = 0
+      while i < n do
+        local pkt, rport
+        pkt, err, rport = server:receivefrom()
+        if not pkt then
+          break
+        end
+        if pkt == "KONG_UDP_HELLO" then
+          if not handshake_done then
+            handshake_done = true
+            server:sendto("KONG_UDP_READY", "127.0.0.1", rport)
+          end
+        else
+          i = i + 1
+          data[i] = pkt
+        end
+      end
       server:close()
-      return data, err
+      return (n > 1 and data or data[1]), err
     end
-  }, port or MOCK_UPSTREAM_PORT)
-
+  }, port or MOCK_UPSTREAM_PORT, n or 1, timeout)
   thread:start()
 
-  ngx.sleep(0.1)
+  local socket = require "socket"
+  local handshake = socket.udp()
+  handshake:settimeout(0.01)
+  handshake:setsockname("127.0.0.1", 0)
+  while true do
+    handshake:sendto("KONG_UDP_HELLO", "127.0.0.1", port)
+    local data = handshake:receive()
+    if data == "KONG_UDP_READY" then
+      break
+    end
+  end
+  handshake:close()
 
   return thread
 end


### PR DESCRIPTION
This is done in two commits because there is a part that is common on `master` and `next`, and one that is `next`-specific.

* Adds arguments for number of packets and timeout value in `helpers.udp_server`
* Increases default TCP and UDP timeouts to 360 seconds as a safety net for CI slowness, but no test should be designed to wait for the entire timeout
* Removes all repeated instances of customized UDP servers that only differ in the number of packets received, making their behavior more consistent in the process.

This modifies tests for `statsd` and `datadog` in both `spec/` and `spec-old-api/`.