### PR TITLE
[master] tests(*) improve timeouts and refactor duplication in udp/tcp tests

### DIFF
--- a/spec/01-unit/013-reports_spec.lua
+++ b/spec/01-unit/013-reports_spec.lua
@@ -40,7 +40,7 @@ describe("reports", function()
     it("doesn't send if not enabled", function()
       reports.toggle(false)
 
-      local thread = helpers.udp_server(8189)
+      local thread = helpers.udp_server(8189, 1, 0.1)
 
       reports.send({
         foo = "bar"

--- a/spec/03-plugins/06-statsd/01-log_spec.lua
+++ b/spec/03-plugins/06-statsd/01-log_spec.lua
@@ -281,25 +281,7 @@ describe("Plugin: statsd (log)", function()
 
   describe("metrics", function()
     it("logs over UDP with default metrics", function()
-      local threads = require "llthreads2.ex"
-
-      local thread = threads.new({
-        function(port)
-          local socket = require "socket"
-          local server = assert(socket.udp())
-          server:settimeout(1)
-          server:setoption("reuseaddr", true)
-          server:setsockname("127.0.0.1", port)
-          local metrics = {}
-          for i = 1, 12 do
-            metrics[#metrics+1] = server:receive()
-          end
-          server:close()
-          return metrics
-        end
-      }, UDP_PORT)
-      thread:start()
-      ngx.sleep(0.1)
+      local thread = helpers.udp_server(UDP_PORT, 12)
 
       local response = assert(client:send {
         method = "GET",
@@ -328,25 +310,7 @@ describe("Plugin: statsd (log)", function()
                       metrics)
     end)
     it("logs over UDP with default metrics and new prefix", function()
-      local threads = require "llthreads2.ex"
-
-      local thread = threads.new({
-        function(port)
-          local socket = require "socket"
-          local server = assert(socket.udp())
-          server:settimeout(1)
-          server:setoption("reuseaddr", true)
-          server:setsockname("127.0.0.1", port)
-          local metrics = {}
-          for i = 1, 12 do
-            metrics[#metrics+1] = server:receive()
-          end
-          server:close()
-          return metrics
-        end
-      }, UDP_PORT)
-      thread:start()
-      ngx.sleep(0.1)
+      local thread = helpers.udp_server(UDP_PORT, 12)
 
       local response = assert(client:send {
         method = "GET",
@@ -389,25 +353,7 @@ describe("Plugin: statsd (log)", function()
       assert.equal("kong.stastd5.request.count:1|c", res)
     end)
     it("status_count", function()
-      local threads = require "llthreads2.ex"
-
-      local thread = threads.new({
-        function(port)
-          local socket = require "socket"
-          local server = assert(socket.udp())
-          server:settimeout(1)
-          server:setoption("reuseaddr", true)
-          server:setsockname("127.0.0.1", port)
-          local metrics = {}
-          for i = 1, 2 do
-            metrics[#metrics+1] = server:receive()
-          end
-          server:close()
-          return metrics
-        end
-      }, UDP_PORT)
-      thread:start()
-      ngx.sleep(0.1)
+      local thread = helpers.udp_server(UDP_PORT, 2)
 
       local response = assert(client:send {
         method = "GET",
@@ -514,25 +460,7 @@ describe("Plugin: statsd (log)", function()
       assert.matches("kong.stastd9.user.uniques:robert|s", res)
     end)
     it("status_count_per_user", function()
-      local threads = require "llthreads2.ex"
-
-      local thread = threads.new({
-        function(port)
-          local socket = require "socket"
-          local server = assert(socket.udp())
-          server:settimeout(1)
-          server:setoption("reuseaddr", true)
-          server:setsockname("127.0.0.1", port)
-          local metrics = {}
-          for i = 1, 2 do
-            metrics[#metrics+1] = server:receive()
-          end
-          server:close()
-          return metrics
-        end
-      }, UDP_PORT)
-      thread:start()
-      ngx.sleep(0.1)
+      local thread = helpers.udp_server(UDP_PORT, 2)
 
       local response = assert(client:send {
         method = "GET",

--- a/spec/03-plugins/08-datadog/01-log_spec.lua
+++ b/spec/03-plugins/08-datadog/01-log_spec.lua
@@ -1,5 +1,4 @@
 local helpers = require "spec.helpers"
-local threads = require "llthreads2.ex"
 local pl_file = require "pl.file"
 
 describe("Plugin: datadog (log)", function()
@@ -121,23 +120,7 @@ describe("Plugin: datadog (log)", function()
   end)
 
   it("logs metrics over UDP", function()
-    local thread = threads.new({
-      function()
-        local socket = require "socket"
-        local server = assert(socket.udp())
-        server:settimeout(1)
-        server:setoption("reuseaddr", true)
-        server:setsockname("127.0.0.1", 9999)
-        local gauges = {}
-        for _ = 1, 12 do
-          gauges[#gauges+1] = server:receive()
-        end
-        server:close()
-        return gauges
-      end
-    })
-    thread:start()
-    ngx.sleep(0.1)
+    local thread = helpers.udp_server(9999, 12)
 
     local res = assert(client:send {
       method = "GET",
@@ -168,23 +151,7 @@ describe("Plugin: datadog (log)", function()
   end)
 
   it("logs metrics over UDP with custome prefix", function()
-    local thread = threads.new({
-      function()
-        local socket = require "socket"
-        local server = assert(socket.udp())
-        server:settimeout(1)
-        server:setoption("reuseaddr", true)
-        server:setsockname("127.0.0.1", 9999)
-        local gauges = {}
-        for _ = 1, 12 do
-          gauges[#gauges+1] = server:receive()
-        end
-        server:close()
-        return gauges
-      end
-    })
-    thread:start()
-    ngx.sleep(0.1)
+    local thread = helpers.udp_server(9999, 12)
 
     local res = assert(client:send {
       method = "GET",
@@ -216,23 +183,7 @@ describe("Plugin: datadog (log)", function()
   end)
 
   it("logs only given metrics", function()
-    local thread = threads.new({
-      function()
-        local socket = require "socket"
-        local server = assert(socket.udp())
-        server:settimeout(1)
-        server:setoption("reuseaddr", true)
-        server:setsockname("127.0.0.1", 9999)
-        local gauges = {}
-        for _ = 1, 3 do
-          gauges[#gauges+1] = server:receive()
-        end
-        server:close()
-        return gauges
-      end
-    })
-    thread:start()
-    ngx.sleep(0.1)
+    local thread = helpers.udp_server(9999, 3)
 
     local res = assert(client:send {
       method = "GET",
@@ -252,23 +203,7 @@ describe("Plugin: datadog (log)", function()
   end)
 
   it("logs metrics with tags", function()
-    local thread = threads.new({
-      function()
-        local socket = require "socket"
-        local server = assert(socket.udp())
-        server:settimeout(1)
-        server:setoption("reuseaddr", true)
-        server:setsockname("127.0.0.1", 9999)
-        local gauges = {}
-        for _ = 1, 4 do
-          gauges[#gauges+1] = server:receive()
-        end
-        server:close()
-        return gauges
-      end
-    })
-    thread:start()
-    ngx.sleep(0.1)
+    local thread = helpers.udp_server(9999, 4)
 
     local res = assert(client:send {
       method = "GET",
@@ -288,20 +223,7 @@ describe("Plugin: datadog (log)", function()
   end)
 
   it("should not return a runtime error (regression)", function()
-    local thread = threads.new({
-      function()
-        local socket = require "socket"
-        local server = assert(socket.udp())
-        server:settimeout(1)
-        server:setoption("reuseaddr", true)
-        server:setsockname("127.0.0.1", 9999)
-        local gauge = server:receive()
-        server:close()
-        return gauge
-      end
-    })
-    thread:start()
-    ngx.sleep(0.1)
+    helpers.udp_server(9999, 1, 1)
 
     local res = assert(client:send {
       method = "GET",


### PR DESCRIPTION
This is done in two commits because there is a part that is common on `master` and `next`, and one that is `master`-specific.

* Adds arguments for number of packets and timeout value in helpers.udp_server
* Increases default TCP and UDP timeouts to 360 seconds as a safety net for CI slowness, but no test should be designed to wait for the entire timeout
* Removes all repeated instances of customized UDP servers that only differ in the number of packets received, making their behavior more consistent in the process.

This modifies tests for `statsd` and `datadog` in  `spec/`. Based on PR #3282.