### PR TITLE
chore(deps) bump lua-multipart version from 0.5.4 to 0.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [Scheduled](#scheduled)
 - [Released](#released)
+    - [0.13.0rc3](#0130rc3)
     - [0.13.0rc2](#0130rc2)
     - [0.12.3](#0123---20180312)
     - [0.13.0rc1](#0130rc1)
@@ -29,6 +30,15 @@ a detailed changeset of their content.
 
 This section describes publicly available releases and a detailed changeset of
 their content.
+
+## [0.13.0rc3]
+
+### Changed
+
+##### Dependencies
+
+- Bumped [lua-multipart](https://github.com/Kong/lua-multipart) to `0.5.5`.
+  [#3290](https://github.com/Kong/kong/pull/3290)
 
 ## [0.13.0rc2]
 

--- a/kong-0.13.0rc2-0.rockspec
+++ b/kong-0.13.0rc2-0.rockspec
@@ -16,7 +16,7 @@ dependencies = {
   "penlight == 1.5.4",
   "lua-resty-http == 0.12",
   "lua-resty-jit-uuid == 0.0.7",
-  "multipart == 0.5.4",
+  "multipart == 0.5.5",
   "version == 0.2",
   "kong-lapis == 1.6.0.1",
   "lua-cassandra == 1.2.3",


### PR DESCRIPTION
### Summary

Bumps `multipart` from `0.5.4` to `0.5.5`.