### PR TITLE
fix(plugins) basic auth plugin no longer salts with 'nil' if credenti…

### DIFF
--- a/kong/plugins/basic-auth/crypto.lua
+++ b/kong/plugins/basic-auth/crypto.lua
@@ -8,7 +8,11 @@ local format = string.format
 -- Password is salted with the credential's consumer_id (long enough, unique)
 -- @param credential The basic auth credential table
 local function salt_password(credential)
-  return format("%s%s", credential.password or "", credential.consumer_id)
+  local password = credential.password
+  if password == nil or password == ngx.null then
+    password = ""
+  end
+  return format("%s%s", password, credential.consumer_id)
 end
 
 return {

--- a/kong/plugins/basic-auth/crypto.lua
+++ b/kong/plugins/basic-auth/crypto.lua
@@ -8,7 +8,7 @@ local format = string.format
 -- Password is salted with the credential's consumer_id (long enough, unique)
 -- @param credential The basic auth credential table
 local function salt_password(credential)
-  return format("%s%s", credential.password, credential.consumer_id)
+  return format("%s%s", credential.password or "", credential.consumer_id)
 end
 
 return {

--- a/spec/03-plugins/11-basic-auth/01-crypto_spec.lua
+++ b/spec/03-plugins/11-basic-auth/01-crypto_spec.lua
@@ -13,7 +13,7 @@ describe("Plugin: basic-auth (crypto)", function()
     assert.equals(crypto.encrypt(credential), crypto.encrypt(credential))
   end)
 
-  it("substitutes empty string for nil password in salt", function()
+  it("substitutes empty string for password equal to nil", function()
     local credential = {
       consumer_id = "id123"
     }
@@ -21,6 +21,18 @@ describe("Plugin: basic-auth (crypto)", function()
     local credential2 = {
       consumer_id = "id123",
       password = ""
+    }
+    assert.equals(crypto.encrypt(credential), crypto.encrypt(credential2))
+  end)
+
+  it("substitutes empty string for password equal to ngx.null", function()
+    local credential = {
+      consumer_id = "id123"
+    }
+
+    local credential2 = {
+      consumer_id = "id123",
+      password = ngx.null
     }
     assert.equals(crypto.encrypt(credential), crypto.encrypt(credential2))
   end)

--- a/spec/03-plugins/11-basic-auth/01-crypto_spec.lua
+++ b/spec/03-plugins/11-basic-auth/01-crypto_spec.lua
@@ -12,4 +12,16 @@ describe("Plugin: basic-auth (crypto)", function()
     assert.equals(40, #value)
     assert.equals(crypto.encrypt(credential), crypto.encrypt(credential))
   end)
+
+  it("substitutes empty string for nil password in salt", function()
+    local credential = {
+      consumer_id = "id123"
+    }
+
+    local credential2 = {
+      consumer_id = "id123",
+      password = ""
+    }
+    assert.equals(crypto.encrypt(credential), crypto.encrypt(credential2))
+  end)
 end)


### PR DESCRIPTION
…al.password is nil

NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

### Summary

Passwords are optional when creating basic auth credentials, but if the request doesn't have the password parameter set, `salt_password` formats the salt with literal nil in the string. This makes all subsequent requests fail with invalid authentication credentials. 

Related: https://github.com/Kong/kong/pull/3243

### Full changelog

* check for nil password before formatting salt
* add test