### PR TITLE
fix(plugin) reuse redis conn for different db & auth optimize

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ jdk:
 notifications:
   email: false
 
+services:
+  - redis-server
+
 addons:
   postgresql: "9.4"
   apt:

--- a/kong/plugins/rate-limiting/policies/init.lua
+++ b/kong/plugins/rate-limiting/policies/init.lua
@@ -97,6 +97,7 @@ return {
         end
       end
 
+      -- redis connection pool conflicts with other plugin instance which used same reids
       local ok, err = red:select(conf.redis_database or 0)
       if not ok then
         ngx_log(ngx.ERR, "failed to change Redis database: ", err)
@@ -167,6 +168,7 @@ return {
         end
       end
 
+      -- redis connection pool conflicts with other plugin instance which used same reids
       local ok, err = red:select(conf.redis_database or 0)
       if not ok then
         ngx_log(ngx.ERR, "failed to change Redis database: ", err)

--- a/kong/plugins/rate-limiting/policies/init.lua
+++ b/kong/plugins/rate-limiting/policies/init.lua
@@ -89,7 +89,7 @@ return {
         ngx_log(ngx.ERR, "failed to get connect reused times: ", err)
         return nil, err
       end
-      if conf.redis_password and conf.redis_password ~= "" and times == 0 then
+      if times == 0 and conf.redis_password and conf.redis_password ~= "" then
         local ok, err = red:auth(conf.redis_password)
         if not ok then
           ngx_log(ngx.ERR, "failed to auth Redis: ", err)
@@ -97,11 +97,7 @@ return {
         end
       end
 
-      local db = 0
-      if conf.redis_database ~= nil then
-        db = conf.redis_database
-      end
-      local ok, err = red:select(db)
+      local ok, err = red:select(conf.redis_database or 0)
       if not ok then
         ngx_log(ngx.ERR, "failed to change Redis database: ", err)
         return nil, err
@@ -163,7 +159,7 @@ return {
         ngx_log(ngx.ERR, "failed to get connect reused times: ", err)
         return nil, err
       end
-      if conf.redis_password and conf.redis_password ~= "" and times == 0 then
+      if times == 0 and conf.redis_password and conf.redis_password ~= "" then
         local ok, err = red:auth(conf.redis_password)
         if not ok then
           ngx_log(ngx.ERR, "failed to connect to Redis: ", err)
@@ -171,11 +167,7 @@ return {
         end
       end
 
-      local db = 0
-      if conf.redis_database ~= nil then
-        db = conf.redis_database
-      end
-      local ok, err = red:select(db)
+      local ok, err = red:select(conf.redis_database or 0)
       if not ok then
         ngx_log(ngx.ERR, "failed to change Redis database: ", err)
         return nil, err

--- a/kong/plugins/rate-limiting/policies/init.lua
+++ b/kong/plugins/rate-limiting/policies/init.lua
@@ -84,20 +84,27 @@ return {
         return nil, err
       end
 
-      if conf.redis_password and conf.redis_password ~= "" then
+      local times, err = red:get_reused_times()
+      if err then
+        ngx_log(ngx.ERR, "failed to get connect reused times: ", err)
+        return nil, err
+      end
+      if conf.redis_password and conf.redis_password ~= "" and times == 0 then
         local ok, err = red:auth(conf.redis_password)
         if not ok then
-          ngx_log(ngx.ERR, "failed to connect to Redis: ", err)
+          ngx_log(ngx.ERR, "failed to auth Redis: ", err)
           return nil, err
         end
       end
 
-      if conf.redis_database ~= nil and conf.redis_database > 0 then
-        local ok, err = red:select(conf.redis_database)
-        if not ok then
-          ngx_log(ngx.ERR, "failed to change Redis database: ", err)
-          return nil, err
-        end
+      local db = 0
+      if conf.redis_database ~= nil then
+        db = conf.redis_database
+      end
+      local ok, err = red:select(db)
+      if not ok then
+        ngx_log(ngx.ERR, "failed to change Redis database: ", err)
+        return nil, err
       end
 
       local keys = {}
@@ -151,7 +158,12 @@ return {
         return nil, err
       end
 
-      if conf.redis_password and conf.redis_password ~= "" then
+      local times, err = red:get_reused_times()
+      if err then
+        ngx_log(ngx.ERR, "failed to get connect reused times: ", err)
+        return nil, err
+      end
+      if conf.redis_password and conf.redis_password ~= "" and times == 0 then
         local ok, err = red:auth(conf.redis_password)
         if not ok then
           ngx_log(ngx.ERR, "failed to connect to Redis: ", err)
@@ -159,12 +171,14 @@ return {
         end
       end
 
-      if conf.redis_database ~= nil and conf.redis_database > 0 then
-        local ok, err = red:select(conf.redis_database)
-        if not ok then
-          ngx_log(ngx.ERR, "failed to change Redis database: ", err)
-          return nil, err
-        end
+      local db = 0
+      if conf.redis_database ~= nil then
+        db = conf.redis_database
+      end
+      local ok, err = red:select(db)
+      if not ok then
+        ngx_log(ngx.ERR, "failed to change Redis database: ", err)
+        return nil, err
       end
 
       reports.retrieve_redis_version(red)

--- a/kong/plugins/response-ratelimiting/policies/init.lua
+++ b/kong/plugins/response-ratelimiting/policies/init.lua
@@ -84,20 +84,27 @@ return {
         return nil, err
       end
 
-      if conf.redis_password and conf.redis_password ~= "" then
+      local times, err = red:get_reused_times()
+      if err then
+        ngx_log(ngx.ERR, "failed to get connect reused times: ", err)
+        return nil, err
+      end
+      if conf.redis_password and conf.redis_password ~= "" and times == 0 then
         local ok, err = red:auth(conf.redis_password)
         if not ok then
-          ngx_log(ngx.ERR, "failed to connect to Redis: ", err)
+          ngx_log(ngx.ERR, "failed to auth Redis: ", err)
           return nil, err
         end
       end
 
-      if conf.redis_database ~= nil and conf.redis_database > 0 then
-        local ok, err = red:select(conf.redis_database)
-        if not ok then
-          ngx_log(ngx.ERR, "failed to change Redis database: ", err)
-          return nil, err
-        end
+      local db = 0
+      if conf.redis_database ~= nil then
+        db = conf.redis_database
+      end
+      local ok, err = red:select(db)
+      if not ok then
+        ngx_log(ngx.ERR, "failed to change Redis database: ", err)
+        return nil, err
       end
 
       local keys = {}
@@ -149,20 +156,27 @@ return {
         return nil, err
       end
 
-      if conf.redis_password and conf.redis_password ~= "" then
+      local times, err = red:get_reused_times()
+      if err then
+        ngx_log(ngx.ERR, "failed to get connect reused times: ", err)
+        return nil, err
+      end
+      if conf.redis_password and conf.redis_password ~= "" and times == 0 then
         local ok, err = red:auth(conf.redis_password)
         if not ok then
-          ngx_log(ngx.ERR, "failed to connect to Redis: ", err)
+          ngx_log(ngx.ERR, "failed to auth Redis: ", err)
           return nil, err
         end
       end
 
-      if conf.redis_database ~= nil and conf.redis_database > 0 then
-        local ok, err = red:select(conf.redis_database)
-        if not ok then
-          ngx_log(ngx.ERR, "failed to change Redis database: ", err)
-          return nil, err
-        end
+      local db = 0
+      if conf.redis_database ~= nil then
+        db = conf.redis_database
+      end
+      local ok, err = red:select(db)
+      if not ok then
+        ngx_log(ngx.ERR, "failed to change Redis database: ", err)
+        return nil, err
       end
 
       reports.retrieve_redis_version(red)

--- a/kong/plugins/response-ratelimiting/policies/init.lua
+++ b/kong/plugins/response-ratelimiting/policies/init.lua
@@ -97,6 +97,7 @@ return {
         end
       end
 
+      -- redis connection pool conflicts with other plugin instance which used same reids
       local ok, err = red:select(conf.redis_database or 0)
       if not ok then
         ngx_log(ngx.ERR, "failed to change Redis database: ", err)
@@ -165,6 +166,7 @@ return {
         end
       end
 
+      -- redis connection pool conflicts with other plugin instance which used same reids
       local ok, err = red:select(conf.redis_database or 0)
       if not ok then
         ngx_log(ngx.ERR, "failed to change Redis database: ", err)

--- a/kong/plugins/response-ratelimiting/policies/init.lua
+++ b/kong/plugins/response-ratelimiting/policies/init.lua
@@ -89,7 +89,7 @@ return {
         ngx_log(ngx.ERR, "failed to get connect reused times: ", err)
         return nil, err
       end
-      if conf.redis_password and conf.redis_password ~= "" and times == 0 then
+      if times == 0 and conf.redis_password and conf.redis_password ~= "" then
         local ok, err = red:auth(conf.redis_password)
         if not ok then
           ngx_log(ngx.ERR, "failed to auth Redis: ", err)
@@ -97,11 +97,7 @@ return {
         end
       end
 
-      local db = 0
-      if conf.redis_database ~= nil then
-        db = conf.redis_database
-      end
-      local ok, err = red:select(db)
+      local ok, err = red:select(conf.redis_database or 0)
       if not ok then
         ngx_log(ngx.ERR, "failed to change Redis database: ", err)
         return nil, err
@@ -161,7 +157,7 @@ return {
         ngx_log(ngx.ERR, "failed to get connect reused times: ", err)
         return nil, err
       end
-      if conf.redis_password and conf.redis_password ~= "" and times == 0 then
+      if times == 0 and conf.redis_password and conf.redis_password ~= "" then
         local ok, err = red:auth(conf.redis_password)
         if not ok then
           ngx_log(ngx.ERR, "failed to auth Redis: ", err)
@@ -169,11 +165,7 @@ return {
         end
       end
 
-      local db = 0
-      if conf.redis_database ~= nil then
-        db = conf.redis_database
-      end
-      local ok, err = red:select(db)
+      local ok, err = red:select(conf.redis_database or 0)
       if not ok then
         ngx_log(ngx.ERR, "failed to change Redis database: ", err)
         return nil, err

--- a/spec/03-plugins/24-rate-limiting/05-integration_spec.lua
+++ b/spec/03-plugins/24-rate-limiting/05-integration_spec.lua
@@ -1,0 +1,177 @@
+local helpers = require "spec.helpers"
+local redis = require "resty.redis"
+
+local REDIS_HOST = "127.0.0.1"
+local REDIS_PORT = 6379
+local REDIS_PASSWORD = ""
+local REDIS_DATABASE = 1
+local REDIS_DATABASE_SECOND = 0
+
+local SLEEP_TIME = 1
+
+local function flush_redis(db)
+  local red = redis:new()
+  red:set_timeout(2000)
+  local ok, err = red:connect(REDIS_HOST, REDIS_PORT)
+  if not ok then
+    error("failed to connect to Redis: " .. err)
+  end
+
+  if REDIS_PASSWORD and REDIS_PASSWORD ~= "" then
+    local ok, err = red:auth(REDIS_PASSWORD)
+    if not ok then
+      error("failed to connect to Redis: " .. err)
+    end
+  end
+
+  local ok, err = red:select(db)
+  if not ok then
+    error("failed to change Redis database: " .. err)
+  end
+
+  red:flushall()
+  red:close()
+end
+
+describe("Plugin: rate-limiting (integration)", function()
+
+  local client
+
+  setup(function()
+    helpers.dao:drop_schema()
+    helpers.run_migrations()
+  end)
+
+  teardown(function()
+    flush_redis(REDIS_DATABASE)
+    flush_redis(REDIS_DATABASE_SECOND)
+    if client then client:close() end
+    helpers.stop_kong()
+  end)
+
+  describe("Redis conn select database", function()
+    -- Regression test for the following issue:
+    -- https://github.com/Kong/kong/issues/3292
+
+    setup(function()
+      flush_redis(REDIS_DATABASE)
+      flush_redis(REDIS_DATABASE_SECOND)
+      local api1 = assert(helpers.dao.apis:insert {
+        name         = "redistest1_com",
+        hosts        = { "redistest1.com" },
+        upstream_url = helpers.mock_upstream_url,
+      })
+      assert(helpers.dao.plugins:insert {
+        name   = "rate-limiting",
+        api_id = api1.id,
+        config = {
+          minute              = 1,
+          policy              = "redis",
+          redis_host          = REDIS_HOST,
+          redis_port          = REDIS_PORT,
+          redis_password      = REDIS_PASSWORD,
+          redis_database      = REDIS_DATABASE,
+          fault_tolerant      = false
+        },
+      })
+
+      local api2 = assert(helpers.dao.apis:insert {
+        name         = "redistest2_com",
+        hosts        = { "redistest2.com" },
+        upstream_url = helpers.mock_upstream_url,
+      })
+      assert(helpers.dao.plugins:insert {
+        name   = "rate-limiting",
+        api_id = api2.id,
+        config = {
+          minute              = 1,
+          policy              = "redis",
+          redis_host          = REDIS_HOST,
+          redis_port          = REDIS_PORT,
+          redis_password      = REDIS_PASSWORD,
+          redis_database      = REDIS_DATABASE_SECOND,
+          fault_tolerant      = false
+        }
+      })
+      assert(helpers.start_kong({
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+      }))
+      client = helpers.proxy_client()
+    end)
+
+    it("redis conn select databases", function()
+      local red = redis:new()
+      red:set_timeout(2000)
+      local ok, err = red:connect(REDIS_HOST, REDIS_PORT)
+      if not ok then
+        error("failed to connect to Redis: " .. err)
+      end
+      if REDIS_PASSWORD and REDIS_PASSWORD ~= "" then
+        local ok, err = red:auth(REDIS_PASSWORD)
+        if not ok then
+          error("failed to connect to Redis: " .. err)
+        end
+      end
+      red:select(REDIS_DATABASE)
+      local val1, err = red:dbsize()
+      if err then
+        error("failed to call dbsize: " .. err)
+      end
+      red:select(REDIS_DATABASE_SECOND)
+      local val2, err = red:dbsize()
+      if err then
+        error("failed to call dbsize: " .. err)
+      end
+      assert.are.same(0, tonumber(val1))
+      assert.are.same(0, tonumber(val2))
+
+      local res = assert(client:send {
+        method = "GET",
+        path = "/status/200",
+        headers = {
+          ["Host"] = "redistest1.com"
+        }
+      })
+      assert.res_status(200, res)
+      ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
+
+      red:select(REDIS_DATABASE)
+      local val1, err = red:dbsize()
+      if err then
+        error("failed to call dbsize: " .. err)
+      end
+      red:select(REDIS_DATABASE_SECOND)
+      local val2, err = red:dbsize()
+      if err then
+        error("failed to call dbsize: " .. err)
+      end
+      assert.are.same(1, tonumber(val1))
+      assert.are.same(0, tonumber(val2))
+
+      -- rate-limiting plugin reuse api1 redis connection
+      local res = assert(client:send {
+        method = "GET",
+        path = "/status/200",
+        headers = {
+          ["Host"] = "redistest2.com"
+        }
+      })
+      assert.res_status(200, res)
+      ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
+
+      red:select(REDIS_DATABASE)
+      local val1, err = red:dbsize()
+      if err then
+        error("failed to call dbsize: " .. err)
+      end
+      red:select(REDIS_DATABASE_SECOND)
+      local val2, err = red:dbsize()
+      if err then
+        error("failed to call dbsize: " .. err)
+      end
+      red:close()
+      assert.are.same(1, tonumber(val1))
+      assert.are.same(1, tonumber(val2))
+    end)
+  end)
+end)

--- a/spec/03-plugins/24-rate-limiting/05-integration_spec.lua
+++ b/spec/03-plugins/24-rate-limiting/05-integration_spec.lua
@@ -38,13 +38,10 @@ describe("Plugin: rate-limiting (integration)", function()
   local client
 
   setup(function()
-    helpers.dao:drop_schema()
     helpers.run_migrations()
   end)
 
   teardown(function()
-    flush_redis(REDIS_DATABASE)
-    flush_redis(REDIS_DATABASE_SECOND)
     if client then client:close() end
     helpers.stop_kong()
   end)
@@ -102,22 +99,16 @@ describe("Plugin: rate-limiting (integration)", function()
     it("redis conn select databases", function()
       local red = redis:new()
       red:set_timeout(2000)
-      local ok, err = red:connect(REDIS_HOST, REDIS_PORT)
-      if not ok then
-        error("failed to connect to Redis: " .. err)
-      end
+      assert(red:connect(REDIS_HOST, REDIS_PORT))
       if REDIS_PASSWORD and REDIS_PASSWORD ~= "" then
-        local ok, err = red:auth(REDIS_PASSWORD)
-        if not ok then
-          error("failed to connect to Redis: " .. err)
-        end
+        assert(red:auth(REDIS_PASSWORD))
       end
-      red:select(REDIS_DATABASE)
+      assert(red:select(REDIS_DATABASE))
       local val1, err = red:dbsize()
       if err then
         error("failed to call dbsize: " .. err)
       end
-      red:select(REDIS_DATABASE_SECOND)
+      assert(red:select(REDIS_DATABASE_SECOND))
       local val2, err = red:dbsize()
       if err then
         error("failed to call dbsize: " .. err)
@@ -135,12 +126,12 @@ describe("Plugin: rate-limiting (integration)", function()
       assert.res_status(200, res)
       ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
 
-      red:select(REDIS_DATABASE)
+      assert(red:select(REDIS_DATABASE))
       local val1, err = red:dbsize()
       if err then
         error("failed to call dbsize: " .. err)
       end
-      red:select(REDIS_DATABASE_SECOND)
+      assert(red:select(REDIS_DATABASE_SECOND))
       local val2, err = red:dbsize()
       if err then
         error("failed to call dbsize: " .. err)
@@ -159,12 +150,12 @@ describe("Plugin: rate-limiting (integration)", function()
       assert.res_status(200, res)
       ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
 
-      red:select(REDIS_DATABASE)
+      assert(red:select(REDIS_DATABASE))
       local val1, err = red:dbsize()
       if err then
         error("failed to call dbsize: " .. err)
       end
-      red:select(REDIS_DATABASE_SECOND)
+      assert(red:select(REDIS_DATABASE_SECOND))
       local val2, err = red:dbsize()
       if err then
         error("failed to call dbsize: " .. err)

--- a/spec/03-plugins/25-response-rate-limiting/05-integration_spec.lua
+++ b/spec/03-plugins/25-response-rate-limiting/05-integration_spec.lua
@@ -38,13 +38,10 @@ describe("Plugin: rate-limiting (integration)", function()
   local client
 
   setup(function()
-    helpers.dao:drop_schema()
     helpers.run_migrations()
   end)
 
   teardown(function()
-    flush_redis(REDIS_DATABASE)
-    flush_redis(REDIS_DATABASE_SECOND)
     if client then client:close() end
     helpers.stop_kong()
   end)
@@ -102,22 +99,16 @@ describe("Plugin: rate-limiting (integration)", function()
     it("redis conn select databases", function()
       local red = redis:new()
       red:set_timeout(2000)
-      local ok, err = red:connect(REDIS_HOST, REDIS_PORT)
-      if not ok then
-        error("failed to connect to Redis: " .. err)
-      end
+      assert(red:connect(REDIS_HOST, REDIS_PORT))
       if REDIS_PASSWORD and REDIS_PASSWORD ~= "" then
-        local ok, err = red:auth(REDIS_PASSWORD)
-        if not ok then
-          error("failed to connect to Redis: " .. err)
-        end
+        assert(red:auth(REDIS_PASSWORD))
       end
-      red:select(REDIS_DATABASE)
+      assert(red:select(REDIS_DATABASE))
       local val1, err = red:dbsize()
       if err then
         error("failed to call dbsize: " .. err)
       end
-      red:select(REDIS_DATABASE_SECOND)
+      assert(red:select(REDIS_DATABASE_SECOND))
       local val2, err = red:dbsize()
       if err then
         error("failed to call dbsize: " .. err)
@@ -136,12 +127,12 @@ describe("Plugin: rate-limiting (integration)", function()
       assert.equal(6, tonumber(res.headers["x-ratelimit-limit-video-minute"]))
       assert.equal(5, tonumber(res.headers["x-ratelimit-remaining-video-minute"]))
       ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
-      red:select(REDIS_DATABASE)
+      assert(red:select(REDIS_DATABASE))
       local val1, err = red:dbsize()
       if err then
         error("failed to call dbsize: " .. err)
       end
-      red:select(REDIS_DATABASE_SECOND)
+      assert(red:select(REDIS_DATABASE_SECOND))
       local val2, err = red:dbsize()
       if err then
         error("failed to call dbsize: " .. err)
@@ -161,12 +152,12 @@ describe("Plugin: rate-limiting (integration)", function()
       assert.equal(6, tonumber(res.headers["x-ratelimit-limit-video-minute"]))
       assert.equal(5, tonumber(res.headers["x-ratelimit-remaining-video-minute"]))
       ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
-      red:select(REDIS_DATABASE)
+      assert(red:select(REDIS_DATABASE))
       local val1, err = red:dbsize()
       if err then
         error("failed to call dbsize: " .. err)
       end
-      red:select(REDIS_DATABASE_SECOND)
+      assert(red:select(REDIS_DATABASE_SECOND))
       local val2, err = red:dbsize()
       if err then
         error("failed to call dbsize: " .. err)

--- a/spec/03-plugins/25-response-rate-limiting/05-integration_spec.lua
+++ b/spec/03-plugins/25-response-rate-limiting/05-integration_spec.lua
@@ -1,0 +1,179 @@
+local helpers = require "spec.helpers"
+local redis = require "resty.redis"
+
+local REDIS_HOST = "127.0.0.1"
+local REDIS_PORT = 6379
+local REDIS_PASSWORD = ""
+local REDIS_DATABASE = 1
+local REDIS_DATABASE_SECOND = 0
+
+local SLEEP_TIME = 1
+
+local function flush_redis(db)
+  local red = redis:new()
+  red:set_timeout(2000)
+  local ok, err = red:connect(REDIS_HOST, REDIS_PORT)
+  if not ok then
+    error("failed to connect to Redis: " .. err)
+  end
+
+  if REDIS_PASSWORD and REDIS_PASSWORD ~= "" then
+    local ok, err = red:auth(REDIS_PASSWORD)
+    if not ok then
+      error("failed to connect to Redis: " .. err)
+    end
+  end
+
+  local ok, err = red:select(db)
+  if not ok then
+    error("failed to change Redis database: " .. err)
+  end
+
+  red:flushall()
+  red:close()
+end
+
+describe("Plugin: rate-limiting (integration)", function()
+
+  local client
+
+  setup(function()
+    helpers.dao:drop_schema()
+    helpers.run_migrations()
+  end)
+
+  teardown(function()
+    flush_redis(REDIS_DATABASE)
+    flush_redis(REDIS_DATABASE_SECOND)
+    if client then client:close() end
+    helpers.stop_kong()
+  end)
+
+  describe("Redis conn select database", function()
+    -- Regression test for the following issue:
+    -- https://github.com/Kong/kong/issues/3292
+
+    setup(function()
+      flush_redis(REDIS_DATABASE)
+      flush_redis(REDIS_DATABASE_SECOND)
+      local api1 = assert(helpers.dao.apis:insert {
+        name         = "redistest1_com",
+        hosts        = { "redistest1.com" },
+        upstream_url = helpers.mock_upstream_url,
+      })
+      assert(helpers.dao.plugins:insert {
+        name   = "response-ratelimiting",
+        api_id = api1.id,
+        config = {
+          policy              = "redis",
+          redis_host          = REDIS_HOST,
+          redis_port          = REDIS_PORT,
+          redis_password      = REDIS_PASSWORD,
+          redis_database      = REDIS_DATABASE,
+          fault_tolerant      = false,
+          limits              = { video = { minute = 6 } },
+        },
+      })
+
+      local api2 = assert(helpers.dao.apis:insert {
+        name         = "redistest2_com",
+        hosts        = { "redistest2.com" },
+        upstream_url = helpers.mock_upstream_url,
+      })
+      assert(helpers.dao.plugins:insert {
+        name   = "response-ratelimiting",
+        api_id = api2.id,
+        config = {
+          policy              = "redis",
+          redis_host          = REDIS_HOST,
+          redis_port          = REDIS_PORT,
+          redis_password      = REDIS_PASSWORD,
+          redis_database      = REDIS_DATABASE_SECOND,
+          fault_tolerant      = false,
+          limits              = { video = { minute = 6 } },
+        },
+      })
+      assert(helpers.start_kong({
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+      }))
+      client = helpers.proxy_client()
+    end)
+
+    it("redis conn select databases", function()
+      local red = redis:new()
+      red:set_timeout(2000)
+      local ok, err = red:connect(REDIS_HOST, REDIS_PORT)
+      if not ok then
+        error("failed to connect to Redis: " .. err)
+      end
+      if REDIS_PASSWORD and REDIS_PASSWORD ~= "" then
+        local ok, err = red:auth(REDIS_PASSWORD)
+        if not ok then
+          error("failed to connect to Redis: " .. err)
+        end
+      end
+      red:select(REDIS_DATABASE)
+      local val1, err = red:dbsize()
+      if err then
+        error("failed to call dbsize: " .. err)
+      end
+      red:select(REDIS_DATABASE_SECOND)
+      local val2, err = red:dbsize()
+      if err then
+        error("failed to call dbsize: " .. err)
+      end
+      assert(tonumber(val1) == 0)
+      assert(tonumber(val2) == 0)
+
+      local res = assert(client:send {
+        method = "GET",
+        path = "/response-headers?x-kong-limit=video=1",
+        headers = {
+          ["Host"] = "redistest1.com"
+        }
+      })
+      assert.res_status(200, res)
+      assert.equal(6, tonumber(res.headers["x-ratelimit-limit-video-minute"]))
+      assert.equal(5, tonumber(res.headers["x-ratelimit-remaining-video-minute"]))
+      ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
+      red:select(REDIS_DATABASE)
+      local val1, err = red:dbsize()
+      if err then
+        error("failed to call dbsize: " .. err)
+      end
+      red:select(REDIS_DATABASE_SECOND)
+      local val2, err = red:dbsize()
+      if err then
+        error("failed to call dbsize: " .. err)
+      end
+      assert(tonumber(val1) > 0)
+      assert(tonumber(val2) == 0)
+
+      -- rate-limiting plugin reuse api1 redis connection
+      local res = assert(client:send {
+        method = "GET",
+        path = "/response-headers?x-kong-limit=video=1",
+        headers = {
+          ["Host"] = "redistest2.com"
+        }
+      })
+      assert.res_status(200, res)
+      assert.equal(6, tonumber(res.headers["x-ratelimit-limit-video-minute"]))
+      assert.equal(5, tonumber(res.headers["x-ratelimit-remaining-video-minute"]))
+      ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
+      red:select(REDIS_DATABASE)
+      local val1, err = red:dbsize()
+      if err then
+        error("failed to call dbsize: " .. err)
+      end
+      red:select(REDIS_DATABASE_SECOND)
+      local val2, err = red:dbsize()
+      if err then
+        error("failed to call dbsize: " .. err)
+      end
+      red:close()
+      assert(tonumber(val1) > 0)
+      assert(tonumber(val2) > 0)
+    end)
+  end)
+end)


### PR DESCRIPTION
### Summary

If user configure response-ratelimiting、response-ratelimiting use same redis instance with `db0` and `other` will get unexpected results.

### Full changelog

* red:select each time.
* red:auth only once.

### Issues resolved

Fix #3292
