### PR TITLE
fix(cli) catch compilation errors of nginx config templates

### DIFF
--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -114,7 +114,11 @@ local function compile_conf(kong_config, conf_template)
   compile_env.admin_http2 = kong_config.admin_http2 and " http2" or ""
   compile_env.proxy_protocol = kong_config.real_ip_header == "proxy_protocol" and " proxy_protocol" or ""
 
-  local post_template = pl_template.substitute(conf_template, compile_env)
+  local post_template, err = pl_template.substitute(conf_template, compile_env)
+  if not post_template then
+    return nil, "failed to compile nginx config template: " .. err
+  end
+
   return string.gsub(post_template, "(${%b{}})", function(w)
     local name = w:sub(4, -3)
     return compile_env[name:lower()] or ""

--- a/spec/01-unit/003-prefix_handler_spec.lua
+++ b/spec/01-unit/003-prefix_handler_spec.lua
@@ -465,6 +465,25 @@ describe("NGINX conf compiler", function()
         assert.is_nil(ok)
         assert.equal("no such file: spec/fixtures/inexistent.template", err)
       end)
+      it("reports Penlight templating errors", function()
+        local u = helpers.unindent
+        local tmp = os.tmpname()
+
+        helpers.file.write(tmp, u[[
+          > if t.hello then
+
+          > end
+        ]])
+
+        finally(function()
+          helpers.file.delete(tmp)
+        end)
+
+        local ok, err = prefix_handler.prepare_prefix(helpers.test_conf, tmp)
+        assert.is_nil(ok)
+        assert.matches("failed to compile nginx config template: .* " ..
+                       "attempt to index global 't' %(a nil value%)", err)
+      end)
     end)
   end)
 end)


### PR DESCRIPTION
Prior to this patch, an error in the Penlight template for custom nginx
configurations would result in `compile_conf()` returning `nil`, which
would result in errors later in the execution path (trying to write a
`nil` value at `<prefix>/nginx-kong.conf` instead of a `string`).

This fix now catches errors returned by `pl_template.substitute`.