### PR TITLE
fix(balancer) update default size from 100 to 10000

### DIFF
--- a/kong/dao/schemas/upstreams.lua
+++ b/kong/dao/schemas/upstreams.lua
@@ -3,7 +3,7 @@ local utils = require "kong.tools.utils"
 local match = string.match
 local sub = string.sub
 
-local DEFAULT_SLOTS = 100
+local DEFAULT_SLOTS = 10000
 local SLOTS_MIN, SLOTS_MAX = 10, 2^16
 local SLOTS_MSG = "number of slots must be between " .. SLOTS_MIN .. " and " .. SLOTS_MAX
 

--- a/spec-old-api/01-unit/007-entities_schemas_spec.lua
+++ b/spec-old-api/01-unit/007-entities_schemas_spec.lua
@@ -719,7 +719,7 @@ describe("Entities Schemas", function()
   --
 
   describe("Upstreams", function()
-    local slots_default, slots_min, slots_max = 100, 10, 2^16
+    local slots_default, slots_min, slots_max = 10000, 10, 2^16
 
     it("should require a valid `name` and no port", function()
       local valid, errors, check

--- a/spec/01-unit/007-entities_schemas_spec.lua
+++ b/spec/01-unit/007-entities_schemas_spec.lua
@@ -793,7 +793,7 @@ describe("Entities Schemas", function()
   --
 
   describe("Upstreams", function()
-    local slots_default, slots_min, slots_max = 100, 10, 2^16
+    local slots_default, slots_min, slots_max = 10000, 10, 2^16
 
     it("should require a valid `name` and no port", function()
       local valid, errors, check

--- a/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
@@ -3,7 +3,7 @@ local dao_helpers = require "spec.02-integration.03-dao.helpers"
 local cjson = require "cjson"
 local DAOFactory = require "kong.dao.factory"
 
-local slots_default, slots_max = 100, 2^16
+local slots_default, slots_max = 10000, 2^16
 
 local function it_content_types(title, fn)
   local test_form_encoded = fn("application/x-www-form-urlencoded")


### PR DESCRIPTION
Updates the default balancer size from 100 to 65535 (max size). The original size is to low as the advice is 100 slots for each target. 

This should have been included in #3220 since that implemented the performance (speed and footprint) improvement for the balancer to enable the new size default.

Related #3220
