### PR TITLE
fix(cli) stop redirecting output when not starting as a daemon

### DIFF
--- a/kong/cmd/utils/nginx_signals.lua
+++ b/kong/cmd/utils/nginx_signals.lua
@@ -84,12 +84,23 @@ function _M.start(kong_conf)
 
   log.debug("starting nginx: %s", cmd)
 
-  local ok, _, _, stderr = pl_utils.executeex(cmd)
-  if not ok then
-    return nil, stderr
-  end
+  if kong_conf.nginx_daemon == "on" then
+    -- running as daemon, so we capture command output to temp files using
+    -- the "executeex" method
+    local ok, _, _, stderr = pl_utils.executeex(cmd)
+    if not ok then
+      return nil, stderr
+    end
+    log.debug("nginx started")
 
-  log.debug("nginx started")
+  else
+    -- not as a dameon, so we cannot redirect because in long running processes
+    -- the output will fill the disk. Use "execute" without redirection instead.
+    local ok, retcode = pl_utils.execute(cmd)
+    if not ok then
+      return nil, ("failed to start nginx (exit code: %s)"):format(tostring(retcode))
+    end
+  end
 
   return true
 end

--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -1,4 +1,6 @@
 local helpers = require "spec.helpers"
+local pl_utils = require "pl.utils"
+local pl_path = require "pl.path"
 
 describe("kong start/stop", function()
   setup(function()
@@ -38,6 +40,120 @@ describe("kong start/stop", function()
   it("start dumps Kong config in prefix", function()
     assert(helpers.kong_exec("start --conf " .. helpers.test_conf_path))
     assert.truthy(helpers.path.exists(helpers.test_conf.kong_env))
+  end)
+  it("#only start without daemonizing will properly log to stdout/stderr", function()
+    --[[
+    What are we testing exactly?
+    When Kong starts, the cli commands will shell out to start the 'nginx'
+    executable. The stdout/stderr of this command is redirected to be captured
+    in case of errors.
+    A problem arises when Kong runs in the foreground 'nginx_daemon=off', and
+    the nginx log output is set to '/dev/stderr' and '/std/stdout'.
+    In this case the shell command to start Kong will capture all output send
+    to stdout/stderr by nginx. Which causes the tempfiles to grow uncontrolable.
+
+    So when Kong is run in the foreground, no redirects should be used when
+    starting Kong to prevent the above from happening. Or in other words we
+    want the stdout/stderr of the "kong start" command to receive all output
+    of the nginx logs. Instead of them being swallowed by the intermediary
+    nginx start command (used by "kong start" under the hood).
+    --]]
+    local exec = os.execute  -- luacheck: ignore
+    local stdout = pl_path.tmpname()
+    local stderr = pl_path.tmpname()
+    -- create a finalizer that will stop Kong and cleanup logfiles
+    finally(function()
+      os.remove(stdout)
+      os.remove(stderr)
+      os.execute = exec  -- luacheck: ignore
+      assert(helpers.kong_exec("stop", {
+        prefix = helpers.test_conf.prefix,
+      }))
+    end)
+    -- catch the prepared start command (let the 'helpers' do
+    -- the hard work of building the command)
+    local start_cmd
+    os.execute = function(cmd) start_cmd = cmd return true end  -- luacheck: ignore
+    assert(helpers.kong_exec("start", {
+      prefix = helpers.test_conf.prefix,
+      database = helpers.test_conf.database,
+      pg_database = helpers.test_conf.pg_database,
+      cassandra_keyspace = helpers.test_conf.cassandra_keyspace,
+      proxy_listen = "127.0.0.1:" .. helpers.test_conf.proxy_listeners[1].port,
+      admin_listen = "127.0.0.1:" .. helpers.test_conf.admin_listeners[1].port,
+      admin_access_log = "/dev/stdout",
+      admin_error_log = "/dev/stderr",
+      proxy_access_log = "/dev/stdout",
+      proxy_error_log = "/dev/stderr",
+      log_level = "debug",
+      nginx_daemon = "off",
+    }))
+    os.execute = exec  -- luacheck: ignore
+    -- remove the stdout/stderr redirects from the captured command
+    -- and insert new ones for us to track
+    start_cmd = start_cmd:match("^(.- bin/kong start).-$")
+    start_cmd = start_cmd .. " > " .. stdout .. " 2> " .. stderr
+    start_cmd = start_cmd .. " &"  -- run it detached
+    -- Now start Kong non-daemonized, but detached
+    assert(pl_utils.execute(start_cmd))
+    -- wait for Kong to be up and running, create a test service
+    helpers.wait_until(function()
+      local success, admin_client = pcall(helpers.admin_client)
+      if not success then
+        --print(admin_client)
+        return false
+      end
+      local res = assert(admin_client:send {
+        method = "POST",
+        path = "/services",
+        body = {
+          name = "my-service",
+          host = "127.0.0.1",
+          port = helpers.test_conf.admin_listeners[1].port,
+        },
+        headers = {["Content-Type"] = "application/json"}
+      })
+      admin_client:close()
+      --print(res.status)
+      return res.status == 201
+    end, 60)
+    -- add a test route
+    helpers.wait_until(function()
+      local success, admin_client = pcall(helpers.admin_client)
+      if not success then
+        --print(admin_client)
+        return false
+      end
+      local res = assert(admin_client:send {
+        method = "POST",
+        path = "/services/my-service/routes",
+        body = {
+          paths = { "/" },
+        },
+        headers = {["Content-Type"] = "application/json"}
+      })
+      admin_client:close()
+      --print(res.status)
+      return res.status == 201
+    end, 10)
+    -- make at least 1 succesful proxy request
+    helpers.wait_until(function()
+      -- make a request on the proxy port
+      local proxy_client = helpers.proxy_client()
+      local res = assert(proxy_client:send {
+        method = "GET",
+        path = "/",
+      })
+      proxy_client:close()
+      --print(res.status)
+      return res.status == 200
+    end, 10)
+    -- fetch the log files we set
+    local logout = assert(pl_utils.readfile(stdout))
+    local logerr = assert(pl_utils.readfile(stderr))
+    -- validate that the output contains the expected log messages
+    assert(logerr:find("load_plugins(): Discovering used plugins", 1, true))
+    assert(logout:find('"GET / HTTP/1.1" 200 ', 1, true))
   end)
   it("creates prefix directory if it doesn't exist", function()
     finally(function()


### PR DESCRIPTION
redirecting the nginx start command to temp files will slowly
fill the disk when the process is not started as a daemon.

Initial attempt. Please review carefully, I might not have gotten potential side effects completely covered.

Reference code: [pl.utils.execute()](https://github.com/stevedonovan/Penlight/blob/master/lua/pl/compat.lua#L23-L46) and [pl.utils.executeex()](https://github.com/stevedonovan/Penlight/blob/master/lua/pl/utils.lua#L262-L287)

### Issues resolved

Fix https://discuss.konghq.com/t/stdout-stderr-being-redirected-to-tmp/505
