### PR TITLE
style(meta) use 'or' instead of ternary operator

### DIFF
--- a/kong/meta.lua
+++ b/kong/meta.lua
@@ -6,7 +6,7 @@ local version = setmetatable({
 }, {
   __tostring = function(t)
     return string.format("%d.%d.%d%s", t.major, t.minor, t.patch,
-                         t.suffix and t.suffix or "")
+                         t.suffix or "")
   end
 })
 


### PR DESCRIPTION
### Summary

Style fix . change a ternary operation by a simple "or" keeping the same behavior

### Full changelog

meta.lua - change a ternary operation by an "or"