### PR TITLE
fix(schemas) check upper bound on healthcheck time values

### DIFF
--- a/kong/dao/schemas/upstreams.lua
+++ b/kong/dao/schemas/upstreams.lua
@@ -8,9 +8,9 @@ local SLOTS_MIN, SLOTS_MAX = 10, 2^16
 local SLOTS_MSG = "number of slots must be between " .. SLOTS_MIN .. " and " .. SLOTS_MAX
 
 
-local function check_nonnegative(arg)
-  if arg < 0 then
-    return false, "must be greater than or equal to 0"
+local function check_seconds(arg)
+  if arg < 0 or arg > 65535 then
+    return false, "must be between 0 and 65535"
   end
 end
 
@@ -108,9 +108,9 @@ local healthchecks_defaults = {
 
 
 local funcs = {
-  timeout = check_nonnegative,
+  timeout = check_seconds,
   concurrency = check_positive_int,
-  interval = check_nonnegative,
+  interval = check_seconds,
   successes = check_positive_int_or_zero,
   tcp_failures = check_positive_int_or_zero,
   timeouts = check_positive_int_or_zero,

--- a/spec/01-unit/007-entities_schemas_spec.lua
+++ b/spec/01-unit/007-entities_schemas_spec.lua
@@ -752,13 +752,15 @@ describe("Entities Schemas", function()
 
       -- tests for failure
       local tests = {
-        {{ active = { timeout = -1 }}, "greater than or equal to 0" },
+        {{ active = { timeout = -1 }}, "between 0 and 65535" },
+        {{ active = { timeout = 1e+42 }}, "between 0 and 65535" },
         {{ active = { concurrency = 0.5 }}, "must be an integer" },
         {{ active = { concurrency = 0 }}, "must be an integer" },
         {{ active = { concurrency = -10 }}, "must be an integer" },
         {{ active = { http_path = "" }}, "is empty" },
         {{ active = { http_path = "ovo" }}, "must be prefixed with slash" },
-        {{ active = { healthy = { interval = -1 }}}, "greater than or equal to 0" },
+        {{ active = { healthy = { interval = -1 }}}, "between 0 and 65535" },
+        {{ active = { healthy = { interval = 1e+42 }}}, "between 0 and 65535" },
         {{ active = { healthy = { http_statuses = 404 }}}, "not an array" },
         {{ active = { healthy = { http_statuses = { "ovo" }}}}, "not a number" },
         {{ active = { healthy = { http_statuses = { -1 }}}}, "status code" },
@@ -768,7 +770,8 @@ describe("Entities Schemas", function()
         {{ active = { healthy = { successes = 0.5 }}}, "must be 0 (disabled), or an integer" },
         --{{ active = { healthy = { successes = 0 }}}, "must be an integer" },
         {{ active = { healthy = { successes = -1 }}}, "an integer between" },
-        {{ active = { unhealthy = { interval = -1 }}}, "greater than or equal to 0" },
+        {{ active = { unhealthy = { interval = -1 }}}, "between 0 and 65535" },
+        {{ active = { unhealthy = { interval = 1e+42 }}}, "between 0 and 65535" },
         {{ active = { unhealthy = { http_statuses = 404 }}}, "not an array" },
         {{ active = { unhealthy = { http_statuses = { "ovo" }}}}, "not a number" },
         {{ active = { unhealthy = { http_statuses = { -1 }}}}, "status code" },


### PR DESCRIPTION
Check for the upper bound of all `timeout` and `interval` fields in the health check configuration.
