### PR TITLE
feat: check database version compatibility

### DIFF
--- a/kong/cmd/start.lua
+++ b/kong/cmd/start.lua
@@ -13,8 +13,14 @@ local function execute(args)
   assert(not kill.is_running(conf.nginx_pid),
          "Kong is already running in " .. conf.prefix)
 
-  local err
   local dao = assert(DAOFactory.new(conf))
+  local ok, err_t = dao:init()
+  if not ok then
+    error(tostring(err_t))
+  end
+
+  local err
+
   xpcall(function()
     assert(prefix_handler.prepare_prefix(conf, args.nginx_conf))
 

--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -74,4 +74,14 @@ return {
     "kong_cluster_events",
     "kong_healthchecks",
   },
+  DATABASE = {
+    POSTGRES = {
+      MIN = "9.5",
+      DEPRECATED = "9.4",
+    },
+    CASSANDRA = {
+      MIN = "2.2",
+      DEPRECATED = "2.1",
+    }
+  }
 }

--- a/kong/dao/db/cassandra.lua
+++ b/kong/dao/db/cassandra.lua
@@ -180,6 +180,7 @@ end
 
 function _M:infos()
   return {
+    db_name = "Cassandra",
     desc = "keyspace",
     name = self.cluster_options.keyspace,
     version = self.major_minor_version or "unknown",

--- a/kong/dao/db/postgres.lua
+++ b/kong/dao/db/postgres.lua
@@ -78,6 +78,7 @@ end
 
 function _M:infos()
   return {
+    db_name = "PostgreSQL",
     desc = "database",
     name = self:clone_query_options().database,
     version = self.major_minor_version or "unknown",

--- a/kong/dao/factory.lua
+++ b/kong/dao/factory.lua
@@ -1,6 +1,11 @@
 local DAO = require "kong.dao.dao"
+local log = require "kong.cmd.utils.log"
 local utils = require "kong.tools.utils"
+local version = require "version"
+local constants = require "kong.constants"
 local ModelFactory = require "kong.dao.model_factory"
+
+local fmt = string.format
 
 local CORE_MODELS = {
   "apis",
@@ -128,8 +133,50 @@ function _M.new(kong_config)
   return setmetatable(self, _M)
 end
 
+function _M:check_version_compat(min, deprecated)
+  local db_infos = self:infos()
+  if db_infos.version == "unknown" then
+    return nil, "could not check database compatibility: version " ..
+                "is unknown (did you call ':init'?)"
+  end
+
+  local db_v = version.version(db_infos.version)
+  local min_v = version.version(min)
+
+  if db_v < min_v then
+    if deprecated then
+      local depr_v = version.version(deprecated)
+
+      if db_v >= depr_v then
+        log.warn("Currently using %s %s which is considered deprecated, " ..
+                 "please use %s or greater", db_infos.db_name,
+                 db_infos.version, min)
+
+        return true
+      end
+    end
+
+    return nil, fmt("Kong requires %s %s or greater (currently using %s)",
+                    db_infos.db_name, min, db_infos.version)
+  end
+
+  return true
+end
+
 function _M:init()
-  return self.db:init()
+  local ok, err = self.db:init()
+  if not ok then
+    return nil, err
+  end
+
+  local db_constants = constants.DATABASE[self.db_type:upper()]
+
+  ok, err = self:check_version_compat(db_constants.MIN, db_constants.DEPRECATED)
+  if not ok then
+    return nil, err
+  end
+
+  return true
 end
 
 function _M:init_worker()
@@ -296,13 +343,11 @@ local function migrate(self, identifier, migrations_modules, cur_migrations, on_
 end
 
 local function default_on_migrate(identifier, db_infos)
-  local log = require "kong.cmd.utils.log"
   log("migrating %s for %s %s",
       identifier, db_infos.desc, db_infos.name)
 end
 
 local function default_on_success(identifier, migration_name, db_infos)
-  local log = require "kong.cmd.utils.log"
   log("%s migrated up to: %s",
       identifier, migration_name)
 end
@@ -318,8 +363,6 @@ function _M:are_migrations_uptodate()
     return ret_error_string(self.db.name, nil,
                             "could not retrieve current migrations: " .. err)
   end
-
-  local log = require "kong.cmd.utils.log"
 
   for module, migrations in pairs(migrations_modules) do
     for _, migration in ipairs(migrations) do
@@ -350,8 +393,6 @@ function _M:check_schema_consensus()
     return true -- only applicable for cassandra
   end
 
-  local log = require "kong.cmd.utils.log"
-
   log.verbose("checking Cassandra schema consensus...")
 
   local ok, err = self.db:check_schema_consensus()
@@ -369,8 +410,6 @@ end
 function _M:run_migrations(on_migrate, on_success)
   on_migrate = on_migrate or default_on_migrate
   on_success = on_success or default_on_success
-
-  local log = require "kong.cmd.utils.log"
 
   log.verbose("running datastore migrations")
 

--- a/spec/02-integration/03-dao/01-factory_spec.lua
+++ b/spec/02-integration/03-dao/01-factory_spec.lua
@@ -27,6 +27,7 @@ helpers.for_each_dao(function(kong_conf)
 
       if kong_conf.database == "postgres" then
         assert.same({
+          db_name = "PostgreSQL",
           desc = "database",
           name = kong_conf.pg_database,
           version = "unknown",
@@ -34,6 +35,7 @@ helpers.for_each_dao(function(kong_conf)
 
       elseif kong_conf.database == "cassandra" then
         assert.same({
+          db_name = "Cassandra",
           desc = "keyspace",
           name = kong_conf.cassandra_keyspace,
           version = "unknown",
@@ -50,7 +52,17 @@ helpers.for_each_dao(function(kong_conf)
 
       local info = factory:infos()
       assert.is_string(info.version)
-      assert.not_equal("unknown", info.version)
+      -- should be <major>.<minor>
+      assert.matches("%d+%.%d+", info.version)
+    end)
+
+    it("calls :check_version_compat()", function()
+      local factory = assert(Factory.new(kong_conf))
+      local s = spy.on(factory, "check_version_compat")
+
+      factory:init()
+
+      assert.spy(s).was_called()
     end)
 
     if kong_conf.database == "cassandra" then
@@ -61,5 +73,137 @@ helpers.for_each_dao(function(kong_conf)
         assert.is_number(factory.db.major_version_n)
       end)
     end
+  end)
+
+  describe(":check_version_compat()", function()
+    local factory
+    local db_name
+
+    before_each(function()
+      factory = assert(Factory.new(kong_conf))
+
+      local db_infos = factory:infos()
+      db_name = db_infos.db_name
+    end)
+
+    it("errors if init() was not called", function()
+      local ok, err = factory:check_version_compat()
+      assert.is_nil(ok)
+      assert.equal("could not check database compatibility: version " ..
+                   "is unknown (did you call ':init'?)", err)
+    end)
+
+    describe("db_ver < min", function()
+      it("errors", function()
+        local versions_to_test = {
+          "1.0",
+          "9.0",
+          "9.3",
+        }
+
+        for _, v in ipairs(versions_to_test) do
+          factory.db.major_minor_version = v
+
+          local ok, err = factory:check_version_compat("10.0")
+          assert.is_nil(ok)
+          assert.equal("Kong requires " .. db_name .. " 10.0 or greater " ..
+                       "(currently using " .. v .. ")", err)
+        end
+      end)
+    end)
+
+    describe("db_ver < deprecated < min", function()
+      it("errors", function()
+        local versions_to_test = {
+          "1.0",
+          "9.0",
+          "9.3",
+        }
+
+        for _, v in ipairs(versions_to_test) do
+          factory.db.major_minor_version = v
+
+          local ok, err = factory:check_version_compat("10.0", "9.4")
+          assert.is_nil(ok)
+          assert.equal("Kong requires " .. db_name .. " 10.0 or greater " ..
+                       "(currently using " .. v .. ")", err)
+        end
+      end)
+    end)
+
+    describe("deprecated <= db_ver < min", function()
+      it("logs deprecation warning", function()
+        local log = require "kong.cmd.utils.log"
+        local s = spy.on(log, "log")
+
+        local versions_to_test = {
+          "9.3",
+          "9.4",
+        }
+
+        for _, v in ipairs(versions_to_test) do
+          factory.db.major_minor_version = v
+
+          local ok, err = factory:check_version_compat("9.5", "9.3")
+          assert.is_nil(err)
+          assert.is_true(ok) -- no error on deprecation notices
+          assert.spy(s).was_called_with(log.levels.warn,
+            "Currently using %s %s which is considered deprecated, " ..
+            "please use %s or greater", db_name, v, "9.5")
+        end
+      end)
+    end)
+
+    describe("min < deprecated <= db_ver", function()
+      -- Note: constants should not be configured in this fashion, but this
+      -- test is for robustness's sake
+      it("fine", function()
+        local versions_to_test = {
+          "10.0",
+          "11.1",
+        }
+
+        for _, v in ipairs(versions_to_test) do
+          factory.db.major_minor_version = v
+
+          local ok, err = factory:check_version_compat("9.4", "10.0")
+          assert.is_nil(err)
+          assert.is_true(ok)
+        end
+      end)
+    end)
+
+    describe("deprecated < min <= db_ver", function()
+      it("fine", function()
+        local versions_to_test = {
+          "9.5",
+          "10.0",
+          "11.1",
+        }
+
+        for _, v in ipairs(versions_to_test) do
+          factory.db.major_minor_version = v
+
+          local ok, err = factory:check_version_compat("9.5", "9.4")
+          assert.is_nil(err)
+          assert.is_true(ok)
+        end
+      end)
+    end)
+
+    it("asserts current constants", function()
+      -- current min versions hard-coded in the tests to see them fail when we
+      -- update the constants
+      factory.db.major_minor_version = kong_conf.database == "postgres" and
+                                       "9.5" or "2.2"
+
+      local constants = require "kong.constants"
+      local db_constants = constants.DATABASE[kong_conf.database:upper()]
+
+      local ok, err = factory:check_version_compat(db_constants.MIN,
+                                                   db_constants.DEPRECATED)
+      assert.is_nil(err)
+      assert.is_true(ok)
+    end)
   end)
 end)


### PR DESCRIPTION
Add a check to the DAO's `init()` method to ensure the compatibility of the underlying database (PostgreSQL or Cassandra). This check is ran:
1. In the `kong start` command
2. In `init_by_lua`

We support "minimum recommended version", and an _optional_ "oldest deprecated version", which as of today and 0.12.3 are:

PostgreSQL
- current minimum recommended: 9.5
- deprecated: 9.4

Cassandra
- current minimum recommended: 2.2
- deprecated: 2.1

---

When using a deprecated datastore, the CLI shows:
```
$ bin/kong start                 
2018/03/16 17:38:18 [warn] Currently using PostgreSQL 9.4 which is considered deprecated, please use 9.5 or greater
Kong started
```

It is also shown in the nginx logs when starting Kong from `nginx` (e.g. Docker images).

---

When using a version that is below the minimum recommended, and below the oldest deprecated one, we error out from the CLI (and from `init_by_lua`):
```
$ bin/kong start
Error: Kong requires PostgreSQL 9.5 or greater (currently using 9.4)

  Run with --v (verbose) or --vv (debug) for more details
```