### PR TITLE
feat(jwt) support for config.key_claim_name in header

### DIFF
--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -118,8 +118,9 @@ local function do_authentication(conf)
   end
 
   local claims = jwt.claims
-
-  local jwt_secret_key = claims[conf.key_claim_name]
+  local header = jwt.header
+  
+  local jwt_secret_key = claims[conf.key_claim_name] or header[conf.key_claim_name]
   if not jwt_secret_key then
     return false, {status = 401, message = "No mandatory '" .. conf.key_claim_name .. "' in claims"}
   end


### PR DESCRIPTION
Addresses the issue discussed in #2858. 

## Context

The JWT plug-in previously only supported setting the config.key_claim_name parameter to a claim in the body and not the header. Many identity providers who use JWKS (such as Amazon Cognito) support signing their tokens with more than one public key. This results in the need to support the "kid" (key ID) claim which identifies the public key required to validate the signature of the token. Due to the JWKS defining multiple public keys, the standard "iss" (issuer) claim is not unique. The "kid" claim is typically set in the header of the token and therefore requires also checking the token header for claims. The change that was made is fully backwards compatible due to keeping the functionality that checks the token body claims first and if the config.key_claim_name is not found there it then checks the header. An additional test case was also written to confirm that setting config.key_claim_name to a claim that is in the header succeeds.

## Solution

The current release of the JWT plugin [only checks the token body (claims)](https://github.com/Kong/kong/blob/master/kong/plugins/jwt/handler.lua#L120-L125) for the config.key_claim_name parameter. While this works for most scenarios, in the aforementioned scenario of the "kid" claim in the header, this does not suffice. Adding an [additional check against the header of the token](https://github.com/brycehemme/kong/blob/master/kong/plugins/jwt/handler.lua#L121-L123) if the config.key_claim_name parameter isn't found in the body resolves this issue.

After making this change, an IdP that uses more than one public key can be configured for a single consumer as follows - 

```bash
# Configure the plugin and ensure config.key_claim_name is set to the appropriate header claim -
curl -X POST http://localhost:8001/apis/myapi/plugins --data "name=jwt" --data "config.claims_to_verify=exp" --data "config.key_claim_name=kid"

# Configure the FIRST public key for the consumer. Each of the parameters in curly braces should be replaced to fit your scenario -
curl -i -X POST http://localhost:8001/consumers/{MY_CONSUMER}/jwt -F "algorithm=RS256" -F "rsa_public_key=@{PATH_TO_MY_FIRST_PUBLIC_KEY.pem}" -F "key={MY_FIRST_PUBLIC_KEY_KID}"

# Configure the SECOND public key for the consumer. Each of the parameters in curly braces should be replaced to fit your scenario -
curl -i -X POST http://localhost:8001/consumers/{MY_CONSUMER}/jwt -F "algorithm=RS256" -F "rsa_public_key=@{PATH_TO_MY_SECOND_PUBLIC_KEY.pem}" -F "key={MY_SECOND_PUBLIC_KEY_KID}"
```

## See also

JWKS standard: https://tools.ietf.org/html/rfc7517#section-5
Related issue: https://github.com/Kong/kong/issues/2858