### PR TITLE
chore(deps) bump lua-resty-healthcheck to 0.4.0

### DIFF
--- a/kong-0.13.0rc2-0.rockspec
+++ b/kong-0.13.0rc2-0.rockspec
@@ -30,7 +30,7 @@ dependencies = {
   "lua-resty-dns-client == 2.0.0",
   "lua-resty-worker-events == 0.3.1",
   "lua-resty-mediador == 0.1.2",
-  "lua-resty-healthcheck == 0.3.0",
+  "lua-resty-healthcheck == 0.4.0",
 }
 build = {
   type = "builtin",


### PR DESCRIPTION
This update fixes the setting of defaults in `http_statuses` fields.
