### PR TITLE
feat(router) expose router as a singleton

### DIFF
--- a/kong/core/handler.lua
+++ b/kong/core/handler.lua
@@ -64,6 +64,7 @@ local function build_router(dao, version)
     router_version = version
   end
 
+  singletons.router = router
   return true
 end
 

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -170,6 +170,7 @@ function Kong.init()
   singletons.loaded_plugins = assert(load_plugins(config, dao))
   singletons.dao = dao
   singletons.configuration = config
+  singletons.router = nil
 
   assert(core.build_router(dao, "init"))
 end


### PR DESCRIPTION
Exposing the router as a singleton allows for more introspection of the defined api routes programmatically