### PR TITLE
added support for maximum expiration of a JWT token

### DIFF
--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -165,6 +165,15 @@ local function do_authentication(conf)
     return false, {status = 401, message = errors}
   end
 
+  -- Verify the JWT registered claims
+  if conf.maximum_expiration ~= nil and conf.maximum_expiration > 0 then
+    local ok, errors = jwt:check_maximum_expiration(conf.maximum_expiration)
+    if not ok then
+      return false, {status = 403, message = errors}
+    end
+  end
+
+
   -- Retrieve the consumer
   local consumer_cache_key = singletons.db.consumers:cache_key(jwt_secret.consumer_id)
   local consumer, err      = singletons.cache:get(consumer_cache_key, nil,

--- a/kong/plugins/jwt/jwt_parser.lua
+++ b/kong/plugins/jwt/jwt_parser.lua
@@ -282,6 +282,23 @@ function _M:verify_registered_claims(claims_to_verify)
   return errors == nil, errors
 end
 
+--- check the maximum allowed expiration 
+-- @param maximum_expiration of the claim
+-- @return A Boolean indicating true, if the claim the maximum allowed expiration
+-- @return error if any
+function _M:check_maximum_expiration(maximum_expiration)
+  if maximum_expiration <= 0 then
+     return true
+  end
+
+  local exp = self.claims["exp"]
+  if exp == nil or (exp - ngx_time()) > maximum_expiration then
+    return false, {exp = "exceeds maximum allowed expiration"}
+  end
+
+  return true
+end
+
 _M.encode = encode_token
 
 return _M

--- a/kong/plugins/jwt/migrations/cassandra.lua
+++ b/kong/plugins/jwt/migrations/cassandra.lua
@@ -68,4 +68,22 @@ return {
     end,
     down = function(_, _, dao) end  -- not implemented
   },
+  {
+    name = "2018-03-15-150000_jwt_maximum_expiration",
+    up = function(_, _, dao)
+      for ok, config, update in plugin_config_iterator(dao, "jwt") do
+        if not ok then
+          return config
+        end
+        if config.maximum_expiration == nil then
+          config.maximum_expiration = 0
+          local _, err = update(config)
+          if err then
+            return err
+          end
+        end
+      end
+    end,
+    down = function(_, _, dao) end  -- not implemented
+  },
 }

--- a/kong/plugins/jwt/migrations/postgres.lua
+++ b/kong/plugins/jwt/migrations/postgres.lua
@@ -86,4 +86,22 @@ return {
     end,
     down = function(_, _, dao) end  -- not implemented
   },
+  {
+    name = "2018-03-15-150000_jwt_maximum_expiration",
+    up = function(_, _, dao)
+      for ok, config, update in plugin_config_iterator(dao, "jwt") do
+        if not ok then
+          return config
+        end
+        if config.maximum_expiration == nil then
+          config.maximum_expiration = 0
+          local _, err = update(config)
+          if err then
+            return err
+          end
+        end
+      end
+    end,
+    down = function(_, _, dao) end  -- not implemented
+  },
 }

--- a/kong/plugins/jwt/schema.lua
+++ b/kong/plugins/jwt/schema.lua
@@ -1,4 +1,5 @@
 local utils = require "kong.tools.utils"
+local Errors = require "kong.dao.errors"
 
 local function check_user(anonymous)
   if anonymous == "" or utils.is_valid_uuid(anonymous) then
@@ -6,6 +7,13 @@ local function check_user(anonymous)
   end
 
   return false, "the anonymous user must be empty or a valid uuid"
+end
+
+local function check_positive(v)
+  if v < 0 then
+    return false, "should be 0 or greater"
+  end
+  return true
 end
 
 return {
@@ -18,5 +26,23 @@ return {
     claims_to_verify = {type = "array", enum = {"exp", "nbf"}},
     anonymous = {type = "string", default = "", func = check_user},
     run_on_preflight = {type = "boolean", default = true},
+    maximum_expiration = {type = "number", default = 0, func = check_positive},
   },
+  self_check = function(schema, plugin_t, dao, is_update)
+    if plugin_t.maximum_expiration ~= nil and plugin_t.maximum_expiration > 0 then
+      local has_exp = false
+      if plugin_t.claims_to_verify then
+        for index, value in ipairs(plugin_t.claims_to_verify) do
+          if value == "exp" then
+            has_exp = true
+            break
+          end
+        end
+      end
+      if not has_exp then
+        return false, Errors.schema "to set maximum_expiration, you need to add 'exp' in claims_to_verify"
+      end
+    end
+    return true
+  end
 }

--- a/spec/03-plugins/17-jwt/06-schema_spec.lua
+++ b/spec/03-plugins/17-jwt/06-schema_spec.lua
@@ -1,0 +1,21 @@
+local jwt_schema = require "kong.plugins.jwt.schema"
+
+describe("Plugin: jwt (schema)", function()
+   local ok, res
+   ok = jwt_schema.self_check(nil, {maximum_expiration = -1}, nil, true)
+   assert.is_true(ok) 
+
+   ok, res = jwt_schema.self_check(nil, {maximum_expiration = 300}, nil, true)
+   assert.is_false(ok) 
+   assert.is_equals(res.message, "to set maximum_expiration, you need to add 'exp' in claims_to_verify") 
+
+   ok = jwt_schema.self_check(nil, {maximum_expiration = 300, claims_to_verify = {}}, nil, true)
+   assert.is_false(ok) 
+   assert.is_equals(res.message, "to set maximum_expiration, you need to add 'exp' in claims_to_verify") 
+
+   ok = jwt_schema.self_check(nil, {maximum_expiration = 300, claims_to_verify = {"exp"}}, nil, true)
+   assert.is_true(ok) 
+
+   ok = jwt_schema.self_check(nil, {maximum_expiration = -1, claims_to_verify = {"iss", "exp", "nbf"}}, nil, true)
+   assert.is_true(ok) 
+end)


### PR DESCRIPTION
### Summary

Support for limiting the expiration period on JWT tokens.

In the JWT plugin you can set  the property 'maximum_expiration'  to a positive integer, indicating the maximum number of seconds the 'exp' claim in the token may be ahead in the future.

The purpose of this feature is to prevent the use of tokens with extreme long lifetimes.

### Full changelog
- Added the 'maximum_expiration' to the jwt plugin schema
- Added a check in the handler
- Added unit tests for handler and schema.

