### PR TITLE
fix(hmac-auth) use ngx var request_uri instead uri

### DIFF
--- a/kong/plugins/hmac-auth/access.lua
+++ b/kong/plugins/hmac-auth/access.lua
@@ -127,6 +127,8 @@ local function retrieve_hmac_fields(request, headers, header_name, conf)
   return hmac_params
 end
 
+-- plugin assumes the request parameters being used for creating
+-- signature by client are not changed by core or any other plugin
 local function create_hash(request, hmac_params, headers)
   local signing_string = ""
   local hmac_headers = hmac_params.hmac_headers
@@ -139,7 +141,8 @@ local function create_hash(request, hmac_params, headers)
     if not header_value then
       if header == "request-line" then
         -- request-line in hmac headers list
-        local request_line = fmt("%s %s HTTP/%s", ngx.req.get_method(), ngx.var.uri, ngx.req.http_version())
+        local request_line = fmt("%s %s HTTP/%s", ngx.req.get_method(),
+                                 ngx.var.request_uri, ngx.req.http_version())
         signing_string = signing_string .. request_line
       else
         signing_string = signing_string .. header .. ":"

--- a/spec/03-plugins/20-hmac-auth/03-access_spec.lua
+++ b/spec/03-plugins/20-hmac-auth/03-access_spec.lua
@@ -4,6 +4,8 @@ local helpers = require "spec.helpers"
 local utils = require "kong.tools.utils"
 local resty_sha256 = require "resty.sha256"
 
+local fmt = string.format
+
 
 local hmac_sha1_binary = function(secret, data)
   return openssl_hmac.new(secret, "sha1"):final(data)
@@ -1076,6 +1078,198 @@ for _, strategy in helpers.each_strategy() do
           },
         })
         assert.res_status(200, res)
+      end)
+
+      it("should pass with GET with request-line having query param", function()
+        local date = os.date("!%a, %d %b %Y %H:%M:%S GMT")
+        local encodedSignature = ngx.encode_base64(
+          hmac_sha1_binary("secret", "date: "
+            .. date .. "\n" .. "content-md5: md5" .. "\nGET /request?name=foo HTTP/1.1"))
+        local hmacAuth = [[hmac username="bob",  algorithm="hmac-sha1", ]]
+          .. [[headers="date content-md5 request-line", signature="]]
+          .. encodedSignature .. [["]]
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/request?name=foo",
+          body    = {},
+          headers = {
+            ["HOST"]                = "hmacauth5.com",
+            date                    = date,
+            ["proxy-authorization"] = hmacAuth,
+            ["content-md5"]         = "md5",
+          },
+        })
+        assert.res_status(200, res)
+
+        encodedSignature = ngx.encode_base64(
+          hmac_sha1_binary("secret", "date: "
+            .. date .. "\n" .. "content-md5: md5" .. "\nGET /request/?name=foo HTTP/1.1"))
+        local hmacAuth = [[hmac username="bob",  algorithm="hmac-sha1", ]]
+          .. [[headers="date content-md5 request-line", signature="]]
+          .. encodedSignature .. [["]]
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/request/?name=foo",
+          body    = {},
+          headers = {
+            ["HOST"]                = "hmacauth5.com",
+            date                    = date,
+            ["proxy-authorization"] = hmacAuth,
+            ["content-md5"]         = "md5",
+          },
+        })
+        assert.res_status(200, res)
+      end)
+
+      it("should pass with GET with request-line having encoded query param", function()
+        local date = os.date("!%a, %d %b %Y %H:%M:%S GMT")
+        local escaped_uri = fmt("/request?name=%s",
+                                ngx.escape_uri("foo bar"))
+        local encodedSignature = ngx.encode_base64(
+          hmac_sha1_binary("secret", "date: "
+            .. date .. "\n" .. "content-md5: md5" .. "\nGET " .. escaped_uri .. " HTTP/1.1"))
+        local hmacAuth = [[hmac username="bob",  algorithm="hmac-sha1", ]]
+          .. [[headers="date content-md5 request-line", signature="]]
+          .. encodedSignature .. [["]]
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = escaped_uri,
+          body    = {},
+          headers = {
+            ["HOST"]                = "hmacauth5.com",
+            date                    = date,
+            ["proxy-authorization"] = hmacAuth,
+            ["content-md5"]         = "md5",
+          },
+        })
+        local body = assert.res_status(200, res)
+        local json_body = cjson.decode(body)
+        assert.is.equal("foo bar", json_body.uri_args.name)
+
+        local escaped_uri = fmt("/request?name=%s",
+                                ngx.escape_uri("foo bár"))
+        encodedSignature = ngx.encode_base64(
+          hmac_sha1_binary("secret", "date: "
+            .. date .. "\n" .. "content-md5: md5" .. "\nGET " .. escaped_uri .." HTTP/1.1"))
+        local hmacAuth = [[hmac username="bob",  algorithm="hmac-sha1", ]]
+          .. [[headers="date content-md5 request-line", signature="]]
+          .. encodedSignature .. [["]]
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = escaped_uri,
+          body    = {},
+          headers = {
+            ["HOST"]                = "hmacauth5.com",
+            date                    = date,
+            ["proxy-authorization"] = hmacAuth,
+            ["content-md5"]         = "md5",
+          },
+        })
+        local body = assert.res_status(200, res)
+        local json_body = cjson.decode(body)
+        assert.is.equal("foo bár", json_body.uri_args.name)
+      end)
+
+      it("should pass with GET with request-line having multiple query params", function()
+        local date = os.date("!%a, %d %b %Y %H:%M:%S GMT")
+        local escaped_uri = fmt("/request?name=%s&address=%s" ,
+                                ngx.escape_uri("foo bar"),
+                                ngx.escape_uri("san francisco"))
+        local encodedSignature = ngx.encode_base64(
+          hmac_sha1_binary("secret", "date: "
+            .. date .. "\n" .. "content-md5: md5" .. "\nGET " .. escaped_uri .. " HTTP/1.1"))
+        local hmacAuth = [[hmac username="bob",  algorithm="hmac-sha1", ]]
+          .. [[headers="date content-md5 request-line", signature="]]
+          .. encodedSignature .. [["]]
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = escaped_uri,
+          body    = {},
+          headers = {
+            ["HOST"]                = "hmacauth5.com",
+            date                    = date,
+            ["proxy-authorization"] = hmacAuth,
+            ["content-md5"]         = "md5",
+          },
+        })
+        local body = assert.res_status(200, res)
+        local json_body = cjson.decode(body)
+        assert.is.equal("foo bar", json_body.uri_args.name)
+        assert.is.equal("san francisco", json_body.uri_args.address)
+      end)
+
+      it("should pass with GET with request-line having multiple same query param", function()
+        local date = os.date("!%a, %d %b %Y %H:%M:%S GMT")
+        local encodedSignature = ngx.encode_base64(
+          hmac_sha1_binary("secret", "date: "
+            .. date .. "\n" .. "content-md5: md5" .. "\nGET /request?name=foo&name=bar HTTP/1.1"))
+        local hmacAuth = [[hmac username="bob",  algorithm="hmac-sha1", ]]
+          .. [[headers="date content-md5 request-line", signature="]]
+          .. encodedSignature .. [["]]
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/request?name=foo&name=bar",
+          body    = {},
+          headers = {
+            ["HOST"]                = "hmacauth5.com",
+            date                    = date,
+            ["proxy-authorization"] = hmacAuth,
+            ["content-md5"]         = "md5",
+          },
+        })
+        local body = assert.res_status(200, res)
+        local json_body = cjson.decode(body)
+        assert.is.equal("foo", json_body.uri_args.name[1])
+        assert.is.equal("bar", json_body.uri_args.name[2])
+      end)
+
+      it("should pass with GET with request-line having no uri", function()
+        local date = os.date("!%a, %d %b %Y %H:%M:%S GMT")
+        local encodedSignature = ngx.encode_base64(
+          hmac_sha1_binary("secret", "date: "
+            .. date .. "\n" .. "content-md5: md5" .. "\nGET / HTTP/1.1"))
+        local hmacAuth = [[hmac username="bob",  algorithm="hmac-sha1", ]]
+          .. [[headers="date content-md5 request-line", signature="]]
+          .. encodedSignature .. [["]]
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          body    = {},
+          headers = {
+            ["HOST"]                = "hmacauth5.com",
+            date                    = date,
+            ["proxy-authorization"] = hmacAuth,
+            ["content-md5"]         = "md5",
+          },
+        })
+        assert.res_status(200, res)
+      end)
+
+      it("should pass with GET with request-line having encoded path param", function()
+        local date = os.date("!%a, %d %b %Y %H:%M:%S GMT")
+        local escaped_uri = fmt("/request/%s/?name=foo&name=bar",
+                                ngx.escape_uri("some value"))
+        local encodedSignature = ngx.encode_base64(
+          hmac_sha1_binary("secret", "date: "
+            .. date .. "\n" .. "content-md5: md5" .. "\nGET ".. escaped_uri .. " HTTP/1.1"))
+        local hmacAuth = [[hmac username="bob",  algorithm="hmac-sha1", ]]
+          .. [[headers="date content-md5 request-line", signature="]]
+          .. encodedSignature .. [["]]
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = escaped_uri,
+          body    = {},
+          headers = {
+            ["HOST"]                = "hmacauth5.com",
+            date                    = date,
+            ["proxy-authorization"] = hmacAuth,
+            ["content-md5"]         = "md5",
+          },
+        })
+        local body = assert.res_status(200, res)
+        local json_body = cjson.decode(body)
+        assert.is.equal("foo", json_body.uri_args.name[1])
+        assert.is.equal("bar", json_body.uri_args.name[2])
+        assert.is.equal("/request/some value/", json_body.vars.uri)
       end)
 
       it("should fail with GET when enforced header request-line missing", function()


### PR DESCRIPTION
### Summary

`ngx.var.uri` is normalized and so `ngx.var.request_uri` should be
used to get request origional uri with arguments

### Full changelog

* signature generator logic now use ngx.var.request_uri to
  get original request uri 

