### PR TITLE
fix(ldap) cache key to work when plugin is configured globally

### DIFF
--- a/kong/plugins/ldap-auth/schema.lua
+++ b/kong/plugins/ldap-auth/schema.lua
@@ -8,16 +8,18 @@ local function check_user(anonymous)
   return false, "the anonymous user must be empty or a valid uuid"
 end
 
+-- If you add more configuration parameters, be sure to check if it needs to be added to cache key
+
 return {
   no_consumer = true,
   fields = {
-    ldap_host = {required = true, type = "string"},
-    ldap_port = {required = true, type = "number"},
+    ldap_host = {required = true, type = "string"},                          -- used for cache key
+    ldap_port = {required = true, type = "number"},                          -- used for cache key
     start_tls = {required = true, type = "boolean", default = false},
     verify_ldap_host = {required = true, type = "boolean", default = false},
-    base_dn = {required = true, type = "string"},
-    attribute = {required = true, type = "string"},
-    cache_ttl = {required = true, type = "number", default = 60},
+    base_dn = {required = true, type = "string"},                            -- used for cache key
+    attribute = {required = true, type = "string"},                          -- used for cache key
+    cache_ttl = {required = true, type = "number", default = 60},            -- used for cache key
     hide_credentials = {type = "boolean", default = false},
     timeout = {type = "number", default = 10000},
     keepalive = {type = "number", default = 60000},


### PR DESCRIPTION
### Summary

Changes the way how LDAP cache key in constructed. Previously it didn't share cache with similarly configured LDAP plugins. And more importantly, it was broken when configured as a global plugin (that was reported with #3335)

### Full changelog

* Implement cache key based on plugin configuration

### Issues resolved

Fix #3335
