### PR TITLE
fix(dao) cassandra to handle ngx.null with check_*_constraints

### DIFF
--- a/kong/dao/db/cassandra.lua
+++ b/kong/dao/db/cassandra.lua
@@ -357,7 +357,7 @@ local function check_unique_constraints(self, table_name, constraints, values, p
 
   for col, constraint in pairs(constraints.unique) do
     -- Only check constraints if value is non-null
-    if values[col] ~= nil then
+    if values[col] ~= nil and values[col] ~= ngx.null then
       local where, args = get_where(constraint.schema, {[col] = values[col]})
       local query = select_query(table_name, where)
       local rows, err = self:query(query, args, nil, constraint.schema)
@@ -393,7 +393,7 @@ local function check_foreign_constaints(self, values, constraints)
   for col, constraint in pairs(constraints.foreign) do
     -- Only check foreign keys if value is non-null,
     -- if must not be null, field should be required
-    if values[col] ~= nil then
+    if values[col] ~= nil and values[col] ~= ngx.null then
       local res, err = self:find(constraint.table, constraint.schema, {
         [constraint.col] = values[col]
       })

--- a/kong/dao/schemas_validation.lua
+++ b/kong/dao/schemas_validation.lua
@@ -277,9 +277,19 @@ function _M.validate_entity(tbl, schema, options)
       end
 
       if errors == nil and type(schema.self_check) == "function" then
+        local nil_c = {}
+        for column in pairs(schema.fields) do
+          if t[column] == ngx.null then
+            t[column] = nil
+            table.insert(nil_c, column)
+          end
+        end
         local ok, err = schema.self_check(schema, t, options.dao, options.update)
         if ok == false then
           return false, nil, err
+        end
+        for _, column in ipairs(nil_c) do
+          t[column] = ngx.null
         end
       end
     end

--- a/spec/02-integration/04-admin_api/04-plugins_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/04-plugins_routes_spec.lua
@@ -1,187 +1,230 @@
 local helpers = require "spec.helpers"
-local cjson = require "cjson"
+local cjson   = require "cjson"
 
-describe("Admin API", function()
-  local client
-  setup(function()
-    assert(helpers.dao:run_migrations())
-    assert(helpers.db:truncate())
+for _, strategy in helpers.each_strategy() do
 
-    assert(helpers.start_kong())
-    client = helpers.admin_client()
-  end)
-  teardown(function()
-    if client then client:close() end
-    helpers.stop_kong()
-  end)
-
-  describe("/plugins/enabled", function()
-    it("returns a list of enabled plugins on this node", function()
-      local res = assert(client:send {
-        method = "GET",
-        path = "/plugins/enabled",
-      })
-      local body = assert.res_status(200, res)
-      local json = cjson.decode(body)
-      assert.is_table(json.enabled_plugins)
-      assert.True(#json.enabled_plugins > 0)
-    end)
-  end)
-
-  describe("/plugins", function()
-    local plugins = {}
+  describe("Admin API #" .. strategy, function()
+    local dao
+    local db
+    local client
 
     setup(function()
-      for i = 1, 3 do
-        local service, err, err_t = helpers.db.services:insert {
-          name = "service-" .. i,
-          protocol = "http",
-          host = "127.0.0.1",
-          port = 15555,
-        }
-        assert.is_nil(err_t)
-        assert.is_nil(err)
+      _, db, dao = helpers.get_db_utils(strategy)
+      assert(helpers.start_kong({
+        database = strategy
+      }))
 
-        plugins[i] = assert(helpers.dao.plugins:insert {
-          name = "key-auth",
-          service_id = service.id,
-        })
+      dao:run_migrations()
+
+      dao:truncate_tables()
+      db:truncate()
+    end)
+
+    teardown(function()
+      helpers.stop_kong()
+    end)
+
+    before_each(function()
+      client = helpers.admin_client()
+    end)
+
+    after_each(function()
+      if client then
+        client:close()
       end
     end)
 
-    describe("GET", function()
-      it("retrieves all plugins configured", function()
+    describe("/plugins/enabled", function()
+      it("returns a list of enabled plugins on this node", function()
         local res = assert(client:send {
           method = "GET",
-          path = "/plugins"
+          path = "/plugins/enabled",
         })
         local body = assert.res_status(200, res)
         local json = cjson.decode(body)
-        assert.equal(3, json.total)
-        assert.equal(3, #json.data)
+        assert.is_table(json.enabled_plugins)
+        assert.True(#json.enabled_plugins > 0)
       end)
     end)
-    it("returns 405 on invalid method", function()
-      local methods = {"DELETE", "PATCH"}
-      for i = 1, #methods do
-        local res = assert(client:send {
-          method = methods[i],
-          path = "/plugins",
-          body = {}, -- tmp: body to allow POST/PUT to work
-          headers = {["Content-Type"] = "application/json"}
-        })
-        local body = assert.response(res).has.status(405)
-        local json = cjson.decode(body)
-        assert.same({ message = "Method not allowed" }, json)
-      end
-    end)
 
-    describe("/plugins/{plugin}", function()
+    describe("/plugins", function()
+      local services = {}
+      local plugins = {}
+
+      setup(function()
+        for i = 1, 3 do
+          local service, err, err_t = db.services:insert {
+            name = "service-" .. i,
+            protocol = "http",
+            host = "127.0.0.1",
+            port = 15555,
+          }
+          assert.is_nil(err_t)
+          assert.is_nil(err)
+
+          services[i] = service
+
+          plugins[i] = assert(dao.plugins:insert {
+            name = "key-auth",
+            service_id = service.id,
+          })
+        end
+      end)
+
       describe("GET", function()
-        it("retrieves a plugin by id", function()
+        it("retrieves all plugins configured", function()
           local res = assert(client:send {
             method = "GET",
-            path = "/plugins/" .. plugins[1].id
+            path = "/plugins"
           })
           local body = assert.res_status(200, res)
           local json = cjson.decode(body)
-          assert.same(plugins[1], json)
-        end)
-        it("returns 404 if not found", function()
-          local res = assert(client:send {
-            method = "GET",
-            path = "/plugins/f4aecadc-05c7-11e6-8d41-1f3b3d5fa15c"
-          })
-          assert.res_status(404, res)
+          assert.equal(3, json.total)
+          assert.equal(3, #json.data)
         end)
       end)
-
-
-      describe("PATCH", function()
-        it("updates a plugin", function()
+      it("returns 405 on invalid method", function()
+        local methods = {"DELETE", "PATCH"}
+        for i = 1, #methods do
           local res = assert(client:send {
-            method = "PATCH",
-            path = "/plugins/" .. plugins[1].id,
-            body = {enabled = false},
+            method = methods[i],
+            path = "/plugins",
+            body = {}, -- tmp: body to allow POST/PUT to work
             headers = {["Content-Type"] = "application/json"}
           })
-          local body = assert.res_status(200, res)
+          local body = assert.response(res).has.status(405)
           local json = cjson.decode(body)
-          assert.False(json.enabled)
+          assert.same({ message = "Method not allowed" }, json)
+        end
+      end)
 
-          local in_db = assert(helpers.dao.plugins:find(plugins[1]))
-          assert.same(json, in_db)
-        end)
-        it("updates a plugin bis", function()
-          local plugin = assert(helpers.dao.plugins:find(plugins[2]))
-
-          plugin.enabled = not plugin.enabled
-          plugin.created_at = nil
-
-          local res = assert(client:send {
-            method = "PATCH",
-            path = "/plugins/" .. plugin.id,
-            body = plugin,
-            headers = {["Content-Type"] = "application/json"}
-          })
-          local body = assert.res_status(200, res)
-          local json = cjson.decode(body)
-          assert.equal(plugin.enabled, json.enabled)
-        end)
-        describe("errors", function()
-          it("returns 404 if not found", function()
+      describe("/plugins/{plugin}", function()
+        describe("GET", function()
+          it("retrieves a plugin by id", function()
             local res = assert(client:send {
-              method = "PATCH",
-              path = "/plugins/f4aecadc-05c7-11e6-8d41-1f3b3d5fa15c",
-              body = {enabled = false},
-              headers = {["Content-Type"] = "application/json"}
+              method = "GET",
+              path = "/plugins/" .. plugins[1].id
             })
-            assert.res_status(404, res)
+            local body = assert.res_status(200, res)
+            local json = cjson.decode(body)
+            assert.same(plugins[1], json)
           end)
-        end)
-      end)
-
-      describe("DELETE", function()
-        it("deletes by id", function()
-          local res = assert(client:send {
-            method = "DELETE",
-            path = "/plugins/" .. plugins[3].id
-          })
-          assert.res_status(204, res)
-        end)
-        describe("errors", function()
           it("returns 404 if not found", function()
             local res = assert(client:send {
-              method = "DELETE",
+              method = "GET",
               path = "/plugins/f4aecadc-05c7-11e6-8d41-1f3b3d5fa15c"
             })
             assert.res_status(404, res)
           end)
         end)
+
+
+        describe("PATCH", function()
+          it("updates a plugin", function()
+            local res = assert(client:send {
+              method = "PATCH",
+              path = "/plugins/" .. plugins[1].id,
+              body = {enabled = false},
+              headers = {["Content-Type"] = "application/json"}
+            })
+            local body = assert.res_status(200, res)
+            local json = cjson.decode(body)
+            assert.False(json.enabled)
+
+            local in_db = assert(dao.plugins:find(plugins[1]))
+            assert.same(json, in_db)
+          end)
+          it("updates a plugin bis", function()
+            local plugin = assert(dao.plugins:find(plugins[2]))
+
+            plugin.enabled = not plugin.enabled
+            plugin.created_at = nil
+
+            local res = assert(client:send {
+              method = "PATCH",
+              path = "/plugins/" .. plugin.id,
+              body = plugin,
+              headers = {["Content-Type"] = "application/json"}
+            })
+            local body = assert.res_status(200, res)
+            local json = cjson.decode(body)
+            assert.equal(plugin.enabled, json.enabled)
+          end)
+          it("updates a plugin (removing foreign key reference)", function()
+            assert.equal(services[2].id, plugins[2].service_id)
+
+            local res = assert(client:send {
+              method = "PATCH",
+              path = "/plugins/" .. plugins[2].id,
+              body = {
+                service_id = cjson.null
+              },
+              headers = {["Content-Type"] = "application/json"}
+            })
+            local body = assert.res_status(200, res)
+            local json = cjson.decode(body)
+            assert.is_nil(json.service_id)
+
+            local in_db = assert(dao.plugins:find(plugins[2]))
+            assert.same(json, in_db)
+          end)
+
+          describe("errors", function()
+            it("returns 404 if not found", function()
+              local res = assert(client:send {
+                method = "PATCH",
+                path = "/plugins/f4aecadc-05c7-11e6-8d41-1f3b3d5fa15c",
+                body = {enabled = false},
+                headers = {["Content-Type"] = "application/json"}
+              })
+              assert.res_status(404, res)
+            end)
+          end)
+        end)
+
+        describe("DELETE", function()
+          it("deletes by id", function()
+            local res = assert(client:send {
+              method = "DELETE",
+              path = "/plugins/" .. plugins[3].id
+            })
+            assert.res_status(204, res)
+          end)
+          describe("errors", function()
+            it("returns 404 if not found", function()
+              local res = assert(client:send {
+                method = "DELETE",
+                path = "/plugins/f4aecadc-05c7-11e6-8d41-1f3b3d5fa15c"
+              })
+              assert.res_status(404, res)
+            end)
+          end)
+        end)
+      end)
+    end)
+
+    describe("/plugins/schema/{plugin}", function()
+      describe("GET", function()
+        it("returns the schema of a plugin config", function()
+          local res = assert(client:send {
+            method = "GET",
+            path = "/plugins/schema/key-auth",
+          })
+          local body = assert.res_status(200, res)
+          local json = cjson.decode(body)
+          assert.is_table(json.fields)
+        end)
+        it("returns 404 on invalid plugin", function()
+          local res = assert(client:send {
+            method = "GET",
+            path = "/plugins/schema/foobar",
+          })
+          local body = assert.res_status(404, res)
+          local json = cjson.decode(body)
+          assert.same({ message = "No plugin named 'foobar'" }, json)
+        end)
       end)
     end)
   end)
 
-  describe("/plugins/schema/{plugin}", function()
-    describe("GET", function()
-      it("returns the schema of a plugin config", function()
-        local res = assert(client:send {
-          method = "GET",
-          path = "/plugins/schema/key-auth",
-        })
-        local body = assert.res_status(200, res)
-        local json = cjson.decode(body)
-        assert.is_table(json.fields)
-      end)
-      it("returns 404 on invalid plugin", function()
-        local res = assert(client:send {
-          method = "GET",
-          path = "/plugins/schema/foobar",
-        })
-        local body = assert.res_status(404, res)
-        local json = cjson.decode(body)
-        assert.same({ message = "No plugin named 'foobar'" }, json)
-      end)
-    end)
-  end)
-end)
+end


### PR DESCRIPTION
### Summary

Fix some issues with C* when doing verifications on constraints while the value was `ngx.null`.

### Full changelog

* Implement check for `ngx.null` in `check_unique_constraints`
* Implement check for `ngx.null` in `check_foreign_constaints`

### How to reproduce the problem

```bash
KONG_DATABASE=cassandra bin/kong start
http :8001/apis name=test upstream_url=http://www.google.com/ uris=/
http :8001/consumers username=test
http :8001/plugins name=request-transformer api_id=<API_ID> consumer_id=<CONSUMER_ID>
http patch :8001/plugins/<PLUGIN_ID> consumer_id:=null
```

### Issues resolved

Fix #3308
