### PR TITLE
fix(api) parsing service url default to 443 for https

### DIFF
--- a/kong/api/api_helpers.lua
+++ b/kong/api/api_helpers.lua
@@ -75,7 +75,11 @@ function _M.resolve_url_params(self)
     local parsed_url        = url.parse(sugar_url)
     self.args.post.protocol = parsed_url.scheme
     self.args.post.host     = parsed_url.host
-    self.args.post.port     = tonumber(parsed_url.port) or parsed_url.port
+    self.args.post.port     = tonumber(parsed_url.port) or
+                              parsed_url.port or
+                              (parsed_url.scheme == "http" and 80) or
+                              (parsed_url.scheme == "https" and 443) or
+                              nil
     self.args.post.path     = parsed_url.path
     self.args.post.url      = nil
   end

--- a/spec/02-integration/04-admin_api/21-services_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/21-services_routes_spec.lua
@@ -97,6 +97,31 @@ for _, strategy in helpers.each_strategy() do
             assert.equals(60000, json.read_timeout)
           end
         end)
+
+        it_content_types("'port' defaults to 443 when 'url' scheme is https", function(content_type)
+          return function()
+            local res = client:post("/services", {
+              body = {
+                url = "https://service.com/",
+              },
+              headers = { ["Content-Type"] = content_type },
+            })
+            local body = assert.res_status(201, res)
+            local json = cjson.decode(body)
+
+            assert.is_string(json.id)
+            assert.is_number(json.created_at)
+            assert.is_number(json.updated_at)
+            assert.equals(cjson.null, json.name)
+            assert.equals("https", json.protocol)
+            assert.equals("service.com", json.host)
+            assert.equals("/", json.path)
+            assert.equals(443, json.port)
+            assert.equals(60000, json.connect_timeout)
+            assert.equals(60000, json.write_timeout)
+            assert.equals(60000, json.read_timeout)
+          end
+        end)
       end)
 
       describe("GET", function()


### PR DESCRIPTION
The `url` convenience property was parsed, but defaulted
to port 80, even for 'https' schemes. Updated to 443.

fixes #3357
