### PR TITLE
tests(dao) increase speed and reliability of DAO ttl tests

### DIFF
--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -211,14 +211,16 @@ local function wait_until(f, timeout)
     error("arg #1 must be a function", 2)
   end
 
+  ngx.update_time()
+
   timeout = timeout or 2
   local tstart = ngx.time()
   local texp = tstart + timeout
   local ok, res, err
 
   repeat
-    ngx.sleep(0.2)
     ok, res, err = pcall(f)
+    ngx.sleep(0.05)
   until not ok or res or ngx.time() >= texp
 
   if not ok then


### PR DESCRIPTION
### increase speed and reliability of DAO ttl tests 

* remove explicit uses of `ngx.sleep`, make tests rely on `wait_until` only.
* increase `wait_until` timeouts, to make them more resilient to slowness in CI environment
* lower ttl values in examples to make tests run faster

###  ensure `wait_until` runs with an updated time

Update the internal `ngx` clock before calculating the start time of the `wait_until` loop. This also allows moving the `ngx.sleep` of the loop after the `pcall` (without the `ngx.update_time` at the top, some tests would break if `ngx.sleep` was done after the `pcall` as they were implicitly assuming that they ran with an updated clock).