### PR TITLE
fix(dao) cassandra boolean serialization

### DIFF
--- a/kong/dao/db/cassandra.lua
+++ b/kong/dao/db/cassandra.lua
@@ -317,6 +317,8 @@ local function serialize_arg(field, value)
     return cassandra.uuid(value)
   elseif field.type == "timestamp" then
     return cassandra.timestamp(value)
+  elseif field.type == "boolean" then
+    return cassandra.boolean(value)
   elseif field.type == "table" or field.type == "array" then
     return cjson.encode(value)
   else

--- a/spec/02-integration/03-dao/03-crud_spec.lua
+++ b/spec/02-integration/03-dao/03-crud_spec.lua
@@ -402,6 +402,14 @@ helpers.for_each_dao(function(kong_config)
         assert.equal(1, #rows)
         assert.same(first_api, rows[1])
       end)
+      it("support a boolean filter", function()
+        local rows, err, _ = apis:find_page {
+          name = "fixture_2",
+          https_only = "false"
+        }
+        assert.falsy(err)
+        assert.is_table(rows)
+      end)
       describe("errors", function()
         it("handle invalid arg", function()
           assert.has_error(function()


### PR DESCRIPTION
### Summary

Correctly serialize boolean values in Cassandra.

### Issues resolved

Queries filtering on boolean values would result in an error. At the admin API level, this can be reproduced by issuing a request that filters on a boolean field - e.g., `GET /apis?preserve_host=false`, which will result in a 500 response.