### PR TITLE
feat(schema) friendlier behavior for at_least_one_of

### DIFF
--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -366,6 +366,7 @@ end
 Schema.entity_checkers = {
 
   at_least_one_of = {
+    run_with_missing_fields = true,
     fn = function(entity, field_names)
       for _, name in ipairs(field_names) do
         if is_nonempty(entity[name]) then
@@ -736,9 +737,11 @@ local function run_entity_check(self, name, input, arg)
   local all_nil = true
   for _, fname in ipairs(fields_to_check) do
     if input[fname] == nil then
-      local err = validation_errors.REQUIRED_FOR_ENTITY_CHECK:format(fname)
-      field_errors[fname] = err
-      ok = false
+      if not checker.run_with_missing_fields then
+        local err = validation_errors.REQUIRED_FOR_ENTITY_CHECK:format(fname)
+        field_errors[fname] = err
+        ok = false
+      end
     else
       all_nil = false
     end

--- a/spec/02-integration/000-new-dao/02-db_core_entities_spec.lua
+++ b/spec/02-integration/000-new-dao/02-db_core_entities_spec.lua
@@ -551,7 +551,7 @@ for _, strategy in helpers.each_strategy() do
           setup(function()
             assert(db:truncate())
 
-            for i = 1, 2000 do
+            for i = 1, 1002 do
               bp.routes:insert({ hosts = { "example-" .. i .. ".com" } })
             end
           end)
@@ -565,7 +565,7 @@ for _, strategy in helpers.each_strategy() do
           end)
 
           it("max page_size = 1000", function()
-            local rows, err, err_t = db.routes:page(2000)
+            local rows, err, err_t = db.routes:page(1002)
             assert.is_nil(err_t)
             assert.is_nil(err)
             assert.is_table(rows)
@@ -1520,7 +1520,7 @@ for _, strategy in helpers.each_strategy() do
             it("max page_size = 1000", function()
               local rows, err, err_t = db.routes:for_service({
                 id = service.id,
-              }, 2000)
+              }, 1002)
               assert.is_nil(err_t)
               assert.is_nil(err)
               assert.equal(1000, #rows)

--- a/spec/02-integration/000-new-dao/02-db_core_entities_spec.lua
+++ b/spec/02-integration/000-new-dao/02-db_core_entities_spec.lua
@@ -359,7 +359,7 @@ for _, strategy in helpers.each_strategy() do
           assert.is_nil(new_route)
           local message = unindent([[
             schema violation
-            (at least one of these fields must be non-empty: 'methods', 'hosts', 'paths')
+            (when updating, at least one of these fields must be non-empty: 'methods', 'hosts', 'paths')
           ]], true, true)
           assert.equal(fmt("[%s] %s", strategy, message), err)
           assert.same({
@@ -369,7 +369,7 @@ for _, strategy in helpers.each_strategy() do
             message     = message,
             fields      = {
               ["@entity"] = {
-                "at least one of these fields must be non-empty: 'methods', 'hosts', 'paths'",
+                "when updating, at least one of these fields must be non-empty: 'methods', 'hosts', 'paths'",
               }
             }
           }, err_t)
@@ -432,11 +432,11 @@ for _, strategy in helpers.each_strategy() do
             strategy    = strategy,
             message  = unindent([[
               schema violation
-              (at least one of these fields must be non-empty: 'methods', 'hosts', 'paths')
+              (when updating, at least one of these fields must be non-empty: 'methods', 'hosts', 'paths')
             ]], true, true),
             fields   = {
               ["@entity"] = {
-                "at least one of these fields must be non-empty: 'methods', 'hosts', 'paths'",
+                "when updating, at least one of these fields must be non-empty: 'methods', 'hosts', 'paths'",
               }
             },
           }, err_t)

--- a/spec/02-integration/000-new-dao/02-db_core_entities_spec.lua
+++ b/spec/02-integration/000-new-dao/02-db_core_entities_spec.lua
@@ -48,13 +48,13 @@ for _, strategy in helpers.each_strategy() do
             strategy = strategy,
             message  = unindent([[
               2 schema violations
-              (at least one of 'methods', 'hosts' or 'paths' must be non-empty;
+              (at least one of these fields must be non-empty: 'methods', 'hosts', 'paths';
               service: required field missing)
             ]], true, true),
             fields   = {
               service     = "required field missing",
               ["@entity"] = {
-                "at least one of 'methods', 'hosts' or 'paths' must be non-empty",
+                "at least one of these fields must be non-empty: 'methods', 'hosts', 'paths'",
               }
             },
 
@@ -359,7 +359,7 @@ for _, strategy in helpers.each_strategy() do
           assert.is_nil(new_route)
           local message = unindent([[
             schema violation
-            (at least one of 'methods', 'hosts' or 'paths' must be non-empty)
+            (at least one of these fields must be non-empty: 'methods', 'hosts', 'paths')
           ]], true, true)
           assert.equal(fmt("[%s] %s", strategy, message), err)
           assert.same({
@@ -369,7 +369,7 @@ for _, strategy in helpers.each_strategy() do
             message     = message,
             fields      = {
               ["@entity"] = {
-                "at least one of 'methods', 'hosts' or 'paths' must be non-empty",
+                "at least one of these fields must be non-empty: 'methods', 'hosts', 'paths'",
               }
             }
           }, err_t)
@@ -432,11 +432,11 @@ for _, strategy in helpers.each_strategy() do
             strategy    = strategy,
             message  = unindent([[
               schema violation
-              (at least one of 'methods', 'hosts' or 'paths' must be non-empty)
+              (at least one of these fields must be non-empty: 'methods', 'hosts', 'paths')
             ]], true, true),
             fields   = {
               ["@entity"] = {
-                "at least one of 'methods', 'hosts' or 'paths' must be non-empty",
+                "at least one of these fields must be non-empty: 'methods', 'hosts', 'paths'",
               }
             },
           }, err_t)

--- a/spec/02-integration/04-admin_api/20-routes_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/20-routes_routes_spec.lua
@@ -121,13 +121,13 @@ for _, strategy in helpers.each_strategy("postgres") do
                 name    = "schema violation",
                 message = unindent([[
                   2 schema violations
-                  (at least one of 'methods', 'hosts' or 'paths' must be non-empty;
+                  (at least one of these fields must be non-empty: 'methods', 'hosts', 'paths';
                   service: required field missing)
                 ]], true, true),
                 fields  = {
                   service   = "required field missing",
                   ["@entity"] = {
-                    "at least one of 'methods', 'hosts' or 'paths' must be non-empty"
+                    "at least one of these fields must be non-empty: 'methods', 'hosts', 'paths'"
                   }
                 }
               }, cjson.decode(body))


### PR DESCRIPTION
Make the behavior of the validation of routes friendlier:

Without this patch, if a user performs a PATCH request without giving explicit values to all three of `methods`, `hosts` or `paths`, we reject the request because we need to cross-check all three fields to ensure that at least one of those is not-null. If only one of those
is to be set, the user needs to explicitly set the other two to `null` in the request.

With this patch, if a user performs a PATCH request giving one non-empty value for at least one of `methods`, `hosts` or `paths`, we now accept it even if the other fields are missing, because this request cannot put these fields in an invalid state.

This was implementing in a very simple way, by adding a new internal property to `entity_checkers`, called `run_with_missing_fields`. Currently, the only entity checker that can run with missing fields is `at_least_one_of`, which is used by the Route entity.

This PR includes a "progression" test ( :) ). Note that this causes a couple of error messages to change, but I don't this should be considered a serious breaking change (especially since users are way less likely to bump into these errors with this patch).

Closes #3361.