### PR TITLE
feat (config) allow the user the ability to change

### DIFF
--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -67,6 +67,8 @@ local CONF_INFERENCES = {
   real_ip_header = {typ = "string"},
   real_ip_recursive = {typ = "ngx_boolean"},
   client_max_body_size = {typ = "string"},
+  large_client_header_buffer_count = {typ = "number"},
+  large_client_header_buffer_size = {typ = "string"},
   client_body_buffer_size = {typ = "string"},
   error_default_type = {enum = {"application/json", "application/xml",
                                 "text/html", "text/plain"}},

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -31,6 +31,8 @@ trusted_ips = NONE
 real_ip_header = X-Real-IP
 real_ip_recursive = off
 client_max_body_size = 0
+large_client_header_buffer_count = 4
+large_client_header_buffer_size = 8k
 client_body_buffer_size = 8k
 error_default_type = text/plain
 

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -19,6 +19,7 @@ error_log ${{PROXY_ERROR_LOG}} ${{LOG_LEVEL}};
 >-- reset_timedout_connection on; # disabled until benchmarked
 > end
 
+large_client_header_buffers ${{LARGE_CLIENT_HEADER_BUFFER_COUNT}} ${{LARGE_CLIENT_HEADER_BUFFER_SIZE}};
 client_max_body_size ${{CLIENT_MAX_BODY_SIZE}};
 proxy_ssl_server_name on;
 underscores_in_headers on;

--- a/spec/01-unit/003-prefix_handler_spec.lua
+++ b/spec/01-unit/003-prefix_handler_spec.lua
@@ -176,6 +176,19 @@ describe("NGINX conf compiler", function()
       local nginx_conf = prefix_handler.compile_kong_conf(conf)
       assert.matches("error_log syslog:server=.+:61828 error;", nginx_conf)
     end)
+    it("defines the wlarge_client_header_buffers by default", function()
+      local conf = assert(conf_loader(nil, {}))
+      local nginx_conf = prefix_handler.compile_kong_conf(conf)
+      assert.matches("large_client_header_buffers 4 8k", nginx_conf, nil, true)
+    end)
+    it("writes the large_client_header_buffers as defined", function()
+      local conf = assert(conf_loader(nil, {
+        large_client_header_buffer_count = 16,
+        large_client_header_buffer_size = "32k",
+      }))
+      local nginx_conf = prefix_handler.compile_kong_conf(conf)
+      assert.matches("large_client_header_buffers 16 32k", nginx_conf, nil, true)
+    end)
     it("defines the client_max_body_size by default", function()
       local conf = assert(conf_loader(nil, {}))
       local nginx_conf = prefix_handler.compile_kong_conf(conf)
@@ -188,6 +201,10 @@ describe("NGINX conf compiler", function()
       local nginx_conf = prefix_handler.compile_kong_conf(conf)
       assert.matches("client_max_body_size 1m", nginx_conf, nil, true)
     end)
+
+
+
+
     it("defines the client_body_buffer_size directive by default", function()
       local conf = assert(conf_loader(nil, {}))
       local nginx_conf = prefix_handler.compile_kong_conf(conf)
@@ -489,4 +506,3 @@ describe("NGINX conf compiler", function()
     end)
   end)
 end)
-


### PR DESCRIPTION
### Summary

large_client_header_buffers nginx configuration option in kong.conf

Nginx returns "400 Request Header Or Cookie Too Large" when cookies are
too large, so the large_client_header_buffers needs to be configured to
allow large cookie request through Kong.

### Full changelog

* set nginx default in kong_defaults.lua
* allow overrides in the templating
* tests to ensure that changes git picked up

### Issues resolved

