### PR TITLE
Started at enclosed in ""

### DIFF
--- a/kong/plugins/log-serializers/basic.lua
+++ b/kong/plugins/log-serializers/basic.lua
@@ -43,7 +43,7 @@ function _M.serialize(ngx)
     api = ngx.ctx.api,
     consumer = ngx.ctx.authenticated_consumer,
     client_ip = ngx.var.remote_addr,
-    started_at = ngx.req.start_time() * 1000
+    started_at = ngx.req.start_time() * 1000,
     started_at_unix_ms = "" .. ngx.req.start_time() * 1000 .. ""
   }
 end

--- a/kong/plugins/log-serializers/basic.lua
+++ b/kong/plugins/log-serializers/basic.lua
@@ -44,6 +44,7 @@ function _M.serialize(ngx)
     consumer = ngx.ctx.authenticated_consumer,
     client_ip = ngx.var.remote_addr,
     started_at = ngx.req.start_time() * 1000
+    started_at_unix_ms = "" .. ngx.req.start_time() * 1000 .. ""
   }
 end
 


### PR DESCRIPTION
Sending logs to elastic search through HTTP-LOG plugin, don't work with Kibana because timestamp is not able to work with default started at variable in pipeline that was setup in Elastic Search. Doing debug in elastic search we can see problem it is expecting a string. I have been manually adding this code since version 8, it will be nice if Kong can add this to official distribution.

NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

### Summary

SUMMARY_GOES_HERE

### Full changelog

* [Implement ...]
* [Add related tests]
* ...

### Issues resolved

Fix #XXX
