### PR TITLE
fix(dao) properly serialize string booleans

### DIFF
--- a/kong/dao/db/cassandra.lua
+++ b/kong/dao/db/cassandra.lua
@@ -324,9 +324,9 @@ local function serialize_arg(field, value)
   elseif field.type == "boolean" then
     if type(value) == "boolean" then
       return cassandra.boolean(value)
-    else
-      return cassandra.boolean(value == 'true')
     end
+
+    return cassandra.boolean(value == "true")
   elseif field.type == "table" or field.type == "array" then
     return cjson.encode(value)
   else

--- a/kong/dao/db/cassandra.lua
+++ b/kong/dao/db/cassandra.lua
@@ -322,7 +322,11 @@ local function serialize_arg(field, value)
   elseif field.type == "timestamp" then
     return cassandra.timestamp(value)
   elseif field.type == "boolean" then
-    return cassandra.boolean(value)
+    if type(value) == "boolean" then
+      return cassandra.boolean(value)
+    else
+      return cassandra.boolean(value == 'true')
+    end
   elseif field.type == "table" or field.type == "array" then
     return cjson.encode(value)
   else

--- a/spec/02-integration/03-dao/03-crud_spec.lua
+++ b/spec/02-integration/03-dao/03-crud_spec.lua
@@ -407,11 +407,14 @@ helpers.for_each_dao(function(kong_config)
 
       local run_boolean_checks = true
 
+      -- Filtering on non-primary key columns only supported in C* 3.5+
+      -- Since we do not maintain an index on https_only we can
+      -- only run the boolean checks against Cassandra 3.5+
       if kong_config.database == "cassandra" then
         local db_infos = factory.db:infos()
         if db_infos.version ~= "unknown" then
           local db_v = version.version(db_infos.version)
-          local min_v = version.version("3.0") -- 3.5 is the minimum version, but parsed we get 3.0
+          local min_v = version.version("3.5")
           run_boolean_checks = db_v >= min_v
         end
       end

--- a/spec/02-integration/03-dao/03-crud_spec.lua
+++ b/spec/02-integration/03-dao/03-crud_spec.lua
@@ -326,10 +326,15 @@ helpers.for_each_dao(function(kong_config)
         factory:truncate_tables()
 
         for i = 1, 100 do
+          local https_only = true
+          if i == 5 then
+            https_only = false
+          end
           local api, err = apis:insert {
             name = "fixture_" .. i,
             hosts = { "fixture" .. i .. ".com" },
-            upstream_url = "http://fixture.org"
+            upstream_url = "http://fixture.org",
+            https_only = https_only
           }
           assert.falsy(err)
           assert.truthy(api)
@@ -402,7 +407,15 @@ helpers.for_each_dao(function(kong_config)
         assert.equal(1, #rows)
         assert.same(first_api, rows[1])
       end)
-      it("filter supports a boolean value", function()
+      it("filter supports a truthy boolean value", function()
+        local rows, err, _ = apis:find_page {
+          name = "fixture_5",
+          https_only = "true"
+        }
+        assert.falsy(err)
+        assert.is_table(rows)
+      end)
+      it("filter supports a false boolean value", function()
         local rows, err, _ = apis:find_page {
           name = "fixture_2",
           https_only = "false"

--- a/spec/02-integration/03-dao/03-crud_spec.lua
+++ b/spec/02-integration/03-dao/03-crud_spec.lua
@@ -326,15 +326,11 @@ helpers.for_each_dao(function(kong_config)
         factory:truncate_tables()
 
         for i = 1, 100 do
-          local https_only = true
-          if i == 5 then
-            https_only = false
-          end
           local api, err = apis:insert {
             name = "fixture_" .. i,
             hosts = { "fixture" .. i .. ".com" },
             upstream_url = "http://fixture.org",
-            https_only = https_only
+            https_only = i == 5
           }
           assert.falsy(err)
           assert.truthy(api)

--- a/spec/02-integration/03-dao/03-crud_spec.lua
+++ b/spec/02-integration/03-dao/03-crud_spec.lua
@@ -409,19 +409,23 @@ helpers.for_each_dao(function(kong_config)
       end)
       it("filter supports a truthy boolean value", function()
         local rows, err, _ = apis:find_page {
-          name = "fixture_5",
           https_only = "true"
         }
         assert.falsy(err)
         assert.is_table(rows)
+        assert.equal(1, #rows)
+        assert.equal(true, rows[1].https_only)
+        assert.equal("fixture_5", rows[1].name)
       end)
       it("filter supports a false boolean value", function()
         local rows, err, _ = apis:find_page {
-          name = "fixture_2",
           https_only = "false"
         }
         assert.falsy(err)
         assert.is_table(rows)
+        for i = 1, #rows do
+          assert.equal(false, rows[i].https_only)
+        end
       end)
       describe("errors", function()
         it("handle invalid arg", function()


### PR DESCRIPTION
### Summary

Correctly serialize string based boolean values for Cassandra.

### Issues resolved

Filtering on boolean values through API queries would always result in a
list of truthy based results. This is because the value passed to
serialize_arg is of type string. This can be reproduced by issuing a
request against entities with true fields with a query filter of false.