### PR TITLE
chore(deps) bump lua-resty-worker-events to 0.3.2

### DIFF
--- a/kong-0.13.0-0.rockspec
+++ b/kong-0.13.0-0.rockspec
@@ -28,7 +28,7 @@ dependencies = {
   "luasyslog == 1.0.0",
   "lua_pack == 1.0.5",
   "lua-resty-dns-client == 2.0.0",
-  "lua-resty-worker-events == 0.3.1",
+  "lua-resty-worker-events == 0.3.2",
   "lua-resty-mediador == 0.1.2",
   "lua-resty-healthcheck == 0.4.0",
 }


### PR DESCRIPTION
This worker events release includes a fix in error handling, and improved stacktraces.
