### PR TITLE
chore(core) fix a typo in comments of globalpatches.lua

### DIFF
--- a/kong/core/globalpatches.lua
+++ b/kong/core/globalpatches.lua
@@ -83,7 +83,7 @@ return function(options)
       -- with minor fixes and addtions such as exptime
       --
       -- See https://github.com/openresty/resty-cli/pull/12
-      -- for a definitive solution ot using shms in CLI
+      -- for a definitive solution of using shms in CLI
       local SharedDict = {}
       local function set(data, key, value)
         data[key] = {


### PR DESCRIPTION
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

### Summary

This PR fixes an typo in `core/globalpatches.lua`.

### Full changelog

* Change **ot** to **of**.

### Issues resolved

