### PR TITLE
fix(aws-lambda) fix a typo in request headers

### DIFF
--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -96,7 +96,7 @@ function AWSLambdaHandler:access(conf)
     headers = {
       ["X-Amz-Target"] = "invoke",
       ["X-Amz-Invocation-Type"] = conf.invocation_type,
-      ["X-Amx-Log-Type"] = conf.log_type,
+      ["X-Amz-Log-Type"] = conf.log_type,
       ["Content-Type"] = "application/x-amz-json-1.1",
       ["Content-Length"] = upstream_body_json and tostring(#upstream_body_json),
     },


### PR DESCRIPTION
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

### Summary

This PR fixes a typo in the `aws-lambda` plugin.

### Full changelog

* Change the request header `X-Amx-Log-Type` to `X-Amz-Log-Type`.

### Issues resolved


