### PR TITLE
fix(cluster-events) log recurring timer failed to start to ngx.CRIT

### DIFF
--- a/kong/cluster_events.lua
+++ b/kong/cluster_events.lua
@@ -4,6 +4,7 @@ local public = require "kong.tools.public"
 local ngx_debug = ngx.config.debug
 local DEBUG     = ngx.DEBUG
 local ERR       = ngx.ERR
+local CRIT      = ngx.CRIT
 local max       = math.max
 local type      = type
 local pcall     = pcall
@@ -343,7 +344,7 @@ poll_handler = function(premature, self)
   if not get_lock(self) then
     local ok, err = timer_at(self.poll_interval, poll_handler, self)
     if not ok then
-      log(ERR, "failed to start recurring polling timer: ", err)
+      log(CRIT, "failed to start recurring polling timer: ", err)
     end
 
     return
@@ -365,7 +366,7 @@ poll_handler = function(premature, self)
 
   local ok, err = timer_at(self.poll_interval, poll_handler, self)
   if not ok then
-    log(ERR, "failed to start recurring polling timer: ", err)
+    log(CRIT, "failed to start recurring polling timer: ", err)
   end
 end
 


### PR DESCRIPTION
### Summary

If Kong fails to create a recurring timer when `poll_handler` is called, we now log this to `ngx.CRIT` level.

The reason of doing this is, if a recurring timer ever fails to create or start, any function that relies on this, like health check or cache invalidation, will stop working from then. This is a serious situation and deserves the CRIT level.

### Full changelog

* Change log level to ngx.CRIT when recurring timer fails to start.

### Issues resolved

