### PR TITLE
hotfix(dao) ensure 'init()' errors are prefixed with DB name

### DIFF
--- a/kong/dao/db/postgres.lua
+++ b/kong/dao/db/postgres.lua
@@ -94,7 +94,7 @@ end
 function _M:init()
   local res, err = self:query("SHOW server_version;")
   if not res then
-    return nil, err
+    return nil, Errors.db("could not retrieve server_version: " .. err)
   end
 
   if #res < 1 or not res[1].server_version then

--- a/kong/dao/factory.lua
+++ b/kong/dao/factory.lua
@@ -167,14 +167,14 @@ end
 function _M:init()
   local ok, err = self.db:init()
   if not ok then
-    return nil, err
+    return ret_error_string(self.db_type, nil, err)
   end
 
   local db_constants = constants.DATABASE[self.db_type:upper()]
 
   ok, err = self:check_version_compat(db_constants.MIN, db_constants.DEPRECATED)
   if not ok then
-    return nil, err
+    return ret_error_string(self.db_type, nil, err)
   end
 
   return true

--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -142,6 +142,14 @@ describe("kong start/stop", function()
         assert.False(ok)
         assert.matches("the current database schema does not match this version of Kong.", stderr)
       end)
+      it("connection check errors are prefixed with DB-specific prefix", function()
+        local ok, stderr = helpers.kong_exec("start --conf " .. helpers.test_conf_path, {
+          pg_port = 99999,
+          cassandra_port = 99999,
+        })
+        assert.False(ok)
+        assert.matches("[" .. helpers.test_conf.database .. " error]", stderr, 1, true)
+      end)
     end)
   end)
 

--- a/spec/02-integration/03-dao/01-factory_spec.lua
+++ b/spec/02-integration/03-dao/01-factory_spec.lua
@@ -20,6 +20,26 @@ helpers.for_each_dao(function(kong_conf)
     end)
   end)
 
+  describe(":init()", function()
+    it("returns DB-specific error string", function()
+      local pg_port = kong_conf.pg_port
+      local cassandra_port = kong_conf.cassandra_port
+
+      finally(function()
+        kong_conf.pg_port = pg_port
+        kong_conf.cassandra_port = cassandra_port
+      end)
+
+      kong_conf.pg_port = 9999
+      kong_conf.cassandra_port = 9999
+
+      local factory = assert(Factory.new(kong_conf))
+      local ok, err = factory:init()
+      assert.is_nil(ok)
+      assert.matches("[" .. kong_conf.database .. " error]", err, 1, true)
+    end)
+  end)
+
   describe(":init() + :infos()", function()
     it("returns DB info + 'unknown' for version if missing", function()
       local factory = assert(Factory.new(kong_conf))


### PR DESCRIPTION
This fixes a regression introduced in #3310.

If the database is unreachabel when Kong start, it is our policy that
the error message be prefixed with `[postgres error]` (in the case of
PostgreSQL) to help the user troubleshoot the issue.

Prior to this patch, this behavior was changed in #3310, since it
introduced a call to `init()` in the CLI. Users would see:
```
$ kong start
Error: connection refused
```

Instead of:
```
$ kong start
Error: [postgres error] could not retrieve server_version: connection refused
```