### PR TITLE
feat(admin) implement inferring, endpoint key and put support

### DIFF
--- a/kong/api/arguments.lua
+++ b/kong/api/arguments.lua
@@ -1,12 +1,10 @@
 local cjson         = require "cjson.safe"
 local upload        = require "resty.upload"
-local utils         = require "kong.tools.utils"
 
 
 local setmetatable  = setmetatable
 local getmetatable  = getmetatable
 local tonumber      = tonumber
-local tostring      = tostring
 local rawget        = rawget
 local concat        = table.concat
 local insert        = table.insert
@@ -14,7 +12,6 @@ local ipairs        = ipairs
 local pairs         = pairs
 local lower         = string.lower
 local find          = string.find
-local fmt           = string.format
 local sub           = string.sub
 local type          = type
 local ngx           = ngx
@@ -27,7 +24,6 @@ local get_uri_args  = req.get_uri_args
 local get_body_data = req.get_body_data
 local get_post_args = req.get_post_args
 local json_decode   = cjson.decode
-local json_encode   = cjson.encode
 
 
 local NOTICE        = ngx.NOTICE
@@ -59,6 +55,8 @@ end
 
 
 local defaults = {
+  decode        = true,
+  multipart     = true,
   timeout       = 1000,
   chunk_size    = 4096,
   max_uri_args  = 100,
@@ -68,56 +66,7 @@ local defaults = {
 }
 
 
-local function escape_unescaped_double_quotes(value)
-  if type(value) ~= "string" then
-    return nil
-  end
-
-  local s = find(value, '"', 1, true)
-
-  if not s then
-    return value
-  end
-
-  local r = {}
-  local i = 0
-  local p = 1
-
-  while s do
-    local escape = false
-    if s == 1 then
-      escape = true
-
-    else
-      local backslashes = 0
-
-      for n = s - 1, p, -1 do
-        if sub(value, n, n) ~= [[\]] then
-          break
-        end
-
-        backslashes = backslashes + 1
-      end
-
-      if backslashes % 2 == 0 then
-        escape = true
-      end
-    end
-
-    if escape then
-      r[i + 1] = sub(value, p, s - 1)
-      r[i + 2] = [[\"]]
-      i = i + 2
-      p = s + 1
-    end
-
-    s = find(value, '"', s + 1, true)
-  end
-
-  r[i + 1] = sub(value, p)
-
-  return concat(r)
-end
+defaults.__index = defaults
 
 
 local function basename(path, separator)
@@ -147,7 +96,7 @@ local function basename(path, separator)
 end
 
 
-local function content_type_boundary(content_type)
+local function find_content_type_boundary(content_type)
   if not content_type then
     return nil
   end
@@ -161,6 +110,11 @@ local function content_type_boundary(content_type)
 
     else
       boundary = sub(content_type, e + 1)
+    end
+
+    if (sub(boundary, 1, 1) == '"' and sub(boundary, -1)  == '"') or
+       (sub(boundary, 1, 1) == "'" and sub(boundary, -1)  == "'") then
+      boundary = sub(boundary, 2, -2)
     end
   end
 
@@ -212,32 +166,79 @@ local function combine(args)
 end
 
 
-local function decode_value(value)
-  if type(value) == "string" then
-    if value == "" then
-      return ngx.null
-    end
+local infer
 
+
+local function infer_value(value, field)
+  if not value or type(field) ~= "table" then
+    return value
+  end
+
+  if value == "" then
+    return ngx.null
+  end
+
+  if field.type == "number" or field.type == "integer" then
+    return tonumber(value) or value
+
+  elseif field.type == "boolean" then
     if value == "true" then
       return true
-    end
 
-    if value == "false" then
+    elseif value == "false" then
       return false
     end
 
-    local n = tonumber(value)
-    if n then
-      return n
+  elseif field.type == "array" or field.type == "set" then
+    if type(value) ~= "table" then
+      value = { value }
     end
 
-  elseif type(value) == "table" then
-    for i, v in ipairs(value) do
-      value[i] = decode_value(v)
+    for i, item in ipairs(value) do
+      value[i] = infer_value(item, field.elements)
+    end
+
+  elseif field.type == "foreign" then
+    if type(value) == "table" then
+      return infer(value, field.schema)
+    end
+
+  elseif field.type == "map" then
+    if type(value) == "table" then
+      for k, v in pairs(value) do
+        value[k] = infer_value(v, field.elements)
+      end
+    end
+
+  elseif field.type == "record" then
+    if type(value) == "table" then
+      for k, v in pairs(value) do
+        value[k] = infer_value(v, field.fields[k])
+      end
     end
   end
 
   return value
+end
+
+
+infer = function(args, schema)
+  if not args then
+    return
+  end
+
+  if not schema then
+    return args
+  end
+
+  for field_name, field in schema:each_field() do
+    local value = args[field_name]
+    if value then
+      args[field_name] = infer_value(value, field)
+    end
+  end
+
+  return args
 end
 
 
@@ -358,7 +359,7 @@ local function decode_arg(name, value)
 end
 
 
-local function decode(args)
+local function decode(args, schema)
   local i = 0
   local r = {}
 
@@ -368,158 +369,26 @@ local function decode(args)
 
   for name, value in pairs(args) do
     i = i + 1
-    r[i] = decode_arg(name, decode_value(value))
+    r[i] = decode_arg(name, value)
   end
 
-  return combine(r)
-end
-
-
-local function encode_value(value)
-  if value == ngx.null then
-    return ""
-  end
-
-  if getmetatable(value) == multipart_mt then
-    return value
-  end
-
-  return tostring(value)
-end
-
-
-local function encode_args(args, results, prefix)
-  if type(args) ~= "table" then
-    return results
-  end
-
-  for k, v in pairs(args) do
-    local name
-
-    if prefix then
-      if type(k) == "number" then
-        name = fmt("%s[%d]", prefix, k)
-
-      else
-        if sub(prefix, -1) == "." then
-          name = prefix .. k
-
-        else
-          name = fmt("%s.%s", prefix, k)
-        end
-      end
-
-    else
-      if type(k) == "number" then
-        name = fmt("[%d]", prefix, k)
-
-      else
-        name = k
-      end
-    end
-
-    if type(v) == "table" and getmetatable(v) ~= multipart_mt then
-      encode_args(v, results, name)
-
-    else
-      results[name] = encode_value(v)
-    end
-  end
-
-  return results
-end
-
-
-local function encode(args, content_type)
-  if not content_type then
-    content_type = ngx.var.content_type
-
-    if not content_type then
-      return nil, "missing encoding content type"
-    end
-
-    if type(content_type) == "table" then
-      content_type = content_type[1]
-    end
-  end
-
-  if sub(content_type, 1, 33) == "application/x-www-form-urlencoded" then
-    return ngx.encode_args(encode_args(args, {}))
-
-  elseif sub(content_type, 1, 19) == "multipart/form-data" then
-    local boundary = content_type_boundary(content_type) or utils.random_string()
-
-    local encoded_args = encode_args(args, {})
-    local i = 0
-    local r = {}
-
-    for k, v in pairs(encoded_args) do
-      r[i + 1] = "\r\n--"
-      r[i + 2] = boundary
-      r[i + 3] = "\r\n"
-      r[i + 4] = 'Content-Disposition: form-data; name="'
-      r[i + 5] = escape_unescaped_double_quotes(k)
-      r[i + 6] = '"'
-
-      i = i + 6
-
-      if getmetatable(v) == multipart_mt then
-
-        if v.filename then
-          r[i + 1] = '" filename="'
-          r[i + 2] = escape_unescaped_double_quotes(v.filename)
-          r[i + 3] = '"\r\n'
-
-          i = i + 3
-        end
-
-        if v.type then
-          r[i + 1] = "Content-Type: "
-          r[i + 2] = v.type
-
-          i = i + 2
-        end
-
-        r[i + 1] = "\r\n\r\n"
-        r[i + 2] = v.data
-
-        i = i + 2
-
-      else
-        r[i + 1] = "\r\n\r\n"
-        r[i + 2] = v
-
-        i = i + 2
-      end
-    end
-
-    if i > 0 then
-      r[i + 1] = "\r\n--"
-      r[i + 2] = boundary
-      r[i + 3] = "--"
-
-      i = i + 3
-
-      return concat(r, nil, 1, i)
-    end
-
-    return ""
-
-  elseif sub(content_type, 1, 16) == "application/json" then
-    return json_encode(args)
-  end
-
-  return nil, "unsupported encoding content type '" .. content_type .. "'"
+  return infer(combine(r), schema)
 end
 
 
 local function parse_multipart_header(header, results)
-  local name, value
+  local name
+  local value
 
   local boundary = find(header, "=", 1, true)
   if boundary then
-    name = sub(header, 2, boundary - 1)
+    name  = sub(header, 2, boundary - 1)
     value = sub(header, boundary + 2, -2)
+
+    if (sub(value, 1, 1) == '"' and sub(value, -1)  == '"') or
+       (sub(value, 1, 1) == "'" and sub(value, -1)  == "'") then
+      value = sub(value, 2, -2)
+    end
 
     if sub(name, -1) == "*" and lower(sub(value, 1, 7)) == "utf-8''" then
       name = sub(name, 1, -2)
@@ -564,25 +433,19 @@ local function parse_multipart_headers(headers)
 end
 
 
-local function parse_multipart(options, content_type)
-  local boundary
-
-  if content_type then
-    boundary = content_type_boundary(content_type)
-  end
-
+local function parse_multipart_stream(options, boundary)
   local part_args = {}
 
-  local max_part_size = options.max_part_size or defaults.max_part_size
-  local max_post_args = options.max_post_args or defaults.max_post_args
-  local chunk_size    = options.chunk_size    or defaults.chunk_size
+  local max_part_size = options.max_part_size
+  local max_post_args = options.max_post_args
+  local chunk_size    = options.chunk_size
 
-  local multipart, err = upload:new(chunk_size, options.max_line_size or defaults.max_line_size)
+  local multipart, err = upload:new(chunk_size, options.max_line_size)
   if not multipart then
     return nil, err
   end
 
-  multipart:set_timeout(options.timeout or defaults.timeout)
+  multipart:set_timeout(options.timeout)
 
   local parts_count = 0
 
@@ -707,35 +570,38 @@ local function parse_multipart(options, content_type)
     end
   end
 
+  multipart:read()
+
   return part_args
 end
 
 
-local function load(options)
-  options = options or defaults
+local function parse_multipart(options, content_type)
+  local boundary
+
+  if content_type then
+    boundary = find_content_type_boundary(content_type)
+  end
+
+  return parse_multipart_stream(options, boundary)
+end
+
+
+local function load(opts)
+  local options = setmetatable(opts or {}, defaults)
 
   local args  = setmetatable({
     uri  = {},
     post = {},
   }, arguments_mt)
 
-  args.uri = decode(get_uri_args(options.max_uri_args or defaults.max_uri_args))
+  local uargs = get_uri_args(options.max_uri_args)
 
-  local content_length = ngx.var.content_length
-  if content_length then
-    if type(content_length) == "table" then
-      content_length = content_length[1]
-    end
+  if options.decode then
+    args.uri = decode(uargs, options.schema)
 
-    if content_length == "0" then
-      return args
-    end
-
-    content_length = tonumber(content_length)
-
-    if content_length and content_length < 1 then
-      return args
-    end
+  else
+    args.uri = uargs
   end
 
   local content_type = ngx.var.content_type
@@ -743,36 +609,29 @@ local function load(options)
     return args
   end
 
-  if type(content_type) == "table" then
-    content_type = content_type[1]
-  end
+  local content_type_lower = lower(content_type)
 
-  if sub(content_type, 1, 33) == "application/x-www-form-urlencoded" then
+  if find(content_type_lower, "application/x-www-form-urlencoded", 1, true) == 1 then
     req_read_body()
-    local pargs, err = get_post_args(options.max_post_args or defaults.max_post_args)
+    local pargs, err = get_post_args(options.max_post_args)
     if pargs then
-      args.post = decode(pargs)
+      if options.decode then
+        args.post = decode(pargs, options.schema)
+
+      else
+        args.post = pargs
+      end
 
     elseif err then
       log(NOTICE, err)
     end
 
-  elseif sub(content_type, 1, 19) == "multipart/form-data" then
-    local pargs, err = parse_multipart(options, content_type)
-    if pargs then
-      args.post = decode(pargs)
-
-    elseif err then
-      log(NOTICE, err)
-    end
-
-  elseif sub(content_type, 1, 16) == "application/json" then
+  elseif find(content_type_lower, "application/json", 1, true) == 1 then
     req_read_body()
 
     -- we don't support file i/o in case the body is
     -- buffered to a file, and that is how we want it.
     local body_data = get_body_data()
-
     if body_data then
       local pargs, err = json_decode(body_data)
       if pargs then
@@ -781,6 +640,31 @@ local function load(options)
       elseif err then
         log(NOTICE, err)
       end
+    end
+
+  elseif options.multipart and find(content_type_lower, "multipart/form-data", 1, true) == 1 then
+    local pargs, err = parse_multipart(options, content_type)
+    if pargs then
+      if options.decode then
+        args.post = decode(pargs, options.schema)
+
+      else
+        args.post = pargs
+      end
+
+    elseif err then
+      log(NOTICE, err)
+    end
+
+  else
+    req_read_body()
+
+    -- we don't support file i/o in case the body is
+    -- buffered to a file, and that is how we want it.
+    local body_data = get_body_data()
+
+    if body_data then
+      args.body = body_data
     end
   end
 
@@ -792,10 +676,8 @@ return {
   load         = load,
   decode       = decode,
   decode_arg   = decode_arg,
-  decode_value = decode_value,
-  encode       = encode,
-  encode_args  = encode,
-  encode_value = encode_value,
+  infer        = infer,
+  infer_value  = infer_value,
   combine      = combine,
   multipart_mt = multipart_mt,
 }

--- a/kong/api/endpoints.lua
+++ b/kong/api/endpoints.lua
@@ -1,13 +1,14 @@
-local Errors      = require "kong.db.errors"
-local responses   = require "kong.tools.responses"
-local utils       = require "kong.tools.utils"
-local app_helpers = require "lapis.application"
+local Errors       = require "kong.db.errors"
+local responses    = require "kong.tools.responses"
+local utils        = require "kong.tools.utils"
+local arguments    = require "kong.api.arguments"
+local app_helpers  = require "lapis.application"
 
 
-local escape_uri  = ngx.escape_uri
-local null        = ngx.null
-local fmt         = string.format
-local sub         = string.sub
+local escape_uri   = ngx.escape_uri
+local unescape_uri = ngx.unescape_uri
+local null         = ngx.null
+local fmt          = string.format
 
 
 -- error codes http status codes
@@ -33,6 +34,27 @@ local function handle_error(err_t)
 end
 
 
+local function select_entity(db, schema, params)
+  local dao = db[schema.name]
+
+  local id = unescape_uri(params[schema.name])
+  if utils.is_valid_uuid(id) then
+    local entity, _, err_t = dao:select({ id = id })
+    if entity or err_t then
+      return entity, _, err_t
+    end
+  end
+
+  if schema.endpoint_key then
+    local field = schema.fields[schema.endpoint_key]
+    local inferred_value = arguments.infer_value(id, field)
+    return dao["select_by_" .. schema.endpoint_key](dao, inferred_value)
+  end
+
+  return dao:select({ id = id })
+end
+
+
 -- Generates admin api get collection endpoint functions
 --
 -- Examples:
@@ -43,18 +65,16 @@ end
 -- and
 --
 -- /services
-local function get_collection_endpoint(schema_name, entity_name,
-                                       parent_schema_name,
-                                       parent_entity_has_unique_name)
-  if not parent_schema_name then
+local function get_collection_endpoint(schema, foreign_schema, foreign_field_name)
+  if not foreign_schema then
     return function(self, db, helpers)
-      local data, _, err_t, offset = db[schema_name]:page(self.args.size,
+      local data, _, err_t, offset = db[schema.name]:page(self.args.size,
                                                           self.args.offset)
       if err_t then
         return handle_error(err_t)
       end
 
-      local next_page = offset and fmt("/%s?offset=%s", schema_name,
+      local next_page = offset and fmt("/%s?offset=%s", schema.name,
                                        escape_uri(offset)) or null
 
       return helpers.responses.send_HTTP_OK {
@@ -66,41 +86,33 @@ local function get_collection_endpoint(schema_name, entity_name,
   end
 
   return function(self, db, helpers)
-    local id = self.params[parent_schema_name]
-
-    -- TODO: composite key support
-    local parent_entity, _, err_t
-    if parent_entity_has_unique_name and not utils.is_valid_uuid(id) then
-      parent_entity, _, err_t = db[parent_schema_name]:select_by_name(id)
-
-    else
-      parent_entity, _, err_t = db[parent_schema_name]:select({ id = id })
-    end
-
+    local foreign_entity, _, err_t = select_entity(db, foreign_schema, self.params)
     if err_t then
       return handle_error(err_t)
     end
 
-    if not parent_entity then
+    if not foreign_entity then
       return helpers.responses.send_HTTP_NOT_FOUND()
     end
 
-    local entity = db[schema_name]
-
-    -- TODO: composite key support
-    local rows, _, err_t, offset = entity["for_" .. entity_name](entity, {
-      id = parent_entity.id
-    }, self.args.size, self.args.offset)
+    local dao = db[schema.name]
+    local data, _, err_t, offset = dao["for_" .. foreign_field_name](dao, { id = foreign_entity.id },
+                                                                     self.args.size, self.args.offset)
     if err_t then
       return handle_error(err_t)
     end
 
-    local next_page = offset and fmt("/%s/%s/%s?offset=%s", parent_schema_name,
-                                     escape_uri(id), schema_name,
-                                     escape_uri(offset)) or null
+    local next_page
+    if offset then
+      next_page = fmt("/%s/%s/%s?offset=%s", foreign_schema.name, escape_uri(foreign_entity.id),
+                      schema.name, escape_uri(offset))
+
+    else
+      next_page = null
+    end
 
     return helpers.responses.send_HTTP_OK {
-      data   = rows,
+      data   = data,
       offset = offset,
       next   = next_page,
     }
@@ -118,40 +130,27 @@ end
 -- and
 --
 -- /services
-local function post_collection_endpoint(schema_name, entity_name,
-                                        parent_schema_name,
-                                        parent_entity_has_unique_name)
+local function post_collection_endpoint(schema, foreign_schema, foreign_field_name)
   return function(self, db, helpers)
-    if parent_schema_name then
-      local id = self.params[parent_schema_name]
-
-      -- TODO: composite key support
-      local parent_entity, _, err_t
-      if parent_entity_has_unique_name and not utils.is_valid_uuid(id) then
-        parent_entity, _, err_t = db[parent_schema_name]:select_by_name(id)
-
-      else
-        parent_entity, _, err_t = db[parent_schema_name]:select({ id = id })
-      end
-
+    if foreign_schema then
+      local foreign_entity, _, err_t = select_entity(db, foreign_schema, self.params)
       if err_t then
         return handle_error(err_t)
       end
 
-      if not parent_entity then
+      if not foreign_entity then
         return helpers.responses.send_HTTP_NOT_FOUND()
       end
 
-      -- TODO: composite key support
-      self.args.post[entity_name] = { id = parent_entity.id }
+      self.args.post[foreign_field_name] = { id = foreign_entity.id }
     end
 
-    local data, _, err_t = db[schema_name]:insert(self.args.post)
+    local entity, _, err_t = db[schema.name]:insert(self.args.post)
     if err_t then
       return handle_error(err_t)
     end
 
-    return helpers.responses.send_HTTP_CREATED(data)
+    return helpers.responses.send_HTTP_CREATED(entity)
   end
 end
 
@@ -166,46 +165,140 @@ end
 -- and
 --
 -- /services/:services
-local function get_entity_endpoint(schema_name, entity_has_unique_name,
-                                   entity_name, parent_schema_name,
-                                   parent_entity_has_unique_name)
+local function get_entity_endpoint(schema, foreign_schema, foreign_field_name)
   return function(self, db, helpers)
-    local entity, _, err_t
+    local entity, _, err_t = select_entity(db, schema, self.params)
+    if err_t then
+      return handle_error(err_t)
+    end
 
-    if not parent_schema_name then
-      local id = self.params[schema_name]
+    if not entity then
+      return helpers.responses.send_HTTP_NOT_FOUND()
+    end
 
-      -- TODO: composite key support
-      if entity_has_unique_name and not utils.is_valid_uuid(id) then
-        entity, _, err_t = db[schema_name]:select_by_name(id)
-
-      else
-        entity, _, err_t = db[schema_name]:select({ id = id })
+    if foreign_schema then
+      local id = entity[foreign_field_name]
+      if not id or id == null then
+        return helpers.responses.send_HTTP_NOT_FOUND()
       end
 
-    else
-      local id = self.params[parent_schema_name]
-
-      -- TODO: composite key support
-      local parent_entity
-      if parent_entity_has_unique_name and not utils.is_valid_uuid(id) then
-        parent_entity, _, err_t = db[parent_schema_name]:select_by_name(id)
-
-      else
-        parent_entity, _, err_t = db[parent_schema_name]:select({ id = id })
-      end
-
+      entity, _, err_t = db[foreign_schema.name]:select(id)
       if err_t then
         return handle_error(err_t)
       end
 
-      if not parent_entity or parent_entity[entity_name] == null then
+      if not entity then
         return helpers.responses.send_HTTP_NOT_FOUND()
       end
-
-      entity, _, err_t = db[schema_name]:select(parent_entity[entity_name])
     end
 
+    return helpers.responses.send_HTTP_OK(entity)
+  end
+end
+
+
+-- Generates admin api put entity endpoint functions
+--
+-- Examples:
+--
+-- /routes/:routes
+-- /routes/:routes/service
+--
+-- and
+--
+-- /services/:services
+local function put_entity_endpoint(schema, foreign_schema, foreign_field_name)
+  if not foreign_schema then
+    return function(self, db, helpers)
+      local entity, _, err_t = select_entity(db, schema, self.params)
+      if err_t then
+        return handle_error(err_t)
+      end
+
+      if entity then
+        local args = schema:process_auto_fields(self.args.post, "insert")
+
+        for key, _ in schema:each_field() do
+          if not args[key] then
+            args[key] = null
+          end
+        end
+
+        args.id = nil
+
+        entity, _, err_t = db[schema.name]:update({ id = entity.id }, args)
+        if err_t then
+          return handle_error(err_t)
+        end
+
+        if not entity then
+          return helpers.responses.send_HTTP_NOT_FOUND()
+        end
+
+        return helpers.responses.send_HTTP_OK(entity)
+
+      else
+        local id = unescape_uri(self.params[schema.name])
+        if utils.is_valid_uuid(id) then
+          self.args.post.id = id
+          entity, _, err_t = db[schema.name]:insert(self.args.post)
+          if err_t then
+            return handle_error(err_t)
+          end
+
+          return helpers.responses.send_HTTP_CREATED(entity)
+        else
+          if schema.endpoint_key then
+            local field = schema.fields[schema.endpoint_key]
+            local inferred_value = arguments.infer_value(id, field)
+            self.args.post[schema.endpoint_key] = inferred_value
+            entity, _, err_t = db[schema.name]:insert(self.args.post)
+            if err_t then
+              return handle_error(err_t)
+            end
+
+            return helpers.responses.send_HTTP_CREATED(entity)
+          end
+
+          self.args.post.id = id
+
+          local entity, _, err_t = db[schema.name]:insert(self.args.post)
+          if err_t then
+            return handle_error(err_t)
+          end
+
+          return helpers.responses.send_HTTP_CREATED(entity)
+        end
+      end
+    end
+  end
+
+  return function(self, db, helpers)
+    local entity, _, err_t = select_entity(db, schema, self.params)
+    if err_t then
+      return handle_error(err_t)
+    end
+
+    if not entity then
+      return helpers.responses.send_HTTP_NOT_FOUND()
+    end
+
+    local id = entity[foreign_field_name]
+    if not id or id == null then
+      return helpers.responses.send_HTTP_NOT_FOUND()
+    end
+
+    local args = foreign_schema:process_auto_fields(self.args.post, "insert")
+
+    for key, field in foreign_schema:each_field() do
+      if not args[key] then
+        args[key] = null
+      end
+    end
+
+    args.id = nil
+
+    entity, _, err_t = db[foreign_schema.name]:update(id, args)
     if err_t then
       return handle_error(err_t)
     end
@@ -229,49 +322,35 @@ end
 -- and
 --
 -- /services/:services
-local function patch_entity_endpoint(schema_name, entity_has_unique_name,
-                                     entity_name, parent_schema_name,
-                                     parent_entity_has_unique_name)
+local function patch_entity_endpoint(schema, foreign_schema, foreign_field_name)
   return function(self, db, helpers)
-    local entity, _, err_t
+    local entity, _, err_t = select_entity(db, schema, self.params)
+    if err_t then
+      return handle_error(err_t)
+    end
 
-    if not parent_schema_name then
-      local id = self.params[schema_name]
+    if not entity then
+      return helpers.responses.send_HTTP_NOT_FOUND()
+    end
 
-      -- TODO: composite key support
-      if entity_has_unique_name and not utils.is_valid_uuid(id) then
-        entity, _, err_t = db[schema_name]:update_by_name(id, self.args.post)
-
-      else
-        entity, _, err_t = db[schema_name]:update({ id = id }, self.args.post)
-      end
+    if not foreign_schema then
+      entity, _, err_t = db[schema.name]:update({ id = entity.id }, self.args.post)
 
     else
-      local id = self.params[parent_schema_name]
-
-      -- TODO: composite key support
-      local parent_entity
-      if parent_entity_has_unique_name and not utils.is_valid_uuid(id) then
-        parent_entity, _, err_t = db[parent_schema_name]:select_by_name(id)
-
-      else
-        parent_entity, _, err_t = db[parent_schema_name]:select({ id = id })
-      end
-
-      if err_t then
-        return handle_error(err_t)
-      end
-
-      if not parent_entity or parent_entity[entity_name] == null then
+      local id = entity[foreign_field_name]
+      if not id or id == null then
         return helpers.responses.send_HTTP_NOT_FOUND()
       end
 
-      entity, _, err_t = db[schema_name]:update(parent_entity[entity_name],
-                                                self.args.post)
+      entity, _, err_t = db[foreign_schema.name]:update(id, self.args.post)
     end
 
     if err_t then
       return handle_error(err_t)
+    end
+
+    if not entity then
+      return helpers.responses.send_HTTP_NOT_FOUND()
     end
 
     return helpers.responses.send_HTTP_OK(entity)
@@ -289,22 +368,19 @@ end
 -- and
 --
 -- /services/:services
-local function delete_entity_endpoint(schema_name, entity_has_unique_name,
-                                      entity_name, parent_schema_name,
-                                      parent_entity_has_unique_name)
+local function delete_entity_endpoint(schema, foreign_schema, foreign_field_name)
   return function(self, db, helpers)
-    if not parent_schema_name then
-      local id = self.params[schema_name]
+    local entity, _, err_t = select_entity(db, schema, self.params)
+    if err_t then
+      return handle_error(err_t)
+    end
 
-      -- TODO: composite key support
-      local _, err_t
-      if entity_has_unique_name and not utils.is_valid_uuid(id) then
-        _, _, err_t = db[schema_name]:delete_by_name(id)
-
-      else
-        _, _, err_t = db[schema_name]:delete({ id = id })
+    if not foreign_schema then
+      if not entity then
+        return helpers.responses.send_HTTP_NO_CONTENT()
       end
 
+      _, _, err_t = db[schema.name]:delete({ id = entity.id })
       if err_t then
         return handle_error(err_t)
       end
@@ -312,22 +388,8 @@ local function delete_entity_endpoint(schema_name, entity_has_unique_name,
       return helpers.responses.send_HTTP_NO_CONTENT()
 
     else
-      local id = self.params[parent_schema_name]
-
-      -- TODO: composite key support
-      local parent_entity, _, err_t
-      if parent_entity_has_unique_name and not utils.is_valid_uuid(id) then
-        parent_entity, _, err_t = db[parent_schema_name]:select_by_name(id)
-
-      else
-        parent_entity, _, err_t = db[parent_schema_name]:select({ id = id })
-      end
-
-      if err_t then
-        return handle_error(err_t)
-      end
-
-      if not parent_entity or parent_entity[entity_name] == null then
+      local id = entity and entity[foreign_field_name]
+      if not id or id == null then
         return helpers.responses.send_HTTP_NOT_FOUND()
       end
 
@@ -337,14 +399,22 @@ local function delete_entity_endpoint(schema_name, entity_has_unique_name,
 end
 
 
-local function generate_collection_endpoints(endpoints, schema, collection_path, ...)
+local function generate_collection_endpoints(endpoints, schema, foreign_schema, foreign_field_name)
+  local collection_path
+  if foreign_schema then
+    collection_path = fmt("/%s/:%s/%s", foreign_schema.name, foreign_schema.name, schema.name)
+
+  else
+    collection_path = fmt("/%s", schema.name)
+  end
+
   endpoints[collection_path] = {
     schema  = schema,
     methods = {
       --OPTIONS = method_not_allowed,
       --HEAD    = method_not_allowed,
-      GET     = get_collection_endpoint(...),
-      POST    = post_collection_endpoint(...),
+      GET     = get_collection_endpoint(schema, foreign_schema, foreign_field_name),
+      POST    = post_collection_endpoint(schema, foreign_schema, foreign_field_name),
       --PUT     = method_not_allowed,
       --PATCH   = method_not_allowed,
       --DELETE  = method_not_allowed,
@@ -353,17 +423,25 @@ local function generate_collection_endpoints(endpoints, schema, collection_path,
 end
 
 
-local function generate_entity_endpoints(endpoints, schema, entity_path, ...)
+local function generate_entity_endpoints(endpoints, schema, foreign_schema, foreign_field_name)
+  local entity_path
+  if foreign_schema then
+    entity_path = fmt("/%s/:%s/%s", schema.name, schema.name, foreign_field_name)
+
+  else
+    entity_path = fmt("/%s/:%s", schema.name, schema.name)
+  end
+
   endpoints[entity_path] = {
-    schema   = schema,
+    schema  = foreign_schema or schema,
     methods = {
       --OPTIONS = method_not_allowed,
       --HEAD    = method_not_allowed,
-      GET     = get_entity_endpoint(...),
+      GET     = get_entity_endpoint(schema, foreign_schema, foreign_field_name),
       --POST    = method_not_allowed,
-      --PUT     = method_not_allowed,
-      PATCH   = patch_entity_endpoint(...),
-      DELETE  = delete_entity_endpoint(...),
+      PUT     = put_entity_endpoint(schema, foreign_schema, foreign_field_name),
+      PATCH   = patch_entity_endpoint(schema, foreign_schema, foreign_field_name),
+      DELETE  = delete_entity_endpoint(schema, foreign_schema, foreign_field_name),
     },
   }
 end
@@ -382,63 +460,20 @@ end
 --
 -- /services
 -- /services/:services
-local function generate_endpoints(schema, endpoints, prefix)
-  local path_prefix
-  if prefix then
-    if sub(prefix, -1) == "/" then
-      path_prefix = prefix
-
-    else
-      path_prefix = prefix .. "/"
-    end
-
-  else
-    path_prefix = "/"
-  end
-
-  local schema_name = schema.name
-  local collection_path = path_prefix .. schema_name
-
+local function generate_endpoints(schema, endpoints)
   -- e.g. /routes
-  generate_collection_endpoints(endpoints, schema, collection_path, schema_name)
-
-  local entity_path = fmt("%s/:%s", collection_path, schema_name)
-  local entity_name_field = schema.fields.name
-  local entity_has_unique_name = entity_name_field and entity_name_field.unique
+  generate_collection_endpoints(endpoints, schema)
 
   -- e.g. /routes/:routes
-  generate_entity_endpoints(endpoints, schema, entity_path, schema_name,
-                            entity_has_unique_name)
+  generate_entity_endpoints(endpoints, schema)
 
   for foreign_field_name, foreign_field in schema:each_field() do
     if foreign_field.type == "foreign" then
-      local foreign_schema      = foreign_field.schema
-      local foreign_schema_name = foreign_schema.name
-
-      local foreign_entity_path = fmt("%s/%s", entity_path, foreign_field_name)
-      local foreign_entity_name_field = foreign_schema.fields.name
-      local foreign_entity_has_unique_name = foreign_entity_name_field and foreign_entity_name_field.unique
-
       -- e.g. /routes/:routes/service
-      generate_entity_endpoints(endpoints,
-                                foreign_schema,
-                                foreign_entity_path,
-                                foreign_schema_name,
-                                foreign_entity_has_unique_name,
-                                foreign_field_name, schema_name,
-                                entity_has_unique_name)
+      generate_entity_endpoints(endpoints, schema, foreign_field.schema, foreign_field_name)
 
       -- e.g. /services/:services/routes
-      local foreign_collection_path = fmt("/%s/:%s/%s", foreign_schema_name,
-                                          foreign_schema_name, schema_name)
-
-      generate_collection_endpoints(endpoints,
-                                    schema,
-                                    foreign_collection_path,
-                                    schema_name,
-                                    foreign_field_name,
-                                    foreign_schema_name,
-                                    foreign_entity_has_unique_name)
+      generate_collection_endpoints(endpoints, schema, foreign_field.schema, foreign_field_name)
     end
   end
 
@@ -449,8 +484,8 @@ end
 local Endpoints = { handle_error = handle_error }
 
 
-function Endpoints.new(schema, endpoints, prefix)
-  return generate_endpoints(schema, endpoints, prefix)
+function Endpoints.new(schema, endpoints)
+  return generate_endpoints(schema, endpoints)
 end
 
 

--- a/kong/api/init.lua
+++ b/kong/api/init.lua
@@ -191,12 +191,18 @@ end
 
 
 local function attach_new_db_routes(routes)
-  for route_path, methods in pairs(routes) do
+  for route_path, definition in pairs(routes) do
+    local schema  = definition.schema
+    local methods = definition.methods
+
     methods.on_error = methods.on_error or new_db_on_error
 
     for method_name, method_handler in pairs(methods) do
       local wrapped_handler = function(self)
-        self.args = arguments.load()
+        self.args = arguments.load({
+          schema = schema,
+        })
+
         return method_handler(self, singletons.db, handler_helpers)
       end
 
@@ -235,26 +241,29 @@ do
       for route_pattern, verbs in pairs(custom_endpoints) do
         if routes[route_pattern] ~= nil and type(verbs) == "table" then
           for verb, handler in pairs(verbs) do
-            local parent = routes[route_pattern][verb]
+            local parent = routes[route_pattern]["methods"][verb]
             if parent ~= nil and type(handler) == "function" then
-              routes[route_pattern][verb] = function(self, db, helpers)
+              routes[route_pattern]["methods"][verb] = function(self, db, helpers)
                 return handler(self, db, helpers, function()
                   return parent(self, db, helpers)
                 end)
               end
 
             else
-              routes[route_pattern][verb] = handler
+              routes[route_pattern]["methods"][verb] = handler
             end
           end
 
         else
-          routes[route_pattern] = verbs
+          routes[route_pattern] = {
+            schema  = dao.schema,
+            methods = verbs,
+          }
         end
       end
     end
-
   end
+
   attach_new_db_routes(routes)
 end
 

--- a/kong/api/routes/services.lua
+++ b/kong/api/routes/services.lua
@@ -20,7 +20,11 @@ return {
   },
 
   ["/services/:services"] = {
-    PATCH  = function(self, _, _, parent)
+    PUT = function(self, _, _, parent)
+      api_helpers.resolve_url_params(self)
+      return parent()
+    end,
+    PATCH = function(self, _, _, parent)
       api_helpers.resolve_url_params(self)
       return parent()
     end,

--- a/kong/db/schema/entities/services.lua
+++ b/kong/db/schema/entities/services.lua
@@ -15,6 +15,7 @@ end
 return {
   name = "services",
   primary_key = { "id" },
+  endpoint_key = "name",
 
   fields = {
     { id              = typedefs.uuid, },

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -961,10 +961,14 @@ function Schema:process_auto_fields(input, context)
     if field.auto then
       if field.uuid and context == "insert" then
         output[key] = utils.uuid()
+      elseif field.uuid and context == "upsert" and output[key] == nil then
+        output[key] = utils.uuid()
 
-      elseif (key == "created_at" and (context == "insert")) or
-             (key == "updated_at" and (context == "update"   or
-                                       context == "insert")) then
+      elseif (key == "created_at" and (context == "insert" or
+                                       context == "upsert")) or
+             (key == "updated_at" and (context == "insert" or
+                                       context == "upsert" or
+                                       context == "update")) then
         output[key] = now
       end
     end
@@ -1084,6 +1088,19 @@ function Schema:validate_update(input)
   validation_errors.AT_LEAST_ONE_OF = aloo
 
   return ok, err, err_t
+end
+
+
+--- Validate a table against the schema, ensuring that the entity is complete.
+-- It validates fields for their attributes,
+-- and runs the global entity checks against the entire table.
+-- @param input The input table.
+-- @return True on success.
+-- On failure, it returns nil and a table containing all errors,
+-- indexed numerically for general errors, and by field name for field errors.
+-- In all cases, the input table is untouched.
+function Schema:validate_upsert(input)
+  return self:validate(input, true)
 end
 
 

--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -124,6 +124,8 @@ local meta_errors = {
   TYPE = "missing type declaration",
   FIELDS_ARRAY = "each entry in fields must be a sub-table",
   FIELDS_KEY = "each key in fields must be a string",
+  ENDPOINT_KEY = "value must be a field name",
+  ENDPOINT_KEY_UNIQUE = "endpoint key must be a unique field",
 }
 
 
@@ -223,6 +225,12 @@ local MetaSchema = Schema.new({
       },
     },
     {
+      endpoint_key = {
+        type = "string",
+        nilable = true,
+      },
+    },
+    {
       fields = {
         type = "array",
         elements = {
@@ -257,6 +265,24 @@ local MetaSchema = Schema.new({
     if not schema.fields then
       errors["fields"] = meta_errors.TABLE:format("fields")
       return nil, errors
+    end
+
+    if schema.endpoint_key then
+      local found = false
+      for _, item in ipairs(schema.fields) do
+        local k = next(item)
+        local field = item[k]
+        if schema.endpoint_key == k then
+          if not field.unique then
+            errors["endpoint_key"] = meta_errors.ENDPOINT_KEY_UNIQUE
+          end
+          found = true
+          break
+        end
+      end
+      if not found then
+        errors["endpoint_key"] = meta_errors.ENDPOINT_KEY
+      end
     end
 
     for _, item in ipairs(schema.fields) do

--- a/kong/db/strategies/postgres/connector.lua
+++ b/kong/db/strategies/postgres/connector.lua
@@ -2,8 +2,11 @@ local pgmoon       = require "pgmoon"
 
 
 local setmetatable = setmetatable
+local tonumber     = tonumber
+local tostring     = tostring
 local concat       = table.concat
-local setmetatable = setmetatable
+local floor        = math.floor
+local fmt          = string.format
 --local pairs        = pairs
 --local type         = type
 local ngx          = ngx
@@ -97,6 +100,32 @@ local _mt = {}
 
 
 _mt.__index = _mt
+
+
+function _mt:init()
+  local res, err = self:query("SHOW server_version_num;")
+  local ver = tonumber(res and res[1] and res[1].server_version_num)
+  if not ver then
+    return nil, err or "postgres version not detected"
+  end
+
+  self.version_num = ver
+
+
+  local major = floor(ver / 10000)
+  if major < 10 then
+    self.major_version = fmt("%u.%u", major, floor(ver / 100 % 100))
+    self.minor_version = tostring(ver % 100)
+
+  else
+    self.major_version = tostring(major)
+    self.minor_version = tostring(ver % 100)
+  end
+
+  self.version = fmt("%s.%s", self.major_version, self.minor_version)
+
+  return true
+end
 
 
 function _mt:connect()

--- a/spec/01-unit/000-new-dao/01-schema/02-metaschema_spec.lua
+++ b/spec/01-unit/000-new-dao/01-schema/02-metaschema_spec.lua
@@ -113,6 +113,49 @@ describe("metaschema", function()
     end
   end)
 
+  it("allows specifying an endpoint key with endpoint_key", function()
+    local s = {
+      name = "test",
+      endpoint_key = "str",
+      fields = {
+        { str = { type = "string", unique = true } },
+        { num = { type = "number" } },
+      },
+      primary_key = { "str" },
+    }
+    assert.truthy(MetaSchema:validate(s))
+  end)
+
+  it("endpoint_key must be a field", function()
+    local s = {
+      name = "test",
+      endpoint_key = "bla",
+      fields = {
+        { str = { type = "string", unique = true } },
+        { num = { type = "number" } },
+      },
+      primary_key = { "str" },
+    }
+    local ok, err = MetaSchema:validate(s)
+    assert.falsy(ok)
+    assert.match("value must be a field name", err.endpoint_key)
+  end)
+
+  it("endpoint_key must be unique", function()
+    local s = {
+      name = "test",
+      endpoint_key = "num",
+      fields = {
+        { str = { type = "string", unique = true } },
+        { num = { type = "number" } },
+      },
+      primary_key = { "str" },
+    }
+    local ok, err = MetaSchema:validate(s)
+    assert.falsy(ok)
+    assert.match("endpoint key must be a unique field", err.endpoint_key)
+  end)
+
   it("supports the unique attribute in base types", function()
     local s = {
       name = "test",

--- a/spec/01-unit/000-new-dao/03-arguments_spec.lua
+++ b/spec/01-unit/000-new-dao/03-arguments_spec.lua
@@ -1,85 +1,156 @@
 local arguments    = require "kong.api.arguments"
+local Schema       = require "kong.db.schema"
+
+local infer_value = arguments.infer_value
+local infer       = arguments.infer
+local decode_arg  = arguments.decode_arg
+local decode      = arguments.decode
+local combine     = arguments.combine
 
 
-local decode_value = arguments.decode_value
-local decode       = arguments.decode
-local tonumber     = tonumber
-local null         = ngx.null
-
-
-describe("arguments.decode_value", function()
-  it("infers empty strings", function()
-    assert.equal(null, decode_value(""))
+describe("arguments.infer_value", function()
+  it("infers numbers", function()
+    assert.equal(2, infer_value("2", { type = "number" }))
+    assert.equal(2, infer_value("2", { type = "integer" }))
+    assert.equal(2.5, infer_value("2.5", { type = "number" }))
+    assert.equal(2.5, infer_value("2.5", { type = "integer" })) -- notice that integers are not rounded
   end)
 
   it("infers booleans", function()
-    assert.equal(true, decode_value("true"))
-    assert.equal(false, decode_value("false"))
+    assert.equal(false, infer_value("false", { type = "boolean" }))
+    assert.equal(true, infer_value("true", { type = "boolean" }))
   end)
 
-  it("infers numbers", function()
-    assert.equal(tonumber("123"), decode_value("123"))
-    assert.equal(tonumber("0.1"), decode_value("0.1"))
+  it("infers arrays and sets", function()
+    assert.same({ "a" }, infer_value("a",   { type = "array", elements = { type = "string" } }))
+    assert.same({ 2 },   infer_value("2",   { type = "array", elements = { type = "number" } }))
+    assert.same({ "a" }, infer_value({"a"}, { type = "array", elements = { type = "string" } }))
+    assert.same({ 2 },   infer_value({"2"}, { type = "array", elements = { type = "number" } }))
+
+    assert.same({ "a" }, infer_value("a",   { type = "set", elements = { type = "string" } }))
+    assert.same({ 2 },   infer_value("2",   { type = "set", elements = { type = "number" } }))
+    assert.same({ "a" }, infer_value({"a"}, { type = "set", elements = { type = "string" } }))
+    assert.same({ 2 },   infer_value({"2"}, { type = "set", elements = { type = "number" } }))
   end)
 
-  it("infers arrays", function()
-    assert.same(
-      { null, true, false, tonumber("123"), tonumber("0.1") },
-      decode_value { "", "true", "false", "123", "0.1" }
-    )
+  it("infers nulls from empty strings", function()
+    assert.equal(ngx.null, infer_value("", { type = "string" }))
+    assert.equal(ngx.null, infer_value("", { type = "array" }))
+    assert.equal(ngx.null, infer_value("", { type = "set" }))
+    assert.equal(ngx.null, infer_value("", { type = "number" }))
+    assert.equal(ngx.null, infer_value("", { type = "integer" }))
+    assert.equal(ngx.null, infer_value("", { type = "boolean" }))
+    assert.equal(ngx.null, infer_value("", { type = "foreign" }))
+    assert.equal(ngx.null, infer_value("", { type = "map" }))
+    assert.equal(ngx.null, infer_value("", { type = "record" }))
+  end)
+
+  it("doesn't infer nulls from empty strings on unknown types", function()
+    assert.equal("", infer_value(""))
+  end)
+
+  it("infers maps", function()
+    assert.same({ x = "1" }, infer_value({ x = "1" }, { type = "map", elements = { type = "string" } }))
+    assert.same({ x = 1 },   infer_value({ x = "1" }, { type = "map", elements = { type = "number" } }))
+  end)
+
+  it("infers records", function()
+    assert.same({ age = "1" }, infer_value({ age = "1" },
+                                           { type = "record", fields = { age = { type = "string" } } }))
+    assert.same({ age = 1 },   infer_value({ age = "1" },
+                                           { type = "record", fields = { age = { type = "number" } } }))
+  end)
+
+  it("returns the provided value when inferring is not possible", function()
+    assert.equal("not number", infer_value("not number", { type = "number" }))
+    assert.equal("not integer", infer_value("not integer", { type = "integer" }))
+    assert.equal("not boolean", infer_value("not boolean", { type = "boolean" }))
   end)
 end)
 
 
-describe("arguments.decode", function()
-  it("decodes empty strings", function()
-    assert.same({ name = decode_value("") }, decode{ name = "" })
+describe("arguments.infer", function()
+  it("returns nil for nil args", function()
+    assert.is_nil(infer())
   end)
 
-  it("decodes booleans", function()
-    assert.same({ name = decode_value("true") }, decode{ name = "true" })
-    assert.same({ name = decode_value("false") }, decode{ name = "false" })
+  it("does no inferring without schema", function()
+    assert.same("args", infer("args"))
   end)
 
-  it("decodes numbers", function()
-    assert.same({ name = decode_value("123") }, decode{ name = "123" })
-    assert.same({ name = decode_value("0.1") }, decode{ name = "0.1" })
+  it("infers every field using the schema", function()
+    local schema = Schema.new({
+      fields = {
+        { name = { type = "string" } },
+        { age  = { type = "number" } },
+        { has_license = { type = "boolean" } },
+        { aliases = { type = "set", elements = { type = { "string" } } } },
+        { comments = { type = "string" } },
+      }
+    })
+
+    local args = { name = "peter",
+                   age = "45",
+                   has_license = "true",
+                   aliases = "peta",
+                   comments = "" }
+    assert.same({
+      name = "peter",
+      age = 45,
+      has_license = true,
+      aliases = { "peta" },
+      comments = ngx.null
+    }, infer(args, schema))
+  end)
+end)
+
+describe("arguments.combine", function()
+  it("merges arguments together, creating arrays when finding repeated names, recursively", function()
+    local monster = {
+      { a = { [99] = "wayne", }, },
+      { a = { "first", }, },
+      { a = { b = { c = { "true", }, }, }, },
+      { a = { "a", "b", "c" }, },
+      { a = { b = { c = { d = "" }, }, }, },
+      { c = "test", },
+      { a = { "1", "2", "3", }, },
+    }
+
+    local combined_monster = {
+      a = {
+        { "first", "a", "1" }, { "b", "2" }, { "c", "3" },
+        [99] = "wayne",
+        b = { c = { "true", d = "", }, }
+      },
+      c = "test",
+    }
+
+    assert.same(combined_monster, combine(monster))
+  end)
+end)
+
+
+describe("arguments.decode_arg", function()
+  it("does not infer numbers, booleans or nulls from strings", function()
+    assert.same({ x = "" }, decode_arg("x", ""))
+    assert.same({ x = "true" }, decode_arg("x", "true"))
+    assert.same({ x = "false" }, decode_arg("x", "false"))
+    assert.same({ x = "10" }, decode_arg("x", "10"))
   end)
 
   it("decodes arrays", function()
-    assert.same(
-      { name = { decode_value(""), decode_value("true"), decode_value("false"), decode_value("123"), decode_value("0.1") }},
-      decode { name = { "", "true", "false", "123", "0.1" } }
-    )
+    assert.same({ x = { "a" } }, decode_arg("x[]", "a"))
+    assert.same({ x = { "a" } }, decode_arg("x[1]", "a"))
+    assert.same({ x = { nil, "a" } }, decode_arg("x[2]", "a"))
   end)
 
-  it("decodes object", function()
-    assert.same({ service = { name = decode_value("") }},              decode{ ["service.name"] = "" })
-    assert.same({ service = { name = decode_value("true") }},          decode{ ["service.name"] = "true" })
-    assert.same({ service = { name = decode_value("false") }},         decode{ ["service.name"] = "false" })
-    assert.same({ service = { name = decode_value("123") }},           decode{ ["service.name"] = "123" })
-    assert.same({ service = { name = decode_value("0.1") }},           decode{ ["service.name"] = "0.1" })
-    assert.same({ service = { name = decode_value("true"),  id = 1 }}, decode{ ["service.name"] = "true",  ["service.id"] = "1" })
-    assert.same({ service = { name = decode_value("false"), id = 1 }}, decode{ ["service.name"] = "false", ["service.id"] = "1" })
-    assert.same({ service = { name = decode_value("123"),   id = 1 }}, decode{ ["service.name"] = "123",   ["service.id"] = "1" })
-    assert.same({ service = { name = decode_value("0.1"),   id = 1 }}, decode{ ["service.name"] = "0.1",   ["service.id"] = "1" })
+  it("decodes nested arrays", function()
+    assert.same({ x = { { "a" } } }, decode_arg("x[1][1]", "a"))
+    assert.same({ x = { nil, { "a" } } }, decode_arg("x[2][1]", "a"))
   end)
+end)
 
-  it("decodes array and object parts", function()
-    assert.same(
-      { service = { name = { decode_value(""), decode_value("true"), decode_value("false"), decode_value("123"), decode_value("0.1") }}},
-      decode { ["service.name"] = { "", "true", "false", "123", "0.1" } }
-    )
-    assert.same(
-      { service = { name = { decode_value(""), decode_value("true"), decode_value("false"), decode_value("123"), decode_value("0.1") }, id = 1 }},
-      decode { ["service.name"] = { "", "true", "false", "123", "0.1" }, ["service.id"] = 1 }
-    )
-
-    assert.same(
-      { service = { decode_value(""), decode_value("true"), decode_value("false"), decode_value("123"), decode_value("0.1"), id = 1 }},
-      decode { ["service[]"] = { "", "true", "false", "123", "0.1" }, ["service.id"] = "1" }
-    )
-  end)
+describe("arguments.decode", function()
 
   it("decodes complex nested parameters", function()
     assert.same({
@@ -88,21 +159,21 @@ describe("arguments.decode", function()
         {
           "first",
           "a",
-          1,
+          "1",
         },
         {
           "b",
-          2,
+          "2",
         },
         {
           "c",
-          3,
+          "3",
         },
         [99] = "wayne",
         b = {
           c = {
-            true,
-            d = null
+            "true",
+            d = ""
           }
         }
       },
@@ -197,38 +268,38 @@ describe("arguments.decode", function()
       ["a[2]"] = { "5", "6" },
     }
 
-    assert.is_table(decoded.a[1])
-    assert.equal(3, #decoded.a[1])
+    assert.same(
+      { a = {
+          { "4", "1", "3" },
+          { "5", "6", "2" },
+        }
+      },
+      decoded
+    )
+  end)
 
-    local f1 = {
-      [1] = false,
-      [3] = false,
-      [4] = false,
-    }
+  it("infers values when provided with a schema", function()
+    local schema = Schema.new({
+      fields = {
+        { name = { type = "string" } },
+        { age  = { type = "number" } },
+        { has_license = { type = "boolean" } },
+        { aliases = { type = "set", elements = { type = { "string" } } } },
+        { comments = { type = "string" } },
+      }
+    })
 
-    for _, v in ipairs(decoded.a[1]) do
-      f1[v] = true
-    end
-
-    for _, ok in pairs(f1) do
-      assert.is_true(ok)
-    end
-
-    local f2 = {
-      [2] = false,
-      [5] = false,
-      [6] = false,
-    }
-
-    for _, v in ipairs(decoded.a[2]) do
-      f2[v] = true
-    end
-
-    for _, ok in pairs(f2) do
-      assert.is_true(ok)
-    end
-
-    assert.is_table(decoded.a[2])
-    assert.equal(3, #decoded.a[2])
+    local args = { name = "peter",
+                   age = "45",
+                   has_license = "true",
+                   ["aliases[]"] = "peta",
+                   comments = "" }
+    assert.same({
+      name = "peter",
+      age = 45,
+      has_license = true,
+      aliases = { "peta" },
+      comments = ngx.null
+    }, decode(args, schema))
   end)
 end)

--- a/spec/02-integration/04-admin_api/20-routes_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/20-routes_routes_spec.lua
@@ -15,7 +15,7 @@ local function it_content_types(title, fn)
 end
 
 
-for _, strategy in helpers.each_strategy("postgres") do
+for _, strategy in helpers.each_strategy() do
   describe("Admin API #" .. strategy, function()
     local bp
     local db
@@ -327,6 +327,133 @@ for _, strategy in helpers.each_strategy("postgres") do
           end)
         end)
 
+        describe("PUT", function()
+          it_content_types("creates if not found", function(content_type)
+            return function()
+              local res = client:put("/routes/" .. route.id, {
+                headers = {
+                  ["Content-Type"] = content_type
+                },
+                body = {
+                  paths   = { "/updated-paths" },
+                  service = route.service
+                },
+              })
+              local body = assert.res_status(200, res)
+              local json = cjson.decode(body)
+              assert.same({ "/updated-paths" }, json.paths)
+              assert.same(cjson.null, json.hosts)
+              assert.same(cjson.null, json.methods)
+              assert.equal(route.id, json.id)
+
+              local in_db = assert(db.routes:select({ id = route.id }))
+              assert.same(json, in_db)
+            end
+          end)
+
+          it_content_types("updates if found", function(content_type)
+            return function()
+              local res = client:put("/routes/" .. route.id, {
+                headers = {
+                  ["Content-Type"] = content_type
+                },
+                body = {
+                  paths   = { "/updated-paths" },
+                  service = route.service
+                },
+              })
+              local body = assert.res_status(200, res)
+              local json = cjson.decode(body)
+              assert.same({ "/updated-paths" }, json.paths)
+              assert.same(cjson.null, json.hosts)
+              assert.same(cjson.null, json.methods)
+              assert.equal(route.id, json.id)
+
+              local in_db = assert(db.routes:select({ id = route.id }))
+              assert.same(json, in_db)
+            end
+          end)
+
+          describe("errors", function()
+            it("handles malformed JSON body", function()
+              local res = client:put("/routes/" .. route.id, {
+                body    = '{"hello": "world"',
+                headers = { ["Content-Type"] = "application/json" }
+              })
+              local body = assert.res_status(400, res)
+              assert.equal('{"message":"Cannot parse JSON body"}', body)
+            end)
+
+
+            it_content_types("handles invalid input", function(content_type)
+              return function()
+                -- Missing params
+                local res = client:put("/routes/" .. utils.uuid(), {
+                  body = {},
+                  headers = { ["Content-Type"] = content_type }
+                })
+                local body = assert.res_status(400, res)
+                assert.same({
+                  code    = Errors.codes.SCHEMA_VIOLATION,
+                  name    = "schema violation",
+                  message = unindent([[
+                  2 schema violations
+                  (at least one of these fields must be non-empty: 'methods', 'hosts', 'paths';
+                  service: required field missing)
+                ]], true, true),
+                  fields  = {
+                    service   = "required field missing",
+                    ["@entity"] = {
+                      "at least one of these fields must be non-empty: 'methods', 'hosts', 'paths'"
+                    }
+                  }
+                }, cjson.decode(body))
+
+                -- Invalid parameter
+                res = client:put("/routes/" .. utils.uuid(), {
+                  body = {
+                    methods   = { "GET" },
+                    protocols = { "foo" },
+                  },
+                  headers = { ["Content-Type"] = content_type }
+                })
+                body = assert.res_status(400, res)
+                assert.same({
+                  code    = Errors.codes.SCHEMA_VIOLATION,
+                  name    = "schema violation",
+                  message = "2 schema violations " ..
+                    "(protocols: expected one of: http, https; " ..
+                    "service: required field missing)",
+                  fields  = {
+                    protocols = "expected one of: http, https",
+                    service   = "required field missing",
+                  }
+                }, cjson.decode(body))
+
+                local res = client:put("/routes/" .. route.id, {
+                  headers = {
+                    ["Content-Type"] = content_type
+                  },
+                  body = {
+                    service        = route.service,
+                    paths          = { "/" },
+                    regex_priority = "foobar",
+                  },
+                })
+                local body = assert.res_status(400, res)
+                assert.same({
+                  code    = Errors.codes.SCHEMA_VIOLATION,
+                  name    = "schema violation",
+                  message = "schema violation (regex_priority: expected an integer)",
+                  fields  = {
+                    regex_priority = "expected an integer"
+                  },
+                }, cjson.decode(body))
+              end
+            end)
+          end)
+        end)
+
         describe("PATCH", function()
           it_content_types("updates if found", function(content_type)
             return function()
@@ -431,12 +558,20 @@ for _, strategy in helpers.each_strategy("postgres") do
             })
 
             local body = assert.res_status(200, res)
-            assert.matches('"methods":%[%]', body)
-            assert.matches('"paths":%[%]', body)
             local json = cjson.decode(body)
-            assert.same({}, json.paths)
+
+            if strategy == "cassandra" then
+              assert.equals(ngx.null, json.paths)
+              assert.equals(ngx.null, json.methods)
+
+            else
+              assert.matches('"methods":%[%]', body)
+              assert.matches('"paths":%[%]', body)
+              assert.same({}, json.paths)
+              assert.same({}, json.methods)
+            end
+
             assert.same({ "my-updated.tld" }, json.hosts)
-            assert.same({}, json.methods)
             assert.equal(route.id, json.id)
           end)
 


### PR DESCRIPTION
### Summary

This PR enhances our new model autogenerated Admin API in several ways:

1. It has more intelligent type inferring for `application/x-www-form-urlencoded` that takes into account information from schemas
2. It adds support for `endpoint_key` parameter in schemas that can be pointed to any unique field (allows us to e.g. autogenerate `/consumers/<uuid-or-username>`)
3. It adds proper `PUT` support (by `<uuid>` or by `<schema.endpoint_key>` (aka unique)

### Issues resolved

Fix #3378 

It will also close these when the respective entities are moved to new model:

Fix (or make obsolete) #3183
Fix (or make obsolete) #3168