### PR TITLE
hotfix(config) parse headers config option from .kong_env

### DIFF
--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -606,31 +606,33 @@ local function load(path, custom_conf)
 
   -- load headers configuration
   do
-    local headers_enabled = {}
+    local enabled_headers = {}
 
     for _, v in pairs(header_key_to_name) do
-      headers_enabled[v] = false
+      enabled_headers[v] = false
     end
 
     if #conf.headers > 0 and conf.headers[1] ~= "off" then
       for _, token in ipairs(conf.headers) do
         if token ~= "off" then
-          headers_enabled[header_key_to_name[string.lower(token)]] = true
+          enabled_headers[header_key_to_name[string.lower(token)]] = true
         end
       end
     end
 
-    if headers_enabled.server_tokens then
-      headers_enabled[headers.VIA] = true
-      headers_enabled[headers.SERVER] = true
+    if enabled_headers.server_tokens then
+      enabled_headers[headers.VIA] = true
+      enabled_headers[headers.SERVER] = true
     end
 
-    if headers_enabled.latency_tokens then
-      headers_enabled[headers.PROXY_LATENCY] = true
-      headers_enabled[headers.UPSTREAM_LATENCY] = true
+    if enabled_headers.latency_tokens then
+      enabled_headers[headers.PROXY_LATENCY] = true
+      enabled_headers[headers.UPSTREAM_LATENCY] = true
     end
 
-    conf.headers = headers_enabled
+    conf.enabled_headers = setmetatable(enabled_headers, {
+      __tostring = function() return "" end,
+    })
   end
 
   -- load absolute paths

--- a/kong/error_handlers.lua
+++ b/kong/error_handlers.lua
@@ -58,7 +58,7 @@ return function(ngx)
   local status = ngx.status
   message = BODIES["s" .. status] and BODIES["s" .. status] or format(BODIES.default, status)
 
-  if singletons.configuration.headers[constants.HEADERS.SERVER] then
+  if singletons.configuration.enabled_headers[constants.HEADERS.SERVER] then
     ngx.header[constants.HEADERS.SERVER] = SERVER_HEADER
   end
 

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -698,20 +698,20 @@ return {
       local header = ngx.header
 
       if ctx.KONG_PROXIED then
-        if singletons.configuration.headers[constants.HEADERS.UPSTREAM_LATENCY] then
+        if singletons.configuration.enabled_headers[constants.HEADERS.UPSTREAM_LATENCY] then
           header[constants.HEADERS.UPSTREAM_LATENCY] = ctx.KONG_WAITING_TIME
         end
 
-        if singletons.configuration.headers[constants.HEADERS.PROXY_LATENCY] then
+        if singletons.configuration.enabled_headers[constants.HEADERS.PROXY_LATENCY] then
           header[constants.HEADERS.PROXY_LATENCY] = ctx.KONG_PROXY_LATENCY
         end
 
-        if singletons.configuration.headers[constants.HEADERS.VIA] then
+        if singletons.configuration.enabled_headers[constants.HEADERS.VIA] then
           header[constants.HEADERS.VIA] = server_header
         end
 
       else
-        if singletons.configuration.headers[constants.HEADERS.SERVER] then
+        if singletons.configuration.enabled_headers[constants.HEADERS.SERVER] then
           header[constants.HEADERS.SERVER] = server_header
 
         else

--- a/spec/fixtures/headers.conf
+++ b/spec/fixtures/headers.conf
@@ -1,0 +1,29 @@
+# 1st digit is 9 for our test instances
+admin_listen = 127.0.0.1:9001
+proxy_listen = 0.0.0.0:9000, 0.0.0.0:9443 ssl
+
+ssl_cert = spec/fixtures/kong_spec.crt
+ssl_cert_key = spec/fixtures/kong_spec.key
+
+admin_ssl_cert = spec/fixtures/kong_spec.crt
+admin_ssl_cert_key = spec/fixtures/kong_spec.key
+
+dnsmasq = off
+dns_resolver = 8.8.8.8
+database = postgres
+pg_host = 127.0.0.1
+pg_port = 5432
+pg_database = kong_tests
+cassandra_keyspace = kong_tests
+cassandra_timeout = 10000
+anonymous_reports = off
+
+dns_hostsfile = spec/fixtures/hosts
+
+nginx_worker_processes = 1
+nginx_optimizations = off
+
+prefix = servroot
+log_level = debug
+
+headers = server_tokens, X-Kong-Proxy-Latency


### PR DESCRIPTION
This fixes a bug introduced in 976dd87 (#3300)
where headers config option was being overwritten
as a table. The table is not persisted in the intermediate
config file and hence the config option does not take effect.

This commit also exposes `get_running_conf` helper function to
read conf from prefix directory in use during the current test.