### PR TITLE
feat(key-auth) add expires_in to key-auth

### DIFF
--- a/kong/plugins/key-auth/daos.lua
+++ b/kong/plugins/key-auth/daos.lua
@@ -8,7 +8,8 @@ local SCHEMA = {
     id = {type = "id", dao_insert_value = true},
     created_at = {type = "timestamp", immutable = true, dao_insert_value = true},
     consumer_id = {type = "id", required = true, foreign = "consumers:id"},
-    key = {type = "string", required = false, unique = true, default = utils.random_string}
+    key = {type = "string", required = false, unique = true, default = utils.random_string},
+    expires_in = {type = "number", required = false, default = 0}
   },
 }
 

--- a/kong/plugins/key-auth/migrations/cassandra.lua
+++ b/kong/plugins/key-auth/migrations/cassandra.lua
@@ -37,4 +37,14 @@ return {
     end,
     down = function(_, _, dao) end  -- not implemented
   },
+  {
+    name = "2018-04-26_key-auth_expires_in",
+    up = [[
+      ALTER TABLE keyauth_credentials ADD expires_in int;
+    ]],
+    down = [[
+      ALTER TABLE keyauth_credentials DROP expires_in;
+    ]]
+  },
 }
+

--- a/kong/plugins/key-auth/migrations/postgres.lua
+++ b/kong/plugins/key-auth/migrations/postgres.lua
@@ -44,4 +44,13 @@ return {
     end,
     down = function(_, _, dao) end  -- not implemented
   },
+  {
+    name = "2018-04-26_key-auth_expires_in",
+    up = [[
+      ALTER TABLE keyauth_credentials ADD COLUMN expires_in int;
+    ]],
+    down = [[
+      ALTER TABLE keyauth_credentials DROP COLUMN expires_in;
+    ]]
+  },
 }

--- a/spec/03-plugins/10-key-auth/01-api_spec.lua
+++ b/spec/03-plugins/10-key-auth/01-api_spec.lua
@@ -62,6 +62,7 @@ for _, strategy in helpers.each_strategy() do
           local json = cjson.decode(body)
           assert.equal(consumer.id, json.consumer_id)
           assert.equal("1234", json.key)
+          assert.equal(0, json.expires_in) -- expires_in default should be 0
         end)
         it("creates a key-auth auto-generating a unique key", function()
           local res = assert(admin_client:send {
@@ -94,6 +95,24 @@ for _, strategy in helpers.each_strategy() do
           assert.is_string(json.key)
 
           assert.not_equal(first_key, json.key)
+        end)
+        it("creates a key-auth credential with expires_in", function()
+          local res = assert(admin_client:send {
+            method  = "POST",
+            path    = "/consumers/bob/key-auth",
+            body    = {
+              key        = "12345",
+              expires_in = 1000
+            },
+            headers = {
+              ["Content-Type"] = "application/json"
+            }
+          })
+          local body = assert.res_status(201, res)
+          local json = cjson.decode(body)
+          assert.equal(consumer.id, json.consumer_id)
+          assert.equal("12345", json.key)
+          assert.equal(1000, json.expires_in)
         end)
       end)
 

--- a/spec/03-plugins/10-key-auth/02-access_spec.lua
+++ b/spec/03-plugins/10-key-auth/02-access_spec.lua
@@ -72,6 +72,12 @@ for _, strategy in helpers.each_strategy() do
         consumer_id = consumer.id,
       }
 
+      bp.keyauth_credentials:insert {
+        key         = "key_with_expires_in",
+        consumer_id = consumer.id,
+        expires_in  = 1
+      }
+
       bp.plugins:insert {
         name     = "key-auth",
         route_id = route3.id,
@@ -173,6 +179,18 @@ for _, strategy in helpers.each_strategy() do
         })
         res:read_body()
         assert.equal('Key realm="' .. meta._NAME .. '"', res.headers["WWW-Authenticate"])
+      end)
+      it("returns key_invalid if key expires", function()
+        ngx.sleep(2)
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/request",
+          headers = {
+            ["Host"]   = "key-auth1.com",
+            ["apikey"] = "key_with_expires_in"
+          }
+        })
+        assert.res_status(401, res)
       end)
     end)
 


### PR DESCRIPTION
### Summary
This pr adds the `expires_in` field to key-auth plugin. And its default value is `0`.
This pr also requires a migration, i.e. adding the new column `expires_in`. Let me know if it's ok to base on master or next branch.

### Full changelog
* Implement expires_in for key-auth plugin

### Issues resolved
Fix https://github.com/Kong/kong/issues/87
