### PR TITLE
enabling lambda functions to return custom status, body, and headers

### DIFF
--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -12,6 +12,7 @@ local public_utils = require "kong.tools.public"
 
 
 local tostring             = tostring
+local tonumber             = tonumber
 local pairs                = pairs
 local type                 = type
 local fmt                  = string.format
@@ -37,6 +38,53 @@ local server_header = meta._SERVER_TOKENS
 
 local AWS_PORT = 443
 
+
+--[[
+  Response format should be
+  {
+      "statusCode": httpStatusCode,
+      "headers": { "headerName": "headerValue", ... },
+      "body": "..."
+  }
+--]]
+local function validate_custom_response(response)
+  if type(response.statusCode) ~= "number" then
+    return nil, "statusCode must be a number"
+  end
+
+  if response.headers ~= nil and type(response.headers) ~= "table" then
+    return nil, "headers must be a table"
+  end
+
+  if response.body ~= nil and type(response.body) ~= "string" then
+    return nil, "body must be a string"
+  end
+
+  return true
+end
+
+
+local function extract_proxy_response(content)
+  local serialized_content, err = cjson.decode(content)
+  if not serialized_content then
+    return nil, err
+  end
+
+  local ok, err = validate_custom_response(serialized_content)
+  if not ok then
+    return nil, err
+  end
+
+  local headers = serialized_content.headers or {}
+  local body = serialized_content.body or ""
+  headers["Content-Length"] = #body
+
+  return {
+    status_code = tonumber(serialized_content.statusCode),
+    body = body,
+    headers = headers,
+  }
+end
 
 local function send(status, content, headers)
   ngx.status = status
@@ -187,13 +235,27 @@ function AWSLambdaHandler:access(conf)
   end
 
   local status
-  if conf.unhandled_status
-     and headers["X-Amz-Function-Error"] == "Unhandled"
-  then
-    status = conf.unhandled_status
 
-  else
-    status = res.status
+  if conf.is_proxy_integration then
+    local proxy_response, err = extract_proxy_response(content)
+    if not proxy_response then
+      return responses.send_HTTP_BAD_GATEWAY(err)
+    end
+
+    headers = utils.table_merge(headers, proxy_response.headers)
+    content = proxy_response.body
+    status = proxy_response.status_code
+  end
+
+  if not status then
+    if conf.unhandled_status
+      and headers["X-Amz-Function-Error"] == "Unhandled"
+    then
+      status = conf.unhandled_status
+
+    else
+      status = res.status
+    end
   end
 
   local ctx = ngx.ctx

--- a/kong/plugins/aws-lambda/schema.lua
+++ b/kong/plugins/aws-lambda/schema.lua
@@ -97,5 +97,9 @@ return {
       type = "boolean",
       default = false,
     },
+    is_proxy_integration = {
+      type = "boolean",
+      default = false,
+    },
   },
 }

--- a/kong/tools/responses.lua
+++ b/kong/tools/responses.lua
@@ -59,6 +59,7 @@ local _M = {
     HTTP_CONFLICT = 409,
     HTTP_UNSUPPORTED_MEDIA_TYPE = 415,
     HTTP_INTERNAL_SERVER_ERROR = 500,
+    HTTP_BAD_GATEWAY = 502,
     HTTP_SERVICE_UNAVAILABLE = 503,
   }
 }
@@ -73,6 +74,7 @@ local _M = {
 -- @field status_codes.HTTP_INTERNAL_SERVER_ERROR Always "Internal Server Error"
 -- @field status_codes.HTTP_METHOD_NOT_ALLOWED Always "Method not allowed"
 -- @field status_codes.HTTP_SERVICE_UNAVAILABLE Default: "Service unavailable"
+-- @field status_codes.HTTP_BAD_GATEWAY Always: "Bad Gateway"
 local response_default_content = {
   [_M.status_codes.HTTP_UNAUTHORIZED] = function(content)
     return content or "Unauthorized"
@@ -91,6 +93,9 @@ local response_default_content = {
   end,
   [_M.status_codes.HTTP_SERVICE_UNAVAILABLE] = function(content)
     return content or "Service unavailable"
+  end,
+  [_M.status_codes.HTTP_BAD_GATEWAY] = function(content)
+    return "Bad Gateway"
   end,
 }
 
@@ -116,7 +121,7 @@ local function send_response(status_code)
       coroutine.yield()
     end
 
-    if status_code == _M.status_codes.HTTP_INTERNAL_SERVER_ERROR then
+    if status_code == _M.status_codes.HTTP_INTERNAL_SERVER_ERROR or status_code == _M.status_codes.HTTP_BAD_GATEWAY then
       if content then
         ngx.log(ngx.ERR, tostring(content))
       end

--- a/spec/01-unit/009-responses_spec.lua
+++ b/spec/01-unit/009-responses_spec.lua
@@ -59,7 +59,7 @@ describe("Response helpers", function()
       end)
     end
   end)
-  it("calls `ngx.log` if and only if a 500 status code was given", function()
+  it("calls `ngx.log` if and only if a 500 or 502 status code was given", function()
     responses.send_HTTP_BAD_REQUEST()
     assert.stub(ngx.log).was_not_called()
 
@@ -69,8 +69,14 @@ describe("Response helpers", function()
     responses.send_HTTP_INTERNAL_SERVER_ERROR()
     assert.stub(ngx.log).was_not_called()
 
+    responses.send_HTTP_BAD_GATEWAY()
+    assert.stub(ngx.log).was_not_called()
+
     responses.send_HTTP_INTERNAL_SERVER_ERROR("error")
     assert.stub(ngx.log).was_called()
+
+    responses.send_HTTP_BAD_GATEWAY("error")
+    assert.stub(ngx.log).was_called(2)
   end)
 
   it("don't call `ngx.log` if a 503 status code was given", function()

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -244,7 +244,11 @@ http {
                   end
                   ngx.status = status
 
-                  if type(res) == 'string' then
+                  if string.match(ngx.var.uri, "functionWithBadJSON") then
+                    local badRes = "{\"foo\":\"bar\""
+                    ngx.header["Content-Length"] = #badRes + 1
+                    ngx.say(badRes)
+                  elseif type(res) == 'string' then
                     ngx.header["Content-Length"] = #res + 1
                     ngx.say(res)
 
@@ -252,6 +256,7 @@ http {
                     ngx.req.discard_body()
                     ngx.header['Content-Length'] = 0
                   end
+
 
                   ngx.exit(0)
                 end


### PR DESCRIPTION
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

### Summary

Currently, the AWS Lambda plugin will only return a 200, 202, or 204 HTTP status response code on successful requests. This adds the ability for Lambda functions to define custom response status codes by returning a specific object. For example returning the following from a Lambda function will set custom values on the Kong response.

```
{
    statusCode = "201",
    body = {
      key1 = "some_value_post1",
      key2 = "some_value_post2",
      key3 = "some_value_post3"
    },
    headers = {
      ["X-Custom-Header"] = "Hello world!"
    }
}
```

Returning this from your Lambda function would set that status to 201, the response body to `body` and add the custom headers in `headers`.

This same functionality is [already present with API Gateway](https://stackoverflow.com/a/39936210/5419691), and it would be great to replicate it here. It would make switching from API Gateway to Kong seamless :).

### Full changelog

* Update plugin to look for a statusCode, body, and headers in the Lambda response and apply them to the Kong response.
* Added test.
