### PR TITLE
hotfix(core) check enabled_headers while injecting X-Kong-Upstream-Status header

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -698,7 +698,7 @@ return {
         ctx.KONG_HEADER_FILTER_STARTED_AT = now
 
         local upstream_status_header = constants.HEADERS.UPSTREAM_STATUS
-        if singletons.configuration.headers[upstream_status_header] then
+        if singletons.configuration.enabled_headers[upstream_status_header] then
           local matches, err = re_match(var.upstream_status, "[0-9]+$", "oj")
           if err then
             log(ERR, "failed to set ", upstream_status_header, " header: ", err)


### PR DESCRIPTION
The hotfix commit 75e071b (#3419) changes the configuration property from
`headers` to `enabled_headers`.
The commit did not update a conditional statement introduced in
60c335e6 (#3263). This commit corrects the check from `headers` to
`enabled_headers`.

This was caught by the test suite and hence no regression test
has been added.