### PR TITLE
zipkin plugin

### DIFF
--- a/kong-0.13.1-0.rockspec
+++ b/kong-0.13.1-0.rockspec
@@ -34,6 +34,7 @@ dependencies = {
   "lua-resty-mlcache == 2.0.2",
   -- external Kong plugins
   "kong-plugin-azure-functions == 0.1.0",
+  "kong-plugin-zipkin == 0.0.1",
 }
 build = {
   type = "builtin",

--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -28,6 +28,7 @@ local plugins = {
   "request-termination",
   -- external plugins
   "azure-functions",
+  "zipkin",
 }
 
 local plugin_map = {}

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -680,7 +680,6 @@ return {
       -- record try-latency
       local try_latency = get_now() - current_try.balancer_start
       current_try.balancer_latency = try_latency
-      current_try.balancer_start = nil
 
       -- record overall latency
       ctx.KONG_BALANCER_TIME = (ctx.KONG_BALANCER_TIME or 0) + try_latency

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -27,6 +27,7 @@ local ngx         = ngx
 local log         = ngx.log
 local null        = ngx.null
 local ngx_now     = ngx.now
+local update_time = ngx.update_time
 local re_match    = ngx.re.match
 local unpack      = unpack
 
@@ -45,6 +46,7 @@ local server_header = _KONG._NAME .. "/" .. _KONG._VERSION
 
 
 local function get_now()
+  update_time()
   return ngx_now() * 1000 -- time is kept in seconds with millisecond resolution.
 end
 

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -737,11 +737,15 @@ return {
   },
   body_filter = {
     after = function(ctx)
-      if ngx.arg[2] and ctx.KONG_PROXIED then
-        -- time spent receiving the response (header_filter + body_filter)
-        -- we could use $upstream_response_time but we need to distinguish the waiting time
-        -- from the receiving time in our logging plugins (especially ALF serializer).
-        ctx.KONG_RECEIVE_TIME = get_now() - ctx.KONG_HEADER_FILTER_STARTED_AT
+      if ngx.arg[2] then
+        local now = get_now()
+        ctx.KONG_BODY_FILTER_ENDED_AT = now
+        if ctx.KONG_PROXIED then
+          -- time spent receiving the response (header_filter + body_filter)
+          -- we could use $upstream_response_time but we need to distinguish the waiting time
+          -- from the receiving time in our logging plugins (especially ALF serializer).
+          ctx.KONG_RECEIVE_TIME = now - ctx.KONG_HEADER_FILTER_STARTED_AT
+        end
       end
     end
   },

--- a/spec/01-unit/014-plugins_order_spec.lua
+++ b/spec/01-unit/014-plugins_order_spec.lua
@@ -49,6 +49,7 @@ describe("Plugins", function()
     -- backwards-compatibility
 
     local order = {
+      "zipkin",
       "bot-detection",
       "cors",
       "jwt",


### PR DESCRIPTION
This PR adds the zipkin plugin to the Kong installation. The plugin itself is external, see https://github.com/Kong/kong-plugin-zipkin
The plugin has not tagged a release yet; when it does we should update the rockspec with the released version.

You may want to merge this on top of #3428 


### Full changelog

  - Add `ngx.ctx.KONG_BODY_FILTER_ENDED_AT`
  - Don't nil out `balancer_start`
  - Add zipkin plugin
  - Update nginx time cache in each phase

### Issues resolved

Fixes #1330
