### PR TITLE
fix(api-router) support routing requests without Host header for HTTP/1.0

### DIFF
--- a/kong/api_router.lua
+++ b/kong/api_router.lua
@@ -837,7 +837,7 @@ function _M.new(apis)
       end
     end
 
-    local req_host = ngx.var.http_host
+    local req_host = ngx.var.http_host or ""
 
     local match_t = find_api(method, uri, req_host, ngx)
     if not match_t then

--- a/spec-old-api/01-unit/010-router_spec.lua
+++ b/spec-old-api/01-unit/010-router_spec.lua
@@ -921,6 +921,25 @@ describe("Router", function()
       return _ngx
     end
 
+    it("[uri + empty host]", function()
+      -- uri only (no Host)
+      -- Supported for HTTP/1.0 requests without a Host header
+      -- Regression for https://github.com/Kong/kong/issues/3435
+      local use_case_apis = {
+        {
+          name = "api-1",
+          uris = { "/my-api" },
+          upstream_url = "http://example.org",
+        },
+      }
+
+      local router = assert(Router.new(use_case_apis))
+
+      local _ngx = mock_ngx("GET", "/my-api", { ["host"] = nil })
+      local match_t = router.exec(_ngx)
+      assert.same(use_case_apis[1], match_t.api)
+    end)
+
     it("returns parsed upstream_url + upstream_uri", function()
       local use_case_apis = {
         {


### PR DESCRIPTION
Port of cd8b4df0bfb6e162056f7986502ffbce9b009f28 to the legacy API
router (backwards-compatible router for APIs).

Fix #3435