### PR TITLE
feat(aws-lambda) add forward_request_uri_path_params config option

### DIFF
--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -38,6 +38,7 @@ function AWSLambdaHandler:access(conf)
 
   if conf.forward_request_body or conf.forward_request_headers
     or conf.forward_request_method or conf.forward_request_uri
+    or conf.forward_request_uri_path_params
   then
     -- new behavior to forward request method, body, uri and their args
     local var = ngx.var
@@ -67,6 +68,11 @@ function AWSLambdaHandler:access(conf)
 
       upstream_body.request_body      = body_raw
       upstream_body.request_body_args = body_args
+    end
+
+    if conf.forward_request_uri_path_params then
+      local uri_captures = ngx.ctx.router_matches.uri_captures
+      upstream_body.request_uri_path_params = uri_captures
     end
 
   else

--- a/kong/plugins/aws-lambda/schema.lua
+++ b/kong/plugins/aws-lambda/schema.lua
@@ -96,5 +96,9 @@ return {
       type = "boolean",
       default = false,
     },
+    forward_request_uri_path_params = {
+      type = "boolean",
+      default = false
+    },
   },
 }


### PR DESCRIPTION
### Summary

When defining a Kong Route with a regex with capturing groups such as:

```/version/(?<version>\d+)/users/(?<user>\S+)```

The matched params will be available inside the plugin on ```local router_matches = ngx.ctx.router_matches```.

This adds the config option to forward those matched path params to the Lambda event body under ```request_uri_path_params```.

Therefore, the above route regex will produce a Lambda event body of:

```
{
  request_uri_path_params = {
    user = "batman",
    ["1"] = "12",
    ["2"] = "batman",
    version = "12",
    ["0"] = "/versions/12/users/batman"
  },
}
```

### Full changelog

* Added forward_request_uri_path_params config option and passing params to upstream body
* Add related tests.