### PR TITLE
chore(deps) bump lua-resty-worker-events to 0.3.3

### DIFF
--- a/kong-0.13.1-0.rockspec
+++ b/kong-0.13.1-0.rockspec
@@ -28,7 +28,7 @@ dependencies = {
   "luasyslog == 1.0.0",
   "lua_pack == 1.0.5",
   "lua-resty-dns-client == 2.0.0",
-  "lua-resty-worker-events == 0.3.2",
+  "lua-resty-worker-events == 0.3.3",
   "lua-resty-mediador == 0.1.2",
   "lua-resty-healthcheck == 0.4.0",
   "lua-resty-mlcache == 2.0.2",


### PR DESCRIPTION
Updates worker-events to 0.3.3 to fix the timeout issue for some events at startup, see #3417.

### Issues resolved

Fixes #3417
