### PR TITLE
fix(api) correctly handle sni in PUT /certificates/foo.com

### DIFF
--- a/kong/api/routes/certificates.lua
+++ b/kong/api/routes/certificates.lua
@@ -1,22 +1,31 @@
 local endpoints   = require "kong.api.endpoints"
 local utils       = require "kong.tools.utils"
 local responses   = require "kong.tools.responses"
+local Set         = require "pl.Set"
 
 
 local function get_cert_id_from_sni(self, db, helpers)
-  local id = self.params.certificates
-  if not utils.is_valid_uuid(id) then
-    local sni, _, err_t = db.snis:select_by_name(id)
-    if err_t then
-      return endpoints.handle_error(err_t)
-    end
-
-    if not sni then
-      responses.send_HTTP_NOT_FOUND("SNI not found")
-    end
-
-    self.params.certificates = sni.certificate.id
+  local id = ngx.unescape_uri(self.params.certificates)
+  if utils.is_valid_uuid(id) then
+    return
   end
+
+  local sni, _, err_t = db.snis:select_by_name(id)
+  if err_t then
+    return endpoints.handle_error(err_t)
+  end
+
+  if sni then
+    self.params.certificates = sni.certificate.id
+    return
+  end
+
+  if self.req.cmd_mth == "PUT" then
+    self.new_put_sni = id
+    return
+  end
+
+  responses.send_HTTP_NOT_FOUND("SNI not found")
 end
 
 
@@ -31,6 +40,35 @@ return {
       local cert, _, err_t = db.certificates:select_with_name_list(pk)
       if err_t then
         return endpoints.handle_error(err_t)
+      end
+
+      return helpers.responses.send_HTTP_OK(cert)
+    end,
+
+    -- override to create a new SNI in the PUT /certificates/foo.com (create) case
+    PUT = function(self, db, helpers)
+      local args = self.args.post
+      local cert, err_t, _
+      local id = ngx.unescape_uri(self.params.certificates)
+
+      -- cert was found via id or sni inside `before` section
+      if utils.is_valid_uuid(id) then
+        cert, _, err_t = db.certificates:upsert({ id = id }, args)
+
+      else -- create a new cert. Add extra sni if provided on url
+        if self.new_put_sni then
+          args.snis = Set.values(Set(args.snis or {}) + self.new_put_sni)
+          self.new_put_sni = nil
+        end
+        cert, _, err_t = db.certificates:insert(args)
+      end
+
+      if err_t then
+        return endpoints.handle_error(err_t)
+      end
+
+      if not cert then
+        return helpers.responses.send_HTTP_NOT_FOUND()
       end
 
       return helpers.responses.send_HTTP_OK(cert)

--- a/spec/02-integration/04-admin_api/06-certificates_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/06-certificates_routes_spec.lua
@@ -234,7 +234,7 @@ describe("Admin API: #" .. strategy, function()
           body = {
             cert = "created_cert",
             key = "created_key",
-            snis = { "pandoras-box.com" },
+            snis = { "example.com" },
           },
           headers = { ["Content-Type"] = "application/json" },
         })
@@ -242,10 +242,31 @@ describe("Admin API: #" .. strategy, function()
         local json = cjson.decode(body)
         assert.same("created_cert", json.cert)
 
-        assert.same({ "pandoras-box.com" }, json.snis)
+        assert.same({ "example.com" }, json.snis)
         json.snis = nil
 
         local in_db = assert(db.certificates:select({ id = id }))
+        assert.same(json, in_db)
+      end)
+
+      it("creates a new sni when provided in the url", function()
+        local res = client:put("/certificates/new-sni.com", {
+          body = {
+            cert = "created_cert",
+            key = "created_key",
+            snis = { "example.com" },
+          },
+          headers = { ["Content-Type"] = "application/json" },
+        })
+
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.same("created_cert", json.cert)
+
+        assert.same({ "example.com", "new-sni.com" }, json.snis)
+        json.snis = nil
+
+        local in_db = assert(db.certificates:select({ id = json.id }))
         assert.same(json, in_db)
       end)
 


### PR DESCRIPTION
Previously this method did create an extra certificate, but not the
accompanying SNI included on the URL. See the spec for details.