### PR TITLE
Fixes #233: Add generic X-RateLimit-* and X-RateLimit-Reset headers too.

### DIFF
--- a/kong/plugins/rate-limiting/policies/init.lua
+++ b/kong/plugins/rate-limiting/policies/init.lua
@@ -59,6 +59,7 @@ local EXPIRATIONS = {
 
 
 return {
+  ["EXPIRATIONS"] = EXPIRATIONS,
   ["local"] = {
     increment = function(conf, limits, identifier, current_timestamp, value)
       local periods = timestamp.get_timestamps(current_timestamp)


### PR DESCRIPTION
### Summary

In case of 429, returns `Retry-After` as per https://tools.ietf.org/html/rfc6585#section-4

Return the lowest limit header as X-RateLimit-Remaining and
the associate X-RateLimit-Reset.

### Full changelog

* Add `Retry-After` when clients are throttled out
* Add X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset using the lower values between the configured ones

### Issues resolved

Fix #233 
