### PR TITLE
fix(admin) empty url sugar attribute, see #3448

### DIFF
--- a/kong/api/api_helpers.lua
+++ b/kong/api/api_helpers.lua
@@ -71,18 +71,26 @@ end
 
 function _M.resolve_url_params(self)
   local sugar_url = self.args.post.url
-  if sugar_url then
-    local parsed_url        = url.parse(sugar_url)
-    self.args.post.protocol = parsed_url.scheme
-    self.args.post.host     = parsed_url.host
-    self.args.post.port     = tonumber(parsed_url.port) or
-                              parsed_url.port or
-                              (parsed_url.scheme == "http" and 80) or
-                              (parsed_url.scheme == "https" and 443) or
-                              nil
-    self.args.post.path     = parsed_url.path
-    self.args.post.url      = nil
+
+  self.args.post.url = nil
+
+  if type(sugar_url) ~= "string" then
+    return
   end
+
+  local parsed_url = url.parse(sugar_url)
+  if not parsed_url then
+    return
+  end
+
+  self.args.post.protocol = parsed_url.scheme
+  self.args.post.host     = parsed_url.host
+  self.args.post.port     = tonumber(parsed_url.port) or
+                            parsed_url.port or
+                            (parsed_url.scheme == "http" and 80) or
+                            (parsed_url.scheme == "https" and 443) or
+                            nil
+  self.args.post.path     = parsed_url.path
 end
 
 

--- a/spec/02-integration/04-admin_api/21-services_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/21-services_routes_spec.lua
@@ -122,6 +122,30 @@ for _, strategy in helpers.each_strategy() do
             assert.equals(60000, json.read_timeout)
           end
         end)
+
+        it_content_types("client error with with empty url", function(content_type)
+          return function()
+            local res = client:post("/services", {
+              body = {
+                url = "",
+              },
+              headers = { ["Content-Type"] = content_type },
+            })
+            assert.res_status(400, res)
+          end
+        end)
+
+        it_content_types("client error with invalid url", function(content_type)
+          return function()
+            local res = client:post("/services", {
+              body = {
+                url = " ",
+              },
+              headers = { ["Content-Type"] = content_type },
+            })
+            assert.res_status(400, res)
+          end
+        end)
       end)
 
       describe("GET", function()


### PR DESCRIPTION
### Summary

Fixes unexpected error on admin api when using invalid `url´ sugar attribute on services endpoints reported by @thefosk.

### Issues resolved

Fix #3448
