### PR TITLE
ScyllaDB compatibility: explicitly drop index before dropping table

### DIFF
--- a/kong/dao/migrations/cassandra.lua
+++ b/kong/dao/migrations/cassandra.lua
@@ -487,7 +487,7 @@ return {
   {
     name = "2017-05-19-173100_remove_nodes_table",
     up = [[
-      DROP INDEX IF EXISTS nodes_cluster_listening_address_idx_index;
+      DROP INDEX IF EXISTS nodes_cluster_listening_address_idx;
       DROP TABLE nodes;
     ]],
   },

--- a/kong/dao/migrations/cassandra.lua
+++ b/kong/dao/migrations/cassandra.lua
@@ -487,7 +487,7 @@ return {
   {
     name = "2017-05-19-173100_remove_nodes_table",
     up = [[
-      DROP INDEX nodes_cluster_listening_address_idx_index;
+      DROP INDEX IF EXISTS nodes_cluster_listening_address_idx_index;
       DROP TABLE nodes;
     ]],
   },

--- a/kong/dao/migrations/cassandra.lua
+++ b/kong/dao/migrations/cassandra.lua
@@ -487,6 +487,7 @@ return {
   {
     name = "2017-05-19-173100_remove_nodes_table",
     up = [[
+      DROP INDEX nodes_cluster_listening_address_idx_index;
       DROP TABLE nodes;
     ]],
   },


### PR DESCRIPTION
### Summary

ScyllaDB compatibility patch

### Full changelog

Added an explicit `DROP INDEX`, because otherwise Scylla refuses to drop `nodes` with the following error:

```
migrating core for keyspace kong
Error: [cassandra error] Error during migration 2017-05-19-173100_remove_nodes_table: [Invalid] Cannot drop table when materialized views still depend on it (kong.{nodes_cluster_listening_address_idx_index})
```

