### PR TITLE
Match route 'host' inclusive of port

### DIFF
--- a/kong/db/schema/typedefs.lua
+++ b/kong/db/schema/typedefs.lua
@@ -15,13 +15,9 @@ local type = type
 
 
 local function validate_host(host)
-  local res, err_or_port = utils.normalize_ip(host)
-  if type(err_or_port) == "string" and err_or_port ~= "invalid port number" then
+  local _, err_or_port = utils.normalize_ip(host)
+  if type(err_or_port) == "string" then
     return nil, "invalid value: " .. host
-  end
-
-  if err_or_port == "invalid port number" or type(res.port) == "number" then
-    return nil, "must not have a port"
   end
 
   return true

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -814,12 +814,12 @@ return {
       local trusted_ip = kong.ip.is_trusted(realip_remote_addr)
       if trusted_ip then
         forwarded_proto = var.http_x_forwarded_proto or var.scheme
-        forwarded_host  = var.http_x_forwarded_host  or var.host
+        forwarded_host  = var.http_x_forwarded_host  or var.http_host or var.host
         forwarded_port  = var.http_x_forwarded_port  or var.server_port
 
       else
         forwarded_proto = var.scheme
-        forwarded_host  = var.host
+        forwarded_host  = var.http_host or var.host
         forwarded_port  = var.server_port
       end
 

--- a/spec/01-unit/000-new-dao/01-schema/04-services_spec.lua
+++ b/spec/01-unit/000-new-dao/01-schema/04-services_spec.lua
@@ -301,16 +301,6 @@ describe("services", function()
       end
     end)
 
-    it("rejects values with a valid port", function()
-      local service = {
-        host = "example.com:80",
-      }
-
-      local ok, err = Services:validate(service)
-      assert.falsy(ok)
-      assert.equal("must not have a port", err.host)
-    end)
-
     it("rejects values with an invalid port", function()
       local service = {
         host = "example.com:1000000",
@@ -318,7 +308,7 @@ describe("services", function()
 
       local ok, err = Services:validate(service)
       assert.falsy(ok)
-      assert.equal("must not have a port", err.host)
+      assert.equal("invalid value: example.com:1000000", err.host)
     end)
 
     -- acceptance
@@ -336,6 +326,7 @@ describe("services", function()
         "hello.abcd",
         "example_api.com",
         "localhost",
+        "example.com:80",
         -- below:
         -- punycode examples from RFC3492;
         -- https://tools.ietf.org/html/rfc3492#page-14

--- a/spec/01-unit/000-new-dao/01-schema/05-routes_spec.lua
+++ b/spec/01-unit/000-new-dao/01-schema/05-routes_spec.lua
@@ -351,16 +351,6 @@ describe("routes schema", function()
       end
     end)
 
-    it("rejects values with a valid port", function()
-      local route = {
-        hosts = { "example.com:80" }
-      }
-
-      local ok, err = Routes:validate(route)
-      assert.falsy(ok)
-      assert.equal("must not have a port", err.hosts)
-    end)
-
     it("rejects values with an invalid port", function()
       local route = {
         hosts = { "example.com:1000000" }
@@ -368,7 +358,7 @@ describe("routes schema", function()
 
       local ok, err = Routes:validate(route)
       assert.falsy(ok)
-      assert.equal("must not have a port", err.hosts)
+      assert.equal("invalid value: example.com:1000000", err.hosts)
     end)
 
     it("rejects invalid wildcard placement", function()
@@ -424,6 +414,7 @@ describe("routes schema", function()
         "hello.abcd",
         "example_api.com",
         "localhost",
+        "example.com:80",
         -- below:
         -- punycode examples from RFC3492;
         -- https://tools.ietf.org/html/rfc3492#page-14

--- a/spec/01-unit/010-router_spec.lua
+++ b/spec/01-unit/010-router_spec.lua
@@ -501,7 +501,7 @@ describe("Router", function()
       local router = assert(Router.new(use_case))
 
       it("matches leftmost wildcards", function()
-        local match_t = router.select("GET", "/", "foo.route.com", "domain.org")
+        local match_t = router.select("GET", "/", "foo.route.com")
         assert.truthy(match_t)
         assert.same(use_case[1].route, match_t.route)
         assert.same(match_t.matches.host, use_case[1].headers.host[1])

--- a/spec/01-unit/010-router_spec.lua
+++ b/spec/01-unit/010-router_spec.lua
@@ -150,17 +150,6 @@ describe("Router", function()
       assert.same(match_t.matches.uri_captures, nil)
     end)
 
-    it("[host] ignores port", function()
-      -- host
-      local match_t = router.select("GET", "/", "domain-1.org:123")
-      assert.truthy(match_t)
-      assert.same(use_case[1].route, match_t.route)
-      assert.same(match_t.matches.host, use_case[1].headers.host[1])
-      assert.same(match_t.matches.method, nil)
-      assert.same(match_t.matches.uri, nil)
-      assert.same(match_t.matches.uri_captures, nil)
-    end)
-
     it("[uri]", function()
       -- uri
       local match_t = router.select("GET", "/my-route", "domain.org")
@@ -944,6 +933,10 @@ describe("Router", function()
         assert.is_nil(router.select("GET", "/", "domain-3.org"))
       end)
 
+      it("unknown port", function()
+        assert.is_nil(router.select("GET", "/", "domain-1.org:123"))
+      end)
+
       it("invalid host in [host + uri]", function()
         assert.is_nil(router.select("GET", "/route-4", "domain-3.org"))
       end)
@@ -1625,7 +1618,7 @@ describe("Router", function()
             preserve_host = true,
           },
           headers         = {
-            host          = { "preserve.com" },
+            host          = { "preserve.com", "preserve.com:123" },
           },
         },
         -- use the route's upstream_url's Host
@@ -2023,44 +2016,44 @@ describe("Router", function()
       local router = assert(Router.new(use_case))
 
       it("[src_ip]", function()
-        local match_t = router.select(nil, nil, nil, nil, "127.0.0.1")
+        local match_t = router.select(nil, nil, nil, nil, nil, "127.0.0.1")
         assert.truthy(match_t)
         assert.same(use_case[1].route, match_t.route)
 
-        match_t = router.select(nil, nil, nil, nil, "127.0.0.1")
+        match_t = router.select(nil, nil, nil, nil, nil, "127.0.0.1")
         assert.truthy(match_t)
         assert.same(use_case[1].route, match_t.route)
       end)
 
       it("[src_port]", function()
-        local match_t = router.select(nil, nil, nil, nil, "127.0.0.3", 65001)
+        local match_t = router.select(nil, nil, nil, nil, nil, "127.0.0.3", 65001)
         assert.truthy(match_t)
         assert.same(use_case[2].route, match_t.route)
       end)
 
       it("[src_ip] range match", function()
-        local match_t = router.select(nil, nil, nil, nil, "127.168.0.1")
+        local match_t = router.select(nil, nil, nil, nil, nil, "127.168.0.1")
         assert.truthy(match_t)
         assert.same(use_case[3].route, match_t.route)
       end)
 
       it("[src_ip] + [src_port]", function()
-        local match_t = router.select(nil, nil, nil, nil, "127.0.0.1", 65001)
+        local match_t = router.select(nil, nil, nil, nil, nil, "127.0.0.1", 65001)
         assert.truthy(match_t)
         assert.same(use_case[4].route, match_t.route)
       end)
 
       it("[src_ip] range match + [src_port]", function()
-        local match_t = router.select(nil, nil, nil, nil, "127.168.10.1", 65301)
+        local match_t = router.select(nil, nil, nil, nil, nil, "127.168.10.1", 65301)
         assert.truthy(match_t)
         assert.same(use_case[5].route, match_t.route)
       end)
 
       it("[src_ip] no match", function()
-        local match_t = router.select(nil, nil, nil, nil, "10.0.0.1")
+        local match_t = router.select(nil, nil, nil, nil, nil, "10.0.0.1")
         assert.falsy(match_t)
 
-        match_t = router.select(nil, nil, nil, nil, "10.0.0.2", 65301)
+        match_t = router.select(nil, nil, nil, nil, nil, "10.0.0.2", 65301)
         assert.falsy(match_t)
       end)
     end)
@@ -2119,51 +2112,51 @@ describe("Router", function()
       local router = assert(Router.new(use_case))
 
       it("[dst_ip]", function()
-        local match_t = router.select(nil, nil, nil, nil, nil, nil,
+        local match_t = router.select(nil, nil, nil, nil, nil, nil, nil,
                                       "127.0.0.1")
         assert.truthy(match_t)
         assert.same(use_case[1].route, match_t.route)
 
-        match_t = router.select(nil, nil, nil, nil, nil, nil,
+        match_t = router.select(nil, nil, nil, nil, nil, nil, nil,
                                 "127.0.0.1")
         assert.truthy(match_t)
         assert.same(use_case[1].route, match_t.route)
       end)
 
       it("[dst_port]", function()
-        local match_t = router.select(nil, nil, nil, nil, nil, nil,
+        local match_t = router.select(nil, nil, nil, nil, nil, nil, nil,
                                       "127.0.0.3", 65001)
         assert.truthy(match_t)
         assert.same(use_case[2].route, match_t.route)
       end)
 
       it("[dst_ip] range match", function()
-        local match_t = router.select(nil, nil, nil, nil, nil, nil,
+        local match_t = router.select(nil, nil, nil, nil, nil, nil, nil,
                                       "127.168.0.1")
         assert.truthy(match_t)
         assert.same(use_case[3].route, match_t.route)
       end)
 
       it("[dst_ip] + [dst_port]", function()
-        local match_t = router.select(nil, nil, nil, nil, nil, nil,
+        local match_t = router.select(nil, nil, nil, nil, nil, nil, nil,
                                       "127.0.0.1", 65001)
         assert.truthy(match_t)
         assert.same(use_case[4].route, match_t.route)
       end)
 
       it("[dst_ip] range match + [dst_port]", function()
-        local match_t = router.select(nil, nil, nil, nil, nil, nil,
+        local match_t = router.select(nil, nil, nil, nil, nil, nil, nil,
                                       "127.168.10.1", 65301)
         assert.truthy(match_t)
         assert.same(use_case[5].route, match_t.route)
       end)
 
       it("[dst_ip] no match", function()
-        local match_t = router.select(nil, nil, nil, nil, nil, nil,
+        local match_t = router.select(nil, nil, nil, nil, nil, nil, nil,
                                       "10.0.0.1")
         assert.falsy(match_t)
 
-        match_t = router.select(nil, nil, nil, nil, nil, nil,
+        match_t = router.select(nil, nil, nil, nil, nil, nil, nil,
                                 "10.0.0.2", 65301)
         assert.falsy(match_t)
       end)
@@ -2184,7 +2177,7 @@ describe("Router", function()
 
       it("[sni]", function()
         local match_t = router.select(nil, nil, nil, nil, nil, nil, nil, nil,
-                                      "www.example.org")
+                                      nil, "www.example.org")
         assert.truthy(match_t)
         assert.same(use_case[1].route, match_t.route)
       end)
@@ -2219,12 +2212,12 @@ describe("Router", function()
 
       local router = assert(Router.new(use_case))
 
-      local match_t = router.select(nil, nil, nil, nil, "127.0.0.1", nil,
+      local match_t = router.select(nil, nil, nil, nil, nil, "127.0.0.1", nil,
                                     nil, nil, "www.example.org")
       assert.truthy(match_t)
       assert.same(use_case[1].route, match_t.route)
 
-      match_t = router.select(nil, nil, nil, nil, nil, nil,
+      match_t = router.select(nil, nil, nil, nil, nil, nil, nil,
                               "172.168.0.1", nil, "www.example.org")
       assert.truthy(match_t)
       assert.same(use_case[1].route, match_t.route)
@@ -2253,7 +2246,7 @@ describe("Router", function()
 
       local router = assert(Router.new(use_case))
 
-      local match_t = router.select(nil, nil, nil, nil, "127.0.0.1", nil,
+      local match_t = router.select(nil, nil, nil, nil, nil, "127.0.0.1", nil,
                                     "172.168.0.1", nil, "www.example.org")
       assert.truthy(match_t)
       assert.same(use_case[2].route, match_t.route)

--- a/spec/02-integration/05-proxy/01-router_spec.lua
+++ b/spec/02-integration/05-proxy/01-router_spec.lua
@@ -678,7 +678,7 @@ for _, strategy in helpers.each_strategy() do
         insert_routes {
           {
             preserve_host = true,
-            hosts         = { "preserved.com" },
+            hosts         = { "preserved.com", "preserved.com:123" },
             service       = {
               path        = "/request"
             },


### PR DESCRIPTION
## Summary

Currently a route is matched based on the hostname. This PR changes it to match on a host+port pair, as sent in the `Host` header.

I think the current situation came about due to the confusing identifier of `host`: in some places it is used to mean "host name", while in others it is used to mean "form of a Host header". As ports are optional in host headers, it is easy to conflate the two.

## Open Questions

1.  When a HTTP request is sent to the nominal port (80 for http; 443 for https), the host header does not include the port.

      - <s>What route should be used if a client sends `Host: myhost.com:80`?</s>
          - <s>What about if it was a https request?</s>
      - <s>Does nginx strip or modify things in any way?</s>
      - If an admin adds a route with host `myhost.com:80`, when should it match?

2. Should X-Forwarded-Port be removed?
