### PR TITLE
Alter datadog plugin to tag metric data per datadog best-practices

### DIFF
--- a/kong/plugins/datadog/handler.lua
+++ b/kong/plugins/datadog/handler.lua
@@ -7,7 +7,6 @@ local ngx_log       = ngx.log
 local ngx_timer_at  = ngx.timer.at
 local string_gsub   = string.gsub
 local pairs         = pairs
-local string_format = string.format
 local NGX_ERR       = ngx.ERR
 
 


### PR DESCRIPTION
### Summary

Currently all metrics for datadog are pushed to differently named metrics (eg: kong.api_name.latency, kong.api2_name.latency).  This is bad practice on Datadog and it makes it impossible to make a single dashboard in Datadog with variable options (eg: choosing which API) to change which API you'd like to analyze.  With the current implementation you have to manually create a dashboard for every API you ever make.  Datadog best-practices dictate that you use a static metric name and use tags to differentiate your data within' that metric.

### Full changelog

* Made all datadog metric names static
* Added proper tagging to datadog metrics instead of variable metric names
* Removed a now-obsolete metric (totals) since you can glean this from a single metric without specifying an app_name tag.

### Additional notes

* Because the way this plugin works is fundamentally changing (improving) any/all blogs and articles that point to the old way this works needs to be updated.  These are more external, but the one I used was: https://www.datadoghq.com/blog/monitor-kong-datadog/ .  I've submitted a handful of improvement requests to their articles lately... I'm sure another one or two wouldn't hurt.
* Admittedly, I'm not a Lua programmer.  Maintainers, please edit/change/modify as necessary.  I tried to fit within' the contribution and code style guidelines, but I could be way off in some ways.

### Relevant Links

[Datadog - Tagging](https://docs.datadoghq.com/getting_started/tagging/)
[Datadog - Using Tags](https://docs.datadoghq.com/getting_started/tagging/using_tags/)
[Datadog - Why to use tags](https://www.datadoghq.com/blog/the-power-of-tagged-metrics/)
[Datadog - Dashboard Template Variables](https://docs.datadoghq.com/graphing/faq/correlate-metrics-and-events-using-dashboard-template-variables/)