### PR TITLE
docs(config) add lua_package_path default

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -485,10 +485,10 @@
                                  # This includes the certificates configured
                                  # for Kong's database connections.
 
-#lua_package_path =              # Sets the Lua module search path (LUA_PATH).
-                                 # Useful when developing or using custom
-                                 # plugins not stored in the default search
-                                 # path.
+#lua_package_path = ./?.lua;./?/init.lua; # Sets the Lua module search path
+                                          # (LUA_PATH). Useful when developing
+                                          # or using custom plugins not stored
+                                          # in the default search path.
 
 #lua_package_cpath =             # Sets the Lua C module search path
                                  # (LUA_CPATH).


### PR DESCRIPTION
### Summary

lua_package_path has a default in kong_defaults.lua but not reflective in kong.conf.default

### Full changelog
* docs(config) add lua_package_path default
