### PR TITLE
Add hash on cookie

### DIFF
--- a/kong-0.13.1-0.rockspec
+++ b/kong-0.13.1-0.rockspec
@@ -31,6 +31,7 @@ dependencies = {
   "lua-resty-worker-events == 0.3.3",
   "lua-resty-mediador == 0.1.2",
   "lua-resty-healthcheck == 0.4.0",
+  "lua-resty-cookie == 0.1.0",
   "lua-resty-mlcache == 2.0.2",
   -- external Kong plugins
   "kong-plugin-azure-functions == 0.1.0",

--- a/kong/dao/migrations/cassandra.lua
+++ b/kong/dao/migrations/cassandra.lua
@@ -748,5 +748,16 @@ return {
       CREATE INDEX IF NOT EXISTS ON consumers(custom_id);
       CREATE INDEX IF NOT EXISTS ON consumers(username);
     ]]
+  },
+  {
+    name = "2018-05-17-173100_hash_on_cookie",
+    up = [[
+      ALTER TABLE upstreams ADD hash_on_cookie text;
+      ALTER TABLE upstreams ADD hash_on_cookie_path text;
+    ]],
+    down = [[
+      ALTER TABLE upstreams DROP hash_on_cookie;
+      ALTER TABLE upstreams DROP hash_on_cookie_path;
+    ]]
   }
 }

--- a/kong/dao/migrations/postgres.lua
+++ b/kong/dao/migrations/postgres.lua
@@ -785,4 +785,15 @@ return {
     ]],
     down = nil
   },
+  {
+    name = "2018-05-17-173100_hash_on_cookie",
+    up = [[
+      ALTER TABLE upstreams ADD hash_on_cookie text;
+      ALTER TABLE upstreams ADD hash_on_cookie_path text;
+    ]],
+    down = [[
+      ALTER TABLE upstreams DROP hash_on_cookie;
+      ALTER TABLE upstreams DROP hash_on_cookie_path;
+    ]]
+  }
 }

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -7,6 +7,7 @@
 --
 -- In the `access_by_lua` phase, it is responsible for retrieving the route being proxied by
 -- a consumer. Then it is responsible for loading the plugins to execute on this request.
+local ck          = require "resty.cookie"
 local utils       = require "kong.tools.utils"
 local Router      = require "kong.router"
 local ApiRouter   = require "kong.api_router"
@@ -705,6 +706,18 @@ return {
 
           elseif matches then
             header[upstream_status_header] = matches[0]
+          end
+        end
+
+        local cookie_hash_data = ctx.balancer_hash_cookie
+        if cookie_hash_data then
+          local cookie = ck:new()
+          local ok, err = cookie:set(cookie_hash_data)
+
+          if not ok then
+            log(ngx.WARN, "failed to set the cookie for hash-based load balancing: ", err,
+                          " (key=", cookie_hash_data.key,
+                          ", path=", cookie_hash_data.path, ")")
           end
         end
       end

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -810,4 +810,22 @@ _M.validate_header_name = function(name)
               "', allowed characters are A-Z, a-z, 0-9, '_', and '-'"
 end
 
+--- Validates a cookie name.
+-- Checks characters used in a cookie name to be valid
+-- a-z, A-Z, 0-9, '_' and '-' are allowed.
+-- @param name (string) the cookie name to verify
+-- @return the valid cookie name, or `nil+error`
+_M.validate_cookie_name = function(name)
+  if name == nil or name == "" then
+    return nil, "no cookie name provided"
+  end
+
+  if re_match(name, "^[a-zA-Z0-9-_]+$", "jo") then
+    return name
+  end
+
+  return nil, "bad cookie name '" .. name ..
+              "', allowed characters are A-Z, a-z, 0-9, '_', and '-'"
+end
+
 return _M

--- a/spec/01-unit/004-utils_spec.lua
+++ b/spec/01-unit/004-utils_spec.lua
@@ -525,6 +525,21 @@ describe("Utils", function()
       end
     end
   end)
+  it("validate_cookie_name() validates cookie names", function()
+    local header_chars = [[_-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz]]
+
+    for i = 1, 255 do
+      local c = string.char(i)
+
+      if string.find(header_chars, c, nil, true) then
+        assert(utils.validate_cookie_name(c) == c,
+          "ascii character '" .. c .. "' (" .. i .. ") should have been allowed")
+      else
+        assert(utils.validate_cookie_name(c) == nil,
+          "ascii character " .. i .. " should not have been allowed")
+      end
+    end
+  end)
   it("pack() stores results, including nils, properly", function()
     assert.same({ n = 0 }, utils.pack())
     assert.same({ n = 1 }, utils.pack(nil))

--- a/spec/01-unit/011-balancer_spec.lua
+++ b/spec/01-unit/011-balancer_spec.lua
@@ -506,6 +506,27 @@ describe("Balancer", function()
       })
       assert.are.same(crc32(value), hash)
     end)
+    describe("cookie", function()
+      it("uses the cookie when present in the request", function()
+        local value = "some cookie value"
+        ngx.var.cookie_Foo = value
+        local hash = balancer._create_hash({
+          hash_on = "cookie",
+          hash_on_cookie = "Foo",
+        })
+        assert.are.same(crc32(value), hash)
+        assert.is_nil(ngx.ctx.balancer_hash_cookie)
+      end)
+      it("creates the cookie when not present in the request", function()
+        balancer._create_hash({
+          hash_on = "cookie",
+          hash_on_cookie = "Foo",
+          hash_on_cookie_path = "/",
+        })
+        assert.are.same(ngx.ctx.balancer_hash_cookie.key, "Foo")
+        assert.are.same(ngx.ctx.balancer_hash_cookie.path, "/")
+      end)
+    end)
     it("multi-header", function()
       local value = { "some header value", "another value" }
       headers.HeaderName = value
@@ -561,6 +582,29 @@ describe("Balancer", function()
             hash_fallback_header = "HeaderName",
         })
         assert.are.same(crc32(table.concat(value)), hash)
+      end)
+      describe("cookie", function()
+        it("uses the cookie when present in the request", function()
+          local value = "some cookie value"
+          ngx.var.cookie_Foo = value
+          local hash = balancer._create_hash({
+            hash_on = "consumer",
+            hash_fallback = "cookie",
+            hash_on_cookie = "Foo",
+          })
+          assert.are.same(crc32(value), hash)
+          assert.is_nil(ngx.ctx.balancer_hash_cookie)
+        end)
+        it("creates the cookie when not present in the request", function()
+          balancer._create_hash({
+            hash_on = "consumer",
+            hash_fallback = "cookie",
+            hash_on_cookie = "Foo",
+            hash_on_cookie_path = "/",
+          })
+          assert.are.same(ngx.ctx.balancer_hash_cookie.key, "Foo")
+          assert.are.same(ngx.ctx.balancer_hash_cookie.path, "/")
+        end)
       end)
     end)
   end)

--- a/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
@@ -87,6 +87,29 @@ describe("Admin API: #" .. kong_config.database, function()
           assert.are.equal("HeaderFallback", json.hash_fallback_header)
         end
       end)
+      it_content_types("creates an upstream with hash_on cookie parameters", function(content_type)
+        return function()
+          local res = assert(client:send {
+            method = "POST",
+            path = "/upstreams",
+            body = {
+              name = "my.upstream",
+              hash_on = "cookie",
+              hash_on_cookie = "CookieName1",
+              hash_on_cookie_path = "/foo",
+            },
+            headers = {["Content-Type"] = content_type}
+          })
+          assert.response(res).has.status(201)
+          local json = assert.response(res).has.jsonbody()
+          assert.equal("my.upstream", json.name)
+          assert.is_number(json.created_at)
+          assert.is_string(json.id)
+          assert.are.equal("cookie", json.hash_on)
+          assert.are.equal("CookieName1", json.hash_on_cookie)
+          assert.are.equal("/foo", json.hash_on_cookie_path)
+        end
+      end)
       it_content_types("creates an upstream with 2 header hashes", function(content_type)
         return function()
           local res = assert(client:send {
@@ -198,7 +221,7 @@ describe("Admin API: #" .. kong_config.database, function()
             })
             body = assert.res_status(400, res)
             local json = cjson.decode(body)
-            assert.same({ hash_on = '"something that is invalid" is not allowed. Allowed values are: "none", "consumer", "ip", "header"' }, json)
+            assert.same({ hash_on = '"something that is invalid" is not allowed. Allowed values are: "none", "consumer", "ip", "header", "cookie"' }, json)
 
             -- Invalid hash_fallback entries
             res = assert(client:send {
@@ -213,7 +236,7 @@ describe("Admin API: #" .. kong_config.database, function()
             })
             body = assert.res_status(400, res)
             local json = cjson.decode(body)
-            assert.same({ hash_fallback = '"something that is invalid" is not allowed. Allowed values are: "none", "consumer", "ip", "header"' }, json)
+            assert.same({ hash_fallback = '"something that is invalid" is not allowed. Allowed values are: "none", "consumer", "ip", "header", "cookie"' }, json)
 
             -- same hash entries
             res = assert(client:send {
@@ -246,7 +269,7 @@ describe("Admin API: #" .. kong_config.database, function()
             local json = cjson.decode(body)
             assert.same({ message = "Header: bad header name 'not a <> valid <> header name', allowed characters are A-Z, a-z, 0-9, '_', and '-'" }, json)
 
-            -- Invalid header
+            -- Invalid fallback header
             res = assert(client:send {
               method = "POST",
               path = "/upstreams",
@@ -279,6 +302,23 @@ describe("Admin API: #" .. kong_config.database, function()
             local json = cjson.decode(body)
             assert.same({ message = "Cannot set fallback and primary hashes to the same value" }, json)
 
+            -- Cookie with hash_fallback
+            res = assert(client:send {
+              method = "POST",
+              path = "/upstreams",
+              body = {
+                name = "my.upstream",
+                hash_on = "cookie",
+                hash_on_cookie = "cookiename",
+                hash_fallback = "header",
+                hash_fallback_header = "Cool-Header",
+              },
+              headers = {["Content-Type"] = content_type}
+            })
+            body = assert.res_status(400, res)
+            local json = cjson.decode(body)
+            assert.same({ message = "Cannot set `hash_fallback` if primary `hash_on` is set to cookie" }, json)
+
             -- No headername provided
             res = assert(client:send {
               method = "POST",
@@ -310,6 +350,70 @@ describe("Admin API: #" .. kong_config.database, function()
             body = assert.res_status(400, res)
             local json = cjson.decode(body)
             assert.same({ message = "Hashing on 'header', but no header name provided" }, json)
+
+            -- Invalid cookie
+            res = assert(client:send {
+              method = "POST",
+              path = "/upstreams",
+              body = {
+                name = "my.upstream",
+                hash_on = "cookie",
+                hash_on_cookie = "not a <> valid <> cookie name",
+              },
+              headers = {["Content-Type"] = content_type}
+            })
+            body = assert.res_status(400, res)
+            local json = cjson.decode(body)
+            assert.same({ message = "Cookie name: bad cookie name 'not a <> valid <> cookie name', allowed characters are A-Z, a-z, 0-9, '_', and '-'" }, json)
+
+            -- Invalid cookie path
+            res = assert(client:send {
+              method = "POST",
+              path = "/upstreams",
+              body = {
+                name = "my.upstream",
+                hash_on = "cookie",
+                hash_on_cookie = "hashme",
+                hash_on_cookie_path = "not a path",
+              },
+              headers = {["Content-Type"] = content_type}
+            })
+            body = assert.res_status(400, res)
+            local json = cjson.decode(body)
+            assert.same({ message = "Cookie path: must be prefixed with slash" }, json)
+
+            -- Invalid cookie in hash fallback
+            res = assert(client:send {
+              method = "POST",
+              path = "/upstreams",
+              body = {
+                name = "my.upstream",
+                hash_on = "consumer",
+                hash_fallback = "cookie",
+                hash_on_cookie = "not a <> valid <> cookie name",
+              },
+              headers = {["Content-Type"] = content_type}
+            })
+            body = assert.res_status(400, res)
+            local json = cjson.decode(body)
+            assert.same({ message = "Cookie name: bad cookie name 'not a <> valid <> cookie name', allowed characters are A-Z, a-z, 0-9, '_', and '-'" }, json)
+
+            -- Invalid cookie path in hash fallback
+            res = assert(client:send {
+              method = "POST",
+              path = "/upstreams",
+              body = {
+                name = "my.upstream",
+                hash_on = "consumer",
+                hash_fallback = "cookie",
+                hash_on_cookie = "my-cookie",
+                hash_on_cookie_path = "not a path",
+              },
+              headers = {["Content-Type"] = content_type}
+            })
+            body = assert.res_status(400, res)
+            local json = cjson.decode(body)
+            assert.same({ message = "Cookie path: must be prefixed with slash" }, json)
 
           end
         end)


### PR DESCRIPTION
### Summary

Add ability to hash on cookie. Per a [discussion on the feature suggestion board](https://discuss.konghq.com/t/support-sticky-sessions-for-websockets/937/9) with @Tieske , this adds a `cookie` option for the `hash_on` feature, which works very similarly to the `header option. The use case for this is to allow load balancing with cookie injection, creating a sticky session for API consumers who all behind the same NAT gateway. Specifically this is useful for websockets.

### Full changelog

* Implement cookie source for hashing algorithm
  * Upstream config can use `cookie` for `hash_on` and `hash_fallback` value
  * Upstream config uses `hash_on_cookie` or `hash_fallback_cookie` for the name of the cookie to use
  * Upstream config uses `hash_on_cookie_path` or `hash_fallback_cookie_path` to add the path to the `Set-Cookie` header
* Add related unit and integration tests

### Notes

I'm new to Lua (and, hence, this project), so feel encouraged to tell me everything that's wrong with my code ;) I'm not sure if there's a place for me to add documentation.
I will clean up git history after making any requested changes/ getting final approval.