### PR TITLE
fix(balancer) avoid needless rebuild of balancer when adding target

### DIFF
--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -416,8 +416,9 @@ local function check_target_history(upstream, balancer)
   -- compare balancer history with db-loaded history
   local last_equal_index = 0  -- last index where history is the same
   for i, entry in ipairs(old_history) do
-    if entry.order ~= (new_history[i] or EMPTY_T).order then
-      last_equal_index = i - 1
+    if new_history[i] and entry.order == new_history[i].order then
+      last_equal_index = i
+    else
       break
     end
   end

--- a/spec/01-unit/011-balancer_spec.lua
+++ b/spec/01-unit/011-balancer_spec.lua
@@ -8,6 +8,7 @@ describe("Balancer", function()
   local uuid = require("kong.tools.utils").uuid
   local upstream_hc
   local upstream_ph
+  local upstream_ote
 
   teardown(function()
     ngx.log:revert()
@@ -78,9 +79,11 @@ describe("Balancer", function()
       [6] = { id = "f", name = "upstream_f", slots = 10, healthchecks = hc_defaults },
       [7] = { id = "hc", name = "upstream_hc", slots = 10, healthchecks = passive_hc },
       [8] = { id = "ph", name = "upstream_ph", slots = 10, healthchecks = passive_hc },
+      [9] = { id = "ote", name = "upstream_ote", slots = 10, healthchecks = hc_defaults },
     }
     upstream_hc = UPSTREAMS_FIXTURES[7]
     upstream_ph = UPSTREAMS_FIXTURES[8]
+    upstream_ote = UPSTREAMS_FIXTURES[9]
 
     TARGETS_FIXTURES = {
       -- 1st upstream; a
@@ -185,6 +188,14 @@ describe("Balancer", function()
         created_at = "001",
         upstream_id = "ph",
         target = "127.0.0.1:2222",
+        weight = 10,
+      },
+      -- upstream_ote
+      {
+        id = "ote1",
+        created_at = "001",
+        upstream_id = "ote",
+        target = "localhost:1111",
         weight = 10,
       },
     }
@@ -371,6 +382,31 @@ describe("Balancer", function()
       assert(targets[2].id == "a2")
       assert(targets[3].id == "a4")
       assert(targets[4].id == "a1")
+    end)
+  end)
+
+  describe("on_target_event()", function()
+    setup(function()
+      balancer._load_targets_into_memory("ote")
+    end)
+
+    it("adding a target does not recreate a balancer", function()
+      local b1 = balancer._create_balancer(upstream_ote)
+      assert.same(1, #(balancer._get_target_history(b1)))
+
+      table.insert(TARGETS_FIXTURES, {
+        id = "ote2",
+        created_at = "002",
+        upstream_id = "ote",
+        target = "localhost:1112",
+        weight = 10,
+      })
+      balancer.on_target_event("create", { upstream_id = "ote" })
+
+      local b2 = balancer._create_balancer(upstream_ote)
+      assert.same(2, #(balancer._get_target_history(b2)))
+
+      assert(b1 == b2)
     end)
   end)
 


### PR DESCRIPTION
This bug was introduced when the loop to find `last_equal_index` was changed from looping the new targets list into looping the old targets list. Looping the old targets list is more efficient, but the logic for checking the index needed to be updated.

Includes a regression test that verifies that adding a target works and does not rebuild the balancer.