### PR TITLE
chore(deps) bump DNS lib to 2.1.0

### DIFF
--- a/kong-0.13.1-0.rockspec
+++ b/kong-0.13.1-0.rockspec
@@ -27,7 +27,7 @@ dependencies = {
   "luaossl == 20171028",
   "luasyslog == 1.0.0",
   "lua_pack == 1.0.5",
-  "lua-resty-dns-client == 2.0.0",
+  "lua-resty-dns-client == 2.1.0",
   "lua-resty-worker-events == 0.3.3",
   "lua-resty-mediador == 0.1.2",
   "lua-resty-healthcheck == 0.4.0",


### PR DESCRIPTION
See https://github.com/Kong/lua-resty-dns-client#history for the changes in version 2.1.0.
