### PR TITLE
[refactor] Extract group related functions from acl plugin

### DIFF
--- a/kong-0.13.1-0.rockspec
+++ b/kong-0.13.1-0.rockspec
@@ -247,6 +247,7 @@ build = {
     ["kong.plugins.acl.schema"] = "kong/plugins/acl/schema.lua",
     ["kong.plugins.acl.api"] = "kong/plugins/acl/api.lua",
     ["kong.plugins.acl.daos"] = "kong/plugins/acl/daos.lua",
+    ["kong.plugins.acl.groups"] = "kong/plugins/acl/groups.lua",
 
     ["kong.plugins.correlation-id.handler"] = "kong/plugins/correlation-id/handler.lua",
     ["kong.plugins.correlation-id.schema"] = "kong/plugins/correlation-id/schema.lua",

--- a/kong/plugins/acl/groups.lua
+++ b/kong/plugins/acl/groups.lua
@@ -2,9 +2,7 @@ local singletons = require "kong.singletons"
 local pl_tablex = require "pl.tablex"
 
 
-
 local EMPTY = pl_tablex.readonly {}
-
 
 
 local mt_cache = { __mode = "k" }
@@ -12,13 +10,8 @@ local consumer_groups_cache = setmetatable({}, mt_cache)
 local consumer_in_groups_cache = setmetatable({}, mt_cache)
 
 
-
 local function load_groups_into_memory(consumer_id)
-  local results, err = singletons.dao.acls:find_all {consumer_id = consumer_id}
-  if err then
-    return nil, err
-  end
-  return results
+  return singletons.dao.acls:find_all {consumer_id = consumer_id}
 end
 
 
@@ -28,7 +21,8 @@ end
 local function get_consumer_groups_raw(consumer_id)
   local cache_key = singletons.dao.acls:cache_key(consumer_id)
   local raw_groups, err = singletons.cache:get(cache_key, nil,
-                                         load_groups_into_memory, consumer_id)
+                                               load_groups_into_memory,
+                                               consumer_id)
   if err then
     return nil, err
   end

--- a/kong/plugins/acl/groups.lua
+++ b/kong/plugins/acl/groups.lua
@@ -1,0 +1,138 @@
+local singletons = require "kong.singletons"
+local pl_tablex = require "pl.tablex"
+
+
+
+local EMPTY = pl_tablex.readonly {}
+
+
+
+local mt_cache = { __mode = "k" }
+local consumer_groups_cache = setmetatable({}, mt_cache)
+local consumer_in_groups_cache = setmetatable({}, mt_cache)
+
+
+
+local function load_groups_into_memory(consumer_id)
+  local results, err = singletons.dao.acls:find_all {consumer_id = consumer_id}
+  if err then
+    return nil, err
+  end
+  return results
+end
+
+
+--- Returns the database records with groups the consumer belongs to
+-- @param conumer_id (string) the consumer for which to fetch the groups it belongs to
+-- @return table with group records (empty table if none), or nil+error
+local function get_consumer_groups_raw(consumer_id)
+  local cache_key = singletons.dao.acls:cache_key(consumer_id)
+  local raw_groups, err = singletons.cache:get(cache_key, nil,
+                                         load_groups_into_memory, consumer_id)
+  if err then
+    return nil, err
+  end
+
+  -- use EMPTY to be able to use it as a cache key, since a new table would
+  -- immediately be collected again and not allow for negative caching.
+  return raw_groups or EMPTY
+end
+
+
+--- Returns a table with all group names a consumer belongs to.
+-- The table will have an array part to iterate over, and a hash part
+-- where each group name is indexed by itself. Eg.
+-- {
+--   [1] = "users",
+--   [2] = "admins",
+--   users = "users",
+--   admins = "admins",
+-- }
+-- If there are no groups defined, it will return an empty table
+-- @param conumer_id (string) the consumer for which to fetch the groups it belongs to
+-- @return table with groups (empty table if none) or nil+error
+local function get_consumer_groups(consumer_id)
+  local raw_groups, err = get_consumer_groups_raw(consumer_id)
+  if not raw_groups then
+    return nil, err
+  end
+
+  local groups = consumer_groups_cache[raw_groups]
+  if not groups then
+    groups = {}
+    consumer_groups_cache[raw_groups] = groups
+    for i = 1, #raw_groups do
+      local group = raw_groups[i].group
+      groups[i] = group
+      groups[group] = group
+    end
+  end
+  return groups
+end
+
+
+--- checks whether a consumer-group-list is part of a given list of groups.
+-- @param groups_to_check (table) an array of group names. Note: since the
+-- results will be cached by this table, always use the same table for the
+-- same set of groups!
+-- @param consumer_groups (table) list of consumer groups (result from
+-- `get_consumer_groups`)
+-- @return (boolean) whether the consumer is part of any of the groups.
+local function consumer_in_groups(groups_to_check, consumer_groups)
+  -- 1st level cache on "groups_to_check"
+  local result1 = consumer_in_groups_cache[groups_to_check]
+  if result1 == nil then
+    result1 = setmetatable({}, mt_cache)
+    consumer_in_groups_cache[groups_to_check] = result1
+  end
+
+  -- 2nd level cache on "consumer_groups"
+  local result2 = result1[consumer_groups]
+  if result2 ~= nil then
+    return result2
+  end
+
+  -- not found, so validate and populate 2nd level cache
+  result2 = false
+  for i = 1, #groups_to_check do
+    if consumer_groups[groups_to_check[i]] then
+      result2 = true
+      break
+    end
+  end
+  result1[consumer_groups] = result2
+  return result2
+end
+
+
+--- checks whether a consumer is part of the gieven list of groups
+-- @param groups_to_check (table) an array of group names. Note: since the
+-- results will be cached by this table, always use the same table for the
+-- same set of groups!
+-- @param consumer_id (string) id of consumer to verify
+local function consumer_id_in_groups(groups_to_check, consumer_id)
+  local consumer_groups, err = get_consumer_groups(consumer_id)
+  if not consumer_groups then
+    return nil, err
+  end
+  return consumer_in_groups(groups_to_check, consumer_groups)
+end
+
+
+--- Gets the currently identified consumer for the request.
+-- Checks both consumer and if not found the credentials.
+-- @return consumer_id (string), or alternatively `nil` if no consumer was
+-- authenticated.
+local function get_current_consumer_id()
+  local ctx = ngx.ctx
+  return (ctx.authenticated_consumer or EMPTY).id or
+         (ctx.authenticated_credential or EMPTY).consumer_id
+end
+
+
+return {
+  get_consumer_groups = get_consumer_groups,
+  consumer_in_groups = consumer_in_groups,
+  consumer_id_in_groups = consumer_id_in_groups,
+  get_current_consumer_id = get_current_consumer_id,
+}

--- a/kong/plugins/acl/handler.lua
+++ b/kong/plugins/acl/handler.lua
@@ -1,8 +1,8 @@
 local BasePlugin = require "kong.plugins.base_plugin"
 local responses = require "kong.tools.responses"
 local constants = require "kong.constants"
-local singletons = require "kong.singletons"
 local pl_tablex = require "pl.tablex"
+local groups = require "kong.plugins.acl.groups"
 
 local table_concat = table.concat
 local set_header = ngx.req.set_header
@@ -12,155 +12,76 @@ local EMPTY = pl_tablex.readonly {}
 local BLACK = "BLACK"
 local WHITE = "WHITE"
 
-local reverse_cache = setmetatable({}, { __mode = "k" })
+local mt_cache = { __mode = "k" }
+local config_cache = setmetatable({}, mt_cache)
 
-local new_tab
-do
-  local ok
-  ok, new_tab = pcall(require, "table.new")
-  if not ok then
-    new_tab = function() return {} end
-  end
-end
 
 
 local ACLHandler = BasePlugin:extend()
 
+
 ACLHandler.PRIORITY = 950
-ACLHandler.VERSION = "0.1.0"
+ACLHandler.VERSION = "0.1.1"
+
 
 function ACLHandler:new()
   ACLHandler.super.new(self, "acl")
 end
 
-local function load_acls_into_memory(consumer_id)
-  local results, err = singletons.dao.acls:find_all {consumer_id = consumer_id}
-  if err then
-    return nil, err
-  end
-  return results
-end
 
 function ACLHandler:access(conf)
   ACLHandler.super.access(self)
 
-  local consumer_id
-  local ctx = ngx.ctx
-
-  local authenticated_consumer = ctx.authenticated_consumer
-  if authenticated_consumer then
-    consumer_id = authenticated_consumer.id
+  -- simplify our plugins 'conf' table
+  local config = config_cache[conf]
+  if not config then
+    config = {}
+    config.type = (conf.blacklist or EMPTY)[1] and BLACK or WHITE
+    config.groups = config.type == BLACK and conf.blacklist or conf.whitelist
+    config.cache = setmetatable({}, mt_cache)
   end
 
-  if not consumer_id then
-    local authenticated_credential = ctx.authenticated_credential
-    if authenticated_credential then
-      consumer_id = authenticated_credential.consumer_id
-    end
-  end
-
+  -- get the consumer/credentials
+  local consumer_id = groups.get_current_consumer_id()
   if not consumer_id then
     ngx_log(ngx_error, "[acl plugin] Cannot identify the consumer, add an ",
                        "authentication plugin to use the ACL plugin")
     return responses.send_HTTP_FORBIDDEN("You cannot consume this service")
   end
 
-  -- Retrieve ACL
-  local cache_key = singletons.dao.acls:cache_key(consumer_id)
-  local acls, err = singletons.cache:get(cache_key, nil,
-                                         load_acls_into_memory, consumer_id)
-  if err then
+  -- get the consumer groups, since we need those as cache-keys to make sure
+  -- we invalidate properly if they change
+  local consumer_groups, err = groups.get_consumer_groups(consumer_id)
+  if not consumer_groups then
     return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
   end
-  if not acls then
-    acls = EMPTY
-  end
 
-  -- build and cache a reverse-lookup table from our plugins 'conf' table
-  local reverse = reverse_cache[conf]
-  if not reverse then
-    local groups = {}
-    reverse = {
-      groups = groups,
-      type = (conf.blacklist or EMPTY)[1] and BLACK or WHITE,
-    }
-
-    -- cache by 'conf', the cache has weak keys, so invalidation of the
-    -- plugin 'conf' will also remove it from our local cache here
-    reverse_cache[conf] = reverse
-    -- build reverse tables for quick lookup
-    if reverse.type == BLACK then
-      for i = 1, #(conf.blacklist or EMPTY) do
-        local groupname = conf.blacklist[i]
-        groups[groupname] = groupname
-      end
-
-    else
-      for i = 1, #(conf.whitelist or EMPTY) do
-        local groupname = conf.whitelist[i]
-        groups[groupname] = groupname
-      end
-    end
-    -- now create another cache inside this cache for the consumer acls so we
-    -- only ever need to evaluate a white/blacklist once.
-    -- The key for this cache will be 'acls' which will be invalidated upon
-    -- changes. The weak key will make sure our local entry get's GC'ed.
-    -- One exception: a blacklist scenario, and a consumer that does
-    -- not have any groups. In that case 'acls == EMPTY' so all those users
-    -- will be indexed by that table, which is ok, as their result is the
-    -- same as well.
-    reverse.consumer_access = setmetatable({}, { __mode = "k" })
-  end
-
-  -- 'cached_block' is either 'true' if it's to be blocked, or the header
+  -- 'to_be_blocked' is either 'true' if it's to be blocked, or the header
   -- value if it is to be passed
-  local cached_block = reverse.consumer_access[acls]
-  if not cached_block then
-    -- nothing cached, so check our lists and groups
-    local block
-    if reverse.type == BLACK then
-      -- check blacklist
-      block = false
-      for i = 1, #acls do
-        if reverse.groups[acls[i].group] then
-          block = true
-          break
-        end
-      end
+  local to_be_blocked = config.cache[consumer_groups]
+  if to_be_blocked == nil then
+    local in_group = groups.consumer_in_groups(config.groups, consumer_groups)
 
+    if config.type == BLACK then
+      to_be_blocked = in_group
     else
-      -- check whitelist
-      block = true
-      for i = 1, #acls do
-        if reverse.groups[acls[i].group] then
-          block = false
-          break
-        end
-      end
+      to_be_blocked = not in_group
     end
 
-    if block then
-      cached_block = true
-
-    else
-      -- allowed, create the header
-      local n = #acls
-      local str_acls = new_tab(n, 0)
-      for i = 1, n do
-        str_acls[i] = acls[i].group
-      end
-      cached_block = table_concat(str_acls, ", ")
+    if to_be_blocked == false then
+      -- we're allowed, so go and convert 'false' to the header value
+      to_be_blocked = table_concat(consumer_groups, ", ")
     end
 
-    -- store the result in the cache
-    reverse.consumer_access[acls] = cached_block
+    -- update cache
+    config.cache[consumer_groups] = to_be_blocked
   end
 
-  if cached_block == true then -- NOTE: we only catch the boolean here!
+  if to_be_blocked == true then -- NOTE: we only catch the boolean here!
     return responses.send_HTTP_FORBIDDEN("You cannot consume this service")
   end
 
-  set_header(constants.HEADERS.CONSUMER_GROUPS, cached_block)
+  set_header(constants.HEADERS.CONSUMER_GROUPS, to_be_blocked)
 end
 
 return ACLHandler


### PR DESCRIPTION
Consumer groups are managed from the acl plugin. This refactor extracts the logic to access and validate the groups into a separate file exposing the functions.

Ideally the whole group feature (including endpoints for managing them) would be extracted from the acl plugin. But with the migration to the new DAO and the plugin SDK coming up I just disentangled the code. Leaving relocation of it up to the new DAO and SDK.

Functionally nothing changed.