### PR TITLE
feat(JWT Plugin) Inject claims to request header for upstream servers

### DIFF
--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -189,6 +189,12 @@ local function do_authentication(conf)
 
   set_consumer(consumer, jwt_secret, token)
 
+  for _, claim_name in ipairs(conf.inject_claims) do
+    if claims[claim_name] then
+      ngx_set_header("x-" .. claim_name, claims[claim_name])
+    end
+  end
+  
   return true
 end
 

--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -189,9 +189,11 @@ local function do_authentication(conf)
 
   set_consumer(consumer, jwt_secret, token)
 
-  for _, claim_name in ipairs(conf.inject_claims) do
-    if claims[claim_name] then
-      ngx_set_header("x-" .. claim_name, claims[claim_name])
+  if conf.inject_claims then
+    for _, claim_name in ipairs(conf.inject_claims) do
+      if claims[claim_name] then
+        ngx_set_header("x-" .. claim_name, claims[claim_name])
+      end
     end
   end
   

--- a/kong/plugins/jwt/migrations/cassandra.lua
+++ b/kong/plugins/jwt/migrations/cassandra.lua
@@ -86,4 +86,22 @@ return {
     end,
     down = function(_, _, dao) end  -- not implemented
   },
+  {
+    name = "2018-05-28-151700_jwt_inject_claims_default",
+    up = function(_, _, dao)
+      for ok, config, update in plugin_config_iterator(dao, "jwt") do
+        if not ok then
+          return config
+        end
+        if config.inject_claims == nil then
+          config.inject_claims = {}
+          local _, err = update(config)
+          if err then
+            return err
+          end
+        end
+      end
+    end,
+    down = function(_, _, dao) end  -- not implemented
+  },
 }

--- a/kong/plugins/jwt/migrations/cassandra.lua
+++ b/kong/plugins/jwt/migrations/cassandra.lua
@@ -68,33 +68,23 @@ return {
     end,
     down = function(_, _, dao) end  -- not implemented
   },
-  {
-    name = "2018-03-15-150000_jwt_maximum_expiration",
+{
+    name = "2018-05-28-151700_jwt_max_exp_and_inject_claims",
     up = function(_, _, dao)
       for ok, config, update in plugin_config_iterator(dao, "jwt") do
         if not ok then
           return config
         end
+        local update_config = false
         if config.maximum_expiration == nil then
           config.maximum_expiration = 0
-          local _, err = update(config)
-          if err then
-            return err
-          end
-        end
-      end
-    end,
-    down = function(_, _, dao) end  -- not implemented
-  },
-  {
-    name = "2018-05-28-151700_jwt_inject_claims_default",
-    up = function(_, _, dao)
-      for ok, config, update in plugin_config_iterator(dao, "jwt") do
-        if not ok then
-          return config
+          update_config = true
         end
         if config.inject_claims == nil then
           config.inject_claims = {}
+          update_config = true
+        end
+        if update_config then
           local _, err = update(config)
           if err then
             return err

--- a/kong/plugins/jwt/migrations/postgres.lua
+++ b/kong/plugins/jwt/migrations/postgres.lua
@@ -87,32 +87,22 @@ return {
     down = function(_, _, dao) end  -- not implemented
   },
   {
-    name = "2018-03-15-150000_jwt_maximum_expiration",
+    name = "2018-05-28-151700_jwt_max_exp_and_inject_claims",
     up = function(_, _, dao)
       for ok, config, update in plugin_config_iterator(dao, "jwt") do
         if not ok then
           return config
         end
+        local update_config = false
         if config.maximum_expiration == nil then
           config.maximum_expiration = 0
-          local _, err = update(config)
-          if err then
-            return err
-          end
-        end
-      end
-    end,
-    down = function(_, _, dao) end  -- not implemented
-  },
-  {
-    name = "2018-05-28-151700_jwt_inject_claims_default",
-    up = function(_, _, dao)
-      for ok, config, update in plugin_config_iterator(dao, "jwt") do
-        if not ok then
-          return config
+          update_config = true
         end
         if config.inject_claims == nil then
           config.inject_claims = {}
+          update_config = true
+        end
+        if update_config then  
           local _, err = update(config)
           if err then
             return err

--- a/kong/plugins/jwt/migrations/postgres.lua
+++ b/kong/plugins/jwt/migrations/postgres.lua
@@ -104,4 +104,22 @@ return {
     end,
     down = function(_, _, dao) end  -- not implemented
   },
+  {
+    name = "2018-05-28-151700_jwt_inject_claims_default",
+    up = function(_, _, dao)
+      for ok, config, update in plugin_config_iterator(dao, "jwt") do
+        if not ok then
+          return config
+        end
+        if config.inject_claims == nil then
+          config.inject_claims = {}
+          local _, err = update(config)
+          if err then
+            return err
+          end
+        end
+      end
+    end,
+    down = function(_, _, dao) end  -- not implemented
+  },
 }

--- a/kong/plugins/jwt/schema.lua
+++ b/kong/plugins/jwt/schema.lua
@@ -17,6 +17,16 @@ local function check_positive(v)
   return true
 end
 
+local function check_for_value(value)
+  for i, entry in ipairs(value) do
+    local ok = string.find(entry, ":")
+    if not ok then
+      return false, "key '" .. entry .. "' has no value. Format is 'claim:headerName'"
+    end
+  end
+  return true
+end
+
 return {
   no_consumer = true,
   fields = {
@@ -28,7 +38,7 @@ return {
     anonymous = {type = "string", default = "", func = check_user},
     run_on_preflight = {type = "boolean", default = true},
     maximum_expiration = {type = "number", default = 0, func = check_positive},
-    inject_claims = {type = "array", default = {}},
+    inject_claims = {type = "array", default = {}, func = check_for_value},
   },
   self_check = function(schema, plugin_t, dao, is_update)
     if plugin_t.maximum_expiration ~= nil

--- a/kong/plugins/jwt/schema.lua
+++ b/kong/plugins/jwt/schema.lua
@@ -28,6 +28,7 @@ return {
     anonymous = {type = "string", default = "", func = check_user},
     run_on_preflight = {type = "boolean", default = true},
     maximum_expiration = {type = "number", default = 0, func = check_positive},
+	inject_claims = {type = "array", default = {}},
   },
   self_check = function(schema, plugin_t, dao, is_update)
     if plugin_t.maximum_expiration ~= nil

--- a/kong/plugins/jwt/schema.lua
+++ b/kong/plugins/jwt/schema.lua
@@ -28,7 +28,7 @@ return {
     anonymous = {type = "string", default = "", func = check_user},
     run_on_preflight = {type = "boolean", default = true},
     maximum_expiration = {type = "number", default = 0, func = check_positive},
-	inject_claims = {type = "array", default = {}},
+    inject_claims = {type = "array", default = {}},
   },
   self_check = function(schema, plugin_t, dao, is_update)
     if plugin_t.maximum_expiration ~= nil


### PR DESCRIPTION
### Summary
JWT Plugin - Inject claims from token into request header.

The user can now configure any of the claims contained in the verified token to inject into the request header "x-{claim_name}" before it is forwarded to the API.

This allows the API to know details of the requester (eg. user_name) without having to decode the token.

This is meant for services that are secure behind the reverse proxy.

### Full changelog

* Added a new field (the claims that should be injected) to the jwt plugin configuration (schema) and added migration code to set defaults for postgres and casandra.

* Added the code that injects the configured claims into the header in the handler.