### PR TITLE
tests(helpers) try harder to extract the OpenResty version

### DIFF
--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -43,12 +43,12 @@ package.path = CUSTOM_PLUGIN_PATH .. ";" .. package.path
 -- Ex: 1.11.2.2 -> 11122
 local function openresty_ver_num()
   local nginx_bin = assert(nginx_signals.find_nginx_bin())
-  local ok, _, _, stderr = pl_utils.executeex(string.format("%s -V", nginx_bin))
-  if not ok then
+  local _, _, _, stderr = pl_utils.executeex(string.format("%s -V", nginx_bin))
+
+  local a, b, c, d = string.match(stderr or "", "openresty/(%d+)%.(%d+)%.(%d+)%.(%d+)")
+  if not a then
     error("could not execute 'nginx -V': " .. stderr)
   end
-
-  local a, b, c, d = string.match(stderr, "openresty/(%d+)%.(%d+)%.(%d+)%.(%d+)")
 
   return tonumber(a .. b .. c .. d)
 end


### PR DESCRIPTION
This doesn't look like it should have been necessary, but at least one strange CI failure could have been avoided by this: https://travis-ci.com/Kong/kong-private/jobs/126566137

