### PR TITLE
tests(admin) change "methd" to "method" in admin api tests

### DIFF
--- a/spec-old-api/02-integration/04-admin_api/03-consumers_routes_spec.lua
+++ b/spec-old-api/02-integration/04-admin_api/03-consumers_routes_spec.lua
@@ -385,7 +385,7 @@ describe("Admin API", function()
 
       it("retrieves the first page", function()
         local res = assert(client:send {
-          methd = "GET",
+          method = "GET",
           path = "/consumers"
         })
         res = assert.res_status(200, res)

--- a/spec-old-api/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec-old-api/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -244,7 +244,7 @@ describe("Admin API", function()
 
       it("retrieves the first page", function()
         local res = assert(client:send {
-          methd = "GET",
+          method = "GET",
           path = "/upstreams/" .. upstream_name .. "/targets/all",
         })
         assert.response(res).has.status(200)
@@ -293,7 +293,7 @@ describe("Admin API", function()
       end)
       it("ignores an invalid body", function()
         local res = assert(client:send {
-          methd = "GET",
+          method = "GET",
           path = "/upstreams/" .. upstream_name .. "/targets/all",
           body = "this fails if decoded as json",
           headers = {

--- a/spec/02-integration/04-admin_api/03-consumers_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/03-consumers_routes_spec.lua
@@ -392,7 +392,7 @@ describe("Admin API", function()
 
       it("retrieves the first page", function()
         local res = assert(client:send {
-          methd = "GET",
+          method = "GET",
           path = "/consumers"
         })
         res = assert.res_status(200, res)

--- a/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
@@ -475,7 +475,7 @@ describe("Admin API: #" .. kong_config.database, function()
 
       it("retrieves the first page", function()
         local res = assert(client:send {
-          methd = "GET",
+          method = "GET",
           path = "/upstreams"
         })
         assert.response(res).has.status(200)
@@ -524,7 +524,7 @@ describe("Admin API: #" .. kong_config.database, function()
       end)
       it("ignores an invalid body", function()
         local res = assert(client:send {
-          methd = "GET",
+          method = "GET",
           path = "/upstreams",
           body = "this fails if decoded as json",
           headers = {

--- a/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -457,7 +457,7 @@ describe("Admin API", function()
 
       it("retrieves the first page", function()
         local res = assert(client:send {
-          methd = "GET",
+          method = "GET",
           path = "/upstreams/" .. upstream_name .. "/targets/all",
         })
         assert.response(res).has.status(200)
@@ -506,7 +506,7 @@ describe("Admin API", function()
       end)
       it("ignores an invalid body", function()
         local res = assert(client:send {
-          methd = "GET",
+          method = "GET",
           path = "/upstreams/" .. upstream_name .. "/targets/all",
           body = "this fails if decoded as json",
           headers = {


### PR DESCRIPTION

### Summary

This PR corrects a typo in the send method used in a number of the admin API tests. It changes `methd` to `method`. The key `methd` currently works because the default method for [lua-resty-http](https://github.com/pintsized/lua-resty-http/blob/master/lib/resty/http.lua#L115) is `GET` .   However, if `methd` were used for any other verb, the resulting call would be instead be `GET`. This could possibly lead to confusion and false positives when writing new tests that require verbs other than `GET`

### Full changelog

* change "methd" to "method" in admin api tests
