### PR TITLE
fix(conf) retain IPv6 brackets in proxy_listen and admin_listen

### DIFF
--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -411,8 +411,13 @@ local function parse_listeners(values)
       ip.host, ip.port = remainder:match("(.+):([%d]+)$")
 
     else
-      -- It's an IPv4 or IPv6, just normalize it
+      -- It's an IPv4 or IPv6, normalize it
       ip = utils.normalize_ip(remainder)
+      -- nginx requires brackets in IPv6 addresses, but normalize_ip does
+      -- not include them (due to backwards compatibility with its other uses)
+      if ip and ip.type == "ipv6" then
+        ip.host = "[" .. ip.host .. "]"
+      end
     end
 
     if not ip or not ip.port then

--- a/spec/01-unit/002-conf_loader_spec.lua
+++ b/spec/01-unit/002-conf_loader_spec.lua
@@ -95,6 +95,35 @@ describe("Configuration loader", function()
     assert.equal(false, conf.proxy_listeners[2].http2)
     assert.equal("0.0.0.0:8443 ssl", conf.proxy_listeners[2].listener)
   end)
+  it("parses IPv6 from proxy_listen/admin_listen", function()
+    local conf = assert(conf_loader(nil, {
+      proxy_listen = "[::]:8000, [::]:8443 ssl",
+      admin_listen = "[::1]:8001, [::1]:8444 ssl",
+    }))
+    assert.equal("[0000:0000:0000:0000:0000:0000:0000:0001]", conf.admin_listeners[1].ip)
+    assert.equal(8001, conf.admin_listeners[1].port)
+    assert.equal(false, conf.admin_listeners[1].ssl)
+    assert.equal(false, conf.admin_listeners[1].http2)
+    assert.equal("[0000:0000:0000:0000:0000:0000:0000:0001]:8001", conf.admin_listeners[1].listener)
+
+    assert.equal("[0000:0000:0000:0000:0000:0000:0000:0001]", conf.admin_listeners[2].ip)
+    assert.equal(8444, conf.admin_listeners[2].port)
+    assert.equal(true, conf.admin_listeners[2].ssl)
+    assert.equal(false, conf.admin_listeners[2].http2)
+    assert.equal("[0000:0000:0000:0000:0000:0000:0000:0001]:8444 ssl", conf.admin_listeners[2].listener)
+
+    assert.equal("[0000:0000:0000:0000:0000:0000:0000:0000]", conf.proxy_listeners[1].ip)
+    assert.equal(8000, conf.proxy_listeners[1].port)
+    assert.equal(false, conf.proxy_listeners[1].ssl)
+    assert.equal(false, conf.proxy_listeners[1].http2)
+    assert.equal("[0000:0000:0000:0000:0000:0000:0000:0000]:8000", conf.proxy_listeners[1].listener)
+
+    assert.equal("[0000:0000:0000:0000:0000:0000:0000:0000]", conf.proxy_listeners[2].ip)
+    assert.equal(8443, conf.proxy_listeners[2].port)
+    assert.equal(true, conf.proxy_listeners[2].ssl)
+    assert.equal(false, conf.proxy_listeners[2].http2)
+    assert.equal("[0000:0000:0000:0000:0000:0000:0000:0000]:8443 ssl", conf.proxy_listeners[2].listener)
+  end)
   it("extracts ssl flags properly when hostnames contain them", function()
     local conf
     conf = assert(conf_loader(nil, {


### PR DESCRIPTION
Nginx requires brackets in IPv6 addresses, but `normalize_ip` does not include them (due to backwards compatibility with its other uses elsewhere in the codebase).

Fixes #3475.
