### PR TITLE
chore(azure-functions) bump to 0.1.1

### DIFF
--- a/kong-0.13.1-0.rockspec
+++ b/kong-0.13.1-0.rockspec
@@ -34,7 +34,7 @@ dependencies = {
   "lua-resty-cookie == 0.1.0",
   "lua-resty-mlcache == 2.0.2",
   -- external Kong plugins
-  "kong-plugin-azure-functions == 0.1.0",
+  "kong-plugin-azure-functions == 0.1.1",
   "kong-plugin-zipkin == 0.0.1",
   "kong-prometheus-plugin == 0.1.0",
 }


### PR DESCRIPTION
### Summary

Bump `azure-functions` plugin to `0.1.1`.

Related to this (do not merge before):
https://github.com/Kong/kong-plugin-azure-functions/pull/1