### PR TITLE
fix(plugins) raise ip-restriction priority to 3000

### DIFF
--- a/kong/plugins/ip-restriction/handler.lua
+++ b/kong/plugins/ip-restriction/handler.lua
@@ -18,7 +18,7 @@ local cache = {}
 
 local IpRestrictionHandler = BasePlugin:extend()
 
-IpRestrictionHandler.PRIORITY = 990
+IpRestrictionHandler.PRIORITY = 3000
 IpRestrictionHandler.VERSION = "0.1.0"
 
 local function cidr_cache(cidr_tab)

--- a/spec/01-unit/014-plugins_order_spec.lua
+++ b/spec/01-unit/014-plugins_order_spec.lua
@@ -49,6 +49,7 @@ describe("Plugins", function()
     -- backwards-compatibility
 
     local order = {
+      "ip-restriction",
       "bot-detection",
       "cors",
       "jwt",
@@ -57,7 +58,6 @@ describe("Plugins", function()
       "ldap-auth",
       "basic-auth",
       "hmac-auth",
-      "ip-restriction",
       "request-size-limiting",
       "acl",
       "rate-limiting",


### PR DESCRIPTION
### Summary

Raises the priority of the `ip-restriction` plugin to `3000` so that it runs before other plugins, like `bot-detection` to prevent code execution that is not required. 

See: https://getkong.org/docs/0.13.x/plugin-development/custom-logic/#plugins-execution-order