### PR TITLE
fix(response-transformer) add default for rt_body_chunks and ctx.rt_body_chunk_number

### DIFF
--- a/kong/plugins/response-transformer/handler.lua
+++ b/kong/plugins/response-transformer/handler.lua
@@ -33,6 +33,15 @@ function ResponseTransformerHandler:body_filter(conf)
   if is_body_transform_set(conf) and is_json_body(ngx.header["content-type"]) then
     local ctx = ngx.ctx
     local chunk, eof = ngx.arg[1], ngx.arg[2]
+
+    if not ctx.rt_body_chunks then
+      ctx.rt_body_chunks = {}
+    end
+
+    if not ctx.rt_body_chunk_number then
+      ctx.rt_body_chunk_number = 1
+    end
+
     if eof then
       local body = body_filter.transform_json_body(conf, table_concat(ctx.rt_body_chunks))
       ngx.arg[1] = body

--- a/spec/03-plugins/16-response-transformer/04-filter_spec.lua
+++ b/spec/03-plugins/16-response-transformer/04-filter_spec.lua
@@ -16,6 +16,10 @@ for _, strategy in helpers.each_strategy() do
         hosts = { "response2.com" },
       })
 
+      local route3 = bp.routes:insert({
+        hosts = { "response3.com" },
+      })
+
       bp.plugins:insert {
         route_id = route1.id,
         name     = "response-transformer",
@@ -35,6 +39,21 @@ for _, strategy in helpers.each_strategy() do
             json  = {"headers:/hello/world", "uri_args:this is a / test", "url:\"wot\""}
           }
         }
+      }
+
+      bp.plugins:insert {
+        route_id = route3.id,
+        name     = "response-transformer",
+        config   = {
+          remove = {
+            json  = {"ip"}
+          }
+        }
+      }
+
+      bp.plugins:insert {
+        route_id = route3.id,
+        name     = "basic-auth",
       }
 
       assert(helpers.start_kong({
@@ -95,6 +114,20 @@ for _, strategy in helpers.each_strategy() do
         assert.equals([[/hello/world]], json.headers)
         assert.equals([["wot"]], json.url)
         assert.equals([[this is a / test]], json.uri_args)
+      end)
+    end)
+
+    describe("unauthorized", function()
+      it("doesn't err when unauthorized", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/get",
+          headers = {
+            host  = "response3.com"
+          }
+        })
+
+        assert.response(res).status(401)
       end)
     end)
   end)


### PR DESCRIPTION
### Summary

 When `ResponseTransformerHandler:access` is not executed, `ResponseTransformerHandler:body_filter` attempts to access nil `ctx.rt_body_chunks` and nil `ctx.rt_body_chunk_number`. This PR adds checks for both and initializes them to defaults if nil.  

A test case has been added to verify there is no error if `ResponseTransformerHandler:access` is not executed.

### Full changelog

* Add defaults for `ctx.rt_body_chunks`  and `ctx.rt_body_chunk_number` in `ResponseTransformerHandler:body_filter`
* Add test case (unauthorized request, skips `ResponseTransformerHandler:access`)

### Issues resolved

Fix [#3521](https://github.com/Kong/kong/issues/3521)
