### PR TITLE
fix(ip-restriction) disallow plugin on Consumers

### DIFF
--- a/kong/plugins/ip-restriction/schema.lua
+++ b/kong/plugins/ip-restriction/schema.lua
@@ -14,6 +14,7 @@ local function validate_ips(v, t, column)
 end
 
 return {
+  no_consumer = true,
   fields = {
     whitelist = {type = "array", func = validate_ips},
     blacklist = {type = "array", func = validate_ips}

--- a/spec/03-plugins/18-ip-restriction/02-access_spec.lua
+++ b/spec/03-plugins/18-ip-restriction/02-access_spec.lua
@@ -333,6 +333,27 @@ for _, strategy in helpers.each_strategy() do
       assert.same({ message = "Your IP address is not allowed" }, json)
     end)
 
+    it("cannot be configured on a Consumer", function()
+      local utils = require "kong.tools.utils"
+      local cjson = require "cjson"
+
+      local res = assert(admin_client:send {
+        method = "POST",
+        path = "/plugins",
+        headers = {
+          ["Content-Type"] = "application/json",
+        },
+        body = {
+          name = "ip-restriction",
+          consumer_id = utils.uuid(),
+          ["config.whitelist"] = { "127.0.0.1" },
+        }
+      })
+      local body = assert.res_status(400, res)
+      local json = cjson.decode(body)
+      assert.equal("No consumer can be configured for that plugin", json.message)
+    end)
+
     describe("#regression", function()
       it("handles a CIDR entry with 0.0.0.0/0", function()
         local res = assert(proxy_client:send {


### PR DESCRIPTION
A followup commit to dcb253643db67d775d58ec09ec7c97cef32f2961, which
made the ip-restriction plugin run before authentication ones. Thus, it
does not make sense to allow this plugin to be added to a Consumer
anymore (since they will always be identified after this plugin runs).

It is arguable whether there is any value at all in allowing this plugin
to run on specific Consumers, since L7 authentication and IP restriction
reside on different levels of the stacks altogether. Most use-cases
would require this plugin to run first, as per the aforementioned
commit.

If this were to be reverted, then so should
dcb253643db67d775d58ec09ec7c97cef32f2961.