### PR TITLE
chore(conf) drop 'dnsmasq' property form test config

### DIFF
--- a/spec-old-api/kong_tests.conf
+++ b/spec-old-api/kong_tests.conf
@@ -8,7 +8,6 @@ ssl_cert_key = spec-old-api/fixtures/kong_spec.key
 admin_ssl_cert = spec-old-api/fixtures/kong_spec.crt
 admin_ssl_cert_key = spec-old-api/fixtures/kong_spec.key
 
-dnsmasq = off
 dns_resolver = 8.8.8.8
 database = postgres
 pg_host = 127.0.0.1

--- a/spec/kong_tests.conf
+++ b/spec/kong_tests.conf
@@ -8,7 +8,6 @@ ssl_cert_key = spec/fixtures/kong_spec.key
 admin_ssl_cert = spec/fixtures/kong_spec.crt
 admin_ssl_cert_key = spec/fixtures/kong_spec.key
 
-dnsmasq = off
 dns_resolver = 8.8.8.8
 database = postgres
 pg_host = 127.0.0.1


### PR DESCRIPTION
Dnsmasq dependency was removed in v0.11.0.
This commit removes a harmless leftover config value from a configuration
file that is used to run Kong during tests.