### PR TITLE
feat(aws-lambda) Add AWS Gov Cloud region to plugin schema

### DIFF
--- a/kong/plugins/aws-lambda/schema.lua
+++ b/kong/plugins/aws-lambda/schema.lua
@@ -34,6 +34,7 @@ return {
         "us-east-2",
         "us-west-1",
         "us-west-2",
+        "us-gov-west-1",
         "ap-northeast-1",
         "ap-northeast-2",
         "ap-southeast-1",


### PR DESCRIPTION
### Summary

Add us-gov-west-1 to the list of allowed regions to permit AWS Lambda
functions to be invoked from the AWS GovCloud region.

### Full changelog

* Add us-gov-west-1 to schema of aws_region config in aws-lambda plugin