### PR TITLE
Use DAO layer instead of raw 'SELECT *' during migration

### DIFF
--- a/kong/dao/migrations/cassandra.lua
+++ b/kong/dao/migrations/cassandra.lua
@@ -414,6 +414,11 @@ return {
   {
     name = "2017-01-24-132600_upstream_timeouts_2",
     up = function(_, _, dao)
+      local ok, err = dao.db:wait_for_schema_consensus()
+      if not ok then
+        return err
+      end
+
       local rows, err = dao.db:query([[
         SELECT * FROM apis;
       ]])


### PR DESCRIPTION

### Summary

This PR directly addresses issue https://github.com/Kong/kong/issues/3392 (and indirectly addresses some posts of issue https://github.com/Kong/kong/issues/3005)

Step `2017-01-24-132600_upstream_timeouts_2` of the migration process starts with a selection of all rows of the apis table (https://github.com/Kong/kong/blob/master/kong/dao/migrations/cassandra.lua#L417). However:
- This comes just after step `2017-01-24-132600_upstream_timeouts` that just altered the same `apis` table
- And the selection is done by directly using a raw `SELECT * FROM apis` query, so not using the DAO layer... so not taking benefit on the "retry on read failure" policy nor of the "wait schema consensus" provided by this DAO layer.

Working on the issue with a Cassandra DBA, the analysis is that:
- As working on a multi-nodes Cassandra cluster, the table alteration might not have been propagated properly on all nodes when the raw `SELECT *` is run, generating a read error (most probably due to an inconsistency on the schema of the queried node)... and unfortunately, no retry is implemented on this read error as this is a raw query that is done.
- Solution is just to use `local rows, err = dao.apis:find_all()` instead of the `local rows, err = dao.db:query([[ SELECT * FROM apis; ]])`: the schema consensus is obtained and even if a read error occurs, a retry is performed by the DAO layer.

### Full changelog

* use `local rows, err = dao.apis:find_all()` instead of the `local rows, err = dao.db:query([[ SELECT * FROM apis; ]])` in `kong/doa/migrations/cassandra.lua` (line 417)

Sorry, it not really clear on my fork: it mentions some "old" commits I already pushed a couple of month ago... but it says that the only updated file is `kong/doa/migrations/cassandra.lua` (which is correct).
Can you cross check that from your side the updates included in this PR are limited to this file only? Thanks a lot!

### Issues resolved

Fix https://github.com/Kong/kong/issues/3392
