### PR TITLE
fix(nginx-conf) add missing 'default_type' directive

### DIFF
--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -112,6 +112,8 @@ server {
 > end
 
     location / {
+        default_type                     '';
+
         set $ctx_ref                     '';
         set $upstream_host               '';
         set $upstream_upgrade            '';


### PR DESCRIPTION
Likely the result of a merge gone wrong, since this value was added in
cbe4a612ee85b395d176ab85b38561a3839db183.