### PR TITLE
chore(deps) bump mlcache to 2.1.0

### DIFF
--- a/kong-0.13.1-0.rockspec
+++ b/kong-0.13.1-0.rockspec
@@ -31,7 +31,7 @@ dependencies = {
   "lua-resty-worker-events == 0.3.3",
   "lua-resty-mediador == 0.1.2",
   "lua-resty-healthcheck == 0.4.2",
-  "lua-resty-mlcache == 2.0.2",
+  "lua-resty-mlcache == 2.1.0",
 }
 build = {
   type = "builtin",


### PR DESCRIPTION
Changelog 2.0.2...2.1.0:

  https://github.com/thibaultcha/lua-resty-mlcache/compare/2.0.2...2.1.0

Mainly useful to take advantage of the new `shm_locks` option.