### PR TITLE
fix(schema) catch properly when foreign keys are null

### DIFF
--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -71,6 +71,7 @@ local validation_errors = {
   SCHEMA_NO_DEFINITION      = "expected a definition table",
   SCHEMA_NO_FIELDS          = "error in schema definition: no 'fields' table",
   SCHEMA_MISSING_ATTRIBUTE  = "error in schema definition: missing attribute",
+  SCHEMA_BAD_REFERENCE      = "schema refers to an invalid foreign entity: %s",
   SCHEMA_TYPE               = "invalid type: %s",
   -- primary key errors
   NOT_PK                    = "not a primary key",
@@ -1224,8 +1225,11 @@ function Schema.new(definition)
   for key, field in self:each_field() do
     self.fields[key] = field
     if field.type == "foreign" then
-      -- TODO: add error handling
-      field.schema = get_foreign_schema_for_field(field)
+      local err
+      field.schema, err = get_foreign_schema_for_field(field)
+      if not field.schema then
+        return nil, err
+      end
     end
   end
 

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -859,8 +859,13 @@ function Schema:validate_primary_key(pk, ignore_others)
     pk_set[k] = true
     local field = self.fields[k]
     local v = pk[k]
+
     if not v then
       errors[k] = validation_errors.MISSING_PK
+
+    elseif (field.required or field.auto) and v == null then
+      errors[k] = validation_errors.REQUIRED
+
     else
       local _
       _, errors[k] = self:validate_field(field, v)

--- a/spec/01-unit/000-new-dao/01-schema/01-schema_spec.lua
+++ b/spec/01-unit/000-new-dao/01-schema/01-schema_spec.lua
@@ -48,6 +48,19 @@ describe("schema", function()
       assert.string(err)
     end)
 
+
+    it("fails on invalid foreign reference", function()
+      local Test, err = Schema.new({
+        fields = {
+          { f = { type = "foreign", reference = "invalid_reference" } },
+          { b = { type = "number" }, },
+          { c = { type = "number" }, },
+        }
+      })
+      assert.falsy(Test)
+      assert.match("invalid_reference", err)
+    end)
+
   end)
 
   describe("validate", function()

--- a/spec/01-unit/000-new-dao/01-schema/03-routes_spec.lua
+++ b/spec/01-unit/000-new-dao/01-schema/03-routes_spec.lua
@@ -32,6 +32,22 @@ describe("routes schema", function()
     assert.falsy(route.strip_path)
   end)
 
+  it("fails when service is null", function()
+    local route = { service = ngx.null, paths = {"/"} }
+    route = Routes:process_auto_fields(route, "insert")
+    local ok, errs = Routes:validate_insert(route)
+    assert.falsy(ok)
+    assert.truthy(errs["service"])
+  end)
+
+  it("fails when service.id is null", function()
+    local route = { service = { id = ngx.null }, paths = {"/"} }
+    route = Routes:process_auto_fields(route, "insert")
+    local ok, errs = Routes:validate_insert(route)
+    assert.falsy(ok)
+    assert.truthy(errs["service"])
+  end)
+
   it("fails when protocol is missing", function()
     local route = { protocols = ngx.null }
     route = Routes:process_auto_fields(route, "insert")


### PR DESCRIPTION
Thanks to @fffonion for reporting it and to @bungle for the fix!

Includes both a general regression test for the schema library and a regression test specific for the Routes entity.
