### PR TITLE
feat(nginx-conf) add a 'kong_locks' shm for resty-lock users

### DIFF
--- a/kong/cache.lua
+++ b/kong/cache.lua
@@ -71,6 +71,7 @@ function _M.new(opts)
 
   local mlcache, err = resty_mlcache.new(SHM_CACHE, SHM_CACHE, {
     shm_miss         = ngx.shared.kong_db_cache_miss and "kong_db_cache_miss" or nil,
+    shm_locks        = ngx.shared.kong_locks and "kong_locks" or nil,
     shm_set_retries  = 3,
     lru_size         = LRU_SIZE,
     ttl              = max(opts.ttl     or 3600, 0),

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -31,6 +31,7 @@ lua_max_pending_timers 16384;
 lua_shared_dict kong                5m;
 lua_shared_dict kong_cache          ${{MEM_CACHE_SIZE}};
 lua_shared_dict kong_db_cache_miss 12m;
+lua_shared_dict kong_locks          8m;
 lua_shared_dict kong_process_events 5m;
 lua_shared_dict kong_cluster_events 5m;
 lua_shared_dict kong_healthchecks   5m;

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -44,6 +44,7 @@ http {
     lua_shared_dict kong                5m;
     lua_shared_dict kong_cache          ${{MEM_CACHE_SIZE}};
     lua_shared_dict kong_db_cache_miss 12m;
+    lua_shared_dict kong_locks          8m;
     lua_shared_dict kong_process_events 5m;
     lua_shared_dict kong_cluster_events 5m;
     lua_shared_dict kong_healthchecks   5m;


### PR DESCRIPTION
This commit introduces a new shm, `kong_locks`, to be used by instances
of lua-resty-lock across Kong or its libraries, if possible.

Since #3543 bumped the mlcache dependency, the DB cache is the first
consumer of this shm to store its locks, which helps in limiting the
effects of LRU churning in certain workloads. More components should use
this shm to store their resty-lock instances, especially instead of
relying on the `kong` shm, which is to be considered "immutable".

The chosen size for this shm is 8Mb:

1. In the not too far future, users should be able to customize the size
   of _any_ shm via configuration properties. Some additional work on top
   of #3530 is needed for this.
2. Such a size allows to store (based on estimations with a test script)
   about 65.000 lua-resty-lock items. While this number is very much
   workload specific, it should be appropriate even in situations where
   requests trigger cache misses in the runloop and the core, which
   would amount for up to 10, or maybe 15 locks (with very bad luck),
   which means we could still process several thousands of such cold
   requests concurrently, and comfortably.
3. Ideally, abstraction layers on top of eviction-sensitive shms should
   be built, in order to monitor LRU eviction on locks, or forbid them
   entirely on immutable shms.

This commit is considered backwards-compatible and thus does not require
the `kong_locks` shm to be defined.