### PR TITLE
fix(dao) fix error message double wrapping

### DIFF
--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -244,17 +244,16 @@ function DAO:each(size)
   local next_row = self.strategy:each(size)
 
   return function()
-    local err_t
-    local row, err, page = next_row()
+    local row, err_t, page = next_row()
     if not row then
-      if err then
-        local err_t = self.errors:database_error(err)
+      if err_t then
         return nil, tostring(err_t), err_t
       end
 
       return nil
     end
 
+    local err
     row, err, err_t = self:row_to_entity(row)
     if not row then
       return nil, err, err_t

--- a/kong/runloop/plugins_iterator.lua
+++ b/kong/runloop/plugins_iterator.lua
@@ -22,7 +22,7 @@ local function load_plugin_into_memory(route_id,
            api_id = api_id,
   }
   if err then
-    error(err)
+    error(tostring(err))
   end
 
   if #rows > 0 then


### PR DESCRIPTION
Lower level strategy module already wraps error message as table and
we should not wrap it again.
