### PR TITLE
feat: new 'db_resurrect_ttl' configuration property + resilient cache callbacks 

### DIFF
--- a/kong-0.14.0rc2-0.rockspec
+++ b/kong-0.14.0rc2-0.rockspec
@@ -33,7 +33,7 @@ dependencies = {
   "lua-resty-mediador == 0.1.2",
   "lua-resty-healthcheck == 0.4.2",
   "lua-resty-cookie == 0.1.0",
-  "lua-resty-mlcache == 2.1.0",
+  "lua-resty-mlcache == 2.2.0",
   -- external Kong plugins
   "kong-plugin-azure-functions == 0.1.1",
   "kong-plugin-zipkin == 0.0.2",

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -452,6 +452,13 @@
                                  # If set to 0 (default), such cached entities
                                  # or misses never expire.
 
+#db_resurrect_ttl = 30           # Time (in seconds) for which stale entities
+                                 # from the datastore should be resurrected for
+                                 # when they cannot be refreshed (e.g., the
+                                 # datastore is unreachable). When this TTL
+                                 # expires, a new attempt to refresh the stale
+                                 # entities will be made.
+
 #------------------------------------------------------------------------------
 # DNS RESOLVER
 #------------------------------------------------------------------------------

--- a/kong/cache.lua
+++ b/kong/cache.lua
@@ -76,6 +76,7 @@ function _M.new(opts)
     lru_size         = LRU_SIZE,
     ttl              = max(opts.ttl     or 3600, 0),
     neg_ttl          = max(opts.neg_ttl or 300,  0),
+    resurrect_ttl    = opts.resurrect_ttl or 30,
     resty_lock_opts  = opts.resty_lock_opts,
     ipc = {
       register_listeners = function(events)

--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -76,6 +76,7 @@ local CONF_INFERENCES = {
   db_update_frequency = { typ = "number" },
   db_update_propagation = { typ = "number" },
   db_cache_ttl = { typ = "number" },
+  db_resurrect_ttl = { typ = "number" },
   nginx_user = {typ = "string"},
   nginx_worker_processes = {typ = "string"},
   upstream_keepalive = {typ = "number"},

--- a/kong/globalpatches.lua
+++ b/kong/globalpatches.lua
@@ -97,6 +97,7 @@ return function(options)
       function SharedDict:get(key)
         return self.data[key] and self.data[key].value, nil
       end
+      SharedDict.get_stale = SharedDict.get
       function SharedDict:set(key, value)
         set(self.data, key, value)
         return true, nil, false

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -281,6 +281,7 @@ function Kong.init_worker()
     propagation_delay = kong.configuration.db_update_propagation,
     ttl               = kong.configuration.db_cache_ttl,
     neg_ttl           = kong.configuration.db_cache_ttl,
+    resurrect_ttl     = kong.configuration.resurrect_ttl,
     resty_lock_opts   = {
       exptime = 10,
       timeout = 5,

--- a/kong/runloop/plugins_iterator.lua
+++ b/kong/runloop/plugins_iterator.lua
@@ -34,8 +34,6 @@ local function load_plugin_into_memory(route_id,
       end
     end
   end
-  -- insert a cached value to not trigger too many DB queries.
-  return { null = true }  -- works because: `.enabled == nil`
 end
 
 

--- a/kong/runloop/plugins_iterator.lua
+++ b/kong/runloop/plugins_iterator.lua
@@ -4,7 +4,6 @@ local responses    = require "kong.tools.responses"
 local kong         = kong
 local setmetatable = setmetatable
 local ipairs       = ipairs
-local error        = error
 
 
 -- Loads a plugin config from the datastore.
@@ -22,7 +21,7 @@ local function load_plugin_into_memory(route_id,
            api_id = api_id,
   }
   if err then
-    error(tostring(err))
+    return nil, tostring(err)
   end
 
   if #rows > 0 then

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -61,6 +61,7 @@ cassandra_schema_consensus_timeout = 10000
 db_update_frequency = 5
 db_update_propagation = 0
 db_cache_ttl = 0
+db_resurrect_ttl = 30
 
 dns_resolver = NONE
 dns_hostsfile = /etc/hosts


### PR DESCRIPTION
* Bump mlcache to 2.2.0

This new version adds support for `resurrect_ttl`, which resurrects
stale values when the callback fails on soft errors.

https://github.com/thibaultcha/lua-resty-mlcache/blob/master/CHANGELOG.md#220

* add a new 'db_resurrect_ttl' config option

Documentation for its behaviour can be read in the description test
included in kong.conf.default.

* do not throw error from plugin loader

In order for the resurrection of stale cached values to occur when
callback I/O fails (see c932dc6), we have to return soft errors from our
callbacks, and not throw them via error().

Additionally, we rely on the modern behavior of mlcache with regards to
the caching of cache misses - returning `nil` is cached my mlcache.