### PR TITLE
chore(deps) bump llthreads library, test-only dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 OS := $(shell uname)
 
-DEV_ROCKS = "busted 2.0.rc12" "luacheck 0.20.0" "lua-llthreads2 0.1.4"
+DEV_ROCKS = "busted 2.0.rc12" "luacheck 0.20.0" "lua-llthreads2 0.1.5"
 BUSTED_ARGS ?= -v
 TEST_CMD ?= bin/busted $(BUSTED_ARGS)
 


### PR DESCRIPTION
### Summary

Fixes compiler warnings on some newer platforms. Warnings occur on the Vagrant box since it was bumped to the Ubuntu Xenial64 image.

### Issues resolved

Compiler warnings on some newer platforms resolved. Especially the Kong-Vagrant box.
