### PR TITLE
chore(deps) bump lua-cassandra to 1.3.1

### DIFF
--- a/kong-0.14.0rc3-0.rockspec
+++ b/kong-0.14.0rc3-0.rockspec
@@ -20,7 +20,7 @@ dependencies = {
   "multipart == 0.5.5",
   "version == 0.2",
   "kong-lapis == 1.6.0.1",
-  "lua-cassandra == 1.3.0",
+  "lua-cassandra == 1.3.1",
   "pgmoon == 1.8.0",
   "luatz == 0.3",
   "lua_system_constants == 0.1.2",


### PR DESCRIPTION
This version ensures the new request-aware LB policies can be used in
init_by_lua* contexts when using the lua-resty-core module.

Changelog:

https://github.com/thibaultcha/lua-cassandra/blob/master/CHANGELOG.md#131---20180702

Fix #3580