### PR TITLE
hotfix(runloop) use proper property to set log namespace

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -331,7 +331,7 @@ function Kong.init_worker()
 
 
   for _, plugin in ipairs(loaded_plugins) do
-    kong_global.set_namespaced_log(kong, plugin.handler._name)
+    kong_global.set_namespaced_log(kong, plugin.name)
 
     plugin.handler:init_worker()
   end
@@ -345,7 +345,7 @@ function Kong.ssl_certificate()
   runloop.certificate.before(ctx)
 
   for plugin, plugin_conf in plugins_iterator(loaded_plugins, true) do
-    kong_global.set_namespaced_log(kong, plugin.handler._name)
+    kong_global.set_namespaced_log(kong, plugin.name)
     plugin.handler:certificate(plugin_conf)
     kong_global.reset_log(kong)
   end
@@ -441,7 +441,7 @@ function Kong.rewrite()
   -- plugins
   for plugin, plugin_conf in plugins_iterator(loaded_plugins, true) do
     kong_global.set_named_ctx(kong, "plugin", plugin_conf)
-    kong_global.set_namespaced_log(kong, plugin.handler._name)
+    kong_global.set_namespaced_log(kong, plugin.name)
 
     plugin.handler:rewrite(plugin_conf)
 
@@ -463,7 +463,7 @@ function Kong.access()
   for plugin, plugin_conf in plugins_iterator(loaded_plugins, true) do
     if not ctx.delayed_response then
       kong_global.set_named_ctx(kong, "plugin", plugin_conf)
-      kong_global.set_namespaced_log(kong, plugin.handler._name)
+      kong_global.set_namespaced_log(kong, plugin.name)
 
       local err = coroutine.wrap(plugin.handler.access)(plugin.handler, plugin_conf)
 
@@ -494,7 +494,7 @@ function Kong.header_filter()
 
   for plugin, plugin_conf in plugins_iterator(loaded_plugins) do
     kong_global.set_named_ctx(kong, "plugin", plugin_conf)
-    kong_global.set_namespaced_log(kong, plugin.handler._name)
+    kong_global.set_namespaced_log(kong, plugin.name)
 
     plugin.handler:header_filter(plugin_conf)
 
@@ -509,7 +509,7 @@ function Kong.body_filter()
 
   for plugin, plugin_conf in plugins_iterator(loaded_plugins) do
     kong_global.set_named_ctx(kong, "plugin", plugin_conf)
-    kong_global.set_namespaced_log(kong, plugin.handler._name)
+    kong_global.set_namespaced_log(kong, plugin.name)
 
     plugin.handler:body_filter(plugin_conf)
 
@@ -524,7 +524,7 @@ function Kong.log()
 
   for plugin, plugin_conf in plugins_iterator(loaded_plugins) do
     kong_global.set_named_ctx(kong, "plugin", plugin_conf)
-    kong_global.set_namespaced_log(kong, plugin.handler._name)
+    kong_global.set_namespaced_log(kong, plugin.name)
 
     plugin.handler:log(plugin_conf)
 

--- a/spec/fixtures/custom_plugins/kong/plugins/logger-last/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/logger-last/handler.lua
@@ -4,11 +4,11 @@ local LoggerHandler = require "spec.fixtures.custom_plugins.kong.plugins.logger.
 local LoggerLastHandler = BasePlugin:extend()
 
 
-LoggerLastHandler.PRIORITY = 10000
+LoggerLastHandler.PRIORITY = 0
 
 
 function LoggerLastHandler:new()
-  LoggerLastHandler.super.new(self, "logger")
+  LoggerLastHandler.super.new(self, "logger-last")
 end
 
 

--- a/spec/fixtures/custom_plugins/kong/plugins/logger/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/logger/handler.lua
@@ -8,7 +8,7 @@ LoggerHandler.PRIORITY = 1000
 
 
 function LoggerHandler:new()
-  LoggerHandler.super.new(self, "logger-last")
+  LoggerHandler.super.new(self, "logger")
 end
 
 


### PR DESCRIPTION
Nothing guarantees that `plugin.handler._name` is properly set in
plugins if they do not inherit the base_plugin.lua class. This is the
case with the `reports.lua` module, which is built as a plugin but not
inheriting from the base_plugin.lua class.

Since anonymous reports are disabled in all development/CI environments,
this issue was not caught immediately, but an error logs complaining that
arg #2 of the `set_namespaced_log()` function was nil would show up in
the error logs.

Instead, we we `plugin.name` which, as per the `load_plugin()` function,
is guaranteed to be set even when plugins do not inherit from the
base_plugin.lua class.