### PR TITLE
fix(schema) fix validation of nested records in metaschema

### DIFF
--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1194,32 +1194,19 @@ end
 
 --- Cycle-aware table copy.
 -- To be replaced by tablex.deepcopy() when it supports cycles.
-local function copy(t, c, cache)
+local function copy(t, cache)
   if type(t) ~= "table" then
     return t
   end
   cache = cache or {}
-  c = c or {}
+  if cache[t] then
+    return cache[t]
+  end
+  local c = {}
+  cache[t] = c
   for k, v in pairs(t) do
-    local kk, vv = k, v
-    if type(k) == "table" then
-      if cache[k] then
-        kk = cache[k]
-      else
-        kk = {}
-        cache[k] = kk
-        copy(k, kk, cache)
-      end
-    end
-    if type(v) == "table" then
-      if cache[v] then
-        vv = cache[v]
-      else
-        vv = {}
-        cache[v] = vv
-        copy(v, vv, cache)
-      end
-    end
+    local kk = copy(k, cache)
+    local vv = copy(v, cache)
     c[kk] = vv
   end
   return c

--- a/spec/01-unit/000-new-dao/01-schema/01-schema_spec.lua
+++ b/spec/01-unit/000-new-dao/01-schema/01-schema_spec.lua
@@ -671,6 +671,25 @@ describe("schema", function()
       assert.falsy(Test:validate({ f = { a = 2, b = "foo" } }))
     end)
 
+   it("validates nested records", function()
+      local Test = Schema.new({
+        fields = {
+          { f = {
+              type = "record",
+              fields = {
+                { r = {
+                    type = "record",
+                    fields = {
+                      { a = { type = "string" } },
+                      { b = { type = "number" } } }}}}}}}})
+      assert.truthy(Test:validate({ f = { r = { a = "foo" }}}))
+      assert.truthy(Test:validate({ f = { r = { b = 42 }}}))
+      assert.truthy(Test:validate({ f = { r = { a = "foo", b = 42 }}}))
+      assert.falsy(Test:validate({ f = { r = { a = 2 }}}))
+      assert.falsy(Test:validate({ f = { r = { b = "foo" }}}))
+      assert.falsy(Test:validate({ f = { r = { a = 2, b = "foo" }}}))
+    end)
+
     it("validates an integer", function()
       local Test = Schema.new({
         fields = {

--- a/spec/01-unit/000-new-dao/01-schema/02-metaschema_spec.lua
+++ b/spec/01-unit/000-new-dao/01-schema/02-metaschema_spec.lua
@@ -2,9 +2,6 @@ local Schema = require "kong.db.schema"
 local MetaSchema = require "kong.db.schema.metaschema"
 
 
-Schema.new(MetaSchema)
-
-
 describe("metaschema", function()
   it("rejects a bad schema", function()
     local s = {
@@ -29,6 +26,23 @@ describe("metaschema", function()
       }
     }
     assert.falsy(MetaSchema:validate(s))
+  end)
+
+  it("validates a schema with nested records", function()
+    local s = {
+      name = "hello",
+      primary_key = { "foo" },
+      fields = {
+        { foo = { type = "number" } },
+        { f = {
+            type = "record",
+            fields = {
+              { r = {
+                  type = "record",
+                  fields = {
+                    { a = { type = "string" }, },
+                    { b = { type = "number" }, } }}}}}}}}
+    assert.truthy(MetaSchema:validate(s))
   end)
 
   it("allows only one entity check per array field", function()


### PR DESCRIPTION
Includes a regression test in the metaschema testsuite, and a testcase in the
schema testsuite (which demonstrates that the nested records issue was a
metaschema-only problem).

Includes some minor corrections to the metaschema specification, detected
using the metaschema to attempt to validate itself... unfortunately the schema
validator doesn't implement a type system strong enough to fully validate the
metaschema without falling into an infinite loop -- in fact, the schema library isn't strong enough to validate schemas without having the metaschema
"cheat" and perform some of its validation of schemas using the
`check` escape-hatch function to recurse into records, as we see in this
commit. This is by design, because the schema library is meant to be only as complex as necessary for handling Kong entities; the additional complexity is tucked away in the metaschema, which remains a non-essential nice-to-have. Still, the metaschema is useful enough to catch syntax errors in schema definitions, so it's good to keep it around.

As a bonus, there's an extra commit that simplifies some code of the schema module.