### PR TITLE
chore(rockspec) unpin patch version numbers of plugins

### DIFF
--- a/kong-0.14.0rc3-0.rockspec
+++ b/kong-0.14.0rc3-0.rockspec
@@ -35,10 +35,10 @@ dependencies = {
   "lua-resty-cookie == 0.1.0",
   "lua-resty-mlcache == 2.2.0",
   -- external Kong plugins
-  "kong-plugin-azure-functions == 0.1.1",
-  "kong-plugin-zipkin == 0.0.2",
-  "kong-plugin-serverless-functions == 0.1.0",
-  "kong-prometheus-plugin == 0.1.0",
+  "kong-plugin-azure-functions ~> 0.1",
+  "kong-plugin-zipkin ~> 0.0",
+  "kong-plugin-serverless-functions ~> 0.1",
+  "kong-prometheus-plugin ~> 0.1",
 }
 build = {
   type = "builtin",


### PR DESCRIPTION
Unpin the patch version (x.y.Z) version numbers of bundled plugins,
so that users can install strictly-bugfix releases using
`luarocks install <plugin-name>`.
