### PR TITLE
chore(dev) auto-convert Windows line-endings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,11 +65,10 @@ pdk-phase-checks:
 
 fix-windows:
 	@for script in $(WIN_SCRIPTS) ; do \
-	  if [ $$(grep -obUaPc '\015' $$script) -gt 0 ] ; then \
-	    echo Converting Windows file $$script ; \
-	    mv $$script $$script.win ; \
-	    tr -d '\015' <$$script.win >$$script ; \
-	    rm $$script.win ; \
-	  fi \
+	  echo Converting Windows file $$script ; \
+	  mv $$script $$script.win ; \
+	  tr -d '\015' <$$script.win >$$script ; \
+	  rm $$script.win ; \
+	  chmod 0755 $$script ; \
 	done;
 

--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,12 @@ else
 OPENSSL_DIR ?= /usr
 endif
 
-.PHONY: install dev lint test test-integration test-plugins test-all win_scripts
+.PHONY: install dev lint test test-integration test-plugins test-all fix-windows
 
-install: win_scripts
+install:
 	@luarocks make OPENSSL_DIR=$(OPENSSL_DIR) CRYPTO_DIR=$(OPENSSL_DIR)
 
-dev: win_scripts
+dev:
 	-@luarocks remove kong
 	@luarocks make OPENSSL_DIR=$(OPENSSL_DIR) CRYPTO_DIR=$(OPENSSL_DIR)
 	@for rock in $(DEV_ROCKS) ; do \
@@ -31,28 +31,28 @@ dev: win_scripts
 lint:
 	@luacheck -q .
 
-test: win_scripts
+test:
 	@$(TEST_CMD) spec/01-unit
 
-test-integration: win_scripts
+test-integration:
 	@$(TEST_CMD) spec/02-integration
 
-test-plugins: win_scripts
+test-plugins:
 	@$(TEST_CMD) spec/03-plugins
 
-test-all: win_scripts
+test-all:
 	@$(TEST_CMD) spec/
 
-old-test: win_scripts
+old-test:
 	@$(TEST_CMD) spec-old-api/01-unit
 
-old-test-integration: win_scripts
+old-test-integration:
 	@$(TEST_CMD) spec-old-api/02-integration
 
-old-test-plugins: win_scripts
+old-test-plugins:
 	@$(TEST_CMD) spec-old-api/03-plugins
 
-old-test-all: win_scripts
+old-test-all:
 	@$(TEST_CMD) spec-old-api/
 
 pdk-phase-checks:
@@ -63,7 +63,7 @@ pdk-phase-checks:
 	grep "ngx\\." t/phase_checks.report
 	grep "check_" t/phase_checks.report
 
-win_scripts:
+fix-windows:
 	@for script in $(WIN_SCRIPTS) ; do \
 	  if [ $$(grep -obUaPc '\015' $$script) -gt 0 ] ; then \
 	    echo Converting Windows file $$script ; \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 OS := $(shell uname)
 
 DEV_ROCKS = "busted 2.0.rc12" "luacheck 0.20.0" "lua-llthreads2 0.1.5"
+WIN_SCRIPTS = "bin/busted" "bin/kong"
 BUSTED_ARGS ?= -v
 TEST_CMD ?= bin/busted $(BUSTED_ARGS)
 
@@ -10,12 +11,12 @@ else
 OPENSSL_DIR ?= /usr
 endif
 
-.PHONY: install dev lint test test-integration test-plugins test-all
+.PHONY: install dev lint test test-integration test-plugins test-all win_scripts
 
-install:
+install: win_scripts
 	@luarocks make OPENSSL_DIR=$(OPENSSL_DIR) CRYPTO_DIR=$(OPENSSL_DIR)
 
-dev:
+dev: win_scripts
 	-@luarocks remove kong
 	@luarocks make OPENSSL_DIR=$(OPENSSL_DIR) CRYPTO_DIR=$(OPENSSL_DIR)
 	@for rock in $(DEV_ROCKS) ; do \
@@ -30,28 +31,28 @@ dev:
 lint:
 	@luacheck -q .
 
-test:
+test: win_scripts
 	@$(TEST_CMD) spec/01-unit
 
-test-integration:
+test-integration: win_scripts
 	@$(TEST_CMD) spec/02-integration
 
-test-plugins:
+test-plugins: win_scripts
 	@$(TEST_CMD) spec/03-plugins
 
-test-all:
+test-all: win_scripts
 	@$(TEST_CMD) spec/
 
-old-test:
+old-test: win_scripts
 	@$(TEST_CMD) spec-old-api/01-unit
 
-old-test-integration:
+old-test-integration: win_scripts
 	@$(TEST_CMD) spec-old-api/02-integration
 
-old-test-plugins:
+old-test-plugins: win_scripts
 	@$(TEST_CMD) spec-old-api/03-plugins
 
-old-test-all:
+old-test-all: win_scripts
 	@$(TEST_CMD) spec-old-api/
 
 pdk-phase-checks:
@@ -61,3 +62,14 @@ pdk-phase-checks:
 	luacov -c t/phase_checks.luacov
 	grep "ngx\\." t/phase_checks.report
 	grep "check_" t/phase_checks.report
+
+win_scripts:
+	@for script in $(WIN_SCRIPTS) ; do \
+	  if [ $$(grep -obUaPc '\015' $$script) -gt 0 ] ; then \
+	    echo Converting Windows file $$script ; \
+	    mv $$script $$script.win ; \
+	    tr -d '\015' <$$script.win >$$script ; \
+	    rm $$script.win ; \
+	  fi \
+	done;
+


### PR DESCRIPTION
Git clients on Windows tend to convert line endings to Windows
format, such that Windows editors can be used (is reverted on commit).
This doesn't work if mounting those files from a Unix machine for
development for example (Kong-Vagrant). Lua is agnostic to the format,
but the Unix shell is not. Hence only the scripts in `./kong/bin` are
affected.

This change will have the makefile automatically convert those scripts
back to Unix format. This allows Windows users to work on the Kong code
and custom plugins without other configuration.

### Issues resolved

Fix https://github.com/Kong/kong-vagrant/issues/84
