### PR TITLE
refactor(runloop) ngx.ctx usage optimizations and other small changes to runloop and related

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -75,6 +75,7 @@ local balancer_execute = require("kong.runloop.balancer").execute
 local kong_cluster_events = require "kong.cluster_events"
 local kong_error_handlers = require "kong.error_handlers"
 
+local kong             = kong
 local ngx              = ngx
 local header           = ngx.header
 local ngx_log          = ngx.log

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -362,7 +362,7 @@ function Kong.balancer()
   balancer_data.try_count = balancer_data.try_count + 1
   tries[balancer_data.try_count] = current_try
 
-  runloop.balancer.before()
+  runloop.balancer.before(ctx)
 
   if balancer_data.try_count > 1 then
     -- only call balancer on retry, first one is done in `runloop.access.after`
@@ -426,7 +426,7 @@ function Kong.balancer()
     ngx_log(ngx_ERR, "could not set upstream timeouts: ", err)
   end
 
-  runloop.balancer.after()
+  runloop.balancer.after(ctx)
 end
 
 function Kong.rewrite()

--- a/kong/plugins/log-serializers/basic.lua
+++ b/kong/plugins/log-serializers/basic.lua
@@ -5,47 +5,51 @@ local _M = {}
 local EMPTY = tablex.readonly({})
 
 function _M.serialize(ngx)
+  local ctx = ngx.ctx
+  local var = ngx.var
+  local req = ngx.req
+
   local authenticated_entity
-  if ngx.ctx.authenticated_credential ~= nil then
+  if ctx.authenticated_credential ~= nil then
     authenticated_entity = {
-      id = ngx.ctx.authenticated_credential.id,
-      consumer_id = ngx.ctx.authenticated_credential.consumer_id
+      id = ctx.authenticated_credential.id,
+      consumer_id = ctx.authenticated_credential.consumer_id
     }
   end
 
-  local request_uri = ngx.var.request_uri or ""
+  local request_uri = var.request_uri or ""
 
   return {
     request = {
       uri = request_uri,
-      url = ngx.var.scheme .. "://" .. ngx.var.host .. ":" .. ngx.var.server_port .. request_uri,
-      querystring = ngx.req.get_uri_args(), -- parameters, as a table
-      method = ngx.req.get_method(), -- http method
-      headers = ngx.req.get_headers(),
-      size = ngx.var.request_length
+      url = var.scheme .. "://" .. var.host .. ":" .. var.server_port .. request_uri,
+      querystring = req.get_uri_args(), -- parameters, as a table
+      method = req.get_method(), -- http method
+      headers = req.get_headers(),
+      size = var.request_length
     },
-    upstream_uri = ngx.var.upstream_uri,
+    upstream_uri = var.upstream_uri,
     response = {
       status = ngx.status,
       headers = ngx.resp.get_headers(),
-      size = ngx.var.bytes_sent
+      size = var.bytes_sent
     },
-    tries = (ngx.ctx.balancer_data or EMPTY).tries,
+    tries = (ctx.balancer_data or EMPTY).tries,
     latencies = {
-      kong = (ngx.ctx.KONG_ACCESS_TIME or 0) +
-             (ngx.ctx.KONG_RECEIVE_TIME or 0) +
-             (ngx.ctx.KONG_REWRITE_TIME or 0) +
-             (ngx.ctx.KONG_BALANCER_TIME or 0),
-      proxy = ngx.ctx.KONG_WAITING_TIME or -1,
-      request = ngx.var.request_time * 1000
+      kong = (ctx.KONG_ACCESS_TIME or 0) +
+             (ctx.KONG_RECEIVE_TIME or 0) +
+             (ctx.KONG_REWRITE_TIME or 0) +
+             (ctx.KONG_BALANCER_TIME or 0),
+      proxy = ctx.KONG_WAITING_TIME or -1,
+      request = var.request_time * 1000
     },
     authenticated_entity = authenticated_entity,
-    route = ngx.ctx.route,
-    service = ngx.ctx.service,
-    api = ngx.ctx.api,
-    consumer = ngx.ctx.authenticated_consumer,
-    client_ip = ngx.var.remote_addr,
-    started_at = ngx.req.start_time() * 1000
+    route = ctx.route,
+    service = ctx.service,
+    api = ctx.api,
+    consumer = ctx.authenticated_consumer,
+    client_ip = var.remote_addr,
+    started_at = req.start_time() * 1000
   }
 end
 

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -22,6 +22,7 @@ local certificate = require "kong.runloop.certificate"
 
 local kong        = kong
 local tostring    = tostring
+local tonumber    = tonumber
 local sub         = string.sub
 local lower       = string.lower
 local fmt         = string.format
@@ -31,7 +32,6 @@ local log         = ngx.log
 local null        = ngx.null
 local ngx_now     = ngx.now
 local update_time = ngx.update_time
-local re_match    = ngx.re.match
 local unpack      = unpack
 
 
@@ -706,12 +706,9 @@ return {
 
         local upstream_status_header = constants.HEADERS.UPSTREAM_STATUS
         if singletons.configuration.enabled_headers[upstream_status_header] then
-          local matches, err = re_match(var.upstream_status, "[0-9]+$", "oj")
-          if err then
-            log(ERR, "failed to set ", upstream_status_header, " header: ", err)
-
-          elseif matches then
-            header[upstream_status_header] = matches[0]
+          header[upstream_status_header] = tonumber(sub(ngx.var.upstream_status or "", -3))
+          if not header[upstream_status_header] then
+            log(ERR, "failed to set ", upstream_status_header, " header")
           end
         end
 

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -634,7 +634,7 @@ return {
         end
       end
 
-      local ok, err, errcode = balancer.execute(ctx.balancer_data)
+      local ok, err, errcode = balancer.execute(ctx.balancer_data, ctx)
       if not ok then
         if errcode == 500 then
           err = "failed the initial dns/balancer resolve for '" ..
@@ -675,13 +675,12 @@ return {
     end
   },
   balancer = {
-    before = function()
-      local balancer_data = ngx.ctx.balancer_data
+    before = function(ctx)
+      local balancer_data = ctx.balancer_data
       local current_try = balancer_data.tries[balancer_data.try_count]
       current_try.balancer_start = get_now()
     end,
-    after = function ()
-      local ctx = ngx.ctx
+    after = function(ctx)
       local balancer_data = ctx.balancer_data
       local current_try = balancer_data.tries[balancer_data.try_count]
 

--- a/kong/runloop/plugins_iterator.lua
+++ b/kong/runloop/plugins_iterator.lua
@@ -46,7 +46,8 @@ end
 -- @param[type=stirng] plugin_name Name of the plugin being tested for.
 -- @param[type=string] api_id ID of the API being proxied.
 -- @treturn table Plugin retrieved from the cache or database.
-local function load_plugin_configuration(route_id,
+local function load_plugin_configuration(ctx,
+                                         route_id,
                                          service_id,
                                          consumer_id,
                                          plugin_name,
@@ -66,7 +67,7 @@ local function load_plugin_configuration(route_id,
                                      plugin_name,
                                      api_id)
   if err then
-    ngx.ctx.delay_response = false
+    ctx.delay_response = false
     return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
   end
 
@@ -121,69 +122,69 @@ local function get_next(self)
     repeat
 
       if route_id and service_id and consumer_id then
-        plugin_configuration = load_plugin_configuration(route_id, service_id, consumer_id, plugin_name, nil)
+        plugin_configuration = load_plugin_configuration(ctx, route_id, service_id, consumer_id, plugin_name, nil)
         if plugin_configuration then
           break
         end
       end
 
       if route_id and consumer_id then
-        plugin_configuration = load_plugin_configuration(route_id, nil, consumer_id, plugin_name, nil)
+        plugin_configuration = load_plugin_configuration(ctx, route_id, nil, consumer_id, plugin_name, nil)
         if plugin_configuration then
           break
         end
       end
 
       if service_id and consumer_id then
-        plugin_configuration = load_plugin_configuration(nil, service_id, consumer_id, plugin_name, nil)
+        plugin_configuration = load_plugin_configuration(ctx, nil, service_id, consumer_id, plugin_name, nil)
         if plugin_configuration then
           break
         end
       end
 
       if api_id and consumer_id then
-        plugin_configuration = load_plugin_configuration(nil, nil, consumer_id, plugin_name, api_id)
+        plugin_configuration = load_plugin_configuration(ctx, nil, nil, consumer_id, plugin_name, api_id)
         if plugin_configuration then
           break
         end
       end
 
       if route_id and service_id then
-        plugin_configuration = load_plugin_configuration(route_id, service_id, nil, plugin_name, nil)
+        plugin_configuration = load_plugin_configuration(ctx, route_id, service_id, nil, plugin_name, nil)
         if plugin_configuration then
           break
         end
       end
 
       if consumer_id then
-        plugin_configuration = load_plugin_configuration(nil, nil, consumer_id, plugin_name, nil)
+        plugin_configuration = load_plugin_configuration(ctx, nil, nil, consumer_id, plugin_name, nil)
         if plugin_configuration then
           break
         end
       end
 
       if route_id then
-        plugin_configuration = load_plugin_configuration(route_id, nil, nil, plugin_name, nil)
+        plugin_configuration = load_plugin_configuration(ctx, route_id, nil, nil, plugin_name, nil)
         if plugin_configuration then
           break
         end
       end
 
       if service_id then
-        plugin_configuration = load_plugin_configuration(nil, service_id, nil, plugin_name, nil)
+        plugin_configuration = load_plugin_configuration(ctx, nil, service_id, nil, plugin_name, nil)
         if plugin_configuration then
           break
         end
       end
 
       if api_id then
-        plugin_configuration = load_plugin_configuration(nil, nil, nil, plugin_name, api_id)
+        plugin_configuration = load_plugin_configuration(ctx, nil, nil, nil, plugin_name, api_id)
         if plugin_configuration then
           break
         end
       end
 
-      plugin_configuration = load_plugin_configuration(nil, nil, nil, plugin_name, nil)
+      plugin_configuration = load_plugin_configuration(ctx, nil, nil, nil, plugin_name, nil)
 
     until true
 
@@ -212,9 +213,7 @@ local plugin_iter_mt = { __call = get_next }
 -- is access_by_lua_block. We don't use `ngx.get_phase()` simply because we can
 -- avoid it.
 -- @treturn function iterator
-local function iter_plugins_for_req(loaded_plugins, access_or_cert_ctx)
-  local ctx = ngx.ctx
-
+local function iter_plugins_for_req(ctx, loaded_plugins, access_or_cert_ctx)
   if not ctx.plugins_for_request then
     ctx.plugins_for_request = {}
   end


### PR DESCRIPTION
### Summary

* localizes `kong` global access on `handler`
* removes `regex` for simple `string.sub`
* passes `ngx.ctx` to `plugins iterator`
* passes `ngx.ctx` to `balancer`
* optimizations on `basic` serializer (mainly `ngx.ctx` localization)
* reduces some nesting in `handler`