### PR TITLE
misc(travis) only run travis on master and next branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ notifications:
 services:
   - redis-server
 
+branches:
+  only:
+  - master
+  - next
+
 addons:
   postgresql: "9.5"
   apt:


### PR DESCRIPTION
to reduce the travis queue lets only run travis on master and next branches and all PR merge results