### PR TITLE
fix(db) kong.db.errors module did not receive name of the strategy

### DIFF
--- a/kong/api/endpoints.lua
+++ b/kong/api/endpoints.lua
@@ -7,7 +7,9 @@ local app_helpers  = require "lapis.application"
 
 local escape_uri   = ngx.escape_uri
 local unescape_uri = ngx.unescape_uri
+local tostring     = tostring
 local null         = ngx.null
+local type         = type
 local fmt          = string.format
 
 
@@ -25,6 +27,14 @@ local ERRORS_HTTP_CODES = {
 
 
 local function handle_error(err_t)
+  if type(err_t) ~= "table" then
+    responses.send(500, tostring(err_t))
+  end
+
+  if err_t.strategy then
+    err_t.strategy = nil
+  end
+
   local status = ERRORS_HTTP_CODES[err_t.code]
   if not status or status == 500 then
     return app_helpers.yield_error(err_t)

--- a/kong/api/init.lua
+++ b/kong/api/init.lua
@@ -79,6 +79,10 @@ local function new_db_on_error(self)
     return responses.send_HTTP_INTERNAL_SERVER_ERROR(tostring(err))
   end
 
+  if err.strategy then
+    err.strategy = nil
+  end
+
   if err.code == Errors.codes.SCHEMA_VIOLATION
   or err.code == Errors.codes.INVALID_PRIMARY_KEY
   or err.code == Errors.codes.FOREIGN_KEY_VIOLATION

--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -12,7 +12,6 @@ local log          = ngx.log
 local fmt          = string.format
 
 
-
 local ERR          = ngx.ERR
 
 
@@ -297,6 +296,10 @@ function DAO:each(size)
     local row, err, page = next_row()
     if not row then
       if err then
+        if type(err) == "table" then
+          return nil, tostring(err), err
+        end
+
         local err_t = self.errors:database_error(err)
         return nil, tostring(err_t), err_t
       end

--- a/kong/db/init.lua
+++ b/kong/db/init.lua
@@ -43,7 +43,7 @@ function DB.new(kong_config, strategy)
 
   -- load errors
 
-  local errors = Errors.new(strategy)
+  local errors = Errors.new(strategy or kong_config.database)
 
   local schemas = {}
 


### PR DESCRIPTION
### Summary

`kong.db.errors` module did not receive name of the strategy and `dao:each` didn't handle database errors correctly.