### PR TITLE
fix(tests) fix flaky tests

### DIFF
--- a/spec-old-api/03-plugins/02-udp-log/01-udp-log_spec.lua
+++ b/spec-old-api/03-plugins/02-udp-log/01-udp-log_spec.lua
@@ -57,7 +57,11 @@ describe("Plugin: udp-log (log)", function()
     local log_message = cjson.decode(res)
 
     assert.True(log_message.latencies.proxy < 3000)
-    assert.True(log_message.latencies.request >= log_message.latencies.kong + log_message.latencies.proxy)
+    local is_latencies_sum_adding_up =
+      1+log_message.latencies.request >= log_message.latencies.kong +
+      log_message.latencies.proxy
+
+    assert.True(is_latencies_sum_adding_up)
   end)
 
   it("logs to UDP", function()

--- a/spec-old-api/03-plugins/08-datadog/01-log_spec.lua
+++ b/spec-old-api/03-plugins/08-datadog/01-log_spec.lua
@@ -223,7 +223,7 @@ describe("Plugin: datadog (log)", function()
   end)
 
   it("should not return a runtime error (regression)", function()
-    helpers.udp_server(9999, 1, 1)
+    local thread = helpers.udp_server(9999, 1, 1)
 
     local res = assert(client:send {
       method = "GET",
@@ -237,5 +237,6 @@ describe("Plugin: datadog (log)", function()
 
     local err_log = pl_file.read(helpers.test_conf.nginx_err_logs)
     assert.not_matches("attempt to index field 'api' (a nil value)", err_log, nil, true)
+    thread:join()
   end)
 end)

--- a/spec-old-api/03-plugins/10-key-auth/01-api_spec.lua
+++ b/spec-old-api/03-plugins/10-key-auth/01-api_spec.lua
@@ -1,6 +1,7 @@
 local cjson = require "cjson"
 local helpers = require "spec.helpers"
 local utils = require "kong.tools.utils"
+local pl_file = require "pl.file"
 
 describe("Plugin: key-auth (API)", function()
   local consumer
@@ -25,9 +26,15 @@ describe("Plugin: key-auth (API)", function()
     consumer = bp.consumers:insert {
       username = "bob"
     }
-    assert(helpers.start_kong({
+    local res = helpers.start_kong({
       nginx_conf = "spec/fixtures/custom_nginx.template",
-    }))
+    })
+
+    if not res then
+      assert(false, "Error starting kong:\n" ..
+        pl_file.read(helpers.test_conf.nginx_err_logs))
+    end
+
     admin_client = helpers.admin_client()
   end)
   teardown(function()

--- a/spec/03-plugins/02-udp-log/01-udp-log_spec.lua
+++ b/spec/03-plugins/02-udp-log/01-udp-log_spec.lua
@@ -63,7 +63,12 @@ for _, strategy in helpers.each_strategy() do
       local log_message = cjson.decode(res)
 
       assert.True(log_message.latencies.proxy < 3000)
-      assert.True(log_message.latencies.request >= log_message.latencies.kong + log_message.latencies.proxy)
+
+      local is_latencies_sum_adding_up =
+        1+log_message.latencies.request >= log_message.latencies.kong +
+        log_message.latencies.proxy
+
+      assert.True(is_latencies_sum_adding_up)
     end)
 
     it("logs to UDP", function()


### PR DESCRIPTION
This PR cleans 2 flaky tests.

* join an opened thread to clean test environment
* Allow 1 extra ms more for a test to pass (probably an split ms
  issue)
* More verbose logging in case of failure starting Kong
