### PR TITLE
feat(schema) add support for subschemas

### DIFF
--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -39,6 +39,7 @@ local validation_errors = {
   INTEGER                   = "expected an integer",
   FUNCTION                  = "expected a function",
   -- validations
+  EQ                        = "value must be %s",
   BETWEEN                   = "value should be between %d and %d",
   LEN_EQ                    = "length must be %d",
   LEN_MIN                   = "length must be at least %d",
@@ -131,6 +132,14 @@ Schema.validators = {
       return nil, validation_errors.BETWEEN:format(limits[1], limits[2])
     end
     return true
+  end,
+
+  eq = function(value, wanted)
+    if value == wanted then
+      return true
+    end
+    local str = (wanted == null) and "null" or tostring(value)
+    return nil, validation_errors.EQ:format(str)
   end,
 
   len_eq = make_length_validator("LEN_EQ", function(len, n)
@@ -227,6 +236,7 @@ Schema.validators = {
 
 
 Schema.validators_order = {
+  "eq",
   "one_of",
 
   -- type-dependent

--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -34,6 +34,7 @@ local match_any_list = {
 -- Field attributes which match a validator function in the Schema class
 local validators = {
   { between = { type = "array", elements = { type = "integer" }, len_eq = 2 }, },
+  { eq = { type = "self" }, },
   { len_eq = { type = "integer" }, },
   { len_min = { type = "integer" }, },
   { len_max = { type = "integer" }, },

--- a/spec/01-unit/000-new-dao/01-schema/01-schema_spec.lua
+++ b/spec/01-unit/000-new-dao/01-schema/01-schema_spec.lua
@@ -110,6 +110,17 @@ describe("schema", function()
       assert.falsy(Test:validate({ a_number = "wat" }))
     end)
 
+    it("forces a value with 'eq'", function()
+      local Test = Schema.new({
+        fields = {
+          { a_number = { type = "number", eq = 9 } }
+        }
+      })
+      assert.truthy(Test:validate({ a_number = 9 }))
+      assert.falsy(Test:validate({ a_number = 8 }))
+      assert.falsy(Test:validate({ a_number = "wat" }))
+    end)
+
     it("makes sure all types run validators", function()
       local num = { type = "number" }
       local tests = {

--- a/spec/01-unit/000-new-dao/01-schema/01-schema_spec.lua
+++ b/spec/01-unit/000-new-dao/01-schema/01-schema_spec.lua
@@ -880,6 +880,327 @@ describe("schema", function()
       assert.falsy(errmsg)
     end)
 
+    describe("subschemas", function()
+      it("validates loading a subschema", function()
+        local Test = Schema.new({
+          name = "test",
+          subschema_key = "name",
+          fields = {
+            { name = { type = "string", required = true, } },
+            { config = { type = "record", abstract = true, } },
+          }
+        })
+        Test:new_subschema("my_subschema", {
+          fields = {
+            { config = {
+                type = "record",
+                fields = {
+                  { foo = { type = "string" } },
+                  { bar = { type = "integer" } },
+                }
+            } }
+          }
+        })
+        assert.truthy(Test:validate({
+          name = "my_subschema",
+          config = {
+            foo = "hello",
+            bar = 123,
+          }
+        }))
+      end)
+
+      it("fails if subschema doesn't exist", function()
+        local Test = Schema.new({
+          name = "test",
+          subschema_key = "name",
+          fields = {
+            { name = { type = "string", required = true, } },
+          }
+        })
+        local ok, errors = Test:validate({
+          name = "my_invalid_subschema",
+        })
+        assert.falsy(ok)
+        assert.same({
+          ["name"] = "unknown type: my_invalid_subschema",
+        }, errors)
+      end)
+
+      it("ignores missing non-required abstract fields", function()
+        local Test = Schema.new({
+          name = "test",
+          subschema_key = "name",
+          fields = {
+            { name = { type = "string", required = true, } },
+            { config = { type = "record", abstract = true, } },
+            { bla = { type = "integer", abstract = true, } },
+          }
+        })
+        Test:new_subschema("my_subschema", {
+          fields = {
+            { config = {
+                type = "record",
+                fields = {
+                  { foo = { type = "string" } },
+                  { bar = { type = "integer" } },
+                }
+            } }
+          }
+        })
+        assert.truthy(Test:validate({
+          name = "my_subschema",
+          config = {
+            foo = "hello",
+            bar = 123,
+          }
+        }))
+      end)
+
+      it("cannot introduce new top-level fields", function()
+        local Test = Schema.new({
+          name = "test",
+          subschema_key = "name",
+          fields = {
+            { name = { type = "string", required = true, } },
+            { config = {
+                type = "record",
+                fields = {
+                  { foo = { type = "integer" } },
+                }
+            } },
+          }
+        })
+        Test:new_subschema("my_subschema", {
+          fields = {
+            { config = {
+                type = "record",
+                fields = {
+                  { foo = { type = "integer" } },
+                  { bar = { type = "integer" } },
+                }
+            } },
+            { new_field = { type = "string", required = true, } },
+          }
+        })
+
+        local ok, errors = Test:validate({
+          name = "my_subschema",
+          config = {
+            foo = 123,
+          },
+          new_field = "blah",
+        })
+        assert.falsy(ok)
+        assert.same({
+          new_field = "unknown field",
+        }, errors)
+      end)
+
+      it("fails when trying to use an abstract field (incomplete subschema)", function()
+        local Test = Schema.new({
+          name = "test",
+          subschema_key = "name",
+          fields = {
+            { name = { type = "string", required = true, } },
+            { config = { type = "record", abstract = true, } },
+            { bla = { type = "integer", abstract = true, } },
+          }
+        })
+        Test:new_subschema("my_subschema", {
+          fields = {
+            { config = {
+                type = "record",
+                fields = {
+                  { foo = { type = "string" } },
+                  { bar = { type = "integer" } },
+                }
+            } }
+          }
+        })
+        local ok, errors = Test:validate({
+          name = "my_subschema",
+          config = {
+            foo = "hello",
+            bar = 123,
+          },
+          bla = 456,
+        })
+        assert.falsy(ok)
+        assert.same({
+          bla = "error in schema definition: abstract field was not specialized",
+        }, errors)
+      end)
+
+      it("validates using both schema and subschema", function()
+        local Test = Schema.new({
+          name = "test",
+          subschema_key = "name",
+          fields = {
+            { name = { type = "string", required = true, } },
+            { bla = { type = "integer", } },
+            { config = { type = "record", abstract = true, } },
+          }
+        })
+        Test:new_subschema("my_subschema", {
+          fields = {
+            { config = {
+                type = "record",
+                fields = {
+                  { foo = { type = "string" } },
+                  { bar = { type = "integer" } },
+                }
+            } }
+          }
+        })
+        local ok, errors = Test:validate({
+          name = "my_subschema",
+          bla = 4.5,
+          config = {
+            foo = 456,
+            bar = 123,
+          }
+        })
+        assert.falsy(ok)
+        assert.same({
+          bla = "expected an integer",
+          config = {
+            foo = "expected a string",
+          }
+        }, errors)
+      end)
+
+      it("can specialize a field of the parent schema", function()
+        local Test = Schema.new({
+          name = "test",
+          subschema_key = "name",
+          fields = {
+            { name = { type = "string", required = true, } },
+            { consumer = { type = "string", } },
+          }
+        })
+        Test:new_subschema("length_5", {
+          fields = {
+            { consumer = {
+                type = "string",
+                len_eq = 5,
+            } }
+          }
+        })
+        Test:new_subschema("no_restrictions", {
+          fields = {}
+        })
+
+        local ok, errors = Test:validate({
+          name = "length_5",
+          consumer = "aaa",
+        })
+        assert.falsy(ok)
+        assert.same({
+          consumer = "length must be 5",
+        }, errors)
+
+        ok = Test:validate({
+          name = "length_5",
+          consumer = "aaaaa",
+        })
+        assert.truthy(ok)
+
+        ok = Test:validate({
+          name = "no_restrictions",
+          consumer = "aaa",
+        })
+        assert.truthy(ok)
+
+      end)
+
+      it("cannot change type when specializing a field", function()
+        local Test = Schema.new({
+          name = "test",
+          subschema_key = "name",
+          fields = {
+            { name = { type = "string", required = true, } },
+            { consumer = { type = "string", } },
+          }
+        })
+        Test:new_subschema("length_5", {
+          fields = {
+            { consumer = {
+                type = "integer",
+            } }
+          }
+        })
+        Test:new_subschema("no_restrictions", {
+          fields = {}
+        })
+
+        local ok, errors = Test:validate({
+          name = "length_5",
+          consumer = "aaaaa",
+        })
+        assert.falsy(ok)
+        assert.same({
+          consumer = "error in schema definition: cannot change type in a specialized field",
+        }, errors)
+
+        ok = Test:validate({
+          name = "no_restrictions",
+          consumer = "aaa",
+        })
+        assert.truthy(ok)
+
+      end)
+
+      it("a specialized field can force a value using 'eq'", function()
+        package.loaded["kong.db.schema.entities.mock_consumers"] = {
+          name = "mock_consumer",
+          primary_key = { "id" },
+          fields = {
+            { id = { type = "string" }, },
+          }
+        }
+        local Test = Schema.new({
+          name = "test",
+          subschema_key = "name",
+          fields = {
+            { name = { type = "string", required = true, } },
+            { consumer = { type = "foreign", reference = "mock_consumers" } },
+          }
+        })
+        Test:new_subschema("no_consumer", {
+          fields = {
+            { consumer = { type = "foreign", reference = "mock_consumers", eq = ngx.null } }
+          }
+        })
+        Test:new_subschema("no_restrictions", {
+          fields = {}
+        })
+
+        local ok, errors = Test:validate({
+          name = "no_consumer",
+          consumer = { id = "hello" },
+        })
+        assert.falsy(ok)
+        assert.same({
+          consumer = "value must be null",
+        }, errors)
+
+        ok = Test:validate({
+          name = "no_consumer",
+          consumer = ngx.null,
+        })
+        assert.truthy(ok)
+
+        ok = Test:validate({
+          name = "no_restrictions",
+          consumer = { id = "hello" },
+        })
+        assert.truthy(ok)
+
+      end)
+
+    end)
+
   end)
 
   describe("validate_primary_key", function()


### PR DESCRIPTION
This resolves three difficulties that would appear when porting the Plugins entity over to the new DAO: loading the plugin configuration schema dynamically, the fact that this schema depends on a value of the entity row itself, and the fact that the specific plugin type can impose further constraints on values.

The old DAO implemented this by allowing records to have a `schema` field that would be either a table or a function evaluated at validation time, and using an ad-hoc validation that checked for a `no_consumer` field to restrict the value of `consumer_id` to `null`.

The new DAO implements this by allowing an entity (such as Plugins) to declare that it is extensible via **subschemas**:

* a schema may declare that it allows subschemas, tagged by one specific string key of the schema, with the top-level `subschema_key` property.
  * essentially, the set of all plugins taken as one works like a tagged union.
  * for Plugins, `subschema_key` will be `"name"`
* a schema may declare where it gets subschemas from, with the `subschema_module`.
  * for Plugins, `subschema_module` will be `"kong.plugins.?.schema"`
* the parent schema may declare fields as "abstract", which are meant to be specialized by the subschema. Abstract records don't need their `fields` property to be set, and they must be given in the specialized ones.
  * for Plugins, `config` will be `abstract`
* the set of fields considered when validating an entity is that of the parent schema
  * subschemas cannot introduce new fields, those need to be declared in the parent schema ("abstract" if needed)
  * the data model of strategies can be inferred from parent schema alone
* subschemas may override both abstract and non-abstract fields.
  * they cannot change the type of a field
  * a field declared in the subschema overrides the parent schema's field completely (constraints are not merged)
  * for Plugins, plugins will override `config`, and for the `no_consumer` feature, they can override `consumer` using the `eq = null` validator