### PR TITLE
fix(globalpathces) ngx socket connect to unix domain socket

### DIFF
--- a/kong/globalpatches.lua
+++ b/kong/globalpatches.lua
@@ -299,7 +299,7 @@ return function(options)
 
       local target_ip, target_port = toip(host, port)
       if not target_ip then
-        return nil, "[toip() name lookup failed]: " .. tostring(target_port) -- err
+        return nil, "[toip() name lookup failed]: " .. tostring(target_port)
       end
 
       -- need to do the extra check here: https://github.com/openresty/lua-nginx-module/issues/860

--- a/kong/globalpatches.lua
+++ b/kong/globalpatches.lua
@@ -288,38 +288,37 @@ return function(options)
     local old_tcp_connect
     local old_udp_setpeername
 
-  -- need to do the extra check here: https://github.com/openresty/lua-nginx-module/issues/860
-    local function strip_nils(port, opts)
-      if port and opts then
-        return port, opts
-      elseif opts then
-        return opts
-      elseif port then
-        return port
+    local function strip_nils(first, second)
+      if second then
+        return first, second
+      elseif first then
+        return first
       end
     end
-
-    local function resolve_connect(f, sock, host, port, sock_opts)
-      local target_ip, target_port
+  
+    -- need to do the extra check here: https://github.com/openresty/lua-nginx-module/issues/860
+    local function resolve_connect(f, sock, host, port_or_opts, opts)
       if sub(host, 1, 5) == "unix:" then
-        target_ip = host
-      else
-        target_ip, target_port = toip(host, port)
+        opts = port_or_opts
+        return f(sock, host, strip_nils(opts))
       end
+    
+      local port = port_or_opts
+      local target_ip, target_port = toip(host, port)
       if not target_ip then
         return nil, "[toip() name lookup failed]: " .. tostring(target_port)
       end
-      return f(sock, target_ip, strip_nils(target_port, sock_opts))
+      return f(sock, target_ip, strip_nils(target_port, opts))
     end
-
-    local function tcp_resolve_connect(sock, host, port, sock_opts)
-      return resolve_connect(old_tcp_connect, sock, host, port, sock_opts)
+  
+    local function tcp_resolve_connect(sock, host, port_or_opts, opts)
+      return resolve_connect(old_tcp_connect, sock, host, port_or_opts, opts)
     end
-
+  
     local function udp_resolve_setpeername(sock, host, port)
       return resolve_connect(old_udp_setpeername, sock, host, port)
     end
-
+  
     -- STEP 4: patch globals
     _G.ngx.socket.tcp = function(...)
       local sock = old_tcp(...)

--- a/kong/globalpatches.lua
+++ b/kong/globalpatches.lua
@@ -289,28 +289,20 @@ return function(options)
     local old_udp_setpeername
 
     local function tcp_resolve_connect(sock, host, port, sock_opts)
-      local target_ip, target_port
-
       if sub(host, 1, 5) == "unix:" then
-        target_ip = host -- unix domain socket, so just maintain the named values
-
-      else
-        target_ip, target_port = toip(host, port)
-
-        if not target_ip then
-          return nil, "[toip() name lookup failed]: " .. tostring(target_port) -- err
-        end
-      end
-      
-      -- need to do the extra check here: https://github.com/openresty/lua-nginx-module/issues/860
-      if type(target_port) ~= "number" then
         if not sock_opts then 
-          return old_tcp_connect(sock, target_ip)
+          return old_tcp_connect(sock, host)
         end
 
-        return old_tcp_connect(sock, target_ip, sock_opts)
+        return old_tcp_connect(sock, host, sock_opts)
       end
 
+      local target_ip, target_port = toip(host, port)
+      if not target_ip then
+        return nil, "[toip() name lookup failed]: " .. tostring(target_port) -- err
+      end
+
+      -- need to do the extra check here: https://github.com/openresty/lua-nginx-module/issues/860
       if not sock_opts then
         return old_tcp_connect(sock, target_ip, target_port)
       end
@@ -319,21 +311,13 @@ return function(options)
     end
 
     local function udp_resolve_setpeername(sock, host, port)
-      local target_ip, target_port
-
       if sub(host, 1, 5) == "unix:" then
-        target_ip = host -- unix domain socket, so just maintain the named values
-
-      else
-        target_ip, target_port = toip(host, port)
-
-        if not target_ip then
-          return nil, "[toip() name lookup failed]: " .. tostring(target_port) -- err
-        end
+        return old_udp_setpeername(sock, host) -- unix domain socket, so just maintain the named values and call connect without port
       end
 
-      if type(target_port) ~= "number" then
-        return old_udp_setpeername(sock, target_ip)
+      local target_ip, target_port = toip(host, port)
+      if not target_ip then
+        return nil, "[toip() name lookup failed]: " .. tostring(target_port) -- err
       end
       
       return old_udp_setpeername(sock, target_ip, target_port)


### PR DESCRIPTION
### Summary

When connecting to unix domain socket, port parameter should not
be passed to tcpsock:connect or udpsock:connect

### Full changelog

* globalpatches of ngx.socket to connect to unix domain socket

### Issues resolved

Fix #3626
