### PR TITLE
feat/ldap auth windows

### DIFF
--- a/kong-0.11.0-0.rockspec
+++ b/kong-0.11.0-0.rockspec
@@ -275,6 +275,7 @@ build = {
     ["kong.plugins.aws-lambda.handler"] = "kong/plugins/aws-lambda/handler.lua",
     ["kong.plugins.aws-lambda.schema"] = "kong/plugins/aws-lambda/schema.lua",
     ["kong.plugins.aws-lambda.v4"] = "kong/plugins/aws-lambda/v4.lua",
+    ["kong.plugins.aws-lambda.iam-role-credentials"] = "kong/plugins/aws-lambda/iam-role-credentials.lua",
 
     ["kong.plugins.request-termination.handler"] = "kong/plugins/request-termination/handler.lua",
     ["kong.plugins.request-termination.schema"] = "kong/plugins/request-termination/schema.lua",

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -7,13 +7,17 @@ local utils = require "kong.tools.utils"
 local http = require "resty.http"
 local cjson = require "cjson.safe"
 local public_utils = require "kong.tools.public"
-local get_credentials_from_iam_role = require "kong.plugins.aws-lambda.iam-role-credentials"
+local fetch_iam_credentials_from_metadata_service = require "kong.plugins.aws-lambda.iam-role-credentials"
+local singletons = require "kong.singletons"
 
 local tostring             = tostring
 local ngx_req_read_body    = ngx.req.read_body
 local ngx_req_get_uri_args = ngx.req.get_uri_args
 local ngx_req_get_headers  = ngx.req.get_headers
 local ngx_encode_base64    = ngx.encode_base64
+
+local DEFAULT_CACHE_IAM_INSTANCE_CREDS_DURATION = 60
+local IAM_CREDENTIALS_CACHE_KEY = "plugin.aws-lambda.iam_role_temp_creds"
 
 local new_tab
 do
@@ -109,7 +113,9 @@ function AWSLambdaHandler:access(conf)
   }
 
   if conf.use_ec2_iam_role then
-    local iam_role_credentials, err = get_credentials_from_iam_role()
+    local iam_role_credentials, err = singletons.cache:get(IAM_CREDENTIALS_CACHE_KEY, { ttl = DEFAULT_CACHE_IAM_INSTANCE_CREDS_DURATION },
+                                                           fetch_iam_credentials_from_metadata_service)
+
     if not iam_role_credentials then
       return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
     end

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -109,7 +109,11 @@ function AWSLambdaHandler:access(conf)
   }
 
   if conf.use_ec2_iam_role then
-    local iam_role_credentials = get_credentials_from_iam_role()
+    local iam_role_credentials, err = get_credentials_from_iam_role()
+    if not iam_role_credentials then
+      return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+    end
+
     opts.access_key = iam_role_credentials.access_key
     opts.secret_key = iam_role_credentials.secret_key
     opts.headers["X-Amz-Security-Token"] = iam_role_credentials.session_token

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -7,6 +7,7 @@ local utils = require "kong.tools.utils"
 local http = require "resty.http"
 local cjson = require "cjson.safe"
 local public_utils = require "kong.tools.public"
+local get_credentials_from_iam_role = require "kong.plugins.aws-lambda.iam-role-credentials"
 
 local tostring             = tostring
 local ngx_req_read_body    = ngx.req.read_body
@@ -104,10 +105,18 @@ function AWSLambdaHandler:access(conf)
     path = path,
     host = host,
     port = port,
-    access_key = conf.aws_key,
-    secret_key = conf.aws_secret,
     query = conf.qualifier and "Qualifier=" .. conf.qualifier
   }
+
+  if conf.use_ec2_iam_role then
+    local iam_role_credentials = get_credentials_from_iam_role()
+    opts.access_key = iam_role_credentials.access_key
+    opts.secret_key = iam_role_credentials.secret_key
+    opts.headers['X-Amz-Security-Token'] = iam_role_credentials.session_token
+  else
+    opts.access_key = conf.aws_key
+    opts.secret_key = conf.aws_secret
+  end
 
   local request, err = aws_v4(opts)
   if err then

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -112,7 +112,8 @@ function AWSLambdaHandler:access(conf)
     local iam_role_credentials = get_credentials_from_iam_role()
     opts.access_key = iam_role_credentials.access_key
     opts.secret_key = iam_role_credentials.secret_key
-    opts.headers['X-Amz-Security-Token'] = iam_role_credentials.session_token
+    opts.headers["X-Amz-Security-Token"] = iam_role_credentials.session_token
+
   else
     opts.access_key = conf.aws_key
     opts.secret_key = conf.aws_secret

--- a/kong/plugins/aws-lambda/iam-role-credentials.lua
+++ b/kong/plugins/aws-lambda/iam-role-credentials.lua
@@ -1,23 +1,16 @@
-local http = require 'resty.http'
-local json = require 'cjson'
-local cache = require "kong.tools.database_cache"
+local http  = require 'resty.http'
+local json  = require 'cjson'
+local cache = require 'kong.tools.database_cache'
 
 local CACHE_IAM_INSTANCE_CREDS_DURATION = 60 -- seconds to cache credentials from metadata service
-    
-local function get_iam_credentials_cache_key()
-  return "plugin.aws-lambda-iam-role.iam_role_temp_creds"
-end
-
+local IAM_CREDENTIALS_CACHE_KEY = "plugin.aws-lambda.iam_role_temp_creds"
 
 local function fetch_iam_credentials_from_metadata_service(metadata_service_host, metadata_service_port)
-    metadata_service_host = metadata_service_host or '169.254.169.254'
-    metadata_service_port = metadata_service_port or 80
- 
     local client = http.new()
     local ok, err = client:connect(metadata_service_host, metadata_service_port) 
     
     if not ok then
-      ngx.log(ngx.ERR, "Could not connect to metadata service: " .. err)
+      ngx.log(ngx.ERR, "[aws-lambda] Could not connect to metadata service: ", err)
       return nil, err
     end
     
@@ -27,23 +20,24 @@ local function fetch_iam_credentials_from_metadata_service(metadata_service_host
     }
      
     if not role_name_request_res or role_name_request_res == "" then
-          ngx.log(ngx.ERR, "Could not fetch role name from metadata service: ".. err)
+          ngx.log(ngx.ERR, "[aws-lambda] Could not fetch role name from metadata service: ", err)
         return nil, err
     end 
      
     if role_name_request_res.status ~= 200 then
-      return nil, "[aws-lambda] Fetching role name from metadata service returned status code ".. role_name_request_res.status  .. 
-                   "with body " .. role_name_request_res.body
+      return nil, "[aws-lambda] Fetching role name from metadata service returned status code "..
+                  role_name_request_res.status  .. "with body " .. role_name_request_res.body
     end
            
     local iam_role_name = role_name_request_res:read_body() 
     
-    ngx.log(ngx.INFO, "[aws-lambda] IAM role '" .. iam_role_name .. "' is available through metadata service, fetching IAM credentials")
+    ngx.log(ngx.DEBUG, "[aws-lambda] IAM role '" .. iam_role_name ..
+                       "' is available through metadata service, fetching IAM credentials")
     
     local ok, err = client:connect(metadata_service_host, metadata_service_port) 
     
     if not ok then
-      ngx.log(ngx.ERR, "Could not connect to metadata service: " .. err)
+      ngx.log(ngx.ERR, "Could not connect to metadata service: ", err)
       return nil, err
     end
     
@@ -66,20 +60,23 @@ local function fetch_iam_credentials_from_metadata_service(metadata_service_host
     end
 
     local iam_security_token_data = json.decode(iam_security_token_request:read_body())
-    
-    ngx.log(ngx.INFO, "[aws-lambda] Received temporary IAM credential from metadata service for role '" ..
-                       iam_role_name .. "' with session token " .. iam_security_token_data['Token'])
-  
+
+    ngx.log(ngx.DEBUG, "[aws-lambda] Received temporary IAM credential from metadata service for role '" ..
+                       iam_role_name .. "' with session token " .. iam_security_token_data.Token)
+
     return {
-        access_key = iam_security_token_data['AccessKeyId'],
-        secret_key = iam_security_token_data['SecretAccessKey'],
-        session_token = iam_security_token_data['Token']
+        access_key = iam_security_token_data.AccessKeyId,
+        secret_key = iam_security_token_data.SecretAccessKey,
+        session_token = iam_security_token_data.Token
     }
 end
 
-local function get_iam_credentials_from_instance_profile()
-    local iam_profile_credentials, err = cache.get_or_set(get_iam_credentials_cache_key(), CACHE_IAM_INSTANCE_CREDS_DURATION,
-                                       fetch_iam_credentials_from_metadata_service)
+local function get_iam_credentials_from_instance_profile(metadata_service_host, metadata_service_port)
+    metadata_service_host = metadata_service_host or '169.254.169.254'
+    metadata_service_port = metadata_service_port or 80
+
+    local iam_profile_credentials, err = cache.get_or_set(IAM_CREDENTIALS_CACHE_KEY, CACHE_IAM_INSTANCE_CREDS_DURATION,
+                                       fetch_iam_credentials_from_metadata_service, metadata_service_host, metadata_service_port)
     if not iam_profile_credentials then
       ngx.log(ngx.ERR, err)
       return ngx.exit(ngx.ERROR)

--- a/kong/plugins/aws-lambda/iam-role-credentials.lua
+++ b/kong/plugins/aws-lambda/iam-role-credentials.lua
@@ -52,8 +52,8 @@ local function fetch_iam_credentials_from_metadata_service(metadata_service_host
     end
     
     if iam_security_token_request.status == 404 then
-        return nil, '[aws-lambda] Unable to request IAM credentials for role' .. iam_role_name ..
-                    ' Request returned status code ' .. iam_security_token_request.status
+        return nil, "[aws-lambda] Unable to request IAM credentials for role" .. iam_role_name ..
+                    " Request returned status code " .. iam_security_token_request.status
     end
 
     if iam_security_token_request.status ~= 200 then
@@ -73,7 +73,7 @@ local function fetch_iam_credentials_from_metadata_service(metadata_service_host
 end
 
 local function get_iam_credentials_from_instance_profile(metadata_service_host, metadata_service_port)
-    metadata_service_host = metadata_service_host or '169.254.169.254'
+    metadata_service_host = metadata_service_host or "169.254.169.254"
     metadata_service_port = metadata_service_port or 80
 
     return cache.get_or_set(IAM_CREDENTIALS_CACHE_KEY, CACHE_IAM_INSTANCE_CREDS_DURATION,

--- a/kong/plugins/aws-lambda/iam-role-credentials.lua
+++ b/kong/plugins/aws-lambda/iam-role-credentials.lua
@@ -1,0 +1,91 @@
+local http = require 'resty.http'
+local json = require 'cjson'
+local cache = require "kong.tools.database_cache"
+
+local CACHE_IAM_INSTANCE_CREDS_DURATION = 60 -- seconds to cache credentials from metadata service
+    
+local function get_iam_credentials_cache_key()
+  return "plugin.aws-lambda-iam-role.iam_role_temp_creds"
+end
+
+
+local function fetch_iam_credentials_from_metadata_service(metadata_service_host, metadata_service_port)
+    metadata_service_host = metadata_service_host or '169.254.169.254'
+    metadata_service_port = metadata_service_port or 80
+ 
+    local client = http.new()
+    local ok, err = client:connect(metadata_service_host, metadata_service_port) 
+    
+    if not ok then
+      ngx.log(ngx.ERR, "Could not connect to metadata service: " .. err)
+      return nil, err
+    end
+    
+    local role_name_request_res, err = client:request {
+      method = "GET",
+      path = "/latest/meta-data/iam/security-credentials/"
+    }
+     
+    if not role_name_request_res or role_name_request_res == "" then
+          ngx.log(ngx.ERR, "Could not fetch role name from metadata service: ".. err)
+        return nil, err
+    end 
+     
+    if role_name_request_res.status ~= 200 then
+      return nil, "[aws-lambda] Fetching role name from metadata service returned status code ".. role_name_request_res.status  .. 
+                   "with body " .. role_name_request_res.body
+    end
+           
+    local iam_role_name = role_name_request_res:read_body() 
+    
+    ngx.log(ngx.INFO, "[aws-lambda] IAM role '" .. iam_role_name .. "' is available through metadata service, fetching IAM credentials")
+    
+    local ok, err = client:connect(metadata_service_host, metadata_service_port) 
+    
+    if not ok then
+      ngx.log(ngx.ERR, "Could not connect to metadata service: " .. err)
+      return nil, err
+    end
+    
+    local iam_security_token_request, err = client:request {
+      method = "GET",
+      path = "/latest/meta-data/iam/security-credentials/" .. iam_role_name
+    }    
+    
+    if not iam_security_token_request then
+        return nil, err
+    end
+    
+    if iam_security_token_request.status == 404 then
+        return nil, '[aws-lambda] Unable to request IAM credentials for role' .. iam_role_name ..
+                    ' Request returned status code ' .. iam_security_token_request.status
+    end
+
+    if iam_security_token_request.status ~= 200 then
+        return nil, iam_security_token_request:read_body()
+    end
+
+    local iam_security_token_data = json.decode(iam_security_token_request:read_body())
+    
+    ngx.log(ngx.INFO, "[aws-lambda] Received temporary IAM credential from metadata service for role '" ..
+                       iam_role_name .. "' with session token " .. iam_security_token_data['Token'])
+  
+    return {
+        access_key = iam_security_token_data['AccessKeyId'],
+        secret_key = iam_security_token_data['SecretAccessKey'],
+        session_token = iam_security_token_data['Token']
+    }
+end
+
+local function get_iam_credentials_from_instance_profile()
+    local iam_profile_credentials, err = cache.get_or_set(get_iam_credentials_cache_key(), CACHE_IAM_INSTANCE_CREDS_DURATION,
+                                       fetch_iam_credentials_from_metadata_service)
+    if not iam_profile_credentials then
+      ngx.log(ngx.ERR, err)
+      return ngx.exit(ngx.ERROR)
+    end
+
+  return iam_profile_credentials
+end
+
+return get_iam_credentials_from_instance_profile

--- a/kong/plugins/aws-lambda/iam-role-credentials.lua
+++ b/kong/plugins/aws-lambda/iam-role-credentials.lua
@@ -6,78 +6,78 @@ local CACHE_IAM_INSTANCE_CREDS_DURATION = 60 -- seconds to cache credentials fro
 local IAM_CREDENTIALS_CACHE_KEY = "plugin.aws-lambda.iam_role_temp_creds"
 
 local function fetch_iam_credentials_from_metadata_service(metadata_service_host, metadata_service_port)
-    local client = http.new()
-    client:set_timeout(500)
+  local client = http.new()
+  client:set_timeout(500)
 
-    local ok, err = client:connect(metadata_service_host, metadata_service_port)
-    
-    if not ok then
-      ngx.log(ngx.ERR, "[aws-lambda] Could not connect to metadata service: ", err)
-      return nil, err
-    end
-    
-    local role_name_request_res, err = client:request {
-      method = "GET",
-      path = "/latest/meta-data/iam/security-credentials/",
-    }
-     
-    if not role_name_request_res or role_name_request_res == "" then
-          ngx.log(ngx.ERR, "[aws-lambda] Could not fetch role name from metadata service: ", err)
-        return nil, err
-    end 
-     
-    if role_name_request_res.status ~= 200 then
-      return nil, "[aws-lambda] Fetching role name from metadata service returned status code " ..
-                  role_name_request_res.status  .. "with body " .. role_name_request_res.body
-    end
-           
-    local iam_role_name = role_name_request_res:read_body() 
-    
-    ngx.log(ngx.DEBUG, "[aws-lambda] Found IAM role on instance with name: ", iam_role_name)
-    
-    local ok, err = client:connect(metadata_service_host, metadata_service_port) 
-    
-    if not ok then
-      ngx.log(ngx.ERR, "Could not connect to metadata service: ", err)
-      return nil, err
-    end
-    
-    local iam_security_token_request, err = client:request {
-      method = "GET",
-      path = "/latest/meta-data/iam/security-credentials/" .. iam_role_name,
-    }    
-    
-    if not iam_security_token_request then
-        return nil, err
-    end
-    
-    if iam_security_token_request.status == 404 then
-        return nil, "[aws-lambda] Unable to request IAM credentials for role" .. iam_role_name ..
-                    " Request returned status code " .. iam_security_token_request.status
-    end
+  local ok, err = client:connect(metadata_service_host, metadata_service_port)
 
-    if iam_security_token_request.status ~= 200 then
-        return nil, iam_security_token_request:read_body()
-    end
+  if not ok then
+    ngx.log(ngx.ERR, "[aws-lambda] Could not connect to metadata service: ", err)
+    return nil, err
+  end
 
-    local iam_security_token_data = json.decode(iam_security_token_request:read_body())
+  local role_name_request_res, err = client:request {
+    method = "GET",
+    path   = "/latest/meta-data/iam/security-credentials/",
+  }
 
-    ngx.log(ngx.DEBUG, "[aws-lambda] Received temporary IAM credential from metadata service for role '",
-                       iam_role_name, "' with session token: ", iam_security_token_data.Token)
+  if not role_name_request_res or role_name_request_res == "" then
+    ngx.log(ngx.ERR, "[aws-lambda] Could not fetch role name from metadata service: ", err)
+    return nil, err
+  end
 
-    return {
-        access_key    = iam_security_token_data.AccessKeyId,
-        secret_key    = iam_security_token_data.SecretAccessKey,
-        session_token = iam_security_token_data.Token,
-    }
+  if role_name_request_res.status ~= 200 then
+    return nil, "[aws-lambda] Fetching role name from metadata service returned status code " ..
+                role_name_request_res.status .. "with body " .. role_name_request_res.body
+  end
+
+  local iam_role_name = role_name_request_res:read_body()
+
+  ngx.log(ngx.DEBUG, "[aws-lambda] Found IAM role on instance with name: ", iam_role_name)
+
+  local ok, err = client:connect(metadata_service_host, metadata_service_port)
+
+  if not ok then
+    ngx.log(ngx.ERR, "Could not connect to metadata service: ", err)
+    return nil, err
+  end
+
+  local iam_security_token_request, err = client:request {
+    method = "GET",
+    path   = "/latest/meta-data/iam/security-credentials/" .. iam_role_name,
+  }
+
+  if not iam_security_token_request then
+    return nil, err
+  end
+
+  if iam_security_token_request.status == 404 then
+    return nil, "[aws-lambda] Unable to request IAM credentials for role" .. iam_role_name ..
+                " Request returned status code " .. iam_security_token_request.status
+  end
+
+  if iam_security_token_request.status ~= 200 then
+    return nil, iam_security_token_request:read_body()
+  end
+
+  local iam_security_token_data = json.decode(iam_security_token_request:read_body())
+
+  ngx.log(ngx.DEBUG, "[aws-lambda] Received temporary IAM credential from metadata service for role '",
+                     iam_role_name, "' with session token: ", iam_security_token_data.Token)
+
+  return {
+    access_key    = iam_security_token_data.AccessKeyId,
+    secret_key    = iam_security_token_data.SecretAccessKey,
+    session_token = iam_security_token_data.Token,
+  }
 end
 
 local function get_iam_credentials_from_instance_profile(metadata_service_host, metadata_service_port)
-    metadata_service_host = metadata_service_host or "169.254.169.254"
-    metadata_service_port = metadata_service_port or 80
+  metadata_service_host = metadata_service_host or "169.254.169.254"
+  metadata_service_port = metadata_service_port or 80
 
-    return cache.get_or_set(IAM_CREDENTIALS_CACHE_KEY, CACHE_IAM_INSTANCE_CREDS_DURATION,
-                            fetch_iam_credentials_from_metadata_service, metadata_service_host, metadata_service_port)
+  return cache.get_or_set(IAM_CREDENTIALS_CACHE_KEY, CACHE_IAM_INSTANCE_CREDS_DURATION,
+                          fetch_iam_credentials_from_metadata_service, metadata_service_host, metadata_service_port)
 end
 
 return get_iam_credentials_from_instance_profile

--- a/kong/plugins/aws-lambda/iam-role-credentials.lua
+++ b/kong/plugins/aws-lambda/iam-role-credentials.lua
@@ -77,7 +77,7 @@ local function get_iam_credentials_from_instance_profile(metadata_service_host, 
     metadata_service_port = metadata_service_port or 80
 
     return cache.get_or_set(IAM_CREDENTIALS_CACHE_KEY, CACHE_IAM_INSTANCE_CREDS_DURATION,
-                                       fetch_iam_credentials_from_metadata_service, metadata_service_host, metadata_service_port)
+                            fetch_iam_credentials_from_metadata_service, metadata_service_host, metadata_service_port)
 end
 
 return get_iam_credentials_from_instance_profile

--- a/kong/plugins/aws-lambda/iam-role-credentials.lua
+++ b/kong/plugins/aws-lambda/iam-role-credentials.lua
@@ -2,12 +2,16 @@ local http  = require "resty.http"
 local json  = require "cjson"
 local cache = require "kong.tools.database_cache"
 
-local CACHE_IAM_INSTANCE_CREDS_DURATION = 60 -- seconds to cache credentials from metadata service
+local DEFAULT_CACHE_IAM_INSTANCE_CREDS_DURATION = 60 -- seconds to cache credentials from metadata service
+local DEFAULT_METADATA_SERVICE_PORT = 80
+local DEFAULT_METADATA_SERVICE_HOST = "169.254.169.254"
+local DEFAULT_METADATA_SERVICE_REQUEST_TIMEOUT = 5000
 local IAM_CREDENTIALS_CACHE_KEY = "plugin.aws-lambda.iam_role_temp_creds"
 
-local function fetch_iam_credentials_from_metadata_service(metadata_service_host, metadata_service_port)
+local function fetch_iam_credentials_from_metadata_service(metadata_service_host, metadata_service_port,
+                                                           metadata_service_request_timeout)
   local client = http.new()
-  client:set_timeout(500)
+  client:set_timeout(metadata_service_request_timeout)
 
   local ok, err = client:connect(metadata_service_host, metadata_service_port)
 
@@ -72,12 +76,16 @@ local function fetch_iam_credentials_from_metadata_service(metadata_service_host
   }
 end
 
-local function get_iam_credentials_from_instance_profile(metadata_service_host, metadata_service_port)
-  metadata_service_host = metadata_service_host or "169.254.169.254"
-  metadata_service_port = metadata_service_port or 80
+local function get_iam_credentials_from_instance_profile(metadata_service_host, metadata_service_port,
+                                                         metadata_service_request_timeout, credentials_cache_ttl)
+  metadata_service_host = metadata_service_host or DEFAULT_METADATA_SERVICE_HOST
+  metadata_service_port = metadata_service_port or DEFAULT_METADATA_SERVICE_PORT
+  metadata_service_request_timeout = metadata_service_request_timeout or DEFAULT_METADATA_SERVICE_REQUEST_TIMEOUT
+  credentials_cache_ttl = credentials_cache_ttl or DEFAULT_CACHE_IAM_INSTANCE_CREDS_DURATION
 
-  return cache.get_or_set(IAM_CREDENTIALS_CACHE_KEY, CACHE_IAM_INSTANCE_CREDS_DURATION,
-                          fetch_iam_credentials_from_metadata_service, metadata_service_host, metadata_service_port)
+  return cache.get_or_set(IAM_CREDENTIALS_CACHE_KEY, credentials_cache_ttl,
+                          fetch_iam_credentials_from_metadata_service, metadata_service_host, metadata_service_port,
+                          metadata_service_request_timeout)
 end
 
 return get_iam_credentials_from_instance_profile

--- a/kong/plugins/aws-lambda/iam-role-credentials.lua
+++ b/kong/plugins/aws-lambda/iam-role-credentials.lua
@@ -7,6 +7,7 @@ local DEFAULT_METADATA_SERVICE_HOST = "169.254.169.254"
 
 local function fetch_iam_credentials_from_metadata_service(metadata_service_host, metadata_service_port,
                                                            metadata_service_request_timeout)
+
   metadata_service_host = metadata_service_host or DEFAULT_METADATA_SERVICE_HOST
   metadata_service_port = metadata_service_port or DEFAULT_METADATA_SERVICE_PORT
   metadata_service_request_timeout = metadata_service_request_timeout or DEFAULT_METADATA_SERVICE_REQUEST_TIMEOUT
@@ -14,7 +15,10 @@ local function fetch_iam_credentials_from_metadata_service(metadata_service_host
   local client = http.new()
   client:set_timeout(metadata_service_request_timeout)
 
+  -- Set no proxy for 169.254.169.254
+  client:set_proxy_options(metadata_service_host)
   local ok, err = client:connect(metadata_service_host, metadata_service_port)
+ 
 
   if not ok then
     ngx.log(ngx.ERR, "[aws-lambda] Could not connect to metadata service: ", err)

--- a/kong/plugins/aws-lambda/schema.lua
+++ b/kong/plugins/aws-lambda/schema.lua
@@ -101,9 +101,9 @@ return {
     },
   },
   self_check =  function(schema, plugin_t, dao, is_update)
-    if not plugin_t["use_ec2_iam_role"] or plugin_t["use_ec2_iam_role"] == false then
+    if not plugin_t.use_ec2_iam_role or plugin_t.use_ec2_iam_role == false then
       -- if iam_profile is not set, aws_key and aws_secret are required
-      if not plugin_t["aws_key"] or not plugin_t["aws_secret"] then
+      if not plugin_t.aws_key or not plugin_t.aws_secret then
         return false, Errors.schema "You need to set aws_key and aws_secret or need to use EC2 IAM roles"
       end
       return true

--- a/kong/plugins/aws-lambda/schema.lua
+++ b/kong/plugins/aws-lambda/schema.lua
@@ -100,7 +100,7 @@ return {
       type="boolean",
     },
   },
-  self_check =  function(schema, plugin_t, dao, is_update)
+  self_check = function(schema, plugin_t, dao, is_update)
     if not plugin_t.use_ec2_iam_role then
       -- if iam_profile is not set, aws_key and aws_secret are required
       if not plugin_t.aws_key or plugin_t.aws_key == "" or not plugin_t.aws_secret or plugin_t.aws_secret == "" then

--- a/kong/plugins/aws-lambda/schema.lua
+++ b/kong/plugins/aws-lambda/schema.lua
@@ -103,7 +103,7 @@ return {
   self_check =  function(schema, plugin_t, dao, is_update)
     if not plugin_t.use_ec2_iam_role or plugin_t.use_ec2_iam_role == false then
       -- if iam_profile is not set, aws_key and aws_secret are required
-      if not plugin_t.aws_key or not plugin_t.aws_secret then
+      if not plugin_t.aws_key or plugin_t.aws_key == "" or not plugin_t.aws_secret or plugin_t.aws_secret == "" then
         return false, Errors.schema "You need to set aws_key and aws_secret or need to use EC2 IAM roles"
       end
       return true

--- a/kong/plugins/aws-lambda/schema.lua
+++ b/kong/plugins/aws-lambda/schema.lua
@@ -1,3 +1,5 @@
+local Errors = require "kong.dao.errors"
+
 local function check_status(status)
   if status and (status < 100 or status > 999) then
     return false, "unhandled_status must be within 100 - 999."
@@ -20,11 +22,9 @@ return {
     },
     aws_key = {
       type = "string",
-      required = true,
     },
     aws_secret = {
       type = "string",
-      required = true,
     },
     aws_region = {
       type = "string",
@@ -96,5 +96,18 @@ return {
       type = "boolean",
       default = false,
     },
+    use_ec2_iam_role = {
+      type="boolean",
+    },
   },
+  self_check =  function(schema, plugin_t, dao, is_update)
+    if not plugin_t["use_ec2_iam_role"] or plugin_t["use_ec2_iam_role"] == false then
+      -- if iam_profile is not set, aws_key and aws_secret are required
+      if not plugin_t["aws_key"] or not plugin_t["aws_secret"] then
+        return false, Errors.schema "You need to set aws_key and aws_secret or need to use EC2 IAM roles"
+      end
+      return true
+    end
+    return true
+  end
 }

--- a/kong/plugins/aws-lambda/schema.lua
+++ b/kong/plugins/aws-lambda/schema.lua
@@ -101,7 +101,7 @@ return {
     },
   },
   self_check =  function(schema, plugin_t, dao, is_update)
-    if not plugin_t.use_ec2_iam_role or plugin_t.use_ec2_iam_role == false then
+    if not plugin_t.use_ec2_iam_role then
       -- if iam_profile is not set, aws_key and aws_secret are required
       if not plugin_t.aws_key or plugin_t.aws_key == "" or not plugin_t.aws_secret or plugin_t.aws_secret == "" then
         return false, Errors.schema "You need to set aws_key and aws_secret or need to use EC2 IAM roles"

--- a/kong/plugins/aws-lambda/schema.lua
+++ b/kong/plugins/aws-lambda/schema.lua
@@ -26,6 +26,14 @@ return {
     aws_secret = {
       type = "string",
     },
+    proxy_scheme = {
+      type = "string",
+      enum = {
+        "http",
+        "https",
+      }
+    },
+    proxy_url = { type = "string" },
     aws_region = {
       type = "string",
       required = true,
@@ -105,6 +113,13 @@ return {
       -- if iam_profile is not set, aws_key and aws_secret are required
       if not plugin_t.aws_key or plugin_t.aws_key == "" or not plugin_t.aws_secret or plugin_t.aws_secret == "" then
         return false, Errors.schema "You need to set aws_key and aws_secret or need to use EC2 IAM roles"
+      end
+      return true
+    end
+    if plugin_t.proxy_url then
+      -- if iam_profile is not set, aws_key and aws_secret are required
+      if not plugin_t.proxy_scheme then
+        return false, Errors.schema "You need to set proxy_scheme when proxy_url is set"
       end
       return true
     end

--- a/kong/plugins/aws-lambda/v4.lua
+++ b/kong/plugins/aws-lambda/v4.lua
@@ -3,7 +3,8 @@
 
 local resty_sha256 = require "resty.sha256"
 local pl_string = require "pl.stringx"
-local crypto = require "crypto"
+-- local crypto = require "crypto"
+local openssl_hmac = require "openssl.hmac"
 
 local ALGORITHM = "AWS4-HMAC-SHA256"
 
@@ -14,8 +15,10 @@ for i = 0, 255 do
   CHAR_TO_HEX[char] = hex
 end
 
-local function hmac(key, msg)
-  return crypto.hmac.digest("sha256", msg, key, true)
+-- local function hmac(key, msg)
+-- return crypto.hmac.digest("sha256", msg, key, true)
+local function hmac(secret, data)
+  return openssl_hmac.new(secret, "sha256"):final(data)
 end
 
 local function hash(str)

--- a/kong/plugins/ldap-auth-windows/access.lua
+++ b/kong/plugins/ldap-auth-windows/access.lua
@@ -1,0 +1,220 @@
+local responses = require "kong.tools.responses"
+local constants = require "kong.constants"
+local singletons = require "kong.singletons"
+local ldap = require "kong.plugins.ldap-auth-windows.ldap"
+
+local match = string.match
+local lower = string.lower
+local find = string.find
+local sub = string.sub
+local fmt = string.format
+local ngx_log = ngx.log
+local request = ngx.req
+local ngx_error = ngx.ERR
+local ngx_debug = ngx.DEBUG
+local md5 = ngx.md5
+local decode_base64 = ngx.decode_base64
+local ngx_socket_tcp = ngx.socket.tcp
+local ngx_set_header = ngx.req.set_header
+local tostring =  tostring
+
+local AUTHORIZATION = "authorization"
+local PROXY_AUTHORIZATION = "proxy-authorization"
+
+
+local ldap_config_cache = setmetatable({}, { __mode = "k" })
+
+
+local _M = {}
+
+local function retrieve_credentials(authorization_header_value, conf)
+  local username, password
+  if authorization_header_value then
+    local s, e = find(lower(authorization_header_value), "^%s*" .. lower(conf.header_type) .. "%s+")
+    if s == 1 then
+      local cred = sub(authorization_header_value, e + 1)
+      local decoded_cred = decode_base64(cred)
+      username, password = match(decoded_cred, "(.+):(.+)")
+    end
+  end
+  return username, password
+end
+
+local function ldap_authenticate(given_username, given_password, conf)
+  local is_authenticated
+  local err, suppressed_err, ok
+
+  local sock = ngx_socket_tcp()
+  sock:settimeout(conf.timeout)
+  ok, err = sock:connect(conf.ldap_host, conf.ldap_port)
+  if not ok then
+    ngx_log(ngx_error, "[ldap-auth-windows] failed to connect to " .. conf.ldap_host .. ":" .. tostring(conf.ldap_port) .. ": ", err)
+    return nil, err
+  end
+
+  if conf.start_tls then
+    local success, err = ldap.start_tls(sock)
+    if not success then
+      return false, err
+    end
+    local _, err = sock:sslhandshake(true, conf.ldap_host, conf.verify_ldap_host)
+    if err ~= nil then
+      return false, "failed to do SSL handshake with " .. conf.ldap_host .. ":" .. tostring(conf.ldap_port) .. ": " .. err
+    end
+  end
+
+  local who = given_username .. "@" .. conf.ad_domain
+  is_authenticated, err = ldap.bind_request(sock, who, given_password)
+
+  ok, suppressed_err = sock:setkeepalive(conf.keepalive)
+  if not ok then
+    ngx_log(ngx_error, "[ldap-auth-windows] failed to keepalive to " .. conf.ldap_host .. ":" .. tostring(conf.ldap_port) .. ": ", suppressed_err)
+  end
+  return is_authenticated, err
+end
+
+local function load_credential(given_username, given_password, conf)
+  ngx_log(ngx_debug, "[ldap-auth-windows] authenticating user against LDAP server: " .. conf.ldap_host .. ":" .. conf.ldap_port)
+
+  local ok, err = ldap_authenticate(given_username, given_password, conf)
+  if err ~= nil then
+    ngx_log(ngx_error, err)
+  end
+
+  if ok == nil then
+    return nil
+  end
+  if ok == false then
+    return false
+  end
+  return {username = given_username, password = given_password}
+end
+
+
+local function cache_key(conf, username)
+  if not ldap_config_cache[conf] then
+    ldap_config_cache[conf] = md5(fmt("%s:%u:%s:%s:%u",
+      lower(conf.ldap_host),
+      conf.ldap_port,
+      conf.base_dn,
+      conf.attribute,
+      conf.cache_ttl
+    ))
+  end
+
+  return fmt("ldap_auth_cache:%s:%s", ldap_config_cache[conf], username)
+end
+
+
+local function authenticate(conf, given_credentials)
+  local given_username, given_password = retrieve_credentials(given_credentials, conf)
+  if given_username == nil then
+    return false
+  end
+
+  local credential, err = singletons.cache:get(cache_key(conf, given_username), {
+    ttl = conf.cache_ttl,
+    neg_ttl = conf.cache_ttl,
+  }, load_credential, given_username, given_password, conf)
+  if err or credential == nil then
+    return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+  end
+
+  return credential and credential.password == given_password, credential
+end
+
+local function load_consumer(consumer_id, anonymous)
+  local result, err = singletons.db.consumers:select { id = consumer_id }
+  if not result then
+    if anonymous and not err then
+      err = 'anonymous consumer "' .. consumer_id .. '" not found'
+    end
+    return nil, err
+  end
+  return result
+end
+
+local function set_consumer(consumer, credential)
+
+  if consumer then
+    -- this can only be the Anonymous user in this case
+    ngx_set_header(constants.HEADERS.CONSUMER_ID, consumer.id)
+    ngx_set_header(constants.HEADERS.CONSUMER_CUSTOM_ID, consumer.custom_id)
+    ngx_set_header(constants.HEADERS.CONSUMER_USERNAME, consumer.username)
+    ngx_set_header(constants.HEADERS.ANONYMOUS, true)
+    ngx.ctx.authenticated_consumer = consumer
+    return
+  end
+
+  -- here we have been authenticated by ldap
+  ngx_set_header(constants.HEADERS.CREDENTIAL_USERNAME, credential.username)
+  ngx.ctx.authenticated_credential = credential
+
+  -- in case of auth plugins concatenation, remove remnants of anonymous
+  ngx.ctx.authenticated_consumer = nil
+  ngx_set_header(constants.HEADERS.ANONYMOUS, nil)
+  ngx_set_header(constants.HEADERS.CONSUMER_ID, nil)
+  ngx_set_header(constants.HEADERS.CONSUMER_CUSTOM_ID, nil)
+  ngx_set_header(constants.HEADERS.CONSUMER_USERNAME, nil)
+
+end
+
+local function do_authentication(conf)
+  local headers = request.get_headers()
+  local authorization_value = headers[AUTHORIZATION]
+  local proxy_authorization_value = headers[PROXY_AUTHORIZATION]
+
+  -- If both headers are missing, return 401
+  if not (authorization_value or proxy_authorization_value) then
+    ngx.header["WWW-Authenticate"] = 'LDAP realm="kong"'
+    return false, {status = 401}
+  end
+
+  local is_authorized, credential = authenticate(conf, proxy_authorization_value)
+  if not is_authorized then
+    is_authorized, credential = authenticate(conf, authorization_value)
+  end
+
+  if not is_authorized then
+    return false, {status = 403, message = "Invalid authentication credentials"}
+  end
+
+  if conf.hide_credentials then
+    request.clear_header(AUTHORIZATION)
+    request.clear_header(PROXY_AUTHORIZATION)
+  end
+
+  set_consumer(nil, credential)
+
+  return true
+end
+
+
+function _M.execute(conf)
+
+  if ngx.ctx.authenticated_credential and conf.anonymous ~= "" then
+    -- we're already authenticated, and we're configured for using anonymous,
+    -- hence we're in a logical OR between auth methods and we're already done.
+    return
+  end
+
+  local ok, err = do_authentication(conf)
+  if not ok then
+    if conf.anonymous ~= "" then
+      -- get anonymous user
+      local consumer_cache_key = singletons.db.consumers:cache_key(conf.anonymous)
+      local consumer, err      = singletons.cache:get(consumer_cache_key, nil,
+                                                      load_consumer,
+                                                      conf.anonymous, true)
+      if err then
+        responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+      end
+      set_consumer(consumer, nil)
+    else
+      return responses.send(err.status, err.message)
+    end
+  end
+end
+
+
+return _M

--- a/kong/plugins/ldap-auth-windows/asn1.lua
+++ b/kong/plugins/ldap-auth-windows/asn1.lua
@@ -1,0 +1,365 @@
+require "lua_pack"
+
+local bpack = string.pack
+local bunpack = string.unpack
+local math = math
+local bit = bit
+local setmetatable = setmetatable
+local table = table
+local string_reverse = string.reverse
+local string_char = string.char
+
+local _M = {}
+
+_M.BERCLASS = {
+  Universal = 0,
+  Application = 64,
+  ContextSpecific = 128,
+  Private = 192
+}
+
+_M.ASN1Decoder = {
+
+  new = function(self,o)
+    o = o or {}
+    setmetatable(o, self)
+    self.__index = self
+    o:registerBaseDecoders()
+    return o
+  end,
+
+  decode = function(self, encStr, pos)
+    local etype, elen
+    local newpos = pos
+    newpos, etype = bunpack(encStr, "X1", newpos)
+    newpos, elen = self.decodeLength(encStr, newpos)
+    if self.decoder[etype] then
+      return self.decoder[etype](self, encStr, elen, newpos)
+    else
+      return newpos, nil
+    end
+  end,
+
+  setStopOnError = function(self, val)
+    self.stoponerror = val
+  end,
+
+  registerBaseDecoders = function(self)
+    self.decoder = {}
+
+    self.decoder["0A"] = function(self, encStr, elen, pos)
+      return self.decodeInt(encStr, elen, pos)
+    end
+
+    self.decoder["8A"] = function(self, encStr, elen, pos)
+      return bunpack(encStr, "A" .. elen, pos)
+    end
+
+    self.decoder["31"] = function(self, encStr, elen, pos)
+      return pos, nil
+    end
+
+    -- Boolean
+    self.decoder["01"] = function(self, encStr, elen, pos)
+      local val = bunpack(encStr, "X", pos)
+      if val ~= "FF" then
+        return pos, true
+      else
+        return pos, false
+      end
+    end
+
+    -- Integer
+    self.decoder["02"] = function(self, encStr, elen, pos)
+      return self.decodeInt(encStr, elen, pos)
+    end
+
+    -- Octet String
+    self.decoder["04"] = function(self, encStr, elen, pos)
+      return bunpack(encStr, "A" .. elen, pos)
+    end
+
+    -- Null
+    self.decoder["05"] = function(self, encStr, elen, pos)
+      return pos, false
+    end
+
+    -- Object Identifier
+    self.decoder["06"] = function(self, encStr, elen, pos)
+      return self:decodeOID(encStr, elen, pos)
+    end
+
+    -- Context specific tags
+    self.decoder["30"] = function(self, encStr, elen, pos)
+      return self:decodeSeq(encStr, elen, pos)
+    end
+  end,
+
+  registerTagDecoders = function(self, tagDecoders)
+    self:registerBaseDecoders()
+    for k, v in pairs(tagDecoders) do
+      self.decoder[k] = v
+    end
+  end,
+
+  decodeLength = function(encStr, pos)
+    local elen
+    pos, elen = bunpack(encStr, 'C', pos)
+    if elen > 128 then
+      elen = elen - 128
+      local elenCalc = 0
+      local elenNext
+      for i = 1, elen do
+        elenCalc = elenCalc * 256
+        pos, elenNext = bunpack(encStr, 'C', pos)
+        elenCalc = elenCalc + elenNext
+      end
+      elen = elenCalc
+    end
+    return pos, elen
+  end,
+
+  decodeSeq = function(self, encStr, len, pos)
+    local seq = {}
+    local sPos = 1
+    local sStr
+    pos, sStr = bunpack(encStr, "A" .. len, pos)
+    while (sPos < len) do
+      local newSeq
+      sPos, newSeq = self:decode(sStr, sPos)
+      if not newSeq and self.stoponerror then
+        break
+      end
+      table.insert(seq, newSeq)
+    end
+    return pos, seq
+  end,
+
+  decode_oid_component = function(encStr, pos)
+    local octet
+    local n = 0
+
+    repeat
+      pos, octet = bunpack(encStr, "b", pos)
+      n = n * 128 + bit.band(0x7F, octet)
+    until octet < 128
+
+    return pos, n
+  end,
+
+  decodeOID = function(self, encStr, len, pos)
+    local last
+    local oid = {}
+    local octet
+
+    last = pos + len - 1
+    if pos <= last then
+      oid._snmp = '06'
+      pos, octet = bunpack(encStr, "C", pos)
+      oid[2] = math.fmod(octet, 40)
+      octet = octet - oid[2]
+      oid[1] = octet/40
+    end
+
+    while pos <= last do
+      local c
+      pos, c = self.decode_oid_component(encStr, pos)
+      oid[#oid + 1] = c
+    end
+
+    return pos, oid
+  end,
+
+  decodeInt = function(encStr, len, pos)
+    local hexStr
+    pos, hexStr = bunpack(encStr, "X" .. len, pos)
+    local value = tonumber(hexStr, 16)
+    if value >= math.pow(256, len)/2 then
+      value = value - math.pow(256, len)
+    end
+    return pos, value
+  end
+}
+
+_M.ASN1Encoder = {
+
+  new = function(self)
+    local o = {}
+    setmetatable(o, self)
+    self.__index = self
+    o:registerBaseEncoders()
+    return o
+  end,
+
+  encodeSeq = function(self, seqData)
+    return bpack('XAA' , '30', self.encodeLength(#seqData), seqData)
+  end,
+
+  encode = function(self, val)
+    local vtype = type(val)
+
+    if self.encoder[vtype] then
+      return self.encoder[vtype](self,val)
+    end
+  end,
+
+  registerTagEncoders = function(self, tagEncoders)
+    self:registerBaseEncoders()
+    for k, v in pairs(tagEncoders) do
+      self.encoder[k] = v
+    end
+  end,
+
+  registerBaseEncoders = function(self)
+    self.encoder = {}
+
+    self.encoder['table'] = function(self, val)
+      if val._ldap == '0A' then
+        local ival = self.encodeInt(val[1])
+        local len = self.encodeLength(#ival)
+        return bpack('XAA', '0A', len, ival)
+      end
+      if val._ldaptype then
+        local len
+        if val[1] == nil or #val[1] == 0 then
+          return bpack('XC', val._ldaptype, 0)
+        else
+          len = self.encodeLength(#val[1])
+          return bpack('XAA', val._ldaptype, len, val[1])
+        end
+      end
+
+      local encVal = ""
+      for _, v in ipairs(val) do
+        encVal = encVal .. self.encode(v) -- todo: buffer?
+      end
+      local tableType = "\x30"
+      if val["_snmp"] then
+        tableType = bpack("X", val["_snmp"])
+      end
+      return bpack('AAA', tableType, self.encodeLength(#encVal), encVal)
+    end
+
+    -- Boolean encoder
+    self.encoder['boolean'] = function(self, val)
+      if val then
+        return bpack('X','01 01 FF')
+      else
+        return bpack('X', '01 01 00')
+      end
+    end
+
+    -- Integer encoder
+    self.encoder['number'] = function(self, val)
+      local ival = self.encodeInt(val)
+      local len = self.encodeLength(#ival)
+      return bpack('XAA', '02', len, ival)
+    end
+
+    -- Octet String encoder
+    self.encoder['string'] = function(self, val)
+      local len = self.encodeLength(#val)
+      return bpack('XAA', '04', len, val)
+    end
+
+    -- Null encoder
+    self.encoder['nil'] = function(self, val)
+      return bpack('X', '05 00')
+    end
+
+  end,
+
+  encode_oid_component = function(n)
+    local parts = {}
+    --parts[1] = string_char(bit.mod(n, 128))
+    parts[1] = string_char(n % 128)
+    while n >= 128 do
+      n = bit.rshift(n, 7)
+      --parts[#parts + 1] = string_char(bit.mod(n, 128) + 0x80)
+      parts[#parts + 1] = string_char(n % 128  + 0x80)
+    end
+    return string_reverse(table.concat(parts))
+  end,
+
+  encodeInt = function(val)
+    local lsb = 0
+    if val > 0 then
+      local valStr = ""
+      while (val > 0) do
+        lsb = math.fmod(val, 256)
+        valStr = valStr .. bpack('C', lsb)
+        val = math.floor(val/256)
+      end
+      if lsb > 127 then
+        valStr = valStr .. "\0"
+      end
+
+      return string_reverse(valStr)
+    elseif val < 0 then
+      local i = 1
+      local tcval = val + 256
+      while tcval <= 127 do
+        tcval = tcval + (math.pow(256, i) * 255)
+        i = i+1
+      end
+      local valStr = ""
+      while (tcval > 0) do
+        lsb = math.fmod(tcval, 256)
+        valStr = valStr .. bpack("C", lsb)
+        tcval = math.floor(tcval/256)
+      end
+      return string_reverse(valStr)
+    else -- val == 0
+      return bpack("x")
+    end
+  end,
+
+  encodeLength = function(len)
+    if len < 128 then
+      return string_char(len)
+    else
+      local parts = {}
+
+      while len > 0 do
+        --parts[#parts + 1] = string_char(bit.mod(len, 256))
+        parts[#parts + 1] = string_char(len % 256)
+        len = bit.rshift(len, 8)
+      end
+
+      return string_char(#parts + 0x80) .. string_reverse(table.concat(parts))
+    end
+  end
+}
+
+function _M.BERtoInt(class, constructed, number)
+  local asn1_type = class + number
+
+  if constructed == true then
+    asn1_type = asn1_type + 32
+  end
+
+  return asn1_type
+end
+
+function _M.intToBER(i)
+  local ber = {}
+  if bit.band(i, _M.BERCLASS.Application) == _M.BERCLASS.Application then
+    ber.class = _M.BERCLASS.Application
+  elseif bit.band(i, _M.BERCLASS.ContextSpecific) == _M.BERCLASS.ContextSpecific then
+    ber.class = _M.BERCLASS.ContextSpecific
+  elseif bit.band(i, _M.BERCLASS.Private) == _M.BERCLASS.Private then
+    ber.class = _M.BERCLASS.Private
+  else
+    ber.class = _M.BERCLASS.Universal
+  end
+  if bit.band(i, 32) == 32 then
+    ber.constructed = true
+    ber.number = i - ber.class - 32
+  else
+    ber.primitive = true
+    ber.number = i - ber.class
+  end
+  return ber
+end
+
+return _M

--- a/kong/plugins/ldap-auth-windows/handler.lua
+++ b/kong/plugins/ldap-auth-windows/handler.lua
@@ -1,0 +1,18 @@
+local access = require "kong.plugins.ldap-auth-windows.access"
+local BasePlugin = require "kong.plugins.base_plugin"
+
+local LdapAuthHandler = BasePlugin:extend()
+
+function LdapAuthHandler:new()
+  LdapAuthHandler.super.new(self, "ldap-auth-windows")
+end
+
+function LdapAuthHandler:access(conf)
+  LdapAuthHandler.super.access(self)
+  access.execute(conf)
+end
+
+LdapAuthHandler.PRIORITY = 1002
+LdapAuthHandler.VERSION = "0.1.0"
+
+return LdapAuthHandler

--- a/kong/plugins/ldap-auth-windows/ldap.lua
+++ b/kong/plugins/ldap-auth-windows/ldap.lua
@@ -1,0 +1,144 @@
+local asn1 = require "kong.plugins.ldap-auth-windows.asn1"
+local bunpack = string.unpack
+
+local string_format = string.format
+
+local _M = {}
+
+local ldapMessageId = 1
+
+local ERROR_MSG = {
+  [1]  = "Initialization of LDAP library failed.",
+  [4]  = "Size limit exceeded.",
+  [13] = "Confidentiality required",
+  [32] = "No such object",
+  [34] = "Invalid DN",
+  [49] = "The supplied credential is invalid."
+}
+
+local APPNO = {
+  BindRequest = 0,
+  BindResponse = 1,
+  UnbindRequest = 2,
+  ExtendedRequest = 23,
+  ExtendedResponse = 24
+}
+
+local function encodeLDAPOp(encoder, appno, isConstructed, data)
+  local asn1_type = asn1.BERtoInt(asn1.BERCLASS.Application, isConstructed, appno)
+  return encoder:encode({ _ldaptype = string_format("%X", asn1_type), data })
+end
+
+local function claculate_payload_length(encStr, pos, socket)
+  local elen
+  pos, elen = bunpack(encStr, 'C', pos)
+  if elen > 128 then
+    elen = elen - 128
+    local elenCalc = 0
+    local elenNext
+    for i = 1, elen do
+      elenCalc = elenCalc * 256
+      encStr = encStr .. socket:receive(1)
+      pos, elenNext = bunpack(encStr, 'C', pos)
+      elenCalc = elenCalc + elenNext
+    end
+    elen = elenCalc
+  end
+  return pos, elen
+end
+
+function _M.bind_request(socket, username, password)
+  local encoder = asn1.ASN1Encoder:new()
+  local decoder = asn1.ASN1Decoder:new()
+
+  local ldapAuth = encoder:encode({ _ldaptype = 80, password })
+  local bindReq = encoder:encode(3) .. encoder:encode(username) .. ldapAuth
+  local ldapMsg = encoder:encode(ldapMessageId) .. encodeLDAPOp(encoder, APPNO.BindRequest, true, bindReq)
+  local packet
+  local pos, packet_len, tmp, _
+  local response = {}
+
+  packet = encoder:encodeSeq(ldapMsg)
+  ldapMessageId = ldapMessageId +1
+  socket:send(packet)
+  packet = socket:receive(2)
+  _, packet_len = claculate_payload_length(packet, 2, socket)
+
+  packet = socket:receive(packet_len)
+  pos, response.messageID = decoder:decode(packet, 1)
+  pos, tmp = bunpack(packet, "C", pos)
+  pos = decoder.decodeLength(packet, pos)
+  response.protocolOp = asn1.intToBER(tmp)
+
+  if response.protocolOp.number ~= APPNO.BindResponse then
+    return false, string_format("Received incorrect Op in packet: %d, expected %d", response.protocolOp.number, APPNO.BindResponse)
+  end
+
+  pos, response.resultCode = decoder:decode(packet, pos)
+
+  if response.resultCode ~= 0 then
+    local error_msg
+    pos, response.matchedDN = decoder:decode(packet, pos)
+    _, response.errorMessage = decoder:decode(packet, pos)
+    error_msg = ERROR_MSG[response.resultCode]
+    return false, string_format("\n  Error: %s\n  Details: %s",
+      error_msg or "Unknown error occurred (code: " .. response.resultCode ..
+      ")", response.errorMessage or "")
+  else
+    return true
+  end
+end
+
+
+function _M.unbind_request(socket)
+  local ldapMsg, packet
+  local encoder = asn1.ASN1Encoder:new()
+
+  ldapMessageId = ldapMessageId +1
+  ldapMsg = encoder:encode(ldapMessageId) .. encodeLDAPOp(encoder, APPNO.UnbindRequest, false, nil)
+  packet = encoder:encodeSeq(ldapMsg)
+  socket:send(packet)
+  return true, ""
+end
+
+function _M.start_tls(socket)
+
+  local ldapMsg, pos, packet, packet_len, tmp, _
+  local response = {}
+  local encoder = asn1.ASN1Encoder:new()
+  local decoder = asn1.ASN1Decoder:new()
+
+  local method_name = encoder:encode({_ldaptype = 80, "1.3.6.1.4.1.1466.20037"})
+  ldapMessageId = ldapMessageId +1
+  ldapMsg = encoder:encode(ldapMessageId) .. encodeLDAPOp(encoder, APPNO.ExtendedRequest, true, method_name)
+  packet = encoder:encodeSeq(ldapMsg)
+  socket:send(packet)
+  packet = socket:receive(2)
+  _, packet_len = claculate_payload_length(packet, 2, socket)
+
+  packet = socket:receive(packet_len)
+  pos, response.messageID = decoder:decode(packet, 1)
+  pos, tmp = bunpack(packet, "C", pos)
+  pos = decoder.decodeLength(packet, pos)
+  response.protocolOp = asn1.intToBER(tmp)
+
+  if response.protocolOp.number ~= APPNO.ExtendedResponse then
+    return false, string_format("Received incorrect Op in packet: %d, expected %d", response.protocolOp.number, APPNO.ExtendedResponse)
+  end
+
+  pos, response.resultCode = decoder:decode(packet, pos)
+
+  if response.resultCode ~= 0 then
+    local error_msg
+    pos, response.matchedDN = decoder:decode(packet, pos)
+    _, response.errorMessage = decoder:decode(packet, pos)
+    error_msg = ERROR_MSG[response.resultCode]
+    return false, string_format("\n  Error: %s\n  Details: %s",
+      error_msg or "Unknown error occurred (code: " .. response.resultCode ..
+      ")", response.errorMessage or "")
+  else
+    return true
+  end
+end
+
+return _M;

--- a/kong/plugins/ldap-auth-windows/migrations/cassandra.lua
+++ b/kong/plugins/ldap-auth-windows/migrations/cassandra.lua
@@ -1,0 +1,23 @@
+local plugin_config_iterator = require("kong.dao.migrations.helpers").plugin_config_iterator
+local schema = require("kong.plugins.ldap-auth-windows.schema")
+
+return {
+  {
+    name = "2018-07-25-150900_header_type_default",
+    up = function(_, _, dao)
+      for ok, config, update in plugin_config_iterator(dao, "ldap-auth-windows") do
+        if not ok then
+          return config
+        end
+        if config.header_type == nil then
+          config.header_type = schema.fields.header_type.default
+          local _, err = update(config)
+          if err then
+            return err
+          end
+        end
+      end
+    end,
+    down = function(_, _, dao) end  -- not implemented
+  },
+}

--- a/kong/plugins/ldap-auth-windows/migrations/postgres.lua
+++ b/kong/plugins/ldap-auth-windows/migrations/postgres.lua
@@ -1,0 +1,23 @@
+local plugin_config_iterator = require("kong.dao.migrations.helpers").plugin_config_iterator
+local schema = require("kong.plugins.ldap-auth-windows.schema")
+
+return {
+  {
+    name = "2018-07-25-150900_header_type_default",
+    up = function(_, _, dao)
+      for ok, config, update in plugin_config_iterator(dao, "ldap-auth-windows") do
+        if not ok then
+          return config
+        end
+        if config.header_type == nil then
+          config.header_type = schema.fields.header_type.default
+          local _, err = update(config)
+          if err then
+            return err
+          end
+        end
+      end
+    end,
+    down = function(_, _, dao) end  -- not implemented
+  },
+}

--- a/kong/plugins/ldap-auth-windows/schema.lua
+++ b/kong/plugins/ldap-auth-windows/schema.lua
@@ -1,0 +1,28 @@
+local utils = require "kong.tools.utils"
+
+local function check_user(anonymous)
+  if anonymous == "" or utils.is_valid_uuid(anonymous) then
+    return true
+  end
+
+  return false, "the anonymous user must be empty or a valid uuid"
+end
+
+-- If you add more configuration parameters, be sure to check if it needs to be added to cache key
+
+return {
+  no_consumer = true,
+  fields = {
+    ldap_host = {required = true, type = "string"},                          -- used for cache key
+    ldap_port = {required = true, type = "number"},                          -- used for cache key
+    start_tls = {required = true, type = "boolean", default = false},
+    verify_ldap_host = {required = true, type = "boolean", default = false},
+    cache_ttl = {required = true, type = "number", default = 60},            -- used for cache key
+    hide_credentials = {type = "boolean", default = true},
+    timeout = {type = "number", default = 10000},
+    keepalive = {type = "number", default = 60000},
+    anonymous = {type = "string", default = "", func = check_user},
+    header_type = {type = "string", default = "Basic"},
+    ad_domain = {required = true, type= "string" }
+  }
+}

--- a/spec/03-plugins/23-aws-lambda/02-schema_spec.lua
+++ b/spec/03-plugins/23-aws-lambda/02-schema_spec.lua
@@ -16,11 +16,6 @@ describe("Plugin: AWS Lambda (schema)", function()
     port  = 443,
   }
 
-  local DEFAULTS_IAM_ROLE_AUTH = {
-    function_name = DEFAULTS.function_name,
-    aws_region = DEFAULTS.aws_region
-  }
-
   it("accepts nil Unhandled Response Status Code", function()
     local entity = utils.table_merge(DEFAULTS, { unhandled_status = nil })
     local ok, err = validate_entity(entity, aws_lambda_schema)
@@ -50,28 +45,37 @@ describe("Plugin: AWS Lambda (schema)", function()
   end)
 
   it("errors with no aws_key and use_ec2_iam_role set to false", function()
-    local entity = utils.table_merge(DEFAULTS_IAM_ROLE_AUTH, { aws_key = "" })
+    local entity = utils.table_merge(DEFAULTS, { aws_key = "" })
     local ok, err, self_err = validate_entity(entity, aws_lambda_schema)
+    assert.is_nil(err)
     assert.equal("You need to set aws_key and aws_secret or need to use EC2 IAM roles", self_err.message)
     assert.False(ok)
   end)
 
   it("errors with empty aws_secret and use_ec2_iam_role set to false", function()
-    local entity = utils.table_merge(DEFAULTS_IAM_ROLE_AUTH, { aws_secret = "" })
+    local entity = utils.table_merge(DEFAULTS, { aws_secret = "" })
     local ok, err, self_err = validate_entity(entity, aws_lambda_schema)
+    assert.is_nil(err)
     assert.equal("You need to set aws_key and aws_secret or need to use EC2 IAM roles", self_err.message)
     assert.False(ok)
   end)
 
   it("errors with empty aws_secret or aws_key and use_ec2_iam_role set to false", function()
-    local ok, err, self_err = validate_entity(DEFAULTS_IAM_ROLE_AUTH, aws_lambda_schema)
+    local entity = utils.table_merge(DEFAULTS, {})
+    entity.aws_key = nil
+    entity.aws_secret = nil
+    local ok, err, self_err = validate_entity(entity, aws_lambda_schema)
+    assert.is_nil(err)
     assert.equal("You need to set aws_key and aws_secret or need to use EC2 IAM roles", self_err.message)
     assert.False(ok)
   end)
 
   it("ok if aws_key or aws_secret is missing but use_ec2_iam_role is set to true", function()
-    local entity = utils.table_merge(DEFAULTS_IAM_ROLE_AUTH, { use_ec2_iam_role = true })
-    local ok, err= validate_entity(entity, aws_lambda_schema)
+    local entity = utils.table_merge(DEFAULTS, { use_ec2_iam_role = true })
+    entity.aws_key = nil
+    entity.aws_secret = nil
+    local ok, err = validate_entity(entity, aws_lambda_schema)
+    assert.is_nil(err)
     assert.True(ok)
   end)
 

--- a/spec/03-plugins/23-aws-lambda/02-schema_spec.lua
+++ b/spec/03-plugins/23-aws-lambda/02-schema_spec.lua
@@ -16,6 +16,11 @@ describe("Plugin: AWS Lambda (schema)", function()
     port  = 443,
   }
 
+  local DEFAULTS_IAM_ROLE_AUTH = {
+    function_name = DEFAULTS.function_name,
+    aws_region = DEFAULTS.aws_region
+  }
+
   it("accepts nil Unhandled Response Status Code", function()
     local entity = utils.table_merge(DEFAULTS, { unhandled_status = nil })
     local ok, err = validate_entity(entity, aws_lambda_schema)
@@ -43,4 +48,31 @@ describe("Plugin: AWS Lambda (schema)", function()
     assert.equal("unhandled_status must be within 100 - 999.", err.unhandled_status)
     assert.False(ok)
   end)
+
+  it("errors with no aws_key and use_ec2_iam_role set to false", function()
+    local entity = utils.table_merge(DEFAULTS_IAM_ROLE_AUTH, { aws_key = "" })
+    local ok, err, self_err = validate_entity(entity, aws_lambda_schema)
+    assert.equal("You need to set aws_key and aws_secret or need to use EC2 IAM roles", self_err.message)
+    assert.False(ok)
+  end)
+
+  it("errors with empty aws_secret and use_ec2_iam_role set to false", function()
+    local entity = utils.table_merge(DEFAULTS_IAM_ROLE_AUTH, { aws_secret = "" })
+    local ok, err, self_err = validate_entity(entity, aws_lambda_schema)
+    assert.equal("You need to set aws_key and aws_secret or need to use EC2 IAM roles", self_err.message)
+    assert.False(ok)
+  end)
+
+  it("errors with empty aws_secret or aws_key and use_ec2_iam_role set to false", function()
+    local ok, err, self_err = validate_entity(DEFAULTS_IAM_ROLE_AUTH, aws_lambda_schema)
+    assert.equal("You need to set aws_key and aws_secret or need to use EC2 IAM roles", self_err.message)
+    assert.False(ok)
+  end)
+
+  it("ok if aws_key or aws_secret is missing but use_ec2_iam_role is set to true", function()
+    local entity = utils.table_merge(DEFAULTS_IAM_ROLE_AUTH, { use_ec2_iam_role = true })
+    local ok, err= validate_entity(entity, aws_lambda_schema)
+    assert.True(ok)
+  end)
+
 end)

--- a/spec/03-plugins/23-aws-lambda/03-get-iam-role-credentials_spec.lua
+++ b/spec/03-plugins/23-aws-lambda/03-get-iam-role-credentials_spec.lua
@@ -13,9 +13,18 @@ describe("Plugin: aws-lambda", function()
     end)
 
     describe("IAM Metadata service", function()
-        it("should fetch credentials from metadata service", function()
-            local iam_role_credentials = get_credentials_from_iam_role('127.0.0.1', 9999)
+        it("should return error if metadata service is not running on provided endpoint", function()
+            local iam_role_credentials, err = get_credentials_from_iam_role('192.0.2.0', 1234)
 
+            assert.is_nil(iam_role_credentials)
+            assert.is_not_nil(err)
+            assert.equal("timeout", err)
+        end)
+
+        it("should fetch credentials from metadata service", function()
+            local iam_role_credentials, err = get_credentials_from_iam_role('127.0.0.1', 9999)
+
+            assert.is_nil(err)
             assert.equal("test_iam_access_key_id", iam_role_credentials.access_key)
             assert.equal("test_iam_secret_access_key", iam_role_credentials.secret_key)
             assert.equal("test_session_token", iam_role_credentials.session_token)

--- a/spec/03-plugins/23-aws-lambda/03-get-iam-role-credentials_spec.lua
+++ b/spec/03-plugins/23-aws-lambda/03-get-iam-role-credentials_spec.lua
@@ -1,33 +1,31 @@
 local helpers = require "spec.helpers"
 local get_credentials_from_iam_role = require "kong.plugins.aws-lambda.iam-role-credentials"
 
-describe("Plugin: aws-lambda", function()
-    setup(function()
-        assert(helpers.start_kong{
-            nginx_conf = "spec/fixtures/custom_nginx.template",
-        })
-    end)
+describe("Plugin: AWS Lambda (metadata service credentials)", function()
+  setup(function()
+    assert(helpers.start_kong {
+      nginx_conf = "spec/fixtures/custom_nginx.template",
+    })
+  end)
 
-    teardown(function()
-        helpers.stop_kong()
-    end)
+  teardown(function()
+    helpers.stop_kong()
+  end)
 
-    describe("IAM Metadata service", function()
-        it("should return error if metadata service is not running on provided endpoint", function()
-            local iam_role_credentials, err = get_credentials_from_iam_role('192.0.2.0', 1234)
+  it("should return error if metadata service is not running on provided endpoint", function()
+    local iam_role_credentials, err = get_credentials_from_iam_role('192.0.2.0', 1234)
 
-            assert.is_nil(iam_role_credentials)
-            assert.is_not_nil(err)
-            assert.equal("timeout", err)
-        end)
+    assert.is_nil(iam_role_credentials)
+    assert.is_not_nil(err)
+    assert.equal("timeout", err)
+  end)
 
-        it("should fetch credentials from metadata service", function()
-            local iam_role_credentials, err = get_credentials_from_iam_role('127.0.0.1', 9999)
+  it("should fetch credentials from metadata service", function()
+    local iam_role_credentials, err = get_credentials_from_iam_role('127.0.0.1', 9999)
 
-            assert.is_nil(err)
-            assert.equal("test_iam_access_key_id", iam_role_credentials.access_key)
-            assert.equal("test_iam_secret_access_key", iam_role_credentials.secret_key)
-            assert.equal("test_session_token", iam_role_credentials.session_token)
-        end)
-    end)
+    assert.is_nil(err)
+    assert.equal("test_iam_access_key_id", iam_role_credentials.access_key)
+    assert.equal("test_iam_secret_access_key", iam_role_credentials.secret_key)
+    assert.equal("test_session_token", iam_role_credentials.session_token)
+  end)
 end)

--- a/spec/03-plugins/23-aws-lambda/03-get-iam-role-credentials_spec.lua
+++ b/spec/03-plugins/23-aws-lambda/03-get-iam-role-credentials_spec.lua
@@ -21,7 +21,7 @@ describe("Plugin: AWS Lambda (metadata service credentials)", function()
   end)
 
   it("should fetch credentials from metadata service", function()
-    local iam_role_credentials, err = get_credentials_from_iam_role('127.0.0.1', 9999, 200, 0)
+    local iam_role_credentials, err = get_credentials_from_iam_role('127.0.0.1', 55555, 200, 0)
 
     assert.is_nil(err)
     assert.equal("test_iam_access_key_id", iam_role_credentials.access_key)

--- a/spec/03-plugins/23-aws-lambda/03-get-iam-role-credentials_spec.lua
+++ b/spec/03-plugins/23-aws-lambda/03-get-iam-role-credentials_spec.lua
@@ -13,7 +13,7 @@ describe("Plugin: AWS Lambda (metadata service credentials)", function()
   end)
 
   it("should return error if metadata service is not running on provided endpoint", function()
-    local iam_role_credentials, err = get_credentials_from_iam_role('192.0.2.0', 1234)
+    local iam_role_credentials, err = get_credentials_from_iam_role('192.0.2.0', 1234, 200, 0)
 
     assert.is_nil(iam_role_credentials)
     assert.is_not_nil(err)
@@ -21,7 +21,7 @@ describe("Plugin: AWS Lambda (metadata service credentials)", function()
   end)
 
   it("should fetch credentials from metadata service", function()
-    local iam_role_credentials, err = get_credentials_from_iam_role('127.0.0.1', 9999)
+    local iam_role_credentials, err = get_credentials_from_iam_role('127.0.0.1', 9999, 200, 0)
 
     assert.is_nil(err)
     assert.equal("test_iam_access_key_id", iam_role_credentials.access_key)

--- a/spec/03-plugins/23-aws-lambda/03-get-iam-role-credentials_spec.lua
+++ b/spec/03-plugins/23-aws-lambda/03-get-iam-role-credentials_spec.lua
@@ -1,0 +1,24 @@
+local helpers = require "spec.helpers"
+local get_credentials_from_iam_role = require "kong.plugins.aws-lambda.iam-role-credentials"
+
+describe("Plugin: aws-lambda", function()
+    setup(function()
+        assert(helpers.start_kong{
+            nginx_conf = "spec/fixtures/custom_nginx.template",
+        })
+    end)
+
+    teardown(function()
+        helpers.stop_kong()
+    end)
+
+    describe("IAM Metadata service", function()
+        it("should fetch credentials from metadata service", function()
+            local iam_role_credentials = get_credentials_from_iam_role('127.0.0.1', 9999)
+
+            assert.equal("test_iam_access_key_id", iam_role_credentials.access_key)
+            assert.equal("test_iam_secret_access_key", iam_role_credentials.secret_key)
+            assert.equal("test_session_token", iam_role_credentials.session_token)
+        end)
+    end)
+end)

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -394,7 +394,7 @@ http {
                     AccessKeyId = "test_iam_access_key_id",
                     SecretAccessKey ="test_iam_secret_access_key",
                     Token = "test_session_token"
-                 }
+                }
                 local IAM_ROLE_TEMPORARY_CREDS_TXT = require("cjson").encode(IAM_ROLE_TEMPORARY_CREDS)
 
                 ngx.status = 200

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -374,5 +374,35 @@ http {
                 end
             }
         }
+
+        location = "/latest/meta-data/iam/security-credentials/" {
+            content_by_lua_block {
+                local IAM_ROLE_NAME = 'testrole'
+                ngx.header["Content-Length"] = #IAM_ROLE_NAME
+                ngx.header["Content-Type"] = "text/plain"
+                ngx.status = 200
+                ngx.say(IAM_ROLE_NAME)
+                ngx.exit(0)
+            }
+        }
+
+        location = "/latest/meta-data/iam/security-credentials/testrole" {
+            content_by_lua_block {
+                local IAM_ROLE_TEMPORARY_CREDS = {
+                    Code = "Success",
+                    Type = "AWS-HMAC",
+                    AccessKeyId = "test_iam_access_key_id",
+                    SecretAccessKey ="test_iam_secret_access_key",
+                    Token = "test_session_token"
+                 }
+                local IAM_ROLE_TEMPORARY_CREDS_TXT = require("cjson").encode(IAM_ROLE_TEMPORARY_CREDS)
+
+                ngx.status = 200
+                ngx.header["Content-Length"] = #IAM_ROLE_TEMPORARY_CREDS_TXT
+                ngx.header["Content-Type"] = "text/plain"
+                ngx.say(IAM_ROLE_TEMPORARY_CREDS_TXT)
+                ngx.exit(0)
+           }
+        }
     }
 }


### PR DESCRIPTION


### Summary

Created a new plugin "ldap-auth-windows" based on ldap-auth base plugin. This plugin allows to bind against windows AD using UserPrincipalName.

### Full changelog

Added new field in schema.lua to configure windows domain to authenticate against
Updated access.lua to create UserPrincipalName using given_username@ad_domain
Updated Migrations/postgres.lua to create a new name
Updated Migrations/cassandra.lua to create a new name
