### PR TITLE
Fix (JWT) allow int custom_id in JWT plugin

### DIFF
--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -62,7 +62,7 @@ function JwtHandler:new()
 end
 
 local function load_credential(jwt_secret_key)
-  local rows, err = singletons.dao.jwt_secrets:find_all {key = jwt_secret_key}
+  local rows, err = singletons.dao.jwt_secrets:find_all {key = tostring(jwt_secret_key)}
   if err then
     return nil, err
   end


### PR DESCRIPTION
Kong requests fail when an int custom_id parameter is set in the JWT claims. The schema for jwt_secrets table defines the key as a string, but there is no type check or stringification before querying the datastore for a JWT secret. As a result, when the custom_id claim is an integer instead of a string, the query generated by DAO fails with a type inconsistency error. The fix just makes sure, that the value passed to the query is a string before executing.