### PR TITLE
feat: configurable phase handlers

### DIFF
--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -35,6 +35,14 @@ local DYNAMIC_KEY_PREFIXES = {
   ["nginx_admin_directives"] = "nginx_admin_",
 }
 
+local KONG_PHASE_HANDLERS = {
+  "rewrite",
+  "access",
+  "header_filter",
+  "body_filter",
+  "log",
+}
+
 local PREFIX_PATHS = {
   nginx_pid = {"pids", "nginx.pid"},
   nginx_err_logs = {"logs", "error.log"},
@@ -134,6 +142,8 @@ local CONF_INFERENCES = {
 
   lua_ssl_verify_depth = {typ = "number"},
   lua_socket_pool_size = {typ = "number"},
+
+  phase_handlers = {typ = "array"}
 }
 
 -- List of settings whose values must not be printed when
@@ -340,6 +350,13 @@ local function check_and_infer(conf)
       errors[#errors+1] = "trusted_ips must be a comma separated list in "..
                           "the form of IPv4 or IPv6 address or CIDR "..
                           "block or 'unix:', got '" .. address .. "'"
+    end
+  end
+
+  -- validate phase handlers
+  for _, phase in ipairs(conf.phase_handlers) do
+    if not tablex.find(KONG_PHASE_HANDLERS, phase) then
+      errors[#errors + 1] = "'" .. phase .. "' is not a valid phase handler"
     end
   end
 

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -76,4 +76,6 @@ lua_ssl_trusted_certificate = NONE
 lua_ssl_verify_depth = 1
 lua_package_path = ./?.lua;./?/init.lua;
 lua_package_cpath = NONE
+
+phase_handlers = rewrite,access,header_filter,body_filter,log
 ]]

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -126,14 +126,12 @@ server {
         set $upstream_x_forwarded_host   '';
         set $upstream_x_forwarded_port   '';
 
-        rewrite_by_lua_block {
-            Kong.rewrite()
+> for _, phase in ipairs(phase_handlers) do
+        $(phase)_by_lua_block {
+            Kong.$(phase)()
         }
 
-        access_by_lua_block {
-            Kong.access()
-        }
-
+> end
         proxy_http_version 1.1;
         proxy_set_header   Host              $upstream_host;
         proxy_set_header   Upgrade           $upstream_upgrade;
@@ -147,18 +145,6 @@ server {
         proxy_pass_header  Date;
         proxy_ssl_name     $upstream_host;
         proxy_pass         $upstream_scheme://kong_upstream$upstream_uri;
-
-        header_filter_by_lua_block {
-            Kong.header_filter()
-        }
-
-        body_filter_by_lua_block {
-            Kong.body_filter()
-        }
-
-        log_by_lua_block {
-            Kong.log()
-        }
     }
 
     location = /kong_error_handler {

--- a/spec/01-unit/002-conf_loader_spec.lua
+++ b/spec/01-unit/002-conf_loader_spec.lua
@@ -293,6 +293,29 @@ describe("Configuration loader", function()
     end)
   end)
 
+  describe("phase_handlers", function()
+    it("accepts the default phase handlers", function()
+      local conf = assert(conf_loader(helpers.test_conf_path))
+      assert.is_table(conf.phase_handlers)
+    end)
+    it("ignores an undefined default phase handler", function()
+      local ignored_phase = "rewrite"
+      local conf = assert(conf_loader(helpers.test_conf_path, {
+        phase_handlers = { "access", "header_filter", "body_filter", "log" },
+      }))
+      for _, phase in ipairs(conf.phase_handlers) do
+        assert.not_equals(phase, ignored_phase)
+      end
+    end)
+    it("errors when given an unknown phase", function()
+      local conf, err = conf_loader(helpers.test_conf_path, {
+        phase_handlers = { "nope" },
+      })
+      assert.is_nil(conf)
+      assert.equal("'nope' is not a valid phase handler", err)
+    end)
+  end)
+
   describe("nginx_user", function()
     it("is nil by default", function()
       local conf = assert(conf_loader(helpers.test_conf_path))


### PR DESCRIPTION
This commit provides a Kong config option to enable/disable
various phase handlers. This behavior can result in substantial
performance gains when use to ignore certain phase handlers in which
no substantial work is done by Kong, but various core behavior such
as the plugins iterator result in CPU cycles spent on a nop behavior.


* Implement a loop generator to write configured phase handlers into
  the generated Nginx config
* Test relevant conf_loader behaviors