### PR TITLE
feat(basic-auth) don't trim whitespace from basic-auth passwords

### DIFF
--- a/kong/dao/schemas_validation.lua
+++ b/kong/dao/schemas_validation.lua
@@ -127,7 +127,9 @@ function _M.validate_entity(tbl, schema, options)
           local is_valid_type
           -- ALIASES: number, timestamp, boolean and array can be passed as strings and will be converted
           if type(t[column]) == "string" then
-            t[column] = utils.strip(t[column])
+            if schema.fields[column].trim_whitespace ~= false then
+              t[column] = utils.strip(t[column])
+            end
             if v.type == "boolean" then
               local bool = t[column]:lower()
               is_valid_type = bool == "true" or bool == "false"

--- a/kong/plugins/basic-auth/daos.lua
+++ b/kong/plugins/basic-auth/daos.lua
@@ -25,7 +25,7 @@ local SCHEMA = {
     created_at = {type = "timestamp", immutable = true, dao_insert_value = true},
     consumer_id = {type = "id", required = true, foreign = "consumers:id"},
     username = {type = "string", required = true, unique = true },
-    password = {type = "string", func = encrypt_password}
+    password = {type = "string", func = encrypt_password, trim_whitespace = false}
   },
 }
 

--- a/spec/01-unit/006-schema_validation_spec.lua
+++ b/spec/01-unit/006-schema_validation_spec.lua
@@ -82,7 +82,7 @@ describe("Schemas", function()
 
         local values = {string = " kong "}
 
-        local valid, err = validate_entity(values, trimSchema)
+        local valid, err = validate_entity(values, trim_schema)
         assert.True(valid)
         assert.falsy(err)
         assert.are.same("kong", values.string)
@@ -96,7 +96,7 @@ describe("Schemas", function()
 
         local values = {string = " kong "}
 
-        local valid, err = validate_entity(values, notrimSchema)
+        local valid, err = validate_entity(values, notrim_schema)
         assert.True(valid)
         assert.falsy(err)
         assert.are.same(" kong ", values.string)

--- a/spec/01-unit/006-schema_validation_spec.lua
+++ b/spec/01-unit/006-schema_validation_spec.lua
@@ -64,6 +64,45 @@ describe("Schemas", function()
       end)
     end)
 
+    describe("[string]", function()
+      it("should trim whitespace from value with no trim_whitespace property set", function()
+        local values = {string = " kong "}
+
+        local valid, err = validate_entity(values, schema)
+        assert.True(valid)
+        assert.falsy(err)
+        assert.are.same("kong", values.string)
+      end)
+      it("should trim whitespace from value with trim_whitespace = true", function()
+        local trim_schema = {
+          fields = {
+            string = { type = "string", trim_whitespace = true},
+          }
+        }
+
+        local values = {string = " kong "}
+
+        local valid, err = validate_entity(values, trimSchema)
+        assert.True(valid)
+        assert.falsy(err)
+        assert.are.same("kong", values.string)
+      end)
+      it("should not trim whitespace from value with trim_whitespace = false", function()
+        local notrim_schema = {
+          fields = {
+            string = { type = "string", trim_whitespace = false},
+          }
+        }
+
+        local values = {string = " kong "}
+
+        local valid, err = validate_entity(values, notrimSchema)
+        assert.True(valid)
+        assert.falsy(err)
+        assert.are.same(" kong ", values.string)
+      end)
+    end)
+
     describe("[type]", function()
       --[]
       it("should validate the type of a property if it has a type field", function()

--- a/spec/03-plugins/11-basic-auth/02-api_spec.lua
+++ b/spec/03-plugins/11-basic-auth/02-api_spec.lua
@@ -77,6 +77,30 @@ for _, strategy in helpers.each_strategy() do
           }
           assert.equal(hash, json.password)
         end)
+        it("encrypts the password without trimming whitespace", function()
+          local res = assert(admin_client:send {
+            method  = "POST",
+            path    = "/consumers/bob/basic-auth",
+            body    = {
+              username = "bob",
+              password = " kong "
+            },
+            headers = {
+              ["Content-Type"] = "application/json"
+            }
+          })
+          local body = assert.res_status(201, res)
+          local json = cjson.decode(body)
+          assert.is_string(json.password)
+          assert.not_equal(" kong ", json.password)
+
+          local crypto = require "kong.plugins.basic-auth.crypto"
+          local hash   = crypto.encrypt {
+            consumer_id = consumer.id,
+            password    = " kong "
+          }
+          assert.equal(hash, json.password)
+        end)
         describe("errors", function()
           it("returns bad request", function()
             local res = assert(admin_client:send {


### PR DESCRIPTION
* adding option to basic-auth schema to disable trimming whitespace from
password.
* adding test

fix #3595 
