### PR TITLE
feat(db) add operation to truncate single table in new DAO

### DIFF
--- a/kong/dao/factory.lua
+++ b/kong/dao/factory.lua
@@ -168,8 +168,7 @@ local function create_legacy_wrappers(self, constraints)
 
       truncate = function(_)
         log.debug(debug.traceback("[legacy wrapper] using legacy wrapper"))
-        log.err("[legacy wrapper] truncate not implemented")
-        return nil
+        return new_dao:truncate()
       end,
     }
   end

--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -222,6 +222,11 @@ function _M.new(db, schema, strategy, errors)
 end
 
 
+function DAO:truncate()
+  return self.strategy:truncate()
+end
+
+
 function DAO:select(primary_key)
   if type(primary_key) ~= "table" then
     error("primary_key must be a table", 2)

--- a/kong/db/init.lua
+++ b/kong/db/init.lua
@@ -158,8 +158,18 @@ function DB:reset()
 end
 
 
-function DB:truncate()
-  local ok, err = self.connector:truncate()
+function DB:truncate(table_name)
+  if table_name ~= nil and type(table_name) ~= "string" then
+    error("table_name must be a string", 2)
+  end
+  local ok, err
+
+  if table_name then
+    ok, err = self.connector:truncate_table(table_name)
+  else
+    ok, err = self.connector:truncate()
+  end
+
   if not ok then
     return nil, prefix_err(self, err)
   end

--- a/kong/db/strategies/cassandra/connector.lua
+++ b/kong/db/strategies/cassandra/connector.lua
@@ -301,4 +301,28 @@ function CassandraConnector:truncate()
 end
 
 
+function CassandraConnector:truncate_table(table_name)
+  local ok, err = self:connect()
+  if not ok then
+    return nil, err
+  end
+
+  local cql = string.format("TRUNCATE TABLE %s.%s",
+                            self.keyspace, table_name)
+
+  local ok, err = self:query(cql)
+  if not ok then
+    self:setkeepalive()
+    return nil, err
+  end
+
+  ok, err = self:setkeepalive()
+  if not ok then
+    return nil, err
+  end
+
+  return true
+end
+
+
 return CassandraConnector

--- a/kong/db/strategies/cassandra/connector.lua
+++ b/kong/db/strategies/cassandra/connector.lua
@@ -284,7 +284,7 @@ function CassandraConnector:truncate()
       local cql = string.format("TRUNCATE TABLE %s.%s",
                                 self.keyspace, table_name)
 
-      local ok, err = self:query(cql)
+      local ok, err = self:query(cql, nil, nil, "write")
       if not ok then
         self:setkeepalive()
         return nil, err
@@ -302,26 +302,10 @@ end
 
 
 function CassandraConnector:truncate_table(table_name)
-  local ok, err = self:connect()
-  if not ok then
-    return nil, err
-  end
-
   local cql = string.format("TRUNCATE TABLE %s.%s",
                             self.keyspace, table_name)
 
-  local ok, err = self:query(cql)
-  if not ok then
-    self:setkeepalive()
-    return nil, err
-  end
-
-  ok, err = self:setkeepalive()
-  if not ok then
-    return nil, err
-  end
-
-  return true
+  return self:query(cql, nil, nil, "write")
 end
 
 

--- a/kong/db/strategies/cassandra/init.lua
+++ b/kong/db/strategies/cassandra/init.lua
@@ -986,4 +986,9 @@ function _mt:delete_by_field(field_name, field_value)
 end
 
 
+function _mt:truncate()
+  return self.connector:truncate_table(self.schema.name)
+end
+
+
 return _M

--- a/kong/db/strategies/postgres/connector.lua
+++ b/kong/db/strategies/postgres/connector.lua
@@ -313,6 +313,20 @@ function _mt:truncate()
 end
 
 
+function _mt:truncate_table(table_name)
+  local truncate_statement = {
+    "TRUNCATE TABLE ", table_name, " RESTART IDENTITY CASCADE;"
+  }
+
+  local ok, err = self:query(truncate_statement)
+  if not ok then
+    return nil, err
+  end
+
+  return true
+end
+
+
 local _M = {}
 
 

--- a/kong/db/strategies/postgres/init.lua
+++ b/kong/db/strategies/postgres/init.lua
@@ -618,7 +618,7 @@ end
 
 
 function _mt:truncate()
-  local res, err = execute(self, "drop")
+  local res, err = execute(self, "truncate")
   if not res then
     return toerror(self, err)
   end
@@ -1276,7 +1276,7 @@ function _M.new(connector, schema, errors)
   }
 
   local truncate_statement = concat {
-    "TRUNCATE ", table_name_escaped, ";"
+    "TRUNCATE TABLE ", table_name_escaped, " RESTART IDENTITY CASCADE;"
   }
 
   local drop_statement

--- a/spec-old-api/02-integration/03-dao/04-constraints_spec.lua
+++ b/spec-old-api/02-integration/03-dao/04-constraints_spec.lua
@@ -22,10 +22,6 @@ for _, strategy in helpers.each_strategy() do
       bp, db, dao = helpers.get_db_utils(strategy)
       apis = dao.apis
       plugins = dao.plugins
-      assert(dao:run_migrations())
-
-      dao:truncate_tables()
-      assert(db:truncate())
     end)
     before_each(function()
       plugin_fixture = utils.shallow_copy(plugin_tbl)
@@ -34,8 +30,9 @@ for _, strategy in helpers.each_strategy() do
       api_fixture = api
     end)
     after_each(function()
-      dao:truncate_tables()
-      assert(db:truncate())
+      dao:truncate_table("apis")
+      dao:truncate_table("plugins")
+      assert(db:truncate("consumers"))
     end)
 
     -- Check behavior just in case
@@ -177,8 +174,9 @@ for _, strategy in helpers.each_strategy() do
         assert.falsy(err)
       end)
       after_each(function()
-        dao:truncate_tables()
-        assert(db:truncate())
+        dao:truncate_table("apis")
+        dao:truncate_table("plugins")
+        assert(db:truncate("consumers"))
       end)
 
       it("delete", function()

--- a/spec-old-api/02-integration/03-dao/05-use_cases_spec.lua
+++ b/spec-old-api/02-integration/03-dao/05-use_cases_spec.lua
@@ -5,15 +5,15 @@ local helpers = require "spec.helpers"
 
 for _, strategy in helpers.each_strategy() do
   describe("Real use-cases with DB: #" .. strategy, function()
-    local dao
-    local bp
+    local bp, db, dao
     setup(function()
-      local _
-      bp, _, dao = helpers.get_db_utils(strategy)
+      bp, db, dao = helpers.get_db_utils(strategy)
     end)
 
     before_each(function()
-      dao:truncate_tables()
+      dao:truncate_table("apis")
+      dao:truncate_table("plugins")
+      db:truncate("consumers")
     end)
 
     it("retrieves plugins for plugins_iterator", function()

--- a/spec-old-api/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec-old-api/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -21,7 +21,8 @@ describe("Admin API", function()
     assert(helpers.start_kong())
     client = assert(helpers.admin_client())
 
-    helpers.dao:truncate_tables()
+    helpers.dao:truncate_table("upstreams")
+    helpers.dao:truncate_table("targets")
 
     upstream = assert(helpers.dao.upstreams:insert {
       name = upstream_name,

--- a/spec-old-api/02-integration/05-proxy/01-router_spec.lua
+++ b/spec-old-api/02-integration/05-proxy/01-router_spec.lua
@@ -6,7 +6,7 @@ local function insert_apis(arr)
     return error("expected arg #1 to be a table", 2)
   end
 
-  helpers.dao:truncate_tables()
+  helpers.dao:truncate_table("apis")
 
   for i = 1, #arr do
     assert(helpers.dao.apis:insert(arr[i]))
@@ -29,7 +29,9 @@ describe("Router", function()
   describe("no APIs match", function()
 
     setup(function()
-      helpers.dao:truncate_tables()
+      helpers.dao:truncate_table("apis")
+      helpers.db:truncate("routes")
+      helpers.db:truncate("services")
       helpers.dao:run_migrations()
       assert(helpers.start_kong())
     end)
@@ -180,7 +182,7 @@ describe("Router", function()
 
   describe("URI regexes order of evaluation", function()
     setup(function()
-      helpers.dao:truncate_tables()
+      helpers.dao:truncate_table("apis")
 
       assert(helpers.dao.apis:insert {
         name = "api-1",
@@ -714,7 +716,7 @@ describe("Router", function()
     }
 
     setup(function()
-      helpers.dao:truncate_tables()
+      helpers.dao:truncate_table("apis")
 
       for i, args in ipairs(checks) do
         assert(helpers.dao.apis:insert {

--- a/spec-old-api/02-integration/05-proxy/02-upstream_headers_spec.lua
+++ b/spec-old-api/02-integration/05-proxy/02-upstream_headers_spec.lua
@@ -7,7 +7,7 @@ local function insert_apis(arr)
     return error("expected arg #1 to be a table", 2)
   end
 
-  helpers.dao:truncate_tables()
+  helpers.dao:truncate_table("apis")
 
   for i = 1, #arr do
     assert(helpers.dao.apis:insert(arr[i]))

--- a/spec-old-api/02-integration/05-proxy/03-plugins_triggering_spec.lua
+++ b/spec-old-api/02-integration/05-proxy/03-plugins_triggering_spec.lua
@@ -174,7 +174,8 @@ describe("Plugins triggering", function()
       end
 
       helpers.stop_kong()
-      helpers.dao:truncate_tables()
+      helpers.dao:truncate_table("apis")
+      helpers.dao:truncate_table("plugins")
 
 
       do
@@ -389,7 +390,8 @@ describe("Plugins triggering", function()
 
       helpers.stop_kong()
 
-      helpers.dao:truncate_tables()
+      helpers.dao:truncate_table("apis")
+      helpers.dao:truncate_table("plugins")
 
       local api      = assert(helpers.dao.apis:insert {
         name         = "example",

--- a/spec-old-api/02-integration/05-proxy/09-balancer_spec.lua
+++ b/spec-old-api/02-integration/05-proxy/09-balancer_spec.lua
@@ -416,14 +416,6 @@ do
 end
 
 
-local function truncate_relevant_tables(db, dao)
-  dao.apis:truncate()
-  dao.upstreams:truncate()
-  dao.targets:truncate()
-  dao.plugins:truncate()
-end
-
-
 local function poll_wait_health(upstream_name, localhost, port, value)
   local hard_timeout = 300
   local expire = ngx.now() + hard_timeout
@@ -470,9 +462,13 @@ for _, strategy in helpers.each_strategy() do
   describe("Ring-balancer #" .. strategy, function()
 
     setup(function()
-      local _, db, dao = helpers.get_db_utils(strategy, true)
+      assert(helpers.get_db_utils(strategy, {
+        "apis",
+        "plugins",
+        "upstreams",
+        "targets",
+      }))
 
-      truncate_relevant_tables(db, dao)
       helpers.start_kong({
         database   = strategy,
         nginx_conf = "spec/fixtures/custom_nginx.template",

--- a/spec-old-api/02-integration/05-proxy/11-error_default_type_spec.lua
+++ b/spec-old-api/02-integration/05-proxy/11-error_default_type_spec.lua
@@ -10,7 +10,7 @@ describe("Proxy errors Content-Type", function()
   local client
 
   setup(function()
-    helpers.dao:truncate_tables()
+    helpers.dao:truncate_table("apis")
 
     assert(helpers.dao.apis:insert {
       name                     = "api-1",

--- a/spec-old-api/03-plugins/19-acl/01-api_spec.lua
+++ b/spec-old-api/03-plugins/19-acl/01-api_spec.lua
@@ -4,11 +4,10 @@ local utils = require "kong.tools.utils"
 
 describe("Plugin: acl (API)", function()
   local consumer, admin_client
-  local dao
-  local bp
-  local _
+  local bp, db, dao
+
   setup(function()
-    bp, _, dao = helpers.get_db_utils()
+    bp, db, dao = helpers.get_db_utils()
 
     assert(helpers.start_kong())
     admin_client = helpers.admin_client()
@@ -20,7 +19,8 @@ describe("Plugin: acl (API)", function()
 
   describe("/consumers/:consumer/acls/", function()
     setup(function()
-      dao:truncate_tables()
+      db:truncate("consumers")
+      dao:truncate_table("acls")
       consumer = bp.consumers:insert {
         username = "bob"
       }

--- a/spec-old-api/03-plugins/20-hmac-auth/02-api_spec.lua
+++ b/spec-old-api/03-plugins/20-hmac-auth/02-api_spec.lua
@@ -25,8 +25,13 @@ describe("Plugin: hmac-auth (API)", function()
   describe("/consumers/:consumer/hmac-auth/", function()
     describe("POST", function()
       before_each(function()
-        dao:truncate_tables()
-        db:truncate()
+        assert(db:truncate("routes"))
+        assert(db:truncate("services"))
+        assert(db:truncate("consumers"))
+        dao:truncate_table("apis")
+        dao:truncate_table("plugins")
+        dao:truncate_table("hmacauth_credentials")
+
         consumer = bp.consumers:insert {
           username = "bob",
           custom_id = "1234"

--- a/spec-old-api/03-plugins/26-oauth2/04-invalidations_spec.lua
+++ b/spec-old-api/03-plugins/26-oauth2/04-invalidations_spec.lua
@@ -10,16 +10,18 @@ describe("Plugin: oauth2 (invalidations)", function()
 
   setup(function()
     bp, db, dao = helpers.get_db_utils(strategy)
-
-    assert(db:truncate())
-    dao:truncate_tables()
-    assert(dao:run_migrations())
   end)
 
 
   before_each(function()
-    assert(db:truncate())
-    dao:truncate_tables()
+    assert(db:truncate("routes"))
+    assert(db:truncate("services"))
+    assert(db:truncate("consumers"))
+    dao:truncate_table("apis")
+    dao:truncate_table("plugins")
+    dao:truncate_table("oauth2_tokens")
+    dao:truncate_table("oauth2_credentials")
+    dao:truncate_table("oauth2_authorization_codes")
 
     local api = assert(dao.apis:insert {
       name         = "api-1",

--- a/spec/02-integration/000-new-dao/02-db_core_entities_spec.lua
+++ b/spec/02-integration/000-new-dao/02-db_core_entities_spec.lua
@@ -540,7 +540,7 @@ for _, strategy in helpers.each_strategy() do
 
         -- I/O
         it("returns a table encoding to a JSON Array when empty", function()
-          assert(db:truncate())
+          assert(db:truncate("routes"))
 
           local rows, err, err_t, offset = db.routes:page()
           assert.is_nil(err_t)
@@ -552,7 +552,7 @@ for _, strategy in helpers.each_strategy() do
         end)
 
         it("invokes schema post-processing", function()
-          assert(db:truncate())
+          assert(db:truncate("routes"))
 
           bp.routes:insert {
             methods = { "GET" },
@@ -569,7 +569,7 @@ for _, strategy in helpers.each_strategy() do
 
         describe("page size", function()
           setup(function()
-            assert(db:truncate())
+            assert(db:truncate("routes"))
 
             for i = 1, 1002 do
               bp.routes:insert({ hosts = { "example-" .. i .. ".com" } })
@@ -595,7 +595,7 @@ for _, strategy in helpers.each_strategy() do
 
         describe("page offset", function()
           setup(function()
-            assert(db:truncate())
+            assert(db:truncate("routes"))
 
             for i = 1, 10 do
               bp.routes:insert({
@@ -736,7 +736,7 @@ for _, strategy in helpers.each_strategy() do
 
       describe(":each()", function()
         setup(function()
-          assert(db:truncate())
+          assert(db:truncate("routes"))
 
           for i = 1, 100 do
             bp.routes:insert({
@@ -977,7 +977,7 @@ for _, strategy in helpers.each_strategy() do
 
       describe(":select_by_name()", function()
         setup(function()
-          assert(db:truncate())
+          assert(db:truncate("services"))
 
           for i = 1, 5 do
             assert(db.services:insert({
@@ -1106,7 +1106,7 @@ for _, strategy in helpers.each_strategy() do
 
       describe(":update_by_name()", function()
         before_each(function()
-          assert(db:truncate())
+          assert(db:truncate("services"))
 
           assert(db.services:insert({
             name = "test-service",
@@ -1252,7 +1252,7 @@ for _, strategy in helpers.each_strategy() do
         local service
 
         setup(function()
-          assert(db:truncate())
+          assert(db:truncate("services"))
 
           service = assert(db.services:insert({
             name = "service_1",
@@ -1516,7 +1516,7 @@ for _, strategy in helpers.each_strategy() do
 
           describe("page size", function()
             setup(function()
-              assert(db:truncate())
+              assert(db:truncate("services"))
 
               service = bp.services:insert()
 
@@ -1549,7 +1549,7 @@ for _, strategy in helpers.each_strategy() do
 
           describe("page offset", function()
             setup(function()
-              assert(db:truncate())
+              assert(db:truncate("services"))
 
               service = bp.services:insert()
 

--- a/spec/02-integration/03-dao/03-crud_spec.lua
+++ b/spec/02-integration/03-dao/03-crud_spec.lua
@@ -48,13 +48,13 @@ helpers.for_each_dao(function(kong_config)
       assert(factory:run_migrations())
     end)
     teardown(function()
-      factory:truncate_tables()
+      factory:truncate_table("apis")
       ngx.shared.kong_cassandra:flush_expired()
     end)
 
     describe("insert()", function()
       after_each(function()
-        factory:truncate_tables()
+        factory:truncate_table("apis")
       end)
       it("insert a valid API", function()
         local api, err = apis:insert(api_tbl)
@@ -78,6 +78,10 @@ helpers.for_each_dao(function(kong_config)
         assert.raw_table(api)
       end)
       it("insert a valid array field and return it properly", function()
+        finally(function()
+          factory:truncate_table("oauth2_credentials")
+        end)
+
         local res, err = oauth2_credentials:insert {
           name = "test_app",
           redirect_uri = "https://example.org"
@@ -91,6 +95,10 @@ helpers.for_each_dao(function(kong_config)
         assert.raw_table(res)
       end)
       it("insert a valid array field and return it properly bis", function()
+        finally(function()
+          factory:truncate_table("oauth2_credentials")
+        end)
+
         local res, err = oauth2_credentials:insert {
           name = "test_app",
           redirect_uri = "https://example.org, https://example.com"
@@ -183,7 +191,7 @@ helpers.for_each_dao(function(kong_config)
         api_fixture = api
       end)
       after_each(function()
-        factory:truncate_tables()
+        factory:truncate_table("apis")
       end)
 
       it("select by primary key", function()
@@ -223,7 +231,8 @@ helpers.for_each_dao(function(kong_config)
 
     describe("find_all()", function()
       setup(function()
-        factory:truncate_tables()
+        factory:truncate_table("apis")
+        factory:truncate_table("oauth2_credentials")
 
         for i = 1, 100 do
           local api, err = apis:insert {
@@ -243,7 +252,8 @@ helpers.for_each_dao(function(kong_config)
         assert.truthy(res)
       end)
       teardown(function()
-        factory:truncate_tables()
+        factory:truncate_table("apis")
+        factory:truncate_table("oauth2_credentials")
       end)
 
       it("retrieve all rows", function()
@@ -274,6 +284,9 @@ helpers.for_each_dao(function(kong_config)
         assert.equal("fixture_100", rows[1].name)
       end)
       it("return rows with arrays", function()
+        finally(function()
+          factory:truncate_table("oauth2_credentials")
+        end)
         local rows, err = oauth2_credentials:find_all()
         assert.falsy(err)
         assert.is_table(rows)
@@ -327,7 +340,7 @@ helpers.for_each_dao(function(kong_config)
 
     describe("find_page()", function()
       setup(function()
-        factory:truncate_tables()
+        factory:truncate_table("apis")
 
         for i = 1, 100 do
           local api, err = apis:insert {
@@ -341,7 +354,7 @@ helpers.for_each_dao(function(kong_config)
         end
       end)
       teardown(function()
-        factory:truncate_tables()
+        factory:truncate_table("apis")
       end)
 
       it("has a default_page size (100)", function()
@@ -498,7 +511,7 @@ helpers.for_each_dao(function(kong_config)
 
     describe("count()", function()
       setup(function()
-        factory:truncate_tables()
+        factory:truncate_table("apis")
 
         for i = 1, 100 do
           local api, err = apis:insert {
@@ -512,7 +525,7 @@ helpers.for_each_dao(function(kong_config)
       end)
 
       teardown(function()
-        factory:truncate_tables()
+        factory:truncate_table("apis")
       end)
 
       it("return the count of rows", function()
@@ -561,14 +574,14 @@ helpers.for_each_dao(function(kong_config)
     describe("update()", function()
       local api_fixture
       before_each(function()
-        factory:truncate_tables()
+        factory:truncate_table("apis")
 
         local api, err = apis:insert(api_tbl)
         assert.falsy(err)
         api_fixture = api
       end)
       after_each(function()
-        factory:truncate_tables()
+        factory:truncate_table("apis")
       end)
 
       it("update by primary key", function()
@@ -767,14 +780,14 @@ helpers.for_each_dao(function(kong_config)
     describe("delete()", function()
       local api_fixture
       before_each(function()
-        factory:truncate_tables()
+        factory:truncate_table("apis")
 
         local api, err = apis:insert(api_tbl)
         assert.falsy(err)
         api_fixture = api
       end)
       after_each(function()
-        factory:truncate_tables()
+        factory:truncate_table("apis")
       end)
 
       it("delete a row", function()

--- a/spec/02-integration/03-dao/04-constraints_spec.lua
+++ b/spec/02-integration/03-dao/04-constraints_spec.lua
@@ -14,8 +14,10 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     before_each(function()
-      dao:truncate_tables()
-      assert(db:truncate())
+      dao:truncate_table("plugins")
+      assert(db:truncate("routes"))
+      assert(db:truncate("services"))
+      assert(db:truncate("consumers"))
 
       local service, _, err_t = db.services:insert {
         protocol = "http",

--- a/spec/02-integration/03-dao/08-ipc_events_spec.lua
+++ b/spec/02-integration/03-dao/08-ipc_events_spec.lua
@@ -17,7 +17,7 @@ describe("DAO propagates CRUD events with DB: #" .. kong_conf.database, function
   local mock_ipc
 
   teardown(function()
-    dao:truncate_tables()
+    dao:truncate_table("apis")
   end)
 
   before_each(function()
@@ -28,7 +28,7 @@ describe("DAO propagates CRUD events with DB: #" .. kong_conf.database, function
 
     dao = assert(kong_dao_factory.new(kong_conf, db))
     dao:set_events_handler(mock_ipc)
-    dao:truncate_tables()
+    dao:truncate_table("apis")
   end)
 
   after_each(function()

--- a/spec/02-integration/04-admin_api/03-consumers_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/03-consumers_routes_spec.lua
@@ -34,8 +34,7 @@ describe("Admin API (" .. strategy .. "): ", function()
 
   local consumer, consumer2
   before_each(function()
-    assert(db:truncate())
-    dao:truncate_tables()
+    assert(db:truncate("consumers"))
     consumer = assert(bp.consumers:insert {
       username = "bob",
       custom_id = "wxyz"
@@ -191,13 +190,12 @@ describe("Admin API (" .. strategy .. "): ", function()
 
     describe("GET", function()
       before_each(function()
-        assert(db:truncate())
-        dao:truncate_tables()
+        assert(db:truncate("consumers"))
         bp.consumers:insert_n(10)
       end)
       teardown(function()
-        assert(db:truncate())
-        dao:truncate_tables()
+        assert(db:truncate("consumers"))
+        dao:truncate_table("plugins")
       end)
 
       it("retrieves the first page", function()

--- a/spec/02-integration/04-admin_api/06-certificates_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/06-certificates_routes_spec.lua
@@ -52,7 +52,7 @@ describe("Admin API: #" .. strategy, function()
   end)
 
   setup(function()
-    bp, db, dao = helpers.get_db_utils(strategy)
+    bp, db, dao = helpers.get_db_utils(strategy, {})
     assert(dao:run_migrations())
 
     assert(helpers.start_kong({
@@ -66,7 +66,9 @@ describe("Admin API: #" .. strategy, function()
 
   describe("/certificates", function()
     before_each(function()
-      assert(db:truncate())
+      assert(db:truncate("certificates"))
+      assert(db:truncate("snis"))
+
       local res = client:post("/certificates", {
         body    = {
           cert  = ssl_fixtures.cert,
@@ -176,7 +178,9 @@ describe("Admin API: #" .. strategy, function()
     local certificate
 
     before_each(function()
-      assert(db:truncate())
+      assert(db:truncate("certificates"))
+      assert(db:truncate("snis"))
+
       local res = client:post("/certificates", {
         body    = {
           cert  = ssl_fixtures.cert,
@@ -313,7 +317,8 @@ describe("Admin API: #" .. strategy, function()
       local cert_bar
 
       before_each(function()
-        assert(db:truncate())
+        assert(db:truncate("certificates"))
+        assert(db:truncate("snis"))
 
         local res = client:post("/certificates", {
           body    = {
@@ -551,7 +556,8 @@ describe("Admin API: #" .. strategy, function()
 
       local certificate
       before_each(function()
-        assert(db:truncate())
+        assert(db:truncate("certificates"))
+        assert(db:truncate("snis"))
 
         certificate = bp.certificates:insert()
         bp.snis:insert({
@@ -628,7 +634,9 @@ describe("Admin API: #" .. strategy, function()
 
     describe("GET", function()
       it("retrieves a list of snis", function()
-        assert(db:truncate())
+        assert(db:truncate("certificates"))
+        assert(db:truncate("snis"))
+
         local certificate = bp.certificates:insert()
         bp.snis:insert {
           name        = "foo.com",
@@ -649,7 +657,9 @@ describe("Admin API: #" .. strategy, function()
     local certificate, sni
 
     before_each(function()
-      assert(db:truncate())
+      assert(db:truncate("certificates"))
+      assert(db:truncate("snis"))
+
       certificate = bp.certificates:insert()
       sni = bp.snis:insert {
         name        = "foo.com",

--- a/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
@@ -20,7 +20,7 @@ describe("Admin API: #" .. kong_config.database, function()
   setup(function()
 
     local _
-    _, _, dao = helpers.get_db_utils(kong_config.database)
+    _, _, dao = helpers.get_db_utils(kong_config.database, {})
 
     assert(helpers.start_kong{
       database = kong_config.database
@@ -36,7 +36,7 @@ describe("Admin API: #" .. kong_config.database, function()
   describe("/upstreams #" .. kong_config.database, function()
     describe("POST", function()
       before_each(function()
-        dao:truncate_tables()
+        dao:truncate_table("upstreams")
       end)
       it_content_types("creates an upstream with defaults", function(content_type)
         return function()
@@ -447,7 +447,7 @@ describe("Admin API: #" .. kong_config.database, function()
 
     describe("PUT", function()
       before_each(function()
-        dao:truncate_tables()
+        dao:truncate_table("upstreams")
       end)
 
       it_content_types("creates if not exists", function(content_type)
@@ -565,7 +565,7 @@ describe("Admin API: #" .. kong_config.database, function()
 
     describe("GET", function()
       setup(function()
-        dao:truncate_tables()
+        dao:truncate_table("upstreams")
 
         for i = 1, 10 do
           assert(dao.upstreams:insert {
@@ -574,7 +574,7 @@ describe("Admin API: #" .. kong_config.database, function()
         end
       end)
       teardown(function()
-        dao:truncate_tables()
+        dao:truncate_table("upstreams")
       end)
 
       it("retrieves the first page", function()
@@ -640,7 +640,7 @@ describe("Admin API: #" .. kong_config.database, function()
 
       describe("empty results", function()
         setup(function()
-          dao:truncate_tables()
+          dao:truncate_table("upstreams")
         end)
 
         it("data property is an empty array", function()

--- a/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -10,7 +10,7 @@ end
 
 local function client_send(req)
   local client = helpers.admin_client()
-  local res = client:send(req)
+  local res = assert(client:send(req))
   local status, body = res.status, res:read_body()
   client:close()
   return status, body
@@ -45,7 +45,8 @@ describe("Admin API", function()
     }))
     client = assert(helpers.admin_client())
 
-    helpers.dao:truncate_tables()
+    helpers.dao:truncate_table("upstreams")
+    helpers.dao:truncate_table("targets")
 
     upstream = assert(helpers.dao.upstreams:insert {
       name = upstream_name,

--- a/spec/02-integration/04-admin_api/09-post_processing_spec.lua
+++ b/spec/02-integration/04-admin_api/09-post_processing_spec.lua
@@ -16,6 +16,7 @@ describe("Admin API post-processing", function()
 
   setup(function()
     assert(helpers.dao:run_migrations())
+    helpers.dao:truncate_table("plugins")
     assert(helpers.start_kong {
       plugins = "bundled, admin-api-post-process, dummy"
     })
@@ -32,7 +33,7 @@ describe("Admin API post-processing", function()
   end)
 
   before_each(function()
-    helpers.dao:truncate_tables()
+    helpers.dao:truncate_table("plugins")
     plugin =  helpers.dao.plugins:insert({
       name = "admin-api-post-process",
     })

--- a/spec/02-integration/04-admin_api/20-routes_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/20-routes_routes_spec.lua
@@ -23,7 +23,7 @@ for _, strategy in helpers.each_strategy() do
     local client
 
     setup(function()
-      bp, db, dao = helpers.get_db_utils(strategy)
+      bp, db, dao = helpers.get_db_utils(strategy, {})
     end)
 
     teardown(function()
@@ -32,7 +32,8 @@ for _, strategy in helpers.each_strategy() do
 
     before_each(function()
       helpers.stop_kong()
-      assert(db:truncate())
+      assert(db:truncate("routes"))
+      assert(db:truncate("services"))
       assert(helpers.start_kong({
         database = strategy,
       }))

--- a/spec/02-integration/04-admin_api/21-services_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/21-services_routes_spec.lua
@@ -32,7 +32,7 @@ for _, strategy in helpers.each_strategy() do
 
     before_each(function()
       helpers.stop_kong()
-      assert(db:truncate())
+      assert(db:truncate("services"))
       assert(helpers.start_kong({
         database = strategy,
       }))

--- a/spec/02-integration/04-admin_api/22-reports_spec.lua
+++ b/spec/02-integration/04-admin_api/22-reports_spec.lua
@@ -109,7 +109,7 @@ for _, strategy in helpers.each_strategy() do
     before_each(function()
       reports_server = mock_reports_server()
 
-      assert(helpers.get_db_utils(strategy))
+      assert(helpers.get_db_utils(strategy, {}))
 
       assert(helpers.start_kong({
         nginx_conf = "spec/fixtures/custom_nginx.template",

--- a/spec/02-integration/05-proxy/01-router_spec.lua
+++ b/spec/02-integration/05-proxy/01-router_spec.lua
@@ -66,8 +66,9 @@ for _, strategy in helpers.each_strategy() do
 
     describe("no routes match", function()
       setup(function()
-        assert(db:truncate())
-        dao:truncate_tables()
+        assert(db:truncate("routes"))
+        assert(db:truncate("services"))
+        dao:truncate_table("apis")
 
         assert(helpers.start_kong({
           database = strategy,
@@ -98,8 +99,9 @@ for _, strategy in helpers.each_strategy() do
       local routes
 
       setup(function()
-        assert(db:truncate())
-        dao:truncate_tables()
+        assert(db:truncate("routes"))
+        assert(db:truncate("services"))
+        dao:truncate_table("apis")
 
         routes = insert_routes {
           { -- service-1
@@ -301,8 +303,9 @@ for _, strategy in helpers.each_strategy() do
       local routes1, routes2
 
       setup(function()
-        assert(db:truncate())
-        dao:truncate_tables()
+        assert(db:truncate("routes"))
+        assert(db:truncate("services"))
+        dao:truncate_table("apis")
 
         routes1 = insert_routes {
           {
@@ -378,8 +381,9 @@ for _, strategy in helpers.each_strategy() do
 
     describe("URI regexes order of evaluation with regex_priority", function()
       setup(function()
-        assert(db:truncate())
-        dao:truncate_tables()
+        assert(db:truncate("routes"))
+        assert(db:truncate("services"))
+        dao:truncate_table("apis")
 
         -- TEST 1 (regex_priority)
 
@@ -469,16 +473,15 @@ for _, strategy in helpers.each_strategy() do
     describe("URI arguments (querystring)", function()
 
       setup(function()
-        assert(db:truncate())
-        dao:truncate_tables()
+        assert(db:truncate("routes"))
+        assert(db:truncate("services"))
+        dao:truncate_table("apis")
 
         insert_routes {
           {
             hosts = { "mock_upstream" },
           },
         }
-
-        assert(dao:run_migrations())
 
         assert(helpers.start_kong({
           database   = strategy,
@@ -542,8 +545,9 @@ for _, strategy in helpers.each_strategy() do
       local routes
 
       setup(function()
-        assert(db:truncate())
-        dao:truncate_tables()
+        assert(db:truncate("routes"))
+        assert(db:truncate("services"))
+        dao:truncate_table("apis")
 
         routes = insert_routes {
           {
@@ -598,8 +602,9 @@ for _, strategy in helpers.each_strategy() do
     describe("strip_path", function()
 
       setup(function()
-        assert(db:truncate())
-        dao:truncate_tables()
+        assert(db:truncate("routes"))
+        assert(db:truncate("services"))
+        dao:truncate_table("apis")
 
         insert_routes {
           {
@@ -666,8 +671,9 @@ for _, strategy in helpers.each_strategy() do
     describe("preserve_host", function()
 
       setup(function()
-        assert(db:truncate())
-        dao:truncate_tables()
+        assert(db:truncate("routes"))
+        assert(db:truncate("services"))
+        dao:truncate_table("apis")
 
         insert_routes {
           {
@@ -784,8 +790,9 @@ for _, strategy in helpers.each_strategy() do
       local routes
 
       setup(function()
-        assert(db:truncate())
-        dao:truncate_tables()
+        assert(db:truncate("routes"))
+        assert(db:truncate("services"))
+        dao:truncate_table("apis")
 
         routes = insert_routes {
           {
@@ -839,8 +846,9 @@ for _, strategy in helpers.each_strategy() do
       local routes
 
       setup(function()
-        assert(db:truncate())
-        dao:truncate_tables()
+        assert(db:truncate("routes"))
+        assert(db:truncate("services"))
+        dao:truncate_table("apis")
 
         routes = insert_routes {
           {
@@ -886,8 +894,9 @@ for _, strategy in helpers.each_strategy() do
       local routes
 
       setup(function()
-        assert(db:truncate())
-        dao:truncate_tables()
+        assert(db:truncate("routes"))
+        assert(db:truncate("services"))
+        dao:truncate_table("apis")
 
         routes = insert_routes {
           {
@@ -966,8 +975,9 @@ for _, strategy in helpers.each_strategy() do
       }
 
       setup(function()
-        assert(db:truncate())
-        dao:truncate_tables()
+        assert(db:truncate("routes"))
+        assert(db:truncate("services"))
+        dao:truncate_table("apis")
 
         for i, args in ipairs(checks) do
           assert(insert_routes {

--- a/spec/02-integration/05-proxy/02-upstream_headers_spec.lua
+++ b/spec/02-integration/05-proxy/02-upstream_headers_spec.lua
@@ -38,7 +38,8 @@ for _, strategy in helpers.each_strategy() do
 
     local function start_kong(config)
       return function()
-        assert(db:truncate())
+        assert(db:truncate("routes"))
+        assert(db:truncate("services"))
 
         insert_routes {
           {

--- a/spec/02-integration/05-proxy/03-plugins_triggering_spec.lua
+++ b/spec/02-integration/05-proxy/03-plugins_triggering_spec.lua
@@ -220,7 +220,11 @@ for _, strategy in helpers.each_strategy() do
         end
 
         helpers.stop_kong()
-        dao:truncate_tables()
+        db:truncate("routes")
+        db:truncate("services")
+        db:truncate("consumers")
+        dao:truncate_table("plugins")
+        dao:truncate_table("keyauth_credentials")
 
         do
           local service = assert(bp.services:insert {
@@ -434,8 +438,11 @@ for _, strategy in helpers.each_strategy() do
 
         helpers.stop_kong()
 
-        assert(db:truncate())
-        dao:truncate_tables()
+        db:truncate("routes")
+        db:truncate("services")
+        db:truncate("consumers")
+        dao:truncate_table("plugins")
+        dao:truncate_table("keyauth_credentials")
 
         local service = bp.services:insert {
           name = "example",
@@ -506,8 +513,11 @@ for _, strategy in helpers.each_strategy() do
 
 
       setup(function()
-        assert(db:truncate())
-        dao:truncate_tables()
+        db:truncate("routes")
+        db:truncate("services")
+        db:truncate("consumers")
+        dao:truncate_table("plugins")
+        dao:truncate_table("keyauth_credentials")
 
         do
           -- service to mock HTTP 502

--- a/spec/02-integration/05-proxy/09-balancer_spec.lua
+++ b/spec/02-integration/05-proxy/09-balancer_spec.lua
@@ -432,15 +432,6 @@ do
 end
 
 
-local function truncate_relevant_tables(db, dao)
-  db:truncate("services")
-  db:truncate("routes")
-  dao.upstreams:truncate()
-  dao.targets:truncate()
-  dao.plugins:truncate()
-end
-
-
 local function poll_wait_health(upstream_name, host, port, value, admin_port)
   local hard_timeout = 300
   local expire = ngx.now() + hard_timeout
@@ -489,9 +480,14 @@ for _, strategy in helpers.each_strategy() do
   describe("Ring-balancer #" .. strategy, function()
 
     setup(function()
-      local _, db, dao = helpers.get_db_utils(strategy, true)
+      assert(helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+        "upstreams",
+        "targets",
+      }))
 
-      truncate_relevant_tables(db, dao)
       helpers.start_kong({
         database   = strategy,
         nginx_conf = "spec/fixtures/custom_nginx.template",

--- a/spec/02-integration/05-proxy/10-handler_spec.lua
+++ b/spec/02-integration/05-proxy/10-handler_spec.lua
@@ -8,7 +8,12 @@ for _, strategy in helpers.each_strategy() do
         local proxy_client
 
         setup(function()
-          local bp = helpers.get_db_utils(strategy)
+          local bp = helpers.get_db_utils(strategy, {
+            "apis",
+            "routes",
+            "services",
+            "plugins",
+          })
 
           -- insert plugin-less route and a global plugin
           local service = bp.services:insert {
@@ -61,7 +66,12 @@ for _, strategy in helpers.each_strategy() do
         local proxy_client
 
         setup(function()
-          local bp = helpers.get_db_utils(strategy)
+          local bp = helpers.get_db_utils(strategy, {
+            "apis",
+            "routes",
+            "services",
+            "plugins",
+          })
 
           -- route specific plugin
           local service = bp.services:insert {
@@ -114,7 +124,14 @@ for _, strategy in helpers.each_strategy() do
         local proxy_client
 
         setup(function()
-          local bp = helpers.get_db_utils(strategy)
+          local bp = helpers.get_db_utils(strategy, {
+            "apis",
+            "routes",
+            "services",
+            "plugins",
+            "consumers",
+            "keyauth_credentials",
+          })
 
           -- consumer specific plugin
           local service = bp.services:insert {

--- a/spec/02-integration/07-sdk/01-ctx_spec.lua
+++ b/spec/02-integration/07-sdk/01-ctx_spec.lua
@@ -7,8 +7,8 @@ describe("SDK: kong.ctx", function()
 
   before_each(function()
     bp, db, dao = helpers.get_db_utils()
-    dao:truncate_tables()
-    assert(db:truncate())
+    assert(db:truncate("routes"))
+    dao:truncate_table("plugins")
     dao:run_migrations()
   end)
 
@@ -17,10 +17,10 @@ describe("SDK: kong.ctx", function()
       proxy_client:close()
     end
 
-    dao:truncate_tables()
-    assert(db:truncate())
-
     helpers.stop_kong()
+
+    assert(db:truncate("routes"))
+    dao:truncate_table("plugins")
   end)
 
   it("isolates kong.ctx.plugin per-plugin", function()

--- a/spec/02-integration/07-sdk/02-log_spec.lua
+++ b/spec/02-integration/07-sdk/02-log_spec.lua
@@ -23,8 +23,9 @@ describe("SDK: kong.log", function()
 
   before_each(function()
     bp, db, dao = helpers.get_db_utils()
-    dao:truncate_tables()
-    assert(db:truncate())
+    assert(db:truncate("routes"))
+    assert(db:truncate("services"))
+    dao:truncate_table("plugins")
     dao:run_migrations()
   end)
 
@@ -33,10 +34,11 @@ describe("SDK: kong.log", function()
       proxy_client:close()
     end
 
-    dao:truncate_tables()
-    assert(db:truncate())
-
     helpers.stop_kong()
+
+    assert(db:truncate("routes"))
+    assert(db:truncate("services"))
+    dao:truncate_table("plugins")
   end)
 
   it("namespaces the logs with the plugin name inside a plugin", function()

--- a/spec/03-plugins/11-basic-auth/02-api_spec.lua
+++ b/spec/03-plugins/11-basic-auth/02-api_spec.lua
@@ -18,11 +18,17 @@ for _, strategy in helpers.each_strategy() do
         database = strategy,
       }))
 
-      admin_client = helpers.admin_client()
     end)
     teardown(function()
-      if admin_client then admin_client:close() end
       helpers.stop_kong()
+    end)
+
+    before_each(function()
+      admin_client = helpers.admin_client()
+    end)
+
+    after_each(function()
+      if admin_client then admin_client:close() end
     end)
 
     describe("/consumers/:consumer/basic-auth/", function()

--- a/spec/03-plugins/11-basic-auth/04-invalidations_spec.lua
+++ b/spec/03-plugins/11-basic-auth/04-invalidations_spec.lua
@@ -14,8 +14,11 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     before_each(function()
-      assert(db:truncate())
-      dao:truncate_tables()
+      assert(db:truncate("routes"))
+      assert(db:truncate("services"))
+      assert(db:truncate("consumers"))
+      dao:truncate_table("plugins")
+      dao:truncate_table("hmacauth_credentials")
 
       local route = bp.routes:insert {
         hosts = { "basic-auth.com" },

--- a/spec/03-plugins/20-hmac-auth/02-api_spec.lua
+++ b/spec/03-plugins/20-hmac-auth/02-api_spec.lua
@@ -33,8 +33,11 @@ for _, strategy in helpers.each_strategy() do
     describe("/consumers/:consumer/hmac-auth/", function()
       describe("POST", function()
         before_each(function()
-          assert(db:truncate())
-          dao:truncate_tables()
+          assert(db:truncate("routes"))
+          assert(db:truncate("services"))
+          assert(db:truncate("consumers"))
+          dao:truncate_table("plugins")
+          dao:truncate_table("hmacauth_credentials")
 
           consumer = bp.consumers:insert {
             username  = "bob",

--- a/spec/03-plugins/26-oauth2/02-api_spec.lua
+++ b/spec/03-plugins/26-oauth2/02-api_spec.lua
@@ -14,9 +14,13 @@ for _, strategy in helpers.each_strategy() do
     setup(function()
       bp, db, dao = helpers.get_db_utils(strategy)
 
-      assert(db:truncate())
-      dao:truncate_tables()
-      assert(dao:run_migrations())
+      assert(db:truncate("routes"))
+      assert(db:truncate("services"))
+      assert(db:truncate("consumers"))
+      dao:truncate_table("plugins")
+      dao:truncate_table("oauth2_tokens")
+      dao:truncate_table("oauth2_credentials")
+      dao:truncate_table("oauth2_authorization_codes")
 
       helpers.prepare_prefix()
 
@@ -251,7 +255,9 @@ for _, strategy in helpers.each_strategy() do
       local credential
       before_each(function()
         dao:truncate_table("oauth2_credentials")
-        assert(db:truncate())
+        assert(db:truncate("routes"))
+        assert(db:truncate("services"))
+        assert(db:truncate("consumers"))
 
         service = bp.services:insert({ host = "oauth2_token.com" })
         consumer = bp.consumers:insert({ username = "bob" })

--- a/spec/03-plugins/26-oauth2/04-invalidations_spec.lua
+++ b/spec/03-plugins/26-oauth2/04-invalidations_spec.lua
@@ -12,15 +12,16 @@ for _, strategy in helpers.each_strategy() do
 
     setup(function()
       bp, db, dao = helpers.get_db_utils(strategy)
-
-      assert(db:truncate())
-      dao:truncate_tables()
-      assert(dao:run_migrations())
     end)
 
     before_each(function()
-      assert(db:truncate())
-      dao:truncate_tables()
+      assert(db:truncate("routes"))
+      assert(db:truncate("services"))
+      assert(db:truncate("consumers"))
+      dao:truncate_table("plugins")
+      dao:truncate_table("oauth2_tokens")
+      dao:truncate_table("oauth2_credentials")
+      dao:truncate_table("oauth2_authorization_codes")
 
       local service = bp.services:insert()
 


### PR DESCRIPTION
Introduces the ability to truncate a single table in the new DAO, using either
`entities:truncate()` or `db.truncate("entities")`.

Adjusts all tests to avoid truncating all tables at once deliberately. This is
done to speed up the test suite.

Note that the tests still truncate the entire database once at the beginning
of each file when they use `helpers.get_db_utils` in the top-level `setup`
directive.
