### PR TITLE
Fix wrong type exception in key-auth plugin

### DIFF
--- a/kong/plugins/key-auth/handler.lua
+++ b/kong/plugins/key-auth/handler.lua
@@ -46,7 +46,7 @@ local function set_consumer(consumer, credential)
   local new_headers = {
     [const.CONSUMER_ID]        = consumer.id,
     [const.CONSUMER_CUSTOM_ID] = tostring(consumer.custom_id),
-    [const.CONSUMER_USERNAME]  = consumer.username,
+    [const.CONSUMER_USERNAME]  = tostring(consumer.username),
   }
 
   kong.ctx.shared.authenticated_consumer = consumer -- forward compatibility


### PR DESCRIPTION
add tostring() around consumer.username

### Summary

kong-community-edition-0.14.0-1.noarch on CentOS 7 fails with:

```
2018/07/30 11:22:21 [error] 17610#0: *1895 lua coroutine: runtime error: /usr/local/share/lua/5.1/kong/plugins/key-auth/handler.lua:65: invalid header value for "X-Consumer-Username": got userdata, expected string, number, boolean or array of strings
stack traceback:
coroutine 0:
        [C]: in function 'error'
        /usr/local/share/lua/5.1/kong/pdk/private/checks.lua:92: in function 'validate_headers'
        /usr/local/share/lua/5.1/kong/pdk/service/request.lua:370: in function 'set_headers'
        /usr/local/share/lua/5.1/kong/plugins/key-auth/handler.lua:65: in function 'set_consumer'
        /usr/local/share/lua/5.1/kong/plugins/key-auth/handler.lua:165: in function 'do_authentication'
        /usr/local/share/lua/5.1/kong/plugins/key-auth/handler.lua:188: in function </usr/local/share/lua/5.1/kong/plugins/key-auth/handler.lua:171>
coroutine 1:
        [C]: in function 'resume'
        coroutine.wrap:21: in function <coroutine.wrap:21>
        /usr/local/share/lua/5.1/kong/init.lua:468: in function 'access'
        access_by_lua(nginx-kong.conf:86):2: in function <access_by_lua(nginx-kong.conf:86):1>,
```

I've converted the userdata object to string to prevent the crash from happening.