### PR TITLE
LDAP Auth: Fix WWW-Authenticate header with custom cred type

### DIFF
--- a/kong/plugins/ldap-auth/access.lua
+++ b/kong/plugins/ldap-auth/access.lua
@@ -5,6 +5,7 @@ local ldap = require "kong.plugins.ldap-auth.ldap"
 
 local match = string.match
 local lower = string.lower
+local upper = string.upper
 local find = string.find
 local sub = string.sub
 local fmt = string.format
@@ -165,7 +166,14 @@ local function do_authentication(conf)
 
   -- If both headers are missing, return 401
   if not (authorization_value or proxy_authorization_value) then
-    ngx.header["WWW-Authenticate"] = 'LDAP realm="kong"'
+    local scheme = conf.header_type
+    if scheme == "ldap" then
+      -- ensure backwards compatibility (see GH PR #3656)
+      -- TODO: provide migration to capitalize older configurations
+      scheme = upper(scheme)
+    end
+
+    ngx.header["WWW-Authenticate"] = scheme .. ' realm="kong"'
     return false, {status = 401}
   end
 

--- a/spec/03-plugins/21-ldap-auth/01-access_spec.lua
+++ b/spec/03-plugins/21-ldap-auth/01-access_spec.lua
@@ -123,7 +123,7 @@ for _, strategy in helpers.each_strategy() do
           start_tls = false,
           base_dn   = "ou=scientists,dc=ldap,dc=mashape,dc=com",
           attribute = "uid",
-          header_type = "basic",
+          header_type = "Basic",
         }
       }
 
@@ -359,6 +359,20 @@ for _, strategy in helpers.each_strategy() do
         }
       })
       assert.response(r).has.status(200)
+    end)
+    it("returns 'invalid credentials' and www-authenticate header when the credential is missing and custom credential type is configured", function()
+      local res = assert(proxy_client:send {
+        method  = "GET",
+        path    = "/get",
+        headers = {
+          host  = "ldap5.com"
+        }
+      })
+      assert.response(res).has.status(401)
+      local value = assert.response(res).has.header("www-authenticate")
+      assert.are.equal('Basic realm="kong"', value)
+      local json = assert.response(res).has.jsonbody()
+      assert.equal("Unauthorized", json.message)
     end)
     it("fails if custom credential type is invalid in post request", function()
       local r = assert(proxy_client:send {


### PR DESCRIPTION
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

### Summary

When using custom credential type for LDAP authentication (the `config.header_type` setting),
the WWW-Authenticate header that is sent back when auth failed should be accordingly set.

Using `Basic` as the header type should allow the use of any web browser as a client. When there's no (or an invalid) authentication data in the query, Kong replies with the `WWW-Authenticate` header. Currently, this header doesn't use  `config.header_type` so it sets `WWW-Authenticate: LDAP`, which is not understood by the browser, hence **the login popup won't show**. 

### Full changelog

* Fix in `kong/plugins/ldap-auth/access.lua`
* Add related tests in `spec/03-plugins/21-ldap-auth/01-access_spec.lua`

### Issues resolved

I don't think a proper issue has been open, but it has been reported [on discuss.konghq.com](https://discuss.konghq.com/t/how-to-enable-ldap-auth-browser-popup/1579)
