### PR TITLE
tests(pdk) fix phase checks for kong.response.get_source

### DIFF
--- a/t/01-pdk/08-response/00-phase_checks.t
+++ b/t/01-pdk/08-response/00-phase_checks.t
@@ -133,10 +133,10 @@ qq{
             }, {
                 method        = "get_source",
                 args          = { },
-                init_worker   = false,
+                init_worker   = "forced false",
                 certificate   = "pending",
-                rewrite       = false,
-                access        = false,
+                rewrite       = "forced false",
+                access        = "forced false",
                 header_filter = true,
                 body_filter   = true,
                 log           = true,


### PR DESCRIPTION
This function never generates an OpenResty error.
