### PR TITLE
feat(nightly) make rhel:6/7 and amazonlinux nightly as well

### DIFF
--- a/.ci/trigger-travis.sh
+++ b/.ci/trigger-travis.sh
@@ -109,6 +109,9 @@ body="{
         \"BUILD_RELEASE=true PLATFORM=ubuntu:12.04.5 $NIGHTLY $VERSION\",
         \"BUILD_RELEASE=true PLATFORM=ubuntu:14.04.2 $NIGHTLY $VERSION\",
         \"BUILD_RELEASE=true PLATFORM=ubuntu:16.04 $NIGHTLY $VERSION\",
+        \"BUILD_RELEASE=true PLATFORM=rhel:6 $NIGHTLY $VERSION\",
+        \"BUILD_RELEASE=true PLATFORM=rhel:7 $NIGHTLY $VERSION\",
+        \"BUILD_RELEASE=true PLATFORM=amazonlinux $NIGHTLY $VERSION\",
         \"BUILD_RELEASE=true PLATFORM=alpine $NIGHTLY $VERSION\"
       ]
     }


### PR DESCRIPTION
add rhel:6, rhel:7 and amazonlinux to the trigger-travis job that builds kong