### PR TITLE
fix(schema) declare timestamps as number to keep millisecond precision

### DIFF
--- a/kong/db/schema/entities/certificates.lua
+++ b/kong/db/schema/entities/certificates.lua
@@ -7,7 +7,7 @@ return {
 
   fields = {
     { id = typedefs.uuid, },
-    { created_at     = { type = "integer", timestamp = true, auto = true }, },
+    { created_at     = typedefs.auto_timestamp },
     { cert           = { type = "string",  required = true}, },
     { key            = { type = "string",  required = true}, },
   },

--- a/kong/db/schema/entities/consumers.lua
+++ b/kong/db/schema/entities/consumers.lua
@@ -8,7 +8,7 @@ return {
 
   fields = {
     { id             = typedefs.uuid, },
-    { created_at     = { type = "integer", timestamp = true, auto = true }, },
+    { created_at     = typedefs.auto_timestamp },
     { username       = { type = "string",  unique = true }, },
     { custom_id      = { type = "string",  unique = true }, },
   },

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -35,8 +35,8 @@ return {
 
   fields = {
     { id             = typedefs.uuid, },
-    { created_at     = { type = "integer", timestamp = true, auto = true }, },
-    { updated_at     = { type = "integer", timestamp = true, auto = true }, },
+    { created_at     = typedefs.auto_timestamp },
+    { updated_at     = typedefs.auto_timestamp },
     { protocols      = { type     = "set",
                          len_min  = 1,
                          required = true,

--- a/kong/db/schema/entities/services.lua
+++ b/kong/db/schema/entities/services.lua
@@ -19,8 +19,8 @@ return {
 
   fields = {
     { id              = typedefs.uuid, },
-    { created_at      = { type = "integer", timestamp = true, auto = true }, },
-    { updated_at      = { type = "integer", timestamp = true, auto = true }, },
+    { created_at      = typedefs.auto_timestamp },
+    { updated_at      = typedefs.auto_timestamp },
     { name            = { type = "string", unique = true,
                           custom_validator = validate_name }, },
     { retries         = { type = "integer", default = 5, between = { 0, 32767 } }, },

--- a/kong/db/schema/entities/snis.lua
+++ b/kong/db/schema/entities/snis.lua
@@ -9,7 +9,7 @@ return {
   fields = {
     { id           = typedefs.uuid, },
     { name         = { type = "string", required = true, unique = true }, },
-    { created_at   = { type = "integer", timestamp = true, auto = true }, },
+    { created_at   = typedefs.auto_timestamp },
     { certificate  = { type = "foreign", reference = "certificates", required = true }, },
   },
 

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -15,7 +15,7 @@ local pcall        = pcall
 local floor        = math.floor
 local type         = type
 local next         = next
-local time         = ngx.time
+local ngx_now      = ngx.now
 local null         = ngx.null
 local max          = math.max
 local sub          = string.sub
@@ -1022,7 +1022,7 @@ end
 -- appropriate updated values.
 function Schema:process_auto_fields(input, context)
   local output = tablex.deepcopy(input)
-  local now = time()
+  local now = ngx_now()
 
   for key, field in self:each_field() do
     if field.auto then

--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -174,7 +174,7 @@ local attribute_types = {
     ["integer"] = true,
   },
   timestamp = {
-    ["integer"] = true,
+    ["number"] = true,
   },
   uuid = {
     ["string"] = true,

--- a/kong/db/schema/typedefs.lua
+++ b/kong/db/schema/typedefs.lua
@@ -87,4 +87,10 @@ typedefs.uuid = Schema.define {
   auto = true,
 }
 
+typedefs.auto_timestamp = Schema.define {
+  type = "number",
+  timestamp = true,
+  auto = true
+}
+
 return typedefs

--- a/kong/db/strategies/cassandra/init.lua
+++ b/kong/db/strategies/cassandra/init.lua
@@ -433,7 +433,7 @@ local function deserialize_row(self, row)
   -- deserialize rows
   -- replace `nil` fields with `ngx.null`
   -- replace `foreign_key` with `foreign = { key = "" }`
-  -- give seconds precisions to timestamps instead of ms
+  -- return timestamps in seconds instead of ms
 
   for field_name, field in self.schema:each_field() do
     if field.type == "foreign" then

--- a/spec/01-unit/000-new-dao/01-schema/02-metaschema_spec.lua
+++ b/spec/01-unit/000-new-dao/01-schema/02-metaschema_spec.lua
@@ -176,7 +176,7 @@ describe("metaschema", function()
       ttl = true,
       fields = {
         { str = { type = "string", unique = true } },
-        { created_at = { type = "integer", timestamp = true, auto = true } },
+        { created_at = { type = "number", timestamp = true, auto = true } },
       },
       primary_key = { "str" },
     }

--- a/spec/02-integration/000-new-dao/02-db_core_entities_spec.lua
+++ b/spec/02-integration/000-new-dao/02-db_core_entities_spec.lua
@@ -205,8 +205,8 @@ for _, strategy in helpers.each_strategy() do
           }))
 
           local route_in_db = assert(db.routes:select({ id = route.id }))
-          assert.equal(now, route_in_db.created_at)
-          assert.equal(now, route_in_db.updated_at)
+          assert.truthy(now - route_in_db.created_at < 0.1)
+          assert.truthy(now - route_in_db.updated_at < 0.1)
         end)
 
         it("created_at/updated_at cannot be overriden", function()
@@ -1258,13 +1258,6 @@ for _, strategy in helpers.each_strategy() do
             name = "service_1",
             host = "service1.com",
           }))
-        end)
-
-        -- no I/O
-        it("errors on invalid arg", function()
-          assert.has_error(function()
-            db.services:delete_by_name(123)
-          end, "invalid argument 'name' (expected a string)")
         end)
 
         -- I/O


### PR DESCRIPTION
Currently the `created_at` the field in the new DAO uses second-level numbers instead of millisecond-level numbers (since we use `ngx.time` instead of `ngx.now`)

This changes that and makes all timestamps be stored with millisecond precision (no changes to the database are required, just that we replaced `ngx.time` by `ngx.now`).

However this is a breaking change: until now the `created_at` field looked like an integer, and now it will start looking like a float. 

This change is required by #3622 

