### PR TITLE
fix(conf) drop custom_plugins warning if already using plugins

### DIFF
--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -652,11 +652,14 @@ local function load(path, custom_conf)
     end
 
     if conf.custom_plugins and #conf.custom_plugins > 0 then
-      log.warn("the 'custom_plugins' configuration property is deprecated, " ..
-               "use 'plugins' instead")
-
+      local warned
       for i = 1, #conf.custom_plugins do
         local plugin_name = pl_stringx.strip(conf.custom_plugins[i])
+        if not plugins[plugin_name] and not warned then
+          log.warn("the 'custom_plugins' configuration property is deprecated, " ..
+                   "use 'plugins' instead")
+          warned = true
+        end
         plugins[plugin_name] = true
       end
     end

--- a/spec/fixtures/deprecated_custom_plugin.conf
+++ b/spec/fixtures/deprecated_custom_plugin.conf
@@ -1,6 +1,6 @@
 admin_listen = 127.0.0.1:9001
 proxy_listen = 0.0.0.0:9000
 prefix = servroot
-custom_plugins = key-auth
+custom_plugins = ctx-checker
 pg_database = kong_tests
 cassandra_keyspace = kong_tests


### PR DESCRIPTION
Only warn if the plugins listed in `custom_plugins` were not already in `plugins`.

