### PR TITLE
Changed priority so it runs second

### DIFF
--- a/kong/plugins/ip-restriction/handler.lua
+++ b/kong/plugins/ip-restriction/handler.lua
@@ -18,7 +18,7 @@ local cache = {}
 
 local IpRestrictionHandler = BasePlugin:extend()
 
-IpRestrictionHandler.PRIORITY = 990
+IpRestrictionHandler.PRIORITY = 2300
 IpRestrictionHandler.VERSION = "0.1.0"
 
 local function cidr_cache(cidr_tab)


### PR DESCRIPTION
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

### Summary

If someone is using this plugin, it makes sense to have it run before the auth does. That way, if a consumer is not on the whitelist (or on the blacklist), there is no need to even attempt to authenticate them. 

### Full changelog

* Changed priority of plugin from 990 to 2300
* 
* ...

### Issues resolved

Fix #XXX
