### PR TITLE
feat(jwt) add support to a custom header name

### DIFF
--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -50,13 +50,13 @@ local function retrieve_token(conf)
       end
       local iterator, iter_err = re_gmatch(token_header, "\\s*[Bb]earer\\s+(.+)")
       if not iterator then
-        ngx.log(ngx.ERR, "[jwt]: ", iter_err)
+        kong.log.err(iter_err)
         break
       end
 
       local m, err = iterator()
       if err then
-        ngx.log(ngx.ERR, "[jwt]: ", err)
+        kong.log.err(err)
         break
       end
 

--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -15,12 +15,12 @@ local JwtHandler = BasePlugin:extend()
 
 
 JwtHandler.PRIORITY = 1005
-JwtHandler.VERSION = "0.2.0"
+JwtHandler.VERSION = "0.2.1"
 
 
 --- Retrieve a JWT in a request.
 -- Checks for the JWT in URI parameters, then in cookies, and finally
--- in the `Authorization` header.
+-- in the configured header_names (defaults to `[Authorization]`).
 -- @param request ngx request object
 -- @param conf Plugin configuration
 -- @return token JWT token contained in request (can be a table) or nil
@@ -41,20 +41,28 @@ local function retrieve_token(conf)
     end
   end
 
-  local authorization_header = kong.request.get_header("authorization")
-  if authorization_header then
-    local iterator, iter_err = re_gmatch(authorization_header, "\\s*[Bb]earer\\s+(.+)")
-    if not iterator then
-      return nil, iter_err
-    end
+  local request_headers = kong.request.get_headers()
+  for _, v in ipairs(conf.header_names) do
+    local token_header = request_headers[v]
+    if token_header then
+      if type(token_header) == "table" then
+        token_header = token_header[1]
+      end
+      local iterator, iter_err = re_gmatch(token_header, "\\s*[Bb]earer\\s+(.+)")
+      if not iterator then
+        ngx.log(ngx.ERR, "[jwt]: ", iter_err)
+        break
+      end
 
-    local m, err = iterator()
-    if err then
-      return nil, err
-    end
+      local m, err = iterator()
+      if err then
+        ngx.log(ngx.ERR, "[jwt]: ", err)
+        break
+      end
 
-    if m and #m > 0 then
-      return m[1]
+      if m and #m > 0 then
+        return m[1]
+      end
     end
   end
 end

--- a/kong/plugins/jwt/schema.lua
+++ b/kong/plugins/jwt/schema.lua
@@ -29,6 +29,11 @@ return {
             default = 0,
             between = { 0, 31536000 },
           }, },
+          { header_names = {
+            type = "set",
+            elements = { type = "string" },
+            default = { "authorization" },
+          }, },
         },
       },
     },


### PR DESCRIPTION
### Summary

It allow the jwt plugin to work together with another authentication
method that uses the 'Authorization' header

Reference: https://discuss.konghq.com/t/custom-header-on-jwt-plugin/1524

### Full changelog

* Add a `header_names` field to jwt plugin schema;
* Change the `retrieve_token` method to  use the `header_names` field;
* Add a test to check if the custom `header_names` is used;
* Bump jwt plugin version from `0.2.0` to `0.2.1`.
