### PR TITLE
tests(admin) fix tests assuming the strategy is printed on errors

### DIFF
--- a/spec/02-integration/04-admin_api/03-consumers_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/03-consumers_routes_spec.lua
@@ -493,7 +493,6 @@ describe("Admin API (" .. strategy .. "): ", function()
               assert.same({
                 code     = Errors.codes.SCHEMA_VIOLATION,
                 name     = "schema violation",
-                strategy = strategy,
                 fields   = {
                   ["@entity"] = {
                     "at least one of these fields must be non-empty: 'custom_id', 'username'"

--- a/spec/02-integration/04-admin_api/06-certificates_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/06-certificates_routes_spec.lua
@@ -302,7 +302,6 @@ describe("Admin API: #" .. strategy, function()
         assert.same({
           code     = Errors.codes.SCHEMA_VIOLATION,
           name     = "schema violation",
-          strategy = strategy,
           message  = "2 schema violations (cert: required field missing; key: required field missing)",
           fields  = {
             cert = "required field missing",
@@ -729,7 +728,6 @@ describe("Admin API: #" .. strategy, function()
         assert.same({
           code     = Errors.codes.SCHEMA_VIOLATION,
           name     = "schema violation",
-          strategy = strategy,
           message  = "2 schema violations (certificate: required field missing; name: required field missing)",
           fields   = {
             certificate = "required field missing",

--- a/spec/02-integration/04-admin_api/20-routes_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/20-routes_routes_spec.lua
@@ -120,7 +120,6 @@ for _, strategy in helpers.each_strategy() do
               assert.same({
                 code     = Errors.codes.SCHEMA_VIOLATION,
                 name     = "schema violation",
-                strategy = strategy,
                 message  = unindent([[
                   2 schema violations
                   (at least one of these fields must be non-empty: 'methods', 'hosts', 'paths';
@@ -146,7 +145,6 @@ for _, strategy in helpers.each_strategy() do
               assert.same({
                 code     = Errors.codes.SCHEMA_VIOLATION,
                 name     = "schema violation",
-                strategy = strategy,
                 message  = "2 schema violations " ..
                           "(protocols: expected one of: http, https; " ..
                           "service: required field missing)",
@@ -239,7 +237,6 @@ for _, strategy in helpers.each_strategy() do
             assert.same({
               code     = Errors.codes.INVALID_OFFSET,
               name     = "invalid offset",
-              strategy = strategy,
               message  = "'x' is not a valid offset for this strategy: bad base64 encoding"
             }, cjson.decode(body))
 
@@ -252,7 +249,6 @@ for _, strategy in helpers.each_strategy() do
             assert.same({
               code     = Errors.codes.INVALID_OFFSET,
               name     = "invalid offset",
-              strategy = strategy,
             }, json)
           end)
 
@@ -275,7 +271,6 @@ for _, strategy in helpers.each_strategy() do
             assert.same({
               code     = Errors.codes.INVALID_PRIMARY_KEY,
               name     = "invalid primary key",
-              strategy = strategy,
               message  = [[invalid primary key: '{id="expected a valid UUID"}']],
               fields   = pk
             }, cjson.decode(body))
@@ -402,7 +397,6 @@ for _, strategy in helpers.each_strategy() do
                 assert.same({
                   code     = Errors.codes.SCHEMA_VIOLATION,
                   name     = "schema violation",
-                  strategy = strategy,
                   message  = unindent([[
                   2 schema violations
                   (at least one of these fields must be non-empty: 'methods', 'hosts', 'paths';
@@ -428,7 +422,6 @@ for _, strategy in helpers.each_strategy() do
                 assert.same({
                   code     = Errors.codes.SCHEMA_VIOLATION,
                   name     = "schema violation",
-                  strategy = strategy,
                   message  = "2 schema violations " ..
                     "(protocols: expected one of: http, https; " ..
                     "service: required field missing)",
@@ -452,7 +445,6 @@ for _, strategy in helpers.each_strategy() do
                 assert.same({
                   code     = Errors.codes.SCHEMA_VIOLATION,
                   name     = "schema violation",
-                  strategy = strategy,
                   message  = "schema violation (regex_priority: expected an integer)",
                   fields   = {
                     regex_priority = "expected an integer"
@@ -615,7 +607,6 @@ for _, strategy in helpers.each_strategy() do
                 assert.same({
                   code     = Errors.codes.SCHEMA_VIOLATION,
                   name     = "schema violation",
-                  strategy = strategy,
                   message  = "schema violation (regex_priority: expected an integer)",
                   fields   = {
                     regex_priority = "expected an integer"
@@ -758,7 +749,6 @@ for _, strategy in helpers.each_strategy() do
                 assert.same({
                   code     = Errors.codes.SCHEMA_VIOLATION,
                   name     = "schema violation",
-                  strategy = strategy,
                   message  = "schema violation (connect_timeout: expected an integer)",
                   fields   = {
                     connect_timeout = "expected an integer",

--- a/spec/02-integration/04-admin_api/21-services_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/21-services_routes_spec.lua
@@ -753,7 +753,6 @@ for _, strategy in helpers.each_strategy() do
             assert.same(
               {
                 name     = "schema violation",
-                strategy = strategy,
                 code     = Errors.codes.SCHEMA_VIOLATION,
                 message  = unindent([[
                   2 schema violations


### PR DESCRIPTION
**Note:** `next` is currently broken because tests expect `strategy` to appear but the code doesn't produce it; this is one possible solution: changing the tests. The other one is in an alternative PR, #3671 — one should be merged, the other dropped. :)

About this PR:

Error tables returned by the new DB calls now include the strategy:

https://github.com/Kong/kong/commit/9f5102fbcb05c53fdb0df9d178ab92630384d43b

But the Admin API cleans them up:

https://github.com/Kong/kong/blob/next/kong/api/endpoints.lua#L34-L36

This adjusts the tests to not expect `strategy`.