### PR TITLE
fix(api) no longer hide the strategy in returned errors

### DIFF
--- a/kong/api/endpoints.lua
+++ b/kong/api/endpoints.lua
@@ -31,10 +31,6 @@ local function handle_error(err_t)
     responses.send(500, tostring(err_t))
   end
 
-  if err_t.strategy then
-    err_t.strategy = nil
-  end
-
   local status = ERRORS_HTTP_CODES[err_t.code]
   if not status or status == 500 then
     return app_helpers.yield_error(err_t)

--- a/kong/api/init.lua
+++ b/kong/api/init.lua
@@ -79,10 +79,6 @@ local function new_db_on_error(self)
     return responses.send_HTTP_INTERNAL_SERVER_ERROR(tostring(err))
   end
 
-  if err.strategy then
-    err.strategy = nil
-  end
-
   if err.code == Errors.codes.SCHEMA_VIOLATION
   or err.code == Errors.codes.INVALID_PRIMARY_KEY
   or err.code == Errors.codes.FOREIGN_KEY_VIOLATION


### PR DESCRIPTION
**Note:** `next` is currently broken because tests expect `strategy` to appear but the code doesn't produce it; this is one possible solution: changing the tests. The other one is in an alternative PR, #3670 — one should be merged, the other dropped. :)

About this PR:

Avoid hiding the strategy name in errors returned by the Admin API.
