### PR TITLE
Bump lua-resty-healthcheck version

### DIFF
--- a/kong-0.14.0-0.rockspec
+++ b/kong-0.14.0-0.rockspec
@@ -31,7 +31,7 @@ dependencies = {
   "lua-resty-dns-client == 2.1.0",
   "lua-resty-worker-events == 0.3.3",
   "lua-resty-mediador == 0.1.2",
-  "lua-resty-healthcheck == 0.4.2",
+  "lua-resty-healthcheck == 0.5.0",
   "lua-resty-cookie == 0.1.0",
   "lua-resty-mlcache == 2.2.0",
   -- external Kong plugins


### PR DESCRIPTION
### Summary

This PR bumps lua-resty-healthcheck version to 0.5.0. The 0.5.0 version includes https active checks.

### Full changelog

* Bump lua-resty-healthcheck version 
