### PR TITLE
fix(globalpatches) properly cache mock ngx.shared dicts

### DIFF
--- a/kong/globalpatches.lua
+++ b/kong/globalpatches.lua
@@ -185,7 +185,7 @@ return function(options)
           local shm = rawget(self, key)
           if not shm then
             shm = SharedDict:new()
-            rawset(self, key, SharedDict:new())
+            rawset(self, key, shm)
           end
           return shm
         end

--- a/spec/02-integration/06-invalidations/01-cluster_events_spec.lua
+++ b/spec/02-integration/06-invalidations/01-cluster_events_spec.lua
@@ -19,6 +19,16 @@ for _, strategy in helpers.each_strategy() do
       cluster_events.strategy:truncate_events()
     end)
 
+    before_each(function()
+      ngx.shared.kong:flush_all()
+      ngx.shared.kong:flush_expired()
+      ngx.shared.kong_cluster_events:flush_all()
+      ngx.shared.kong_cluster_events:flush_expired()
+
+      local cluster_events = assert(kong_cluster_events.new { dao = dao })
+      cluster_events.strategy:truncate_events()
+    end)
+
     describe("new()", function()
       it("creates an instance", function()
         local cluster_events, err = kong_cluster_events.new { dao = dao }


### PR DESCRIPTION
Prior to this change, the shm retrieved as a result of the very first
`ngx.shared.<shm>` reference would be different than the one retrieved
in subsequent references to `ngx.shared.<shm>`.

This is an issue since the data stored by each of these mock shms is
stored in instances of themselves, therefore several references to
`ngx.shared.<shm>` could hold different data - which is breaking
compared to the real behavior of shms.