### PR TITLE
Bump luasec to 0.7

### DIFF
--- a/kong-0.14.0-0.rockspec
+++ b/kong-0.14.0-0.rockspec
@@ -12,7 +12,7 @@ description = {
 }
 dependencies = {
   "inspect == 3.1.1",
-  "luasec == 0.6",
+  "luasec == 0.7",
   "luasocket == 3.0-rc1",
   "penlight == 1.5.4",
   "lua-resty-http == 0.12",


### PR DESCRIPTION
### Summary

The dependency luasec 0.6 is not compatible with OpenSSL 1.1.0, thus could not compile.

See the issue
[https://github.com/brunoos/luasec/issues/101](url)

### Issues resolved

- Bump dependency luasec to 0.7
