### PR TITLE
 feat(core) add kong.resty.getssl module 

### DIFF
--- a/kong-0.14.0-0.rockspec
+++ b/kong-0.14.0-0.rockspec
@@ -65,6 +65,7 @@ build = {
     ["kong.templates.kong_defaults"] = "kong/templates/kong_defaults.lua",
 
     ["kong.resty.ctx"] = "kong/resty/ctx.lua",
+    ["kong.resty.getssl"] = "kong/resty/getssl.lua",
     ["kong.vendor.classic"] = "kong/vendor/classic.lua",
 
     ["kong.cmd"] = "kong/cmd/init.lua",

--- a/kong/resty/getssl.lua
+++ b/kong/resty/getssl.lua
@@ -1,0 +1,32 @@
+local ffi = require "ffi"
+local pushssl = require "openssl.ssl".pushffi -- will define SSL* in ffi
+local get_ssl_pointer = require "ngx.ssl".get_ssl_pointer
+
+
+local getssl
+if get_ssl_pointer == nil then
+  local err_msg = "OpenResty patch missing. See https://github.com/Kong/openresty-patches"
+
+  ngx.log(ngx.WARN, err_msg)
+
+  function getssl()
+    return nil, err_msg
+  end
+else
+  local cast = ffi.cast
+  local SSLp = ffi.typeof "SSL*"
+
+  function getssl()
+    local ptr, err = get_ssl_pointer()
+    if not ptr then
+      return nil, err
+    end
+    ptr = cast(SSLp, ptr)
+    return pushssl(ptr)
+  end
+end
+
+
+return {
+  getssl = getssl,
+}


### PR DESCRIPTION
### Summary

This allows fetching the `SSL*` object for the current client as a luaossl object