### PR TITLE
feat(db) implement the db:cluster_mutex() utility

### DIFF
--- a/kong/db/strategies/connector.lua
+++ b/kong/db/strategies/connector.lua
@@ -35,4 +35,24 @@ function Connector:truncate()
 end
 
 
+function Connector:setup_locks()
+  error(fmt("setup_locks() not implemented for '%s' strategy", self.database))
+end
+
+
+function Connector:insert_lock()
+  error(fmt("insert_lock() not implemented for '%s' strategy", self.database))
+end
+
+
+function Connector:read_lock()
+  error(fmt("read_lock() not implemented for '%s' strategy", self.database))
+end
+
+
+function Connector:remove_lock()
+  error(fmt("remove_lock() not implemented for '%s' strategy", self.database))
+end
+
+
 return Connector

--- a/spec/02-integration/000-new-dao/03-db_cluster_mutex_spec.lua
+++ b/spec/02-integration/000-new-dao/03-db_cluster_mutex_spec.lua
@@ -1,0 +1,112 @@
+local helpers = require "spec.helpers"
+
+
+for _, strategy in helpers.each_strategy("cassandra") do
+  describe("kong.db [#" .. strategy .. "]", function()
+    local db
+
+
+    setup(function()
+      local _
+      _, db, _ = helpers.get_db_utils(strategy)
+    end)
+
+
+    describe("db:cluster_mutex()", function()
+      it("returns 'true' when mutex ran and 'false' otherwise", function()
+        local t1 = ngx.thread.spawn(function()
+          local ok, err = db:cluster_mutex("my_key", nil, function()
+            ngx.sleep(0.1)
+          end)
+          assert.is_nil(err)
+          assert.equal(true, ok)
+        end)
+
+        local t2 = ngx.thread.spawn(function()
+          local ok, err = db:cluster_mutex("my_key", nil, function() end)
+          assert.is_nil(err)
+          assert.equal(false, ok)
+        end)
+
+        ngx.thread.wait(t1)
+        ngx.thread.wait(t2)
+      end)
+
+
+      it("mutex ensures only one callback gets called", function()
+        local cb1 = spy.new(function() end)
+        local cb2 = spy.new(function() ngx.sleep(0.3) end)
+
+        local t1 = ngx.thread.spawn(function()
+          ngx.sleep(0.2)
+
+          local _, err = db:cluster_mutex("my_key_2", { owner = "1" }, cb1)
+          assert.is_nil(err)
+        end)
+
+        local t2 = ngx.thread.spawn(function()
+          local _, err = db:cluster_mutex("my_key_2", { owner = "2" }, cb2)
+          assert.is_nil(err)
+        end)
+
+        ngx.thread.wait(t1)
+        ngx.thread.wait(t2)
+
+        assert.spy(cb2).was_called()
+        assert.spy(cb1).was_not_called()
+      end)
+
+
+      it("mutex can be subsequently acquired once released", function()
+        local cb1 = spy.new(function() end)
+        local cb2 = spy.new(function() end)
+
+        local t1 = ngx.thread.spawn(function()
+          local _, err = db:cluster_mutex("my_key_3", nil, cb1)
+          assert.is_nil(err)
+        end)
+
+        local t2 = ngx.thread.spawn(function()
+          local _, err = db:cluster_mutex("my_key_3", nil, cb2)
+          assert.is_nil(err)
+        end)
+
+        ngx.thread.wait(t1)
+        ngx.thread.wait(t2)
+
+        assert.spy(cb1).was_called()
+        assert.spy(cb2).was_called()
+      end)
+
+
+      it("mutex cannot be held for longer than opts.ttl across nodes (DB lock)", function()
+        local cb1 = spy.new(function()
+          -- remove worker lock
+          ngx.shared.kong_locks:delete("my_key_5")
+          -- make DB lock expire
+          ngx.sleep(1)
+        end)
+
+        local cb2 = spy.new(function() end)
+
+        local t1 = ngx.thread.spawn(function()
+          local ok, err = db:cluster_mutex("my_key_5", { ttl = 0.5 }, cb1)
+          assert.is_nil(err)
+          assert.equal(true, ok)
+        end)
+
+        local t2 = ngx.thread.spawn(function()
+          local ok, err = db:cluster_mutex("my_key_5", { ttl = 0.5 }, cb2)
+          assert.is_nil(ok)
+          assert.equal("timeout", err)
+        end)
+
+        ngx.thread.wait(t1)
+        ngx.thread.wait(t2)
+
+        assert.spy(cb1).was_called()
+        assert.spy(cb2).was_not_called()
+      end)
+    end)
+  end)
+end


### PR DESCRIPTION
This function can be called to set a cluster-wide lock (via the
underlying DB, currently C* only) to execute some code in a
"cluster-wide mutex".