### PR TITLE
Provide with migrations following #3656

### DIFF
--- a/kong/plugins/ldap-auth/access.lua
+++ b/kong/plugins/ldap-auth/access.lua
@@ -5,7 +5,6 @@ local ldap = require "kong.plugins.ldap-auth.ldap"
 
 local match = string.match
 local lower = string.lower
-local upper = string.upper
 local find = string.find
 local sub = string.sub
 local fmt = string.format
@@ -166,14 +165,7 @@ local function do_authentication(conf)
 
   -- If both headers are missing, return 401
   if not (authorization_value or proxy_authorization_value) then
-    local scheme = conf.header_type
-    if scheme == "ldap" then
-      -- ensure backwards compatibility (see GH PR #3656)
-      -- TODO: provide migration to capitalize older configurations
-      scheme = upper(scheme)
-    end
-
-    ngx.header["WWW-Authenticate"] = scheme .. ' realm="kong"'
+    ngx.header["WWW-Authenticate"] = conf.header_type .. ' realm="kong"'
     return false, {status = 401}
   end
 

--- a/kong/plugins/ldap-auth/migrations/cassandra.lua
+++ b/kong/plugins/ldap-auth/migrations/cassandra.lua
@@ -20,4 +20,35 @@ return {
     end,
     down = function(_, _, dao) end  -- not implemented
   },
+  {
+    name = "2018-08-08-100000_header_type_default_uppercase",
+    up = function(_, _, dao)
+      for ok, config, update in plugin_config_iterator(dao, "ldap-auth") do
+        if not ok then
+          return config
+        end
+        if config.header_type == 'ldap' then
+          config.header_type = 'LDAP'
+          local _, err = update(config)
+          if err then
+            return err
+          end
+        end
+      end
+    end,
+    down = function(_, _, dao)
+      for ok, config, update in plugin_config_iterator(dao, "ldap-auth") do
+        if not ok then
+          return config
+        end
+        if config.header_type == 'LDAP' then
+          config.header_type = 'ldap'
+          local _, err = update(config)
+          if err then
+            return err
+          end
+        end
+      end
+    end
+  },
 }

--- a/kong/plugins/ldap-auth/migrations/postgres.lua
+++ b/kong/plugins/ldap-auth/migrations/postgres.lua
@@ -20,4 +20,35 @@ return {
     end,
     down = function(_, _, dao) end  -- not implemented
   },
+  {
+    name = "2018-08-08-100000_header_type_default_uppercase",
+    up = function(_, _, dao)
+      for ok, config, update in plugin_config_iterator(dao, "ldap-auth") do
+        if not ok then
+          return config
+        end
+        if config.header_type == 'ldap' then
+          config.header_type = 'LDAP'
+          local _, err = update(config)
+          if err then
+            return err
+          end
+        end
+      end
+    end,
+    down = function(_, _, dao)
+      for ok, config, update in plugin_config_iterator(dao, "ldap-auth") do
+        if not ok then
+          return config
+        end
+        if config.header_type == 'LDAP' then
+          config.header_type = 'ldap'
+          local _, err = update(config)
+          if err then
+            return err
+          end
+        end
+      end
+    end
+  },
 }

--- a/kong/plugins/ldap-auth/schema.lua
+++ b/kong/plugins/ldap-auth/schema.lua
@@ -24,6 +24,6 @@ return {
     timeout = {type = "number", default = 10000},
     keepalive = {type = "number", default = 60000},
     anonymous = {type = "string", default = "", func = check_user},
-    header_type = {type = "string", default = "ldap"},
+    header_type = {type = "string", default = "LDAP"},
   }
 }


### PR DESCRIPTION
1. Add postgres/cassandra migrations
2. Change default config.header_type value from ldap to LDAP
3. Remove temporary code in ldap-auth/access.lua

NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

### Summary

Provide with migrations following #3656

### Full changelog

* Add postgres/cassandra migrations to update config.header_type value from ldap to LDAP
* Change default config.header_type value from ldap to LDAP
* Remove temporary code added in #3656 in ldap-auth/access.lua

### Issues resolved

Cleanup following #3656
