### PR TITLE
fix(*) properly check worker_events.post_local() ret values

### DIFF
--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -501,13 +501,13 @@ end
 
 function DAO:post_crud_event(operation, entity)
   if self.events then
-    local ok, err = self.events.post_local("dao:crud", operation, {
+    local _, err = self.events.post_local("dao:crud", operation, {
       operation = operation,
       schema    = self.schema,
       new_db    = true,
       entity    = entity,
     })
-    if not ok then
+    if err then
       log(ERR, "[db] failed to propagate CRUD operation: ", err)
     end
   end

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -213,15 +213,15 @@ return {
                                              data.operation)
 
         -- crud:routes
-        local ok, err = worker_events.post_local("crud", entity_channel, data)
-        if not ok then
+        local _, err = worker_events.post_local("crud", entity_channel, data)
+        if err then
           log(ngx.ERR, "[events] could not broadcast crud event: ", err)
           return
         end
 
         -- crud:routes:create
-        ok, err = worker_events.post_local("crud", entity_operation_channel, data)
-        if not ok then
+        _, err = worker_events.post_local("crud", entity_operation_channel, data)
+        if err then
           log(ngx.ERR, "[events] could not broadcast crud event: ", err)
           return
         end


### PR DESCRIPTION
This function can return one of:

1. `true, nil`
2. `nil, err`
3. `false, nil`

Case 3. occurs when the library is already polling, likely in situations
with busy Admin API workloads. Because our return values check were
incorrect, some error logs would appear such as:

```
[error] 32#0: *6883 [lua] handler.lua:218: [events] could not broadcast crud event: nil, client: 10.x.x.x, server: kong, request: "POST /auth/oauth2/token HTTP/1.1"
```