### PR TITLE
chore(deps) bump lua-cassandra to 1.3.2

### DIFF
--- a/kong-0.14.0-0.rockspec
+++ b/kong-0.14.0-0.rockspec
@@ -20,7 +20,7 @@ dependencies = {
   "multipart == 0.5.5",
   "version == 0.2",
   "kong-lapis == 1.6.0.1",
-  "lua-cassandra == 1.3.1",
+  "lua-cassandra == 1.3.2",
   "pgmoon == 1.8.0",
   "luatz == 0.3",
   "lua_system_constants == 0.1.2",


### PR DESCRIPTION
This release fixes an issue encountered in environments with DNS
load-balancing in effect for contact_points provided as hostnames (e.g.
Kubernetes with `contact_points = { "cassandra" }`).

This could result in `no host details for <peer IP>` errors when using
multiple instances of the Cluster module.

Changelog:

https://github.com/thibaultcha/lua-cassandra/blob/master/CHANGELOG.md#132