### PR TITLE
Optional X-Consumer-Groups ACL Header Improvement

### DIFF
--- a/kong/plugins/acl/handler.lua
+++ b/kong/plugins/acl/handler.lua
@@ -81,7 +81,9 @@ function ACLHandler:access(conf)
     return responses.send_HTTP_FORBIDDEN("You cannot consume this service")
   end
 
-  set_header(constants.HEADERS.CONSUMER_GROUPS, to_be_blocked)
+  if conf.set_groups_header then
+    set_header(constants.HEADERS.CONSUMER_GROUPS, to_be_blocked)
+  end
 end
 
 return ACLHandler

--- a/kong/plugins/acl/handler.lua
+++ b/kong/plugins/acl/handler.lua
@@ -81,7 +81,7 @@ function ACLHandler:access(conf)
     return responses.send_HTTP_FORBIDDEN("You cannot consume this service")
   end
 
-  if conf.set_groups_header then
+  if not conf.hide_groups_header then
     set_header(constants.HEADERS.CONSUMER_GROUPS, to_be_blocked)
   end
 end

--- a/kong/plugins/acl/schema.lua
+++ b/kong/plugins/acl/schema.lua
@@ -4,7 +4,8 @@ return {
   no_consumer = true,
   fields = {
     whitelist = { type = "array" },
-    blacklist = { type = "array" }
+    blacklist = { type = "array" },
+    set_groups_header = { type = "boolean", default = true }
   },
   self_check = function(schema, plugin_t, dao, is_update)
     if next(plugin_t.whitelist or {}) and next(plugin_t.blacklist or {}) then

--- a/kong/plugins/acl/schema.lua
+++ b/kong/plugins/acl/schema.lua
@@ -5,7 +5,7 @@ return {
   fields = {
     whitelist = { type = "array" },
     blacklist = { type = "array" },
-    set_groups_header = { type = "boolean", default = true }
+    hide_groups_header = { type = "boolean", default = false }
   },
   self_check = function(schema, plugin_t, dao, is_update)
     if next(plugin_t.whitelist or {}) and next(plugin_t.blacklist or {}) then


### PR DESCRIPTION
### Summary

As discussed here : https://github.com/Kong/kong/issues/3609

One of my biggest concerns with Kong's ACL functionality as it stands today is including the arbitrarily growing in size list of a consumers entire ACL groups as a header. In our specific implementation of Kong every route gets is own ACL group as the routes existing uuid, so we can then give consumers access to specific routes by adding that uuid to their ACL, I suspect this will be a popular pattern going forward for many users who implement Kong. 

I propose a boolean that will act as a switch and enable/disable sending the consumer groups as a header, as I suspect for plenty of use cases that the arbitrary group info in the header is not necessary and as it grows in size could one day break an otherwise working proxy by increasing the header size past what a API Provider will accept (since many API providers have a 8kb header size limit by default like Apache Tomcat). I would like a predictable header size going to the API provider that is static when it comes to size generally, and by enabling this functionality on the ACL plugin we can achieve that with Kong.

### Full changelog

1. Modify schema.lua to include new boolean property 'hide_groups_header' defaulted to false as to not break existing functionality

2. Modify handler.lua to account for 'hide_groups_header' boolean setting.

### Issues resolved

Fixes concern for growing Kong header size as ACL groups list grow. Also improves bytes across the wire to exclude potentially extraneous info of a consumers entire ACL group list.

---

Let me know if I am missing anything, not super familiar with the PR process in general but would like to see this functionality in one of Kong's upcoming releases as I have a few Kong consumer accounts at 50+ ACL groups and that extra header is already irking me a bit 😄 .