### PR TITLE
Get_last_failure does not catch errors such as POST, PATCH, which can…

### DIFF
--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -59,6 +59,7 @@ init_worker_by_lua_block {
     Kong.init_worker()
 }
 
+proxy_next_upstream timeout error  non_idempotent;
 
 > if #proxy_listeners > 0 then
 upstream kong_upstream {
@@ -81,7 +82,7 @@ server {
     error_log ${{PROXY_ERROR_LOG}} ${{LOG_LEVEL}};
 
     client_body_buffer_size ${{CLIENT_BODY_BUFFER_SIZE}};
-
+    
 > if proxy_ssl_enabled then
     ssl_certificate ${{SSL_CERT}};
     ssl_certificate_key ${{SSL_CERT_KEY}};


### PR DESCRIPTION
… affect the retry mechanism because the default value of proxy_next_upstream, error timeout, does not contain non_idempotent

The following is the explanation of proxy_next_upstream.
proxy_next_upstream
Specifies in which cases a request should be passed to the next server:
Default:
proxy_next_upstream error timeout;

non_idempotent
normally, requests with a non-idempotent method (POST, LOCK, PATCH) are not passed to the next server if a request has been sent to an upstream server (1.9.13); enabling this option explicitly allows retrying such requests;

NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

### Summary

SUMMARY_GOES_HERE

### Full changelog

* [Implement ...]
* [Add related tests]
* ...

### Issues resolved

Fix #XXX
