### PR TITLE
fix(hmac-auth) add deprecation transition for pr #3339

### DIFF
--- a/kong/plugins/hmac-auth/access.lua
+++ b/kong/plugins/hmac-auth/access.lua
@@ -190,12 +190,13 @@ end
 
 local function validate_signature(request, hmac_params, headers)
   local signature_1            = create_hash(request, hmac_params, headers)
-  local signature_1_deprecated = create_hash_deprecated(request, hmac_params, headers)
   local signature_2            = ngx_decode_base64(hmac_params.signature)
 
   if signature_1 == signature_2 then
     return true
   else
+    local signature_1_deprecated = create_hash_deprecated(request, hmac_params, headers)
+
     return signature_1_deprecated == signature_2
   end
 end

--- a/kong/plugins/hmac-auth/access.lua
+++ b/kong/plugins/hmac-auth/access.lua
@@ -129,7 +129,7 @@ end
 
 -- plugin assumes the request parameters being used for creating
 -- signature by client are not changed by core or any other plugin
-local function create_hash(request, hmac_params, headers)
+local function create_hash(request, request_uri, hmac_params, headers)
   local signing_string = ""
   local hmac_headers = hmac_params.hmac_headers
   local count = #hmac_headers
@@ -142,38 +142,7 @@ local function create_hash(request, hmac_params, headers)
       if header == "request-line" then
         -- request-line in hmac headers list
         local request_line = fmt("%s %s HTTP/%s", ngx.req.get_method(),
-                                 ngx.var.request_uri, ngx.req.http_version())
-        signing_string = signing_string .. request_line
-      else
-        signing_string = signing_string .. header .. ":"
-      end
-    else
-      signing_string = signing_string .. header .. ":" .. " " .. header_value
-    end
-    if i < count then
-      signing_string = signing_string .. "\n"
-    end
-  end
-  return hmac[hmac_params.algorithm](hmac_params.secret, signing_string)
-end
-
--- plugin assumes the request parameters being used for creating
--- signature by client are not changed by core or any other plugin
--- DEPRECATED BY: https://github.com/Kong/kong/pull/3339
-local function create_hash_deprecated(request, hmac_params, headers)
-  local signing_string = ""
-  local hmac_headers = hmac_params.hmac_headers
-  local count = #hmac_headers
-
-  for i = 1, count do
-    local header = hmac_headers[i]
-    local header_value = headers[header]
-
-    if not header_value then
-      if header == "request-line" then
-        -- request-line in hmac headers list
-        local request_line = fmt("%s %s HTTP/%s", ngx.req.get_method(), ngx.var.uri, ngx.req.http_version())
-
+                                 request_uri, ngx.req.http_version())
         signing_string = signing_string .. request_line
       else
         signing_string = signing_string .. header .. ":"
@@ -189,16 +158,17 @@ local function create_hash_deprecated(request, hmac_params, headers)
 end
 
 local function validate_signature(request, hmac_params, headers)
-  local signature_1 = create_hash(request, hmac_params, headers)
+  local signature_1 = create_hash(request, ngx.var.request_uri, hmac_params, headers)
   local signature_2 = ngx_decode_base64(hmac_params.signature)
 
   if signature_1 == signature_2 then
     return true
-  else
-    local signature_1_deprecated = create_hash_deprecated(request, hmac_params, headers)
-
-    return signature_1_deprecated == signature_2
   end
+
+  -- DEPRECATED BY: https://github.com/Kong/kong/pull/3339
+  local signature_1_deprecated = create_hash(request, ngx.var.uri, hmac_params, headers)
+
+  return signature_1_deprecated == signature_2
 end
 
 local function load_credential_into_memory(username)

--- a/kong/plugins/hmac-auth/access.lua
+++ b/kong/plugins/hmac-auth/access.lua
@@ -189,8 +189,8 @@ local function create_hash_deprecated(request, hmac_params, headers)
 end
 
 local function validate_signature(request, hmac_params, headers)
-  local signature_1            = create_hash(request, hmac_params, headers)
-  local signature_2            = ngx_decode_base64(hmac_params.signature)
+  local signature_1 = create_hash(request, hmac_params, headers)
+  local signature_2 = ngx_decode_base64(hmac_params.signature)
 
   if signature_1 == signature_2 then
     return true

--- a/spec/03-plugins/20-hmac-auth/03-access_spec.lua
+++ b/spec/03-plugins/20-hmac-auth/03-access_spec.lua
@@ -1080,6 +1080,47 @@ for _, strategy in helpers.each_strategy() do
         assert.res_status(200, res)
       end)
 
+      it("should pass with GET with request-line having query param but signed without query param", function()
+        local date = os.date("!%a, %d %b %Y %H:%M:%S GMT")
+        local encodedSignature = ngx.encode_base64(
+          hmac_sha1_binary("secret", "date: "
+            .. date .. "\n" .. "content-md5: md5" .. "\nGET /request HTTP/1.1"))
+        local hmacAuth = [[hmac username="bob",  algorithm="hmac-sha1", ]]
+          .. [[headers="date content-md5 request-line", signature="]]
+          .. encodedSignature .. [["]]
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/request?name=foo",
+          body    = {},
+          headers = {
+            ["HOST"]                = "hmacauth5.com",
+            date                    = date,
+            ["proxy-authorization"] = hmacAuth,
+            ["content-md5"]         = "md5",
+          },
+        })
+        assert.res_status(200, res)
+
+        encodedSignature = ngx.encode_base64(
+          hmac_sha1_binary("secret", "date: "
+            .. date .. "\n" .. "content-md5: md5" .. "\nGET /request/ HTTP/1.1"))
+        local hmacAuth = [[hmac username="bob",  algorithm="hmac-sha1", ]]
+          .. [[headers="date content-md5 request-line", signature="]]
+          .. encodedSignature .. [["]]
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/request/?name=foo",
+          body    = {},
+          headers = {
+            ["HOST"]                = "hmacauth5.com",
+            date                    = date,
+            ["proxy-authorization"] = hmacAuth,
+            ["content-md5"]         = "md5",
+          },
+        })
+        assert.res_status(200, res)
+      end)
+
       it("should pass with GET with request-line having query param", function()
         local date = os.date("!%a, %d %b %Y %H:%M:%S GMT")
         local encodedSignature = ngx.encode_base64(

--- a/spec/03-plugins/20-hmac-auth/03-access_spec.lua
+++ b/spec/03-plugins/20-hmac-auth/03-access_spec.lua
@@ -1081,6 +1081,10 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       it("should pass with GET with request-line having query param but signed without query param", function()
+        -- hmac-auth needs to validate signatures created both with and without 
+        -- query params for a supported deprecation period.
+        --
+        -- Regression for https://github.com/Kong/kong/issues/3672
         local date = os.date("!%a, %d %b %Y %H:%M:%S GMT")
         local encodedSignature = ngx.encode_base64(
           hmac_sha1_binary("secret", "date: "


### PR DESCRIPTION
### Summary
Add deprecation transition for PR #3339 by adding support for older signatures generated from `request-line` without the query_string. This is intended to be a patch on 0.13.1 but may apply to 0.14+ although I haven't tested this. 

### Full changelog
* add deprecation hmac-auth transition for pr #3339 

### Issues resolved

Fix #3672
