### PR TITLE
fix(ci) adjust deploy condition per travis docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ stages:
   - pdk tests
   - test
   - name: deploy
-    if: tag =~ 0. || TRAVIS_EVENT_TYPE == cron
+    if: tag =~ 0. || type == cron
 
 jobs:
   include:


### PR DESCRIPTION
the travis docs are a little ambiguous :(

travis uses travis-conditional for `if` logic that's applies to builds, stages and jobs but the deploy job `on` conditional has it's own way of working.

Since we're using `if` per the `travis-conditional` library documentation

```
The following known attributes are available:

type (the current event type, known event types are: push, pull_request, api, cron)
```

**References**
https://github.com/travis-ci/travis-conditions
https://docs.travis-ci.com/user/deployment#conditional-releases-with-on