### PR TITLE
Optional X-Consumer-Groups ACL Header Improvement, secondary memory footprint enhancement

### DIFF
--- a/kong/plugins/acl/handler.lua
+++ b/kong/plugins/acl/handler.lua
@@ -71,7 +71,7 @@ function ACLHandler:access(conf)
     if to_be_blocked == false then
       -- we're allowed, so go and convert 'false' to the header value, if we need it.
       -- if we don't need it, set a dummy value to save memory for potentially very long strings
-      to_be_blocked = conf.hide_groups_header and nil or table_concat(consumer_groups, ", ")
+      to_be_blocked = conf.hide_groups_header and "" or table_concat(consumer_groups, ", ")
     end
 
     -- update cache

--- a/kong/plugins/acl/handler.lua
+++ b/kong/plugins/acl/handler.lua
@@ -69,8 +69,9 @@ function ACLHandler:access(conf)
     end
 
     if to_be_blocked == false then
-      -- we're allowed, so go and convert 'false' to the header value
-      to_be_blocked = table_concat(consumer_groups, ", ")
+      -- we're allowed, so go and convert 'false' to the header value, if we need it.
+      -- if we don't need it, set a dummy value to save memory for potentially very long strings
+      to_be_blocked = conf.hide_groups_header and nil or table_concat(consumer_groups, ", ")
     end
 
     -- update cache

--- a/kong/plugins/acl/handler.lua
+++ b/kong/plugins/acl/handler.lua
@@ -69,9 +69,10 @@ function ACLHandler:access(conf)
     end
 
     if to_be_blocked == false then
-      -- we're allowed, so go and convert 'false' to the header value, if we need it.
-      -- if we don't need it, set a dummy value to save memory for potentially very long strings
-      to_be_blocked = conf.hide_groups_header and "" or table_concat(consumer_groups, ", ")
+      -- we're allowed, convert 'false' to the header value, if needed
+      -- if not needed, set dummy value to save mem for potential long strings
+      to_be_blocked = conf.hide_groups_header and "" 
+                      or table_concat(consumer_groups, ", ")
     end
 
     -- update cache


### PR DESCRIPTION
### Summary

Update to reduce Kong memory pressure when ACL X-Consumer-Groups header has been hidden as suggested by @Tieske . Related to Original PR https://github.com/Kong/kong/pull/3703

### Full changelog

* Modify kong/plugins/acl/handler.lua to_be_blocked = nil if conf.hide_groups_header enabled.

### Issues resolved
Improve memory footprint with ACL plugin.