### PR TITLE
refactor(db) default behavior was changed for how dao handled missing fields (ngx.null to nil)

### DIFF
--- a/kong/api/arguments.lua
+++ b/kong/api/arguments.lua
@@ -13,6 +13,7 @@ local pairs         = pairs
 local lower         = string.lower
 local find          = string.find
 local sub           = string.sub
+local next          = next
 local type          = type
 local ngx           = ngx
 local req           = ngx.req
@@ -213,7 +214,16 @@ local function infer_value(value, field)
   elseif field.type == "record" then
     if type(value) == "table" then
       for k, v in pairs(value) do
-        value[k] = infer_value(v, field.fields[k])
+        for i in ipairs(field.fields) do
+          local item = field.fields[i]
+          if item then
+            local key = next(item)
+            local fld = item[key]
+            if k == key then
+              value[k] = infer_value(v, fld)
+            end
+          end
+        end
       end
     end
   end

--- a/kong/api/routes/certificates.lua
+++ b/kong/api/routes/certificates.lua
@@ -1,11 +1,13 @@
 local endpoints   = require "kong.api.endpoints"
 local utils       = require "kong.tools.utils"
-local responses   = require "kong.tools.responses"
 local Set         = require "pl.Set"
 
 
+local unescape_uri = ngx.unescape_uri
+
+
 local function get_cert_id_from_sni(self, db, helpers)
-  local id = ngx.unescape_uri(self.params.certificates)
+  local id = unescape_uri(self.params.certificates)
   if utils.is_valid_uuid(id) then
     return
   end
@@ -25,7 +27,7 @@ local function get_cert_id_from_sni(self, db, helpers)
     return
   end
 
-  responses.send_HTTP_NOT_FOUND("SNI not found")
+  helpers.responses.send_HTTP_NOT_FOUND("SNI not found")
 end
 
 
@@ -37,9 +39,15 @@ return {
     GET = function(self, db, helpers)
       local pk = { id = self.params.certificates }
 
-      local cert, _, err_t = db.certificates:select_with_name_list(pk)
+      local opts = endpoints.extract_options(self.args.uri, db.certificates.schema, "select")
+
+      local cert, _, err_t = db.certificates:select_with_name_list(pk, opts)
       if err_t then
         return endpoints.handle_error(err_t)
+      end
+
+      if not cert then
+        return helpers.responses.send_HTTP_NOT_FOUND()
       end
 
       return helpers.responses.send_HTTP_OK(cert)
@@ -48,19 +56,23 @@ return {
     -- override to create a new SNI in the PUT /certificates/foo.com (create) case
     PUT = function(self, db, helpers)
       local args = self.args.post
+
+      local opts = endpoints.extract_options(args, db.certificates.schema, "upsert")
+
       local cert, err_t, _
-      local id = ngx.unescape_uri(self.params.certificates)
+      local id = unescape_uri(self.params.certificates)
 
       -- cert was found via id or sni inside `before` section
       if utils.is_valid_uuid(id) then
-        cert, _, err_t = db.certificates:upsert({ id = id }, args)
+        cert, _, err_t = db.certificates:upsert({ id = id }, args, opts)
 
       else -- create a new cert. Add extra sni if provided on url
         if self.new_put_sni then
           args.snis = Set.values(Set(args.snis or {}) + self.new_put_sni)
           self.new_put_sni = nil
         end
-        cert, _, err_t = db.certificates:insert(args)
+
+        cert, _, err_t = db.certificates:insert(args, opts)
       end
 
       if err_t then

--- a/kong/api/routes/routes.lua
+++ b/kong/api/routes/routes.lua
@@ -43,9 +43,7 @@ return {
     end,
 
     before = function(self, db, helpers)
-      local id = self.params.routes
-
-      local parent_entity, _, err_t = db.routes:select({ id = id })
+      local parent_entity, _, err_t = db.routes:select({ id = self.params.routes })
       if err_t then
         return endpoints.handle_error(err_t)
       end

--- a/kong/api/routes/upstreams.lua
+++ b/kong/api/routes/upstreams.lua
@@ -4,35 +4,55 @@ local utils = require "kong.tools.utils"
 local public = require "kong.tools.public"
 
 
-local function select_upstream(db, upstream_id)
-  local id = ngx.unescape_uri(upstream_id)
+local unescape_uri = ngx.unescape_uri
+local escape_uri = ngx.escape_uri
+local null = ngx.null
+local fmt = string.format
+
+
+local function select_upstream(db, upstream_id, options)
+  local id = unescape_uri(upstream_id)
   if utils.is_valid_uuid(id) then
-    return db.upstreams:select({ id = id })
+    return db.upstreams:select({ id = id }, options)
   end
-  return db.upstreams:select_by_name(id)
+
+  return db.upstreams:select_by_name(id, options)
 end
 
 
-local function select_target(db, upstream, target_id)
-  local id = ngx.unescape_uri(target_id)
+local function select_target(db, upstream, target_id, options)
+  local id = unescape_uri(target_id)
   local filter = utils.is_valid_uuid(id) and { id = id } or { target = id }
-  return db.targets:for_upstream_first({ id = upstream.id }, filter)
+
+  return db.targets:for_upstream_first({ id = upstream.id }, filter, options)
 end
 
 
 local function post_health(self, db, is_healthy)
-  local upstream, _, err_t = select_upstream(db, self.params.upstreams)
-  if err_t then
-    return endpoints.handle_error(err_t)
-  end
-  local target, _, err_t = select_target(db, upstream, self.params.targets)
+  local args = self.args.post
+  local opts = endpoints.extract_options(args, db.upstreams.schema, "select")
+
+  local upstream, _, err_t = select_upstream(db, self.params.upstreams, opts)
   if err_t then
     return endpoints.handle_error(err_t)
   end
 
-  local ok, err = db.targets:post_health(upstream, target, is_healthy)
-  if not ok then
-    responses.send_HTTP_BAD_REQUEST(err)
+  if not upstream then
+    return responses.send_HTTP_NOT_FOUND()
+  end
+
+  opts = endpoints.extract_options(args, db.targets.schema, "select", opts)
+
+  local target, _, err_t = select_target(db, upstream, self.params.targets, opts)
+  if err_t then
+    return endpoints.handle_error(err_t)
+  end
+
+  if target then
+    local ok, err = db.targets:post_health(upstream, target, is_healthy)
+    if not ok then
+      responses.send_HTTP_BAD_REQUEST(err)
+    end
   end
 
   return responses.send_HTTP_NO_CONTENT()
@@ -42,30 +62,40 @@ end
 return {
   ["/upstreams/:upstreams/health"] = {
     GET = function(self, db)
-      local node_id, err = public.get_node_id()
-      if err then
-        ngx.log(ngx.ERR, "failed getting node id: ", err)
-      end
+      local args = self.args.uri
+      local opts = endpoints.extract_options(args, db.upstreams.schema, "select")
 
-      local upstream, _, err_t = select_upstream(db, self.params.upstreams)
+      local upstream, _, err_t = select_upstream(db, self.params.upstreams, opts)
       if err_t then
         return endpoints.handle_error(err_t)
       end
 
+      if not upstream then
+        return responses.send_HTTP_NOT_FOUND()
+      end
+
+      local id = { id = upstream.id }
+      local size, err = endpoints.get_page_size(args)
+      if err then
+        return endpoints.handle_error(db.targets.errors:invalid_size(err))
+      end
+
+      opts = endpoints.extract_options(args, db.targets.schema, "select")
+
       local targets_with_health, _, err_t, offset =
-      db.targets:for_upstream_with_health({ id = upstream.id },
-                                          tonumber(self.args.size),
-                                          self.args.offset)
-      if not targets_with_health then
+        db.targets:for_upstream_with_health(id, size, args.offset, opts)
+      if err_t then
         return endpoints.handle_error(err_t)
       end
 
-      local next_page = ngx.null
-      if offset then
-        next_page = string.format("/upstreams/%s/health?offset=%s",
-                                  ngx.escape_uri(upstream.id),
-                                  ngx.escape_uri(offset))
+      local next_page = offset and fmt("/upstreams/%s/health?offset=%s",
+                                       escape_uri(upstream.id),
+                                       escape_uri(offset)) or null
 
+
+      local node_id, err = public.get_node_id()
+      if err then
+        ngx.log(ngx.ERR, "failed getting node id: ", err)
       end
 
       return responses.send_HTTP_OK({
@@ -79,30 +109,38 @@ return {
 
   ["/upstreams/:upstreams/targets/all"] = {
     GET = function(self, db)
-      local upstream, _, err_t = select_upstream(db, self.params.upstreams)
+      local args = self.args.uri
+      local opts = endpoints.extract_options(args, db.upstreams.schema, "select")
+
+      local upstream, _, err_t = select_upstream(db, self.params.upstreams, opts)
       if err_t then
         return endpoints.handle_error(err_t)
       end
-      local targets, _, err_t, offset =
-        db.targets:for_upstream_raw({ id = upstream.id },
-                                    tonumber(self.args.size),
-                                    self.args.offset)
-      if not targets then
+
+      if not upstream then
+        return responses.send_HTTP_NOT_FOUND()
+      end
+
+      local id = { id = upstream.id }
+      local opts = endpoints.extract_options(args, db.targets.schema, "select")
+      local size, err = endpoints.get_page_size(args)
+      if err then
+        return endpoints.handle_error(db.targets.errors:invalid_size(err))
+      end
+
+      local targets, _, err_t, offset = db.targets:for_upstream_raw(id, size, args.offset, opts)
+      if err_t then
         return endpoints.handle_error(err_t)
       end
 
-      local next_page
-      if offset then
-        next_page = string.format("/upstreams/%s/targets/all?offset=%s",
-                                  ngx.escape_uri(upstream.id),
-                                  ngx.escape_uri(offset))
-      end
-
+      local next_page = offset and fmt("/upstreams/%s/targets/all?offset=%s",
+                                       escape_uri(upstream.id),
+                                       escape_uri(offset)) or null
 
       return responses.send_HTTP_OK({
-        data  = targets,
-        offset  = offset,
-        next    = next_page,
+        data   = targets,
+        offset = offset,
+        next   = next_page,
       })
     end
   },
@@ -121,20 +159,35 @@ return {
 
   ["/upstreams/:upstreams/targets/:targets"] = {
     DELETE = function(self, db)
-      local upstream, _, err_t = select_upstream(db, self.params.upstreams)
+      local args = self.args.uri
+      local opts = endpoints.extract_options(args, db.upstreams.schema, "select")
+
+      local upstream, _, err_t = select_upstream(db, self.params.upstreams, opts)
       if err_t then
         return endpoints.handle_error(err_t)
       end
-      local target, _, err_t = select_target(db, upstream, self.params.targets)
+
+      if not upstream then
+        return responses.send_HTTP_NOT_FOUND()
+      end
+
+      opts = endpoints.extract_options(args, db.targets.schema, "select")
+
+      local target, _, err_t = select_target(db, upstream, self.params.targets, opts)
       if err_t then
         return endpoints.handle_error(err_t)
       end
-      local _, _, err_t = db.targets:delete({ id = target.id })
-      if err_t then
-        return endpoints.handle_error(err_t)
+
+      if target then
+        opts = endpoints.extract_options(args, db.targets.schema, "delete")
+
+        local _, _, err_t = db.targets:delete({ id = target.id }, opts)
+        if err_t then
+          return endpoints.handle_error(err_t)
+        end
       end
+
       return responses.send_HTTP_NO_CONTENT()
     end
-  }
+  },
 }
-

--- a/kong/db/dao/consumers.lua
+++ b/kong/db/dao/consumers.lua
@@ -1,4 +1,8 @@
+local pairs = pairs
+
+
 local _Consumers = {}
+
 
 local function delete_cascade(self, table_name, fk)
   local old_dao = self.db.old_dao
@@ -37,22 +41,26 @@ local function delete_cascade_all(self, consumer_id)
 end
 
 
-function _Consumers:delete(primary_key)
+function _Consumers:delete(primary_key, options)
   delete_cascade_all(self, primary_key.id)
-  return self.super.delete(self, primary_key)
+
+  return self.super.delete(self, primary_key, options)
 end
 
 
-function _Consumers:delete_by_username(username)
+function _Consumers:delete_by_username(username, options)
   local entity, err, err_t = self:select_by_username(username)
   if err then
     return nil, err, err_t
   end
+
   if not entity then
     return true
   end
+
   delete_cascade_all(self, entity.id)
-  return self.super.delete_by_username(self, username)
+
+  return self.super.delete_by_username(self, username, options)
 end
 
 

--- a/kong/db/dao/snis.lua
+++ b/kong/db/dao/snis.lua
@@ -2,6 +2,12 @@ local cjson = require "cjson"
 local Set   = require "pl.Set"
 
 
+local setmetatable = setmetatable
+local tostring = tostring
+local ipairs = ipairs
+local table = table
+
+
 local function invalidate_cache(self, old_entity, err, err_t)
   if err then
     return nil, err, err_t
@@ -59,7 +65,7 @@ end
 function _SNIs:delete_list(name_list)
   local err_list = {}
   local errors_len = 0
-  local first_err_t = nil
+  local first_err_t
   for i = 1, #name_list do
     local ok, err, err_t = self:delete_by_name(name_list[i])
     if not ok then
@@ -78,17 +84,20 @@ end
 
 
 -- Returns the name list for a given certificate
-function _SNIs:list_for_certificate(cert_pk)
+function _SNIs:list_for_certificate(cert_pk, options)
   local name_list = setmetatable({}, cjson.empty_array_mt)
-  local rows, err, err_t = self:for_certificate(cert_pk)
+
+  local rows, err, err_t = self:for_certificate(cert_pk, options)
   if err then
     return nil, err, err_t
   end
+
   for i = 1, #rows do
     name_list[i] = rows[i].name
   end
 
   table.sort(name_list)
+
   return name_list
 end
 
@@ -120,46 +129,46 @@ end
 
 
 -- invalidates the *old* name when updating it to a new name
-function _SNIs:update(pk, entity)
+function _SNIs:update(pk, entity, options)
   local _, err, err_t = invalidate_cache(self, self:select(pk))
   if err then
     return nil, err, err_t
   end
 
-  return self.super.update(self, pk, entity)
+  return self.super.update(self, pk, entity, options)
 end
 
 
 -- invalidates the *old* name when updating it to a new name
-function _SNIs:update_by_name(name, entity)
+function _SNIs:update_by_name(name, entity, options)
   local _, err, err_t = invalidate_cache(self, self:select_by_name(name))
   if err then
     return nil, err, err_t
   end
 
-  return self.super.update_by_name(self, name, entity)
+  return self.super.update_by_name(self, name, entity, options)
 end
 
 
 -- invalidates the *old* name when updating it to a new name
-function _SNIs:upsert(pk, entity)
+function _SNIs:upsert(pk, entity, options)
   local _, err, err_t = invalidate_cache(self, self:select(pk))
   if err then
     return nil, err, err_t
   end
 
-  return self.super.upsert(self, pk, entity)
+  return self.super.upsert(self, pk, entity, options)
 end
 
 
 -- invalidates the *old* name when updating it to a new name
-function _SNIs:upsert_by_name(name, entity)
+function _SNIs:upsert_by_name(name, entity, options)
   local _, err, err_t = invalidate_cache(self, self:select_by_name(name))
   if err then
     return nil, err, err_t
   end
 
-  return self.super.upsert_by_name(self, name, entity)
+  return self.super.upsert_by_name(self, name, entity, options)
 end
 
 

--- a/kong/db/strategies/cassandra/connector.lua
+++ b/kong/db/strategies/cassandra/connector.lua
@@ -264,7 +264,7 @@ function CassandraConnector:reset()
 end
 
 
-function CassandraConnector:truncate()
+function CassandraConnector:truncate(options)
   local ok, err = self:connect()
   if not ok then
     return nil, err
@@ -301,7 +301,7 @@ function CassandraConnector:truncate()
 end
 
 
-function CassandraConnector:truncate_table(table_name)
+function CassandraConnector:truncate_table(table_name, options)
   local cql = string.format("TRUNCATE TABLE %s.%s",
                             self.keyspace, table_name)
 

--- a/kong/db/strategies/cassandra/init.lua
+++ b/kong/db/strategies/cassandra/init.lua
@@ -4,6 +4,10 @@ local cjson = require "cjson"
 
 local fmt           = string.format
 local rep           = string.rep
+local null          = ngx.null
+local error         = error
+local pairs         = pairs
+local ipairs        = ipairs
 local insert        = table.insert
 local concat        = table.concat
 local setmetatable  = setmetatable
@@ -232,7 +236,7 @@ end
 local function serialize_arg(field, arg)
   local serialized_arg
 
-  if arg == ngx.null then
+  if arg == null then
     serialized_arg = cassandra.null
 
   elseif field.uuid then
@@ -289,8 +293,8 @@ local function serialize_foreign_pk(db_columns, args, args_names, foreign_pk)
   for _, db_column in ipairs(db_columns) do
     local to_serialize
 
-    if foreign_pk == ngx.null then
-      to_serialize = ngx.null
+    if foreign_pk == null then
+      to_serialize = null
 
     else
       to_serialize = foreign_pk[db_column.foreign_field_name]
@@ -444,8 +448,8 @@ function _M.new(connector, schema, errors)
         insert(select_foreign_bind_args, foreign_key_column.col_name .. " = ?")
       end
 
-      self[method_name] = function(self, foreign_key, size, offset)
-        return self:page(size, offset, foreign_key, db_columns)
+      self[method_name] = function(self, foreign_key, size, offset, options)
+        return self:page(size, offset, options, foreign_key, db_columns)
       end
     end
   end
@@ -493,7 +497,7 @@ local function deserialize_row(self, row)
     end
 
     if row[field_name] == nil then
-      row[field_name] = ngx.null
+      row[field_name] = null
     end
   end
 
@@ -547,7 +551,7 @@ function _mt:insert(entity, options)
     if field.type == "foreign" then
       local foreign_pk = entity[field_name]
 
-      if foreign_pk ~= ngx.null then
+      if foreign_pk ~= null then
         -- if given, check if this foreign entity exists
         local exists, err_t = foreign_pk_exists(self, field_name, field, foreign_pk)
         if not exists then
@@ -560,7 +564,7 @@ function _mt:insert(entity, options)
 
     else
       if field.unique
-        and entity[field_name] ~= ngx.null
+        and entity[field_name] ~= null
         and entity[field_name] ~= nil
       then
         -- a UNIQUE constaint is set on this field.
@@ -612,11 +616,11 @@ function _mt:insert(entity, options)
     local value = entity[field_name]
 
     if field.type == "foreign" then
-      if value ~= ngx.null and value ~= nil then
+      if value ~= null and value ~= nil then
         value = extract_pk_values(field.schema, value)
 
       else
-        value = ngx.null
+        value = null
       end
     end
 
@@ -664,7 +668,7 @@ do
   local opts = new_tab(0, 2)
 
 
-  function _mt:page(size, offset, foreign_key, foreign_key_db_columns)
+  function _mt:page(size, offset, options, foreign_key, foreign_key_db_columns)
     if offset then
       local offset_decoded = decode_base64(offset)
       if not offset_decoded then
@@ -778,6 +782,7 @@ do
       rows_idx     = nil,
       offset       = nil,
       size         = size,
+      options      = options,
       strategy     = self,
     }
 
@@ -813,7 +818,7 @@ do
         if field.type == "foreign" then
           local foreign_pk = entity[field_name]
 
-          if foreign_pk ~= ngx.null then
+          if foreign_pk ~= null then
             -- if given, check if this foreign entity exists
             local exists, err_t = foreign_pk_exists(self, field_name, field, foreign_pk)
             if not exists then
@@ -825,7 +830,7 @@ do
           serialize_foreign_pk(db_columns, args, args_names, foreign_pk)
 
         else
-          if field.unique and entity[field_name] ~= ngx.null then
+          if field.unique and entity[field_name] ~= null then
             -- a UNIQUE constaint is set on this field.
             -- We unfortunately follow a read-before-write pattern in this case,
             -- but this is made necessary for Kong to behave in a
@@ -1045,8 +1050,8 @@ function _mt:delete_by_field(field_name, field_value, options)
 end
 
 
-function _mt:truncate()
-  return self.connector:truncate_table(self.schema.name)
+function _mt:truncate(options)
+  return self.connector:truncate_table(self.schema.name, options)
 end
 
 

--- a/kong/db/strategies/cassandra/routes.lua
+++ b/kong/db/strategies/cassandra/routes.lua
@@ -38,7 +38,7 @@ function _Routes:delete(primary_key)
     }, nil, "write")
     if not res then
       return nil, self.errors:database_error("could not delete plugin " ..
-                                              "associated with Route: " .. err)
+                                             "associated with Route: " .. err)
     end
   end
 

--- a/kong/db/strategies/cassandra/services.lua
+++ b/kong/db/strategies/cassandra/services.lua
@@ -50,8 +50,8 @@ local function delete_cascade(connector, table_name, service_id, errors)
 end
 
 
-function _Services:delete(primary_key)
-  local ok, err_t = self.super.delete(self, primary_key)
+function _Services:delete(primary_key, options)
+  local ok, err_t = self.super.delete(self, primary_key, options)
   if not ok then
     return nil, err_t
   end

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -29,7 +29,6 @@ local fmt         = string.format
 local sort        = table.sort
 local ngx         = ngx
 local log         = ngx.log
-local null        = ngx.null
 local ngx_now     = ngx.now
 local update_time = ngx.update_time
 local unpack      = unpack
@@ -109,7 +108,7 @@ local function build_router(db, version)
       service = service,
     }
 
-    if route.hosts ~= null then
+    if route.hosts then
       -- TODO: headers should probably be moved to route
       r.headers = {
         host = route.hosts,
@@ -544,7 +543,7 @@ return {
       -- TODO: this is probably not optimal
       do
         local retries = service.retries or api.retries
-        if retries ~= null then
+        if retries then
           balancer_data.retries = retries
 
         else
@@ -553,7 +552,7 @@ return {
 
         local connect_timeout = service.connect_timeout or
                                 api.upstream_connect_timeout
-        if connect_timeout ~= null then
+        if connect_timeout then
           balancer_data.connect_timeout = connect_timeout
 
         else
@@ -562,7 +561,7 @@ return {
 
         local send_timeout = service.write_timeout or
                              api.upstream_send_timeout
-        if send_timeout ~= null then
+        if send_timeout then
           balancer_data.send_timeout = send_timeout
 
         else
@@ -571,7 +570,7 @@ return {
 
         local read_timeout = service.read_timeout or
                              api.upstream_read_timeout
-        if read_timeout ~= null then
+        if read_timeout then
           balancer_data.read_timeout = read_timeout
 
         else

--- a/spec-old-api/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec-old-api/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -315,7 +315,10 @@ describe("Admin API #" .. strategy, function()
           })
           local body = assert.response(res).has.status(200)
           local json = cjson.decode(body)
-          assert.same({ data = {} }, json)
+          assert.same({
+            data = {},
+            next = ngx.null
+          }, json)
         end)
       end)
     end)

--- a/spec/01-unit/000-new-dao/03-arguments_spec.lua
+++ b/spec/01-unit/000-new-dao/03-arguments_spec.lua
@@ -56,9 +56,9 @@ describe("arguments.infer_value", function()
 
   it("infers records", function()
     assert.same({ age = "1" }, infer_value({ age = "1" },
-                                           { type = "record", fields = { age = { type = "string" } } }))
+                                           { type = "record", fields = {{ age = { type = "string" } } }}))
     assert.same({ age = 1 },   infer_value({ age = "1" },
-                                           { type = "record", fields = { age = { type = "number" } } }))
+                                           { type = "record", fields = {{ age = { type = "number" } } }}))
   end)
 
   it("returns the provided value when inferring is not possible", function()

--- a/spec/02-integration/000-new-dao/02-db_core_entities_spec.lua
+++ b/spec/02-integration/000-new-dao/02-db_core_entities_spec.lua
@@ -182,9 +182,7 @@ for _, strategy in helpers.each_strategy() do
             created_at      = route.created_at,
             updated_at      = route.updated_at,
             protocols       = { "http" },
-            methods         = ngx.null,
             hosts           = { "example.com" },
-            paths           = ngx.null,
             regex_priority  = 0,
             preserve_host   = false,
             strip_path      = true,
@@ -214,7 +212,6 @@ for _, strategy in helpers.each_strategy() do
             created_at      = route.created_at,
             updated_at      = route.updated_at,
             protocols       = { "http" },
-            methods         = ngx.null,
             hosts           = { "example.com" },
             paths           = { "/example" },
             regex_priority  = 3,
@@ -457,7 +454,6 @@ for _, strategy in helpers.each_strategy() do
             assert.is_nil(err)
             assert.same({ "example2.com" }, new_route.hosts)
             assert.same({ "GET" }, new_route.methods)
-            assert.same(ngx.null, new_route.paths)
             route.hosts     = nil
             new_route.hosts = nil
             assert.same(route, new_route)
@@ -878,11 +874,9 @@ for _, strategy in helpers.each_strategy() do
             id              = service.id,
             created_at      = service.created_at,
             updated_at      = service.updated_at,
-            name            = ngx.null,
             protocol        = "http",
             host            = "example.com",
             port            = 80,
-            path            = ngx.null,
             connect_timeout = 60000,
             write_timeout   = 60000,
             read_timeout    = 60000,
@@ -1349,9 +1343,7 @@ for _, strategy in helpers.each_strategy() do
           created_at       = route.created_at,
           updated_at       = route.updated_at,
           protocols        = { "http" },
-          methods          = ngx.null,
           hosts            = { "example.com" },
-          paths            = ngx.null,
           regex_priority   = 0,
           strip_path       = true,
           preserve_host    = false,

--- a/spec/02-integration/04-admin_api/03-consumers_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/03-consumers_routes_spec.lua
@@ -315,7 +315,7 @@ describe("Admin API (" .. strategy .. "): ", function()
             assert.equal("alice", json.username)
             assert.equal(consumer.id, json.id)
 
-            local in_db = assert(db.consumers:select {id = consumer.id})
+            local in_db = assert(db.consumers:select {id = consumer.id}, { nulls = true })
             assert.same(json, in_db)
           end
         end)
@@ -334,7 +334,7 @@ describe("Admin API (" .. strategy .. "): ", function()
             assert.equal("alice", json.username)
             assert.equal(consumer.id, json.id)
 
-            local in_db = assert(db.consumers:select {id = consumer.id})
+            local in_db = assert(db.consumers:select {id = consumer.id}, { nulls = true })
             assert.same(json, in_db)
           end
         end)
@@ -355,7 +355,7 @@ describe("Admin API (" .. strategy .. "): ", function()
             assert.equal("wxyz", json.custom_id)
             assert.equal(consumer.id, json.id)
 
-            local in_db = assert(db.consumers:select {id = consumer.id})
+            local in_db = assert(db.consumers:select {id = consumer.id}, { nulls = true })
             assert.same(json, in_db)
           end
         end)
@@ -443,7 +443,7 @@ describe("Admin API (" .. strategy .. "): ", function()
             local json = cjson.decode(body)
             assert.equal("peter", json.username)
 
-            local in_db = assert(db.consumers:select({ id = consumer.id }))
+            local in_db = assert(db.consumers:select({ id = consumer.id }, { nulls = true }))
             assert.same(json, in_db)
           end
         end)

--- a/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -44,8 +44,8 @@ describe("Admin API #" .. strategy, function()
   end)
 
   before_each(function()
-    assert(db:truncate("upstreams"))
     assert(db:truncate("targets"))
+    assert(db:truncate("upstreams"))
     assert(helpers.start_kong({
       database   = strategy,
       nginx_conf = "spec/fixtures/custom_nginx.template",
@@ -527,7 +527,10 @@ describe("Admin API #" .. strategy, function()
           })
           local body = assert.response(res).has.status(200)
           local json = cjson.decode(body)
-          assert.same({ data = {} }, json)
+          assert.same({
+            data = {},
+            next = ngx.null,
+          }, json)
         end)
       end)
     end)

--- a/spec/02-integration/04-admin_api/20-routes_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/20-routes_routes_spec.lua
@@ -32,6 +32,7 @@ for _, strategy in helpers.each_strategy() do
 
     before_each(function()
       helpers.stop_kong()
+      assert(db:truncate("plugins"))
       assert(db:truncate("routes"))
       assert(db:truncate("services"))
       assert(helpers.start_kong({
@@ -368,7 +369,7 @@ for _, strategy in helpers.each_strategy() do
               assert.same(cjson.null, json.methods)
               assert.equal(route.id, json.id)
 
-              local in_db = assert(db.routes:select({ id = route.id }))
+              local in_db = assert(db.routes:select({ id = route.id }, { nulls = true }))
               assert.same(json, in_db)
             end
           end)
@@ -391,7 +392,7 @@ for _, strategy in helpers.each_strategy() do
               assert.same(cjson.null, json.methods)
               assert.equal(route.id, json.id)
 
-              local in_db = assert(db.routes:select({ id = route.id }))
+              local in_db = assert(db.routes:select({ id = route.id }, { nulls = true }))
               assert.same(json, in_db)
             end
           end)
@@ -496,7 +497,7 @@ for _, strategy in helpers.each_strategy() do
               assert.same(cjson.null, json.methods)
               assert.equal(route.id, json.id)
 
-              local in_db = assert(db.routes:select({ id = route.id }))
+              local in_db = assert(db.routes:select({ id = route.id }, { nulls = true }))
               assert.same(json, in_db)
             end
           end)
@@ -516,7 +517,7 @@ for _, strategy in helpers.each_strategy() do
               assert.True(json.strip_path)
               assert.equal(route.id, json.id)
 
-              local in_db = assert(db.routes:select({id = route.id}))
+              local in_db = assert(db.routes:select({id = route.id}, { nulls = true }))
               assert.same(json, in_db)
             end
           end)
@@ -540,7 +541,7 @@ for _, strategy in helpers.each_strategy() do
               assert.same(cjson.null, json.methods)
               assert.equal(route.id, json.id)
 
-              local in_db = assert(db.routes:select({id = route.id}))
+              local in_db = assert(db.routes:select({id = route.id}, { nulls = true }))
               assert.same(json, in_db)
             end
           end)
@@ -563,7 +564,7 @@ for _, strategy in helpers.each_strategy() do
             assert.same(cjson.null, json.methods)
             assert.equal(route.id, json.id)
 
-            local in_db = assert(db.routes:select({id = route.id}))
+            local in_db = assert(db.routes:select({id = route.id}, { nulls = true }))
             assert.same(json, in_db)
           end)
 
@@ -644,7 +645,7 @@ for _, strategy in helpers.each_strategy() do
             local body = assert.res_status(204, res)
             assert.equal("", body)
 
-            local in_db, err = db.routes:select({id = route.id})
+            local in_db, err = db.routes:select({id = route.id}, { nulls = true })
             assert.is_nil(err)
             assert.is_nil(in_db)
           end)
@@ -663,8 +664,8 @@ for _, strategy in helpers.each_strategy() do
         local route
 
         before_each(function()
-          service = bp.services:insert({ host = "example.com", path = "/" })
-          route   = bp.routes:insert({ paths = { "/my-route" }, service = service })
+          service = bp.services:insert({ host = "example.com", path = "/" }, { nulls = true })
+          route   = bp.routes:insert({ paths = { "/my-route" }, service = service }, { nulls = true })
         end)
 
         describe("GET", function()
@@ -712,7 +713,7 @@ for _, strategy in helpers.each_strategy() do
               assert.same(cjson.null,    json.path)
 
 
-              local in_db = assert(db.services:select({ id = service.id }))
+              local in_db = assert(db.services:select({ id = service.id }, { nulls = true }))
               assert.same(json, in_db)
             end
           end)
@@ -734,7 +735,7 @@ for _, strategy in helpers.each_strategy() do
               assert.equal("/foo",        json.path)
 
 
-              local in_db = assert(db.services:select({ id = service.id }))
+              local in_db = assert(db.services:select({ id = service.id }, { nulls = true }))
               assert.same(json, in_db)
             end
           end)

--- a/spec/02-integration/04-admin_api/21-services_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/21-services_routes_spec.lua
@@ -295,7 +295,7 @@ for _, strategy in helpers.each_strategy() do
               assert.equal("https",    json.protocol)
               assert.equal(service.id, json.id)
 
-              local in_db = assert(db.services:select({ id = service.id }))
+              local in_db = assert(db.services:select({ id = service.id }, { nulls = true }))
               assert.same(json, in_db)
             end
           end)
@@ -316,7 +316,7 @@ for _, strategy in helpers.each_strategy() do
               assert.equal(service.id,   json.id)
               assert.equal(service.name, json.name)
 
-              local in_db = assert(db.services:select_by_name(service.name))
+              local in_db = assert(db.services:select_by_name(service.name), { nulls = true })
               assert.same(json, in_db)
             end
           end)
@@ -329,7 +329,7 @@ for _, strategy in helpers.each_strategy() do
             local body = assert.res_status(204, res)
             assert.equal("", body)
 
-            local in_db, err = db.services:select({ id = service.id })
+            local in_db, err = db.services:select({ id = service.id }, { nulls = true })
             assert.is_nil(err)
             assert.is_nil(in_db)
           end)
@@ -339,7 +339,7 @@ for _, strategy in helpers.each_strategy() do
             local body = assert.res_status(204, res)
             assert.equal("", body)
 
-            local in_db, err = db.services:select_by_name(service.name)
+            local in_db, err = db.services:select_by_name(service.name, { nulls = true })
             assert.is_nil(err)
             assert.is_nil(in_db)
           end)

--- a/spec/fixtures/blueprints.lua
+++ b/spec/fixtures/blueprints.lua
@@ -15,8 +15,8 @@ function Blueprint:build(overrides)
 end
 
 
-function Blueprint:insert(overrides)
-  local entity, err = self.dao:insert(self:build(overrides))
+function Blueprint:insert(overrides, options)
+  local entity, err = self.dao:insert(self:build(overrides), options)
   if err then
     error(err, 2)
   end
@@ -24,10 +24,10 @@ function Blueprint:insert(overrides)
 end
 
 
-function Blueprint:insert_n(n, overrides)
+function Blueprint:insert_n(n, overrides, options)
   local res = {}
   for i=1,n do
-    res[i] = self:insert(overrides)
+    res[i] = self:insert(overrides, options)
   end
   return res
 end


### PR DESCRIPTION
### Summary

Refactor DAO and Admin API so that Admin API uses `null`s and DAO doesn't use them by default (makes them Lua-land `nil`s aka missing values).

Fix #3617, #3609