### PR TITLE
fix(cli) catch DB module instantiation errors

### DIFF
--- a/kong/cmd/migrations.lua
+++ b/kong/cmd/migrations.lua
@@ -29,7 +29,7 @@ end
 
 local function execute(args)
   local conf = assert(conf_loader(args.conf))
-  local db = DB.new(conf)
+  local db = assert(DB.new(conf))
   assert(db:init_connector())
   local dao = assert(DAOFactory.new(conf, db))
 

--- a/kong/cmd/start.lua
+++ b/kong/cmd/start.lua
@@ -14,7 +14,7 @@ local function execute(args)
   assert(not kill.is_running(conf.nginx_pid),
          "Kong is already running in " .. conf.prefix)
 
-  local db = DB.new(conf)
+  local db = assert(DB.new(conf))
   assert(db:init_connector())
   local dao = assert(DAOFactory.new(conf, db))
   local ok, err_t = dao:init()


### PR DESCRIPTION
This avoids the (even more) unpleasant error:

    attempt to index local 'db' (a nil value)