### PR TITLE
fix(dao) select NULL fields as nil from the proxy

### DIFF
--- a/kong/api/routes/certificates.lua
+++ b/kong/api/routes/certificates.lua
@@ -53,14 +53,14 @@ return {
 
       -- cert was found via id or sni inside `before` section
       if utils.is_valid_uuid(id) then
-        cert, _, err_t = db.certificates:upsert({ id = id }, args)
+        cert, _, err_t = db.certificates:upsert({ id = id }, args, { nulls = true })
 
       else -- create a new cert. Add extra sni if provided on url
         if self.new_put_sni then
           args.snis = Set.values(Set(args.snis or {}) + self.new_put_sni)
           self.new_put_sni = nil
         end
-        cert, _, err_t = db.certificates:insert(args)
+        cert, _, err_t = db.certificates:insert(args, { nulls = true })
       end
 
       if err_t then

--- a/kong/api/routes/consumers.lua
+++ b/kong/api/routes/consumers.lua
@@ -23,7 +23,8 @@ return {
       end
 
       local data, _, err_t, offset = db.consumers:page(self.args.size,
-                                                       self.args.offset)
+                                                       self.args.offset,
+                                                       { nulls = true })
       if err_t then
         return Endpoints.handle_error(err_t)
       end

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -957,9 +957,10 @@ end
 -- @param input The table containing data to be processed.
 -- @param context a string describing the CRUD context:
 -- valid values are: "insert", "update"
+-- @param nulls boolean: return nulls as explicit ngx.null values
 -- @return A new table, with the auto fields containing
 -- appropriate updated values.
-function Schema:process_auto_fields(input, context)
+function Schema:process_auto_fields(input, context, nulls)
   local output = tablex.deepcopy(input)
   local now = time()
 
@@ -991,6 +992,10 @@ function Schema:process_auto_fields(input, context)
 
     elseif context ~= "update" then
       handle_missing_field(key, field, output)
+    end
+
+    if context == "select" and output[key] == null and not nulls then
+      output[key] = nil
     end
   end
 

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -28,7 +28,6 @@ local fmt         = string.format
 local sort        = table.sort
 local ngx         = ngx
 local log         = ngx.log
-local null        = ngx.null
 local ngx_now     = ngx.now
 local update_time = ngx.update_time
 local re_match    = ngx.re.match
@@ -86,7 +85,7 @@ end
 
 local function build_router(db, version)
   local routes, i = {}, 0
-  local routes_iterator = db.routes:each(nil, { nulls = true })
+  local routes_iterator = db.routes:each()
 
   local route, err = routes_iterator()
   while route do
@@ -99,7 +98,7 @@ local function build_router(db, version)
     local service
 
     -- TODO: db requests in loop, problem or not
-    service, err = db.services:select(service_pk, { nulls = true })
+    service, err = db.services:select(service_pk)
     if not service then
       return nil, "could not find service for route (" .. route.id .. "): " .. err
     end
@@ -109,7 +108,7 @@ local function build_router(db, version)
       service = service,
     }
 
-    if route.hosts ~= null then
+    if route.hosts then
       -- TODO: headers should probably be moved to route
       r.headers = {
         host = route.hosts,
@@ -543,7 +542,7 @@ return {
       -- TODO: this is probably not optimal
       do
         local retries = service.retries or api.retries
-        if retries ~= null then
+        if retries then
           balancer_data.retries = retries
 
         else
@@ -552,7 +551,7 @@ return {
 
         local connect_timeout = service.connect_timeout or
                                 api.upstream_connect_timeout
-        if connect_timeout ~= null then
+        if connect_timeout then
           balancer_data.connect_timeout = connect_timeout
 
         else
@@ -561,7 +560,7 @@ return {
 
         local send_timeout = service.write_timeout or
                              api.upstream_send_timeout
-        if send_timeout ~= null then
+        if send_timeout then
           balancer_data.send_timeout = send_timeout
 
         else
@@ -570,7 +569,7 @@ return {
 
         local read_timeout = service.read_timeout or
                              api.upstream_read_timeout
-        if read_timeout ~= null then
+        if read_timeout then
           balancer_data.read_timeout = read_timeout
 
         else

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -86,7 +86,7 @@ end
 
 local function build_router(db, version)
   local routes, i = {}, 0
-  local routes_iterator = db.routes:each()
+  local routes_iterator = db.routes:each(nil, { nulls = true })
 
   local route, err = routes_iterator()
   while route do
@@ -99,7 +99,7 @@ local function build_router(db, version)
     local service
 
     -- TODO: db requests in loop, problem or not
-    service, err = db.services:select(service_pk)
+    service, err = db.services:select(service_pk, { nulls = true })
     if not service then
       return nil, "could not find service for route (" .. route.id .. "): " .. err
     end

--- a/spec/02-integration/000-new-dao/02-db_core_entities_spec.lua
+++ b/spec/02-integration/000-new-dao/02-db_core_entities_spec.lua
@@ -139,7 +139,7 @@ for _, strategy in helpers.each_strategy() do
             protocols = { "http" },
             hosts = { "example.com" },
             service = assert(db.services:insert({ host = "service.com" })),
-          })
+          }, { nulls = true })
           assert.is_nil(err_t)
           assert.is_nil(err)
 
@@ -171,7 +171,7 @@ for _, strategy in helpers.each_strategy() do
             regex_priority  = 3,
             strip_path      = true,
             service         = bp.services:insert(),
-          })
+          }, { nulls = true })
           assert.is_nil(err_t)
           assert.is_nil(err)
 
@@ -419,16 +419,17 @@ for _, strategy in helpers.each_strategy() do
               hosts   = { "example.com" },
               methods = { "GET" },
               paths   = ngx.null,
-            })
+            }, { nulls = true })
 
             local new_route, err, err_t = db.routes:update({ id = route.id }, {
               hosts   = { "example2.com" },
-            })
+            }, { nulls = true })
             assert.is_nil(err_t)
             assert.is_nil(err)
             assert.same({ "example2.com" }, new_route.hosts)
             assert.same({ "GET" }, new_route.methods)
             assert.same(ngx.null, new_route.paths)
+            assert.same(ngx.null, route.paths)
             route.hosts     = nil
             new_route.hosts = nil
             assert.same(route, new_route)
@@ -838,7 +839,7 @@ for _, strategy in helpers.each_strategy() do
           local service, err, err_t = db.services:insert({
             --name     = "example service",
             host = "example.com",
-          })
+          }, { nulls = true })
           assert.is_nil(err_t)
           assert.is_nil(err)
 
@@ -1307,7 +1308,7 @@ for _, strategy in helpers.each_strategy() do
           protocols = { "http" },
           hosts     = { "example.com" },
           service   = service,
-        })
+        }, { nulls = true })
         assert.is_nil(err_t)
         assert.is_nil(err)
         assert.same({
@@ -1326,7 +1327,7 @@ for _, strategy in helpers.each_strategy() do
           },
         }, route)
 
-        local route_in_db, err, err_t = db.routes:select({ id = route.id })
+        local route_in_db, err, err_t = db.routes:select({ id = route.id }, { nulls = true })
         assert.is_nil(err_t)
         assert.is_nil(err)
         assert.same(route, route_in_db)

--- a/spec/02-integration/04-admin_api/03-consumers_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/03-consumers_routes_spec.lua
@@ -443,7 +443,7 @@ describe("Admin API (" .. strategy .. "): ", function()
             local json = cjson.decode(body)
             assert.equal("peter", json.username)
 
-            local in_db = assert(db.consumers:select({ id = consumer.id }))
+            local in_db = assert(db.consumers:select({ id = consumer.id }, { nulls = true }))
             assert.same(json, in_db)
           end
         end)

--- a/spec/02-integration/04-admin_api/20-routes_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/20-routes_routes_spec.lua
@@ -352,7 +352,7 @@ for _, strategy in helpers.each_strategy() do
               assert.same(cjson.null, json.methods)
               assert.equal(route.id, json.id)
 
-              local in_db = assert(db.routes:select({ id = route.id }))
+              local in_db = assert(db.routes:select({ id = route.id }, { nulls = true }))
               assert.same(json, in_db)
             end
           end)
@@ -375,7 +375,7 @@ for _, strategy in helpers.each_strategy() do
               assert.same(cjson.null, json.methods)
               assert.equal(route.id, json.id)
 
-              local in_db = assert(db.routes:select({ id = route.id }))
+              local in_db = assert(db.routes:select({ id = route.id }, { nulls = true }))
               assert.same(json, in_db)
             end
           end)
@@ -483,7 +483,7 @@ for _, strategy in helpers.each_strategy() do
               assert.same(cjson.null, json.methods)
               assert.equal(route.id, json.id)
 
-              local in_db = assert(db.routes:select({ id = route.id }))
+              local in_db = assert(db.routes:select({ id = route.id }, { nulls = true }))
               assert.same(json, in_db)
             end
           end)
@@ -503,7 +503,7 @@ for _, strategy in helpers.each_strategy() do
               assert.True(json.strip_path)
               assert.equal(route.id, json.id)
 
-              local in_db = assert(db.routes:select({id = route.id}))
+              local in_db = assert(db.routes:select({id = route.id}, { nulls = true }))
               assert.same(json, in_db)
             end
           end)
@@ -527,7 +527,7 @@ for _, strategy in helpers.each_strategy() do
               assert.same(cjson.null, json.methods)
               assert.equal(route.id, json.id)
 
-              local in_db = assert(db.routes:select({id = route.id}))
+              local in_db = assert(db.routes:select({id = route.id}, { nulls = true }))
               assert.same(json, in_db)
             end
           end)
@@ -550,7 +550,7 @@ for _, strategy in helpers.each_strategy() do
             assert.same(cjson.null, json.methods)
             assert.equal(route.id, json.id)
 
-            local in_db = assert(db.routes:select({id = route.id}))
+            local in_db = assert(db.routes:select({id = route.id}, { nulls = true }))
             assert.same(json, in_db)
           end)
 
@@ -632,7 +632,7 @@ for _, strategy in helpers.each_strategy() do
             local body = assert.res_status(204, res)
             assert.equal("", body)
 
-            local in_db, err = db.routes:select({id = route.id})
+            local in_db, err = db.routes:select({id = route.id}, { nulls = true })
             assert.is_nil(err)
             assert.is_nil(in_db)
           end)
@@ -651,8 +651,8 @@ for _, strategy in helpers.each_strategy() do
         local route
 
         before_each(function()
-          service = bp.services:insert({ host = "example.com", path = "/" })
-          route   = bp.routes:insert({ paths = { "/my-route" }, service = service })
+          service = bp.services:insert({ host = "example.com", path = "/" }, { nulls = true })
+          route   = bp.routes:insert({ paths = { "/my-route" }, service = service }, { nulls = true })
         end)
 
         describe("GET", function()
@@ -700,7 +700,7 @@ for _, strategy in helpers.each_strategy() do
               assert.same(cjson.null,    json.path)
 
 
-              local in_db = assert(db.services:select({ id = service.id }))
+              local in_db = assert(db.services:select({ id = service.id }, { nulls = true }))
               assert.same(json, in_db)
             end
           end)
@@ -722,7 +722,7 @@ for _, strategy in helpers.each_strategy() do
               assert.equal("/foo",        json.path)
 
 
-              local in_db = assert(db.services:select({ id = service.id }))
+              local in_db = assert(db.services:select({ id = service.id }, { nulls = true }))
               assert.same(json, in_db)
             end
           end)

--- a/spec/02-integration/04-admin_api/21-services_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/21-services_routes_spec.lua
@@ -295,7 +295,7 @@ for _, strategy in helpers.each_strategy() do
               assert.equal("https",    json.protocol)
               assert.equal(service.id, json.id)
 
-              local in_db = assert(db.services:select({ id = service.id }))
+              local in_db = assert(db.services:select({ id = service.id }, { nulls = true }))
               assert.same(json, in_db)
             end
           end)
@@ -329,7 +329,7 @@ for _, strategy in helpers.each_strategy() do
             local body = assert.res_status(204, res)
             assert.equal("", body)
 
-            local in_db, err = db.services:select({ id = service.id })
+            local in_db, err = db.services:select({ id = service.id }, { nulls = true })
             assert.is_nil(err)
             assert.is_nil(in_db)
           end)

--- a/spec/fixtures/blueprints.lua
+++ b/spec/fixtures/blueprints.lua
@@ -15,8 +15,8 @@ function Blueprint:build(overrides)
 end
 
 
-function Blueprint:insert(overrides)
-  local entity, err = self.dao:insert(self:build(overrides))
+function Blueprint:insert(overrides, options)
+  local entity, err = self.dao:insert(self:build(overrides), options)
   if err then
     error(err, 2)
   end


### PR DESCRIPTION
When reading from the proxy, we do not wish to retrieve unset columns as
`ngx.null` for backwards-compatibility reasons. That is now the default
for all plugins since 735314c (parent commit), for plugins, and it is
now for the runloop as well.

Context: retrieving unset columns as `nil` instead of `ngx.null` allows
for backwards-compatibility with existing plugins. An example of this is
authentication plugins retrieving the authenticated Consumer, and
injecting its fields as headers into the upstream request (e.g.
`X-Consumer-Username`). When such fields are unset, the following
headers were sent upstream: `X-Consumer-Username: userdata: NULL`
instead of no header at all (or worse, producing HTTP 500 errors).

This replaces parts of (but not all) #3710.