### PR TITLE
Feature: Allow keepalive to be disabled when set to 0

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -213,6 +213,9 @@
                                  # preserved in the cache of each worker
                                  # process. When this number is exceeded, the
                                  # least recently used connections are closed.
+                                 # A value of `0` will disable this behavior 
+                                 # altogether, forcing each upstream request 
+                                 # to open a new connection
 
 #headers = server_tokens, latency_tokens
                                  # Specify Kong-specific headers that should

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -66,7 +66,9 @@ upstream kong_upstream {
     balancer_by_lua_block {
         Kong.balancer()
     }
+> if upstream_keepalive > 0 then 
     keepalive ${{UPSTREAM_KEEPALIVE}};
+> end
 }
 
 server {

--- a/spec/01-unit/003-prefix_handler_spec.lua
+++ b/spec/01-unit/003-prefix_handler_spec.lua
@@ -104,6 +104,13 @@ describe("NGINX conf compiler", function()
       assert.matches("listen 127.0.0.1:9001;", kong_nginx_conf, nil, true)
       assert.matches("listen 127.0.0.1:8444 ssl http2;", kong_nginx_conf, nil, true)
     end)
+    it("disables upstream keepalive", function()
+      local conf = assert(conf_loader(helpers.test_conf_path, {
+        upstream_keepalive = 0,
+      }))
+      local kong_nginx_conf = prefix_handler.compile_kong_conf(conf)
+      assert.not_matches("keepalive %d+;", kong_nginx_conf)
+    end)
     it("enables proxy_protocol", function()
       local conf = assert(conf_loader(helpers.test_conf_path, {
         proxy_listen = "0.0.0.0:9000 proxy_protocol",

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -80,7 +80,9 @@ http {
         balancer_by_lua_block {
             Kong.balancer()
         }
+> if upstream_keepalive > 0 then 
         keepalive ${{UPSTREAM_KEEPALIVE}};
+> end
     }
 
     server {


### PR DESCRIPTION
### Summary

Allow Engineers to disable keeaplive by setting upstream_keepalive to 0. In our infrastructure we did not want to have nginx workers keeping the backend connections alive that were to externally lb services. This fixed various connection resets for us. 

### Full changelog

* Implemented ability to disable upstream_keepalive

### Issues resolved

Possibly: #3287
