### PR TITLE
feat(file-log) add log_level to file-log plugin

### DIFF
--- a/kong/plugins/file-log/schema.lua
+++ b/kong/plugins/file-log/schema.lua
@@ -1,5 +1,6 @@
 local pl_file = require "pl.file"
 local pl_path = require "pl.path"
+local ALLOWED_LEVELS = { "debug", "info", "notice", "warning", "err", "crit", "alert", "emerg" }
 
 local function validate_file(value)
   -- create file in case it doesn't exist
@@ -17,5 +18,9 @@ return {
   fields = {
     path = { required = true, type = "string", func = validate_file },
     reopen = { type = "boolean", default = false },
+    log_level = { type = "string", enum = ALLOWED_LEVELS, default = "info" },
+    successful_severity = { type = "string", enum = ALLOWED_LEVELS, default = "info" },
+    client_errors_severity = { type = "string", enum = ALLOWED_LEVELS, default = "info" },
+    server_errors_severity = { type = "string", enum = ALLOWED_LEVELS, default = "info" },
   }
 }


### PR DESCRIPTION
Implements a log_level concept in the file-log plugin, similar to syslog or loggly.

## Summary

Use Case: if you rely on the file-log plugin, and you'd like to log only errors from Kong (such is the case at my company).

## Question / Discussion

Maybe this should be a separate plugin, to preserve compatibility ?