### PR TITLE
chore(deps) bump DNS lib to 2.2.0, introducing ttl-override

### DIFF
--- a/kong-0.14.1-0.rockspec
+++ b/kong-0.14.1-0.rockspec
@@ -28,7 +28,7 @@ dependencies = {
   "luaossl == 20171028",
   "luasyslog == 1.0.0",
   "lua_pack == 1.0.5",
-  "lua-resty-dns-client == 2.1.0",
+  "lua-resty-dns-client == 2.2.0",
   "lua-resty-worker-events == 0.3.3",
   "lua-resty-mediador == 0.1.2",
   "lua-resty-healthcheck == 0.5.0",

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -486,6 +486,11 @@
                                  # specified name). The format is a (case
                                  # insensitive) comma separated list.
 
+#dns_valid_ttl =                 # By default, DNS records are cached using
+                                 # the TTL value of a response. If this
+                                 # property receives a value (in seconds), it
+                                 # will override the TTL for all records.
+
 #dns_stale_ttl = 4               # Defines, in seconds, how long a record will
                                  # remain in cache past its TTL. This value
                                  # will be used while the new DNS record is

--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -113,6 +113,7 @@ local CONF_INFERENCES = {
   dns_resolver = {typ = "array"},
   dns_hostsfile = {typ = "string"},
   dns_order = {typ = "array"},
+  dns_valid_ttl = {typ = "number"},
   dns_stale_ttl = {typ = "number"},
   dns_not_found_ttl = {typ = "number"},
   dns_error_ttl = {typ = "number"},

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -66,6 +66,7 @@ db_resurrect_ttl = 30
 dns_resolver = NONE
 dns_hostsfile = /etc/hosts
 dns_order = LAST,SRV,A,CNAME
+dns_valid_ttl = NONE
 dns_stale_ttl = 4
 dns_not_found_ttl = 30
 dns_error_ttl = 1

--- a/kong/tools/dns.lua
+++ b/kong/tools/dns.lua
@@ -27,6 +27,7 @@ local setup_client = function(conf)
     enable_ipv6 = true,              -- allow for ipv6 nameserver addresses
     retrans = nil,                   -- taken from system resolv.conf; attempts
     timeout = nil,                   -- taken from system resolv.conf; timeout
+    validTtl = conf.dns_valid_ttl,   -- ttl in seconds overriding ttl of valid records
     badTtl = conf.dns_not_found_ttl, -- ttl in seconds for dns error responses (except 3 - name error)
     emptyTtl = conf.dns_error_ttl,   -- ttl in seconds for empty and "(3) name error" dns responses
     staleTtl = conf.dns_stale_ttl,   -- ttl in seconds for records once they become stale


### PR DESCRIPTION
This bump fixes a number of minor issues (see
https://github.com/Kong/lua-resty-dns-client#history), and
introduces a new option to override the DNS record ttl.

