### PR TITLE
fix(ldap-auth) hardcode ldap header so schema can change

### DIFF
--- a/kong/plugins/ldap-auth/migrations/cassandra.lua
+++ b/kong/plugins/ldap-auth/migrations/cassandra.lua
@@ -10,7 +10,7 @@ return {
           return config
         end
         if config.header_type == nil then
-          config.header_type = schema.fields.header_type.default
+          config.header_type = "ldap"
           local _, err = update(config)
           if err then
             return err

--- a/kong/plugins/ldap-auth/migrations/cassandra.lua
+++ b/kong/plugins/ldap-auth/migrations/cassandra.lua
@@ -1,5 +1,4 @@
 local plugin_config_iterator = require("kong.dao.migrations.helpers").plugin_config_iterator
-local schema = require("kong.plugins.ldap-auth.schema")
 
 return {
   {

--- a/kong/plugins/ldap-auth/migrations/postgres.lua
+++ b/kong/plugins/ldap-auth/migrations/postgres.lua
@@ -10,7 +10,7 @@ return {
           return config
         end
         if config.header_type == nil then
-          config.header_type = schema.fields.header_type.default
+          config.header_type = "ldap"
           local _, err = update(config)
           if err then
             return err

--- a/kong/plugins/ldap-auth/migrations/postgres.lua
+++ b/kong/plugins/ldap-auth/migrations/postgres.lua
@@ -1,5 +1,4 @@
 local plugin_config_iterator = require("kong.dao.migrations.helpers").plugin_config_iterator
-local schema = require("kong.plugins.ldap-auth.schema")
 
 return {
   {


### PR DESCRIPTION
### Summary

Hard coding header default so that schema can change in later versions of Kong without affecting behavior of migration.