### PR TITLE
feat(ci) parallelize travis builds

### DIFF
--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -8,14 +8,24 @@ if [ "$KONG_TEST_DATABASE" == "postgres" ]; then
     export KONG_TEST_PG_USER=postgres
     export KONG_TEST_PG_DATABASE=travis
     export TEST_CMD="bin/busted $BUSTED_ARGS,cassandra"
-    eval "$TEST_CMD" spec/02-integration/
-    eval "$TEST_CMD" spec/03-plugins/
-    eval "$TEST_CMD" spec-old-api/02-integration/
-    eval "$TEST_CMD" spec-old-api/03-plugins/
 elif [ "$KONG_TEST_DATABASE" == "cassandra" ]; then
     export KONG_TEST_CASSANDRA_KEYSPACE=kong_tests
     export KONG_TEST_DB_UPDATE_PROPAGATION=1
     export TEST_CMD="bin/busted $BUSTED_ARGS,postgres"
+fi
+
+if [ "$TEST_SUITE" == "integration" ]; then
     eval "$TEST_CMD" spec/02-integration/
+fi
+if [ "$TEST_SUITE" == "plugins" ]; then
     eval "$TEST_CMD" spec/03-plugins/
+fi
+if [ "$TEST_SUITE" == "old-integration" ]; then
+    eval "$TEST_CMD" spec-old-api/02-integration/
+fi
+if [ "$TEST_SUITE" == "old-plugins" ]; then
+    eval "$TEST_CMD" spec-old-api/03-plugins/
+fi
+if [ "$TEST_SUITE" == "pdk" ]; then
+    TEST_NGINX_RANDOMIZE=1 prove -I. -j$JOBS -r t/01-pdk
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,15 @@ env:
     - INSTALL_CACHE=$HOME/install-cache
     - JOBS=2
   matrix:
-    - KONG_TEST_DATABASE=postgres
-    - KONG_TEST_DATABASE=cassandra CASSANDRA=2.2
-    - KONG_TEST_DATABASE=cassandra CASSANDRA=3.9
+    - KONG_TEST_DATABASE=postgres TEST_SUITE=integration
+    - KONG_TEST_DATABASE=cassandra CASSANDRA=2.2 TEST_SUITE=integration
+    - KONG_TEST_DATABASE=cassandra CASSANDRA=3.9 TEST_SUITE=integration
+    - KONG_TEST_DATABASE=postgres TEST_SUITE=plugins
+    - KONG_TEST_DATABASE=cassandra CASSANDRA=2.2 TEST_SUITE=plugins
+    - KONG_TEST_DATABASE=cassandra CASSANDRA=3.9 TEST_SUITE=plugins
+    - KONG_TEST_DATABASE=postgres TEST_SUITE=old-integration
+    - KONG_TEST_DATABASE=postgres TEST_SUITE=old-plugins
+    - TEST_SUITE=pdk
 
 before_install:
   - source .ci/setup_env.sh
@@ -66,10 +72,6 @@ jobs:
       - bin/busted -v -o gtest spec-old-api/01-unit
       env:
         - KONG_DATABASE=none
-    - stage: pdk tests
-      script: TEST_NGINX_RANDOMIZE=1 prove -I. -j$JOBS -r t/01-pdk
-      env:
-        - KONG_DATABASE=none TEST_SUITE=pdk
     - stage: deploy
       install: skip
       before_install: skip


### PR DESCRIPTION
Separate parallelized builds for

```
postgres vs cassandra2.2 vs cassandra3.9 
X
integration vs plugin vs old-integration vs old-plugin
```

result is a build time (wall clock) of ~15-20min depending on cache etc