### PR TITLE
Groundwork for porting the Plugins core entity to kong.db

### DIFF
--- a/kong-0.14.1-0.rockspec
+++ b/kong-0.14.1-0.rockspec
@@ -139,6 +139,7 @@ build = {
     ["kong.db.dao.consumers"] = "kong/db/dao/consumers.lua",
     ["kong.db.dao.targets"] = "kong/db/dao/targets.lua",
     ["kong.db.schema"] = "kong/db/schema/init.lua",
+    ["kong.db.schema.entities.apis"] = "kong/db/schema/entities/apis.lua",
     ["kong.db.schema.entities.consumers"] = "kong/db/schema/entities/consumers.lua",
     ["kong.db.schema.entities.routes"] = "kong/db/schema/entities/routes.lua",
     ["kong.db.schema.entities.services"] = "kong/db/schema/entities/services.lua",

--- a/kong/api/arguments.lua
+++ b/kong/api/arguments.lua
@@ -210,7 +210,7 @@ local function infer_value(value, field)
       end
     end
 
-  elseif field.type == "record" then
+  elseif field.type == "record" and not field.abstract then
     if type(value) == "table" then
       for k, v in pairs(value) do
         value[k] = infer_value(v, field.fields[k])

--- a/kong/api/endpoints.lua
+++ b/kong/api/endpoints.lua
@@ -216,7 +216,7 @@ end
 --
 -- /services
 local function post_collection_endpoint(schema, foreign_schema, foreign_field_name)
-  return function(self, db, helpers)
+  return function(self, db, helpers, post_process)
     if foreign_schema then
       local foreign_entity, _, err_t = select_entity(self, db, foreign_schema)
       if err_t then
@@ -234,6 +234,13 @@ local function post_collection_endpoint(schema, foreign_schema, foreign_field_na
     local entity, _, err_t = db[schema.name]:insert(self.args.post, options)
     if err_t then
       return handle_error(err_t)
+    end
+
+    if post_process then
+      entity, _, err_t = post_process(entity)
+      if err_t then
+        handle_error(err_t)
+      end
     end
 
     return helpers.responses.send_HTTP_CREATED(entity)
@@ -511,6 +518,8 @@ local Endpoints = {
   handle_error = handle_error,
   extract_options = extract_options,
   get_page_size = get_page_size,
+  get_collection_endpoint = get_collection_endpoint,
+  post_collection_endpoint = post_collection_endpoint,
 }
 
 

--- a/kong/api/endpoints.lua
+++ b/kong/api/endpoints.lua
@@ -494,7 +494,7 @@ local function generate_endpoints(schema, endpoints)
   generate_entity_endpoints(endpoints, schema)
 
   for foreign_field_name, foreign_field in schema:each_field() do
-    if foreign_field.type == "foreign" then
+    if foreign_field.type == "foreign" and not foreign_field.schema.legacy then
       -- e.g. /routes/:routes/service
       generate_entity_endpoints(endpoints, schema, foreign_field.schema, foreign_field_name)
 

--- a/kong/api/init.lua
+++ b/kong/api/init.lua
@@ -48,29 +48,6 @@ local function parse_params(fn)
 end
 
 
--- old DAO
-local function on_error(self)
-  local err = self.errors[1]
-
-  if type(err) ~= "table" then
-    return responses.send_HTTP_INTERNAL_SERVER_ERROR(tostring(err))
-  end
-
-  if err.db then
-    return responses.send_HTTP_INTERNAL_SERVER_ERROR(err.message)
-  end
-
-  if err.unique then
-    return responses.send_HTTP_CONFLICT(err.tbl)
-  end
-
-  if err.foreign then
-    return responses.send_HTTP_NOT_FOUND(err.tbl)
-  end
-
-  return responses.send_HTTP_BAD_REQUEST(err.tbl or err.message)
-end
-
 -- new DB
 local function new_db_on_error(self)
   local err = self.errors[1]
@@ -102,6 +79,34 @@ local function new_db_on_error(self)
   end
 
   return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+end
+
+
+-- old DAO
+local function on_error(self)
+  local err = self.errors[1]
+
+  if type(err) ~= "table" then
+    return responses.send_HTTP_INTERNAL_SERVER_ERROR(tostring(err))
+  end
+
+  if err.name then
+    return new_db_on_error(self)
+  end
+
+  if err.db then
+    return responses.send_HTTP_INTERNAL_SERVER_ERROR(err.message)
+  end
+
+  if err.unique then
+    return responses.send_HTTP_CONFLICT(err.tbl)
+  end
+
+  if err.foreign then
+    return responses.send_HTTP_NOT_FOUND(err.tbl)
+  end
+
+  return responses.send_HTTP_BAD_REQUEST(err.tbl or err.message)
 end
 
 

--- a/kong/api/init.lua
+++ b/kong/api/init.lua
@@ -250,8 +250,8 @@ do
             local parent = routes[route_pattern]["methods"][verb]
             if parent ~= nil and type(handler) == "function" then
               routes[route_pattern]["methods"][verb] = function(self, db, helpers)
-                return handler(self, db, helpers, function()
-                  return parent(self, db, helpers)
+                return handler(self, db, helpers, function(post_process)
+                  return parent(self, db, helpers, post_process)
                 end)
               end
 

--- a/kong/api/init.lua
+++ b/kong/api/init.lua
@@ -233,12 +233,15 @@ do
 
   -- Auto Generated Routes
   for _, dao in pairs(singletons.db.daos) do
-    routes = Endpoints.new(dao.schema, routes)
+    if not dao.schema.legacy then
+      routes = Endpoints.new(dao.schema, routes)
+    end
   end
 
   -- Custom Routes
   for _, dao in pairs(singletons.db.daos) do
     local schema = dao.schema
+
     local ok, custom_endpoints = utils.load_module_if_exists("kong.api.routes." .. schema.name)
     if ok then
       for route_pattern, verbs in pairs(custom_endpoints) do

--- a/kong/dao/factory.lua
+++ b/kong/dao/factory.lua
@@ -109,9 +109,7 @@ local function create_legacy_wrappers(self, constraints)
       end,
 
       entity_cache_key = function(_, entity)
-        log.debug(debug.traceback("[legacy wrapper] using legacy wrapper"))
-        log.err("[legacy wrapper] entity_cache_key not implemented")
-        return nil
+        return new_dao:cache_key(entity)
       end,
 
       insert = function(_, tbl, opts)

--- a/kong/dao/factory.lua
+++ b/kong/dao/factory.lua
@@ -121,13 +121,21 @@ local function create_legacy_wrappers(self, constraints)
             log.warn("[legacy wrapper] quiet is ignored, event always sent")
           end
         end
-        return new_dao:insert(tbl, { ttl = opts and opts.ttl })
+        local ok, _, err_t = new_dao:insert(tbl, { ttl = opts and opts.ttl })
+        if not ok then
+          return ok, err_t
+        end
+        return ok
       end,
 
       find = function(_, args)
         log.debug(debug.traceback("[legacy wrapper] using legacy wrapper"))
         local pk = new_dao.schema:extract_pk_values(args)
-        return new_dao:select(pk)
+        local row, _, err_t = new_dao:select(pk)
+        if not row then
+          return row, err_t
+        end
+        return row
       end,
 
       find_all = function(_, filt)
@@ -169,9 +177,9 @@ local function create_legacy_wrappers(self, constraints)
 
       count = function(self, filt)
         log.debug(debug.traceback("[legacy wrapper] using legacy wrapper"))
-        local rows, err = self:find_all(filt)
+        local rows, err, err_t = self:find_all(filt)
         if err then
-          return nil, err
+          return nil, err_t
         end
         return #rows
       end,
@@ -195,7 +203,11 @@ local function create_legacy_wrappers(self, constraints)
           end
         end
         local pk = new_dao.schema:extract_pk_values(filter_keys)
-        return new_dao:update(pk, tbl)
+        local ok, _, err_t = new_dao:update(pk, tbl)
+        if not ok then
+          return ok, err_t
+        end
+        return ok
       end,
 
       delete = function(_, tbl, opts)
@@ -205,7 +217,11 @@ local function create_legacy_wrappers(self, constraints)
             log.warn("[legacy wrapper] quiet is ignored, event always sent")
           end
         end
-        return new_dao:delete(tbl)
+        local ok, _, err_t = new_dao:delete(tbl)
+        if not ok then
+          return ok, err_t
+        end
+        return ok
       end,
 
       truncate = function(_)

--- a/kong/dao/factory.lua
+++ b/kong/dao/factory.lua
@@ -96,6 +96,10 @@ local function create_legacy_wrappers(self, constraints)
   local new_db = self.db.new_db
   local dao_wrappers = {}
   for name, new_dao in pairs(new_db.daos) do
+    if new_dao.schema.legacy then
+      goto continue
+    end
+
     dao_wrappers[name] = {
 
       constraints = constraints[name],
@@ -169,6 +173,8 @@ local function create_legacy_wrappers(self, constraints)
         return new_dao:truncate()
       end,
     }
+
+    ::continue::
   end
 
   -- Make wrappers accessible by keying daos, but do not return

--- a/kong/dao/migrations/postgres.lua
+++ b/kong/dao/migrations/postgres.lua
@@ -464,10 +464,15 @@ return {
   {
     name = "2017-04-18-153000_unique_plugins_id_2",
     up = [[
-      ALTER TABLE plugins ADD CONSTRAINT plugins_id_key UNIQUE(id);
+      DO $$
+      BEGIN
+        ALTER TABLE plugins ADD CONSTRAINT plugins_id_key UNIQUE(id);
+      EXCEPTION WHEN duplicate_table THEN
+        -- Do nothing, accept existing state
+      END$$;
     ]],
     down = [[
-      ALTER TABLE plugins DROP CONSTRAINT plugins_id_key;
+      DROP CONSTRAINT IF EXISTS plugins_id_key;
     ]],
   },
   {
@@ -684,8 +689,19 @@ return {
   {
     name = "2017-10-25-180700_plugins_routes_and_services",
     up = [[
-      ALTER TABLE plugins ADD route_id uuid REFERENCES routes(id) ON DELETE CASCADE;
-      ALTER TABLE plugins ADD service_id uuid REFERENCES services(id) ON DELETE CASCADE;
+      DO $$
+      BEGIN
+        ALTER TABLE plugins ADD route_id uuid REFERENCES routes(id) ON DELETE CASCADE;
+      EXCEPTION WHEN duplicate_column THEN
+        -- Do nothing, accept existing state
+      END$$;
+
+      DO $$
+      BEGIN
+        ALTER TABLE plugins ADD service_id uuid REFERENCES services(id) ON DELETE CASCADE;
+      EXCEPTION WHEN duplicate_column THEN
+        -- Do nothing, accept existing state
+      END$$;
 
       DO $$
       BEGIN

--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -250,7 +250,7 @@ local function generate_foreign_key_methods(schema)
           validate_options_type(options)
         end
 
-        local ok, errors = self.schema:validate_primary_key(foreign_key)
+        local ok, errors = self.schema:validate_field(field, foreign_key)
         if not ok then
           local err_t = self.errors:invalid_primary_key(errors)
           return nil, tostring(err_t), err_t

--- a/kong/db/errors.lua
+++ b/kong/db/errors.lua
@@ -283,7 +283,7 @@ function _M:unique_violation(unique_key)
   end
 
   local message = fmt("UNIQUE violation detected on '%s'",
-                      pl_pretty(unique_key, ""))
+                      pl_pretty(unique_key, ""):gsub("\"userdata: NULL\"", "null"))
 
   return new_err_t(self, ERRORS.UNIQUE_VIOLATION, message, unique_key)
 end

--- a/kong/db/schema/entities/apis.lua
+++ b/kong/db/schema/entities/apis.lua
@@ -1,0 +1,13 @@
+local typedefs = require "kong.db.schema.typedefs"
+
+return {
+  name = "apis",
+  legacy = true,
+  primary_key  = { "id" },
+  endpoint_key = "name",
+
+  fields = {
+    { id = typedefs.uuid, },
+    { name = { type = "string", unique = true } },
+  },
+}

--- a/kong/db/schema/entity.lua
+++ b/kong/db/schema/entity.lua
@@ -30,6 +30,10 @@ function Entity.new(definition)
       return nil, entity_errors.NO_NILABLE:format(name)
     end
 
+    if field.abstract then
+      goto continue
+    end
+
     if field.type == "map" then
       if field.keys.type ~= "string" then
         return nil, entity_errors.MAP_KEY_STRINGS_ONLY:format(name)
@@ -44,6 +48,8 @@ function Entity.new(definition)
       end
 
     end
+
+    ::continue::
   end
 
   return self

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1195,7 +1195,8 @@ function Schema:validate(input, full_check)
   if self.subschema_key then
     local key = input[self.subschema_key]
     if not (self.subschemas and self.subschemas[key]) then
-      subschema_error = validation_errors.SUBSCHEMA_UNKNOWN:format(key)
+      local errmsg = self.subschema_error or validation_errors.SUBSCHEMA_UNKNOWN
+      subschema_error = errmsg:format(key)
     end
   end
 

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1111,10 +1111,12 @@ function Schema:process_auto_fields(input, context, nulls)
   local output = tablex.deepcopy(input)
   local now_s  = ngx_time()
   local now_ms = ngx_now()
+  local read_before_write = false
 
   for key, field in self:each_field(input) do
+
     if field.auto then
-      if field.uuid and context == "insert" then
+      if field.uuid and context == "insert" and output[key] == nil then
         output[key] = utils.uuid()
       elseif field.uuid and context == "upsert" and output[key] == nil then
         output[key] = utils.uuid()
@@ -1142,6 +1144,9 @@ function Schema:process_auto_fields(input, context, nulls)
       elseif field_type == "set" then
         output[key] = make_set(field_value)
       elseif field_type == "record" and not field.abstract then
+        if context == "update" then
+          read_before_write = true
+        end
         if field_value ~= null then
           local field_schema = get_field_schema(field)
           output[key] = field_schema:process_auto_fields(field_value, context)
@@ -1157,6 +1162,42 @@ function Schema:process_auto_fields(input, context, nulls)
     end
   end
 
+  -- If a partial update does not provide the subschema key,
+  -- we need to do a read-before-write to get it and be
+  -- able to properly validate the entity.
+  if context == "update"
+     and self.subschema_key
+     and input[self.subschema_key] == nil then
+    read_before_write = true
+  end
+
+  return output, nil, read_before_write
+end
+
+
+--- Schema-aware deep-merge of two entities.
+-- Uses schema knowledge to merge two records field-by-field,
+-- but not merge the content of two arrays.
+-- @param top the entity whose values take precedence
+-- @param bottom the entity whose values are the fallback
+-- @return the merged entity
+function Schema:merge_values(top, bottom)
+  local output = {}
+  bottom = bottom or {}
+  for key, field in self:each_field(bottom) do
+    local top_v = top[key]
+
+    if top_v == nil then
+      output[key] = bottom[key]
+
+    else
+      if field.type == "record" and not field.abstract and top_v ~= null then
+        output[key] = get_field_schema(field):merge_values(top_v, bottom[key])
+      else
+        output[key] = top_v
+      end
+    end
+  end
   return output
 end
 

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -26,6 +26,18 @@ local Schema       = {}
 Schema.__index     = Schema
 
 
+local new_tab
+do
+  local ok
+  ok, new_tab = pcall(require, "table.new")
+  if not ok then
+    new_tab = function(narr, nrec)
+      return {}
+    end
+  end
+end
+
+
 local validation_errors = {
   -- general message
   ERROR                     = "Validation error: %s",
@@ -1321,6 +1333,23 @@ function Schema:errors_to_string(errors)
 
   local summary = concat(msgs, "; ")
   return validation_errors.ERROR:format(summary)
+end
+
+
+--- Given an entity, return a table containing only its primary key entries
+-- @param entity a table mapping field names to their values
+-- @return a subset of the input table, containing only the keys that
+-- are part of the primary key for this schema.
+function Schema:extract_pk_values(entity)
+  local pk_len = #self.primary_key
+  local pk_values = new_tab(0, pk_len)
+
+  for i = 1, pk_len do
+    local pk_name = self.primary_key[i]
+    pk_values[pk_name] = entity[pk_name]
+  end
+
+  return pk_values
 end
 
 

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -79,7 +79,7 @@ local validation_errors = {
   ENTITY_CHECK              = "failed entity check: %s(%s)",
   ENTITY_CHECK_N_FIELDS     = "entity check requires %d fields",
   CHECK                     = "entity check failed",
-  CONDITIONAL               = "failed conditional validation",
+  CONDITIONAL               = "failed conditional validation given value of field '%s'",
   AT_LEAST_ONE_OF           = "at least one of these fields must be non-empty: %s",
   ONLY_ONE_OF               = "only one of these fields must be non-empty: %s",
   DISTINCT                  = "values of these fields must be distinct: %s",
@@ -473,7 +473,7 @@ Schema.entity_checkers = {
       -- Handle `required`
       if arg.then_match.required == true and then_value == null then
         local field_errors = { [arg.then_field] = validation_errors.REQUIRED }
-        return nil, validation_errors.CONDITIONAL, field_errors
+        return nil, arg.if_field, field_errors
       end
 
       local then_merged = merge_field(schema.fields[arg.then_field], arg.then_match)
@@ -481,7 +481,7 @@ Schema.entity_checkers = {
       ok, err = Schema.validate_field(schema, then_merged, then_value)
       if not ok then
         local field_errors = { [arg.then_field] = err }
-        return nil, validation_errors.CONDITIONAL, field_errors
+        return nil, arg.if_field, field_errors
       end
 
       return true

--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -34,7 +34,8 @@ local match_any_list = {
 -- Field attributes which match a validator function in the Schema class
 local validators = {
   { between = { type = "array", elements = { type = "integer" }, len_eq = 2 }, },
-  { eq = { type = "self" }, },
+  { eq = { type = "any" }, },
+  { ne = { type = "any" }, },
   { len_eq = { type = "integer" }, },
   { len_min = { type = "integer" }, },
   { len_max = { type = "integer" }, },

--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -57,6 +57,7 @@ local field_schema = {
   { reference = { type = "string" }, },
   { auto = { type = "boolean" }, },
   { unique = { type = "boolean" }, },
+  { on_delete = { type = "string", one_of = { "restrict", "cascade", "null" } }, },
   { default = { type = "self" }, },
   { abstract = { type = "boolean" }, },
 }

--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -298,6 +298,12 @@ local MetaSchema = Schema.new({
       },
     },
     {
+      legacy = {
+        type = "boolean",
+        nilable = true,
+      },
+    },
+    {
       fields = fields_array,
     },
     {

--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -142,6 +142,7 @@ local meta_errors = {
   FIELDS_ARRAY = "each entry in fields must be a sub-table",
   FIELDS_KEY = "each key in fields must be a string",
   ENDPOINT_KEY = "value must be a field name",
+  CACHE_KEY = "values must be field names",
   TTL_RESERVED = "ttl is a reserved field name when ttl is enabled",
   SUBSCHEMA_KEY = "value must be a field name",
   SUBSCHEMA_KEY_STRING = "must be a string field",
@@ -292,6 +293,15 @@ local MetaSchema = Schema.new({
       },
     },
     {
+      cache_key = {
+        type = "array",
+        elements = {
+          type = "string",
+        },
+        nilable = true,
+      },
+    },
+    {
       ttl = {
         type = "boolean",
         nilable = true,
@@ -348,6 +358,23 @@ local MetaSchema = Schema.new({
       end
       if not found then
         errors["endpoint_key"] = meta_errors.ENDPOINT_KEY
+      end
+    end
+
+    if schema.cache_key then
+      for _, e in ipairs(schema.cache_key) do
+        local found = false
+        for _, item in ipairs(schema.fields) do
+          local k = next(item)
+          if e == k then
+            found = true
+            break
+          end
+        end
+        if not found then
+          errors["cache_key"] = meta_errors.CACHE_KEY
+          break
+        end
       end
     end
 

--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -315,6 +315,12 @@ local MetaSchema = Schema.new({
       },
     },
     {
+      subschema_error = {
+        type = "string",
+        nilable = true,
+      },
+    },
+    {
       legacy = {
         type = "boolean",
         nilable = true,

--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -46,6 +46,7 @@ local validators = {
   { match_any = match_any_list },
   { starts_with = { type = "string" }, },
   { one_of = { type = "array", elements = { type = "string" } }, },
+  { is_regex = { type = "boolean" }, },
   { timestamp = { type = "boolean" }, },
   { uuid = { type = "boolean" }, },
   { custom_validator = { type = "function" }, },
@@ -176,6 +177,9 @@ local attribute_types = {
     ["string"] = true,
     ["number"] = true,
     ["integer"] = true,
+  },
+  is_regex = {
+    ["string"] = true,
   },
   timestamp = {
     ["number"] = true,

--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -137,6 +137,7 @@ local meta_errors = {
   TABLE = "'%s' must be a table",
   BOOLEAN = "'%s' must be a boolean",
   TYPE = "missing type declaration",
+  FIELD_EMPTY = "field entry table is empty",
   FIELDS_ARRAY = "each entry in fields must be a sub-table",
   FIELDS_KEY = "each key in fields must be a string",
   ENDPOINT_KEY = "value must be a field name",
@@ -212,6 +213,10 @@ local check_fields = function(schema, errors)
       break
     end
     local k = next(item)
+    if not k then
+      errors["fields"] = meta_errors.FIELD_EMPTY
+      break
+    end
     local field = item[k]
     if type(field) == "table" then
       check_field(k, field, errors)

--- a/kong/db/schema/typedefs.lua
+++ b/kong/db/schema/typedefs.lua
@@ -99,4 +99,29 @@ typedefs.auto_timestamp_ms = Schema.define {
   auto = true
 }
 
+typedefs.no_api = Schema.define {
+  type = "foreign",
+  reference = "apis",
+  eq = ngx.null,
+}
+
+typedefs.no_route = Schema.define {
+  type = "foreign",
+  reference = "routes",
+  eq = ngx.null,
+}
+
+typedefs.no_service = Schema.define {
+  type = "foreign",
+  reference = "services",
+  eq = ngx.null,
+}
+
+typedefs.no_consumer = Schema.define {
+  type = "foreign",
+  reference = "consumers",
+  eq = ngx.null,
+}
+
+
 return typedefs

--- a/kong/db/strategies/cassandra/init.lua
+++ b/kong/db/strategies/cassandra/init.lua
@@ -445,7 +445,7 @@ function _M.new(connector, schema, errors)
 end
 
 
-local function deserialize_row(self, row)
+function _mt:deserialize_row(row)
   if not row then
     error("row must be a table", 2)
   end
@@ -510,7 +510,7 @@ local function _select(self, cql, args)
     return nil
   end
 
-  return deserialize_row(self, row)
+  return self:deserialize_row(row)
 end
 
 
@@ -705,7 +705,7 @@ do
     end
 
     for i = 1, #rows do
-      rows[i] = deserialize_row(self, rows[i])
+      rows[i] = self:deserialize_row(rows[i])
     end
 
     local next_offset

--- a/kong/db/strategies/cassandra/init.lua
+++ b/kong/db/strategies/cassandra/init.lua
@@ -648,7 +648,8 @@ function _mt:select_by_field(field_name, field_value, options)
   end
   local select_cql = fmt(cql, field_name .. " = ?")
   local bind_args = new_tab(1, 0)
-  bind_args[1] = field_value
+  local field = self.schema.fields[field_name]
+  bind_args[1] = serialize_arg(field, field_value)
 
   return _select(self, select_cql, bind_args)
 end

--- a/kong/db/strategies/cassandra/init.lua
+++ b/kong/db/strategies/cassandra/init.lua
@@ -48,19 +48,6 @@ local _mt = {}
 _mt.__index = _mt
 
 
-local function extract_pk_values(schema, entity)
-  local pk_len = #schema.primary_key
-  local pk_values = new_tab(0, pk_len)
-
-  for i = 1, pk_len do
-    local pk_name = schema.primary_key[i]
-    pk_values[pk_name] = entity[pk_name]
-  end
-
-  return pk_values
-end
-
-
 local function is_partitioned(self)
   local cql
 
@@ -600,7 +587,7 @@ function _mt:insert(entity, options)
   if res[APPLIED_COLUMN] == false then
     -- lightweight transaction (IF NOT EXISTS) failed,
     -- retrieve PK values for the PK violation error
-    local pk_values = extract_pk_values(schema, entity)
+    local pk_values = schema:extract_pk_values(entity)
 
     return nil, self.errors:primary_key_violation(pk_values)
   end
@@ -616,7 +603,7 @@ function _mt:insert(entity, options)
 
     if field.type == "foreign" then
       if value ~= ngx.null and value ~= nil then
-        value = extract_pk_values(field.schema, value)
+        value = field.schema:extract_pk_values(value)
 
       else
         value = ngx.null
@@ -864,7 +851,7 @@ do
       end
     end
 
-    local pk = extract_pk_values(self.schema, row)
+    local pk = self.schema:extract_pk_values(row)
 
     return self[mode](self, pk, entity, options)
   end
@@ -983,7 +970,7 @@ function _mt:delete_by_field(field_name, field_value, options)
     return true
   end
 
-  local pk = extract_pk_values(self.schema, row)
+  local pk = self.schema:extract_pk_values(row)
 
   return self:delete(pk)
 end

--- a/kong/db/strategies/cassandra/init.lua
+++ b/kong/db/strategies/cassandra/init.lua
@@ -488,8 +488,11 @@ local function deserialize_row(self, row)
 
     elseif field.timestamp and row[field_name] ~= nil then
       row[field_name] = row[field_name] / 1000
+
     elseif field.type == "record" then
-      row[field_name] = cjson.decode(row[field_name])
+      if type(row[field_name]) == "string" then
+        row[field_name] = cjson.decode(row[field_name])
+      end
     end
 
     if row[field_name] == nil then

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -85,10 +85,12 @@ end
 
 local function build_router(db, version)
   local routes, i = {}, 0
-  local routes_iterator = db.routes:each()
 
-  local route, err = routes_iterator()
-  while route do
+  for route, err in db.routes:each() do
+    if err then
+      return nil, "could not load routes: " .. err
+    end
+
     local service_pk = route.service
 
     if not service_pk then
@@ -117,12 +119,6 @@ local function build_router(db, version)
 
     i = i + 1
     routes[i] = r
-
-    route, err = routes_iterator()
-  end
-
-  if err then
-    return nil, "could not load routes: " .. err
   end
 
   sort(routes, function(r1, r2)
@@ -133,6 +129,7 @@ local function build_router(db, version)
     return r1.regex_priority > r2.regex_priority
   end)
 
+  local err
   router, err = Router.new(routes)
   if not router then
     return nil, "could not create router: " .. err

--- a/spec-old-api/02-integration/03-dao/09-cache_key_spec.lua
+++ b/spec-old-api/02-integration/03-dao/09-cache_key_spec.lua
@@ -2,13 +2,6 @@ local helpers = require "spec.helpers"
 
 describe("<dao>:cache_key()", function()
   describe("generates unique cache keys for core entities", function()
-    it("(Consumers)", function()
-      local consumer_id = "59c7fb5e-3430-11e7-b51f-784f437104fa"
-
-      local cache_key = helpers.db.consumers:cache_key(consumer_id)
-      assert.equal("consumers:" .. consumer_id .. "::::", cache_key)
-    end)
-
     it("(Plugins)", function()
       local name        = "my-plugin"
       local api_id      = "7c46b5f8-3430-11e7-afec-784f437104fa"

--- a/spec/01-unit/000-new-dao/01-schema/02-metaschema_spec.lua
+++ b/spec/01-unit/000-new-dao/01-schema/02-metaschema_spec.lua
@@ -45,6 +45,24 @@ describe("metaschema", function()
     assert.truthy(MetaSchema:validate(s))
   end)
 
+  it("a schema can be marked as legacy", function()
+    local s = {
+      name = "hello",
+      primary_key = { "foo" },
+      legacy = true,
+      fields = {
+        { foo = { type = "number" } } } }
+    assert.truthy(MetaSchema:validate(s))
+
+    s = {
+      name = "hello",
+      primary_key = { "foo" },
+      legacy = 2,
+      fields = {
+        { foo = { type = "number" } } } }
+    assert.falsy(MetaSchema:validate(s))
+  end)
+
   it("allows only one entity check per array field", function()
     local s = {
       name = "bad",

--- a/spec/01-unit/000-new-dao/01-schema/02-metaschema_spec.lua
+++ b/spec/01-unit/000-new-dao/01-schema/02-metaschema_spec.lua
@@ -14,6 +14,19 @@ describe("metaschema", function()
     assert.falsy(MetaSchema:validate(s))
   end)
 
+  it("fields cannot be empty", function()
+    local s = {
+      name = "bad",
+      fields = {
+        {}
+      },
+      primary_key = { "foo" },
+    }
+    local ok, err = MetaSchema:validate(s)
+    assert.falsy(ok)
+    assert.match("field entry table is empty", err.fields)
+  end)
+
   it("rejects an invalid entity check", function()
     local s = {
       name = "bad",

--- a/spec/02-integration/03-dao/09-cache_key_spec.lua
+++ b/spec/02-integration/03-dao/09-cache_key_spec.lua
@@ -5,7 +5,13 @@ describe("<dao>:cache_key()", function()
     it("(Consumers)", function()
       local consumer_id = "59c7fb5e-3430-11e7-b51f-784f437104fa"
 
+      -- raw string is a backwards-compatible alternative for entities
+      -- with an `id` as their primary key
       local cache_key = helpers.db.consumers:cache_key(consumer_id)
+      assert.equal("consumers:" .. consumer_id .. "::::", cache_key)
+
+      -- primary key in table form works the same
+      cache_key = helpers.db.consumers:cache_key({ id = consumer_id })
       assert.equal("consumers:" .. consumer_id .. "::::", cache_key)
     end)
 

--- a/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
@@ -238,7 +238,7 @@ describe("Admin API: #" .. kong_config.database, function()
             local json = cjson.decode(body)
             assert.equals("schema violation", json.name)
             assert.same({
-              ["@entity"] = { 'failed conditional validation' },
+              ["@entity"] = { [[failed conditional validation given value of field 'hash_on']] },
               hash_fallback = "expected one of: none, ip, header, cookie",
             }, json.fields)
 
@@ -256,7 +256,7 @@ describe("Admin API: #" .. kong_config.database, function()
             body = assert.res_status(400, res)
             local json = cjson.decode(body)
             assert.same({
-              ["@entity"] = { 'failed conditional validation' },
+              ["@entity"] = { [[failed conditional validation given value of field 'hash_on']] },
               hash_fallback = "expected one of: none, ip, header, cookie",
             }, json.fields)
 
@@ -275,7 +275,6 @@ describe("Admin API: #" .. kong_config.database, function()
             body = assert.res_status(400, res)
             local json = cjson.decode(body)
             assert.same({
-              ["@entity"] = { 'failed conditional validation' },
               hash_on_header = "bad header name 'not a <> valid <> header name', allowed characters are A-Z, a-z, 0-9, '_', and '-'",
             }, json.fields)
 
@@ -294,7 +293,6 @@ describe("Admin API: #" .. kong_config.database, function()
             body = assert.res_status(400, res)
             local json = cjson.decode(body)
             assert.same({
-              ["@entity"] = { 'failed conditional validation' },
               hash_fallback_header = "bad header name 'not a <> valid <> header name', allowed characters are A-Z, a-z, 0-9, '_', and '-'",
             }, json.fields)
 
@@ -332,7 +330,7 @@ describe("Admin API: #" .. kong_config.database, function()
             body = assert.res_status(400, res)
             local json = cjson.decode(body)
             assert.same({
-              ["@entity"] = { 'failed conditional validation' },
+              ["@entity"] = { [[failed conditional validation given value of field 'hash_on']] },
               hash_fallback = "expected one of: none",
             }, json.fields)
 
@@ -352,7 +350,7 @@ describe("Admin API: #" .. kong_config.database, function()
             body = assert.res_status(400, res)
             local json = cjson.decode(body)
             assert.same({
-              ["@entity"] = { 'failed conditional validation' },
+              ["@entity"] = { [[failed conditional validation given value of field 'hash_on']] },
               hash_on_header = "required field missing",
             }, json.fields)
 
@@ -370,7 +368,7 @@ describe("Admin API: #" .. kong_config.database, function()
             body = assert.res_status(400, res)
             local json = cjson.decode(body)
             assert.same({
-              ["@entity"] = { 'failed conditional validation' },
+              ["@entity"] = { [[failed conditional validation given value of field 'hash_fallback']] },
               hash_fallback_header = "required field missing",
             }, json.fields)
 
@@ -388,7 +386,6 @@ describe("Admin API: #" .. kong_config.database, function()
             body = assert.res_status(400, res)
             local json = cjson.decode(body)
             assert.same({
-              ["@entity"] = { 'failed conditional validation' },
               hash_on_cookie = "bad cookie name 'not a <> valid <> cookie name', allowed characters are A-Z, a-z, 0-9, '_', and '-'",
             }, json.fields)
 
@@ -423,7 +420,6 @@ describe("Admin API: #" .. kong_config.database, function()
             body = assert.res_status(400, res)
             local json = cjson.decode(body)
             assert.same({
-              ["@entity"] = { 'failed conditional validation' },
               hash_on_cookie = "bad cookie name 'not a <> valid <> cookie name', allowed characters are A-Z, a-z, 0-9, '_', and '-'",
             }, json.fields)
 


### PR DESCRIPTION
This is the first half of the work porting the Plugins core entity to kong.db — Plugins is the last pending core entity using the old DAO; after this, the only core entity using the old DAO will be the deprecated Apis entity, as well as the non-core entities from Plugins, which are on the way to being ported as well.

This PR contains a number of features and fixes needed to port Plugins to `kong.db`, the new DAO infrastructure. This contains all the work that can be merged prior to "flicking the switch" and deleting the entity from `kong.dao` and adding the entity in `kong.db`.

This contains the minimal changes to the test suite to keep tests passing. Tests exercising the new behaviors added will appear in the second PR, in which the Plugins entity is ported over.