### PR TITLE
[WIP] Refactor request construction

### DIFF
--- a/kong/pdk/service/request.lua
+++ b/kong/pdk/service/request.lua
@@ -91,7 +91,7 @@ local function new(self)
       error("invalid scheme: " .. scheme, 2)
     end
 
-    ngx.var.upstream_scheme = scheme
+    ngx.ctx.upstream_url_data.upstream_scheme = scheme
   end
 
 
@@ -117,7 +117,8 @@ local function new(self)
 
     -- TODO: is this necessary in specific phases?
     -- ngx.req.set_uri(path)
-    ngx.var.upstream_uri = path
+    ngx.ctx.upstream_url_data.request_uri_base = path
+    ngx.ctx.upstream_url_data.request_uri_postfix = ""
   end
 
 
@@ -244,7 +245,7 @@ local function new(self)
   -- Sets a header in the request to the Service with the given value. Any existing header
   -- with the same name will be overridden.
   --
-  -- If the `header` argument is `"host"` (case-insensitive), then this is
+  -- If the `header` argument is `"host"` (case-insensitive), then this
   -- will also set the SNI of the request to the Service.
   --
   -- @function kong.service.request.set_header
@@ -260,7 +261,7 @@ local function new(self)
     validate_header(header, value)
 
     if string_lower(header) == "host" then
-      ngx.var.upstream_host = value
+      ngx.ctx.upstream_url_data.upstream_host = value
     end
 
     ngx.req.set_header(header, normalize_header(value))
@@ -286,7 +287,7 @@ local function new(self)
     validate_header(header, value)
 
     if string_lower(header) == "host" then
-      ngx.var.upstream_host = value
+      ngx.ctx.upstream_url_data.upstream_host = value
     end
 
     local headers = ngx.req.get_headers()[header]
@@ -370,10 +371,10 @@ local function new(self)
     validate_headers(headers)
 
     -- Now we can use ngx.req.set_header without pcall
-
+    local ctx = ngx.ctx
     for k, v in pairs(headers) do
       if string_lower(k) == "host" then
-        ngx.var.upstream_host = v
+        ctx.upstream_url_data.upstream_host = v
       end
 
       ngx.req.set_header(k, normalize_multi_header(v))

--- a/kong/router.lua
+++ b/kong/router.lua
@@ -388,14 +388,14 @@ do
           end
 
           -- plain or prefix match from the index
-          if route_t.strip_uri then
+--          if route_t.strip_uri then
             local stripped_uri = sub(ctx.req_uri, #uri_t.value + 1)
             if sub(stripped_uri, 1, 1) ~= "/" then
               stripped_uri = "/" .. stripped_uri
             end
 
             ctx.matches.stripped_uri = stripped_uri
-          end
+--          end
 
           ctx.matches.uri = uri_t.value
 
@@ -436,14 +436,14 @@ do
           if from == 1 then
             ctx.matches.uri = sub(ctx.req_uri, 1, to)
 
-            if route_t.strip_uri then
+--            if route_t.strip_uri then
               local stripped_uri = sub(ctx.req_uri, to + 1)
               if sub(stripped_uri, 1, 1) ~= "/" then
                 stripped_uri = "/" .. stripped_uri
               end
 
               ctx.matches.stripped_uri = stripped_uri
-            end
+--            end
 
             ctx.matches.uri = uri_t.value
 
@@ -644,7 +644,7 @@ function _M.new(routes)
 
     -- input sanitization for matchers
 
-    local raw_req_host = req_host
+--    local raw_req_host = req_host
 
     req_method = upper(req_method)
 
@@ -767,7 +767,7 @@ function _M.new(routes)
           end
 
           if matched_route then
-            local upstream_host
+--            local upstream_host
             local upstream_uri   = req_uri
             local upstream_url_t = matched_route.upstream_url_t
             local matches        = ctx.matches
@@ -775,7 +775,6 @@ function _M.new(routes)
             -- URI stripping logic
 
             local uri_root = req_uri == "/"
-
             if not uri_root and matched_route.strip_uri
                and matches.stripped_uri
             then
@@ -811,29 +810,34 @@ function _M.new(routes)
               end
             end
 
-            -- preserve_host header logic
-
-            if matched_route.preserve_host then
-              upstream_host = raw_req_host or ngx.var.http_host
-            end
+--            -- preserve_host header logic
+--
+--            if matched_route.preserve_host then
+--              upstream_host = raw_req_host or ngx.var.http_host
+--            end
 
             local match_t     = {
               route           = matched_route.route,
               service         = matched_route.service,
               headers         = matched_route.headers,
               upstream_url_t  = upstream_url_t,
-              upstream_scheme = upstream_url_t.scheme,
-              upstream_uri    = upstream_uri,
-              upstream_host   = upstream_host,
+              upstream_scheme = upstream_url_t.scheme, -- TODO: remove, just pass-through, no value add?
+              upstream_uri    = upstream_uri, -- TODO: remove when construction is in after-access
+--              upstream_host   = upstream_host, -- TODO: remove, preserve_host above logic gone, so no value add
               matches         = {
                 uri_captures  = matches.uri_captures,
                 uri           = matches.uri,
+                uri_postfix   = matches.stripped_uri,
                 host          = matches.host,
                 method        = matches.method,
               }
             }
 
             cache:set(cache_key, match_t)
+
+--print(require("pl.pretty").write(match_t))
+
+
 
             return match_t
           end

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -523,6 +523,24 @@ return {
         return responses.send(426, "Please use HTTPS protocol")
       end
 
+      local upstream_url_data = {
+        -- info captured from the incoming request
+        request_host         = var.http_host or "",
+        request_uri_base     = match_t.matches.uri,
+        request_uri_postfix  = match_t.upstream_uri_postfix,
+        -- describe the outgoing/proxied request
+        -- (host & port go in 'balancer_data' below)
+        upstream_scheme      = upstream_url_t.scheme,
+        upstream_uri_base    = upstream_url_t.path,
+        upstream_file_base   = upstream_url_t.file,   -- TODO: do we need this here?
+        upstream_uri_postfix = match_t.upstream_uri_postfix,
+        upstream_uri_full    = match_t.upstream_uri,  -- TODO: remove when construction is in after-access
+        -- settings influencing the final construction of the proxied request
+        strip_path           = route.strip_path,
+        preserve_host        = route.preserve_host,
+      }
+--print(require("pl.pretty").write(upstream_url_data))
+
       local balancer_data = {
         type           = upstream_url_t.type, -- type of 'host': ipv4, ipv6, name
         host           = upstream_url_t.host, -- target host per `upstream_url`
@@ -575,20 +593,21 @@ return {
       end
 
       -- TODO: this needs to be removed when references to ctx.api are removed
-      ctx.api              = api
-      ctx.service          = service
-      ctx.route            = route
-      ctx.router_matches   = match_t.matches
-      ctx.balancer_data    = balancer_data
-      ctx.balancer_address = balancer_data -- for plugin backward compatibility
+      ctx.api               = api
+      ctx.service           = service
+      ctx.route             = route
+      ctx.router_matches    = match_t.matches
+      ctx.balancer_data     = balancer_data
+      ctx.balancer_address  = balancer_data -- for plugin backward compatibility
+      ctx.upstream_url_data = upstream_url_data
 
       -- `scheme` is the scheme to use for the upstream call
       -- `uri` is the URI with which to call upstream, as returned by the
       --       router, which might have truncated it (`strip_uri`).
       -- `host` is the original header to be preserved if set.
-      var.upstream_scheme = match_t.upstream_scheme
-      var.upstream_uri    = match_t.upstream_uri
-      var.upstream_host   = match_t.upstream_host
+--      var.upstream_scheme = match_t.upstream_scheme  --TODO: remove entire block since it goes to after-access
+--      var.upstream_uri    = match_t.upstream_uri
+--      var.upstream_host   = match_t.upstream_host
 
       -- Keep-Alive and WebSocket Protocol Upgrade Headers
       if var.http_upgrade and lower(var.http_upgrade) == "websocket" then
@@ -616,18 +635,26 @@ return {
     -- Only executed if the `router` module found a route and allows nginx to proxy it.
     after = function(ctx)
       local var = ngx.var
+      local upstream_url_data = ctx.upstream_url_data
 
-      do
+      local upstream_scheme = upstream_url_data.upstream_scheme
+      var.upstream_scheme = upstream_scheme
+
+      do  -- set the upstream uri
+
         -- Nginx's behavior when proxying a request with an empty querystring
         -- `/foo?` is to keep `$is_args` an empty string, hence effectively
         -- stripping the empty querystring.
         -- We overcome this behavior with our own logic, to preserve user
         -- desired semantics.
-        local upstream_uri = var.upstream_uri
+
+        -- TODO: build the upstream_uri instead of grabbing it
+        local upstream_uri = upstream_url_data.upstream_uri_full
 
         if var.is_args == "?" or sub(var.request_uri, -1) == "?" then
-          var.upstream_uri = upstream_uri .. "?" .. (var.args or "")
+          upstream_uri = upstream_uri .. "?" .. (var.args or "")
         end
+        var.upstream_uri = upstream_uri
       end
 
       local ok, err, errcode = balancer.execute(ctx.balancer_data, ctx)
@@ -640,23 +667,22 @@ return {
         return responses.send(errcode, err)
       end
 
-      do
-        -- set the upstream host header if not `preserve_host`
-        local upstream_host = var.upstream_host
+      do  -- set the upstream host header
+        local upstream_host
+        local balancer_data = ctx.balancer_data
 
-        if not upstream_host or upstream_host == "" then
-          local balancer_data = ctx.balancer_data
+        if upstream_url_data.preserve_host then
+          upstream_host = upstream_url_data.request_host
+        else
           upstream_host = balancer_data.hostname
-
-          local upstream_scheme = var.upstream_scheme
           if upstream_scheme == "http"  and balancer_data.port ~= 80 or
-             upstream_scheme == "https" and balancer_data.port ~= 443
+            upstream_scheme == "https" and balancer_data.port ~= 443
           then
             upstream_host = upstream_host .. ":" .. balancer_data.port
           end
-
-          var.upstream_host = upstream_host
         end
+
+        var.upstream_host = upstream_host
       end
 
       local now = get_now()

--- a/spec/01-unit/010-router_spec.lua
+++ b/spec/01-unit/010-router_spec.lua
@@ -1637,7 +1637,9 @@ describe("Router", function()
           assert.equal("example.org", match_t.upstream_url_t.host)
         end)
 
-        it("uses the request's Host header when `grab_header` is disabled", function()
+        pending("uses the request's Host header when `grab_header` is disabled", function()
+-- the test looks obsolete, since the codde that introduced `grab_header` seesm to be gone
+-- from the code base.
           local use_case_routes = {
             {
               service         = service,
@@ -1661,7 +1663,7 @@ describe("Router", function()
 
         pending("uses the request's Host header if an route with no host was cached", function()
 -- since the host header is now constructed elsewhere, it no longer interferes
--- with whatever the router does.
+-- with whatever the router does. So this test can be removed?
           -- This is a regression test for:
           -- https://github.com/Kong/kong/issues/2825
           -- Ensure cached routes (in the LRU cache) still get proxied with the

--- a/t/01-pdk/02-log/03-set_format.t
+++ b/t/01-pdk/02-log/03-set_format.t
@@ -328,7 +328,6 @@ GET /t
 
 
 === TEST 14: log.set_format() complex format
---- ONLY
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location /t {
@@ -355,6 +354,6 @@ GET /t
 GET /t
 --- no_response_body
 --- error_log
-[kong] [%%namespace: my_namespace | my_namespace, %%file_src: content_by_lua(nginx.conf:192) | content_by_lua(nginx.conf:192), %%line_src: 14 | 14, %%func_name my_func | my_func, %%message hello world | hello world]
+[kong] [%%namespace: my_namespace | my_namespace, %%file_src: content_by_lua(nginx.conf:193) | content_by_lua(nginx.conf:193), %%line_src: 14 | 14, %%func_name my_func | my_func, %%message hello world | hello world]
 --- no_error_log
 [error]

--- a/t/01-pdk/06-service-request/01-set_scheme.t
+++ b/t/01-pdk/06-service-request/01-set_scheme.t
@@ -85,6 +85,8 @@ qq{
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
 
+            ngx.ctx.upstream_url_data = {}
+
             local ok, err = pdk.service.request.set_scheme("https")
         }
 
@@ -122,6 +124,8 @@ qq{
         access_by_lua_block {
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
+
+            ngx.ctx.upstream_url_data = {}
 
             local ok, err = pdk.service.request.set_scheme("http")
         }

--- a/t/01-pdk/06-service-request/09-set_header.t
+++ b/t/01-pdk/06-service-request/09-set_header.t
@@ -122,6 +122,7 @@ qq{
             ngx.ctx.balancer_address = {
                 host = "foo.xyz"
             }
+            ngx.ctx.upstream_url_data = {}
 
             pdk.service.request.set_header("Host", "example.com")
 
@@ -160,6 +161,8 @@ qq{
         access_by_lua_block {
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
+
+            ngx.ctx.upstream_url_data = {}
 
             pdk.service.request.set_header("X-Foo", "hello world")
 

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -38,6 +38,7 @@ our $HttpConfig = <<_EOC_;
 
             -- mock balancer structure
             ngx.ctx.balancer_address = {}
+            ngx.ctx.upstream_url_data = {}
 
             local mod
             do


### PR DESCRIPTION
Move construction of request properties to the `access.after` handler. This allows updates of individual components, and even settings like `preserve_host` or `strip_path`, in the access phase.

More importantly it allows plugins currently limited to only replacing the full upstream uri, to update only the prefix, and still get the post-fix (the dynamic part beyond the path match), included in the final uri.

