### PR TITLE
chore(*) rename 'balancer_address' to 'balancer_data'

### DIFF
--- a/kong/pdk/service.lua
+++ b/kong/pdk/service.lua
@@ -58,7 +58,7 @@ local function new()
       return nil, "could not find an Upstream named '" .. host .. "'"
     end
 
-    ngx.ctx.balancer_address.host = host
+    ngx.ctx.balancer_data.host = host
     return true
   end
 
@@ -95,8 +95,8 @@ local function new()
     end
 
     ngx.var.upstream_host = host
-    ngx.ctx.balancer_address.host = host
-    ngx.ctx.balancer_address.port = port
+    ngx.ctx.balancer_data.host = host
+    ngx.ctx.balancer_data.port = port
   end
 
 

--- a/t/01-pdk/06-service-request/01-set_scheme.t
+++ b/t/01-pdk/06-service-request/01-set_scheme.t
@@ -21,7 +21,7 @@ __DATA__
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
 
-            ngx.ctx.balancer_address = 8000
+            ngx.ctx.balancer_data = 8000
 
             local pok, err = pcall(pdk.service.request.set_scheme)
             ngx.say(err)
@@ -44,7 +44,7 @@ scheme must be a string
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
 
-            ngx.ctx.balancer_address = 8000
+            ngx.ctx.balancer_data = 8000
 
             local pok, err = pcall(pdk.service.request.set_scheme, "HTTP")
             ngx.say(err)

--- a/t/01-pdk/06-service-request/09-set_header.t
+++ b/t/01-pdk/06-service-request/09-set_header.t
@@ -119,7 +119,7 @@ qq{
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
 
-            ngx.ctx.balancer_address = {
+            ngx.ctx.balancer_data = {
                 host = "foo.xyz"
             }
 

--- a/t/01-pdk/06-service-request/10-add_header.t
+++ b/t/01-pdk/06-service-request/10-add_header.t
@@ -119,7 +119,7 @@ qq{
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
 
-            ngx.ctx.balancer_address = {
+            ngx.ctx.balancer_data = {
                 host = "foo.xyz"
             }
 
@@ -163,7 +163,7 @@ qq{
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
 
-            ngx.ctx.balancer_address = {
+            ngx.ctx.balancer_data = {
                 host = "foo.xyz"
             }
 

--- a/t/01-pdk/06-service-request/12-set_headers.t
+++ b/t/01-pdk/06-service-request/12-set_headers.t
@@ -77,7 +77,7 @@ qq{
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
 
-            ngx.ctx.balancer_address = {
+            ngx.ctx.balancer_data = {
                 host = "foo.xyz"
             }
 

--- a/t/01-pdk/09-service/01-set-upstream.t
+++ b/t/01-pdk/09-service/01-set-upstream.t
@@ -32,7 +32,7 @@ host must be a string
 
 
 
-=== TEST 2: service.set_upstream() sets ngx.ctx.balancer_address.host
+=== TEST 2: service.set_upstream() sets ngx.ctx.balancer_data.host
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -53,14 +53,14 @@ host must be a string
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
 
-            ngx.ctx.balancer_address = {
+            ngx.ctx.balancer_data = {
                 host = "foo.xyz"
             }
 
             local ok = pdk.service.set_upstream("my_upstream")
 
             ngx.say(tostring(ok))
-            ngx.say("host: ", ngx.ctx.balancer_address.host)
+            ngx.say("host: ", ngx.ctx.balancer_data.host)
         }
     }
 --- request
@@ -94,7 +94,7 @@ host: my_upstream
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
 
-            ngx.ctx.balancer_address = {
+            ngx.ctx.balancer_data = {
                 host = "foo.xyz"
             }
 

--- a/t/01-pdk/09-service/02-set-target.t
+++ b/t/01-pdk/09-service/02-set-target.t
@@ -32,7 +32,7 @@ host must be a string
 
 
 
-=== TEST 2: service.set_target() sets ngx.ctx.balancer_address.host
+=== TEST 2: service.set_target() sets ngx.ctx.balancer_data.host
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -43,14 +43,14 @@ host must be a string
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
 
-            ngx.ctx.balancer_address = {
+            ngx.ctx.balancer_data = {
                 host = "foo.xyz"
             }
 
             local ok = pdk.service.set_target("example.com", 123)
 
             ngx.say(tostring(ok))
-            ngx.say("host: ", ngx.ctx.balancer_address.host)
+            ngx.say("host: ", ngx.ctx.balancer_data.host)
         }
     }
 --- request
@@ -71,7 +71,7 @@ host: example.com
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
 
-            ngx.ctx.balancer_address = 8000
+            ngx.ctx.balancer_data = 8000
 
             local pok, err = pcall(pdk.service.set_target, "example.com", "foo")
             ngx.say(err)
@@ -94,7 +94,7 @@ port must be an integer
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
 
-            ngx.ctx.balancer_address = 8000
+            ngx.ctx.balancer_data = 8000
 
             local pok, err = pcall(pdk.service.set_target, "example.com", 123.4)
 
@@ -118,7 +118,7 @@ port must be an integer
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
 
-            ngx.ctx.balancer_address = 8000
+            ngx.ctx.balancer_data = 8000
 
             local pok, err = pcall(pdk.service.set_target, "example.com", -1)
             ngx.say(err)
@@ -147,14 +147,14 @@ port must be an integer between 0 and 65535: given 70000
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
 
-            ngx.ctx.balancer_address = {
+            ngx.ctx.balancer_data = {
                 port = 8000
             }
 
             local ok = pdk.service.set_target("example.com", 1234)
 
             ngx.say(tostring(ok))
-            ngx.say("port: ", ngx.ctx.balancer_address.port)
+            ngx.say("port: ", ngx.ctx.balancer_data.port)
         }
     }
 --- request

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -37,7 +37,7 @@ our $HttpConfig = <<_EOC_;
         function phase_check_functions(phase, skip_fnlist)
 
             -- mock balancer structure
-            ngx.ctx.balancer_address = {}
+            ngx.ctx.balancer_data = {}
 
             local mod
             do


### PR DESCRIPTION
The PDK and PDK tests were still using the old `balancer_address`
structure name (renamed in fe834e7c64767446546dcc6e640f1c66485740d3).