### PR TITLE
Add manual datastore refresh endpoint

### DIFF
--- a/kong/api/routes/kong.lua
+++ b/kong/api/routes/kong.lua
@@ -77,6 +77,18 @@ return {
       }
     end
   },
+  ["/refresh"] = {
+    PUT = function(self, dao, helpers)
+      local ok, err = dao.db:refresh()
+      if not ok then
+        ngx.log(ngx.ERR, "failed to refresh database as part of ",
+                         "/refresh endpoint: ", err)
+        return helpers.responses.send_HTTP_SERVICE_UNAVAILABLE(err)
+      end
+
+      return helpers.responses.send_HTTP_NO_CONTENT()
+    end
+  },
   ["/status"] = {
     GET = function(self, dao, helpers)
       local r = ngx.location.capture "/nginx_status"

--- a/kong/api/routes/kong.lua
+++ b/kong/api/routes/kong.lua
@@ -82,8 +82,7 @@ return {
       local worker_events  = singletons.worker_events
       local ok, err = worker_events.post("database", "invalid", nil)
       if not ok then
-        ngx.log(ngx.ERR, "failed to refresh database as part of ",
-                         "/refresh endpoint: ", err)
+        ngx.log(ngx.ERR, "failed to schedule DB refresh ", err)
         return helpers.responses.send_HTTP_SERVICE_UNAVAILABLE(err)
       end
 

--- a/kong/api/routes/kong.lua
+++ b/kong/api/routes/kong.lua
@@ -79,7 +79,8 @@ return {
   },
   ["/refresh"] = {
     PUT = function(self, dao, helpers)
-      local ok, err = dao.db:refresh()
+      local worker_events  = singletons.worker_events
+      local ok, err = worker_events.post("database", "invalid", nil)
       if not ok then
         ngx.log(ngx.ERR, "failed to refresh database as part of ",
                          "/refresh endpoint: ", err)

--- a/kong/dao/db/cassandra.lua
+++ b/kong/dao/db/cassandra.lua
@@ -834,4 +834,13 @@ function _M:reachable()
   return true
 end
 
+function _M:refresh()
+  local ok, err = self.cluster:refresh()
+  if not ok then
+    return nil, Errors.db(err)
+  end
+
+  return true
+end
+
 return _M

--- a/kong/dao/db/postgres.lua
+++ b/kong/dao/db/postgres.lua
@@ -631,4 +631,15 @@ function _M:reachable()
   return true
 end
 
+function _M:refresh()
+  -- This is a dummy function to provide compatibility.
+  -- Refresh only applies to Cassandra.
+  local ok, err = true, true
+  if not ok then
+    return nil, Errors.db(err)
+  end
+
+  return true
+end
+
 return _M

--- a/kong/dao/db/postgres.lua
+++ b/kong/dao/db/postgres.lua
@@ -634,11 +634,6 @@ end
 function _M:refresh()
   -- This is a dummy function to provide compatibility.
   -- Refresh only applies to Cassandra.
-  local ok, err = true, true
-  if not ok then
-    return nil, Errors.db(err)
-  end
-
   return true
 end
 

--- a/kong/db/strategies/cassandra/connector.lua
+++ b/kong/db/strategies/cassandra/connector.lua
@@ -312,7 +312,7 @@ end
 function CassandraConnector:refresh()
   local ok, err = self.cluster:refresh()
   if not ok then
-    return nil, Errors.db(err)
+    return nil, err
   end
 
   return true

--- a/kong/db/strategies/cassandra/connector.lua
+++ b/kong/db/strategies/cassandra/connector.lua
@@ -309,4 +309,14 @@ function CassandraConnector:truncate_table(table_name)
 end
 
 
+function CassandraConnector:refresh()
+  local ok, err = self.cluster:refresh()
+  if not ok then
+    return nil, Errors.db(err)
+  end
+
+  return true
+end
+
+
 return CassandraConnector

--- a/kong/db/strategies/postgres/connector.lua
+++ b/kong/db/strategies/postgres/connector.lua
@@ -326,6 +326,11 @@ function _mt:truncate_table(table_name)
   return true
 end
 
+function _mt:refresh()
+  -- This is a dummy function to provide compatibility.
+  -- Refresh only applies to Cassandra.
+  return true
+end
 
 local _M = {}
 

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -165,9 +165,16 @@ return {
       local worker_events  = singletons.worker_events
       local cluster_events = singletons.cluster_events
 
+      -- database topology refresher
+
+      worker_events.register(function()
+        local ok, err = dao.db:refresh()
+        if not ok then
+          ngx.log(ERR, "[events] failed to schedule DB refresh: ", err)
+        end
+      end, "database", "invalid")
 
       -- events dispatcher
-
 
       worker_events.register(function(data)
         if not data.new_db then

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -170,7 +170,11 @@ return {
       worker_events.register(function()
         local ok, err = dao.db:refresh()
         if not ok then
-          ngx.log(CRIT, "[events] failed to refresh database: ", err)
+          ngx.log(ngx.CRIT, "[events] failed to refresh database: ", err)
+        end
+        local ok, err = db.connector:refresh()
+        if not ok then
+          ngx.log(ngx.CRIT, "[events] failed to refresh database: ", err)
         end
       end, "database", "invalid")
 

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -170,7 +170,7 @@ return {
       worker_events.register(function()
         local ok, err = dao.db:refresh()
         if not ok then
-          ngx.log(ERR, "[events] failed to schedule DB refresh: ", err)
+          ngx.log(CRIT, "[events] failed to refresh database: ", err)
         end
       end, "database", "invalid")
 


### PR DESCRIPTION
### Summary

Add manual datastore refresh functionality.

### Full changelog

* Adds refresh functions for Cassandra and Postgres. The latter is a dummy function for compatibility.
* Adds Admin API route to call datastore refresh functions.

### Background

Related to issue #2674. Although this is not a complete fix (ideally refreshes should not require manual intervention) it's a better workaround than completely restarting a node.

For Cassandra, this adds a simple means of calling the existing Cluster:refresh() function provided by the lua-cassandra driver. Postgres does not have similar needs, so its function is a dummy that the Admin API route can always call successfully.

No tests added as lua-cassandra should handle everything important and test it independently. I performed basic testing by starting Kong, adding a node to its Cassandra cluster, calling refresh, and confirming that the new node's IP was selected by the DB load balancing policy. I then removed the node from the cluster, observed that `set_peer_down()` was called on the node IP, refreshed again, and confirmed that calls to `set_peer_down()` had stopped.