### PR TITLE
optimized non-idempotent method's retry times

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -399,7 +399,9 @@ function Kong.balancer()
   else
     -- first try, so set the max number of retries
     local retries = balancer_data.retries
-    if retries > 0 then
+    -- non-idempotent method should not be retried
+    local method = ngx.req.get_method()
+    if retries > 0 and method ~= "POST" and method ~= "PATCH" and method ~= "LOCK"then
       set_more_tries(retries)
     end
   end


### PR DESCRIPTION
### Summary

The non-idempotent request method's more retry times should be set to 0.