### PR TITLE
feat(db) make schema set fields to default if missing from DB 

### DIFF
--- a/kong/db/schema/entity.lua
+++ b/kong/db/schema/entity.lua
@@ -17,6 +17,18 @@ local base_types = {
   integer = true,
 }
 
+-- Make records in Entities non-nullable by default,
+-- so that they return their full structure on API queries.
+local function make_records_non_nullable(field)
+  if field.nullable == nil then
+    field.nullable = false
+  end
+  for _, f in Schema.each_field(field) do
+    if f.type == "record" then
+      make_records_non_nullable(f)
+    end
+  end
+end
 
 function Entity.new(definition)
 
@@ -46,6 +58,9 @@ function Entity.new(definition)
       if not base_types[field.elements.type] then
         return nil, entity_errors.AGGREGATE_ON_BASE_TYPES_ONLY:format(name)
       end
+
+    elseif field.type == "record" then
+      make_records_non_nullable(field)
 
     end
 

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1210,7 +1210,7 @@ function Schema:process_auto_fields(input, context, nulls)
         end
         if field_value ~= null then
           local field_schema = get_field_schema(field)
-          output[key] = field_schema:process_auto_fields(field_value, context)
+          output[key] = field_schema:process_auto_fields(field_value, context, nulls)
         end
       end
 

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -495,7 +495,8 @@ Schema.entity_checkers = {
   --                 then_match = { required = true } }
   -- ```
   conditional = {
-    field_sources = { "if_field" },
+    field_sources = { "if_field", "then_field" },
+    required_fields = { ["if_field"] = true },
     fn = function(entity, arg, schema)
       local if_value = get_field(entity, arg.if_field)
       local then_value = get_field(entity, arg.then_field) or null
@@ -909,10 +910,12 @@ local function run_entity_check(self, name, input, arg, full_check)
   end
 
   local all_nil = true
+  local required_fields = checker.required_fields
   for _, fname in ipairs(fields_to_check) do
     local value = get_field(input, fname)
     if value == nil then
-      if not checker.run_with_missing_fields then
+      if not (checker.run_with_missing_fields or
+             (required_fields and not required_fields[fname])) then
         local err = validation_errors.REQUIRED_FOR_ENTITY_CHECK
         set_field(field_errors, fname, err)
         ok = false

--- a/spec/01-unit/000-new-dao/01-schema/01-schema_spec.lua
+++ b/spec/01-unit/000-new-dao/01-schema/01-schema_spec.lua
@@ -1430,8 +1430,11 @@ describe("schema", function()
         redis_host = "example.com",
         redis_port = 80
       }))
-      assert.falsy(Test:validate_update({
+      assert.truthy(Test:validate_update({
         policy = "bla",
+      }))
+      assert.falsy(Test:validate_update({
+        policy = "redis",
       }))
     end)
 
@@ -1476,6 +1479,11 @@ describe("schema", function()
         }
       }))
       assert.falsy(Test:validate_update({
+        config = {
+          policy = "redis",
+        }
+      }))
+      assert.truthy(Test:validate_update({
         config = {
           policy = "bla",
         }
@@ -1536,7 +1544,7 @@ describe("schema", function()
           { d = { type = "integer" }, },
           { e = { type = "boolean" }, },
           { f = { type = "string" }, },
-                { g = { type = "record", fields = {} }, },
+          { g = { type = "record", fields = {} }, },
           { h = { type = "map", keys = {}, values = {} }, },
         }
       })

--- a/spec/01-unit/000-new-dao/04-dao.lua
+++ b/spec/01-unit/000-new-dao/04-dao.lua
@@ -1,0 +1,348 @@
+local Schema = require("kong.db.schema.init")
+local Entity = require("kong.db.schema.entity")
+local DAO = require("kong.db.dao.init")
+local errors = require("kong.db.errors")
+local utils = require("kong.tools.utils")
+
+local null = ngx.null
+
+local nullable_schema_definition = {
+  name = "Foo",
+  primary_key = { "a" },
+  fields = {
+    { a = { type = "number" }, },
+    { b = { type = "string", default = "hello" }, },
+    { u = { type = "string" }, },
+    { r = { type = "record",
+            nullable = true,
+            fields = {
+              { f1 = { type = "number" } },
+              { f2 = { type = "string", default = "world" } },
+            } } },
+  }
+}
+
+local non_nullable_schema_definition = {
+  name = "Foo",
+  primary_key = { "a" },
+  fields = {
+    { a = { type = "number" }, },
+    { b = { type = "string", default = "hello", nullable = false }, },
+    { u = { type = "string" }, },
+    { r = { type = "record",
+            fields = {
+              { f1 = { type = "number" } },
+              { f2 = { type = "string", default = "world", nullable = false } },
+            } } },
+  }
+}
+
+local mock_db = {}
+
+
+describe("DAO", function()
+
+  describe("select", function()
+
+    it("applies defaults if strategy returns column as nil and is nullable in schema", function()
+      local schema = assert(Schema.new(nullable_schema_definition))
+
+      -- mock strategy
+      local strategy = {
+        select = function()
+          return { a = 42, b = nil, r = { f1 = 10 } }
+        end,
+      }
+
+      local dao = DAO.new(mock_db, schema, strategy, errors)
+
+      local row = dao:select({ a = 42 })
+      assert.same(42, row.a)
+      assert.same("hello", row.b)
+      assert.same(10, row.r.f1)
+      assert.same("world", row.r.f2)
+    end)
+
+    it("applies defaults if strategy returns column as nil and is not nullable in schema", function()
+      local schema = assert(Schema.new(non_nullable_schema_definition))
+
+      -- mock strategy
+      local strategy = {
+        select = function()
+          return { a = 42, b = nil, r = { f1 = 10 } }
+        end,
+      }
+
+      local dao = DAO.new(mock_db, schema, strategy, errors)
+
+      local row = dao:select({ a = 42 })
+      assert.same(42, row.a)
+      assert.same("hello", row.b)
+      assert.same(10, row.r.f1)
+      assert.same("world", row.r.f2)
+    end)
+
+    it("applies defaults if strategy returns column as null and is not nullable in schema", function()
+      local schema = assert(Schema.new(non_nullable_schema_definition))
+
+      -- mock strategy
+      local strategy = {
+        select = function()
+          return { a = 42, b = null, r = { f1 = 10, f2 = null } }
+        end,
+      }
+
+      local dao = DAO.new(mock_db, schema, strategy, errors)
+
+      local row = dao:select({ a = 42 })
+      assert.same(42, row.a)
+      assert.same("hello", row.b)
+      assert.same(10, row.r.f1)
+      assert.same("world", row.r.f2)
+    end)
+
+    it("preserves null if strategy returns column as null and is nullable in schema", function()
+      local schema = assert(Schema.new(nullable_schema_definition))
+
+      -- mock strategy
+      local strategy = {
+        select = function()
+          return { a = 42, b = null, r = { f1 = 10, f2 = null } }
+        end,
+      }
+
+      local dao = DAO.new(mock_db, schema, strategy, errors)
+
+      local row = dao:select({ a = 42 }, { nulls = true })
+      assert.same(42, row.a)
+      assert.same(null, row.b)
+      assert.same(10, row.r.f1)
+      assert.same(null, row.r.f2)
+    end)
+  end)
+
+  describe("update", function()
+
+    it("does not pre-apply defaults on partial update if field is nullable in schema", function()
+      local schema = assert(Schema.new(nullable_schema_definition))
+
+      -- mock strategy
+      local data
+      local strategy = {
+        update = function(_, _, value)
+          -- no defaults pre-applied before partial update
+          assert(value.b == nil)
+          assert(value.r == nil or value.r.f2 == nil)
+          data = utils.deep_merge(data, value)
+          return data
+        end,
+      }
+
+      local dao = DAO.new(mock_db, schema, strategy, errors)
+
+      data = { a = 42, b = nil, u = nil, r = nil }
+      local row, err = dao:update({ a = 43 }, { u = "foo", r = { f1 = 10 } })
+      assert.falsy(err)
+      assert.same({ a = 42, b = "hello", u = "foo", r = { f1 = 10, f2 = "world" } }, row)
+    end)
+
+    it("always returns the structure of records when using Entities", function()
+      local entity = assert(Entity.new(non_nullable_schema_definition))
+
+      -- mock strategy
+      local data
+      local strategy = {
+        update = function(_, _, value)
+          -- no defaults pre-applied before partial update
+          assert(value.b == nil)
+          assert(value.r == nil or value.r.f2 == nil)
+          data = utils.deep_merge(data, value)
+          return data
+        end,
+      }
+
+      local dao = DAO.new(mock_db, entity, strategy, errors)
+
+      data = { a = 42, b = nil, u = nil, r = nil }
+      local row, err = dao:update({ a = 42 }, { u = "foo" }, { nulls = true })
+      assert.falsy(err)
+      assert.same({ a = 42, b = "hello", u = "foo", r = { f1 = ngx.null, f2 = "world" } }, row)
+    end)
+
+    it("does not apply defaults on entity if record is nullable in schema", function()
+      local schema = assert(Schema.new(non_nullable_schema_definition))
+
+      -- mock strategy
+      local data
+      local strategy = {
+        update = function(_, _, value)
+          -- no defaults pre-applied before partial update
+          assert(value.b == nil)
+          assert(value.r == nil or value.r.f2 == nil)
+          data = utils.deep_merge(data, value)
+          return data
+        end,
+      }
+
+      local dao = DAO.new(mock_db, schema, strategy, errors)
+
+      data = { a = 42, b = nil, u = nil, r = nil }
+      local row, err = dao:update({ a = 42 }, { u = "foo" }, { nulls = true })
+      assert.falsy(err)
+      -- defaults are applied when returning the full updated entity
+      assert.same({ a = 42, b = "hello", u = "foo", r = null }, row)
+    end)
+
+    it("applies defaults on entity for record in Entity", function()
+      local schema = assert(Entity.new(non_nullable_schema_definition))
+
+      -- mock strategy
+      local data
+      local strategy = {
+        update = function(_, _, value)
+          -- no defaults pre-applied before partial update
+          assert(value.b == nil)
+          assert(value.r == nil or value.r.f2 == nil)
+          data = utils.deep_merge(data, value)
+          return data
+        end,
+      }
+
+      local dao = DAO.new(mock_db, schema, strategy, errors)
+
+      data = { a = 42, b = nil, u = nil, r = nil }
+      local row, err = dao:update({ a = 42 }, { u = "foo" }, { nulls = true })
+      assert.falsy(err)
+      -- defaults are applied when returning the full updated entity
+      assert.same({ a = 42, b = "hello", u = "foo", r = { f1 = null, f2 = "world" } }, row)
+
+      -- likewise for record update:
+
+      data = { a = 42, b = nil, u = nil, r = nil }
+      row, err = dao:update({ a = 43 }, { u = "foo", r = { f1 = 10 } })
+      assert.falsy(err)
+      assert.same({ a = 42, b = "hello", u = "foo", r = { f1 = 10, f2 = "world" } }, row)
+    end)
+
+    it("applies defaults if strategy returns column as null and is not nullable in schema", function()
+      local schema = assert(Schema.new(non_nullable_schema_definition))
+
+      -- mock strategy
+      local strategy = {
+        update = function()
+          return { a = 42, b = null, r = { f1 = 10, f2 = null } }
+        end,
+      }
+
+      local dao = DAO.new(mock_db, schema, strategy, errors)
+
+      local row = dao:update({ a = 42 }, { u = "foo" })
+      assert.same(42, row.a)
+      assert.same("hello", row.b)
+      assert.same(10, row.r.f1)
+      assert.same("world", row.r.f2)
+    end)
+
+    it("preserves null if strategy returns column as null and is nullable in schema", function()
+      local schema = assert(Schema.new(nullable_schema_definition))
+
+      -- mock strategy
+      local data
+      local strategy = {
+        update = function(_, _, value)
+          data = utils.deep_merge(data, value)
+          return data
+        end,
+      }
+
+      local dao = DAO.new(mock_db, schema, strategy, errors)
+
+      data = { a = 42, b = null, u = null, r = null }
+      local row, err = dao:update({ a = 42 }, { u = "foo" }, { nulls = true })
+      assert.falsy(err)
+      assert.same({ a = 42, b = null, u = "foo", r = null }, row)
+    end)
+
+    it("sets default in r.f2 when setting r.f1 and r is currently nil", function()
+      local schema = assert(Schema.new(nullable_schema_definition))
+
+      -- mock strategy
+      local data
+      local strategy = {
+        update = function(_, _, value)
+          data = utils.deep_merge(data, value)
+          return data
+        end,
+      }
+
+      local dao = DAO.new(mock_db, schema, strategy, errors)
+
+      data = { a = 42, b = null, u = null, r = nil }
+      local row, err = dao:update({ a = 43 }, { u = "foo", r = { f1 = 10 } }, { nulls = true })
+      assert.falsy(err)
+      assert.same({ a = 42, b = null, u = "foo", r = { f1 = 10, f2 = "world" } }, row)
+    end)
+
+    it("sets default in r.f2 when setting r.f1 and r is currently nil", function()
+      local schema = assert(Schema.new(non_nullable_schema_definition))
+
+      -- mock strategy
+      local data
+      local strategy = {
+        update = function(_, _, value)
+          data = utils.deep_merge(data, value)
+          return data
+        end,
+      }
+
+      local dao = DAO.new(mock_db, schema, strategy, errors)
+
+      data = { a = 42, b = null, u = null, r = nil }
+      local row, err = dao:update({ a = 43 }, { u = "foo", r = { f1 = 10 } }, { nulls = true })
+      assert.falsy(err)
+      assert.same({ a = 42, b = "hello", u = "foo", r = { f1 = 10, f2 = "world" } }, row)
+    end)
+
+    it("sets default in r.f2 when setting r.f1 and r is currently null", function()
+      local schema = assert(Schema.new(nullable_schema_definition))
+
+      -- mock strategy
+      local data
+      local strategy = {
+        update = function(_, _, value)
+          data = utils.deep_merge(data, value)
+          return data
+        end,
+      }
+
+      local dao = DAO.new(mock_db, schema, strategy, errors)
+
+      data = { a = 42, b = null, u = null, r = null }
+      local row, err = dao:update({ a = 43 }, { u = "foo", r = { f1 = 10 } }, { nulls = true })
+      assert.falsy(err)
+      assert.same({ a = 42, b = null, u = "foo", r = { f1 = 10, f2 = "world" } }, row)
+    end)
+
+    it("preserves null in r.f2 when setting r.f1", function()
+      local schema = assert(Schema.new(nullable_schema_definition))
+
+      -- mock strategy
+      local data
+      local strategy = {
+        update = function(_, _, value)
+          data = utils.deep_merge(data, value)
+          return data
+        end,
+      }
+
+      local dao = DAO.new(mock_db, schema, strategy, errors)
+
+      -- setting r.f2 as an explicit null
+      data = { a = 42, b = null, u = null, r = { f1 = 9, f2 = null } }
+      local row, err = dao:update({ a = 43 }, { u = "foo", r = { f1 = 10, f2 = null } }, { nulls = true })
+      assert.falsy(err)
+      assert.same({ a = 42, b = null, u = "foo", r = { f1 = 10, f2 = null } }, row)
+    end)
+  end)
+
+end)


### PR DESCRIPTION
This PR proposes new semantics for handling missing or unset values arriving from the strategies. With this PR, the DAO will apply the default values if a strategy returns a column as `ngx.null` and is marked as `nullable = false` in a schema. We also make records in entities non-nullable by default, so that we always recurse their structure, filling defaults for their fields.

This will allow us to produce default values in newly-added columns without requiring a migration filling the table with default values.