### PR TITLE
fix(cors) set missing vary=origin

### DIFF
--- a/kong/plugins/cors/handler.lua
+++ b/kong/plugins/cors/handler.lua
@@ -79,6 +79,7 @@ local function configure_credentials(ngx, conf)
     if req_origin then
       ngx.header["Access-Control-Allow-Origin"]      = req_origin
       ngx.header["Access-Control-Allow-Credentials"] = "true"
+      ngx.header["Vary"] = "Origin"
     end
   end
 end

--- a/spec/03-plugins/14-cors/01-access_spec.lua
+++ b/spec/03-plugins/14-cors/01-access_spec.lua
@@ -160,6 +160,7 @@ for _, strategy in helpers.each_strategy() do
         assert.is_nil(res.headers["Access-Control-Expose-Headers"])
         assert.is_nil(res.headers["Access-Control-Allow-Credentials"])
         assert.is_nil(res.headers["Access-Control-Max-Age"])
+        assert.is_nil(res.headers["Vary"])
       end)
 
       it("gives * wildcard when origins is empty", function()
@@ -182,6 +183,7 @@ for _, strategy in helpers.each_strategy() do
         assert.is_nil(res.headers["Access-Control-Expose-Headers"])
         assert.is_nil(res.headers["Access-Control-Allow-Credentials"])
         assert.is_nil(res.headers["Access-Control-Max-Age"])
+        assert.is_nil(res.headers["Vary"])
       end)
 
       it("gives appropriate defaults when origin is explicitly set to *", function()
@@ -198,6 +200,7 @@ for _, strategy in helpers.each_strategy() do
         assert.is_nil(res.headers["Access-Control-Expose-Headers"])
         assert.is_nil(res.headers["Access-Control-Allow-Credentials"])
         assert.is_nil(res.headers["Access-Control-Max-Age"])
+        assert.is_nil(res.headers["Vary"])
       end)
 
       it("accepts config options", function()
@@ -259,6 +262,7 @@ for _, strategy in helpers.each_strategy() do
         assert.is_nil(res.headers["Access-Control-Expose-Headers"])
         assert.is_nil(res.headers["Access-Control-Allow-Credentials"])
         assert.is_nil(res.headers["Access-Control-Max-Age"])
+        assert.is_nil(res.headers["Vary"])
       end)
 
       it("accepts config options", function()
@@ -293,6 +297,7 @@ for _, strategy in helpers.each_strategy() do
         assert.is_nil(res.headers["Access-Control-Expose-Headers"])
         assert.is_nil(res.headers["Access-Control-Allow-Credentials"])
         assert.is_nil(res.headers["Access-Control-Max-Age"])
+        assert.is_nil(res.headers["Vary"])
       end)
 
       it("works with 40x responses returned by another plugin", function()
@@ -309,6 +314,7 @@ for _, strategy in helpers.each_strategy() do
         assert.is_nil(res.headers["Access-Control-Expose-Headers"])
         assert.is_nil(res.headers["Access-Control-Allow-Credentials"])
         assert.is_nil(res.headers["Access-Control-Max-Age"])
+        assert.is_nil(res.headers["Vary"])
       end)
 
       it("sets CORS orgin based on origin host", function()
@@ -397,6 +403,7 @@ for _, strategy in helpers.each_strategy() do
         assert.res_status(200, res)
         assert.equals("*", res.headers["Access-Control-Allow-Origin"])
         assert.is_nil(res.headers["Access-Control-Allow-Credentials"])
+        assert.is_nil(res.headers["Vary"])
       end)
     end)
   end)

--- a/spec/03-plugins/14-cors/01-access_spec.lua
+++ b/spec/03-plugins/14-cors/01-access_spec.lua
@@ -321,6 +321,7 @@ for _, strategy in helpers.each_strategy() do
         })
         assert.res_status(200, res)
         assert.equal("http://www.example.com", res.headers["Access-Control-Allow-Origin"])
+        assert.equal("Origin", res.headers["Vary"])
 
         local domains = {
           ["example.com"]         = true,
@@ -341,6 +342,7 @@ for _, strategy in helpers.each_strategy() do
           assert.res_status(200, res)
           assert.equal(domains[domain] and domain or nil,
                        res.headers["Access-Control-Allow-Origin"])
+          assert.equal("Origin", res.headers["Vary"])
         end
       end)
 

--- a/spec/03-plugins/14-cors/01-access_spec.lua
+++ b/spec/03-plugins/14-cors/01-access_spec.lua
@@ -213,6 +213,7 @@ for _, strategy in helpers.each_strategy() do
         assert.equal("23", res.headers["Access-Control-Max-Age"])
         assert.equal("true", res.headers["Access-Control-Allow-Credentials"])
         assert.equal("origin,type,accepts", res.headers["Access-Control-Allow-Headers"])
+        assert.equal("Origin", res.headers["Vary"])
         assert.is_nil(res.headers["Access-Control-Expose-Headers"])
       end)
 
@@ -271,6 +272,7 @@ for _, strategy in helpers.each_strategy() do
         assert.equal("example.com", res.headers["Access-Control-Allow-Origin"])
         assert.equal("x-auth-token", res.headers["Access-Control-Expose-Headers"])
         assert.equal("true", res.headers["Access-Control-Allow-Credentials"])
+        assert.equal("Origin", res.headers["Vary"])
         assert.is_nil(res.headers["Access-Control-Allow-Methods"])
         assert.is_nil(res.headers["Access-Control-Allow-Headers"])
         assert.is_nil(res.headers["Access-Control-Max-Age"])
@@ -365,6 +367,7 @@ for _, strategy in helpers.each_strategy() do
         assert.res_status(200, res)
         assert.equals("http://www.example.net", res.headers["Access-Control-Allow-Origin"])
         assert.equals("true", res.headers["Access-Control-Allow-Credentials"])
+        assert.equal("Origin", res.headers["Vary"])
       end)
 
       it("responds with the requested Origin (including port) when config.credentials=true", function()
@@ -378,6 +381,7 @@ for _, strategy in helpers.each_strategy() do
         assert.res_status(200, res)
         assert.equals("http://www.example.net:3000", res.headers["Access-Control-Allow-Origin"])
         assert.equals("true", res.headers["Access-Control-Allow-Credentials"])
+        assert.equal("Origin", res.headers["Vary"])
       end)
 
       it("responds with * when config.credentials=false", function()


### PR DESCRIPTION
When Access-Control-Allow-Origin is not *, the cors plugins normally
sets Vary=Origin.  In the case where the plugin sets
Access-Control-Allow-Credentials the Vary=Origin is missing.

When that happens, the browser is told to uses its cache even when the
origin is different and then CORS fails by rejecting the non-matching
origin.
