### PR TITLE
refactor(tests) introduce extra setting for PDK testing

### DIFF
--- a/t/01-pdk/04-request/00-phase_checks.t
+++ b/t/01-pdk/04-request/00-phase_checks.t
@@ -3,8 +3,7 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 2);
 

--- a/t/01-pdk/04-request/00-phase_checks.t
+++ b/t/01-pdk/04-request/00-phase_checks.t
@@ -4,6 +4,7 @@ use Test::Nginx::Socket::Lua;
 use t::Util;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 2);
 
@@ -17,7 +18,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             return 200;
@@ -232,7 +233,7 @@ qq{
 }
 --- config
     location /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
         set $upstream_uri '/t';
         set $upstream_scheme 'http';
 

--- a/t/01-pdk/04-request/01-get_scheme.t
+++ b/t/01-pdk/04-request/01-get_scheme.t
@@ -4,7 +4,6 @@ use Test::Nginx::Socket::Lua;
 use File::Spec;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
 $ENV{TEST_NGINX_CERT_DIR} ||= File::Spec->catdir(server_root(), '..', 'certs');
 $ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 

--- a/t/01-pdk/04-request/01-get_scheme.t
+++ b/t/01-pdk/04-request/01-get_scheme.t
@@ -6,6 +6,7 @@ use t::Util;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
 $ENV{TEST_NGINX_CERT_DIR} ||= File::Spec->catdir(server_root(), '..', 'certs');
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 
@@ -39,7 +40,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock ssl;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock ssl;
         ssl_certificate $ENV{TEST_NGINX_CERT_DIR}/test.crt;
         ssl_certificate_key $ENV{TEST_NGINX_CERT_DIR}/test.key;
 
@@ -59,7 +60,7 @@ qq{
 --- config
     location = /t {
         proxy_ssl_verify off;
-        proxy_pass https://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass https://unix:$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t

--- a/t/01-pdk/04-request/02-get_host.t
+++ b/t/01-pdk/04-request/02-get_host.t
@@ -6,6 +6,7 @@ use t::Util;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
 $ENV{TEST_NGINX_CERT_DIR} ||= File::Spec->catdir(server_root(), '..', 'certs');
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 
@@ -39,7 +40,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock ssl;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock ssl;
         ssl_certificate $ENV{TEST_NGINX_CERT_DIR}/test.crt;
         ssl_certificate_key $ENV{TEST_NGINX_CERT_DIR}/test.key;
 
@@ -59,7 +60,7 @@ qq{
 --- config
     location = /t {
         proxy_ssl_verify off;
-        proxy_pass https://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass https://unix:$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -77,7 +78,7 @@ qq{
 
     server {
         server_name kong;
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             content_by_lua_block {
@@ -95,7 +96,7 @@ qq{
 --- config
     location /t {
         proxy_set_header Host "";
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -221,7 +222,7 @@ qq{
 
     server {
         server_name K0nG;
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             content_by_lua_block {
@@ -239,7 +240,7 @@ qq{
 --- config
     location /t {
         proxy_set_header Host "";
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t

--- a/t/01-pdk/04-request/02-get_host.t
+++ b/t/01-pdk/04-request/02-get_host.t
@@ -4,7 +4,6 @@ use Test::Nginx::Socket::Lua;
 use File::Spec;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
 $ENV{TEST_NGINX_CERT_DIR} ||= File::Spec->catdir(server_root(), '..', 'certs');
 $ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 

--- a/t/01-pdk/04-request/04-get_forwarded_scheme.t
+++ b/t/01-pdk/04-request/04-get_forwarded_scheme.t
@@ -4,7 +4,6 @@ use Test::Nginx::Socket::Lua;
 use File::Spec;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
 $ENV{TEST_NGINX_CERT_DIR} ||= File::Spec->catdir(server_root(), '..', 'certs');
 $ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 

--- a/t/01-pdk/04-request/04-get_forwarded_scheme.t
+++ b/t/01-pdk/04-request/04-get_forwarded_scheme.t
@@ -6,6 +6,7 @@ use t::Util;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
 $ENV{TEST_NGINX_CERT_DIR} ||= File::Spec->catdir(server_root(), '..', 'certs');
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 
@@ -133,7 +134,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock ssl;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock ssl;
         ssl_certificate $ENV{TEST_NGINX_CERT_DIR}/test.crt;
         ssl_certificate_key $ENV{TEST_NGINX_CERT_DIR}/test.key;
 
@@ -155,7 +156,7 @@ qq{
 --- config
     location = /t {
         proxy_ssl_verify off;
-        proxy_pass https://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass https://unix:$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t

--- a/t/01-pdk/04-request/05-get_forwarded_host.t
+++ b/t/01-pdk/04-request/05-get_forwarded_host.t
@@ -4,7 +4,6 @@ use Test::Nginx::Socket::Lua;
 use File::Spec;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
 $ENV{TEST_NGINX_CERT_DIR} ||= File::Spec->catdir(server_root(), '..', 'certs');
 $ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 

--- a/t/01-pdk/04-request/05-get_forwarded_host.t
+++ b/t/01-pdk/04-request/05-get_forwarded_host.t
@@ -6,6 +6,7 @@ use t::Util;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
 $ENV{TEST_NGINX_CERT_DIR} ||= File::Spec->catdir(server_root(), '..', 'certs');
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 
@@ -41,7 +42,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock ssl;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock ssl;
         ssl_certificate $ENV{TEST_NGINX_CERT_DIR}/test.crt;
         ssl_certificate_key $ENV{TEST_NGINX_CERT_DIR}/test.key;
 
@@ -61,7 +62,7 @@ qq{
 --- config
     location = /t {
         proxy_ssl_verify off;
-        proxy_pass https://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass https://unix:$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -81,7 +82,7 @@ qq{
 
     server {
         server_name kong;
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             content_by_lua_block {
@@ -99,7 +100,7 @@ qq{
 --- config
     location /t {
         proxy_set_header Host "";
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -233,7 +234,7 @@ qq{
 
     server {
         server_name k0ng;
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             content_by_lua_block {
@@ -251,7 +252,7 @@ qq{
 --- config
     location /t {
         proxy_set_header Host "";
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -294,7 +295,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock ssl;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock ssl;
         ssl_certificate $ENV{TEST_NGINX_CERT_DIR}/test.crt;
         ssl_certificate_key $ENV{TEST_NGINX_CERT_DIR}/test.key;
 
@@ -316,7 +317,7 @@ qq{
 --- config
     location = /t {
         proxy_ssl_verify off;
-        proxy_pass https://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass https://unix:$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t

--- a/t/01-pdk/04-request/06-get_forwarded_port.t
+++ b/t/01-pdk/04-request/06-get_forwarded_port.t
@@ -3,7 +3,6 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
 $ENV{TEST_NGINX_CERT_DIR} ||= File::Spec->catdir(server_root(), '..', 'certs');
 $ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 

--- a/t/01-pdk/04-request/06-get_forwarded_port.t
+++ b/t/01-pdk/04-request/06-get_forwarded_port.t
@@ -5,6 +5,7 @@ use t::Util;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
 $ENV{TEST_NGINX_CERT_DIR} ||= File::Spec->catdir(server_root(), '..', 'certs');
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 
@@ -134,7 +135,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock ssl;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock ssl;
         ssl_certificate $ENV{TEST_NGINX_CERT_DIR}/test.crt;
         ssl_certificate_key $ENV{TEST_NGINX_CERT_DIR}/test.key;
 
@@ -154,7 +155,7 @@ qq{
 --- config
     location = /t {
         proxy_ssl_verify off;
-        proxy_pass https://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass https://unix:$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t

--- a/t/01-pdk/05-client/00-phase_checks.t
+++ b/t/01-pdk/05-client/00-phase_checks.t
@@ -3,8 +3,7 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 2);
 

--- a/t/01-pdk/05-client/00-phase_checks.t
+++ b/t/01-pdk/05-client/00-phase_checks.t
@@ -4,6 +4,7 @@ use Test::Nginx::Socket::Lua;
 use t::Util;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 2);
 
@@ -17,7 +18,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             return 200;
@@ -82,7 +83,7 @@ qq{
 }
 --- config
     location /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
         set $upstream_uri '/t';
         set $upstream_scheme 'http';
 

--- a/t/01-pdk/05-client/01-get_ip.t
+++ b/t/01-pdk/05-client/01-get_ip.t
@@ -3,8 +3,7 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/05-client/01-get_ip.t
+++ b/t/01-pdk/05-client/01-get_ip.t
@@ -4,6 +4,7 @@ use Test::Nginx::Socket::Lua;
 use t::Util;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 
@@ -46,7 +47,7 @@ qq{
 
     server {
         server_name kong;
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock proxy_protocol;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock proxy_protocol;
 
         location / {
             real_ip_header proxy_protocol;
@@ -69,7 +70,7 @@ qq{
     location = /t {
         content_by_lua_block {
             local sock = ngx.socket.tcp()
-            sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+            sock:connect("unix:$TEST_NGINX_NXSOCK/nginx.sock")
 
             local request = "PROXY TCP4 10.0.0.1 " ..
                             ngx.var.server_addr    .. " " ..

--- a/t/01-pdk/05-client/02-get_forwarded_ip.t
+++ b/t/01-pdk/05-client/02-get_forwarded_ip.t
@@ -3,8 +3,7 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/05-client/02-get_forwarded_ip.t
+++ b/t/01-pdk/05-client/02-get_forwarded_ip.t
@@ -4,6 +4,7 @@ use Test::Nginx::Socket::Lua;
 use t::Util;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 
@@ -102,7 +103,7 @@ qq{
 
     server {
         server_name kong;
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock proxy_protocol;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock proxy_protocol;
 
         location / {
             real_ip_header proxy_protocol;
@@ -124,7 +125,7 @@ qq{
     location = /t {
         content_by_lua_block {
             local sock = ngx.socket.tcp()
-            sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+            sock:connect("unix:$TEST_NGINX_NXSOCK/nginx.sock")
 
             local request = "PROXY TCP4 10.0.0.1 " ..
                             ngx.var.server_addr    .. " " ..
@@ -224,7 +225,7 @@ qq{
 
     server {
         server_name kong;
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock proxy_protocol;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock proxy_protocol;
 
         location / {
             real_ip_header proxy_protocol;
@@ -242,7 +243,7 @@ qq{
     location = /t {
         content_by_lua_block {
             local sock = ngx.socket.tcp()
-            sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+            sock:connect("unix:$TEST_NGINX_NXSOCK/nginx.sock")
 
             local request = "PROXY TCP4 10.0.0.1 " ..
                             ngx.var.server_addr    .. " " ..

--- a/t/01-pdk/05-client/03-get_port.t
+++ b/t/01-pdk/05-client/03-get_port.t
@@ -3,8 +3,7 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/05-client/03-get_port.t
+++ b/t/01-pdk/05-client/03-get_port.t
@@ -4,6 +4,7 @@ use Test::Nginx::Socket::Lua;
 use t::Util;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 
@@ -58,7 +59,7 @@ qq{
 
     server {
         server_name kong;
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock proxy_protocol;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock proxy_protocol;
 
         location / {
             real_ip_header proxy_protocol;
@@ -80,7 +81,7 @@ qq{
     location = /t {
         content_by_lua_block {
             local sock = ngx.socket.tcp()
-            sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+            sock:connect("unix:$TEST_NGINX_NXSOCK/nginx.sock")
 
             local request = "PROXY TCP4 10.0.0.1 " ..
                             ngx.var.server_addr    .. " " ..

--- a/t/01-pdk/05-client/04-get_forwarded_port.t
+++ b/t/01-pdk/05-client/04-get_forwarded_port.t
@@ -3,8 +3,7 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/05-client/04-get_forwarded_port.t
+++ b/t/01-pdk/05-client/04-get_forwarded_port.t
@@ -4,6 +4,7 @@ use Test::Nginx::Socket::Lua;
 use t::Util;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 
@@ -172,7 +173,7 @@ qq{
 
     server {
         server_name kong;
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock proxy_protocol;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock proxy_protocol;
 
         location / {
             real_ip_header proxy_protocol;
@@ -194,7 +195,7 @@ qq{
     location = /t {
         content_by_lua_block {
             local sock = ngx.socket.tcp()
-            sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+            sock:connect("unix:$TEST_NGINX_NXSOCK/nginx.sock")
 
             local request = "PROXY TCP4 10.0.0.1 " ..
                             ngx.var.server_addr    .. " " ..
@@ -322,7 +323,7 @@ qq{
 
     server {
         server_name kong;
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock proxy_protocol;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock proxy_protocol;
 
         location / {
             real_ip_header proxy_protocol;
@@ -340,7 +341,7 @@ qq{
     location = /t {
         content_by_lua_block {
             local sock = ngx.socket.tcp()
-            sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock")
+            sock:connect("unix:$TEST_NGINX_NXSOCK/nginx.sock")
 
             local request = "PROXY TCP4 10.0.0.1 " ..
                             ngx.var.server_addr    .. " " ..

--- a/t/01-pdk/06-service-request/00-phase_checks.t
+++ b/t/01-pdk/06-service-request/00-phase_checks.t
@@ -3,8 +3,7 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 2);
 

--- a/t/01-pdk/06-service-request/00-phase_checks.t
+++ b/t/01-pdk/06-service-request/00-phase_checks.t
@@ -4,6 +4,7 @@ use Test::Nginx::Socket::Lua;
 use t::Util;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 2);
 
@@ -17,7 +18,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             return 200;
@@ -152,7 +153,7 @@ qq{
 }
 --- config
     location /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
         set $upstream_uri '/t';
         set $upstream_scheme 'http';
 

--- a/t/01-pdk/06-service-request/01-set_scheme.t
+++ b/t/01-pdk/06-service-request/01-set_scheme.t
@@ -6,6 +6,7 @@ use t::Util;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
 $ENV{TEST_NGINX_CERT_DIR} ||= File::Spec->catdir(server_root(), '..', 'certs');
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 
@@ -65,7 +66,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock ssl;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock ssl;
         ssl_certificate $ENV{TEST_NGINX_CERT_DIR}/test.crt;
         ssl_certificate_key $ENV{TEST_NGINX_CERT_DIR}/test.key;
 
@@ -88,7 +89,7 @@ qq{
             local ok, err = pdk.service.request.set_scheme("https")
         }
 
-        proxy_pass $upstream_scheme://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass $upstream_scheme://unix:$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -105,7 +106,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -126,7 +127,7 @@ qq{
             local ok, err = pdk.service.request.set_scheme("http")
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t

--- a/t/01-pdk/06-service-request/01-set_scheme.t
+++ b/t/01-pdk/06-service-request/01-set_scheme.t
@@ -4,7 +4,6 @@ use Test::Nginx::Socket::Lua;
 use File::Spec;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
 $ENV{TEST_NGINX_CERT_DIR} ||= File::Spec->catdir(server_root(), '..', 'certs');
 $ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 

--- a/t/01-pdk/06-service-request/04-set_path.t
+++ b/t/01-pdk/06-service-request/04-set_path.t
@@ -3,8 +3,7 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/06-service-request/04-set_path.t
+++ b/t/01-pdk/06-service-request/04-set_path.t
@@ -4,6 +4,7 @@ use Test::Nginx::Socket::Lua;
 use t::Util;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 
@@ -63,7 +64,7 @@ qq{
 
     server {
         server_name K0nG;
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /foo {
             content_by_lua_block {
@@ -83,7 +84,7 @@ qq{
             pdk.service.request.set_path("/foo")
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock:$upstream_uri;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock:$upstream_uri;
     }
 --- request
 GET /t
@@ -101,7 +102,7 @@ qq{
 
     server {
         server_name K0nG;
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /foo {
             content_by_lua_block {
@@ -121,7 +122,7 @@ qq{
             pdk.service.request.set_path("/foo")
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock:$upstream_uri;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock:$upstream_uri;
     }
 --- request
 GET /t

--- a/t/01-pdk/06-service-request/05-set_raw_query.t
+++ b/t/01-pdk/06-service-request/05-set_raw_query.t
@@ -3,8 +3,7 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/06-service-request/05-set_raw_query.t
+++ b/t/01-pdk/06-service-request/05-set_raw_query.t
@@ -4,6 +4,7 @@ use Test::Nginx::Socket::Lua;
 use t::Util;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 
@@ -60,7 +61,7 @@ qq{
 
     server {
         server_name K0nG;
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -82,7 +83,7 @@ qq{
         }
 
         proxy_set_header Host $upstream_host;
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -100,7 +101,7 @@ qq{
 
     server {
         server_name K0nG;
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -122,7 +123,7 @@ qq{
         }
 
         proxy_set_header Host $upstream_host;
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -140,7 +141,7 @@ qq{
 
     server {
         server_name K0nG;
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -162,7 +163,7 @@ qq{
         }
 
         proxy_set_header Host $upstream_host;
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t?bla&baz=hello%20mars&something_else=is_set

--- a/t/01-pdk/06-service-request/06-set_method.t
+++ b/t/01-pdk/06-service-request/06-set_method.t
@@ -3,8 +3,7 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/06-service-request/06-set_method.t
+++ b/t/01-pdk/06-service-request/06-set_method.t
@@ -4,6 +4,7 @@ use Test::Nginx::Socket::Lua;
 use t::Util;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 
@@ -101,7 +102,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -120,7 +121,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -137,7 +138,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -156,7 +157,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -172,7 +173,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -191,7 +192,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -208,7 +209,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -227,7 +228,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -244,7 +245,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -263,7 +264,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -280,7 +281,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -299,7 +300,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -316,7 +317,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -334,7 +335,7 @@ qq{
             pdk.service.request.set_method("MKCOL")
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -351,7 +352,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -369,7 +370,7 @@ qq{
             pdk.service.request.set_method("COPY")
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -386,7 +387,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -404,7 +405,7 @@ qq{
             pdk.service.request.set_method("MOVE")
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -421,7 +422,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -439,7 +440,7 @@ qq{
             pdk.service.request.set_method("PROPFIND")
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -456,7 +457,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -474,7 +475,7 @@ qq{
             pdk.service.request.set_method("PROPPATCH")
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -491,7 +492,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -509,7 +510,7 @@ qq{
             pdk.service.request.set_method("LOCK")
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -526,7 +527,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -544,7 +545,7 @@ qq{
             pdk.service.request.set_method("UNLOCK")
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -561,7 +562,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -579,7 +580,7 @@ qq{
             pdk.service.request.set_method("PATCH")
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -596,7 +597,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -614,7 +615,7 @@ qq{
             pdk.service.request.set_method("TRACE")
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t

--- a/t/01-pdk/06-service-request/07-set_body.t
+++ b/t/01-pdk/06-service-request/07-set_body.t
@@ -3,8 +3,7 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/06-service-request/07-set_body.t
+++ b/t/01-pdk/06-service-request/07-set_body.t
@@ -4,6 +4,7 @@ use Test::Nginx::Socket::Lua;
 use t::Util;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 
@@ -138,7 +139,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -158,7 +159,7 @@ qq{
             pdk.service.request.set_body({}, "application/x-www-form-urlencoded")
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 POST /t
@@ -175,7 +176,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -199,7 +200,7 @@ qq{
             assert(pdk.service.request.set_body({}))
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 POST /t
@@ -220,7 +221,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -245,7 +246,7 @@ qq{
             }, "application/x-www-form-urlencoded"))
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 POST /t
@@ -266,7 +267,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -291,7 +292,7 @@ qq{
             }, "application/x-www-form-urlencoded"))
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 POST /t
@@ -310,7 +311,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -338,7 +339,7 @@ qq{
             }, "application/x-www-form-urlencoded"))
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 POST /t
@@ -357,7 +358,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -385,7 +386,7 @@ qq{
             }, "application/x-www-form-urlencoded"))
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 POST /t
@@ -404,7 +405,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -429,7 +430,7 @@ qq{
             }, "application/x-www-form-urlencoded"))
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 POST /t
@@ -448,7 +449,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -473,7 +474,7 @@ qq{
             }, "application/x-www-form-urlencoded"))
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 POST /t
@@ -492,7 +493,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -517,7 +518,7 @@ qq{
             }, "application/x-www-form-urlencoded"))
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 POST /t
@@ -536,7 +537,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -562,7 +563,7 @@ qq{
             }, "application/x-www-form-urlencoded"))
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -640,7 +641,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -660,7 +661,7 @@ qq{
             assert(pdk.service.request.set_body({}, "application/json"))
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 POST /t
@@ -677,7 +678,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -701,7 +702,7 @@ qq{
             assert(pdk.service.request.set_body({}))
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 POST /t
@@ -722,7 +723,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -747,7 +748,7 @@ qq{
             }, "application/json"))
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 POST /t
@@ -768,7 +769,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -796,7 +797,7 @@ qq{
             }, "application/json"))
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 POST /t
@@ -815,7 +816,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -843,7 +844,7 @@ qq{
             }, "application/json"))
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 POST /t
@@ -862,7 +863,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -887,7 +888,7 @@ qq{
             }, "application/json"))
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 POST /t
@@ -906,7 +907,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -931,7 +932,7 @@ qq{
             }, "application/json"))
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 POST /t
@@ -977,7 +978,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -1011,7 +1012,7 @@ qq{
             }, "multipart/form-data"))
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 POST /t
@@ -1030,7 +1031,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -1065,7 +1066,7 @@ qq{
             }))
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 POST /t

--- a/t/01-pdk/06-service-request/08-set_query.t
+++ b/t/01-pdk/06-service-request/08-set_query.t
@@ -3,8 +3,7 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/06-service-request/08-set_query.t
+++ b/t/01-pdk/06-service-request/08-set_query.t
@@ -4,6 +4,7 @@ use Test::Nginx::Socket::Lua;
 use t::Util;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 
@@ -115,7 +116,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -135,7 +136,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -152,7 +153,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -174,7 +175,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t?foo=bar
@@ -191,7 +192,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -213,7 +214,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 POST /t
@@ -230,7 +231,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -255,7 +256,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 POST /t
@@ -272,7 +273,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -297,7 +298,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 POST /t
@@ -314,7 +315,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -336,7 +337,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 POST /t
@@ -353,7 +354,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -375,7 +376,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 POST /t
@@ -392,7 +393,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -414,7 +415,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 POST /t

--- a/t/01-pdk/06-service-request/09-set_header.t
+++ b/t/01-pdk/06-service-request/09-set_header.t
@@ -3,8 +3,7 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/06-service-request/09-set_header.t
+++ b/t/01-pdk/06-service-request/09-set_header.t
@@ -4,6 +4,7 @@ use Test::Nginx::Socket::Lua;
 use t::Util;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 
@@ -101,7 +102,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -128,7 +129,7 @@ qq{
         }
 
         proxy_set_header Host $upstream_host;
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -145,7 +146,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -165,7 +166,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -182,7 +183,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -202,7 +203,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -219,7 +220,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -239,7 +240,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -256,7 +257,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -276,7 +277,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -296,7 +297,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -316,7 +317,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -333,7 +334,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -353,7 +354,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -370,7 +371,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -390,7 +391,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -407,7 +408,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -429,7 +430,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t

--- a/t/01-pdk/06-service-request/10-add_header.t
+++ b/t/01-pdk/06-service-request/10-add_header.t
@@ -3,8 +3,7 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/06-service-request/10-add_header.t
+++ b/t/01-pdk/06-service-request/10-add_header.t
@@ -4,6 +4,7 @@ use Test::Nginx::Socket::Lua;
 use t::Util;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 
@@ -101,7 +102,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -128,7 +129,7 @@ qq{
         }
 
         proxy_set_header Host $upstream_host;
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -145,7 +146,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -174,7 +175,7 @@ qq{
         }
 
         proxy_set_header Host $upstream_host;
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -191,7 +192,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -211,7 +212,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -228,7 +229,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -248,7 +249,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -265,7 +266,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -285,7 +286,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -302,7 +303,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -327,7 +328,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -345,7 +346,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -368,7 +369,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -390,7 +391,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -410,7 +411,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -427,7 +428,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -447,7 +448,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -464,7 +465,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -484,7 +485,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -501,7 +502,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -523,7 +524,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t

--- a/t/01-pdk/06-service-request/11-clear_header.t
+++ b/t/01-pdk/06-service-request/11-clear_header.t
@@ -3,8 +3,7 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/06-service-request/11-clear_header.t
+++ b/t/01-pdk/06-service-request/11-clear_header.t
@@ -4,6 +4,7 @@ use Test::Nginx::Socket::Lua;
 use t::Util;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 
@@ -59,7 +60,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -79,7 +80,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -98,7 +99,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -118,7 +119,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -138,7 +139,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -160,7 +161,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -177,7 +178,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -201,7 +202,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t

--- a/t/01-pdk/06-service-request/12-set_headers.t
+++ b/t/01-pdk/06-service-request/12-set_headers.t
@@ -3,8 +3,7 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/06-service-request/12-set_headers.t
+++ b/t/01-pdk/06-service-request/12-set_headers.t
@@ -4,6 +4,7 @@ use Test::Nginx::Socket::Lua;
 use t::Util;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 
@@ -59,7 +60,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -86,7 +87,7 @@ qq{
         }
 
         proxy_set_header Host $upstream_host;
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -103,7 +104,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -123,7 +124,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -140,7 +141,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -160,7 +161,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -180,7 +181,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -200,7 +201,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -217,7 +218,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -237,7 +238,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -254,7 +255,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -274,7 +275,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -291,7 +292,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -311,7 +312,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -328,7 +329,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -348,7 +349,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -365,7 +366,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -387,7 +388,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -471,7 +472,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -499,7 +500,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -517,7 +518,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -542,7 +543,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -562,7 +563,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -586,7 +587,7 @@ qq{
 
         }
 
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t

--- a/t/01-pdk/06-service-request/13-set_raw_body.t
+++ b/t/01-pdk/06-service-request/13-set_raw_body.t
@@ -3,8 +3,7 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/06-service-request/13-set_raw_body.t
+++ b/t/01-pdk/06-service-request/13-set_raw_body.t
@@ -4,6 +4,7 @@ use Test::Nginx::Socket::Lua;
 use t::Util;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 
@@ -59,7 +60,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -83,7 +84,7 @@ qq{
         }
 
         proxy_set_header Host $upstream_host;
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -100,7 +101,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -124,7 +125,7 @@ qq{
         }
 
         proxy_set_header Host $upstream_host;
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -141,7 +142,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -165,7 +166,7 @@ qq{
         }
 
         proxy_set_header Host $upstream_host;
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -182,7 +183,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -221,7 +222,7 @@ qq{
         }
 
         proxy_set_header Host $upstream_host;
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t
@@ -250,7 +251,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -274,7 +275,7 @@ qq{
         }
 
         proxy_set_header Host $upstream_host;
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 POST /t
@@ -293,7 +294,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         client_max_body_size 10m;
         client_body_buffer_size 10m;
@@ -323,7 +324,7 @@ qq{
         }
 
         proxy_set_header Host $upstream_host;
-        proxy_pass http://unix:/$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock;
     }
 --- request
 GET /t

--- a/t/01-pdk/07-service-response/00-phase_checks.t
+++ b/t/01-pdk/07-service-response/00-phase_checks.t
@@ -3,8 +3,7 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 2);
 

--- a/t/01-pdk/07-service-response/00-phase_checks.t
+++ b/t/01-pdk/07-service-response/00-phase_checks.t
@@ -4,6 +4,7 @@ use Test::Nginx::Socket::Lua;
 use t::Util;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 2);
 
@@ -17,7 +18,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             return 200;
@@ -94,7 +95,7 @@ qq{
 }
 --- config
     location /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         rewrite_by_lua_block {
             phase_check_functions(phases.rewrite)

--- a/t/01-pdk/07-service-response/01-get_status.t
+++ b/t/01-pdk/07-service-response/01-get_status.t
@@ -3,8 +3,7 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/07-service-response/01-get_status.t
+++ b/t/01-pdk/07-service-response/01-get_status.t
@@ -4,6 +4,7 @@ use Test::Nginx::Socket::Lua;
 use t::Util;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 
@@ -17,7 +18,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             return 200;
@@ -26,7 +27,7 @@ qq{
 }
 --- config
     location /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil
@@ -55,7 +56,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             return 200;
@@ -64,7 +65,7 @@ qq{
 }
 --- config
     location /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil
@@ -93,7 +94,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             return 404;
@@ -102,7 +103,7 @@ qq{
 }
 --- config
     location /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil
@@ -132,7 +133,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             return 404;
@@ -141,7 +142,7 @@ qq{
 }
 --- config
     location /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil

--- a/t/01-pdk/07-service-response/02-get_headers.t
+++ b/t/01-pdk/07-service-response/02-get_headers.t
@@ -3,8 +3,7 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/07-service-response/02-get_headers.t
+++ b/t/01-pdk/07-service-response/02-get_headers.t
@@ -4,6 +4,7 @@ use Test::Nginx::Socket::Lua;
 use t::Util;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 
@@ -17,7 +18,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             return 200;
@@ -26,7 +27,7 @@ qq{
 }
 --- config
     location /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil
@@ -55,7 +56,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             content_by_lua_block {
@@ -71,7 +72,7 @@ qq{
 }
 --- config
     location = /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil
@@ -108,7 +109,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             content_by_lua_block {
@@ -119,7 +120,7 @@ qq{
 }
 --- config
     location = /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil
@@ -157,7 +158,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             default_type '';
@@ -172,7 +173,7 @@ qq{
 --- config
     location = /t {
         default_type '';
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil
@@ -209,7 +210,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             default_type '';
@@ -224,7 +225,7 @@ qq{
 --- config
     location = /t {
         default_type '';
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil
@@ -257,7 +258,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             default_type '';
@@ -272,7 +273,7 @@ qq{
 --- config
     location = /t {
         default_type  '';
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil
@@ -309,7 +310,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             return 200;
@@ -318,7 +319,7 @@ qq{
 }
 --- config
     location = /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil
@@ -349,7 +350,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             return 200;
@@ -358,7 +359,7 @@ qq{
 }
 --- config
     location = /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil
@@ -389,7 +390,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             return 200;
@@ -398,7 +399,7 @@ qq{
 }
 --- config
     location = /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil
@@ -429,7 +430,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             content_by_lua_block {
@@ -444,7 +445,7 @@ qq{
             ngx.header["X-Non-Service-Header"] = "test"
         }
 
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil

--- a/t/01-pdk/07-service-response/03-get_header.t
+++ b/t/01-pdk/07-service-response/03-get_header.t
@@ -3,8 +3,7 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/07-service-response/03-get_header.t
+++ b/t/01-pdk/07-service-response/03-get_header.t
@@ -4,6 +4,7 @@ use Test::Nginx::Socket::Lua;
 use t::Util;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 
@@ -17,7 +18,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             content_by_lua_block {
@@ -31,7 +32,7 @@ qq{
 }
 --- config
     location = /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil
@@ -60,7 +61,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             content_by_lua_block {
@@ -71,7 +72,7 @@ qq{
 }
 --- config
     location = /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil
@@ -107,7 +108,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             return 200;
@@ -116,7 +117,7 @@ qq{
 }
 --- config
     location = /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil
@@ -145,7 +146,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             content_by_lua_block {
@@ -160,7 +161,7 @@ qq{
 }
 --- config
     location = /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil
@@ -189,7 +190,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             return 200;
@@ -198,7 +199,7 @@ qq{
 }
 --- config
     location = /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil
@@ -229,7 +230,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             content_by_lua_block {
@@ -244,7 +245,7 @@ qq{
             ngx.header["X-Non-Service-Header"] = "test"
         }
 
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil
@@ -280,7 +281,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             content_by_lua_block {
@@ -298,7 +299,7 @@ qq{
             ngx.header["X-Non-Service-Header"] = "test"
         }
 
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil

--- a/t/01-pdk/07-service-response/04-get_raw_body.t
+++ b/t/01-pdk/07-service-response/04-get_raw_body.t
@@ -3,8 +3,6 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-
 plan tests => repeat_each() * (blocks() * 3);
 
 run_tests();

--- a/t/01-pdk/07-service-response/05-get_body.t
+++ b/t/01-pdk/07-service-response/05-get_body.t
@@ -3,8 +3,6 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-
 plan tests => repeat_each() * (blocks() * 3);
 
 run_tests();

--- a/t/01-pdk/08-response/00-phase_checks.t
+++ b/t/01-pdk/08-response/00-phase_checks.t
@@ -3,8 +3,7 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 2);
 

--- a/t/01-pdk/08-response/00-phase_checks.t
+++ b/t/01-pdk/08-response/00-phase_checks.t
@@ -4,6 +4,7 @@ use Test::Nginx::Socket::Lua;
 use t::Util;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 2);
 
@@ -17,7 +18,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             return 200;
@@ -152,7 +153,7 @@ qq{
 }
 --- config
     location /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
         set $upstream_uri '/t';
         set $upstream_scheme 'http';
 
@@ -189,7 +190,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             return 200;
@@ -224,7 +225,7 @@ qq{
 }
 --- config
     location /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
         set $upstream_uri '/t';
         set $upstream_scheme 'http';
 
@@ -256,7 +257,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             return 200;
@@ -285,7 +286,7 @@ qq{
 }
 --- config
     location /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
         set $upstream_uri '/t';
         set $upstream_scheme 'http';
 
@@ -306,7 +307,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             return 200;
@@ -335,7 +336,7 @@ qq{
 }
 --- config
     location /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
         set $upstream_uri '/t';
         set $upstream_scheme 'http';
 
@@ -356,7 +357,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             return 200;
@@ -385,7 +386,7 @@ qq{
 }
 --- config
     location /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
         set $upstream_uri '/t';
         set $upstream_scheme 'http';
 
@@ -406,7 +407,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             return 200;
@@ -435,7 +436,7 @@ qq{
 }
 --- config
     location /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
         set $upstream_uri '/t';
         set $upstream_scheme 'http';
 

--- a/t/01-pdk/08-response/01-get_status.t
+++ b/t/01-pdk/08-response/01-get_status.t
@@ -3,8 +3,7 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/08-response/01-get_status.t
+++ b/t/01-pdk/08-response/01-get_status.t
@@ -4,6 +4,7 @@ use Test::Nginx::Socket::Lua;
 use t::Util;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 
@@ -47,7 +48,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             return 200;
@@ -56,7 +57,7 @@ qq{
 }
 --- config
     location /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil
@@ -85,7 +86,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             return 404;
@@ -94,7 +95,7 @@ qq{
 }
 --- config
     location /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil
@@ -124,7 +125,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             content_by_lua_block {
@@ -149,7 +150,7 @@ qq{
             ngx.status = 202
         }
 
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil

--- a/t/01-pdk/08-response/02-get_header.t
+++ b/t/01-pdk/08-response/02-get_header.t
@@ -3,8 +3,7 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/08-response/02-get_header.t
+++ b/t/01-pdk/08-response/02-get_header.t
@@ -4,6 +4,7 @@ use Test::Nginx::Socket::Lua;
 use t::Util;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 
@@ -190,7 +191,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             content_by_lua_block {
@@ -205,7 +206,7 @@ qq{
             ngx.header["X-Non-Service-Header"] = "test"
         }
 
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil

--- a/t/01-pdk/08-response/03-get_headers.t
+++ b/t/01-pdk/08-response/03-get_headers.t
@@ -3,8 +3,7 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/08-response/03-get_headers.t
+++ b/t/01-pdk/08-response/03-get_headers.t
@@ -4,6 +4,7 @@ use Test::Nginx::Socket::Lua;
 use t::Util;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 
@@ -48,7 +49,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             content_by_lua_block {
@@ -64,7 +65,7 @@ qq{
 }
 --- config
     location = /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil
@@ -101,7 +102,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             content_by_lua_block {
@@ -112,7 +113,7 @@ qq{
 }
 --- config
     location = /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil
@@ -374,7 +375,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             content_by_lua_block {
@@ -389,7 +390,7 @@ qq{
             ngx.header["X-Non-Service-Header"] = "test"
         }
 
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil

--- a/t/01-pdk/08-response/04-set_status.t
+++ b/t/01-pdk/08-response/04-set_status.t
@@ -3,8 +3,7 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/08-response/04-set_status.t
+++ b/t/01-pdk/08-response/04-set_status.t
@@ -4,6 +4,7 @@ use Test::Nginx::Socket::Lua;
 use t::Util;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 
@@ -98,7 +99,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -115,7 +116,7 @@ qq{
 }
 --- config
     location = /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil
@@ -142,7 +143,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -159,7 +160,7 @@ qq{
 }
 --- config
     location = /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             local pdk = require "kong.pdk"

--- a/t/01-pdk/08-response/05-set_header.t
+++ b/t/01-pdk/08-response/05-set_header.t
@@ -4,6 +4,7 @@ use Test::Nginx::Socket::Lua;
 use t::Util;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 
@@ -212,7 +213,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -229,7 +230,7 @@ qq{
 }
 --- config
     location = /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil

--- a/t/01-pdk/08-response/05-set_header.t
+++ b/t/01-pdk/08-response/05-set_header.t
@@ -3,8 +3,7 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/08-response/06-add_header.t
+++ b/t/01-pdk/08-response/06-add_header.t
@@ -3,8 +3,7 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/08-response/06-add_header.t
+++ b/t/01-pdk/08-response/06-add_header.t
@@ -4,6 +4,7 @@ use Test::Nginx::Socket::Lua;
 use t::Util;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 
@@ -217,7 +218,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -228,7 +229,7 @@ qq{
 }
 --- config
     location = /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil
@@ -267,7 +268,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -284,7 +285,7 @@ qq{
 }
 --- config
     location = /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil

--- a/t/01-pdk/08-response/07-clear_header.t
+++ b/t/01-pdk/08-response/07-clear_header.t
@@ -3,8 +3,7 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/08-response/07-clear_header.t
+++ b/t/01-pdk/08-response/07-clear_header.t
@@ -4,6 +4,7 @@ use Test::Nginx::Socket::Lua;
 use t::Util;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3);
 
@@ -83,7 +84,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -94,7 +95,7 @@ qq{
 }
 --- config
     location = /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil
@@ -125,7 +126,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -136,7 +137,7 @@ qq{
 }
 --- config
     location = /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil

--- a/t/01-pdk/08-response/08-set_headers.t
+++ b/t/01-pdk/08-response/08-set_headers.t
@@ -4,6 +4,7 @@ use Test::Nginx::Socket::Lua;
 use t::Util;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3) + 1;
 
@@ -83,7 +84,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -100,7 +101,7 @@ qq{
 }
 --- config
     location = /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil
@@ -126,7 +127,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -137,7 +138,7 @@ qq{
 }
 --- config
     location = /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil
@@ -168,7 +169,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -185,7 +186,7 @@ qq{
 }
 --- config
     location = /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil
@@ -211,7 +212,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -228,7 +229,7 @@ qq{
 }
 --- config
     location = /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil
@@ -254,7 +255,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -271,7 +272,7 @@ qq{
 }
 --- config
     location = /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil
@@ -297,7 +298,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -314,7 +315,7 @@ qq{
 }
 --- config
     location = /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil
@@ -474,7 +475,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -497,7 +498,7 @@ qq{
 }
 --- config
     location = /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil
@@ -529,7 +530,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -541,7 +542,7 @@ qq{
 }
 --- config
     location = /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil
@@ -582,7 +583,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location /t {
             content_by_lua_block {
@@ -594,7 +595,7 @@ qq{
 }
 --- config
     location = /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
 
         header_filter_by_lua_block {
             ngx.header.content_length = nil

--- a/t/01-pdk/08-response/08-set_headers.t
+++ b/t/01-pdk/08-response/08-set_headers.t
@@ -3,8 +3,7 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 3) + 1;
 

--- a/t/01-pdk/08-response/09-set_raw_body.t
+++ b/t/01-pdk/08-response/09-set_raw_body.t
@@ -3,8 +3,6 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-
 plan tests => repeat_each() * (blocks() * 3);
 
 run_tests();

--- a/t/01-pdk/08-response/10-set_body.t
+++ b/t/01-pdk/08-response/10-set_body.t
@@ -3,8 +3,6 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-
 plan tests => repeat_each() * (blocks() * 3);
 
 run_tests();

--- a/t/01-pdk/08-response/11-exit.t
+++ b/t/01-pdk/08-response/11-exit.t
@@ -3,8 +3,6 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-
 plan tests => repeat_each() * (blocks() * 4) + 1;
 
 run_tests();

--- a/t/01-pdk/08-response/12-get_source.t
+++ b/t/01-pdk/08-response/12-get_source.t
@@ -2,8 +2,6 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-
 plan tests => repeat_each() * (blocks() * 3);
 
 run_tests();

--- a/t/01-pdk/09-service/00-phase_checks.t
+++ b/t/01-pdk/09-service/00-phase_checks.t
@@ -3,8 +3,7 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 2);
 

--- a/t/01-pdk/09-service/00-phase_checks.t
+++ b/t/01-pdk/09-service/00-phase_checks.t
@@ -4,6 +4,7 @@ use Test::Nginx::Socket::Lua;
 use t::Util;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
 
 plan tests => repeat_each() * (blocks() * 2);
 
@@ -17,7 +18,7 @@ qq{
     $t::Util::HttpConfig
 
     server {
-        listen unix:$ENV{TEST_NGINX_HTML_DIR}/nginx.sock;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
 
         location / {
             return 200;
@@ -71,7 +72,7 @@ qq{
 }
 --- config
     location /t {
-        proxy_pass http://unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
         set $upstream_host 'example.com';
         set $upstream_uri '/t';
         set $upstream_scheme 'http';

--- a/t/01-pdk/09-service/01-set-upstream.t
+++ b/t/01-pdk/09-service/01-set-upstream.t
@@ -3,8 +3,6 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-
 plan tests => repeat_each() * (blocks() * 3);
 
 run_tests();

--- a/t/01-pdk/09-service/02-set-target.t
+++ b/t/01-pdk/09-service/02-set-target.t
@@ -3,8 +3,6 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
-
 plan tests => repeat_each() * (blocks() * 3);
 
 run_tests();


### PR DESCRIPTION
The pdk tests use local files for sockets and those cannot be
located on a mounted/shared filesystem. Hence an extra environment
variable for setting the location. This will allow to run the PDK
tests from Vagrant and Docker for example.

Variable is named TEST_NGINX_NXSOCK and should point to a
directory.
