### PR TITLE
fix(admin) inferring of arguments for record types

### DIFF
--- a/kong/api/arguments.lua
+++ b/kong/api/arguments.lua
@@ -13,6 +13,7 @@ local pairs         = pairs
 local lower         = string.lower
 local find          = string.find
 local sub           = string.sub
+local next          = next
 local type          = type
 local ngx           = ngx
 local req           = ngx.req
@@ -213,7 +214,16 @@ local function infer_value(value, field)
   elseif field.type == "record" and not field.abstract then
     if type(value) == "table" then
       for k, v in pairs(value) do
-        value[k] = infer_value(v, field.fields[k])
+        for i in ipairs(field.fields) do
+          local item = field.fields[i]
+          if item then
+            local key = next(item)
+            local fld = item[key]
+            if k == key then
+              value[k] = infer_value(v, fld)
+            end
+          end
+        end
       end
     end
   end

--- a/spec/01-unit/000-new-dao/03-arguments_spec.lua
+++ b/spec/01-unit/000-new-dao/03-arguments_spec.lua
@@ -56,9 +56,9 @@ describe("arguments.infer_value", function()
 
   it("infers records", function()
     assert.same({ age = "1" }, infer_value({ age = "1" },
-                                           { type = "record", fields = { age = { type = "string" } } }))
+                                           { type = "record", fields = {{ age = { type = "string" } } }}))
     assert.same({ age = 1 },   infer_value({ age = "1" },
-                                           { type = "record", fields = { age = { type = "number" } } }))
+                                           { type = "record", fields = {{ age = { type = "number" } } }}))
   end)
 
   it("returns the provided value when inferring is not possible", function()


### PR DESCRIPTION
### Summary

Fixes inferring record fields on Admin API when using `application/x-www-form-urlencoded`.

This was originally proposed in
#3710 

And this is one of the series of PRs that were previously implemented in that branch.