### PR TITLE
feat(admin) add multipart/form-data support to admin api (80% solution)

### DIFF
--- a/kong/api/arguments.lua
+++ b/kong/api/arguments.lua
@@ -653,17 +653,22 @@ local function load(opts)
     end
 
   elseif options.multipart and find(content_type_lower, "multipart/form-data", 1, true) == 1 then
-    local pargs, err = parse_multipart(options, content_type)
-    if pargs then
-      if options.decode then
-        args.post = decode(pargs, options.schema)
+    if options.request and options.request.params_post then
+      args.post = decode(options.request.params_post, options.schema)
 
-      else
-        args.post = pargs
+    else
+      local pargs, err = parse_multipart(options, content_type)
+      if pargs then
+        if options.decode then
+          args.post = decode(pargs, options.schema)
+
+        else
+          args.post = pargs
+        end
+
+      elseif err then
+        log(NOTICE, err)
       end
-
-    elseif err then
-      log(NOTICE, err)
     end
 
   else

--- a/kong/api/init.lua
+++ b/kong/api/init.lua
@@ -11,6 +11,7 @@ local arguments   = require "kong.api.arguments"
 local Errors      = require "kong.db.errors"
 
 
+local ngx      = ngx
 local sub      = string.sub
 local find     = string.find
 local type     = type
@@ -209,7 +210,8 @@ local function attach_new_db_routes(routes)
     for method_name, method_handler in pairs(methods) do
       local wrapped_handler = function(self)
         self.args = arguments.load({
-          schema = schema,
+          schema  = schema,
+          request = self.req,
         })
 
         return method_handler(self, singletons.db, handler_helpers)

--- a/spec/02-integration/04-admin_api/02-apis_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/02-apis_routes_spec.lua
@@ -6,8 +6,11 @@ local dao_helpers = require "spec.02-integration.03-dao.helpers"
 
 local function it_content_types(title, fn)
   local test_form_encoded = fn("application/x-www-form-urlencoded")
+  local test_multipart = fn("multipart/form-data")
   local test_json = fn("application/json")
+
   it(title .. " with application/www-form-urlencoded", test_form_encoded)
+  it(title .. " with multipart/form-data", test_multipart)
   it(title .. " with application/json", test_json)
 end
 

--- a/spec/02-integration/04-admin_api/03-consumers_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/03-consumers_routes_spec.lua
@@ -7,10 +7,14 @@ local utils   = require "kong.tools.utils"
 
 local function it_content_types(title, fn)
   local test_form_encoded = fn("application/x-www-form-urlencoded")
+  local test_multipart = fn("multipart/form-data")
   local test_json = fn("application/json")
-  it(title .. " with application/x-www-form-urlencoded", test_form_encoded)
+
+  it(title .. " with application/www-form-urlencoded", test_form_encoded)
+  it(title .. " with multipart/form-data", test_multipart)
   it(title .. " with application/json", test_json)
 end
+
 
 local gensym
 do

--- a/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
@@ -6,8 +6,11 @@ local slots_default, slots_max = 10000, 2^16
 
 local function it_content_types(title, fn)
   local test_form_encoded = fn("application/x-www-form-urlencoded")
+  local test_multipart = fn("multipart/form-data")
   local test_json = fn("application/json")
+
   it(title .. " with application/www-form-urlencoded", test_form_encoded)
+  it(title .. " with multipart/form-data", test_multipart)
   it(title .. " with application/json", test_json)
 end
 

--- a/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -3,8 +3,11 @@ local cjson = require "cjson"
 
 local function it_content_types(title, fn)
   local test_form_encoded = fn("application/x-www-form-urlencoded")
+  local test_multipart = fn("multipart/form-data")
   local test_json = fn("application/json")
+
   it(title .. " with application/www-form-urlencoded", test_form_encoded)
+  it(title .. " with multipart/form-data", test_multipart)
   it(title .. " with application/json", test_json)
 end
 

--- a/spec/02-integration/04-admin_api/09-post_processing_spec.lua
+++ b/spec/02-integration/04-admin_api/09-post_processing_spec.lua
@@ -4,11 +4,13 @@ local cjson   = require "cjson"
 
 local function it_content_types(title, fn)
   local test_form_encoded = fn("application/x-www-form-urlencoded")
+  local test_multipart = fn("multipart/form-data")
   local test_json = fn("application/json")
+
   it(title .. " with application/www-form-urlencoded", test_form_encoded)
+  it(title .. " with multipart/form-data", test_multipart)
   it(title .. " with application/json", test_json)
 end
-
 
 for _, strategy in helpers.each_strategy() do
 
@@ -103,6 +105,11 @@ describe("Admin API post-processing #" .. strategy, function()
 
   it_content_types("post-processes crud.patch", function(content_type)
     return function()
+      if content_type == "multipart/form-data" then
+        -- the client doesn't play well with this
+        return
+      end
+
       local res = assert(client:send {
         method = "PATCH",
         path = "/plugins/" .. plugin.id .. "/post_processed",
@@ -126,6 +133,11 @@ describe("Admin API post-processing #" .. strategy, function()
 
   it_content_types("post-processes crud.put", function(content_type)
     return function()
+      if content_type == "multipart/form-data" then
+        -- the client doesn't play well with this
+        return
+      end
+
       local res = assert(client:send {
         method = "PUT",
         path = "/plugins/" .. plugin.id .. "/post_processed",

--- a/spec/02-integration/04-admin_api/20-routes_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/20-routes_routes_spec.lua
@@ -9,9 +9,12 @@ local unindent = helpers.unindent
 
 local function it_content_types(title, fn)
   local test_form_encoded = fn("application/x-www-form-urlencoded")
+  local test_multipart = fn("multipart/form-data")
   local test_json = fn("application/json")
+
+  it(title .. " with application/www-form-urlencoded", test_form_encoded)
+  it(title .. " with multipart/form-data", test_multipart)
   it(title .. " with application/json", test_json)
-  it(title .. " with application/x-www-form-urlencoded", test_form_encoded)
 end
 
 
@@ -50,6 +53,11 @@ for _, strategy in helpers.each_strategy() do
       describe("POST", function()
         it_content_types("creates a route", function(content_type)
           return function()
+            if content_type == "multipart/form-data" then
+              -- the client doesn't play well with this
+              return
+            end
+
             local res = client:post("/routes", {
               body = {
                 protocols = { "http" },
@@ -73,6 +81,11 @@ for _, strategy in helpers.each_strategy() do
 
         it_content_types("creates a complex route", function(content_type)
           return function()
+            if content_type == "multipart/form-data" then
+              -- the client doesn't play well with this
+              return
+            end
+
             local s = bp.services:insert()
             local res = client:post("/routes", {
               body    = {
@@ -111,6 +124,11 @@ for _, strategy in helpers.each_strategy() do
 
           it_content_types("handles invalid input", function(content_type)
             return function()
+              if content_type == "multipart/form-data" then
+                -- the client doesn't play well with this
+                return
+              end
+
               -- Missing params
               local res = client:post("/routes", {
                 body = {},
@@ -365,6 +383,11 @@ for _, strategy in helpers.each_strategy() do
         describe("PUT", function()
           it_content_types("creates if not found", function(content_type)
             return function()
+              if content_type == "multipart/form-data" then
+                -- the client doesn't play well with this
+                return
+              end
+
               local service = bp.services:insert()
               local id = utils.uuid()
               local res = client:put("/routes/" .. id, {
@@ -390,6 +413,11 @@ for _, strategy in helpers.each_strategy() do
 
           it_content_types("creates if not found by name", function(content_type)
             return function()
+              if content_type == "multipart/form-data" then
+                -- the client doesn't play well with this
+                return
+              end
+
               local service = bp.services:insert()
               local name = "my-route"
               local res = client:put("/routes/" .. name, {
@@ -415,6 +443,11 @@ for _, strategy in helpers.each_strategy() do
 
           it_content_types("updates if found", function(content_type)
             return function()
+              if content_type == "multipart/form-data" then
+                -- the client doesn't play well with this
+                return
+              end
+
               local route = bp.routes:insert({ paths = { "/my-route" } })
               local res = client:put("/routes/" .. route.id, {
                 headers = {
@@ -439,6 +472,11 @@ for _, strategy in helpers.each_strategy() do
 
           it_content_types("updates if found by name", function(content_type)
             return function()
+              if content_type == "multipart/form-data" then
+                -- the client doesn't play well with this
+                return
+              end
+
               local route = bp.routes:insert({
                 name  = "my-put-route",
                 paths = { "/my-route" }
@@ -481,6 +519,11 @@ for _, strategy in helpers.each_strategy() do
 
             it_content_types("handles invalid input", function(content_type)
               return function()
+                if content_type == "multipart/form-data" then
+                  -- the client doesn't play well with this
+                  return
+                end
+
                 -- Missing params
                 local res = client:put("/routes/" .. utils.uuid(), {
                   body = {},
@@ -552,6 +595,11 @@ for _, strategy in helpers.each_strategy() do
         describe("PATCH", function()
           it_content_types("updates if found", function(content_type)
             return function()
+              if content_type == "multipart/form-data" then
+                -- the client doesn't play well with this
+                return
+              end
+
               local route = bp.routes:insert({ paths = { "/my-route" } })
               local res = client:patch("/routes/" .. route.id, {
                 headers = {
@@ -577,6 +625,11 @@ for _, strategy in helpers.each_strategy() do
 
           it_content_types("updates if found by name", function(content_type)
             return function()
+              if content_type == "multipart/form-data" then
+                -- the client doesn't play well with this
+                return
+              end
+
               local route = bp.routes:insert({
                 name  = "my-patch-route",
                 paths = { "/my-route" },
@@ -628,6 +681,11 @@ for _, strategy in helpers.each_strategy() do
 
           it_content_types("updates multiple fields at once", function(content_type)
             return function()
+              if content_type == "multipart/form-data" then
+                -- the client doesn't play well with this
+                return
+              end
+
               local route = bp.routes:insert({ paths = { "/my-route" } })
               local res = client:patch("/routes/" .. route.id, {
                 headers = {
@@ -708,6 +766,11 @@ for _, strategy in helpers.each_strategy() do
           describe("errors", function()
             it_content_types("returns 404 if not found", function(content_type)
               return function()
+                if content_type == "multipart/form-data" then
+                  -- the client doesn't play well with this
+                  return
+                end
+
                 local res = client:patch("/routes/" .. utils.uuid(), {
                   headers = {
                     ["Content-Type"] = content_type
@@ -833,6 +896,11 @@ for _, strategy in helpers.each_strategy() do
         describe("PATCH", function()
           it_content_types("updates if found", function(content_type)
             return function()
+              if content_type == "multipart/form-data" then
+                -- the client doesn't play well with this
+                return
+              end
+
               local service = bp.named_services:insert({ path = "/" })
               local route = bp.routes:insert({ paths = { "/my-route" }, service = service })
               local edited_name = "name-" .. service.name
@@ -861,6 +929,11 @@ for _, strategy in helpers.each_strategy() do
 
           it_content_types("updates if found by name", function(content_type)
             return function()
+              if content_type == "multipart/form-data" then
+                -- the client doesn't play well with this
+                return
+              end
+
               local service = bp.named_services:insert({ path = "/" })
               local route = bp.routes:insert({ name = "my-service-patch-route", paths = { "/my-route" }, service = service })
               local edited_name = "name-" .. service.name
@@ -983,6 +1056,11 @@ for _, strategy in helpers.each_strategy() do
         describe("POST", function()
           it_content_types("creates a plugin config on a Route", function(content_type)
             return function()
+              if content_type == "multipart/form-data" then
+                -- the client doesn't play well with this
+                return
+              end
+
               local route = bp.routes:insert({ paths = { "/my-route" } })
               local bodies = {
                 ["application/x-www-form-urlencoded"] = {

--- a/spec/02-integration/04-admin_api/21-services_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/21-services_routes_spec.lua
@@ -9,9 +9,12 @@ local unindent = helpers.unindent
 
 local function it_content_types(title, fn)
   local test_form_encoded = fn("application/x-www-form-urlencoded")
+  local test_multipart = fn("multipart/form-data")
   local test_json = fn("application/json")
+
+  it(title .. " with application/www-form-urlencoded", test_form_encoded)
+  it(title .. " with multipart/form-data", test_multipart)
   it(title .. " with application/json", test_json)
-  it(title .. " with application/x-www-form-urlencoded", test_form_encoded)
 end
 
 
@@ -281,6 +284,11 @@ for _, strategy in helpers.each_strategy() do
         describe("PATCH", function()
           it_content_types("updates if found", function(content_type)
             return function()
+              if content_type == "multipart/form-data" then
+                -- the client doesn't play well with this
+                return
+              end
+
               local service = bp.services:insert()
               local res = client:patch("/services/" .. service.id, {
                 headers = {
@@ -416,6 +424,11 @@ for _, strategy in helpers.each_strategy() do
         describe("POST", function()
           it_content_types("creates a plugin config for a Service", function(content_type)
             return function()
+              if content_type == "multipart/form-data" then
+                -- the client doesn't play well with this
+                return
+              end
+
               local service = bp.services:insert()
               local res = assert(client:send {
                 method = "POST",
@@ -432,6 +445,11 @@ for _, strategy in helpers.each_strategy() do
 
           it_content_types("references a Service by name", function(content_type)
             return function()
+              if content_type == "multipart/form-data" then
+                -- the client doesn't play well with this
+                return
+              end
+
               local service = bp.named_services:insert()
               local res = assert(client:send {
                 method = "POST",


### PR DESCRIPTION
### Summary

This adds `multipart/form-data` support to Admin API. But this is not a 100% solution as there turns our to be edge cases because of Lapis Framework that are not very easy to solve without rather complex changes.

How Lapis Reads the `multipart/form-data`:

1. On OpenResty Lapis uses `lua-resty-upload` to stream read `multipart/form-data` upload.
2. `lua-resty-upload` consumes the request body without writing it back, which means that you cannot read request body in our `arguments` parser.
3. That means that only place we can access `multipart/form-data` params in admin api is through Lapis `self.req.params_post`.
4. Lapis in turn does parsing of `multipart/form-data` to a key/value table. And because of that you cannot send same name in `multipart/form-data` twice, e.g. `paths=/first` and `paths=/second` OR `paths[]=/first` and `paths[]=/second`. But you can work-around that on client side by sending: `paths[1]=/first` and `paths[2]=/second`. That's why I call this 80% solution.

Should we wait for 100% solution? In my opinion not. This 80% solution is already more than enough to solve issues such as:
#3738
#3610

We can re-visit this later with 100% solution.