### PR TITLE
chore(deps) bump LuaRocks to 3.0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ addons:
 
 env:
   global:
-    - LUAROCKS=2.4.3
+    - LUAROCKS=3.0.4
     - OPENSSL=1.1.1
     - OPENRESTY_BASE=1.13.6.2
     - OPENRESTY_LATEST=1.13.6.2


### PR DESCRIPTION
Bumps LuaRocks in the Travis environment to version 3.0.4.
