### PR TITLE
fix(aws-plugin) handle empty json arrays

### DIFF
--- a/kong/tools/public.lua
+++ b/kong/tools/public.lua
@@ -8,7 +8,9 @@ local _M = {}
 
 do
   local multipart = require "multipart"
-  local cjson     = require "cjson.safe"
+  local cjson     = (require "cjson.safe").new()
+  cjson.decode_array_with_array_mt(true)
+
   local utils     = require "kong.tools.utils"
 
 

--- a/spec/03-plugins/23-aws-lambda/01-access_spec.lua
+++ b/spec/03-plugins/23-aws-lambda/01-access_spec.lua
@@ -273,6 +273,19 @@ for _, strategy in helpers.each_strategy() do
       assert.is_string(res.headers["x-amzn-RequestId"])
       assert.equal("some_value_json1", body.key1)
     end)
+    it("passes empty json arrays unmodified", function()
+      local res = assert(proxy_client:send {
+        method  = "POST",
+        path    = "/post",
+        headers = {
+          ["Host"]         = "lambda.com",
+          ["Content-Type"] = "application/json"
+        },
+        body = '[{}, []]'
+      })
+      assert.res_status(200, res)
+      assert.equal('[{},[]]', string.gsub(res:read_body(), "\n",""))
+    end)
     it("invokes a Lambda function with POST and both querystring and body params", function()
       local res = assert(proxy_client:send {
         method  = "POST",


### PR DESCRIPTION
Empty tables are decoded as empty json arrays instead of emtpy
objects.