### PR TITLE
hotfix(db) postgres ttl cleanup timer

### DIFF
--- a/kong/db/strategies/postgres/connector.lua
+++ b/kong/db/strategies/postgres/connector.lua
@@ -198,7 +198,7 @@ function _mt:init_worker(strategies)
         local name = schema.name
         graph:add(name)
         for _, field in schema:each_field() do
-          if field.type == "foreign" then
+          if field.type == "foreign" and field.schema.ttl then
             graph:add(name, field.schema.name)
           end
         end


### PR DESCRIPTION
### Summary

Fixes unfortunate bug in Postgres `TTL` cleanup  timer where it tried to delete rows from tables that didn't have `ttl=true`.