### PR TITLE
perf(oauth2) do not read request body if unnecessary

### DIFF
--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -450,19 +450,21 @@ end
 
 local function parse_access_token(conf)
   local found_in = {}
-  local result = retrieve_parameters()["access_token"]
-  if not result then
-    local authorization = ngx.req.get_headers()[conf.auth_header_name]
-    if authorization then
-      local parts = {}
-      for v in authorization:gmatch("%S+") do -- Split by space
-        table.insert(parts, v)
-      end
-      if #parts == 2 and (parts[1]:lower() == "token" or parts[1]:lower() == "bearer") then
-        result = parts[2]
-        found_in.authorization_header = true
-      end
+  local access_token = ngx.req.get_headers()[conf.auth_header_name]
+  if access_token then
+    if type(access_token) == "table" then --Take the first found
+      access_token = access_token[1]
     end
+    local parts = {}
+    for v in access_token:gmatch("%S+") do -- Split by space
+      table.insert(parts, v)
+    end
+    if #parts == 2 and (parts[1]:lower() == "token" or parts[1]:lower() == "bearer") then
+      access_token = parts[2]
+      found_in.authorization_header = true
+    end
+  else
+    access_token = retrieve_parameters()[ACCESS_TOKEN]  
   end
 
   if conf.hide_credentials then
@@ -489,7 +491,7 @@ local function parse_access_token(conf)
     end
   end
 
-  return result
+  return access_token
 end
 
 local function load_oauth2_credential_into_memory(credential_id)

--- a/spec/03-plugins/26-oauth2/03-access_spec.lua
+++ b/spec/03-plugins/26-oauth2/03-access_spec.lua
@@ -1718,6 +1718,19 @@ for _, strategy in helpers.each_strategy() do
         })
         assert.res_status(200, res)
       end)
+      it("works when a correct access_token is being sent in duplicate custom headers", function()
+        local token = provision_token("oauth2_11.com",nil,"clientid1011","secret1011")
+
+        local res = assert(proxy_ssl_client:send {
+          method = "GET",
+          path = "/request",
+          headers = {
+            ["Host"] = "oauth2_11.com",
+            ["custom_header_name"] = { "bearer " .. token.access_token, "bearer " .. token.access_token },
+          }
+        })
+        assert.res_status(200, res)
+      end)
       it("fails when a correct access_token is being sent in the wrong header", function()
         local token = provision_token("oauth2_11.com",nil,"clientid1011","secret1011")
 


### PR DESCRIPTION
Improve OAuth2.0 by checking headers first and not reading every request body into memory by default. 

Also is a nice fix for https://github.com/Kong/kong/issues/3768 since everyone within our company uses token in the header(Which IMO for the record is the right way 😄).

### Summary

OAuth2.0 Plugin currently reads the request body to parse for an access_token prematurely, this PR optimizes performance in the event users are not sticking their access_token in the HTTP Body but rather as a Header.

### Full changelog
* modify access.lua  parse_access_token() function for improvements. 

### Issues resolved
Fixes https://github.com/Kong/kong/issues/3768

Existing tests with the plugin will validate out this logic since nothing changed, otherwise if for some reason newer tests must be made let me know.