### PR TITLE
perf(plugins-iterator) execute iterator only on configured plugins

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -266,6 +266,15 @@ return {
       end, "crud", "services")
 
 
+      worker_events.register(function(data)
+        -- assume an update doesnt also change the whole entity!
+        if data.operation ~= "update" then
+          log(DEBUG, "[events] Plugin updated, invalidating plugin map")
+          cache:invalidate("plugins_map:version")
+        end
+      end, "crud", "plugins")
+
+
       -- SSL certs / SNIs invalidations
 
 

--- a/kong/runloop/plugins_iterator.lua
+++ b/kong/runloop/plugins_iterator.lua
@@ -68,6 +68,10 @@ local function get_next(self)
 
   self.i = i
 
+  if not self.configured_plugins[plugin.name] then
+    return get_next(self)
+  end
+
   local ctx = self.ctx
 
   -- load the plugin configuration in early phases
@@ -194,7 +198,8 @@ local plugin_iter_mt = { __call = get_next }
 -- is access_by_lua_block. We don't use `ngx.get_phase()` simply because we can
 -- avoid it.
 -- @treturn function iterator
-local function iter_plugins_for_req(ctx, loaded_plugins, access_or_cert_ctx)
+local function iter_plugins_for_req(ctx, loaded_plugins, configured_plugins,
+                                    access_or_cert_ctx)
   if not ctx.plugins_for_request then
     ctx.plugins_for_request = {}
   end
@@ -206,6 +211,7 @@ local function iter_plugins_for_req(ctx, loaded_plugins, access_or_cert_ctx)
     route                 = ctx.route,
     service               = ctx.service,
     loaded_plugins        = loaded_plugins,
+    configured_plugins    = configured_plugins,
     access_or_cert_ctx    = access_or_cert_ctx,
   }
 

--- a/spec/02-integration/06-invalidations/03-plugins_map_invalidation_spec.lua
+++ b/spec/02-integration/06-invalidations/03-plugins_map_invalidation_spec.lua
@@ -1,0 +1,262 @@
+local cjson        = require "cjson"
+local helpers      = require "spec.helpers"
+
+
+local POLL_INTERVAL = 0.3
+
+
+for _, strategy in helpers.each_strategy() do
+  describe("plugins map with db [#" .. strategy .. "]", function()
+
+    local admin_client_1
+    local admin_client_2
+
+    local proxy_client_1
+    local proxy_client_2
+
+    local wait_for_propagation
+
+    local service_fixture
+
+    setup(function()
+      local bp = helpers.get_db_utils(strategy, {
+        "apis",
+        "routes",
+        "services",
+        "plugins",
+        "certificates",
+      })
+
+      -- insert single fixture Service
+      service_fixture = bp.services:insert()
+
+      local db_update_propagation = strategy == "cassandra" and 0.1 or 0
+
+      assert(helpers.start_kong {
+        log_level             = "debug",
+        prefix                = "servroot1",
+        database              = strategy,
+        proxy_listen          = "0.0.0.0:8000, 0.0.0.0:8443 ssl",
+        admin_listen          = "0.0.0.0:8001",
+        db_update_frequency   = POLL_INTERVAL,
+        db_update_propagation = db_update_propagation,
+        nginx_conf            = "spec/fixtures/custom_nginx.template",
+      })
+
+      assert(helpers.start_kong {
+        log_level             = "debug",
+        prefix                = "servroot2",
+        database              = strategy,
+        proxy_listen          = "0.0.0.0:9000, 0.0.0.0:9443 ssl",
+        admin_listen          = "0.0.0.0:9001",
+        db_update_frequency   = POLL_INTERVAL,
+        db_update_propagation = db_update_propagation,
+      })
+
+      admin_client_1 = helpers.http_client("127.0.0.1", 8001)
+      admin_client_2 = helpers.http_client("127.0.0.1", 9001)
+      proxy_client_1 = helpers.http_client("127.0.0.1", 8000)
+      proxy_client_2 = helpers.http_client("127.0.0.1", 9000)
+
+      wait_for_propagation = function()
+        ngx.sleep(POLL_INTERVAL * 2 + db_update_propagation * 2)
+      end
+    end)
+
+    teardown(function()
+      helpers.stop_kong("servroot1", true)
+      helpers.stop_kong("servroot2", true)
+    end)
+
+    before_each(function()
+      admin_client_1 = helpers.http_client("127.0.0.1", 8001)
+      admin_client_2 = helpers.http_client("127.0.0.1", 9001)
+      proxy_client_1 = helpers.http_client("127.0.0.1", 8000)
+      proxy_client_2 = helpers.http_client("127.0.0.1", 9000)
+    end)
+
+    after_each(function()
+      admin_client_1:close()
+      admin_client_2:close()
+      proxy_client_1:close()
+      proxy_client_2:close()
+    end)
+
+    describe("plugins_map:version", function()
+      local service_plugin_id, version_1, version_2
+
+      it("is created at startup", function()
+        local admin_res_1 = assert(admin_client_1:send {
+          method = "GET",
+          path   = "/cache/plugins_map:version",
+        })
+        local body_1 = assert.res_status(200, admin_res_1)
+        local msg_1  = cjson.decode(body_1)
+
+        local admin_res_2 = assert(admin_client_2:send {
+          method = "GET",
+          path   = "/cache/plugins_map:version",
+        })
+        local body_2 = assert.res_status(200, admin_res_2)
+        local msg_2  = cjson.decode(body_2)
+
+        assert.equal("init", msg_1.message)
+        assert.equal("init", msg_2.message)
+      end)
+
+      it("is invalidated on plugin creation", function()
+        -- create Plugin
+
+        local admin_res_plugin = assert(admin_client_1:send {
+          method = "POST",
+          path   = "/plugins",
+          body   = {
+            name    = "dummy",
+            service = { id = service_fixture.id },
+          },
+          headers = {
+            ["Content-Type"] = "application/json",
+          },
+        })
+        local body = assert.res_status(201, admin_res_plugin)
+        local plugin = cjson.decode(body)
+        service_plugin_id = plugin.id
+
+        local admin_res_1 = assert(admin_client_1:send {
+          method = "GET",
+          path   = "/cache/plugins_map:version",
+        })
+        assert.res_status(404, admin_res_1)
+
+        wait_for_propagation()
+
+        local admin_res_2 = assert(admin_client_2:send {
+          method = "GET",
+          path   = "/cache/plugins_map:version",
+        })
+        assert.res_status(404, admin_res_2)
+      end)
+
+      local admin_res = assert(admin_client_1:send {
+        method  = "POST",
+        path    = "/routes",
+        body    = {
+          protocols = { "http" },
+          hosts     = { "dummy.com" },
+          service   = {
+            id = service_fixture.id,
+          }
+        },
+        headers = {
+          ["Content-Type"] = "application/json",
+        },
+      })
+      assert.res_status(201, admin_res)
+
+      it("is created on proxied request", function()
+        local res_1 = assert(proxy_client_1:send {
+          method  = "GET",
+          path    = "/status/200",
+          headers = {
+            host = "dummy.com",
+          }
+        })
+        assert.res_status(200, res_1)
+
+        local admin_res_1 = assert(admin_client_1:send {
+          method = "GET",
+          path   = "/cache/plugins_map:version",
+        })
+        local body_1 = assert.res_status(200, admin_res_1)
+        local msg_1  = cjson.decode(body_1)
+
+        assert.matches("^[%w-]+$", msg_1.message)
+        version_1 = msg_1.message
+
+        wait_for_propagation()
+
+        local admin_res_2 = assert(admin_client_2:send {
+          method = "GET",
+          path   = "/cache/plugins_map:version",
+        })
+        assert.res_status(404, admin_res_2)
+
+        local res_2 = assert(proxy_client_2:send {
+          method  = "GET",
+          path    = "/status/200",
+          headers = {
+            host = "dummy.com",
+          }
+        })
+        assert.res_status(200, res_2)
+
+        local admin_res_2 = assert(admin_client_2:send {
+          method = "GET",
+          path   = "/cache/plugins_map:version",
+        })
+        local body_2 = assert.res_status(200, admin_res_2)
+        local msg_2  = cjson.decode(body_2)
+
+        assert.matches("^[%w-]+$", msg_2.message)
+        version_2 = msg_2.message
+
+        -- each node has their own map version
+        assert.not_equal(msg_1.message, msg_2.message)
+      end)
+
+      it("is not invalidated on plugin update", function()
+        local admin_res_plugin = assert(admin_client_1:send {
+          method = "PATCH",
+          path   = "/plugins/" .. service_plugin_id,
+          body   = {
+            ["config.resp_header_value"] = "2",
+          },
+          headers = {
+            ["Content-Type"] = "application/json",
+          },
+        })
+        assert.res_status(200, admin_res_plugin)
+
+        wait_for_propagation()
+
+        local admin_res_1 = assert(admin_client_1:send {
+          method = "GET",
+          path   = "/cache/plugins_map:version",
+        })
+        local body_1 = assert.res_status(200, admin_res_1)
+        local msg_1  = cjson.decode(body_1)
+        assert.equal(version_1, msg_1.message)
+
+        local admin_res_2 = assert(admin_client_2:send {
+          method = "GET",
+          path   = "/cache/plugins_map:version",
+        })
+        local body_2 = assert.res_status(200, admin_res_2)
+        local msg_2  = cjson.decode(body_2)
+        assert.equal(version_2, msg_2.message)
+      end)
+
+      it("is invalidated on plugin delete", function()
+        local admin_res_plugin = assert(admin_client_1:send {
+          method = "DELETE",
+          path   = "/plugins/" .. service_plugin_id,
+        })
+        assert.res_status(204, admin_res_plugin)
+
+        local admin_res_1 = assert(admin_client_1:send {
+          method = "GET",
+          path   = "/cache/plugins_map:version",
+        })
+        assert.res_status(404, admin_res_1)
+
+        wait_for_propagation()
+
+        local admin_res_2 = assert(admin_client_2:send {
+          method = "GET",
+          path   = "/cache/plugins_map:version",
+        })
+        assert.res_status(404, admin_res_2)
+      end)
+    end)
+  end)
+end

--- a/spec/02-integration/06-invalidations/03-plugins_map_invalidation_spec.lua
+++ b/spec/02-integration/06-invalidations/03-plugins_map_invalidation_spec.lua
@@ -64,8 +64,8 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     teardown(function()
-      helpers.stop_kong("servroot1", true)
-      helpers.stop_kong("servroot2", true)
+      helpers.stop_kong("servroot1")
+      helpers.stop_kong("servroot2")
     end)
 
     before_each(function()


### PR DESCRIPTION
### Summary

Reduce the number of invocations of the plugins iterator by attempting
to load configurations only for plugins we know are configured on the
cluster. A map of distinct names of configs plugins is maintained by
iterating over each row in the plugins table. Plugins CRUD events are
handled and delete a node cache entry representing the current version
of the plugins map; in the request path this value is used to determine
if a rebuild of the map is necessary. This logic mimics that of the
router rebuild mechanism. Additionally, plugin maps rebuilds are wrapped
in a worker-level mutex (implemented via ngx.semaphore); this prevents
stampeding database connections during rebuild events in high-concurrency
situations.

### Full Changelog

* Execute iterator only on configured plugins
* Add integration test to validate plugin map cache key invalidation