### PR TITLE
chore(deps) bump kong-prometheus-plugin to 0.2

### DIFF
--- a/kong-0.14.1-0.rockspec
+++ b/kong-0.14.1-0.rockspec
@@ -38,7 +38,7 @@ dependencies = {
   "kong-plugin-azure-functions ~> 0.1",
   "kong-plugin-zipkin ~> 0.0",
   "kong-plugin-serverless-functions ~> 0.1",
-  "kong-prometheus-plugin ~> 0.1",
+  "kong-prometheus-plugin ~> 0.2",
 }
 build = {
   type = "builtin",


### PR DESCRIPTION
See 0.2.0 changelog:
https://github.com/Kong/kong-plugin-prometheus/blob/master/CHANGELOG.md#020---20180924

### Summary

Bump and pin Prometheus plugin to 0.2.0

The change is going into the `next` branch since some redundant metrics are being dropped.
