### PR TITLE
tests(helpers) add manual collectgarbage call when kong is stopped

### DIFF
--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -1245,6 +1245,9 @@ return {
     if not preserve_prefix then
       clean_prefix(prefix)
     end
+
+    collectgarbage()
+
     return ok, err
   end,
   -- Only use in CLI tests from spec/02-integration/01-cmd


### PR DESCRIPTION
### Summary

This helps with a random tests halting infinitely issue when spinning up UDP servers with llthreads2.ex and luasocket.