### PR TITLE
test(tcp-log-plugin) fix flaky test

### DIFF
--- a/spec/03-plugins/01-tcp-log/01-tcp-log_spec.lua
+++ b/spec/03-plugins/01-tcp-log/01-tcp-log_spec.lua
@@ -100,7 +100,15 @@ for _, strategy in helpers.each_strategy() do
       local log_message = cjson.decode(res)
 
       assert.True(log_message.latencies.proxy < 3000)
-      assert.True(log_message.latencies.request >= log_message.latencies.kong + log_message.latencies.proxy)
+
+      -- Sometimes there's a split milisecond that makes numbers not
+      -- add up by 1. Adding an artificial 1 to make the test
+      -- resilient to those.
+      local is_latencies_sum_adding_up =
+        1+log_message.latencies.request >= log_message.latencies.kong +
+        log_message.latencies.proxy
+
+      assert.True(is_latencies_sum_adding_up)
     end)
 
     it("performs a TLS handshake on the remote TCP server", function()

--- a/spec/03-plugins/02-udp-log/01-udp-log_spec.lua
+++ b/spec/03-plugins/02-udp-log/01-udp-log_spec.lua
@@ -64,6 +64,9 @@ for _, strategy in helpers.each_strategy() do
 
       assert.True(log_message.latencies.proxy < 3000)
 
+      -- Sometimes there's a split milisecond that makes numbers not
+      -- add up by 1. Adding an artificial 1 to make the test
+      -- resilient to those.
       local is_latencies_sum_adding_up =
         1+log_message.latencies.request >= log_message.latencies.kong +
         log_message.latencies.proxy


### PR DESCRIPTION
In some cases, there's 1 split ms that makes the test fail.
Allowing for 1 extra ms.