### PR TITLE
 feat(db) add pg_timeout configuration parameter to postgres strategy

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -332,6 +332,9 @@
 
 #pg_host = 127.0.0.1             # The PostgreSQL host to connect to.
 #pg_port = 5432                  # The port to connect to.
+#pg_timeout = 5000               # Defines the timeout (in ms), for connecting,
+                                 # reading and writing.
+
 #pg_user = kong                  # The username to authenticate if required.
 #pg_password =                   # The password to authenticate if required.
 #pg_database = kong              # The database name to connect to.

--- a/kong/cmd/migrations.lua
+++ b/kong/cmd/migrations.lua
@@ -74,9 +74,11 @@ local function execute(args)
   end
 
   local conf = assert(conf_loader(args.conf))
+
+  conf.pg_timeout = args.db_timeout -- connect + send + read
+
   conf.cassandra_timeout = args.db_timeout -- connect + send + read
   conf.cassandra_schema_consensus_timeout = args.db_timeout
-  -- TODO: no support for custom pgmoon timeout
 
   local db = DB.new(conf)
   assert(db:init_connector())

--- a/kong/cmd/start.lua
+++ b/kong/cmd/start.lua
@@ -15,9 +15,10 @@ local function execute(args)
     prefix = args.prefix
   }))
 
+  conf.pg_timeout = args.db_timeout -- connect + send + read
+
   conf.cassandra_timeout = args.db_timeout -- connect + send + read
   conf.cassandra_schema_consensus_timeout = args.db_timeout
-  -- TODO: no support for custom pgmoon timeout
 
   assert(not kill.is_running(conf.nginx_pid),
          "Kong is already running in " .. conf.prefix)

--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -104,6 +104,7 @@ local CONF_INFERENCES = {
 
   database = { enum = { "postgres", "cassandra" }  },
   pg_port = { typ = "number" },
+  pg_timeout = { typ = "number" },
   pg_password = { typ = "string" },
   pg_ssl = { typ = "boolean" },
   pg_ssl_verify = { typ = "boolean" },

--- a/kong/dao/db/postgres.lua
+++ b/kong/dao/db/postgres.lua
@@ -58,6 +58,7 @@ function _M.new(kong_config)
   self.query_options = {
     host = kong_config.pg_host,
     port = kong_config.pg_port,
+    timeout = kong_config.pg_timeout,
     user = kong_config.pg_user,
     password = kong_config.pg_password,
     database = kong_config.pg_database,
@@ -354,6 +355,11 @@ end
 function _M:query(query, schema)
   local conn_opts = query_opts(self)
   local pg = pgmoon.new(conn_opts)
+
+  if conn_opts.timeout then
+    pg:settimeout(conn_opts.timeout)
+  end
+
   local ok, err = pg:connect()
   if not ok then
     return nil, Errors.db(err)
@@ -621,6 +627,10 @@ end
 function _M:reachable()
   local conn_opts = query_opts(self)
   local pg = pgmoon.new(conn_opts)
+
+  if conn_opts.timeout then
+    pg:settimeout(conn_opts.timeout)
+  end
 
   local ok, err = pg:connect()
   if not ok then

--- a/kong/db/strategies/cassandra/connector.lua
+++ b/kong/db/strategies/cassandra/connector.lua
@@ -157,11 +157,16 @@ end
 
 
 function CassandraConnector:infos()
+  local db_ver
+  if self.major_minor_version then
+    db_ver = extract_major_minor(self.major_minor_version)
+  end
+
   return {
     strategy = "Cassandra",
     db_name = self.keyspace,
     db_desc = "keyspace",
-    db_ver = self.major_minor_version or "unknown",
+    db_ver = db_ver or "unknown",
   }
 end
 

--- a/kong/db/strategies/postgres/connector.lua
+++ b/kong/db/strategies/postgres/connector.lua
@@ -138,6 +138,10 @@ local function connect(config)
   connection.convert_null = true
   connection.NULL         = null
 
+  if config.timeout then
+    connection:settimeout(config.timeout)
+  end
+
   local ok, err = connection:connect()
   if not ok then
     return nil, err
@@ -230,6 +234,7 @@ function _mt:init()
   if major < 10 then
     self.major_version       = tonumber(fmt("%u.%u", major, floor(ver / 100 % 100)))
     self.major_minor_version = fmt("%u.%u.%u", major, floor(ver / 100 % 100), ver % 100)
+
   else
     self.major_version       = major
     self.major_minor_version = fmt("%u.%u", major, ver % 100)
@@ -761,6 +766,7 @@ function _M.new(kong_config)
   local config = {
     host       = kong_config.pg_host,
     port       = kong_config.pg_port,
+    timeout    = kong_config.pg_timeout,
     user       = kong_config.pg_user,
     password   = kong_config.pg_password,
     database   = kong_config.pg_database,

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -39,6 +39,7 @@ database = postgres
 pg_host = 127.0.0.1
 pg_port = 5432
 pg_database = kong
+pg_timeout = 5000
 pg_user = kong
 pg_password = NONE
 pg_ssl = off

--- a/spec-old-api/kong_tests.conf
+++ b/spec-old-api/kong_tests.conf
@@ -12,6 +12,7 @@ dns_resolver = 8.8.8.8
 database = postgres
 pg_host = 127.0.0.1
 pg_port = 5432
+pg_timeout = 10000
 pg_database = kong_tests
 cassandra_keyspace = kong_tests
 cassandra_timeout = 10000

--- a/spec/01-unit/000-new-dao/05-cassandra_spec.lua
+++ b/spec/01-unit/000-new-dao/05-cassandra_spec.lua
@@ -1,0 +1,75 @@
+local connector = require "kong.db.strategies.cassandra.connector"
+
+
+describe("kong.db [#postgres] connector", function()
+  describe(":infos()", function()
+    it("returns infos db_ver always with two digit groups divided with dot (.)", function()
+      local infos = connector.infos{ major_version = 2, major_minor_version = "2.10" }
+      assert.same({
+        db_desc  = "keyspace",
+        db_ver   = "2.10",
+        strategy = "Cassandra",
+      }, infos)
+
+      infos = connector.infos{ major_version = 2, major_minor_version = "2.10.1" }
+      assert.same({
+        db_desc  = "keyspace",
+        db_ver   = "2.10",
+        strategy = "Cassandra",
+      }, infos)
+
+      infos = connector.infos{ major_version = 3, major_minor_version = "3.7" }
+      assert.same({
+        db_desc  = "keyspace",
+        db_ver   = "3.7",
+        strategy = "Cassandra",
+      }, infos)
+    end)
+
+    it("returns infos with db_ver as \"unknown\" when missing major_minor_version", function()
+      local infos = connector.infos{ major_version = 2 }
+      assert.same({
+        db_desc  = "keyspace",
+        db_ver   = "unknown",
+        strategy = "Cassandra",
+      }, infos)
+
+      infos = connector.infos{ major_version = 3 }
+      assert.same({
+        db_desc  = "keyspace",
+        db_ver   = "unknown",
+        strategy = "Cassandra",
+      }, infos)
+
+      infos = connector.infos{}
+      assert.same({
+        db_desc  = "keyspace",
+        db_ver   = "unknown",
+        strategy = "Cassandra",
+      }, infos)
+    end)
+
+    it("returns infos with db_ver as \"unknown\" when invalid major_minor_version", function()
+      local infos = connector.infos{ major_version = 2, major_minor_version = "invalid" }
+      assert.same({
+        db_desc  = "keyspace",
+        db_ver   = "unknown",
+        strategy = "Cassandra",
+      }, infos)
+
+      infos = connector.infos{ major_version = 3, major_minor_version = "invalid" }
+      assert.same({
+        db_desc  = "keyspace",
+        db_ver   = "unknown",
+        strategy = "Cassandra",
+      }, infos)
+
+      infos = connector.infos{ major_minor_version = "invalid" }
+      assert.same({
+        db_desc  = "keyspace",
+        db_ver   = "unknown",
+        strategy = "Cassandra",
+      }, infos)
+    end)
+  end)
+end)

--- a/spec/01-unit/000-new-dao/05-cassandra_spec.lua
+++ b/spec/01-unit/000-new-dao/05-cassandra_spec.lua
@@ -1,7 +1,7 @@
 local connector = require "kong.db.strategies.cassandra.connector"
 
 
-describe("kong.db [#postgres] connector", function()
+describe("kong.db [#cassandra] connector", function()
   describe(":infos()", function()
     it("returns infos db_ver always with two digit groups divided with dot (.)", function()
       local infos = connector.infos{ major_version = 2, major_minor_version = "2.10" }

--- a/spec/01-unit/000-new-dao/06-postgres_spec.lua
+++ b/spec/01-unit/000-new-dao/06-postgres_spec.lua
@@ -1,0 +1,94 @@
+local config = {
+  pg_database = "kong"
+}
+
+
+local connector = require "kong.db.strategies.postgres.connector".new(config)
+
+
+describe("kong.db [#postgres] connector", function()
+  describe(":infos()", function()
+    it("returns infos db_ver always with two digit groups divided with dot (.)", function()
+      local infos = connector.infos{ major_version = 9, major_minor_version = "9.5", config = config }
+      assert.same({
+        db_desc  = "database",
+        db_ver   = "9.5",
+        strategy = "PostgreSQL",
+      }, infos)
+
+      local infos = connector.infos{ major_version = 9.5, major_minor_version = "9.5", config = config }
+      assert.same({
+        db_desc  = "database",
+        db_ver   = "9.5",
+        strategy = "PostgreSQL",
+      }, infos)
+
+      infos = connector.infos{ major_version = 9, major_minor_version = "9.5.1", config = config }
+      assert.same({
+        db_desc  = "database",
+        db_ver   = "9.5",
+        strategy = "PostgreSQL",
+      }, infos)
+
+      infos = connector.infos{ major_version = 9.5, major_minor_version = "9.5.1", config = config }
+      assert.same({
+        db_desc  = "database",
+        db_ver   = "9.5",
+        strategy = "PostgreSQL",
+      }, infos)
+
+      infos = connector.infos{ major_version = 10, major_minor_version = "10.5", config = config }
+      assert.same({
+        db_desc  = "database",
+        db_ver   = "10.5",
+        strategy = "PostgreSQL",
+      }, infos)
+    end)
+
+    it("returns infos with db_ver as \"unknown\" when missing major_minor_version", function()
+      local infos = connector.infos{ major_version = 9, config = config }
+      assert.same({
+        db_desc  = "database",
+        db_ver   = "unknown",
+        strategy = "PostgreSQL",
+      }, infos)
+
+      infos = connector.infos{ major_version = 10, config = config }
+      assert.same({
+        db_desc  = "database",
+        db_ver   = "unknown",
+        strategy = "PostgreSQL",
+      }, infos)
+
+      infos = connector.infos{ config = config }
+      assert.same({
+        db_desc  = "database",
+        db_ver   = "unknown",
+        strategy = "PostgreSQL",
+      }, infos)
+    end)
+
+    it("returns infos with db_ver as \"unknown\" when invalid major_minor_version", function()
+      local infos = connector.infos{ major_version = 9, major_minor_version = "invalid", config = config }
+      assert.same({
+        db_desc  = "database",
+        db_ver   = "unknown",
+        strategy = "PostgreSQL",
+      }, infos)
+
+      infos = connector.infos{ major_version = 10, major_minor_version = "invalid", config = config }
+      assert.same({
+        db_desc  = "database",
+        db_ver   = "unknown",
+        strategy = "PostgreSQL",
+      }, infos)
+
+      infos = connector.infos{ major_minor_version = "invalid", config = config }
+      assert.same({
+        db_desc  = "database",
+        db_ver   = "unknown",
+        strategy = "PostgreSQL",
+      }, infos)
+    end)
+  end)
+end)

--- a/spec/02-integration/03-dao/02-migrations_spec.lua
+++ b/spec/02-integration/03-dao/02-migrations_spec.lua
@@ -137,16 +137,19 @@ helpers.for_each_dao(function(kong_config)
     describe("errors", function()
       it("returns errors prefixed by the DB type in __tostring()", function()
         local pg_port = kong_config.pg_port
+        local pg_timeout = kong_config.pg_timeout
         local cassandra_port = kong_config.cassandra_port
         local cassandra_timeout = kong_config.cassandra_timeout
         finally(function()
           kong_config.pg_port = pg_port
+          kong_config.pg_timeout = pg_timeout
           kong_config.cassandra_port = cassandra_port
           kong_config.cassandra_timeout = cassandra_timeout
           ngx.shared.kong_cassandra:flush_all()
           ngx.shared.kong_cassandra:flush_expired()
         end)
         kong_config.pg_port = 3333
+        kong_config.pg_timeout = 1000
         kong_config.cassandra_port = 3333
         kong_config.cassandra_timeout = 1000
 

--- a/spec/02-integration/03-dao/03-crud_spec.lua
+++ b/spec/02-integration/03-dao/03-crud_spec.lua
@@ -771,16 +771,19 @@ helpers.for_each_dao(function(kong_config)
     describe("errors", function()
       it("returns errors prefixed by the DB type in __tostring()", function()
         local pg_port = kong_config.pg_port
+        local pg_timeout = kong_config.pg_timeout
         local cassandra_port = kong_config.cassandra_port
         local cassandra_timeout = kong_config.cassandra_timeout
         finally(function()
           kong_config.pg_port = pg_port
+          kong_config.pg_timeout = pg_timeout
           kong_config.cassandra_port = cassandra_port
           kong_config.cassandra_timeout = cassandra_timeout
           ngx.shared.kong_cassandra:flush_all()
           ngx.shared.kong_cassandra:flush_expired()
         end)
         kong_config.pg_port = 3333
+        kong_config.pg_timeout = 1000
         kong_config.cassandra_port = 3333
         kong_config.cassandra_timeout = 1000
 

--- a/spec/fixtures/headers.conf
+++ b/spec/fixtures/headers.conf
@@ -12,6 +12,7 @@ dns_resolver = 8.8.8.8
 database = postgres
 pg_host = 127.0.0.1
 pg_port = 5432
+pg_timeout = 10000
 pg_database = kong_tests
 cassandra_keyspace = kong_tests
 cassandra_timeout = 10000

--- a/spec/kong_tests.conf
+++ b/spec/kong_tests.conf
@@ -12,6 +12,7 @@ dns_resolver = 8.8.8.8
 database = postgres
 pg_host = 127.0.0.1
 pg_port = 5432
+pg_timeout = 10000
 pg_database = kong_tests
 cassandra_keyspace = kong_tests
 cassandra_timeout = 10000


### PR DESCRIPTION
### Summary

Adds support for `pg_timeout` configuration parameter. Also fixes `major_minor_version` of Postgres according to Postgres versioning policy: https://www.postgresql.org/support/versioning/.