### PR TITLE
refactor(api) make deactivated endpoints more declarative

### DIFF
--- a/kong/api/endpoints.lua
+++ b/kong/api/endpoints.lua
@@ -520,7 +520,17 @@ local function generate_endpoints(schema, endpoints)
 end
 
 
+-- A reusable handler for endpoints that are deactivated
+-- (e.g. /targets/:targets)
+local not_found = {
+  before = function()
+    return responses.send_HTTP_NOT_FOUND()
+  end
+}
+
+
 local Endpoints = {
+  not_found = not_found,
   handle_error = handle_error,
   get_page_size = get_page_size,
   select_entity = select_entity,

--- a/kong/api/routes/snis.lua
+++ b/kong/api/routes/snis.lua
@@ -1,8 +1,7 @@
+local endpoints = require "kong.api.endpoints"
+
+
 return {
   -- deactivate endpoint (use /certificates/sni instead)
-  ["/snis/:snis/certificate"] = {
-    before = function(self, db, helpers)
-      return helpers.responses.send_HTTP_NOT_FOUND()
-    end
-  },
+  ["/snis/:snis/certificate"] = endpoints.not_found,
 }

--- a/kong/api/routes/targets.lua
+++ b/kong/api/routes/targets.lua
@@ -1,18 +1,9 @@
-local responses = require "kong.tools.responses"
+local endpoints = require "kong.api.endpoints"
 
-local not_found = function()
-  return responses.send_HTTP_NOT_FOUND()
-end
 
 return {
   -- deactivate endpoints (use /upstream/{upstream}/targets instead)
-  ["/targets"] = {
-    before = not_found,
-  },
-  ["/targets/:targets"] = {
-    before = not_found,
-  },
-  ["/targets/:targets/upstream"] = {
-    before = not_found,
-  }
+  ["/targets"] = endpoints.not_found,
+  ["/targets/:targets"] = endpoints.not_found,
+  ["/targets/:targets/upstream"] = endpoints.not_found,
 }


### PR DESCRIPTION
This is a minor refactor that adds a utility function `endpoints.not_found` to be used when overriding an auto-generated endpoint to make it return 404 at all times.

This causes no functional change, but makes the specifications a bit more declarative, which makes it easier to inspect for deactivated endpoints.
