### PR TITLE
renaming internal `balancer_data` structure

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -532,7 +532,7 @@ function Kong.balancer()
     -- Report HTTP status for health checks
     local balancer = proxy.balancer
     if balancer then
-      local ip, port = proxy.resolved_ip, proxy.resolved_port
+      local ip, port = request_out.resolved_ip, request_out.resolved_port
 
       if previous_try.state == "failed" then
         if previous_try.code == 504 then

--- a/kong/pdk/service.lua
+++ b/kong/pdk/service.lua
@@ -58,7 +58,7 @@ local function new()
       return nil, "could not find an Upstream named '" .. host .. "'"
     end
 
-    ngx.ctx.balancer_data.host = host
+    ngx.ctx.proxy_request_state.request_out.host = host
     return true
   end
 
@@ -95,8 +95,8 @@ local function new()
     end
 
     ngx.var.upstream_host = host
-    ngx.ctx.balancer_data.host = host
-    ngx.ctx.balancer_data.port = port
+    ngx.ctx.proxy_request_state.request_out.host = host
+    ngx.ctx.proxy_request_state.request_out.port = port
   end
 
 

--- a/kong/plugins/datadog/handler.lua
+++ b/kong/plugins/datadog/handler.lua
@@ -161,8 +161,9 @@ end
 function DatadogHandler:log(conf)
   DatadogHandler.super.log(self)
 
-  if not ngx.ctx.service and
-     not ngx.ctx.api     then
+  local routing = ngx.ctx.proxy_request_state.routing
+  if not routing.service and
+     not routing.api     then
     return
   end
 

--- a/kong/plugins/log-serializers/basic.lua
+++ b/kong/plugins/log-serializers/basic.lua
@@ -8,6 +8,8 @@ function _M.serialize(ngx)
   local ctx = ngx.ctx
   local var = ngx.var
   local req = ngx.req
+  local proxy_request_state = ctx.proxy_request_state or EMPTY
+  local routing = proxy_request_state.routing or EMPTY
 
   local authenticated_entity
   if ctx.authenticated_credential ~= nil then
@@ -34,7 +36,7 @@ function _M.serialize(ngx)
       headers = ngx.resp.get_headers(),
       size = var.bytes_sent
     },
-    tries = (ctx.balancer_data or EMPTY).tries,
+    tries = ((ctx.proxy_request_state or EMPTY).proxy or EMPTY).try_data,
     latencies = {
       kong = (ctx.KONG_ACCESS_TIME or 0) +
              (ctx.KONG_RECEIVE_TIME or 0) +
@@ -44,9 +46,9 @@ function _M.serialize(ngx)
       request = var.request_time * 1000
     },
     authenticated_entity = authenticated_entity,
-    route = ctx.route,
-    service = ctx.service,
-    api = ctx.api,
+    route = routing.route,
+    service = routing.service,
+    api = routing.api,
     consumer = ctx.authenticated_consumer,
     client_ip = var.remote_addr,
     started_at = req.start_time() * 1000

--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -668,7 +668,7 @@ local create_hash = function(upstream, ctx)
 
         identifier = utils.uuid()
 
-        ctx.proxy_request_data.proxy.hash_cookie = {
+        ctx.proxy_request_state.proxy.hash_cookie = {
           key = upstream.hash_on_cookie,
           value = identifier,
           path = upstream.hash_on_cookie_path

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1055,9 +1055,9 @@ protect_table(ctx.proxy_request_state)
       local proxy_request_state = ctx.proxy_request_state
       if proxy_request_state and
          proxy_request_state.proxy.balancer and
-         proxy_request_state.resolved_ip then
-        local ip   = proxy_request_state.resolved_ip
-        local port = proxy_request_state.resolved_port
+         proxy_request_state.request_out.resolved_ip then
+        local ip   = proxy_request_state.request_out.resolved_ip
+        local port = proxy_request_state.request_out.resolved_port
 
         local status = ngx.status
         if status == 504 then

--- a/kong/runloop/plugins_iterator.lua
+++ b/kong/runloop/plugins_iterator.lua
@@ -2,6 +2,9 @@ local kong         = kong
 local setmetatable = setmetatable
 
 
+local EMPTY = {}
+
+
 -- Loads a plugin config from the datastore.
 -- @return plugin config table or an empty sentinel table in case of a db-miss
 local function load_plugin_into_memory(key)
@@ -204,12 +207,14 @@ local function iter_plugins_for_req(ctx, loaded_plugins, configured_plugins,
     ctx.plugins_for_request = {}
   end
 
+  local routing = (ctx.proxy_request_state or EMPTY).routing or EMPTY
+
   local plugin_iter_state = {
     i                     = 0,
     ctx                   = ctx,
-    api                   = ctx.api,
-    route                 = ctx.route,
-    service               = ctx.service,
+    api                   = routing.api,
+    route                 = routing.route,
+    service               = routing.service,
     loaded_plugins        = loaded_plugins,
     configured_plugins    = configured_plugins,
     access_or_cert_ctx    = access_or_cert_ctx,

--- a/spec/01-unit/011-balancer_spec.lua
+++ b/spec/01-unit/011-balancer_spec.lua
@@ -318,7 +318,9 @@ describe("Balancer", function()
 
     it("balancer and healthchecker match; remove and re-add", function()
       local my_balancer = assert(balancer._get_balancer({
-        host = "upstream_e"
+        request_out = {
+          host = "upstream_e",
+        },
       }, true))
       local target_history = {
         { name = "127.0.0.1", port = 2112, order = "1000:e1", weight = 10 },
@@ -334,7 +336,9 @@ describe("Balancer", function()
 
     it("balancer and healthchecker match; remove and not re-add", function()
       local my_balancer = assert(balancer._get_balancer({
-        host = "upstream_f"
+        request_out = {
+          host = "upstream_f",
+        },
       }, true))
       local target_history = {
         { name = "127.0.0.1", port = 5150, order = "1000:f1", weight = 10 },
@@ -565,23 +569,23 @@ describe("Balancer", function()
       it("uses the cookie when present in the request", function()
         local value = "some cookie value"
         ngx.var.cookie_Foo = value
-        ngx.ctx.balancer_data = {}
+        ngx.ctx.proxy_request_data = { proxy = {} }
         local hash = balancer._create_hash({
           hash_on = "cookie",
           hash_on_cookie = "Foo",
         })
         assert.are.same(crc32(value), hash)
-        assert.is_nil(ngx.ctx.balancer_data.hash_cookie)
+        assert.is_nil(ngx.ctx.proxy_request_data.proxy.hash_cookie)
       end)
       it("creates the cookie when not present in the request", function()
-        ngx.ctx.balancer_data = {}
+        ngx.ctx.proxy_request_data = { proxy = {} }
         balancer._create_hash({
           hash_on = "cookie",
           hash_on_cookie = "Foo",
           hash_on_cookie_path = "/",
         })
-        assert.are.same(ngx.ctx.balancer_data.hash_cookie.key, "Foo")
-        assert.are.same(ngx.ctx.balancer_data.hash_cookie.path, "/")
+        assert.are.same(ngx.ctx.proxy_request_data.proxy.hash_cookie.key, "Foo")
+        assert.are.same(ngx.ctx.proxy_request_data.proxy.hash_cookie.path, "/")
       end)
     end)
     it("multi-header", function()
@@ -644,25 +648,25 @@ describe("Balancer", function()
         it("uses the cookie when present in the request", function()
           local value = "some cookie value"
           ngx.var.cookie_Foo = value
-          ngx.ctx.balancer_data = {}
+          ngx.ctx.proxy_request_data = { proxy = {} }
           local hash = balancer._create_hash({
             hash_on = "consumer",
             hash_fallback = "cookie",
             hash_on_cookie = "Foo",
           })
           assert.are.same(crc32(value), hash)
-          assert.is_nil(ngx.ctx.balancer_data.hash_cookie)
+          assert.is_nil(ngx.ctx.proxy_request_data.proxy.hash_cookie)
         end)
         it("creates the cookie when not present in the request", function()
-          ngx.ctx.balancer_data = {}
+          ngx.ctx.proxy_request_data = { proxy = {} }
           balancer._create_hash({
             hash_on = "consumer",
             hash_fallback = "cookie",
             hash_on_cookie = "Foo",
             hash_on_cookie_path = "/",
           })
-          assert.are.same(ngx.ctx.balancer_data.hash_cookie.key, "Foo")
-          assert.are.same(ngx.ctx.balancer_data.hash_cookie.path, "/")
+          assert.are.same(ngx.ctx.proxy_request_data.proxy.hash_cookie.key, "Foo")
+          assert.are.same(ngx.ctx.proxy_request_data.proxy.hash_cookie.path, "/")
         end)
       end)
     end)

--- a/spec/01-unit/011-balancer_spec.lua
+++ b/spec/01-unit/011-balancer_spec.lua
@@ -569,23 +569,23 @@ describe("Balancer", function()
       it("uses the cookie when present in the request", function()
         local value = "some cookie value"
         ngx.var.cookie_Foo = value
-        ngx.ctx.proxy_request_data = { proxy = {} }
+        ngx.ctx.proxy_request_state = { proxy = {} }
         local hash = balancer._create_hash({
           hash_on = "cookie",
           hash_on_cookie = "Foo",
         })
         assert.are.same(crc32(value), hash)
-        assert.is_nil(ngx.ctx.proxy_request_data.proxy.hash_cookie)
+        assert.is_nil(ngx.ctx.proxy_request_state.proxy.hash_cookie)
       end)
       it("creates the cookie when not present in the request", function()
-        ngx.ctx.proxy_request_data = { proxy = {} }
+        ngx.ctx.proxy_request_state = { proxy = {} }
         balancer._create_hash({
           hash_on = "cookie",
           hash_on_cookie = "Foo",
           hash_on_cookie_path = "/",
         })
-        assert.are.same(ngx.ctx.proxy_request_data.proxy.hash_cookie.key, "Foo")
-        assert.are.same(ngx.ctx.proxy_request_data.proxy.hash_cookie.path, "/")
+        assert.are.same(ngx.ctx.proxy_request_state.proxy.hash_cookie.key, "Foo")
+        assert.are.same(ngx.ctx.proxy_request_state.proxy.hash_cookie.path, "/")
       end)
     end)
     it("multi-header", function()
@@ -648,25 +648,25 @@ describe("Balancer", function()
         it("uses the cookie when present in the request", function()
           local value = "some cookie value"
           ngx.var.cookie_Foo = value
-          ngx.ctx.proxy_request_data = { proxy = {} }
+          ngx.ctx.proxy_request_state = { proxy = {} }
           local hash = balancer._create_hash({
             hash_on = "consumer",
             hash_fallback = "cookie",
             hash_on_cookie = "Foo",
           })
           assert.are.same(crc32(value), hash)
-          assert.is_nil(ngx.ctx.proxy_request_data.proxy.hash_cookie)
+          assert.is_nil(ngx.ctx.proxy_request_state.proxy.hash_cookie)
         end)
         it("creates the cookie when not present in the request", function()
-          ngx.ctx.proxy_request_data = { proxy = {} }
+          ngx.ctx.proxy_request_state = { proxy = {} }
           balancer._create_hash({
             hash_on = "consumer",
             hash_fallback = "cookie",
             hash_on_cookie = "Foo",
             hash_on_cookie_path = "/",
           })
-          assert.are.same(ngx.ctx.proxy_request_data.proxy.hash_cookie.key, "Foo")
-          assert.are.same(ngx.ctx.proxy_request_data.proxy.hash_cookie.path, "/")
+          assert.are.same(ngx.ctx.proxy_request_state.proxy.hash_cookie.key, "Foo")
+          assert.are.same(ngx.ctx.proxy_request_state.proxy.hash_cookie.path, "/")
         end)
       end)
     end)

--- a/spec/01-unit/012-log_serializer_spec.lua
+++ b/spec/01-unit/012-log_serializer_spec.lua
@@ -6,11 +6,13 @@ describe("Log Serializer", function()
   before_each(function()
     ngx = {
       ctx = {
-        balancer_data = {
-          tries = {
-            {
-              ip = "127.0.0.1",
-              port = 8000,
+        proxy_request_state = {
+          proxy = {
+            try_data = {
+              {
+                ip = "127.0.0.1",
+                port = 8000,
+              },
             },
           },
         },
@@ -77,8 +79,12 @@ describe("Log Serializer", function()
     end)
 
     it("serializes the matching Route and Services", function()
-      ngx.ctx.route = { id = "my_route" }
-      ngx.ctx.service = { id = "my_service" }
+      ngx.ctx.proxy_request_state = {
+        routing = {
+          route = { id = "my_route" },
+          service = { id = "my_service" },
+        },
+      }
 
       local res = basic.serialize(ngx)
       assert.is_table(res)
@@ -114,10 +120,14 @@ describe("Log Serializer", function()
     end)
 
     it("serializes the tries and failure information", function()
-      ngx.ctx.balancer_data.tries = {
-        { ip = "127.0.0.1", port = 1234, state = "next",   code = 502 },
-        { ip = "127.0.0.1", port = 1234, state = "failed", code = nil },
-        { ip = "127.0.0.1", port = 1234 },
+      ngx.ctx.proxy_request_state = {
+        proxy = {
+          try_data = {
+            { ip = "127.0.0.1", port = 1234, state = "next",   code = 502 },
+            { ip = "127.0.0.1", port = 1234, state = "failed", code = nil },
+            { ip = "127.0.0.1", port = 1234 },
+          },
+        },
       }
 
       local res = basic.serialize(ngx)
@@ -141,7 +151,7 @@ describe("Log Serializer", function()
     end)
 
     it("does not fail when the 'balancer_data' structure is missing", function()
-      ngx.ctx.balancer_data = nil
+      ngx.ctx.proxy_request_state = nil
 
       local res = basic.serialize(ngx)
       assert.is_table(res)

--- a/spec/01-unit/012-log_serializer_spec.lua
+++ b/spec/01-unit/012-log_serializer_spec.lua
@@ -150,7 +150,7 @@ describe("Log Serializer", function()
         }, res.tries)
     end)
 
-    it("does not fail when the 'balancer_data' structure is missing", function()
+    it("does not fail when the 'proxy_request_state' structure is missing", function()
       ngx.ctx.proxy_request_state = nil
 
       local res = basic.serialize(ngx)

--- a/spec/01-unit/016-dns_spec.lua
+++ b/spec/01-unit/016-dns_spec.lua
@@ -94,10 +94,14 @@ describe("DNS", function()
     }
 
     local ip, port, code = balancer.execute({
-      type = "name",
-      port = nil,
-      host = "konghq.com",
-      try_count = 0,
+      request_out = {
+        host_type = "name",
+        port = nil,
+        host = "konghq.com",
+      },
+      proxy = {
+        try_count = 0,
+      },
     })
     assert.is_nil(ip)
     assert.equals("name resolution failed", port)
@@ -113,10 +117,14 @@ describe("DNS", function()
     }
 
     local ip, port, code = balancer.execute({
-      type = "name",
-      port = nil,
-      host = "konghq.com",
-      try_count = 0,
+      request_out = {
+        host_type = "name",
+        port = nil,
+        host = "konghq.com",
+      },
+      proxy = {
+        try_count = 0,
+      },
     })
     assert.is_nil(ip)
     assert.equals("name resolution failed", port)

--- a/spec/02-integration/05-proxy/09-balancer_spec.lua
+++ b/spec/02-integration/05-proxy/09-balancer_spec.lua
@@ -1682,7 +1682,7 @@ for _, strategy in helpers.each_strategy() do
                   assert.is_nil(set_cookie)
                 end)
 
-                it("replies with Set-Cookie if cookie is not set", function()
+                it("#only replies with Set-Cookie if cookie is not set", function()
                   local requests = SLOTS * 2 -- go round the balancer twice
 
                   local upstream_name = add_upstream({

--- a/spec/fixtures/custom_plugins/kong/plugins/error-handler-log/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/error-handler-log/handler.lua
@@ -39,7 +39,8 @@ function ErrHandlerLog:header_filter(conf)
   ngx.header["Content-Length"] = nil
   ngx.header["Log-Plugin-Phases"] = table.concat(phases, ",")
 
-  ngx.header["Log-Plugin-Service-Matched"] = ngx.ctx.service and ngx.ctx.service.name
+  local service = ((ngx.ctx.proxy_request_state or {}).routing or {}).service
+  ngx.header["Log-Plugin-Service-Matched"] = service and service.name
 end
 
 

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -37,7 +37,7 @@ our $HttpConfig = <<_EOC_;
         function phase_check_functions(phase, skip_fnlist)
 
             -- mock balancer structure
-            ngx.ctx.balancer_data = {}
+            ngx.ctx.proxy_request_state = { request_out = {} }
 
             local mod
             do


### PR DESCRIPTION
The initial attempt to refactor the request construction (see #3744) is now phased into multiple PR's

First one being the refactor of the request path building (#3780 ), this is the second one where the internal structures are renamed and expanded. The routing properties will now be set AFTER the access phase.
