### PR TITLE
feat(migrations) 0.14.0 to 0.15.0 migrations with added checks

### DIFF
--- a/kong/cmd/migrations.lua
+++ b/kong/cmd/migrations.lua
@@ -67,7 +67,7 @@ end
 
 local function execute(args)
   args.db_timeout = args.db_timeout * 1000
-  args.lock_timeout = args.lock_timeout * 1000
+  args.lock_timeout = args.lock_timeout
 
   if args.quiet then
     log.disable()

--- a/kong/cmd/start.lua
+++ b/kong/cmd/start.lua
@@ -9,7 +9,7 @@ local DB = require "kong.db"
 
 local function execute(args)
   args.db_timeout = args.db_timeout * 1000
-  args.lock_timeout = args.lock_timeout * 1000
+  args.lock_timeout = args.lock_timeout
 
   local conf = assert(conf_loader(args.conf, {
     prefix = args.prefix

--- a/kong/db/init.lua
+++ b/kong/db/init.lua
@@ -739,20 +739,60 @@ do
                               self.strategy, mig.name)
         end
 
+        if t.subsystem == "core" and mig.name == "000_base" then
+          local res, err = self.connector:is_014()
+          if err then
+            return nil, fmt_err(self, "unable to detect database version (%s)",
+                                err)
+          end
+
+
+
+          if not res.is_eq_014 and not res.is_gt_014 then
+            if res.missing_migration then
+              return nil, fmt_err(self,
+                                  "Migration to 1.0 can only be performed "  ..
+                                  "from a 0.14.x %s %s, but the current "    ..
+                                  "one seems to be older (missing "          ..
+                                  "migration '%s' for '%s'). Migrate to "    ..
+                                  "0.14.x first, or install 1.0 on "         ..
+                                  "a fresh %s.",
+                                  self.strategy, self.infos.db_desc,
+                                  res.missing_migration, res.missing_component,
+                                  self.infos.db_desc)
+
+            elseif res.missing_component then
+              return nil, fmt_err(self,
+                                  "Migration to 1.0 can only be performed "  ..
+                                  "from a 0.14.x %s %s, but the current "    ..
+                                  "one seems to be older (missing "          ..
+                                  "migrations for '%s'). Migrate to 0.14.x " ..
+                                  "first, or install 1.0 on a fresh %s.",
+                                  self.strategy, self.infos.db_desc,
+                                  res.missing_component, self.infos.db_desc)
+            end
+
+            return nil, fmt_err(self,
+                                "Migration to 1.0 can only be performed "    ..
+                                "from a 0.14.x %s %s, but the current one "  ..
+                                "seems to be older (missing migrations)."    ..
+                                "Migrate to 0.14.x first, or install 1.0 "   ..
+                                "on a fresh %s.", self.strategy,
+                                self.infos.db_desc, self.infos.db_desc)
+          end
+        end
+
         log.debug("running migration: %s", mig.name)
 
         if run_up then
           -- kong migrations bootstrap
           -- kong migrations up
-
-          local ok, err = self.connector:run_up_migration(mig.name,
-                                                          strategy_migration.up)
+          ok, err = self.connector:run_up_migration(mig.name, strategy_migration.up)
           if not ok then
             self.connector:close()
             return nil, fmt_err(self, "failed to run migration '%s' up: %s",
                                 mig.name, err)
           end
-
 
           local state = "executed"
           if strategy_migration.teardown then
@@ -761,8 +801,7 @@ do
             n_pending = n_pending + 1
           end
 
-          local ok, err = self.connector:record_migration(t.subsystem,
-                                                          mig.name, state)
+          ok, err = self.connector:record_migration(t.subsystem, mig.name, state)
           if not ok then
             self.connector:close()
             return nil, fmt_err(self, "failed to record migration '%s': %s",
@@ -780,11 +819,9 @@ do
             self.connector:close()
             return nil, fmt_err(self, "failed to run migration '%s' teardown: %s",
                                 mig.name, perr or err)
-
           end
 
-          local ok, err = self.connector:record_migration(t.subsystem,
-                                                          mig.name, "teardown")
+          ok, err = self.connector:record_migration(t.subsystem, mig.name, "teardown")
           if not ok then
             self.connector:close()
             return nil, fmt_err(self, "failed to record migration '%s': %s",

--- a/kong/db/migrations/core/000_base.lua
+++ b/kong/db/migrations/core/000_base.lua
@@ -115,7 +115,7 @@ return {
         "custom_id"   TEXT                         UNIQUE
       );
 
-      CREATE INDEX IF NOT EXISTS username_idx ON "consumers" (LOWER("username"));
+      CREATE INDEX IF NOT EXISTS "username_idx" ON "consumers" (LOWER("username"));
 
 
 
@@ -165,7 +165,7 @@ return {
         "weight"       INTEGER                      NOT NULL
       );
 
-      CREATE INDEX IF NOT EXISTS "targets_target_idx"      ON "targets" ("target");
+      CREATE INDEX IF NOT EXISTS "targets_target_idx" ON "targets" ("target");
 
 
 

--- a/kong/db/migrations/core/001_14_to_15.lua
+++ b/kong/db/migrations/core/001_14_to_15.lua
@@ -47,23 +47,79 @@ return {
 
 
 
-      ALTER INDEX IF EXISTS "username_idx"               RENAME TO "consumers_username_idx";
-      ALTER INDEX IF EXISTS "ssl_certificates_pkey"      RENAME TO "certificates_pkey";
-      ALTER INDEX IF EXISTS "idx_cluster_events_at"      RENAME TO "cluster_events_at_idx";
-      ALTER INDEX IF EXISTS "idx_cluster_events_channel" RENAME TO "cluster_events_channel_idx";
-      ALTER INDEX IF EXISTS "routes_fkey_service"        RENAME TO "routes_service_id_idx";
-      ALTER INDEX IF EXISTS "snis_fkey_certificate"      RENAME TO "snis_certificate_id_idx";
-      ALTER INDEX IF EXISTS "plugins_api_idx"            RENAME TO "plugins_api_id_idx";
-      ALTER INDEX IF EXISTS "plugins_consumer_idx"       RENAME TO "plugins_consumer_id_idx";
+      DO $$
+      BEGIN
+        ALTER INDEX IF EXISTS "username_idx" RENAME TO "consumers_username_idx";
+      EXCEPTION WHEN DUPLICATE_TABLE THEN
+        -- Do nothing, accept existing state
+      END;
+      $$;
 
+      DO $$
+      BEGIN
+        ALTER INDEX IF EXISTS "ssl_certificates_pkey" RENAME TO "certificates_pkey";
+      EXCEPTION WHEN DUPLICATE_TABLE THEN
+        -- Do nothing, accept existing state
+      END;
+      $$;
 
+      DO $$
+      BEGIN
+        ALTER INDEX IF EXISTS "idx_cluster_events_at" RENAME TO "cluster_events_at_idx";
+      EXCEPTION WHEN DUPLICATE_TABLE THEN
+        -- Do nothing, accept existing state
+      END;
+      $$;
+
+      DO $$
+      BEGIN
+        ALTER INDEX IF EXISTS "idx_cluster_events_channel" RENAME TO "cluster_events_channel_idx";
+      EXCEPTION WHEN DUPLICATE_TABLE THEN
+        -- Do nothing, accept existing state
+      END;
+      $$;
+
+      DO $$
+      BEGIN
+        ALTER INDEX IF EXISTS "routes_fkey_service" RENAME TO "routes_service_id_idx";
+      EXCEPTION WHEN DUPLICATE_TABLE THEN
+        -- Do nothing, accept existing state
+      END;
+      $$;
+
+      DO $$
+      BEGIN
+        ALTER INDEX IF EXISTS "snis_fkey_certificate" RENAME TO "snis_certificate_id_idx";
+      EXCEPTION WHEN DUPLICATE_TABLE THEN
+        -- Do nothing, accept existing state
+      END;
+      $$;
+
+      DO $$
+      BEGIN
+        ALTER INDEX IF EXISTS "plugins_api_idx" RENAME TO "plugins_api_id_idx";
+      EXCEPTION WHEN DUPLICATE_TABLE THEN
+        -- Do nothing, accept existing state
+      END;
+      $$;
+
+      DO $$
+      BEGIN
+        ALTER INDEX IF EXISTS "plugins_consumer_idx" RENAME TO "plugins_consumer_id_idx";
+      EXCEPTION WHEN DUPLICATE_TABLE THEN
+        -- Do nothing, accept existing state
+      END;
+      $$;
 
       DO $$
       BEGIN
         ALTER TABLE IF EXISTS ONLY "snis"
           RENAME CONSTRAINT "snis_name_unique" TO "snis_name_key";
-      EXCEPTION WHEN UNDEFINED_OBJECT THEN
-        -- Do nothing, accept existing state
+      EXCEPTION
+        WHEN UNDEFINED_OBJECT THEN
+          -- Do nothing, accept existing state
+        WHEN DUPLICATE_TABLE THEN
+          -- Do nothing, accept existing state
       END;
       $$;
 
@@ -118,6 +174,8 @@ return {
           assert(connector:query(sql))
         end
       end
+
+      assert(connector:query('DROP TABLE IF EXISTS "schema_migrations" CASCADE;'))
     end,
   },
 
@@ -260,6 +318,7 @@ return {
       }))
 
       assert(connector:query("DROP TABLE IF EXISTS plugins_temp"))
+      assert(connector:query("DROP TABLE IF EXISTS schema_migrations"))
     end,
   },
 }

--- a/kong/db/strategies/cassandra/connector.lua
+++ b/kong/db/strategies/cassandra/connector.lua
@@ -841,6 +841,203 @@ do
 
     return true
   end
+
+
+  function CassandraConnector:is_014()
+    local rows, err = self:schema_migrations()
+    if err then
+      return nil, err
+    end
+
+    if rows and #rows > 0 then
+      return {
+        is_eq_014 = false,
+        is_gt_014 = true,
+      }
+    end
+
+    local needed_migrations = {
+      ["core"] = {
+        "2015-01-12-175310_skeleton",
+        "2015-01-12-175310_init_schema",
+        "2015-11-23-817313_nodes",
+        "2016-02-25-160900_remove_null_consumer_id",
+        "2016-02-29-121813_remove_ttls",
+        "2016-09-05-212515_retries_step_1",
+        "2016-09-05-212515_retries_step_2",
+        "2016-09-16-141423_upstreams",
+        "2016-12-14-172100_move_ssl_certs_to_core",
+        "2016-11-11-151900_new_apis_router_1",
+        "2016-11-11-151900_new_apis_router_2",
+        "2016-11-11-151900_new_apis_router_3",
+        "2017-01-24-132600_upstream_timeouts",
+        "2017-01-24-132600_upstream_timeouts_2",
+        "2017-03-27-132300_anonymous",
+        "2017-04-04-145100_cluster_events",
+        "2017-05-19-173100_remove_nodes_table",
+        "2017-07-28-225000_balancer_orderlist_remove",
+        "2017-11-07-192000_upstream_healthchecks",
+        "2017-10-27-134100_consistent_hashing_1",
+        "2017-11-07-192100_upstream_healthchecks_2",
+        "2017-10-27-134100_consistent_hashing_2",
+        "2017-09-14-140200_routes_and_services",
+        "2017-10-25-180700_plugins_routes_and_services",
+        "2018-02-23-142400_targets_add_index",
+        "2018-03-22-141700_create_new_ssl_tables",
+        "2018-03-26-234600_copy_records_to_new_ssl_tables",
+        "2018-03-27-002500_drop_old_ssl_tables",
+        "2018-03-16-160000_index_consumers",
+        "2018-05-17-173100_hash_on_cookie",
+      },
+      ["response-transformer"] = {
+        "2016-03-10-160000_resp_trans_schema_changes",
+      },
+      ["jwt"] = {
+        "2015-06-09-jwt-auth",
+        "2016-03-07-jwt-alg",
+        "2017-07-31-120200_jwt-auth_preflight_default",
+        "2017-10-25-211200_jwt_cookie_names_default",
+        "2018-03-15-150000_jwt_maximum_expiration",
+      },
+      ["ip-restriction"] = {
+        "2016-05-24-remove-cache",
+      },
+      ["statsd"] = {
+        "2017-06-09-160000_statsd_schema_changes",
+      },
+      ["cors"] = {
+        "2017-03-14_multiple_orgins",
+      },
+      ["basic-auth"] = {
+        "2015-08-03-132400_init_basicauth",
+      },
+      ["key-auth"] = {
+        "2015-07-31-172400_init_keyauth",
+        "2017-07-31-120200_key-auth_preflight_default",
+      },
+      ["ldap-auth"] = {
+        "2017-10-23-150900_header_type_default",
+      },
+      ["hmac-auth"] = {
+        "2015-09-16-132400_init_hmacauth",
+        "2017-06-21-132400_init_hmacauth",
+      },
+      ["datadog"] = {
+        "2017-06-09-160000_datadog_schema_changes",
+      },
+      ["tcp-log"] = {
+        "2017-12-13-120000_tcp-log_tls",
+      },
+      ["acl"] = {
+        "2015-08-25-841841_init_acl",
+      },
+      ["response-ratelimiting"] = {
+        "2015-08-21_init_response-rate-limiting",
+        "2016-08-04-321512_response-rate-limiting_policies",
+        "2017-12-19-120000_add_route_and_service_id_to_response_ratelimiting",
+      },
+      ["request-transformer"] = {
+        "2016-03-10-160000_req_trans_schema_changes",
+      },
+      ["rate-limiting"] = {
+        "2015-08-03-132400_init_ratelimiting",
+        "2016-07-25-471385_ratelimiting_policies",
+        "2017-11-30-120000_add_route_and_service_id",
+      },
+      ["oauth2"] = {
+        "2016-09-19-oauth2_api_id",
+        "2016-12-15-set_global_credentials",
+        "2017-10-19-set_auth_header_name_default",
+        "2017-10-11-oauth2_new_refresh_token_ttl_config_value",
+        "2018-01-09-oauth2_c_add_service_id",
+      },
+    }
+
+    local cql
+
+    -- For now we will assume that a release version number of 3 and greater
+    -- will use the same schema. This is recognized as a hotfix and will be
+    -- revisited for a more considered solution at a later time.
+    if self.major_version >= 3 then
+      cql = [[
+        SELECT COUNT(*) FROM system_schema.tables
+         WHERE keyspace_name = ? AND table_name = ?
+      ]]
+    else
+      cql = [[
+        SELECT COUNT(*) FROM system.schema_columnfamilies
+         WHERE keyspace_name = ? AND columnfamily_name = ?
+      ]]
+    end
+
+    rows, err = self.connection:execute(cql,
+                                        { self.keyspace, "schema_migrations" })
+    if err then
+      return nil, err
+    end
+
+    if not rows or not rows[1] or rows[1].count == 0 then
+      return {
+        is_eq_014 = false,
+        is_gt_014 = true,
+      }
+    end
+
+    rows, err = self.connection:execute([[
+      SELECT id, migrations
+        FROM schema_migrations
+    ]])
+    if err then
+      return nil, err
+    end
+
+    if not rows then
+      return {
+        is_eq_014 = false,
+        is_gt_014 = false,
+      }
+    end
+
+    local schema_migrations = {}
+    for i = 1, #rows do
+      local row = rows[i]
+      schema_migrations[row.id] = row.migrations
+    end
+
+    for name, migrations in pairs(needed_migrations) do
+      local current_migrations = schema_migrations[name]
+      if not current_migrations then
+        return {
+          is_eq_014 = false,
+          is_gt_014 = false,
+          missing_component = name,
+        }
+      end
+
+      for _, needed_migration in ipairs(migrations) do
+        local found = false
+        for _, current_migration in ipairs(current_migrations) do
+          if current_migration == needed_migration then
+            found = true
+            break
+          end
+        end
+        if not found then
+          return {
+            is_eq_014 = false,
+            is_gt_014 = false,
+            missing_component = name,
+            missing_migration = needed_migration,
+          }
+        end
+      end
+    end
+
+    return {
+      is_eq_014 = true,
+      is_gt_014 = false,
+    }
+  end
 end
 
 

--- a/kong/db/strategies/connector.lua
+++ b/kong/db/strategies/connector.lua
@@ -112,4 +112,12 @@ function Connector:record_migration()
 end
 
 
+function Connector:is_014()
+  return {
+    is_eq_014 = false,
+    is_gt_014 = true,
+  }
+end
+
+
 return Connector

--- a/kong/plugins/acl/migrations/001_14_to_15.lua
+++ b/kong/plugins/acl/migrations/001_14_to_15.lua
@@ -13,8 +13,21 @@ return {
         ALTER "created_at" TYPE TIMESTAMP WITH TIME ZONE USING "created_at" AT TIME ZONE 'UTC',
         ALTER "created_at" SET DEFAULT CURRENT_TIMESTAMP(0) AT TIME ZONE 'UTC';
 
-      ALTER INDEX IF EXISTS "acls_consumer_id" RENAME TO "acls_consumer_id_idx";
-      ALTER INDEX IF EXISTS "acls_group"       RENAME TO "acls_group_idx";
+      DO $$
+      BEGIN
+        ALTER INDEX IF EXISTS "acls_consumer_id" RENAME TO "acls_consumer_id_idx";
+      EXCEPTION WHEN DUPLICATE_TABLE THEN
+        -- Do nothing, accept existing state
+      END;
+      $$;
+
+      DO $$
+      BEGIN
+        ALTER INDEX IF EXISTS "acls_group" RENAME TO "acls_group_idx";
+      EXCEPTION WHEN DUPLICATE_TABLE THEN
+        -- Do nothing, accept existing state
+      END;
+      $$;
     ]],
 
     teardown = function(connector, helpers)

--- a/kong/plugins/hmac-auth/migrations/001_14_to_15.lua
+++ b/kong/plugins/hmac-auth/migrations/001_14_to_15.lua
@@ -5,7 +5,13 @@ return {
         ALTER "created_at" TYPE TIMESTAMP WITH TIME ZONE USING "created_at" AT TIME ZONE 'UTC',
         ALTER "created_at" SET DEFAULT CURRENT_TIMESTAMP(0) AT TIME ZONE 'UTC';
 
-      ALTER INDEX IF EXISTS "hmacauth_credentials_consumer_id" RENAME TO "hmacauth_credentials_consumer_id_idx";
+      DO $$
+      BEGIN
+        ALTER INDEX IF EXISTS "hmacauth_credentials_consumer_id" RENAME TO "hmacauth_credentials_consumer_id_idx";
+      EXCEPTION WHEN DUPLICATE_TABLE THEN
+        -- Do nothing, accept existing state
+      END;
+      $$;
 
       -- Unique constraint on "username" already adds btree index
       DROP INDEX IF EXISTS "hmacauth_credentials_username";

--- a/kong/plugins/jwt/migrations/001_14_to_15.lua
+++ b/kong/plugins/jwt/migrations/001_14_to_15.lua
@@ -5,8 +5,21 @@ return {
         ALTER "created_at" TYPE TIMESTAMP WITH TIME ZONE USING "created_at" AT TIME ZONE 'UTC',
         ALTER "created_at" SET DEFAULT CURRENT_TIMESTAMP(0) AT TIME ZONE 'UTC';
 
-      ALTER INDEX IF EXISTS "jwt_secrets_consumer_id" RENAME TO "jwt_secrets_consumer_id_idx";
-      ALTER INDEX IF EXISTS "jwt_secrets_secret"      RENAME TO "jwt_secrets_secret_idx";
+      DO $$
+      BEGIN
+        ALTER INDEX IF EXISTS "jwt_secrets_consumer_id" RENAME TO "jwt_secrets_consumer_id_idx";
+      EXCEPTION WHEN DUPLICATE_TABLE THEN
+        -- Do nothing, accept existing state
+      END;
+      $$;
+
+      DO $$
+      BEGIN
+        ALTER INDEX IF EXISTS "jwt_secrets_secret" RENAME TO "jwt_secrets_secret_idx";
+      EXCEPTION WHEN DUPLICATE_TABLE THEN
+        -- Do nothing, accept existing state
+      END;
+      $$;
 
       -- Unique constraint on "key" already adds btree index
       DROP INDEX IF EXISTS "jwt_secrets_key";

--- a/kong/plugins/key-auth/migrations/001_14_to_15.lua
+++ b/kong/plugins/key-auth/migrations/001_14_to_15.lua
@@ -5,7 +5,13 @@ return {
         ALTER "created_at" TYPE TIMESTAMP WITH TIME ZONE USING "created_at" AT TIME ZONE 'UTC',
         ALTER "created_at" SET DEFAULT CURRENT_TIMESTAMP(0) AT TIME ZONE 'UTC';
 
-      ALTER INDEX IF EXISTS "keyauth_consumer_idx" RENAME TO "keyauth_credentials_consumer_id_idx";
+      DO $$
+      BEGIN
+        ALTER INDEX IF EXISTS "keyauth_consumer_idx" RENAME TO "keyauth_credentials_consumer_id_idx";
+      EXCEPTION WHEN DUPLICATE_TABLE THEN
+        -- Do nothing, accept existing state
+      END;
+      $$;
 
       -- Unique constraint on "key" already adds btree index
       DROP INDEX IF EXISTS "keyauth_key_idx";

--- a/kong/plugins/oauth2/migrations/001_14_to_15.lua
+++ b/kong/plugins/oauth2/migrations/001_14_to_15.lua
@@ -61,9 +61,30 @@ return {
       CREATE INDEX IF NOT EXISTS "oauth2_tokens_api_id_idx"               ON "oauth2_tokens" ("api_id");
 
 
-      ALTER INDEX IF EXISTS "oauth2_credentials_consumer_idx" RENAME TO "oauth2_credentials_consumer_id_idx";
-      ALTER INDEX IF EXISTS "oauth2_authorization_userid_idx" RENAME TO "oauth2_authorization_codes_authenticated_userid_idx";
-      ALTER INDEX IF EXISTS "oauth2_token_userid_idx"         RENAME TO "oauth2_tokens_authenticated_userid_idx";
+      DO $$
+      BEGIN
+        ALTER INDEX IF EXISTS "oauth2_credentials_consumer_idx" RENAME TO "oauth2_credentials_consumer_id_idx";
+      EXCEPTION WHEN DUPLICATE_TABLE THEN
+        -- Do nothing, accept existing state
+      END;
+      $$;
+
+      DO $$
+      BEGIN
+        ALTER INDEX IF EXISTS "oauth2_authorization_userid_idx" RENAME TO "oauth2_authorization_codes_authenticated_userid_idx";
+      EXCEPTION WHEN DUPLICATE_TABLE THEN
+        -- Do nothing, accept existing state
+      END;
+      $$;
+
+      DO $$
+      BEGIN
+        ALTER INDEX IF EXISTS "oauth2_token_userid_idx" RENAME TO "oauth2_tokens_authenticated_userid_idx";
+      EXCEPTION WHEN DUPLICATE_TABLE THEN
+        -- Do nothing, accept existing state
+      END;
+      $$;
+
 
       -- Unique constraint on "client_id" already adds btree index
       DROP INDEX IF EXISTS "oauth2_credentials_client_idx";


### PR DESCRIPTION
### Summary

**Original description:**

When running 'kong migrations up' from a 0.15 install (this ignores plugins):

- If we detect an existing Kong install (0.14 only, detected via previously ran migrations), then, no need for 'bootstrap step'. In an 'if' statement somewhere, follow a special migration path as such:
- Invoke DAO's 'bootstrap' step. Now, the schema_meta and locks tables are available. We assume that the rest of the DB is of the same state as if we ran the `init` migration of each subsystem.
- In a cluster_mutex (so that multiple nodes can be running this 0.14 to 0.15 migration), run the 014_to_015 migration of each subsystem (but still record the init migration as having ran). Now, both the init and the 014_to_015 migrations are recorded as pending/executed in `schema_meta` (but only the latter really ran).

At this point, we have:
- The `schema_meta` table with `init` and `014_to_015` migrations pending/executed (allowing the user to start 0.15 nodes)
- The `schema_migrations` table with all 0.14 migrations (allowing the user to start 0.14 nodes while still migrating)
- A DB schema similar to 0.14, but with some 0.15 improvements (from the `014_to_015` migrations)

Eventually, the user runs `kong migrations teardown` (just like the new framework). The same detection is done again on the `schema_migrations` table, and we detect that we are in a 0.14 to 0.15 migration path. Instead of running the above steps again, this time, we *drop* the `schema_migrations` table, and then run all `teardown` phases of the `14_to_15` migrations (if any). Once this operation is completed, the schema is only valid for 0.15 and above.

This implements the new 2-steps migrations framework (up + teardown), but for a 0.14 to 0.15 migration.

TODO: there needs to be special handling for custom plugins with migrations.

**About the implementation:**

While it doesn't strictly work exactly as described above, e.g. it runs `base` migration always as it is harmless, but that's the way we can get exactly the schema as what we get from fresh bootstrap (as the `base` migration adds some `indexes` and updates some triggers and functions on Postgres, not worth to move them I think), and this together with #3819 will make schemas the same (except column order in table might be different, but it doesn't matter, and there is hardly anything we can do about it).