### PR TITLE
feat(pdk) add kong.node module with '.get_id()' util

### DIFF
--- a/kong-0.14.1-0.rockspec
+++ b/kong-0.14.1-0.rockspec
@@ -180,6 +180,7 @@ build = {
     ["kong.pdk.request"] = "kong/pdk/request.lua",
     ["kong.pdk.response"] = "kong/pdk/response.lua",
     ["kong.pdk.table"] = "kong/pdk/table.lua",
+    ["kong.pdk.node"] = "kong/pdk/node.lua",
 
     ["kong.plugins.base_plugin"] = "kong/plugins/base_plugin.lua",
 

--- a/kong/pdk/init.lua
+++ b/kong/pdk/init.lua
@@ -193,6 +193,11 @@
 -- @section utilities
 
 
+--- Node-level utilities
+-- @field kong.node
+-- @redirect kong.node
+
+
 --- Utilities for Lua tables
 -- @field kong.table
 -- @redirect kong.table
@@ -211,6 +216,7 @@ local MAJOR_VERSIONS = {
     version = "0.1.0",
     modules = {
       "table",
+      "node",
       "log",
       "ctx",
       "ip",

--- a/kong/pdk/node.lua
+++ b/kong/pdk/node.lua
@@ -1,0 +1,56 @@
+--- Node-level utilities
+--
+-- @module kong.node
+
+local utils = require "kong.tools.utils"
+
+
+local NODE_ID_KEY = "kong:node_id"
+
+
+local node_id
+
+
+local function new(self)
+  local _NODE = {}
+
+
+  ---
+  -- Returns the id used by this node to describe itself.
+  --
+  -- @function kong.node.get_id
+  -- @treturn string The v4 UUID used by this node as its id
+  -- @usage
+  -- local id, err = kong.node.get_id()
+  function _NODE.get_id()
+    if node_id then
+      return node_id
+    end
+
+    local shm = ngx.shared.kong
+
+    local ok, err = shm:safe_add(NODE_ID_KEY, utils.uuid())
+    if not ok and err ~= "exists" then
+      error("failed to set 'node_id' in shm: " .. err)
+    end
+
+    node_id, err = shm:get(NODE_ID_KEY)
+    if err then
+      error("failed to get 'node_id' in shm: " .. err)
+    end
+
+    if not node_id then
+      error("no 'node_id' set in shm")
+    end
+
+    return node_id
+  end
+
+
+  return _NODE
+end
+
+
+return {
+  new = new,
+}

--- a/t/01-pdk/12-node/00-phase_checks.t
+++ b/t/01-pdk/12-node/00-phase_checks.t
@@ -1,0 +1,84 @@
+use strict;
+use warnings FATAL => 'all';
+use Test::Nginx::Socket::Lua;
+use t::Util;
+
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
+
+plan tests => repeat_each() * (blocks() * 2);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: verify phase checking in kong.service
+--- http_config eval
+qq{
+    $t::Util::HttpConfig
+
+    lua_shared_dict kong 24k;
+
+    server {
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
+
+        location / {
+            return 200;
+        }
+    }
+
+    init_worker_by_lua_block {
+        phases = require("kong.pdk.private.phases").phases
+
+        phase_check_module = "node"
+        phase_check_data = {
+            {
+                method        = "get_id",
+                args          = {},
+                init_worker   = true,
+                certificate   = "pending",
+                rewrite       = true,
+                access        = true,
+                header_filter = true,
+                body_filter   = true,
+                log           = true,
+            },
+        }
+
+        phase_check_functions(phases.init_worker)
+    }
+
+    #ssl_certificate_by_lua_block {
+    #    phase_check_functions(phases.certificate)
+    #}
+}
+--- config
+    location /t {
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
+        set $upstream_host 'example.com';
+        set $upstream_uri '/t';
+        set $upstream_scheme 'http';
+
+        rewrite_by_lua_block {
+            phase_check_functions(phases.rewrite)
+        }
+
+        access_by_lua_block {
+            phase_check_functions(phases.access)
+        }
+
+        header_filter_by_lua_block {
+            phase_check_functions(phases.header_filter)
+        }
+
+        body_filter_by_lua_block {
+            phase_check_functions(phases.body_filter)
+        }
+
+        log_by_lua_block {
+            phase_check_functions(phases.log)
+        }
+    }
+--- request
+GET /t
+--- no_error_log
+[error]

--- a/t/01-pdk/12-node/01-get_id.t
+++ b/t/01-pdk/12-node/01-get_id.t
@@ -1,0 +1,35 @@
+use strict;
+use warnings FATAL => 'all';
+use Test::Nginx::Socket::Lua;
+use t::Util;
+
+plan tests => repeat_each() * (blocks() * 3);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: node.get_id() returns node identifier
+--- http_config eval
+qq{
+    $t::Util::HttpConfig
+
+    lua_shared_dict kong 24k;
+}
+--- config
+    location = /t {
+        content_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            math.randomseed(ngx.time())
+
+            ngx.say(pdk.node.get_id())
+        }
+    }
+--- request
+GET /t
+--- response_body_like
+[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}
+--- no_error_log
+[error]


### PR DESCRIPTION
This new module provides node-level utilities, such as
`kong.node.get_id()`, which is a replacement to the old
`kong.tools.public` module's `get_node_id()` utility.

Reminder: the `kong.tools.public` module is to be stripped away for the
1.0 stable release.

This new implementation **throws** errors instead of returning them, for
two reasons:

1. Simplicity of usage: now that this function is exposed for public
consumption (and already used by plugins such as Zipkin), avoiding for
the need to check for errors simplifies its usage.
2. If such an error occurs, it will be during the initialization of the
master process, and will then properly prevent Kong from starting. At
runtime, no such error should occur since the id is cached, but if they
do, they should be very obvious and provide their stacktraces.

The `kong.node` module could also contain the following utilities in the
future:

* get_hostname()
* get_system_infos()
* ...