### PR TITLE
fix(migrations) Fix migration 2017-03-27-132300_anonymous erroring with postgres

### DIFF
--- a/kong/dao/migrations/postgres.lua
+++ b/kong/dao/migrations/postgres.lua
@@ -402,7 +402,7 @@ return {
         end
 
         for _, row in ipairs(rows) do
-          local config = cjson.decode(row.config)
+          local config = row.config
 
           if not config.anonymous then
             config.anonymous = ""


### PR DESCRIPTION
### Summary

Our current setup is Kong 0.9.3 + postgres 9.5. We are attempting to upgrade to Kong 0.14.1, but are being blocked because the migration "2017-03-27-132300_anonymous erroring" is failing:

```
kong migrations up -vv
2018/10/06 18:32:39 [verbose] Kong: 0.14.1
2018/10/06 18:32:39 [debug] ngx_lua: 10013
2018/10/06 18:32:39 [debug] nginx: 1013006
2018/10/06 18:32:39 [debug] Lua: LuaJIT 2.1.0-beta3
2018/10/06 18:32:39 [verbose] no config file found at /etc/kong/kong.conf
2018/10/06 18:32:39 [verbose] no config file found at /etc/kong.conf
2018/10/06 18:32:39 [verbose] no config file, skipping loading
2018/10/06 18:32:39 [debug] reading environment variables
2018/10/06 18:32:39 [debug] KONG_ADMIN_LISTEN ENV found with "0.0.0.0:8001, 0.0.0.0:8444 ssl"
2018/10/06 18:32:39 [debug] KONG_PREFIX ENV found with "/kong/servroot"
2018/10/06 18:32:39 [debug] admin_access_log = "logs/admin_access.log"
2018/10/06 18:32:39 [debug] admin_error_log = "logs/error.log"
2018/10/06 18:32:39 [debug] admin_listen = {"0.0.0.0:8001","0.0.0.0:8444 ssl"}
2018/10/06 18:32:39 [debug] anonymous_reports = true
2018/10/06 18:32:39 [debug] cassandra_consistency = "ONE"
2018/10/06 18:32:39 [debug] cassandra_contact_points = {"127.0.0.1"}
2018/10/06 18:32:39 [debug] cassandra_data_centers = {"dc1:2","dc2:3"}
2018/10/06 18:32:39 [debug] cassandra_keyspace = "kong"
2018/10/06 18:32:39 [debug] cassandra_lb_policy = "RoundRobin"
2018/10/06 18:32:39 [debug] cassandra_port = 9042
2018/10/06 18:32:39 [debug] cassandra_repl_factor = 1
2018/10/06 18:32:39 [debug] cassandra_repl_strategy = "SimpleStrategy"
2018/10/06 18:32:39 [debug] cassandra_schema_consensus_timeout = 10000
2018/10/06 18:32:39 [debug] cassandra_ssl = false
2018/10/06 18:32:39 [debug] cassandra_ssl_verify = false
2018/10/06 18:32:39 [debug] cassandra_timeout = 5000
2018/10/06 18:32:39 [debug] cassandra_username = "kong"
2018/10/06 18:32:39 [debug] client_body_buffer_size = "8k"
2018/10/06 18:32:39 [debug] client_max_body_size = "0"
2018/10/06 18:32:39 [debug] client_ssl = false
2018/10/06 18:32:39 [debug] custom_plugins = {}
2018/10/06 18:32:39 [debug] database = "postgres"
2018/10/06 18:32:39 [debug] db_cache_ttl = 0
2018/10/06 18:32:39 [debug] db_resurrect_ttl = 30
2018/10/06 18:32:39 [debug] db_update_frequency = 5
2018/10/06 18:32:39 [debug] db_update_propagation = 0
2018/10/06 18:32:39 [debug] dns_error_ttl = 1
2018/10/06 18:32:39 [debug] dns_hostsfile = "/etc/hosts"
2018/10/06 18:32:39 [debug] dns_no_sync = false
2018/10/06 18:32:39 [debug] dns_not_found_ttl = 30
2018/10/06 18:32:39 [debug] dns_order = {"LAST","SRV","A","CNAME"}
2018/10/06 18:32:39 [debug] dns_resolver = {}
2018/10/06 18:32:39 [debug] dns_stale_ttl = 4
2018/10/06 18:32:39 [debug] error_default_type = "text/plain"
2018/10/06 18:32:39 [debug] headers = {"server_tokens","latency_tokens"}
2018/10/06 18:32:39 [debug] log_level = "notice"
2018/10/06 18:32:39 [debug] lua_package_cpath = ""
2018/10/06 18:32:39 [debug] lua_package_path = "./?.lua;./?/init.lua;"
2018/10/06 18:32:39 [debug] lua_socket_pool_size = 30
2018/10/06 18:32:39 [debug] lua_ssl_verify_depth = 1
2018/10/06 18:32:39 [debug] mem_cache_size = "128m"
2018/10/06 18:32:39 [debug] nginx_admin_directives = {}
2018/10/06 18:32:39 [debug] nginx_daemon = "on"
2018/10/06 18:32:39 [debug] nginx_http_directives = {}
2018/10/06 18:32:39 [debug] nginx_optimizations = true
2018/10/06 18:32:39 [debug] nginx_proxy_directives = {}
2018/10/06 18:32:39 [debug] nginx_user = "nobody nobody"
2018/10/06 18:32:39 [debug] nginx_worker_processes = "auto"
2018/10/06 18:32:39 [debug] pg_database = "kong"
2018/10/06 18:32:39 [debug] pg_host = "127.0.0.1"
2018/10/06 18:32:39 [debug] pg_port = 5432
2018/10/06 18:32:39 [debug] pg_ssl = false
2018/10/06 18:32:39 [debug] pg_ssl_verify = false
2018/10/06 18:32:39 [debug] pg_user = "kong"
2018/10/06 18:32:39 [debug] plugins = {"bundled"}
2018/10/06 18:32:39 [debug] prefix = "/kong/servroot"
2018/10/06 18:32:39 [debug] proxy_access_log = "logs/access.log"
2018/10/06 18:32:39 [debug] proxy_error_log = "logs/error.log"
2018/10/06 18:32:39 [debug] proxy_listen = {"0.0.0.0:8000","0.0.0.0:8443 ssl"}
2018/10/06 18:32:39 [debug] real_ip_header = "X-Real-IP"
2018/10/06 18:32:39 [debug] real_ip_recursive = "off"
2018/10/06 18:32:39 [debug] ssl_cipher_suite = "modern"
2018/10/06 18:32:39 [debug] ssl_ciphers = "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256"
2018/10/06 18:32:39 [debug] trusted_ips = {}
2018/10/06 18:32:39 [debug] upstream_keepalive = 60
2018/10/06 18:32:39 [verbose] prefix in use: /kong/servroot
2018/10/06 18:32:39 [verbose] running datastore migrations
2018/10/06 18:32:39 [info] migrating core for database kong
Error: 
./kong/dao/migrations/postgres.lua:405: bad argument #1 to 'decode' (string expected, got table)
stack traceback:
        [C]: in function 'decode'
        ./kong/dao/migrations/postgres.lua:405: in function 'up'
        ./kong/dao/factory.lua:416: in function 'migrate'
        ./kong/dao/factory.lua:527: in function 'run_migrations'
        ./kong/cmd/migrations.lua:37: in function 'cmd_exec'
        ./kong/cmd/init.lua:87: in function <./kong/cmd/init.lua:87>
        [C]: in function 'xpcall'
        ./kong/cmd/init.lua:87: in function <./kong/cmd/init.lua:44>
        /usr/local/bin/kong:7: in function 'file_gen'
        init_worker_by_lua:48: in function <init_worker_by_lua:46>
        [C]: in function 'xpcall'
        init_worker_by_lua:55: in function <init_worker_by_lua:53>
```

The change proposed in the PR unblocked us.