### PR TITLE
Feat/plugins code to new db

### DIFF
--- a/kong/plugins/acl/acls.lua
+++ b/kong/plugins/acl/acls.lua
@@ -23,7 +23,7 @@ function _ACLs:post_crud_event(operation, entity)
   if err then
     return nil, err, err_t
   end
-  return self.super.post_crud_event(self, entity)
+  return self.super.post_crud_event(self, operation, entity)
 end
 
 return _ACLs

--- a/kong/plugins/ldap-auth/access.lua
+++ b/kong/plugins/ldap-auth/access.lua
@@ -128,7 +128,7 @@ local function authenticate(conf, given_credentials)
 end
 
 local function load_consumer(consumer_id, anonymous)
-  local result, err = singletons.db.consumers:select { id = consumer_id }
+  local result, err = kong.db.consumers:select { id = consumer_id }
   if not result then
     if anonymous and not err then
       err = 'anonymous consumer "' .. consumer_id .. '" not found'
@@ -213,7 +213,7 @@ function _M.execute(conf)
   if not ok then
     if conf.anonymous then
       -- get anonymous user
-      local consumer_cache_key = singletons.db.consumers:cache_key(conf.anonymous)
+      local consumer_cache_key = kong.db.consumers:cache_key(conf.anonymous)
       local consumer, err      = singletons.cache:get(consumer_cache_key, nil,
                                                       load_consumer,
                                                       conf.anonymous, true)

--- a/spec-old-api/03-plugins/24-rate-limiting/02-policies_spec.lua
+++ b/spec-old-api/03-plugins/24-rate-limiting/02-policies_spec.lua
@@ -13,9 +13,9 @@ describe("Plugin: rate-limiting (policies)", function()
     local dao
 
     setup(function()
-      local singletons = require "kong.singletons"
-      dao = select(3, helpers.get_db_utils())
-      singletons.dao = dao
+      local _, db
+      _, db, dao = helpers.get_db_utils()
+      _G.kong = _G.kong or { db = db }
 
       dao:truncate_tables()
     end)

--- a/spec-old-api/03-plugins/25-response-rate-limiting/02-policies_spec.lua
+++ b/spec-old-api/03-plugins/25-response-rate-limiting/02-policies_spec.lua
@@ -13,10 +13,10 @@ describe("Plugin: response-ratelimiting (policies)", function()
     local dao
 
     setup(function()
-      dao = select(3, helpers.get_db_utils())
+      local _, db
+      _, db, dao = helpers.get_db_utils()
 
-      local singletons = require "kong.singletons"
-      singletons.dao = dao
+      _G.kong = _G.kong or { db = db }
 
       dao:truncate_tables()
     end)

--- a/spec/03-plugins/24-rate-limiting/02-policies_spec.lua
+++ b/spec/03-plugins/24-rate-limiting/02-policies_spec.lua
@@ -18,9 +18,7 @@ for _, strategy in helpers.each_strategy() do
       setup(function()
         local _
         _, db, dao = helpers.get_db_utils(strategy)
-
-        local singletons = require "kong.singletons"
-        singletons.dao   = dao
+        _G.kong = _G.kong or { db = db }
       end)
 
       after_each(function()

--- a/spec/03-plugins/25-response-rate-limiting/02-policies_spec.lua
+++ b/spec/03-plugins/25-response-rate-limiting/02-policies_spec.lua
@@ -15,11 +15,9 @@ for _, strategy in helpers.each_strategy() do
       local dao
 
       setup(function()
-        local _
-        _, _, dao = helpers.get_db_utils(strategy, {})
-
-        local singletons = require "kong.singletons"
-        singletons.dao   = dao
+        local _, db
+        _, db, dao = helpers.get_db_utils(strategy, {})
+        _G.kong = _G.kong or { db = db }
       end)
 
       before_each(function()


### PR DESCRIPTION
Replaces usage of old-style DAO with new-style db in all plugins:

* Noticed a bug in the ACL plugin cache invalidation code. Fixed here.
* The main purpose of this task was replacing `singletons.dao` with calls to `kong.db`. <del>I also replaced `singletons.cache` with `kong.cache` and `singletons.configuration` with `kong.configuration`</del>.