### PR TITLE
Feat/groundwork for zipkin

### DIFF
--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -279,7 +279,7 @@ local function new(self)
   function _REQUEST.get_path()
     check_phase(PHASES.request)
 
-    local uri = ngx.var.request_uri
+    local uri = ngx.var.request_uri or ""
     local s = find(uri, "?", 2, true)
     return s and sub(uri, 1, s - 1) or uri
   end
@@ -298,7 +298,7 @@ local function new(self)
   -- kong.request.get_raw_path_and_query() -- "/v1/movies?movie=foo"
   function _REQUEST.get_raw_path_and_query()
     check_phase(PHASES.request)
-    return ngx.var.request_uri
+    return ngx.var.request_uri or ""
   end
 
   ---

--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -641,6 +641,18 @@ local function new(self)
     end
   end
 
+  ---
+  -- Returns the time at which the request was created
+  --
+  -- @function kong.request.get_start_time
+  -- @phases rewrite, access, header_filter, body_filter, log
+  -- @treturn number the distance in seconds from epoch, with milliseconds as the decimal part.
+  -- @usage
+  -- kong.request.get_start_time() -- 290132101.123
+  function _REQUEST.get_start_time()
+    check_phase(PHASES.request)
+    return ngx.req.start_time()
+  end
 
   return _REQUEST
 end

--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -286,6 +286,22 @@ local function new(self)
 
 
   ---
+  -- When the request has a query string, returns the path + "?" + the query string.
+  -- Otherwise it returns just the path. No transformations/normalizations are done.
+  --
+  -- @function kong.request.get_raw_path_and_query()
+  -- @phases rewrite, access, header_filter, body_filter, log
+  -- @treturn string the path and querystring
+  -- @usage
+  -- -- Given a request to https://example.com:1234/v1/movies?movie=foo
+  --
+  -- kong.request.get_raw_path_and_query() -- "/v1/movies?movie=foo"
+  function _REQUEST.get_raw_path_and_query()
+    check_phase(PHASES.request)
+    return ngx.var.request_uri
+  end
+
+  ---
   -- Returns the query component of the request's URL. It is not normalized in
   -- any way (not even URL-decoding of special characters) and does not
   -- include the leading `?` character.

--- a/t/01-pdk/04-request/00-phase_checks.t
+++ b/t/01-pdk/04-request/00-phase_checks.t
@@ -130,6 +130,17 @@ qq{
                 log           = true,
                 admin_api     = true,
             }, {
+                method        = "get_raw_path_and_query",
+                args          = {},
+                init_worker   = false,
+                certificate   = "pending",
+                rewrite       = true,
+                access        = true,
+                header_filter = true,
+                body_filter   = true,
+                log           = true,
+                admin_api     = true,
+            }, {
                 method        = "get_raw_query",
                 args          = {},
                 init_worker   = false,

--- a/t/01-pdk/04-request/00-phase_checks.t
+++ b/t/01-pdk/04-request/00-phase_checks.t
@@ -240,6 +240,18 @@ qq{
                 log           = false,
                 admin_api     = true,
             },
+            {
+                method        = "get_start_time",
+                args          = {},
+                init_worker   = false,
+                certificate   = "pending",
+                rewrite       = true,
+                access        = true,
+                header_filter = true,
+                body_filter   = true,
+                log           = true,
+                admin_api     = true,
+            },
         }
 
         phase_check_functions(phases.init_worker)

--- a/t/01-pdk/04-request/17-get_start_time.t
+++ b/t/01-pdk/04-request/17-get_start_time.t
@@ -1,0 +1,28 @@
+use strict;
+use warnings FATAL => 'all';
+use Test::Nginx::Socket::Lua;
+use t::Util;
+
+plan tests => repeat_each() * (blocks() * 2);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: request.get_start_time() returns a number
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        access_by_lua_block {
+            local PDK = require("kong.pdk")
+            local pdk = PDK.new()
+
+            ngx.say("request start time: ", string.format("%.3f", pdk.request.get_start_time()))
+        }
+    }
+--- request
+GET /t
+request start time: \d+\.?\d\d\d
+--- no_error_log
+[error]
+

--- a/t/01-pdk/04-request/18-get_raw_path_and_query.t
+++ b/t/01-pdk/04-request/18-get_raw_path_and_query.t
@@ -1,0 +1,50 @@
+use strict;
+use warnings FATAL => 'all';
+use Test::Nginx::Socket::Lua;
+use t::Util;
+
+plan tests => repeat_each() * (blocks() * 3);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: request.get_raw_path_and_query() returns the path when no query string is present
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            local path_and_querystring = pdk.request.get_raw_path_and_query()
+
+            ngx.say("path_and_querystring=", path_and_querystring)
+        }
+    }
+--- request
+GET /t
+--- response_body
+path_and_querystring=/t
+--- no_error_log
+[error]
+
+=== TEST 2: request.get_raw_path_and_query() returns the path + ? + querystring when querystring is present
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            local path_and_querystring = pdk.request.get_raw_path_and_query()
+
+            ngx.say("path_and_querystring=", path_and_querystring)
+        }
+    }
+--- request
+GET /t?foo=1&bar=2
+--- response_body
+path_and_querystring=/t?foo=1&bar=2
+--- no_error_log
+[error]


### PR DESCRIPTION
This PR adds a couple features to the PDK:
* `kong.request.get_start_time()`, which wraps `ngx.req.start_time()`
* `kong.request.get_raw_path_and_query()`

It also fix a (possible?) problem when ngx.request_uri is nil.

It is needed for the zipkin update: https://github.com/Kong/kong-plugin-zipkin/pull/24