### PR TITLE
feat(schema) introduce custom_entity_check

### DIFF
--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -113,6 +113,13 @@ local entity_checkers = {
       },
     },
   },
+  { custom_entity_check = {
+    type = "record",
+    fields = {
+      { field_sources = { type = "array", elements = { type = "string" } } },
+      { fn = { type = "function" } },
+    }
+  } },
 }
 
 local entity_check_names = {}

--- a/spec/01-unit/000-new-dao/01-schema/02-metaschema_spec.lua
+++ b/spec/01-unit/000-new-dao/01-schema/02-metaschema_spec.lua
@@ -138,6 +138,28 @@ describe("metaschema", function()
     assert.truthy(errs)
   end)
 
+  it("accepts a function in an entity check", function()
+    local s = {
+      name = "bad",
+      fields = {
+        { a = { type = "number" } },
+        { b = { type = "number" } },
+      },
+      entity_checks = {
+        { custom_entity_check = {
+            field_sources = { "a" },
+            fn = function()
+              return true
+            end,
+          }
+        },
+      }
+    }
+    local ok, errs = MetaSchema:validate(s)
+    assert.falsy(ok)
+    assert.truthy(errs)
+  end)
+
   it("demands a primary key", function()
     local s = {
       name = "bad",

--- a/spec/03-plugins/08-datadog/02-schema_spec.lua
+++ b/spec/03-plugins/08-datadog/02-schema_spec.lua
@@ -35,7 +35,7 @@ describe("Plugin: datadog (schema)", function()
       }
     }
     local _, err = v({ metrics = metrics_input }, schema_def)
-    assert.same({ stat_type = "required field missing" }, err.config.metrics)
+    assert.same({ stat_type = "field required for entity check" }, err.config.metrics)
     local metrics_input = {
       {
         stat_type = "counter",
@@ -43,7 +43,7 @@ describe("Plugin: datadog (schema)", function()
       }
     }
     _, err = v({ metrics = metrics_input }, schema_def)
-    assert.same("required field missing", err.config.metrics.name)
+    assert.same("field required for entity check", err.config.metrics.name)
   end)
   it("rejects counters without sample rate", function()
     local metrics_input = {


### PR DESCRIPTION
Allows a user function to perform a cross-field check:

```lua
{
  fields = {
    { aaa = { type = "string" } },
    { bbb = { type = "string" } },
    { ccc = { type = "number" } },
  },
  entity_checks = {
    { custom_entity_check = {
      field_sources = { "bbb", "ccc" },
      fn = function(entity)
        assert(entity.aaa == nil)
        if entity.bbb == "foo" and entity.ccc == 42 then
          return true
        end
        return nil, "oh no"
      end,
    } }
  }
```

Note that only the fields specifying in `field_sources` are visible
to the `entity` table received by `fn` (this is to allow partial
updates to work properly -- the check is skipped if none of the
fields in `field_sources` is being updated).
