### PR TITLE
(refactor) plugins to remove dependencies to kong.tools and use more PDK

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -624,6 +624,8 @@ function Kong.handle_error()
 end
 
 function Kong.serve_admin_api(options)
+  kong_global.set_phase(kong, PHASES.admin_api)
+
   options = options or {}
 
   header["Access-Control-Allow-Origin"] = options.allow_origin or "*"

--- a/kong/pdk/private/phases.lua
+++ b/kong/pdk/private/phases.lua
@@ -18,6 +18,7 @@ local PHASES = {
   body_filter   = 0x00000400,
   --timer       = 0x00001000,
   log           = 0x00002000,
+  admin_api     = 0x10000000,
 }
 
 
@@ -108,7 +109,8 @@ local public_phases = setmetatable({
                       PHASES.access,
                       PHASES.header_filter,
                       PHASES.body_filter,
-                      PHASES.log),
+                      PHASES.log,
+                      PHASES.admin_api),
 }, {
   __index = function(t, k)
     error("unknown phase or phase alias: " .. k)

--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -57,7 +57,7 @@ local function new(self)
   -- normalized to lower-case form.
   --
   -- @function kong.request.get_scheme
-  -- @phases rewrite, access, header_filter, body_filter, log
+  -- @phases rewrite, access, header_filter, body_filter, log, admin_api
   -- @treturn string a string like `"http"` or `"https"`
   -- @usage
   -- -- Given a request to https://example.com:1234/v1/movies
@@ -75,7 +75,7 @@ local function new(self)
   -- "Host" header. The returned value is normalized to lower-case form.
   --
   -- @function kong.request.get_host
-  -- @phases rewrite, access, header_filter, body_filter, log
+  -- @phases rewrite, access, header_filter, body_filter, log, admin_api
   -- @treturn string the host
   -- @usage
   -- -- Given a request to https://example.com:1234/v1/movies
@@ -93,7 +93,7 @@ local function new(self)
   -- as a Lua number.
   --
   -- @function kong.request.get_port
-  -- @phases certificate, rewrite, access, header_filter, body_filter, log
+  -- @phases certificate, rewrite, access, header_filter, body_filter, log, admin_api
   -- @treturn number the port
   -- @usage
   -- -- Given a request to https://example.com:1234/v1/movies
@@ -122,7 +122,7 @@ local function new(self)
   -- offered yet since it is not supported by ngx\_http\_realip\_module.
   --
   -- @function kong.request.get_forwarded_scheme
-  -- @phases rewrite, access, header_filter, body_filter, log
+  -- @phases rewrite, access, header_filter, body_filter, log, admin_api
   -- @treturn string the forwarded scheme
   -- @usage
   -- kong.request.get_forwarded_scheme() -- "https"
@@ -157,7 +157,7 @@ local function new(self)
   -- (RFC 7239) since it is not supported by ngx_http_realip_module.
   --
   -- @function kong.request.get_forwarded_host
-  -- @phases rewrite, access, header_filter, body_filter, log
+  -- @phases rewrite, access, header_filter, body_filter, log, admin_api
   -- @treturn string the forwarded host
   -- @usage
   -- kong.request.get_forwarded_host() -- "example.com"
@@ -197,7 +197,7 @@ local function new(self)
   -- (RFC 7239) since it is not supported by ngx_http_realip_module.
   --
   -- @function kong.request.get_forwareded_port
-  -- @phases rewrite, access, header_filter, body_filter, log
+  -- @phases rewrite, access, header_filter, body_filter, log, admin_api
   -- @treturn number the forwared port
   -- @usage
   -- kong.request.get_forwarded_port() -- 1234
@@ -238,7 +238,7 @@ local function new(self)
   -- unrecognized values.
   --
   -- @function kong.request.get_http_version
-  -- @phases rewrite, access, header_filter, body_filter, log
+  -- @phases rewrite, access, header_filter, body_filter, log, admin_api
   -- @treturn string|nil the http version
   -- @usage
   -- kong.request.get_http_version() -- "1.1"
@@ -254,7 +254,7 @@ local function new(self)
   -- upper-case.
   --
   -- @function kong.request.get_method
-  -- @phases rewrite, access, header_filter, body_filter, log
+  -- @phases rewrite, access, header_filter, body_filter, log, admin_api
   -- @treturn string the request method
   -- @usage
   -- kong.request.get_method() -- "GET"
@@ -270,7 +270,7 @@ local function new(self)
   -- any way and does not include the querystring.
   --
   -- @function kong.request.get_path
-  -- @phases rewrite, access, header_filter, body_filter, log
+  -- @phases rewrite, access, header_filter, body_filter, log, admin_api
   -- @treturn string the path
   -- @usage
   -- -- Given a request to https://example.com:1234/v1/movies?movie=foo
@@ -291,7 +291,7 @@ local function new(self)
   -- include the leading `?` character.
   --
   -- @function kong.request.get_raw_query
-  -- @phases rewrite, access, header_filter, body_filter, log
+  -- @phases rewrite, access, header_filter, body_filter, log, admin_api
   -- @return string the query component of the request's URL
   -- @usage
   -- -- Given a request to https://example.com/foo?msg=hello%20world&bla=&bar
@@ -316,7 +316,7 @@ local function new(self)
   -- querystring, this function will return the value of the first occurrence.
   --
   -- @function kong.request.get_query_arg
-  -- @phases rewrite, access, header_filter, body_filter, log
+  -- @phases rewrite, access, header_filter, body_filter, log, admin_api
   -- @treturn string|boolean|nil the value of the argument
   -- @usage
   -- -- Given a request GET /test?foo=hello%20world&bar=baz&zzz&blo=&bar=bla&bar
@@ -357,7 +357,7 @@ local function new(self)
   -- greater than **1** and not greater than **1000**.
   --
   -- @function kong.request.get_query
-  -- @phases rewrite, access, header_filter, body_filter, log
+  -- @phases rewrite, access, header_filter, body_filter, log, admin_api
   -- @tparam[opt] number max_args set a limit on the maximum number of parsed
   -- arguments
   -- @treturn table A table representation of the query string
@@ -409,7 +409,7 @@ local function new(self)
   -- `X-Custom-Header` can also be retrieved as `x_custom_header`.
   --
   -- @function kong.request.get_header
-  -- @phases rewrite, access, header_filter, body_filter, log
+  -- @phases rewrite, access, header_filter, body_filter, log, admin_api
   -- @tparam string name the name of the header to be returned
   -- @treturn string|nil the value of the header or nil if not present
   -- @usage
@@ -452,7 +452,7 @@ local function new(self)
   -- be greater than **1** and not greater than **1000**.
   --
   -- @function kong.request.get_headers
-  -- @phases rewrite, access, header_filter, body_filter, log
+  -- @phases rewrite, access, header_filter, body_filter, log, admin_api
   -- @tparam[opt] number max_headers set a limit on the maximum number of
   -- parsed headers
   -- @treturn table the request headers in table form
@@ -490,7 +490,7 @@ local function new(self)
   end
 
 
-  local before_content = phase_checker.new(PHASES.rewrite, PHASES.access)
+  local before_content = phase_checker.new(PHASES.rewrite, PHASES.access, PHASES.admin_api)
 
 
   ---
@@ -503,7 +503,7 @@ local function new(self)
   -- message explaining this limitation.
   --
   -- @function kong.request.get_raw_body
-  -- @phases rewrite, access
+  -- @phases rewrite, access, admin_api
   -- @treturn string the plain request body
   -- @usage
   -- -- Given a body with payload "Hello, Earth!":
@@ -562,7 +562,7 @@ local function new(self)
   -- what MIME type the body was parsed as.
   --
   -- @function kong.request.get_body
-  -- @phases rewrite, access
+  -- @phases rewrite, access, admin_api
   -- @tparam[opt] string mimetype the MIME type
   -- @tparam[opt] number max_args set a limit on the maximum number of parsed
   -- arguments

--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -618,8 +618,9 @@ local function new(self)
         return nil, err, CONTENT_TYPE_JSON
       end
 
-      -- TODO: cjson.decode_array_with_array_mt(true) (?)
+      cjson.decode_array_with_array_mt(true)
       local json = cjson.decode(body)
+      cjson.decode_array_with_array_mt(false)
       if not json then
         return nil, "invalid json body", CONTENT_TYPE_JSON
       end

--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -411,7 +411,7 @@ local function new(self)
   -- @function kong.request.get_header
   -- @phases rewrite, access, header_filter, body_filter, log
   -- @tparam string name the name of the header to be returned
-  -- @treturn string the value of the header
+  -- @treturn string|nil the value of the header or nil if not present
   -- @usage
   -- -- Given a request with the following headers:
   --

--- a/kong/pdk/response.lua
+++ b/kong/pdk/response.lua
@@ -37,14 +37,17 @@ local PHASES = phase_checker.phases
 
 local header_body_log = phase_checker.new(PHASES.header_filter,
                                           PHASES.body_filter,
-                                          PHASES.log)
+                                          PHASES.log,
+                                          PHASES.admin_api)
 
 local rewrite_access = phase_checker.new(PHASES.rewrite,
-                                         PHASES.access)
+                                         PHASES.access,
+                                         PHASES.admin_api)
 
 local rewrite_access_header = phase_checker.new(PHASES.rewrite,
                                                 PHASES.access,
-                                                PHASES.header_filter)
+                                                PHASES.header_filter,
+                                                PHASES.admin_api)
 
 
 local function new(self, major_version)
@@ -81,7 +84,7 @@ local function new(self, major_version)
   -- returned as-is.
   --
   -- @function kong.response.get_status
-  -- @phases header_filter, body_filter, log
+  -- @phases header_filter, body_filter, log, admin_api
   -- @treturn number status The HTTP status code currently set for the
   -- downstream response
   -- @usage
@@ -107,7 +110,7 @@ local function new(self, major_version)
   -- of the first occurrence of this header.
   --
   -- @function kong.response.get_header
-  -- @phases header_filter, body_filter, log
+  -- @phases header_filter, body_filter, log, admin_api
   -- @tparam string name The name of the header
   --
   -- Header names are case-insensitive and dashes (`-`) can be written as
@@ -162,7 +165,7 @@ local function new(self, major_version)
   -- be greater than **1** and not greater than **1000**.
   --
   -- @function kong.response.get_headers
-  -- @phases header_filter, body_filter, log
+  -- @phases header_filter, body_filter, log, admin_api
   -- @tparam[opt] number max_headers Limits how many headers are parsed
   -- @treturn table headers A table representation of the headers in the
   -- response
@@ -220,7 +223,7 @@ local function new(self, major_version)
   --   contacting the proxied Service.
   --
   -- @function kong.response.get_source
-  -- @phases header_filter, body_filter, log
+  -- @phases header_filter, body_filter, log, admin_api
   -- @treturn string the source.
   -- @usage
   -- if kong.response.get_source() == "service" then
@@ -253,7 +256,7 @@ local function new(self, major_version)
   -- preparing headers to be sent back to the client.
   --
   -- @function kong.response.set_status
-  -- @phases rewrite, access, header_filter
+  -- @phases rewrite, access, header_filter, admin_api
   -- @tparam number status The new status
   -- @return Nothing; throws an error on invalid input.
   -- @usage
@@ -287,7 +290,7 @@ local function new(self, major_version)
   -- This function should be used in the `header_filter` phase, as Kong is
   -- preparing headers to be sent back to the client.
   -- @function kong.response.set_header
-  -- @phases rewrite, access, header_filter
+  -- @phases rewrite, access, header_filter, admin_api
   -- @tparam string name The name of the header
   -- @tparam string|number|boolean value The new value for the header
   -- @return Nothing; throws an error on invalid input.
@@ -317,7 +320,7 @@ local function new(self, major_version)
   -- This function should be used in the `header_filter` phase, as Kong is
   -- preparing headers to be sent back to the client.
   -- @function kong.response.add_header
-  -- @phases rewrite, access, header_filter
+  -- @phases rewrite, access, header_filter, admin_api
   -- @tparam string name The header name
   -- @tparam string|number|boolean value The header value
   -- @return Nothing; throws an error on invalid input.
@@ -352,7 +355,7 @@ local function new(self, major_version)
   -- preparing headers to be sent back to the client.
   --
   -- @function kong.response.clear_header
-  -- @phases rewrite, access, header_filter
+  -- @phases rewrite, access, header_filter, admin_api
   -- @tparam string name The name of the header to be cleared
   -- @return Nothing; throws an error on invalid input.
   -- @usage
@@ -393,7 +396,7 @@ local function new(self, major_version)
   -- specified in the `headers` argument. Other headers remain unchanged.
   --
   -- @function kong.response.set_headers
-  -- @phases rewrite, access, header_filter
+  -- @phases rewrite, access, header_filter, admin_api
   -- @tparam table headers
   -- @return Nothing; throws an error on invalid input.
   -- @usage
@@ -525,7 +528,7 @@ local function new(self, major_version)
   -- Unless manually specified, this method will automatically set the
   -- Content-Length header in the produced response for convenience.
   -- @function kong.response.exit
-  -- @phases rewrite, access
+  -- @phases rewrite, access, admin_api
   -- @tparam number status The status to be used
   -- @tparam[opt] table|string body The body to be used
   -- @tparam[opt] table headers The headers to be used

--- a/kong/pdk/response.lua
+++ b/kong/pdk/response.lua
@@ -47,7 +47,7 @@ local rewrite_access_header = phase_checker.new(PHASES.rewrite,
                                                 PHASES.header_filter)
 
 
-local function new(pdk, major_version)
+local function new(self, major_version)
   local _RESPONSE = {}
 
   local MIN_HEADERS          = 1
@@ -59,6 +59,9 @@ local function new(pdk, major_version)
 
   local SERVER_HEADER_NAME   = "Server"
   local SERVER_HEADER_VALUE  = meta._NAME .. "/" .. meta._VERSION
+
+  local SERVER_VIA_NAME   = "Via"
+  local SERVER_VIA_VALUE  = SERVER_HEADER_VALUE
 
   local CONTENT_LENGTH_NAME  = "Content-Length"
   local CONTENT_TYPE_NAME    = "Content-Type"
@@ -446,7 +449,12 @@ local function new(pdk, major_version)
     end
 
     ngx.status = status
-    ngx.header[SERVER_HEADER_NAME] = SERVER_HEADER_VALUE
+    if self.configuration.enabled_headers[SERVER_HEADER_NAME] then
+      ngx.header[SERVER_HEADER_NAME] = SERVER_HEADER_VALUE
+    end
+    if self.configuration.enabled_headers[SERVER_VIA_NAME] then
+      ngx.header[SERVER_VIA_NAME] = SERVER_VIA_VALUE
+    end
 
     if headers ~= nil then
       for name, value in pairs(headers) do

--- a/kong/pdk/table.lua
+++ b/kong/pdk/table.lua
@@ -52,10 +52,29 @@ do
 end
 
 
+--- Merges the contents of two tables together, producing a new one.
+-- The entries of both tables are copied non-recursively to the new one.
+-- If both tables have the same key, the second one takes precedence.
+-- @tparam table t1 The first table
+-- @tparam table t2 The second table
+-- @treturn table The (new) merged table
+local function merge_tab(t1, t2)
+  local res = {}
+  if t1 then
+    for k,v in pairs(t1) do res[k] = v end
+  end
+  if t2 then
+    for k,v in pairs(t2) do res[k] = v end
+  end
+  return res
+end
+
+
 local function new(self)
   return {
     new = new_tab,
     clear = clear_tab,
+    merge = merge_tab,
   }
 end
 

--- a/kong/plugins/acl/acls.lua
+++ b/kong/plugins/acl/acls.lua
@@ -1,29 +1,37 @@
 local singletons = require "kong.singletons"
 
 
+local type = type
+
+
 local invalidate_cache = function(self, entity)
   local consumer = entity.consumer
   if type(consumer) ~= "table" then
     return true
   end
+
   -- skip next lines in some tests where singletons is not available
   if not singletons.cache then
     return true
   end
 
   local cache_key = self:cache_key(consumer.id)
+
   return singletons.cache:invalidate(cache_key)
 end
 
 
 local _ACLs = {}
 
-function _ACLs:post_crud_event(operation, entity)
+
+function _ACLs:post_crud_event(_, entity)
   local _, err, err_t = invalidate_cache(self, entity)
   if err then
     return nil, err, err_t
   end
+
   return self.super.post_crud_event(self, entity)
 end
+
 
 return _ACLs

--- a/kong/plugins/acl/api.lua
+++ b/kong/plugins/acl/api.lua
@@ -1,8 +1,10 @@
 local endpoints = require "kong.api.endpoints"
-local responses = require "kong.tools.responses"
 
+
+local kong             = kong
 local acls_schema      = kong.db.acls.schema
 local consumers_schema = kong.db.consumers.schema
+
 
 return {
   ["/consumers/:consumers/acls/"] = {
@@ -24,7 +26,7 @@ return {
           return endpoints.handle_error(err_t)
         end
         if not consumer then
-          return responses.send_HTTP_NOT_FOUND()
+          return kong.response.exit(404, { message = "Not found" })
         end
 
         self.consumer = consumer
@@ -36,7 +38,7 @@ return {
 
         if self.req.cmd_mth ~= "PUT" then
           if not acl or acl.consumer.id ~= consumer.id then
-            return responses.send_HTTP_NOT_FOUND()
+            return kong.response.exit(404, { message = "Not found" })
           end
           self.acl = acl
           self.params.acls = acl.id

--- a/kong/plugins/acl/handler.lua
+++ b/kong/plugins/acl/handler.lua
@@ -1,27 +1,28 @@
 local BasePlugin = require "kong.plugins.base_plugin"
-local responses = require "kong.tools.responses"
 local constants = require "kong.constants"
-local pl_tablex = require "pl.tablex"
+local tablex = require "pl.tablex"
 local groups = require "kong.plugins.acl.groups"
 
-local table_concat = table.concat
-local set_header = ngx.req.set_header
-local ngx_error = ngx.ERR
-local ngx_log = ngx.log
-local EMPTY = pl_tablex.readonly {}
+
+local setmetatable = setmetatable
+local concat = table.concat
+local kong = kong
+
+
+local EMPTY = tablex.readonly {}
 local BLACK = "BLACK"
 local WHITE = "WHITE"
 
+
 local mt_cache = { __mode = "k" }
 local config_cache = setmetatable({}, mt_cache)
-
 
 
 local ACLHandler = BasePlugin:extend()
 
 
 ACLHandler.PRIORITY = 950
-ACLHandler.VERSION = "0.1.1"
+ACLHandler.VERSION = "0.1.2"
 
 
 function ACLHandler:new()
@@ -44,16 +45,17 @@ function ACLHandler:access(conf)
   -- get the consumer/credentials
   local consumer_id = groups.get_current_consumer_id()
   if not consumer_id then
-    ngx_log(ngx_error, "[acl plugin] Cannot identify the consumer, add an ",
-                       "authentication plugin to use the ACL plugin")
-    return responses.send_HTTP_FORBIDDEN("You cannot consume this service")
+    kong.log.err("Cannot identify the consumer, add an authentication " ..
+                 "plugin to use the ACL plugin")
+    return kong.response.exit(403, { message = "You cannot consume this service" })
   end
 
   -- get the consumer groups, since we need those as cache-keys to make sure
   -- we invalidate properly if they change
   local consumer_groups, err = groups.get_consumer_groups(consumer_id)
   if not consumer_groups then
-    return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+    kong.log.err(err)
+    return kong.response.exit(500, { message = "An unexpected error occurred" })
   end
 
   -- 'to_be_blocked' is either 'true' if it's to be blocked, or the header
@@ -71,8 +73,8 @@ function ACLHandler:access(conf)
     if to_be_blocked == false then
       -- we're allowed, convert 'false' to the header value, if needed
       -- if not needed, set dummy value to save mem for potential long strings
-      to_be_blocked = conf.hide_groups_header and "" 
-                      or table_concat(consumer_groups, ", ")
+      to_be_blocked = conf.hide_groups_header and ""
+                      or concat(consumer_groups, ", ")
     end
 
     -- update cache
@@ -80,12 +82,14 @@ function ACLHandler:access(conf)
   end
 
   if to_be_blocked == true then -- NOTE: we only catch the boolean here!
-    return responses.send_HTTP_FORBIDDEN("You cannot consume this service")
+    return kong.response.exit(403, { message = "You cannot consume this service" })
   end
 
   if not conf.hide_groups_header then
-    set_header(constants.HEADERS.CONSUMER_GROUPS, to_be_blocked)
+    kong.service.request.set_header(constants.HEADERS.CONSUMER_GROUPS,
+                                    to_be_blocked)
   end
 end
+
 
 return ACLHandler

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -1,39 +1,24 @@
 -- Copyright (C) Kong Inc.
 local BasePlugin = require "kong.plugins.base_plugin"
 local aws_v4 = require "kong.plugins.aws-lambda.v4"
-local singletons = require "kong.singletons"
-local responses = require "kong.tools.responses"
-local constants = require "kong.constants"
-local utils = require "kong.tools.utils"
-local meta = require "kong.meta"
 local http = require "resty.http"
 local cjson = require "cjson.safe"
-local public_utils = require "kong.tools.public"
 
 
 local tostring             = tostring
 local tonumber             = tonumber
-local pairs                = pairs
 local type                 = type
 local fmt                  = string.format
-local ngx                  = ngx
-local ngx_req_read_body    = ngx.req.read_body
-local ngx_req_get_uri_args = ngx.req.get_uri_args
-local ngx_req_get_headers  = ngx.req.get_headers
 local ngx_encode_base64    = ngx.encode_base64
 
 
-local new_tab
-do
-  local ok
-  ok, new_tab = pcall(require, "table.new")
-  if not ok then
-    new_tab = function(narr, nrec) return {} end
-  end
-end
-
-
-local server_header = meta._SERVER_TOKENS
+local raw_content_types = {
+  ["text/plain"] = true,
+  ["text/html"] = true,
+  ["application/xml"] = true,
+  ["text/xml"] = true,
+  ["application/soap+xml"] = true,
+}
 
 
 local AWS_PORT = 443
@@ -87,36 +72,6 @@ local function extract_proxy_response(content)
 end
 
 
-local function send(status, content, headers)
-  ngx.status = status
-
-  if type(headers) == "table" then
-    for k, v in pairs(headers) do
-      ngx.header[k] = v
-    end
-  end
-
-  if not ngx.header["Content-Length"] then
-    ngx.header["Content-Length"] = #content
-  end
-
-  if singletons.configuration.enabled_headers[constants.HEADERS.VIA] then
-    ngx.header[constants.HEADERS.VIA] = server_header
-  end
-
-  ngx.print(content)
-
-  return ngx.exit(status)
-end
-
-
-local function flush(ctx)
-  ctx = ctx or ngx.ctx
-  local response = ctx.delayed_response
-  return send(response.status_code, response.content, response.headers)
-end
-
-
 local AWSLambdaHandler = BasePlugin:extend()
 
 
@@ -128,35 +83,42 @@ end
 function AWSLambdaHandler:access(conf)
   AWSLambdaHandler.super.access(self)
 
-  local upstream_body = new_tab(0, 6)
+  local upstream_body = kong.table.new(0, 6)
 
   if conf.forward_request_body or conf.forward_request_headers
     or conf.forward_request_method or conf.forward_request_uri
   then
     -- new behavior to forward request method, body, uri and their args
-    local var = ngx.var
-
     if conf.forward_request_method then
-      upstream_body.request_method = var.request_method
+      upstream_body.request_method = kong.request.get_method()
     end
 
     if conf.forward_request_headers then
-      upstream_body.request_headers = ngx_req_get_headers()
+      upstream_body.request_headers = kong.request.get_headers()
     end
 
     if conf.forward_request_uri then
-      upstream_body.request_uri      = var.request_uri
-      upstream_body.request_uri_args = ngx_req_get_uri_args()
+      local path = kong.request.get_path()
+      local query = kong.request.get_raw_query()
+      if query ~= "" then
+        upstream_body.request_uri = path .. "?" .. query
+      else
+        upstream_body.request_uri = path
+      end
+      upstream_body.request_uri_args = kong.request.get_query()
     end
 
     if conf.forward_request_body then
-      ngx_req_read_body()
-
-      local body_args, err_code, body_raw = public_utils.get_body_info()
-      if err_code == public_utils.req_body_errors.unknown_ct then
-        -- don't know what this body MIME type is, base64 it just in case
-        body_raw = ngx_encode_base64(body_raw)
-        upstream_body.request_body_base64 = true
+      local content_type = kong.request.get_header("content-type")
+      local body_raw = kong.request.get_raw_body()
+      local body_args, err = kong.request.get_body()
+      if err and err:match("content type") then
+        body_args = {}
+        if not raw_content_types[content_type] then
+          -- don't know what this body MIME type is, base64 it just in case
+          body_raw = ngx_encode_base64(body_raw)
+          upstream_body.request_body_base64 = true
+        end
       end
 
       upstream_body.request_body      = body_raw
@@ -166,16 +128,14 @@ function AWSLambdaHandler:access(conf)
   else
     -- backwards compatible upstream body for configurations not specifying
     -- `forward_request_*` values
-    ngx_req_read_body()
-
-    local body_args = public_utils.get_body_args()
-    upstream_body = utils.table_merge(ngx_req_get_uri_args(), body_args)
+    local body_args = kong.request.get_body()
+    upstream_body = kong.table.merge(kong.request.get_query(), body_args)
   end
 
   local upstream_body_json, err = cjson.encode(upstream_body)
   if not upstream_body_json then
-    ngx.log(ngx.ERR, "[aws-lambda] could not JSON encode upstream body",
-                     " to forward request values: ", err)
+    kong.log.err("could not JSON encode upstream body",
+                 " to forward request values: ", err)
   end
 
   local host = fmt("lambda.%s.amazonaws.com", conf.aws_region)
@@ -205,7 +165,7 @@ function AWSLambdaHandler:access(conf)
 
   local request, err = aws_v4(opts)
   if err then
-    return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+    return kong.response.exit(500, { message = err })
   end
 
   -- Trigger request
@@ -214,7 +174,7 @@ function AWSLambdaHandler:access(conf)
   client:connect(host, port)
   local ok, err = client:ssl_handshake()
   if not ok then
-    return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+    return kong.response.exit(500, { message = err })
   end
 
   local res, err = client:request {
@@ -224,7 +184,7 @@ function AWSLambdaHandler:access(conf)
     headers = request.headers
   }
   if not res then
-    return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+    return kong.response.exit(500, { message = err })
   end
 
   local content = res:read_body()
@@ -232,7 +192,7 @@ function AWSLambdaHandler:access(conf)
 
   local ok, err = client:set_keepalive(conf.keepalive)
   if not ok then
-    return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+    return kong.response.exit(500, { message = err })
   end
 
   local status
@@ -240,12 +200,13 @@ function AWSLambdaHandler:access(conf)
   if conf.is_proxy_integration then
     local proxy_response, err = extract_proxy_response(content)
     if not proxy_response then
-      return responses.send_HTTP_BAD_GATEWAY("could not JSON decode Lambda " ..
-                                             "function response: " .. err)
+      return kong.response.exit(502, { message = "Bad Gateway",
+                                       error = "could not JSON decode Lambda " ..
+                                               "function response: " .. err })
     end
 
     status = proxy_response.status_code
-    headers = utils.table_merge(headers, proxy_response.headers)
+    headers = kong.table.merge(headers, proxy_response.headers)
     content = proxy_response.body
   end
 
@@ -260,20 +221,7 @@ function AWSLambdaHandler:access(conf)
     end
   end
 
-  local ctx = ngx.ctx
-  if ctx.delay_response and not ctx.delayed_response then
-    ctx.delayed_response = {
-      status_code = status,
-      content     = content,
-      headers     = headers,
-    }
-
-    ctx.delayed_response_callback = flush
-
-    return
-  end
-
-  return send(status, content, headers)
+  return kong.response.exit(status, content, headers)
 end
 
 

--- a/kong/plugins/basic-auth/basicauth_credentials.lua
+++ b/kong/plugins/basic-auth/basicauth_credentials.lua
@@ -1,5 +1,20 @@
 local crypto = require "kong.plugins.basic-auth.crypto"
-local utils  = require "kong.tools.utils"
+
+
+local type = type
+local re_find = ngx.re.find
+
+
+local uuid_regex = "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+
+
+local function is_valid_uuid(str)
+  if type(str) ~= 'string' or #str ~= 36 then
+    return false
+  end
+
+  return re_find(str, uuid_regex, 'ioj') ~= nil
+end
 
 
 local encrypt_password = function(self, cred_id_or_username, cred)
@@ -8,7 +23,7 @@ local encrypt_password = function(self, cred_id_or_username, cred)
   local existing
   if cred_id_or_username then
     local err, err_t
-    if utils.is_valid_uuid(cred_id_or_username) then
+    if is_valid_uuid(cred_id_or_username) then
       existing, err, err_t = self:select({ id = cred_id_or_username })
     else
       existing, err, err_t = self:select_by_username(cred_id_or_username)

--- a/kong/plugins/basic-auth/crypto.lua
+++ b/kong/plugins/basic-auth/crypto.lua
@@ -1,8 +1,8 @@
 -- Module to encrypt the basic-auth credentials password field
-
-local resty_sha1 = require "resty.sha1"
+local sha1 = require "resty.sha1"
 local to_hex = require "resty.string".to_hex
-local format = string.format
+local assert = assert
+
 
 --- Salt the password
 -- Password is salted with the credential's consumer_id (long enough, unique)
@@ -11,8 +11,10 @@ local function salt_password(consumer_id, password)
   if password == nil or password == ngx.null then
     password = ""
   end
-  return format("%s%s", password, consumer_id)
+
+  return password .. consumer_id
 end
+
 
 return {
   --- Encrypt the password field credential table
@@ -20,7 +22,7 @@ return {
   -- @return hash of the salted credential's password
   encrypt = function(consumer_id, password)
     local salted = salt_password(consumer_id, password)
-    local digest = resty_sha1:new()
+    local digest = sha1:new()
     assert(digest:update(salted))
     return to_hex(digest:final())
   end

--- a/kong/plugins/basic-auth/daos.lua
+++ b/kong/plugins/basic-auth/daos.lua
@@ -1,5 +1,6 @@
 local typedefs = require "kong.db.schema.typedefs"
 
+
 return {
   basicauth_credentials = {
     dao = "kong.plugins.basic-auth.basicauth_credentials",

--- a/kong/plugins/basic-auth/handler.lua
+++ b/kong/plugins/basic-auth/handler.lua
@@ -1,20 +1,24 @@
 -- Copyright (C) Kong Inc.
-
 local BasePlugin = require "kong.plugins.base_plugin"
 local access = require "kong.plugins.basic-auth.access"
 
+
 local BasicAuthHandler = BasePlugin:extend()
+
 
 function BasicAuthHandler:new()
   BasicAuthHandler.super.new(self, "basic-auth")
 end
+
 
 function BasicAuthHandler:access(conf)
   BasicAuthHandler.super.access(self)
   access.execute(conf)
 end
 
+
 BasicAuthHandler.PRIORITY = 1001
-BasicAuthHandler.VERSION = "0.1.0"
+BasicAuthHandler.VERSION = "0.1.1"
+
 
 return BasicAuthHandler

--- a/kong/plugins/basic-auth/schema.lua
+++ b/kong/plugins/basic-auth/schema.lua
@@ -1,5 +1,6 @@
 local typedefs = require "kong.db.schema.typedefs"
 
+
 return {
   name = "basic-auth",
   fields = {

--- a/kong/plugins/bot-detection/handler.lua
+++ b/kong/plugins/bot-detection/handler.lua
@@ -1,17 +1,17 @@
 local BasePlugin = require "kong.plugins.base_plugin"
-local responses = require "kong.tools.responses"
 local rules = require "kong.plugins.bot-detection.rules"
-local strip = require("kong.tools.utils").strip
 local lrucache = require "resty.lrucache"
 
 local ipairs = ipairs
-local get_headers = ngx.req.get_headers
 local re_find = ngx.re.find
 
 local BotDetectionHandler = BasePlugin:extend()
 
 BotDetectionHandler.PRIORITY = 2500
 BotDetectionHandler.VERSION = "0.1.0"
+
+local BAD_GATEWAY = 502
+local FORBIDDEN = 403
 
 local MATCH_EMPTY     = 0
 local MATCH_WHITELIST = 1
@@ -25,7 +25,7 @@ local ua_caches = setmetatable({}, { __mode = "k" })
 local UA_CACHE_SIZE = 10 ^ 4
 
 local function get_user_agent()
-  local user_agent = get_headers()["user-agent"]
+  local user_agent = kong.request.get_headers()["user-agent"]
   if type(user_agent) == "table" then
     return nil, "Only one User-Agent header allowed"
   end
@@ -33,7 +33,7 @@ local function get_user_agent()
 end
 
 local function examine_agent(user_agent, conf)
-  user_agent = strip(user_agent)
+  user_agent = user_agent:match("^%s*(.*)%s*$")
 
   if conf.whitelist then
     for _, rule in ipairs(conf.whitelist) do
@@ -69,7 +69,7 @@ function BotDetectionHandler:access(conf)
 
   local user_agent, err = get_user_agent()
   if err then
-    return responses.send_HTTP_BAD_REQUEST(err)
+    return kong.response.exit(BAD_GATEWAY, { message = err })
   end
 
   if not user_agent then
@@ -91,7 +91,7 @@ function BotDetectionHandler:access(conf)
   -- if we saw a blacklisted UA or bot, return forbidden. otherwise,
   -- fall out of our handler
   if match > 1 then
-    return responses.send_HTTP_FORBIDDEN()
+    return kong.response.exit(FORBIDDEN)
   end
 end
 

--- a/kong/plugins/correlation-id/handler.lua
+++ b/kong/plugins/correlation-id/handler.lua
@@ -1,49 +1,58 @@
 -- Copyright (C) Kong Inc.
-
 local BasePlugin = require "kong.plugins.base_plugin"
-local req_set_header = ngx.req.set_header
-local req_get_headers = ngx.req.get_headers
-local uuid = require("kong.tools.utils").uuid
+local uuid = require "kong.tools.utils".uuid
 
-local CorrelationIdHandler = BasePlugin:extend()
 
-CorrelationIdHandler.PRIORITY = 1
-CorrelationIdHandler.VERSION = "0.1.0"
+local kong = kong
+
 
 local worker_uuid
 local worker_counter
+local generators
 
-local fmt = string.format
-local now = ngx.now
-local worker_pid = ngx.worker.pid()
 
-local generators = setmetatable({
-  ["uuid"] = function()
-    return uuid()
-  end,
-  ["uuid#counter"] = function()
-    worker_counter = worker_counter + 1
-    return worker_uuid .. "#" .. worker_counter
-  end,
-  ["tracker"] = function()
-    local var = ngx.var
-    return fmt("%s-%s-%d-%s-%s-%0.3f",
-      var.server_addr,
-      var.server_port,
-      worker_pid,
-      var.connection, -- connection serial number
-      var.connection_requests, -- current number of requests made through a connection
-      now() -- the current time stamp from the nginx cached time.
-    )
-  end,
-}, { __index = function(self, generator)
-    ngx.log(ngx.ERR, "Invalid generator: " .. generator)
+do
+  local worker_pid = ngx.worker.pid()
+  local now = ngx.now
+  local fmt = string.format
+
+  generators = setmetatable({
+    ["uuid"] = function()
+      return uuid()
+    end,
+    ["uuid#counter"] = function()
+      worker_counter = worker_counter + 1
+      return worker_uuid .. "#" .. worker_counter
+    end,
+    ["tracker"] = function()
+      local var = ngx.var
+      return fmt("%s-%s-%d-%s-%s-%0.3f",
+        var.server_addr,
+        var.server_port,
+        worker_pid,
+        var.connection, -- connection serial number
+        var.connection_requests, -- current number of requests made through a connection
+        now() -- the current time stamp from the nginx cached time.
+      )
+    end,
+  }, { __index = function(_, generator)
+      kong.log.err("Invalid generator: " .. generator)
+    end
+  })
 end
-})
+
+
+local CorrelationIdHandler = BasePlugin:extend()
+
+
+CorrelationIdHandler.PRIORITY = 1
+CorrelationIdHandler.VERSION = "0.1.1"
+
 
 function CorrelationIdHandler:new()
   CorrelationIdHandler.super.new(self, "correlation-id")
 end
+
 
 function CorrelationIdHandler:init_worker()
   CorrelationIdHandler.super.init_worker(self)
@@ -51,28 +60,32 @@ function CorrelationIdHandler:init_worker()
   worker_counter = 0
 end
 
+
 function CorrelationIdHandler:access(conf)
   CorrelationIdHandler.super.access(self)
 
   -- Set header for upstream
-  local header_value = req_get_headers()[conf.header_name]
+  local header_value = kong.request.get_header(conf.header_name)
   if not header_value then
     -- Generate the header value
     header_value = generators[conf.generator]()
-    req_set_header(conf.header_name, header_value)
+    kong.service.request.set_header(conf.header_name, header_value)
   end
 
   if conf.echo_downstream then
     -- For later use, to echo it back downstream
-    ngx.ctx.correlationid_header_value = header_value
+    kong.ctx.plugin.correlationid_header_value = header_value
   end
 end
 
+
 function CorrelationIdHandler:header_filter(conf)
   CorrelationIdHandler.super.header_filter(self)
+
   if conf.echo_downstream then
-    ngx.header[conf.header_name] = ngx.ctx.correlationid_header_value
+    kong.response.set_header(conf.header_name, kong.ctx.plugin.correlationid_header_value)
   end
 end
+
 
 return CorrelationIdHandler

--- a/kong/plugins/cors/handler.lua
+++ b/kong/plugins/cors/handler.lua
@@ -1,12 +1,13 @@
 local BasePlugin = require "kong.plugins.base_plugin"
-local responses  = require "kong.tools.responses"
 
 
-local req_get_method  = ngx.req.get_method
 local re_find         = ngx.re.find
 local concat          = table.concat
 local tostring        = tostring
 local ipairs          = ipairs
+
+
+local NO_CONTENT = 204
 
 
 local CorsHandler = BasePlugin:extend()
@@ -16,104 +17,74 @@ CorsHandler.PRIORITY = 2000
 CorsHandler.VERSION = "0.1.0"
 
 
-local function configure_origin(ngx, conf)
+local function configure_origin(conf)
   local n_origins = conf.origins ~= nil and #conf.origins or 0
+  local set_header = kong.response.set_header
 
   if n_origins == 0 then
-    ngx.header["Access-Control-Allow-Origin"] = "*"
-    ngx.ctx.cors_allow_all = true
-    return
+    set_header("Access-Control-Allow-Origin", "*")
+    return true
   end
 
   if n_origins == 1 then
     if conf.origins[1] == "*" then
-      ngx.ctx.cors_allow_all = true
-      ngx.header["Access-Control-Allow-Origin"] = "*"
-      return
+      set_header("Access-Control-Allow-Origin", "*")
+      return true
     end
 
-    ngx.header["Vary"] = "Origin"
+    set_header("Vary", "Origin")
 
     -- if this doesnt look like a regex, set the ACAO header directly
     -- otherwise, we'll fall through to an iterative search and
     -- set the ACAO header based on the client Origin
     local from, _, err = re_find(conf.origins[1], "^[A-Za-z0-9.:/-]+$", "jo")
     if err then
-      ngx.log(ngx.ERR, "[cors] could not inspect origin for type: ", err)
+      kong.log.err("could not inspect origin for type: ", err)
     end
 
     if from then
-      ngx.header["Access-Control-Allow-Origin"] = conf.origins[1]
-      return
+      set_header("Access-Control-Allow-Origin", conf.origins[1])
+      return false
     end
   end
 
-  local req_origin = ngx.var.http_origin
+  local req_origin = kong.request.get_header("origin")
   if req_origin then
     for _, domain in ipairs(conf.origins) do
       local from, _, err = re_find(req_origin, domain, "jo")
       if err then
-        ngx.log(ngx.ERR, "[cors] could not search for domain: ", err)
+        kong.log.err("could not search for domain: ", err)
       end
 
       if from then
-        ngx.header["Access-Control-Allow-Origin"] = req_origin
-        ngx.header["Vary"] = "Origin"
-        return
+        set_header("Access-Control-Allow-Origin", req_origin)
+        set_header("Vary", "Origin")
+        return false
       end
     end
   end
+  return false
 end
 
 
-local function configure_credentials(ngx, conf)
-  if conf.credentials then
-    if not ngx.ctx.cors_allow_all then
-      ngx.header["Access-Control-Allow-Credentials"] = "true"
-      return
-    end
+local function configure_credentials(conf, allow_all)
+  local set_header = kong.response.set_header
 
-    -- Access-Control-Allow-Origin is '*', must change it because ACAC cannot
-    -- be 'true' if ACAO is '*'.
-    local req_origin = ngx.var.http_origin
-    if req_origin then
-      ngx.header["Access-Control-Allow-Origin"]      = req_origin
-      ngx.header["Access-Control-Allow-Credentials"] = "true"
-    end
+  if not conf.credentials then
+    return
   end
-end
 
-
-local function configure_headers(ngx, conf)
-  if not conf.headers then
-    ngx.header["Access-Control-Allow-Headers"] = ngx.var["http_access_control_request_headers"] or ""
-
-  else
-    ngx.header["Access-Control-Allow-Headers"] = concat(conf.headers, ",")
+  if not allow_all then
+    set_header("Access-Control-Allow-Credentials", "true")
+    return
   end
-end
 
-
-local function configure_exposed_headers(ngx, conf)
-  if conf.exposed_headers then
-    ngx.header["Access-Control-Expose-Headers"] = concat(conf.exposed_headers, ",")
-  end
-end
-
-
-local function configure_methods(ngx, conf)
-  if not conf.methods then
-    ngx.header["Access-Control-Allow-Methods"] = "GET,HEAD,PUT,PATCH,POST,DELETE"
-
-  else
-    ngx.header["Access-Control-Allow-Methods"] = concat(conf.methods, ",")
-  end
-end
-
-
-local function configure_max_age(ngx, conf)
-  if conf.max_age then
-    ngx.header["Access-Control-Max-Age"] = tostring(conf.max_age)
+  -- Access-Control-Allow-Origin is '*', must change it because ACAC cannot
+  -- be 'true' if ACAO is '*'.
+  local req_origin = kong.request.get_header("origin")
+  if req_origin then
+    set_header("Access-Control-Allow-Origin", req_origin)
+    set_header("Access-Control-Allow-Credentials", "true")
   end
 end
 
@@ -126,20 +97,40 @@ end
 function CorsHandler:access(conf)
   CorsHandler.super.access(self)
 
-  if req_get_method() == "OPTIONS" then
+  if kong.request.get_method() == "OPTIONS" then
     -- don't add any response header because we are delegating the preflight to
     -- the upstream API (conf.preflight_continue=true), or because we already
     -- added them all
-    ngx.ctx.skip_response_headers = true
+    kong.ctx.plugin.skip_response_headers = true
 
     if not conf.preflight_continue then
-      configure_origin(ngx, conf)
-      configure_credentials(ngx, conf)
-      configure_headers(ngx, conf)
-      configure_methods(ngx, conf)
-      configure_max_age(ngx, conf)
+      local allow_all = configure_origin(conf)
+      configure_credentials(conf, allow_all)
 
-      return responses.send_HTTP_NO_CONTENT()
+      local set_header = kong.response.set_header
+
+      if not conf.headers then
+        local acrh = kong.request.get_header("Access-Control-Request-Headers")
+        if acrh then
+          set_header("Access-Control-Allow-Headers", acrh)
+        else
+          kong.response.clear_header("Access-Control-Allow-Headers")
+        end
+      else
+        set_header("Access-Control-Allow-Headers", concat(conf.headers, ","))
+      end
+
+      if not conf.methods then
+        set_header("Access-Control-Allow-Methods", "GET,HEAD,PUT,PATCH,POST,DELETE")
+      else
+        set_header("Access-Control-Allow-Methods", concat(conf.methods, ","))
+      end
+
+      if conf.max_age then
+        set_header("Access-Control-Max-Age", tostring(conf.max_age))
+      end
+
+      return kong.response.exit(NO_CONTENT)
     end
   end
 end
@@ -148,10 +139,15 @@ end
 function CorsHandler:header_filter(conf)
   CorsHandler.super.header_filter(self)
 
-  if not ngx.ctx.skip_response_headers then
-    configure_origin(ngx, conf)
-    configure_credentials(ngx, conf)
-    configure_exposed_headers(ngx, conf)
+  if not kong.ctx.plugin.skip_response_headers then
+    local allow_all = configure_origin(conf)
+    configure_credentials(conf, allow_all)
+
+    if conf.exposed_headers then
+      kong.response.set_header("Access-Control-Expose-Headers",
+                               concat(conf.exposed_headers, ","))
+    end
+
   end
 end
 

--- a/kong/plugins/hmac-auth/access.lua
+++ b/kong/plugins/hmac-auth/access.lua
@@ -1,24 +1,20 @@
-local utils = require "kong.tools.utils"
-local responses = require "kong.tools.responses"
 local constants = require "kong.constants"
-local openssl_hmac = require "openssl.hmac"
-local resty_sha256 = require "resty.sha256"
+local sha256 = require "resty.sha256"
+local hmac = require "openssl.hmac"
+local stringx = require "pl.stringx"
 
-local math_abs = math.abs
-local ngx_time = ngx.time
-local ngx_gmatch = ngx.re.gmatch
-local ngx_decode_base64 = ngx.decode_base64
-local ngx_encode_base64 = ngx.encode_base64
-local ngx_parse_time = ngx.parse_http_time
-local ngx_set_header = ngx.req.set_header
-local ngx_get_headers = ngx.req.get_headers
-local ngx_log = ngx.log
-local req_read_body = ngx.req.read_body
-local req_get_body_data = ngx.req.get_body_data
-local ngx_hmac_sha1 = ngx.hmac_sha1
-local split = utils.split
-local fmt = string.format
+
+local kong = kong
+local time = ngx.time
+local abs = math.abs
+local decode_base64 = ngx.decode_base64
+local encode_base64 = ngx.encode_base64
+local parse_time = ngx.parse_http_time
+local re_gmatch = ngx.re.gmatch
+local hmac_sha1 = ngx.hmac_sha1
 local ipairs = ipairs
+local fmt = string.format
+
 
 local AUTHORIZATION = "authorization"
 local PROXY_AUTHORIZATION = "proxy-authorization"
@@ -27,6 +23,7 @@ local X_DATE = "x-date"
 local DIGEST = "digest"
 local SIGNATURE_NOT_VALID = "HMAC signature cannot be verified"
 local SIGNATURE_NOT_SAME = "HMAC signature does not match"
+
 
 local new_tab
 do
@@ -38,22 +35,21 @@ do
 end
 
 
-local _M = {}
-
 local hmac = {
   ["hmac-sha1"] = function(secret, data)
-    return ngx_hmac_sha1(secret, data)
+    return hmac_sha1(secret, data)
   end,
   ["hmac-sha256"] = function(secret, data)
-    return openssl_hmac.new(secret, "sha256"):final(data)
+    return hmac.new(secret, "sha256"):final(data)
   end,
   ["hmac-sha384"] = function(secret, data)
-    return openssl_hmac.new(secret, "sha384"):final(data)
+    return hmac.new(secret, "sha384"):final(data)
   end,
   ["hmac-sha512"] = function(secret, data)
-    return openssl_hmac.new(secret, "sha512"):final(data)
-  end
+    return hmac.new(secret, "sha512"):final(data)
+  end,
 }
+
 
 local function list_as_set(list)
   local set = new_tab(0, #list)
@@ -64,6 +60,7 @@ local function list_as_set(list)
   return set
 end
 
+
 local function validate_params(params, conf)
   -- check username and signature are present
   if not params.username and params.signature then
@@ -73,11 +70,13 @@ local function validate_params(params, conf)
   -- check enforced headers are present
   if conf.enforce_headers and #conf.enforce_headers >= 1 then
     local enforced_header_set = list_as_set(conf.enforce_headers)
+
     if params.hmac_headers then
       for _, header in ipairs(params.hmac_headers) do
         enforced_header_set[header] = nil
       end
     end
+
     for _, header in ipairs(conf.enforce_headers) do
       if enforced_header_set[header] then
         return nil, "enforced header not used for signature creation"
@@ -95,81 +94,86 @@ local function validate_params(params, conf)
   return nil, fmt("algorithm %s not supported", params.algorithm)
 end
 
-local function retrieve_hmac_fields(request, headers, header_name, conf)
+
+local function retrieve_hmac_fields(authorization_header)
   local hmac_params = {}
-  local authorization_header = headers[header_name]
+
   -- parse the header to retrieve hamc parameters
   if authorization_header then
-    local iterator, iter_err = ngx_gmatch(authorization_header, "\\s*[Hh]mac\\s*username=\"(.+)\",\\s*algorithm=\"(.+)\",\\s*headers=\"(.+)\",\\s*signature=\"(.+)\"")
+    local iterator, iter_err = re_gmatch(authorization_header,
+                                          "\\s*[Hh]mac\\s*username=\"(.+)\",\\s*algorithm=\"(.+)\",\\s*headers=\"(.+)\",\\s*signature=\"(.+)\"")
     if not iterator then
-      ngx_log(ngx.ERR, iter_err)
+      kong.log.err(iter_err)
       return
     end
 
     local m, err = iterator()
     if err then
-      ngx_log(ngx.ERR, err)
+      kong.log.err(err)
       return
     end
 
     if m and #m >= 4 then
       hmac_params.username = m[1]
       hmac_params.algorithm = m[2]
-      hmac_params.hmac_headers = split(m[3], " ")
+      hmac_params.hmac_headers = stringx.split(m[3], " ")
       hmac_params.signature = m[4]
     end
-  end
-
-  if conf.hide_credentials then
-    request.clear_header(header_name)
   end
 
   return hmac_params
 end
 
+
 -- plugin assumes the request parameters being used for creating
 -- signature by client are not changed by core or any other plugin
-local function create_hash(request, request_uri, hmac_params, headers)
+local function create_hash(request_uri, hmac_params)
   local signing_string = ""
   local hmac_headers = hmac_params.hmac_headers
-  local count = #hmac_headers
 
+  local count = #hmac_headers
   for i = 1, count do
     local header = hmac_headers[i]
-    local header_value = headers[header]
+    local header_value = kong.request.get_header(header)
 
     if not header_value then
       if header == "request-line" then
         -- request-line in hmac headers list
-        local request_line = fmt("%s %s HTTP/%s", ngx.req.get_method(),
-                                 request_uri, ngx.req.http_version())
+        local request_line = fmt("%s %s HTTP/%s", kong.request.get_method(),
+                                 request_uri, kong.request.get_http_version())
         signing_string = signing_string .. request_line
+
       else
         signing_string = signing_string .. header .. ":"
       end
+
     else
       signing_string = signing_string .. header .. ":" .. " " .. header_value
     end
+
     if i < count then
       signing_string = signing_string .. "\n"
     end
   end
+
   return hmac[hmac_params.algorithm](hmac_params.secret, signing_string)
 end
 
-local function validate_signature(request, hmac_params, headers)
-  local signature_1 = create_hash(request, ngx.var.request_uri, hmac_params, headers)
-  local signature_2 = ngx_decode_base64(hmac_params.signature)
+
+local function validate_signature(hmac_params)
+  local signature_1 = create_hash(ngx.var.request_uri, hmac_params)
+  local signature_2 = decode_base64(hmac_params.signature)
 
   if signature_1 == signature_2 then
     return true
   end
 
   -- DEPRECATED BY: https://github.com/Kong/kong/pull/3339
-  local signature_1_deprecated = create_hash(request, ngx.var.uri, hmac_params, headers)
+  local signature_1_deprecated = create_hash(ngx.var.uri, hmac_params)
 
   return signature_1_deprecated == signature_2
 end
+
 
 local function load_credential_into_memory(username)
   local key, err = kong.db.hmacauth_credentials:select_by_username(username)
@@ -178,6 +182,7 @@ local function load_credential_into_memory(username)
   end
   return key
 end
+
 
 local function load_credential(username)
   local credential, err
@@ -189,45 +194,54 @@ local function load_credential(username)
   end
 
   if err then
-    return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+    kong.log.err(err)
+    return kong.response.exit(500, { message = "An unexpected error occurred" })
   end
 
   return credential
 end
 
-local function validate_clock_skew(headers, date_header_name, allowed_clock_skew)
-  local date = headers[date_header_name]
+
+local function validate_clock_skew(date_header_name, allowed_clock_skew)
+  local date = kong.request.get_header(date_header_name)
   if not date then
     return false
   end
 
-  local requestTime = ngx_parse_time(date)
+  local requestTime = parse_time(date)
   if not requestTime then
     return false
   end
 
-  local skew = math_abs(ngx_time() - requestTime)
+  local skew = abs(time() - requestTime)
   if skew > allowed_clock_skew then
     return false
   end
+
   return true
 end
 
-local function validate_body(digest_received)
-  req_read_body()
-  local body = req_get_body_data()
 
-  if not digest_received then
-    -- if there is no digest and no body, it is ok
-    return not body
+local function validate_body()
+  local body, err = kong.request.get_raw_body()
+  if err then
+    kong.log.debug(err)
+    return false
   end
 
-  local sha256 = resty_sha256:new()
-  sha256:update(body or '')
-  local digest_created = "SHA-256=" .. ngx_encode_base64(sha256:final())
+  local digest_received = kong.request.get_header(DIGEST)
+  if not digest_received then
+    -- if there is no digest and no body, it is ok
+    return body == ""
+  end
+
+  local digest = sha256:new()
+  digest:update(body or '')
+  local digest_created = "SHA-256=" .. encode_base64(digest:final())
 
   return digest_created == digest_received
 end
+
 
 local function load_consumer_into_memory(consumer_id, anonymous)
   local result, err = kong.db.consumers:select { id = consumer_id }
@@ -240,62 +254,86 @@ local function load_consumer_into_memory(consumer_id, anonymous)
   return result
 end
 
-local function set_consumer(consumer, credential)
-  ngx_set_header(constants.HEADERS.CONSUMER_ID, consumer.id)
-  ngx_set_header(constants.HEADERS.CONSUMER_CUSTOM_ID, consumer.custom_id)
-  ngx_set_header(constants.HEADERS.CONSUMER_USERNAME, consumer.username)
-  ngx.ctx.authenticated_consumer = consumer
-  if credential then
-    ngx_set_header(constants.HEADERS.CREDENTIAL_USERNAME, credential.username)
-    ngx.ctx.authenticated_credential = credential
-    ngx_set_header(constants.HEADERS.ANONYMOUS, nil) -- in case of auth plugins concatenation
-  else
-    ngx_set_header(constants.HEADERS.ANONYMOUS, true)
-  end
 
+local function set_consumer(consumer, credential)
+  kong.service.request.set_header(constants.HEADERS.CONSUMER_ID, consumer.id)
+  kong.service.request.set_header(constants.HEADERS.CONSUMER_CUSTOM_ID, consumer.custom_id)
+  kong.service.request.set_header(constants.HEADERS.CONSUMER_USERNAME, consumer.username)
+
+  local shared_ctx = kong.ctx.shared
+  local ngx_ctx = ngx.ctx -- TODO: for bc only
+
+  shared_ctx.authenticated_consumer = consumer
+  ngx_ctx.authenticated_consumer = consumer
+
+  if credential then
+    shared_ctx.authenticated_credential = credential
+    ngx_ctx.authenticated_credential = credential
+
+    kong.service.request.set_header(constants.HEADERS.CREDENTIAL_USERNAME, credential.username)
+    kong.service.request.clear_header(constants.HEADERS.ANONYMOUS)
+
+  else
+    kong.service.request.set_header(constants.HEADERS.ANONYMOUS, true)
+  end
 end
 
+
 local function do_authentication(conf)
-  local headers = ngx_get_headers()
+  local authorization = kong.request.get_header(AUTHORIZATION)
+  local proxy_authorization = kong.request.get_header(PROXY_AUTHORIZATION)
+
   -- If both headers are missing, return 401
-  if not (headers[AUTHORIZATION] or headers[PROXY_AUTHORIZATION]) then
-    return false, {status = 401}
+  if not (authorization or proxy_authorization) then
+    return false, { status = 401, message = "Unauthorized" }
   end
 
   -- validate clock skew
-  if not (validate_clock_skew(headers, X_DATE, conf.clock_skew) or validate_clock_skew(headers, DATE, conf.clock_skew)) then
-    return false, {status = 403, message = "HMAC signature cannot be verified, a valid date or x-date header is required for HMAC Authentication"}
+  if not (validate_clock_skew(X_DATE, conf.clock_skew) or
+          validate_clock_skew(DATE, conf.clock_skew)) then
+    return false, {
+      status = 403,
+      message = "HMAC signature cannot be verified, a valid date or " ..
+                "x-date header is required for HMAC Authentication"
+    }
   end
 
   -- retrieve hmac parameter from Proxy-Authorization header
-  local hmac_params = retrieve_hmac_fields(ngx.req, headers, PROXY_AUTHORIZATION, conf)
+  local hmac_params = retrieve_hmac_fields(proxy_authorization)
 
   -- Try with the authorization header
   if not hmac_params.username then
-    hmac_params = retrieve_hmac_fields(ngx.req, headers, AUTHORIZATION, conf)
+    hmac_params = retrieve_hmac_fields(authorization)
+    if hmac_params and conf.hide_credentials then
+      kong.service.request.clear_header(AUTHORIZATION)
+    end
+
+  elseif conf.hide_credentials then
+    kong.service.request.clear_header(PROXY_AUTHORIZATION)
   end
 
   local ok, err = validate_params(hmac_params, conf)
   if not ok then
-    ngx_log(ngx.DEBUG, err)
-    return false, {status = 403, message = SIGNATURE_NOT_VALID}
+    kong.log.debug(err)
+    return false, { status = 403, message = SIGNATURE_NOT_VALID }
   end
 
   -- validate signature
   local credential = load_credential(hmac_params.username)
   if not credential then
-    ngx_log(ngx.DEBUG, "failed to retrieve credential for ", hmac_params.username)
-    return false, {status = 403, message = SIGNATURE_NOT_VALID}
+    kong.log.debug("failed to retrieve credential for ", hmac_params.username)
+    return false, { status = 403, message = SIGNATURE_NOT_VALID }
   end
+
   hmac_params.secret = credential.secret
 
-  if not validate_signature(ngx.req, hmac_params, headers) then
+  if not validate_signature(hmac_params) then
     return false, { status = 403, message = SIGNATURE_NOT_SAME }
   end
 
   -- If request body validation is enabled, then verify digest.
-  if conf.validate_request_body and not validate_body(headers[DIGEST]) then
-    ngx_log(ngx.DEBUG, "digest validation failed")
+  if conf.validate_request_body and not validate_body() then
+    kong.log.debug("digest validation failed")
     return false, { status = 403, message = SIGNATURE_NOT_SAME }
   end
 
@@ -305,7 +343,8 @@ local function do_authentication(conf)
                                             load_consumer_into_memory,
                                             credential.consumer.id)
   if err then
-    return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+    kong.log.err(err)
+    return kong.response.exit(500, { message = "An unexpected error occurred" })
   end
 
   set_consumer(consumer, credential)
@@ -314,12 +353,24 @@ local function do_authentication(conf)
 end
 
 
-function _M.execute(conf)
+local _M = {}
 
-  if ngx.ctx.authenticated_credential and conf.anonymous then
-    -- we're already authenticated, and we're configured for using anonymous,
-    -- hence we're in a logical OR between auth methods and we're already done.
-    return
+
+function _M.execute(conf)
+  if conf.anonymous then
+    local shared_ctx = kong.ctx.shared
+    if shared_ctx.authenticated_credential then
+      -- we're already authenticated, and we're configured for using anonymous,
+      -- hence we're in a logical OR between auth methods and we're already done.
+      return
+    end
+
+    local ngx_ctx = ngx.ctx -- TODO: for bc only
+    if ngx_ctx.authenticated_credential then
+      -- we're already authenticated, and we're configured for using anonymous,
+      -- hence we're in a logical OR between auth methods and we're already done.
+      return
+    end
   end
 
   local ok, err = do_authentication(conf)
@@ -331,11 +382,14 @@ function _M.execute(conf)
                                                 load_consumer_into_memory,
                                                 conf.anonymous, true)
       if err then
-        return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+        kong.log.err(err)
+        return kong.response.exit(500, { message = "An unexpected error occurred" })
       end
+
       set_consumer(consumer, nil)
+
     else
-      return responses.send(err.status, err.message)
+      return kong.response.exit(err.status, { message = err.message }, err.headers)
     end
   end
 end

--- a/kong/plugins/hmac-auth/api.lua
+++ b/kong/plugins/hmac-auth/api.lua
@@ -1,9 +1,10 @@
 local endpoints = require "kong.api.endpoints"
-local responses = require "kong.tools.responses"
 
 
+local kong               = kong
 local credentials_schema = kong.db.hmacauth_credentials.schema
 local consumers_schema   = kong.db.consumers.schema
+
 
 return{
   ["/consumers/:consumers/hmac-auth"] = {
@@ -20,13 +21,13 @@ return{
   ["/consumers/:consumers/hmac-auth/:hmacauth_credentials"] = {
     schema = credentials_schema,
     methods = {
-      before = function(self, db, helpers)
+      before = function(self, db)
         local consumer, _, err_t = endpoints.select_entity(self, db, consumers_schema)
         if err_t then
           return endpoints.handle_error(err_t)
         end
         if not consumer then
-          return responses.send_HTTP_NOT_FOUND()
+          return kong.response.exit(404, { message = "Not found" })
         end
 
         self.consumer = consumer
@@ -38,16 +39,17 @@ return{
 
         if self.req.cmd_mth ~= "PUT" then
           if not cred or cred.consumer.id ~= consumer.id then
-            return responses.send_HTTP_NOT_FOUND()
+            return kong.response.exit(404, { message = "Not found" })
           end
+
           self.hmacauth_credential = cred
           self.params.hmacauth_credentials = cred.id
         end
       end,
       GET  = endpoints.get_entity_endpoint(credentials_schema),
-      PUT  = function(self, db, helpers)
+      PUT  = function(self, ...)
         self.args.post.consumer = { id = self.consumer.id }
-        return endpoints.put_entity_endpoint(credentials_schema)(self, db, helpers)
+        return endpoints.put_entity_endpoint(credentials_schema)(self, ...)
       end,
       PATCH  = endpoints.patch_entity_endpoint(credentials_schema),
       DELETE = endpoints.delete_entity_endpoint(credentials_schema),

--- a/kong/plugins/hmac-auth/daos.lua
+++ b/kong/plugins/hmac-auth/daos.lua
@@ -1,5 +1,6 @@
 local typedefs = require "kong.db.schema.typedefs"
 
+
 return {
   hmacauth_credentials = {
     primary_key = { "id" },

--- a/kong/plugins/hmac-auth/handler.lua
+++ b/kong/plugins/hmac-auth/handler.lua
@@ -1,20 +1,24 @@
 -- Copyright (C) Kong Inc.
-
 local BasePlugin = require "kong.plugins.base_plugin"
 local access = require "kong.plugins.hmac-auth.access"
 
+
 local HMACAuthHandler = BasePlugin:extend()
+
 
 function HMACAuthHandler:new()
   HMACAuthHandler.super.new(self, "hmac-auth")
 end
+
 
 function HMACAuthHandler:access(conf)
   HMACAuthHandler.super.access(self)
   access.execute(conf)
 end
 
+
 HMACAuthHandler.PRIORITY = 1000
-HMACAuthHandler.VERSION = "0.1.0"
+HMACAuthHandler.VERSION = "0.1.1"
+
 
 return HMACAuthHandler

--- a/kong/plugins/jwt/asn_sequence.lua
+++ b/kong/plugins/jwt/asn_sequence.lua
@@ -1,42 +1,59 @@
+local sub = string.sub
+local byte = string.byte
+local char = string.char
+local sort = table.sort
+local type = type
 local error = error
-local string_sub = string.sub
-local string_byte = string.byte
-local string_char = string.char
-local table_sort = table.sort
-local table_insert = table.insert
+local pairs = pairs
+local ipairs = ipairs
+local insert = table.insert
+
 
 local _M = {}
+
+
 _M.__index = _M
+
 
 function _M.create_simple_sequence(input)
   if type(input) ~= "table"
     then error("Argument #1 must be a table", 2)
   end
+
   local sortTable = {}
   for pair in pairs(input) do
-    table_insert(sortTable, pair)
+    insert(sortTable, pair)
   end
-  table_sort(sortTable)
+
+  sort(sortTable)
+
   local numbers = ""
-  for i,n in ipairs(sortTable) do
-    if type(n) ~= "number"
-      then error("Table must use numbers as keys", 2)
+
+  for i, n in ipairs(sortTable) do
+    if type(n) ~= "number" then
+      error("Table must use numbers as keys", 2)
     end
+
     local number = input[sortTable[i]]
     if type(number) ~= "string" then
       error("Table contains non-string value.", 2)
     end
+
     local length = #number
     if length > 0x7F then
       error("Mult-byte lengths are not supported")
     end
-    numbers = numbers .. "\x02" .. string_char(length) .. number
+
+    numbers = numbers .. "\x02" .. char(length) .. number
   end
-  if #numbers > 0x7F
-    then error("Multi-byte lengths are not supported")
+
+  if #numbers > 0x7F then
+    error("Multi-byte lengths are not supported")
   end
-  return "\x30" .. string_char(#numbers) .. numbers
+
+  return "\x30" .. char(#numbers) .. numbers
 end
+
 
 function _M.parse_simple_sequence(input)
   if type(input) ~= "string" then
@@ -44,45 +61,54 @@ function _M.parse_simple_sequence(input)
   elseif #input == 0 then
     error("Argument #1 must not be empty", 2)
   end
-  if string_byte(input, 1) ~= 0x30 then
+
+  if byte(input, 1) ~= 0x30 then
     error("Argument #1 is not a sequence")
   end
-  local length = string_byte(input, 2)
+
+  local length = byte(input, 2)
   if length == nil then
     error("Sequence is incomplete")
   elseif length > 0x7F then
     error("Multi-byte lengths are not supported")
-  elseif length ~= #input-2 then
+  elseif length ~= #input - 2 then
     error("Sequence's asn length does not match expected length")
   end
+
   local seq = {}
   local counter = 1
   local position = 3
+
   while true do
-    if position == #input+1 then
+    if position == #input + 1 then
       break
-    elseif position > #input+1 then
+    elseif position > #input + 1 then
       error("Sequence moved out of bounds.")
     elseif counter > 0xFF then
       error("Sequence is too long")
     end
-    local chunk = string_sub(input, position)
-    if string_byte(chunk, 1) ~= 0x2 then
+
+    local chunk = sub(input, position)
+    if byte(chunk, 1) ~= 0x2 then
       error("Sequence did not contain integers")
     end
-    local integerLength = string_byte(chunk, 2)
+
+    local integerLength = byte(chunk, 2)
     if integerLength > 0x7F then
       error("Multi-byte lengths are not supported.")
-    elseif integerLength > #chunk-2 then
+    elseif integerLength > #chunk - 2 then
       error("Integer is longer than remaining length")
     end
-    local integer = string_sub(chunk, 3, integerLength+2)
+
+    local integer = sub(chunk, 3, integerLength + 2)
     seq[counter] = integer
     position = position + integerLength + 2
     counter = counter + 1
   end
+
   return seq
 end
+
 
 function _M.unsign_integer(input, len)
   if type(input) ~= "string" then
@@ -90,39 +116,50 @@ function _M.unsign_integer(input, len)
   elseif #input == 0 then
     error("Argument #1 must not be empty", 2)
   end
-  if string_byte(input) ~= 0 and #input > len then
+
+  if byte(input) ~= 0 and #input > len then
     error("Cannot unsign integer to length.", 2)
-  elseif string_byte(input) == 0 and #input == len+1 then
-    return string_sub(input, 2)
+  elseif byte(input) == 0 and #input == len + 1 then
+    return sub(input, 2)
   end
+
   if #input == len then
     return input
+
   elseif #input < len then
     while #input < len do
       input = "\x00" .. input
     end
+
     return input
+
   else
+
     error("Unable to unsign integer")
   end
 end
+
 
 -- @param input (string) 32 characters, format to be validated before calling
 function _M.resign_integer(input)
   if type(input) ~= "string" then
     error("Argument #1 must be string", 2)
   end
-  if string_byte(input) > 0x7F then
+
+  if byte(input) > 0x7F then
     input = "\x00" .. input
   end
+
   while true do
-    if string_byte(input) == 0 and string_byte(input, 2) <= 0x7F then
-      input = string_sub(input, 2, -1)
+    if byte(input) == 0 and byte(input, 2) <= 0x7F then
+      input = sub(input, 2, -1)
     else
       break
     end
   end
+
   return input
 end
+
 
 return _M

--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -1,18 +1,22 @@
 local BasePlugin = require "kong.plugins.base_plugin"
-local responses = require "kong.tools.responses"
 local constants = require "kong.constants"
 local jwt_decoder = require "kong.plugins.jwt.jwt_parser"
 
-local ipairs         = ipairs
-local string_format  = string.format
-local ngx_re_gmatch  = ngx.re.gmatch
-local ngx_set_header = ngx.req.set_header
-local get_method     = ngx.req.get_method
+
+local fmt = string.format
+local kong = kong
+local type = type
+local ipairs = ipairs
+local tostring = tostring
+local re_gmatch = ngx.re.gmatch
+
 
 local JwtHandler = BasePlugin:extend()
 
+
 JwtHandler.PRIORITY = 1005
-JwtHandler.VERSION = "0.1.0"
+JwtHandler.VERSION = "0.1.1"
+
 
 --- Retrieve a JWT in a request.
 -- Checks for the JWT in URI parameters, then in cookies, and finally
@@ -21,26 +25,24 @@ JwtHandler.VERSION = "0.1.0"
 -- @param conf Plugin configuration
 -- @return token JWT token contained in request (can be a table) or nil
 -- @return err
-local function retrieve_token(request, conf)
-  local uri_parameters = request.get_uri_args()
-
+local function retrieve_token(conf)
+  local args = kong.request.get_query()
   for _, v in ipairs(conf.uri_param_names) do
-    if uri_parameters[v] then
-      return uri_parameters[v]
+    if args[v] then
+      return args[v]
     end
   end
 
-  local ngx_var = ngx.var
   for _, v in ipairs(conf.cookie_names) do
-    local jwt_cookie = ngx_var["cookie_" .. v]
-    if jwt_cookie and jwt_cookie ~= "" then
-      return jwt_cookie
+    local cookie = ngx.var["cookie_" .. v]
+    if cookie and cookie ~= "" then
+      return cookie
     end
   end
 
-  local authorization_header = request.get_headers()["authorization"]
+  local authorization_header = kong.request.get_header("authorization")
   if authorization_header then
-    local iterator, iter_err = ngx_re_gmatch(authorization_header, "\\s*[Bb]earer\\s+(.+)")
+    local iterator, iter_err = re_gmatch(authorization_header, "\\s*[Bb]earer\\s+(.+)")
     if not iterator then
       return nil, iter_err
     end
@@ -56,9 +58,11 @@ local function retrieve_token(request, conf)
   end
 end
 
+
 function JwtHandler:new()
   JwtHandler.super.new(self, "jwt")
 end
+
 
 local function load_credential(jwt_secret_key)
   local row, err = kong.db.jwt_secrets:select_by_key(jwt_secret_key)
@@ -67,6 +71,7 @@ local function load_credential(jwt_secret_key)
   end
   return row
 end
+
 
 local function load_consumer(consumer_id, anonymous)
   local result, err = kong.db.consumers:select { id = consumer_id }
@@ -79,42 +84,60 @@ local function load_consumer(consumer_id, anonymous)
   return result
 end
 
-local function set_consumer(consumer, jwt_secret, token)
-  ngx_set_header(constants.HEADERS.CONSUMER_ID, consumer.id)
-  ngx_set_header(constants.HEADERS.CONSUMER_CUSTOM_ID, consumer.custom_id)
-  ngx_set_header(constants.HEADERS.CONSUMER_USERNAME, consumer.username)
-  ngx.ctx.authenticated_consumer = consumer
-  if jwt_secret then
-    ngx.ctx.authenticated_credential = jwt_secret
-    ngx.ctx.authenticated_jwt_token = token
-    ngx_set_header(constants.HEADERS.ANONYMOUS, nil) -- in case of auth plugins concatenation
-  else
-    ngx_set_header(constants.HEADERS.ANONYMOUS, true)
-  end
 
+local function set_consumer(consumer, credential, token)
+  kong.service.request.set_header(constants.HEADERS.CONSUMER_ID, consumer.id)
+  kong.service.request.set_header(constants.HEADERS.CONSUMER_CUSTOM_ID, consumer.custom_id)
+  kong.service.request.set_header(constants.HEADERS.CONSUMER_USERNAME, consumer.username)
+
+  local shared_ctx = kong.ctx.shared
+  local ngx_ctx = ngx.ctx -- TODO: for bc only
+
+  shared_ctx.authenticated_consumer = consumer
+  ngx_ctx.authenticated_consumer = consumer
+
+  if credential then
+    shared_ctx.authenticated_credential = credential
+    shared_ctx.authenticated_jwt_token = token
+    ngx_ctx.authenticated_credential = credential
+    ngx_ctx.authenticated_jwt_token = token
+
+    if credential.username then
+      kong.service.request.set_header(constants.HEADERS.CREDENTIAL_USERNAME, credential.username)
+    else
+      kong.service.request.clear_header(constants.HEADERS.CREDENTIAL_USERNAME)
+    end
+
+    kong.service.request.clear_header(constants.HEADERS.ANONYMOUS)
+
+  else
+    kong.service.request.set_header(constants.HEADERS.ANONYMOUS, true)
+  end
 end
 
+
 local function do_authentication(conf)
-  local token, err = retrieve_token(ngx.req, conf)
+  local token, err = retrieve_token(conf)
   if err then
-    return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+    kong.log.err(err)
+    return kong.response.exit(500, { message = "An unexpected error occurred" })
   end
 
-  local ttype = type(token)
-  if ttype ~= "string" then
-    if ttype == "nil" then
-      return false, {status = 401}
-    elseif ttype == "table" then
-      return false, {status = 401, message = "Multiple tokens provided"}
+  local token_type = type(token)
+  if token_type ~= "string" then
+    if token_type == "nil" then
+      return false, { status = 401, message = "Unauthorized" }
+    elseif token_type == "table" then
+      return false, { status = 401, message = "Multiple tokens provided" }
     else
-      return false, {status = 401, message = "Unrecognizable token"}
+      return false, { status = 401, message = "Unrecognizable token" }
     end
   end
 
   -- Decode token to find out who the consumer is
   local jwt, err = jwt_decoder:new(token)
   if err then
-    return false, {status = 401, message = "Bad token; " .. tostring(err)}
+    return false, { status = 401, message = "Bad token; " .. tostring(err) }
   end
 
   local claims = jwt.claims
@@ -122,7 +145,7 @@ local function do_authentication(conf)
 
   local jwt_secret_key = claims[conf.key_claim_name] or header[conf.key_claim_name]
   if not jwt_secret_key then
-    return false, {status = 401, message = "No mandatory '" .. conf.key_claim_name .. "' in claims"}
+    return false, { status = 401, message = "No mandatory '" .. conf.key_claim_name .. "' in claims" }
   end
 
   -- Retrieve the secret
@@ -130,11 +153,12 @@ local function do_authentication(conf)
   local jwt_secret, err      = kong.cache:get(jwt_secret_cache_key, nil,
                                               load_credential, jwt_secret_key)
   if err then
-    return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+    kong.log.err(err)
+    return kong.response.exit(500, { message = "An unexpected error occurred" })
   end
 
   if not jwt_secret then
-    return false, {status = 403, message = "No credentials found for given '" .. conf.key_claim_name .. "'"}
+    return false, { status = 403, message = "No credentials found for given '" .. conf.key_claim_name .. "'" }
   end
 
   local algorithm = jwt_secret.algorithm or "HS256"
@@ -146,30 +170,31 @@ local function do_authentication(conf)
 
   local jwt_secret_value = algorithm ~= nil and algorithm:sub(1, 2) == "HS" and
                              jwt_secret.secret or jwt_secret.rsa_public_key
+
   if conf.secret_is_base64 then
-    jwt_secret_value = jwt:b64_decode(jwt_secret_value)
+    jwt_secret_value = jwt:base64_decode(jwt_secret_value)
   end
 
   if not jwt_secret_value then
-    return false, {status = 403, message = "Invalid key/secret"}
+    return false, { status = 403, message = "Invalid key/secret" }
   end
 
   -- Now verify the JWT signature
   if not jwt:verify_signature(jwt_secret_value) then
-    return false, {status = 403, message = "Invalid signature"}
+    return false, { status = 403, message = "Invalid signature" }
   end
 
   -- Verify the JWT registered claims
   local ok_claims, errors = jwt:verify_registered_claims(conf.claims_to_verify)
   if not ok_claims then
-    return false, {status = 401, message = errors}
+    return false, { status = 401, errors = errors }
   end
 
   -- Verify the JWT registered claims
   if conf.maximum_expiration ~= nil and conf.maximum_expiration > 0 then
     local ok, errors = jwt:check_maximum_expiration(conf.maximum_expiration)
     if not ok then
-      return false, {status = 403, message = errors}
+      return false, { status = 403, errors = errors }
     end
   end
 
@@ -179,12 +204,16 @@ local function do_authentication(conf)
                                             load_consumer,
                                             jwt_secret.consumer.id, true)
   if err then
-    return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+    kong.log.err(err)
+    return kong.response.exit(500, { message = "An unexpected error occurred" })
   end
 
   -- However this should not happen
   if not consumer then
-    return false, {status = 403, message = string_format("Could not find consumer for '%s=%s'", conf.key_claim_name, jwt_secret_key)}
+    return false, {
+      status = 403,
+      message = fmt("Could not find consumer for '%s=%s'", conf.key_claim_name, jwt_secret_key)
+    }
   end
 
   set_consumer(consumer, jwt_secret, token)
@@ -197,14 +226,24 @@ function JwtHandler:access(conf)
   JwtHandler.super.access(self)
 
   -- check if preflight request and whether it should be authenticated
-  if not conf.run_on_preflight and get_method() == "OPTIONS" then
+  if not conf.run_on_preflight and kong.request.get_method() == "OPTIONS" then
     return
   end
 
-  if ngx.ctx.authenticated_credential and conf.anonymous then
-    -- we're already authenticated, and we're configured for using anonymous,
-    -- hence we're in a logical OR between auth methods and we're already done.
-    return
+  if conf.anonymous then
+    local shared_ctx = kong.ctx.shared
+    if shared_ctx.authenticated_credential then
+      -- we're already authenticated, and we're configured for using anonymous,
+      -- hence we're in a logical OR between auth methods and we're already done.
+      return
+    end
+
+    local ngx_ctx = ngx.ctx -- TODO: for bc only
+    if ngx_ctx.authenticated_credential then
+      -- we're already authenticated, and we're configured for using anonymous,
+      -- hence we're in a logical OR between auth methods and we're already done.
+      return
+    end
   end
 
   local ok, err = do_authentication(conf)
@@ -216,11 +255,14 @@ function JwtHandler:access(conf)
                                                 load_consumer,
                                                 conf.anonymous, true)
       if err then
-        return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+        kong.log.err(err)
+        return kong.response.exit(500, { message = "An unexpected error occurred" })
       end
+
       set_consumer(consumer, nil, nil)
+
     else
-      return responses.send(err.status, err.message)
+      return kong.response.exit(err.status, err.errors or { message = err.message })
     end
   end
 end

--- a/kong/plugins/jwt/jwt_parser.lua
+++ b/kong/plugins/jwt/jwt_parser.lua
@@ -6,33 +6,41 @@
 -- @see https://github.com/x25/luajwt
 
 local json = require "cjson"
-local utils = require "kong.tools.utils"
 local openssl_digest = require "openssl.digest"
 local openssl_hmac = require "openssl.hmac"
 local openssl_pkey = require "openssl.pkey"
 local asn_sequence = require "kong.plugins.jwt.asn_sequence"
 
-local error = error
+
+local rep = string.rep
+local sub = string.sub
+local find = string.find
 local type = type
+local time = ngx.time
+local pairs = pairs
+local error = error
 local pcall = pcall
-local ngx_time = ngx.time
-local string_rep = string.rep
-local string_sub = string.sub
-local table_concat = table.concat
+local concat = table.concat
+local insert = table.insert
+local unpack = unpack
+local assert = assert
+local tostring = tostring
 local setmetatable = setmetatable
+local getmetatable = getmetatable
 local encode_base64 = ngx.encode_base64
 local decode_base64 = ngx.decode_base64
 
+
 --- Supported algorithms for signing tokens.
 local alg_sign = {
-  ["HS256"] = function(data, key) return openssl_hmac.new(key, "sha256"):final(data) end,
-  ["HS384"] = function(data, key) return openssl_hmac.new(key, "sha384"):final(data) end,
-  ["HS512"] = function(data, key) return openssl_hmac.new(key, "sha512"):final(data) end,
-  ["RS256"] = function(data, key) return openssl_pkey.new(key):sign(openssl_digest.new("sha256"):update(data)) end,
-  ["RS512"] = function(data, key) return openssl_pkey.new(key):sign(openssl_digest.new("sha512"):update(data)) end,
-  ["ES256"] = function(data, key)
-    local pkeyPrivate = openssl_pkey.new(key)
-    local signature = pkeyPrivate:sign(openssl_digest.new("sha256"):update(data))
+  HS256 = function(data, key) return openssl_hmac.new(key, "sha256"):final(data) end,
+  HS384 = function(data, key) return openssl_hmac.new(key, "sha384"):final(data) end,
+  HS512 = function(data, key) return openssl_hmac.new(key, "sha512"):final(data) end,
+  RS256 = function(data, key) return openssl_pkey.new(key):sign(openssl_digest.new("sha256"):update(data)) end,
+  RS512 = function(data, key) return openssl_pkey.new(key):sign(openssl_digest.new("sha512"):update(data)) end,
+  ES256 = function(data, key)
+    local pkey = openssl_pkey.new(key)
+    local signature = pkey:sign(openssl_digest.new("sha256"):update(data))
 
     local derSequence = asn_sequence.parse_simple_sequence(signature)
     local r = asn_sequence.unsign_integer(derSequence[1], 32)
@@ -43,59 +51,63 @@ local alg_sign = {
   end
 }
 
+
 --- Supported algorithms for verifying tokens.
 local alg_verify = {
-  ["HS256"] = function(data, signature, key) return signature == alg_sign["HS256"](data, key) end,
-  ["HS384"] = function(data, signature, key) return signature == alg_sign["HS384"](data, key) end,
-  ["HS512"] = function(data, signature, key) return signature == alg_sign["HS512"](data, key) end,
-  ["RS256"] = function(data, signature, key)
+  HS256 = function(data, signature, key) return signature == alg_sign.HS256(data, key) end,
+  HS384 = function(data, signature, key) return signature == alg_sign.HS384(data, key) end,
+  HS512 = function(data, signature, key) return signature == alg_sign.HS512(data, key) end,
+  RS256 = function(data, signature, key)
     local pkey_ok, pkey = pcall(openssl_pkey.new, key)
     assert(pkey_ok, "Consumer Public Key is Invalid")
-    local digest = openssl_digest.new('sha256'):update(data)
+    local digest = openssl_digest.new("sha256"):update(data)
     return pkey:verify(signature, digest)
   end,
-  ["RS512"] = function(data, signature, key)
+  RS512 = function(data, signature, key)
     local pkey_ok, pkey = pcall(openssl_pkey.new, key)
     assert(pkey_ok, "Consumer Public Key is Invalid")
-    local digest = openssl_digest.new('sha512'):update(data)
+    local digest = openssl_digest.new("sha512"):update(data)
     return pkey:verify(signature, digest)
   end,
-  ["ES256"] = function(data, signature, key)
+  ES256 = function(data, signature, key)
     local pkey_ok, pkey = pcall(openssl_pkey.new, key)
     assert(pkey_ok, "Consumer Public Key is Invalid")
     assert(#signature == 64, "Signature must be 64 bytes.")
     local asn = {}
-    asn[1] = asn_sequence.resign_integer(string_sub(signature, 1, 32))
-    asn[2] = asn_sequence.resign_integer(string_sub(signature, 33, 64))
+    asn[1] = asn_sequence.resign_integer(sub(signature, 1, 32))
+    asn[2] = asn_sequence.resign_integer(sub(signature, 33, 64))
     local signatureAsn = asn_sequence.create_simple_sequence(asn)
-    local digest = openssl_digest.new('sha256'):update(data)
+    local digest = openssl_digest.new("sha256"):update(data)
     return pkey:verify(signatureAsn, digest)
   end
 }
 
+
 --- base 64 encoding
 -- @param input String to base64 encode
 -- @return Base64 encoded string
-local function b64_encode(input)
-  local result = encode_base64(input)
-  result = result:gsub("+", "-"):gsub("/", "_"):gsub("=", "")
+local function base64_encode(input)
+  local result = encode_base64(input, true)
+  result = result:gsub("+", "-"):gsub("/", "_")
   return result
 end
+
 
 --- base 64 decode
 -- @param input String to base64 decode
 -- @return Base64 decoded string
-local function b64_decode(input)
+local function base64_decode(input)
   local remainder = #input % 4
 
   if remainder > 0 then
     local padlen = 4 - remainder
-    input = input .. string_rep('=', padlen)
+    input = input .. rep("=", padlen)
   end
 
   input = input:gsub("-", "+"):gsub("_", "/")
   return decode_base64(input)
 end
+
 
 --- Tokenize a string by delimiter
 -- Used to separate the header, claims and signature part of a JWT
@@ -106,8 +118,12 @@ end
 local function tokenize(str, div, len)
   local result, pos = {}, 0
 
-  for st, sp in function() return str:find(div, pos, true) end do
-    result[#result + 1] = str:sub(pos, st-1)
+  local iter = function()
+    return find(str, div, pos, true)
+  end
+
+  for st, sp in iter do
+    result[#result + 1] = sub(str, pos, st-1)
     pos = sp + 1
     len = len - 1
     if len <= 1 then
@@ -115,9 +131,10 @@ local function tokenize(str, div, len)
     end
   end
 
-  result[#result + 1] = str:sub(pos)
+  result[#result + 1] = sub(str, pos)
   return result
 end
+
 
 --- Parse a JWT
 -- Parse a JWT and validate header values.
@@ -129,9 +146,9 @@ local function decode_token(token)
 
   -- Decode JSON
   local ok, header, claims, signature = pcall(function()
-    return json.decode(b64_decode(header_64)),
-           json.decode(b64_decode(claims_64)),
-           b64_decode(signature_64)
+    return json.decode(base64_decode(header_64)),
+           json.decode(base64_decode(claims_64)),
+           base64_decode(signature_64)
   end)
   if not ok then
     return nil, "invalid JSON"
@@ -164,14 +181,17 @@ local function decode_token(token)
   }
 end
 
+
 -- For test purposes
 local function encode_token(data, key, alg, header)
   if type(data) ~= "table" then
     error("Argument #1 must be table", 2)
   end
+
   if type(key) ~= "string" then
     error("Argument #2 must be string", 2)
   end
+
   if header and type(header) ~= "table" then
     error("Argument #4 must be a table", 2)
   end
@@ -182,17 +202,42 @@ local function encode_token(data, key, alg, header)
     error("Algorithm not supported", 2)
   end
 
-  local header = header or {typ = "JWT", alg = alg}
+  local header = header or { typ = "JWT", alg = alg }
   local segments = {
-    b64_encode(json.encode(header)),
-    b64_encode(json.encode(data))
+    base64_encode(json.encode(header)),
+    base64_encode(json.encode(data))
   }
 
-  local signing_input = table_concat(segments, ".")
+  local signing_input = concat(segments, ".")
   local signature = alg_sign[alg](signing_input, key)
-  segments[#segments+1] = b64_encode(signature)
-  return table_concat(segments, ".")
+
+  segments[#segments+1] = base64_encode(signature)
+
+  return concat(segments, ".")
 end
+
+
+local err_list_mt = {}
+
+
+local function add_error(errors, k, v)
+  if not errors then
+    errors = {}
+  end
+
+  if errors and errors[k] then
+    if getmetatable(errors[k]) ~= err_list_mt then
+      errors[k] = setmetatable({errors[k]}, err_list_mt)
+    end
+
+    insert(errors[k], v)
+  else
+    errors[k] = v
+  end
+
+  return errors
+end
+
 
 --[[
 
@@ -200,8 +245,12 @@ end
 
 ]]--
 
+
 local _M = {}
+
+
 _M.__index = _M
+
 
 --- Instanciate a JWT parser
 -- Parse a JWT and instanciate a JWT parser for further operations
@@ -222,6 +271,7 @@ function _M:new(token)
   return setmetatable(token, _M)
 end
 
+
 --- Verify a JWT signature
 -- Verify the current JWT signature against a given key
 -- @param key Key against which to verify the signature
@@ -230,29 +280,32 @@ function _M:verify_signature(key)
   return alg_verify[self.header.alg](self.header_64 .. "." .. self.claims_64, self.signature, key)
 end
 
-function _M:b64_decode(input)
-  return b64_decode(input)
+
+function _M:base64_decode(input)
+  return base64_decode(input)
 end
+
 
 --- Registered claims according to RFC 7519 Section 4.1
 local registered_claims = {
-  ["nbf"] = {
+  nbf = {
     type = "number",
     check = function(nbf)
-      if nbf > ngx_time() then
+      if nbf > time() then
         return "token not valid yet"
       end
     end
   },
-  ["exp"] = {
+  exp = {
     type = "number",
     check = function(exp)
-      if exp <= ngx_time() then
+      if exp <= time() then
         return "token expired"
       end
     end
   }
 }
+
 
 --- Verify registered claims (according to RFC 7519 Section 4.1)
 -- Claims are verified by type and a check.
@@ -263,24 +316,29 @@ function _M:verify_registered_claims(claims_to_verify)
   if not claims_to_verify then
     claims_to_verify = {}
   end
-  local errors = nil
-  local claim, claim_rules
+
+  local errors
+  local claim
+  local claim_rules
 
   for _, claim_name in pairs(claims_to_verify) do
     claim = self.claims[claim_name]
     claim_rules = registered_claims[claim_name]
+
     if type(claim) ~= claim_rules.type then
-      errors = utils.add_error(errors, claim_name, "must be a " .. claim_rules.type)
+      errors = add_error(errors, claim_name, "must be a " .. claim_rules.type)
+
     else
       local check_err = claim_rules.check(claim)
       if check_err then
-        errors = utils.add_error(errors, claim_name, check_err)
+        errors = add_error(errors, claim_name, check_err)
       end
     end
   end
 
   return errors == nil, errors
 end
+
 
 --- Check that the maximum allowed expiration is not reached
 -- @param maximum_expiration of the claim
@@ -292,14 +350,16 @@ function _M:check_maximum_expiration(maximum_expiration)
     return true
   end
 
-  local exp = self.claims["exp"]
-  if exp == nil or exp - ngx_time() > maximum_expiration then
-    return false, {exp = "exceeds maximum allowed expiration"}
+  local exp = self.claims.exp
+  if exp == nil or exp - time() > maximum_expiration then
+    return false, { exp = "exceeds maximum allowed expiration" }
   end
 
   return true
 end
 
+
 _M.encode = encode_token
+
 
 return _M

--- a/kong/plugins/key-auth/api.lua
+++ b/kong/plugins/key-auth/api.lua
@@ -1,9 +1,11 @@
 local endpoints = require "kong.api.endpoints"
-local responses = require "kong.tools.responses"
 
 
 local credentials_schema = kong.db.keyauth_credentials.schema
 local consumers_schema   = kong.db.consumers.schema
+
+
+local HTTP_NOT_FOUND = 404
 
 
 return {
@@ -26,7 +28,7 @@ return {
           return endpoints.handle_error(err_t)
         end
         if not consumer then
-          return responses.send_HTTP_NOT_FOUND()
+          return kong.response.exit(HTTP_NOT_FOUND)
         end
 
         self.consumer = consumer
@@ -38,7 +40,7 @@ return {
 
         if self.req.cmd_mth ~= "PUT" then
           if not cred or cred.consumer.id ~= consumer.id then
-            return responses.send_HTTP_NOT_FOUND()
+            return kong.response.exit(HTTP_NOT_FOUND)
           end
           self.keyauth_credential = cred
           self.params.keyauth_credentials = cred.id

--- a/kong/plugins/key-auth/handler.lua
+++ b/kong/plugins/key-auth/handler.lua
@@ -137,7 +137,7 @@ local function do_authentication(conf)
                                     key)
   if err then
     kong.log.err(err)
-    return kong.response.exit(500, "An unexpected error ocurred")
+    return kong.response.exit(500, "An unexpected error occurred")
   end
 
   -- no credential in DB, for this key, it is invalid, HTTP 403
@@ -156,7 +156,7 @@ local function do_authentication(conf)
                                        credential.consumer.id)
   if err then
     kong.log.err(err)
-    return nil, { status = 500, message = "An unexpected error ocurred" }
+    return nil, { status = 500, message = "An unexpected error occurred" }
   end
 
   set_consumer(consumer, credential)
@@ -191,7 +191,7 @@ function KeyAuthHandler:access(conf)
                                            load_consumer, conf.anonymous, true)
       if err then
         kong.log.err(err)
-        return kong.response.exit(500, { message = "An unexpected error ocurred" })
+        return kong.response.exit(500, { message = "An unexpected error occurred" })
       end
 
       set_consumer(consumer, nil)

--- a/kong/plugins/ldap-auth/access.lua
+++ b/kong/plugins/ldap-auth/access.lua
@@ -1,22 +1,20 @@
-local responses = require "kong.tools.responses"
 local constants = require "kong.constants"
 local singletons = require "kong.singletons"
 local ldap = require "kong.plugins.ldap-auth.ldap"
 
+
+local kong = kong
+local decode_base64 = ngx.decode_base64
+local tostring =  tostring
 local match = string.match
 local lower = string.lower
 local upper = string.upper
 local find = string.find
 local sub = string.sub
 local fmt = string.format
-local ngx_log = ngx.log
-local request = ngx.req
-local ngx_error = ngx.ERR
+local tcp = ngx.socket.tcp
 local md5 = ngx.md5
-local decode_base64 = ngx.decode_base64
-local ngx_socket_tcp = ngx.socket.tcp
-local ngx_set_header = ngx.req.set_header
-local tostring =  tostring
+
 
 local AUTHORIZATION = "authorization"
 local PROXY_AUTHORIZATION = "proxy-authorization"
@@ -26,6 +24,7 @@ local ldap_config_cache = setmetatable({}, { __mode = "k" })
 
 
 local _M = {}
+
 
 local function retrieve_credentials(authorization_header_value, conf)
   local username, password
@@ -38,19 +37,23 @@ local function retrieve_credentials(authorization_header_value, conf)
       username, password = match(decoded_cred, "(.+):(.+)")
     end
   end
+
   return username, password
 end
+
 
 local function ldap_authenticate(given_username, given_password, conf)
   local is_authenticated
   local err, suppressed_err, ok
 
-  local sock = ngx_socket_tcp()
+  local sock = tcp()
+
   sock:settimeout(conf.timeout)
+
   ok, err = sock:connect(conf.ldap_host, conf.ldap_port)
   if not ok then
-    ngx_log(ngx_error, "[ldap-auth] failed to connect to ", conf.ldap_host,
-            ":", tostring(conf.ldap_port),": ", err)
+    kong.log.err("failed to connect to ", conf.ldap_host, ":",
+                   tostring(conf.ldap_port), ": ", err)
     return nil, err
   end
 
@@ -59,6 +62,7 @@ local function ldap_authenticate(given_username, given_password, conf)
     if not success then
       return false, err
     end
+
     local _, err = sock:sslhandshake(true, conf.ldap_host, conf.verify_ldap_host)
     if err ~= nil then
       return false, fmt("failed to do SSL handshake with %s:%s: %s",
@@ -71,37 +75,39 @@ local function ldap_authenticate(given_username, given_password, conf)
 
   ok, suppressed_err = sock:setkeepalive(conf.keepalive)
   if not ok then
-    ngx_log(ngx_error, "[ldap-auth] failed to keepalive to ", conf.ldap_host, ":",
-            tostring(conf.ldap_port), ": ", suppressed_err)
+    kong.log.err("failed to keepalive to ", conf.ldap_host, ":",
+                   tostring(conf.ldap_port), ": ", suppressed_err)
   end
+
   return is_authenticated, err
 end
 
 local function load_credential(given_username, given_password, conf)
   local ok, err = ldap_authenticate(given_username, given_password, conf)
   if err ~= nil then
-    ngx_log(ngx_error, err)
+    kong.log.err(err)
   end
 
   if ok == nil then
     return nil
   end
+
   if ok == false then
     return false
   end
-  return {username = given_username, password = given_password}
+
+  return { username = given_username, password = given_password }
 end
 
 
 local function cache_key(conf, username, password)
   if not ldap_config_cache[conf] then
     ldap_config_cache[conf] = md5(fmt("%s:%u:%s:%s:%u",
-      lower(conf.ldap_host),
-      conf.ldap_port,
-      conf.base_dn,
-      conf.attribute,
-      conf.cache_ttl
-    ))
+                                      lower(conf.ldap_host),
+                                      conf.ldap_port,
+                                      conf.base_dn,
+                                      conf.attribute,
+                                      conf.cache_ttl))
   end
 
   return fmt("ldap_auth_cache:%s:%s:%s", ldap_config_cache[conf],
@@ -110,8 +116,7 @@ end
 
 
 local function authenticate(conf, given_credentials)
-  local given_username, given_password = retrieve_credentials(given_credentials,
-                                                              conf)
+  local given_username, given_password = retrieve_credentials(given_credentials, conf)
   if given_username == nil then
     return false
   end
@@ -120,12 +125,15 @@ local function authenticate(conf, given_credentials)
     ttl = conf.cache_ttl,
     neg_ttl = conf.cache_ttl
   }, load_credential, given_username, given_password, conf)
+
   if err or credential == nil then
-    return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+    kong.log.err(err)
+    return kong.response.exit(500, { message = "An unexpected error occurred" })
   end
 
   return credential and credential.password == given_password, credential
 end
+
 
 local function load_consumer(consumer_id, anonymous)
   local result, err = singletons.db.consumers:select { id = consumer_id }
@@ -135,38 +143,49 @@ local function load_consumer(consumer_id, anonymous)
     end
     return nil, err
   end
+
   return result
 end
 
+
 local function set_consumer(consumer, credential)
+  local shared_ctx = kong.ctx.shared
+  local ngx_ctx = ngx.ctx -- TODO: for bc only
 
   if consumer then
     -- this can only be the Anonymous user in this case
-    ngx_set_header(constants.HEADERS.CONSUMER_ID, consumer.id)
-    ngx_set_header(constants.HEADERS.CONSUMER_CUSTOM_ID, consumer.custom_id)
-    ngx_set_header(constants.HEADERS.CONSUMER_USERNAME, consumer.username)
-    ngx_set_header(constants.HEADERS.ANONYMOUS, true)
-    ngx.ctx.authenticated_consumer = consumer
+    kong.service.request.set_header(constants.HEADERS.CONSUMER_ID, consumer.id)
+    kong.service.request.set_header(constants.HEADERS.CONSUMER_CUSTOM_ID, consumer.custom_id)
+    kong.service.request.set_header(constants.HEADERS.CONSUMER_USERNAME, consumer.username)
+    kong.service.request.set_header(constants.HEADERS.ANONYMOUS, true)
+
+    shared_ctx.authenticated_consumer = consumer
+    ngx_ctx.authenticated_consumer = consumer -- TODO: for bc only
+
     return
   end
 
-  -- here we have been authenticated by ldap
-  ngx_set_header(constants.HEADERS.CREDENTIAL_USERNAME, credential.username)
-  ngx.ctx.authenticated_credential = credential
+  if credential then
+    -- here we have been authenticated by ldap
+    kong.service.request.set_header(constants.HEADERS.CREDENTIAL_USERNAME, credential.username)
+
+    ngx_ctx.authenticated_credential = credential
+  end
 
   -- in case of auth plugins concatenation, remove remnants of anonymous
-  ngx.ctx.authenticated_consumer = nil
-  ngx_set_header(constants.HEADERS.ANONYMOUS, nil)
-  ngx_set_header(constants.HEADERS.CONSUMER_ID, nil)
-  ngx_set_header(constants.HEADERS.CONSUMER_CUSTOM_ID, nil)
-  ngx_set_header(constants.HEADERS.CONSUMER_USERNAME, nil)
+  shared_ctx.authenticated_consumer = nil
+  ngx_ctx.authenticated_consumer = nil -- TODO: for bc only
 
+  kong.service.request.clear_header(constants.HEADERS.ANONYMOUS)
+  kong.service.request.clear_header(constants.HEADERS.CONSUMER_ID)
+  kong.service.request.clear_header(constants.HEADERS.CONSUMER_CUSTOM_ID)
+  kong.service.request.clear_header(constants.HEADERS.CONSUMER_USERNAME)
 end
 
+
 local function do_authentication(conf)
-  local headers = request.get_headers()
-  local authorization_value = headers[AUTHORIZATION]
-  local proxy_authorization_value = headers[PROXY_AUTHORIZATION]
+  local authorization_value = kong.request.get_header(AUTHORIZATION)
+  local proxy_authorization_value = kong.request.get_header(PROXY_AUTHORIZATION)
 
   -- If both headers are missing, return 401
   if not (authorization_value or proxy_authorization_value) then
@@ -177,8 +196,11 @@ local function do_authentication(conf)
       scheme = upper(scheme)
     end
 
-    ngx.header["WWW-Authenticate"] = scheme .. ' realm="kong"'
-    return false, {status = 401}
+    return false, {
+      status = 401,
+      message = "Unauthorized",
+      headers = { ["WWW-Authenticate"] = scheme .. ' realm="kong"' }
+    }
   end
 
   local is_authorized, credential = authenticate(conf, proxy_authorization_value)
@@ -187,12 +209,12 @@ local function do_authentication(conf)
   end
 
   if not is_authorized then
-    return false, {status = 403, message = "Invalid authentication credentials"}
+    return false, {status = 403, message = "Invalid authentication credentials" }
   end
 
   if conf.hide_credentials then
-    request.clear_header(AUTHORIZATION)
-    request.clear_header(PROXY_AUTHORIZATION)
+    kong.service.request.clear_header(AUTHORIZATION)
+    kong.service.request.clear_header(PROXY_AUTHORIZATION)
   end
 
   set_consumer(nil, credential)
@@ -202,11 +224,20 @@ end
 
 
 function _M.execute(conf)
+  if conf.anonymous then
+    local shared_ctx = kong.ctx.shared
+    if shared_ctx.authenticated_credential then
+      -- we're already authenticated, and we're configured for using anonymous,
+      -- hence we're in a logical OR between auth methods and we're already done.
+      return
+    end
 
-  if ngx.ctx.authenticated_credential and conf.anonymous then
-    -- we're already authenticated, and we're configured for using anonymous,
-    -- hence we're in a logical OR between auth methods and we're already done.
-    return
+    local ngx_ctx = ngx.ctx -- TODO: for bc only
+    if ngx_ctx.authenticated_credential then
+      -- we're already authenticated, and we're configured for using anonymous,
+      -- hence we're in a logical OR between auth methods and we're already done.
+      return
+    end
   end
 
   local ok, err = do_authentication(conf)
@@ -218,11 +249,14 @@ function _M.execute(conf)
                                                       load_consumer,
                                                       conf.anonymous, true)
       if err then
-        responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+        kong.log.err(err)
+        return kong.response.exit(500, { message = "An unexpected error occurred" })
       end
+
       set_consumer(consumer, nil)
+
     else
-      return responses.send(err.status, err.message)
+      return kong.response.exit(err.status, { message = err.message }, err.headers)
     end
   end
 end

--- a/kong/plugins/ldap-auth/handler.lua
+++ b/kong/plugins/ldap-auth/handler.lua
@@ -1,18 +1,23 @@
 local access = require "kong.plugins.ldap-auth.access"
 local BasePlugin = require "kong.plugins.base_plugin"
 
+
 local LdapAuthHandler = BasePlugin:extend()
+
 
 function LdapAuthHandler:new()
   LdapAuthHandler.super.new(self, "ldap-auth")
 end
+
 
 function LdapAuthHandler:access(conf)
   LdapAuthHandler.super.access(self)
   access.execute(conf)
 end
 
+
 LdapAuthHandler.PRIORITY = 1002
-LdapAuthHandler.VERSION = "0.1.0"
+LdapAuthHandler.VERSION = "0.1.1"
+
 
 return LdapAuthHandler

--- a/kong/plugins/ldap-auth/ldap.lua
+++ b/kong/plugins/ldap-auth/ldap.lua
@@ -1,11 +1,15 @@
 local asn1 = require "kong.plugins.ldap-auth.asn1"
-local bunpack = string.unpack
 
-local string_format = string.format
+
+local bunpack = string.unpack
+local fmt = string.format
+
 
 local _M = {}
 
+
 local ldapMessageId = 1
+
 
 local ERROR_MSG = {
   [1]  = "Initialization of LDAP library failed.",
@@ -16,6 +20,7 @@ local ERROR_MSG = {
   [49] = "The supplied credential is invalid."
 }
 
+
 local APPNO = {
   BindRequest = 0,
   BindResponse = 1,
@@ -24,28 +29,36 @@ local APPNO = {
   ExtendedResponse = 24
 }
 
+
 local function encodeLDAPOp(encoder, appno, isConstructed, data)
   local asn1_type = asn1.BERtoInt(asn1.BERCLASS.Application, isConstructed, appno)
-  return encoder:encode({ _ldaptype = string_format("%X", asn1_type), data })
+  return encoder:encode({ _ldaptype = fmt("%X", asn1_type), data })
 end
 
-local function claculate_payload_length(encStr, pos, socket)
+
+local function calculate_payload_length(encStr, pos, socket)
   local elen
-  pos, elen = bunpack(encStr, 'C', pos)
+
+  pos, elen = bunpack(encStr, "C", pos)
+
   if elen > 128 then
     elen = elen - 128
     local elenCalc = 0
     local elenNext
+
     for i = 1, elen do
       elenCalc = elenCalc * 256
       encStr = encStr .. socket:receive(1)
-      pos, elenNext = bunpack(encStr, 'C', pos)
+      pos, elenNext = bunpack(encStr, "C", pos)
       elenCalc = elenCalc + elenNext
     end
+
     elen = elenCalc
   end
+
   return pos, elen
 end
+
 
 function _M.bind_request(socket, username, password)
   local encoder = asn1.ASN1Encoder:new()
@@ -54,16 +67,25 @@ function _M.bind_request(socket, username, password)
   local ldapAuth = encoder:encode({ _ldaptype = 80, password })
   local bindReq = encoder:encode(3) .. encoder:encode(username) .. ldapAuth
   local ldapMsg = encoder:encode(ldapMessageId) ..
-    encodeLDAPOp(encoder, APPNO.BindRequest, true, bindReq)
+                    encodeLDAPOp(encoder, APPNO.BindRequest, true, bindReq)
+
   local packet
-  local pos, packet_len, tmp, _
+  local pos
+  local packet_len
+  local tmp
+  local _
+
   local response = {}
 
   packet = encoder:encodeSeq(ldapMsg)
-  ldapMessageId = ldapMessageId +1
+
+  ldapMessageId = ldapMessageId + 1
+
   socket:send(packet)
+
   packet = socket:receive(2)
-  _, packet_len = claculate_payload_length(packet, 2, socket)
+
+  _, packet_len = calculate_payload_length(packet, 2, socket)
 
   packet = socket:receive(packet_len)
   pos, response.messageID = decoder:decode(packet, 1)
@@ -72,8 +94,8 @@ function _M.bind_request(socket, username, password)
   response.protocolOp = asn1.intToBER(tmp)
 
   if response.protocolOp.number ~= APPNO.BindResponse then
-    return false, string_format("Received incorrect Op in packet: %d, expected %d",
-                                response.protocolOp.number, APPNO.BindResponse)
+    return false, fmt("Received incorrect Op in packet: %d, expected %d",
+                      response.protocolOp.number, APPNO.BindResponse)
   end
 
   pos, response.resultCode = decoder:decode(packet, pos)
@@ -83,9 +105,11 @@ function _M.bind_request(socket, username, password)
     pos, response.matchedDN = decoder:decode(packet, pos)
     _, response.errorMessage = decoder:decode(packet, pos)
     error_msg = ERROR_MSG[response.resultCode]
-    return false, string_format("\n  Error: %s\n  Details: %s",
-      error_msg or "Unknown error occurred (code: " .. response.resultCode ..
-      ")", response.errorMessage or "")
+
+    return false, fmt("\n  Error: %s\n  Details: %s",
+                      error_msg or "Unknown error occurred (code: " ..
+                      response.resultCode .. ")", response.errorMessage or "")
+
   else
     return true
   end
@@ -96,30 +120,37 @@ function _M.unbind_request(socket)
   local ldapMsg, packet
   local encoder = asn1.ASN1Encoder:new()
 
-  ldapMessageId = ldapMessageId +1
+  ldapMessageId = ldapMessageId + 1
+
   ldapMsg = encoder:encode(ldapMessageId) ..
-            encodeLDAPOp(encoder, APPNO.UnbindRequest,
-                         false, nil)
+                           encodeLDAPOp(encoder, APPNO.UnbindRequest,
+                                        false, nil)
   packet = encoder:encodeSeq(ldapMsg)
+
   socket:send(packet)
+
   return true, ""
 end
 
-function _M.start_tls(socket)
 
+function _M.start_tls(socket)
   local ldapMsg, pos, packet, packet_len, tmp, _
   local response = {}
   local encoder = asn1.ASN1Encoder:new()
   local decoder = asn1.ASN1Decoder:new()
 
-  local method_name = encoder:encode({_ldaptype = 80, "1.3.6.1.4.1.1466.20037"})
-  ldapMessageId = ldapMessageId +1
+  local method_name = encoder:encode({ _ldaptype = 80, "1.3.6.1.4.1.1466.20037" })
+
+  ldapMessageId = ldapMessageId + 1
+
   ldapMsg = encoder:encode(ldapMessageId) ..
-    encodeLDAPOp(encoder, APPNO.ExtendedRequest, true, method_name)
+                           encodeLDAPOp(encoder, APPNO.ExtendedRequest, true, method_name)
+
   packet = encoder:encodeSeq(ldapMsg)
   socket:send(packet)
   packet = socket:receive(2)
-  _, packet_len = claculate_payload_length(packet, 2, socket)
+
+  _, packet_len = calculate_payload_length(packet, 2, socket)
 
   packet = socket:receive(packet_len)
   pos, response.messageID = decoder:decode(packet, 1)
@@ -128,23 +159,27 @@ function _M.start_tls(socket)
   response.protocolOp = asn1.intToBER(tmp)
 
   if response.protocolOp.number ~= APPNO.ExtendedResponse then
-    return false, string_format("Received incorrect Op in packet: %d, expected %d",
-                                response.protocolOp.number, APPNO.ExtendedResponse)
+    return false, fmt("Received incorrect Op in packet: %d, expected %d",
+                      response.protocolOp.number, APPNO.ExtendedResponse)
   end
 
   pos, response.resultCode = decoder:decode(packet, pos)
 
   if response.resultCode ~= 0 then
     local error_msg
+
     pos, response.matchedDN = decoder:decode(packet, pos)
     _, response.errorMessage = decoder:decode(packet, pos)
     error_msg = ERROR_MSG[response.resultCode]
-    return false, string_format("\n  Error: %s\n  Details: %s",
-      error_msg or "Unknown error occurred (code: " .. response.resultCode ..
-      ")", response.errorMessage or "")
+
+    return false, fmt("\n  Error: %s\n  Details: %s",
+                      error_msg or "Unknown error occurred (code: " ..
+                      response.resultCode .. ")", response.errorMessage or "")
+
   else
     return true
   end
 end
+
 
 return _M;

--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -110,7 +110,7 @@ local function retrieve_parameters()
     ngx.req.read_body()
     local body_args = public_utils.get_body_args()
 
-    return utils.table_merge(uri_args, body_args)
+    return kong.table.merge(uri_args, body_args)
   end
 
   return uri_args
@@ -224,7 +224,7 @@ local function authorize(conf)
 
   -- Appending kong generated params to redirect_uri query string
   if parsed_redirect_uri then
-    local encoded_params = utils.encode_args(utils.table_merge(ngx.decode_args(
+    local encoded_params = utils.encode_args(kong.table.merge(ngx.decode_args(
       (is_implicit_grant and
         (parsed_redirect_uri.fragment and parsed_redirect_uri.fragment or "") or
         (parsed_redirect_uri.query and parsed_redirect_uri.query or "")

--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -1,22 +1,27 @@
 local url = require "socket.url"
 local utils = require "kong.tools.utils"
-local responses = require "kong.tools.responses"
 local constants = require "kong.constants"
 local timestamp = require "kong.tools.timestamp"
-local public_utils = require "kong.tools.public"
+
 
 local string_find = string.find
-local req_get_headers = ngx.req.get_headers
-local ngx_set_header = ngx.req.set_header
-local ngx_req_get_method = ngx.req.get_method
-local ngx_req_get_uri_args = ngx.req.get_uri_args
+
+
+local split = utils.split
+local strip = utils.strip
 local check_https = utils.check_https
+local encode_args = utils.encode_args
+local random_string = utils.random_string
+local table_contains = utils.table_contains
+
+
+local ngx_decode_args = ngx.decode_args
+local ngx_re_gmatch = ngx.re.gmatch
+local ngx_decode_base64 = ngx.decode_base64
 
 
 local _M = {}
 
-local CONTENT_LENGTH = "content-length"
-local CONTENT_TYPE = "content-type"
 local RESPONSE_TYPE = "response_type"
 local STATE = "state"
 local CODE = "code"
@@ -36,12 +41,30 @@ local ERROR = "error"
 local AUTHENTICATED_USERID = "authenticated_userid"
 
 
+local HTTP_INTERNAL_SERVER_ERROR = 500
+
+
+local function get_ctx(k)
+  local v = kong.ctx.shared[k] -- forward compatibility
+  if v ~= nil then
+    return v
+  end
+  return ngx.ctx[k] -- backward compatibility
+end
+
+
+local function set_ctx(k, v)
+  kong.ctx.shared[k] = v  -- forward compatibility
+  ngx.ctx[k] = v          -- backward compatibility
+end
+
+
 local function generate_token(conf, service, api, credential, authenticated_userid, scope, state, expiration, disable_refresh)
   local token_expiration = expiration or conf.token_expiration
 
   local refresh_token
   if not disable_refresh and token_expiration > 0 then
-    refresh_token = utils.random_string()
+    refresh_token = random_string()
   end
 
   local refresh_token_ttl
@@ -67,7 +90,7 @@ local function generate_token(conf, service, api, credential, authenticated_user
                                                                 -- permanently deleted after 'refresh_token_ttl' seconds
 
   if err then
-    return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+    return kong.response.exit(HTTP_INTERNAL_SERVER_ERROR, { message = err })
   end
 
   return {
@@ -95,7 +118,7 @@ local function get_redirect_uris(client_id)
                                  load_oauth2_credential_by_client_id_into_memory,
                                  client_id)
     if err then
-      return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+      return kong.response.exit(HTTP_INTERNAL_SERVER_ERROR, { message = err })
     end
   end
   return client and client.redirect_uris or nil, client
@@ -103,12 +126,11 @@ end
 
 local function retrieve_parameters()
   -- OAuth2 parameters could be in both the querystring or body
-  local uri_args = ngx_req_get_uri_args()
-  local method   = ngx_req_get_method()
+  local uri_args = kong.request.get_query()
+  local method   = kong.request.get_method()
 
   if method == "POST" or method == "PUT" or method == "PATCH" then
-    ngx.req.read_body()
-    local body_args = public_utils.get_body_args()
+    local body_args = kong.request.get_body()
 
     return kong.table.merge(uri_args, body_args)
   end
@@ -126,7 +148,7 @@ local function retrieve_scope(parameters, conf)
     end
 
     for v in scope:gmatch("%S+") do
-      if not utils.table_contains(conf.scopes, v) then
+      if not table_contains(conf.scopes, v) then
         return nil, {[ERROR] = "invalid_scope", error_description = "\"" .. v .. "\" is an invalid " .. SCOPE}
       else
         table.insert(scopes, v)
@@ -148,14 +170,14 @@ local function authorize(conf)
   local allowed_redirect_uris, client, redirect_uri, parsed_redirect_uri
   local is_implicit_grant
 
-  local is_https, err = check_https(kong.ip.is_trusted(ngx.var.realip_remote_addr),
+  local is_https, err = check_https(kong.ip.is_trusted(kong.client.get_ip()),
                                     conf.accept_http_if_already_terminated)
   if not is_https then
     response_params = {[ERROR] = "access_denied", error_description = err or "You must use HTTPS"}
   else
     if conf.provision_key ~= parameters.provision_key then
       response_params = {[ERROR] = "invalid_provision_key", error_description = "Invalid provision_key"}
-    elseif not parameters.authenticated_userid or utils.strip(parameters.authenticated_userid) == "" then
+    elseif not parameters.authenticated_userid or strip(parameters.authenticated_userid) == "" then
       response_params = {[ERROR] = "invalid_authenticated_userid", error_description = "Missing authenticated_userid parameter"}
     else
       local response_type = parameters[RESPONSE_TYPE]
@@ -178,7 +200,7 @@ local function authorize(conf)
       else
         redirect_uri = parameters[REDIRECT_URI] and parameters[REDIRECT_URI] or allowed_redirect_uris[1]
 
-        if not utils.table_contains(allowed_redirect_uris, redirect_uri) then
+        if not table_contains(allowed_redirect_uris, redirect_uri) then
           response_params = {[ERROR] = "invalid_request", error_description = "Invalid " .. REDIRECT_URI .. " that does not match with any redirect_uri created with the application" }
           -- redirect_uri used in this case is the first one registered with the application
           redirect_uri = allowed_redirect_uris[1]
@@ -192,8 +214,8 @@ local function authorize(conf)
         if response_type == CODE then
           local service_id, api_id
           if not conf.global_credentials then
-            service_id = ngx.ctx.service.id
-            api_id = ngx.ctx.api.id
+            service_id = get_ctx("service").id
+            api_id = get_ctx("api").id
           end
           local authorization_code, err = kong.db.oauth2_authorization_codes:insert({
             service = service_id and { id = service_id } or nil,
@@ -204,7 +226,7 @@ local function authorize(conf)
           }, { ttl = 300 })
 
           if err then
-            return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+            return kong.response.exit(HTTP_INTERNAL_SERVER_ERROR, { message = err })
           end
 
           response_params = {
@@ -212,7 +234,7 @@ local function authorize(conf)
           }
         else
           -- Implicit grant, override expiration to zero
-          response_params = generate_token(conf, ngx.ctx.service, ngx.ctx.api, client, parameters[AUTHENTICATED_USERID], scopes, state, nil, true)
+          response_params = generate_token(conf, get_ctx("service"), get_ctx("api"), client, parameters[AUTHENTICATED_USERID], scopes, state, nil, true)
           is_implicit_grant = true
         end
       end
@@ -224,7 +246,7 @@ local function authorize(conf)
 
   -- Appending kong generated params to redirect_uri query string
   if parsed_redirect_uri then
-    local encoded_params = utils.encode_args(kong.table.merge(ngx.decode_args(
+    local encoded_params = encode_args(kong.table.merge(ngx_decode_args(
       (is_implicit_grant and
         (parsed_redirect_uri.fragment and parsed_redirect_uri.fragment or "") or
         (parsed_redirect_uri.query and parsed_redirect_uri.query or "")
@@ -246,7 +268,7 @@ local function authorize(conf)
     body = response_params
   end
 
-  return responses.send(status, body, {
+  return kong.response.exit(status, body, {
     ["cache-control"] = "no-store",
     ["pragma"] = "no-cache"
   })
@@ -254,28 +276,28 @@ end
 
 local function retrieve_client_credentials(parameters, conf)
   local client_id, client_secret, from_authorization_header
-  local authorization_header = ngx.req.get_headers()[conf.auth_header_name]
+  local authorization_header = kong.request.get_header(conf.auth_header_name)
   if parameters[CLIENT_ID] and parameters[CLIENT_SECRET] then
     client_id = parameters[CLIENT_ID]
     client_secret = parameters[CLIENT_SECRET]
   elseif authorization_header then
     from_authorization_header = true
-    local iterator, iter_err = ngx.re.gmatch(authorization_header, "\\s*[Bb]asic\\s*(.+)")
+    local iterator, iter_err = ngx_re_gmatch(authorization_header, "\\s*[Bb]asic\\s*(.+)")
     if not iterator then
-      ngx.log(ngx.ERR, iter_err)
+      kong.log.err(iter_err)
       return
     end
 
     local m, err = iterator()
     if err then
-      ngx.log(ngx.ERR, err)
+      kong.log.err(err)
       return
     end
 
     if m and next(m) then
-      local decoded_basic = ngx.decode_base64(m[1])
+      local decoded_basic = ngx_decode_base64(m[1])
       if decoded_basic then
-        local basic_parts = utils.split(decoded_basic, ":")
+        local basic_parts = split(decoded_basic, ":")
         client_id = basic_parts[1]
         client_secret = basic_parts[2]
       end
@@ -292,7 +314,7 @@ local function issue_token(conf)
   local parameters = retrieve_parameters()
   local state = parameters[STATE]
 
-  local is_https, err = check_https(kong.ip.is_trusted(ngx.var.realip_remote_addr),
+  local is_https, err = check_https(kong.ip.is_trusted(kong.client.get_ip()),
                                     conf.accept_http_if_already_terminated)
   if not is_https then
     response_params = {[ERROR] = "access_denied", error_description = err or "You must use HTTPS"}
@@ -311,7 +333,7 @@ local function issue_token(conf)
     local allowed_redirect_uris, client = get_redirect_uris(client_id)
     if allowed_redirect_uris then
       local redirect_uri = parameters[REDIRECT_URI] and parameters[REDIRECT_URI] or allowed_redirect_uris[1]
-      if not utils.table_contains(allowed_redirect_uris, redirect_uri) then
+      if not table_contains(allowed_redirect_uris, redirect_uri) then
         response_params = {[ERROR] = "invalid_request", error_description = "Invalid " .. REDIRECT_URI .. " that does not match with any redirect_uri created with the application" }
       end
 
@@ -334,8 +356,8 @@ local function issue_token(conf)
         local code = parameters[CODE]
         local service_id, api_id
         if not conf.global_credentials then
-          service_id = ngx.ctx.service.id
-          api_id = ngx.ctx.api.id
+          service_id = get_ctx("service").id
+          api_id = get_ctx("api").id
         end
         local authorization_code =
           code and kong.db.oauth2_authorization_codes:select_by_code(code)
@@ -352,7 +374,7 @@ local function issue_token(conf)
                              error_description = "Invalid " .. CODE}
 
         else
-          response_params = generate_token(conf, ngx.ctx.service, ngx.ctx.api, client,
+          response_params = generate_token(conf, get_ctx("service"), get_ctx("api"), client,
                                            authorization_code.authenticated_userid, authorization_code.scope, state)
           kong.db.oauth2_authorization_codes:delete({ id = authorization_code.id }) -- Delete authorization code so it cannot be reused
         end
@@ -369,7 +391,7 @@ local function issue_token(conf)
             response_params = err -- If it's not ok, then this is the error message
 
           else
-            response_params = generate_token(conf, ngx.ctx.service, ngx.ctx.api, client,
+            response_params = generate_token(conf, get_ctx("service"), get_ctx("api"), client,
                                              parameters.authenticated_userid, scope, state, nil, true)
           end
         end
@@ -379,7 +401,7 @@ local function issue_token(conf)
         if conf.provision_key ~= parameters.provision_key then
           response_params = {[ERROR] = "invalid_provision_key", error_description = "Invalid provision_key"}
 
-        elseif not parameters.authenticated_userid or utils.strip(parameters.authenticated_userid) == "" then
+        elseif not parameters.authenticated_userid or strip(parameters.authenticated_userid) == "" then
           response_params = {[ERROR] = "invalid_authenticated_userid", error_description = "Missing authenticated_userid parameter"}
 
         else
@@ -389,7 +411,7 @@ local function issue_token(conf)
             response_params = err -- If it's not ok, then this is the error message
 
           else
-            response_params = generate_token(conf, ngx.ctx.service, ngx.ctx.api, client,
+            response_params = generate_token(conf, get_ctx("service"), get_ctx("api"), client,
                                              parameters.authenticated_userid, scope, state)
           end
         end
@@ -398,8 +420,8 @@ local function issue_token(conf)
         local refresh_token = parameters[REFRESH_TOKEN]
         local service_id, api_id
         if not conf.global_credentials then
-          service_id = ngx.ctx.service.id
-          api_id = ngx.ctx.api.id
+          service_id = get_ctx("service").id
+          api_id = get_ctx("api").id
         end
         local token = refresh_token and
                       kong.db.oauth2_tokens:select_by_refresh_token(refresh_token)
@@ -415,7 +437,7 @@ local function issue_token(conf)
             response_params = {[ERROR] = "invalid_client", error_description = "Invalid client authentication"}
 
           else
-            response_params = generate_token(conf, ngx.ctx.service, ngx.ctx.api, client,
+            response_params = generate_token(conf, get_ctx("service"), get_ctx("api"), client,
                                              token.authenticated_userid, token.scope, state)
             kong.db.oauth2_tokens:delete({ id = token.id }) -- Delete old token
           end
@@ -428,7 +450,7 @@ local function issue_token(conf)
   response_params.state = state
 
   -- Sending response in JSON format
-  return responses.send(response_params[ERROR] and (invalid_client_properties and invalid_client_properties.status or 400)
+  return kong.response.exit(response_params[ERROR] and (invalid_client_properties and invalid_client_properties.status or 400)
                         or 200, response_params, {
     ["cache-control"] = "no-store",
     ["pragma"] = "no-cache",
@@ -462,10 +484,10 @@ local function retrieve_token(conf, access_token)
     local token_cache_key = kong.db.oauth2_tokens:cache_key(access_token)
     token, err = kong.cache:get(token_cache_key, nil,
                                 load_token_into_memory, conf,
-                                ngx.ctx.service, ngx.ctx.api,
+                                get_ctx("service"), get_ctx("api"),
                                 access_token)
     if err then
-      return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+      return kong.response.exit(HTTP_INTERNAL_SERVER_ERROR, { message = err })
     end
   end
   return token
@@ -473,7 +495,7 @@ end
 
 local function parse_access_token(conf)
   local found_in = {}
-  local access_token = ngx.req.get_headers()[conf.auth_header_name]
+  local access_token = kong.request.get_header(conf.auth_header_name)
   if access_token then
     if type(access_token) == "table" then --Take the first found
       access_token = access_token[1]
@@ -492,24 +514,21 @@ local function parse_access_token(conf)
 
   if conf.hide_credentials then
     if found_in.authorization_header then
-      ngx.req.clear_header(conf.auth_header_name)
+      kong.service.request.clear_header(conf.auth_header_name)
     else
       -- Remove from querystring
-      local parameters = ngx.req.get_uri_args()
+      local parameters = kong.request.get_query()
       parameters[ACCESS_TOKEN] = nil
-      ngx.req.set_uri_args(parameters)
+      kong.service.request.set_query(parameters)
 
-      local content_type = req_get_headers()[CONTENT_TYPE]
+      local content_type = kong.request.get_header("content-type")
       local is_form_post = content_type and
         string_find(content_type, "application/x-www-form-urlencoded", 1, true)
 
-      if ngx.req.get_method() ~= "GET" and is_form_post then -- Remove from body
-        ngx.req.read_body()
-        parameters = public_utils.get_body_args()
+      if kong.request.get_method() ~= "GET" and is_form_post then -- Remove from body
+        parameters = kong.request.get_body()
         parameters[ACCESS_TOKEN] = nil
-        local encoded_args = ngx.encode_args(parameters)
-        ngx.req.set_header(CONTENT_LENGTH, #encoded_args)
-        ngx.req.set_body_data(encoded_args)
+        kong.service.request.set_body(parameters)
       end
     end
   end
@@ -537,17 +556,20 @@ local function load_consumer_into_memory(consumer_id, anonymous)
 end
 
 local function set_consumer(consumer, credential, token)
-  ngx_set_header(constants.HEADERS.CONSUMER_ID, consumer.id)
-  ngx_set_header(constants.HEADERS.CONSUMER_CUSTOM_ID, consumer.custom_id)
-  ngx_set_header(constants.HEADERS.CONSUMER_USERNAME, consumer.username)
-  ngx.ctx.authenticated_consumer = consumer
+  local clear_header = kong.service.request.clear_header
+  local set_header = kong.service.request.set_header
+
+  set_header(constants.HEADERS.CONSUMER_ID, consumer.id)
+  set_header(constants.HEADERS.CONSUMER_CUSTOM_ID, consumer.custom_id)
+  set_header(constants.HEADERS.CONSUMER_USERNAME, consumer.username)
+  set_ctx("authenticated_consumer", consumer)
   if credential then
-    ngx_set_header("x-authenticated-scope", token.scope)
-    ngx_set_header("x-authenticated-userid", token.authenticated_userid)
-    ngx.ctx.authenticated_credential = credential
-    ngx_set_header(constants.HEADERS.ANONYMOUS, nil) -- in case of auth plugins concatenation
+    set_header("x-authenticated-scope", token.scope)
+    set_header("x-authenticated-userid", token.authenticated_userid)
+    set_ctx("authenticated_credential", credential)
+    clear_header(constants.HEADERS.ANONYMOUS) -- in case of auth plugins concatenation
   else
-    ngx_set_header(constants.HEADERS.ANONYMOUS, true)
+    set_header(constants.HEADERS.ANONYMOUS, true)
   end
 
 end
@@ -563,8 +585,8 @@ local function do_authentication(conf)
     return nil, {status = 401, message = {[ERROR] = "invalid_token", error_description = "The access token is invalid or has expired"}, headers = {["WWW-Authenticate"] = 'Bearer realm="service" error="invalid_token" error_description="The access token is invalid or has expired"'}}
   end
 
-  if (token.service and token.service.id and ngx.ctx.service.id ~= token.service.id)
-  or (token.api and token.api.id and ngx.ctx.api.id ~= token.api.id)
+  if (token.service and token.service.id and get_ctx("service").id ~= token.service.id)
+  or (token.api and token.api.id and get_ctx("api").id ~= token.api.id)
   or ((not token.service or not token.service.id)
       and (not token.api or not token.api.id)
       and not conf.global_credentials)
@@ -586,7 +608,7 @@ local function do_authentication(conf)
                                                load_oauth2_credential_into_memory,
                                                token.credential.id)
   if err then
-    return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+    return kong.response.exit(HTTP_INTERNAL_SERVER_ERROR, { message = err })
   end
 
   -- Retrieve the consumer from the credential
@@ -595,7 +617,7 @@ local function do_authentication(conf)
                                             load_consumer_into_memory,
                                             credential.consumer.id)
   if err then
-    return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+    return kong.response.exit(HTTP_INTERNAL_SERVER_ERROR, { message = err })
   end
 
   set_consumer(consumer, credential, token)
@@ -607,21 +629,21 @@ end
 function _M.execute(conf)
 
 
-  if ngx.ctx.authenticated_credential and conf.anonymous then
+  if get_ctx("authenticated_credential") and conf.anonymous then
     -- we're already authenticated, and we're configured for using anonymous,
     -- hence we're in a logical OR between auth methods and we're already done.
     return
   end
 
-  if ngx.req.get_method() == "POST" then
-    local uri = ngx.var.uri
+  if kong.request.get_method() == "POST" then
+    local path = kong.request.get_path()
 
-    local from = string_find(uri, "/oauth2/token", nil, true)
+    local from = string_find(path, "/oauth2/token", nil, true)
     if from then
       return issue_token(conf)
     end
 
-    from = string_find(uri, "/oauth2/authorize", nil, true)
+    from = string_find(path, "/oauth2/authorize", nil, true)
     if from then
       return authorize(conf)
     end
@@ -636,12 +658,12 @@ function _M.execute(conf)
                                                 load_consumer_into_memory,
                                                 conf.anonymous, true)
       if err then
-        return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+        return kong.response.exit(HTTP_INTERNAL_SERVER_ERROR, { message = err })
       end
       set_consumer(consumer, nil, nil)
 
     else
-      return responses.send(err.status, err.message, err.headers)
+      return kong.response.exit(err.status, err.message, err.headers)
     end
   end
 end

--- a/kong/plugins/oauth2/api.lua
+++ b/kong/plugins/oauth2/api.lua
@@ -1,5 +1,7 @@
 local endpoints = require "kong.api.endpoints"
-local responses = require "kong.tools.responses"
+
+
+local HTTP_NOT_FOUND = 404
 
 
 local credentials_schema = kong.db.oauth2_credentials.schema
@@ -53,7 +55,7 @@ return {
           return endpoints.handle_error(err_t)
         end
         if not consumer then
-          return responses.send_HTTP_NOT_FOUND()
+          return kong.response.exit(HTTP_NOT_FOUND)
         end
 
         self.consumer = consumer
@@ -65,7 +67,7 @@ return {
 
         if self.req.cmd_mth ~= "PUT" then
           if not cred or cred.consumer.id ~= consumer.id then
-            return responses.send_HTTP_NOT_FOUND()
+            return kong.response.exit(HTTP_NOT_FOUND)
           end
           self.oauth2_credential = cred
           self.params.oauth2_credentials = cred.id

--- a/kong/plugins/rate-limiting/daos.lua
+++ b/kong/plugins/rate-limiting/daos.lua
@@ -1,3 +1,5 @@
 return {
-  tables = {"ratelimiting_metrics"}
+  tables = {
+    "ratelimiting_metrics"
+  },
 }

--- a/kong/plugins/rate-limiting/handler.lua
+++ b/kong/plugins/rate-limiting/handler.lua
@@ -1,49 +1,64 @@
 -- Copyright (C) Kong Inc.
-
 local policies = require "kong.plugins.rate-limiting.policies"
-local timestamp = require "kong.tools.timestamp"
-local responses = require "kong.tools.responses"
 local BasePlugin = require "kong.plugins.base_plugin"
 
-local ngx_log = ngx.log
+
+local kong = kong
+local ngx = ngx
+local max = math.max
+local time = ngx.time
 local pairs = pairs
 local tostring = tostring
-local ngx_timer_at = ngx.timer.at
+local timer_at = ngx.timer.at
+
 
 local RATELIMIT_LIMIT = "X-RateLimit-Limit"
 local RATELIMIT_REMAINING = "X-RateLimit-Remaining"
 
+
 local RateLimitingHandler = BasePlugin:extend()
 
+
 RateLimitingHandler.PRIORITY = 901
-RateLimitingHandler.VERSION = "0.1.0"
+RateLimitingHandler.VERSION = "0.1.1"
+
 
 local function get_identifier(conf)
   local identifier
 
-  -- Consumer is identified by ip address or authenticated_credential id
-  if conf.limit_by == "consumer" then
-    identifier = ngx.ctx.authenticated_consumer and ngx.ctx.authenticated_consumer.id
-    if not identifier and ngx.ctx.authenticated_credential then -- Fallback on credential
-      identifier = ngx.ctx.authenticated_credential.id
+  if conf.limit_by == "consumer" or conf.limit_by == "credential" then
+    local shared_ctx = kong.ctx.shared
+    local ngx_ctx = ngx.ctx
+
+    local consumer = shared_ctx.authenticated_consumer or
+                     ngx_ctx.authenticated_consumer
+
+    if conf.limit_by == "consumer" then
+      identifier = consumer and consumer.id
     end
-  elseif conf.limit_by == "credential" then
-    identifier = ngx.ctx.authenticated_credential and ngx.ctx.authenticated_credential.id
+
+    if not identifier then
+      local credential = shared_ctx.authenticated_credential or
+                         ngx_ctx.authenticated_credential
+
+      identifier = credential and credential.id
+    end
   end
 
   if not identifier then
-    identifier = ngx.var.remote_addr
+    identifier = kong.client.get_forwarded_ip()
   end
 
   return identifier
 end
 
+
 local function get_usage(conf, identifier, current_timestamp, limits)
   local usage = {}
   local stop
 
-  for name, limit in pairs(limits) do
-    local current_usage, err = policies[conf.policy].usage(conf, identifier, current_timestamp, name)
+  for period, limit in pairs(limits) do
+    local current_usage, err = policies[conf.policy].usage(conf, identifier, period, current_timestamp)
     if err then
       return nil, nil, err
     end
@@ -52,30 +67,41 @@ local function get_usage(conf, identifier, current_timestamp, limits)
     local remaining = limit - current_usage
 
     -- Recording usage
-    usage[name] = {
+    usage[period] = {
       limit = limit,
-      remaining = remaining
+      remaining = remaining,
     }
 
     if remaining <= 0 then
-      stop = name
+      stop = period
     end
   end
 
   return usage, stop
 end
 
+
+local function increment(premature, conf, ...)
+  if premature then
+    return
+  end
+
+  policies[conf.policy].increment(conf, ...)
+end
+
+
 function RateLimitingHandler:new()
   RateLimitingHandler.super.new(self, "rate-limiting")
 end
 
+
 function RateLimitingHandler:access(conf)
   RateLimitingHandler.super.access(self)
-  local current_timestamp = timestamp.get_utc()
+
+  local current_timestamp = time() * 1000
 
   -- Consumer is identified by ip address or authenticated_credential id
   local identifier = get_identifier(conf)
-  local policy = conf.policy
   local fault_tolerant = conf.fault_tolerant
 
   -- Load current metric for configured period
@@ -85,45 +111,65 @@ function RateLimitingHandler:access(conf)
     hour = conf.hour,
     day = conf.day,
     month = conf.month,
-    year = conf.year
+    year = conf.year,
   }
 
   local usage, stop, err = get_usage(conf, identifier, current_timestamp, limits)
   if err then
     if fault_tolerant then
-      ngx_log(ngx.ERR, "failed to get usage: ", tostring(err))
+      kong.log.err("failed to get usage: ", tostring(err))
     else
-      return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)
+      kong.log.err(err)
+      return kong.response.exit(500, { message = "An unexpected error occurred" })
     end
   end
 
   if usage then
     -- Adding headers
     if not conf.hide_client_headers then
+      local headers = {}
       for k, v in pairs(usage) do
-        ngx.header[RATELIMIT_LIMIT .. "-" .. k] = v.limit
-        ngx.header[RATELIMIT_REMAINING .. "-" .. k] = math.max(0, (stop == nil or stop == k) and v.remaining - 1 or v.remaining) -- -increment_value for this current request
+        if stop == nil or stop == k then
+          v.remaining = v.remaining - 1
+        end
+
+        headers[RATELIMIT_LIMIT .. "-" .. k] = v.limit
+        headers[RATELIMIT_REMAINING .. "-" .. k] = max(0, v.remaining)
       end
+
+      kong.ctx.plugin.headers = headers
     end
 
     -- If limit is exceeded, terminate the request
     if stop then
-      return responses.send(429, "API rate limit exceeded")
+      return kong.response.exit(429, { message = "API rate limit exceeded" })
     end
   end
 
-  local incr = function(premature, conf, limits, identifier, current_timestamp, value)
-    if premature then
-      return
+  kong.ctx.plugin.timer = function()
+    local ok, err = timer_at(0, increment, conf, limits, identifier, current_timestamp, 1)
+    if not ok then
+      kong.log.err("failed to create timer: ", err)
     end
-    policies[policy].increment(conf, limits, identifier, current_timestamp, value)
-  end
-
-  -- Increment metrics for configured periods if the request goes through
-  local ok, err = ngx_timer_at(0, incr, conf, limits, identifier, current_timestamp, 1)
-  if not ok then
-    ngx_log(ngx.ERR, "failed to create timer: ", err)
   end
 end
+
+
+function RateLimitingHandler:header_filter(_)
+  RateLimitingHandler.super.header_filter(self)
+
+  local headers = kong.ctx.plugin.headers
+  if headers then
+    kong.response.set_headers(headers)
+  end
+end
+
+
+function RateLimitingHandler:log(_)
+  if kong.ctx.plugin.timer then
+    kong.ctx.plugin.timer()
+  end
+end
+
 
 return RateLimitingHandler

--- a/kong/plugins/rate-limiting/migrations/001_14_to_15.lua
+++ b/kong/plugins/rate-limiting/migrations/001_14_to_15.lua
@@ -4,6 +4,15 @@ return {
       ALTER TABLE IF EXISTS ONLY "ratelimiting_metrics"
         ALTER "period_date" TYPE TIMESTAMP WITH TIME ZONE USING "period_date" AT TIME ZONE 'UTC';
     ]],
+    teardown = function(connector)
+      assert(connector:connect_migrations())
+      assert(connector:query([[
+        DROP FUNCTION IF EXISTS "increment_rate_limits_api" (UUID, TEXT, TEXT, TIMESTAMP WITH TIME ZONE, INTEGER),
+                                "increment_rate_limits" (UUID, TEXT, TEXT, TIMESTAMP WITHOUT TIME ZONE, INTEGER),
+                                "increment_rate_limits" (UUID, TEXT, TEXT, TIMESTAMP WITH TIME ZONE, INTEGER),
+                                "increment_rate_limits" (UUID, UUID, TEXT, TEXT, TIMESTAMP WITH TIME ZONE, INTEGER) CASCADE;
+      ]]))
+    end,
   },
 
   cassandra = {

--- a/kong/plugins/rate-limiting/policies/cluster.lua
+++ b/kong/plugins/rate-limiting/policies/cluster.lua
@@ -1,208 +1,294 @@
-local timestamp = require "kong.tools.timestamp"
+local luatz = require "luatz"
 
+
+local kong = kong
+local timetable = luatz.timetable
 local concat = table.concat
 local pairs = pairs
+local floor = math.floor
 local fmt = string.format
-local log = ngx.log
-local ERR = ngx.ERR
 
 
-local NULL_UUID = "00000000-0000-0000-0000-000000000000"
+local EMPTY_UUID = "00000000-0000-0000-0000-000000000000"
+
+
+local ms_check = timetable.new(20000, 1, 1, 0, 0, 0):timestamp()
+
+
+local function get_timetable(now)
+  if now > ms_check then
+    return timetable.new_from_timestamp(now / 1000)
+  end
+
+  return timetable.new_from_timestamp(now)
+end
+
+
+local function get_timestamps(now)
+  local timetable = get_timetable(now)
+  local stamps = {}
+
+  timetable.sec = floor(timetable.sec)   -- reduce to second precision
+  stamps.second = timetable:timestamp() * 1000
+
+  timetable.sec = 0
+  stamps.minute = timetable:timestamp() * 1000
+
+  timetable.min = 0
+  stamps.hour = timetable:timestamp() * 1000
+
+  timetable.hour = 0
+  stamps.day = timetable:timestamp() * 1000
+
+  timetable.day = 1
+  stamps.month = timetable:timestamp() * 1000
+
+  timetable.month = 1
+  stamps.year = timetable:timestamp() * 1000
+
+  return stamps
+end
 
 
 return {
-  ["cassandra"] = {
-    increment = function(db, limits, route_id, service_id, identifier, current_timestamp, value)
-      local periods = timestamp.get_timestamps(current_timestamp)
+  cassandra = {
+    increment = function(db, limits, identifier, current_timestamp, service_id, route_id, value)
+      local periods = get_timestamps(current_timestamp)
 
       for period, period_date in pairs(periods) do
         if limits[period] then
           local res, err = db:query([[
             UPDATE ratelimiting_metrics
-            SET value = value + ?
-            WHERE route_id = ?
-              AND service_id = ?
-              AND api_id = ?
-              AND identifier = ?
-              AND period_date = ?
-              AND period = ?
+               SET value = value + ?
+             WHERE identifier = ?
+               AND period = ?
+               AND period_date = ?
+               AND service_id = ?
+               AND route_id = ?
+               AND api_id = ?
           ]], {
             db.cassandra.counter(value),
-            db.cassandra.uuid(route_id),
+            identifier,
+            period,
+            db.cassandra.timestamp(period_date),
             db.cassandra.uuid(service_id),
-            db.cassandra.uuid(NULL_UUID),
-            identifier,
-            db.cassandra.timestamp(period_date),
-            period,
+            db.cassandra.uuid(route_id),
+            db.cassandra.uuid(EMPTY_UUID),
           })
           if not res then
-            log(ERR, "[rate-limiting] cluster policy: could not increment ",
-                     "cassandra counter for period '", period, "': ", err)
+            kong.log.err("cluster policy: could not increment cassandra counter for period '",
+                         period, "': ", err)
           end
         end
       end
 
       return true
     end,
-    increment_api = function(db, limits, api_id, identifier, current_timestamp, value)
-      local periods = timestamp.get_timestamps(current_timestamp)
+    increment_api = function(db, limits, identifier, current_timestamp, api_id, value)
+      local periods = get_timestamps(current_timestamp)
 
       for period, period_date in pairs(periods) do
         if limits[period] then
           local res, err = db:query([[
             UPDATE ratelimiting_metrics
-            SET value = value + ?
-            WHERE api_id = ? AND
-                  route_id = ? AND
-                  service_id = ? AND
-                  identifier = ? AND
-                  period_date = ? AND
-                  period = ?
+               SET value = value + ?
+             WHERE identifier = ?
+               AND period = ?
+               AND period_date = ?
+               AND service_id = ?
+               AND route_id = ?
+               AND api_id = ?
           ]], {
             db.cassandra.counter(value),
-            db.cassandra.uuid(api_id),
-            db.cassandra.uuid(NULL_UUID),
-            db.cassandra.uuid(NULL_UUID),
             identifier,
-            db.cassandra.timestamp(period_date),
             period,
+            db.cassandra.timestamp(period_date),
+            db.cassandra.uuid(EMPTY_UUID),
+            db.cassandra.uuid(EMPTY_UUID),
+            db.cassandra.uuid(api_id),
+
           })
           if not res then
-            log(ERR, "[rate-limiting] cluster policy: could not increment ",
-              "cassandra counter for period '", period, "': ", err)
+            kong.log.err("cluster policy: could not increment cassandra counter for period '",
+                         period, "': ", err)
           end
         end
       end
 
       return true
     end,
-    find = function(db, route_id, service_id, identifier, current_timestamp, period)
-      local periods = timestamp.get_timestamps(current_timestamp)
+    find = function(db, identifier, period, current_timestamp, service_id, route_id)
+      local periods = get_timestamps(current_timestamp)
 
       local rows, err = db:query([[
-        SELECT * FROM ratelimiting_metrics
-        WHERE route_id = ?
-          AND service_id = ?
-          AND api_id = ?
-          AND identifier = ?
-          AND period_date = ?
-          AND period = ?
+        SELECT value
+          FROM ratelimiting_metrics
+         WHERE identifier = ?
+           AND period = ?
+           AND period_date = ?
+           AND service_id = ?
+           AND route_id = ?
+           AND api_id = ?
       ]], {
-        db.cassandra.uuid(route_id),
+        identifier,
+        period,
+        db.cassandra.timestamp(periods[period]),
         db.cassandra.uuid(service_id),
-        db.cassandra.uuid(NULL_UUID),
-        identifier,
-        db.cassandra.timestamp(periods[period]),
-        period,
+        db.cassandra.uuid(route_id),
+        db.cassandra.uuid(EMPTY_UUID),
       })
-      if not rows then       return nil, err
-      elseif #rows <= 1 then return rows[1]
-      else                   return nil, "bad rows result" end
+
+      if not rows then
+        return nil, err
+      elseif #rows <= 1 then
+        return rows[1]
+      else
+        return nil, "bad rows result"
+      end
     end,
-    find_api = function(db, api_id, identifier, current_timestamp, period)
-      local periods = timestamp.get_timestamps(current_timestamp)
+    find_api = function(db, identifier, period, current_timestamp, api_id)
+      local periods = get_timestamps(current_timestamp)
 
       local rows, err = db:query([[
-        SELECT *
-        FROM ratelimiting_metrics
-        WHERE api_id = ? AND
-              route_id = ? AND
-              service_id = ? AND
-              identifier = ? AND
-              period_date = ? AND
-              period = ?
+        SELECT value
+          FROM ratelimiting_metrics
+         WHERE identifier = ?
+           AND period = ?
+           AND period_date = ?
+           AND service_id = ?
+           AND route_id = ?
+           AND api_id = ?
       ]], {
-        db.cassandra.uuid(api_id),
-        db.cassandra.uuid(NULL_UUID),
-        db.cassandra.uuid(NULL_UUID),
         identifier,
-        db.cassandra.timestamp(periods[period]),
         period,
+        db.cassandra.timestamp(periods[period]),
+        db.cassandra.uuid(EMPTY_UUID),
+        db.cassandra.uuid(EMPTY_UUID),
+        db.cassandra.uuid(api_id),
       })
-      if not rows then       return nil, err
-      elseif #rows <= 1 then return rows[1]
-      else                   return nil, "bad rows result" end
+
+      if not rows then
+        return nil, err
+      elseif #rows <= 1 then
+        return rows[1]
+      else
+        return nil, "bad rows result" end
     end,
   },
-  ["postgres"] = {
-    increment = function(db, limits, route_id, service_id, identifier, current_timestamp, value)
-      local buf = {}
-      local periods = timestamp.get_timestamps(current_timestamp)
+  postgres = {
+    increment = function(db, limits, identifier, current_timestamp, service_id, route_id, value)
+      local buf = { "BEGIN" }
+      local len = 1
+      local periods = get_timestamps(current_timestamp)
 
       for period, period_date in pairs(periods) do
         if limits[period] then
-          buf[#buf + 1] = fmt([[
-            SELECT increment_rate_limits('%s', '%s', '%s', '%s',
-                                         to_timestamp('%s') at time zone 'UTC', %d)
-          ]], route_id, service_id, identifier, period, period_date/1000, value)
+          len = len + 1
+          buf[len] = fmt([[
+            INSERT INTO "ratelimiting_metrics" ("identifier", "period", "period_date", "service_id", "route_id", "api_id", "value")
+                 VALUES ('%s', '%s', TO_TIMESTAMP('%s') AT TIME ZONE 'UTC', '%s', '%s', '%s', %d)
+            ON CONFLICT ("identifier", "period", "period_date", "service_id", "route_id", "api_id") DO UPDATE
+                    SET "value" = "ratelimiting_metrics"."value" + EXCLUDED."value"
+          ]], identifier, period, floor(period_date / 1000), service_id, route_id, EMPTY_UUID, value)
         end
       end
 
-      local res, err = db:query(concat(buf, ";"))
-      if not res then
-        return nil, err
+      if len > 1 then
+        local sql
+        if len == 2 then
+          sql = buf[2]
+
+        else
+          buf[len + 1] = "COMMIT;"
+          sql = concat(buf, ";\n")
+        end
+
+        local res, err = db:query(sql)
+        if not res then
+          return nil, err
+        end
       end
 
       return true
     end,
-    increment_api = function(db, limits, api_id, identifier, current_timestamp, value)
-      local buf = {}
-      local periods = timestamp.get_timestamps(current_timestamp)
+    increment_api = function(db, limits, identifier, current_timestamp, api_id, value)
+      local buf = { "BEGIN" }
+      local len = 1
+      local periods = get_timestamps(current_timestamp)
 
       for period, period_date in pairs(periods) do
         if limits[period] then
-          buf[#buf+1] = fmt([[
-            SELECT increment_rate_limits_api('%s', '%s', '%s', to_timestamp('%s')
-            at time zone 'UTC', %d)
-          ]], api_id, identifier, period, period_date/1000, value)
+          len = len + 1
+          buf[len] = fmt([[
+            INSERT INTO "ratelimiting_metrics" ("identifier", "period", "period_date", "service_id", "route_id", "api_id", "value")
+                 VALUES ('%s', '%s', TO_TIMESTAMP('%s') AT TIME ZONE 'UTC', '%s', '%s', '%s', %d)
+            ON CONFLICT ("identifier", "period", "period_date", "service_id", "route_id", "api_id") DO UPDATE
+                    SET "value" = "ratelimiting_metrics"."value" + EXCLUDED."value"
+          ]], identifier, period, floor(period_date / 1000), EMPTY_UUID, EMPTY_UUID, api_id, value)
         end
       end
 
-      local res, err = db:query(concat(buf, ";"))
-      if not res then
-        return nil, err
+      if len > 1 then
+        local sql
+        if len == 2 then
+          sql = buf[2]
+
+        else
+          buf[len + 1] = "COMMIT;"
+          sql = concat(buf, ";\n")
+        end
+
+        local res, err = db:query(sql)
+        if not res then
+          return nil, err
+        end
       end
 
       return true
     end,
-    find = function(db, route_id, service_id, identifier, current_timestamp, period)
-      local periods = timestamp.get_timestamps(current_timestamp)
+    find = function(db, identifier, period, current_timestamp, service_id, route_id)
+      local periods = get_timestamps(current_timestamp)
 
-      local q = fmt([[
-        SELECT *, extract(epoch from period_date)*1000 AS period_date
-        FROM ratelimiting_metrics
-        WHERE route_id = '%s'
-          AND service_id = '%s'
-          AND identifier = '%s'
-          AND period_date = to_timestamp('%s') at time zone 'UTC'
-          AND period = '%s'
-      ]], route_id, service_id, identifier, periods[period]/1000, period)
+      local sql = fmt([[
+        SELECT "value"
+          FROM "ratelimiting_metrics"
+         WHERE "identifier" = '%s'
+           AND "period" = '%s'
+           AND "period_date" = TO_TIMESTAMP('%s') AT TIME ZONE 'UTC'
+           AND "service_id" = '%s'
+           AND "route_id" = '%s'
+           AND "api_id" = '%s'
+         LIMIT 1;
+      ]], identifier, period, floor(periods[period] / 1000), service_id, route_id, EMPTY_UUID)
 
-      local res, err = db:query(q)
+      local res, err = db:query(sql)
       if not res or err then
         return nil, err
       end
 
       return res[1]
     end,
-    find_api = function(db, api_id, identifier, current_timestamp, period)
-      local periods = timestamp.get_timestamps(current_timestamp)
+    find_api = function(db, identifier, period, current_timestamp, api_id)
+      local periods = get_timestamps(current_timestamp)
 
-      local q = fmt([[
-        SELECT *, extract(epoch from period_date)*1000 AS period_date
-        FROM ratelimiting_metrics
-        WHERE api_id = '%s' AND
-              identifier = '%s' AND
-              period_date = to_timestamp('%s') at time zone 'UTC' AND
-              period = '%s'
-      ]], api_id, identifier, periods[period]/1000, period)
+      local sql = fmt([[
+        SELECT "value"
+          FROM "ratelimiting_metrics"
+         WHERE "identifier" = '%s'
+           AND "period" = '%s'
+           AND "period_date" = TO_TIMESTAMP('%s') AT TIME ZONE 'UTC'
+           AND "service_id" = '%s'
+           AND "route_id" = '%s'
+           AND "api_id" = '%s'
+         LIMIT 1;
+      ]], identifier, period, floor(periods[period] / 1000), EMPTY_UUID, EMPTY_UUID, api_id)
 
-      local res, err = db:query(q)
+      local res, err = db:query(sql)
       if not res or err then
         return nil, err
       end
 
       return res[1]
     end,
-  }
+  },
 }

--- a/kong/plugins/rate-limiting/policies/init.lua
+++ b/kong/plugins/rate-limiting/policies/init.lua
@@ -1,21 +1,65 @@
-local singletons = require "kong.singletons"
-local timestamp = require "kong.tools.timestamp"
-local redis = require "resty.redis"
 local policy_cluster = require "kong.plugins.rate-limiting.policies.cluster"
+local singletons = require "kong.singletons"
 local reports = require "kong.reports"
+local redis = require "resty.redis"
+local luatz = require "luatz"
 
 
-local ngx_log = ngx.log
-local shm = ngx.shared.kong_rate_limiting_counters
+local timetable = luatz.timetable
 local pairs = pairs
+local floor = math.floor
+local null = ngx.null
+local shm = ngx.shared.kong_rate_limiting_counters
 local fmt = string.format
 
 
-local NULL_UUID = "00000000-0000-0000-0000-000000000000"
+local log_err = kong and kong.log.err or function(...)
+  return ngx.log(ngx.ERR, ...)
+end
+
+
+local EMPTY_UUID = "00000000-0000-0000-0000-000000000000"
+
+
+local ms_check = timetable.new(20000, 1, 1, 0, 0, 0):timestamp()
+
+local function get_timetable(now)
+  if now > ms_check then
+    return timetable.new_from_timestamp(now / 1000)
+  end
+
+  return timetable.new_from_timestamp(now)
+end
+
+
+local function get_timestamps(now)
+  local timetable = get_timetable(now)
+  local stamps = {}
+
+  timetable.sec = floor(timetable.sec)   -- reduce to second precision
+  stamps.second = timetable:timestamp() * 1000
+
+  timetable.sec = 0
+  stamps.minute = timetable:timestamp() * 1000
+
+  timetable.min = 0
+  stamps.hour = timetable:timestamp() * 1000
+
+  timetable.hour = 0
+  stamps.day = timetable:timestamp() * 1000
+
+  timetable.day = 1
+  stamps.month = timetable:timestamp() * 1000
+
+  timetable.month = 1
+  stamps.year = timetable:timestamp() * 1000
+
+  return stamps
+end
 
 
 local function is_present(str)
-  return str and str ~= "" and str ~= ngx.null
+  return str and str ~= "" and str ~= null
 end
 
 
@@ -24,59 +68,58 @@ local function get_ids(conf)
 
   local api_id = conf.api_id
 
-  if api_id and api_id ~= ngx.null then
-    return nil, nil, api_id
+  if api_id and api_id ~= null then
+    return EMPTY_UUID, EMPTY_UUID, api_id
   end
 
-  api_id = NULL_UUID
+  api_id = EMPTY_UUID
 
-  local route_id   = conf.route_id
   local service_id = conf.service_id
+  local route_id   = conf.route_id
 
-  if not route_id or route_id == ngx.null then
-    route_id = NULL_UUID
+  if not service_id or service_id == null then
+    service_id = EMPTY_UUID
   end
 
-  if not service_id or service_id == ngx.null then
-    service_id = NULL_UUID
+  if not route_id or route_id == null then
+    route_id = EMPTY_UUID
   end
 
-  return route_id, service_id, api_id
+  return service_id, route_id, api_id
 end
 
 
-local get_local_key = function(conf, identifier, period_date, name)
-  local route_id, service_id, api_id = get_ids(conf)
+local get_local_key = function(conf, identifier, period, period_date)
+  local service_id, route_id, api_id = get_ids(conf)
 
-  if api_id == NULL_UUID then
-    return fmt("ratelimit:%s:%s:%s:%s:%s", route_id, service_id, identifier, period_date, name)
+  if api_id == EMPTY_UUID then
+    return fmt("ratelimit:%s:%s:%s:%s:%s", route_id, service_id, identifier, period_date, period)
   end
 
-  return fmt("ratelimit:%s:%s:%s:%s", api_id, identifier, period_date, name)
+  return fmt("ratelimit:%s:%s:%s:%s", api_id, identifier, period_date, period)
 end
 
 
 local EXPIRATIONS = {
   second = 1,
   minute = 60,
-  hour = 3600,
-  day = 86400,
-  month = 2592000,
-  year = 31536000,
+  hour   = 3600,
+  day    = 86400,
+  month  = 2592000,
+  year   = 31536000,
 }
 
 
 return {
   ["local"] = {
     increment = function(conf, limits, identifier, current_timestamp, value)
-      local periods = timestamp.get_timestamps(current_timestamp)
+      local periods = get_timestamps(current_timestamp)
       for period, period_date in pairs(periods) do
         if limits[period] then
           local cache_key = get_local_key(conf, identifier, period_date, period)
           local newval, err = shm:incr(cache_key, value, 0)
           if not newval then
-            ngx_log(ngx.ERR, "[rate-limiting] could not increment counter ",
-                             "for period '", period, "': ", err)
+            log_err("could not increment counter for period '", period, "': ", err)
             return nil, err
           end
         end
@@ -84,57 +127,60 @@ return {
 
       return true
     end,
-    usage = function(conf, identifier, current_timestamp, name)
-      local periods = timestamp.get_timestamps(current_timestamp)
-      local cache_key = get_local_key(conf, identifier, periods[name], name)
+    usage = function(conf, identifier, period, current_timestamp)
+      local periods = get_timestamps(current_timestamp)
+      local cache_key = get_local_key(conf, identifier, periods[period], period)
       local current_metric, err = shm:get(cache_key)
       if err then
         return nil, err
       end
-      return current_metric and current_metric or 0
+      return current_metric or 0
     end
   },
   ["cluster"] = {
     increment = function(conf, limits, identifier, current_timestamp, value)
       local db = singletons.dao.db
-      local route_id, service_id, api_id = get_ids(conf)
+      local service_id, route_id, api_id = get_ids(conf)
 
       local ok, err
 
-      if api_id == NULL_UUID then
-        ok, err = policy_cluster[db.name].increment(db, limits, route_id, service_id,
-                                                    identifier, current_timestamp, value)
+      if api_id == EMPTY_UUID then
+        ok, err = policy_cluster[db.name].increment(db, limits, identifier, current_timestamp,
+                                                    service_id, route_id, value)
 
       else
-        ok, err = policy_cluster[db.name].increment_api(db, limits, api_id, identifier,
-                                                        current_timestamp, value)
+        ok, err = policy_cluster[db.name].increment_api(db, limits, identifier, current_timestamp,
+                                                        api_id, value)
       end
 
       if not ok then
-        ngx_log(ngx.ERR, "[rate-limiting] cluster policy: could not increment ",
-                          db.name, " counter: ", err)
+        log_err("cluster policy: could not increment ", db.name, " counter: ", err)
       end
 
       return ok, err
     end,
-    usage = function(conf, identifier, current_timestamp, name)
+    usage = function(conf, identifier, period, current_timestamp)
       local db = singletons.dao.db
-      local route_id, service_id, api_id = get_ids(conf)
+      local service_id, route_id, api_id = get_ids(conf)
       local row, err
 
-      if api_id == NULL_UUID then
-        row, err = policy_cluster[db.name].find(db, route_id, service_id,
-                                                identifier, current_timestamp, name)
+      if api_id == EMPTY_UUID then
+        row, err = policy_cluster[db.name].find(db, identifier, period, current_timestamp,
+                                                service_id, route_id)
       else
-        row, err = policy_cluster[db.name].find_api(db, api_id, identifier,
-                                                    current_timestamp, name)
+        row, err = policy_cluster[db.name].find_api(db, identifier, period, current_timestamp,
+                                                    api_id)
       end
 
       if err then
         return nil, err
       end
 
-      return row and row.value or 0
+      if row and row.value ~= null and row.value > 0 then
+        return row.value
+      end
+
+      return 0
     end
   },
   ["redis"] = {
@@ -143,20 +189,20 @@ return {
       red:set_timeout(conf.redis_timeout)
       local ok, err = red:connect(conf.redis_host, conf.redis_port)
       if not ok then
-        ngx_log(ngx.ERR, "failed to connect to Redis: ", err)
+        log_err("failed to connect to Redis: ", err)
         return nil, err
       end
 
       local times, err = red:get_reused_times()
       if err then
-        ngx_log(ngx.ERR, "failed to get connect reused times: ", err)
+        log_err("failed to get connect reused times: ", err)
         return nil, err
       end
 
       if times == 0 and is_present(conf.redis_password) then
         local ok, err = red:auth(conf.redis_password)
         if not ok then
-          ngx_log(ngx.ERR, "failed to auth Redis: ", err)
+          log_err("failed to auth Redis: ", err)
           return nil, err
         end
       end
@@ -172,7 +218,7 @@ return {
 
         local ok, err = red:select(conf.redis_database or 0)
         if not ok then
-          ngx_log(ngx.ERR, "failed to change Redis database: ", err)
+          log_err("failed to change Redis database: ", err)
           return nil, err
         end
       end
@@ -180,13 +226,13 @@ return {
       local keys = {}
       local expirations = {}
       local idx = 0
-      local periods = timestamp.get_timestamps(current_timestamp)
+      local periods = get_timestamps(current_timestamp)
       for period, period_date in pairs(periods) do
         if limits[period] then
           local cache_key = get_local_key(conf, identifier, period_date, period)
           local exists, err = red:exists(cache_key)
           if err then
-            ngx_log(ngx.ERR, "failed to query Redis: ", err)
+            log_err("failed to query Redis: ", err)
             return nil, err
           end
 
@@ -208,36 +254,39 @@ return {
 
       local _, err = red:commit_pipeline()
       if err then
-        ngx_log(ngx.ERR, "failed to commit pipeline in Redis: ", err)
+        log_err("failed to commit pipeline in Redis: ", err)
         return nil, err
       end
+
       local ok, err = red:set_keepalive(10000, 100)
       if not ok then
-        ngx_log(ngx.ERR, "failed to set Redis keepalive: ", err)
+        log_err("failed to set Redis keepalive: ", err)
         return nil, err
       end
 
       return true
     end,
-    usage = function(conf, identifier, current_timestamp, name)
+    usage = function(conf, identifier, period, current_timestamp)
       local red = redis:new()
+
       red:set_timeout(conf.redis_timeout)
+
       local ok, err = red:connect(conf.redis_host, conf.redis_port)
       if not ok then
-        ngx_log(ngx.ERR, "failed to connect to Redis: ", err)
+        log_err("failed to connect to Redis: ", err)
         return nil, err
       end
 
       local times, err = red:get_reused_times()
       if err then
-        ngx_log(ngx.ERR, "failed to get connect reused times: ", err)
+        log_err("failed to get connect reused times: ", err)
         return nil, err
       end
 
       if times == 0 and is_present(conf.redis_password) then
         local ok, err = red:auth(conf.redis_password)
         if not ok then
-          ngx_log(ngx.ERR, "failed to connect to Redis: ", err)
+          log_err("failed to connect to Redis: ", err)
           return nil, err
         end
       end
@@ -253,27 +302,28 @@ return {
 
         local ok, err = red:select(conf.redis_database or 0)
         if not ok then
-          ngx_log(ngx.ERR, "failed to change Redis database: ", err)
+          log_err("failed to change Redis database: ", err)
           return nil, err
         end
       end
 
       reports.retrieve_redis_version(red)
 
-      local periods = timestamp.get_timestamps(current_timestamp)
-      local cache_key = get_local_key(conf, identifier, periods[name], name)
+      local periods = get_timestamps(current_timestamp)
+      local cache_key = get_local_key(conf, identifier, period, periods[period])
+
       local current_metric, err = red:get(cache_key)
       if err then
         return nil, err
       end
 
-      if current_metric == ngx.null then
+      if current_metric == null then
         current_metric = nil
       end
 
       local ok, err = red:set_keepalive(10000, 100)
       if not ok then
-        ngx_log(ngx.ERR, "failed to set Redis keepalive: ", err)
+        log_err("failed to set Redis keepalive: ", err)
       end
 
       return current_metric or 0

--- a/kong/plugins/request-size-limiting/handler.lua
+++ b/kong/plugins/request-size-limiting/handler.lua
@@ -1,7 +1,6 @@
 -- Copyright (C) Kong Inc.
 
 local BasePlugin = require "kong.plugins.base_plugin"
-local responses = require "kong.tools.responses"
 local strip = require("pl.stringx").strip
 local tonumber = tonumber
 
@@ -16,9 +15,9 @@ local function check_size(length, allowed_size, headers)
   local allowed_bytes_size = allowed_size * MB
   if length > allowed_bytes_size then
     if headers.expect and strip(headers.expect:lower()) == "100-continue" then
-      return responses.send(417, "Request size limit exceeded")
+      return kong.response.exit(417, { message = "Request size limit exceeded" })
     else
-      return responses.send(413, "Request size limit exceeded")
+      return kong.response.exit(413, { message = "Request size limit exceeded" })
     end
   end
 end
@@ -29,15 +28,14 @@ end
 
 function RequestSizeLimitingHandler:access(conf)
   RequestSizeLimitingHandler.super.access(self)
-  local headers = ngx.req.get_headers()
+  local headers = kong.request.get_headers()
   local cl = headers["content-length"]
 
   if cl and tonumber(cl) then
     check_size(tonumber(cl), conf.allowed_payload_size, headers)
   else
     -- If the request body is too big, this could consume too much memory (to check)
-    ngx.req.read_body()
-    local data = ngx.req.get_body_data()
+    local data = kong.request.get_raw_body()
     if data then
       check_size(#data, conf.allowed_payload_size, headers)
     end

--- a/kong/plugins/response-ratelimiting/handler.lua
+++ b/kong/plugins/response-ratelimiting/handler.lua
@@ -27,9 +27,9 @@ end
 
 
 function ResponseRateLimitingHandler:log(conf)
-  if not ngx.ctx.stop_log and ngx.ctx.usage then
+  if not kong.ctx.plugin.stop_log and kong.ctx.plugin.usage then
     ResponseRateLimitingHandler.super.log(self)
-    log.execute(conf, ngx.ctx.identifier, ngx.ctx.current_timestamp, ngx.ctx.increments, ngx.ctx.usage)
+    log.execute(conf, kong.ctx.plugin.identifier, kong.ctx.plugin.current_timestamp, kong.ctx.plugin.increments, kong.ctx.plugin.usage)
   end
 end
 

--- a/kong/plugins/response-ratelimiting/header_filter.lua
+++ b/kong/plugins/response-ratelimiting/header_filter.lua
@@ -34,17 +34,17 @@ local function parse_header(header_value, limits)
 end
 
 function _M.execute(conf)
-  ngx.ctx.increments = {}
+  kong.ctx.plugin.increments = {}
 
   if not next(conf.limits) then
     return
   end
 
   -- Parse header
-  local increments = parse_header(ngx.header[conf.header_name], conf.limits)
-  ngx.ctx.increments = increments
+  local increments = parse_header(kong.service.response.get_header(conf.header_name), conf.limits)
+  kong.ctx.plugin.increments = increments
 
-  local usage = ngx.ctx.usage -- Load current usage
+  local usage = kong.ctx.plugin.usage -- Load current usage
   if not usage then
     return
   end
@@ -53,8 +53,14 @@ function _M.execute(conf)
   for limit_name in pairs(usage) do
     for period_name, lv in pairs(usage[limit_name]) do
       if not conf.hide_client_headers then
-        ngx.header[RATELIMIT_LIMIT .. "-" .. limit_name .. "-" .. period_name] = lv.limit
-        ngx.header[RATELIMIT_REMAINING .. "-" .. limit_name .. "-" .. period_name] = math_max(0, lv.remaining - (increments[limit_name] and increments[limit_name] or 0)) -- increment_value for this current request
+
+        -- increment_value for this current request
+        local remain = math_max(0, lv.remaining - (increments[limit_name] and increments[limit_name] or 0))
+
+        local limit_hdr  = RATELIMIT_LIMIT .. "-" .. limit_name .. "-" .. period_name
+        local remain_hdr = RATELIMIT_REMAINING .. "-" .. limit_name .. "-" .. period_name
+        kong.response.set_header(limit_hdr, lv.limit)
+        kong.response.set_header(remain_hdr, remain)
       end
 
       if increments[limit_name] and increments[limit_name] > 0 and lv.remaining <= 0 then
@@ -63,12 +69,11 @@ function _M.execute(conf)
     end
   end
 
-  -- Remove header
-  ngx.header[conf.header_name] = nil
+  kong.response.clear_header(conf.header_name)
 
   -- If limit is exceeded, terminate the request
   if stop then
-    ngx.ctx.stop_log = true
+    kong.ctx.plugin.stop_log = true
     return responses.send(429) -- Don't set a body
   end
 end

--- a/kong/plugins/response-ratelimiting/log.lua
+++ b/kong/plugins/response-ratelimiting/log.lua
@@ -19,7 +19,7 @@ end
 function _M.execute(conf, identifier, current_timestamp, increments, usage)
   local ok, err = ngx.timer.at(0, log, conf, identifier, current_timestamp, increments, usage)
   if not ok then
-    ngx.log(ngx.ERR, "failed to create timer: ", err)
+    kong.log.err("failed to create timer: ", err)
   end
 end
 

--- a/kong/plugins/response-ratelimiting/migrations/000_base_response_rate_limiting.lua
+++ b/kong/plugins/response-ratelimiting/migrations/000_base_response_rate_limiting.lua
@@ -59,7 +59,7 @@ return {
 
             BEGIN
               INSERT INTO response_ratelimiting_metrics (identifier, period, period_date, service_id, route_id, value)
-                   VALUES (i, p, p_date, r_id, s_id, v);
+                   VALUES (i, p, p_date, s_id, r_id, v);
               RETURN;
             EXCEPTION WHEN unique_violation THEN
 

--- a/kong/plugins/response-ratelimiting/migrations/001_14_to_15.lua
+++ b/kong/plugins/response-ratelimiting/migrations/001_14_to_15.lua
@@ -4,6 +4,17 @@ return {
       ALTER TABLE IF EXISTS ONLY "response_ratelimiting_metrics"
         ALTER "period_date" TYPE TIMESTAMP WITH TIME ZONE USING "period_date" AT TIME ZONE 'UTC';
     ]],
+    teardown = function(connector)
+      assert(connector:connect_migrations())
+      assert(connector:query([[
+        DROP FUNCTION IF EXISTS "increment_response_rate_limits" (UUID, UUID, TEXT, TEXT, TIMESTAMP WITH TIME ZONE, INTEGER),
+                                "increment_response_rate_limits" (UUID, UUID, TEXT, TEXT, TIMESTAMP WITHOUT TIME ZONE, INTEGER),
+                                "increment_response_rate_limits" (UUID, TEXT, TEXT, TIMESTAMP WITH TIME ZONE, INTEGER),
+                                "increment_response_rate_limits" (UUID, TEXT, TEXT, TIMESTAMP WITHOUT TIME ZONE, INTEGER),
+                                "increment_response_rate_limits_api" (UUID, TEXT, TEXT, TIMESTAMP WITH TIME ZONE, INTEGER),
+                                "increment_response_rate_limits_api" (UUID, TEXT, TEXT, TIMESTAMP WITHOUT TIME ZONE, INTEGER) CASCADE;
+      ]]))
+    end
   },
 
   cassandra = {

--- a/kong/plugins/response-ratelimiting/policies/cluster.lua
+++ b/kong/plugins/response-ratelimiting/policies/cluster.lua
@@ -128,9 +128,11 @@ return {
 
       for period, period_date in pairs(periods) do
         buf[#buf + 1] = fmt([[
-          SELECT increment_response_rate_limits('%s', '%s', '%s', '%s_%s',
-                                                to_timestamp('%s') at time zone 'UTC', %d)
-        ]], route_id, service_id, identifier, name, period, period_date/1000, value)
+          INSERT INTO response_ratelimiting_metrics AS old(identifier, period, period_date, service_id, route_id, value)
+                      VALUES ('%s', '%s_%s', to_timestamp('%s') at time zone 'UTC', '%s', '%s', %d)
+          ON CONFLICT ON CONSTRAINT response_ratelimiting_metrics_pkey
+          DO UPDATE SET value = old.value + %d;
+        ]], identifier, name, period, period_date/1000, service_id, route_id, value, value)
       end
 
       local res, err = db:query(concat(buf, ";"))
@@ -145,10 +147,12 @@ return {
       local periods = timestamp.get_timestamps(current_timestamp)
 
       for period, period_date in pairs(periods) do
-        buf[#buf+1] = fmt([[
-          SELECT increment_response_rate_limits_api('%s', '%s', '%s_%s', to_timestamp('%s')
-          at time zone 'UTC', %d)
-        ]], api_id, identifier, name, period, period_date/1000, value)
+        buf[#buf + 1] = fmt([[
+          INSERT INTO response_ratelimiting_metrics AS old(identifier, period, period_date, api_id, value)
+                      VALUES ('%s', '%s_%s', to_timestamp('%s') at time zone 'UTC', '%s', %d)
+          ON CONFLICT ON CONSTRAINT response_ratelimiting_metrics_pkey
+          DO UPDATE SET value = old.value + %d;
+        ]], identifier, name, period, period_date/1000, api_id, value, value)
       end
 
       local res, err = db:query(concat(buf, ";"))

--- a/kong/plugins/response-ratelimiting/policies/cluster.lua
+++ b/kong/plugins/response-ratelimiting/policies/cluster.lua
@@ -3,8 +3,6 @@ local timestamp = require "kong.tools.timestamp"
 local concat = table.concat
 local pairs = pairs
 local fmt = string.format
-local log = ngx.log
-local ERR = ngx.ERR
 
 
 local NULL_UUID = "00000000-0000-0000-0000-000000000000"
@@ -36,8 +34,8 @@ return {
         })
 
         if not res then
-          log(ERR, "[response-ratelimiting] cluster policy: could not increment ",
-                   "cassandra counter for period '", period, "': ", err)
+          kong.log.err("cluster policy: could not increment ",
+                       "cassandra counter for period '", period, "': ", err)
         end
       end
 
@@ -66,8 +64,8 @@ return {
           name .. "_" .. period,
         })
         if not res then
-          log(ERR, "[response-ratelimiting] cluster policy: could not increment ",
-            "cassandra counter for period '", period, "': ", err)
+          kong.log.err("cluster policy: could not increment ",
+                       "cassandra counter for period '", period, "': ", err)
         end
       end
 

--- a/kong/plugins/response-ratelimiting/policies/init.lua
+++ b/kong/plugins/response-ratelimiting/policies/init.lua
@@ -5,7 +5,7 @@ local policy_cluster = require "kong.plugins.response-ratelimiting.policies.clus
 local reports = require "kong.reports"
 
 
-local ngx_log = ngx.log
+local null = ngx.null
 local shm = ngx.shared.kong_rate_limiting_counters
 local pairs = pairs
 local fmt = string.format
@@ -15,7 +15,7 @@ local NULL_UUID = "00000000-0000-0000-0000-000000000000"
 
 
 local function is_present(str)
-  return str and str ~= "" and str ~= ngx.null
+  return str and str ~= "" and str ~= null
 end
 
 
@@ -24,7 +24,7 @@ local function get_ids(conf)
 
   local api_id = conf.api_id
 
-  if api_id and api_id ~= ngx.null then
+  if api_id and api_id ~= null then
     return nil, nil, api_id
   end
 
@@ -33,11 +33,11 @@ local function get_ids(conf)
   local route_id   = conf.route_id
   local service_id = conf.service_id
 
-  if not route_id or route_id == ngx.null then
+  if not route_id or route_id == null then
     route_id = NULL_UUID
   end
 
-  if not service_id or service_id == ngx.null then
+  if not service_id or service_id == null then
     service_id = NULL_UUID
   end
 
@@ -75,8 +75,8 @@ return {
 
         local newval, err = shm:incr(cache_key, value, 0)
         if not newval then
-          ngx_log(ngx.ERR, "[response-ratelimiting] could not increment counter ",
-                           "for period '", period, "': ", err)
+          kong.log.err("could not increment counter for period '",
+                       period, "': ", err)
           return nil, err
         end
       end
@@ -110,8 +110,8 @@ return {
       end
 
       if not ok then
-        ngx_log(ngx.ERR, "[response-ratelimiting] cluster policy: could not increment ",
-                          db.name, " counter: ", err)
+        kong.log.err("cluster policy: could not increment ", db.name,
+                     " counter: ", err)
       end
 
       return ok, err
@@ -144,20 +144,20 @@ return {
       red:set_timeout(conf.redis_timeout)
       local ok, err = red:connect(conf.redis_host, conf.redis_port)
       if not ok then
-        ngx_log(ngx.ERR, "failed to connect to Redis: ", err)
+        kong.log.err("failed to connect to Redis: ", err)
         return nil, err
       end
 
       local times, err = red:get_reused_times()
       if err then
-        ngx_log(ngx.ERR, "failed to get connect reused times: ", err)
+        kong.log.err("failed to get connect reused times: ", err)
         return nil, err
       end
 
       if times == 0 and is_present(conf.redis_password) then
         local ok, err = red:auth(conf.redis_password)
         if not ok then
-          ngx_log(ngx.ERR, "failed to auth Redis: ", err)
+          kong.log.err("failed to auth Redis: ", err)
           return nil, err
         end
       end
@@ -173,7 +173,7 @@ return {
 
         local ok, err = red:select(conf.redis_database or 0)
         if not ok then
-          ngx_log(ngx.ERR, "failed to change Redis database: ", err)
+          kong.log.err("failed to change Redis database: ", err)
           return nil, err
         end
       end
@@ -186,7 +186,7 @@ return {
         local cache_key = get_local_key(conf, identifier, period_date, name, period)
         local exists, err = red:exists(cache_key)
         if err then
-          ngx_log(ngx.ERR, "failed to query Redis: ", err)
+          kong.log.err("failed to query Redis: ", err)
           return nil, err
         end
 
@@ -207,12 +207,12 @@ return {
 
       local _, err = red:commit_pipeline()
       if err then
-        ngx_log(ngx.ERR, "failed to commit pipeline in Redis: ", err)
+        kong.log.err("failed to commit pipeline in Redis: ", err)
         return nil, err
       end
       local ok, err = red:set_keepalive(10000, 100)
       if not ok then
-        ngx_log(ngx.ERR, "failed to set Redis keepalive: ", err)
+        kong.log.err("failed to set Redis keepalive: ", err)
         return nil, err
       end
 
@@ -223,20 +223,20 @@ return {
       red:set_timeout(conf.redis_timeout)
       local ok, err = red:connect(conf.redis_host, conf.redis_port)
       if not ok then
-        ngx_log(ngx.ERR, "failed to connect to Redis: ", err)
+        kong.log.err("failed to connect to Redis: ", err)
         return nil, err
       end
 
       local times, err = red:get_reused_times()
       if err then
-        ngx_log(ngx.ERR, "failed to get connect reused times: ", err)
+        kong.log.err("failed to get connect reused times: ", err)
         return nil, err
       end
 
       if times == 0 and is_present(conf.redis_password) then
         local ok, err = red:auth(conf.redis_password)
         if not ok then
-          ngx_log(ngx.ERR, "failed to auth Redis: ", err)
+          kong.log.err("failed to auth Redis: ", err)
           return nil, err
         end
       end
@@ -252,7 +252,7 @@ return {
 
         local ok, err = red:select(conf.redis_database or 0)
         if not ok then
-          ngx_log(ngx.ERR, "failed to change Redis database: ", err)
+          kong.log.err("failed to change Redis database: ", err)
           return nil, err
         end
       end
@@ -266,13 +266,13 @@ return {
         return nil, err
       end
 
-      if current_metric == ngx.null then
+      if current_metric == null then
         current_metric = nil
       end
 
       local ok, err = red:set_keepalive(10000, 100)
       if not ok then
-        ngx_log(ngx.ERR, "failed to set Redis keepalive: ", err)
+        kong.log.err("failed to set Redis keepalive: ", err)
       end
 
       return current_metric or 0

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -412,24 +412,6 @@ _M.check_https = function(trusted_ip, allow_terminated)
   return false
 end
 
---- Merges two table together.
--- A new table is created with a non-recursive copy of the provided tables
--- @param t1 The first table
--- @param t2 The second table
--- @return The (new) merged table
-function _M.table_merge(t1, t2)
-  if not t1 then
-    t1 = {}
-  end
-  if not t2 then
-    t2 = {}
-  end
-
-  local res = {}
-  for k,v in pairs(t1) do res[k] = v end
-  for k,v in pairs(t2) do res[k] = v end
-  return res
-end
 
 --- Checks if a value exists in a table.
 -- @param arr The table to use

--- a/spec-old-api/03-plugins/26-oauth2/03-access_spec.lua
+++ b/spec-old-api/03-plugins/26-oauth2/03-access_spec.lua
@@ -2,6 +2,12 @@ local cjson = require "cjson"
 local helpers = require "spec.helpers"
 local utils = require "kong.tools.utils"
 
+
+local kong = {
+  table = require("kong.pdk.table").new()
+}
+
+
 local function provision_code(host, extra_headers, client_id)
   local request_client = helpers.proxy_ssl_client()
   local res = assert(request_client:send {
@@ -15,7 +21,7 @@ local function provision_code(host, extra_headers, client_id)
       state = "hello",
       authenticated_userid = "userid123"
     },
-    headers = utils.table_merge({
+    headers = kong.table.merge({
       ["Host"] = host or "oauth2.com",
       ["Content-Type"] = "application/json"
     }, extra_headers)
@@ -43,7 +49,7 @@ local function provision_token(host, extra_headers, client_id, client_secret)
              client_id = client_id or "clientid123",
              client_secret = client_secret or "secret123",
              grant_type = "authorization_code" },
-    headers = utils.table_merge({
+    headers = kong.table.merge({
       ["Host"] = host or "oauth2.com",
       ["Content-Type"] = "application/json"
     }, extra_headers)

--- a/spec-old-api/fixtures/mock_upstream.lua
+++ b/spec-old-api/fixtures/mock_upstream.lua
@@ -5,6 +5,11 @@ local ws_server  = require "resty.websocket.server"
 local pl_stringx = require "pl.stringx"
 
 
+local kong = {
+  table = require("kong.pdk.table").new()
+}
+
+
 local function parse_multipart_form_params(body, content_type)
   if not content_type then
     return nil, 'missing content-type'
@@ -231,7 +236,7 @@ end
 
 
 local function send_default_json_response(extra_fields, response_headers)
-  local tbl = utils.table_merge(get_default_json_response(), extra_fields)
+  local tbl = kong.table.merge(get_default_json_response(), extra_fields)
   return send_text_response(cjson.encode(tbl),
                             "application/json", response_headers)
 end

--- a/spec/03-plugins/23-aws-lambda/02-schema_spec.lua
+++ b/spec/03-plugins/23-aws-lambda/02-schema_spec.lua
@@ -1,6 +1,10 @@
 local schema_def = require "kong.plugins.aws-lambda.schema"
-local utils = require "kong.tools.utils"
 local validate_plugin_config_schema = require("spec.helpers").validate_plugin_config_schema
+
+
+local kong = {
+  table = require("kong.pdk.table").new()
+}
 
 
 local DEFAULTS = {
@@ -18,7 +22,7 @@ local DEFAULTS = {
 
 local function v(config)
   return validate_plugin_config_schema(
-    utils.table_merge(DEFAULTS, config),
+    kong.table.merge(DEFAULTS, config),
     schema_def
   )
 end

--- a/spec/03-plugins/24-rate-limiting/02-policies_spec.lua
+++ b/spec/03-plugins/24-rate-limiting/02-policies_spec.lua
@@ -33,8 +33,7 @@ for _, strategy in helpers.each_strategy() do
         local periods = timestamp.get_timestamps(current_timestamp)
 
         for period in pairs(periods) do
-          local metric = assert(cluster_policy.usage(conf, identifier,
-                                                     current_timestamp, period))
+          local metric = assert(cluster_policy.usage(conf, identifier, period, current_timestamp))
           assert.equal(0, metric)
         end
       end)
@@ -57,8 +56,7 @@ for _, strategy in helpers.each_strategy() do
 
         -- First select
         for period in pairs(periods) do
-          local metric = assert(cluster_policy.usage(conf, identifier,
-                                                     current_timestamp, period))
+          local metric = assert(cluster_policy.usage(conf, identifier, period, current_timestamp))
           assert.equal(1, metric)
         end
 
@@ -67,8 +65,7 @@ for _, strategy in helpers.each_strategy() do
 
         -- Second select
         for period in pairs(periods) do
-          local metric = assert(cluster_policy.usage(conf, identifier,
-                                                     current_timestamp, period))
+          local metric = assert(cluster_policy.usage(conf, identifier, period, current_timestamp))
           assert.equal(2, metric)
         end
 
@@ -86,8 +83,7 @@ for _, strategy in helpers.each_strategy() do
             expected_value = 1
           end
 
-          local metric = assert(cluster_policy.usage(conf, identifier,
-                                                     current_timestamp, period))
+          local metric = assert(cluster_policy.usage(conf, identifier, period, current_timestamp))
           assert.equal(expected_value, metric)
         end
       end)

--- a/spec/03-plugins/24-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/24-rate-limiting/04-access_spec.lua
@@ -9,12 +9,7 @@ local REDIS_PASSWORD = ""
 local REDIS_DATABASE = 1
 
 
-local SLEEP_TIME     = 1
-
-
 local fmt = string.format
-
-
 local proxy_client = helpers.proxy_client
 
 
@@ -26,6 +21,27 @@ local function wait(second_offset)
   if current_second > (second_offset or 0) then
     ngx.sleep(60 - current_second)
   end
+end
+
+
+local function GET(url, opts, res_status)
+  local client = proxy_client()
+  local res, err  = client:get(url, opts)
+  if not res then
+    client:close()
+    return nil, err
+  end
+
+  local body, err = assert.res_status(res_status, res)
+  if not body then
+    return nil, err
+  end
+
+  client:close()
+
+  ngx.sleep(0.010)
+
+  return res, body
 end
 
 
@@ -233,7 +249,6 @@ for _, strategy in helpers.each_strategy() do
         }))
       end)
 
-
       teardown(function()
         helpers.stop_kong()
         assert(db:truncate())
@@ -246,21 +261,19 @@ for _, strategy in helpers.each_strategy() do
       describe("Without authentication (IP address)", function()
         it("blocks if exceeding limit", function()
           for i = 1, 6 do
-            local res = proxy_client():get("/status/200", {
+            local res = GET("/status/200", {
               headers = { Host = "test1.com" },
-            })
+            }, 200)
 
-            ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
-
-            assert.res_status(200, res)
             assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
             assert.are.same(6 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
           end
 
           -- Additonal request, while limit is 6/minute
-          local res = proxy_client():get("/status/200", {
+          local res = GET("/status/200", {
             headers = { Host = "test1.com" },
-          })
+          }, 429)
+
           local body = assert.res_status(429, res)
           local json = cjson.decode(body)
           assert.same({ message = "API rate limit exceeded" }, json)
@@ -268,32 +281,28 @@ for _, strategy in helpers.each_strategy() do
 
         it("counts against the same service register from different routes", function()
           for i = 1, 3 do
-            local res = proxy_client():get("/status/200", {
+            local res = GET("/status/200", {
               headers = { Host = "test-service1.com" },
-            })
-            ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
+            }, 200)
 
-            assert.res_status(200, res)
             assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
             assert.are.same(6 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
           end
 
           for i = 4, 6 do
-            local res = proxy_client():get("/status/200", {
+            local res = GET("/status/200", {
               headers = { Host = "test-service2.com" },
-            })
-            ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
+            }, 200)
 
-            assert.res_status(200, res)
             assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
             assert.are.same(6 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
           end
 
           -- Additonal request, while limit is 6/minute
-          local res = proxy_client():get("/status/200", {
+          local res, body = GET("/status/200", {
             headers = { Host = "test-service1.com" },
-          })
-          local body = assert.res_status(429, res)
+          }, 429)
+
           local json = cjson.decode(body)
           assert.same({ message = "API rate limit exceeded" }, json)
         end)
@@ -305,24 +314,21 @@ for _, strategy in helpers.each_strategy() do
           }
 
           for i = 1, 3 do
-            local res = proxy_client():get("/status/200", {
+            local res = GET("/status/200", {
               headers = { Host = "test2.com" },
-            })
+            }, 200)
 
-            ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
-
-            assert.res_status(200, res)
             assert.are.same(limits.minute, tonumber(res.headers["x-ratelimit-limit-minute"]))
             assert.are.same(limits.minute - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
             assert.are.same(limits.hour, tonumber(res.headers["x-ratelimit-limit-hour"]))
             assert.are.same(limits.hour - i, tonumber(res.headers["x-ratelimit-remaining-hour"]))
           end
 
-          local res = proxy_client():get("/status/200", {
+          local res, body = GET("/status/200", {
             path    = "/status/200",
             headers = { Host = "test2.com" },
-          })
-          local body = assert.res_status(429, res)
+          }, 429)
+
           local json = cjson.decode(body)
           assert.same({ message = "API rate limit exceeded" }, json)
           assert.are.equal(2, tonumber(res.headers["x-ratelimit-remaining-hour"]))
@@ -333,70 +339,61 @@ for _, strategy in helpers.each_strategy() do
         describe("API-specific plugin", function()
           it("blocks if exceeding limit", function()
             for i = 1, 6 do
-              local res = proxy_client():get("/status/200?apikey=apikey123", {
+              local res = GET("/status/200?apikey=apikey123", {
                 headers = { Host = "test3.com" },
-              })
+              }, 200)
 
-              ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
-
-              assert.res_status(200, res)
               assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
               assert.are.same(6 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
             end
 
             -- Third query, while limit is 2/minute
-            local res = proxy_client():get("/status/200?apikey=apikey123", {
+            local res = GET("/status/200?apikey=apikey123", {
               headers = { Host = "test3.com" },
-            })
+            }, 429)
+
             local body = assert.res_status(429, res)
             local json = cjson.decode(body)
             assert.same({ message = "API rate limit exceeded" }, json)
 
             -- Using a different key of the same consumer works
-            local res = proxy_client():get("/status/200?apikey=apikey333", {
+            local res = GET("/status/200?apikey=apikey333", {
               headers = { Host = "test3.com" },
-            })
-            assert.res_status(200, res)
+            }, 200)
           end)
         end)
         describe("Plugin customized for specific consumer and route", function()
           it("blocks if exceeding limit", function()
             for i = 1, 8 do
-              local res = proxy_client():get("/status/200?apikey=apikey122", {
+              local res = GET("/status/200?apikey=apikey122", {
                 headers = { Host = "test3.com" },
-              })
+              }, 200)
 
-              ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
-
-              assert.res_status(200, res)
               assert.are.same(8, tonumber(res.headers["x-ratelimit-limit-minute"]))
               assert.are.same(8 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
             end
 
-            local res = proxy_client():get("/status/200?apikey=apikey122", {
+            local res, body = GET("/status/200?apikey=apikey122", {
               headers = { Host = "test3.com" },
-            })
-            local body = assert.res_status(429, res)
+            }, 429)
+
             local json = cjson.decode(body)
             assert.same({ message = "API rate limit exceeded" }, json)
           end)
           it("blocks if the only rate-limiting plugin existing is per consumer and not per API", function()
             for i = 1, 6 do
-              local res = proxy_client():get("/status/200?apikey=apikey122", {
+              local res = GET("/status/200?apikey=apikey122", {
                 headers = { Host = "test4.com" },
-              })
+              }, 200)
 
-              ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
-
-              assert.res_status(200, res)
               assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
               assert.are.same(6 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
             end
 
-            local res = proxy_client():get("/status/200?apikey=apikey122", {
+            local res, body = GET("/status/200?apikey=apikey122", {
               headers = { Host = "test4.com" },
-            })
-            local body = assert.res_status(429, res)
+            }, 429)
+
             local json = cjson.decode(body)
             assert.same({ message = "API rate limit exceeded" }, json)
           end)
@@ -405,11 +402,10 @@ for _, strategy in helpers.each_strategy() do
 
       describe("Config with hide_client_headers", function()
         it("does not send rate-limit headers when hide_client_headers==true", function()
-          local res = proxy_client():get("/status/200", {
+          local res = GET("/status/200", {
             headers = { Host = "test5.com" },
-          })
+          }, 200)
 
-          assert.res_status(200, res)
           assert.is_nil(res.headers["x-ratelimit-limit-minute"])
           assert.is_nil(res.headers["x-ratelimit-remaining-minute"])
         end)
@@ -455,10 +451,10 @@ for _, strategy in helpers.each_strategy() do
           end)
 
           it("does not work if an error occurs", function()
-            local res = proxy_client():get("/status/200", {
+            local res = GET("/status/200", {
               headers = { Host = "failtest1.com" },
-            })
-            assert.res_status(200, res)
+            }, 200)
+
             assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
             assert.are.same(5, tonumber(res.headers["x-ratelimit-remaining-minute"]))
 
@@ -466,18 +462,21 @@ for _, strategy in helpers.each_strategy() do
             assert(dao.db:drop_table("ratelimiting_metrics"))
 
             -- Make another request
-            local res = proxy_client():get("/status/200", {
+            local res, body = GET("/status/200", {
               headers = { Host = "failtest1.com" },
-            })
-            local body = assert.res_status(500, res)
+            }, 500)
+
             local json = cjson.decode(body)
             assert.same({ message = "An unexpected error occurred" }, json)
+
+            db:reset()
+            helpers.get_db_utils(strategy)
           end)
           it("keeps working if an error occurs", function()
-            local res = proxy_client():get("/status/200", {
+            local res = GET("/status/200", {
               headers = { Host = "failtest2.com" },
-            })
-            assert.res_status(200, res)
+            }, 200)
+
             assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
             assert.are.same(5, tonumber(res.headers["x-ratelimit-remaining-minute"]))
 
@@ -485,12 +484,15 @@ for _, strategy in helpers.each_strategy() do
             assert(dao.db:drop_table("ratelimiting_metrics"))
 
             -- Make another request
-            local res = proxy_client():get("/status/200", {
+            local res = GET("/status/200", {
               headers = { Host = "failtest2.com" },
-            })
-            assert.res_status(200, res)
+            }, 200)
+
             assert.falsy(res.headers["x-ratelimit-limit-minute"])
             assert.falsy(res.headers["x-ratelimit-remaining-minute"])
+
+            db:reset()
+            helpers.get_db_utils(strategy)
           end)
         end)
 
@@ -535,19 +537,18 @@ for _, strategy in helpers.each_strategy() do
 
           it("does not work if an error occurs", function()
             -- Make another request
-            local res = proxy_client():get("/status/200", {
+            local res, body = GET("/status/200", {
               headers = { Host = "failtest3.com" },
-            })
-            local body = assert.res_status(500, res)
+            }, 500)
+
             local json = cjson.decode(body)
             assert.same({ message = "An unexpected error occurred" }, json)
           end)
           it("keeps working if an error occurs", function()
-            -- Make another request
-            local res = proxy_client():get("/status/200", {
+            local res = GET("/status/200", {
               headers = { Host = "failtest4.com" },
-            })
-            assert.res_status(200, res)
+            }, 200)
+
             assert.falsy(res.headers["x-ratelimit-limit-minute"])
             assert.falsy(res.headers["x-ratelimit-remaining-minute"])
           end)
@@ -586,25 +587,19 @@ for _, strategy in helpers.each_strategy() do
         end)
 
         describe("expires a counter", function()
-          local res = proxy_client():get("/status/200", {
+          local res = GET("/status/200", {
             headers = { Host = "expire1.com" },
-          })
+          }, 200)
 
-          ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
-
-          assert.res_status(200, res)
           assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
           assert.are.same(5, tonumber(res.headers["x-ratelimit-remaining-minute"]))
 
           ngx.sleep(61) -- Wait for counter to expire
 
-          local res = proxy_client():get("/status/200", {
+          local res = GET("/status/200", {
             headers = { Host = "expire1.com" }
-          })
+          }, 200)
 
-          ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
-
-          assert.res_status(200, res)
           assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
           assert.are.same(5, tonumber(res.headers["x-ratelimit-remaining-minute"]))
         end)
@@ -663,20 +658,19 @@ for _, strategy in helpers.each_strategy() do
 
       it("blocks when the consumer exceeds their quota, no matter what service/route used", function()
         for i = 1, 6 do
-          local res = proxy_client():get("/status/200?apikey=apikey125", {
+          local res = GET("/status/200?apikey=apikey125", {
             headers = { Host = fmt("test%d.com", i) },
-          })
-
-          ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
+          }, 200)
 
           assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
           assert.are.same(6 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
         end
 
         -- Additonal request, while limit is 6/minute
-        local res = proxy_client():get("/status/200?apikey=apikey125", {
+        local res, body = GET("/status/200?apikey=apikey125", {
           headers = { Host = "test1.com" },
-        })
+        }, 429)
+
         local body = assert.res_status(429, res)
         local json = cjson.decode(body)
         assert.same({ message = "API rate limit exceeded" }, json)
@@ -722,27 +716,22 @@ for _, strategy in helpers.each_strategy() do
 
       it("blocks if exceeding limit", function()
         for i = 1, 6 do
-          local res = proxy_client():get("/status/200", {
+          local res = GET("/status/200", {
             headers = { Host = fmt("test%d.com", i) },
-          })
+          }, 200)
 
-          assert.res_status(200, res)
           assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
           assert.are.same(6 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
         end
 
-        ngx.sleep(SLEEP_TIME)
-
         -- Additonal request, while limit is 6/minute
-        local res = proxy_client():get("/status/200", {
+        local res, body = GET("/status/200", {
           headers = { Host = "test1.com" },
-        })
-        local body = assert.res_status(429, res)
+        }, 429)
+
         local json = cjson.decode(body)
         assert.same({ message = "API rate limit exceeded" }, json)
       end)
     end)
   end
 end
-
-

--- a/spec/03-plugins/25-response-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/25-response-rate-limiting/04-access_spec.lua
@@ -1,6 +1,5 @@
 local cjson          = require "cjson"
 local helpers        = require "spec.helpers"
-local timestamp      = require "kong.tools.timestamp"
 
 
 local REDIS_HOST     = "127.0.0.1"
@@ -9,8 +8,8 @@ local REDIS_PASSWORD = ""
 local REDIS_DATABASE = 1
 
 
-local SLEEP_TIME = 1
-
+local SLEEP_TIME = 0.01
+local ITERATIONS = 10
 
 local fmt = string.format
 
@@ -18,14 +17,11 @@ local fmt = string.format
 local proxy_client = helpers.proxy_client
 
 
-local function wait(second_offset)
-  -- If the minute elapses in the middle of the test, then the test will
-  -- fail. So we give it this test 30 seconds to execute, and if the second
-  -- of the current minute is > 30, then we wait till the new minute kicks in
-  local current_second = timestamp.get_timetable().sec
-  if current_second > (second_offset or 0) then
-    ngx.sleep(60 - current_second)
-  end
+local function wait()
+  ngx.update_time()
+  local now = ngx.now()
+  local millis = (now - math.floor(now))
+  ngx.sleep(1 - millis)
 end
 
 
@@ -55,834 +51,776 @@ local function flush_redis()
 end
 
 
+local function test_limit(path, host, limit)
+  wait()
+  limit = limit or ITERATIONS
+  for i = 1, limit do
+    local res = proxy_client():get(path, {
+      headers = { Host = host:format(i) },
+    })
+    assert.res_status(200, res)
+  end
+
+  ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
+
+  local res = proxy_client():get(path, {
+    headers = { Host = host:format(1) },
+  })
+  assert.res_status(429, res)
+  assert.equal(limit, tonumber(res.headers["x-ratelimit-limit-video-second"]))
+  assert.equal(0, tonumber(res.headers["x-ratelimit-remaining-video-second"]))
+end
+
+
+local function init_db(strategy, policy)
+  local bp = helpers.get_db_utils(strategy, {
+    "routes",
+    "services",
+    "plugins",
+    "consumers",
+    "keyauth_credentials",
+  })
+
+  if policy == "redis" then
+    flush_redis()
+  end
+
+  return bp
+end
+
+
 for _, strategy in helpers.each_strategy() do
-  for i, policy in ipairs({"local", "cluster", "redis"}) do
-    describe(fmt("#flaky Plugin: response-ratelimiting (access) with policy: %s [#%s]", policy, strategy), function()
-      local dao
-      local db
-      local bp
+for _, policy in ipairs({"local", "cluster", "redis"}) do
 
-      setup(function()
-        bp, db, dao = helpers.get_db_utils(strategy, {
-          "routes",
-          "services",
-          "plugins",
-          "consumers",
-          "keyauth_credentials",
-        })
-        dao.db:truncate_table("response_ratelimiting_metrics")
+describe(fmt("#flaky Plugin: response-ratelimiting (access) with policy: #%s [#%s]", policy, strategy), function()
 
-        flush_redis()
+  setup(function()
+    local bp = init_db(strategy, policy)
 
-        local consumer1 = bp.consumers:insert {custom_id = "provider_123"}
-        bp.keyauth_credentials:insert {
-          key      = "apikey123",
-          consumer = { id = consumer1.id },
-        }
+    if policy == "local" then
+      SLEEP_TIME = 0.001
+    else
+      SLEEP_TIME = 0.15
+    end
 
-        local consumer2 = bp.consumers:insert {custom_id = "provider_124"}
-        bp.keyauth_credentials:insert {
-          key      = "apikey124",
-          consumer = { id = consumer2.id },
-        }
+    local consumer1 = bp.consumers:insert {custom_id = "provider_123"}
+    bp.keyauth_credentials:insert {
+      key      = "apikey123",
+      consumer = { id = consumer1.id },
+    }
 
-        local consumer3 = bp.consumers:insert {custom_id = "provider_125"}
-        bp.keyauth_credentials:insert {
-          key      = "apikey125",
-          consumer = { id = consumer3.id },
-        }
+    local consumer2 = bp.consumers:insert {custom_id = "provider_124"}
+    bp.keyauth_credentials:insert {
+      key      = "apikey124",
+      consumer = { id = consumer2.id },
+    }
 
-        local service1 = bp.services:insert()
+    local route1 = bp.routes:insert {
+      hosts      = { "test1.com" },
+      protocols  = { "http", "https" },
+    }
 
-        local route1 = bp.routes:insert {
-          hosts      = { "test1.com" },
-          protocols  = { "http", "https" },
-          service    = service1
-        }
+    bp.response_ratelimiting_plugins:insert({
+      route = { id = route1.id },
+      config   = {
+        fault_tolerant = false,
+        policy         = policy,
+        redis_host     = REDIS_HOST,
+        redis_port     = REDIS_PORT,
+        redis_password = REDIS_PASSWORD,
+        redis_database = REDIS_DATABASE,
+        limits         = { video = { second = ITERATIONS } },
+      },
+    })
 
-        bp.response_ratelimiting_plugins:insert({
-          route = { id = route1.id },
-          config   = {
-            fault_tolerant = false,
-            policy         = policy,
-            redis_host     = REDIS_HOST,
-            redis_port     = REDIS_PORT,
-            redis_password = REDIS_PASSWORD,
-            redis_database = REDIS_DATABASE,
-            limits         = { video = { minute = 6 } },
+    local route2 = bp.routes:insert {
+      hosts      = { "test2.com" },
+      protocols  = { "http", "https" },
+    }
+
+    bp.response_ratelimiting_plugins:insert({
+      route = { id = route2.id },
+      config   = {
+        fault_tolerant = false,
+        policy         = policy,
+        redis_host     = REDIS_HOST,
+        redis_port     = REDIS_PORT,
+        redis_password = REDIS_PASSWORD,
+        redis_database = REDIS_DATABASE,
+        limits         = { video = { second = ITERATIONS*2, minute = ITERATIONS*4 },
+                           image = { second = ITERATIONS } },
+      },
+    })
+
+    local route3 = bp.routes:insert {
+      hosts      = { "test3.com" },
+      protocols  = { "http", "https" },
+    }
+
+    bp.plugins:insert {
+      name     = "key-auth",
+      route = { id = route3.id },
+    }
+
+    bp.response_ratelimiting_plugins:insert({
+      route = { id = route3.id },
+      config   = {
+        policy = policy,
+        redis_host     = REDIS_HOST,
+        redis_port     = REDIS_PORT,
+        redis_password = REDIS_PASSWORD,
+        redis_database = REDIS_DATABASE,
+        limits = { video = { second = ITERATIONS - 3 }
+      } },
+    })
+
+    bp.response_ratelimiting_plugins:insert({
+      route = { id = route3.id },
+      consumer = { id = consumer1.id },
+      config      = {
+        fault_tolerant = false,
+        policy         = policy,
+        redis_host     = REDIS_HOST,
+        redis_port     = REDIS_PORT,
+        redis_password = REDIS_PASSWORD,
+        redis_database = REDIS_DATABASE,
+        limits         = { video = { second = ITERATIONS - 2 } },
+      },
+    })
+
+    local route4 = bp.routes:insert {
+      hosts      = { "test4.com" },
+      protocols  = { "http", "https" },
+    }
+
+    bp.response_ratelimiting_plugins:insert({
+      route = { id = route4.id },
+      config   = {
+        fault_tolerant = false,
+        policy         = policy,
+        redis_host     = REDIS_HOST,
+        redis_port     = REDIS_PORT,
+        redis_password = REDIS_PASSWORD,
+        redis_database = REDIS_DATABASE,
+        limits         = {
+          video = { second = ITERATIONS * 2 + 2 },
+          image = { second = ITERATIONS }
+        },
+      }
+    })
+
+    local route7 = bp.routes:insert {
+      hosts      = { "test7.com" },
+      protocols  = { "http", "https" },
+    }
+
+    bp.response_ratelimiting_plugins:insert({
+      route = { id = route7.id },
+      config   = {
+        fault_tolerant           = false,
+        policy                   = policy,
+        redis_host               = REDIS_HOST,
+        redis_port               = REDIS_PORT,
+        redis_password           = REDIS_PASSWORD,
+        redis_database           = REDIS_DATABASE,
+        block_on_first_violation = true,
+        limits                   = {
+          video = {
+            second = ITERATIONS,
+            minute = ITERATIONS * 2,
           },
-        })
-
-        local service2 = bp.services:insert()
-
-        local route2 = bp.routes:insert {
-          hosts      = { "test2.com" },
-          protocols  = { "http", "https" },
-          service    = service2
-        }
-
-        bp.response_ratelimiting_plugins:insert({
-          route = { id = route2.id },
-          config   = {
-            fault_tolerant = false,
-            policy         = policy,
-            redis_host     = REDIS_HOST,
-            redis_port     = REDIS_PORT,
-            redis_password = REDIS_PASSWORD,
-            redis_database = REDIS_DATABASE,
-            limits         = { video = { minute = 6, hour = 10 },
-                               image = { minute = 4 } },
+          image = {
+            second = 4,
           },
-        })
-
-        local service3 = bp.services:insert()
-
-        local route3 = bp.routes:insert {
-          hosts      = { "test3.com" },
-          protocols  = { "http", "https" },
-          service    = service3
-        }
-
-        bp.plugins:insert {
-          name     = "key-auth",
-          route = { id = route3.id },
-        }
-
-        bp.response_ratelimiting_plugins:insert({
-          route = { id = route3.id },
-          config   = { limits = { video = { minute = 6 } } },
-        })
-
-        bp.response_ratelimiting_plugins:insert({
-          route = { id = route3.id },
-          consumer = { id = consumer1.id },
-          config      = {
-            fault_tolerant = false,
-            policy         = policy,
-            redis_host     = REDIS_HOST,
-            redis_port     = REDIS_PORT,
-            redis_password = REDIS_PASSWORD,
-            redis_database = REDIS_DATABASE,
-            limits         = { video = { minute = 2 } },
-          },
-        })
-
-        local service4 = bp.services:insert()
-
-        local route4 = bp.routes:insert {
-          hosts      = { "test4.com" },
-          protocols  = { "http", "https" },
-          service    = service4
-        }
-
-        bp.response_ratelimiting_plugins:insert({
-          route = { id = route4.id },
-          config   = {
-            fault_tolerant = false,
-            policy         = policy,
-            redis_host     = REDIS_HOST,
-            redis_port     = REDIS_PORT,
-            redis_password = REDIS_PASSWORD,
-            redis_database = REDIS_DATABASE,
-            limits         = { video = { minute = 6 }, image = { minute = 4 } },
-          }
-        })
-
-        local service7 = bp.services:insert()
-
-        local route7 = bp.routes:insert {
-          hosts      = { "test7.com" },
-          protocols  = { "http", "https" },
-          service    = service7
-        }
-
-        bp.response_ratelimiting_plugins:insert({
-          route = { id = route7.id },
-          config   = {
-            fault_tolerant           = false,
-            policy                   = policy,
-            redis_host               = REDIS_HOST,
-            redis_port               = REDIS_PORT,
-            redis_password           = REDIS_PASSWORD,
-            redis_database           = REDIS_DATABASE,
-            block_on_first_violation = true,
-            limits                   = {
-              video = {
-                minute = 6,
-                hour  = 10,
-              },
-              image = {
-                minute = 4,
-              },
-            },
-          }
-        })
-
-        local service8 = bp.services:insert()
-
-        local route8 = bp.routes:insert {
-          hosts      = { "test8.com" },
-          protocols  = { "http", "https" },
-          service    = service8
-        }
-
-        bp.response_ratelimiting_plugins:insert({
-          route = { id = route8.id },
-          config   = {
-            fault_tolerant = false,
-            policy         = policy,
-            redis_host     = REDIS_HOST,
-            redis_port     = REDIS_PORT,
-            redis_password = REDIS_PASSWORD,
-            redis_database = REDIS_DATABASE,
-            limits         = { video = { minute = 6, hour = 10 },
-                               image = { minute = 4 } },
-          }
-        })
-
-        local service9 = bp.services:insert()
-
-        local route9 = bp.routes:insert {
-          hosts      = { "test9.com" },
-          protocols  = { "http", "https" },
-          service    = service9
-        }
-
-        bp.response_ratelimiting_plugins:insert({
-          route = { id = route9.id },
-          config   = {
-            fault_tolerant      = false,
-            policy              = policy,
-            hide_client_headers = true,
-            redis_host          = REDIS_HOST,
-            redis_port          = REDIS_PORT,
-            redis_password      = REDIS_PASSWORD,
-            redis_database      = REDIS_DATABASE,
-            limits              = { video = { minute = 6 } },
-          }
-        })
-
-
-        local service10 = bp.services:insert()
-        bp.routes:insert {
-          hosts = { "test-service1.com" },
-          service = service10,
-        }
-        bp.routes:insert {
-          hosts = { "test-service2.com" },
-          service = service10,
-        }
-
-        bp.response_ratelimiting_plugins:insert({
-          service = { id = service10.id },
-          config = {
-            fault_tolerant = false,
-            policy         = policy,
-            redis_host     = REDIS_HOST,
-            redis_port     = REDIS_PORT,
-            redis_password = REDIS_PASSWORD,
-            redis_database = REDIS_DATABASE,
-            limits         = { video = { minute = 6 } },
-          }
-        })
-
-        assert(helpers.start_kong({
-          database   = strategy,
-          nginx_conf = "spec/fixtures/custom_nginx.template",
-        }))
-      end)
-
-      teardown(function()
-        helpers.stop_kong()
-      end)
-
-      before_each(function()
-        wait(45)
-      end)
-
-      describe("Without authentication (IP address)", function()
-        it("blocks if exceeding limit", function()
-          for i = 1, 6 do
-            local res = proxy_client():get("/response-headers?x-kong-limit=video=1, test=5", {
-              headers = { Host = "test1.com" },
-            })
-
-            ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
-
-            assert.res_status(200, res)
-            assert.equal(6, tonumber(res.headers["x-ratelimit-limit-video-minute"]))
-            assert.equal(6 - i, tonumber(res.headers["x-ratelimit-remaining-video-minute"]))
-          end
-
-          local res = proxy_client():get("/response-headers?x-kong-limit=video=1", {
-            headers = { Host = "test1.com" },
-          })
-
-          assert.res_status(429, res)
-        end)
-
-        it("counts against the same service register from different routes", function()
-          for i = 1, 3 do
-
-            local res = proxy_client():get("/response-headers?x-kong-limit=video=1, test=5", {
-              headers = { Host = "test-service1.com" },
-            })
-            ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
-
-            assert.res_status(200, res)
-            assert.equal(6, tonumber(res.headers["x-ratelimit-limit-video-minute"]))
-            assert.equal(6 - i, tonumber(res.headers["x-ratelimit-remaining-video-minute"]))
-          end
-
-          for i = 4, 6 do
-            local res = proxy_client():get("/response-headers?x-kong-limit=video=1, test=5", {
-              headers = { Host = "test-service2.com" },
-            })
-            ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
-            assert.res_status(200, res)
-            assert.equal(6, tonumber(res.headers["x-ratelimit-limit-video-minute"]))
-            assert.equal(6 - i, tonumber(res.headers["x-ratelimit-remaining-video-minute"]))
-          end
-
-          -- Additonal request, while limit is 6/minute
-          local res = proxy_client():get("/response-headers?x-kong-limit=video=1, test=5", {
-            headers = { Host = "test-service1.com" },
-          })
-          assert.res_status(429, res)
-        end)
-
-        it("handles multiple limits", function()
-          for i = 1, 3 do
-
-            local res = proxy_client():get("/response-headers?x-kong-limit=video=2, image=1", {
-              headers = { Host = "test2.com" },
-            })
-
-            ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
-
-            assert.res_status(200, res)
-            assert.equal(6, tonumber(res.headers["x-ratelimit-limit-video-minute"]))
-            assert.equal(6 - (i * 2), tonumber(res.headers["x-ratelimit-remaining-video-minute"]))
-            assert.equal(10, tonumber(res.headers["x-ratelimit-limit-video-hour"]))
-            assert.equal(10 - (i * 2), tonumber(res.headers["x-ratelimit-remaining-video-hour"]))
-            assert.equal(4, tonumber(res.headers["x-ratelimit-limit-image-minute"]))
-            assert.equal(4 - i, tonumber(res.headers["x-ratelimit-remaining-image-minute"]))
-          end
-
-          local res = proxy_client():get("/response-headers?x-kong-limit=video=2, image=1", {
-            headers = { Host = "test2.com" },
-          })
-
-          assert.res_status(429, res)
-          assert.equal(0, tonumber(res.headers["x-ratelimit-remaining-video-minute"]))
-          assert.equal(4, tonumber(res.headers["x-ratelimit-remaining-video-hour"]))
-          assert.equal(1, tonumber(res.headers["x-ratelimit-remaining-image-minute"]))
-        end)
-      end)
-
-      describe("With authentication", function()
-        describe("API-specific plugin", function()
-          it("blocks if exceeding limit and a per consumer & route setting", function()
-            for i = 1, 2 do
-              local res = proxy_client():get("/response-headers?apikey=apikey123&x-kong-limit=video=1", {
-                headers = { Host = "test3.com" },
-              })
-
-              ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
-
-              assert.res_status(200, res)
-              assert.equal(2, tonumber(res.headers["x-ratelimit-limit-video-minute"]))
-              assert.equal(2 - i, tonumber(res.headers["x-ratelimit-remaining-video-minute"]))
-            end
-
-            -- Third query, while limit is 2/minute
-            local res = proxy_client():get("/response-headers?apikey=apikey123&x-kong-limit=video=1", {
-              headers = { Host = "test3.com" },
-            })
-            assert.res_status(429, res)
-            assert.equal(0, tonumber(res.headers["x-ratelimit-remaining-video-minute"]))
-            assert.equal(2, tonumber(res.headers["x-ratelimit-limit-video-minute"]))
-          end)
-
-          it("blocks if exceeding limit and a per consumer & route setting", function()
-            for i = 1, 6 do
-              local res = proxy_client():get("/response-headers?apikey=apikey124&x-kong-limit=video=1", {
-                headers = { Host = "test3.com" },
-              })
-
-              ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
-
-              assert.res_status(200, res)
-              assert.equal(6, tonumber(res.headers["x-ratelimit-limit-video-minute"]))
-              assert.equal(6 - i, tonumber(res.headers["x-ratelimit-remaining-video-minute"]))
-            end
-
-            local res = proxy_client():get("/response-headers?apikey=apikey124", {
-              headers = { Host = "test3.com" },
-            })
-
-            assert.res_status(200, res)
-            assert.equal(0, tonumber(res.headers["x-ratelimit-remaining-video-minute"]))
-            assert.equal(6, tonumber(res.headers["x-ratelimit-limit-video-minute"]))
-          end)
-
-          it("blocks if exceeding limit", function()
-            for i = 1, 6 do
-              local res = proxy_client():get("/response-headers?apikey=apikey125&x-kong-limit=video=1", {
-                headers = { Host = "test3.com" },
-              })
-
-              ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
-
-              assert.res_status(200, res)
-              assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-video-minute"]))
-              assert.are.same(6 - i, tonumber(res.headers["x-ratelimit-remaining-video-minute"]))
-            end
-
-            -- Third query, while limit is 2/minute
-            local res = proxy_client():get("/response-headers?apikey=apikey125&x-kong-limit=video=1", {
-              headers = { Host = "test3.com" },
-            })
-            assert.res_status(429, res)
-            assert.equal(0, tonumber(res.headers["x-ratelimit-remaining-video-minute"]))
-            assert.equal(6, tonumber(res.headers["x-ratelimit-limit-video-minute"]))
-          end)
-        end)
-      end)
-
-      describe("Upstream usage headers", function()
-        it("should append the headers with multiple limits", function()
-          local res = proxy_client():get("/get", {
-            headers = { Host = "test8.com" },
-          })
-          local json = cjson.decode(assert.res_status(200, res))
-          assert.equal(4, tonumber(json.headers["x-ratelimit-remaining-image"]))
-          assert.equal(6, tonumber(json.headers["x-ratelimit-remaining-video"]))
-
-          -- Actually consume the limits
-          local res = proxy_client():get("/response-headers?x-kong-limit=video=2, image=1", {
-            headers = { Host = "test8.com" },
-          })
-          assert.res_status(200, res)
-
-          ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
-
-          local res = proxy_client():get("/get", {
-            headers = { Host = "test8.com" },
-          })
-          local body = cjson.decode(assert.res_status(200, res))
-          assert.equal(3, tonumber(body.headers["x-ratelimit-remaining-image"]))
-          assert.equal(4, tonumber(body.headers["x-ratelimit-remaining-video"]))
-        end)
-
-        it("combines multiple x-kong-limit headers from upstream", function()
-          for i = 1, 3 do
-            local res = proxy_client():get("/response-headers?x-kong-limit=video%3D2&x-kong-limit=image%3D1", {
-              headers = { Host = "test4.com" },
-            })
-
-            assert.res_status(200, res)
-            assert.equal(6, tonumber(res.headers["x-ratelimit-limit-video-minute"]))
-            assert.equal(6 - (i * 2), tonumber(res.headers["x-ratelimit-remaining-video-minute"]))
-            assert.equal(4, tonumber(res.headers["x-ratelimit-limit-image-minute"]))
-            assert.equal(4 - i, tonumber(res.headers["x-ratelimit-remaining-image-minute"]))
-
-            ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
-          end
-
-          local res = proxy_client():get("/response-headers?x-kong-limit=video%3D2&x-kong-limit=image%3D1", {
-            headers = { Host = "test4.com" },
-          })
-
-          assert.res_status(429, res)
-          assert.equal(0, tonumber(res.headers["x-ratelimit-remaining-video-minute"]))
-          assert.equal(1, tonumber(res.headers["x-ratelimit-remaining-image-minute"]))
-        end)
-      end)
-
-      it("should block on first violation", function()
-        local res = proxy_client():get("/response-headers?x-kong-limit=video=2, image=4", {
-          headers = { Host = "test7.com" },
-        })
-        assert.res_status(200, res)
-
-        ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
-
-        local res = proxy_client():get("/response-headers?x-kong-limit=video=2", {
-          headers = { Host = "test7.com" },
-        })
-        local body = assert.res_status(429, res)
-        local json = cjson.decode(body)
-        assert.same({ message = "API rate limit exceeded for 'image'" }, json)
-      end)
-
-      describe("Config with hide_client_headers", function()
-        it("does not send rate-limit headers when hide_client_headers==true", function()
-          local res = proxy_client():get("/status/200", {
-            headers = { Host = "test9.com" },
-          })
-
-          assert.res_status(200, res)
-          assert.is_nil(res.headers["x-ratelimit-remaining-video-minute"])
-          assert.is_nil(res.headers["x-ratelimit-limit-video-minute"])
-        end)
-      end)
-
-      if policy == "cluster" then
-        describe("Fault tolerancy", function()
-
-          before_each(function()
-            helpers.kill_all()
-            assert(db:truncate())
-
-            local route1 = bp.routes:insert {
-              hosts = { "failtest1.com" },
-            }
-
-            bp.response_ratelimiting_plugins:insert {
-              route = { id = route1.id },
-              config   = {
-                fault_tolerant = false,
-                policy         = policy,
-                redis_host     = REDIS_HOST,
-                redis_port     = REDIS_PORT,
-                redis_password = REDIS_PASSWORD,
-                limits         = { video = { minute = 6} },
-              }
-            }
-
-            local route2 = bp.routes:insert {
-              hosts = { "failtest2.com" },
-            }
-
-            bp.response_ratelimiting_plugins:insert {
-              route = { id = route2.id },
-              config   = {
-                fault_tolerant = true,
-                policy         = policy,
-                redis_host     = REDIS_HOST,
-                redis_port     = REDIS_PORT,
-                redis_password = REDIS_PASSWORD,
-                limits         = { video = {minute = 6} }
-              }
-            }
-
-            assert(helpers.start_kong({
-              database   = strategy,
-              nginx_conf = "spec/fixtures/custom_nginx.template",
-            }))
-          end)
-
-          teardown(function()
-            helpers.kill_all()
-            assert(db:truncate())
-          end)
-
-          it("does not work if an error occurs", function()
-            local res = proxy_client():get("/response-headers?x-kong-limit=video=1", {
-              headers = { Host = "failtest1.com" },
-            })
-            assert.res_status(200, res)
-            assert.equal(6, tonumber(res.headers["x-ratelimit-limit-video-minute"]))
-            assert.equal(5, tonumber(res.headers["x-ratelimit-remaining-video-minute"]))
-
-            -- Simulate an error on the database
-            assert(dao.db:drop_table("response_ratelimiting_metrics"))
-
-            -- Make another request
-            local res = proxy_client():get("/response-headers?x-kong-limit=video=1", {
-              headers = { Host = "failtest1.com" },
-            })
-            local body = assert.res_status(500, res)
-            local json = cjson.decode(body)
-            assert.same({ message = "An unexpected error occurred" }, json)
-          end)
-
-          it("keeps working if an error occurs", function()
-            local res = proxy_client():get("/response-headers?x-kong-limit=video=1", {
-              headers = { Host = "failtest2.com" },
-            })
-            assert.res_status(200, res)
-            assert.equal(6, tonumber(res.headers["x-ratelimit-limit-video-minute"]))
-            assert.equal(5, tonumber(res.headers["x-ratelimit-remaining-video-minute"]))
-
-            -- Simulate an error on the database
-            assert(dao.db:drop_table("response_ratelimiting_metrics"))
-
-            -- Make another request
-            local res = proxy_client():get("/response-headers?x-kong-limit=video=1", {
-              headers = { Host = "failtest2.com" },
-            })
-            assert.res_status(200, res)
-            assert.is_nil(res.headers["x-ratelimit-limit-video-minute"])
-            assert.is_nil(res.headers["x-ratelimit-remaining-video-minute"])
-          end)
-        end)
-
-      elseif policy == "redis" then
-        describe("Fault tolerancy", function()
-
-          before_each(function()
-            helpers.kill_all()
-            assert(db:truncate())
-
-            local service1 = bp.services:insert()
-
-            local route1 = bp.routes:insert {
-              hosts      = { "failtest3.com" },
-              protocols  = { "http", "https" },
-              service    = service1
-            }
-
-            bp.response_ratelimiting_plugins:insert {
-              route = { id = route1.id },
-              config   = {
-                fault_tolerant = false,
-                policy         = policy,
-                redis_host     = "5.5.5.5",
-                limits         = { video = { minute = 6 } },
-              }
-            }
-
-            local service2 = bp.services:insert()
-
-            local route2 = bp.routes:insert {
-              hosts      = { "failtest4.com" },
-              protocols  = { "http", "https" },
-              service    = service2
-            }
-
-            bp.response_ratelimiting_plugins:insert {
-              route = { id = route2.id },
-              config   = {
-                fault_tolerant = true,
-                policy         = policy,
-                redis_host     = "5.5.5.5",
-                limits         = { video = { minute = 6 } },
-              }
-            }
-
-            assert(helpers.start_kong({
-              database   = strategy,
-              nginx_conf = "spec/fixtures/custom_nginx.template",
-            }))
-          end)
-
-          it("does not work if an error occurs", function()
-            -- Make another request
-            local res = proxy_client():get("/status/200", {
-              headers = { Host = "failtest3.com" },
-            })
-            local body = assert.res_status(500, res)
-            local json = cjson.decode(body)
-            assert.same({ message = "An unexpected error occurred" }, json)
-          end)
-          it("keeps working if an error occurs", function()
-            -- Make another request
-            local res = proxy_client():get("/status/200", {
-              headers = { Host = "failtest4.com" },
-            })
-            assert.res_status(200, res)
-            assert.falsy(res.headers["x-ratelimit-limit-video-minute"])
-            assert.falsy(res.headers["x-ratelimit-remaining-video-minute"])
-          end)
-        end)
-      end
-
-      describe("Expirations", function()
-        setup(function()
-          helpers.stop_kong()
-          assert(db:truncate())
-
-          local service = bp.services:insert()
-
-          local route = bp.routes:insert {
-            hosts      = { "expire1.com" },
-            protocols  = { "http", "https" },
-            service    = service
-          }
-
-          bp.response_ratelimiting_plugins:insert {
-            route = { id = route.id },
-            config   = {
-              policy         = policy,
-              redis_host     = REDIS_HOST,
-              redis_port     = REDIS_PORT,
-              redis_password = REDIS_PASSWORD,
-              fault_tolerant = false,
-              limits         = { video = { minute = 6 } },
-            }
-          }
-
-          assert(helpers.start_kong({
-            database   = strategy,
-            nginx_conf = "spec/fixtures/custom_nginx.template",
-          }))
-        end)
-
-        it("expires a counter", function()
-          local res = proxy_client():get("/response-headers?x-kong-limit=video=1", {
-            headers = { Host = "expire1.com" },
-          })
-
-          ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
-
-          assert.res_status(200, res)
-          assert.equal(6, tonumber(res.headers["x-ratelimit-limit-video-minute"]))
-          assert.equal(5, tonumber(res.headers["x-ratelimit-remaining-video-minute"]))
-
-          ngx.sleep(61) -- Wait for counter to expire
-
-          local res = proxy_client():get("/response-headers?x-kong-limit=video=1", {
-            headers = { Host = "expire1.com" },
-          })
-
-          ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
-
-          assert.res_status(200, res)
-          assert.equal(6, tonumber(res.headers["x-ratelimit-limit-video-minute"]))
-          assert.equal(5, tonumber(res.headers["x-ratelimit-remaining-video-minute"]))
-        end)
-      end)
-    end)
-
-    describe(fmt("#flaky Plugin: response-rate-limiting (access - global for single consumer) with policy: %s [#%s]", policy, strategy), function()
-      local bp
-      local dao
-      setup(function()
-        helpers.kill_all()
-        flush_redis()
-        local _
-        bp, _, dao = helpers.get_db_utils(strategy, {
-          "routes",
-          "services",
-          "plugins",
-          "consumers",
-          "keyauth_credentials",
-        })
-        dao.db:truncate_table("response_ratelimiting_metrics")
-
-        local consumer = bp.consumers:insert {
-          custom_id = "provider_125",
-        }
-
-        bp.key_auth_plugins:insert()
-
-        bp.keyauth_credentials:insert {
-          key      = "apikey125",
-          consumer = { id = consumer.id },
-        }
-
-        -- just consumer, no no route or service
-        bp.response_ratelimiting_plugins:insert({
-          consumer = { id = consumer.id },
-          config = {
-            fault_tolerant = false,
-            policy         = policy,
-            redis_host     = REDIS_HOST,
-            redis_port     = REDIS_PORT,
-            redis_password = REDIS_PASSWORD,
-            redis_database = REDIS_DATABASE,
-            limits         = { video = { minute = 6 } },
-          }
-        })
-
-        for i = 1, 6 do
-          bp.routes:insert({ hosts = { fmt("test%d.com", i) } })
-        end
-
-        assert(helpers.start_kong({
-          database   = strategy,
-          nginx_conf = "spec/fixtures/custom_nginx.template",
-        }))
-      end)
-
-      teardown(function()
-        helpers.stop_kong()
-      end)
-
-      it("blocks when the consumer exceeds their quota, no matter what service/route used", function()
-        for i = 1, 6 do
-          local res = proxy_client():get("/response-headers?apikey=apikey125&x-kong-limit=video=1", {
-            headers = { Host = fmt("test%d.com", i) },
-          })
-
-          ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
-
-          assert.res_status(200, res)
-          assert.equal(6, tonumber(res.headers["x-ratelimit-limit-video-minute"]))
-          assert.equal(6 - i, tonumber(res.headers["x-ratelimit-remaining-video-minute"]))
-        end
-
-        -- 7th query, while limit is 6/minute
-        local res = proxy_client():get("/response-headers?apikey=apikey125&x-kong-limit=video=1", {
-          headers = { Host = "test1.com" },
-        })
-        assert.res_status(429, res)
-        assert.equal(0, tonumber(res.headers["x-ratelimit-remaining-video-minute"]))
-        assert.equal(6, tonumber(res.headers["x-ratelimit-limit-video-minute"]))
-      end)
-    end)
-
-    describe(fmt("#flaky Plugin: rate-limiting (access - global) with policy: %s [#%s]", policy, strategy), function()
-      local bp
-      local db
-
-      setup(function()
-        helpers.kill_all()
-        flush_redis()
-        bp, db = helpers.get_db_utils(strategy)
-
-        -- global plugin (not attached to route, service or consumer)
-        bp.response_ratelimiting_plugins:insert({
-          config = {
-            fault_tolerant = false,
-            policy         = policy,
-            redis_host     = REDIS_HOST,
-            redis_port     = REDIS_PORT,
-            redis_password = REDIS_PASSWORD,
-            redis_database = REDIS_DATABASE,
-            limits         = { video = { minute = 6 } },
-          }
-        })
-
-        for i = 1, 6 do
-          bp.routes:insert({ hosts = { fmt("test%d.com", i) } })
-        end
-
-        assert(helpers.start_kong({
-          database   = strategy,
-          nginx_conf = "spec/fixtures/custom_nginx.template",
-        }))
-      end)
-
-      teardown(function()
-        helpers.kill_all()
-        assert(db:truncate())
-      end)
-
-      it("blocks if exceeding limit", function()
-        for i = 1, 6 do
-          local res = proxy_client():get("/response-headers?x-kong-limit=video=1", {
-            headers = { Host = fmt("test%d.com", i) },
-          })
-
-          ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
-
-          assert.res_status(200, res)
-          assert.equal(6, tonumber(res.headers["x-ratelimit-limit-video-minute"]))
-          assert.equal(6 - i, tonumber(res.headers["x-ratelimit-remaining-video-minute"]))
-        end
-
-        -- 7th query, while limit is 6/minute
+        },
+      }
+    })
+
+    local route8 = bp.routes:insert {
+      hosts      = { "test8.com" },
+      protocols  = { "http", "https" },
+    }
+
+    bp.response_ratelimiting_plugins:insert({
+      route = { id = route8.id },
+      config   = {
+        fault_tolerant = false,
+        policy         = policy,
+        redis_host     = REDIS_HOST,
+        redis_port     = REDIS_PORT,
+        redis_password = REDIS_PASSWORD,
+        redis_database = REDIS_DATABASE,
+        limits         = { video = { second = ITERATIONS, minute = ITERATIONS*2 },
+                           image = { second = ITERATIONS-1 } },
+      }
+    })
+
+    local route9 = bp.routes:insert {
+      hosts      = { "test9.com" },
+      protocols  = { "http", "https" },
+    }
+
+    bp.response_ratelimiting_plugins:insert({
+      route = { id = route9.id },
+      config   = {
+        fault_tolerant      = false,
+        policy              = policy,
+        hide_client_headers = true,
+        redis_host          = REDIS_HOST,
+        redis_port          = REDIS_PORT,
+        redis_password      = REDIS_PASSWORD,
+        redis_database      = REDIS_DATABASE,
+        limits              = { video = { second = ITERATIONS } },
+      }
+    })
+
+
+    local service10 = bp.services:insert()
+    bp.routes:insert {
+      hosts = { "test-service1.com" },
+      service = service10,
+    }
+    bp.routes:insert {
+      hosts = { "test-service2.com" },
+      service = service10,
+    }
+
+    bp.response_ratelimiting_plugins:insert({
+      service = { id = service10.id },
+      config = {
+        fault_tolerant = false,
+        policy         = policy,
+        redis_host     = REDIS_HOST,
+        redis_port     = REDIS_PORT,
+        redis_password = REDIS_PASSWORD,
+        redis_database = REDIS_DATABASE,
+        limits         = { video = { second = ITERATIONS } },
+      }
+    })
+
+    assert(helpers.start_kong({
+      database   = strategy,
+      nginx_conf = "spec/fixtures/custom_nginx.template",
+    }))
+  end)
+
+  teardown(function()
+    helpers.stop_kong(nil, true)
+  end)
+
+  describe("Without authentication (IP address)", function()
+
+    it("returns remaining counter", function()
+      wait()
+      local n = math.floor(ITERATIONS / 2)
+      for _ = 1, n do
         local res = proxy_client():get("/response-headers?x-kong-limit=video=1", {
           headers = { Host = "test1.com" },
         })
-        assert.res_status(429, res)
-        assert.equal(0, tonumber(res.headers["x-ratelimit-remaining-video-minute"]))
-        assert.equal(6, tonumber(res.headers["x-ratelimit-limit-video-minute"]))
-      end)
+        assert.res_status(200, res)
+      end
+
+      ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
+
+      local res = proxy_client():get("/response-headers?x-kong-limit=video=1", {
+        headers = { Host = "test1.com" },
+      })
+      assert.res_status(200, res)
+      assert.equal(ITERATIONS, tonumber(res.headers["x-ratelimit-limit-video-second"]))
+      assert.equal(ITERATIONS - n - 1, tonumber(res.headers["x-ratelimit-remaining-video-second"]))
     end)
 
+    it("blocks if exceeding limit", function()
+      test_limit("/response-headers?x-kong-limit=video=1", "test1.com")
+    end)
+
+    it("counts against the same service register from different routes", function()
+      wait()
+      local n = math.floor(ITERATIONS / 2)
+      for i = 1, n do
+        local res = proxy_client():get("/response-headers?x-kong-limit=video=1, test=" .. ITERATIONS, {
+          headers = { Host = "test-service1.com" },
+        })
+        assert.res_status(200, res)
+      end
+
+      for i = n+1, ITERATIONS do
+        local res = proxy_client():get("/response-headers?x-kong-limit=video=1, test=" .. ITERATIONS, {
+          headers = { Host = "test-service2.com" },
+        })
+        assert.res_status(200, res)
+      end
+
+      ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the list
+
+      -- Additonal request, while limit is ITERATIONS/second
+      local res = proxy_client():get("/response-headers?x-kong-limit=video=1, test=" .. ITERATIONS, {
+        headers = { Host = "test-service1.com" },
+      })
+      assert.res_status(429, res)
+    end)
+
+    it("handles multiple limits", function()
+      wait()
+      local n = math.floor(ITERATIONS / 2)
+      local res
+      for i = 1, n do
+        if i == n then
+          ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
+        end
+        res = proxy_client():get("/response-headers?x-kong-limit=video=2, image=1", {
+          headers = { Host = "test2.com" },
+        })
+        assert.res_status(200, res)
+      end
+
+      assert.equal(ITERATIONS * 2, tonumber(res.headers["x-ratelimit-limit-video-second"]))
+      assert.equal(ITERATIONS * 2 - (n * 2), tonumber(res.headers["x-ratelimit-remaining-video-second"]))
+      assert.equal(ITERATIONS * 4, tonumber(res.headers["x-ratelimit-limit-video-minute"]))
+      assert.equal(ITERATIONS * 4 - (n * 2), tonumber(res.headers["x-ratelimit-remaining-video-minute"]))
+      assert.equal(ITERATIONS, tonumber(res.headers["x-ratelimit-limit-image-second"]))
+      assert.equal(ITERATIONS - n, tonumber(res.headers["x-ratelimit-remaining-image-second"]))
+
+      for i = n+1, ITERATIONS do
+        res = proxy_client():get("/response-headers?x-kong-limit=video=1, image=1", {
+          headers = { Host = "test2.com" },
+        })
+        assert.res_status(200, res)
+      end
+
+      ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
+
+      local res = proxy_client():get("/response-headers?x-kong-limit=video=1, image=1", {
+        headers = { Host = "test2.com" },
+      })
+
+      assert.equal(0, tonumber(res.headers["x-ratelimit-remaining-image-second"]))
+      assert.equal(ITERATIONS * 4 - (n * 2) - (ITERATIONS - n), tonumber(res.headers["x-ratelimit-remaining-video-minute"]))
+      assert.equal(ITERATIONS * 2 - (n * 2) - (ITERATIONS - n), tonumber(res.headers["x-ratelimit-remaining-video-second"]))
+      assert.res_status(429, res)
+    end)
+  end)
+
+  describe("With authentication", function()
+    describe("API-specific plugin", function()
+      it("blocks if exceeding limit and a per consumer & route setting", function()
+        test_limit("/response-headers?apikey=apikey123&x-kong-limit=video=1", "test3.com", ITERATIONS - 2)
+      end)
+
+      it("blocks if exceeding limit and a per route setting", function()
+        test_limit("/response-headers?apikey=apikey124&x-kong-limit=video=1", "test3.com", ITERATIONS - 3)
+      end)
+    end)
+  end)
+
+  describe("Upstream usage headers", function()
+    it("should append the headers with multiple limits", function()
+      wait()
+      local res = proxy_client():get("/get", {
+        headers = { Host = "test8.com" },
+      })
+      local json = cjson.decode(assert.res_status(200, res))
+      assert.equal(ITERATIONS-1, tonumber(json.headers["x-ratelimit-remaining-image"]))
+      assert.equal(ITERATIONS, tonumber(json.headers["x-ratelimit-remaining-video"]))
+
+      -- Actually consume the limits
+      local res = proxy_client():get("/response-headers?x-kong-limit=video=2, image=1", {
+        headers = { Host = "test8.com" },
+      })
+      assert.res_status(200, res)
+
+      ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
+
+      local res = proxy_client():get("/get", {
+        headers = { Host = "test8.com" },
+      })
+      local body = cjson.decode(assert.res_status(200, res))
+      assert.equal(ITERATIONS-2, tonumber(body.headers["x-ratelimit-remaining-image"]))
+      assert.equal(ITERATIONS-2, tonumber(body.headers["x-ratelimit-remaining-video"]))
+    end)
+
+    it("combines multiple x-kong-limit headers from upstream", function()
+      wait()
+      for _ = 1, ITERATIONS do
+        local res = proxy_client():get("/response-headers?x-kong-limit=video%3D2&x-kong-limit=image%3D1", {
+          headers = { Host = "test4.com" },
+        })
+        assert.res_status(200, res)
+      end
+
+      proxy_client():get("/response-headers?x-kong-limit=video%3D1", {
+        headers = { Host = "test4.com" },
+      })
+
+      ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
+
+      local res = proxy_client():get("/response-headers?x-kong-limit=video%3D2&x-kong-limit=image%3D1", {
+        headers = { Host = "test4.com" },
+      })
+
+      assert.res_status(429, res)
+      assert.equal(0, tonumber(res.headers["x-ratelimit-remaining-image-second"]))
+      assert.equal(1, tonumber(res.headers["x-ratelimit-remaining-video-second"]))
+    end)
+  end)
+
+  it("should block on first violation", function()
+    wait()
+    local res = proxy_client():get("/response-headers?x-kong-limit=video=2, image=4", {
+      headers = { Host = "test7.com" },
+    })
+    assert.res_status(200, res)
+
+    ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
+
+    local res = proxy_client():get("/response-headers?x-kong-limit=video=2", {
+      headers = { Host = "test7.com" },
+    })
+    local body = assert.res_status(429, res)
+    local json = cjson.decode(body)
+    assert.same({ message = "API rate limit exceeded for 'image'" }, json)
+  end)
+
+  describe("Config with hide_client_headers", function()
+    it("does not send rate-limit headers when hide_client_headers==true", function()
+      wait()
+      local res = proxy_client():get("/status/200", {
+        headers = { Host = "test9.com" },
+      })
+
+      assert.res_status(200, res)
+      assert.is_nil(res.headers["x-ratelimit-remaining-video-second"])
+      assert.is_nil(res.headers["x-ratelimit-limit-video-second"])
+    end)
+  end)
+end)
+
+describe(fmt("#flaky Plugin: response-ratelimiting (expirations) with policy: #%s [#%s]", policy, strategy), function()
+
+  setup(function()
+    local bp = init_db(strategy, policy)
+
+    local route = bp.routes:insert {
+      hosts      = { "expire1.com" },
+      protocols  = { "http", "https" },
+    }
+
+    bp.response_ratelimiting_plugins:insert {
+      route = { id = route.id },
+      config   = {
+        policy         = policy,
+        redis_host     = REDIS_HOST,
+        redis_port     = REDIS_PORT,
+        redis_password = REDIS_PASSWORD,
+        fault_tolerant = false,
+        limits         = { video = { second = ITERATIONS } },
+      }
+    }
+
+    assert(helpers.start_kong({
+      database   = strategy,
+      nginx_conf = "spec/fixtures/custom_nginx.template",
+    }))
+  end)
+
+  teardown(function()
+    helpers.stop_kong(nil, true)
+  end)
+
+  it("expires a counter", function()
+    wait()
+    local res = proxy_client():get("/response-headers?x-kong-limit=video=1", {
+      headers = { Host = "expire1.com" },
+    })
+
+    ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
+
+    assert.res_status(200, res)
+    assert.equal(ITERATIONS, tonumber(res.headers["x-ratelimit-limit-video-second"]))
+    assert.equal(ITERATIONS-1, tonumber(res.headers["x-ratelimit-remaining-video-second"]))
+
+    ngx.sleep(0.01)
+    wait() -- Wait for counter to expire
+
+    local res = proxy_client():get("/response-headers?x-kong-limit=video=1", {
+      headers = { Host = "expire1.com" },
+    })
+
+    ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
+
+    assert.res_status(200, res)
+    assert.equal(ITERATIONS, tonumber(res.headers["x-ratelimit-limit-video-second"]))
+    assert.equal(ITERATIONS-1, tonumber(res.headers["x-ratelimit-remaining-video-second"]))
+  end)
+end)
+
+describe(fmt("#flaky Plugin: response-ratelimiting (access - global for single consumer) with policy: #%s [#%s]", policy, strategy), function()
+
+  setup(function()
+    local bp = init_db(strategy, policy)
+
+    local consumer = bp.consumers:insert {
+      custom_id = "provider_126",
+    }
+
+    bp.key_auth_plugins:insert()
+
+    bp.keyauth_credentials:insert {
+      key      = "apikey126",
+      consumer = { id = consumer.id },
+    }
+
+    -- just consumer, no no route or service
+    bp.response_ratelimiting_plugins:insert({
+      consumer = { id = consumer.id },
+      config = {
+        fault_tolerant = false,
+        policy         = policy,
+        redis_host     = REDIS_HOST,
+        redis_port     = REDIS_PORT,
+        redis_password = REDIS_PASSWORD,
+        redis_database = REDIS_DATABASE,
+        limits         = { video = { second = ITERATIONS } },
+      }
+    })
+
+    for i = 1, ITERATIONS do
+      bp.routes:insert({ hosts = { fmt("test%d.com", i) } })
+    end
+
+    assert(helpers.start_kong({
+      database   = strategy,
+      nginx_conf = "spec/fixtures/custom_nginx.template",
+    }))
+  end)
+
+  teardown(function()
+    helpers.stop_kong(nil, true)
+  end)
+
+  it("blocks when the consumer exceeds their quota, no matter what service/route used", function()
+    test_limit("/response-headers?apikey=apikey126&x-kong-limit=video=1", "test%d.com")
+  end)
+end)
+
+describe(fmt("#flaky Plugin: response-ratelimiting (access - global) with policy: #%s [#%s]", policy, strategy), function()
+
+  setup(function()
+    local bp = init_db(strategy, policy)
+
+    -- global plugin (not attached to route, service or consumer)
+    bp.response_ratelimiting_plugins:insert({
+      config = {
+        fault_tolerant = false,
+        policy         = policy,
+        redis_host     = REDIS_HOST,
+        redis_port     = REDIS_PORT,
+        redis_password = REDIS_PASSWORD,
+        redis_database = REDIS_DATABASE,
+        limits         = { video = { second = ITERATIONS } },
+      }
+    })
+
+    for i = 1, ITERATIONS do
+      bp.routes:insert({ hosts = { fmt("test%d.com", i) } })
+    end
+
+    assert(helpers.start_kong({
+      database   = strategy,
+      nginx_conf = "spec/fixtures/custom_nginx.template",
+    }))
+  end)
+
+  teardown(function()
+    helpers.stop_kong(nil, true)
+  end)
+
+  before_each(function()
+    wait()
+  end)
+
+  it("blocks if exceeding limit", function()
+    wait()
+    for i = 1, ITERATIONS do
+      local res = proxy_client():get("/response-headers?x-kong-limit=video=1", {
+        headers = { Host = fmt("test%d.com", i) },
+      })
+      assert.res_status(200, res)
+    end
+
+    ngx.sleep(SLEEP_TIME) -- Wait for async timer to increment the limit
+
+    -- last query, while limit is ITERATIONS/second
+    local res = proxy_client():get("/response-headers?x-kong-limit=video=1", {
+      headers = { Host = "test1.com" },
+    })
+    assert.res_status(429, res)
+    assert.equal(0, tonumber(res.headers["x-ratelimit-remaining-video-second"]))
+    assert.equal(ITERATIONS, tonumber(res.headers["x-ratelimit-limit-video-second"]))
+  end)
+end)
+
+describe(fmt("#flaky Plugin: response-ratelimiting (fault tolerance) with policy: #%s [#%s]", policy, strategy), function()
+--  if policy == "cluster" then
+--    local bp, db
+--
+--    before_each(function()
+--      bp, db = init_db(strategy, policy)
+--
+--      local route1 = bp.routes:insert {
+--        hosts = { "failtest1.com" },
+--      }
+--
+--      bp.response_ratelimiting_plugins:insert {
+--        route = { id = route1.id },
+--        config   = {
+--          fault_tolerant = false,
+--          policy         = policy,
+--          redis_host     = REDIS_HOST,
+--          redis_port     = REDIS_PORT,
+--          redis_password = REDIS_PASSWORD,
+--          limits         = { video = { second = ITERATIONS} },
+--        }
+--      }
+--
+--      local route2 = bp.routes:insert {
+--        hosts = { "failtest2.com" },
+--      }
+--
+--      bp.response_ratelimiting_plugins:insert {
+--        route = { id = route2.id },
+--        config   = {
+--          fault_tolerant = true,
+--          policy         = policy,
+--          redis_host     = REDIS_HOST,
+--          redis_port     = REDIS_PORT,
+--          redis_password = REDIS_PASSWORD,
+--          limits         = { video = {second = ITERATIONS} }
+--        }
+--      }
+--
+--      assert(helpers.start_kong({
+--        database   = strategy,
+--        nginx_conf = "spec/fixtures/custom_nginx.template",
+--      }))
+--
+--      wait()
+--    end)
+--
+--    after_each(function()
+--      helpers.stop_kong(nil, true)
+--    end)
+--
+--    it("does not work if an error occurs", function()
+--      local res = proxy_client():get("/response-headers?x-kong-limit=video=1", {
+--        headers = { Host = "failtest1.com" },
+--      })
+--      assert.res_status(200, res)
+--      assert.equal(ITERATIONS, tonumber(res.headers["x-ratelimit-limit-video-second"]))
+--      assert.equal(ITERATIONS, tonumber(res.headers["x-ratelimit-remaining-video-second"]))
+--
+--      -- Simulate an error on the database
+--      -- (valid SQL and CQL)
+--      db.connector:query("DROP TABLE response_ratelimiting_metrics;")
+--
+--      -- Make another request
+--      local res = proxy_client():get("/response-headers?x-kong-limit=video=1", {
+--        headers = { Host = "failtest1.com" },
+--      })
+--      local body = assert.res_status(500, res)
+--      local json = cjson.decode(body)
+--      assert.same({ message = "An unexpected error occurred" }, json)
+--    end)
+--
+--    it("keeps working if an error occurs", function()
+--      local res = proxy_client():get("/response-headers?x-kong-limit=video=1", {
+--        headers = { Host = "failtest2.com" },
+--      })
+--      assert.res_status(200, res)
+--      assert.equal(ITERATIONS, tonumber(res.headers["x-ratelimit-limit-video-second"]))
+--      assert.equal(ITERATIONS, tonumber(res.headers["x-ratelimit-remaining-video-second"]))
+--
+--      -- Simulate an error on the database
+--      -- (valid SQL and CQL)
+--      db.connector:query("DROP TABLE response_ratelimiting_metrics;")
+--
+--      -- Make another request
+--      local res = proxy_client():get("/response-headers?x-kong-limit=video=1", {
+--        headers = { Host = "failtest2.com" },
+--      })
+--      assert.res_status(200, res)
+--      assert.is_nil(res.headers["x-ratelimit-limit-video-second"])
+--      assert.is_nil(res.headers["x-ratelimit-remaining-video-second"])
+--    end)
+--  end
+--
+  if policy == "redis" then
+
+    before_each(function()
+      local bp = init_db(strategy, policy)
+
+      local route1 = bp.routes:insert {
+        hosts      = { "failtest3.com" },
+        protocols  = { "http", "https" },
+      }
+
+      bp.response_ratelimiting_plugins:insert {
+        route = { id = route1.id },
+        config   = {
+          fault_tolerant = false,
+          policy         = policy,
+          redis_host     = "5.5.5.5",
+          limits         = { video = { second = ITERATIONS } },
+        }
+      }
+
+      local route2 = bp.routes:insert {
+        hosts      = { "failtest4.com" },
+        protocols  = { "http", "https" },
+      }
+
+      bp.response_ratelimiting_plugins:insert {
+        route = { id = route2.id },
+        config   = {
+          fault_tolerant = true,
+          policy         = policy,
+          redis_host     = "5.5.5.5",
+          limits         = { video = { second = ITERATIONS } },
+        }
+      }
+
+      assert(helpers.start_kong({
+        database   = strategy,
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+      }))
+
+      wait()
+    end)
+
+    after_each(function()
+      helpers.stop_kong(nil, true)
+    end)
+
+    it("does not work if an error occurs", function()
+      -- Make another request
+      local res = proxy_client():get("/status/200", {
+        headers = { Host = "failtest3.com" },
+      })
+      local body = assert.res_status(500, res)
+      local json = cjson.decode(body)
+      assert.same({ message = "An unexpected error occurred" }, json)
+    end)
+    it("keeps working if an error occurs", function()
+      -- Make another request
+      local res = proxy_client():get("/status/200", {
+        headers = { Host = "failtest4.com" },
+      })
+      assert.res_status(200, res)
+      assert.falsy(res.headers["x-ratelimit-limit-video-second"])
+      assert.falsy(res.headers["x-ratelimit-remaining-video-second"])
+    end)
   end
+end)
+
+end
 end

--- a/spec/03-plugins/26-oauth2/03-access_spec.lua
+++ b/spec/03-plugins/26-oauth2/03-access_spec.lua
@@ -3,6 +3,11 @@ local helpers = require "spec.helpers"
 local utils   = require "kong.tools.utils"
 
 
+local kong = {
+  table = require("kong.pdk.table").new()
+}
+
+
 local function provision_code(host, extra_headers, client_id)
   local request_client = helpers.proxy_ssl_client()
   local res = assert(request_client:send {
@@ -16,7 +21,7 @@ local function provision_code(host, extra_headers, client_id)
       state = "hello",
       authenticated_userid = "userid123"
     },
-    headers = utils.table_merge({
+    headers = kong.table.merge({
       ["Host"] = host or "oauth2.com",
       ["Content-Type"] = "application/json"
     }, extra_headers)
@@ -45,7 +50,7 @@ local function provision_token(host, extra_headers, client_id, client_secret)
              client_id = client_id or "clientid123",
              client_secret = client_secret or "secret123",
              grant_type = "authorization_code" },
-    headers = utils.table_merge({
+    headers = kong.table.merge({
       ["Host"] = host or "oauth2.com",
       ["Content-Type"] = "application/json"
     }, extra_headers)

--- a/spec/fixtures/mock_upstream.lua
+++ b/spec/fixtures/mock_upstream.lua
@@ -5,6 +5,11 @@ local ws_server  = require "resty.websocket.server"
 local pl_stringx = require "pl.stringx"
 
 
+local kong = {
+  table = require("kong.pdk.table").new()
+}
+
+
 local function parse_multipart_form_params(body, content_type)
   if not content_type then
     return nil, 'missing content-type'
@@ -231,7 +236,7 @@ end
 
 
 local function send_default_json_response(extra_fields, response_headers)
-  local tbl = utils.table_merge(get_default_json_response(), extra_fields)
+  local tbl = kong.table.merge(get_default_json_response(), extra_fields)
   return send_text_response(cjson.encode(tbl),
                             "application/json", response_headers)
 end

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -37,7 +37,11 @@ local nginx_signals = require "kong.cmd.utils.nginx_signals"
 local log = require "kong.cmd.utils.log"
 local DB = require "kong.db"
 
-local table_merge = utils.table_merge
+
+local kong = {
+  table = require("kong.pdk.table").new()
+}
+
 
 log.set_lvl(log.levels.quiet) -- disable stdout logs in tests
 
@@ -385,9 +389,9 @@ end
 -- Implements http_client:get("path", [options]), as well as post, put, etc.
 -- These methods are equivalent to calling http_client:send, but are shorter
 -- They also come with a built-in assert
-for method_name in ("get post put patch delete"):gmatch("%w+") do
+for _, method_name in ipairs({"get", "post", "put", "patch", "delete"}) do
   resty_http_proxy_mt[method_name] = function(self, path, options)
-    local full_options = table_merge({ method = method_name:upper(), path = path}, options or {})
+    local full_options = kong.table.merge({ method = method_name:upper(), path = path}, options)
     return assert(self:send(full_options))
   end
 end

--- a/t/01-pdk/01-table.t
+++ b/t/01-pdk/01-table.t
@@ -58,3 +58,39 @@ hello: nil
 #t: 0
 --- no_error_log
 [error]
+
+
+
+=== TEST 3: table.merge()
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local inspect = require "inspect"
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+            local function insp(x)
+                return (inspect(x):gsub("%s", ""))
+            end
+
+            ngx.say(insp(pdk.table.merge({ x = "hello" }, { y = "world" })))
+            ngx.say(insp(pdk.table.merge({ x = "hello" }, {})))
+            ngx.say(insp(pdk.table.merge({}, { y = "world" })))
+            ngx.say(insp(pdk.table.merge({ x = "hello" }, { x = "world" })))
+            ngx.say(insp(pdk.table.merge({1, 2, 3, 4, 5}, {6, 7, 8})))
+            ngx.say(insp(pdk.table.merge({ x = "hello" }, nil)))
+            ngx.say(insp(pdk.table.merge(nil, { y = "world" })))
+        }
+    }
+--- request
+GET /t
+--- response_body
+{x="hello",y="world"}
+{x="hello"}
+{y="world"}
+{x="world"}
+{6,7,8,4,5}
+{x="hello"}
+{y="world"}
+--- no_error_log
+[error]

--- a/t/01-pdk/04-request/00-phase_checks.t
+++ b/t/01-pdk/04-request/00-phase_checks.t
@@ -40,6 +40,7 @@ qq{
                 header_filter = true,
                 body_filter   = true,
                 log           = true,
+                admin_api     = true,
             }, {
                 method        = "get_host",
                 args          = {},
@@ -50,6 +51,7 @@ qq{
                 header_filter = true,
                 body_filter   = true,
                 log           = true,
+                admin_api     = true,
             }, {
                 method        = "get_port",
                 args          = {},
@@ -60,6 +62,7 @@ qq{
                 header_filter = true,
                 body_filter   = true,
                 log           = true,
+                admin_api     = true,
             }, {
                 method        = "get_forwarded_scheme",
                 args          = {},
@@ -70,6 +73,7 @@ qq{
                 header_filter = true,
                 body_filter   = true,
                 log           = true,
+                admin_api     = true,
             }, {
                 method        = "get_forwarded_host",
                 args          = {},
@@ -80,6 +84,7 @@ qq{
                 header_filter = true,
                 body_filter   = true,
                 log           = true,
+                admin_api     = true,
             }, {
                 method        = "get_forwarded_port",
                 args          = {},
@@ -90,6 +95,7 @@ qq{
                 header_filter = true,
                 body_filter   = true,
                 log           = true,
+                admin_api     = true,
             }, {
                 method        = "get_http_version",
                 args          = {},
@@ -100,6 +106,7 @@ qq{
                 header_filter = true,
                 body_filter   = true,
                 log           = true,
+                admin_api     = true,
             }, {
                 method        = "get_method",
                 args          = {},
@@ -110,6 +117,7 @@ qq{
                 header_filter = true,
                 body_filter   = true,
                 log           = true,
+                admin_api     = true,
             }, {
                 method        = "get_path",
                 args          = {},
@@ -120,6 +128,7 @@ qq{
                 header_filter = true,
                 body_filter   = true,
                 log           = true,
+                admin_api     = true,
             }, {
                 method        = "get_raw_query",
                 args          = {},
@@ -130,6 +139,7 @@ qq{
                 header_filter = true,
                 body_filter   = true,
                 log           = true,
+                admin_api     = true,
             }, {
                 method        = "get_query_arg",
                 args          = { "foo" },
@@ -140,6 +150,7 @@ qq{
                 header_filter = true,
                 body_filter   = true,
                 log           = true,
+                admin_api     = true,
             }, {
                 method        = "get_query",
                 args          = {},
@@ -150,6 +161,7 @@ qq{
                 header_filter = true,
                 body_filter   = true,
                 log           = true,
+                admin_api     = true,
             }, {
                 method        = "get_query",
                 args          = { 100 },
@@ -160,6 +172,7 @@ qq{
                 header_filter = true,
                 body_filter   = true,
                 log           = true,
+                admin_api     = true,
             }, {
                 method        = "get_header",
                 args          = { "Host" },
@@ -170,6 +183,7 @@ qq{
                 header_filter = true,
                 body_filter   = true,
                 log           = true,
+                admin_api     = true,
             }, {
                 method        = "get_headers",
                 args          = {},
@@ -180,6 +194,7 @@ qq{
                 header_filter = true,
                 body_filter   = true,
                 log           = true,
+                admin_api     = true,
             }, {
                 method        = "get_headers",
                 args          = { 100 },
@@ -190,6 +205,7 @@ qq{
                 header_filter = true,
                 body_filter   = true,
                 log           = true,
+                admin_api     = true,
             }, {
                 method        = "get_raw_body",
                 args          = {},
@@ -200,6 +216,7 @@ qq{
                 header_filter = false,
                 body_filter   = false,
                 log           = false,
+                admin_api     = true,
             }, {
                 method        = "get_body",
                 args          = { "application/json" },
@@ -210,6 +227,7 @@ qq{
                 header_filter = false,
                 body_filter   = false,
                 log           = false,
+                admin_api     = true,
             }, {
                 method        = "get_body",
                 args          = { "application/x-www-form-urlencoded" },
@@ -220,6 +238,7 @@ qq{
                 header_filter = false,
                 body_filter   = false,
                 log           = false,
+                admin_api     = true,
             },
         }
 
@@ -242,6 +261,7 @@ qq{
 
         access_by_lua_block {
             phase_check_functions(phases.access)
+            phase_check_functions(phases.admin_api)
         }
 
         header_filter_by_lua_block {

--- a/t/01-pdk/05-client/00-phase_checks.t
+++ b/t/01-pdk/05-client/00-phase_checks.t
@@ -40,6 +40,7 @@ qq{
                 header_filter = true,
                 body_filter   = true,
                 log           = true,
+                admin_api     = true,
             }, {
                 method        = "get_forwarded_ip",
                 args          = {},
@@ -50,6 +51,7 @@ qq{
                 header_filter = true,
                 body_filter   = true,
                 log           = true,
+                admin_api     = true,
             }, {
                 method        = "get_port",
                 args          = {},
@@ -60,6 +62,7 @@ qq{
                 header_filter = true,
                 body_filter   = true,
                 log           = true,
+                admin_api     = true,
             }, {
                 method        = "get_forwarded_port",
                 args          = {},
@@ -70,6 +73,7 @@ qq{
                 header_filter = true,
                 body_filter   = true,
                 log           = true,
+                admin_api     = true,
             },
         }
 
@@ -92,6 +96,7 @@ qq{
 
         access_by_lua_block {
             phase_check_functions(phases.access)
+            phase_check_functions(phases.admin_api)
         }
 
         header_filter_by_lua_block {

--- a/t/01-pdk/06-service-request/00-phase_checks.t
+++ b/t/01-pdk/06-service-request/00-phase_checks.t
@@ -40,6 +40,7 @@ qq{
                 header_filter = "forced false",
                 body_filter   = "forced false",
                 log           = "forced false",
+                admin_api     = "forced false",
             }, {
                 method        = "set_method",
                 args          = { "GET" },
@@ -50,6 +51,7 @@ qq{
                 header_filter = "forced false",
                 body_filter   = "forced false",
                 log           = "forced false",
+                admin_api     = "forced false",
             }, {
                 method        = "set_path",
                 args          = { "/" },
@@ -60,6 +62,7 @@ qq{
                 header_filter = "forced false",
                 body_filter   = "forced false",
                 log           = "forced false",
+                admin_api     = "forced false",
             }, {
                 method        = "set_raw_query",
                 args          = { "foo=bar&baz=bla" },
@@ -70,6 +73,7 @@ qq{
                 header_filter = "forced false",
                 body_filter   = "forced false",
                 log           = "forced false",
+                admin_api     = "forced false",
             }, {
                 method        = "set_query",
                 args          = { { foo = "bar", baz = "bla" } },
@@ -80,6 +84,7 @@ qq{
                 header_filter = "forced false",
                 body_filter   = "forced false",
                 log           = "forced false",
+                admin_api     = "forced false",
             }, {
                 method        = "set_header",
                 args          = { "X-Foo", "bar" },
@@ -90,6 +95,7 @@ qq{
                 header_filter = "forced false",
                 body_filter   = "forced false",
                 log           = "forced false",
+                admin_api     = "forced false",
             }, {
                 method        = "add_header",
                 args          = { "X-Foo", "bar" },
@@ -100,6 +106,7 @@ qq{
                 header_filter = "forced false",
                 body_filter   = "forced false",
                 log           = "forced false",
+                admin_api     = "forced false",
             }, {
                 method        = "clear_header",
                 args          = { "X-Foo" },
@@ -110,6 +117,7 @@ qq{
                 header_filter = "forced false",
                 body_filter   = "forced false",
                 log           = "forced false",
+                admin_api     = "forced false",
             }, {
                 method        = "set_headers",
                 args          = { { ["X-Foo"] = "bar" } },
@@ -120,6 +128,7 @@ qq{
                 header_filter = "forced false",
                 body_filter   = "forced false",
                 log           = "forced false",
+                admin_api     = "forced false",
             }, {
                 method        = "set_raw_body",
                 args          = { "foo" },
@@ -130,6 +139,7 @@ qq{
                 header_filter = false,
                 body_filter   = false,
                 log           = false,
+                admin_api     = "forced false",
             }, {
                 method        = "set_body",
                 args          = { { foo = "bar" }, "application/json" },
@@ -140,6 +150,7 @@ qq{
                 header_filter = false,
                 body_filter   = false,
                 log           = false,
+                admin_api     = "forced false",
             },
         }
 
@@ -162,6 +173,7 @@ qq{
 
         access_by_lua_block {
             phase_check_functions(phases.access)
+            phase_check_functions(phases.admin_api)
         }
 
         header_filter_by_lua_block {

--- a/t/01-pdk/07-service-response/00-phase_checks.t
+++ b/t/01-pdk/07-service-response/00-phase_checks.t
@@ -40,6 +40,7 @@ qq{
                 header_filter = true,
                 body_filter   = true,
                 log           = true,
+                admin_api     = "forced false",
             }, {
                 method        = "get_headers",
                 args          = {},
@@ -50,6 +51,7 @@ qq{
                 header_filter = true,
                 body_filter   = true,
                 log           = true,
+                admin_api     = "forced false",
             }, {
                 method        = "get_header",
                 args          = { "Host" },
@@ -60,6 +62,7 @@ qq{
                 header_filter = true,
                 body_filter   = true,
                 log           = true,
+                admin_api     = "forced false",
             }, {
                 -- NYI, let everything pass
                 method        = "get_raw_body",
@@ -71,6 +74,7 @@ qq{
                 header_filter = true,
                 body_filter   = true,
                 log           = true,
+                admin_api     = true,
             }, {
                 -- NYI, let everything pass
                 method        = "get_body",
@@ -82,6 +86,7 @@ qq{
                 header_filter = true,
                 body_filter   = true,
                 log           = true,
+                admin_api     = true,
             },
         }
 
@@ -102,6 +107,7 @@ qq{
 
         access_by_lua_block {
             phase_check_functions(phases.access)
+            phase_check_functions(phases.admin_api)
         }
 
         header_filter_by_lua_block {

--- a/t/01-pdk/08-response/12-get_source.t
+++ b/t/01-pdk/08-response/12-get_source.t
@@ -59,7 +59,7 @@ X-Source: service
     location /t {
         content_by_lua_block {
           local PDK = require "kong.pdk"
-          local pdk = PDK.new()
+          local pdk = PDK.new({ enabled_headers = {} })
           pdk.response.exit(200, "ok")
         }
 

--- a/t/01-pdk/09-service/00-phase_checks.t
+++ b/t/01-pdk/09-service/00-phase_checks.t
@@ -49,6 +49,7 @@ qq{
                 header_filter = "forced false",
                 body_filter   = "forced false",
                 log           = "forced false",
+                admin_api     = "forced false",
             }, {
                 method        = "set_target",
                 args          = { "example.com", 8000 },
@@ -59,6 +60,7 @@ qq{
                 header_filter = "forced false",
                 body_filter   = "forced false",
                 log           = "forced false",
+                admin_api     = "forced false",
             },
         }
 
@@ -82,6 +84,7 @@ qq{
 
         access_by_lua_block {
             phase_check_functions(phases.access)
+            phase_check_functions(phases.admin_api)
         }
 
         header_filter_by_lua_block {

--- a/t/01-pdk/12-node/00-phase_checks.t
+++ b/t/01-pdk/12-node/00-phase_checks.t
@@ -41,6 +41,7 @@ qq{
                 header_filter = true,
                 body_filter   = true,
                 log           = true,
+                admin_api     = true,
             },
         }
 
@@ -64,6 +65,7 @@ qq{
 
         access_by_lua_block {
             phase_check_functions(phases.access)
+            phase_check_functions(phases.admin_api)
         }
 
         header_filter_by_lua_block {

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -42,7 +42,7 @@ our $HttpConfig = <<_EOC_;
             local mod
             do
                 local PDK = require "kong.pdk"
-                local pdk = PDK.new()
+                local pdk = PDK.new({ enabled_headers = { ["Server"] = true } })
                 mod = pdk
                 for part in phase_check_module:gmatch("[^.]+") do
                     mod = mod[part]


### PR DESCRIPTION
### Summary

This contains changes to following plugins and their test suite? This is rebased on @hishamhm's https://github.com/Kong/kong/tree/feat/plugins-to-new-dao-api branch which should be merged before this.

- acl
- basic-auth
- correlation-id
- hmac-auth
- jwt
- ldap-auth
- rate-limiting (still has some flaky tests)
- request-termination

Also contains a small fix to a typo on key-auth plugin. 