### PR TITLE
feat(certificate) use lru cache built into ml-cache

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -71,6 +71,7 @@ local DAOFactory = require "kong.dao.factory"
 local kong_cache = require "kong.cache"
 local ngx_balancer = require "ngx.balancer"
 local kong_resty_ctx = require "kong.resty.ctx"
+local certificate = require "kong.runloop.certificate"
 local plugins_iterator = require "kong.runloop.plugins_iterator"
 local balancer_execute = require("kong.runloop.balancer").execute
 local kong_cluster_events = require "kong.cluster_events"
@@ -302,6 +303,10 @@ function Kong.init()
   kong.dao = dao
   kong.db = db
   kong.dns = singletons.dns
+
+  if config.proxy_ssl_enabled then
+    certificate.init()
+  end
 
   -- Load plugins as late as possible so that everything is set up
   loaded_plugins = assert(db.plugins:load_plugin_schemas(config.loaded_plugins))

--- a/kong/runloop/certificate.lua
+++ b/kong/runloop/certificate.lua
@@ -1,6 +1,6 @@
-local pl_utils   = require "pl.utils"
-local ssl        = require "ngx.ssl"
 local singletons = require "kong.singletons"
+local ngx_ssl = require "ngx.ssl"
+local pl_utils = require "pl.utils"
 
 
 local ngx_log = ngx.log
@@ -50,12 +50,12 @@ local function parse_key_and_cert(row)
 
   -- parse cert and priv key for later usage by ngx.ssl
 
-  local cert, err = ssl.parse_pem_cert(row.cert)
+  local cert, err = ngx_ssl.parse_pem_cert(row.cert)
   if not cert then
     return nil, "could not parse PEM certificate: " .. err
   end
 
-  local key, err = ssl.parse_pem_priv_key(row.key)
+  local key, err = ngx_ssl.parse_pem_priv_key(row.key)
   if not key then
     return nil, "could not parse PEM private key: " .. err
   end
@@ -91,7 +91,7 @@ end
 
 
 local function execute()
-  local sn, err = ssl.server_name()
+  local sn, err = ngx_ssl.server_name()
   if err then
     log(ERR, "could not retrieve SNI: ", err)
     return ngx.exit(ngx.ERROR)
@@ -110,19 +110,19 @@ local function execute()
 
   -- set the certificate for this connection
 
-  local ok, err = ssl.clear_certs()
+  local ok, err = ngx_ssl.clear_certs()
   if not ok then
     log(ERR, "could not clear existing (default) certificates: ", err)
     return ngx.exit(ngx.ERROR)
   end
 
-  ok, err = ssl.set_cert(cert_and_key.cert)
+  ok, err = ngx_ssl.set_cert(cert_and_key.cert)
   if not ok then
     log(ERR, "could not set configured certificate: ", err)
     return ngx.exit(ngx.ERROR)
   end
 
-  ok, err = ssl.set_priv_key(cert_and_key.key)
+  ok, err = ngx_ssl.set_priv_key(cert_and_key.key)
   if not ok then
     log(ERR, "could not set configured private key: ", err)
     return ngx.exit(ngx.ERROR)

--- a/kong/runloop/certificate.lua
+++ b/kong/runloop/certificate.lua
@@ -1,3 +1,4 @@
+local pl_utils   = require "pl.utils"
 local ssl        = require "ngx.ssl"
 local singletons = require "kong.singletons"
 
@@ -7,15 +8,15 @@ local ERR     = ngx.ERR
 local DEBUG   = ngx.DEBUG
 
 
+local default_cert_and_key
+
+
 local function log(lvl, ...)
   ngx_log(lvl, "[ssl] ", ...)
 end
 
 
-local _M = {}
-
-
-local function find_certificate(sni_name)
+local function fetch_certificate(sni_name)
   local row, err = singletons.db.snis:select_by_name(sni_name)
   if err then
     return nil, err
@@ -38,65 +39,73 @@ local function find_certificate(sni_name)
     return nil, "no SSL certificate configured for sni: " .. sni_name
   end
 
+  return certificate
+end
+
+
+local function parse_key_and_cert(row)
+  if row == true then
+    return default_cert_and_key
+  end
+
+  -- parse cert and priv key for later usage by ngx.ssl
+
+  local cert, err = ssl.parse_pem_cert(row.cert)
+  if not cert then
+    return nil, "could not parse PEM certificate: " .. err
+  end
+
+  local key, err = ssl.parse_pem_priv_key(row.key)
+  if not key then
+    return nil, "could not parse PEM private key: " .. err
+  end
+
   return {
-    cert = certificate.cert,
-    key  = certificate.key,
+    cert = cert,
+    key = key,
   }
 end
 
 
-function _M.execute()
-  -- retrieve sni or raw server IP
+local function init()
+  default_cert_and_key = parse_key_and_cert {
+    cert = assert(pl_utils.readfile(singletons.configuration.ssl_cert)),
+    key = assert(pl_utils.readfile(singletons.configuration.ssl_cert_key)),
+  }
+end
 
+
+local get_opts = {
+  l1_serializer = parse_key_and_cert,
+}
+local function find_certificate(sn)
+  if not sn then
+    log(DEBUG, "no SNI provided by client, serving default SSL certificate")
+    return default_cert_and_key
+  end
+
+  local cache_key = "certificates:" .. sn
+
+  return singletons.cache:get(cache_key, get_opts, fetch_certificate, sn)
+end
+
+
+local function execute()
   local sn, err = ssl.server_name()
   if err then
     log(ERR, "could not retrieve SNI: ", err)
     return ngx.exit(ngx.ERROR)
   end
 
-  if not sn then
-    log(DEBUG, "no SNI provided by client, serving ",
-               "default proxy SSL certificate")
-    -- use fallback certificate
-    return
-  end
-
-  local lru              = singletons.cache.mlcache.lru
-  local pem_cache_key    = "pem_ssl_certificates:" .. sn
-  local parsed_cache_key = "parsed_ssl_certificates:" .. sn
-
-  local pem_cert_and_key, err = singletons.cache:get(pem_cache_key, nil,
-                                                     find_certificate, sn)
-  if not pem_cert_and_key then
+  local cert_and_key, err = find_certificate(sn)
+  if err then
     log(ERR, err)
     return ngx.exit(ngx.ERROR)
   end
 
-  if pem_cert_and_key == true then
-    -- use fallback certificate
+  if cert_and_key == default_cert_and_key then
+    -- use (already set) fallback certificate
     return
-  end
-
-  local cert_and_key = lru:get(parsed_cache_key)
-  if not cert_and_key then
-    -- parse cert and priv key for later usage by ngx.ssl
-
-    local cert, err = ssl.parse_pem_cert(pem_cert_and_key.cert)
-    if not cert then
-      return nil, "could not parse PEM certificate: " .. err
-    end
-
-    local key, err = ssl.parse_pem_priv_key(pem_cert_and_key.key)
-    if not key then
-      return nil, "could not parse PEM private key: " .. err
-    end
-
-    cert_and_key = {
-      cert = cert,
-      key = key,
-    }
-
-    lru:set(parsed_cache_key, cert_and_key)
   end
 
   -- set the certificate for this connection
@@ -121,4 +130,8 @@ function _M.execute()
 end
 
 
-return _M
+return {
+  init = init,
+  find_certificate = find_certificate,
+  execute = execute,
+}

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -370,8 +370,7 @@ return {
         log(DEBUG, "[events] SNI updated, invalidating cached certificates")
         local sn = data.entity
 
-        cache:invalidate("pem_ssl_certificates:"    .. sn.name)
-        cache:invalidate("parsed_ssl_certificates:" .. sn.name)
+        cache:invalidate("certificates:" .. sn.name)
       end, "crud", "snis")
 
 
@@ -386,8 +385,7 @@ return {
             break
           end
 
-          cache:invalidate("pem_ssl_certificates:"    .. sn.name)
-          cache:invalidate("parsed_ssl_certificates:" .. sn.name)
+          cache:invalidate("certificates:" .. sn.name)
         end
       end, "crud", "certificates")
 


### PR DESCRIPTION
<s>This PR modifies the certificate phase to use luaossl via the kong.resty.getssl module instead of ngx.ssl

This allows us to use the same certificate management code (newly exposed via `find_certificate`) for both http and stream modes.</s>

This PR now just refactors the runloop/certificate module to use the lru cache built into ml-cache. The code is organised in a way to make a followup PR to add stream support have a minimal diff.