### PR TITLE
chore(git) ignore kong.conf.env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ servroot*
 # kong
 nginx_tmp/
 kong*.yml
+kong.conf.*
+!kong.conf.default
 
 # luacov
 luacov.*

--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,7 @@ servroot*
 
 # kong
 nginx_tmp/
-kong*.yml
-kong.conf.*
+kong.conf*
 !kong.conf.default
 
 # luacov


### PR DESCRIPTION
## RFC

### Problem
When developing locally or maintaining a .conf file that is loaded in different environments (`kong.conf.dev, kong.conf.{prod, staging}`) it can be helpful to not have to constantly stash the changes or keep the conf file outside the repo. This is also helpful for not accidentally checking in conf file changes. Conf files are where secrets can be stored such as db passwords, etc and so it is important to provide safeguards here. During kong development, it is common to either copy `kong.conf.default` to `kong.env` or change `kong.conf.default` directly to test config changes. These both result in git changesets and require the user to either add to their global .gitignore or consistently ignore the changes they've made.

### Proposed solution
Add kong.conf* to gitignore

### Checklist

- [ ] get feedback
- [x] add kong.conf and kong.conf.* to .gitignore
- [ ] provide users with development docs for how they might local develop with different kong configs.

### Full changelog
* chore(git) ignore kong env configuration in source control
* remove kong*.yml
