### PR TITLE
feat(balancer) use luaossl created SSL_CTX

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -107,6 +107,10 @@ local ffi = require "ffi"
 local cast = ffi.cast
 local voidpp = ffi.typeof("void**")
 
+local TLS_SCHEMES = {
+  https = true,
+}
+
 local PLUGINS_MAP_CACHE_OPTS = { ttl = 0 }
 
 local plugins_map_semaphore
@@ -597,7 +601,7 @@ function Kong.balancer()
   end
 
   local ssl_ctx = balancer_data.ssl_ctx
-  if ssl_ctx then
+  if TLS_SCHEMES[balancer_data.scheme] and ssl_ctx ~= nil then
     if not set_ssl_ctx then
       -- this API depends on an OpenResty patch
       ngx_log(ngx_ERR, "failed to set the upstream SSL_CTX*: missing ",

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -159,7 +159,7 @@ local function balancer_setup_stage1(ctx, scheme, host_type, host, port,
     port           = port,      -- final target port
     try_count      = 0,         -- retry counter
     tries          = {},        -- stores info per try
-    -- ssl_ctx     = nil,       -- custom SSL_CTX* to use
+    ssl_ctx        = kong.default_client_ssl_ctx, -- SSL_CTX* to use
     -- ip          = nil,       -- final target IP address
     -- balancer    = nil,       -- the balancer object, if any
     -- hostname    = nil,       -- hostname of the final target IP


### PR DESCRIPTION
This PR is another foundational piece for service mesh.

The default SSL_CTX should be exposed somewhere for other internal modules to use.
I was going to add it to singletons, however that seems to be deprecated soon? I added it to the kong object for now, does anyone have a preference of where it is stored and/or which module creates it? Ideally it should be created somewhere with access to the kong config; and earlier than most other pieces (so that the mesh code or other code can then modify it).

Note: an earlier version of this PR didn't respect `client_ssl_cert_key` and `client_ssl_cert` set in the kong config; surprisingly this didn't make any tests fail!