### PR TITLE
misc(ci) track failure statistics

### DIFF
--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -14,18 +14,19 @@ elif [ "$KONG_TEST_DATABASE" == "cassandra" ]; then
     export TEST_CMD="bin/busted $BUSTED_ARGS,postgres"
 fi
 
+mkdir output
 if [ "$TEST_SUITE" == "integration" ]; then
-    eval "$TEST_CMD" spec/02-integration/
+    eval "$TEST_CMD" spec/02-integration/ | tee output/integration.txt
 fi
 if [ "$TEST_SUITE" == "plugins" ]; then
-    eval "$TEST_CMD" spec/03-plugins/
+    eval "$TEST_CMD" spec/03-plugins/ | tee output/plugins.txt
 fi
 if [ "$TEST_SUITE" == "old-integration" ]; then
-    eval "$TEST_CMD" spec-old-api/02-integration/
+    eval "$TEST_CMD" spec-old-api/02-integration/ | tee output/old_integration.txt
 fi
 if [ "$TEST_SUITE" == "old-plugins" ]; then
-    eval "$TEST_CMD" spec-old-api/03-plugins/
+    eval "$TEST_CMD" spec-old-api/03-plugins/ | tee output/old_plugins.txt
 fi
 if [ "$TEST_SUITE" == "pdk" ]; then
-    TEST_NGINX_RANDOMIZE=1 prove -I. -j$JOBS -r t/01-pdk
+    TEST_NGINX_RANDOMIZE=1 prove -I. -j$JOBS -r t/01-pdk | tee output/pdk.txt
 fi

--- a/.ci/track_failures.sh
+++ b/.ci/track_failures.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+if [ "$TRAVIS_BRANCH"  != "master" ]; then
+  exit 0
+fi
+
 pip install datadog
 cat >~/.dogrc <<EOL
 [Connection]

--- a/.ci/track_failures.sh
+++ b/.ci/track_failures.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+pip install datadog
+cat >~/.dogrc <<EOL
+[Connection]
+apikey = $DD_API_KEY
+appkey = $DD_APP_KEY
+EOL
+
+cat ~/output/* | grep 'FAILED  ' | grep -v listed | grep -v ms > collated_output.txt
+cat collated_output.txt | sed 's/^.*spec\///; s/\.lua.*$//' | sed 's/^/travis_ci.kong.failure./' > parsed_output.txt
+cat parsed_output.txt | sed 's/-/_/g' | sed 's/[^a-zA-Z0-9_]/\./g' > dd_compatible.txt
+<dd_compatible.txt xargs -I % dog metric post % 1

--- a/.ci/track_failures.sh
+++ b/.ci/track_failures.sh
@@ -12,6 +12,6 @@ appkey = $DD_APP_KEY
 EOL
 
 cat ~/output/* | grep 'FAILED  ' | grep -v listed | grep -v ms > collated_output.txt
-cat collated_output.txt | sed 's/^.*spec\///; s/\.lua.*$//' | sed 's/^/travis_ci.kong.failure./' > parsed_output.txt
+cat collated_output.txt | sed 's/^.*spec\///; s/\.lua.*$//' | sed 's/^//' > parsed_output.txt
 cat parsed_output.txt | sed 's/-/_/g' | sed 's/[^a-zA-Z0-9_]/\./g' > dd_compatible.txt
-<dd_compatible.txt xargs -I % dog metric post % 1
+<dd_compatible.txt xargs -I % dog metric post travis_ci.kong.failure --type count --tags "test:%" 1

--- a/.ci/track_failures.sh
+++ b/.ci/track_failures.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "$TRAVIS_BRANCH"  != "master" ]; then
+if ! [[ "$TRAVIS_BRANCH" == "master" || "$TRAVIS_BRANCH" == "next" ]] ; then
   exit 0
 fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,3 +78,6 @@ jobs:
 
 script:
   - .ci/run_tests.sh
+
+after_failure:
+  - .ci/track_failures.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 dist: trusty
 sudo: false
 
-language: java
-
-jdk:
-  - oraclejdk8
+language: python
 
 notifications:
   email: false


### PR DESCRIPTION
On builds of master with failing tests send the test name as a datapoint to datadog

All tests are output to stdout and to a file via `tee`. From there we `sed` / `grep` to manipulate only the failed tests to something that is formatted appropriately to be sent to datadog. Requires that datadog credentials exist where this is ran (already added to travis-ci)