### PR TITLE
feat(pdk) add kong.request.get_path_and_querystring

### DIFF
--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -286,6 +286,22 @@ local function new(self)
 
 
   ---
+  -- When the request has a query string, returns the path + "?" + the query string.
+  -- Otherwise it returns just the path. No transformations/normalizations are done.
+  --
+  -- @function kong.request.get_path_and_querystring()
+  -- @phases rewrite, access, header_filter, body_filter, log
+  -- @treturn string the path and querystring
+  -- @usage
+  -- -- Given a request to https://example.com:1234/v1/movies?movie=foo
+  --
+  -- kong.request.get_path_and_querystring() -- "/v1/movies?movie=foo"
+  function _REQUEST.get_path_and_querystring()
+    check_phase(PHASES.request)
+    return ngx.var.request_uri
+  end
+
+  ---
   -- Returns the query component of the request's URL. It is not normalized in
   -- any way (not even URL-decoding of special characters) and does not
   -- include the leading `?` character.

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -210,6 +210,7 @@ local function balancer_setup_stage1(ctx, scheme, host_type, host, port,
   ctx.route            = route
   ctx.balancer_data    = balancer_data
   ctx.balancer_address = balancer_data -- for plugin backward compatibility
+  kong.ctx.shared.balancer_data = balancer_data -- for plugin forwards compatibility
 end
 
 

--- a/t/01-pdk/04-request/00-phase_checks.t
+++ b/t/01-pdk/04-request/00-phase_checks.t
@@ -121,6 +121,16 @@ qq{
                 body_filter   = true,
                 log           = true,
             }, {
+                method        = "get_path_and_querystring",
+                args          = {},
+                init_worker   = false,
+                certificate   = "pending",
+                rewrite       = true,
+                access        = true,
+                header_filter = true,
+                body_filter   = true,
+                log           = true,
+            }, {
                 method        = "get_raw_query",
                 args          = {},
                 init_worker   = false,

--- a/t/01-pdk/04-request/17-get_path_and_querystring.t
+++ b/t/01-pdk/04-request/17-get_path_and_querystring.t
@@ -1,0 +1,50 @@
+use strict;
+use warnings FATAL => 'all';
+use Test::Nginx::Socket::Lua;
+use t::Util;
+
+plan tests => repeat_each() * (blocks() * 3);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: request.get_path_and_querystring() returns the path when no query string is present
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            local path_and_querystring = pdk.request.get_path_and_querystring()
+
+            ngx.say("path_and_querystring=", path_and_querystring)
+        }
+    }
+--- request
+GET /t
+--- response_body
+path_and_querystring=/t
+--- no_error_log
+[error]
+
+=== TEST 2: request.get_path_and_querystring() returns the path + ? + querystring when querystring is present
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            local path_and_querystring = pdk.request.get_path_and_querystring()
+
+            ngx.say("path_and_querystring=", path_and_querystring)
+        }
+    }
+--- request
+GET /t?foo=1&bar=2
+--- response_body
+path_and_querystring=/t?foo=1&bar=2
+--- no_error_log
+[error]


### PR DESCRIPTION
When the path + querystring is needed, this prevents having to manually check wether the querystring is present and concatenating the path + "?" + the query string every time.

Needed for the zipkin plugin. https://github.com/Kong/kong-plugin-zipkin/pull/24