### PR TITLE
refactor(db) replace db.old_dao:infos() with db.infos

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -195,9 +195,8 @@ local function sort_plugins_for_execution(kong_conf, db, plugin_list)
   if kong_conf.anonymous_reports then
     local reports = require "kong.reports"
 
-    local db_infos = db.old_dao:infos()
     reports.add_ping_value("database", kong_conf.database)
-    reports.add_ping_value("database_version", db_infos.version)
+    reports.add_ping_value("database_version", db.infos.db_ver)
 
     reports.toggle(true)
 

--- a/spec/02-integration/000-new-dao/01-db_spec.lua
+++ b/spec/02-integration/000-new-dao/01-db_spec.lua
@@ -2,38 +2,103 @@ local DB      = require "kong.db"
 local helpers = require "spec.helpers"
 
 
--- TODO: make those tests run for all supported databases
-describe("kong.db.init", function()
-  describe(".new()", function()
-    it("errors on invalid arg", function()
-      assert.has_error(function()
-        DB.new()
-      end, "missing kong_config")
 
-      assert.has_error(function()
-        DB.new(helpers.test_conf, 123)
-      end, "strategy must be a string")
+for _, strategy in helpers.each_strategy() do
+  describe("kong.db.init [#" .. strategy .. "]", function()
+    describe(".new()", function()
+      it("errors on invalid arg", function()
+        assert.has_error(function()
+          DB.new(nil, strategy)
+        end, "missing kong_config")
+
+        assert.has_error(function()
+          DB.new(helpers.test_conf, 123)
+        end, "strategy must be a string")
+      end)
+
+      it("instantiates a DB", function()
+        local db, err = DB.new(helpers.test_conf, strategy)
+        assert.is_nil(err)
+        assert.is_table(db)
+      end)
+
+      it("initializes infos", function()
+        local db, err = DB.new(helpers.test_conf, strategy)
+
+        assert.is_nil(err)
+        assert.is_table(db)
+
+        local infos = db.infos
+
+        if strategy == "postgres" then
+          assert.same({
+            strategy = "PostgreSQL",
+            db_desc = "database",
+            db_name = helpers.test_conf.pg_database,
+            db_ver  = "unknown",
+          }, infos)
+
+        elseif strategy == "cassandra" then
+          assert.same({
+            strategy = "Cassandra",
+            db_desc = "keyspace",
+            db_name = helpers.test_conf.cassandra_keyspace,
+            db_ver  = "unknown",
+          }, infos)
+
+        else
+          error("unknown database")
+        end
+      end)
     end)
+  end)
 
-    it("instantiates a DB", function()
-      local db, err = DB.new(helpers.test_conf)
+
+  describe(":init_connector() [#" .. strategy .. "]", function()
+    it("initializes infos", function()
+      local db, err = DB.new(helpers.test_conf, strategy)
+
       assert.is_nil(err)
       assert.is_table(db)
+
+      assert(db:init_connector())
+
+      local infos = db.infos
+
+      assert.matches("^%d+%.?%d*%.?%d*$", infos.db_ver)
+      assert.not_matches("%.$", infos.db_ver)
+
+
+      if strategy == "postgres" then
+        assert.same({
+          strategy = "PostgreSQL",
+          db_desc = "database",
+          db_name = helpers.test_conf.pg_database,
+          db_ver  = infos.db_ver,
+        }, infos)
+
+      elseif strategy == "cassandra" then
+        assert.same({
+          strategy = "Cassandra",
+          db_desc = "keyspace",
+          db_name = helpers.test_conf.cassandra_keyspace,
+          db_ver  = infos.db_ver,
+        }, infos)
+
+      else
+        error("unknown database")
+      end
     end)
-  end)
-
-
-  describe(":init_connector()", function()
 
   end)
 
 
-  describe(":connect()", function()
+  describe(":connect() [#" .. strategy .. "]", function()
 
   end)
 
 
-  describe(":setkeepalive()", function()
+  describe(":setkeepalive() [#" .. strategy .. "]", function()
 
   end)
-end)
+end


### PR DESCRIPTION
### Summary

Very tiny patch to replace `db.old_dao:infos` with `db.infos`.