### PR TITLE
fix(db) handle nils in copy_cassandra_records migration helper

### DIFF
--- a/kong/db/migrations/helpers.lua
+++ b/kong/db/migrations/helpers.lua
@@ -186,7 +186,11 @@ function _M:copy_cassandra_records(source_table_def,
                             dest_column_name, source_table_def[dest_column_name])
           end
 
-          source_value = type_converter(source_value)
+          if source_value == nil then
+            source_value = cassandra.unset
+          else
+            source_value = type_converter(source_value)
+          end
 
         elseif type(source_value) == "function" then
           source_value = source_value(source_row)


### PR DESCRIPTION
Fixes `copy_cassandra_records` to handle `nil` values and use `cassandra.null` instead of calling the cassandra type constructor (`cassandra.uuid(x)`, etc.)

(Does not include a regression test in this PR as this is in the process of being tested in https://github.com/kong/kong-upgrade-tests )