### PR TITLE
fix(db) fix use of iterate in migration of plugins for postgres

### DIFF
--- a/kong/db/migrations/core/001_14_to_15.lua
+++ b/kong/db/migrations/core/001_14_to_15.lua
@@ -151,28 +151,25 @@ return {
     teardown = function(connector, helpers)
       assert(connector:connect_migrations())
 
-      for rows, err in connector:iterate('SELECT * FROM "plugins";') do
+      for row, err in connector:iterate('SELECT * FROM "plugins";') do
         if err then
           return nil, err
         end
 
-        for i = 1, #rows do
-          local row = rows[i]
-          local cache_key = table.concat({
-            "plugins",
-            row.name,
-            row.route_id or "",
-            row.service_id or "",
-            row.consumer_id or "",
-            row.api_id or ""
-          }, ":")
+        local cache_key = table.concat({
+          "plugins",
+          row.name,
+          row.route_id    == ngx.null and "" or row.route_id,
+          row.service_id  == ngx.null and "" or row.service_id,
+          row.consumer_id == ngx.null and "" or row.consumer_id,
+          row.api_id      == ngx.null and "" or row.api_id,
+        }, ":")
 
-          local sql = string.format([[
-            UPDATE "plugins" SET "cache_key" = '%s' WHERE "id" = '%s';
-          ]], cache_key, row.id)
+        local sql = string.format([[
+          UPDATE "plugins" SET "cache_key" = '%s' WHERE "id" = '%s';
+        ]], cache_key, row.id)
 
-          assert(connector:query(sql))
-        end
+        assert(connector:query(sql))
       end
 
       assert(connector:query('DROP TABLE IF EXISTS "schema_migrations" CASCADE;'))


### PR DESCRIPTION
There are two differences in the behavior of `connector:iterate` between the Postgres and Cassandra low-level strategies: Cassandra returns pages, Postgres returns rows; the Cassandra iterator is also returning `nil` on nulls, Postgres is returning `ngx.null`. These differences per se are not a problem, as the high-level DAO objects handle that correctly. This commit makes the fixes to the direct use of the iterator in the `core/001_14_to_15` migration of `plugins` when inserting new the `cache_key` values.