### PR TITLE
fix(db) Fix incorrect check for primary key violations under cassandra

### DIFF
--- a/kong/db/strategies/cassandra/init.lua
+++ b/kong/db/strategies/cassandra/init.lua
@@ -549,7 +549,7 @@ function _mt:insert(entity)
 
   -- check for linearizable consistency (Paxos)
 
-  if res[APPLIED_COLUMN] == false then
+  if res[1][APPLIED_COLUMN] == false then
     -- lightweight transaction (IF NOT EXISTS) failed,
     -- retrieve PK values for the PK violation error
     local pk_values = extract_pk_values(schema, entity)

--- a/spec/02-integration/000-new-dao/02-db_core_entities_spec.lua
+++ b/spec/02-integration/000-new-dao/02-db_core_entities_spec.lua
@@ -916,6 +916,35 @@ for _, strategy in helpers.each_strategy() do
           assert.not_equal(0, service.updated_at)
         end)
 
+        it("cannot create a Service with an existing id", function()
+          -- insert 1
+          local _, _, err_t = db.services:insert {
+            id = a_blank_uuid,
+            name = "my_service",
+            protocol = "http",
+            host = "example.com",
+          }
+          assert.is_nil(err_t)
+
+          -- insert 2
+          local service, _, err_t = db.services:insert {
+            id = a_blank_uuid,
+            name = "my_other_service",
+            protocol = "http",
+            host = "other-example.com",
+          }
+          assert.is_nil(service)
+          assert.same({
+            code     = Errors.codes.PRIMARY_KEY_VIOLATION,
+            name     = "primary key violation",
+            message  = "primary key violation on key '{id=\"" .. a_blank_uuid .. "\"}'",
+            strategy = strategy,
+            fields   = {
+              id = a_blank_uuid,
+            }
+          }, err_t)
+        end)
+
         it("cannot create a Service with an existing name", function()
           -- insert 1
           local _, _, err_t = db.services:insert {


### PR DESCRIPTION
The old code would never throw a primary key violation.