### PR TITLE
tests(pdk) test for kong.request.get_path_with_query on error requests

### DIFF
--- a/t/01-pdk/04-request/17-get_path_with_query.t
+++ b/t/01-pdk/04-request/17-get_path_with_query.t
@@ -3,6 +3,8 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
+
 plan tests => repeat_each() * (blocks() * 3);
 
 run_tests();
@@ -48,5 +50,56 @@ path_and_querystring=/t
 GET /t?foo=1&bar=2
 --- response_body
 path_and_querystring=/t?foo=1&bar=2
+--- no_error_log
+[error]
+
+
+
+=== TEST 3: returns empty string on error-handling requests
+--- http_config eval
+qq{
+    $t::Util::HttpConfig
+
+    server {
+        server_name kong;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
+
+        error_page 400 /error_handler;
+
+        location = /error_handler {
+          internal;
+
+          content_by_lua_block {
+              local PDK = require "kong.pdk"
+              local pdk = PDK.new()
+              local path = pdk.request.get_path_with_query()
+              local msg = "get_path_with_query: '" .. path .. "', type: " .. type(path)
+              -- must change the status to 200, otherwise nginx will
+              -- use the default 400 error page for the body
+              return pdk.response.exit(200, msg)
+          }
+        }
+
+        location / {
+          content_by_lua_block {
+            error("This should never be reached on this test")
+          }
+        }
+    }
+}
+--- config
+    location = /t {
+        content_by_lua_block {
+            local sock = ngx.socket.tcp()
+            sock:connect("unix:$TEST_NGINX_NXSOCK/nginx.sock")
+            sock:send("invalid http request")
+            ngx.print(sock:receive("*a"))
+        }
+    }
+
+--- request
+GET /t
+--- response_body_like chop
+HTTP.*? 200 OK(\s|.)+get_path_with_query: '', type: string
 --- no_error_log
 [error]


### PR DESCRIPTION
Related with https://github.com/Kong/kong-plugin-zipkin/pull/24

Explanation:

When kong receives an invalid request, it activates its [internal `kong_error_handler` location](https://github.com/Kong/kong/blob/master/kong/templates/nginx_kong.lua#L164):

```
    error_page 400 404 408 411 412 413 414 417 494 /kong_error_handler;
    error_page 500 502 503 504 /kong_error_handler;
    
    ...
    
    location = /kong_error_handler {
        internal;
        uninitialized_variable_warn off;
        content_by_lua_block {
            Kong.handle_error()
        }
        header_filter_by_lua_block {
            Kong.header_filter()
        }
        body_filter_by_lua_block {
            Kong.body_filter()
        }
        log_by_lua_block {
            Kong.log()
        }
    }
```

This code will activate plugins which have header filters, body filters or log phases. On these cases, `ngx.var.request_uri` can indeed be `nil` (on invalid http requests for example), so the test makes sure that even in those cases `kong.request.get_path_with_query` is an empty string (and not nil).

Notes:
* On this test, the error which triggers the error handler is 400, since sending `invalid http request` over a socket is not a valid http request.
* It was not possible to send a non-http request directly from the `request` section of `test-nginx` so instead we made nginx "call himself" via a socket.