### PR TITLE
fix(db) support for cassandra 4

### DIFF
--- a/kong/db/strategies/cassandra/connector.lua
+++ b/kong/db/strategies/cassandra/connector.lua
@@ -211,7 +211,8 @@ local function select_tables(self)
 
   local cql
 
-  if self.major_version == 3 then
+  -- Assume a release version number of 3 & greater will use the same schema.
+  if self.major_version >= 3 then
     cql = [[SELECT * FROM system_schema.tables WHERE keyspace_name = ?]]
 
   else
@@ -235,7 +236,8 @@ function CassandraConnector:reset()
   end
 
   for i = 1, #rows do
-    local table_name = self.major_version == 3
+    -- Assume a release version number of 3 & greater will use the same schema.
+    local table_name = self.major_version >= 3
                        and rows[i].table_name
                        or rows[i].columnfamily_name
 
@@ -276,7 +278,8 @@ function CassandraConnector:truncate()
   end
 
   for i = 1, #rows do
-    local table_name = self.major_version == 3
+    -- Assume a release version number of 3 & greater will use the same schema.
+    local table_name = self.major_version >= 3
                        and rows[i].table_name
                        or rows[i].columnfamily_name
 

--- a/kong/db/strategies/cassandra/init.lua
+++ b/kong/db/strategies/cassandra/init.lua
@@ -63,7 +63,8 @@ end
 local function is_partitioned(self)
   local cql
 
-  if self.connector.major_version == 3 then
+  -- Assume a release version number of 3 & greater will use the same schema.
+  if self.connector.major_version >= 3 then
     cql = fmt([[
       SELECT * FROM system_schema.columns
       WHERE keyspace_name = '%s'
@@ -85,7 +86,8 @@ local function is_partitioned(self)
     return nil, err
   end
 
-  if self.connector.major_version == 3 then
+  -- Assume a release version number of 3 & greater will use the same schema.
+  if self.connector.major_version >= 3 then
     return rows[1] and rows[1].kind == "partition_key"
   end
 


### PR DESCRIPTION
### Summary

Kong 014.0 fails to start when backed by Datastax Enterprise 6.X with error 

`could not load routes: [Invalid] table schema_columns does not exist`

DSE 6.X reports 4.0.X as the release_version in system.local table.  The system schema components used by Kong in 3 are the same in 4 so changes were made such that schema selection based on cassandra major_version assumes future versions use the same schema.

### Issues resolved

Fix #3837
