### PR TITLE
hotfix(migrations) do not demand bootstrap when running up from 0.14

### DIFF
--- a/kong/cmd/utils/migrations.lua
+++ b/kong/cmd/utils/migrations.lua
@@ -70,8 +70,7 @@ end
 
 local function up(schema_state, db, opts)
   if schema_state.needs_bootstrap then
-    error("can't run migrations: database needs bootstrapping; " ..
-          "run 'kong migrations bootstrap'")
+    assert(db:schema_bootstrap())
   end
 
   local ok, err = db:cluster_mutex(MIGRATIONS_MUTEX_KEY, opts, function()


### PR DESCRIPTION
When migrating from 0.14 to 1.0, the `schema_meta` table (which is the new table for holding the migrations history) does not exist yet.

When that did not exist, `kong migrations up` failed with an error message telling the user to run `kong migrations bootstrap`, but that command does three things: it creates the new migrations table, runs the `migrations up` operations and then the `migrations finish` operations, all in one go (in other words, `kong migrations bootstrap` is the "do everything" command intended for green-field installations).

With this change, `kong migrations up` will auto-create the migrations history table if it's not present. This can run before obtaining the `cluster_mutex` lock because all operations of `db:schema_bootstrap()` in both strategies are idempotent (in fact it _needs_ to run before it because part of what `db:schema_bootstrap()` does is creating the `locks` table, and if `schema_bootstrap` is not implemented by the strategies in an idempotent way than we're in for trouble).