### PR TITLE
docs fix typo in comment

### DIFF
--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -435,7 +435,7 @@ local function overrides(k, default_v, file_conf, arg_conf)
   -- default values have lowest priority
 
   if file_conf and file_conf[k] == nil then
-    -- PL will ignore empty strings, so we need a placeholer (NONE)
+    -- PL will ignore empty strings, so we need a placeholder (NONE)
     value = default_v == "NONE" and "" or default_v
   else
     value = file_conf[k] -- given conf values have middle priority


### PR DESCRIPTION
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

### Summary

Fix typo in `kong/conf_loader.lua`

### Full changelog

* docs fix typo in `kong/conf_loader.lua`

### Issues resolved

