### PR TITLE
fix(db) type 'any' shouldn't cause metaschema validation errors

### DIFF
--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -736,8 +736,8 @@ function Schema:validate_field(field, value)
       return nil, validation_errors[field.type:upper()]
     end
 
-  -- if type is "skip" (an internal marker), run validators only
-  elseif field.type ~= "skip" then
+  -- if type is "any" or "skip" (an internal marker), run validators only
+  elseif field.type ~= "any" and field.type ~= "skip" then
     return nil, validation_errors.SCHEMA_TYPE:format(field.type)
   end
 

--- a/spec/01-unit/000-new-dao/01-schema/02-metaschema_spec.lua
+++ b/spec/01-unit/000-new-dao/01-schema/02-metaschema_spec.lua
@@ -351,6 +351,17 @@ describe("metaschema", function()
     assert.match("'set' cannot have attribute 'unique'", err.set)
   end)
 
+  it("a schema cannot have a field of type 'any'", function()
+    local s = {
+      name = "hello",
+      primary_key = { "foo" },
+      fields = {
+        { foo = { type = "any" } } } }
+    local ok, err = MetaSchema:validate(s)
+    assert.falsy(ok)
+    assert.match("expected one of", err.fields.type)
+  end)
+
   describe("subschemas", function()
 
     it("supports declaring subschemas", function()
@@ -459,6 +470,16 @@ describe("metaschema", function()
       assert.truthy(ok)
     end)
 
+  end)
+
+  it("validates a value with 'eq'", function()
+    assert.truthy(MetaSchema:validate({
+      name = "test",
+      primary_key = { "pk" },
+      fields = {
+        { pk = { type = "boolean", default = true, eq = true } },
+      },
+    }))
   end)
 
   it("validates the routes schema", function()


### PR DESCRIPTION
Trying the proposal at https://github.com/Kong/kong/commit/3365902caa785fef3fcdbf723f2547342e336971#r30944834 I ran into an issue where `eq` was not accepted by the metaschema validator (though it seems to be accepted by the normal schema validator?)