### PR TITLE
feat(conf) add support for 'transparent' in listeners

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -110,8 +110,11 @@
                          #   enabled.
                          # - `http2` will allow for clients to open HTTP/2
                          #   connections to Kong's proxy server.
-                         # - Finally, `proxy_protocol` will enable usage of the
+                         # - `proxy_protocol` will enable usage of the
                          #   PROXY protocol for a given address/port.
+                         # - `transparent` will cause kong to listen to, and
+                         #   respond from, any and all IP addresses and ports
+                         #   you configure in iptables.
                          #
                          # This value can be set to `off`, thus disabling
                          # the proxy port for this node, enabling a

--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -545,7 +545,7 @@ end
 -- `port` (number), `ssl` (bool), `http2` (bool), `listener` (string, full listener)
 local function parse_listeners(values)
   local list = {}
-  local flags = { "ssl", "http2", "proxy_protocol" }
+  local flags = { "ssl", "http2", "proxy_protocol", "transparent" }
   local usage = "must be of form: [off] | <ip>:<port> [" ..
                 concat(flags, "] [") .. "], [... next entry ...]"
 

--- a/spec/01-unit/002-conf_loader_spec.lua
+++ b/spec/01-unit/002-conf_loader_spec.lua
@@ -405,13 +405,13 @@ describe("Configuration loader", function()
         admin_listen = "127.0.0.1"
       })
       assert.is_nil(conf)
-      assert.equal("admin_listen must be of form: [off] | <ip>:<port> [ssl] [http2] [proxy_protocol], [... next entry ...]", err)
+      assert.equal("admin_listen must be of form: [off] | <ip>:<port> [ssl] [http2] [proxy_protocol] [transparent], [... next entry ...]", err)
 
       conf, err = conf_loader(nil, {
         proxy_listen = "127.0.0.1"
       })
       assert.is_nil(conf)
-      assert.equal("proxy_listen must be of form: [off] | <ip>:<port> [ssl] [http2] [proxy_protocol], [... next entry ...]", err)
+      assert.equal("proxy_listen must be of form: [off] | <ip>:<port> [ssl] [http2] [proxy_protocol] [transparent], [... next entry ...]", err)
     end)
     it("errors when dns_resolver is not a list in ipv4/6[:port] format", function()
       local conf, err = conf_loader(nil, {


### PR DESCRIPTION
Requires https://github.com/Kong/openresty-patches/pull/10
Related to https://trac.nginx.org/nginx/ticket/287