### PR TITLE
hotfix(db) migrations bootstrap properly handles 0.14 

### DIFF
--- a/kong/db/init.lua
+++ b/kong/db/init.lua
@@ -743,12 +743,14 @@ do
         local ok, mod = utils.load_module_if_exists(t.namespace .. "." ..
                                                     mig.name)
         if not ok then
+          self.connector:close()
           return nil, fmt_err(self, "failed to load migration '%s': %s",
                               mig.name, mod)
         end
 
         local strategy_migration = mod[self.strategy]
         if not strategy_migration then
+          self.connector:close()
           return nil, fmt_err(self, "missing %s strategy for migration '%s'",
                               self.strategy, mig.name)
         end
@@ -829,6 +831,7 @@ do
     if run_up then
       ok, err = self.connector:post_run_up_migrations()
       if not ok then
+        self.connector:close()
         return nil, prefix_err(self, err)
       end
     end

--- a/kong/db/strategies/postgres/connector.lua
+++ b/kong/db/strategies/postgres/connector.lua
@@ -768,17 +768,7 @@ end
 
 
 function _mt:is_014()
-  local rows, err = self:schema_migrations()
-  if err then
-    return nil, err
-  end
-
-  if rows and #rows > 0 then
-    return {
-      is_eq_014 = false,
-      is_gt_014 = true,
-    }
-  end
+  local res = {}
 
   local needed_migrations = {
     ["core"] = {
@@ -892,41 +882,36 @@ function _mt:is_014()
   end
 
   if not rows or not rows[1] or rows[1].name ~= "schema_migrations" then
-    return {
-      is_eq_014 = false,
-      is_gt_014 = true,
-    }
+    -- no trace of legacy migrations: above 0.14
+    return res
   end
 
-  rows, err = self:query([[
-    SELECT "id", "migrations"
-      FROM "schema_migrations";
+  local schema_migrations_rows, err = self:query([[
+    SELECT "id", "migrations" FROM "schema_migrations";
   ]])
   if err then
     return nil, err
   end
 
-  if not rows then
-    return {
-      is_eq_014 = false,
-      is_gt_014 = false,
-    }
+  if not schema_migrations_rows then
+    -- empty legacy migrations: invalid state
+    res.invalid_state = true
+    return res
   end
 
   local schema_migrations = {}
-  for i = 1, #rows do
-    local row = rows[i]
+  for i = 1, #schema_migrations_rows do
+    local row = schema_migrations_rows[i]
     schema_migrations[row.id] = row.migrations
   end
 
   for name, migrations in pairs(needed_migrations) do
     local current_migrations = schema_migrations[name]
     if not current_migrations then
-      return {
-        is_eq_014 = false,
-        is_gt_014 = false,
-        missing_component = name,
-      }
+      -- missing all migrations for a component: below 0.14
+      res.invalid_state = true
+      res.missing_component = name
+      return res
     end
 
     for _, needed_migration in ipairs(migrations) do
@@ -940,20 +925,19 @@ function _mt:is_014()
       end
 
       if not found then
-        return {
-          is_eq_014 = false,
-          is_gt_014 = false,
-          missing_component = name,
-          missing_migration = needed_migration,
-        }
+        -- missing at least one migration for a component: below 0.14
+        res.invalid_state = true
+        res.missing_component = name
+        res.missing_migration = needed_migration
+        return res
       end
     end
   end
 
-  return {
-    is_eq_014 = true,
-    is_gt_014 = false,
-  }
+  -- all migrations match: 0.14 install
+  res.is_014 = true
+
+  return res
 end
 
 


### PR DESCRIPTION
The 'bootstrap' command is meant to be run on an empty schema, for it is
supposed to create the keyspace (for C*) and other 'meta' tables. As
such, this patch prevents the use of 'migrations bootstrap' on a 0.14
schema.

Additionally, one had to previously run 'migrations bootstrap' on a 0.14
schema before running 'migrations up', but only the latter should be
necessary when upgrading from 0.14 to 1.0. Especially since 'migrations
bootstrap' became forbidden to run on 0.14.

The result of this patch:

* from a < 0.14 node: 'up'/'bootstrap' do not work
* from a == 0.14 node: 'boAdd some missing connection closing statements when errors occur during
the migration process.otstrap' does not work, 'up' works
* from a fresh install: 'bootstrap' works, 'up' does not work
* from a 1.0 install: 'bootstrap' does not work, 'up' works

---

Also: 

Add some missing connection closing statements when errors occur during
the migration process.