### PR TITLE
refactor(certificates) use l1_serializer for parsing PEM data

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -263,7 +263,6 @@ return {
         local sn = data.entity
 
         cache:invalidate("pem_ssl_certificates:"    .. sn.name)
-        cache:invalidate("parsed_ssl_certificates:" .. sn.name)
       end, "crud", "snis")
 
 
@@ -279,7 +278,6 @@ return {
           end
 
           cache:invalidate("pem_ssl_certificates:"    .. sn.name)
-          cache:invalidate("parsed_ssl_certificates:" .. sn.name)
         end
       end, "crud", "certificates")
 


### PR DESCRIPTION
### Summary

lua-resty-mlcache's l1_serializer function is now used to parse the PEM-encoded certificate stored in Certificate objects. This simplifies the code path used to manage certificate cache data and reduces the number of necessary live cache keys.

### Full changelog

* Move PEM parsing functionality to a separate (local) function
* Leverage lua-resty-mlcache `l1_serializer` opt to parse PEM-encoded certificates
* Remove `parsed_ssl_certificates:` LRU cache prefix
* Remove call to delete `parsed_ssl_certificates:` prefixed data on Certificate/SNI object CRUD events