### PR TITLE
chore(travis) compile with stream_ssl_preread_module

### DIFF
--- a/.ci/setup_env.sh
+++ b/.ci/setup_env.sh
@@ -66,6 +66,7 @@ if [ ! "$(ls -A $OPENRESTY_INSTALL)" ]; then
     "--with-http_realip_module"
     "--with-http_stub_status_module"
     "--with-http_v2_module"
+    "--with-stream_ssl_preread_module"
   )
 
   pushd $OPENRESTY_DOWNLOAD


### PR DESCRIPTION
### Summary

Compiles OpenResty with added `--with-stream_ssl_preread_module`.

This is needed for Service Mesh to be fully functional.