### PR TITLE
hotfix(schema) fix propagation of values on updates

### DIFF
--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1195,9 +1195,7 @@ local function adjust_field_for_context(field, value, context, nulls)
     local should_recurse
     if context == "update" then
       -- avoid filling defaults in partial updates of records
-      should_recurse = ((value == null and field.nullable == false)
-                        or (value == nil and field.nullable == false)
-                        or (value ~= null and value ~= nil))
+      should_recurse = (value ~= null and value ~= nil)
     else
       should_recurse = (value ~= null and
                         (value ~= nil or field.nullable == false))
@@ -1338,6 +1336,12 @@ end
 function Schema:merge_values(top, bottom)
   local output = {}
   bottom = bottom or {}
+  for k,v in pairs(bottom) do
+    output[k] = v
+  end
+  for k,v in pairs(top) do
+    output[k] = v
+  end
   for key, field in self:each_field(bottom) do
     local top_v = top[key]
 
@@ -1498,6 +1502,8 @@ end
 -- Returns a function to be used in `for` loops,
 -- which produces the key and the field table,
 -- as in `for field_name, field_data in self:each_field() do`
+-- @param values An instance of the entity, which is used
+-- only to determine which subschema to use.
 -- @return the iteration function
 function Schema:each_field(values)
   local i = 1

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1203,7 +1203,9 @@ local function adjust_field_for_context(field, value, context, nulls)
     if should_recurse then
       local field_schema = get_field_schema(field)
       value = value or handle_missing_field(field, value)
-      return field_schema:process_auto_fields(value, context, nulls)
+      if type(value) == "table" then
+        return field_schema:process_auto_fields(value, context, nulls)
+      end
     end
   end
   if value == nil then

--- a/spec/01-unit/000-new-dao/01-schema/01-schema_spec.lua
+++ b/spec/01-unit/000-new-dao/01-schema/01-schema_spec.lua
@@ -1721,6 +1721,42 @@ describe("schema", function()
       assert.is_nil(data.i)
     end)
 
+    -- regression test for #3910
+    it("lets invalid values pass unchanged", function()
+      local Test = Schema.new({
+        fields = {
+          { my_array = { type = "array", elements = { type = "string" } }, },
+          { my_set = { type = "set", elements = { type = "string" } }, },
+          { my_number = { type = "number" }, },
+          { my_integer = { type = "integer" }, },
+          { my_boolean = { type = "boolean" }, },
+          { my_string = { type = "string" }, },
+          { my_record = { type = "record", fields = { { my_field = { type = "integer" } } } } },
+          { my_map = { type = "map", keys = {}, values = {} }, },
+          { my_function = { type = "function" }, },
+        }
+      })
+      check_all_types_covered(Test.fields)
+      local bad_value = {
+        my_array = "hello",
+        my_set = "hello",
+        my_number = "hello",
+        my_integer = "hello",
+        my_boolean = "hello",
+        my_string = 123,
+        my_record = "hello",
+        my_map = "hello",
+        my_function = "hello",
+      }
+      local data, err = Test:process_auto_fields(bad_value)
+      assert.is_nil(err)
+      assert.same(data, bad_value)
+
+      local data2, err = Test:process_auto_fields(bad_value, "update")
+      assert.is_nil(err)
+      assert.same(data2, bad_value)
+    end)
+
     it("honors given default values", function()
       local f = function() end
 


### PR DESCRIPTION
Fixes some problems with PATCH operations on updates:

* `adjust_field_for_context`: the filling of default values was recursing incorrectly when values are nil on "update" contexts: it should not recurse, and in case the table is not nullable, it should just fail on validation later; fixing this prevents clobbering partial updates with default values.
* `merge_values`: make sure that invalid fields are merged as well, so that it failed validation in the next step when passing a bogus field on input.

For regression testing, this PR adds more tests for failure cases of PATCH operations on plugins.