### PR TITLE
tests(deps) update busted to 2.0rc13 and remove global patch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 OS := $(shell uname)
 
-DEV_ROCKS = "busted 2.0.rc12" "luacheck 0.20.0" "lua-llthreads2 0.1.5"
+DEV_ROCKS = "busted 2.0.rc13" "luacheck 0.20.0" "lua-llthreads2 0.1.5"
 WIN_SCRIPTS = "bin/busted" "bin/kong"
 BUSTED_ARGS ?= -v
 TEST_CMD ?= bin/busted $(BUSTED_ARGS)

--- a/kong/globalpatches.lua
+++ b/kong/globalpatches.lua
@@ -27,31 +27,6 @@ return function(options)
 
 
 
-  do -- deal with ffi re-loading issues
-
-    if options.rbusted then
-      -- pre-load the ffi module, such that it becomes part of the environment
-      -- and Busted will not try to GC and reload it. The ffi is not suited
-      -- for that and will occasionally segfault if done so.
-      local ffi = require "ffi"
-
-      -- Now patch ffi.cdef to only be called once with each definition
-      local old_cdef = ffi.cdef
-      local exists = {}
-      ffi.cdef = function(def)
-        if exists[def] then
-          return
-        end
-        exists[def] = true
-        return old_cdef(def)
-      end
-
-    end
-
-  end
-
-
-
   do -- implement `sleep` in the `init_worker` context
 
     -- initialization code regularly uses the shm and locks.
@@ -296,7 +271,7 @@ return function(options)
         return first
       end
     end
-  
+
     local function resolve_connect(f, sock, host, port, opts)
       if sub(host, 1, 5) ~= "unix:" then
         host, port = toip(host, port)


### PR DESCRIPTION
After release rc13 the ffi patch was incorporated in Busted, hence
no more need to carry it with Kong itself.

See https://github.com/Olivine-Labs/busted/pull/555
