### PR TITLE
Feat/plugins mesh field 1/2

### DIFF
--- a/kong/cmd/migrations.lua
+++ b/kong/cmd/migrations.lua
@@ -80,7 +80,7 @@ local function execute(args)
   conf.cassandra_timeout = args.db_timeout -- connect + send + read
   conf.cassandra_schema_consensus_timeout = args.db_timeout
 
-  local db = DB.new(conf)
+  local db = assert(DB.new(conf))
   assert(db:init_connector())
 
   local schema_state = assert(db:schema_state())

--- a/kong/db/migrations/core/001_14_to_15.lua
+++ b/kong/db/migrations/core/001_14_to_15.lua
@@ -123,6 +123,15 @@ return {
       END;
       $$;
 
+      DO $$
+      BEGIN
+        ALTER TABLE IF EXISTS ONLY "plugins" ADD "run_on" TEXT;
+      EXCEPTION WHEN DUPLICATE_COLUMN THEN
+        -- Do nothing, accept existing state
+      END;
+      $$;
+
+      CREATE INDEX IF NOT EXISTS "plugins_run_on_idx" ON "plugins" ("run_on");
 
 
       ALTER TABLE IF EXISTS ONLY "apis"
@@ -190,7 +199,6 @@ return {
       CREATE INDEX IF NOT EXISTS routes_name_idx ON routes(name);
 
 
-
       CREATE TABLE IF NOT EXISTS plugins_temp(
         id uuid,
         created_at timestamp,
@@ -198,6 +206,7 @@ return {
         route_id uuid,
         service_id uuid,
         consumer_id uuid,
+        run_on text,
         name text,
         config text, -- serialized plugin configuration
         enabled boolean,
@@ -241,6 +250,7 @@ return {
           route_id = "uuid",
           service_id = "uuid",
           consumer_id = "uuid",
+          run_on = "text",
           created_at = "timestamp",
           enabled = "boolean",
           cache_key = "text",
@@ -285,6 +295,7 @@ return {
           route_id uuid,
           service_id uuid,
           consumer_id uuid,
+          run_on text,
           name text,
           config text, -- serialized plugin configuration
           enabled boolean,
@@ -298,6 +309,7 @@ return {
         CREATE INDEX IF NOT EXISTS ON plugins(service_id);
         CREATE INDEX IF NOT EXISTS ON plugins(consumer_id);
         CREATE INDEX IF NOT EXISTS ON plugins(cache_key);
+        CREATE INDEX IF NOT EXISTS ON plugins(run_on);
       ]]))
 
       plugins_def = {
@@ -310,6 +322,7 @@ return {
           route_id = "uuid",
           service_id = "uuid",
           consumer_id = "uuid",
+          run_on = "text",
           created_at = "timestamp",
           enabled = "boolean",
           cache_key = "text",
@@ -325,6 +338,7 @@ return {
         route_id = "route_id",
         service_id = "service_id",
         consumer_id = "consumer_id",
+        run_on = "run_on",
         created_at = "created_at",
         enabled = "enabled",
         cache_key = "cache_key",

--- a/kong/db/schema/entities/plugins.lua
+++ b/kong/db/schema/entities/plugins.lua
@@ -20,6 +20,7 @@ return {
     { service = { type = "foreign", reference = "services", default = null, on_delete = "cascade", }, },
     { consumer = { type = "foreign", reference = "consumers", default = null, on_delete = "cascade", }, },
     { config = { type = "record", abstract = true, }, },
+    { run_on = typedefs.run_on },
     { enabled = { type = "boolean", default = true, }, },
   },
 

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -844,9 +844,6 @@ local function compatible_fields(f1, f2)
   if t1 == "array" or t1 == "set" then
     return f1.elements.type == f2.elements.type
   end
-  if t1 == "array" or t1 == "set" then
-    return f1.elements.type == f2.elements.type
-  end
   if t1 == "map" then
     return f1.keys.type == f2.keys.type and f1.values.type == f2.values.type
   end

--- a/kong/db/schema/typedefs.lua
+++ b/kong/db/schema/typedefs.lua
@@ -258,6 +258,12 @@ typedefs.run_on = Schema.define {
   one_of = { "first", "second", "all" },
 }
 
+typedefs.run_on_first = Schema.define {
+  type = "string",
+  default = "first",
+  one_of = { "first" },
+}
+
 
 setmetatable(typedefs, {
   __index = function(_, k)

--- a/kong/db/schema/typedefs.lua
+++ b/kong/db/schema/typedefs.lua
@@ -252,6 +252,13 @@ typedefs.key = Schema.define {
 }
 
 
+typedefs.run_on = Schema.define {
+  type = "string",
+  default = "first",
+  one_of = { "first", "second", "all" },
+}
+
+
 setmetatable(typedefs, {
   __index = function(_, k)
     error("schema typedef error: definition " .. k .. " does not exist", 2)

--- a/kong/plugins/acl/schema.lua
+++ b/kong/plugins/acl/schema.lua
@@ -5,6 +5,7 @@ return {
   name = "acl",
   fields = {
     { consumer = typedefs.no_consumer },
+    { run_on = typedefs.run_on_first },
     { config = {
         type = "record",
         fields = {

--- a/kong/plugins/aws-lambda/schema.lua
+++ b/kong/plugins/aws-lambda/schema.lua
@@ -17,6 +17,7 @@ local REGIONS = {
 return {
   name = "aws-lambda",
   fields = {
+    { run_on = typedefs.run_on_first },
     { config = {
         type = "record",
         fields = {

--- a/kong/plugins/basic-auth/schema.lua
+++ b/kong/plugins/basic-auth/schema.lua
@@ -5,6 +5,7 @@ return {
   name = "basic-auth",
   fields = {
     { consumer = typedefs.no_consumer },
+    { run_on = typedefs.run_on_first },
     { config = {
         type = "record",
         fields = {

--- a/kong/plugins/bot-detection/schema.lua
+++ b/kong/plugins/bot-detection/schema.lua
@@ -4,6 +4,7 @@ return {
   name = "bot-detection",
   fields = {
     { consumer = typedefs.no_consumer },
+    { run_on = typedefs.run_on_first },
     { config = {
         type = "record",
         fields = {

--- a/kong/plugins/correlation-id/schema.lua
+++ b/kong/plugins/correlation-id/schema.lua
@@ -1,6 +1,10 @@
+local typedefs = require "kong.db.schema.typedefs"
+
+
 return {
   name = "correlation-id",
   fields = {
+    { run_on = typedefs.run_on_first },
     { config = {
         type = "record",
         fields = {

--- a/kong/plugins/cors/schema.lua
+++ b/kong/plugins/cors/schema.lua
@@ -14,6 +14,7 @@ return {
   name = "cors",
   fields = {
     { consumer = typedefs.no_consumer },
+    { run_on = typedefs.run_on_first },
     { config = {
         type = "record",
         fields = {

--- a/kong/plugins/hmac-auth/schema.lua
+++ b/kong/plugins/hmac-auth/schema.lua
@@ -13,6 +13,7 @@ return {
   name = "hmac-auth",
   fields = {
     { consumer = typedefs.no_consumer },
+    { run_on = typedefs.run_on_first },
     { config = {
         type = "record",
         fields = {

--- a/kong/plugins/ip-restriction/schema.lua
+++ b/kong/plugins/ip-restriction/schema.lua
@@ -1,4 +1,5 @@
 local iputils = require "resty.iputils"
+local typedefs = require "kong.db.schema.typedefs"
 
 
 local function validate_ip(ip)
@@ -17,6 +18,7 @@ local ip = { type = "string", custom_validator = validate_ip }
 return {
   name = "ip-restriction",
   fields = {
+    { run_on = typedefs.run_on_first },
     { config = {
         type = "record",
         fields = {

--- a/kong/plugins/jwt/schema.lua
+++ b/kong/plugins/jwt/schema.lua
@@ -1,6 +1,10 @@
+local typedefs = require "kong.db.schema.typedefs"
+
+
 return {
   name = "jwt",
   fields = {
+    { run_on = typedefs.run_on_first },
     { config = {
         type = "record",
         fields = {

--- a/kong/plugins/key-auth/schema.lua
+++ b/kong/plugins/key-auth/schema.lua
@@ -5,6 +5,7 @@ return {
   name = "key-auth",
   fields = {
     { consumer = typedefs.no_consumer },
+    { run_on = typedefs.run_on_first },
     { config = {
         type = "record",
         fields = {

--- a/kong/plugins/ldap-auth/schema.lua
+++ b/kong/plugins/ldap-auth/schema.lua
@@ -7,6 +7,7 @@ return {
   name = "ldap-auth",
   fields = {
     { consumer = typedefs.no_consumer },
+    { run_on = typedefs.run_on_first },
     { config = {
         type = "record",
         fields = {

--- a/kong/plugins/oauth2/schema.lua
+++ b/kong/plugins/oauth2/schema.lua
@@ -16,6 +16,7 @@ return {
   name = "oauth2",
   fields = {
     { consumer = typedefs.no_consumer },
+    { run_on = typedefs.run_on_first },
     { config = {
         type = "record",
         fields = {

--- a/kong/plugins/rate-limiting/schema.lua
+++ b/kong/plugins/rate-limiting/schema.lua
@@ -26,6 +26,7 @@ end
 return {
   name = "rate-limiting",
   fields = {
+    { run_on = typedefs.run_on { one_of = { "first", "second" } } },
     { config = {
         type = "record",
         fields = {

--- a/kong/plugins/request-size-limiting/schema.lua
+++ b/kong/plugins/request-size-limiting/schema.lua
@@ -1,6 +1,10 @@
+local typedefs = require "kong.db.schema.typedefs"
+
+
 return {
   name = "request-size-limiting",
   fields = {
+    { run_on = typedefs.run_on_first },
     { config = {
         type = "record",
         fields = {

--- a/kong/plugins/request-termination/schema.lua
+++ b/kong/plugins/request-termination/schema.lua
@@ -1,3 +1,6 @@
+local typedefs = require "kong.db.schema.typedefs"
+
+
 local is_present = function(v)
   return type(v) == "string" and #v > 0
 end
@@ -6,6 +9,7 @@ end
 return {
   name = "request-termination",
   fields = {
+    { run_on = typedefs.run_on_first },
     { config = {
         type = "record",
         fields = {

--- a/kong/plugins/request-transformer/schema.lua
+++ b/kong/plugins/request-transformer/schema.lua
@@ -38,6 +38,7 @@ local colon_strings_array_record = {
 return {
   name = "request-transformer",
   fields = {
+    { run_on = typedefs.run_on_first },
     { config = {
         type = "record",
         fields = {

--- a/kong/plugins/response-ratelimiting/schema.lua
+++ b/kong/plugins/response-ratelimiting/schema.lua
@@ -26,6 +26,7 @@ end
 return {
   name = "response-ratelimiting",
   fields = {
+    { run_on = typedefs.run_on { one_of = { "first", "second" } } },
     { config = {
         type = "record",
         fields = {

--- a/kong/plugins/response-transformer/schema.lua
+++ b/kong/plugins/response-transformer/schema.lua
@@ -1,3 +1,6 @@
+local typedefs = require "kong.db.schema.typedefs"
+
+
 local string_array = {
   type = "array",
   default = {},
@@ -34,6 +37,7 @@ local colon_string_record = {
 return {
   name = "response-transformer",
   fields = {
+    { run_on = typedefs.run_on_first },
     { config = {
         type = "record",
         fields = {


### PR DESCRIPTION
This PR includes:
* A fix on the schema, found by chance while studying how to best implement the new field
* A new field called `mesh_mode` to tag plugins with `inbound`, `outbound` or `two-way`. Note that `two-way` plugin instances can be individually tagged as `inbound` or `outbound` on creation, but plugins tagged as `inbound` can only have `inbound` instances, and the same goes for `outbound` pluggins.

I have tagged 15 plugins as `two-way` on this PR. There are multiple commits with explanations for my reasons.
