### PR TITLE
add extract configuration to response transformer plugin

### DIFF
--- a/kong/plugins/response-transformer/body_transformer.lua
+++ b/kong/plugins/response-transformer/body_transformer.lua
@@ -66,6 +66,16 @@ function _M.transform_json_body(conf, buffered_data)
     json_body[name] = nil
   end
 
+  -- extract value from key and populate the body of the response
+  -- by parsing the value and adding each key individually
+  for _, name in iter(conf.extract.json) do
+    decoded_value = cjson_decode(json_body[name])
+    json_body[name] = nil
+    for k, v in pairs(decoded_value) do
+      json_body[k] = v
+    end
+  end
+
   -- replace key:value to body
   for _, name, value in iter(conf.replace.json) do
     local v = cjson_encode(value)

--- a/kong/plugins/response-transformer/body_transformer.lua
+++ b/kong/plugins/response-transformer/body_transformer.lua
@@ -69,9 +69,9 @@ function _M.transform_json_body(conf, buffered_data)
   -- extract value from key and populate the body of the response
   -- by parsing the value and adding each key individually
   for _, name in iter(conf.extract.json) do
-    decoded_value = cjson_decode(json_body[name])
+    local extracted_decoded_value = cjson_decode(json_body[name])
     json_body[name] = nil
-    for k, v in pairs(decoded_value) do
+    for k, v in pairs(extracted_decoded_value) do
       json_body[k] = v
     end
   end

--- a/spec/03-plugins/16-response-transformer/02-body_transformer_spec.lua
+++ b/spec/03-plugins/16-response-transformer/02-body_transformer_spec.lua
@@ -17,6 +17,9 @@ describe("Plugin: response-transformer", function()
         append   = {
           json   = {}
         },
+        extract  = {
+          json   = {}
+        },
       }
       it("parameter", function()
         local json = [[{"p2":"v1"}]]
@@ -45,6 +48,9 @@ describe("Plugin: response-transformer", function()
         },
         append   = {
           json   = {"p1:v1", "p3:\"v1\""}
+        },
+        extract  = {
+          json   = {}
         },
       }
       it("new key:value if key does not exists", function()
@@ -80,7 +86,10 @@ describe("Plugin: response-transformer", function()
         },
         append   = {
           json   = {}
-        }
+        },
+        extract  = {
+          json   = {}
+        },
       }
       it("parameter", function()
         local json = [[{"p1" : "v1", "p2" : "v1"}]]
@@ -102,7 +111,10 @@ describe("Plugin: response-transformer", function()
         },
         append   = {
           json   = {}
-        }
+        },
+        extract  = {
+          json   = {}
+        },
       }
       it("parameter if it exists", function()
         local json = [[{"p1" : "v1", "p2" : "v1"}]]
@@ -138,12 +150,145 @@ describe("Plugin: response-transformer", function()
         append   = {
           json   = {"p3:v2"}
         },
+        extract  = {
+          json   = {}
+        }
       }
       it("combination", function()
         local json = [[{"p1" : "v1", "p2" : "v1"}]]
         local body = body_transformer.transform_json_body(conf, json)
         local body_json = cjson.decode(body)
         assert.same({p2 = "v2", p3 = {"v1", "v2"}}, body_json)
+      end)
+    end)
+
+    describe("remove, extract", function()
+      local conf = {
+        remove   = {
+          json   = {"p1"}
+        },
+        replace  = {
+          json   = {}
+        },
+        add      = {
+          json   = {}
+        },
+        append   = {
+          json   = {}
+        },
+        extract  = {
+          json   = {"p2"}
+        },
+      }
+      it("combination", function()
+        local json = [[{"p1" : "v1", "p2" : "{\"foo\":\"bar\"}"}]]
+        local body = body_transformer.transform_json_body(conf, json)
+        local body_json = cjson.decode(body)
+        assert.same({foo = "bar"}, body_json)
+      end)
+    end)
+
+    describe("extract, replace", function()
+      local conf = {
+        remove   = {
+          json   = {}
+        },
+        extract  = {
+          json   = {"p2"}
+        },
+        replace  = {
+          json   = {"foo:baz"}
+        },
+        add      = {
+          json   = {}
+        },
+        append   = {
+          json   = {}
+        },
+      }
+      it("combination", function()
+        local json = [[{"p1" : "v1", "p2" : "{\"foo\":\"bar\"}"}]]
+        local body = body_transformer.transform_json_body(conf, json)
+        local body_json = cjson.decode(body)
+        assert.same({p1 = "v1", foo = "baz"}, body_json)
+      end)
+    end)
+
+    describe("extract, replace, add", function()
+      local conf = {
+        remove   = {
+          json   = {}
+        },
+        extract  = {
+          json   = {"p2"}
+        },
+        replace  = {
+          json   = {"foo:baz"}
+        },
+        add      = {
+          json   = {"bar:gummies"}
+        },
+        append   = {
+          json   = {}
+        },
+      }
+      it("combination", function()
+        local json = [[{"p1" : "v1", "p2" : "{\"foo\":\"bar\"}"}]]
+        local body = body_transformer.transform_json_body(conf, json)
+        local body_json = cjson.decode(body)
+        assert.same({p1 = "v1", foo = "baz", bar = "gummies"}, body_json)
+      end)
+    end)
+
+    describe("extract, replace, add, append", function()
+      local conf = {
+        remove   = {
+          json   = {}
+        },
+        extract  = {
+          json   = {"p2"}
+        },
+        replace  = {
+          json   = {"foo:baz"}
+        },
+        add      = {
+          json   = {"bar:gummies"}
+        },
+        append   = {
+          json   = {"foo:bar"}
+        },
+      }
+      it("combination", function()
+        local json = [[{"p1" : "v1", "p2" : "{\"foo\":\"bar\"}"}]]
+        local body = body_transformer.transform_json_body(conf, json)
+        local body_json = cjson.decode(body)
+        assert.same({p1 = "v1", foo = {"baz", "bar"}, bar = "gummies"}, body_json)
+      end)
+    end)
+
+    describe("remove, extract, replace, add, append", function()
+      local conf = {
+        remove   = {
+          json   = {"p1"}
+        },
+        extract  = {
+          json   = {"p2"}
+        },
+        replace  = {
+          json   = {"foo:baz"}
+        },
+        add      = {
+          json   = {"bar:gummies"}
+        },
+        append   = {
+          json   = {"foo:bar"}
+        },
+      }
+      it("combination", function()
+        local json = [[{"p1" : "v1", "p2" : "{\"foo\":\"bar\"}"}]]
+        local body = body_transformer.transform_json_body(conf, json)
+        local body_json = cjson.decode(body)
+        assert.same({foo = {"baz", "bar"}, bar = "gummies"}, body_json)
       end)
     end)
   end)

--- a/spec/03-plugins/16-response-transformer/02-body_transformer_spec.lua
+++ b/spec/03-plugins/16-response-transformer/02-body_transformer_spec.lua
@@ -162,10 +162,10 @@ describe("Plugin: response-transformer", function()
       end)
     end)
 
-    describe("remove, extract", function()
+    describe("extract", function()
       local conf = {
         remove   = {
-          json   = {"p1"}
+          json   = {}
         },
         replace  = {
           json   = {}
@@ -180,11 +180,11 @@ describe("Plugin: response-transformer", function()
           json   = {"p2"}
         },
       }
-      it("combination", function()
+      it("removes p2 and encode stringified json", function()
         local json = [[{"p1" : "v1", "p2" : "{\"foo\":\"bar\"}"}]]
         local body = body_transformer.transform_json_body(conf, json)
         local body_json = cjson.decode(body)
-        assert.same({foo = "bar"}, body_json)
+        assert.same({p1 = "v1", foo = "bar"}, body_json)
       end)
     end)
 


### PR DESCRIPTION
### Summary
Our case is around the integration of Kong + AWS Lambda plugin. When an error occurs in the Lambda end, the full response sent back by the Lambda is displayed on the response body, which includes the stack trace and the type of error.

Here's an example:

```
{
    "errorMessage": "{\"errorCode\":8,\"errorMessage\":\"actual error message\"}",
    "errorType": "java.lang.Exception",
    "stackTrace": [
        "sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)",
        "sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)",
        "sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)",
        "java.lang.reflect.Constructor.newInstance(Constructor.java:423)",
        "clojure.lang.Reflector.invokeConstructor(Reflector.java:180)",
        "shared.lambda$format_error.invokeStatic(lambda.clj:14)",
        "shared.lambda$format_error.invoke(lambda.clj:8)",
        "shared.lambda$handle.invokeStatic(lambda.clj:28)",
        "shared.lambda$handle.invoke(lambda.clj:17)",
        "clazzz.lambda$G__10962handleRequest.invokeStatic(lambda.clj:7)",
        "clazzz.lambda$G__10962handleRequest.invoke(lambda.clj:6)",
        "clazzz.lambda.handler.handleRequest(Unknown Source)"
    ]
}
```

The payload above contains way too much info and what we really want to send back is the contents of the `errorMessage` key. Since this is JSON content, we thought we could use the `response-transfomer` plugin to extract that information and send it back but the plugin does not support extraction.

So we decided to have a simple implementation of the use case above **with the only assumption that the content of the key you want to extract is actually a stringified JSON**.

As you can see by the tests, you can also combine with the other configuration options in the plugin allowing for manipulation of the content extracted. We thought that's a very powerful feature - initially we were not going to do this way but thought that could be really useful for other use cases.

Thus the sequence goes like this now:
```
remove -> extract -> replace -> add -> append
```
Hope that makes sense. Happy to provide more information.

### Full changelog

* add extract configuration to response transformer
* rename and use local variable (commit post-lint)
* using a single 'extract' test block to deal with specific 'extract' tests
