### PR TITLE
feat(schema) nicer error message for typedef errors

### DIFF
--- a/kong/db/schema/typedefs.lua
+++ b/kong/db/schema/typedefs.lua
@@ -252,4 +252,11 @@ typedefs.key = Schema.define {
 }
 
 
+setmetatable(typedefs, {
+  __index = function(_, k)
+    error("schema typedef error: definition " .. k .. " does not exist", 2)
+  end
+})
+
+
 return typedefs


### PR DESCRIPTION
A typo in a typedef could lead to very cryptic error messages. This adds a metatable which catches accesses to unknown fields, producing an immediate error that is more evident for plugin authors. Since the metatable only hits on invalid accesses which are always plugin development bugs, this metatable adds no runtime overhead.