### PR TITLE
fix(schema) handle conditionals on structured data 

### DIFF
--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -167,7 +167,7 @@ Schema.validators = {
     if value == wanted then
       return true
     end
-    local str = (wanted == null) and "null" or tostring(value)
+    local str = (wanted == null) and "null" or tostring(wanted)
     return nil, validation_errors.EQ:format(str)
   end,
 


### PR DESCRIPTION
Conditionals set on properties of a structured field, such
as elements of a set, were not being correctly checked, because
the `if_match` validator ignored the type of the field, and
thus did not recurse on attributes such as `elements`.

The core of the fix is the one-line change in the `conditional`
validator. The rest of the additions (`get_schema_field`,
`allow_record_fields_by_name`) are there to allow nested fields
to be specified (e.g. so that a match on field `config.a.b`
can trigger a constraint on field `config.c.d`).

Includes a test.