### PR TITLE
fix(acl) prevent 014_to_015 migration from throwing an error

### DIFF
--- a/kong/plugins/acl/migrations/001_14_to_15.lua
+++ b/kong/plugins/acl/migrations/001_14_to_15.lua
@@ -61,6 +61,7 @@ return {
     ]],
 
     teardown = function(connector, helpers)
+      local cassandra = require "cassandra"
       local coordinator = assert(connector:connect_migrations())
 
       for rows, err in coordinator:iterate("SELECT * FROM acls") do
@@ -74,11 +75,10 @@ return {
                                           row.consumer_id or "",
                                           row.group or "")
 
-          local cql = string.format([[
-            UPDATE acls SET cache_key = '%s' WHERE id = '%s'
-          ]], cache_key, row.id)
-
-          assert(connector:query(cql))
+          assert(connector:query("UPDATE acls SET cache_key = ? WHERE id = ?", {
+            cache_key,
+            cassandra.uuid(row.id),
+          }))
         end
       end
     end,


### PR DESCRIPTION
The `id` column is a UUID, but given as a string, producing the error:

[Cassandra error] failed to run migration '001_14_to_15' teardown:
...are/lua/5.1/kong/plugins/acl/migrations/001_14_to_15.lua:81:
[Invalid] Invalid STRING constant (c8b871b7-7a18-45a9-9cd3-aa0a78c6073d)
for "id" of type uuid

See #3924