### PR TITLE
feat(migrations) implement post up and teardown functionality in connectors

### DIFF
--- a/kong/db/init.lua
+++ b/kong/db/init.lua
@@ -570,6 +570,14 @@ do
       end
     end
 
+    if run_teardown then
+      ok, err = self.connector:post_run_teardown_migrations()
+      if not ok then
+        self.connector:close()
+        return nil, prefix_err(self, err)
+      end
+    end
+
     self.connector:close()
 
     return true

--- a/kong/db/strategies/cassandra/connector.lua
+++ b/kong/db/strategies/cassandra/connector.lua
@@ -836,7 +836,17 @@ do
   end
 
 
-  function CassandraConnector:post_up_migrations()
+  function CassandraConnector:post_run_up_migrations()
+    local ok, err = wait_for_schema_consensus(self)
+    if not ok then
+      return nil, err
+    end
+
+    return true
+  end
+
+
+  function CassandraConnector:post_run_teardown_migrations()
     local ok, err = wait_for_schema_consensus(self)
     if not ok then
       return nil, err

--- a/kong/db/strategies/connector.lua
+++ b/kong/db/strategies/connector.lua
@@ -106,6 +106,11 @@ function Connector:post_run_up_migrations()
 end
 
 
+function Connector:post_run_teardown_migrations()
+  return true
+end
+
+
 function Connector:record_migration()
   error(fmt("record_migration() not implemented for '%s' strategy",
             self.database))

--- a/kong/db/strategies/postgres/connector.lua
+++ b/kong/db/strategies/postgres/connector.lua
@@ -770,7 +770,12 @@ function _mt:record_migration(subsystem, name, state)
 end
 
 
-function _mt:post_up_migrations()
+function _mt:post_run_up_migrations()
+  return true
+end
+
+
+function _mt:post_run_teardown_migrations()
   return true
 end
 


### PR DESCRIPTION
### Summary

This implements a way to run a strategy specific code after `up` and `teardown` migration phases. For Cassandra it also implements `a wait for consensus` on those calls.

It is made according to this comment on issue #3924:
https://github.com/Kong/kong/issues/3924#issuecomment-436343538