### PR TITLE
(fix) correlation-id ensure plugin header not nil

### DIFF
--- a/kong/plugins/correlation-id/handler.lua
+++ b/kong/plugins/correlation-id/handler.lua
@@ -80,7 +80,7 @@ end
 function CorrelationIdHandler:header_filter(conf)
   CorrelationIdHandler.super.header_filter(self)
 
-  if conf.echo_downstream then
+  if conf.echo_downstream and kong.ctx.plugin.correlationid_header_value then
     kong.response.set_header(conf.header_name, kong.ctx.plugin.correlationid_header_value)
   end
 end


### PR DESCRIPTION
Fix clashing plugins issue reported in #3924

### Summary

As found, the request-termination plugin and correlation-id enabled on the same service/route produce error during correlation-id header_filter phase if echo_downstream is enabled. This is due to expected headers being dropped by the opposing plugin(request-termination) and the pdk producing errors around setting a header to nil. This is a fix to correlation-id to ensure error free execution, with further discussions taking place with Kong internally about how they want pdk improvements around kong.response.set_header().

### Full changelog
Modify /kong/plugins/correlation-id/handler.lua

### Issues resolved
Fix #3924