### PR TITLE
chore(conf) drop the 'custom_plugins' property

### DIFF
--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -170,7 +170,6 @@ local CONF_INFERENCES = {
                 }
               },
   plugins = { typ = "array" },
-  custom_plugins = { typ = "array" },
   anonymous_reports = { typ = "boolean" },
   nginx_daemon = { typ = "ngx_boolean" },
   nginx_optimizations = { typ = "boolean" },
@@ -786,22 +785,6 @@ local function load(path, custom_conf)
             plugins[plugin_name] = true
           end
         end
-      end
-    end
-
-    if conf.custom_plugins and #conf.custom_plugins > 0 then
-      local warned
-
-      for i = 1, #conf.custom_plugins do
-        local plugin_name = pl_stringx.strip(conf.custom_plugins[i])
-
-        if not plugins[plugin_name] and not warned then
-          log.warn("the 'custom_plugins' configuration property is " ..
-                   "deprecated, use 'plugins' instead")
-          warned = true
-        end
-
-        plugins[plugin_name] = true
       end
     end
 

--- a/kong/pdk/init.lua
+++ b/kong/pdk/init.lua
@@ -74,7 +74,7 @@
 -- @usage
 -- print(kong.configuration.prefix) -- "/usr/local/kong"
 -- -- this table is read-only; the following throws an error:
--- kong.configuration.custom_plugins = "foo"
+-- kong.configuration.prefix = "foo"
 
 --
 --- Request/Response

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -6,7 +6,6 @@ proxy_error_log = logs/error.log
 admin_access_log = logs/admin_access.log
 admin_error_log = logs/error.log
 plugins = bundled
-custom_plugins = NONE
 anonymous_reports = on
 
 proxy_listen = 0.0.0.0:8000, 0.0.0.0:8443 ssl

--- a/spec/01-unit/002-conf_loader_spec.lua
+++ b/spec/01-unit/002-conf_loader_spec.lua
@@ -71,7 +71,7 @@ describe("Configuration loader", function()
   end)
   it("loads custom plugins", function()
     local conf = assert(conf_loader(nil, {
-      custom_plugins = "hello-world,my-plugin"
+      plugins = "hello-world,my-plugin"
     }))
     assert.True(conf.loaded_plugins["hello-world"])
     assert.True(conf.loaded_plugins["my-plugin"])
@@ -79,18 +79,15 @@ describe("Configuration loader", function()
   it("merges plugins and custom plugins", function()
     local conf = assert(conf_loader(nil, {
       plugins = "foo, bar",
-      custom_plugins = "baz,foobaz",
     }))
     assert.is_not_nil(conf.loaded_plugins)
-    assert.same(4, tablex.size(conf.loaded_plugins))
+    assert.same(2, tablex.size(conf.loaded_plugins))
     assert.True(conf.loaded_plugins["foo"])
     assert.True(conf.loaded_plugins["bar"])
-    assert.True(conf.loaded_plugins["baz"])
-    assert.True(conf.loaded_plugins["foobaz"])
   end)
   it("loads custom plugins surrounded by spaces", function()
     local conf = assert(conf_loader(nil, {
-      custom_plugins = " hello-world ,   another-one  "
+      plugins = " hello-world ,   another-one  "
     }))
     assert.True(conf.loaded_plugins["hello-world"])
     assert.True(conf.loaded_plugins["another-one"])

--- a/spec/01-unit/003-prefix_handler_spec.lua
+++ b/spec/01-unit/003-prefix_handler_spec.lua
@@ -437,7 +437,7 @@ describe("NGINX conf compiler", function()
     end)
     it("writes custom plugins in Kong conf", function()
       local conf = assert(conf_loader(nil, {
-        custom_plugins = { "foo", "bar" },
+        plugins = { "foo", "bar" },
         prefix = tmp_config.prefix
       }))
 

--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -101,16 +101,6 @@ describe("kong start/stop", function()
     end)
   end)
 
-  describe("using deprecated custom_plugin property" , function()
-    it("prints a warning to stderr", function()
-      local _, stderr, stdout = assert(helpers.kong_exec("start --conf " ..
-                                  "spec/fixtures/deprecated_custom_plugin.conf"))
-      assert.matches("Kong started", stdout, nil, true)
-      assert.matches("[warn] the 'custom_plugins' configuration property is " ..
-                     "deprecated, use 'plugins' instead", stderr, nil, true)
-    end)
-  end)
-
   describe("/etc/hosts resolving in CLI", function()
     it("resolves #cassandra hostname", function()
       assert(helpers.kong_exec("start --vv --run-migrations --conf " .. helpers.test_conf_path, {

--- a/spec/02-integration/05-proxy/14-upstream-status-header_spec.lua
+++ b/spec/02-integration/05-proxy/14-upstream-status-header_spec.lua
@@ -54,7 +54,7 @@ describe(constants.HEADERS.UPSTREAM_STATUS .. " header", function()
       assert(helpers.start_kong {
         nginx_conf = "spec/fixtures/custom_nginx.template",
         headers = "server_tokens,latency_tokens,x-kong-upstream-status",
-        custom_plugins = "dummy",
+        plugins = "bundled,dummy",
       })
 
       client = helpers.proxy_client()

--- a/spec/02-integration/07-sdk/01-ctx_spec.lua
+++ b/spec/02-integration/07-sdk/01-ctx_spec.lua
@@ -59,7 +59,7 @@ describe("SDK: kong.ctx", function()
     })
 
     assert(helpers.start_kong({
-      custom_plugins = "ctx-checker,ctx-checker-last",
+      plugins = "bundled,ctx-checker,ctx-checker-last",
       nginx_conf     = "spec/fixtures/custom_nginx.template",
     }))
 
@@ -102,7 +102,7 @@ describe("SDK: kong.ctx", function()
     })
 
     assert(helpers.start_kong({
-      custom_plugins = "ctx-checker,ctx-checker-last",
+      plugins = "bundled,ctx-checker,ctx-checker-last",
       nginx_conf     = "spec/fixtures/custom_nginx.template",
     }))
 

--- a/spec/02-integration/07-sdk/02-log_spec.lua
+++ b/spec/02-integration/07-sdk/02-log_spec.lua
@@ -66,7 +66,7 @@ describe("SDK: kong.log", function()
     })
 
     assert(helpers.start_kong({
-      custom_plugins = "logger,logger-last",
+      plugins = "bundled,logger,logger-last",
       nginx_conf     = "spec/fixtures/custom_nginx.template",
     }))
 


### PR DESCRIPTION
This commit drops the `custom_plugins` property which was deprecated
since 0.14.0, in favor of `plugins`, which was introduced in
80acbf848e897a469c728395bf255dcbfda4cff3