### PR TITLE
chore(deps) update dns lib to 3.0.2

### DIFF
--- a/kong-1.0.3-0.rockspec
+++ b/kong-1.0.3-0.rockspec
@@ -29,7 +29,7 @@ dependencies = {
   "luaossl == 20181207",
   "luasyslog == 1.0.0",
   "lua_pack == 1.0.5",
-  "lua-resty-dns-client == 2.2.0",
+  "lua-resty-dns-client == 3.0.2",
   "lua-resty-worker-events == 0.3.3",
   "lua-resty-mediador == 0.1.2",
   "lua-resty-healthcheck == 0.6.0",

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -550,17 +550,16 @@ function Kong.balancer()
     -- Report HTTP status for health checks
     local balancer = balancer_data.balancer
     if balancer then
-      local ip, port = balancer_data.ip, balancer_data.port
-
       if previous_try.state == "failed" then
         if previous_try.code == 504 then
-          balancer.report_timeout(ip, port)
+          balancer.report_timeout(balancer_data.balancer_handle)
         else
-          balancer.report_tcp_failure(ip, port)
+          balancer.report_tcp_failure(balancer_data.balancer_handle)
         end
 
       else
-        balancer.report_http_status(ip, port, previous_try.code)
+        balancer.report_http_status(balancer_data.balancer_handle,
+                                    previous_try.code)
       end
     end
 

--- a/spec/01-unit/09-balancer_spec.lua
+++ b/spec/01-unit/09-balancer_spec.lua
@@ -486,10 +486,22 @@ describe("Balancer", function()
       })
     end
     balancer.subscribe_to_healthcheck_events(cb)
-    my_balancer.report_http_status("127.0.0.1", 1111, 429)
-    my_balancer.report_http_status("127.0.0.1", 1111, 200)
+    my_balancer.report_http_status({
+      address = {
+        ip = "127.0.0.1",
+        port = 1111,
+      }}, 429)
+    my_balancer.report_http_status({
+      address = {
+        ip = "127.0.0.1",
+        port = 1111,
+      }}, 200)
     balancer.unsubscribe_from_healthcheck_events(cb)
-    my_balancer.report_http_status("127.0.0.1", 1111, 429)
+    my_balancer.report_http_status({
+      address = {
+        ip = "127.0.0.1",
+        port = 1111,
+      }}, 429)
     hc:stop()
     assert.same({
       upstream_id = "hc",

--- a/spec/02-integration/05-proxy/10-balancer_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer_spec.lua
@@ -559,6 +559,112 @@ local localhosts = {
 
 for _, strategy in helpers.each_strategy() do
 
+  describe("Ring-balancer resolution #" .. strategy, function()
+
+    local dns_mock_filename = helpers.test_conf.prefix .. "/dns_mock_records.lua"
+
+    setup(function()
+      assert(helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+        "upstreams",
+        "targets",
+      }))
+
+      helpers.start_kong({
+        database   = strategy,
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+        db_update_frequency = 0.1,
+        -- inject path to mock-resolver to make Kong load that module
+        lua_package_path = "spec/fixtures/mocks/lua-resty-dns/?.lua;" .. package.path,
+      })
+
+      -- write the mock dns file AFTER kong starts, or it will be erased again
+      assert(require("pl.utils").writefile(dns_mock_filename,[[
+        local TYPE_A, TYPE_AAAA, TYPE_CNAME, TYPE_SRV = 1, 28, 5, 33
+        return {
+          [TYPE_SRV] = {
+            ["my.srv.test.com"] = {
+              {
+                type     = TYPE_SRV,
+                name     = "my.srv.test.com",
+                target   = "a.my.srv.test.com",
+                port     = 80,  -- this port should FAIL to connect
+                weight   = 10,
+                ttl      = 600,
+                priority = 20,
+                class    = 1,
+              },
+            },
+          },
+
+          [TYPE_A] = {
+            ["a.my.srv.test.com"] = {
+              {
+                type     = TYPE_A,
+                name     = "a.my.srv.test.com",
+                address  = "127.0.0.1",
+                ttl      = 600,
+                class    = 1,
+              },
+            },
+          },
+
+          [TYPE_AAAA] = {
+          },
+
+          [TYPE_CNAME] = {
+          },
+        }
+      ]]))
+
+    end)
+
+    teardown(function()
+      os.remove(dns_mock_filename)
+      helpers.stop_kong(nil, true, true)
+    end)
+
+    it("2-level dns sets the proper health-check", function()
+
+      -- Issue is that 2 level dns hits a mismatch between a name
+      -- in the second level, and the IP address that failed.
+      -- Typically an SRV pointing to an A record will result in a
+      -- internal balancer structure Address that hold a name rather
+      -- than an IP. So when Kong reports IP xyz failed to connect,
+      -- and the healthchecker marks it as down. That IP will not be
+      -- found in the balancer (since its only known by name), and hence
+      -- and error is returned that the target could not be disabled.
+
+      -- configure healthchecks
+      local upstream_name = add_upstream({
+        healthchecks = healthchecks_config {
+          passive = {
+            unhealthy = {
+              tcp_failures = 1,
+            }
+          }
+        }
+      })
+      -- the following port will not be used, will be overwritten by
+      -- the mocked SRV record.
+      add_target(upstream_name, "my.srv.test.com", 80)
+      local api_host = add_api(upstream_name)
+
+      -- we do not set up servers, since we want the connection to get refused
+      -- Go hit the api with requests, 1x round the balancer
+      client_requests(SLOTS, api_host)
+
+      local health = get_upstream_health(upstream_name)
+      assert.is.table(health)
+      assert.is.table(health.data)
+      assert.is.table(health.data[1])
+      assert.equals("UNHEALTHY", health.data[1].health)
+    end)
+
+  end)
+
   describe("Ring-balancer #" .. strategy, function()
 
     lazy_setup(function()

--- a/spec/02-integration/05-proxy/10-balancer_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer_spec.lua
@@ -1026,7 +1026,7 @@ for _, strategy in helpers.each_strategy() do
 
           end)
 
-          it("#perform passive health checks", function()
+          it("perform passive health checks", function()
 
             for nfails = 1, 3 do
 

--- a/spec/fixtures/mocks/lua-resty-dns/resty/dns/resolver.lua
+++ b/spec/fixtures/mocks/lua-resty-dns/resty/dns/resolver.lua
@@ -1,0 +1,97 @@
+-- Mock for the underlying 'resty.dns.resolver' library
+-- (so NOT the Kong dns client)
+
+-- this file should be in the Kong working direrctory (prefix)
+local MOCK_RECORD_FILENAME = "dns_mock_records.lua"
+
+
+
+-- first thing is to get the original (non-mock) resolver
+local resolver
+do
+  local function get_source_path()
+    -- find script path remember to strip off the starting @
+    -- should be like: 'spec/fixtures/mocks/lua-resty-dns/resty/dns/resolver.lua'
+    return debug.getinfo(2, "S").source:sub(2)  --only works in a function, hence the wrapper
+  end
+  local path = get_source_path()
+
+  -- module part is like: 'resty.dns.resolver'
+  local module_part = select(1,...)
+
+  -- create the packagepath part, like: 'spec/fixtures/mocks/lua-resty-dns/?.lua'
+  path = path:gsub(module_part:gsub("%.", "/"), "?") .. ";" -- prefix path, so semi-colon at end
+
+  -- grab current paths
+  local old_paths = package.path
+
+  -- drop the element that picked this mock from the path
+  local s, e = old_paths:find(path, 1, true)
+  package.path = old_paths:sub(1, s-1) .. old_paths:sub(e + 1, -1)
+
+  -- With the mock out of the path, require the module again to get the original.
+  -- Problem is that package.loaded contains a userdata now, because we're in
+  -- the middle of loading that same module name. So swap it.
+  local swap
+  swap, package.loaded[module_part] = package.loaded[module_part], nil
+  resolver = require(module_part)
+  package.loaded[module_part] = swap
+
+  -- restore the package path
+  package.path = old_paths
+end
+
+
+-- load and cache the mock-records
+local get_mock_records
+do
+  local mock_records
+  get_mock_records = function()
+    if mock_records then
+      return mock_records
+    end
+
+    local is_file = require("pl.path").isfile
+    local prefix = ((kong or {}).configuration or {}).prefix
+    if not prefix then
+      -- we might be invoked before the Kong config was loaded, so exit early
+      -- and do not set _mock_records yet.
+      return {}
+    end
+
+    local filename = prefix .. "/" .. MOCK_RECORD_FILENAME
+
+    mock_records = {}
+    if not is_file(filename) then
+      -- no mock records set up, return empty default
+      return mock_records
+    end
+
+    -- there is a file with mock records available, go load it
+    mock_records = assert(loadfile(filename))()
+    assert(type(mock_records) == "table",
+           "expected mock_record file to contain a table")
+
+    return mock_records
+  end
+end
+
+
+-- patch the actual query method
+local old_query = resolver.query
+resolver.query = function(self, name, options, tries)
+  local mock_records = get_mock_records()
+  local qtype = (options or {}).qtype or resolver.TYPE_A
+
+  local answer = (mock_records[qtype] or {})[name]
+  if answer then
+    -- we actually have a mock answer, return it
+    return answer, nil, tries
+  end
+
+  -- no mock, so invoke original resolver
+  return old_query(self, name, options, tries)
+end
+
+
+return resolver


### PR DESCRIPTION
Bumps the DNS client and loadbalancer lib to 3.0.2

- Fix (DNS lib + Kong): a potential issue with the healthchecks not being able to set the status of a peer. This happens when there are multiple levels of dns, eg: SRV -> A -> ip-address.
- Fix (DNS lib): the (long time) outstanding fix for the error `attempt to index local 'address' (a nil value)`
