### PR TITLE
chore(deps) bump lua-cassandra to 1.3.3

### DIFF
--- a/kong-0.14.1-0.rockspec
+++ b/kong-0.14.1-0.rockspec
@@ -20,7 +20,7 @@ dependencies = {
   "multipart == 0.5.5",
   "version == 0.2",
   "kong-lapis == 1.6.0.1",
-  "lua-cassandra == 1.3.2",
+  "lua-cassandra == 1.3.3",
   "pgmoon == 1.9.0",
   "luatz == 0.3",
   "lua_system_constants == 0.1.2",


### PR DESCRIPTION
This release makes sure that we favor the `rpc_address` to connect to
the elected contact point. It also adds support for CQL frames with
custom payloads.

Changelog:

https://github.com/thibaultcha/lua-cassandra/blob/master/CHANGELOG.md#133