### PR TITLE
feat(*) add ability to route on sni, source and destination

### DIFF
--- a/kong/db/migrations/core/001_14_to_15.lua
+++ b/kong/db/migrations/core/001_14_to_15.lua
@@ -205,6 +205,11 @@ return {
       CREATE INDEX IF NOT EXISTS routes_name_idx ON routes(name);
 
 
+      ALTER TABLE routes ADD snis set<text>;
+      ALTER TABLE routes ADD sources set<text>;
+      ALTER TABLE routes ADD destinations set<text>;
+
+
       CREATE TABLE IF NOT EXISTS plugins_temp(
         id uuid,
         created_at timestamp,

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -77,8 +77,9 @@ return {
     { regex_priority = { type = "integer", default = 0 }, },
     { strip_path     = { type = "boolean", default = true }, },
     { preserve_host  = { type = "boolean", default = false }, },
-    { snis = { type = "set",
-               elements = typedefs.sni }, },
+    -- TLS layer attributes
+    { snis           = { type = "set", elements = typedefs.sni }, },
+    -- IP layer attributes
     { sources = { type = "set",
                   elements = {
                     type = "record",
@@ -109,7 +110,7 @@ return {
   entity_checks = {
     { conditional_at_least_one_of = { if_field = "protocols",
                                       if_match = { elements = { type = "string", one_of = { "http", "https" }}},
-                                      then_at_least_one_of = { "methods", "hosts", "paths" },
+                                      then_at_least_one_of = { "methods", "hosts", "paths", "sources", "destinations", "snis" },
                                       then_err = "must set one of %s when 'protocols' is 'http' or 'https'",
                                       else_match = { elements = { type = "string", one_of = { "tcp", "tls" }}},
                                       else_then_at_least_one_of = { "sources", "destinations", "snis" },
@@ -133,25 +134,6 @@ return {
                       then_field = "methods",
                       then_match = { len_eq = 0 },
                       then_err = "cannot set 'methods' when 'protocols' is 'tcp' or 'tls'",
-                    }},
-
-    { conditional = { if_field = "protocols",
-                      if_match = { elements = { type = "string", one_of = { "http", "https" }}},
-                      then_field = "snis",
-                      then_match = { len_eq = 0 },
-                      then_err = "cannot set 'snis' when 'protocols' is 'http' or 'https'",
-                    }},
-    { conditional = { if_field = "protocols",
-                      if_match = { elements = { type = "string", one_of = { "http", "https" }}},
-                      then_field = "destinations",
-                      then_match = { len_eq = 0 },
-                      then_err = "cannot set 'destinations' when 'protocols' is 'http' or 'https'",
-                    }},
-    { conditional = { if_field = "protocols",
-                      if_match = { elements = { type = "string", one_of = { "http", "https" }}},
-                      then_field = "sources",
-                      then_match = { len_eq = 0 },
-                      then_err = "cannot set 'sources' when 'protocols' is 'http' or 'https'",
                     }},
   },
 }

--- a/spec/01-unit/000-new-dao/01-schema/05-routes_spec.lua
+++ b/spec/01-unit/000-new-dao/01-schema/05-routes_spec.lua
@@ -59,17 +59,6 @@ describe("routes schema", function()
     assert.truthy(errs["protocols"])
   end)
 
-  it("fails given an invalid method", function()
-    local route = {
-      protocols = { "http" },
-      methods = { "get" },
-    }
-    route = Routes:process_auto_fields(route, "insert")
-    local ok, errs = Routes:validate(route)
-    assert.falsy(ok)
-    assert.truthy(errs["methods"])
-  end)
-
   it("missing method, host, path & service produces error", function()
     local s = { id = "a4fbd24e-6a52-4937-bd78-2536713072d2" }
     local tests = {
@@ -94,7 +83,6 @@ describe("routes schema", function()
   end)
 
   it("invalid protocols produces error", function()
-
     local route = Routes:process_auto_fields({ protocols = {} }, "insert")
     local ok, errs = Routes:validate(route)
     assert.falsy(ok)
@@ -146,407 +134,6 @@ describe("routes schema", function()
     assert.truthy(Routes.fields.service)
     assert.truthy(Routes.fields.service.schema)
     assert.truthy(Routes.fields.service.schema.fields)
-  end)
-
-  describe("paths attribute", function()
-    -- refusals
-    it("must be a string", function()
-      local route = {
-        paths = { false },
-      }
-
-      local ok, err = Routes:validate(route)
-      assert.falsy(ok)
-      assert.equal("expected a string", err.paths)
-    end)
-
-    it("must be a non-empty string", function()
-      local route = {
-        paths = { "" },
-      }
-
-      local ok, err = Routes:validate(route)
-      assert.falsy(ok)
-      assert.equal("length must be at least 1", err.paths)
-    end)
-
-    it("must start with /", function()
-      local route = {
-        paths = { "foo" },
-      }
-
-      local ok, err = Routes:validate(route)
-      assert.falsy(ok)
-      assert.equal("should start with: /", err.paths)
-    end)
-
-    it("must not have empty segments (/foo//bar)", function()
-      local invalid_paths = {
-        "/foo//bar",
-        "/foo/bar//",
-        "//foo/bar",
-      }
-
-      for i = 1, #invalid_paths do
-        local route = {
-          paths = { invalid_paths[i] },
-        }
-
-        local ok, err = Routes:validate(route)
-        assert.falsy(ok)
-        assert.equal("must not have empty segments", err.paths)
-      end
-    end)
-
-    it("must dry-run values that are considered regexes", function()
-      local u = require("spec.helpers").unindent
-
-      local invalid_paths = {
-        [[/users/(foo/profile]],
-      }
-
-      for i = 1, #invalid_paths do
-        local route = {
-          paths = { invalid_paths[i] },
-        }
-
-        local ok, err = Routes:validate(route)
-        assert.falsy(ok)
-        assert.equal(u([[invalid regex: '/users/(foo/profile' (PCRE returned:
-                         pcre_compile() failed: missing ) in
-                         "/users/(foo/profile")]], true, true), err.paths)
-      end
-    end)
-
-    it("rejects badly percent-encoded values", function()
-      local invalid_paths = {
-        "/some%2words",
-        "/some%0Xwords",
-        "/some%2Gwords",
-        "/some%20words%",
-        "/some%20words%a",
-        "/some%20words%ax",
-      }
-
-      local errstr = { "%2w", "%0X", "%2G", "%", "%a", "%ax" }
-
-      for i = 1, #invalid_paths do
-        local route = {
-          paths = { invalid_paths[i] },
-        }
-
-        local ok, err = Routes:validate(route)
-        assert.falsy(ok)
-        assert.matches("invalid url-encoded value: '" .. errstr[i] .. "'",
-                       err.paths, nil, true)
-      end
-    end)
-
-    -- acceptance
-    it("accepts an apex '/'", function()
-      local route = {
-        protocols = { "http" },
-        service = { id = a_valid_uuid },
-        methods = {},
-        hosts = {},
-        paths = { "/" },
-      }
-
-      local ok, err = Routes:validate(route)
-      assert.is_nil(err)
-      assert.is_true(ok)
-    end)
-
-    it("accepts unreserved characters from RFC 3986", function()
-      local route = {
-        protocols = { "http" },
-        service = { id = a_valid_uuid },
-        methods = {},
-        hosts = {},
-        paths = { "/abcd~user~2" },
-      }
-
-      local ok, err = Routes:validate(route)
-      assert.is_nil(err)
-      assert.is_true(ok)
-    end)
-
-    it("accepts properly percent-encoded values", function()
-      local valid_paths = { "/abcd%aa%10%ff%AA%FF" }
-
-      for i = 1, #valid_paths do
-        local route = {
-          protocols = { "http" },
-          service = { id = a_valid_uuid },
-          methods = {},
-          hosts = {},
-          paths = { valid_paths[i] },
-        }
-
-        local ok, err = Routes:validate(route)
-        assert.is_nil(err)
-        assert.is_true(ok)
-      end
-    end)
-
-    it("accepts trailing slash", function()
-      local route = {
-        protocols = { "http" },
-        service = { id = a_valid_uuid },
-        methods = {},
-        hosts = {},
-        paths = { "/ovo/" },
-      }
-
-      local ok, err = Routes:validate(route)
-      assert.is_nil(err)
-      assert.is_true(ok)
-    end)
-  end)
-
-  describe("hosts attribute", function()
-    -- refusals
-    it("must be a string", function()
-      local route = {
-        hosts = { false },
-      }
-
-      local ok, err = Routes:validate(route)
-      assert.falsy(ok)
-      assert.equal("expected a string", err.hosts)
-    end)
-
-    it("must be a non-empty string", function()
-      local route = {
-        hosts = { "" },
-      }
-
-      local ok, err = Routes:validate(route)
-      assert.falsy(ok)
-      assert.equal("length must be at least 1", err.hosts)
-    end)
-
-    it("rejects invalid hostnames", function()
-      local invalid_hosts = {
-        "/example",
-        ".example",
-        "example.",
-        "example:",
-        "mock;bin",
-        "example.com/org",
-        "example-.org",
-        "example.org-",
-        "hello..example.com",
-        "hello-.example.com",
-      }
-
-      for i = 1, #invalid_hosts do
-        local route = {
-          hosts = { invalid_hosts[i] },
-        }
-
-        local ok, err = Routes:validate(route)
-        assert.falsy(ok)
-        assert.equal("invalid value: " .. invalid_hosts[i], err.hosts)
-      end
-    end)
-
-    it("rejects values with a valid port", function()
-      local route = {
-        hosts = { "example.com:80" }
-      }
-
-      local ok, err = Routes:validate(route)
-      assert.falsy(ok)
-      assert.equal("must not have a port", err.hosts)
-    end)
-
-    it("rejects values with an invalid port", function()
-      local route = {
-        hosts = { "example.com:1000000" }
-      }
-
-      local ok, err = Routes:validate(route)
-      assert.falsy(ok)
-      assert.equal("must not have a port", err.hosts)
-    end)
-
-    it("rejects invalid wildcard placement", function()
-      local invalid_hosts = {
-        "*example.com",
-        "www.example*",
-        "mock*bin.com",
-      }
-
-      for i = 1, #invalid_hosts do
-        local route = {
-          hosts = { invalid_hosts[i] },
-        }
-
-        local ok, err = Routes:validate(route)
-        assert.falsy(ok)
-        assert.equal("invalid wildcard: must be placed at leftmost or " ..
-                     "rightmost label", err.hosts)
-      end
-    end)
-
-    it("rejects host with too many wildcards", function()
-      local invalid_hosts = {
-        "*.example.*",
-        "**.example.com",
-        "*.example*.*",
-      }
-
-      for i = 1, #invalid_hosts do
-        local route = {
-          hosts = { invalid_hosts[i] },
-        }
-
-        local ok, err = Routes:validate(route)
-        assert.falsy(ok)
-        assert.equal("invalid wildcard: must have at most one wildcard",
-                     err.hosts)
-      end
-    end)
-
-    -- acceptance
-    it("accepts valid hosts", function()
-      local valid_hosts = {
-        "hello.com",
-        "hello.fr",
-        "test.hello.com",
-        "1991.io",
-        "hello.COM",
-        "HELLO.com",
-        "123helloWORLD.com",
-        "example.123",
-        "example-api.com",
-        "hello.abcd",
-        "example_api.com",
-        "localhost",
-        -- below:
-        -- punycode examples from RFC3492;
-        -- https://tools.ietf.org/html/rfc3492#page-14
-        -- specifically the japanese ones as they mix
-        -- ascii with escaped characters
-        "3B-ww4c5e180e575a65lsy2b",
-        "-with-SUPER-MONKEYS-pc58ag80a8qai00g7n9n",
-        "Hello-Another-Way--fc4qua05auwb3674vfr0b",
-        "2-u9tlzr9756bt3uc0v",
-        "MajiKoi5-783gue6qz075azm5e",
-        "de-jg4avhby1noc0d",
-        "d9juau41awczczp",
-      }
-
-      for i = 1, #valid_hosts do
-        local route = {
-          protocols = { "http" },
-          service = { id = a_valid_uuid },
-          methods = {},
-          paths = {},
-          hosts = { valid_hosts[i] },
-        }
-
-        local ok, err = Routes:validate(route)
-        assert.is_nil(err)
-        assert.is_true(ok)
-      end
-    end)
-
-    it("accepts hosts with valid wildcard", function()
-      local valid_hosts = {
-        "example.*",
-        "*.example.org",
-      }
-
-      for i = 1, #valid_hosts do
-        local route = {
-          protocols = { "http" },
-          service = { id = a_valid_uuid },
-          methods = {},
-          paths = {},
-          hosts = { valid_hosts[i] },
-        }
-
-        local ok, err = Routes:validate(route)
-        assert.is_nil(err)
-        assert.is_true(ok)
-      end
-    end)
-  end)
-
-  describe("methods attribute", function()
-    -- refusals
-    it("must be a string", function()
-      local route = {
-        methods = { false },
-      }
-
-      local ok, err = Routes:validate(route)
-      assert.falsy(ok)
-      assert.equal("expected a string", err.methods)
-    end)
-
-    it("must be a non-empty string", function()
-      local route = {
-        methods = { "" },
-      }
-
-      local ok, err = Routes:validate(route)
-      assert.falsy(ok)
-      assert.equal("length must be at least 1", err.methods)
-    end)
-
-    it("rejects invalid values", function()
-      local invalid_methods = {
-        "HELLO WORLD",
-        " GET",
-      }
-
-      for i = 1, #invalid_methods do
-        local route = {
-          methods = { invalid_methods[i] },
-        }
-
-        local ok, err = Routes:validate(route)
-        assert.falsy(ok)
-        assert.equal("invalid value: " .. invalid_methods[i],
-                     err.methods)
-      end
-    end)
-
-    it("rejects non-uppercased values", function()
-      local route = {
-        methods = { "get" },
-      }
-
-      local ok, err = Routes:validate(route)
-      assert.falsy(ok)
-      assert.equal("invalid value: get", err.methods)
-    end)
-
-    -- acceptance
-    it("accepts valid HTTP methods", function()
-      local valid_methods = {
-        "GET",
-        "POST",
-        "CUSTOM",
-      }
-
-      for i = 1, #valid_methods do
-        local route = {
-          protocols = { "http" },
-          service = { id = a_valid_uuid },
-          paths = {},
-          hosts = {},
-          methods = { valid_methods[i] },
-        }
-
-        local ok, err = Routes:validate(route)
-        assert.is_nil(err)
-        assert.is_true(ok)
-      end
-    end)
   end)
 
   describe("name attribute", function()
@@ -620,6 +207,437 @@ describe("routes schema", function()
     end)
   end)
 
+  describe("#http context", function()
+    describe("paths attribute", function()
+      -- refusals
+      it("must be a string", function()
+        local route = {
+          paths = { false },
+        }
+
+        local ok, err = Routes:validate(route)
+        assert.falsy(ok)
+        assert.equal("expected a string", err.paths)
+      end)
+
+      it("must be a non-empty string", function()
+        local route = {
+          paths = { "" },
+        }
+
+        local ok, err = Routes:validate(route)
+        assert.falsy(ok)
+        assert.equal("length must be at least 1", err.paths)
+      end)
+
+      it("must start with /", function()
+        local route = {
+          paths = { "foo" },
+        }
+
+        local ok, err = Routes:validate(route)
+        assert.falsy(ok)
+        assert.equal("should start with: /", err.paths)
+      end)
+
+      it("must not have empty segments (/foo//bar)", function()
+        local invalid_paths = {
+          "/foo//bar",
+          "/foo/bar//",
+          "//foo/bar",
+        }
+
+        for i = 1, #invalid_paths do
+          local route = {
+            paths = { invalid_paths[i] },
+          }
+
+          local ok, err = Routes:validate(route)
+          assert.falsy(ok)
+          assert.equal("must not have empty segments", err.paths)
+        end
+      end)
+
+      it("must dry-run values that are considered regexes", function()
+        local u = require("spec.helpers").unindent
+
+        local invalid_paths = {
+          [[/users/(foo/profile]],
+        }
+
+        for i = 1, #invalid_paths do
+          local route = {
+            paths = { invalid_paths[i] },
+          }
+
+          local ok, err = Routes:validate(route)
+          assert.falsy(ok)
+          assert.equal(u([[invalid regex: '/users/(foo/profile' (PCRE returned:
+                           pcre_compile() failed: missing ) in
+                           "/users/(foo/profile")]], true, true), err.paths)
+        end
+      end)
+
+      it("rejects badly percent-encoded values", function()
+        local invalid_paths = {
+          "/some%2words",
+          "/some%0Xwords",
+          "/some%2Gwords",
+          "/some%20words%",
+          "/some%20words%a",
+          "/some%20words%ax",
+        }
+
+        local errstr = { "%2w", "%0X", "%2G", "%", "%a", "%ax" }
+
+        for i = 1, #invalid_paths do
+          local route = {
+            paths = { invalid_paths[i] },
+          }
+
+          local ok, err = Routes:validate(route)
+          assert.falsy(ok)
+          assert.matches("invalid url-encoded value: '" .. errstr[i] .. "'",
+                         err.paths, nil, true)
+        end
+      end)
+
+      -- acceptance
+      it("accepts an apex '/'", function()
+        local route = {
+          protocols = { "http" },
+          service = { id = a_valid_uuid },
+          methods = {},
+          hosts = {},
+          paths = { "/" },
+        }
+
+        local ok, err = Routes:validate(route)
+        assert.is_nil(err)
+        assert.is_true(ok)
+      end)
+
+      it("accepts unreserved characters from RFC 3986", function()
+        local route = {
+          protocols = { "http" },
+          service = { id = a_valid_uuid },
+          methods = {},
+          hosts = {},
+          paths = { "/abcd~user~2" },
+        }
+
+        local ok, err = Routes:validate(route)
+        assert.is_nil(err)
+        assert.is_true(ok)
+      end)
+
+      it("accepts properly percent-encoded values", function()
+        local valid_paths = { "/abcd%aa%10%ff%AA%FF" }
+
+        for i = 1, #valid_paths do
+          local route = {
+            protocols = { "http" },
+            service = { id = a_valid_uuid },
+            methods = {},
+            hosts = {},
+            paths = { valid_paths[i] },
+          }
+
+          local ok, err = Routes:validate(route)
+          assert.is_nil(err)
+          assert.is_true(ok)
+        end
+      end)
+
+      it("accepts trailing slash", function()
+        local route = {
+          protocols = { "http" },
+          service = { id = a_valid_uuid },
+          methods = {},
+          hosts = {},
+          paths = { "/ovo/" },
+        }
+
+        local ok, err = Routes:validate(route)
+        assert.is_nil(err)
+        assert.is_true(ok)
+      end)
+    end)
+
+    describe("hosts attribute", function()
+      -- refusals
+      it("must be a string", function()
+        local route = {
+          hosts = { false },
+        }
+
+        local ok, err = Routes:validate(route)
+        assert.falsy(ok)
+        assert.equal("expected a string", err.hosts)
+      end)
+
+      it("must be a non-empty string", function()
+        local route = {
+          hosts = { "" },
+        }
+
+        local ok, err = Routes:validate(route)
+        assert.falsy(ok)
+        assert.equal("length must be at least 1", err.hosts)
+      end)
+
+      it("rejects invalid hostnames", function()
+        local invalid_hosts = {
+          "/example",
+          ".example",
+          "example.",
+          "example:",
+          "mock;bin",
+          "example.com/org",
+          "example-.org",
+          "example.org-",
+          "hello..example.com",
+          "hello-.example.com",
+        }
+
+        for i = 1, #invalid_hosts do
+          local route = {
+            hosts = { invalid_hosts[i] },
+          }
+
+          local ok, err = Routes:validate(route)
+          assert.falsy(ok)
+          assert.equal("invalid value: " .. invalid_hosts[i], err.hosts)
+        end
+      end)
+
+      it("rejects values with a valid port", function()
+        local route = {
+          hosts = { "example.com:80" }
+        }
+
+        local ok, err = Routes:validate(route)
+        assert.falsy(ok)
+        assert.equal("must not have a port", err.hosts)
+      end)
+
+      it("rejects values with an invalid port", function()
+        local route = {
+          hosts = { "example.com:1000000" }
+        }
+
+        local ok, err = Routes:validate(route)
+        assert.falsy(ok)
+        assert.equal("must not have a port", err.hosts)
+      end)
+
+      it("rejects invalid wildcard placement", function()
+        local invalid_hosts = {
+          "*example.com",
+          "www.example*",
+          "mock*bin.com",
+        }
+
+        for i = 1, #invalid_hosts do
+          local route = {
+            hosts = { invalid_hosts[i] },
+          }
+
+          local ok, err = Routes:validate(route)
+          assert.falsy(ok)
+          assert.equal("invalid wildcard: must be placed at leftmost or " ..
+                       "rightmost label", err.hosts)
+        end
+      end)
+
+      it("rejects host with too many wildcards", function()
+        local invalid_hosts = {
+          "*.example.*",
+          "**.example.com",
+          "*.example*.*",
+        }
+
+        for i = 1, #invalid_hosts do
+          local route = {
+            hosts = { invalid_hosts[i] },
+          }
+
+          local ok, err = Routes:validate(route)
+          assert.falsy(ok)
+          assert.equal("invalid wildcard: must have at most one wildcard",
+                       err.hosts)
+        end
+      end)
+
+      -- acceptance
+      it("accepts valid hosts", function()
+        local valid_hosts = {
+          "hello.com",
+          "hello.fr",
+          "test.hello.com",
+          "1991.io",
+          "hello.COM",
+          "HELLO.com",
+          "123helloWORLD.com",
+          "example.123",
+          "example-api.com",
+          "hello.abcd",
+          "example_api.com",
+          "localhost",
+          -- below:
+          -- punycode examples from RFC3492;
+          -- https://tools.ietf.org/html/rfc3492#page-14
+          -- specifically the japanese ones as they mix
+          -- ascii with escaped characters
+          "3B-ww4c5e180e575a65lsy2b",
+          "-with-SUPER-MONKEYS-pc58ag80a8qai00g7n9n",
+          "Hello-Another-Way--fc4qua05auwb3674vfr0b",
+          "2-u9tlzr9756bt3uc0v",
+          "MajiKoi5-783gue6qz075azm5e",
+          "de-jg4avhby1noc0d",
+          "d9juau41awczczp",
+        }
+
+        for i = 1, #valid_hosts do
+          local route = {
+            protocols = { "http" },
+            service = { id = a_valid_uuid },
+            methods = {},
+            paths = {},
+            hosts = { valid_hosts[i] },
+          }
+
+          local ok, err = Routes:validate(route)
+          assert.is_nil(err)
+          assert.is_true(ok)
+        end
+      end)
+
+      it("accepts hosts with valid wildcard", function()
+        local valid_hosts = {
+          "example.*",
+          "*.example.org",
+        }
+
+        for i = 1, #valid_hosts do
+          local route = {
+            protocols = { "http" },
+            service = { id = a_valid_uuid },
+            methods = {},
+            paths = {},
+            hosts = { valid_hosts[i] },
+          }
+
+          local ok, err = Routes:validate(route)
+          assert.is_nil(err)
+          assert.is_true(ok)
+        end
+      end)
+    end)
+
+    describe("methods attribute", function()
+      -- refusals
+      it("fails given an invalid method", function()
+        local route = {
+          protocols = { "http" },
+          methods = { "get" },
+        }
+        route = Routes:process_auto_fields(route, "insert")
+        local ok, errs = Routes:validate(route)
+        assert.falsy(ok)
+        assert.truthy(errs["methods"])
+      end)
+
+      it("must be a string", function()
+        local route = {
+          methods = { false },
+        }
+
+        local ok, err = Routes:validate(route)
+        assert.falsy(ok)
+        assert.equal("expected a string", err.methods)
+      end)
+
+      it("must be a non-empty string", function()
+        local route = {
+          methods = { "" },
+        }
+
+        local ok, err = Routes:validate(route)
+        assert.falsy(ok)
+        assert.equal("length must be at least 1", err.methods)
+      end)
+
+      it("rejects invalid values", function()
+        local invalid_methods = {
+          "HELLO WORLD",
+          " GET",
+        }
+
+        for i = 1, #invalid_methods do
+          local route = {
+            methods = { invalid_methods[i] },
+          }
+
+          local ok, err = Routes:validate(route)
+          assert.falsy(ok)
+          assert.equal("invalid value: " .. invalid_methods[i],
+                       err.methods)
+        end
+      end)
+
+      it("rejects non-uppercased values", function()
+        local route = {
+          methods = { "get" },
+        }
+
+        local ok, err = Routes:validate(route)
+        assert.falsy(ok)
+        assert.equal("invalid value: get", err.methods)
+      end)
+
+      -- acceptance
+      it("accepts valid HTTP methods", function()
+        local valid_methods = {
+          "GET",
+          "POST",
+          "CUSTOM",
+        }
+
+        for i = 1, #valid_methods do
+          local route = {
+            protocols = { "http" },
+            service = { id = a_valid_uuid },
+            paths = {},
+            hosts = {},
+            methods = { valid_methods[i] },
+          }
+
+          local ok, err = Routes:validate(route)
+          assert.is_nil(err)
+          assert.is_true(ok)
+        end
+      end)
+    end)
+
+    it("errors if no L7 matching attribute set", function()
+      local s = { id = "a4fbd24e-6a52-4937-bd78-2536713072d2" }
+        for _, v in ipairs({ "http", "https" }) do
+          local route = Routes:process_auto_fields({
+            protocols = { v },
+            service = s,
+          }, "insert")
+          local ok, errs = Routes:validate(route)
+          assert.falsy(ok)
+          assert.same({
+            ["@entity"] = {
+              "must set one of 'methods', 'hosts', 'paths', 'sources', 'destinations', 'snis' when 'protocols' is 'http' or 'https'"
+            }
+          }, errs)
+        end
+    end)
+  end)
+
   describe("#stream context", function()
     it("'protocol' accepts 'tcp'", function()
       local s = { id = "a4fbd24e-6a52-4937-bd78-2536713072d2" }
@@ -684,157 +702,6 @@ describe("routes schema", function()
       end
     end)
 
-    describe("'sources' and 'destinations' matching attributes", function()
-      local s = { id = "a4fbd24e-6a52-4937-bd78-2536713072d2" }
-      for _, v in ipairs({
-        "sources",
-        "destinations"
-      }) do
-        it("'" .. v .. "' accepts valid IPs and ports", function()
-          for _, protocol in ipairs({ "tcp", "tls" }) do
-            local route = Routes:process_auto_fields({
-              protocols = { protocol },
-              [v] = {
-                { ip = "127.75.78.72", port = 8000 },
-              },
-              service = s,
-            }, "insert")
-            local ok, errs = Routes:validate(route)
-            assert.is_nil(errs)
-            assert.truthy(ok)
-            assert.same({ protocol }, route.protocols)
-            assert.same({ ip = "127.75.78.72", port = 8000 }, route[v][1])
-          end
-        end)
-
-        it("'" .. v .. "' accepts valid IPs (no port)", function()
-          for _, protocol in ipairs({ "tcp", "tls" }) do
-            local route = Routes:process_auto_fields({
-              protocols = { protocol },
-              [v] = {
-                { ip = "127.0.0.1" },
-                { ip = "127.75.78.72", port = 8000 },
-              },
-              service = s,
-            }, "insert")
-            local ok, errs = Routes:validate(route)
-            assert.is_nil(errs)
-            assert.truthy(ok)
-            assert.same({ protocol }, route.protocols)
-            assert.same({ ip = "127.0.0.1" }, route[v][1])
-          end
-        end)
-
-        it("'" .. v .. "' accepts valid ports (no IP)", function()
-          for _, protocol in ipairs({ "tcp", "tls" }) do
-            local route = Routes:process_auto_fields({
-              protocols = { protocol },
-              [v] = {
-                { port = 8000 },
-                { ip = "127.75.78.72", port = 8000 },
-              },
-              service = s,
-            }, "insert")
-            local ok, errs = Routes:validate(route)
-            assert.is_nil(errs)
-            assert.truthy(ok)
-            assert.same({ protocol }, route.protocols)
-            assert.same({ port = 8000 }, route[v][1])
-          end
-        end)
-
-        it("'" .. v .. "' rejects invalid 'port' values", function()
-          for _, protocol in ipairs({ "tcp", "tls" }) do
-            local route = Routes:process_auto_fields({
-              protocols = { protocol },
-              [v] = {
-                { ip = "127.0.0.1" },
-                { ip = "127.75.78.72", port = 65536 },
-              },
-              service = s,
-            }, "insert")
-            local ok, errs = Routes:validate(route)
-            assert.falsy(ok)
-            assert.same({
-              [v] = { port = "value should be between 0 and 65535" },
-            }, errs)
-          end
-        end)
-
-        it("'" .. v .. "' rejects invalid 'ip' values", function()
-          -- invalid IPs
-          for _, ip_val in ipairs({ "127.", ":::1", "1" }) do
-            for _, protocol in ipairs({ "tcp", "tls" }) do
-              local route = Routes:process_auto_fields({
-                protocols = { protocol },
-                [v] = {
-                  { ip = ip_val },
-                  { ip = "127.75.78.72", port = 8000 },
-                },
-                service = s,
-              }, "insert")
-              local ok, errs = Routes:validate(route)
-              assert.falsy(ok, "ip test value was valid: " .. ip_val)
-              assert.matches("invalid cidr range: Invalid IP", errs[v].ip)
-            end
-          end
-
-          -- hostnames
-          for _, ip_val in ipairs({ "f", "example.org" }) do
-            for _, protocol in ipairs({ "tcp", "tls" }) do
-              local route = Routes:process_auto_fields({
-                protocols = { protocol },
-                [v] = {
-                  { ip = ip_val },
-                  { ip = "127.75.78.72", port = 8000 },
-                },
-                service = s,
-              }, "insert")
-              local ok, errs = Routes:validate(route)
-              assert.falsy(ok, "ip test value was valid: " .. ip_val)
-              assert.matches("invalid cidr range: Invalid IP", errs[v].ip)
-            end
-          end
-        end)
-      end
-    end)
-
-    describe("'snis' matching attribute", function()
-      local s = { id = "a4fbd24e-6a52-4937-bd78-2536713072d2" }
-
-      it("accepts valid SNIs", function()
-        for _, sni in ipairs({ "example.org", "www.example.org" }) do
-          local route = Routes:process_auto_fields({
-            protocols = { "tcp", "tls" },
-            snis = { sni },
-            service = s,
-          }, "insert")
-          local ok, errs = Routes:validate(route)
-          assert.is_nil(errs)
-          assert.truthy(ok)
-        end
-      end)
-
-      it("rejects invalid SNIs", function()
-        for _, sni in ipairs({ "127.0.0.1", "example.org:80" }) do
-          local route = Routes:process_auto_fields({
-            protocols = { "tcp", "tls" },
-            snis = { sni },
-            service = s,
-          }, "insert")
-          local ok, errs = Routes:validate(route)
-          assert.falsy(ok, "sni test value was valid: " .. sni)
-          if not pcall(function()
-                         assert.matches("must not be an IP", errs.snis, nil,
-                                        true)
-                       end)
-          then
-            assert.matches("must not have a port", errs.snis, nil, true)
-          end
-        end
-      end)
-    end)
-
     it("errors if no L4 matching attribute set", function()
       local s = { id = "a4fbd24e-6a52-4937-bd78-2536713072d2" }
       for _, v in ipairs({ "tcp", "tls" }) do
@@ -853,20 +720,154 @@ describe("routes schema", function()
     end)
   end)
 
-  it("errors if no L7 matching attribute set", function()
+  describe("'sources' and 'destinations' matching attributes", function()
     local s = { id = "a4fbd24e-6a52-4937-bd78-2536713072d2" }
-      for _, v in ipairs({ "http", "https" }) do
+    for _, v in ipairs({
+      "sources",
+      "destinations"
+    }) do
+      it("'" .. v .. "' accepts valid IPs and ports", function()
+        for _, protocol in ipairs({ "http", "https", "tcp", "tls" }) do
+          local route = Routes:process_auto_fields({
+            protocols = { protocol },
+            [v] = {
+              { ip = "127.75.78.72", port = 8000 },
+            },
+            service = s,
+          }, "insert")
+          local ok, errs = Routes:validate(route)
+          assert.is_nil(errs)
+          assert.truthy(ok)
+          assert.same({ protocol }, route.protocols)
+          assert.same({ ip = "127.75.78.72", port = 8000 }, route[v][1])
+        end
+      end)
+
+      it("'" .. v .. "' accepts valid IPs (no port)", function()
+        for _, protocol in ipairs({ "http", "https", "tcp", "tls" }) do
+          local route = Routes:process_auto_fields({
+            protocols = { protocol },
+            [v] = {
+              { ip = "127.0.0.1" },
+              { ip = "127.75.78.72", port = 8000 },
+            },
+            service = s,
+          }, "insert")
+          local ok, errs = Routes:validate(route)
+          assert.is_nil(errs)
+          assert.truthy(ok)
+          assert.same({ protocol }, route.protocols)
+          assert.same({ ip = "127.0.0.1" }, route[v][1])
+        end
+      end)
+
+      it("'" .. v .. "' accepts valid ports (no IP)", function()
+        for _, protocol in ipairs({ "http", "https", "tcp", "tls" }) do
+          local route = Routes:process_auto_fields({
+            protocols = { protocol },
+            [v] = {
+              { port = 8000 },
+              { ip = "127.75.78.72", port = 8000 },
+            },
+            service = s,
+          }, "insert")
+          local ok, errs = Routes:validate(route)
+          assert.is_nil(errs)
+          assert.truthy(ok)
+          assert.same({ protocol }, route.protocols)
+          assert.same({ port = 8000 }, route[v][1])
+        end
+      end)
+
+      it("'" .. v .. "' rejects invalid 'port' values", function()
+        for _, protocol in ipairs({ "http", "https", "tcp", "tls" }) do
+          local route = Routes:process_auto_fields({
+            protocols = { protocol },
+            [v] = {
+              { ip = "127.0.0.1" },
+              { ip = "127.75.78.72", port = 65536 },
+            },
+            service = s,
+          }, "insert")
+          local ok, errs = Routes:validate(route)
+          assert.falsy(ok)
+          assert.same({
+            [v] = { port = "value should be between 0 and 65535" },
+          }, errs)
+        end
+      end)
+
+      it("'" .. v .. "' rejects invalid 'ip' values", function()
+        -- invalid IPs
+        for _, ip_val in ipairs({ "127.", ":::1", "1" }) do
+          for _, protocol in ipairs({ "http", "https", "tcp", "tls" }) do
+            local route = Routes:process_auto_fields({
+              protocols = { protocol },
+              [v] = {
+                { ip = ip_val },
+                { ip = "127.75.78.72", port = 8000 },
+              },
+              service = s,
+            }, "insert")
+            local ok, errs = Routes:validate(route)
+            assert.falsy(ok, "ip test value was valid: " .. ip_val)
+            assert.matches("invalid cidr range: Invalid IP", errs[v].ip)
+          end
+        end
+
+        -- hostnames
+        for _, ip_val in ipairs({ "f", "example.org" }) do
+          for _, protocol in ipairs({ "http", "https", "tcp", "tls" }) do
+            local route = Routes:process_auto_fields({
+              protocols = { protocol },
+              [v] = {
+                { ip = ip_val },
+                { ip = "127.75.78.72", port = 8000 },
+              },
+              service = s,
+            }, "insert")
+            local ok, errs = Routes:validate(route)
+            assert.falsy(ok, "ip test value was valid: " .. ip_val)
+            assert.matches("invalid cidr range: Invalid IP", errs[v].ip)
+          end
+        end
+      end)
+    end
+  end)
+
+  describe("'snis' matching attribute", function()
+    local s = { id = "a4fbd24e-6a52-4937-bd78-2536713072d2" }
+
+    it("accepts valid SNIs", function()
+      for _, sni in ipairs({ "example.org", "www.example.org" }) do
         local route = Routes:process_auto_fields({
-          protocols = { v },
+          protocols = { "http", "https", "tcp", "tls" },
+          snis = { sni },
           service = s,
         }, "insert")
         local ok, errs = Routes:validate(route)
-        assert.falsy(ok)
-        assert.same({
-          ["@entity"] = {
-            "must set one of 'methods', 'hosts', 'paths' when 'protocols' is 'http' or 'https'"
-          }
-        }, errs)
+        assert.is_nil(errs)
+        assert.truthy(ok)
       end
+    end)
+
+    it("rejects invalid SNIs", function()
+      for _, sni in ipairs({ "127.0.0.1", "example.org:80" }) do
+        local route = Routes:process_auto_fields({
+          protocols = { "http", "https", "tcp", "tls" },
+          snis = { sni },
+          service = s,
+        }, "insert")
+        local ok, errs = Routes:validate(route)
+        assert.falsy(ok, "sni test value was valid: " .. sni)
+        if not pcall(function()
+                       assert.matches("must not be an IP", errs.snis, nil,
+                                      true)
+                     end)
+        then
+          assert.matches("must not have a port", errs.snis, nil, true)
+        end
+      end
+    end)
   end)
 end)

--- a/spec/01-unit/010-router_spec.lua
+++ b/spec/01-unit/010-router_spec.lua
@@ -1968,205 +1968,202 @@ describe("Router", function()
     end)
   end)
 
-
-  describe("#stream context", function()
-    describe("[sources]", function()
-      local use_case = {
-        -- plain
-        {
-          service = service,
-          route = {
-            sources = {
-              { ip = "127.0.0.1" },
-              { ip = "127.0.0.2" },
-            }
+  describe("[sources]", function()
+    local use_case = {
+      -- plain
+      {
+        service = service,
+        route = {
+          sources = {
+            { ip = "127.0.0.1" },
+            { ip = "127.0.0.2" },
           }
-        },
-        {
-          service = service,
-          route = {
-            sources = {
-              { port = 65001 },
-              { port = 65002 },
-            }
+        }
+      },
+      {
+        service = service,
+        route = {
+          sources = {
+            { port = 65001 },
+            { port = 65002 },
           }
-        },
-        -- range
-        {
-          service = service,
-          route = {
-            sources = {
-              { ip = "127.168.0.0/8" },
-            }
+        }
+      },
+      -- range
+      {
+        service = service,
+        route = {
+          sources = {
+            { ip = "127.168.0.0/8" },
           }
-        },
-        -- ip + port
-        {
-          service = service,
-          route = {
-            sources = {
-              { ip = "127.0.0.1", port = 65001 },
-            }
+        }
+      },
+      -- ip + port
+      {
+        service = service,
+        route = {
+          sources = {
+            { ip = "127.0.0.1", port = 65001 },
           }
-        },
-        {
-          service = service,
-          route = {
-            sources = {
-              { ip = "127.0.0.2", port = 65300 },
-              { ip = "127.168.0.0/16", port = 65301 },
-            }
+        }
+      },
+      {
+        service = service,
+        route = {
+          sources = {
+            { ip = "127.0.0.2", port = 65300 },
+            { ip = "127.168.0.0/16", port = 65301 },
           }
-        },
-      }
+        }
+      },
+    }
 
-      local router = assert(Router.new(use_case))
+    local router = assert(Router.new(use_case))
 
-      it("[src_ip]", function()
-        local match_t = router.select(nil, nil, nil, nil, "127.0.0.1")
-        assert.truthy(match_t)
-        assert.same(use_case[1].route, match_t.route)
+    it("[src_ip]", function()
+      local match_t = router.select(nil, nil, nil, nil, "127.0.0.1")
+      assert.truthy(match_t)
+      assert.same(use_case[1].route, match_t.route)
 
-        match_t = router.select(nil, nil, nil, nil, "127.0.0.1")
-        assert.truthy(match_t)
-        assert.same(use_case[1].route, match_t.route)
-      end)
-
-      it("[src_port]", function()
-        local match_t = router.select(nil, nil, nil, nil, "127.0.0.3", 65001)
-        assert.truthy(match_t)
-        assert.same(use_case[2].route, match_t.route)
-      end)
-
-      it("[src_ip] range match", function()
-        local match_t = router.select(nil, nil, nil, nil, "127.168.0.1")
-        assert.truthy(match_t)
-        assert.same(use_case[3].route, match_t.route)
-      end)
-
-      it("[src_ip] + [src_port]", function()
-        local match_t = router.select(nil, nil, nil, nil, "127.0.0.1", 65001)
-        assert.truthy(match_t)
-        assert.same(use_case[4].route, match_t.route)
-      end)
-
-      it("[src_ip] range match + [src_port]", function()
-        local match_t = router.select(nil, nil, nil, nil, "127.168.10.1", 65301)
-        assert.truthy(match_t)
-        assert.same(use_case[5].route, match_t.route)
-      end)
-
-      it("[src_ip] no match", function()
-        local match_t = router.select(nil, nil, nil, nil, "10.0.0.1")
-        assert.falsy(match_t)
-
-        match_t = router.select(nil, nil, nil, nil, "10.0.0.2", 65301)
-        assert.falsy(match_t)
-      end)
+      match_t = router.select(nil, nil, nil, nil, "127.0.0.1")
+      assert.truthy(match_t)
+      assert.same(use_case[1].route, match_t.route)
     end)
 
+    it("[src_port]", function()
+      local match_t = router.select(nil, nil, nil, nil, "127.0.0.3", 65001)
+      assert.truthy(match_t)
+      assert.same(use_case[2].route, match_t.route)
+    end)
 
-    describe("[destinations]", function()
-      local use_case = {
-        -- plain
-        {
-          service = service,
-          route = {
-            destinations = {
-              { ip = "127.0.0.1" },
-              { ip = "127.0.0.2" },
-            }
+    it("[src_ip] range match", function()
+      local match_t = router.select(nil, nil, nil, nil, "127.168.0.1")
+      assert.truthy(match_t)
+      assert.same(use_case[3].route, match_t.route)
+    end)
+
+    it("[src_ip] + [src_port]", function()
+      local match_t = router.select(nil, nil, nil, nil, "127.0.0.1", 65001)
+      assert.truthy(match_t)
+      assert.same(use_case[4].route, match_t.route)
+    end)
+
+    it("[src_ip] range match + [src_port]", function()
+      local match_t = router.select(nil, nil, nil, nil, "127.168.10.1", 65301)
+      assert.truthy(match_t)
+      assert.same(use_case[5].route, match_t.route)
+    end)
+
+    it("[src_ip] no match", function()
+      local match_t = router.select(nil, nil, nil, nil, "10.0.0.1")
+      assert.falsy(match_t)
+
+      match_t = router.select(nil, nil, nil, nil, "10.0.0.2", 65301)
+      assert.falsy(match_t)
+    end)
+  end)
+
+
+  describe("[destinations]", function()
+    local use_case = {
+      -- plain
+      {
+        service = service,
+        route = {
+          destinations = {
+            { ip = "127.0.0.1" },
+            { ip = "127.0.0.2" },
           }
-        },
-        {
-          service = service,
-          route = {
-            destinations = {
-              { port = 65001 },
-              { port = 65002 },
-            }
+        }
+      },
+      {
+        service = service,
+        route = {
+          destinations = {
+            { port = 65001 },
+            { port = 65002 },
           }
-        },
-        -- range
-        {
-          service = service,
-          route = {
-            destinations = {
-              { ip = "127.168.0.0/8" },
-            }
+        }
+      },
+      -- range
+      {
+        service = service,
+        route = {
+          destinations = {
+            { ip = "127.168.0.0/8" },
           }
-        },
-        -- ip + port
-        {
-          service = service,
-          route = {
-            destinations = {
-              { ip = "127.0.0.1", port = 65001 },
-            }
+        }
+      },
+      -- ip + port
+      {
+        service = service,
+        route = {
+          destinations = {
+            { ip = "127.0.0.1", port = 65001 },
           }
-        },
-        {
-          service = service,
-          route = {
-            destinations = {
-              { ip = "127.0.0.2", port = 65300 },
-              { ip = "127.168.0.0/16", port = 65301 },
-            }
+        }
+      },
+      {
+        service = service,
+        route = {
+          destinations = {
+            { ip = "127.0.0.2", port = 65300 },
+            { ip = "127.168.0.0/16", port = 65301 },
           }
-        },
-      }
+        }
+      },
+    }
 
-      local router = assert(Router.new(use_case))
+    local router = assert(Router.new(use_case))
 
-      it("[dst_ip]", function()
-        local match_t = router.select(nil, nil, nil, nil, nil, nil,
-                                      "127.0.0.1")
-        assert.truthy(match_t)
-        assert.same(use_case[1].route, match_t.route)
+    it("[dst_ip]", function()
+      local match_t = router.select(nil, nil, nil, nil, nil, nil,
+                                    "127.0.0.1")
+      assert.truthy(match_t)
+      assert.same(use_case[1].route, match_t.route)
 
-        match_t = router.select(nil, nil, nil, nil, nil, nil,
-                                "127.0.0.1")
-        assert.truthy(match_t)
-        assert.same(use_case[1].route, match_t.route)
-      end)
+      match_t = router.select(nil, nil, nil, nil, nil, nil,
+                              "127.0.0.1")
+      assert.truthy(match_t)
+      assert.same(use_case[1].route, match_t.route)
+    end)
 
-      it("[dst_port]", function()
-        local match_t = router.select(nil, nil, nil, nil, nil, nil,
-                                      "127.0.0.3", 65001)
-        assert.truthy(match_t)
-        assert.same(use_case[2].route, match_t.route)
-      end)
+    it("[dst_port]", function()
+      local match_t = router.select(nil, nil, nil, nil, nil, nil,
+                                    "127.0.0.3", 65001)
+      assert.truthy(match_t)
+      assert.same(use_case[2].route, match_t.route)
+    end)
 
-      it("[dst_ip] range match", function()
-        local match_t = router.select(nil, nil, nil, nil, nil, nil,
-                                      "127.168.0.1")
-        assert.truthy(match_t)
-        assert.same(use_case[3].route, match_t.route)
-      end)
+    it("[dst_ip] range match", function()
+      local match_t = router.select(nil, nil, nil, nil, nil, nil,
+                                    "127.168.0.1")
+      assert.truthy(match_t)
+      assert.same(use_case[3].route, match_t.route)
+    end)
 
-      it("[dst_ip] + [dst_port]", function()
-        local match_t = router.select(nil, nil, nil, nil, nil, nil,
-                                      "127.0.0.1", 65001)
-        assert.truthy(match_t)
-        assert.same(use_case[4].route, match_t.route)
-      end)
+    it("[dst_ip] + [dst_port]", function()
+      local match_t = router.select(nil, nil, nil, nil, nil, nil,
+                                    "127.0.0.1", 65001)
+      assert.truthy(match_t)
+      assert.same(use_case[4].route, match_t.route)
+    end)
 
-      it("[dst_ip] range match + [dst_port]", function()
-        local match_t = router.select(nil, nil, nil, nil, nil, nil,
-                                      "127.168.10.1", 65301)
-        assert.truthy(match_t)
-        assert.same(use_case[5].route, match_t.route)
-      end)
+    it("[dst_ip] range match + [dst_port]", function()
+      local match_t = router.select(nil, nil, nil, nil, nil, nil,
+                                    "127.168.10.1", 65301)
+      assert.truthy(match_t)
+      assert.same(use_case[5].route, match_t.route)
+    end)
 
-      it("[dst_ip] no match", function()
-        local match_t = router.select(nil, nil, nil, nil, nil, nil,
-                                      "10.0.0.1")
-        assert.falsy(match_t)
+    it("[dst_ip] no match", function()
+      local match_t = router.select(nil, nil, nil, nil, nil, nil,
+                                    "10.0.0.1")
+      assert.falsy(match_t)
 
-        match_t = router.select(nil, nil, nil, nil, nil, nil,
-                                "10.0.0.2", 65301)
-        assert.falsy(match_t)
-      end)
+      match_t = router.select(nil, nil, nil, nil, nil, nil,
+                              "10.0.0.2", 65301)
+      assert.falsy(match_t)
     end)
 
 

--- a/spec/02-integration/000-new-dao/02-db_core_entities_spec.lua
+++ b/spec/02-integration/000-new-dao/02-db_core_entities_spec.lua
@@ -57,13 +57,13 @@ for _, strategy in helpers.each_strategy() do
             strategy = strategy,
             message  = unindent([[
               2 schema violations
-              (must set one of 'methods', 'hosts', 'paths' when 'protocols' is 'http' or 'https';
+              (must set one of 'methods', 'hosts', 'paths', 'sources', 'destinations', 'snis' when 'protocols' is 'http' or 'https';
               service: required field missing)
             ]], true, true),
             fields   = {
               service     = "required field missing",
               ["@entity"] = {
-                "must set one of 'methods', 'hosts', 'paths' when 'protocols' is 'http' or 'https'",
+                "must set one of 'methods', 'hosts', 'paths', 'sources', 'destinations', 'snis' when 'protocols' is 'http' or 'https'",
               }
             },
 
@@ -197,6 +197,9 @@ for _, strategy in helpers.each_strategy() do
             regex_priority  = 0,
             preserve_host   = false,
             strip_path      = true,
+            snis            = ngx.null,
+            sources         = ngx.null,
+            destinations    = ngx.null,
             service         = route.service,
           }, route)
         end)
@@ -233,6 +236,9 @@ for _, strategy in helpers.each_strategy() do
             regex_priority  = 3,
             strip_path      = true,
             preserve_host   = false,
+            snis            = ngx.null,
+            sources         = ngx.null,
+            destinations    = ngx.null,
             service         = route.service,
           }, route)
         end)
@@ -267,35 +273,48 @@ for _, strategy in helpers.each_strategy() do
           assert.not_equal(0, route.updated_at)
         end)
 
-        describe("#stream context", function()
-          it("creates a Route with 'snis'", function()
-            local route, err, err_t = db.routes:insert({
-              protocols = { "tcp" },
-              snis      = { "example.com" },
-              service   = bp.services:insert(),
-            })
-            assert.is_nil(err_t)
-            assert.is_nil(err)
-            assert.is_table(route)
-          end)
+<<<<<<< HEAD
+        it("creates a Route with 'snis'", function()
+          local route, err, err_t = db.routes:insert({
+            protocols = { "tcp" },
+            snis      = { "example.com" },
+            service   = bp.services:insert(),
+          })
+          assert.is_nil(err_t)
+          assert.is_nil(err)
+          assert.is_table(route)
+        end)
 
-          it("creates a Route with 'sources' and 'destinations'", function()
-            local route, err, err_t = db.routes:insert({
-              protocols  = { "tcp" },
-              sources    = {
-                { ip = "127.0.0.1" },
-                { ip = "127.75.78.72", port = 8000 },
-              },
-              destinations = {
-                { ip = "127.0.0.1" },
-                { ip = "127.75.78.72", port = 8000 },
-              },
-              service = bp.services:insert(),
-            })
-            assert.is_nil(err_t)
-            assert.is_nil(err)
-            assert.is_table(route)
-          end)
+=======
+
+        it("creates a Route with 'snis'", function()
+          local route, err, err_t = db.routes:insert({
+            protocols = { "tcp" },
+            snis      = { "example.com" },
+            service   = bp.services:insert(),
+          })
+          assert.is_nil(err_t)
+          assert.is_nil(err)
+          assert.is_table(route)
+        end)
+
+>>>>>>> 8680f72d... feat(schema) add sni, source and destination routing attributes
+        it("creates a Route with 'sources' and 'destinations'", function()
+          local route, err, err_t = db.routes:insert({
+            protocols  = { "tcp" },
+            sources    = {
+              { ip = "127.0.0.1" },
+              { ip = "127.75.78.72", port = 8000 },
+            },
+            destinations = {
+              { ip = "127.0.0.1" },
+              { ip = "127.75.78.72", port = 8000 },
+            },
+            service = bp.services:insert(),
+          })
+          assert.is_nil(err_t)
+          assert.is_nil(err)
+          assert.is_table(route)
         end)
 
         pending("cannot create a Route with an existing PK", function()
@@ -332,29 +351,27 @@ for _, strategy in helpers.each_strategy() do
           assert.same(route_inserted, route)
         end)
 
-        describe("#stream context", function()
-          it("returns a Route with L4 matching properties", function()
-            local route_inserted, err = db.routes:insert({
-              protocols  = { "tcp" },
-              snis       = { "example.com" },
-              sources    = {
-                { ip = "127.0.0.1" },
-                { ip = "127.75.78.72", port = 8000 },
-              },
-              destinations = {
-                { ip = "127.0.0.1" },
-                { ip = "127.75.78.72", port = 8000 },
-              },
-              service = bp.services:insert(),
-            })
-            assert.is_nil(err)
-            local route, err, err_t = db.routes:select({
-              id = route_inserted.id
-            })
-            assert.is_nil(err_t)
-            assert.is_nil(err)
-            assert.same(route_inserted, route)
-          end)
+        it("returns a Route with L4 matching properties", function()
+          local route_inserted, err = db.routes:insert({
+            protocols  = { "tcp" },
+            snis       = { "example.com" },
+            sources    = {
+              { ip = "127.0.0.1" },
+              { ip = "127.75.78.72", port = 8000 },
+            },
+            destinations = {
+              { ip = "127.0.0.1" },
+              { ip = "127.75.78.72", port = 8000 },
+            },
+            service = bp.services:insert(),
+          })
+          assert.is_nil(err)
+          local route, err, err_t = db.routes:select({
+            id = route_inserted.id
+          })
+          assert.is_nil(err_t)
+          assert.is_nil(err)
+          assert.same(route_inserted, route)
         end)
       end)
 
@@ -391,7 +408,11 @@ for _, strategy in helpers.each_strategy() do
           local pk = { id = utils.uuid() }
           local new_route, err, err_t = db.routes:update(pk, {
             protocols = { "https" },
+<<<<<<< HEAD
             hosts = { "example.com" },
+=======
+            hosts     = { "example.com" },
+>>>>>>> feat(schema) add sni, source and destination routing attributes
           })
           assert.is_nil(new_route)
           local message = fmt(
@@ -419,7 +440,11 @@ for _, strategy in helpers.each_strategy() do
 
           local new_route, err, err_t = db.routes:update({ id = route.id }, {
             protocols = { "https" },
+<<<<<<< HEAD
             hosts = { "example.com" },
+=======
+            hosts     = { "example.com" },
+>>>>>>> feat(schema) add sni, source and destination routing attributes
             regex_priority = 5,
           })
           assert.is_nil(err_t)
@@ -467,6 +492,7 @@ for _, strategy in helpers.each_strategy() do
             })
 
             local new_route, err, err_t = db.routes:update({ id = route.id }, {
+              protocols = { "https" },
               methods = ngx.null
             })
             assert.is_nil(err_t)
@@ -491,6 +517,7 @@ for _, strategy in helpers.each_strategy() do
             })
 
             local new_route, _, err_t = db.routes:update({ id = route.id }, {
+              protocols = { "https" },
               hosts   = ngx.null,
               methods = ngx.null,
             })
@@ -501,11 +528,11 @@ for _, strategy in helpers.each_strategy() do
               strategy    = strategy,
               message  = unindent([[
                 schema violation
-                (must set one of 'methods', 'hosts', 'paths' when 'protocols' is 'http' or 'https')
+                (must set one of 'methods', 'hosts', 'paths', 'sources', 'destinations', 'snis' when 'protocols' is 'http' or 'https')
               ]], true, true),
               fields   = {
                 ["@entity"] = {
-                  "must set one of 'methods', 'hosts', 'paths' when 'protocols' is 'http' or 'https'",
+                  "must set one of 'methods', 'hosts', 'paths', 'sources', 'destinations', 'snis' when 'protocols' is 'http' or 'https'",
                 }
               },
             }, err_t)
@@ -541,6 +568,7 @@ for _, strategy in helpers.each_strategy() do
             })
 
             local new_route, _, err_t = db.routes:update({ id = route.id }, {
+              protocols = { "http" },
               hosts   = ngx.null,
               methods = ngx.null,
             })
@@ -551,11 +579,11 @@ for _, strategy in helpers.each_strategy() do
               strategy    = strategy,
               message  = unindent([[
                 schema violation
-                (must set one of 'methods', 'hosts', 'paths' when 'protocols' is 'http' or 'https')
+                (must set one of 'methods', 'hosts', 'paths', 'sources', 'destinations', 'snis' when 'protocols' is 'http' or 'https')
               ]], true, true),
               fields   = {
                 ["@entity"] = {
-                  "must set one of 'methods', 'hosts', 'paths' when 'protocols' is 'http' or 'https'",
+                  "must set one of 'methods', 'hosts', 'paths', 'sources', 'destinations', 'snis' when 'protocols' is 'http' or 'https'",
                 }
               },
             }, err_t)
@@ -1465,6 +1493,9 @@ for _, strategy in helpers.each_strategy() do
           regex_priority   = 0,
           strip_path       = true,
           preserve_host    = false,
+          snis             = ngx.null,
+          sources          = ngx.null,
+          destinations     = ngx.null,
           service          = {
             id = service.id
           },

--- a/spec/02-integration/04-admin_api/20-routes_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/20-routes_routes_spec.lua
@@ -140,13 +140,13 @@ for _, strategy in helpers.each_strategy() do
                 name    = "schema violation",
                 message = unindent([[
                   2 schema violations
-                  (must set one of 'methods', 'hosts', 'paths' when 'protocols' is 'http' or 'https';
+                  (must set one of 'methods', 'hosts', 'paths', 'sources', 'destinations', 'snis' when 'protocols' is 'http' or 'https';
                   service: required field missing)
                 ]], true, true),
                 fields = {
                   service   = "required field missing",
                   ["@entity"] = {
-                    "must set one of 'methods', 'hosts', 'paths' when 'protocols' is 'http' or 'https'"
+                    "must set one of 'methods', 'hosts', 'paths', 'sources', 'destinations', 'snis' when 'protocols' is 'http' or 'https'"
                   }
                 }
               }, cjson.decode(body))
@@ -535,13 +535,13 @@ for _, strategy in helpers.each_strategy() do
                   name    = "schema violation",
                   message = unindent([[
                   2 schema violations
-                  (must set one of 'methods', 'hosts', 'paths' when 'protocols' is 'http' or 'https';
+                  (must set one of 'methods', 'hosts', 'paths', 'sources', 'destinations', 'snis' when 'protocols' is 'http' or 'https';
                   service: required field missing)
                 ]], true, true),
                   fields  = {
                     service   = "required field missing",
                     ["@entity"] = {
-                      "must set one of 'methods', 'hosts', 'paths' when 'protocols' is 'http' or 'https'"
+                      "must set one of 'methods', 'hosts', 'paths', 'sources', 'destinations', 'snis' when 'protocols' is 'http' or 'https'"
                     }
                   }
                 }, cjson.decode(body))


### PR DESCRIPTION
This pull request adds the ability for **HTTP** routes to be selected based on:

  - SNI presented by client
  - source ip
  - destination ip
