### PR TITLE
feat(schema) remove default port from services scheme

### DIFF
--- a/kong/db/schema/entities/services.lua
+++ b/kong/db/schema/entities/services.lua
@@ -15,7 +15,7 @@ return {
     -- { tags          = { type = "array", array = { type = "string" } }, },
     { protocol        = typedefs.protocol { required = true, default = "http" } },
     { host            = typedefs.host { required = true } },
-    { port            = typedefs.port { required = true, default = 80 }, },
+    { port            = typedefs.port { required = true } },
     { path            = typedefs.path },
     { connect_timeout = typedefs.timeout { default = 60000 }, },
     { write_timeout   = typedefs.timeout { default = 60000 }, },

--- a/spec/01-unit/000-new-dao/01-schema/04-services_spec.lua
+++ b/spec/01-unit/000-new-dao/01-schema/04-services_spec.lua
@@ -50,11 +50,22 @@ describe("services", function()
 
   it("missing host produces error", function()
     local service = {
+      port = 80,
     }
     service = Services:process_auto_fields(service, "insert")
     local ok, errs = Services:validate(service)
     assert.falsy(ok)
     assert.truthy(errs["host"])
+  end)
+
+  it("missing port produces error", function()
+    local service = {
+      host = "www.example.com",
+    }
+    service = Services:process_auto_fields(service, "insert")
+    local ok, errs = Services:validate(service)
+    assert.falsy(ok)
+    assert.truthy(errs["port"])
   end)
 
   it("invalid retries produces error", function()
@@ -71,6 +82,7 @@ describe("services", function()
   it("produces defaults", function()
     local service = {
       host = "www.example.com",
+      port = 80,
     }
     service = Services:process_auto_fields(service, "insert")
     local ok, err = Services:validate(service)

--- a/spec/02-integration/000-new-dao/02-db_core_entities_spec.lua
+++ b/spec/02-integration/000-new-dao/02-db_core_entities_spec.lua
@@ -148,7 +148,7 @@ for _, strategy in helpers.each_strategy() do
           local route, err, err_t = db.routes:insert({
             protocols = { "http" },
             hosts = { "example.com" },
-            service = assert(db.services:insert({ host = "service.com" })),
+            service = assert(db.services:insert({ host = "service.com", port = 80 })),
           }, {
             ttl = 100,
           })
@@ -172,7 +172,7 @@ for _, strategy in helpers.each_strategy() do
           local route, err, err_t = db.routes:insert({
             protocols = { "http" },
             hosts = { "example.com" },
-            service = assert(db.services:insert({ host = "service.com" })),
+            service = assert(db.services:insert({ host = "service.com", port = 80 })),
           }, { nulls = true })
           assert.is_nil(err_t)
           assert.is_nil(err)
@@ -860,10 +860,11 @@ for _, strategy in helpers.each_strategy() do
           assert.same({
             code        = Errors.codes.SCHEMA_VIOLATION,
             name        = "schema violation",
-            message     = "schema violation (host: required field missing)",
+            message     = "2 schema violations (host: required field missing; port: required field missing)",
             strategy    = strategy,
             fields      = {
               host = "required field missing",
+              port = "required field missing",
             }
           }, err_t)
         end)
@@ -873,6 +874,7 @@ for _, strategy in helpers.each_strategy() do
           local service, err, err_t = db.services:insert({
             --name     = "example service",
             host = "example.com",
+            port = 80,
           }, { nulls = true })
           assert.is_nil(err_t)
           assert.is_nil(err)
@@ -939,6 +941,7 @@ for _, strategy in helpers.each_strategy() do
             name       = "example_service_overriding_created_at",
             protocol   = "http",
             host       = "example.com",
+            port       = 80,
             created_at = 0,
             updated_at = 0,
           })
@@ -962,6 +965,7 @@ for _, strategy in helpers.each_strategy() do
             name = "my_service",
             protocol = "http",
             host = "example.com",
+            port = 80,
           }
           assert.is_nil(err_t)
 
@@ -971,6 +975,7 @@ for _, strategy in helpers.each_strategy() do
             name = "my_other_service",
             protocol = "http",
             host = "other-example.com",
+            port = 80,
           }
           assert.is_nil(service)
           assert.same({
@@ -990,6 +995,7 @@ for _, strategy in helpers.each_strategy() do
             name = "my_service_name",
             protocol = "http",
             host = "example.com",
+            port = 80,
           }
           assert.is_nil(err_t)
 
@@ -998,6 +1004,7 @@ for _, strategy in helpers.each_strategy() do
             name = "my_service_name",
             protocol = "http",
             host = "other-example.com",
+            port = 80,
           }
           assert.is_nil(service)
           assert.same({
@@ -1032,7 +1039,8 @@ for _, strategy in helpers.each_strategy() do
 
         it("returns existing Service", function()
           local service = assert(db.services:insert({
-            host = "example.com"
+            host = "example.com",
+            port = 80,
           }))
 
           local service_in_db, err, err_t = db.services:select({
@@ -1052,6 +1060,7 @@ for _, strategy in helpers.each_strategy() do
             assert(db.services:insert({
               name = "service_" .. i,
               host = "service" .. i .. ".com",
+              port = 80,
             }))
           end
         end)
@@ -1121,7 +1130,8 @@ for _, strategy in helpers.each_strategy() do
 
         it("updates an existing Service", function()
           local service = assert(db.services:insert({
-            host = "service.com"
+            host = "service.com",
+            port = 80,
           }))
 
           local updated_service, err, err_t = db.services:update({
@@ -1145,6 +1155,7 @@ for _, strategy in helpers.each_strategy() do
             name = "service",
             protocol = "http",
             host = "example.com",
+            port = 80,
           }
           assert.is_nil(err_t)
 
@@ -1153,6 +1164,7 @@ for _, strategy in helpers.each_strategy() do
             name = "service_bis",
             protocol = "http",
             host = "other-example.com",
+            port = 80,
           }
           assert.is_nil(err_t)
 
@@ -1180,11 +1192,13 @@ for _, strategy in helpers.each_strategy() do
           assert(db.services:insert({
             name = "test-service",
             host = "test-service.com",
+            port = 80,
           }))
 
           assert(db.services:insert({
             name = "existing-service",
             host = "existing-service.com",
+            port = 80,
           }))
         end)
 
@@ -1226,7 +1240,8 @@ for _, strategy in helpers.each_strategy() do
 
         it("updates an existing Service", function()
           local service = assert(db.services:insert({
-            host = "service.com"
+            host = "service.com",
+            port = 80,
           }))
 
           local updated_service, err, err_t = db.services:update({
@@ -1305,7 +1320,8 @@ for _, strategy in helpers.each_strategy() do
 
         it("deletes an existing Service", function()
           local service = assert(db.services:insert({
-            host = "example.com"
+            host = "example.com",
+            port = 80,
           }))
 
           local ok, err, err_t = db.services:delete({
@@ -1333,6 +1349,7 @@ for _, strategy in helpers.each_strategy() do
           service = assert(db.services:insert({
             name = "service_1",
             host = "service1.com",
+            port = 80,
           }))
         end)
 
@@ -1376,7 +1393,8 @@ for _, strategy in helpers.each_strategy() do
       it(":insert() a Route with a relation to a Service", function()
         local service = assert(db.services:insert({
           protocol = "http",
-          host     = "service.com"
+          host     = "service.com",
+          port = 80,
         }))
 
         local route, err, err_t = db.routes:insert({
@@ -1410,8 +1428,8 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       it(":update() attaches a Route to an existing Service", function()
-        local service1 = bp.services:insert({ host = "service1.com" })
-        local service2 = bp.services:insert({ host = "service2.com" })
+        local service1 = bp.services:insert({ host = "service1.com", port = 80 })
+        local service2 = bp.services:insert({ host = "service2.com", port = 80 })
 
         local route = bp.routes:insert({ service = service1, methods = { "GET" } })
 
@@ -1458,6 +1476,7 @@ for _, strategy in helpers.each_strategy() do
       it(":delete() a Service is not allowed if a Route is associated to it", function()
         local service = bp.services:insert({
           host = "example.com",
+          port = 80,
         })
 
         bp.routes:insert({ service = service, methods = { "GET" } })
@@ -1480,6 +1499,7 @@ for _, strategy in helpers.each_strategy() do
       it(":delete() a Route without deleting the associated Service", function()
         local service = bp.services:insert({
           host = "example.com",
+          port = 80,
         })
 
         local route = bp.routes:insert({ service = service, methods = { "GET" } })

--- a/spec/02-integration/03-dao/04-constraints_spec.lua
+++ b/spec/02-integration/03-dao/04-constraints_spec.lua
@@ -21,6 +21,7 @@ for _, strategy in helpers.each_strategy() do
       local service, _, err_t = db.services:insert({
         protocol = "http",
         host     = "example.com",
+        port     = 80,
       })
       assert.is_nil(err_t)
 
@@ -137,6 +138,7 @@ for _, strategy in helpers.each_strategy() do
 
           service, _, err_t = db.services:insert {
             host = "example.com",
+            port = 80,
           }
 
           assert.is_nil(err_t)
@@ -189,6 +191,7 @@ for _, strategy in helpers.each_strategy() do
 
           service, _, err_t = db.services:insert {
             host = "example.com",
+            port = 80,
           }
 
           assert.is_nil(err_t)
@@ -247,6 +250,7 @@ for _, strategy in helpers.each_strategy() do
 
           service, _, err_t = db.services:insert {
             host = "example.com",
+            port = 80,
           }
 
           assert.is_nil(err_t)
@@ -436,6 +440,7 @@ for _, strategy in helpers.each_strategy() do
 
         service, _, err_t = db.services:insert {
           host = "example.com",
+          port = 80,
         }
 
         assert.is_nil(err_t)

--- a/spec/02-integration/04-admin_api/21-services_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/21-services_routes_spec.lua
@@ -57,6 +57,7 @@ for _, strategy in helpers.each_strategy() do
               body = {
                 protocol = "http",
                 host     = "service.com",
+                port     = 80,
               },
               headers = { ["Content-Type"] = content_type },
             })
@@ -378,6 +379,7 @@ for _, strategy in helpers.each_strategy() do
             local service = db.services:insert({
               protocol = "http",
               host     = "service.com",
+              port     = 80,
             })
 
             local route = db.routes:insert({
@@ -714,12 +716,14 @@ for _, strategy in helpers.each_strategy() do
             local json = cjson.decode(body)
             assert.same({
                 host = "required field missing",
+                port = "required field missing",
               }, json.fields)
 
             -- Invalid parameter
             res = client:post("/services", {
                 body = {
                   host     = "example.com",
+                  port     = 80,
                   protocol = "foo",
                 },
                 headers = { ["Content-Type"] = content_type }
@@ -745,12 +749,14 @@ for _, strategy in helpers.each_strategy() do
                 name     = "schema violation",
                 code     = Errors.codes.SCHEMA_VIOLATION,
                 message  = unindent([[
-                  2 schema violations
+                  3 schema violations
                   (host: required field missing;
-                  path: should start with: /)
+                  path: should start with: /;
+                  port: required field missing)
                 ]], true, true),
                 fields = {
                   host = "required field missing",
+                  port = "required field missing",
                   path = "should start with: /",
                 },
               }, json


### PR DESCRIPTION
The default of 80 was unsuitable for HTTPS and even more unsuitable for
stream support.

This cause minimal breakage as a default is injected via
`api_helpers.resolve_url_params` when using the /services url argument.

Note: the router also has a default for the port if the protocol is absent.
