### PR TITLE
tests(*) lazy-setup and teardown

### DIFF
--- a/spec-old-api/01-unit/010-router_spec.lua
+++ b/spec-old-api/01-unit/010-router_spec.lua
@@ -617,14 +617,14 @@ describe("Router", function()
       end)
 
       describe("root / [uri]", function()
-        setup(function()
+        lazy_setup(function()
           table.insert(use_case, 1, {
             name = "api-root-uri",
             uris = {"/"},
           })
         end)
 
-        teardown(function()
+        lazy_teardown(function()
           table.remove(use_case, 1)
         end)
 
@@ -660,7 +660,7 @@ describe("Router", function()
 
         local n = 6
 
-        setup(function()
+        lazy_setup(function()
           -- all those APIs are of the same category:
           -- [host + uri]
           for _ = 1, n - 1 do
@@ -682,7 +682,7 @@ describe("Router", function()
           })
         end)
 
-        teardown(function()
+        lazy_teardown(function()
           for _ = 1, n do
             table.remove(use_case)
           end
@@ -761,7 +761,7 @@ describe("Router", function()
         local target_domain
         local benchmark_use_cases = {}
 
-        setup(function()
+        lazy_setup(function()
           for i = 1, 10^5 do
             benchmark_use_cases[i] = {
               name = "api-" .. i,
@@ -788,7 +788,7 @@ describe("Router", function()
         local target_domain
         local benchmark_use_cases = {}
 
-        setup(function()
+        lazy_setup(function()
           local n = 10^5
 
           for i = 1, n - 1 do
@@ -833,7 +833,7 @@ describe("Router", function()
         local target_domain
         local benchmark_use_cases = {}
 
-        setup(function()
+        lazy_setup(function()
           local n = 10^5
 
           for i = 1, n - 1 do
@@ -1206,7 +1206,7 @@ describe("Router", function()
         },
       }
 
-      setup(function()
+      lazy_setup(function()
         router = assert(Router.new(use_case_apis))
       end)
 
@@ -1365,7 +1365,7 @@ describe("Router", function()
         },
       }
 
-      setup(function()
+      lazy_setup(function()
         router = assert(Router.new(use_case_apis))
       end)
 

--- a/spec-old-api/02-integration/01-helpers/00-helpers_spec.lua
+++ b/spec-old-api/02-integration/01-helpers/00-helpers_spec.lua
@@ -5,7 +5,7 @@ for _, strategy in helpers.each_strategy() do
 describe("helpers [#" .. strategy .. "]: assertions and modifiers", function()
   local client
 
-  setup(function()
+  lazy_setup(function()
     local _, _, dao = helpers.get_db_utils(strategy)
 
     assert(dao.apis:insert {
@@ -19,7 +19,7 @@ describe("helpers [#" .. strategy .. "]: assertions and modifiers", function()
       nginx_conf = "spec/fixtures/custom_nginx.template",
     }))
   end)
-  teardown(function()
+  lazy_teardown(function()
     helpers.stop_kong()
   end)
 

--- a/spec-old-api/02-integration/03-dao/04-constraints_spec.lua
+++ b/spec-old-api/02-integration/03-dao/04-constraints_spec.lua
@@ -18,7 +18,7 @@ for _, strategy in helpers.each_strategy() do
     local plugin_fixture, api_fixture
     local apis, plugins
     local bp, db, dao
-    setup(function()
+    lazy_setup(function()
       bp, db, dao = helpers.get_db_utils(strategy)
       apis = dao.apis
       plugins = db.plugins

--- a/spec-old-api/02-integration/03-dao/05-use_cases_spec.lua
+++ b/spec-old-api/02-integration/03-dao/05-use_cases_spec.lua
@@ -6,7 +6,7 @@ local helpers = require "spec.helpers"
 for _, strategy in helpers.each_strategy() do
   describe("Real use-cases with DB: #" .. strategy, function()
     local bp, db, dao
-    setup(function()
+    lazy_setup(function()
       bp, db, dao = helpers.get_db_utils(strategy)
     end)
 

--- a/spec-old-api/02-integration/04-admin_api/01-kong_routes_spec.lua
+++ b/spec-old-api/02-integration/04-admin_api/01-kong_routes_spec.lua
@@ -8,7 +8,7 @@ describe("Admin API - Kong routes", function()
     local meta = require "kong.meta"
     local client
 
-    setup(function()
+    lazy_setup(function()
       helpers.get_db_utils()
       assert(helpers.start_kong {
         pg_password = "hide_me"
@@ -16,7 +16,7 @@ describe("Admin API - Kong routes", function()
       client = helpers.admin_client(10000)
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       if client then client:close() end
       helpers.stop_kong()
     end)
@@ -100,7 +100,7 @@ describe("Admin API - Kong routes", function()
     describe("/status with DB: #" .. kong_conf.database, function()
       local client
 
-      setup(function()
+      lazy_setup(function()
         helpers.get_db_utils(kong_conf.database)
 
         assert(helpers.start_kong {
@@ -109,7 +109,7 @@ describe("Admin API - Kong routes", function()
         client = helpers.admin_client(10000)
       end)
 
-      teardown(function()
+      lazy_teardown(function()
         if client then client:close() end
         helpers.stop_kong()
       end)

--- a/spec-old-api/02-integration/04-admin_api/02-apis_routes_spec.lua
+++ b/spec-old-api/02-integration/04-admin_api/02-apis_routes_spec.lua
@@ -17,14 +17,14 @@ describe("Admin API #" .. kong_config.database, function()
   local client
   local dao, db, _
 
-  setup(function()
+  lazy_setup(function()
     _, db, dao = helpers.get_db_utils(kong_config.database)
 
     assert(helpers.start_kong{
       database = kong_config.database
     })
   end)
-  teardown(function()
+  lazy_teardown(function()
     helpers.stop_kong()
   end)
 
@@ -344,7 +344,7 @@ describe("Admin API #" .. kong_config.database, function()
     end)
 
     describe("GET", function()
-      setup(function()
+      lazy_setup(function()
         dao:truncate_table("apis")
         db:truncate("plugins")
 
@@ -356,7 +356,7 @@ describe("Admin API #" .. kong_config.database, function()
           })
         end
       end)
-      teardown(function()
+      lazy_teardown(function()
         dao:truncate_table("apis")
         db:truncate("plugins")
       end)
@@ -429,7 +429,7 @@ describe("Admin API #" .. kong_config.database, function()
       end)
 
       describe("empty results", function()
-        setup(function()
+        lazy_setup(function()
           dao:truncate_table("apis")
           db:truncate("plugins")
         end)
@@ -475,7 +475,7 @@ describe("Admin API #" .. kong_config.database, function()
 
   describe("/apis/{api}", function()
     local api
-    setup(function()
+    lazy_setup(function()
       dao:truncate_table("apis")
       db:truncate("plugins")
     end)
@@ -737,7 +737,7 @@ describe("Admin API #" .. kong_config.database, function()
 
   describe("/apis/{api}/plugins", function()
     local api
-    setup(function()
+    lazy_setup(function()
       dao:truncate_table("apis")
       db:truncate("plugins")
 
@@ -1150,7 +1150,7 @@ end)
 
 describe("Admin API request size", function()
   local client
-  setup(function()
+  lazy_setup(function()
     local dao = select(3, helpers.get_db_utils())
 
     assert(dao.apis:insert {
@@ -1162,7 +1162,7 @@ describe("Admin API request size", function()
     assert(helpers.start_kong())
     client = assert(helpers.admin_client())
   end)
-  teardown(function()
+  lazy_teardown(function()
     if client then client:close() end
     helpers.stop_kong()
   end)

--- a/spec-old-api/02-integration/04-admin_api/04-plugins_routes_spec.lua
+++ b/spec-old-api/02-integration/04-admin_api/04-plugins_routes_spec.lua
@@ -8,7 +8,7 @@ for _, strategy in helpers.each_strategy() do
     local db
     local client
 
-    setup(function()
+    lazy_setup(function()
       _, db, dao = helpers.get_db_utils(strategy, {
         "apis",
         "plugins",
@@ -21,7 +21,7 @@ for _, strategy in helpers.each_strategy() do
       }))
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong(nil, true)
     end)
 
@@ -51,7 +51,7 @@ for _, strategy in helpers.each_strategy() do
     describe("/plugins", function()
       local plugins = {}
 
-      setup(function()
+      lazy_setup(function()
         for i = 1, 3 do
           local api = assert(dao.apis:insert {
             name         = "api-" .. i,

--- a/spec-old-api/02-integration/04-admin_api/05-cache_routes_spec.lua
+++ b/spec-old-api/02-integration/04-admin_api/05-cache_routes_spec.lua
@@ -7,7 +7,7 @@ describe("Admin API /cache", function()
   local proxy_client
   local admin_client
 
-  setup(function()
+  lazy_setup(function()
     local _, _, dao = helpers.get_db_utils(strategy, {
       "apis",
       "plugins",
@@ -33,7 +33,7 @@ describe("Admin API /cache", function()
   end)
 
 
-  teardown(function()
+  lazy_teardown(function()
     if admin_client then
       admin_client:close()
     end

--- a/spec-old-api/02-integration/05-proxy/01-router_spec.lua
+++ b/spec-old-api/02-integration/05-proxy/01-router_spec.lua
@@ -28,7 +28,7 @@ describe("Router", function()
 
   describe("no APIs match", function()
 
-    setup(function()
+    lazy_setup(function()
       helpers.dao:truncate_table("apis")
       helpers.db:truncate("routes")
       helpers.db:truncate("services")
@@ -36,7 +36,7 @@ describe("Router", function()
       assert(helpers.start_kong())
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 
@@ -57,7 +57,7 @@ describe("Router", function()
 
   describe("use-cases", function()
 
-    setup(function()
+    lazy_setup(function()
       insert_apis {
         {
           name         = "api-1",
@@ -97,7 +97,7 @@ describe("Router", function()
       }))
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 
@@ -181,7 +181,7 @@ describe("Router", function()
   end)
 
   describe("URI regexes order of evaluation", function()
-    setup(function()
+    lazy_setup(function()
       helpers.dao:truncate_table("apis")
 
       assert(helpers.dao.apis:insert {
@@ -211,7 +211,7 @@ describe("Router", function()
       }))
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 
@@ -236,7 +236,7 @@ describe("Router", function()
 
   describe("URI arguments (querystring)", function()
 
-    setup(function()
+    lazy_setup(function()
       insert_apis {
         {
           name         = "api-1",
@@ -251,7 +251,7 @@ describe("Router", function()
       }))
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 
@@ -305,7 +305,7 @@ describe("Router", function()
 
   describe("percent-encoded URIs", function()
 
-    setup(function()
+    lazy_setup(function()
       insert_apis {
         {
           name         = "api-1",
@@ -325,7 +325,7 @@ describe("Router", function()
       }))
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 
@@ -354,7 +354,7 @@ describe("Router", function()
 
   describe("strip_uri", function()
 
-    setup(function()
+    lazy_setup(function()
       insert_apis {
         {
           name         = "api-strip-uri",
@@ -370,7 +370,7 @@ describe("Router", function()
       }))
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 
@@ -421,7 +421,7 @@ describe("Router", function()
 
   describe("preserve_host", function()
 
-    setup(function()
+    lazy_setup(function()
       insert_apis {
         {
           name          = "api-1",
@@ -450,7 +450,7 @@ describe("Router", function()
       }))
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 
@@ -535,7 +535,7 @@ describe("Router", function()
 
   describe("edge-cases", function()
 
-    setup(function()
+    lazy_setup(function()
       insert_apis {
         {
           name         = "root-uri",
@@ -555,7 +555,7 @@ describe("Router", function()
       }))
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 
@@ -582,7 +582,7 @@ describe("Router", function()
 
   describe("[uris] + [methods]", function()
 
-    setup(function()
+    lazy_setup(function()
       insert_apis {
         {
           name = "root-api",
@@ -604,7 +604,7 @@ describe("Router", function()
       }))
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 
@@ -624,7 +624,7 @@ describe("Router", function()
 
   describe("[uris] + [hosts]", function()
 
-    setup(function()
+    lazy_setup(function()
       insert_apis {
         {
           name         = "root-api",
@@ -646,7 +646,7 @@ describe("Router", function()
       }))
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 
@@ -715,7 +715,7 @@ describe("Router", function()
       {  "/get/bar/",    "/get/bar/",    "/get/bar/",    "/get/bar/get/bar/",    false     },
     }
 
-    setup(function()
+    lazy_setup(function()
       helpers.dao:truncate_table("apis")
 
       for i, args in ipairs(checks) do
@@ -738,7 +738,7 @@ describe("Router", function()
       }))
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 

--- a/spec-old-api/02-integration/05-proxy/02-upstream_headers_spec.lua
+++ b/spec-old-api/02-integration/05-proxy/02-upstream_headers_spec.lua
@@ -67,12 +67,12 @@ describe("Upstream header(s)", function()
 
   describe("(using the default configuration values)", function()
 
-    setup(start_kong {
+    lazy_setup(start_kong {
         nginx_conf       = "spec/fixtures/custom_nginx.template",
         lua_package_path = "?/init.lua;./kong/?.lua;./spec-old-api/fixtures/?.lua",
     })
 
-    teardown(stop_kong)
+    lazy_teardown(stop_kong)
 
     describe("X-Real-IP", function()
       it("should be added if not present in request", function()
@@ -243,13 +243,13 @@ describe("Upstream header(s)", function()
 
   describe("(using the trusted configuration values)", function()
 
-    setup(start_kong {
+    lazy_setup(start_kong {
         trusted_ips      = "127.0.0.1",
         nginx_conf       = "spec/fixtures/custom_nginx.template",
         lua_package_path = "?/init.lua;./kong/?.lua;./spec-old-api/fixtures/?.lua",
     })
 
-    teardown(stop_kong)
+    lazy_teardown(stop_kong)
 
     describe("X-Real-IP", function()
       it("should be added if not present in request", function()
@@ -353,13 +353,13 @@ describe("Upstream header(s)", function()
 
   describe("(using the non-trusted configuration values)", function()
 
-    setup(start_kong {
+    lazy_setup(start_kong {
         trusted_ips      = "10.0.0.1",
         nginx_conf       = "spec/fixtures/custom_nginx.template",
         lua_package_path = "?/init.lua;./kong/?.lua;./spec-old-api/fixtures/?.lua",
     })
 
-    teardown(stop_kong)
+    lazy_teardown(stop_kong)
 
     describe("X-Real-IP", function()
       it("should be added if not present in request", function()
@@ -461,7 +461,7 @@ describe("Upstream header(s)", function()
 
   describe("(using the recursive trusted configuration values)", function()
 
-    setup(start_kong {
+    lazy_setup(start_kong {
         real_ip_header    = "X-Forwarded-For",
         real_ip_recursive = "on",
         trusted_ips       = "127.0.0.1,172.16.0.1,192.168.0.1",
@@ -469,7 +469,7 @@ describe("Upstream header(s)", function()
         lua_package_path  = "?/init.lua;./kong/?.lua;./spec-old-api/fixtures/?.lua",
     })
 
-    teardown(stop_kong)
+    lazy_teardown(stop_kong)
 
     describe("X-Real-IP and X-Forwarded-For", function()
       it("should be added if not present in request", function()
@@ -522,7 +522,7 @@ describe("Upstream header(s)", function()
   end)
 
   describe("(using the recursive non-trusted configuration values)", function()
-    setup(start_kong {
+    lazy_setup(start_kong {
         real_ip_header    = "X-Forwarded-For",
         real_ip_recursive = "on",
         trusted_ips       = "10.0.0.1,172.16.0.1,192.168.0.1",
@@ -530,7 +530,7 @@ describe("Upstream header(s)", function()
         lua_package_path  = "?/init.lua;./kong/?.lua;./spec-old-api/fixtures/?.lua",
     })
 
-    teardown(stop_kong)
+    lazy_teardown(stop_kong)
 
     describe("X-Real-IP and X-Forwarded-For", function()
       it("should be added if not present in request", function()
@@ -587,7 +587,7 @@ describe("Upstream header(s)", function()
     local proxy_ip = helpers.get_proxy_ip(false)
     local proxy_port = helpers.get_proxy_port(false)
 
-    setup(start_kong {
+    lazy_setup(start_kong {
       proxy_listen      = proxy_ip .. ":" .. proxy_port .. " proxy_protocol",
       real_ip_header    = "proxy_protocol",
       real_ip_recursive = "on",
@@ -596,7 +596,7 @@ describe("Upstream header(s)", function()
       lua_package_path  = "?/init.lua;./kong/?.lua;./spec-old-api/fixtures/?.lua",
     })
 
-    teardown(stop_kong)
+    lazy_teardown(stop_kong)
 
     describe("X-Real-IP, X-Forwarded-For and X-Forwarded-Port", function()
       it("should be added if not present in request", function()
@@ -692,7 +692,7 @@ describe("Upstream header(s)", function()
     local proxy_ip = helpers.get_proxy_ip(false)
     local proxy_port = helpers.get_proxy_port(false)
 
-    setup(start_kong {
+    lazy_setup(start_kong {
       proxy_listen      = proxy_ip .. ":" .. proxy_port .. " proxy_protocol",
       real_ip_header    = "proxy_protocol",
       real_ip_recursive = "on",
@@ -701,7 +701,7 @@ describe("Upstream header(s)", function()
       lua_package_path  = "?/init.lua;./kong/?.lua;./spec-old-api/fixtures/?.lua",
     })
 
-    teardown(stop_kong)
+    lazy_teardown(stop_kong)
 
     describe("X-Real-IP, X-Forwarded-For and X-Forwarded-Port", function()
       it("should be added if not present in request", function()

--- a/spec-old-api/02-integration/05-proxy/03-plugins_triggering_spec.lua
+++ b/spec-old-api/02-integration/05-proxy/03-plugins_triggering_spec.lua
@@ -6,7 +6,7 @@ describe("Plugins triggering #" .. strategy, function()
   local client
   local bp, db, dao
 
-  setup(function()
+  lazy_setup(function()
     bp, db, dao = helpers.get_db_utils(strategy, {
       "consumers",
       "apis",
@@ -119,7 +119,7 @@ describe("Plugins triggering #" .. strategy, function()
     client = helpers.proxy_client()
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     if client then client:close() end
     helpers.stop_kong(nil, true)
   end)
@@ -181,7 +181,7 @@ describe("Plugins triggering #" .. strategy, function()
   describe("short-circuited requests", function()
     local FILE_LOG_PATH = os.tmpname()
 
-    setup(function()
+    lazy_setup(function()
       if client then
         client:close()
       end
@@ -261,7 +261,7 @@ describe("Plugins triggering #" .. strategy, function()
       client = helpers.proxy_client()
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       if client then
         client:close()
       end
@@ -398,7 +398,7 @@ describe("Plugins triggering #" .. strategy, function()
     -- tries to evaluate is the `schema.no_consumer` flag is set.
     -- Since the reports plugin has no `schema`, this indexing fails.
 
-    setup(function()
+    lazy_setup(function()
       if client then
         client:close()
       end
@@ -438,7 +438,7 @@ describe("Plugins triggering #" .. strategy, function()
       client = helpers.proxy_client()
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       if client then
         client:close()
       end

--- a/spec-old-api/02-integration/05-proxy/04-dns_spec.lua
+++ b/spec-old-api/02-integration/05-proxy/04-dns_spec.lua
@@ -42,7 +42,7 @@ end
 describe("DNS", function()
   local dao
 
-  setup(function()
+  lazy_setup(function()
     dao = select(3, helpers.get_db_utils())
   end)
 
@@ -50,7 +50,7 @@ describe("DNS", function()
     local retries = 3
     local client
 
-    setup(function()
+    lazy_setup(function()
       assert(dao.apis:insert {
         name = "tests-retries",
         hosts = { "retries.com" },
@@ -62,7 +62,7 @@ describe("DNS", function()
       client = helpers.proxy_client()
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       if client then client:close() end
       helpers.stop_kong()
     end)
@@ -90,7 +90,7 @@ describe("DNS", function()
   describe("upstream resolve failure", function()
     local client
 
-    setup(function()
+    lazy_setup(function()
       assert(dao.apis:insert {
         name = "tests-retries-bis",
         hosts = { "retries-bis.com" },
@@ -101,7 +101,7 @@ describe("DNS", function()
       client = helpers.proxy_client()
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       if client then client:close() end
       helpers.stop_kong()
     end)

--- a/spec-old-api/02-integration/05-proxy/05-ssl_spec.lua
+++ b/spec-old-api/02-integration/05-proxy/05-ssl_spec.lua
@@ -16,7 +16,7 @@ end
 describe("SSL", function()
   local admin_client, client, https_client
 
-  setup(function()
+  lazy_setup(function()
     local _, _, dao = helpers.get_db_utils()
 
     assert(dao.apis:insert {
@@ -85,7 +85,7 @@ describe("SSL", function()
     })
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     helpers.stop_kong()
   end)
 
@@ -188,7 +188,7 @@ describe("SSL", function()
 
       -- restart kong and use a new client to simulate a connection from an
       -- untrusted ip
-      setup(function()
+      lazy_setup(function()
         assert(helpers.kong_exec("restart -c " .. helpers.test_conf_path, {
           trusted_ips = "1.2.3.4", -- explicitly trust an IP that is not us
         }))

--- a/spec-old-api/02-integration/05-proxy/06-upstream_timeouts_spec.lua
+++ b/spec-old-api/02-integration/05-proxy/06-upstream_timeouts_spec.lua
@@ -7,7 +7,7 @@ dao_helpers.for_each_dao(function(kong_config)
   describe("upstream timeouts with DB: #" .. kong_config.database, function()
     local client
 
-    setup(function()
+    lazy_setup(function()
       local _, _, dao = helpers.get_db_utils(kong_config.database)
 
       local apis = {
@@ -40,7 +40,7 @@ dao_helpers.for_each_dao(function(kong_config)
       }))
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 

--- a/spec-old-api/02-integration/05-proxy/07-uri_encoding_spec.lua
+++ b/spec-old-api/02-integration/05-proxy/07-uri_encoding_spec.lua
@@ -4,7 +4,7 @@ local helpers = require "spec.helpers"
 describe("URI encoding", function()
   local client
 
-  setup(function()
+  lazy_setup(function()
     helpers.get_db_utils()
 
     assert(helpers.dao.apis:insert {
@@ -39,7 +39,7 @@ describe("URI encoding", function()
     client = helpers.proxy_client()
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     helpers.stop_kong()
   end)
 

--- a/spec-old-api/02-integration/05-proxy/08-websockets_spec.lua
+++ b/spec-old-api/02-integration/05-proxy/08-websockets_spec.lua
@@ -3,7 +3,7 @@ local helpers = require "spec.helpers"
 local cjson = require "cjson"
 
 describe("Websockets", function()
-  setup(function()
+  lazy_setup(function()
     assert(helpers.dao.apis:insert {
       name = "ws",
       uris = { "/up-ws" },
@@ -16,7 +16,7 @@ describe("Websockets", function()
     }))
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     helpers.stop_kong()
   end)
 

--- a/spec-old-api/02-integration/05-proxy/09-balancer_spec.lua
+++ b/spec-old-api/02-integration/05-proxy/09-balancer_spec.lua
@@ -469,7 +469,7 @@ for _, strategy in helpers.each_strategy() do
 
   describe("Ring-balancer #" .. strategy, function()
 
-    setup(function()
+    lazy_setup(function()
       local _, db, dao = helpers.get_db_utils(strategy, {})
 
       truncate_relevant_tables(db, dao)
@@ -480,13 +480,13 @@ for _, strategy in helpers.each_strategy() do
       })
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 
     describe("#healthchecks (#cluster)", function()
 
-      setup(function()
+      lazy_setup(function()
         -- start a second Kong instance (ports are Kong test ports + 10)
         helpers.start_kong({
           database   = strategy,
@@ -500,7 +500,7 @@ for _, strategy in helpers.each_strategy() do
         })
       end)
 
-      teardown(function()
+      lazy_teardown(function()
         helpers.stop_kong("servroot2", true, true)
       end)
 

--- a/spec-old-api/02-integration/05-proxy/10-handler_spec.lua
+++ b/spec-old-api/02-integration/05-proxy/10-handler_spec.lua
@@ -5,7 +5,7 @@ describe("OpenResty phases", function()
     describe("enabled on all APIs", function()
       local api_client, proxy_client
 
-      setup(function()
+      lazy_setup(function()
         local dao = select(3, helpers.get_db_utils())
 
         -- insert plugin-less api and a global plugin
@@ -29,7 +29,7 @@ describe("OpenResty phases", function()
         proxy_client = helpers.proxy_client()
       end)
 
-      teardown(function()
+      lazy_teardown(function()
         if api_client then api_client:close() end
         helpers.stop_kong()
       end)
@@ -51,7 +51,7 @@ describe("OpenResty phases", function()
     describe("enabled on a specific APIs", function()
       local api_client, proxy_client
 
-      setup(function()
+      lazy_setup(function()
         local dao = select(3, helpers.get_db_utils())
 
         -- api specific plugin
@@ -76,7 +76,7 @@ describe("OpenResty phases", function()
         proxy_client = helpers.proxy_client()
       end)
 
-      teardown(function()
+      lazy_teardown(function()
         if api_client then api_client:close() end
         helpers.stop_kong()
       end)
@@ -97,7 +97,7 @@ describe("OpenResty phases", function()
     describe("enabled on a specific Consumers", function()
       local api_client, proxy_client
 
-      setup(function()
+      lazy_setup(function()
         local bp, _, dao = helpers.get_db_utils()
 
         -- consumer specific plugin
@@ -133,7 +133,7 @@ describe("OpenResty phases", function()
         proxy_client = helpers.proxy_client()
       end)
 
-      teardown(function()
+      lazy_teardown(function()
         if api_client then api_client:close() end
         helpers.stop_kong()
       end)

--- a/spec-old-api/02-integration/05-proxy/11-error_default_type_spec.lua
+++ b/spec-old-api/02-integration/05-proxy/11-error_default_type_spec.lua
@@ -9,7 +9,7 @@ local RESPONSE_MESSAGE = "The upstream server is timing out"
 describe("Proxy errors Content-Type", function()
   local client
 
-  setup(function()
+  lazy_setup(function()
     helpers.dao:truncate_table("apis")
 
     assert(helpers.dao.apis:insert {
@@ -26,7 +26,7 @@ describe("Proxy errors Content-Type", function()
     })
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     helpers.stop_kong()
   end)
 
@@ -58,7 +58,7 @@ describe("Proxy errors Content-Type", function()
   end)
 
   describe("", function()
-    setup(function()
+    lazy_setup(function()
       assert(helpers.kong_exec(("restart --conf %s --nginx-conf %s"):format(
                                helpers.test_conf_path,
                                "spec/fixtures/custom_nginx.template")))

--- a/spec-old-api/02-integration/05-proxy/12-server_tokens_spec.lua
+++ b/spec-old-api/02-integration/05-proxy/12-server_tokens_spec.lua
@@ -41,11 +41,11 @@ describe("Server Tokens", function()
 
   describe("(with default configration values)", function()
 
-    setup(start {
+    lazy_setup(start {
       nginx_conf = "spec/fixtures/custom_nginx.template",
     })
 
-    teardown(helpers.stop_kong)
+    lazy_teardown(helpers.stop_kong)
 
     it("should return Kong 'Via' header but not change the 'Server' header when request was proxied", function()
       local res = assert(client:send {
@@ -79,12 +79,12 @@ describe("Server Tokens", function()
 
   describe("(with server_tokens = on)", function()
 
-    setup(start {
+    lazy_setup(start {
       nginx_conf    = "spec/fixtures/custom_nginx.template",
       headers = "server_tokens",
     })
 
-    teardown(helpers.stop_kong)
+    lazy_teardown(helpers.stop_kong)
 
     it("should return Kong 'Via' header but not change the 'Server' header when request was proxied", function()
       local res = assert(client:send {
@@ -118,12 +118,12 @@ describe("Server Tokens", function()
 
   describe("(with server_tokens = off)", function()
 
-    setup(start {
+    lazy_setup(start {
       nginx_conf    = "spec/fixtures/custom_nginx.template",
       headers = "off",
     })
 
-    teardown(helpers.stop_kong)
+    lazy_teardown(helpers.stop_kong)
 
     it("should not return Kong 'Via' header but it should forward the 'Server' header when request was proxied", function()
       local res = assert(client:send {
@@ -173,11 +173,11 @@ describe("Latency Tokens", function()
 
   describe("(with default configration values)", function()
 
-    setup(start {
+    lazy_setup(start {
       nginx_conf = "spec/fixtures/custom_nginx.template",
     })
 
-    teardown(helpers.stop_kong)
+    lazy_teardown(helpers.stop_kong)
 
     it("should be returned when request was proxied", function()
       local res = assert(client:send {
@@ -211,12 +211,12 @@ describe("Latency Tokens", function()
 
   describe("(with latency_tokens = on)", function()
 
-    setup(start {
+    lazy_setup(start {
       nginx_conf = "spec/fixtures/custom_nginx.template",
       headers = "latency_tokens",
     })
 
-    teardown(helpers.stop_kong)
+    lazy_teardown(helpers.stop_kong)
 
     it("should be returned when request was proxied", function()
       local res = assert(client:send {
@@ -250,12 +250,12 @@ describe("Latency Tokens", function()
 
   describe("(with latency_tokens = off)", function()
 
-    setup(start {
+    lazy_setup(start {
       nginx_conf     = "spec/fixtures/custom_nginx.template",
       headers = "off",
     })
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 

--- a/spec-old-api/02-integration/06-invalidations/02-core_entities_invalidations_spec.lua
+++ b/spec-old-api/02-integration/06-invalidations/02-core_entities_invalidations_spec.lua
@@ -17,7 +17,7 @@ describe("core entities are invalidated with db: #" .. strategy, function()
 
   local wait_for_propagation
 
-  setup(function()
+  lazy_setup(function()
     helpers.get_db_utils(strategy)
 
     local db_update_propagation = strategy == "cassandra" and 3 or 0
@@ -53,7 +53,7 @@ describe("core entities are invalidated with db: #" .. strategy, function()
     end
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     helpers.stop_kong("servroot1")
     helpers.stop_kong("servroot2")
   end)
@@ -78,7 +78,7 @@ describe("core entities are invalidated with db: #" .. strategy, function()
 
   describe("APIs (router)", function()
 
-    setup(function()
+    lazy_setup(function()
       -- populate cache with a miss on
       -- both nodes
 
@@ -232,7 +232,7 @@ describe("core entities are invalidated with db: #" .. strategy, function()
       return stderr
     end
 
-    setup(function()
+    lazy_setup(function()
       -- populate cache with a miss on
       -- both nodes
       local cert_1 = get_cert(8443, "ssl-example.com")

--- a/spec-old-api/03-plugins/01-tcp-log/01-tcp-log_spec.lua
+++ b/spec-old-api/03-plugins/01-tcp-log/01-tcp-log_spec.lua
@@ -6,7 +6,7 @@ local TCP_PORT = 35001
 describe("Plugin: tcp-log (log)", function()
   local client
 
-  setup(function()
+  lazy_setup(function()
     local _, db, dao = helpers.get_db_utils()
 
     local api1 = assert(dao.apis:insert {
@@ -45,7 +45,7 @@ describe("Plugin: tcp-log (log)", function()
     }))
     client = helpers.proxy_client()
   end)
-  teardown(function()
+  lazy_teardown(function()
     if client then client:close() end
     helpers.stop_kong()
   end)

--- a/spec-old-api/03-plugins/02-udp-log/01-udp-log_spec.lua
+++ b/spec-old-api/03-plugins/02-udp-log/01-udp-log_spec.lua
@@ -6,7 +6,7 @@ local UDP_PORT = 35001
 describe("Plugin: udp-log (log)", function()
   local client
 
-  setup(function()
+  lazy_setup(function()
     local _, db, dao = helpers.get_db_utils()
 
     local api1 = assert(dao.apis:insert {
@@ -30,7 +30,7 @@ describe("Plugin: udp-log (log)", function()
     client = helpers.proxy_client()
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     if client then client:close() end
     helpers.stop_kong()
   end)

--- a/spec-old-api/03-plugins/03-http-log/01-log_spec.lua
+++ b/spec-old-api/03-plugins/03-http-log/01-log_spec.lua
@@ -28,7 +28,7 @@ pending("Plugin: http-log (log)", function()
   -- Pending: at the time of this change, mockbin.com's behavior with bins
   -- seems to be broken.
   local client
-  setup(function()
+  lazy_setup(function()
     helpers.run_migrations()
 
     local api1 = assert(helpers.dao.apis:insert {
@@ -75,7 +75,7 @@ pending("Plugin: http-log (log)", function()
     assert(helpers.start_kong())
 
   end)
-  teardown(function()
+  lazy_teardown(function()
     helpers.stop_kong()
   end)
 

--- a/spec-old-api/03-plugins/04-file-log/01-log_spec.lua
+++ b/spec-old-api/03-plugins/04-file-log/01-log_spec.lua
@@ -9,7 +9,7 @@ local FILE_LOG_PATH = os.tmpname()
 
 describe("Plugin: file-log (log)", function()
   local client
-  setup(function()
+  lazy_setup(function()
     local _, db, dao = helpers.get_db_utils()
 
     local api1 = assert(dao.apis:insert {
@@ -31,7 +31,7 @@ describe("Plugin: file-log (log)", function()
       nginx_conf = "spec/fixtures/custom_nginx.template",
     }))
   end)
-  teardown(function()
+  lazy_teardown(function()
     helpers.stop_kong()
   end)
 

--- a/spec-old-api/03-plugins/05-syslog/01-log_spec.lua
+++ b/spec-old-api/03-plugins/05-syslog/01-log_spec.lua
@@ -5,7 +5,7 @@ local pl_stringx = require "pl.stringx"
 
 describe("#flaky Plugin: syslog (log)", function()
   local client, platform
-  setup(function()
+  lazy_setup(function()
     helpers.run_migrations()
 
     local api1 = assert(helpers.dao.apis:insert {
@@ -63,7 +63,7 @@ describe("#flaky Plugin: syslog (log)", function()
       nginx_conf = "spec/fixtures/custom_nginx.template",
     }))
   end)
-  teardown(function()
+  lazy_teardown(function()
     helpers.stop_kong()
   end)
 

--- a/spec-old-api/03-plugins/06-statsd/01-log_spec.lua
+++ b/spec-old-api/03-plugins/06-statsd/01-log_spec.lua
@@ -3,7 +3,7 @@ local UDP_PORT = 20000
 
 describe("Plugin: statsd (log)", function()
   local client
-  setup(function()
+  lazy_setup(function()
     local bp, db, dao = helpers.get_db_utils()
 
     local consumer1 = bp.consumers:insert {
@@ -274,7 +274,7 @@ describe("Plugin: statsd (log)", function()
     client = helpers.proxy_client()
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     if client then client:close() end
     helpers.stop_kong()
   end)

--- a/spec-old-api/03-plugins/07-loggly/01-log_spec.lua
+++ b/spec-old-api/03-plugins/07-loggly/01-log_spec.lua
@@ -5,7 +5,7 @@ local UDP_PORT = 20000
 
 describe("Plugin: loggly (log)", function()
   local client
-  setup(function()
+  lazy_setup(function()
     local _, db, dao = helpers.get_db_utils()
 
     local api1 = assert(dao.apis:insert {
@@ -79,7 +79,7 @@ describe("Plugin: loggly (log)", function()
       nginx_conf = "spec/fixtures/custom_nginx.template",
     }))
   end)
-  teardown(function()
+  lazy_teardown(function()
     helpers.stop_kong()
   end)
 

--- a/spec-old-api/03-plugins/08-datadog/01-log_spec.lua
+++ b/spec-old-api/03-plugins/08-datadog/01-log_spec.lua
@@ -3,7 +3,7 @@ local pl_file = require "pl.file"
 
 describe("Plugin: datadog (log)", function()
   local client
-  setup(function()
+  lazy_setup(function()
     local bp, db, dao = helpers.get_db_utils()
 
     local consumer1 = bp.consumers:insert {
@@ -114,7 +114,7 @@ describe("Plugin: datadog (log)", function()
     }))
     client = helpers.proxy_client()
   end)
-  teardown(function()
+  lazy_teardown(function()
     if client then client:close() end
     helpers.stop_kong()
   end)

--- a/spec-old-api/03-plugins/10-key-auth/01-api_spec.lua
+++ b/spec-old-api/03-plugins/10-key-auth/01-api_spec.lua
@@ -10,7 +10,7 @@ describe("Plugin: key-auth (API)", function()
   local bp
   local db
 
-  setup(function()
+  lazy_setup(function()
     bp, db, dao = helpers.get_db_utils()
 
     assert(dao.apis:insert {
@@ -37,7 +37,7 @@ describe("Plugin: key-auth (API)", function()
 
     admin_client = helpers.admin_client()
   end)
-  teardown(function()
+  lazy_teardown(function()
     if admin_client then admin_client:close() end
     helpers.stop_kong()
   end)
@@ -99,14 +99,14 @@ describe("Plugin: key-auth (API)", function()
 
 
     describe("GET", function()
-      setup(function()
+      lazy_setup(function()
         for i = 1, 3 do
           bp.keyauth_credentials:insert {
             consumer = { id = consumer.id },
           }
         end
       end)
-      teardown(function()
+      lazy_teardown(function()
         db:truncate("keyauth_credentials")
       end)
       it("retrieves the first page", function()
@@ -321,7 +321,7 @@ describe("Plugin: key-auth (API)", function()
     local consumer2
 
     describe("GET", function()
-      setup(function()
+      lazy_setup(function()
         db:truncate("keyauth_credentials")
 
         for i = 1, 3 do
@@ -397,7 +397,7 @@ describe("Plugin: key-auth (API)", function()
     describe("GET", function()
       local credential
 
-      setup(function()
+      lazy_setup(function()
         db:truncate("keyauth_credentials")
         credential = bp.keyauth_credentials:insert {
           consumer = { id = consumer.id },

--- a/spec-old-api/03-plugins/10-key-auth/02-access_spec.lua
+++ b/spec-old-api/03-plugins/10-key-auth/02-access_spec.lua
@@ -5,7 +5,7 @@ local utils = require "kong.tools.utils"
 
 describe("Plugin: key-auth (access)", function()
   local client
-  setup(function()
+  lazy_setup(function()
     local bp, db, dao = helpers.get_db_utils()
 
     local anonymous_user = bp.consumers:insert {
@@ -114,7 +114,7 @@ describe("Plugin: key-auth (access)", function()
     }))
     client = helpers.proxy_client()
   end)
-  teardown(function()
+  lazy_teardown(function()
     if client then client:close() end
     helpers.stop_kong()
   end)
@@ -409,7 +409,7 @@ describe("Plugin: key-auth (access)", function()
 
   local client, user1, user2, anonymous
 
-  setup(function()
+  lazy_setup(function()
     local bp, db, dao = helpers.get_db_utils()
 
     local api1 = assert(dao.apis:insert {
@@ -473,7 +473,7 @@ describe("Plugin: key-auth (access)", function()
   end)
 
 
-  teardown(function()
+  lazy_teardown(function()
     if client then client:close() end
     helpers.stop_kong()
   end)

--- a/spec-old-api/03-plugins/11-basic-auth/03-access_spec.lua
+++ b/spec-old-api/03-plugins/11-basic-auth/03-access_spec.lua
@@ -7,7 +7,7 @@ describe("Plugin: basic-auth (access)", function()
 
   local client
 
-  setup(function()
+  lazy_setup(function()
     local bp, db, dao = helpers.get_db_utils()
 
     local api1 = assert(dao.apis:insert {
@@ -88,7 +88,7 @@ describe("Plugin: basic-auth (access)", function()
   end)
 
 
-  teardown(function()
+  lazy_teardown(function()
     if client then client:close() end
     helpers.stop_kong()
   end)
@@ -350,7 +350,7 @@ describe("Plugin: basic-auth (access)", function()
 
   local client, user1, user2, anonymous
 
-  setup(function()
+  lazy_setup(function()
     local bp, db, dao = helpers.get_db_utils()
 
     local api1 = assert(dao.apis:insert {
@@ -414,7 +414,7 @@ describe("Plugin: basic-auth (access)", function()
   end)
 
 
-  teardown(function()
+  lazy_teardown(function()
     if client then client:close() end
     helpers.stop_kong()
   end)

--- a/spec-old-api/03-plugins/12-correlation-id/01-access_spec.lua
+++ b/spec-old-api/03-plugins/12-correlation-id/01-access_spec.lua
@@ -7,7 +7,7 @@ local TRACKER_PATTERN = "%d+%.%d+%.%d+%.%d+%-%d+%-%d+%-%d+%-%d+%-%d%d%d%d%d%d%d%
 
 describe("Plugin: correlation-id (access)", function()
   local client
-  setup(function()
+  lazy_setup(function()
     local _, db, dao = helpers.get_db_utils()
 
     local api1     = assert(dao.apis:insert {
@@ -64,7 +64,7 @@ describe("Plugin: correlation-id (access)", function()
     client = helpers.proxy_client()
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     if client then client:close() end
     helpers.stop_kong()
   end)

--- a/spec-old-api/03-plugins/13-request-size-limiting/01-access_spec.lua
+++ b/spec-old-api/03-plugins/13-request-size-limiting/01-access_spec.lua
@@ -7,7 +7,7 @@ local MB = 2^20
 describe("Plugin: request-size-limiting (access)", function()
   local client
 
-  setup(function()
+  lazy_setup(function()
     local _, db, dao = helpers.get_db_utils()
 
     local api = assert(dao.apis:insert {
@@ -29,7 +29,7 @@ describe("Plugin: request-size-limiting (access)", function()
     client = helpers.proxy_client()
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     if client then client:close() end
     helpers.stop_kong()
   end)

--- a/spec-old-api/03-plugins/14-cors/01-access_spec.lua
+++ b/spec-old-api/03-plugins/14-cors/01-access_spec.lua
@@ -4,7 +4,7 @@ local cjson = require "cjson"
 describe("Plugin: cors (access)", function()
   local client
 
-  setup(function()
+  lazy_setup(function()
     local _, db, dao = helpers.get_db_utils()
 
     local api1 = assert(dao.apis:insert {
@@ -147,7 +147,7 @@ describe("Plugin: cors (access)", function()
     client = helpers.proxy_client()
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     if client then client:close() end
     helpers.stop_kong()
   end)

--- a/spec-old-api/03-plugins/15-request-transformer/02-access_spec.lua
+++ b/spec-old-api/03-plugins/15-request-transformer/02-access_spec.lua
@@ -4,7 +4,7 @@ local cjson   = require "cjson"
 describe("Plugin: request-transformer (access)", function()
   local client
 
-  setup(function()
+  lazy_setup(function()
     local _, db, dao = helpers.get_db_utils()
 
     local api1 = assert(dao.apis:insert { name = "api-1", hosts = { "test1.com" }, upstream_url = helpers.mock_upstream_url})
@@ -125,7 +125,7 @@ describe("Plugin: request-transformer (access)", function()
     }))
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     helpers.stop_kong()
   end)
 

--- a/spec-old-api/03-plugins/15-request-transformer/03-api_spec.lua
+++ b/spec-old-api/03-plugins/15-request-transformer/03-api_spec.lua
@@ -4,7 +4,7 @@ local cjson = require "cjson"
 describe("Plugin: request-transformer (API)", function()
   local admin_client
 
-  teardown(function()
+  lazy_teardown(function()
     if admin_client then
       admin_client:close()
     end
@@ -13,7 +13,7 @@ describe("Plugin: request-transformer (API)", function()
   end)
 
   describe("POST", function()
-    setup(function()
+    lazy_setup(function()
       local dao = select(3, helpers.get_db_utils())
 
       assert(dao.apis:insert {

--- a/spec-old-api/03-plugins/16-response-transformer/02-body_transformer_spec.lua
+++ b/spec-old-api/03-plugins/16-response-transformer/02-body_transformer_spec.lua
@@ -167,7 +167,7 @@ describe("Plugin: response-transformer", function()
 
     local old_ngx, handler
 
-    setup(function()
+    lazy_setup(function()
       old_ngx = ngx
       _G.ngx = {       -- busted requires explicit _G to access the global environment
         log = function() end,
@@ -183,7 +183,7 @@ describe("Plugin: response-transformer", function()
       handler:new()
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       -- luacheck: globals ngx
       ngx = old_ngx
     end)

--- a/spec-old-api/03-plugins/16-response-transformer/03-api_spec.lua
+++ b/spec-old-api/03-plugins/16-response-transformer/03-api_spec.lua
@@ -4,7 +4,7 @@ local cjson = require "cjson"
 describe("Plugin: response-transformer (API)", function()
   local admin_client
 
-  teardown(function()
+  lazy_teardown(function()
     if admin_client then
       admin_client:close()
     end
@@ -12,7 +12,7 @@ describe("Plugin: response-transformer (API)", function()
   end)
 
   describe("POST", function()
-    setup(function()
+    lazy_setup(function()
       local dao = select(3, helpers.get_db_utils())
 
       assert(dao.apis:insert {

--- a/spec-old-api/03-plugins/16-response-transformer/04-filter_spec.lua
+++ b/spec-old-api/03-plugins/16-response-transformer/04-filter_spec.lua
@@ -3,7 +3,7 @@ local helpers = require "spec.helpers"
 describe("Plugin: response-transformer (filter)", function()
   local client
 
-  setup(function()
+  lazy_setup(function()
     local _, db, dao = helpers.get_db_utils()
 
     local api1 = assert(dao.apis:insert {
@@ -42,7 +42,7 @@ describe("Plugin: response-transformer (filter)", function()
     }))
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     helpers.stop_kong()
   end)
 

--- a/spec-old-api/03-plugins/16-response-transformer/05-big_response_body_spec.lua
+++ b/spec-old-api/03-plugins/16-response-transformer/05-big_response_body_spec.lua
@@ -11,7 +11,7 @@ end
 describe("Plugin: response-transformer", function()
   local client
 
-  setup(function()
+  lazy_setup(function()
     local _, db, dao = helpers.get_db_utils()
 
     local api = assert(dao.apis:insert {
@@ -38,7 +38,7 @@ describe("Plugin: response-transformer", function()
   end)
 
 
-  teardown(function()
+  lazy_teardown(function()
     helpers.stop_kong()
   end)
 

--- a/spec-old-api/03-plugins/17-jwt/02-api_spec.lua
+++ b/spec-old-api/03-plugins/17-jwt/02-api_spec.lua
@@ -10,7 +10,7 @@ describe("Plugin: jwt (API) [#" .. strategy .. "]", function()
   local bp
   local db
 
-  setup(function()
+  lazy_setup(function()
     bp, db = helpers.get_db_utils(strategy)
 
     assert(helpers.start_kong({
@@ -22,7 +22,7 @@ describe("Plugin: jwt (API) [#" .. strategy .. "]", function()
       username = "bob"
     }
   end)
-  teardown(function()
+  lazy_teardown(function()
     if admin_client then
       admin_client:close()
     end
@@ -30,7 +30,7 @@ describe("Plugin: jwt (API) [#" .. strategy .. "]", function()
   end)
 
   describe("/consumers/:consumer/jwt/", function()
-    setup(function()
+    lazy_setup(function()
       bp.consumers:insert {
         username = "alice"
       }
@@ -38,7 +38,7 @@ describe("Plugin: jwt (API) [#" .. strategy .. "]", function()
 
     describe("POST", function()
       local jwt1, jwt2
-      teardown(function()
+      lazy_teardown(function()
         if jwt1 == nil then return end
         db.jwt_secrets:delete(jwt1)
         if jwt2 == nil then return end
@@ -342,7 +342,7 @@ describe("Plugin: jwt (API) [#" .. strategy .. "]", function()
   describe("/jwts", function()
     local consumer2
     describe("GET", function()
-      setup(function()
+      lazy_setup(function()
         consumer2 = bp.consumers:insert {
           username = "bob-the-buidler"
         }

--- a/spec-old-api/03-plugins/17-jwt/03-access_spec.lua
+++ b/spec-old-api/03-plugins/17-jwt/03-access_spec.lua
@@ -15,7 +15,7 @@ describe("Plugin: jwt (access)", function()
   local jwt_secret, base64_jwt_secret, rsa_jwt_secret_1, rsa_jwt_secret_2, rsa_jwt_secret_3
   local proxy_client, admin_client
 
-  setup(function()
+  lazy_setup(function()
     local bp, db, dao = helpers.get_db_utils()
 
     local apis = {}
@@ -102,7 +102,7 @@ describe("Plugin: jwt (access)", function()
     admin_client = helpers.admin_client()
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     if proxy_client then proxy_client:close() end
     if admin_client then admin_client:close() end
     helpers.stop_kong()
@@ -542,7 +542,7 @@ describe("Plugin: jwt (access)", function()
 
   local client, user1, user2, anonymous, jwt_token
 
-  setup(function()
+  lazy_setup(function()
     local bp, db, dao = helpers.get_db_utils()
 
     local api1 = assert(dao.apis:insert {
@@ -607,7 +607,7 @@ describe("Plugin: jwt (access)", function()
   end)
 
 
-  teardown(function()
+  lazy_teardown(function()
     if client then client:close() end
     helpers.stop_kong()
   end)

--- a/spec-old-api/03-plugins/18-ip-restriction/02-access_spec.lua
+++ b/spec-old-api/03-plugins/18-ip-restriction/02-access_spec.lua
@@ -6,7 +6,7 @@ describe("Plugin: ip-restriction (access)", function()
   local client, admin_client
   local dao, db, _
 
-  setup(function()
+  lazy_setup(function()
     _, db, dao = helpers.get_db_utils()
 
     local api1 = assert(dao.apis:insert {
@@ -122,7 +122,7 @@ describe("Plugin: ip-restriction (access)", function()
     admin_client = helpers.admin_client()
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     if client and admin_client then
       client:close()
       admin_client:close()

--- a/spec-old-api/03-plugins/19-acl/01-api_spec.lua
+++ b/spec-old-api/03-plugins/19-acl/01-api_spec.lua
@@ -9,7 +9,7 @@ describe("Plugin: acl (API) [#" .. strategy .. "]", function()
   local bp
   local db
 
-  setup(function()
+  lazy_setup(function()
     bp, db = helpers.get_db_utils(strategy)
 
     assert(helpers.start_kong({
@@ -19,7 +19,7 @@ describe("Plugin: acl (API) [#" .. strategy .. "]", function()
     admin_client = helpers.admin_client()
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     if admin_client then
       admin_client:close()
     end
@@ -28,7 +28,7 @@ describe("Plugin: acl (API) [#" .. strategy .. "]", function()
   end)
 
   describe("/consumers/:consumer/acls/", function()
-    setup(function()
+    lazy_setup(function()
       db:truncate()
       consumer = bp.consumers:insert {
         username = "bob"
@@ -74,7 +74,7 @@ describe("Plugin: acl (API) [#" .. strategy .. "]", function()
 
 
     describe("GET", function()
-      teardown(function()
+      lazy_teardown(function()
         db:truncate("acls")
       end)
       it("retrieves the first page", function()
@@ -282,7 +282,7 @@ describe("Plugin: acl (API) [#" .. strategy .. "]", function()
     local consumer2
 
     describe("GET", function()
-      setup(function()
+      lazy_setup(function()
         db:truncate("acls")
 
         for i = 1, 3 do
@@ -360,7 +360,7 @@ describe("Plugin: acl (API) [#" .. strategy .. "]", function()
     describe("GET", function()
       local credential
 
-      setup(function()
+      lazy_setup(function()
         db:truncate("acls")
         credential = bp.acls:insert {
           group = "foo-group",

--- a/spec-old-api/03-plugins/19-acl/02-access_spec.lua
+++ b/spec-old-api/03-plugins/19-acl/02-access_spec.lua
@@ -5,7 +5,7 @@ describe("Plugin: ACL (access)", function()
   local client, api_client
   local bp, db, dao
 
-  setup(function()
+  lazy_setup(function()
     bp, db, dao = helpers.get_db_utils()
 
     local consumer1 = bp.consumers:insert {
@@ -227,7 +227,7 @@ describe("Plugin: ACL (access)", function()
     api_client:close()
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     helpers.stop_kong()
   end)
 

--- a/spec-old-api/03-plugins/20-hmac-auth/02-api_spec.lua
+++ b/spec-old-api/03-plugins/20-hmac-auth/02-api_spec.lua
@@ -8,7 +8,7 @@ describe("Plugin: hmac-auth (API)", function()
   local db
   local dao
 
-  setup(function()
+  lazy_setup(function()
     bp, db, dao = helpers.get_db_utils()
 
     helpers.prepare_prefix()
@@ -16,7 +16,7 @@ describe("Plugin: hmac-auth (API)", function()
     client = helpers.admin_client()
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     if client then client:close() end
     assert(helpers.stop_kong())
     helpers.clean_prefix()
@@ -229,7 +229,7 @@ describe("Plugin: hmac-auth (API)", function()
   describe("/hmac-auths", function()
     local consumer2
     describe("GET", function()
-      setup(function()
+      lazy_setup(function()
         db:truncate("hmacauth_credentials")
         bp.hmacauth_credentials:insert({
           consumer = { id = consumer.id },
@@ -297,7 +297,7 @@ describe("Plugin: hmac-auth (API)", function()
   describe("/hmac-auths/:hmac_username_or_id/consumer", function()
     describe("GET", function()
       local credential
-      setup(function()
+      lazy_setup(function()
         db:truncate("hmacauth_credentials")
         credential = bp.hmacauth_credentials:insert({
           consumer = { id = consumer.id },

--- a/spec-old-api/03-plugins/20-hmac-auth/03-access_spec.lua
+++ b/spec-old-api/03-plugins/20-hmac-auth/03-access_spec.lua
@@ -13,7 +13,7 @@ local SIGNATURE_NOT_VALID = "HMAC signature cannot be verified"
 describe("Plugin: hmac-auth (access)", function()
   local client, consumer, credential
 
-  setup(function()
+  lazy_setup(function()
     local bp, db, dao = helpers.get_db_utils()
 
     local api1 = assert(dao.apis:insert {
@@ -124,7 +124,7 @@ describe("Plugin: hmac-auth (access)", function()
     client = helpers.proxy_client()
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     if client then client:close() end
     helpers.stop_kong()
   end)
@@ -1203,7 +1203,7 @@ describe("Plugin: hmac-auth (access)", function()
 
   local client, user1, user2, anonymous, hmacAuth, hmacDate
 
-  setup(function()
+  lazy_setup(function()
     local bp, db, dao = helpers.get_db_utils()
 
     local api1 = assert(dao.apis:insert {
@@ -1271,7 +1271,7 @@ describe("Plugin: hmac-auth (access)", function()
   end)
 
 
-  teardown(function()
+  lazy_teardown(function()
     if client then client:close() end
     helpers.stop_kong()
   end)

--- a/spec-old-api/03-plugins/20-hmac-auth/04-invalidations_spec.lua
+++ b/spec-old-api/03-plugins/20-hmac-auth/04-invalidations_spec.lua
@@ -9,7 +9,7 @@ describe("Plugin: hmac-auth (invalidations)", function()
   local bp
   local db
 
-  setup(function()
+  lazy_setup(function()
     bp, db, dao = helpers.get_db_utils()
 
     local api = assert(dao.apis:insert {
@@ -42,7 +42,7 @@ describe("Plugin: hmac-auth (invalidations)", function()
     client_admin = helpers.admin_client()
   end)
 
-   teardown(function()
+   lazy_teardown(function()
     if client_proxy and client_admin then
       client_proxy:close()
       client_admin:close()

--- a/spec-old-api/03-plugins/21-ldap-auth/01-access_spec.lua
+++ b/spec-old-api/03-plugins/21-ldap-auth/01-access_spec.lua
@@ -24,7 +24,7 @@ local ldap_host_aws = "ec2-54-172-82-117.compute-1.amazonaws.com"
 describe("Plugin: ldap-auth (access)", function()
   local client, client_admin, api2, plugin2
 
-  setup(function()
+  lazy_setup(function()
     local bp, db, dao = helpers.get_db_utils()
 
     local api1 = assert(dao.apis:insert {
@@ -140,7 +140,7 @@ describe("Plugin: ldap-auth (access)", function()
     }))
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     helpers.stop_kong()
   end)
 
@@ -452,7 +452,7 @@ describe("Plugin: ldap-auth (access)", function()
 
   local client, user1, anonymous
 
-  setup(function()
+  lazy_setup(function()
     local bp, db, dao = helpers.get_db_utils()
 
     local api1 = assert(dao.apis:insert {
@@ -520,7 +520,7 @@ describe("Plugin: ldap-auth (access)", function()
   end)
 
 
-  teardown(function()
+  lazy_teardown(function()
     if client then client:close() end
     helpers.stop_kong()
   end)

--- a/spec-old-api/03-plugins/22-bot-detection/01-access_spec.lua
+++ b/spec-old-api/03-plugins/22-bot-detection/01-access_spec.lua
@@ -5,7 +5,7 @@ local FACEBOOK = "facebookexternalhit/1.1"  -- matches a known bot in `rules.lua
 
 describe("Plugin: bot-detection (access)", function()
   local client
-  setup(function()
+  lazy_setup(function()
     local _, db, dao = helpers.get_db_utils()
 
     local api1 = assert(dao.apis:insert {
@@ -52,7 +52,7 @@ describe("Plugin: bot-detection (access)", function()
     }))
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     helpers.stop_kong()
   end)
 
@@ -153,7 +153,7 @@ end)
 
 describe("Plugin: bot-detection configured global (access)", function()
   local client
-  setup(function()
+  lazy_setup(function()
     local _, db, dao = helpers.get_db_utils()
 
     assert(dao.apis:insert {
@@ -174,7 +174,7 @@ describe("Plugin: bot-detection configured global (access)", function()
     }))
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     helpers.stop_kong()
   end)
 

--- a/spec-old-api/03-plugins/22-bot-detection/02-invalidations_spec.lua
+++ b/spec-old-api/03-plugins/22-bot-detection/02-invalidations_spec.lua
@@ -3,7 +3,7 @@ local helpers = require "spec.helpers"
 describe("Plugin: bot-detection (hooks)", function()
   local plugin, proxy_client, admin_client
 
-  setup(function()
+  lazy_setup(function()
     local _, db, dao = helpers.get_db_utils()
 
     local api1 = assert(dao.apis:insert {
@@ -22,7 +22,7 @@ describe("Plugin: bot-detection (hooks)", function()
     }))
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     helpers.stop_kong()
   end)
 

--- a/spec-old-api/03-plugins/22-bot-detection/03-api_spec.lua
+++ b/spec-old-api/03-plugins/22-bot-detection/03-api_spec.lua
@@ -5,7 +5,7 @@ local BAD_REGEX = [[(https?:\/\/.*]]  -- illegal regex, errors out
 describe("Plugin: bot-detection (API)", function()
   local client
 
-  setup(function()
+  lazy_setup(function()
     local dao = select(3, helpers.get_db_utils())
 
     assert(dao.apis:insert {
@@ -24,7 +24,7 @@ describe("Plugin: bot-detection (API)", function()
     }))
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     helpers.stop_kong()
   end)
 

--- a/spec-old-api/03-plugins/23-aws-lambda/01-access_spec.lua
+++ b/spec-old-api/03-plugins/23-aws-lambda/01-access_spec.lua
@@ -3,7 +3,7 @@ local helpers = require "spec.helpers"
 describe("Plugin: AWS Lambda (access)", function()
   local client, api_client
 
-  setup(function()
+  lazy_setup(function()
     local _, db, dao = helpers.get_db_utils()
 
     local api1 = assert(dao.apis:insert {
@@ -214,7 +214,7 @@ describe("Plugin: AWS Lambda (access)", function()
     api_client:close()
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     helpers.stop_kong()
   end)
 

--- a/spec-old-api/03-plugins/24-rate-limiting/02-policies_spec.lua
+++ b/spec-old-api/03-plugins/24-rate-limiting/02-policies_spec.lua
@@ -10,7 +10,7 @@ describe("Plugin: rate-limiting (policies)", function()
     local dao
     local policies
 
-    setup(function()
+    lazy_setup(function()
       local _, db
       _, db, dao = helpers.get_db_utils()
 

--- a/spec-old-api/03-plugins/24-rate-limiting/03-api_spec.lua
+++ b/spec-old-api/03-plugins/24-rate-limiting/03-api_spec.lua
@@ -5,17 +5,17 @@ describe("Plugin: rate-limiting (API)", function()
   local admin_client
   local dao
 
-  setup(function()
+  lazy_setup(function()
     dao = select(3, helpers.get_db_utils())
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     if admin_client then admin_client:close() end
     helpers.stop_kong()
   end)
 
   describe("POST", function()
-    setup(function()
+    lazy_setup(function()
 
       assert(dao.apis:insert {
         name         = "test",

--- a/spec-old-api/03-plugins/24-rate-limiting/04-access_spec.lua
+++ b/spec-old-api/03-plugins/24-rate-limiting/04-access_spec.lua
@@ -48,7 +48,7 @@ end
 
 for i, policy in ipairs({"local", "cluster", "redis"}) do
   describe("#flaky Plugin: rate-limiting (access) with policy: " .. policy, function()
-    setup(function()
+    lazy_setup(function()
       helpers.kill_all()
       flush_redis()
       helpers.dao:drop_schema()
@@ -200,7 +200,7 @@ for i, policy in ipairs({"local", "cluster", "redis"}) do
       }))
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 
@@ -438,7 +438,7 @@ for i, policy in ipairs({"local", "cluster", "redis"}) do
           }))
         end)
 
-        teardown(function()
+        lazy_teardown(function()
           helpers.kill_all()
           helpers.dao:drop_schema()
           helpers.run_migrations()
@@ -564,7 +564,7 @@ for i, policy in ipairs({"local", "cluster", "redis"}) do
 
     describe("Expirations", function()
       local api
-      setup(function()
+      lazy_setup(function()
         helpers.stop_kong()
         helpers.dao:drop_schema()
         helpers.run_migrations()

--- a/spec-old-api/03-plugins/25-response-rate-limiting/02-policies_spec.lua
+++ b/spec-old-api/03-plugins/25-response-rate-limiting/02-policies_spec.lua
@@ -12,7 +12,7 @@ describe("Plugin: response-ratelimiting (policies)", function()
     local identifier = uuid()
     local dao
 
-    setup(function()
+    lazy_setup(function()
       local _, db
       _, db, dao = helpers.get_db_utils()
 

--- a/spec-old-api/03-plugins/25-response-rate-limiting/03-api_spec.lua
+++ b/spec-old-api/03-plugins/25-response-rate-limiting/03-api_spec.lua
@@ -4,7 +4,7 @@ local cjson = require "cjson"
 describe("Plugin: response-rate-limiting (API)", function()
   local admin_client
 
-  teardown(function()
+  lazy_teardown(function()
     if admin_client then
       admin_client:close()
     end
@@ -12,7 +12,7 @@ describe("Plugin: response-rate-limiting (API)", function()
   end)
 
   describe("POST", function()
-    setup(function()
+    lazy_setup(function()
       helpers.dao.apis:truncate()
       helpers.db.plugins:truncate()
       assert(helpers.dao.apis:insert {

--- a/spec-old-api/03-plugins/25-response-rate-limiting/04-access_spec.lua
+++ b/spec-old-api/03-plugins/25-response-rate-limiting/04-access_spec.lua
@@ -48,7 +48,7 @@ end
 
 for i, policy in ipairs({"local", "cluster", "redis"}) do
   describe("#flaky Plugin: response-ratelimiting (access) with policy: " .. policy, function()
-    setup(function()
+    lazy_setup(function()
       flush_redis()
       helpers.dao:drop_schema()
       helpers.run_migrations()
@@ -231,7 +231,7 @@ for i, policy in ipairs({"local", "cluster", "redis"}) do
       }))
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 
@@ -567,7 +567,7 @@ for i, policy in ipairs({"local", "cluster", "redis"}) do
           }))
         end)
 
-        teardown(function()
+        lazy_teardown(function()
           helpers.kill_all()
           helpers.dao:drop_schema()
           helpers.run_migrations()
@@ -698,7 +698,7 @@ for i, policy in ipairs({"local", "cluster", "redis"}) do
 
     describe("Expirations", function()
       local api
-      setup(function()
+      lazy_setup(function()
         helpers.stop_kong()
         helpers.dao:drop_schema()
         helpers.run_migrations()

--- a/spec-old-api/03-plugins/26-oauth2/02-api_spec.lua
+++ b/spec-old-api/03-plugins/26-oauth2/02-api_spec.lua
@@ -10,7 +10,7 @@ describe("Plugin: oauth (API)", function()
   local bp
   local dao
 
-  setup(function()
+  lazy_setup(function()
     bp, db, dao = helpers.get_db_utils(strategy)
 
     assert(db:truncate("routes"))
@@ -30,14 +30,14 @@ describe("Plugin: oauth (API)", function()
 
     admin_client = helpers.admin_client()
   end)
-  teardown(function()
+  lazy_teardown(function()
     if admin_client then admin_client:close() end
     assert(helpers.stop_kong())
     helpers.clean_prefix()
   end)
 
   describe("/consumers/:consumer/oauth2/", function()
-    setup(function()
+    lazy_setup(function()
       api = dao.apis:insert {
         name         = "oauth2_token.com",
         hosts        = { "oauth2_token.com" },
@@ -195,7 +195,7 @@ describe("Plugin: oauth (API)", function()
 
 
     describe("GET", function()
-      setup(function()
+      lazy_setup(function()
         for i = 1, 3 do
           bp.oauth2_credentials:insert {
             name          = "app" .. i,
@@ -204,7 +204,7 @@ describe("Plugin: oauth (API)", function()
           }
         end
       end)
-      teardown(function()
+      lazy_teardown(function()
         assert(db:truncate("oauth2_credentials"))
       end)
       it("retrieves the first page", function()
@@ -399,7 +399,7 @@ describe("Plugin: oauth (API)", function()
 
   describe("/oauth2_tokens/", function()
     local oauth2_credential
-    setup(function()
+    lazy_setup(function()
       oauth2_credential = bp.oauth2_credentials:insert {
         name          = "Test APP",
         redirect_uris = { helpers.mock_upstream_ssl_url },
@@ -450,7 +450,7 @@ describe("Plugin: oauth (API)", function()
     end)
 
     describe("GET", function()
-      setup(function()
+      lazy_setup(function()
         for _ = 1, 3 do
           bp.oauth2_tokens:insert {
             credential = { id = oauth2_credential.id },
@@ -459,7 +459,7 @@ describe("Plugin: oauth (API)", function()
           }
         end
       end)
-      teardown(function()
+      lazy_teardown(function()
         assert(db:truncate("oauth2_tokens"))
       end)
       it("retrieves the first page", function()

--- a/spec-old-api/03-plugins/26-oauth2/03-access_spec.lua
+++ b/spec-old-api/03-plugins/26-oauth2/03-access_spec.lua
@@ -68,7 +68,7 @@ describe("Plugin: oauth2 (access)", function()
   local bp
   local db
   local dao
-  setup(function()
+  lazy_setup(function()
     bp, db, dao = helpers.get_db_utils()
 
     local consumer = bp.consumers:insert {
@@ -364,7 +364,7 @@ describe("Plugin: oauth2 (access)", function()
     proxy_client    = helpers.proxy_client()
     proxy_ssl_client = helpers.proxy_ssl_client()
   end)
-  teardown(function()
+  lazy_teardown(function()
     if proxy_client and proxy_ssl_client then
       proxy_client:close()
       proxy_ssl_client:close()
@@ -2348,7 +2348,7 @@ describe("Plugin: oauth2 (access)", function()
   local bp
   local db
 
-  setup(function()
+  lazy_setup(function()
     bp, db, dao = helpers.get_db_utils()
 
     local api1 = assert(dao.apis:insert {
@@ -2431,7 +2431,7 @@ describe("Plugin: oauth2 (access)", function()
   end)
 
 
-  teardown(function()
+  lazy_teardown(function()
     if client then client:close() end
     helpers.stop_kong()
   end)
@@ -2577,7 +2577,7 @@ for _, strategy in helpers.each_strategy() do
     local bp
     local db
 
-    setup(function()
+    lazy_setup(function()
       bp, db, dao = helpers.get_db_utils(strategy)
 
       local api11 = assert(dao.apis:insert {
@@ -2636,7 +2636,7 @@ for _, strategy in helpers.each_strategy() do
       client = helpers.proxy_client()
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       if client then client:close() end
       helpers.stop_kong()
     end)

--- a/spec-old-api/03-plugins/26-oauth2/04-invalidations_spec.lua
+++ b/spec-old-api/03-plugins/26-oauth2/04-invalidations_spec.lua
@@ -8,7 +8,7 @@ describe("Plugin: oauth2 (invalidations)", function()
   local dao
   local bp
 
-  setup(function()
+  lazy_setup(function()
     bp, db, dao = helpers.get_db_utils(strategy)
   end)
 

--- a/spec-old-api/03-plugins/27-request-termination/02-access_spec.lua
+++ b/spec-old-api/03-plugins/27-request-termination/02-access_spec.lua
@@ -4,7 +4,7 @@ local cjson = require "cjson"
 describe("Plugin: request-termination (access)", function()
   local client, admin_client
 
-  setup(function()
+  lazy_setup(function()
     local _, db, dao = helpers.get_db_utils()
 
     local api1 = assert(dao.apis:insert {
@@ -89,7 +89,7 @@ describe("Plugin: request-termination (access)", function()
     admin_client = helpers.admin_client()
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     if client and admin_client then
       client:close()
       admin_client:close()

--- a/spec-old-api/03-plugins/27-request-termination/03-integration_spec.lua
+++ b/spec-old-api/03-plugins/27-request-termination/03-integration_spec.lua
@@ -4,7 +4,7 @@ describe("Plugin: request-termination (integration)", function()
   local client, admin_client
   local consumer1
 
-  setup(function()
+  lazy_setup(function()
     local bp, db, dao = helpers.get_db_utils()
 
     assert(dao.apis:insert {
@@ -30,7 +30,7 @@ describe("Plugin: request-termination (integration)", function()
     admin_client = helpers.admin_client()
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     if client and admin_client then
       client:close()
       admin_client:close()

--- a/spec/01-unit/000-new-dao/01-schema/06-plugins_spec.lua
+++ b/spec/01-unit/000-new-dao/01-schema/06-plugins_spec.lua
@@ -13,7 +13,7 @@ describe("plugins", function()
   local Plugins
   local db
 
-  setup(function()
+  lazy_setup(function()
     assert(Entity.new(consumers_definition))
     assert(Entity.new(services_definition))
     assert(Entity.new(routes_definition))

--- a/spec/01-unit/001-rockspec_meta_spec.lua
+++ b/spec/01-unit/001-rockspec_meta_spec.lua
@@ -7,7 +7,7 @@ describe("rockspec/meta", function()
   local rock, lua_srcs = {}
   local rock_filename
 
-  setup(function()
+  lazy_setup(function()
     lua_srcs = pl_dir.getallfiles("./kong", "*.lua")
     assert.True(#lua_srcs > 0)
 

--- a/spec/01-unit/004-utils_spec.lua
+++ b/spec/01-unit/004-utils_spec.lua
@@ -50,7 +50,7 @@ describe("Utils", function()
     local old_ngx
     local headers = {}
 
-    setup(function()
+    lazy_setup(function()
       old_ngx = ngx
       _G.ngx = {
         var = {
@@ -62,12 +62,12 @@ describe("Utils", function()
       }
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       _G.ngx = old_ngx
     end)
 
     describe("without X-Forwarded-Proto header", function()
-      setup(function()
+      lazy_setup(function()
         headers["x-forwarded-proto"] = nil
       end)
 
@@ -91,7 +91,7 @@ describe("Utils", function()
 
     describe("with X-Forwarded-Proto header", function()
 
-      teardown(function()
+      lazy_teardown(function()
         headers["x-forwarded-proto"] = nil
       end)
 

--- a/spec/01-unit/010-router_spec.lua
+++ b/spec/01-unit/010-router_spec.lua
@@ -829,7 +829,7 @@ describe("Router", function()
       end)
 
       describe("root / [uri]", function()
-        setup(function()
+        lazy_setup(function()
           table.insert(use_case, 1, {
             service = service,
             route   = {
@@ -838,7 +838,7 @@ describe("Router", function()
           })
         end)
 
-        teardown(function()
+        lazy_teardown(function()
           table.remove(use_case, 1)
         end)
 
@@ -874,7 +874,7 @@ describe("Router", function()
 
         local n = 6
 
-        setup(function()
+        lazy_setup(function()
           -- all those routes are of the same category:
           -- [host + uri]
           for _ = 1, n - 1 do
@@ -900,7 +900,7 @@ describe("Router", function()
           })
         end)
 
-        teardown(function()
+        lazy_teardown(function()
           for _ = 1, n do
             table.remove(use_case)
           end
@@ -983,7 +983,7 @@ describe("Router", function()
         local target_domain
         local benchmark_use_cases = {}
 
-        setup(function()
+        lazy_setup(function()
           for i = 1, 10^5 do
             benchmark_use_cases[i] = {
               service = service,
@@ -1012,7 +1012,7 @@ describe("Router", function()
         local target_domain
         local benchmark_use_cases = {}
 
-        setup(function()
+        lazy_setup(function()
           local n = 10^5
 
           for i = 1, n - 1 do
@@ -1060,7 +1060,7 @@ describe("Router", function()
         local target_domain
         local benchmark_use_cases = {}
 
-        setup(function()
+        lazy_setup(function()
           local n = 10^5
 
           for i = 1, n - 1 do
@@ -1466,7 +1466,7 @@ describe("Router", function()
         },
       }
 
-      setup(function()
+      lazy_setup(function()
         router = assert(Router.new(use_case_routes))
       end)
 
@@ -1643,7 +1643,7 @@ describe("Router", function()
         },
       }
 
-      setup(function()
+      lazy_setup(function()
         router = assert(Router.new(use_case_routes))
       end)
 

--- a/spec/01-unit/011-balancer_spec.lua
+++ b/spec/01-unit/011-balancer_spec.lua
@@ -10,12 +10,12 @@ describe("Balancer", function()
   local upstream_ph
   local upstream_ote
 
-  teardown(function()
+  lazy_teardown(function()
     ngx.log:revert()
   end)
 
 
-  setup(function()
+  lazy_setup(function()
     stub(ngx, "log")
 
     balancer = require "kong.runloop.balancer"
@@ -310,7 +310,7 @@ describe("Balancer", function()
     local dns_client = require("resty.dns.client")
     dns_client.init()
 
-    setup(function()
+    lazy_setup(function()
       -- In these tests, we pass `true` to get_balancer
       -- to ensure that the upstream was created by `balancer.init()`
       balancer.init()
@@ -351,7 +351,7 @@ describe("Balancer", function()
 
   describe("load_upstreams_dict_into_memory()", function()
     local upstreams_dict
-    setup(function()
+    lazy_setup(function()
       upstreams_dict = balancer._load_upstreams_dict_into_memory()
     end)
 
@@ -390,7 +390,7 @@ describe("Balancer", function()
   describe("load_targets_into_memory()", function()
     local targets
     local upstream
-    setup(function()
+    lazy_setup(function()
       upstream = "a"
       targets = balancer._load_targets_into_memory(upstream)
     end)
@@ -405,7 +405,7 @@ describe("Balancer", function()
   end)
 
   describe("on_target_event()", function()
-    setup(function()
+    lazy_setup(function()
       balancer._load_targets_into_memory("ote")
     end)
 
@@ -432,12 +432,12 @@ describe("Balancer", function()
   describe("post_health()", function()
     local hc, my_balancer
 
-    setup(function()
+    lazy_setup(function()
       my_balancer = assert(balancer._create_balancer(upstream_ph))
       hc = assert(balancer._get_healthchecker(my_balancer))
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       if hc then
         hc:stop()
       end

--- a/spec/01-unit/013-reports_spec.lua
+++ b/spec/01-unit/013-reports_spec.lua
@@ -6,7 +6,7 @@ local cjson = require "cjson"
 
 describe("reports", function()
   describe("send()", function()
-    setup(function()
+    lazy_setup(function()
       reports.toggle(true)
     end)
     it("sends report over UDP", function()
@@ -70,11 +70,11 @@ describe("reports", function()
   end)
 
   describe("retrieve_redis_version()", function()
-    setup(function()
+    lazy_setup(function()
       stub(ngx, "log")
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       ngx.log:revert()
     end)
 

--- a/spec/01-unit/014-plugins_order_spec.lua
+++ b/spec/01-unit/014-plugins_order_spec.lua
@@ -7,7 +7,7 @@ local fmt = string.format
 describe("Plugins", function()
   local plugins
 
-  setup(function()
+  lazy_setup(function()
     local conf = assert(conf_loader(nil, {
       -- ensure we test the galileo priority even if galileo isn't enabled by
       -- default anymore

--- a/spec/01-unit/015-plugins_version_spec.lua
+++ b/spec/01-unit/015-plugins_version_spec.lua
@@ -4,7 +4,7 @@ local conf_loader = require "kong.conf_loader"
 describe("Plugins", function()
   local plugins
 
-  setup(function()
+  lazy_setup(function()
     local conf = assert(conf_loader())
 
     plugins = {}

--- a/spec/01-unit/016-dns_spec.lua
+++ b/spec/01-unit/016-dns_spec.lua
@@ -8,7 +8,7 @@ describe("DNS", function()
   local balancer, resolver, query_func, old_new
   local mock_records, singletons, client
 
-  setup(function()
+  lazy_setup(function()
     stub(ngx, "log")
     singletons = require "kong.singletons"
 
@@ -30,7 +30,7 @@ describe("DNS", function()
     client = require "resty.dns.client"
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     if type(ngx.log) == "table" then
       ngx.log:revert()
     end

--- a/spec/02-integration/000-new-dao/02-db_core_entities_spec.lua
+++ b/spec/02-integration/000-new-dao/02-db_core_entities_spec.lua
@@ -14,7 +14,7 @@ for _, strategy in helpers.each_strategy() do
   describe("kong.db [#" .. strategy .. "]", function()
     local db, bp
 
-    setup(function()
+    lazy_setup(function()
       bp, db = helpers.get_db_utils(strategy, {
         "routes",
         "services",
@@ -602,7 +602,7 @@ for _, strategy in helpers.each_strategy() do
         end)
 
         describe("page size", function()
-          setup(function()
+          lazy_setup(function()
             assert(db:truncate("routes"))
 
             for i = 1, 202 do
@@ -620,7 +620,7 @@ for _, strategy in helpers.each_strategy() do
         end)
 
         describe("page offset", function()
-          setup(function()
+          lazy_setup(function()
             assert(db:truncate("routes"))
 
             for i = 1, 10 do
@@ -774,7 +774,7 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       describe(":each()", function()
-        setup(function()
+        lazy_setup(function()
           assert(db:truncate("routes"))
 
           for i = 1, 100 do
@@ -1045,7 +1045,7 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       describe(":select_by_name()", function()
-        setup(function()
+        lazy_setup(function()
           assert(db:truncate("services"))
 
           for i = 1, 5 do
@@ -1327,7 +1327,7 @@ for _, strategy in helpers.each_strategy() do
       describe(":delete_by_name()", function()
         local service
 
-        setup(function()
+        lazy_setup(function()
           assert(db:truncate("services"))
 
           service = assert(db.services:insert({
@@ -1588,7 +1588,7 @@ for _, strategy in helpers.each_strategy() do
           local service
 
           describe("page size", function()
-            setup(function()
+            lazy_setup(function()
               assert(db:truncate("services"))
 
               service = bp.services:insert()
@@ -1624,7 +1624,7 @@ for _, strategy in helpers.each_strategy() do
           end)
 
           describe("page offset", function()
-            setup(function()
+            lazy_setup(function()
               assert(db:truncate("services"))
 
               service = bp.services:insert()

--- a/spec/02-integration/000-new-dao/03-db_cluster_ca_spec.lua
+++ b/spec/02-integration/000-new-dao/03-db_cluster_ca_spec.lua
@@ -13,7 +13,7 @@ for _, strategy in helpers.each_strategy() do
       local ca_key
       local ca_cert
 
-      setup(function()
+      lazy_setup(function()
         local _
         _, db = helpers.get_db_utils(strategy, {
           "cluster_ca",

--- a/spec/02-integration/000-new-dao/03-db_cluster_mutex_spec.lua
+++ b/spec/02-integration/000-new-dao/03-db_cluster_mutex_spec.lua
@@ -6,7 +6,7 @@ for _, strategy in helpers.each_strategy() do
     local db
 
 
-    setup(function()
+    lazy_setup(function()
       local _
       _, db, _ = helpers.get_db_utils(strategy)
 

--- a/spec/02-integration/000-new-dao/03-plugins_spec.lua
+++ b/spec/02-integration/000-new-dao/03-plugins_spec.lua
@@ -8,7 +8,7 @@ for _, strategy in helpers.each_strategy() do
   describe("kong.db [#" .. strategy .. "]", function()
     local db, bp
 
-    setup(function()
+    lazy_setup(function()
       bp, db = helpers.get_db_utils(strategy)
     end)
 

--- a/spec/02-integration/01-helpers/00-helpers_spec.lua
+++ b/spec/02-integration/01-helpers/00-helpers_spec.lua
@@ -6,7 +6,7 @@ for _, strategy in helpers.each_strategy() do
   describe("helpers [#" .. strategy .. "]: assertions and modifiers", function()
     local proxy_client
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy)
 
       local service = bp.services:insert {
@@ -27,7 +27,7 @@ for _, strategy in helpers.each_strategy() do
       }))
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 

--- a/spec/02-integration/01-helpers/01-blueprints_spec.lua
+++ b/spec/02-integration/01-helpers/01-blueprints_spec.lua
@@ -12,7 +12,7 @@ for _, strategy in helpers.each_strategy() do
   describe(string.format("blueprints db [#%s]", strategy), function()
 
     local bp
-    setup(function()
+    lazy_setup(function()
       local db = assert(DB.new(helpers.test_conf, strategy))
       assert(db:init_connector())
       assert(db.plugins:load_plugin_schemas(helpers.test_conf.loaded_plugins))
@@ -74,7 +74,7 @@ end
 dao_helpers.for_each_dao(function(kong_config)
   local bp, dao, db
 
-  setup(function()
+  lazy_setup(function()
     db = assert(DB.new(helpers.test_conf, kong_config.database))
     assert(db:init_connector())
     assert(db.plugins:load_plugin_schemas(helpers.test_conf.loaded_plugins))
@@ -82,7 +82,7 @@ dao_helpers.for_each_dao(function(kong_config)
     bp  = assert(Blueprints.new(dao, db))
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     if dao then
       dao:truncate_tables()
     end

--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -1,14 +1,14 @@
 local helpers = require "spec.helpers"
 
 describe("kong start/stop", function()
-  setup(function()
+  lazy_setup(function()
     helpers.get_db_utils() -- runs migrations
     helpers.prepare_prefix()
   end)
   after_each(function()
     helpers.kill_all()
   end)
-  teardown(function()
+  lazy_teardown(function()
     helpers.clean_prefix()
   end)
 

--- a/spec/02-integration/02-cmd/03-reload_spec.lua
+++ b/spec/02-integration/02-cmd/03-reload_spec.lua
@@ -1,11 +1,11 @@
 local helpers = require "spec.helpers"
 
 describe("kong reload", function()
-  setup(function()
+  lazy_setup(function()
     helpers.get_db_utils() -- runs migrations
     helpers.prepare_prefix()
   end)
-  teardown(function()
+  lazy_teardown(function()
     helpers.clean_prefix()
   end)
   after_each(function()

--- a/spec/02-integration/02-cmd/06-restart_spec.lua
+++ b/spec/02-integration/02-cmd/06-restart_spec.lua
@@ -1,11 +1,11 @@
 local helpers = require "spec.helpers"
 
 describe("kong restart", function()
-  setup(function()
+  lazy_setup(function()
     helpers.get_db_utils() -- runs migrations
     helpers.prepare_prefix()
   end)
-  teardown(function()
+  lazy_teardown(function()
     helpers.clean_prefix()
   end)
   after_each(function()

--- a/spec/02-integration/02-cmd/07-health_spec.lua
+++ b/spec/02-integration/02-cmd/07-health_spec.lua
@@ -1,10 +1,10 @@
 local helpers = require "spec.helpers"
 
 describe("kong health", function()
-  setup(function()
+  lazy_setup(function()
     helpers.prepare_prefix()
   end)
-  teardown(function()
+  lazy_teardown(function()
     helpers.clean_prefix()
   end)
   after_each(function()

--- a/spec/02-integration/02-cmd/08-quit_spec.lua
+++ b/spec/02-integration/02-cmd/08-quit_spec.lua
@@ -1,14 +1,14 @@
 local helpers = require "spec.helpers"
 
 describe("kong quit", function()
-  setup(function()
+  lazy_setup(function()
     helpers.get_db_utils() -- runs migrations
     helpers.prepare_prefix()
   end)
   after_each(function()
     helpers.kill_all()
   end)
-  teardown(function()
+  lazy_teardown(function()
     helpers.clean_prefix()
   end)
 

--- a/spec/02-integration/02-cmd/09-prepare_spec.lua
+++ b/spec/02-integration/02-cmd/09-prepare_spec.lua
@@ -5,7 +5,7 @@ local TEST_PREFIX = "servroot_prepared_test"
 
 
 describe("kong prepare", function()
-  setup(function()
+  lazy_setup(function()
     pcall(helpers.dir.rmtree, TEST_PREFIX)
   end)
 

--- a/spec/02-integration/02-cmd/10-migrations_spec.lua
+++ b/spec/02-integration/02-cmd/10-migrations_spec.lua
@@ -40,7 +40,7 @@ for _, strategy in helpers.each_strategy() do
 
   describe("kong migrations #" .. strategy, function()
 
-    teardown(function()
+    lazy_teardown(function()
       run_kong("migrations reset --yes")
     end)
 

--- a/spec/02-integration/03-dao/02-migrations_spec.lua
+++ b/spec/02-integration/03-dao/02-migrations_spec.lua
@@ -9,7 +9,7 @@ helpers.for_each_dao(function(kong_config)
   -- avoid potential corruptions of the test database
   pending("Model migrations with DB: #" .. kong_config.database, function()
     local factory
-    setup(function()
+    lazy_setup(function()
       -- some `setup` functions also use `factory` and they run before the `before_each` chain
       -- hence we need to set it here, and again in `before_each`.
       local db = assert(DB.new(kong_config))
@@ -18,7 +18,7 @@ helpers.for_each_dao(function(kong_config)
       factory:drop_schema()
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       ngx.shared.kong_cassandra:flush_expired()
     end)
 
@@ -63,7 +63,7 @@ helpers.for_each_dao(function(kong_config)
     describe("[INTEGRATION]", function()
       local n_ids = 0
       local flatten_migrations = {}
-      setup(function()
+      lazy_setup(function()
         factory:drop_schema()
         for identifier, migs in pairs(factory:migrations_modules()) do
           n_ids = n_ids + 1

--- a/spec/02-integration/03-dao/03-crud_spec.lua
+++ b/spec/02-integration/03-dao/03-crud_spec.lua
@@ -36,7 +36,7 @@ local api_tbl = {
 helpers.for_each_dao(function(kong_config)
   describe("Model (CRUD) with DB: #" .. kong_config.database, function()
     local factory, apis
-    setup(function()
+    lazy_setup(function()
       local db = DB.new(kong_config)
       assert(db:init_connector())
 
@@ -46,7 +46,7 @@ helpers.for_each_dao(function(kong_config)
       assert(factory:init())
       apis = factory.apis
     end)
-    teardown(function()
+    lazy_teardown(function()
       factory:truncate_table("apis")
       ngx.shared.kong_cassandra:flush_expired()
     end)
@@ -195,7 +195,7 @@ helpers.for_each_dao(function(kong_config)
     end)
 
     describe("find_all()", function()
-      setup(function()
+      lazy_setup(function()
         factory:truncate_table("apis")
 
         for i = 1, 100 do
@@ -208,7 +208,7 @@ helpers.for_each_dao(function(kong_config)
           assert.truthy(api)
         end
       end)
-      teardown(function()
+      lazy_teardown(function()
         factory:truncate_table("apis")
       end)
 
@@ -282,7 +282,7 @@ helpers.for_each_dao(function(kong_config)
     end)
 
     describe("find_page()", function()
-      setup(function()
+      lazy_setup(function()
         factory:truncate_table("apis")
 
         for i = 1, 100 do
@@ -296,7 +296,7 @@ helpers.for_each_dao(function(kong_config)
           assert.truthy(api)
         end
       end)
-      teardown(function()
+      lazy_teardown(function()
         factory:truncate_table("apis")
       end)
 
@@ -453,7 +453,7 @@ helpers.for_each_dao(function(kong_config)
     end)
 
     describe("count()", function()
-      setup(function()
+      lazy_setup(function()
         factory:truncate_table("apis")
 
         for i = 1, 100 do
@@ -467,7 +467,7 @@ helpers.for_each_dao(function(kong_config)
         end
       end)
 
-      teardown(function()
+      lazy_teardown(function()
         factory:truncate_table("apis")
       end)
 

--- a/spec/02-integration/03-dao/04-constraints_spec.lua
+++ b/spec/02-integration/03-dao/04-constraints_spec.lua
@@ -8,7 +8,7 @@ for _, strategy in helpers.each_strategy() do
     local plugin_fixture
     local db
 
-    setup(function()
+    lazy_setup(function()
       _, db = helpers.get_db_utils(strategy)
     end)
 

--- a/spec/02-integration/03-dao/05-use_cases_spec.lua
+++ b/spec/02-integration/03-dao/05-use_cases_spec.lua
@@ -5,7 +5,7 @@ for _, strategy in helpers.each_strategy() do
   describe("use-cases with DB: #" .. strategy, function()
     local bp, db
 
-    setup(function()
+    lazy_setup(function()
       bp, db = helpers.get_db_utils(strategy)
     end)
 

--- a/spec/02-integration/03-dao/06-plugins_daos_spec.lua
+++ b/spec/02-integration/03-dao/06-plugins_daos_spec.lua
@@ -13,7 +13,7 @@ helpers.for_each_dao(function(kong_config)
 
     describe("plugins migrations", function()
       local factory
-      setup(function()
+      lazy_setup(function()
         local db = DB.new(kong_config)
         assert(db:init_connector())
         factory = assert(Factory.new(kong_config, db))

--- a/spec/02-integration/03-dao/07-ttl_spec.lua
+++ b/spec/02-integration/03-dao/07-ttl_spec.lua
@@ -11,7 +11,7 @@ for _, strategy in helpers.each_strategy() do
   describe("TTL with #" .. strategy, function()
     local dao
 
-    setup(function()
+    lazy_setup(function()
       _, _, dao = helpers.get_db_utils(strategy)
     end)
 

--- a/spec/02-integration/03-dao/08-ipc_events_spec.lua
+++ b/spec/02-integration/03-dao/08-ipc_events_spec.lua
@@ -16,7 +16,7 @@ describe("DAO propagates CRUD events with DB: #" .. kong_conf.database, function
   local dao
   local mock_ipc
 
-  teardown(function()
+  lazy_teardown(function()
     dao:truncate_table("apis")
   end)
 

--- a/spec/02-integration/03-dao/10-cache_spec.lua
+++ b/spec/02-integration/03-dao/10-cache_spec.lua
@@ -29,7 +29,7 @@ describe("dao in-memory cache", function()
 
   local cache, key
 
-  setup(function()
+  lazy_setup(function()
     assert(worker_events.configure {
       shm = "kong_process_events",
     })

--- a/spec/02-integration/03-dao/11-cassandra_db_spec.lua
+++ b/spec/02-integration/03-dao/11-cassandra_db_spec.lua
@@ -5,7 +5,7 @@ describe("DAO db/cassandra.lua #cassandra", function()
   local cassandra_db
 
 
-  setup(function()
+  lazy_setup(function()
     local dao = select(3, helpers.get_db_utils("cassandra"))
     cassandra_db = dao.db
   end)

--- a/spec/02-integration/04-admin_api/01-kong_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/01-kong_routes_spec.lua
@@ -10,7 +10,7 @@ describe("Admin API - Kong routes", function()
     local meta = require "kong.meta"
     local client
 
-    setup(function()
+    lazy_setup(function()
       helpers.get_db_utils() -- runs migrations
       assert(helpers.start_kong {
         pg_password = "hide_me"
@@ -18,7 +18,7 @@ describe("Admin API - Kong routes", function()
       client = helpers.admin_client(10000)
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       if client then client:close() end
       helpers.stop_kong()
     end)
@@ -111,7 +111,7 @@ describe("Admin API - Kong routes", function()
     describe("/status with DB: #" .. kong_conf.database, function()
       local client
 
-      setup(function()
+      lazy_setup(function()
         helpers.get_db_utils(kong_conf.database)
 
         assert(helpers.start_kong {
@@ -120,7 +120,7 @@ describe("Admin API - Kong routes", function()
         client = helpers.admin_client(10000)
       end)
 
-      teardown(function()
+      lazy_teardown(function()
         if client then client:close() end
         helpers.stop_kong()
       end)

--- a/spec/02-integration/04-admin_api/02-apis_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/02-apis_routes_spec.lua
@@ -21,7 +21,7 @@ pending("Admin API #" .. kong_config.database, function()
   local dao
   local db
 
-  setup(function()
+  lazy_setup(function()
     local _
     _, db, dao = helpers.get_db_utils(kong_config.database, {})
 
@@ -30,7 +30,7 @@ pending("Admin API #" .. kong_config.database, function()
     })
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     helpers.stop_kong()
     dao:truncate_table("apis")
     db:truncate("plugins")
@@ -1252,7 +1252,7 @@ end)
 describe("Admin API request size", function()
   local client
 
-  setup(function()
+  lazy_setup(function()
     assert(helpers.get_db_utils(kong_config.database, {
       "apis",
       "plugins",
@@ -1264,7 +1264,7 @@ describe("Admin API request size", function()
     })
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     helpers.stop_kong()
   end)
 

--- a/spec/02-integration/04-admin_api/03-consumers_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/03-consumers_routes_spec.lua
@@ -32,7 +32,7 @@ describe("Admin API (#" .. strategy .. "): ", function()
   local db
   local client
 
-  setup(function()
+  lazy_setup(function()
     bp, db = helpers.get_db_utils(strategy, {
       "consumers",
       "plugins",
@@ -45,7 +45,7 @@ describe("Admin API (#" .. strategy .. "): ", function()
     }))
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     helpers.stop_kong(nil, true)
   end)
 
@@ -205,7 +205,7 @@ describe("Admin API (#" .. strategy .. "): ", function()
         assert(db:truncate("consumers"))
         bp.consumers:insert_n(10)
       end)
-      teardown(function()
+      lazy_teardown(function()
         assert(db:truncate("consumers"))
         db:truncate("plugins")
       end)

--- a/spec/02-integration/04-admin_api/04-plugins_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/04-plugins_routes_spec.lua
@@ -7,7 +7,7 @@ for _, strategy in helpers.each_strategy() do
     local db
     local client
 
-    setup(function()
+    lazy_setup(function()
       _, db = helpers.get_db_utils(strategy, {
         "services",
         "routes",
@@ -21,7 +21,7 @@ for _, strategy in helpers.each_strategy() do
       }))
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong(nil, true)
     end)
 
@@ -52,7 +52,7 @@ for _, strategy in helpers.each_strategy() do
       local services = {}
       local plugins = {}
 
-      setup(function()
+      lazy_setup(function()
         for i = 1, 3 do
           local service, err, err_t = db.services:insert {
             name = "service-" .. i,

--- a/spec/02-integration/04-admin_api/05-cache_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/05-cache_routes_spec.lua
@@ -6,7 +6,7 @@ describe("Admin API /cache [#" .. strategy .. "]", function()
   local proxy_client
   local admin_client
 
-  setup(function()
+  lazy_setup(function()
     local bp = helpers.get_db_utils(strategy, {
       "routes",
       "services",
@@ -43,7 +43,7 @@ describe("Admin API /cache [#" .. strategy .. "]", function()
   end)
 
 
-  teardown(function()
+  lazy_teardown(function()
     if admin_client then
       admin_client:close()
     end

--- a/spec/02-integration/04-admin_api/06-certificates_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/06-certificates_routes_spec.lua
@@ -54,7 +54,7 @@ describe("Admin API: #" .. strategy, function()
     end
   end)
 
-  setup(function()
+  lazy_setup(function()
     bp, db = helpers.get_db_utils(strategy, {})
 
     assert(helpers.start_kong({
@@ -62,7 +62,7 @@ describe("Admin API: #" .. strategy, function()
     }))
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     helpers.stop_kong()
   end)
 

--- a/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
@@ -21,7 +21,7 @@ describe("Admin API: #" .. kong_config.database, function()
   local bp
   local db
 
-  setup(function()
+  lazy_setup(function()
 
     bp, db = helpers.get_db_utils(kong_config.database, {})
 
@@ -31,7 +31,7 @@ describe("Admin API: #" .. kong_config.database, function()
     client = assert(helpers.admin_client())
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     if client then client:close() end
     helpers.stop_kong()
   end)
@@ -555,11 +555,11 @@ describe("Admin API: #" .. kong_config.database, function()
     end)
 
     describe("GET", function()
-      setup(function()
+      lazy_setup(function()
         assert(db:truncate("upstreams"))
         bp.upstreams:insert_n(10)
       end)
-      teardown(function()
+      lazy_teardown(function()
         assert(db:truncate("upstreams"))
       end)
 
@@ -621,7 +621,7 @@ describe("Admin API: #" .. kong_config.database, function()
       end)
 
       describe("empty results", function()
-        setup(function()
+        lazy_setup(function()
           assert(db:truncate("upstreams"))
         end)
 

--- a/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -28,7 +28,7 @@ describe("Admin API #" .. strategy, function()
   local weight_default, weight_min, weight_max = 100, 0, 1000
   local default_port = 8000
 
-  setup(function()
+  lazy_setup(function()
     bp, db = helpers.get_db_utils(strategy, {
       "upstreams",
       "targets",
@@ -39,7 +39,7 @@ describe("Admin API #" .. strategy, function()
     }))
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     assert(helpers.stop_kong())
   end)
 
@@ -319,7 +319,7 @@ describe("Admin API #" .. strategy, function()
         end
       end
 
-      setup(function()
+      lazy_setup(function()
         local status, body = client_send({
           method = "GET",
           path = "/",

--- a/spec/02-integration/04-admin_api/09-post_processing_spec.lua
+++ b/spec/02-integration/04-admin_api/09-post_processing_spec.lua
@@ -19,7 +19,7 @@ describe("Admin API post-processing #" .. strategy, function()
   local plugin
   local db
 
-  setup(function()
+  lazy_setup(function()
     local _
     _, db = helpers.get_db_utils(strategy, {
       "plugins",
@@ -36,7 +36,7 @@ describe("Admin API post-processing #" .. strategy, function()
     client = assert(helpers.admin_client())
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     if client then
       client:close()
     end

--- a/spec/02-integration/04-admin_api/20-routes_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/20-routes_routes_spec.lua
@@ -25,7 +25,7 @@ for _, strategy in helpers.each_strategy() do
     local dao
     local client
 
-    setup(function()
+    lazy_setup(function()
       bp, db, dao = helpers.get_db_utils(strategy, {
         "routes",
         "services",
@@ -35,7 +35,7 @@ for _, strategy in helpers.each_strategy() do
       }))
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong(nil, true)
     end)
 
@@ -178,7 +178,7 @@ for _, strategy in helpers.each_strategy() do
 
       describe("GET", function()
         describe("with data", function()
-          setup(function()
+          lazy_setup(function()
             db:truncate("routes")
             for i = 1, 10 do
               bp.routes:insert({ paths = { "/route-" .. i } })
@@ -226,7 +226,7 @@ for _, strategy in helpers.each_strategy() do
         end)
 
         describe("with no data", function()
-          setup(function()
+          lazy_setup(function()
             db:truncate("routes")
           end)
           it("data property is an empty array and not an empty hash", function()

--- a/spec/02-integration/04-admin_api/21-services_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/21-services_routes_spec.lua
@@ -25,7 +25,7 @@ for _, strategy in helpers.each_strategy() do
     local dao
     local client
 
-    setup(function()
+    lazy_setup(function()
       bp, db, dao = helpers.get_db_utils(strategy, {
         "routes",
         "services",
@@ -35,7 +35,7 @@ for _, strategy in helpers.each_strategy() do
       }))
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong(nil, true)
     end)
 
@@ -153,7 +153,7 @@ for _, strategy in helpers.each_strategy() do
 
       describe("GET", function()
         describe("with data", function()
-          setup(function()
+          lazy_setup(function()
             db:truncate("services")
             for _ = 1, 10 do
               assert(bp.named_services:insert())
@@ -195,7 +195,7 @@ for _, strategy in helpers.each_strategy() do
         end)
 
         describe("with no data", function()
-          setup(function()
+          lazy_setup(function()
             db:truncate("services")
           end)
           it("data property is an empty array and not an empty hash", function()

--- a/spec/02-integration/04-admin_api/22-reports_spec.lua
+++ b/spec/02-integration/04-admin_api/22-reports_spec.lua
@@ -95,14 +95,14 @@ for _, strategy in helpers.each_strategy() do
     local dns_hostsfile
     local reports_server
 
-    setup(function()
+    lazy_setup(function()
       dns_hostsfile = assert(os.tmpname())
       local fd = assert(io.open(dns_hostsfile, "w"))
       assert(fd:write("127.0.0.1 " .. constants.REPORTS.ADDRESS))
       assert(fd:close())
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       os.remove(dns_hostsfile)
     end)
 

--- a/spec/02-integration/04-admin_api/23-deprecated_plugin_spec.lua
+++ b/spec/02-integration/04-admin_api/23-deprecated_plugin_spec.lua
@@ -9,7 +9,7 @@ describe("Deprecated plugin API #" .. strategy, function()
   local db
 
   describe("deprecated not enabled plugins" , function()
-    setup(function()
+    lazy_setup(function()
       local _
       _, db = helpers.get_db_utils(strategy, {
         "plugins",
@@ -23,7 +23,7 @@ describe("Deprecated plugin API #" .. strategy, function()
       client = helpers.admin_client()
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       if client then
         client:close()
       end
@@ -56,7 +56,7 @@ describe("Deprecated plugin API #" .. strategy, function()
   end)
 
   describe("deprecated enabled plugins" , function()
-    setup(function()
+    lazy_setup(function()
       assert(helpers.start_kong({
         database = strategy,
         nginx_conf = "spec/fixtures/custom_nginx.template",
@@ -64,7 +64,7 @@ describe("Deprecated plugin API #" .. strategy, function()
       }))
       client = helpers.admin_client()
     end)
-    teardown(function()
+    lazy_teardown(function()
       if client then
         client:close()
       end

--- a/spec/02-integration/04-admin_api/24-plugins-conf.lua
+++ b/spec/02-integration/04-admin_api/24-plugins-conf.lua
@@ -7,14 +7,14 @@ describe("Plugins conf property" , function()
 
   describe("with 'plugins=bundled'", function()
     local client
-    setup(function()
+    lazy_setup(function()
       helpers.get_db_utils()
       assert(helpers.start_kong({
         plugins = "bundled",
       }))
       client = helpers.admin_client()
     end)
-    teardown(function()
+    lazy_teardown(function()
       if client then
         client:close()
       end
@@ -35,14 +35,14 @@ describe("Plugins conf property" , function()
 
   describe("with 'plugins=off'", function()
     local client
-    setup(function()
+    lazy_setup(function()
       helpers.get_db_utils()
       assert(helpers.start_kong({
         plugins = "off",
       }))
       client = helpers.admin_client()
     end)
-    teardown(function()
+    lazy_teardown(function()
       if client then
         client:close()
       end
@@ -61,13 +61,13 @@ describe("Plugins conf property" , function()
 
   describe("with 'plugins=off, key-auth'", function()
     local client
-    setup(function()
+    lazy_setup(function()
       assert(helpers.start_kong({
         plugins = "off, key-auth",
       }))
       client = helpers.admin_client()
     end)
-    teardown(function()
+    lazy_teardown(function()
       if client then
         client:close()
       end
@@ -86,13 +86,13 @@ describe("Plugins conf property" , function()
 
   describe("with plugins='key-auth, off, basic-auth", function()
     local client
-    setup(function()
+    lazy_setup(function()
       assert(helpers.start_kong({
         plugins = "key-auth, off, basic-auth",
       }))
       client = helpers.admin_client()
     end)
-    teardown(function()
+    lazy_teardown(function()
       if client then
         client:close()
       end
@@ -113,13 +113,13 @@ describe("Plugins conf property" , function()
 
   describe("with a plugin list in conf, admin API" , function()
     local client
-    setup(function()
+    lazy_setup(function()
       assert(helpers.start_kong({
         plugins = "key-auth, basic-auth"
       }))
       client = helpers.admin_client()
     end)
-    teardown(function()
+    lazy_teardown(function()
       if client then
         client:close()
       end

--- a/spec/02-integration/05-proxy/01-router_spec.lua
+++ b/spec/02-integration/05-proxy/01-router_spec.lua
@@ -50,7 +50,7 @@ for _, strategy in helpers.each_strategy() do
       return routes
     end
 
-    setup(function()
+    lazy_setup(function()
       bp, db, dao = helpers.get_db_utils(strategy)
     end)
 
@@ -65,7 +65,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     describe("no routes match", function()
-      setup(function()
+      lazy_setup(function()
         assert(db:truncate("routes"))
         assert(db:truncate("services"))
         dao:truncate_table("apis")
@@ -76,7 +76,7 @@ for _, strategy in helpers.each_strategy() do
         }))
       end)
 
-      teardown(function()
+      lazy_teardown(function()
         helpers.stop_kong()
       end)
 
@@ -98,7 +98,7 @@ for _, strategy in helpers.each_strategy() do
     describe("use-cases", function()
       local routes
 
-      setup(function()
+      lazy_setup(function()
         assert(db:truncate("routes"))
         assert(db:truncate("services"))
         dao:truncate_table("apis")
@@ -147,7 +147,7 @@ for _, strategy in helpers.each_strategy() do
         }))
       end)
 
-      teardown(function()
+      lazy_teardown(function()
         helpers.stop_kong()
       end)
 
@@ -302,7 +302,7 @@ for _, strategy in helpers.each_strategy() do
     describe("URI regexes order of evaluation with created_at", function()
       local routes1, routes2
 
-      setup(function()
+      lazy_setup(function()
         assert(db:truncate("routes"))
         assert(db:truncate("services"))
         dao:truncate_table("apis")
@@ -350,7 +350,7 @@ for _, strategy in helpers.each_strategy() do
         }))
       end)
 
-      teardown(function()
+      lazy_teardown(function()
         helpers.stop_kong()
       end)
 
@@ -380,7 +380,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     describe("URI regexes order of evaluation with regex_priority", function()
-      setup(function()
+      lazy_setup(function()
         assert(db:truncate("routes"))
         assert(db:truncate("services"))
         dao:truncate_table("apis")
@@ -445,7 +445,7 @@ for _, strategy in helpers.each_strategy() do
         }))
       end)
 
-      teardown(function()
+      lazy_teardown(function()
         helpers.stop_kong()
       end)
 
@@ -472,7 +472,7 @@ for _, strategy in helpers.each_strategy() do
 
     describe("URI arguments (querystring)", function()
 
-      setup(function()
+      lazy_setup(function()
         assert(db:truncate("routes"))
         assert(db:truncate("services"))
         dao:truncate_table("apis")
@@ -489,7 +489,7 @@ for _, strategy in helpers.each_strategy() do
         }))
       end)
 
-      teardown(function()
+      lazy_teardown(function()
         helpers.stop_kong()
       end)
 
@@ -544,7 +544,7 @@ for _, strategy in helpers.each_strategy() do
     describe("percent-encoded URIs", function()
       local routes
 
-      setup(function()
+      lazy_setup(function()
         assert(db:truncate("routes"))
         assert(db:truncate("services"))
         dao:truncate_table("apis")
@@ -566,7 +566,7 @@ for _, strategy in helpers.each_strategy() do
         }))
       end)
 
-      teardown(function()
+      lazy_teardown(function()
         helpers.stop_kong()
       end)
 
@@ -601,7 +601,7 @@ for _, strategy in helpers.each_strategy() do
 
     describe("strip_path", function()
 
-      setup(function()
+      lazy_setup(function()
         assert(db:truncate("routes"))
         assert(db:truncate("services"))
         dao:truncate_table("apis")
@@ -619,7 +619,7 @@ for _, strategy in helpers.each_strategy() do
         }))
       end)
 
-      teardown(function()
+      lazy_teardown(function()
         helpers.stop_kong()
       end)
 
@@ -670,7 +670,7 @@ for _, strategy in helpers.each_strategy() do
 
     describe("preserve_host", function()
 
-      setup(function()
+      lazy_setup(function()
         assert(db:truncate("routes"))
         assert(db:truncate("services"))
         dao:truncate_table("apis")
@@ -703,7 +703,7 @@ for _, strategy in helpers.each_strategy() do
         }))
       end)
 
-      teardown(function()
+      lazy_teardown(function()
         helpers.stop_kong()
       end)
 
@@ -789,7 +789,7 @@ for _, strategy in helpers.each_strategy() do
     describe("edge-cases", function()
       local routes
 
-      setup(function()
+      lazy_setup(function()
         assert(db:truncate("routes"))
         assert(db:truncate("services"))
         dao:truncate_table("apis")
@@ -811,7 +811,7 @@ for _, strategy in helpers.each_strategy() do
         }))
       end)
 
-      teardown(function()
+      lazy_teardown(function()
         helpers.stop_kong()
       end)
 
@@ -845,7 +845,7 @@ for _, strategy in helpers.each_strategy() do
     describe("[paths] + [methods]", function()
       local routes
 
-      setup(function()
+      lazy_setup(function()
         assert(db:truncate("routes"))
         assert(db:truncate("services"))
         dao:truncate_table("apis")
@@ -869,7 +869,7 @@ for _, strategy in helpers.each_strategy() do
         }))
       end)
 
-      teardown(function()
+      lazy_teardown(function()
         helpers.stop_kong()
       end)
 
@@ -893,7 +893,7 @@ for _, strategy in helpers.each_strategy() do
     describe("[paths] + [hosts]", function()
       local routes
 
-      setup(function()
+      lazy_setup(function()
         assert(db:truncate("routes"))
         assert(db:truncate("services"))
         dao:truncate_table("apis")
@@ -917,7 +917,7 @@ for _, strategy in helpers.each_strategy() do
         }))
       end)
 
-      teardown(function()
+      lazy_teardown(function()
         helpers.stop_kong()
       end)
 
@@ -1027,7 +1027,7 @@ for _, strategy in helpers.each_strategy() do
       }
 
       describe("(plain)", function()
-        setup(function()
+        lazy_setup(function()
           assert(db:truncate("routes"))
           assert(db:truncate("services"))
           dao:truncate_table("apis")
@@ -1056,7 +1056,7 @@ for _, strategy in helpers.each_strategy() do
           }))
         end)
 
-        teardown(function()
+        lazy_teardown(function()
           helpers.stop_kong()
         end)
 
@@ -1095,7 +1095,7 @@ for _, strategy in helpers.each_strategy() do
           return "/[0]?" .. path:sub(2, -1)
         end
 
-        setup(function()
+        lazy_setup(function()
           assert(db:truncate("routes"))
           assert(db:truncate("services"))
           dao:truncate_table("apis")
@@ -1124,7 +1124,7 @@ for _, strategy in helpers.each_strategy() do
           }))
         end)
 
-        teardown(function()
+        lazy_teardown(function()
           helpers.stop_kong()
         end)
 

--- a/spec/02-integration/05-proxy/02-upstream_headers_spec.lua
+++ b/spec/02-integration/05-proxy/02-upstream_headers_spec.lua
@@ -57,7 +57,7 @@ for _, strategy in helpers.each_strategy() do
       end
     end
 
-    setup(function()
+    lazy_setup(function()
       bp, db = helpers.get_db_utils(strategy)
     end)
 
@@ -72,13 +72,13 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     describe("(using the default configuration values)", function()
-      setup(start_kong {
+      lazy_setup(start_kong {
         database         = strategy,
         nginx_conf       = "spec/fixtures/custom_nginx.template",
         lua_package_path = "?/init.lua;./kong/?.lua;./spec/fixtures/?.lua",
       })
 
-      teardown(stop_kong)
+      lazy_teardown(stop_kong)
 
       describe("X-Real-IP", function()
         it("should be added if not present in request", function()
@@ -248,14 +248,14 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     describe("(using the trusted configuration values)", function()
-      setup(start_kong {
+      lazy_setup(start_kong {
         database         = strategy,
         trusted_ips      = "127.0.0.1",
         nginx_conf       = "spec/fixtures/custom_nginx.template",
         lua_package_path = "?/init.lua;./kong/?.lua;./spec/fixtures/?.lua",
       })
 
-      teardown(stop_kong)
+      lazy_teardown(stop_kong)
 
       describe("X-Real-IP", function()
         it("should be added if not present in request", function()
@@ -358,14 +358,14 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     describe("(using the non-trusted configuration values)", function()
-      setup(start_kong {
+      lazy_setup(start_kong {
         database         = strategy,
         trusted_ips      = "10.0.0.1",
         nginx_conf       = "spec/fixtures/custom_nginx.template",
         lua_package_path = "?/init.lua;./kong/?.lua;./spec/fixtures/?.lua",
       })
 
-      teardown(stop_kong)
+      lazy_teardown(stop_kong)
 
       describe("X-Real-IP", function()
         it("should be added if not present in request", function()
@@ -466,7 +466,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     describe("(using the recursive trusted configuration values)", function()
-      setup(start_kong {
+      lazy_setup(start_kong {
         database          = strategy,
         real_ip_header    = "X-Forwarded-For",
         real_ip_recursive = "on",
@@ -475,7 +475,7 @@ for _, strategy in helpers.each_strategy() do
         lua_package_path  = "?/init.lua;./kong/?.lua;./spec/fixtures/?.lua",
       })
 
-      teardown(stop_kong)
+      lazy_teardown(stop_kong)
 
       describe("X-Real-IP and X-Forwarded-For", function()
         it("should be added if not present in request", function()
@@ -528,7 +528,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     describe("(using the recursive non-trusted configuration values)", function()
-      setup(start_kong {
+      lazy_setup(start_kong {
         database          = strategy,
         real_ip_header    = "X-Forwarded-For",
         real_ip_recursive = "on",
@@ -537,7 +537,7 @@ for _, strategy in helpers.each_strategy() do
         lua_package_path  = "?/init.lua;./kong/?.lua;./spec/fixtures/?.lua",
       })
 
-      teardown(stop_kong)
+      lazy_teardown(stop_kong)
 
       describe("X-Real-IP and X-Forwarded-For", function()
         it("should be added if not present in request", function()
@@ -594,7 +594,7 @@ for _, strategy in helpers.each_strategy() do
       local proxy_ip = helpers.get_proxy_ip(false)
       local proxy_port = helpers.get_proxy_port(false)
 
-      setup(start_kong {
+      lazy_setup(start_kong {
         database          = strategy,
         proxy_listen      = proxy_ip .. ":" .. proxy_port .. " proxy_protocol",
         real_ip_header    = "proxy_protocol",
@@ -604,7 +604,7 @@ for _, strategy in helpers.each_strategy() do
         lua_package_path  = "?/init.lua;./kong/?.lua;./spec/fixtures/?.lua",
       })
 
-      teardown(stop_kong)
+      lazy_teardown(stop_kong)
 
       describe("X-Real-IP, X-Forwarded-For and X-Forwarded-Port", function()
         it("should be added if not present in request", function()
@@ -700,7 +700,7 @@ for _, strategy in helpers.each_strategy() do
       local proxy_ip = helpers.get_proxy_ip(false)
       local proxy_port = helpers.get_proxy_port(false)
 
-      setup(start_kong {
+      lazy_setup(start_kong {
         database          = strategy,
         proxy_listen      = "0.0.0.0:" .. proxy_port .. " proxy_protocol",
         real_ip_header    = "proxy_protocol",
@@ -710,7 +710,7 @@ for _, strategy in helpers.each_strategy() do
         lua_package_path  = "?/init.lua;./kong/?.lua;./spec/fixtures/?.lua",
       })
 
-      teardown(stop_kong)
+      lazy_teardown(stop_kong)
 
       describe("X-Real-IP, X-Forwarded-For and X-Forwarded-Port", function()
         it("should be added if not present in request", function()

--- a/spec/02-integration/05-proxy/03-plugins_triggering_spec.lua
+++ b/spec/02-integration/05-proxy/03-plugins_triggering_spec.lua
@@ -17,7 +17,7 @@ for _, strategy in helpers.each_strategy() do
     local dao
     local bp
 
-    setup(function()
+    lazy_setup(function()
       bp, db, dao = helpers.get_db_utils(strategy, {
         "apis",
         "routes",
@@ -159,7 +159,7 @@ for _, strategy in helpers.each_strategy() do
       proxy_client = helpers.proxy_client()
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       if proxy_client then proxy_client:close() end
       helpers.stop_kong()
     end)
@@ -226,7 +226,7 @@ for _, strategy in helpers.each_strategy() do
     describe("short-circuited requests", function()
       local FILE_LOG_PATH = os.tmpname()
 
-      setup(function()
+      lazy_setup(function()
         if proxy_client then
           proxy_client:close()
         end
@@ -317,7 +317,7 @@ for _, strategy in helpers.each_strategy() do
         proxy_client = helpers.proxy_client()
       end)
 
-      teardown(function()
+      lazy_teardown(function()
         if proxy_client then
           proxy_client:close()
         end
@@ -443,7 +443,7 @@ for _, strategy in helpers.each_strategy() do
       -- tries to evaluate is the `schema.no_consumer` flag is set.
       -- Since the reports plugin has no `schema`, this indexing fails.
 
-      setup(function()
+      lazy_setup(function()
         if proxy_client then
           proxy_client:close()
         end
@@ -490,7 +490,7 @@ for _, strategy in helpers.each_strategy() do
         proxy_client = helpers.proxy_client()
       end)
 
-      teardown(function()
+      lazy_teardown(function()
         if proxy_client then
           proxy_client:close()
         end
@@ -524,7 +524,7 @@ for _, strategy in helpers.each_strategy() do
       local FILE_LOG_PATH = os.tmpname()
 
 
-      setup(function()
+      lazy_setup(function()
         db:truncate("routes")
         db:truncate("services")
         db:truncate("consumers")
@@ -636,7 +636,7 @@ for _, strategy in helpers.each_strategy() do
       end)
 
 
-      teardown(function()
+      lazy_teardown(function()
         helpers.stop_kong("servroot2")
         helpers.stop_kong()
       end)

--- a/spec/02-integration/05-proxy/04-dns_spec.lua
+++ b/spec/02-integration/05-proxy/04-dns_spec.lua
@@ -45,7 +45,7 @@ for _, strategy in helpers.each_strategy() do
       local retries = 3
       local proxy_client
 
-      setup(function()
+      lazy_setup(function()
         local bp = helpers.get_db_utils(strategy)
 
         local service = bp.services:insert {
@@ -66,7 +66,7 @@ for _, strategy in helpers.each_strategy() do
         proxy_client = helpers.proxy_client()
       end)
 
-      teardown(function()
+      lazy_teardown(function()
         if proxy_client then
           proxy_client:close()
         end
@@ -97,7 +97,7 @@ for _, strategy in helpers.each_strategy() do
     describe("upstream resolve failure", function()
       local proxy_client
 
-      setup(function()
+      lazy_setup(function()
         local bp = helpers.get_db_utils(strategy)
 
         local service = bp.services:insert {
@@ -120,7 +120,7 @@ for _, strategy in helpers.each_strategy() do
         proxy_client = helpers.proxy_client()
       end)
 
-      teardown(function()
+      lazy_teardown(function()
         if proxy_client then
           proxy_client:close()
         end

--- a/spec/02-integration/05-proxy/05-ssl_spec.lua
+++ b/spec/02-integration/05-proxy/05-ssl_spec.lua
@@ -18,7 +18,7 @@ for _, strategy in helpers.each_strategy() do
     local proxy_client
     local https_client
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy)
 
       local service = bp.services:insert {
@@ -105,7 +105,7 @@ for _, strategy in helpers.each_strategy() do
       })
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 
@@ -155,7 +155,7 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       describe("from not trusted_ip", function()
-        setup(function()
+        lazy_setup(function()
           helpers.stop_kong(nil, nil, true)
 
           assert(helpers.start_kong {
@@ -181,7 +181,7 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       describe("from trusted_ip", function()
-        setup(function()
+        lazy_setup(function()
           helpers.stop_kong(nil, nil, true)
 
           assert(helpers.start_kong {
@@ -223,7 +223,7 @@ for _, strategy in helpers.each_strategy() do
 
         -- restart kong and use a new client to simulate a connection from an
         -- untrusted ip
-        setup(function()
+        lazy_setup(function()
           assert(helpers.kong_exec("restart -c " .. helpers.test_conf_path, {
             database = strategy,
             trusted_ips = "1.2.3.4", -- explicitly trust an IP that is not us

--- a/spec/02-integration/05-proxy/06-upstream_timeouts_spec.lua
+++ b/spec/02-integration/05-proxy/06-upstream_timeouts_spec.lua
@@ -42,7 +42,7 @@ for _, strategy in helpers.each_strategy() do
       return true
     end
 
-    setup(function()
+    lazy_setup(function()
       bp = helpers.get_db_utils(strategy)
 
       insert_routes {
@@ -78,7 +78,7 @@ for _, strategy in helpers.each_strategy() do
       }))
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 

--- a/spec/02-integration/05-proxy/07-uri_encoding_spec.lua
+++ b/spec/02-integration/05-proxy/07-uri_encoding_spec.lua
@@ -5,7 +5,7 @@ for _, strategy in helpers.each_strategy() do
   describe("URI encoding [#" ..  strategy .. "]", function()
     local proxy_client
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy)
 
       bp.routes:insert {
@@ -36,7 +36,7 @@ for _, strategy in helpers.each_strategy() do
       proxy_client = helpers.proxy_client()
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 

--- a/spec/02-integration/05-proxy/08-websockets_spec.lua
+++ b/spec/02-integration/05-proxy/08-websockets_spec.lua
@@ -4,7 +4,7 @@ local cjson = require "cjson"
 
 for _, strategy in helpers.each_strategy() do
   describe("Websockets [#" .. strategy .. "]", function()
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy)
 
       local service = bp.services:insert {
@@ -25,7 +25,7 @@ for _, strategy in helpers.each_strategy() do
       }))
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 

--- a/spec/02-integration/05-proxy/09-balancer_spec.lua
+++ b/spec/02-integration/05-proxy/09-balancer_spec.lua
@@ -550,7 +550,7 @@ for _, strategy in helpers.each_strategy() do
 
   describe("Ring-balancer #" .. strategy, function()
 
-    setup(function()
+    lazy_setup(function()
       local _, db, dao = helpers.get_db_utils(strategy, {})
 
       truncate_relevant_tables(db, dao)
@@ -562,7 +562,7 @@ for _, strategy in helpers.each_strategy() do
       })
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 
@@ -574,7 +574,7 @@ for _, strategy in helpers.each_strategy() do
       local proxy_port_2 = 9010
       local admin_port_2 = 9011
 
-      setup(function()
+      lazy_setup(function()
         -- start a second Kong instance
         helpers.start_kong({
           database   = strategy,
@@ -586,7 +586,7 @@ for _, strategy in helpers.each_strategy() do
         })
       end)
 
-      teardown(function()
+      lazy_teardown(function()
         helpers.stop_kong("servroot2", true, true)
       end)
 

--- a/spec/02-integration/05-proxy/10-handler_spec.lua
+++ b/spec/02-integration/05-proxy/10-handler_spec.lua
@@ -7,7 +7,7 @@ for _, strategy in helpers.each_strategy() do
         local admin_client
         local proxy_client
 
-        setup(function()
+        lazy_setup(function()
           local bp = helpers.get_db_utils(strategy, {
             "apis",
             "routes",
@@ -42,7 +42,7 @@ for _, strategy in helpers.each_strategy() do
           proxy_client = helpers.proxy_client()
         end)
 
-        teardown(function()
+        lazy_teardown(function()
           if admin_client then admin_client:close() end
           helpers.stop_kong(nil, true)
         end)
@@ -65,7 +65,7 @@ for _, strategy in helpers.each_strategy() do
         local admin_client
         local proxy_client
 
-        setup(function()
+        lazy_setup(function()
           local bp = helpers.get_db_utils(strategy, {
             "apis",
             "routes",
@@ -101,7 +101,7 @@ for _, strategy in helpers.each_strategy() do
           proxy_client = helpers.proxy_client()
         end)
 
-        teardown(function()
+        lazy_teardown(function()
           if admin_client then admin_client:close() end
           helpers.stop_kong(nil, true)
         end)
@@ -123,7 +123,7 @@ for _, strategy in helpers.each_strategy() do
         local admin_client
         local proxy_client
 
-        setup(function()
+        lazy_setup(function()
           local bp = helpers.get_db_utils(strategy, {
             "apis",
             "routes",
@@ -176,7 +176,7 @@ for _, strategy in helpers.each_strategy() do
           proxy_client = helpers.proxy_client()
         end)
 
-        teardown(function()
+        lazy_teardown(function()
           if admin_client then admin_client:close() end
           helpers.stop_kong(nil, true)
         end)

--- a/spec/02-integration/05-proxy/11-error_default_type_spec.lua
+++ b/spec/02-integration/05-proxy/11-error_default_type_spec.lua
@@ -9,7 +9,7 @@ for _, strategy in helpers.each_strategy() do
   describe("Proxy errors Content-Type [#" .. strategy .. "]", function()
     local proxy_client
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy)
 
       local service = bp.services:insert {
@@ -33,7 +33,7 @@ for _, strategy in helpers.each_strategy() do
       })
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 
@@ -75,7 +75,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     describe("", function()
-      setup(function()
+      lazy_setup(function()
         assert(helpers.kong_exec(("restart --conf %s --nginx-conf %s"):format(
                                  helpers.test_conf_path,
                                  "spec/fixtures/custom_nginx.template"), {

--- a/spec/02-integration/05-proxy/12-error_handlers_spec.lua
+++ b/spec/02-integration/05-proxy/12-error_handlers_spec.lua
@@ -4,13 +4,13 @@ local helpers = require "spec.helpers"
 describe("Proxy error handlers", function()
   local proxy_client
 
-  setup(function()
+  lazy_setup(function()
     assert(helpers.start_kong {
       nginx_conf = "spec/fixtures/custom_nginx.template",
     })
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     helpers.stop_kong()
   end)
 

--- a/spec/02-integration/05-proxy/13-server_tokens_spec.lua
+++ b/spec/02-integration/05-proxy/13-server_tokens_spec.lua
@@ -28,7 +28,7 @@ describe("headers [#" .. strategy .. "]", function()
       end
     end
 
-    setup(function()
+    lazy_setup(function()
       bp = helpers.get_db_utils(strategy)
     end)
 
@@ -44,9 +44,9 @@ describe("headers [#" .. strategy .. "]", function()
 
     describe("(with default configration values)", function()
 
-      setup(start())
+      lazy_setup(start())
 
-      teardown(helpers.stop_kong)
+      lazy_teardown(helpers.stop_kong)
 
       it("should return Kong 'Via' header but not change the 'Server' header when request was proxied", function()
         local res = assert(proxy_client:send {
@@ -80,11 +80,11 @@ describe("headers [#" .. strategy .. "]", function()
 
     describe("(with headers = Via)", function()
 
-      setup(start {
+      lazy_setup(start {
         headers = "Via",
       })
 
-      teardown(helpers.stop_kong)
+      lazy_teardown(helpers.stop_kong)
 
       it("should return Kong 'Via' header but not touch 'Server' header when request was proxied", function()
         local res = assert(proxy_client:send {
@@ -118,11 +118,11 @@ describe("headers [#" .. strategy .. "]", function()
 
     describe("(with headers = Server)", function()
 
-      setup(start {
+      lazy_setup(start {
         headers = "Server",
       })
 
-      teardown(helpers.stop_kong)
+      lazy_teardown(helpers.stop_kong)
 
       it("should not return Kong 'Via' header but not change the 'Server' header when request was proxied", function()
         local res = assert(proxy_client:send {
@@ -156,11 +156,11 @@ describe("headers [#" .. strategy .. "]", function()
 
     describe("(with headers = server_tokens)", function()
 
-      setup(start {
+      lazy_setup(start {
         headers = "server_tokens",
       })
 
-      teardown(helpers.stop_kong)
+      lazy_teardown(helpers.stop_kong)
 
       it("should return Kong 'Via' header but not change the 'Server' header when request was proxied", function()
         local res = assert(proxy_client:send {
@@ -194,11 +194,11 @@ describe("headers [#" .. strategy .. "]", function()
 
     describe("(with no server_tokens in headers)", function()
 
-      setup(start {
+      lazy_setup(start {
         headers = "off",
       })
 
-      teardown(helpers.stop_kong)
+      lazy_teardown(helpers.stop_kong)
 
       it("should not return Kong 'Via' header but it should forward the 'Server' header when request was proxied", function()
         local res = assert(proxy_client:send {
@@ -251,7 +251,7 @@ describe("headers [#" .. strategy .. "]", function()
       end
     end
 
-    setup(function()
+    lazy_setup(function()
       bp = helpers.get_db_utils(strategy)
     end)
 
@@ -268,9 +268,9 @@ describe("headers [#" .. strategy .. "]", function()
 
     describe("(with default configration values)", function()
 
-      setup(start())
+      lazy_setup(start())
 
-      teardown(helpers.stop_kong)
+      lazy_teardown(helpers.stop_kong)
 
       it("should be returned when request was proxied", function()
         local res = assert(proxy_client:send {
@@ -304,11 +304,11 @@ describe("headers [#" .. strategy .. "]", function()
 
     describe("(with headers = latency_tokens)", function()
 
-      setup(start {
+      lazy_setup(start {
         headers = "latency_tokens",
       })
 
-      teardown(helpers.stop_kong)
+      lazy_teardown(helpers.stop_kong)
 
       it("should be returned when request was proxied", function()
         local res = assert(proxy_client:send {
@@ -342,11 +342,11 @@ describe("headers [#" .. strategy .. "]", function()
 
     describe("(with headers = X-Kong-Upstream-Latency)", function()
 
-      setup(start {
+      lazy_setup(start {
         headers = "X-Kong-Upstream-Latency",
       })
 
-      teardown(helpers.stop_kong)
+      lazy_teardown(helpers.stop_kong)
 
       it("should return 'X-Kong-Upstream-Latency' header but not 'X-Kong-Proxy-Latency' when request was proxied", function()
         local res = assert(proxy_client:send {
@@ -380,11 +380,11 @@ describe("headers [#" .. strategy .. "]", function()
 
     describe("(with headers = X-Kong-Proxy-Latency)", function()
 
-      setup(start {
+      lazy_setup(start {
         headers = "X-Kong-Proxy-Latency",
       })
 
-      teardown(helpers.stop_kong)
+      lazy_teardown(helpers.stop_kong)
 
       it("should return 'X-Kong-Proxy-Latency' header but not 'X-Kong-Upstream-Latency' when request was proxied", function()
         local res = assert(proxy_client:send {
@@ -418,11 +418,11 @@ describe("headers [#" .. strategy .. "]", function()
 
     describe("(with no latency_tokens in headers)", function()
 
-      setup(start {
+      lazy_setup(start {
         headers = "off",
       })
 
-      teardown(function()
+      lazy_teardown(function()
         helpers.stop_kong()
       end)
 
@@ -458,11 +458,11 @@ describe("headers [#" .. strategy .. "]", function()
 
     describe("(with headers='server_tokens, X-Kong-Proxy-Latency')", function()
 
-      setup(start{
+      lazy_setup(start{
         headers = "server_tokens, X-Kong-Proxy-Latency",
       })
 
-      teardown(helpers.stop_kong)
+      lazy_teardown(helpers.stop_kong)
 
       it("should return Kong 'Via' and 'X-Kong-Proxy-Latency' header but not change the 'Server' header when request was proxied", function()
         local res = assert(proxy_client:send {
@@ -517,11 +517,11 @@ describe("headers [#" .. strategy .. "]", function()
 
     describe("(with headers='server_tokens, off, X-Kong-Proxy-Latency')", function()
 
-      setup(start{
+      lazy_setup(start{
         headers = "server_tokens, off, X-Kong-Proxy-Latency",
       })
 
-      teardown(helpers.stop_kong)
+      lazy_teardown(helpers.stop_kong)
 
       it("should return Kong 'Via' and 'X-Kong-Proxy-Latency' header as 'off' will not take effect", function()
         local res = assert(proxy_client:send {
@@ -574,7 +574,7 @@ describe("headers [#" .. strategy .. "]", function()
       end
     end
 
-    setup(function()
+    lazy_setup(function()
       bp = helpers.get_db_utils(strategy)
     end)
 
@@ -590,11 +590,11 @@ describe("headers [#" .. strategy .. "]", function()
 
     describe("are case insensitive", function()
 
-      setup(start{
+      lazy_setup(start{
         headers = "serVer_TokEns, x-kOng-pRoXy-lAtency"
       })
 
-      teardown(helpers.stop_kong)
+      lazy_teardown(helpers.stop_kong)
 
       it("should return Kong 'Via' and 'X-Kong-Proxy-Latency' header", function()
         local res = assert(proxy_client:send {

--- a/spec/02-integration/05-proxy/14-upstream-status-header_spec.lua
+++ b/spec/02-integration/05-proxy/14-upstream-status-header_spec.lua
@@ -48,7 +48,7 @@ describe(constants.HEADERS.UPSTREAM_STATUS .. " header", function()
   local client
 
   describe("should be same as upstream status code", function()
-    setup(function()
+    lazy_setup(function()
       setup_db()
 
       assert(helpers.start_kong {
@@ -60,7 +60,7 @@ describe(constants.HEADERS.UPSTREAM_STATUS .. " header", function()
       client = helpers.proxy_client()
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       if client then
         client:close()
       end
@@ -95,7 +95,7 @@ describe(constants.HEADERS.UPSTREAM_STATUS .. " header", function()
   end)
 
   describe("is not injected with default configuration", function()
-    setup(function()
+    lazy_setup(function()
       setup_db()
 
       assert(helpers.start_kong {
@@ -103,7 +103,7 @@ describe(constants.HEADERS.UPSTREAM_STATUS .. " header", function()
       })
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       if client then
         client:close()
       end
@@ -126,7 +126,7 @@ describe(constants.HEADERS.UPSTREAM_STATUS .. " header", function()
   end)
 
   describe("is injected with configuration [headers=X-Kong-Upstream-Status]", function()
-    setup(function()
+    lazy_setup(function()
       setup_db()
 
       assert(helpers.start_kong {
@@ -135,7 +135,7 @@ describe(constants.HEADERS.UPSTREAM_STATUS .. " header", function()
       })
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       if client then
         client:close()
       end
@@ -158,7 +158,7 @@ describe(constants.HEADERS.UPSTREAM_STATUS .. " header", function()
   end)
 
   describe("short-circuited requests", function()
-    setup(function()
+    lazy_setup(function()
       setup_db()
 
       assert(helpers.start_kong {
@@ -167,7 +167,7 @@ describe(constants.HEADERS.UPSTREAM_STATUS .. " header", function()
       })
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       if client then
         client:close()
       end

--- a/spec/02-integration/05-proxy/15-custom_nginx_directive_spec.lua
+++ b/spec/02-integration/05-proxy/15-custom_nginx_directive_spec.lua
@@ -18,7 +18,7 @@ describe("Custom NGINX directives", function()
     end
   end
 
-  setup(function()
+  lazy_setup(function()
     bp = helpers.get_db_utils()
   end)
 
@@ -34,11 +34,11 @@ describe("Custom NGINX directives", function()
 
   describe("with config value 'nginx_proxy_add_header=foo-header bar-value'", function()
 
-    setup(start {
+    lazy_setup(start {
       ["nginx_proxy_add_header"] = "foo-header bar-value"
     })
 
-    teardown(helpers.stop_kong)
+    lazy_teardown(helpers.stop_kong)
 
     it("should insert 'foo-header' header", function()
       local res = assert(proxy_client:send {

--- a/spec/02-integration/06-invalidations/01-cluster_events_spec.lua
+++ b/spec/02-integration/06-invalidations/01-cluster_events_spec.lua
@@ -9,12 +9,12 @@ for _, strategy in helpers.each_strategy() do
   describe("cluster_events with db [#" .. strategy .. "]", function()
     local db
 
-    setup(function()
+    lazy_setup(function()
       local _
       _, db = helpers.get_db_utils(strategy)
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       local cluster_events = assert(kong_cluster_events.new { db = db })
       cluster_events.strategy:truncate_events()
     end)

--- a/spec/02-integration/06-invalidations/02-core_entities_invalidations_spec.lua
+++ b/spec/02-integration/06-invalidations/02-core_entities_invalidations_spec.lua
@@ -19,7 +19,7 @@ for _, strategy in helpers.each_strategy() do
 
     local service_fixture
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy, {
         "apis",
         "routes",
@@ -64,7 +64,7 @@ for _, strategy in helpers.each_strategy() do
       end
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong("servroot1", true)
       helpers.stop_kong("servroot2", true)
     end)
@@ -89,7 +89,7 @@ for _, strategy in helpers.each_strategy() do
 
 
     describe("Routes (router)", function()
-      setup(function()
+      lazy_setup(function()
         -- populate cache with a miss on
         -- both nodes
 
@@ -396,7 +396,7 @@ for _, strategy in helpers.each_strategy() do
         return stderr
       end
 
-      setup(function()
+      lazy_setup(function()
         -- populate cache with a miss on
         -- both nodes
         local cert_1 = get_cert(8443, "ssl-example.com")

--- a/spec/02-integration/06-invalidations/03-plugins_map_invalidation_spec.lua
+++ b/spec/02-integration/06-invalidations/03-plugins_map_invalidation_spec.lua
@@ -18,7 +18,7 @@ for _, strategy in helpers.each_strategy() do
 
     local service_fixture
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy, {
         "apis",
         "routes",
@@ -76,7 +76,7 @@ for _, strategy in helpers.each_strategy() do
       end
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong("servroot1")
       helpers.stop_kong("servroot2")
     end)

--- a/spec/03-plugins/01-tcp-log/01-tcp-log_spec.lua
+++ b/spec/03-plugins/01-tcp-log/01-tcp-log_spec.lua
@@ -9,7 +9,7 @@ for _, strategy in helpers.each_strategy() do
   describe("Plugin: tcp-log (log) [#" .. strategy .. "]", function()
     local proxy_client
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy)
 
       local route = bp.routes:insert {
@@ -47,7 +47,7 @@ for _, strategy in helpers.each_strategy() do
       proxy_client = helpers.proxy_client()
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       if proxy_client then
         proxy_client:close()
       end

--- a/spec/03-plugins/02-udp-log/01-udp-log_spec.lua
+++ b/spec/03-plugins/02-udp-log/01-udp-log_spec.lua
@@ -9,7 +9,7 @@ for _, strategy in helpers.each_strategy() do
   describe("Plugin: udp-log (log) [#" .. strategy .. "]", function()
     local proxy_client
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy)
 
       local route = bp.routes:insert {
@@ -33,7 +33,7 @@ for _, strategy in helpers.each_strategy() do
       proxy_client = helpers.proxy_client()
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       if proxy_client then
         proxy_client:close()
       end

--- a/spec/03-plugins/03-http-log/01-log_spec.lua
+++ b/spec/03-plugins/03-http-log/01-log_spec.lua
@@ -6,7 +6,7 @@ for _, strategy in helpers.each_strategy() do
   describe("Plugin: http-log (log) [#" .. strategy .. "]", function()
     local proxy_client
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy)
 
       local service1 = bp.services:insert{
@@ -122,7 +122,7 @@ for _, strategy in helpers.each_strategy() do
       }))
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 

--- a/spec/03-plugins/04-file-log/01-log_spec.lua
+++ b/spec/03-plugins/04-file-log/01-log_spec.lua
@@ -13,7 +13,7 @@ for _, strategy in helpers.each_strategy() do
   describe("Plugin: file-log (log) [#" .. strategy .. "]", function()
     local proxy_client
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy)
 
       local route = bp.routes:insert {
@@ -34,7 +34,7 @@ for _, strategy in helpers.each_strategy() do
         nginx_conf = "spec/fixtures/custom_nginx.template",
       }))
     end)
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 

--- a/spec/03-plugins/05-syslog/01-log_spec.lua
+++ b/spec/03-plugins/05-syslog/01-log_spec.lua
@@ -9,7 +9,7 @@ for _, strategy in helpers.each_strategy() do
     local proxy_client
     local platform
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy)
 
       local route1 = bp.routes:insert {
@@ -66,7 +66,7 @@ for _, strategy in helpers.each_strategy() do
         nginx_conf = "spec/fixtures/custom_nginx.template",
       }))
     end)
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 

--- a/spec/03-plugins/06-statsd/01-log_spec.lua
+++ b/spec/03-plugins/06-statsd/01-log_spec.lua
@@ -11,7 +11,7 @@ for _, strategy in helpers.each_strategy() do
   describe("Plugin: statsd (log) [#" .. strategy .. "]", function()
     local proxy_client
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy)
 
       local consumer = bp.consumers:insert {
@@ -237,7 +237,7 @@ for _, strategy in helpers.each_strategy() do
       proxy_client = helpers.proxy_client()
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       if proxy_client then
         proxy_client:close()
       end

--- a/spec/03-plugins/07-loggly/01-log_spec.lua
+++ b/spec/03-plugins/07-loggly/01-log_spec.lua
@@ -9,7 +9,7 @@ for _, strategy in helpers.each_strategy() do
   describe("Plugin: loggly (log) [#" .. strategy .. "]", function()
     local proxy_client
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy)
 
       local route1 = bp.routes:insert {
@@ -82,7 +82,7 @@ for _, strategy in helpers.each_strategy() do
       }))
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 

--- a/spec/03-plugins/08-datadog/01-log_spec.lua
+++ b/spec/03-plugins/08-datadog/01-log_spec.lua
@@ -6,7 +6,7 @@ for _, strategy in helpers.each_strategy() do
   describe("Plugin: datadog (log) [#" .. strategy .. "]", function()
     local proxy_client
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy)
 
       local consumer = bp.consumers:insert {
@@ -125,7 +125,7 @@ for _, strategy in helpers.each_strategy() do
 
       proxy_client = helpers.proxy_client()
     end)
-    teardown(function()
+    lazy_teardown(function()
       if proxy_client then
         proxy_client:close()
       end

--- a/spec/03-plugins/09-galileo/01-alf_spec.lua
+++ b/spec/03-plugins/09-galileo/01-alf_spec.lua
@@ -181,10 +181,10 @@ describe("ALF serializer", function()
 
     describe("request body", function()
       local get_headers
-      setup(function()
+      lazy_setup(function()
         get_headers = _G.ngx.req.get_headers
       end)
-      teardown(function()
+      lazy_teardown(function()
         _G.ngx.req.get_headers = get_headers
         reload_alf_serializer()
       end)
@@ -318,10 +318,10 @@ describe("ALF serializer", function()
 
     describe("response body", function()
       local get_headers
-      setup(function()
+      lazy_setup(function()
         get_headers = _G.ngx.resp.get_headers
       end)
-      teardown(function()
+      lazy_teardown(function()
         _G.ngx.resp.get_headers = get_headers
         reload_alf_serializer()
       end)

--- a/spec/03-plugins/10-key-auth/01-api_spec.lua
+++ b/spec/03-plugins/10-key-auth/01-api_spec.lua
@@ -12,7 +12,7 @@ for _, strategy in helpers.each_strategy() do
     local route1
     local route2
 
-    setup(function()
+    lazy_setup(function()
       bp, db = helpers.get_db_utils(strategy)
 
       route1 = bp.routes:insert {
@@ -34,7 +34,7 @@ for _, strategy in helpers.each_strategy() do
 
       admin_client = helpers.admin_client()
     end)
-    teardown(function()
+    lazy_teardown(function()
       if admin_client then
         admin_client:close()
       end
@@ -98,14 +98,14 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       describe("GET", function()
-        setup(function()
+        lazy_setup(function()
           for i = 1, 3 do
             assert(bp.keyauth_credentials:insert {
               consumer = { id = consumer.id }
             })
           end
         end)
-        teardown(function()
+        lazy_teardown(function()
           db:truncate("keyauth_credentials")
         end)
         it("retrieves the first page", function()
@@ -318,7 +318,7 @@ for _, strategy in helpers.each_strategy() do
       local consumer2
 
       describe("GET", function()
-        setup(function()
+        lazy_setup(function()
           db:truncate("keyauth_credentials")
 
           for i = 1, 3 do
@@ -394,7 +394,7 @@ for _, strategy in helpers.each_strategy() do
       describe("GET", function()
         local credential
 
-        setup(function()
+        lazy_setup(function()
           db:truncate("keyauth_credentials")
           credential = bp.keyauth_credentials:insert {
             consumer = { id = consumer.id },

--- a/spec/03-plugins/10-key-auth/02-access_spec.lua
+++ b/spec/03-plugins/10-key-auth/02-access_spec.lua
@@ -7,7 +7,7 @@ for _, strategy in helpers.each_strategy() do
   describe("Plugin: key-auth (access) [#" .. strategy .. "]", function()
     local proxy_client
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy)
 
       local anonymous_user = bp.consumers:insert {
@@ -120,7 +120,7 @@ for _, strategy in helpers.each_strategy() do
 
       proxy_client = helpers.proxy_client()
     end)
-    teardown(function()
+    lazy_teardown(function()
       if proxy_client then
         proxy_client:close()
       end
@@ -469,7 +469,7 @@ for _, strategy in helpers.each_strategy() do
     local user2
     local anonymous
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy)
 
       local route1 = bp.routes:insert {
@@ -543,7 +543,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
 
-    teardown(function()
+    lazy_teardown(function()
       if proxy_client then
         proxy_client:close()
       end

--- a/spec/03-plugins/11-basic-auth/02-api_spec.lua
+++ b/spec/03-plugins/11-basic-auth/02-api_spec.lua
@@ -10,14 +10,14 @@ for _, strategy in helpers.each_strategy() do
     local bp
     local db
 
-    setup(function()
+    lazy_setup(function()
       bp, db = helpers.get_db_utils(strategy)
 
       assert(helpers.start_kong({
         database = strategy,
       }))
     end)
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 
@@ -30,7 +30,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     describe("/consumers/:consumer/basic-auth/", function()
-      setup(function()
+      lazy_setup(function()
         consumer = bp.consumers:insert {
           username = "bob"
         }
@@ -145,7 +145,7 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       describe("GET", function()
-        setup(function()
+        lazy_setup(function()
           for i = 1, 3 do
             bp.basicauth_credentials:insert {
               username = "bob" .. i,
@@ -154,7 +154,7 @@ for _, strategy in helpers.each_strategy() do
             }
           end
         end)
-        teardown(function()
+        lazy_teardown(function()
           db:truncate("basicauth_credentials")
         end)
         it("retrieves the first page", function()
@@ -337,7 +337,7 @@ for _, strategy in helpers.each_strategy() do
     describe("/basic-auths", function()
       local consumer2
       describe("GET", function()
-        setup(function()
+        lazy_setup(function()
           db:truncate("basicauth_credentials")
           bp.basicauth_credentials:insert {
             consumer = { id = consumer.id },
@@ -405,7 +405,7 @@ for _, strategy in helpers.each_strategy() do
     describe("/basic-auths/:credential_username_or_id/consumer", function()
       describe("GET", function()
         local credential
-        setup(function()
+        lazy_setup(function()
           db:truncate("basicauth_credentials")
           credential = bp.basicauth_credentials:insert {
             consumer = { id = consumer.id },

--- a/spec/03-plugins/11-basic-auth/03-access_spec.lua
+++ b/spec/03-plugins/11-basic-auth/03-access_spec.lua
@@ -8,7 +8,7 @@ for _, strategy in helpers.each_strategy() do
   describe("Plugin: basic-auth (access) [#" .. strategy .. "]", function()
     local proxy_client
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy)
 
       local consumer = bp.consumers:insert {
@@ -91,7 +91,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
 
-    teardown(function()
+    lazy_teardown(function()
       if proxy_client then
         proxy_client:close()
       end
@@ -354,7 +354,7 @@ for _, strategy in helpers.each_strategy() do
     local user2
     local anonymous
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy)
 
       anonymous = bp.consumers:insert {
@@ -432,7 +432,7 @@ for _, strategy in helpers.each_strategy() do
       proxy_client = helpers.proxy_client()
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       if proxy_client then
         proxy_client:close()
       end

--- a/spec/03-plugins/11-basic-auth/04-invalidations_spec.lua
+++ b/spec/03-plugins/11-basic-auth/04-invalidations_spec.lua
@@ -8,7 +8,7 @@ for _, strategy in helpers.each_strategy() do
     local bp
     local db
 
-    setup(function()
+    lazy_setup(function()
       bp, db = helpers.get_db_utils(strategy)
     end)
 

--- a/spec/03-plugins/12-correlation-id/01-access_spec.lua
+++ b/spec/03-plugins/12-correlation-id/01-access_spec.lua
@@ -11,7 +11,7 @@ for _, strategy in helpers.each_strategy() do
   describe("Plugin: correlation-id (access) [#" .. strategy .. "]", function()
     local proxy_client
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy)
 
       local route1 = bp.routes:insert {
@@ -90,7 +90,7 @@ for _, strategy in helpers.each_strategy() do
       proxy_client = helpers.proxy_client()
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       if proxy_client then
         proxy_client:close()
       end

--- a/spec/03-plugins/13-request-size-limiting/01-access_spec.lua
+++ b/spec/03-plugins/13-request-size-limiting/01-access_spec.lua
@@ -10,7 +10,7 @@ for _, strategy in helpers.each_strategy() do
   describe("Plugin: request-size-limiting (access) [#" .. strategy .. "]", function()
     local proxy_client
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy)
 
       local route = bp.routes:insert {
@@ -33,7 +33,7 @@ for _, strategy in helpers.each_strategy() do
       proxy_client = helpers.proxy_client()
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       if proxy_client then
         proxy_client:close()
       end

--- a/spec/03-plugins/14-cors/01-access_spec.lua
+++ b/spec/03-plugins/14-cors/01-access_spec.lua
@@ -5,7 +5,7 @@ for _, strategy in helpers.each_strategy() do
   describe("Plugin: cors (access) [#" .. strategy .. "]", function()
     local proxy_client
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy)
 
       local route1 = bp.routes:insert({
@@ -140,7 +140,7 @@ for _, strategy in helpers.each_strategy() do
       proxy_client = helpers.proxy_client()
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       if proxy_client then proxy_client:close() end
       helpers.stop_kong()
     end)

--- a/spec/03-plugins/15-request-transformer/02-access_spec.lua
+++ b/spec/03-plugins/15-request-transformer/02-access_spec.lua
@@ -6,7 +6,7 @@ for _, strategy in helpers.each_strategy() do
   describe("Plugin: request-transformer (access) [#" .. strategy .. "]", function()
     local proxy_client
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy)
 
       local route1 = bp.routes:insert({
@@ -161,7 +161,7 @@ for _, strategy in helpers.each_strategy() do
       }))
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 

--- a/spec/03-plugins/15-request-transformer/03-api_spec.lua
+++ b/spec/03-plugins/15-request-transformer/03-api_spec.lua
@@ -6,7 +6,7 @@ for _, strategy in helpers.each_strategy() do
   describe("Plugin: request-transformer (API) [#" .. strategy .. "]", function()
     local admin_client
 
-    teardown(function()
+    lazy_teardown(function()
       if admin_client then
         admin_client:close()
       end
@@ -15,7 +15,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     describe("POST", function()
-      setup(function()
+      lazy_setup(function()
         helpers.get_db_utils(strategy)
 
         assert(helpers.start_kong({

--- a/spec/03-plugins/16-response-transformer/02-body_transformer_spec.lua
+++ b/spec/03-plugins/16-response-transformer/02-body_transformer_spec.lua
@@ -167,7 +167,7 @@ describe("Plugin: response-transformer", function()
 
     local old_ngx, handler
 
-    setup(function()
+    lazy_setup(function()
       old_ngx  = ngx
       _G.ngx   = {       -- busted requires explicit _G to access the global environment
         log    = function() end,
@@ -183,7 +183,7 @@ describe("Plugin: response-transformer", function()
       handler:new()
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       -- luacheck: globals ngx
       ngx = old_ngx
     end)

--- a/spec/03-plugins/16-response-transformer/03-api_spec.lua
+++ b/spec/03-plugins/16-response-transformer/03-api_spec.lua
@@ -5,7 +5,7 @@ for _, strategy in helpers.each_strategy() do
   describe("Plugin: response-transformer (API) [#" .. strategy .. "]", function()
     local admin_client
 
-    teardown(function()
+    lazy_teardown(function()
       if admin_client then
         admin_client:close()
       end
@@ -13,7 +13,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     describe("POST", function()
-      setup(function()
+      lazy_setup(function()
         helpers.get_db_utils(strategy, {
           "plugins"
         })

--- a/spec/03-plugins/16-response-transformer/04-filter_spec.lua
+++ b/spec/03-plugins/16-response-transformer/04-filter_spec.lua
@@ -5,7 +5,7 @@ for _, strategy in helpers.each_strategy() do
   describe("Plugin: response-transformer (filter) [#" .. strategy .. "]", function()
     local proxy_client
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy)
 
       local route1 = bp.routes:insert({
@@ -62,7 +62,7 @@ for _, strategy in helpers.each_strategy() do
       }))
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 

--- a/spec/03-plugins/16-response-transformer/05-big_response_body_spec.lua
+++ b/spec/03-plugins/16-response-transformer/05-big_response_body_spec.lua
@@ -14,7 +14,7 @@ for _, strategy in helpers.each_strategy() do
   describe("Plugin: response-transformer [#" .. strategy .. "]", function()
     local proxy_client
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy)
 
       local route = bp.routes:insert({
@@ -41,7 +41,7 @@ for _, strategy in helpers.each_strategy() do
       }))
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 

--- a/spec/03-plugins/17-jwt/02-api_spec.lua
+++ b/spec/03-plugins/17-jwt/02-api_spec.lua
@@ -10,7 +10,7 @@ for _, strategy in helpers.each_strategy() do
     local db
     local bp
 
-    setup(function()
+    lazy_setup(function()
       bp, db = helpers.get_db_utils(strategy)
       db:truncate()
 
@@ -24,7 +24,7 @@ for _, strategy in helpers.each_strategy() do
         username = "bob"
       }
     end)
-    teardown(function()
+    lazy_teardown(function()
       if admin_client then
         admin_client:close()
       end
@@ -33,7 +33,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     describe("/consumers/:consumer/jwt/", function()
-      setup(function()
+      lazy_setup(function()
         bp.consumers:insert {
           username = "alice"
         }
@@ -41,7 +41,7 @@ for _, strategy in helpers.each_strategy() do
 
       describe("POST", function()
         local jwt1, jwt2
-        teardown(function()
+        lazy_teardown(function()
           if jwt1 == nil then return end
           db.jwt_secrets:delete(jwt1)
           if jwt2 == nil then return end
@@ -348,7 +348,7 @@ for _, strategy in helpers.each_strategy() do
     describe("/jwts", function()
       local consumer2
       describe("GET", function()
-        setup(function()
+        lazy_setup(function()
           consumer2 = bp.consumers:insert {
             username = "bob-the-buidler"
           }

--- a/spec/03-plugins/17-jwt/03-access_spec.lua
+++ b/spec/03-plugins/17-jwt/03-access_spec.lua
@@ -25,7 +25,7 @@ for _, strategy in helpers.each_strategy() do
     local proxy_client
     local admin_client
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy, nil, { "ctx-checker" })
 
       local routes = {}
@@ -168,7 +168,7 @@ for _, strategy in helpers.each_strategy() do
       admin_client = helpers.admin_client()
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       if proxy_client then
         proxy_client:close()
       end
@@ -725,7 +725,7 @@ for _, strategy in helpers.each_strategy() do
     local anonymous
     local jwt_token
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy)
 
       local service1 = bp.services:insert({
@@ -804,7 +804,7 @@ for _, strategy in helpers.each_strategy() do
       client = helpers.proxy_client()
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       if client then
         client:close()
       end

--- a/spec/03-plugins/18-ip-restriction/02-access_spec.lua
+++ b/spec/03-plugins/18-ip-restriction/02-access_spec.lua
@@ -9,7 +9,7 @@ for _, strategy in helpers.each_strategy() do
     local admin_client
     local db
 
-    setup(function()
+    lazy_setup(function()
       local bp
       bp, db = helpers.get_db_utils(strategy)
 
@@ -121,7 +121,7 @@ for _, strategy in helpers.each_strategy() do
       admin_client = helpers.admin_client()
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       if proxy_client and admin_client then
         proxy_client:close()
         admin_client:close()

--- a/spec/03-plugins/19-acl/01-api_spec.lua
+++ b/spec/03-plugins/19-acl/01-api_spec.lua
@@ -9,7 +9,7 @@ for _, strategy in helpers.each_strategy() do
     local bp
     local db
 
-    setup(function()
+    lazy_setup(function()
       bp, db = helpers.get_db_utils(strategy)
 
       assert(helpers.start_kong({
@@ -19,7 +19,7 @@ for _, strategy in helpers.each_strategy() do
       admin_client = helpers.admin_client()
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       if admin_client then
         admin_client:close()
       end
@@ -28,7 +28,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     describe("/consumers/:consumer/acls/", function()
-      setup(function()
+      lazy_setup(function()
         db:truncate()
         consumer = bp.consumers:insert {
           username = "bob"
@@ -73,7 +73,7 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       describe("GET", function()
-        teardown(function()
+        lazy_teardown(function()
           db:truncate("acls")
         end)
         it("retrieves the first page", function()
@@ -281,7 +281,7 @@ for _, strategy in helpers.each_strategy() do
       local consumer2
 
       describe("GET", function()
-        setup(function()
+        lazy_setup(function()
           db:truncate("acls")
 
           for i = 1, 3 do
@@ -359,7 +359,7 @@ for _, strategy in helpers.each_strategy() do
       describe("GET", function()
         local credential
 
-        setup(function()
+        lazy_setup(function()
           db:truncate("acls")
           credential = db.acls:insert {
             group = "foo-group",

--- a/spec/03-plugins/19-acl/02-access_spec.lua
+++ b/spec/03-plugins/19-acl/02-access_spec.lua
@@ -9,7 +9,7 @@ for _, strategy in helpers.each_strategy() do
     local bp
     local db
 
-    setup(function()
+    lazy_setup(function()
       bp, db = helpers.get_db_utils(strategy)
 
       local consumer1 = bp.consumers:insert {
@@ -275,7 +275,7 @@ for _, strategy in helpers.each_strategy() do
       admin_client:close()
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 

--- a/spec/03-plugins/20-hmac-auth/02-api_spec.lua
+++ b/spec/03-plugins/20-hmac-auth/02-api_spec.lua
@@ -10,7 +10,7 @@ for _, strategy in helpers.each_strategy() do
     local bp
     local db
 
-    setup(function()
+    lazy_setup(function()
       bp, db = helpers.get_db_utils(strategy)
 
       assert(helpers.start_kong({
@@ -20,7 +20,7 @@ for _, strategy in helpers.each_strategy() do
       admin_client = helpers.admin_client()
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       if admin_client then
         admin_client:close()
       end
@@ -266,7 +266,7 @@ for _, strategy in helpers.each_strategy() do
     describe("/hmac-auths", function()
       local consumer2
       describe("GET", function()
-        setup(function()
+        lazy_setup(function()
           db:truncate("hmacauth_credentials")
           bp.hmacauth_credentials:insert {
             consumer = { id = consumer.id },
@@ -334,7 +334,7 @@ for _, strategy in helpers.each_strategy() do
     describe("/hmac-auths/:hmac_username_or_id/consumer", function()
       describe("GET", function()
         local credential
-        setup(function()
+        lazy_setup(function()
           db:truncate("hmacauth_credentials")
           credential = bp.hmacauth_credentials:insert({
             consumer = { id = consumer.id },

--- a/spec/03-plugins/20-hmac-auth/03-access_spec.lua
+++ b/spec/03-plugins/20-hmac-auth/03-access_spec.lua
@@ -21,7 +21,7 @@ for _, strategy in helpers.each_strategy() do
     local consumer
     local credential
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy)
 
       local route1 = bp.routes:insert {
@@ -130,7 +130,7 @@ for _, strategy in helpers.each_strategy() do
       proxy_client = helpers.proxy_client()
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       if proxy_client then
         proxy_client:close()
       end
@@ -1520,7 +1520,7 @@ for _, strategy in helpers.each_strategy() do
     local hmacAuth
     local hmacDate
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy)
 
       local service1 = bp.services:insert({
@@ -1605,7 +1605,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
 
-    teardown(function()
+    lazy_teardown(function()
       if proxy_client then proxy_client:close() end
       helpers.stop_kong()
     end)

--- a/spec/03-plugins/20-hmac-auth/04-invalidations_spec.lua
+++ b/spec/03-plugins/20-hmac-auth/04-invalidations_spec.lua
@@ -10,7 +10,7 @@ for _, strategy in helpers.each_strategy() do
     local credential
     local db
 
-    setup(function()
+    lazy_setup(function()
       local bp
       bp, db = helpers.get_db_utils(strategy)
 
@@ -46,7 +46,7 @@ for _, strategy in helpers.each_strategy() do
       admin_client = helpers.admin_client()
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       if proxy_client and admin_client then
         proxy_client:close()
         admin_client:close()

--- a/spec/03-plugins/21-ldap-auth/01-access_spec.lua
+++ b/spec/03-plugins/21-ldap-auth/01-access_spec.lua
@@ -30,7 +30,7 @@ for _, strategy in helpers.each_strategy() do
     local route2
     local plugin2
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy)
 
       local route1 = bp.routes:insert {
@@ -144,7 +144,7 @@ for _, strategy in helpers.each_strategy() do
       }))
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 
@@ -487,7 +487,7 @@ for _, strategy in helpers.each_strategy() do
     local user
     local anonymous
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy)
 
       local service1 = bp.services:insert({
@@ -568,7 +568,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
 
-    teardown(function()
+    lazy_teardown(function()
       if proxy_client then
         proxy_client:close()
       end

--- a/spec/03-plugins/21-ldap-auth/02-invalidations_spec.lua
+++ b/spec/03-plugins/21-ldap-auth/02-invalidations_spec.lua
@@ -11,7 +11,7 @@ for _, strategy in helpers.each_strategy() do
     local proxy_client
     local plugin
 
-    setup(function()
+    lazy_setup(function()
       local bp
       bp = helpers.get_db_utils(strategy)
 
@@ -52,7 +52,7 @@ for _, strategy in helpers.each_strategy() do
       end
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong(nil, true)
     end)
 

--- a/spec/03-plugins/22-bot-detection/01-access_spec.lua
+++ b/spec/03-plugins/22-bot-detection/01-access_spec.lua
@@ -9,7 +9,7 @@ for _, strategy in helpers.each_strategy() do
   describe("Plugin: bot-detection (access) [#" .. strategy .. "]", function()
     local proxy_client
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy, {
         "plugins",
         "routes",
@@ -56,7 +56,7 @@ for _, strategy in helpers.each_strategy() do
       }))
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 
@@ -160,7 +160,7 @@ for _, strategy in helpers.each_strategy() do
   describe("Plugin: bot-detection configured global (access) [#" .. strategy .. "]", function()
     local proxy_client
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy, {
         "plugins",
         "routes",
@@ -183,7 +183,7 @@ for _, strategy in helpers.each_strategy() do
       }))
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 

--- a/spec/03-plugins/22-bot-detection/02-invalidations_spec.lua
+++ b/spec/03-plugins/22-bot-detection/02-invalidations_spec.lua
@@ -6,7 +6,7 @@ for _, strategy in helpers.each_strategy() do
     local proxy_client
     local admin_client
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy)
 
       local route = bp.routes:insert {
@@ -25,7 +25,7 @@ for _, strategy in helpers.each_strategy() do
       }))
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 

--- a/spec/03-plugins/22-bot-detection/03-api_spec.lua
+++ b/spec/03-plugins/22-bot-detection/03-api_spec.lua
@@ -11,7 +11,7 @@ for _, strategy in helpers.each_strategy() do
     local route1
     local route2
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy)
 
       route1 = bp.routes:insert {
@@ -28,7 +28,7 @@ for _, strategy in helpers.each_strategy() do
       }))
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 

--- a/spec/03-plugins/23-aws-lambda/01-access_spec.lua
+++ b/spec/03-plugins/23-aws-lambda/01-access_spec.lua
@@ -11,7 +11,7 @@ for _, strategy in helpers.each_strategy() do
     local proxy_client
     local admin_client
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy)
 
       local route1 = bp.routes:insert {
@@ -287,7 +287,7 @@ for _, strategy in helpers.each_strategy() do
       admin_client:close()
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 

--- a/spec/03-plugins/24-rate-limiting/02-policies_spec.lua
+++ b/spec/03-plugins/24-rate-limiting/02-policies_spec.lua
@@ -13,7 +13,7 @@ for _, strategy in helpers.each_strategy() do
       local dao
       local policies
 
-      setup(function()
+      lazy_setup(function()
         local _
         _, db, dao = helpers.get_db_utils(strategy)
 

--- a/spec/03-plugins/24-rate-limiting/03-api_spec.lua
+++ b/spec/03-plugins/24-rate-limiting/03-api_spec.lua
@@ -10,7 +10,7 @@ for _, strategy in helpers.each_strategy() do
     local admin_client
     local bp
 
-    setup(function()
+    lazy_setup(function()
       bp = helpers.get_db_utils(strategy, {
         "routes",
         "services",
@@ -18,7 +18,7 @@ for _, strategy in helpers.each_strategy() do
       })
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       if admin_client then
         admin_client:close()
       end
@@ -29,7 +29,7 @@ for _, strategy in helpers.each_strategy() do
     describe("POST", function()
       local route
 
-      setup(function()
+      lazy_setup(function()
         local service = bp.services:insert()
 
         route = bp.routes:insert {

--- a/spec/03-plugins/24-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/24-rate-limiting/04-access_spec.lua
@@ -78,7 +78,7 @@ for _, strategy in helpers.each_strategy() do
       local db
       local dao
 
-      setup(function()
+      lazy_setup(function()
         helpers.kill_all()
         flush_redis()
 
@@ -249,7 +249,7 @@ for _, strategy in helpers.each_strategy() do
         }))
       end)
 
-      teardown(function()
+      lazy_teardown(function()
         helpers.stop_kong()
         assert(db:truncate())
       end)
@@ -445,7 +445,7 @@ for _, strategy in helpers.each_strategy() do
             }))
           end)
 
-          teardown(function()
+          lazy_teardown(function()
             helpers.kill_all()
             assert(db:truncate())
           end)
@@ -538,7 +538,7 @@ for _, strategy in helpers.each_strategy() do
             }))
           end)
 
-          teardown(function()
+          lazy_teardown(function()
             helpers.kill_all()
             assert(db:truncate())
           end)
@@ -566,7 +566,7 @@ for _, strategy in helpers.each_strategy() do
       describe("Expirations", function()
         local route
 
-        setup(function()
+        lazy_setup(function()
           helpers.stop_kong()
 
           local bp = helpers.get_db_utils(strategy)
@@ -618,7 +618,7 @@ for _, strategy in helpers.each_strategy() do
       local bp
       local db
 
-      setup(function()
+      lazy_setup(function()
         helpers.kill_all()
         flush_redis()
         bp, db = helpers.get_db_utils(strategy)
@@ -659,7 +659,7 @@ for _, strategy in helpers.each_strategy() do
         }))
       end)
 
-      teardown(function()
+      lazy_teardown(function()
         helpers.kill_all()
         assert(db:truncate())
       end)
@@ -688,7 +688,7 @@ for _, strategy in helpers.each_strategy() do
       local bp
       local db
 
-      setup(function()
+      lazy_setup(function()
         helpers.kill_all()
         flush_redis()
         bp, db = helpers.get_db_utils(strategy)
@@ -716,7 +716,7 @@ for _, strategy in helpers.each_strategy() do
         }))
       end)
 
-      teardown(function()
+      lazy_teardown(function()
         helpers.kill_all()
         assert(db:truncate())
       end)

--- a/spec/03-plugins/24-rate-limiting/05-integration_spec.lua
+++ b/spec/03-plugins/24-rate-limiting/05-integration_spec.lua
@@ -25,7 +25,7 @@ describe("Plugin: rate-limiting (integration)", function()
   local client
   local bp
 
-  setup(function()
+  lazy_setup(function()
     bp = helpers.get_db_utils(nil, {
       "routes",
       "services",
@@ -35,7 +35,7 @@ describe("Plugin: rate-limiting (integration)", function()
     })
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     if client then
       client:close()
     end
@@ -47,7 +47,7 @@ describe("Plugin: rate-limiting (integration)", function()
     -- Regression test for the following issue:
     -- https://github.com/Kong/kong/issues/3292
 
-    setup(function()
+    lazy_setup(function()
       flush_redis(REDIS_DB_1)
       flush_redis(REDIS_DB_2)
 

--- a/spec/03-plugins/25-response-rate-limiting/02-policies_spec.lua
+++ b/spec/03-plugins/25-response-rate-limiting/02-policies_spec.lua
@@ -14,7 +14,7 @@ for _, strategy in helpers.each_strategy() do
 
       local dao
 
-      setup(function()
+      lazy_setup(function()
         local _, db
         _, db, dao = helpers.get_db_utils(strategy, {})
         _G.kong = _G.kong or { db = db }

--- a/spec/03-plugins/25-response-rate-limiting/03-api_spec.lua
+++ b/spec/03-plugins/25-response-rate-limiting/03-api_spec.lua
@@ -8,7 +8,7 @@ for _, strategy in helpers.each_strategy() do
     local admin_client
     local bp
 
-    setup(function()
+    lazy_setup(function()
       bp = helpers.get_db_utils(strategy, {
         "routes",
         "services",
@@ -21,7 +21,7 @@ for _, strategy in helpers.each_strategy() do
       }))
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 

--- a/spec/03-plugins/25-response-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/25-response-rate-limiting/04-access_spec.lua
@@ -94,7 +94,7 @@ for _, policy in ipairs({"local", "cluster", "redis"}) do
 
 describe(fmt("#flaky Plugin: response-ratelimiting (access) with policy: #%s [#%s]", policy, strategy), function()
 
-  setup(function()
+  lazy_setup(function()
     local bp = init_db(strategy, policy)
 
     if policy == "local" then
@@ -304,7 +304,7 @@ describe(fmt("#flaky Plugin: response-ratelimiting (access) with policy: #%s [#%
     }))
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     helpers.stop_kong(nil, true)
   end)
 
@@ -497,7 +497,7 @@ end)
 
 describe(fmt("#flaky Plugin: response-ratelimiting (expirations) with policy: #%s [#%s]", policy, strategy), function()
 
-  setup(function()
+  lazy_setup(function()
     local bp = init_db(strategy, policy)
 
     local route = bp.routes:insert {
@@ -523,7 +523,7 @@ describe(fmt("#flaky Plugin: response-ratelimiting (expirations) with policy: #%
     }))
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     helpers.stop_kong(nil, true)
   end)
 
@@ -556,7 +556,7 @@ end)
 
 describe(fmt("#flaky Plugin: response-ratelimiting (access - global for single consumer) with policy: #%s [#%s]", policy, strategy), function()
 
-  setup(function()
+  lazy_setup(function()
     local bp = init_db(strategy, policy)
 
     local consumer = bp.consumers:insert {
@@ -594,7 +594,7 @@ describe(fmt("#flaky Plugin: response-ratelimiting (access - global for single c
     }))
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     helpers.stop_kong(nil, true)
   end)
 
@@ -605,7 +605,7 @@ end)
 
 describe(fmt("#flaky Plugin: response-ratelimiting (access - global) with policy: #%s [#%s]", policy, strategy), function()
 
-  setup(function()
+  lazy_setup(function()
     local bp = init_db(strategy, policy)
 
     -- global plugin (not attached to route, service or consumer)
@@ -631,7 +631,7 @@ describe(fmt("#flaky Plugin: response-ratelimiting (access - global) with policy
     }))
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     helpers.stop_kong(nil, true)
   end)
 

--- a/spec/03-plugins/25-response-rate-limiting/05-integration_spec.lua
+++ b/spec/03-plugins/25-response-rate-limiting/05-integration_spec.lua
@@ -25,7 +25,7 @@ describe("Plugin: rate-limiting (integration)", function()
   local client
   local bp
 
-  setup(function()
+  lazy_setup(function()
     -- only to run migrations
     bp = helpers.get_db_utils(nil, {
       "routes",
@@ -36,7 +36,7 @@ describe("Plugin: rate-limiting (integration)", function()
     })
   end)
 
-  teardown(function()
+  lazy_teardown(function()
     if client then
       client:close()
     end
@@ -48,7 +48,7 @@ describe("Plugin: rate-limiting (integration)", function()
     -- Regression test for the following issue:
     -- https://github.com/Kong/kong/issues/3292
 
-    setup(function()
+    lazy_setup(function()
       flush_redis(REDIS_DB_1)
       flush_redis(REDIS_DB_2)
 

--- a/spec/03-plugins/26-oauth2/02-api_spec.lua
+++ b/spec/03-plugins/26-oauth2/02-api_spec.lua
@@ -10,7 +10,7 @@ for _, strategy in helpers.each_strategy() do
     local db
     local bp
 
-    setup(function()
+    lazy_setup(function()
       bp, db = helpers.get_db_utils(strategy)
 
       assert(db:truncate("routes"))
@@ -30,14 +30,14 @@ for _, strategy in helpers.each_strategy() do
 
       admin_client = helpers.admin_client()
     end)
-    teardown(function()
+    lazy_teardown(function()
       if admin_client then admin_client:close() end
       assert(helpers.stop_kong())
       helpers.clean_prefix()
     end)
 
     describe("/consumers/:consumer/oauth2/", function()
-      setup(function()
+      lazy_setup(function()
         service = bp.services:insert({ host = "oauth2_token.com" })
         consumer = bp.consumers:insert({ username = "bob" })
         bp.consumers:insert({ username = "sally" })
@@ -225,7 +225,7 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       describe("GET", function()
-        setup(function()
+        lazy_setup(function()
           for i = 1, 3 do
             bp.oauth2_credentials:insert {
               name          = "app" .. i,
@@ -234,7 +234,7 @@ for _, strategy in helpers.each_strategy() do
             }
           end
         end)
-        teardown(function()
+        lazy_teardown(function()
           assert(db:truncate("oauth2_credentials"))
         end)
         it("retrieves the first page", function()
@@ -400,7 +400,7 @@ for _, strategy in helpers.each_strategy() do
 
     describe("/oauth2_tokens/", function()
       local oauth2_credential
-      setup(function()
+      lazy_setup(function()
         oauth2_credential = bp.oauth2_credentials:insert {
           name          = "Test APP",
           redirect_uris = { helpers.mock_upstream_ssl_url },
@@ -451,7 +451,7 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       describe("GET", function()
-        setup(function()
+        lazy_setup(function()
           for _ = 1, 3 do
             bp.oauth2_tokens:insert {
               credential = { id = oauth2_credential.id },
@@ -460,7 +460,7 @@ for _, strategy in helpers.each_strategy() do
             }
           end
         end)
-        teardown(function()
+        lazy_teardown(function()
           assert(db:truncate("oauth2_tokens"))
         end)
         it("retrieves the first page", function()

--- a/spec/03-plugins/26-oauth2/03-access_spec.lua
+++ b/spec/03-plugins/26-oauth2/03-access_spec.lua
@@ -71,7 +71,7 @@ for _, strategy in helpers.each_strategy() do
     local db
     local bp
 
-    setup(function()
+    lazy_setup(function()
       bp, db = helpers.get_db_utils(strategy)
 
       local consumer = bp.consumers:insert {
@@ -321,7 +321,7 @@ for _, strategy in helpers.each_strategy() do
       proxy_ssl_client = helpers.proxy_ssl_client()
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       if proxy_client and proxy_ssl_client then
         proxy_client:close()
         proxy_ssl_client:close()
@@ -2350,7 +2350,7 @@ for _, strategy in helpers.each_strategy() do
     local db
     local bp
 
-    setup(function()
+    lazy_setup(function()
       bp, db = helpers.get_db_utils(strategy)
 
       local service1 = bp.services:insert({
@@ -2433,7 +2433,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
 
-    teardown(function()
+    lazy_teardown(function()
       if proxy_client then proxy_client:close() end
       helpers.stop_kong()
     end)
@@ -2573,7 +2573,7 @@ for _, strategy in helpers.each_strategy() do
     local db
     local bp
 
-    setup(function()
+    lazy_setup(function()
       bp, db = helpers.get_db_utils(strategy)
 
       local route11 = assert(db.routes:insert({
@@ -2631,7 +2631,7 @@ for _, strategy in helpers.each_strategy() do
       }))
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       helpers.stop_kong()
     end)
 

--- a/spec/03-plugins/26-oauth2/04-invalidations_spec.lua
+++ b/spec/03-plugins/26-oauth2/04-invalidations_spec.lua
@@ -9,7 +9,7 @@ for _, strategy in helpers.each_strategy() do
     local db
     local bp
 
-    setup(function()
+    lazy_setup(function()
       bp, db = helpers.get_db_utils(strategy)
     end)
 

--- a/spec/03-plugins/27-request-termination/02-access_spec.lua
+++ b/spec/03-plugins/27-request-termination/02-access_spec.lua
@@ -11,7 +11,7 @@ for _, strategy in helpers.each_strategy() do
     local proxy_client
     local admin_client
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy)
 
       local route1 = bp.routes:insert({
@@ -97,7 +97,7 @@ for _, strategy in helpers.each_strategy() do
       admin_client = helpers.admin_client()
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       if proxy_client and admin_client then
         proxy_client:close()
         admin_client:close()

--- a/spec/03-plugins/27-request-termination/03-integration_spec.lua
+++ b/spec/03-plugins/27-request-termination/03-integration_spec.lua
@@ -7,7 +7,7 @@ for _, strategy in helpers.each_strategy() do
     local admin_client
     local consumer
 
-    setup(function()
+    lazy_setup(function()
       local bp = helpers.get_db_utils(strategy)
 
       bp.routes:insert({
@@ -36,7 +36,7 @@ for _, strategy in helpers.each_strategy() do
       admin_client = helpers.admin_client()
     end)
 
-    teardown(function()
+    lazy_teardown(function()
       if proxy_client and admin_client then
         proxy_client:close()
         admin_client:close()


### PR DESCRIPTION
The default `setup()` and `teardown()` always run, even if there are no tests to be executed within the describe block. The lazy-ones (`lazy_setup()` and `lazy_teardown()`) only execute when there is actually a test to run.

Effectively this means that tests that run migrations and are executed with the `#postgres` tag, would still also run the migrations on C*.

This should improve the test-suite execution time.
