### PR TITLE
feat/required plugins.run_on field

### DIFF
--- a/kong/db/dao/plugins.lua
+++ b/kong/db/dao/plugins.lua
@@ -73,7 +73,7 @@ local function convert_legacy_schema(name, old_schema)
     fields = {
       config = {
         type = "record",
-        nullable = false,
+        required = true,
         fields = {}
       }
     },
@@ -95,7 +95,7 @@ local function convert_legacy_schema(name, old_schema)
             new_fdata.type = "map"
           else
             new_fdata.type = "record"
-            new_fdata.nullable = false
+            new_fdata.required = true
           end
 
         elseif v == "array" then
@@ -129,7 +129,7 @@ local function convert_legacy_schema(name, old_schema)
           new_fdata.keys = { type = "string" }
           new_fdata.values = {
             type = "record",
-            nullable = false,
+            required = true,
             fields = rfields,
           }
         else

--- a/kong/db/schema/entity.lua
+++ b/kong/db/schema/entity.lua
@@ -18,15 +18,15 @@ local base_types = {
   integer = true,
 }
 
--- Make records in Entities non-nullable by default,
+-- Make records in Entities required by default,
 -- so that they return their full structure on API queries.
-local function make_records_non_nullable(field)
-  if field.nullable == nil then
-    field.nullable = false
+local function make_records_required(field)
+  if field.required == nil then
+    field.required = true
   end
   for _, f in Schema.each_field(field) do
     if f.type == "record" then
-      make_records_non_nullable(f)
+      make_records_required(f)
     end
   end
 end
@@ -61,7 +61,7 @@ function Entity.new(definition)
       end
 
     elseif field.type == "record" then
-      make_records_non_nullable(field)
+      make_records_required(field)
 
     elseif field.type == "function" then
       return nil, entity_errors.NO_FUNCTIONS:format(name)
@@ -75,8 +75,8 @@ end
 
 
 function Entity.new_subschema(schema, key, definition)
-  make_records_non_nullable(definition)
-  definition.nullable = nil
+  make_records_required(definition)
+  definition.required = nil
   return Schema.new_subschema(schema, key, definition)
 end
 

--- a/kong/db/schema/typedefs.lua
+++ b/kong/db/schema/typedefs.lua
@@ -254,12 +254,14 @@ typedefs.key = Schema.define {
 
 typedefs.run_on = Schema.define {
   type = "string",
+  required = true,
   default = "first",
   one_of = { "first", "second", "all" },
 }
 
 typedefs.run_on_first = Schema.define {
   type = "string",
+  required = true,
   default = "first",
   one_of = { "first" },
 }

--- a/kong/plugins/response-ratelimiting/schema.lua
+++ b/kong/plugins/response-ratelimiting/schema.lua
@@ -54,7 +54,7 @@ return {
               keys = { type = "string" },
               values = {
                 type = "record",
-                nullable = false,
+                required = true,
                 fields = {
                   { second = { type = "number", gt = 0 }, },
                   { minute = { type = "number", gt = 0 }, },

--- a/spec/01-unit/000-new-dao/01-schema/04-services_spec.lua
+++ b/spec/01-unit/000-new-dao/01-schema/04-services_spec.lua
@@ -28,12 +28,22 @@ describe("services", function()
     assert.truthy(Services:validate(service))
   end)
 
-  it("missing protocol produces error", function()
+  it("null protocol produces error", function()
     local service = {
       protocol = ngx.null,
     }
     service = Services:process_auto_fields(service, "insert")
     local ok, errs = Services:validate(service)
+    assert.falsy(ok)
+    assert.truthy(errs["protocol"])
+  end)
+
+  it("null protocol produces error on update", function()
+    local service = {
+      protocol = ngx.null,
+    }
+    service = Services:process_auto_fields(service, "update")
+    local ok, errs = Services:validate_update(service)
     assert.falsy(ok)
     assert.truthy(errs["protocol"])
   end)

--- a/spec/01-unit/000-new-dao/04-dao.lua
+++ b/spec/01-unit/000-new-dao/04-dao.lua
@@ -14,7 +14,7 @@ local nullable_schema_definition = {
     { b = { type = "string", default = "hello" }, },
     { u = { type = "string" }, },
     { r = { type = "record",
-            nullable = true,
+            required = false,
             fields = {
               { f1 = { type = "number" } },
               { f2 = { type = "string", default = "world" } },
@@ -27,12 +27,12 @@ local non_nullable_schema_definition = {
   primary_key = { "a" },
   fields = {
     { a = { type = "number" }, },
-    { b = { type = "string", default = "hello", nullable = false }, },
+    { b = { type = "string", default = "hello", required = true }, },
     { u = { type = "string" }, },
     { r = { type = "record",
             fields = {
               { f1 = { type = "number" } },
-              { f2 = { type = "string", default = "world", nullable = false } },
+              { f2 = { type = "string", default = "world", required = true } },
             } } },
   }
 }


### PR DESCRIPTION
This PR marks the `plugins.run_on` field as required, so it gets a default value after migrating from 0.14 to 0.15.

It also includes a change in the schema to make `required` work this way, taking over the role previously hold by `nullable`.

Related with https://github.com/Kong/kong-upgrade-tests/pull/12