### PR TITLE
perf(key-auth) unroll header sets to improve JITability

### DIFF
--- a/kong/plugins/key-auth/handler.lua
+++ b/kong/plugins/key-auth/handler.lua
@@ -41,23 +41,22 @@ end
 local function set_consumer(consumer, credential)
   local const = constants.HEADERS
 
-  local new_headers = {
-    [const.CONSUMER_ID]        = consumer.id,
-    [const.CONSUMER_CUSTOM_ID] = tostring(consumer.custom_id),
-    [const.CONSUMER_USERNAME]  = consumer.username,
-  }
-
   kong.client.authenticate(consumer, credential)
 
+  kong.service.request.set_header(const.CONSUMER_ID, consumer.id)
+  kong.service.request.set_header(const.CONSUMER_CUSTOM_ID, tostring(consumer.custom_id))
+  kong.service.request.set_header(const.CONSUMER_USERNAME, consumer.username)
+
   if credential then
-    new_headers[const.CREDENTIAL_USERNAME] = credential.username
+    if credential.username then
+      kong.service.request.set_header(const.CREDENTIAL_USERNAME, credential.username)
+    end
+
     kong.service.request.clear_header(const.ANONYMOUS) -- in case of auth plugins concatenation
 
   else
-    new_headers[const.ANONYMOUS] = true
+    kong.service.request.set_header(const.ANONYMOUS, true)
   end
-
-  kong.service.request.set_headers(new_headers)
 end
 
 


### PR DESCRIPTION
### Summary

The PDK's 'set_headers' function relies on NYI LuaJIT operations that result in the JIT trace being aborted, forcing OpenResty to fall back to interpreted code. This commit unrolls the header
definitions into individual PDK 'set_header' calls, improving JITability of this chunk.

In lab tests we observed that Kong's maximum throughput (in a CPU-bound workload) increased 10% with this change. Backtrace flamegraphs of non-JITed captures show that this change results in non-JITed key-auth handler code reduced from 32% of traces to 1% of traces:

![rc2-nojit](https://user-images.githubusercontent.com/4625425/48727148-3e001b80-ebe6-11e8-8e94-c1e23f1d9a1e.png)
![key-auth-jit-nojit](https://user-images.githubusercontent.com/4625425/48727149-3e001b80-ebe6-11e8-9ae1-998086ed8245.png)

### Full changelog

* Replace PDK `set_headers` call in `key-auth` with appropriate `set_header`.