### PR TITLE
fix(db) add premature check for postgres cleanup timer, fix #3975

### DIFF
--- a/kong/db/strategies/postgres/connector.lua
+++ b/kong/db/strategies/postgres/connector.lua
@@ -290,7 +290,11 @@ function _mt:init_worker(strategies)
       "COMMIT;"
     }, "\n")
 
-    return timer_every(60, function()
+    return timer_every(60, function(premature)
+      if premature then
+        return
+      end
+
       local ok, err = self:query(cleanup_statement)
       if not ok then
         if err then


### PR DESCRIPTION
### Summary

Adds `premature` check to Postgres cleanup timer.

### Issues resolved

Fix #3975
