### PR TITLE
fix delete target can not offline old target issue

### DIFF
--- a/kong/api/routes/upstreams.lua
+++ b/kong/api/routes/upstreams.lua
@@ -263,11 +263,11 @@ return {
       clean_history(self.upstream.id, dao_factory)
 
       -- this is just a wrapper around POSTing a new target with weight=0
-      local _, err = dao_factory.targets:insert({
+      local _, err = dao_factory.targets:update({
         target      = self.target.target,
         upstream_id = self.upstream.id,
         weight      = 0,
-      })
+      }, { id = self.target.id})
       if err then
         return app_helpers.yield_error(err)
       end


### PR DESCRIPTION
Currently, if we delete a target from upstream by Admin API, the old target is still there, and new target with same upstream id and target and 0 weight will be created, this will cause the target still server the request. So this PR use update to set weight to 0, make the target server offline, and keeping history there.