### PR TITLE
feat(acl) add support for authenticated groups (for 3rd party authentication)

### DIFF
--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -61,6 +61,7 @@ return {
     RATELIMIT_LIMIT = "X-RateLimit-Limit",
     RATELIMIT_REMAINING = "X-RateLimit-Remaining",
     CONSUMER_GROUPS = "X-Consumer-Groups",
+    AUTHENTICATED_GROUPS = "X-Authenticated-Groups",
     FORWARDED_HOST = "X-Forwarded-Host",
     FORWARDED_PREFIX = "X-Forwarded-Prefix",
     ANONYMOUS = "X-Anonymous-Consumer",

--- a/kong/plugins/acl/groups.lua
+++ b/kong/plugins/acl/groups.lua
@@ -5,6 +5,7 @@ local EMPTY = tablex.readonly {}
 
 
 local kong = kong
+local type = type
 local mt_cache = { __mode = "k" }
 local setmetatable = setmetatable
 local consumer_groups_cache = setmetatable({}, mt_cache)
@@ -28,7 +29,7 @@ end
 
 
 --- Returns the database records with groups the consumer belongs to
--- @param conumer_id (string) the consumer for which to fetch the groups it belongs to
+-- @param consumer_id (string) the consumer for which to fetch the groups it belongs to
 -- @return table with group records (empty table if none), or nil+error
 local function get_consumer_groups_raw(consumer_id)
   local cache_key = kong.db.acls:cache_key(consumer_id)
@@ -55,7 +56,7 @@ end
 --   admins = "admins",
 -- }
 -- If there are no groups defined, it will return an empty table
--- @param conumer_id (string) the consumer for which to fetch the groups it belongs to
+-- @param consumer_id (string) the consumer for which to fetch the groups it belongs to
 -- @return table with groups (empty table if none) or nil+error
 local function get_consumer_groups(consumer_id)
   local raw_groups, err = get_consumer_groups_raw(consumer_id)
@@ -113,21 +114,6 @@ local function consumer_in_groups(groups_to_check, consumer_groups)
 end
 
 
---- checks whether a consumer is part of the gieven list of groups
--- @param groups_to_check (table) an array of group names. Note: since the
--- results will be cached by this table, always use the same table for the
--- same set of groups!
--- @param consumer_id (string) id of consumer to verify
-local function consumer_id_in_groups(groups_to_check, consumer_id)
-  local consumer_groups, err = get_consumer_groups(consumer_id)
-  if not consumer_groups then
-    return nil, err
-  end
-
-  return consumer_in_groups(groups_to_check, consumer_groups)
-end
-
-
 --- Gets the currently identified consumer for the request.
 -- Checks both consumer and if not found the credentials.
 -- @return consumer_id (string), or alternatively `nil` if no consumer was
@@ -138,9 +124,60 @@ local function get_current_consumer_id()
 end
 
 
+--- Returns a table with all group names.
+-- The table will have an array part to iterate over, and a hash part
+-- where each group name is indexed by itself. Eg.
+-- {
+--   [1] = "users",
+--   [2] = "admins",
+--   users = "users",
+--   admins = "admins",
+-- }
+-- If there are no authenticated_groups defined, it will return nil
+-- @return table with groups or nil
+local function get_authenticated_groups()
+  local authenticated_groups = kong.ctx.shared.authenticated_groups
+  if type(authenticated_groups) ~= "table" then
+    authenticated_groups = ngx.ctx.authenticated_groups
+    if authenticated_groups == nil then
+      return nil
+    end
+
+    if type(authenticated_groups) ~= "table" then
+      kong.log.warn("invalid authenticated_groups, a table was expected")
+      return nil
+    end
+  end
+
+  local groups = {}
+  for i = 1, #authenticated_groups do
+    groups[i] = authenticated_groups[i]
+    groups[authenticated_groups[i]] = authenticated_groups[i]
+  end
+
+  return groups
+end
+
+
+--- checks whether a group-list is part of a given list of groups.
+-- @param groups_to_check (table) an array of group names.
+-- @param groups (table) list of groups (result from
+-- `get_authenticated_groups`)
+-- @return (boolean) whether the authenticated group is part of any of the
+-- groups.
+local function group_in_groups(groups_to_check, groups)
+  for i = 1, #groups_to_check do
+    if groups[groups_to_check[i]] then
+      return true
+    end
+  end
+end
+
+
 return {
-  get_consumer_groups = get_consumer_groups,
-  consumer_in_groups = consumer_in_groups,
-  consumer_id_in_groups = consumer_id_in_groups,
   get_current_consumer_id = get_current_consumer_id,
+  get_consumer_groups = get_consumer_groups,
+  get_authenticated_groups = get_authenticated_groups,
+  consumer_in_groups = consumer_in_groups,
+  group_in_groups = group_in_groups,
 }

--- a/kong/plugins/acl/handler.lua
+++ b/kong/plugins/acl/handler.lua
@@ -18,6 +18,24 @@ local mt_cache = { __mode = "k" }
 local config_cache = setmetatable({}, mt_cache)
 
 
+local function get_to_be_blocked(config, groups, in_group)
+  local to_be_blocked
+  if config.type == BLACK then
+    to_be_blocked = in_group
+  else
+    to_be_blocked = not in_group
+  end
+
+  if to_be_blocked == false then
+    -- we're allowed, convert 'false' to the header value, if needed
+    -- if not needed, set dummy value to save mem for potential long strings
+    to_be_blocked = config.hide_groups_header and "" or concat(groups, ", ")
+  end
+
+  return to_be_blocked
+end
+
+
 local ACLHandler = BasePlugin:extend()
 
 
@@ -36,58 +54,83 @@ function ACLHandler:access(conf)
   -- simplify our plugins 'conf' table
   local config = config_cache[conf]
   if not config then
-    config = {}
-    config.type = (conf.blacklist or EMPTY)[1] and BLACK or WHITE
-    config.groups = config.type == BLACK and conf.blacklist or conf.whitelist
-    config.cache = setmetatable({}, mt_cache)
+    local config_type = (conf.blacklist or EMPTY)[1] and BLACK or WHITE
+
+    config = {
+      hide_groups_header = conf.hide_groups_header,
+      type = config_type,
+      groups = config_type == BLACK and conf.blacklist or conf.whitelist,
+      cache = setmetatable({}, mt_cache),
+    }
+
     config_cache[conf] = config
   end
+
+  local to_be_blocked
 
   -- get the consumer/credentials
   local consumer_id = groups.get_current_consumer_id()
   if not consumer_id then
-    kong.log.err("Cannot identify the consumer, add an authentication ",
-                 "plugin to use the ACL plugin")
-    return kong.response.exit(403, { message = "You cannot consume this service" })
-  end
+    local authenticated_groups = groups.get_authenticated_groups()
+    if not authenticated_groups then
+      kong.log.err("Cannot identify the consumer, add an authentication ",
+                   "plugin to use the ACL plugin")
 
-  -- get the consumer groups, since we need those as cache-keys to make sure
-  -- we invalidate properly if they change
-  local consumer_groups, err = groups.get_consumer_groups(consumer_id)
-  if not consumer_groups then
-    kong.log.err(err)
-    return kong.response.exit(500, { message = "An unexpected error occurred" })
-  end
+      return kong.response.exit(403, {
+        message = "You cannot consume this service"
+      })
+    end
 
-  -- 'to_be_blocked' is either 'true' if it's to be blocked, or the header
-  -- value if it is to be passed
-  local to_be_blocked = config.cache[consumer_groups]
-  if to_be_blocked == nil then
-    local in_group = groups.consumer_in_groups(config.groups, consumer_groups)
+    local in_group = groups.group_in_groups(config.groups, authenticated_groups)
+    to_be_blocked = get_to_be_blocked(config, authenticated_groups, in_group)
 
-    if config.type == BLACK then
-      to_be_blocked = in_group
+  else
+    local authenticated_groups
+    if not kong.client.get_credential() then
+      -- authenticated groups overrides anonymous groups
+      authenticated_groups = groups.get_authenticated_groups()
+    end
+
+    if authenticated_groups then
+      consumer_id = nil
+
+      local in_group = groups.group_in_groups(config.groups, authenticated_groups)
+      to_be_blocked = get_to_be_blocked(config, authenticated_groups, in_group)
+
     else
-      to_be_blocked = not in_group
-    end
+      -- get the consumer groups, since we need those as cache-keys to make sure
+      -- we invalidate properly if they change
+      local consumer_groups, err = groups.get_consumer_groups(consumer_id)
+      if not consumer_groups then
+        kong.log.err(err)
+        return kong.response.exit(500, {
+          message = "An unexpected error occurred"
+        })
+      end
 
-    if to_be_blocked == false then
-      -- we're allowed, convert 'false' to the header value, if needed
-      -- if not needed, set dummy value to save mem for potential long strings
-      to_be_blocked = conf.hide_groups_header and ""
-                      or concat(consumer_groups, ", ")
-    end
+      -- 'to_be_blocked' is either 'true' if it's to be blocked, or the header
+      -- value if it is to be passed
+      to_be_blocked = config.cache[consumer_groups]
+      if to_be_blocked == nil then
+        local in_group = groups.consumer_in_groups(config.groups, consumer_groups)
+        to_be_blocked = get_to_be_blocked(config, consumer_groups, in_group)
 
-    -- update cache
-    config.cache[consumer_groups] = to_be_blocked
+        -- update cache
+        config.cache[consumer_groups] = to_be_blocked
+      end
+    end
   end
 
   if to_be_blocked == true then -- NOTE: we only catch the boolean here!
-    return kong.response.exit(403, { message = "You cannot consume this service" })
+    return kong.response.exit(403, {
+      message = "You cannot consume this service"
+    })
   end
 
   if not conf.hide_groups_header and to_be_blocked then
-    kong.service.request.set_header(constants.HEADERS.CONSUMER_GROUPS,
+    kong.service.request.set_header(consumer_id and
+                                    constants.HEADERS.CONSUMER_GROUPS or
+                                    constants.HEADERS.AUTHENTICATED_GROUPS,
                                     to_be_blocked)
   end
 end

--- a/spec/03-plugins/18-acl/01-api_spec.lua
+++ b/spec/03-plugins/18-acl/01-api_spec.lua
@@ -46,16 +46,14 @@ for _, strategy in helpers.each_strategy() do
 
       describe("POST", function()
         it("creates an ACL association", function()
-          local res = assert(admin_client:send {
-            method  = "POST",
-            path    = "/consumers/bob/acls",
+          local res = assert(admin_client:post("/consumers/bob/acls", {
             body    = {
               group = "admin"
             },
             headers = {
               ["Content-Type"] = "application/json"
             }
-          })
+          }))
           local body = assert.res_status(201, res)
           local json = cjson.decode(body)
           assert.equal(consumer.id, json.consumer.id)
@@ -63,14 +61,12 @@ for _, strategy in helpers.each_strategy() do
         end)
         describe("errors", function()
           it("returns bad request", function()
-            local res = assert(admin_client:send {
-              method  = "POST",
-              path    = "/consumers/bob/acls",
+            local res = assert(admin_client:post("/consumers/bob/acls", {
               body    = {},
               headers = {
                 ["Content-Type"] = "application/json"
               }
-            })
+            }))
             local body = assert.res_status(400, res)
             local json = cjson.decode(body)
             assert.same({ group = "required field missing" }, json.fields)
@@ -85,10 +81,7 @@ for _, strategy in helpers.each_strategy() do
         it("retrieves the first page", function()
           bp.acls:insert_n(3, { consumer = { id = consumer.id } })
 
-          local res = assert(admin_client:send {
-            method  = "GET",
-            path    = "/consumers/bob/acls"
-          })
+          local res = assert(admin_client:get("/consumers/bob/acls"))
           local body = assert.res_status(200, res)
           local json = cjson.decode(body)
           assert.is_table(json.data)
@@ -112,19 +105,13 @@ for _, strategy in helpers.each_strategy() do
       end)
       describe("GET", function()
         it("retrieves by id", function()
-          local res = assert(admin_client:send {
-            method  = "GET",
-            path    = "/consumers/bob/acls/" .. acl.id
-          })
+          local res = assert(admin_client:get("/consumers/bob/acls/" .. acl.id))
           local body = assert.res_status(200, res)
           local json = cjson.decode(body)
           assert.equal(acl.id, json.id)
         end)
         it("retrieves by group", function()
-          local res = assert(admin_client:send {
-            method  = "GET",
-            path    = "/consumers/bob/acls/" .. acl.group
-          })
+          local res = assert(admin_client:get("/consumers/bob/acls/" .. acl.group))
           local body = assert.res_status(200, res)
           local json = cjson.decode(body)
           assert.equal(acl.id, json.id)
@@ -134,43 +121,29 @@ for _, strategy in helpers.each_strategy() do
             username = "alice"
           }
 
-          local res = assert(admin_client:send {
-            method  = "GET",
-            path    = "/consumers/bob/acls/" .. acl.id
-          })
+          local res = assert(admin_client:get("/consumers/bob/acls/" .. acl.id))
           assert.res_status(200, res)
 
-          res = assert(admin_client:send {
-            method = "GET",
-            path   = "/consumers/alice/acls/" .. acl.id
-          })
+          res = assert(admin_client:get("/consumers/alice/acls/" .. acl.id))
           assert.res_status(404, res)
         end)
         it("retrieves ACL by group only if the ACL belongs to the specified consumer", function()
-          local res = assert(admin_client:send {
-            method  = "GET",
-            path    = "/consumers/bob/acls/" .. acl.group
-          })
+          local res = assert(admin_client:get("/consumers/bob/acls/" .. acl.group))
           assert.res_status(200, res)
 
-          res = assert(admin_client:send {
-            method = "GET",
-            path   = "/consumers/alice/acls/" .. acl.group
-          })
+          res = assert(admin_client:get("/consumers/alice/acls/" .. acl.group))
           assert.res_status(404, res)
         end)
       end)
 
       describe("PUT", function()
         it("updates an ACL's groupname", function()
-          local res = assert(admin_client:send {
-            method = "PUT",
-            path = "/consumers/bob/acls/pro",
+          local res = assert(admin_client:put("/consumers/bob/acls/pro", {
             body = {},
             headers = {
               ["Content-Type"] = "application/json"
             }
-          })
+          }))
           local body = assert.res_status(200, res)
           local json = cjson.decode(body)
           assert.equal(consumer.id, json.consumer.id)
@@ -178,16 +151,14 @@ for _, strategy in helpers.each_strategy() do
         end)
         describe("errors", function()
           it("returns bad request", function()
-            local res = assert(admin_client:send {
-              method  = "PUT",
-              path    = "/consumers/bob/acls/f7852533-9160-4f5a-ae12-1ab99219ea95",
+            local res = assert(admin_client:put("/consumers/bob/acls/f7852533-9160-4f5a-ae12-1ab99219ea95", {
               body    = {
                 group = 123,
               },
               headers = {
                 ["Content-Type"] = "application/json"
               }
-            })
+            }))
             local body = assert.res_status(400, res)
             local json = cjson.decode(body)
             assert.same({ group = "expected a string" }, json.fields)
@@ -199,16 +170,14 @@ for _, strategy in helpers.each_strategy() do
         it("updates an ACL group by id", function()
           local previous_group = acl.group
 
-          local res = assert(admin_client:send {
-            method  = "PATCH",
-            path    = "/consumers/bob/acls/" .. acl.id,
+          local res = assert(admin_client:patch("/consumers/bob/acls/" .. acl.id, {
             body    = {
               group            = "updatedGroup"
             },
             headers = {
               ["Content-Type"] = "application/json"
             }
-          })
+          }))
           local body = assert.res_status(200, res)
           local json = cjson.decode(body)
           assert.not_equal(previous_group, json.group)
@@ -216,32 +185,28 @@ for _, strategy in helpers.each_strategy() do
         it("updates an ACL group by group", function()
           local previous_group = acl.group
 
-          local res = assert(admin_client:send {
-            method  = "PATCH",
-            path    = "/consumers/bob/acls/" .. acl.group,
+          local res = assert(admin_client:patch("/consumers/bob/acls/" .. acl.group, {
             body    = {
               group            = "updatedGroup2"
             },
             headers = {
               ["Content-Type"] = "application/json"
             }
-          })
+          }))
           local body = assert.res_status(200, res)
           local json = cjson.decode(body)
           assert.not_equal(previous_group, json.group)
         end)
         describe("errors", function()
           it("handles invalid input", function()
-            local res = assert(admin_client:send {
-              method  = "PATCH",
-              path    = "/consumers/bob/acls/" .. acl.id,
+            local res = assert(admin_client:patch("/consumers/bob/acls/" .. acl.id, {
               body    = {
                 group            = 123,
               },
               headers = {
                 ["Content-Type"] = "application/json"
               }
-            })
+            }))
             local body = assert.res_status(400, res)
             local json = cjson.decode(body)
             assert.same({ group = "expected a string" }, json.fields)
@@ -251,32 +216,20 @@ for _, strategy in helpers.each_strategy() do
 
       describe("DELETE", function()
         it("deletes an ACL group by id", function()
-          local res = assert(admin_client:send {
-            method  = "DELETE",
-            path    = "/consumers/bob/acls/" .. acl.id,
-          })
+          local res = assert(admin_client:delete("/consumers/bob/acls/" .. acl.id))
           assert.res_status(204, res)
         end)
         it("deletes an ACL group by group", function()
-          local res = assert(admin_client:send {
-            method  = "DELETE",
-            path    = "/consumers/bob/acls/" .. acl2.group,
-          })
+          local res = assert(admin_client:delete("/consumers/bob/acls/" .. acl2.group))
           assert.res_status(204, res)
         end)
         describe("errors", function()
           it("returns 404 on missing group", function()
-            local res = assert(admin_client:send {
-              method  = "DELETE",
-              path    = "/consumers/bob/acls/blah"
-            })
+            local res = assert(admin_client:delete("/consumers/bob/acls/blah"))
             assert.res_status(404, res)
           end)
           it("returns 404 if not found", function()
-            local res = assert(admin_client:send {
-              method  = "DELETE",
-              path    = "/consumers/bob/acls/00000000-0000-0000-0000-000000000000"
-            })
+            local res = assert(admin_client:delete("/consumers/bob/acls/00000000-0000-0000-0000-000000000000"))
             assert.res_status(404, res)
           end)
         end)
@@ -310,43 +263,32 @@ for _, strategy in helpers.each_strategy() do
         end)
 
         it("retrieves all the acls with trailing slash", function()
-          local res = assert(admin_client:send {
-            method = "GET",
-            path = "/acls/",
-          })
+          local res = assert(admin_client:get("/acls/"))
           local body = assert.res_status(200, res)
           local json = cjson.decode(body)
           assert.is_table(json.data)
           assert.equal(6, #json.data)
         end)
         it("retrieves all the acls without trailing slash", function()
-          local res = assert(admin_client:send {
-            method = "GET",
-            path = "/acls",
-          })
+          local res = assert(admin_client:get("/acls"))
           local body = assert.res_status(200, res)
           local json = cjson.decode(body)
           assert.is_table(json.data)
           assert.equal(6, #json.data)
         end)
         it("paginates through the acls", function()
-          local res = assert(admin_client:send {
-            method = "GET",
-            path = "/acls?size=3",
-          })
+          local res = assert(admin_client:get("/acls?size=3"))
           local body = assert.res_status(200, res)
           local json_1 = cjson.decode(body)
           assert.is_table(json_1.data)
           assert.equal(3, #json_1.data)
 
-          res = assert(admin_client:send {
-            method = "GET",
-            path = "/acls",
+          res = assert(admin_client:get("/acls", {
             query = {
               size = 3,
               offset = json_1.offset,
             }
-          })
+          }))
           body = assert.res_status(200, res)
           local json_2 = cjson.decode(body)
           assert.is_table(json_2.data)
@@ -373,10 +315,7 @@ for _, strategy in helpers.each_strategy() do
           }
         end)
         it("retrieves a Consumer from an acl's id", function()
-          local res = assert(admin_client:send {
-            method = "GET",
-            path = "/acls/" .. credential.id .. "/consumer",
-          })
+          local res = assert(admin_client:get("/acls/" .. credential.id .. "/consumer"))
           local body = assert.res_status(200, res)
           local json = cjson.decode(body)
           assert.same(consumer, json)

--- a/spec/03-plugins/18-acl/02-access_spec.lua
+++ b/spec/03-plugins/18-acl/02-access_spec.lua
@@ -17,7 +17,7 @@ for _, strategy in helpers.each_strategy() do
         "consumers",
         "acls",
         "keyauth_credentials",
-      })
+      }, { "ctx-checker" })
 
       local consumer1 = bp.consumers:insert {
         username = "consumer1"
@@ -94,9 +94,9 @@ for _, strategy in helpers.each_strategy() do
       }
 
       bp.plugins:insert {
-        name     = "acl",
+        name = "acl",
         route = { id = route1.id },
-        config   = {
+        config = {
           whitelist = { "admin" },
         }
       }
@@ -106,17 +106,61 @@ for _, strategy in helpers.each_strategy() do
       }
 
       bp.plugins:insert {
-        name     = "acl",
+        name = "acl",
         route = { id = route2.id },
-        config   = {
+        config = {
           whitelist = { "admin" },
         }
       }
 
       bp.plugins:insert {
-        name     = "key-auth",
+        name = "key-auth",
         route = { id = route2.id },
-        config   = {}
+        config = {}
+      }
+
+      local route2b = bp.routes:insert {
+        hosts = { "acl2b.com" },
+      }
+
+      bp.plugins:insert {
+        name = "acl",
+        route = { id = route2b.id },
+        config = {
+          whitelist = { "admin" },
+        }
+      }
+
+      bp.plugins:insert {
+        name = "ctx-checker",
+        route = { id = route2b.id },
+        config = {
+          ctx_kind      = "kong.ctx.shared",
+          ctx_set_field = "authenticated_groups",
+          ctx_set_array = { "admin" },
+        }
+      }
+
+      local route2c = bp.routes:insert {
+        hosts = { "acl2c.com" },
+      }
+
+      bp.plugins:insert {
+        name = "acl",
+        route = { id = route2c.id },
+        config = {
+          whitelist = { "admin" },
+        }
+      }
+
+      bp.plugins:insert {
+        name = "ctx-checker",
+        route = { id = route2c.id },
+        config = {
+          ctx_kind      = "kong.ctx.shared",
+          ctx_set_field = "authenticated_groups",
+          ctx_set_array = { },
+        }
       }
 
       local route3 = bp.routes:insert {
@@ -124,17 +168,61 @@ for _, strategy in helpers.each_strategy() do
       }
 
       bp.plugins:insert {
-        name     = "acl",
+        name = "acl",
         route = { id = route3.id },
-        config   = {
-          blacklist = {"admin"}
+        config = {
+          blacklist = { "admin" }
         }
       }
 
       bp.plugins:insert {
-        name     = "key-auth",
+        name = "key-auth",
         route = { id = route3.id },
-        config   = {}
+        config = {}
+      }
+
+      local route3b = bp.routes:insert {
+        hosts = { "acl3b.com" },
+      }
+
+      bp.plugins:insert {
+        name = "acl",
+        route = { id = route3b.id },
+        config = {
+          blacklist = { "admin" }
+        }
+      }
+
+      bp.plugins:insert {
+        name = "ctx-checker",
+        route = { id = route3b.id },
+        config = {
+          ctx_kind      = "kong.ctx.shared",
+          ctx_set_field = "authenticated_groups",
+          ctx_set_array = { },
+        }
+      }
+
+      local route3c = bp.routes:insert {
+        hosts = { "acl3c.com" },
+      }
+
+      bp.plugins:insert {
+        name = "acl",
+        route = { id = route3c.id },
+        config = {
+          blacklist = { "admin" }
+        }
+      }
+
+      bp.plugins:insert {
+        name = "ctx-checker",
+        route = { id = route3c.id },
+        config = {
+          ctx_kind      = "kong.ctx.shared",
+          ctx_set_field = "authenticated_groups",
+          ctx_set_array = { "admin" },
+        }
       }
 
       local route4 = bp.routes:insert {
@@ -142,17 +230,61 @@ for _, strategy in helpers.each_strategy() do
       }
 
       bp.plugins:insert {
-        name     = "acl",
+        name = "acl",
         route = { id = route4.id },
-        config   = {
-          whitelist = {"admin", "pro"}
+        config = {
+          whitelist = { "admin", "pro" }
         }
       }
 
       bp.plugins:insert {
-        name     = "key-auth",
+        name = "key-auth",
         route = { id = route4.id },
-        config   = {}
+        config = {}
+      }
+
+      local route4b = bp.routes:insert {
+        hosts = { "acl4b.com" },
+      }
+
+      bp.plugins:insert {
+        name = "acl",
+        route = { id = route4b.id },
+        config = {
+          whitelist = { "admin", "pro" }
+        }
+      }
+
+      bp.plugins:insert {
+        name = "ctx-checker",
+        route = { id = route4b.id },
+        config = {
+          ctx_kind      = "kong.ctx.shared",
+          ctx_set_field = "authenticated_groups",
+          ctx_set_array = { "pro", "hello" },
+        }
+      }
+
+      local route4c = bp.routes:insert {
+        hosts = { "acl4c.com" },
+      }
+
+      bp.plugins:insert {
+        name = "acl",
+        route = { id = route4c.id },
+        config = {
+          whitelist = { "admin", "pro" }
+        }
+      }
+
+      bp.plugins:insert {
+        name = "ctx-checker",
+        route = { id = route4c.id },
+        config = {
+          ctx_kind      = "kong.ctx.shared",
+          ctx_set_field = "authenticated_groups",
+          ctx_set_array = { "free", "hello" },
+        }
       }
 
       local route5 = bp.routes:insert {
@@ -160,17 +292,61 @@ for _, strategy in helpers.each_strategy() do
       }
 
       bp.plugins:insert {
-        name     = "acl",
+        name = "acl",
         route = { id = route5.id },
-        config   = {
-          blacklist = {"admin", "pro"}
+        config = {
+          blacklist = { "admin", "pro" }
         }
       }
 
       bp.plugins:insert {
-        name     = "key-auth",
+        name = "key-auth",
         route = { id = route5.id },
-        config   = {}
+        config = {}
+      }
+
+      local route5b = bp.routes:insert {
+        hosts = { "acl5b.com" },
+      }
+
+      bp.plugins:insert {
+        name = "acl",
+        route = { id = route5b.id },
+        config = {
+          blacklist = { "admin", "pro" }
+        }
+      }
+
+      bp.plugins:insert {
+        name = "ctx-checker",
+        route = { id = route5b.id },
+        config = {
+          ctx_kind      = "kong.ctx.shared",
+          ctx_set_field = "authenticated_groups",
+          ctx_set_array = { "pro", "hello" },
+        }
+      }
+
+      local route5c = bp.routes:insert {
+        hosts = { "acl5c.com" },
+      }
+
+      bp.plugins:insert {
+        name = "acl",
+        route = { id = route5c.id },
+        config = {
+          blacklist = { "admin", "pro" }
+        }
+      }
+
+      bp.plugins:insert {
+        name = "ctx-checker",
+        route = { id = route5c.id },
+        config = {
+          ctx_kind      = "kong.ctx.shared",
+          ctx_set_field = "authenticated_groups",
+          ctx_set_array = { "free", "hello" },
+        }
       }
 
       local route6 = bp.routes:insert {
@@ -178,17 +354,61 @@ for _, strategy in helpers.each_strategy() do
       }
 
       bp.plugins:insert {
-        name     = "acl",
+        name = "acl",
         route = { id = route6.id },
-        config   = {
-          blacklist = {"admin", "pro", "hello"}
+        config = {
+          blacklist = { "admin", "pro", "hello" }
         }
       }
 
       bp.plugins:insert {
-        name     = "key-auth",
+        name = "key-auth",
         route = { id = route6.id },
-        config   = {}
+        config = {}
+      }
+
+      local route6b = bp.routes:insert {
+        hosts = { "acl6b.com" },
+      }
+
+      bp.plugins:insert {
+        name = "acl",
+        route = { id = route6b.id },
+        config = {
+          blacklist = { "admin", "pro", "hello" }
+        }
+      }
+
+      bp.plugins:insert {
+        name = "ctx-checker",
+        route = { id = route6b.id },
+        config = {
+          ctx_kind      = "kong.ctx.shared",
+          ctx_set_field = "authenticated_groups",
+          ctx_set_array = { "free", "hello" },
+        }
+      }
+
+      local route6c = bp.routes:insert {
+        hosts = { "acl6c.com" },
+      }
+
+      bp.plugins:insert {
+        name = "acl",
+        route = { id = route6c.id },
+        config = {
+          blacklist = { "admin", "pro", "hello" }
+        }
+      }
+
+      bp.plugins:insert {
+        name = "ctx-checker",
+        route = { id = route6c.id },
+        config = {
+          ctx_kind      = "kong.ctx.shared",
+          ctx_set_field = "authenticated_groups",
+          ctx_set_array = { "pro", "hello" },
+        }
       }
 
       local route7 = bp.routes:insert {
@@ -196,16 +416,39 @@ for _, strategy in helpers.each_strategy() do
       }
 
       bp.plugins:insert {
-        name     = "acl",
+        name = "acl",
         route = { id = route7.id },
-        config   = {
-          whitelist = {"admin", "pro", "hello"}
+        config = {
+          whitelist = { "admin", "pro", "hello" }
         }
       }
+
       bp.plugins:insert {
-        name     = "key-auth",
+        name = "key-auth",
         route = { id = route7.id },
-        config   = {}
+        config = {}
+      }
+
+      local route7b = bp.routes:insert {
+        hosts = { "acl7b.com" },
+      }
+
+      bp.plugins:insert {
+        name = "acl",
+        route = { id = route7b.id },
+        config = {
+          whitelist = { "admin", "pro", "hello" }
+        }
+      }
+
+      bp.plugins:insert {
+        name = "ctx-checker",
+        route = { id = route7b.id },
+        config = {
+          ctx_kind      = "kong.ctx.shared",
+          ctx_set_field = "authenticated_groups",
+          ctx_set_array = { "free", "hello" },
+        }
       }
 
       local route8 = bp.routes:insert {
@@ -213,18 +456,48 @@ for _, strategy in helpers.each_strategy() do
       }
 
       bp.plugins:insert {
-        name     = "acl",
+        name = "acl",
         route = { id = route8.id },
-        config   = {
-          whitelist = {"anonymous"}
+        config = {
+          whitelist = { "anonymous" }
         }
       }
 
       bp.plugins:insert {
-        name     = "key-auth",
+        name = "key-auth",
         route = { id = route8.id },
-        config   = {
+        config = {
           anonymous = anonymous.id,
+        }
+      }
+
+      local route8b = bp.routes:insert {
+        hosts = { "acl8b.com" },
+      }
+
+      bp.plugins:insert {
+        name = "acl",
+        route = { id = route8b.id },
+        config = {
+          whitelist = { "anonymous" }
+        }
+      }
+
+      bp.plugins:insert {
+        name = "key-auth",
+        route = { id = route8b.id },
+        config = {
+          anonymous = anonymous.id,
+        }
+      }
+
+      bp.plugins:insert {
+        name = "ctx-checker",
+        route = { id = route8b.id },
+        config = {
+          ctx_kind      = "kong.ctx.shared",
+          ctx_set_field = "authenticated_groups",
+          ctx_set_array = { "anonymous" },
         }
       }
 
@@ -247,6 +520,29 @@ for _, strategy in helpers.each_strategy() do
         config = {}
       }
 
+      local route9b = bp.routes:insert {
+        hosts = { "acl9b.com" },
+      }
+
+      bp.plugins:insert {
+        name = "acl",
+        route = { id = route9b.id },
+        config = {
+          whitelist = { "admin" },
+          hide_groups_header = true
+        }
+      }
+
+      bp.plugins:insert {
+        name = "ctx-checker",
+        route = { id = route9b.id },
+        config = {
+          ctx_kind      = "kong.ctx.shared",
+          ctx_set_field = "authenticated_groups",
+          ctx_set_array = { "admin" },
+        }
+      }
+
       local route10 = bp.routes:insert {
         hosts = { "acl10.com" },
       }
@@ -266,7 +562,124 @@ for _, strategy in helpers.each_strategy() do
         config = {}
       }
 
+      local route10b = bp.routes:insert {
+        hosts = { "acl10b.com" },
+      }
+
+      bp.plugins:insert {
+        name = "acl",
+        route = { id = route10b.id },
+        config = {
+          whitelist = { "admin" },
+          hide_groups_header = false
+        }
+      }
+
+      bp.plugins:insert {
+        name = "ctx-checker",
+        route = { id = route10b.id },
+        config = {
+          ctx_kind      = "kong.ctx.shared",
+          ctx_set_field = "authenticated_groups",
+          ctx_set_array = { "admin" },
+        }
+      }
+
+      local route11 = bp.routes:insert {
+        hosts = { "acl11.com" },
+      }
+
+      bp.plugins:insert {
+        name = "acl",
+        route = { id = route11.id },
+        config = {
+          whitelist = { "admin", "anonymous" },
+          hide_groups_header = false
+        }
+      }
+
+      bp.plugins:insert {
+        name = "key-auth",
+        route = { id = route11.id },
+        config = {
+          anonymous = anonymous.id,
+        }
+      }
+
+      bp.plugins:insert {
+        name = "ctx-checker",
+        route = { id = route11.id },
+        config = {
+          ctx_kind      = "kong.ctx.shared",
+          ctx_set_field = "authenticated_groups",
+          ctx_set_array = { "admin" },
+        }
+      }
+
+      local route12 = bp.routes:insert {
+        hosts = { "acl12.com" },
+      }
+
+      bp.plugins:insert {
+        name = "acl",
+        route = { id = route12.id },
+        config = {
+          whitelist = { "anonymous" },
+          hide_groups_header = false
+        }
+      }
+
+      bp.plugins:insert {
+        name = "key-auth",
+        route = { id = route12.id },
+        config = {
+          anonymous = anonymous.id,
+        }
+      }
+
+      bp.plugins:insert {
+        name = "ctx-checker",
+        route = { id = route12.id },
+        config = {
+          ctx_kind      = "kong.ctx.shared",
+          ctx_set_field = "authenticated_groups",
+          ctx_set_array = { "anonymous" },
+        }
+      }
+
+      local route13 = bp.routes:insert {
+        hosts = { "acl13.com" },
+      }
+
+      bp.plugins:insert {
+        name = "acl",
+        route = { id = route13.id },
+        config = {
+          whitelist = { "anonymous" },
+          hide_groups_header = false
+        }
+      }
+
+      bp.plugins:insert {
+        name = "key-auth",
+        route = { id = route13.id },
+        config = {
+          anonymous = anonymous.id,
+        }
+      }
+
+      bp.plugins:insert {
+        name = "ctx-checker",
+        route = { id = route13.id },
+        config = {
+          ctx_kind      = "kong.ctx.shared",
+          ctx_set_field = "authenticated_groups",
+          ctx_set_array = { "admin" },
+        }
+      }
+
       assert(helpers.start_kong({
+        plugins    = "bundled, ctx-checker",
         database   = strategy,
         nginx_conf = "spec/fixtures/custom_nginx.template",
       }))
@@ -287,116 +700,192 @@ for _, strategy in helpers.each_strategy() do
     end)
 
 
-    describe("Mapping to Consumer", function()
+    describe("Mapping to Consumer or Authenticated Groups", function()
       it("should work with consumer with credentials", function()
-        local res = assert(proxy_client:send {
-          method  = "GET",
-          path    = "/request?apikey=apikey124",
+        local res = assert(proxy_client:get("/request?apikey=apikey124", {
           headers = {
             ["Host"] = "acl2.com"
           }
-        })
+        }))
 
         local body = cjson.decode(assert.res_status(200, res))
         assert.equal("admin", body.headers["x-consumer-groups"])
+        assert.equal(nil, body.headers["x-authenticated-groups"])
+      end)
+
+      it("should work with authenticated groups", function()
+        local res = assert(proxy_client:get("/request", {
+          headers = {
+            ["Host"] = "acl2b.com"
+          }
+        }))
+
+        local body = cjson.decode(assert.res_status(200, res))
+        assert.equal("admin", body.headers["x-authenticated-groups"])
+        assert.equal(nil, body.headers["x-consumer-groups"])
       end)
 
       it("should work with consumer without credentials", function()
-        local res = assert(proxy_client:send {
-          method  = "GET",
-          path    = "/request",
+        local res = assert(proxy_client:get("/request", {
           headers = {
             ["Host"] = "acl8.com"
           }
-        })
+        }))
 
         local body = cjson.decode(assert.res_status(200, res))
         assert.equal("anonymous", body.headers["x-consumer-groups"])
+        assert.equal(nil, body.headers["x-authenticated-groups"])
       end)
+
+      it("should work with authenticated groups without credentials", function()
+        local res = assert(proxy_client:get("/request", {
+          headers = {
+            ["Host"] = "acl8b.com"
+          }
+        }))
+
+        local body = cjson.decode(assert.res_status(200, res))
+        assert.equal("anonymous", body.headers["x-authenticated-groups"])
+        assert.equal(nil, body.headers["x-consumer-groups"])
+      end)
+
     end)
 
     describe("Simple lists", function()
       it("should fail when an authentication plugin is missing", function()
-        local res = assert(proxy_client:send {
-          method  = "GET",
-          path    = "/status/200",
+        local res = assert(proxy_client:get("/status/200", {
           headers = {
             ["Host"] = "acl1.com"
           }
-        })
+        }))
         local body = assert.res_status(403, res)
         local json = cjson.decode(body)
         assert.same({ message = "You cannot consume this service" }, json)
       end)
 
       it("should fail when not in whitelist", function()
-        local res = assert(proxy_client:send {
-          method  = "GET",
-          path    = "/status/200?apikey=apikey123",
+        local res = assert(proxy_client:get("/status/200?apikey=apikey123", {
           headers = {
             ["Host"] = "acl2.com"
           }
-        })
+        }))
+        local body = assert.res_status(403, res)
+        local json = cjson.decode(body)
+        assert.same({ message = "You cannot consume this service" }, json)
+      end)
+
+      it("should fail when not in whitelist with authenticated groups", function()
+        local res = assert(proxy_client:get("/status/200", {
+          headers = {
+            ["Host"] = "acl2c.com"
+          }
+        }))
         local body = assert.res_status(403, res)
         local json = cjson.decode(body)
         assert.same({ message = "You cannot consume this service" }, json)
       end)
 
       it("should work when in whitelist", function()
-        local res = assert(proxy_client:send {
-          method  = "GET",
-          path    = "/request?apikey=apikey124",
+        local res = assert(proxy_client:get("/request?apikey=apikey124", {
           headers = {
             ["Host"] = "acl2.com"
           }
-        })
+        }))
         local body = cjson.decode(assert.res_status(200, res))
         assert.equal("admin", body.headers["x-consumer-groups"])
+        assert.equal(nil, body.headers["x-authenticated-groups"])
       end)
 
-      it("should not send x-consumer-groups header when hide_groups_header flag true", function()
-        local res = assert(proxy_client:send {
-          method  = "GET",
-          path    = "/request?apikey=apikey124",
+      it("should work when in whitelist with authenticated groups", function()
+        local res = assert(proxy_client:get("/request", {
           headers = {
-            ["Host"] = "acl9.com"
+            ["Host"] = "acl2b.com"
           }
-        })
+        }))
         local body = cjson.decode(assert.res_status(200, res))
+        assert.equal("admin", body.headers["x-authenticated-groups"])
         assert.equal(nil, body.headers["x-consumer-groups"])
       end)
 
+      it("should not send x-consumer-groups header when hide_groups_header flag true", function()
+        local res = assert(proxy_client:get("/request?apikey=apikey124", {
+          headers = {
+            ["Host"] = "acl9.com"
+          }
+        }))
+        local body = cjson.decode(assert.res_status(200, res))
+        assert.equal(nil, body.headers["x-consumer-groups"])
+        assert.equal(nil, body.headers["x-authenticated-groups"])
+      end)
+
+      it("should not send x-authenticated-groups header when hide_groups_header flag true", function()
+        local res = assert(proxy_client:get("/request", {
+          headers = {
+            ["Host"] = "acl9b.com"
+          }
+        }))
+        local body = cjson.decode(assert.res_status(200, res))
+        assert.equal(nil, body.headers["x-consumer-groups"])
+        assert.equal(nil, body.headers["x-authenticated-groups"])
+      end)
+
       it("should send x-consumer-groups header when hide_groups_header flag false", function()
-        local res = assert(proxy_client:send {
-          method  = "GET",
-          path    = "/request?apikey=apikey124",
+        local res = assert(proxy_client:get("/request?apikey=apikey124", {
           headers = {
             ["Host"] = "acl10.com"
           }
-        })
+        }))
         local body = cjson.decode(assert.res_status(200, res))
         assert.equal("admin", body.headers["x-consumer-groups"])
+        assert.equal(nil, body.headers["x-authenticated-groups"])
+      end)
+
+      it("should send x-authenticated-groups header when hide_groups_header flag false", function()
+        local res = assert(proxy_client:get("/request", {
+          headers = {
+            ["Host"] = "acl10b.com"
+          }
+        }))
+        local body = cjson.decode(assert.res_status(200, res))
+        assert.equal("admin", body.headers["x-authenticated-groups"])
+        assert.equal(nil, body.headers["x-consumer-groups"])
       end)
 
       it("should work when not in blacklist", function()
-        local res = assert(proxy_client:send {
-          method  = "GET",
-          path    = "/request?apikey=apikey123",
+        local res = assert(proxy_client:get("/request?apikey=apikey123", {
           headers = {
             ["Host"] = "acl3.com"
           }
-        })
+        }))
+        assert.res_status(200, res)
+      end)
+
+      it("should work when not in blacklist with authenticated groups", function()
+        local res = assert(proxy_client:get("/request", {
+          headers = {
+            ["Host"] = "acl3b.com"
+          }
+        }))
         assert.res_status(200, res)
       end)
 
       it("should fail when in blacklist", function()
-        local res = assert(proxy_client:send {
-          method  = "GET",
-          path    = "/request?apikey=apikey124",
+        local res = assert(proxy_client:get("/request?apikey=apikey124", {
           headers = {
             ["Host"] = "acl3.com"
           }
-        })
+        }))
+        local body = assert.res_status(403, res)
+        local json = cjson.decode(body)
+        assert.same({ message = "You cannot consume this service" }, json)
+      end)
+
+      it("should fail when in blacklist with authenticated groups", function()
+        local res = assert(proxy_client:get("/request", {
+          headers = {
+            ["Host"] = "acl3c.com"
+          }
+        }))
         local body = assert.res_status(403, res)
         local json = cjson.decode(body)
         assert.same({ message = "You cannot consume this service" }, json)
@@ -405,86 +894,147 @@ for _, strategy in helpers.each_strategy() do
 
     describe("Multi lists", function()
       it("should work when in whitelist", function()
-        local res = assert(proxy_client:send {
-          method  = "GET",
-          path    = "/request?apikey=apikey125",
+        local res = assert(proxy_client:get("/request?apikey=apikey125", {
           headers = {
             ["Host"] = "acl4.com"
           }
-        })
+        }))
         local body = cjson.decode(assert.res_status(200, res))
         assert.True(body.headers["x-consumer-groups"] == "pro, hello" or body.headers["x-consumer-groups"] == "hello, pro")
+        assert.equal(nil, body.headers["x-authenticated-groups"])
+      end)
+
+      it("should work when in whitelist with authenticated groups", function()
+        local res = assert(proxy_client:get("/request", {
+          headers = {
+            ["Host"] = "acl4b.com"
+          }
+        }))
+        local body = cjson.decode(assert.res_status(200, res))
+        assert.True(body.headers["x-authenticated-groups"] == "pro, hello" or body.headers["x-consumer-groups"] == "hello, pro")
+        assert.equal(nil, body.headers["x-consumer-groups"])
       end)
 
       it("should fail when not in whitelist", function()
-        local res = assert(proxy_client:send {
-          method  = "GET",
-          path    = "/request?apikey=apikey126",
+        local res = assert(proxy_client:get("/request?apikey=apikey126", {
           headers = {
             ["Host"] = "acl4.com"
           }
-        })
+        }))
+        local body = assert.res_status(403, res)
+        local json = cjson.decode(body)
+        assert.same({ message = "You cannot consume this service" }, json)
+      end)
+
+      it("should fail when not in whitelist with authenticated groups", function()
+        local res = assert(proxy_client:get("/request", {
+          headers = {
+            ["Host"] = "acl4c.com"
+          }
+        }))
         local body = assert.res_status(403, res)
         local json = cjson.decode(body)
         assert.same({ message = "You cannot consume this service" }, json)
       end)
 
       it("should fail when in blacklist", function()
-        local res = assert(proxy_client:send {
-          method  = "GET",
-          path    = "/request?apikey=apikey125",
+        local res = assert(proxy_client:get("/request?apikey=apikey125", {
           headers = {
             ["Host"] = "acl5.com"
           }
-        })
+        }))
         local body = assert.res_status(403, res)
         local json = cjson.decode(body)
         assert.same({ message = "You cannot consume this service" }, json)
       end)
 
+      it("should fail when in blacklist with authenticated groups", function()
+        local res = assert(proxy_client:get("/request", {
+          headers = {
+            ["Host"] = "acl5b.com"
+          }
+        }))
+        local body = assert.res_status(403, res)
+        local json = cjson.decode(body)
+        assert.same({ message = "You cannot consume this service" }, json)
+      end)
+
+
       it("should work when not in blacklist", function()
-        local res = assert(proxy_client:send {
-          method  = "GET",
-          path    = "/request?apikey=apikey126",
+        local res = assert(proxy_client:get("/request?apikey=apikey126", {
           headers = {
             ["Host"] = "acl5.com"
           }
-        })
+        }))
+        assert.res_status(200, res)
+      end)
+
+      it("should work when not in blacklist with authenticated groups", function()
+        local res = assert(proxy_client:get("/request", {
+          headers = {
+            ["Host"] = "acl5c.com"
+          }
+        }))
         assert.res_status(200, res)
       end)
 
       it("should not work when one of the ACLs in the blacklist", function()
-        local res = assert(proxy_client:send {
-          method  = "GET",
-          path    = "/request?apikey=apikey126",
+        local res = assert(proxy_client:get("/request?apikey=apikey126", {
           headers = {
             ["Host"] = "acl6.com"
           }
-        })
+        }))
+        local body = assert.res_status(403, res)
+        local json = cjson.decode(body)
+        assert.same({ message = "You cannot consume this service" }, json)
+      end)
+
+      it("should not work when one of the ACLs in the blacklist with authenticated groups", function()
+        local res = assert(proxy_client:get("/request", {
+          headers = {
+            ["Host"] = "acl6b.com"
+          }
+        }))
         local body = assert.res_status(403, res)
         local json = cjson.decode(body)
         assert.same({ message = "You cannot consume this service" }, json)
       end)
 
       it("should work when one of the ACLs in the whitelist", function()
-        local res = assert(proxy_client:send {
-          method  = "GET",
-          path    = "/request?apikey=apikey126",
+        local res = assert(proxy_client:get("/request?apikey=apikey126", {
           headers = {
             ["Host"] = "acl7.com"
           }
-        })
+        }))
+        assert.res_status(200, res)
+      end)
+
+      it("should work when one of the ACLs in the whitelist with authenticated groups", function()
+        local res = assert(proxy_client:get("/request", {
+          headers = {
+            ["Host"] = "acl7b.com"
+          }
+        }))
         assert.res_status(200, res)
       end)
 
       it("should not work when at least one of the ACLs in the blacklist", function()
-        local res = assert(proxy_client:send {
-          method  = "GET",
-          path    = "/request?apikey=apikey125",
+        local res = assert(proxy_client:get("/request?apikey=apikey125", {
           headers = {
             ["Host"] = "acl6.com"
           }
-        })
+        }))
+        local body = assert.res_status(403, res)
+        local json = cjson.decode(body)
+        assert.same({ message = "You cannot consume this service" }, json)
+      end)
+
+      it("should not work when at least one of the ACLs in the blacklist with authenticated groups", function()
+        local res = assert(proxy_client:get("/request", {
+          headers = {
+            ["Host"] = "acl6c.com"
+          }
+        }))
         local body = assert.res_status(403, res)
         local json = cjson.decode(body)
         assert.same({ message = "You cannot consume this service" }, json)
@@ -494,105 +1044,90 @@ for _, strategy in helpers.each_strategy() do
     describe("Real-world usage", function()
       it("should not fail when multiple rules are set fast", function()
         -- Create consumer
-        local res = assert(admin_client:send {
-          method  = "POST",
-          path    = "/consumers/",
+        local res = assert(admin_client:post("/consumers/", {
           headers = {
             ["Content-Type"] = "application/json"
           },
-          body    = {
+          body = {
             username = "acl_consumer"
           }
-        })
+        }))
         local body = cjson.decode(assert.res_status(201, res))
         local consumer = { id = body.id }
 
         -- Create key
-        local res = assert(admin_client:send {
-          method  = "POST",
-          path    = "/consumers/acl_consumer/key-auth/",
+        local res = assert(admin_client:post("/consumers/acl_consumer/key-auth", {
           headers = {
             ["Content-Type"] = "application/json"
           },
-          body    = {
-            key              = "secret123"
+          body = {
+            key = "secret123"
           }
-        })
+        }))
         assert.res_status(201, res)
 
         for i = 1, 3 do
           -- Create API
           local service = bp.services:insert()
 
-          local res = assert(admin_client:send {
-            method  = "POST",
-            path    = "/routes/",
+          local res = assert(admin_client:post("/routes", {
             headers = {
               ["Content-Type"] = "application/json"
             },
-            body    = {
-              hosts            = { "acl_test" .. i .. ".com" },
-              protocols        = { "http", "https" },
-              service          = {
+            body = {
+              hosts     = { "acl_test" .. i .. ".com" },
+              protocols = { "http", "https" },
+              service   = {
                 id = service.id
               },
             },
-          })
+          }))
 
           local body = assert.res_status(201, res)
           local json = cjson.decode(body)
 
           -- Add the ACL plugin to the new API with the new group
-          local res = assert(admin_client:send {
-            method  = "POST",
-            path    = "/plugins",
+          local res = assert(admin_client:post("/plugins", {
             headers = {
-              ["Content-Type"]     = "application/json"
+              ["Content-Type"] = "application/json"
             },
-            body    = {
-              name                 = "acl",
+            body = {
+              name   = "acl",
               config = { whitelist = { "admin" .. i } },
-              route = { id = json.id },
+              route  = { id = json.id },
             }
-          })
+          }))
 
           assert.res_status(201, res)
 
           -- Add key-authentication to API
-          local res = assert(admin_client:send {
-            method  = "POST",
-            path    = "/plugins",
+          local res = assert(admin_client:post("/plugins", {
             headers = {
               ["Content-Type"] = "application/json"
             },
-            body    = {
-              name     = "key-auth",
+            body = {
+              name  = "key-auth",
               route = { id = json.id },
             }
-          })
+          }))
           assert.res_status(201, res)
 
           -- Add a new group to the consumer
-          local res = assert(admin_client:send {
-            method  = "POST",
-            path    = "/consumers/acl_consumer/acls/",
+          local res = assert(admin_client:post("/consumers/acl_consumer/acls", {
             headers = {
               ["Content-Type"] = "application/json"
             },
-            body    = {
-              group            = "admin" .. i
+            body = {
+              group = "admin" .. i
             }
-          })
+          }))
           assert.res_status(201, res)
 
           -- Wait for cache to be invalidated
           local cache_key = db.acls:cache_key(consumer)
 
           helpers.wait_until(function()
-            local res = assert(admin_client:send {
-              method  = "GET",
-              path    = "/cache/" .. cache_key
-            })
+            local res = assert(admin_client:get("/cache/" .. cache_key))
             res:read_body()
             return res.status == 404
           end, 5)
@@ -601,19 +1136,132 @@ for _, strategy in helpers.each_strategy() do
 
           local res
           helpers.wait_until(function()
-            res = assert(proxy_client:send {
-              method  = "GET",
-              path    = "/status/200?apikey=secret123",
+            res = assert(proxy_client:get("/status/200?apikey=secret123", {
               headers = {
                 ["Host"] = "acl_test" .. i .. ".com"
               }
-            })
+            }))
             res:read_body()
             return res.status ~= 404
           end, 5)
 
           assert.res_status(200, res)
         end
+      end)
+      it("should not fail when multiple rules are set fast with authenticated groups", function()
+        for i = 1, 3 do
+          -- Create API
+          local service = bp.services:insert()
+
+          local res = assert(admin_client:post("/routes/", {
+            headers = {
+              ["Content-Type"] = "application/json"
+            },
+            body = {
+              hosts     = { "acl_test" .. i .. "b.com" },
+              protocols = { "http", "https" },
+              service   = {
+                id = service.id
+              },
+            },
+          }))
+
+          local body = assert.res_status(201, res)
+          local json = cjson.decode(body)
+
+          -- Add the ACL plugin to the new API with the new group
+          local res = assert(admin_client:post("/plugins", {
+            headers = {
+              ["Content-Type"] = "application/json"
+            },
+            body = {
+              name   = "acl",
+              config = { whitelist = { "admin" .. i } },
+              route  = { id = json.id },
+            }
+          }))
+
+          assert.res_status(201, res)
+
+          -- Add key-authentication to API
+          local res = assert(admin_client:post("/plugins", {
+            headers = {
+              ["Content-Type"] = "application/json"
+            },
+            body = {
+              name  = "ctx-checker",
+              route = { id = json.id },
+              config = {
+                ctx_kind      = "kong.ctx.shared",
+                ctx_set_field = "authenticated_groups",
+                ctx_set_array = { "admin" .. i },
+              }
+            }
+          }))
+          assert.res_status(201, res)
+
+          -- Make the request, and it should work
+          local res
+          helpers.wait_until(function()
+            res = assert(proxy_client:get("/status/200", {
+              headers = {
+                ["Host"] = "acl_test" .. i .. "b.com"
+              }
+            }))
+            res:read_body()
+            return res.status ~= 404
+          end, 5)
+
+          assert.res_status(200, res)
+        end
+      end)
+    end)
+
+    describe("Permits with", function()
+      it("authenticated consumer even when authorized groups are present", function()
+        local res = assert(proxy_client:get("/request?apikey=apikey124", {
+          headers = {
+            ["Host"] = "acl11.com"
+          }
+        }))
+        local body = cjson.decode(assert.res_status(200, res))
+        assert.equal("admin", body.headers["x-consumer-groups"])
+        assert.equal(nil, body.headers["x-authenticated-groups"])
+      end)
+
+      it("authorized groups even when anonymous consumer is present", function()
+        local res = assert(proxy_client:get("/request", {
+          headers = {
+            ["Host"] = "acl11.com"
+          }
+        }))
+        local body = cjson.decode(assert.res_status(200, res))
+        assert.equal("admin", body.headers["x-authenticated-groups"])
+        assert.equal(nil, body.headers["x-consumer-groups"])
+      end)
+    end)
+
+    describe("Forbids with", function()
+      it("authenticated consumer even when authorized groups are present", function()
+        local res = assert(proxy_client:get("/request?apikey=apikey124", {
+          headers = {
+            ["Host"] = "acl12.com"
+          }
+        }))
+        local body = assert.res_status(403, res)
+        local json = cjson.decode(body)
+        assert.same({ message = "You cannot consume this service" }, json)
+      end)
+
+      it("authorized groups even when anonymous consumer is present", function()
+        local res = assert(proxy_client:get("/request", {
+          headers = {
+            ["Host"] = "acl13.com"
+          }
+        }))
+        local body = assert.res_status(403, res)
+        local json = cjson.decode(body)
+        assert.same({ message = "You cannot consume this service" }, json)
       end)
     end)
   end)

--- a/spec/03-plugins/18-acl/03-invalidations_spec.lua
+++ b/spec/03-plugins/18-acl/03-invalidations_spec.lua
@@ -107,126 +107,102 @@ for _, strategy in helpers.each_strategy() do
     describe("ACL entity invalidation", function()
       it("should invalidate when ACL entity is deleted", function()
         -- It should work
-        local res = assert(proxy_client:send {
-          method  = "GET",
-          path    = "/status/200?apikey=apikey123",
+        local res = assert(proxy_client:get("/status/200?apikey=apikey123", {
           headers = {
             ["Host"] = "acl1.com"
           }
-        })
+        }))
         assert.res_status(200, res)
 
         -- Check that the cache is populated
 
         local cache_key = db.acls:cache_key(consumer.id)
-        local res = assert(admin_client:send {
-          method  = "GET",
-          path    = "/cache/" .. cache_key,
+        local res = assert(admin_client:get("/cache/" .. cache_key, {
           headers = {}
-        })
+        }))
         assert.res_status(200, res)
 
         -- Delete ACL group (which triggers invalidation)
-        local res = assert(admin_client:send {
-          method  = "DELETE",
-          path    = "/consumers/consumer1/acls/" .. acl.id,
+        local res = assert(admin_client:delete("/consumers/consumer1/acls/" .. acl.id, {
           headers = {}
-        })
+        }))
         assert.res_status(204, res)
 
         -- Wait for cache to be invalidated
         helpers.wait_until(function()
-          local res = assert(admin_client:send {
-            method  = "GET",
-            path    = "/cache/" .. cache_key,
+          local res = assert(admin_client:get("/cache/" .. cache_key, {
             headers = {}
-          })
+          }))
           res:read_body()
           return res.status == 404
         end, 3)
 
         -- It should not work
-        local res = assert(proxy_client:send {
-          method  = "GET",
-          path    = "/status/200?apikey=apikey123",
+        local res = assert(proxy_client:get("/status/200?apikey=apikey123", {
           headers = {
             ["Host"] = "acl1.com"
           }
-        })
+        }))
         assert.res_status(403, res)
       end)
       it("should invalidate when ACL entity is updated", function()
         -- It should work
-        local res = assert(proxy_client:send {
-          method  = "GET",
-          path    = "/status/200?apikey=apikey123&prova=scemo",
+        local res = assert(proxy_client:get("/status/200?apikey=apikey123&prova=scemo", {
           headers = {
             ["Host"] = "acl1.com"
           }
-        })
+        }))
         assert.res_status(200, res)
 
         -- It should not work
-        local res = assert(proxy_client:send {
-          method  = "GET",
-          path    = "/status/200?apikey=apikey123",
+        local res = assert(proxy_client:get("/status/200?apikey=apikey123", {
           headers = {
             ["Host"] = "acl2.com"
           }
-        })
+        }))
         assert.res_status(403, res)
 
         -- Check that the cache is populated
         local cache_key = db.acls:cache_key(consumer.id)
-        local res = assert(admin_client:send {
-          method  = "GET",
-          path    = "/cache/" .. cache_key,
+        local res = assert(admin_client:get("/cache/" .. cache_key, {
           headers = {}
-        })
+        }))
         assert.res_status(200, res)
 
         -- Update ACL group (which triggers invalidation)
-        local res = assert(admin_client:send {
-          method  = "PATCH",
-          path    = "/consumers/consumer1/acls/" .. acl.id,
+        local res = assert(admin_client:patch("/consumers/consumer1/acls/" .. acl.id, {
           headers = {
             ["Content-Type"] = "application/json"
           },
           body = {
             group            = "ya"
           }
-        })
+        }))
         assert.res_status(200, res)
 
         -- Wait for cache to be invalidated
         helpers.wait_until(function()
-          local res = assert(admin_client:send {
-            method  = "GET",
-            path    = "/cache/" .. cache_key,
+          local res = assert(admin_client:get("/cache/" .. cache_key, {
             headers = {}
-          })
+          }))
           res:read_body()
           return res.status == 404
         end, 3)
 
         -- It should not work
-        local res = assert(proxy_client:send {
-          method  = "GET",
-          path    = "/status/200?apikey=apikey123",
+        local res = assert(proxy_client:get("/status/200?apikey=apikey123", {
           headers = {
             ["Host"] = "acl1.com"
           }
-        })
+        }))
         assert.res_status(403, res)
 
         -- It works now
-        local res = assert(proxy_client:send {
-          method  = "GET",
-          path    = "/status/200?apikey=apikey123",
+        local res = assert(proxy_client:get("/status/200?apikey=apikey123", {
           headers = {
             ["Host"] = "acl2.com"
           }
-        })
+        }))
         assert.res_status(200, res)
       end)
     end)
@@ -234,39 +210,31 @@ for _, strategy in helpers.each_strategy() do
     describe("Consumer entity invalidation", function()
       it("should invalidate when Consumer entity is deleted", function()
         -- It should work
-        local res = assert(proxy_client:send {
-          method  = "GET",
-          path    = "/status/200?apikey=apikey123",
+        local res = assert(proxy_client:get("/status/200?apikey=apikey123", {
           headers = {
             ["Host"] = "acl1.com"
           }
-        })
+        }))
         assert.res_status(200, res)
 
         -- Check that the cache is populated
         local cache_key = db.acls:cache_key(consumer.id)
-        local res = assert(admin_client:send {
-          method  = "GET",
-          path    = "/cache/" .. cache_key,
+        local res = assert(admin_client:get("/cache/" .. cache_key, {
           headers = {}
-        })
+        }))
         assert.res_status(200, res)
 
         -- Delete Consumer (which triggers invalidation)
-        local res = assert(admin_client:send {
-          method  = "DELETE",
-          path    = "/consumers/consumer1",
+        local res = assert(admin_client:delete("/consumers/consumer1", {
           headers = {}
-        })
+        }))
         assert.res_status(204, res)
 
         -- Wait for cache to be invalidated
         helpers.wait_until(function()
-          local res = assert(admin_client:send {
-            method  = "GET",
-            path    = "/cache/" .. cache_key,
+          local res = assert(admin_client:get("/cache/" .. cache_key, {
             headers = {}
-          })
+          }))
           res:read_body()
           return res.status == 404
         end, 3)
@@ -274,23 +242,19 @@ for _, strategy in helpers.each_strategy() do
         -- Wait for key to be invalidated
         local keyauth_cache_key = db.keyauth_credentials:cache_key("apikey123")
         helpers.wait_until(function()
-          local res = assert(admin_client:send {
-            method  = "GET",
-            path    = "/cache/" .. keyauth_cache_key,
+          local res = assert(admin_client:get("/cache/" .. keyauth_cache_key, {
             headers = {}
-          })
+          }))
           res:read_body()
           return res.status == 404
         end, 3)
 
         -- It should not work
-        local res = assert(proxy_client:send {
-          method  = "GET",
-          path    = "/status/200?apikey=apikey123",
+        local res = assert(proxy_client:get("/status/200?apikey=apikey123", {
           headers = {
             ["Host"] = "acl1.com"
           }
-        })
+        }))
         assert.res_status(403, res)
       end)
     end)

--- a/spec/fixtures/custom_plugins/kong/plugins/ctx-checker/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/ctx-checker/schema.lua
@@ -2,8 +2,10 @@ return {
   fields = {
     ctx_set_field   = { type = "string" },
     ctx_set_value   = { type = "string", default = "set_by_ctx_checker" },
+    ctx_set_array   = { type = "array"  },
     ctx_check_field = { type = "string" },
     ctx_check_value = { type = "string" },
+    ctx_check_array = { type = "array"  },
     ctx_kind        = { type = "string", default = "ngx.ctx" },
     ctx_throw_error = { type = "boolean", default = false },
   }


### PR DESCRIPTION
### Summary

This PR adds support for a new `context` value:
```lua
kong.ctx.shared.authenticated_groups
```

The value of this `context` parameter should be a Lua array, e.g.:
```lua
kong.ctx.shared.authenticated_groups = { "sales", "management" }
```

And updates `ACL` plugin to support the `context` value, in addition to the consumer acl groups that it supported before this patch.

Why?

Authentication plugins that use a 3rd party (other than Kong) to store credentials can benefit from using a central `ACL` plugin to do authorization for them. And this also allows users to do authorization with multiple plugins running in `OR` configuration on a same route or service (well perhaps even globally). Those 3rd party plugins include plugins from core, from community, and plugins in Kong Enterprise, to mention a few:

- `ldap`
- `ldap-advanced`
- `openid-connect`
- `oauth2-introspection`
- `jwt`
- `jwt-signer`

Of course the support to this needs to be implemented in the plugins as well, but this PR solves other side of the chicken-egg problem, and makes it at least possible.

Some use cases:
1. use ldap directory information e.g. user groups with acl plugin without need to create any Kong consumers
2. use arbitrary claim value from a JWT token as a group information and acl plugin to white- or blacklist the access based on that (again, without a need to use Kong consumers).