### PR TITLE
fix/cassandra-migration-drop-index:

### DIFF
--- a/kong/dao/migrations/cassandra.lua
+++ b/kong/dao/migrations/cassandra.lua
@@ -263,7 +263,7 @@ return {
       ALTER TABLE apis ADD http_if_terminated boolean;
     ]],
     down = [[
-      DROP INDEX ssl_servers_names_ssl_certificate_idx;
+      DROP INDEX ssl_servers_names_ssl_certificate_id_idx;
 
       DROP TABLE ssl_certificates;
       DROP TABLE ssl_servers_names;
@@ -742,7 +742,7 @@ return {
   },
   { name = "2018-03-27-002500_drop_old_ssl_tables",
     up = [[
-      DROP INDEX ssl_servers_names_ssl_certificate_id_idx;
+      DROP INDEX IF EXISTS ssl_servers_names_ssl_certificate_id_idx;
       DROP TABLE ssl_certificates;
       DROP TABLE ssl_servers_names;
     ]],


### PR DESCRIPTION
### Summary

This PR fixes migrations `03-27-002500_drop_old_ssl_tables` and `2016-12-14-172100_move_ssl_certs_to_core`, thus addressing issue https://github.com/Kong/kong/issues/3664.

### Full changelog

* `dao/migrations/cassandra.lua`: add a `IF EXISTS` on the `DROP INDEX` command of the `03-27-002500_drop_old_ssl_tables` migration.
* `dao/migrations/cassandra.lua`: correct the index name in the `down` step of the `2016-12-14-172100_move_ssl_certs_to_core` migration.

### Issues resolved

Fix https://github.com/Kong/kong/issues/3664
