### PR TITLE
tests(*) speed up test suite, reduce flakiness

### DIFF
--- a/spec-old-api/03-plugins/01-tcp-log/01-tcp-log_spec.lua
+++ b/spec-old-api/03-plugins/01-tcp-log/01-tcp-log_spec.lua
@@ -79,7 +79,7 @@ describe("Plugin: tcp-log (log)", function()
     -- Making the request
     local r = assert(client:send {
       method  = "GET",
-      path    = "/delay/2",
+      path    = "/delay/1",
       headers = {
         host  = "tcp_logging.com",
       },
@@ -95,7 +95,15 @@ describe("Plugin: tcp-log (log)", function()
     local log_message = cjson.decode(res)
 
     assert.True(log_message.latencies.proxy < 3000)
-    assert.True(log_message.latencies.request >= log_message.latencies.kong + log_message.latencies.proxy)
+
+    -- Sometimes there's a split milisecond that makes numbers not
+    -- add up by 1. Adding an artificial 1 to make the test
+    -- resilient to those.
+    local is_latencies_sum_adding_up =
+      1+log_message.latencies.request >= log_message.latencies.kong +
+      log_message.latencies.proxy
+
+    assert.True(is_latencies_sum_adding_up)
   end)
 
   it("performs a TLS handshake on the remote TCP server", function()

--- a/spec/02-integration/000-new-dao/03-db_cluster_mutex_spec.lua
+++ b/spec/02-integration/000-new-dao/03-db_cluster_mutex_spec.lua
@@ -8,7 +8,7 @@ for _, strategy in helpers.each_strategy() do
 
     lazy_setup(function()
       local _
-      _, db, _ = helpers.get_db_utils(strategy)
+      _, db, _ = helpers.get_db_utils(strategy, {})
 
       assert(db.connector:setup_locks(60))
     end)

--- a/spec/02-integration/000-new-dao/03-plugins_spec.lua
+++ b/spec/02-integration/000-new-dao/03-plugins_spec.lua
@@ -9,7 +9,11 @@ for _, strategy in helpers.each_strategy() do
     local db, bp
 
     lazy_setup(function()
-      bp, db = helpers.get_db_utils(strategy)
+      bp, db = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+      })
     end)
 
     describe("Plugins #plugins", function()

--- a/spec/02-integration/01-helpers/00-helpers_spec.lua
+++ b/spec/02-integration/01-helpers/00-helpers_spec.lua
@@ -7,7 +7,10 @@ for _, strategy in helpers.each_strategy() do
     local proxy_client
 
     lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy)
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+      })
 
       local service = bp.services:insert {
         host     = helpers.mock_upstream_host,

--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -2,7 +2,7 @@ local helpers = require "spec.helpers"
 
 describe("kong start/stop", function()
   lazy_setup(function()
-    helpers.get_db_utils() -- runs migrations
+    helpers.get_db_utils(nil, {}) -- runs migrations
     helpers.prepare_prefix()
   end)
   after_each(function()

--- a/spec/02-integration/02-cmd/03-reload_spec.lua
+++ b/spec/02-integration/02-cmd/03-reload_spec.lua
@@ -2,7 +2,7 @@ local helpers = require "spec.helpers"
 
 describe("kong reload", function()
   lazy_setup(function()
-    helpers.get_db_utils() -- runs migrations
+    helpers.get_db_utils(nil, {}) -- runs migrations
     helpers.prepare_prefix()
   end)
   lazy_teardown(function()

--- a/spec/02-integration/02-cmd/06-restart_spec.lua
+++ b/spec/02-integration/02-cmd/06-restart_spec.lua
@@ -11,7 +11,7 @@ end
 
 describe("kong restart", function()
   lazy_setup(function()
-    helpers.get_db_utils() -- runs migrations
+    helpers.get_db_utils(nil, {}) -- runs migrations
     helpers.prepare_prefix()
   end)
   lazy_teardown(function()

--- a/spec/02-integration/02-cmd/08-quit_spec.lua
+++ b/spec/02-integration/02-cmd/08-quit_spec.lua
@@ -2,7 +2,7 @@ local helpers = require "spec.helpers"
 
 describe("kong quit", function()
   lazy_setup(function()
-    helpers.get_db_utils() -- runs migrations
+    helpers.get_db_utils(nil, {}) -- runs migrations
     helpers.prepare_prefix()
   end)
   after_each(function()

--- a/spec/02-integration/03-dao/04-constraints_spec.lua
+++ b/spec/02-integration/03-dao/04-constraints_spec.lua
@@ -9,7 +9,7 @@ for _, strategy in helpers.each_strategy() do
     local db
 
     lazy_setup(function()
-      _, db = helpers.get_db_utils(strategy)
+      _, db = helpers.get_db_utils(strategy, {})
     end)
 
     before_each(function()

--- a/spec/02-integration/03-dao/05-use_cases_spec.lua
+++ b/spec/02-integration/03-dao/05-use_cases_spec.lua
@@ -6,7 +6,13 @@ for _, strategy in helpers.each_strategy() do
     local bp, db
 
     lazy_setup(function()
-      bp, db = helpers.get_db_utils(strategy)
+      bp, db = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "consumers",
+        "plugins",
+        "keyauth_credentials",
+      })
     end)
 
     it("retrieves plugins for plugins_iterator", function()

--- a/spec/02-integration/03-dao/07-ttl_spec.lua
+++ b/spec/02-integration/03-dao/07-ttl_spec.lua
@@ -12,7 +12,7 @@ for _, strategy in helpers.each_strategy() do
     local dao
 
     lazy_setup(function()
-      _, _, dao = helpers.get_db_utils(strategy)
+      _, _, dao = helpers.get_db_utils(strategy, {})
     end)
 
     before_each(function()

--- a/spec/02-integration/04-admin_api/00-admin_api_spec.lua
+++ b/spec/02-integration/04-admin_api/00-admin_api_spec.lua
@@ -30,7 +30,7 @@ end
 
 describe("Admin API listeners", function()
   before_each(function()
-    helpers.get_db_utils()
+    helpers.get_db_utils(nil, {})
   end)
 
   after_each(function()

--- a/spec/02-integration/04-admin_api/01-kong_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/01-kong_routes_spec.lua
@@ -11,7 +11,7 @@ describe("Admin API - Kong routes", function()
     local client
 
     lazy_setup(function()
-      helpers.get_db_utils() -- runs migrations
+      helpers.get_db_utils(nil, {}) -- runs migrations
       assert(helpers.start_kong {
         pg_password = "hide_me"
       })

--- a/spec/02-integration/04-admin_api/24-plugins-conf.lua
+++ b/spec/02-integration/04-admin_api/24-plugins-conf.lua
@@ -8,7 +8,7 @@ describe("Plugins conf property" , function()
   describe("with 'plugins=bundled'", function()
     local client
     lazy_setup(function()
-      helpers.get_db_utils()
+      helpers.get_db_utils(nil, {}) -- runs migrations
       assert(helpers.start_kong({
         plugins = "bundled",
       }))
@@ -36,7 +36,6 @@ describe("Plugins conf property" , function()
   describe("with 'plugins=off'", function()
     local client
     lazy_setup(function()
-      helpers.get_db_utils()
       assert(helpers.start_kong({
         plugins = "off",
       }))

--- a/spec/02-integration/05-proxy/00-proxy_spec.lua
+++ b/spec/02-integration/05-proxy/00-proxy_spec.lua
@@ -30,7 +30,7 @@ end
 
 describe("Proxy interface listeners", function()
   before_each(function()
-    helpers.get_db_utils()
+    helpers.get_db_utils(nil, {})
   end)
 
   after_each(function()

--- a/spec/02-integration/05-proxy/02-upstream_headers_spec.lua
+++ b/spec/02-integration/05-proxy/02-upstream_headers_spec.lua
@@ -58,7 +58,10 @@ for _, strategy in helpers.each_strategy() do
     end
 
     lazy_setup(function()
-      bp, db = helpers.get_db_utils(strategy)
+      bp, db = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+      })
     end)
 
     before_each(function()

--- a/spec/02-integration/05-proxy/04-dns_spec.lua
+++ b/spec/02-integration/05-proxy/04-dns_spec.lua
@@ -46,7 +46,10 @@ for _, strategy in helpers.each_strategy() do
       local proxy_client
 
       lazy_setup(function()
-        local bp = helpers.get_db_utils(strategy)
+        local bp = helpers.get_db_utils(strategy, {
+          "routes",
+          "services",
+        })
 
         local service = bp.services:insert {
           name    = "tests-retries",
@@ -98,7 +101,10 @@ for _, strategy in helpers.each_strategy() do
       local proxy_client
 
       lazy_setup(function()
-        local bp = helpers.get_db_utils(strategy)
+        local bp = helpers.get_db_utils(strategy, {
+          "routes",
+          "services",
+        })
 
         local service = bp.services:insert {
           name     = "tests-retries",

--- a/spec/02-integration/05-proxy/05-ssl_spec.lua
+++ b/spec/02-integration/05-proxy/05-ssl_spec.lua
@@ -19,7 +19,11 @@ for _, strategy in helpers.each_strategy() do
     local https_client
 
     lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy)
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "certificates",
+      })
 
       local service = bp.services:insert {
         name = "global-cert",

--- a/spec/02-integration/05-proxy/06-upstream_timeouts_spec.lua
+++ b/spec/02-integration/05-proxy/06-upstream_timeouts_spec.lua
@@ -43,7 +43,10 @@ for _, strategy in helpers.each_strategy() do
     end
 
     lazy_setup(function()
-      bp = helpers.get_db_utils(strategy)
+      bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+      })
 
       insert_routes {
         {

--- a/spec/02-integration/05-proxy/07-uri_encoding_spec.lua
+++ b/spec/02-integration/05-proxy/07-uri_encoding_spec.lua
@@ -6,7 +6,10 @@ for _, strategy in helpers.each_strategy() do
     local proxy_client
 
     lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy)
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+      })
 
       bp.routes:insert {
         hosts     = { "mock_upstream" },

--- a/spec/02-integration/05-proxy/08-websockets_spec.lua
+++ b/spec/02-integration/05-proxy/08-websockets_spec.lua
@@ -5,7 +5,10 @@ local cjson = require "cjson"
 for _, strategy in helpers.each_strategy() do
   describe("Websockets [#" .. strategy .. "]", function()
     lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy)
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+      })
 
       local service = bp.services:insert {
         name = "ws",

--- a/spec/02-integration/05-proxy/11-error_default_type_spec.lua
+++ b/spec/02-integration/05-proxy/11-error_default_type_spec.lua
@@ -10,7 +10,10 @@ for _, strategy in helpers.each_strategy() do
     local proxy_client
 
     lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy)
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+      })
 
       local service = bp.services:insert {
         name            = "api-1",

--- a/spec/02-integration/05-proxy/13-server_tokens_spec.lua
+++ b/spec/02-integration/05-proxy/13-server_tokens_spec.lua
@@ -29,7 +29,10 @@ describe("headers [#" .. strategy .. "]", function()
     end
 
     lazy_setup(function()
-      bp = helpers.get_db_utils(strategy)
+      bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+      })
     end)
 
     before_each(function()
@@ -252,7 +255,10 @@ describe("headers [#" .. strategy .. "]", function()
     end
 
     lazy_setup(function()
-      bp = helpers.get_db_utils(strategy)
+      bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+      })
     end)
 
 
@@ -575,7 +581,10 @@ describe("headers [#" .. strategy .. "]", function()
     end
 
     lazy_setup(function()
-      bp = helpers.get_db_utils(strategy)
+      bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+      })
     end)
 
     before_each(function()

--- a/spec/02-integration/05-proxy/14-upstream-status-header_spec.lua
+++ b/spec/02-integration/05-proxy/14-upstream-status-header_spec.lua
@@ -3,7 +3,12 @@ local constants = require "kong.constants"
 
 
 local function setup_db()
-  local bp = helpers.get_db_utils()
+  local bp = helpers.get_db_utils(nil, {
+    "routes",
+    "services",
+    "plugins",
+    "keyauth_credentials",
+  })
 
   local service = bp.services:insert {
     host = helpers.mock_upstream_host,

--- a/spec/02-integration/05-proxy/15-custom_nginx_directive_spec.lua
+++ b/spec/02-integration/05-proxy/15-custom_nginx_directive_spec.lua
@@ -19,7 +19,10 @@ describe("Custom NGINX directives", function()
   end
 
   lazy_setup(function()
-    bp = helpers.get_db_utils()
+    bp = helpers.get_db_utils(nil, {
+      "routes",
+      "services",
+    })
   end)
 
   before_each(function()

--- a/spec/02-integration/05-proxy/16-origins_spec.lua
+++ b/spec/02-integration/05-proxy/16-origins_spec.lua
@@ -5,7 +5,10 @@ describe("origins config option", function()
   local bp
 
   before_each(function()
-    bp = helpers.get_db_utils()
+    bp = helpers.get_db_utils(nil, {
+      "routes",
+      "services",
+    })
   end)
 
   after_each(function()

--- a/spec/02-integration/06-invalidations/01-cluster_events_spec.lua
+++ b/spec/02-integration/06-invalidations/01-cluster_events_spec.lua
@@ -11,7 +11,7 @@ for _, strategy in helpers.each_strategy() do
 
     lazy_setup(function()
       local _
-      _, db = helpers.get_db_utils(strategy)
+      _, db = helpers.get_db_utils(strategy, {})
     end)
 
     lazy_teardown(function()

--- a/spec/03-plugins/01-tcp-log/01-tcp-log_spec.lua
+++ b/spec/03-plugins/01-tcp-log/01-tcp-log_spec.lua
@@ -10,7 +10,11 @@ for _, strategy in helpers.each_strategy() do
     local proxy_client
 
     lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy)
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+      })
 
       local route = bp.routes:insert {
         hosts = { "tcp_logging.com" },
@@ -84,7 +88,7 @@ for _, strategy in helpers.each_strategy() do
       -- Making the request
       local r = assert(proxy_client:send {
         method  = "GET",
-        path    = "/delay/2",
+        path    = "/delay/1",
         headers = {
           host  = "tcp_logging.com",
         },

--- a/spec/03-plugins/02-udp-log/01-udp-log_spec.lua
+++ b/spec/03-plugins/02-udp-log/01-udp-log_spec.lua
@@ -10,7 +10,11 @@ for _, strategy in helpers.each_strategy() do
     local proxy_client
 
     lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy)
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+      })
 
       local route = bp.routes:insert {
         hosts = { "udp_logging.com" },

--- a/spec/03-plugins/03-http-log/01-log_spec.lua
+++ b/spec/03-plugins/03-http-log/01-log_spec.lua
@@ -7,7 +7,11 @@ for _, strategy in helpers.each_strategy() do
     local proxy_client
 
     lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy)
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+      })
 
       local service1 = bp.services:insert{
         protocol = "http",

--- a/spec/03-plugins/04-file-log/01-log_spec.lua
+++ b/spec/03-plugins/04-file-log/01-log_spec.lua
@@ -14,7 +14,11 @@ for _, strategy in helpers.each_strategy() do
     local proxy_client
 
     lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy)
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+      })
 
       local route = bp.routes:insert {
         hosts = { "file_logging.com" },

--- a/spec/03-plugins/05-syslog/01-log_spec.lua
+++ b/spec/03-plugins/05-syslog/01-log_spec.lua
@@ -10,7 +10,11 @@ for _, strategy in helpers.each_strategy() do
     local platform
 
     lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy)
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+      })
 
       local route1 = bp.routes:insert {
         hosts = { "logging.com" },

--- a/spec/03-plugins/06-statsd/01-log_spec.lua
+++ b/spec/03-plugins/06-statsd/01-log_spec.lua
@@ -12,7 +12,13 @@ for _, strategy in helpers.each_strategy() do
     local proxy_client
 
     lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy)
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+        "consumers",
+        "keyauth_credentials",
+      })
 
       local consumer = bp.consumers:insert {
         username  = "bob",

--- a/spec/03-plugins/07-loggly/01-log_spec.lua
+++ b/spec/03-plugins/07-loggly/01-log_spec.lua
@@ -10,7 +10,11 @@ for _, strategy in helpers.each_strategy() do
     local proxy_client
 
     lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy)
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+      })
 
       local route1 = bp.routes:insert {
         hosts = { "logging.com" },

--- a/spec/03-plugins/08-datadog/01-log_spec.lua
+++ b/spec/03-plugins/08-datadog/01-log_spec.lua
@@ -7,7 +7,13 @@ for _, strategy in helpers.each_strategy() do
     local proxy_client
 
     lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy)
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+        "consumers",
+        "keyauth_credentials",
+      })
 
       local consumer = bp.consumers:insert {
         username  = "foo",

--- a/spec/03-plugins/10-key-auth/01-api_spec.lua
+++ b/spec/03-plugins/10-key-auth/01-api_spec.lua
@@ -13,7 +13,13 @@ for _, strategy in helpers.each_strategy() do
     local route2
 
     lazy_setup(function()
-      bp, db = helpers.get_db_utils(strategy)
+      bp, db = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+        "consumers",
+        "keyauth_credentials",
+      })
 
       route1 = bp.routes:insert {
         hosts = { "keyauth1.test" },

--- a/spec/03-plugins/10-key-auth/02-access_spec.lua
+++ b/spec/03-plugins/10-key-auth/02-access_spec.lua
@@ -8,7 +8,13 @@ for _, strategy in helpers.each_strategy() do
     local proxy_client
 
     lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy)
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+        "consumers",
+        "keyauth_credentials",
+      })
 
       local anonymous_user = bp.consumers:insert {
         username = "no-body",
@@ -470,7 +476,13 @@ for _, strategy in helpers.each_strategy() do
     local anonymous
 
     lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy)
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+        "consumers",
+        "keyauth_credentials",
+      })
 
       local route1 = bp.routes:insert {
         hosts = { "logical-and.com" },

--- a/spec/03-plugins/10-key-auth/03-invalidations_spec.lua
+++ b/spec/03-plugins/10-key-auth/03-invalidations_spec.lua
@@ -9,7 +9,13 @@ for _, strategy in helpers.each_strategy() do
 
     before_each(function()
       local bp
-      bp, db = helpers.get_db_utils(strategy)
+      bp, db = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+        "consumers",
+        "keyauth_credentials",
+      })
 
       local route = bp.routes:insert {
         hosts = { "key-auth.com" },

--- a/spec/03-plugins/11-basic-auth/02-api_spec.lua
+++ b/spec/03-plugins/11-basic-auth/02-api_spec.lua
@@ -11,7 +11,13 @@ for _, strategy in helpers.each_strategy() do
     local db
 
     lazy_setup(function()
-      bp, db = helpers.get_db_utils(strategy)
+      bp, db = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+        "consumers",
+        "basicauth_credentials",
+      })
 
       assert(helpers.start_kong({
         database = strategy,

--- a/spec/03-plugins/11-basic-auth/03-access_spec.lua
+++ b/spec/03-plugins/11-basic-auth/03-access_spec.lua
@@ -9,7 +9,13 @@ for _, strategy in helpers.each_strategy() do
     local proxy_client
 
     lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy)
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+        "consumers",
+        "basicauth_credentials",
+      })
 
       local consumer = bp.consumers:insert {
         username = "bob",
@@ -355,7 +361,13 @@ for _, strategy in helpers.each_strategy() do
     local anonymous
 
     lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy)
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+        "consumers",
+        "basicauth_credentials",
+      })
 
       anonymous = bp.consumers:insert {
         username = "Anonymous",

--- a/spec/03-plugins/13-request-size-limiting/01-access_spec.lua
+++ b/spec/03-plugins/13-request-size-limiting/01-access_spec.lua
@@ -11,7 +11,11 @@ for _, strategy in helpers.each_strategy() do
     local proxy_client
 
     lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy)
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+      })
 
       local route = bp.routes:insert {
         hosts = { "limit.com" },

--- a/spec/03-plugins/15-request-transformer/02-access_spec.lua
+++ b/spec/03-plugins/15-request-transformer/02-access_spec.lua
@@ -7,7 +7,11 @@ for _, strategy in helpers.each_strategy() do
     local proxy_client
 
     lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy)
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+      })
 
       local route1 = bp.routes:insert({
         hosts = { "test1.com" },

--- a/spec/03-plugins/15-request-transformer/03-api_spec.lua
+++ b/spec/03-plugins/15-request-transformer/03-api_spec.lua
@@ -16,7 +16,9 @@ for _, strategy in helpers.each_strategy() do
 
     describe("POST", function()
       lazy_setup(function()
-        helpers.get_db_utils(strategy)
+        helpers.get_db_utils(strategy, {
+          "plugins",
+        })
 
         assert(helpers.start_kong({
           database   = strategy,

--- a/spec/03-plugins/16-response-transformer/04-filter_spec.lua
+++ b/spec/03-plugins/16-response-transformer/04-filter_spec.lua
@@ -6,7 +6,11 @@ for _, strategy in helpers.each_strategy() do
     local proxy_client
 
     lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy)
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+      })
 
       local route1 = bp.routes:insert({
         hosts = { "response.com" },

--- a/spec/03-plugins/16-response-transformer/05-big_response_body_spec.lua
+++ b/spec/03-plugins/16-response-transformer/05-big_response_body_spec.lua
@@ -15,7 +15,11 @@ for _, strategy in helpers.each_strategy() do
     local proxy_client
 
     lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy)
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+      })
 
       local route = bp.routes:insert({
         hosts   = { "response.com" },

--- a/spec/03-plugins/17-jwt/02-api_spec.lua
+++ b/spec/03-plugins/17-jwt/02-api_spec.lua
@@ -11,8 +11,13 @@ for _, strategy in helpers.each_strategy() do
     local bp
 
     lazy_setup(function()
-      bp, db = helpers.get_db_utils(strategy)
-      db:truncate()
+      bp, db = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+        "consumers",
+        "jwt_secrets",
+      })
 
       assert(helpers.start_kong({
         database = strategy,

--- a/spec/03-plugins/17-jwt/03-access_spec.lua
+++ b/spec/03-plugins/17-jwt/03-access_spec.lua
@@ -26,7 +26,15 @@ for _, strategy in helpers.each_strategy() do
     local admin_client
 
     lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy, nil, { "ctx-checker" })
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+        "consumers",
+        "jwt_secrets",
+      }, {
+        "ctx-checker",
+      })
 
       local routes = {}
 
@@ -726,7 +734,14 @@ for _, strategy in helpers.each_strategy() do
     local jwt_token
 
     lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy)
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+        "consumers",
+        "jwt_secrets",
+        "keyauth_credentials",
+      })
 
       local service1 = bp.services:insert({
         path = "/request"

--- a/spec/03-plugins/17-jwt/04-invalidations_spec.lua
+++ b/spec/03-plugins/17-jwt/04-invalidations_spec.lua
@@ -13,7 +13,13 @@ for _, strategy in helpers.each_strategy() do
 
     before_each(function()
       local bp
-      bp, db = helpers.get_db_utils(strategy)
+      bp, db = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+        "consumers",
+        "jwt_secrets",
+      })
 
       route = bp.routes:insert {
         hosts = { "jwt.com" },

--- a/spec/03-plugins/18-ip-restriction/02-access_spec.lua
+++ b/spec/03-plugins/18-ip-restriction/02-access_spec.lua
@@ -11,7 +11,11 @@ for _, strategy in helpers.each_strategy() do
 
     lazy_setup(function()
       local bp
-      bp, db = helpers.get_db_utils(strategy)
+      bp, db = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+      })
 
       local route1 = bp.routes:insert {
         hosts = { "ip-restriction1.com" },

--- a/spec/03-plugins/19-acl/01-api_spec.lua
+++ b/spec/03-plugins/19-acl/01-api_spec.lua
@@ -10,7 +10,13 @@ for _, strategy in helpers.each_strategy() do
     local db
 
     lazy_setup(function()
-      bp, db = helpers.get_db_utils(strategy)
+      bp, db = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+        "consumers",
+        "acls",
+      })
 
       assert(helpers.start_kong({
         database = strategy,

--- a/spec/03-plugins/19-acl/02-access_spec.lua
+++ b/spec/03-plugins/19-acl/02-access_spec.lua
@@ -10,7 +10,14 @@ for _, strategy in helpers.each_strategy() do
     local db
 
     lazy_setup(function()
-      bp, db = helpers.get_db_utils(strategy)
+      bp, db = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+        "consumers",
+        "acls",
+        "keyauth_credentials",
+      })
 
       local consumer1 = bp.consumers:insert {
         username = "consumer1"

--- a/spec/03-plugins/19-acl/03-invalidations_spec.lua
+++ b/spec/03-plugins/19-acl/03-invalidations_spec.lua
@@ -10,7 +10,14 @@ for _, strategy in helpers.each_strategy() do
 
     before_each(function()
       local bp
-      bp, db = helpers.get_db_utils(strategy)
+      bp, db = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+        "consumers",
+        "acls",
+        "keyauth_credentials",
+      })
 
       consumer = bp.consumers:insert {
         username = "consumer1"

--- a/spec/03-plugins/20-hmac-auth/02-api_spec.lua
+++ b/spec/03-plugins/20-hmac-auth/02-api_spec.lua
@@ -11,7 +11,13 @@ for _, strategy in helpers.each_strategy() do
     local db
 
     lazy_setup(function()
-      bp, db = helpers.get_db_utils(strategy)
+      bp, db = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "consumers",
+        "plugins",
+        "hmacauth_credentials",
+      })
 
       assert(helpers.start_kong({
         database = strategy,

--- a/spec/03-plugins/20-hmac-auth/03-access_spec.lua
+++ b/spec/03-plugins/20-hmac-auth/03-access_spec.lua
@@ -22,7 +22,13 @@ for _, strategy in helpers.each_strategy() do
     local credential
 
     lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy)
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "consumers",
+        "plugins",
+        "hmacauth_credentials",
+      })
 
       local route1 = bp.routes:insert {
         hosts = { "hmacauth.com" },
@@ -1521,7 +1527,14 @@ for _, strategy in helpers.each_strategy() do
     local hmacDate
 
     lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy)
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "consumers",
+        "plugins",
+        "hmacauth_credentials",
+        "keyauth_credentials",
+      })
 
       local service1 = bp.services:insert({
         path = "/request"

--- a/spec/03-plugins/20-hmac-auth/04-invalidations_spec.lua
+++ b/spec/03-plugins/20-hmac-auth/04-invalidations_spec.lua
@@ -12,7 +12,13 @@ for _, strategy in helpers.each_strategy() do
 
     lazy_setup(function()
       local bp
-      bp, db = helpers.get_db_utils(strategy)
+      bp, db = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+        "consumers",
+        "hmacauth_credentials",
+      })
 
       local route = bp.routes:insert {
         hosts = { "hmacauth.com" },

--- a/spec/03-plugins/21-ldap-auth/01-access_spec.lua
+++ b/spec/03-plugins/21-ldap-auth/01-access_spec.lua
@@ -31,7 +31,12 @@ for _, strategy in helpers.each_strategy() do
     local plugin2
 
     lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy)
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+        "consumers",
+      })
 
       local route1 = bp.routes:insert {
         hosts = { "ldap.com" },
@@ -488,7 +493,13 @@ for _, strategy in helpers.each_strategy() do
     local anonymous
 
     lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy)
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+        "consumers",
+        "keyauth_credentials",
+      })
 
       local service1 = bp.services:insert({
         path = "/request"

--- a/spec/03-plugins/21-ldap-auth/02-invalidations_spec.lua
+++ b/spec/03-plugins/21-ldap-auth/02-invalidations_spec.lua
@@ -12,8 +12,11 @@ for _, strategy in helpers.each_strategy() do
     local plugin
 
     lazy_setup(function()
-      local bp
-      bp = helpers.get_db_utils(strategy)
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+      })
 
       local route = bp.routes:insert {
         hosts = { "ldapauth.com" },

--- a/spec/03-plugins/22-bot-detection/02-invalidations_spec.lua
+++ b/spec/03-plugins/22-bot-detection/02-invalidations_spec.lua
@@ -7,7 +7,11 @@ for _, strategy in helpers.each_strategy() do
     local admin_client
 
     lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy)
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+      })
 
       local route = bp.routes:insert {
         hosts = { "bot.com" },

--- a/spec/03-plugins/22-bot-detection/03-api_spec.lua
+++ b/spec/03-plugins/22-bot-detection/03-api_spec.lua
@@ -12,7 +12,11 @@ for _, strategy in helpers.each_strategy() do
     local route2
 
     lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy)
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+      })
 
       route1 = bp.routes:insert {
         hosts = { "bot1.com" },

--- a/spec/03-plugins/23-aws-lambda/01-access_spec.lua
+++ b/spec/03-plugins/23-aws-lambda/01-access_spec.lua
@@ -12,7 +12,11 @@ for _, strategy in helpers.each_strategy() do
     local admin_client
 
     lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy)
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+      })
 
       local route1 = bp.routes:insert {
         hosts = { "lambda.com" },

--- a/spec/03-plugins/24-rate-limiting/02-policies_spec.lua
+++ b/spec/03-plugins/24-rate-limiting/02-policies_spec.lua
@@ -10,12 +10,11 @@ for _, strategy in helpers.each_strategy() do
       local conf       = { route = { id = uuid() }, service = { id = uuid() } }
 
       local db
-      local dao
       local policies
 
       lazy_setup(function()
         local _
-        _, db, dao = helpers.get_db_utils(strategy)
+        _, db = helpers.get_db_utils(strategy, {})
 
         if _G.kong then
           _G.kong.db = db
@@ -27,9 +26,8 @@ for _, strategy in helpers.each_strategy() do
         policies = require "kong.plugins.rate-limiting.policies"
       end)
 
-      after_each(function()
-        assert(db:truncate())
-        dao:truncate_tables()
+      before_each(function()
+        assert(db:truncate("ratelimiting_metrics"))
       end)
 
       it("returns 0 when rate-limiting metrics don't exist yet", function()

--- a/spec/03-plugins/26-oauth2/01-schema_spec.lua
+++ b/spec/03-plugins/26-oauth2/01-schema_spec.lua
@@ -8,7 +8,15 @@ local fmt = string.format
 for _, strategy in helpers.each_strategy() do
 
   describe(fmt("Plugin: oauth2 [#%s] (schema)", strategy), function()
-    local bp, db = helpers.get_db_utils(strategy)
+    local bp, db = helpers.get_db_utils(strategy, {
+      "routes",
+      "services",
+      "consumers",
+      "plugins",
+      "oauth2_tokens",
+      "oauth2_authorization_codes",
+      "oauth2_credentials",
+    })
 
     local oauth2_authorization_codes_schema = db.oauth2_authorization_codes.schema
     local oauth2_tokens_schema = db.oauth2_tokens.schema

--- a/spec/03-plugins/26-oauth2/04-invalidations_spec.lua
+++ b/spec/03-plugins/26-oauth2/04-invalidations_spec.lua
@@ -10,7 +10,15 @@ for _, strategy in helpers.each_strategy() do
     local bp
 
     lazy_setup(function()
-      bp, db = helpers.get_db_utils(strategy)
+      bp, db = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "consumers",
+        "plugins",
+        "oauth2_tokens",
+        "oauth2_credentials",
+        "oauth2_authorization_codes",
+      })
     end)
 
     before_each(function()

--- a/spec/03-plugins/27-request-termination/02-access_spec.lua
+++ b/spec/03-plugins/27-request-termination/02-access_spec.lua
@@ -12,7 +12,11 @@ for _, strategy in helpers.each_strategy() do
     local admin_client
 
     lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy)
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+      })
 
       local route1 = bp.routes:insert({
         hosts = { "api1.request-termination.com" },

--- a/spec/03-plugins/27-request-termination/03-integration_spec.lua
+++ b/spec/03-plugins/27-request-termination/03-integration_spec.lua
@@ -8,7 +8,13 @@ for _, strategy in helpers.each_strategy() do
     local consumer
 
     lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy)
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+        "consumers",
+        "keyauth_credentials",
+      })
 
       bp.routes:insert({
         hosts = { "api1.request-termination.com" },

--- a/spec/fixtures/admin_api.lua
+++ b/spec/fixtures/admin_api.lua
@@ -42,7 +42,6 @@ local entities = {
   "oauth2_tokens",
   "oauth2_authorization_codes",
   "keyauth_credentials",
-  "basicauth_credentials",
   "hmacauth_credentials",
 }
 
@@ -52,14 +51,23 @@ local admin_api_as_db = {}
 for _, name in ipairs(entities) do
   admin_api_as_db[name] = {
     insert = function(_, tbl)
-      local ok, err = api_send("POST", "/" .. name, tbl)
-      return ok, err
+      return api_send("POST", "/" .. name, tbl)
     end,
     remove = function(_, tbl)
       return api_send("DELETE", "/" .. name .. "/" .. tbl.id)
     end,
   }
 end
+
+
+admin_api_as_db["basicauth_credentials"] = {
+  insert = function(_, tbl)
+    return api_send("POST", "/consumers/" .. tbl.consumer.id .. "/basic-auth", tbl)
+  end,
+  remove = function(_, tbl)
+    return api_send("DELETE", "/consumers/" .. tbl.consumer.id .. "/basic-auth/" .. tbl.id)
+  end,
+}
 
 
 return blueprints.new(nil, admin_api_as_db)

--- a/spec/fixtures/admin_api.lua
+++ b/spec/fixtures/admin_api.lua
@@ -1,0 +1,65 @@
+local blueprints = require "spec.fixtures.blueprints"
+local helpers = require "spec.helpers"
+local cjson = require "cjson"
+
+
+local function api_send(method, path, body, forced_port)
+  local api_client = helpers.admin_client(nil, forced_port)
+  local res, err = api_client:send({
+    method = method,
+    path = path,
+    headers = {
+      ["Content-Type"] = "application/json"
+    },
+    body = body,
+  })
+  if not res then
+    return nil, err
+  end
+  local resbody = res.status ~= 204 and res:read_body()
+  api_client:close()
+  if res.status == 204 then
+    return nil
+  elseif res.status < 300 then
+    return cjson.decode(resbody)
+  else
+    return nil, "Error " .. tostring(res.status) .. ": " .. resbody
+  end
+end
+
+
+local entities = {
+  "snis",
+  "certificates",
+  "upstreams",
+  "consumers",
+  "targets",
+  "plugins",
+  "routes",
+  "services",
+  "jwt_secrets",
+  "oauth2_credentials",
+  "oauth2_tokens",
+  "oauth2_authorization_codes",
+  "keyauth_credentials",
+  "basicauth_credentials",
+  "hmacauth_credentials",
+}
+
+
+local admin_api_as_db = {}
+
+for _, name in ipairs(entities) do
+  admin_api_as_db[name] = {
+    insert = function(_, tbl)
+      local ok, err = api_send("POST", "/" .. name, tbl)
+      return ok, err
+    end,
+    remove = function(_, tbl)
+      return api_send("DELETE", "/" .. name .. "/" .. tbl.id)
+    end,
+  }
+end
+
+
+return blueprints.new(nil, admin_api_as_db)

--- a/spec/fixtures/blueprints.lua
+++ b/spec/fixtures/blueprints.lua
@@ -24,6 +24,15 @@ function Blueprint:insert(overrides, options)
 end
 
 
+function Blueprint:remove(overrides, options)
+  local entity, err = self.dao:remove({ id = overrides.id }, options)
+  if err then
+    error(err, 2)
+  end
+  return entity
+end
+
+
 function Blueprint:insert_n(n, overrides, options)
   local res = {}
   for i=1,n do

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -287,7 +287,7 @@ local function wait_until(f, timeout)
 
   ngx.update_time()
 
-  timeout = timeout or 2
+  timeout = timeout or 5
   local tstart = ngx.time()
   local texp = tstart + timeout
   local ok, res, err

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -543,7 +543,9 @@ local function tcp_server(port, opts, ...)
     end
   }, port, opts)
 
-  return thread:start(...)
+  local thr = thread:start(...)
+  ngx.sleep(0.01)
+  return thr
 end
 
 --- Starts a HTTP server.


### PR DESCRIPTION
I spent some time catching some low-hanging fruit to speed up our test suite and reduce some of the flakiness.

It seems to reduce "total time" from around 45 to 37 min, which translate in clock time to tests going down from 13-14 (best case, no flaky restarts) to something like 11-12 mins. After this is merged and the `spec-old-api` tests are finally removed in 1.0, I hope we can get to a sub-10 minute test suite (at least before we add more tests!).