### PR TITLE
feat(rate-limiting) global rate-limiting to protect back-end

### DIFF
--- a/kong/plugins/rate-limiting/handler.lua
+++ b/kong/plugins/rate-limiting/handler.lua
@@ -29,10 +29,12 @@ local function get_identifier(conf)
     end
   elseif conf.limit_by == "credential" then
     identifier = ngx.ctx.authenticated_credential and ngx.ctx.authenticated_credential.id
+  elseif conf.limit_by == "ip" then
+    identifier = ngx.var.remote_addr
   end
 
   if not identifier then
-    identifier = ngx.var.remote_addr
+    identifier = ngx.var.server_addr .. "-" .. ngx.var.server_name .. ngx.var.pid .. "-" .."-global"
   end
 
   return identifier

--- a/kong/plugins/rate-limiting/schema.lua
+++ b/kong/plugins/rate-limiting/schema.lua
@@ -10,7 +10,7 @@ return {
     day = { type = "number" },
     month = { type = "number" },
     year = { type = "number" },
-    limit_by = { type = "string", enum = {"consumer", "credential", "ip"}, default = "consumer" },
+    limit_by = { type = "string", enum = {"consumer", "credential", "ip", "global"}, default = "global" },
     policy = { type = "string", enum = {"local", "cluster", REDIS}, default = "cluster" },
     fault_tolerant = { type = "boolean", default = true },
     redis_host = { type = "string" },


### PR DESCRIPTION
This minor feature enable to perform global rate-limiting over a given endpoint aggregating count globally on the whole kong instance in case you want to protect the back-end to exceed its limits.

### Summary

Current rate-limiting limit_by modes are: consumer, credential, ip.
Default is ip.
A new mode, is implemented and named "global".
It was tested and validated only using policy=local, but should also work on cluster or REDIS as soon as nginx server ip differs between knog/nginx instances.

### Full changelog

I did not add new tests. Existing luacheck tests are OK.

### Issues resolved

It is linked to the following forum thread: 
https://discuss.konghq.com/t/common-rate-limiting-for-all-consumers/2218/5
https://discuss.konghq.com/t/rate-limiting-behaviour/2081/2

