### PR TITLE
fix(cors) follow mozilla guidelines for preflight request

### DIFF
--- a/kong/plugins/cors/handler.lua
+++ b/kong/plugins/cors/handler.lua
@@ -8,7 +8,7 @@ local tostring = tostring
 local ipairs   = ipairs
 
 
-local NO_CONTENT = 204
+local HTTP_OK = 200
 
 
 local CorsHandler = BasePlugin:extend()
@@ -137,7 +137,7 @@ function CorsHandler:access(conf)
     set_header("Access-Control-Max-Age", tostring(conf.max_age))
   end
 
-  return kong.response.exit(NO_CONTENT)
+  return kong.response.exit(HTTP_OK)
 end
 
 

--- a/kong/plugins/cors/handler.lua
+++ b/kong/plugins/cors/handler.lua
@@ -137,6 +137,8 @@ function CorsHandler:access(conf)
     set_header("Access-Control-Max-Age", tostring(conf.max_age))
   end
 
+  set_header("Content-Length", "0")
+
   return kong.response.exit(HTTP_OK)
 end
 

--- a/kong/plugins/cors/handler.lua
+++ b/kong/plugins/cors/handler.lua
@@ -137,8 +137,6 @@ function CorsHandler:access(conf)
     set_header("Access-Control-Max-Age", tostring(conf.max_age))
   end
 
-  set_header("Content-Length", "0")
-
   return kong.response.exit(HTTP_OK)
 end
 

--- a/spec-old-api/03-plugins/14-cors/01-access_spec.lua
+++ b/spec-old-api/03-plugins/14-cors/01-access_spec.lua
@@ -160,7 +160,8 @@ describe("Plugin: cors (access)", function()
           ["Host"] = "cors1.com"
         }
       })
-      assert.res_status(204, res)
+      assert.res_status(200, res)
+      assert.equal("0", res.headers["Content-Length"])
       assert.equal("GET,HEAD,PUT,PATCH,POST,DELETE", res.headers["Access-Control-Allow-Methods"])
       assert.equal("*", res.headers["Access-Control-Allow-Origin"])
       assert.is_nil(res.headers["Access-Control-Allow-Headers"])
@@ -182,7 +183,8 @@ describe("Plugin: cors (access)", function()
           ["Host"] = "cors-empty-origins.com",
         }
       })
-      assert.res_status(204, res)
+      assert.res_status(200, res)
+      assert.equal("0", res.headers["Content-Length"])
       assert.equal("GET,HEAD,PUT,PATCH,POST,DELETE", res.headers["Access-Control-Allow-Methods"])
       assert.equal("*", res.headers["Access-Control-Allow-Origin"])
       assert.is_nil(res.headers["Access-Control-Allow-Headers"])
@@ -198,7 +200,8 @@ describe("Plugin: cors (access)", function()
           ["Host"] = "cors5.com"
         }
       })
-      assert.res_status(204, res)
+      assert.res_status(200, res)
+      assert.equal("0", res.headers["Content-Length"])
       assert.equal("GET,HEAD,PUT,PATCH,POST,DELETE", res.headers["Access-Control-Allow-Methods"])
       assert.equal("*", res.headers["Access-Control-Allow-Origin"])
       assert.is_nil(res.headers["Access-Control-Allow-Headers"])
@@ -214,7 +217,8 @@ describe("Plugin: cors (access)", function()
           ["Host"] = "cors2.com"
         }
       })
-      assert.res_status(204, res)
+      assert.res_status(200, res)
+      assert.equal("0", res.headers["Content-Length"])
       assert.equal("GET", res.headers["Access-Control-Allow-Methods"])
       assert.equal("example.com", res.headers["Access-Control-Allow-Origin"])
       assert.equal("23", res.headers["Access-Control-Max-Age"])
@@ -245,7 +249,8 @@ describe("Plugin: cors (access)", function()
         }
       })
 
-      assert.res_status(204, res)
+      assert.res_status(200, res)
+      assert.equal("0", res.headers["Content-Length"])
       assert.equal("origin,accepts", res.headers["Access-Control-Allow-Headers"])
     end)
   end)

--- a/spec/03-plugins/14-cors/01-access_spec.lua
+++ b/spec/03-plugins/14-cors/01-access_spec.lua
@@ -201,7 +201,8 @@ for _, strategy in helpers.each_strategy() do
             ["Host"] = "cors1.com"
           }
         })
-        assert.res_status(204, res)
+        assert.res_status(200, res)
+        assert.equal("0", res.headers["Content-Length"])
         assert.equal("GET,HEAD,PUT,PATCH,POST,DELETE", res.headers["Access-Control-Allow-Methods"])
         assert.equal("*", res.headers["Access-Control-Allow-Origin"])
         assert.is_nil(res.headers["Access-Control-Allow-Headers"])
@@ -224,7 +225,8 @@ for _, strategy in helpers.each_strategy() do
             ["Host"] = "cors-empty-origins.com",
           }
         })
-        assert.res_status(204, res)
+        assert.res_status(200, res)
+        assert.equal("0", res.headers["Content-Length"])
         assert.equal("GET,HEAD,PUT,PATCH,POST,DELETE", res.headers["Access-Control-Allow-Methods"])
         assert.equal("*", res.headers["Access-Control-Allow-Origin"])
         assert.is_nil(res.headers["Access-Control-Allow-Headers"])
@@ -241,7 +243,8 @@ for _, strategy in helpers.each_strategy() do
             ["Host"] = "cors5.com"
           }
         })
-        assert.res_status(204, res)
+        assert.res_status(200, res)
+        assert.equal("0", res.headers["Content-Length"])
         assert.equal("GET,HEAD,PUT,PATCH,POST,DELETE", res.headers["Access-Control-Allow-Methods"])
         assert.equal("*", res.headers["Access-Control-Allow-Origin"])
         assert.is_nil(res.headers["Access-Control-Allow-Headers"])
@@ -258,7 +261,8 @@ for _, strategy in helpers.each_strategy() do
             ["Host"] = "cors2.com"
           }
         })
-        assert.res_status(204, res)
+        assert.res_status(200, res)
+        assert.equal("0", res.headers["Content-Length"])
         assert.equal("GET", res.headers["Access-Control-Allow-Methods"])
         assert.equal("example.com", res.headers["Access-Control-Allow-Origin"])
         assert.equal("23", res.headers["Access-Control-Max-Age"])
@@ -290,7 +294,8 @@ for _, strategy in helpers.each_strategy() do
           }
         })
 
-        assert.res_status(204, res)
+        assert.res_status(200, res)
+        assert.equal("0", res.headers["Content-Length"])
         assert.equal("origin,accepts", res.headers["Access-Control-Allow-Headers"])
       end)
     end)


### PR DESCRIPTION
### Summary

Follow the mozilla guidelines for preflight request (https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request) for the cors plugin implementation.

### Full changelog

* On OPTIONS requests
	* Send 200 instead of 204
	* Set `Content-Length` to `0`

### Issues resolved

Fixes #4008
