### PR TITLE
fix(aws-lambda) strip Connection header if client is using HTTP/2

### DIFF
--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -236,9 +236,7 @@ function AWSLambdaHandler:access(conf)
     headers["Keep-Alive"] = ""
     headers["Proxy-Connection"] = ""
     headers["Upgrade"] = ""
-    if headers["Transfer-Encoding"] ~= "trailers" then
-      headers["Transfer-Encoding"] = ""
-    end
+    headers["Transfer-Encoding"] = ""
   end
 
   local ok, err = client:set_keepalive(conf.keepalive)

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -233,11 +233,11 @@ function AWSLambdaHandler:access(conf)
 
   if var.http2 then
     headers["Connection"] = ""
-    response_headers["Keep-Alive"] = ""
-    response_headers["Proxy-Connection"] = ""
-    response_headers["Upgrade"] = ""
-    if response_headers["Transfer-Encoding"] ~= "trailers" then
-      response_headers["Transfer-Encoding"] = ""
+    headers["Keep-Alive"] = ""
+    headers["Proxy-Connection"] = ""
+    headers["Upgrade"] = ""
+    if headers["Transfer-Encoding"] ~= "trailers" then
+      headers["Transfer-Encoding"] = ""
     end
   end
 

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -129,6 +129,7 @@ function AWSLambdaHandler:access(conf)
   AWSLambdaHandler.super.access(self)
 
   local upstream_body = new_tab(0, 6)
+  local var = ngx.var
 
   if conf.forward_request_body or conf.forward_request_headers
     or conf.forward_request_method or conf.forward_request_uri
@@ -229,6 +230,10 @@ function AWSLambdaHandler:access(conf)
 
   local content = res:read_body()
   local headers = res.headers
+
+  if var.http2 then
+    headers["Connection"] = ""
+  end
 
   local ok, err = client:set_keepalive(conf.keepalive)
   if not ok then

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -232,11 +232,11 @@ function AWSLambdaHandler:access(conf)
   local headers = res.headers
 
   if var.http2 then
-    headers["Connection"] = ""
-    headers["Keep-Alive"] = ""
-    headers["Proxy-Connection"] = ""
-    headers["Upgrade"] = ""
-    headers["Transfer-Encoding"] = ""
+    headers["Connection"] = nil
+    headers["Keep-Alive"] = nil
+    headers["Proxy-Connection"] = nil
+    headers["Upgrade"] = nil
+    headers["Transfer-Encoding"] = nil
   end
 
   local ok, err = client:set_keepalive(conf.keepalive)

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -233,6 +233,12 @@ function AWSLambdaHandler:access(conf)
 
   if var.http2 then
     headers["Connection"] = ""
+    response_headers["Keep-Alive"] = ""
+    response_headers["Proxy-Connection"] = ""
+    response_headers["Upgrade"] = ""
+    if response_headers["Transfer-Encoding"] ~= "trailers" then
+      response_headers["Transfer-Encoding"] = ""
+    end
   end
 
   local ok, err = client:set_keepalive(conf.keepalive)

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -135,7 +135,6 @@ function AWSLambdaHandler:access(conf)
     or conf.forward_request_method or conf.forward_request_uri
   then
     -- new behavior to forward request method, body, uri and their args
-    local var = ngx.var
 
     if conf.forward_request_method then
       upstream_body.request_method = var.request_method


### PR DESCRIPTION
### Summary
Strip Connection headers from AWS Lambda responses if client is using HTTP per [RFC 7540](https://tools.ietf.org/html/rfc7540#section-8.1.2.2)

### Issues resolved

Fix #2991 