### PR TITLE
hotfix(admin_api) ensure offset is a string for targets list endpoint

### DIFF
--- a/kong/db/dao/targets.lua
+++ b/kong/db/dao/targets.lua
@@ -214,7 +214,7 @@ function _TARGETS:page_for_upstream(upstream_pk, size, offset, options)
 
   local next_offset
   if all_active_targets[size + offset + 1] then
-    next_offset = size + offset
+    next_offset = tostring(size + offset)
   end
 
   return page, nil, nil, next_offset

--- a/spec/02-integration/000-new-dao/02-db_core_entities_spec.lua
+++ b/spec/02-integration/000-new-dao/02-db_core_entities_spec.lua
@@ -19,6 +19,8 @@ for _, strategy in helpers.each_strategy() do
         "routes",
         "services",
         "basicauth_credentials",
+        "upstreams",
+        "targets",
       })
     end)
 
@@ -1849,5 +1851,26 @@ for _, strategy in helpers.each_strategy() do
         end) -- paginates
       end) -- routes:page_for_service()
     end) -- Services and Routes association
+    describe("Targets", function()
+      local upstream
+
+      lazy_setup(function()
+        upstream = bp.upstreams:insert()
+        for i = 1, 2 do
+          bp.targets:insert({
+            upstream = upstream,
+            target = "target" .. i,
+          })
+        end
+      end)
+
+      it("offset is a string", function()
+        local page, _, _, offset = db.targets:page_for_upstream({
+          id = upstream.id,
+        }, 1)
+        assert.not_nil(page)
+        assert.is_string(offset)
+      end)
+    end)
   end) -- kong.db [strategy]
 end

--- a/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -461,6 +461,16 @@ describe("Admin API #" .. strategy, function()
         local json = assert.response(res).has.jsonbody()
         assert.equal(10, #json.data)
       end)
+      it("offset is a string", function()
+        local res = assert(client:send {
+          method = "GET",
+          path = "/upstreams/" .. upstream.name .. "/targets",
+          query = {size = 3},
+        })
+        assert.response(res).has.status(200)
+        local json = assert.response(res).has.jsonbody()
+        assert.is_string(json.offset)
+      end)
       it("paginates a set", function()
         local pages = {}
         local offset


### PR DESCRIPTION
`offset` is a string on the Admin API for all list endpoints.
This change ensures that `/upstreams/:upstream/targets` endpoint
conforms to this expectation.

Fix #4043
