### PR TITLE
chore(deps) bump azure-functions plugin to 0.3

### DIFF
--- a/kong-1.0.0rc3-0.rockspec
+++ b/kong-1.0.0rc3-0.rockspec
@@ -36,7 +36,7 @@ dependencies = {
   "lua-resty-cookie == 0.1.0",
   "lua-resty-mlcache == 2.2.0",
   -- external Kong plugins
-  "kong-plugin-azure-functions ~> 0.2",
+  "kong-plugin-azure-functions ~> 0.3",
   "kong-plugin-zipkin ~> 0.1",
   "kong-plugin-serverless-functions ~> 0.2",
   "kong-prometheus-plugin ~> 0.3",


### PR DESCRIPTION
* Fix invalid references to functions invoked in the handler module
* Strip connections headers disallowed by HTTP/2
* Restrict the config.run_on field to first

Changelog:

https://github.com/Kong/kong-plugin-azure-functions#history