### PR TITLE
chore(reports) only return arch and OS name

### DIFF
--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -122,7 +122,7 @@ do
       _system_infos.cores = tonumber(stdout:sub(1, -2))
     end
 
-    ok, _, stdout = pl_utils.executeex("uname -a")
+    ok, _, stdout = pl_utils.executeex("uname -ms")
     if ok then
       _system_infos.uname = stdout:gsub(";", ","):sub(1, -2)
     end


### PR DESCRIPTION
Only return architecture and OS name, like `Darwin i386`.