### PR TITLE
hotfix(db) ensure an empty JSON array is returned when no targets

### DIFF
--- a/kong/db/dao/targets.lua
+++ b/kong/db/dao/targets.lua
@@ -176,7 +176,7 @@ function _TARGETS:page_for_upstream(upstream_pk, size, offset, options)
     return nil, err, err_t
   end
 
-  local all_active_targets = setmetatable({}, cjson.empty_array_mt)
+  local all_active_targets = {}
   local seen = {}
   local len = 0
 
@@ -201,7 +201,7 @@ function _TARGETS:page_for_upstream(upstream_pk, size, offset, options)
   end
 
   -- Extract the requested page
-  local page = {}
+  local page = setmetatable({}, cjson.empty_array_mt)
   size = math.min(size or 100, 1000)
   offset = offset or 0
   for i = 1 + offset, size + offset do

--- a/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -249,6 +249,18 @@ describe("Admin API #" .. strategy, function()
           assert.equal(apis[2].target, json.data[3].target)
         end
       end)
+
+      describe("empty results", function()
+        it("data property is an empty array", function()
+          local empty_upstream = bp.upstreams:insert {}
+          local res = assert(client:send {
+            method = "GET",
+            path = "/upstreams/" .. empty_upstream.name .. "/targets",
+          })
+          local body = assert.response(res).has.status(200)
+          assert.match('"data":%[%]', body)
+        end)
+      end)
     end)
   end)
 
@@ -532,6 +544,8 @@ describe("Admin API #" .. strategy, function()
             data = {},
             next = ngx.null,
           }, json)
+          -- ensure JSON representation is correct
+          assert.match('"data":%[%]', body)
         end)
       end)
     end)


### PR DESCRIPTION
When an upstream is created and no targets are added, `GET
/upstreams/:upstream/targets` should return an empty `data` JSON property
in the response as an array.

This change ensure an empty JSON array(`[]`) is returned and not an
empty object(`{}`).

A regression test has been added to ensure we catch this for endpoints:
- `/upstreams/:upstream/targets`
- `/upstreams/:upstream/targets/all`

Fix #4043