### PR TITLE
chore(*) travis to be more explicit about openssl

### DIFF
--- a/.ci/setup_env.sh
+++ b/.ci/setup_env.sh
@@ -102,7 +102,8 @@ fi
 
 export OPENSSL_DIR=$OPENSSL_INSTALL # for LuaSec install
 
-export PATH=$PATH:$OPENRESTY_INSTALL/nginx/sbin:$OPENRESTY_INSTALL/bin:$LUAROCKS_INSTALL/bin:$CPAN_DOWNLOAD
+export PATH=$OPENSSL_INSTALL/bin:$OPENRESTY_INSTALL/nginx/sbin:$OPENRESTY_INSTALL/bin:$LUAROCKS_INSTALL/bin:$CPAN_DOWNLOAD:$PATH
+export LD_LIBRARY_PATH=$OPENSSL_INSTALL/lib:$LD_LIBRARY_PATH
 
 eval `luarocks path`
 
@@ -128,3 +129,4 @@ fi
 nginx -V
 resty -V
 luarocks --version
+openssl version

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ dev:
 	    echo $$rock already installed, skipping ; \
 	  else \
 	    echo $$rock not found, installing via luarocks... ; \
-	    luarocks install $$rock ; \
+	    luarocks install $$rock OPENSSL_DIR=$(OPENSSL_DIR) CRYPTO_DIR=$(OPENSSL_DIR); \
 	  fi \
 	done;
 

--- a/spec-old-api/02-integration/05-proxy/05-ssl_spec.lua
+++ b/spec-old-api/02-integration/05-proxy/05-ssl_spec.lua
@@ -105,15 +105,15 @@ describe("SSL", function()
   describe("handshake", function()
     it("sets the default fallback SSL certificate if no SNI match", function()
       local cert = get_cert("test.com")
-      assert.matches("CN=localhost", cert, nil, true)
+      assert.cn("localhost", cert)
     end)
 
     it("sets the configured SSL certificate if SNI match", function()
       local cert = get_cert("ssl1.com")
-      assert.matches("CN=ssl-example.com", cert, nil, true)
+      assert.cn("ssl-example.com", cert)
 
       cert = get_cert("example.com")
-      assert.matches("CN=ssl-example.com", cert, nil, true)
+      assert.cn("ssl-example.com", cert)
     end)
   end)
 

--- a/spec-old-api/02-integration/06-invalidations/02-core_entities_invalidations_spec.lua
+++ b/spec-old-api/02-integration/06-invalidations/02-core_entities_invalidations_spec.lua
@@ -240,8 +240,8 @@ describe("core entities are invalidated with db: #" .. strategy, function()
 
       -- if you get an error when running these, you likely have an outdated version of openssl installed
       -- to update in osx: https://github.com/Kong/kong/pull/2776#issuecomment-320275043
-      assert.matches("CN=localhost", cert_1, nil, true)
-      assert.matches("CN=localhost", cert_2, nil, true)
+      assert.cn("localhost", cert_1)
+      assert.cn("localhost", cert_2)
     end)
 
     it("on certificate+SNI create", function()
@@ -263,12 +263,12 @@ describe("core entities are invalidated with db: #" .. strategy, function()
       -- because our test instance only has 1 worker
 
       local cert_1 = get_cert(8443, "ssl-example.com")
-      assert.matches("CN=ssl-example.com", cert_1, nil, true)
+      assert.cn("ssl-example.com", cert_1)
 
       wait_for_propagation()
 
       local cert_2 = get_cert(9443, "ssl-example.com")
-      assert.matches("CN=ssl-example.com", cert_2, nil, true)
+      assert.cn("ssl-example.com", cert_2)
     end)
 
     it("on certificate delete+re-creation", function()
@@ -300,18 +300,18 @@ describe("core entities are invalidated with db: #" .. strategy, function()
       -- because our test instance only has 1 worker
 
       local cert_1a = get_cert(8443, "ssl-example.com")
-      assert.matches("CN=localhost", cert_1a, nil, true)
+      assert.cn("localhost", cert_1a)
 
       local cert_1b = get_cert(8443, "new-ssl-example.com")
-      assert.matches("CN=ssl-example.com", cert_1b, nil, true)
+      assert.cn("ssl-example.com", cert_1b)
 
       wait_for_propagation()
 
       local cert_2a = get_cert(9443, "ssl-example.com")
-      assert.matches("CN=localhost", cert_2a, nil, true)
+      assert.cn("localhost", cert_2a)
 
       local cert_2b = get_cert(9443, "new-ssl-example.com")
-      assert.matches("CN=ssl-example.com", cert_2b, nil, true)
+      assert.cn("ssl-example.com", cert_2b)
     end)
 
     it("on certificate update", function()
@@ -335,12 +335,12 @@ describe("core entities are invalidated with db: #" .. strategy, function()
       -- because our test instance only has 1 worker
 
       local cert_1 = get_cert(8443, "new-ssl-example.com")
-      assert.matches("CN=ssl-alt.com", cert_1, nil, true)
+      assert.cn("ssl-alt.com", cert_1)
 
       wait_for_propagation()
 
       local cert_2 = get_cert(9443, "new-ssl-example.com")
-      assert.matches("CN=ssl-alt.com", cert_2, nil, true)
+      assert.cn("ssl-alt.com", cert_2)
     end)
 
     pending("on SNI update", function()
@@ -369,10 +369,10 @@ describe("core entities are invalidated with db: #" .. strategy, function()
       -- because our test instance only has 1 worker
 
       local cert_1_old_sni = get_cert(8443, "new-ssl-example.com")
-      assert.matches("CN=localhost", cert_1_old_sni, nil, true)
+      assert.cn("localhost", cert_1_old_sni)
 
       local cert_1_new_sni = get_cert(8443, "updated-sni.com")
-      assert.matches("CN=updated-sni.com", cert_1_new_sni, nil, true)
+      assert.cn("updated-sni.com", cert_1_new_sni)
     end)
 
     it("on certificate delete", function()
@@ -395,12 +395,12 @@ describe("core entities are invalidated with db: #" .. strategy, function()
       -- because our test instance only has 1 worker
 
       local cert_1 = get_cert(8443, "new-ssl-example.com")
-      assert.matches("CN=localhost", cert_1, nil, true)
+      assert.cn("localhost", cert_1)
 
       wait_for_propagation()
 
       local cert_2 = get_cert(9443, "new-ssl-example.com")
-      assert.matches("CN=localhost", cert_2, nil, true)
+      assert.cn("localhost", cert_2)
     end)
   end)
 

--- a/spec/02-integration/06-invalidations/02-core_entities_invalidations_spec.lua
+++ b/spec/02-integration/06-invalidations/02-core_entities_invalidations_spec.lua
@@ -26,6 +26,7 @@ for _, strategy in helpers.each_strategy() do
         "services",
         "plugins",
         "certificates",
+        "snis",
       })
 
       -- insert single fixture Service
@@ -490,12 +491,12 @@ for _, strategy in helpers.each_strategy() do
         -- because our test instance only has 1 worker
 
         local cert_1 = get_cert(8443, "new-ssl-example.com")
-        assert.cn("ssl-alt.com", cert_1, nil, true)
+        assert.cn("ssl-alt.com", cert_1)
 
         wait_for_propagation()
 
         local cert_2 = get_cert(9443, "new-ssl-example.com")
-        assert.cn("ssl-alt.com", cert_2, nil, true)
+        assert.cn("ssl-alt.com", cert_2)
       end)
 
       it("on sni update via id", function()
@@ -510,18 +511,18 @@ for _, strategy in helpers.each_strategy() do
         assert.res_status(200, admin_res)
 
         local cert_1_old = get_cert(8443, "new-ssl-example.com")
-        assert.cn("localhost", cert_1_old, nil, true)
+        assert.cn("localhost", cert_1_old)
 
         local cert_1_new = get_cert(8443, "updated-sn-via-id.com")
-        assert.cn("ssl-alt.com", cert_1_new, nil, true)
+        assert.cn("ssl-alt.com", cert_1_new)
 
         wait_for_propagation()
 
         local cert_2_old = get_cert(9443, "new-ssl-example.com")
-        assert.cn("localhost", cert_2_old, nil, true)
+        assert.cn("localhost", cert_2_old)
 
         local cert_2_new = get_cert(9443, "updated-sn-via-id.com")
-        assert.cn("ssl-alt.com", cert_2_new, nil, true)
+        assert.cn("ssl-alt.com", cert_2_new)
       end)
 
       it("on sni update via name", function()
@@ -532,18 +533,18 @@ for _, strategy in helpers.each_strategy() do
         assert.res_status(200, admin_res)
 
         local cert_1_old = get_cert(8443, "updated-sn-via-id.com")
-        assert.cn("localhost", cert_1_old, nil, true)
+        assert.cn("localhost", cert_1_old)
 
         local cert_1_new = get_cert(8443, "updated-sn.com")
-        assert.cn("ssl-alt.com", cert_1_new, nil, true)
+        assert.cn("ssl-alt.com", cert_1_new)
 
         wait_for_propagation()
 
         local cert_2_old = get_cert(9443, "updated-sn-via-id.com")
-        assert.cn("localhost", cert_2_old, nil, true)
+        assert.cn("localhost", cert_2_old)
 
         local cert_2_new = get_cert(9443, "updated-sn.com")
-        assert.cn("ssl-alt.com", cert_2_new, nil, true)
+        assert.cn("ssl-alt.com", cert_2_new)
       end)
 
       it("on certificate delete", function()
@@ -556,12 +557,12 @@ for _, strategy in helpers.each_strategy() do
         -- because our test instance only has 1 worker
 
         local cert_1 = get_cert(8443, "updated-sn.com")
-        assert.cn("localhost", cert_1, nil, true)
+        assert.cn("localhost", cert_1)
 
         wait_for_propagation()
 
         local cert_2 = get_cert(9443, "updated-sn.com")
-        assert.cn("localhost", cert_2, nil, true)
+        assert.cn("localhost", cert_2)
       end)
     end)
 


### PR DESCRIPTION
### Summary

This should fix the `next` branch failing on Travis. It now explicitly sets the `openssl` and uses our `assert.cn` instead of `assert.matches`.