### PR TITLE
fix(pdk) make kong.request.get_body() to return nil, err on simple json values

### DIFF
--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -638,7 +638,7 @@ local function new(self)
       cjson.decode_array_with_array_mt(true)
       local json = cjson.decode(body)
       cjson.decode_array_with_array_mt(false)
-      if not json then
+      if type(json) ~= "table" then
         return nil, "invalid json body", CONTENT_TYPE_JSON
       end
 

--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -500,9 +500,6 @@ local function parse_access_token(conf)
   local found_in = {}
   local access_token = kong.request.get_header(conf.auth_header_name)
   if access_token then
-    if type(access_token) == "table" then --Take the first found
-      access_token = access_token[1]
-    end
     local parts = {}
     for v in access_token:gmatch("%S+") do -- Split by space
       table.insert(parts, v)
@@ -513,6 +510,9 @@ local function parse_access_token(conf)
     end
   else
     access_token = retrieve_parameters()[ACCESS_TOKEN]
+    if type(access_token) ~= "string" then
+      return
+    end
   end
 
   if conf.hide_credentials then

--- a/t/01-pdk/04-request/16-get_body.t
+++ b/t/01-pdk/04-request/16-get_body.t
@@ -174,7 +174,227 @@ error: invalid json body
 
 
 
-=== TEST 7: request.get_body() content type value is case-insensitive
+=== TEST 7: request.get_body() returns error with null json body
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            local json, err = pdk.request.get_body()
+
+            ngx.say("type: ", type(json))
+            ngx.say("error: ", err)
+        }
+    }
+--- request
+POST /t
+null
+--- more_headers
+Content-Type: application/json
+--- response_body
+type: nil
+error: invalid json body
+--- no_error_log
+[error]
+
+
+
+=== TEST 8: request.get_body() returns error with string json body
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            local json, err = pdk.request.get_body()
+
+            ngx.say("type: ", type(json))
+            ngx.say("error: ", err)
+        }
+    }
+--- request
+POST /t
+"test"
+--- more_headers
+Content-Type: application/json
+--- response_body
+type: nil
+error: invalid json body
+--- no_error_log
+[error]
+
+
+
+=== TEST 9: request.get_body() returns error with number json body
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            local json, err = pdk.request.get_body()
+
+            ngx.say("type: ", type(json))
+            ngx.say("error: ", err)
+        }
+    }
+--- request
+POST /t
+123
+--- more_headers
+Content-Type: application/json
+--- response_body
+type: nil
+error: invalid json body
+--- no_error_log
+[error]
+
+
+
+=== TEST 10: request.get_body() returns error with number (float) json body
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            local json, err = pdk.request.get_body()
+
+            ngx.say("type: ", type(json))
+            ngx.say("error: ", err)
+        }
+    }
+--- request
+POST /t
+123.23
+--- more_headers
+Content-Type: application/json
+--- response_body
+type: nil
+error: invalid json body
+--- no_error_log
+[error]
+
+
+
+=== TEST 11: request.get_body() returns error with boolean true json body
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            local json, err = pdk.request.get_body()
+
+            ngx.say("type: ", type(json))
+            ngx.say("error: ", err)
+        }
+    }
+--- request
+POST /t
+true
+--- more_headers
+Content-Type: application/json
+--- response_body
+type: nil
+error: invalid json body
+--- no_error_log
+[error]
+
+
+
+=== TEST 12: request.get_body() returns error with boolean false json body
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            local json, err = pdk.request.get_body()
+
+            ngx.say("type: ", type(json))
+            ngx.say("error: ", err)
+        }
+    }
+--- request
+POST /t
+false
+--- more_headers
+Content-Type: application/json
+--- response_body
+type: nil
+error: invalid json body
+--- no_error_log
+[error]
+
+
+
+=== TEST 13: request.get_body() returns empty object json body as table without metatable
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            local json, err = pdk.request.get_body()
+
+            ngx.say("type: ", type(json))
+            ngx.say("meta: ", type(getmetatable(json)))
+            ngx.say("error: ", type(err))
+        }
+    }
+--- request
+POST /t
+{}
+--- more_headers
+Content-Type: application/json
+--- response_body
+type: table
+meta: nil
+error: nil
+--- no_error_log
+[error]
+
+
+
+=== TEST 14: request.get_body() returns empty array json body as table with metatable
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            local json, err = pdk.request.get_body()
+
+            ngx.say("type: ", type(json))
+            ngx.say("meta: ", getmetatable(json) == require "cjson".array_mt and "correct" or "incorrect")
+            ngx.say("error: ", type(err))
+        }
+    }
+--- request
+POST /t
+[]
+--- more_headers
+Content-Type: application/json
+--- response_body
+type: table
+meta: correct
+error: nil
+--- no_error_log
+[error]
+
+
+
+=== TEST 15: request.get_body() content type value is case-insensitive
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -203,7 +423,7 @@ mime=application/x-www-form-urlencoded
 
 
 
-=== TEST 8: request.get_body() with application/x-www-form-urlencoded returns request post arguments
+=== TEST 16: request.get_body() with application/x-www-form-urlencoded returns request post arguments
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -231,7 +451,7 @@ Accept: application/json, text/html
 
 
 
-=== TEST 9: request.get_body() with application/x-www-form-urlencoded returns empty table with header Content-Length: 0
+=== TEST 17: request.get_body() with application/x-www-form-urlencoded returns empty table with header Content-Length: 0
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -255,7 +475,7 @@ next: nil
 
 
 
-=== TEST 10: request.get_body() with application/x-www-form-urlencoded returns request post arguments case-sensitive
+=== TEST 18: request.get_body() with application/x-www-form-urlencoded returns request post arguments case-sensitive
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -283,7 +503,7 @@ fOO: Too
 
 
 
-=== TEST 11: request.get_body() with application/x-www-form-urlencoded fetches 100 post arguments by default
+=== TEST 19: request.get_body() with application/x-www-form-urlencoded fetches 100 post arguments by default
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -320,7 +540,7 @@ number of query arguments fetched: 100
 
 
 
-=== TEST 12: request.get_body() with application/x-www-form-urlencoded fetches max_args argument
+=== TEST 20: request.get_body() with application/x-www-form-urlencoded fetches max_args argument
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -357,7 +577,7 @@ number of query arguments fetched: 60
 
 
 
-=== TEST 13: request.get_body() with application/x-www-form-urlencoded raises error when trying to fetch with max_args invalid value
+=== TEST 21: request.get_body() with application/x-www-form-urlencoded raises error when trying to fetch with max_args invalid value
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -379,7 +599,7 @@ error: max_args must be a number
 
 
 
-=== TEST 14: request.get_body() with application/x-www-form-urlencoded raises error when trying to fetch with max_args < 1
+=== TEST 22: request.get_body() with application/x-www-form-urlencoded raises error when trying to fetch with max_args < 1
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -401,7 +621,7 @@ error: max_args must be >= 1
 
 
 
-=== TEST 15: request.get_body() with application/x-www-form-urlencoded raises error when trying to fetch with max_args > 1000
+=== TEST 23: request.get_body() with application/x-www-form-urlencoded raises error when trying to fetch with max_args > 1000
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -423,7 +643,7 @@ error: max_args must be <= 1000
 
 
 
-=== TEST 16: request.get_body() with application/x-www-form-urlencoded returns nil + error when the body is too big
+=== TEST 24: request.get_body() with application/x-www-form-urlencoded returns nil + error when the body is too big
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {


### PR DESCRIPTION
### Summary

Changes `kong.request.get_body()` to return `nil, err` on `application/json` simple types as a root (and only) content:
- strings
- numbers
- booleans
- nulls

So you can after this is merged only use this to read following JSON content:
- arrays
- objects

as a root content.

Fix #4007 
