### PR TITLE
feat(core) add ctx.is_service_mesh_request context value with tls mesh

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -651,6 +651,7 @@ return {
         -- Is probably an incoming service mesh connection
         -- terminate service-mesh Mutual TLS
         ssl_termination_ctx = mesh.mesh_server_ssl_ctx
+        ctx.is_service_mesh_request = true
       else
         -- TODO: stream router should decide if TLS is terminated or not
         -- XXX: for now, use presence of SNI to terminate.


### PR DESCRIPTION
### Summary

This PR makes it possible for code to check if the Kong node is running as a `service-mesh` node or not with `mutual tls` connection between two Kong nodes in a same cluster using stream module.