### PR TITLE
feat(core) enable plugin.run_on support on plugins iterator

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -621,7 +621,7 @@ return {
       ctx.KONG_REWRITE_START = get_now()
       mesh.rewrite()
     end,
-    after = function (ctx)
+    after = function(ctx)
       ctx.KONG_REWRITE_TIME = get_now() - ctx.KONG_REWRITE_START -- time spent in Kong's rewrite_by_lua
     end
   },

--- a/kong/runloop/mesh.lua
+++ b/kong/runloop/mesh.lua
@@ -192,16 +192,16 @@ local function certificate()
 end
 
 
-local function rewrite()
+local function rewrite(ctx)
   local ssl = getssl()
   if ssl and ssl:getAlpnSelected() == mesh_alpn then
-    if ngx.ctx.is_service_mesh_request then
+    if ctx.is_service_mesh_request then
       ngx.log(ngx.ERR, "already service mesh; circular routing?")
       return ngx.exit(500)
     end
 
     -- Assume OpenSSL verification worked
-    ngx.ctx.is_service_mesh_request = true
+    ctx.is_service_mesh_request = true
 
     -- Fixup Host
     -- Unless the route had preserve_host set then the host on the request has

--- a/kong/runloop/plugins_iterator.lua
+++ b/kong/runloop/plugins_iterator.lua
@@ -45,16 +45,31 @@ local function load_plugin_configuration(ctx,
     return ngx.exit(ngx.ERROR)
   end
 
-  if plugin ~= nil and plugin.enabled then
-    local cfg = plugin.config or {}
-
-    cfg.api_id      = plugin.api and plugin.api.id
-    cfg.route_id    = plugin.route and plugin.route.id
-    cfg.service_id  = plugin.service and plugin.service.id
-    cfg.consumer_id = plugin.consumer and plugin.consumer.id
-
-    return cfg
+  if not plugin or not plugin.enabled then
+    return
   end
+
+  if plugin.run_on ~= "all" then
+    if ctx.is_service_mesh_request then
+      if plugin.run_on == "first" then
+        return
+      end
+
+    else
+      if plugin.run_on == "second" then
+        return
+      end
+    end
+  end
+
+  local cfg = plugin.config or {}
+
+  cfg.api_id      = plugin.api and plugin.api.id
+  cfg.route_id    = plugin.route and plugin.route.id
+  cfg.service_id  = plugin.service and plugin.service.id
+  cfg.consumer_id = plugin.consumer and plugin.consumer.id
+
+  return cfg
 end
 
 


### PR DESCRIPTION
### Summary

This will add support for `run_on` attribute on Plugins to make them run on:
1. `all` Kong nodes regardless
2. `first` Kong node in `gateway` or `service-mesh` modes only
3. `second` Kong node in `service-mesh` mode only

This is manually tested to be working with latest (not yet released) `luaossl` and our (released) `openresty-patches`, but this does not include `busted` tests yet. If that is a blocker for `release` of a release candidate, then I will update this PR on monday.