### PR TITLE
chore(deps) bump luaossl to 20181207

### DIFF
--- a/kong-1.0.0rc3-0.rockspec
+++ b/kong-1.0.0rc3-0.rockspec
@@ -26,7 +26,7 @@ dependencies = {
   "http == 0.2",
   "lua_system_constants == 0.1.2",
   "lua-resty-iputils == 0.3.0",
-  "luaossl == 20181102",
+  "luaossl == 20181207",
   "luasyslog == 1.0.0",
   "lua_pack == 1.0.5",
   "lua-resty-dns-client == 2.2.0",


### PR DESCRIPTION
### Summary

Bumps `luaossl` to latest. Makes #4066 work (edit: almost).