### PR TITLE
fix(mesh) set up SSL_CTX in the init phase

### DIFF
--- a/kong-1.0.0rc3-0.rockspec
+++ b/kong-1.0.0rc3-0.rockspec
@@ -67,6 +67,7 @@ build = {
     ["kong.templates.kong_defaults"] = "kong/templates/kong_defaults.lua",
 
     ["kong.resty.ctx"] = "kong/resty/ctx.lua",
+    ["kong.resty.config"] = "kong/resty/config.lua",
     ["kong.resty.getssl"] = "kong/resty/getssl.lua",
     ["kong.vendor.classic"] = "kong/vendor/classic.lua",
 

--- a/kong/resty/config.lua
+++ b/kong/resty/config.lua
@@ -1,0 +1,64 @@
+local ffi = require "ffi"
+local openssl_ssl_context = require "openssl.ssl.context"
+
+local has_patch = pcall(ffi.cdef, [[
+  void* ngx_http_lua_get_server_block(uintptr_t);
+  ngx_str_t* ngx_http_lua_server_block_server_name(void*);
+  SSL_CTX* ngx_http_lua_ssl_get_SSL_CTX(void*);
+]])
+
+
+local ngx_lua_get_server_block
+local ngx_lua_server_block_server_name
+local ngx_lua_get_SSL_CTX
+if has_patch and ngx.config.subsystem == "http" then
+  ngx_lua_get_server_block = ffi.C.ngx_http_lua_get_server_block
+  ngx_lua_server_block_server_name = ffi.C.ngx_http_lua_server_block_server_name
+  ngx_lua_get_SSL_CTX = ffi.C.ngx_http_lua_ssl_get_SSL_CTX
+
+else
+  ngx_lua_get_server_block = function()
+    error("could not get server block (missing ffi interfaces from server_conf patch)")
+  end
+end
+
+
+local function get_server_block(i)
+  local srv_ptr = ngx_lua_get_server_block(i)
+  if srv_ptr == nil then
+    return nil
+  end
+  return {
+    get_ssl_ctx = function()
+      local ptr = ngx_lua_get_SSL_CTX(srv_ptr)
+      if ptr == nil then
+        return nil
+      end
+      return openssl_ssl_context.pushffi(ptr)
+    end,
+    get_server_name = function()
+      local str = ngx_lua_server_block_server_name(srv_ptr)
+      return ffi.string(str.data, str.len)
+    end,
+  }
+end
+
+
+local function each_server_block()
+  local i = 0
+  return function()
+    local srv = get_server_block(i)
+    if srv == nil then
+      return nil
+    end
+    i = i + 1
+    return srv
+  end
+end
+
+
+return {
+  can_get_server_block = has_patch,
+  get_server_block = get_server_block,
+  each_server_block = each_server_block,
+}

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -612,7 +612,6 @@ return {
   },
   certificate = {
     before = function(_)
-      mesh.certificate()
       certificate.execute()
     end
   },


### PR DESCRIPTION
With OpenSSL 1.1.1 setting up the `SSL_CTX*` in the certificate
phase no longer works.

This commit introduces a new kong.resty.config module which
uses the patches at https://github.com/Kong/openresty-patches/pull/31 and https://github.com/Kong/openresty-patches/pull/32
