### PR TITLE
feat(migrations) add --force flag

### DIFF
--- a/kong/cmd/migrations.lua
+++ b/kong/cmd/migrations.lua
@@ -29,6 +29,9 @@ Options:
 
  -q,--quiet                         Suppress all output.
 
+ -f,--force                         Run migrations even if database reports
+                                    as already executed.
+
  --db-timeout     (default 60)      Timeout, in seconds, for all database
                                     operations (including schema consensus for
                                     Cassandra).
@@ -131,11 +134,15 @@ local function execute(args)
   elseif args.command == "up" then
     migrations_utils.up(schema_state, db, {
       ttl = args.lock_timeout,
+      force = args.force,
       abort = true, -- exit the mutex if another node acquired it
     })
 
   elseif args.command == "finish" then
-    migrations_utils.finish(schema_state, db, args.lock_timeout)
+    migrations_utils.finish(schema_state, db, {
+      ttl = args.lock_timeout,
+      force = args.force,
+    })
 
   else
     error("unreachable")

--- a/kong/db/migrations/core/001_14_to_15.lua
+++ b/kong/db/migrations/core/001_14_to_15.lua
@@ -4,8 +4,29 @@ return {
       DO $$
       BEGIN
         ALTER TABLE IF EXISTS ONLY "routes" ADD "name" TEXT UNIQUE;
-        ALTER TABLE IF EXISTS ONLY "routes" ADD "snis" TEXT[];
+      EXCEPTION WHEN DUPLICATE_COLUMN THEN
+        -- Do nothing, accept existing state
+      END;
+      $$;
+
+      DO $$
+      BEGIN
+        ALTER TABLE IF EXISTS "routes" ADD "snis" TEXT[];
+      EXCEPTION WHEN DUPLICATE_COLUMN THEN
+        -- Do nothing, accept existing state
+      END;
+      $$;
+
+      DO $$
+      BEGIN
         ALTER TABLE IF EXISTS ONLY "routes" ADD "sources" JSONB[];
+      EXCEPTION WHEN DUPLICATE_COLUMN THEN
+        -- Do nothing, accept existing state
+      END;
+      $$;
+
+      DO $$
+      BEGIN
         ALTER TABLE IF EXISTS ONLY "routes" ADD "destinations" JSONB[];
       EXCEPTION WHEN DUPLICATE_COLUMN THEN
         -- Do nothing, accept existing state
@@ -21,8 +42,24 @@ return {
       DO $$
       BEGIN
         ALTER TABLE IF EXISTS ONLY "plugins"
-          DROP CONSTRAINT IF EXISTS "plugins_pkey",
-          DROP CONSTRAINT IF EXISTS "plugins_id_key",
+          DROP CONSTRAINT IF EXISTS "plugins_pkey";
+      EXCEPTION WHEN DUPLICATE_TABLE OR INVALID_TABLE_DEFINITION THEN
+          -- Do nothing, accept existing state
+      END;
+      $$;
+
+      DO $$
+      BEGIN
+        ALTER TABLE IF EXISTS ONLY "plugins"
+          DROP CONSTRAINT IF EXISTS "plugins_id_key";
+      EXCEPTION WHEN DUPLICATE_TABLE OR INVALID_TABLE_DEFINITION THEN
+          -- Do nothing, accept existing state
+      END;
+      $$;
+
+      DO $$
+      BEGIN
+        ALTER TABLE IF EXISTS ONLY "plugins"
           ADD PRIMARY KEY ("id");
       EXCEPTION WHEN DUPLICATE_TABLE OR INVALID_TABLE_DEFINITION THEN
           -- Do nothing, accept existing state
@@ -196,6 +233,7 @@ return {
       ALTER TABLE routes ADD snis set<text>;
       ALTER TABLE routes ADD sources set<text>;
       ALTER TABLE routes ADD destinations set<text>;
+      ALTER TABLE plugins ADD run_on text;
       CREATE INDEX IF NOT EXISTS routes_name_idx ON routes(name);
 
 


### PR DESCRIPTION
Adds a `--force` flag to `kong migrations up` to allow for migrating from one release candidate to the next (since the name of the migration file is unchanged). 

A more robust solution should be in place for future rc cycles, but this might be sufficient for now. Tested locally by:

1. checking out 1.0.0rc2
2. resetting/migrating the database
3. checking out `next`
4. running `kong migrations up --force`
5. running the test suite

Verified to fail with the errors seen by users when skipping step 4 and to work with Postgres and Cassandra when including it.

See #4033, #4042, #4049.