### PR TITLE
fix(core) move pcall to correct location

### DIFF
--- a/kong/runloop/mesh.lua
+++ b/kong/runloop/mesh.lua
@@ -163,7 +163,7 @@ local function init()
         end
       end
     else
-      ngx.log(ngx.INFO, "Nginx server block API unavailable. mesh will not be"
+      ngx.log(ngx.INFO, "Nginx server block API unavailable. mesh will not be "
                      .. "negotiated for incoming HTTP connections to this node")
     end
   else -- stream


### PR DESCRIPTION
`ffi.cdef` doesn't throw unless the type is missing, instead the `pcall` needs to be around the index of `ffi.C`

This fixes an error when openresty-patches is not applied