### PR TITLE
fix(admin) avoid Lapis handler when handler doesn't exit explicitly

### DIFF
--- a/kong/api/endpoints.lua
+++ b/kong/api/endpoints.lua
@@ -240,7 +240,7 @@ local function post_collection_endpoint(schema, foreign_schema, foreign_field_na
     if post_process then
       entity, _, err_t = post_process(entity)
       if err_t then
-        handle_error(err_t)
+        return handle_error(err_t)
       end
     end
 

--- a/kong/api/init.lua
+++ b/kong/api/init.lua
@@ -44,7 +44,12 @@ local function parse_params(fn)
 
     self.params = api_helpers.normalize_nested_params(self.params)
 
-    return fn(self, ...)
+    local res = fn(self, ...)
+    if res == nil and ngx.status >= 200 then
+      return ngx.exit(0)
+    end
+
+    return res
   end)
 end
 

--- a/spec/02-integration/04-admin_api/25-plugin-endpoints.lua
+++ b/spec/02-integration/04-admin_api/25-plugin-endpoints.lua
@@ -1,0 +1,46 @@
+local helpers = require "spec.helpers"
+
+
+for _, strategy in helpers.each_strategy() do
+
+describe("Admin API endpoints added via plugins #" .. strategy, function()
+  local client
+
+  setup(function()
+    local bp = helpers.get_db_utils(strategy, {
+      "plugins",
+    }, {
+      "admin-api-method"
+    })
+
+    bp.plugins:insert({
+      name = "admin-api-method",
+    })
+
+    assert(helpers.start_kong({
+      database = strategy,
+      nginx_conf = "spec/fixtures/custom_nginx.template",
+      plugins = "admin-api-method",
+    }))
+    client = helpers.admin_client()
+  end)
+
+  teardown(function()
+    if client then
+      client:close()
+    end
+    helpers.stop_kong()
+  end)
+
+  it("a method without an explicit exit does not add Lapis output", function()
+    local res = assert(client:send {
+      method = "GET",
+      path = "/method_without_exit",
+      headers = { ["Content-Type"] = "application/json" }
+    })
+    local body = assert.res_status(201 , res)
+    assert.same("hello", body)
+  end)
+end)
+
+end

--- a/spec/fixtures/custom_plugins/kong/plugins/admin-api-method/api.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/admin-api-method/api.lua
@@ -1,0 +1,9 @@
+return {
+  ["/method_without_exit"] = {
+    GET = function()
+      kong.response.set_status(201)
+      kong.response.set_header("x-foo", "bar")
+      ngx.print("hello")
+    end,
+  },
+}

--- a/spec/fixtures/custom_plugins/kong/plugins/admin-api-method/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/admin-api-method/handler.lua
@@ -1,0 +1,16 @@
+-- a plugin fixture to test a method on the admin api
+local BasePlugin = require "kong.plugins.base_plugin"
+
+
+local AdminApiMethod = BasePlugin:extend()
+
+
+AdminApiMethod.PRIORITY = 1000
+
+
+function AdminApiMethod:new()
+  AdminApiMethod.super.new(self, "admin-api-method")
+end
+
+
+return AdminApiMethod

--- a/spec/fixtures/custom_plugins/kong/plugins/admin-api-method/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/admin-api-method/schema.lua
@@ -1,0 +1,5 @@
+return {
+  fields = {
+    foo = { type = "string" }
+  }
+}


### PR DESCRIPTION
If an Admin API handler did not exit explicitly using `kong.response.exit` (or
`ngx.exit`), it would end up concatenating HTML produced by Lapis (for an
example of this behavior, remove `kong.response.exit(200)` from the `collect`
function in kong-prometheus-plugin 0.3.2).

This ensures that only the handler function executes without falling into
Lapis.

Includes a plugin fixture and a regression test.