### PR TITLE
chore(*) bump bundled plugins to version 1.0.0 (symbolic)

### DIFF
--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -250,7 +250,7 @@ end
 
 
 AWSLambdaHandler.PRIORITY = 750
-AWSLambdaHandler.VERSION = "0.1.1"
+AWSLambdaHandler.VERSION = "1.0.0"
 
 
 return AWSLambdaHandler

--- a/kong/plugins/bot-detection/handler.lua
+++ b/kong/plugins/bot-detection/handler.lua
@@ -9,7 +9,7 @@ local re_find = ngx.re.find
 local BotDetectionHandler = BasePlugin:extend()
 
 BotDetectionHandler.PRIORITY = 2500
-BotDetectionHandler.VERSION = "0.1.0"
+BotDetectionHandler.VERSION = "1.0.0"
 
 local BAD_REQUEST = 400
 local FORBIDDEN = 403

--- a/kong/plugins/datadog/handler.lua
+++ b/kong/plugins/datadog/handler.lua
@@ -13,7 +13,7 @@ local NGX_ERR       = ngx.ERR
 
 local DatadogHandler    = BasePlugin:extend()
 DatadogHandler.PRIORITY = 10
-DatadogHandler.VERSION = "0.1.0"
+DatadogHandler.VERSION = "1.0.0"
 
 
 local get_consumer_id = {

--- a/kong/plugins/file-log/handler.lua
+++ b/kong/plugins/file-log/handler.lua
@@ -61,7 +61,7 @@ end
 local FileLogHandler = BasePlugin:extend()
 
 FileLogHandler.PRIORITY = 9
-FileLogHandler.VERSION = "0.1.0"
+FileLogHandler.VERSION = "1.0.0"
 
 function FileLogHandler:new()
   FileLogHandler.super.new(self, "file-log")

--- a/kong/plugins/http-log/handler.lua
+++ b/kong/plugins/http-log/handler.lua
@@ -15,7 +15,7 @@ local HttpLogHandler = BasePlugin:extend()
 
 
 HttpLogHandler.PRIORITY = 12
-HttpLogHandler.VERSION = "0.1.0"
+HttpLogHandler.VERSION = "1.0.0"
 
 
 local buffers = {} -- buffers per-route

--- a/kong/plugins/ip-restriction/handler.lua
+++ b/kong/plugins/ip-restriction/handler.lua
@@ -12,7 +12,7 @@ local cache = {}
 local IpRestrictionHandler = BasePlugin:extend()
 
 IpRestrictionHandler.PRIORITY = 990
-IpRestrictionHandler.VERSION = "0.1.0"
+IpRestrictionHandler.VERSION = "1.0.0"
 
 local function cidr_cache(cidr_tab)
   local cidr_tab_len = #cidr_tab

--- a/kong/plugins/loggly/handler.lua
+++ b/kong/plugins/loggly/handler.lua
@@ -5,7 +5,7 @@ local cjson = require "cjson"
 local LogglyLogHandler = BasePlugin:extend()
 
 LogglyLogHandler.PRIORITY = 6
-LogglyLogHandler.VERSION = "0.1.0"
+LogglyLogHandler.VERSION = "1.0.0"
 
 local os_date = os.date
 local tostring = tostring

--- a/kong/plugins/request-size-limiting/handler.lua
+++ b/kong/plugins/request-size-limiting/handler.lua
@@ -9,7 +9,7 @@ local MB = 2^20
 local RequestSizeLimitingHandler = BasePlugin:extend()
 
 RequestSizeLimitingHandler.PRIORITY = 951
-RequestSizeLimitingHandler.VERSION = "0.1.0"
+RequestSizeLimitingHandler.VERSION = "1.0.0"
 
 local function check_size(length, allowed_size, headers)
   local allowed_bytes_size = allowed_size * MB

--- a/kong/plugins/request-termination/handler.lua
+++ b/kong/plugins/request-termination/handler.lua
@@ -22,7 +22,7 @@ local RequestTerminationHandler = BasePlugin:extend()
 
 
 RequestTerminationHandler.PRIORITY = 2
-RequestTerminationHandler.VERSION = "0.2.0"
+RequestTerminationHandler.VERSION = "1.0.0"
 
 
 function RequestTerminationHandler:new()

--- a/kong/plugins/statsd/handler.lua
+++ b/kong/plugins/statsd/handler.lua
@@ -13,7 +13,7 @@ local NGX_ERR       = ngx.ERR
 
 local StatsdHandler = BasePlugin:extend()
 StatsdHandler.PRIORITY = 11
-StatsdHandler.VERSION = "0.1.0"
+StatsdHandler.VERSION = "1.0.0"
 
 
 local get_consumer_id = {

--- a/kong/plugins/syslog/handler.lua
+++ b/kong/plugins/syslog/handler.lua
@@ -12,7 +12,7 @@ local string_upper = string.upper
 local SysLogHandler = BasePlugin:extend()
 
 SysLogHandler.PRIORITY = 4
-SysLogHandler.VERSION = "0.1.0"
+SysLogHandler.VERSION = "1.0.0"
 
 local SENDER_NAME = "kong"
 

--- a/kong/plugins/tcp-log/handler.lua
+++ b/kong/plugins/tcp-log/handler.lua
@@ -5,7 +5,7 @@ local cjson = require "cjson"
 local TcpLogHandler = BasePlugin:extend()
 
 TcpLogHandler.PRIORITY = 7
-TcpLogHandler.VERSION = "0.1.0"
+TcpLogHandler.VERSION = "1.0.0"
 
 local function log(premature, conf, message)
   if premature then

--- a/kong/plugins/udp-log/handler.lua
+++ b/kong/plugins/udp-log/handler.lua
@@ -8,7 +8,7 @@ local udp = ngx.socket.udp
 local UdpLogHandler = BasePlugin:extend()
 
 UdpLogHandler.PRIORITY = 8
-UdpLogHandler.VERSION = "0.1.0"
+UdpLogHandler.VERSION = "1.0.0"
 
 local function log(premature, conf, str)
   if premature then


### PR DESCRIPTION
### Summary

Bumps all bundled plugins to `1.0.0` as a symbolic bump for `1.0.0` release.