### PR TITLE
fix(db) store connection in request-aware context

### DIFF
--- a/kong/db/strategies/connector.lua
+++ b/kong/db/strategies/connector.lua
@@ -16,6 +16,39 @@ function Connector:init_worker()
 end
 
 
+do
+  local past_init
+  local ngx = ngx
+
+
+  function Connector:store_connection(conn)
+    if not past_init and ngx and ngx.get_phase() ~= "init" then
+      past_init = true
+    end
+
+    if ngx and past_init then
+      ngx.ctx.connection = conn
+
+    else
+      self.connection = conn
+    end
+  end
+
+
+  function Connector:get_stored_connection()
+    if not past_init and ngx and ngx.get_phase() ~= "init" then
+      past_init = true
+    end
+
+    if ngx and past_init then
+      return ngx.ctx.connection
+    end
+
+    return self.connection
+  end
+end
+
+
 function Connector:infos()
   error(fmt("infos() not implemented for '%s' strategy", self.database))
 end

--- a/kong/db/strategies/init.lua
+++ b/kong/db/strategies/init.lua
@@ -31,7 +31,16 @@ function _M.new(kong_config, strategy, schemas, errors)
   do
     local base_connector = require "kong.db.strategies.connector"
     local mt = getmetatable(connector)
-    setmetatable(mt, { __index = base_connector })
+    setmetatable(mt, {
+      __index = function(t, k)
+        -- explicit parent
+        if k == "super" then
+          return base_connector
+        end
+
+        return base_connector[k]
+      end
+    })
   end
 
   local strategies = {}


### PR DESCRIPTION
Calling `db:connect()` used to store the connection in as an instance
attribute in `self`, therefore in a worker singleton (`kong.db`), which
would produce `bad request` errors when used at runtime (i.e.
non-migration contexts).

This error presents itself when within the `plugins:select_by_cache_key`
special DAO method, in which the schema_state module performs a
`connect()` and subsequent operations to determine the database schema
state.

Storing the connection object in the request aware context (`ngx.ctx`)
prevents this issue. We still store the connection as an instance
attribute in non-request contexts.