### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -705,7 +705,7 @@ end
 local function check()
   local ok, err = do_thing()
   if not ok then
-    return nil, "could not do thing: " .. err
+    return nil, "could not do thing : " .. err
   end
 
   return true


### PR DESCRIPTION
there should be space between "things" and ":" . Because it is a good code habit.

NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

### Summary

SUMMARY_GOES_HERE

### Full changelog

* [Implement ...]
* [Add related tests]
* ...

### Issues resolved

Fix #XXX
