### PR TITLE
feat: router mutex fallthrough

### DIFF
--- a/spec/01-unit/018-runloop_handler_spec.lua
+++ b/spec/01-unit/018-runloop_handler_spec.lua
@@ -6,9 +6,25 @@ describe("runloop handler", function()
       routes = {}
     }
 
+    do
+      local _ngx = _G.ngx
+
+      _G.ngx = setmetatable({
+        log = function()
+          -- avoid stdout output during test
+        end,
+      }, { __index = _ngx })
+
+      finally(function()
+        _G.ngx = _ngx
+      end)
+    end
+
     local function mock_module(name, tbl)
       local old_module = require(name)
-      package.loaded[name] = tbl
+      package.loaded[name] = setmetatable(tbl, {
+        __index = old_module,
+      })
       finally(function()
         package.loaded[name] = old_module
       end)

--- a/spec/01-unit/018-runloop_handler_spec.lua
+++ b/spec/01-unit/018-runloop_handler_spec.lua
@@ -56,12 +56,13 @@ describe("runloop handler", function()
       new = function()
         local s = {
           value = 0,
-          wait = function(self)
+          wait = function(self, timeout)
             self.value = self.value - 1
             return true
           end,
-          post = function(self)
-            self.value = self.value + 1
+          post = function(self, n)
+            n = n or 1
+            self.value = self.value + n
             return true
           end,
         }

--- a/spec/01-unit/018-runloop_handler_spec.lua
+++ b/spec/01-unit/018-runloop_handler_spec.lua
@@ -1,127 +1,159 @@
-describe("runloop handler", function()
+local function setup_it_block()
+  local mocked_modules = {}
+  local _ngx = _G.ngx
 
-  it("releases the lock when rebuilding the router fails", function()
-    -- mock db
-    local db = {
-      routes = {}
-    }
-
-    do
-      local _ngx = _G.ngx
-
-      _G.ngx = setmetatable({
-        log = function()
-          -- avoid stdout output during test
-        end,
-      }, { __index = _ngx })
-
-      finally(function()
-        _G.ngx = _ngx
-      end)
-    end
-
-    local function mock_module(name, tbl)
-      local old_module = require(name)
-      package.loaded[name] = setmetatable(tbl, {
-        __index = old_module,
-      })
-      finally(function()
-        package.loaded[name] = old_module
-      end)
-    end
-
-    mock_module("kong.singletons", {
-      configuration = {
-        database = "dummy",
-      },
-      worker_events = {
-        register = function() end,
-      },
-      cluster_events = {
-        subscribe = function() end,
-      },
-      -- FIXME remove apis {{{
-      dao = {
-        apis = {
-          find_all = function() return {} end,
-        }
-      },
-      -- FIXME }}}
-      db = db,
-      cache = {
-        get = function()
-          return "1"
-        end
-      }
+  local function mock_module(name, tbl)
+    local old_module = require(name)
+    mocked_modules[name] = true
+    package.loaded[name] = setmetatable(tbl or {}, {
+      __index = old_module,
     })
+  end
 
-    mock_module("kong.runloop.balancer", {
-      init = function() end
-    })
+  _G.ngx = setmetatable({
+    log = function()
+      -- avoid stdout output during test
+    end,
+  }, { __index = _ngx })
 
-    -- FIXME remove kong.tools.responses {{{
-    mock_module("kong.tools.responses", {
-      send_HTTP_INTERNAL_SERVER_ERROR = function() end,
-    })
-    -- FIXME }}}
+  finally(function()
+    _G.ngx = _ngx
 
-    -- keep track of created semaphores
-    local semaphores = {}
-
-    mock_module("ngx.semaphore", {
-      new = function()
-        local s = {
-          value = 0,
-          wait = function(self, timeout)
-            self.value = self.value - 1
-            return true
-          end,
-          post = function(self, n)
-            n = n or 1
-            self.value = self.value + n
-            return true
-          end,
-        }
-        table.insert(semaphores, s)
-        return s
-      end
-    })
-
-    local handler = require "kong.runloop.handler"
-    finally(function()
-      -- unload module using mocked dependencies
-      package.loaded["kong.runloop.handler"] = nil
-    end)
-
-    -- initialize building empty router
-    db.routes.each = function()
-      return function()
-               return nil
-             end
+    for k in pairs(mocked_modules) do
+      package.loaded[k] = nil
     end
-
-    handler.init_worker.before()
-
-    -- check semaphore
-    assert.same(semaphores[1].value, 1)
-    -- FIXME remove apis {{{
-    assert.same(semaphores[2].value, 1)
-    -- FIXME }}}
-
-    -- this will cause rebuilding the router to fail
-    db.routes.each = function()
-      return function()
-               return false, "error injected by test (feel free to ignore :) )"
-             end
-    end
-
-    handler.access.before({})
-
-    -- check semaphore
-    assert.same(semaphores[1].value, 1)
-    -- FIXME remove apis {{{
-    assert.same(semaphores[2].value, 1)
-    -- FIXME }}}
   end)
 
+  mock_module("kong.singletons", {
+    configuration = {
+      database = "dummy",
+    },
+    worker_events = {
+      register = function() end,
+    },
+    cluster_events = {
+      subscribe = function() end,
+    },
+    -- FIXME remove apis {{{
+    dao = {
+      apis = {
+        find_all = function() return {} end,
+      }
+    },
+    -- FIXME }}}
+    cache = {
+      get = function()
+        return "1"
+      end
+    }
+  })
+
+  mock_module("kong.runloop.balancer", {
+    init = function() end
+  })
+
+  -- FIXME remove kong.tools.responses {{{
+  mock_module("kong.tools.responses", {
+    send_HTTP_INTERNAL_SERVER_ERROR = function() end,
+  })
+  -- FIXME }}}
+
+  -- keep track of created semaphores
+  local semaphores = {}
+
+  mock_module("ngx.semaphore", {
+    _semaphores = semaphores,
+    new = function()
+      local s = {
+        value = 0,
+        wait = function(self, timeout)
+          self.value = self.value - 1
+          return true
+        end,
+        post = function(self, n)
+          n = n or 1
+          self.value = self.value + n
+          return true
+        end,
+      }
+      table.insert(semaphores, s)
+      return s
+    end,
+  })
+
+  mock_module("kong.runloop.handler")
+end
+
+describe("runloop handler", function()
+  describe("router rebuilds", function()
+
+    it("releases the lock when rebuilding the router fails", function()
+      setup_it_block()
+
+      local semaphores = require "ngx.semaphore"._semaphores
+      local handler = require "kong.runloop.handler"
+
+      local check_router_rebuild_spy = spy.new(function()
+        return nil, "error injected by test (feel free to ignore :) )"
+      end)
+
+      handler._set_check_router_rebuild(check_router_rebuild_spy)
+
+      handler.init_worker.before()
+
+      -- check semaphore
+      assert.equal(1, semaphores[1].value)
+      -- FIXME remove apis {{{
+      assert.equal(1, semaphores[2].value)
+      -- FIXME }}}
+
+      handler.access.before({})
+
+      assert.spy(check_router_rebuild_spy).was_called(1)
+
+      -- check semaphore
+      assert.equal(1, semaphores[1].value)
+      -- FIXME remove apis {{{
+      assert.equal(1, semaphores[2].value)
+      -- FIXME }}}
+    end)
+
+    it("bypasses router_semaphore upon acquisition timeout", function()
+      setup_it_block()
+
+      local semaphores = require "ngx.semaphore"._semaphores
+      local handler = require "kong.runloop.handler"
+
+      local check_router_rebuild_spy = spy.new(function()
+        return handler.check_router_rebuild()
+      end)
+
+      handler._set_check_router_rebuild(check_router_rebuild_spy)
+
+      handler.init_worker.before()
+
+      -- cause failure to acquire semaphore
+      semaphores[2].wait = function()
+        return nil, "timeout"
+      end
+
+      -- check semaphore
+      assert.equal(1, semaphores[1].value)
+      -- FIXME remove apis {{{
+      assert.equal(1, semaphores[2].value)
+      -- FIXME }}}
+
+      handler.access.before({})
+
+      -- was called even if semaphore timed out on acquisition
+      assert.spy(check_router_rebuild_spy).was_called(1)
+
+      -- check semaphore
+      assert.equal(1, semaphores[1].value)
+      -- FIXME remove apis {{{
+      assert.equal(1, semaphores[2].value)
+      -- FIXME }}}
+    end)
+
+  end)
 end)


### PR DESCRIPTION
Upon semaphore acquisition timeout (due to another coroutine being slow to release it while performing its own router rebuild), we now fallthrough to rebuild the router in order to ensure a best effort strategy.

I considered adding a second level semaphore (e.g. releasing a few more resources for some other coroutines instead of _all_ waiting coroutines), but this behavior is close to 0.14 all the while preserving the new router mutex in most cases (as long as they don't timeout). This alleviates some of the issues observed in #4055.

Also see discussion [here](https://github.com/Kong/kong/pull/4084#discussion_r241475200) (and other references there) for context around this behavior.