### PR TITLE
feat(migrations) check presence of apis before migrating

### DIFF
--- a/kong/cmd/utils/migrations.lua
+++ b/kong/cmd/utils/migrations.lua
@@ -110,6 +110,17 @@ local function up(schema_state, db, opts)
     end
 
     if schema_state.legacy_is_014 then
+      local present, err = db:are_014_apis_present()
+      if err then
+        error(err)
+      end
+
+      if present then
+        error("cannot run migrations: you have `api` entities in your database; " ..
+              "please convert them to `routes` and `services` prior to " ..
+              "migrating to Kong 1.0.")
+      end
+
       -- legacy: migration from 0.14 to 1.0 can be performed
       log("upgrading from 0.14, bootstrapping database...")
       assert(db:schema_bootstrap())

--- a/kong/db/init.lua
+++ b/kong/db/init.lua
@@ -416,6 +416,24 @@ do
   end
 
 
+  function DB:are_014_apis_present()
+    local ok, err = self.connector:connect_migrations({ no_keyspace = true })
+    if not ok then
+      return nil, prefix_err(self, err)
+    end
+
+    ok, err = self.connector:are_014_apis_present()
+
+    self.connector:close()
+
+    if err then
+      return nil, prefix_err(self, "failed checking for presence of 0.14 apis: " .. err)
+    end
+
+    return ok
+  end
+
+
   function DB:schema_bootstrap()
     local ok, err = self.connector:connect_migrations({ no_keyspace = true })
     if not ok then

--- a/kong/db/strategies/postgres/connector.lua
+++ b/kong/db/strategies/postgres/connector.lua
@@ -774,6 +774,28 @@ function _mt:record_migration(subsystem, name, state)
 end
 
 
+function _mt:are_014_apis_present()
+  local _, err = self:query([[
+    DO $$
+    BEGIN
+      IF EXISTS(SELECT id FROM apis) THEN
+        RAISE EXCEPTION 'there are apis in the db';
+      END IF;
+    EXCEPTION WHEN UNDEFINED_TABLE THEN
+      -- Do nothing, table does not exist
+    END;
+    $$;
+  ]])
+  if err and err:match("there are apis in the db") then
+    return true
+  end
+  if err then
+    return nil, err
+  end
+  return false
+end
+
+
 function _mt:is_014()
   local res = {}
 


### PR DESCRIPTION
Refuse to perform a 1.0 migration if there are any contents in the "apis" table. The user needs to migrate away from APIs into Routes and Services before upgrading to Kong 1.0.

Tested using https://github.com/Kong/kong-upgrade-tests/pull/15:

```
./test.sh -b kong:0.14.1 -t kong:feat/check-apis-on-migration upgrade_paths/0.14.1_1.0.0_fails_apis
./test.sh -b kong:0.14.1 -t kong:feat/check-apis-on-migration upgrade_paths/0.14.1_1.0.0
./test.sh -d cassandra -b kong:0.14.1 -t kong:feat/check-apis-on-migration upgrade_paths/0.14.1_1.0.0_fails_apis
./test.sh -d cassandra -b kong:0.14.1 -t kong:feat/check-apis-on-migration upgrade_paths/0.14.1_1.0.0
```

(Note that to run the above tests I needed to add a temporary hack to test.sh in which it switches the currently-active OpenSSL version installed in my GoboLinux system back and forth between 1.0 and 1.1)