### PR TITLE
feat(core) router rebuild timer (revisited)

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -643,6 +643,22 @@
                                  # single query.
 
 #------------------------------------------------------------------------------
+# TUNING & BEHAVIOR
+#------------------------------------------------------------------------------
+
+router_timeout = 5000            # Defines, in milliseconds, how long request
+                                 # handler should wait for a new router to be
+                                 # built. If you set this value to a negative
+                                 # number, the router is never rebuilt during
+                                 # the request, but only by a worker background
+                                 # timer. When set to 0, the request can still
+                                 # start rebuilding a new router, but will not
+                                 # wait for it to be built, and instead use the
+                                 # old router. When set to a positive number
+                                 # greater than 0, the new router is built
+                                 # synchronously.
+
+#------------------------------------------------------------------------------
 # DEVELOPMENT & MISCELLANEOUS
 #------------------------------------------------------------------------------
 

--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -163,6 +163,8 @@ local CONF_INFERENCES = {
   dns_error_ttl = { typ = "number" },
   dns_no_sync = { typ = "boolean" },
 
+  router_timeout = { typ = "number" },
+
   client_ssl = { typ = "boolean" },
 
   proxy_access_log = { typ = "string" },

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -432,7 +432,7 @@ function Kong.init()
     end
   end
 
-  assert(runloop.build_router(db, "init"))
+  runloop.init.after()
 
   db:close()
 end

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -76,6 +76,8 @@ dns_not_found_ttl = 30
 dns_error_ttl = 1
 dns_no_sync = off
 
+router_timeout = 5000
+
 lua_socket_pool_size = 30
 lua_ssl_trusted_certificate = NONE
 lua_ssl_verify_depth = 1

--- a/spec/01-unit/16-runloop_handler_spec.lua
+++ b/spec/01-unit/16-runloop_handler_spec.lua
@@ -17,10 +17,23 @@ local function setup_it_block()
     kong = {
       log = {
         err = function() end,
-        warn = function() end,
       },
       response = {
         exit = function() end,
+      },
+      configuration = {
+        database = "dummy",
+      },
+      worker_events = {
+        register = function() end,
+      },
+      cluster_events = {
+        subscribe = function() end,
+      },
+      cache = {
+        get = function()
+          return "1"
+        end
       },
     },
 
@@ -50,7 +63,7 @@ local function setup_it_block()
         _semaphores = semaphores,
         new = function()
           local s = {
-            value = 0,
+            value = 1,
             wait = function(self, timeout)
               self.value = self.value - 1
               return true
@@ -65,8 +78,6 @@ local function setup_it_block()
           return s
         end,
       }},
-
-      { "kong.concurrency", {} },
 
       { "kong.runloop.handler", {} },
 
@@ -84,15 +95,19 @@ describe("runloop handler", function()
       local semaphores = require "ngx.semaphore"._semaphores
       local handler = require "kong.runloop.handler"
 
-      local check_router_rebuild_spy = spy.new(function()
+      local rebuild_router_spy = spy.new(function()
         return nil, "error injected by test (feel free to ignore :) )"
       end)
 
-      handler._set_check_router_rebuild(check_router_rebuild_spy)
+      handler._set_rebuild_router(rebuild_router_spy)
+      handler.init_worker.before()
+
+      -- check semaphore
+      assert.equal(1, semaphores[1].value)
 
       handler.access.before({})
 
-      assert.spy(check_router_rebuild_spy).was_called(1)
+      assert.spy(rebuild_router_spy).was_called(1)
 
       -- check semaphore
       assert.equal(1, semaphores[1].value)
@@ -104,29 +119,23 @@ describe("runloop handler", function()
       local semaphores = require "ngx.semaphore"._semaphores
       local handler = require "kong.runloop.handler"
 
-      local check_router_rebuild_spy = spy.new(function()
-        return handler.check_router_rebuild()
-      end)
+      local rebuild_router_spy = spy.new(function() end)
 
-      handler._set_check_router_rebuild(check_router_rebuild_spy)
-
-      handler.access.before({})
-
-      -- check semaphore
-      assert.equal(1, semaphores[1].value)
-
-      -- was called even if semaphore timed out on acquisition
-      assert.spy(check_router_rebuild_spy).was_called(1)
+      handler._set_rebuild_router(rebuild_router_spy)
+      handler.init_worker.before()
 
       -- cause failure to acquire semaphore
       semaphores[1].wait = function()
         return nil, "timeout"
       end
 
+      -- check semaphore
+      assert.equal(1, semaphores[1].value)
+
       handler.access.before({})
 
       -- was called even if semaphore timed out on acquisition
-      assert.spy(check_router_rebuild_spy).was_called(2)
+      assert.spy(rebuild_router_spy).was_called(1)
 
       -- check semaphore
       assert.equal(1, semaphores[1].value)


### PR DESCRIPTION
### Summary

This PR refactors Kong's router rebuilding. Previously our router rebuilding happened synchronously only on request time which is good in sense that it maintains rather good consistency between workers. The problem is that it makes workers to wait for a new router (and queue requests), and it really shows up in P99 etc (and I don't think there is a way to make rebuilding really fast on request time whatever we do — except maybe granular updates). There is also a smaller issue when having large numbers of routes that db state changes when router building is paging through the routes and meanwhile the changes happen to routes or services.

This PR tries to fix issues, and instead of trying to be one size fits all solution (like the previous implementation) there is now a configuration value:

```
router_timeout = <milliseconds>
```

The default value for this parameter is `5000`. `0` means that whenever request acquires a router rebuild mutex, it starts a rebuild in a background timer (and serves the request with the old one). If timer creation fails, it runs rebuilding synchronously (before routing request). Usually this should not happen though as the rebuilding now also rebuilds when it gets worker events for `router:version` changes. It also now broadcasts the rebuild across all the workers and the cluster (pre-warming the new router).

If you set the value to negative e.g. `-1` the router rebuilding fully relies on background worker events to rebuild a router (there is no request time penalty or mutexes).

The previous implementation is pretty much the same as setting the value to (this is also a default value so that expectations won't change on this — it is also noted elsewhere that we should not use pg or cassandra timeout here for this as we currently do):
```
router_timeout = 5000
```

So there you go:
1. most request performance, set this to `-1` (if timer creation fails, new router will not be build, but you can trigger a new try with modifying routes or services)
2. good balance, set this to `0` (we also try to rebuild with a timer on request, and fallback to synchronous building)
3. bit more consistenty set this to `1` (1 ms wait for mutex before doing synchronous rebuilding on request)
4. more queuing and less db hammering, set this to `1000` or perhaps `5000` (the old and new default)

This PR also implements caching of the `service` entities, needed for rebuilding the router. 

This is continuation of the previous failed attempt: #4087 to fix #4055.

There are some other work recently merged or discussed:
#4101 (does prefetching instead of caching as this pr)
#4098 (mutex fallthrough that also this pr does when config value is > 0)
#4084 (mutex is always released)

### Issues resolved

Fix #4055
