### PR TITLE
hotfix(oauth2) make Cassandra migration more resilient

### DIFF
--- a/kong/plugins/oauth2/migrations/001_14_to_15.lua
+++ b/kong/plugins/oauth2/migrations/001_14_to_15.lua
@@ -127,19 +127,21 @@ return {
         end
 
         for _, row in ipairs(rows) do
-          local uris = cjson.decode(row.redirect_uri)
-          local buffer = {}
+          if row.redirect_uri then
+            local uris = cjson.decode(row.redirect_uri)
+            local buffer = {}
 
-          for i, uri in ipairs(uris) do
-            buffer[i] = "'" .. uri .. "'"
+            for i, uri in ipairs(uris) do
+              buffer[i] = "'" .. uri .. "'"
+            end
+
+            local q = string.format([[
+                        UPDATE oauth2_credentials
+                        SET redirect_uris = {%s} WHERE id = %s
+                      ]], table.concat(buffer, ","), row.id)
+
+            assert(connector:query(q))
           end
-
-          local q = string.format([[
-                      UPDATE oauth2_credentials
-                      SET redirect_uris = {%s} WHERE id = %s
-                    ]], table.concat(buffer, ","), row.id)
-
-          assert(connector:query(q))
         end
       end
 


### PR DESCRIPTION
Avoid a crash if, during a Blue/Green migration, a new credential
is inserted by the Blue cluster.