### PR TITLE
fix(plugins) call redis:select only necessary in usage() as well

### DIFF
--- a/kong/plugins/rate-limiting/policies/init.lua
+++ b/kong/plugins/rate-limiting/policies/init.lua
@@ -213,8 +213,13 @@ return {
       local red = redis:new()
 
       red:set_timeout(conf.redis_timeout)
-
-      local ok, err = red:connect(conf.redis_host, conf.redis_port)
+      -- use a special pool name only if redis_database is set to non-zero
+      -- otherwise use the default pool name host:port
+      sock_opts.pool = conf.redis_database and
+                       conf.redis_host .. ":" .. conf.redis_port ..
+                       ":" .. conf.redis_database
+      local ok, err = red:connect(conf.redis_host, conf.redis_port,
+                                  sock_opts)
       if not ok then
         kong.log.err("failed to connect to Redis: ", err)
         return nil, err
@@ -226,27 +231,24 @@ return {
         return nil, err
       end
 
-      if times == 0 and is_present(conf.redis_password) then
-        local ok, err = red:auth(conf.redis_password)
-        if not ok then
-          kong.log.err("failed to connect to Redis: ", err)
-          return nil, err
+      if times == 0 then
+        if is_present(conf.redis_password) then
+          local ok, err = red:auth(conf.redis_password)
+          if not ok then
+            kong.log.err("failed to auth Redis: ", err)
+            return nil, err
+          end
         end
-      end
 
-      if times ~= 0 or conf.redis_database then
-        -- The connection pool is shared between multiple instances of this
-        -- plugin, and instances of the response-ratelimiting plugin.
-        -- Because there isn't a way for us to know which Redis database a given
-        -- socket is connected to without a roundtrip, we force the retrieved
-        -- socket to select the desired database.
-        -- When the connection is fresh and the database is the default one, we
-        -- can skip this roundtrip.
+        if conf.redis_database ~= 0 then
+          -- Only call select first time, since we know the connection is shared
+          -- between instances that use the same redis database
 
-        local ok, err = red:select(conf.redis_database or 0)
-        if not ok then
-          kong.log.err("failed to change Redis database: ", err)
-          return nil, err
+          local ok, err = red:select(conf.redis_database)
+          if not ok then
+            kong.log.err("failed to change Redis database: ", err)
+            return nil, err
+          end
         end
       end
 

--- a/kong/plugins/response-ratelimiting/policies/init.lua
+++ b/kong/plugins/response-ratelimiting/policies/init.lua
@@ -208,8 +208,13 @@ return {
     usage = function(conf, identifier, name, period, current_timestamp)
       local red = redis:new()
       red:set_timeout(conf.redis_timeout)
-
-      local ok, err = red:connect(conf.redis_host, conf.redis_port)
+      -- use a special pool name only if redis_database is set to non-zero
+      -- otherwise use the default pool name host:port
+      sock_opts.pool = conf.redis_database and
+                       conf.redis_host .. ":" .. conf.redis_port ..
+                       ":" .. conf.redis_database
+      local ok, err = red:connect(conf.redis_host, conf.redis_port,
+                                  sock_opts)
       if not ok then
         kong.log.err("failed to connect to Redis: ", err)
         return nil, err
@@ -221,27 +226,24 @@ return {
         return nil, err
       end
 
-      if times == 0 and is_present(conf.redis_password) then
-        local ok, err = red:auth(conf.redis_password)
-        if not ok then
-          kong.log.err("failed to auth Redis: ", err)
-          return nil, err
+      if times == 0 then
+        if is_present(conf.redis_password) then
+          local ok, err = red:auth(conf.redis_password)
+          if not ok then
+            kong.log.err("failed to auth Redis: ", err)
+            return nil, err
+          end
         end
-      end
 
-      if times ~= 0 or conf.redis_database then
-        -- The connection pool is shared between multiple instances of this
-        -- plugin, and instances of the response-ratelimiting plugin.
-        -- Because there isn't a way for us to know which Redis database a given
-        -- socket is connected to without a roundtrip, we force the retrieved
-        -- socket to select the desired database.
-        -- When the connection is fresh and the database is the default one, we
-        -- can skip this roundtrip.
+        if conf.redis_database ~= 0 then
+          -- Only call select first time, since we know the connection is shared
+          -- between instances that use the same redis database
 
-        local ok, err = red:select(conf.redis_database or 0)
-        if not ok then
-          kong.log.err("failed to change Redis database: ", err)
-          return nil, err
+          local ok, err = red:select(conf.redis_database)
+          if not ok then
+            kong.log.err("failed to change Redis database: ", err)
+            return nil, err
+          end
         end
       end
 


### PR DESCRIPTION
### Summary

In https://github.com/Kong/kong/pull/3973 the logic of selective call redis:select is implemented for `increment` but not `usage`. This patch applies the same logic to `usage` as well.

### Full changelog

* Use database-based redis connection pool to reduce unnecessary select call in `usage()` call.
