### PR TITLE
chore(rockspec) correct license to Apache 2.0

### DIFF
--- a/kong-1.0.0-0.rockspec
+++ b/kong-1.0.0-0.rockspec
@@ -7,8 +7,8 @@ source = {
 }
 description = {
   summary = "Kong is a scalable and customizable API Management Layer built on top of Nginx.",
-  homepage = "http://getkong.org",
-  license = "MIT"
+  homepage = "https://konghq.com",
+  license = "Apache 2.0"
 }
 dependencies = {
   "inspect == 3.1.1",


### PR DESCRIPTION
Kong has been Apache 2.0 licensed as noted in the LICENSE file but the
rockspec license has incorrectly been recorded as MIT.