### PR TITLE
feat(stream) add support for stream real ip configuration

### DIFF
--- a/kong/templates/nginx.lua
+++ b/kong/templates/nginx.lua
@@ -20,7 +20,9 @@ events {
 }
 
 http {
+> if #proxy_listeners > 0 or #admin_listeners > 0 then
     include 'nginx-kong.conf';
+> end
 }
 
 > if #stream_listeners > 0 then

--- a/spec/01-unit/04-prefix_handler_spec.lua
+++ b/spec/01-unit/04-prefix_handler_spec.lua
@@ -321,6 +321,15 @@ describe("NGINX conf compiler", function()
         assert.matches("set_real_ip_from%s+192.168.1.0",    nginx_conf)
         assert.matches("set_real_ip_from%s+2001:0db8::/32", nginx_conf)
       end)
+      it("set_real_ip_from (stream proxy)", function()
+        local conf = assert(conf_loader(nil, {
+          trusted_ips = "192.168.1.0/24,192.168.2.1,2001:0db8::/32"
+        }))
+        local nginx_conf = prefix_handler.compile_kong_stream_conf(conf)
+        assert.matches("set_real_ip_from%s+192.168.1.0/24", nginx_conf)
+        assert.matches("set_real_ip_from%s+192.168.1.0",    nginx_conf)
+        assert.matches("set_real_ip_from%s+2001:0db8::/32", nginx_conf)
+      end)
       it("proxy_protocol", function()
         local conf = assert(conf_loader(nil, {
           proxy_listen = "0.0.0.0:8000 proxy_protocol, 0.0.0.0:8443 ssl",

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -12,6 +12,7 @@ error_log logs/error.log ${{LOG_LEVEL}};
 events {}
 
 http {
+> if #proxy_listeners > 0 or #admin_listeners > 0 then
     charset UTF-8;
 
     error_log logs/error.log ${{LOG_LEVEL}};
@@ -454,11 +455,11 @@ http {
             }
         }
     }
+> end
 }
 
 > if #stream_listeners > 0 then
 stream {
-
     log_format basic '$remote_addr [$time_local] '
                      '$protocol $status $bytes_sent $bytes_received '
                      '$session_time';
@@ -483,13 +484,6 @@ stream {
     $(el.name) $(el.value);
 > end
 
-    upstream kong_upstream {
-        server 0.0.0.1:1;
-        balancer_by_lua_block {
-            Kong.balancer()
-        }
-    }
-
     init_by_lua_block {
         -- shared dictionaries conflict between stream/http modules. use a prefix.
         local shared = ngx.shared
@@ -512,6 +506,13 @@ stream {
         Kong.init_worker()
     }
 
+    upstream kong_upstream {
+        server 0.0.0.1:1;
+        balancer_by_lua_block {
+            Kong.balancer()
+        }
+    }
+
     server {
 > for i = 1, #stream_listeners do
         listen $(stream_listeners[i].listener);
@@ -519,6 +520,10 @@ stream {
 
         access_log logs/access.log basic;
         error_log logs/error.log debug;
+
+> for i = 1, #trusted_ips do
+        set_real_ip_from   $(trusted_ips[i]);
+> end
 
         # injected nginx_sproxy_* directives
 > for _, el in ipairs(nginx_sproxy_directives) do
@@ -554,6 +559,5 @@ stream {
             ngx.say(data) -- echo whatever was sent
         }
     }
-
 }
 > end

--- a/t/01-pdk/05-client/01-get_ip.t
+++ b/t/01-pdk/05-client/01-get_ip.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
+use Test::Nginx::Socket::Lua::Stream;
 use t::Util;
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
@@ -39,7 +40,28 @@ ip: 127.0.0.1
 
 
 
-=== TEST 2: client.get_ip() returns client ip not affected by proxy_protocol
+=== TEST 2: client.get_ip() returns client ip (stream)
+--- stream_server_config
+    set_real_ip_from 0.0.0.0/0;
+    set_real_ip_from ::/0;
+    set_real_ip_from unix:;
+
+    content_by_lua_block {
+        require "resty.core"
+
+        local PDK = require "kong.pdk"
+        local pdk = PDK.new()
+
+        ngx.say("ip: ", pdk.client.get_ip())
+    }
+--- stream_response
+ip: 127.0.0.1
+--- no_error_log
+[error]
+
+
+
+=== TEST 3: client.get_ip() returns client ip not affected by proxy_protocol
 --- http_config eval
 qq{
     $t::Util::HttpConfig
@@ -55,8 +77,9 @@ qq{
             set_real_ip_from ::/0;
             set_real_ip_from unix:;
 
-
             content_by_lua_block {
+                require "resty.core"
+
                 local PDK = require "kong.pdk"
                 local pdk = PDK.new()
 
@@ -84,6 +107,47 @@ qq{
 --- request
 GET /t
 --- response_body
+ip: unix:
+--- no_error_log
+[error]
+
+
+
+=== TEST 4: client.get_ip() returns client ip not affected by proxy_protocol (stream)
+--- stream_config eval
+qq{
+    server {
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock proxy_protocol;
+
+        set_real_ip_from 0.0.0.0/0;
+        set_real_ip_from ::/0;
+        set_real_ip_from unix:;
+
+        content_by_lua_block {
+            require "resty.core"
+
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            ngx.say("ip: ", pdk.client.get_ip())
+        }
+    }
+}
+--- stream_server_config
+    content_by_lua_block {
+        local sock = ngx.socket.tcp()
+        sock:connect("unix:$TEST_NGINX_NXSOCK/nginx.sock")
+
+        local request = "PROXY TCP4 10.0.0.1 " ..
+                        ngx.var.server_addr    .. " " ..
+                        ngx.var.remote_port    .. " " ..
+                        ngx.var.server_port    .. "\r\n" ..
+                        "Hello!\r\n"
+
+        sock:send(request)
+        ngx.print(sock:receive())
+    }
+--- stream_response chop
 ip: unix:
 --- no_error_log
 [error]

--- a/t/01-pdk/05-client/03-get_port.t
+++ b/t/01-pdk/05-client/03-get_port.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
+use Test::Nginx::Socket::Lua::Stream;
 use t::Util;
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
@@ -31,7 +32,28 @@ port: \d+
 
 
 
-=== TEST 2: client.get_port() returns a number
+=== TEST 2: client.get_port() returns client port (stream)
+--- stream_server_config
+    set_real_ip_from 0.0.0.0/0;
+    set_real_ip_from ::/0;
+    set_real_ip_from unix:;
+
+    content_by_lua_block {
+        require "resty.core"
+
+        local PDK = require "kong.pdk"
+        local pdk = PDK.new()
+
+        ngx.say("port: ", pdk.client.get_port())
+    }
+--- stream_response_like chomp
+port: \d+
+--- no_error_log
+[error]
+
+
+
+=== TEST 3: client.get_port() returns a number
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -51,7 +73,7 @@ port type: number
 
 
 
-=== TEST 3: client.get_ip() returns client port not affected by proxy_protocol
+=== TEST 4: client.get_port() returns client port not affected by proxy_protocol
 --- http_config eval
 qq{
     $t::Util::HttpConfig
@@ -95,6 +117,47 @@ qq{
 --- request
 GET /t
 --- response_body
+port: nil
+--- no_error_log
+[error]
+
+
+
+=== TEST 5: client.get_port() returns client port not affected by proxy_protocol (stream)
+--- stream_config eval
+qq{
+    server {
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock proxy_protocol;
+
+        set_real_ip_from 0.0.0.0/0;
+        set_real_ip_from ::/0;
+        set_real_ip_from unix:;
+
+        content_by_lua_block {
+            require "resty.core"
+
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            ngx.say("port: ", pdk.client.get_port())
+        }
+    }
+}
+--- stream_server_config
+    content_by_lua_block {
+        local sock = ngx.socket.tcp()
+        sock:connect("unix:$TEST_NGINX_NXSOCK/nginx.sock")
+
+        local request = "PROXY TCP4 10.0.0.1 " ..
+                        ngx.var.server_addr    .. " " ..
+                        ngx.var.remote_port    .. " " ..
+                        ngx.var.server_port    .. "\r\n" ..
+                        "Hello!\r\n"
+
+        sock:send(request)
+        ngx.print(sock:receive())
+    }
+--- stream_response chop
 port: nil
 --- no_error_log
 [error]


### PR DESCRIPTION
### Summary

A stream module supports real ip when using `proxy_protocol` flag on stream `listen`. This enables the `trusted ips` to work with stream module.