### PR TITLE
fix(datadog) fix sample_rate accepted range

### DIFF
--- a/kong/api/init.lua
+++ b/kong/api/init.lua
@@ -42,7 +42,13 @@ local function parse_params(fn)
 
     self.params = api_helpers.normalize_nested_params(self.params)
 
-    local res = fn(self, ...)
+    local res, err = fn(self, ...)
+
+    if err then
+      kong.log.err(err)
+      return ngx.exit(500)
+    end
+
     if res == nil and ngx.status >= 200 then
       return ngx.exit(0)
     end

--- a/kong/api/routes/plugins.lua
+++ b/kong/api/routes/plugins.lua
@@ -79,6 +79,17 @@ do
       elseif type(v) == "table" then
         out[k] = fdata_to_jsonable(v)
 
+      elseif type(v) == "number" then
+        if v ~= v then
+          out[k] = "nan"
+        elseif v == math.huge then
+          out[k] = "inf"
+        elseif v == -math.huge then
+          out[k] = "-inf"
+        else
+          out[k] = v
+        end
+
       elseif type(v) ~= "function" then
         out[k] = v
       end

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -501,6 +501,8 @@ function Kong.init_worker()
     kong_global.set_namespaced_log(kong, plugin.name)
 
     plugin.handler:init_worker()
+
+    kong_global.reset_log(kong)
   end
 end
 

--- a/kong/plugins/datadog/schema.lua
+++ b/kong/plugins/datadog/schema.lua
@@ -109,7 +109,7 @@ return {
                   { name = { type = "string", required = true, one_of = STAT_NAMES }, },
                   { stat_type = { type = "string", required = true, one_of = STAT_TYPES }, },
                   { tags = { type = "array", elements = { type = "string", match = "^.*[^:]$" }, }, },
-                  { sample_rate = { type = "number", between = { 1, math.huge }, }, },
+                  { sample_rate = { type = "number", between = { 0, 1 }, }, },
                   { consumer_identifier = { type = "string", one_of = CONSUMER_IDENTIFIERS }, },
                 },
                 entity_checks = {

--- a/spec/02-integration/04-admin_api/04-plugins_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/04-plugins_routes_spec.lua
@@ -230,14 +230,16 @@ for _, strategy in helpers.each_strategy() do
 
     describe("/plugins/schema/{plugin}", function()
       describe("GET", function()
-        it("returns the schema of a plugin config", function()
-          local res = assert(client:send {
-            method = "GET",
-            path = "/plugins/schema/request-transformer",
-          })
-          local body = assert.res_status(200, res)
-          local json = cjson.decode(body)
-          assert.is_table(json.fields)
+        it("returns the schema of all bundled plugins", function()
+          for plugin, _ in pairs(helpers.test_conf.loaded_plugins) do
+            local res = assert(client:send {
+              method = "GET",
+              path = "/plugins/schema/" .. plugin,
+            })
+            local body = assert.res_status(200, res)
+            local json = cjson.decode(body)
+            assert.is_table(json.fields)
+          end
         end)
         it("returns 404 on invalid plugin", function()
           local res = assert(client:send {


### PR DESCRIPTION
Fixes a number of small issues that compounded into #4136:

* `fix(api) catch handler failures and return 500` - We were getting a Lapis handler because of a failure inside the PDK. This fixes that.
* `fix(core) reset log namespace on init_worker` - Once that was fixed, we were getting a logged error with the wrong namespace.
* `fix(api) encode non-JSON-representable numbers as strings` - Once that was fixed, the error reported that it was an issue when JSON-encoding the schema. This fixed the encoding.
* `fix(datadog) correct valid sample_rate range` - Finally, that value in the datadog schema shouldn't be there in the first place; this fixes the `sample_rate` to the correct range (between 0 and 1).

For datadog sample_rate, see:
* https://docs.datadoghq.com/developers/faq/dog-statsd-sample-rate-parameter-explained/
* https://thenewstack.io/collecting-metrics-using-statsd-a-standard-for-real-time-monitoring/

Fixes #4136.