### PR TITLE
feat(stream) nginx directive injections for stream config

### DIFF
--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -39,6 +39,8 @@ local HEADER_KEY_TO_NAME = {
 local DYNAMIC_KEY_PREFIXES = {
   ["nginx_http_directives"] = "nginx_http_",
   ["nginx_proxy_directives"] = "nginx_proxy_",
+  ["nginx_stream_directives"] = "nginx_stream_",
+  ["nginx_sproxy_directives"] = "nginx_sproxy_",
   ["nginx_admin_directives"] = "nginx_admin_",
 }
 

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -110,7 +110,7 @@ server {
 > end
 
     # injected nginx_proxy_* directives
-> for _, el in ipairs(nginx_proxy_directives)  do
+> for _, el in ipairs(nginx_proxy_directives) do
     $(el.name) $(el.value);
 > end
 
@@ -211,7 +211,7 @@ server {
 > end
 
     # injected nginx_admin_* directives
-> for _, el in ipairs(nginx_admin_directives)  do
+> for _, el in ipairs(nginx_admin_directives) do
     $(el.name) $(el.value);
 > end
 

--- a/kong/templates/nginx_kong_stream.lua
+++ b/kong/templates/nginx_kong_stream.lua
@@ -18,6 +18,11 @@ lua_shared_dict stream_kong_cassandra      5m;
 > end
 lua_shared_dict stream_prometheus_metrics  5m;
 
+# injected nginx_stream_* directives
+> for _, el in ipairs(nginx_stream_directives) do
+$(el.name) $(el.value);
+> end
+
 upstream kong_upstream {
     server 0.0.0.1:1;
     balancer_by_lua_block {
@@ -55,12 +60,18 @@ server {
     access_log ${{PROXY_ACCESS_LOG}} basic;
     error_log ${{PROXY_ERROR_LOG}} ${{LOG_LEVEL}};
 
+    # injected nginx_sproxy_* directives
+> for _, el in ipairs(nginx_sproxy_directives) do
+    $(el.name) $(el.value);
+> end
+
 > if ssl_preread_enabled then
     ssl_preread on;
 > end
     preread_by_lua_block {
         Kong.preread()
     }
+
     proxy_pass kong_upstream;
 
     log_by_lua_block {

--- a/spec/01-unit/002-conf_loader_spec.lua
+++ b/spec/01-unit/002-conf_loader_spec.lua
@@ -227,9 +227,22 @@ describe("Configuration loader", function()
         plugins = "off",
       }))
       assert.True(search_directive(conf.nginx_http_directives,
-                  "lua_shared_dict", "custom_cache 5m"))
+                                   "variables_hash_bucket_size", [["128"]]))
+      assert.True(search_directive(conf.nginx_stream_directives,
+                                   "variables_hash_bucket_size", [["128"]]))
+
       assert.True(search_directive(conf.nginx_http_directives,
-                  "large_client_header_buffers", "8 24k"))
+                                   "lua_shared_dict", "custom_cache 5m"))
+      assert.True(search_directive(conf.nginx_stream_directives,
+                                   "lua_shared_dict", "custom_cache 5m"))
+
+      assert.True(search_directive(conf.nginx_proxy_directives,
+                                   "proxy_bind", "127.0.0.1 transparent"))
+      assert.True(search_directive(conf.nginx_sproxy_directives,
+                                   "proxy_bind", "127.0.0.1 transparent"))
+
+      assert.True(search_directive(conf.nginx_admin_directives,
+                                   "server_tokens", "off"))
     end)
 
     it("quotes numeric flexible prefix based configs", function()
@@ -244,15 +257,33 @@ describe("Configuration loader", function()
 
     it("accepts flexible config values with precedence", function()
       local conf = assert(conf_loader("spec/fixtures/nginx-directives.conf", {
-        ["nginx_http_large_client_header_buffers"] = "4 16k",
+        ["nginx_http_variables_hash_bucket_size"] = "256",
+        ["nginx_stream_variables_hash_bucket_size"] = "256",
         ["nginx_http_lua_shared_dict"] = "custom_cache 2m",
+        ["nginx_stream_lua_shared_dict"] = "custom_cache 2m",
+        ["nginx_proxy_proxy_bind"] = "127.0.0.2 transparent",
+        ["nginx_sproxy_proxy_bind"] = "127.0.0.2 transparent",
+        ["nginx_admin_server_tokens"] = "build",
         plugins = "off",
       }))
 
       assert.True(search_directive(conf.nginx_http_directives,
-                  "lua_shared_dict", "custom_cache 2m"))
+                                   "variables_hash_bucket_size", [["256"]]))
+      assert.True(search_directive(conf.nginx_stream_directives,
+                                   "variables_hash_bucket_size", [["256"]]))
+
       assert.True(search_directive(conf.nginx_http_directives,
-                  "large_client_header_buffers", "4 16k"))
+                                   "lua_shared_dict", "custom_cache 2m"))
+      assert.True(search_directive(conf.nginx_stream_directives,
+                                   "lua_shared_dict", "custom_cache 2m"))
+
+      assert.True(search_directive(conf.nginx_proxy_directives,
+                                   "proxy_bind", "127.0.0.2 transparent"))
+      assert.True(search_directive(conf.nginx_sproxy_directives,
+                                   "proxy_bind", "127.0.0.2 transparent"))
+
+      assert.True(search_directive(conf.nginx_admin_directives,
+                                   "server_tokens", "build"))
     end)
   end)
 

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -61,7 +61,7 @@ http {
     lua_shared_dict kong_mock_upstream_loggers 10m;
 
 # injected nginx_http_* directives
-> for _, el in ipairs(nginx_http_directives)  do
+> for _, el in ipairs(nginx_http_directives) do
     $(el.name) $(el.value);
 > end
 
@@ -113,7 +113,7 @@ http {
 > end
 
     # injected nginx_proxy_* directives
-> for _, el in ipairs(nginx_proxy_directives)  do
+> for _, el in ipairs(nginx_proxy_directives) do
         $(el.name) $(el.value);
 > end
 
@@ -208,7 +208,7 @@ http {
 > end
 
     # injected nginx_admin_* directives
-> for _, el in ipairs(nginx_admin_directives)  do
+> for _, el in ipairs(nginx_admin_directives) do
         $(el.name) $(el.value);
 > end
 
@@ -478,6 +478,11 @@ stream {
 > end
     lua_shared_dict stream_prometheus_metrics  5m;
 
+    # injected nginx_stream_* directives
+> for _, el in ipairs(nginx_stream_directives) do
+    $(el.name) $(el.value);
+> end
+
     upstream kong_upstream {
         server 0.0.0.1:1;
         balancer_by_lua_block {
@@ -515,12 +520,19 @@ stream {
         access_log logs/access.log basic;
         error_log logs/error.log debug;
 
+        # injected nginx_sproxy_* directives
+> for _, el in ipairs(nginx_sproxy_directives) do
+        $(el.name) $(el.value);
+> end
+
 > if ssl_preread_enabled then
         ssl_preread on;
 > end
+
         preread_by_lua_block {
             Kong.preread()
         }
+
         proxy_pass kong_upstream;
 
         log_by_lua_block {

--- a/spec/fixtures/nginx-directives.conf
+++ b/spec/fixtures/nginx-directives.conf
@@ -1,2 +1,7 @@
-nginx_http_large_client_header_buffers = 8 24k
+nginx_http_variables_hash_bucket_size = 128
+nginx_stream_variables_hash_bucket_size = 128
 nginx_http_lua_shared_dict = custom_cache 5m
+nginx_stream_lua_shared_dict = custom_cache 5m
+nginx_proxy_proxy_bind = 127.0.0.1 transparent
+nginx_sproxy_proxy_bind = 127.0.0.1 transparent
+nginx_admin_server_tokens = off


### PR DESCRIPTION
Makes it possible to inject Nginx directives also to the
stream configurations with configuration or environment
variables:

KONG_NGINX_STREAM_* (see KONG_NGINX_HTTP)
KONG_NGINX_SPROXY_* (see KONG_NGINX_PROXY)

E.g.

KONG_NGINX_SPROXY_PROXY_BIND = 127.0.0.1 transparent

NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

### Summary

SUMMARY_GOES_HERE

### Full changelog

* [Implement ...]
* [Add related tests]
* ...

### Issues resolved

Fix #XXX
