### PR TITLE
fix(reports) do not send unnecessary attributes in 'ping' message

### DIFF
--- a/kong/api/routes/plugins.lua
+++ b/kong/api/routes/plugins.lua
@@ -1,5 +1,4 @@
 local kong = kong
-local null = ngx.null
 local cjson = require "cjson"
 local utils = require "kong.tools.utils"
 local reports = require "kong.reports"
@@ -104,15 +103,25 @@ end
 
 local function post_process(data)
   local r_data = utils.deep_copy(data)
+
   r_data.config = nil
-  if data.service ~= null and data.service.id then
+  r_data.route = nil
+  r_data.service = nil
+  r_data.consumer = nil
+  r_data.enabled = nil
+
+  if type(data.service) == "table" and data.service.id then
     r_data.e = "s"
-  elseif data.route ~= null and data.route.id then
+
+  elseif type(data.route) == "table" and data.route.id then
     r_data.e = "r"
-  elseif data.consumer ~= null and data.consumer.id then
+
+  elseif type(data.consumer) == "table" and data.consumer.id then
     r_data.e = "c"
   end
+
   reports.send("api", r_data)
+
   return data
 end
 


### PR DESCRIPTION
Prior to this patch, configuring a plugin via `POST /plugins` would send
reports with `<entity>=userdata;<entity>=userdata;` when the plugin was
not configured on a given entity (e.g. when configuring a global plugin,
or a plugin with a Route only).

We also avoid sending `enabled=true` which has very little value and
takes space in our already limited UDP packet length.