### PR TITLE
fix(tcp-log) remove trailing carriage return

### DIFF
--- a/kong/plugins/tcp-log/handler.lua
+++ b/kong/plugins/tcp-log/handler.lua
@@ -36,7 +36,7 @@ local function log(premature, conf, message)
     end
   end
 
-  ok, err = sock:send(cjson.encode(message) .. "\r\n")
+  ok, err = sock:send(cjson.encode(message) .. "\n")
   if not ok then
     ngx.log(ngx.ERR, "[tcp-log] failed to send data to " .. host .. ":" .. tostring(port) .. ": ", err)
   end


### PR DESCRIPTION
Do not add a carriage return anymore to payload
(CR is not needed and can produce an invalid JSON on receiver side)

Fix #4048