### PR TITLE
fix(api) fix output of records in /plugins/schema

### DIFF
--- a/kong/api/routes/plugins.lua
+++ b/kong/api/routes/plugins.lua
@@ -70,14 +70,52 @@ end
 -- cjson can encode the schema.
 local schema_to_jsonable
 do
-  local function fdata_to_jsonable(fdata)
+  local insert = table.insert
+  local ipairs = ipairs
+  local next = next
+
+  local fdata_to_jsonable
+
+
+  local function fields_to_jsonable(fields)
     local out = {}
-    for k, v in pairs(fdata) do
+    for _, field in ipairs(fields) do
+      local fname = next(field)
+      local fdata = field[fname]
+      insert(out, { [fname] = fdata_to_jsonable(fdata, "no") })
+    end
+    setmetatable(out, cjson.array_mt)
+    return out
+  end
+
+
+  -- Convert field data from schemas into something that can be
+  -- passed to a JSON encoder.
+  -- @tparam table fdata A Lua table with field data
+  -- @tparam string is_array A three-state enum: "yes", "no" or "maybe"
+  -- @treturn table A JSON-convertible Lua table
+  fdata_to_jsonable = function(fdata, is_array)
+    local out = {}
+    local iter = is_array == "yes" and ipairs or pairs
+
+    for k, v in iter(fdata) do
+      if is_array == "maybe" and type(k) ~= "number" then
+        is_array = "no"
+      end
+
       if k == "schema" then
         out[k] = schema_to_jsonable(v)
 
       elseif type(v) == "table" then
-        out[k] = fdata_to_jsonable(v)
+        if k == "fields" and fdata.type == "record" then
+          out[k] = fields_to_jsonable(v)
+
+        elseif k == "default" and fdata.type == "array" then
+          out[k] = fdata_to_jsonable(v, "yes")
+
+        else
+          out[k] = fdata_to_jsonable(v, "maybe")
+        end
 
       elseif type(v) == "number" then
         if v ~= v then
@@ -94,20 +132,15 @@ do
         out[k] = v
       end
     end
+    if is_array == "yes" or is_array == "maybe" then
+      setmetatable(out, cjson.array_mt)
+    end
     return out
   end
 
-  local insert = table.insert
-  local ipairs = ipairs
-  local next = next
 
   schema_to_jsonable = function(schema)
-    local fields = {}
-    for _, field in ipairs(schema.fields) do
-      local fname = next(field)
-      local fdata = field[fname]
-      insert(fields, { [fname] = fdata_to_jsonable(fdata) })
-    end
+    local fields = fields_to_jsonable(schema.fields)
     return { fields = fields }
   end
 end
@@ -172,7 +205,7 @@ return {
 
   ["/plugins/enabled"] = {
     GET = function(_, _, helpers)
-      local enabled_plugins = setmetatable({}, cjson.empty_array_mt)
+      local enabled_plugins = setmetatable({}, cjson.array_mt)
       for k in pairs(singletons.configuration.loaded_plugins) do
         enabled_plugins[#enabled_plugins+1] = k
       end

--- a/spec/02-integration/04-admin_api/04-plugins_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/04-plugins_routes_spec.lua
@@ -241,6 +241,17 @@ for _, strategy in helpers.each_strategy() do
             assert.is_table(json.fields)
           end
         end)
+        it("returns nested records and empty array defaults as arrays", function()
+          local res = assert(client:send {
+            method = "GET",
+            path = "/plugins/schema/request-transformer",
+          })
+          local body = assert.res_status(200, res)
+          assert.match('{"fields":[{', body, 1, true)
+          assert.not_match('"fields":{', body, 1, true)
+          assert.match('"default":[]', body, 1, true)
+          assert.not_match('"default":{}', body, 1, true)
+        end)
         it("returns 404 on invalid plugin", function()
           local res = assert(client:send {
             method = "GET",


### PR DESCRIPTION
* Ensure that plugin schemas return sub-fields of nested records in the same
format as the toplevel `fields` entry (i.e., as an array of single-fields
objects, so that the field order can be retrieved).
* Ensure `fields` in `/plugins/schema` always returns a JSON array,
even when it is empty (as in the prometheus plugin).

This produces an incompatible output from that of 1.0.0, but I'm opening this against `master` because the one in 1.0.0 is arguably broken, so this produces the intended result.

Fixes #4137.