### PR TITLE
chore(ci) build nginx with stream_realip_module

### DIFF
--- a/.ci/setup_env.sh
+++ b/.ci/setup_env.sh
@@ -67,6 +67,7 @@ if [ ! "$(ls -A $OPENRESTY_INSTALL)" ]; then
     "--with-http_stub_status_module"
     "--with-http_v2_module"
     "--with-stream_ssl_preread_module"
+    "--with-stream_realip_module"
   )
 
   pushd $OPENRESTY_DOWNLOAD


### PR DESCRIPTION
### Summary

Adds `--with-stream_realip_module` to OpenResty `configure` flags. Needed by: #4149.

See also:

- https://github.com/Kong/openresty-patches/pull/35
- https://github.com/Kong/homebrew-kong/pull/86