### PR TITLE
feat(db) add support for postgres schemas

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -372,6 +372,10 @@
 #pg_password =                   # The password to authenticate if required.
 #pg_database = kong              # The database name to connect to.
 
+#pg_schema =                     # The database schema to use. If unspecified,
+                                 # Kong will respect the `search_path` value of
+                                 # your PostgreSQL instance.
+
 #pg_ssl = off                    # Toggles client-server TLS connections
                                  # between Kong and PostgreSQL.
 

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -39,6 +39,7 @@ database = postgres
 pg_host = 127.0.0.1
 pg_port = 5432
 pg_database = kong
+pg_schema = NONE
 pg_timeout = 5000
 pg_user = kong
 pg_password = NONE

--- a/spec/01-unit/04-prefix_handler_spec.lua
+++ b/spec/01-unit/04-prefix_handler_spec.lua
@@ -454,12 +454,15 @@ describe("NGINX conf compiler", function()
     it("dump Kong conf (custom conf)", function()
       local conf = assert(conf_loader(nil, {
         pg_database = "foobar",
+        pg_schema   = "foo",
         prefix = tmp_config.prefix
       }))
       assert.equal("foobar", conf.pg_database)
+      assert.equal("foo", conf.pg_schema)
       assert(prefix_handler.prepare_prefix(conf))
       local in_prefix_kong_conf = assert(conf_loader(tmp_config.kong_env, {
         pg_database = "foobar",
+        pg_schema = "foo",
         prefix = tmp_config.prefix,
       }))
       assert.same(conf, in_prefix_kong_conf)

--- a/spec/02-integration/03-db/01-db_spec.lua
+++ b/spec/02-integration/03-db/01-db_spec.lua
@@ -1,6 +1,6 @@
 local DB      = require "kong.db"
 local helpers = require "spec.helpers"
-
+local utils   = require "kong.tools.utils"
 
 
 for _, strategy in helpers.each_strategy() do
@@ -35,6 +35,7 @@ for _, strategy in helpers.each_strategy() do
             strategy = "PostgreSQL",
             db_desc = "database",
             db_name = helpers.test_conf.pg_database,
+            db_schema = helpers.test_conf.pg_schema or "",
             db_ver  = "unknown",
           }, infos)
 
@@ -50,9 +51,32 @@ for _, strategy in helpers.each_strategy() do
           error("unknown database")
         end
       end)
+
+      if strategy == "postgres" then
+        it("initializes infos with custom schema", function()
+          local conf = utils.deep_copy(helpers.test_conf)
+
+          conf.pg_schema = "demo"
+
+          local db, err = DB.new(conf, strategy)
+
+          assert.is_nil(err)
+          assert.is_table(db)
+
+          local infos = db.infos
+
+          assert.same({
+            strategy = "PostgreSQL",
+            db_desc = "database",
+            db_name = conf.pg_database,
+            db_schema = conf.pg_schema,
+            db_ver  = "unknown",
+          }, infos)
+
+        end)
+      end
     end)
   end)
-
 
   describe(":init_connector() [#" .. strategy .. "]", function()
     it("initializes infos", function()
@@ -68,12 +92,14 @@ for _, strategy in helpers.each_strategy() do
       assert.matches("^%d+%.?%d*%.?%d*$", infos.db_ver)
       assert.not_matches("%.$", infos.db_ver)
 
-
       if strategy == "postgres" then
         assert.same({
           strategy = "PostgreSQL",
           db_desc = "database",
           db_name = helpers.test_conf.pg_database,
+          -- this depends on pg config, but for test-suite it is "public"
+          -- when not specified-
+          db_schema = helpers.test_conf.pg_schema or "public",
           db_ver  = infos.db_ver,
         }, infos)
 
@@ -90,19 +116,80 @@ for _, strategy in helpers.each_strategy() do
       end
     end)
 
-  end)
+    if strategy == "postgres" then
+      it("initializes infos with custom schema", function()
+        local conf = utils.deep_copy(helpers.test_conf)
 
+        conf.pg_schema = "demo"
+
+        local db, err = DB.new(conf, strategy)
+
+        assert.is_nil(err)
+        assert.is_table(db)
+
+        assert(db:init_connector())
+
+        local infos = db.infos
+
+        assert.matches("^%d+%.?%d*%.?%d*$", infos.db_ver)
+        assert.not_matches("%.$", infos.db_ver)
+
+        assert.same({
+          strategy = "PostgreSQL",
+          db_desc = "database",
+          db_name = conf.pg_database,
+          db_schema = conf.pg_schema,
+          db_ver  = infos.db_ver,
+        }, infos)
+      end)
+    end
+  end)
 
   describe(":connect() [#" .. strategy .. "]", function()
+    if strategy == "postgres" then
+      it("connects to schema configured in postgres by default", function()
+        local db, err = DB.new(helpers.test_conf, strategy)
 
+        assert.is_nil(err)
+        assert.is_table(db)
+        assert(db:init_connector())
+        assert(db:connect())
+
+        local res = assert(db.connector:query("SELECT CURRENT_SCHEMA AS schema;"))
+
+        assert.is_table(res[1])
+        -- in test suite the CURRENT_SCHEMA is public
+        assert.equal("public", res[1]["schema"])
+
+        assert(db:close())
+      end)
+
+      it("connects to custom schema when configured", function()
+        local conf = utils.deep_copy(helpers.test_conf)
+
+        conf.pg_schema = "demo"
+
+        local db, err = DB.new(conf, strategy)
+
+        assert.is_nil(err)
+        assert.is_table(db)
+        assert(db:init_connector())
+        assert(db:connect())
+        assert(db:reset())
+
+        local res = assert(db.connector:query("SELECT CURRENT_SCHEMA AS schema;"))
+
+        assert.is_table(res[1])
+        assert.equal("demo", res[1]["schema"])
+
+        assert(db:close())
+      end)
+    end
   end)
 
-
   describe(":setkeepalive() [#" .. strategy .. "]", function()
-
   end)
 
   describe(":close() [#" .. strategy .. "]", function()
-
   end)
 end


### PR DESCRIPTION
### Summary

Adds support for Postgres schemas. Makes it possible to use other schemas, and not only the `public` schema in Postgres with an explicit configuration option.

Introduces a new configuration parameter:
```
pg_schema
````

The `unspecified` is the default value of the parameter.

### Issues resolved

Fix #4145
