### PR TITLE
perf(pdk) track the size of the Lua table via local Lua variable inst…

### DIFF
--- a/kong/pdk/ip.lua
+++ b/kong/pdk/ip.lua
@@ -41,11 +41,13 @@ local function new(self)
   -- supports.  Also as an optimization we will only compile trusted ips if
   -- Kong is not run with the default 0.0.0.0/0, ::/0 aka trust all ip
   -- addresses settings.
+  local idx = 1
   for i = 1, n_ips do
     local address = ips[i]
 
     if ip.valid(address) then
-      table.insert(trusted_ips, address)
+      trusted_ips[idx] = address
+      idx = idx + 1
 
       if address == "0.0.0.0/0" then
         trust_all_ipv4 = true


### PR DESCRIPTION
…ead of table.insert.

NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

### Summary

The `table.insert` is an O(n) operation due to the  lj_tab_len call inside LuaJIT. 
We can avoid it in hot loops for better performance.

### Full changelog

* track the size of the Lua table via local Lua variable instead of table.insert.
