### PR TITLE
style(basic-auth) rename password hashing function

### DIFF
--- a/kong/plugins/basic-auth/access.lua
+++ b/kong/plugins/basic-auth/access.lua
@@ -71,7 +71,7 @@ end
 -- @param given_password The password as given in the Authorization header
 -- @return Success of authentication
 local function validate_credentials(credential, given_password)
-  local digest, err = crypto.encrypt(credential.consumer.id, given_password)
+  local digest, err = crypto.hash(credential.consumer.id, given_password)
   if err then
     kong.log.err(err)
   end

--- a/kong/plugins/basic-auth/basicauth_credentials.lua
+++ b/kong/plugins/basic-auth/basicauth_credentials.lua
@@ -2,8 +2,8 @@ local crypto = require "kong.plugins.basic-auth.crypto"
 local utils = require "kong.tools.utils"
 
 
-local encrypt_password = function(self, cred_id_or_username, cred)
-  -- Don't re-encrypt the password digest on update, if the password hasn't changed
+local hash_password = function(self, cred_id_or_username, cred)
+  -- Don't re-hash the password digest on update, if the password hasn't changed
   -- This causes a bug when a new password is effectively equal the to previous digest
   local existing
   if cred_id_or_username then
@@ -27,7 +27,7 @@ local encrypt_password = function(self, cred_id_or_username, cred)
     end
   end
 
-  cred.password = crypto.encrypt(cred.consumer.id, cred.password)
+  cred.password = crypto.hash(cred.consumer.id, cred.password)
 
   return true
 end
@@ -37,7 +37,7 @@ local _BasicauthCredentials = {}
 
 
 function _BasicauthCredentials:insert(cred, options)
-  local ok, err, err_t = encrypt_password(self, cred.id, cred)
+  local ok, err, err_t = hash_password(self, cred.id, cred)
   if not ok then
     return nil, err, err_t
   end
@@ -46,7 +46,7 @@ end
 
 
 function _BasicauthCredentials:update(cred_pk, cred, options)
-  local ok, err, err_t = encrypt_password(self, cred_pk.id, cred)
+  local ok, err, err_t = hash_password(self, cred_pk.id, cred)
   if not ok then
     return nil, err, err_t
   end
@@ -55,7 +55,7 @@ end
 
 
 function _BasicauthCredentials:update_by_username(username, cred, options)
-  local ok, err, err_t = encrypt_password(self, username, cred)
+  local ok, err, err_t = hash_password(self, username, cred)
   if not ok then
     return nil, err, err_t
   end
@@ -64,7 +64,7 @@ end
 
 
 function _BasicauthCredentials:upsert(cred_pk, cred, options)
-  local ok, err, err_t = encrypt_password(self, cred_pk.id, cred)
+  local ok, err, err_t = hash_password(self, cred_pk.id, cred)
   if not ok then
     return nil, err, err_t
   end
@@ -73,7 +73,7 @@ end
 
 
 function _BasicauthCredentials:upsert_by_username(username, cred, options)
-  local ok, err, err_t = encrypt_password(self, username, cred)
+  local ok, err, err_t = hash_password(self, username, cred)
   if not ok then
     return nil, err, err_t
   end

--- a/kong/plugins/basic-auth/crypto.lua
+++ b/kong/plugins/basic-auth/crypto.lua
@@ -1,4 +1,4 @@
--- Module to encrypt the basic-auth credentials password field
+-- Module to hash the basic-auth credentials password field
 local sha1 = require "resty.sha1"
 local to_hex = require "resty.string".to_hex
 local assert = assert
@@ -17,10 +17,10 @@ end
 
 
 return {
-  --- Encrypt the password field credential table
+  --- Hash the password field credential table
   -- @param credential The basic auth credential table
   -- @return hash of the salted credential's password
-  encrypt = function(consumer_id, password)
+  hash = function(consumer_id, password)
     local salted = salt_password(consumer_id, password)
     local digest = sha1:new()
     assert(digest:update(salted))

--- a/spec/03-plugins/10-basic-auth/01-crypto_spec.lua
+++ b/spec/03-plugins/10-basic-auth/01-crypto_spec.lua
@@ -1,18 +1,18 @@
 local crypto = require "kong.plugins.basic-auth.crypto"
 
 describe("Plugin: basic-auth (crypto)", function()
-  it("encrypts a credential with consumer_id salt", function()
-    local value = crypto.encrypt("id123", "pass123")
+  it("hashs a credential with consumer_id salt", function()
+    local value = crypto.hash("id123", "pass123")
     assert.is_string(value)
     assert.equals(40, #value)
-    assert.equals(crypto.encrypt("id123", "pass123"), crypto.encrypt("id123", "pass123"))
+    assert.equals(crypto.hash("id123", "pass123"), crypto.hash("id123", "pass123"))
   end)
 
   it("substitutes empty string for password equal to nil", function()
-    assert.equals(crypto.encrypt("id123"), crypto.encrypt("id123", ""))
+    assert.equals(crypto.hash("id123"), crypto.hash("id123", ""))
   end)
 
   it("substitutes empty string for password equal to ngx.null", function()
-    assert.equals(crypto.encrypt("id123"), crypto.encrypt("id123", ngx.null))
+    assert.equals(crypto.hash("id123"), crypto.hash("id123", ngx.null))
   end)
 end)

--- a/spec/03-plugins/10-basic-auth/02-api_spec.lua
+++ b/spec/03-plugins/10-basic-auth/02-api_spec.lua
@@ -63,7 +63,7 @@ for _, strategy in helpers.each_strategy() do
           assert.equal(consumer.id, json.consumer.id)
           assert.equal("bob", json.username)
         end)
-        it("encrypts the password", function()
+        it("hashes the password", function()
           local res = assert(admin_client:send {
             method  = "POST",
             path    = "/consumers/bob/basic-auth",
@@ -81,10 +81,10 @@ for _, strategy in helpers.each_strategy() do
           assert.not_equal("kong", json.password)
 
           local crypto = require "kong.plugins.basic-auth.crypto"
-          local hash   = crypto.encrypt(consumer.id, "kong")
+          local hash   = crypto.hash(consumer.id, "kong")
           assert.equal(hash, json.password)
         end)
-        it("encrypts the password without trimming whitespace", function()
+        it("hashes the password without trimming whitespace", function()
           local res = assert(admin_client:send {
             method  = "POST",
             path    = "/consumers/bob/basic-auth",
@@ -102,7 +102,7 @@ for _, strategy in helpers.each_strategy() do
           assert.not_equal(" kong ", json.password)
 
           local crypto = require "kong.plugins.basic-auth.crypto"
-          local hash   = crypto.encrypt(consumer.id, " kong ")
+          local hash   = crypto.hash(consumer.id, " kong ")
           assert.equal(hash, json.password)
         end)
         describe("errors", function()


### PR DESCRIPTION
### Summary

This commit simply updates the function names used to generated the SHA1 of the basic-auth credential's password to correctly identify the function's purpose and result. This lays the groundwork to be able to use symmetric encryption within Kong at large, without being confused by the legacy functionality present here.

### Full changelog

* rename basic-auth plugins `crypto.encrypt` to `crypto.hash`
* rename basic auth plugin credential's DAO local function `encrypt_password` to `hash_password`