### PR TITLE
perf(db) keep connection available on phases and requests

### DIFF
--- a/kong/api/init.lua
+++ b/kong/api/init.lua
@@ -10,6 +10,7 @@ local arguments   = require "kong.api.arguments"
 local Errors      = require "kong.db.errors"
 
 
+local kong     = kong
 local ngx      = ngx
 local sub      = string.sub
 local find     = string.find
@@ -44,6 +45,8 @@ local function parse_params(fn)
 
     local res, err = fn(self, ...)
 
+    kong.db:setkeepalive()
+
     if err then
       kong.log.err(err)
       return ngx.exit(500)
@@ -60,6 +63,8 @@ end
 
 -- new DB
 local function new_db_on_error(self)
+  kong.db:setkeepalive()
+
   local err = self.errors[1]
 
   if type(err) ~= "table" then
@@ -96,6 +101,8 @@ end
 
 -- old DAO
 local function on_error(self)
+  kong.db:setkeepalive()
+
   local err = self.errors[1]
 
   if type(err) ~= "table" then
@@ -144,6 +151,8 @@ end
 
 
 app.handle_error = function(self, err, trace)
+  kong.db:setkeepalive()
+
   if err then
     if type(err) ~= "string" then
       err = pl_pretty.write(err)

--- a/kong/db/dao/plugins.lua
+++ b/kong/db/dao/plugins.lua
@@ -30,7 +30,7 @@ function Plugins:check_db_against_config(plugin_set)
   local in_db_plugins = {}
   ngx_log(ngx_DEBUG, "Discovering used plugins")
 
-  for row, err in self:each() do
+  for row, err in self:each(1000) do
     if err then
       return nil, tostring(err)
     end

--- a/kong/db/strategies/cassandra/connector.lua
+++ b/kong/db/strategies/cassandra/connector.lua
@@ -172,10 +172,12 @@ function CassandraConnector:infos()
 end
 
 
-function CassandraConnector:connect()
-  local conn = self:get_stored_connection()
-  if conn then
-    return conn
+function CassandraConnector:connect(opts)
+  if opts and not opts.reconnect then
+    local conn = self:get_stored_connection()
+    if conn then
+      return conn
+    end
   end
 
   local peer, err = self.cluster:next_coordinator()
@@ -218,9 +220,9 @@ end
 
 
 function CassandraConnector:setkeepalive()
-  local conn = self:get_stored_connection()
+  local conn = self:get_stored_connection(true)
   if not conn then
-    return
+    return true
   end
 
   local ok, err = conn:setkeepalive()
@@ -236,9 +238,9 @@ end
 
 
 function CassandraConnector:close()
-  local conn = self:get_stored_connection()
+  local conn = self:get_stored_connection(true)
   if not conn then
-    return
+    return true
   end
 
   local ok, err = conn:close()

--- a/kong/db/strategies/connector.lua
+++ b/kong/db/strategies/connector.lua
@@ -1,6 +1,9 @@
 local fmt = string.format
 
 
+local RECONNECT = { reconnect = true }
+
+
 local Connector = {}
 
 
@@ -35,13 +38,22 @@ do
   end
 
 
-  function Connector:get_stored_connection()
+  function Connector:get_stored_connection(closing)
     if not past_init and ngx and ngx.get_phase() ~= "init" then
       past_init = true
     end
 
     if ngx and past_init then
-      return ngx.ctx.connection
+      local connection = ngx.ctx.connection
+      if connection then
+        return connection
+      end
+
+      if closing then
+        return nil
+      end
+
+      return self:connect(RECONNECT)
     end
 
     return self.connection

--- a/kong/db/strategies/postgres/connector.lua
+++ b/kong/db/strategies/postgres/connector.lua
@@ -223,8 +223,8 @@ local _mt = {}
 _mt.__index = _mt
 
 
-function _mt:get_stored_connection()
-  local conn = self.super.get_stored_connection(self)
+function _mt:get_stored_connection(closing)
+  local conn = self.super.get_stored_connection(self, closing)
   if conn and conn.sock then
     return conn
   end
@@ -333,10 +333,12 @@ function _mt:infos()
 end
 
 
-function _mt:connect()
-  local conn = self:get_stored_connection()
-  if conn then
-    return conn
+function _mt:connect(opts)
+  if opts and not opts.reconnect then
+    local conn = self:get_stored_connection()
+    if conn then
+      return conn
+    end
   end
 
   local connection, err = connect(self.config)
@@ -356,7 +358,7 @@ end
 
 
 function _mt:close()
-  local conn = self:get_stored_connection()
+  local conn = self:get_stored_connection(true)
   if not conn then
     return true
   end
@@ -374,7 +376,7 @@ end
 
 
 function _mt:setkeepalive()
-  local conn = self:get_stored_connection()
+  local conn = self:get_stored_connection(true)
   if not conn then
     return true
   end

--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -471,7 +471,7 @@ do
   -- and upstream entity tables as values, or nil+error
   local function load_upstreams_dict_into_memory()
     local upstreams_dict = {}
-    for up in singletons.db.upstreams:each() do
+    for up in singletons.db.upstreams:each(1000) do
     -- build a dictionary, indexed by the upstream name
       upstreams_dict[up.name] = up.id
     end


### PR DESCRIPTION
### Summary

This PR is here just for discussing how the performance of Kong could be improved on issues reported by @jeremyjpj0916:

- #4164
- #4138 

This is continuation of the optimizations and can be applied with #4102.

What this PR does is:
1. try to improve startup time by caching db connection (e.g. callling `:connect`)
2. try to improve startup time by changing some `:each` iterations to `1000` chunks, instead of default `100` -> this is especially nice (?) with caching db connection
3 try to improve proxy performance in case it needs to access db by caching the connection to `ngx.ctx`.


The implementation is slightly hacky especially in `get_stored_connection`, and it makes `query` and possible other `connector` functions to store `connection` to `ngx.ctx`, that means it differs from the original.

So let's have this for discussion and testing.