### PR TITLE
fix(pdk) prevent memory leaks in 'kong.service.response' & 'kong.ctx'

### DIFF
--- a/kong/pdk/ctx.lua
+++ b/kong/pdk/ctx.lua
@@ -91,7 +91,7 @@ local function new(self)
     -- those would be visible on the *.ctx namespace for now
     -- TODO: hide them in a private table shared between this
     -- module and the global.lua one
-    keys = setmetatable({}, { __mode = "k" }),
+    keys = setmetatable({}, { __mode = "v" }),
   }
 
 


### PR DESCRIPTION
#### Leak 1

Introduced in eb20498, this index
metamethod attachment for response headers tables maintains a references
to itself. This was verified by increasing upvalues, functions, and
table object counts increasing when using this API over time.

The newer implementation is also more efficient and avoids creating
closures at runtime.

#### Leak 2

See `kong.global` module's `set_named_ctx` API. The third argument
(`key`) will be a plugin's configuration table. It is important not to
hold references to those configuration tables, as already observed
across many parts of the codebase. 
