### PR TITLE
feat(aws-lambda) add AWS China region to plugin schema

### DIFF
--- a/kong/plugins/aws-lambda/schema.lua
+++ b/kong/plugins/aws-lambda/schema.lua
@@ -5,6 +5,8 @@ local REGIONS = {
   "ap-south-1",
   "ap-southeast-1", "ap-southeast-2",
   "ca-central-1",
+  "cn-north-1",
+  "cn-northwest-1",
   "eu-central-1",
   "eu-west-1", "eu-west-2",
   "sa-east-1",

--- a/kong/plugins/http-log/sender.lua
+++ b/kong/plugins/http-log/sender.lua
@@ -7,7 +7,6 @@ local sender = {}
 
 local ngx_encode_base64 = ngx.encode_base64
 local ERR = ngx.ERR
-print('1')
 
 
 -- Parse host url.

--- a/kong/plugins/http-log/sender.lua
+++ b/kong/plugins/http-log/sender.lua
@@ -7,6 +7,7 @@ local sender = {}
 
 local ngx_encode_base64 = ngx.encode_base64
 local ERR = ngx.ERR
+print('1')
 
 
 -- Parse host url.


### PR DESCRIPTION
Add   "cn-north-1" and  "cn-northwest-1" to the list of allowed regions to permit AWS Lambda
functions to be invoked from the AWS China region.

@thibaultcha Thanks.
