### PR TITLE
perf(db) change page size in full iterations from 100 to 1000

### DIFF
--- a/kong/api/routes/kong.lua
+++ b/kong/api/routes/kong.lua
@@ -24,7 +24,7 @@ return {
 
       do
         local set = {}
-        for row, err in kong.db.plugins:each() do
+        for row, err in kong.db.plugins:each(1000) do
           if err then
             kong.log.err(err)
             return kong.response.exit(500, { message = "An unexpected error happened" })

--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -216,7 +216,7 @@ local function find_cascade_delete_entities(self, entity)
 
     local dao = self.db.daos[constraint.schema.name]
     local method = "each_for_" .. constraint.field_name
-    for row, err in dao[method](dao, pk) do
+    for row, err in dao[method](dao, pk, 1000) do
       if not row then
         log(ERR, "[db] failed to traverse entities for cascade-delete: ", err)
         break

--- a/kong/db/dao/plugins.lua
+++ b/kong/db/dao/plugins.lua
@@ -30,7 +30,7 @@ function Plugins:check_db_against_config(plugin_set)
   local in_db_plugins = {}
   ngx_log(ngx_DEBUG, "Discovering used plugins")
 
-  for row, err in self:each() do
+  for row, err in self:each(1000) do
     if err then
       return nil, tostring(err)
     end

--- a/kong/db/dao/snis.lua
+++ b/kong/db/dao/snis.lua
@@ -87,7 +87,7 @@ end
 function _SNIs:list_for_certificate(cert_pk, options)
   local name_list = setmetatable({}, cjson.empty_array_mt)
 
-  for sni, err, err_t in self:each_for_certificate(cert_pk, options) do
+  for sni, err, err_t in self:each_for_certificate(cert_pk, 1000, options) do
     if err then
       return nil, err, err_t
     end

--- a/kong/db/dao/targets.lua
+++ b/kong/db/dao/targets.lua
@@ -171,7 +171,7 @@ function _TARGETS:page_for_upstream(upstream_pk, size, offset, options)
   -- extract the page requested by the user.
 
   -- Read all targets; this returns the target history sorted chronologically
-  local targets, err, err_t = self:select_by_upstream_raw(upstream_pk, nil, options)
+  local targets, err, err_t = self:select_by_upstream_raw(upstream_pk, 1000, options)
   if not targets then
     return nil, err, err_t
   end

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -121,7 +121,7 @@ local schema_state
 local function build_plugins_map(db, version)
   local map = {}
 
-  for plugin, err in db.plugins:each() do
+  for plugin, err in db.plugins:each(1000) do
     if err then
       return nil, err
     end

--- a/kong/plugins/acl/groups.lua
+++ b/kong/plugins/acl/groups.lua
@@ -15,7 +15,7 @@ local function load_groups_into_memory(consumer_pk)
   local groups = {}
   local len    = 0
 
-  for row, err in kong.db.acls:each_for_consumer(consumer_pk) do
+  for row, err in kong.db.acls:each_for_consumer(consumer_pk, 1000) do
     if err then
       return nil, err
     end

--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -471,7 +471,7 @@ do
   -- and upstream entity tables as values, or nil+error
   local function load_upstreams_dict_into_memory()
     local upstreams_dict = {}
-    for up in singletons.db.upstreams:each() do
+    for up in singletons.db.upstreams:each(1000) do
     -- build a dictionary, indexed by the upstream name
       upstreams_dict[up.name] = up.id
     end

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -436,7 +436,7 @@ return {
         log(DEBUG, "[events] SSL cert updated, invalidating cached certificates")
         local certificate = data.entity
 
-        for sn, err in db.snis:each_for_certificate({ id = certificate.id }) do
+        for sn, err in db.snis:each_for_certificate({ id = certificate.id }, 1000) do
           if err then
             log(ERR, "[events] could not find associated snis for certificate: ",
                      err)


### PR DESCRIPTION
### Summary

This is a first PR that comes from the discussion of #4171.

This changes full table iterations to use `1000` as a page size instead of the previous `100` (the default in admin api).

Introduces slight performance benefits.