### PR TITLE
perf(db) improve kong startup time by reusing luasocket on kong.init

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -289,6 +289,7 @@ function Kong.init()
   end
   --]]
 
+  assert(db:connect())
   assert(db.plugins:check_db_against_config(config.loaded_plugins))
 
   -- LEGACY
@@ -344,12 +345,10 @@ function Kong.init()
   sort_plugins_for_execution(config, db, loaded_plugins)
 
   local err
-  plugins_map_semaphore, err = semaphore.new()
+  plugins_map_semaphore, err = semaphore.new(1) -- 1 = treat this as a mutex
   if not plugins_map_semaphore then
     error("failed to create plugins map semaphore: " .. err)
   end
-
-  plugins_map_semaphore:post(1) -- one resource, treat this as a mutex
 
   local _, err = build_plugins_map(db, "init")
   if err then
@@ -357,6 +356,8 @@ function Kong.init()
   end
 
   assert(runloop.build_router(db, "init"))
+
+  assert(db:close())
 end
 
 


### PR DESCRIPTION
### Summary

This is the seond PR that comes from the discussion of #4171.

Without this patch the Postgres strategy creates 7 non-pooled luasocket connections to database on Kong.init(). This patch reduces that to 3.

Without this patch the Cassandra strategy creates 9 non-pooled luasocket connections to database on Kong.init(). This patch reduces that to 1.

The difference is because Postgres needs to run initialization SQL to setup the connection timezone and database schema on new connections. And for Postgres `connect_migrations` is the same
as `connect` while with Cassandra it is not. It is still a tiny improvement for Postgres as well.