### PR TITLE
perf(db) reuse first call of schema_state in translation function

### DIFF
--- a/kong/db/dao/plugins.lua
+++ b/kong/db/dao/plugins.lua
@@ -304,6 +304,15 @@ end
 
 
 function Plugins:select_by_cache_key(key)
+  local schema_state = assert(self.db:last_schema_state())
+
+  -- if migration is complete, disable this translator function
+  -- and use the regular function
+  if schema_state:is_migration_executed("core", "001_14_to_15") then
+    self.select_by_cache_key = self.super.select_by_cache_key
+    Plugins.select_by_cache_key = nil
+    return self.super.select_by_cache_key(self, key)
+  end
 
   -- first try new way
   local entity, new_err = self.super.select_by_cache_key(self, key)

--- a/kong/db/init.lua
+++ b/kong/db/init.lua
@@ -411,8 +411,19 @@ do
   local MigrationHelpers = require "kong.db.migrations.helpers"
   local MigrationsState = require "kong.db.migrations.state"
 
+
+  local last_schema_state
+
+
   function DB:schema_state()
-    return MigrationsState.load(self)
+    local err
+    last_schema_state, err = MigrationsState.load(self)
+    return last_schema_state, err
+  end
+
+
+  function DB:last_schema_state()
+    return last_schema_state or self:schema_state()
   end
 
 

--- a/spec/01-unit/01-db/07-db.lua
+++ b/spec/01-unit/01-db/07-db.lua
@@ -1,0 +1,99 @@
+local mocker = require("spec.fixtures.mocker")
+
+
+local function setup_it_block()
+  mocker.setup(finally, {
+    modules = {
+      {"kong.db.strategies", {
+        new = function()
+          local connector = {
+            infos = function()
+              return {}
+            end,
+            connect_migrations = function()
+              return true
+            end,
+            schema_migrations = function()
+              return {}
+            end,
+            is_014 = function()
+              return { is_014 = false }
+            end,
+            close = function()
+            end,
+          }
+          local strategies = mocker.table_where_every_key_returns({})
+          return connector, strategies
+        end,
+      }},
+      {"kong.db", {}},
+    }
+  })
+end
+
+
+describe("DB", function()
+
+  describe("schema_state", function()
+
+    it("returns the state of migrations", function()
+      setup_it_block()
+
+      local DB = require("kong.db")
+
+      local kong_config = {
+        loaded_plugins = {},
+      }
+      local db, err = DB.new(kong_config, "mock")
+      assert.is_nil(err)
+      assert.is_table(db)
+
+      local state = db:schema_state()
+      assert.is_table(state)
+    end)
+
+  end)
+
+  describe("last_schema_state", function()
+
+    it("returns the last fetched state of migrations", function()
+      setup_it_block()
+
+      local DB = require("kong.db")
+
+      local kong_config = {
+        loaded_plugins = {},
+      }
+      local db, err = DB.new(kong_config, "mock")
+      assert.is_nil(err)
+      assert.is_table(db)
+
+      local state = db:schema_state()
+      assert.is_table(state)
+
+      local last_state = db:last_schema_state()
+
+      -- calling last_schema_state returns the same object
+      assert(state == last_state)
+
+      local last_state_2 = db:last_schema_state()
+
+      -- calling it again returns the same object
+      assert(state == last_state_2)
+
+      local state_2 = db:schema_state()
+      assert.is_table(state_2)
+
+      -- schema_state always returns a new object
+      assert(state ~= state_2)
+
+      local last_state_3 = db:last_schema_state()
+
+      -- the latest object created by schema_state is the one cached
+      assert(state_2 == last_state_3)
+
+    end)
+
+  end)
+
+end)

--- a/spec/01-unit/01-db/07-db.lua
+++ b/spec/01-unit/01-db/07-db.lua
@@ -73,24 +73,27 @@ describe("DB", function()
 
       local last_state = db:last_schema_state()
 
-      -- calling last_schema_state returns the same object
-      assert(state == last_state)
+      assert(state == last_state,
+             "expected that calling last_schema_state returned " ..
+             "the same object as schema_state")
 
       local last_state_2 = db:last_schema_state()
 
-      -- calling it again returns the same object
-      assert(state == last_state_2)
+      assert(state == last_state_2,
+             "expected that calling last_schema_state twice " ..
+             "returns the same object")
 
       local state_2 = db:schema_state()
       assert.is_table(state_2)
 
-      -- schema_state always returns a new object
-      assert(state ~= state_2)
+      assert(state ~= state_2,
+             "expected schema_state to always return a new object")
 
       local last_state_3 = db:last_schema_state()
 
-      -- the latest object created by schema_state is the one cached
-      assert(state_2 == last_state_3)
+      assert(state_2 == last_state_3,
+             "expected the object returned by last_schema_state " ..
+             "to be the latest created by schema_state")
 
     end)
 

--- a/spec/fixtures/mocker.lua
+++ b/spec/fixtures/mocker.lua
@@ -1,0 +1,52 @@
+local mocker = {}
+
+-- Setup mocks, which are undone in a finally() block
+-- @param finally The `finally` function, that needs to be passed in because
+-- Busted generates it dynamically.
+-- @param args A table containing three optional fields:
+-- * modules: an array of pairs (module name, module content).
+--   This allows modules to be declared in order.
+-- * kong: a mock of the kong global (which will fallback to the default one
+--   via metatable)
+-- * ngx: a mock of the ngx global (which will fallback to the default one
+--   via metatable)
+function mocker.setup(finally, args)
+
+  local mocked_modules = {}
+  local _ngx = _G.ngx
+  local _kong = _G.kong
+
+  local function mock_module(name, tbl)
+    local old_module = require(name)
+    mocked_modules[name] = true
+    package.loaded[name] = setmetatable(tbl or {}, {
+      __index = old_module,
+    })
+  end
+
+  if args.ngx then
+    _G.ngx = setmetatable(args.ngx, { __index = _ngx })
+  end
+
+  if args.kong then
+    _G.kong = setmetatable(args.kong, { __index = _kong })
+  end
+
+  if args.modules then
+    for _, pair in ipairs(args.modules) do
+      mock_module(pair[1], pair[2])
+    end
+  end
+
+  finally(function()
+    _G.ngx = _ngx
+    _G.kong = _kong
+
+    for k in pairs(mocked_modules) do
+      package.loaded[k] = nil
+    end
+  end)
+end
+
+
+return mocker

--- a/spec/fixtures/mocker.lua
+++ b/spec/fixtures/mocker.lua
@@ -49,4 +49,13 @@ function mocker.setup(finally, args)
 end
 
 
+function mocker.table_where_every_key_returns(value)
+  return setmetatable({}, {
+     __index = function()
+                 return value
+               end
+  })
+end
+
+
 return mocker


### PR DESCRIPTION
The translation function for plugins:select_by_cache_key needs to poll
schema_state to decide when to stop using the "migrating" version of the
operation.

Kong checks the schema state once on startup. This commit adds a new
operation, `DB:last_schema_state` to retrieve the last value obtained
(`DB:schema_state` remains the same, re-querying the live database). The
`plugins:select_by_cache_key` translation function first checks
`last_schema_state` before performing the more expensive operation using
`schema_state`.

In the usual scenario where Kong is properly migrated before startup, the use
of `last_schema_state` will be sufficient for disabling the translation
function.

See #4164.