### PR TITLE
Add test helper to get Kong version, bump version.lua to 1.0.1

### DIFF
--- a/kong-1.0.0-0.rockspec
+++ b/kong-1.0.0-0.rockspec
@@ -18,7 +18,7 @@ dependencies = {
   "lua-resty-http == 0.12",
   "lua-resty-jit-uuid == 0.0.7",
   "multipart == 0.5.5",
-  "version == 0.2",
+  "version == 1.0.1",
   "kong-lapis == 1.6.0.1",
   "lua-cassandra == 1.3.3",
   "pgmoon == 1.9.0",

--- a/spec/02-integration/01-helpers/01-helpers_spec.lua
+++ b/spec/02-integration/01-helpers/01-helpers_spec.lua
@@ -63,6 +63,13 @@ for _, strategy in helpers.each_strategy() do
       end)
     end)
 
+    describe("get_version()", function()
+      it("gets the version of Kong running", function()
+        local meta = require 'kong.meta'
+        local version = require 'version'
+        assert.equal(version(meta._VERSION), helpers.get_version())
+      end)
+    end)
 
     describe("wait_until()", function()
       it("does not errors out if thing happens", function()

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -27,6 +27,7 @@ local pl_stringx = require "pl.stringx"
 local pl_utils = require "pl.utils"
 local pl_path = require "pl.path"
 local pl_file = require "pl.file"
+local version = require "version"
 local pl_dir = require "pl.dir"
 local pl_Set = require "pl.Set"
 local Schema = require "kong.db.schema"
@@ -1247,6 +1248,21 @@ local function validate_plugin_config_schema(config, schema_def)
 end
 
 
+--- Return the actual Kong version the tests are running against.
+-- See [version.lua](https://github.com/kong/version.lua) for the format. This is mostly useful for testing plugins
+-- that should work with multiple Kong versions.
+-- @return a `version`
+-- @usage
+-- local version = require 'version'
+-- if helpers.get_version() < version("0.15.0") then
+--   -- do something
+-- end
+local function get_version()
+  return version(select(3, assert(kong_exec("version"))))
+end
+
+
+
 ----------
 -- Exposed
 ----------
@@ -1287,6 +1303,7 @@ return {
   -- Kong testing helpers
   execute = exec,
   kong_exec = kong_exec,
+  get_version = get_version,
   http_client = http_client,
   wait_until = wait_until,
   tcp_server = tcp_server,


### PR DESCRIPTION
### Summary

The test helper is mainly for plugins testing, since recent changes make the test set up harder. See https://github.com/Kong/kong-plugin/pull/9

### Full changelog

* updated `version.lua` to 1.0.1
* added `helpers.get_version()` to dynamically get the Kong version (not from meta data)
