### PR TITLE
fix(admin) targets endpoints and refactor endpoints to more reusable

### DIFF
--- a/kong/api/endpoints.lua
+++ b/kong/api/endpoints.lua
@@ -81,11 +81,6 @@ local function no_content()
 end
 
 
-local function bad_request(...)
-  return kong.response.exit(400, get_message("Bad request", ...))
-end
-
-
 local function not_found(...)
   return kong.response.exit(404, get_message("Not found", ...))
 end
@@ -626,15 +621,7 @@ local disable = {
 
 local Endpoints = {
   disable = disable,
-  ok = ok,
-  created = not_found,
-  no_content = no_content,
-  bad_request = bad_request,
-  not_found = not_found,
-  method_not_allowed = method_not_allowed,
-  unexpected = unexpected,
   handle_error = handle_error,
-  get_page_size = get_page_size,
   extract_options = extract_options,
   select_entity = select_entity,
   update_entity = update_entity,

--- a/kong/api/routes/cache.lua
+++ b/kong/api/routes/cache.lua
@@ -1,35 +1,39 @@
-local singletons = require "kong.singletons"
+local endpoints = require "kong.api.endpoints"
+
+
+local kong = kong
+
 
 return {
   ["/cache/:key"] = {
-    GET = function(self, _, helpers)
+    GET = function(self)
       -- probe the cache to see if a key has been requested before
 
-      local ttl, err, value = singletons.cache:probe(self.params.key)
+      local ttl, err, value = kong.cache:probe(self.params.key)
       if err then
         kong.log.err(err)
-        return kong.response.exit(500, { message = "An unexpected error happened" })
+        return endpoints.unexpected()
       end
 
       if ttl then
-        return kong.response.exit(200, type(value) == "table" and value or { message = value })
+        return endpoints.ok(value)
       end
 
-      return kong.response.exit(404, { message = "Not found" })
+      return endpoints.not_found()
     end,
 
-    DELETE = function(self, _, helpers)
-      singletons.cache:invalidate_local(self.params.key)
+    DELETE = function(self)
+      kong.cache:invalidate_local(self.params.key)
 
-      return kong.response.exit(204) -- no content
+      return endpoints.no_content()
     end,
   },
 
   ["/cache"] = {
-    DELETE = function(self, _, helpers)
-      singletons.cache:purge()
+    DELETE = function()
+      kong.cache:purge()
 
-      return kong.response.exit(204) -- no content
+      return endpoints.no_content()
     end,
   },
 }

--- a/kong/api/routes/cache.lua
+++ b/kong/api/routes/cache.lua
@@ -1,6 +1,3 @@
-local endpoints = require "kong.api.endpoints"
-
-
 local kong = kong
 
 
@@ -12,20 +9,20 @@ return {
       local ttl, err, value = kong.cache:probe(self.params.key)
       if err then
         kong.log.err(err)
-        return endpoints.unexpected()
+        return kong.response.exit(500, { message = "An unexpected error happened" })
       end
 
       if ttl then
-        return endpoints.ok(value)
+        return kong.response.exit(200, type(value) == "table" and value or { message = value })
       end
 
-      return endpoints.not_found()
+      return kong.response.exit(404, { message = "Not found" })
     end,
 
     DELETE = function(self)
       kong.cache:invalidate_local(self.params.key)
 
-      return endpoints.no_content()
+      return kong.response.exit(204) -- no content
     end,
   },
 
@@ -33,7 +30,7 @@ return {
     DELETE = function()
       kong.cache:purge()
 
-      return endpoints.no_content()
+      return kong.response.exit(204) -- no content
     end,
   },
 }

--- a/kong/api/routes/certificates.lua
+++ b/kong/api/routes/certificates.lua
@@ -3,6 +3,7 @@ local utils       = require "kong.tools.utils"
 local Set         = require "pl.Set"
 
 
+local kong = kong
 local unescape_uri = ngx.unescape_uri
 
 
@@ -26,7 +27,7 @@ local function get_cert_id_from_sni(self, db, helpers)
     return
   end
 
-  return endpoints.not_found("SNI not found")
+  return kong.response.exit(404, { message = "SNI not found" })
 end
 
 
@@ -57,10 +58,10 @@ return {
       end
 
       if not cert then
-        return endpoints.not_found()
+        return kong.response.exit(404, { message = "Not found" })
       end
 
-      return endpoints.ok(cert)
+      return kong.response.exit(200, cert)
     end,
   },
 

--- a/kong/api/routes/consumers.lua
+++ b/kong/api/routes/consumers.lua
@@ -3,6 +3,7 @@ local reports = require "kong.reports"
 local utils = require "kong.tools.utils"
 
 
+local kong = kong
 local null = ngx.null
 
 
@@ -28,10 +29,10 @@ return {
           return endpoints.handle_error(err_t)
         end
 
-        return endpoints.ok {
+        return kong.response.exit(200, {
           data = { consumer },
           next = null,
-        }
+        })
       end
 
       return parent()

--- a/kong/api/routes/consumers.lua
+++ b/kong/api/routes/consumers.lua
@@ -6,23 +6,32 @@ local utils = require "kong.tools.utils"
 local null = ngx.null
 
 
+local function post_process(data)
+  local r_data = utils.deep_copy(data)
+  r_data.config = nil
+  r_data.e = "c"
+  reports.send("api", r_data)
+  return data
+end
+
+
 return {
   ["/consumers"] = {
     GET = function(self, db, helpers, parent)
       local args = self.args.uri
-      local opts = endpoints.extract_options(args, db.consumers.schema, "select")
 
       -- Search by custom_id: /consumers?custom_id=xxx
       if args.custom_id then
-        local consumer, _, err_t = db.consumers:select_by_custom_id(args.custom_id, opts)
+        self.params.consumers = args.custom_id
+        local consumer, _, err_t = endpoints.select_entity(self, db, db.consumers.schema, "select_by_custom_id")
         if err_t then
           return endpoints.handle_error(err_t)
         end
 
-        return kong.response.exit(200, {
+        return endpoints.ok {
           data = { consumer },
           next = null,
-        })
+        }
       end
 
       return parent()
@@ -31,13 +40,6 @@ return {
 
   ["/consumers/:consumers/plugins"] = {
     POST = function(_, _, _, parent)
-      local post_process = function(data)
-        local r_data = utils.deep_copy(data)
-        r_data.config = nil
-        r_data.e = "c"
-        reports.send("api", r_data)
-        return data
-      end
       return parent(post_process)
     end,
   },

--- a/kong/api/routes/kong.lua
+++ b/kong/api/routes/kong.lua
@@ -1,4 +1,3 @@
-local endpoints = require "kong.api.endpoints"
 local utils = require "kong.tools.utils"
 local singletons = require "kong.singletons"
 local conf_loader = require "kong.conf_loader"
@@ -29,7 +28,7 @@ return {
         for row, err in kong.db.plugins:each(1000) do
           if err then
             kong.log.err(err)
-            return endpoints.unexpected()
+            return kong.response.exit(500, { message = "An unexpected error happened" })
           end
 
           if not set[row.name] then
@@ -62,7 +61,7 @@ return {
         ngx.log(ngx.ERR, "could not get node id: ", err)
       end
 
-      return endpoints.ok {
+      return kong.response.exit(200, {
         tagline = tagline,
         version = version,
         hostname = utils.get_hostname(),
@@ -78,7 +77,7 @@ return {
         lua_version = lua_version,
         configuration = conf_loader.remove_sensitive(singletons.configuration),
         prng_seeds = prng_seeds,
-      }
+      })
     end
   },
   ["/status"] = {
@@ -86,7 +85,7 @@ return {
       local r = ngx.location.capture "/nginx_status"
       if r.status ~= 200 then
         kong.log.err(r.body)
-        return endpoints.unexpected()
+        return kong.response.exit(500, { message = "An unexpected error happened" })
       end
 
       local var = ngx.var
@@ -118,7 +117,7 @@ return {
       -- ignore error
       kong.db:close()
 
-      return endpoints.ok(status_response)
+      return kong.response.exit(200, status_response)
     end
   }
 }

--- a/kong/api/routes/plugins.lua
+++ b/kong/api/routes/plugins.lua
@@ -1,4 +1,3 @@
-local kong = kong
 local cjson = require "cjson"
 local utils = require "kong.tools.utils"
 local reports = require "kong.reports"
@@ -7,6 +6,7 @@ local arguments = require "kong.api.arguments"
 local singletons = require "kong.singletons"
 
 
+local kong = kong
 local type = type
 local pairs = pairs
 local setmetatable = setmetatable
@@ -25,7 +25,7 @@ local function before_plugin_for_entity(entity_name, plugin_field)
     end
 
     if not entity then
-      return endpoints.not_found()
+      return kong.response.exit(404, { message = "Not found" })
     end
 
     local plugin, _, err_t = endpoints.select_entity(self, db, db.plugins.schema)
@@ -36,7 +36,7 @@ local function before_plugin_for_entity(entity_name, plugin_field)
     if not plugin
        or type(plugin[plugin_field]) ~= "table"
        or plugin[plugin_field].id ~= entity.id then
-      return endpoints.not_found()
+      return kong.response.exit(404, { message = "Not found" })
     end
 
     self.plugin = plugin
@@ -203,7 +203,7 @@ return {
         end
 
         if not plugin then
-          return endpoints.not_found()
+          return kong.response.exit(404, { message = "Not found" })
         end
 
         fill_plugin_data(self.args, plugin)
@@ -217,11 +217,11 @@ return {
     GET = function(self, db, helpers)
       local subschema = db.plugins.schema.subschemas[self.params.name]
       if not subschema then
-        return endpoints.not_found("No plugin named '", self.params.name, "'")
+        return kong.response.exit(404, { message = "No plugin named '" .. self.params.name .. "'" })
       end
 
       local copy = schema_to_jsonable(subschema.fields.config)
-      return endpoints.ok(copy)
+      return kong.response.exit(200, copy)
     end
   },
 
@@ -231,9 +231,9 @@ return {
       for k in pairs(singletons.configuration.loaded_plugins) do
         enabled_plugins[#enabled_plugins+1] = k
       end
-      return endpoints.ok {
+      return kong.response.exit(200, {
         enabled_plugins = enabled_plugins
-      }
+      })
     end
   },
 

--- a/kong/api/routes/snis.lua
+++ b/kong/api/routes/snis.lua
@@ -3,5 +3,5 @@ local endpoints = require "kong.api.endpoints"
 
 return {
   -- deactivate endpoint (use /certificates/sni instead)
-  ["/snis/:snis/certificate"] = endpoints.not_found,
+  ["/snis/:snis/certificate"] = endpoints.disable,
 }

--- a/kong/api/routes/targets.lua
+++ b/kong/api/routes/targets.lua
@@ -3,7 +3,7 @@ local endpoints = require "kong.api.endpoints"
 
 return {
   -- deactivate endpoints (use /upstream/{upstream}/targets instead)
-  ["/targets"] = endpoints.not_found,
-  ["/targets/:targets"] = endpoints.not_found,
-  ["/targets/:targets/upstream"] = endpoints.not_found,
+  ["/targets"] = endpoints.disable,
+  ["/targets/:targets"] = endpoints.disable,
+  ["/targets/:targets/upstream"] = endpoints.disable,
 }

--- a/kong/api/routes/upstreams.lua
+++ b/kong/api/routes/upstreams.lua
@@ -1,151 +1,100 @@
 local endpoints = require "kong.api.endpoints"
 local utils = require "kong.tools.utils"
-local knode = (kong and kong.node) and kong.node or
-              require "kong.pdk.node".new()
 
 
-local unescape_uri = ngx.unescape_uri
+local kong = kong
 local escape_uri = ngx.escape_uri
+local unescape_uri = ngx.unescape_uri
 local null = ngx.null
 local fmt = string.format
 
 
-local function select_upstream(db, upstream_id, opts)
-  local id = unescape_uri(upstream_id)
-  if utils.is_valid_uuid(id) then
-    return db.upstreams:select({ id = id }, opts)
-  end
-
-  return db.upstreams:select_by_name(id, opts)
-end
-
-
-local function select_target(db, upstream, target_id, opts)
-  local id = unescape_uri(target_id)
-  local filter = utils.is_valid_uuid(id) and { id = id } or { target = id }
-
-  return db.targets:select_by_upstream_filter({ id = upstream.id }, filter, opts)
-end
-
-
 local function post_health(self, db, is_healthy)
-  local args = self.args.post
-  local opts = endpoints.extract_options(args, db.upstreams.schema, "select")
-
-  local upstream, _, err_t = select_upstream(db, self.params.upstreams, opts)
+  local upstream, _, err_t = endpoints.select_entity(self, db, db.upstreams.schema)
   if err_t then
     return endpoints.handle_error(err_t)
   end
 
   if not upstream then
-    return kong.response.exit(404, { message = "Not found" })
+    return endpoints.not_found()
   end
 
-  opts = endpoints.extract_options(args, db.targets.schema, "select", opts)
+  local target
+  if utils.is_valid_uuid(unescape_uri(self.params.targets)) then
+    target, _, err_t = endpoints.select_entity(self, db, db.targets.schema)
 
-  local target, _, err_t = select_target(db, upstream, self.params.targets, opts)
+  else
+    local opts = endpoints.extract_options(self.args.uri, db.targets.schema, "select")
+    local upstream_pk = db.upstreams.schema:extract_pk_values(upstream)
+    target, _, err_t = db.targets:select_by_upstream_target(upstream_pk, unescape_uri(self.params.targets), opts)
+  end
+
   if err_t then
     return endpoints.handle_error(err_t)
   end
 
-  if target then
-    local ok, err = db.targets:post_health(upstream, target, is_healthy)
-    if not ok then
-      local body = utils.get_default_exit_body(400, err)
-      return kong.response.exit(400, body)
-    end
+  if not target then
+    return endpoints.not_found()
   end
 
-  return kong.response.exit(204) -- no content
+  local ok, err = db.targets:post_health(upstream, target, is_healthy)
+  if not ok then
+    return endpoints.bad_request(err)
+  end
+
+  return endpoints.no_content()
 end
 
 
 return {
   ["/upstreams/:upstreams/health"] = {
     GET = function(self, db)
-      local args = self.args.uri
-      local opts = endpoints.extract_options(args, db.upstreams.schema, "select")
-
-      local upstream, _, err_t = select_upstream(db, self.params.upstreams, opts)
+      local upstream, _, err_t = endpoints.select_entity(self, db, db.upstreams.schema)
       if err_t then
         return endpoints.handle_error(err_t)
       end
 
       if not upstream then
-        return kong.response.exit(404, { message = "Not found" })
+        return endpoints.not_found()
       end
 
-      local upstream_pk = { id = upstream.id }
-      local size, err = endpoints.get_page_size(args)
-      if err then
-        return endpoints.handle_error(db.targets.errors:invalid_size(err))
-      end
-
-      opts = endpoints.extract_options(args, db.targets.schema, "select")
-
+      self.params.targets = db.upstreams.schema:extract_pk_values(upstream)
       local targets_with_health, _, err_t, offset =
-        db.targets:page_for_upstream_with_health(upstream_pk, size, args.offset, opts)
+        endpoints.page_collection(self, db, db.targets.schema, "page_for_upstream_with_health")
+
       if err_t then
         return endpoints.handle_error(err_t)
       end
 
       local next_page = offset and fmt("/upstreams/%s/health?offset=%s",
-                                       escape_uri(upstream.id),
+                                       self.params.upstreams,
                                        escape_uri(offset)) or null
 
-      local node_id, err = knode.get_id()
+      local node_id, err = kong.node.get_id()
       if err then
-        ngx.log(ngx.ERR, "failed getting node id: ", err)
+        kong.log.err("failed getting node id: ", err)
       end
 
-      return kong.response.exit(200, {
+      return endpoints.ok {
         data    = targets_with_health,
         offset  = offset,
         next    = next_page,
         node_id = node_id,
-      })
+      }
     end
   },
 
+  ["/upstreams/:upstreams/targets"] = {
+    GET = endpoints.get_collection_endpoint(kong.db.targets.schema,
+                                            kong.db.upstreams.schema,
+                                            "upstream",
+                                            "page_for_upstream_without_inactive"),
+  },
+
   ["/upstreams/:upstreams/targets/all"] = {
-    GET = function(self, db)
-      local args = self.args.uri
-      local opts = endpoints.extract_options(args, db.upstreams.schema, "select")
-
-      local upstream, _, err_t = select_upstream(db, self.params.upstreams, opts)
-      if err_t then
-        return endpoints.handle_error(err_t)
-      end
-
-      if not upstream then
-        return kong.response.exit(404, { message = "Not found" })
-      end
-
-      local upstream_pk = { id = upstream.id }
-      local opts = endpoints.extract_options(args, db.targets.schema, "select")
-      local size, err = endpoints.get_page_size(args)
-      if err then
-        return endpoints.handle_error(db.targets.errors:invalid_size(err))
-      end
-
-      local targets, _, err_t, offset = db.targets:page_for_upstream_raw(upstream_pk,
-                                                                         size,
-                                                                         args.offset,
-                                                                         opts)
-      if err_t then
-        return endpoints.handle_error(err_t)
-      end
-
-      local next_page = offset and fmt("/upstreams/%s/targets/all?offset=%s",
-                                       escape_uri(upstream.id),
-                                       escape_uri(offset)) or null
-
-      return kong.response.exit(200, {
-        data   = targets,
-        offset = offset,
-        next   = next_page,
-      })
-    end
+    GET = endpoints.get_collection_endpoint(kong.db.targets.schema,
+                                            kong.db.upstreams.schema,
+                                            "upstream")
   },
 
   ["/upstreams/:upstreams/targets/:targets/healthy"] = {
@@ -162,35 +111,40 @@ return {
 
   ["/upstreams/:upstreams/targets/:targets"] = {
     DELETE = function(self, db)
-      local args = self.args.uri
-      local opts = endpoints.extract_options(args, db.upstreams.schema, "select")
-
-      local upstream, _, err_t = select_upstream(db, self.params.upstreams, opts)
+      local upstream, _, err_t = endpoints.select_entity(self, db, db.upstreams.schema)
       if err_t then
         return endpoints.handle_error(err_t)
       end
 
       if not upstream then
-        return kong.response.exit(404, { message = "Not found" })
+        return endpoints.not_found()
       end
 
-      opts = endpoints.extract_options(args, db.targets.schema, "select")
+      local target
+      if utils.is_valid_uuid(unescape_uri(self.params.targets)) then
+        target, _, err_t = endpoints.select_entity(self, db, db.targets.schema)
 
-      local target, _, err_t = select_target(db, upstream, self.params.targets, opts)
+      else
+        local opts = endpoints.extract_options(self.args.uri, db.targets.schema, "select")
+        local upstream_pk = db.upstreams.schema:extract_pk_values(upstream)
+        target, _, err_t = db.targets:select_by_upstream_target(upstream_pk, unescape_uri(self.params.targets), opts)
+      end
+
       if err_t then
         return endpoints.handle_error(err_t)
       end
 
-      if target then
-        opts = endpoints.extract_options(args, db.targets.schema, "delete")
-
-        local _, _, err_t = db.targets:delete({ id = target.id }, opts)
-        if err_t then
-          return endpoints.handle_error(err_t)
-        end
+      if not target then
+        return endpoints.not_found()
       end
 
-      return kong.response.exit(204) -- no content
+      self.params.targets = db.upstreams.schema:extract_pk_values(target)
+      _, _, err_t = endpoints.delete_entity(self, db, db.targets.schema)
+      if err_t then
+        return endpoints.handle_error(err_t)
+      end
+
+      return endpoints.no_content()
     end
   },
 }

--- a/kong/api/routes/upstreams.lua
+++ b/kong/api/routes/upstreams.lua
@@ -16,7 +16,7 @@ local function post_health(self, db, is_healthy)
   end
 
   if not upstream then
-    return endpoints.not_found()
+    return kong.response.exit(404, { message = "Not found" })
   end
 
   local target
@@ -34,15 +34,15 @@ local function post_health(self, db, is_healthy)
   end
 
   if not target then
-    return endpoints.not_found()
+    return kong.response.exit(404, { message = "Not found" })
   end
 
   local ok, err = db.targets:post_health(upstream, target, is_healthy)
   if not ok then
-    return endpoints.bad_request(err)
+    return kong.response.exit(400, { message = err })
   end
 
-  return endpoints.no_content()
+  return kong.response.exit(204)
 end
 
 
@@ -55,7 +55,7 @@ return {
       end
 
       if not upstream then
-        return endpoints.not_found()
+        return kong.response.exit(404, { message = "Not found" })
       end
 
       self.params.targets = db.upstreams.schema:extract_pk_values(upstream)
@@ -75,12 +75,12 @@ return {
         kong.log.err("failed getting node id: ", err)
       end
 
-      return endpoints.ok {
+      return kong.response.exit(200, {
         data    = targets_with_health,
         offset  = offset,
         next    = next_page,
         node_id = node_id,
-      }
+      })
     end
   },
 
@@ -117,7 +117,7 @@ return {
       end
 
       if not upstream then
-        return endpoints.not_found()
+        return kong.response.exit(404, { message = "Not found" })
       end
 
       local target
@@ -135,7 +135,7 @@ return {
       end
 
       if not target then
-        return endpoints.not_found()
+        return kong.response.exit(404, { message = "Not found" })
       end
 
       self.params.targets = db.upstreams.schema:extract_pk_values(target)
@@ -144,7 +144,7 @@ return {
         return endpoints.handle_error(err_t)
       end
 
-      return endpoints.no_content()
+      return kong.response.exit(204)
     end
   },
 }

--- a/kong/db/dao/certificates.lua
+++ b/kong/db/dao/certificates.lua
@@ -37,7 +37,7 @@ local function parse_name_list(input, errors)
   end
 
   table.sort(name_list)
-  return setmetatable(name_list, cjson.empty_array_mt)
+  return setmetatable(name_list, cjson.array_mt)
 end
 
 

--- a/kong/plugins/acl/api.lua
+++ b/kong/plugins/acl/api.lua
@@ -26,7 +26,7 @@ return {
           return endpoints.handle_error(err_t)
         end
         if not consumer then
-          return endpoints.not_found()
+          return kong.response.exit(404, { message = "Not found" })
         end
 
         self.consumer = consumer
@@ -38,7 +38,7 @@ return {
           end
 
           if not acl or acl.consumer.id ~= consumer.id then
-            return endpoints.not_found()
+            return kong.response.exit(404, { message = "Not found" })
           end
 
           self.acl = acl

--- a/kong/plugins/acl/api.lua
+++ b/kong/plugins/acl/api.lua
@@ -26,20 +26,21 @@ return {
           return endpoints.handle_error(err_t)
         end
         if not consumer then
-          return kong.response.exit(404, { message = "Not found" })
+          return endpoints.not_found()
         end
 
         self.consumer = consumer
 
-        local acl, _, err_t = endpoints.select_entity(self, db, acls_schema)
-        if err_t then
-          return endpoints.handle_error(err_t)
-        end
-
-        if self.req.cmd_mth ~= "PUT" then
-          if not acl or acl.consumer.id ~= consumer.id then
-            return kong.response.exit(404, { message = "Not found" })
+        if self.req.method ~= "PUT" then
+          local acl, _, err_t = endpoints.select_entity(self, db, acls_schema)
+          if err_t then
+            return endpoints.handle_error(err_t)
           end
+
+          if not acl or acl.consumer.id ~= consumer.id then
+            return endpoints.not_found()
+          end
+
           self.acl = acl
           self.params.acls = acl.id
         end

--- a/kong/plugins/basic-auth/api.lua
+++ b/kong/plugins/basic-auth/api.lua
@@ -25,8 +25,9 @@ return {
         if err_t then
           return endpoints.handle_error(err_t)
         end
+
         if not consumer then
-          return endpoints.not_found()
+          return kong.response.exit(404, { message = "Not found" })
         end
 
         self.consumer = consumer
@@ -38,7 +39,7 @@ return {
           end
 
           if not cred or cred.consumer.id ~= consumer.id then
-            return endpoints.not_found()
+            return kong.response.exit(404, { message = "Not found" })
           end
 
           self.basicauth_credential = cred

--- a/kong/plugins/basic-auth/api.lua
+++ b/kong/plugins/basic-auth/api.lua
@@ -26,19 +26,19 @@ return {
           return endpoints.handle_error(err_t)
         end
         if not consumer then
-          return kong.response.exit(404, { message = "Not found" })
+          return endpoints.not_found()
         end
 
         self.consumer = consumer
 
-        local cred, _, err_t = endpoints.select_entity(self, db, credentials_schema)
-        if err_t then
-          return endpoints.handle_error(err_t)
-        end
+        if self.req.method ~= "PUT" then
+          local cred, _, err_t = endpoints.select_entity(self, db, credentials_schema)
+          if err_t then
+            return endpoints.handle_error(err_t)
+          end
 
-        if self.req.cmd_mth ~= "PUT" then
           if not cred or cred.consumer.id ~= consumer.id then
-            return kong.response.exit(404, { message = "Not found" })
+            return endpoints.not_found()
           end
 
           self.basicauth_credential = cred

--- a/kong/plugins/hmac-auth/api.lua
+++ b/kong/plugins/hmac-auth/api.lua
@@ -27,19 +27,19 @@ return{
           return endpoints.handle_error(err_t)
         end
         if not consumer then
-          return kong.response.exit(404, { message = "Not found" })
+          return endpoints.not_found()
         end
 
         self.consumer = consumer
 
-        local cred, _, err_t = endpoints.select_entity(self, db, credentials_schema)
-        if err_t then
-          return endpoints.handle_error(err_t)
-        end
+        if self.req.method ~= "PUT" then
+          local cred, _, err_t = endpoints.select_entity(self, db, credentials_schema)
+          if err_t then
+            return endpoints.handle_error(err_t)
+          end
 
-        if self.req.cmd_mth ~= "PUT" then
           if not cred or cred.consumer.id ~= consumer.id then
-            return kong.response.exit(404, { message = "Not found" })
+            return endpoints.not_found()
           end
 
           self.hmacauth_credential = cred

--- a/kong/plugins/hmac-auth/api.lua
+++ b/kong/plugins/hmac-auth/api.lua
@@ -27,7 +27,7 @@ return{
           return endpoints.handle_error(err_t)
         end
         if not consumer then
-          return endpoints.not_found()
+          return kong.response.exit(404, { message = "Not found" })
         end
 
         self.consumer = consumer
@@ -39,7 +39,7 @@ return{
           end
 
           if not cred or cred.consumer.id ~= consumer.id then
-            return endpoints.not_found()
+            return kong.response.exit(404, { message = "Not found" })
           end
 
           self.hmacauth_credential = cred

--- a/kong/plugins/jwt/api.lua
+++ b/kong/plugins/jwt/api.lua
@@ -25,20 +25,21 @@ return {
           return endpoints.handle_error(err_t)
         end
         if not consumer then
-          return kong.response.exit(404, { message = "Not found" })
+          return endpoints.not_found()
         end
 
         self.consumer = consumer
 
-        local cred, _, err_t = endpoints.select_entity(self, db, jwt_secrets_schema)
-        if err_t then
-          return endpoints.handle_error(err_t)
-        end
-
-        if self.req.cmd_mth ~= "PUT" then
-          if not cred or cred.consumer.id ~= consumer.id then
-            return kong.response.exit(404, { message = "Not found" })
+        if self.req.method ~= "PUT" then
+          local cred, _, err_t = endpoints.select_entity(self, db, jwt_secrets_schema)
+          if err_t then
+            return endpoints.handle_error(err_t)
           end
+
+          if not cred or cred.consumer.id ~= consumer.id then
+            return endpoints.not_found()
+          end
+
           self.keyauth_credential = cred
           self.params.keyauth_jwt_secrets = cred.id
         end

--- a/kong/plugins/jwt/api.lua
+++ b/kong/plugins/jwt/api.lua
@@ -25,7 +25,7 @@ return {
           return endpoints.handle_error(err_t)
         end
         if not consumer then
-          return endpoints.not_found()
+          return kong.response.exit(404, { message = "Not found" })
         end
 
         self.consumer = consumer
@@ -37,7 +37,7 @@ return {
           end
 
           if not cred or cred.consumer.id ~= consumer.id then
-            return endpoints.not_found()
+            return kong.response.exit(404, { message = "Not found" })
           end
 
           self.keyauth_credential = cred

--- a/kong/plugins/key-auth/api.lua
+++ b/kong/plugins/key-auth/api.lua
@@ -25,7 +25,7 @@ return {
           return endpoints.handle_error(err_t)
         end
         if not consumer then
-          return endpoints.not_found()
+          return kong.response.exit(404, { message = "Not found" })
         end
 
         self.consumer = consumer
@@ -37,7 +37,7 @@ return {
           end
 
           if not cred or cred.consumer.id ~= consumer.id then
-            return endpoints.not_found()
+            return kong.response.exit(404, { message = "Not found" })
           end
 
           self.keyauth_credential = cred

--- a/kong/plugins/oauth2/api.lua
+++ b/kong/plugins/oauth2/api.lua
@@ -1,9 +1,6 @@
 local endpoints = require "kong.api.endpoints"
 
 
-local HTTP_NOT_FOUND = 404
-
-
 local kong = kong
 local credentials_schema = kong.db.oauth2_credentials.schema
 local tokens_schema = kong.db.oauth2_tokens.schema
@@ -56,20 +53,21 @@ return {
           return endpoints.handle_error(err_t)
         end
         if not consumer then
-          return kong.response.exit(HTTP_NOT_FOUND, { message = "Not Found" })
+          return endpoints.not_found()
         end
 
         self.consumer = consumer
 
-        local cred, _, err_t = endpoints.select_entity(self, db, credentials_schema)
-        if err_t then
-          return endpoints.handle_error(err_t)
-        end
-
-        if self.req.cmd_mth ~= "PUT" then
-          if not cred or cred.consumer.id ~= consumer.id then
-            return kong.response.exit(HTTP_NOT_FOUND, { message = "Not Found" })
+        if self.req.method ~= "PUT" then
+          local cred, _, err_t = endpoints.select_entity(self, db, credentials_schema)
+          if err_t then
+            return endpoints.handle_error(err_t)
           end
+
+          if not cred or cred.consumer.id ~= consumer.id then
+            return endpoints.not_found()
+          end
+
           self.oauth2_credential = cred
           self.params.oauth2_credentials = cred.id
         end

--- a/kong/plugins/oauth2/api.lua
+++ b/kong/plugins/oauth2/api.lua
@@ -53,7 +53,7 @@ return {
           return endpoints.handle_error(err_t)
         end
         if not consumer then
-          return endpoints.not_found()
+          return kong.response.exit(404, { message = "Not found" })
         end
 
         self.consumer = consumer
@@ -65,7 +65,7 @@ return {
           end
 
           if not cred or cred.consumer.id ~= consumer.id then
-            return endpoints.not_found()
+            return kong.response.exit(404, { message = "Not found" })
           end
 
           self.oauth2_credential = cred

--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -111,7 +111,9 @@ do
   local function load_targets_into_memory(upstream_id)
     log(DEBUG, "fetching targets for upstream: ", tostring(upstream_id))
 
-    local target_history, err, err_t = singletons.db.targets:select_by_upstream_raw({ id = upstream_id })
+    local target_history, err, err_t =
+      singletons.db.targets:for_upstream({ id = upstream_id }, 1000)
+
     if not target_history then
       return nil, err, err_t
     end

--- a/spec/01-unit/09-balancer_spec.lua
+++ b/spec/01-unit/09-balancer_spec.lua
@@ -223,7 +223,7 @@ describe("Balancer", function()
     singletons.db = {
       targets = {
         each = each(TARGETS_FIXTURES),
-        select_by_upstream_raw = function(self, upstream_pk)
+        for_upstream = function(self, upstream_pk)
           local upstream_id = upstream_pk.id
           local res, len = {}, 0
           for tgt in self:each() do

--- a/spec/02-integration/03-db/02-db_core_entities_spec.lua
+++ b/spec/02-integration/03-db/02-db_core_entities_spec.lua
@@ -1855,7 +1855,7 @@ for _, strategy in helpers.each_strategy() do
     --[[
     -- Targets entity
 
-    db.targets:page_for_upstream(primary_key)
+    db.targets:page_for_upstream_without_inactive(primary_key)
     --]]
 
     describe("Targets", function()
@@ -1872,9 +1872,9 @@ for _, strategy in helpers.each_strategy() do
         end
       end)
 
-      describe(":page_for_upstream()", function()
+      describe(":page_for_upstream_without_inactive()", function()
         it("return value 'offset' is a string", function()
-          local page, _, _, offset = db.targets:page_for_upstream({
+          local page, _, _, offset = db.targets:page_for_upstream_without_inactive({
             id = upstream.id,
           }, 1)
           assert.not_nil(page)

--- a/spec/02-integration/04-admin_api/03-consumers_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/03-consumers_routes_spec.lua
@@ -27,7 +27,7 @@ end
 
 for _, strategy in helpers.each_strategy() do
 
-describe("Admin API (#" .. strategy .. "): ", function()
+describe("Admin API (#" .. strategy .. "):", function()
   local bp
   local db
   local client
@@ -710,7 +710,7 @@ describe("Admin API (#" .. strategy .. "): ", function()
 
       it("retrieves by id", function()
         local consumer = bp.consumers:insert()
-        local plugin = bp.rewriter_plugins:insert({ consumer = { id = consumer.id }})
+        local plugin = bp.rewriter_plugins:insert({ consumer = { id = consumer.id }}, { nulls = true })
 
         local res = assert(client:send {
           method = "GET",
@@ -722,7 +722,7 @@ describe("Admin API (#" .. strategy .. "): ", function()
       end)
       it("retrieves by consumer id when it has spaces", function()
         local consumer = bp.consumers:insert()
-        local plugin = bp.rewriter_plugins:insert({ consumer = { id = consumer.id }})
+        local plugin = bp.rewriter_plugins:insert({ consumer = { id = consumer.id }}, { nulls = true })
 
         local res = assert(client:send {
           method = "GET",

--- a/spec/02-integration/04-admin_api/04-plugins_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/04-plugins_routes_spec.lua
@@ -65,13 +65,13 @@ for _, strategy in helpers.each_strategy() do
 
           services[i] = service
 
-          plugins[i] = assert(db.plugins:insert {
+          plugins[i] = assert(db.plugins:insert({
             name = "key-auth",
             service = { id = service.id },
             config = {
               key_names = { "testkey" },
             }
-          })
+          }, { nulls = true }))
         end
       end)
 

--- a/spec/02-integration/04-admin_api/09-routes_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/09-routes_routes_spec.lua
@@ -329,7 +329,7 @@ for _, strategy in helpers.each_strategy() do
       describe("/routes/{route}", function()
         describe("GET", function()
           it("retrieves by id", function()
-            local route = bp.routes:insert({ paths = { "/my-route" } })
+            local route = bp.routes:insert({ paths = { "/my-route" } }, { nulls = true })
             local res  = client:get("/routes/" .. route.id)
             local body = assert.res_status(200, res)
 
@@ -338,7 +338,7 @@ for _, strategy in helpers.each_strategy() do
           end)
 
           it("retrieves by name", function()
-            local route = bp.named_routes:insert()
+            local route = bp.named_routes:insert(nil, { nulls = true })
             local res  = client:get("/routes/" .. route.name)
             local body = assert.res_status(200, res)
 

--- a/spec/02-integration/04-admin_api/10-services_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/10-services_routes_spec.lua
@@ -230,7 +230,7 @@ for _, strategy in helpers.each_strategy() do
 
         describe("GET", function()
           it("retrieves by id", function()
-            local service = bp.services:insert()
+            local service = bp.services:insert(nil, { nulls = true })
             local res  = client:get("/services/" .. service.id)
             local body = assert.res_status(200, res)
 
@@ -239,7 +239,7 @@ for _, strategy in helpers.each_strategy() do
           end)
 
           it("retrieves by name", function()
-            local service = bp.named_services:insert()
+            local service = bp.named_services:insert(nil, { nulls = true })
             local res  = client:get("/services/" .. service.name)
             local body = assert.res_status(200, res)
 

--- a/spec/02-integration/05-proxy/10-balancer_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer_spec.lua
@@ -723,6 +723,7 @@ for _, strategy in helpers.each_strategy() do
                   successes = 1
                 },
                 http_path = "/status",
+                https_sni = cjson.null,
                 https_verify_certificate = true,
                 timeout = 1,
                 unhealthy = {


### PR DESCRIPTION
This is a way bigger than I hoped, but I found more issues while trying to tackle the issue at hand:

Fixes #4132: Unable to set health of Targets

Also fixes issues with `nulls = true` (see e.g. the edited tests, which were wrong) not always passed with custom Admin APIs. But that is not the whole story as I went to refactor our APIs to be more symmetric and added some helpers. It changes the `kong.db.targets` API a little bit to make it more similar on autogenerated side as other kong.db.* apis.

Exposes new endpoints helpers.

Database:

 - endpoints.update_entity
 - endpoints.upsert_entity
 - endpoints.delete_entity
 - endpoints.insert_entity
 - endpoints.page_collection

~~HTTP Response:~~

~~- endpoints.ok~~
~~- endpoints.created~~
~~- endpoints.no_content~~
~~- endpoints.bad_request~~
~~- endpoints.not_found~~
~~- endpoints.method_not_allowed~~
~~- endpoints.unexpected~~

This PR also makes `kong.api.endpoints` to use these and also updates custom apis to use these.

Renames previous helper `endpoints.not_found` to `endpoints.disable` (used to disable autogenerated apis).

Targets APIs now take optimistic approach when `uuid` is passed. This also renames `konf.db.targets` APIs (removes the `_raw` ones which should be the normal ones, and adds more specific methods for the target specific cases. I think this is more what people expect from DAO (the normal dao methods are not changed).

### Issues resolved

Fix #4132: Unable to set health of Targets
