### PR TITLE
chore(gh) remove OOD notation in GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,3 @@
-NOTE: GitHub issues are reserved for **bug reports only**. For anything else,
-please join the conversation in Kong Nation https://discuss.konghq.com/.
-
 Please read the CONTRIBUTING.md guidelines to learn on which channels you can
 seek for help and ask general questions:
 


### PR DESCRIPTION
Remove the note that GitHub issues are reserved excluslvely for
bug reports, as feature requests are now accepted here as of
950fc30dd53b13699f493177874f9c0300312073.