### PR TITLE
fix(conf) kong crashes on start with only stream listener

### DIFF
--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -247,8 +247,8 @@ local function prepare_prefix(kong_config, nginx_custom_template_path)
   end
 
   -- generate default SSL certs if needed
-  if kong_config.proxy_ssl_enabled and not kong_config.ssl_cert and
-     not kong_config.ssl_cert_key then
+  if not kong_config.ssl_cert and not kong_config.ssl_cert_key and
+    (kong_config.proxy_ssl_enabled or kong_config.stream_listeners[1] ~= nil) then
     log.verbose("SSL enabled, no custom certificate set: using default certificate")
     local ok, err = gen_default_ssl_cert(kong_config)
     if not ok then

--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -38,6 +38,17 @@ describe("kong start/stop", function()
     assert(helpers.kong_exec("start --conf " .. helpers.test_conf_path))
     assert(helpers.kong_exec("stop --prefix " .. helpers.test_conf.prefix))
   end)
+  it("start/stop Kong with only stream listeners enabled", function()
+    assert(helpers.kong_exec("start ", {
+      prefix = helpers.test_conf.prefix,
+      admin_listen = "off",
+      proxy_listen = "off",
+      stream_listen = "127.0.0.1:9022",
+    }))
+    assert(helpers.kong_exec("stop", {
+      prefix = helpers.test_conf.prefix
+    }))
+  end)
   it("start dumps Kong config in prefix", function()
     assert(helpers.kong_exec("start --conf " .. helpers.test_conf_path))
     assert.truthy(helpers.path.exists(helpers.test_conf.kong_env))


### PR DESCRIPTION
### Summary

To reproduce the issue, start Kong with:
```
KONG_PROXY_LISTEN=off \
KONG_ADMIN_LISTEN=off \
KONG_STREAM_LISTEN=0.0.0.0:9000 kong start --vv
```

This PR fixes the above to work.