### PR TITLE
feat(schema) verify the validity of plugin schemas

### DIFF
--- a/kong/cmd/migrations.lua
+++ b/kong/cmd/migrations.lua
@@ -2,6 +2,7 @@ local DB = require "kong.db"
 local log = require "kong.cmd.utils.log"
 local tty = require "kong.cmd.utils.tty"
 local conf_loader = require "kong.conf_loader"
+local kong_global = require "kong.global"
 local migrations_utils = require "kong.cmd.utils.migrations"
 
 
@@ -82,6 +83,9 @@ local function execute(args)
 
   conf.cassandra_timeout = args.db_timeout -- connect + send + read
   conf.cassandra_schema_consensus_timeout = args.db_timeout
+
+  _G.kong = kong_global.new()
+  kong_global.init_pdk(_G.kong, conf, nil) -- nil: latest PDK
 
   local db = assert(DB.new(conf))
   assert(db:init_connector())

--- a/kong/cmd/start.lua
+++ b/kong/cmd/start.lua
@@ -2,6 +2,7 @@ local migrations_utils = require "kong.cmd.utils.migrations"
 local prefix_handler = require "kong.cmd.utils.prefix_handler"
 local nginx_signals = require "kong.cmd.utils.nginx_signals"
 local conf_loader = require "kong.conf_loader"
+local kong_global = require "kong.global"
 local kill = require "kong.cmd.utils.kill"
 local log = require "kong.cmd.utils.log"
 local DB = require "kong.db"
@@ -21,6 +22,9 @@ local function execute(args)
 
   assert(not kill.is_running(conf.nginx_pid),
          "Kong is already running in " .. conf.prefix)
+
+  _G.kong = kong_global.new()
+  kong_global.init_pdk(_G.kong, conf, nil) -- nil: latest PDK
 
   local db = assert(DB.new(conf))
   assert(db:init_connector())

--- a/kong/db/dao/plugins.lua
+++ b/kong/db/dao/plugins.lua
@@ -233,7 +233,15 @@ function Plugins:load_plugin_schemas(plugin_set)
 
     local err
 
-    if not schema.name then
+    if schema.name then
+      local err_t
+      ok, err_t = MetaSchema.MetaSubSchema:validate(schema)
+      if not ok then
+        kong.log.warn("schema for plugin '", plugin, "' is invalid: ",
+                      tostring(self.errors:schema_violation(err_t)))
+      end
+
+    else
       schema, err = convert_legacy_schema(plugin, schema)
       if err then
         return nil, "failed converting legacy schema for " ..

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -916,7 +916,7 @@ end
 
 
 local function resolve_field(self, k, field, subschema)
-  field = field or self.fields[k]
+  field = field or self.fields[tostring(k)]
   if not field then
     return nil, validation_errors.UNKNOWN
   end
@@ -949,7 +949,7 @@ validate_fields = function(self, input)
 
   for k, v in pairs(input) do
     local err
-    local field = self.fields[k]
+    local field = self.fields[tostring(k)]
     if field and field.type == "self" then
       field = input
     else

--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -493,4 +493,42 @@ function MetaSchema.get_supported_validator_set()
 end
 
 
+MetaSchema.MetaSubSchema = Schema.new({
+
+  name = "metasubschema",
+
+  fields = {
+    {
+      name = {
+        type = "string",
+        required = true,
+      },
+    },
+    {
+      fields = fields_array,
+    },
+    {
+      entity_checks = entity_checks_schema,
+    },
+    {
+      check = {
+        type = "function",
+        nilable = true,
+      },
+    },
+  },
+
+  check = function(schema)
+    local errors = {}
+
+    if not schema.fields then
+      errors["fields"] = meta_errors.TABLE:format("fields")
+      return nil, errors
+    end
+
+    return check_fields(schema, errors)
+  end,
+
+})
+
 return MetaSchema

--- a/kong/globalpatches.lua
+++ b/kong/globalpatches.lua
@@ -1,4 +1,8 @@
+require("resty.core")
+
+
 local ran_before
+
 
 return function(options)
 

--- a/kong/pdk/init.lua
+++ b/kong/pdk/init.lua
@@ -201,7 +201,7 @@
 -- @redirect kong.log
 
 
-require("resty.core")
+assert(package.loaded["resty.core"])
 
 
 local MAJOR_VERSIONS = {

--- a/spec/01-unit/01-db/07-dao/01-plugins_spec.lua
+++ b/spec/01-unit/01-db/07-dao/01-plugins_spec.lua
@@ -1,0 +1,78 @@
+local Plugins = require("kong.db.dao.plugins")
+local Entity = require("kong.db.schema.entity")
+local Errors = require("kong.db.errors")
+require("spec.helpers") -- add spec/fixtures/custom_plugins to package.path
+
+
+describe("kong.db.dao.plugins", function()
+  local self
+
+  lazy_setup(function()
+    assert(Entity.new(require("kong.db.schema.entities.services")))
+    assert(Entity.new(require("kong.db.schema.entities.routes")))
+    assert(Entity.new(require("kong.db.schema.entities.consumers")))
+    local schema = assert(Entity.new(require("kong.db.schema.entities.plugins")))
+
+    self = {
+      schema = schema,
+      errors = Errors.new("mock"),
+      db = {},
+    }
+  end)
+
+  describe("load_plugin_schemas", function()
+
+    it("loads valid plugin schemas", function()
+      local schemas, err = Plugins.load_plugin_schemas(self, {
+        ["key-auth"] = true,
+        ["basic-auth"] = true,
+      })
+      assert.is_nil(err)
+
+      table.sort(schemas, function(a, b)
+        return a.name < b.name
+      end)
+
+      assert.same({
+        {
+          handler = { _name = "basic-auth" },
+          name = "basic-auth",
+        },
+        {
+          handler = { _name = "key-auth" },
+          name = "key-auth",
+        },
+      }, schemas)
+    end)
+
+    it("reports invalid plugin schemas", function()
+      local s = spy.on(kong.log, "warn")
+
+      local schemas, err = Plugins.load_plugin_schemas(self, {
+        ["key-auth"] = true,
+        ["invalid-schema"] = true,
+      })
+
+      assert.spy(s).was_called(1)
+      mock.revert(kong.log)
+
+      table.sort(schemas, function(a, b)
+        return a.name < b.name
+      end)
+
+      assert.is_nil(err)
+      assert.same({
+        {
+          handler = { _name = "invalid-schema" },
+          name = "invalid-schema",
+        },
+        {
+          handler = { _name = "key-auth" },
+          name = "key-auth",
+        },
+      }, schemas)
+    end)
+
+  end)
+
+end)

--- a/spec/fixtures/custom_plugins/kong/plugins/dummy/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/dummy/schema.lua
@@ -3,7 +3,6 @@ return {
   fields = {
     { config = {
         type = "record",
-        nullable = false,
         fields = {
           { resp_header_value = { type = "string", default = "1" }, },
           { append_body = { type = "string" }, },

--- a/spec/fixtures/custom_plugins/kong/plugins/invalid-schema/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/invalid-schema/handler.lua
@@ -1,0 +1,15 @@
+local BasePlugin = require "kong.plugins.base_plugin"
+
+
+local InvalidSchemaHandler = BasePlugin:extend()
+
+
+InvalidSchemaHandler.PRIORITY = 1000
+
+
+function InvalidSchemaHandler:new()
+  InvalidSchemaHandler.super.new(self, "invalid-schema")
+end
+
+
+return InvalidSchemaHandler

--- a/spec/fixtures/custom_plugins/kong/plugins/invalid-schema/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/invalid-schema/schema.lua
@@ -1,0 +1,10 @@
+return {
+  name = "dummy",
+  fields = {
+    { config = {
+        type = "record",
+        fields = {
+          { foo = { type = "bar" }, },
+    }, }, },
+  },
+}

--- a/spec/fixtures/custom_plugins/kong/plugins/rewriter/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/rewriter/schema.lua
@@ -3,7 +3,6 @@ return {
   fields = {
     { config = {
         type = "record",
-        nullable = false,
         fields = {
           { value = { type = "string" }, },
           { extra = { type = "string", default = "extra" }, },

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -17,11 +17,14 @@ local MOCK_UPSTREAM_SSL_PORT = 15556
 local MOCK_UPSTREAM_STREAM_PORT = 15557
 local MOCK_UPSTREAM_STREAM_SSL_PORT = 15558
 
+require("resty.core")
+
 local consumers_schema_def = require "kong.db.schema.entities.consumers"
 local services_schema_def = require "kong.db.schema.entities.services"
 local plugins_schema_def = require "kong.db.schema.entities.plugins"
 local routes_schema_def = require "kong.db.schema.entities.routes"
 local conf_loader = require "kong.conf_loader"
+local kong_global = require "kong.global"
 local Blueprints = require "spec.fixtures.blueprints"
 local pl_stringx = require "pl.stringx"
 local pl_utils = require "pl.utils"
@@ -36,11 +39,6 @@ local http = require "resty.http"
 local nginx_signals = require "kong.cmd.utils.nginx_signals"
 local log = require "kong.cmd.utils.log"
 local DB = require "kong.db"
-
-
-local kong = {
-  table = require("kong.pdk.table").new()
-}
 
 
 log.set_lvl(log.levels.quiet) -- disable stdout logs in tests
@@ -103,6 +101,10 @@ end
 -- Conf and DAO
 ---------------
 local conf = assert(conf_loader(TEST_CONF_PATH))
+
+_G.kong = kong_global.new()
+kong_global.init_pdk(_G.kong, conf, nil) -- nil: latest PDK
+
 local db = assert(DB.new(conf))
 assert(db:init_connector())
 db.plugins:load_plugin_schemas(conf.loaded_plugins)

--- a/t/01-pdk/08-response/12-get_source.t
+++ b/t/01-pdk/08-response/12-get_source.t
@@ -79,6 +79,7 @@ X-Source: exit
 
 
 === TEST 4: response.get_source() returns "error" when upstream timeouts
+--- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
         proxy_pass http://localhost:58252;
@@ -108,6 +109,7 @@ content source: error
 
 
 === TEST 5: response.get_source() returns "error" when upstream timeouts even with KONG_PROXIED = true
+--- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
         access_by_lua_block {
@@ -141,6 +143,7 @@ content source: error
 
 
 === TEST 6: response.get_source() returns "error" when upstream timeouts even with KONG_EXITED = true
+--- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
         access_by_lua_block {


### PR DESCRIPTION
### feat(schema) verify the validity of plugins schema.lua files

Introduces a "MetaSubSchema" for validating subschemas.

For Kong 1.0.x, this will only raise a warning log and not prevent plugins accepted by Kong 1.0.0 from loading.

To add the warning log, I also needed this:

### refactor(*) ensure kong global is always available

The `kong` global, which offers the PDK APIs such as `kong.log`, was available from some parts of the Kong core and not from others. Because of this, we would often end up recoursing to `ngx` APIs instead of the improved `kong` ones.

This refactor loads the `kong` global for two environments where it wasn't being loaded, namely the test files and the `bin/kong` CLI.

Because the Kong core initializes a PDK instance and that loaded `resty.core` (which patches `ngx` fields) and `kong.globalpatches` also patches `ngx` fields for the CLI and tests, it was necessary to move the loading of `resty.core` earlier than the PDK initialization. (An `assert` was kept to verify that the PDK always runs with `resty.core` enabled.)
