### PR TITLE
fix(api) fix handling of invalid targets, better handling of nulls

### DIFF
--- a/kong/api/routes/certificates.lua
+++ b/kong/api/routes/certificates.lua
@@ -3,6 +3,7 @@ local utils       = require "kong.tools.utils"
 local Set         = require "pl.Set"
 
 
+local kong = kong
 local unescape_uri = ngx.unescape_uri
 
 
@@ -22,12 +23,11 @@ local function get_cert_id_from_sni(self, db, helpers)
     return
   end
 
-  if self.req.cmd_mth == "PUT" then
-    self.new_put_sni = id
+  if self.req.method == "PUT" then
     return
   end
 
-  kong.response.exit(404, { message = "SNI not found" })
+  return kong.response.exit(404, { message = "SNI not found" })
 end
 
 
@@ -36,43 +36,21 @@ return {
     before = get_cert_id_from_sni,
 
     -- override to include the snis list when getting an individual certificate
-    GET = function(self, db, helpers)
-      local pk = { id = self.params.certificates }
-
-      local opts = endpoints.extract_options(self.args.uri, db.certificates.schema, "select")
-
-      local cert, _, err_t = db.certificates:select_with_name_list(pk, opts)
-      if err_t then
-        return endpoints.handle_error(err_t)
-      end
-
-      if not cert then
-        kong.response.exit(404, { message = "Not found" })
-      end
-
-      return kong.response.exit(200, cert)
-    end,
+    GET = endpoints.get_entity_endpoint(kong.db.certificates.schema,
+                                        nil, nil, "select_with_name_list"),
 
     -- override to create a new SNI in the PUT /certificates/foo.com (create) case
     PUT = function(self, db, helpers)
-      local args = self.args.post
-
-      local opts = endpoints.extract_options(args, db.certificates.schema, "upsert")
-
       local cert, err_t, _
       local id = unescape_uri(self.params.certificates)
 
       -- cert was found via id or sni inside `before` section
       if utils.is_valid_uuid(id) then
-        cert, _, err_t = db.certificates:upsert({ id = id }, args, opts)
+        cert, _, err_t = endpoints.upsert_entity(self, db, db.certificates.schema)
 
       else -- create a new cert. Add extra sni if provided on url
-        if self.new_put_sni then
-          args.snis = Set.values(Set(args.snis or {}) + self.new_put_sni)
-          self.new_put_sni = nil
-        end
-
-        cert, _, err_t = db.certificates:insert(args, opts)
+        self.args.post.snis = Set.values(Set(self.args.post.snis or {}) + id)
+        cert, _, err_t = endpoints.insert_entity(self, db, db.certificates.schema)
       end
 
       if err_t then
@@ -80,7 +58,7 @@ return {
       end
 
       if not cert then
-        kong.response.exit(404, { message = "Not found" })
+        return kong.response.exit(404, { message = "Not found" })
       end
 
       return kong.response.exit(200, cert)

--- a/kong/api/routes/consumers.lua
+++ b/kong/api/routes/consumers.lua
@@ -3,6 +3,7 @@ local reports = require "kong.reports"
 local utils = require "kong.tools.utils"
 
 
+local kong = kong
 local null = ngx.null
 
 
@@ -10,11 +11,11 @@ return {
   ["/consumers"] = {
     GET = function(self, db, helpers, parent)
       local args = self.args.uri
-      local opts = endpoints.extract_options(args, db.consumers.schema, "select")
 
       -- Search by custom_id: /consumers?custom_id=xxx
       if args.custom_id then
-        local consumer, _, err_t = db.consumers:select_by_custom_id(args.custom_id, opts)
+        self.params.consumers = args.custom_id
+        local consumer, _, err_t = endpoints.select_entity(self, db, db.consumers.schema, "select_by_custom_id")
         if err_t then
           return endpoints.handle_error(err_t)
         end

--- a/kong/api/routes/upstreams.lua
+++ b/kong/api/routes/upstreams.lua
@@ -10,29 +10,8 @@ local null = ngx.null
 local fmt = string.format
 
 
-local function select_upstream(db, upstream_id, opts)
-  local id = unescape_uri(upstream_id)
-  if utils.is_valid_uuid(id) then
-    return db.upstreams:select({ id = id }, opts)
-  end
-
-  return db.upstreams:select_by_name(id, opts)
-end
-
-
-local function select_target(db, upstream, target_id, opts)
-  local id = unescape_uri(target_id)
-  local filter = utils.is_valid_uuid(id) and { id = id } or { target = id }
-
-  return db.targets:select_by_upstream_filter({ id = upstream.id }, filter, opts)
-end
-
-
 local function post_health(self, db, is_healthy)
-  local args = self.args.post
-  local opts = endpoints.extract_options(args, db.upstreams.schema, "select")
-
-  local upstream, _, err_t = select_upstream(db, self.params.upstreams, opts)
+  local upstream, _, err_t = endpoints.select_entity(self, db, db.upstreams.schema)
   if err_t then
     return endpoints.handle_error(err_t)
   end
@@ -41,32 +20,38 @@ local function post_health(self, db, is_healthy)
     return kong.response.exit(404, { message = "Not found" })
   end
 
-  opts = endpoints.extract_options(args, db.targets.schema, "select", opts)
+  local target
+  if utils.is_valid_uuid(unescape_uri(self.params.targets)) then
+    target, _, err_t = endpoints.select_entity(self, db, db.targets.schema)
 
-  local target, _, err_t = select_target(db, upstream, self.params.targets, opts)
+  else
+    local opts = endpoints.extract_options(self.args.uri, db.targets.schema, "select")
+    local upstream_pk = db.upstreams.schema:extract_pk_values(upstream)
+    local filter = { target = unescape_uri(self.params.targets) }
+    target, _, err_t = db.targets:select_by_upstream_filter(upstream_pk, filter, opts)
+  end
+
   if err_t then
     return endpoints.handle_error(err_t)
   end
 
-  if target then
-    local ok, err = db.targets:post_health(upstream, target, is_healthy)
-    if not ok then
-      local body = utils.get_default_exit_body(400, err)
-      return kong.response.exit(400, body)
-    end
+  if not target or target.upstream.id ~= upstream.id then
+    return kong.response.exit(404, { message = "Not found" })
   end
 
-  return kong.response.exit(204) -- no content
+  local ok, err = db.targets:post_health(upstream, target, is_healthy)
+  if not ok then
+    return kong.response.exit(400, { message = err })
+  end
+
+  return kong.response.exit(204)
 end
 
 
 return {
   ["/upstreams/:upstreams/health"] = {
     GET = function(self, db)
-      local args = self.args.uri
-      local opts = endpoints.extract_options(args, db.upstreams.schema, "select")
-
-      local upstream, _, err_t = select_upstream(db, self.params.upstreams, opts)
+      local upstream, _, err_t = endpoints.select_entity(self, db, db.upstreams.schema)
       if err_t then
         return endpoints.handle_error(err_t)
       end
@@ -75,16 +60,10 @@ return {
         return kong.response.exit(404, { message = "Not found" })
       end
 
-      local upstream_pk = { id = upstream.id }
-      local size, err = endpoints.get_page_size(args)
-      if err then
-        return endpoints.handle_error(db.targets.errors:invalid_size(err))
-      end
-
-      opts = endpoints.extract_options(args, db.targets.schema, "select")
-
+      self.params.targets = db.upstreams.schema:extract_pk_values(upstream)
       local targets_with_health, _, err_t, offset =
-        db.targets:page_for_upstream_with_health(upstream_pk, size, args.offset, opts)
+        endpoints.page_collection(self, db, db.targets.schema, "page_for_upstream_with_health")
+
       if err_t then
         return endpoints.handle_error(err_t)
       end
@@ -107,45 +86,18 @@ return {
     end
   },
 
+  ["/upstreams/:upstreams/targets"] = {
+    GET = endpoints.get_collection_endpoint(kong.db.targets.schema,
+                                            kong.db.upstreams.schema,
+                                            "upstream",
+                                            "page_for_upstream"),
+  },
+
   ["/upstreams/:upstreams/targets/all"] = {
-    GET = function(self, db)
-      local args = self.args.uri
-      local opts = endpoints.extract_options(args, db.upstreams.schema, "select")
-
-      local upstream, _, err_t = select_upstream(db, self.params.upstreams, opts)
-      if err_t then
-        return endpoints.handle_error(err_t)
-      end
-
-      if not upstream then
-        return kong.response.exit(404, { message = "Not found" })
-      end
-
-      local upstream_pk = { id = upstream.id }
-      local opts = endpoints.extract_options(args, db.targets.schema, "select")
-      local size, err = endpoints.get_page_size(args)
-      if err then
-        return endpoints.handle_error(db.targets.errors:invalid_size(err))
-      end
-
-      local targets, _, err_t, offset = db.targets:page_for_upstream_raw(upstream_pk,
-                                                                         size,
-                                                                         args.offset,
-                                                                         opts)
-      if err_t then
-        return endpoints.handle_error(err_t)
-      end
-
-      local next_page = offset and fmt("/upstreams/%s/targets/all?offset=%s",
-                                       escape_uri(upstream.id),
-                                       escape_uri(offset)) or null
-
-      return kong.response.exit(200, {
-        data   = targets,
-        offset = offset,
-        next   = next_page,
-      })
-    end
+    GET = endpoints.get_collection_endpoint(kong.db.targets.schema,
+                                            kong.db.upstreams.schema,
+                                            "upstream",
+                                            "page_for_upstream_raw")
   },
 
   ["/upstreams/:upstreams/targets/:targets/healthy"] = {
@@ -162,10 +114,7 @@ return {
 
   ["/upstreams/:upstreams/targets/:targets"] = {
     DELETE = function(self, db)
-      local args = self.args.uri
-      local opts = endpoints.extract_options(args, db.upstreams.schema, "select")
-
-      local upstream, _, err_t = select_upstream(db, self.params.upstreams, opts)
+      local upstream, _, err_t = endpoints.select_entity(self, db, db.upstreams.schema)
       if err_t then
         return endpoints.handle_error(err_t)
       end
@@ -174,20 +123,29 @@ return {
         return kong.response.exit(404, { message = "Not found" })
       end
 
-      opts = endpoints.extract_options(args, db.targets.schema, "select")
+      local target
+      if utils.is_valid_uuid(unescape_uri(self.params.targets)) then
+        target, _, err_t = endpoints.select_entity(self, db, db.targets.schema)
 
-      local target, _, err_t = select_target(db, upstream, self.params.targets, opts)
+      else
+        local opts = endpoints.extract_options(self.args.uri, db.targets.schema, "select")
+        local upstream_pk = db.upstreams.schema:extract_pk_values(upstream)
+        local filter = { target = unescape_uri(self.params.targets) }
+        target, _, err_t = db.targets:select_by_upstream_filter(upstream_pk, filter, opts)
+      end
+
       if err_t then
         return endpoints.handle_error(err_t)
       end
 
-      if target then
-        opts = endpoints.extract_options(args, db.targets.schema, "delete")
+      if not target or target.upstream.id ~= upstream.id then
+        return kong.response.exit(404, { message = "Not found" })
+      end
 
-        local _, _, err_t = db.targets:delete({ id = target.id }, opts)
-        if err_t then
-          return endpoints.handle_error(err_t)
-        end
+      self.params.targets = db.upstreams.schema:extract_pk_values(target)
+      _, _, err_t = endpoints.delete_entity(self, db, db.targets.schema)
+      if err_t then
+        return endpoints.handle_error(err_t)
       end
 
       return kong.response.exit(204) -- no content

--- a/spec/02-integration/04-admin_api/03-consumers_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/03-consumers_routes_spec.lua
@@ -710,7 +710,7 @@ describe("Admin API (#" .. strategy .. "): ", function()
 
       it("retrieves by id", function()
         local consumer = bp.consumers:insert()
-        local plugin = bp.rewriter_plugins:insert({ consumer = { id = consumer.id }})
+        local plugin = bp.rewriter_plugins:insert({ consumer = { id = consumer.id }}, { nulls = true })
 
         local res = assert(client:send {
           method = "GET",
@@ -722,7 +722,7 @@ describe("Admin API (#" .. strategy .. "): ", function()
       end)
       it("retrieves by consumer id when it has spaces", function()
         local consumer = bp.consumers:insert()
-        local plugin = bp.rewriter_plugins:insert({ consumer = { id = consumer.id }})
+        local plugin = bp.rewriter_plugins:insert({ consumer = { id = consumer.id }}, { nulls = true })
 
         local res = assert(client:send {
           method = "GET",

--- a/spec/02-integration/04-admin_api/04-plugins_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/04-plugins_routes_spec.lua
@@ -65,13 +65,13 @@ for _, strategy in helpers.each_strategy() do
 
           services[i] = service
 
-          plugins[i] = assert(db.plugins:insert {
+          plugins[i] = assert(db.plugins:insert({
             name = "key-auth",
             service = { id = service.id },
             config = {
               key_names = { "testkey" },
             }
-          })
+          }, { nulls = true }))
         end
       end)
 

--- a/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -1,5 +1,6 @@
 local helpers = require "spec.helpers"
 local cjson = require "cjson"
+local utils   = require "kong.tools.utils"
 
 local function it_content_types(title, fn)
   local test_form_encoded = fn("application/x-www-form-urlencoded")
@@ -563,11 +564,18 @@ describe("Admin API #" .. strategy, function()
       describe("POST #" .. mode, function()
         local upstream
         local target_path
-        local my_target_name = localhost .. ":8192"
+        local target
+        local wrong_target
 
-        before_each(function()
+        lazy_setup(function()
+          local my_target_name = localhost .. ":8192"
+
+          wrong_target = bp.targets:insert {
+            target = my_target_name,
+            weight = 10
+          }
+
           upstream = bp.upstreams:insert {}
-          target_path = "/upstreams/" .. upstream.id .. "/targets/" .. my_target_name
           local status, body = assert(client_send({
             method = "PATCH",
             path = "/upstreams/" .. upstream.id,
@@ -590,7 +598,7 @@ describe("Admin API #" .. strategy, function()
           assert.same(200, status, body)
           local json = assert(cjson.decode(body))
 
-          status = assert(client_send({
+          status, body = assert(client_send({
             method = "POST",
             path = "/upstreams/" .. upstream.id .. "/targets",
             headers = {["Content-Type"] = "application/json"},
@@ -601,6 +609,26 @@ describe("Admin API #" .. strategy, function()
             }
           }))
           assert.same(201, status)
+          target = assert(cjson.decode(body))
+          assert.same(my_target_name, target.target)
+
+          target_path = "/upstreams/" .. upstream.id .. "/targets/" .. target.target
+        end)
+
+        it("checks every combination of valid and invalid upstream and target", function()
+          for i, u in ipairs({ utils.uuid(), "invalid", upstream.name, upstream.id }) do
+            for j, t in ipairs({ utils.uuid(), "invalid:1234", wrong_target.id, target.target, target.id }) do
+              for _, e in ipairs({ "healthy", "unhealthy" }) do
+                local expected = (i >= 3 and j >= 4) and 204 or 404
+                local path = "/upstreams/" .. u .. "/targets/" .. t .. "/" .. e
+                local status = assert(client_send {
+                  method = "POST",
+                  path = "/upstreams/" .. u .. "/targets/" .. t .. "/" .. e
+                })
+                assert.same(expected, status, "bad status for path " .. path)
+              end
+            end
+          end
         end)
 
         it("flips the target status from UNHEALTHY to HEALTHY", function()
@@ -616,7 +644,7 @@ describe("Admin API #" .. strategy, function()
           })
           assert.same(200, status)
           json = assert(cjson.decode(body))
-          assert.same(my_target_name, json.data[1].target)
+          assert.same(target.target, json.data[1].target)
           assert.same("UNHEALTHY", json.data[1].health)
           status = assert(client_send {
             method = "POST",
@@ -629,7 +657,7 @@ describe("Admin API #" .. strategy, function()
           })
           assert.same(200, status)
           json = assert(cjson.decode(body))
-          assert.same(my_target_name, json.data[1].target)
+          assert.same(target.target, json.data[1].target)
           assert.same("HEALTHY", json.data[1].health)
         end)
 
@@ -646,7 +674,7 @@ describe("Admin API #" .. strategy, function()
           })
           assert.same(200, status)
           json = assert(cjson.decode(body))
-          assert.same(my_target_name, json.data[1].target)
+          assert.same(target.target, json.data[1].target)
           assert.same("HEALTHY", json.data[1].health)
           status = assert(client_send {
             method = "POST",
@@ -659,7 +687,7 @@ describe("Admin API #" .. strategy, function()
           })
           assert.same(200, status)
           json = assert(cjson.decode(body))
-          assert.same(my_target_name, json.data[1].target)
+          assert.same(target.target, json.data[1].target)
           assert.same("UNHEALTHY", json.data[1].health)
         end)
       end)

--- a/spec/02-integration/04-admin_api/09-routes_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/09-routes_routes_spec.lua
@@ -329,7 +329,7 @@ for _, strategy in helpers.each_strategy() do
       describe("/routes/{route}", function()
         describe("GET", function()
           it("retrieves by id", function()
-            local route = bp.routes:insert({ paths = { "/my-route" } })
+            local route = bp.routes:insert({ paths = { "/my-route" } }, { nulls = true })
             local res  = client:get("/routes/" .. route.id)
             local body = assert.res_status(200, res)
 
@@ -338,7 +338,7 @@ for _, strategy in helpers.each_strategy() do
           end)
 
           it("retrieves by name", function()
-            local route = bp.named_routes:insert()
+            local route = bp.named_routes:insert(nil, { nulls = true })
             local res  = client:get("/routes/" .. route.name)
             local body = assert.res_status(200, res)
 

--- a/spec/02-integration/04-admin_api/10-services_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/10-services_routes_spec.lua
@@ -230,7 +230,7 @@ for _, strategy in helpers.each_strategy() do
 
         describe("GET", function()
           it("retrieves by id", function()
-            local service = bp.services:insert()
+            local service = bp.services:insert(nil, { nulls = true })
             local res  = client:get("/services/" .. service.id)
             local body = assert.res_status(200, res)
 
@@ -239,7 +239,7 @@ for _, strategy in helpers.each_strategy() do
           end)
 
           it("retrieves by name", function()
-            local service = bp.named_services:insert()
+            local service = bp.named_services:insert(nil, { nulls = true })
             local res  = client:get("/services/" .. service.name)
             local body = assert.res_status(200, res)
 

--- a/spec/02-integration/05-proxy/10-balancer_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer_spec.lua
@@ -723,6 +723,7 @@ for _, strategy in helpers.each_strategy() do
                   successes = 1
                 },
                 http_path = "/status",
+                https_sni = cjson.null,
                 https_verify_certificate = true,
                 timeout = 1,
                 unhealthy = {


### PR DESCRIPTION
This PR includes two bugfixes:

* invalid handling of targets, reported in #4132 
* some null values were not being returned as `null` by the Admin API

As part of the fix, a new `method` argument was added to methods of the `kong.api.endpoints` module, allowing a refactor of several endpoint handlers.

The commits of this PR were extracted from #4189.

Fixes #4132.