### PR TITLE
fix(db) ensure boot when using C* with client-to-node TLS

### DIFF
--- a/kong/db/strategies/cassandra/connector.lua
+++ b/kong/db/strategies/cassandra/connector.lua
@@ -220,7 +220,7 @@ end
 function CassandraConnector:setkeepalive()
   local conn = self:get_stored_connection()
   if not conn then
-    return
+    return true
   end
 
   local ok, err = conn:setkeepalive()
@@ -238,14 +238,14 @@ end
 function CassandraConnector:close()
   local conn = self:get_stored_connection()
   if not conn then
-    return
+    return true
   end
 
-  local ok, err = conn:close()
+  local _, err = conn:close()
 
   self:store_connection(nil)
 
-  if not ok then
+  if err then
     return nil, err
   end
 

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -357,7 +357,7 @@ function Kong.init()
 
   assert(runloop.build_router(db, "init"))
 
-  assert(db:close())
+  db:close()
 end
 
 


### PR DESCRIPTION
A fix for #4212 - more details to come.

EDIT: adding details below

In the init phase, lua-cassandra fallbacks to LuaSocket (since cosockets
are not supported). When we ask Kong to connect to the C* peers over
TLS, we use LuaSec. LuaSec wraps the LuaSocket TCP object (which itself
wraps the kernel socket).

LuaSocket normally returns `1` when calling `sock:close()`, but when
wrapped by LuaSec, the latter dismisses that return value, and thus,
`sslsock:close()` does _not_ return anything.

We could work around this limitation by providing an additional fix to
the pgmoon and lua-cassandra LuaSocket metatable wrappers, but this
commit presents a faster fix for the sake of efficiency, in the spirit
of the 1.0.2 release.

Note also how we changed the return value of `db_conn:close()` to `true`
when no stored connection is found. While not following the initial
design of this API, this changes will help prevent misuses in
higher-level modules (such as the DAO).