### PR TITLE
chore(deps) bump lua-resty-mlcache to 2.3.0

### DIFF
--- a/kong-1.0.1-0.rockspec
+++ b/kong-1.0.1-0.rockspec
@@ -34,7 +34,7 @@ dependencies = {
   "lua-resty-mediador == 0.1.2",
   "lua-resty-healthcheck == 0.6.0",
   "lua-resty-cookie == 0.1.0",
-  "lua-resty-mlcache == 2.2.0",
+  "lua-resty-mlcache == 2.3.0",
   -- external Kong plugins
   "kong-plugin-azure-functions ~> 0.3",
   "kong-plugin-zipkin ~> 0.1",


### PR DESCRIPTION
Changes:

* Returning a negative ttl value from the L3 callback will now make the
  fetched data bypass the cache (it will still be returned by get()). This
  is useful when some fetched data indicates that it is not cacheable.
* When get() returns a value from L2 (shm) during its last millisecond
  of freshness, we do not erroneously cache the value in L1 (LRU)
  indefinitely anymore.
* When get() returns a previously resurrected value from L2 (shm), we
  now correctly set the hit_lvl return value to 4, instead of 2.

Full Changelog:

https://github.com/thibaultcha/lua-resty-mlcache/blob/master/CHANGELOG.md