### PR TITLE
chore(db) connector:close and connector:setkeepalive cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+- [1.0.2](#102)
 - [1.0.1](#101)
 - [1.0.0](#100)
 - [0.15.0](#0150)
@@ -20,6 +21,31 @@
 - [0.10.1](#0101---20170327)
 - [0.10.0](#0100---20170307)
 - [0.9.9 and prior](#099---20170202)
+
+## [1.0.2]
+
+> Released on: 2019/01/17
+
+This is a hotfix release fixing an issue when connecting to Cassandra over TLS.
+
+### Fixes
+
+##### Core
+
+- Fix an issue that would prevent Kong from starting when connecting to
+  Cassandra over TLS. [#4214](https://github.com/Kong/kong/pull/4214)
+
+##### Plugins
+
+- zipkin
+  - Fix a logging failure when DNS is not resolved.
+    [kong-plugin-zipkin@a563f51](https://github.com/Kong/kong-plugin-zipkin/commit/a563f513f943ba0a30f3c69373d9092680a8f670)
+  - Avoid sending redundant tags.
+    [kong-plugin-zipkin/pull/28](https://github.com/Kong/kong-plugin-zipkin/pull/28)
+  - Move `run_on` field to top level plugin schema instead of its config.
+    [kong-plugin-zipkin/pull/38](https://github.com/Kong/kong-plugin-zipkin/pull/38)
+
+[Back to TOC](#table-of-contents)
 
 ## [1.0.1]
 
@@ -3307,6 +3333,7 @@ First version running with Cassandra.
 
 [Back to TOC](#table-of-contents)
 
+[1.0.2]: https://github.com/Kong/kong/compare/1.0.1...1.0.2
 [1.0.1]: https://github.com/Kong/kong/compare/1.0.0...1.0.1
 [1.0.0]: https://github.com/Kong/kong/compare/0.15.0...1.0.0
 [0.15.0]: https://github.com/Kong/kong/compare/0.14.1...0.15.0

--- a/kong-1.0.1-0.rockspec
+++ b/kong-1.0.1-0.rockspec
@@ -34,7 +34,7 @@ dependencies = {
   "lua-resty-mediador == 0.1.2",
   "lua-resty-healthcheck == 0.6.0",
   "lua-resty-cookie == 0.1.0",
-  "lua-resty-mlcache == 2.2.0",
+  "lua-resty-mlcache == 2.3.0",
   -- external Kong plugins
   "kong-plugin-azure-functions ~> 0.3",
   "kong-plugin-zipkin ~> 0.1",

--- a/kong-1.0.2-0.rockspec
+++ b/kong-1.0.2-0.rockspec
@@ -1,9 +1,9 @@
 package = "kong"
-version = "1.0.1-0"
+version = "1.0.2-0"
 supported_platforms = {"linux", "macosx"}
 source = {
   url = "git://github.com/Kong/kong",
-  tag = "1.0.1"
+  tag = "1.0.2"
 }
 description = {
   summary = "Kong is a scalable and customizable API Management Layer built on top of Nginx.",

--- a/kong/api/endpoints.lua
+++ b/kong/api/endpoints.lua
@@ -615,15 +615,13 @@ end
 
 -- A reusable handler for endpoints that are deactivated
 -- (e.g. /targets/:targets)
-local not_found = {
-  before = function()
-    return kong.response.exit(404, { message = "Not found" })
-  end
+local disable = {
+  before = not_found
 }
 
 
 local Endpoints = {
-  not_found = not_found,
+  disable = disable,
   handle_error = handle_error,
   get_page_size = get_page_size,
   extract_options = extract_options,

--- a/kong/api/endpoints.lua
+++ b/kong/api/endpoints.lua
@@ -8,6 +8,9 @@ local kong         = kong
 local escape_uri   = ngx.escape_uri
 local unescape_uri = ngx.unescape_uri
 local tonumber     = tonumber
+local tostring     = tostring
+local select       = select
+local concat       = table.concat
 local null         = ngx.null
 local type         = type
 local fmt          = string.format
@@ -29,10 +32,74 @@ local ERRORS_HTTP_CODES = {
 }
 
 
+local function get_message(default, ...)
+  local message
+  local n = select("#", ...)
+  if n > 0 then
+    if n == 1 then
+      local arg = select(1, ...)
+      if type(arg) == "table" then
+        message = arg
+      elseif arg ~= nil then
+        message = tostring(arg)
+      end
+
+    else
+      message = {}
+      for i = 1, n do
+        local arg = select(i, ...)
+        message[i] = tostring(arg)
+      end
+      message = concat(message)
+    end
+  end
+
+  if not message then
+    message = default
+  end
+
+  if type(message) == "string" then
+    message = { message = message }
+  end
+
+  return message
+end
+
+
+local function ok(...)
+  return kong.response.exit(200, get_message(nil, ...))
+end
+
+
+local function created(...)
+  return kong.response.exit(201, get_message(nil, ...))
+end
+
+
+local function no_content()
+  return kong.response.exit(204)
+end
+
+
+local function not_found(...)
+  return kong.response.exit(404, get_message("Not found", ...))
+end
+
+
+local function method_not_allowed(...)
+  return kong.response.exit(405, get_message("Method not allowed", ...))
+end
+
+
+local function unexpected(...)
+  return kong.response.exit(500, get_message("An unexpected error occurred", ...))
+end
+
+
 local function handle_error(err_t)
   if type(err_t) ~= "table" then
     kong.log.err(err_t)
-    kong.response.exit(500, { message = "An unexpected error occurred" })
+    return unexpected()
   end
 
   if err_t.strategy then
@@ -191,11 +258,12 @@ local function get_collection_endpoint(schema, foreign_schema, foreign_field_nam
                                      schema.name,
                                      escape_uri(offset)) or null
 
-    return kong.response.exit(200, {
+    return ok {
       data   = data,
       offset = offset,
       next   = next_page,
-    })
+    }
+
   end or function(self, db, helpers)
     local foreign_entity, _, err_t = select_entity(self, db, foreign_schema)
     if err_t then
@@ -203,7 +271,7 @@ local function get_collection_endpoint(schema, foreign_schema, foreign_field_nam
     end
 
     if not foreign_entity then
-      return kong.response.exit(404, { message = "Not found" })
+      return not_found()
     end
 
     self.params[schema.name] = foreign_schema:extract_pk_values(foreign_entity)
@@ -219,11 +287,11 @@ local function get_collection_endpoint(schema, foreign_schema, foreign_field_nam
                                      foreign_key, schema.name, escape_uri(offset)) or null
 
 
-    return kong.response.exit(200, {
+    return ok {
       data   = data,
       offset = offset,
       next   = next_page,
-    })
+    }
   end
 end
 
@@ -247,7 +315,7 @@ local function post_collection_endpoint(schema, foreign_schema, foreign_field_na
       end
 
       if not foreign_entity then
-        return kong.response.exit(404, { message = "Not found" })
+        return not_found()
       end
 
       self.args.post[foreign_field_name] = foreign_schema:extract_pk_values(foreign_entity)
@@ -265,7 +333,7 @@ local function post_collection_endpoint(schema, foreign_schema, foreign_field_na
       end
     end
 
-    return kong.response.exit(201, entity)
+    return created(entity)
   end
 end
 
@@ -294,13 +362,13 @@ local function get_entity_endpoint(schema, foreign_schema, foreign_field_name, m
     end
 
     if not entity then
-      return kong.response.exit(404, { message = "Not found" })
+      return not_found()
     end
 
     if foreign_schema then
       local pk = entity[foreign_field_name]
       if not pk or pk == null then
-        return kong.response.exit(404, { message = "Not found" })
+        return not_found()
       end
 
       self.params[foreign_schema.name] = pk
@@ -311,11 +379,11 @@ local function get_entity_endpoint(schema, foreign_schema, foreign_field_name, m
       end
 
       if not entity then
-        return kong.response.exit(404, { message = "Not found" })
+        return not_found()
       end
     end
 
-    return kong.response.exit(200, entity)
+    return ok(entity)
   end
 end
 
@@ -338,10 +406,10 @@ local function put_entity_endpoint(schema, foreign_schema, foreign_field_name, m
     end
 
     if not entity then
-      return kong.response.exit(404, { message = "Not found" })
+      return not_found()
     end
 
-    return kong.response.exit(200, entity)
+    return ok(entity)
 
   end or function(self, db, helpers)
     local entity, _, err_t = select_entity(self, db, schema)
@@ -350,12 +418,12 @@ local function put_entity_endpoint(schema, foreign_schema, foreign_field_name, m
     end
 
     if not entity then
-      return kong.response.exit(404, { message = "Not found" })
+      return not_found()
     end
 
     local pk = entity[foreign_field_name]
     if not pk or pk == null then
-      return kong.response.exit(404, { message = "Not found" })
+      return not_found()
     end
 
     self.params[foreign_schema.name] = pk
@@ -366,10 +434,10 @@ local function put_entity_endpoint(schema, foreign_schema, foreign_field_name, m
     end
 
     if not entity then
-      return kong.response.exit(404, { message = "Not found" })
+      return not_found()
     end
 
-    return kong.response.exit(200, entity)
+    return ok(entity)
   end
 end
 
@@ -392,10 +460,10 @@ local function patch_entity_endpoint(schema, foreign_schema, foreign_field_name,
     end
 
     if not entity then
-      return kong.response.exit(404, { message = "Not found" })
+      return not_found()
     end
 
-    return kong.response.exit(200, entity)
+    return ok(entity)
 
   end or function(self, db, helpers)
     local entity, _, err_t = select_entity(self, db, schema)
@@ -404,12 +472,12 @@ local function patch_entity_endpoint(schema, foreign_schema, foreign_field_name,
     end
 
     if not entity then
-      return kong.response.exit(404, { message = "Not found" })
+      return not_found()
     end
 
     local pk = entity[foreign_field_name]
     if not pk or pk == null then
-      return kong.response.exit(404, { message = "Not found" })
+      return not_found()
     end
 
     self.params[foreign_schema.name] = pk
@@ -420,10 +488,10 @@ local function patch_entity_endpoint(schema, foreign_schema, foreign_field_name,
     end
 
     if not entity then
-      return kong.response.exit(404, { message = "Not found" })
+      return not_found()
     end
 
-    return kong.response.exit(200, entity)
+    return ok(entity)
   end
 end
 
@@ -445,7 +513,7 @@ local function delete_entity_endpoint(schema, foreign_schema, foreign_field_name
       return handle_error(err_t)
     end
 
-    return kong.response.exit(204)
+    return no_content()
 
   end or function(self, db, helpers)
     local entity, _, err_t = select_entity(self, db, schema)
@@ -455,10 +523,10 @@ local function delete_entity_endpoint(schema, foreign_schema, foreign_field_name
 
     local id = entity and entity[foreign_field_name]
     if not id or id == null then
-      return kong.response.exit(404, { message = "Not found" })
+      return not_found()
     end
 
-    return kong.response.exit(405, { message = "Method not allowed" })
+    return method_not_allowed()
   end
 end
 

--- a/kong/api/routes/cache.lua
+++ b/kong/api/routes/cache.lua
@@ -1,11 +1,12 @@
-local singletons = require "kong.singletons"
+local kong = kong
+
 
 return {
   ["/cache/:key"] = {
-    GET = function(self, _, helpers)
+    GET = function(self)
       -- probe the cache to see if a key has been requested before
 
-      local ttl, err, value = singletons.cache:probe(self.params.key)
+      local ttl, err, value = kong.cache:probe(self.params.key)
       if err then
         kong.log.err(err)
         return kong.response.exit(500, { message = "An unexpected error happened" })
@@ -18,16 +19,16 @@ return {
       return kong.response.exit(404, { message = "Not found" })
     end,
 
-    DELETE = function(self, _, helpers)
-      singletons.cache:invalidate_local(self.params.key)
+    DELETE = function(self)
+      kong.cache:invalidate_local(self.params.key)
 
       return kong.response.exit(204) -- no content
     end,
   },
 
   ["/cache"] = {
-    DELETE = function(self, _, helpers)
-      singletons.cache:purge()
+    DELETE = function()
+      kong.cache:purge()
 
       return kong.response.exit(204) -- no content
     end,

--- a/kong/api/routes/kong.lua
+++ b/kong/api/routes/kong.lua
@@ -19,7 +19,7 @@ local lua_version = jit and jit.version or _VERSION
 return {
   ["/"] = {
     GET = function(self, dao, helpers)
-      local distinct_plugins = setmetatable({}, cjson.empty_array_mt)
+      local distinct_plugins = setmetatable({}, cjson.array_mt)
       local prng_seeds = {}
 
       do

--- a/kong/api/routes/snis.lua
+++ b/kong/api/routes/snis.lua
@@ -3,5 +3,5 @@ local endpoints = require "kong.api.endpoints"
 
 return {
   -- deactivate endpoint (use /certificates/sni instead)
-  ["/snis/:snis/certificate"] = endpoints.not_found,
+  ["/snis/:snis/certificate"] = endpoints.disable,
 }

--- a/kong/api/routes/targets.lua
+++ b/kong/api/routes/targets.lua
@@ -3,7 +3,7 @@ local endpoints = require "kong.api.endpoints"
 
 return {
   -- deactivate endpoints (use /upstream/{upstream}/targets instead)
-  ["/targets"] = endpoints.not_found,
-  ["/targets/:targets"] = endpoints.not_found,
-  ["/targets/:targets/upstream"] = endpoints.not_found,
+  ["/targets"] = endpoints.disable,
+  ["/targets/:targets"] = endpoints.disable,
+  ["/targets/:targets/upstream"] = endpoints.disable,
 }

--- a/kong/api/routes/upstreams.lua
+++ b/kong/api/routes/upstreams.lua
@@ -68,7 +68,7 @@ return {
       end
 
       local next_page = offset and fmt("/upstreams/%s/health?offset=%s",
-                                       escape_uri(upstream.id),
+                                       self.params.upstreams,
                                        escape_uri(offset)) or null
 
       local node_id, err = kong.node.get_id()

--- a/kong/api/routes/upstreams.lua
+++ b/kong/api/routes/upstreams.lua
@@ -1,11 +1,10 @@
 local endpoints = require "kong.api.endpoints"
 local utils = require "kong.tools.utils"
-local knode = (kong and kong.node) and kong.node or
-              require "kong.pdk.node".new()
 
 
-local unescape_uri = ngx.unescape_uri
+local kong = kong
 local escape_uri = ngx.escape_uri
+local unescape_uri = ngx.unescape_uri
 local null = ngx.null
 local fmt = string.format
 
@@ -72,9 +71,9 @@ return {
                                        escape_uri(upstream.id),
                                        escape_uri(offset)) or null
 
-      local node_id, err = knode.get_id()
+      local node_id, err = kong.node.get_id()
       if err then
-        ngx.log(ngx.ERR, "failed getting node id: ", err)
+        kong.log.err("failed getting node id: ", err)
       end
 
       return kong.response.exit(200, {

--- a/kong/db/dao/certificates.lua
+++ b/kong/db/dao/certificates.lua
@@ -37,7 +37,7 @@ local function parse_name_list(input, errors)
   end
 
   table.sort(name_list)
-  return setmetatable(name_list, cjson.empty_array_mt)
+  return setmetatable(name_list, cjson.array_mt)
 end
 
 

--- a/kong/db/dao/targets.lua
+++ b/kong/db/dao/targets.lua
@@ -9,6 +9,7 @@ local tostring = tostring
 local ipairs = ipairs
 local assert = assert
 local table = table
+local min = math.min
 
 
 local _TARGETS = {}
@@ -201,8 +202,8 @@ function _TARGETS:page_for_upstream(upstream_pk, size, offset, options)
   end
 
   -- Extract the requested page
-  local page = setmetatable({}, cjson.empty_array_mt)
-  size = math.min(size or 100, 1000)
+  local page = setmetatable({}, cjson.array_mt)
+  size = min(size or 100, 1000)
   offset = offset or 0
   for i = 1 + offset, size + offset do
     local target = all_active_targets[i]

--- a/kong/db/dao/targets.lua
+++ b/kong/db/dao/targets.lua
@@ -260,23 +260,12 @@ function _TARGETS:select_by_upstream_filter(upstream_pk, filter, options)
   if not targets then
     return nil, err, err_t
   end
-  if filter.id then
-    for _, t in ipairs(targets) do
-      if t.id == filter.id then
-        return t
-      end
-    end
-    local err_t = self.errors:not_found(filter.id)
-    return nil, tostring(err_t), err_t
-  end
 
   for _, t in ipairs(targets) do
-    if t.target == filter.target then
+    if t.id == filter.id or t.target == filter.target then
       return t
     end
   end
-  err_t = self.errors:not_found_by_field({ target = filter.target })
-  return nil, tostring(err_t), err_t
 end
 
 

--- a/kong/db/dao/targets.lua
+++ b/kong/db/dao/targets.lua
@@ -7,7 +7,6 @@ local cjson = require "cjson"
 local setmetatable = setmetatable
 local tostring = tostring
 local ipairs = ipairs
-local assert = assert
 local table = table
 local min = math.min
 
@@ -32,7 +31,7 @@ local function clean_history(self, upstream_pk)
   local cleanup_factor = 10
 
   --cleaning up history, check if it's necessary...
-  local targets, err, err_t = self:select_by_upstream_raw(upstream_pk)
+  local targets, err, err_t = self:select_by_upstream_raw(upstream_pk, 1000)
   if not targets then
     return nil, err, err_t
   end
@@ -257,9 +256,7 @@ end
 
 
 function _TARGETS:select_by_upstream_filter(upstream_pk, filter, options)
-  assert(filter.id or filter.target)
-
-  local targets, err, err_t = self:select_by_upstream_raw(upstream_pk, nil, options)
+  local targets, err, err_t = self:select_by_upstream_raw(upstream_pk, 1000, options)
   if not targets then
     return nil, err, err_t
   end

--- a/kong/db/strategies/cassandra/connector.lua
+++ b/kong/db/strategies/cassandra/connector.lua
@@ -223,11 +223,11 @@ function CassandraConnector:setkeepalive()
     return true
   end
 
-  local ok, err = conn:setkeepalive()
+  local _, err = conn:setkeepalive()
 
   self:store_connection(nil)
 
-  if not ok then
+  if err then
     return nil, err
   end
 

--- a/kong/db/strategies/cassandra/connector.lua
+++ b/kong/db/strategies/cassandra/connector.lua
@@ -220,7 +220,7 @@ end
 function CassandraConnector:setkeepalive()
   local conn = self:get_stored_connection()
   if not conn then
-    return
+    return true
   end
 
   local ok, err = conn:setkeepalive()
@@ -238,14 +238,14 @@ end
 function CassandraConnector:close()
   local conn = self:get_stored_connection()
   if not conn then
-    return
+    return true
   end
 
-  local ok, err = conn:close()
+  local _, err = conn:close()
 
   self:store_connection(nil)
 
-  if not ok then
+  if err then
     return nil, err
   end
 

--- a/kong/db/strategies/postgres/connector.lua
+++ b/kong/db/strategies/postgres/connector.lua
@@ -171,56 +171,20 @@ local function connect(config)
 end
 
 
-local function close(connection)
-  if not connection or not connection.sock then
-    return nil, "no active connection"
-  end
-
-  local ok, err = connection:disconnect()
-  if not ok then
-    if err then
-      log(WARN, "unable to close postgres connection (", err, ")")
-
-    else
-      log(WARN, "unable to close postgres connection")
-    end
-
-    return nil, err
-  end
-
-  return true
-end
-
-
 setkeepalive = function(connection)
   if not connection or not connection.sock then
-    return nil, "no active connection"
+    return true
   end
 
-  local ok, err
   if connection.sock_type == "luasocket" then
-    ok, err = connection:disconnect()
-    if not ok then
-      if err then
-        log(WARN, "unable to close postgres connection (", err, ")")
-
-      else
-        log(WARN, "unable to close postgres connection")
-      end
-
+    local _, err = connection:disconnect()
+    if err then
       return nil, err
     end
 
   else
-    ok, err = connection:keepalive()
-    if not ok then
-      if err then
-        log(WARN, "unable to set keepalive for postgres connection (", err, ")")
-
-      else
-        log(WARN, "unable to set keepalive for postgres connection")
-      end
-
+    local _, err = connection:keepalive()
+    if err then
       return nil, err
     end
   end
@@ -373,11 +337,11 @@ function _mt:close()
     return true
   end
 
-  local ok, err = close(conn)
+  local _, err = conn:disconnect()
 
   self:store_connection(nil)
 
-  if not ok then
+  if err then
     return nil, err
   end
 
@@ -391,11 +355,11 @@ function _mt:setkeepalive()
     return true
   end
 
-  local ok, err = setkeepalive(conn)
+  local _, err = setkeepalive(conn)
 
   self:store_connection(nil)
 
-  if not ok then
+  if err then
     return nil, err
   end
 

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -357,7 +357,7 @@ function Kong.init()
 
   assert(runloop.build_router(db, "init"))
 
-  assert(db:close())
+  db:close()
 end
 
 

--- a/kong/meta.lua
+++ b/kong/meta.lua
@@ -1,7 +1,7 @@
 local version = setmetatable({
   major = 1,
   minor = 0,
-  patch = 1,
+  patch = 2,
   --suffix = ""
 }, {
   __tostring = function(t)

--- a/kong/plugins/acl/api.lua
+++ b/kong/plugins/acl/api.lua
@@ -31,15 +31,16 @@ return {
 
         self.consumer = consumer
 
-        local acl, _, err_t = endpoints.select_entity(self, db, acls_schema)
-        if err_t then
-          return endpoints.handle_error(err_t)
-        end
+        if self.req.method ~= "PUT" then
+          local acl, _, err_t = endpoints.select_entity(self, db, acls_schema)
+          if err_t then
+            return endpoints.handle_error(err_t)
+          end
 
-        if self.req.cmd_mth ~= "PUT" then
           if not acl or acl.consumer.id ~= consumer.id then
             return kong.response.exit(404, { message = "Not found" })
           end
+
           self.acl = acl
           self.params.acls = acl.id
         end

--- a/kong/plugins/basic-auth/api.lua
+++ b/kong/plugins/basic-auth/api.lua
@@ -31,12 +31,12 @@ return {
 
         self.consumer = consumer
 
-        local cred, _, err_t = endpoints.select_entity(self, db, credentials_schema)
-        if err_t then
-          return endpoints.handle_error(err_t)
-        end
+        if self.req.method ~= "PUT" then
+          local cred, _, err_t = endpoints.select_entity(self, db, credentials_schema)
+          if err_t then
+            return endpoints.handle_error(err_t)
+          end
 
-        if self.req.cmd_mth ~= "PUT" then
           if not cred or cred.consumer.id ~= consumer.id then
             return kong.response.exit(404, { message = "Not found" })
           end

--- a/kong/plugins/hmac-auth/api.lua
+++ b/kong/plugins/hmac-auth/api.lua
@@ -32,12 +32,12 @@ return{
 
         self.consumer = consumer
 
-        local cred, _, err_t = endpoints.select_entity(self, db, credentials_schema)
-        if err_t then
-          return endpoints.handle_error(err_t)
-        end
+        if self.req.method ~= "PUT" then
+          local cred, _, err_t = endpoints.select_entity(self, db, credentials_schema)
+          if err_t then
+            return endpoints.handle_error(err_t)
+          end
 
-        if self.req.cmd_mth ~= "PUT" then
           if not cred or cred.consumer.id ~= consumer.id then
             return kong.response.exit(404, { message = "Not found" })
           end

--- a/kong/plugins/jwt/api.lua
+++ b/kong/plugins/jwt/api.lua
@@ -30,15 +30,16 @@ return {
 
         self.consumer = consumer
 
-        local cred, _, err_t = endpoints.select_entity(self, db, jwt_secrets_schema)
-        if err_t then
-          return endpoints.handle_error(err_t)
-        end
+        if self.req.method ~= "PUT" then
+          local cred, _, err_t = endpoints.select_entity(self, db, jwt_secrets_schema)
+          if err_t then
+            return endpoints.handle_error(err_t)
+          end
 
-        if self.req.cmd_mth ~= "PUT" then
           if not cred or cred.consumer.id ~= consumer.id then
             return kong.response.exit(404, { message = "Not found" })
           end
+
           self.keyauth_credential = cred
           self.params.keyauth_jwt_secrets = cred.id
         end

--- a/kong/plugins/key-auth/api.lua
+++ b/kong/plugins/key-auth/api.lua
@@ -33,12 +33,12 @@ return {
 
         self.consumer = consumer
 
-        local cred, _, err_t = endpoints.select_entity(self, db, credentials_schema)
-        if err_t then
-          return endpoints.handle_error(err_t)
-        end
+        if self.req.method ~= "PUT" then
+          local cred, _, err_t = endpoints.select_entity(self, db, credentials_schema)
+          if err_t then
+            return endpoints.handle_error(err_t)
+          end
 
-        if self.req.cmd_mth ~= "PUT" then
           if not cred or cred.consumer.id ~= consumer.id then
             return kong.response.exit(HTTP_NOT_FOUND, { message = "Not found" })
           end

--- a/kong/plugins/oauth2/api.lua
+++ b/kong/plugins/oauth2/api.lua
@@ -61,12 +61,12 @@ return {
 
         self.consumer = consumer
 
-        local cred, _, err_t = endpoints.select_entity(self, db, credentials_schema)
-        if err_t then
-          return endpoints.handle_error(err_t)
-        end
+        if self.req.method ~= "PUT" then
+          local cred, _, err_t = endpoints.select_entity(self, db, credentials_schema)
+          if err_t then
+            return endpoints.handle_error(err_t)
+          end
 
-        if self.req.cmd_mth ~= "PUT" then
           if not cred or cred.consumer.id ~= consumer.id then
             return kong.response.exit(HTTP_NOT_FOUND, { message = "Not Found" })
           end

--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -111,7 +111,9 @@ do
   local function load_targets_into_memory(upstream_id)
     log(DEBUG, "fetching targets for upstream: ", tostring(upstream_id))
 
-    local target_history, err, err_t = singletons.db.targets:select_by_upstream_raw({ id = upstream_id })
+    local target_history, err, err_t =
+      singletons.db.targets:select_by_upstream_raw({ id = upstream_id }, 1000)
+
     if not target_history then
       return nil, err, err_t
     end

--- a/spec/02-integration/03-db/01-db_spec.lua
+++ b/spec/02-integration/03-db/01-db_spec.lua
@@ -1,9 +1,11 @@
 local DB      = require "kong.db"
 local helpers = require "spec.helpers"
-
+local utils   = require "kong.tools.utils"
 
 
 for _, strategy in helpers.each_strategy() do
+  local it_ssl = strategy == "cassandra" and pending or it
+
   describe("kong.db.init [#" .. strategy .. "]", function()
     describe(".new()", function()
       it("errors on invalid arg", function()
@@ -94,15 +96,591 @@ for _, strategy in helpers.each_strategy() do
 
 
   describe(":connect() [#" .. strategy .. "]", function()
+    lazy_setup(function()
+      helpers.get_db_utils(strategy, {})
+    end)
 
+    it("returns connection", function()
+      ngx.IS_CLI = false
+
+      local db, err = DB.new(helpers.test_conf, strategy)
+
+      assert.is_nil(err)
+      assert.is_table(db)
+
+      assert(db:init_connector())
+      local conn, err = db:connect()
+      assert.is_nil(err)
+      assert.is_table(conn)
+
+      if strategy == "postgres" then
+        assert.equal("nginx", db.connector:get_stored_connection().sock_type)
+      --elseif strategy == "cassandra" then
+      --TODO: cassandra forces luasocket on timer
+      end
+
+      assert.equal(false, db.connector:get_stored_connection().ssl)
+
+      db:close()
+    end)
+
+    it("returns connection using luasocket", function()
+      ngx.IS_CLI = true
+
+      local db, err = DB.new(helpers.test_conf, strategy)
+
+      assert.is_nil(err)
+      assert.is_table(db)
+
+      assert(db:init_connector())
+      local conn, err = db:connect()
+      assert.is_nil(err)
+      assert.is_table(conn)
+
+      if strategy == "postgres" then
+        assert.equal("luasocket", db.connector:get_stored_connection().sock_type)
+      --elseif strategy == "cassandra" then
+      --TODO: cassandra forces luasocket on timer
+      end
+
+      assert.equal(false, db.connector:get_stored_connection().ssl)
+
+      db:close()
+    end)
+
+    it_ssl("returns connection with ssl", function()
+      ngx.IS_CLI = false
+
+      local conf = utils.deep_copy(helpers.test_conf)
+
+      conf.pg_ssl = true
+      conf.cassandra_ssl = true
+
+      local db, err = DB.new(conf, strategy)
+
+      assert.is_nil(err)
+      assert.is_table(db)
+
+      assert(db:init_connector())
+      local conn, err = db:connect()
+      assert.is_nil(err)
+      assert.is_table(conn)
+
+      if strategy == "postgres" then
+        assert.equal("nginx", db.connector:get_stored_connection().sock_type)
+      --elseif strategy == "cassandra" then
+      --TODO: cassandra forces luasocket on timer
+      end
+
+      assert.equal(true, db.connector:get_stored_connection().ssl)
+
+      db:close()
+    end)
+
+    it_ssl("returns connection using luasocket with ssl", function()
+      ngx.IS_CLI = true
+
+      local conf = utils.deep_copy(helpers.test_conf)
+
+      conf.pg_ssl = true
+      conf.cassandra_ssl = true
+
+      local db, err = DB.new(conf, strategy)
+
+      assert.is_nil(err)
+      assert.is_table(db)
+
+      assert(db:init_connector())
+      local conn, err = db:connect()
+      assert.is_nil(err)
+      assert.is_table(conn)
+
+      if strategy == "postgres" then
+        assert.equal("luasocket", db.connector:get_stored_connection().sock_type)
+      --elseif strategy == "cassandra" then
+      --TODO: cassandra forces luasocket on timer
+      end
+
+      assert.equal(true, db.connector:get_stored_connection().ssl)
+
+      db:close()
+    end)
   end)
 
 
   describe(":setkeepalive() [#" .. strategy .. "]", function()
+    lazy_setup(function()
+      helpers.get_db_utils(strategy, {})
+    end)
 
+    it("return true when there is a stored connection", function()
+      ngx.IS_CLI = false
+
+      local db, err = DB.new(helpers.test_conf, strategy)
+
+      assert.is_nil(err)
+      assert.is_table(db)
+
+      assert(db:init_connector())
+
+      local conn, err = db:connect()
+      assert.is_nil(err)
+      assert.is_table(conn)
+
+      if strategy == "postgres" then
+        assert.equal("nginx", db.connector:get_stored_connection().sock_type)
+      --elseif strategy == "cassandra" then
+      --TODO: cassandra forces luasocket on timer
+      end
+
+      assert.equal(false, db.connector:get_stored_connection().ssl)
+      assert.equal(true, db:setkeepalive())
+
+      db:close()
+    end)
+
+    it("return true when there is a stored connection using luasocket", function()
+      ngx.IS_CLI = true
+
+      local db, err = DB.new(helpers.test_conf, strategy)
+
+      assert.is_nil(err)
+      assert.is_table(db)
+
+      assert(db:init_connector())
+
+      local conn, err = db:connect()
+      assert.is_nil(err)
+      assert.is_table(conn)
+
+      if strategy == "postgres" then
+        assert.equal("luasocket", db.connector:get_stored_connection().sock_type)
+      --elseif strategy == "cassandra" then
+      --TODO: cassandra forces luasocket on timer
+      end
+
+      assert.equal(false, db.connector:get_stored_connection().ssl)
+      assert.equal(true, db:setkeepalive())
+
+      db:close()
+    end)
+
+    it_ssl("return true when there is a stored connection with ssl", function()
+      ngx.IS_CLI = false
+
+      local conf = utils.deep_copy(helpers.test_conf)
+
+      conf.pg_ssl = true
+      conf.cassandra_ssl = true
+
+      local db, err = DB.new(conf, strategy)
+
+      assert.is_nil(err)
+      assert.is_table(db)
+
+      assert(db:init_connector())
+
+      local conn, err = db:connect()
+      assert.is_nil(err)
+      assert.is_table(conn)
+
+      if strategy == "postgres" then
+        assert.equal("nginx", db.connector:get_stored_connection().sock_type)
+      --elseif strategy == "cassandra" then
+      --TODO: cassandra forces luasocket on timer
+      end
+
+      assert.equal(true, db.connector:get_stored_connection().ssl)
+      assert.equal(true, db:setkeepalive())
+
+      db:close()
+    end)
+
+    it_ssl("return true when there is a stored connection using luasocket with ssl", function()
+      ngx.IS_CLI = true
+
+      local conf = utils.deep_copy(helpers.test_conf)
+
+      conf.pg_ssl = true
+      conf.cassandra_ssl = true
+
+      local db, err = DB.new(conf, strategy)
+
+      assert.is_nil(err)
+      assert.is_table(db)
+
+      assert(db:init_connector())
+
+      local conn, err = db:connect()
+      assert.is_nil(err)
+      assert.is_table(conn)
+
+      if strategy == "postgres" then
+        assert.equal("luasocket", db.connector:get_stored_connection().sock_type)
+      --elseif strategy == "cassandra" then
+      --TODO: cassandra forces luasocket on timer
+      end
+
+      assert.equal(true, db.connector:get_stored_connection().ssl)
+      assert.equal(true, db:setkeepalive())
+
+      db:close()
+    end)
+
+
+    it("return true when there is no stored connection", function()
+      ngx.IS_CLI = false
+
+      local db, err = DB.new(helpers.test_conf, strategy)
+
+      assert.is_nil(err)
+      assert.is_table(db)
+
+      assert(db:init_connector())
+
+      local conn, err = db:connect()
+      assert.is_nil(err)
+      assert.is_table(conn)
+
+      if strategy == "postgres" then
+        assert.equal("nginx", db.connector:get_stored_connection().sock_type)
+      --elseif strategy == "cassandra" then
+      --TODO: cassandra forces luasocket on timer
+      end
+
+      assert.equal(false, db.connector:get_stored_connection().ssl)
+
+      db:close()
+
+      assert.is_nil(db.connector:get_stored_connection())
+      assert.equal(true, db:setkeepalive())
+    end)
+
+    it("return true when there is no stored connection using luasocket", function()
+      ngx.IS_CLI = true
+
+      local db, err = DB.new(helpers.test_conf, strategy)
+
+      assert.is_nil(err)
+      assert.is_table(db)
+
+      assert(db:init_connector())
+
+      local conn, err = db:connect()
+      assert.is_nil(err)
+      assert.is_table(conn)
+
+      if strategy == "postgres" then
+        assert.equal("luasocket", db.connector:get_stored_connection().sock_type)
+      --elseif strategy == "cassandra" then
+      --TODO: cassandra forces luasocket on timer
+      end
+
+      assert.equal(false, db.connector:get_stored_connection().ssl)
+
+      db:close()
+
+      assert.is_nil(db.connector:get_stored_connection())
+      assert.equal(true, db:setkeepalive())
+    end)
+
+
+    it_ssl("return true when there is no stored connection with ssl", function()
+      ngx.IS_CLI = false
+
+      local conf = utils.deep_copy(helpers.test_conf)
+
+      conf.pg_ssl = true
+      conf.cassandra_ssl = true
+
+      local db, err = DB.new(conf, strategy)
+
+      assert.is_nil(err)
+      assert.is_table(db)
+
+      assert(db:init_connector())
+
+      local conn, err = db:connect()
+      assert.is_nil(err)
+      assert.is_table(conn)
+
+      if strategy == "postgres" then
+        assert.equal("nginx", db.connector:get_stored_connection().sock_type)
+      --elseif strategy == "cassandra" then
+      --TODO: cassandra forces luasocket on timer
+      end
+
+      assert.equal(true, db.connector:get_stored_connection().ssl)
+
+      db:close()
+
+      assert.is_nil(db.connector:get_stored_connection())
+      assert.equal(true, db:setkeepalive())
+    end)
+
+    it_ssl("return true when there is no stored connection using luasocket with ssl", function()
+      ngx.IS_CLI = true
+
+      local conf = utils.deep_copy(helpers.test_conf)
+
+      conf.pg_ssl = true
+      conf.cassandra_ssl = true
+
+      local db, err = DB.new(conf, strategy)
+
+      assert.is_nil(err)
+      assert.is_table(db)
+
+      assert(db:init_connector())
+      local conn, err = db:connect()
+      assert.is_nil(err)
+      assert.is_table(conn)
+
+      if strategy == "postgres" then
+        assert.equal("luasocket", db.connector:get_stored_connection().sock_type)
+      --elseif strategy == "cassandra" then
+      --TODO: cassandra forces luasocket on timer
+      end
+
+      assert.equal(true, db.connector:get_stored_connection().ssl)
+
+      db:close()
+
+      assert.is_nil(db.connector:get_stored_connection())
+      assert.equal(true, db:setkeepalive())
+    end)
   end)
 
   describe(":close() [#" .. strategy .. "]", function()
+    lazy_setup(function()
+      helpers.get_db_utils(strategy, {})
+    end)
 
+    it("return true when there is a stored connection", function()
+      ngx.IS_CLI = false
+
+      local db, err = DB.new(helpers.test_conf, strategy)
+
+      assert.is_nil(err)
+      assert.is_table(db)
+
+      assert(db:init_connector())
+
+      local conn, err = db:connect()
+      assert.is_nil(err)
+      assert.is_table(conn)
+
+      if strategy == "postgres" then
+        assert.equal("nginx", db.connector:get_stored_connection().sock_type)
+      --elseif strategy == "cassandra" then
+      --TODO: cassandra forces luasocket on timer
+      end
+
+      assert.equal(false, db.connector:get_stored_connection().ssl)
+      assert.equal(true, db:close())
+    end)
+
+    it("return true when there is a stored connection using luasocket", function()
+      ngx.IS_CLI = true
+
+      local db, err = DB.new(helpers.test_conf, strategy)
+
+      assert.is_nil(err)
+      assert.is_table(db)
+
+      assert(db:init_connector())
+
+      local conn, err = db:connect()
+      assert.is_nil(err)
+      assert.is_table(conn)
+
+      if strategy == "postgres" then
+        assert.equal("luasocket", db.connector:get_stored_connection().sock_type)
+      --elseif strategy == "cassandra" then
+      --TODO: cassandra forces luasocket on timer
+      end
+
+      assert.equal(false, db.connector:get_stored_connection().ssl)
+      assert.equal(true, db:close())
+    end)
+
+    it_ssl("return true when there is a stored connection with ssl", function()
+      ngx.IS_CLI = false
+
+      local conf = utils.deep_copy(helpers.test_conf)
+
+      conf.pg_ssl = true
+      conf.cassandra_ssl = true
+
+      local db, err = DB.new(conf, strategy)
+
+      assert.is_nil(err)
+      assert.is_table(db)
+
+      assert(db:init_connector())
+
+      local conn, err = db:connect()
+      assert.is_nil(err)
+      assert.is_table(conn)
+
+      if strategy == "postgres" then
+        assert.equal("nginx", db.connector:get_stored_connection().sock_type)
+      --elseif strategy == "cassandra" then
+      --TODO: cassandra forces luasocket on timer
+      end
+
+      assert.equal(true, db.connector:get_stored_connection().ssl)
+      assert.equal(true, db:close())
+    end)
+
+    it_ssl("return true when there is a stored connection using luasocket with ssl", function()
+      ngx.IS_CLI = true
+
+      local conf = utils.deep_copy(helpers.test_conf)
+
+      conf.pg_ssl = true
+      conf.cassandra_ssl = true
+
+      local db, err = DB.new(conf, strategy)
+
+      assert.is_nil(err)
+      assert.is_table(db)
+
+      assert(db:init_connector())
+
+      local conn, err = db:connect()
+      assert.is_nil(err)
+      assert.is_table(conn)
+
+      if strategy == "postgres" then
+        assert.equal("luasocket", db.connector:get_stored_connection().sock_type)
+      --elseif strategy == "cassandra" then
+      --TODO: cassandra forces luasocket on timer
+      end
+
+      assert.equal(true, db.connector:get_stored_connection().ssl)
+      assert.equal(true, db:close())
+    end)
+
+    it("return true when there is no stored connection", function()
+      ngx.IS_CLI = false
+
+      local db, err = DB.new(helpers.test_conf, strategy)
+
+      assert.is_nil(err)
+      assert.is_table(db)
+
+      assert(db:init_connector())
+
+      local conn, err = db:connect()
+      assert.is_nil(err)
+      assert.is_table(conn)
+
+      if strategy == "postgres" then
+        assert.equal("nginx", db.connector:get_stored_connection().sock_type)
+      --elseif strategy == "cassandra" then
+      --TODO: cassandra forces luasocket on timer
+      end
+
+      assert.equal(false, db.connector:get_stored_connection().ssl)
+
+      db:close()
+
+      assert.is_nil(db.connector:get_stored_connection())
+      assert.equal(true, db:close())
+    end)
+
+    it("return true when there is no stored connection using luasocket", function()
+      ngx.IS_CLI = true
+
+      local db, err = DB.new(helpers.test_conf, strategy)
+
+      assert.is_nil(err)
+      assert.is_table(db)
+
+      assert(db:init_connector())
+      local conn, err = db:connect()
+      assert.is_nil(err)
+      assert.is_table(conn)
+
+      if strategy == "postgres" then
+        assert.equal("luasocket", db.connector:get_stored_connection().sock_type)
+      --elseif strategy == "cassandra" then
+      --TODO: cassandra forces luasocket on timer
+      end
+
+      assert.equal(false, db.connector:get_stored_connection().ssl)
+
+      db:close()
+
+      assert.is_nil(db.connector:get_stored_connection())
+      assert.equal(true, db:close())
+    end)
+
+    it_ssl("return true when there is no stored connection with ssl", function()
+      ngx.IS_CLI = false
+
+      local conf = utils.deep_copy(helpers.test_conf)
+
+      conf.pg_ssl = true
+      conf.cassandra_ssl = true
+
+      local db, err = DB.new(conf, strategy)
+
+      assert.is_nil(err)
+      assert.is_table(db)
+
+      assert(db:init_connector())
+
+      local conn, err = db:connect()
+      assert.is_nil(err)
+      assert.is_table(conn)
+
+      if strategy == "postgres" then
+        assert.equal("nginx", db.connector:get_stored_connection().sock_type)
+      --elseif strategy == "cassandra" then
+      --TODO: cassandra forces luasocket on timer
+      end
+
+      assert.equal(true, db.connector:get_stored_connection().ssl)
+
+      db:close()
+
+      assert.is_nil(db.connector:get_stored_connection())
+      assert.equal(true, db:close())
+    end)
+
+    it_ssl("return true when there is no stored connection using luasocket with ssl", function()
+      ngx.IS_CLI = true
+
+      local conf = utils.deep_copy(helpers.test_conf)
+
+      conf.pg_ssl = true
+      conf.cassandra_ssl = true
+
+      local db, err = DB.new(conf, strategy)
+
+      assert.is_nil(err)
+      assert.is_table(db)
+
+      assert(db:init_connector())
+
+      local conn, err = db:connect()
+      assert.is_nil(err)
+      assert.is_table(conn)
+
+      if strategy == "postgres" then
+        assert.equal("luasocket", db.connector:get_stored_connection().sock_type)
+      --elseif strategy == "cassandra" then
+      --TODO: cassandra forces luasocket on timer
+      end
+
+      assert.equal(true, db.connector:get_stored_connection().ssl)
+
+      db:close()
+
+      assert.is_nil(db.connector:get_stored_connection())
+      assert.equal(true, db:close())
+    end)
   end)
 end


### PR DESCRIPTION
### Summary

Make both Postgres and Cassandra database connectors behave similarly on `connector:close` and `connetor:setkeepalive`.

Also adds tests for the mentioned methods + :connect, including tests with ssl connection.

This is continuation of the work to make the fix to #4212 be catched with our test suite, if it ever happens again.