### PR TITLE
fix(core) ensure a plugin created with PUT gets enabled

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -413,11 +413,8 @@ return {
 
 
       worker_events.register(function(data)
-        -- assume an update doesnt also change the whole entity!
-        if data.operation ~= "update" then
-          log(DEBUG, "[events] Plugin updated, invalidating plugins map")
-          cache:invalidate("plugins_map:version")
-        end
+        log(DEBUG, "[events] Plugin updated, invalidating plugins map")
+        cache:invalidate("plugins_map:version")
       end, "crud", "plugins")
 
 

--- a/spec/02-integration/06-invalidations/03-plugins_map_invalidation_spec.lua
+++ b/spec/02-integration/06-invalidations/03-plugins_map_invalidation_spec.lua
@@ -96,7 +96,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     describe("plugins_map:version", function()
-      local service_plugin_id, version_1, version_2
+      local service_plugin_id
 
       it("is created at startup", function()
         local admin_res_1 = assert(admin_client_1:send {
@@ -168,7 +168,6 @@ for _, strategy in helpers.each_strategy() do
         local msg_1  = cjson.decode(body_1)
 
         assert.matches("^[%w-]+$", msg_1.message)
-        version_1 = msg_1.message
 
         wait_for_propagation()
 
@@ -195,13 +194,12 @@ for _, strategy in helpers.each_strategy() do
         local msg_2  = cjson.decode(body_2)
 
         assert.matches("^[%w-]+$", msg_2.message)
-        version_2 = msg_2.message
 
         -- each node has their own map version
         assert.not_equal(msg_1.message, msg_2.message)
       end)
 
-      it("is not invalidated on plugin update", function()
+      it("is invalidated on plugin update", function()
         local admin_res_plugin = assert(admin_client_1:send {
           method = "PATCH",
           path   = "/plugins/" .. service_plugin_id,
@@ -216,21 +214,11 @@ for _, strategy in helpers.each_strategy() do
 
         wait_for_propagation()
 
-        local admin_res_1 = assert(admin_client_1:send {
-          method = "GET",
-          path   = "/cache/plugins_map:version",
-        })
-        local body_1 = assert.res_status(200, admin_res_1)
-        local msg_1  = cjson.decode(body_1)
-        assert.equal(version_1, msg_1.message)
-
         local admin_res_2 = assert(admin_client_2:send {
           method = "GET",
           path   = "/cache/plugins_map:version",
         })
-        local body_2 = assert.res_status(200, admin_res_2)
-        local msg_2  = cjson.decode(body_2)
-        assert.equal(version_2, msg_2.message)
+        assert.res_status(404, admin_res_2)
       end)
 
       it("is invalidated on plugin delete", function()


### PR DESCRIPTION
When a plugin is newly created with PUT (e.g. with `/plugins/{uuid}`), this needs to trigger a regeneration of the plugins map.

Our `dao:upsert` operation triggers an `"update"` CRUD event. This change is the conservative approach to fixing the problem, instead of changing the CRUD event and ensuring that all consumers of CRUD events handle a new `"upsert"` event.

Includes a regression test.

Fixes #4191.