### PR TITLE
feat(basic-auth) haveibeenpwned integration

### DIFF
--- a/kong-1.0.2-0.rockspec
+++ b/kong-1.0.2-0.rockspec
@@ -184,6 +184,7 @@ build = {
     ["kong.plugins.basic-auth.api"] = "kong/plugins/basic-auth/api.lua",
     ["kong.plugins.basic-auth.daos"] = "kong/plugins/basic-auth/daos.lua",
     ["kong.plugins.basic-auth.basicauth_credentials"] = "kong/plugins/basic-auth/basicauth_credentials.lua",
+    ["kong.plugins.basic-auth.meta"] = "kong/plugins/basic-auth/meta.lua",
 
     ["kong.plugins.key-auth.migrations"] = "kong/plugins/key-auth/migrations/init.lua",
     ["kong.plugins.key-auth.migrations.000_base_key_auth"] = "kong/plugins/key-auth/migrations/000_base_key_auth.lua",

--- a/kong/plugins/basic-auth/api.lua
+++ b/kong/plugins/basic-auth/api.lua
@@ -1,9 +1,35 @@
 local endpoints = require "kong.api.endpoints"
+local to_hex = require "resty.string".to_hex
+local http = require "resty.http"
+local meta = require "kong.plugins.basic-auth.meta"
 
 
 local kong               = kong
 local credentials_schema = kong.db.basicauth_credentials.schema
 local consumers_schema   = kong.db.consumers.schema
+
+
+-- verify is a password sent via the Admin API is present in the
+-- haveibeenpwned.com passwords data set
+local function been_pwned(password)
+  local sha = string.upper(to_hex(ngx.sha1_bin(password)))
+  local r = sha:sub(1, 5)
+  local suffix = sha:sub(6)
+
+  local c = http.new()
+  local res, err = c:request_uri(meta.HIBP_URL .. r, {
+    ssl_verify = false,
+  })
+  if err then
+    return nil, err
+  end
+
+  if res.status ~= 200 then
+    return nil, "invalid response code " .. res.status
+  end
+
+  return string.find(res.body, suffix, nil, true) and true or false
+end
 
 
 return {
@@ -13,8 +39,18 @@ return {
       GET = endpoints.get_collection_endpoint(
               credentials_schema, consumers_schema, "consumer"),
 
-      POST = endpoints.post_collection_endpoint(
-              credentials_schema, consumers_schema, "consumer"),
+      POST = function(self, ...)
+        local pwned, err = been_pwned(self.args.post.password)
+        if err then
+          return kong.response.exit(500, { message = err })
+        end
+        if pwned then
+          return kong.response.exit(400, { message = "PWNED!" })
+        end
+
+        return endpoints.post_collection_endpoint(
+              credentials_schema, consumers_schema, "consumer")(self, ...)
+      end,
     },
   },
   ["/consumers/:consumers/basic-auth/:basicauth_credentials"] = {
@@ -49,9 +85,28 @@ return {
       GET  = endpoints.get_entity_endpoint(credentials_schema),
       PUT  = function(self, ...)
         self.args.post.consumer = { id = self.consumer.id }
+
+        local pwned, err = been_pwned(self.args.post.password)
+        if err then
+          return kong.response.exit(500, { message = err })
+        end
+        if pwned then
+          return kong.response.exit(400, { message = "PWNED!" })
+        end
+
         return endpoints.put_entity_endpoint(credentials_schema)(self, ...)
       end,
-      PATCH  = endpoints.patch_entity_endpoint(credentials_schema),
+      PATCH  = function(self, ...)
+        local pwned, err = been_pwned(self.args.post.password)
+        if err then
+          return kong.response.exit(500, { message = err })
+        end
+        if pwned then
+          return kong.response.exit(400, { message = "PWNED!" })
+        end
+
+        return endpoints.patch_entity_endpoint(credentials_schema)(self, ...)
+      end,
       DELETE = endpoints.delete_entity_endpoint(credentials_schema),
     },
   },

--- a/kong/plugins/basic-auth/meta.lua
+++ b/kong/plugins/basic-auth/meta.lua
@@ -1,0 +1,3 @@
+return {
+  HIBP_URL = "https://api.pwnedpasswords.com/range/",
+}

--- a/spec/03-plugins/10-basic-auth/04-invalidations_spec.lua
+++ b/spec/03-plugins/10-basic-auth/04-invalidations_spec.lua
@@ -20,6 +20,7 @@ for _, strategy in helpers.each_strategy() do
       assert(helpers.start_kong({
         database   = strategy,
         nginx_conf = "spec/fixtures/custom_nginx.template",
+        lua_package_path = "./spec/fixtures/mocks/?.lua",
       }))
     end)
 

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -453,6 +453,13 @@ http {
                 return mu.retrieve_log(ngx.var.logname)
             }
         }
+
+        location "/mock-hibp/range" {
+            content_by_lua_block {
+                -- thispasswordhasbeenpwnd = f1f34d10ed3559aa88ed4a3129c9bf128bfc773a
+                ngx.say("D10ED3559AA88ED4A3129C9BF128BFC773A:1")
+            }
+        }
     }
 }
 

--- a/spec/fixtures/mocks/kong/plugins/basic-auth/meta.lua
+++ b/spec/fixtures/mocks/kong/plugins/basic-auth/meta.lua
@@ -1,0 +1,3 @@
+return {
+  HIBP_URL = "http://127.0.0.1:15555/mock-hibp/range",
+}


### PR DESCRIPTION
### Summary

This commit integrates the PwnedPasswords API from the haveibeenpwned.com service, with the basic-auth plugin. Passwords sent to the Admin API as part of create/update/upsert operations on a given credential are validated for presence within the haveibeenpwned data set. If a password hash is found to be present, the API request is rejected.

For more information on haveibeenpwned see

  https://haveibeenpwned.com/Passwords

and

  https://haveibeenpwned.com/API/v2#PwnedPasswords

### Full changelog

* integrate haveibeenpwned API logic with basic-auth credentials Admin API endpoints
* add mock haveibeenpwned passwords range endpoint
* override basic-auth meta in `spec/03-plugins/10-basic-auth/04-invalidations_spec.lua` to avoid calling the production haveibeenpwned service in unrelated tests