### PR TITLE
fix(core) pass the context table to mesh.rewrite

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -585,7 +585,7 @@ return {
   rewrite = {
     before = function(ctx)
       ctx.KONG_REWRITE_START = get_now()
-      mesh.rewrite()
+      mesh.rewrite(ctx)
     end,
     after = function(ctx)
       ctx.KONG_REWRITE_TIME = get_now() - ctx.KONG_REWRITE_START -- time spent in Kong's rewrite_by_lua


### PR DESCRIPTION
### Summary

Originally done here:
https://github.com/Kong/kong/commit/40a073ea57155c5e99e717724dae86dbc0f02508#diff-1f0f137350308286de76ec59740c8eda

Bug introduced here (the next commit after ^):
https://github.com/Kong/kong/commit/ba3f4e46d122f1e134d6bff4024e9a9af8f1baeb#diff-1f0f137350308286de76ec59740c8eda

Yes, this is quite severe bug.