### PR TITLE
fix(db) ensure we reach schema consensus while bootstrapping

### DIFF
--- a/kong/db/init.lua
+++ b/kong/db/init.lua
@@ -561,7 +561,7 @@ do
           if run_up then
             -- ensure schema consensus is reached before running DML queries
             -- that could span all peers
-            ok, err = self.connector:post_run_up_migrations()
+            ok, err = self.connector:wait_for_schema_consensus()
             if not ok then
               self.connector:close()
               return nil, prefix_err(self, err)
@@ -595,7 +595,7 @@ do
             -- DML queries; if the next migration runs its up step, it will
             -- run DDL queries against the same node, so no need to reach
             -- schema consensus
-            ok, err = self.connector:post_run_teardown_migrations()
+            ok, err = self.connector:wait_for_schema_consensus()
             if not ok then
               self.connector:close()
               return nil, prefix_err(self, err)
@@ -614,7 +614,7 @@ do
         -- wait for schema consensus after the last migration has run
         -- (only if `run_up`, since if not, we just called it from the
         -- teardown step)
-        ok, err = self.connector:post_run_teardown_migrations()
+        ok, err = self.connector:wait_for_schema_consensus()
         if not ok then
           self.connector:close()
           return nil, prefix_err(self, err)

--- a/kong/db/init.lua
+++ b/kong/db/init.lua
@@ -508,7 +508,7 @@ do
     local n_migrations = 0
     local n_pending = 0
 
-    for _, t in ipairs(migrations) do
+    for i, t in ipairs(migrations) do
       log("migrating %s on %s '%s'...", t.subsystem, self.infos.db_desc,
           self.infos.db_name)
 
@@ -558,6 +558,16 @@ do
         end
 
         if run_teardown and strategy_migration.teardown then
+          if run_up then
+            -- ensure schema consensus is reached before running DML queries
+            -- that could span all peers
+            ok, err = self.connector:post_run_up_migrations()
+            if not ok then
+              self.connector:close()
+              return nil, prefix_err(self, err)
+            end
+          end
+
           -- kong migrations teardown
           local f = strategy_migration.teardown
 
@@ -578,6 +588,19 @@ do
           end
 
           n_pending = math.max(n_pending - 1, 0)
+
+          if not run_up then
+            -- ensure schema consensus is reached when the next migration to
+            -- run will execute its teardown step, since it may make further
+            -- DML queries; if the next migration runs its up step, it will
+            -- run DDL queries against the same node, so no need to reach
+            -- schema consensus
+            ok, err = self.connector:post_run_teardown_migrations()
+            if not ok then
+              self.connector:close()
+              return nil, prefix_err(self, err)
+            end
+          end
         end
 
         log("%s migrated up to: %s %s", t.subsystem, mig.name,
@@ -585,6 +608,17 @@ do
             and not run_teardown and "(pending)" or "(executed)")
 
         n_migrations = n_migrations + 1
+      end
+
+      if run_up and i == #migrations then
+        -- wait for schema consensus after the last migration has run
+        -- (only if `run_up`, since if not, we just called it from the
+        -- teardown step)
+        ok, err = self.connector:post_run_teardown_migrations()
+        if not ok then
+          self.connector:close()
+          return nil, prefix_err(self, err)
+        end
       end
     end
 
@@ -599,21 +633,6 @@ do
 
     if n_pending > 0 then
       log("%d pending", n_pending)
-    end
-
-    if run_up then
-      ok, err = self.connector:post_run_up_migrations()
-      if not ok then
-        self.connector:close()
-        return nil, prefix_err(self, err)
-      end
-
-    elseif run_teardown then -- do not run if 'run_up' is already 'true'
-      ok, err = self.connector:post_run_teardown_migrations()
-      if not ok then
-        self.connector:close()
-        return nil, prefix_err(self, err)
-      end
     end
 
     self.connector:close()

--- a/kong/db/strategies/connector.lua
+++ b/kong/db/strategies/connector.lua
@@ -134,12 +134,7 @@ function Connector:run_up_migration()
 end
 
 
-function Connector:post_run_up_migrations()
-  return true
-end
-
-
-function Connector:post_run_teardown_migrations()
+function Connector:wait_for_schema_consensus()
   return true
 end
 


### PR DESCRIPTION
When bootstrapping, both `up` and `teardown` phases of each migration
execute subsequently. If the `teardown` step executed DML statements,
such statements can span all peers (due to replication factors). If the
replica peers have not yet reached consensus for their schema, they will
provoke errors and make the bootstrapping fail.

This change ensures that we wait for schema consensus when:

* before running `teardown` if `up` was just ran
* after running `teardown` if `up` was _not_ just ran (see comment as
  for why)
* after running all migrations that were to be run, if executing
  `run_up` only

From another perspective:

* `run_up == true`: wait for consensus at the very end (after executing
  all up steps)
* `run_teardown == true`: wait for consensus after each teardown step
* `run_up == true and run_teardown == true`: wait for consensus before
  each `teardown` step, and once at the very end (after all up and
  teardown steps)

Fix #4229