### PR TITLE
chore(deps) bump lua-cassandra to 1.3.4

### DIFF
--- a/kong-1.0.2-0.rockspec
+++ b/kong-1.0.2-0.rockspec
@@ -20,7 +20,7 @@ dependencies = {
   "multipart == 0.5.5",
   "version == 0.2",
   "kong-lapis == 1.6.0.1",
-  "lua-cassandra == 1.3.3",
+  "lua-cassandra == 1.3.4",
   "pgmoon == 1.9.0",
   "luatz == 0.3",
   "http == 0.2",


### PR DESCRIPTION
Changes:

- Do not log the "rpc_address set to 0.0.0.0" warning when opts.silent
  is on.

Full Changelog:

https://github.com/thibaultcha/lua-cassandra/blob/master/CHANGELOG.md#134