### PR TITLE
fix(basic-auth, ldap-auth, key-auth, jwt, hmac-auth) status code for unauthorized requests

### DIFF
--- a/kong/plugins/basic-auth/access.lua
+++ b/kong/plugins/basic-auth/access.lua
@@ -179,7 +179,7 @@ local function do_authentication(conf)
   end
 
   if not credential or not validate_credentials(credential, given_password) then
-    return false, { status = 403, message = "Invalid authentication credentials" }
+    return false, { status = 401, message = "Invalid authentication credentials" }
   end
 
   -- Retrieve consumer

--- a/kong/plugins/hmac-auth/access.lua
+++ b/kong/plugins/hmac-auth/access.lua
@@ -299,7 +299,7 @@ local function do_authentication(conf)
   if not (validate_clock_skew(X_DATE, conf.clock_skew) or
           validate_clock_skew(DATE, conf.clock_skew)) then
     return false, {
-      status = 403,
+      status = 401,
       message = "HMAC signature cannot be verified, a valid date or " ..
                 "x-date header is required for HMAC Authentication"
     }
@@ -322,26 +322,26 @@ local function do_authentication(conf)
   local ok, err = validate_params(hmac_params, conf)
   if not ok then
     kong.log.debug(err)
-    return false, { status = 403, message = SIGNATURE_NOT_VALID }
+    return false, { status = 401, message = SIGNATURE_NOT_VALID }
   end
 
   -- validate signature
   local credential = load_credential(hmac_params.username)
   if not credential then
     kong.log.debug("failed to retrieve credential for ", hmac_params.username)
-    return false, { status = 403, message = SIGNATURE_NOT_VALID }
+    return false, { status = 401, message = SIGNATURE_NOT_VALID }
   end
 
   hmac_params.secret = credential.secret
 
   if not validate_signature(hmac_params) then
-    return false, { status = 403, message = SIGNATURE_NOT_SAME }
+    return false, { status = 401, message = SIGNATURE_NOT_SAME }
   end
 
   -- If request body validation is enabled, then verify digest.
   if conf.validate_request_body and not validate_body() then
     kong.log.debug("digest validation failed")
-    return false, { status = 403, message = SIGNATURE_NOT_SAME }
+    return false, { status = 401, message = SIGNATURE_NOT_SAME }
   end
 
   -- Retrieve consumer

--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -171,14 +171,14 @@ local function do_authentication(conf)
   end
 
   if not jwt_secret then
-    return false, { status = 403, message = "No credentials found for given '" .. conf.key_claim_name .. "'" }
+    return false, { status = 401, message = "No credentials found for given '" .. conf.key_claim_name .. "'" }
   end
 
   local algorithm = jwt_secret.algorithm or "HS256"
 
   -- Verify "alg"
   if jwt.header.alg ~= algorithm then
-    return false, {status = 403, message = "Invalid algorithm"}
+    return false, {status = 401, message = "Invalid algorithm"}
   end
 
   local jwt_secret_value = algorithm ~= nil and algorithm:sub(1, 2) == "HS" and
@@ -189,12 +189,12 @@ local function do_authentication(conf)
   end
 
   if not jwt_secret_value then
-    return false, { status = 403, message = "Invalid key/secret" }
+    return false, { status = 401, message = "Invalid key/secret" }
   end
 
   -- Now verify the JWT signature
   if not jwt:verify_signature(jwt_secret_value) then
-    return false, { status = 403, message = "Invalid signature" }
+    return false, { status = 401, message = "Invalid signature" }
   end
 
   -- Verify the JWT registered claims
@@ -207,7 +207,7 @@ local function do_authentication(conf)
   if conf.maximum_expiration ~= nil and conf.maximum_expiration > 0 then
     local ok, errors = jwt:check_maximum_expiration(conf.maximum_expiration)
     if not ok then
-      return false, { status = 403, errors = errors }
+      return false, { status = 401, errors = errors }
     end
   end
 
@@ -224,7 +224,7 @@ local function do_authentication(conf)
   -- However this should not happen
   if not consumer then
     return false, {
-      status = 403,
+      status = 401,
       message = fmt("Could not find consumer for '%s=%s'", conf.key_claim_name, jwt_secret_key)
     }
   end

--- a/kong/plugins/key-auth/handler.lua
+++ b/kong/plugins/key-auth/handler.lua
@@ -160,9 +160,9 @@ local function do_authentication(conf)
     return kong.response.exit(500, "An unexpected error occurred")
   end
 
-  -- no credential in DB, for this key, it is invalid, HTTP 403
+  -- no credential in DB, for this key, it is invalid, HTTP 401
   if not credential then
-    return nil, { status = 403, message = "Invalid authentication credentials" }
+    return nil, { status = 401, message = "Invalid authentication credentials" }
   end
 
   -----------------------------------------

--- a/kong/plugins/ldap-auth/access.lua
+++ b/kong/plugins/ldap-auth/access.lua
@@ -219,7 +219,7 @@ local function do_authentication(conf)
   end
 
   if not is_authorized then
-    return false, {status = 403, message = "Invalid authentication credentials" }
+    return false, {status = 401, message = "Invalid authentication credentials" }
   end
 
   if conf.hide_credentials then

--- a/spec/03-plugins/09-key-auth/02-access_spec.lua
+++ b/spec/03-plugins/09-key-auth/02-access_spec.lua
@@ -193,7 +193,7 @@ for _, strategy in helpers.each_strategy() do
         })
         assert.res_status(200, res)
       end)
-      it("returns 403 Forbidden on invalid key", function()
+      it("returns 401 Unauthorized on invalid key", function()
         local res = assert(proxy_client:send {
           method  = "GET",
           path    = "/status/200?apikey=123",
@@ -201,7 +201,7 @@ for _, strategy in helpers.each_strategy() do
             ["Host"] = "key-auth1.com"
           }
         })
-        local body = assert.res_status(403, res)
+        local body = assert.res_status(401, res)
         local json = cjson.decode(body)
         assert.same({ message = "Invalid authentication credentials" }, json)
       end)
@@ -235,7 +235,7 @@ for _, strategy in helpers.each_strategy() do
             })
             assert.res_status(200, res)
           end)
-          it("returns 403 Forbidden on invalid key", function()
+          it("returns 401 Unauthorized on invalid key", function()
             local res = assert(proxy_client:send {
               path    = "/status/200",
               headers = {
@@ -246,7 +246,7 @@ for _, strategy in helpers.each_strategy() do
                 apikey = "123",
               }
             })
-            local body = assert.res_status(403, res)
+            local body = assert.res_status(401, res)
             local json = cjson.decode(body)
             assert.same({ message = "Invalid authentication credentials" }, json)
           end)
@@ -287,7 +287,7 @@ for _, strategy in helpers.each_strategy() do
         })
         assert.res_status(200, res)
       end)
-      it("returns 403 Forbidden on invalid key", function()
+      it("returns 401 Unauthorized on invalid key", function()
         local res = assert(proxy_client:send {
           method  = "GET",
           path    = "/status/200",
@@ -296,7 +296,7 @@ for _, strategy in helpers.each_strategy() do
             ["apikey"] = "123"
           }
         })
-        local body = assert.res_status(403, res)
+        local body = assert.res_status(401, res)
         local json = cjson.decode(body)
         assert.same({ message = "Invalid authentication credentials" }, json)
       end)

--- a/spec/03-plugins/09-key-auth/03-invalidations_spec.lua
+++ b/spec/03-plugins/09-key-auth/03-invalidations_spec.lua
@@ -98,7 +98,7 @@ for _, strategy in helpers.each_strategy() do
           ["apikey"] = "kong"
         }
       })
-      assert.res_status(403, res)
+      assert.res_status(401, res)
     end)
 
     it("invalidates credentials from cache when deleted", function()
@@ -147,7 +147,7 @@ for _, strategy in helpers.each_strategy() do
           ["apikey"] = "kong"
         }
       })
-      assert.res_status(403, res)
+      assert.res_status(401, res)
     end)
 
     it("invalidated credentials from cache when updated", function()
@@ -202,7 +202,7 @@ for _, strategy in helpers.each_strategy() do
           ["apikey"] = "kong"
         }
       })
-      assert.res_status(403, res)
+      assert.res_status(401, res)
 
       res = assert(proxy_client:send {
         method  = "GET",

--- a/spec/03-plugins/10-basic-auth/03-access_spec.lua
+++ b/spec/03-plugins/10-basic-auth/03-access_spec.lua
@@ -134,9 +134,9 @@ for _, strategy in helpers.each_strategy() do
 
     end)
 
-    describe("Forbidden", function()
+    describe("Unauthorized", function()
 
-      it("returns 403 Forbidden on invalid credentials in Authorization", function()
+      it("returns 401 Unauthorized on invalid credentials in Authorization", function()
         local res = assert(proxy_client:send {
           method  = "GET",
           path    = "/status/200",
@@ -145,12 +145,12 @@ for _, strategy in helpers.each_strategy() do
             ["Host"]          = "basic-auth1.com"
           }
         })
-        local body = assert.res_status(403, res)
+        local body = assert.res_status(401, res)
         local json = cjson.decode(body)
         assert.same({ message = "Invalid authentication credentials" }, json)
       end)
 
-      it("returns 403 Forbidden on invalid credentials in Proxy-Authorization", function()
+      it("returns 401 Unauthorized on invalid credentials in Proxy-Authorization", function()
         local res = assert(proxy_client:send {
           method  = "GET",
           path    = "/status/200",
@@ -159,12 +159,12 @@ for _, strategy in helpers.each_strategy() do
             ["Host"]                = "basic-auth1.com"
           }
         })
-        local body = assert.res_status(403, res)
+        local body = assert.res_status(401, res)
         local json = cjson.decode(body)
         assert.same({ message = "Invalid authentication credentials" }, json)
       end)
 
-      it("returns 403 Forbidden on password only", function()
+      it("returns 401 Unauthorized on password only", function()
         local res = assert(proxy_client:send {
           method  = "GET",
           path    = "/status/200",
@@ -173,12 +173,12 @@ for _, strategy in helpers.each_strategy() do
             ["Host"]          = "basic-auth1.com"
           }
         })
-        local body = assert.res_status(403, res)
+        local body = assert.res_status(401, res)
         local json = cjson.decode(body)
         assert.same({ message = "Invalid authentication credentials" }, json)
       end)
 
-      it("returns 403 Forbidden on username only", function()
+      it("returns 401 Unauthorized on username only", function()
         local res = assert(proxy_client:send {
           method  = "GET",
           path    = "/status/200",
@@ -187,7 +187,7 @@ for _, strategy in helpers.each_strategy() do
             ["Host"]          = "basic-auth1.com"
           }
         })
-        local body = assert.res_status(403, res)
+        local body = assert.res_status(401, res)
         local json = cjson.decode(body)
         assert.same({ message = "Invalid authentication credentials" }, json)
       end)
@@ -230,7 +230,7 @@ for _, strategy in helpers.each_strategy() do
         assert.equal("bob", body.headers["x-consumer-username"])
       end)
 
-      it("returns 403 for valid Base64 encoding", function()
+      it("returns 401 for valid Base64 encoding", function()
         local res = assert(proxy_client:send {
           method  = "GET",
           path    = "/status/200",
@@ -239,7 +239,7 @@ for _, strategy in helpers.each_strategy() do
             ["Host"]          = "basic-auth1.com"
           }
         })
-        local body = assert.res_status(403, res)
+        local body = assert.res_status(401, res)
         local json = cjson.decode(body)
         assert.same({ message = "Invalid authentication credentials" }, json)
       end)

--- a/spec/03-plugins/10-basic-auth/04-invalidations_spec.lua
+++ b/spec/03-plugins/10-basic-auth/04-invalidations_spec.lua
@@ -118,7 +118,7 @@ for _, strategy in helpers.each_strategy() do
           ["Host"]          = "basic-auth.com"
         }
       })
-      assert.res_status(403, res)
+      assert.res_status(401, res)
     end)
 
     it("invalidates credentials from cache when deleted", function()
@@ -168,7 +168,7 @@ for _, strategy in helpers.each_strategy() do
           ["Host"]          = "basic-auth.com"
         }
       })
-      assert.res_status(403, res)
+      assert.res_status(401, res)
     end)
 
     it("invalidated credentials from cache when updated", function()
@@ -225,7 +225,7 @@ for _, strategy in helpers.each_strategy() do
           ["Host"]          = "basic-auth.com"
         }
       })
-      assert.res_status(403, res)
+      assert.res_status(401, res)
 
       res = assert(proxy_client:send {
         method  = "GET",

--- a/spec/03-plugins/16-jwt/03-access_spec.lua
+++ b/spec/03-plugins/16-jwt/03-access_spec.lua
@@ -215,7 +215,7 @@ for _, strategy in helpers.each_strategy() do
         local json = cjson.decode(body)
         assert.same({ message = "No mandatory 'iss' in claims" }, json)
       end)
-      it("returns 403 Forbidden if the iss does not match a credential", function()
+      it("returns 401 Unauthorized if the iss does not match a credential", function()
         PAYLOAD.iss = "123456789"
         local jwt = jwt_encoder.encode(PAYLOAD, jwt_secret.secret)
         local authorization = "Bearer " .. jwt
@@ -227,11 +227,11 @@ for _, strategy in helpers.each_strategy() do
             ["Host"]          = "jwt1.com",
           }
         })
-        local body = assert.res_status(403, res)
+        local body = assert.res_status(401, res)
         local json = cjson.decode(body)
         assert.same({ message = "No credentials found for given 'iss'" }, json)
       end)
-      it("returns 403 Forbidden if the signature is invalid", function()
+      it("returns 401 Unauthorized if the signature is invalid", function()
         PAYLOAD.iss = jwt_secret.key
         local jwt = jwt_encoder.encode(PAYLOAD, "foo")
         local authorization = "Bearer " .. jwt
@@ -243,11 +243,11 @@ for _, strategy in helpers.each_strategy() do
             ["Host"]          = "jwt1.com",
           }
         })
-        local body = assert.res_status(403, res)
+        local body = assert.res_status(401, res)
         local json = cjson.decode(body)
         assert.same({ message = "Invalid signature" }, json)
       end)
-      it("returns 403 Forbidden if the alg does not match the credential", function()
+      it("returns 401 Unauthorized if the alg does not match the credential", function()
         local header = {typ = "JWT", alg = 'RS256'}
         local jwt = jwt_encoder.encode(PAYLOAD, jwt_secret.secret, 'HS256', header)
         local authorization = "Bearer " .. jwt
@@ -259,7 +259,7 @@ for _, strategy in helpers.each_strategy() do
             ["Host"]          = "jwt1.com",
           }
         })
-        local body = assert.res_status(403, res)
+        local body = assert.res_status(401, res)
         local json = cjson.decode(body)
         assert.same({ message = "Invalid algorithm" }, json)
       end)
@@ -284,7 +284,7 @@ for _, strategy in helpers.each_strategy() do
         local body = assert.res_status(401, res)
         assert.equal([[{"message":"Unauthorized"}]], body)
       end)
-      it("returns 403 if the token exceeds the maximum allowed expiration limit", function()
+      it("returns 401 if the token exceeds the maximum allowed expiration limit", function()
         local payload = {
           iss = jwt_secret.key,
           exp = os.time() + 3600,
@@ -298,7 +298,7 @@ for _, strategy in helpers.each_strategy() do
             ["Host"] = "jwt11.com"
           }
         })
-        local body = assert.res_status(403, res)
+        local body = assert.res_status(401, res)
         assert.equal('{"exp":"exceeds maximum allowed expiration"}', body)
       end)
       it("accepts a JWT token within the maximum allowed expiration limit", function()
@@ -423,7 +423,7 @@ for _, strategy in helpers.each_strategy() do
         })
         assert.res_status(200, res)
       end)
-      it("returns 403 if the JWT found in the cookie does not match a credential", function()
+      it("returns 401 if the JWT found in the cookie does not match a credential", function()
         PAYLOAD.iss = "incorrect-issuer"
         local jwt = jwt_encoder.encode(PAYLOAD, jwt_secret.secret)
         local res = assert(proxy_client:send {
@@ -434,7 +434,7 @@ for _, strategy in helpers.each_strategy() do
             ["Cookie"] = "silly=" .. jwt .. "; path=/;domain=.jwt9.com",
           }
         })
-        local body = assert.res_status(403, res)
+        local body = assert.res_status(401, res)
         local json = cjson.decode(body)
         assert.same({ message = "No credentials found for given 'iss'" }, json)
       end)

--- a/spec/03-plugins/16-jwt/04-invalidations_spec.lua
+++ b/spec/03-plugins/16-jwt/04-invalidations_spec.lua
@@ -128,7 +128,7 @@ for _, strategy in helpers.each_strategy() do
             ["Host"]          = "jwt.com"
           }
         })
-        assert.res_status(403, res)
+        assert.res_status(401, res)
       end)
       it("should invalidate when JWT Auth Credential entity is updated", function()
         -- It should work
@@ -151,7 +151,7 @@ for _, strategy in helpers.each_strategy() do
             ["Host"]          = "jwt.com"
           }
         })
-        assert.res_status(403, res)
+        assert.res_status(401, res)
 
         -- Check that cache is populated
         local cache_key = db.jwt_secrets:cache_key("key123")
@@ -213,7 +213,7 @@ for _, strategy in helpers.each_strategy() do
             ["Host"]          = "jwt.com"
           }
         })
-        assert.res_status(403, res)
+        assert.res_status(401, res)
       end)
     end)
     describe("Consumer entity invalidation", function()
@@ -263,7 +263,7 @@ for _, strategy in helpers.each_strategy() do
             ["Host"]          = "jwt.com"
           }
         })
-        assert.res_status(403, res)
+        assert.res_status(401, res)
       end)
     end)
   end)

--- a/spec/03-plugins/18-acl/03-invalidations_spec.lua
+++ b/spec/03-plugins/18-acl/03-invalidations_spec.lua
@@ -255,7 +255,7 @@ for _, strategy in helpers.each_strategy() do
             ["Host"] = "acl1.com"
           }
         }))
-        assert.res_status(403, res)
+        assert.res_status(401, res)
       end)
     end)
   end)

--- a/spec/03-plugins/19-hmac-auth/03-access_spec.lua
+++ b/spec/03-plugins/19-hmac-auth/03-access_spec.lua
@@ -171,7 +171,7 @@ for _, strategy in helpers.each_strategy() do
             authorization = "asd"
           }
         })
-        local body = assert.res_status(403, res)
+        local body = assert.res_status(401, res)
         body = cjson.decode(body)
         assert.equal(SIGNATURE_NOT_VALID, body.message)
       end)
@@ -188,7 +188,7 @@ for _, strategy in helpers.each_strategy() do
             authorization = hmacAuth
           }
         })
-        local body = assert.res_status(403, res)
+        local body = assert.res_status(401, res)
         body = cjson.decode(body)
         assert.equal("HMAC signature does not match", body.message)
       end)
@@ -202,7 +202,7 @@ for _, strategy in helpers.each_strategy() do
             authorization = "asd"
           }
         })
-        local body = assert.res_status(403, res)
+        local body = assert.res_status(401, res)
         body = cjson.decode(body)
         assert.equal([[HMAC signature cannot be verified, ]]
                     .. [[a valid date or x-date header is]]
@@ -220,7 +220,7 @@ for _, strategy in helpers.each_strategy() do
             ["proxy-authorization"] = "asd"
           }
         })
-        local body = assert.res_status(403, res)
+        local body = assert.res_status(401, res)
         body = cjson.decode(body)
         assert.equal(SIGNATURE_NOT_VALID, body.message)
       end)
@@ -236,7 +236,7 @@ for _, strategy in helpers.each_strategy() do
             ["proxy-authorization"] = "hmac :dXNlcm5hbWU6cGFzc3dvcmQ="
           }
         })
-        local body = assert.res_status(403, res)
+        local body = assert.res_status(401, res)
         body = cjson.decode(body)
         assert.equal(SIGNATURE_NOT_VALID, body.message)
       end)
@@ -253,7 +253,7 @@ for _, strategy in helpers.each_strategy() do
               .. [[headers,dXNlcm5hbWU6cGFzc3dvcmQ=]]
           }
         })
-        local body = assert.res_status(403, res)
+        local body = assert.res_status(401, res)
         body = cjson.decode(body)
         assert.equal(SIGNATURE_NOT_VALID, body.message)
       end)
@@ -270,7 +270,7 @@ for _, strategy in helpers.each_strategy() do
               .. [[headers,dXNlcm5hbWU6cGFzc3dvcmQ=]]
           }
         })
-        local body = assert.res_status(403, res)
+        local body = assert.res_status(401, res)
         body = cjson.decode(body)
         assert.equal(SIGNATURE_NOT_VALID, body.message)
       end)
@@ -286,7 +286,7 @@ for _, strategy in helpers.each_strategy() do
             authorization = "hmac username"
           }
         })
-        local body = assert.res_status(403, res)
+        local body = assert.res_status(401, res)
         body = cjson.decode(body)
         assert.equal(SIGNATURE_NOT_VALID, body.message)
       end)
@@ -470,7 +470,7 @@ for _, strategy in helpers.each_strategy() do
               },
             })
 
-        local body = assert.res_status(403, res)
+        local body = assert.res_status(401, res)
         body = cjson.decode(body)
         assert.equal(SIGNATURE_NOT_VALID, body.message)
       end)
@@ -496,7 +496,7 @@ for _, strategy in helpers.each_strategy() do
           },
         })
 
-        local body = assert.res_status(403, res)
+        local body = assert.res_status(401, res)
         body = cjson.decode(body)
         assert.equal(SIGNATURE_NOT_VALID, body.message)
       end)
@@ -523,7 +523,7 @@ for _, strategy in helpers.each_strategy() do
           },
         })
 
-        local body = assert.res_status(403, res)
+        local body = assert.res_status(401, res)
         body = cjson.decode(body)
         assert.equal(SIGNATURE_NOT_VALID, body.message)
       end)
@@ -548,7 +548,7 @@ for _, strategy in helpers.each_strategy() do
             ["content-md5"]         = "md5",
           },
         })
-        local body = assert.res_status(403, res)
+        local body = assert.res_status(401, res)
         body = cjson.decode(body)
         assert.equal(SIGNATURE_NOT_VALID, body.message)
       end)
@@ -573,7 +573,7 @@ for _, strategy in helpers.each_strategy() do
             ["content-md5"]         = "md5",
           },
         })
-        local body = assert.res_status(403, res)
+        local body = assert.res_status(401, res)
         body = cjson.decode(body)
         assert.equal(SIGNATURE_NOT_VALID, body.message)
       end)
@@ -598,7 +598,7 @@ for _, strategy in helpers.each_strategy() do
             ["content-md5"]         = "md5",
           },
         })
-        local body = assert.res_status(403, res)
+        local body = assert.res_status(401, res)
         body = cjson.decode(body)
         assert.equal(SIGNATURE_NOT_VALID, body.message)
       end)
@@ -623,7 +623,7 @@ for _, strategy in helpers.each_strategy() do
             ["content-md5"]         = "md5",
           },
         })
-        local body = assert.res_status(403, res)
+        local body = assert.res_status(401, res)
         body = cjson.decode(body)
         assert.equal(SIGNATURE_NOT_VALID, body.message)
       end)
@@ -671,7 +671,7 @@ for _, strategy in helpers.each_strategy() do
             ["content-md5"]         = "md5",
           },
         })
-        assert.res_status(403, res)
+        assert.res_status(401, res)
       end)
 
       it("should pass the right headers to the upstream server", function()
@@ -742,7 +742,7 @@ for _, strategy in helpers.each_strategy() do
             ["content-md5"]         = "md5",
           },
         })
-        local body = assert.res_status(403, res)
+        local body = assert.res_status(401, res)
         body = cjson.decode(body)
         assert.equal([[HMAC signature cannot be verified, a valid date or]]
           .. [[ x-date header is required for HMAC Authentication]], body.message)
@@ -767,7 +767,7 @@ for _, strategy in helpers.each_strategy() do
             ["content-md5"] = "md5",
           },
         })
-        local body = assert.res_status(403, res)
+        local body = assert.res_status(401, res)
         body = cjson.decode(body)
         assert.equal([[HMAC signature cannot be verified, a valid date or]]
           .. [[ x-date header is required for HMAC Authentication]], body.message)
@@ -887,7 +887,7 @@ for _, strategy in helpers.each_strategy() do
         assert.is_nil(body.headers["x-anonymous-consumer"])
       end)
 
-      it("should return 403 when body validation enabled and no digest header is present", function()
+      it("should return 401 when body validation enabled and no digest header is present", function()
         local date = os.date("!%a, %d %b %Y %H:%M:%S GMT")
         local postBody = '{"a":"apple","b":"ball"}'
         local sha256 = resty_sha256:new()
@@ -907,7 +907,7 @@ for _, strategy in helpers.each_strategy() do
             authorization = hmacAuth,
           }
         })
-        local body = assert.res_status(403, res)
+        local body = assert.res_status(401, res)
         body = cjson.decode(body)
         assert.equal("HMAC signature does not match", body.message)
       end)
@@ -1072,7 +1072,7 @@ for _, strategy in helpers.each_strategy() do
             authorization = hmacAuth,
           },
         })
-        local body = assert.res_status(403, res)
+        local body = assert.res_status(401, res)
         body = cjson.decode(body)
         assert.equal("HMAC signature does not match", body.message)
       end)
@@ -1099,7 +1099,7 @@ for _, strategy in helpers.each_strategy() do
             authorization = hmacAuth,
           },
         })
-        local body = assert.res_status(403, res)
+        local body = assert.res_status(401, res)
         body = cjson.decode(body)
         assert.equal("HMAC signature does not match", body.message)
       end)
@@ -1126,7 +1126,7 @@ for _, strategy in helpers.each_strategy() do
             authorization = hmacAuth,
           }
         })
-        local body = assert.res_status(403, res)
+        local body = assert.res_status(401, res)
         body = cjson.decode(body)
         assert.equal("HMAC signature does not match", body.message)
       end)
@@ -1409,7 +1409,7 @@ for _, strategy in helpers.each_strategy() do
             ["content-md5"]         = "md5",
           },
         })
-        assert.res_status(403, res)
+        assert.res_status(401, res)
       end)
 
       it("should pass with GET with hmac-sha384", function()
@@ -1475,10 +1475,10 @@ for _, strategy in helpers.each_strategy() do
             ["content-md5"]         = "md5",
           },
         })
-        assert.res_status(403, res)
+        assert.res_status(401, res)
       end)
 
-      it("should return a 403 with an invalid authorization header", function()
+      it("should return a 401 with an invalid authorization header", function()
         local date = os.date("!%a, %d %b %Y %H:%M:%S GMT")
         local res = assert(proxy_client:send {
           method  = "GET",
@@ -1490,7 +1490,7 @@ for _, strategy in helpers.each_strategy() do
             ["proxy-authorization"] = "this is no hmac token at all is it?",
           },
         })
-        assert.res_status(403, res)
+        assert.res_status(401, res)
       end)
 
       it("should pass with hmac-sha1", function()

--- a/spec/03-plugins/19-hmac-auth/04-invalidations_spec.lua
+++ b/spec/03-plugins/19-hmac-auth/04-invalidations_spec.lua
@@ -137,7 +137,7 @@ for _, strategy in helpers.each_strategy() do
             authorization = authorization
           }
         })
-        assert.res_status(403, res)
+        assert.res_status(401, res)
       end)
       it("should invalidate when Hmac Auth Credential entity is updated", function()
         local res = assert(admin_client:send {
@@ -181,7 +181,7 @@ for _, strategy in helpers.each_strategy() do
             authorization = authorization
           }
         })
-        assert.res_status(403, res)
+        assert.res_status(401, res)
 
         -- Update Hmac Auth credential (which triggers invalidation)
         res = assert(admin_client:send {
@@ -275,7 +275,7 @@ for _, strategy in helpers.each_strategy() do
             authorization = authorization
           }
         })
-        assert.res_status(403, res)
+        assert.res_status(401, res)
       end)
     end)
   end)

--- a/spec/03-plugins/20-ldap-auth/01-access_spec.lua
+++ b/spec/03-plugins/20-ldap-auth/01-access_spec.lua
@@ -191,7 +191,7 @@ for _, strategy in helpers.each_strategy() do
           authorization = "abcd"
         }
       })
-      assert.response(res).has.status(403)
+      assert.response(res).has.status(401)
       local json = assert.response(res).has.jsonbody()
       assert.equal("Invalid authentication credentials", json.message)
     end)
@@ -204,7 +204,7 @@ for _, strategy in helpers.each_strategy() do
           ["proxy-authorization"] = "abcd"
         }
       })
-      assert.response(res).has.status(403)
+      assert.response(res).has.status(401)
       local json = assert.response(res).has.jsonbody()
       assert.equal("Invalid authentication credentials", json.message)
     end)
@@ -217,7 +217,7 @@ for _, strategy in helpers.each_strategy() do
           authorization = "ldap "
         }
       })
-      assert.response(res).has.status(403)
+      assert.response(res).has.status(401)
       local json = assert.response(res).has.jsonbody()
       assert.equal("Invalid authentication credentials", json.message)
     end)
@@ -245,7 +245,7 @@ for _, strategy in helpers.each_strategy() do
           ["content-type"] = "application/x-www-form-urlencoded",
         }
       })
-      assert.response(r).has.status(403)
+      assert.response(r).has.status(401)
     end)
     it("passes if credential is valid and starts with space in post request", function()
       local res = assert(proxy_client:send {
@@ -292,7 +292,7 @@ for _, strategy in helpers.each_strategy() do
           authorization = "ldap " .. ngx.encode_base64("einstein:")
         }
       })
-      assert.response(res).has.status(403)
+      assert.response(res).has.status(401)
     end)
     it("authorization fails with correct status with wrong very long password", function()
       local res = assert(proxy_client:send {
@@ -303,7 +303,7 @@ for _, strategy in helpers.each_strategy() do
           authorization = "ldap " .. ngx.encode_base64("einstein:e0d91f53c566e0d91f53c566e0d91f53c566e0d91f53c566e0d91f53c566e0d91f53c566e0d91f53c566e0d91f53c566e0d91f53c566e0d91f53c566e0d91f53c566e0d91f53c566e0d91f53c566")
         }
       })
-      assert.response(res).has.status(403)
+      assert.response(res).has.status(401)
     end)
     it("authorization fails if credential has multiple encoded usernames or passwords separated by ':' in get request", function()
       local res = assert(proxy_client:send {
@@ -314,7 +314,7 @@ for _, strategy in helpers.each_strategy() do
           authorization = "ldap " .. ngx.encode_base64("einstein:password:another_password")
         }
       })
-      assert.response(res).has.status(403)
+      assert.response(res).has.status(401)
     end)
     it("does not pass if credential is invalid in get request", function()
       local res = assert(proxy_client:send {
@@ -325,7 +325,7 @@ for _, strategy in helpers.each_strategy() do
           authorization = "ldap " .. ngx.encode_base64("einstein:wrong_password")
         }
       })
-      assert.response(res).has.status(403)
+      assert.response(res).has.status(401)
     end)
     it("does not hide credential sent along with authorization header to upstream server", function()
       local res = assert(proxy_client:send {
@@ -391,7 +391,7 @@ for _, strategy in helpers.each_strategy() do
           ["content-type"] = "application/x-www-form-urlencoded",
         }
       })
-      assert.response(r).has.status(403)
+      assert.response(r).has.status(401)
     end)
     it("passes if credential is valid in get request using global plugin", function()
       local res = assert(proxy_client:send {

--- a/spec/03-plugins/20-ldap-auth/02-invalidations_spec.lua
+++ b/spec/03-plugins/20-ldap-auth/02-invalidations_spec.lua
@@ -83,7 +83,7 @@ for _, strategy in helpers.each_strategy() do
             authorization = "ldap " .. ngx.encode_base64("einstein:wrongpassword")
           }
         })
-        assert.res_status(403, res)
+        assert.res_status(401, res)
 
         local cache_key = cache_key(plugin.config, "einstein", "wrongpassword")
         res = assert(admin_client:send {


### PR DESCRIPTION
### Summary

Fix(basic-auth, ldap-auth, key-auth, jwt, hmac-auth) status code for unauthorized requests

### Full changelog

* Fix status code from 403 to 401 for unauthorized requests for basic-auth plugin [#3713](https://github.com/Kong/kong/issues/3713)
* Fix status code from 403 to 401 for unauthorized requests for key-auth plugin
* Fix status code from 403 to 401 for unauthorized requests for ldap-auth plugin
* Fix status code from 403 to 401 for unauthorized requests for jwt plugin
* Fix status code from 403 to 401 for unauthorized requests for hmac-auth plugin

### Issues resolved

Fix #3713
