### PR TITLE
docs(conf) remove old option that was incorrectly ressurected

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -228,14 +228,6 @@
                                  # `m`, with a minimum recommended value of
                                  # a few MBs.
 
-#ssl: on                         # Determines if Nginx should be
-                                 # listening for HTTPS traffic on the
-                                 # `proxy_listen_ssl` address. If disabled,
-                                 # Nginx will only bind itself on
-                                 # `proxy_listen`, and all SSL settings
-                                 # will be ignored.
-
-
 #ssl_cipher_suite = modern       # Defines the TLS ciphers served by Nginx.
                                  # Accepted values are `modern`,
                                  # `intermediate`, `old`, or `custom`.


### PR DESCRIPTION
The `ssl` option no longer exists. It was added back to `kong.conf.default` in 4fa780a2, but it should be removed from both `kong.conf.default` and the website documentation.

This was detected because a `grep` performed by kong-upgrade-tests misbehaved due to this paragraph referencing `proxy_listen_ssl`.