### PR TITLE
fix(router) ensure rebuilds when Routes have 'regex_priority = nil'

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -110,10 +110,15 @@ do
 
     sort(routes, function(r1, r2)
       r1, r2 = r1.route, r2.route
-      if r1.regex_priority == r2.regex_priority then
+
+      local rp1 = r1.regex_priority or 0
+      local rp2 = r2.regex_priority or 0
+
+      if rp1 == rp2 then
         return r1.created_at < r2.created_at
       end
-      return r1.regex_priority > r2.regex_priority
+
+      return rp1 > rp2
     end)
 
     local err


### PR DESCRIPTION
If Routes have `regex_priority` properties mixed between numbers and nil
(e.g. one Route was created with a default `regex_priority`, the other
was created with a purposefully NULL `regex_priority`, the comparison in
the router rebuild sorting of Routes would error out, because we are
comparing one Route's `nil` value against another Route's `number`.

Fix #4254