### PR TITLE
fix(jwt) fix typ handling

### DIFF
--- a/kong/plugins/jwt/jwt_parser.lua
+++ b/kong/plugins/jwt/jwt_parser.lua
@@ -154,10 +154,6 @@ local function decode_token(token)
     return nil, "invalid JSON"
   end
 
-  if header.typ and header.typ:upper() ~= "JWT" then
-    return nil, "invalid typ"
-  end
-
   if not header.alg or type(header.alg) ~= "string" or not alg_verify[header.alg] then
     return nil, "invalid alg"
   end

--- a/spec/03-plugins/16-jwt/01-jwt_parser_spec.lua
+++ b/spec/03-plugins/16-jwt/01-jwt_parser_spec.lua
@@ -120,11 +120,6 @@ describe("Plugin: jwt (parser)", function()
         jwt_parser:new()
       end, "Token must be a string, got nil")
     end)
-    it("refuses invalid typ", function()
-      local token = jwt_parser.encode({sub = "1234"}, "secret", nil, {typ = "foo"})
-      local _, err = jwt_parser:new(token)
-      assert.equal("invalid typ", err)
-    end)
     it("refuses invalid alg", function()
       local token = jwt_parser.encode({sub = "1234"}, "secret", nil, {
         typ = "JWT",


### PR DESCRIPTION
### Summary

When using JOSE  (Json Object Signature and Validation),  Kong incorrectly returns:
```json
{"message":"Bad token; invalid typ"}
``` 

After some investigation (see #4217), it appears that Kong explicitly rejects any `typ` not equal to JWT. This includes `typ` JOSE.

RFC [7519 section 5.1](https://tools.ietf.org/html/rfc7519#section-5.1) states:
> ...This [`typ`] parameter is ignored by JWT implementations; any processing of this parameter is
performed by the JWT application....

Given the above statement, it appears that Kong should ignore the `typ` header. This PR does that. 
Effectively, this change resolves the original `invalid typ` and is able to properly verify a JWT with `typ` JOSE.

### Full changelog

* [Implement ...]
* [Add related tests]
* ...

### Issues resolved

Fix #4217
