### PR TITLE
chore(db) drop un-used `upsert_ttl` postgres function

### DIFF
--- a/kong/db/migrations/core/003_100_to_110.lua
+++ b/kong/db/migrations/core/003_100_to_110.lua
@@ -7,6 +7,9 @@ return {
       UPDATE upstreams SET created_at = DATE_TRUNC('seconds', created_at);
       UPDATE targets   SET created_at = DATE_TRUNC('milliseconds', created_at);
 
+
+      DROP FUNCTION IF EXISTS "upsert_ttl" (TEXT, UUID, TEXT, TEXT, TIMESTAMP WITHOUT TIME ZONE);
+
     ]],
   },
 


### PR DESCRIPTION
### Summary

Drops legacy `upsert_ttl` function (not used anymore)