### PR TITLE
fix(db) workaround starttls bug by reverting pg to luasockets on preread

### DIFF
--- a/kong/db/strategies/postgres/connector.lua
+++ b/kong/db/strategies/postgres/connector.lua
@@ -123,7 +123,10 @@ local setkeepalive
 
 local function connect(config)
   local phase  = get_phase()
-  if phase == "init" or phase == "init_worker" or ngx.IS_CLI then
+  -- TODO: remove preread from here when the issue with starttls has been fixed
+  -- TODO: make also sure that Cassandra doesn't use LuaSockets on preread after
+  --       starttls has been fixed
+  if phase == "preread" or phase == "init" or phase == "init_worker" or ngx.IS_CLI then
     -- Force LuaSocket usage in the CLI in order to allow for self-signed
     -- certificates to be trusted (via opts.cafile) in the resty-cli
     -- interpreter (no way to set lua_ssl_trusted_certificate).


### PR DESCRIPTION
### Summary

Makes `preread` phase work on tests shown in #4243. But this is a work-around, as it forces `LuaSockets` on `proxy`. On the other hand, this is the current, and wrong, behavior of `lua-cassandra` as well.

This was made for `1.0.3` as it is better to have working implementation (even with `luasockets`) than a broken implementation. If `starttls` can be corrected so that tests run correctly with tests added in #4243, this can be closed.

### Issues resolved

Workaround: #4243