### PR TITLE
misc(ci) remove distributions we no longer support because they've be…

### DIFF
--- a/.ci/trigger-travis.sh
+++ b/.ci/trigger-travis.sh
@@ -103,10 +103,8 @@ body="{
       \"matrix\": [
         \"BUILD_RELEASE=true PLATFORM=centos:6 $NIGHTLY $VERSION\",
         \"BUILD_RELEASE=true PLATFORM=centos:7 $NIGHTLY $VERSION\",
-        \"BUILD_RELEASE=true PLATFORM=debian:7 $NIGHTLY $VERSION\",
         \"BUILD_RELEASE=true PLATFORM=debian:8 $NIGHTLY $VERSION\",
         \"BUILD_RELEASE=true PLATFORM=debian:9 $NIGHTLY $VERSION\",
-        \"BUILD_RELEASE=true PLATFORM=ubuntu:12.04.5 $NIGHTLY $VERSION\",
         \"BUILD_RELEASE=true PLATFORM=ubuntu:14.04.2 $NIGHTLY $VERSION\",
         \"BUILD_RELEASE=true PLATFORM=ubuntu:16.04 $NIGHTLY $VERSION\",
         \"BUILD_RELEASE=true PLATFORM=ubuntu:17.04 $NIGHTLY $VERSION\",


### PR DESCRIPTION
Debian 7 and Ubuntu 12.04 are both EOL so we no longer build / support these distributions