### PR TITLE
feat(core) make service on routes optional (transparent proxying)

### DIFF
--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -104,7 +104,7 @@ return {
                        },
                      }, },
     { tags             = typedefs.tags },
-    { service = { type = "foreign", reference = "services", required = true }, },
+    { service = { type = "foreign", reference = "services" }, },
   },
 
   entity_checks = {

--- a/kong/router.lua
+++ b/kong/router.lua
@@ -7,7 +7,6 @@ local bit           = require "bit"
 local hostname_type = utils.hostname_type
 local re_match      = ngx.re.match
 local re_find       = ngx.re.find
-local null          = ngx.null
 local insert        = table.insert
 local sort          = table.sort
 local upper         = string.upper
@@ -89,18 +88,22 @@ local protocol_subsystem = {
 }
 
 local function marshall_route(r)
-  local route    = r.route          or null
-  local service  = r.service        or null
-  local headers  = r.headers        or null
-  local paths    = route.paths      or null
-  local methods  = route.methods    or null
-  local protocol = service.protocol or null
-  local sources  = route.sources  or null
-  local destinations = route.destinations or null
-  local snis     = route.snis or null
+  local route        = r.route
+  local service      = r.service
+  local headers      = r.headers
+  local paths        = route.paths
+  local methods      = route.methods
+  local snis         = route.snis
+  local sources      = route.sources
+  local destinations = route.destinations
 
-  if not (headers ~= null or methods ~= null or paths ~= null or
-          sources ~= null or destinations ~= null or snis ~= null) then
+
+  local protocol
+  if service then
+    protocol = service.protocol
+  end
+
+  if not (headers or methods or paths or snis or sources or destinations) then
     return nil, "could not categorize route"
   end
 
@@ -125,7 +128,7 @@ local function marshall_route(r)
   -- headers
 
 
-  if headers ~= null then
+  if headers then
     if type(headers) ~= "table" then
       return nil, "headers field must be a table"
     end
@@ -174,7 +177,7 @@ local function marshall_route(r)
   -- paths
 
 
-  if paths ~= null then
+  if paths then
     if type(paths) ~= "table" then
       return nil, "paths field must be a table"
     end
@@ -219,7 +222,7 @@ local function marshall_route(r)
   -- methods
 
 
-  if methods ~= null then
+  if methods then
     if type(methods) ~= "table" then
       return nil, "methods field must be a table"
     end
@@ -238,7 +241,7 @@ local function marshall_route(r)
   -- sources
 
 
-  if sources ~= null then
+  if sources then
     if type(sources) ~= "table" then
       return nil, "sources field must be a table"
     end
@@ -271,7 +274,7 @@ local function marshall_route(r)
   -- destinations
 
 
-  if destinations ~= null then
+  if destinations then
     if type(destinations) ~= "table" then
       return nil, "destinations field must be a table"
     end
@@ -304,7 +307,7 @@ local function marshall_route(r)
   -- snis
 
 
-  if snis ~= null then
+  if snis then
     if type(snis) ~= "table" then
       return nil, "snis field must be a table"
     end
@@ -323,16 +326,15 @@ local function marshall_route(r)
   end
 
 
-  if protocol ~= null then
-    route_t.upstream_url_t.scheme = protocol
-  end
-
-
   -- upstream_url parsing
 
 
-  local host = service.host or null
-  if host ~= null then
+  if protocol then
+    route_t.upstream_url_t.scheme = protocol
+  end
+
+  local host = service.host
+  if host then
     route_t.upstream_url_t.host = host
     route_t.upstream_url_t.type = hostname_type(host)
 
@@ -340,8 +342,8 @@ local function marshall_route(r)
     route_t.upstream_url_t.type = hostname_type("")
   end
 
-  local port = service.port or null
-  if port ~= null then
+  local port = service.port
+  if port then
     route_t.upstream_url_t.port = port
 
   else

--- a/spec/01-unit/01-db/01-schema/06-routes_spec.lua
+++ b/spec/01-unit/01-db/01-schema/06-routes_spec.lua
@@ -35,12 +35,20 @@ describe("routes schema", function()
     assert.falsy(route.strip_path)
   end)
 
-  it("fails when service is null", function()
+  it("it does not fail when service is null", function()
     local route = { service = ngx.null, paths = {"/"} }
     route = Routes:process_auto_fields(route, "insert")
     local ok, errs = Routes:validate_insert(route)
-    assert.falsy(ok)
-    assert.truthy(errs["service"])
+    assert.truthy(ok)
+    assert.is_nil(errs)
+  end)
+
+  it("it does not fail when service is missing", function()
+    local route = { paths = {"/"} }
+    route = Routes:process_auto_fields(route, "insert")
+    local ok, errs = Routes:validate_insert(route)
+    assert.truthy(ok)
+    assert.is_nil(errs)
   end)
 
   it("fails when service.id is null", function()

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -12,7 +12,7 @@ local service = {
 
 local use_case = {
 
--- host
+  -- 1. host
   {
     service = service,
     route   = {
@@ -24,7 +24,7 @@ local use_case = {
       },
     },
   },
-  -- method
+  -- 2. method
   {
     service = service,
     route   = {
@@ -33,7 +33,7 @@ local use_case = {
       },
     }
   },
-  -- uri
+  -- 3. uri
   {
     service = service,
     route   = {
@@ -42,7 +42,7 @@ local use_case = {
       },
     }
   },
-  -- host + uri
+  -- 4. host + uri
   {
     service = service,
     route   = {
@@ -57,7 +57,7 @@ local use_case = {
       },
     },
   },
-  -- host + method
+  -- 5. host + method
   {
     service = service,
     route   = {
@@ -74,7 +74,7 @@ local use_case = {
       },
     },
   },
-  -- uri + method
+  -- 6. uri + method
   {
     service = service,
     route   = {
@@ -88,7 +88,7 @@ local use_case = {
       },
     }
   },
-  -- host + uri + method
+  -- 7. host + uri + method
   {
     service = service,
     route   = {
@@ -107,6 +107,14 @@ local use_case = {
         "domain-with-uri-2.org"
       },
     },
+  },
+  -- 8. serviceless-route
+  {
+    route   = {
+      paths = {
+        "/serviceless"
+      },
+    }
   },
 }
 
@@ -238,6 +246,15 @@ describe("Router", function()
       assert.same(match_t.matches.method, use_case[7].route.methods[2])
       assert.same(match_t.matches.uri, use_case[7].route.paths[1])
       assert.same(match_t.matches.uri_captures, nil)
+    end)
+
+    it("[serviceless]", function()
+      local match_t = router.select("GET", "/serviceless")
+      assert.truthy(match_t)
+      assert.is_nil(match_t.service)
+      assert.is_nil(match_t.matches.uri_captures)
+      assert.same(use_case[8].route, match_t.route)
+      assert.same(match_t.matches.uri, use_case[8].route.paths[1])
     end)
 
     describe("[uri prefix]", function()

--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -61,11 +61,14 @@ describe("kong start/stop #" .. strategy, function()
   if strategy == "cassandra" then
     it("start resolves cassandra contact points", function()
       assert(helpers.kong_exec("start", {
+        prefix = helpers.test_conf.prefix,
         database = strategy,
         cassandra_contact_points = "localhost",
         cassandra_keyspace = helpers.test_conf.cassandra_keyspace,
       }))
-      assert(helpers.kong_exec("stop"))
+      assert(helpers.kong_exec("stop", {
+        prefix = helpers.test_conf.prefix,
+      }))
     end)
   end
 
@@ -356,7 +359,7 @@ describe("kong start/stop #" .. strategy, function()
 
     if strategy == "cassandra" then
       it("errors when cassandra contact points cannot be resolved", function()
-        local ok, stderr = helpers.kong_exec("start --prefix " .. helpers.test_conf.prefix, {
+        local ok, stderr = helpers.start_kong({
           database = strategy,
           cassandra_contact_points = "invalid.inexistent.host",
           cassandra_keyspace = helpers.test_conf.cassandra_keyspace,
@@ -367,6 +370,7 @@ describe("kong start/stop #" .. strategy, function()
                        "(cassandra_contact_points = 'invalid.inexistent.host')", stderr, nil, true)
 
         finally(function()
+          helpers.stop_kong()
           helpers.kill_all()
           pcall(helpers.dir.rmtree)
         end)

--- a/spec/02-integration/03-db/07-tags_spec.lua
+++ b/spec/02-integration/03-db/07-tags_spec.lua
@@ -16,7 +16,7 @@ for _, strategy in helpers.each_strategy() do
 
     -- Note by default the page size is 100, we should keep this number
     -- less than 100/(tags_per_entity)
-    -- otherwise the 'limits maximum queries in single request' tests 
+    -- otherwise the 'limits maximum queries in single request' tests
     -- for Cassandra might fail
     local test_entity_count = 10
 
@@ -87,9 +87,9 @@ for _, strategy in helpers.each_strategy() do
       -- due to the different sql in postgres stragey
       -- we need to test these two methods seperately
       local scenarios = {
-        { "update", { id = service1.id }, "service1", }, 
+        { "update", { id = service1.id }, "service1", },
         { "update_by_name", "service2", "service2"},
-        { "upsert", { id = service3.id }, "service3" }, 
+        { "upsert", { id = service3.id }, "service3" },
         { "upsert_by_name", "service4", "service4"},
       }
       for _, scenario in pairs(scenarios) do
@@ -140,7 +140,7 @@ for _, strategy in helpers.each_strategy() do
       -- due to the different sql in postgres stragey
       -- we need to test these two methods seperately
       local scenarios = {
-        { "delete", { id = service5.id }, "service5" }, 
+        { "delete", { id = service5.id }, "service5" },
         { "delete_by_name", "service6", "service6" },
       }
       for i, scenario in pairs(scenarios) do
@@ -179,7 +179,7 @@ for _, strategy in helpers.each_strategy() do
       -- note this is different from test "update row in tags table with"
       -- as this test actually creats new records
       local scenarios = {
-        { "upsert", { id = require("kong.tools.utils").uuid() }, { "service-upsert-1" } }, 
+        { "upsert", { id = require("kong.tools.utils").uuid() }, { "service-upsert-1" } },
         { "upsert_by_name", "service-upsert-2", { "service-upsert-2" } },
       }
       for _, scenario in pairs(scenarios) do
@@ -232,7 +232,7 @@ for _, strategy in helpers.each_strategy() do
         {
           { { "team_paging_1", "team_paging_2" }, "or" },
           total_entities_count/single_tag_count*2,
-        }, 
+        },
         {
           { { "paging", "team_paging_1" }, "and" },
           total_entities_count/single_tag_count,
@@ -297,7 +297,7 @@ for _, strategy in helpers.each_strategy() do
         it("and exits early if PAGING_MAX_QUERY_ROUNDS exceeded", function()
           stub(ngx, "log")
 
-          local rows, err, err_t, offset = db.services:page(2, nil, 
+          local rows, err, err_t, offset = db.services:page(2, nil,
             { tags = { "paging", "tag_notexist" }, tags_cond = 'and' })
           assert(is_valid_page(rows, err, err_t))
           assert.is_not_nil(offset)
@@ -325,7 +325,7 @@ for _, strategy in helpers.each_strategy() do
           assert.stub(ngx.log).was_not_called()
         end)
 
-        it("and returns as normal if page size is large enough", function()
+        it("#flaky and returns as normal if page size is large enough", function()
           stub(ngx, "log")
 
           local rows, err, err_t, offset = db.services:page(enough_page_size, nil,

--- a/spec/02-integration/05-proxy/18-serviceless_proxying_spec.lua
+++ b/spec/02-integration/05-proxy/18-serviceless_proxying_spec.lua
@@ -1,0 +1,386 @@
+local http_request = require "http.request"
+local http_tls = require "http.tls"
+local openssl_ssl = require "openssl.ssl"
+local helpers = require "spec.helpers"
+local cjson = require "cjson"
+local meta = require "kong.meta"
+
+
+local tonumber = tonumber
+local null = ngx.null
+
+
+local HTTP_PROXY_HOST = helpers.get_proxy_ip(false)
+local HTTP_PROXY_PORT = helpers.get_proxy_port(false)
+local HTTPS_PROXY_HOST = helpers.get_proxy_ip(true)
+local HTTPS_PROXY_PORT = helpers.get_proxy_port(true)
+local HTTP_PROXY_URI  = "http://"  .. HTTP_PROXY_HOST .. ":" .. HTTP_PROXY_PORT
+--local HTTPS_PROXY_URI = "https://" .. HTTPS_PROXY_HOST  .. ":" .. HTTPS_PROXY_PORT
+local HTTP_UPSTREAM_URI = helpers.mock_upstream_url .. "/anything"
+local HTTPS_UPSTREAM_URI = helpers.mock_upstream_ssl_url .. "/anything"
+local HTTP_UPSTREAM_HOST = helpers.mock_upstream_host .. ":" .. helpers.mock_upstream_port
+local HTTPS_UPSTREAM_HOST = helpers.mock_upstream_host .. ":" .. helpers.mock_upstream_ssl_port
+local STREAM_UPSTREAM_HOST = helpers.mock_upstream_host
+local STREAM_UPSTREAM_PORT = helpers.mock_upstream_stream_port
+local STREAM_UPSTREAM_SSL_PORT = helpers.mock_upstream_stream_ssl_port
+
+
+for _, strategy in helpers.each_strategy() do
+  describe("Serviceless Proxying [#" .. strategy .. "]", function()
+    describe("[http]", function()
+      lazy_setup(function()
+        local bp = helpers.get_db_utils(strategy, {
+          "routes",
+        })
+
+        bp.routes:insert {
+          paths   = { "/" },
+          service = null,
+        }
+
+        assert(helpers.start_kong({
+          database      = strategy,
+          nginx_conf    = "spec/fixtures/custom_nginx.template",
+          stream_listen = "off",
+          admin_listen  = "off",
+        }))
+      end)
+
+      lazy_teardown(function()
+        helpers.stop_kong(helpers.test_conf.prefix, true)
+      end)
+
+      it("proxies http to http (request-line)", function()
+        local request = http_request.new_from_uri(HTTP_UPSTREAM_URI)
+        request.proxy = HTTP_PROXY_URI
+        request.version = 1.1
+        request.tls = false
+        local headers, stream = request:go()
+
+        assert.equal(200, tonumber((headers:get(":status"))))
+        assert.equal(meta._SERVER_TOKENS, (headers:get("via")))
+
+        local body = assert(stream:get_body_as_string())
+        local json = cjson.decode(body)
+
+        assert.equal(HTTP_PROXY_PORT, tonumber(json.headers["x-forwarded-port"]))
+        assert.equal("http", json.headers["x-forwarded-proto"])
+
+        stream:shutdown()
+      end)
+
+      it("proxies https to http (request-line)", function()
+        local ctx = http_tls.new_client_context()
+        ctx:setVerify(openssl_ssl.VERIFY_NONE)
+
+        local request = http_request.new_from_uri(HTTP_UPSTREAM_URI)
+        request.headers:upsert(":path", request:to_uri(false))
+        request.host = HTTPS_PROXY_HOST
+        request.port = HTTPS_PROXY_PORT
+        request.version = 1.1
+        request.tls = true
+        request.ctx = ctx
+        local headers, stream = request:go()
+
+        assert.equal(200, tonumber((headers:get(":status"))))
+        assert.equal(meta._SERVER_TOKENS, (headers:get("via")))
+
+        local body = assert(stream:get_body_as_string())
+        local json = cjson.decode(body)
+
+        assert.equal(HTTP_UPSTREAM_HOST, json.headers["host"])
+        assert.equal(HTTPS_PROXY_PORT, tonumber(json.headers["x-forwarded-port"]))
+        assert.equal("https", json.headers["x-forwarded-proto"])
+
+        stream:shutdown()
+      end)
+
+      it("proxies http to http (host-header)", function()
+        local request = http_request.new_from_uri(HTTP_UPSTREAM_URI)
+        request.headers:upsert(":path", "/anything")
+        request.headers:upsert("host", HTTP_UPSTREAM_HOST)
+        request.host = HTTP_PROXY_HOST
+        request.port = HTTP_PROXY_PORT
+        request.version = 1.1
+        request.tls = false
+        local headers, stream = request:go()
+
+        assert.equal(200, tonumber((headers:get(":status"))))
+        assert.equal(meta._SERVER_TOKENS, (headers:get("via")))
+
+        local body = assert(stream:get_body_as_string())
+        local json = cjson.decode(body)
+
+        assert.equal(HTTP_UPSTREAM_HOST, json.headers["host"])
+        assert.equal(HTTP_PROXY_PORT, tonumber(json.headers["x-forwarded-port"]))
+        assert.equal("http", json.headers["x-forwarded-proto"])
+
+        stream:shutdown()
+      end)
+
+      -- TODO: needs https://github.com/chobits/ngx_http_proxy_connect_module
+      pending("proxies http to https (connect)", function()
+        local ctx = http_tls.new_client_context()
+        ctx:setVerify(openssl_ssl.VERIFY_NONE)
+
+        local request = http_request.new_from_uri(HTTPS_UPSTREAM_URI)
+        request.proxy = HTTP_PROXY_URI
+        request.version = 1.1
+        request.tls = true
+        request.ctx = ctx
+        local headers, stream = request:go()
+
+        assert.equal(200, tonumber((headers:get(":status"))))
+
+        local body = assert(stream:get_body_as_string())
+        local json = cjson.decode(body)
+
+        assert.equal(HTTPS_UPSTREAM_HOST, json.headers["host"])
+
+        stream:shutdown()
+      end)
+
+      -- TODO: needs https://github.com/chobits/ngx_http_proxy_connect_module
+      pending("proxies https to https (connect)", function()
+      end)
+
+      -- TODO: transparent needs iptables / pf to work on travis
+      pending("proxies http to http (transparent)", function()
+      end)
+
+      -- TODO: transparent needs iptables / pf to work on travis
+      pending("proxies https to http (transparent)", function()
+      end)
+
+      -- TODO: transparent needs iptables / pf to work on travis
+      pending("proxies http to https (transparent)", function()
+      end)
+
+      -- TODO: transparent needs iptables / pf to work on travis
+      pending("proxies https to https (transparent)", function()
+      end)
+    end)
+
+    describe("[http2]", function()
+      lazy_setup(function()
+        local bp = helpers.get_db_utils(strategy, {
+          "routes",
+        })
+
+        bp.routes:insert {
+          paths = { "/" },
+          service = null,
+        }
+
+        assert(helpers.start_kong({
+          proxy_listen  = HTTP_PROXY_HOST  .. ":" .. HTTP_PROXY_PORT  .. " http2, " ..
+                          HTTPS_PROXY_HOST .. ":" .. HTTPS_PROXY_PORT .. " http2 ssl",
+          database      = strategy,
+          nginx_conf    = "spec/fixtures/custom_nginx.template",
+          stream_listen = "off",
+          admin_listen  = "off",
+        }))
+
+      end)
+
+      lazy_teardown(function()
+        helpers.stop_kong(helpers.test_conf.prefix, true)
+      end)
+
+      -- TODO: nginx doesn't allow absolute uris in http2 path component
+      pending("proxies http to http (request-line)", function()
+        local request = http_request.new_from_uri(HTTP_UPSTREAM_URI)
+        request.proxy = HTTP_PROXY_URI
+        request.version = 2.0
+        request.tls = false
+        local headers, stream = request:go()
+
+        assert.equal(200, tonumber((headers:get(":status"))))
+        assert.equal(meta._SERVER_TOKENS, (headers:get("via")))
+
+        local body = assert(stream:get_body_as_string())
+        local json = cjson.decode(body)
+
+        assert.equal(HTTP_UPSTREAM_HOST, json.headers["host"])
+        assert.equal(HTTP_PROXY_PORT, tonumber(json.headers["x-forwarded-port"]))
+        assert.equal("http", json.headers["x-forwarded-proto"])
+
+        stream:shutdown()
+      end)
+
+      -- TODO: nginx doesn't allow absolute uris in http2 path component
+      pending("proxies https to http (request-line)", function()
+        local ctx = http_tls.new_client_context()
+        ctx:setVerify(openssl_ssl.VERIFY_NONE)
+
+        local request = http_request.new_from_uri(HTTP_UPSTREAM_URI)
+        request.headers:upsert(":path", request:to_uri(false))
+        request.host = helpers.get_proxy_ip(true)
+        request.port = helpers.get_proxy_port(true)
+        request.version = 2.0
+        request.tls = true
+        request.ctx = ctx
+        local headers, stream = request:go()
+
+        assert.equal(200, tonumber((headers:get(":status"))))
+        assert.equal(meta._SERVER_TOKENS, (headers:get("via")))
+
+        local body = assert(stream:get_body_as_string())
+        local json = cjson.decode(body)
+
+        assert.equal(HTTP_UPSTREAM_HOST, json.headers["host"])
+        assert.equal(HTTPS_PROXY_PORT, tonumber(json.headers["x-forwarded-port"]))
+        assert.equal("https", json.headers["x-forwarded-proto"])
+
+        stream:shutdown()
+      end)
+
+      it("proxies http to http (host-header)", function()
+        local request = http_request.new_from_uri(HTTP_UPSTREAM_URI)
+        request.headers:upsert(":path", "/anything")
+        request.headers:upsert("host", HTTP_UPSTREAM_HOST)
+        request.host = HTTP_PROXY_HOST
+        request.port = HTTP_PROXY_PORT
+        request.version = 2.0
+        request.tls = false
+        local headers, stream = request:go()
+
+        assert.equal(200, tonumber((headers:get(":status"))))
+        assert.equal(meta._SERVER_TOKENS, (headers:get("via")))
+
+        local body = assert(stream:get_body_as_string())
+        local json = cjson.decode(body)
+
+        assert.equal(HTTP_UPSTREAM_HOST, json.headers["host"])
+        assert.equal(HTTP_PROXY_PORT, tonumber(json.headers["x-forwarded-port"]))
+        assert.equal("http", json.headers["x-forwarded-proto"])
+
+        stream:shutdown()
+      end)
+
+      -- TODO: needs https://github.com/chobits/ngx_http_proxy_connect_module
+      pending("proxies http to https (connect)", function()
+        local ctx = http_tls.new_client_context()
+        ctx:setVerify(openssl_ssl.VERIFY_NONE)
+
+        local request = http_request.new_from_uri(HTTPS_UPSTREAM_URI)
+        request.headers:upsert(":path", "/anything")
+        request.headers:upsert(":authority", HTTPS_UPSTREAM_HOST)
+        request.host = HTTP_PROXY_HOST
+        request.port = HTTP_PROXY_PORT
+        request.version = 2.0
+        request.tls = true
+        request.ctx = ctx
+        local headers, stream = request:go()
+
+        print(stream)
+        assert.equal(200, tonumber((headers:get(":status"))))
+
+        local body = assert(stream:get_body_as_string())
+        local json = cjson.decode(body)
+
+        assert.equal(HTTPS_UPSTREAM_HOST, json.headers["host"])
+
+        stream:shutdown()
+      end)
+
+      -- TODO: needs https://github.com/chobits/ngx_http_proxy_connect_module
+      pending("proxies https to https (connect)", function()
+      end)
+
+      -- TODO: transparent needs iptables / pf to work on travis
+      pending("proxies http to http (transparent)", function()
+      end)
+
+      -- TODO: transparent needs iptables / pf to work on travis
+      pending("proxies https to http (transparent)", function()
+      end)
+
+      -- TODO: transparent needs iptables / pf to work on travis
+      pending("proxies http to https (transparent)", function()
+      end)
+
+      -- TODO: transparent needs iptables / pf to work on travis
+      pending("proxies https to https (transparent)", function()
+      end)
+    end)
+
+    describe("[stream]", function()
+      local MESSAGE = "echo, ping, pong. echo, ping, pong. echo, ping, pong.\n"
+
+      lazy_setup(function()
+        local bp = helpers.get_db_utils(strategy, {
+          "routes",
+        })
+
+        assert(bp.routes:insert {
+          destinations = {
+            { port = 19000, },
+            { port = 19443, },
+          },
+          protocols = {
+            "tcp",
+            "tls",
+          },
+          service = null,
+        })
+
+        assert(helpers.start_kong({
+          stream_listen = HTTP_PROXY_HOST  .. ":19000," ..
+                          HTTPS_PROXY_HOST .. ":19443",
+          database      = strategy,
+          nginx_conf    = "spec/fixtures/custom_nginx.template",
+          proxy_listen  = "off",
+          admin_listen  = "off",
+          origins       = "tcp://127.0.0.1:19000=" ..
+                          "tcp://" .. STREAM_UPSTREAM_HOST ..  ":" .. STREAM_UPSTREAM_PORT .. "," ..
+                          "tls://127.0.0.1:19443=" ..
+                          "tls://" .. STREAM_UPSTREAM_HOST ..  ":" .. STREAM_UPSTREAM_SSL_PORT
+        }))
+      end)
+
+      lazy_teardown(function()
+        helpers.stop_kong(helpers.test_conf.prefix, true)
+      end)
+
+      it("proxies tcp to tcp (origins)", function()
+        local tcp = require "socket".tcp()
+        assert(tcp:connect(HTTP_PROXY_HOST, 19000))
+
+        -- TODO: we need to get rid of the next line!
+        assert(tcp:send(MESSAGE))
+
+        local body = assert(tcp:receive("*a"))
+        assert.equal(MESSAGE, body)
+
+        tcp:close()
+      end)
+
+      it("proxies tls to tls (origins)", function()
+        local tcp = require "socket".tcp()
+        local ssl = require("ssl")
+
+        assert(tcp:connect(HTTPS_PROXY_HOST, 19443))
+
+        tcp = ssl.wrap(tcp, {
+          mode     = "client",
+          verify   = "none",
+          protocol = "any",
+        })
+
+        -- TODO: should SNI really be mandatory?
+        tcp:sni( "this-is-needed.org")
+
+        assert(tcp:dohandshake())
+
+        -- TODO: we need to get rid of the next line!
+        assert(tcp:send(MESSAGE))
+
+        local body = assert(tcp:receive("*a"))
+        assert.equal(MESSAGE, body)
+
+        tcp:close()
+      end)
+    end)
+  end)
+end


### PR DESCRIPTION
### Summary

This is first implementation of so called `allow_by_default` routing. E.g. routes that act as a transparent routes. Which means you don't need to create service entity, but instead you can use HTTP proxying or `iptables` transparent proxying rules.