### PR TITLE
 fix(db) resolve Cassandra contact points when provided as hostnames 

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -433,6 +433,14 @@
 
 #cassandra_contact_points = 127.0.0.1  # A comma-separated list of contact
                                        # points to your cluster.
+                                       # You may specify IP addresses or
+                                       # hostnames. Note that the port
+                                       # component of SRV records will be
+                                       # ignored in favor of `cassandra_port`.
+                                       # When connecting to a multi-DC cluster,
+                                       # ensure that contact points from the
+                                       # local datacenter are specified first
+                                       # in this list.
 
 #cassandra_port = 9042           # The port on which your nodes are listening
                                  # on. All your nodes and contact points must

--- a/spec/02-integration/03-db/01-db_spec.lua
+++ b/spec/02-integration/03-db/01-db_spec.lua
@@ -4,7 +4,7 @@ local utils   = require "kong.tools.utils"
 
 
 for _, strategy in helpers.each_strategy() do
-  local it_ssl = strategy == "cassandra" and pending or it
+  local postgres_only = strategy == "postgres" and it or pending
 
 
   describe("kong.db.init [#" .. strategy .. "]", function()
@@ -154,7 +154,7 @@ for _, strategy in helpers.each_strategy() do
       db:close()
     end)
 
-    it_ssl("returns opened connection with ssl (cosockets)", function()
+    postgres_only("returns opened connection with ssl (cosockets)", function()
       ngx.IS_CLI = false
 
       local conf = utils.deep_copy(helpers.test_conf)
@@ -183,7 +183,7 @@ for _, strategy in helpers.each_strategy() do
       db:close()
     end)
 
-    it_ssl("returns opened connection with ssl (luasocket)", function()
+    postgres_only("returns opened connection with ssl (luasocket)", function()
       ngx.IS_CLI = true
 
       local conf = utils.deep_copy(helpers.test_conf)
@@ -271,7 +271,7 @@ for _, strategy in helpers.each_strategy() do
       db:close()
     end)
 
-    it_ssl("returns true when there is a stored connection with ssl (cosockets)", function()
+    postgres_only("returns true when there is a stored connection with ssl (cosockets)", function()
       ngx.IS_CLI = false
 
       local conf = utils.deep_copy(helpers.test_conf)
@@ -301,7 +301,7 @@ for _, strategy in helpers.each_strategy() do
       db:close()
     end)
 
-    it_ssl("returns true when there is a stored connection with ssl (luasocket)", function()
+    postgres_only("returns true when there is a stored connection with ssl (luasocket)", function()
       ngx.IS_CLI = true
 
       local conf = utils.deep_copy(helpers.test_conf)
@@ -411,7 +411,7 @@ for _, strategy in helpers.each_strategy() do
       assert.is_true(db:close())
     end)
 
-    it_ssl("returns true when there is a stored connection with ssl (cosockets)", function()
+    postgres_only("returns true when there is a stored connection with ssl (cosockets)", function()
       ngx.IS_CLI = false
 
       local conf = utils.deep_copy(helpers.test_conf)
@@ -439,7 +439,7 @@ for _, strategy in helpers.each_strategy() do
       assert.is_true(db:close())
     end)
 
-    it_ssl("returns true when there is a stored connection with ssl (luasocket)", function()
+    postgres_only("returns true when there is a stored connection with ssl (luasocket)", function()
       ngx.IS_CLI = true
 
       local conf = utils.deep_copy(helpers.test_conf)


### PR DESCRIPTION
Resolve contact points before instantiating cluster.  The driver does
not support hostnames in the contact points list, but we accidentally
support this feature by relying on our globalpatches.lua override of
`tcpsock:connect()`, in which we perform DNS resolution. This could lead
to mismatches between the driver policies and the peers info stored in
the shm.

This scenario is described in details here:

thibaultcha/lua-cassandra@8b9fcd9

We do not rely on `kong.dns` since the `kong` global is not always fully
instantiated in all of our components yet (notably the tests and the
CLI).