### PR TITLE
refactor(db) de-hardcode custom strategies list

### DIFF
--- a/kong/db/strategies/cassandra/init.lua
+++ b/kong/db/strategies/cassandra/init.lua
@@ -43,12 +43,7 @@ local APPLIED_COLUMN = "[applied]"
 local cache_key_field = { type = "string" }
 
 
-local _M  = {
-  CUSTOM_STRATEGIES = {
-    services = require("kong.db.strategies.cassandra.services"),
-    plugins = require("kong.db.strategies.cassandra.plugins"),
-  }
-}
+local _M  = {}
 
 local _mt = {}
 _mt.__index = _mt

--- a/kong/db/strategies/postgres/init.lua
+++ b/kong/db/strategies/postgres/init.lua
@@ -867,11 +867,7 @@ function _mt:escape_literal(literal, field_name)
 end
 
 
-local _M  = {
-  CUSTOM_STRATEGIES = {
-    plugins = require("kong.db.strategies.postgres.plugins"),
-  }
-}
+local _M  = {}
 
 
 function _M.new(connector, schema, errors)


### PR DESCRIPTION
The implementation of a core entity consists of up to three parts:

1. the schema of the entity (`kong.db.schema.entities.my_entity`)
2. a DB-agnostic DAO module implementing custom methods for that entity or overriding standard methods in a DB-agnostic manner (`kong.db.dao.my_entity`)
3. one or more DB-specific modules implementing the database backend
   for custom methods, or overriding standard methods in a DB-specific manner (`kong.db.strategies.postgres.my_entity` and    `kong.db.strategies.cassandra.my_entity`)

Instead of using a hardcoded list of customized DB-specific override modules (item 3 above) with this commit we simply attempt to load the module for every entity, and use it if it is available.

This is the backwards-compatible solution to be merged to `master`. Once this is in, a subsequent PR will be made to `next` that adds the ability of loading DB-specific strategies for custom entities in plugins (hi @p0pr0ck5!) in about 3 lines :)
