### PR TITLE
chore(ci) release daily builds for bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,9 @@ jobs:
       env: RESTY_IMAGE_BASE=ubuntu RESTY_IMAGE_TAG=xenial KONG_PACKAGE_NAME=${PWD##*/} KONG_VERSION=`date +%Y-%m-%d` REPOSITORY_NAME=${PWD##*/}-nightly REPOSITORY_OS_NAME=$TRAVIS_BRANCH
       if: type=cron
     - script: make release
+      env: RESTY_IMAGE_BASE=ubuntu RESTY_IMAGE_TAG=bionic KONG_PACKAGE_NAME=${PWD##*/} KONG_VERSION=`date +%Y-%m-%d` REPOSITORY_NAME=${PWD##*/}-nightly REPOSITORY_OS_NAME=$TRAVIS_BRANCH
+      if: type=cron
+    - script: make release
       env: RESTY_IMAGE_BASE=centos RESTY_IMAGE_TAG=6 KONG_PACKAGE_NAME=${PWD##*/} KONG_VERSION=`date +%Y-%m-%d` REPOSITORY_NAME=${PWD##*/}-nightly REPOSITORY_OS_NAME=$TRAVIS_BRANCH
       if: type=cron
     - script: make release


### PR DESCRIPTION
seems I missed an ubuntu. A successful build of a bionic release using kong-build-tools [here](https://travis-ci.com/Kong/kong-build-tools/jobs/177874840)