### PR TITLE
feat(proxy) clear hop-by-hop headers

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -18,6 +18,7 @@ local constants   = require "kong.constants"
 local singletons  = require "kong.singletons"
 local certificate = require "kong.runloop.certificate"
 local concurrency = require "kong.concurrency"
+local ngx_re      = require "ngx.re"
 
 
 local kong        = kong
@@ -34,6 +35,7 @@ local log         = ngx.log
 local ngx_now     = ngx.now
 local re_match    = ngx.re.match
 local re_find     = ngx.re.find
+local re_split    = ngx_re.split
 local update_time = ngx.update_time
 local subsystem   = ngx.config.subsystem
 local unpack      = unpack
@@ -574,6 +576,12 @@ return {
   rewrite = {
     before = function(ctx)
       ctx.KONG_REWRITE_START = get_now()
+
+      -- special handling for proxy-authorization and te headers in case
+      -- the plugin(s) want to specify them (store the original)
+      ctx.http_proxy_authorization = ngx.var.http_proxy_authorization
+      ctx.http_te                  = ngx.var.http_te
+
       mesh.rewrite(ctx)
     end,
     after = function(ctx)
@@ -925,6 +933,58 @@ return {
         end
       end
 
+      -- clear hop-by-hop request headers:
+      local connection = var.http_connection
+      if connection then
+        local header_names = re_split(connection .. ",", [[\s*,\s*]], "djo")
+        if header_names then
+          for i=1, #header_names do
+            if header_names[i] ~= "" then
+              local header_name = lower(header_names[i])
+              -- some of these are already handled by the proxy module,
+              -- proxy-authorization being an exception that is handled
+              -- below with special semantics.
+              if header_name ~= "close" and
+                 header_name ~= "upgrade" and
+                 header_name ~= "keep-alive" and
+                 header_name ~= "proxy-authorization" then
+                ngx.req.clear_header(header_names[i])
+              end
+            end
+          end
+        end
+      end
+
+      -- add te header only when client requests trailers (proxy removes it)
+      local te = var.http_te
+      if te and te == ctx.http_te then
+        local te_values = re_split(te .. ",", [[\s*,\s*]], "djo")
+        if te_values then
+          for i=1, #te_values do
+            if te_values[i] ~= "" and lower(te_values[i]) == "trailers" then
+              ngx.var.upstream_te = "trailers"
+              break
+            end
+          end
+        end
+      end
+
+      if var.http_proxy then
+        ngx.req.clear_header("Proxy")
+      end
+
+      if var.http_proxy_connection then
+        ngx.req.clear_header("Proxy-Connection")
+      end
+
+      -- clear the proxy-authorization header only in case the plugin didn't
+      -- specify it, assuming that the plugin didn't specify the same value.
+      local proxy_authorization = var.http_proxy_authorization
+      if proxy_authorization and
+         proxy_authorization == var.http_proxy_authorization then
+        ngx.req.clear_header("Proxy-Authorization")
+      end
+
       local now = get_now()
 
       -- time spent in Kong's access_by_lua
@@ -966,6 +1026,39 @@ return {
       -- time spent waiting for a response from upstream
       ctx.KONG_WAITING_TIME             = now - ctx.KONG_ACCESS_ENDED_AT
       ctx.KONG_HEADER_FILTER_STARTED_AT = now
+
+      -- clear hop-by-hop response headers:
+      local var = ngx.var
+
+      local connection = var.upstream_http_connection
+      if connection then
+        local header_names = re_split(connection .. ",", [[\s*,\s*]], "djo")
+        if header_names then
+          for i=1, #header_names do
+            if header_names[i] ~= "" then
+              local header_name = lower(header_names[i])
+              if header_name ~= "close" and
+                 header_name ~= "upgrade" and
+                 header_name ~= "keep-alive" then
+                header[header_names[i]] = nil
+              end
+            end
+          end
+        end
+      end
+
+      if var.upstream_http_upgrade then
+        header["Upgrade"] = nil
+      end
+
+      if var.upstream_http_proxy_authenticate then
+        header["Proxy-Authenticate"] = nil
+      end
+
+      -- remove trailer response header when client didn't ask for them
+      if var.upstream_te == "" and var.upstream_http_trailer then
+        header["Trailer"] = nil
+      end
 
       local upstream_status_header = constants.HEADERS.UPSTREAM_STATUS
       if singletons.configuration.enabled_headers[upstream_status_header] then

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -118,6 +118,7 @@ server {
         default_type                     '';
 
         set $ctx_ref                     '';
+        set $upstream_te                 '';
         set $upstream_host               '';
         set $upstream_upgrade            '';
         set $upstream_connection         '';
@@ -137,6 +138,7 @@ server {
         }
 
         proxy_http_version 1.1;
+        proxy_set_header   TE                $upstream_te;
         proxy_set_header   Host              $upstream_host;
         proxy_set_header   Upgrade           $upstream_upgrade;
         proxy_set_header   Connection        $upstream_connection;

--- a/spec/02-integration/05-proxy/03-upstream_headers_spec.lua
+++ b/spec/02-integration/05-proxy/03-upstream_headers_spec.lua
@@ -74,6 +74,97 @@ for _, strategy in helpers.each_strategy() do
       end
     end)
 
+    describe("hop-by-hop headers", function()
+      lazy_setup(start_kong {
+        database         = strategy,
+        nginx_conf       = "spec/fixtures/custom_nginx.template",
+        lua_package_path = "?/init.lua;./kong/?.lua;./spec/fixtures/?.lua",
+      })
+
+      lazy_teardown(stop_kong)
+
+      it("are removed from request", function()
+        local headers = request_headers({
+          ["Connection"]          = "X-Foo, X-Bar",
+          ["Host"]                = "headers-inspect.com",
+          ["Keep-Alive"]          = "timeout=5, max=1000",
+          ["Proxy"]               = "Remove-Me", -- See: https://httpoxy.org/
+          ["Proxy-Connection"]    = "close",
+          -- This is a response header, so we don't remove it, should we?
+          --["Proxy-Authenticate"]  = "Basic",
+          ["Proxy-Authorization"] = "Basic YWxhZGRpbjpvcGVuc2VzYW1l",
+          ["TE"]                  = "trailers, deflate;q=0.5",
+          ["Transfer-Encoding"]   = "identity",
+          -- This is a response header, so we don't remove it, should we?
+          --["Trailer"]             = "Expires",
+          ["Upgrade"]             = "example/1, foo/2",
+          ["X-Foo"]               = "Remove-Me",
+          ["X-Bar"]               = "Remove-Me",
+          ["X-Foo-Bar"]           = "Keep-Me",
+          ["Close"]               = "Keep-Me",
+        })
+
+        assert.is_nil(headers["keep-alive"])
+        assert.is_nil(headers["proxy"])
+        assert.is_nil(headers["proxy-connection"])
+        assert.is_nil(headers["proxy-authenticate"])
+        assert.is_nil(headers["proxy-authorization"])
+        assert.is_nil(headers["te"])
+        assert.is_nil(headers["trailer"])
+        assert.is_nil(headers["upgrade"])
+        assert.is_nil(headers["x-boo"])
+        assert.is_nil(headers["x-bar"])
+        assert.equal("Keep-Me", headers["x-foo-bar"])
+        assert.equal("Keep-Me", headers["close"])
+      end)
+
+      it("are removed from response", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          headers = {
+            ["Host"] = "headers-inspect.com",
+          },
+          path = "/hop-by-hop",
+        })
+
+        assert.res_status(200, res)
+
+        local headers = res.headers
+
+        assert.is_nil(headers["keep-alive"])
+        -- This needs to be cleared only on requests (https://httpoxy.org/)
+        --assert.is_nil(headers["proxy"])
+        -- This is a request header, so we don't remove it, should we?
+        --assert.is_nil(headers["proxy-connection"])
+        assert.is_nil(headers["proxy-authenticate"])
+        -- This is a request header, so we don't remove it, should we?
+        --assert.is_nil(headers["proxy-authorization"])
+        -- This is a request header, so we don't remove it, should we?
+        --assert.is_nil(headers["te"])
+        assert.is_nil(headers["trailer"])
+        assert.is_nil(headers["upgrade"])
+
+        assert.equal("chunked", headers["transfer-encoding"])
+      end)
+
+      it("keeps trailer when requested", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          headers = {
+            ["Host"] = "headers-inspect.com",
+            ["TE"]   = "trailers"
+          },
+          path = "/hop-by-hop",
+        })
+
+        assert.res_status(200, res)
+
+        local headers = res.headers
+
+        assert.equal("Expires", headers["Trailer"])
+      end)
+    end)
+
     describe("(using the default configuration values)", function()
       lazy_setup(start_kong {
         database         = strategy,

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -122,6 +122,7 @@ http {
             default_type '';
 
             set $ctx_ref                     '';
+            set $upstream_te                 '';
             set $upstream_host               '';
             set $upstream_upgrade            '';
             set $upstream_connection         '';
@@ -374,6 +375,25 @@ http {
             content_by_lua_block {
                 local mu = require "spec.fixtures.mock_upstream"
                 return mu.send_default_json_response({}, ngx.req.get_uri_args())
+            }
+        }
+
+        location = /hop-by-hop {
+            content_by_lua_block {
+                local header = ngx.header
+                header["Keep-Alive"]          = "timeout=5, max=1000"
+                header["Proxy"]               = "Remove-Me"
+                header["Proxy-Connection"]    = "close"
+                header["Proxy-Authenticate"]  = "Basic"
+                header["Proxy-Authorization"] = "Basic YWxhZGRpbjpvcGVuc2VzYW1l"
+                header["Transfer-Encoding"]   = "chunked"
+                header["Content-Length"]      = nil
+                header["TE"]                  = "trailers, deflate;q=0.5"
+                header["Trailer"]             = "Expires"
+                header["Upgrade"]             = "example/1, foo/2"
+
+                ngx.print("hello\r\n\r\nExpires: Wed, 21 Oct 2015 07:28:00 GMT\r\n\r\n")
+                ngx.exit(200)
             }
         }
 


### PR DESCRIPTION
### Summary

Removes the following request and response headers:

- `Proxy` (see: https://httpoxy.org/)
- `Proxy-Connection`
- `Proxy-Authenticate`
- `Proxy-Authorization`
- `TE`
- `Transfer-Encoding`
- `Trailer`
- `Upgrade`
    
Headers specified in the value of the Connection header are cleared as well.