### PR TITLE
fix(db) fix target cleanup and cascade-delete for Targets

### DIFF
--- a/kong/db/schema/entities/targets.lua
+++ b/kong/db/schema/entities/targets.lua
@@ -19,7 +19,7 @@ return {
   fields = {
     { id = typedefs.uuid },
     { created_at = typedefs.auto_timestamp_ms },
-    { upstream   = { type = "foreign", reference = "upstreams", required = true }, },
+    { upstream   = { type = "foreign", reference = "upstreams", required = true, on_delete = "cascade" }, },
     { target     = { type = "string", required = true, custom_validator = validate_target, }, },
     { weight     = { type = "integer", default = 100, between = { 0, 1000 }, }, },
   },

--- a/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
@@ -680,6 +680,74 @@ describe("Admin API: #" .. strategy, function()
 
           assert.response(res).has.status(204)
       end)
+
+      it("after deleting its targets (regression test for #4317)", function(content_type)
+        assert(db:truncate("upstreams"))
+        assert(db:truncate("targets"))
+
+        -- create the upstream
+        local res = assert(client:send {
+          method = "POST",
+          path = "/upstreams",
+          body = {
+            name = "my-upstream",
+            slots = 100,
+          },
+          headers = { ["Content-Type"] = "application/json" }
+        })
+
+        assert.response(res).has.status(201)
+
+        client:close()
+        client = assert(helpers.admin_client())
+
+        -- create the target
+        local res = assert(client:send {
+          method = "POST",
+          path = "/upstreams/my-upstream/targets",
+          body = {
+            target = "127.0.0.1:8000",
+          },
+          headers = { ["Content-Type"] = "application/json" }
+        })
+
+        assert.response(res).has.status(201)
+
+        client:close()
+        client = assert(helpers.admin_client())
+
+        -- delete the target
+        local res = assert(client:send {
+          method = "DELETE",
+          path = "/upstreams/my-upstream/targets/127.0.0.1:8000",
+          headers = { ["Content-Type"] = "application/json" }
+        })
+
+        assert.response(res).has.status(204)
+
+        client:close()
+        client = assert(helpers.admin_client())
+
+        -- deleting the target does not delete the upstream
+        local res = assert(client:send {
+          method = "GET",
+          path = "/upstreams/my-upstream",
+          headers = { ["Content-Type"] = "application/json" }
+        })
+
+        assert.response(res).has.status(200)
+
+        client:close()
+        client = assert(helpers.admin_client())
+
+        -- delete the upstream
+        res = assert(client:send {
+          method = "DELETE",
+          path = "/upstreams/my-upstream",
+        })
+
+        assert.response(res).has.status(204)
+      end)
     end)
 
     it("returns 405 on invalid method", function()

--- a/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
@@ -748,6 +748,50 @@ describe("Admin API: #" .. strategy, function()
 
         assert.response(res).has.status(204)
       end)
+
+      it("can delete an upstream with targets", function(content_type)
+        assert(db:truncate("upstreams"))
+        assert(db:truncate("targets"))
+
+        -- create the upstream
+        local res = assert(client:send {
+          method = "POST",
+          path = "/upstreams",
+          body = {
+            name = "my-upstream",
+            slots = 100,
+          },
+          headers = { ["Content-Type"] = "application/json" }
+        })
+
+        assert.response(res).has.status(201)
+
+        client:close()
+        client = assert(helpers.admin_client())
+
+        -- create the target
+        local res = assert(client:send {
+          method = "POST",
+          path = "/upstreams/my-upstream/targets",
+          body = {
+            target = "127.0.0.1:8000",
+          },
+          headers = { ["Content-Type"] = "application/json" }
+        })
+
+        assert.response(res).has.status(201)
+
+        client:close()
+        client = assert(helpers.admin_client())
+
+        -- delete the upstream
+        res = assert(client:send {
+          method = "DELETE",
+          path = "/upstreams/my-upstream",
+        })
+
+        assert.response(res).has.status(204)
+      end)
     end)
 
     it("returns 405 on invalid method", function()

--- a/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -93,17 +93,29 @@ describe("Admin API #" .. strategy, function()
           assert.are.equal(99, json.weight)
         end
       end)
-      it("cleans up old target entries", function()
+      it("#only cleans up old target entries", function()
         local upstream = bp.upstreams:insert { slots = 10 }
-        -- count to 12; 10 old ones, 1 active one, and then nr 12 to
-        -- trigger the cleanup
-        for i = 1, 12 do
+        -- insert elements in two targets alternately to build up a history
+        for i = 1, 11 do
           local res = assert(client:send {
             method = "POST",
             path = "/upstreams/" .. upstream.name .. "/targets/",
             body = {
-              target = "mashape.com:123",
-              weight = 99,
+              target = "mashape.com:1111",
+              weight = i,
+            },
+            headers = {
+              ["Content-Type"] = "application/json"
+            },
+          })
+          assert.response(res).has.status(201)
+
+          local res = assert(client:send {
+            method = "POST",
+            path = "/upstreams/" .. upstream.name .. "/targets/",
+            body = {
+              target = "mashape.com:2222",
+              weight = i,
             },
             headers = {
               ["Content-Type"] = "application/json"
@@ -111,10 +123,36 @@ describe("Admin API #" .. strategy, function()
           })
           assert.response(res).has.status(201)
         end
+
+        -- now insert a few more elements only in the second target, to trigger a cleanup
+        for i = 12, 13 do
+          local res = assert(client:send {
+            method = "POST",
+            path = "/upstreams/" .. upstream.name .. "/targets/",
+            body = {
+              target = "mashape.com:2222",
+              weight = i,
+            },
+            headers = {
+              ["Content-Type"] = "application/json"
+            },
+          })
+          assert.response(res).has.status(201)
+        end
+
         local history = assert(db.targets:select_by_upstream_raw({ id = upstream.id }))
-        -- there should be 2 left; 1 from the cleanup, and the final one
-        -- inserted that triggered the cleanup
-        assert.equal(2, #history)
+        -- cleanup took place
+        assert(#history <= 5)
+
+        -- the remaining entries should be the correct ones
+        -- (i.e. the target not involved in the operation that triggered the cleanup
+        -- should not be corrupted)
+        local targets = assert(db.targets:page_for_upstream({ id = upstream.id }))
+        table.sort(targets, function(a,b) return a.target < b.target end)
+        assert.same("mashape.com:1111", targets[1].target)
+        assert.same(11, targets[1].weight)
+        assert.same("mashape.com:2222", targets[2].target)
+        assert.same(13, targets[2].weight)
       end)
 
       describe("errors", function()


### PR DESCRIPTION
This fixes two problems:

1) Target cleanup was happening in the wrong order. This was not a problem for
the target being inserted (because cleanup happened before insertion), but it
would cause the other targets of the list to be corrupted in case they had a
target history themselves.

   Since cleanup happened before insertion (meaning before a weight=0 entry was
inserted upon deletion), this meant that deleting targets never truly emptied
the table -- this meant that Cassandra could not delete upstreams, because the
cascade-delete annotation was missing from the entity schema. Merely adding
`on_delete = "cascade"` to `targets.upstream` would fix the problem in #4317
illustrated by the regression test added to
spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua but would not
fix the other problem, illustrated by the test added to
spec/02-integration/04-admin_api/08-targets_routes_spec.lua.

2) We also add `on_cascade = "delete"` to the schema, which fixes the inconsistency in behavior between Postgres and Cassandra, as the former included cascade-delete in its migration already.

Fixes #4317.
