### PR TITLE
chore(ci) have travis-ci handle building / releasing Kong

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,6 +94,12 @@ jobs:
     - script: make release
       env: PACKAGE_TYPE=apk RESTY_IMAGE_BASE=alpine RESTY_IMAGE_TAG=latest KONG_PACKAGE_NAME=${PWD##*/} KONG_VERSION=${TRAVIS_TAG}
       if: tag IS present AND tag ~= 1.
+    - script: make release
+      env: PACKAGE_TYPE=rpm RESTY_IMAGE_BASE=rhel RESTY_IMAGE_TAG=6 KONG_PACKAGE_NAME=${PWD##*/} KONG_VERSION=${TRAVIS_TAG}
+      if: tag IS present AND tag ~= 1.
+    - script: make release
+      env: PACKAGE_TYPE=rpm RESTY_IMAGE_BASE=rhel RESTY_IMAGE_TAG=7 KONG_PACKAGE_NAME=${PWD##*/} KONG_VERSION=${TRAVIS_TAG}
+      if: tag IS present AND tag ~= 1.
     - stage: deploy daily build
       install: skip
       before_install: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ stages:
   - test
   - functional tests
   - Deploy daily build
+  - Release
 
 jobs:
   include:
@@ -72,8 +73,30 @@ jobs:
     - stage: functional tests
       script: make functional_tests
       if: type=cron
+    - stage: release
+      install: skip
+      before_install: skip
+      script: make release
+      env: PACKAGE_TYPE=deb RESTY_IMAGE_BASE=ubuntu RESTY_IMAGE_TAG=trusty KONG_PACKAGE_NAME=${PWD##*/} KONG_VERSION=${TRAVIS_TAG}
+      if: tag IS present AND tag ~= 1.
+    - script: make release
+      env: PACKAGE_TYPE=deb RESTY_IMAGE_BASE=ubuntu RESTY_IMAGE_TAG=xenial KONG_PACKAGE_NAME=${PWD##*/} KONG_VERSION=${TRAVIS_TAG}
+      if: tag IS present AND tag ~= 1.
+    - script: make release
+      env: PACKAGE_TYPE=deb RESTY_IMAGE_BASE=ubuntu RESTY_IMAGE_TAG=bionic KONG_PACKAGE_NAME=${PWD##*/} KONG_VERSION=${TRAVIS_TAG}
+      if: tag IS present AND tag ~= 1.
+    - script: make release
+      env: PACKAGE_TYPE=rpm RESTY_IMAGE_BASE=centos RESTY_IMAGE_TAG=6 KONG_PACKAGE_NAME=${PWD##*/} KONG_VERSION=${TRAVIS_TAG}
+      if: tag IS present AND tag ~= 1.
+    - script: make release
+      env: PACKAGE_TYPE=rpm RESTY_IMAGE_BASE=centos RESTY_IMAGE_TAG=7 KONG_PACKAGE_NAME=${PWD##*/} KONG_VERSION=${TRAVIS_TAG}
+      if: tag IS present AND tag ~= 1.
+    - script: make release
+      env: PACKAGE_TYPE=apk RESTY_IMAGE_BASE=alpine RESTY_IMAGE_TAG=latest KONG_PACKAGE_NAME=${PWD##*/} KONG_VERSION=${TRAVIS_TAG}
+      if: tag IS present AND tag ~= 1.
     - stage: deploy daily build
       install: skip
+      before_install: skip
       script: make nightly-release
       env: PACKAGE_TYPE=deb RESTY_IMAGE_BASE=ubuntu RESTY_IMAGE_TAG=trusty KONG_PACKAGE_NAME=${PWD##*/} KONG_VERSION=`date +%Y-%m-%d` REPOSITORY_NAME=${PWD##*/}-nightly REPOSITORY_OS_NAME=$TRAVIS_BRANCH
       if: type=cron


### PR DESCRIPTION
This PR includes a name change to our bintray repository which I'll try to capture 

kong-community-edition-deb kong-deb
kong-community-edition-rpm becomes kong-rpm
kong-community-edition-alpine-tar becomes kong-alpine-tar

Todo:
- [x] Copy assets from kong-community-edition-deb to kong-deb
- [x] Copy assets from kong-community-edition-rpm to kong-rpm
- [x] Copy assets from kong-community-edition-alpine-tar to kong-alpine-tar
- [x] Copy assets from kong-community-edition-aws to kong-aws
- [x] Merge the kong-build-tools / bintray rpm directory fix ( https://github.com/Kong/kong-build-tools/pull/31 )
- [x] Clear RHEL subscription manager in kong-build-tools ( https://github.com/Kong/kong-build-tools/pull/32 )

After merging:
- [ ] Update git://docker-kong to use the new repositories ( https://github.com/Kong/docker-kong/pull/237 )
- [ ] Update docs to reference the new location ( https://github.com/Kong/docs.konghq.com/pull/1182 )
- [ ] Update kong-dist-cloudformation ( https://github.com/Kong/kong-dist-cloudformation/pull/51 )
- [ ] Update download statistics lambda for new repositories
- [ ] Other unknown updates (Puppet, Terraform, Ansible)
- [ ] Ensure the 1.2 changelog notes the breaking change or package and repository naming changes

The following screenshots demo successful releases of a mock 1.0.4

![kong-ci](https://user-images.githubusercontent.com/697188/53050597-b5ed1480-3467-11e9-9243-c3e3907220b7.PNG)
![kong-deb](https://user-images.githubusercontent.com/697188/53050598-b5ed1480-3467-11e9-80e0-6623fef4c75c.PNG)
![kong-rpm](https://user-images.githubusercontent.com/697188/53050599-b5ed1480-3467-11e9-9761-42e5b26d38df.PNG)
![kong-alpine](https://user-images.githubusercontent.com/697188/53050596-b5ed1480-3467-11e9-9e69-95259978b142.PNG)