### PR TITLE
feat(core) add support for stream ipv6 routes

### DIFF
--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -87,7 +87,7 @@ return {
                   elements = {
                     type = "record",
                     fields = {
-                      { ip = typedefs.cidr },
+                      { ip = typedefs.ip_or_cidr },
                       { port = typedefs.port },
                     },
                     entity_checks = {
@@ -99,7 +99,7 @@ return {
                        elements = {
                          type = "record",
                          fields = {
-                           { ip = typedefs.cidr },
+                           { ip = typedefs.ip_or_cidr },
                            { port = typedefs.port },
                          },
                          entity_checks = {

--- a/kong/plugins/ip-restriction/schema.lua
+++ b/kong/plugins/ip-restriction/schema.lua
@@ -9,8 +9,8 @@ return {
     { config = {
         type = "record",
         fields = {
-          { whitelist = { type = "array", elements = typedefs.cidr, }, },
-          { blacklist = { type = "array", elements = typedefs.cidr, }, },
+          { whitelist = { type = "array", elements = typedefs.cidr_v4, }, },
+          { blacklist = { type = "array", elements = typedefs.cidr_v4, }, },
         },
       },
     },
@@ -20,3 +20,4 @@ return {
     { at_least_one_of = { "config.whitelist", "config.blacklist" }, },
   },
 }
+

--- a/spec/03-plugins/17-ip-restriction/01-schema_spec.lua
+++ b/spec/03-plugins/17-ip-restriction/01-schema_spec.lua
@@ -58,5 +58,42 @@ describe("Plugin: ip-restriction (schema)", function()
       }
       assert.same(expected, err["@entity"])
     end)
+    it("should not accept invalid cidr ranges", function()
+      local ok, err = v({ whitelist = { "0.0.0.0/a", "0.0.0.0/-1", "0.0.0.0/33" } }, schema_def)
+      assert.falsy(ok)
+      assert.same({
+        whitelist = {
+          "invalid cidr range: Invalid prefix: /a",
+          "invalid cidr range: Invalid prefix: /-1",
+          "invalid cidr range: Invalid prefix: /33",
+        }
+      }, err.config)
+
+    end)
+    it("should not accept invalid ipv6 cidr ranges", function()
+      local ok, err = v({ whitelist = { "::/a", "::/-1", "::/129", "::1/a", "::1/-1", "::1/129" } }, schema_def)
+      assert.falsy(ok)
+      assert.same({
+        whitelist = {
+          "invalid cidr range: Invalid prefix: /a",
+          "invalid cidr range: Invalid prefix: /-1",
+          "invalid cidr range: Invalid prefix: /129",
+          "invalid cidr range: Invalid prefix: /a",
+          "invalid cidr range: Invalid prefix: /-1",
+          "invalid cidr range: Invalid prefix: /129",
+        }
+      }, err.config)
+    end)
+    it("should not accept valid ipv6 cidr ranges", function()
+      local ok, err = v({ whitelist = { "::/0",  "::/1", "::/128"  } }, schema_def)
+      assert.falsy(ok)
+      assert.same({
+        whitelist = {
+          "invalid cidr range: Invalid IP",
+          "invalid cidr range: Invalid IP",
+          "invalid cidr range: Invalid prefix: /128",
+        }
+      }, err.config)
+    end)
   end)
 end)


### PR DESCRIPTION
### Summary

The validator used ipv4 only `resty.iputils` which caused errors in validating ipv4 addresses in stream routes with destinations and sources. The router itself used `resty.mediador.proxy` which does
have ipv6 support.

The `ip-restriction` plugin is still left to use `resty.iputils` partly because it is very efficient implementation (faster than mediador). We may need in future look for nice optimized way to verify ips and cidr blocks, and match cidr blocks. We also have some tools in `kong.tools.utils` which are a bit restrictive in their implementation.