### PR TITLE
feat(db) implement foreign entity unique / endpoint key field resolver

### DIFF
--- a/kong/api/endpoints.lua
+++ b/kong/api/endpoints.lua
@@ -20,18 +20,19 @@ local split        = utils.split
 
 -- error codes http status codes
 local ERRORS_HTTP_CODES = {
-  [Errors.codes.INVALID_PRIMARY_KEY]   = 400,
-  [Errors.codes.SCHEMA_VIOLATION]      = 400,
-  [Errors.codes.PRIMARY_KEY_VIOLATION] = 400,
-  [Errors.codes.FOREIGN_KEY_VIOLATION] = 400,
-  [Errors.codes.UNIQUE_VIOLATION]      = 409,
-  [Errors.codes.NOT_FOUND]             = 404,
-  [Errors.codes.INVALID_OFFSET]        = 400,
-  [Errors.codes.DATABASE_ERROR]        = 500,
-  [Errors.codes.INVALID_SIZE]          = 400,
-  [Errors.codes.INVALID_UNIQUE]        = 400,
-  [Errors.codes.INVALID_OPTIONS]       = 400,
-  [Errors.codes.OPERATION_UNSUPPORTED] = 405,
+  [Errors.codes.INVALID_PRIMARY_KEY]     = 400,
+  [Errors.codes.SCHEMA_VIOLATION]        = 400,
+  [Errors.codes.PRIMARY_KEY_VIOLATION]   = 400,
+  [Errors.codes.FOREIGN_KEY_VIOLATION]   = 400,
+  [Errors.codes.UNIQUE_VIOLATION]        = 409,
+  [Errors.codes.NOT_FOUND]               = 404,
+  [Errors.codes.INVALID_OFFSET]          = 400,
+  [Errors.codes.DATABASE_ERROR]          = 500,
+  [Errors.codes.INVALID_SIZE]            = 400,
+  [Errors.codes.INVALID_UNIQUE]          = 400,
+  [Errors.codes.INVALID_OPTIONS]         = 400,
+  [Errors.codes.OPERATION_UNSUPPORTED]   = 405,
+  [Errors.codes.FOREIGN_KEYS_UNRESOLVED] = 400,
 }
 
 
@@ -187,11 +188,7 @@ local function query_entity(context, self, db, schema, method)
     args = self.args.uri
   end
 
-  local opts, err = extract_options(args, schema, context)
-  if err then
-    return nil, err, db[schema.name].errors:invalid_size(err)
-  end
-
+  local opts = extract_options(args, schema, context)
   local dao = db[schema.name]
 
   if is_insert then
@@ -290,7 +287,6 @@ local function get_collection_endpoint(schema, foreign_schema, foreign_field_nam
     end
 
     local data, _, err_t, offset = page_collection(self, db, schema, method)
-
     if err_t then
       return handle_error(err_t)
     end

--- a/kong/api/init.lua
+++ b/kong/api/init.lua
@@ -75,6 +75,7 @@ local function new_db_on_error(self)
   or err.code == Errors.codes.INVALID_PRIMARY_KEY
   or err.code == Errors.codes.FOREIGN_KEY_VIOLATION
   or err.code == Errors.codes.INVALID_OFFSET
+  or err.code == Errors.codes.FOREIGN_KEYS_UNRESOLVED
   then
     return kong.response.exit(400, err)
   end

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -791,7 +791,14 @@ function Schema:validate_field(field, value)
     if field.schema and field.schema.validate_primary_key then
       local ok, errs = field.schema:validate_primary_key(value, true)
       if not ok then
-        return nil, errs
+        if type(value) == "table" and field.schema.validate then
+          local foreign_ok, foreign_errs = field.schema:validate(value, false)
+          if not foreign_ok then
+            return nil, foreign_errs
+          end
+        end
+
+        return ok, errs
       end
     end
 

--- a/spec/02-integration/04-admin_api/09-routes_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/09-routes_routes_spec.lua
@@ -139,6 +139,39 @@ for _, strategy in helpers.each_strategy() do
           end
         end)
 
+        it_content_types("creates a complex route by referencing a service by name", function(content_type, name)
+          return function()
+            if content_type == "multipart/form-data" then
+              -- the client doesn't play well with this
+              return
+            end
+
+            local s = bp.named_services:insert()
+            local res = client:post("/routes", {
+              body    = {
+                protocols = { "http" },
+                methods   = { "GET", "POST", "PATCH" },
+                hosts     = { "foo.api.com", "bar.api.com" },
+                paths     = { "/foo", "/bar" },
+                service   = { name = s.name },
+              },
+              headers = { ["Content-Type"] = content_type }
+            })
+
+            -- TODO: For some reason the body which arrives to the server is
+            -- incorrectly parsed on this test: self.params.methods is the string
+            -- "PATCH" instead of an array, for example. I could not find the
+            -- cause
+
+            local body = assert.res_status(201, res)
+            local json = cjson.decode(body)
+            assert.same({ "foo.api.com", "bar.api.com" }, json.hosts)
+            assert.same({ "/foo","/bar" }, json.paths)
+            assert.same({ "GET", "POST", "PATCH" }, json.methods)
+            assert.same(s.id, json.service.id)
+          end
+        end)
+
         describe("errors", function()
           it("handles malformed JSON body", function()
             local res = client:post("/routes", {
@@ -192,6 +225,96 @@ for _, strategy in helpers.each_strategy() do
                           "(protocols.1: expected one of: http, https, tcp, tls)",
                 fields = {
                   protocols = { "expected one of: http, https, tcp, tls" },
+                }
+              }, cjson.decode(body))
+
+              -- Invalid foreign entity
+              res = client:post("/routes", {
+                body = {
+                  methods   = { "GET" },
+                  protocols = { "foo" },
+                  service = { name = [[\o/]] },
+                },
+                headers = { ["Content-Type"] = content_type }
+              })
+              body = assert.res_status(400, res)
+              assert.same({
+                code    = Errors.codes.SCHEMA_VIOLATION,
+                name    = "schema violation",
+                message = "2 schema violations " ..
+                  "(protocols.1: expected one of: http, https, tcp, tls; " ..
+                  [[service.name: invalid value '\o/': it must only contain alphanumeric and '., -, _, ~' characters)]],
+                fields = {
+                  protocols = { "expected one of: http, https, tcp, tls" },
+                  service = {
+                    name = [[invalid value '\o/': it must only contain alphanumeric and '., -, _, ~' characters]]
+                  }
+                }
+              }, cjson.decode(body))
+
+              -- Invalid foreign entity reference
+              res = client:post("/routes", {
+                body = {
+                  methods   = { "GET" },
+                  service = { name = "non-existing" },
+                },
+                headers = { ["Content-Type"] = content_type }
+              })
+              body = assert.res_status(400, res)
+              assert.same({
+                code    = Errors.codes.FOREIGN_KEYS_UNRESOLVED,
+                name    = "foreign keys unresolved",
+                message = [[foreign key unresolved (service.name: the foreign key cannot be resolved with ]] ..
+                          [['{name="non-existing"}' for an existing 'services' entity)]],
+                fields = {
+                  service = {
+                    name = [[the foreign key cannot be resolved with '{name="non-existing"}' ]] ..
+                           [[for an existing 'services' entity]]
+                  }
+                }
+              }, cjson.decode(body))
+
+              local service_name = content_type == "application/json" and cjson.null or ""
+              -- Invalid foreign entity reference
+              res = client:post("/routes", {
+                body = {
+                  methods = { "GET" },
+                  service = { name = service_name },
+                },
+                headers = { ["Content-Type"] = content_type }
+              })
+              body = assert.res_status(400, res)
+              assert.same({
+                code    = Errors.codes.SCHEMA_VIOLATION,
+                name    = "schema violation",
+                message = "schema violation " ..
+                  "(service.id: missing primary key)",
+                fields = {
+                  service = {
+                    id = "missing primary key"
+                  }
+                }
+              }, cjson.decode(body))
+
+
+              -- Foreign entity cannot be resolved
+              res = client:post("/routes", {
+                body = {
+                  methods   = { "GET" },
+                  service = { protocol = "http" },
+                },
+                headers = { ["Content-Type"] = content_type }
+              })
+              body = assert.res_status(400, res)
+              assert.same({
+                code    = Errors.codes.SCHEMA_VIOLATION,
+                name    = "schema violation",
+                message = "schema violation " ..
+                          "(service.id: missing primary key)",
+                fields = {
+                  service = {
+                    id = "missing primary key"
+                  }
                 }
               }, cjson.decode(body))
             end


### PR DESCRIPTION
### Summary

This work was originally done by @hbagdi (thank you):
https://github.com/hbagdi/kong/commit/d627649ee3aad55d7a0c94a09e627f356ea3994e

This commit makes it possible to use names (`unique fields` or `endpoint key`) in `insert`/`update`/`upsert`/`update_by_*`/`upsert_by_*`
kong db calls and admin api calls, e.g.:

```
http :8001/routes paths=/ service.name=test -f
```

(previously you needed to use `service.id=<uuid>`)