### PR TITLE
fix(router) ignore failures on unexisting services when building router

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -107,7 +107,12 @@ do
       else
         local service, err = db.services:select(service_pk)
         if not service then
-          log(WARN, "could not find service for route (" .. route.id .. "): " .. err or 'Not found service')
+          
+          if err == nil then
+            err = 'Not found service'
+          end
+
+          log(WARN, "could not find service for route (" .. route.id .. "): " .. err)
         else
           r = get_route_for_service(service, route)
           if r then


### PR DESCRIPTION
### Summary

The router is being built querying all routes and iterating over each of them by searching the related service.
This is a potentially inconsistency as a service may be deleted during the process, the router won't be built and a 500 error will be returned.
Instead this error is ignored and the router is being built with the rest of routes. After all if a route is not found it will fail with a 404 (that it normal) or the request will be progressed as the service deletion was different.
The request won't be lost in most of the cases.

Moreover: when this process happend (without this fix) the  dao returned nil in err field and this was causing the log to fail:
```
2019/03/05 03:46:38 [error] 35#0: *40775 [kong] handler.lua:689 no router to route request (reason: /usr/local/share/lua/5.1/kong/runloop/handler.lua:89: attempt to concatenate local 'err' (a nil value)), client: 100.98.128.0, server: kong, request: "GET /my-route HTTP/1.1", host: "example.com"
```
What it's also a minor bug that is solved as well.

### Full changelog

* ignore failures when building routes and a service is deleted

