### PR TITLE
fix(api) fix type inference of map values using form-encoded

### DIFF
--- a/kong/api/arguments.lua
+++ b/kong/api/arguments.lua
@@ -207,7 +207,7 @@ local function infer_value(value, field)
   elseif field.type == "map" then
     if type(value) == "table" then
       for k, v in pairs(value) do
-        value[k] = infer_value(v, field.elements)
+        value[k] = infer_value(v, field.values)
       end
     end
 

--- a/spec/01-unit/01-db/03-arguments_spec.lua
+++ b/spec/01-unit/01-db/03-arguments_spec.lua
@@ -50,8 +50,8 @@ describe("arguments.infer_value", function()
   end)
 
   it("infers maps", function()
-    assert.same({ x = "1" }, infer_value({ x = "1" }, { type = "map", elements = { type = "string" } }))
-    assert.same({ x = 1 },   infer_value({ x = "1" }, { type = "map", elements = { type = "number" } }))
+    assert.same({ x = "1" }, infer_value({ x = "1" }, { type = "map", keys = { type = "string" }, values = { type = "string" } }))
+    assert.same({ x = 1 },   infer_value({ x = "1" }, { type = "map", keys = { type = "string" }, values = { type = "number" } }))
   end)
 
   it("infers records", function()


### PR DESCRIPTION
Corrects the type inference of values of map types when using form-encoded inputs. In particular, this was affecting the input of configuration for response-ratelimiting.

Includes a fix to the relevant unit test.

Fixes #4344.