### PR TITLE
chore(ci) do not run setup_env.sh during daily builds deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,10 +42,8 @@ env:
     - KONG_TEST_DATABASE=cassandra CASSANDRA=3.9 TEST_SUITE=plugins
     - TEST_SUITE=pdk
 
-before_install:
-  - source .ci/setup_env.sh
-
 install:
+  - source .ci/setup_env.sh
   - make dev
 
 cache:


### PR DESCRIPTION
We don't need to perform a local compilation of OpenResty etc in the Travis environment when making daily builds because those already happen inside `kong-build-tools`. This should shave a few minutes off from each of the daily build runs.