### PR TITLE
hotfix(dbless) fixes and tests for healthchecks using declarative config

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -433,18 +433,18 @@ return {
         local operation = data.operation
         local target = data.entity
         -- => to worker_events node handler
-        local ok, err = worker_events.post("balancer", "targets", {
+        local _, err = worker_events.post("balancer", "targets", {
           operation = data.operation,
           entity = data.entity,
         })
-        if not ok then
+        if err then
           log(ERR, "failed broadcasting target ",
               operation, " to workers: ", err)
         end
         -- => to cluster_events handler
         local key = fmt("%s:%s", operation, target.upstream.id)
-        ok, err = cluster_events:broadcast("balancer:targets", key)
-        if not ok then
+        _, err = cluster_events:broadcast("balancer:targets", key)
+        if err then
           log(ERR, "failed broadcasting target ", operation, " to cluster: ", err)
         end
       end, "crud", "targets")
@@ -464,13 +464,13 @@ return {
       cluster_events:subscribe("balancer:targets", function(data)
         local operation, key = unpack(utils.split(data, ":"))
         -- => to worker_events node handler
-        local ok, err = worker_events.post("balancer", "targets", {
+        local _, err = worker_events.post("balancer", "targets", {
           operation = operation,
           entity = {
             upstream = { id = key },
           }
         })
-        if not ok then
+        if err then
           log(ERR, "failed broadcasting target ", operation, " to workers: ", err)
         end
       end)
@@ -482,8 +482,8 @@ return {
         local ip, port, health, id, name = data:match(pattern)
         port = tonumber(port)
         local upstream = { id = id, name = name }
-        local ok, err = balancer.post_health(upstream, ip, port, health == "1")
-        if not ok then
+        local _, err = balancer.post_health(upstream, ip, port, health == "1")
+        if err then
           log(ERR, "failed posting health of ", name, " to workers: ", err)
         end
       end)
@@ -497,17 +497,17 @@ return {
         local operation = data.operation
         local upstream = data.entity
         -- => to worker_events node handler
-        local ok, err = worker_events.post("balancer", "upstreams", {
+        local _, err = worker_events.post("balancer", "upstreams", {
           operation = data.operation,
           entity = data.entity,
         })
-        if not ok then
+        if err then
           log(ERR, "failed broadcasting upstream ",
               operation, " to workers: ", err)
         end
         -- => to cluster_events handler
         local key = fmt("%s:%s:%s", operation, upstream.id, upstream.name)
-        ok, err = cluster_events:broadcast("balancer:upstreams", key)
+        local ok, err = cluster_events:broadcast("balancer:upstreams", key)
         if not ok then
           log(ERR, "failed broadcasting upstream ", operation, " to cluster: ", err)
         end
@@ -527,14 +527,14 @@ return {
       cluster_events:subscribe("balancer:upstreams", function(data)
         local operation, id, name = unpack(utils.split(data, ":"))
         -- => to worker_events node handler
-        local ok, err = worker_events.post("balancer", "upstreams", {
+        local _, err = worker_events.post("balancer", "upstreams", {
           operation = operation,
           entity = {
             id = id,
             name = name,
           }
         })
-        if not ok then
+        if err then
           log(ERR, "failed broadcasting upstream ", operation, " to workers: ", err)
         end
       end)

--- a/spec/02-integration/05-proxy/10-balancer_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer_spec.lua
@@ -1,6 +1,7 @@
 -- these tests only apply to the ring-balancer
 -- for dns-record balancing see the `dns_spec` files
 
+local declarative = require "kong.db.declarative"
 local helpers = require "spec.helpers"
 local utils = require "kong.tools.utils"
 local cjson = require "cjson"
@@ -76,8 +77,8 @@ local function direct_request(host, port, path)
 end
 
 
-local function post_target_endpoint(upstream_name, host, port, endpoint)
-  local url = "/upstreams/" .. upstream_name
+local function post_target_endpoint(upstream_id, host, port, endpoint)
+  local url = "/upstreams/" .. upstream_id
                             .. "/targets/"
                             .. utils.format_host(host, port)
                             .. "/" .. endpoint
@@ -107,12 +108,11 @@ local function http_server(host, port, counts, test_log, protocol)
 
   -- This is a "hard limit" for the execution of tests that launch
   -- the custom http_server
-  local hard_timeout = 300
-  local expire = ngx.now() + hard_timeout
+  local hard_timeout = ngx.now() + 300
 
   local threads = require "llthreads2.ex"
   local thread = threads.new({
-    function(expire, host, port, counts, TEST_LOG, protocol) -- luacheck: ignore
+    function(hard_timeout, host, port, counts, TEST_LOG, protocol) -- luacheck: ignore
       local TIMEOUT = -1 -- luacheck: ignore
 
       local function test_log(...) -- luacheck: ignore
@@ -185,8 +185,10 @@ local function http_server(host, port, counts, test_log, protocol)
             server.loop = function(self)
               while not self.quit do
                 local cskt, err = sskt:accept()
-                if socket.gettime() > expire then
-                  cskt:close()
+                if socket.gettime() > hard_timeout then
+                  if cskt then
+                    cskt:close()
+                  end
                   break
                 elseif err ~= "timeout" then
                   if err then
@@ -299,7 +301,7 @@ local function http_server(host, port, counts, test_log, protocol)
       test_log("stopped")
       return ok_responses, fail_responses, n_checks
     end
-  }, expire, host, port, counts, test_log or TEST_LOG, protocol)
+  }, hard_timeout, host, port, counts, test_log or TEST_LOG, protocol)
 
   local server = thread:start()
 
@@ -308,7 +310,7 @@ local function http_server(host, port, counts, test_log, protocol)
     if err then
       ngx.sleep(0.01) -- poll-wait
     end
-  until (ngx.now() > expire) or not err
+  until (ngx.now() > hard_timeout) or not err
 
   server.done = function(self)
     direct_request(host, port, "/shutdown")
@@ -365,9 +367,6 @@ local get_router_version
 local add_target
 local add_api
 local patch_api
-local delete_api
-local add_plugin
-local delete_plugin
 local gen_port
 do
   local gen_sym
@@ -398,32 +397,34 @@ do
     return res.status, res_body
   end
 
-  add_upstream = function(data, name)
-    local upstream_name = name or gen_sym("upstream")
+  add_upstream = function(bp, data)
+    local upstream_id = utils.uuid()
+    local upstream_name = gen_sym("upstream")
     if TEST_LOG then
-      print("ADDING UPSTREAM ", upstream_name)
+      print("ADDING UPSTREAM ", upstream_id)
     end
     local req = utils.deep_copy(data) or {}
     req.name = req.name or upstream_name
     req.slots = req.slots or SLOTS
-    assert.same(201, api_send("POST", "/upstreams", req))
-    return upstream_name
+    req.id = upstream_id
+    bp.upstreams:insert(req)
+    return upstream_name, upstream_id
   end
 
-  patch_upstream = function(upstream_name, data)
-    assert.same(200, api_send("PATCH", "/upstreams/" .. upstream_name, data))
+  patch_upstream = function(upstream_id, data)
+    assert.same(200, api_send("PATCH", "/upstreams/" .. upstream_id, data))
   end
 
-  get_upstream = function(upstream_name, forced_port)
-    local path = "/upstreams/" .. upstream_name
+  get_upstream = function(upstream_id, forced_port)
+    local path = "/upstreams/" .. upstream_id
     local status, body = api_send("GET", path, nil, forced_port)
     if status == 200 then
       return body
     end
   end
 
-  get_upstream_health = function(upstream_name, forced_port)
-    local path = "/upstreams/" .. upstream_name .."/health"
+  get_upstream_health = function(upstream_id, forced_port)
+    local path = "/upstreams/" .. upstream_id .."/health"
     local status, body = api_send("GET", path, nil, forced_port)
     if status == 200 then
       return body
@@ -446,79 +447,52 @@ do
     end
   end
 
-  add_target = function(upstream_name, host, port, data)
+  add_target = function(bp, upstream_id, host, port, data)
     port = port or gen_port()
     local req = utils.deep_copy(data) or {}
     req.target = req.target or utils.format_host(host, port)
     req.weight = req.weight or 10
-    local path = "/upstreams/" .. upstream_name .. "/targets"
-    assert.same(201, api_send("POST", path, req))
+    req.upstream = { id = upstream_id }
+    bp.targets:insert(req)
     return port
   end
 
-  add_api = function(upstream_name, read_timeout, write_timeout, connect_timeout, retries, protocol)
-    local service_name = gen_sym("service")
+  add_api = function(bp, upstream_name, read_timeout, write_timeout, connect_timeout, retries, protocol)
+    local route_id = utils.uuid()
+    local service_id = utils.uuid()
     local route_host = gen_sym("host")
-    assert.same(201, api_send("POST", "/services", {
-      name = service_name,
+    bp.services:insert({
+      id = service_id,
       url = (protocol or "http") .. "://" .. upstream_name .. ":" .. (protocol == "tcp" and 9100 or 80),
       read_timeout = read_timeout,
       write_timeout = write_timeout,
       connect_timeout = connect_timeout,
       retries = retries,
       protocol = protocol,
-    }))
-    local path = "/services/" .. service_name .. "/routes"
-    local status, res = api_send("POST", path, {
+    })
+    bp.routes:insert({
+      id = route_id,
+      service = { id = service_id },
       protocols = { protocol or "http" },
       hosts = protocol ~= "tcp" and { route_host } or nil,
       destinations = (protocol == "tcp") and {{ port = 9100 }} or nil,
     })
-    assert.same(201, status)
-    return route_host, service_name, res.id
+    return route_host, service_id, route_id
   end
 
-  patch_api = function(service_name, new_upstream, read_timeout)
-    assert.same(200, api_send("PATCH", "/services/" .. service_name, {
+  patch_api = function(bp, service_id, new_upstream, read_timeout)
+    bp.services:update(service_id, {
       url = new_upstream,
       read_timeout = read_timeout,
-    }))
-  end
-
-  add_plugin = function(service_name, body)
-    local path = "/services/" .. service_name .. "/plugins"
-    local status, plugin = assert(api_send("POST", path, body))
-    assert.same(status, 201)
-    return plugin.id
-  end
-
-  delete_plugin = function(service_name, plugin_id)
-    local path = "/plugins/" .. plugin_id
-    assert.same(204, api_send("DELETE", path, {}))
-  end
-
-  delete_api = function(service_name, route_id)
-    local path = "/routes/" .. route_id
-    assert.same(204, api_send("DELETE", path, {}))
-    path = "/services/" .. service_name
-    assert.same(204, api_send("DELETE", path, {}))
+    })
   end
 end
 
 
-local function truncate_relevant_tables(db)
-  db:truncate("services")
-  db:truncate("routes")
-  db:truncate("upstreams")
-  db:truncate("targets")
-end
-
-
-local function poll_wait_health(upstream_name, host, port, value, admin_port)
-  local hard_timeout = 300
-  local expire = ngx.now() + hard_timeout
-  while ngx.now() < expire do
-    local health = get_upstream_health(upstream_name, admin_port)
+local function poll_wait_health(upstream_id, host, port, value, admin_port)
+  local hard_timeout = ngx.now() + 10
+  while ngx.now() < hard_timeout do
+    local health = get_upstream_health(upstream_id, admin_port)
     if health then
       for _, d in ipairs(health.data) do
         if d.target == host .. ":" .. port and d.health == value then
@@ -526,18 +500,18 @@ local function poll_wait_health(upstream_name, host, port, value, admin_port)
         end
       end
     end
-    ngx.sleep(0.01) -- poll-wait
+    ngx.sleep(0.1) -- poll-wait
   end
   assert(false, "timed out waiting for " .. host .. ":" .. port .. " in " ..
-                upstream_name .. " to become " .. value)
+                upstream_id .. " to become " .. value)
 end
 
 
-local function wait_for_router_update(old_rv, localhost, proxy_port, admin_port)
+local function wait_for_router_update(bp, old_rv, localhost, proxy_port, admin_port)
   -- add dummy upstream just to rebuild router
-  local dummy_upstream_name = add_upstream()
-  local dummy_port = add_target(dummy_upstream_name, localhost)
-  local dummy_api_host = add_api(dummy_upstream_name)
+  local dummy_upstream_name, dummy_upstream_id = add_upstream(bp)
+  local dummy_port = add_target(bp, dummy_upstream_id, localhost)
+  local dummy_api_host = add_api(bp, dummy_upstream_name)
   local dummy_server = http_server(localhost, dummy_port, { 1000 })
 
   helpers.wait_until(function()
@@ -550,6 +524,40 @@ local function wait_for_router_update(old_rv, localhost, proxy_port, admin_port)
 end
 
 
+local function begin_testcase_setup(strategy, bp)
+  if strategy == "off" then
+    bp.done()
+  end
+end
+
+local function begin_testcase_setup_update(strategy, bp)
+  if strategy == "off" then
+    bp.reset_back()
+  end
+end
+
+
+local function end_testcase_setup(strategy, bp)
+  if strategy == "off" then
+    local cfg = bp.done()
+    local yaml = declarative.to_yaml_string(cfg)
+    local admin_client = helpers.admin_client()
+    local res = assert(admin_client:send {
+      method  = "POST",
+      path    = "/config",
+      body    = {
+        config = yaml,
+      },
+      headers = {
+        ["Content-Type"] = "multipart/form-data",
+      }
+    })
+    assert.res_status(201, res)
+    admin_client:close()
+  end
+end
+
+
 local localhosts = {
   ipv4 = "127.0.0.1",
   ipv6 = "[0000:0000:0000:0000:0000:0000:0000:0001]",
@@ -557,28 +565,37 @@ local localhosts = {
 }
 
 
-for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
+for _, strategy in helpers.each_strategy() do
+
+  local bp
 
   describe("Ring-balancer #" .. strategy, function()
 
     lazy_setup(function()
-      local _, db = helpers.get_db_utils(strategy, {})
-
-      truncate_relevant_tables(db)
-      helpers.start_kong({
+      bp = helpers.get_db_utils(strategy, {
+        "services",
+        "routes",
+        "upstreams",
+        "targets",
+      })
+      if strategy ~= "off" then
+        bp = require("spec.fixtures.admin_api")
+      end
+      assert(helpers.start_kong({
         database   = strategy,
         nginx_conf = "spec/fixtures/custom_nginx.template",
         lua_ssl_trusted_certificate = "../spec/fixtures/kong_spec.crt",
         stream_listen = "0.0.0.0:9100",
         db_update_frequency = 0.1,
-      })
+        plugins = "bundled,fail-once-auth",
+      }))
     end)
 
     lazy_teardown(function()
-      helpers.stop_kong()
+      helpers.stop_kong(nil, true)
     end)
 
-    describe("#healthchecks (#cluster)", function()
+    describe("#healthchecks (#cluster #db)", function()
 
       -- second node ports are Kong test ports + 10
       local proxy_port_1 = 9000
@@ -600,7 +617,7 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
       end)
 
       lazy_teardown(function()
-        helpers.stop_kong("servroot2", true, true)
+        helpers.stop_kong("servroot2", true)
       end)
 
       for mode, localhost in pairs(localhosts) do
@@ -609,13 +626,13 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
 
           it("does not perform health checks when disabled (#3304)", function()
 
+            begin_testcase_setup(strategy, bp)
             local old_rv = get_router_version(admin_port_2)
-
-            local upstream_name = add_upstream()
-            local port = add_target(upstream_name, localhost)
-            local api_host = add_api(upstream_name)
-
-            wait_for_router_update(old_rv, localhost, proxy_port_2, admin_port_2)
+            local upstream_name, upstream_id = add_upstream(bp)
+            local port = add_target(bp, upstream_id, localhost)
+            local api_host = add_api(bp, upstream_name)
+            wait_for_router_update(bp, old_rv, localhost, proxy_port_2, admin_port_2)
+            end_testcase_setup(strategy, bp)
 
             -- server responds, then fails, then responds again
             local server = http_server(localhost, port, { 20, 20, 20 })
@@ -644,25 +661,25 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
 
           it("propagates posted health info #flaky", function()
 
+            begin_testcase_setup(strategy, bp)
             local old_rv = get_router_version(admin_port_2)
-
-            local upstream_name = add_upstream({
+            local _, upstream_id = add_upstream(bp, {
               healthchecks = healthchecks_config {}
             })
-            local port = add_target(upstream_name, localhost)
-
+            local port = add_target(bp, upstream_id, localhost)
             wait_for_router_update(old_rv, localhost, proxy_port_2, admin_port_2)
+            end_testcase_setup(strategy, bp)
 
-            local health1 = get_upstream_health(upstream_name, admin_port_1)
-            local health2 = get_upstream_health(upstream_name, admin_port_2)
+            local health1 = get_upstream_health(upstream_id, admin_port_1)
+            local health2 = get_upstream_health(upstream_id, admin_port_2)
 
             assert.same("HEALTHY", health1.data[1].health)
             assert.same("HEALTHY", health2.data[1].health)
 
-            post_target_endpoint(upstream_name, localhost, port, "unhealthy")
+            post_target_endpoint(upstream_id, localhost, port, "unhealthy")
 
-            poll_wait_health(upstream_name, localhost, port, "UNHEALTHY", admin_port_1)
-            poll_wait_health(upstream_name, localhost, port, "UNHEALTHY", admin_port_2)
+            poll_wait_health(upstream_id, localhost, port, "UNHEALTHY", admin_port_1)
+            poll_wait_health(upstream_id, localhost, port, "UNHEALTHY", admin_port_2)
 
           end)
 
@@ -678,9 +695,11 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
 
           -- Regression test for a missing invalidation in 0.12rc1
           it("created via the API are functional", function()
-            local upstream_name = add_upstream()
-            local target_port = add_target(upstream_name, localhost)
-            local api_host = add_api(upstream_name)
+            begin_testcase_setup(strategy, bp)
+            local upstream_name, upstream_id = add_upstream(bp)
+            local target_port = add_target(bp, upstream_id, localhost)
+            local api_host = add_api(bp, upstream_name)
+            end_testcase_setup(strategy, bp)
 
             local server = http_server(localhost, target_port, { 1 })
 
@@ -694,10 +713,15 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
             assert.same(0, server_fails)
           end)
 
-          it("can have their config partially updated", function()
-            local upstream_name = add_upstream()
+          -- #db == disabled for database=off, because it tests
+          -- for a PATCH operation
+          it("#db can have their config partially updated", function()
+            begin_testcase_setup(strategy, bp)
+            local _, upstream_id = add_upstream(bp)
+            end_testcase_setup(strategy, bp)
 
-            patch_upstream(upstream_name, {
+            begin_testcase_setup_update(strategy, bp)
+            patch_upstream(upstream_id, {
               healthchecks = {
                 active = {
                   http_path = "/status",
@@ -712,6 +736,7 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
                 }
               }
             })
+            end_testcase_setup(strategy, bp)
 
             local updated = {
               active = {
@@ -750,21 +775,27 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
               }
             }
 
-            local upstream_data = get_upstream(upstream_name)
+            local upstream_data = get_upstream(upstream_id)
             assert.same(updated, upstream_data.healthchecks)
           end)
 
-          it("can be renamed without producing stale cache", function()
+          -- #db == disabled for database=off, because it tests
+          -- for a PATCH operation.
+          -- TODO produce an equivalent test when upstreams are preserved
+          -- (not rebuilt) across declarative config updates.
+          it("#db can be renamed without producing stale cache", function()
             -- create two upstreams, each with a target pointing to a server
+            begin_testcase_setup(strategy, bp)
             local upstreams = {}
             for i = 1, 2 do
               upstreams[i] = {}
-              upstreams[i].name = add_upstream({
+              upstreams[i].name = add_upstream(bp, {
                 healthchecks = healthchecks_config {}
               })
-              upstreams[i].port = add_target(upstreams[i].name, localhost)
-              upstreams[i].api_host = add_api(upstreams[i].name)
+              upstreams[i].port = add_target(bp, upstreams[i].name, localhost)
+              upstreams[i].api_host = add_api(bp, upstreams[i].name)
             end
+            end_testcase_setup(strategy, bp)
 
             -- start two servers
             local server1 = http_server(localhost, upstreams[1].port, { 1 })
@@ -802,10 +833,16 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
             assert.same({1, 0}, { server2_oks, server2_fails })
           end)
 
-          it("do not leave a stale healthchecker when renamed", function()
+          -- #db == disabled for database=off, because it tests
+          -- for a PATCH operation.
+          -- TODO produce an equivalent test when upstreams are preserved
+          -- (not rebuilt) across declarative config updates.
+          it("#db do not leave a stale healthchecker when renamed", function()
+
+            begin_testcase_setup(strategy, bp)
 
             -- create an upstream
-            local upstream_name = add_upstream({
+            local upstream_name, upstream_id = add_upstream(bp, {
               healthchecks = healthchecks_config {
                 active = {
                   http_path = "/status",
@@ -820,12 +857,14 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
                 }
               }
             })
-            local port = add_target(upstream_name, localhost)
-            local _, api_name = add_api(upstream_name)
+            local port = add_target(bp, upstream_id, localhost)
+            local _, service_id = add_api(bp, upstream_name)
+
+            end_testcase_setup(strategy, bp)
 
             -- rename upstream
-            local new_name = upstream_name .. "_new"
-            patch_upstream(upstream_name, {
+            local new_name = upstream_id .. "_new"
+            patch_upstream(upstream_id, {
               name = new_name
             })
 
@@ -852,7 +891,9 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
             -- give time for healthchecker to (not!) run
             ngx.sleep(HEALTHCHECK_INTERVAL * 3)
 
-            patch_api(api_name, "http://" .. new_name)
+            begin_testcase_setup_update(strategy, bp)
+            patch_api(bp, service_id, "http://" .. new_name)
+            end_testcase_setup(strategy, bp)
 
             -- collect results
             local _, server1_oks, server1_fails, hcs = server1:done()
@@ -864,10 +905,14 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
 
         describe("#healthchecks", function()
 
+          local stream_it = (mode == "ipv6" or strategy == "off") and pending or it
+
           it("do not count Kong-generated errors as failures", function()
 
+            begin_testcase_setup(strategy, bp)
+
             -- configure healthchecks with a 1-error threshold
-            local upstream_name = add_upstream({
+            local upstream_name, upstream_id = add_upstream(bp, {
               healthchecks = healthchecks_config {
                 passive = {
                   healthy = {
@@ -882,23 +927,25 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
                 }
               }
             })
-            local port1 = add_target(upstream_name, localhost)
-            local port2 = add_target(upstream_name, localhost)
-            local api_host, api_name = add_api(upstream_name)
+            local port1 = add_target(bp, upstream_id, localhost)
+            local port2 = add_target(bp, upstream_id, localhost)
+            local api_host, service_id = add_api(bp, upstream_name)
 
             -- add a plugin
-            local plugin_id = add_plugin(api_name, {
-              name = "key-auth"
+            local plugin_id = utils.uuid()
+            bp.plugins:insert({
+              id = plugin_id,
+              service = { id = service_id },
+              name = "fail-once-auth",
             })
+
+            end_testcase_setup(strategy, bp)
 
             -- run request: fails with 401, but doesn't hit the 1-error threshold
             local oks, fails, last_status = client_requests(1, api_host)
             assert.same(0, oks)
             assert.same(1, fails)
             assert.same(401, last_status)
-
-            -- delete the plugin
-            delete_plugin(api_name, plugin_id)
 
             -- start servers, they are unaffected by the failure above
             local server1 = http_server(localhost, port1, { SLOTS })
@@ -924,8 +971,9 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
 
             for nfails = 1, 3 do
 
+              begin_testcase_setup(strategy, bp)
               -- configure healthchecks
-              local upstream_name = add_upstream({
+              local upstream_name, upstream_id = add_upstream(bp, {
                 healthchecks = healthchecks_config {
                   passive = {
                     unhealthy = {
@@ -934,9 +982,10 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
                   }
                 }
               })
-              local port1 = add_target(upstream_name, localhost)
-              local port2 = add_target(upstream_name, localhost)
-              local api_host = add_api(upstream_name)
+              local port1 = add_target(bp, upstream_id, localhost)
+              local port2 = add_target(bp, upstream_id, localhost)
+              local api_host = add_api(bp, upstream_name)
+              end_testcase_setup(strategy, bp)
 
               local requests = SLOTS * 2 -- go round the balancer twice
 
@@ -970,14 +1019,15 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
             end
           end)
 
-          it("#stream and http modules do not duplicate active health checks", function()
+          stream_it("#stream and http modules do not duplicate active health checks", function()
 
             local port1 = gen_port()
 
             local server1 = http_server(localhost, port1, { 1 })
 
             -- configure healthchecks
-            local upstream_name = add_upstream({
+            begin_testcase_setup(strategy, bp)
+            local _, upstream_id = add_upstream(bp, {
               healthchecks = healthchecks_config {
                 active = {
                   http_path = "/status",
@@ -992,7 +1042,8 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
                 }
               }
             })
-            add_target(upstream_name, localhost, port1)
+            add_target(bp, upstream_id, localhost, port1)
+            end_testcase_setup(strategy, bp)
 
             ngx.sleep(HEALTHCHECK_INTERVAL * 5)
 
@@ -1018,7 +1069,8 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
               local server2 = http_server(localhost, port2, { server2_oks })
 
               -- configure healthchecks
-              local upstream_name = add_upstream({
+              begin_testcase_setup(strategy, bp)
+              local upstream_name, upstream_id = add_upstream(bp, {
                 healthchecks = healthchecks_config {
                   active = {
                     http_path = "/status",
@@ -1033,9 +1085,10 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
                   }
                 }
               })
-              add_target(upstream_name, localhost, port1)
-              add_target(upstream_name, localhost, port2)
-              local api_host = add_api(upstream_name)
+              add_target(bp, upstream_id, localhost, port1)
+              add_target(bp, upstream_id, localhost, port2)
+              local api_host = add_api(bp, upstream_name)
+              end_testcase_setup(strategy, bp)
 
               -- Phase 1: server1 and server2 take requests
               local client_oks, client_fails = client_requests(server2_oks * 2, api_host)
@@ -1044,7 +1097,7 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
               direct_request(localhost, port2, "/unhealthy")
 
               -- Give time for healthchecker to detect
-              poll_wait_health(upstream_name, localhost, port2, "UNHEALTHY")
+              poll_wait_health(upstream_id, localhost, port2, "UNHEALTHY")
 
               -- Phase 3: server1 takes all requests
               do
@@ -1084,7 +1137,8 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
                 local server2 = http_server(localhost, port2, { server2_oks }, nil, protocol)
 
                 -- configure healthchecks
-                local upstream_name = add_upstream({
+                begin_testcase_setup(strategy, bp)
+                local upstream_name, upstream_id = add_upstream(bp, {
                   healthchecks = healthchecks_config {
                     active = {
                       type = protocol,
@@ -1101,9 +1155,10 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
                     }
                   }
                 })
-                add_target(upstream_name, localhost, port1)
-                add_target(upstream_name, localhost, port2)
-                local api_host = add_api(upstream_name)
+                add_target(bp, upstream_id, localhost, port1)
+                add_target(bp, upstream_id, localhost, port2)
+                local api_host = add_api(bp, upstream_name)
+                end_testcase_setup(strategy, bp)
 
                 -- 1) server1 and server2 take requests
                 local oks, fails = client_requests(SLOTS, api_host)
@@ -1111,7 +1166,7 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
                 -- server2 goes unhealthy
                 direct_request(localhost, port2, "/unhealthy")
                 -- Wait until healthchecker detects
-                poll_wait_health(upstream_name, localhost, port2, "UNHEALTHY")
+                poll_wait_health(upstream_id, localhost, port2, "UNHEALTHY")
 
                 -- 2) server1 takes all requests
                 do
@@ -1123,7 +1178,7 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
                 -- server2 goes healthy again
                 direct_request(localhost, port2, "/healthy")
                 -- Give time for healthchecker to detect
-                poll_wait_health(upstream_name, localhost, port2, "HEALTHY")
+                poll_wait_health(upstream_id, localhost, port2, "HEALTHY")
 
                 -- 3) server1 and server2 take requests again
                 do
@@ -1159,7 +1214,8 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
             local server1 = http_server(localhost, port1, { requests })
             local server2 = http_server(localhost, port2, { requests })
             -- configure healthchecks
-            local upstream_name = add_upstream({
+            begin_testcase_setup(strategy, bp)
+            local upstream_name, upstream_id = add_upstream(bp, {
               healthchecks = healthchecks_config {
                 active = {
                   http_path = "/status",
@@ -1175,25 +1231,29 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
                 }
               }
             })
-            add_target(upstream_name, localhost, port1)
-            add_target(upstream_name, localhost, port2)
-            local api_host = add_api(upstream_name)
+            add_target(bp, upstream_id, localhost, port1)
+            add_target(bp, upstream_id, localhost, port2)
+            local api_host = add_api(bp, upstream_name)
+            end_testcase_setup(strategy, bp)
 
             -- server2 goes unhealthy before the first request
             direct_request(localhost, port2, "/unhealthy")
 
             -- restart Kong
-            helpers.stop_kong(nil, true, true)
-            helpers.start_kong({
+            begin_testcase_setup_update(strategy, bp)
+            helpers.restart_kong({
               database   = strategy,
               nginx_conf = "spec/fixtures/custom_nginx.template",
               lua_ssl_trusted_certificate = "../spec/fixtures/kong_spec.crt",
               db_update_frequency = 0.1,
               stream_listen = "0.0.0.0:9100",
+              plugins = "bundled,fail-once-auth",
             })
+            end_testcase_setup(strategy, bp)
+            ngx.sleep(1)
 
             -- Give time for healthchecker to detect
-            poll_wait_health(upstream_name, localhost, port2, "UNHEALTHY")
+            poll_wait_health(upstream_id, localhost, port2, "UNHEALTHY")
 
             -- server1 takes all requests
 
@@ -1218,7 +1278,8 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
 
             for nfails = 1, 3 do
               -- configure healthchecks
-              local upstream_name = add_upstream({
+              begin_testcase_setup(strategy, bp)
+              local upstream_name, upstream_id = add_upstream(bp, {
                 healthchecks = healthchecks_config {
                   passive = {
                     unhealthy = {
@@ -1227,9 +1288,10 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
                   }
                 }
               })
-              local port1 = add_target(upstream_name, localhost)
-              local port2 = add_target(upstream_name, localhost)
-              local api_host = add_api(upstream_name)
+              local port1 = add_target(bp, upstream_id, localhost)
+              local port2 = add_target(bp, upstream_id, localhost)
+              local api_host = add_api(bp, upstream_name)
+              end_testcase_setup(strategy, bp)
 
               -- setup target servers:
               -- server2 will only respond for part of the test,
@@ -1258,7 +1320,7 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
               end
 
               -- manually bring it back using the endpoint
-              post_target_endpoint(upstream_name, localhost, port2, "healthy")
+              post_target_endpoint(upstream_id, localhost, port2, "healthy")
 
               -- 3) server1 and server2 take requests again
               do
@@ -1285,7 +1347,8 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
           it("perform passive health checks -- manual shutdown", function()
 
             -- configure healthchecks
-            local upstream_name = add_upstream({
+            begin_testcase_setup(strategy, bp)
+            local upstream_name, upstream_id = add_upstream(bp, {
               healthchecks = healthchecks_config {
                 passive = {
                   unhealthy = {
@@ -1294,9 +1357,10 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
                 }
               }
             })
-            local port1 = add_target(upstream_name, localhost)
-            local port2 = add_target(upstream_name, localhost)
-            local api_host = add_api(upstream_name)
+            local port1 = add_target(bp, upstream_id, localhost)
+            local port2 = add_target(bp, upstream_id, localhost)
+            local api_host = add_api(bp, upstream_name)
+            end_testcase_setup(strategy, bp)
 
             -- setup target servers:
             -- server2 will only respond for part of the test,
@@ -1310,7 +1374,7 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
             local oks, fails = client_requests(SLOTS, api_host)
 
             -- manually bring it down using the endpoint
-            post_target_endpoint(upstream_name, localhost, port2, "unhealthy")
+            post_target_endpoint(upstream_id, localhost, port2, "unhealthy")
 
             -- 2) server1 takes all requests
             do
@@ -1320,7 +1384,7 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
             end
 
             -- manually bring it back using the endpoint
-            post_target_endpoint(upstream_name, localhost, port2, "healthy")
+            post_target_endpoint(upstream_id, localhost, port2, "healthy")
 
             -- 3) server1 and server2 take requests again
             do
@@ -1347,7 +1411,8 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
           it("perform passive health checks -- connection #timeouts", function()
 
             -- configure healthchecks
-            local upstream_name = add_upstream({
+            begin_testcase_setup(strategy, bp)
+            local upstream_name, upstream_id = add_upstream(bp, {
               healthchecks = healthchecks_config {
                 passive = {
                   unhealthy = {
@@ -1356,9 +1421,10 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
                 }
               }
             })
-            local port1 = add_target(upstream_name, localhost)
-            local port2 = add_target(upstream_name, localhost)
-            local api_host = add_api(upstream_name, 50, 50)
+            local port1 = add_target(bp, upstream_id, localhost)
+            local port2 = add_target(bp, upstream_id, localhost)
+            local api_host = add_api(bp, upstream_name, 50, 50)
+            end_testcase_setup(strategy, bp)
 
             -- setup target servers:
             -- server2 will only respond for half of the test
@@ -1400,11 +1466,11 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
             assert.are.equal(0, fails)
           end)
 
-          local stream_it = (mode == "ipv6") and pending or it
           stream_it("perform passive health checks -- #stream connection failure", function()
 
             -- configure healthchecks
-            local upstream_name = add_upstream({
+            begin_testcase_setup(strategy, bp)
+            local upstream_name, upstream_id = add_upstream(bp, {
               healthchecks = healthchecks_config {
                 passive = {
                   unhealthy = {
@@ -1413,11 +1479,14 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
                 }
               }
             })
-            local port1 = add_target(upstream_name, localhost)
-            local port2 = add_target(upstream_name, localhost)
-            local _, service_name, route_id = add_api(upstream_name, 50, 50, nil, nil, "tcp")
+            local port1 = add_target(bp, upstream_id, localhost)
+            local port2 = add_target(bp, upstream_id, localhost)
+            local _, service_id, route_id = add_api(bp, upstream_name, 50, 50, nil, nil, "tcp")
+            end_testcase_setup(strategy, bp)
+
             finally(function()
-              delete_api(service_name, route_id)
+              bp.routes:remove({ id = route_id })
+              bp.services:remove({ id = service_id })
             end)
 
             -- setup target servers:
@@ -1465,10 +1534,15 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
             assert.are.equal(0, fails)
           end)
 
-          it("perform passive health checks -- send #timeouts", function()
+          -- #db == disabled for database=off, because healthcheckers
+          -- are currently reset when a new configuration is loaded
+          -- TODO enable this test when upstreams are preserved (not rebuild)
+          -- across a declarative config updates.
+          it("#db perform passive health checks -- send #timeouts", function()
 
             -- configure healthchecks
-            local upstream_name = add_upstream({
+            begin_testcase_setup(strategy, bp)
+            local upstream_name, upstream_id = add_upstream(bp, {
               healthchecks = healthchecks_config {
                 passive = {
                   unhealthy = {
@@ -1479,8 +1553,9 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
                 }
               }
             })
-            local port1 = add_target(upstream_name, localhost)
-            local api_host, api_name = add_api(upstream_name, 10, nil, nil, 0)
+            local port1 = add_target(bp, upstream_id, localhost)
+            local api_host, service_id = add_api(bp, upstream_name, 10, nil, nil, 0)
+            end_testcase_setup(strategy, bp)
 
             local server1 = http_server(localhost, port1, {
               TIMEOUT,
@@ -1493,9 +1568,11 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
             assert.same(1, oks1)
             assert.same(0, fails1)
 
-            patch_api(api_name, nil, 60000)
+            begin_testcase_setup_update(strategy, bp)
+            patch_api(bp, service_id, nil, 60000)
+            local port2 = add_target(bp, upstream_id, localhost)
+            end_testcase_setup(strategy, bp)
 
-            local port2 = add_target(upstream_name, localhost)
             local server2 = http_server(localhost, port2, {
               10,
             })
@@ -1506,7 +1583,6 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
             local _, oks2, fails2 = server2:done()
             assert.same(10, oks2)
             assert.same(0, fails2)
-
           end)
 
         end)
@@ -1517,10 +1593,12 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
 
             it("over multiple targets", function()
 
-              local upstream_name = add_upstream()
-              local port1 = add_target(upstream_name, localhost)
-              local port2 = add_target(upstream_name, localhost)
-              local api_host = add_api(upstream_name)
+              begin_testcase_setup(strategy, bp)
+              local upstream_name, upstream_id = add_upstream(bp)
+              local port1 = add_target(bp, upstream_id, localhost)
+              local port2 = add_target(bp, upstream_id, localhost)
+              local api_host = add_api(bp, upstream_name)
+              end_testcase_setup(strategy, bp)
 
               local requests = SLOTS * 2 -- go round the balancer twice
 
@@ -1543,10 +1621,12 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
 
             it("adding a target", function()
 
-              local upstream_name = add_upstream()
-              local port1 = add_target(upstream_name, localhost, nil, { weight = 10 })
-              local port2 = add_target(upstream_name, localhost, nil, { weight = 10 })
-              local api_host = add_api(upstream_name)
+              begin_testcase_setup(strategy, bp)
+              local upstream_name, upstream_id = add_upstream(bp)
+              local port1 = add_target(bp, upstream_id, localhost, nil, { weight = 10 })
+              local port2 = add_target(bp, upstream_id, localhost, nil, { weight = 10 })
+              local api_host = add_api(bp, upstream_name)
+              end_testcase_setup(strategy, bp)
 
               local requests = SLOTS * 2 -- go round the balancer twice
 
@@ -1568,7 +1648,9 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
 
               -- add a new target 3
               -- shift proportions from 50/50 to 40/40/20
-              local port3 = add_target(upstream_name, localhost, nil, { weight = 5 })
+              begin_testcase_setup_update(strategy, bp)
+              local port3 = add_target(bp, upstream_id, localhost, nil, { weight = 5 })
+              end_testcase_setup(strategy, bp)
 
               -- now go and hit the same balancer again
               -----------------------------------------
@@ -1597,10 +1679,12 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
             it("removing a target", function()
               local requests = SLOTS * 2 -- go round the balancer twice
 
-              local upstream_name = add_upstream()
-              local port1 = add_target(upstream_name, localhost)
-              local port2 = add_target(upstream_name, localhost)
-              local api_host = add_api(upstream_name)
+              begin_testcase_setup(strategy, bp)
+              local upstream_name, upstream_id = add_upstream(bp)
+              local port1 = add_target(bp, upstream_id, localhost)
+              local port2 = add_target(bp, upstream_id, localhost)
+              local api_host = add_api(bp, upstream_name)
+              end_testcase_setup(strategy, bp)
 
               -- setup target servers
               local server1 = http_server(localhost, port1, { requests / 2 })
@@ -1619,9 +1703,11 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
               assert.are.equal(requests / 2, count2)
 
               -- modify weight for target 2, set to 0
-              add_target(upstream_name, localhost, port2, {
+              begin_testcase_setup_update(strategy, bp)
+              add_target(bp, upstream_id, localhost, port2, {
                 weight = 0, -- disable this target
               })
+              end_testcase_setup(strategy, bp)
 
               -- now go and hit the same balancer again
               -----------------------------------------
@@ -1642,10 +1728,12 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
             it("modifying target weight", function()
               local requests = SLOTS * 2 -- go round the balancer twice
 
-              local upstream_name = add_upstream()
-              local port1 = add_target(upstream_name, localhost)
-              local port2 = add_target(upstream_name, localhost)
-              local api_host = add_api(upstream_name)
+              begin_testcase_setup(strategy, bp)
+              local upstream_name, upstream_id = add_upstream(bp)
+              local port1 = add_target(bp, upstream_id, localhost)
+              local port2 = add_target(bp, upstream_id, localhost)
+              local api_host = add_api(bp, upstream_name)
+              end_testcase_setup(strategy, bp)
 
               -- setup target servers
               local server1 = http_server(localhost, port1, { requests / 2 })
@@ -1664,9 +1752,11 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
               assert.are.equal(requests / 2, count2)
 
               -- modify weight for target 2
-              add_target(upstream_name, localhost, port2, {
+              begin_testcase_setup_update(strategy, bp)
+              add_target(bp, upstream_id, localhost, port2, {
                 weight = 15,   -- shift proportions from 50/50 to 40/60
               })
+              end_testcase_setup(strategy, bp)
 
               -- now go and hit the same balancer again
               -----------------------------------------
@@ -1691,11 +1781,12 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
             it("failure due to targets all 0 weight", function()
               local requests = SLOTS * 2 -- go round the balancer twice
 
-              local upstream_name = add_upstream()
-
-              local port1 = add_target(upstream_name, localhost)
-              local port2 = add_target(upstream_name, localhost)
-              local api_host = add_api(upstream_name)
+              begin_testcase_setup(strategy, bp)
+              local upstream_name, upstream_id = add_upstream(bp)
+              local port1 = add_target(bp, upstream_id, localhost)
+              local port2 = add_target(bp, upstream_id, localhost)
+              local api_host = add_api(bp, upstream_name)
+              end_testcase_setup(strategy, bp)
 
               -- setup target servers
               local server1 = http_server(localhost, port1, { requests / 2 })
@@ -1714,8 +1805,10 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
               assert.are.equal(requests / 2, count2)
 
               -- modify weight for both targets, set to 0
-              add_target(upstream_name, localhost, port1, { weight = 0 })
-              add_target(upstream_name, localhost, port2, { weight = 0 })
+              begin_testcase_setup_update(strategy, bp)
+              add_target(bp, upstream_id, localhost, port1, { weight = 0 })
+              add_target(bp, upstream_id, localhost, port2, { weight = 0 })
+              end_testcase_setup(strategy, bp)
 
               -- now go and hit the same balancer again
               -----------------------------------------
@@ -1733,13 +1826,15 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
               it("hashing on header", function()
                 local requests = SLOTS * 2 -- go round the balancer twice
 
-                local upstream_name = add_upstream({
+                begin_testcase_setup(strategy, bp)
+                local upstream_name, upstream_id = add_upstream(bp, {
                   hash_on = "header",
                   hash_on_header = "hashme",
                 })
-                local port1 = add_target(upstream_name, localhost)
-                local port2 = add_target(upstream_name, localhost)
-                local api_host = add_api(upstream_name)
+                local port1 = add_target(bp, upstream_id, localhost)
+                local port2 = add_target(bp, upstream_id, localhost)
+                local api_host = add_api(bp, upstream_name)
+                end_testcase_setup(strategy, bp)
 
                 -- setup target servers
                 local server1 = http_server(localhost, port1, { requests })
@@ -1765,12 +1860,14 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
 
               describe("hashing on cookie", function()
                 it("does not reply with Set-Cookie if cookie is already set", function()
-                  local upstream_name = add_upstream({
+                  begin_testcase_setup(strategy, bp)
+                  local upstream_name, upstream_id = add_upstream(bp, {
                     hash_on = "cookie",
                     hash_on_cookie = "hashme",
                   })
-                  local port = add_target(upstream_name, localhost)
-                  local api_host = add_api(upstream_name)
+                  local port = add_target(bp, upstream_id, localhost)
+                  local api_host = add_api(bp, upstream_name)
+                  end_testcase_setup(strategy, bp)
 
                   -- setup target server
                   local server = http_server(localhost, port, { 1 })
@@ -1797,13 +1894,15 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
                 it("replies with Set-Cookie if cookie is not set", function()
                   local requests = SLOTS * 2 -- go round the balancer twice
 
-                  local upstream_name = add_upstream({
+                  begin_testcase_setup(strategy, bp)
+                  local upstream_name, upstream_id = add_upstream(bp, {
                     hash_on = "cookie",
                     hash_on_cookie = "hashme",
                   })
-                  local port1 = add_target(upstream_name, localhost)
-                  local port2 = add_target(upstream_name, localhost)
-                  local api_host = add_api(upstream_name)
+                  local port1 = add_target(bp, upstream_id, localhost)
+                  local port2 = add_target(bp, upstream_id, localhost)
+                  local api_host = add_api(bp, upstream_name)
+                  end_testcase_setup(strategy, bp)
 
                   -- setup target servers
                   local server1 = http_server(localhost, port1, { requests })
@@ -1853,8 +1952,10 @@ for _, strategy in helpers.each_strategy({"postgres", "cassandra"}) do
 
             it("failure due to no targets", function()
 
-              local upstream_name = add_upstream()
-              local api_host = add_api(upstream_name)
+              begin_testcase_setup(strategy, bp)
+              local upstream_name = add_upstream(bp)
+              local api_host = add_api(bp, upstream_name)
+              end_testcase_setup(strategy, bp)
 
               -- Go hit it with a request
               local _, _, status = client_requests(1, api_host)

--- a/spec/fixtures/admin_api.lua
+++ b/spec/fixtures/admin_api.lua
@@ -43,6 +43,9 @@ for name, _ in pairs(helpers.db.daos) do
     remove = function(_, tbl)
       return api_send("DELETE", "/" .. name .. "/" .. tbl.id)
     end,
+    update = function(_, id, tbl)
+      return api_send("PATCH", "/" .. name .. "/" .. id, tbl)
+    end,
   }
 end
 
@@ -53,6 +56,21 @@ admin_api_as_db["basicauth_credentials"] = {
   end,
   remove = function(_, tbl)
     return api_send("DELETE", "/consumers/" .. tbl.consumer.id .. "/basic-auth/" .. tbl.id)
+  end,
+  update = function(_, id, tbl)
+    return api_send("PATCH", "/consumers/" .. tbl.consumer.id .. "/basic-auth/" .. id, tbl)
+  end,
+}
+
+admin_api_as_db["targets"] = {
+  insert = function(_, tbl)
+    return api_send("POST", "/upstreams/" .. tbl.upstream.id .. "/targets", tbl)
+  end,
+  remove = function(_, tbl)
+    return api_send("DELETE", "/upstreams/" .. tbl.upstream.id .. "/targets/" .. tbl.id)
+  end,
+  update = function(_, id, tbl)
+    return api_send("PATCH", "/upstreams/" .. tbl.upstream.id .. "/targets/" .. id, tbl)
   end,
 }
 

--- a/spec/fixtures/blueprints.lua
+++ b/spec/fixtures/blueprints.lua
@@ -34,6 +34,15 @@ function Blueprint:remove(overrides, options)
 end
 
 
+function Blueprint:update(id, overrides, options)
+  local entity, err = self.dao:update(id, overrides, options)
+  if err then
+    error(err, 2)
+  end
+  return entity
+end
+
+
 function Blueprint:insert_n(n, overrides, options)
   local res = {}
   for i=1,n do

--- a/spec/fixtures/custom_plugins/kong/plugins/fail-once-auth/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/fail-once-auth/handler.lua
@@ -1,0 +1,24 @@
+-- a plugin fixture to force one authentication failure
+
+local BasePlugin = require "kong.plugins.base_plugin"
+
+local FailOnceAuth = BasePlugin:extend()
+
+FailOnceAuth.PRIORITY = 1000
+
+function FailOnceAuth:new()
+  FailOnceAuth.super.new(self, "fail-once-auth")
+end
+
+local failed = {}
+
+function FailOnceAuth:access(conf)
+  FailOnceAuth.super.access(self)
+
+  if not failed[conf.service_id] then
+    failed[conf.service_id] = true
+    return kong.response.exit(401, { message = conf.message })
+  end
+end
+
+return FailOnceAuth

--- a/spec/fixtures/custom_plugins/kong/plugins/fail-once-auth/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/fail-once-auth/schema.lua
@@ -1,0 +1,11 @@
+return {
+  name = "fail-once-auth",
+  fields = {
+    { config = {
+        type = "record",
+        fields = {
+          { message = { type = "string", default = "try again!" }, },
+        },
+    }, },
+  }
+}

--- a/spec/fixtures/dc_blueprints.lua
+++ b/spec/fixtures/dc_blueprints.lua
@@ -30,6 +30,7 @@ end
 function dc_blueprints.new(db)
   local dc_as_db = {}
 
+  local save_dc
   local dc = reset()
 
   for name, _ in pairs(db.daos) do
@@ -51,6 +52,26 @@ function dc_blueprints.new(db)
         table.insert(dc[name], remove_nulls(tbl))
         return tablex.deepcopy(tbl)
       end,
+      update = function(_, id, tbl)
+        if not dc[name] then
+          return nil, "not found"
+        end
+        tbl = tablex.deepcopy(tbl)
+        local element
+        for _, e in ipairs(dc[name]) do
+          if e.id == id then
+            element = e
+            break
+          end
+        end
+        if not element then
+          return nil, "not found"
+        end
+        for k,v in pairs(tbl) do
+          element[k] = v
+        end
+        return element
+      end
     }
   end
 
@@ -58,8 +79,13 @@ function dc_blueprints.new(db)
 
   bp.done = function()
     local ret = dc
+    save_dc = dc
     dc = reset()
     return ret
+  end
+
+  bp.reset_back = function()
+    dc = save_dc
   end
 
   return bp

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -1310,6 +1310,7 @@ local function start_kong(env, tables, preserve_prefix)
         return nil, err
       end
     end
+    env = utils.deep_copy(env)
     env.declarative_config = config_yml
   end
 


### PR DESCRIPTION
This PR contains a couple of fixes and a major update to the upstreams and healthcehcks test suite, enabling it to run on `database=off` mode as well.

The main fix issues `"crud"` worker-events when Upstreams and Targets are created via the declarative config endpoint, so that these events propagate and eventually generate and populate the internal balancer objects and healthcheckers. This fixes the behavior of upstreams and healthchecks using db-less mode.

The changes made to the `10-balancer_spec.lua` test suite to make it run on both database and db-less mode are described in more detail in its own commit message.