### PR TITLE
fix(*) quick fix lua_pack as it modifies standard lua string library

### DIFF
--- a/kong/plugins/ldap-auth/asn1.lua
+++ b/kong/plugins/ldap-auth/asn1.lua
@@ -1,22 +1,31 @@
-require "lua_pack"
+local bpack, bunpack
+do
+  local string_pack = string.pack
+  local string_unpack = string.unpack
+  require "lua_pack"
+  bpack = string.pack
+  bunpack = string.unpack
+  -- luacheck: globals string.unpack
+  string.unpack = string_unpack
+  -- luacheck: globals string.pack
+  string.pack = string_pack
+end
 
 
 local setmetatable = setmetatable
 local tonumber = tonumber
-local bunpack = string.unpack
 local reverse = string.reverse
 local ipairs = ipairs
 local concat = table.concat
 local insert = table.insert
 local pairs = pairs
-local bpack = string.pack
 local math = math
 local type = type
 local char = string.char
 local bit = bit
 
 
-local _M = {}
+local _M = { bpack = bpack, bunpack = bunpack }
 
 
 _M.BERCLASS = {

--- a/kong/plugins/ldap-auth/ldap.lua
+++ b/kong/plugins/ldap-auth/ldap.lua
@@ -1,7 +1,7 @@
 local asn1 = require "kong.plugins.ldap-auth.asn1"
 
 
-local bunpack = string.unpack
+local bunpack = asn1.bunpack
 local fmt = string.format
 
 


### PR DESCRIPTION
### Summary

Lua 5.3 comes with `string.pack` and `string.unpack` so there are libraries that try to see if they are in place, like @daurnimator's `lua-http` library. The `lua_pack` modifies standard `string`
library, and adds `pack` and `unpack` functions to it which are incompatible with Lua 5.3 versions of them. `lua-http` on the other hand thinks it is getting the 5.3 ones, and then we see things
crashing.

Another PR with removal of `lua_pack` dependency will follow.

This is based on `next` so that I can rebase #4286 on top of `next` when this is merged.