### PR TITLE
fix(*) cassandra contact points initialization

### DIFF
--- a/kong/db/strategies/cassandra/connector.lua
+++ b/kong/db/strategies/cassandra/connector.lua
@@ -14,7 +14,77 @@ function CassandraConnector.new(kong_config)
   do
     -- Resolve contact points before instantiating cluster, since the
     -- driver does not support hostnames in the contact points list.
+
+    -- TODO: this is an ugly hack to force lua sockets on a third party library
+
+    local tcp_old = ngx.socket.tcp
+    local udp_old = ngx.socket.udp
+
+    local dns_no_sync_old = kong_config.dns_no_sync
+
+    package.loaded["socket"] = nil
+    package.loaded["kong.tools.dns"] = nil
+    package.loaded["resty.dns.client"] = nil
+    package.loaded["resty.dns.resolver"] = nil
+
+    ngx.socket.tcp = function(...)
+      local tcp = require("socket").tcp(...)
+      return setmetatable({}, {
+        __newindex = function(_, k, v)
+          tcp[k] = v
+        end,
+        __index = function(_, k)
+          if type(tcp[k]) == "function" then
+            return function(_, ...)
+              if k == "send" then
+                local value = select(1, ...)
+                if type(value) == "table" then
+                  return tcp.send(tcp, table.concat(value))
+                end
+
+                return tcp.send(tcp, ...)
+              end
+
+              return tcp[k](tcp, ...)
+            end
+          end
+
+          return tcp[k]
+        end
+      })
+    end
+
+    ngx.socket.udp = function(...)
+      local udp = require("socket").udp(...)
+      return setmetatable({}, {
+        __newindex = function(_, k, v)
+          udp[k] = v
+        end,
+        __index = function(_, k)
+          if type(udp[k]) == "function" then
+            return function(_, ...)
+              if k == "send" then
+                local value = select(1, ...)
+                if type(value) == "table" then
+                  return udp.send(udp, table.concat(value))
+                end
+
+                return udp.send(udp, ...)
+              end
+
+              return udp[k](udp, ...)
+            end
+          end
+
+          return udp[k]
+        end
+      })
+    end
+
     local dns_tools = require "kong.tools.dns"
+
+    kong_config.dns_no_sync = true
+
     local dns = dns_tools(kong_config)
 
     for i, cp in ipairs(kong_config.cassandra_contact_points) do
@@ -28,6 +98,16 @@ function CassandraConnector.new(kong_config)
         resolved_contact_points[i] = ip
       end
     end
+
+    kong_config.dns_no_sync = dns_no_sync_old
+
+    package.loaded["resty.dns.resolver"] = nil
+    package.loaded["resty.dns.client"] = nil
+    package.loaded["kong.tools.dns"] = nil
+    package.loaded["socket"] = nil
+
+    ngx.socket.udp = udp_old
+    ngx.socket.tcp = tcp_old
   end
 
   if #resolved_contact_points == 0 then


### PR DESCRIPTION
### Summary

C* doesn't initialize contact points correctly when the contact points need to be resolved with DNS. DNS on the other hand uses Nginx cosockets that cannot be used with init phase. Nginx cosockets are not fully compatible with lua sockets. This PR is a quick fix for the issue.

This is based on `next` to prevent some merge conflicts. I can rebase on master if that is needed.