### PR TITLE
feat(dao) re-introduce immutable field validator to DAO

### DIFF
--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -282,7 +282,7 @@ end
 
 
 local function check_update(self, key, entity, options, name)
-  local entity_to_update, err, read_before_write =
+  local entity_to_update, err, read_before_write, check_immutable_fields =
     self.schema:process_auto_fields(entity, "update")
   if not entity_to_update then
     local err_t = self.errors:schema_violation(err)
@@ -299,6 +299,15 @@ local function check_update(self, key, entity, options, name)
     end
     if err then
       return nil, nil, err, err_t
+    end
+
+    if rbw_entity and check_immutable_fields then
+      local ok, errors = self.schema:validate_immutable_fields(entity_to_update, rbw_entity)
+
+      if not ok then
+        local err_t = self.errors:schema_violation(errors)
+        return nil, nil, tostring(err_t), err_t
+      end
     end
 
     if rbw_entity then

--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -67,6 +67,7 @@ local field_schema = {
   { abstract = { type = "boolean" }, },
   { generate_admin_api = { type = "boolean" }, },
   { legacy = { type = "boolean" }, },
+  { immutable = { type = "boolean" }, },
 }
 
 for _, field in ipairs(validators) do

--- a/spec/01-unit/01-db/01-schema/01-schema_spec.lua
+++ b/spec/01-unit/01-db/01-schema/01-schema_spec.lua
@@ -2425,6 +2425,40 @@ describe("schema", function()
       end
     end)
 
+    it("correctly flags check_immutable_fields when immutable present in schema", function()
+      local test_schema = {
+        name = "test",
+
+        fields = {
+          { name = { type = "string",  immutable = true }, },
+        },
+      }
+      local test_entity = { name = "bob" }
+
+      local TestEntities = Schema.new(test_schema)
+      local _, _, _, check_immutable_fields =
+        TestEntities:process_auto_fields(test_entity, "update")
+
+      assert.truthy(check_immutable_fields)
+    end)
+
+    it("correctly flags check_immutable_fields when immutable absent from schema", function()
+      local test_schema = {
+        name = "test",
+
+        fields = {
+          { name = { type = "string" }, },
+        },
+      }
+      local test_entity = { name = "bob" }
+
+      local TestEntities = Schema.new(test_schema)
+      local _, _, _, check_immutable_fields =
+        TestEntities:process_auto_fields(test_entity, "update")
+
+      assert.falsy(check_immutable_fields)
+    end)
+
     describe("in subschemas", function()
       it("a specialized field can set a default", function()
         local Test = Schema.new({
@@ -2509,6 +2543,169 @@ describe("schema", function()
 
       assert.equals(values.config.foo, expected_values.config.foo)
       assert.equals(values.config.bar, expected_values.config.bar)
+    end)
+  end)
+
+  describe("validate_immutable_fields", function()
+    it("returns ok when immutable unset in schema fields", function()
+      local test_schema = {
+        name = "test",
+
+        fields = {
+          { name = { type = "string" }, },
+        },
+      }
+      local entity_to_update = { name = "test1" }
+      local db_entity = { name = "test2" }
+
+      local TestEntities = Schema.new(test_schema)
+      local ok, _ = TestEntities:validate_immutable_fields(entity_to_update, db_entity)
+
+      assert.truthy(ok)
+    end)
+
+    it("returns errors when immutable set incoming field being updated", function()
+      local test_schema = {
+        name = "test",
+
+        fields = {
+          { name = { type = "string", immutable = true }, },
+          { address = { type = "string", immutable = true }, },
+          { email = { type = "string" }, },
+        },
+      }
+      local entity_to_update = { name = "test1", address = "a", email = "a@thing.com" }
+      local db_entity = { name = "test2", address = "b", email = "b@thing.com" }
+
+      local TestEntities = Schema.new(test_schema)
+      local ok, errors = TestEntities:validate_immutable_fields(entity_to_update, db_entity)
+
+      assert.falsy(ok)
+      assert.equals(errors.name, 'immutable field cannot be updated')
+      assert.equals(errors.address, 'immutable field cannot be updated')
+      assert.falsy(errors.email)
+    end)
+
+    it("returns ok when immutable set incoming field being updated and value is same", function()
+      local test_schema = {
+        name = "test",
+
+        fields = {
+          { name = { type = "string", immutable = true }, },
+        },
+      }
+      local entity_to_update = { name = "test1" }
+      local db_entity = { name = "test1" }
+
+      local TestEntities = Schema.new(test_schema)
+      local ok, _ = TestEntities:validate_immutable_fields(entity_to_update, db_entity)
+
+      assert.truthy(ok)
+    end)
+
+    it("can assess if set type immutable fields are similar", function()
+      local test_schema = {
+        name = "test",
+
+        fields = {
+          { table = { type = "set", immutable = true }, },
+        },
+      }
+
+      local entity_to_update = { table = { dog = "hello", cat = { bat = "hello", }, }, }
+      local db_entity = { table = { dog = "hello", cat = { bat = "hello", }, }, }
+      local TestEntities = Schema.new(test_schema)
+      local ok, _ = TestEntities:validate_immutable_fields(entity_to_update, db_entity)
+
+      assert.truthy(ok)
+    end)
+
+    it("can assess if foriegn type immutable fields are similar", function()
+      local test_schema = {
+        name = "test",
+
+        fields = {
+          { entity = { type = "foriegn", immutable = true }, },
+        },
+      }
+
+      local entity_to_update = { entity = { id = '1' }, }
+      local db_entity = { entity = { id = '1' }, }
+      local TestEntities = Schema.new(test_schema)
+      local ok, _ = TestEntities:validate_immutable_fields(entity_to_update, db_entity)
+
+      assert.truthy(ok)
+    end)
+
+    it("can assess if array type immutable fields are similar", function()
+      local test_schema = {
+        name = "test",
+
+        fields = {
+          { list = { type = "array", immutable = true }, },
+        },
+      }
+
+      local entity_to_update = { 'dog', 'bat', 'cat', }
+      local db_entity = { 'bat', 'cat', 'dog', }
+      local TestEntities = Schema.new(test_schema)
+      local ok, _ = TestEntities:validate_immutable_fields(entity_to_update, db_entity)
+
+      assert.truthy(ok)
+    end)
+
+    it("can assess if set type immutable fields are not similar", function()
+      local test_schema = {
+        name = "test",
+
+        fields = {
+          { table = { type = "set", immutable = true }, },
+        },
+      }
+
+      local entity_to_update = { table = { dog = "hello", cat = { bat = "hello", }, }, }
+      local db_entity = { table = { dog = "hello", cat = { bat = "goodbye", }, }, }
+      local TestEntities = Schema.new(test_schema)
+      local ok, err = TestEntities:validate_immutable_fields(entity_to_update, db_entity)
+
+      assert.falsy(ok)
+      assert.equals(err.table, 'immutable field cannot be updated')
+    end)
+
+    it("can assess if foriegn type immutable fields are not similar", function()
+      local test_schema = {
+        name = "test",
+
+        fields = {
+          { entity = { type = "foriegn", immutable = true }, },
+        },
+      }
+
+      local entity_to_update = { entity = { id = '1' }, }
+      local db_entity = { entity = { id = '2' }, }
+      local TestEntities = Schema.new(test_schema)
+      local ok, err = TestEntities:validate_immutable_fields(entity_to_update, db_entity)
+
+      assert.falsy(ok)
+      assert.equals(err.entity, 'immutable field cannot be updated')
+    end)
+
+    it("can assess if array type immutable fields are not similar", function()
+      local test_schema = {
+        name = "test",
+
+        fields = {
+          { list = { type = "array", immutable = true }, },
+        },
+      }
+
+      local entity_to_update = { list = { 'dog', 'bat', 'cat', }, }
+      local db_entity = { list = { 'bat', 'cat', 'rat', }, }
+      local TestEntities = Schema.new(test_schema)
+      local ok, err = TestEntities:validate_immutable_fields(entity_to_update, db_entity)
+
+      assert.falsy(ok)
+      assert.equals(err.list, 'immutable field cannot be updated')
     end)
   end)
 end)


### PR DESCRIPTION
### Summary
This PR re-introduces the `immutable` field validator to the DAO, allowing Kong to prevent certain fields from being updated. 

### Full changelog
* **schema/init.lua** Introduced `validate_immutable_fields` schema method
* **schema/init.lua** Expanded checks in `process_auto_fields` to include searching each field for `immutable` attribute
* **dao/init.lua** Integrated new functionality into `check_update`
* **spec/01-unit/01-db/04-dao.lua** Added Unit Tests
