### PR TITLE
chore(ci) add functional tests to Kong CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ cache:
 stages:
   - lint and unit
   - test
+  - functional tests
   - Deploy daily build
 
 jobs:
@@ -72,6 +73,9 @@ jobs:
         - KONG_DATABASE=none
     - stage: test
       script: .ci/run_tests.sh
+    - stage: functional tests
+      script: make functional_tests
+      if: type=cron
     - stage: deploy daily build
       install: skip
       script: make nightly-release

--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,15 @@ setup-release:
 	then git pull; \
 	else git clone https://github.com/Kong/kong-build-tools.git; fi
 	cd kong-build-tools; \
-	git reset --hard $$KONG_BUILD_TOOLS;
-	cd kong-build-tools; \
+	git fetch; \
+	git reset --hard origin/$(KONG_BUILD_TOOLS); \
 	make setup_tests
+
+functional_tests: setup-release
+	cd kong-build-tools; \
+	export KONG_SOURCE_LOCATION=`pwd`/../ && \
+	make package-kong && \
+	make test
 
 nightly-release: setup-release
 	sed -i -e '/return string\.format/,/\"\")/c\return "$(KONG_VERSION)\"' kong/meta.lua && \


### PR DESCRIPTION
Utilize the git://kong-build-tools repository to run the Kong functional test suite against any branch builds that are set to build via cron