### PR TITLE
Release: 1.1.0rc2

### DIFF
--- a/kong-1.1.0rc2-0.rockspec
+++ b/kong-1.1.0rc2-0.rockspec
@@ -1,9 +1,9 @@
 package = "kong"
-version = "1.1.0rc1-0"
+version = "1.1.0rc2-0"
 supported_platforms = {"linux", "macosx"}
 source = {
   url = "git://github.com/Kong/kong",
-  tag = "1.1.0rc1"
+  tag = "1.1.0rc2"
 }
 description = {
   summary = "Kong is a scalable and customizable API Management Layer built on top of Nginx.",

--- a/kong/meta.lua
+++ b/kong/meta.lua
@@ -2,7 +2,7 @@ local version = setmetatable({
   major = 1,
   minor = 1,
   patch = 0,
-  suffix = "rc1",
+  suffix = "rc2",
 }, {
   __tostring = function(t)
     return string.format("%d.%d.%d%s", t.major, t.minor, t.patch,


### PR DESCRIPTION
# What's new since Kong 1.1.0rc1:

## Improvements

### Core
* **Transparent proxying** - the `service` attribute on Routes is now optional; a Route without an assigned Service will proxy transparently (#4286)

## Fixes

### Core
* Resolve hostnames in Cassandra contact points (#4378)
* Fix health checks for Targets that need two-level DNS resolution (e.g. SRV → A → IP) (#4386)
* Fix serialization of map types in the Cassandra backend (#4368)

### Admin API
* Fix Admin API inferencing of map types using form-encoded (#4368)

### PDK
* PDK version identifier was bumped to 1.1.0
* `kong.client.get_subsystem` was moved to `kong.nginx.get_subsystem` (#4358)

### DB-less / Declarative config
* fix the behavior of the `/tags` endpoint and `?tags=` query string from the Admin API when using `database=off` (#4380)
* fix initial load of the declarative config file (#4342)
* reloading the declarative config via `/config` refreshes the Upstream balancers (#4372)

## Dependencies

* Bump OpenSSL to 1.1.0b
* Bump lua-resty-dns-client to 3.0.2