### PR TITLE
chore(ci) prevent spurious test from showing up in matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,8 +67,6 @@ jobs:
       - bin/busted -v -o gtest spec/01-unit
       env:
         - KONG_DATABASE=none
-    - stage: test
-      script: .ci/run_tests.sh
     - stage: deploy daily build
       install: skip
       script: make nightly-release


### PR DESCRIPTION
Our test matrix has been showing a duplicate entry for `KONG_TEST_DATABASE=postgres TEST_SUITE=integration` at the end of
the list.

I contacted the support staff at Travis CI and this was the way [they suggested](https://github.com/ssabrii/kong/blob/master/.travis.yml) to fix the problem.
