### PR TITLE
fix(schema) adjustments for legacy schema auto-converter

### DIFF
--- a/kong/db/dao/plugins.lua
+++ b/kong/db/dao/plugins.lua
@@ -181,6 +181,14 @@ local function convert_legacy_schema(name, old_schema)
     if new_fdata.type == "array" then
       new_fdata.elements = elements
     end
+
+    if (new_fdata.type == "map" and new_fdata.keys == nil)
+       or (new_fdata.type == "record" and new_fdata.fields == nil) then
+      new_fdata.type = "map"
+      new_fdata.keys = { type = "string" }
+      new_fdata.values = { type = "string" }
+    end
+
     if new_fdata.type == nil then
       new_fdata.type = "string"
     end

--- a/spec/01-unit/01-db/01-schema/01-schema_spec.lua
+++ b/spec/01-unit/01-db/01-schema/01-schema_spec.lua
@@ -486,15 +486,6 @@ describe("schema", function()
       assert.falsy(Test:validate({ f = "foo" }))
     end)
 
-    it("requires an array schema to have `elements`", function()
-      local Test = Schema.new({
-        fields = {
-          { f = { type = "array" } }
-        }
-      })
-      assert.falsy(Test:validate({ f = {} }))
-    end)
-
     it("validates array elements", function()
       local Test = Schema.new({
         fields = {
@@ -539,15 +530,6 @@ describe("schema", function()
       assert.falsy(Test:validate({ f = "foo" }))
     end)
 
-    it("requires an set schema to have `elements`", function()
-      local Test = Schema.new({
-        fields = {
-          { f = { type = "set" } }
-        }
-      })
-      assert.falsy(Test:validate({ f = {} }))
-    end)
-
     it("validates set elements", function()
       local Test = Schema.new({
         fields = {
@@ -588,33 +570,6 @@ describe("schema", function()
       })
       assert.truthy(Test:validate({ f = {} }))
       assert.falsy(Test:validate({ f = "foo" }))
-    end)
-
-    it("fails with a map without `keys` and `values`", function()
-      local Test = Schema.new({
-        fields = {
-          { f = { type = "map" } }
-        }
-      })
-      assert.falsy(Test:validate({ f = {} }))
-    end)
-
-    it("fails with a map without `values`", function()
-      local Test = Schema.new({
-        fields = {
-          { f = { type = "map", keys = { type = "string" } } }
-        }
-      })
-      assert.falsy(Test:validate({ f = {} }))
-    end)
-
-    it("fails with a map without `keys`", function()
-      local Test = Schema.new({
-        fields = {
-          { f = { type = "map", values = { type = "string" } } }
-        }
-      })
-      assert.falsy(Test:validate({ f = {} }))
     end)
 
     it("accepts a map with `keys` and `values`", function()
@@ -669,13 +624,7 @@ describe("schema", function()
       assert.falsy(Test:validate({ f = "foo" }))
     end)
 
-    it("requires a record to have `fields`", function()
-      local Test = Schema.new({
-        fields = {
-          { f = { type = "record" } }
-        }
-      })
-      assert.falsy(Test:validate({ f = {} }))
+    it("accepts a record with empty `fields`", function()
       local Test = Schema.new({
         fields = {
           {

--- a/spec/01-unit/01-db/01-schema/02-metaschema_spec.lua
+++ b/spec/01-unit/01-db/01-schema/02-metaschema_spec.lua
@@ -15,6 +15,71 @@ describe("metaschema", function()
     assert.falsy(MetaSchema:validate(s))
   end)
 
+  it("requires an array schema to have `elements`", function()
+    local s = {
+      name = "bad",
+      primary_key = { "f" },
+      fields = {
+        { f = { type = "array" } }
+      }
+    }
+    local ok, err = MetaSchema:validate(s)
+    assert.falsy(ok)
+    assert.match("field of type 'array' must declare 'elements'", err.f)
+  end)
+
+  it("requires an set schema to have `elements`", function()
+    local s = {
+      name = "bad",
+      primary_key = { "f" },
+      fields = {
+        { f = { type = "set" } }
+      }
+    }
+    local ok, err = MetaSchema:validate(s)
+    assert.falsy(ok)
+    assert.match("field of type 'set' must declare 'elements'", err.f)
+  end)
+
+  it("requires a map schema to have `keys`", function()
+    local s = {
+      name = "bad",
+      primary_key = { "f" },
+      fields = {
+        { f = { type = "map", values = { type = "string" } } }
+      }
+    }
+    local ok, err = MetaSchema:validate(s)
+    assert.falsy(ok)
+    assert.match("field of type 'map' must declare 'keys'", err.f)
+  end)
+
+  it("requires a map schema to have `values`", function()
+    local s = {
+      name = "bad",
+      primary_key = { "f" },
+      fields = {
+        { f = { type = "map", keys = { type = "string" } } }
+      }
+    }
+    local ok, err = MetaSchema:validate(s)
+    assert.falsy(ok)
+    assert.match("field of type 'map' must declare 'values'", err.f)
+  end)
+
+  it("requires a record schema to have `fields`", function()
+    local s = {
+      name = "bad",
+      primary_key = { "f" },
+      fields = {
+        { f = { type = "record" } }
+      }
+    }
+    local ok, err = MetaSchema:validate(s)
+    assert.falsy(ok)
+    assert.match("field of type 'record' must declare 'fields'", err.f)
+  end)
+
   it("fields cannot be empty", function()
     local s = {
       name = "bad",

--- a/spec/fixtures/custom_plugins/kong/plugins/legacy-plugin-bad/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/legacy-plugin-bad/handler.lua
@@ -1,0 +1,2 @@
+return function() end
+

--- a/spec/fixtures/custom_plugins/kong/plugins/legacy-plugin-bad/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/legacy-plugin-bad/schema.lua
@@ -1,0 +1,21 @@
+-- regression test from #4392
+
+return {
+  no_consumer = true,
+  fields = {
+    foo = {
+      -- an underspecified table with no 'schema' will default
+      -- to a map of string to string
+      type = "table",
+      required = false,
+      -- this default will not match that default
+      default = {
+        foo = 123,
+        bar = "bla",
+      }
+    }
+  },
+  self_check = function()
+    return true
+  end
+}

--- a/spec/fixtures/custom_plugins/kong/plugins/legacy-plugin-good/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/legacy-plugin-good/handler.lua
@@ -1,0 +1,15 @@
+local BasePlugin = require "kong.plugins.base_plugin"
+
+
+local LegacyPluginGoodHandler = BasePlugin:extend()
+
+
+LegacyPluginGoodHandler.PRIORITY = 1000
+
+
+function LegacyPluginGoodHandler:new()
+  LegacyPluginGoodHandler.super.new(self, "legacy-plugin-good")
+end
+
+
+return LegacyPluginGoodHandler

--- a/spec/fixtures/custom_plugins/kong/plugins/legacy-plugin-good/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/legacy-plugin-good/schema.lua
@@ -1,0 +1,19 @@
+return {
+  no_consumer = true,
+  fields = {
+    foo = {
+      -- an underspecified table with no 'schema' will default
+      -- to a map of string to string
+      type = "table",
+      required = false,
+      -- this default will match that
+      default = {
+        foo = "boo",
+        bar = "bla",
+      }
+    }
+  },
+  self_check = function()
+    return true
+  end
+}


### PR DESCRIPTION
When auto-converting a legacy schema from a plugin, we need to determine if something of type "table" is an array, map, set or record. When we failed to pin this down, we were producing an incomplete schema, which led to runtime crashes.

if we have a table type that wasn't further specified in any way, we now make it a map from strings to strings, which is the most generic type (apart from abusing "any", since we don't want dynamically-typed plugin schemas).

To prevent similar problems from happening again, this PR also adds a defensive measure: it runs the MetaSchema validator on the schemas generated by the auto-converter as well. This validation should never fail, because the best-effort legacy schema converter should either produce a valid schema or report failure in advance. However, in case it misbehaves, the MetaSchema validator should be able to catch that, so that an invalid schema does not slip through resulting in crashes further down in the schema library.

:warning: **Note**: This PR targets `master`, but I also have a separate [working branch](https://travis-ci.org/Kong/kong/builds/506828213) with the same fixes [targeting `next`](https://github.com/Kong/kong/tree/fix/table-heuristic), because the plugin loader has been refactored for Kong 1.1. If this is merged into `master`, the best approach is to reuse the code from that other branch for the fixups when merging `master` into `next`, instead of trying to resolve the conflicts manually.

### Issues resolved

Fixes #4392.