### PR TITLE
chore(ci) kong next daily build naming fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ else
 OPENSSL_DIR ?= /usr
 endif
 
-include .requirements
 .PHONY: install dev lint test test-integration test-plugins test-all fix-windows
 
 KONG_GMP_VERSION ?= `grep KONG_GMP_VERSION .requirements | awk -F"=" '{print $$2}'`


### PR DESCRIPTION
the inclusion of `.requirements` doesn't let us specify package names when building releases. Example of this is https://bintray.com/beta/#/kong/kong-nightly/next?tab=overview where the package is always being named for what's in the `.requirements` file and not using the ENV override