### PR TITLE
docs(cmd) add help option to cli output

### DIFF
--- a/kong/cmd/init.lua
+++ b/kong/cmd/init.lua
@@ -6,7 +6,7 @@ local pl_app = require "pl.lapp"
 local log = require "kong.cmd.utils.log"
 
 local options = [[
- -h               help
+ -h, --help       help
  --v              verbose
  --vv             debug
 ]]

--- a/kong/cmd/init.lua
+++ b/kong/cmd/init.lua
@@ -6,6 +6,7 @@ local pl_app = require "pl.lapp"
 local log = require "kong.cmd.utils.log"
 
 local options = [[
+ -h               help
  --v              verbose
  --vv             debug
 ]]


### PR DESCRIPTION
### Summary

It is not immediately obvious from the kong cli to see how you might see info about a specific command. However, you can pass `-h` and it will not give warning about command not being known:

```bash
$ kong check -h
```

Output (already a feature, this PR just adds the doc)
```
Usage: kong check <conf>

Check the validity of a given Kong configuration file.

<conf> (default /etc/kong/kong.conf) configuration file

Options:
 -h, --help       help
 --v              verbose
 --vv             debug
```