### PR TITLE
POC - [do not merge] - feat(runloop) cache prewarm for entities (configurable)

### DIFF
--- a/kong-1.1.1-0.rockspec
+++ b/kong-1.1.1-0.rockspec
@@ -121,6 +121,7 @@ build = {
 
     ["kong.runloop.handler"] = "kong/runloop/handler.lua",
     ["kong.runloop.certificate"] = "kong/runloop/certificate.lua",
+    ["kong.runloop.cache_prewarm"] = "kong/runloop/cache_prewarm.lua",
     ["kong.runloop.mesh"] = "kong/runloop/mesh.lua",
     ["kong.runloop.plugins_iterator"] = "kong/runloop/plugins_iterator.lua",
     ["kong.runloop.balancer"] = "kong/runloop/balancer.lua",

--- a/kong/cache.lua
+++ b/kong/cache.lua
@@ -11,6 +11,8 @@ local DEBUG   = ngx.DEBUG
 
 
 local SHM_CACHE = "kong_db_cache"
+
+
 --[[
 Hypothesis
 ----------
@@ -22,6 +24,81 @@ LRU size must be: (500 * 2^20) / 1024 = 512000
 Floored: 500.000 items should be a good default
 --]]
 local LRU_SIZE = 5e5
+
+-------------------------------------------------------------------------------
+-- NOTE: the following is copied from lua-resty-mlcache:                     --
+------------------------------------------------------------------------ cut --
+local cjson = require "cjson.safe"
+
+
+local fmt = string.format
+local now = ngx.now
+
+
+local TYPES_LOOKUP = {
+  number  = 1,
+  boolean = 2,
+  string  = 3,
+  table   = 4,
+}
+
+
+local marshallers = {
+  shm_value = function(str_value, value_type, at, ttl)
+      return fmt("%d:%f:%f:%s", value_type, at, ttl, str_value)
+  end,
+
+  shm_nil = function(at, ttl)
+      return fmt("0:%f:%f:", at, ttl)
+  end,
+
+  [1] = function(number) -- number
+      return tostring(number)
+  end,
+
+  [2] = function(bool)   -- boolean
+      return bool and "true" or "false"
+  end,
+
+  [3] = function(str)    -- string
+      return str
+  end,
+
+  [4] = function(t)      -- table
+      local json, err = cjson.encode(t)
+      if not json then
+          return nil, "could not encode table value: " .. err
+      end
+
+      return json
+  end,
+}
+
+
+local function marshall_for_shm(value, ttl, neg_ttl)
+  local at = now()
+
+  if value == nil then
+      return marshallers.shm_nil(at, neg_ttl), nil, true -- is_nil
+  end
+
+  -- serialize insertion time + Lua types for shm storage
+
+  local value_type = TYPES_LOOKUP[type(value)]
+
+  if not marshallers[value_type] then
+      error("cannot cache value of type " .. type(value))
+  end
+
+  local str_marshalled, err = marshallers[value_type](value)
+  if not str_marshalled then
+      return nil, "could not serialize value for lua_shared_dict insertion: "
+                  .. err
+  end
+
+  return marshallers.shm_value(str_marshalled, value_type, at, ttl)
+end
+------------------------------------------------------------------------ end --
 
 
 local _init
@@ -147,6 +224,14 @@ function _M:get_bulk(bulk, opts)
   end
 
   return res
+end
+
+
+function _M:safe_set(key, value)
+  local str_marshalled = marshall_for_shm(value, self.mlcache.ttl,
+                                                 self.mlcache.neg_ttl)
+
+  return ngx.shared[SHM_CACHE]:safe_set(SHM_CACHE .. key, str_marshalled)
 end
 
 

--- a/kong/cache.lua
+++ b/kong/cache.lua
@@ -228,8 +228,12 @@ end
 
 
 function _M:safe_set(key, value)
-  local str_marshalled = marshall_for_shm(value, self.mlcache.ttl,
-                                                 self.mlcache.neg_ttl)
+  local str_marshalled, err = marshall_for_shm(value, self.mlcache.ttl,
+                                                      self.mlcache.neg_ttl)
+
+  if err then
+    return nil, err
+  end
 
   return ngx.shared[SHM_CACHE]:safe_set(SHM_CACHE .. key, str_marshalled)
 end

--- a/kong/db/dao/plugins.lua
+++ b/kong/db/dao/plugins.lua
@@ -150,7 +150,7 @@ local function load_plugin_handler(plugin)
 end
 
 
-local function load_plugin_entity_strategy(schema, db)
+local function load_plugin_entity_strategy(plugin, schema, db)
   local Strategy = require(fmt("kong.db.strategies.%s", db.strategy))
   local strategy, err = Strategy.new(db.connector, schema, db.errors)
   if not strategy then
@@ -162,6 +162,7 @@ local function load_plugin_entity_strategy(schema, db)
   if not dao then
     return nil, err
   end
+  dao.plugin_name = plugin
   db.daos[schema.name] = dao
 end
 
@@ -174,7 +175,7 @@ local function plugin_entity_loader(db)
       return nil, err
     end
 
-    load_plugin_entity_strategy(schema, db)
+    load_plugin_entity_strategy(plugin, schema, db)
   end
 end
 

--- a/kong/db/schema/entities/plugins.lua
+++ b/kong/db/schema/entities/plugins.lua
@@ -7,6 +7,7 @@ return {
   primary_key = { "id" },
   cache_key = { "name", "route", "service", "consumer" },
   dao = "kong.db.dao.plugins",
+  prewarm = true,
 
   subschema_key = "name",
   subschema_error = "plugin '%s' not enabled; add it to the 'plugins' configuration property",
@@ -22,6 +23,6 @@ return {
     { run_on = typedefs.run_on },
     { protocols = typedefs.protocols },
     { enabled = { type = "boolean", default = true, }, },
-    { tags           = typedefs.tags },
+    { tags = typedefs.tags },
   },
 }

--- a/kong/db/schema/entities/services.lua
+++ b/kong/db/schema/entities/services.lua
@@ -13,6 +13,7 @@ return {
   name = "services",
   primary_key = { "id" },
   endpoint_key = "name",
+  prewarm = true,
 
   fields = {
     { id              = typedefs.uuid, },

--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -66,6 +66,7 @@ local field_schema = {
   { abstract = { type = "boolean" }, },
   { generate_admin_api = { type = "boolean" }, },
   { legacy = { type = "boolean" }, },
+  { prewarm = { type = "boolean" }, },
 }
 
 for _, field in ipairs(validators) do
@@ -383,6 +384,12 @@ local MetaSchema = Schema.new({
     },
     {
       legacy = {
+        type = "boolean",
+        nilable = true,
+      },
+    },
+    {
+      prewarm = {
         type = "boolean",
         nilable = true,
       },

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -290,13 +290,13 @@ local function load_declarative_config(kong_config, entities)
 end
 
 
-local function execute_cache_prewarm(kong_config)
+local function execute_cache_prewarm(kong_config, configured_plugins)
   if kong_config.database == "off" then
     return true
   end
 
   return concurrency.with_worker_mutex({ name = "cache_prewarm" }, function()
-    local ok, err = cache_prewarm.execute()
+    local ok, err = cache_prewarm.execute(configured_plugins)
     if not ok then
       return nil, err
     end
@@ -550,7 +550,7 @@ function Kong.init_worker()
     return
   end
 
-  ok, err = execute_cache_prewarm(kong.configuration)
+  ok, err = execute_cache_prewarm(kong.configuration, configured_plugins)
   if not ok then
     ngx_log(ngx_CRIT, "error prewarming cache: ", err)
     return

--- a/kong/runloop/cache_prewarm.lua
+++ b/kong/runloop/cache_prewarm.lua
@@ -1,0 +1,63 @@
+local cache_prewarm = {}
+
+
+local ENTITIES_TO_PREWARM = {
+  "services",
+  "plugins",
+}
+
+
+local function cache_prewarm_single_entity(entity_name)
+  local dao = kong.db[entity_name]
+  if not dao then
+    return nil, "Invalid entity name found when prewarming the cache: " .. tostring(entity_name)
+  end
+
+  ngx.log(ngx.NOTICE, "Preloading '" .. entity_name .. "' into the cache ...")
+
+  local start = ngx.now()
+
+  for entity, err in dao:each(1000) do
+    if err then
+      return nil, err
+    end
+
+    local cache_key = dao:cache_key(entity)
+    local ok, err   = kong.cache:get(cache_key, nil, function()
+      return entity
+    end)
+    if not ok then
+      return nil, err
+    end
+  end
+
+  local ellapsed = math.floor((ngx.now() - start) * 1000)
+
+  ngx.log(ngx.NOTICE, "Finished preloading '" .. entity_name ..
+                      "' into the cache. Ellapsed time: " .. tostring(ellapsed) .. "ms.")
+  return true
+end
+
+
+-- Loads entities from the database into the cache, for rapid subsequent
+-- access. This function is intented to be used during worker initialization
+-- The list of entities to be loaded is defined by the ENTITIES_TO_PREWARM
+-- variable.
+function cache_prewarm.execute()
+  -- kong.db and kong.cache might not be active while running tests
+  if not kong.db or not kong.cache then
+    return true
+  end
+
+  for _, entity_name in ipairs(ENTITIES_TO_PREWARM) do
+    local ok, err = cache_prewarm_single_entity(entity_name)
+    if not ok then
+      return nil, err
+    end
+  end
+
+  return true
+end
+
+
+return cache_prewarm

--- a/kong/runloop/cache_prewarm.lua
+++ b/kong/runloop/cache_prewarm.lua
@@ -34,8 +34,9 @@ local function cache_prewarm_single_entity(entity_name, dao)
       return nil, err
     end
 
+    -- NOTE: this is just for warming up L1
     local ok, err   = kong.cache:get(cache_key, nil, function()
-      return entity
+      error("this should never be called as the L2 should already be warmed")
     end)
     if not ok then
       return nil, err
@@ -75,7 +76,8 @@ function cache_prewarm.execute(configured_plugins)
             kong.log.warn("cache prewarming has been stopped because cache ",
                           "memory is exhausted, please consider increasing ",
                           "the value of 'mem_cache_size' (currently at ",
-                          kong.configuration.mem_cache_size, ")")
+                          kong.configuration.mem_cache_size, ") for ",
+                          "optimal performance")
 
             return true
           end


### PR DESCRIPTION
This preloads all plugins & services from the db into the cache during
the init_worker phase. It should accelerate the first run of the
plugins_iterator without affecting any existing functionality or tests.

It should also improve the performance of the router, provided that
the services are loaded from the cache instead of directly from the
database - See #4407
