### PR TITLE
feat(reports) report anonymous usage data of dbless feature

### DIFF
--- a/kong/api/routes/config.lua
+++ b/kong/api/routes/config.lua
@@ -14,7 +14,7 @@ return {
   ["/config"] = {
     POST = function(self, db)
       if kong.db.strategy ~= "off" then
-        kong.response.exit(400, {
+        return kong.response.exit(400, {
           message = "this endpoint is only available when Kong is " ..
                     "configured to not use a database"
         })

--- a/kong/api/routes/config.lua
+++ b/kong/api/routes/config.lua
@@ -1,4 +1,5 @@
 local declarative = require("kong.db.declarative")
+local reports = require("kong.reports")
 local kong = kong
 
 
@@ -7,6 +8,10 @@ local kong = kong
 local accept = {
   yaml = true,
   json = true,
+}
+
+local _reports = {
+  decl_fmt_version = false,
 }
 
 
@@ -24,9 +29,9 @@ return {
 
       local config = self.params.config
       -- TODO extract proper filename from the input
-      local entities, err = dc:parse_string(config, "config.yml", accept)
-      if err then
-        return kong.response.exit(400, { error = err })
+      local entities, err_or_ver = dc:parse_string(config, "config.yml", accept)
+      if not entities then
+        return kong.response.exit(400, { error = err_or_ver })
       end
 
       local ok, err = declarative.load_into_cache(entities)
@@ -34,6 +39,9 @@ return {
         kong.log.err("failed loading declarative config into cache: ", err)
         return kong.response.exit(500, { message = "An unexpected error occurred" })
       end
+
+      _reports.decl_fmt_version = err_or_ver
+      reports.send("dbless-reconfigure", _reports)
 
       return kong.response.exit(201, entities)
     end,

--- a/kong/cmd/config.lua
+++ b/kong/cmd/config.lua
@@ -72,9 +72,9 @@ local function execute(args)
       error("expected a declarative configuration file; see `kong config --help`")
     end
 
-    local dc_table, err = dc:parse_file(filename, accepted_formats)
+    local dc_table, err_or_ver = dc:parse_file(filename, accepted_formats)
     if not dc_table then
-      error("Failed parsing:\n" .. err)
+      error("Failed parsing:\n" .. err_or_ver)
     end
 
     if args.command == "db_import" then
@@ -96,6 +96,16 @@ local function execute(args)
       end
 
       log("import successful")
+
+      -- send anonymous report if reporting is not disabled
+      if conf.anonymous_reports then
+        local kong_reports = require "kong.reports"
+        kong_reports.configure_ping(conf)
+        kong_reports.toggle(true)
+
+        local report = { decl_fmt_version = err_or_ver }
+        kong_reports.send("config-db-import", report)
+      end
 
     else -- parse
       log("parse successful:")

--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -127,7 +127,7 @@ function Config:parse_string(contents, filename, accept)
     return nil, pretty_print_error(err_t), err_t
   end
 
-  return entities
+  return entities, dc_table._format_version
 end
 
 

--- a/spec/01-unit/11-reports_spec.lua
+++ b/spec/01-unit/11-reports_spec.lua
@@ -111,6 +111,19 @@ describe("reports", function()
         local _, res = assert(thread:join())
         assert.matches("database=cassandra", res, nil, true)
       end)
+
+      it("off", function()
+        local conf = assert(conf_loader(nil, {
+          database = "off",
+        }))
+        reports.configure_ping(conf)
+
+        local thread = helpers.udp_server(8189)
+        reports.send_ping("127.0.0.1", 8189)
+
+        local _, res = assert(thread:join())
+        assert.matches("database=off", res, nil, true)
+      end)
     end)
 
     describe("sends '_admin' for 'admin_listen'", function()


### PR DESCRIPTION
### Summary
This PR reports certain usage of the new DB-less or declarative config feature.

* Add tests for hourly "ping" report when `database = off`
* Generate `dbless-reconfigure` event when `/config` API is used to reconfigure with tests
* Generate `config-db-import ` event when `kong config db_import` cmd is used to import config from `.yml` into database with tests
* Fix small styling issue in `/config` API endpoint