### PR TITLE
tests(*) plugin schema helper

### DIFF
--- a/kong/db/schema/entity.lua
+++ b/kong/db/schema/entity.lua
@@ -23,6 +23,14 @@ local function make_records_required(field)
   end
 end
 
+
+function Entity.new_subschema(schema, key, definition)
+  make_records_required(definition)
+  definition.required = nil
+  return Schema.new_subschema(schema, key, definition)
+end
+
+
 function Entity.new(definition)
 
   local self, err = Schema.new(definition)
@@ -54,14 +62,9 @@ function Entity.new(definition)
     ::continue::
   end
 
+  self.new_subschema = Entity.new_subschema
+
   return self
-end
-
-
-function Entity.new_subschema(schema, key, definition)
-  make_records_required(definition)
-  definition.required = nil
-  return Schema.new_subschema(schema, key, definition)
 end
 
 

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -36,6 +36,7 @@ local version = require "version"
 local pl_dir = require "pl.dir"
 local pl_Set = require "pl.Set"
 local Schema = require "kong.db.schema"
+local Entity = require "kong.db.schema.entity"
 local cjson = require "cjson.safe"
 local utils = require "kong.tools.utils"
 local http = require "resty.http"
@@ -1261,7 +1262,7 @@ Schema.new(consumers_schema_def)
 Schema.new(services_schema_def)
 Schema.new(routes_schema_def)
 
-local plugins_schema = assert(Schema.new(plugins_schema_def))
+local plugins_schema = assert(Entity.new(plugins_schema_def))
 
 local function validate_plugin_config_schema(config, schema_def)
   assert(plugins_schema:new_subschema(schema_def.name, schema_def))


### PR DESCRIPTION
### Summary

- Override `Entity.new_subschema` in schema instance returned by `Entity.new`
- Use `Entity.new` to instantiate plugins schemas in spec helpers

These changes allow the helper `validate_plugin_config_schema` to be consistent with how plugins schemas are loaded in the plugins DAO. In particular, this fixes an issue where default values for nested records are not populated in the entity validated and returned by `validate_plugin_config_schema`.