### PR TITLE
feat(db) add mutually_required and mutually_exclusive_sets

### DIFF
--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1186,7 +1186,9 @@ do
     for _, check in ipairs(checks) do
       local check_name = next(check)
       local arg = check[check_name]
-      run_entity_check(self, check_name, input, arg, full_check, errors)
+      if arg and arg ~= null then
+        run_entity_check(self, check_name, input, arg, full_check, errors)
+      end
     end
   end
 

--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -134,12 +134,22 @@ local entity_checkers = {
     },
   },
   { custom_entity_check = {
-    type = "record",
-    fields = {
-      { field_sources = { type = "array", elements = { type = "string" } } },
-      { fn = { type = "function" } },
+      type = "record",
+      fields = {
+        { field_sources = { type = "array", elements = { type = "string" } } },
+        { fn = { type = "function" } },
+      }
     }
-  } },
+  },
+  { mutually_required = { type = "array", elements = { type = "string" } } },
+  { mutually_exclusive_sets = {
+      type = "record",
+      fields = {
+        { set1 = {type = "array", elements = {type = "string"} } },
+        { set2 = {type = "array", elements = {type = "string"} } },
+      }
+    }
+  },
 }
 
 local entity_check_names = {}

--- a/spec/01-unit/01-db/01-schema/01-schema_spec.lua
+++ b/spec/01-unit/01-db/01-schema/01-schema_spec.lua
@@ -1543,6 +1543,74 @@ describe("schema", function()
       }))
     end)
 
+    it("test mutually required checks", function()
+      local Test = Schema.new({
+        fields = {
+          { a1 = { type = "string" } },
+          { a2 = { type = "string" } },
+          { a3 = { type = "string" } },
+        },
+        entity_checks = {
+          { mutually_required = { "a2" } },
+          { mutually_required = { "a1", "a3" } },
+        }
+      })
+
+      local ok, err = Test:validate_update({
+        a1 = "foo"
+      })
+      assert.is_falsy(ok)
+      assert.match("all or none of these fields must be set: 'a1', 'a3'", err["@entity"][1])
+
+      ok, err = Test:validate_update({
+        a2 = "foo"
+      })
+      assert.truthy(ok)
+      assert.falsy(err)
+    end)
+
+    it("test mutually exclusive checks", function()
+      local Test = Schema.new({
+        fields = {
+          { a1 = { type = "string" } },
+          { a2 = { type = "string" } },
+          { a3 = { type = "string" } },
+          { a4 = { type = "string" } },
+          { a5 = { type = "string" } },
+        },
+        entity_checks = {
+          { mutually_exclusive_sets = { set1 = {"a3"}, set2 = {"a5"}} },
+          { mutually_exclusive_sets = { set1 = {"a1", "a2"}, set2 = {"a4", "a5"}} },
+        }
+      })
+
+      local ok, err = Test:validate_update({
+        a1 = "foo",
+        a5 = "bla",
+      })
+      assert.is_falsy(ok)
+      assert.same("these sets are mutually exclusive: ('a1'), ('a5')", err["@entity"][1])
+
+      ok, err = Test:validate_update({
+        a1 = "foo",
+      })
+      assert.truthy(ok)
+      assert.falsy(err)
+
+      ok, err = Test:validate_update({
+        a3 = "foo",
+        a5 = "bla",
+      })
+      assert.is_falsy(ok)
+      assert.same("these sets are mutually exclusive: ('a3'), ('a5')", err["@entity"][1])
+
+      ok, err = Test:validate_update({
+        a5 = "foo",
+      })
+      assert.truthy(ok)
+      assert.falsy(err)
+    end)
+
     it("test conditional checks on set elements", function()
       local Test = Schema.new({
         fields = {


### PR DESCRIPTION
### Summary

Add new schema validators:
- `mutually_required`: all declared fields must be set if any of them is
set
- `mutually_exclusive_sets`: if either of the fields declared is set, none of
the remaining can be set

### TODO

- ~~Naming: I'm still not 100% happy with the names; in particular, I think
argument names in the `mutually_exclusive` validator could be better.
Suggestions very welcome~~