### PR TITLE
fix(key-auth) return unauthorized on empty header

### DIFF
--- a/kong/plugins/key-auth/handler.lua
+++ b/kong/plugins/key-auth/handler.lua
@@ -143,7 +143,7 @@ local function do_authentication(conf)
   end
 
   -- this request is missing an API key, HTTP 401
-  if not key then
+  if not key or key == "" then
     kong.response.set_header("WWW-Authenticate", _realm)
     return nil, { status = 401, message = "No API key found in request" }
   end

--- a/spec/03-plugins/09-key-auth/02-access_spec.lua
+++ b/spec/03-plugins/09-key-auth/02-access_spec.lua
@@ -169,6 +169,19 @@ for _, strategy in helpers.each_strategy() do
         local json = cjson.decode(body)
         assert.same({ message = "No API key found in request" }, json)
       end)
+      it("returns Unauthorized on empty header", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/status/200",
+          headers = {
+            ["Host"] = "key-auth1.com",
+            ["apikey"] = "",
+          }
+        })
+        local body = assert.res_status(401, res)
+        local json = cjson.decode(body)
+        assert.same({ message = "No API key found in request" }, json)
+      end)
       it("returns WWW-Authenticate header on missing credentials", function()
         local res = assert(proxy_client:send {
           method  = "GET",


### PR DESCRIPTION
Fix #4405
