### PR TITLE
feat(schema) make one_of support multiple types

### DIFF
--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -46,7 +46,7 @@ local validators = {
   { match_none = match_list },
   { match_any = match_any_list },
   { starts_with = { type = "string" }, },
-  { one_of = { type = "array", elements = { type = "string" } }, },
+  { one_of = { type = "array", elements = { type = "any" } }, },
   { contains = { type = "any" }, },
   { is_regex = { type = "boolean" }, },
   { timestamp = { type = "boolean" }, },


### PR DESCRIPTION
This change ensures that `one_of` will check to see if an element is of any type, rather than just a string.