### PR TITLE
fix(dao) correctly manage primary keys of type "foreign" 

### DIFF
--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -329,7 +329,8 @@ local function generate_foreign_key_methods(schema)
           validate_options_type(options)
         end
 
-        local ok, errors = self.schema:validate_primary_key(foreign_key)
+        local ok, errors = field.schema:validate_primary_key(foreign_key)
+
         if not ok then
           local err_t = self.errors:invalid_primary_key(errors)
           return iteration.failed(tostring(err_t), err_t)

--- a/kong/db/strategies/cassandra/init.lua
+++ b/kong/db/strategies/cassandra/init.lua
@@ -1041,7 +1041,7 @@ do
           if err then
             return nil, self.errors:database_error("could not gather " ..
                                                    "associated entities " ..
-                                                   "for delete cascade: ", err)
+                                                   "for delete cascade: " .. err)
           end
 
           local row_pk = constraint.schema:extract_pk_values(row)
@@ -1049,7 +1049,7 @@ do
           _, err = strategy:delete(row_pk)
           if err then
             return nil, self.errors:database_error("could not cascade " ..
-                                                   "delete entity: ", err)
+                                                   "delete entity: " .. err)
           end
         end
       end


### PR DESCRIPTION
This PR allows primary keys to be foreign keys (meaning there's a composite pk)

It assumes some conventions (maybe too many of them) as the field names and suffixes added for foreign keys. I'm happy to improve it if needed but don't want to step on other's toes.

