### PR TITLE
fix(schema) change timeout to be at least 1ms

### DIFF
--- a/kong/db/schema/entities/services.lua
+++ b/kong/db/schema/entities/services.lua
@@ -1,4 +1,11 @@
 local typedefs = require "kong.db.schema.typedefs"
+local Schema   = require("kong.db.schema")
+
+
+local nonzero_timeout = Schema.define {
+  type = "integer",
+  between = { 1, math.pow(2, 31) - 2 },
+}
 
 
 return {
@@ -17,9 +24,9 @@ return {
     { host            = typedefs.host { required = true } },
     { port            = typedefs.port { required = true, default = 80 }, },
     { path            = typedefs.path },
-    { connect_timeout = typedefs.timeout { default = 60000 }, },
-    { write_timeout   = typedefs.timeout { default = 60000 }, },
-    { read_timeout    = typedefs.timeout { default = 60000 }, },
+    { connect_timeout = nonzero_timeout { default = 60000 }, },
+    { write_timeout   = nonzero_timeout { default = 60000 }, },
+    { read_timeout    = nonzero_timeout { default = 60000 }, },
     -- { load_balancer = { type = "foreign", reference = "load_balancers" } },
   },
 

--- a/spec/01-unit/01-db/01-schema/05-services_spec.lua
+++ b/spec/01-unit/01-db/01-schema/05-services_spec.lua
@@ -98,6 +98,45 @@ describe("services", function()
     assert.same(service.read_timeout, 60000)
   end)
 
+  describe("timeout attributes", function()
+    -- refusals
+    it("should not be zero", function()
+      local service = {
+        host            = "example.com",
+        port            = 80,
+        protocol        = "https",
+        connect_timeout = 0,
+        read_timeout    = 0,
+        write_timeout   = 0,
+      }
+
+      local ok, err = Services:validate(service)
+      assert.falsy(ok)
+      assert.equal("value should be between 1 and 2147483646",
+                   err.connect_timeout)
+      assert.equal("value should be between 1 and 2147483646",
+                   err.read_timeout)
+      assert.equal("value should be between 1 and 2147483646",
+                   err.write_timeout)
+    end)
+
+    -- acceptance
+    it("should be greater than zero", function()
+      local service = {
+        host            = "example.com",
+        port            = 80,
+        protocol        = "https",
+        connect_timeout = 1,
+        read_timeout    = 10,
+        write_timeout   = 100,
+      }
+
+      local ok, err = Services:validate(service)
+      assert.is_nil(err)
+      assert.is_true(ok)
+    end)
+  end)
+
   describe("path attribute", function()
     -- refusals
     it("must be a string", function()


### PR DESCRIPTION
Timeouts in Service objects can be currently set to 0, but the proxy
calls then return 500s as OpenResty API doesn't allow for zero or
negative timeouts:
https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/balancer.md#set_timeouts

`typedefs.timeout` is not currently used anywhere except for defining
timeouts in the `Service` entity.

A `0` value for a timeout is a valid, and for such a use-case, a user
can define their own type value using the Schema library.