### PR TITLE
hotfix(cmd) fix output of `kong config parse`.

### DIFF
--- a/kong/cmd/config.lua
+++ b/kong/cmd/config.lua
@@ -108,8 +108,7 @@ local function execute(args)
       end
 
     else -- parse
-      log("parse successful:")
-      log(declarative.to_yaml_string(dc_table))
+      log("parse successful")
     end
 
     os.exit(0)


### PR DESCRIPTION
Do not output the string `nil` upon a successful parse.
Thanks @hbagdi for reporting.