### PR TITLE
fix(migration) fix an issue in core migration that resulted in bad sc…

### DIFF
--- a/kong/db/migrations/core/001_14_to_15.lua
+++ b/kong/db/migrations/core/001_14_to_15.lua
@@ -338,6 +338,8 @@ return {
           config text, -- serialized plugin configuration
           enabled boolean,
           cache_key text,
+          protocols set<text>, -- added in 1.1.0
+          tags set<text>, -- added in 1.1.0
           PRIMARY KEY (id)
         );
 


### PR DESCRIPTION
…hema after migrating C*

backed Kong cluster from 0.14 to 1.1.0.

In `kong/db/migrations/core/003_100_to_110.lua`, we added new fields `tags` and `protocols`
to the `plugins` table in the `up` phase, however, the `plugins` table
was recreated in `kong/db/migrations/core/001_14_to_15.lua`'s `teardown`
phase without those two fields. This results green clusters to throw HTTP
500 error for all proxy requests after `kong migrations finish` is
executed.

Thanks @thibaultcha for helping on determining the fix.