### PR TITLE
kong config init should work without a prefix set up

### DIFF
--- a/kong/cmd/config.lua
+++ b/kong/cmd/config.lua
@@ -29,6 +29,11 @@ end
 
 
 local function execute(args)
+  if args.command == "init" then
+    generate_init()
+    os.exit(0)
+  end
+
   log.disable()
   -- retrieve default prefix or use given one
   local default_conf = assert(conf_loader(args.conf, {
@@ -43,11 +48,6 @@ local function execute(args)
 
   -- load <PREFIX>/kong.conf containing running node's config
   local conf = assert(conf_loader(default_conf.kong_env))
-
-  if args.command == "init" then
-    generate_init()
-    os.exit(0)
-  end
 
   if args.command == "db-import" then
     args.command = "db_import"

--- a/kong/cmd/config.lua
+++ b/kong/cmd/config.lua
@@ -18,19 +18,17 @@ local accepted_formats = {
 }
 
 
-local function generate_init()
-  if pl_file.access_time(INIT_FILE) then
-    error(INIT_FILE .. " already exists in the current directory.\n" ..
-          "Will not overwrite it.")
+local function generate_init(filename)
+  if pl_file.access_time(filename) then
+    error(filename .. " already exists.\nWill not overwrite it.")
   end
-
-  pl_file.write(INIT_FILE, kong_yml)
+  pl_file.write(filename, kong_yml)
 end
 
 
 local function execute(args)
   if args.command == "init" then
-    generate_init()
+    generate_init(args[1] or INIT_FILE)
     os.exit(0)
   end
 
@@ -123,7 +121,7 @@ Usage: kong config COMMAND [OPTIONS]
 Use declarative configuration files with Kong.
 
 The available commands are:
-  init                          Generate an example config file to
+  init [file]                   Generate an example config file to
                                 get you started.
 
   db_import <file>              Import a declarative config file into


### PR DESCRIPTION
`kong config init` should work without running `kong prepare` or `kong start && kong stop` first.

I added a 2nd commit here to allow specifying a filename, as it kept causing me issues when running kong from a read-only directory. In future I think we should add some convenience to sending it to stdout (makes it much easier to use with docker). Feel free to cherry-pick just the hotfix if you want.