### PR TITLE
chore(tests) enable plugin specific nginx server/stream mocks

### DIFF
--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -349,6 +349,7 @@ end
 
 return {
   prepare_prefix = prepare_prefix,
+  compile_conf = compile_conf,
   compile_kong_conf = compile_kong_conf,
   compile_kong_stream_conf = compile_kong_stream_conf,
   compile_nginx_conf = compile_nginx_conf,

--- a/spec/03-plugins/22-aws-lambda/01-access_spec.lua
+++ b/spec/03-plugins/22-aws-lambda/01-access_spec.lua
@@ -6,6 +6,79 @@ local meta    = require "kong.meta"
 local server_tokens = meta._SERVER_TOKENS
 
 
+local fixtures = {
+  http_mock = {
+    lambda_plugin = [[
+
+      server {
+          server_name mock_aws_lambda;
+          listen 10001 ssl;
+
+          ssl_certificate ${{SSL_CERT}};
+          ssl_certificate_key ${{SSL_CERT_KEY}};
+          ssl_protocols TLSv1.1 TLSv1.2 TLSv1.3;
+
+          location ~ "/2015-03-31/functions/(?:[^/])*/invocations" {
+              content_by_lua_block {
+                local function x()
+                  local function say(res, status)
+                    ngx.header["x-amzn-RequestId"] = "foo"
+
+                    if string.match(ngx.var.uri, "functionWithUnhandledError") then
+                      ngx.header["X-Amz-Function-Error"] = "Unhandled"
+                    end
+
+                    ngx.status = status
+
+                    if string.match(ngx.var.uri, "functionWithBadJSON") then
+                      local badRes = "{\"foo\":\"bar\""
+                      ngx.header["Content-Length"] = #badRes + 1
+                      ngx.say(badRes)
+
+                    elseif string.match(ngx.var.uri, "functionWithNoResponse") then
+                      ngx.header["Content-Length"] = 0
+
+                    elseif type(res) == 'string' then
+                      ngx.header["Content-Length"] = #res + 1
+                      ngx.say(res)
+
+                    else
+                      ngx.req.discard_body()
+                      ngx.header['Content-Length'] = 0
+                    end
+
+                    ngx.exit(0)
+                  end
+
+                  ngx.sleep(.2) -- mock some network latency
+
+                  local invocation_type = ngx.var.http_x_amz_invocation_type
+                  if invocation_type == 'Event' then
+                    say(nil, 202)
+
+                  elseif invocation_type == 'DryRun' then
+                    say(nil, 204)
+                  end
+
+                  local qargs = ngx.req.get_uri_args()
+                  ngx.req.read_body()
+                  local args = require("cjson").decode(ngx.req.get_body_data())
+
+                  say(ngx.req.get_body_data(), 200)
+                end
+                local ok, err = pcall(x)
+                if not ok then
+                  ngx.log(ngx.ERR, "Mock error: ", err)
+                end
+              }
+          }
+      }
+
+    ]]
+  },
+}
+
+
 for _, strategy in helpers.each_strategy() do
   describe("Plugin: AWS Lambda (access) [#" .. strategy .. "]", function()
     local proxy_client
@@ -293,10 +366,10 @@ for _, strategy in helpers.each_strategy() do
         },
       }
 
-      assert(helpers.start_kong{
+      assert(helpers.start_kong({
         database   = strategy,
         nginx_conf = "spec/fixtures/custom_nginx.template",
-      })
+      }, nil, nil, fixtures))
     end)
 
     before_each(function()

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -233,64 +233,6 @@ http {
 > end
 
     server {
-        server_name mock_aws_lambda;
-        listen 10001 ssl;
-
-        ssl_certificate ${{SSL_CERT}};
-        ssl_certificate_key ${{SSL_CERT_KEY}};
-        ssl_protocols TLSv1.1 TLSv1.2 TLSv1.3;
-
-        location ~ "/2015-03-31/functions/(?:[^/])*/invocations" {
-            content_by_lua_block {
-                local function say(res, status)
-                  ngx.header["x-amzn-RequestId"] = "foo"
-
-                  if string.match(ngx.var.uri, "functionWithUnhandledError") then
-                    ngx.header["X-Amz-Function-Error"] = "Unhandled"
-                  end
-
-                  ngx.status = status
-
-                  if string.match(ngx.var.uri, "functionWithBadJSON") then
-                    local badRes = "{\"foo\":\"bar\""
-                    ngx.header["Content-Length"] = #badRes + 1
-                    ngx.say(badRes)
-
-                  elseif string.match(ngx.var.uri, "functionWithNoResponse") then
-                    ngx.header["Content-Length"] = 0
-
-                  elseif type(res) == 'string' then
-                    ngx.header["Content-Length"] = #res + 1
-                    ngx.say(res)
-
-                  else
-                    ngx.req.discard_body()
-                    ngx.header['Content-Length'] = 0
-                  end
-
-                  ngx.exit(0)
-                end
-
-                ngx.sleep(.2) -- mock some network latency
-
-                local invocation_type = ngx.var.http_x_amz_invocation_type
-                if invocation_type == 'Event' then
-                  say(nil, 202)
-
-                elseif invocation_type == 'DryRun' then
-                  say(nil, 204)
-                end
-
-                local qargs = ngx.req.get_uri_args()
-                ngx.req.read_body()
-                local args = require("cjson").decode(ngx.req.get_body_data())
-
-                say(ngx.req.get_body_data(), 200)
-            }
-        }
-    }
-
-    server {
         server_name mock_upstream;
 
         listen 15555;
@@ -479,6 +421,9 @@ http {
             }
         }
     }
+
+    include '*.http_mock';
+
 > end
 }
 
@@ -583,5 +528,8 @@ stream {
             ngx.say(data) -- echo whatever was sent
         }
     }
+
+    include '*.stream_mock';
+
 }
 > end

--- a/spec/fixtures/mocks/lua-resty-dns/resty/dns/resolver.lua
+++ b/spec/fixtures/mocks/lua-resty-dns/resty/dns/resolver.lua
@@ -2,9 +2,9 @@
 -- (so NOT the Kong dns client)
 
 -- this file should be in the Kong working direrctory (prefix)
-local MOCK_RECORD_FILENAME = "dns_mock_records.lua"
+local MOCK_RECORD_FILENAME = "dns_mock_records.json"
 
-
+local cjson = require "cjson.safe"
 
 -- first thing is to get the original (non-mock) resolver
 local resolver
@@ -68,9 +68,11 @@ do
     end
 
     -- there is a file with mock records available, go load it
-    mock_records = assert(loadfile(filename))()
-    assert(type(mock_records) == "table",
-           "expected mock_record file to contain a table")
+    local f = assert(io.open(filename))
+    local json_file = assert(f:read("*a"))
+    f:close()
+
+    mock_records = assert(cjson.decode(json_file))
 
     return mock_records
   end

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -1103,6 +1103,156 @@ luassert:register("assertion", "cn", assert_cn,
                   "assertion.cn.negative",
                   "assertion.cn.positive")
 
+
+
+local dns_mock = {}
+do
+  dns_mock.__index = dns_mock
+  dns_mock.__tostring = function(self)
+    -- fill array to prevent json encoding errors
+    for i = 1, 33 do
+      self[i] = self[i] or true
+    end
+    local json = assert(cjson.encode(self))
+    return json
+  end
+
+
+  local TYPE_A, TYPE_AAAA, TYPE_CNAME, TYPE_SRV = 1, 28, 5, 33
+
+
+  --- Creates a new DNS mocks.
+  function dns_mock.new()
+    return setmetatable({}, dns_mock)
+  end
+
+  --- Adds an SRV record to the DNS mock.
+  -- Fields name, target, port are required. Other fields get defaults:
+  -- weight (20), ttl (600), priority (20)
+  function dns_mock:SRV(rec)
+    if self == dns_mock then
+      error("can't operate omn the class, you must create an instance", 2)
+    end
+    if getmetatable(self or {}) ~= dns_mock then
+      error("SRV method must be called using the colon notation", 2)
+    end
+    assert(rec, "Missing record parameter")
+    local name = assert(rec.name, "No name field in SRV record")
+
+    self[TYPE_SRV] = self[TYPE_SRV] or {}
+    local query_answer = self[TYPE_SRV][name]
+    if not query_answer then
+      query_answer = {}
+      self[TYPE_SRV][name] = query_answer
+    end
+
+    table.insert(query_answer, {
+      type = TYPE_SRV,
+      name = name,
+      target = assert(rec.target, "No target field in SRV record"),
+      port = assert(rec.port, "No port field in SRV record"),
+      weight = rec.weight or 10,
+      ttl = rec.ttl or 600,
+      priority = rec.priority or 20,
+      class = rec.class or 1
+    })
+    return true
+  end
+
+
+  --- Adds an A record to the DNS mock.
+  -- Fields name, address are required. Other fields get defaults:
+  -- ttl (600)
+  function dns_mock:A(rec)
+    if self == dns_mock then
+      error("can't operate omn the class, you must create an instance", 2)
+    end
+    if getmetatable(self or {}) ~= dns_mock then
+      error("A method must be called using the colon notation", 2)
+    end
+    assert(rec, "Missing record parameter")
+    local name = assert(rec.name, "No name field in A record")
+
+    self[TYPE_A] = self[TYPE_A] or {}
+    local query_answer = self[TYPE_A][name]
+    if not query_answer then
+      query_answer = {}
+      self[TYPE_A][name] = query_answer
+    end
+
+    table.insert(query_answer, {
+      type = TYPE_A,
+      name = name,
+      address = assert(rec.address, "No address field in A record"),
+      ttl = rec.ttl or 600,
+      class = rec.class or 1
+    })
+    return true
+  end
+
+
+  --- Adds an AAAA record to the DNS mock.
+  -- Fields name, address are required. Other fields get defaults:
+  -- ttl (600)
+  function dns_mock:AAAA(rec)
+    if self == dns_mock then
+      error("can't operate omn the class, you must create an instance", 2)
+    end
+    if getmetatable(self or {}) ~= dns_mock then
+      error("AAAA method must be called using the colon notation", 2)
+    end
+    assert(rec, "Missing record parameter")
+    local name = assert(rec.name, "No name field in AAAA record")
+
+    self[TYPE_AAAA] = self[TYPE_AAAA] or {}
+    local query_answer = self[TYPE_AAAA][name]
+    if not query_answer then
+      query_answer = {}
+      self[TYPE_AAAA][name] = query_answer
+    end
+
+    table.insert(query_answer, {
+      type = TYPE_AAAA,
+      name = name,
+      address = assert(rec.address, "No address field in AAAA record"),
+      ttl = rec.ttl or 600,
+      class = rec.class or 1
+    })
+    return true
+  end
+
+
+  --- Adds an CNAME record to the DNS mock.
+  -- Fields name, cname are required. Other fields get defaults:
+  -- ttl (600)
+  function dns_mock:CNAME(rec)
+    if self == dns_mock then
+      error("can't operate omn the class, you must create an instance", 2)
+    end
+    if getmetatable(self or {}) ~= dns_mock then
+      error("CNAME method must be called using the colon notation", 2)
+    end
+    assert(rec, "Missing record parameter")
+    local name = assert(rec.name, "No name field in CNAME record")
+
+    self[TYPE_CNAME] = self[TYPE_CNAME] or {}
+    local query_answer = self[TYPE_CNAME][name]
+    if not query_answer then
+      query_answer = {}
+      self[TYPE_CNAME][name] = query_answer
+    end
+
+    table.insert(query_answer, {
+      type = TYPE_CNAME,
+      name = name,
+      cname = assert(rec.cname, "No cname field in CNAME record"),
+      ttl = rec.ttl or 600,
+      class = rec.class or 1
+    })
+    return true
+  end
+end
+
 ----------------
 -- Shell helpers
 -- @section Shell-helpers
@@ -1318,6 +1468,22 @@ local function render_fixtures(conf, env, prefix, fixtures)
     end
   end
 
+  if fixtures and fixtures.dns_mock then
+    -- write the mock records to the prefix
+    assert(getmetatable(fixtures.dns_mock) == dns_mock,
+           "expected dns_mock to be of a helpers.dns_mock class")
+    assert(pl_utils.writefile(prefix .. "/dns_mock_records.json",
+                              tostring(fixtures.dns_mock)))
+
+    -- add the mock resolver to the path to ensure the records are loaded
+    local path
+    local key = "lua_package_path"
+    path, key = lookup(env, key) -- case insensitive lookup
+
+    -- if no existing path setting then end with double semi-colons
+    env[key] = "spec/fixtures/mocks/lua-resty-dns/?.lua;" .. (path or ";")
+  end
+
   return true
 end
 
@@ -1439,6 +1605,7 @@ return {
 
   -- Kong testing helpers
   execute = exec,
+  dns_mock = dns_mock,
   kong_exec = kong_exec,
   get_version = get_version,
   http_client = http_client,


### PR DESCRIPTION
The mocks are injected into the nginx conf and rendered with the
Kong configuration. The Lambda plugin has been converted to this
format.

Please check commit scope/type, as I wasn't sure