### PR TITLE
docs(conf) document database=off and declarative_config

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -400,19 +400,30 @@
 # DATASTORE
 #------------------------------------------------------------------------------
 
-# Kong will store all of its data (such as Routes, Services, Consumers, and Plugins) in
-# either Cassandra or PostgreSQL, and all Kong nodes belonging to the same cluster
-# must connect themselves to the same database.
+# Kong can run with a database to store coordinated data between Kong nodes in
+# a cluster, or without a database, where each node stores its information
+# independently in memory.
+#
+# When using a database, Kong will store data for all its entities (such as
+# Routes, Services, Consumers, and Plugins) in either Cassandra or PostgreSQL,
+# and all Kong nodes belonging to the same cluster must connect themselves
+# to the same database.
 #
 # Kong supports the following database versions:
 # - **PostgreSQL**: 9.5 and above.
 # - **Cassandra**: 2.2 and above.
 #
+# When not using a database, Kong is said to be in "DB-less mode": it will keep
+# its entities in memory, and each node needs to have this data entered via a
+# declarative configuration file, which can be specified through the
+# `declarative_config` property, or via the Admin API using the `/config`
+# endpoint.
+#
 
 #database = postgres             # Determines which of PostgreSQL or Cassandra
                                  # this node will use as its datastore.
-                                 # Accepted values are `postgres` and
-                                 # `cassandra`.
+                                 # Accepted values are `postgres`,
+                                 # `cassandra`, and `off`.
 
 #pg_host = 127.0.0.1             # Host of the Postgres server.
 #pg_port = 5432                  # Port of the Postgres server.
@@ -520,6 +531,19 @@
                                              # Cassandra nodes.
                                              # This value is only used during
                                              # migrations.
+
+#declarative_config =           # The path to the declarative configuration
+                                # file which holds the specification of all
+                                # entities (Routes, Services, Consumers, etc.)
+                                # to be used when the `database` is set to `off`.
+                                #
+                                # Entities are stored in Kong's in-memory cache,
+                                # so you must ensure that enough memory is
+                                # allocated to it via the `mem_cache_size`
+                                # property. You must also ensure that items
+                                # in the cache never expire, which means that
+                                # `db_cache_ttl` should preserve its default
+                                # value of 0.
 
 #------------------------------------------------------------------------------
 # DATASTORE CACHE

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -45,7 +45,7 @@
 #proxy_error_log = logs/error.log         # Path for proxy port request error
                                           # logs. The granularity of these logs
                                           # is adjusted by the `log_level`
-                                          # directive.
+                                          # property.
 
 #admin_access_log = logs/admin_access.log # Path for Admin API request access
                                           # logs. Set this value to `off` to
@@ -57,7 +57,7 @@
 #admin_error_log = logs/error.log         # Path for Admin API request error
                                           # logs. The granularity of these logs
                                           # is adjusted by the `log_level`
-                                          # directive.
+                                          # property.
 
 #plugins = bundled               # Comma-separated list of plugins this node
                                  # should load. By default, only plugins
@@ -212,8 +212,9 @@
                                  # spawned by Nginx.
                                  #
                                  # See http://nginx.org/en/docs/ngx_core_module.html#worker_processes
-                                 # for detailed usage of this directive and
-                                 # a description of accepted values.
+                                 # for detailed usage of the equivalent Nginx
+                                 # directive and a description of accepted
+                                 # values.
 
 #nginx_daemon = on               # Determines whether Nginx will run as a daemon
                                  # or as a foreground process. Mainly useful
@@ -352,7 +353,7 @@
                                  # See http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header
                                  # for a description of this directive.
 
-#real_ip_recursive = off         # This value sets the ngx_http_realip_module
+#real_ip_recursive = off         # This value sets the `ngx_http_realip_module`
                                  # directive of the same name in the Nginx
                                  # configuration.
                                  #


### PR DESCRIPTION
Add missing documentation in `kong.conf.default` for features introduced in Kong 1.1.
