### PR TITLE
chore(deps) bump mlcache to 2.4.0 and expose 'get_bulk()'

### DIFF
--- a/kong-1.1.1-0.rockspec
+++ b/kong-1.1.1-0.rockspec
@@ -35,7 +35,7 @@ dependencies = {
   "lua-resty-mediador == 0.1.2",
   "lua-resty-healthcheck == 0.6.0",
   "lua-resty-cookie == 0.1.0",
-  "lua-resty-mlcache == 2.3.0",
+  "lua-resty-mlcache == 2.4.0",
   -- external Kong plugins
   "kong-plugin-azure-functions ~> 0.3",
   "kong-plugin-kubernetes-sidecar-injector ~> 0.1",

--- a/kong/cache.lua
+++ b/kong/cache.lua
@@ -132,6 +132,24 @@ function _M:get(key, opts, cb, ...)
 end
 
 
+function _M:get_bulk(bulk, opts)
+  if type(bulk) ~= "table" then
+    return error("bulk must be a table")
+  end
+
+  if opts ~= nil and type(opts) ~= "table" then
+    return error("opts must be a table")
+  end
+
+  local res, err = self.mlcache:get_bulk(bulk, opts)
+  if err then
+    return nil, "failed to get_bulk from node cache: " .. err
+  end
+
+  return res
+end
+
+
 function _M:probe(key)
   if type(key) ~= "string" then
     return error("key must be a string")


### PR DESCRIPTION
2 commits extracted from #4457 

---

This release of mlcache introduces the new `get_bulk()` API needed by
the wildcard SNI feature.

Changelog for 2.4.0:

https://github.com/thibaultcha/lua-resty-mlcache/blob/master/CHANGELOG.md#2.4.0