### PR TITLE
fix(basic-auth) ignore password if nil on basic auth credential patch

### DIFF
--- a/kong/plugins/basic-auth/basicauth_credentials.lua
+++ b/kong/plugins/basic-auth/basicauth_credentials.lua
@@ -46,9 +46,11 @@ end
 
 
 function _BasicauthCredentials:update(cred_pk, cred, options)
-  local ok, err, err_t = hash_password(self, cred_pk.id, cred)
-  if not ok then
-    return nil, err, err_t
+  if cred.password ~= nil then
+    local ok, err, err_t = hash_password(self, cred_pk.id, cred)
+    if not ok then
+      return nil, err, err_t
+    end
   end
   return self.super.update(self, cred_pk, cred, options)
 end

--- a/kong/plugins/basic-auth/basicauth_credentials.lua
+++ b/kong/plugins/basic-auth/basicauth_credentials.lua
@@ -57,9 +57,11 @@ end
 
 
 function _BasicauthCredentials:update_by_username(username, cred, options)
-  local ok, err, err_t = hash_password(self, username, cred)
-  if not ok then
-    return nil, err, err_t
+  if cred.password ~= nil then
+    local ok, err, err_t = hash_password(self, username, cred)
+    if not ok then
+      return nil, err, err_t
+    end
   end
   return self.super.update_by_username(self, username, cred, options)
 end

--- a/spec/03-plugins/10-basic-auth/02-api_spec.lua
+++ b/spec/03-plugins/10-basic-auth/02-api_spec.lua
@@ -278,6 +278,24 @@ for _, strategy in helpers.each_strategy() do
           local json = cjson.decode(body)
           assert.not_equal(previous_hash, json.password)
         end)
+        it("ignores a nil password when updated by id", function()
+          local previous_hash = credential.password
+
+          local res = assert(admin_client:send {
+            method  = "PATCH",
+            path    = "/consumers/bob/basic-auth/" .. credential.id,
+            body    = {
+              username = "Tyrion Lannister"
+            },
+            headers = {
+              ["Content-Type"] = "application/json"
+            }
+          })
+          local body = assert.res_status(200, res)
+          local json = cjson.decode(body)
+          assert.equal("Tyrion Lannister", json.username)
+          assert.equal(previous_hash, json.password)
+        end)
         it("updates a credential by username", function()
           local previous_hash = credential.password
 
@@ -294,6 +312,24 @@ for _, strategy in helpers.each_strategy() do
           local body = assert.res_status(200, res)
           local json = cjson.decode(body)
           assert.not_equal(previous_hash, json.password)
+        end)
+        it("ignores a nil password when updated by username", function()
+          local previous_hash = credential.password
+
+          local res = assert(admin_client:send {
+            method  = "PATCH",
+            path    = "/consumers/bob/basic-auth/" .. credential.username,
+            body    = {
+              username = "Tyrion Lannister"
+            },
+            headers = {
+              ["Content-Type"] = "application/json"
+            }
+          })
+          local body = assert.res_status(200, res)
+          local json = cjson.decode(body)
+          assert.equal("Tyrion Lannister", json.username)
+          assert.equal(previous_hash, json.password)
         end)
         describe("errors", function()
           it("handles invalid input", function()


### PR DESCRIPTION
### Summary

This PR fixes an issue when patching basic auth credentials: `PATCH consumers/:consumers/basic-auth/:basicauth_credentials`. 

Currently, if `password` is not sent in the PATCH request, nil is hashed and saved as the password. The new behavior is to ignore nil password, preserving the current password if one is not sent. 

### Full changelog

* `_BasicauthCredentials:update` only calls `hash_password` if password is not nil
* `_BasicauthCredentials:update_by_username` only calls `hash_password` if password is not nil
* Adds tests

