### PR TITLE
chore(deps) bump lua-resty-healthcheck to 0.6.1

### DIFF
--- a/kong-1.1.1-0.rockspec
+++ b/kong-1.1.1-0.rockspec
@@ -33,7 +33,7 @@ dependencies = {
   "lua-resty-dns-client == 3.0.2",
   "lua-resty-worker-events == 0.3.3",
   "lua-resty-mediador == 0.1.2",
-  "lua-resty-healthcheck == 0.6.0",
+  "lua-resty-healthcheck == 0.6.1",
   "lua-resty-cookie == 0.1.0",
   "lua-resty-mlcache == 2.3.0",
   -- external Kong plugins


### PR DESCRIPTION
This is a backwards-compatible patch-release bump to fix a Kong issue.
See https://github.com/Kong/lua-resty-healthcheck#061-04-apr-2019

Fixes #4453.
