### PR TITLE
feat(cache) prewarm some negative cache entries for plugins

### DIFF
--- a/kong/cache.lua
+++ b/kong/cache.lua
@@ -239,6 +239,18 @@ function _M:safe_set(key, value)
 end
 
 
+function _M:safe_add(key, value)
+  local str_marshalled, err = marshall_for_shm(value, self.mlcache.ttl,
+                                                      self.mlcache.neg_ttl)
+
+  if err then
+    return nil, err
+  end
+
+  return ngx.shared[SHM_CACHE]:safe_add(SHM_CACHE .. key, str_marshalled)
+end
+
+
 function _M:probe(key)
   if type(key) ~= "string" then
     return error("key must be a string")

--- a/kong/runloop/cache_prewarm.lua
+++ b/kong/runloop/cache_prewarm.lua
@@ -8,7 +8,6 @@ do
   end
 end
 
-
 local tostring = tostring
 local math = math
 local ngx = ngx
@@ -17,27 +16,277 @@ local ngx = ngx
 local cache_prewarm = {}
 
 
-local function cache_prewarm_single_entity(entity_name, dao)
+local never_called = function()
+  error("this should never be called as the L2 should already be warmed")
+end
+
+
+local function cache_set(cache, key, value)
+  local ok, err = cache.safe_set(cache, key, value)
+  if not ok then
+    return nil, err
+  end
+
+  -- NOTE: this is just for warming up L1
+  -- We don't do the same for cache_add because it isn't guaranteed there
+  return cache.get(cache, key, nil, never_called)
+end
+
+
+local function cache_add(cache, key, value)
+  local ok, err = cache.safe_add(cache, key, value)
+  -- ignore this case - we don't want to override a value if it's already there
+  if not ok and err == "exists" then
+    return true
+  end
+  return ok, err
+end
+
+
+local function write_entity_in_cache(entity_name, dao, entity)
+  local cache = kong.cache
+  local get_key = dao.cache_key
+  local key
+
+  if entity_name ~= "plugins" then
+    key = get_key(dao, entity)
+    return cache_set(cache, key, entity)
+  end
+  -- Else, we're dealing with a plugin.
+  -- Fill up cache both positively and negatively as much as possible
+
+  local plugin_name = entity.name
+  if not plugin_name then
+    return nil, "Attempted to prewarm a plugin without name"
+  end
+
+  local route_id = nil
+  if not entity.no_route and entity.route then
+    route_id = entity.route.id
+  end
+  local service_id = nil
+  if not entity.no_service and entity.service then
+    service_id = entity.service.id
+  end
+  local consumer_id = nil
+  if not entity.no_consumer and entity.consumer then
+    consumer_id = entity.consumer.id
+  end
+
+  local ok, err
+  if route_id and service_id and consumer_id then
+    key = get_key(dao, plugin_name, route_id, service_id, consumer_id)
+    ok, err = cache_set(cache, key, entity)
+    if not ok then
+      return nil, err
+    end
+
+    key = get_key(dao, plugin_name, route_id, service_id, nil)
+    ok, err = cache_add(cache, key, nil)
+    if not ok then
+      return nil, err
+    end
+
+    key = get_key(dao, plugin_name, route_id, nil, consumer_id)
+    ok, err = cache_add(cache, key, nil)
+    if not ok then
+      return nil, err
+    end
+
+    key = get_key(dao, plugin_name, nil, service_id, consumer_id)
+    ok, err = cache_add(cache, key, nil)
+    if not ok then
+      return nil, err
+    end
+
+    key = get_key(dao, plugin_name, route_id, service_id, nil)
+    ok, err = cache_add(cache, key, nil)
+    if not ok then
+      return nil, err
+    end
+
+    key = get_key(dao, plugin_name, nil, nil, consumer_id)
+    ok, err = cache_add(cache, key, nil)
+    if not ok then
+      return nil, err
+    end
+
+    key = get_key(dao, plugin_name, route_id, nil, nil)
+    ok, err = cache_add(cache, key, nil)
+    if not ok then
+      return nil, err
+    end
+
+    key = get_key(dao, plugin_name, nil, service_id, nil)
+    ok, err = cache_add(cache, key, nil)
+    if not ok then
+      return nil, err
+    end
+
+    key = get_key(dao, plugin_name, nil, nil, nil)
+    ok, err = cache_add(cache, key, nil)
+    if not ok then
+      return nil, err
+    end
+
+    return true
+  end
+
+  if route_id and consumer_id then
+    key = get_key(dao, plugin_name, route_id, nil, consumer_id)
+    ok, err = cache_set(cache, key, entity)
+    if not ok then
+      return nil, err
+    end
+
+    key = get_key(dao, plugin_name, nil, nil, consumer_id)
+    ok, err = cache_add(cache, key, nil)
+    if not ok then
+      return nil, err
+    end
+
+    key = get_key(dao, plugin_name, route_id, nil, nil)
+    ok, err = cache_add(cache, key, nil)
+    if not ok then
+      return nil, err
+    end
+
+    key = get_key(dao, plugin_name, nil, nil, nil)
+    ok, err = cache_add(cache, key, nil)
+    if not ok then
+      return nil, err
+    end
+
+    return true
+  end
+
+  if service_id and consumer_id then
+    key = get_key(dao, plugin_name, nil, service_id, consumer_id)
+    ok, err = cache_set(cache, key, entity)
+    if not ok then
+      return nil, err
+    end
+
+    key = get_key(dao, plugin_name, nil, nil, consumer_id)
+    ok, err = cache_add(cache, key, nil)
+    if not ok then
+      return nil, err
+    end
+
+    key = get_key(dao, plugin_name, nil, service_id, nil)
+    ok, err = cache_add(cache, key, nil)
+    if not ok then
+      return nil, err
+    end
+
+    key = get_key(dao, plugin_name, nil, nil, nil)
+    ok, err = cache_add(cache, key, nil)
+    if not ok then
+      return nil, err
+    end
+
+    return true
+  end
+
+  if route_id and service_id then
+    key = get_key(dao, plugin_name, route_id, service_id, nil)
+    ok, err = cache_set(cache, key, entity)
+    if not ok then
+      return nil, err
+    end
+
+    key = get_key(dao, plugin_name, route_id, nil, nil)
+    ok, err = cache_add(cache, key, nil)
+    if not ok then
+      return nil, err
+    end
+
+    key = get_key(dao, plugin_name, nil, service_id, nil)
+    ok, err = cache_add(cache, key, nil)
+    if not ok then
+      return nil, err
+    end
+
+    key = get_key(dao, plugin_name, nil, nil, nil)
+    ok, err = cache_add(cache, key, nil)
+    if not ok then
+      return nil, err
+    end
+
+    return true
+  end
+
+  if consumer_id then
+    key = get_key(dao, plugin_name, nil, nil, consumer_id)
+    ok, err = cache_set(cache, key, entity)
+    if not ok then
+      return nil, err
+    end
+
+    key = get_key(dao, plugin_name, nil, nil, nil)
+    ok, err = cache_add(cache, key, nil)
+    if not ok then
+      return nil, err
+    end
+
+    return true
+  end
+
+  if route_id then
+    key = get_key(dao, plugin_name, route_id, nil, nil)
+    ok, err = cache_set(cache, key, entity)
+    if not ok then
+      return nil, err
+    end
+
+    key = get_key(dao, plugin_name, nil, nil, nil)
+    ok, err = cache_add(cache, key, nil)
+    if not ok then
+      return nil, err
+    end
+
+    return true
+  end
+
+  if service_id then
+    key = get_key(dao, plugin_name, nil, service_id, nil)
+    ok, err = cache_set(cache, key, entity)
+    if not ok then
+      return nil, err
+    end
+
+    key = get_key(dao, plugin_name, nil, nil, nil)
+    ok, err = cache_add(cache, key, nil)
+    if not ok then
+      return nil, err
+    end
+
+    return true
+  end
+
+  -- if every other combination has failed, then it's a global plugin
+  key = get_key(dao, plugin_name, nil, nil, nil)
+  return cache_set(cache, key, entity)
+end
+
+
+local function cache_prewarm_single_entity(entity_name)
+  local dao = kong.db[entity_name]
+  if not dao then
+    return nil, "Invalid entity name found when prewarming the cache: " .. tostring(entity_name)
+  end
+
   ngx.log(ngx.NOTICE, "Preloading '" .. entity_name .. "' into the cache ...")
 
   local start = ngx.now()
 
+  local ok
   for entity, err in dao:each(1000) do
     if err then
       return nil, err
     end
 
-    local cache_key = dao:cache_key(entity)
-
-    local ok, err = kong.cache:safe_set(cache_key, entity)
-    if not ok then
-      return nil, err
-    end
-
-    -- NOTE: this is just for warming up L1
-    local ok, err   = kong.cache:get(cache_key, nil, function()
-      error("this should never be called as the L2 should already be warmed")
-    end)
+    ok, err = write_entity_in_cache(entity_name, dao, entity)
     if not ok then
       return nil, err
     end


### PR DESCRIPTION
This PR prewarms *some* cache entries for plugins, in addition to the default one (which was provided by `kong.db.plugins:cache_key(plugin)`).

This code is repetitive on purpose (it could be made terser with tables and loops) to make it fast - we want prewarm to be as quick as possible.