### PR TITLE
fix(declarative) fix crash when field has same name as entity

### DIFF
--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -249,7 +249,11 @@ local function populate_references(input, known_entities, by_id, by_key, expecte
     local parent_fk
     local child_key
     if parent_entity then
-      parent_fk = all_schemas[parent_entity]:extract_pk_values(input)
+      local parent_schema = all_schemas[parent_entity]
+      if parent_schema.fields[entity] then
+        goto continue
+      end
+      parent_fk = parent_schema:extract_pk_values(input)
       child_key = foreign_children[parent_entity][entity]
     end
 

--- a/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
+++ b/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
@@ -153,6 +153,40 @@ describe("declarative config: flatten", function()
         }, idempotent(config))
       end)
 
+      it("accepts field names with the same name as entities", function()
+        local config = assert(lyaml.load([[
+          _format_version: "1.1"
+          routes:
+          - name: foo
+            protocols: ["tls"]
+            snis:
+            - "example.com"
+        ]]))
+        config = DeclarativeConfig:flatten(config)
+        assert.same({
+          routes = {
+            {
+              tags = null,
+              created_at = 1234567890,
+              destinations = null,
+              hosts = null,
+              id = "UUID",
+              methods = null,
+              name = "foo",
+              paths = null,
+              preserve_host = false,
+              protocols = { "tls" },
+              regex_priority = 0,
+              service = null,
+              snis = { "example.com" },
+              sources = null,
+              strip_path = true,
+              updated_at = 1234567890
+            }
+          }
+        }, idempotent(config))
+      end)
+
       it("allows url shorthand", function()
         local config = lyaml.load([[
           _format_version: "1.1"


### PR DESCRIPTION
A conflict happened because the `routes` entity has a field called `snis`,
which is also the name of an entity.

Includes a regression test.

Thanks @akasetty for reporting.