### PR TITLE
added index on ratelimiting_metrics. closes #4374

### DIFF
--- a/kong-1.1.1-0.rockspec
+++ b/kong-1.1.1-0.rockspec
@@ -246,6 +246,7 @@ build = {
     ["kong.plugins.rate-limiting.migrations.000_base_rate_limiting"] = "kong/plugins/rate-limiting/migrations/000_base_rate_limiting.lua",
     ["kong.plugins.rate-limiting.migrations.001_14_to_15"] = "kong/plugins/rate-limiting/migrations/001_14_to_15.lua",
     ["kong.plugins.rate-limiting.migrations.002_15_to_10"] = "kong/plugins/rate-limiting/migrations/002_15_to_10.lua",
+    ["kong.plugins.rate-limiting.migrations.003_10_to_112"] = "kong/plugins/rate-limiting/migrations/003_10_to_112.lua",
     ["kong.plugins.rate-limiting.handler"] = "kong/plugins/rate-limiting/handler.lua",
     ["kong.plugins.rate-limiting.schema"] = "kong/plugins/rate-limiting/schema.lua",
     ["kong.plugins.rate-limiting.daos"] = "kong/plugins/rate-limiting/daos.lua",

--- a/kong/plugins/rate-limiting/migrations/003_10_to_112.lua
+++ b/kong/plugins/rate-limiting/migrations/003_10_to_112.lua
@@ -1,0 +1,12 @@
+return {
+  postgres = {
+    up = [[
+      CREATE INDEX IF NOT EXISTS ratelimiting_metrics_idx ON ratelimiting_metrics (service_id, route_id, period_date, period);
+    ]],
+  },
+
+  cassandra = {
+    up = [[
+    ]],
+  },
+}

--- a/kong/plugins/rate-limiting/migrations/init.lua
+++ b/kong/plugins/rate-limiting/migrations/init.lua
@@ -2,4 +2,5 @@ return {
   "000_base_rate_limiting",
   "001_14_to_15",
   "002_15_to_10",
+  "003_10_to_112",
 }


### PR DESCRIPTION
### Summary

Add missing index on rate-limiting plugin metrics on route + service.

### Full changelog

*  added index ratelimiting_metrics on (service_id, route_id, period_date, period).

### Issues resolved

Fix #4374 
