### PR TITLE
fix(core) declarative config should not be parsed with db-mode on start

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -231,7 +231,7 @@ end
 
 
 local function parse_declarative_config(kong_config)
-  if not kong_config.database == "off" then
+  if kong_config.database ~= "off" then
     return {}
   end
 


### PR DESCRIPTION
### Summary

Maybe later it should, but in current form it gives critical errors
to error log:

```
KONG_DECLARATIVE_CONFIG=kong.yml ./bin/kong restart --vv
```

writes to error log:
```
[crit] 7691#0: *1 [lua] init.lua:533: init_worker():
  error loading declarative config file:
    init.lua:266: bad argument #1 to 'pairs' (table expected, got nil),
         context: init_worker_by_lua*
```