### PR TITLE
fix(schema) address issue where field type "record" nested values reset on update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,12 @@ jobs:
       env: PACKAGE_TYPE=deb RESTY_IMAGE_BASE=ubuntu RESTY_IMAGE_TAG=bionic KONG_PACKAGE_NAME=${PWD##*/} KONG_VERSION=${TRAVIS_TAG}
       if: tag IS present AND tag ~= 1.
     - script: make release
+      env: PACKAGE_TYPE=deb RESTY_IMAGE_BASE=debian RESTY_IMAGE_TAG=stretch KONG_PACKAGE_NAME=${PWD##*/} KONG_VERSION=${TRAVIS_TAG}
+      if: tag IS present AND tag ~= 1.
+    - script: make release
+      env: PACKAGE_TYPE=deb RESTY_IMAGE_BASE=debian RESTY_IMAGE_TAG=jessie KONG_PACKAGE_NAME=${PWD##*/} KONG_VERSION=${TRAVIS_TAG}
+      if: tag IS present AND tag ~= 1.
+    - script: make release
       env: PACKAGE_TYPE=rpm RESTY_IMAGE_BASE=centos RESTY_IMAGE_TAG=6 KONG_PACKAGE_NAME=${PWD##*/} KONG_VERSION=${TRAVIS_TAG}
       if: tag IS present AND tag ~= 1.
     - script: make release
@@ -100,6 +106,9 @@ jobs:
     - script: make release
       env: PACKAGE_TYPE=rpm RESTY_IMAGE_BASE=rhel RESTY_IMAGE_TAG=7 KONG_PACKAGE_NAME=${PWD##*/} KONG_VERSION=${TRAVIS_TAG}
       if: tag IS present AND tag ~= 1.
+    - script: make release
+      env: PACKAGE_TYPE=rpm RESTY_IMAGE_BASE=amazonlinux RESTY_IMAGE_TAG=latest KONG_PACKAGE_NAME=${PWD##*/} KONG_VERSION=${TRAVIS_TAG}
+      if: tag IS present AND tag ~= 1.
     - stage: deploy daily build
       install: skip
       before_install: skip
@@ -113,6 +122,12 @@ jobs:
       env: PACKAGE_TYPE=deb RESTY_IMAGE_BASE=ubuntu RESTY_IMAGE_TAG=bionic KONG_PACKAGE_NAME=${PWD##*/} KONG_VERSION=`date +%Y-%m-%d` REPOSITORY_NAME=${PWD##*/}-nightly REPOSITORY_OS_NAME=$TRAVIS_BRANCH
       if: type=cron
     - script: make nightly-release
+      env: PACKAGE_TYPE=deb RESTY_IMAGE_BASE=debian RESTY_IMAGE_TAG=stretch KONG_PACKAGE_NAME=${PWD##*/} KONG_VERSION=`date +%Y-%m-%d` REPOSITORY_NAME=${PWD##*/}-nightly REPOSITORY_OS_NAME=$TRAVIS_BRANCH
+      if: type=cron
+    - script: make nightly-release
+      env: PACKAGE_TYPE=deb RESTY_IMAGE_BASE=debian RESTY_IMAGE_TAG=jessie KONG_PACKAGE_NAME=${PWD##*/} KONG_VERSION=`date +%Y-%m-%d` REPOSITORY_NAME=${PWD##*/}-nightly REPOSITORY_OS_NAME=$TRAVIS_BRANCH
+      if: type=cron
+    - script: make nightly-release
       env: PACKAGE_TYPE=rpm RESTY_IMAGE_BASE=centos RESTY_IMAGE_TAG=6 KONG_PACKAGE_NAME=${PWD##*/} KONG_VERSION=`date +%Y-%m-%d` REPOSITORY_NAME=${PWD##*/}-nightly REPOSITORY_OS_NAME=$TRAVIS_BRANCH
       if: type=cron
     - script: make nightly-release
@@ -121,6 +136,14 @@ jobs:
     - script: make nightly-release
       env: PACKAGE_TYPE=apk RESTY_IMAGE_BASE=alpine RESTY_IMAGE_TAG=latest KONG_PACKAGE_NAME=${PWD##*/} KONG_VERSION=`date +%Y-%m-%d` REPOSITORY_NAME=${PWD##*/}-nightly REPOSITORY_OS_NAME=$TRAVIS_BRANCH
       if: type=cron
-
+    - script: make nightly-release
+      env: PACKAGE_TYPE=rpm RESTY_IMAGE_BASE=rhel RESTY_IMAGE_TAG=6 KONG_PACKAGE_NAME=${PWD##*/} KONG_VERSION=`date +%Y-%m-%d` REPOSITORY_NAME=${PWD##*/}-nightly REPOSITORY_OS_NAME=$TRAVIS_BRANCH
+      if: type=cron
+    - script: make nightly-release
+      env: PACKAGE_TYPE=rpm RESTY_IMAGE_BASE=rhel RESTY_IMAGE_TAG=7 KONG_PACKAGE_NAME=${PWD##*/} KONG_VERSION=`date +%Y-%m-%d` REPOSITORY_NAME=${PWD##*/}-nightly REPOSITORY_OS_NAME=$TRAVIS_BRANCH
+      if: type=cron
+    - script: make nightly-release
+      env: PACKAGE_TYPE=rpm RESTY_IMAGE_BASE=amazonlinux RESTY_IMAGE_TAG=latest KONG_PACKAGE_NAME=${PWD##*/} KONG_VERSION=`date +%Y-%m-%d` REPOSITORY_NAME=${PWD##*/}-nightly REPOSITORY_OS_NAME=$TRAVIS_BRANCH
+      if: type=cron
 script:
   - .ci/run_tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,9 @@ jobs:
       install: skip
       before_install: skip
       script: make release
+      env: PACKAGE_TYPE=src RESTY_IMAGE_BASE=src KONG_PACKAGE_NAME=${PWD##*/} KONG_VERSION=${TRAVIS_TAG}
+      if: tag IS present AND tag ~= 1.
+    - script: make release
       env: PACKAGE_TYPE=deb RESTY_IMAGE_BASE=ubuntu RESTY_IMAGE_TAG=trusty KONG_PACKAGE_NAME=${PWD##*/} KONG_VERSION=${TRAVIS_TAG}
       if: tag IS present AND tag ~= 1.
     - script: make release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 
 > Released on: 2019/03/27
 
-This is a minor release, introducing new features such as **Declarative
+This release introduces new features such as **Declarative
 Configuration**, **DB-less Mode**, **Bulk Database Import**, **Tags**, as well
 as **Transparent Proxying**. It contains a large number of other features and
 fixes, listed below. Also, the Plugin Development kit also saw a minor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+- [1.1.1](#111)
 - [1.1.0](#110)
 - [1.0.3](#103)
 - [1.0.2](#102)
@@ -24,6 +25,24 @@
 - [0.10.0](#0100---20170307)
 - [0.9.9 and prior](#099---20170202)
 
+## [1.1.1]
+
+> Released on: 2019/03/28
+
+This release contains a fix for 0.14 Kong clusters using Cassandra to safely
+migrate to Kong 1.1.
+
+### Fixes
+
+- Ensure the 0.14 -> 1.1 migration path for Cassandra does not corrupt the
+  database schema.
+  [#4450](https://github.com/Kong/kong/pull/4450)
+- Allow the `kong config init` command to run without a pointing to a prefix
+  directory.
+  [#4451](https://github.com/Kong/kong/pull/4451)
+
+[Back to TOC](#table-of-contents)
+
 ## [1.1.0]
 
 > Released on: 2019/03/27
@@ -38,6 +57,12 @@ This release includes database migrations. Please take a few minutes to read
 the [1.1 Upgrade Path](https://github.com/Kong/kong/blob/master/UPGRADE.md)
 for more details regarding changes and migrations before planning to upgrade
 your Kong cluster.
+
+:large_orange_diamond: **Post-release note (as of 2019/03/28):** an issue has
+been found when migrating from a 0.14 Kong cluster to 1.1.0 when running on top
+of Cassandra. Kong 1.1.1 has been released to address this issue. Kong clusters
+running on top of PostgreSQL are not affected by this issue, and can migrate to
+1.1.0 or 1.1.1 safely.
 
 ### Additions
 
@@ -3561,6 +3586,7 @@ First version running with Cassandra.
 
 [Back to TOC](#table-of-contents)
 
+[1.1.1]: https://github.com/Kong/kong/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/Kong/kong/compare/1.0.3...1.1.0
 [1.0.3]: https://github.com/Kong/kong/compare/1.0.2...1.0.3
 [1.0.2]: https://github.com/Kong/kong/compare/1.0.1...1.0.2

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -62,7 +62,7 @@ be aware of the following changes:
   the same OpenSSL version. If you are installing Kong from one of our
   distribution packages, you are not affected by this change.
 
-### 2. Breaking Changes
+#### 2. Breaking Changes
 
 Kong 1.1 does not include any breaking changes over Kong 1.0, but Kong 1.0
 included a number of breaking changes over Kong 0.x. If you are upgrading
@@ -70,9 +70,9 @@ from 0.14,x, please read the section on
 [Kong 1.0 Breaking Changes](#kong-1-0-breaking-changes) carefully before
 proceeding.
 
-### 3. Suggested Upgrade Path
+#### 3. Suggested Upgrade Path
 
-#### Upgrade from `0.x` to `1.1`
+##### Upgrade from `0.x` to `1.1`
 
 The lowest version that Kong 1.1 supports migrating from is 0.14.1. if you
 are migrating from a previous 0.x release, please migrate to 0.14.1 first.
@@ -82,7 +82,7 @@ upgrading from 0.14.1 to Kong 1.0. Please follow the steps described in the
 "Migration Steps from 0.14" in the [Suggested Upgrade Path for Kong
 1.0](#kong-1-0-upgrade-path).
 
-#### Upgrade from `1.0.x` to `1.1`
+##### Upgrade from `1.0.x` to `1.1`
 
 Kong 1.1 supports a no-downtime migration model. This means that while the
 migration is ongoing, you will have two Kong clusters running, sharing the
@@ -117,12 +117,12 @@ database in the final expected state for Kong 1.1).
    was successful. From now on, you can safely make Admin API
    requests to your 1.1 nodes.
 
-#### Upgrade Path from 1.1 Release Candidates
+##### Upgrade Path from 1.1 Release Candidates
 
 The process is the same as for upgrading from 1.0 listed above, but on step 1
 you should run `kong migrations up --force` instead.
 
-#### Installing 1.1 on a Fresh Datastore
+##### Installing 1.1 on a Fresh Datastore
 
 The following commands should be used to prepare a new 1.1 cluster from a fresh datastore:
 
@@ -164,7 +164,7 @@ Changelog](https://github.com/Kong/kong/blob/master/CHANGELOG.md) for a
 complete list of changes and new features.
 
 <a name="kong-1-0-breaking-changes"></a>
-### 1. Breaking Changes
+#### 1. Breaking Changes
 
 ##### Dependencies
 
@@ -424,7 +424,7 @@ that you consult the full [0.15
 Changelog](https://github.com/Kong/kong/blob/master/CHANGELOG.md) for a
 complete list of changes and new features.
 
-### 1. Breaking Changes
+#### 1. Breaking Changes
 
 ##### Dependencies
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,5 @@
 This document guides you through the process of upgrading Kong. First, check if
-a section named "Upgrade to Kong `x.x.x`" exists, with `x.x.x` being the version
+a section named "Upgrade to `x.x.x`" exists, with `x.x.x` being the version
 you are planning to upgrade to. If such a section does not exist, the upgrade
 you want to perform does not have any particular instructions, and you can
 simply consult the [Suggested upgrade path](#suggested-upgrade-path).
@@ -36,7 +36,103 @@ starts new workers, which take over from old workers before those old workers
 are terminated. In this way, Kong will serve new requests via the new
 configuration, without dropping existing in-flight connections.
 
-### Upgrading `1.0.x` patch releases
+
+## Upgrade to `1.1`
+
+Kong adheres to [semantic versioning](https://semver.org/), which makes a
+distinction between "major", "minor" and "patch" versions. The upgrade path
+will be different on which previous version from which you are migrating.
+If you are upgrading from 0.x, this is a major upgrade. If you are
+upgrading from 1.0.x, this is a minor upgrade. Both scenarios are
+explained below.
+
+
+#### 1. Dependencies
+
+If you are using the provided binary packages, all necessary dependencies
+are bundled. If you are building your dependencies by hand, you should
+be aware of the following changes:
+
+- The required OpenResty version is 1.13.6.2, but for a full feature set,
+  including stream routing and service mesh abilities with mutual TLS, you need
+  Kong's [openresty-patches](https://github.com/kong/openresty-patches).
+  Note that the set of patches was updated from 1.0 to 1.1.
+- The minimum required OpenSSL version is 1.1.1. If you are building by hand,
+  make sure all dependencies, including LuaRocks modules, are compiled using
+  the same OpenSSL version. If you are installing Kong from one of our
+  distribution packages, you are not affected by this change.
+
+### 2. Breaking Changes
+
+Kong 1.1 does not include any breaking changes over Kong 1.0, but Kong 1.0
+included a number of breaking changes over Kong 0.x. If you are upgrading
+from 0.14,x, please read the section on
+[Kong 1.0 Breaking Changes](#kong-1-0-breaking-changes) carefully before
+proceeding.
+
+### 3. Suggested Upgrade Path
+
+#### Upgrade from `0.x` to `1.1`
+
+The lowest version that Kong 1.1 supports migrating from is 0.14.1. if you
+are migrating from a previous 0.x release, please migrate to 0.14.1 first.
+
+For upgrading from 0.14.1 to Kong 1.1, the steps for upgrading are the same as
+upgrading from 0.14.1 to Kong 1.0. Please follow the steps described in the
+"Migration Steps from 0.14" in the [Suggested Upgrade Path for Kong
+1.0](#kong-1-0-upgrade-path).
+
+#### Upgrade from `1.0.x` to `1.1`
+
+Kong 1.1 supports a no-downtime migration model. This means that while the
+migration is ongoing, you will have two Kong clusters running, sharing the
+same database. (This is sometimes called the Blue/Green migration model.)
+
+The migrations are designed so that there is no need to fully copy
+the data, but this also means that they are designed in such a way so that
+the new version of Kong is able to use the data as it is migrated, and to do
+it in a way so that the old Kong cluster keeps working until it is finally
+time to decomission it. For this reason, the full migration is now split into
+two steps, which are performed via commands `kong migrations up` (which does
+only non-destructive operations) and `kong migrations finish` (which puts the
+database in the final expected state for Kong 1.1).
+
+1. Download 1.1, and configure it to point to the same datastore
+   as your 1.0 cluster. Run `kong migrations up`.
+2. Once that finishes running, both 1.0 and 1.1 clusters can now
+   run simultaneously on the same datastore. Start provisioning
+   1.1 nodes, but do not use their Admin API yet. If you need to
+   perform Admin API requests, these should be made to your 1.0 nodes.
+   The reason is to prevent the new cluster from generating data
+   that is not understood by the old cluster.
+3. Gradually divert traffic away from your 1.0 nodes, and into
+   your 1.1 cluster. Monitor your traffic to make sure everything
+   is going smoothly.
+4. When your traffic is fully migrated to the 1.1 cluster,
+   decommission your 1.0 nodes.
+5. From your 1.1 cluster, run: `kong migrations finish`.
+   From this point on, it will not be possible to start 1.0
+   nodes pointing to the same datastore anymore. Only run
+   this command when you are confident that your migration
+   was successful. From now on, you can safely make Admin API
+   requests to your 1.1 nodes.
+
+#### Upgrade Path from 1.1 Release Candidates
+
+The process is the same as for upgrading from 1.0 listed above, but on step 1
+you should run `kong migrations up --force` instead.
+
+#### Installing 1.1 on a Fresh Datastore
+
+The following commands should be used to prepare a new 1.1 cluster from a fresh datastore:
+
+```
+$ kong migrations bootstrap [-c config]
+$ kong start [-c config]
+```
+
+
+## Upgrading `1.0.x` patch releases
 
 If you are upgrading from another release in the 1.0.x series (e.g. from 1.0.0
 to 1.0.1), there are no migrations. Simply upgrade your Kong installation and
@@ -49,7 +145,7 @@ $ kong reload [-c configuration_file]
 If you are upgrading from 0.x, then read the following section for
 detailed migration instructions.
 
-### Upgrade from `0.x` to `1.0.x`
+## Upgrade from `0.x` to `1.0.x`
 
 Kong 1.0 is a major upgrade, and includes a number of new features
 as well as breaking changes.
@@ -67,6 +163,7 @@ that you consult the full [1.0.0
 Changelog](https://github.com/Kong/kong/blob/master/CHANGELOG.md) for a
 complete list of changes and new features.
 
+<a name="kong-1-0-breaking-changes"></a>
 ### 1. Breaking Changes
 
 ##### Dependencies
@@ -229,6 +326,7 @@ plugins is now removed.
 
 There are no deprecation notices in this release.
 
+<a name="kong-1-0-upgrade-path"></a>
 #### 3. Suggested Upgrade Path
 
 ##### Preliminary Checks
@@ -308,7 +406,7 @@ $ kong start [-c config]
 ```
 
 
-### Upgrade to `0.15`
+## Upgrade to `0.15`
 
 This is the last release in the 0.x series, giving users one last chance to
 upgrade while still using some of the options and concepts that were marked as

--- a/kong-1.1.0-0.rockspec
+++ b/kong-1.1.0-0.rockspec
@@ -1,9 +1,9 @@
 package = "kong"
-version = "1.1.0rc2-0"
+version = "1.1.0-0"
 supported_platforms = {"linux", "macosx"}
 source = {
   url = "git://github.com/Kong/kong",
-  tag = "1.1.0rc2"
+  tag = "1.1.0"
 }
 description = {
   summary = "Kong is a scalable and customizable API Management Layer built on top of Nginx.",

--- a/kong-1.1.1-0.rockspec
+++ b/kong-1.1.1-0.rockspec
@@ -35,7 +35,7 @@ dependencies = {
   "lua-resty-mediador == 0.1.2",
   "lua-resty-healthcheck == 0.6.0",
   "lua-resty-cookie == 0.1.0",
-  "lua-resty-mlcache == 2.3.0",
+  "lua-resty-mlcache == 2.4.0",
   -- external Kong plugins
   "kong-plugin-azure-functions ~> 0.3",
   "kong-plugin-kubernetes-sidecar-injector ~> 0.1",

--- a/kong-1.1.1-0.rockspec
+++ b/kong-1.1.1-0.rockspec
@@ -1,9 +1,9 @@
 package = "kong"
-version = "1.1.0-0"
+version = "1.1.1-0"
 supported_platforms = {"linux", "macosx"}
 source = {
   url = "git://github.com/Kong/kong",
-  tag = "1.1.0"
+  tag = "1.1.1"
 }
 description = {
   summary = "Kong is a scalable and customizable API Management Layer built on top of Nginx.",

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -400,19 +400,30 @@
 # DATASTORE
 #------------------------------------------------------------------------------
 
-# Kong will store all of its data (such as Routes, Services, Consumers, and Plugins) in
-# either Cassandra or PostgreSQL, and all Kong nodes belonging to the same cluster
-# must connect themselves to the same database.
+# Kong can run with a database to store coordinated data between Kong nodes in
+# a cluster, or without a database, where each node stores its information
+# independently in memory.
+#
+# When using a database, Kong will store data for all its entities (such as
+# Routes, Services, Consumers, and Plugins) in either Cassandra or PostgreSQL,
+# and all Kong nodes belonging to the same cluster must connect themselves
+# to the same database.
 #
 # Kong supports the following database versions:
 # - **PostgreSQL**: 9.5 and above.
 # - **Cassandra**: 2.2 and above.
 #
+# When not using a database, Kong is said to be in "DB-less mode": it will keep
+# its entities in memory, and each node needs to have this data entered via a
+# declarative configuration file, which can be specified through the
+# `declarative_config` property, or via the Admin API using the `/config`
+# endpoint.
+#
 
 #database = postgres             # Determines which of PostgreSQL or Cassandra
                                  # this node will use as its datastore.
-                                 # Accepted values are `postgres` and
-                                 # `cassandra`.
+                                 # Accepted values are `postgres`,
+                                 # `cassandra`, and `off`.
 
 #pg_host = 127.0.0.1             # Host of the Postgres server.
 #pg_port = 5432                  # Port of the Postgres server.
@@ -520,6 +531,19 @@
                                              # Cassandra nodes.
                                              # This value is only used during
                                              # migrations.
+
+#declarative_config =           # The path to the declarative configuration
+                                # file which holds the specification of all
+                                # entities (Routes, Services, Consumers, etc.)
+                                # to be used when the `database` is set to `off`.
+                                #
+                                # Entities are stored in Kong's in-memory cache,
+                                # so you must ensure that enough memory is
+                                # allocated to it via the `mem_cache_size`
+                                # property. You must also ensure that items
+                                # in the cache never expire, which means that
+                                # `db_cache_ttl` should preserve its default
+                                # value of 0.
 
 #------------------------------------------------------------------------------
 # DATASTORE CACHE

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -45,7 +45,7 @@
 #proxy_error_log = logs/error.log         # Path for proxy port request error
                                           # logs. The granularity of these logs
                                           # is adjusted by the `log_level`
-                                          # directive.
+                                          # property.
 
 #admin_access_log = logs/admin_access.log # Path for Admin API request access
                                           # logs. Set this value to `off` to
@@ -57,7 +57,7 @@
 #admin_error_log = logs/error.log         # Path for Admin API request error
                                           # logs. The granularity of these logs
                                           # is adjusted by the `log_level`
-                                          # directive.
+                                          # property.
 
 #plugins = bundled               # Comma-separated list of plugins this node
                                  # should load. By default, only plugins
@@ -212,8 +212,9 @@
                                  # spawned by Nginx.
                                  #
                                  # See http://nginx.org/en/docs/ngx_core_module.html#worker_processes
-                                 # for detailed usage of this directive and
-                                 # a description of accepted values.
+                                 # for detailed usage of the equivalent Nginx
+                                 # directive and a description of accepted
+                                 # values.
 
 #nginx_daemon = on               # Determines whether Nginx will run as a daemon
                                  # or as a foreground process. Mainly useful
@@ -352,7 +353,7 @@
                                  # See http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header
                                  # for a description of this directive.
 
-#real_ip_recursive = off         # This value sets the ngx_http_realip_module
+#real_ip_recursive = off         # This value sets the `ngx_http_realip_module`
                                  # directive of the same name in the Nginx
                                  # configuration.
                                  #

--- a/kong/api/endpoints.lua
+++ b/kong/api/endpoints.lua
@@ -205,7 +205,7 @@ local function query_entity(context, self, db, schema, method)
     end
 
     if not method then
-      return dao[method or context](dao, size, args.offset, opts)
+      return dao[context](dao, size, args.offset, opts)
     end
 
     return dao[method](dao, self.params[schema.name], size, args.offset, opts)

--- a/kong/cache.lua
+++ b/kong/cache.lua
@@ -132,6 +132,24 @@ function _M:get(key, opts, cb, ...)
 end
 
 
+function _M:get_bulk(bulk, opts)
+  if type(bulk) ~= "table" then
+    return error("bulk must be a table")
+  end
+
+  if opts ~= nil and type(opts) ~= "table" then
+    return error("opts must be a table")
+  end
+
+  local res, err = self.mlcache:get_bulk(bulk, opts)
+  if err then
+    return nil, "failed to get_bulk from node cache: " .. err
+  end
+
+  return res
+end
+
+
 function _M:probe(key)
   if type(key) ~= "string" then
     return error("key must be a string")

--- a/kong/cmd/config.lua
+++ b/kong/cmd/config.lua
@@ -29,6 +29,11 @@ end
 
 
 local function execute(args)
+  if args.command == "init" then
+    generate_init()
+    os.exit(0)
+  end
+
   log.disable()
   -- retrieve default prefix or use given one
   local default_conf = assert(conf_loader(args.conf, {
@@ -43,11 +48,6 @@ local function execute(args)
 
   -- load <PREFIX>/kong.conf containing running node's config
   local conf = assert(conf_loader(default_conf.kong_env))
-
-  if args.command == "init" then
-    generate_init()
-    os.exit(0)
-  end
 
   if args.command == "db-import" then
     args.command = "db_import"

--- a/kong/db/migrations/core/001_14_to_15.lua
+++ b/kong/db/migrations/core/001_14_to_15.lua
@@ -338,6 +338,8 @@ return {
           config text, -- serialized plugin configuration
           enabled boolean,
           cache_key text,
+          protocols set<text>, -- added in 1.1.0
+          tags set<text>, -- added in 1.1.0
           PRIMARY KEY (id)
         );
 

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1442,6 +1442,13 @@ function Schema:process_auto_fields(data, context, nulls)
     if context == "select" and field.type == "integer" and type(data[key]) == "number" then
       data[key] = floor(data[key])
     end
+
+    -- Set read_before_write to true,
+    -- to handle deep merge of record object on update.
+    if context == "update" and field.type == "record"
+       and data[key] ~= nil and data[key] ~= null then
+      read_before_write = true
+    end
   end
 
   --[[

--- a/kong/error_handlers.lua
+++ b/kong/error_handlers.lua
@@ -57,7 +57,7 @@ return function(ngx)
   end
 
   local status = ngx.status
-  message = BODIES["s" .. status] and BODIES["s" .. status] or format(BODIES.default, status)
+  message = BODIES["s" .. status] or format(BODIES.default, status)
 
   if singletons.configuration.enabled_headers[constants.HEADERS.SERVER] then
     ngx.header[constants.HEADERS.SERVER] = SERVER_HEADER

--- a/kong/meta.lua
+++ b/kong/meta.lua
@@ -2,7 +2,7 @@ local version = setmetatable({
   major = 1,
   minor = 1,
   patch = 0,
-  suffix = "rc2",
+  --suffix = "",
 }, {
   __tostring = function(t)
     return string.format("%d.%d.%d%s", t.major, t.minor, t.patch,

--- a/kong/meta.lua
+++ b/kong/meta.lua
@@ -1,7 +1,7 @@
 local version = setmetatable({
   major = 1,
   minor = 1,
-  patch = 0,
+  patch = 1,
   --suffix = "",
 }, {
   __tostring = function(t)

--- a/spec/01-unit/01-db/01-schema/01-schema_spec.lua
+++ b/spec/01-unit/01-db/01-schema/01-schema_spec.lua
@@ -2294,6 +2294,51 @@ describe("schema", function()
       end
     end)
 
+    it("sets 'read_before_write' to true when updating field type record", function()
+      local Test = Schema.new({
+        name = "test",
+        fields = {
+          { config = { type = "record", fields = { foo = { type = "string" } } } },
+        }
+      })
+
+      for _, operation in pairs{ "insert", "update", "select", "delete" } do
+        local assertion = assert.falsy
+
+        if operation == "update" then
+          assertion = assert.truthy
+        end
+
+        local _, _, process_auto_fields = Test:process_auto_fields({
+          config = {
+            foo = "dog"
+          }
+        }, operation)
+
+        assertion(process_auto_fields)
+      end
+    end)
+
+    it("sets 'read_before_write' to false when not updating field type record", function()
+      local Test = Schema.new({
+        name = "test",
+        fields = {
+          { config = { type = "record", fields = { foo = { type = "string" } } } },
+          { name = { type = "string" } }
+        }
+      })
+
+      for _, operation in pairs{ "insert", "update", "select", "delete" } do
+        local assertion = assert.falsy
+
+        local _, _, process_auto_fields = Test:process_auto_fields({
+          name = "cat"
+        }, operation)
+
+        assertion(process_auto_fields)
+      end
+    end)
+
     describe("in subschemas", function()
       it("a specialized field can set a default", function()
         local Test = Schema.new({
@@ -2341,6 +2386,43 @@ describe("schema", function()
 
       end)
     end)
+  end)
 
+  describe("merge_values", function()
+    it("should correctly merge records", function()
+      local Test = Schema.new({
+        name = "test", fields = {
+          { config = {
+              type = "record",
+              fields = {
+                foo = { type = "string" },
+                bar = { type = "string" }
+              }
+            }
+          },
+          { name = { type = "string" }
+        }}
+      })
+
+      local old_values = {
+        name = "test",
+        config = { foo = "dog", bar = "cat" },
+      }
+
+      local new_values = {
+        name = "test",
+        config = { foo = "pig" },
+      }
+
+      local expected_values = {
+        name = "test",
+        config = { foo = "pig", bar = "cat" }
+      }
+
+      local values = Test:merge_values(new_values, old_values)
+
+      assert.equals(values.config.foo, expected_values.config.foo)
+      assert.equals(values.config.bar, expected_values.config.bar)
+    end)
   end)
 end)


### PR DESCRIPTION
This PR enables nested `record` field types to merge as expected on `PATCH`.  Previously any unset values within the incoming record object would reset previously set values to either a default value or null. This change allows the previously set values to be respected during a partial update by conditionally setting `read_before_write` to `true`.