### PR TITLE
doc(development) document the docker based development environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,11 @@ Guide](https://docs.konghq.com/latest/plugin-development/), or browse an
 online version of Kong's source code documentation in the [Plugin Development
 Kit (PDK) Reference](https://docs.konghq.com/latest/pdk/).
 
+#### Docker
+
+You can use Docker / docker-compose and a mounted volume to develop Kong by
+following the instructions on [Kong/kong-build-tools](https://github.com/Kong/kong-build-tools#developing-kong).
+
 #### Vagrant
 
 You can use a Vagrant box running Kong and Postgres that you can find at


### PR DESCRIPTION
Just adding a small note to the README about the docker development environment available through git://kong/kong-build-tools