### PR TITLE
fix(schema) address issue where field type "record" nested values reset on update

### DIFF
--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1442,6 +1442,13 @@ function Schema:process_auto_fields(data, context, nulls)
     if context == "select" and field.type == "integer" and type(data[key]) == "number" then
       data[key] = floor(data[key])
     end
+
+    -- Set read_before_write to true,
+    -- to handle deep merge of record object on update.
+    if context == "update" and field.type == "record"
+       and data[key] ~= nil and data[key] ~= null then
+      read_before_write = true
+    end
   end
 
   --[[

--- a/spec/01-unit/01-db/01-schema/01-schema_spec.lua
+++ b/spec/01-unit/01-db/01-schema/01-schema_spec.lua
@@ -2294,6 +2294,51 @@ describe("schema", function()
       end
     end)
 
+    it("sets 'read_before_write' to true when updating field type record", function()
+      local Test = Schema.new({
+        name = "test",
+        fields = {
+          { config = { type = "record", fields = { foo = { type = "string" } } } },
+        }
+      })
+
+      for _, operation in pairs{ "insert", "update", "select", "delete" } do
+        local assertion = assert.falsy
+
+        if operation == "update" then
+          assertion = assert.truthy
+        end
+
+        local _, _, process_auto_fields = Test:process_auto_fields({
+          config = {
+            foo = "dog"
+          }
+        }, operation)
+
+        assertion(process_auto_fields)
+      end
+    end)
+
+    it("sets 'read_before_write' to false when not updating field type record", function()
+      local Test = Schema.new({
+        name = "test",
+        fields = {
+          { config = { type = "record", fields = { foo = { type = "string" } } } },
+          { name = { type = "string" } }
+        }
+      })
+
+      for _, operation in pairs{ "insert", "update", "select", "delete" } do
+        local assertion = assert.falsy
+
+        local _, _, process_auto_fields = Test:process_auto_fields({
+          name = "cat"
+        }, operation)
+
+        assertion(process_auto_fields)
+      end
+    end)
+
     describe("in subschemas", function()
       it("a specialized field can set a default", function()
         local Test = Schema.new({
@@ -2341,6 +2386,43 @@ describe("schema", function()
 
       end)
     end)
+  end)
 
+  describe("merge_values", function()
+    it("should correctly merge records", function()
+      local Test = Schema.new({
+        name = "test", fields = {
+          { config = {
+              type = "record",
+              fields = {
+                foo = { type = "string" },
+                bar = { type = "string" }
+              }
+            }
+          },
+          { name = { type = "string" }
+        }}
+      })
+
+      local old_values = {
+        name = "test",
+        config = { foo = "dog", bar = "cat" },
+      }
+
+      local new_values = {
+        name = "test",
+        config = { foo = "pig" },
+      }
+
+      local expected_values = {
+        name = "test",
+        config = { foo = "pig", bar = "cat" }
+      }
+
+      local values = Test:merge_values(new_values, old_values)
+
+      assert.equals(values.config.foo, expected_values.config.foo)
+      assert.equals(values.config.bar, expected_values.config.bar)
+    end)
   end)
 end)


### PR DESCRIPTION
This PR enables nested record field types to merge as expected on `PATCH`. Previously any unset values within the incoming record object would reset previously set values to either a default value or null. This change allows the previously set values to be respected during a partial update by conditionally setting `read_before_write` to `true`.