### PR TITLE
fix(declarative) do not mis-detect mesh mode

### DIFF
--- a/kong/runloop/mesh.lua
+++ b/kong/runloop/mesh.lua
@@ -199,7 +199,7 @@ end
 
 local function rewrite(ctx)
   local ssl = getssl()
-  if ssl and ssl:getAlpnSelected() == mesh_alpn then
+  if ssl and mesh_alpn and ssl:getAlpnSelected() == mesh_alpn then
     if ctx.is_service_mesh_request then
       ngx.log(ngx.ERR, "already service mesh; circular routing?")
       return ngx.exit(500)


### PR DESCRIPTION
When using declarative config and a `cluster_ca` is not declared,
mesh mode cannot be used. This means that `mesh_alpn` is not declared.

When performing a proxy call to the SSL port with wget like this:

```
wget https://localhost:8443/ --no-check-certificate
```

we get to a state where `getssl()` returns a value but `ssl:getAlpnSelected()`
returns `nil`. We need to avoid this check when `mesh_alpn` is not set.

(Interestingly, this happens with `wget` but does not happen with `curl -k`.)

Fixes #4497.