### PR TITLE
DELETE /cache/:key should invalidate cache in all nodes

### DIFF
--- a/kong/api/routes/cache.lua
+++ b/kong/api/routes/cache.lua
@@ -20,7 +20,7 @@ return {
     end,
 
     DELETE = function(self)
-      kong.cache:invalidate_local(self.params.key)
+      kong.cache:invalidate(self.params.key)
 
       return kong.response.exit(204) -- no content
     end,


### PR DESCRIPTION
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:

https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

### Summary

DELETE /cache/:key should invalidate cache in all nodes

### Full changelog

* DELETE /cache/:key uses invalidate rather than invalidate_local
