### PR TITLE
feat(db) pg username indirection (e.g. azure) and limited permissions support

### DIFF
--- a/kong/db/strategies/postgres/connector.lua
+++ b/kong/db/strategies/postgres/connector.lua
@@ -422,13 +422,11 @@ end
 
 function _mt:reset()
   local schema = self:escape_identifier(self.config.schema)
-  local user = self:escape_identifier(self.config.user)
-
   local ok, err = self:query(concat {
     "BEGIN;\n",
     "  DROP SCHEMA IF EXISTS ", schema ," CASCADE;\n",
-    "  CREATE SCHEMA IF NOT EXISTS ", schema, " AUTHORIZATION ", user, ";\n",
-    "  GRANT ALL ON SCHEMA ", schema ," TO ", user, ";\n",
+    "  CREATE SCHEMA IF NOT EXISTS ", schema, " AUTHORIZATION CURRENT_USER;\n",
+    "  GRANT ALL ON SCHEMA ", schema ," TO CURRENT_USER;\n",
     "  SET SCHEMA ",  self:escape_literal(self.config.schema), ";\n",
     "COMMIT;",
   })
@@ -628,12 +626,10 @@ function _mt:schema_bootstrap(kong_config, default_locks_ttl)
   logger.debug("creating '%s' schema if not existing...", self.config.schema)
 
   local schema = self:escape_identifier(self.config.schema)
-  local user = self:escape_identifier(self.config.user)
-
   local ok, err = self:query(concat {
     "BEGIN;\n",
-    "  CREATE SCHEMA IF NOT EXISTS ", schema, " AUTHORIZATION ", user, ";\n",
-    "  GRANT ALL ON SCHEMA ", schema ," TO ", user, ";\n",
+    "  CREATE SCHEMA IF NOT EXISTS ", schema, " AUTHORIZATION CURRENT_USER;\n",
+    "  GRANT ALL ON SCHEMA ", schema ," TO CURRENT_USER;\n",
     "  SET SCHEMA ",  self:escape_literal(self.config.schema), ";\n",
     "COMMIT;",
   })
@@ -682,13 +678,11 @@ function _mt:schema_reset()
   end
 
   local schema = self:escape_identifier(self.config.schema)
-  local user = self:escape_identifier(self.config.user)
-
   local ok, err = self:query(concat {
     "BEGIN;\n",
     "  DROP SCHEMA IF EXISTS ", schema, " CASCADE;\n",
-    "  CREATE SCHEMA IF NOT EXISTS ", schema, " AUTHORIZATION ", user, ";\n",
-    "  GRANT ALL ON SCHEMA ", schema ," TO ", user, ";\n",
+    "  CREATE SCHEMA IF NOT EXISTS ", schema, " AUTHORIZATION CURRENT_USER;\n",
+    "  GRANT ALL ON SCHEMA ", schema ," TO CURRENT_USER;\n",
     "  SET SCHEMA ",  self:escape_literal(self.config.schema), ";\n",
     "COMMIT;",
   })


### PR DESCRIPTION
### Summary

This PR tries to make Postgres schema bootstrapping and resetting more robust in scenarios where the username used to connect Postgres database has limited permissions (e.g. unable to drop or create schemes), see #4483.

It also fixes issue with (Azure Postgres) username indirection, see: #4502.

### Issues resolved

Fix #4483, #4502
