### PR TITLE
fix(core) prevent declarative_config from causing problems in DB mode

### DIFF
--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -563,6 +563,10 @@ local function parse_listeners(values, flags)
   local usage = "must be of form: [off] | <ip>:<port> [" ..
                 concat(flags, "] [") .. "], [... next entry ...]"
 
+  if #values == 0 then
+    return nil, usage
+  end
+
   if pl_stringx.strip(values[1]) == "off" then
     return list
   end

--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -428,7 +428,7 @@ local function check_and_infer(conf)
 
   -- checking the trusted ips
   for _, address in ipairs(conf.trusted_ips) do
-    if not ip.valid(address) and not address == "unix:" then
+    if not ip.valid(address) and address ~= "unix:" then
       errors[#errors + 1] = "trusted_ips must be a comma separated list in " ..
                             "the form of IPv4 or IPv6 address or CIDR "      ..
                             "block or 'unix:', got '" .. address .. "'"

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -251,7 +251,7 @@ end
 
 
 local function load_declarative_config(kong_config, entities)
-  if not kong_config.database == "off" then
+  if kong_config.database ~= "off" then
     return true
   end
 

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -475,6 +475,19 @@ describe("Configuration loader", function()
       assert.is_nil(conf)
       assert.equal("proxy_listen must be of form: [off] | <ip>:<port> [ssl] [http2] [proxy_protocol] [transparent], [... next entry ...]", err)
     end)
+    it("rejects empty string in listen addresses", function()
+      local conf, err = conf_loader(nil, {
+        admin_listen = ""
+      })
+      assert.is_nil(conf)
+      assert.equal("admin_listen must be of form: [off] | <ip>:<port> [ssl] [http2] [proxy_protocol] [transparent], [... next entry ...]", err)
+
+      conf, err = conf_loader(nil, {
+        proxy_listen = ""
+      })
+      assert.is_nil(conf)
+      assert.equal("proxy_listen must be of form: [off] | <ip>:<port> [ssl] [http2] [proxy_protocol] [transparent], [... next entry ...]", err)
+    end)
     it("errors when dns_resolver is not a list in ipv4/6[:port] format", function()
       local conf, err = conf_loader(nil, {
         dns_resolver = "1.2.3.4:53;4.3.2.1" -- ; as separator


### PR DESCRIPTION
This is a complement to db28453.

When the `declarative_config` entry is set in `kong.conf` alongside `database=postgres` or `database=cassandra`, this caused the initialization of declarative config from DB-less mode to trigger incorrectly in DB mode, causing problems with worker initialization. This commit fixes the issue.

Includes a regression test that demonstrates the problem.

Fixes #4508. Thanks @pamiel for reporting!

Also, this PR includes two other minor fixes for things that came up while fixing this bug:

* when `admin_listener = ` (with no value) in `kong.conf` (I forgot about `off`), we were getting a crash inside Penlight, which translated to a cryptic error message to the user ("error in argument 1: got nil, expected string"). Now we get a proper usage message.
* fix check of "unix:" for trusted_ips property - found while grepping for more occurrences of the `not x == "y"` mistake