### PR TITLE
feat(request-transformer) validate header values in plugin configuration

### DIFF
--- a/kong/plugins/request-transformer/schema.lua
+++ b/kong/plugins/request-transformer/schema.lua
@@ -1,4 +1,25 @@
 local typedefs = require "kong.db.schema.typedefs"
+local validate_header_name = require("kong.tools.utils").validate_header_name
+
+
+local function validate_headers(pair, validate_value)
+  local name, value = pair:match("^([^:]+):*(.-)$")
+  if validate_header_name(name) == nil then
+    return nil, string.format("'%s' is not a valid header", tostring(name))
+  end
+
+  if validate_value then
+    if validate_header_name(value) == nil then
+      return nil, string.format("'%s' is not a valid header", tostring(value))
+    end
+  end
+  return true
+end
+
+
+local function validate_colon_headers(pair)
+  return validate_headers(pair, true)
+end
 
 
 local strings_array = {
@@ -8,11 +29,18 @@ local strings_array = {
 }
 
 
+local headers_array = {
+  type = "array",
+  default = {},
+  elements = { type = "string", custom_validator = validate_headers },
+}
+
+
 local strings_array_record = {
   type = "record",
   fields = {
     { body = strings_array },
-    { headers = strings_array },
+    { headers = headers_array },
     { querystring = strings_array },
   },
 }
@@ -24,12 +52,35 @@ local colon_strings_array = {
   elements = { type = "string", match = "^[^:]+:.*$" },
 }
 
+local colon_headers_array = {
+  type = "array",
+  default = {},
+  elements = { type = "string", match = "^[^:]+:.*$", custom_validator = validate_colon_headers },
+}
+
+
+local colon_header_value_array = {
+  type = "array",
+  default = {},
+  elements = { type = "string", match = "^[^:]+:.*$", custom_validator = validate_headers },
+}
+
 
 local colon_strings_array_record = {
   type = "record",
   fields = {
     { body = colon_strings_array },
-    { headers = colon_strings_array },
+    { headers = colon_header_value_array },
+    { querystring = colon_strings_array },
+  },
+}
+
+
+local colon_rename_strings_array_record = {
+  type = "record",
+  fields = {
+    { body = colon_strings_array },
+    { headers = colon_headers_array },
     { querystring = colon_strings_array },
   },
 }
@@ -45,7 +96,7 @@ return {
         fields = {
           { http_method = typedefs.http_method },
           { remove  = strings_array_record },
-          { rename  = colon_strings_array_record },
+          { rename  = colon_rename_strings_array_record },
           { replace = colon_strings_array_record },
           { add     = colon_strings_array_record },
           { append  = colon_strings_array_record },

--- a/spec/03-plugins/14-request-transformer/01-schema_spec.lua
+++ b/spec/03-plugins/14-request-transformer/01-schema_spec.lua
@@ -13,4 +13,146 @@ describe("Plugin: request-transformer (schema)", function()
     assert.falsy(ok)
     assert.equal("invalid value: HELLO!", err.config.http_method)
   end)
+
+  describe("remove", function()
+    it("accepts remove headers", function()
+      local remove_input = {
+        headers = {
+          "valid"
+        }
+      }
+      local ok, err = v({ remove = remove_input }, schema_def)
+      assert.truthy(ok)
+      assert.falsy(err)
+    end)
+    it("rejects remove invalid headers", function()
+      local remove_input = {
+        headers = {
+          "%invalid%"
+        }
+      }
+      local ok, err = v({ remove = remove_input }, schema_def)
+      assert.falsy(ok)
+      assert.equal("'%invalid%' is not a valid header", err.config.remove.headers[1])
+    end)
+  end)
+
+  describe("rename", function()
+    it("accepts rename headers", function()
+      local rename_input = {
+        headers = {
+          "valid:valid"
+        }
+      }
+      local ok, err = v({ rename = rename_input }, schema_def)
+      assert.truthy(ok)
+      assert.falsy(err)
+    end)
+    it("rejects rename from valid headers to invalid headers", function()
+      local rename_input = {
+        headers = {
+          "valid:%invalid%"
+        }
+      }
+      local ok, err = v({ rename = rename_input }, schema_def)
+      assert.falsy(ok)
+      assert.equal("'%invalid%' is not a valid header", err.config.rename.headers[1])
+    end)
+    it("rejects rename from invalid headers to valid headers", function()
+      local rename_input = {
+        headers = {
+          "%invalid%:valid"
+        }
+      }
+      local ok, err = v({ rename = rename_input }, schema_def)
+      assert.falsy(ok)
+      assert.equal("'%invalid%' is not a valid header", err.config.rename.headers[1])
+    end)
+    it("rejects rename from invalid headers to invalid headers", function()
+      local rename_input = {
+        headers = {
+          "%invalid%:%invalid%"
+        }
+      }
+      local ok, err = v({ rename = rename_input }, schema_def)
+      assert.falsy(ok)
+      assert.equal("'%invalid%' is not a valid header", err.config.rename.headers[1])
+    end)
+  end)
+
+  describe("replace", function()
+    it("accepts replace headers", function()
+      local replace_input = {
+        headers = {
+          "valid:value"
+        }
+      }
+      local ok, err = v({ replace = replace_input }, schema_def)
+      assert.truthy(ok)
+      assert.falsy(err)
+    end)
+    it("rejects replace invalid headers", function()
+      local replace_input = {
+        headers = {
+          "%invalid%:value"
+        }
+      }
+      local ok, err = v({ replace = replace_input }, schema_def)
+      assert.falsy(ok)
+      assert.equal("'%invalid%' is not a valid header", err.config.replace.headers[1])
+    end)
+  end)
+
+  describe("add", function()
+    it("accepts add headers", function()
+      local add_input = {
+        headers = {
+          "valid:value"
+        }
+      }
+      local ok, err = v({ add = add_input }, schema_def)
+      assert.truthy(ok)
+      assert.falsy(err)
+    end)
+    it("rejects add invalid headers", function()
+      local add_input = {
+        headers = {
+          "%invalid%:value"
+        }
+      }
+      local ok, err = v({ add = add_input }, schema_def)
+      assert.falsy(ok)
+      assert.equal("'%invalid%' is not a valid header", err.config.add.headers[1])
+    end)
+  end)
+
+  describe("append", function()
+    it("accepts append headers", function()
+      local append_input = {
+        headers = {
+          "valid:value",
+          "valid: value",
+          "-_ABCDabcd123456:value"
+        }
+      }
+      local ok, err = v({ append = append_input }, schema_def)
+      assert.truthy(ok)
+      assert.falsy(err)
+    end)
+    it("rejects append invalid headers", function()
+      local append_input = {
+        headers = {
+          "%invalid%:value",
+          "invalid header:value",
+          "'*':value"
+        }
+      }
+      local ok, err = v({ append = append_input }, schema_def)
+      assert.falsy(ok)
+      assert.equal("'%invalid%' is not a valid header", err.config.append.headers[1])
+      assert.equal("'invalid header' is not a valid header", err.config.append.headers[2])
+      assert.equal("'\'*\'' is not a valid header", err.config.append.headers[3])
+    end)
+  end)
+
 end)


### PR DESCRIPTION
### Summary

Header-related configurations of request transformer are not validated. Invalid header value configurations would be accepted but the invalid headers are not properly transformed previously. This commit adds validations for header fields.

### Full changelog
* Add request-trasnformer plugin validation
* Add related tests
