### PR TITLE
refactor(migrations) make postgres migrations reentrant

### DIFF
--- a/kong/db/migrations/core/000_base.lua
+++ b/kong/db/migrations/core/000_base.lua
@@ -11,8 +11,19 @@ return {
         "data"       TEXT
       );
 
-      CREATE INDEX IF NOT EXISTS "idx_cluster_events_at"      ON "cluster_events" ("at");
-      CREATE INDEX IF NOT EXISTS "idx_cluster_events_channel" ON "cluster_events" ("channel");
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS "idx_cluster_events_at" ON "cluster_events" ("at");
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
+
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS "idx_cluster_events_channel" ON "cluster_events" ("channel");
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
 
       CREATE OR REPLACE FUNCTION "delete_expired_cluster_events" () RETURNS TRIGGER
       LANGUAGE plpgsql
@@ -64,7 +75,12 @@ return {
 
       );
 
-      CREATE INDEX IF NOT EXISTS "routes_fkey_service" ON "routes" ("service_id");
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS "routes_fkey_service" ON "routes" ("service_id");
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
 
 
 
@@ -112,7 +128,12 @@ return {
         "custom_id"   TEXT                         UNIQUE
       );
 
-      CREATE INDEX IF NOT EXISTS "username_idx" ON "consumers" (LOWER("username"));
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS "username_idx" ON "consumers" (LOWER("username"));
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
 
 
 
@@ -130,11 +151,40 @@ return {
         PRIMARY KEY ("id", "name")
       );
 
-      CREATE INDEX IF NOT EXISTS "plugins_name_idx"       ON "plugins" ("name");
-      CREATE INDEX IF NOT EXISTS "plugins_consumer_idx"   ON "plugins" ("consumer_id");
-      CREATE INDEX IF NOT EXISTS "plugins_service_id_idx" ON "plugins" ("service_id");
-      CREATE INDEX IF NOT EXISTS "plugins_route_id_idx"   ON "plugins" ("route_id");
-      CREATE INDEX IF NOT EXISTS "plugins_api_idx"        ON "plugins" ("api_id");
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS "plugins_name_idx" ON "plugins" ("name");
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
+
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS "plugins_consumer_idx" ON "plugins" ("consumer_id");
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
+
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS "plugins_service_id_idx" ON "plugins" ("service_id");
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
+
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS "plugins_route_id_idx" ON "plugins" ("route_id");
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
+
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS "plugins_api_idx" ON "plugins" ("api_id");
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
 
 
 
@@ -162,7 +212,12 @@ return {
         "weight"       INTEGER                      NOT NULL
       );
 
-      CREATE INDEX IF NOT EXISTS "targets_target_idx" ON "targets" ("target");
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS "targets_target_idx" ON "targets" ("target");
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
 
 
 
@@ -177,7 +232,12 @@ return {
         PRIMARY KEY ("primary_key_value", "table_name")
       );
 
-      CREATE INDEX IF NOT EXISTS "ttls_primary_uuid_value_idx" ON "ttls" ("primary_uuid_value");
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS "ttls_primary_uuid_value_idx" ON "ttls" ("primary_uuid_value");
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
 
       CREATE OR REPLACE FUNCTION "upsert_ttl" (v_primary_key_value TEXT, v_primary_uuid_value UUID, v_primary_key_name TEXT, v_table_name TEXT, v_expire_at TIMESTAMP WITHOUT TIME ZONE) RETURNS void
       LANGUAGE plpgsql

--- a/kong/db/migrations/core/001_14_to_15.lua
+++ b/kong/db/migrations/core/001_14_to_15.lua
@@ -35,7 +35,12 @@ return {
 
 
 
-      CREATE INDEX IF NOT EXISTS "targets_upstream_id_idx" ON "targets" ("upstream_id");
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS "targets_upstream_id_idx" ON "targets" ("upstream_id");
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
 
 
 
@@ -127,7 +132,12 @@ return {
       END;
       $$;
 
-      CREATE INDEX IF NOT EXISTS "snis_certificate_id_idx" ON "snis" ("certificate_id");
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS "snis_certificate_id_idx" ON "snis" ("certificate_id");
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
 
       DO $$
       BEGIN
@@ -149,10 +159,7 @@ return {
       BEGIN
         ALTER TABLE IF EXISTS ONLY "snis"
           RENAME CONSTRAINT "snis_name_unique" TO "snis_name_key";
-      EXCEPTION
-        WHEN UNDEFINED_OBJECT THEN
-          -- Do nothing, accept existing state
-        WHEN DUPLICATE_TABLE THEN
+      EXCEPTION WHEN UNDEFINED_OBJECT OR DUPLICATE_TABLE THEN
           -- Do nothing, accept existing state
       END;
       $$;
@@ -165,37 +172,82 @@ return {
       END;
       $$;
 
-      CREATE INDEX IF NOT EXISTS "plugins_run_on_idx" ON "plugins" ("run_on");
-
-
-      ALTER TABLE IF EXISTS ONLY "apis"
-        ALTER "created_at" TYPE TIMESTAMP WITH TIME ZONE USING "created_at" AT TIME ZONE 'UTC',
-        ALTER "created_at" SET DEFAULT CURRENT_TIMESTAMP(3) AT TIME ZONE 'UTC';
-
-      ALTER TABLE IF EXISTS ONLY "consumers"
-        ALTER "created_at" TYPE TIMESTAMP WITH TIME ZONE USING "created_at" AT TIME ZONE 'UTC',
-        ALTER "created_at" SET DEFAULT CURRENT_TIMESTAMP(0) AT TIME ZONE 'UTC';
-
-      ALTER TABLE IF EXISTS ONLY "plugins"
-        ALTER "config"     TYPE JSONB USING "config"::JSONB,
-        ALTER "created_at" TYPE TIMESTAMP WITH TIME ZONE USING "created_at" AT TIME ZONE 'UTC',
-        ALTER "created_at" SET DEFAULT CURRENT_TIMESTAMP(0) AT TIME ZONE 'UTC';
-
-      ALTER TABLE IF EXISTS ONLY "upstreams"
-        ALTER "healthchecks" TYPE JSONB USING "healthchecks"::JSONB,
-        ALTER "created_at"   TYPE TIMESTAMP WITH TIME ZONE USING "created_at" AT TIME ZONE 'UTC',
-        ALTER "created_at"   SET DEFAULT CURRENT_TIMESTAMP(3) AT TIME ZONE 'UTC';
-
-      ALTER TABLE IF EXISTS ONLY "targets"
-        ALTER "created_at" TYPE TIMESTAMP WITH TIME ZONE USING "created_at" AT TIME ZONE 'UTC',
-        ALTER "created_at" SET DEFAULT CURRENT_TIMESTAMP(3) AT TIME ZONE 'UTC';
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS "plugins_run_on_idx" ON "plugins" ("run_on");
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
 
 
 
-      CREATE TABLE IF NOT EXISTS cluster_ca(
-        pk boolean NOT NULL PRIMARY KEY CHECK(pk=true),
-        key text NOT NULL,
-        cert text NOT NULL
+      DO $$
+      BEGIN
+        ALTER TABLE IF EXISTS ONLY "apis"
+          ALTER "created_at" TYPE TIMESTAMP WITH TIME ZONE USING "created_at" AT TIME ZONE 'UTC',
+          ALTER "created_at" SET DEFAULT CURRENT_TIMESTAMP(3) AT TIME ZONE 'UTC';
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
+
+      DO $$
+      BEGIN
+        ALTER TABLE IF EXISTS ONLY "consumers"
+          ALTER "created_at" TYPE TIMESTAMP WITH TIME ZONE USING "created_at" AT TIME ZONE 'UTC',
+          ALTER "created_at" SET DEFAULT CURRENT_TIMESTAMP(0) AT TIME ZONE 'UTC';
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
+
+      DO $$
+      BEGIN
+        ALTER TABLE IF EXISTS ONLY "plugins"
+          ALTER "config" TYPE JSONB USING "config"::JSONB;
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
+
+      DO $$
+      BEGIN
+        ALTER TABLE IF EXISTS ONLY "plugins"
+          ALTER "created_at" TYPE TIMESTAMP WITH TIME ZONE USING "created_at" AT TIME ZONE 'UTC',
+          ALTER "created_at" SET DEFAULT CURRENT_TIMESTAMP(0) AT TIME ZONE 'UTC';
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
+
+      DO $$
+      BEGIN
+        ALTER TABLE IF EXISTS ONLY "upstreams"
+          ALTER "healthchecks" TYPE JSONB USING "healthchecks"::JSONB;
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
+
+      DO $$
+      BEGIN
+        ALTER TABLE IF EXISTS ONLY "upstreams"
+          ALTER "created_at"   TYPE TIMESTAMP WITH TIME ZONE USING "created_at" AT TIME ZONE 'UTC',
+          ALTER "created_at"   SET DEFAULT CURRENT_TIMESTAMP(3) AT TIME ZONE 'UTC';
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
+
+      DO $$
+      BEGIN
+        ALTER TABLE IF EXISTS ONLY "targets"
+          ALTER "created_at" TYPE TIMESTAMP WITH TIME ZONE USING "created_at" AT TIME ZONE 'UTC',
+          ALTER "created_at" SET DEFAULT CURRENT_TIMESTAMP(3) AT TIME ZONE 'UTC';
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
+
+
+
+      CREATE TABLE IF NOT EXISTS "cluster_ca" (
+        "pk"    BOOLEAN  NOT NULL  PRIMARY KEY CHECK(pk=true),
+        "key"   TEXT     NOT NULL,
+        "cert"  TEXT     NOT NULL
       );
     ]],
 

--- a/kong/db/migrations/core/002_15_to_1.lua
+++ b/kong/db/migrations/core/002_15_to_1.lua
@@ -5,7 +5,12 @@ return {
 
     teardown = function(connector)
       assert(connector:query([[
-        DELETE FROM plugins WHERE name = 'galileo';
+        DO $$
+        BEGIN
+          DELETE FROM plugins WHERE name = 'galileo';
+        EXCEPTION WHEN UNDEFINED_COLUMN OR UNDEFINED_TABLE THEN
+          -- Do nothing, accept existing state
+        END$$;
       ]]))
     end,
   },

--- a/kong/db/migrations/core/003_100_to_110.lua
+++ b/kong/db/migrations/core/003_100_to_110.lua
@@ -1,11 +1,34 @@
 return {
   postgres = {
     up = [[
+      DO $$
+      BEGIN
+        UPDATE consumers SET created_at = DATE_TRUNC('seconds', created_at);
+      EXCEPTION WHEN UNDEFINED_COLUMN OR UNDEFINED_TABLE THEN
+        -- Do nothing, accept existing state
+      END$$;
 
-      UPDATE consumers SET created_at = DATE_TRUNC('seconds', created_at);
-      UPDATE plugins   SET created_at = DATE_TRUNC('seconds', created_at);
-      UPDATE upstreams SET created_at = DATE_TRUNC('seconds', created_at);
-      UPDATE targets   SET created_at = DATE_TRUNC('milliseconds', created_at);
+      DO $$
+      BEGIN
+        UPDATE plugins SET created_at = DATE_TRUNC('seconds', created_at);
+      EXCEPTION WHEN UNDEFINED_COLUMN OR UNDEFINED_TABLE THEN
+        -- Do nothing, accept existing state
+      END$$;
+
+      DO $$
+      BEGIN
+        UPDATE upstreams SET created_at = DATE_TRUNC('seconds', created_at);
+      EXCEPTION WHEN UNDEFINED_COLUMN OR UNDEFINED_TABLE THEN
+        -- Do nothing, accept existing state
+      END$$;
+
+      DO $$
+      BEGIN
+        UPDATE targets SET created_at = DATE_TRUNC('milliseconds', created_at);
+      EXCEPTION WHEN UNDEFINED_COLUMN OR UNDEFINED_TABLE THEN
+        -- Do nothing, accept existing state
+      END$$;
+
 
       DROP FUNCTION IF EXISTS "upsert_ttl" (TEXT, UUID, TEXT, TEXT, TIMESTAMP WITHOUT TIME ZONE);
 
@@ -23,10 +46,23 @@ return {
         tags              TEXT[]
       );
 
-      CREATE INDEX IF NOT EXISTS tags_entity_name_idx ON tags(entity_name);
-      CREATE INDEX IF NOT EXISTS tags_tags_idx ON tags USING GIN(tags);
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS tags_entity_name_idx ON tags(entity_name);
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
 
-      CREATE OR REPLACE FUNCTION sync_tags() RETURNS trigger AS $sync_tags$
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS tags_tags_idx ON tags USING GIN(tags);
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
+
+      CREATE OR REPLACE FUNCTION sync_tags() RETURNS trigger
+      LANGUAGE plpgsql
+      AS $$
         BEGIN
           IF (TG_OP = 'TRUNCATE') THEN
             DELETE FROM tags WHERE entity_name = TG_TABLE_NAME;
@@ -45,7 +81,7 @@ return {
           END IF;
           RETURN NEW;
         END;
-      $sync_tags$ LANGUAGE plpgsql;
+      $$;
 
       DO $$
       BEGIN
@@ -55,14 +91,24 @@ return {
       END;
       $$;
 
-      CREATE INDEX IF NOT EXISTS services_tags_idx ON services USING GIN(tags);
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS services_tags_idx ON services USING GIN(tags);
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
 
       DROP TRIGGER IF EXISTS services_sync_tags_trigger ON services;
 
-      CREATE TRIGGER services_sync_tags_trigger
-      AFTER INSERT OR UPDATE OF tags OR DELETE ON services
-      FOR EACH ROW
-      EXECUTE PROCEDURE sync_tags();
+      DO $$
+      BEGIN
+        CREATE TRIGGER services_sync_tags_trigger
+        AFTER INSERT OR UPDATE OF tags OR DELETE ON services
+        FOR EACH ROW
+        EXECUTE PROCEDURE sync_tags();
+      EXCEPTION WHEN UNDEFINED_COLUMN OR UNDEFINED_TABLE THEN
+        -- Do nothing, accept existing state
+      END$$;
 
 
       DO $$
@@ -73,15 +119,24 @@ return {
       END;
       $$;
 
-      CREATE INDEX IF NOT EXISTS routes_tags_idx ON routes USING GIN(tags);
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS routes_tags_idx ON routes USING GIN(tags);
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
 
       DROP TRIGGER IF EXISTS routes_sync_tags_trigger ON routes;
 
-      CREATE TRIGGER routes_sync_tags_trigger
-      AFTER INSERT OR UPDATE OF tags OR DELETE ON routes
-      FOR EACH ROW
-      EXECUTE PROCEDURE sync_tags();
-
+      DO $$
+      BEGIN
+        CREATE TRIGGER routes_sync_tags_trigger
+        AFTER INSERT OR UPDATE OF tags OR DELETE ON routes
+        FOR EACH ROW
+        EXECUTE PROCEDURE sync_tags();
+      EXCEPTION WHEN UNDEFINED_COLUMN OR UNDEFINED_TABLE THEN
+        -- Do nothing, accept existing state
+      END$$;
 
       DO $$
       BEGIN
@@ -91,14 +146,24 @@ return {
       END;
       $$;
 
-      CREATE INDEX IF NOT EXISTS certificates_tags_idx ON certificates USING GIN(tags);
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS certificates_tags_idx ON certificates USING GIN(tags);
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
 
       DROP TRIGGER IF EXISTS certificates_sync_tags_trigger ON certificates;
 
-      CREATE TRIGGER certificates_sync_tags_trigger
-      AFTER INSERT OR UPDATE OF tags OR DELETE ON certificates
-      FOR EACH ROW
-      EXECUTE PROCEDURE sync_tags();
+      DO $$
+      BEGIN
+        CREATE TRIGGER certificates_sync_tags_trigger
+        AFTER INSERT OR UPDATE OF tags OR DELETE ON certificates
+        FOR EACH ROW
+        EXECUTE PROCEDURE sync_tags();
+      EXCEPTION WHEN UNDEFINED_COLUMN OR UNDEFINED_TABLE THEN
+        -- Do nothing, accept existing state
+      END$$;
 
 
       DO $$
@@ -109,14 +174,24 @@ return {
       END;
       $$;
 
-      CREATE INDEX IF NOT EXISTS snis_tags_idx ON snis USING GIN(tags);
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS snis_tags_idx ON snis USING GIN(tags);
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
 
       DROP TRIGGER IF EXISTS snis_sync_tags_trigger ON snis;
 
-      CREATE TRIGGER snis_sync_tags_trigger
-      AFTER INSERT OR UPDATE OF tags OR DELETE ON snis
-      FOR EACH ROW
-      EXECUTE PROCEDURE sync_tags();
+      DO $$
+      BEGIN
+        CREATE TRIGGER snis_sync_tags_trigger
+        AFTER INSERT OR UPDATE OF tags OR DELETE ON snis
+        FOR EACH ROW
+        EXECUTE PROCEDURE sync_tags();
+      EXCEPTION WHEN UNDEFINED_COLUMN OR UNDEFINED_TABLE THEN
+        -- Do nothing, accept existing state
+      END$$;
 
 
       DO $$
@@ -127,14 +202,24 @@ return {
       END;
       $$;
 
-      CREATE INDEX IF NOT EXISTS consumers_tags_idx ON consumers USING GIN(tags);
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS consumers_tags_idx ON consumers USING GIN(tags);
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
 
       DROP TRIGGER IF EXISTS consumers_sync_tags_trigger ON consumers;
 
-      CREATE TRIGGER consumers_sync_tags_trigger
-      AFTER INSERT OR UPDATE OF tags OR DELETE ON consumers
-      FOR EACH ROW
-      EXECUTE PROCEDURE sync_tags();
+      DO $$
+      BEGIN
+        CREATE TRIGGER consumers_sync_tags_trigger
+        AFTER INSERT OR UPDATE OF tags OR DELETE ON consumers
+        FOR EACH ROW
+        EXECUTE PROCEDURE sync_tags();
+      EXCEPTION WHEN UNDEFINED_COLUMN OR UNDEFINED_TABLE THEN
+        -- Do nothing, accept existing state
+      END$$;
 
 
       DO $$
@@ -145,14 +230,24 @@ return {
       END;
       $$;
 
-      CREATE INDEX IF NOT EXISTS plugins_tags_idx ON plugins USING GIN(tags);
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS plugins_tags_idx ON plugins USING GIN(tags);
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
 
       DROP TRIGGER IF EXISTS plugins_sync_tags_trigger ON plugins;
 
-      CREATE TRIGGER plugins_sync_tags_trigger
-      AFTER INSERT OR UPDATE OF tags OR DELETE ON plugins
-      FOR EACH ROW
-      EXECUTE PROCEDURE sync_tags();
+      DO $$
+      BEGIN
+        CREATE TRIGGER plugins_sync_tags_trigger
+        AFTER INSERT OR UPDATE OF tags OR DELETE ON plugins
+        FOR EACH ROW
+        EXECUTE PROCEDURE sync_tags();
+      EXCEPTION WHEN UNDEFINED_COLUMN OR UNDEFINED_TABLE THEN
+        -- Do nothing, accept existing state
+      END$$;
 
 
       DO $$
@@ -163,14 +258,24 @@ return {
       END;
       $$;
 
-      CREATE INDEX IF NOT EXISTS upstreams_tags_idx ON upstreams USING GIN(tags);
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS upstreams_tags_idx ON upstreams USING GIN(tags);
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
 
       DROP TRIGGER IF EXISTS upstreams_sync_tags_trigger ON upstreams;
 
-      CREATE TRIGGER upstreams_sync_tags_trigger
-      AFTER INSERT OR UPDATE OF tags OR DELETE ON upstreams
-      FOR EACH ROW
-      EXECUTE PROCEDURE sync_tags();
+      DO $$
+      BEGIN
+        CREATE TRIGGER upstreams_sync_tags_trigger
+        AFTER INSERT OR UPDATE OF tags OR DELETE ON upstreams
+        FOR EACH ROW
+        EXECUTE PROCEDURE sync_tags();
+      EXCEPTION WHEN UNDEFINED_COLUMN OR UNDEFINED_TABLE THEN
+        -- Do nothing, accept existing state
+      END$$;
 
 
       DO $$
@@ -181,15 +286,24 @@ return {
       END;
       $$;
 
-      CREATE INDEX IF NOT EXISTS targets_tags_idx ON targets USING GIN(tags);
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS targets_tags_idx ON targets USING GIN(tags);
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
 
       DROP TRIGGER IF EXISTS targets_sync_tags_trigger ON targets;
 
-      CREATE TRIGGER targets_sync_tags_trigger
-      AFTER INSERT OR UPDATE OF tags OR DELETE ON targets
-      FOR EACH ROW
-      EXECUTE PROCEDURE sync_tags();
-
+      DO $$
+      BEGIN
+        CREATE TRIGGER targets_sync_tags_trigger
+        AFTER INSERT OR UPDATE OF tags OR DELETE ON targets
+        FOR EACH ROW
+        EXECUTE PROCEDURE sync_tags();
+      EXCEPTION WHEN UNDEFINED_COLUMN OR UNDEFINED_TABLE THEN
+        -- Do nothing, accept existing state
+      END$$;
 
     ]],
   },

--- a/kong/plugins/acl/migrations/000_base_acl.lua
+++ b/kong/plugins/acl/migrations/000_base_acl.lua
@@ -8,8 +8,19 @@ return {
         "group"        TEXT
       );
 
-      CREATE INDEX IF NOT EXISTS "acls_consumer_id" ON "acls" ("consumer_id");
-      CREATE INDEX IF NOT EXISTS "acls_group"       ON "acls" ("group");
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS "acls_consumer_id" ON "acls" ("consumer_id");
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
+
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS "acls_group" ON "acls" ("group");
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
     ]],
   },
 

--- a/kong/plugins/acl/migrations/001_14_to_15.lua
+++ b/kong/plugins/acl/migrations/001_14_to_15.lua
@@ -9,9 +9,15 @@ return {
       END;
       $$;
 
-      ALTER TABLE IF EXISTS ONLY "acls"
-        ALTER "created_at" TYPE TIMESTAMP WITH TIME ZONE USING "created_at" AT TIME ZONE 'UTC',
-        ALTER "created_at" SET DEFAULT CURRENT_TIMESTAMP(0) AT TIME ZONE 'UTC';
+      DO $$
+      BEGIN
+        ALTER TABLE IF EXISTS ONLY "acls"
+          ALTER "created_at" TYPE TIMESTAMP WITH TIME ZONE USING "created_at" AT TIME ZONE 'UTC',
+          ALTER "created_at" SET DEFAULT CURRENT_TIMESTAMP(0) AT TIME ZONE 'UTC';
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
+
 
       DO $$
       BEGIN

--- a/kong/plugins/basic-auth/migrations/000_base_basic_auth.lua
+++ b/kong/plugins/basic-auth/migrations/000_base_basic_auth.lua
@@ -9,7 +9,12 @@ return {
         "password"     TEXT
       );
 
-      CREATE INDEX IF NOT EXISTS "basicauth_consumer_id_idx" ON "basicauth_credentials" ("consumer_id");
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS "basicauth_consumer_id_idx" ON "basicauth_credentials" ("consumer_id");
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
     ]],
   },
 

--- a/kong/plugins/basic-auth/migrations/001_14_to_15.lua
+++ b/kong/plugins/basic-auth/migrations/001_14_to_15.lua
@@ -1,9 +1,14 @@
 return {
   postgres = {
     up = [[
-      ALTER TABLE IF EXISTS ONLY "basicauth_credentials"
-        ALTER "created_at" TYPE TIMESTAMP WITH TIME ZONE USING "created_at" AT TIME ZONE 'UTC',
-        ALTER "created_at" SET DEFAULT CURRENT_TIMESTAMP(0) AT TIME ZONE 'UTC';
+      DO $$
+      BEGIN
+        ALTER TABLE IF EXISTS ONLY "basicauth_credentials"
+          ALTER "created_at" TYPE TIMESTAMP WITH TIME ZONE USING "created_at" AT TIME ZONE 'UTC',
+          ALTER "created_at" SET DEFAULT CURRENT_TIMESTAMP(0) AT TIME ZONE 'UTC';
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
 
       -- Unique constraint on "username" already adds btree index
       DROP INDEX IF EXISTS "basicauth_username_idx";

--- a/kong/plugins/hmac-auth/migrations/000_base_hmac_auth.lua
+++ b/kong/plugins/hmac-auth/migrations/000_base_hmac_auth.lua
@@ -9,7 +9,12 @@ return {
         "secret"       TEXT
       );
 
-      CREATE INDEX IF NOT EXISTS "hmacauth_credentials_consumer_id" ON "hmacauth_credentials" ("consumer_id");
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS "hmacauth_credentials_consumer_id" ON "hmacauth_credentials" ("consumer_id");
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
     ]],
   },
 

--- a/kong/plugins/hmac-auth/migrations/001_14_to_15.lua
+++ b/kong/plugins/hmac-auth/migrations/001_14_to_15.lua
@@ -1,9 +1,14 @@
 return {
   postgres = {
     up = [[
-      ALTER TABLE IF EXISTS ONLY "hmacauth_credentials"
-        ALTER "created_at" TYPE TIMESTAMP WITH TIME ZONE USING "created_at" AT TIME ZONE 'UTC',
-        ALTER "created_at" SET DEFAULT CURRENT_TIMESTAMP(0) AT TIME ZONE 'UTC';
+      DO $$
+      BEGIN
+        ALTER TABLE IF EXISTS ONLY "hmacauth_credentials"
+          ALTER "created_at" TYPE TIMESTAMP WITH TIME ZONE USING "created_at" AT TIME ZONE 'UTC',
+          ALTER "created_at" SET DEFAULT CURRENT_TIMESTAMP(0) AT TIME ZONE 'UTC';
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
 
       DO $$
       BEGIN

--- a/kong/plugins/jwt/migrations/000_base_jwt.lua
+++ b/kong/plugins/jwt/migrations/000_base_jwt.lua
@@ -11,8 +11,19 @@ return {
         "rsa_public_key"  TEXT
       );
 
-      CREATE INDEX IF NOT EXISTS "jwt_secrets_consumer_id" ON "jwt_secrets" ("consumer_id");
-      CREATE INDEX IF NOT EXISTS "jwt_secrets_secret"      ON "jwt_secrets" ("secret");
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS "jwt_secrets_consumer_id" ON "jwt_secrets" ("consumer_id");
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
+
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS "jwt_secrets_secret" ON "jwt_secrets" ("secret");
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
     ]],
   },
 

--- a/kong/plugins/jwt/migrations/001_14_to_15.lua
+++ b/kong/plugins/jwt/migrations/001_14_to_15.lua
@@ -1,9 +1,14 @@
 return {
   postgres = {
     up = [[
-      ALTER TABLE IF EXISTS ONLY "jwt_secrets"
-        ALTER "created_at" TYPE TIMESTAMP WITH TIME ZONE USING "created_at" AT TIME ZONE 'UTC',
-        ALTER "created_at" SET DEFAULT CURRENT_TIMESTAMP(0) AT TIME ZONE 'UTC';
+      DO $$
+      BEGIN
+        ALTER TABLE IF EXISTS ONLY "jwt_secrets"
+          ALTER "created_at" TYPE TIMESTAMP WITH TIME ZONE USING "created_at" AT TIME ZONE 'UTC',
+          ALTER "created_at" SET DEFAULT CURRENT_TIMESTAMP(0) AT TIME ZONE 'UTC';
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
 
       DO $$
       BEGIN

--- a/kong/plugins/key-auth/migrations/000_base_key_auth.lua
+++ b/kong/plugins/key-auth/migrations/000_base_key_auth.lua
@@ -8,7 +8,12 @@ return {
         "key"          TEXT                         UNIQUE
       );
 
-      CREATE INDEX IF NOT EXISTS "keyauth_consumer_idx" ON "keyauth_credentials" ("consumer_id");
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS "keyauth_consumer_idx" ON "keyauth_credentials" ("consumer_id");
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
     ]],
   },
 

--- a/kong/plugins/key-auth/migrations/001_14_to_15.lua
+++ b/kong/plugins/key-auth/migrations/001_14_to_15.lua
@@ -1,9 +1,14 @@
 return {
   postgres = {
     up = [[
-      ALTER TABLE IF EXISTS ONLY "keyauth_credentials"
-        ALTER "created_at" TYPE TIMESTAMP WITH TIME ZONE USING "created_at" AT TIME ZONE 'UTC',
-        ALTER "created_at" SET DEFAULT CURRENT_TIMESTAMP(0) AT TIME ZONE 'UTC';
+      DO $$
+      BEGIN
+        ALTER TABLE IF EXISTS ONLY "keyauth_credentials"
+          ALTER "created_at" TYPE TIMESTAMP WITH TIME ZONE USING "created_at" AT TIME ZONE 'UTC',
+          ALTER "created_at" SET DEFAULT CURRENT_TIMESTAMP(0) AT TIME ZONE 'UTC';
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
 
       DO $$
       BEGIN

--- a/kong/plugins/oauth2/migrations/000_base_oauth2.lua
+++ b/kong/plugins/oauth2/migrations/000_base_oauth2.lua
@@ -11,8 +11,19 @@ return {
         "redirect_uri"   TEXT
       );
 
-      CREATE INDEX IF NOT EXISTS "oauth2_credentials_consumer_idx" ON "oauth2_credentials" ("consumer_id");
-      CREATE INDEX IF NOT EXISTS "oauth2_credentials_secret_idx"   ON "oauth2_credentials" ("client_secret");
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS "oauth2_credentials_consumer_idx" ON "oauth2_credentials" ("consumer_id");
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
+
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS "oauth2_credentials_secret_idx" ON "oauth2_credentials" ("client_secret");
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
 
 
 
@@ -27,7 +38,12 @@ return {
         "scope"                 TEXT
       );
 
-      CREATE INDEX IF NOT EXISTS "oauth2_authorization_userid_idx" ON "oauth2_authorization_codes" ("authenticated_userid");
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS "oauth2_authorization_userid_idx" ON "oauth2_authorization_codes" ("authenticated_userid");
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
 
 
 
@@ -45,7 +61,12 @@ return {
         "scope"                 TEXT
       );
 
-      CREATE INDEX IF NOT EXISTS "oauth2_token_userid_idx" ON "oauth2_tokens" ("authenticated_userid");
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS "oauth2_token_userid_idx" ON "oauth2_tokens" ("authenticated_userid");
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
     ]],
   },
 

--- a/kong/plugins/oauth2/migrations/001_14_to_15.lua
+++ b/kong/plugins/oauth2/migrations/001_14_to_15.lua
@@ -24,8 +24,13 @@ return {
         -- Do nothing, accept existing state
       END$$;
 
-      UPDATE "oauth2_authorization_codes"
-         SET "ttl" = "created_at" + INTERVAL '300 seconds';
+      DO $$
+      BEGIN
+        UPDATE "oauth2_authorization_codes"
+           SET "ttl" = "created_at" + INTERVAL '300 seconds';
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
 
 
       DO $$
@@ -35,35 +40,97 @@ return {
         -- Do nothing, accept existing state
       END$$;
 
-      UPDATE "oauth2_tokens"
-         SET "ttl" = "created_at" + (COALESCE("expires_in", 0)::TEXT || ' seconds')::INTERVAL;
-
-
-      ALTER TABLE IF EXISTS ONLY "oauth2_credentials"
-        ALTER "created_at" TYPE TIMESTAMP WITH TIME ZONE USING "created_at" AT TIME ZONE 'UTC',
-        ALTER "created_at" SET DEFAULT CURRENT_TIMESTAMP(0) AT TIME ZONE 'UTC';
-
-      ALTER TABLE IF EXISTS ONLY "oauth2_authorization_codes"
-        ALTER "created_at" TYPE TIMESTAMP WITH TIME ZONE USING "created_at" AT TIME ZONE 'UTC',
-        ALTER "created_at" SET DEFAULT CURRENT_TIMESTAMP(0) AT TIME ZONE 'UTC';
-
-      ALTER TABLE IF EXISTS ONLY "oauth2_tokens"
-        ALTER "created_at" TYPE TIMESTAMP WITH TIME ZONE USING "created_at" AT TIME ZONE 'UTC',
-        ALTER "created_at" SET DEFAULT CURRENT_TIMESTAMP(0) AT TIME ZONE 'UTC';
-
-
-      CREATE INDEX IF NOT EXISTS "oauth2_authorization_credential_id_idx" ON "oauth2_authorization_codes" ("credential_id");
-      CREATE INDEX IF NOT EXISTS "oauth2_authorization_service_id_idx"    ON "oauth2_authorization_codes" ("service_id");
-      CREATE INDEX IF NOT EXISTS "oauth2_authorization_api_id_idx"        ON "oauth2_authorization_codes" ("api_id");
-
-      CREATE INDEX IF NOT EXISTS "oauth2_tokens_credential_id_idx"        ON "oauth2_tokens" ("credential_id");
-      CREATE INDEX IF NOT EXISTS "oauth2_tokens_service_id_idx"           ON "oauth2_tokens" ("service_id");
-      CREATE INDEX IF NOT EXISTS "oauth2_tokens_api_id_idx"               ON "oauth2_tokens" ("api_id");
+      DO $$
+      BEGIN
+        UPDATE "oauth2_tokens"
+           SET "ttl" = "created_at" + (COALESCE("expires_in", 0)::TEXT || ' seconds')::INTERVAL;
+      EXCEPTION WHEN UNDEFINED_COLUMN OR UNDEFINED_TABLE THEN
+        -- Do nothing, accept existing state
+      END$$;
 
 
       DO $$
       BEGIN
-        ALTER INDEX IF EXISTS "oauth2_credentials_consumer_idx" RENAME TO "oauth2_credentials_consumer_id_idx";
+        ALTER TABLE IF EXISTS ONLY "oauth2_credentials"
+          ALTER "created_at" TYPE TIMESTAMP WITH TIME ZONE USING "created_at" AT TIME ZONE 'UTC',
+          ALTER "created_at" SET DEFAULT CURRENT_TIMESTAMP(0) AT TIME ZONE 'UTC';
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
+
+      DO $$
+      BEGIN
+        ALTER TABLE IF EXISTS ONLY "oauth2_authorization_codes"
+          ALTER "created_at" TYPE TIMESTAMP WITH TIME ZONE USING "created_at" AT TIME ZONE 'UTC',
+          ALTER "created_at" SET DEFAULT CURRENT_TIMESTAMP(0) AT TIME ZONE 'UTC';
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
+
+      DO $$
+      BEGIN
+        ALTER TABLE IF EXISTS ONLY "oauth2_tokens"
+          ALTER "created_at" TYPE TIMESTAMP WITH TIME ZONE USING "created_at" AT TIME ZONE 'UTC',
+          ALTER "created_at" SET DEFAULT CURRENT_TIMESTAMP(0) AT TIME ZONE 'UTC';
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
+
+
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS "oauth2_authorization_credential_id_idx"
+                                ON "oauth2_authorization_codes" ("credential_id");
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
+
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS "oauth2_authorization_service_id_idx"
+                                ON "oauth2_authorization_codes" ("service_id");
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
+
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS "oauth2_authorization_api_id_idx"
+                                ON "oauth2_authorization_codes" ("api_id");
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
+
+
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS "oauth2_tokens_credential_id_idx"
+                                ON "oauth2_tokens" ("credential_id");
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
+
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS "oauth2_tokens_service_id_idx"
+                                ON "oauth2_tokens" ("service_id");
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
+
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS "oauth2_tokens_api_id_idx"
+                                ON "oauth2_tokens" ("api_id");
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
+
+
+      DO $$
+      BEGIN
+        ALTER INDEX IF EXISTS "oauth2_credentials_consumer_idx"
+                    RENAME TO "oauth2_credentials_consumer_id_idx";
       EXCEPTION WHEN DUPLICATE_TABLE THEN
         -- Do nothing, accept existing state
       END;
@@ -71,7 +138,8 @@ return {
 
       DO $$
       BEGIN
-        ALTER INDEX IF EXISTS "oauth2_authorization_userid_idx" RENAME TO "oauth2_authorization_codes_authenticated_userid_idx";
+        ALTER INDEX IF EXISTS "oauth2_authorization_userid_idx"
+                    RENAME TO "oauth2_authorization_codes_authenticated_userid_idx";
       EXCEPTION WHEN DUPLICATE_TABLE THEN
         -- Do nothing, accept existing state
       END;
@@ -79,7 +147,8 @@ return {
 
       DO $$
       BEGIN
-        ALTER INDEX IF EXISTS "oauth2_token_userid_idx" RENAME TO "oauth2_tokens_authenticated_userid_idx";
+        ALTER INDEX IF EXISTS "oauth2_token_userid_idx"
+                    RENAME TO "oauth2_tokens_authenticated_userid_idx";
       EXCEPTION WHEN DUPLICATE_TABLE THEN
         -- Do nothing, accept existing state
       END;

--- a/kong/plugins/rate-limiting/migrations/001_14_to_15.lua
+++ b/kong/plugins/rate-limiting/migrations/001_14_to_15.lua
@@ -1,8 +1,13 @@
 return {
   postgres = {
     up = [[
-      ALTER TABLE IF EXISTS ONLY "ratelimiting_metrics"
-        ALTER "period_date" TYPE TIMESTAMP WITH TIME ZONE USING "period_date" AT TIME ZONE 'UTC';
+      DO $$
+      BEGIN
+        ALTER TABLE IF EXISTS ONLY "ratelimiting_metrics"
+          ALTER "period_date" TYPE TIMESTAMP WITH TIME ZONE USING "period_date" AT TIME ZONE 'UTC';
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
     ]],
     teardown = function(connector)
       assert(connector:connect_migrations())

--- a/kong/plugins/rate-limiting/migrations/002_15_to_10.lua
+++ b/kong/plugins/rate-limiting/migrations/002_15_to_10.lua
@@ -6,10 +6,21 @@ return {
     teardown = function(connector)
       assert(connector:connect_migrations())
       assert(connector:query [[
-        ALTER TABLE IF EXISTS ONLY "ratelimiting_metrics"
-         DROP CONSTRAINT IF EXISTS "ratelimiting_metrics_pkey" CASCADE,
-                   ADD PRIMARY KEY ("identifier", "period", "period_date", "service_id", "route_id");
+        DO $$
+        BEGIN
+          ALTER TABLE IF EXISTS ONLY "ratelimiting_metrics"
+           DROP CONSTRAINT IF EXISTS "ratelimiting_metrics_pkey" CASCADE;
+        EXCEPTION WHEN UNDEFINED_COLUMN THEN
+          -- Do nothing, accept existing state
+        END$$;
 
+        DO $$
+        BEGIN
+          ALTER TABLE IF EXISTS ONLY "ratelimiting_metrics"
+                     ADD PRIMARY KEY ("identifier", "period", "period_date", "service_id", "route_id");
+        EXCEPTION WHEN UNDEFINED_COLUMN THEN
+          -- Do nothing, accept existing state
+        END$$;
 
         DO $$
         BEGIN

--- a/kong/plugins/response-ratelimiting/migrations/001_14_to_15.lua
+++ b/kong/plugins/response-ratelimiting/migrations/001_14_to_15.lua
@@ -1,8 +1,13 @@
 return {
   postgres = {
     up = [[
-      ALTER TABLE IF EXISTS ONLY "response_ratelimiting_metrics"
-        ALTER "period_date" TYPE TIMESTAMP WITH TIME ZONE USING "period_date" AT TIME ZONE 'UTC';
+      DO $$
+      BEGIN
+        ALTER TABLE IF EXISTS ONLY "response_ratelimiting_metrics"
+          ALTER "period_date" TYPE TIMESTAMP WITH TIME ZONE USING "period_date" AT TIME ZONE 'UTC';
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
     ]],
     teardown = function(connector)
       assert(connector:connect_migrations())

--- a/kong/plugins/response-ratelimiting/migrations/002_15_to_10.lua
+++ b/kong/plugins/response-ratelimiting/migrations/002_15_to_10.lua
@@ -6,10 +6,21 @@ return {
     teardown = function(connector)
       assert(connector:connect_migrations())
       assert(connector:query [[
-        ALTER TABLE IF EXISTS ONLY "response_ratelimiting_metrics"
-         DROP CONSTRAINT IF EXISTS "response_ratelimiting_metrics_pkey" CASCADE,
-                   ADD PRIMARY KEY ("identifier", "period", "period_date", "service_id", "route_id");
+        DO $$
+        BEGIN
+          ALTER TABLE IF EXISTS ONLY "response_ratelimiting_metrics"
+           DROP CONSTRAINT IF EXISTS "response_ratelimiting_metrics_pkey" CASCADE;
+        EXCEPTION WHEN UNDEFINED_COLUMN THEN
+          -- Do nothing, accept existing state
+        END$$;
 
+        DO $$
+        BEGIN
+          ALTER TABLE IF EXISTS ONLY "response_ratelimiting_metrics"
+                     ADD PRIMARY KEY ("identifier", "period", "period_date", "service_id", "route_id");
+        EXCEPTION WHEN UNDEFINED_COLUMN THEN
+          -- Do nothing, accept existing state
+        END$$;
 
         DO $$
         BEGIN


### PR DESCRIPTION
### Summary

Updates postgres migration to be more resilient to schema changes and make them (more) reentrant. This work started with #4506, but was moved to this separate PR.