### PR TITLE
feat(dao) support loading custom DAO strategies for plugins

### DIFF
--- a/spec/02-integration/03-db/03-plugins_spec.lua
+++ b/spec/02-integration/03-db/03-plugins_spec.lua
@@ -187,6 +187,16 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     describe(":load_plugin_schemas()", function()
+      it("loads custom entities with specialized methods", function()
+        local ok, err = db.plugins:load_plugin_schemas({
+          ["plugin-with-custom-dao"] = true,
+        })
+        assert.truthy(ok)
+        assert.is_nil(err)
+
+        assert.same("I was implemented for " .. strategy, db.custom_dao:custom_method())
+      end)
+
       it("reports failure with missing plugins", function()
         local ok, err = db.plugins:load_plugin_schemas({
           ["missing"] = true,

--- a/spec/fixtures/custom_plugins/kong/plugins/plugin-with-custom-dao/custom_dao.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/plugin-with-custom-dao/custom_dao.lua
@@ -1,0 +1,9 @@
+local CustomDAO = {}
+
+
+function CustomDAO:custom_method()
+  return self.strategy:custom_method()
+end
+
+
+return CustomDAO

--- a/spec/fixtures/custom_plugins/kong/plugins/plugin-with-custom-dao/daos.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/plugin-with-custom-dao/daos.lua
@@ -1,0 +1,12 @@
+local typedefs = require "kong.db.schema.typedefs"
+
+return {
+  custom_dao = {
+    dao = "kong.plugins.plugin-with-custom-dao.custom_dao",
+    name = "custom_dao",
+    primary_key = { "id" },
+    fields = {
+      { id = typedefs.uuid },
+    },
+  },
+}

--- a/spec/fixtures/custom_plugins/kong/plugins/plugin-with-custom-dao/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/plugin-with-custom-dao/handler.lua
@@ -1,0 +1,15 @@
+local BasePlugin = require "kong.plugins.base_plugin"
+
+
+local MyHandler = BasePlugin:extend()
+
+
+MyHandler.PRIORITY = 1000
+
+
+function MyHandler:new()
+  MyHandler.super.new(self, "plugin-with-custom-dao")
+end
+
+
+return MyHandler

--- a/spec/fixtures/custom_plugins/kong/plugins/plugin-with-custom-dao/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/plugin-with-custom-dao/schema.lua
@@ -1,0 +1,9 @@
+return {
+  name = "plugin-with-custom-dao",
+  fields = {
+    { config = {
+        type = "record",
+        fields = {}
+    } }
+  }
+}

--- a/spec/fixtures/custom_plugins/kong/plugins/plugin-with-custom-dao/strategies/cassandra/custom_dao.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/plugin-with-custom-dao/strategies/cassandra/custom_dao.lua
@@ -1,0 +1,7 @@
+local CustomDAO = {}
+
+function CustomDAO:custom_method()
+  return "I was implemented for cassandra"
+end
+
+return CustomDAO

--- a/spec/fixtures/custom_plugins/kong/plugins/plugin-with-custom-dao/strategies/postgres/custom_dao.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/plugin-with-custom-dao/strategies/postgres/custom_dao.lua
@@ -1,0 +1,7 @@
+local CustomDAO = {}
+
+function CustomDAO:custom_method()
+  return "I was implemented for postgres"
+end
+
+return CustomDAO


### PR DESCRIPTION
### Summary

This commit introduces new functionality into the plugin_loader module to support attempting to load a strategy for custom plugin DAO implementations. This would allow plugins to define a strategy at a path like

`kong/plugins/<plugin>/db/strategies/<strategy>/<entity>.lua`

This is essentially a copypasta of the custom strategy loader found in kong.db.strategies.

### Full changelog

* support loading custom DAO strategies for plugins