### PR TITLE
style(router) remove passing of ngx and localize functions and magic tables

### DIFF
--- a/kong/router.lua
+++ b/kong/router.lua
@@ -5,8 +5,13 @@ local bit           = require "bit"
 
 
 local hostname_type = utils.hostname_type
+local subsystem     = ngx.config.subsystem
+local get_method    = ngx.req.get_method
 local re_match      = ngx.re.match
 local re_find       = ngx.re.find
+local header        = ngx.header
+local var           = ngx.var
+local ngx_log       = ngx.log
 local insert        = table.insert
 local sort          = table.sort
 local upper         = string.upper
@@ -22,13 +27,12 @@ local band          = bit.band
 local bor           = bit.bor
 
 
-local ERR      = ngx.ERR
+local ERR           = ngx.ERR
 
 
 local clear_tab
 local log
 do
-  local ngx_log = ngx.log
   log = function(lvl, ...)
     ngx_log(lvl, "[router] ", ...)
   end
@@ -73,6 +77,51 @@ local EMPTY_T = {}
 
 local match_route
 local reduce
+
+
+local function _set_ngx(mock_ngx)
+  if type(mock_ngx) ~= "table" then
+    return
+  end
+
+  if mock_ngx.header then
+    header = mock_ngx.header
+  end
+
+  if mock_ngx.var then
+    var = mock_ngx.var
+  end
+
+  if mock_ngx.log then
+    ngx_log = mock_ngx.log
+  end
+
+  if mock_ngx.ERR then
+    ERR = mock_ngx.ERR
+  end
+
+  if type(mock_ngx.req) == "table" then
+    if mock_ngx.req.get_method then
+      get_method = mock_ngx.req.get_method
+    end
+  end
+
+  if type(mock_ngx.config) == "table" then
+    if mock_ngx.config.subsystem then
+      subsystem = mock_ngx.config.subsystem
+    end
+  end
+
+  if type(mock_ngx.re) == "table" then
+    if mock_ngx.re.match then
+      re_match = mock_ngx.re.match
+    end
+
+    if mock_ngx.re.find then
+      re_find = mock_ngx.re.find
+    end
+  end
+end
 
 
 local function has_capturing_groups(subj)
@@ -797,6 +846,10 @@ local _M = {}
 _M.has_capturing_groups = has_capturing_groups
 
 
+-- for unit-testing purposes only
+_M._set_ngx = _set_ngx
+
+
 function _M.new(routes)
   if type(routes) ~= "table" then
     return error("expected arg #1 routes to be a table")
@@ -915,8 +968,10 @@ function _M.new(routes)
     end
   end
 
-  local function find_route(req_method, req_uri, req_host, ngx,
-                            src_ip, src_port, dst_ip, dst_port, sni)
+  local function find_route(req_method, req_uri, req_host,
+                            src_ip, src_port,
+                            dst_ip, dst_port,
+                            sni)
     if req_method and type(req_method) ~= "string" then
       error("method must be a string", 2)
     end
@@ -1163,7 +1218,7 @@ function _M.new(routes)
               -- preserve_host header logic
 
               if matched_route.preserve_host then
-                upstream_host = raw_req_host or ngx.var.http_host
+                upstream_host = raw_req_host or var.http_host
               end
             end
 
@@ -1204,12 +1259,11 @@ function _M.new(routes)
 
 
   self.select = find_route
+  self._set_ngx = _set_ngx
 
-  if ngx.config.subsystem == "http" then
-    function self.exec(ngx)
-      local var = ngx.var
-
-      local req_method = ngx.req.get_method()
+  if subsystem == "http" then
+    function self.exec()
+      local req_method = get_method()
       local req_uri = var.request_uri
       local req_host = var.http_host or ""
       local src_ip = var.remote_addr
@@ -1225,32 +1279,34 @@ function _M.new(routes)
         end
       end
 
-      local match_t = find_route(req_method, req_uri, req_host, ngx,
-                                 src_ip, src_port, dst_ip, dst_port, sni)
+      local match_t = find_route(req_method, req_uri, req_host,
+                                 src_ip, src_port,
+                                 dst_ip, dst_port,
+                                 sni)
       if not match_t then
         return nil
       end
 
       -- debug HTTP request header logic
 
-      if ngx.var.http_kong_debug then
+      if var.http_kong_debug then
         if match_t.route then
           if match_t.route.id then
-            ngx.header["Kong-Route-Id"] = match_t.route.id
+            header["Kong-Route-Id"] = match_t.route.id
           end
 
           if match_t.route.name then
-            ngx.header["Kong-Route-Name"] = match_t.route.name
+            header["Kong-Route-Name"] = match_t.route.name
           end
         end
 
         if match_t.service then
           if match_t.service.id then
-            ngx.header["Kong-Service-Id"] = match_t.service.id
+            header["Kong-Service-Id"] = match_t.service.id
           end
 
           if match_t.service.name then
-            ngx.header["Kong-Service-Name"] = match_t.service.name
+            header["Kong-Service-Name"] = match_t.service.name
           end
         end
       end
@@ -1259,17 +1315,17 @@ function _M.new(routes)
     end
 
   else -- stream
-    function self.exec(ngx)
-      local var = ngx.var
-
+    function self.exec()
       local src_ip = var.remote_addr
       local src_port = tonumber(var.remote_port, 10)
       local dst_ip = var.server_addr
       local dst_port = tonumber(var.server_port, 10)
       local sni = var.ssl_preread_server_name
 
-      return find_route(nil, nil, nil, ngx,
-                        src_ip, src_port, dst_ip, dst_port, sni)
+      return find_route(nil, nil, nil,
+                        src_ip, src_port,
+                        dst_ip, dst_port,
+                        sni)
     end
   end
 

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -588,7 +588,7 @@ return {
         return ngx.exit(500)
       end
 
-      local match_t = router.exec(ngx)
+      local match_t = router.exec()
       if not match_t then
         log(ERR, "no Route found with those values")
         return ngx.exit(500)
@@ -693,7 +693,7 @@ return {
 
       ctx.KONG_ACCESS_START = get_now()
 
-      local match_t = router.exec(ngx)
+      local match_t = router.exec()
       if not match_t then
         return kong.response.exit(404, { message = "no Route matched with those values" })
       end

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -1195,9 +1195,9 @@ describe("Router", function()
       }
 
       local router = assert(Router.new(use_case_routes))
-
       local _ngx = mock_ngx("GET", "/my-route", { host = "domain.org" })
-      local match_t = router.exec(_ngx)
+      router._set_ngx(_ngx)
+      local match_t = router.exec()
       assert.same(use_case_routes[1].route, match_t.route)
 
       -- upstream_url_t
@@ -1210,7 +1210,8 @@ describe("Router", function()
       assert.equal("/my-route", match_t.upstream_uri)
 
       _ngx = mock_ngx("GET", "/my-route-2", { host = "domain.org" })
-      match_t = router.exec(_ngx)
+      router._set_ngx(_ngx)
+      match_t = router.exec()
       assert.same(use_case_routes[2].route, match_t.route)
 
       -- upstream_url_t
@@ -1261,37 +1262,41 @@ describe("Router", function()
       }
 
       local router = assert(Router.new(use_case_routes))
-
       local _ngx = mock_ngx("GET", "/my-route", { host = "host.com" })
-      local match_t = router.exec(_ngx)
+      router._set_ngx(_ngx)
+      local match_t = router.exec()
       assert.same(use_case_routes[1].route, match_t.route)
       assert.equal("host.com", match_t.matches.host)
       assert.equal("/my-route", match_t.matches.uri)
       assert.equal("GET", match_t.matches.method)
 
       _ngx = mock_ngx("GET", "/my-route/prefix/match", { host = "host.com" })
-      match_t = router.exec(_ngx)
+      router._set_ngx(_ngx)
+      match_t = router.exec()
       assert.same(use_case_routes[1].route, match_t.route)
       assert.equal("host.com", match_t.matches.host)
       assert.equal("/my-route", match_t.matches.uri)
       assert.equal("GET", match_t.matches.method)
 
       _ngx = mock_ngx("POST", "/my-route", { host = "host.com" })
-      match_t = router.exec(_ngx)
+      router._set_ngx(_ngx)
+      match_t = router.exec()
       assert.same(use_case_routes[2].route, match_t.route)
       assert.equal("host.com", match_t.matches.host)
       assert.equal("/my-route", match_t.matches.uri)
       assert.is_nil(match_t.matches.method)
 
       _ngx = mock_ngx("GET", "/", { host = "test.host.com" })
-      match_t = router.exec(_ngx)
+      router._set_ngx(_ngx)
+      match_t = router.exec()
       assert.same(use_case_routes[3].route, match_t.route)
       assert.equal("*.host.com", match_t.matches.host)
       assert.is_nil(match_t.matches.uri)
       assert.is_nil(match_t.matches.method)
 
       _ngx = mock_ngx("GET", "/users/123/profile", { host = "domain.org" })
-      match_t = router.exec(_ngx)
+      router._set_ngx(_ngx)
+      match_t = router.exec()
       assert.same(use_case_routes[4].route, match_t.route)
       assert.is_nil(match_t.matches.host)
       assert.equal([[/users/\d+/profile]], match_t.matches.uri)
@@ -1309,10 +1314,10 @@ describe("Router", function()
       }
 
       local router = assert(Router.new(use_case))
-
       local _ngx = mock_ngx("GET", "/users/1984/profile",
                             { host = "domain.org" })
-      local match_t = router.exec(_ngx)
+      router._set_ngx(_ngx)
+      local match_t = router.exec()
       assert.equal("1984", match_t.matches.uri_captures[1])
       assert.equal("1984", match_t.matches.uri_captures.user_id)
       assert.equal("",     match_t.matches.uri_captures[2])
@@ -1324,7 +1329,8 @@ describe("Router", function()
       assert.equal(2, #match_t.matches.uri_captures)
 
       -- again, this time from the LRU cache
-      match_t = router.exec(_ngx)
+      router._set_ngx(_ngx)
+      match_t = router.exec()
       assert.equal("1984", match_t.matches.uri_captures[1])
       assert.equal("1984", match_t.matches.uri_captures.user_id)
       assert.equal("",     match_t.matches.uri_captures[2])
@@ -1337,7 +1343,8 @@ describe("Router", function()
 
       _ngx = mock_ngx("GET", "/users/1984/profile/email",
                       { host = "domain.org" })
-      match_t = router.exec(_ngx)
+      router._set_ngx(_ngx)
+      match_t = router.exec()
       assert.equal("1984",  match_t.matches.uri_captures[1])
       assert.equal("1984",  match_t.matches.uri_captures.user_id)
       assert.equal("email", match_t.matches.uri_captures[2])
@@ -1361,9 +1368,9 @@ describe("Router", function()
       }
 
       local router = assert(Router.new(use_case))
-
       local _ngx = mock_ngx("GET", "/hello/world", { host = "domain.org" })
-      local match_t = router.exec(_ngx)
+      router._set_ngx(_ngx)
+      local match_t = router.exec()
       assert.equal("/world", match_t.upstream_uri)
       assert.is_nil(match_t.matches.uri_captures)
     end)
@@ -1379,10 +1386,10 @@ describe("Router", function()
       }
 
       local router = assert(Router.new(use_case))
-
       local _ngx = mock_ngx("GET", "/users/1984/profile",
                             { host = "domain.org" })
-      local match_t = router.exec(_ngx)
+      router._set_ngx(_ngx)
+      local match_t = router.exec()
       assert.is_nil(match_t.matches.uri_captures)
     end)
 
@@ -1402,9 +1409,9 @@ describe("Router", function()
       }
 
       local router = assert(Router.new(use_case_routes))
-
       local _ngx = mock_ngx("GET", "/my-route", { host = "domain.org" })
-      local match_t = router.exec(_ngx)
+      router._set_ngx(_ngx)
+      local match_t = router.exec()
       assert.same(use_case_routes[1].route, match_t.route)
       assert.equal("/get", match_t.upstream_url_t.path)
     end)
@@ -1436,13 +1443,14 @@ describe("Router", function()
       }
 
       local router = assert(Router.new(use_case_routes))
-
       local _ngx = mock_ngx("GET", "/my-route", { host = "domain.org" })
-      local match_t = router.exec(_ngx)
+      router._set_ngx(_ngx)
+      local match_t = router.exec()
       assert.equal(8080, match_t.upstream_url_t.port)
 
       _ngx = mock_ngx("GET", "/my-route-2", { host = "domain.org" })
-      match_t = router.exec(_ngx)
+      router._set_ngx(_ngx)
+      match_t = router.exec()
       assert.equal(8443, match_t.upstream_url_t.port)
     end)
 
@@ -1457,9 +1465,9 @@ describe("Router", function()
       }
 
       local router = assert(Router.new(use_case_routes))
-
       local _ngx = mock_ngx("GET", "/endel%C3%B8st", { host = "domain.org" })
-      local match_t = router.exec(_ngx)
+      router._set_ngx(_ngx)
+      local match_t = router.exec()
       assert.same(use_case_routes[1].route, match_t.route)
       assert.equal("/endel%C3%B8st", match_t.upstream_uri)
     end)
@@ -1491,16 +1499,16 @@ describe("Router", function()
       it("strips the specified paths from the given uri if matching", function()
         local _ngx = mock_ngx("GET", "/my-route/hello/world",
                               { host = "domain.org" })
-
-        local match_t = router.exec(_ngx)
+        router._set_ngx(_ngx)
+        local match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
         assert.equal("/hello/world", match_t.upstream_uri)
       end)
 
       it("strips if matched URI is plain (not a prefix)", function()
         local _ngx = mock_ngx("GET", "/my-route", { host = "domain.org" })
-
-        local match_t = router.exec(_ngx)
+        router._set_ngx(_ngx)
+        local match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
         assert.equal("/", match_t.upstream_uri)
       end)
@@ -1508,8 +1516,8 @@ describe("Router", function()
       it("doesn't strip if 'strip_uri' is not enabled", function()
         local _ngx = mock_ngx("POST", "/my-route/hello/world",
                               { host = "domain.org" })
-
-        local match_t = router.exec(_ngx)
+        router._set_ngx(_ngx)
+        local match_t = router.exec()
         assert.same(use_case_routes[2].route, match_t.route)
         assert.equal("/my-route/hello/world", match_t.upstream_uri)
       end)
@@ -1529,43 +1537,48 @@ describe("Router", function()
 
         local _ngx = mock_ngx("POST", "/my-route/hello/world",
                               { host = "domain.org" })
-
-        local match_t = router.exec(_ngx)
+        router._set_ngx(_ngx)
+        local match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
         assert.equal("/my-route/hello/world", match_t.upstream_uri)
       end)
 
       it("can find an route with stripped URI several times in a row", function()
         local _ngx = mock_ngx("GET", "/my-route", { host = "domain.org" })
-        local match_t = router.exec(_ngx)
+        router._set_ngx(_ngx)
+        local match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
         assert.equal("/", match_t.upstream_uri)
 
         _ngx = mock_ngx("GET", "/my-route", { host = "domain.org" })
-        match_t = router.exec(_ngx)
+        router._set_ngx(_ngx)
+        match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
         assert.equal("/", match_t.upstream_uri)
       end)
 
       it("can proxy an route with stripped URI with different URIs in a row", function()
         local _ngx = mock_ngx("GET", "/my-route", { host = "domain.org" })
-
-        local match_t = router.exec(_ngx)
+        router._set_ngx(_ngx)
+        local match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
         assert.equal("/", match_t.upstream_uri)
 
         _ngx = mock_ngx("GET", "/this-route", { host = "domain.org" })
-        match_t = router.exec(_ngx)
+        router._set_ngx(_ngx)
+        match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
         assert.equal("/", match_t.upstream_uri)
 
         _ngx = mock_ngx("GET", "/my-route", { host = "domain.org" })
-        match_t = router.exec(_ngx)
+        router._set_ngx(_ngx)
+        match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
         assert.equal("/", match_t.upstream_uri)
 
         _ngx = mock_ngx("GET", "/this-route", { host = "domain.org" })
-        match_t = router.exec(_ngx)
+        router._set_ngx(_ngx)
+        match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
         assert.equal("/", match_t.upstream_uri)
       end)
@@ -1582,9 +1595,9 @@ describe("Router", function()
         }
 
         local router = assert(Router.new(use_case_routes))
-
         local _ngx = mock_ngx("GET", "/endel%C3%B8st", { host = "domain.org" })
-        local match_t = router.exec(_ngx)
+        router._set_ngx(_ngx)
+        local match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
         assert.equal("/", match_t.upstream_uri)
       end)
@@ -1601,10 +1614,10 @@ describe("Router", function()
         }
 
         local router = assert(Router.new(use_case))
-
         local _ngx = mock_ngx("GET", "/users/123/profile/hello/world",
                               { host = "domain.org" })
-        local match_t = router.exec(_ngx)
+        router._set_ngx(_ngx)
+        local match_t = router.exec()
         assert.equal("/hello/world", match_t.upstream_uri)
       end)
 
@@ -1620,10 +1633,10 @@ describe("Router", function()
         }
 
         local router = assert(Router.new(use_case))
-
         local _ngx = mock_ngx("GET", "/users/123/profile/hello/world",
                               { host = "domain.org" })
-        local match_t = router.exec(_ngx)
+        router._set_ngx(_ngx)
+        local match_t = router.exec()
         assert.equal("/hello/world", match_t.upstream_uri)
       end)
     end)
@@ -1670,24 +1683,24 @@ describe("Router", function()
 
         it("uses the request's Host header", function()
           local _ngx = mock_ngx("GET", "/", { host = host })
-
-          local match_t = router.exec(_ngx)
+          router._set_ngx(_ngx)
+          local match_t = router.exec()
           assert.same(use_case_routes[1].route, match_t.route)
           assert.equal(host, match_t.upstream_host)
         end)
 
         it("uses the request's Host header incl. port", function()
           local _ngx = mock_ngx("GET", "/", { host = host .. ":123" })
-
-          local match_t = router.exec(_ngx)
+          router._set_ngx(_ngx)
+          local match_t = router.exec()
           assert.same(use_case_routes[1].route, match_t.route)
           assert.equal(host .. ":123", match_t.upstream_host)
         end)
 
         it("does not change the target upstream", function()
           local _ngx = mock_ngx("GET", "/", { host = host })
-
-          local match_t = router.exec(_ngx)
+          router._set_ngx(_ngx)
+          local match_t = router.exec()
           assert.same(use_case_routes[1].route, match_t.route)
           assert.equal("example.org", match_t.upstream_url_t.host)
         end)
@@ -1706,10 +1719,9 @@ describe("Router", function()
           }
 
           local router = assert(Router.new(use_case_routes))
-
           local _ngx = mock_ngx("GET", "/foo", { host = "preserve.com" })
-
-          local match_t = router.exec(_ngx)
+          router._set_ngx(_ngx)
+          local match_t = router.exec()
           assert.same(use_case_routes[1].route, match_t.route)
           assert.equal("preserve.com", match_t.upstream_host)
         end)
@@ -1733,16 +1745,15 @@ describe("Router", function()
           }
 
           local router = assert(Router.new(use_case_routes))
-
           local _ngx = mock_ngx("GET", "/nohost", { host = "domain1.com" })
-
-          local match_t = router.exec(_ngx)
+          router._set_ngx(_ngx)
+          local match_t = router.exec()
           assert.same(use_case_routes[1].route, match_t.route)
           assert.equal("domain1.com", match_t.upstream_host)
 
           _ngx = mock_ngx("GET", "/nohost", { host = "domain2.com" })
-
-          match_t = router.exec(_ngx)
+          router._set_ngx(_ngx)
+          match_t = router.exec()
           assert.same(use_case_routes[1].route, match_t.route)
           assert.equal("domain2.com", match_t.upstream_host)
         end)
@@ -1753,16 +1764,16 @@ describe("Router", function()
 
         it("does not change the target upstream", function()
           local _ngx = mock_ngx("GET", "/", { host = host })
-
-          local match_t = router.exec(_ngx)
+          router._set_ngx(_ngx)
+          local match_t = router.exec()
           assert.same(use_case_routes[2].route, match_t.route)
           assert.equal("example.org", match_t.upstream_url_t.host)
         end)
 
         it("does not set the host_header", function()
           local _ngx = mock_ngx("GET", "/", { host = host })
-
-          local match_t = router.exec(_ngx)
+          router._set_ngx(_ngx)
+          local match_t = router.exec()
           assert.same(use_case_routes[2].route, match_t.route)
           assert.is_nil(match_t.upstream_host)
         end)
@@ -1887,9 +1898,9 @@ describe("Router", function()
           }
 
           local router = assert(Router.new(use_case_routes) )
-
           local _ngx = mock_ngx("GET", args[3], { host = "test" .. i .. ".domain.org" })
-          local match_t = router.exec(_ngx)
+          router._set_ngx(_ngx)
+          local match_t = router.exec()
           assert.same(use_case_routes[1].route, match_t.route)
           assert.equal(args[1], match_t.upstream_url_t.path)
           assert.equal(args[4], match_t.upstream_uri)
@@ -1933,9 +1944,9 @@ describe("Router", function()
             }
 
             local router = assert(Router.new(use_case_routes) )
-
             local _ngx = mock_ngx("GET", args[3], { host = "test" .. i .. ".domain.org" })
-            local match_t = router.exec(_ngx)
+            router._set_ngx(_ngx)
+            local match_t = router.exec()
             assert.same(use_case_routes[1].route, match_t.route)
             assert.equal(args[1], match_t.upstream_url_t.path)
             assert.equal(args[4], match_t.upstream_uri)
@@ -2040,44 +2051,44 @@ describe("Router", function()
       local router = assert(Router.new(use_case))
 
       it("[src_ip]", function()
-        local match_t = router.select(nil, nil, nil, nil, "127.0.0.1")
+        local match_t = router.select(nil, nil, nil, "127.0.0.1")
         assert.truthy(match_t)
         assert.same(use_case[1].route, match_t.route)
 
-        match_t = router.select(nil, nil, nil, nil, "127.0.0.1")
+        match_t = router.select(nil, nil, nil, "127.0.0.1")
         assert.truthy(match_t)
         assert.same(use_case[1].route, match_t.route)
       end)
 
       it("[src_port]", function()
-        local match_t = router.select(nil, nil, nil, nil, "127.0.0.3", 65001)
+        local match_t = router.select(nil, nil, nil, "127.0.0.3", 65001)
         assert.truthy(match_t)
         assert.same(use_case[2].route, match_t.route)
       end)
 
       it("[src_ip] range match", function()
-        local match_t = router.select(nil, nil, nil, nil, "127.168.0.1")
+        local match_t = router.select(nil, nil, nil, "127.168.0.1")
         assert.truthy(match_t)
         assert.same(use_case[3].route, match_t.route)
       end)
 
       it("[src_ip] + [src_port]", function()
-        local match_t = router.select(nil, nil, nil, nil, "127.0.0.1", 65001)
+        local match_t = router.select(nil, nil, nil, "127.0.0.1", 65001)
         assert.truthy(match_t)
         assert.same(use_case[4].route, match_t.route)
       end)
 
       it("[src_ip] range match + [src_port]", function()
-        local match_t = router.select(nil, nil, nil, nil, "127.168.10.1", 65301)
+        local match_t = router.select(nil, nil, nil, "127.168.10.1", 65301)
         assert.truthy(match_t)
         assert.same(use_case[5].route, match_t.route)
       end)
 
       it("[src_ip] no match", function()
-        local match_t = router.select(nil, nil, nil, nil, "10.0.0.1")
+        local match_t = router.select(nil, nil, nil, "10.0.0.1")
         assert.falsy(match_t)
 
-        match_t = router.select(nil, nil, nil, nil, "10.0.0.2", 65301)
+        match_t = router.select(nil, nil, nil, "10.0.0.2", 65301)
         assert.falsy(match_t)
       end)
     end)
@@ -2136,51 +2147,51 @@ describe("Router", function()
       local router = assert(Router.new(use_case))
 
       it("[dst_ip]", function()
-        local match_t = router.select(nil, nil, nil, nil, nil, nil,
+        local match_t = router.select(nil, nil, nil, nil, nil,
                                       "127.0.0.1")
         assert.truthy(match_t)
         assert.same(use_case[1].route, match_t.route)
 
-        match_t = router.select(nil, nil, nil, nil, nil, nil,
+        match_t = router.select(nil, nil, nil, nil, nil,
                                 "127.0.0.1")
         assert.truthy(match_t)
         assert.same(use_case[1].route, match_t.route)
       end)
 
       it("[dst_port]", function()
-        local match_t = router.select(nil, nil, nil, nil, nil, nil,
+        local match_t = router.select(nil, nil, nil, nil, nil,
                                       "127.0.0.3", 65001)
         assert.truthy(match_t)
         assert.same(use_case[2].route, match_t.route)
       end)
 
       it("[dst_ip] range match", function()
-        local match_t = router.select(nil, nil, nil, nil, nil, nil,
+        local match_t = router.select(nil, nil, nil, nil, nil,
                                       "127.168.0.1")
         assert.truthy(match_t)
         assert.same(use_case[3].route, match_t.route)
       end)
 
       it("[dst_ip] + [dst_port]", function()
-        local match_t = router.select(nil, nil, nil, nil, nil, nil,
+        local match_t = router.select(nil, nil, nil, nil, nil,
                                       "127.0.0.1", 65001)
         assert.truthy(match_t)
         assert.same(use_case[4].route, match_t.route)
       end)
 
       it("[dst_ip] range match + [dst_port]", function()
-        local match_t = router.select(nil, nil, nil, nil, nil, nil,
+        local match_t = router.select(nil, nil, nil, nil, nil,
                                       "127.168.10.1", 65301)
         assert.truthy(match_t)
         assert.same(use_case[5].route, match_t.route)
       end)
 
       it("[dst_ip] no match", function()
-        local match_t = router.select(nil, nil, nil, nil, nil, nil,
+        local match_t = router.select(nil, nil, nil, nil, nil,
                                       "10.0.0.1")
         assert.falsy(match_t)
 
-        match_t = router.select(nil, nil, nil, nil, nil, nil,
+        match_t = router.select(nil, nil, nil, nil, nil,
                                 "10.0.0.2", 65301)
         assert.falsy(match_t)
       end)
@@ -2200,7 +2211,7 @@ describe("Router", function()
       local router = assert(Router.new(use_case))
 
       it("[sni]", function()
-        local match_t = router.select(nil, nil, nil, nil, nil, nil, nil, nil,
+        local match_t = router.select(nil, nil, nil, nil, nil, nil, nil,
                                       "www.example.org")
         assert.truthy(match_t)
         assert.same(use_case[1].route, match_t.route)
@@ -2236,12 +2247,12 @@ describe("Router", function()
 
       local router = assert(Router.new(use_case))
 
-      local match_t = router.select(nil, nil, nil, nil, "127.0.0.1", nil,
+      local match_t = router.select(nil, nil, nil, "127.0.0.1", nil,
                                     nil, nil, "www.example.org")
       assert.truthy(match_t)
       assert.same(use_case[1].route, match_t.route)
 
-      match_t = router.select(nil, nil, nil, nil, nil, nil,
+      match_t = router.select(nil, nil, nil, nil, nil,
                               "172.168.0.1", nil, "www.example.org")
       assert.truthy(match_t)
       assert.same(use_case[1].route, match_t.route)
@@ -2270,7 +2281,7 @@ describe("Router", function()
 
       local router = assert(Router.new(use_case))
 
-      local match_t = router.select(nil, nil, nil, nil, "127.0.0.1", nil,
+      local match_t = router.select(nil, nil, nil, "127.0.0.1", nil,
                                     "172.168.0.1", nil, "www.example.org")
       assert.truthy(match_t)
       assert.same(use_case[2].route, match_t.route)


### PR DESCRIPTION
### Summary

Just a small style change on `router` code to get rid of `mocking` related parameters on public interfaces. I am fully ok, if there are objections at merging this.