### PR TITLE
fix(request-transformer) plugin is case insensitive for header names now

### DIFF
--- a/kong/plugins/request-transformer/access.lua
+++ b/kong/plugins/request-transformer/access.lua
@@ -113,6 +113,7 @@ local function transform_headers(conf)
 
   if remove then
     for _, name, _ in iter(conf.remove.headers) do
+      name = lower(name)
       if headers[name] ~= nil then
         headers[name] = nil
         clear_header(name)
@@ -126,6 +127,7 @@ local function transform_headers(conf)
 
   if rename then
     for _, old_name, new_name in iter(conf.rename.headers) do
+      old_name = lower(old_name)
       local value = headers[old_name]
       if value ~= nil then
         headers[new_name] = value
@@ -142,7 +144,8 @@ local function transform_headers(conf)
 
   if replace then
     for _, name, value in iter(conf.replace.headers) do
-      if headers[name] ~= nil or lower(name) == "host" then
+      name = lower(name)
+      if headers[name] ~= nil or name == "host" then
         headers[name] = value
 
         if not replaced then
@@ -166,7 +169,8 @@ local function transform_headers(conf)
 
   if append then
     for _, name, value in iter(conf.append.headers) do
-      if lower(name) ~= "host" then
+      name = lower(name)
+      if name ~= "host" then
         headers[name] = append_value(headers[name], value)
 
         if not appended then

--- a/kong/plugins/request-transformer/access.lua
+++ b/kong/plugins/request-transformer/access.lua
@@ -144,7 +144,7 @@ local function transform_headers(conf)
 
   if replace then
     for _, name, value in iter(conf.replace.headers) do
-      if headers[name] ~= nil or name == "host" then
+      if headers[name] ~= nil or lower(name) == "host" then
         headers[name] = value
 
         if not replaced then

--- a/kong/plugins/request-transformer/access.lua
+++ b/kong/plugins/request-transformer/access.lua
@@ -144,7 +144,6 @@ local function transform_headers(conf)
 
   if replace then
     for _, name, value in iter(conf.replace.headers) do
-      name = lower(name)
       if headers[name] ~= nil or name == "host" then
         headers[name] = value
 

--- a/spec/03-plugins/14-request-transformer/02-access_spec.lua
+++ b/spec/03-plugins/14-request-transformer/02-access_spec.lua
@@ -207,7 +207,7 @@ for _, strategy in helpers.each_strategy() do
         name     = "request-transformer",
         config   = {
           remove = {
-            headers     = {"x-to-remove"},
+            headers     = {"X-to-Remove"},
             querystring = {"q1"},
             body        = {"toremoveform"}
           }
@@ -231,7 +231,7 @@ for _, strategy in helpers.each_strategy() do
         name     = "request-transformer",
         config   = {
           append = {
-            headers     = {"h1:v1", "h1:v2", "h2:v1",},
+            headers     = {"h1:v1", "h1:v2", "H2:v1",},
             querystring = {"q1:v1", "q1:v2", "q2:v1"},
             body        = {"p1:v1", "p1:v2", "p2:value:1"} -- payload containing a colon
           }
@@ -259,7 +259,7 @@ for _, strategy in helpers.each_strategy() do
         name     = "request-transformer",
         config   = {
           rename = {
-            headers     = {"x-to-rename:x-is-renamed"},
+            headers     = {"X-to-Rename:x-is-renamed"},
             querystring = {"originalparam:renamedparam"},
             body        = {"originalparam:renamedparam"}
           }


### PR DESCRIPTION
ngx_http_lua_module treats all header names as lower case strings, so
when changing something from request they must always be compared this
way.

Issue reported in https://github.com/Kong/kong/issues/4504