### PR TITLE
Fix/dbless config endpoint

### DIFF
--- a/kong/api/routes/config.lua
+++ b/kong/api/routes/config.lua
@@ -1,6 +1,7 @@
 local declarative = require("kong.db.declarative")
 local reports = require("kong.reports")
 local kong = kong
+local dc = declarative.new_config(kong.configuration)
 
 
 -- Do not accept Lua configurations from the Admin API
@@ -25,11 +26,15 @@ return {
         })
       end
 
-      local dc = declarative.new_config(kong.configuration)
-
+      local entities, err_or_ver
+      if self.params._format_version then
+        entities, err_or_ver = dc:parse_table(self.params)
+      else
       local config = self.params.config
-      -- TODO extract proper filename from the input
-      local entities, err_or_ver = dc:parse_string(config, "config.yml", accept)
+        -- TODO extract proper filename from the input
+        entities, err_or_ver = dc:parse_string(config, "config.yml", accept)
+      end
+
       if not entities then
         return kong.response.exit(400, { error = err_or_ver })
       end

--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -121,6 +121,9 @@ end
 
 
 function Config:parse_table(dc_table)
+  if type(dc_table) ~= "table" then
+    return nil, "expected a table as input"
+  end
   local ok, err_t = self.schema:validate(dc_table)
   if not ok then
     return nil, pretty_print_error(err_t), err_t

--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -116,6 +116,11 @@ function Config:parse_string(contents, filename, accept)
         filename .. (err and ": " .. err or "")
   end
 
+  return self:parse_table(dc_table)
+end
+
+
+function Config:parse_table(dc_table)
   local ok, err_t = self.schema:validate(dc_table)
   if not ok then
     return nil, pretty_print_error(err_t), err_t

--- a/spec/02-integration/04-admin_api/15-off_spec.lua
+++ b/spec/02-integration/04-admin_api/15-off_spec.lua
@@ -241,5 +241,23 @@ describe("Admin API #off", function()
 
       assert.response(res).has.status(201)
     end)
+    it("returns 400 on an invalid config string", function()
+      local res = assert(client:send {
+        method = "POST",
+        path = "/config",
+        body = {
+          config = "bobby tables",
+        },
+        headers = {
+          ["Content-Type"] = "application/json"
+        }
+      })
+
+      local body =assert.response(res).has.status(400)
+      local json = cjson.decode(body)
+      assert.same({
+        error = "expected a table as input",
+      }, json)
+    end)
   end)
 end)

--- a/spec/02-integration/04-admin_api/15-off_spec.lua
+++ b/spec/02-integration/04-admin_api/15-off_spec.lua
@@ -179,4 +179,67 @@ describe("Admin API #off", function()
       end
     end)
   end)
+
+  describe("/config", function()
+    it("accepts configuration as JSON body", function()
+      local res = assert(client:send {
+        method = "POST",
+        path = "/config",
+        body = {
+          _format_version = "1.1",
+          consumers = {
+            {
+              username = "bobby",
+            },
+          },
+        },
+        headers = {
+          ["Content-Type"] = "application/json"
+        }
+      })
+
+      assert.response(res).has.status(201)
+    end)
+    it("accepts configuration as a JSON string", function()
+      local res = assert(client:send {
+        method = "POST",
+        path = "/config",
+        body = {
+          config = [[
+          {
+            "_format_version" : "1.1",
+            "consumers" : [
+              {
+                "username" : "bobby",
+              },
+            ],
+          }
+          ]],
+        },
+        headers = {
+          ["Content-Type"] = "application/json"
+        }
+      })
+
+      assert.response(res).has.status(201)
+    end)
+    it("accepts configuration as a YAML string", function()
+      local res = assert(client:send {
+        method = "POST",
+        path = "/config",
+        body = {
+          config = [[
+          _format_version: "1.1"
+          consumers:
+          - username: bobby
+          ]],
+        },
+        headers = {
+          ["Content-Type"] = "application/json"
+        }
+      })
+
+      assert.response(res).has.status(201)
+    end)
+  end)
 end)


### PR DESCRIPTION
Previously:

```
http :8001/config config=@kong.json -v
POST /config HTTP/1.1
Accept: application/json, */*
Accept-Encoding: gzip, deflate
Connection: keep-alive
Content-Length: 98
Content-Type: application/json
Host: localhost:8001
User-Agent: HTTPie/0.9.8

{
    "config": "{\n\t\"_format_version\" : \"1.1\",\n\t\"consumers\": [ {\"username\":\"bobby\"}]}\n"
}

HTTP/1.1 201 Created
Access-Control-Allow-Origin: *
Connection: keep-alive
Content-Length: 143
Content-Type: application/json; charset=utf-8
Date: Fri, 19 Apr 2019 17:46:53 GMT
Server: kong/1.1.1

{
    "consumers": {
        "cd6e36ad-e192-452b-92f2-e5d3cd4eeabb": {
            "created_at": 1555696013,
            "id": "cd6e36ad-e192-452b-92f2-e5d3cd4eeabb",
            "username": "bobby"
        }
    }
}
```

And now, we also accept:

```
cat kong.json | http :8001/config -v
POST /config HTTP/1.1
Accept: application/json, */*
Accept-Encoding: gzip, deflate
Connection: keep-alive
Content-Length: 69
Content-Type: application/json
Host: localhost:8001
User-Agent: HTTPie/0.9.8

{
    "_format_version": "1.1",
    "consumers": [
        {
            "username": "bobby"
        }
    ]
}

HTTP/1.1 201 Created
Access-Control-Allow-Origin: *
Connection: keep-alive
Content-Length: 143
Content-Type: application/json; charset=utf-8
Date: Fri, 19 Apr 2019 17:47:29 GMT
Server: kong/1.1.1

{
    "consumers": {
        "99d5ed85-c14c-4cf5-ad51-cec60b9d6a3f": {
            "created_at": 1555696049,
            "id": "99d5ed85-c14c-4cf5-ad51-cec60b9d6a3f",
            "username": "bobby"
        }
    }
}
```