### PR TITLE
fix(dbless) do not send Upstream CRUD events on first init

### DIFF
--- a/kong/api/routes/config.lua
+++ b/kong/api/routes/config.lua
@@ -34,7 +34,7 @@ return {
         return kong.response.exit(400, { error = err_or_ver })
       end
 
-      local ok, err = declarative.load_into_cache(entities)
+      local ok, err = declarative.load_into_cache_with_events(entities)
       if not ok then
         kong.log.err("failed loading declarative config into cache: ", err)
         return kong.response.exit(500, { message = "An unexpected error occurred" })


### PR DESCRIPTION
Do not send Upstream CRUD events on `load_into_cache` when it is called during first initialization. Create a separate function `load_into_cache_with_events` which is used when refreshing the config in `/config`.

Fixes #4507.

There is no regression test due to the flaky nature of the problem.