### PR TITLE
feat(db): allow swagger path parameters

### DIFF
--- a/kong/db/schema/typedefs.lua
+++ b/kong/db/schema/typedefs.lua
@@ -56,7 +56,8 @@ end
 
 
 local function validate_path(path)
-  if not match(path, "^/[%w%.%-%_~%/%%]*$") then
+  -- Accept '$''{''}' and all characters defined in RFC 3986
+  if not match(path, "^/[%w%.%-%_~%/%%${}]*$") then
     return nil,
            "invalid path: '" .. path ..
            "' (characters outside of the reserved list of RFC 3986 found)",
@@ -304,7 +305,7 @@ typedefs.run_on_first = Schema.define {
 
 typedefs.tag = Schema.define {
   type = "string",
-  required = true, 
+  required = true,
   match = "^[%w%.%-%_~]+$",
 }
 


### PR DESCRIPTION
### Summary

Allow '$', '{' and '}' as allowed characters in upstream paths as they are used in swagger
to represent path variables.
This is not agains RFC 3986 and allow the use of swagger syntax for defining routers

### Full changelog

* [Feat] - Allow swagger path variables when defining upstreams in routes
