### PR TITLE
chore(log) improve dns failure logs

### DIFF
--- a/kong/globalpatches.lua
+++ b/kong/globalpatches.lua
@@ -280,9 +280,11 @@ return function(options)
 
     local function resolve_connect(f, sock, host, port, opts)
       if sub(host, 1, 5) ~= "unix:" then
-        host, port = toip(host, port)
+        local try_list
+        host, port, try_list = toip(host, port)
         if not host then
-          return nil, "[toip() name lookup failed]: " .. tostring(port)
+          return nil, "[toip() name lookup failed]: " .. tostring(port) ..
+                      ". Tried: ", tostring(try_list)
         end
       end
 


### PR DESCRIPTION
Regular tcp/udp connections would skip the additional debug info
available on dns lookup failure. Updated globalpatches to include
the additional infos.
