### PR TITLE
feat(*) better consistency of DNS resolution error messages

### DIFF
--- a/kong/db/strategies/cassandra/connector.lua
+++ b/kong/db/strategies/cassandra/connector.lua
@@ -97,10 +97,10 @@ function CassandraConnector.new(kong_config)
     local dns = dns_tools(kong_config)
 
     for i, cp in ipairs(kong_config.cassandra_contact_points) do
-      local ip, err = dns.toip(cp)
+      local ip, err, try_list = dns.toip(cp)
       if not ip then
-        log.error("could not resolve Cassandra contact point '%s': %s",
-                  cp, err)
+        log.error("[cassandra] DNS resolution failed for contact " ..
+                  "point '%s': %s. Tried: %s", cp, err, tostring(try_list))
 
       else
         log.debug("resolved Cassandra contact point '%s' to: %s", cp, ip)

--- a/kong/globalpatches.lua
+++ b/kong/globalpatches.lua
@@ -283,7 +283,7 @@ return function(options)
         local try_list
         host, port, try_list = toip(host, port)
         if not host then
-          return nil, "[toip() name lookup failed]: " .. tostring(port) ..
+          return nil, "[cosocket] DNS resolution failed: " .. tostring(port) ..
                       ". Tried: " .. tostring(try_list)
         end
       end

--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -819,7 +819,7 @@ local function execute(target, ctx)
     ip, port, try_list = toip(target.host, target.port, dns_cache_only)
     hostname = target.host
     if not ip then
-      log(ERR, "[dns] ", port, ". Tried: ", tostring(try_list))
+      log(ERR, "DNS resolution failed: ", port, ". Tried: ", tostring(try_list))
       if port == "dns server error: 3 name error" or
          port == "dns client error: 101 empty record received" then
         return nil, "name resolution failed", 503


### PR DESCRIPTION
Additions:

- Log the `try_list` JSON string upon DNS resolution failures in the
  Cassandra connector.

Changes for consistency:

- All DNS resolution failures contain the string "DNS resolution
  failed" which is something end-users can understand better than
  implementation details (e.g. "`toip()` called failed"). It can also be
  searched for much more easily.
- The Cassandra connector log is prefixed with the strategy name,
  `[cassandra]`, as all other CLI error messages already are.
- Cosockets DNS resolution failures are prefixed with `[cosocket]`,
  which is much easier to search for, and more obvious for seasoned users
  or maintainers. Since the "DNS resolution failed" string is also in
  the message, we consider this message insightful enough for end-users.
- The balancer's logs don't use a prefix (alas), so no prefix was added
  to the balancer's DNS resolution failure log.
