### PR TITLE
fix(migrations) fix migrations related error messages; migrations up -f fix; migrations finish -f addition

### DIFF
--- a/kong/cmd/migrations.lua
+++ b/kong/cmd/migrations.lua
@@ -1,6 +1,7 @@
 local DB = require "kong.db"
 local log = require "kong.cmd.utils.log"
 local tty = require "kong.cmd.utils.tty"
+local meta = require "kong.meta"
 local conf_loader = require "kong.conf_loader"
 local kong_global = require "kong.global"
 local migrations_utils = require "kong.cmd.utils.migrations"
@@ -94,21 +95,82 @@ local function execute(args)
 
   if args.command == "list" then
     if schema_state.needs_bootstrap then
-      log("database needs bootstrapping; run 'kong migrations bootstrap'")
-      os.exit(3)
+      if schema_state.legacy_invalid_state then
+        -- legacy: migration from 0.14 to 1.0 cannot be performed
+        if schema_state.legacy_missing_component then
+          log("Migrations can only be listed on a %s %s that has been " ..
+              "upgraded to 1.0, but the current %s seems to be older "  ..
+              "than 0.14 (missing migrations for '%s').",
+              db.strategy, db.infos.db_desc, db.infos.db_desc,
+              schema_state.legacy_missing_component)
+
+          os.exit(2)
+        end
+
+        if schema_state.legacy_missing_migration then
+          log("Migrations can only be listed on a %s %s that has been " ..
+              "upgraded to 1.0, but the current %s seems to be older "  ..
+              "than 0.14 (missing migration '%s' for '%s').",
+              db.strategy, db.infos.db_desc, db.infos.db_desc,
+              schema_state.legacy_missing_migration,
+              schema_state.legacy_missing_component)
+
+          os.exit(2)
+        end
+
+        log("Migrations can only be listed on a %s %s that has been "     ..
+            "upgraded to 1.0, but the current %s seems to be older than " ..
+            "0.14 (missing migrations).", db.strategy, db.infos.db_desc,
+            db.infos.db_desc)
+
+        os.exit(2)
+
+      elseif not schema_state.legacy_is_014 then
+        log("database needs bootstrapping; run 'kong migrations bootstrap'")
+        os.exit(3)
+      end
     end
+
+    local r = ""
 
     if schema_state.executed_migrations then
       log("executed migrations:\n%s", schema_state.executed_migrations)
+      r = "\n"
     end
 
-    migrations_utils.print_state(schema_state)
+    if schema_state.pending_migrations then
+      log("%spending migrations:\n%s", r, schema_state.pending_migrations)
+      r = "\n"
+    end
+
+    if schema_state.new_migrations then
+      log("%snew migrations available:\n%s", r, schema_state.new_migrations)
+      r = "\n"
+    end
+
+    if schema_state.pending_migrations and schema_state.new_migrations then
+      if r ~= "" then
+        log("")
+      end
+
+      log.warn("database has pending migrations from a previous upgrade, " ..
+               "and new migrations from this upgrade (version %s)",
+               tostring(meta._VERSION))
+
+      log("\nrun 'kong migrations finish' when ready to complete pending " ..
+          "migrations (%s %s will be incompatible with the previous Kong " ..
+          "version)", db.strategy, db.infos.db_desc)
+
+      os.exit(4)
+    end
 
     if schema_state.pending_migrations then
+      log("\nrun 'kong migrations finish' when ready")
       os.exit(4)
     end
 
     if schema_state.new_migrations then
+      log("\nrun 'kong migrations up' to proceed")
       os.exit(5)
     end
 

--- a/kong/cmd/utils/migrations.lua
+++ b/kong/cmd/utils/migrations.lua
@@ -8,36 +8,24 @@ local MIGRATIONS_MUTEX_KEY = "migrations"
 local NOT_LEADER_MSG = "aborted: another node is performing database changes"
 
 
-local function print_state(schema_state, lvl)
-  local elvl = lvl or "info"
+local function check_state(schema_state, db)
+  if not schema_state:is_up_to_date() then
+    if schema_state.needs_bootstrap then
+      if schema_state.legacy_invalid_state then
+        error(fmt("cannot start Kong 1.x with a legacy %s, upgrade to 0.14 " ..
+                  "first, and run 'kong migrations up'", db.infos.db_desc))
+      end
 
-  if schema_state.needs_bootstrap then
-    log[elvl]("database needs bootstrapping; run 'kong migrations bootstrap'")
-    return
-  end
+      if not schema_state.legacy_is_014 then
+        error("database needs bootstrapping; run 'kong migrations bootstrap'")
+      end
+    end
 
-  if schema_state.missing_migrations then
-    local mlvl = lvl or "warn"
-    log[mlvl]("database is missing some migrations:\n%s",
-              schema_state.missing_migrations)
-  end
-
-  if schema_state.pending_migrations then
-    log[elvl]("database has pending migrations:\n%s",
-              schema_state.pending_migrations)
-  end
-
-  if schema_state.new_migrations then
-    log[elvl]("database has new migrations available:\n%s\n%s",
-              schema_state.new_migrations,
-              "run 'kong migrations up' to proceed")
-
-  elseif not schema_state.pending_migrations
-     and not schema_state.missing_migrations then
-    log("database is up-to-date")
+    if schema_state.new_migrations then
+      error("new migrations available; run 'kong migrations up' to proceed")
+    end
   end
 end
-
 
 local function bootstrap(schema_state, db, ttl)
   if schema_state.needs_bootstrap then
@@ -47,7 +35,7 @@ local function bootstrap(schema_state, db, ttl)
     end
 
     if schema_state.legacy_invalid_state then
-      error(fmt("cannot bootstrap a non-empty %s, upgrade to 0.14 first," ..
+      error(fmt("cannot bootstrap a non-empty %s, upgrade to 0.14 first, " ..
                 "and run 'kong migrations up'", db.infos.db_desc))
     end
 
@@ -87,26 +75,27 @@ local function up(schema_state, db, opts)
       -- legacy: migration from 0.14 to 1.0 cannot be performed
       if schema_state.legacy_missing_component then
         error(fmt("Migration to 1.0 can only be performed from a 0.14 %s " ..
-                  "%s, but the current one seems to be older (missing "    ..
-                  "migrations for '%s'). Migrate to 0.14 first, or "  ..
+                  "%s, but the current %s seems to be older (missing "     ..
+                  "migrations for '%s'). Migrate to 0.14 first, or "       ..
                   "install 1.0 on a fresh %s.", db.strategy, db.infos.db_desc,
-                  schema_state.legacy_missing_component, db.infos.db_desc))
+                  db.infos.db_desc, schema_state.legacy_missing_component,
+                  db.infos.db_desc))
       end
 
       if schema_state.legacy_missing_migration then
         error(fmt("Migration to 1.0 can only be performed from a 0.14 %s " ..
-                  "%s, but the current one seems to be older (missing "    ..
+                  "%s, but the current %s seems to be older (missing "     ..
                   "migration '%s' for '%s'). Migrate to 0.14 first, or "   ..
                   "install 1.0 on a fresh %s.", db.strategy, db.infos.db_desc,
-                  schema_state.legacy_missing_migration,
+                  db.infos.db_desc, schema_state.legacy_missing_migration,
                   schema_state.legacy_missing_component, db.infos.db_desc))
       end
 
       error(fmt("Migration to 1.0 can only be performed from a 0.14 %s " ..
-                "%s, but the current one seems to be older (missing "    ..
+                "%s, but the current %s seems to be older (missing "     ..
                 "migrations). Migrate to 0.14 first, or install 1.0 "    ..
                 "on a fresh %s.", db.strategy, db.infos.db_desc,
-                db.infos.db_desc))
+                db.infos.db_desc, db.infos.db_desc))
     end
 
     if schema_state.legacy_is_014 then
@@ -175,13 +164,21 @@ end
 
 local function finish(schema_state, db, opts)
   if schema_state.needs_bootstrap then
-    log("cannot run migrations: database not bootstrapped")
-    return
+    if schema_state.legacy_invalid_state then
+      -- legacy: migration from 0.14 to 1.0 cannot be performed
+      error(fmt("cannot run migrations on a legacy %s", db.infos.db_desc))
+    end
+
+    if schema_state.legacy_is_014 then
+      error(fmt("cannot run migrations on a legacy %s; run 'kong " ..
+                "migrations up' to proceed", db.infos.db_desc))
+    end
+
+    error("cannot run migrations; run 'kong migrations bootstrap' instead")
   end
 
   if opts.force then
-    log("cannot use --force with 'finish'")
-    return
+    error("cannot use --force with 'finish'")
   end
 
   opts.no_wait = true -- exit the mutex if another node acquired it
@@ -250,5 +247,5 @@ return {
   reset = reset,
   finish = finish,
   bootstrap = bootstrap,
-  print_state = print_state,
+  check_state = check_state,
 }

--- a/kong/cmd/utils/migrations.lua
+++ b/kong/cmd/utils/migrations.lua
@@ -124,7 +124,7 @@ local function up(schema_state, db, opts)
   local ok, err = db:cluster_mutex(MIGRATIONS_MUTEX_KEY, opts, function()
     schema_state = assert(db:schema_state())
 
-    if schema_state.pending_migrations then
+    if not opts.force and schema_state.pending_migrations then
       error("database has pending migrations; run 'kong migrations finish'")
     end
 
@@ -134,13 +134,22 @@ local function up(schema_state, db, opts)
 
       assert(db:run_migrations(schema_state.executed_migrations, {
         run_up = true,
+        run_teardown = true,
+        skip_teardown_migrations = schema_state.pending_migrations
       }))
+
+      schema_state = assert(db:schema_state())
+      if schema_state.pending_migrations then
+        log("\ndatabase has pending migrations; run 'kong migrations finish' when ready")
+        return
+      end
     end
 
     if not schema_state.new_migrations then
       if not opts.force then
         log("database is already up-to-date")
       end
+
       return
     end
 
@@ -149,6 +158,12 @@ local function up(schema_state, db, opts)
     assert(db:run_migrations(schema_state.new_migrations, {
       run_up = true,
     }))
+
+    schema_state = assert(db:schema_state())
+    if schema_state.pending_migrations then
+      log("\ndatabase has pending migrations; run 'kong migrations finish' when ready")
+      return
+    end
   end)
   if err then
     error(err)

--- a/kong/db/migrations/state.lua
+++ b/kong/db/migrations/state.lua
@@ -9,7 +9,9 @@ local Errors = require "kong.db.errors"
 
 local MigrationSchema = Schema.new(Migration)
 
+
 local fmt = string.format
+local max = math.max
 
 
 local function prefix_err(db, err)
@@ -26,6 +28,11 @@ local Migrations_mt = {
   __tostring = function(t)
     local subsystems = {}
 
+    local max_length = 0
+    for _, subsys in ipairs(t) do
+      max_length = max(max_length, #subsys.subsystem)
+    end
+
     for _, subsys in ipairs(t) do
       local names = {}
 
@@ -33,8 +40,8 @@ local Migrations_mt = {
         table.insert(names, migration.name)
       end
 
-      table.insert(subsystems, fmt("%s: %s", subsys.subsystem,
-                                             table.concat(names, ", ")))
+      table.insert(subsystems, fmt("%" .. max_length .. "s: %s",
+                                   subsys.subsystem, table.concat(names, ", ")))
     end
 
     return table.concat(subsystems, "\n")

--- a/kong/db/strategies/connector.lua
+++ b/kong/db/strategies/connector.lua
@@ -149,10 +149,15 @@ function Connector:is_014()
   -- Implemented pre 1.0 release with Postgres/Cassandra connectors.
   -- All future connectors (if any) won't have to provide a mean to
   -- migrate from 0.14, hence do not have to implement this function.
-  return {
-    is_eq_014 = false,
-    is_gt_014 = true,
-  }
+  return {}
+end
+
+
+function Connector:are_014_apis_present()
+  -- Implemented pre 1.0 release with Postgres/Cassandra connectors.
+  -- All future connectors (if any) won't have to provide a mean to
+  -- migrate from 0.14, hence do not have to implement this function.
+  return false
 end
 
 

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -80,6 +80,8 @@ local cache_warmup = require "kong.cache_warmup"
 local plugins_iterator = require "kong.runloop.plugins_iterator"
 local balancer_execute = require("kong.runloop.balancer").execute
 local kong_error_handlers = require "kong.error_handlers"
+local migrations_utils = require "kong.cmd.utils.migrations"
+
 
 local kong             = kong
 local ngx              = ngx
@@ -277,17 +279,19 @@ function Kong.init()
   assert(db:init_connector())
 
   schema_state = assert(db:schema_state())
-  if schema_state.needs_bootstrap  then
-    error("database needs bootstrap; run 'kong migrations bootstrap'")
+  migrations_utils.check_state(schema_state, db)
 
-  elseif schema_state.new_migrations then
-    error("new migrations available; run 'kong migrations list'")
+  if schema_state.missing_migrations or schema_state.pending_migrations then
+    if schema_state.missing_migrations then
+      ngx_log(ngx_WARN, "database is missing some migrations:\n",
+                        schema_state.missing_migrations)
+    end
+
+    if schema_state.pending_migrations then
+      ngx_log(ngx_WARN, "database has pending migrations:\n",
+                        schema_state.pending_migrations)
+    end
   end
-  --[[
-  if schema_state.pending_migrations then
-    assert(db:load_pending_migrations(schema_state.pending_migrations))
-  end
-  --]]
 
   assert(db:connect())
   assert(db.plugins:check_db_against_config(config.loaded_plugins))

--- a/spec/02-integration/02-cmd/10-migrations_spec.lua
+++ b/spec/02-integration/02-cmd/10-migrations_spec.lua
@@ -169,8 +169,11 @@ for _, strategy in helpers.each_strategy() do
           plugins = "with-migrations",
         })
         assert.same(5, code)
-        assert.match("database has new migrations available:\n" ..
-                     "with-migrations: 000_base_with_migrations, 001_14_to_15",
+        assert.match("executed migrations:\n" ..
+                     "core: 000_base\n\n" ..
+                     "new migrations available:\n" ..
+                     "with-migrations: 000_base_with_migrations, 001_14_to_15\n\n" ..
+                     "run 'kong migrations up' to proceed",
                      stdout, 1, true)
       end)
 


### PR DESCRIPTION
### Summary

This PR is meant to fix issues reported here:
https://discuss.konghq.com/t/automating-database-migration-for-a-cd-pipeline/2920

Schema state checking is improved on:
- `kong migrations list`
- `kong start`
- and kong's init

This PR now also includes two extra commits:
1. `fix(migrations) migrations up with -f will also run the executed teardowns`
2. `feat(migrations) migrations finish with -f will also run the executed migrations`