### PR TITLE
fix(api) correctly return "not found" on disabled endpoints

### DIFF
--- a/kong/api/endpoints.lua
+++ b/kong/api/endpoints.lua
@@ -658,7 +658,9 @@ end
 -- A reusable handler for endpoints that are deactivated
 -- (e.g. /targets/:targets)
 local disable = {
-  before = not_found
+  before = function()
+    return not_found()
+  end
 }
 
 

--- a/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -52,6 +52,18 @@ describe("Admin API #" .. strategy, function()
     if client then client:close() end
   end)
 
+  describe("/targets", function()
+    it("returns a 404", function()
+      local res = assert(client:send {
+        method = "GET",
+        path = "/targets"
+      })
+      assert.response(res).has.status(404)
+      local json = assert.response(res).has.jsonbody()
+      assert.equal("Not found", json.message)
+    end)
+  end)
+
   describe("/upstreams/{upstream}/targets/", function()
     describe("POST", function()
       it_content_types("creates a target with defaults", function(content_type)


### PR DESCRIPTION
Previously, a disabled endpoint like `GET /targets` would return:
```
{"message":"table: 0x487eb080table: 0x4198c950table: 0x40ea27e0"}
```

This has been updated to correctly return the body now and a regression
test has been added.