### PR TITLE
chore(deps) bump lua-resty-mlcache to 2.4.0

### DIFF
--- a/kong-1.1.2-0.rockspec
+++ b/kong-1.1.2-0.rockspec
@@ -35,7 +35,7 @@ dependencies = {
   "lua-resty-mediador == 0.1.2",
   "lua-resty-healthcheck == 0.6.1",
   "lua-resty-cookie == 0.1.0",
-  "lua-resty-mlcache == 2.3.0",
+  "lua-resty-mlcache == 2.4.0",
   -- external Kong plugins
   "kong-plugin-azure-functions ~> 0.3",
   "kong-plugin-kubernetes-sidecar-injector ~> 0.1",


### PR DESCRIPTION
Cherry-picked from `next` to reduce GC pressure during `/config` events triggering a `cache:purge()` event.

---

This release of mlcache introduces the new `get_bulk()` API needed by
the wildcard SNI feature.

Changelog for 2.4.0:

https://github.com/thibaultcha/lua-resty-mlcache/blob/master/CHANGELOG.md#2.4.0