### PR TITLE
fix(api) correct error message when /config is given no input

### DIFF
--- a/kong/api/routes/config.lua
+++ b/kong/api/routes/config.lua
@@ -30,7 +30,12 @@ return {
       if self.params._format_version then
         entities, err_or_ver = dc:parse_table(self.params)
       else
-      local config = self.params.config
+        local config = self.params.config
+        if not config then
+          return kong.response.exit(400, {
+            message = "expected a declarative configuration"
+          })
+        end
         -- TODO extract proper filename from the input
         entities, err_or_ver = dc:parse_string(config, "config.yml", accept)
       end

--- a/spec/02-integration/04-admin_api/15-off_spec.lua
+++ b/spec/02-integration/04-admin_api/15-off_spec.lua
@@ -253,10 +253,23 @@ describe("Admin API #off", function()
         }
       })
 
-      local body =assert.response(res).has.status(400)
+      local body = assert.response(res).has.status(400)
       local json = cjson.decode(body)
       assert.same({
         error = "expected a table as input",
+      }, json)
+    end)
+
+    it("returns 400 when given no input", function()
+      local res = assert(client:send {
+        method = "POST",
+        path = "/config",
+      })
+
+      local body = assert.response(res).has.status(400)
+      local json = cjson.decode(body)
+      assert.same({
+        message = "expected a declarative configuration",
       }, json)
     end)
   end)


### PR DESCRIPTION
Catch the case where `/config` is POSTed with no input, and produce
a generic error message instead of dumping an internal lyaml error like

```
{
    "error": "failed parsing declarative configuration file config.yml: .../.luaver/luarocks/3.0.4_5.1/share/lua/5.1/lyaml/init.lua:445: bad argument #1 to 'parser' (must provide a string argument)"
}
```

Thanks @bungle for the report!
