### PR TITLE
feat(cache) introduce cache warmup for entities and DNS

### DIFF
--- a/kong-1.1.2-0.rockspec
+++ b/kong-1.1.2-0.rockspec
@@ -56,6 +56,7 @@ build = {
     ["kong.singletons"] = "kong/singletons.lua",
     ["kong.concurrency"] = "kong/concurrency.lua",
     ["kong.conf_loader"] = "kong/conf_loader.lua",
+    ["kong.cache_warmup"] = "kong/cache_warmup.lua",
     ["kong.globalpatches"] = "kong/globalpatches.lua",
     ["kong.error_handlers"] = "kong/error_handlers.lua",
 

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -600,6 +600,23 @@
                                  # expires, a new attempt to refresh the stale
                                  # entities will be made.
 
+#db_cache_warmup_entities = services, plugins
+                                 # Entities to be pre-loaded from the datastore
+                                 # into the in-memory cache at Kong start-up.
+                                 # This speeds up the first access of endpoints
+                                 # that use the given entities.
+                                 #
+                                 # When the `services` entity is configured
+                                 # for warmup, the DNS entries for values in
+                                 # its `host` attribute are pre-resolved
+                                 # asynchronously as well.
+                                 #
+                                 # Cache size set in `mem_cache_size` should
+                                 # be set to a value large enough to hold all
+                                 # instances of the specified entities.
+                                 # If the size is insufficient, Kong will log
+                                 # a warning.
+
 #------------------------------------------------------------------------------
 # DNS RESOLVER
 #------------------------------------------------------------------------------

--- a/kong/cache.lua
+++ b/kong/cache.lua
@@ -227,8 +227,11 @@ end
 
 
 function _M:safe_set(key, value)
-  local str_marshalled = marshall_for_shm(value, self.mlcache.ttl,
-                                                 self.mlcache.neg_ttl)
+  local str_marshalled, err = marshall_for_shm(value, self.mlcache.ttl,
+                                                      self.mlcache.neg_ttl)
+  if err then
+    return nil, err
+  end
 
   return ngx.shared[SHM_CACHE]:safe_set(SHM_CACHE .. key, str_marshalled)
 end

--- a/kong/cache.lua
+++ b/kong/cache.lua
@@ -24,6 +24,82 @@ Floored: 500.000 items should be a good default
 local LRU_SIZE = 5e5
 
 
+-------------------------------------------------------------------------------
+-- NOTE: the following is copied from lua-resty-mlcache:                     --
+------------------------------------------------------------------------ cut --
+local cjson = require "cjson.safe"
+
+
+local fmt = string.format
+local now = ngx.now
+
+
+local TYPES_LOOKUP = {
+  number  = 1,
+  boolean = 2,
+  string  = 3,
+  table   = 4,
+}
+
+
+local marshallers = {
+  shm_value = function(str_value, value_type, at, ttl)
+      return fmt("%d:%f:%f:%s", value_type, at, ttl, str_value)
+  end,
+
+  shm_nil = function(at, ttl)
+      return fmt("0:%f:%f:", at, ttl)
+  end,
+
+  [1] = function(number) -- number
+      return tostring(number)
+  end,
+
+  [2] = function(bool)   -- boolean
+      return bool and "true" or "false"
+  end,
+
+  [3] = function(str)    -- string
+      return str
+  end,
+
+  [4] = function(t)      -- table
+      local json, err = cjson.encode(t)
+      if not json then
+          return nil, "could not encode table value: " .. err
+      end
+
+      return json
+  end,
+}
+
+
+local function marshall_for_shm(value, ttl, neg_ttl)
+  local at = now()
+
+  if value == nil then
+      return marshallers.shm_nil(at, neg_ttl), nil, true -- is_nil
+  end
+
+  -- serialize insertion time + Lua types for shm storage
+
+  local value_type = TYPES_LOOKUP[type(value)]
+
+  if not marshallers[value_type] then
+      error("cannot cache value of type " .. type(value))
+  end
+
+  local str_marshalled, err = marshallers[value_type](value)
+  if not str_marshalled then
+      return nil, "could not serialize value for lua_shared_dict insertion: "
+                  .. err
+  end
+
+  return marshallers.shm_value(str_marshalled, value_type, at, ttl)
+end
+------------------------------------------------------------------------ end --
+
+
 local _init
 
 
@@ -147,6 +223,14 @@ function _M:get_bulk(bulk, opts)
   end
 
   return res
+end
+
+
+function _M:safe_set(key, value)
+  local str_marshalled = marshall_for_shm(value, self.mlcache.ttl,
+                                                 self.mlcache.neg_ttl)
+
+  return ngx.shared[SHM_CACHE]:safe_set(SHM_CACHE .. key, str_marshalled)
 end
 
 

--- a/kong/cache_warmup.lua
+++ b/kong/cache_warmup.lua
@@ -2,23 +2,25 @@ local cache_warmup = {}
 
 
 local tostring = tostring
-local ipairs = ipairs
+local pairs = pairs
 local math = math
 local kong = kong
 local ngx = ngx
 
 
 local ENTITIES_TO_WARMUP = {
-  "services",
-  "plugins",
+  ["services"] = true,
+  ["plugins"] = true,
 }
 
 
-local function cache_warmup_single_entity(entity_name)
-  local dao = kong.db[entity_name]
-  if not dao then
-    return nil, "Invalid entity name found when warming up the cache: " .. tostring(entity_name)
-  end
+local function fail_cb()
+  error("this should never be called as L2 should already be warmed")
+end
+
+
+local function cache_warmup_single_entity(dao)
+  local entity_name = dao.schema.name
 
   ngx.log(ngx.NOTICE, "Preloading '", entity_name, "' into the cache ...")
 
@@ -36,9 +38,8 @@ local function cache_warmup_single_entity(entity_name)
       return nil, err
     end
 
-    local ok, err = kong.cache:get(cache_key, nil, function()
-      return entity
-    end)
+    -- NOTE: this is just for warming up L1
+    ok, err = kong.cache:get(cache_key, nil, fail_cb)
     if not ok then
       return nil, err
     end
@@ -56,23 +57,30 @@ end
 -- access. This function is intented to be used during worker initialization
 -- The list of entities to be loaded is defined by the ENTITIES_TO_WARMUP
 -- variable.
-function cache_warmup.execute()
+function cache_warmup.execute(configured_plugins)
   if not kong.cache then
     return true
   end
 
-  for _, entity_name in ipairs(ENTITIES_TO_WARMUP) do
-    local ok, err = cache_warmup_single_entity(entity_name)
-    if not ok then
-      if err == "no memory" then
-        kong.log.warn("cache warmup has been stopped because cache ",
-                      "memory is exhausted, please consider increasing ",
-                      "the value of 'mem_cache_size' (currently at ",
-                      kong.configuration.mem_cache_size, ")")
+  for entity_name, dao in pairs(kong.db.daos) do
+    local warmup = ENTITIES_TO_WARMUP[entity_name]
+    if not warmup and dao.plugin_name then
+      warmup = configured_plugins[dao.plugin_name]
+    end
 
-        return true
+    if warmup then
+      local ok, err = cache_warmup_single_entity(dao)
+      if not ok then
+        if err == "no memory" then
+          kong.log.warn("cache warmup has been stopped because cache ",
+                        "memory is exhausted, please consider increasing ",
+                        "the value of 'mem_cache_size' (currently at ",
+                        kong.configuration.mem_cache_size, ")")
+
+          return true
+        end
+        return nil, err
       end
-      return nil, err
     end
   end
 

--- a/kong/cache_warmup.lua
+++ b/kong/cache_warmup.lua
@@ -11,6 +11,11 @@ local kong = kong
 local ngx = ngx
 
 
+function cache_warmup._mock_kong(mock_kong)
+  kong = mock_kong
+end
+
+
 local function warmup_dns(premature, hosts, count)
   if premature then
     return

--- a/kong/cache_warmup.lua
+++ b/kong/cache_warmup.lua
@@ -1,0 +1,66 @@
+local cache_warmup = {}
+
+
+local kong = kong
+local ngx = ngx
+
+
+local ENTITIES_TO_WARMUP = {
+  "services",
+  "plugins",
+}
+
+
+local function cache_warmup_single_entity(entity_name)
+  local dao = kong.db[entity_name]
+  if not dao then
+    return nil, "Invalid entity name found when warming up the cache: " .. tostring(entity_name)
+  end
+
+  ngx.log(ngx.NOTICE, "Preloading '", entity_name, "' into the cache ...")
+
+  local start = ngx.now()
+
+  for entity, err in dao:each(1000) do
+    if err then
+      return nil, err
+    end
+
+    local cache_key = dao:cache_key(entity)
+    local ok, err = kong.cache:get(cache_key, nil, function()
+      return entity
+    end)
+    if not ok then
+      return nil, err
+    end
+  end
+
+  local elapsed = math.floor((ngx.now() - start) * 1000)
+
+  ngx.log(ngx.NOTICE, "finished preloading '", entity_name,
+                      "' into the cache (in ", tostring(elapsed), "ms)")
+  return true
+end
+
+
+-- Loads entities from the database into the cache, for rapid subsequent
+-- access. This function is intented to be used during worker initialization
+-- The list of entities to be loaded is defined by the ENTITIES_TO_WARMUP
+-- variable.
+function cache_warmup.execute()
+  if not kong.cache then
+    return true
+  end
+
+  for _, entity_name in ipairs(ENTITIES_TO_WARMUP) do
+    local ok, err = cache_warmup_single_entity(entity_name)
+    if not ok then
+      return nil, err
+    end
+  end
+
+  return true
+end
+
+
+return cache_warmup

--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -96,6 +96,7 @@ local CONF_INFERENCES = {
   db_update_propagation = {  typ = "number"  },
   db_cache_ttl = {  typ = "number"  },
   db_resurrect_ttl = {  typ = "number"  },
+  db_cache_warmup_entities = { typ = "array" },
   nginx_user = { typ = "string" },
   nginx_worker_processes = { typ = "string" },
   upstream_keepalive = { typ = "number" },

--- a/kong/db/dao/plugins.lua
+++ b/kong/db/dao/plugins.lua
@@ -189,7 +189,6 @@ local function load_plugin_entity_strategy(schema, db, plugin)
   if not dao then
     return nil, err
   end
-  dao.plugin_name = plugin
   db.daos[schema.name] = dao
 end
 

--- a/kong/db/dao/plugins.lua
+++ b/kong/db/dao/plugins.lua
@@ -189,6 +189,7 @@ local function load_plugin_entity_strategy(schema, db, plugin)
   if not dao then
     return nil, err
   end
+  dao.plugin_name = plugin
   db.daos[schema.name] = dao
 end
 

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -251,8 +251,12 @@ end
 
 
 local function execute_cache_warmup(kong_config)
+  if kong_config.database == "off" then
+    return true
+  end
+
   if ngx.worker.id() == 0 then
-    local ok, err = cache_warmup.execute(kong_config.loaded_plugins)
+    local ok, err = cache_warmup.execute(kong_config.db_cache_warmup_entities)
     if not ok then
       return nil, err
     end

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -250,9 +250,9 @@ local function execute_plugins(ctx, phase)
 end
 
 
-local function execute_cache_warmup()
+local function execute_cache_warmup(kong_config)
   if ngx.worker.id() == 0 then
-    local ok, err = cache_warmup.execute()
+    local ok, err = cache_warmup.execute(kong_config.loaded_plugins)
     if not ok then
       return nil, err
     end
@@ -617,7 +617,7 @@ function Kong.init_worker()
     return
   end
 
-  ok, err = execute_cache_warmup()
+  ok, err = execute_cache_warmup(kong.configuration)
   if not ok then
     ngx_log(ngx_CRIT, "error warming up cache: ", err)
     return

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -66,6 +66,7 @@ db_update_frequency = 5
 db_update_propagation = 0
 db_cache_ttl = 0
 db_resurrect_ttl = 30
+db_cache_warmup_entities = services, plugins
 
 dns_resolver = NONE
 dns_hostsfile = /etc/hosts

--- a/spec/01-unit/01-db/08-cache_warmup_spec.lua
+++ b/spec/01-unit/01-db/08-cache_warmup_spec.lua
@@ -1,0 +1,228 @@
+local cache_warmup = require("kong.cache_warmup")
+
+
+local function mock_entity(db_data, entity_name, cache_key)
+  return {
+    schema = {
+      name = entity_name,
+    },
+    each = function()
+      local i = 0
+      return function()
+        i = i + 1
+        return db_data[entity_name][i]
+      end
+    end,
+    cache_key = function(self, value)
+      return tostring(value[cache_key])
+    end
+  }
+end
+
+
+local function mock_cache(cache_table, limit)
+  return {
+    safe_set = function(self, k, v)
+      if limit then
+        local n = 0
+        for _, _ in pairs(cache_table) do
+          n = n + 1
+        end
+        if n >= limit then
+          return nil, "no memory"
+        end
+      end
+      cache_table[k] = v
+      return true
+    end,
+    get = function(self, k, _, fn, arg)
+      if cache_table[k] == nil then
+        cache_table[k] = fn(arg)
+      end
+      return cache_table[k]
+    end,
+  }
+end
+
+
+local function mock_log(logged_warnings, logged_notices)
+  return {
+    warn = function(...)
+      table.insert(logged_warnings, table.concat({...}))
+    end,
+    notice = function(...)
+      table.insert(logged_notices, table.concat({...}))
+    end,
+  }
+end
+
+
+describe("cache_warmup", function()
+
+  it("caches entities", function()
+    local cache_table = {}
+    local db_data = {
+      ["my_entity"] = {
+        { aaa = 111, bbb = 222 },
+        { aaa = 333, bbb = 444 },
+      },
+      ["another_entity"] = {
+        { xxx = 555, yyy = 666 },
+        { xxx = 777, yyy = 888 },
+      }
+    }
+
+    local kong = {
+      db = {
+        my_entity = mock_entity(db_data, "my_entity", "aaa"),
+        another_entity = mock_entity(db_data, "another_entity", "xxx"),
+      },
+      cache = mock_cache(cache_table),
+    }
+
+    cache_warmup._mock_kong(kong)
+
+    assert.truthy(cache_warmup.execute({"my_entity", "another_entity"}))
+
+    assert.same(kong.cache:get("111").bbb, 222)
+    assert.same(kong.cache:get("333").bbb, 444)
+    assert.same(kong.cache:get("555").yyy, 666)
+    assert.same(kong.cache:get("777").yyy, 888)
+  end)
+
+  it("does not cache routes", function()
+    local cache_table = {}
+    local logged_notices = {}
+    local db_data = {
+      ["my_entity"] = {
+        { aaa = 111, bbb = 222 },
+        { aaa = 333, bbb = 444 },
+      },
+      ["routes"] = {
+        { xxx = 555, yyy = 666 },
+        { xxx = 777, yyy = 888 },
+      }
+    }
+
+    local kong = {
+      db = {
+        my_entity = mock_entity(db_data, "my_entity", "aaa"),
+        routes = mock_entity(db_data, "routes", "xxx"),
+      },
+      cache = mock_cache(cache_table),
+      log = mock_log(nil, logged_notices),
+    }
+
+    cache_warmup._mock_kong(kong)
+
+    assert.truthy(cache_warmup.execute({"my_entity", "routes"}))
+
+    assert.match("the 'routes' entry is ignored", logged_notices[1], 1, true)
+
+    assert.same(kong.cache:get("111").bbb, 222)
+    assert.same(kong.cache:get("333").bbb, 444)
+    assert.same(kong.cache:get("555", nil, function() return "nope" end), "nope")
+    assert.same(kong.cache:get("777", nil, function() return "nope" end), "nope")
+  end)
+
+  it("warms up DNS when caching services", function()
+    local cache_table = {}
+    local db_data = {
+      ["my_entity"] = {
+        { aaa = 111, bbb = 222 },
+        { aaa = 333, bbb = 444 },
+      },
+      ["services"] = {
+        { name = "a", host = "example.com", },
+        { name = "b", host = "1.2.3.4", }, -- should be skipped by DNS caching
+        { name = "c", host = "example.test", },
+      }
+    }
+    local dns_queries = {}
+
+    local kong = {
+      db = {
+        my_entity = mock_entity(db_data, "my_entity", "aaa"),
+        services = mock_entity(db_data, "services", "name"),
+      },
+      cache = mock_cache(cache_table),
+      dns = {
+        toip = function(query)
+          table.insert(dns_queries, query)
+        end,
+      }
+    }
+
+    cache_warmup._mock_kong(kong)
+
+    assert.truthy(cache_warmup.execute({"my_entity", "services"}))
+
+    ngx.sleep(0) -- yield so that async DNS caching happens
+
+    assert.same(kong.cache:get("111").bbb, 222)
+    assert.same(kong.cache:get("333").bbb, 444)
+    assert.same(kong.cache:get("a").host, "example.com")
+    assert.same(kong.cache:get("b").host, "1.2.3.4")
+    assert.same(kong.cache:get("c").host, "example.test")
+
+    -- skipped IP entry
+    assert.same({ "example.com", "example.test" }, dns_queries)
+  end)
+
+  it("logs a warning on bad entities", function()
+    local logged_warnings = {}
+
+    local kong = {
+      db = {},
+      cache = {},
+      log = mock_log(logged_warnings),
+    }
+
+    cache_warmup._mock_kong(kong)
+
+    assert.truthy(cache_warmup.execute({"invalid_entity"}))
+
+    assert.match("invalid_entity is not a valid entity name", logged_warnings[1], 1, true)
+  end)
+
+  it("halts warmup and logs when cache is full", function()
+    local logged_warnings = {}
+    local cache_table = {}
+    local db_data = {
+      ["my_entity"] = {
+        { aaa = 111, bbb = 222 },
+        { aaa = 333, bbb = 444 },
+      },
+      ["another_entity"] = {
+        { xxx = 555, yyy = 666 },
+        { xxx = 777, yyy = 888 },
+        { xxx = 999, yyy = 000 },
+      }
+    }
+
+    local kong = {
+      db = {
+        my_entity = mock_entity(db_data, "my_entity", "aaa"),
+        another_entity = mock_entity(db_data, "another_entity", "xxx"),
+      },
+      cache = mock_cache(cache_table, 3),
+      log = mock_log(logged_warnings),
+      configuration = {
+        mem_cache_size = 12345,
+      },
+    }
+
+    cache_warmup._mock_kong(kong)
+
+    assert.truthy(cache_warmup.execute({"my_entity", "another_entity"}))
+
+    assert.match("cache warmup has been stopped", logged_warnings[1], 1, true)
+
+    assert.same(kong.cache:get("111").bbb, 222)
+    assert.same(kong.cache:get("333").bbb, 444)
+    assert.same(kong.cache:get("555").yyy, 666)
+    assert.same(kong.cache:get("777", nil, function() return "nope" end), "nope")
+    assert.same(kong.cache:get("999", nil, function() return "nope" end), "nope")
+  end)
+
+end)


### PR DESCRIPTION
Introduces a new configuration property, `db_cache_warmup_entities`, which allows the user to specify which entities should be warmed up at initialization. 

From the documentation at `kong.conf.default`:

```
#db_cache_warmup_entities = services, plugins
                                 # Entities to be pre-loaded from the datastore
                                 # into the in-memory cache at Kong start-up.
                                 # This speeds up the first access of endpoints
                                 # that use the given entities.
                                 #
                                 # When the `services` entity is configured
                                 # for warmup, the DNS entries for values in
                                 # its `host` attribute are pre-resolved
                                 # asynchronously as well.
                                 #
                                 # Cache size set in `mem_cache_size` should
                                 # be set to a value large enough to hold all
                                 # instances of the specified entities.
                                 # If the size is insufficient, Kong will log
                                 # a warning.
```

The default value is `services, plugins`: the `routes` entity does not need to be warmed up because it is cached via the in-memory router object; specifying this in this configuration property is a no-op.

Includes unit tests for the `kong.cache_warmup` module.

This is a port of work produced by @bungle and kikito in #4408, #4462, #4468, #4488. Thanks @thibaultcha for the preliminary feedback and suggestions on the property name and specifics of the behavior.

(Note that, at @thibaultcha's suggestion, this PR replaces the "cache prewarm" terminology for the more usual "cache warmup" in all commits.)

Closes #4408.