### PR TITLE
chore(deps) bump luatz to 0.4

### DIFF
--- a/kong-1.1.2-0.rockspec
+++ b/kong-1.1.2-0.rockspec
@@ -22,7 +22,7 @@ dependencies = {
   "kong-lapis == 1.6.0.1",
   "lua-cassandra == 1.3.4",
   "pgmoon == 1.9.0",
-  "luatz == 0.3",
+  "luatz == 0.4",
   "http == 0.3",
   "lua_system_constants == 0.1.3",
   "lyaml == 6.2.3",


### PR DESCRIPTION
### Summary

Bump `luatz` dependency to `0.4`.

- Fix timetable normalisation carry bugs (#10, #13)
- Clean up of docs
- No longer throw errors in parse module on error (now return nil, err)
- Support version 3 tzfiles