### PR TITLE
chore(deps) bump pgmoon to 1.10.0

### DIFF
--- a/kong-1.1.2-0.rockspec
+++ b/kong-1.1.2-0.rockspec
@@ -21,7 +21,7 @@ dependencies = {
   "version == 1.0.1",
   "kong-lapis == 1.6.0.1",
   "lua-cassandra == 1.3.4",
-  "pgmoon == 1.9.0",
+  "pgmoon == 1.10.0",
   "luatz == 0.3",
   "http == 0.3",
   "lua_system_constants == 0.1.3",


### PR DESCRIPTION
### Summary

Bump `pgmoon` dependency to `1.10.0`.

* fix fail to run query if it has null byte
* use luaossl for md5 before lua crypto, add better error