### PR TITLE
chore(deps) bump luasec to 0.8

### DIFF
--- a/kong-1.1.2-0.rockspec
+++ b/kong-1.1.2-0.rockspec
@@ -12,7 +12,7 @@ description = {
 }
 dependencies = {
   "inspect == 3.1.1",
-  "luasec == 0.7",
+  "luasec == 0.8",
   "luasocket == 3.0-rc1",
   "penlight == 1.5.4",
   "lua-resty-http == 0.13",


### PR DESCRIPTION
### Summary

Bump `luasec` dependency to `0.8`.

* Add support to ALPN
* Add support to TLS 1.3
* Add support to multiple certificates
* Add timeout to https module (https.TIMEOUT)
* Drop support to SSL 3.0
* Drop support to TLS 1.0 from https module
* Fix invalid reference to Lua state
* Fix memory leak when get certficate extensions