### PR TITLE
fix(declarative) dao transformations are not performed by declarative config

### DIFF
--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -17,7 +17,9 @@ if [ "$TEST_SUITE" == "integration" ]; then
     eval "$TEST_CMD" spec/02-integration/
 fi
 if [ "$TEST_SUITE" == "dbless" ]; then
-    eval "$TEST_CMD" spec/02-integration/02-cmd spec/02-integration/05-proxy
+    eval "$TEST_CMD" spec/02-integration/02-cmd \
+                     spec/02-integration/05-proxy \
+                     spec/03-plugins/10-basic-auth/03-access_spec.lua
 fi
 if [ "$TEST_SUITE" == "plugins" ]; then
     eval "$TEST_CMD" spec/03-plugins/

--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -855,7 +855,7 @@ function DAO:insert(entity, options)
     return nil, err, err_t
   end
 
-  self:post_crud_event("create", row)
+  self:post_crud_event("create", row, nil, options)
 
   return row
 end
@@ -1044,7 +1044,11 @@ function DAO:row_to_entity(row, options)
 end
 
 
-function DAO:post_crud_event(operation, entity, old_entity)
+function DAO:post_crud_event(operation, entity, old_entity, options)
+  if options and options.no_broadcast_crud_event then
+    return
+  end
+
   if self.events then
     local _, err = self.events.post_local("dao:crud", operation, {
       operation  = operation,

--- a/spec/02-integration/05-proxy/04-plugins_triggering_spec.lua
+++ b/spec/02-integration/05-proxy/04-plugins_triggering_spec.lua
@@ -1010,7 +1010,7 @@ for _, strategy in helpers.each_strategy() do
       end)
     end)
 
-    describe("plugin with run_on", function()
+    describe("plugin with", function()
       describe("#http", function()
         local proxy_ssl_client
 
@@ -1520,7 +1520,7 @@ for _, strategy in helpers.each_strategy() do
           helpers.stop_kong("servroot2", true)
         end)
 
-        it("= 'first' does get executed when running on first", function()
+        it("run_on = 'first' does get executed when running on first", function()
           local res = assert(proxy_client:get("/status/200", {
             headers = {
               ["Host"] = "first-on-first.org",
@@ -1536,7 +1536,7 @@ for _, strategy in helpers.each_strategy() do
           }, json)
         end)
 
-        it("= 'first' does get executed when running on first (https)", function()
+        it("run_on = 'first' does get executed when running on first (https)", function()
           local res = assert(proxy_ssl_client:get("/status/200", {
             headers = {
               ["Host"] = "first-on-first-https.org",
@@ -1552,7 +1552,7 @@ for _, strategy in helpers.each_strategy() do
           }, json)
         end)
 
-        it("= 'first' does not get executed when running on second", function()
+        it("run_on = 'first' does not get executed when running on second", function()
           local res = assert(proxy_client:get("/", {
             headers = {
               ["Host"] = "first-on-second.org",
@@ -1568,7 +1568,7 @@ for _, strategy in helpers.each_strategy() do
           }, json)
         end)
 
-        it("= 'first' does not get executed when running on second (https)", function()
+        it("run_on = 'first' does not get executed when running on second (https)", function()
           local res = assert(proxy_ssl_client:get("/", {
             headers = {
               ["Host"] = "first-on-second-https.org",
@@ -1584,7 +1584,7 @@ for _, strategy in helpers.each_strategy() do
           }, json)
         end)
 
-        it("= 'second' does get executed when running on second", function()
+        it("run_on = 'second' does get executed when running on second", function()
           local res = assert(proxy_client:get("/", {
             headers = {
               ["Host"] = "second-on-second.org",
@@ -1600,7 +1600,7 @@ for _, strategy in helpers.each_strategy() do
           }, json)
         end)
 
-        it("= 'second' does get executed when running on second (https)", function()
+        it("run_on = 'second' does get executed when running on second (https)", function()
           local res = assert(proxy_ssl_client:get("/", {
             headers = {
               ["Host"] = "second-on-second-https.org",
@@ -1616,7 +1616,7 @@ for _, strategy in helpers.each_strategy() do
           }, json)
         end)
 
-        it("= 'second' does not get executed when running on first", function()
+        it("run_on = 'second' does not get executed when running on first", function()
           local res = assert(proxy_client:get("/status/200", {
             headers = {
               ["Host"] = "second-on-first.org",
@@ -1632,7 +1632,7 @@ for _, strategy in helpers.each_strategy() do
           }, json)
         end)
 
-        it("= 'second' does not get executed when running on first (https)", function()
+        it("run_on = 'second' does not get executed when running on first (https)", function()
           local res = assert(proxy_ssl_client:get("/status/200", {
             headers = {
               ["Host"] = "second-on-first-https.org",
@@ -1648,7 +1648,7 @@ for _, strategy in helpers.each_strategy() do
           }, json)
         end)
 
-        it("= 'all' does get executed when running on first", function()
+        it("run_on = 'all' does get executed when running on first", function()
           local res = assert(proxy_client:get("/status/200", {
             headers = {
               ["Host"] = "all-on-first.org",
@@ -1664,7 +1664,7 @@ for _, strategy in helpers.each_strategy() do
           }, json)
         end)
 
-        it("= 'all' does get executed when running on first (https)", function()
+        it("run_on = 'all' does get executed when running on first (https)", function()
           local res = assert(proxy_ssl_client:get("/status/200", {
             headers = {
               ["Host"] = "all-on-first-https.org",
@@ -1680,7 +1680,7 @@ for _, strategy in helpers.each_strategy() do
           }, json)
         end)
 
-        it("= 'all' does get executed when running on second", function()
+        it("run_on = 'all' does get executed when running on second", function()
           local res = assert(proxy_client:get("/", {
             headers = {
               ["Host"] = "all-on-second.org",
@@ -1696,7 +1696,7 @@ for _, strategy in helpers.each_strategy() do
           }, json)
         end)
 
-        it("= 'all' does get executed when running on second (https)", function()
+        it("run_on = 'all' does get executed when running on second (https)", function()
           local res = assert(proxy_ssl_client:get("/", {
             headers = {
               ["Host"] = "all-on-second-https.org",
@@ -2194,7 +2194,7 @@ for _, strategy in helpers.each_strategy() do
           helpers.stop_kong("servroot2", true)
         end)
 
-        it("= 'first' does get executed when running on first", function()
+        it("run_on = 'first' does get executed when running on first", function()
           local tcp = ngx.socket.tcp()
           assert(tcp:connect("127.0.0.1", 18003))
 
@@ -2210,7 +2210,7 @@ for _, strategy in helpers.each_strategy() do
           }, json)
         end)
 
-        it("= 'first' does get executed when running on first (tls)", function()
+        it("run_on = 'first' does get executed when running on first (tls)", function()
           local tcp = ngx.socket.tcp()
           assert(tcp:connect("127.0.0.1", 18443))
 
@@ -2226,7 +2226,7 @@ for _, strategy in helpers.each_strategy() do
           }, json)
         end)
 
-        it("= 'first' does not get executed when running on second", function()
+        it("run_on = 'first' does not get executed when running on second", function()
           local tcp = ngx.socket.tcp()
           assert(tcp:connect("127.0.0.1", 18004))
 
@@ -2242,7 +2242,7 @@ for _, strategy in helpers.each_strategy() do
           }, json)
         end)
 
-        it("= 'first' does not get executed when running on second (tls)", function()
+        it("run_on = 'first' does not get executed when running on second (tls)", function()
           local tcp = ngx.socket.tcp()
           assert(tcp:connect("127.0.0.1", 18444))
 
@@ -2258,7 +2258,7 @@ for _, strategy in helpers.each_strategy() do
           }, json)
         end)
 
-        it("= 'second' does get executed when running on second", function()
+        it("run_on = 'second' does get executed when running on second", function()
           local tcp = ngx.socket.tcp()
           assert(tcp:connect("127.0.0.1", 18005))
 
@@ -2274,7 +2274,7 @@ for _, strategy in helpers.each_strategy() do
           }, json)
         end)
 
-        it("= 'second' does get executed when running on second (tls)", function()
+        it("run_on = 'second' does get executed when running on second (tls)", function()
           local tcp = ngx.socket.tcp()
           assert(tcp:connect("127.0.0.1", 18445))
 
@@ -2290,7 +2290,7 @@ for _, strategy in helpers.each_strategy() do
           }, json)
         end)
 
-        it("= 'second' does not get executed when running on first", function()
+        it("run_on = 'second' does not get executed when running on first", function()
           local tcp = ngx.socket.tcp()
           assert(tcp:connect("127.0.0.1", 18006))
 
@@ -2306,7 +2306,7 @@ for _, strategy in helpers.each_strategy() do
           }, json)
         end)
 
-        it("= 'second' does not get executed when running on first (tls)", function()
+        it("run_on = 'second' does not get executed when running on first (tls)", function()
           local tcp = ngx.socket.tcp()
           assert(tcp:connect("127.0.0.1", 18446))
 
@@ -2322,7 +2322,7 @@ for _, strategy in helpers.each_strategy() do
           }, json)
         end)
 
-        it("= 'all' does get executed when running on first", function()
+        it("run_on = 'all' does get executed when running on first", function()
           local tcp = ngx.socket.tcp()
           assert(tcp:connect("127.0.0.1", 18007))
 
@@ -2338,7 +2338,7 @@ for _, strategy in helpers.each_strategy() do
           }, json)
         end)
 
-        it("= 'all' does get executed when running on first (tls)", function()
+        it("run_on = 'all' does get executed when running on first (tls)", function()
           local tcp = ngx.socket.tcp()
           assert(tcp:connect("127.0.0.1", 18447))
 
@@ -2354,7 +2354,7 @@ for _, strategy in helpers.each_strategy() do
           }, json)
         end)
 
-        it("= 'all' does get executed when running on second", function()
+        it("run_on = 'all' does get executed when running on second", function()
           local tcp = ngx.socket.tcp()
           assert(tcp:connect("127.0.0.1", 18008))
 
@@ -2370,7 +2370,7 @@ for _, strategy in helpers.each_strategy() do
           }, json)
         end)
 
-        it("= 'all' does get executed when running on second (tls)", function()
+        it("run_on = 'all' does get executed when running on second (tls)", function()
           local tcp = ngx.socket.tcp()
           assert(tcp:connect("127.0.0.1", 18448))
 


### PR DESCRIPTION
### Summary

The problem is that custom logic added to `DAO:insert` is not performed when filling the declarative config cache.

We have disabled `DAO:insert` consciously in DB-less mode, but to maintain consistency with the DAO behavior plugins expect, we need to allow it only during declarative config load.

@hishamhm, should I rebase this on `master`?

### Issues resolved

Fix #4542