### PR TITLE
feat(dbless) enable atomic update with eviction control

### DIFF
--- a/kong/api/routes/config.lua
+++ b/kong/api/routes/config.lua
@@ -44,6 +44,13 @@ return {
         return declarative.load_into_cache_with_events(entities)
       end)
 
+      if err == "no memory" then
+        kong.log.err("not enough cache space for declarative config")
+        return kong.response.exit(413, {
+          message = "Configuration does not fit in Kong cache"
+        })
+      end
+
       if not ok then
         kong.log.err("failed loading declarative config into cache: ", err)
         return kong.response.exit(500, { message = "An unexpected error occurred" })

--- a/kong/concurrency.lua
+++ b/kong/concurrency.lua
@@ -2,6 +2,9 @@ local resty_lock = require "resty.lock"
 local ngx_semaphore = require "ngx.semaphore"
 
 
+local get_phase = ngx.get_phase
+
+
 local concurrency = {}
 
 
@@ -63,6 +66,10 @@ function concurrency.with_coroutine_mutex(opts, fn)
   end
   if opts.on_timeout and opts.on_timeout ~= "run_unlocked" then
     error("invalid value for opts.on_timeout", 2)
+  end
+
+  if get_phase() == "init_worker" then
+    return fn()
   end
 
   local timeout = opts.timeout or 60

--- a/kong/global.lua
+++ b/kong/global.lua
@@ -151,8 +151,10 @@ do
 
   function _GLOBAL.init_cache(kong_config, cluster_events, worker_events)
     local db_cache_ttl = kong_config.db_cache_ttl
+    local cache_pages = 1
     if kong_config.database == "off" then
       db_cache_ttl = 0
+      cache_pages = 2
     end
 
     return kong_cache.new {
@@ -162,6 +164,7 @@ do
       ttl               = db_cache_ttl,
       neg_ttl           = db_cache_ttl,
       resurrect_ttl     = kong_config.resurrect_ttl,
+      cache_pages       = cache_pages,
       resty_lock_opts   = {
         exptime = 10,
         timeout = 5,

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -487,7 +487,12 @@ function Kong.init_worker()
 
 
   -- run plugins init_worker context
-  runloop.update_plugins_iterator()
+  ok, err = runloop.update_plugins_iterator()
+  if not ok then
+    ngx_log(ngx_CRIT, "error building plugins iterator: ", err)
+    return
+  end
+
   local plugins_iterator = runloop.get_plugins_iterator()
   local mock_ctx = {} -- ctx is not available in init_worker, use table instead
   for plugin, _ in plugins_iterator:iterate(mock_ctx, "init_worker") do

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -30,7 +30,13 @@ lua_max_running_timers 4096;
 lua_max_pending_timers 16384;
 lua_shared_dict kong                5m;
 lua_shared_dict kong_db_cache       ${{MEM_CACHE_SIZE}};
-lua_shared_dict kong_db_cache_miss 12m;
+> if database == "off" then
+lua_shared_dict kong_db_cache_2     ${{MEM_CACHE_SIZE}};
+> end
+lua_shared_dict kong_db_cache_miss   12m;
+> if database == "off" then
+lua_shared_dict kong_db_cache_miss_2 12m;
+> end
 lua_shared_dict kong_locks          8m;
 lua_shared_dict kong_process_events 5m;
 lua_shared_dict kong_cluster_events 5m;

--- a/kong/templates/nginx_kong_stream.lua
+++ b/kong/templates/nginx_kong_stream.lua
@@ -7,7 +7,13 @@ lua_package_path '${{LUA_PACKAGE_PATH}};;';
 lua_package_cpath '${{LUA_PACKAGE_CPATH}};;';
 lua_shared_dict stream_kong                5m;
 lua_shared_dict stream_kong_db_cache       ${{MEM_CACHE_SIZE}};
-lua_shared_dict stream_kong_db_cache_miss 12m;
+> if database == "off" then
+lua_shared_dict stream_kong_db_cache_2     ${{MEM_CACHE_SIZE}};
+> end
+lua_shared_dict stream_kong_db_cache_miss   12m;
+> if database == "off" then
+lua_shared_dict stream_kong_db_cache_miss_2 12m;
+> end
 lua_shared_dict stream_kong_locks          8m;
 lua_shared_dict stream_kong_process_events 5m;
 lua_shared_dict stream_kong_cluster_events 5m;

--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -266,21 +266,30 @@ describe("kong start/stop #" .. strategy, function()
           nginx_conf = "spec/fixtures/custom_nginx.template",
         }))
 
-        -- get a connection, retry until kong starts
         helpers.wait_until(function()
-          local pok
-          pok, proxy_client = pcall(helpers.proxy_client)
-          return pok
-        end, 10)
+          -- get a connection, retry until kong starts
+          helpers.wait_until(function()
+            local pok
+            pok, proxy_client = pcall(helpers.proxy_client)
+            return pok
+          end, 10)
 
-        local res = assert(proxy_client:send {
-          method = "GET",
-          path = "/",
-          headers = {
-            host = "example.test",
-          }
-        })
-        assert.res_status(200, res)
+          local res = assert(proxy_client:send {
+            method = "GET",
+            path = "/",
+            headers = {
+              host = "example.test",
+            }
+          })
+          local ok = res.status == 200
+
+          if proxy_client then
+            proxy_client:close()
+            proxy_client = nil
+          end
+
+          return ok
+        end, 10)
       end)
     end)
   end

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -44,7 +44,13 @@ http {
     lua_max_pending_timers 16384;
     lua_shared_dict kong                5m;
     lua_shared_dict kong_db_cache       ${{MEM_CACHE_SIZE}};
-    lua_shared_dict kong_db_cache_miss 12m;
+> if database == "off" then
+    lua_shared_dict kong_db_cache_2     ${{MEM_CACHE_SIZE}};
+> end
+    lua_shared_dict kong_db_cache_miss   12m;
+> if database == "off" then
+    lua_shared_dict kong_db_cache_miss_2 12m;
+> end
     lua_shared_dict kong_locks          8m;
     lua_shared_dict kong_process_events 5m;
     lua_shared_dict kong_cluster_events 5m;
@@ -464,7 +470,13 @@ stream {
     lua_package_cpath '${{LUA_PACKAGE_CPATH}};;';
     lua_shared_dict stream_kong                5m;
     lua_shared_dict stream_kong_db_cache       ${{MEM_CACHE_SIZE}};
-    lua_shared_dict stream_kong_db_cache_miss 12m;
+> if database == "off" then
+    lua_shared_dict stream_kong_db_cache_2     ${{MEM_CACHE_SIZE}};
+> end
+    lua_shared_dict stream_kong_db_cache_miss    12m;
+> if database == "off" then
+    lua_shared_dict stream_kong_db_cache_miss_2  12m;
+> end
     lua_shared_dict stream_kong_locks          8m;
     lua_shared_dict stream_kong_process_events 5m;
     lua_shared_dict stream_kong_cluster_events 5m;


### PR DESCRIPTION
This PR allows performing DB-less updates atomically and with cache eviction control.

This is done by adding support for "double-buffering" in `kong.cache`: the cache object is able to maintain two lower-level mlcache instances internally, one being the "active page" and another being the "shadow page", writing to the shadow page, and flip between them in one go.

* we enable two cache pages when using DB-less mode
* we load the new configuration into the shadow page, and only if the entire declarative config is loaded successfully the cache pages are flipped.
* when the cache is not large enough to hold a declarative config input, the `/config` endpoint fails with HTTP 413 Request Too Large, and the previous DB-less configuration is retained
* the PR includes tests that demonstrate the HTTP 413 scenario, by using a small cache

Note that this enables two additional shms in the configuration template for the double-buffering (shadow hits and misses), but only when DB-less is used.