### PR TITLE
feat(plugins) log request TLS version

### DIFF
--- a/kong/plugins/log-serializers/basic.lua
+++ b/kong/plugins/log-serializers/basic.lua
@@ -1,4 +1,5 @@
 local tablex = require "pl.tablex"
+local ngx_ssl = require "ngx.ssl"
 
 local _M = {}
 
@@ -17,6 +18,12 @@ function _M.serialize(ngx)
     }
   end
 
+  local request_tls
+  local request_tls_ver = ngx_ssl.get_tls1_version_str()
+  if request_tls_ver then 
+    request_tls = { version = request_tls_ver } 
+  end
+  
   local request_uri = var.request_uri or ""
 
   return {
@@ -26,7 +33,8 @@ function _M.serialize(ngx)
       querystring = req.get_uri_args(), -- parameters, as a table
       method = req.get_method(), -- http method
       headers = req.get_headers(),
-      size = var.request_length
+      size = var.request_length,
+      tls = request_tls
     },
     upstream_uri = var.upstream_uri,
     response = {

--- a/spec/03-plugins/01-tcp-log/01-tcp-log_spec.lua
+++ b/spec/03-plugins/01-tcp-log/01-tcp-log_spec.lua
@@ -7,7 +7,7 @@ local TCP_PORT = 35001
 
 for _, strategy in helpers.each_strategy() do
   describe("Plugin: tcp-log (log) [#" .. strategy .. "]", function()
-    local proxy_client
+    local proxy_client, proxy_ssl_client
 
     lazy_setup(function()
       local bp = helpers.get_db_utils(strategy, {
@@ -49,6 +49,7 @@ for _, strategy in helpers.each_strategy() do
       }))
 
       proxy_client = helpers.proxy_client()
+      proxy_ssl_client = helpers.proxy_ssl_client()
     end)
 
     lazy_teardown(function()
@@ -80,6 +81,9 @@ for _, strategy in helpers.each_strategy() do
       -- Making sure it's alright
       local log_message = cjson.decode(res)
       assert.equal("127.0.0.1", log_message.client_ip)
+
+      -- Since it's over HTTP, let's make sure there are no TLS information
+      assert.is_nil(log_message.request.tls)
     end)
 
     it("logs proper latencies", function()
@@ -136,6 +140,30 @@ for _, strategy in helpers.each_strategy() do
       -- Making sure it's alright
       local log_message = cjson.decode(res)
       assert.equal("127.0.0.1", log_message.client_ip)
+    end)
+
+    it("logs TLS info", function()
+      local thread = helpers.tcp_server(TCP_PORT) -- Starting the mock TCP server
+
+      -- Making the request
+      local r = assert(proxy_ssl_client:send {
+        method  = "GET",
+        path    = "/request",
+        headers = {
+          host  = "tcp_logging.com",
+        },
+      })
+
+      assert.response(r).has.status(200)
+      
+      -- Getting back the TCP server input
+      local ok, res = thread:join()
+      assert.True(ok)
+      assert.is_string(res)
+
+      -- Making sure it's alright
+      local log_message = cjson.decode(res)
+      assert.equal("TLSv1.2", log_message.request.tls.version)
     end)
 
   end)


### PR DESCRIPTION
The following PR logs the TLS version used by the request into the `basic` serializer for every logging plugin.