### PR TITLE
tests(admin) run tests for routes in dbless mode

### DIFF
--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -17,7 +17,9 @@ if [ "$TEST_SUITE" == "integration" ]; then
     eval "$TEST_CMD" spec/02-integration/
 fi
 if [ "$TEST_SUITE" == "dbless" ]; then
-    eval "$TEST_CMD" spec/02-integration/02-cmd spec/02-integration/05-proxy
+    eval "$TEST_CMD" spec/02-integration/02-cmd spec/02-integration/05-proxy \
+      spec/02-integration/04-admin_api/02-kong_routes_spec.lua \
+      spec/02-integration/04-admin_api/15-off_spec.lua
 fi
 if [ "$TEST_SUITE" == "plugins" ]; then
     eval "$TEST_CMD" spec/03-plugins/


### PR DESCRIPTION
- Simplify the test file to setup Kong only once for each strategy to
  speed up tests
- Add `off` strategy for this file. Kong Ingress Controller will start
  using these endpoints once 1.2 in db-less mode. The tests will ensure
  that we don't run regress in future.