### PR TITLE
fix(migrations) oauth2 tokens ttl was incorrectly migrated, fix #4572

### DIFF
--- a/kong/plugins/oauth2/migrations/001_14_to_15.lua
+++ b/kong/plugins/oauth2/migrations/001_14_to_15.lua
@@ -36,7 +36,8 @@ return {
       END$$;
 
       UPDATE "oauth2_tokens"
-         SET "ttl" = "created_at" + (COALESCE("expires_in", 0)::TEXT || ' seconds')::INTERVAL;
+         SET "ttl" = "created_at" + ("expires_in"::TEXT || ' seconds')::INTERVAL
+       WHERE "expires_in" > 0;
 
 
       ALTER TABLE IF EXISTS ONLY "oauth2_credentials"


### PR DESCRIPTION
### Summary

Fixes an issue reported at #4572, where migrations could set a 0 ttl for `oauth2_tokens` that have never expiring `0` tokens, leading to deletion of such tokens.

### Issues resolved

Fix #4572
