### PR TITLE
perf(*) plugins handlers do not have to inherit from BasePlugin anymore

### DIFF
--- a/kong/db/dao/plugins.lua
+++ b/kong/db/dao/plugins.lua
@@ -2,6 +2,7 @@ local constants = require "kong.constants"
 local utils = require "kong.tools.utils"
 local DAO = require "kong.db.dao"
 local plugin_loader = require "kong.db.schema.plugin_loader"
+local BasePlugin = require "kong.plugins.base_plugin"
 
 
 local Plugins = {}
@@ -269,7 +270,14 @@ function Plugins:load_plugin_schemas(plugin_set)
     local handler, err = load_plugin(self, plugin)
 
     if handler then
-      handlers[plugin] = handler()
+      if getmetatable(handler) == BasePlugin then
+        -- Backwards-compatibility for 0.x and 1.x plugins inheriting from the
+        -- BasePlugin class.
+        -- TODO: deprecate & remove
+        handler = handler()
+      end
+
+      handlers[plugin] = handler
 
     else
       errs = errs or {}

--- a/kong/plugins/acl/handler.lua
+++ b/kong/plugins/acl/handler.lua
@@ -1,4 +1,3 @@
-local BasePlugin = require "kong.plugins.base_plugin"
 local constants = require "kong.constants"
 local tablex = require "pl.tablex"
 local groups = require "kong.plugins.acl.groups"
@@ -36,21 +35,14 @@ local function get_to_be_blocked(config, groups, in_group)
 end
 
 
-local ACLHandler = BasePlugin:extend()
+local ACLHandler = {}
 
 
 ACLHandler.PRIORITY = 950
 ACLHandler.VERSION = "1.0.0"
 
 
-function ACLHandler:new()
-  ACLHandler.super.new(self, "acl")
-end
-
-
 function ACLHandler:access(conf)
-  ACLHandler.super.access(self)
-
   -- simplify our plugins 'conf' table
   local config = config_cache[conf]
   if not config then

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -1,5 +1,4 @@
 -- Copyright (C) Kong Inc.
-local BasePlugin = require "kong.plugins.base_plugin"
 local aws_v4 = require "kong.plugins.aws-lambda.v4"
 local http = require "resty.http"
 local cjson = require "cjson.safe"
@@ -78,17 +77,10 @@ local function extract_proxy_response(content)
 end
 
 
-local AWSLambdaHandler = BasePlugin:extend()
-
-
-function AWSLambdaHandler:new()
-  AWSLambdaHandler.super.new(self, "aws-lambda")
-end
+local AWSLambdaHandler = {}
 
 
 function AWSLambdaHandler:access(conf)
-  AWSLambdaHandler.super.access(self)
-
   local upstream_body = kong.table.new(0, 6)
   local var = ngx.var
 

--- a/kong/plugins/basic-auth/handler.lua
+++ b/kong/plugins/basic-auth/handler.lua
@@ -1,18 +1,11 @@
 -- Copyright (C) Kong Inc.
-local BasePlugin = require "kong.plugins.base_plugin"
 local access = require "kong.plugins.basic-auth.access"
 
 
-local BasicAuthHandler = BasePlugin:extend()
-
-
-function BasicAuthHandler:new()
-  BasicAuthHandler.super.new(self, "basic-auth")
-end
+local BasicAuthHandler = {}
 
 
 function BasicAuthHandler:access(conf)
-  BasicAuthHandler.super.access(self)
   access.execute(conf)
 end
 

--- a/kong/plugins/bot-detection/handler.lua
+++ b/kong/plugins/bot-detection/handler.lua
@@ -1,4 +1,3 @@
-local BasePlugin = require "kong.plugins.base_plugin"
 local rules = require "kong.plugins.bot-detection.rules"
 local strip = require("kong.tools.utils").strip
 local lrucache = require "resty.lrucache"
@@ -6,7 +5,7 @@ local lrucache = require "resty.lrucache"
 local ipairs = ipairs
 local re_find = ngx.re.find
 
-local BotDetectionHandler = BasePlugin:extend()
+local BotDetectionHandler = {}
 
 BotDetectionHandler.PRIORITY = 2500
 BotDetectionHandler.VERSION = "1.0.0"
@@ -62,13 +61,7 @@ local function examine_agent(user_agent, conf)
   return MATCH_EMPTY
 end
 
-function BotDetectionHandler:new()
-  BotDetectionHandler.super.new(self, "bot-detection")
-end
-
 function BotDetectionHandler:access(conf)
-  BotDetectionHandler.super.access(self)
-
   local user_agent, err = get_user_agent()
   if err then
     return kong.response.exit(BAD_REQUEST, { message = err })

--- a/kong/plugins/correlation-id/handler.lua
+++ b/kong/plugins/correlation-id/handler.lua
@@ -1,5 +1,4 @@
 -- Copyright (C) Kong Inc.
-local BasePlugin = require "kong.plugins.base_plugin"
 local uuid = require "kong.tools.utils".uuid
 
 
@@ -40,28 +39,20 @@ do
 end
 
 
-local CorrelationIdHandler = BasePlugin:extend()
+local CorrelationIdHandler = {}
 
 
 CorrelationIdHandler.PRIORITY = 1
 CorrelationIdHandler.VERSION = "1.0.0"
 
 
-function CorrelationIdHandler:new()
-  CorrelationIdHandler.super.new(self, "correlation-id")
-end
-
-
 function CorrelationIdHandler:init_worker()
-  CorrelationIdHandler.super.init_worker(self)
   worker_uuid = uuid()
   worker_counter = 0
 end
 
 
 function CorrelationIdHandler:access(conf)
-  CorrelationIdHandler.super.access(self)
-
   -- Set header for upstream
   local correlation_id = kong.request.get_header(conf.header_name)
   if not correlation_id then
@@ -80,8 +71,6 @@ end
 
 
 function CorrelationIdHandler:header_filter(conf)
-  CorrelationIdHandler.super.header_filter(self)
-
   if not conf.echo_downstream then
     return
   end

--- a/kong/plugins/cors/handler.lua
+++ b/kong/plugins/cors/handler.lua
@@ -1,4 +1,3 @@
-local BasePlugin = require "kong.plugins.base_plugin"
 local lrucache   = require "resty.lrucache"
 local url        = require "socket.url"
 
@@ -14,7 +13,7 @@ local ipairs   = ipairs
 local HTTP_OK = 200
 
 
-local CorsHandler = BasePlugin:extend()
+local CorsHandler = {}
 
 
 CorsHandler.PRIORITY = 2000
@@ -181,14 +180,7 @@ local function configure_credentials(conf, allow_all)
 end
 
 
-function CorsHandler:new()
-  CorsHandler.super.new(self, "cors")
-end
-
-
 function CorsHandler:access(conf)
-  CorsHandler.super.access(self)
-
   if kong.request.get_method() ~= "OPTIONS" then
     return
   end
@@ -232,8 +224,6 @@ end
 
 
 function CorsHandler:header_filter(conf)
-  CorsHandler.super.header_filter(self)
-
   if kong.ctx.plugin.skip_response_headers then
     return
   end

--- a/kong/plugins/datadog/handler.lua
+++ b/kong/plugins/datadog/handler.lua
@@ -1,4 +1,3 @@
-local BasePlugin       = require "kong.plugins.base_plugin"
 local basic_serializer = require "kong.plugins.log-serializers.basic"
 local statsd_logger    = require "kong.plugins.datadog.statsd_logger"
 
@@ -11,7 +10,7 @@ local string_format = string.format
 local NGX_ERR       = ngx.ERR
 
 
-local DatadogHandler    = BasePlugin:extend()
+local DatadogHandler    = {}
 DatadogHandler.PRIORITY = 10
 DatadogHandler.VERSION = "1.0.0"
 
@@ -135,13 +134,7 @@ local function log(premature, conf, message)
 end
 
 
-function DatadogHandler:new()
-  DatadogHandler.super.new(self, "datadog")
-end
-
 function DatadogHandler:log(conf)
-  DatadogHandler.super.log(self)
-
   if not ngx.ctx.service then
     return
   end

--- a/kong/plugins/file-log/handler.lua
+++ b/kong/plugins/file-log/handler.lua
@@ -3,7 +3,6 @@ local ffi = require "ffi"
 local cjson = require "cjson"
 local system_constants = require "lua_system_constants"
 local basic_serializer = require "kong.plugins.log-serializers.basic"
-local BasePlugin = require "kong.plugins.base_plugin"
 
 local ngx_timer = ngx.timer.at
 local O_CREAT = system_constants.O_CREAT()
@@ -58,17 +57,12 @@ local function log(premature, conf, message)
   ffi.C.write(fd, msg, #msg)
 end
 
-local FileLogHandler = BasePlugin:extend()
+local FileLogHandler = {}
 
 FileLogHandler.PRIORITY = 9
 FileLogHandler.VERSION = "1.0.0"
 
-function FileLogHandler:new()
-  FileLogHandler.super.new(self, "file-log")
-end
-
 function FileLogHandler:log(conf)
-  FileLogHandler.super.log(self)
   local message = basic_serializer.serialize(ngx)
 
   local ok, err = ngx_timer(0, log, conf, message)

--- a/kong/plugins/hmac-auth/handler.lua
+++ b/kong/plugins/hmac-auth/handler.lua
@@ -1,18 +1,11 @@
 -- Copyright (C) Kong Inc.
-local BasePlugin = require "kong.plugins.base_plugin"
 local access = require "kong.plugins.hmac-auth.access"
 
 
-local HMACAuthHandler = BasePlugin:extend()
-
-
-function HMACAuthHandler:new()
-  HMACAuthHandler.super.new(self, "hmac-auth")
-end
+local HMACAuthHandler = {}
 
 
 function HMACAuthHandler:access(conf)
-  HMACAuthHandler.super.access(self)
   access.execute(conf)
 end
 

--- a/kong/plugins/http-log/handler.lua
+++ b/kong/plugins/http-log/handler.lua
@@ -1,5 +1,4 @@
 local basic_serializer = require "kong.plugins.log-serializers.basic"
-local BasePlugin = require "kong.plugins.base_plugin"
 local BatchQueue = require "kong.tools.batch_queue"
 local cjson = require "cjson"
 local url = require "socket.url"
@@ -12,7 +11,7 @@ local table_concat = table.concat
 local fmt = string.format
 
 
-local HttpLogHandler = BasePlugin:extend()
+local HttpLogHandler = {}
 
 
 HttpLogHandler.PRIORITY = 12
@@ -141,19 +140,7 @@ local function get_queue_id(conf)
 end
 
 
--- Only provide `name` when deriving from this class,
--- not when initializing an instance.
-function HttpLogHandler:new(name)
-  name = name or "http-log"
-  HttpLogHandler.super.new(self, name)
-
-  self.name = name
-end
-
-
 function HttpLogHandler:log(conf)
-  HttpLogHandler.super.log(self)
-
   local entry = cjson_encode(basic_serializer.serialize(ngx))
 
   local queue_id = get_queue_id(conf)

--- a/kong/plugins/ip-restriction/handler.lua
+++ b/kong/plugins/ip-restriction/handler.lua
@@ -1,4 +1,3 @@
-local BasePlugin = require "kong.plugins.base_plugin"
 local iputils = require "resty.iputils"
 
 
@@ -9,7 +8,7 @@ local FORBIDDEN = 403
 local cache = {}
 
 
-local IpRestrictionHandler = BasePlugin:extend()
+local IpRestrictionHandler = {}
 
 IpRestrictionHandler.PRIORITY = 990
 IpRestrictionHandler.VERSION = "1.0.0"
@@ -43,12 +42,7 @@ local function cidr_cache(cidr_tab)
   return parsed_cidrs
 end
 
-function IpRestrictionHandler:new()
-  IpRestrictionHandler.super.new(self, "ip-restriction")
-end
-
 function IpRestrictionHandler:init_worker()
-  IpRestrictionHandler.super.init_worker(self)
   local ok, err = iputils.enable_lrucache()
   if not ok then
     kong.log.err("could not enable lrucache: ", err)
@@ -56,7 +50,6 @@ function IpRestrictionHandler:init_worker()
 end
 
 function IpRestrictionHandler:access(conf)
-  IpRestrictionHandler.super.access(self)
   local block = false
   local binary_remote_addr = ngx.var.binary_remote_addr
 

--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -1,4 +1,3 @@
-local BasePlugin = require "kong.plugins.base_plugin"
 local constants = require "kong.constants"
 local jwt_decoder = require "kong.plugins.jwt.jwt_parser"
 
@@ -11,7 +10,7 @@ local tostring = tostring
 local re_gmatch = ngx.re.gmatch
 
 
-local JwtHandler = BasePlugin:extend()
+local JwtHandler = {}
 
 
 JwtHandler.PRIORITY = 1005
@@ -57,11 +56,6 @@ local function retrieve_token(conf)
       return m[1]
     end
   end
-end
-
-
-function JwtHandler:new()
-  JwtHandler.super.new(self, "jwt")
 end
 
 
@@ -236,8 +230,6 @@ end
 
 
 function JwtHandler:access(conf)
-  JwtHandler.super.access(self)
-
   -- check if preflight request and whether it should be authenticated
   if not conf.run_on_preflight and kong.request.get_method() == "OPTIONS" then
     return

--- a/kong/plugins/key-auth/handler.lua
+++ b/kong/plugins/key-auth/handler.lua
@@ -1,5 +1,4 @@
 local constants = require "kong.constants"
-local BasePlugin = require "kong.plugins.base_plugin"
 
 
 local kong = kong
@@ -9,16 +8,11 @@ local type = type
 local _realm = 'Key realm="' .. _KONG._NAME .. '"'
 
 
-local KeyAuthHandler = BasePlugin:extend()
+local KeyAuthHandler = {}
 
 
 KeyAuthHandler.PRIORITY = 1003
 KeyAuthHandler.VERSION = "1.0.0"
-
-
-function KeyAuthHandler:new()
-  KeyAuthHandler.super.new(self, "key-auth")
-end
 
 
 local function load_credential(key)
@@ -186,8 +180,6 @@ end
 
 
 function KeyAuthHandler:access(conf)
-  KeyAuthHandler.super.access(self)
-
   -- check if preflight request and whether it should be authenticated
   if not conf.run_on_preflight and kong.request.get_method() == "OPTIONS" then
     return

--- a/kong/plugins/ldap-auth/handler.lua
+++ b/kong/plugins/ldap-auth/handler.lua
@@ -1,17 +1,10 @@
 local access = require "kong.plugins.ldap-auth.access"
-local BasePlugin = require "kong.plugins.base_plugin"
 
 
-local LdapAuthHandler = BasePlugin:extend()
-
-
-function LdapAuthHandler:new()
-  LdapAuthHandler.super.new(self, "ldap-auth")
-end
+local LdapAuthHandler = {}
 
 
 function LdapAuthHandler:access(conf)
-  LdapAuthHandler.super.access(self)
   access.execute(conf)
 end
 

--- a/kong/plugins/loggly/handler.lua
+++ b/kong/plugins/loggly/handler.lua
@@ -1,8 +1,7 @@
-local BasePlugin = require "kong.plugins.base_plugin"
 local basic_serializer = require "kong.plugins.log-serializers.basic"
 local cjson = require "cjson"
 
-local LogglyLogHandler = BasePlugin:extend()
+local LogglyLogHandler = {}
 
 LogglyLogHandler.PRIORITY = 6
 LogglyLogHandler.VERSION = "1.0.0"
@@ -103,14 +102,7 @@ local function log(premature, conf, message)
   end
 end
 
-
-function LogglyLogHandler:new()
-  LogglyLogHandler.super.new(self, "loggly")
-end
-
 function LogglyLogHandler:log(conf)
-  LogglyLogHandler.super.log(self)
-
   local message = basic_serializer.serialize(ngx)
 
   local ok, err = ngx_timer_at(0, log, conf, message)

--- a/kong/plugins/oauth2/handler.lua
+++ b/kong/plugins/oauth2/handler.lua
@@ -1,14 +1,8 @@
-local BasePlugin = require "kong.plugins.base_plugin"
 local access = require "kong.plugins.oauth2.access"
 
-local OAuthHandler = BasePlugin:extend()
-
-function OAuthHandler:new()
-  OAuthHandler.super.new(self, "oauth2")
-end
+local OAuthHandler = {}
 
 function OAuthHandler:access(conf)
-  OAuthHandler.super.access(self)
   access.execute(conf)
 end
 

--- a/kong/plugins/rate-limiting/handler.lua
+++ b/kong/plugins/rate-limiting/handler.lua
@@ -1,6 +1,5 @@
 -- Copyright (C) Kong Inc.
 local policies = require "kong.plugins.rate-limiting.policies"
-local BasePlugin = require "kong.plugins.base_plugin"
 
 
 local kong = kong
@@ -16,7 +15,7 @@ local EMPTY = {}
 local RATELIMIT_LIMIT = "X-RateLimit-Limit"
 local RATELIMIT_REMAINING = "X-RateLimit-Remaining"
 
-local RateLimitingHandler = BasePlugin:extend()
+local RateLimitingHandler = {}
 
 
 RateLimitingHandler.PRIORITY = 901
@@ -77,14 +76,7 @@ local function increment(premature, conf, ...)
 end
 
 
-function RateLimitingHandler:new()
-  RateLimitingHandler.super.new(self, "rate-limiting")
-end
-
-
 function RateLimitingHandler:access(conf)
-  RateLimitingHandler.super.access(self)
-
   local current_timestamp = time() * 1000
 
   -- Consumer is identified by ip address or authenticated_credential id
@@ -143,8 +135,6 @@ end
 
 
 function RateLimitingHandler:header_filter(_)
-  RateLimitingHandler.super.header_filter(self)
-
   local headers = kong.ctx.plugin.headers
   if headers then
     kong.response.set_headers(headers)

--- a/kong/plugins/request-size-limiting/handler.lua
+++ b/kong/plugins/request-size-limiting/handler.lua
@@ -1,12 +1,11 @@
 -- Copyright (C) Kong Inc.
 
-local BasePlugin = require "kong.plugins.base_plugin"
 local strip = require("pl.stringx").strip
 local tonumber = tonumber
 
 local MB = 2^20
 
-local RequestSizeLimitingHandler = BasePlugin:extend()
+local RequestSizeLimitingHandler = {}
 
 RequestSizeLimitingHandler.PRIORITY = 951
 RequestSizeLimitingHandler.VERSION = "1.0.0"
@@ -22,12 +21,7 @@ local function check_size(length, allowed_size, headers)
   end
 end
 
-function RequestSizeLimitingHandler:new()
-  RequestSizeLimitingHandler.super.new(self, "request-size-limiting")
-end
-
 function RequestSizeLimitingHandler:access(conf)
-  RequestSizeLimitingHandler.super.access(self)
   local headers = kong.request.get_headers()
   local cl = headers["content-length"]
 

--- a/kong/plugins/request-termination/handler.lua
+++ b/kong/plugins/request-termination/handler.lua
@@ -1,4 +1,3 @@
-local BasePlugin = require "kong.plugins.base_plugin"
 local singletons = require "kong.singletons"
 local constants = require "kong.constants"
 local meta = require "kong.meta"
@@ -18,21 +17,14 @@ local DEFAULT_RESPONSE = {
 }
 
 
-local RequestTerminationHandler = BasePlugin:extend()
+local RequestTerminationHandler = {}
 
 
 RequestTerminationHandler.PRIORITY = 2
 RequestTerminationHandler.VERSION = "1.0.0"
 
 
-function RequestTerminationHandler:new()
-  RequestTerminationHandler.super.new(self, "request-termination")
-end
-
-
 function RequestTerminationHandler:access(conf)
-  RequestTerminationHandler.super.access(self)
-
   local status  = conf.status_code
   local content = conf.body
 

--- a/kong/plugins/request-transformer/handler.lua
+++ b/kong/plugins/request-transformer/handler.lua
@@ -1,14 +1,8 @@
-local BasePlugin = require "kong.plugins.base_plugin"
 local access = require "kong.plugins.request-transformer.access"
 
-local RequestTransformerHandler = BasePlugin:extend()
-
-function RequestTransformerHandler:new()
-  RequestTransformerHandler.super.new(self, "request-transformer")
-end
+local RequestTransformerHandler = {}
 
 function RequestTransformerHandler:access(conf)
-  RequestTransformerHandler.super.access(self)
   access.execute(conf)
 end
 

--- a/kong/plugins/response-ratelimiting/handler.lua
+++ b/kong/plugins/response-ratelimiting/handler.lua
@@ -1,27 +1,19 @@
 -- Copyright (C) Kong Inc.
 
-local BasePlugin = require "kong.plugins.base_plugin"
 local access = require "kong.plugins.response-ratelimiting.access"
 local log = require "kong.plugins.response-ratelimiting.log"
 local header_filter = require "kong.plugins.response-ratelimiting.header_filter"
 
 
-local ResponseRateLimitingHandler = BasePlugin:extend()
-
-
-function ResponseRateLimitingHandler:new()
-  ResponseRateLimitingHandler.super.new(self, "response-ratelimiting")
-end
+local ResponseRateLimitingHandler = {}
 
 
 function ResponseRateLimitingHandler:access(conf)
-  ResponseRateLimitingHandler.super.access(self)
   access.execute(conf)
 end
 
 
 function ResponseRateLimitingHandler:header_filter(conf)
-  ResponseRateLimitingHandler.super.header_filter(self)
   header_filter.execute(conf)
 end
 
@@ -29,7 +21,6 @@ end
 function ResponseRateLimitingHandler:log(conf)
   local ctx = kong.ctx.plugin
   if not ctx.stop_log and ctx.usage then
-    ResponseRateLimitingHandler.super.log(self)
     log.execute(conf, ctx.identifier, ctx.current_timestamp, ctx.increments, ctx.usage)
   end
 end

--- a/kong/plugins/response-transformer/handler.lua
+++ b/kong/plugins/response-transformer/handler.lua
@@ -1,4 +1,3 @@
-local BasePlugin = require "kong.plugins.base_plugin"
 local body_transformer = require "kong.plugins.response-transformer.body_transformer"
 local header_transformer = require "kong.plugins.response-transformer.header_transformer"
 
@@ -10,24 +9,15 @@ local kong = kong
 local ngx = ngx
 
 
-local ResponseTransformerHandler = BasePlugin:extend()
-
-
-function ResponseTransformerHandler:new()
-  ResponseTransformerHandler.super.new(self, "response-transformer")
-end
+local ResponseTransformerHandler = {}
 
 
 function ResponseTransformerHandler:header_filter(conf)
-  ResponseTransformerHandler.super.header_filter(self)
-
   header_transformer.transform_headers(conf, kong.response.get_headers())
 end
 
 
 function ResponseTransformerHandler:body_filter(conf)
-  ResponseTransformerHandler.super.body_filter(self)
-
   if is_body_transform_set(conf) and is_json_body(kong.response.get_header("Content-Type")) then
     local ctx = ngx.ctx
     local chunk, eof = ngx.arg[1], ngx.arg[2]

--- a/kong/plugins/statsd/handler.lua
+++ b/kong/plugins/statsd/handler.lua
@@ -1,4 +1,3 @@
-local BasePlugin       = require "kong.plugins.base_plugin"
 local basic_serializer = require "kong.plugins.log-serializers.basic"
 local statsd_logger    = require "kong.plugins.statsd.statsd_logger"
 
@@ -11,7 +10,7 @@ local string_format = string.format
 local NGX_ERR       = ngx.ERR
 
 
-local StatsdHandler = BasePlugin:extend()
+local StatsdHandler = {}
 StatsdHandler.PRIORITY = 11
 StatsdHandler.VERSION = "1.0.0"
 
@@ -132,14 +131,7 @@ local function log(premature, conf, message)
 end
 
 
-function StatsdHandler:new()
-  StatsdHandler.super.new(self, "statsd")
-end
-
-
 function StatsdHandler:log(conf)
-  StatsdHandler.super.log(self)
-
   if not ngx.ctx.service then
     return
   end

--- a/kong/plugins/syslog/handler.lua
+++ b/kong/plugins/syslog/handler.lua
@@ -1,6 +1,5 @@
 local lsyslog = require "lsyslog"
 local cjson = require "cjson"
-local BasePlugin = require "kong.plugins.base_plugin"
 local basic_serializer = require "kong.plugins.log-serializers.basic"
 local ngx_log = ngx.log
 local ngx_timer_at = ngx.timer.at
@@ -9,7 +8,7 @@ local l_log = lsyslog.log
 local string_upper = string.upper
 
 
-local SysLogHandler = BasePlugin:extend()
+local SysLogHandler = {}
 
 SysLogHandler.PRIORITY = 4
 SysLogHandler.VERSION = "1.0.0"
@@ -48,13 +47,7 @@ local function log(premature, conf, message)
   end
 end
 
-function SysLogHandler:new()
-  SysLogHandler.super.new(self, "syslog")
-end
-
 function SysLogHandler:log(conf)
-  SysLogHandler.super.log(self)
-
   local message = basic_serializer.serialize(ngx)
   local ok, err = ngx_timer_at(0, log, conf, message)
   if not ok then

--- a/kong/plugins/tcp-log/handler.lua
+++ b/kong/plugins/tcp-log/handler.lua
@@ -1,8 +1,7 @@
-local BasePlugin = require "kong.plugins.base_plugin"
 local basic_serializer = require "kong.plugins.log-serializers.basic"
 local cjson = require "cjson"
 
-local TcpLogHandler = BasePlugin:extend()
+local TcpLogHandler = {}
 
 TcpLogHandler.PRIORITY = 7
 TcpLogHandler.VERSION = "1.0.0"
@@ -48,13 +47,7 @@ local function log(premature, conf, message)
   end
 end
 
-function TcpLogHandler:new()
-  TcpLogHandler.super.new(self, "tcp-log")
-end
-
 function TcpLogHandler:log(conf)
-  TcpLogHandler.super.log(self)
-
   local message = basic_serializer.serialize(ngx)
   local ok, err = ngx.timer.at(0, log, conf, message)
   if not ok then

--- a/kong/plugins/udp-log/handler.lua
+++ b/kong/plugins/udp-log/handler.lua
@@ -1,11 +1,10 @@
-local BasePlugin = require "kong.plugins.base_plugin"
 local serializer = require "kong.plugins.log-serializers.basic"
 local cjson = require "cjson"
 
 local timer_at = ngx.timer.at
 local udp = ngx.socket.udp
 
-local UdpLogHandler = BasePlugin:extend()
+local UdpLogHandler = {}
 
 UdpLogHandler.PRIORITY = 8
 UdpLogHandler.VERSION = "1.0.0"
@@ -37,13 +36,7 @@ local function log(premature, conf, str)
   end
 end
 
-function UdpLogHandler:new()
-  UdpLogHandler.super.new(self, "udp-log")
-end
-
 function UdpLogHandler:log(conf)
-  UdpLogHandler.super.log(self)
-
   local ok, err = timer_at(0, log, conf, cjson.encode(serializer.serialize(ngx)))
   if not ok then
     ngx.log(ngx.ERR, "[udp-log] could not create timer: ", err)

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -409,15 +409,15 @@ do
     for _, plugin in ipairs(loaded_plugins) do
       if new_plugins_plan.combos[plugin.name] then
         for phase_name, phase in pairs(new_plugins_plan.phases) do
-          if plugin.handler[phase_name] ~= BasePlugin[phase_name] then
+          if type(plugin.handler[phase_name]) == "function"
+             and plugin.handler[phase_name] ~= BasePlugin[phase_name] then
             phase[plugin.name] = true
           end
         end
 
-      else
-        if plugin.handler.init_worker ~= BasePlugin.init_worker then
-          new_plugins_plan.phases.init_worker[plugin.name] = true
-        end
+      elseif type(plugin.handler.init_worker) == "function"
+             and plugin.handler.init_worker ~= BasePlugin.init_worker then
+        new_plugins_plan.phases.init_worker[plugin.name] = true
       end
     end
 

--- a/spec/01-unit/01-db/07-dao/01-plugins_spec.lua
+++ b/spec/01-unit/01-db/07-dao/01-plugins_spec.lua
@@ -37,16 +37,14 @@ describe("kong.db.dao.plugins", function()
       assert.is_nil(err)
       assert.is_table(handlers)
 
-      assert.same({
-        {
-          handler = { _name = "key-auth" },
-          name = "key-auth",
-        },
-        {
-          handler = { _name = "basic-auth" },
-          name = "basic-auth",
-        },
-      }, handlers)
+      assert.equal("basic-auth", handlers[2].name)
+      assert.equal("key-auth", handlers[1].name)
+
+      for i = 1, #handlers do
+        assert.is_number(handlers[i].handler.PRIORITY)
+        assert.matches("%d%.%d%.%d", handlers[i].handler.VERSION)
+        assert.is_function(handlers[i].handler.access)
+      end
     end)
 
     it("fails on invalid plugin schemas", function()

--- a/spec/03-plugins/15-response-transformer/02-body_transformer_spec.lua
+++ b/spec/03-plugins/15-response-transformer/02-body_transformer_spec.lua
@@ -183,7 +183,6 @@ describe("Plugin: response-transformer", function()
         },
       }
       handler = require("kong.plugins.response-transformer.handler")
-      handler:new()
     end)
 
     lazy_teardown(function()


### PR DESCRIPTION
Plugins handlers have always been inheriting from the `BasePlugin`
class, which is itself inheriting from the `Object` class provided by
`kong.vendor.classic`.

This design predates even the very first public release of Kong in 2015,
and was influenced by the OOP background of its original authors.

Today, the case can be made against this design:

- At best, it makes instances with `debug` log levels extremely noisy.
- At worst, it has a non-negligible performance impact due to the
  constant metatable lookups of a plugin's handlers methods and
  because of the non-JITable `ngx.log` calls sitting on hot code paths.
- All in all, its only purpose was to provide a `_name` attribute which
  was only used by the `BasePlugin` parent class and redundant with the
  `handler.name` property injected by the plugins loader.

This commit removes the need for plugins handlers to inherit from the
`BasePlugin` class, but still ensures backwards-compatibility for
plugins doing so.
Fixture plugins in our test suites were not updated and still inherit
from the `BasePlugin` class as a means to maintain regression tests for
this backwards-compatible behavior.

The `BasePlugin` is *not* deprecated by this commit.

In some initial benchmarks (sample size 3), this change increased
req/s by up to 6% when using a single plugin (key-auth). The more
plugins are configured for a request, the higher the gains.