### PR TITLE
chore(deps) bump lua-cassandra to 1.4.0

### DIFF
--- a/kong-1.1.2-0.rockspec
+++ b/kong-1.1.2-0.rockspec
@@ -20,7 +20,7 @@ dependencies = {
   "multipart == 0.5.5",
   "version == 1.0.1",
   "kong-lapis == 1.6.0.1",
-  "lua-cassandra == 1.3.4",
+  "lua-cassandra == 1.4.0",
   "pgmoon == 1.9.0",
   "luatz == 0.3",
   "http == 0.3",


### PR DESCRIPTION
Changes:

- Improve host still considered down error logs to include the error
  causing each node to be considered as "DOWN", as well as the duration
  for which it will still be considered "DOWN".

E.g.:

    all hosts tried for query failed. 127.0.0.1: host still considered down.
    127.0.0.2: host still considered down

Becomes:

    all hosts tried for query failed. 127.0.0.1: host still considered
    down for 1s (last error: timeout). 127.0.0.2: host still considered
    down for 1s (last error: timeout)

Full Changelog:

https://github.com/thibaultcha/lua-cassandra/blob/master/CHANGELOG.md#140