### PR TITLE
refactor(runloop) plugins_iterator refactors

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -500,9 +500,9 @@ end
 function Kong.ssl_certificate()
   kong_global.set_phase(kong, PHASES.certificate)
 
-  local ctx = ngx.ctx
+  local mock_ctx = {} -- ctx is not available in cert phase, use table instead
 
-  runloop.certificate.before(ctx)
+  runloop.certificate.before(mock_ctx)
 
   local ok, err = runloop.update_plugins_iterator()
   if not ok then
@@ -510,7 +510,7 @@ function Kong.ssl_certificate()
     return ngx.exit(ngx.ERROR)
   end
 
-  execute_plugins_iterator(ctx, "certificate")
+  execute_plugins_iterator(mock_ctx, "certificate")
 end
 
 function Kong.balancer()

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -617,10 +617,13 @@ function Kong.rewrite()
 
   runloop.rewrite.before(ctx)
 
-  local ok, err = runloop.update_plugins_iterator()
-  if not ok then
-    ngx_log(ngx_CRIT, "could not ensure plugins iterator is up to date: ", err)
-    return kong.response.exit(500, { message  = "An unexpected error occurred" })
+  -- On HTTPS requests, the plugins iterator is already updated in the ssl_certificate phase
+  if ngx.var.https ~= "on" then
+    local ok, err = runloop.update_plugins_iterator()
+    if not ok then
+      ngx_log(ngx_CRIT, "could not ensure plugins iterator is up to date: ", err)
+      return kong.response.exit(500, { message  = "An unexpected error occurred" })
+    end
   end
 
   execute_plugins_iterator(ctx, "rewrite")

--- a/kong/runloop/plugins_iterator.lua
+++ b/kong/runloop/plugins_iterator.lua
@@ -233,8 +233,9 @@ local function get_next(self)
     end
   end
 
-  -- return the plugin configuration
-  if ctx.plugins[plugin.name] then
+  local phase = self.iterator.phases[self.phase]
+  if phase and phase[plugin.name]
+  and (ctx.plugins[plugin.name] or self.phase == "init_worker") then
     return plugin, ctx.plugins[plugin.name]
   end
 
@@ -288,17 +289,15 @@ function PluginsIterator.new(version)
     end
   end
 
+  local phase_handler
   for _, plugin in ipairs(loaded_plugins) do
     if combos[plugin.name] then
       for phase_name, phase in pairs(phases) do
-        if plugin.handler[phase_name] ~= BasePlugin[phase_name] then
+        phase_handler = plugin.handler[phase_name]
+        if type(phase_handler) == "function"
+        and phase_handler ~= BasePlugin[phase_name] then
           phase[plugin.name] = true
         end
-      end
-
-    else
-      if plugin.handler.init_worker ~= BasePlugin.init_worker then
-        phases.init_worker[plugin.name] = true
       end
     end
   end

--- a/spec/02-integration/06-invalidations/03-plugins_iterator_invalidation_spec.lua
+++ b/spec/02-integration/06-invalidations/03-plugins_iterator_invalidation_spec.lua
@@ -96,20 +96,20 @@ for _, strategy in helpers.each_strategy() do
       proxy_client_2:close()
     end)
 
-    describe("plugins_plan:version", function()
+    describe("plugins_iterator:version", function()
       local service_plugin_id
 
       it("is created at startup", function()
         local admin_res_1 = assert(admin_client_1:send {
           method = "GET",
-          path   = "/cache/plugins_plan:version",
+          path   = "/cache/plugins_iterator:version",
         })
         local body_1 = assert.res_status(200, admin_res_1)
         local msg_1  = cjson.decode(body_1)
 
         local admin_res_2 = assert(admin_client_2:send {
           method = "GET",
-          path   = "/cache/plugins_plan:version",
+          path   = "/cache/plugins_iterator:version",
         })
         local body_2 = assert.res_status(200, admin_res_2)
         local msg_2  = cjson.decode(body_2)
@@ -138,7 +138,7 @@ for _, strategy in helpers.each_strategy() do
 
         local admin_res_1 = assert(admin_client_1:send {
           method = "GET",
-          path   = "/cache/plugins_plan:version",
+          path   = "/cache/plugins_iterator:version",
         })
         assert.res_status(404, admin_res_1)
 
@@ -146,7 +146,7 @@ for _, strategy in helpers.each_strategy() do
 
         local admin_res_2 = assert(admin_client_2:send {
           method = "GET",
-          path   = "/cache/plugins_plan:version",
+          path   = "/cache/plugins_iterator:version",
         })
         assert.res_status(404, admin_res_2)
       end)
@@ -163,7 +163,7 @@ for _, strategy in helpers.each_strategy() do
 
         local admin_res_1 = assert(admin_client_1:send {
           method = "GET",
-          path   = "/cache/plugins_plan:version",
+          path   = "/cache/plugins_iterator:version",
         })
         local body_1 = assert.res_status(200, admin_res_1)
         local msg_1  = cjson.decode(body_1)
@@ -174,7 +174,7 @@ for _, strategy in helpers.each_strategy() do
 
         local admin_res_2 = assert(admin_client_2:send {
           method = "GET",
-          path   = "/cache/plugins_plan:version",
+          path   = "/cache/plugins_iterator:version",
         })
         assert.res_status(404, admin_res_2)
 
@@ -189,7 +189,7 @@ for _, strategy in helpers.each_strategy() do
 
         local admin_res_2 = assert(admin_client_2:send {
           method = "GET",
-          path   = "/cache/plugins_plan:version",
+          path   = "/cache/plugins_iterator:version",
         })
         local body_2 = assert.res_status(200, admin_res_2)
         local msg_2  = cjson.decode(body_2)
@@ -217,7 +217,7 @@ for _, strategy in helpers.each_strategy() do
 
         local admin_res_2 = assert(admin_client_2:send {
           method = "GET",
-          path   = "/cache/plugins_plan:version",
+          path   = "/cache/plugins_iterator:version",
         })
         assert.res_status(404, admin_res_2)
       end)
@@ -231,7 +231,7 @@ for _, strategy in helpers.each_strategy() do
 
         local admin_res_1 = assert(admin_client_1:send {
           method = "GET",
-          path   = "/cache/plugins_plan:version",
+          path   = "/cache/plugins_iterator:version",
         })
         assert.res_status(404, admin_res_1)
 
@@ -239,7 +239,7 @@ for _, strategy in helpers.each_strategy() do
 
         local admin_res_2 = assert(admin_client_2:send {
           method = "GET",
-          path   = "/cache/plugins_plan:version",
+          path   = "/cache/plugins_iterator:version",
         })
         assert.res_status(404, admin_res_2)
       end)
@@ -261,7 +261,7 @@ for _, strategy in helpers.each_strategy() do
 
         local admin_res_1 = assert(admin_client_1:send {
           method = "GET",
-          path   = "/cache/plugins_plan:version",
+          path   = "/cache/plugins_iterator:version",
         })
         assert.res_status(404, admin_res_1)
 
@@ -269,7 +269,7 @@ for _, strategy in helpers.each_strategy() do
 
         local admin_res_2 = assert(admin_client_2:send {
           method = "GET",
-          path   = "/cache/plugins_plan:version",
+          path   = "/cache/plugins_iterator:version",
         })
         assert.res_status(404, admin_res_2)
       end)


### PR DESCRIPTION
This PR contains 3 refactors:

* Merges plugins_plan and plugins_iterator into a single entity
* Replaces the `repeat ... until` fake loop inside plugins_iterator by `goto`s
* Removes unnecessary metatables in plugins iterator

These refactors will be used as a base for async work