### PR TITLE
feat(schema) make `key` field of `certificate` entity to be optional

### DIFF
--- a/kong/db/dao/certificates.lua
+++ b/kong/db/dao/certificates.lua
@@ -56,7 +56,7 @@ function _Certificates:insert(cert, options)
 
   if (not cert.key or cert.key == null) and name_list and #name_list ~= 0 then
     local err_t = self.errors:schema_violation({
-      snis = "private key is not present, \"snis\" field should be absent",
+      snis = "cannot be specified because the 'key' attribute is not set",
     })
 
     return nil, tostring(err_t), err_t
@@ -118,10 +118,19 @@ function _Certificates:update(cert_pk, cert, options)
   if cert.key or cert.cert then
     if cert.key == null then
       -- user tries to remove private key from cert
-      if (name_list and #name_list ~= 0) or #snis ~= 0 then
+      if #snis > 0 and not name_list then
         local err_t = self.errors:schema_violation({
-          key = "one or more SNI names are still associated with this" ..
-                 " certificate, private key cannot be removed",
+          key = "cannot be removed, since one or more SNIs are still" ..
+                " associated to this Certificate",
+        })
+
+        return nil, tostring(err_t), err_t
+      end
+
+      if name_list and #name_list ~= 0 then
+        local err_t = self.errors:schema_violation({
+          snis = "cannot associate SNIs to this Certificate" ..
+                 " because the 'key' attribute is not set",
         })
 
         return nil, tostring(err_t), err_t
@@ -166,7 +175,7 @@ function _Certificates:upsert(cert_pk, cert, options)
 
   if (not cert.key or cert.key == null) and name_list and #name_list ~= 0 then
     local err_t = self.errors:schema_violation({
-      snis = "private key is not present, \"snis\" field should be absent",
+      snis = "cannot be specified because the 'key' attribute is not set",
     })
 
     return nil, tostring(err_t), err_t

--- a/kong/db/dao/certificates.lua
+++ b/kong/db/dao/certificates.lua
@@ -7,6 +7,7 @@ local tostring = tostring
 local ipairs = ipairs
 local table = table
 local type = type
+local null = ngx.null
 
 
 -- Get an array of SNI names from either
@@ -51,6 +52,14 @@ function _Certificates:insert(cert, options)
   local name_list, err, err_t = parse_name_list(cert.snis, self.errors)
   if err then
     return nil, err, err_t
+  end
+
+  if (not cert.key or cert.key == null) and name_list and #name_list ~= 0 then
+    local err_t = self.errors:schema_violation({
+      snis = "private key is not present, \"snis\" field should be absent",
+    })
+
+    return nil, tostring(err_t), err_t
   end
 
   if name_list then
@@ -99,8 +108,26 @@ function _Certificates:update(cert_pk, cert, options)
     end
   end
 
+  local snis
+  snis, err, err_t = self.db.snis:list_for_certificate(cert_pk)
+  if not snis then
+    return nil, err, err_t
+  end
+
   -- update certificate if necessary
   if cert.key or cert.cert then
+    if cert.key == null then
+      -- user tries to remove private key from cert
+      if (name_list and #name_list ~= 0) or #snis ~= 0 then
+        local err_t = self.errors:schema_violation({
+          key = "one or more SNI names are still associated with this" ..
+                 " certificate, private key cannot be removed",
+        })
+
+        return nil, tostring(err_t), err_t
+      end
+    end
+
     cert.snis = nil
     cert, err, err_t = self.super.update(self, cert_pk, cert, options)
     if err then
@@ -117,10 +144,7 @@ function _Certificates:update(cert_pk, cert, options)
     end
 
   else
-    cert.snis, err, err_t = self.db.snis:list_for_certificate(cert_pk)
-    if not cert.snis then
-      return nil, err, err_t
-    end
+    cert.snis = snis
   end
 
   return cert
@@ -138,6 +162,14 @@ function _Certificates:upsert(cert_pk, cert, options)
     if not ok then
       return nil, err, err_t
     end
+  end
+
+  if (not cert.key or cert.key == null) and name_list and #name_list ~= 0 then
+    local err_t = self.errors:schema_violation({
+      snis = "private key is not present, \"snis\" field should be absent",
+    })
+
+    return nil, tostring(err_t), err_t
   end
 
   cert.snis = nil

--- a/kong/db/dao/snis.lua
+++ b/kong/db/dao/snis.lua
@@ -33,8 +33,8 @@ local function check_private_key_exists(self, sni)
 
   if not cert.key then
     local err_t = self.errors:schema_violation({
-      certificate = "must have the \"key\" field (private key) set to" ..
-                    " assign SNI names",
+      certificate = "cannot be used by SNI because specified Certificate" ..
+                    " does not have the 'key' attribute set",
     })
     return nil, tostring(err_t), err_t
   end

--- a/kong/db/schema/entities/certificates.lua
+++ b/kong/db/schema/entities/certificates.lua
@@ -1,6 +1,7 @@
 local typedefs = require "kong.db.schema.typedefs"
 local openssl_pkey = require "openssl.pkey"
 local openssl_x509 = require "openssl.x509"
+local null = ngx.null
 
 return {
   name        = "certificates",
@@ -11,13 +12,18 @@ return {
     { id = typedefs.uuid, },
     { created_at     = typedefs.auto_timestamp_s },
     { cert           = typedefs.certificate { required = true }, },
-    { key            = typedefs.key         { required = true }, },
+    { key            = typedefs.key, },
   },
 
   entity_checks = {
     { custom_entity_check = {
       field_sources = { "cert", "key" },
       fn = function(entity)
+        if entity.key == null then
+          -- no private key
+          return true
+        end
+
         local cert = openssl_x509.new(entity.cert)
         local key = openssl_pkey.new(entity.key)
 

--- a/spec/02-integration/04-admin_api/06-certificates_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/06-certificates_routes_spec.lua
@@ -159,6 +159,57 @@ describe("Admin API: #" .. strategy, function()
         assert.same({ "bar.com", "foo.com" }, json.data[1].snis)
       end)
 
+      it("allows private key to be absent (CA certificate)", function()
+        local res = client:post("/certificates", {
+          body    = {
+            cert  = ssl_fixtures.cert,
+            snis  = cjson.null,
+          },
+          headers = { ["Content-Type"] = "application/json" },
+        })
+        local body = assert.res_status(201, res)
+        local json = cjson.decode(body)
+
+        local id = json.id
+
+        res  = client:get("/certificates/" .. id)
+        body = assert.res_status(200, res)
+        json = cjson.decode(body)
+        assert.same({}, json.snis)
+      end)
+
+      it("accept empty SNI as array when cert has no private key", function()
+        local res = client:post("/certificates", {
+          body    = {
+            cert  = ssl_fixtures.cert,
+            snis  = {},
+          },
+          headers = { ["Content-Type"] = "application/json" },
+        })
+        local body = assert.res_status(201, res)
+        local json = cjson.decode(body)
+        local id = json.id
+
+        res  = client:get("/certificates/" .. id)
+        body = assert.res_status(200, res)
+        json = cjson.decode(body)
+        assert.same({}, json.snis)
+      end)
+
+      it("prohibits setting SNI on certificate without private keys", function()
+        local res = client:post("/certificates", {
+          body    = {
+            cert  = ssl_fixtures.cert,
+            snis  = { "a.example.com" },
+          },
+          headers = { ["Content-Type"] = "application/json" },
+        })
+        local body = assert.res_status(400, res)
+        local json = cjson.decode(body)
+        assert.matches("snis: private key is not present, \"snis\" field should be absent", json.message,
+                       nil, true)
+      end)
+
       it_content_types("creates a certificate and returns it with the snis pseudo-property", function(content_type)
         return function()
           local body
@@ -354,10 +405,9 @@ describe("Admin API: #" .. strategy, function()
         assert.same({
           code     = Errors.codes.SCHEMA_VIOLATION,
           name     = "schema violation",
-          message  = "2 schema violations (cert: required field missing; key: required field missing)",
+          message  = "schema violation (cert: required field missing)",
           fields  = {
             cert = "required field missing",
-            key = "required field missing",
           }
         }, cjson.decode(body))
       end)
@@ -380,11 +430,94 @@ describe("Admin API: #" .. strategy, function()
           }
         }, cjson.decode(body))
       end)
+
+      it("allows private key to be absent (CA certificate)", function()
+        local id = utils.uuid()
+
+        local res = client:put("/certificates/" .. id, {
+          body    = {
+            cert  = ssl_fixtures.cert,
+            snis  = cjson.null,
+          },
+          headers = { ["Content-Type"] = "application/json" },
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.equal(json.id, id)
+
+        res  = client:get("/certificates/" .. id)
+        body = assert.res_status(200, res)
+        json = cjson.decode(body)
+        assert.same({}, json.snis)
+      end)
+
+      it("accept empty SNI as array when cert has no private key", function()
+        local id = utils.uuid()
+
+        local res = client:put("/certificates/" .. id, {
+          body    = {
+            cert  = ssl_fixtures.cert,
+            snis  = {},
+          },
+          headers = { ["Content-Type"] = "application/json" },
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.equal(json.id, id)
+
+        res  = client:get("/certificates/" .. id)
+        body = assert.res_status(200, res)
+        json = cjson.decode(body)
+        assert.same({}, json.snis)
+      end)
+
+      it("prohibits setting SNI on certificate without private keys", function()
+        local id = utils.uuid()
+
+        local res = client:put("/certificates/" .. id, {
+          body    = {
+            cert  = ssl_fixtures.cert,
+            snis  = { "a.example.com" },
+          },
+          headers = { ["Content-Type"] = "application/json" },
+        })
+        local body = assert.res_status(400, res)
+        local json = cjson.decode(body)
+        assert.matches("snis: private key is not present, \"snis\" field should be absent", json.message,
+                       nil, true)
+      end)
+
+      it("only prohibits adding SNI to certificate without private keys", function()
+        local id = utils.uuid()
+
+        local res = client:put("/certificates/" .. id, {
+          body    = {
+            cert  = ssl_fixtures.cert,
+            snis  = {},
+          },
+          headers = { ["Content-Type"] = "application/json" },
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.equal(json.id, id)
+
+        res = client:put("/certificates/" .. id, {
+          body    = {
+            snis  = { "put.example.com" },
+          },
+          headers = { ["Content-Type"] = "application/json" },
+        })
+        body = assert.res_status(400, res)
+        json = cjson.decode(body)
+        assert.matches("snis: private key is not present, \"snis\" field should be absent",
+                       json.message, nil, true)
+      end)
     end)
 
     describe("PATCH", function()
       local cert_foo
       local cert_bar
+      local cert_no_key
 
       before_each(function()
         assert(db:truncate("certificates"))
@@ -411,6 +544,16 @@ describe("Admin API: #" .. strategy, function()
         })
         local body = assert.res_status(201, res)
         cert_bar = cjson.decode(body)
+
+        local res = client:post("/certificates", {
+          body    = {
+            cert  = ssl_fixtures.cert,
+            snis  = cjson.null,
+          },
+          headers = { ["Content-Type"] = "application/json" },
+        })
+        local body = assert.res_status(201, res)
+        cert_no_key = cjson.decode(body)
       end)
 
       it_content_types("updates a certificate by cert id", function(content_type)
@@ -483,8 +626,8 @@ describe("Admin API: #" .. strategy, function()
         res  = client:get("/certificates")
         local body = assert.res_status(200, res)
         local json = cjson.decode(body)
-        assert.equal(2, #json.data)
-        assert.same({ { "bar.com" }, { "foo.com" } }, get_snis_lists(json.data))
+        assert.equal(3, #json.data)
+        assert.same({ {}, { "bar.com" }, { "foo.com" } }, get_snis_lists(json.data))
       end)
 
       it("updates snis associated with a certificate", function()
@@ -502,8 +645,8 @@ describe("Admin API: #" .. strategy, function()
         res  = client:get("/certificates")
         body = assert.res_status(200, res)
         json = cjson.decode(body)
-        assert.equal(2, #json.data)
-        assert.same({ { "bar.com" }, { "baz.com" } }, get_snis_lists(json.data))
+        assert.equal(3, #json.data)
+        assert.same({ {}, { "bar.com" }, { "baz.com" } }, get_snis_lists(json.data))
       end)
 
       it("updates only the certificate if no snis are specified", function()
@@ -534,7 +677,7 @@ describe("Admin API: #" .. strategy, function()
         res  = client:get("/certificates")
         body = assert.res_status(200, res)
         json = cjson.decode(body)
-        assert.same({ { "bar.com" }, { "foo.com" } }, get_snis_lists(json.data))
+        assert.same({ {}, { "bar.com" }, { "foo.com" } }, get_snis_lists(json.data))
       end)
 
       it("returns a conflict when duplicated snis are present in the request", function()
@@ -553,8 +696,8 @@ describe("Admin API: #" .. strategy, function()
         res = client:get("/certificates")
         body = assert.res_status(200, res)
         json = cjson.decode(body)
-        assert.equal(2, #json.data)
-        assert.same({ { "bar.com" }, { "foo.com" } }, get_snis_lists(json.data))
+        assert.equal(3, #json.data)
+        assert.same({ {}, { "bar.com" }, { "foo.com" } }, get_snis_lists(json.data))
       end)
 
       it("returns a conflict when a pre-existing sni present in " ..
@@ -577,8 +720,8 @@ describe("Admin API: #" .. strategy, function()
         res  = client:get("/certificates")
         body = assert.res_status(200, res)
         json = cjson.decode(body)
-        assert.equal(2, #json.data)
-        assert.same({ { "bar.com" }, { "foo.com" } }, get_snis_lists(json.data))
+        assert.equal(3, #json.data)
+        assert.same({ {}, { "bar.com" }, { "foo.com" } }, get_snis_lists(json.data))
       end)
 
       it("deletes all snis from a certificate if snis field is JSON null", function()
@@ -602,8 +745,34 @@ describe("Admin API: #" .. strategy, function()
         res  = client:get("/certificates")
         body = assert.res_status(200, res)
         json = cjson.decode(body)
-        assert.equal(2, #json.data)
-        assert.same({ {}, { "foo.com" } }, get_snis_lists(json.data))
+        assert.equal(3, #json.data)
+        assert.same({ {}, {}, { "foo.com" } }, get_snis_lists(json.data))
+      end)
+
+      it("prohibits adding SNI to certificate without private keys", function()
+        local res = client:patch("/certificates/" .. cert_no_key.id, {
+          body    = {
+            snis  = { "patch.example.com" },
+          },
+          headers = { ["Content-Type"] = "application/json" },
+        })
+        local body = assert.res_status(400, res)
+        local json = cjson.decode(body)
+        assert.matches("certificate: must have the \"key\" field (private key) set to assign SNI names",
+                       json.message, nil, true)
+      end)
+
+      it("only prohibits removal of private key from certificate with SNI names", function()
+        local res = client:patch("/certificates/" .. cert_foo.id, {
+          body    = {
+            key = cjson.null,
+          },
+          headers = { ["Content-Type"] = "application/json" },
+        })
+        local body = assert.res_status(400, res)
+        local json = cjson.decode(body)
+        assert.matches("key: one or more SNI names are still associated with this certificate, private key cannot be removed",
+                       json.message, nil, true)
       end)
     end)
 
@@ -645,6 +814,8 @@ describe("Admin API: #" .. strategy, function()
     describe("POST", function()
 
       local certificate
+      local certificate_no_key
+
       before_each(function()
         assert(db:truncate("certificates"))
         assert(db:truncate("snis"))
@@ -653,6 +824,10 @@ describe("Admin API: #" .. strategy, function()
         bp.snis:insert({
           name = "ttt.com",
           certificate = { id = certificate.id }
+        })
+
+        certificate_no_key = bp.certificates:insert({
+          key = cjson.null,
         })
       end)
 
@@ -720,6 +895,20 @@ describe("Admin API: #" .. strategy, function()
         local json = cjson.decode(body)
         assert.equals("unique constraint violation", json.name)
       end)
+
+      it("prohibits adding SNI if private key not present", function()
+        local res = client:post("/certificates/" .. certificate_no_key.id .. "/snis", {
+          body    = {
+            name = "foo.com",
+          },
+          headers = { ["Content-Type"] = "application/json" },
+        })
+
+        local body = assert.res_status(400, res)
+        local json = cjson.decode(body)
+        assert.match("certificate: must have the \"key\" field (private key) set to assign SNI names",
+                     json.message, nil, true)
+      end)
     end)
 
     describe("GET", function()
@@ -744,7 +933,7 @@ describe("Admin API: #" .. strategy, function()
   end)
 
   describe("/snis/:name", function()
-    local certificate, sni
+    local certificate, sni, certificate_no_key
 
     before_each(function()
       assert(db:truncate("certificates"))
@@ -755,6 +944,10 @@ describe("Admin API: #" .. strategy, function()
         name        = "foo.com",
         certificate = certificate,
       }
+
+      certificate_no_key = bp.certificates:insert({
+        key = cjson.null,
+      })
     end)
 
     describe("GET", function()
@@ -826,6 +1019,22 @@ describe("Admin API: #" .. strategy, function()
           }
         }, cjson.decode(body))
       end)
+
+      it("prohibits adding SNI if private key not present", function()
+        local id = utils.uuid()
+        local res = client:put("/snis/" .. id, {
+          body    = {
+            name = "updated.com",
+            certificate = { id = certificate_no_key.id },
+          },
+          headers = { ["Content-Type"] = "application/json" },
+        })
+
+        local body = assert.res_status(400, res)
+        local json = cjson.decode(body)
+        assert.match("certificate: must have the \"key\" field (private key) set to assign SNI names",
+                     json.message, nil, true)
+      end)
     end)
 
     describe("PATCH", function()
@@ -855,6 +1064,20 @@ describe("Admin API: #" .. strategy, function()
         local body = assert.res_status(200, res)
         local json = cjson.decode(body)
         assert.same({ "foo.com" }, json.snis)
+      end)
+
+      it("unable to update a SNI to point to a certificate missing private key", function()
+        local res = client:patch("/snis/foo.com", {
+          body = {
+            certificate = { id = certificate_no_key.id },
+          },
+          headers = { ["Content-Type"] = "application/json" },
+        })
+
+        local body = assert.res_status(400, res)
+        local json = cjson.decode(body)
+        assert.match("certificate: must have the \"key\" field (private key) set to assign SNI names",
+                     json.message, nil, true)
       end)
     end)
 

--- a/spec/02-integration/04-admin_api/06-certificates_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/06-certificates_routes_spec.lua
@@ -206,7 +206,7 @@ describe("Admin API: #" .. strategy, function()
         })
         local body = assert.res_status(400, res)
         local json = cjson.decode(body)
-        assert.matches("snis: private key is not present, \"snis\" field should be absent", json.message,
+        assert.matches("snis: cannot be specified because the 'key' attribute is not set", json.message,
                        nil, true)
       end)
 
@@ -483,7 +483,7 @@ describe("Admin API: #" .. strategy, function()
         })
         local body = assert.res_status(400, res)
         local json = cjson.decode(body)
-        assert.matches("snis: private key is not present, \"snis\" field should be absent", json.message,
+        assert.matches("snis: cannot be specified because the 'key' attribute is not set", json.message,
                        nil, true)
       end)
 
@@ -509,7 +509,7 @@ describe("Admin API: #" .. strategy, function()
         })
         body = assert.res_status(400, res)
         json = cjson.decode(body)
-        assert.matches("snis: private key is not present, \"snis\" field should be absent",
+        assert.matches("snis: cannot be specified because the 'key' attribute is not set",
                        json.message, nil, true)
       end)
     end)
@@ -758,7 +758,7 @@ describe("Admin API: #" .. strategy, function()
         })
         local body = assert.res_status(400, res)
         local json = cjson.decode(body)
-        assert.matches("certificate: must have the \"key\" field (private key) set to assign SNI names",
+        assert.matches("certificate: cannot be used by SNI because specified Certificate does not have the 'key' attribute set",
                        json.message, nil, true)
       end)
 
@@ -771,8 +771,22 @@ describe("Admin API: #" .. strategy, function()
         })
         local body = assert.res_status(400, res)
         local json = cjson.decode(body)
-        assert.matches("key: one or more SNI names are still associated with this certificate, private key cannot be removed",
+        assert.matches("key: cannot be removed, since one or more SNIs are still associated to this Certificate",
                        json.message, nil, true)
+      end)
+
+      it("removing private key and SNIs at the same time from certificate should succeed", function()
+        local res = client:patch("/certificates/" .. cert_foo.id, {
+          body    = {
+            key = cjson.null,
+            snis = cjson.null,
+          },
+          headers = { ["Content-Type"] = "application/json" },
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.equal(0, #json.snis)
+        assert.equal(cjson.null, json.key)
       end)
     end)
 
@@ -906,7 +920,7 @@ describe("Admin API: #" .. strategy, function()
 
         local body = assert.res_status(400, res)
         local json = cjson.decode(body)
-        assert.match("certificate: must have the \"key\" field (private key) set to assign SNI names",
+        assert.match("certificate: cannot be used by SNI because specified Certificate does not have the 'key' attribute set",
                      json.message, nil, true)
       end)
     end)
@@ -1032,7 +1046,7 @@ describe("Admin API: #" .. strategy, function()
 
         local body = assert.res_status(400, res)
         local json = cjson.decode(body)
-        assert.match("certificate: must have the \"key\" field (private key) set to assign SNI names",
+        assert.match("certificate: cannot be used by SNI because specified Certificate does not have the 'key' attribute set",
                      json.message, nil, true)
       end)
     end)
@@ -1076,7 +1090,7 @@ describe("Admin API: #" .. strategy, function()
 
         local body = assert.res_status(400, res)
         local json = cjson.decode(body)
-        assert.match("certificate: must have the \"key\" field (private key) set to assign SNI names",
+        assert.match("certificate: cannot be used by SNI because specified Certificate does not have the 'key' attribute set",
                      json.message, nil, true)
       end)
     end)


### PR DESCRIPTION
So that we may use it to store certificates that does not have private key available (for example, CA certs)

Note: PR based on `1.0.2` tag. Will provide a version for `master` as well.