### PR TITLE
hotfix(plugins-iterator) fix a recent performance regression

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -357,8 +357,8 @@ do
   local plugins_iterator
 
 
-  build_plugins_iterator = function()
-    local new_iterator, err = PluginsIterator.new()
+  build_plugins_iterator = function(version)
+    local new_iterator, err = PluginsIterator.new(version)
     if not new_iterator then
       return nil, err
     end

--- a/kong/runloop/plugins_iterator.lua
+++ b/kong/runloop/plugins_iterator.lua
@@ -265,6 +265,10 @@ end
 
 
 function PluginsIterator.new(version)
+  if not version then
+    error("version must be given", 2)
+  end
+
   loaded_plugins = loaded_plugins or get_loaded_plugins()
 
   local map = {}


### PR DESCRIPTION
This fixes a hole left in 27dc712
causing a plugin iterator state to not have a `version` field, thus
forcing the plugins iterator to be rebuilt for every request.

This regression cause a single worker to experience performance drops
of over **80%** in terms of tps.

A similar regression was introduced by
06b760e in which the `version` field of
the `plugins` state was removed, forcing the plugins map to be rebuilt
for each request.

Alas, it seems like no unit test exists as of today for the current
plugins_iterator module ensuring that this property is properly set.