### PR TITLE
feat(schema) make `key` field of `certificate` entity to be optional

### DIFF
--- a/kong/db/dao/certificates.lua
+++ b/kong/db/dao/certificates.lua
@@ -56,7 +56,7 @@ function _Certificates:insert(cert, options)
 
   if (not cert.key or cert.key == null) and name_list and #name_list ~= 0 then
     local err_t = self.errors:schema_violation({
-      snis = "private key is not present, \"snis\" field should be absent",
+      snis = "cannot be specified because the 'key' attribute is not set",
     })
 
     return nil, tostring(err_t), err_t
@@ -118,10 +118,19 @@ function _Certificates:update(cert_pk, cert, options)
   if cert.key or cert.cert then
     if cert.key == null then
       -- user tries to remove private key from cert
-      if (name_list and #name_list ~= 0) or #snis ~= 0 then
+      if #snis > 0 and not name_list then
         local err_t = self.errors:schema_violation({
-          key = "one or more SNI names are still associated with this" ..
-                 " certificate, private key cannot be removed",
+          key = "cannot be removed, since one or more SNIs are still" ..
+                " associated to this Certificate",
+        })
+
+        return nil, tostring(err_t), err_t
+      end
+
+      if name_list and #name_list ~= 0 then
+        local err_t = self.errors:schema_violation({
+          snis = "cannot associate SNIs to this Certificate" ..
+                 " because the 'key' attribute is not set",
         })
 
         return nil, tostring(err_t), err_t
@@ -166,7 +175,7 @@ function _Certificates:upsert(cert_pk, cert, options)
 
   if (not cert.key or cert.key == null) and name_list and #name_list ~= 0 then
     local err_t = self.errors:schema_violation({
-      snis = "private key is not present, \"snis\" field should be absent",
+      snis = "cannot be specified because the 'key' attribute is not set",
     })
 
     return nil, tostring(err_t), err_t

--- a/kong/db/dao/certificates.lua
+++ b/kong/db/dao/certificates.lua
@@ -7,6 +7,7 @@ local tostring = tostring
 local ipairs = ipairs
 local table = table
 local type = type
+local null = ngx.null
 
 
 -- Get an array of SNI names from either
@@ -51,6 +52,14 @@ function _Certificates:insert(cert, options)
   local name_list, err, err_t = parse_name_list(cert.snis, self.errors)
   if err then
     return nil, err, err_t
+  end
+
+  if (not cert.key or cert.key == null) and name_list and #name_list ~= 0 then
+    local err_t = self.errors:schema_violation({
+      snis = "private key is not present, \"snis\" field should be absent",
+    })
+
+    return nil, tostring(err_t), err_t
   end
 
   if name_list then
@@ -99,8 +108,26 @@ function _Certificates:update(cert_pk, cert, options)
     end
   end
 
+  local snis
+  snis, err, err_t = self.db.snis:list_for_certificate(cert_pk)
+  if not snis then
+    return nil, err, err_t
+  end
+
   -- update certificate if necessary
   if cert.key or cert.cert then
+    if cert.key == null then
+      -- user tries to remove private key from cert
+      if (name_list and #name_list ~= 0) or #snis ~= 0 then
+        local err_t = self.errors:schema_violation({
+          key = "one or more SNI names are still associated with this" ..
+                 " certificate, private key cannot be removed",
+        })
+
+        return nil, tostring(err_t), err_t
+      end
+    end
+
     cert.snis = nil
     cert, err, err_t = self.super.update(self, cert_pk, cert, options)
     if err then
@@ -117,10 +144,7 @@ function _Certificates:update(cert_pk, cert, options)
     end
 
   else
-    cert.snis, err, err_t = self.db.snis:list_for_certificate(cert_pk)
-    if not cert.snis then
-      return nil, err, err_t
-    end
+    cert.snis = snis
   end
 
   return cert
@@ -138,6 +162,14 @@ function _Certificates:upsert(cert_pk, cert, options)
     if not ok then
       return nil, err, err_t
     end
+  end
+
+  if (not cert.key or cert.key == null) and name_list and #name_list ~= 0 then
+    local err_t = self.errors:schema_violation({
+      snis = "private key is not present, \"snis\" field should be absent",
+    })
+
+    return nil, tostring(err_t), err_t
   end
 
   cert.snis = nil

--- a/kong/db/dao/snis.lua
+++ b/kong/db/dao/snis.lua
@@ -33,8 +33,8 @@ local function check_private_key_exists(self, sni)
 
   if not cert.key then
     local err_t = self.errors:schema_violation({
-      certificate = "must have the \"key\" field (private key) set to" ..
-                    " assign SNI names",
+      certificate = "cannot be used by SNI because specified Certificate" ..
+                    " does not have the 'key' attribute set",
     })
     return nil, tostring(err_t), err_t
   end

--- a/kong/db/schema/entities/certificates.lua
+++ b/kong/db/schema/entities/certificates.lua
@@ -1,6 +1,7 @@
 local typedefs = require "kong.db.schema.typedefs"
 local openssl_pkey = require "openssl.pkey"
 local openssl_x509 = require "openssl.x509"
+local null = ngx.null
 
 return {
   name        = "certificates",
@@ -11,7 +12,7 @@ return {
     { id = typedefs.uuid, },
     { created_at     = typedefs.auto_timestamp_s },
     { cert           = typedefs.certificate { required = true }, },
-    { key            = typedefs.key         { required = true }, },
+    { key            = typedefs.key, },
     { tags           = typedefs.tags },
   },
 
@@ -19,6 +20,11 @@ return {
     { custom_entity_check = {
       field_sources = { "cert", "key" },
       fn = function(entity)
+        if entity.key == null then
+          -- no private key
+          return true
+        end
+
         local cert = openssl_x509.new(entity.cert)
         local key = openssl_pkey.new(entity.key)
 

--- a/spec/02-integration/04-admin_api/06-certificates_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/06-certificates_routes_spec.lua
@@ -206,7 +206,7 @@ describe("Admin API: #" .. strategy, function()
         })
         local body = assert.res_status(400, res)
         local json = cjson.decode(body)
-        assert.matches("snis: private key is not present, \"snis\" field should be absent", json.message,
+        assert.matches("snis: cannot be specified because the 'key' attribute is not set", json.message,
                        nil, true)
       end)
 
@@ -483,7 +483,7 @@ describe("Admin API: #" .. strategy, function()
         })
         local body = assert.res_status(400, res)
         local json = cjson.decode(body)
-        assert.matches("snis: private key is not present, \"snis\" field should be absent", json.message,
+        assert.matches("snis: cannot be specified because the 'key' attribute is not set", json.message,
                        nil, true)
       end)
 
@@ -509,7 +509,7 @@ describe("Admin API: #" .. strategy, function()
         })
         body = assert.res_status(400, res)
         json = cjson.decode(body)
-        assert.matches("snis: private key is not present, \"snis\" field should be absent",
+        assert.matches("snis: cannot be specified because the 'key' attribute is not set",
                        json.message, nil, true)
       end)
     end)
@@ -758,7 +758,7 @@ describe("Admin API: #" .. strategy, function()
         })
         local body = assert.res_status(400, res)
         local json = cjson.decode(body)
-        assert.matches("certificate: must have the \"key\" field (private key) set to assign SNI names",
+        assert.matches("certificate: cannot be used by SNI because specified Certificate does not have the 'key' attribute set",
                        json.message, nil, true)
       end)
 
@@ -771,8 +771,22 @@ describe("Admin API: #" .. strategy, function()
         })
         local body = assert.res_status(400, res)
         local json = cjson.decode(body)
-        assert.matches("key: one or more SNI names are still associated with this certificate, private key cannot be removed",
+        assert.matches("key: cannot be removed, since one or more SNIs are still associated to this Certificate",
                        json.message, nil, true)
+      end)
+
+      it("removing private key and SNIs at the same time from certificate should succeed", function()
+        local res = client:patch("/certificates/" .. cert_foo.id, {
+          body    = {
+            key = cjson.null,
+            snis = cjson.null,
+          },
+          headers = { ["Content-Type"] = "application/json" },
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.equal(0, #json.snis)
+        assert.equal(cjson.null, json.key)
       end)
     end)
 
@@ -906,7 +920,7 @@ describe("Admin API: #" .. strategy, function()
 
         local body = assert.res_status(400, res)
         local json = cjson.decode(body)
-        assert.match("certificate: must have the \"key\" field (private key) set to assign SNI names",
+        assert.match("certificate: cannot be used by SNI because specified Certificate does not have the 'key' attribute set",
                      json.message, nil, true)
       end)
     end)
@@ -1105,7 +1119,7 @@ describe("Admin API: #" .. strategy, function()
 
         local body = assert.res_status(400, res)
         local json = cjson.decode(body)
-        assert.match("certificate: must have the \"key\" field (private key) set to assign SNI names",
+        assert.match("certificate: cannot be used by SNI because specified Certificate does not have the 'key' attribute set",
                      json.message, nil, true)
       end)
     end)
@@ -1149,7 +1163,7 @@ describe("Admin API: #" .. strategy, function()
 
         local body = assert.res_status(400, res)
         local json = cjson.decode(body)
-        assert.match("certificate: must have the \"key\" field (private key) set to assign SNI names",
+        assert.match("certificate: cannot be used by SNI because specified Certificate does not have the 'key' attribute set",
                      json.message, nil, true)
       end)
     end)


### PR DESCRIPTION
So that we may use it to store certificates that does not have private key available (for example, CA certs)

Same issue as https://github.com/Kong/kong/pull/4599, but against `next` instead.

Docs: https://github.com/Kong/docs.konghq.com/pull/1248