### PR TITLE
hotfix(declarative) fix cache flip + feat(declarative) /cache?check_hash=1

### DIFF
--- a/kong/api/routes/config.lua
+++ b/kong/api/routes/config.lua
@@ -1,6 +1,7 @@
 local declarative = require("kong.db.declarative")
 local concurrency = require("kong.concurrency")
 local reports = require("kong.reports")
+local errors = require("kong.db.errors")
 local kong = kong
 local dc = declarative.new_config(kong.configuration)
 
@@ -27,17 +28,16 @@ return {
         })
       end
 
-      local entities, err_or_ver
+      local entities, err_or_ver, err_t
       if self.params._format_version then
-        entities, err_or_ver = dc:parse_table(self.params)
+        entities, err_or_ver, err_t = dc:parse_table(self.params)
       else
         local config = self.params.config
-        -- TODO extract proper filename from the input
-        entities, err_or_ver = dc:parse_string(config, "config.yml", accept)
+        entities, err_or_ver, err_t = dc:parse_string(config, nil, accept)
       end
 
       if not entities then
-        return kong.response.exit(400, { error = err_or_ver })
+        return kong.response.exit(400, errors:declarative_config(err_t))
       end
 
       local ok, err = concurrency.with_worker_mutex({ name = "dbless-worker" }, function()

--- a/kong/api/routes/config.lua
+++ b/kong/api/routes/config.lua
@@ -28,12 +28,12 @@ return {
         })
       end
 
-      local entities, err_or_ver, err_t
+      local entities, _, err_t, vers
       if self.params._format_version then
-        entities, err_or_ver, err_t = dc:parse_table(self.params)
+        entities, _, err_t, vers = dc:parse_table(self.params)
       else
         local config = self.params.config
-        entities, err_or_ver, err_t = dc:parse_string(config, nil, accept)
+        entities, _, err_t, vers = dc:parse_string(config, nil, accept)
       end
 
       if not entities then
@@ -56,7 +56,7 @@ return {
         return kong.response.exit(500, { message = "An unexpected error occurred" })
       end
 
-      _reports.decl_fmt_version = err_or_ver
+      _reports.decl_fmt_version = vers
       reports.send("dbless-reconfigure", _reports)
 
       return kong.response.exit(201, entities)

--- a/kong/cmd/config.lua
+++ b/kong/cmd/config.lua
@@ -72,9 +72,9 @@ local function execute(args)
       error("expected a declarative configuration file; see `kong config --help`")
     end
 
-    local dc_table, err_or_ver = dc:parse_file(filename, accepted_formats)
+    local dc_table, err, _, vers = dc:parse_file(filename, accepted_formats)
     if not dc_table then
-      error("Failed parsing:\n" .. err_or_ver)
+      error("Failed parsing:\n" .. err)
     end
 
     if args.command == "db_import" then
@@ -103,7 +103,7 @@ local function execute(args)
         kong_reports.configure_ping(conf)
         kong_reports.toggle(true)
 
-        local report = { decl_fmt_version = err_or_ver }
+        local report = { decl_fmt_version = vers }
         kong_reports.send("config-db-import", report)
       end
 

--- a/kong/db/errors.lua
+++ b/kong/db/errors.lua
@@ -40,6 +40,7 @@ local ERRORS              = {
   INVALID_OPTIONS         = 11, -- invalid options given
   OPERATION_UNSUPPORTED   = 12, -- operation is not supported with this strategy
   FOREIGN_KEYS_UNRESOLVED = 13, -- foreign key(s) could not be resolved
+  DECLARATIVE_CONFIG      = 14, -- error parsing declarative configuration
 }
 
 
@@ -60,6 +61,7 @@ local ERRORS_NAMES                 = {
   [ERRORS.INVALID_OPTIONS]         = "invalid options",
   [ERRORS.OPERATION_UNSUPPORTED]   = "operation unsupported",
   [ERRORS.FOREIGN_KEYS_UNRESOLVED] = "foreign keys unresolved",
+  [ERRORS.DECLARATIVE_CONFIG]      = "invalid declarative configuration",
 }
 
 
@@ -447,6 +449,18 @@ function _M:operation_unsupported(err)
   end
 
   return new_err_t(self, ERRORS.OPERATION_UNSUPPORTED, err)
+end
+
+
+function _M:declarative_config(err_t)
+  if type(err_t) ~= "table" then
+    error("err_t must be a table", 2)
+  end
+
+  local message = fmt("declarative config is invalid: %s",
+                      pl_pretty(err_t, ""))
+
+  return new_err_t(self, ERRORS.DECLARATIVE_CONFIG, message, err_t)
 end
 
 

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -250,6 +250,11 @@ local function load_declarative_config(kong_config, entities)
 
     mesh.init()
 
+    ok, err = ngx.shared.kong:safe_set("declarative_config:loaded", true)
+    if not ok then
+      kong.log.warn("failed marking declarative_config as loaded: ", err)
+    end
+
     return true
   end)
 end

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -350,6 +350,18 @@ local function register_events()
       log(ERR, "failed broadcasting upstream ", operation, " to workers: ", err)
     end
   end)
+
+
+  -- declarative config updates
+
+
+  if db.strategy == "off" then
+    worker_events.register(function()
+      cache:flip()
+    end, "declarative", "flip_config")
+  end
+
+
 end
 
 

--- a/spec/02-integration/04-admin_api/15-off_spec.lua
+++ b/spec/02-integration/04-admin_api/15-off_spec.lua
@@ -455,7 +455,14 @@ describe("Admin API #off", function()
       local body =assert.response(res).has.status(400)
       local json = cjson.decode(body)
       assert.same({
-        error = "expected a table as input",
+        code = 14,
+        fields = {
+          error ="failed parsing declarative configuration: expected an object",
+        },
+        message = [[declarative config is invalid: ]] ..
+                  [[{error="failed parsing declarative configuration: ]] ..
+                  [[expected an object"}]],
+        name = "invalid declarative configuration",
       }, json)
     end)
   end)

--- a/spec/02-integration/04-admin_api/15-off_spec.lua
+++ b/spec/02-integration/04-admin_api/15-off_spec.lua
@@ -440,6 +440,45 @@ describe("Admin API #off", function()
       assert.response(res).has.status(201)
     end)
 
+    it("returns 304 if checking hash and configuration is identical", function()
+      local res = assert(client:send {
+        method = "POST",
+        path = "/config?check_hash=1",
+        body = {
+          config = [[
+          _format_version: "1.1"
+          consumers:
+          - username: bobby_tables
+          ]],
+        },
+        headers = {
+          ["Content-Type"] = "application/json"
+        }
+      })
+
+      assert.response(res).has.status(201)
+
+      client:close()
+      client = helpers.admin_client()
+
+      res = assert(client:send {
+        method = "POST",
+        path = "/config?check_hash=1",
+        body = {
+          config = [[
+          _format_version: "1.1"
+          consumers:
+          - username: bobby_tables
+          ]],
+        },
+        headers = {
+          ["Content-Type"] = "application/json"
+        }
+      })
+
+      assert.response(res).has.status(304)
+    end)
+
     it("returns 400 on an invalid config string", function()
       local res = assert(client:send {
         method = "POST",

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -1576,10 +1576,12 @@ local function restart_kong(env, tables)
 end
 
 
-local function make_yaml_file(content)
-  local filename = os.tmpname()
-  os.rename(filename, filename .. ".yml")
-  filename = filename .. ".yml"
+local function make_yaml_file(content, filename)
+  if not filename then
+    filename = os.tmpname()
+    os.rename(filename, filename .. ".yml")
+    filename = filename .. ".yml"
+  end
   local fd = assert(io.open(filename, "w"))
   assert(fd:write(unindent(content)))
   assert(fd:write("\n")) -- ensure last line ends in newline


### PR DESCRIPTION
Instead of opening 2 PRs (one of which would be a single hotfix commit) which would require a rebase and conflict-fix once merged, I'm pushing these combined for review. If desired, I can open `hotfix/cache-flip` as a separate PR. Each commit has its own description and can be reviewed separately (they do not undo work from previous commits).

## hotfix(declarative) propagate cache flip to workers

https://github.com/Kong/kong/commit/2767d9bae41dc2c6451fd16a5e3ef72348c603b8

Thanks @bungle for the report!

This hotfix fixes two problems at once, both related to incorrect behavior flipping cache pages:

* we now propagate worker events so that all workers flip their cache pages and point to the currently-filled shm
* we avoid flipping pages at startup, to prevent dependencies with worker-event propagation order at initialization

Two regression tests are included, one for each scenario. The worker propagation test is probabilistic, but given the configuration of the test, it fails consistently on my machine
without the patch, and passes consistently with it. The startup test is deterministic.

## feat(declarative) hash checking of declarative configuration

The remaining of the the PR is a new feature, motivated by the investigation of the behavior of declarative config with regard to `kong reload`. In #4592, the reset of the `kong ` shm made so that a `kong reload` correctly rescans the declarative file configured in `declarative_config`. This PR adds tests in aa8d5fa that verify that this behavior is correct. While working on the behavior of `kong reload`, I added hash-checking support to the declarative config loader. It made sense to add this functionality to the `/config` endpoint. 

This introduces a new query argument so that the hash of a given declarative configuration is checked against the hash of the current configuration before loading it. For backward compatibility, this was added as a new query argument:

```
$ http :8001/config?check_hash=1 config=@config.yml   # load a config
201 Created
{
   ...
}

$ http :8001/config?check_hash=1 config=@config.yml   # reload the same config
304 Not Modified
```

Hash checking only happens when the value of `check_hash` is `1`. (This design was chosen to allow for future extensibility, if we add new hashing behaviors, those can be set to different numbers.)