### PR TITLE
fix(migrations) make cassandra migrations reentrant and ignore undefined columns errors

### DIFF
--- a/kong/db/migrations/core/001_14_to_15.lua
+++ b/kong/db/migrations/core/001_14_to_15.lua
@@ -342,15 +342,56 @@ return {
           tags set<text>, -- added in 1.1.0
           PRIMARY KEY (id)
         );
-
-        CREATE INDEX IF NOT EXISTS ON plugins(name);
-        CREATE INDEX IF NOT EXISTS ON plugins(api_id);
-        CREATE INDEX IF NOT EXISTS ON plugins(route_id);
-        CREATE INDEX IF NOT EXISTS ON plugins(service_id);
-        CREATE INDEX IF NOT EXISTS ON plugins(consumer_id);
-        CREATE INDEX IF NOT EXISTS ON plugins(cache_key);
-        CREATE INDEX IF NOT EXISTS ON plugins(run_on);
       ]]))
+
+      local _, err = connector:query("CREATE INDEX IF NOT EXISTS ON plugins(name)")
+      if err and not (string.find(err, "Column .- was not found in table") or
+                      string.find(err, "[Ii]nvalid column name")           or
+                      string.find(err, "[Uu]ndefined column name")) then
+        return nil, err
+      end
+
+      _, err = connector:query("CREATE INDEX IF NOT EXISTS ON plugins(api_id)")
+      if err and not (string.find(err, "Column .- was not found in table") or
+                      string.find(err, "[Ii]nvalid column name")           or
+                      string.find(err, "[Uu]ndefined column name")) then
+        return nil, err
+      end
+
+      _, err = connector:query("CREATE INDEX IF NOT EXISTS ON plugins(route_id)")
+      if err and not (string.find(err, "Column .- was not found in table") or
+                      string.find(err, "[Ii]nvalid column name")           or
+                      string.find(err, "[Uu]ndefined column name")) then
+        return nil, err
+      end
+
+      _, err = connector:query("CREATE INDEX IF NOT EXISTS ON plugins(service_id)")
+      if err and not (string.find(err, "Column .- was not found in table") or
+                      string.find(err, "[Ii]nvalid column name")           or
+                      string.find(err, "[Uu]ndefined column name")) then
+        return nil, err
+      end
+
+      _, err = connector:query("CREATE INDEX IF NOT EXISTS ON plugins(consumer_id)")
+      if err and not (string.find(err, "Column .- was not found in table") or
+                      string.find(err, "[Ii]nvalid column name")           or
+                      string.find(err, "[Uu]ndefined column name")) then
+        return nil, err
+      end
+
+      _, err = connector:query("CREATE INDEX IF NOT EXISTS ON plugins(cache_key)")
+      if err and not (string.find(err, "Column .- was not found in table") or
+                      string.find(err, "[Ii]nvalid column name")           or
+                      string.find(err, "[Uu]ndefined column name")) then
+        return nil, err
+      end
+
+      _, err = connector:query("CREATE INDEX IF NOT EXISTS ON plugins(run_on)")
+      if err and not (string.find(err, "Column .- was not found in table") or
+                      string.find(err, "[Ii]nvalid column name")           or
+                      string.find(err, "[Uu]ndefined column name")) then
+        return nil, err
+      end
 
       plugins_def = {
         name    = "plugins",

--- a/kong/db/strategies/cassandra/connector.lua
+++ b/kong/db/strategies/cassandra/connector.lua
@@ -935,11 +935,11 @@ do
       if cql ~= "" then
         local res, err = conn:execute(cql)
         if not res then
-          if string.find(err, "Column .- was not found in table")
-             or string.find(err, "[Ii]nvalid column name") then
+          if string.find(err, "Column .- was not found in table") or
+             string.find(err, "[Ii]nvalid column name")           or
+             string.find(err, "[Uu]ndefined column name") then
             log.warn("ignored error while running '%s' migration: %s (%s)",
                      name, err, cql:gsub("\n", " "):gsub("%s%s+", " "))
-
           else
             return nil, err
           end

--- a/kong/plugins/oauth2/migrations/001_14_to_15.lua
+++ b/kong/plugins/oauth2/migrations/001_14_to_15.lua
@@ -126,6 +126,13 @@ return {
       for rows, err in coordinator:iterate([[
         SELECT id, redirect_uri FROM oauth2_credentials]]) do
         if err then
+          if string.find(err, "Column .- was not found in table") or
+             string.find(err, "[Ii]nvalid column name")           or
+             string.find(err, "[Uu]ndefined column name")
+          then
+            return
+          end
+
           return nil, err
         end
 

--- a/kong/plugins/oauth2/migrations/002_15_to_10.lua
+++ b/kong/plugins/oauth2/migrations/002_15_to_10.lua
@@ -37,11 +37,23 @@ return {
       assert(connector:query([[
         DROP INDEX IF EXISTS oauth2_authorization_codes_api_id_idx;
         DROP INDEX IF EXISTS oauth2_tokens_api_id_idx;
-
-
-        ALTER TABLE oauth2_authorization_codes DROP api_id;
-        ALTER TABLE oauth2_tokens DROP api_id;
       ]]))
+
+
+      local _, err = connector:query([[
+        ALTER TABLE oauth2_authorization_codes DROP api_id]])
+      if err and not (string.find(err, "Column .- was not found in table") or
+                      string.find(err, "[Ii]nvalid column name")           or
+                      string.find(err, "[Uu]ndefined column name")) then
+        return nil, err
+      end
+
+      _, err = connector:query("ALTER TABLE oauth2_tokens DROP api_id")
+      if err and not (string.find(err, "Column .- was not found in table") or
+                      string.find(err, "[Ii]nvalid column name")           or
+                      string.find(err, "[Uu]ndefined column name")) then
+        return nil, err
+      end
     end,
   },
 }


### PR DESCRIPTION
### Summary

This PR contains two fixes that together fix the issue: #4610.

1. It makes cassandra teardown migrations reentrant
2. It makes cassandra up migrations to ignore undefined column errors

### Issues resolved

Fix #4610
