### PR TITLE
fix(migrations) check if there are executed migrations when using -f

### DIFF
--- a/kong/cmd/config.lua
+++ b/kong/cmd/config.lua
@@ -123,14 +123,14 @@ Usage: kong config COMMAND [OPTIONS]
 Use declarative configuration files with Kong.
 
 The available commands are:
-  init                          Generate an example config file to
-                                get you started.
+  init                                Generate an example config file to
+                                      get you started.
 
-  db_import <file>              Import a declarative config file into
-                                the Kong database.
+  db_import <file>                    Import a declarative config file into
+                                      the Kong database.
 
-  parse <file>                  Parse a declarative config file (check
-                                its syntax) but do not load it into Kong.
+  parse <file>                        Parse a declarative config file (check
+                                      its syntax) but do not load it into Kong.
 
 Options:
  -c,--conf        (optional string)   Configuration file.

--- a/kong/cmd/init.lua
+++ b/kong/cmd/init.lua
@@ -39,8 +39,7 @@ The available commands are:
  %s
 
 Options:
-%s
-]], table.concat(cmds_arr, "\n "), options)
+%s]], table.concat(cmds_arr, "\n "), options)
 
 return function(args)
   local cmd_name = table.remove(args, 1)

--- a/kong/cmd/migrations.lua
+++ b/kong/cmd/migrations.lua
@@ -43,6 +43,7 @@ Options:
                                     migrations.
 
  -c,--conf        (optional string) Configuration file.
+
 ]]
 
 

--- a/kong/cmd/prepare.lua
+++ b/kong/cmd/prepare.lua
@@ -22,14 +22,14 @@ be used to start Kong from the nginx binary without using the 'kong start'
 command.
 
 Example usage:
-  kong migrations up
-  kong prepare -p /usr/local/kong -c kong.conf
-  nginx -p /usr/local/kong -c /usr/local/kong/nginx.conf
+ kong migrations up
+ kong prepare -p /usr/local/kong -c kong.conf
+ nginx -p /usr/local/kong -c /usr/local/kong/nginx.conf
 
 Options:
-  -c,--conf       (optional string) configuration file
-  -p,--prefix     (optional string) override prefix directory
-  --nginx-conf    (optional string) custom Nginx configuration template
+ -c,--conf       (optional string) configuration file
+ -p,--prefix     (optional string) override prefix directory
+ --nginx-conf    (optional string) custom Nginx configuration template
 ]]
 
 

--- a/kong/cmd/utils/migrations.lua
+++ b/kong/cmd/utils/migrations.lua
@@ -128,7 +128,7 @@ local function up(schema_state, db, opts)
       error("Database has pending migrations; run 'kong migrations finish'")
     end
 
-    if opts.force then
+    if opts.force and schema_state.executed_migrations then
       log.debug("forcing re-execution of these migrations:\n%s",
                 schema_state.executed_migrations)
 
@@ -197,7 +197,7 @@ local function finish(schema_state, db, opts)
   local ok, err = db:cluster_mutex(MIGRATIONS_MUTEX_KEY, opts, function()
     local schema_state = assert(db:schema_state())
 
-    if opts.force then
+    if opts.force and schema_state.executed_migrations then
       assert(db:run_migrations(schema_state.executed_migrations, {
         run_up = true,
         run_teardown = true,

--- a/kong/db/migrations/core/000_base.lua
+++ b/kong/db/migrations/core/000_base.lua
@@ -72,7 +72,6 @@ return {
         "regex_priority"  BIGINT,
         "strip_path"      BOOLEAN,
         "preserve_host"   BOOLEAN
-
       );
 
       DO $$

--- a/kong/db/strategies/postgres/connector.lua
+++ b/kong/db/strategies/postgres/connector.lua
@@ -639,9 +639,10 @@ end
 
 function _mt:remove_lock(key, owner)
   local sql = concat {
-    "DELETE FROM locks\n",
-    "      WHERE key   = ", self:escape_literal(key), "\n",
-         "   AND owner = ", self:escape_literal(owner), ";"
+    "DELETE\n",
+    "  FROM ", self:escape_identifier("locks"), "\n",
+    " WHERE ", self:escape_identifier("key"), "   = ", self:escape_literal(key), "\n",
+    "   AND ", self:escape_identifier("owner"), " = ", self:escape_literal(owner), ";"
   }
 
   local res, err = self:query(sql)


### PR DESCRIPTION
### Summary

Fixes `kong migrations up|finish -f` (see the `-f`) to not run executed, when there are no executed migrations.

There is also some assorted style fixes related to `kong` cli and `migrations`.