### PR TITLE
chore(plugins) bump version fields

### DIFF
--- a/kong/plugins/acl/handler.lua
+++ b/kong/plugins/acl/handler.lua
@@ -39,7 +39,7 @@ local ACLHandler = {}
 
 
 ACLHandler.PRIORITY = 950
-ACLHandler.VERSION = "1.0.0"
+ACLHandler.VERSION = "2.0.0"
 
 
 function ACLHandler:access(conf)

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -242,7 +242,7 @@ end
 
 
 AWSLambdaHandler.PRIORITY = 750
-AWSLambdaHandler.VERSION = "1.0.0"
+AWSLambdaHandler.VERSION = "2.0.0"
 
 
 return AWSLambdaHandler

--- a/kong/plugins/basic-auth/handler.lua
+++ b/kong/plugins/basic-auth/handler.lua
@@ -11,7 +11,7 @@ end
 
 
 BasicAuthHandler.PRIORITY = 1001
-BasicAuthHandler.VERSION = "1.0.0"
+BasicAuthHandler.VERSION = "2.0.0"
 
 
 return BasicAuthHandler

--- a/kong/plugins/bot-detection/handler.lua
+++ b/kong/plugins/bot-detection/handler.lua
@@ -8,7 +8,7 @@ local re_find = ngx.re.find
 local BotDetectionHandler = {}
 
 BotDetectionHandler.PRIORITY = 2500
-BotDetectionHandler.VERSION = "1.0.0"
+BotDetectionHandler.VERSION = "2.0.0"
 
 local BAD_REQUEST = 400
 local FORBIDDEN = 403

--- a/kong/plugins/correlation-id/handler.lua
+++ b/kong/plugins/correlation-id/handler.lua
@@ -43,7 +43,7 @@ local CorrelationIdHandler = {}
 
 
 CorrelationIdHandler.PRIORITY = 1
-CorrelationIdHandler.VERSION = "1.0.0"
+CorrelationIdHandler.VERSION = "2.0.0"
 
 
 function CorrelationIdHandler:init_worker()

--- a/kong/plugins/cors/handler.lua
+++ b/kong/plugins/cors/handler.lua
@@ -17,7 +17,7 @@ local CorsHandler = {}
 
 
 CorsHandler.PRIORITY = 2000
-CorsHandler.VERSION = "1.0.0"
+CorsHandler.VERSION = "2.0.0"
 
 
 -- per-plugin cache of normalized origins for runtime comparison

--- a/kong/plugins/datadog/handler.lua
+++ b/kong/plugins/datadog/handler.lua
@@ -12,7 +12,7 @@ local NGX_ERR       = ngx.ERR
 
 local DatadogHandler    = {}
 DatadogHandler.PRIORITY = 10
-DatadogHandler.VERSION = "1.0.0"
+DatadogHandler.VERSION = "2.0.0"
 
 
 local get_consumer_id = {

--- a/kong/plugins/file-log/handler.lua
+++ b/kong/plugins/file-log/handler.lua
@@ -60,7 +60,7 @@ end
 local FileLogHandler = {}
 
 FileLogHandler.PRIORITY = 9
-FileLogHandler.VERSION = "1.0.0"
+FileLogHandler.VERSION = "2.0.0"
 
 function FileLogHandler:log(conf)
   local message = basic_serializer.serialize(ngx)

--- a/kong/plugins/hmac-auth/handler.lua
+++ b/kong/plugins/hmac-auth/handler.lua
@@ -11,7 +11,7 @@ end
 
 
 HMACAuthHandler.PRIORITY = 1000
-HMACAuthHandler.VERSION = "1.0.0"
+HMACAuthHandler.VERSION = "2.0.0"
 
 
 return HMACAuthHandler

--- a/kong/plugins/http-log/handler.lua
+++ b/kong/plugins/http-log/handler.lua
@@ -15,7 +15,7 @@ local HttpLogHandler = {}
 
 
 HttpLogHandler.PRIORITY = 12
-HttpLogHandler.VERSION = "1.0.0"
+HttpLogHandler.VERSION = "2.0.0"
 
 
 local queues = {} -- one queue per unique plugin config

--- a/kong/plugins/ip-restriction/handler.lua
+++ b/kong/plugins/ip-restriction/handler.lua
@@ -11,7 +11,7 @@ local cache = {}
 local IpRestrictionHandler = {}
 
 IpRestrictionHandler.PRIORITY = 990
-IpRestrictionHandler.VERSION = "1.0.0"
+IpRestrictionHandler.VERSION = "2.0.0"
 
 local function cidr_cache(cidr_tab)
   local cidr_tab_len = #cidr_tab

--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -14,7 +14,7 @@ local JwtHandler = {}
 
 
 JwtHandler.PRIORITY = 1005
-JwtHandler.VERSION = "1.0.0"
+JwtHandler.VERSION = "2.0.0"
 
 
 --- Retrieve a JWT in a request.

--- a/kong/plugins/key-auth/handler.lua
+++ b/kong/plugins/key-auth/handler.lua
@@ -12,7 +12,7 @@ local KeyAuthHandler = {}
 
 
 KeyAuthHandler.PRIORITY = 1003
-KeyAuthHandler.VERSION = "1.0.0"
+KeyAuthHandler.VERSION = "2.0.0"
 
 
 local function load_credential(key)

--- a/kong/plugins/ldap-auth/handler.lua
+++ b/kong/plugins/ldap-auth/handler.lua
@@ -10,7 +10,7 @@ end
 
 
 LdapAuthHandler.PRIORITY = 1002
-LdapAuthHandler.VERSION = "1.0.0"
+LdapAuthHandler.VERSION = "2.0.0"
 
 
 return LdapAuthHandler

--- a/kong/plugins/loggly/handler.lua
+++ b/kong/plugins/loggly/handler.lua
@@ -4,7 +4,7 @@ local cjson = require "cjson"
 local LogglyLogHandler = {}
 
 LogglyLogHandler.PRIORITY = 6
-LogglyLogHandler.VERSION = "1.0.0"
+LogglyLogHandler.VERSION = "2.0.0"
 
 local os_date = os.date
 local tostring = tostring

--- a/kong/plugins/oauth2/handler.lua
+++ b/kong/plugins/oauth2/handler.lua
@@ -7,6 +7,6 @@ function OAuthHandler:access(conf)
 end
 
 OAuthHandler.PRIORITY = 1004
-OAuthHandler.VERSION = "1.0.0"
+OAuthHandler.VERSION = "2.0.0"
 
 return OAuthHandler

--- a/kong/plugins/rate-limiting/handler.lua
+++ b/kong/plugins/rate-limiting/handler.lua
@@ -19,7 +19,7 @@ local RateLimitingHandler = {}
 
 
 RateLimitingHandler.PRIORITY = 901
-RateLimitingHandler.VERSION = "1.0.0"
+RateLimitingHandler.VERSION = "2.0.0"
 
 
 local function get_identifier(conf)

--- a/kong/plugins/request-size-limiting/handler.lua
+++ b/kong/plugins/request-size-limiting/handler.lua
@@ -8,7 +8,7 @@ local MB = 2^20
 local RequestSizeLimitingHandler = {}
 
 RequestSizeLimitingHandler.PRIORITY = 951
-RequestSizeLimitingHandler.VERSION = "1.0.0"
+RequestSizeLimitingHandler.VERSION = "2.0.0"
 
 local function check_size(length, allowed_size, headers)
   local allowed_bytes_size = allowed_size * MB

--- a/kong/plugins/request-termination/handler.lua
+++ b/kong/plugins/request-termination/handler.lua
@@ -21,7 +21,7 @@ local RequestTerminationHandler = {}
 
 
 RequestTerminationHandler.PRIORITY = 2
-RequestTerminationHandler.VERSION = "1.0.0"
+RequestTerminationHandler.VERSION = "2.0.0"
 
 
 function RequestTerminationHandler:access(conf)

--- a/kong/plugins/request-transformer/handler.lua
+++ b/kong/plugins/request-transformer/handler.lua
@@ -7,6 +7,6 @@ function RequestTransformerHandler:access(conf)
 end
 
 RequestTransformerHandler.PRIORITY = 801
-RequestTransformerHandler.VERSION = "1.0.0"
+RequestTransformerHandler.VERSION = "2.0.0"
 
 return RequestTransformerHandler

--- a/kong/plugins/response-ratelimiting/handler.lua
+++ b/kong/plugins/response-ratelimiting/handler.lua
@@ -27,7 +27,7 @@ end
 
 
 ResponseRateLimitingHandler.PRIORITY = 900
-ResponseRateLimitingHandler.VERSION = "1.0.0"
+ResponseRateLimitingHandler.VERSION = "2.0.0"
 
 
 return ResponseRateLimitingHandler

--- a/kong/plugins/response-transformer/handler.lua
+++ b/kong/plugins/response-transformer/handler.lua
@@ -40,7 +40,7 @@ end
 
 
 ResponseTransformerHandler.PRIORITY = 800
-ResponseTransformerHandler.VERSION = "1.0.0"
+ResponseTransformerHandler.VERSION = "2.0.0"
 
 
 return ResponseTransformerHandler

--- a/kong/plugins/statsd/handler.lua
+++ b/kong/plugins/statsd/handler.lua
@@ -12,7 +12,7 @@ local NGX_ERR       = ngx.ERR
 
 local StatsdHandler = {}
 StatsdHandler.PRIORITY = 11
-StatsdHandler.VERSION = "1.0.0"
+StatsdHandler.VERSION = "2.0.0"
 
 
 local get_consumer_id = {

--- a/kong/plugins/syslog/handler.lua
+++ b/kong/plugins/syslog/handler.lua
@@ -11,7 +11,7 @@ local string_upper = string.upper
 local SysLogHandler = {}
 
 SysLogHandler.PRIORITY = 4
-SysLogHandler.VERSION = "1.0.0"
+SysLogHandler.VERSION = "2.0.0"
 
 local SENDER_NAME = "kong"
 

--- a/kong/plugins/tcp-log/handler.lua
+++ b/kong/plugins/tcp-log/handler.lua
@@ -4,7 +4,7 @@ local cjson = require "cjson"
 local TcpLogHandler = {}
 
 TcpLogHandler.PRIORITY = 7
-TcpLogHandler.VERSION = "1.0.0"
+TcpLogHandler.VERSION = "2.0.0"
 
 local function log(premature, conf, message)
   if premature then

--- a/kong/plugins/udp-log/handler.lua
+++ b/kong/plugins/udp-log/handler.lua
@@ -7,7 +7,7 @@ local udp = ngx.socket.udp
 local UdpLogHandler = {}
 
 UdpLogHandler.PRIORITY = 8
-UdpLogHandler.VERSION = "1.0.0"
+UdpLogHandler.VERSION = "2.0.0"
 
 local function log(premature, conf, str)
   if premature then


### PR DESCRIPTION
### Summary

Bump plugins versions to account for recent internal changes their
handlers (a29c355). Said changes removed plugins handlers dependency
on the base plugin class; there were changes in the plugins DAO
(`load_plugin_schemas`) to accommodate for the base class removal, making
it non-backwards compatible, warranting a major version bump in plugins
versions.