### PR TITLE
fix(ldap-auth) reuse connection if starttls has been already started

### DIFF
--- a/spec/03-plugins/20-ldap-auth/01-access_spec.lua
+++ b/spec/03-plugins/20-ldap-auth/01-access_spec.lua
@@ -22,687 +22,695 @@ end
 
 local ldap_host_aws = "ec2-54-172-82-117.compute-1.amazonaws.com"
 
+local ldap_strategies = {
+  non_secure = { name = "non-secure", start_tls = false },
+  start_tls = { name = "starttls", start_tls = true }
+}
 
-for _, strategy in helpers.each_strategy() do
-  describe("Plugin: ldap-auth (access) [#" .. strategy .. "]", function()
-    local proxy_client
-    local admin_client
-    local route2
-    local plugin2
-
-    lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy, {
-        "routes",
-        "services",
-        "plugins",
-        "consumers",
-      })
-
-      local route1 = bp.routes:insert {
-        hosts = { "ldap.com" },
-      }
-
-      route2 = bp.routes:insert {
-        hosts = { "ldap2.com" },
-      }
-
-      local route3 = bp.routes:insert {
-        hosts = { "ldap3.com" },
-      }
-
-      local route4 = bp.routes:insert {
-        hosts = { "ldap4.com" },
-      }
-
-      local route5 = bp.routes:insert {
-        hosts = { "ldap5.com" },
-      }
-
-      bp.routes:insert {
-        hosts = { "ldap6.com" },
-      }
-
-      local anonymous_user = bp.consumers:insert {
-        username = "no-body"
-      }
-
-      bp.plugins:insert {
-        route = { id = route1.id },
-        name     = "ldap-auth",
-        config   = {
-          ldap_host = ldap_host_aws,
-          ldap_port = 389,
-          start_tls = false,
-          base_dn   = "ou=scientists,dc=ldap,dc=mashape,dc=com",
-          attribute = "uid"
-        }
-      }
-
-      plugin2 = bp.plugins:insert {
-        route = { id = route2.id },
-        name     = "ldap-auth",
-        config   = {
-          ldap_host        = ldap_host_aws,
-          ldap_port        = 389,
-          start_tls        = false,
-          base_dn          = "ou=scientists,dc=ldap,dc=mashape,dc=com",
-          attribute        = "uid",
-          hide_credentials = true,
-          cache_ttl        = 2,
-        }
-      }
-
-      bp.plugins:insert {
-        route = { id = route3.id },
-        name     = "ldap-auth",
-        config   = {
-          ldap_host = ldap_host_aws,
-          ldap_port = 389,
-          start_tls = false,
-          base_dn   = "ou=scientists,dc=ldap,dc=mashape,dc=com",
-          attribute = "uid",
-          anonymous = anonymous_user.id,
-        }
-      }
-
-      bp.plugins:insert {
-        route = { id = route4.id },
-        name     = "ldap-auth",
-        config   = {
-          ldap_host = "ec2-54-210-29-167.compute-1.amazonaws.com",
-          ldap_port = 389,
-          start_tls = false,
-          base_dn   = "ou=scientists,dc=ldap,dc=mashape,dc=com",
-          attribute = "uid",
-          cache_ttl = 2,
-          anonymous = utils.uuid(), -- non existing consumer
-        }
-      }
-
-      bp.plugins:insert {
-        route = { id = route5.id },
-        name     = "ldap-auth",
-        config   = {
-          ldap_host = ldap_host_aws,
-          ldap_port = 389,
-          start_tls = false,
-          base_dn   = "ou=scientists,dc=ldap,dc=mashape,dc=com",
-          attribute = "uid",
-          header_type = "Basic",
-        }
-      }
-
-      bp.plugins:insert {
-        name     = "ldap-auth",
-        config   = {
-          ldap_host = ldap_host_aws,
-          ldap_port = 389,
-          start_tls = false,
-          base_dn   = "ou=scientists,dc=ldap,dc=mashape,dc=com",
-          attribute = "uid"
-        }
-      }
-
-      assert(helpers.start_kong({
-        database   = strategy,
-        nginx_conf = "spec/fixtures/custom_nginx.template",
-      }))
-    end)
-
-    lazy_teardown(function()
-      helpers.stop_kong()
-    end)
-
-    before_each(function()
-      proxy_client = helpers.proxy_client()
-      admin_client = helpers.admin_client()
-    end)
-
-    after_each(function()
-      if proxy_client then
-        proxy_client:close()
-      end
-
-      if admin_client then
-        admin_client:close()
-      end
-    end)
-
-    it("returns 'invalid credentials' and www-authenticate header when the credential is missing", function()
-      local res = assert(proxy_client:send {
-        method  = "GET",
-        path    = "/get",
-        headers = {
-          host  = "ldap.com"
-        }
-      })
-      assert.response(res).has.status(401)
-      local value = assert.response(res).has.header("www-authenticate")
-      assert.are.equal('LDAP realm="kong"', value)
-      local json = assert.response(res).has.jsonbody()
-      assert.equal("Unauthorized", json.message)
-    end)
-    it("returns 'invalid credentials' when credential value is in wrong format in authorization header", function()
-      local res = assert(proxy_client:send {
-        method  = "GET",
-        path    = "/get",
-        headers = {
-          host  = "ldap.com",
-          authorization = "abcd"
-        }
-      })
-      assert.response(res).has.status(401)
-      local json = assert.response(res).has.jsonbody()
-      assert.equal("Invalid authentication credentials", json.message)
-    end)
-    it("returns 'invalid credentials' when credential value is in wrong format in proxy-authorization header", function()
-      local res = assert(proxy_client:send {
-        method  = "GET",
-        path    = "/get",
-        headers = {
-          host  = "ldap.com",
-          ["proxy-authorization"] = "abcd"
-        }
-      })
-      assert.response(res).has.status(401)
-      local json = assert.response(res).has.jsonbody()
-      assert.equal("Invalid authentication credentials", json.message)
-    end)
-    it("returns 'invalid credentials' when credential value is missing in authorization header", function()
-      local res = assert(proxy_client:send {
-        method  = "GET",
-        path    = "/get",
-        headers = {
-          host          = "ldap.com",
-          authorization = "ldap "
-        }
-      })
-      assert.response(res).has.status(401)
-      local json = assert.response(res).has.jsonbody()
-      assert.equal("Invalid authentication credentials", json.message)
-    end)
-    it("passes if credential is valid in post request", function()
-      local res = assert(proxy_client:send {
-        method  = "POST",
-        path    = "/request",
-        body    = {},
-        headers = {
-          host             = "ldap.com",
-          authorization    = "ldap " .. ngx.encode_base64("einstein:password"),
-          ["content-type"] = "application/x-www-form-urlencoded",
-        }
-      })
-      assert.response(res).has.status(200)
-    end)
-    it("fails if credential type is invalid in post request", function()
-      local r = assert(proxy_client:send {
-        method = "POST",
-        path = "/request",
-        body = {},
-        headers = {
-          host = "ldap.com",
-          authorization = "invalidldap " .. ngx.encode_base64("einstein:password"),
-          ["content-type"] = "application/x-www-form-urlencoded",
-        }
-      })
-      assert.response(r).has.status(401)
-    end)
-    it("passes if credential is valid and starts with space in post request", function()
-      local res = assert(proxy_client:send {
-        method  = "POST",
-        path    = "/request",
-        headers = {
-          host          = "ldap.com",
-          authorization = " ldap " .. ngx.encode_base64("einstein:password")
-        }
-      })
-      assert.response(res).has.status(200)
-    end)
-    it("passes if signature type indicator is in caps and credential is valid in post request", function()
-      local res = assert(proxy_client:send {
-        method  = "POST",
-        path    = "/request",
-        headers = {
-          host          = "ldap.com",
-          authorization = "LDAP " .. ngx.encode_base64("einstein:password")
-        }
-      })
-      assert.response(res).has.status(200)
-    end)
-    it("passes if credential is valid in get request", function()
-      local res = assert(proxy_client:send {
-        method  = "GET",
-        path    = "/request",
-        headers = {
-          host          = "ldap.com",
-          authorization = "ldap " .. ngx.encode_base64("einstein:password")
-        }
-      })
-      assert.response(res).has.status(200)
-      local value = assert.request(res).has.header("x-credential-username")
-      assert.are.equal("einstein", value)
-      assert.request(res).has_not.header("x-anonymous-username")
-    end)
-    it("authorization fails if credential does has no password encoded in get request", function()
-      local res = assert(proxy_client:send {
-        method  = "GET",
-        path    = "/request",
-        headers = {
-          host          = "ldap.com",
-          authorization = "ldap " .. ngx.encode_base64("einstein:")
-        }
-      })
-      assert.response(res).has.status(401)
-    end)
-    it("authorization fails with correct status with wrong very long password", function()
-      local res = assert(proxy_client:send {
-        method  = "GET",
-        path    = "/request",
-        headers = {
-          host          = "ldap.com",
-          authorization = "ldap " .. ngx.encode_base64("einstein:e0d91f53c566e0d91f53c566e0d91f53c566e0d91f53c566e0d91f53c566e0d91f53c566e0d91f53c566e0d91f53c566e0d91f53c566e0d91f53c566e0d91f53c566e0d91f53c566e0d91f53c566")
-        }
-      })
-      assert.response(res).has.status(401)
-    end)
-    it("authorization fails if credential has multiple encoded usernames or passwords separated by ':' in get request", function()
-      local res = assert(proxy_client:send {
-        method  = "GET",
-        path    = "/request",
-        headers = {
-          host          = "ldap.com",
-          authorization = "ldap " .. ngx.encode_base64("einstein:password:another_password")
-        }
-      })
-      assert.response(res).has.status(401)
-    end)
-    it("does not pass if credential is invalid in get request", function()
-      local res = assert(proxy_client:send {
-        method  = "GET",
-        path    = "/request",
-        headers = {
-          host          = "ldap.com",
-          authorization = "ldap " .. ngx.encode_base64("einstein:wrong_password")
-        }
-      })
-      assert.response(res).has.status(401)
-    end)
-    it("does not hide credential sent along with authorization header to upstream server", function()
-      local res = assert(proxy_client:send {
-        method  = "GET",
-        path    = "/request",
-        headers = {
-          host          = "ldap.com",
-          authorization = "ldap " .. ngx.encode_base64("einstein:password")
-        }
-      })
-      assert.response(res).has.status(200)
-      local value = assert.request(res).has.header("authorization")
-      assert.equal("ldap " .. ngx.encode_base64("einstein:password"), value)
-    end)
-    it("hides credential sent along with authorization header to upstream server", function()
-      local res = assert(proxy_client:send {
-        method  = "GET",
-        path    = "/request",
-        headers = {
-          host          = "ldap2.com",
-          authorization = "ldap " .. ngx.encode_base64("einstein:password")
-        }
-      })
-      assert.response(res).has.status(200)
-      assert.request(res).has.no.header("authorization")
-    end)
-    it("passes if custom credential type is given in post request", function()
-      local r = assert(proxy_client:send {
-        method = "POST",
-        path = "/request",
-        body = {},
-        headers = {
-          host = "ldap5.com",
-          authorization = "basic " .. ngx.encode_base64("einstein:password"),
-          ["content-type"] = "application/x-www-form-urlencoded",
-        }
-      })
-      assert.response(r).has.status(200)
-    end)
-    it("injects conf.header_type in WWW-Authenticate header", function()
-      local res = assert(proxy_client:send {
-        method  = "GET",
-        path    = "/get",
-        headers = {
-          host  = "ldap5.com",
-        }
-      })
-      assert.response(res).has.status(401)
-
-      local value = assert.response(res).has.header("www-authenticate")
-      assert.equal('Basic realm="kong"', value)
-      local json = assert.response(res).has.jsonbody()
-      assert.equal("Unauthorized", json.message)
-    end)
-    it("fails if custom credential type is invalid in post request", function()
-      local r = assert(proxy_client:send {
-        method = "POST",
-        path = "/request",
-        body = {},
-        headers = {
-          host = "ldap5.com",
-          authorization = "invalidldap " .. ngx.encode_base64("einstein:password"),
-          ["content-type"] = "application/x-www-form-urlencoded",
-        }
-      })
-      assert.response(r).has.status(401)
-    end)
-    it("passes if credential is valid in get request using global plugin", function()
-      local res = assert(proxy_client:send {
-        method  = "GET",
-        path    = "/request",
-        headers = {
-          host          = "ldap6.com",
-          authorization = "ldap " .. ngx.encode_base64("einstein:password")
-        }
-      })
-      assert.response(res).has.status(200)
-      local value = assert.request(res).has.header("x-credential-username")
-      assert.are.equal("einstein", value)
-      assert.request(res).has_not.header("x-anonymous-username")
-    end)
-    it("caches LDAP Auth Credential", function()
-      local res = assert(proxy_client:send {
-        method  = "GET",
-        path    = "/request",
-        headers = {
-          host          = "ldap2.com",
-          authorization = "ldap " .. ngx.encode_base64("einstein:password")
-        }
-      })
-      assert.response(res).has.status(200)
-
-      -- Check that cache is populated
-      local key = cache_key(plugin2.config, "einstein", "password")
-
-      helpers.wait_until(function()
-        local res = assert(admin_client:send {
-          method  = "GET",
-          path    = "/cache/" .. key
-        })
-        res:read_body()
-        return res.status == 200
-      end)
-
-      -- Check that cache is invalidated
-      helpers.wait_until(function()
-        local res = admin_client:send {
-          method  = "GET",
-          path    = "/cache/" .. key
-        }
-        res:read_body()
-        --if res.status ~= 404 then
-        --  ngx.sleep( plugin2.config.cache_ttl / 5 )
-        --end
-        return res.status == 404
-      end, plugin2.config.cache_ttl + 10)
-    end)
-
-    describe("config.anonymous", function()
-      it("works with right credentials and anonymous", function()
-        local res = assert(proxy_client:send {
-          method  = "GET",
-          path    = "/request",
-          headers = {
-            host          = "ldap3.com",
-            authorization = "ldap " .. ngx.encode_base64("einstein:password")
+for _, ldap_strategy in pairs(ldap_strategies) do
+  describe("Connection strategy [" .. ldap_strategy.name .. "]", function()
+    for _, strategy in helpers.each_strategy() do
+      describe("Plugin: ldap-auth (access) [#" .. strategy .. "]", function()
+        local proxy_client
+        local admin_client
+        local route2
+        local plugin2
+    
+        lazy_setup(function()
+          local bp = helpers.get_db_utils(strategy, {
+            "routes",
+            "services",
+            "plugins",
+            "consumers",
+          })
+    
+          local route1 = bp.routes:insert {
+            hosts = { "ldap.com" },
           }
-        })
-        assert.response(res).has.status(200)
-
-        local value = assert.request(res).has.header("x-credential-username")
-        assert.are.equal("einstein", value)
-        assert.request(res).has_not.header("x-anonymous-username")
-      end)
-      it("works with wrong credentials and anonymous", function()
-        local res = assert(proxy_client:send {
-          method  = "GET",
-          path    = "/request",
-          headers = {
-            host  = "ldap3.com"
+    
+          route2 = bp.routes:insert {
+            hosts = { "ldap2.com" },
           }
-        })
-        assert.response(res).has.status(200)
-        local value = assert.request(res).has.header("x-anonymous-consumer")
-        assert.are.equal("true", value)
-        value = assert.request(res).has.header("x-consumer-username")
-        assert.equal('no-body', value)
-      end)
-      it("errors when anonymous user doesn't exist", function()
-        local res = assert(proxy_client:send {
-          method  = "GET",
-          path    = "/request",
-          headers = {
-            ["Host"] = "ldap4.com"
+    
+          local route3 = bp.routes:insert {
+            hosts = { "ldap3.com" },
           }
-        })
-        assert.response(res).has.status(500)
-      end)
-    end)
-  end)
-
-  describe("Plugin: ldap-auth (access) [#" .. strategy .. "]", function()
-    local proxy_client
-    local user
-    local anonymous
-
-    lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy, {
-        "routes",
-        "services",
-        "plugins",
-        "consumers",
-        "keyauth_credentials",
-      })
-
-      local service1 = bp.services:insert({
-        path = "/request"
-      })
-
-      local route1 = bp.routes:insert {
-        hosts   = { "logical-and.com" },
-        service = service1,
-      }
-
-      bp.plugins:insert {
-        route = { id = route1.id },
-        name     = "ldap-auth",
-        config   = {
-          ldap_host = ldap_host_aws,
-          ldap_port = 389,
-          start_tls = false,
-          base_dn   = "ou=scientists,dc=ldap,dc=mashape,dc=com",
-          attribute = "uid",
-        },
-      }
-
-      bp.plugins:insert {
-        name     = "key-auth",
-        route = { id = route1.id },
-      }
-
-      anonymous = bp.consumers:insert {
-        username = "Anonymous",
-      }
-
-      user = bp.consumers:insert {
-        username = "Mickey",
-      }
-
-      local service2 = bp.services:insert({
-        path = "/request"
-      })
-
-      local route2 = bp.routes:insert {
-        hosts   = { "logical-or.com" },
-        service = service2
-      }
-
-      bp.plugins:insert {
-        route = { id = route2.id },
-        name     = "ldap-auth",
-        config   = {
-          ldap_host = ldap_host_aws,
-          ldap_port = 389,
-          start_tls = false,
-          base_dn   = "ou=scientists,dc=ldap,dc=mashape,dc=com",
-          attribute = "uid",
-          anonymous = anonymous.id,
-        },
-      }
-
-      bp.plugins:insert {
-        name     = "key-auth",
-        route = { id = route2.id },
-        config   = {
-          anonymous = anonymous.id,
-        },
-      }
-
-      bp.keyauth_credentials:insert {
-        key      = "Mouse",
-        consumer = { id = user.id },
-      }
-
-      assert(helpers.start_kong({
-        database   = strategy,
-        nginx_conf = "spec/fixtures/custom_nginx.template",
-      }))
-
-      proxy_client = helpers.proxy_client()
-    end)
-
-
-    lazy_teardown(function()
-      if proxy_client then
-        proxy_client:close()
-      end
-
-      helpers.stop_kong()
-    end)
-
-    describe("multiple auth without anonymous, logical AND", function()
-
-      it("passes with all credentials provided", function()
-        local res = assert(proxy_client:send {
-          method  = "GET",
-          path    = "/request",
-          headers = {
-            ["Host"]          = "logical-and.com",
-            ["apikey"]        = "Mouse",
-            ["Authorization"] = "ldap " .. ngx.encode_base64("einstein:password"),
+    
+          local route4 = bp.routes:insert {
+            hosts = { "ldap4.com" },
           }
-        })
-        assert.response(res).has.status(200)
-        assert.request(res).has.no.header("x-anonymous-consumer")
-      end)
-
-      it("fails 401, with only the first credential provided", function()
-        local res = assert(proxy_client:send {
-          method  = "GET",
-          path    = "/request",
-          headers = {
-            ["Host"]   = "logical-and.com",
-            ["apikey"] = "Mouse",
+    
+          local route5 = bp.routes:insert {
+            hosts = { "ldap5.com" },
           }
-        })
-        assert.response(res).has.status(401)
-      end)
-
-      it("fails 401, with only the second credential provided", function()
-        local res = assert(proxy_client:send {
-          method  = "GET",
-          path    = "/request",
-          headers = {
-            ["Host"]          = "logical-and.com",
-            ["Authorization"] = "ldap " .. ngx.encode_base64("einstein:password"),
+    
+          bp.routes:insert {
+            hosts = { "ldap6.com" },
           }
-        })
-        assert.response(res).has.status(401)
-      end)
-
-      it("fails 401, with no credential provided", function()
-        local res = assert(proxy_client:send {
-          method  = "GET",
-          path    = "/request",
-          headers = {
-            ["Host"] = "logical-and.com",
+    
+          local anonymous_user = bp.consumers:insert {
+            username = "no-body"
           }
-        })
-        assert.response(res).has.status(401)
-      end)
-
-    end)
-
-    describe("multiple auth with anonymous, logical OR", function()
-
-      it("passes with all credentials provided", function()
-        local res = assert(proxy_client:send {
-          method  = "GET",
-          path    = "/request",
-          headers = {
-            ["Host"]          = "logical-or.com",
-            ["apikey"]        = "Mouse",
-            ["Authorization"] = "ldap " .. ngx.encode_base64("einstein:password"),
+    
+          bp.plugins:insert {
+            route = { id = route1.id },
+            name     = "ldap-auth",
+            config   = {
+              ldap_host = ldap_host_aws,
+              ldap_port = 389,
+              start_tls = ldap_strategy.start_tls,
+              base_dn   = "ou=scientists,dc=ldap,dc=mashape,dc=com",
+              attribute = "uid"
+            }
           }
-        })
-        assert.response(res).has.status(200)
-        assert.request(res).has.no.header("x-anonymous-consumer")
-        local id = assert.request(res).has.header("x-consumer-id")
-        assert.not_equal(id, anonymous.id)
-        assert(id == user.id)
-      end)
-
-      it("passes with only the first credential provided", function()
-        local res = assert(proxy_client:send {
-          method  = "GET",
-          path    = "/request",
-          headers = {
-            ["Host"]   = "logical-or.com",
-            ["apikey"] = "Mouse",
+    
+          plugin2 = bp.plugins:insert {
+            route = { id = route2.id },
+            name     = "ldap-auth",
+            config   = {
+              ldap_host        = ldap_host_aws,
+              ldap_port        = 389,
+              start_tls        = ldap_strategy.start_tls,
+              base_dn          = "ou=scientists,dc=ldap,dc=mashape,dc=com",
+              attribute        = "uid",
+              hide_credentials = true,
+              cache_ttl        = 2,
+            }
           }
-        })
-        assert.response(res).has.status(200)
-        assert.request(res).has.no.header("x-anonymous-consumer")
-        local id = assert.request(res).has.header("x-consumer-id")
-        assert.not_equal(id, anonymous.id)
-        assert.equal(user.id, id)
-      end)
-
-      it("passes with only the second credential provided", function()
-        local res = assert(proxy_client:send {
-          method  = "GET",
-          path    = "/request",
-          headers = {
-            ["Host"]          = "logical-or.com",
-            ["Authorization"] = "ldap " .. ngx.encode_base64("einstein:password"),
+    
+          bp.plugins:insert {
+            route = { id = route3.id },
+            name     = "ldap-auth",
+            config   = {
+              ldap_host = ldap_host_aws,
+              ldap_port = 389,
+              start_tls = ldap_strategy.start_tls,
+              base_dn   = "ou=scientists,dc=ldap,dc=mashape,dc=com",
+              attribute = "uid",
+              anonymous = anonymous_user.id,
+            }
           }
-        })
-        assert.response(res).has.status(200)
-        assert.request(res).has.no.header("x-anonymous-consumer")
-        local id = assert.request(res).has.header("x-credential-username")
-        assert.equal("einstein", id)
-      end)
-
-      it("passes with no credential provided", function()
-        local res = assert(proxy_client:send {
-          method  = "GET",
-          path    = "/request",
-          headers = {
-            ["Host"] = "logical-or.com",
+    
+          bp.plugins:insert {
+            route = { id = route4.id },
+            name     = "ldap-auth",
+            config   = {
+              ldap_host = "ec2-54-210-29-167.compute-1.amazonaws.com",
+              ldap_port = 389,
+              start_tls = ldap_strategy.start_tls,
+              base_dn   = "ou=scientists,dc=ldap,dc=mashape,dc=com",
+              attribute = "uid",
+              cache_ttl = 2,
+              anonymous = utils.uuid(), -- non existing consumer
+            }
           }
-        })
-        assert.response(res).has.status(200)
-        assert.request(res).has.header("x-anonymous-consumer")
-        local id = assert.request(res).has.header("x-consumer-id")
-        assert.equal(id, anonymous.id)
+    
+          bp.plugins:insert {
+            route = { id = route5.id },
+            name     = "ldap-auth",
+            config   = {
+              ldap_host = ldap_host_aws,
+              ldap_port = 389,
+              start_tls = ldap_strategy.start_tls,
+              base_dn   = "ou=scientists,dc=ldap,dc=mashape,dc=com",
+              attribute = "uid",
+              header_type = "Basic",
+            }
+          }
+    
+          bp.plugins:insert {
+            name     = "ldap-auth",
+            config   = {
+              ldap_host = ldap_host_aws,
+              ldap_port = 389,
+              start_tls = ldap_strategy.start_tls,
+              base_dn   = "ou=scientists,dc=ldap,dc=mashape,dc=com",
+              attribute = "uid"
+            }
+          }
+    
+          assert(helpers.start_kong({
+            database   = strategy,
+            nginx_conf = "spec/fixtures/custom_nginx.template",
+          }))
+        end)
+    
+        lazy_teardown(function()
+          helpers.stop_kong()
+        end)
+    
+        before_each(function()
+          proxy_client = helpers.proxy_client()
+          admin_client = helpers.admin_client()
+        end)
+    
+        after_each(function()
+          if proxy_client then
+            proxy_client:close()
+          end
+    
+          if admin_client then
+            admin_client:close()
+          end
+        end)
+    
+        it("returns 'invalid credentials' and www-authenticate header when the credential is missing", function()
+          local res = assert(proxy_client:send {
+            method  = "GET",
+            path    = "/get",
+            headers = {
+              host  = "ldap.com"
+            }
+          })
+          assert.response(res).has.status(401)
+          local value = assert.response(res).has.header("www-authenticate")
+          assert.are.equal('LDAP realm="kong"', value)
+          local json = assert.response(res).has.jsonbody()
+          assert.equal("Unauthorized", json.message)
+        end)
+        it("returns 'invalid credentials' when credential value is in wrong format in authorization header", function()
+          local res = assert(proxy_client:send {
+            method  = "GET",
+            path    = "/get",
+            headers = {
+              host  = "ldap.com",
+              authorization = "abcd"
+            }
+          })
+          assert.response(res).has.status(401)
+          local json = assert.response(res).has.jsonbody()
+          assert.equal("Invalid authentication credentials", json.message)
+        end)
+        it("returns 'invalid credentials' when credential value is in wrong format in proxy-authorization header", function()
+          local res = assert(proxy_client:send {
+            method  = "GET",
+            path    = "/get",
+            headers = {
+              host  = "ldap.com",
+              ["proxy-authorization"] = "abcd"
+            }
+          })
+          assert.response(res).has.status(401)
+          local json = assert.response(res).has.jsonbody()
+          assert.equal("Invalid authentication credentials", json.message)
+        end)
+        it("returns 'invalid credentials' when credential value is missing in authorization header", function()
+          local res = assert(proxy_client:send {
+            method  = "GET",
+            path    = "/get",
+            headers = {
+              host          = "ldap.com",
+              authorization = "ldap "
+            }
+          })
+          assert.response(res).has.status(401)
+          local json = assert.response(res).has.jsonbody()
+          assert.equal("Invalid authentication credentials", json.message)
+        end)
+        it("passes if credential is valid in post request", function()
+          local res = assert(proxy_client:send {
+            method  = "POST",
+            path    = "/request",
+            body    = {},
+            headers = {
+              host             = "ldap.com",
+              authorization    = "ldap " .. ngx.encode_base64("einstein:password"),
+              ["content-type"] = "application/x-www-form-urlencoded",
+            }
+          })
+          assert.response(res).has.status(200)
+        end)
+        it("fails if credential type is invalid in post request", function()
+          local r = assert(proxy_client:send {
+            method = "POST",
+            path = "/request",
+            body = {},
+            headers = {
+              host = "ldap.com",
+              authorization = "invalidldap " .. ngx.encode_base64("einstein:password"),
+              ["content-type"] = "application/x-www-form-urlencoded",
+            }
+          })
+          assert.response(r).has.status(401)
+        end)
+        it("passes if credential is valid and starts with space in post request", function()
+          local res = assert(proxy_client:send {
+            method  = "POST",
+            path    = "/request",
+            headers = {
+              host          = "ldap.com",
+              authorization = " ldap " .. ngx.encode_base64("einstein:password")
+            }
+          })
+          assert.response(res).has.status(200)
+        end)
+        it("passes if signature type indicator is in caps and credential is valid in post request", function()
+          local res = assert(proxy_client:send {
+            method  = "POST",
+            path    = "/request",
+            headers = {
+              host          = "ldap.com",
+              authorization = "LDAP " .. ngx.encode_base64("einstein:password")
+            }
+          })
+          assert.response(res).has.status(200)
+        end)
+        it("passes if credential is valid in get request", function()
+          local res = assert(proxy_client:send {
+            method  = "GET",
+            path    = "/request",
+            headers = {
+              host          = "ldap.com",
+              authorization = "ldap " .. ngx.encode_base64("einstein:password")
+            }
+          })
+          assert.response(res).has.status(200)
+          local value = assert.request(res).has.header("x-credential-username")
+          assert.are.equal("einstein", value)
+          assert.request(res).has_not.header("x-anonymous-username")
+        end)
+        it("authorization fails if credential does has no password encoded in get request", function()
+          local res = assert(proxy_client:send {
+            method  = "GET",
+            path    = "/request",
+            headers = {
+              host          = "ldap.com",
+              authorization = "ldap " .. ngx.encode_base64("einstein:")
+            }
+          })
+          assert.response(res).has.status(401)
+        end)
+        it("authorization fails with correct status with wrong very long password", function()
+          local res = assert(proxy_client:send {
+            method  = "GET",
+            path    = "/request",
+            headers = {
+              host          = "ldap.com",
+              authorization = "ldap " .. ngx.encode_base64("einstein:e0d91f53c566e0d91f53c566e0d91f53c566e0d91f53c566e0d91f53c566e0d91f53c566e0d91f53c566e0d91f53c566e0d91f53c566e0d91f53c566e0d91f53c566e0d91f53c566e0d91f53c566")
+            }
+          })
+          assert.response(res).has.status(401)
+        end)
+        it("authorization fails if credential has multiple encoded usernames or passwords separated by ':' in get request", function()
+          local res = assert(proxy_client:send {
+            method  = "GET",
+            path    = "/request",
+            headers = {
+              host          = "ldap.com",
+              authorization = "ldap " .. ngx.encode_base64("einstein:password:another_password")
+            }
+          })
+          assert.response(res).has.status(401)
+        end)
+        it("does not pass if credential is invalid in get request", function()
+          local res = assert(proxy_client:send {
+            method  = "GET",
+            path    = "/request",
+            headers = {
+              host          = "ldap.com",
+              authorization = "ldap " .. ngx.encode_base64("einstein:wrong_password")
+            }
+          })
+          assert.response(res).has.status(401)
+        end)
+        it("does not hide credential sent along with authorization header to upstream server", function()
+          local res = assert(proxy_client:send {
+            method  = "GET",
+            path    = "/request",
+            headers = {
+              host          = "ldap.com",
+              authorization = "ldap " .. ngx.encode_base64("einstein:password")
+            }
+          })
+          assert.response(res).has.status(200)
+          local value = assert.request(res).has.header("authorization")
+          assert.equal("ldap " .. ngx.encode_base64("einstein:password"), value)
+        end)
+        it("hides credential sent along with authorization header to upstream server", function()
+          local res = assert(proxy_client:send {
+            method  = "GET",
+            path    = "/request",
+            headers = {
+              host          = "ldap2.com",
+              authorization = "ldap " .. ngx.encode_base64("einstein:password")
+            }
+          })
+          assert.response(res).has.status(200)
+          assert.request(res).has.no.header("authorization")
+        end)
+        it("passes if custom credential type is given in post request", function()
+          local r = assert(proxy_client:send {
+            method = "POST",
+            path = "/request",
+            body = {},
+            headers = {
+              host = "ldap5.com",
+              authorization = "basic " .. ngx.encode_base64("einstein:password"),
+              ["content-type"] = "application/x-www-form-urlencoded",
+            }
+          })
+          assert.response(r).has.status(200)
+        end)
+        it("injects conf.header_type in WWW-Authenticate header", function()
+          local res = assert(proxy_client:send {
+            method  = "GET",
+            path    = "/get",
+            headers = {
+              host  = "ldap5.com",
+            }
+          })
+          assert.response(res).has.status(401)
+    
+          local value = assert.response(res).has.header("www-authenticate")
+          assert.equal('Basic realm="kong"', value)
+          local json = assert.response(res).has.jsonbody()
+          assert.equal("Unauthorized", json.message)
+        end)
+        it("fails if custom credential type is invalid in post request", function()
+          local r = assert(proxy_client:send {
+            method = "POST",
+            path = "/request",
+            body = {},
+            headers = {
+              host = "ldap5.com",
+              authorization = "invalidldap " .. ngx.encode_base64("einstein:password"),
+              ["content-type"] = "application/x-www-form-urlencoded",
+            }
+          })
+          assert.response(r).has.status(401)
+        end)
+        it("passes if credential is valid in get request using global plugin", function()
+          local res = assert(proxy_client:send {
+            method  = "GET",
+            path    = "/request",
+            headers = {
+              host          = "ldap6.com",
+              authorization = "ldap " .. ngx.encode_base64("einstein:password")
+            }
+          })
+          assert.response(res).has.status(200)
+          local value = assert.request(res).has.header("x-credential-username")
+          assert.are.equal("einstein", value)
+          assert.request(res).has_not.header("x-anonymous-username")
+        end)
+        it("caches LDAP Auth Credential", function()
+          local res = assert(proxy_client:send {
+            method  = "GET",
+            path    = "/request",
+            headers = {
+              host          = "ldap2.com",
+              authorization = "ldap " .. ngx.encode_base64("einstein:password")
+            }
+          })
+          assert.response(res).has.status(200)
+    
+          -- Check that cache is populated
+          local key = cache_key(plugin2.config, "einstein", "password")
+    
+          helpers.wait_until(function()
+            local res = assert(admin_client:send {
+              method  = "GET",
+              path    = "/cache/" .. key
+            })
+            res:read_body()
+            return res.status == 200
+          end)
+    
+          -- Check that cache is invalidated
+          helpers.wait_until(function()
+            local res = admin_client:send {
+              method  = "GET",
+              path    = "/cache/" .. key
+            }
+            res:read_body()
+            --if res.status ~= 404 then
+            --  ngx.sleep( plugin2.config.cache_ttl / 5 )
+            --end
+            return res.status == 404
+          end, plugin2.config.cache_ttl + 10)
+        end)
+    
+        describe("config.anonymous", function()
+          it("works with right credentials and anonymous", function()
+            local res = assert(proxy_client:send {
+              method  = "GET",
+              path    = "/request",
+              headers = {
+                host          = "ldap3.com",
+                authorization = "ldap " .. ngx.encode_base64("einstein:password")
+              }
+            })
+            assert.response(res).has.status(200)
+    
+            local value = assert.request(res).has.header("x-credential-username")
+            assert.are.equal("einstein", value)
+            assert.request(res).has_not.header("x-anonymous-username")
+          end)
+          it("works with wrong credentials and anonymous", function()
+            local res = assert(proxy_client:send {
+              method  = "GET",
+              path    = "/request",
+              headers = {
+                host  = "ldap3.com"
+              }
+            })
+            assert.response(res).has.status(200)
+            local value = assert.request(res).has.header("x-anonymous-consumer")
+            assert.are.equal("true", value)
+            value = assert.request(res).has.header("x-consumer-username")
+            assert.equal('no-body', value)
+          end)
+          it("errors when anonymous user doesn't exist", function()
+            local res = assert(proxy_client:send {
+              method  = "GET",
+              path    = "/request",
+              headers = {
+                ["Host"] = "ldap4.com"
+              }
+            })
+            assert.response(res).has.status(500)
+          end)
+        end)
       end)
-    end)
+    
+      describe("Plugin: ldap-auth (access) [#" .. strategy .. "]", function()
+        local proxy_client
+        local user
+        local anonymous
+    
+        lazy_setup(function()
+          local bp = helpers.get_db_utils(strategy, {
+            "routes",
+            "services",
+            "plugins",
+            "consumers",
+            "keyauth_credentials",
+          })
+    
+          local service1 = bp.services:insert({
+            path = "/request"
+          })
+    
+          local route1 = bp.routes:insert {
+            hosts   = { "logical-and.com" },
+            service = service1,
+          }
+    
+          bp.plugins:insert {
+            route = { id = route1.id },
+            name     = "ldap-auth",
+            config   = {
+              ldap_host = ldap_host_aws,
+              ldap_port = 389,
+              start_tls = ldap_strategy.start_tls,
+              base_dn   = "ou=scientists,dc=ldap,dc=mashape,dc=com",
+              attribute = "uid",
+            },
+          }
+    
+          bp.plugins:insert {
+            name     = "key-auth",
+            route = { id = route1.id },
+          }
+    
+          anonymous = bp.consumers:insert {
+            username = "Anonymous",
+          }
+    
+          user = bp.consumers:insert {
+            username = "Mickey",
+          }
+    
+          local service2 = bp.services:insert({
+            path = "/request"
+          })
+    
+          local route2 = bp.routes:insert {
+            hosts   = { "logical-or.com" },
+            service = service2
+          }
+    
+          bp.plugins:insert {
+            route = { id = route2.id },
+            name     = "ldap-auth",
+            config   = {
+              ldap_host = ldap_host_aws,
+              ldap_port = 389,
+              start_tls = ldap_strategy.start_tls,
+              base_dn   = "ou=scientists,dc=ldap,dc=mashape,dc=com",
+              attribute = "uid",
+              anonymous = anonymous.id,
+            },
+          }
+    
+          bp.plugins:insert {
+            name     = "key-auth",
+            route = { id = route2.id },
+            config   = {
+              anonymous = anonymous.id,
+            },
+          }
+    
+          bp.keyauth_credentials:insert {
+            key      = "Mouse",
+            consumer = { id = user.id },
+          }
+    
+          assert(helpers.start_kong({
+            database   = strategy,
+            nginx_conf = "spec/fixtures/custom_nginx.template",
+          }))
+    
+          proxy_client = helpers.proxy_client()
+        end)
+    
+    
+        lazy_teardown(function()
+          if proxy_client then
+            proxy_client:close()
+          end
+    
+          helpers.stop_kong()
+        end)
+    
+        describe("multiple auth without anonymous, logical AND", function()
+    
+          it("passes with all credentials provided", function()
+            local res = assert(proxy_client:send {
+              method  = "GET",
+              path    = "/request",
+              headers = {
+                ["Host"]          = "logical-and.com",
+                ["apikey"]        = "Mouse",
+                ["Authorization"] = "ldap " .. ngx.encode_base64("einstein:password"),
+              }
+            })
+            assert.response(res).has.status(200)
+            assert.request(res).has.no.header("x-anonymous-consumer")
+          end)
+    
+          it("fails 401, with only the first credential provided", function()
+            local res = assert(proxy_client:send {
+              method  = "GET",
+              path    = "/request",
+              headers = {
+                ["Host"]   = "logical-and.com",
+                ["apikey"] = "Mouse",
+              }
+            })
+            assert.response(res).has.status(401)
+          end)
+    
+          it("fails 401, with only the second credential provided", function()
+            local res = assert(proxy_client:send {
+              method  = "GET",
+              path    = "/request",
+              headers = {
+                ["Host"]          = "logical-and.com",
+                ["Authorization"] = "ldap " .. ngx.encode_base64("einstein:password"),
+              }
+            })
+            assert.response(res).has.status(401)
+          end)
+    
+          it("fails 401, with no credential provided", function()
+            local res = assert(proxy_client:send {
+              method  = "GET",
+              path    = "/request",
+              headers = {
+                ["Host"] = "logical-and.com",
+              }
+            })
+            assert.response(res).has.status(401)
+          end)
+    
+        end)
+    
+        describe("multiple auth with anonymous, logical OR", function()
+    
+          it("passes with all credentials provided", function()
+            local res = assert(proxy_client:send {
+              method  = "GET",
+              path    = "/request",
+              headers = {
+                ["Host"]          = "logical-or.com",
+                ["apikey"]        = "Mouse",
+                ["Authorization"] = "ldap " .. ngx.encode_base64("einstein:password"),
+              }
+            })
+            assert.response(res).has.status(200)
+            assert.request(res).has.no.header("x-anonymous-consumer")
+            local id = assert.request(res).has.header("x-consumer-id")
+            assert.not_equal(id, anonymous.id)
+            assert(id == user.id)
+          end)
+    
+          it("passes with only the first credential provided", function()
+            local res = assert(proxy_client:send {
+              method  = "GET",
+              path    = "/request",
+              headers = {
+                ["Host"]   = "logical-or.com",
+                ["apikey"] = "Mouse",
+              }
+            })
+            assert.response(res).has.status(200)
+            assert.request(res).has.no.header("x-anonymous-consumer")
+            local id = assert.request(res).has.header("x-consumer-id")
+            assert.not_equal(id, anonymous.id)
+            assert.equal(user.id, id)
+          end)
+    
+          it("passes with only the second credential provided", function()
+            local res = assert(proxy_client:send {
+              method  = "GET",
+              path    = "/request",
+              headers = {
+                ["Host"]          = "logical-or.com",
+                ["Authorization"] = "ldap " .. ngx.encode_base64("einstein:password"),
+              }
+            })
+            assert.response(res).has.status(200)
+            assert.request(res).has.no.header("x-anonymous-consumer")
+            local id = assert.request(res).has.header("x-credential-username")
+            assert.equal("einstein", id)
+          end)
+    
+          it("passes with no credential provided", function()
+            local res = assert(proxy_client:send {
+              method  = "GET",
+              path    = "/request",
+              headers = {
+                ["Host"] = "logical-or.com",
+              }
+            })
+            assert.response(res).has.status(200)
+            assert.request(res).has.header("x-anonymous-consumer")
+            local id = assert.request(res).has.header("x-consumer-id")
+            assert.equal(id, anonymous.id)
+          end)
+        end)
+      end)
+    end
   end)
 end

--- a/spec/03-plugins/20-ldap-auth/02-invalidations_spec.lua
+++ b/spec/03-plugins/20-ldap-auth/02-invalidations_spec.lua
@@ -5,142 +5,151 @@ local md5 = ngx.md5
 
 local ldap_host_aws = "ec2-54-172-82-117.compute-1.amazonaws.com"
 
-for _, strategy in helpers.each_strategy() do
-  describe("Plugin: ldap-auth (invalidation) [#" .. strategy .. "]", function()
-    local admin_client
-    local proxy_client
-    local plugin
+local ldap_strategies = {
+  non_secure = { name = "non-secure", start_tls = false },
+  start_tls = { name = "starttls", start_tls = true }
+}
 
-    lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy, {
-        "routes",
-        "services",
-        "plugins",
-      })
-
-      local route = bp.routes:insert {
-        hosts = { "ldapauth.com" },
-      }
-
-      plugin = bp.plugins:insert {
-        route = { id = route.id },
-        name     = "ldap-auth",
-        config   = {
-          ldap_host = ldap_host_aws,
-          ldap_port = 389,
-          start_tls = false,
-          base_dn   = "ou=scientists,dc=ldap,dc=mashape,dc=com",
-          attribute = "uid",
-          cache_ttl = 1,
-        }
-      }
-
-      assert(helpers.start_kong({
-        database   = strategy,
-        nginx_conf = "spec/fixtures/custom_nginx.template",
-      }))
-    end)
-
-    before_each(function()
-      admin_client = helpers.admin_client()
-      proxy_client = helpers.proxy_client()
-    end)
-
-    after_each(function()
-      if admin_client then
-        admin_client:close()
-      end
-      if proxy_client then
-        proxy_client:close()
-      end
-    end)
-
-    lazy_teardown(function()
-      helpers.stop_kong(nil, true)
-    end)
-
-    local function cache_key(conf, username, password)
-        local ldap_config_cache = md5(fmt("%s:%u:%s:%s:%u",
-          lower(conf.ldap_host),
-          conf.ldap_port,
-          conf.base_dn,
-          conf.attribute,
-          conf.cache_ttl
-        ))
-
-      return fmt("ldap_auth_cache:%s:%s:%s", ldap_config_cache,
-                 username, password)
+for _, ldap_strategy in pairs(ldap_strategies) do
+  describe("Connection strategy [" .. ldap_strategy.name .. "]", function()
+    for _, strategy in helpers.each_strategy() do
+      describe("Plugin: ldap-auth (invalidation) [#" .. strategy .. "]", function()
+        local admin_client
+        local proxy_client
+        local plugin
+    
+        lazy_setup(function()
+          local bp = helpers.get_db_utils(strategy, {
+            "routes",
+            "services",
+            "plugins",
+          })
+    
+          local route = bp.routes:insert {
+            hosts = { "ldapauth.com" },
+          }
+    
+          plugin = bp.plugins:insert {
+            route = { id = route.id },
+            name     = "ldap-auth",
+            config   = {
+              ldap_host = ldap_host_aws,
+              ldap_port = 389,
+              start_tls = ldap_strategy.start_tls,
+              base_dn   = "ou=scientists,dc=ldap,dc=mashape,dc=com",
+              attribute = "uid",
+              cache_ttl = 1,
+            }
+          }
+    
+          assert(helpers.start_kong({
+            database   = strategy,
+            nginx_conf = "spec/fixtures/custom_nginx.template",
+          }))
+        end)
+    
+        before_each(function()
+          admin_client = helpers.admin_client()
+          proxy_client = helpers.proxy_client()
+        end)
+    
+        after_each(function()
+          if admin_client then
+            admin_client:close()
+          end
+          if proxy_client then
+            proxy_client:close()
+          end
+        end)
+    
+        lazy_teardown(function()
+          helpers.stop_kong(nil, true)
+        end)
+    
+        local function cache_key(conf, username, password)
+            local ldap_config_cache = md5(fmt("%s:%u:%s:%s:%u",
+              lower(conf.ldap_host),
+              conf.ldap_port,
+              conf.base_dn,
+              conf.attribute,
+              conf.cache_ttl
+            ))
+    
+          return fmt("ldap_auth_cache:%s:%s:%s", ldap_config_cache,
+                     username, password)
+        end
+    
+        describe("authenticated LDAP user get cached", function()
+          it("should cache invalid credential", function()
+            local res = assert(proxy_client:send {
+              method = "GET",
+              path = "/requests",
+              body = {},
+              headers = {
+                ["HOST"] = "ldapauth.com",
+                authorization = "ldap " .. ngx.encode_base64("einstein:wrongpassword")
+              }
+            })
+            assert.res_status(401, res)
+    
+            local cache_key = cache_key(plugin.config, "einstein", "wrongpassword")
+            res = assert(admin_client:send {
+              method = "GET",
+              path   = "/cache/" .. cache_key,
+              body   = {},
+            })
+            assert.res_status(200, res)
+          end)
+          it("should invalidate negative cache once ttl expires", function()
+            local cache_key = cache_key(plugin.config, "einstein", "wrongpassword")
+    
+            helpers.wait_until(function()
+              local res = assert(admin_client:send {
+                method = "GET",
+                path   = "/cache/" .. cache_key,
+                body   = {},
+              })
+              res:read_body()
+              return res.status == 404
+            end)
+          end)
+          it("should cache valid credential", function()
+            -- It should work
+            local res = assert(proxy_client:send {
+              method = "GET",
+              path = "/requests",
+              body = {},
+              headers = {
+                ["HOST"] = "ldapauth.com",
+                authorization = "ldap " .. ngx.encode_base64("einstein:password")
+              }
+            })
+            assert.res_status(200, res)
+    
+            -- Check that cache is populated
+            local cache_key = cache_key(plugin.config, "einstein", "password")
+            res = assert(admin_client:send {
+              method = "GET",
+              path   = "/cache/" .. cache_key,
+              body   = {},
+            })
+            assert.res_status(200, res)
+          end)
+          it("should invalidate cache once ttl expires", function()
+            local cache_key = cache_key(plugin.config, "einstein", "password")
+    
+            helpers.wait_until(function()
+              local res = assert(admin_client:send {
+                method = "GET",
+                path   = "/cache/" .. cache_key,
+                body   = {},
+              })
+              res:read_body()
+              return res.status == 404
+            end)
+          end)
+        end)
+      end)
     end
-
-    describe("authenticated LDAP user get cached", function()
-      it("should cache invalid credential", function()
-        local res = assert(proxy_client:send {
-          method = "GET",
-          path = "/requests",
-          body = {},
-          headers = {
-            ["HOST"] = "ldapauth.com",
-            authorization = "ldap " .. ngx.encode_base64("einstein:wrongpassword")
-          }
-        })
-        assert.res_status(401, res)
-
-        local cache_key = cache_key(plugin.config, "einstein", "wrongpassword")
-        res = assert(admin_client:send {
-          method = "GET",
-          path   = "/cache/" .. cache_key,
-          body   = {},
-        })
-        assert.res_status(200, res)
-      end)
-      it("should invalidate negative cache once ttl expires", function()
-        local cache_key = cache_key(plugin.config, "einstein", "wrongpassword")
-
-        helpers.wait_until(function()
-          local res = assert(admin_client:send {
-            method = "GET",
-            path   = "/cache/" .. cache_key,
-            body   = {},
-          })
-          res:read_body()
-          return res.status == 404
-        end)
-      end)
-      it("should cache valid credential", function()
-        -- It should work
-        local res = assert(proxy_client:send {
-          method = "GET",
-          path = "/requests",
-          body = {},
-          headers = {
-            ["HOST"] = "ldapauth.com",
-            authorization = "ldap " .. ngx.encode_base64("einstein:password")
-          }
-        })
-        assert.res_status(200, res)
-
-        -- Check that cache is populated
-        local cache_key = cache_key(plugin.config, "einstein", "password")
-        res = assert(admin_client:send {
-          method = "GET",
-          path   = "/cache/" .. cache_key,
-          body   = {},
-        })
-        assert.res_status(200, res)
-      end)
-      it("should invalidate cache once ttl expires", function()
-        local cache_key = cache_key(plugin.config, "einstein", "password")
-
-        helpers.wait_until(function()
-          local res = assert(admin_client:send {
-            method = "GET",
-            path   = "/cache/" .. cache_key,
-            body   = {},
-          })
-          res:read_body()
-          return res.status == 404
-        end)
-      end)
-    end)
   end)
 end


### PR DESCRIPTION
### Summary

This patch fixes STARTTLS functionality which hasn't been working because plugin starts TLS connection even for existing connections from the pool and then fails.

This patch separates connection pool for TLS connections because STARTTLS extention works on the same port as non-secure connections and two plugins configured with different settings can end up using secure connection or worse non-secure.

This patch adds additional check if TLS connection is being reused or not, that helps to prevent getting error messages from LDAP when plugins tries to STARTTLS connection even if it is already started.

This patch supplements tests with additional configuration for multiple LDAP connection strategies (non-secure, starttls).

### Full changelog

* Add separate connection pool for secure connections
* Add additional check for TLS connections to know if connection is reused
* Add configuration for tests to run on multiple LDAP connection strategies

### Issues resolved

Fix STARTTLS connection initialization and connections re-usage from connection pool. 
