### PR TITLE
feat(log) adding more TLS information in basic serializer

### DIFF
--- a/kong/plugins/log-serializers/basic.lua
+++ b/kong/plugins/log-serializers/basic.lua
@@ -20,10 +20,14 @@ function _M.serialize(ngx)
 
   local request_tls
   local request_tls_ver = ngx_ssl.get_tls1_version_str()
-  if request_tls_ver then 
-    request_tls = { version = request_tls_ver } 
+  if request_tls_ver then
+    request_tls = {
+      version = request_tls_ver,
+      cipher = var.ssl_cipher,
+      client_verify = var.ssl_client_verify,
+    }
   end
-  
+
   local request_uri = var.request_uri or ""
 
   return {

--- a/spec/03-plugins/01-tcp-log/01-tcp-log_spec.lua
+++ b/spec/03-plugins/01-tcp-log/01-tcp-log_spec.lua
@@ -155,7 +155,7 @@ for _, strategy in helpers.each_strategy() do
       })
 
       assert.response(r).has.status(200)
-      
+
       -- Getting back the TCP server input
       local ok, res = thread:join()
       assert.True(ok)
@@ -164,6 +164,8 @@ for _, strategy in helpers.each_strategy() do
       -- Making sure it's alright
       local log_message = cjson.decode(res)
       assert.equal("TLSv1.2", log_message.request.tls.version)
+      assert.is_string(log_message.request.tls.cipher)
+      assert.equal("NONE", log_message.request.tls.client_verify)
     end)
 
   end)


### PR DESCRIPTION
Adding the following entries in the `basic` log serializer:

* `request.tls.cipher`
* `request.tls.client_verify`