### PR TITLE
feat(pdk) implemented 'kong.node.get_memory_stats()'

### DIFF
--- a/kong/api/routes/kong.lua
+++ b/kong/api/routes/kong.lua
@@ -43,6 +43,15 @@ for shm_name, shm in pairs(ngx.shared) do
 end
 
 
+local function convert_bytes(bytes, unit, scale)
+  if string.lower(unit) == "b" then
+    return bytes
+  end
+
+  return utils.bytes_to_str(bytes, unit, scale)
+end
+
+
 return {
   ["/"] = {
     GET = function(self, dao, helpers)
@@ -192,8 +201,8 @@ return {
 
         if count then
           table.insert(status_response.memory.workers_lua_vms, {
-            pid = pid,
-            allocated_gc = utils.bytes_to_str(count, unit, scale)
+            pid = tonumber(pid),
+            http_allocated_gc = convert_bytes(count, unit, scale)
           })
         end
 
@@ -212,8 +221,8 @@ return {
         local allocated = shm.capacity - shm.zone:free_space()
 
         status_response.memory.lua_shared_dicts[shm.name] = {
-          capacity = utils.bytes_to_str(shm.capacity, unit, scale),
-          allocated_slabs = utils.bytes_to_str(allocated, unit, scale),
+          capacity = convert_bytes(shm.capacity, unit, scale),
+          allocated_slabs = convert_bytes(allocated, unit, scale),
         }
       end
 

--- a/kong/globalpatches.lua
+++ b/kong/globalpatches.lua
@@ -73,6 +73,12 @@ return function(options)
       function SharedDict:new()
         return setmetatable({data = {}}, {__index = self})
       end
+      function SharedDict:capacity()
+        return 0
+      end
+      function SharedDict:free_space()
+        return 0
+      end
       function SharedDict:get(key)
         return self.data[key] and self.data[key].value, nil
       end

--- a/kong/pdk/node.lua
+++ b/kong/pdk/node.lua
@@ -5,10 +5,43 @@
 local utils = require "kong.tools.utils"
 
 
+local floor = math.floor
+local lower = string.lower
+local match = string.match
+local sort = table.sort
+local insert = table.insert
+local shared = ngx.shared
+
+
 local NODE_ID_KEY = "kong:node_id"
 
 
 local node_id
+local shms = {}
+local n_workers = ngx.worker.count()
+
+
+for shm_name, shm in pairs(shared) do
+  insert(shms, {
+    zone = shm,
+    name = shm_name,
+    capacity = shm:capacity(),
+  })
+end
+
+
+local function convert_bytes(bytes, unit, scale)
+  if not unit or lower(unit) == "b" then
+    return floor(bytes)
+  end
+
+  return utils.bytes_to_str(bytes, unit, scale)
+end
+
+
+local function sort_pid_asc(a, b)
+  return a.pid < b.pid
+end
 
 
 local function new(self)
@@ -44,6 +77,152 @@ local function new(self)
     end
 
     return node_id
+  end
+
+
+  ---
+  -- Returns memory usage statistics about this node.
+  --
+  -- @function kong.node.get_memory_stats
+  -- @tparam[opt] string unit The unit memory should be reported in. Can be
+  -- either of `b/B`, `k/K`, `m/M`, or `g/G` for bytes, kibibytes, mebibytes,
+  -- or gibibytes, respectively. Defaults to `b` (bytes).
+  -- @tparam[opt] number scale The number of digits to the right of the decimal
+  -- point. Defaults to 2.
+  -- @treturn table A table containing memory usage statistics for this node.
+  -- If `unit` is `b/B` (the default) reported values will be Lua numbers.
+  -- Otherwise, reported values will be a string with the unit as a suffix.
+  -- @usage
+  -- local res = kong.node.get_memory_stats()
+  -- -- res will have the following structure:
+  -- {
+  --   lua_shared_dicts = {
+  --     kong = {
+  --       allocated_slabs = 12288,
+  --       capacity = 24576
+  --     },
+  --     kong_db_cache = {
+  --       allocated_slabs = 12288,
+  --       capacity = 12288
+  --     }
+  --   },
+  --   workers_lua_vms = {
+  --     {
+  --       http_allocated_gc = 1102,
+  --       pid = 18004
+  --     },
+  --     {
+  --       http_allocated_gc = 1102,
+  --       pid = 18005
+  --     }
+  --   }
+  -- }
+  --
+  -- local res = kong.node.get_memory_stats("k", 1)
+  -- -- res will have the following structure:
+  -- {
+  --   lua_shared_dicts = {
+  --     kong = {
+  --       allocated_slabs = "12.0 KiB",
+  --       capacity = "24.0 KiB",
+  --     },
+  --     kong_db_cache = {
+  --       allocated_slabs = "12.0 KiB",
+  --       capacity = "12.0 KiB",
+  --     }
+  --   },
+  --   workers_lua_vms = {
+  --     {
+  --       http_allocated_gc = "1.1 KiB",
+  --       pid = 18004
+  --     },
+  --     {
+  --       http_allocated_gc = "1.1 KiB",
+  --       pid = 18005
+  --     }
+  --   }
+  -- }
+  function _NODE.get_memory_stats(unit, scale)
+    -- validate arguments
+
+    do
+      unit = unit or "b"
+      scale = scale or 2
+
+      local pok, perr = pcall(utils.bytes_to_str, 0, unit, scale)
+      if not pok then
+        error(perr, 2)
+      end
+    end
+
+    local res = {
+      workers_lua_vms = self.table.new(n_workers, 0),
+      lua_shared_dicts = self.table.new(0, #shms),
+    }
+
+    -- get workers Lua VM allocated memory
+
+    do
+      if not shared.kong then
+        goto lua_shared_dicts
+      end
+
+      local keys, err = shared.kong:get_keys()
+      if not keys then
+        res.workers_lua_vms.err = "could not get kong shm keys: " .. err
+        goto lua_shared_dicts
+      end
+
+      if #keys == 1024 then
+        -- Preventive warning log for future Kong developers, in case 'kong'
+        -- shm becomes mis-used or over-used.
+        ngx.log(ngx.WARN, "ngx.shared.kong:get_keys() returned 1024 keys, ",
+                          "but it may have more")
+      end
+
+      for i = 1, #keys do
+        local pid = match(keys[i], "kong:mem:(%d+)")
+        if not pid then
+          goto continue
+        end
+
+        local w = self.table.new(0, 2)
+        w.pid = tonumber(pid)
+
+        local count, err = shared.kong:get("kong:mem:" .. pid)
+        if err then
+          w.err = "could not get worker's HTTP Lua VM memory (pid: " ..
+                  pid .. "): " .. err
+
+        elseif type(count) ~= "number" then
+          w.err = "could not get worker's HTTP Lua VM memory (pid: " ..
+                  pid .. "): reported value is corrupted"
+
+        else
+          w.http_allocated_gc = convert_bytes(count, unit, scale)
+        end
+
+        insert(res.workers_lua_vms, w)
+
+        ::continue::
+      end
+
+      sort(res.workers_lua_vms, sort_pid_asc)
+    end
+
+    -- get lua_shared_dicts allocated slabs
+    ::lua_shared_dicts::
+
+    for _, shm in ipairs(shms) do
+      local allocated = shm.capacity - shm.zone:free_space()
+
+      res.lua_shared_dicts[shm.name] = {
+        capacity = convert_bytes(shm.capacity, unit, scale),
+        allocated_slabs = convert_bytes(allocated, unit, scale),
+      }
+    end
+
+    return res
   end
 
 

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -800,6 +800,7 @@ return {
   _set_router_version = _set_router_version,
   _set_update_plugins_iterator = _set_update_plugins_iterator,
   _get_updated_router = get_updated_router,
+  _update_lua_mem = update_lua_mem,
 
   init_worker = {
     before = function()

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -930,8 +930,8 @@ end
 -- of `b/B`, `k/K`, `m/M`, or `g/G` for bytes (unchanged), kibibytes,
 -- mebibytes, or gibibytes, respectively. Defaults to `b` (bytes).
 -- @tparam[opt] number scale The number of digits to the right of the decimal
--- point.
--- @return string A human-readable string.
+-- point. Defaults to 2.
+-- @treturn string A human-readable string.
 -- @usage
 --
 -- bytes_to_str(5497558) -- "5497558"
@@ -944,7 +944,12 @@ function _M.bytes_to_str(bytes, unit, scale)
   end
 
   scale = scale or 2
-  local fspec = "%." .. scale .. "f"
+
+  if type(scale) ~= "number" or scale < 0 then
+    error("scale must be equal or greater than 0", 2)
+  end
+
+  local fspec = fmt("%%.%df", scale)
 
   if lower(unit) == "k" then
     return fmt(fspec .. " KiB", bytes / 2^10)

--- a/spec/01-unit/05-utils_spec.lua
+++ b/spec/01-unit/05-utils_spec.lua
@@ -592,17 +592,34 @@ describe("Utils", function()
     end)
 
     it("scale arg", function()
+      -- 3
       assert.equal("5497558", utils.bytes_to_str(5497558, "b", 3))
       assert.equal("5368.709 KiB", utils.bytes_to_str(5497558, "k", 3))
       assert.equal("5.243 MiB", utils.bytes_to_str(5497558, "m", 3))
       assert.equal("0.005 GiB", utils.bytes_to_str(5497558, "g", 3))
       assert.equal("5.120 GiB", utils.bytes_to_str(5497558998, "g", 3))
+
+      -- 0
+      assert.equal("5 GiB", utils.bytes_to_str(5497558998, "g", 0))
+
+      -- decimals
+      assert.equal("5.12 GiB", utils.bytes_to_str(5497558998, "g", 2.2))
     end)
 
     it("errors on invalid unit arg", function()
       assert.has_error(function()
         utils.bytes_to_str(1234, "V")
       end, "invalid unit 'V' (expected 'k/K', 'm/M', or 'g/G')")
+    end)
+
+    it("errors on invalid scale arg", function()
+      assert.has_error(function()
+        utils.bytes_to_str(1234, "k", -1)
+      end, "scale must be equal or greater than 0")
+
+      assert.has_error(function()
+        utils.bytes_to_str(1234, "k", "")
+      end, "scale must be equal or greater than 0")
     end)
   end)
 end)

--- a/spec/02-integration/04-admin_api/02-kong_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/02-kong_routes_spec.lua
@@ -221,7 +221,7 @@ describe("Admin API - Kong routes with strategy #" .. strategy, function()
         if #workers_lua_vms > 1 then
           for i = 1, #workers_lua_vms do
             if workers_lua_vms[i + 1] then
-              assert.gt(workers_lua_vms[i + 1].pid, workers_lua_vms[i].pid)
+              assert.gt(workers_lua_vms[i].pid, workers_lua_vms[i + 1].pid)
             end
           end
         end

--- a/t/01-pdk/12-node/00-phase_checks.t
+++ b/t/01-pdk/12-node/00-phase_checks.t
@@ -43,6 +43,18 @@ qq{
                 log           = true,
                 admin_api     = true,
             },
+            {
+                method        = "get_memory_stats",
+                args          = {},
+                init_worker   = true,
+                certificate   = "pending",
+                rewrite       = true,
+                access        = true,
+                header_filter = true,
+                body_filter   = true,
+                log           = true,
+                admin_api     = true,
+            },
         }
 
         phase_check_functions(phases.init_worker)

--- a/t/01-pdk/12-node/02-get_memory_stats.t
+++ b/t/01-pdk/12-node/02-get_memory_stats.t
@@ -1,0 +1,438 @@
+use strict;
+use warnings FATAL => 'all';
+use Test::Nginx::Socket::Lua;
+use t::Util;
+
+master_on();
+workers(2);
+
+plan tests => repeat_each() * (blocks() * 3);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: node.get_memory_stats() returns Lua VM and lua_shared_dict stats
+--- http_config eval
+qq{
+    $t::Util::HttpConfig
+
+    lua_shared_dict kong 24k;
+    lua_shared_dict kong_db_cache 32k;
+
+    init_worker_by_lua_block {
+        local runloop_handler = require "kong.runloop.handler"
+
+        runloop_handler._update_lua_mem(true)
+
+        -- NOTE: insert garbage
+        ngx.shared.kong:set("kong:mem:foo", "garbage")
+    }
+}
+--- config
+    location = /t {
+        content_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            local res = pdk.node.get_memory_stats()
+
+            ngx.say("lua_shared_dicts")
+            for dict_name, dict_info in pairs(res.lua_shared_dicts) do
+                ngx.say("  ", dict_name, ": ",
+                        dict_info.allocated_slabs, "/", dict_info.capacity)
+            end
+
+            ngx.say("workers_lua_vms")
+            for _, worker_info in ipairs(res.workers_lua_vms) do
+                ngx.say("  ", worker_info.pid, ": ",
+                        worker_info.http_allocated_gc or worker_info.err)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body_like chomp
+\Alua_shared_dicts
+  \S+: \d+\/2[45]\d{3}
+  \S+: \d+\/3[23]\d{3}
+workers_lua_vms
+  (?:\d+: \d+\s*){1,2}\Z
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: node.get_memory_stats() returns workers Lua VM reports in PID ascending order
+--- http_config eval
+qq{
+    $t::Util::HttpConfig
+
+    lua_shared_dict kong 24k;
+    lua_shared_dict kong_db_cache 32k;
+
+    init_worker_by_lua_block {
+        local runloop_handler = require "kong.runloop.handler"
+
+        runloop_handler._update_lua_mem(true)
+
+        -- NOTE: insert mock workers
+        ngx.shared.kong:set("kong:mem:1", 1234)
+        ngx.shared.kong:set("kong:mem:2", 1234)
+    }
+}
+--- config
+    location = /t {
+        content_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            local res = pdk.node.get_memory_stats()
+
+            ngx.say("lua_shared_dicts")
+            for dict_name, dict_info in pairs(res.lua_shared_dicts) do
+                ngx.say("  ", dict_name, ": ",
+                        dict_info.allocated_slabs, "/", dict_info.capacity)
+            end
+
+            ngx.say("workers_lua_vms")
+            for _, worker_info in ipairs(res.workers_lua_vms) do
+                ngx.say("  ", worker_info.pid, ": ",
+                        worker_info.http_allocated_gc or worker_info.err)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body_like
+lua_shared_dicts
+  \S+: \d+\/2[45]\d{3}
+  \S+: \d+\/3[23]\d{3}
+workers_lua_vms
+  1: 1234
+  2: 1234
+  (?:\d+: \d+\s*){1,2}
+--- no_error_log
+[error]
+
+
+
+=== TEST 3: node.get_memory_stats() accepts 'unit' argument
+--- http_config eval
+qq{
+    $t::Util::HttpConfig
+
+    lua_shared_dict kong 32k;
+    lua_shared_dict kong_db_cache 64k;
+
+    init_worker_by_lua_block {
+        local runloop_handler = require "kong.runloop.handler"
+
+        runloop_handler._update_lua_mem(true)
+    }
+}
+--- config
+    location = /t {
+        content_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            local res = pdk.node.get_memory_stats("k")
+
+            ngx.say("lua_shared_dicts")
+            for dict_name, dict_info in pairs(res.lua_shared_dicts) do
+                ngx.say("  ", dict_name, ": ",
+                        dict_info.allocated_slabs, "/", dict_info.capacity)
+            end
+
+            ngx.say("workers_lua_vms")
+            for _, worker_info in ipairs(res.workers_lua_vms) do
+                ngx.say("  ", worker_info.pid, ": ",
+                        worker_info.http_allocated_gc or worker_info.err)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body_like
+lua_shared_dicts
+  \S+: 12\.\d+ KiB\/3[23]\.\d+ KiB
+  \S+: 12\.\d+ KiB\/6[45]\.\d+ KiB
+workers_lua_vms
+  (?:\d+: \d+\.\d+ KiB\s*){1,2}
+--- no_error_log
+[error]
+
+
+
+=== TEST 4: node.get_memory_stats() 'unit = b' returns Lua numbers
+--- http_config eval
+qq{
+    $t::Util::HttpConfig
+
+    lua_shared_dict kong 32k;
+    lua_shared_dict kong_db_cache 64k;
+
+    init_worker_by_lua_block {
+        local runloop_handler = require "kong.runloop.handler"
+
+        runloop_handler._update_lua_mem(true)
+    }
+}
+--- config
+    location = /t {
+        content_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            local res = pdk.node.get_memory_stats("b")
+
+            ngx.say("lua_shared_dicts")
+            for dict_name, dict_info in pairs(res.lua_shared_dicts) do
+                ngx.say("  ", dict_name, ": ",
+                        dict_info.allocated_slabs, "/", dict_info.capacity)
+
+                assert(type(dict_info.allocated_slabs) == "number")
+                assert(type(dict_info.capacity) == "number")
+            end
+
+            ngx.say("workers_lua_vms")
+            for _, worker_info in ipairs(res.workers_lua_vms) do
+                ngx.say("  ", worker_info.pid, ": ",
+                        worker_info.http_allocated_gc or worker_info.err)
+
+                assert(type(worker_info.http_allocated_gc) == "number")
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body_like
+lua_shared_dicts
+  \S+: \d+\/3[23]\d{3}
+  \S+: \d+\/6[45]\d{3}
+workers_lua_vms
+  (?:\d+: \d+\s*){1,2}
+--- no_error_log
+[error]
+
+
+
+=== TEST 5: node.get_memory_stats() accepts 'scale' argument
+--- http_config eval
+qq{
+    $t::Util::HttpConfig
+
+    lua_shared_dict kong 32k;
+    lua_shared_dict kong_db_cache 64k;
+
+    init_worker_by_lua_block {
+        local runloop_handler = require "kong.runloop.handler"
+
+        runloop_handler._update_lua_mem(true)
+    }
+}
+--- config
+    location = /t {
+        content_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            local res = pdk.node.get_memory_stats("k", 4)
+
+            ngx.say("lua_shared_dicts")
+            for dict_name, dict_info in pairs(res.lua_shared_dicts) do
+                ngx.say("  ", dict_name, ": ",
+                        dict_info.allocated_slabs, "/", dict_info.capacity)
+            end
+
+            ngx.say("workers_lua_vms")
+            for _, worker_info in ipairs(res.workers_lua_vms) do
+                ngx.say("  ", worker_info.pid, ": ",
+                        worker_info.http_allocated_gc or worker_info.err)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body_like
+lua_shared_dicts
+  \S+: 12\.\d{4} KiB\/3[23]\.\d{4} KiB
+  \S+: 12\.\d{4} KiB\/6[45]\.\d{4} KiB
+workers_lua_vms
+  (?:\d+: \d+\.\d{4} KiB\s*){1,2}
+--- no_error_log
+[error]
+
+
+
+=== TEST 6: node.get_memory_stats() validates arguments
+--- http_config eval
+qq{
+    $t::Util::HttpConfig
+}
+--- config
+    location = /t {
+        content_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            local pok, perr = pcall(pdk.node.get_memory_stats, "V")
+            if not pok then
+                ngx.say(perr)
+            end
+
+            local pok, perr = pcall(pdk.node.get_memory_stats, "k", -1)
+            if not pok then
+                ngx.say(perr)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+invalid unit 'V' (expected 'k/K', 'm/M', or 'g/G')
+scale must be equal or greater than 0
+--- no_error_log
+[error]
+
+
+
+=== TEST 7: node.get_memory_stats() handles bad workers Lua VM reports (no reports)
+--- http_config eval
+qq{
+    $t::Util::HttpConfig
+
+    lua_shared_dict kong 24k;
+    lua_shared_dict kong_db_cache 32k;
+
+    init_worker_by_lua_block {
+        -- NOTE: workers are not reporting Lua VM GC
+    }
+}
+--- config
+    location = /t {
+        content_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            local res = pdk.node.get_memory_stats()
+
+            ngx.say("lua_shared_dicts")
+            for dict_name, dict_info in pairs(res.lua_shared_dicts) do
+                ngx.say("  ", dict_name, ": ",
+                        dict_info.allocated_slabs, "/", dict_info.capacity)
+            end
+
+            ngx.say("workers_lua_vms")
+            for _, worker_info in ipairs(res.workers_lua_vms) do
+                ngx.say("  ", worker_info.pid, ": ",
+                        worker_info.http_allocated_gc or worker_info.err)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body_like chomp
+\Alua_shared_dicts
+  \S+: \d+\/2[45]\d{3}
+  \S+: \d+\/3[23]\d{3}
+workers_lua_vms\Z
+--- no_error_log
+[error]
+
+
+
+=== TEST 8: node.get_memory_stats() handles bad workers Lua VM reports (corrupted report)
+--- http_config eval
+qq{
+    $t::Util::HttpConfig
+
+    lua_shared_dict kong 24k;
+    lua_shared_dict kong_db_cache 32k;
+
+    init_worker_by_lua_block {
+        local runloop_handler = require "kong.runloop.handler"
+
+        runloop_handler._update_lua_mem(true)
+
+        -- NOTE: insert corrupted data
+        ngx.shared.kong:set("kong:mem:1", "garbage")
+    }
+}
+--- config
+    location = /t {
+        content_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            -- NOTE: delete memory report for this worker
+            ngx.shared.kong:delete("kong:mem:" .. ngx.worker.pid())
+
+            local res = pdk.node.get_memory_stats()
+
+            ngx.say("lua_shared_dicts")
+            for dict_name, dict_info in pairs(res.lua_shared_dicts) do
+                ngx.say("  ", dict_name, ": ",
+                        dict_info.allocated_slabs, "/", dict_info.capacity)
+            end
+
+            ngx.say("workers_lua_vms")
+            for _, worker_info in ipairs(res.workers_lua_vms) do
+                ngx.say("  ", worker_info.pid, ": ",
+                        worker_info.http_allocated_gc or worker_info.err)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body_like
+lua_shared_dicts
+  \S+: \d+\/2[45]\d{3}
+  \S+: \d+\/3[25]\d{3}
+workers_lua_vms
+  1: could not get worker's HTTP Lua VM memory \(pid: 1\): reported value is corrupted(?:\s*\d+: \d+\s*){0,2}
+--- no_error_log
+[error]
+
+
+
+=== TEST 9: node.get_memory_stats() handles no lua_shared_dict and no Lua VM reports
+--- http_config eval
+qq{
+    $t::Util::HttpConfig
+
+    # NOTE: no lua_shared_dict
+
+    init_worker_by_lua_block {
+        -- NOTE: workers are not reporting Lua VM GC
+    }
+}
+--- config
+    location = /t {
+        content_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            local res = pdk.node.get_memory_stats()
+
+            ngx.say("lua_shared_dicts")
+            for dict_name, dict_info in pairs(res.lua_shared_dicts) do
+                ngx.say("  ", dict_name, ": ",
+                        dict_info.allocated_slabs, "/", dict_info.capacity)
+            end
+
+            ngx.say("workers_lua_vms")
+            for _, worker_info in ipairs(res.workers_lua_vms) do
+                ngx.say("  ", worker_info.pid, ": ",
+                        worker_info.http_allocated_gc or worker_info.err)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body_like chomp
+\Alua_shared_dicts
+workers_lua_vms\Z
+--- no_error_log
+[error]

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -7,7 +7,7 @@ use Cwd qw(cwd);
 our $cwd = cwd();
 
 our $HttpConfig = <<_EOC_;
-    lua_package_path \'$cwd/?/init.lua;;\';
+    lua_package_path \'$cwd/?.lua;$cwd/?/init.lua;;\';
 
     init_by_lua_block {
         local log = ngx.log


### PR DESCRIPTION
- Move memory reporting into a standardized PDK function
- Some updates to the memory reporting result including better semantics for clients (Lua numbers instead of strings)
- Update Admin API `/status` endpoint to use aforementioned PDK function