### PR TITLE
fix(dao) make read-before-write updates to handle default values correctly

### DIFF
--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -293,9 +293,9 @@ local function check_update(self, key, entity, options, name)
   if read_before_write then
     local err, err_t
     if name then
-       rbw_entity, err, err_t = self.strategy:select_by_field(name, key, options)
+       rbw_entity, err, err_t = self["select_by_" .. name](self, key, options)
     else
-       rbw_entity, err, err_t = self.strategy:select(key, options)
+       rbw_entity, err, err_t = self:select(key, options)
     end
     if err then
       return nil, nil, err, err_t


### PR DESCRIPTION
### Summary

The `check_update` function used strategy function directly, that does not handle the default values correctly. This is usually not a problem but it becomes a problem when we add new columns to database, and then want to rely on `schema` defaults (the database could have a `null` as a value when migrated).

### Issues resolved

Solves one part of the issue reported here #4631
