### PR TITLE
perf(runloop) pure async rebuilds with config option

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -721,6 +721,23 @@
                                  # single query.
 
 #------------------------------------------------------------------------------
+# TUNING & BEHAVIOR
+#------------------------------------------------------------------------------
+
+#router_consistency = strict     # Defines whether or not updates of internal
+                                 # data structures used in routing are
+                                 # done asynchronously. Accepted values are:
+                                 #
+                                 # - `strict` - the state of memory is
+                                 #   checked against the latest datastore
+                                 #   state on each request: if memory is
+                                 #   outdated, it is updated before handling
+                                 #   the request.
+                                 # - `eventual` - the state of memory is
+                                 #   updated asynchronously via an internal
+                                 #   periodic timer.
+
+#------------------------------------------------------------------------------
 # DEVELOPMENT & MISCELLANEOUS
 #------------------------------------------------------------------------------
 

--- a/kong/concurrency.lua
+++ b/kong/concurrency.lua
@@ -64,7 +64,9 @@ function concurrency.with_coroutine_mutex(opts, fn)
   if opts.timeout and type(opts.timeout) ~= "number" then
     error("opts.timeout must be a number", 2)
   end
-  if opts.on_timeout and opts.on_timeout ~= "run_unlocked" then
+  if opts.on_timeout and
+     opts.on_timeout ~= "run_unlocked" and
+     opts.on_timeout ~= "return_true" then
     error("invalid value for opts.on_timeout", 2)
   end
 
@@ -98,6 +100,8 @@ function concurrency.with_coroutine_mutex(opts, fn)
 
     if opts.on_timeout == "run_unlocked" then
       kong.log.warn("bypassing ", opts.name, " lock: timeout")
+    elseif opts.on_timeout == "return_true" then
+      return true
     else
       return nil, "timeout acquiring " .. opts.name .. " lock"
     end

--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -165,6 +165,7 @@ local CONF_INFERENCES = {
   dns_not_found_ttl = { typ = "number" },
   dns_error_ttl = { typ = "number" },
   dns_no_sync = { typ = "boolean" },
+  router_consistency = { enum = { "strict", "eventual" } },
 
   client_ssl = { typ = "boolean" },
 

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -246,7 +246,7 @@ local function load_declarative_config(kong_config, entities)
       error("error building initial plugins iterator: " .. err)
     end
 
-    assert(runloop.build_router(kong.db, "init"))
+    assert(runloop.build_router("init"))
 
     mesh.init()
 
@@ -389,7 +389,7 @@ function Kong.init()
       error("error building initial plugins: " .. tostring(err))
     end
 
-    assert(runloop.build_router(db, "init"))
+    assert(runloop.build_router("init"))
   end
 
   db:close()

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -66,9 +66,9 @@ local TTL_ZERO = { ttl = 0 }
 
 local get_plugins_iterator, build_plugins_iterator, update_plugins_iterator
 
-local get_router, build_router
+local get_router, build_router, update_router
 local server_header = meta._SERVER_TOKENS
-local _set_check_router_rebuild
+local _set_build_router
 
 local build_router_timeout
 
@@ -522,7 +522,8 @@ do
     return service
   end
 
-  build_router = function(db, version)
+  build_router = function(version)
+    local db = kong.db
     local routes, i = {}, 0
 
     local err
@@ -585,11 +586,12 @@ do
       return rp1 > rp2
     end)
 
-    local err
-    router, err = Router.new(routes)
-    if not router then
+    local new_router, err = Router.new(routes)
+    if not new_router then
       return nil, "could not create router: " .. err
     end
+
+    router = new_router
 
     if version then
       router_version = version
@@ -601,13 +603,13 @@ do
   end
 
 
-  local function check_router_rebuild()
+  update_router = function()
     -- we might not need to rebuild the router (if we were not
     -- the first request in this process to enter this code path)
     -- check again and rebuild only if necessary
-    local version, err = singletons.cache:get("router:version",
-                                              CACHE_ROUTER_OPTS,
-                                              utils.uuid)
+    local version, err = kong.cache:get("router:version",
+                                        CACHE_ROUTER_OPTS,
+                                        utils.uuid)
     if err then
       log(CRIT, "could not ensure router is up to date: ", err)
       return nil, err
@@ -615,38 +617,6 @@ do
 
     if version == router_version then
       return true
-    end
-
-    -- router needs to be rebuilt in this worker
-    log(DEBUG, "rebuilding router")
-
-    local ok, err = build_router(singletons.db, version)
-    if not ok then
-      log(CRIT, "could not rebuild router: ", err)
-      return nil, err
-    end
-
-    return true
-  end
-
-
-  -- for unit-testing purposes only
-  _set_check_router_rebuild = function(f)
-    check_router_rebuild = f
-  end
-
-
-  get_router = function()
-    local version, err = singletons.cache:get("router:version",
-                                              CACHE_ROUTER_OPTS,
-                                              utils.uuid)
-    if err then
-      log(CRIT, "could not ensure router is up to date: ", err)
-      return nil, err
-    end
-
-    if version == router_version then
-      return router
     end
 
     -- wrap router rebuilds in a per-worker mutex:
@@ -661,12 +631,39 @@ do
       timeout = build_router_timeout,
       on_timeout = "run_unlocked",
     }
-    local ok, err = concurrency.with_coroutine_mutex(opts, check_router_rebuild)
+    local ok, err = concurrency.with_coroutine_mutex(opts, function()
+      -- we have the lock but we might not have needed it. check the
+      -- version again and rebuild if necessary
+      version, err = kong.cache:get("router:version", CACHE_ROUTER_OPTS, utils.uuid)
+      if err then
+        return nil, "failed to re-retrieve router version: " .. err
+      end
+
+      if version ~= router_version then
+        local ok, err = build_router(version)
+        if not ok then
+          return nil, "error found when building router: " .. err
+        end
+      end
+
+      return true
+    end)
 
     if not ok then
       return nil, err
     end
 
+    return true
+  end
+
+
+  -- for unit-testing purposes only
+  _set_build_router = function(f)
+    build_router = f
+  end
+
+
+  get_router = function()
     return router
   end
 end
@@ -759,7 +756,7 @@ return {
   get_plugins_iterator = get_plugins_iterator,
   set_init_versions_in_cache = set_init_versions_in_cache,
   -- exported for unit-testing purposes only
-  _set_check_router_rebuild = _set_check_router_rebuild,
+  _set_build_router = _set_build_router,
 
   init_worker = {
     before = function()
@@ -809,8 +806,12 @@ return {
   },
   preread = {
     before = function(ctx)
-      local router, err = get_router()
-      if not router then
+      local router
+      local ok, err = update_router()
+      if ok then
+        router = get_router()
+      end
+      if not ok or not router then
         log(ERR, "no router to route connection (reason: " .. err .. ")")
         return exit(500)
       end
@@ -906,8 +907,13 @@ return {
     before = function(ctx)
       -- router for Routes/Services
 
-      local router, err = get_router()
-      if not router then
+      local router
+      local ok, err = update_router()
+      if ok then
+        router = get_router()
+      end
+
+      if not ok or not router then
         kong.log.err("no router to route request (reason: " .. tostring(err) ..  ")")
         return kong.response.exit(500, { message  = "An unexpected error occurred" })
       end

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -444,10 +444,12 @@ do
 
 
   get_updated_plugins_iterator = function()
-    local ok, err = rebuild_plugins_iterator(PLUGINS_ITERATOR_SYNC_OPTS)
-    if not ok then
-      -- If an error happens while updating, log it and return non-updated version
-      log(CRIT, "error while updating plugins iterator: ", err)
+    if kong.configuration.router_consistency == "strict" then
+      local ok, err = rebuild_plugins_iterator(PLUGINS_ITERATOR_SYNC_OPTS)
+      if not ok then
+        -- If an error happens while updating, log it and return non-updated version
+        log(CRIT, "error while updating plugins iterator: ", err)
+      end
     end
     return plugins_iterator
   end
@@ -667,10 +669,12 @@ do
 
 
   get_updated_router = function()
-    local ok, err = rebuild_router(ROUTER_SYNC_OPTS)
-    if not ok then
-      -- If an error happens while updating, log it and return non-updated version
-      log(CRIT, "error while updating router(reason: ", err, ")")
+    if kong.configuration.router_consistency == "strict" then
+      local ok, err = rebuild_router(ROUTER_SYNC_OPTS)
+      if not ok then
+        -- If an error happens while updating, log it and return non-updated version
+        log(CRIT, "error while updating router(reason: ", err, ")")
+      end
     end
     return router
   end

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -79,6 +79,8 @@ dns_not_found_ttl = 30
 dns_error_ttl = 1
 dns_no_sync = off
 
+router_consistency = strict
+
 lua_socket_pool_size = 30
 lua_ssl_trusted_certificate = NONE
 lua_ssl_verify_depth = 1

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -454,6 +454,12 @@ describe("Configuration loader", function()
       assert.equal("database has an invalid value: 'mysql' (postgres, cassandra, off)", err)
       assert.is_nil(conf)
 
+      local conf, err = conf_loader(nil, {
+        router_consistency = "magical"
+      })
+      assert.equal("router_consistency has an invalid value: 'magical' (strict, eventual)", err)
+      assert.is_nil(conf)
+
       conf, err = conf_loader(nil, {
         cassandra_consistency = "FOUR"
       })
@@ -461,6 +467,7 @@ describe("Configuration loader", function()
                  .. " (ALL, EACH_QUORUM, QUORUM, LOCAL_QUORUM, ONE, TWO,"
                  .. " THREE, LOCAL_ONE)", err)
       assert.is_nil(conf)
+
     end)
     it("enforces listen addresses format", function()
       local conf, err = conf_loader(nil, {


### PR DESCRIPTION
This is a continuation of #4627, but has been kept separate in order to make merging them separately easier.

This PR introduces the `router_consistency` config option which, if set to `eventual` completely decouples the building of the router and plugins iterator from the treatment of each request - Kong instead relies on the fact that rebuilds are triggered every second via a timer. The default remains `strict`, which matches the same level of router consistency of as that of past Kong releases.

This was extracted from #4488 

