### PR TITLE
refactor(router) move path construction to after_access

### DIFF
--- a/kong/router.lua
+++ b/kong/router.lua
@@ -1185,35 +1185,15 @@ function _M.new(routes)
           end
 
           if matched_route then
+            local request_postfix
             local upstream_host
-            local upstream_uri
             local upstream_url_t = matched_route.upstream_url_t
             local matches        = ctx.matches
-
-            -- Path construction
 
             if matched_route.type == "http" then
               -- if we do not have a path-match, then the postfix is simply the
               -- incoming path, without the initial slash
-              local request_postfix = matches.uri_postfix or sub(req_uri, 2, -1)
-              local upstream_base = upstream_url_t.path or "/"
-
-              if matched_route.strip_uri then
-                -- we drop the matched part, replacing it with the upstream path
-                if sub(upstream_base, -1, -1) == "/" and
-                   sub(request_postfix, 1, 1) == "/" then
-                  -- double "/", so drop the first
-                  upstream_uri = sub(upstream_base, 1, -2) .. request_postfix
-
-                else
-                  upstream_uri = upstream_base .. request_postfix
-                end
-
-              else
-                -- we retain the incoming path, just prefix it with the upstream
-                -- path, but skip the initial slash
-                upstream_uri = upstream_base .. sub(req_uri, 2, -1)
-              end
+              request_postfix = matches.uri_postfix or sub(req_uri, 2, -1)
 
               -- preserve_host header logic
 
@@ -1222,24 +1202,24 @@ function _M.new(routes)
               end
             end
 
-            local match_t     = {
-              route           = matched_route.route,
-              service         = matched_route.service,
-              headers         = matched_route.headers,
-              upstream_url_t  = upstream_url_t,
-              upstream_scheme = upstream_url_t.scheme,
-              upstream_uri    = upstream_uri,
-              upstream_host   = upstream_host,
-              matches         = {
-                uri_captures  = matches.uri_captures,
-                uri           = matches.uri,
-                host          = matches.host,
-                method        = matches.method,
-                src_ip        = matches.src_ip,
-                src_port      = matches.src_port,
-                dst_ip        = matches.dst_ip,
-                dst_port      = matches.dst_port,
-                sni           = matches.sni,
+            local match_t = {
+              route                = matched_route.route,
+              service              = matched_route.service,
+              headers              = matched_route.headers,
+              upstream_url_t       = upstream_url_t,
+              upstream_scheme      = upstream_url_t.scheme,
+              upstream_host        = upstream_host,
+              upstream_uri_postfix = request_postfix,
+              matches = {
+                uri_captures       = matches.uri_captures,
+                uri                = matches.uri,
+                host               = matches.host,
+                method             = matches.method,
+                src_ip             = matches.src_ip,
+                src_port           = matches.src_port,
+                dst_ip             = matches.dst_ip,
+                dst_port           = matches.dst_port,
+                sni                = matches.sni,
               }
             }
 

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -705,10 +705,12 @@ do
 end
 
 
-local function balancer_prepare(ctx, scheme, host_type, host, port,
+local function balancer_prepare(ctx, match_t, host_type, host, port,
                                 service, route)
+  local request_uri = var.request_uri
+
   local balancer_data = {
-    scheme         = scheme,    -- scheme for balancer: http, https
+    scheme         = match_t.upstream_scheme, -- scheme for balancer: http, https
     type           = host_type, -- type of 'host': ipv4, ipv6, name
     host           = host,      -- target host per `upstream_url`
     port           = port,      -- final target port
@@ -720,7 +722,33 @@ local function balancer_prepare(ctx, scheme, host_type, host, port,
     -- hostname    = nil,       -- hostname of the final target IP
     -- hash_cookie = nil,       -- if Upstream sets hash_on_cookie
     -- balancer_handle = nil,   -- balancer handle for the current connection
+    uri = {                     -- components for upstream uri construction
+      strip_path          = route.strip_path,
+      request_uri         = request_uri,
+      upstream_postfix    = match_t.upstream_uri_postfix or "",
+      upstream_prefix     = (service or EMPTY_T).path or "/",
+      -- downstream_match = nil,
+      -- has_args         = nil,
+    }
   }
+
+  do
+    if request_uri then
+      local idx = request_uri:find("?", 2, true)
+
+      if idx then
+        idx = idx - 1
+        balancer_data.uri.has_args = true
+      else
+        idx = #request_uri
+        balancer_data.uri.has_args = false
+      end
+
+      idx = idx - #(match_t.upstream_uri_postfix or "")
+
+      balancer_data.uri.downstream_match = request_uri:sub(1, idx)
+    end
+  end
 
   do
     local s = service or EMPTY_T
@@ -763,6 +791,37 @@ local function balancer_execute(ctx)
 end
 
 
+local function build_upstream_uri(components, request_args)
+  local upstream_uri
+  local postfix = components.upstream_postfix
+  local prefix = components.upstream_prefix or "/"
+
+  if components.strip_path then
+    -- we drop the matched part, replacing it with the upstream path
+    if sub(prefix, -1, -1) == "/" and
+       sub(postfix, 1, 1) == "/" then
+      -- double "/", so drop the first
+      upstream_uri = sub(prefix, 1, -2) .. postfix
+
+    else
+      upstream_uri = prefix .. postfix
+    end
+
+  else
+    -- we retain the incoming path, just prefix it with the upstream
+    -- path, but skip the initial slash
+    upstream_uri = prefix .. sub(components.request_uri, 2, -1)
+  end
+
+
+  if components.has_args then
+    return upstream_uri .. "?" .. (request_args or "")
+  end
+
+  return upstream_uri
+end
+
+
 local function set_init_versions_in_cache()
   local ok, err = kong.cache:get("router:version", TTL_ZERO, function()
     return "init"
@@ -801,6 +860,7 @@ return {
   _set_update_plugins_iterator = _set_update_plugins_iterator,
   _get_updated_router = get_updated_router,
   _update_lua_mem = update_lua_mem,
+  _build_upstream_uri = build_upstream_uri,
 
   init_worker = {
     before = function()
@@ -961,7 +1021,7 @@ return {
         upstream_url_t.port = tonumber(var.server_port, 10)
       end
 
-      balancer_prepare(ctx, match_t.upstream_scheme,
+      balancer_prepare(ctx, match_t,
                        upstream_url_t.type,
                        upstream_url_t.host,
                        upstream_url_t.port,
@@ -1154,7 +1214,7 @@ return {
         upstream_url_t.port = service_port
       end
 
-      balancer_prepare(ctx, match_t.upstream_scheme,
+      balancer_prepare(ctx, match_t,
                        upstream_url_t.type,
                        upstream_url_t.host,
                        upstream_url_t.port,
@@ -1166,7 +1226,6 @@ return {
       --       router, which might have truncated it (`strip_uri`).
       -- `host` is the original header to be preserved if set.
       var.upstream_scheme = match_t.upstream_scheme -- COMPAT: pdk
-      var.upstream_uri    = match_t.upstream_uri
       var.upstream_host   = match_t.upstream_host
 
       -- Keep-Alive and WebSocket Protocol Upgrade Headers
@@ -1194,20 +1253,12 @@ return {
     end,
     -- Only executed if the `router` module found a route and allows nginx to proxy it.
     after = function(ctx)
-      do
-        -- Nginx's behavior when proxying a request with an empty querystring
-        -- `/foo?` is to keep `$is_args` an empty string, hence effectively
-        -- stripping the empty querystring.
-        -- We overcome this behavior with our own logic, to preserve user
-        -- desired semantics.
-        local upstream_uri = var.upstream_uri
+      local balancer_data = ctx.balancer_data
 
-        if var.is_args == "?" or sub(var.request_uri, -1) == "?" then
-          var.upstream_uri = upstream_uri .. "?" .. (var.args or "")
-        end
+      if balancer_data.uri.request_uri then
+        var.upstream_uri = build_upstream_uri(balancer_data.uri, var.args)
       end
 
-      local balancer_data = ctx.balancer_data
       balancer_data.scheme = var.upstream_scheme -- COMPAT: pdk
 
       local ok, err, errcode = balancer_execute(ctx)

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -728,7 +728,6 @@ local function balancer_prepare(ctx, match_t, host_type, host, port,
       upstream_postfix    = match_t.upstream_uri_postfix or "",
       upstream_prefix     = (service or EMPTY_T).path or "/",
       -- downstream_match = nil,
-      -- has_args         = nil,
     }
   }
 
@@ -738,10 +737,8 @@ local function balancer_prepare(ctx, match_t, host_type, host, port,
 
       if idx then
         idx = idx - 1
-        balancer_data.uri.has_args = true
       else
         idx = #request_uri
-        balancer_data.uri.has_args = false
       end
 
       idx = idx - #(match_t.upstream_uri_postfix or "")
@@ -791,7 +788,7 @@ local function balancer_execute(ctx)
 end
 
 
-local function build_upstream_uri(components, request_args)
+local function build_upstream_uri(components)
   local upstream_uri
   local postfix = components.upstream_postfix
   local prefix = components.upstream_prefix or "/"
@@ -814,8 +811,8 @@ local function build_upstream_uri(components, request_args)
   end
 
 
-  if components.has_args then
-    return upstream_uri .. "?" .. (request_args or "")
+  if var.is_args == "?" or sub(var.request_uri, -1) == "?" then
+    upstream_uri = upstream_uri .. "?" .. (var.args or "")
   end
 
   return upstream_uri
@@ -1256,7 +1253,7 @@ return {
       local balancer_data = ctx.balancer_data
 
       if balancer_data.uri.request_uri then
-        var.upstream_uri = build_upstream_uri(balancer_data.uri, var.args)
+        var.upstream_uri = build_upstream_uri(balancer_data.uri)
       end
 
       balancer_data.scheme = var.upstream_scheme -- COMPAT: pdk

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -87,6 +87,17 @@ local _set_router
 local _set_router_version
 
 
+local function _set_ngx(mock_ngx)
+  if type(mock_ngx) ~= "table" then
+    return
+  end
+
+  if mock_ngx.var then
+    var = mock_ngx.var
+  end
+end
+
+
 local update_lua_mem
 do
   local pid = ngx.worker.pid
@@ -810,7 +821,6 @@ local function build_upstream_uri(components)
     upstream_uri = prefix .. sub(components.request_uri, 2, -1)
   end
 
-
   if var.is_args == "?" or sub(var.request_uri, -1) == "?" then
     upstream_uri = upstream_uri .. "?" .. (var.args or "")
   end
@@ -855,6 +865,7 @@ return {
   _set_build_router = _set_build_router,
   _set_router_version = _set_router_version,
   _set_update_plugins_iterator = _set_update_plugins_iterator,
+  _set_ngx = _set_ngx,
   _get_updated_router = get_updated_router,
   _update_lua_mem = update_lua_mem,
   _build_upstream_uri = build_upstream_uri,

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -1207,7 +1207,7 @@ describe("Router", function()
 
       -- upstream_uri
       assert.is_nil(match_t.upstream_host) -- only when `preserve_host = true`
-      assert.equal("/my-route", match_t.upstream_uri)
+      assert.equal("", match_t.upstream_uri_postfix)
 
       _ngx = mock_ngx("GET", "/my-route-2", { host = "domain.org" })
       router._set_ngx(_ngx)
@@ -1221,7 +1221,7 @@ describe("Router", function()
 
       -- upstream_uri
       assert.is_nil(match_t.upstream_host) -- only when `preserve_host = true`
-      assert.equal("/my-route-2", match_t.upstream_uri)
+      assert.equal("", match_t.upstream_uri_postfix)
     end)
 
     it("returns matched_host + matched_uri + matched_method", function()
@@ -1371,7 +1371,7 @@ describe("Router", function()
       local _ngx = mock_ngx("GET", "/hello/world", { host = "domain.org" })
       router._set_ngx(_ngx)
       local match_t = router.exec()
-      assert.equal("/world", match_t.upstream_uri)
+      assert.equal("/world", match_t.upstream_uri_postfix)
       assert.is_nil(match_t.matches.uri_captures)
     end)
 
@@ -1469,7 +1469,7 @@ describe("Router", function()
       router._set_ngx(_ngx)
       local match_t = router.exec()
       assert.same(use_case_routes[1].route, match_t.route)
-      assert.equal("/endel%C3%B8st", match_t.upstream_uri)
+      assert.equal("", match_t.upstream_uri_postfix)
     end)
 
     describe("stripped paths", function()
@@ -1502,7 +1502,7 @@ describe("Router", function()
         router._set_ngx(_ngx)
         local match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
-        assert.equal("/hello/world", match_t.upstream_uri)
+        assert.equal("/hello/world", match_t.upstream_uri_postfix)
       end)
 
       it("strips if matched URI is plain (not a prefix)", function()
@@ -1510,7 +1510,7 @@ describe("Router", function()
         router._set_ngx(_ngx)
         local match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
-        assert.equal("/", match_t.upstream_uri)
+        assert.equal("", match_t.upstream_uri_postfix)
       end)
 
       it("doesn't strip if 'strip_uri' is not enabled", function()
@@ -1519,7 +1519,7 @@ describe("Router", function()
         router._set_ngx(_ngx)
         local match_t = router.exec()
         assert.same(use_case_routes[2].route, match_t.route)
-        assert.equal("/my-route/hello/world", match_t.upstream_uri)
+        assert.equal("/hello/world", match_t.upstream_uri_postfix)
       end)
 
       it("does not strips root / URI", function()
@@ -1540,7 +1540,7 @@ describe("Router", function()
         router._set_ngx(_ngx)
         local match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
-        assert.equal("/my-route/hello/world", match_t.upstream_uri)
+        assert.equal("my-route/hello/world", match_t.upstream_uri_postfix)
       end)
 
       it("can find an route with stripped URI several times in a row", function()
@@ -1548,13 +1548,13 @@ describe("Router", function()
         router._set_ngx(_ngx)
         local match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
-        assert.equal("/", match_t.upstream_uri)
+        assert.equal("", match_t.upstream_uri_postfix)
 
         _ngx = mock_ngx("GET", "/my-route", { host = "domain.org" })
         router._set_ngx(_ngx)
         match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
-        assert.equal("/", match_t.upstream_uri)
+        assert.equal("", match_t.upstream_uri_postfix)
       end)
 
       it("can proxy an route with stripped URI with different URIs in a row", function()
@@ -1562,25 +1562,25 @@ describe("Router", function()
         router._set_ngx(_ngx)
         local match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
-        assert.equal("/", match_t.upstream_uri)
+        assert.equal("", match_t.upstream_uri_postfix)
 
         _ngx = mock_ngx("GET", "/this-route", { host = "domain.org" })
         router._set_ngx(_ngx)
         match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
-        assert.equal("/", match_t.upstream_uri)
+        assert.equal("", match_t.upstream_uri_postfix)
 
         _ngx = mock_ngx("GET", "/my-route", { host = "domain.org" })
         router._set_ngx(_ngx)
         match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
-        assert.equal("/", match_t.upstream_uri)
+        assert.equal("", match_t.upstream_uri_postfix)
 
         _ngx = mock_ngx("GET", "/this-route", { host = "domain.org" })
         router._set_ngx(_ngx)
         match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
-        assert.equal("/", match_t.upstream_uri)
+        assert.equal("", match_t.upstream_uri_postfix)
       end)
 
       it("strips url encoded paths", function()
@@ -1599,7 +1599,7 @@ describe("Router", function()
         router._set_ngx(_ngx)
         local match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
-        assert.equal("/", match_t.upstream_uri)
+        assert.equal("", match_t.upstream_uri_postfix)
       end)
 
       it("strips a [uri regex]", function()
@@ -1618,7 +1618,7 @@ describe("Router", function()
                               { host = "domain.org" })
         router._set_ngx(_ngx)
         local match_t = router.exec()
-        assert.equal("/hello/world", match_t.upstream_uri)
+        assert.equal("/hello/world", match_t.upstream_uri_postfix)
       end)
 
       it("strips a [uri regex] with a capture group", function()
@@ -1637,7 +1637,7 @@ describe("Router", function()
                               { host = "domain.org" })
         router._set_ngx(_ngx)
         local match_t = router.exec()
-        assert.equal("/hello/world", match_t.upstream_uri)
+        assert.equal("/hello/world", match_t.upstream_uri_postfix)
       end)
     end)
 
@@ -1778,193 +1778,6 @@ describe("Router", function()
           assert.is_nil(match_t.upstream_host)
         end)
       end)
-    end)
-
-
-    describe("slash handling", function()
-      local checks = {
-        -- upstream url    paths           request path    expected path           strip uri
-        {  "/",            "/",            "/",            "/",                    true      }, -- 1
-        {  "/",            "/",            "/foo/bar",     "/foo/bar",             true      },
-        {  "/",            "/",            "/foo/bar/",    "/foo/bar/",            true      },
-        {  "/",            "/foo/bar",     "/foo/bar",     "/",                    true      },
-        {  "/",            "/foo/bar",     "/foo/bar/",    "/",                    true      },
-        {  "/",            "/foo/bar/",    "/foo/bar/",    "/",                    true      },
-        {  "/fee/bor",     "/",            "/",            "/fee/bor",             true      },
-        {  "/fee/bor",     "/",            "/foo/bar",     "/fee/borfoo/bar",      true      },
-        {  "/fee/bor",     "/",            "/foo/bar/",    "/fee/borfoo/bar/",     true      },
-        {  "/fee/bor",     "/foo/bar",     "/foo/bar",     "/fee/bor",             true      }, -- 10
-        {  "/fee/bor",     "/foo/bar",     "/foo/bar/",    "/fee/bor/",            true      },
-        {  "/fee/bor",     "/foo/bar/",    "/foo/bar/",    "/fee/bor",             true      },
-        {  "/fee/bor/",    "/",            "/",            "/fee/bor/",            true      },
-        {  "/fee/bor/",    "/",            "/foo/bar",     "/fee/bor/foo/bar",     true      },
-        {  "/fee/bor/",    "/",            "/foo/bar/",    "/fee/bor/foo/bar/",    true      },
-        {  "/fee/bor/",    "/foo/bar",     "/foo/bar",     "/fee/bor/",            true      },
-        {  "/fee/bor/",    "/foo/bar",     "/foo/bar/",    "/fee/bor/",            true      },
-        {  "/fee/bor/",    "/foo/bar/",    "/foo/bar/",    "/fee/bor/",            true      },
-        {  "/",            "/",            "/",            "/",                    false     },
-        {  "/",            "/",            "/foo/bar",     "/foo/bar",             false     }, -- 20
-        {  "/",            "/",            "/foo/bar/",    "/foo/bar/",            false     },
-        {  "/",            "/foo/bar",     "/foo/bar",     "/foo/bar",             false     },
-        {  "/",            "/foo/bar",     "/foo/bar/",    "/foo/bar/",            false     },
-        {  "/",            "/foo/bar/",    "/foo/bar/",    "/foo/bar/",            false     },
-        {  "/fee/bor",     "/",            "/",            "/fee/bor",             false     },
-        {  "/fee/bor",     "/",            "/foo/bar",     "/fee/borfoo/bar",      false     },
-        {  "/fee/bor",     "/",            "/foo/bar/",    "/fee/borfoo/bar/",     false     },
-        {  "/fee/bor",     "/foo/bar",     "/foo/bar",     "/fee/borfoo/bar",      false     },
-        {  "/fee/bor",     "/foo/bar",     "/foo/bar/",    "/fee/borfoo/bar/",     false     },
-        {  "/fee/bor",     "/foo/bar/",    "/foo/bar/",    "/fee/borfoo/bar/",     false     }, -- 30
-        {  "/fee/bor/",    "/",            "/",            "/fee/bor/",            false     },
-        {  "/fee/bor/",    "/",            "/foo/bar",     "/fee/bor/foo/bar",     false     },
-        {  "/fee/bor/",    "/",            "/foo/bar/",    "/fee/bor/foo/bar/",    false     },
-        {  "/fee/bor/",    "/foo/bar",     "/foo/bar",     "/fee/bor/foo/bar",     false     },
-        {  "/fee/bor/",    "/foo/bar",     "/foo/bar/",    "/fee/bor/foo/bar/",    false     },
-        {  "/fee/bor/",    "/foo/bar/",    "/foo/bar/",    "/fee/bor/foo/bar/",    false     },
-        -- the following block runs the same tests, but with a request path that is longer
-        -- than the matched part, so either matches in the middle of a segment, or has an
-        -- additional segment.
-        {  "/",            "/",            "/foo/bars",    "/foo/bars",            true      },
-        {  "/",            "/",            "/foo/bar/s",   "/foo/bar/s",           true      },
-        {  "/",            "/foo/bar",     "/foo/bars",    "/s",                   true      },
-        {  "/",            "/foo/bar/",    "/foo/bar/s",   "/s",                   true      }, -- 40
-        {  "/fee/bor",     "/",            "/foo/bars",    "/fee/borfoo/bars",     true      },
-        {  "/fee/bor",     "/",            "/foo/bar/s",   "/fee/borfoo/bar/s",    true      },
-        {  "/fee/bor",     "/foo/bar",     "/foo/bars",    "/fee/bors",            true      },
-        {  "/fee/bor",     "/foo/bar/",    "/foo/bar/s",   "/fee/bors",            true      },
-        {  "/fee/bor/",    "/",            "/foo/bars",    "/fee/bor/foo/bars",    true      },
-        {  "/fee/bor/",    "/",            "/foo/bar/s",   "/fee/bor/foo/bar/s",   true      },
-        {  "/fee/bor/",    "/foo/bar",     "/foo/bars",    "/fee/bor/s",           true      },
-        {  "/fee/bor/",    "/foo/bar/",    "/foo/bar/s",   "/fee/bor/s",           true      },
-        {  "/",            "/",            "/foo/bars",    "/foo/bars",            false     },
-        {  "/",            "/",            "/foo/bar/s",   "/foo/bar/s",           false     }, -- 50
-        {  "/",            "/foo/bar",     "/foo/bars",    "/foo/bars",            false     },
-        {  "/",            "/foo/bar/",    "/foo/bar/s",   "/foo/bar/s",           false     },
-        {  "/fee/bor",     "/",            "/foo/bars",    "/fee/borfoo/bars",     false     },
-        {  "/fee/bor",     "/",            "/foo/bar/s",   "/fee/borfoo/bar/s",    false     },
-        {  "/fee/bor",     "/foo/bar",     "/foo/bars",    "/fee/borfoo/bars",     false     },
-        {  "/fee/bor",     "/foo/bar/",    "/foo/bar/s",   "/fee/borfoo/bar/s",    false     },
-        {  "/fee/bor/",    "/",            "/foo/bars",    "/fee/bor/foo/bars",    false     },
-        {  "/fee/bor/",    "/",            "/foo/bar/s",   "/fee/bor/foo/bar/s",   false     },
-        {  "/fee/bor/",    "/foo/bar",     "/foo/bars",    "/fee/bor/foo/bars",    false     },
-        {  "/fee/bor/",    "/foo/bar/",    "/foo/bar/s",   "/fee/bor/foo/bar/s",   false     }, -- 60
-        -- the following block matches on host, instead of path
-        {  "/",            nil,            "/",            "/",                    false     },
-        {  "/",            nil,            "/foo/bar",     "/foo/bar",             false     },
-        {  "/",            nil,            "/foo/bar/",    "/foo/bar/",            false     },
-        {  "/fee/bor",     nil,            "/",            "/fee/bor",             false     },
-        {  "/fee/bor",     nil,            "/foo/bar",     "/fee/borfoo/bar",      false     },
-        {  "/fee/bor",     nil,            "/foo/bar/",    "/fee/borfoo/bar/",     false     },
-        {  "/fee/bor/",    nil,            "/",            "/fee/bor/",            false     },
-        {  "/fee/bor/",    nil,            "/foo/bar",     "/fee/bor/foo/bar",     false     },
-        {  "/fee/bor/",    nil,            "/foo/bar/",    "/fee/bor/foo/bar/",    false     },
-        {  "/",            nil,            "/",            "/",                    true      }, -- 70
-        {  "/",            nil,            "/foo/bar",     "/foo/bar",             true      },
-        {  "/",            nil,            "/foo/bar/",    "/foo/bar/",            true      },
-        {  "/fee/bor",     nil,            "/",            "/fee/bor",             true      },
-        {  "/fee/bor",     nil,            "/foo/bar",     "/fee/borfoo/bar",      true      },
-        {  "/fee/bor",     nil,            "/foo/bar/",    "/fee/borfoo/bar/",     true      },
-        {  "/fee/bor/",    nil,            "/",            "/fee/bor/",            true      },
-        {  "/fee/bor/",    nil,            "/foo/bar",     "/fee/bor/foo/bar",     true      },
-        {  "/fee/bor/",    nil,            "/foo/bar/",    "/fee/bor/foo/bar/",    true      },
-      }
-
-      for i, args in ipairs(checks) do
-
-        local config
-        if args[5] == true then
-          config = "(strip = on, plain)"
-        else
-          config = "(strip = off, plain)"
-        end
-
-        local description
-        if args[2] then
-          description = string.format("(%d) (%s) %s with uri %s when requesting %s",
-            i, config, args[1], args[2], args[3])
-        else
-          description = string.format("(%d) (%s) %s with host %s when requesting %s",
-            i, config, args[1], "localbin-" .. i .. ".com", args[3])
-        end
-
-        it(description, function()
-          local use_case_routes = {
-            {
-              service      = {
-                protocol   = "http",
-                name       = "service-invalid",
-                path       = args[1],
-              },
-              route        = {
-                strip_path = args[5],
-                paths      = { args[2] },
-              },
-              headers      = {
-                -- only add the header is no path is provided
-                host       = args[2] == nil and nil or { "localbin-" .. i .. ".com" },
-              },
-            }
-          }
-
-          local router = assert(Router.new(use_case_routes) )
-          local _ngx = mock_ngx("GET", args[3], { host = "localbin-" .. i .. ".com" })
-          router._set_ngx(_ngx)
-          local match_t = router.exec()
-          assert.same(use_case_routes[1].route, match_t.route)
-          assert.equal(args[1], match_t.upstream_url_t.path)
-          assert.equal(args[4], match_t.upstream_uri)
-        end)
-      end
-
-      -- this is identical to the tests above, except that for the path we match
-      -- with an injected regex sequence, effectively transforming the path
-      -- match into a regex match
-      local function make_a_regex(path)
-        return "/[0]?" .. path:sub(2, -1)
-      end
-
-      for i, args in ipairs(checks) do
-        local config
-        if args[5] == true then
-          config = "(strip = on, regex)"
-        else
-          config = "(strip = off, regex)"
-        end
-
-        if args[2] then -- skip test cases which match on host
-          local description = string.format("(%d) (%s) %s with uri %s when requesting %s",
-                                            i, config, args[1], make_a_regex(args[2]), args[3])
-
-          it(description, function()
-
-
-            local use_case_routes = {
-              {
-                service      = {
-                  protocol   = "http",
-                  name       = "service-invalid",
-                  path       = args[1],
-                },
-                route        = {
-                  strip_path = args[5],
-                  paths      = { make_a_regex(args[2]) },
-                },
-                headers      = {
-                  -- only add the header is no path is provided
-                  host       = args[2] == nil and nil or { "localbin-" .. i .. ".com" },
-                },
-              }
-            }
-
-            local router = assert(Router.new(use_case_routes) )
-            local _ngx = mock_ngx("GET", args[3], { host = "localbin-" .. i .. ".com" })
-            router._set_ngx(_ngx)
-            local match_t = router.exec()
-            assert.same(use_case_routes[1].route, match_t.route)
-            assert.equal(args[1], match_t.upstream_url_t.path)
-            assert.equal(args[4], match_t.upstream_uri)
-          end)
-        end
-      end
     end)
   end)
 

--- a/spec/01-unit/18-upstream_uri_spec.lua
+++ b/spec/01-unit/18-upstream_uri_spec.lua
@@ -1,0 +1,235 @@
+local Router = require "kong.router"
+local build_upstream_uri = require("kong.runloop.handler")._build_upstream_uri
+
+local spy_stub = {
+  nop = function() end
+}
+
+local function mock_ngx(method, request_uri, headers)
+  local _ngx
+  _ngx = {
+    re = ngx.re,
+    var = setmetatable({
+      request_uri = request_uri,
+      http_kong_debug = headers.kong_debug
+    }, {
+      __index = function(_, key)
+        if key == "http_host" then
+          spy_stub.nop()
+          return headers.host
+        end
+      end
+    }),
+    req = {
+      get_method = function()
+        return method
+      end,
+      get_headers = function()
+        return headers
+      end
+    }
+  }
+
+  return _ngx
+end
+
+
+describe("build_upstream_uri", function()
+  local checks = {
+    -- upstream url    paths           request path    expected path           strip uri
+    {  "/",            "/",            "/",            "/",                    true      }, -- 1
+    {  "/",            "/",            "/foo/bar",     "/foo/bar",             true      },
+    {  "/",            "/",            "/foo/bar/",    "/foo/bar/",            true      },
+    {  "/",            "/foo/bar",     "/foo/bar",     "/",                    true      },
+    {  "/",            "/foo/bar",     "/foo/bar/",    "/",                    true      },
+    {  "/",            "/foo/bar/",    "/foo/bar/",    "/",                    true      },
+    {  "/fee/bor",     "/",            "/",            "/fee/bor",             true      },
+    {  "/fee/bor",     "/",            "/foo/bar",     "/fee/borfoo/bar",      true      },
+    {  "/fee/bor",     "/",            "/foo/bar/",    "/fee/borfoo/bar/",     true      },
+    {  "/fee/bor",     "/foo/bar",     "/foo/bar",     "/fee/bor",             true      }, -- 10
+    {  "/fee/bor",     "/foo/bar",     "/foo/bar/",    "/fee/bor/",            true      },
+    {  "/fee/bor",     "/foo/bar/",    "/foo/bar/",    "/fee/bor",             true      },
+    {  "/fee/bor/",    "/",            "/",            "/fee/bor/",            true      },
+    {  "/fee/bor/",    "/",            "/foo/bar",     "/fee/bor/foo/bar",     true      },
+    {  "/fee/bor/",    "/",            "/foo/bar/",    "/fee/bor/foo/bar/",    true      },
+    {  "/fee/bor/",    "/foo/bar",     "/foo/bar",     "/fee/bor/",            true      },
+    {  "/fee/bor/",    "/foo/bar",     "/foo/bar/",    "/fee/bor/",            true      },
+    {  "/fee/bor/",    "/foo/bar/",    "/foo/bar/",    "/fee/bor/",            true      },
+    {  "/",            "/",            "/",            "/",                    false     },
+    {  "/",            "/",            "/foo/bar",     "/foo/bar",             false     }, -- 20
+    {  "/",            "/",            "/foo/bar/",    "/foo/bar/",            false     },
+    {  "/",            "/foo/bar",     "/foo/bar",     "/foo/bar",             false     },
+    {  "/",            "/foo/bar",     "/foo/bar/",    "/foo/bar/",            false     },
+    {  "/",            "/foo/bar/",    "/foo/bar/",    "/foo/bar/",            false     },
+    {  "/fee/bor",     "/",            "/",            "/fee/bor",             false     },
+    {  "/fee/bor",     "/",            "/foo/bar",     "/fee/borfoo/bar",      false     },
+    {  "/fee/bor",     "/",            "/foo/bar/",    "/fee/borfoo/bar/",     false     },
+    {  "/fee/bor",     "/foo/bar",     "/foo/bar",     "/fee/borfoo/bar",      false     },
+    {  "/fee/bor",     "/foo/bar",     "/foo/bar/",    "/fee/borfoo/bar/",     false     },
+    {  "/fee/bor",     "/foo/bar/",    "/foo/bar/",    "/fee/borfoo/bar/",     false     }, -- 30
+    {  "/fee/bor/",    "/",            "/",            "/fee/bor/",            false     },
+    {  "/fee/bor/",    "/",            "/foo/bar",     "/fee/bor/foo/bar",     false     },
+    {  "/fee/bor/",    "/",            "/foo/bar/",    "/fee/bor/foo/bar/",    false     },
+    {  "/fee/bor/",    "/foo/bar",     "/foo/bar",     "/fee/bor/foo/bar",     false     },
+    {  "/fee/bor/",    "/foo/bar",     "/foo/bar/",    "/fee/bor/foo/bar/",    false     },
+    {  "/fee/bor/",    "/foo/bar/",    "/foo/bar/",    "/fee/bor/foo/bar/",    false     },
+    -- the following block runs the same tests, but with a request path that is longer
+    -- than the matched part, so either matches in the middle of a segment, or has an
+    -- additional segment.
+    {  "/",            "/",            "/foo/bars",    "/foo/bars",            true      },
+    {  "/",            "/",            "/foo/bar/s",   "/foo/bar/s",           true      },
+    {  "/",            "/foo/bar",     "/foo/bars",    "/s",                   true      },
+    {  "/",            "/foo/bar/",    "/foo/bar/s",   "/s",                   true      }, -- 40
+    {  "/fee/bor",     "/",            "/foo/bars",    "/fee/borfoo/bars",     true      },
+    {  "/fee/bor",     "/",            "/foo/bar/s",   "/fee/borfoo/bar/s",    true      },
+    {  "/fee/bor",     "/foo/bar",     "/foo/bars",    "/fee/bors",            true      },
+    {  "/fee/bor",     "/foo/bar/",    "/foo/bar/s",   "/fee/bors",            true      },
+    {  "/fee/bor/",    "/",            "/foo/bars",    "/fee/bor/foo/bars",    true      },
+    {  "/fee/bor/",    "/",            "/foo/bar/s",   "/fee/bor/foo/bar/s",   true      },
+    {  "/fee/bor/",    "/foo/bar",     "/foo/bars",    "/fee/bor/s",           true      },
+    {  "/fee/bor/",    "/foo/bar/",    "/foo/bar/s",   "/fee/bor/s",           true      },
+    {  "/",            "/",            "/foo/bars",    "/foo/bars",            false     },
+    {  "/",            "/",            "/foo/bar/s",   "/foo/bar/s",           false     }, -- 50
+    {  "/",            "/foo/bar",     "/foo/bars",    "/foo/bars",            false     },
+    {  "/",            "/foo/bar/",    "/foo/bar/s",   "/foo/bar/s",           false     },
+    {  "/fee/bor",     "/",            "/foo/bars",    "/fee/borfoo/bars",     false     },
+    {  "/fee/bor",     "/",            "/foo/bar/s",   "/fee/borfoo/bar/s",    false     },
+    {  "/fee/bor",     "/foo/bar",     "/foo/bars",    "/fee/borfoo/bars",     false     },
+    {  "/fee/bor",     "/foo/bar/",    "/foo/bar/s",   "/fee/borfoo/bar/s",    false     },
+    {  "/fee/bor/",    "/",            "/foo/bars",    "/fee/bor/foo/bars",    false     },
+    {  "/fee/bor/",    "/",            "/foo/bar/s",   "/fee/bor/foo/bar/s",   false     },
+    {  "/fee/bor/",    "/foo/bar",     "/foo/bars",    "/fee/bor/foo/bars",    false     },
+    {  "/fee/bor/",    "/foo/bar/",    "/foo/bar/s",   "/fee/bor/foo/bar/s",   false     }, -- 60
+    -- the following block matches on host, instead of path
+    {  "/",            nil,            "/",            "/",                    false     },
+    {  "/",            nil,            "/foo/bar",     "/foo/bar",             false     },
+    {  "/",            nil,            "/foo/bar/",    "/foo/bar/",            false     },
+    {  "/fee/bor",     nil,            "/",            "/fee/bor",             false     },
+    {  "/fee/bor",     nil,            "/foo/bar",     "/fee/borfoo/bar",      false     },
+    {  "/fee/bor",     nil,            "/foo/bar/",    "/fee/borfoo/bar/",     false     },
+    {  "/fee/bor/",    nil,            "/",            "/fee/bor/",            false     },
+    {  "/fee/bor/",    nil,            "/foo/bar",     "/fee/bor/foo/bar",     false     },
+    {  "/fee/bor/",    nil,            "/foo/bar/",    "/fee/bor/foo/bar/",    false     },
+    {  "/",            nil,            "/",            "/",                    true      }, -- 70
+    {  "/",            nil,            "/foo/bar",     "/foo/bar",             true      },
+    {  "/",            nil,            "/foo/bar/",    "/foo/bar/",            true      },
+    {  "/fee/bor",     nil,            "/",            "/fee/bor",             true      },
+    {  "/fee/bor",     nil,            "/foo/bar",     "/fee/borfoo/bar",      true      },
+    {  "/fee/bor",     nil,            "/foo/bar/",    "/fee/borfoo/bar/",     true      },
+    {  "/fee/bor/",    nil,            "/",            "/fee/bor/",            true      },
+    {  "/fee/bor/",    nil,            "/foo/bar",     "/fee/bor/foo/bar",     true      },
+    {  "/fee/bor/",    nil,            "/foo/bar/",    "/fee/bor/foo/bar/",    true      },
+  }
+
+  for i, args in ipairs(checks) do
+
+    local config
+    if args[5] == true then
+      config = "(strip = on, plain)"
+    else
+      config = "(strip = off, plain)"
+    end
+
+    local description
+    if args[2] then
+      description = string.format("(%d) (%s) %s with uri %s when requesting %s",
+        i, config, args[1], args[2], args[3])
+    else
+      description = string.format("(%d) (%s) %s with host %s when requesting %s",
+        i, config, args[1], "localbin-" .. i .. ".com", args[3])
+    end
+
+    it(description, function()
+      local use_case_routes = {
+        {
+          service      = {
+            protocol   = "http",
+            name       = "service-invalid",
+            path       = args[1],
+          },
+          route        = {
+            strip_path = args[5],
+            paths      = { args[2] },
+          },
+          headers      = {
+            -- only add the header is no path is provided
+            host       = args[2] == nil and nil or { "localbin-" .. i .. ".com" },
+          },
+        }
+      }
+
+      local router = assert(Router.new(use_case_routes) )
+      local _ngx = mock_ngx("GET", args[3], { host = "localbin-" .. i .. ".com" })
+      router._set_ngx(_ngx)
+      local match_t = router.exec()
+      assert.same(use_case_routes[1].route, match_t.route)
+      assert.equal(args[1], match_t.upstream_url_t.path)
+      local uri = {
+        request_uri      = args[3],
+        strip_path       = use_case_routes[1].route.strip_path,
+        upstream_prefix  = use_case_routes[1].service.path,
+        upstream_postfix = match_t.upstream_uri_postfix,
+      }
+      local upstream_uri = build_upstream_uri(uri, "")
+      assert.equal(args[4], upstream_uri)
+    end)
+  end
+
+  -- this is identical to the tests above, except that for the path we match
+  -- with an injected regex sequence, effectively transforming the path
+  -- match into a regex match
+  local function make_a_regex(path)
+    return "/[0]?" .. path:sub(2, -1)
+  end
+
+  for i, args in ipairs(checks) do
+    local config
+    if args[5] == true then
+      config = "(strip = on, regex)"
+    else
+      config = "(strip = off, regex)"
+    end
+
+    if args[2] then -- skip test cases which match on host
+      local description = string.format("(%d) (%s) %s with uri %s when requesting %s",
+                                        i, config, args[1], make_a_regex(args[2]), args[3])
+
+      it(description, function()
+
+
+        local use_case_routes = {
+          {
+            service      = {
+              protocol   = "http",
+              name       = "service-invalid",
+              path       = args[1],
+            },
+            route        = {
+              strip_path = args[5],
+              paths      = { make_a_regex(args[2]) },
+            },
+            headers      = {
+              -- only add the header is no path is provided
+              host       = args[2] == nil and nil or { "localbin-" .. i .. ".com" },
+            },
+          }
+        }
+
+        local router = assert(Router.new(use_case_routes) )
+        local _ngx = mock_ngx("GET", args[3], { host = "localbin-" .. i .. ".com" })
+        router._set_ngx(_ngx)
+        local match_t = router.exec()
+        assert.same(use_case_routes[1].route, match_t.route)
+        assert.equal(args[1], match_t.upstream_url_t.path)
+        local uri = {
+          request_uri      = args[3],
+          strip_path       = use_case_routes[1].route.strip_path,
+          upstream_prefix  = use_case_routes[1].service.path,
+          upstream_postfix = match_t.upstream_uri_postfix,
+        }
+        local upstream_uri = build_upstream_uri(uri, "")
+        assert.equal(args[4], upstream_uri)
+      end)
+    end
+  end
+end)

--- a/spec/01-unit/18-upstream_uri_spec.lua
+++ b/spec/01-unit/18-upstream_uri_spec.lua
@@ -1,5 +1,6 @@
 local Router = require "kong.router"
-local build_upstream_uri = require("kong.runloop.handler")._build_upstream_uri
+local runloop = require "kong.runloop.handler"
+local build_upstream_uri = runloop._build_upstream_uri
 
 local spy_stub = {
   nop = function() end
@@ -10,6 +11,7 @@ local function mock_ngx(method, request_uri, headers)
   _ngx = {
     re = ngx.re,
     var = setmetatable({
+      is_args = "",
       request_uri = request_uri,
       http_kong_debug = headers.kong_debug
     }, {
@@ -161,6 +163,7 @@ describe("build_upstream_uri", function()
       local router = assert(Router.new(use_case_routes) )
       local _ngx = mock_ngx("GET", args[3], { host = "localbin-" .. i .. ".com" })
       router._set_ngx(_ngx)
+      runloop._set_ngx(_ngx)
       local match_t = router.exec()
       assert.same(use_case_routes[1].route, match_t.route)
       assert.equal(args[1], match_t.upstream_url_t.path)
@@ -218,6 +221,7 @@ describe("build_upstream_uri", function()
         local router = assert(Router.new(use_case_routes) )
         local _ngx = mock_ngx("GET", args[3], { host = "localbin-" .. i .. ".com" })
         router._set_ngx(_ngx)
+        runloop._set_ngx(_ngx)
         local match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
         assert.equal(args[1], match_t.upstream_url_t.path)
@@ -233,3 +237,4 @@ describe("build_upstream_uri", function()
     end
   end
 end)
+


### PR DESCRIPTION
The router was responsible for path construction but this would
happen in the before-access phase. Allowing path manipulation to
only be done on the full path, not on the individual components.

This commit changes it by creating an intermediate table with the
path components (for plugins to modify) and does the final
construction only in the after-access phase
