### PR TITLE
feat(tests) allow to override log/prefix cleaning

### DIFF
--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -1611,7 +1611,8 @@ local function stop_kong(prefix, preserve_prefix, preserve_dc)
 
   wait_pid(running_conf.nginx_pid)
 
-  if not preserve_prefix then
+  -- note: set env var "KONG_TEST_DONT_CLEAN" !! the "_TEST" will be dropped
+  if not (preserve_prefix or os.getenv("KONG_DONT_CLEAN")) then
     clean_prefix(prefix)
   end
 


### PR DESCRIPTION
Instead of setting a parameter on the kong stop function, it can now
be specified as an env variable.

Variable is: KONG_TEST_DONT_CLEAN (KONG_DONT_CLEAN in tests)
