### PR TITLE
refactor(runloop) change order of ctx and phase arguments, prepare plugins_iterator structures, localize globals on plugins_iterator

### DIFF
--- a/kong/runloop/plugins_iterator.lua
+++ b/kong/runloop/plugins_iterator.lua
@@ -2,7 +2,14 @@ local BasePlugin   = require "kong.plugins.base_plugin"
 local constants    = require "kong.constants"
 local reports      = require "kong.reports"
 
+
 local kong         = kong
+local type         = type
+local error        = error
+local pairs        = pairs
+local ipairs       = ipairs
+local assert       = assert
+local tostring     = tostring
 
 
 local COMBO_R      = 1
@@ -129,9 +136,9 @@ local function load_configuration_through_combos(ctx, combos, plugin)
   local plugin_configuration
   local name = plugin.name
 
-  local route        = ctx.route
-  local service      = ctx.service
-  local consumer     = ctx.authenticated_consumer
+  local route    = ctx.route
+  local service  = ctx.service
+  local consumer = ctx.authenticated_consumer
 
   if route and plugin.no_route then
     route = nil

--- a/kong/runloop/plugins_iterator.lua
+++ b/kong/runloop/plugins_iterator.lua
@@ -261,10 +261,11 @@ local PluginsIterator = {}
 -- Iterate over the plugin loaded for a request, stored in
 --`ngx.ctx.plugins`.
 --
--- @param[type=table] ctx Nginx context table
 -- @param[type=string] phase Plugins iterator execution phase
+-- @param[type=table] ctx Nginx context table
 -- @treturn function iterator
-local function iterate(self, ctx, phase)
+local function iterate(self, phase, ctx)
+  -- no ctx, we are in init_worker phase
   if ctx and not ctx.plugins then
     ctx.plugins = {}
   end


### PR DESCRIPTION
### Summary

~Fixes issue with plugins_iterator not executing `init_worker` when starting Kong where the plugin was not already configured (in a database). This issue was introduced in `1.2.0rc1`.~

The PR also does some style changes and refactorings like:
1. localizing global variable access on plugins iterator
2. changed the order of `phase` and `ctx` arguments given to iterator on first call
3. loads the needed structures for iterator earlier (on iterator construction)
4. does not use `mock_ctx` anymore -> certificate passes ngx.ctx (which current version of OpenResty rewrite phase clears, but it still gives a table and future proofs that code path) and init_worker passes `nil` (as the ngx.ctx is not used for anything on init_worker with plugins iterator)
~5. finally it adds tests that check that `init_worker` is called when pre-configured and runtime-configured~

### Issues resolved

Fix #4665
