### PR TITLE
hotfix(plugins) execute ':new()' when Plugins deep-inherit from BasePlugin

### DIFF
--- a/kong/db/dao/plugins.lua
+++ b/kong/db/dao/plugins.lua
@@ -270,7 +270,7 @@ function Plugins:load_plugin_schemas(plugin_set)
     local handler, err = load_plugin(self, plugin)
 
     if handler then
-      if getmetatable(handler) == BasePlugin then
+      if type(handler.is) == "function" and handler:is(BasePlugin) then
         -- Backwards-compatibility for 0.x and 1.x plugins inheriting from the
         -- BasePlugin class.
         -- TODO: deprecate & remove


### PR DESCRIPTION
In a29c355, we removed the need for Plugins to inherit from the
BasePlugin class, but added backwards-compatibility ensuring existing
plugins can still inherit from it, and their constructor (`:new()`) is
called.

However, the Zipkin plugin deep-inherits from BasePlugin, via an
intermediate parent class (OpenTracing):

https://github.com/Kong/kong-plugin-zipkin/blob/master/kong/plugins/zipkin/handler.lua#L8

This patch ensures that such plugins have their `:new()` constructor
called as well, by hardening the "does it inherit from BasePlugin?"
check performed on their `handler` module. We do so by using
`classic.lua`'s `is()` method.