### PR TITLE
perf(runloop) warmup dns on router rebuilds

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -164,6 +164,12 @@ local function execute_cache_warmup(kong_config)
       return nil, err
     end
   end
+
+  local ok, err = cache_warmup.warm_services_dns(kong_config.db_cache_warmup_entities)
+  if not ok then
+    return nil, err
+  end
+
   return true
 end
 

--- a/spec/01-unit/01-db/08-cache_warmup_spec.lua
+++ b/spec/01-unit/01-db/08-cache_warmup_spec.lua
@@ -125,7 +125,7 @@ describe("cache_warmup", function()
     assert.same(kong.cache:get("777", nil, function() return "nope" end), "nope")
   end)
 
-  it("warms up DNS when caching services", function()
+  it("warms up DNS", function()
     local cache_table = {}
     local db_data = {
       ["my_entity"] = {
@@ -156,6 +156,7 @@ describe("cache_warmup", function()
     cache_warmup._mock_kong(kong)
 
     assert.truthy(cache_warmup.execute({"my_entity", "services"}))
+    assert.truthy(cache_warmup.warm_services_dns())
 
     ngx.sleep(0) -- yield so that async DNS caching happens
 


### PR DESCRIPTION
### Summary

Just an alternative approach to #4656.

- Warms up all the workers DNS on startup (not just worker 0)
- Warms up all services DNS on router rebuild

Not sure if it is worth it. DNS will get warmed on use after all. But if someone wants to benchmark it here is a PR that you can try. You should perhaps benchmark the initial latency of a first request and latency of request after adding a service with a new host.

But... I don't know if this is really wanted, and if not I propose even removing DNS warming on worker 0 during `service` entities warming.