### PR TITLE
feat(api) create service when creating a route

### DIFF
--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -108,7 +108,7 @@ return {
                        },
                      }, },
     { tags             = typedefs.tags },
-    { service = { type = "foreign", reference = "services" }, },
+    { service = { type = "foreign", reference = "services", creatable = true }, },
   },
 
   entity_checks = {

--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -66,6 +66,7 @@ local field_schema = {
   { default = { type = "self" }, },
   { abstract = { type = "boolean" }, },
   { generate_admin_api = { type = "boolean" }, },
+  { creatable = { type = "boolean" }, },
   { legacy = { type = "boolean" }, },
 }
 


### PR DESCRIPTION
### Summary

Creates service when creating an route, e.g. this works:
```
http :8001/routes paths=/ service.url=http://www.example.org/ -f
```

This has shortcomings, e.g. this:
```
http :8001/routes paths=/ service.name=existing-service service.url=http://www.example.org/ -f
```

May resolve by name to existing-service (which may have different url than `http://www.example.org/`, and the `url` will not be updated, should it)?

Also
```
http :8001/routes paths=/ service.id=<inexisting-uuid> service.url=http://www.example.org/ -f
```

Gives error about id not found (this can be fixed with read-before write, or perhaps by doing upsert).

So this is more for discussion. It is usable as is, but may cause make API bit strange on some edges. Perhaps we can work it out here.
