### PR TITLE
Feat/change rate lim opts for dbless

### DIFF
--- a/kong/plugins/rate-limiting/schema.lua
+++ b/kong/plugins/rate-limiting/schema.lua
@@ -1,3 +1,4 @@
+local kong = kong
 local typedefs = require "kong.db.schema.typedefs"
 
 
@@ -22,6 +23,10 @@ local function validate_periods_order(config)
   return true
 end
 
+local conf_db = kong and kong.configuration and kong.configuration.database
+local default_policy = conf_db == "off" and "local" or "cluster"
+local valid_policies = conf_db == "off" and { "local", "redis" } or
+                      { "local", "cluster", "redis" }
 
 return {
   name = "rate-limiting",
@@ -44,9 +49,9 @@ return {
           }, },
           { policy = {
               type = "string",
-              default = "cluster",
+              default = default_policy,
               len_min = 0,
-              one_of = { "local", "cluster", "redis" },
+              one_of = valid_policies,
           }, },
           { fault_tolerant = { type = "boolean", default = true }, },
           { redis_host = typedefs.host },

--- a/spec/03-plugins/23-rate-limiting/01-schema_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/01-schema_spec.lua
@@ -1,3 +1,4 @@
+local helpers = require "spec.helpers"
 local schema_def = require "kong.plugins.rate-limiting.schema"
 local v = require("spec.helpers").validate_plugin_config_schema
 
@@ -14,6 +15,20 @@ describe("Plugin: rate-limiting (schema)", function()
     local ok, _, err = v(config, schema_def)
     assert.truthy(ok)
     assert.is_nil(err)
+  end)
+
+  it("proper database strategy/policy combination", function()
+    if helpers.db.strategy == "off" then
+      local config = { policy = "cluster", second = 10, }
+      local ok, err = v(config, schema_def)
+      assert.falsy(ok)
+      assert.equal("expected one of: local, redis", err.config.policy)
+      config = { policy = "local", second = 10, }
+      assert(v(config, schema_def))
+    else
+      local config = { policy = "cluster", second = 10, }
+      assert(v(config, schema_def))
+    end
   end)
 
   describe("errors", function()


### PR DESCRIPTION
### Summary

rate-limiting plugin now accepts only "local" or "redis" as policy options when kong is running in dbless mode.

### Full changelog

* rate-limiting plugin schema now checks the database strategy to define acceptable policies.
* Added test case to validate policies usage in different database strategies.