### PR TITLE
chore(deps) bump several plugins on removal of `BasePlugin` dependency

### DIFF
--- a/kong-1.2.0rc2-0.rockspec
+++ b/kong-1.2.0rc2-0.rockspec
@@ -37,11 +37,11 @@ dependencies = {
   "lua-resty-cookie == 0.1.0",
   "lua-resty-mlcache == 2.4.0",
   -- external Kong plugins
-  "kong-plugin-azure-functions ~> 0.3",
-  "kong-plugin-kubernetes-sidecar-injector ~> 0.1",
+  "kong-plugin-azure-functions ~> 0.4",
+  "kong-plugin-kubernetes-sidecar-injector ~> 0.2",
   "kong-plugin-zipkin ~> 0.1",
-  "kong-plugin-serverless-functions ~> 0.2",
-  "kong-prometheus-plugin ~> 0.3",
+  "kong-plugin-serverless-functions ~> 0.3",
+  "kong-prometheus-plugin ~> 0.4",
   "kong-proxy-cache-plugin ~> 1.2",
   "kong-plugin-request-transformer ~> 1.2",
 }


### PR DESCRIPTION
### Summary

These were bumped:

- `kong-plugin-azure-functions` to `~> 0.4`
- `kong-plugin-kubernetes-sidecar-injector` to `~> 0.2`
- `kong-plugin-serverless-functions` to `~> 0.3`
- `kong-prometheus-plugin` to `~> 0.4`,

The `kong-plugin-zipkin` is still using `BasePlugin` and was not
bumped here as it uses multiple levels of inheritance.

There was no need to bump these plugins:

- `kong-proxy-cache-plugin`
- `kong-plugin-request-transformer`

Because they were moved to Kong as of `1.2.0`.