### PR TITLE
feat(conf) add `deferred`, `bind` and `reuseport` listen flags

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -130,6 +130,14 @@
                          # - `transparent` will cause kong to listen to, and
                          #   respond from, any and all IP addresses and ports
                          #   you configure in iptables.
+                         # - `deferred` instructs to use a deferred accept on
+                         #   Linux (the TCP_DEFER_ACCEPT socket option).
+                         # - `bind` instructs to make a separate bind() call
+                         #   for a given address:port pair.
+                         # - `reuseport` instructs to create an individual
+                         #   listening socket for each worker process
+                         #   allowing a kernel to distribute incoming
+                         #   connections between worker processes
                          #
                          # This value can be set to `off`, thus disabling
                          # the HTTP/HTTPS proxy port for this node.
@@ -165,6 +173,12 @@
                          # - `transparent` will cause kong to listen to, and
                          #   respond from, any and all IP addresses and ports
                          #   you configure in iptables.
+                         # - `bind` instructs to make a separate bind() call
+                         #   for a given address:port pair.
+                         # - `reuseport` instructs to create an individual
+                         #   listening socket for each worker process
+                         #   allowing a kernel to distribute incoming
+                         #   connections between worker processes
                          #
                          # **Note:** The `ssl` suffix is not supported,
                          # and each address/port will accept TCP with or
@@ -200,8 +214,19 @@
                          #   enabled.
                          # - `http2` will allow for clients to open HTTP/2
                          #   connections to Kong's proxy server.
-                         # - Finally, `proxy_protocol` will enable usage of the
+                         # - `proxy_protocol` will enable usage of the
                          #   PROXY protocol for a given address/port.
+                         # - `transparent` will cause kong to listen to, and
+                         #   respond from, any and all IP addresses and ports
+                         #   you configure in iptables.
+                         # - `deferred` instructs to use a deferred accept on
+                         #   Linux (the TCP_DEFER_ACCEPT socket option).
+                         # - `bind` instructs to make a separate bind() call
+                         #   for a given address:port pair.
+                         # - `reuseport` instructs to create an individual
+                         #   listening socket for each worker process
+                         #   allowing a kernel to distribute incoming
+                         #   connections between worker processes
                          #
                          # This value can be set to `off`, thus disabling
                          # the Admin interface for this node, enabling a

--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -865,8 +865,10 @@ local function load(path, custom_conf)
   end
 
   do
-    local http_flags = { "ssl", "http2", "proxy_protocol", "transparent" }
-    local stream_flags = { "proxy_protocol", "transparent" }
+    local http_flags = { "ssl", "http2", "proxy_protocol", "transparent",
+                         "deferred", "bind", "reuseport" }
+    local stream_flags = { "proxy_protocol", "transparent", "bind",
+                           "reuseport" }
 
     -- extract ports/listen ips
     conf.proxy_listeners, err = parse_listeners(conf.proxy_listen, http_flags)

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -474,26 +474,26 @@ describe("Configuration loader", function()
         admin_listen = "127.0.0.1"
       })
       assert.is_nil(conf)
-      assert.equal("admin_listen must be of form: [off] | <ip>:<port> [ssl] [http2] [proxy_protocol] [transparent], [... next entry ...]", err)
+      assert.equal("admin_listen must be of form: [off] | <ip>:<port> [ssl] [http2] [proxy_protocol] [transparent] [deferred] [bind] [reuseport], [... next entry ...]", err)
 
       conf, err = conf_loader(nil, {
         proxy_listen = "127.0.0.1"
       })
       assert.is_nil(conf)
-      assert.equal("proxy_listen must be of form: [off] | <ip>:<port> [ssl] [http2] [proxy_protocol] [transparent], [... next entry ...]", err)
+      assert.equal("proxy_listen must be of form: [off] | <ip>:<port> [ssl] [http2] [proxy_protocol] [transparent] [deferred] [bind] [reuseport], [... next entry ...]", err)
     end)
     it("rejects empty string in listen addresses", function()
       local conf, err = conf_loader(nil, {
         admin_listen = ""
       })
       assert.is_nil(conf)
-      assert.equal("admin_listen must be of form: [off] | <ip>:<port> [ssl] [http2] [proxy_protocol] [transparent], [... next entry ...]", err)
+      assert.equal("admin_listen must be of form: [off] | <ip>:<port> [ssl] [http2] [proxy_protocol] [transparent] [deferred] [bind] [reuseport], [... next entry ...]", err)
 
       conf, err = conf_loader(nil, {
         proxy_listen = ""
       })
       assert.is_nil(conf)
-      assert.equal("proxy_listen must be of form: [off] | <ip>:<port> [ssl] [http2] [proxy_protocol] [transparent], [... next entry ...]", err)
+      assert.equal("proxy_listen must be of form: [off] | <ip>:<port> [ssl] [http2] [proxy_protocol] [transparent] [deferred] [bind] [reuseport], [... next entry ...]", err)
     end)
     it("errors when dns_resolver is not a list in ipv4/6[:port] format", function()
       local conf, err = conf_loader(nil, {

--- a/spec/01-unit/04-prefix_handler_spec.lua
+++ b/spec/01-unit/04-prefix_handler_spec.lua
@@ -149,6 +149,27 @@ describe("NGINX conf compiler", function()
       assert.matches("listen 0.0.0.0:9000 proxy_protocol;", kong_nginx_conf, nil, true)
       assert.matches("real_ip_header%s+proxy_protocol;", kong_nginx_conf)
     end)
+    it("enables deferred", function()
+      local conf = assert(conf_loader(helpers.test_conf_path, {
+        proxy_listen = "0.0.0.0:9000 deferred",
+      }))
+      local kong_nginx_conf = prefix_handler.compile_kong_conf(conf)
+      assert.matches("listen 0.0.0.0:9000 deferred;", kong_nginx_conf, nil, true)
+    end)
+    it("enables bind", function()
+      local conf = assert(conf_loader(helpers.test_conf_path, {
+        proxy_listen = "0.0.0.0:9000 bind",
+      }))
+      local kong_nginx_conf = prefix_handler.compile_kong_conf(conf)
+      assert.matches("listen 0.0.0.0:9000 bind;", kong_nginx_conf, nil, true)
+    end)
+    it("enables reuseport", function()
+      local conf = assert(conf_loader(helpers.test_conf_path, {
+        proxy_listen = "0.0.0.0:9000 reuseport",
+      }))
+      local kong_nginx_conf = prefix_handler.compile_kong_conf(conf)
+      assert.matches("listen 0.0.0.0:9000 reuseport;", kong_nginx_conf, nil, true)
+    end)
     it("disables SSL", function()
       local conf = assert(conf_loader(helpers.test_conf_path, {
         proxy_listen = "127.0.0.1:8000",


### PR DESCRIPTION
### Summary

On `http` you can now give new listen flags:
- `deferred`
- `bind`
- `reuseport`

On `stream` you can now give new listen flags:
- `bind`
- `reuseport`

Deferred is not supported on `stream` that's why it is not there.

### Issues resolved

Fix #4452
