### PR TITLE
feat(schema) support removing fields in records without migrations

### DIFF
--- a/kong/db/dao/plugins.lua
+++ b/kong/db/dao/plugins.lua
@@ -93,7 +93,7 @@ end
 
 
 function Plugins:update(primary_key, entity, options)
-  local rbw_entity = self.strategy:select(primary_key, options) -- ignore errors
+  local rbw_entity = self.super.select(self, primary_key, options) -- ignore errors
   if rbw_entity then
     entity = self.schema:merge_values(entity, rbw_entity)
   end
@@ -107,7 +107,7 @@ end
 
 
 function Plugins:upsert(primary_key, entity, options)
-  local rbw_entity = self.strategy:select(primary_key, options) -- ignore errors
+  local rbw_entity = self.super.select(self, primary_key, options) -- ignore errors
   if rbw_entity then
     entity = self.schema:merge_values(entity, rbw_entity)
   end

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1546,6 +1546,13 @@ function Schema:process_auto_fields(data, context, nulls)
     or self.entity_checks)
   then
     read_before_write = true
+
+  elseif context == "select" then
+    for key in pairs(data) do
+      if not self.fields[key] then
+        data[key] = nil
+      end
+    end
   end
 
   return data, nil, read_before_write

--- a/spec/01-unit/01-db/01-schema/01-schema_spec.lua
+++ b/spec/01-unit/01-db/01-schema/01-schema_spec.lua
@@ -2469,7 +2469,37 @@ describe("schema", function()
             foo = "bla",
           }
         }, output)
+      end)
 
+      it("removes fields that have been removed from the schema (on select context)", function()
+        local Test = Schema.new({
+          name = "test",
+          subschema_key = "name",
+          fields = {
+            { name = { type = "string", required = true, } },
+            { config = { type = "record", abstract = true } },
+          }
+        })
+        assert(Test:new_subschema("my_subschema", {
+          fields = {
+            { config = {
+              type = "record",
+              fields = {
+                { foo = { type = "string" } },
+              },
+              default = { foo = "bla" }
+            } }
+          }
+        }))
+
+        local input = {
+          name = "my_subschema",
+          config = { foo = "hello", bar = "world" },
+        }
+
+        local output = Test:process_auto_fields(input, "select")
+        input.config.bar = nil
+        assert.same(input, output)
       end)
     end)
   end)


### PR DESCRIPTION
### Summary

What it does is that it removes fields that are not part of the `record` fields from values returned from strategies on `Schema:process_auto_fields` on `select` context (e.g. when read-before-write entities are used).

It allows removal of fields from records without needing to make a migration too.