### PR TITLE
feat(db) support unique constraint on foreign fields

### DIFF
--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -439,7 +439,8 @@ local function generate_foreign_key_methods(schema)
   local methods = {}
 
   for name, field in schema:each_field() do
-    if field.type == "foreign" then
+    local field_is_foreign = field.type == "foreign"
+    if field_is_foreign then
       validate_foreign_key_is_single_primary_key(field)
 
       local page_method_name = "page_for_" .. name
@@ -527,8 +528,7 @@ local function generate_foreign_key_methods(schema)
           validate_options_type(options)
         end
 
-        local ok, errors = field.schema:validate_primary_key(foreign_key)
-
+        local ok, errors = schema:validate_field(field, foreign_key)
         if not ok then
           local err_t = self.errors:invalid_primary_key(errors)
           return iteration.failed(tostring(err_t), err_t)
@@ -550,8 +550,9 @@ local function generate_foreign_key_methods(schema)
 
         return iteration.by_row(self, pager, size, options)
       end
+    end
 
-    elseif field.unique or schema.endpoint_key == name then
+    if field.unique or schema.endpoint_key == name then
       methods["select_by_" .. name] = function(self, unique_value, options)
         validate_unique_type(unique_value, name, field)
 
@@ -559,14 +560,18 @@ local function generate_foreign_key_methods(schema)
           validate_options_type(options)
         end
 
-        local ok, err = schema:validate_field(field, unique_value)
+        local ok, errors = schema:validate_field(field, unique_value)
         if not ok then
-          local err_t = self.errors:invalid_unique(name, err)
+          if field_is_foreign then
+            local err_t = self.errors:invalid_foreign_key(errors)
+            return nil, tostring(err_t), err_t
+          end
+
+          local err_t = self.errors:invalid_unique(name, errors)
           return nil, tostring(err_t), err_t
         end
 
         if options ~= nil then
-          local errors
           ok, errors = validate_options_value(options, schema, "select")
           if not ok then
             local err_t = self.errors:invalid_options(errors)
@@ -594,9 +599,14 @@ local function generate_foreign_key_methods(schema)
           validate_options_type(options)
         end
 
-        local ok, err = schema:validate_field(field, unique_value)
+        local ok, errors = schema:validate_field(field, unique_value)
         if not ok then
-          local err_t = self.errors:invalid_unique(name, err)
+          if field_is_foreign then
+            local err_t = self.errors:invalid_foreign_key(errors)
+            return nil, tostring(err_t), err_t
+          end
+
+          local err_t = self.errors:invalid_unique(name, errors)
           return nil, tostring(err_t), err_t
         end
 
@@ -630,9 +640,14 @@ local function generate_foreign_key_methods(schema)
           validate_options_type(options)
         end
 
-        local ok, err = schema:validate_field(field, unique_value)
+        local ok, errors = schema:validate_field(field, unique_value)
         if not ok then
-          local err_t = self.errors:invalid_unique(name, err)
+          if field_is_foreign then
+            local err_t = self.errors:invalid_foreign_key(errors)
+            return nil, tostring(err_t), err_t
+          end
+
+          local err_t = self.errors:invalid_unique(name, errors)
           return nil, tostring(err_t), err_t
         end
 
@@ -665,14 +680,18 @@ local function generate_foreign_key_methods(schema)
           validate_options_type(options)
         end
 
-        local ok, err = schema:validate_field(field, unique_value)
+        local ok, errors = schema:validate_field(field, unique_value)
         if not ok then
-          local err_t = self.errors:invalid_unique(name, err)
+          if field_is_foreign then
+            local err_t = self.errors:invalid_foreign_key(errors)
+            return nil, tostring(err_t), err_t
+          end
+
+          local err_t = self.errors:invalid_unique(name, errors)
           return nil, tostring(err_t), err_t
         end
 
         if options ~= nil then
-          local errors
           ok, errors = validate_options_value(options, schema, "delete")
           if not ok then
             local err_t = self.errors:invalid_options(errors)

--- a/kong/db/errors.lua
+++ b/kong/db/errors.lua
@@ -42,6 +42,7 @@ local ERRORS              = {
   FOREIGN_KEYS_UNRESOLVED = 13, -- foreign key(s) could not be resolved
   DECLARATIVE_CONFIG      = 14, -- error parsing declarative configuration
   TRANSFORMATION_ERROR    = 15, -- error with dao transformations
+  INVALID_FOREIGN_KEY     = 16,
 }
 
 
@@ -64,6 +65,7 @@ local ERRORS_NAMES                 = {
   [ERRORS.FOREIGN_KEYS_UNRESOLVED] = "foreign keys unresolved",
   [ERRORS.DECLARATIVE_CONFIG]      = "invalid declarative configuration",
   [ERRORS.TRANSFORMATION_ERROR]    = "transformation error",
+  [ERRORS.INVALID_FOREIGN_KEY]     = "invalid foreign key",
 }
 
 
@@ -184,6 +186,17 @@ function _M:invalid_primary_key(primary_key)
   local message = fmt("invalid primary key: '%s'", pl_pretty(primary_key, ""))
 
   return new_err_t(self, ERRORS.INVALID_PRIMARY_KEY, message, primary_key)
+end
+
+
+function _M:invalid_foreign_key(foreign_key)
+  if type(foreign_key) ~= "table" then
+    error("foreign_key must be a table", 2)
+  end
+
+  local message = fmt("invalid foreign key: '%s'", pl_pretty(foreign_key, ""))
+
+  return new_err_t(self, ERRORS.INVALID_FOREIGN_KEY, message, foreign_key)
 end
 
 

--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -290,6 +290,7 @@ local attribute_types = {
     ["string"] = true,
     ["number"] = true,
     ["integer"] = true,
+    ["foreign"] = true,
   },
   abstract = {
     ["string"] = true,

--- a/kong/db/strategies/cassandra/init.lua
+++ b/kong/db/strategies/cassandra/init.lua
@@ -920,14 +920,23 @@ function _mt:select_by_field(field_name, field_value, options)
   if err then
     return nil, err
   end
-  local select_cql = fmt(cql, field_name .. " = ?")
-  local bind_args = new_tab(1, 0)
-  local field = self.schema.fields[field_name]
 
+  local field
   if field_name == "cache_key" then
     field = cache_key_field
+  else
+    field = self.schema.fields[field_name]
+    if field
+      and field.reference
+      and self.foreign_keys_db_columns[field_name]
+      and self.foreign_keys_db_columns[field_name][1]
+    then
+      field_name = self.foreign_keys_db_columns[field_name][1].col_name
+    end
   end
 
+  local select_cql = fmt(cql, field_name .. " = ?")
+  local bind_args = new_tab(1, 0)
   bind_args[1] = serialize_arg(field, field_value)
 
   return _select(self, select_cql, bind_args)
@@ -1258,6 +1267,13 @@ do
 
     for _, field_name, field in self.each_non_pk_field() do
       if entity[field_name] ~= nil then
+        if field.unique and entity[field_name] ~= null then
+          local _, err_t = check_unique(self, primary_key, entity, field_name)
+          if err_t then
+            return nil, err_t
+          end
+        end
+
         if field.type == "foreign" then
           local foreign_pk = entity[field_name]
 
@@ -1273,13 +1289,6 @@ do
           serialize_foreign_pk(db_columns, args, args_names, foreign_pk)
 
         else
-          if field.unique and entity[field_name] ~= null then
-            local _, err_t = check_unique(self, primary_key, entity, field_name)
-            if err_t then
-              return nil, err_t
-            end
-          end
-
           insert(args, serialize_arg(field, entity[field_name]))
           insert(args_names, field_name)
         end

--- a/kong/db/strategies/off/init.lua
+++ b/kong/db/strategies/off/init.lua
@@ -183,6 +183,11 @@ end
 
 
 local function select_by_field(self, field, value)
+  if type(value) == "table" then
+    local _
+    _, value = next(value)
+  end
+
   local key = self.schema.name .. "|" .. field .. ":" .. value
   return select_by_key(self, key)
 end

--- a/spec/01-unit/01-db/02-db-errors_spec.lua
+++ b/spec/01-unit/01-db/02-db-errors_spec.lua
@@ -64,6 +64,31 @@ describe("DB Errors", function()
     end)
 
 
+    describe("INVALID_FOREIGN_KEY", function()
+      local pk = {
+        id = "missing",
+        id2 = "missing2",
+      }
+
+      local err_t = e:invalid_foreign_key(pk)
+
+      it("creates", function()
+        assert.same({
+          code = Errors.codes.INVALID_FOREIGN_KEY,
+          name = "invalid foreign key",
+          strategy = "some_strategy",
+          message = [[invalid foreign key: '{id2="missing2",id="missing"}']],
+          fields = pk,
+        }, err_t)
+      end)
+
+      it("__tostring", function()
+        local s = fmt("[%s] %s", err_t.strategy, err_t.message)
+        assert.equals(s, tostring(err_t))
+      end)
+    end)
+
+
     describe("SCHEMA_VIOLATION", function()
       local schema_errors = {
         foo = "expected an integer",

--- a/spec/02-integration/03-db/10-db_unique_foreign_spec.lua
+++ b/spec/02-integration/03-db/10-db_unique_foreign_spec.lua
@@ -1,0 +1,356 @@
+local Errors  = require "kong.db.errors"
+local helpers = require "spec.helpers"
+local utils   = require "kong.tools.utils"
+
+
+local fmt = string.format
+
+
+for _, strategy in helpers.each_strategy() do
+  describe("kong.db [#" .. strategy .. "]", function()
+    local _, db
+    local unique_foreigns
+    local unique_references
+
+    lazy_setup(function()
+      _, db = helpers.get_db_utils(strategy, {
+        "unique_foreigns",
+        "unique_references",
+      }, {
+        "unique-foreign"
+      })
+
+      local env = {}
+      env.database = strategy
+      env.plugins = env.plugins or "unique-foreign"
+
+      local lua_path = [[ KONG_LUA_PATH_OVERRIDE="./spec/fixtures/migrations/?.lua;]] ..
+                       [[./spec/fixtures/migrations/?/init.lua;]]..
+                       [[./spec/fixtures/custom_plugins/?.lua;]]..
+                       [[./spec/fixtures/custom_plugins/?/init.lua;" ]]
+
+      local cmdline = "migrations up -c " .. helpers.test_conf_path
+      local _, code, _, stderr = helpers.kong_exec(cmdline, env, true, lua_path)
+      assert.same(0, code)
+      assert.equal("", stderr)
+
+      unique_foreigns = {}
+      unique_references = {}
+
+      for i = 1, 5 do
+        local unique_foreign = assert(db.unique_foreigns:insert({
+          name = "unique_" .. i,
+        }))
+
+        local unique_reference = assert(db.unique_references:insert({
+          note = "note_" .. i,
+          unique_foreign = {
+            id = unique_foreign.id
+          }
+        }))
+
+        unique_foreigns[i] = unique_foreign
+        unique_references[i] = unique_reference
+      end
+    end)
+
+    describe("Unique Reference", function()
+      describe(":select_by_unique_foreign()", function()
+        -- no I/O
+        it("errors on invalid arg", function()
+          assert.has_error(function()
+            db.unique_references:select_by_unique_foreign(123)
+          end, "unique_foreign must be a table")
+        end)
+
+        -- I/O
+        it("returns existing Unique Foreign", function()
+          for i = 1, 5 do
+            local unique_reference, err, err_t = db.unique_references:select_by_unique_foreign({
+              id = unique_foreigns[i].id,
+            })
+
+            assert.is_nil(err)
+            assert.is_nil(err_t)
+
+            assert.same(unique_references[i], unique_reference)
+          end
+        end)
+
+        it("returns nothing on non-existing Unique Foreign", function()
+          for i = 1, 5 do
+            local unique_reference, err, err_t = db.unique_references:select_by_unique_foreign({
+              id = utils.uuid()
+            })
+
+            assert.is_nil(err)
+            assert.is_nil(err_t)
+            assert.is_nil(unique_reference)
+          end
+        end)
+      end)
+
+      describe(":update_by_unique_foreign()", function()
+        -- no I/O
+        it("errors on invalid arg", function()
+          assert.has_error(function()
+            db.unique_references:update_by_unique_foreign(123)
+          end, "unique_foreign must be a table")
+        end)
+
+        it("errors on invalid values", function()
+          local unique_reference, err, err_t = db.unique_references:update_by_unique_foreign({
+            id = unique_foreigns[1].id,
+          }, {
+            note = 123,
+          })
+          assert.is_nil(unique_reference)
+          local message = "schema violation (note: expected a string)"
+          assert.equal(fmt("[%s] %s", strategy, message), err)
+          assert.same({
+            code        = Errors.codes.SCHEMA_VIOLATION,
+            name        = "schema violation",
+            message     = message,
+            strategy    = strategy,
+            fields      = {
+              note  = "expected a string",
+            }
+          }, err_t)
+        end)
+
+        -- I/O
+        it("returns not found error", function()
+          local uuid = utils.uuid()
+          local unique_reference, err, err_t = db.unique_references:update_by_unique_foreign({
+            id = uuid,
+          }, {
+            note = "hello",
+          })
+          assert.is_nil(unique_reference)
+          local message = fmt(
+            [[[%s] could not find the entity with '{unique_foreign={id="%s"}}']],
+            strategy, uuid)
+          assert.equal(message, err)
+          assert.equal(Errors.codes.NOT_FOUND, err_t.code)
+        end)
+
+        it("updates an existing Unique Reference", function()
+          local unique_reference, err, err_t = db.unique_references:update_by_unique_foreign({
+              id = unique_foreigns[1].id,
+            }, {
+            note = "note updated",
+          })
+          assert.is_nil(err_t)
+          assert.is_nil(err)
+          assert.equal("note updated", unique_reference.note)
+
+          local unique_reference_in_db, err, err_t = db.unique_references:select({
+            id = unique_reference.id
+          })
+          assert.is_nil(err_t)
+          assert.is_nil(err)
+          assert.equal("note updated", unique_reference_in_db.note)
+        end)
+
+        it("cannot update a Unique Reference to be an already existing Unique Foreign", function()
+          local updated_service, _, err_t = db.unique_references:update_by_unique_foreign({
+            id = unique_foreigns[1].id,
+          }, {
+            unique_foreign = {
+              id = unique_foreigns[2].id,
+            }
+          })
+          assert.is_nil(updated_service)
+          assert.same({
+            code     = Errors.codes.UNIQUE_VIOLATION,
+            name     = "unique constraint violation",
+            message  = fmt([[UNIQUE violation detected on '{unique_foreign={id="%s"}}']], unique_foreigns[2].id),
+            strategy = strategy,
+            fields   = {
+              unique_foreign = {
+                id = unique_foreigns[2].id,
+              }
+            }
+          }, err_t)
+        end)
+      end)
+
+      describe(":upsert_by_unique_foreign()", function()
+        -- no I/O
+        it("errors on invalid arg", function()
+          assert.has_error(function()
+            db.unique_references:upsert_by_unique_foreign(123)
+          end, "unique_foreign must be a table")
+        end)
+
+        it("errors on invalid values", function()
+          local unique_reference, err, err_t = db.unique_references:upsert_by_unique_foreign({
+            id = unique_foreigns[1].id,
+          }, {
+            note = 123,
+          })
+          assert.is_nil(unique_reference)
+          local message = "schema violation (note: expected a string)"
+          assert.equal(fmt("[%s] %s", strategy, message), err)
+          assert.same({
+            code        = Errors.codes.SCHEMA_VIOLATION,
+            name        = "schema violation",
+            message     = message,
+            strategy    = strategy,
+            fields      = {
+              note  = "expected a string",
+            }
+          }, err_t)
+        end)
+
+        -- I/O
+        it("returns not found error", function()
+          local uuid = utils.uuid()
+          local unique_reference, err, err_t = db.unique_references:upsert_by_unique_foreign({
+            id = uuid,
+          }, {
+            note = "hello",
+          })
+          assert.is_nil(unique_reference)
+          local message = fmt(
+            [[[%s] the foreign key '{id="%s"}' does not reference an existing 'unique_foreigns' entity.]],
+            strategy, uuid)
+          assert.equal(message, err)
+          assert.equal(Errors.codes.FOREIGN_KEY_VIOLATION, err_t.code)
+        end)
+
+        it("upserts an existing Unique Reference", function()
+          local unique_reference, err, err_t = db.unique_references:upsert_by_unique_foreign({
+            id = unique_foreigns[1].id,
+          }, {
+            note = "note updated",
+          })
+          assert.is_nil(err_t)
+          assert.is_nil(err)
+          assert.equal("note updated", unique_reference.note)
+
+          local unique_reference_in_db, err, err_t = db.unique_references:select({
+            id = unique_reference.id
+          })
+          assert.is_nil(err_t)
+          assert.is_nil(err)
+          assert.equal("note updated", unique_reference_in_db.note)
+        end)
+
+        it("unique foreign given with entity is ignored when upserting by unique foreign", function()
+          -- TODO: this is slightly unexpected, but it has its uses when thinking about idempotency
+          --       of `PUT`. This has been like that with other DAO methods do, but perhaps we want
+          --       to revisit this later.
+          local unique_reference, err, err_t = db.unique_references:upsert_by_unique_foreign({
+            id = unique_foreigns[1].id,
+          }, {
+            unique_foreign = {
+              id = unique_foreigns[2].id,
+            }
+          })
+
+          assert.is_nil(err_t)
+          assert.is_nil(err)
+          assert.equal(unique_foreigns[1].id, unique_reference.unique_foreign.id)
+        end)
+      end)
+
+      describe(":update()", function()
+        it("cannot update a Unique Reference to be an already existing Unique Foreign", function()
+          local updated_unique_reference, _, err_t = db.unique_references:update({
+            id = unique_references[1].id,
+          }, {
+            unique_foreign = {
+              id = unique_foreigns[2].id,
+            }
+          })
+
+          assert.is_nil(updated_unique_reference)
+          assert.same({
+            code     = Errors.codes.UNIQUE_VIOLATION,
+            name     = "unique constraint violation",
+            message  = fmt([[UNIQUE violation detected on '{unique_foreign={id="%s"}}']], unique_foreigns[2].id),
+            strategy = strategy,
+            fields   = {
+              unique_foreign = {
+                id = unique_foreigns[2].id,
+              }
+            }
+          }, err_t)
+        end)
+
+        it("changes a Unique Reference to point to a new Unique Foreign", function()
+          local unique_foreign = assert(db.unique_foreigns:insert({
+            name = "new unique foreign",
+          }))
+
+          local updated_unique_reference, err, err_t = db.unique_references:update({
+            id = unique_references[1].id,
+          }, {
+            note = "updated note",
+            unique_foreign = {
+              id = unique_foreign.id,
+            },
+          })
+
+          assert.is_nil(err_t)
+          assert.is_nil(err)
+          assert.equal("updated note", updated_unique_reference.note)
+          assert.equal(unique_foreign.id, updated_unique_reference.unique_foreign.id)
+        end)
+      end)
+
+      describe(":delete_by_unique_foreign()", function()
+        local unique_foreign
+        local unique_reference
+
+        lazy_setup(function()
+          unique_foreign = assert(db.unique_foreigns:insert({
+            name = "test",
+          }))
+
+          unique_reference = assert(db.unique_references:insert({
+            note = "test",
+            unique_foreign = {
+              id = unique_foreign.id
+            }
+          }))
+        end)
+
+        -- no I/O
+        it("errors on invalid arg", function()
+          assert.has_error(function()
+            db.unique_references:delete_by_unique_foreign(123)
+          end, "unique_foreign must be a table")
+        end)
+
+        -- I/O
+        it("returns nothing if the Unique Foreign does not exist", function()
+          local ok, err, err_t = db.unique_references:delete_by_unique_foreign({
+            id = utils.uuid()
+          })
+          assert.is_true(ok)
+          assert.is_nil(err_t)
+          assert.is_nil(err)
+        end)
+
+        it("deletes an existing Unique Reference", function()
+          local ok, err, err_t = db.unique_references:delete_by_unique_foreign({
+            id = unique_foreign.id,
+          })
+          assert.is_nil(err_t)
+          assert.is_nil(err)
+          assert.is_true(ok)
+
+          local unique_reference, err, err_t = db.unique_references:select({
+            id = unique_reference.id
+          })
+          assert.is_nil(err_t)
+          assert.is_nil(err)
+          assert.is_nil(unique_reference)
+        end)
+      end)
+    end)
+
+  end) -- kong.db [strategy]
+end

--- a/spec/fixtures/custom_plugins/kong/plugins/unique-foreign/daos.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/unique-foreign/daos.lua
@@ -1,0 +1,24 @@
+local typedefs = require "kong.db.schema.typedefs"
+
+
+return {
+  {
+    name = "unique_foreigns",
+    primary_key = { "id" },
+    admin_api_name = "unique-foreigns",
+    fields = {
+      { id = typedefs.uuid },
+      { name = { type = "string" }, },
+    },
+  },
+  {
+    name = "unique_references",
+    primary_key = { "id" },
+    admin_api_name = "unique-references",
+    fields = {
+      { id = typedefs.uuid },
+      { note = { type = "string" }, },
+      { unique_foreign = { type = "foreign", reference = "unique_foreigns", on_delete = "cascade", unique = true }, },
+    },
+  },
+}

--- a/spec/fixtures/custom_plugins/kong/plugins/unique-foreign/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/unique-foreign/handler.lua
@@ -1,0 +1,3 @@
+return {
+  PRIORITY = 1
+}

--- a/spec/fixtures/custom_plugins/kong/plugins/unique-foreign/migrations/000_base_unique_foreign.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/unique-foreign/migrations/000_base_unique_foreign.lua
@@ -1,0 +1,33 @@
+return {
+  postgres = {
+    up = [[
+      CREATE TABLE IF NOT EXISTS "unique_foreigns" (
+        "id"   UUID  PRIMARY KEY,
+        "name" TEXT
+      );
+
+      CREATE TABLE IF NOT EXISTS "unique_references" (
+        "id"                 UUID   PRIMARY KEY,
+        "note"               TEXT,
+        "unique_foreign_id"  UUID   UNIQUE        REFERENCES "unique_foreigns" ("id") ON DELETE CASCADE
+      );
+    ]],
+  },
+
+  cassandra = {
+    up = [[
+      CREATE TABLE IF NOT EXISTS unique_foreigns (
+        id          uuid PRIMARY KEY,
+        name        text
+      );
+
+      CREATE TABLE IF NOT EXISTS unique_references (
+        id                 uuid   PRIMARY KEY,
+        note               text,
+        unique_foreign_id  uuid
+      );
+
+      CREATE INDEX IF NOT EXISTS ON unique_references(unique_foreign_id);
+    ]],
+  },
+}

--- a/spec/fixtures/custom_plugins/kong/plugins/unique-foreign/migrations/init.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/unique-foreign/migrations/init.lua
@@ -1,0 +1,3 @@
+return {
+  "000_base_unique_foreign",
+}

--- a/spec/fixtures/custom_plugins/kong/plugins/unique-foreign/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/unique-foreign/schema.lua
@@ -1,0 +1,12 @@
+return {
+  name = "unique-foreign",
+  fields = {
+    {
+      config = {
+        type = "record",
+        fields = {
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Summary

Adds support for unique foreign key fields in `schema` like:
```lua
{ service = { type = "foreign", reference = "services", unique = true, }, },
```

Also generates all the normal `unique` `DAO` functions for `unique` foreign keys:
- `select_by_[service]`
- `update_by_[service]`
- `upsert_by_[service]`
- `delete_by_[service]` 

Where `[service]` is the foreign field with `unique=true`.

This PR also adds new error `invalid foreign key` and changes the code to use it where it should.