### PR TITLE
fix(dao) convert null/nil to empty string when generating cache_key from table

### DIFF
--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -1103,13 +1103,11 @@ function DAO:cache_key(key, arg2, arg3, arg4, arg5)
   for _, name in ipairs(source) do
     local field = self.schema.fields[name]
     local value = key[name]
-    if field.type == "foreign" then
+    if value == null or value == nil then
+      value = ""
+    elseif field.type == "foreign" then
       -- FIXME extract foreign key, do not assume `id`
-      if value == null or value == nil then
-        value = ""
-      else
-        value = value.id
-      end
+      value = value.id
     end
     values[i] = tostring(value)
     i = i + 1

--- a/spec/01-unit/01-db/04-dao_spec.lua
+++ b/spec/01-unit/01-db/04-dao_spec.lua
@@ -37,6 +37,17 @@ local non_nullable_schema_definition = {
   }
 }
 
+local optional_cache_key_fields_schema = {
+  name = "Foo",
+  primary_key = { "a" },
+  cache_key = { "b", "u" },
+  fields = {
+    { a = { type = "number" }, },
+    { b = { type = "string" }, },
+    { u = { type = "string" }, },
+  },
+}
+
 local mock_db = {}
 
 
@@ -387,4 +398,25 @@ describe("DAO", function()
     end)
   end)
 
+  describe("cache_key", function()
+
+    it("converts null in composite cache_key to empty string", function()
+      local schema = assert(Schema.new(optional_cache_key_fields_schema))
+      local dao = DAO.new(mock_db, schema, {}, errors)
+
+      -- setting u as an explicit null
+      local data = { a = 42, b = "foo", u = null }
+      local cache_key = dao:cache_key(data)
+      assert.equals("Foo:foo::::", cache_key)
+    end)
+
+    it("converts nil in composite cache_key to empty string", function()
+      local schema = assert(Schema.new(optional_cache_key_fields_schema))
+      local dao = DAO.new(mock_db, schema, {}, errors)
+
+      local data = { a = 42, b = "foo", u = nil }
+      local cache_key = dao:cache_key(data)
+      assert.equals("Foo:foo::::", cache_key)
+    end)
+  end)
 end)


### PR DESCRIPTION
### Summary

This PR corrects an issue with cache_key generation when a schema defines a composite cache_key with optional fields that are not type `foreign`. The issues occurs when calling `DAO:cache_key` with `key` parameter of type `table` containing properties with value `nil` or `null`:

Example Schema
```
local schema = {
  name = "Foo",
  primary_key = { "a" },
  cache_key = { "b", "u" },
  fields = {
    { a = { type = "number" }, },
    { b = { type = "string" }, }, -- optional cache_key component
    { u = { type = "string" }, }, -- optional cache_key component
  },
}
```

nil
```
dao:cache_key({a = 1, b = "foo", u = ngx.null})
 -- 'Foo:foo:userdata: NULL:::'
```

null
```
dao:cache_key({a = 1, b = "foo", u = nil})
 -- 'Foo:foo:nil:::'
```

This PR converts nil/null cache_key components to an empty string, resulting in a cache_key output: 

nil/null
```
'Foo:foo::::'
```

### Full changelog

* convert null/nil to empty string when generating cache_key from table
* add regression test for nil/null in composite cache_key

