### PR TITLE
fix(proxy) do not clear upgrade header with websockets, fix #4718

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1042,8 +1042,8 @@ return {
         local redirect_status_code = route.https_redirect_status_code or 426
 
         if redirect_status_code == 426 then
-          ngx.header["connection"] = "Upgrade"
-          ngx.header["upgrade"]    = "TLS/1.2, HTTP/1.1"
+          header["Connection"] = "Upgrade"
+          header["Upgrade"]    = "TLS/1.2, HTTP/1.1"
           return kong.response.exit(426, { message = "Please use HTTPS protocol" })
         end
 
@@ -1051,7 +1051,7 @@ return {
           redirect_status_code == 302 or
           redirect_status_code == 307 or
           redirect_status_code == 308 then
-          ngx.header["Location"] = "https://" .. forwarded_host .. var.request_uri
+          header["Location"] = "https://" .. forwarded_host .. var.request_uri
           return kong.response.exit(redirect_status_code)
         end
       end
@@ -1348,7 +1348,8 @@ return {
         end
       end
 
-      if var.upstream_http_upgrade then
+      if var.upstream_http_upgrade and
+         var.upstream_http_upgrade ~= var.upstream_upgrade then
         header["Upgrade"] = nil
       end
 

--- a/spec/02-integration/05-proxy/09-websockets_spec.lua
+++ b/spec/02-integration/05-proxy/09-websockets_spec.lua
@@ -38,6 +38,59 @@ for _, strategy in helpers.each_strategy() do
       return wc
     end
 
+    local function check_headers(host, port)
+      local is_kong = (host == helpers.get_proxy_ip(false) and
+                       port == helpers.get_proxy_port(false)) or
+                      (host == helpers.get_proxy_ip(true) and
+                       port == helpers.get_proxy_port(true))
+
+      local encode_base64 = ngx.encode_base64
+      local rand = math.random
+      local char = string.char
+      local sock = assert(ngx.socket.tcp())
+      local path = is_kong and "/up-ws" or "/ws"
+
+      assert(sock:connect(host, port))
+
+      local bytes = char(rand(256) - 1, rand(256) - 1, rand(256) - 1,
+                         rand(256) - 1, rand(256) - 1, rand(256) - 1,
+                         rand(256) - 1, rand(256) - 1, rand(256) - 1,
+                         rand(256) - 1, rand(256) - 1, rand(256) - 1,
+                         rand(256) - 1, rand(256) - 1, rand(256) - 1,
+                         rand(256) - 1)
+
+      local key = encode_base64(bytes)
+      local req = "GET " .. path .. " HTTP/1.1\r\nUpgrade: websocket\r\nHost: "
+        .. host .. ":" .. port
+        .. "\r\nSec-WebSocket-Key: " .. key
+        .. "\r\nSec-WebSocket-Version: 13"
+        .. "\r\nConnection: Upgrade\r\n\r\n"
+
+      assert(sock:send(req))
+
+      local header_reader = sock:receiveuntil("\r\n\r\n")
+      local header = assert(header_reader())
+      assert(sock:close())
+
+      assert.equal(true, string.find(header, "HTTP/1.1 101 Switching Protocols") ~= nil, 1, true)
+      assert.equal(true, string.find(header, "Connection: upgrade") ~= nil, 1, true)
+      assert.equal(true, string.find(header, "Upgrade: websocket") ~= nil, 1, true)
+
+      if is_kong then
+        assert.equal(true, string.find(header, "Via: kong") ~= nil, 1, true)
+      end
+    end
+
+    describe("headers", function()
+      it("returns correct headers on handshake without Kong", function()
+        check_headers("127.0.0.1", "15555")
+      end)
+
+      it("returns correct headers on handshake with Kong", function()
+        check_headers(helpers.get_proxy_ip(false), helpers.get_proxy_port(false))
+      end)
+    end)
+
     describe("text", function()
       local function send_text_and_get_echo(uri)
         local payload = { message = "hello websocket" }


### PR DESCRIPTION
### Summary

Ensures that `Upgrade` header is not cleared with `websockets`.

### Issues resolved

Fix #4718
