### PR TITLE
fix(db) snis dao to set correct array metatable on non-empty arrays

### DIFF
--- a/kong/db/dao/snis.lua
+++ b/kong/db/dao/snis.lua
@@ -85,7 +85,7 @@ end
 
 -- Returns the name list for a given certificate
 function _SNIs:list_for_certificate(cert_pk, options)
-  local name_list = setmetatable({}, cjson.empty_array_mt)
+  local name_list = setmetatable({}, cjson.array_mt)
 
   for sni, err, err_t in self:each_for_certificate(cert_pk, 1000, options) do
     if err then


### PR DESCRIPTION
### Summary

Fixes `snis` dao to set correct metatable on non-empty arrays:
`cjson.empty_array_mt` to `cjson.array_mt`