### PR TITLE
docs(conf) fix formatting of kong.conf.default

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -734,12 +734,12 @@
                                  # Accepted values are:
                                  #
                                  # - `strict`: the router will be rebuilt
-                                 # synchronously, causing incoming requests to
-                                 # be delayed until the rebuild is finished.
+                                 #   synchronously, causing incoming requests to
+                                 #   be delayed until the rebuild is finished.
                                  # - `eventual`: the router will be rebuilt
-                                 # asynchronously via a recurring background
-                                 # job running every second inside of each
-                                 # worker.
+                                 #   asynchronously via a recurring background
+                                 #   job running every second inside of each
+                                 #   worker.
                                  #
                                  # Note that `strict` ensures that all workers
                                  # of a given node will always proxy requests


### PR DESCRIPTION
Minor adjustment to the formatting, to match the Markdown format expected by the autodoc documentation generator for https://docs.konghq.com.
