### PR TITLE
test(*) add KONG_SPEC_REDIS_HOST env var

### DIFF
--- a/bin/busted
+++ b/bin/busted
@@ -28,7 +28,8 @@ if not os.getenv("KONG_BUSTED_RESPAWNED") then
     end
 
     local var = line:match("^(KONG_[^=]*)")
-    if var then
+    local var_for_spec = line:match("^(KONG_SPEC_[^=]*)")
+    if var and not var_for_spec then
       -- remove existing KONG_xxx and KONG_TEST_xxx variables; prepend
       table.insert(script, 1, "unset " .. var)
     end

--- a/spec/03-plugins/23-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/04-access_spec.lua
@@ -3,7 +3,7 @@ local timestamp      = require "kong.tools.timestamp"
 local cjson          = require "cjson"
 
 
-local REDIS_HOST     = "127.0.0.1"
+local REDIS_HOST     = helpers.redis_host
 local REDIS_PORT     = 6379
 local REDIS_PASSWORD = ""
 local REDIS_DATABASE = 1

--- a/spec/03-plugins/23-rate-limiting/05-integration_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/05-integration_spec.lua
@@ -2,7 +2,7 @@ local helpers = require "spec.helpers"
 local redis = require "resty.redis"
 
 
-local REDIS_HOST = "127.0.0.1"
+local REDIS_HOST = helpers.redis_host
 local REDIS_PORT = 6379
 local REDIS_DB_1 = 1
 local REDIS_DB_2 = 2

--- a/spec/03-plugins/24-response-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/24-response-rate-limiting/04-access_spec.lua
@@ -2,7 +2,7 @@ local cjson          = require "cjson"
 local helpers        = require "spec.helpers"
 
 
-local REDIS_HOST     = "127.0.0.1"
+local REDIS_HOST     = helpers.redis_host
 local REDIS_PORT     = 6379
 local REDIS_PASSWORD = ""
 local REDIS_DATABASE = 1

--- a/spec/03-plugins/24-response-rate-limiting/05-integration_spec.lua
+++ b/spec/03-plugins/24-response-rate-limiting/05-integration_spec.lua
@@ -2,7 +2,7 @@ local helpers = require "spec.helpers"
 local redis = require "resty.redis"
 
 
-local REDIS_HOST = "127.0.0.1"
+local REDIS_HOST = helpers.redis_host
 local REDIS_PORT = 6379
 local REDIS_DB_1 = 1
 local REDIS_DB_2 = 2

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -1682,6 +1682,7 @@ return {
 
   mock_upstream_stream_port     = MOCK_UPSTREAM_STREAM_PORT,
   mock_upstream_stream_ssl_port = MOCK_UPSTREAM_STREAM_SSL_PORT,
+  redis_host = os.getenv("KONG_SPEC_REDIS_HOST") or "127.0.0.1",
 
   -- Kong testing helpers
   execute = exec,


### PR DESCRIPTION
### Summary

Adds a KONG_SPEC_REDIS_HOST env var to make it easy to bind it in tests.

### Full changelog

* change the hardcoded addrs for redis to a helper variable
* change bin/busted so it doesn't override `KONG_SPEC.*` env vars

