### PR TITLE
fixes: better handling of C* config validation and serial_consistency option

### DIFF
--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -295,11 +295,11 @@ local function check_and_infer(conf)
   ---------------------
 
   if conf.database == "cassandra" then
-    if conf.cassandra_lb_policy == "DCAwareRoundRobin"
+    if string.find(conf.cassandra_lb_policy, "DCAware", nil, true)
        and not conf.cassandra_local_datacenter
     then
       errors[#errors + 1] = "must specify 'cassandra_local_datacenter' when " ..
-                          "DCAwareRoundRobin policy is in use"
+                            conf.cassandra_lb_policy .. " policy is in use"
     end
 
     for _, contact_point in ipairs(conf.cassandra_contact_points) do

--- a/kong/db/strategies/cassandra/connector.lua
+++ b/kong/db/strategies/cassandra/connector.lua
@@ -175,6 +175,15 @@ function CassandraConnector.new(kong_config)
     cluster_options.lb_policy = policy.new(kong_config.cassandra_local_datacenter)
   end
 
+  local serial_consistency
+
+  if string.find(kong_config.cassandra_lb_policy, "DCAware", nil, true) then
+    serial_consistency = cassandra.consistencies.local_serial
+
+  else
+    serial_consistency = cassandra.consistencies.serial
+  end
+
   local cluster, err = Cluster.new(cluster_options)
   if not cluster then
     return nil, err
@@ -188,7 +197,7 @@ function CassandraConnector.new(kong_config)
         cassandra.consistencies[kong_config.cassandra_consistency:lower()],
       read_consistency =
         cassandra.consistencies[kong_config.cassandra_consistency:lower()],
-      serial_consistency = cassandra.consistencies.serial, -- TODO: or local_serial
+      serial_consistency = serial_consistency,
     },
     connection = nil, -- created by connect()
   }

--- a/spec/01-unit/01-db/05-cassandra_spec.lua
+++ b/spec/01-unit/01-db/05-cassandra_spec.lua
@@ -1,7 +1,38 @@
 local connector = require "kong.db.strategies.cassandra.connector"
+local cassandra = require "cassandra"
+local helpers = require "spec.helpers"
 
 
 describe("kong.db [#cassandra] connector", function()
+  describe(".new()", function()
+    local test_conf = helpers.test_conf
+    local test_conf_lb_policy = test_conf.cassandra_lb_policy
+    local test_conf_local_datacenter = test_conf.cassandra_local_datacenter
+
+    lazy_teardown(function()
+      test_conf.cassandra_lb_policy = test_conf_lb_policy
+      test_conf.cassandra_local_datacenter = test_conf_local_datacenter
+    end)
+
+    it("sets serial_consistency to serial if LB policy is not DCAware", function()
+      for _, policy in ipairs({ "RoundRobin", "RequestRoundRobin" }) do
+        test_conf.cassandra_lb_policy = policy
+        local c = assert(connector.new(test_conf))
+        assert.equal(cassandra.consistencies.serial, c.opts.serial_consistency)
+      end
+    end)
+
+    it("sets serial_consistency to local_serial if LB policy is DCAware", function()
+      test_conf.cassandra_local_datacenter = "dc1"
+
+      for _, policy in ipairs({ "DCAwareRoundRobin", "RequestDCAwareRoundRobin" }) do
+        test_conf.cassandra_lb_policy = policy
+        local c = assert(connector.new(test_conf))
+        assert.equal(cassandra.consistencies.local_serial, c.opts.serial_consistency)
+      end
+    end)
+  end)
+
   describe(":infos()", function()
     it("returns infos db_ver always with two digit groups divided with dot (.)", function()
       local infos = connector.infos{ major_version = 2, major_minor_version = "2.10" }

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -807,13 +807,16 @@ describe("Configuration loader", function()
       local conf = assert(conf_loader(helpers.test_conf_path))
       assert.equal("postgres", conf.database)
     end)
-    it("requires cassandra_local_datacenter if DCAwareRoundRobin is in use", function()
-      local conf, err = conf_loader(nil, {
-        database            = "cassandra",
-        cassandra_lb_policy = "DCAwareRoundRobin"
-      })
-      assert.is_nil(conf)
-      assert.equal("must specify 'cassandra_local_datacenter' when DCAwareRoundRobin policy is in use", err)
+    it("requires cassandra_local_datacenter if DCAware LB policy is in use", function()
+      for _, policy in ipairs({ "DCAwareRoundRobin", "RequestDCAwareRoundRobin" }) do
+        local conf, err = conf_loader(nil, {
+          database            = "cassandra",
+          cassandra_lb_policy = policy,
+        })
+        assert.is_nil(conf)
+        assert.equal("must specify 'cassandra_local_datacenter' when " ..
+                     policy .. " policy is in use", err)
+      end
     end)
     it("honors path if provided even if a default file exists", function()
       conf_loader.add_default_path("spec/fixtures/to-strip.conf")


### PR DESCRIPTION
1. fix(conf) ensure 'cassandra_local_datacenter' must be specified for all DCAware LB policies
2. fix(db) ensure C* serial consistency is local when DCAware LB policy is in use

The hard-coded setting in 2. could cause some LWT (e.g. `INSERT INTO ... IF NOT EXISTS`) to fail with unavailable exceptions when running atop of a multi-DC cluster with cross-datacenter network issues.

An error that one can observe on such issues looks like so:

    could not execute insertion query: [Unavailable exception] Cannot achieve consistency level QUORUM