### PR TITLE
rate-limiting plugin support at service level

### DIFF
--- a/kong/plugins/rate-limiting/handler.lua
+++ b/kong/plugins/rate-limiting/handler.lua
@@ -25,7 +25,9 @@ RateLimitingHandler.VERSION = "2.0.0"
 local function get_identifier(conf)
   local identifier
 
-  if conf.limit_by == "consumer" then
+  if conf.limit_by == "service" then
+    identifier = ""
+  elseif conf.limit_by == "consumer" then
     identifier = (kong.client.get_consumer() or
                   kong.client.get_credential() or
                   EMPTY).id
@@ -33,9 +35,11 @@ local function get_identifier(conf)
   elseif conf.limit_by == "credential" then
     identifier = (kong.client.get_credential() or
                   EMPTY).id
+  elseif conf.limit_by == "ip" then
+    identifier = kong.client.get_forwarded_ip()
   end
 
-  return identifier or kong.client.get_forwarded_ip()
+  return identifier
 end
 
 

--- a/kong/plugins/rate-limiting/schema.lua
+++ b/kong/plugins/rate-limiting/schema.lua
@@ -39,8 +39,8 @@ return {
           { year = { type = "number", gt = 0 }, },
           { limit_by = {
               type = "string",
-              default = "consumer",
-              one_of = { "consumer", "credential", "ip" },
+              default = "service",
+              one_of = { "consumer", "credential", "ip", "service" },
           }, },
           { policy = {
               type = "string",


### PR DESCRIPTION
rate-limiting plugin support at service level

The original code can't support rate limiting at service level, it's not satisfied the plugin usage.


