### PR TITLE
fix(routes/upstreams) healthcheck support by IP:port

### DIFF
--- a/kong-1.2.0-0.rockspec
+++ b/kong-1.2.0-0.rockspec
@@ -30,7 +30,7 @@ dependencies = {
   "luaossl == 20190612",
   "luasyslog == 1.0.0",
   "lua_pack == 1.0.5",
-  "lua-resty-dns-client == 3.0.2",
+  "lua-resty-dns-client == 4.0.0",
   "lua-resty-worker-events == 0.3.3",
   "lua-resty-mediador == 0.1.2",
   "lua-resty-healthcheck == 0.6.2",

--- a/kong/api/routes/upstreams.lua
+++ b/kong/api/routes/upstreams.lua
@@ -38,7 +38,7 @@ local function post_health(self, db, is_healthy)
     return kong.response.exit(404, { message = "Not found" })
   end
 
-  local ok, err = db.targets:post_health(upstream, target, is_healthy)
+  local ok, err = db.targets:post_health(upstream, target, self.params.address, is_healthy)
   if not ok then
     return kong.response.exit(400, { message = err })
   end
@@ -106,6 +106,18 @@ return {
   },
 
   ["/upstreams/:upstreams/targets/:targets/unhealthy"] = {
+    POST = function(self, db)
+      return post_health(self, db, false)
+    end,
+  },
+
+  ["/upstreams/:upstreams/targets/:targets/:address/healthy"] = {
+    POST = function(self, db)
+      return post_health(self, db, true)
+    end,
+  },
+
+  ["/upstreams/:upstreams/targets/:targets/:address/unhealthy"] = {
     POST = function(self, db)
       return post_health(self, db, false)
     end,

--- a/spec/01-unit/09-balancer_spec.lua
+++ b/spec/01-unit/09-balancer_spec.lua
@@ -451,17 +451,18 @@ describe("Balancer", function()
         { host = "localhost", port = 1111, health = false },
       }
       for _, t in ipairs(tests) do
-        assert(balancer.post_health(upstream_ph, t.host, t.port, t.health))
+        assert(balancer.post_health(upstream_ph, t.host, nil, t.port, t.health))
         local health_info = assert(balancer.get_upstream_health("ph"))
         local response = t.health and "HEALTHY" or "UNHEALTHY"
-        assert.same(response, health_info[t.host .. ":" .. t.port])
+        assert.same(response,
+                    health_info[t.host .. ":" .. t.port].addresses[1].health)
       end
     end)
 
     it("requires hostname if that was used in the Target", function()
-      local ok, err = balancer.post_health(upstream_ph, "127.0.0.1", 1111, true)
+      local ok, err = balancer.post_health(upstream_ph, "127.0.0.1", nil, 1111, true)
       assert.falsy(ok)
-      assert.match(err, "target not found for 127.0.0.1:1111")
+      assert.match(err, "No host found by: '127.0.0.1:1111'")
     end)
 
     it("fails if upstream/balancer doesn't exist", function()

--- a/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -377,7 +377,14 @@ describe("Admin API #" .. strategy, function()
           assert.equal(targets[3].target, res.data[2].target)
           assert.equal(targets[2].target, res.data[3].target)
           for i = 1, n do
-            assert.equal(health, res.data[i].health)
+            if res.data[i].data ~= nil and res.data[i].data.addresses ~= nil then
+              for j = 1, #res.data[i].data.addresses do
+                assert.equal(health, res.data[i].data.addresses[j].health)
+              end
+
+            else
+              assert.equal(health, res.data[i].health)
+            end
           end
         end
       end

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -1625,9 +1625,9 @@ end
 
 
 -- Restart Kong, reusing declarative config when using database=off
-local function restart_kong(env, tables)
+local function restart_kong(env, tables, fixtures)
   stop_kong(env.prefix, true, true)
-  return start_kong(env, tables, true)
+  return start_kong(env, tables, true, fixtures)
 end
 
 


### PR DESCRIPTION
- Added routes to set healthy/unhealthy status for each record's IP entry.
- Report health status for each record's IP entry individually.