### PR TITLE
feat(jwt) add support to custom header names

### DIFF
--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -14,12 +14,12 @@ local JwtHandler = {}
 
 
 JwtHandler.PRIORITY = 1005
-JwtHandler.VERSION = "2.0.0"
+JwtHandler.VERSION = "0.2.1"
 
 
 --- Retrieve a JWT in a request.
 -- Checks for the JWT in URI parameters, then in cookies, and finally
--- in the `Authorization` header.
+-- in the configured header_names (defaults to `[Authorization]`).
 -- @param request ngx request object
 -- @param conf Plugin configuration
 -- @return token JWT token contained in request (can be a table) or nil
@@ -40,20 +40,28 @@ local function retrieve_token(conf)
     end
   end
 
-  local authorization_header = kong.request.get_header("authorization")
-  if authorization_header then
-    local iterator, iter_err = re_gmatch(authorization_header, "\\s*[Bb]earer\\s+(.+)")
-    if not iterator then
-      return nil, iter_err
-    end
+  local request_headers = kong.request.get_headers()
+  for _, v in ipairs(conf.header_names) do
+    local token_header = request_headers[v]
+    if token_header then
+      if type(token_header) == "table" then
+        token_header = token_header[1]
+      end
+      local iterator, iter_err = re_gmatch(token_header, "\\s*[Bb]earer\\s+(.+)")
+      if not iterator then
+        ngx.log(ngx.ERR, "[jwt]: ", iter_err)
+        break
+      end
 
-    local m, err = iterator()
-    if err then
-      return nil, err
-    end
+      local m, err = iterator()
+      if err then
+        ngx.log(ngx.ERR, "[jwt]: ", err)
+        break
+      end
 
-    if m and #m > 0 then
-      return m[1]
+      if m and #m > 0 then
+        return m[1]
+      end
     end
   end
 end

--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -14,7 +14,7 @@ local JwtHandler = {}
 
 
 JwtHandler.PRIORITY = 1005
-JwtHandler.VERSION = "0.2.1"
+JwtHandler.VERSION = "2.0.0"
 
 
 --- Retrieve a JWT in a request.
@@ -49,13 +49,13 @@ local function retrieve_token(conf)
       end
       local iterator, iter_err = re_gmatch(token_header, "\\s*[Bb]earer\\s+(.+)")
       if not iterator then
-        ngx.log(ngx.ERR, "[jwt]: ", iter_err)
+        kong.log.err(iter_err)
         break
       end
 
       local m, err = iterator()
       if err then
-        ngx.log(ngx.ERR, "[jwt]: ", err)
+        kong.log.err(err)
         break
       end
 

--- a/kong/plugins/jwt/schema.lua
+++ b/kong/plugins/jwt/schema.lua
@@ -34,6 +34,11 @@ return {
             default = 0,
             between = { 0, 31536000 },
           }, },
+          { header_names = {
+            type = "set",
+            elements = { type = "string" },
+            default = { "authorization" },
+          }, },
         },
       },
     },

--- a/spec/03-plugins/16-jwt/03-access_spec.lua
+++ b/spec/03-plugins/16-jwt/03-access_spec.lua
@@ -38,7 +38,7 @@ for _, strategy in helpers.each_strategy() do
 
       local routes = {}
 
-      for i = 1, 11 do
+      for i = 1, 12 do
         routes[i] = bp.routes:insert {
           hosts = { "jwt" .. i .. ".com" },
         }
@@ -121,6 +121,12 @@ for _, strategy in helpers.each_strategy() do
         name     = "jwt",
         route = { id = routes[11].id },
         config   = { claims_to_verify = {"nbf", "exp"}, maximum_expiration = 300 },
+      })
+
+      plugins:insert({
+        name     = "jwt",
+        route = { id = routes[12].id },
+        config   = { header_names = { "CustomAuthorization" } },
       })
 
       plugins:insert({
@@ -474,6 +480,32 @@ for _, strategy in helpers.each_strategy() do
           }
         })
         assert.res_status(401, res)
+      end)
+      it("returns 200 without cookies but with a JWT token in the CustomAuthorization header", function()
+        PAYLOAD.iss = jwt_secret.key
+        local jwt = jwt_encoder.encode(PAYLOAD, jwt_secret.secret)
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/request",
+          headers = {
+            ["Host"] = "jwt12.com",
+            ["CustomAuthorization"] = "Bearer " .. jwt,
+          }
+        })
+        assert.res_status(200, res)
+      end)
+      it("finds the JWT in the first header occurrence of a duplicated custom authorization header", function()
+        PAYLOAD.iss = jwt_secret.key
+        local jwt = jwt_encoder.encode(PAYLOAD, jwt_secret.secret)
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/request",
+          headers = {
+            ["Host"] = "jwt12.com",
+            ["CustomAuthorization"] = {"Bearer " .. jwt, "Bearer other-token"}
+          }
+        })
+        assert.res_status(200, res)
       end)
       it("finds the JWT if given in URL parameters", function()
         PAYLOAD.iss = jwt_secret.key


### PR DESCRIPTION
### Summary

Replaces #3668 

It allow the jwt plugin to work together with another authentication method that uses the 'Authorization' header

Reference: https://discuss.konghq.com/t/custom-header-on-jwt-plugin/1524

Closes #3668 