### PR TITLE
add feature to jwt plugin:allow set headers from claim

### DIFF
--- a/kong/plugins/jwt/schema.lua
+++ b/kong/plugins/jwt/schema.lua
@@ -27,6 +27,11 @@ return {
                 type = "string",
                 one_of = { "exp", "nbf" },
           }, }, },
+          { headers_to_set = {
+              type = "set",
+              elements = {
+                type = "string"
+          }, }, },
           { anonymous = { type = "string", uuid = true, legacy = true }, },
           { run_on_preflight = { type = "boolean", default = true }, },
           { maximum_expiration = {


### PR DESCRIPTION
### Summary

Add feature to `jwt` plugin: allow set header from claims.

### Full changelog

* [Implement] jwt plugin: allow set header from claims
   if you configure `headers_to_set`(set) , headers with prefix "X-Jwt-Claim-" will be set to the response. For example, if 'sub' and 'app' are configured, and both of them are found in jwt's claims, two headers will be set to the response: `X-Jwt-Claim-Sub` and `X-Jwt-Claim-App`.  

