### PR TITLE
perf(db) cassandra cascade delete to use 1000 as page size

### DIFF
--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -532,11 +532,11 @@ local function generate_foreign_key_methods(schema)
 
         local strategy = self.strategy
 
-        local pager = function(size, offset)
+        local pager = function(size, offset, options)
           return strategy[page_method_name](strategy, foreign_key, size, offset, options)
         end
 
-        return iteration.by_row(self, pager, size)
+        return iteration.by_row(self, pager, size, options)
       end
 
     elseif field.unique or schema.endpoint_key == name then

--- a/kong/db/strategies/cassandra/init.lua
+++ b/kong/db/strategies/cassandra/init.lua
@@ -1461,7 +1461,7 @@ do
         local pager = function(size, offset)
           return strategy[method](strategy, primary_key, size, offset)
         end
-        for row, err in iteration.by_row(self, pager) do
+        for row, err in iteration.by_row(self, pager, 1000) do
           if err then
             return nil, self.errors:database_error("could not gather " ..
                                                    "associated entities " ..
@@ -1522,7 +1522,7 @@ function _mt:delete_by_field(field_name, field_value, options)
 
   local pk = self.schema:extract_pk_values(row)
 
-  return self:delete(pk)
+  return self:delete(pk, options)
 end
 
 


### PR DESCRIPTION
### Summary

Changes Cassandra to use `1000` as a page size for cascading deletes instead of the default `100`. This change may have some impact on #4769.