### PR TITLE
fix(proxy) do not clear upgrade header (case-insensitive), fix #4779

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1349,7 +1349,7 @@ return {
       end
 
       if var.upstream_http_upgrade and
-         var.upstream_http_upgrade ~= var.upstream_upgrade then
+         lower(var.upstream_http_upgrade) ~= lower(var.upstream_upgrade) then
         header["Upgrade"] = nil
       end
 


### PR DESCRIPTION
### Summary

Ensures that `Upgrade` header is not cleared on `websocket`. This is the second patch after the initial patch PR #4719. It seems like some servers send back `Upgrade: WebSocket` instead of `Upgrade: websocket` which caused the proxy to clear the `Upgrade` header. This ensures that the value is compared case-insensitive.

The test is missing as it is a bit tricky to implement that as our mock websocket server always sends the `Upgrade` header back as lower case `websocket` which does not cause this issue. But the fix in itself is rather simple.

### Issues resolved

Fix #4779
