### PR TITLE
chore(deps) bump session plugin to 2.1

### DIFF
--- a/kong-1.2.1-0.rockspec
+++ b/kong-1.2.1-0.rockspec
@@ -44,7 +44,7 @@ dependencies = {
   "kong-prometheus-plugin ~> 0.4",
   "kong-proxy-cache-plugin ~> 1.2",
   "kong-plugin-request-transformer ~> 1.2",
-  "kong-plugin-session ~> 2.0",
+  "kong-plugin-session ~> 2.1",
 }
 build = {
   type = "builtin",


### PR DESCRIPTION
### Summary

Changes:

- style related updates
- small change to make migration a bit more re-entrant
- use kong pdk to read the post args for logout
- remove unused base plugin require
- bump resty session to 2.24
- bump versions on travis ci to make it work with next branch of kong