### PR TITLE
feat(balancer) healthcheck uses ip+port+hostname combo

### DIFF
--- a/kong-1.2.1-0.rockspec
+++ b/kong-1.2.1-0.rockspec
@@ -30,7 +30,7 @@ dependencies = {
   "luaossl == 20190612",
   "luasyslog == 1.0.0",
   "lua_pack == 1.0.5",
-  "lua-resty-dns-client == 3.0.2",
+  "lua-resty-dns-client == 4.0.0",
   "lua-resty-worker-events == 1.0.0",
   "lua-resty-mediador == 0.1.2",
   "lua-resty-healthcheck == 0.6.2",

--- a/kong-1.2.1-0.rockspec
+++ b/kong-1.2.1-0.rockspec
@@ -33,7 +33,7 @@ dependencies = {
   "lua-resty-dns-client == 4.0.0",
   "lua-resty-worker-events == 1.0.0",
   "lua-resty-mediador == 0.1.2",
-  "lua-resty-healthcheck == 0.6.2",
+  "lua-resty-healthcheck == 1.0.0",
   "lua-resty-cookie == 0.1.0",
   "lua-resty-mlcache == 2.4.0",
   -- external Kong plugins

--- a/kong/api/routes/upstreams.lua
+++ b/kong/api/routes/upstreams.lua
@@ -38,7 +38,7 @@ local function post_health(self, db, is_healthy)
     return kong.response.exit(404, { message = "Not found" })
   end
 
-  local ok, err = db.targets:post_health(upstream, target, is_healthy)
+  local ok, err = db.targets:post_health(upstream, target, self.params.address, is_healthy)
   if not ok then
     return kong.response.exit(400, { message = err })
   end
@@ -106,6 +106,18 @@ return {
   },
 
   ["/upstreams/:upstreams/targets/:targets/unhealthy"] = {
+    POST = function(self, db)
+      return post_health(self, db, false)
+    end,
+  },
+
+  ["/upstreams/:upstreams/targets/:targets/:address/healthy"] = {
+    POST = function(self, db)
+      return post_health(self, db, true)
+    end,
+  },
+
+  ["/upstreams/:upstreams/targets/:targets/:address/unhealthy"] = {
     POST = function(self, db)
       return post_health(self, db, false)
     end,

--- a/kong/db/dao/targets.lua
+++ b/kong/db/dao/targets.lua
@@ -252,13 +252,15 @@ function _TARGETS:page_for_upstream_with_health(upstream_pk, ...)
     -- library will issue the callback and the target will change state.
     if health_info[target.target] ~= nil and
       #health_info[target.target].addresses > 0 then
-      target.health = "UNHEALTHY"
+      target.health = "HEALTHCHECKS_OFF"
       -- If any of the target addresses are healthy, then the target is
       -- considered healthy.
       for _, address in ipairs(health_info[target.target].addresses) do
         if address.health == "HEALTHY" then
           target.health = "HEALTHY"
           break
+        elseif address.health == "UNHEALTHY" then
+          target.health = "UNHEALTHY"
         end
 
       end

--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -194,7 +194,7 @@ local function populate_healthchecker(hc, balancer)
         -- Get existing health status which may have been initialized
         -- with data from another worker, and apply to the new balancer.
         local tgt_status = hc:get_target_status(ipaddr, port)
-        balancer:setPeerStatus(tgt_status, ipaddr, port, hostname)
+        balancer:setAddressStatus(tgt_status, ipaddr, port, hostname)
 
       else
         log(ERR, "[healthchecks] failed adding target: ", err)
@@ -217,9 +217,9 @@ do
 
     ------------------------------------------------------------------------------
     -- Callback function that informs the healthchecker when targets are added
-    -- or removed to a balancer.
+    -- or removed to a balancer and when targets health status change.
     -- @param balancer the ring balancer object that triggers this callback.
-    -- @param action "added" or "removed"
+    -- @param action "added", "removed", or "health"
     -- @param address balancer address object
     -- @param ip string
     -- @param port number
@@ -235,8 +235,18 @@ do
       elseif action == "removed" then
         local ok, err = healthchecker:remove_target(ip, port)
         if not ok then
-          log(ERR, "[healthchecks] failed adding a target: ", err)
+          log(ERR, "[healthchecks] failed removing a target: ", err)
         end
+
+      elseif action == "health" then
+        local balancer_status
+        if address then
+          balancer_status = "HEALTHY"
+        else
+          balancer_status = "UNHEALTHY"
+        end
+        log(WARN, "[healthchecks] balancer ", healthchecker.name,
+            " reported health status changed to ", balancer_status)
 
       else
         log(WARN, "[healthchecks] unknown status from balancer: ",
@@ -259,7 +269,7 @@ do
         end
 
         local ok, err
-        ok, err = balancer:setPeerStatus(status, tgt.ip, tgt.port, tgt.hostname)
+        ok, err = balancer:setAddressStatus(status, tgt.ip, tgt.port, tgt.hostname)
 
         local health = status and "healthy" or "unhealthy"
         for _, subscriber in ipairs(healthcheck_subscribers) do
@@ -818,7 +828,8 @@ local function execute(target, ctx)
     ip, port, hostname, handle = balancer:getPeer(dns_cache_only,
                                           target.balancer_handle,
                                           hash_value)
-    if not ip and port == "No peers are available" then
+    if not ip and
+      (port == "No peers are available" or port == "Balancer is unhealthy") then
       return nil, "failure to get a peer from the ring-balancer", 503
     end
     target.hash_value = hash_value
@@ -870,7 +881,7 @@ local function post_health(upstream, hostname, ip, port, is_healthy)
   end
 
   if ip then
-    return balancer:setPeerStatus(is_healthy, ip, port, hostname)
+    return balancer:setAddressStatus(is_healthy, ip, port, hostname)
   end
 
   return balancer:setHostStatus(is_healthy, hostname, port)

--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -853,25 +853,15 @@ end
 -- Update health status and broadcast to workers
 -- @param upstream a table with upstream data: must have `name` and `id`
 -- @param hostname target hostname
+-- @param ip target entry. if nil updates all entries
 -- @param port target port
 -- @param is_healthy boolean: true if healthy, false if unhealthy
 -- @return true if posting event was successful, nil+error otherwise
-local function post_health(upstream, hostname, port, is_healthy)
+local function post_health(upstream, hostname, ip, port, is_healthy)
 
   local balancer = balancers[upstream.id]
   if not balancer then
     return nil, "Upstream " .. tostring(upstream.name) .. " has no balancer"
-  end
-
-  local ip
-  for weight, addr, host in balancer:addressIter() do
-    if weight > 0 and hostname == host.hostname and port == addr.port then
-      ip = addr.ip
-      break
-    end
-  end
-  if not ip then
-    return nil, "target not found for " .. hostname .. ":" .. port
   end
 
   local healthchecker = healthcheckers[balancer]
@@ -879,7 +869,11 @@ local function post_health(upstream, hostname, port, is_healthy)
     return nil, "no healthchecker found for " .. tostring(upstream.name)
   end
 
-  return healthchecker:set_target_status(ip, port, is_healthy)
+  if ip then
+    return balancer:setPeerStatus(is_healthy, ip, port, hostname)
+  end
+
+  return balancer:setHostStatus(is_healthy, hostname, port)
 end
 
 
@@ -953,17 +947,17 @@ local function get_upstream_health(upstream_id)
   end
 
   local health_info = {}
-
-  for weight, addr, host in balancer:addressIter() do
-    if weight > 0 then
-      local health
+  local hosts = balancer.hosts
+  for _, host in ipairs(hosts) do
+    local key = host.hostname .. ":" .. host.port
+    health_info[key] = host:getStatus()
+    for _, address in ipairs(health_info[key].addresses) do
       if using_hc then
-        health = healthchecker:get_target_status(addr.ip, addr.port)
-                 and "HEALTHY" or "UNHEALTHY"
+        address.health = address.healthy and "HEALTHY" or "UNHEALTHY"
       else
-        health = "HEALTHCHECKS_OFF"
+        address.health = "HEALTHCHECKS_OFF"
       end
-      health_info[host.hostname .. ":" .. addr.port] = health
+      address.healthy = nil
     end
   end
 

--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -193,7 +193,7 @@ local function populate_healthchecker(hc, balancer)
       if ok then
         -- Get existing health status which may have been initialized
         -- with data from another worker, and apply to the new balancer.
-        local tgt_status = hc:get_target_status(ipaddr, port)
+        local tgt_status = hc:get_target_status(ipaddr, port, hostname)
         balancer:setAddressStatus(tgt_status, ipaddr, port, hostname)
 
       else
@@ -233,7 +233,7 @@ do
         end
 
       elseif action == "removed" then
-        local ok, err = healthchecker:remove_target(ip, port)
+        local ok, err = healthchecker:remove_target(ip, port, hostname)
         if not ok then
           log(ERR, "[healthchecks] failed removing a target: ", err)
         end
@@ -245,7 +245,7 @@ do
         else
           balancer_status = "UNHEALTHY"
         end
-        log(WARN, "[healthchecks] balancer ", healthchecker.name,
+        log(DEBUG, "[healthchecks] balancer ", healthchecker.name,
             " reported health status changed to ", balancer_status)
 
       else
@@ -291,7 +291,8 @@ do
 
       balancer.report_http_status = function(handle, status)
         local ip, port = handle.address.ip, handle.address.port
-        local _, err = hc:report_http_status(ip, port, status, "passive")
+        local hostname = handle.address.host and handle.address.host.hostname or nil
+        local _, err = hc:report_http_status(ip, port, hostname, status, "passive")
         if err then
           log(ERR, "[healthchecks] failed reporting status: ", err)
         end
@@ -299,7 +300,8 @@ do
 
       balancer.report_tcp_failure = function(handle)
         local ip, port = handle.address.ip, handle.address.port
-        local _, err = hc:report_tcp_failure(ip, port, nil, "passive")
+        local hostname = handle.address.host and handle.address.host.hostname or nil
+        local _, err = hc:report_tcp_failure(ip, port, hostname, nil, "passive")
         if err then
           log(ERR, "[healthchecks] failed reporting status: ", err)
         end
@@ -307,7 +309,8 @@ do
 
       balancer.report_timeout = function(handle)
         local ip, port = handle.address.ip, handle.address.port
-        local _, err = hc:report_timeout(ip, port, "passive")
+        local hostname = handle.address.host and handle.address.host.hostname or nil
+        local _, err = hc:report_timeout(ip, port, hostname, "passive")
         if err then
           log(ERR, "[healthchecks] failed reporting status: ", err)
         end

--- a/spec/01-unit/09-balancer_spec.lua
+++ b/spec/01-unit/09-balancer_spec.lua
@@ -452,17 +452,18 @@ describe("Balancer", function()
         { host = "localhost", port = 1111, health = false },
       }
       for _, t in ipairs(tests) do
-        assert(balancer.post_health(upstream_ph, t.host, t.port, t.health))
+        assert(balancer.post_health(upstream_ph, t.host, nil, t.port, t.health))
         local health_info = assert(balancer.get_upstream_health("ph"))
         local response = t.health and "HEALTHY" or "UNHEALTHY"
-        assert.same(response, health_info[t.host .. ":" .. t.port])
+        assert.same(response,
+                    health_info[t.host .. ":" .. t.port].addresses[1].health)
       end
     end)
 
     it("requires hostname if that was used in the Target", function()
-      local ok, err = balancer.post_health(upstream_ph, "127.0.0.1", 1111, true)
+      local ok, err = balancer.post_health(upstream_ph, "127.0.0.1", nil, 1111, true)
       assert.falsy(ok)
-      assert.match(err, "target not found for 127.0.0.1:1111")
+      assert.match(err, "No host found by: '127.0.0.1:1111'")
     end)
 
     it("fails if upstream/balancer doesn't exist", function()

--- a/spec/01-unit/09-balancer_spec.lua
+++ b/spec/01-unit/09-balancer_spec.lua
@@ -492,17 +492,20 @@ describe("Balancer", function()
       address = {
         ip = "127.0.0.1",
         port = 1111,
+        host = {hostname = "localhost"},
       }}, 429)
     my_balancer.report_http_status({
       address = {
         ip = "127.0.0.1",
         port = 1111,
+        host = {hostname = "localhost"},
       }}, 200)
     balancer.unsubscribe_from_healthcheck_events(cb)
     my_balancer.report_http_status({
       address = {
         ip = "127.0.0.1",
         port = 1111,
+        host = {hostname = "localhost"},
       }}, 429)
     hc:stop()
     assert.same({

--- a/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -377,7 +377,14 @@ describe("Admin API #" .. strategy, function()
           assert.equal(targets[3].target, res.data[2].target)
           assert.equal(targets[2].target, res.data[3].target)
           for i = 1, n do
-            assert.equal(health, res.data[i].health)
+            if res.data[i].data ~= nil and res.data[i].data.addresses ~= nil then
+              for j = 1, #res.data[i].data.addresses do
+                assert.equal(health, res.data[i].data.addresses[j].health)
+              end
+
+            else
+              assert.equal(health, res.data[i].health)
+            end
           end
         end
       end

--- a/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -381,8 +381,6 @@ describe("Admin API #" .. strategy, function()
               for j = 1, #res.data[i].data.addresses do
                 assert.equal(health, res.data[i].data.addresses[j].health)
               end
-
-            else
               assert.equal(health, res.data[i].health)
             end
           end

--- a/spec/02-integration/05-proxy/10-balancer/01-ring-balancer_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer/01-ring-balancer_spec.lua
@@ -691,6 +691,39 @@ for _, strategy in helpers.each_strategy() do
       assert.equals("HEALTHY", health.data[1].data.addresses[1].health)
     end)
 
+    it("a target that has healthchecks disabled", function()
+      -- configure healthchecks
+      begin_testcase_setup(strategy, bp)
+      local upstream_name, upstream_id = add_upstream(bp, {
+        healthchecks = healthchecks_config {
+          passive = {
+            unhealthy = {
+              http_failures = 0,
+              tcp_failures = 0,
+              timeouts = 0,
+            },
+          },
+          active = {
+            healthy = {
+              interval = 0,
+            },
+            unhealthy = {
+              interval = 0,
+            },
+          },
+        }
+      })
+      add_target(bp, upstream_id, "multiple-ips.test", 80)
+      add_api(bp, upstream_name)
+      end_testcase_setup(strategy, bp)
+      local health = get_upstream_health(upstream_name)
+      assert.is.table(health)
+      assert.is.table(health.data)
+      assert.is.table(health.data[1])
+      assert.equals("HEALTHCHECKS_OFF", health.data[1].health)
+      assert.equals("HEALTHCHECKS_OFF", health.data[1].data.addresses[1].health)
+    end)
+
   end)
 
   describe("Ring-balancer #" .. strategy, function()

--- a/spec/02-integration/05-proxy/10-balancer/01-ring-balancer_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer/01-ring-balancer_spec.lua
@@ -56,7 +56,7 @@ local TEST_LOG = false -- extra verbose logging of test server
 local TIMEOUT = -1  -- marker for timeouts in http_server
 
 
-local function direct_request(host, port, path, protocol)
+local function direct_request(host, port, path, protocol, host_header)
   local pok, client = pcall(helpers.http_client, host, port)
   if not pok then
     return nil, "pcall: " .. client .. " : " .. host ..":"..port
@@ -72,7 +72,7 @@ local function direct_request(host, port, path, protocol)
   local res, err = client:send {
     method = "GET",
     path = path,
-    headers = { ["Host"] = "whatever" }
+    headers = { ["Host"] = host_header or host }
   }
   local body = res and res:read_body()
   client:close()
@@ -119,7 +119,7 @@ local function http_server(host, port, counts, test_log, protocol)
   local cmd = "resty --errlog-level error " .. -- silence _G write guard warns
               "spec/fixtures/balancer_https_server.lua " ..
               protocol .. " " .. host .. " " .. port ..
-              " \"" .. cjson.encode(counts) .. "\" " ..
+              " \"" .. cjson.encode(counts):gsub('"', '\\"') .. "\" " ..
               (test_log or "") .. " &"
   os.execute(cmd)
 
@@ -131,8 +131,8 @@ local function http_server(host, port, counts, test_log, protocol)
   until (ngx.now() > hard_timeout) or not err
 
   local server = {}
-  server.done = function()
-    local body = direct_request(host, port, "/shutdown", protocol)
+  server.done = function(_, host_header)
+    local body = direct_request(host, port, "/shutdown", protocol, host_header)
     if body then
       local tbl = assert(cjson.decode(body))
       return true, tbl.ok_responses, tbl.fail_responses, tbl.n_checks
@@ -1333,13 +1333,14 @@ for _, strategy in helpers.each_strategy() do
                   dns_mock = helpers.dns_mock.new()
                 }
 
+                local hostname = "multiple-hosts.test"
                 fixtures.dns_mock:SRV {
-                  name = "multiple-hosts.test",
+                  name = hostname,
                   target = localhost,
                   port = port1,
                 }
                 fixtures.dns_mock:SRV {
-                  name = "multiple-hosts.test",
+                  name = hostname,
                   target = localhost,
                   port = port2,
                 }
@@ -1395,7 +1396,7 @@ for _, strategy in helpers.each_strategy() do
                 local oks, fails = client_requests(SLOTS, api_host)
 
                 -- server2 goes unhealthy
-                direct_request(localhost, port2, "/unhealthy", protocol)
+                direct_request(localhost, port2, "/unhealthy", protocol, hostname)
                 -- Wait until healthchecker detects
                 poll_wait_address_health(upstream_id, "multiple-hosts.test", port1, localhost, port2, "UNHEALTHY")
 
@@ -1407,7 +1408,7 @@ for _, strategy in helpers.each_strategy() do
                 end
 
                 -- server2 goes healthy again
-                direct_request(localhost, port2, "/healthy", protocol)
+                direct_request(localhost, port2, "/healthy", protocol, hostname)
                 -- Give time for healthchecker to detect
                 poll_wait_address_health(upstream_id, "multiple-hosts.test", port1, localhost, port2, "HEALTHY")
 
@@ -1419,8 +1420,8 @@ for _, strategy in helpers.each_strategy() do
                 end
 
                 -- collect server results; hitcount
-                local _, ok1, fail1 = server1:done()
-                local _, ok2, fail2 = server2:done()
+                local _, ok1, fail1 = server1:done(hostname)
+                local _, ok2, fail2 = server2:done(hostname)
 
                 -- verify
                 assert.are.equal(SLOTS * 2, ok1)

--- a/spec/02-integration/05-proxy/10-balancer/01-ring-balancer_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer/01-ring-balancer_spec.lua
@@ -325,21 +325,52 @@ do
 end
 
 
-local function poll_wait_health(upstream_id, host, port, value, admin_port)
-  local hard_timeout = ngx.now() + 10
-  while ngx.now() < hard_timeout do
-    local health = get_upstream_health(upstream_id, admin_port)
-    if health then
-      for _, d in ipairs(health.data) do
-        if d.target == host .. ":" .. port and d.health == value then
-          return
+local poll_wait_health
+local poll_wait_address_health
+do
+  local function poll_wait(upstream_id, host, port, admin_port, fn)
+    local hard_timeout = ngx.now() + 10
+    while ngx.now() < hard_timeout do
+      local health = get_upstream_health(upstream_id, admin_port)
+      if health then
+        for _, d in ipairs(health.data) do
+          if d.target == host .. ":" .. port and fn(d) then
+            return true
+          end
         end
       end
+      ngx.sleep(0.1) -- poll-wait
     end
-    ngx.sleep(0.1) -- poll-wait
+    return false
   end
-  assert(false, "timed out waiting for " .. host .. ":" .. port .. " in " ..
-                upstream_id .. " to become " .. value)
+
+  poll_wait_health = function(upstream_id, host, port, value, admin_port)
+    local ok = poll_wait(upstream_id, host, port, admin_port, function(d)
+      return d.health == value
+    end)
+    if ok then
+      return true
+    end
+    assert(false, "timed out waiting for " .. host .. ":" .. port .. " in " ..
+                  upstream_id .. " to become " .. value)
+  end
+
+  poll_wait_address_health = function(upstream_id, host, port, address_host, address_port, value)
+    local ok = poll_wait(upstream_id, host, port, nil, function(d)
+      for _, ad in ipairs(d.data.addresses) do
+        if ad.ip == address_host
+        and ad.port == address_port
+        and ad.health == value then
+          return true
+        end
+      end
+    end)
+    if ok then
+      return true
+    end
+    assert(false, "timed out waiting for " .. address_host .. ":" .. address_port .. " in " ..
+                  upstream_id .. " to become " .. value)
+  end
 end
 
 
@@ -1203,7 +1234,7 @@ for _, strategy in helpers.each_strategy() do
             end
           end)
 
-          for _, protocol in ipairs({"http"}) do
+          for _, protocol in ipairs({"http", "https"}) do
             it("perform active health checks -- automatic recovery #" .. protocol, function()
               for nchecks = 1, 3 do
 
@@ -1264,6 +1295,121 @@ for _, strategy in helpers.each_strategy() do
                 direct_request(localhost, port2, "/healthy", protocol)
                 -- Give time for healthchecker to detect
                 poll_wait_health(upstream_id, localhost, port2, "HEALTHY")
+
+                -- 3) server1 and server2 take requests again
+                do
+                  local o, f = client_requests(SLOTS, api_host)
+                  oks = oks + o
+                  fails = fails + f
+                end
+
+                -- collect server results; hitcount
+                local _, ok1, fail1 = server1:done()
+                local _, ok2, fail2 = server2:done()
+
+                -- verify
+                assert.are.equal(SLOTS * 2, ok1)
+                assert.are.equal(SLOTS, ok2)
+                assert.are.equal(0, fail1)
+                assert.are.equal(0, fail2)
+
+                assert.are.equal(SLOTS * 3, oks)
+                assert.are.equal(0, fails)
+              end
+            end)
+
+            it("#only perform active health checks on a target that resolves to multiple addresses -- automatic recovery #" .. protocol, function()
+              for nchecks = 1, 3 do
+
+                local port1 = gen_port()
+                local port2 = gen_port()
+
+                local dns_mock_filename = helpers.test_conf.prefix .. "/dns_mock_records.lua"
+                finally(function()
+                  os.remove(dns_mock_filename)
+                end)
+
+                local fixtures = {
+                  dns_mock = helpers.dns_mock.new()
+                }
+
+                fixtures.dns_mock:SRV {
+                  name = "multiple-hosts.test",
+                  target = localhost,
+                  port = port1,
+                }
+                fixtures.dns_mock:SRV {
+                  name = "multiple-hosts.test",
+                  target = localhost,
+                  port = port2,
+                }
+
+                -- restart Kong
+                begin_testcase_setup_update(strategy, bp)
+                helpers.restart_kong({
+                  database   = strategy,
+                  nginx_conf = "spec/fixtures/custom_nginx.template",
+                  lua_ssl_trusted_certificate = "../spec/fixtures/kong_spec.crt",
+                  db_update_frequency = 0.1,
+                  stream_listen = "0.0.0.0:9100",
+                  plugins = "bundled,fail-once-auth",
+                }, nil, fixtures)
+                end_testcase_setup(strategy, bp)
+                ngx.sleep(1)
+
+                -- setup target servers:
+                -- server2 will only respond for part of the test,
+                -- then server1 will take over.
+                local server1_oks = SLOTS * 2
+                local server2_oks = SLOTS
+                local server1 = http_server(localhost, port1, { server1_oks }, nil, protocol)
+                local server2 = http_server(localhost, port2, { server2_oks }, nil, protocol)
+
+                -- configure healthchecks
+                begin_testcase_setup(strategy, bp)
+                local upstream_name, upstream_id = add_upstream(bp, {
+                  healthchecks = healthchecks_config {
+                    active = {
+                      type = protocol,
+                      http_path = "/status",
+                      https_verify_certificate = (protocol == "https" and localhost == "localhost"),
+                      healthy = {
+                        interval = HEALTHCHECK_INTERVAL,
+                        successes = nchecks,
+                      },
+                      unhealthy = {
+                        interval = HEALTHCHECK_INTERVAL,
+                        http_failures = nchecks,
+                      },
+                    }
+                  }
+                })
+                add_target(bp, upstream_id, "multiple-hosts.test", port1) -- port gets overridden at DNS resolution
+                local api_host = add_api(bp, upstream_name, {
+                  service_protocol = protocol
+                })
+
+                end_testcase_setup(strategy, bp)
+
+                -- 1) server1 and server2 take requests
+                local oks, fails = client_requests(SLOTS, api_host)
+
+                -- server2 goes unhealthy
+                direct_request(localhost, port2, "/unhealthy", protocol)
+                -- Wait until healthchecker detects
+                poll_wait_address_health(upstream_id, "multiple-hosts.test", port1, localhost, port2, "UNHEALTHY")
+
+                -- 2) server1 takes all requests
+                do
+                  local o, f = client_requests(SLOTS, api_host)
+                  oks = oks + o
+                  fails = fails + f
+                end
+
+                -- server2 goes healthy again
+                direct_request(localhost, port2, "/healthy", protocol)
+                -- Give time for healthchecker to detect
+                poll_wait_address_health(upstream_id, "multiple-hosts.test", port1, localhost, port2, "HEALTHY")
 
                 -- 3) server1 and server2 take requests again
                 do

--- a/spec/02-integration/05-proxy/10-balancer/01-ring-balancer_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer/01-ring-balancer_spec.lua
@@ -190,6 +190,7 @@ local add_upstream
 local patch_upstream
 local get_upstream
 local get_upstream_health
+local post_target_address_health
 local get_router_version
 local add_target
 local add_api
@@ -256,6 +257,11 @@ do
     if status == 200 then
       return body
     end
+  end
+
+  post_target_address_health = function(upstream_id, target_id, address, mode, forced_port)
+    local path = "/upstreams/" .. upstream_id .. "/targets/" .. target_id .. "/" .. address .. "/" .. mode
+    return api_send("POST", path, {}, forced_port)
   end
 
   get_router_version = function(forced_port)
@@ -454,6 +460,26 @@ for _, strategy in helpers.each_strategy() do
         address = "127.0.0.1",
       }
 
+      fixtures.dns_mock:A {
+        name = "multiple-ips.test",
+        address = "127.0.0.1",
+      }
+      fixtures.dns_mock:A {
+        name = "multiple-ips.test",
+        address = "127.0.0.2",
+      }
+
+      fixtures.dns_mock:SRV {
+        name = "srv-changes-port.test",
+        target = "a-changes-port.test",
+        port = 90,  -- port should fail to connect
+      }
+
+      fixtures.dns_mock:A {
+        name = "a-changes-port.test",
+        address = "127.0.0.3",
+      }
+
       assert(helpers.start_kong({
         database   = strategy,
         nginx_conf = "spec/fixtures/custom_nginx.template",
@@ -507,6 +533,122 @@ for _, strategy in helpers.each_strategy() do
       assert.is.table(health.data)
       assert.is.table(health.data[1])
       assert.equals("UNHEALTHY", health.data[1].health)
+    end)
+
+    it("a target that resolves to 2 IPs reports health separately", function()
+
+      -- configure healthchecks
+      begin_testcase_setup(strategy, bp)
+      local upstream_name, upstream_id = add_upstream(bp, {
+        healthchecks = healthchecks_config {
+          passive = {
+            unhealthy = {
+              tcp_failures = 1,
+            }
+          }
+        }
+      })
+      -- the following port will not be used, will be overwritten by
+      -- the mocked SRV record.
+      add_target(bp, upstream_id, "multiple-ips.test", 80)
+      local api_host = add_api(bp, upstream_name)
+      end_testcase_setup(strategy, bp)
+
+      -- we do not set up servers, since we want the connection to get refused
+      -- Go hit the api with requests, 1x round the balancer
+      local oks, fails, last_status = client_requests(SLOTS, api_host)
+      assert.same(0, oks)
+      assert.same(10, fails)
+      assert.same(503, last_status)
+
+      local health = get_upstream_health(upstream_name)
+      assert.is.table(health)
+      assert.is.table(health.data)
+      assert.is.table(health.data[1])
+      assert.same("127.0.0.1", health.data[1].data.addresses[1].ip)
+      assert.same("127.0.0.2", health.data[1].data.addresses[2].ip)
+      assert.equals("UNHEALTHY", health.data[1].health)
+      assert.equals("UNHEALTHY", health.data[1].data.addresses[1].health)
+      assert.equals("UNHEALTHY", health.data[1].data.addresses[2].health)
+
+      local status = post_target_address_health(upstream_id, "multiple-ips.test:80", "127.0.0.2:80", "healthy")
+      assert.same(204, status)
+
+      health = get_upstream_health(upstream_name)
+      assert.is.table(health)
+      assert.is.table(health.data)
+      assert.is.table(health.data[1])
+      assert.same("127.0.0.1", health.data[1].data.addresses[1].ip)
+      assert.same("127.0.0.2", health.data[1].data.addresses[2].ip)
+      assert.equals("HEALTHY", health.data[1].health)
+      assert.equals("UNHEALTHY", health.data[1].data.addresses[1].health)
+      assert.equals("HEALTHY", health.data[1].data.addresses[2].health)
+
+      local status = post_target_address_health(upstream_id, "multiple-ips.test:80", "127.0.0.2:80", "unhealthy")
+      assert.same(204, status)
+
+      health = get_upstream_health(upstream_name)
+      assert.is.table(health)
+      assert.is.table(health.data)
+      assert.is.table(health.data[1])
+      assert.same("127.0.0.1", health.data[1].data.addresses[1].ip)
+      assert.same("127.0.0.2", health.data[1].data.addresses[2].ip)
+      assert.equals("UNHEALTHY", health.data[1].health)
+      assert.equals("UNHEALTHY", health.data[1].data.addresses[1].health)
+      assert.equals("UNHEALTHY", health.data[1].data.addresses[2].health)
+
+    end)
+
+    it("a target that resolves to an SRV record that changes port", function()
+
+      -- configure healthchecks
+      begin_testcase_setup(strategy, bp)
+      local upstream_name, upstream_id = add_upstream(bp, {
+        healthchecks = healthchecks_config {
+          passive = {
+            unhealthy = {
+              tcp_failures = 1,
+            }
+          }
+        }
+      })
+      -- the following port will not be used, will be overwritten by
+      -- the mocked SRV record.
+      add_target(bp, upstream_id, "srv-changes-port.test", 80)
+      local api_host = add_api(bp, upstream_name)
+      end_testcase_setup(strategy, bp)
+
+      -- we do not set up servers, since we want the connection to get refused
+      -- Go hit the api with requests, 1x round the balancer
+      local oks, fails, last_status = client_requests(SLOTS, api_host)
+      assert.same(0, oks)
+      assert.same(10, fails)
+      assert.same(503, last_status)
+
+      local health = get_upstream_health(upstream_name)
+      assert.is.table(health)
+      assert.is.table(health.data)
+      assert.is.table(health.data[1])
+
+      assert.same("a-changes-port.test", health.data[1].data.addresses[1].ip)
+      assert.same(90, health.data[1].data.addresses[1].port)
+
+      assert.equals("UNHEALTHY", health.data[1].health)
+      assert.equals("UNHEALTHY", health.data[1].data.addresses[1].health)
+
+      local status = post_target_address_health(upstream_id, "srv-changes-port.test:80", "a-changes-port.test:90", "healthy")
+      assert.same(204, status)
+
+      health = get_upstream_health(upstream_name)
+      assert.is.table(health)
+      assert.is.table(health.data)
+      assert.is.table(health.data[1])
+
+      assert.same("a-changes-port.test", health.data[1].data.addresses[1].ip)
+      assert.same(90, health.data[1].data.addresses[1].port)
+
+      assert.equals("HEALTHY", health.data[1].health)
+      assert.equals("HEALTHY", health.data[1].data.addresses[1].health)
     end)
 
   end)

--- a/spec/fixtures/balancer_https_server.lua
+++ b/spec/fixtures/balancer_https_server.lua
@@ -76,8 +76,11 @@ local httpserver = {
           local headers = {}
           local path
           while true do
-            local line = cskt:receive("*l")
-            if not path then
+            local line, err = cskt:receive("*l")
+            if err and err == "closed" then
+              break
+
+            elseif not path then
               path = line:match("(/[^%s]*)")
 
             elseif line and not line:match("^%s*$") then

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -1197,7 +1197,7 @@ do
   dns_mock.__tostring = function(self)
     -- fill array to prevent json encoding errors
     for i = 1, 33 do
-      self[i] = self[i] or true
+      self[i] = self[i] or {}
     end
     local json = assert(cjson.encode(self))
     return json

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -1634,9 +1634,9 @@ end
 
 
 -- Restart Kong, reusing declarative config when using database=off
-local function restart_kong(env, tables)
+local function restart_kong(env, tables, fixtures)
   stop_kong(env.prefix, true, true)
-  return start_kong(env, tables, true)
+  return start_kong(env, tables, true, fixtures)
 end
 
 


### PR DESCRIPTION
- Changes needed for lua-resty-healthcheck 1.0.0 which requires that hostnames
are used combined with IP and port to know exactly which host is being checked.
- lua-resty-healthcheck version bumped in rockspeck.