### PR TITLE
feat(pdk) implemented kong.service.request.set_cert_key()

### DIFF
--- a/.ci/setup_env.sh
+++ b/.ci/setup_env.sh
@@ -25,6 +25,7 @@ kong-ngx-build \
     --prefix $INSTALL_ROOT \
     --openresty $OPENRESTY \
     --openresty-patches $OPENRESTY_PATCHES_BRANCH \
+    --kong-nginx-module $KONG_NGINX_MODULE_BRANCH \
     --luarocks $LUAROCKS \
     --openssl $OPENSSL \
     -j $JOBS

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ env:
     - DOWNLOAD_ROOT=$HOME/download-root
     - INSTALL_CACHE=$HOME/install-cache
     - OPENRESTY_PATCHES_BRANCH=master
+    - KONG_NGINX_MODULE_BRANCH=master
     - KONG_TEST_PG_DATABASE=travis
     - KONG_TEST_PG_USER=postgres
     - JOBS=2

--- a/kong/pdk/init.lua
+++ b/kong/pdk/init.lua
@@ -211,7 +211,7 @@ assert(package.loaded["resty.core"])
 
 local MAJOR_VERSIONS = {
   [1] = {
-    version = "1.1.0",
+    version = "1.2.0",
     modules = {
       "table",
       "node",

--- a/t/01-pdk/09-service/03-set-tls-cert-key.t
+++ b/t/01-pdk/09-service/03-set-tls-cert-key.t
@@ -1,0 +1,85 @@
+use strict;
+use warnings FATAL => 'all';
+use Test::Nginx::Socket::Lua;
+use t::Util;
+
+plan tests => repeat_each() * (blocks() * 3);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: service.set_tls_cert_key() errors if cert is not cdata
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            local pok, err = pcall(pdk.service.set_tls_cert_key, "foo", "bar")
+            ngx.say(err)
+        }
+    }
+--- request
+GET /t
+--- response_body
+chain must be a parsed cdata object
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: service.set_tls_cert_key() errors if key is not cdata
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local PDK = require("kong.pdk")
+            local ffi = require("ffi")
+            local pdk = PDK.new()
+
+            local pok, err = pcall(pdk.service.set_tls_cert_key, ffi.new("void *"), "bar")
+            ngx.say(err)
+        }
+    }
+--- request
+GET /t
+--- response_body
+key must be a parsed cdata object
+--- no_error_log
+[error]
+
+
+
+=== TEST 3: service.set_tls_cert_key() works with valid cert and key
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        access_by_lua_block {
+            local PDK = require("kong.pdk")
+            local ssl = require("ngx.ssl")
+            local pdk = PDK.new()
+
+            local f = assert(io.open("t/certs/test.crt"))
+            local cert_data = f:read("*a")
+            f:close()
+
+            local chain = assert(ssl.parse_pem_cert(cert_data))
+
+            f = assert(io.open("t/certs/test.key"))
+            local key_data = f:read("*a")
+            f:close()
+            local key = assert(ssl.parse_pem_priv_key(key_data))
+
+
+            local ok, err = pdk.service.set_tls_cert_key(chain, key)
+            ngx.say(ok, ", ", err)
+        }
+    }
+--- request
+GET /t
+--- response_body
+true, nil
+--- no_error_log
+[error]


### PR DESCRIPTION
This feature allows plugins to override client certificate used while handshaking with services dynamically.