### PR TITLE
chore(deps) bump worker-events to 1.0.0

### DIFF
--- a/kong-1.2.1-0.rockspec
+++ b/kong-1.2.1-0.rockspec
@@ -31,7 +31,7 @@ dependencies = {
   "luasyslog == 1.0.0",
   "lua_pack == 1.0.5",
   "lua-resty-dns-client == 3.0.2",
-  "lua-resty-worker-events == 0.3.3",
+  "lua-resty-worker-events == 1.0.0",
   "lua-resty-mediador == 0.1.2",
   "lua-resty-healthcheck == 0.6.2",
   "lua-resty-cookie == 0.1.0",

--- a/kong/cache.lua
+++ b/kong/cache.lua
@@ -175,7 +175,11 @@ function _M.new(opts)
             end
           end,
           broadcast = function(channel, data)
-            opts.worker_events.post(channel_name, channel, data)
+            local ok, err = opts.worker_events.post(channel_name, channel, data)
+            if not ok then
+              log(ERR, "failed to post event '", channel_name, "', '",
+                       channel, "': ", err)
+            end
           end
         }
       })

--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -1059,13 +1059,13 @@ function DAO:post_crud_event(operation, entity, old_entity, options)
   end
 
   if self.events then
-    local _, err = self.events.post_local("dao:crud", operation, {
+    local ok, err = self.events.post_local("dao:crud", operation, {
       operation  = operation,
       schema     = self.schema,
       entity     = entity,
       old_entity = old_entity,
     })
-    if err then
+    if not ok then
       log(ERR, "[db] failed to propagate CRUD operation: ", err)
     end
   end

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -168,15 +168,15 @@ local function register_events()
       data.operation)
 
     -- crud:routes
-    local _, err = worker_events.post_local("crud", entity_channel, data)
-    if err then
+    local ok, err = worker_events.post_local("crud", entity_channel, data)
+    if not ok then
       log(ERR, "[events] could not broadcast crud event: ", err)
       return
     end
 
     -- crud:routes:create
-    _, err = worker_events.post_local("crud", entity_operation_channel, data)
-    if err then
+    ok, err = worker_events.post_local("crud", entity_operation_channel, data)
+    if not ok then
       log(ERR, "[events] could not broadcast crud event: ", err)
       return
     end
@@ -256,18 +256,18 @@ local function register_events()
     local operation = data.operation
     local target = data.entity
     -- => to worker_events node handler
-    local _, err = worker_events.post("balancer", "targets", {
+    local ok, err = worker_events.post("balancer", "targets", {
         operation = data.operation,
         entity = data.entity,
       })
-    if err then
+    if not ok then
       log(ERR, "failed broadcasting target ",
         operation, " to workers: ", err)
     end
     -- => to cluster_events handler
     local key = fmt("%s:%s", operation, target.upstream.id)
-    _, err = cluster_events:broadcast("balancer:targets", key)
-    if err then
+    ok, err = cluster_events:broadcast("balancer:targets", key)
+    if not ok then
       log(ERR, "failed broadcasting target ", operation, " to cluster: ", err)
     end
   end, "crud", "targets")
@@ -287,13 +287,13 @@ local function register_events()
   cluster_events:subscribe("balancer:targets", function(data)
     local operation, key = unpack(utils.split(data, ":"))
     -- => to worker_events node handler
-    local _, err = worker_events.post("balancer", "targets", {
+    local ok, err = worker_events.post("balancer", "targets", {
         operation = operation,
         entity = {
           upstream = { id = key },
         }
       })
-    if err then
+    if not ok then
       log(ERR, "failed broadcasting target ", operation, " to workers: ", err)
     end
   end)
@@ -320,11 +320,11 @@ local function register_events()
     local operation = data.operation
     local upstream = data.entity
     -- => to worker_events node handler
-    local _, err = worker_events.post("balancer", "upstreams", {
+    local ok, err = worker_events.post("balancer", "upstreams", {
         operation = data.operation,
         entity = data.entity,
       })
-    if err then
+    if not ok then
       log(ERR, "failed broadcasting upstream ",
         operation, " to workers: ", err)
     end
@@ -350,14 +350,14 @@ local function register_events()
   cluster_events:subscribe("balancer:upstreams", function(data)
     local operation, id, name = unpack(utils.split(data, ":"))
     -- => to worker_events node handler
-    local _, err = worker_events.post("balancer", "upstreams", {
+    local ok, err = worker_events.post("balancer", "upstreams", {
         operation = operation,
         entity = {
           id = id,
           name = name,
         }
       })
-    if err then
+    if not ok then
       log(ERR, "failed broadcasting upstream ", operation, " to workers: ", err)
     end
   end)


### PR DESCRIPTION
This version has the `shm_retries` option (default 5) to fix
potential 'no memory' errors, as reported by @hbagdi .

Additionally the return values of `post`, `post_local` and `poll`
behave more Lua-ish. So we can now check on `ok` instead of on `err`

