### PR TITLE
fix(declarative) compound key for endpoints that can be identical

### DIFF
--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -409,10 +409,24 @@ local function get_key_for_uuid_gen(entity, item, schema, parent_fk, child_key)
     return
   end
 
-  if schema.endpoint_key and
-     item[schema.endpoint_key] ~= nil then
+  if schema.endpoint_key and item[schema.endpoint_key] ~= nil then
+    local key = item[schema.endpoint_key]
+
+    -- If this item has foreign keys with on_delete "cascade", it is inferred
+    -- that its endpoint is not necessarily unique, so its key must be composed
+    -- by parent's key, avoiding that it is overwritten by identical endpoints
+    -- under other parents.
+    for _, field in schema:each_field(item) do
+      if field.type == "foreign" and field.on_delete == "cascade" then
+        local foreign_key_keys = all_schemas[field.reference].primary_key
+        for _, fk_pk in ipairs(foreign_key_keys) do
+          key = key .. ":" .. parent_fk[fk_pk]
+        end
+
+      end
+    end
     -- generate a PK based on the endpoint_key
-    return pk_name, item[schema.endpoint_key]
+    return pk_name, key
   end
 
   if schema.cache_key then

--- a/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
+++ b/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
@@ -1096,6 +1096,44 @@ describe("declarative config: flatten", function()
         end)
       end)
     end)
+    describe("upstream:", function()
+      it("identical targets", function()
+        local config = assert(lyaml.load([[
+          _format_version: '1.1'
+          upstreams:
+          - name: first-upstream
+            targets:
+            - target: 127.0.0.1:6661
+              weight: 1
+          - name: second-upstream
+            targets:
+            - target: 127.0.0.1:6661
+              weight: 1
+        ]]))
+        config = DeclarativeConfig:flatten(config)
+        assert.same({
+          targets = {
+            {
+              created_at = 1234567890,
+              id = "UUID",
+              tags = null,
+              target = '127.0.0.1:6661',
+              upstream = { id = 'UUID' },
+              weight = 1,
+            },
+            {
+              created_at = 1234567890,
+              id = "UUID",
+              tags = null,
+              target = '127.0.0.1:6661',
+              upstream = { id = 'UUID' },
+              weight = 1,
+            },
+          },
+
+        }, idempotent({targets = config.targets}))
+      end)
+    end)
   end)
 
   describe("custom entities", function()


### PR DESCRIPTION
# Summary

Endpoints that could be identical under different parents, e.g. identical targets under different upstreams, were being overwritten when using a declarative config. This PR makes auto-generated primary keys to be compound by parent's foreign keys, avoiding that issue.

### Issues resolved

Fix #4778
