### PR TITLE
fix(db_export) skip basicauth_credentials on db_export

### DIFF
--- a/kong/plugins/basic-auth/daos.lua
+++ b/kong/plugins/basic-auth/daos.lua
@@ -8,6 +8,9 @@ return {
     primary_key = { "id" },
     cache_key = { "username" },
     endpoint_key = "username",
+    -- Passwords are hashed on insertion, so the exported passwords would be encrypted.
+    -- Importing them back would require "plain" unencrypted passwords instead
+    db_export = false,
     admin_api_name = "basic-auths",
     admin_api_nested_name = "basic-auth",
     fields = {

--- a/spec/02-integration/03-db/08-declarative_spec.lua
+++ b/spec/02-integration/03-db/08-declarative_spec.lua
@@ -161,6 +161,13 @@ for _, strategy in helpers.each_strategy() do
     describe("export_from_db", function()
       it("exports base and custom entities with associations", function()
 
+        -- Add a basicauth_credential to make sure it is not exported
+        db.basicauth_credentials:insert({
+          username = "some_username",
+          password = "secret",
+          consumer = { id = consumer_def.id },
+        })
+
         local fake_file = {
           buffer = {},
           write = function(self, str)
@@ -173,7 +180,7 @@ for _, strategy in helpers.each_strategy() do
         local exported_str = table.concat(fake_file.buffer)
         local yaml = lyaml.load(exported_str)
 
-        -- ensure tags and cluster_ca are not being exported
+        -- ensure tags, cluster_ca & basicauth_credentials are not being exported
         local toplevel_keys = {}
         for k in pairs(yaml) do
           toplevel_keys[#toplevel_keys + 1] = k


### PR DESCRIPTION
This change makes basicauth_credentials non-exportable by db_export.

Explanation: basicauth_credentials have a built-in encryption system - the passwords are encrypted in the database.

If these are exported, they cannot be imported back to the database (they would be re-encrypted, rendering them useless).

The recommended way to import credentials for now is using plain, unencrypted passwords (which can not be obtained from the database).