### PR TITLE
fix(balancer) added round-robin to algorithms enum

### DIFF
--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -207,8 +207,9 @@ end
 local create_balancer
 do
   local balancer_types = {
-    ["consistent"] = require("resty.dns.balancer.ring"),
+    ["consistent-hashing"] = require("resty.dns.balancer.ring"),
     ["least-connections"] = require("resty.dns.balancer.least_connections"),
+    ["round-robin"] = require("resty.dns.balancer.ring"),
   }
 
   local create_healthchecker
@@ -677,7 +678,7 @@ end
 -- @return integer value or nil if there is no hash to calculate
 local create_hash = function(upstream, ctx)
   local hash_on = upstream.hash_on
-  if hash_on == "none" then
+  if hash_on == "none" or hash_on == nil or hash_on == ngx.null then
     return -- not hashing, exit fast
   end
 

--- a/spec/01-unit/09-balancer_spec.lua
+++ b/spec/01-unit/09-balancer_spec.lua
@@ -71,15 +71,15 @@ describe("Balancer", function()
     passive_hc.passive.unhealthy.http_failures = 1
 
     UPSTREAMS_FIXTURES = {
-      [1] = { id = "a", name = "mashape", slots = 10, healthchecks = hc_defaults, algorithm = "consistent" },
-      [2] = { id = "b", name = "kong",    slots = 10, healthchecks = hc_defaults, algorithm = "consistent" },
-      [3] = { id = "c", name = "gelato",  slots = 20, healthchecks = hc_defaults, algorithm = "consistent" },
-      [4] = { id = "d", name = "galileo", slots = 20, healthchecks = hc_defaults, algorithm = "consistent" },
-      [5] = { id = "e", name = "upstream_e", slots = 10, healthchecks = hc_defaults, algorithm = "consistent" },
-      [6] = { id = "f", name = "upstream_f", slots = 10, healthchecks = hc_defaults, algorithm = "consistent" },
-      [7] = { id = "hc", name = "upstream_hc", slots = 10, healthchecks = passive_hc, algorithm = "consistent" },
-      [8] = { id = "ph", name = "upstream_ph", slots = 10, healthchecks = passive_hc, algorithm = "consistent" },
-      [9] = { id = "ote", name = "upstream_ote", slots = 10, healthchecks = hc_defaults, algorithm = "consistent" },
+      [1] = { id = "a", name = "mashape", slots = 10, healthchecks = hc_defaults, algorithm = "round-robin" },
+      [2] = { id = "b", name = "kong",    slots = 10, healthchecks = hc_defaults, algorithm = "round-robin" },
+      [3] = { id = "c", name = "gelato",  slots = 20, healthchecks = hc_defaults, algorithm = "round-robin" },
+      [4] = { id = "d", name = "galileo", slots = 20, healthchecks = hc_defaults, algorithm = "round-robin" },
+      [5] = { id = "e", name = "upstream_e", slots = 10, healthchecks = hc_defaults, algorithm = "round-robin" },
+      [6] = { id = "f", name = "upstream_f", slots = 10, healthchecks = hc_defaults, algorithm = "round-robin" },
+      [7] = { id = "hc", name = "upstream_hc", slots = 10, healthchecks = passive_hc, algorithm = "round-robin" },
+      [8] = { id = "ph", name = "upstream_ph", slots = 10, healthchecks = passive_hc, algorithm = "round-robin" },
+      [9] = { id = "ote", name = "upstream_ote", slots = 10, healthchecks = hc_defaults, algorithm = "round-robin" },
     }
     upstream_hc = UPSTREAMS_FIXTURES[7]
     upstream_ph = UPSTREAMS_FIXTURES[8]


### PR DESCRIPTION
### Summary

- `"round-robin"` is now an available balancing algorithm, with the same behavior that was found in `algorithm="consistent"` and `hash_on="none"` combination before.
- Added migrations to set new `algorithm` field values, according to existent `hash_on` values.
- Added `shorthands` to the schema to keep backward compatibility in admin API and declarative config, avoiding inconsistent settings.
