### PR TITLE
feat(oauth2) hash client secret

### DIFF
--- a/kong-1.2.1-0.rockspec
+++ b/kong-1.2.1-0.rockspec
@@ -228,6 +228,8 @@ build = {
     ["kong.plugins.oauth2.access"] = "kong/plugins/oauth2/access.lua",
     ["kong.plugins.oauth2.schema"] = "kong/plugins/oauth2/schema.lua",
     ["kong.plugins.oauth2.daos"] = "kong/plugins/oauth2/daos.lua",
+    ["kong.plugins.oauth2.crypto"] = "kong/plugins/oauth2/crypto.lua",
+    ["kong.plugins.oauth2.oauth2_credentials"] = "kong/plugins/oauth2/oauth2_credentials.lua",
 
 
     ["kong.plugins.log-serializers.basic"] = "kong/plugins/log-serializers/basic.lua",

--- a/kong/plugins/oauth2/crypto.lua
+++ b/kong/plugins/oauth2/crypto.lua
@@ -1,0 +1,28 @@
+-- Module to hash the basic-auth credentials password field
+local sha256 = require "resty.sha256"
+local to_hex = require "resty.string".to_hex
+local resty_random = require "resty.random"
+local assert = assert
+
+
+local function hash_secret_with_salt(client_secret, salt)
+  if client_secret == nil or client_secret == ngx.null then
+    client_secret = ""
+  end
+
+  local salted = client_secret .. salt
+  local digest = sha256:new()
+  assert(digest:update(salted))
+  return to_hex(digest:final())
+end
+
+return {
+  hash = function(secret)
+    local salt = to_hex(resty_random.bytes(16))
+    return hash_secret_with_salt(secret, salt), salt
+  end,
+
+  validate = function(secret, hashed_secret, salt)
+    return hashed_secret == hash_secret_with_salt(secret, salt)
+  end
+}

--- a/kong/plugins/oauth2/daos.lua
+++ b/kong/plugins/oauth2/daos.lua
@@ -16,6 +16,7 @@ end
 
 
 local oauth2_credentials = {
+  dao = "kong.plugins.oauth2.oauth2_credentials",
   primary_key = { "id" },
   name = "oauth2_credentials",
   cache_key = { "client_id" },

--- a/kong/plugins/oauth2/oauth2_credentials.lua
+++ b/kong/plugins/oauth2/oauth2_credentials.lua
@@ -1,0 +1,92 @@
+local crypto = require "kong.plugins.oauth2.crypto"
+local utils = require "kong.tools.utils"
+
+
+local hash_secret = function(self, cred_id_or_client_id, cred)
+  -- Don't re-hash the secret digest on update, if the secret hasn't changed
+  -- This causes a bug when a new secret is effectively equal the to previous
+  -- digest
+
+  local existing
+  if cred_id_or_client_id then
+    local err, err_t
+    if utils.is_valid_uuid(cred_id_or_client_id) then
+      existing, err, err_t = self:select({ id = cred_id_or_client_id })
+    else
+      existing, err, err_t = self:select_by_client_id(cred_id_or_client_id)
+    end
+    if err then
+      return nil, err, err_t
+    end
+  end
+
+  if existing then
+    if existing.client_secret == cred.client_secret then
+      return
+    end
+    if not cred.consumer then
+      cred.consumer = existing.consumer
+    end
+  end
+
+  local hashed_secret, salt = crypto.hash(cred.client_secret)
+  cred.client_secret = "s256|" .. hashed_secret .. "|" .. salt
+
+  return true
+end
+
+
+local _Oauth2Credentials = {}
+
+
+function _Oauth2Credentials:insert(cred, options)
+  local ok, err, err_t = hash_secret(self, cred.id, cred)
+  if not ok then
+    return nil, err, err_t
+  end
+  return self.super.insert(self, cred, options)
+end
+
+
+function _Oauth2Credentials:update(cred_pk, cred, options)
+  if cred.client_secret ~= nil then
+    local ok, err, err_t = hash_secret(self, cred_pk.id, cred)
+    if not ok then
+      return nil, err, err_t
+    end
+  end
+  return self.super.update(self, cred_pk, cred, options)
+end
+
+
+function _Oauth2Credentials:update_by_client_id(client_id, cred, options)
+  if cred.client_secret ~= nil then
+    local ok, err, err_t = hash_secret(self, client_id, cred)
+    if not ok then
+      return nil, err, err_t
+    end
+  end
+  return self.super.update_by_client_id(self, client_id, cred, options)
+end
+
+
+function _Oauth2Credentials:upsert(cred_pk, cred, options)
+  local ok, err, err_t = hash_secret(self, cred_pk.id, cred)
+  if not ok then
+    return nil, err, err_t
+  end
+  return self.super.upsert(self, cred_pk, cred, options)
+end
+
+
+function _Oauth2Credentials:upsert_by_client_id(client_id, cred, options)
+  local ok, err, err_t = hash_secret(self, client_id, cred)
+  if not ok then
+    return nil, err, err_t
+  end
+  return self.super.upsert_by_client_id(self, client_id, cred, options)
+end
+
+
+return _Oauth2Credentials
+

--- a/spec/02-integration/01-helpers/02-blueprints_spec.lua
+++ b/spec/02-integration/01-helpers/02-blueprints_spec.lua
@@ -192,7 +192,7 @@ for _, strategy in helpers.each_strategy() do
         redirect_uris = { "http://foo.com" },
       })
       assert.equals("oauth2 credential", c.name)
-      assert.equals("secret", c.client_secret)
+      assert.matches("s256|%w+|%w+", c.client_secret)
       assert.matches(UUID_PATTERN, c.id)
     end)
 


### PR DESCRIPTION
### Summary

Hashing is done using sha256 provided by openresty library. The change
is backwards compatible by validating hashed secrets only if they are
stored in the right format: `s256|hashed_secret|salt`. If the secret
doesn't match the format the code assumes secret is stored raw. Most of
the code is based on hashing code used in basic-auth plugin.

### Issues resolved

Closes #1237