### PR TITLE
hotfix(schema) grpc subschema entity checker

### DIFF
--- a/kong/db/schema/entities/routes_subschemas.lua
+++ b/kong/db/schema/entities/routes_subschemas.lua
@@ -51,10 +51,10 @@ local grpc_subschema = {
   entity_checks = {
     { conditional_at_least_one_of = { if_field = "protocols",
                                       if_match = { contains = "grpcs" },
-                                      then_at_least_one_of = { "methods", "hosts", "headers", "paths", "snis" },
+                                      then_at_least_one_of = { "hosts", "headers", "paths", "snis" },
                                       then_err = "must set one of %s when 'protocols' is 'grpcs'",
                                       else_match = { contains = "grpc" },
-                                      else_then_at_least_one_of = { "methods", "hosts", "headers", "paths" },
+                                      else_then_at_least_one_of = { "hosts", "headers", "paths" },
                                       else_then_err = "must set one of %s when 'protocols' is 'grpc'",
                                     }},
   },

--- a/spec/01-unit/01-db/01-schema/06-routes_spec.lua
+++ b/spec/01-unit/01-db/01-schema/06-routes_spec.lua
@@ -1076,7 +1076,7 @@ describe("routes schema", function()
     assert.falsy(ok)
     assert.same({
       ["@entity"] = {
-        "must set one of 'methods', 'hosts', 'headers', 'paths' when 'protocols' is 'grpc'"
+        "must set one of 'hosts', 'headers', 'paths' when 'protocols' is 'grpc'"
       }
     }, errs)
 
@@ -1088,7 +1088,7 @@ describe("routes schema", function()
     assert.falsy(ok)
     assert.same({
       ["@entity"] = {
-        "must set one of 'methods', 'hosts', 'headers', 'paths', 'snis' when 'protocols' is 'grpcs'"
+        "must set one of 'hosts', 'headers', 'paths', 'snis' when 'protocols' is 'grpcs'"
       }
     }, errs)
   end)
@@ -1097,6 +1097,7 @@ describe("routes schema", function()
     local s = { id = "a4fbd24e-6a52-4937-bd78-2536713072d2" }
     local route = Routes:process_auto_fields({
       methods = "GET",
+      paths = { "/foo" },
       protocols = { "grpc" },
       service = s,
     }, "insert")
@@ -1108,6 +1109,7 @@ describe("routes schema", function()
 
     route = Routes:process_auto_fields({
       methods = "GET",
+      paths = { "/foo" },
       protocols = { "grpcs" },
       service = s,
     }, "insert")
@@ -1122,6 +1124,7 @@ describe("routes schema", function()
     local s = { id = "a4fbd24e-6a52-4937-bd78-2536713072d2" }
     local route = Routes:process_auto_fields({
       methods = "GET",
+      paths = { "/foo" },
       protocols = { "grpc" },
       service = s,
     }, "insert")
@@ -1133,6 +1136,7 @@ describe("routes schema", function()
 
     route = Routes:process_auto_fields({
       methods = "GET",
+      paths = { "/foo" },
       protocols = { "grpcs" },
       service = s,
     }, "insert")

--- a/spec/02-integration/03-db/02-db_core_entities_spec.lua
+++ b/spec/02-integration/03-db/02-db_core_entities_spec.lua
@@ -708,6 +708,7 @@ for _, strategy in helpers.each_strategy() do
             local route, err, err_t = db.routes:insert({
               protocols = { "grpc", "grpcs" },
               methods   = { "PATCH" },
+              paths     = { "/foo", "/bar" },
               service   = bp.services:insert(),
             })
             assert.is_nil(route)

--- a/spec/02-integration/04-admin_api/09-routes_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/09-routes_routes_spec.lua
@@ -907,11 +907,11 @@ for _, strategy in helpers.each_strategy() do
                   name    = "schema violation",
                   message = unindent([[
                   schema violation
-                  (must set one of 'methods', 'hosts', 'headers', 'paths', 'snis' when 'protocols' is 'grpcs')
+                  (must set one of 'hosts', 'headers', 'paths', 'snis' when 'protocols' is 'grpcs')
                   ]], true, true),
                   fields  = {
                     ["@entity"] = {
-                      "must set one of 'methods', 'hosts', 'headers', 'paths', 'snis' when 'protocols' is 'grpcs'",
+                      "must set one of 'hosts', 'headers', 'paths', 'snis' when 'protocols' is 'grpcs'",
                     }
                   }
                 }, cjson.decode(body))
@@ -941,6 +941,7 @@ for _, strategy in helpers.each_strategy() do
                 local res = client:post("/routes", {
                   body = {
                     protocols = { "grpc", "grpcs" },
+                    paths = { "/" },
                     methods = { "GET" }
                   },
                   headers = { ["Content-Type"] = content_type }


### PR DESCRIPTION
### Summary

Fix inconsistency in error message reported by entity checker and schema
rules. gRPC doesn't accept a `methods` attribute.