### PR TITLE
tests(tcp-log) add tests for grpc client protocol

### DIFF
--- a/.ci/setup_env.sh
+++ b/.ci/setup_env.sh
@@ -68,7 +68,7 @@ fi
 # ----------------
 # Run gRPC server |
 # ----------------
-if [[ "$TEST_SUITE" =~ integration|dbless ]]; then
+if [[ "$TEST_SUITE" =~ integration|dbless|plugins ]]; then
   docker run -d --name grpcbin -p 15002:9000 -p 15003:9001 moul/grpcbin
 fi
 

--- a/spec/03-plugins/01-tcp-log/01-tcp-log_spec.lua
+++ b/spec/03-plugins/01-tcp-log/01-tcp-log_spec.lua
@@ -8,6 +8,7 @@ local TCP_PORT = 35001
 for _, strategy in helpers.each_strategy() do
   describe("Plugin: tcp-log (log) [#" .. strategy .. "]", function()
     local proxy_client, proxy_ssl_client
+    local proxy_client_grpc, proxy_client_grpcs
 
     lazy_setup(function()
       local bp = helpers.get_db_utils(strategy, {
@@ -43,6 +44,46 @@ for _, strategy in helpers.each_strategy() do
         },
       }
 
+      local grpc_service = assert(bp.services:insert {
+        name = "grpc-service",
+        url = "grpc://localhost:15002",
+      })
+
+      local route3 = assert(bp.routes:insert {
+        service = grpc_service,
+        protocols = { "grpc" },
+        hosts = { "tcp_logging_grpc.test" },
+      })
+
+      bp.plugins:insert {
+        route = { id = route3.id },
+        name     = "tcp-log",
+        config   = {
+          host   = "127.0.0.1",
+          port   = TCP_PORT,
+        },
+      }
+
+      local grpcs_service = assert(bp.services:insert {
+        name = "grpcs-service",
+        url = "grpcs://localhost:15003",
+      })
+
+      local route4 = assert(bp.routes:insert {
+        service = grpcs_service,
+        protocols = { "grpcs" },
+        hosts = { "tcp_logging_grpcs.test" },
+      })
+
+      bp.plugins:insert {
+        route = { id = route4.id },
+        name     = "tcp-log",
+        config   = {
+          host   = "127.0.0.1",
+          port   = TCP_PORT,
+        },
+      }
+
       assert(helpers.start_kong({
         database   = strategy,
         nginx_conf = "spec/fixtures/custom_nginx.template",
@@ -50,6 +91,8 @@ for _, strategy in helpers.each_strategy() do
 
       proxy_client = helpers.proxy_client()
       proxy_ssl_client = helpers.proxy_ssl_client()
+      proxy_client_grpc = helpers.proxy_client_grpc()
+      proxy_client_grpcs = helpers.proxy_client_grpcs()
     end)
 
     lazy_teardown(function()
@@ -86,6 +129,36 @@ for _, strategy in helpers.each_strategy() do
       assert.is_nil(log_message.request.tls)
     end)
 
+    it("logs to TCP (grpc)", function()
+      local thread = helpers.tcp_server(TCP_PORT) -- Starting the mock TCP server
+
+      -- Making the request
+      local ok, resp = proxy_client_grpc({
+        service = "hello.HelloService.SayHello",
+        body = {
+          greeting = "world!"
+        },
+        opts = {
+          ["-authority"] = "tcp_logging_grpc.test",
+        }
+      })
+      assert.truthy(ok)
+      assert.truthy(resp)
+
+      -- Getting back the TCP server input
+      local ok, res = thread:join()
+      assert.True(ok)
+      assert.is_string(res)
+
+      -- Making sure it's alright
+      local log_message = cjson.decode(res)
+      assert.equal("127.0.0.1", log_message.client_ip)
+      assert.equal("grpc-service", log_message.service.name)
+
+      -- Since it's over HTTP, let's make sure there are no TLS information
+      assert.is_nil(log_message.request.tls)
+    end)
+
     it("logs proper latencies", function()
       local tcp_thread = helpers.tcp_server(TCP_PORT) -- Starting the mock TCP server
 
@@ -114,6 +187,42 @@ for _, strategy in helpers.each_strategy() do
       -- resilient to those.
       local is_latencies_sum_adding_up =
         1+log_message.latencies.request >= log_message.latencies.kong +
+        log_message.latencies.proxy
+
+      assert.True(is_latencies_sum_adding_up)
+    end)
+
+    it("logs proper latencies (grpc)", function()
+      local tcp_thread = helpers.tcp_server(TCP_PORT) -- Starting the mock TCP server
+
+      -- Making the request
+      local ok, resp = proxy_client_grpc({
+        service = "hello.HelloService.SayHello",
+        body = {
+          greeting = "world!"
+        },
+        opts = {
+          ["-authority"] = "tcp_logging_grpc.test",
+        }
+      })
+      assert.truthy(ok)
+      assert.truthy(resp)
+
+      -- Getting back the TCP server input
+      local ok, res = tcp_thread:join()
+      assert.True(ok)
+      assert.is_string(res)
+
+      -- Making sure it's alright
+      local log_message = cjson.decode(res)
+
+      assert.True(log_message.latencies.proxy < 3000)
+
+      -- Sometimes there's a split milisecond that makes numbers not
+      -- add up by 1. Adding an artificial 1 to make the test
+      -- resilient to those.
+      local is_latencies_sum_adding_up =
+        1 + log_message.latencies.request >= log_message.latencies.kong +
         log_message.latencies.proxy
 
       assert.True(is_latencies_sum_adding_up)
@@ -155,6 +264,34 @@ for _, strategy in helpers.each_strategy() do
       })
 
       assert.response(r).has.status(200)
+
+      -- Getting back the TCP server input
+      local ok, res = thread:join()
+      assert.True(ok)
+      assert.is_string(res)
+
+      -- Making sure it's alright
+      local log_message = cjson.decode(res)
+      assert.equal("TLSv1.2", log_message.request.tls.version)
+      assert.is_string(log_message.request.tls.cipher)
+      assert.equal("NONE", log_message.request.tls.client_verify)
+    end)
+
+    it("logs TLS info (grpcs)", function()
+      local thread = helpers.tcp_server(TCP_PORT) -- Starting the mock TCP server
+
+      -- Making the request
+      local ok, resp = proxy_client_grpcs({
+        service = "hello.HelloService.SayHello",
+        body = {
+          greeting = "world!"
+        },
+        opts = {
+          ["-authority"] = "tcp_logging_grpcs.test",
+        }
+      })
+      assert.truthy(ok)
+      assert.truthy(resp)
 
       -- Getting back the TCP server input
       local ok, res = thread:join()


### PR DESCRIPTION
### Summary

Add tests for tcp-log with gRPC client protocol.