### PR TITLE
fix(balancer) invalidate upstream cache before creating balancer

### DIFF
--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -377,6 +377,11 @@ do
     return nil, "timeout"
   end
 
+  local function invalidate_upstream_caches(upstream_id)
+    singletons.cache:invalidate_local("balancer:upstreams:" .. upstream_id)
+    singletons.cache:invalidate_local("balancer:targets:" .. upstream_id)
+  end
+
   ------------------------------------------------------------------------------
   -- @param upstream (table) A db.upstreams entity
   -- @param recreate (boolean, optional) create new balancer even if one exists
@@ -407,6 +412,8 @@ do
     if not balancer then
       return nil, err
     end
+
+    invalidate_upstream_caches(upstream.id)
 
     target_histories[balancer] = {}
 


### PR DESCRIPTION
### Summary

When using dbless configs caches from removed targets were still valid after a reload and were being recreated. This change invalidates upstream caches before creating new balancers, forcing them to be retrieved from DAO.

### Issues resolved

Fix #4808