### PR TITLE
docs(admin-api) verify automated reference docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,8 @@ kong*.yml
 luacov.*
 /doc
 
+# autodoc
+autodoc/output
+
 kong-build-tools
 bin/grpcurl

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,7 @@ jobs:
     - stage: lint and unit
       script:
       - luacheck -q .
+      - scripts/autodoc-admin-api
       - bin/busted -v -o gtest spec/01-unit
       env:
         - KONG_DATABASE=none

--- a/autodoc/data/admin-api.lua
+++ b/autodoc/data/admin-api.lua
@@ -408,6 +408,11 @@ return {
         Service. See the [Proxy Reference][proxy-reference] for a detailed explanation
         of how Kong proxies traffic.
       ]],
+
+      ["/services/:services/client_certificate"] = {
+        endpoint = false,
+      },
+
       fields = {
         id = { skip = true },
         created_at = { skip = true },

--- a/autodoc/data/admin-api.lua
+++ b/autodoc/data/admin-api.lua
@@ -1059,7 +1059,7 @@ return {
             The `data` field of the response contains an array of Target objects.
             The health for each Target is returned in its `health` field:
 
-            * If a Target fails to be activated in the ring balancer due to DNS issues,
+            * If a Target fails to be activated in the balancer due to DNS issues,
               its status displays as `DNS_ERROR`.
             * When [health checks][healthchecks] are not enabled in the Upstream
               configuration, the health status for active Targets is displayed as
@@ -1067,7 +1067,7 @@ return {
             * When health checks are enabled and the Target is determined to be healthy,
               either automatically or [manually](#set-target-as-healthy),
               its status is displayed as `HEALTHY`. This means that this Target is
-              currently included in this Upstream's load balancer ring.
+              currently included in this Upstream's load balancer execution.
             * When a Target has been disabled by either active or passive health checks
               (circuit breakers) or [manually](#set-target-as-unhealthy),
               its status is displayed as `UNHEALTHY`. The load balancer is not directing
@@ -1258,7 +1258,8 @@ return {
           title = [[Set target as healthy]],
           description = [[
             Set the current health status of a target in the load balancer to "healthy"
-            in the entire Kong cluster.
+            in the entire Kong cluster. This sets the "healthy" status to all addresses
+            resolved by this target.
 
             This endpoint can be used to manually re-enable a target that was previously
             disabled by the upstream's [health checker][healthchecks]. Upstreams only
@@ -1289,12 +1290,12 @@ return {
           title = [[Set target as unhealthy]],
           description = [[
             Set the current health status of a target in the load balancer to "unhealthy"
-            in the entire Kong cluster.
+            in the entire Kong cluster. This sets the "unhealthy" status to all addresses
+            resolved by this target.
 
             This endpoint can be used to manually disable a target and have it stop
             responding to requests. Upstreams only forward requests to healthy nodes, so
-            this call tells Kong to start skipping this target in the ring-balancer
-            algorithm.
+            this call tells Kong to start skipping this target.
 
             This call resets the health counters of the health checkers running in all
             workers of the Kong node, and broadcasts a cluster-wide message so that the
@@ -1303,7 +1304,75 @@ return {
             [Active health checks][active] continue to execute for unhealthy
             targets. Note that if active health checks are enabled and the probe detects
             that the target is actually healthy, it will automatically re-enable it again.
-            To permanently remove a target from the ring-balancer, you should [delete a
+            To permanently remove a target from the balancer, you should [delete a
+            target](#delete-target) instead.
+          ]],
+          endpoint = [[
+            <div class="endpoint post">/upstreams/{upstream name or id}/targets/{target or id}/unhealthy</div>
+
+            Attributes | Description
+            ---:| ---
+            `upstream name or id`<br>**required** | The unique identifier **or** the name of the upstream.
+            `target or id`<br>**required** | The host/port combination element of the target to set as unhealthy, or the `id` of an existing target entry.
+          ]],
+          response = [[
+            ```
+            HTTP 204 No Content
+            ```
+          ]],
+        }
+      },
+      ["/upstreams/:upstreams/targets/:targets/:address/healthy"] = {
+        POST = {
+          title = [[Set target address as healthy]],
+          description = [[
+            Set the current health status of an individual address resolved by a target
+            in the load balancer to "healthy" in the entire Kong cluster.
+
+            This endpoint can be used to manually re-enable an address resolved by a
+            target that was previously disabled by the upstream's [health checker][healthchecks].
+            Upstreams only forward requests to healthy nodes, so this call tells Kong
+            to start using this address again.
+
+            This resets the health counters of the health checkers running in all workers
+            of the Kong node, and broadcasts a cluster-wide message so that the "healthy"
+            status is propagated to the whole Kong cluster.
+          ]],
+          endpoint = [[
+            <div class="endpoint post">/upstreams/{upstream name or id}/targets/{target or id}/{address}/healthy</div>
+
+            Attributes | Description
+            ---:| ---
+            `upstream name or id`<br>**required** | The unique identifier **or** the name of the upstream.
+            `target or id`<br>**required** | The host/port combination element of the target to set as healthy, or the `id` of an existing target entry.
+            `address`<br>**required** | The host/port combination element of the address to set as healthy.
+          ]],
+          response = [[
+            ```
+            HTTP 204 No Content
+            ```
+          ]],
+        }
+      },
+      ["/upstreams/:upstreams/targets/:targets/:address/unhealthy"] = {
+        POST = {
+          title = [[Set target address as unhealthy]],
+          description = [[
+            Set the current health status of an individual address resolved by a target
+            in the load balancer to "unhealthy" in the entire Kong cluster.
+
+            This endpoint can be used to manually disable an address and have it stop
+            responding to requests. Upstreams only forward requests to healthy nodes, so
+            this call tells Kong to start skipping this address.
+
+            This call resets the health counters of the health checkers running in all
+            workers of the Kong node, and broadcasts a cluster-wide message so that the
+            "unhealthy" status is propagated to the whole Kong cluster.
+
+            [Active health checks][active] continue to execute for unhealthy
+            addresses. Note that if active health checks are enabled and the probe detects
+            that the address is actually healthy, it will automatically re-enable it again.
+            To permanently remove a target from the balancer, you should [delete a
             target](#delete-target) instead.
           ]],
           endpoint = [[

--- a/autodoc/data/admin-api.lua
+++ b/autodoc/data/admin-api.lua
@@ -456,6 +456,12 @@ return {
             for transmitting a request to the upstream server.
           ]]
         },
+        client_certificate = {
+          description = [[
+            Certificate to be used as client certificate while TLS handshaking
+            to the upstream server.
+          ]],
+        },
         tags = {
           description = [[
             An optional set of strings associated with the Service, for grouping and filtering.

--- a/autodoc/data/admin-api.lua
+++ b/autodoc/data/admin-api.lua
@@ -25,6 +25,7 @@ return {
       "consumers",
       "plugins",
       "certificates",
+      "ca_certificates",
       "snis",
       "upstreams",
       "targets",
@@ -900,12 +901,16 @@ return {
         encrypted requests, or for use as a trusted CA store when validating peer certificate of
         client/service. Certificates are optionally associated with SNI objects to
         tie a cert/key pair to one or more hostnames.
+
+        If intermediate certificates are required in addition to the main
+        certificate, they should be concatenated together into one string according to
+        the following order: main certificate on the top, followed by any intermediates.
       ]],
       fields = {
         id = { skip = true },
         created_at = { skip = true },
         cert = {
-          description = [[PEM-encoded public certificate of the SSL key pair.]],
+          description = [[PEM-encoded public certificate chain of the SSL key pair.]],
           example = "-----BEGIN CERTIFICATE-----...",
         },
         key = {
@@ -935,6 +940,32 @@ return {
         } },
       },
 
+    },
+
+    ca_certificates = {
+      entity_title = "CA Certificate",
+      entity_title_plural = "CA Certificates",
+      description = [[
+        A CA certificate object represents a trusted CA. These objects are used by Kong to
+        verify the validity of a client or server certificate.
+      ]],
+      fields = {
+        id = { skip = true },
+        created_at = { skip = true },
+        cert = {
+          description = [[PEM-encoded public certificate of the CA.]],
+          example = "-----BEGIN CERTIFICATE-----...",
+        },
+        tags = {
+          description = [[
+            An optional set of strings associated with the Certificate, for grouping and filtering.
+          ]],
+          examples = {
+            { "user-level", "low-priority" },
+            { "admin", "high-priority", "critical" }
+          },
+        },
+      },
     },
 
     snis = {

--- a/autodoc/data/admin-api.lua
+++ b/autodoc/data/admin-api.lua
@@ -1,0 +1,1653 @@
+return {
+
+--------------------------------------------------------------------------------
+-- Known files and entities, to compare what's coded to what's documented
+--
+-- We avoid automagic detection based on traversal of filesystem and modules,
+-- so that adding new info to the documentation becomes a conscious process.
+-- We traverse the filesystem and modules to cross-check that everything that
+-- is present in the code is either documented or consciously omitted from
+-- the docs (e.g. in the last stage of deprecation).
+--------------------------------------------------------------------------------
+
+  known = {
+    general_files = {
+      "kong/api/routes/kong.lua",
+      "kong/api/routes/config.lua",
+      "kong/api/routes/tags.lua",
+    },
+    nodoc_files = {
+      "kong/api/routes/cache.lua", -- FIXME should we document this?
+    },
+    entities = {
+      "services",
+      "routes",
+      "consumers",
+      "plugins",
+      "certificates",
+      "snis",
+      "upstreams",
+      "targets",
+    },
+    nodoc_entities = {
+    },
+  },
+
+--------------------------------------------------------------------------------
+-- General (non-entity) Admin API route files
+--------------------------------------------------------------------------------
+
+  intro = {
+    {
+      text = [[
+        <div class="alert alert-info.blue" role="alert">
+          This page refers to the Admin API for running Kong configured with a
+          database (Postgres or Cassandra). For using the Admin API for Kong
+          in DB-less mode, please refer to the
+          <a href="/{{page.kong_version}}/db-less-admin-api">Admin API for DB-less Mode</a>
+          page.
+        </div>
+
+        Kong comes with an **internal** RESTful Admin API for administration purposes.
+        Requests to the Admin API can be sent to any node in the cluster, and Kong will
+        keep the configuration consistent across all nodes.
+
+        - `8001` is the default port on which the Admin API listens.
+        - `8444` is the default port for HTTPS traffic to the Admin API.
+
+        This API is designed for internal use and provides full control over Kong, so
+        care should be taken when setting up Kong environments to avoid undue public
+        exposure of this API. See [this document][secure-admin-api] for a discussion
+        of methods to secure the Admin API.
+      ]]
+    }, {
+      title = [[Supported Content Types]],
+      text = [[
+        The Admin API accepts 2 content types on every endpoint:
+
+        - **application/x-www-form-urlencoded**
+
+        Simple enough for basic request bodies, you will probably use it most of the time.
+        Note that when sending nested values, Kong expects nested objects to be referenced
+        with dotted keys. Example:
+
+        ```
+        config.limit=10&config.period=seconds
+        ```
+
+        - **application/json**
+
+        Handy for complex bodies (ex: complex plugin configuration), in that case simply send
+        a JSON representation of the data you want to send. Example:
+
+        ```json
+        {
+            "config": {
+                "limit": 10,
+                "period": "seconds"
+            }
+        }
+        ```
+      ]]
+    },
+  },
+
+  footer = [[
+    [clustering]: /{{page.kong_version}}/clustering
+    [cli]: /{{page.kong_version}}/cli
+    [active]: /{{page.kong_version}}/health-checks-circuit-breakers/#active-health-checks
+    [healthchecks]: /{{page.kong_version}}/health-checks-circuit-breakers
+    [secure-admin-api]: /{{page.kong_version}}/secure-admin-api
+    [proxy-reference]: /{{page.kong_version}}/proxy
+    [db-less-admin-api]: /{{page.kong_version}}/db-less-admin-api
+  ]],
+
+  general = {
+    kong = {
+      title = [[Information routes]],
+      description = "",
+      ["/"] = {
+        GET = {
+          title = [[Retrieve node information]],
+          endpoint = [[<div class="endpoint get">/</div>]],
+          description = [[Retrieve generic details about a node.]],
+          response =[[
+            ```
+            HTTP 200 OK
+            ```
+
+            ```json
+            {
+                "hostname": "",
+                "node_id": "6a72192c-a3a1-4c8d-95c6-efabae9fb969",
+                "lua_version": "LuaJIT 2.1.0-beta3",
+                "plugins": {
+                    "available_on_server": [
+                        ...
+                    ],
+                    "enabled_in_cluster": [
+                        ...
+                    ]
+                },
+                "configuration" : {
+                    ...
+                },
+                "tagline": "Welcome to Kong",
+                "version": "0.14.0"
+            }
+            ```
+
+            * `node_id`: A UUID representing the running Kong node. This UUID
+              is randomly generated when Kong starts, so the node will have a
+              different `node_id` each time it is restarted.
+            * `available_on_server`: Names of plugins that are installed on the node.
+            * `enabled_in_cluster`: Names of plugins that are enabled/configured.
+              That is, the plugins configurations currently in the datastore shared
+              by all Kong nodes.
+          ]],
+        },
+      },
+      ["/status"] = {
+        GET = {
+          title = [[Retrieve node status]],
+          endpoint = [[<div class="endpoint get">/status</div>]],
+          description = [[
+            Retrieve usage information about a node, with some basic information
+            about the connections being processed by the underlying nginx process,
+            the status of the database connection, and node's memory usage.
+
+            If you want to monitor the Kong process, since Kong is built on top
+            of nginx, every existing nginx monitoring tool or agent can be used.
+          ]],
+          response = [[
+            ```
+            HTTP 200 OK
+            ```
+
+            ```json
+            {
+                "database": {
+                  "reachable": true
+                },
+                "memory": {
+                    "workers_lua_vms": [{
+                        "http_allocated_gc": "0.02 MiB",
+                        "pid": 18477
+                      }, {
+                        "http_allocated_gc": "0.02 MiB",
+                        "pid": 18478
+                    }],
+                    "lua_shared_dicts": {
+                        "kong": {
+                            "allocated_slabs": "0.04 MiB",
+                            "capacity": "5.00 MiB"
+                        },
+                        "kong_db_cache": {
+                            "allocated_slabs": "0.80 MiB",
+                            "capacity": "128.00 MiB"
+                        },
+                    }
+                },
+                "server": {
+                    "total_requests": 3,
+                    "connections_active": 1,
+                    "connections_accepted": 1,
+                    "connections_handled": 1,
+                    "connections_reading": 0,
+                    "connections_writing": 1,
+                    "connections_waiting": 0
+                }
+            }
+            ```
+
+            * `memory`: Metrics about the memory usage.
+                * `workers_lua_vms`: An array with all workers of the Kong node, where each
+                  entry contains:
+                * `http_allocated_gc`: HTTP submodule's Lua virtual machine's memory
+                  usage information, as reported by `collectgarbage("count")`, for every
+                  active worker, i.e. a worker that received a proxy call in the last 10
+                  seconds.
+                * `pid`: worker's process identification number.
+                * `lua_shared_dicts`: An array of information about dictionaries that are
+                  shared with all workers in a Kong node, where each array node contains how
+                  much memory is dedicated for the specific shared dictionary (`capacity`)
+                  and how much of said memory is in use (`allocated_slabs`).
+                  These shared dictionaries have least recent used (LRU) eviction
+                  capabilities, so a full dictionary, where `allocated_slabs == capacity`,
+                  will work properly. However for some dictionaries, e.g. cache HIT/MISS
+                  shared dictionaries, increasing their size can be beneficial for the
+                  overall performance of a Kong node.
+              * The memory usage unit and precision can be changed using the querystring
+                arguments `unit` and `scale`:
+                  * `unit`: one of `b/B`, `k/K`, `m/M`, `g/G`, which will return results
+                    in bytes, kibibytes, mebibytes, or gibibytes, respectively. When
+                    "bytes" are requested, the memory values in the response will have a
+                    number type instead of string. Defaults to `m`.
+                  * `scale`: the number of digits to the right of the decimal points when
+                    values are given in human-readable memory strings (unit other than
+                    "bytes"). Defaults to `2`.
+                  You can get the shared dictionaries memory usage in kibibytes with 4
+                  digits of precision by doing: `GET /status?unit=k&scale=4`
+            * `server`: Metrics about the nginx HTTP/S server.
+                * `total_requests`: The total number of client requests.
+                * `connections_active`: The current number of active client
+                  connections including Waiting connections.
+                * `connections_accepted`: The total number of accepted client
+                  connections.
+                * `connections_handled`: The total number of handled connections.
+                  Generally, the parameter value is the same as accepts unless
+                  some resource limits have been reached.
+                * `connections_reading`: The current number of connections
+                  where Kong is reading the request header.
+                * `connections_writing`: The current number of connections
+                  where nginx is writing the response back to the client.
+                * `connections_waiting`: The current number of idle client
+                  connections waiting for a request.
+            * `database`: Metrics about the database.
+                * `reachable`: A boolean value reflecting the state of the
+                  database connection. Please note that this flag **does not**
+                  reflect the health of the database itself.
+          ]],
+        },
+      }
+    },
+    config = {
+      skip = true,
+    },
+    tags = {
+      title = [[ Tags ]],
+      description = [[
+        Tags are strings associated to entities in Kong. Each tag must be composed of one or more
+        alphanumeric characters, `_`, `-`, `.` or `~`.
+
+        Most core entities can be *tagged* via their `tags` attribute, upon creation or edition.
+
+        Tags can be used to filter core entities as well, via the `?tags` querystring parameter.
+
+        For example: if you normally get a list of all the Services by doing:
+
+        ```
+        GET /services
+        ```
+
+        You can get the list of all the Services tagged `example` by doing:
+
+        ```
+        GET /services?tags=example
+        ```
+
+        Similarly, if you want to filter Services so that you only get the ones tagged `example` *and*
+        `admin`, you can do that like so:
+
+        ```
+        GET /services?tags=example,admin
+        ```
+
+        Finally, if you wanted to filter the Services tagged `example` *or* `admin`, you could use:
+
+        ```
+        GET /services?tags=example/admin
+        ```
+
+        Some notes:
+
+        * A maximum of 5 tags can be queried simultaneously in a single request with `,` or `/`
+        * Mixing operators is not supported: if you try to mix `,` with `/` in the same querystring,
+          you will receive an error.
+        * You may need to quote and/or escape some characters when using them from the
+          command line.
+        * Filtering by `tags` is not supported in foreign key relationship endpoints. For example,
+          the `tags` parameter will be ignored in a request such as `GET /services/foo/routes?tags=a,b`
+        * `offset` parameters are not guaranteed to work if the `tags` parameter is altered or removed
+      ]],
+      ["/tags"] = {
+        GET = {
+          title = [[ List all tags ]],
+          endpoint = [[<div class="endpoint get">/tags</div>]],
+          description = [[
+            Returns a paginated list of all the tags in the system.
+
+            The list of entities will not be restricted to a single entity type: all the
+            entities tagged with tags will be present on this list.
+
+            If an entity is tagged with more than one tag, the `entity_id` for that entity
+            will appear more than once in the resulting list. Similarly, if several entities
+            have been tagged with the same tag, the tag will appear in several items of this list.
+          ]],
+          response = [[
+            ```
+            HTTP 200 OK
+            ```
+
+            ``` json
+            {
+                {
+                  "data": [
+                    { "entity_name": "services",
+                      "entity_id": "acf60b10-125c-4c1a-bffe-6ed55daefba4",
+                      "tag": "s1",
+                    },
+                    { "entity_name": "services",
+                      "entity_id": "acf60b10-125c-4c1a-bffe-6ed55daefba4",
+                      "tag": "s2",
+                    },
+                    { "entity_name": "routes",
+                      "entity_id": "60631e85-ba6d-4c59-bd28-e36dd90f6000",
+                      "tag": "s1",
+                    },
+                    ...
+                  ],
+                  "offset" = "c47139f3-d780-483d-8a97-17e9adc5a7ab",
+                  "next" = "/tags?offset=c47139f3-d780-483d-8a97-17e9adc5a7ab",
+                }
+            }
+            ```
+          ]]
+        },
+      },
+
+      ["/tags/:tags"] = {
+        GET = {
+          title = [[ List entity IDs by tag ]],
+          endpoint = [[<div class="endpoint get">/tags/:tags</div>]],
+          description = [[
+            Returns the entities that have been tagged with the specified tag.
+
+            The list of entities will not be restricted to a single entity type: all the
+            entities tagged with tags will be present on this list.
+          ]],
+          response = [[
+            ```
+            HTTP 200 OK
+            ```
+
+            ``` json
+            {
+                {
+                  "data": [
+                    { "entity_name": "services",
+                      "entity_id": "c87440e1-0496-420b-b06f-dac59544bb6c",
+                      "tag": "example",
+                    },
+                    { "entity_name": "routes",
+                      "entity_id": "8a99e4b1-d268-446b-ab8b-cd25cff129b1",
+                      "tag": "example",
+                    },
+                    ...
+                  ],
+                  "offset" = "1fb491c4-f4a7-4bca-aeba-7f3bcee4d2f9",
+                  "next" = "/tags/example?offset=1fb491c4-f4a7-4bca-aeba-7f3bcee4d2f9",
+                }
+            }
+            ```
+          ]]
+        },
+      },
+    },
+  },
+
+--------------------------------------------------------------------------------
+-- Entities
+--------------------------------------------------------------------------------
+
+  entities = {
+    services = {
+      description = [[
+        Service entities, as the name implies, are abstractions of each of your own
+        upstream services. Examples of Services would be a data transformation
+        microservice, a billing API, etc.
+
+        The main attribute of a Service is its URL (where Kong should proxy traffic
+        to), which can be set as a single string or by specifying its `protocol`,
+        `host`, `port` and `path` individually.
+
+        Services are associated to Routes (a Service can have many Routes associated
+        with it). Routes are entry-points in Kong and define rules to match client
+        requests. Once a Route is matched, Kong proxies the request to its associated
+        Service. See the [Proxy Reference][proxy-reference] for a detailed explanation
+        of how Kong proxies traffic.
+      ]],
+      fields = {
+        id = { skip = true },
+        created_at = { skip = true },
+        updated_at = { skip = true },
+        name = {
+          description = [[The Service name.]]
+        },
+        protocol = {
+          description = [[
+            The protocol used to communicate with the upstream.
+            It can be one of `http` or `https`.
+          ]]
+        },
+        host = {
+          description = [[The host of the upstream server.]],
+          example = "example.com",
+        },
+        port = {
+          description = [[The upstream server port.]]
+        },
+        path = {
+          description = [[The path to be used in requests to the upstream server.]],
+          examples = {
+            "/some_api",
+            "/another_api",
+          }
+        },
+        retries = {
+          description = [[The number of retries to execute upon failure to proxy.]]
+        },
+        connect_timeout = {
+          description = [[
+            The timeout in milliseconds for establishing a connection to the
+            upstream server.
+          ]]
+        },
+        write_timeout = {
+          description = [[
+            The timeout in milliseconds between two successive write operations
+            for transmitting a request to the upstream server.
+          ]]
+        },
+        read_timeout = {
+          description = [[
+            The timeout in milliseconds between two successive read operations
+            for transmitting a request to the upstream server.
+          ]]
+        },
+        tags = {
+          description = [[
+            An optional set of strings associated with the Service, for grouping and filtering.
+          ]],
+          examples = {
+            { "user-level", "low-priority" },
+            { "admin", "high-priority", "critical" }
+          },
+        },
+      },
+      extra_fields = {
+        { url = {
+          kind = "shorthand-attribute",
+          description = [[
+            Shorthand attribute to set `protocol`, `host`, `port` and `path`
+            at once. This attribute is write-only (the Admin API never
+            "returns" the url).
+          ]]
+        } },
+      }
+    },
+
+    routes = {
+      description = [[
+        Route entities define rules to match client requests. Each Route is
+        associated with a Service, and a Service may have multiple Routes associated to
+        it. Every request matching a given Route will be proxied to its associated
+        Service.
+
+        The combination of Routes and Services (and the separation of concerns between
+        them) offers a powerful routing mechanism with which it is possible to define
+        fine-grained entry-points in Kong leading to different upstream services of
+        your infrastructure.
+      ]],
+      fields = {
+        id = { skip = true },
+        created_at = { skip = true },
+        updated_at = { skip = true },
+        name = {
+          description = [[The name of the Route.]]
+        },
+        regex_priority = {
+          description = [[
+            A number used to choose which route resolves a given request when several
+            routes match it using regexes simultaneously. When two routes match the path
+            and have the same `regex_priority`, the older one (lowest `created_at`)
+            is used. Note that the priority for non-regex routes is different (longer
+            non-regex routes are matched before shorter ones).
+          ]]
+        },
+        protocols = {
+          description = [[
+            A list of the protocols this Route should allow. When set to `["https"]`,
+            HTTP requests are answered with a request to upgrade to HTTPS.
+          ]],
+          examples = {
+            {"http", "https"},
+            {"tcp", "tls"},
+          }
+        },
+        methods = {
+          kind = "semi-optional",
+          description = [[
+            A list of HTTP methods that match this Route.
+            When using `http` or `https` protocols, at least one of `hosts`, `paths`, or `methods` must be set.
+          ]],
+          examples = { {"GET", "POST"}, nil },
+          skip_in_example = true, -- hack so we get HTTP fields in the first example and Stream fields in the second
+        },
+        hosts = {
+          kind = "semi-optional",
+          description = [[
+            A list of domain names that match this Route.
+            When using `http` or `https` protocols, at least one of `hosts`, `paths`, or `methods` must be set.
+          ]],
+          examples = { {"example.com", "foo.test"}, nil },
+          skip_in_example = true, -- hack so we get HTTP fields in the first example and Stream fields in the second
+        },
+        paths = {
+          kind = "semi-optional",
+          description = [[
+            A list of paths that match this Route.
+            When using `http` or `https` protocols, at least one of `hosts`, `paths`, or `methods` must be set.
+          ]],
+          examples = { {"/foo", "/bar"}, nil },
+          skip_in_example = true, -- hack so we get HTTP fields in the first example and Stream fields in the second
+        },
+        snis = {
+          kind = "semi-optional",
+          description = [[
+            A list of SNIs that match this Route when using stream routing.
+            When using `tcp` or `tls` protocols, at least one of `snis`, `sources`, or `destinations` must be set.
+          ]],
+          examples = { nil, {"foo.test", "example.com"} },
+          skip_in_example = true, -- hack so we get HTTP fields in the first example and Stream fields in the second
+        },
+        sources = {
+          kind = "semi-optional",
+          description = [[
+            A list of IP sources of incoming connections that match this Route when using stream routing.
+            Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port".
+            When using `tcp` or `tls` protocols, at least one of `snis`, `sources`, or `destinations` must be set.
+          ]],
+          examples = { nil, {{ip = "10.1.0.0/16", port = 1234}, {ip = "10.2.2.2"}, {port = 9123}} },
+          skip_in_example = true, -- hack so we get HTTP fields in the first example and Stream fields in the second
+        },
+        destinations = {
+          kind = "semi-optional",
+          description = [[
+            A list of IP destinations of incoming connections that match this Route when using stream routing.
+            Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port".
+            When using `tcp` or `tls` protocols, at least one of `snis`, `sources`, or `destinations` must be set.
+          ]],
+          examples = { nil, {{ip = "10.1.0.0/16", port = 1234}, {ip = "10.2.2.2"}, {port = 9123}} },
+          skip_in_example = true, -- hack so we get HTTP fields in the first example and Stream fields in the second
+        },
+        strip_path = {
+          description = [[
+            When matching a Route via one of the `paths`,
+            strip the matching prefix from the upstream request URL.
+          ]]
+        },
+        preserve_host = {
+          description = [[
+            When matching a Route via one of the `hosts` domain names,
+            use the request `Host` header in the upstream request headers.
+            If set to `false`, the upstream `Host` header will be that of
+            the Service's `host`.
+          ]]
+        },
+        service = {
+          description = [[
+            The Service this Route is associated to.
+            This is where the Route proxies traffic to.
+          ]]
+        },
+        https_redirect_status_code = {
+          description = [[
+            The status code Kong responds with when all properties of a Route
+            match except the protocol i.e. if the protocol of the request
+            is `HTTP` instead of `HTTPS`.
+            `Location` header is injected by Kong if the field is set
+            to 301, 302, 307 or 308.
+          ]]
+        },
+        tags = {
+          description = [[
+            An optional set of strings associated with the Route, for grouping and filtering.
+          ]],
+          examples = {
+            { "user-level", "low-priority" },
+            { "admin", "high-priority", "critical" }
+          },
+        },
+      }
+    },
+
+    consumers = {
+      description = [[
+        The Consumer object represents a consumer - or a user - of a Service. You can
+        either rely on Kong as the primary datastore, or you can map the consumer list
+        with your database to keep consistency between Kong and your existing primary
+        datastore.
+      ]],
+      fields = {
+        id = { skip = true },
+        created_at = { skip = true },
+        updated_at = { skip = true },
+        username = {
+          kind = "semi-optional",
+          description = [[
+            The unique username of the consumer. You must send either
+            this field or `custom_id` with the request.
+          ]],
+          example = "my-username",
+        },
+        custom_id = {
+          kind = "semi-optional",
+          description = [[
+            Field for storing an existing unique ID for the consumer -
+            useful for mapping Kong with users in your existing database.
+            You must send either this field or `username` with the request.
+          ]],
+          example = "my-custom-id",
+        },
+        tags = {
+          description = [[
+            An optional set of strings associated with the Consumer, for grouping and filtering.
+          ]],
+          examples = {
+            { "user-level", "low-priority" },
+            { "admin", "high-priority", "critical" }
+          },
+        },
+      }
+    },
+
+    plugins = {
+      description = [[
+        A Plugin entity represents a plugin configuration that will be executed during
+        the HTTP request/response lifecycle. It is how you can add functionalities
+        to Services that run behind Kong, like Authentication or Rate Limiting for
+        example. You can find more information about how to install and what values
+        each plugin takes by visiting the [Kong Hub](https://docs.konghq.com/hub/).
+
+        When adding a Plugin Configuration to a Service, every request made by a client to
+        that Service will run said Plugin. If a Plugin needs to be tuned to different
+        values for some specific Consumers, you can do so by creating a separate
+        plugin instance that specifies both the Service and the Consumer, through the
+        `service` and `consumer` fields.
+      ]],
+      details = [[
+        See the [Precedence](#precedence) section below for more details.
+
+        #### Precedence
+
+        A plugin will always be run once and only once per request. But the
+        configuration with which it will run depends on the entities it has been
+        configured for.
+
+        Plugins can be configured for various entities, combination of entities, or
+        even globally. This is useful, for example, when you wish to configure a plugin
+        a certain way for most requests, but make _authenticated requests_ behave
+        slightly differently.
+
+        Therefore, there exists an order of precedence for running a plugin when it has
+        been applied to different entities with different configurations. The rule of
+        thumb is: the more specific a plugin is with regards to how many entities it
+        has been configured on, the higher its priority.
+
+        The complete order of precedence when a plugin has been configured multiple
+        times is:
+
+        1. Plugins configured on a combination of: a Route, a Service, and a Consumer.
+            (Consumer means the request must be authenticated).
+        2. Plugins configured on a combination of a Route and a Consumer.
+            (Consumer means the request must be authenticated).
+        3. Plugins configured on a combination of a Service and a Consumer.
+            (Consumer means the request must be authenticated).
+        4. Plugins configured on a combination of a Route and a Service.
+        5. Plugins configured on a Consumer.
+            (Consumer means the request must be authenticated).
+        6. Plugins configured on a Route.
+        7. Plugins configured on a Service.
+        8. Plugins configured to run globally.
+
+        **Example**: if the `rate-limiting` plugin is applied twice (with different
+        configurations): for a Service (Plugin config A), and for a Consumer (Plugin
+        config B), then requests authenticating this Consumer will run Plugin config B
+        and ignore A. However, requests that do not authenticate this Consumer will
+        fallback to running Plugin config A. Note that if config B is disabled
+        (its `enabled` flag is set to `false`), config A will apply to requests that
+        would have otherwise matched config B.
+      ]],
+
+      ["/plugins/schema/:name"] = {
+        GET = {
+          title = [[Retrieve Plugin Schema]],
+          endpoint = [[<div class="endpoint get">/plugins/schema/{plugin name}</div>]],
+          description = [[
+            Retrieve the schema of a plugin's configuration. This is useful to
+            understand what fields a plugin accepts, and can be used for building
+            third-party integrations to the Kong's plugin system.
+          ]],
+          response = [[
+            ```
+            HTTP 200 OK
+            ```
+
+            ```json
+            {
+                "fields": {
+                    "hide_credentials": {
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "key_names": {
+                        "default": "function",
+                        "required": true,
+                        "type": "array"
+                    }
+                }
+            }
+            ```
+          ]],
+        }
+      },
+
+      ["/plugins/enabled"] = {
+        GET = {
+          title = [[Retrieve Enabled Plugins]],
+          description = [[Retrieve a list of all installed plugins on the Kong node.]],
+          endpoint = [[<div class="endpoint get">/plugins/enabled</div>]],
+          response = [[
+            ```
+            HTTP 200 OK
+            ```
+
+            ```json
+            {
+                "enabled_plugins": [
+                    "jwt",
+                    "acl",
+                    "cors",
+                    "oauth2",
+                    "tcp-log",
+                    "udp-log",
+                    "file-log",
+                    "http-log",
+                    "key-auth",
+                    "hmac-auth",
+                    "basic-auth",
+                    "ip-restriction",
+                    "request-transformer",
+                    "response-transformer",
+                    "request-size-limiting",
+                    "rate-limiting",
+                    "response-ratelimiting",
+                    "aws-lambda",
+                    "bot-detection",
+                    "correlation-id",
+                    "datadog",
+                    "galileo",
+                    "ldap-auth",
+                    "loggly",
+                    "statsd",
+                    "syslog"
+                ]
+            }
+            ```
+          ]]
+        }
+      },
+
+      -- While these endpoints actually support DELETE (deleting the entity and
+      -- cascade-deleting the plugin), we do not document them, as this operation
+      -- is somewhat odd.
+      ["/plugins/:plugins/route"] = {
+        DELETE = {
+          endpoint = false,
+        }
+      },
+      ["/plugins/:plugins/service"] = {
+        DELETE = {
+          endpoint = false,
+        }
+      },
+      ["/plugins/:plugins/consumer"] = {
+        DELETE = {
+          endpoint = false,
+        }
+      },
+      -- Skip deprecated endpoints
+      ["/routes/:routes/plugins/:plugins"] = {
+        skip = true,
+      },
+      ["/services/:services/plugins/:plugins"] = {
+        skip = true,
+      },
+      ["/consumers/:consumers/plugins/:plugins"] = {
+        skip = true,
+      },
+
+      fields = {
+        id = { skip = true },
+        created_at = { skip = true },
+        updated_at = { skip = true },
+        name = {
+          description = [[
+            The name of the Plugin that's going to be added. Currently the
+            Plugin must be installed in every Kong instance separately.
+          ]],
+          example = "rate-limiting",
+        },
+        config = {
+          description = [[
+            The configuration properties for the Plugin which can be found on
+            the plugins documentation page in the
+            [Kong Hub](https://docs.konghq.com/hub/).
+          ]],
+          example = { minute = 20, hour = 500 },
+        },
+        enabled = { description = [[Whether the plugin is applied.]] },
+        route = { description = [[
+          If set, the plugin will only activate when receiving requests via the specified route. Leave
+          unset for the plugin to activate regardless of the Route being used.
+        ]] },
+        service = { description = [[
+          If set, the plugin will only activate when receiving requests via one of the routes belonging to the
+          specified Service. Leave unset for the plugin to activate regardless of the Service being
+          matched.
+        ]] },
+        consumer = { description = [[
+          If set, the plugin will activate only for requests where the specified has been authenticated.
+          (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin
+          to activate regardless of the authenticated consumer.
+        ]] },
+        run_on = { description = [[
+          Control on which Kong nodes this plugin will run, given a Service Mesh scenario.
+          Accepted values are:
+          * `first`, meaning "run on the first Kong node that is encountered by the request".
+            On an API Getaway scenario, this is the usual operation, since there is only
+            one Kong node in between source and destination. In a sidecar-to-sidecar Service
+            Mesh scenario, this means running the plugin only on the
+            Kong sidecar of the outbound connection.
+          * `second`, meaning "run on the second node that is encountered by the request".
+            This option is only relevant for sidecar-to-sidecar Service
+            Mesh scenarios: this means running the plugin only on the
+            Kong sidecar of the inbound connection.
+          * `all` means "run on all nodes", meaning both sidecars in a sidecar-to-sidecar
+            scenario. This is useful for tracing/logging plugins.
+        ]] },
+        protocols = {
+          description = [[
+            A list of the request protocols that will trigger this plugin. Possible values are
+            `"http"`, `"https"`, `"tcp"`, and `"tls"`.
+
+            The default value, as well as the possible values allowed on this field, may change
+            depending on the plugin type. For example, plugins that only work in stream mode will
+            may only support `"tcp"` and `"tls"`.
+          ]],
+          examples = {
+            { "http", "https" },
+            { "tcp", "tls" },
+          },
+        },
+        tags = {
+          description = [[
+            An optional set of strings associated with the Plugin, for grouping and filtering.
+          ]],
+          examples = {
+            { "user-level", "low-priority" },
+            { "admin", "high-priority", "critical" }
+          },
+        },
+      }
+    },
+
+    certificates = {
+      description = [[
+        A certificate object represents a public certificate, and can be optionally paired with the
+        corresponding private key. These objects are used by Kong to handle SSL/TLS termination for
+        encrypted requests, or for use as a trusted CA store when validating peer certificate of
+        client/service. Certificates are optionally associated with SNI objects to
+        tie a cert/key pair to one or more hostnames.
+      ]],
+      fields = {
+        id = { skip = true },
+        created_at = { skip = true },
+        cert = {
+          description = [[PEM-encoded public certificate of the SSL key pair.]],
+          example = "-----BEGIN CERTIFICATE-----...",
+        },
+        key = {
+          description = [[PEM-encoded private key of the SSL key pair.]],
+          example = "-----BEGIN RSA PRIVATE KEY-----..."
+        },
+        tags = {
+          description = [[
+            An optional set of strings associated with the Certificate, for grouping and filtering.
+          ]],
+          examples = {
+            { "user-level", "low-priority" },
+            { "admin", "high-priority", "critical" }
+          },
+        },
+      },
+      extra_fields = {
+        { snis = {
+          kind = "shorthand-attribute",
+          description = [[
+            An array of zero or more hostnames to associate with this
+            certificate as SNIs. This is a sugar parameter that will, under the
+            hood, create an SNI object and associate it with this certificate
+            for your convenience. To set this attribute this certificate must
+            have a valid private key associated with it.
+          ]]
+        } },
+      },
+
+    },
+
+    snis = {
+      entity_title = "SNI",
+      entity_title_plural = "SNIs",
+      description = [[
+        An SNI object represents a many-to-one mapping of hostnames to a certificate.
+        That is, a certificate object can have many hostnames associated with it; when
+        Kong receives an SSL request, it uses the SNI field in the Client Hello to
+        lookup the certificate object based on the SNI associated with the certificate.
+      ]],
+      ["/snis/:snis/certificate"] = {
+        endpoint = false,
+      },
+      fields = {
+        id = { skip = true },
+        created_at = { skip = true },
+        name = { description = [[The SNI name to associate with the given certificate.]] },
+        certificate = {
+          description = [[
+            The id (a UUID) of the certificate with which to associate the SNI hostname.
+            The Certificate must have a valid private key associated with it to be used
+            by the SNI object.
+          ]]
+        },
+        tags = {
+          description = [[
+            An optional set of strings associated with the SNIs, for grouping and filtering.
+          ]],
+          examples = {
+            { "user-level", "low-priority" },
+            { "admin", "high-priority", "critical" }
+          },
+        },
+      },
+    },
+
+    upstreams = {
+      description = [[
+        The upstream object represents a virtual hostname and can be used to loadbalance
+        incoming requests over multiple services (targets). So for example an upstream
+        named `service.v1.xyz` for a Service object whose `host` is `service.v1.xyz`.
+        Requests for this Service would be proxied to the targets defined within the upstream.
+
+        An upstream also includes a [health checker][healthchecks], which is able to
+        enable and disable targets based on their ability or inability to serve
+        requests. The configuration for the health checker is stored in the upstream
+        object, and applies to all of its targets.
+      ]],
+      ["/upstreams/:upstreams/health"] = {
+        GET = {
+          title = [[Show Upstream health for node]],
+          description = [[
+            Displays the health status for all Targets of a given Upstream, according to
+            the perspective of a specific Kong node. Note that, being node-specific
+            information, making this same request to different nodes of the Kong cluster
+            may produce different results. For example, one specific node of the Kong
+            cluster may be experiencing network issues, causing it to fail to connect to
+            some Targets: these Targets will be marked as unhealthy by that node
+            (directing traffic from this node to other Targets that it can successfully
+            reach), but healthy to all others Kong nodes (which have no problems using that
+            Target).
+
+            The `data` field of the response contains an array of Target objects.
+            The health for each Target is returned in its `health` field:
+
+            * If a Target fails to be activated in the ring balancer due to DNS issues,
+              its status displays as `DNS_ERROR`.
+            * When [health checks][healthchecks] are not enabled in the Upstream
+              configuration, the health status for active Targets is displayed as
+              `HEALTHCHECKS_OFF`.
+            * When health checks are enabled and the Target is determined to be healthy,
+              either automatically or [manually](#set-target-as-healthy),
+              its status is displayed as `HEALTHY`. This means that this Target is
+              currently included in this Upstream's load balancer ring.
+            * When a Target has been disabled by either active or passive health checks
+              (circuit breakers) or [manually](#set-target-as-unhealthy),
+              its status is displayed as `UNHEALTHY`. The load balancer is not directing
+              any traffic to this Target via this Upstream.
+          ]],
+          endpoint = [[
+            <div class="endpoint get">/upstreams/{name or id}/health/</div>
+
+            Attributes | Description
+            ---:| ---
+            `name or id`<br>**required** | The unique identifier **or** the name of the Upstream for which to display Target health.
+          ]],
+          response = [[
+            ```
+            HTTP 200 OK
+            ```
+
+            ```json
+            {
+                "total": 2,
+                "node_id": "cbb297c0-14a9-46bc-ad91-1d0ef9b42df9",
+                "data": [
+                    {
+                        "created_at": 1485524883980,
+                        "id": "18c0ad90-f942-4098-88db-bbee3e43b27f",
+                        "health": "HEALTHY",
+                        "target": "127.0.0.1:20000",
+                        "upstream_id": "07131005-ba30-4204-a29f-0927d53257b4",
+                        "weight": 100
+                    },
+                    {
+                        "created_at": 1485524914883,
+                        "id": "6c6f34eb-e6c3-4c1f-ac58-4060e5bca890",
+                        "health": "UNHEALTHY",
+                        "target": "127.0.0.1:20002",
+                        "upstream_id": "07131005-ba30-4204-a29f-0927d53257b4",
+                        "weight": 200
+                    }
+                ]
+            }
+            ```
+          ]],
+        },
+
+      },
+      fields = {
+        id = { skip = true },
+        created_at = { skip = true },
+        ["name"] = { description = [[This is a hostname, which must be equal to the `host` of a Service.]] },
+        ["slots"] = { description = [[The number of slots in the loadbalancer algorithm (`10`-`65536`).]] },
+        ["hash_on"] = { description = [[What to use as hashing input: `none` (resulting in a weighted-round-robin scheme with no hashing), `consumer`, `ip`, `header`, or `cookie`.]] },
+        ["hash_fallback"] = { description = [[What to use as hashing input if the primary `hash_on` does not return a hash (eg. header is missing, or no consumer identified). One of: `none`, `consumer`, `ip`, `header`, or `cookie`. Not available if `hash_on` is set to `cookie`.]] },
+        ["hash_on_header"] = { kind = "semi-optional", skip_in_example = true, description = [[The header name to take the value from as hash input. Only required when `hash_on` is set to `header`.]] },
+        ["hash_fallback_header"] = { kind = "semi-optional", skip_in_example = true, description = [[The header name to take the value from as hash input. Only required when `hash_fallback` is set to `header`.]] },
+        ["hash_on_cookie"] = { kind = "semi-optional", skip_in_example = true, description = [[The cookie name to take the value from as hash input. Only required when `hash_on` or `hash_fallback` is set to `cookie`. If the specified cookie is not in the request, Kong will generate a value and set the cookie in the response.]] },
+        ["hash_on_cookie_path"] = { kind = "semi-optional", skip_in_example = true, description = [[The cookie path to set in the response headers. Only required when `hash_on` or `hash_fallback` is set to `cookie`.]] },
+        ["healthchecks.active.timeout"] = { description = [[Socket timeout for active health checks (in seconds).]] },
+        ["healthchecks.active.concurrency"] = { description = [[Number of targets to check concurrently in active health checks.]] },
+        ["healthchecks.active.type"] = { description = [[Whether to perform active health checks using HTTP or HTTPS, or just attempt a TCP connection. Possible values are `tcp`, `http` or `https`.]] },
+        ["healthchecks.active.http_path"] = { description = [[Path to use in GET HTTP request to run as a probe on active health checks.]] },
+        ["healthchecks.active.https_verify_certificate"] = { description = [[Whether to check the validity of the SSL certificate of the remote host when performing active health checks using HTTPS.]] },
+        ["healthchecks.active.https_sni"] = { description = [[The hostname to use as an SNI (Server Name Identification) when performing active health checks using HTTPS. This is particularly useful when Targets are configured using IPs, so that the target host's certificate can be verified with the proper SNI.]], example = "example.com", },
+        ["healthchecks.active.healthy.interval"] = { description = [[Interval between active health checks for healthy targets (in seconds). A value of zero indicates that active probes for healthy targets should not be performed.]] },
+        ["healthchecks.active.healthy.http_statuses"] = { description = [[An array of HTTP statuses to consider a success, indicating healthiness, when returned by a probe in active health checks.]] },
+        ["healthchecks.active.healthy.successes"] = { description = [[Number of successes in active probes (as defined by `healthchecks.active.healthy.http_statuses`) to consider a target healthy.]] },
+        ["healthchecks.active.unhealthy.interval"] = { description = [[Interval between active health checks for unhealthy targets (in seconds). A value of zero indicates that active probes for unhealthy targets should not be performed.]] },
+        ["healthchecks.active.unhealthy.http_statuses"] = { description = [[An array of HTTP statuses to consider a failure, indicating unhealthiness, when returned by a probe in active health checks.]] },
+        ["healthchecks.active.unhealthy.tcp_failures"] = { description = [[Number of TCP failures in active probes to consider a target unhealthy.]] },
+        ["healthchecks.active.unhealthy.timeouts"] = { description = [[Number of timeouts in active probes to consider a target unhealthy.]] },
+        ["healthchecks.active.unhealthy.http_failures"] = { description = [[Number of HTTP failures in active probes (as defined by `healthchecks.active.unhealthy.http_statuses`) to consider a target unhealthy.]] },
+        ["healthchecks.passive.type"] = { description = [[Whether to perform passive health checks interpreting HTTP/HTTPS statuses, or just check for TCP connection success. Possible values are `tcp`, `http` or `https` (in passive checks, `http` and `https` options are equivalent.).]] },
+        ["healthchecks.passive.healthy.http_statuses"] = { description = [[An array of HTTP statuses which represent healthiness when produced by proxied traffic, as observed by passive health checks.]] },
+        ["healthchecks.passive.healthy.successes"] = { description = [[Number of successes in proxied traffic (as defined by `healthchecks.passive.healthy.http_statuses`) to consider a target healthy, as observed by passive health checks.]] },
+        ["healthchecks.passive.unhealthy.http_statuses"] = { description = [[An array of HTTP statuses which represent unhealthiness when produced by proxied traffic, as observed by passive health checks.]] },
+        ["healthchecks.passive.unhealthy.tcp_failures"] = { description = [[Number of TCP failures in proxied traffic to consider a target unhealthy, as observed by passive health checks.]] },
+        ["healthchecks.passive.unhealthy.timeouts"] = { description = [[Number of timeouts in proxied traffic to consider a target unhealthy, as observed by passive health checks.]] },
+        ["healthchecks.passive.unhealthy.http_failures"] = { description = [[Number of HTTP failures in proxied traffic (as defined by `healthchecks.passive.unhealthy.http_statuses`) to consider a target unhealthy, as observed by passive health checks.]] },
+        tags = {
+          description = [[
+            An optional set of strings associated with the Upstream, for grouping and filtering.
+          ]],
+          examples = {
+            { "user-level", "low-priority" },
+            { "admin", "high-priority", "critical" }
+          },
+        },
+      }
+    },
+
+    targets = {
+      entity_endpoint_key = "host:port",
+      description = [[
+        A target is an ip address/hostname with a port that identifies an instance of a backend
+        service. Every upstream can have many targets, and the targets can be
+        dynamically added. Changes are effectuated on the fly.
+
+        Because the upstream maintains a history of target changes, the targets cannot
+        be deleted or modified. To disable a target, post a new one with `weight=0`;
+        alternatively, use the `DELETE` convenience method to accomplish the same.
+
+        The current target object definition is the one with the latest `created_at`.
+      ]],
+      ["/targets"] = {
+        -- This is not using `skip = true` because
+        -- we want the sections for GETting targets and POSTing targets to appear,
+        -- but we don't want them to appear using `GET /targets` and `POST /targets`.
+        -- Instead, we want the section itself to appear, but only the endpoints
+        -- generated via foreign keys (`GET /upstreams/:upstreams/targets` and
+        -- `POST /upstreams/:upstream/targets`)
+        endpoint = false,
+      },
+      ["/targets/:targets"] = {
+        skip = true,
+      },
+      ["/targets/:targets/upstreams"] = {
+        skip = true,
+      },
+      ["/upstreams/:upstreams/targets/:targets"] = {
+        DELETE = {
+          title = [[Delete Target]],
+          description = [[
+            Disable a target in the load balancer. Under the hood, this method creates
+            a new entry for the given target definition with a `weight` of 0.
+          ]],
+          endpoint = [[
+            <div class="endpoint delete">/upstreams/{upstream name or id}/targets/{host:port or id}</div>
+
+            Attributes | Description
+            ---:| ---
+            `upstream name or id`<br>**required** | The unique identifier **or** the name of the upstream for which to delete the target.
+            `host:port or id`<br>**required** | The host:port combination element of the target to remove, or the `id` of an existing target entry.
+          ]],
+          response = [[
+            ```
+            HTTP 204 No Content
+            ```
+          ]]
+        }
+      },
+
+      ["/upstreams/:upstreams/targets/all"] = {
+        GET = {
+          title = [[List all Targets]],
+          description = [[
+            Lists all targets of the upstream. Multiple target objects for the same
+            target may be returned, showing the history of changes for a specific target.
+            The target object with the latest `created_at` is the current definition.
+          ]],
+          endpoint = [[
+            <div class="endpoint get">/upstreams/{name or id}/targets/all/</div>
+
+            Attributes | Description
+            ---:| ---
+            `name or id`<br>**required** | The unique identifier **or** the name of the upstream for which to list the targets.
+          ]],
+          response = [[
+            ```
+            HTTP 200 OK
+            ```
+
+            ```json
+            {
+                "total": 2,
+                "data": [
+                    {
+                        "created_at": 1485524883980,
+                        "id": "18c0ad90-f942-4098-88db-bbee3e43b27f",
+                        "target": "127.0.0.1:20000",
+                        "upstream_id": "07131005-ba30-4204-a29f-0927d53257b4",
+                        "weight": 100
+                    },
+                    {
+                        "created_at": 1485524914883,
+                        "id": "6c6f34eb-e6c3-4c1f-ac58-4060e5bca890",
+                        "target": "127.0.0.1:20002",
+                        "upstream_id": "07131005-ba30-4204-a29f-0927d53257b4",
+                        "weight": 200
+                    }
+                ]
+            }
+            ```
+          ]],
+        }
+      },
+      ["/upstreams/:upstreams/targets/:targets/healthy"] = {
+        POST = {
+          title = [[Set target as healthy]],
+          description = [[
+            Set the current health status of a target in the load balancer to "healthy"
+            in the entire Kong cluster.
+
+            This endpoint can be used to manually re-enable a target that was previously
+            disabled by the upstream's [health checker][healthchecks]. Upstreams only
+            forward requests to healthy nodes, so this call tells Kong to start using this
+            target again.
+
+            This resets the health counters of the health checkers running in all workers
+            of the Kong node, and broadcasts a cluster-wide message so that the "healthy"
+            status is propagated to the whole Kong cluster.
+          ]],
+          endpoint = [[
+            <div class="endpoint post">/upstreams/{upstream name or id}/targets/{target or id}/healthy</div>
+
+            Attributes | Description
+            ---:| ---
+            `upstream name or id`<br>**required** | The unique identifier **or** the name of the upstream.
+            `target or id`<br>**required** | The host/port combination element of the target to set as healthy, or the `id` of an existing target entry.
+          ]],
+          response = [[
+            ```
+            HTTP 204 No Content
+            ```
+          ]],
+        }
+      },
+      ["/upstreams/:upstreams/targets/:targets/unhealthy"] = {
+        POST = {
+          title = [[Set target as unhealthy]],
+          description = [[
+            Set the current health status of a target in the load balancer to "unhealthy"
+            in the entire Kong cluster.
+
+            This endpoint can be used to manually disable a target and have it stop
+            responding to requests. Upstreams only forward requests to healthy nodes, so
+            this call tells Kong to start skipping this target in the ring-balancer
+            algorithm.
+
+            This call resets the health counters of the health checkers running in all
+            workers of the Kong node, and broadcasts a cluster-wide message so that the
+            "unhealthy" status is propagated to the whole Kong cluster.
+
+            [Active health checks][active] continue to execute for unhealthy
+            targets. Note that if active health checks are enabled and the probe detects
+            that the target is actually healthy, it will automatically re-enable it again.
+            To permanently remove a target from the ring-balancer, you should [delete a
+            target](#delete-target) instead.
+          ]],
+          endpoint = [[
+            <div class="endpoint post">/upstreams/{upstream name or id}/targets/{target or id}/unhealthy</div>
+
+            Attributes | Description
+            ---:| ---
+            `upstream name or id`<br>**required** | The unique identifier **or** the name of the upstream.
+            `target or id`<br>**required** | The host/port combination element of the target to set as unhealthy, or the `id` of an existing target entry.
+          ]],
+          response = [[
+            ```
+            HTTP 204 No Content
+            ```
+          ]],
+        }
+      },
+      fields = {
+        id = { skip = true },
+        created_at = { skip = true },
+        upstream = { skip = true },
+        target = {
+          description = [[
+            The target address (ip or hostname) and port.
+            If the hostname resolves to an SRV record, the `port` value will
+            be overridden by the value from the DNS record.
+          ]],
+          example = "example.com:8000",
+        },
+        weight = {
+          description = [[
+            The weight this target gets within the upstream loadbalancer (`0`-`1000`).
+            If the hostname resolves to an SRV record, the `weight` value will be
+            overridden by the value from the DNS record.
+          ]]
+        },
+        tags = {
+          description = [[
+            An optional set of strings associated with the Target, for grouping and filtering.
+          ]],
+          examples = {
+            { "user-level", "low-priority" },
+            { "admin", "high-priority", "critical" }
+          },
+        },
+      },
+    }
+  },
+
+--------------------------------------------------------------------------------
+-- Templates for auto-generated endpoints
+--------------------------------------------------------------------------------
+
+  collection_templates = {
+    GET = {
+      title = [[List ${Entities}]],
+      endpoint_w_ek = [[
+        ##### List All ${Entities}
+
+        <div class="endpoint ${method}">/${entities_url}</div>
+      ]],
+      endpoint = [[
+        ##### List All ${Entities}
+
+        <div class="endpoint ${method}">/${entities_url}</div>
+      ]],
+      fk_endpoint = [[
+        ##### List ${Entities} Associated to a Specific ${ForeignEntity}
+
+        <div class="endpoint ${method}">/${foreign_entities_url}/{${foreign_entity} id}/${entities_url}</div>
+
+        Attributes | Description
+        ---:| ---
+        `${foreign_entity} id`<br>**required** | The unique identifier of the ${ForeignEntity} whose ${Entities} are to be retrieved. When using this endpoint, only ${Entities} associated to the specified ${ForeignEntity} will be listed.
+      ]],
+      fk_endpoint_w_ek = [[
+        ##### List ${Entities} Associated to a Specific ${ForeignEntity}
+
+        <div class="endpoint ${method}">/${foreign_entities_url}/{${foreign_entity} ${endpoint_key} or id}/${entities_url}</div>
+
+        Attributes | Description
+        ---:| ---
+        `${foreign_entity} ${endpoint_key} or id`<br>**required** | The unique identifier or the `${endpoint_key}` attribute of the ${ForeignEntity} whose ${Entities} are to be retrieved. When using this endpoint, only ${Entities} associated to the specified ${ForeignEntity} will be listed.
+      ]],
+      request_query = [[
+        Attributes | Description
+        ---:| ---
+        `offset`<br>*optional* | A cursor used for pagination. `offset` is an object identifier that defines a place in the list.
+        `size`<br>*optional, default is __100__ max is __1000__* | A limit on the number of objects to be returned per page.
+      ]],
+      response = [[
+        ```
+        HTTP 200 OK
+        ```
+
+        ```json
+        {
+        {{ page.${entity}_data }}
+            "next": "http://localhost:8001/${entities_url}?offset=6378122c-a0a1-438d-a5c6-efabae9fb969"
+        }
+        ```
+      ]],
+    },
+    POST = {
+      title = [[Add ${Entity}]],
+      endpoint_w_ek = [[
+        ##### Create ${Entity}
+
+        <div class="endpoint ${method}">/${entities_url}</div>
+      ]],
+      endpoint = [[
+        ##### Create ${Entity}
+
+        <div class="endpoint ${method}">/${entities_url}</div>
+      ]],
+      fk_endpoint = [[
+        ##### Create ${Entity} Associated to a Specific ${ForeignEntity}
+
+        <div class="endpoint ${method}">/${foreign_entities_url}/{${foreign_entity} id}/${entities_url}</div>
+
+        Attributes | Description
+        ---:| ---
+        `${foreign_entity} id`<br>**required** | The unique identifier of the ${ForeignEntity} that should be associated to the newly-created ${Entity}.
+      ]],
+      fk_endpoint_w_ek = [[
+        ##### Create ${Entity} Associated to a Specific ${ForeignEntity}
+
+        <div class="endpoint ${method}">/${foreign_entities_url}/{${foreign_entity} ${endpoint_key} or id}/${entities_url}</div>
+
+        Attributes | Description
+        ---:| ---
+        `${foreign_entity} ${endpoint_key} or id`<br>**required** | The unique identifier or the `${endpoint_key}` attribute of the ${ForeignEntity} that should be associated to the newly-created ${Entity}.
+      ]],
+      request_body = [[
+        {{ page.${entity}_body }}
+      ]],
+      response = [[
+        ```
+        HTTP 201 Created
+        ```
+
+        ```json
+        {{ page.${entity}_json }}
+        ```
+      ]],
+    },
+  },
+  entity_templates = {
+    tags = [[
+      ${Entities} can be both [tagged and filtered by tags](#tags).
+    ]],
+    endpoint_w_ek = [[
+      ##### ${Active_verb} ${Entity}
+
+      <div class="endpoint ${method}">/${entities_url}/{${endpoint_key} or id}</div>
+
+      Attributes | Description
+      ---:| ---
+      `${endpoint_key} or id`<br>**required** | The unique identifier **or** the ${endpoint_key} of the ${Entity} to ${active_verb}.
+    ]],
+    fk_endpoint_w_ek = [[
+      ##### ${Active_verb} ${ForeignEntity} Associated to a Specific ${Entity}
+
+      <div class="endpoint ${method}">/${entities_url}/{${entity} ${endpoint_key} or id}/${foreign_entity_url}</div>
+
+      Attributes | Description
+      ---:| ---
+      `${entity} ${endpoint_key} or id`<br>**required** | The unique identifier **or** the ${endpoint_key} of the ${Entity} associated to the ${ForeignEntity} to be ${passive_verb}.
+    ]],
+    endpoint = [[
+      ##### ${Active_verb} ${Entity}
+
+      <div class="endpoint ${method}">/${entities_url}/{${entity} id}</div>
+
+      Attributes | Description
+      ---:| ---
+      `${entity} id`<br>**required** | The unique identifier of the ${Entity} to ${active_verb}.
+    ]],
+    fk_endpoint = [[
+      ##### ${Active_verb} ${ForeignEntity} Associated to a Specific ${Entity}
+
+      <div class="endpoint ${method}">/${entities_url}/{${entity} id}/${foreign_entity_url}</div>
+
+      Attributes | Description
+      ---:| ---
+      `${entity} id`<br>**required** | The unique identifier of the ${Entity} associated to the ${ForeignEntity} to be ${passive_verb}.
+    ]],
+    GET = {
+      title = [[Retrieve ${Entity}]],
+      response = [[
+        ```
+        HTTP 200 OK
+        ```
+
+        ```json
+        {{ page.${entity}_json }}
+        ```
+      ]],
+    },
+    PATCH = {
+      title = [[Update ${Entity}]],
+      request_body = [[
+        {{ page.${entity}_body }}
+      ]],
+      response = [[
+        ```
+        HTTP 200 OK
+        ```
+
+        ```json
+        {{ page.${entity}_json }}
+        ```
+      ]],
+    },
+    PUT = {
+      title = [[Update or create ${Entity}]],
+      request_body = [[
+        {{ page.${entity}_body }}
+      ]],
+      details = [[
+        Inserts (or replaces) the ${Entity} under the requested resource with the
+        definition specified in the body. The ${Entity} will be identified via the `${endpoint_key}
+        or id` attribute.
+
+        When the `${endpoint_key} or id` attribute has the structure of a UUID, the ${Entity} being
+        inserted/replaced will be identified by its `id`. Otherwise it will be
+        identified by its `${endpoint_key}`.
+
+        When creating a new ${Entity} without specifying `id` (neither in the URL nor in
+        the body), then it will be auto-generated.
+
+        Notice that specifying a `${endpoint_key}` in the URL and a different one in the request
+        body is not allowed.
+      ]],
+      response = [[
+        ```
+        HTTP 201 Created or HTTP 200 OK
+        ```
+
+        See POST and PATCH responses.
+      ]],
+    },
+    DELETE = {
+      title = [[Delete ${Entity}]],
+      response = [[
+        ```
+        HTTP 204 No Content
+        ```
+      ]],
+    }
+  },
+
+--------------------------------------------------------------------------------
+-- Overrides for DB-less mode
+--------------------------------------------------------------------------------
+
+  dbless = {
+
+    intro = {
+      {
+        text = [[
+          <div class="alert alert-info.blue" role="alert">
+            This page refers to the Admin API for running Kong configured without a
+            database, managing in-memory entities via declarative config.
+            For using the Admin API for Kong with a database, please refer to the
+            <a href="/{{page.kong_version}}/admin-api">Admin API for Database Mode</a> page.
+          </div>
+
+          Kong comes with an **internal** RESTful Admin API for administration purposes.
+          In [DB-less mode][db-less], this Admin API can be used to load a new declarative
+          configuration, and for inspecting the current configuration. In DB-less mode,
+          the Admin API for each Kong node functions independently, reflecting the memory state
+          of that particular Kong node. This is the case because there is no database
+          coordination between Kong nodes.
+
+          - `8001` is the default port on which the Admin API listens.
+          - `8444` is the default port for HTTPS traffic to the Admin API.
+
+          This API provides full control over Kong, so care should be taken when setting
+          up Kong environments to avoid undue public exposure of this API.
+          See [this document][secure-admin-api] for a discussion
+          of methods to secure the Admin API.
+        ]],
+      },
+      {
+        title = [[Supported Content Types]],
+        text = [[
+          The Admin API accepts 2 content types on every endpoint:
+
+          - **application/x-www-form-urlencoded**
+          - **application/json**
+        ]],
+      },
+    },
+
+    footer = [[
+      [clustering]: /{{page.kong_version}}/clustering
+      [cli]: /{{page.kong_version}}/cli
+      [active]: /{{page.kong_version}}/health-checks-circuit-breakers/#active-health-checks
+      [healthchecks]: /{{page.kong_version}}/health-checks-circuit-breakers
+      [secure-admin-api]: /{{page.kong_version}}/secure-admin-api
+      [proxy-reference]: /{{page.kong_version}}/proxy
+      [db-less]: /{{page.kong_version}}/db-less-and-declarative-config
+      [admin-api]: /{{page.kong_version}}/admin-api
+    ]],
+
+    general = {
+      config = {
+        skip = false,
+        title = [[Declarative Configuration]],
+        description = [[
+          Loading the declarative configuration of entities into Kong
+          can be done in two ways: at start-up, through the `declarative_config`
+          property, or at run-time, through the Admin API using the `/config`
+          endpoint.
+
+          To get started using declarative configuration, you need a file
+          (in YAML or JSON format) containing entity definitions. You can
+          generate a sample declarative configuration with the command:
+
+          ```
+          kong config init
+          ```
+
+          It generates a file named `kong.yml` in the current directory,
+          containing the appropriate structure and examples.
+        ]],
+        ["/config"] = {
+          POST = {
+            title = [[Reload declarative configuration]],
+            endpoint = [[
+              <div class="endpoint post">/config</div>
+
+              Attributes | Description
+              ---:| ---
+              `config`<br>**required** | The config data (in YAML or JSON format) to be loaded.
+            ]],
+
+            description = [[
+              This endpoint allows resetting a DB-less Kong with a new
+              declarative configuration data file. All previous contents
+              are erased from memory, and the entities specified in the
+              given file take their place.
+
+              To learn more about the file format, please read the
+              [declarative configuration][db-less] documentation.
+            ]],
+            response = [[
+              ```
+              HTTP 200 OK
+              ```
+
+              ``` json
+              {
+                  { "services": [],
+                    "routes": []
+                  }
+              }
+              ```
+
+              The response contains a list of all the entities that were parsed from the
+              input file.
+            ]]
+          }
+        },
+      },
+    },
+
+    entities = {
+      methods = {
+        -- in DB-less mode, only document GET endpoints for entities
+        ["GET"] = true,
+        ["POST"] = false,
+        ["PATCH"] = false,
+        ["PUT"] = false,
+        ["DELETE"] = false,
+        -- exceptions for the healthcheck endpoints:
+        ["/upstreams/:upstreams/targets/:targets/healthy"] = {
+          ["POST"] = true,
+        },
+        ["/upstreams/:upstreams/targets/:targets/unhealthy"] = {
+          ["POST"] = true,
+        },
+      },
+    }
+
+  },
+
+--------------------------------------------------------------------------------
+-- Template for Admin API section of the Navigation file
+--------------------------------------------------------------------------------
+
+  nav = {
+    header = [[
+      - title: Admin API
+        url: /admin-api/
+        items:
+          - text: DB-less
+            url: /db-less-admin-api
+
+          - text: Declarative Configuration
+            url: /db-less-admin-api/#declarative-configuration
+      ]],
+  }
+
+}

--- a/autodoc/data/admin-api.lua
+++ b/autodoc/data/admin-api.lua
@@ -1091,6 +1091,7 @@ return {
         created_at = { skip = true },
         ["name"] = { description = [[This is a hostname, which must be equal to the `host` of a Service.]] },
         ["slots"] = { description = [[The number of slots in the loadbalancer algorithm (`10`-`65536`).]] },
+        ["algorithm"] = { description = [[Which load balancing algorithm to use. One of: `round-robin`, `consistent-hashing`, or `least-connections`.]] },
         ["hash_on"] = { description = [[What to use as hashing input: `none` (resulting in a weighted-round-robin scheme with no hashing), `consumer`, `ip`, `header`, or `cookie`.]] },
         ["hash_fallback"] = { description = [[What to use as hashing input if the primary `hash_on` does not return a hash (eg. header is missing, or no consumer identified). One of: `none`, `consumer`, `ip`, `header`, or `cookie`. Not available if `hash_on` is set to `cookie`.]] },
         ["hash_on_header"] = { kind = "semi-optional", skip_in_example = true, description = [[The header name to take the value from as hash input. Only required when `hash_on` is set to `header`.]] },

--- a/autodoc/data/admin-api.lua
+++ b/autodoc/data/admin-api.lua
@@ -500,6 +500,18 @@ return {
         them) offers a powerful routing mechanism with which it is possible to define
         fine-grained entry-points in Kong leading to different upstream services of
         your infrastructure.
+
+        You need at least one matching rule that applies to the protocol being matched
+        by the Route. Depending on the protocols configured to be matched by the Route
+        (as defined with the `protocols` field), this means that at least one of the
+        following attributes must be set:
+
+        * For `http`, at least one of `methods`, `hosts`, `headers` or `paths`;
+        * For `https`, at least one of `methods`, `hosts`, `headers`, `paths` or `snis`;
+        * For `tcp`, at least one of `sources` or `destinations`;
+        * For `tls`, at least one of `sources`, `destinations` or `snis`;
+        * For `grpc`, at least one of `hosts`, `headers` or `paths`;
+        * For `grpcs`, at least one of `hosts`, `headers`, `paths` or `snis`.
       ]],
       fields = {
         id = { skip = true },
@@ -531,7 +543,6 @@ return {
           kind = "semi-optional",
           description = [[
             A list of HTTP methods that match this Route.
-            When using `http` or `https` protocols, at least one of `hosts`, `paths`, or `methods` must be set.
           ]],
           examples = { {"GET", "POST"}, nil },
           skip_in_example = true, -- hack so we get HTTP fields in the first example and Stream fields in the second
@@ -540,7 +551,6 @@ return {
           kind = "semi-optional",
           description = [[
             A list of domain names that match this Route.
-            When using `http` or `https` protocols, at least one of `hosts`, `paths`, or `methods` must be set.
           ]],
           examples = { {"example.com", "foo.test"}, nil },
           skip_in_example = true, -- hack so we get HTTP fields in the first example and Stream fields in the second
@@ -549,7 +559,16 @@ return {
           kind = "semi-optional",
           description = [[
             A list of paths that match this Route.
-            When using `http` or `https` protocols, at least one of `hosts`, `paths`, or `methods` must be set.
+          ]],
+          examples = { {"/foo", "/bar"}, nil },
+          skip_in_example = true, -- hack so we get HTTP fields in the first example and Stream fields in the second
+        },
+        headers = {
+          kind = "semi-optional",
+          description = [[
+            A list of headers that will cause this Route to match if present in the request.
+            The `Host` header cannot be used with this attribute: hosts should be specified
+            using the `hosts` attribute.
           ]],
           examples = { {"/foo", "/bar"}, nil },
           skip_in_example = true, -- hack so we get HTTP fields in the first example and Stream fields in the second
@@ -558,7 +577,6 @@ return {
           kind = "semi-optional",
           description = [[
             A list of SNIs that match this Route when using stream routing.
-            When using `tcp` or `tls` protocols, at least one of `snis`, `sources`, or `destinations` must be set.
           ]],
           examples = { nil, {"foo.test", "example.com"} },
           skip_in_example = true, -- hack so we get HTTP fields in the first example and Stream fields in the second
@@ -568,7 +586,6 @@ return {
           description = [[
             A list of IP sources of incoming connections that match this Route when using stream routing.
             Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port".
-            When using `tcp` or `tls` protocols, at least one of `snis`, `sources`, or `destinations` must be set.
           ]],
           examples = { nil, {{ip = "10.1.0.0/16", port = 1234}, {ip = "10.2.2.2"}, {port = 9123}} },
           skip_in_example = true, -- hack so we get HTTP fields in the first example and Stream fields in the second
@@ -578,7 +595,6 @@ return {
           description = [[
             A list of IP destinations of incoming connections that match this Route when using stream routing.
             Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port".
-            When using `tcp` or `tls` protocols, at least one of `snis`, `sources`, or `destinations` must be set.
           ]],
           examples = { nil, {{ip = "10.1.0.0/16", port = 1234}, {ip = "10.2.2.2"}, {port = 9123}} },
           skip_in_example = true, -- hack so we get HTTP fields in the first example and Stream fields in the second

--- a/autodoc/general.lua
+++ b/autodoc/general.lua
@@ -1,0 +1,16 @@
+return {
+
+  title_exceptions = {
+    ["api"] = "API",
+    ["curl"] = "cURL",
+    ["db-less"] = "DB-less",
+    ["dns"] = "DNS",
+    ["nginx"] = "NGINX",
+    ["rbac"] = "RBAC",
+    ["sni"] = "SNI",
+    ["snis"] = "SNIs",
+    ["httpie"] = "HTTPie",
+    ["ca"] = "CA",
+  }
+
+}

--- a/scripts/autodoc-admin-api
+++ b/scripts/autodoc-admin-api
@@ -696,8 +696,9 @@ local function prepare_foreign_key_endpoints(data, entity_infos, entity)
   local edata = einfo.data
 
   for fname, finfo in each_field(einfo.schema.fields) do
-    if finfo.type == "foreign" and not (data.known.nodoc_entities[finfo.reference]) then
-      local foreigns = to_plural(fname)
+    local foreigns = finfo.reference
+
+    if finfo.type == "foreign" and not data.known.nodoc_entities[foreigns] then
       local feinfo = entity_infos[foreigns]
       local fedata = feinfo.data
       local subs = gen_template_subs_table(einfo.data, entity, einfo.schema, fedata, foreigns)

--- a/scripts/autodoc-admin-api
+++ b/scripts/autodoc-admin-api
@@ -673,7 +673,8 @@ local function prepare_entity(data, plural, entity_data)
   end
 
   local filename = "kong/api/routes/" .. plural .. ".lua"
-  local mod = assert(loadfile(KONG_PATH .. "/" .. filename))()
+  local modtbl = loadfile(KONG_PATH .. "/" .. filename)
+  local mod = modtbl and modtbl() or {}
 
   local collection_endpoint = "/" .. plural
   gen_endpoint(entity_data, data.collection_templates, subs, collection_endpoint, "GET")

--- a/scripts/autodoc-admin-api
+++ b/scripts/autodoc-admin-api
@@ -1,0 +1,903 @@
+#!/usr/bin/env resty
+
+setmetatable(_G, nil)
+
+local lfs = require("lfs")
+local cjson = require("cjson")
+local pl_tablex = require("pl.tablex")
+local general = require("autodoc.general")
+
+local method_array = {
+  "POST",
+  "GET",
+  "PATCH",
+  "PUT",
+  "DELETE",
+}
+
+-- Chicago-style prepositions to be lowercased,
+-- based on https://capitalizemytitle.com/
+for _, p in ipairs({
+  "about",
+  "above",
+  "across",
+  "after",
+  "against",
+  "along",
+  "among",
+  "around",
+  "at",
+  "before",
+  "behind",
+  "below",
+  "beneath",
+  "beside",
+  "beyond",
+  "by",
+  "down",
+  "during",
+  "for",
+  "from",
+  "in",
+  "inside",
+  "into",
+  "near",
+  "of",
+  "off",
+  "on",
+  "out",
+  "outside",
+  "over",
+  "past",
+  "through",
+  "throughout",
+  "to",
+  "toward",
+  "under",
+}) do
+  general.title_exceptions[p] = p
+end
+
+local utils = {
+  -- "EXAMPLE of teXT using dns" => "Example of Text Using DNS".
+  titleize = function(str)
+    local text = str:gsub("(%a[%w_'-]*)", function(word)
+      local exception = general.title_exceptions[word:lower()]
+      if exception then
+        return exception
+      else
+        return word:sub(1,1):upper()..word:sub(2):lower()
+      end
+    end)
+    -- force very first character uppercase
+    return text:sub(1,1):upper()..text:sub(2)
+  end
+}
+
+local KONG_PATH = os.getenv("KONG_PATH") or "."
+
+package.path = KONG_PATH .. "/?.lua;" .. KONG_PATH .. "/?/init.lua;" .. package.path
+
+local pok, kong_meta = pcall(require, "kong.meta")
+if not pok then
+  error("failed loading Kong modules. please set the KONG_PATH environment variable.")
+end
+
+local admin_api_data = require("autodoc.data.admin-api")
+
+local function deep_merge(t1, t2)
+  local copy = {}
+  for k, v in pairs(t1) do
+    copy[k] = v
+  end
+  for k, v in pairs(t2) do
+    if type(v) == "table" and type(t1[k]) == "table" then
+      copy[k] = deep_merge(t1[k], v)
+    else
+      copy[k] = v
+    end
+  end
+  return copy
+end
+
+local dbless_data = pl_tablex.deepcopy(admin_api_data)
+local dbless_overrides = dbless_data.dbless
+dbless_data.dbless = nil
+dbless_data = deep_merge(dbless_data, dbless_overrides)
+
+local Endpoints = require("kong.api.endpoints")
+
+-- Minimal boilerplate so that module files can be loaded
+_KONG = require("kong.meta")          -- luacheck: ignore
+kong = require("kong.global").new()   -- luacheck: ignore
+kong.configuration = {                -- luacheck: ignore
+  loaded_plugins = {},
+}
+kong.db = require("kong.db").new({    -- luacheck: ignore
+  database = "postgres",
+})
+kong.configuration = { -- luacheck: ignore
+  loaded_plugins = {}
+}
+
+--------------------------------------------------------------------------------
+
+local function sortedpairs(tbl)
+  local keys = {}
+  for key, _ in pairs(tbl) do
+    table.insert(keys, key)
+  end
+  table.sort(keys)
+  local i = 0
+  return function()
+    i = i + 1
+    local k = keys[i]
+    return k, tbl[k]
+  end
+end
+
+local function render(template, subs)
+  subs = setmetatable(subs, { __index = function(_, k)
+    error("failed applying autodoc template: no variable ${" .. k .. "}")
+  end })
+  return (template:gsub("${([^}]+)}", subs))
+end
+
+local function get_or_create(tbl, key)
+  local v = tbl[key]
+  if not v then
+    v = {}
+    tbl[key] = v
+  end
+  return v
+end
+
+local function to_plural(singular)
+  return singular .. "s"
+end
+
+local function to_singular(plural)
+  return plural:gsub("s$", "")
+end
+
+local function entity_to_api_path(entity)
+  return "kong/api/routes/" .. entity .. ".lua"
+end
+
+local function entity_to_schema_path(entity)
+  return "kong/db/schema/entities/" .. entity .. ".lua"
+end
+
+local function cjson_encode(value)
+  return (cjson.encode(value):gsub("\\/", "/"):gsub(",", ", "))
+end
+
+-- A deterministic pseudo-UUID generator, to make autodoc idempotent.
+local gen_uuid
+local reset_uuid
+do
+  local uuids = {
+    "9748f662-7711-4a90-8186-dc02f10eb0f5",
+    "4e3ad2e4-0bc4-4638-8e34-c84a417ba39b",
+    "a5fb8d9b-a99d-40e9-9d35-72d42a62d83a",
+    "51e77dc2-8f3e-4afa-9d0e-0e3bbbcfd515",
+    "fc73f2af-890d-4f9b-8363-af8945001f7f",
+    "4506673d-c825-444c-a25b-602e3c2ec16e",
+    "d35165e2-d03e-461a-bdeb-dad0a112abfe",
+    "af8330d3-dbdc-48bd-b1be-55b98608834b",
+    "a9daa3ba-8186-4a0d-96e8-00d80ce7240b",
+    "127dfc88-ed57-45bf-b77a-a9d3a152ad31",
+    "9aa116fd-ef4a-4efa-89bf-a0b17c4be982",
+    "ba641b07-e74a-430a-ab46-94b61e5ea66b",
+    "ec1a1f6f-2aa4-4e58-93ff-b56368f19b27",
+    "a4407883-c166-43fd-80ca-3ca035b0cdb7",
+    "01c23299-839c-49a5-a6d5-8864c09184af",
+    "ce44eef5-41ed-47f6-baab-f725cecf98c7",
+    "02621eee-8309-4bf6-b36b-a82017a5393e",
+    "66c7b5c4-4aaf-4119-af1e-ee3ad75d0af4",
+    "7fca84d6-7d37-4a74-a7b0-93e576089a41",
+    "d044b7d4-3dc2-4bbc-8e9f-6b7a69416df6",
+    "a9b2107f-a214-47b3-add4-46b942187924",
+    "04fbeacf-a9f1-4a5d-ae4a-b0407445db3f",
+    "43429efd-b3a5-4048-94cb-5cc4029909bb",
+    "d26761d5-83a4-4f24-ac6c-cff276f2b79c",
+    "91020192-062d-416f-a275-9addeeaffaf2",
+    "a2e013e8-7623-4494-a347-6d29108ff68b",
+    "147f5ef0-1ed6-4711-b77f-489262f8bff7",
+    "a3ad71a8-6685-4b03-a101-980a953544f6",
+    "b87eb55d-69a1-41d2-8653-8d706eecefc0",
+    "4e8d95d4-40f2-4818-adcb-30e00c349618",
+    "58c8ccbb-eafb-4566-991f-2ed4f678fa70",
+    "ea29aaa3-3b2d-488c-b90c-56df8e0dd8c6",
+    "4fe14415-73d5-4f00-9fbc-c72a0fccfcb2",
+    "a3395f66-2af6-4c79-bea2-1b6933764f80",
+    "885a0392-ef1b-4de3-aacf-af3f1697ce2c",
+    "f5a9c0ca-bdbb-490f-8928-2ca95836239a",
+    "173a6cee-90d1-40a7-89cf-0329eca780a6",
+    "bdab0e47-4e37-4f0b-8fd0-87d95cc4addc",
+    "f00c6da4-3679-4b44-b9fb-36a19bd3ae83",
+    "0c61e164-6171-4837-8836-8f5298726d53",
+  }
+
+  local ctr = 0
+
+  gen_uuid = function()
+    ctr = ctr + 1
+    return assert(uuids[ctr])
+  end
+
+  reset_uuid = function()
+    ctr = 0
+  end
+end
+
+--------------------------------------------------------------------------------
+-- Unindent a multi-line string for proper indenting in
+-- square brackets.
+--
+-- Ex:
+--   unindent([[
+--       hello world
+--       foo bar
+--   ]])
+--
+-- will return: "hello world\nfoo bar"
+local function unindent(str)
+  local min = 2^31
+  local lines = {}
+  str = (str:sub(-1) == "\n") and str or (str .. "\n")
+  for line in str:gmatch("([^\n]*)\n") do
+    local nonblank = line:match("()[^%s]")
+    if nonblank and nonblank < min then
+      min = nonblank
+    end
+    table.insert(lines, line)
+  end
+  for i, line in ipairs(lines) do
+    lines[i] = line:sub(min)
+  end
+  return table.concat(lines, "\n")
+end
+
+local function each_field(fields)
+  local i = 0
+  return function()
+    i = i + 1
+    local f = fields[i]
+    if f then
+      local k = next(f)
+      local v = f[k]
+      return k, v
+    end
+  end
+end
+
+--------------------------------------------------------------------------------
+
+local function gen_kind(finfo, field_data)
+  if field_data.kind then
+    return "<br>*"  .. field_data.kind .. "*"
+  elseif finfo.required ~= true then
+    return "<br>*optional*"
+  else
+    return ""
+  end
+end
+
+local function gen_defaults(finfo)
+  if finfo.default then
+    return " Defaults to `" .. cjson_encode(finfo.default) .. "`."
+  else
+    return ""
+  end
+end
+
+local function gen_notation(fname, finfo, field_data)
+  if finfo.type == "array" then
+    local form_example = {}
+    local example = field_data.examples
+                    and (field_data.examples[1] or field_data.examples[2])
+                    or field_data.example
+    for i, item in ipairs(example or finfo.default) do
+      table.insert(form_example, fname .. "[]=" .. item)
+      if i == 2 then
+        break
+      end
+    end
+    return [[ With form-encoded, the notation is `]] ..
+           table.concat(form_example, "&") ..
+           [[`. With JSON, use an Array.]]
+  elseif finfo.type == "foreign" then
+    return [[ With form-encoded, the notation is `]] ..
+           fname .. [[.id=<]] .. fname ..
+           [[_id>`. With JSON, use `"]] .. fname ..
+           [[":{"id":"<]] .. fname .. [[_id>"}`.]]
+  else
+    return ""
+  end
+end
+
+local function write_field(outfd, fname, finfo, fullname, field_data, entity_name)
+  local kind = gen_kind(finfo, field_data)
+  local description = assert(field_data.description,
+                             "Missing description for " .. entity_name .. "." .. fullname)
+                      :gsub("%s+", " ")
+  local defaults = gen_defaults(finfo)
+  local notation = gen_notation(fname, finfo, field_data)
+
+  outfd:write("    `" .. fullname .. "`" .. kind .. " | " .. description .. defaults .. notation .. "\n")
+end
+
+local function process_field(outfd, entity_data, entity_name, fname, finfo, prefix)
+  local fullname = (prefix or "") .. fname
+  local field_data = entity_data.fields[fullname]
+  if not field_data then
+    if finfo.type == "record" then
+      for rfname, rfinfo in each_field(finfo.fields) do
+        process_field(outfd, entity_data, entity_name, rfname, rfinfo, fullname .. ".")
+      end
+      return
+    else
+      error("Missing autodoc data for field " .. entity_name .. "." .. fullname)
+    end
+  end
+
+  if field_data.skip then
+    return
+  end
+
+  write_field(outfd, fname, finfo, fullname, field_data, entity_name)
+end
+
+local function gen_example(exn, entity, entity_data, fields, indent, prefix)
+  local csv = {}
+  for fname, finfo in each_field(fields) do
+    local fullname = (prefix or "") .. fname
+
+    local value
+    local field_data = entity_data.fields[fullname]
+    if finfo.type == "record" and not finfo.abstract then
+      value = gen_example(exn, entity, entity_data, finfo.fields, indent .. "    ", fullname .. ".")
+    elseif finfo.default ~= nil and field_data.examples == nil and field_data.example == nil then
+      value = cjson_encode(finfo.default)
+    else
+      local example = field_data.examples and field_data.examples[exn]
+      if example == nil then
+        example = field_data.example
+      end
+      if example == nil then
+        if finfo.uuid then
+          example = gen_uuid()
+        elseif finfo.type == "foreign" then
+          example = { id = gen_uuid() }
+        elseif finfo.timestamp then
+          example = 1422386534
+        elseif fname == "name" then
+          example = "my-" .. to_singular(entity)
+        end
+      end
+      if example ~= nil then
+        value = cjson_encode(example)
+      elseif not field_data.skip_in_example then
+        error("missing example value for " .. entity .. "." .. fname)
+      end
+    end
+
+    if value ~= nil then
+      table.insert(csv, indent .. "    " .. '"' .. fname .. '": ' .. value)
+    end
+  end
+  local out = {"{\n"}
+  table.insert(out, table.concat(csv, ",\n"))
+  table.insert(out, "\n")
+  table.insert(out, indent .. "}")
+  return table.concat(out)
+end
+
+local function write_entity_templates(outfd, entity, entity_data)
+  local schema = assert(require("kong.db.schema.entities." .. entity))
+  local singular = to_singular(entity)
+
+  assert(entity_data.fields, "Missing autodoc fields entry for " .. entity)
+
+  outfd:write(singular .. "_body: |\n")
+  outfd:write("    Attributes | Description\n")
+  outfd:write("    ---:| ---\n")
+  for fname, finfo in each_field(schema.fields) do
+    process_field(outfd, entity_data, entity, fname, finfo)
+  end
+
+  if entity_data.extra_fields then
+    for efname, efinfo in each_field(entity_data.extra_fields) do
+      write_field(outfd, efname, efinfo, efname, efinfo, entity)
+    end
+  end
+
+  outfd:write("\n")
+  outfd:write(singular .. "_json: |\n")
+  outfd:write("    " .. gen_example(1, entity, entity_data, schema.fields, "    ") .. "\n")
+  outfd:write("\n")
+  outfd:write(singular .. "_data: |\n")
+  outfd:write('    "data": [' .. gen_example(1, entity, entity_data, schema.fields, "    ") .. ", ")
+  outfd:write(gen_example(2, entity, entity_data, schema.fields, "    ") .. "],\n")
+  outfd:write("\n")
+end
+
+
+local function bold_text_section(outfd, title, content)
+  if not content then
+    return
+  end
+  outfd:write(title and ("*" .. utils.titleize(title) .. "*\n\n") or "")
+  outfd:write(unindent(content) .. "\n")
+  outfd:write("\n")
+end
+
+
+local titles = {}
+
+local function write_title(outfd, level, title)
+  if not title then
+    return
+  end
+  title = utils.titleize(title):gsub("^%s*", ""):gsub("%s*$", "")
+  table.insert(titles, {
+    level = level,
+    title = title,
+  })
+  outfd:write((("#"):rep(level) .. " " .. title .. "\n\n"))
+end
+
+local function section(outfd, title, content)
+  if not content then
+    return
+  end
+  write_title(outfd, 4, title)
+  outfd:write(unindent(content) .. "\n")
+  outfd:write("\n")
+end
+
+local function write_endpoint(outfd, endpoint, ep_data, methods)
+  assert(ep_data, "Missing autodoc data for endpoint " .. endpoint)
+  if ep_data.done or ep_data.skip then
+    return
+  end
+
+  -- check for endpoint-specific overrides (useful for db-less)
+  methods = methods and methods[endpoint] or methods
+
+  for i, method in ipairs(method_array) do
+    if methods == nil or methods[method] == true then
+
+    local meth_data = ep_data[method]
+    if meth_data then
+      assert(meth_data.title, "Missing autodoc info for " .. method .. " " .. endpoint)
+      write_title(outfd, 3, meth_data.title)
+      section(outfd, nil, meth_data.description)
+      local fk_endpoints = meth_data.fk_endpoints or {}
+      section(outfd, nil, meth_data.endpoint)
+      for _, fk_endpoint in ipairs(fk_endpoints) do
+        section(outfd, nil, fk_endpoint)
+      end
+      bold_text_section(outfd, "Request Querystring Parameters", meth_data.request_query)
+      bold_text_section(outfd, "Request Body", meth_data.request_body)
+      section(outfd, nil, meth_data.details)
+      bold_text_section(outfd, "Response", meth_data.response)
+      outfd:write("---\n\n")
+    end
+
+    end
+  end
+  ep_data.done = true
+end
+
+local function write_endpoints(outfd, info, all_endpoints, methods)
+  for endpoint, ep_data in sortedpairs(info.data) do
+    if endpoint:match("^/") then
+      write_endpoint(outfd, endpoint, ep_data, methods)
+      all_endpoints[endpoint] = ep_data
+    end
+  end
+  return all_endpoints
+end
+
+
+
+local function write_general_section(outfd, filename, all_endpoints, name, data_general)
+  local file_data = assert(data_general[name], "Missing autodoc data for " .. filename)
+
+  if file_data.skip == true then
+    return
+  end
+
+  write_title(outfd, 2, file_data.title)
+
+  assert(file_data.description,
+         "Missing autodoc general description for " .. filename)
+
+  outfd:write(unindent(file_data.description))
+  outfd:write("\n\n")
+
+  local info = {
+    filename = filename,
+    data = file_data,
+    mod = assert(loadfile(KONG_PATH .. "/" .. filename))()
+  }
+
+  write_endpoints(outfd, info, all_endpoints, data_general.methods)
+end
+
+local active_verbs = {
+  GET = "retrieve",
+  POST = "create",
+  PATCH = "update",
+  PUT = "create or update",
+  DELETE = "delete",
+}
+
+local passive_verbs = {
+  GET = "retrieved",
+  POST = "created",
+  PATCH = "updated",
+  PUT = "created or updated",
+  DELETE = "deleted",
+}
+
+local function adjust_for_method(subs, method)
+  subs.method = method:lower()
+  subs.METHOD = method:upper()
+  subs.active_verb = active_verbs[subs.METHOD]
+  subs.passive_verb = passive_verbs[subs.METHOD]
+  subs.Active_verb = utils.titleize(subs.active_verb)
+  subs.Passive_verb = utils.titleize(subs.passive_verb)
+end
+
+local gen_endpoint
+do
+  local template_keys = {
+    "title",
+    "description",
+    "details",
+    "request_querystring",
+    "request_body",
+    "response",
+    "endpoint",
+  }
+
+  gen_endpoint = function(edata, templates, subs, endpoint, method, has_ek)
+    local ep_data = get_or_create(edata, endpoint)
+    if ep_data.skip then
+      return
+    end
+    local meth_data = get_or_create(ep_data, method)
+    assert(templates, "Missing autodoc templates definition for " .. endpoint)
+    local meth_tpls = templates[method]
+    assert(meth_tpls, "Missing autodoc templates definition for " .. method .. " " .. endpoint)
+    adjust_for_method(subs, method)
+
+    for _, k in ipairs(template_keys) do
+      local tk = (k == "endpoint")
+                 and (has_ek and "endpoint_w_ek" or "endpoint")
+                 or k
+      local template = meth_tpls[tk] or templates[tk]
+      if meth_data[k] == nil and ep_data[k] ~= nil then
+        meth_data[k] = ep_data[k]
+      end
+      if meth_data[k] == nil and template then
+        meth_data[k] = render(template, subs)
+      end
+    end
+  end
+end
+
+local function gen_fk_endpoint(edata, templates, subs, parent_endpoint, method, has_ek)
+  local ep_data = assert(edata[parent_endpoint],
+                         "Expected entity data to exist for endpoint " .. parent_endpoint)
+  local meth_data = assert(ep_data[method]) -- get_or_create(ep_data, method)
+  assert(templates, "Missing autodoc templates definition for " .. parent_endpoint)
+  local meth_tpls = templates[method]
+  assert(meth_tpls, "Missing autodoc templates definition for " .. method .. " " .. parent_endpoint)
+  local tk = has_ek and "fk_endpoint_w_ek" or "fk_endpoint"
+  local tpl = meth_tpls[tk] or templates[tk]
+  assert(tpl, "Missing autodoc " .. tk .. " template for " .. method .. " " .. parent_endpoint)
+  adjust_for_method(subs, method)
+
+  assert(meth_data.title)
+  local fk_endpoints = get_or_create(meth_data, "fk_endpoints")
+  table.insert(fk_endpoints, render(tpl, subs))
+end
+
+local function gen_template_subs_table(edata, plural, schema, fedata, fplural)
+  local singular = to_singular(plural)
+  local subs = {
+    ["Entity"] = edata.entity_title or utils.titleize(singular),
+    ["Entities"] = edata.entity_title_plural or utils.titleize(plural),
+    ["entity"] = edata.entity_lower or singular:lower(),
+    ["entities"] = edata.entity_lower_plural or plural:lower(),
+    ["entities_url"] = edata.entity_url_collection_name or plural,
+    ["entity_url"] = edata.entity_url_name or singular,
+    ["endpoint_key"] = edata.entity_endpoint_key or schema.endpoint_key or "name",
+  }
+  if fedata then
+    local fsingular = to_singular(fplural)
+    subs["ForeignEntity"] = fedata.entity_title or utils.titleize(fsingular)
+    subs["ForeignEntities"] = fedata.entity_title_plural or utils.titleize(fplural)
+    subs["foreign_entity"] = fedata.entity_lower or fsingular:lower()
+    subs["foreign_entities"] = fedata.entity_lower_plural or fplural:lower()
+    subs["foreign_entities_url"] = fedata.entity_url_collection_name or fplural
+    subs["foreign_entity_url"] = fedata.entity_url_name or fsingular
+  end
+  return subs
+end
+
+local function prepare_entity(data, plural, entity_data)
+  local out = {}
+
+  assert(entity_data.description,
+         "Missing autodoc entity description for " .. plural)
+
+  local schema = assert(loadfile(KONG_PATH .. "/" .. entity_to_schema_path(plural)))()
+  local subs = gen_template_subs_table(entity_data, plural, schema)
+
+  local title = entity_data.title or (subs.Entity .. " Object")
+
+  table.insert(out, unindent(entity_data.description))
+
+  if entity_data.fields.tags then
+    table.insert(out, "\n")
+    table.insert(out, unindent(render(data.entity_templates.tags, subs)))
+  end
+
+  table.insert(out, "\n\n")
+  table.insert(out, "```json\n")
+  table.insert(out, "{{ page." .. subs.entity .. "_json }}\n")
+  table.insert(out, "```\n\n")
+
+  if entity_data.details then
+    table.insert(out, unindent(entity_data.details))
+    table.insert(out, "\n\n")
+  end
+
+  local filename = "kong/api/routes/" .. plural .. ".lua"
+  local mod = assert(loadfile(KONG_PATH .. "/" .. filename))()
+
+  local collection_endpoint = "/" .. plural
+  gen_endpoint(entity_data, data.collection_templates, subs, collection_endpoint, "GET")
+  gen_endpoint(entity_data, data.collection_templates, subs, collection_endpoint, "POST")
+
+  local entity_endpoint = "/" .. plural .. "/:" .. plural
+  local has_ek = schema.endpoint_key ~= nil
+  gen_endpoint(entity_data, data.entity_templates, subs, entity_endpoint, "GET", has_ek)
+  gen_endpoint(entity_data, data.entity_templates, subs, entity_endpoint, "PUT", has_ek)
+  gen_endpoint(entity_data, data.entity_templates, subs, entity_endpoint, "PATCH", has_ek)
+  gen_endpoint(entity_data, data.entity_templates, subs, entity_endpoint, "DELETE", has_ek)
+
+  return {
+    filename = filename,
+    entity = plural,
+    schema = schema,
+    title = title,
+    intro = table.concat(out),
+    data = entity_data,
+    mod = mod,
+  }
+end
+
+local function skip_fk_endpoint(edata, endpoint, method)
+  local ret = edata
+         and edata[endpoint]
+         and ((edata[endpoint].endpoint == false)
+              or (edata[endpoint][method] and edata[endpoint][method].endpoint == false))
+  return ret
+end
+
+local function prepare_foreign_key_endpoints(data, entity_infos, entity)
+  local einfo = entity_infos[entity]
+  local edata = einfo.data
+
+  for fname, finfo in each_field(einfo.schema.fields) do
+    if finfo.type == "foreign" and not (data.known.nodoc_entities[finfo.reference]) then
+      local foreigns = to_plural(fname)
+      local feinfo = entity_infos[foreigns]
+      local fedata = feinfo.data
+      local subs = gen_template_subs_table(einfo.data, entity, einfo.schema, fedata, foreigns)
+      local has_ek = einfo.schema.endpoint_key ~= nil
+
+      local function gen_fk_endpoints(parent_endpoint, endpoint, meths, templates, srcdata, dstdata)
+        for _, method in ipairs(meths) do
+          if not skip_fk_endpoint(edata, endpoint, method) then
+            gen_fk_endpoint(dstdata, templates, subs, parent_endpoint, method, has_ek)
+            local ep_data = get_or_create(srcdata, endpoint)
+            ep_data.done = true
+          end
+        end
+      end
+
+      gen_fk_endpoints(
+        "/" .. entity,
+        "/" .. foreigns .. "/:" .. foreigns .. "/" .. entity,
+        {"GET", "POST"},
+        data.collection_templates,
+        fedata, edata
+      )
+      gen_fk_endpoints(
+        "/" .. foreigns .. "/:" .. foreigns,
+        "/" .. entity .. "/:" .. entity .. "/" .. fname,
+        {"GET", "PUT", "PATCH", "DELETE"},
+        data.entity_templates,
+        edata, fedata
+      )
+    end
+  end
+
+end
+
+--------------------------------------------------------------------------------
+
+-- Check that all modules present in the Admin API are known by this script.
+local function check_admin_api_modules(data)
+  local file_set = {}
+  for _, item in ipairs(data.known.general_files) do
+    file_set[item] = "use"
+    data.known.general_files[item] = true
+  end
+  for _, item in ipairs(data.known.entities) do
+    file_set[entity_to_api_path(item)] = "use"
+    data.known.entities[item] = true
+  end
+  for _, item in ipairs(data.known.nodoc_entities) do
+    file_set[entity_to_api_path(item)] = "nodoc"
+    data.known.nodoc_entities[item] = true
+  end
+  for _, item in ipairs(data.known.nodoc_files) do
+    file_set[item] = "nodoc"
+    data.known.nodoc_files[item] = true
+  end
+
+  for file in lfs.dir(KONG_PATH .. "/kong/api/routes") do
+    if file:match("%.lua$") then
+      local name = "kong/api/routes/" .. file
+      if not file_set[name] then
+        error("File " .. name .. " not known to autodoc-admin-api! "  ..
+              "Please add to the data.known tables.")
+      end
+    end
+  end
+end
+
+--------------------------------------------------------------------------------
+
+local function write_admin_api(filename, data, title)
+  lfs.mkdir("autodoc")
+  lfs.mkdir("autodoc/output")
+  lfs.mkdir("autodoc/output/admin-api")
+  local outpath = "autodoc/output/admin-api/" .. filename
+
+  local outfd = assert(io.open(outpath, "w+"))
+
+  reset_uuid()
+
+  outfd:write("---\n")
+  outfd:write("title: " .. utils.titleize(title) .. "\n\n")
+  for _, entity in ipairs(data.known.entities) do
+    local entity_data = assert(data.entities[entity],
+                               "Missing autodoc entity data for " .. entity)
+
+    write_entity_templates(outfd, entity, entity_data)
+  end
+  outfd:write("\n---\n")
+
+  for _, ipart in ipairs(assert(data.intro, "Missing intro string in data.lua")) do
+    outfd:write("\n")
+    write_title(outfd, 2, ipart.title)
+    outfd:write(unindent(ipart.text))
+  end
+
+  outfd:write("\n---\n\n")
+
+  local all_endpoints = {}
+
+  for _, fullname in ipairs(data.known.general_files) do
+    local name = fullname:match("/([^/]+)%.lua$")
+    write_general_section(outfd, fullname, all_endpoints, name, data.general)
+  end
+
+  local entity_infos = {}
+
+  for _, entity in ipairs(data.known.entities) do
+    local einfo = prepare_entity(data, entity, data.entities[entity])
+    table.insert(entity_infos, einfo)
+    entity_infos[entity] = einfo
+  end
+
+  for _, entity in ipairs(data.known.entities) do
+    prepare_foreign_key_endpoints(data, entity_infos, entity)
+  end
+
+  for _, entity_info in ipairs(entity_infos) do
+    write_title(outfd, 2, entity_info.title)
+    outfd:write(entity_info.intro)
+    write_endpoints(outfd, entity_info, all_endpoints, data.entities.methods)
+  end
+
+  -- Check that all endpoints were traversed
+  for _, info in ipairs(entity_infos) do
+    for endpoint, handler in pairs(info.mod) do
+      if handler ~= Endpoints.not_found then
+        assert(all_endpoints[endpoint],
+               "Missing autodoc data for implemented endpoint " ..
+               endpoint .. " -- did you document it in data.lua?")
+        assert(all_endpoints[endpoint].done
+               or all_endpoints[endpoint].skip,
+               "Expected done mark in autodoc endpoint " .. endpoint)
+      end
+    end
+  end
+
+  outfd:write(unindent(assert(data.footer, "Missing footer string in data.lua")))
+
+  outfd:close()
+
+  print("Wrote " .. outpath)
+end
+
+--------------------------------------------------------------------------------
+
+local function write_admin_api_nav(filename, data)
+  lfs.mkdir("autodoc")
+  lfs.mkdir("autodoc/output")
+  lfs.mkdir("autodoc/output/nav")
+  local outpath = "autodoc/output/nav/" .. filename
+
+  local outfd = assert(io.open(outpath, "w+"))
+
+  outfd:write("# Generated via autodoc-admin-api\n")
+  outfd:write(unindent(data.nav.header))
+
+  local level = 3
+  for _, t in ipairs(titles) do
+    if t.level <= level then
+      outfd:write("\n")
+    elseif t.level > level then
+      outfd:write(("    "):rep(level - 1) .. "  items:\n")
+    end
+    level = t.level
+    outfd:write(("    "):rep(level - 1) .. "- text: " .. t.title .. "\n")
+    outfd:write(("    "):rep(level - 1) .. "  url: /admin-api/#" .. t.title:lower():gsub(" ", "-") .. "\n")
+  end
+
+  outfd:close()
+
+  print("Wrote " .. outpath)
+end
+
+--------------------------------------------------------------------------------
+
+local function main()
+  print("Building Admin API docs...")
+
+  check_admin_api_modules(admin_api_data)
+
+  write_admin_api(
+    "admin-api.md",
+    admin_api_data,
+    "Admin API"
+  )
+
+  write_admin_api_nav(
+    "docs_nav.yml.admin-api.in",
+    admin_api_data
+  )
+
+  write_admin_api(
+    "db-less-admin-api.md",
+    dbless_data,
+    "Admin API for DB-less Mode",
+    {
+      "GET",
+    }
+  )
+
+end
+
+main()

--- a/scripts/autodoc-admin-api
+++ b/scripts/autodoc-admin-api
@@ -274,6 +274,20 @@ end
 
 --------------------------------------------------------------------------------
 
+local function assert_data(value, description)
+  if value == nil then
+    error("\n\n" ..
+          "****************************************\n" ..
+          "Missing " .. description .. "\n" ..
+          "-- please document it in autodoc/data/admin-api.lua\n" ..
+          "****************************************\n", 2)
+  end
+
+  return value
+end
+
+--------------------------------------------------------------------------------
+
 local function gen_kind(finfo, field_data)
   if field_data.kind then
     return "<br>*"  .. field_data.kind .. "*"
@@ -319,8 +333,8 @@ end
 
 local function write_field(outfd, fname, finfo, fullname, field_data, entity_name)
   local kind = gen_kind(finfo, field_data)
-  local description = assert(field_data.description,
-                             "Missing description for " .. entity_name .. "." .. fullname)
+  local description = assert_data(field_data.description,
+                                  "description for " .. entity_name .. "." .. fullname)
                       :gsub("%s+", " ")
   local defaults = gen_defaults(finfo)
   local notation = gen_notation(fname, finfo, field_data)
@@ -398,7 +412,7 @@ local function write_entity_templates(outfd, entity, entity_data)
   local schema = assert(require("kong.db.schema.entities." .. entity))
   local singular = to_singular(entity)
 
-  assert(entity_data.fields, "Missing autodoc fields entry for " .. entity)
+  assert_data(entity_data.fields, "'fields' entry for " .. entity)
 
   outfd:write(singular .. "_body: |\n")
   outfd:write("    Attributes | Description\n")
@@ -458,7 +472,7 @@ local function section(outfd, title, content)
 end
 
 local function write_endpoint(outfd, endpoint, ep_data, methods)
-  assert(ep_data, "Missing autodoc data for endpoint " .. endpoint)
+  assert_data(ep_data, "data for endpoint " .. endpoint)
   if ep_data.done or ep_data.skip then
     return
   end
@@ -471,7 +485,7 @@ local function write_endpoint(outfd, endpoint, ep_data, methods)
 
     local meth_data = ep_data[method]
     if meth_data then
-      assert(meth_data.title, "Missing autodoc info for " .. method .. " " .. endpoint)
+      assert_data(meth_data.title, "info for " .. method .. " " .. endpoint)
       write_title(outfd, 3, meth_data.title)
       section(outfd, nil, meth_data.description)
       local fk_endpoints = meth_data.fk_endpoints or {}
@@ -504,7 +518,7 @@ end
 
 
 local function write_general_section(outfd, filename, all_endpoints, name, data_general)
-  local file_data = assert(data_general[name], "Missing autodoc data for " .. filename)
+  local file_data = assert_data(data_general[name], "data for " .. filename)
 
   if file_data.skip == true then
     return
@@ -512,8 +526,8 @@ local function write_general_section(outfd, filename, all_endpoints, name, data_
 
   write_title(outfd, 2, file_data.title)
 
-  assert(file_data.description,
-         "Missing autodoc general description for " .. filename)
+  assert_data(file_data.description,
+              "'description' field for " .. filename)
 
   outfd:write(unindent(file_data.description))
   outfd:write("\n\n")
@@ -570,9 +584,9 @@ do
       return
     end
     local meth_data = get_or_create(ep_data, method)
-    assert(templates, "Missing autodoc templates definition for " .. endpoint)
+    assert_data(templates, "templates definition for " .. endpoint)
     local meth_tpls = templates[method]
-    assert(meth_tpls, "Missing autodoc templates definition for " .. method .. " " .. endpoint)
+    assert_data(meth_tpls, "templates definition for " .. method .. " " .. endpoint)
     adjust_for_method(subs, method)
 
     for _, k in ipairs(template_keys) do
@@ -591,18 +605,18 @@ do
 end
 
 local function gen_fk_endpoint(edata, templates, subs, parent_endpoint, method, has_ek)
-  local ep_data = assert(edata[parent_endpoint],
-                         "Expected entity data to exist for endpoint " .. parent_endpoint)
+  local ep_data = assert_data(edata[parent_endpoint],
+                              "entity data for endpoint " .. parent_endpoint)
   local meth_data = assert(ep_data[method]) -- get_or_create(ep_data, method)
-  assert(templates, "Missing autodoc templates definition for " .. parent_endpoint)
+  assert_data(templates, "templates definition for " .. parent_endpoint)
   local meth_tpls = templates[method]
-  assert(meth_tpls, "Missing autodoc templates definition for " .. method .. " " .. parent_endpoint)
+  assert_data(meth_tpls, "templates definition for " .. method .. " " .. parent_endpoint)
   local tk = has_ek and "fk_endpoint_w_ek" or "fk_endpoint"
   local tpl = meth_tpls[tk] or templates[tk]
-  assert(tpl, "Missing autodoc " .. tk .. " template for " .. method .. " " .. parent_endpoint)
+  assert_data(tpl, tk .. " template for " .. method .. " " .. parent_endpoint)
   adjust_for_method(subs, method)
 
-  assert(meth_data.title)
+  assert_data(meth_data.title, "'title' field for " .. method .. " " .. parent_endpoint)
   local fk_endpoints = get_or_create(meth_data, "fk_endpoints")
   table.insert(fk_endpoints, render(tpl, subs))
 end
@@ -633,8 +647,8 @@ end
 local function prepare_entity(data, plural, entity_data)
   local out = {}
 
-  assert(entity_data.description,
-         "Missing autodoc entity description for " .. plural)
+  assert_data(entity_data.description,
+              "'description' field for " .. plural)
 
   local schema = assert(loadfile(KONG_PATH .. "/" .. entity_to_schema_path(plural)))()
   local subs = gen_template_subs_table(entity_data, plural, schema)
@@ -781,14 +795,14 @@ local function write_admin_api(filename, data, title)
   outfd:write("---\n")
   outfd:write("title: " .. utils.titleize(title) .. "\n\n")
   for _, entity in ipairs(data.known.entities) do
-    local entity_data = assert(data.entities[entity],
-                               "Missing autodoc entity data for " .. entity)
+    local entity_data = assert_data(data.entities[entity],
+                                    "entity data for " .. entity)
 
     write_entity_templates(outfd, entity, entity_data)
   end
   outfd:write("\n---\n")
 
-  for _, ipart in ipairs(assert(data.intro, "Missing intro string in data.lua")) do
+  for _, ipart in ipairs(assert_data(data.intro, "intro string")) do
     outfd:write("\n")
     write_title(outfd, 2, ipart.title)
     outfd:write(unindent(ipart.text))
@@ -825,17 +839,15 @@ local function write_admin_api(filename, data, title)
   for _, info in ipairs(entity_infos) do
     for endpoint, handler in pairs(info.mod) do
       if handler ~= Endpoints.not_found then
-        assert(all_endpoints[endpoint],
-               "Missing autodoc data for implemented endpoint " ..
-               endpoint .. " -- did you document it in data.lua?")
-        assert(all_endpoints[endpoint].done
-               or all_endpoints[endpoint].skip,
-               "Expected done mark in autodoc endpoint " .. endpoint)
+        assert_data(all_endpoints[endpoint],
+                    "data for implemented endpoint " .. endpoint)
+        assert_data(all_endpoints[endpoint].done or all_endpoints[endpoint].skip,
+                    "done or skip mark in endpoint " .. endpoint)
       end
     end
   end
 
-  outfd:write(unindent(assert(data.footer, "Missing footer string in data.lua")))
+  outfd:write(unindent(assert_data(data.footer, "footer string")))
 
   outfd:close()
 


### PR DESCRIPTION
This PR merges the auto-generation of reference docs for the Admin API, which currently live in the https://github.com/kong/docs.konghq.com repository, into this repository.

It also integrates the generation in the CI run. This means that whenever a new entity, schema attribute or Admin API endpoint is added to the code base, it will have to be documented to make the tests pass.

This PR includes @dndx's recent fixes and documentation of the CA Certificates entity (superseding https://github.com/Kong/docs.konghq.com/pull/1421)  as well as new docs for new Upstreams endpoints introduced in #4752 and the `headers` attribute for Routes introduced in #4758.