### PR TITLE
chore(deps) update dns client to 4.1.0

### DIFF
--- a/kong-1.2.1-0.rockspec
+++ b/kong-1.2.1-0.rockspec
@@ -30,7 +30,7 @@ dependencies = {
   "luaossl == 20190612",
   "luasyslog == 1.0.0",
   "lua_pack == 1.0.5",
-  "lua-resty-dns-client == 4.0.0",
+  "lua-resty-dns-client == 4.1.0",
   "lua-resty-worker-events == 1.0.0",
   "lua-resty-mediador == 0.1.2",
   "lua-resty-healthcheck == 1.0.0",


### PR DESCRIPTION
see release notes: https://github.com/Kong/lua-resty-dns-client#410-7-aug-2019

Fixes #4781
