### PR TITLE
fix(plugins) foreign fields were not always required as they should

### DIFF
--- a/kong/plugins/acl/daos.lua
+++ b/kong/plugins/acl/daos.lua
@@ -10,7 +10,7 @@ return {
     fields = {
       { id = typedefs.uuid },
       { created_at = typedefs.auto_timestamp_s },
-      { consumer = { type = "foreign", reference = "consumers", default = ngx.null, on_delete = "cascade", }, },
+      { consumer = { type = "foreign", reference = "consumers", required = true, on_delete = "cascade" }, },
       { group = { type = "string", required = true } },
     },
   },

--- a/kong/plugins/basic-auth/basicauth_credentials.lua
+++ b/kong/plugins/basic-auth/basicauth_credentials.lua
@@ -27,7 +27,11 @@ local hash_password = function(self, cred_id_or_username, cred)
     end
   end
 
-  cred.password = crypto.hash(cred.consumer.id, cred.password)
+  if cred.consumer then
+    cred.password = crypto.hash(cred.consumer.id, cred.password)
+  else
+    cred.password = crypto.hash(utils.uuid(), cred.password)
+  end
 
   return true
 end

--- a/kong/plugins/basic-auth/daos.lua
+++ b/kong/plugins/basic-auth/daos.lua
@@ -16,7 +16,7 @@ return {
     fields = {
       { id = typedefs.uuid },
       { created_at = typedefs.auto_timestamp_s },
-      { consumer = { type = "foreign", reference = "consumers", default = ngx.null, on_delete = "cascade", }, },
+      { consumer = { type = "foreign", reference = "consumers", required = true, on_delete = "cascade", }, },
       { username = { type = "string", required = true, unique = true }, },
       { password = { type = "string", required = true }, },
     },

--- a/kong/plugins/hmac-auth/daos.lua
+++ b/kong/plugins/hmac-auth/daos.lua
@@ -12,7 +12,7 @@ return {
     fields = {
       { id = typedefs.uuid },
       { created_at = typedefs.auto_timestamp_s },
-      { consumer = { type = "foreign", reference = "consumers", default = ngx.null, on_delete = "cascade", }, },
+      { consumer = { type = "foreign", reference = "consumers", required = true, on_delete = "cascade", }, },
       { username = { type = "string", required = true, unique = true }, },
       { secret = { type = "string", auto = true }, },
     },

--- a/kong/plugins/jwt/daos.lua
+++ b/kong/plugins/jwt/daos.lua
@@ -21,7 +21,7 @@ return {
     fields = {
       { id = typedefs.uuid },
       { created_at = typedefs.auto_timestamp_s },
-      { consumer = { type = "foreign", reference = "consumers", default = ngx.null, on_delete = "cascade", }, },
+      { consumer = { type = "foreign", reference = "consumers", required = true, on_delete = "cascade", }, },
       { key = { type = "string", required = false, unique = true, auto = true }, },
       { secret = { type = "string", auto = true }, },
       { rsa_public_key = { type = "string" }, },

--- a/kong/plugins/key-auth/daos.lua
+++ b/kong/plugins/key-auth/daos.lua
@@ -11,7 +11,7 @@ return {
     fields = {
       { id = typedefs.uuid },
       { created_at = typedefs.auto_timestamp_s },
-      { consumer = { type = "foreign", reference = "consumers", default = ngx.null, on_delete = "cascade", }, },
+      { consumer = { type = "foreign", reference = "consumers", required = true, on_delete = "cascade", }, },
       { key = { type = "string", required = false, unique = true, auto = true }, },
     },
   },

--- a/kong/plugins/oauth2/daos.lua
+++ b/kong/plugins/oauth2/daos.lua
@@ -24,7 +24,7 @@ local oauth2_credentials = {
   fields = {
     { id = typedefs.uuid },
     { created_at = typedefs.auto_timestamp_s },
-    { consumer = { type = "foreign", reference = "consumers", default = ngx.null, on_delete = "cascade", }, },
+    { consumer = { type = "foreign", reference = "consumers", required = true, on_delete = "cascade", }, },
     { name = { type = "string", required = true }, },
     { client_id = { type = "string", required = false, unique = true, auto = true }, },
     { client_secret = { type = "string", required = false, auto = true }, },
@@ -48,7 +48,7 @@ local oauth2_authorization_codes = {
     { id = typedefs.uuid },
     { created_at = typedefs.auto_timestamp_s },
     { service = { type = "foreign", reference = "services", default = ngx.null, on_delete = "cascade", }, },
-    { credential = { type = "foreign", reference = "oauth2_credentials", default = ngx.null, on_delete = "cascade", }, },
+    { credential = { type = "foreign", reference = "oauth2_credentials", required = true, on_delete = "cascade", }, },
     { code = { type = "string", required = false, unique = true, auto = true }, }, -- FIXME immutable
     { authenticated_userid = { type = "string", required = false }, },
     { scope = { type = "string" }, },
@@ -67,7 +67,7 @@ local oauth2_tokens = {
     { id = typedefs.uuid },
     { created_at = typedefs.auto_timestamp_s },
     { service = { type = "foreign", reference = "services", default = ngx.null, on_delete = "cascade", }, },
-    { credential = { type = "foreign", reference = "oauth2_credentials", default = ngx.null, on_delete = "cascade", }, },
+    { credential = { type = "foreign", reference = "oauth2_credentials", required = true, on_delete = "cascade", }, },
     { token_type = { type = "string", required = true, one_of = { BEARER }, default = BEARER }, },
     { expires_in = { type = "integer", required = true }, },
     { access_token = { type = "string", required = false, unique = true, auto = true }, },

--- a/spec/01-unit/01-db/01-schema/11-declarative_config/01-validate_spec.lua
+++ b/spec/01-unit/01-db/01-schema/11-declarative_config/01-validate_spec.lua
@@ -608,6 +608,7 @@ describe("declarative config: validate", function()
           _format_version: "1.1"
           oauth2_credentials:
           - name: my-credential
+            consumer: foo
             redirect_uris:
             - https://example.com
           - name: another-credential
@@ -654,6 +655,7 @@ describe("declarative config: validate", function()
         assert.same({
           ["oauth2_credentials"] = {
             {
+              ["consumer"] = "required field missing",
               ["redirect_uris"] = {
                 [2] = "cannot parse 'foobar'",
               }
@@ -788,6 +790,7 @@ describe("declarative config: validate", function()
             _format_version: "1.1"
             oauth2_credentials:
             - name: my-credential
+              consumer: bob
               redirect_uris:
               - https://example.com
               oauth2_tokens:
@@ -799,6 +802,7 @@ describe("declarative config: validate", function()
             _format_version: "1.1"
             oauth2_credentials:
             - name: my-credential
+              consumer: bob
               redirect_uris:
               - https://example.com
               oauth2_tokens:
@@ -824,6 +828,7 @@ describe("declarative config: validate", function()
           assert.same({
             ["oauth2_credentials"] = {
               {
+                ["consumer"] = "required field missing",
                 ["oauth2_tokens"] = {
                   {
                     ["expires_in"] = "required field missing",
@@ -839,6 +844,7 @@ describe("declarative config: validate", function()
             _format_version: "1.1"
             oauth2_credentials:
             - name: my-credential
+              consumer: bob
               redirect_uris:
               - https://example.com
               oauth2_tokens:

--- a/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
+++ b/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
@@ -1166,6 +1166,7 @@ describe("declarative config: flatten", function()
           _format_version: "1.1"
           oauth2_credentials:
           - name: my-credential
+            consumer: foo
             redirect_uris:
             - https://example.com
           - name: another-credential
@@ -1180,6 +1181,9 @@ describe("declarative config: flatten", function()
             [1] = {
               [1] = "invalid reference 'consumer: foo' (no such entry in 'consumers')"
             },
+            [2] = {
+              [1] = "invalid reference 'consumer: foo' (no such entry in 'consumers')"
+            },
           }
         }, err)
       end)
@@ -1187,20 +1191,25 @@ describe("declarative config: flatten", function()
       it("accepts entities", function()
         local config = assert(lyaml.load([[
           _format_version: "1.1"
-          oauth2_credentials:
-          - name: my-credential
-            redirect_uris:
-            - https://example.com
-          - name: another-credential
-            redirect_uris:
-            - https://example.test
+          consumers:
+          - username: bob
+            oauth2_credentials:
+            - name: my-credential
+              redirect_uris:
+              - https://example.com
+            - name: another-credential
+              redirect_uris:
+              - https://example.test
         ]]))
         config = DeclarativeConfig:flatten(config)
+        config.consumers = nil
         assert.same({
           oauth2_credentials = { {
               client_id = "RANDOM",
-                    client_secret = "RANDOM",
-                          consumer = null,
+              client_secret = "RANDOM",
+              consumer = {
+                id = "UUID"
+              },
               created_at = 1234567890,
               id = "UUID",
               name = "another-credential",
@@ -1208,7 +1217,9 @@ describe("declarative config: flatten", function()
             }, {
               client_id = "RANDOM",
               client_secret = "RANDOM",
-              consumer = null,
+              consumer = {
+                id = "UUID",
+              },
               created_at = 1234567890,
               id = "UUID",
               name = "my-credential",
@@ -1291,18 +1302,24 @@ describe("declarative config: flatten", function()
         it("accepts an empty list", function()
           local config = assert(lyaml.load([[
             _format_version: "1.1"
+            consumers:
+            - username: bob
             oauth2_credentials:
             - name: my-credential
+              consumer: bob
               redirect_uris:
               - https://example.com
               oauth2_tokens:
           ]]))
           config = DeclarativeConfig:flatten(config)
+          config.consumers = nil
           assert.same({
             oauth2_credentials = { {
                 client_id = "RANDOM",
-                      client_secret = "RANDOM",
-                consumer = null,
+                client_secret = "RANDOM",
+                consumer = {
+                  id = "UUID"
+                },
                 created_at = 1234567890,
                 id = "UUID",
                 name = "my-credential",
@@ -1314,8 +1331,11 @@ describe("declarative config: flatten", function()
         it("accepts entities", function()
           local config = assert(lyaml.load([[
             _format_version: "1.1"
+            consumers:
+            - username: bob
             oauth2_credentials:
             - name: my-credential
+              consumer: bob
               redirect_uris:
               - https://example.com
               oauth2_tokens:
@@ -1324,12 +1344,15 @@ describe("declarative config: flatten", function()
               - expires_in: 10
                 scope: "foo"
           ]]))
-          config = DeclarativeConfig:flatten(config)
+          local config = DeclarativeConfig:flatten(config)
+          config.consumers = nil
           assert.same({
             oauth2_credentials = { {
                 client_id = "RANDOM",
                 client_secret = "RANDOM",
-                consumer = null,
+                consumer = {
+                  id = "UUID"
+                },
                 created_at = 1234567890,
                 id = "UUID",
                 name = "my-credential",

--- a/spec/03-plugins/09-key-auth/01-api_spec.lua
+++ b/spec/03-plugins/09-key-auth/01-api_spec.lua
@@ -394,6 +394,87 @@ for _, strategy in helpers.each_strategy() do
           --assert.is_nil(json_2.offset) -- last page
         end)
       end)
+
+      describe("POST", function()
+        lazy_setup(function()
+          db:truncate("keyauth_credentials")
+        end)
+
+        it("does not create key-auth credential when missing consumer", function()
+          local res = assert(admin_client:send {
+            method = "POST",
+            path = "/key-auths",
+            body = {
+              key = "1234",
+            },
+            headers = {
+              ["Content-Type"] = "application/json"
+            }
+          })
+          local body = assert.res_status(400, res)
+          local json = cjson.decode(body)
+          assert.same("schema violation (consumer: required field missing)", json.message)
+        end)
+
+        it("creates key-auth credential", function()
+          local res = assert(admin_client:send {
+            method = "POST",
+            path = "/key-auths",
+            body = {
+              key = "1234",
+              consumer = {
+                id = consumer.id
+              }
+            },
+            headers = {
+              ["Content-Type"] = "application/json"
+            }
+          })
+          local body = assert.res_status(201, res)
+          local json = cjson.decode(body)
+          assert.equal("1234", json.key)
+        end)
+      end)
+    end)
+
+    describe("/key-auths/:credential_key_or_id", function()
+      describe("PUT", function()
+        lazy_setup(function()
+          db:truncate("keyauth_credentials")
+        end)
+
+        it("does not create key-auth credential when missing consumer", function()
+          local res = assert(admin_client:send {
+            method = "PUT",
+            path = "/key-auths/1234",
+            body = { },
+            headers = {
+              ["Content-Type"] = "application/json"
+            }
+          })
+          local body = assert.res_status(400, res)
+          local json = cjson.decode(body)
+          assert.same("schema violation (consumer: required field missing)", json.message)
+        end)
+
+        it("creates key-auth credential", function()
+          local res = assert(admin_client:send {
+            method = "PUT",
+            path = "/key-auths/1234",
+            body = {
+              consumer = {
+                id = consumer.id
+              }
+            },
+            headers = {
+              ["Content-Type"] = "application/json"
+            }
+          })
+          local body = assert.res_status(200, res)
+          local json = cjson.decode(body)
+          assert.equal("1234", json.key)
+        end)
+      end)
     end)
 
     describe("/key-auths/:credential_key_or_id/consumer", function()

--- a/spec/03-plugins/10-basic-auth/03-access_spec.lua
+++ b/spec/03-plugins/10-basic-auth/03-access_spec.lua
@@ -367,6 +367,7 @@ for _, strategy in helpers.each_strategy() do
         "plugins",
         "consumers",
         "basicauth_credentials",
+        "keyauth_credentials",
       })
 
       anonymous = bp.consumers:insert {

--- a/spec/03-plugins/19-hmac-auth/02-api_spec.lua
+++ b/spec/03-plugins/19-hmac-auth/02-api_spec.lua
@@ -336,7 +336,90 @@ for _, strategy in helpers.each_strategy() do
           --assert.is_nil(json_2.offset) -- last page
         end)
       end)
+
+      describe("POST", function()
+        lazy_setup(function()
+          db:truncate("hmacauth_credentials")
+        end)
+
+        it("does not create hmac-auth credential when missing consumer", function()
+          local res = assert(admin_client:send {
+            method = "POST",
+            path = "/hmac-auths",
+            body = {
+              username = "bob",
+            },
+            headers = {
+              ["Content-Type"] = "application/json"
+            }
+          })
+          local body = assert.res_status(400, res)
+          local json = cjson.decode(body)
+          assert.same("schema violation (consumer: required field missing)", json.message)
+        end)
+
+        it("creates hmac-auth credential", function()
+          local res = assert(admin_client:send {
+            method = "POST",
+            path = "/hmac-auths",
+            body = {
+              username = "bob",
+              consumer = {
+                id = consumer.id
+              }
+            },
+            headers = {
+              ["Content-Type"] = "application/json"
+            }
+          })
+          local body = assert.res_status(201, res)
+          local json = cjson.decode(body)
+          assert.equal("bob", json.username)
+        end)
+      end)
     end)
+
+    describe("/hmac-auths/:username_or_id", function()
+      describe("PUT", function()
+        lazy_setup(function()
+          db:truncate("hmacauth_credentials")
+        end)
+
+        it("does not create hmac-auth credential when missing consumer", function()
+          local res = assert(admin_client:send {
+            method = "PUT",
+            path = "/hmac-auths/bob",
+            body = {
+            },
+            headers = {
+              ["Content-Type"] = "application/json"
+            }
+          })
+          local body = assert.res_status(400, res)
+          local json = cjson.decode(body)
+          assert.same("schema violation (consumer: required field missing)", json.message)
+        end)
+
+        it("creates hmac-auth credential", function()
+          local res = assert(admin_client:send {
+            method = "PUT",
+            path = "/hmac-auths/bob",
+            body = {
+              consumer = {
+                id = consumer.id
+              }
+            },
+            headers = {
+              ["Content-Type"] = "application/json"
+            }
+          })
+          local body = assert.res_status(200, res)
+          local json = cjson.decode(body)
+          assert.equal("bob", json.username)
+        end)
+      end)
+    end)
+
     describe("/hmac-auths/:hmac_username_or_id/consumer", function()
       describe("GET", function()
         local credential


### PR DESCRIPTION
### Summary

The issue originates from converting the old schema to new one where some fields where marked as `default=ngx.null` instead of `required=true`. This PR changes those back to required.

### Issues resolved

Fix #4875