### PR TITLE
fix(dao) PUT on plugin configs behaves like PATCH (instead of replace)

### DIFF
--- a/kong/db/dao/plugins.lua
+++ b/kong/db/dao/plugins.lua
@@ -107,10 +107,6 @@ end
 
 
 function Plugins:upsert(primary_key, entity, options)
-  local rbw_entity = self.super.select(self, primary_key, options) -- ignore errors
-  if rbw_entity then
-    entity = self.schema:merge_values(entity, rbw_entity)
-  end
   local ok, err, err_t = check_protocols_match(self, entity)
   if not ok then
     return nil, err, err_t

--- a/spec/02-integration/03-db/03-plugins_spec.lua
+++ b/spec/02-integration/03-db/03-plugins_spec.lua
@@ -173,13 +173,13 @@ for _, strategy in helpers.each_strategy() do
     describe(":upsert()", function()
       it("returns an error when upserting mismatched plugins", function()
         local p, _, err_t = db.plugins:upsert({ id = global_plugin.id },
-                                              { route = { id = route.id } })
+                                              { route = { id = route.id }, protocols = { "http" } })
         assert.is_nil(p)
         assert.equals(err_t.fields.protocols, "must match the associated route's protocols")
 
 
         local p, _, err_t = db.plugins:upsert({ id = global_plugin.id },
-                                              { service = { id = service.id } })
+                                              { service = { id = service.id }, protocols = { "http" } })
         assert.is_nil(p)
         assert.equals(err_t.fields.protocols,
                       "must match the protocols of at least one route pointing to this Plugin's service")


### PR DESCRIPTION
### Summary

The plugins had an customized api that used read-before-write on upserts which is not how our definition of upsert should work.

There are many interpretation of what upsert can mean, the two most common ones are:

1. insert (post) or update (patch)
2. insert (post) or replace (put)

Our definition is the 2. where replace means that we do not retain any properties of the existing entity, except the primary key (to avoid deleting the entity prior inserting a new one).

### Issues resolved

Fix #4802