### PR TITLE
fix(oauth2) empty client_id wasn't checked, which resulted server error

### DIFF
--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -108,7 +108,7 @@ end
 
 local function get_redirect_uris(client_id)
   local client, err
-  if client_id then
+  if client_id and client_id ~= "" then
     local credential_cache_key = kong.db.oauth2_credentials:cache_key(client_id)
     client, err = kong.cache:get(credential_cache_key, nil,
                                  load_oauth2_credential_by_client_id,

--- a/spec/03-plugins/25-oauth2/03-access_spec.lua
+++ b/spec/03-plugins/25-oauth2/03-access_spec.lua
@@ -921,7 +921,27 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
           local json = cjson.decode(body)
           assert.same({ error_description = "Invalid client authentication", error = "invalid_client" }, json)
         end)
-        it("returns an error when client_secret is not sent", function()
+        it("returns an error when empty client_id and empty client_secret is sent", function()
+          local res = assert(proxy_ssl_client:send {
+            method  = "POST",
+            path    = "/oauth2/token",
+            body    = {
+              client_id        = "",
+              client_secret    = "",
+              scope            = "email",
+              response_type    = "token",
+              grant_type       = "client_credentials",
+            },
+            headers = {
+              ["Host"]         = "oauth2_4.com",
+              ["Content-Type"] = "application/json"
+            }
+          })
+          local body = assert.res_status(400, res)
+          local json = cjson.decode(body)
+          assert.same({ error_description = "Invalid client authentication", error = "invalid_client" }, json)
+        end)
+        it("returns an error when grant_type is not sent", function()
           local res = assert(proxy_ssl_client:send {
             method  = "POST",
             path    = "/oauth2/token",


### PR DESCRIPTION
### Summary

`client_id` (from downstream client) was not validated against empty string before it was used, and that subsequently caused a DAO validation error. This fixes that.

### Issues resolved

Fix #4728