### PR TITLE
hotfix(schema) allow 'host' sub-string in headers

### DIFF
--- a/kong/db/schema/typedefs.lua
+++ b/kong/db/schema/typedefs.lua
@@ -506,7 +506,7 @@ typedefs.headers = Schema.define {
     type = "string",
     match_none = {
       {
-        pattern = "[Hh][Oo][Ss][Tt]",
+        pattern = "^[Hh][Oo][Ss][Tt]$",
         err = "cannot contain 'host' header, which must be specified in the 'hosts' attribute",
       },
     },

--- a/spec/01-unit/01-db/01-schema/03-typedefs_spec.lua
+++ b/spec/01-unit/01-db/01-schema/03-typedefs_spec.lua
@@ -175,5 +175,15 @@ describe("typedefs", function()
     assert.falsy(Test:validate({ f = 123 }))
   end)
 
+  it("headers rejects 'host' but accepts 'host' substring", function()
+    local Test = Schema.new({
+      fields = {
+        { f = typedefs.headers() }
+      }
+    })
+    assert.falsy(Test:validate({ f = { ["host"]  = { "example.com" } } }))
+    assert.truthy(Test:validate({ f = { ["hostname"]  = { "example.com" } } }))
+  end)
+
 
 end)


### PR DESCRIPTION
### Summary

An exact match of `host` header should not be allowed in the headers
property of routes but a header with `host` as a sub-string in the key should be
allowed.

### Full changelog

* hotfix(schema) allow 'host' substrings in headers