### PR TITLE
 fix(pdk) response.exit to error when using table body with content-type

### DIFF
--- a/kong/pdk/response.lua
+++ b/kong/pdk/response.lua
@@ -14,7 +14,6 @@
 
 local cjson = require "cjson.safe"
 local meta = require "kong.meta"
-local constants = require "kong.constants"
 local checks = require "kong.pdk.private.checks"
 local phase_checker = require "kong.pdk.private.phases"
 
@@ -35,7 +34,6 @@ local check_phase = phase_checker.check
 
 
 local PHASES = phase_checker.phases
-local GRPC_PROXY_MODES = constants.GRPC_PROXY_MODES
 
 
 local header_body_log = phase_checker.new(PHASES.header_filter,
@@ -508,8 +506,6 @@ local function new(self, major_version)
     if res_ctype then
       is_grpc = find(res_ctype, CONTENT_TYPE_GRPC, 1, true) == 1
       is_grpc_output = is_grpc
-    elseif GRPC_PROXY_MODES[ngx.var.kong_proxy_mode] then
-      is_grpc = true
     elseif req_ctype then
       is_grpc = find(req_ctype, CONTENT_TYPE_GRPC, 1, true) == 1
                   and ngx.req.http_version() == "2"

--- a/kong/pdk/response.lua
+++ b/kong/pdk/response.lua
@@ -557,9 +557,11 @@ local function new(self, major_version)
         ngx.header[CONTENT_LENGTH_NAME] = 0
         ngx.header[GRPC_MESSAGE_NAME] = body
 
+        ngx.print() -- avoid default content
+
       else
         ngx.header[CONTENT_LENGTH_NAME] = #body
-        if grpc_status then
+        if grpc_status and not ngx.header[GRPC_MESSAGE_NAME] then
           ngx.header[GRPC_MESSAGE_NAME] = GRPC_MESSAGES[grpc_status]
         end
 
@@ -568,8 +570,12 @@ local function new(self, major_version)
 
     else
       ngx.header[CONTENT_LENGTH_NAME] = 0
-      if grpc_status then
+      if grpc_status and not ngx.header[GRPC_MESSAGE_NAME] then
         ngx.header[GRPC_MESSAGE_NAME] = GRPC_MESSAGES[grpc_status]
+      end
+
+      if is_grpc then
+        ngx.print() -- avoid default content
       end
     end
 

--- a/kong/pdk/response.lua
+++ b/kong/pdk/response.lua
@@ -532,10 +532,16 @@ local function new(self, major_version)
     local json
     if type(body) == "table" then
       if is_grpc then
-        if type(body.message) == "string" then
+        if is_grpc_output then
+          error("table body encoding with gRPC is not supported", 2)
+
+        elseif type(body.message) == "string" then
           body = body.message
+
         else
-          body = nil -- grpc table encoding not supported currently
+          self.log.warn("body was removed because table body encoding with " ..
+                        "gRPC is not supported")
+          body = nil
         end
 
       else

--- a/t/01-pdk/08-response/11-exit.t
+++ b/t/01-pdk/08-response/11-exit.t
@@ -611,11 +611,10 @@ Content-Length: 19
 === TEST 23: response.exit() does not send body with gRPC
 --- http_config eval: $t::Util::HttpConfig
 --- config
-    set $kong_proxy_mode 'grpc';
-
     location = /t {
         default_type 'text/test';
         access_by_lua_block {
+            ngx.req.http_version = function() return "2" end
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
 
@@ -624,6 +623,8 @@ Content-Length: 19
     }
 --- request
 GET /t
+--- more_headers
+Content-Type: application/grpc
 --- error_code: 200
 --- response_headers_like
 Content-Length: 0
@@ -634,11 +635,9 @@ grpc-message: hello
 
 
 
-=== TEST 24: response.exit() does sends body with gRPC when asked
+=== TEST 24: response.exit() does send body with gRPC when asked
 --- http_config eval: $t::Util::HttpConfig
 --- config
-    set $kong_proxy_mode 'grpc';
-
     location = /t {
         default_type 'text/test';
         access_by_lua_block {

--- a/t/01-pdk/08-response/11-exit.t
+++ b/t/01-pdk/08-response/11-exit.t
@@ -3,7 +3,7 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use t::Util;
 
-plan tests => repeat_each() * (blocks() * 4) - 5;
+plan tests => repeat_each() * (blocks() * 4) + 13;
 
 run_tests();
 
@@ -635,7 +635,7 @@ grpc-message: hello
 
 
 
-=== TEST 24: response.exit() does send body with gRPC when asked
+=== TEST 24: response.exit() sends body with gRPC when asked (explicit)
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -644,7 +644,7 @@ grpc-message: hello
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
 
-            pdk.response.exit(200, { message = "hello" }, {
+            pdk.response.exit(200, "hello", {
                 content_type = "application/grpc"
             })
         }
@@ -658,5 +658,260 @@ grpc-status: 0
 grpc-message: OK
 --- response_body chop
 hello
+--- no_error_log
+[error]
+
+
+
+=== TEST 25: response.exit() sends body with gRPC when asked (implicit)
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        default_type 'text/test';
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            pdk.response.set_header("Content-Type", "application/grpc")
+            pdk.response.exit(200, "hello")
+        }
+    }
+--- request
+GET /t
+--- error_code: 200
+--- response_headers_like
+Content-Length: 5
+grpc-status: 0
+grpc-message: OK
+--- response_body chop
+hello
+--- no_error_log
+[error]
+
+
+
+=== TEST 26: response.exit() body replaces grpc-message
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        default_type 'text/test';
+        access_by_lua_block {
+            ngx.req.http_version = function() return "2" end
+
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            pdk.response.exit(200, "OK", {
+              ["grpc-message"] = "REPLACE ME"
+            })
+        }
+    }
+--- request
+GET /t
+--- more_headers
+Content-Type: application/grpc
+--- error_code: 200
+--- response_headers_like
+Content-Length: 0
+grpc-status: 0
+grpc-message: OK
+--- response_body chop
+--- no_error_log
+[error]
+
+
+
+=== TEST 27: response.exit() body does not replace grpc-message with content-type specified (explicit)
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        default_type 'text/test';
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            pdk.response.exit(200, "OK", {
+              ["Content-Type"]  = "application/grpc",
+              ["grpc-message"] = "SHOW ME"
+            })
+        }
+    }
+--- request
+GET /t
+--- error_code: 200
+--- response_headers_like
+Content-Length: 2
+grpc-status: 0
+grpc-message: SHOW ME
+--- response_body chop
+OK
+--- no_error_log
+[error]
+
+
+
+=== TEST 28: response.exit() body does not replace grpc-message with content-type specified (implicit)
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        default_type 'text/test';
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            pdk.response.set_header("Content-Type", "application/grpc")
+            pdk.response.exit(200, "OK", {
+              ["grpc-message"] = "SHOW ME"
+            })
+        }
+    }
+--- request
+GET /t
+--- error_code: 200
+--- response_headers_like
+Content-Length: 2
+grpc-status: 0
+grpc-message: SHOW ME
+--- response_body chop
+OK
+--- no_error_log
+[error]
+
+
+
+=== TEST 29: response.exit() nil body does not replace grpc-message with default message
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        default_type 'text/test';
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            pdk.response.set_header("Content-Type", "application/grpc")
+            pdk.response.exit(200, nil, {
+              ["grpc-message"] = "SHOW ME"
+            })
+        }
+    }
+--- request
+GET /t
+--- error_code: 200
+--- response_headers_like
+Content-Length: 0
+grpc-status: 0
+grpc-message: SHOW ME
+--- response_body chop
+--- no_error_log
+[error]
+
+
+
+=== TEST 30: response.exit() sends default grpc-message (200)
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        default_type 'text/test';
+        access_by_lua_block {
+            ngx.req.http_version = function() return "2" end
+
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            pdk.response.exit(200)
+        }
+    }
+--- request
+GET /t
+--- more_headers
+Content-Type: application/grpc
+--- error_code: 200
+--- response_headers_like
+Content-Length: 0
+grpc-status: 0
+grpc-message: OK
+--- response_body chop
+--- no_error_log
+[error]
+
+
+
+=== TEST 31: response.exit() sends default grpc-message (403)
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        default_type 'text/test';
+        access_by_lua_block {
+            ngx.req.http_version = function() return "2" end
+
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            pdk.response.exit(403)
+        }
+    }
+--- request
+GET /t
+--- more_headers
+Content-Type: application/grpc
+--- error_code: 403
+--- response_headers_like
+Content-Length: 0
+grpc-status: 7
+grpc-message: PermissionDenied
+--- response_body chop
+--- no_error_log
+[error]
+
+
+
+=== TEST 32: response.exit() sends default grpc-message when specifying content-type (explicit)
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        default_type 'text/test';
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            pdk.response.exit(401, nil, {
+                ["Content-Type"]  = "application/grpc"
+            })
+        }
+    }
+--- request
+GET /t
+--- error_code: 401
+--- response_headers_like
+Content-Length: 0
+grpc-status: 16
+grpc-message: Unauthenticated
+--- response_body chop
+--- no_error_log
+[error]
+
+
+
+=== TEST 33: response.exit() sends default grpc-message when specifying content-type (implicit)
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        default_type 'text/test';
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            pdk.response.set_header("Content-Type", "application/grpc")
+            pdk.response.exit(401)
+        }
+    }
+--- request
+GET /t
+--- error_code: 401
+--- response_headers_like
+Content-Length: 0
+grpc-status: 16
+grpc-message: Unauthenticated
+--- response_body chop
 --- no_error_log
 [error]


### PR DESCRIPTION
### Summary

This contains more refinements to PDK's `kong.response.exit` for better gRPC support and compatibility with a current code and gRPC (a bit like best effort). Also explicitly errors on cases where explicitly outputting grpc content that we cannot encode.

* fix(pdk) remove the grpc_mode check, checking content types is enough. Also fixes warning that is logged when using this on admin api.
* fix(pdk) do not replace headers when specified with response.exit
* fix(pdk) response.exit to error when using table body with content-type.  Also logs warning when using table body that is not the common:
```
{
  message = "<string>"
}
```
and then basically ignores that body for better compatibility withcurrent Kong core and plugins that are not necessarily build for grpc in mind.