### PR TITLE
fix(pdk) make sure `response.add_header` works in `rewrite` phase and

### DIFF
--- a/kong/pdk/response.lua
+++ b/kong/pdk/response.lua
@@ -25,13 +25,13 @@ local type = type
 local find = string.find
 local error = error
 local pairs = pairs
-local insert = table.insert
 local coroutine = coroutine
 local normalize_header = checks.normalize_header
 local normalize_multi_header = checks.normalize_multi_header
 local validate_header = checks.validate_header
 local validate_headers = checks.validate_headers
 local check_phase = phase_checker.check
+local add_header = require("ngx.resp").add_header
 
 
 local PHASES = phase_checker.phases
@@ -382,14 +382,7 @@ local function new(self, major_version)
 
     validate_header(name, value)
 
-    local new_value = _RESPONSE.get_headers()[name]
-    if type(new_value) ~= "table" then
-      new_value = { new_value }
-    end
-
-    insert(new_value, normalize_header(value))
-
-    ngx.header[name] = new_value
+    add_header(name, normalize_header(value))
   end
 
 

--- a/kong/pdk/response.lua
+++ b/kong/pdk/response.lua
@@ -31,7 +31,10 @@ local normalize_multi_header = checks.normalize_multi_header
 local validate_header = checks.validate_header
 local validate_headers = checks.validate_headers
 local check_phase = phase_checker.check
-local add_header = require("ngx.resp").add_header
+local add_header
+if ngx and ngx.config.subsystem == "http" then
+  add_header = require("ngx.resp").add_header
+end
 
 
 local PHASES = phase_checker.phases
@@ -374,6 +377,9 @@ local function new(self, major_version)
   -- kong.response.add_header("Cache-Control", "no-cache")
   -- kong.response.add_header("Cache-Control", "no-store")
   function _RESPONSE.add_header(name, value)
+    -- stream subsystem would been stopped by the phase checker below
+    -- therefore the nil reference to add_header will never have chance
+    -- to show
     check_phase(rewrite_access_header)
 
     if ngx.headers_sent then

--- a/spec/03-plugins/15-response-transformer/01-header_transformer_spec.lua
+++ b/spec/03-plugins/15-response-transformer/01-header_transformer_spec.lua
@@ -23,7 +23,10 @@ describe("Plugin: response-transformer", function()
     _G.ngx = {
       headers_sent = false,
       resp = {
-      }
+      },
+      config = {
+        subsystem = "http",
+      },
     }
     _G.kong = {
       response = require "kong.pdk.response".new(),
@@ -33,6 +36,18 @@ describe("Plugin: response-transformer", function()
         }
       }
     }
+
+    -- mock since FFI based ngx.resp.add_header won't work in this setup
+    _G.kong.response.add_header = function(name, value)
+      local new_value = _G.kong.response.get_headers()[name]
+      if type(new_value) ~= "table" then
+        new_value = { new_value }
+      end
+
+      table.insert(new_value, value)
+
+      ngx.header[name] = new_value
+    end
 
     header_transformer = require "kong.plugins.response-transformer.header_transformer"
   end)

--- a/t/01-pdk/08-response/00-phase_checks.t
+++ b/t/01-pdk/08-response/00-phase_checks.t
@@ -101,7 +101,7 @@ qq{
                 args          = { "X-Foo", "bar" },
                 init_worker   = false,
                 certificate   = "pending",
-                rewrite       = "forced false",
+                rewrite       = true,
                 access        = true,
                 header_filter = true,
                 body_filter   = false,


### PR DESCRIPTION
enable phase test for it. fix #4848

We take advantage of the new [ngx.resp.add_header](https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/resp.md#add_header) function which is both simpler and faster.

Note on mock of `kong.response.add_header` in plugin tests. Since the purpose of that file is to test whether the transformer calls `add_header` correctly instead of testing the `add_header` API itself, this change is appropriate. The PDK test suite already ensured `add_header` will function properly.