### PR TITLE
 fix(response-transformer) allow specify type for config value

### DIFF
--- a/kong/plugins/response-transformer/body_transformer.lua
+++ b/kong/plugins/response-transformer/body_transformer.lua
@@ -114,7 +114,7 @@ function _M.transform_json_body(conf, buffered_data)
       v = cast_value(v, v_type)
     end
 
-    if json_body[name] and v then
+    if json_body[name] and v ~= nil then
       json_body[name] = v
     end
   end
@@ -133,7 +133,7 @@ function _M.transform_json_body(conf, buffered_data)
       v = cast_value(v, v_type)
     end
 
-    if not json_body[name] and v then
+    if not json_body[name] and v ~= nil then
       json_body[name] = v
     end
 
@@ -153,7 +153,7 @@ function _M.transform_json_body(conf, buffered_data)
       v = cast_value(v, v_type)
     end
 
-    if v then
+    if v ~= nil then
       json_body[name] = append_value(json_body[name],v)
     end
   end

--- a/kong/plugins/response-transformer/body_transformer.lua
+++ b/kong/plugins/response-transformer/body_transformer.lua
@@ -19,6 +19,15 @@ local noop = function() end
 local _M = {}
 
 
+local function cast_value(value)
+  local num_v = tonumber(value)
+  if num_v == nil then
+    return value
+  end
+  return num_v
+end
+
+
 local function read_json_body(body)
   if body then
     return cjson.decode(body)
@@ -30,15 +39,15 @@ local function append_value(current_value, value)
   local current_value_type = type(current_value)
 
   if current_value_type  == "string" then
-    return {current_value, value }
+    return {current_value, cast_value(value) }
   end
 
   if current_value_type  == "table" then
-    insert(current_value, value)
+    insert(current_value, cast_value(value))
     return current_value
   end
 
-  return { value }
+  return { cast_value(value) }
 end
 
 
@@ -90,7 +99,7 @@ function _M.transform_json_body(conf, buffered_data)
 
     v = v and gsub(v, [[\/]], [[/]]) -- To prevent having double encoded slashes
     if json_body[name] and v then
-      json_body[name] = v
+      json_body[name] = cast_value(v)
     end
   end
 
@@ -103,8 +112,9 @@ function _M.transform_json_body(conf, buffered_data)
 
     v = v and gsub(v, [[\/]], [[/]]) -- To prevent having double encoded slashes
     if not json_body[name] and v then
-      json_body[name] = v
+      json_body[name] = cast_value(v)
     end
+
   end
 
   -- append new key:value or value to existing key

--- a/kong/plugins/response-transformer/schema.lua
+++ b/kong/plugins/response-transformer/schema.lua
@@ -29,6 +29,14 @@ local colon_string_record = {
   type = "record",
   fields = {
     { json = colon_string_array },
+    { json_types = {
+      type = "array",
+      default = {},
+      elements = {
+        type = "string",
+        one_of = { "boolean", "number", "string" }
+      }
+    } },
     { headers = colon_string_array },
   },
 }
@@ -51,4 +59,3 @@ return {
     },
   },
 }
-

--- a/spec/01-unit/01-db/01-schema/07-plugins_spec.lua
+++ b/spec/01-unit/01-db/01-schema/07-plugins_spec.lua
@@ -140,15 +140,18 @@ describe("plugins", function()
       },
       replace = {
         headers = {},
-        json = {}
+        json = {},
+        json_types = {}
       },
       add = {
         headers = {},
-        json = {}
+        json = {},
+        json_types = {}
       },
       append = {
         headers = {},
-        json = {}
+        json = {},
+        json_types = {}
       }
     }, plugin.config)
   end)

--- a/spec/03-plugins/15-response-transformer/02-body_transformer_spec.lua
+++ b/spec/03-plugins/15-response-transformer/02-body_transformer_spec.lua
@@ -13,7 +13,7 @@ describe("Plugin: response-transformer", function()
           json   = {}
         },
         add      = {
-          json   = {"p1:v1", "p3:value:3", "p4:\"v1\""}
+          json   = {"p1:v1", "p3:value:3", "p4:\"v1\"", "p5:-1"}
         },
         append   = {
           json   = {}
@@ -23,13 +23,19 @@ describe("Plugin: response-transformer", function()
         local json = [[{"p2":"v1"}]]
         local body = body_transformer.transform_json_body(conf, json)
         local body_json = cjson.decode(body)
-        assert.same({p1 = "v1", p2 = "v1", p3 = "value:3", p4 = '"v1"'}, body_json)
+        assert.same({p1 = "v1", p2 = "v1", p3 = "value:3", p4 = '"v1"', p5 = -1}, body_json)
       end)
       it("add value in double quotes", function()
         local json = [[{"p2":"v1"}]]
         local body = body_transformer.transform_json_body(conf, json)
         local body_json = cjson.decode(body)
-        assert.same({p1 = "v1", p2 = "v1", p3 = "value:3", p4 = '"v1"'}, body_json)
+        assert.same({p1 = "v1", p2 = "v1", p3 = "value:3", p4 = '"v1"', p5 = -1}, body_json)
+      end)
+      it("add number", function()
+        local json = [[{"p2":-1}]]
+        local body = body_transformer.transform_json_body(conf, json)
+        local body_json = cjson.decode(body)
+        assert.same({p1 = "v1", p2 = -1, p3 = "value:3", p4 = '"v1"', p5 = -1}, body_json)
       end)
       it("preserves empty arrays", function()
         local json = [[{"p2":"v1", "a":[]}]]
@@ -52,26 +58,32 @@ describe("Plugin: response-transformer", function()
           json   = {}
         },
         append   = {
-          json   = {"p1:v1", "p3:\"v1\""}
+          json   = {"p1:v1", "p3:\"v1\"", "p4:-1"}
         },
       }
       it("new key:value if key does not exists", function()
         local json = [[{"p2":"v1"}]]
         local body = body_transformer.transform_json_body(conf, json)
         local body_json = cjson.decode(body)
-        assert.same({ p2 = "v1", p1 = {"v1"}, p3 = {'"v1"'}}, body_json)
+        assert.same({ p2 = "v1", p1 = {"v1"}, p3 = {'"v1"'}, p4 = {-1}}, body_json)
       end)
       it("value if key exists", function()
         local json = [[{"p1":"v2"}]]
         local body = body_transformer.transform_json_body(conf, json)
         local body_json = cjson.decode(body)
-        assert.same({ p1 = {"v2","v1"}, p3 = {'"v1"'}}, body_json)
+        assert.same({ p1 = {"v2","v1"}, p3 = {'"v1"'}, p4 = {-1}}, body_json)
       end)
       it("value in double quotes", function()
         local json = [[{"p3":"v2"}]]
         local body = body_transformer.transform_json_body(conf, json)
         local body_json = cjson.decode(body)
-        assert.same({p1 = {"v1"}, p3 = {"v2",'"v1"'}}, body_json)
+        assert.same({p1 = {"v1"}, p3 = {"v2",'"v1"'}, p4 = {-1}}, body_json)
+      end)
+      it("number", function()
+        local json = [[{"p4":"v2"}]]
+        local body = body_transformer.transform_json_body(conf, json)
+        local body_json = cjson.decode(body)
+        assert.same({p1 = {"v1"}, p3 = {'"v1"'}, p4={"v2", -1}}, body_json)
       end)
       it("preserves empty arrays", function()
         local json = [[{"p2":"v1", "a":[]}]]
@@ -117,7 +129,7 @@ describe("Plugin: response-transformer", function()
           json   = {}
         },
         replace  = {
-          json   = {"p1:v2", "p2:\"v2\""}
+          json   = {"p1:v2", "p2:\"v2\"", "p3:-1"}
         },
         add      = {
           json   = {}
@@ -150,6 +162,12 @@ describe("Plugin: response-transformer", function()
         local body_json = cjson.decode(body)
         assert.same({p1 = "v2", p2 = '"v2"', a = {}}, body_json)
         assert.equals('[]', cjson.encode(body_json.a))
+      end)
+      it("number", function()
+        local json = [[{"p3" : "v1"}]]
+        local body = body_transformer.transform_json_body(conf, json)
+        local body_json = cjson.decode(body)
+        assert.same({p3 = -1}, body_json)
       end)
     end)
 

--- a/spec/03-plugins/15-response-transformer/02-body_transformer_spec.lua
+++ b/spec/03-plugins/15-response-transformer/02-body_transformer_spec.lua
@@ -13,8 +13,8 @@ describe("Plugin: response-transformer", function()
           json   = {}
         },
         add      = {
-          json   = {"p1:v1", "p3:value:3", "p4:\"v1\"", "p5:-1"},
-          json_types = {"string", "string", "string", "number"}
+          json   = {"p1:v1", "p3:value:3", "p4:\"v1\"", "p5:-1", "p6:false", "p7:true"},
+          json_types = {"string", "string", "string", "number", "boolean", "boolean"}
         },
         append   = {
           json   = {}
@@ -24,25 +24,31 @@ describe("Plugin: response-transformer", function()
         local json = [[{"p2":"v1"}]]
         local body = body_transformer.transform_json_body(conf, json)
         local body_json = cjson.decode(body)
-        assert.same({p1 = "v1", p2 = "v1", p3 = "value:3", p4 = '"v1"', p5 = -1}, body_json)
+        assert.same({p1 = "v1", p2 = "v1", p3 = "value:3", p4 = '"v1"', p5 = -1, p6 = false, p7 = true}, body_json)
       end)
       it("add value in double quotes", function()
         local json = [[{"p2":"v1"}]]
         local body = body_transformer.transform_json_body(conf, json)
         local body_json = cjson.decode(body)
-        assert.same({p1 = "v1", p2 = "v1", p3 = "value:3", p4 = '"v1"', p5 = -1}, body_json)
+        assert.same({p1 = "v1", p2 = "v1", p3 = "value:3", p4 = '"v1"', p5 = -1, p6 = false, p7 = true}, body_json)
       end)
-      it("add number", function()
+      it("number", function()
         local json = [[{"p2":-1}]]
         local body = body_transformer.transform_json_body(conf, json)
         local body_json = cjson.decode(body)
-        assert.same({p1 = "v1", p2 = -1, p3 = "value:3", p4 = '"v1"', p5 = -1}, body_json)
+        assert.same({p1 = "v1", p2 = -1, p3 = "value:3", p4 = '"v1"', p5 = -1, p6 = false, p7 = true}, body_json)
+      end)
+      it("boolean", function()
+        local json = [[{"p2":false}]]
+        local body = body_transformer.transform_json_body(conf, json)
+        local body_json = cjson.decode(body)
+        assert.same({p1 = "v1", p2 = false, p3 = "value:3", p4 = '"v1"', p5 = -1, p6 = false, p7 = true}, body_json)
       end)
       it("preserves empty arrays", function()
         local json = [[{"p2":"v1", "a":[]}]]
         local body = body_transformer.transform_json_body(conf, json)
         local body_json = cjson.decode(body)
-        assert.same({p1 = "v1", p2 = "v1", p3 = "value:3", p4 = '"v1"', p5 = -1, a = {}}, body_json)
+        assert.same({p1 = "v1", p2 = "v1", p3 = "value:3", p4 = '"v1"', p5 = -1, p6 = false, p7 = true, a = {}}, body_json)
         assert.equals('[]', cjson.encode(body_json.a))
       end)
     end)
@@ -59,39 +65,45 @@ describe("Plugin: response-transformer", function()
           json   = {}
         },
         append   = {
-          json   = {"p1:v1", "p3:\"v1\"", "p4:-1"},
-          json_types = {"string", "string", "number"}
+          json   = {"p1:v1", "p3:\"v1\"", "p4:-1", "p5:false", "p6:true"},
+          json_types = {"string", "string", "number", "boolean", "boolean"}
         },
       }
       it("new key:value if key does not exists", function()
         local json = [[{"p2":"v1"}]]
         local body = body_transformer.transform_json_body(conf, json)
         local body_json = cjson.decode(body)
-        assert.same({ p2 = "v1", p1 = {"v1"}, p3 = {'"v1"'}, p4 = {-1}}, body_json)
+        assert.same({ p2 = "v1", p1 = {"v1"}, p3 = {'"v1"'}, p4 = {-1}, p5 = {false}, p6 = {true}}, body_json)
       end)
       it("value if key exists", function()
         local json = [[{"p1":"v2"}]]
         local body = body_transformer.transform_json_body(conf, json)
         local body_json = cjson.decode(body)
-        assert.same({ p1 = {"v2","v1"}, p3 = {'"v1"'}, p4 = {-1}}, body_json)
+        assert.same({ p1 = {"v2","v1"}, p3 = {'"v1"'}, p4 = {-1}, p5 = {false}, p6 = {true}}, body_json)
       end)
       it("value in double quotes", function()
         local json = [[{"p3":"v2"}]]
         local body = body_transformer.transform_json_body(conf, json)
         local body_json = cjson.decode(body)
-        assert.same({p1 = {"v1"}, p3 = {"v2",'"v1"'}, p4 = {-1}}, body_json)
+        assert.same({p1 = {"v1"}, p3 = {"v2",'"v1"'}, p4 = {-1}, p5 = {false}, p6 = {true}}, body_json)
       end)
       it("number", function()
         local json = [[{"p4":"v2"}]]
         local body = body_transformer.transform_json_body(conf, json)
         local body_json = cjson.decode(body)
-        assert.same({p1 = {"v1"}, p3 = {'"v1"'}, p4={"v2", -1}}, body_json)
+        assert.same({p1 = {"v1"}, p3 = {'"v1"'}, p4={"v2", -1}, p5 = {false}, p6 = {true}}, body_json)
+      end)
+      it("boolean", function()
+        local json = [[{"p5":"v5", "p6":"v6"}]]
+        local body = body_transformer.transform_json_body(conf, json)
+        local body_json = cjson.decode(body)
+        assert.same({p1 = {"v1"}, p3 = {'"v1"'}, p4={-1}, p5 = {"v5", false}, p6 = {"v6", true}}, body_json)
       end)
       it("preserves empty arrays", function()
         local json = [[{"p2":"v1", "a":[]}]]
         local body = body_transformer.transform_json_body(conf, json)
         local body_json = cjson.decode(body)
-        assert.same({ p2 = "v1", p1 = {"v1"}, p3 = {'"v1"'}, p4 = {-1}, a = {} }, body_json)
+        assert.same({ p2 = "v1", a = {}, p1 = {"v1"}, p3 = {'"v1"'}, p4 = {-1}, p5 = {false}, p6 = {true} }, body_json)
         assert.equals('[]', cjson.encode(body_json.a))
       end)
     end)
@@ -131,8 +143,8 @@ describe("Plugin: response-transformer", function()
           json   = {}
         },
         replace  = {
-          json   = {"p1:v2", "p2:\"v2\"", "p3:-1"},
-          json_types = {"string", "string", "number"}
+          json   = {"p1:v2", "p2:\"v2\"", "p3:-1", "p4:false", "p5:true"},
+          json_types = {"string", "string", "number", "boolean", "boolean"}
         },
         add      = {
           json   = {}
@@ -171,6 +183,12 @@ describe("Plugin: response-transformer", function()
         local body = body_transformer.transform_json_body(conf, json)
         local body_json = cjson.decode(body)
         assert.same({p3 = -1}, body_json)
+      end)
+      it("boolean", function()
+        local json = [[{"p4" : "v4", "p5" : "v5"}]]
+        local body = body_transformer.transform_json_body(conf, json)
+        local body_json = cjson.decode(body)
+        assert.same({p4 = false, p5 = true}, body_json)
       end)
     end)
 

--- a/spec/03-plugins/15-response-transformer/02-body_transformer_spec.lua
+++ b/spec/03-plugins/15-response-transformer/02-body_transformer_spec.lua
@@ -7,13 +7,14 @@ describe("Plugin: response-transformer", function()
     describe("add", function()
       local conf = {
         remove   = {
-          json   = {}
+          json   = {},
         },
         replace  = {
           json   = {}
         },
         add      = {
-          json   = {"p1:v1", "p3:value:3", "p4:\"v1\"", "p5:-1"}
+          json   = {"p1:v1", "p3:value:3", "p4:\"v1\"", "p5:-1"},
+          json_types = {"string", "string", "string", "number"}
         },
         append   = {
           json   = {}
@@ -41,7 +42,7 @@ describe("Plugin: response-transformer", function()
         local json = [[{"p2":"v1", "a":[]}]]
         local body = body_transformer.transform_json_body(conf, json)
         local body_json = cjson.decode(body)
-        assert.same({p1 = "v1", p2 = "v1", p3 = "value:3", p4 = '"v1"', a = {}}, body_json)
+        assert.same({p1 = "v1", p2 = "v1", p3 = "value:3", p4 = '"v1"', p5 = -1, a = {}}, body_json)
         assert.equals('[]', cjson.encode(body_json.a))
       end)
     end)
@@ -58,7 +59,8 @@ describe("Plugin: response-transformer", function()
           json   = {}
         },
         append   = {
-          json   = {"p1:v1", "p3:\"v1\"", "p4:-1"}
+          json   = {"p1:v1", "p3:\"v1\"", "p4:-1"},
+          json_types = {"string", "string", "number"}
         },
       }
       it("new key:value if key does not exists", function()
@@ -89,7 +91,7 @@ describe("Plugin: response-transformer", function()
         local json = [[{"p2":"v1", "a":[]}]]
         local body = body_transformer.transform_json_body(conf, json)
         local body_json = cjson.decode(body)
-        assert.same({ p2 = "v1", p1 = {"v1"}, p3 = {'"v1"'}, a = {} }, body_json)
+        assert.same({ p2 = "v1", p1 = {"v1"}, p3 = {'"v1"'}, p4 = {-1}, a = {} }, body_json)
         assert.equals('[]', cjson.encode(body_json.a))
       end)
     end)
@@ -129,7 +131,8 @@ describe("Plugin: response-transformer", function()
           json   = {}
         },
         replace  = {
-          json   = {"p1:v2", "p2:\"v2\"", "p3:-1"}
+          json   = {"p1:v2", "p2:\"v2\"", "p3:-1"},
+          json_types = {"string", "string", "number"}
         },
         add      = {
           json   = {}


### PR DESCRIPTION
### Summary

Response transformer is turning every value into string, which is not something expected. This change updates response transformer to convert values into its expected type accordingly.

### Issues resolved

Fix #4880 
