### PR TITLE
feat(conf) add router_update_frequency configuration option

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -842,6 +842,15 @@
                                  # for a short period of time after Routes and
                                  # Services updates.
 
+#router_update_frequency = 1     # Defines how often the router changes are
+                                 # checked with a background job. When a change
+                                 # is detected, a new router will be built. By
+                                 # default we check for changes every second.
+                                 # Raising this value will decrease the load on
+                                 # database servers and result in less jitter
+                                 # in proxy latency, with downside of longer
+                                 # converge time for router updates.
+
 #------------------------------------------------------------------------------
 # DEVELOPMENT & MISCELLANEOUS
 #------------------------------------------------------------------------------

--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -199,6 +199,7 @@ local CONF_INFERENCES = {
   dns_error_ttl = { typ = "number" },
   dns_no_sync = { typ = "boolean" },
   router_consistency = { enum = { "strict", "eventual" } },
+  router_update_frequency = { typ = "number" },
 
   client_ssl = { typ = "boolean" },
 
@@ -526,6 +527,10 @@ local function check_and_infer(conf)
 
   if conf.pg_semaphore_timeout ~= math.floor(conf.pg_semaphore_timeout) then
     errors[#errors + 1] = "pg_semaphore_timeout must be an integer greater than 0"
+  end
+
+  if conf.router_update_frequency <= 0 then
+    errors[#errors + 1] = "router_update_frequency must be greater than 0"
   end
 
   return #errors == 0, errors[1], errors

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -877,7 +877,9 @@ return {
         balancer.init()
       end)
 
-      timer_every(1, function(premature)
+      local router_update_frequency = kong.configuration.router_update_frequency or 1
+
+      timer_every(router_update_frequency, function(premature)
         if premature then
           return
         end
@@ -892,7 +894,7 @@ return {
         end
       end)
 
-      timer_every(1, function(premature)
+      timer_every(router_update_frequency, function(premature)
         if premature then
           return
         end

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -85,6 +85,7 @@ dns_error_ttl = 1
 dns_no_sync = off
 
 router_consistency = strict
+router_update_frequency = 1
 
 lua_socket_pool_size = 30
 lua_ssl_trusted_certificate = NONE

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -870,6 +870,30 @@ describe("Configuration loader", function()
     end)
   end)
 
+  describe("router_update_frequency option", function()
+    it("is rejected with a zero", function()
+      local conf, err = conf_loader(nil, {
+        router_update_frequency = 0,
+      })
+      assert.is_nil(conf)
+      assert.equal("router_update_frequency must be greater than 0", err)
+    end)
+    it("is rejected with a negative number", function()
+      local conf, err = conf_loader(nil, {
+        router_update_frequency = -1,
+      })
+      assert.is_nil(conf)
+      assert.equal("router_update_frequency must be greater than 0", err)
+    end)
+    it("accepts decimal numbers", function()
+      local conf, err = conf_loader(nil, {
+        router_update_frequency = 0.01,
+      })
+      assert.equal(conf.router_update_frequency, 0.01)
+      assert.is_nil(err)
+    end)
+  end)
+
   describe("origins config option", function()
     it("rejects an invalid origins config option", function()
       local conf, err = conf_loader(nil, {


### PR DESCRIPTION
### Summary

Prior this change the router and plugins where checked for changes every second (starting two timers per second on each worker). The issue #4872 reported some issues that frequent updates may cause on proxying performance and suggested we allow configuring the value. This PR adds `router_update_frequency` configuration option, which still default to that same once per second. This is mostly usable with `router_consistency=eventual`. But it will affect `strict` too (but raising this value with `strict` will make it more likely that the routers are rebuild on request time (making a timers bit useless, though it may be ok with slow traffic scenarios).

### Issues resolved

Fix #4872
