### PR TITLE
WIP: fix(cors) allow pre-flight requests to options / trace / connect endpoints

### DIFF
--- a/kong-1.2.2-0.rockspec
+++ b/kong-1.2.2-0.rockspec
@@ -275,6 +275,7 @@ build = {
     ["kong.plugins.response-transformer.header_transformer"] = "kong/plugins/response-transformer/header_transformer.lua",
     ["kong.plugins.response-transformer.schema"] = "kong/plugins/response-transformer/schema.lua",
 
+    ["kong.plugins.cors.api"] = "kong/plugins/cors/api.lua",
     ["kong.plugins.cors.handler"] = "kong/plugins/cors/handler.lua",
     ["kong.plugins.cors.schema"] = "kong/plugins/cors/schema.lua",
 

--- a/kong/plugins/cors/api.lua
+++ b/kong/plugins/cors/api.lua
@@ -1,0 +1,3 @@
+return {
+  DEFAULT_METHODS = { "HEAD", "GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "TRACE", "CONNECT" }
+}

--- a/kong/plugins/cors/handler.lua
+++ b/kong/plugins/cors/handler.lua
@@ -181,7 +181,9 @@ end
 
 
 function CorsHandler:access(conf)
-  if kong.request.get_method() ~= "OPTIONS" then
+  if not (kong.request.get_method() == "OPTIONS"
+            and kong.request.get_header("origin")
+            and kong.request.get_header("Access-Control-Request-Method")) then
     return
   end
 
@@ -212,7 +214,6 @@ function CorsHandler:access(conf)
   end
 
   local methods = conf.methods and concat(conf.methods, ",")
-                  or "GET,HEAD,PUT,PATCH,POST,DELETE"
   set_header("Access-Control-Allow-Methods", methods)
 
   if conf.max_age then

--- a/kong/plugins/cors/schema.lua
+++ b/kong/plugins/cors/schema.lua
@@ -1,6 +1,6 @@
 local typedefs = require "kong.db.schema.typedefs"
 local is_regex = require("kong.db.schema").validators.is_regex
-
+local cors_api = require "kong.plugins.cors.api"
 
 local function validate_asterisk_or_regex(value)
   if value == "*" or is_regex(value) then
@@ -29,9 +29,10 @@ return {
           { exposed_headers = { type = "array", elements = { type = "string" }, }, },
           { methods = {
               type = "array",
+              default = cors_api.DEFAULT_METHODS,
               elements = {
                 type = "string",
-                one_of = { "HEAD", "GET", "POST", "PUT", "PATCH", "DELETE" },
+                one_of = cors_api.DEFAULT_METHODS,
           }, }, },
           { max_age = { type = "number" }, },
           { credentials = { type = "boolean", default = false }, },

--- a/spec/03-plugins/13-cors/02-schema_spec.lua
+++ b/spec/03-plugins/13-cors/02-schema_spec.lua
@@ -1,7 +1,7 @@
 local schema_def = require "kong.plugins.cors.schema"
 local v = require("spec.helpers").validate_plugin_config_schema
 
-describe("cors schema", function()
+describe("origins in cors schema", function()
   it("validates '*'", function()
     local ok, err = v({ origins = { "*" } }, schema_def)
 
@@ -30,7 +30,27 @@ describe("cors schema", function()
 
       assert.falsy(ok)
       assert.equals("'invalid_**regex' is not a valid regex",
-                    err.config.origins[2])
+        err.config.origins[2])
     end)
   end)
+end)
+
+describe("methods in cors schema", function()
+  for _,method in ipairs({"HEAD", "GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "TRACE", "CONNECT"}) do
+    it("should allow " .. method, function()
+      local ok, err = v({ methods = { method } }, schema_def)
+
+      assert.truthy(ok)
+      assert.falsy(err)
+    end)
+  end
+
+  it("should disallow non-existing ", function()
+    local ok, err = v({ methods = { "FAKE" } }, schema_def)
+
+    assert.falsy(ok)
+    assert.equals("expected one of: HEAD, GET, POST, PUT, PATCH, DELETE, OPTIONS, TRACE, CONNECT",
+      err.config.methods[1])
+  end)
+
 end)


### PR DESCRIPTION
### Summary

Fix cors plugin configuration and behavior for processing pre-flight requests to OPTIONS / TRACE / CONNECT endpoints

### Full changelog

* allow pre-flight requests to options / trace / connect endpoints

### Issues resolved

Fix #4898 
