### PR TITLE
chore(deps) bump resty-http from 0.13 to 0.15

### DIFF
--- a/kong-1.2.1-0.rockspec
+++ b/kong-1.2.1-0.rockspec
@@ -15,7 +15,7 @@ dependencies = {
   "luasec == 0.8",
   "luasocket == 3.0-rc1",
   "penlight == 1.5.4",
-  "lua-resty-http == 0.13",
+  "lua-resty-http == 0.15",
   "lua-resty-jit-uuid == 0.0.7",
   "multipart == 0.5.5",
   "version == 1.0.1",


### PR DESCRIPTION
### Summary

Changes:

* Add Content-Length: 0 header on POST/PUT/PATCH when the body is absent
* Add flag to enable debug logging

### Issues resolved

The `Content-Length` issue has been reported outside of the public channels.