### PR TITLE
fix(pdk) treat custom content blocks as the Admin API

### DIFF
--- a/kong/pdk/private/phases.lua
+++ b/kong/pdk/private/phases.lua
@@ -3,6 +3,7 @@ local bit = require "bit"
 
 local band = bit.band
 local fmt = string.format
+local ngx_get_phase = ngx.get_phase
 
 
 local PHASES = {
@@ -63,7 +64,12 @@ local function check_phase(accepted_phases)
 
   local current_phase = kong.ctx.core.phase
   if not current_phase then
-    error("no phase in kong.ctx.core.phase")
+    if ngx_get_phase() == "content" then
+      -- treat custom content blocks as the Admin API
+      current_phase = PHASES.admin_api
+    else
+      error("no phase in kong.ctx.core.phase")
+    end
   end
 
   if band(current_phase, accepted_phases) ~= 0 then


### PR DESCRIPTION
This is a small workaround to a problem that happens when any custom
content_by_lua block attempts to use the PDK. For example, this happens when
trying to hit the `/` endpoint of the metrics server of the Prometheus plugin:

https://github.com/Kong/kong-plugin-prometheus/blob/0.4.1/kong/plugins/prometheus/serve.lua#L32

In normal operation of Kong, `kong.ctx.core.phase` is always set,
so the code path added should never be hit.

This is a regression test for kong-plugin-prometheus that demonstrates the fix:

```
diff --git a/spec/03-custom-serve_spec.lua b/spec/03-custom-serve_spec.lua
index 032e34d..c70afb0 100644
--- a/spec/03-custom-serve_spec.lua
+++ b/spec/03-custom-serve_spec.lua
@@ -67,5 +67,14 @@ describe("Plugin: prometheus (custom server)",function()
       local body = assert.res_status(404, res)
       assert.matches('{"message":"Not found"}', body, nil, true)
     end)
+    it("custom port returns 200 and sends you to /metrics at the root", function()
+      local client = helpers.http_client("127.0.0.1", 9542)
+      local res = assert(client:send {
+        method  = "GET",
+        path    = "/",
+      })
+      local body = assert.res_status(200, res)
+      assert.matches('visit /metrics', body, nil, true)
+    end)
   end)
 end)
```