### PR TITLE
fix(balancer) target entities default to port 80

### DIFF
--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -134,7 +134,12 @@ do
       -- split `target` field into `name` and `port`
       local port
       target.name, port = string.match(target.target, "^(.-):(%d+)$")
-      target.port = tonumber(port)
+      if target.name and port then
+        target.port = tonumber(port)
+      else
+        target.name = target.target
+        target.port = 80
+      end
     end
 
     return target_history

--- a/spec/02-integration/04-admin_api/15-off_spec.lua
+++ b/spec/02-integration/04-admin_api/15-off_spec.lua
@@ -440,6 +440,49 @@ describe("Admin API #off", function()
       assert.response(res).has.status(201)
     end)
 
+    it("can reload upstreams (regression test)", function()
+      local config = [[
+        _format_version: "1.1"
+        services:
+        - host: foo
+          routes:
+          - paths:
+            - "/"
+        upstreams:
+        - name: "foo"
+          targets:
+          - target: 10.20.30.40
+      ]]
+      local res = assert(client:send {
+        method = "POST",
+        path = "/config",
+        body = {
+          config = config,
+        },
+        headers = {
+          ["Content-Type"] = "application/json"
+        }
+      })
+
+      assert.response(res).has.status(201)
+
+      client:close()
+      client = helpers.admin_client()
+
+      local res = assert(client:send {
+        method = "POST",
+        path = "/config",
+        body = {
+          config = config,
+        },
+        headers = {
+          ["Content-Type"] = "application/json"
+        }
+      })
+
+      assert.response(res).has.status(201)
+    end)
+
     it("returns 304 if checking hash and configuration is identical", function()
       local res = assert(client:send {
         method = "POST",


### PR DESCRIPTION
When target entities don't have a port `create_balancer` was not being able to parse them and was trying to use empty values for hostname and port to add a new host to dns client.