### PR TITLE
tests(proxy) fix flappy tests caused by instability in DNS resolving

### DIFF
--- a/spec/02-integration/05-proxy/04-plugins_triggering_spec.lua
+++ b/spec/02-integration/05-proxy/04-plugins_triggering_spec.lua
@@ -588,21 +588,21 @@ for _, strategy in helpers.each_strategy() do
 
         do
           -- service to mock HTTP 504
-          local httpbin_service = bp.services:insert {
+          local blackhole_service = bp.services:insert {
             name            = "timeout",
-            host            = "httpbin.org",
+            host            = helpers.blackhole_host,
             connect_timeout = 1, -- ms
           }
 
           bp.routes:insert {
             hosts     = { "connect_timeout" },
             protocols = { "http" },
-            service   = httpbin_service,
+            service   = blackhole_service,
           }
 
           bp.plugins:insert {
             name     = "file-log",
-            service  = { id = httpbin_service.id },
+            service  = { id = blackhole_service.id },
             config   = {
               path   = FILE_LOG_PATH,
               reopen = true,

--- a/spec/02-integration/05-proxy/12-error_default_type_spec.lua
+++ b/spec/02-integration/05-proxy/12-error_default_type_spec.lua
@@ -19,7 +19,7 @@ for _, strategy in helpers.each_strategy() do
         local service = bp.services:insert {
           name            = "api-1",
           protocol        = "http",
-          host            = "10.255.255.255",
+          host            = helpers.blackhole_host,
           port            = 81,
           connect_timeout = 1,
         }
@@ -89,7 +89,7 @@ for _, strategy in helpers.each_strategy() do
         local service = bp.services:insert {
           name            = "api-1",
           protocol        = "http",
-          host            = "10.255.255.255",
+          host            = helpers.blackhole_host,
           port            = 81,
           connect_timeout = 1,
         }

--- a/spec/02-integration/05-proxy/12-error_default_type_spec.lua
+++ b/spec/02-integration/05-proxy/12-error_default_type_spec.lua
@@ -19,7 +19,7 @@ for _, strategy in helpers.each_strategy() do
         local service = bp.services:insert {
           name            = "api-1",
           protocol        = "http",
-          host            = "konghq.com",
+          host            = "10.255.255.255",
           port            = 81,
           connect_timeout = 1,
         }
@@ -89,7 +89,7 @@ for _, strategy in helpers.each_strategy() do
         local service = bp.services:insert {
           name            = "api-1",
           protocol        = "http",
-          host            = "konghq.com",
+          host            = "10.255.255.255",
           port            = 81,
           connect_timeout = 1,
         }

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -16,6 +16,7 @@ local MOCK_UPSTREAM_PORT = 15555
 local MOCK_UPSTREAM_SSL_PORT = 15556
 local MOCK_UPSTREAM_STREAM_PORT = 15557
 local MOCK_UPSTREAM_STREAM_SSL_PORT = 15558
+local BLACKHOLE_HOST = "10.255.255.255"
 
 require("resty.core")
 
@@ -1681,6 +1682,8 @@ return {
 
   mock_upstream_stream_port     = MOCK_UPSTREAM_STREAM_PORT,
   mock_upstream_stream_ssl_port = MOCK_UPSTREAM_STREAM_SSL_PORT,
+
+  blackhole_host = BLACKHOLE_HOST,
 
   -- Kong testing helpers
   execute = exec,


### PR DESCRIPTION
This should eliminate the `Status expected: (number) 504 Status received: (number) 503 Body: (string) '{"message":"name resolution failed"}` failure we have been seeing recently.

Note on the selection of IP address. It is just one of the RFC 1918 address that is likely not being used. This may or may not work depends on the network environment but as far as Travis, Docker, VMWare or VirtualBox are concerned, it works well (and much better than the domain we had in there).