### PR TITLE
feat(*) do not expose openresty version

### DIFF
--- a/kong/plugins/key-auth/handler.lua
+++ b/kong/plugins/key-auth/handler.lua
@@ -151,7 +151,9 @@ local function do_authentication(conf)
                                     key)
   if err then
     kong.log.err(err)
-    return kong.response.exit(500, "An unexpected error occurred")
+    return kong.response.exit(500, {
+      message = "An unexpected error occurred"
+    })
   end
 
   -- no credential in DB, for this key, it is invalid, HTTP 401

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -1,5 +1,6 @@
 return [[
 charset UTF-8;
+server_tokens off;
 
 > if anonymous_reports then
 ${{SYSLOG_REPORTS}}

--- a/spec/02-integration/05-proxy/13-error_handlers_spec.lua
+++ b/spec/02-integration/05-proxy/13-error_handlers_spec.lua
@@ -37,4 +37,16 @@ describe("Proxy error handlers", function()
     assert.matches("kong/", res.headers.server, nil, true)
     assert.equal("Request Header Or Cookie Too Large\n", body)
   end)
+
+  it("does not expose OpenResty version", function()
+    local res = assert(proxy_client:send {
+      method = "TRACE",
+      path = "/",
+    })
+
+    assert.res_status(405, res)
+    local body = res:read_body()
+    assert.matches("kong/", res.headers.server, nil, true)
+    assert.not_matches("openresty/", body, nil, true)
+  end)
 end)

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -14,6 +14,7 @@ events {}
 http {
 > if #proxy_listeners > 0 or #admin_listeners > 0 then
     charset UTF-8;
+    server_tokens off;
 
     error_log logs/error.log ${{LOG_LEVEL}};
 


### PR DESCRIPTION
### Summary

Previously, e.g. when doing `TRACE` request:
```
http TRACE :8000
```

Nginx terminated the request with the following headers and body:

```html
HTTP/1.1 405 Not Allowed
Connection: close
Content-Length: 163
Content-Type: text/html; charset=UTF-8
Date: Fri, 16 Aug 2019 09:19:10 GMT
Server: kong/1.2.1

<html>
<head><title>405 Not Allowed</title></head>
<body>
<center><h1>405 Not Allowed</h1></center>
<hr><center>openresty/1.15.8.1</center>
</body>
</html>
```

With this change, the output doesn't expose OpenResty version anymore, although it is to be noted, that it still exposes `openresty`, which can be considered a bug in Nginx/OpenResty default response body templates as they don't seem to respect `server_tokens=off` that this commit adds
to our server templates.

This also affects other default response bodies, such as those sent
with:

```lua
ngx.redirect("<url>");
```

Further development on this, we should perhaps add a white-labeling patch to OpenResty patches to patch the default templates to get rid of OpenResty labeling (which of course does not mean we are not proud of the OpenResty, but just to be more consistent with our product).

### Issues resolved

#3908