### PR TITLE
chore(deps) bump lyaml from 6.2.3 to 6.2.4

### DIFF
--- a/kong-1.3.0-0.rockspec
+++ b/kong-1.3.0-0.rockspec
@@ -25,7 +25,7 @@ dependencies = {
   "luatz == 0.4",
   "http == 0.3",
   "lua_system_constants == 0.1.3",
-  "lyaml == 6.2.3",
+  "lyaml == 6.2.4",
   "lua-resty-iputils == 0.3.0",
   "luaossl == 20190731",
   "luasyslog == 1.0.0",


### PR DESCRIPTION
### Summary

Changelog:

- luke works with upgraded bootstrap luarocks version of require

(whatever that means)