### PR TITLE
chore(deps) bump luaossl from 20190612 to 20190731

### DIFF
--- a/kong-1.2.1-0.rockspec
+++ b/kong-1.2.1-0.rockspec
@@ -27,7 +27,7 @@ dependencies = {
   "lua_system_constants == 0.1.3",
   "lyaml == 6.2.3",
   "lua-resty-iputils == 0.3.0",
-  "luaossl == 20190612",
+  "luaossl == 20190731",
   "luasyslog == 1.0.0",
   "lua_pack == 1.0.5",
   "lua-resty-dns-client == 4.1.0",


### PR DESCRIPTION
### Summary

Changes:

- introduce workarounds for LuaJIT 47bit userdata