### PR TITLE
chore(ci) bump the kong-build-tools version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ RESTY_VERSION ?= `grep RESTY_VERSION .requirements | awk -F"=" '{print $$2}'`
 RESTY_LUAROCKS_VERSION ?= `grep RESTY_LUAROCKS_VERSION .requirements | awk -F"=" '{print $$2}'`
 RESTY_OPENSSL_VERSION ?= `grep RESTY_OPENSSL_VERSION .requirements | awk -F"=" '{print $$2}'`
 RESTY_PCRE_VERSION ?= `grep RESTY_PCRE_VERSION .requirements | awk -F"=" '{print $$2}'`
-KONG_BUILD_TOOLS ?= '2.0.0'
+KONG_BUILD_TOOLS ?= '2.0.1'
 KONG_VERSION ?= `cat kong-*.rockspec | grep tag | awk '{print $$3}' | sed 's/"//g'`
 
 setup-kong-build-tools:


### PR DESCRIPTION
most important change is fixes around building and release from source. Entire diff is here https://github.com/Kong/kong-build-tools/compare/2.0.0...2.0.1