### PR TITLE
feat(pdk) add get_authenticated_groups

### DIFF
--- a/kong/pdk/client.lua
+++ b/kong/pdk/client.lua
@@ -244,12 +244,12 @@ local function new(self)
 
   ---
   -- Returns a table of `authenticated_groups` of the currently authenticated
-  -- consumer.
+  -- consumer, or nil if groups is not set.
   -- @function kong.client.get_authenticated_groups
   -- @phases access, header_filter, body_filter, log
-  -- @treturn table,nil|err
-  -- The table will have an array part to iterate over, and a hash part where each
-  -- group name is indexed by itself. Eg.
+  -- @treturn table|nil
+  -- The table will have an array part to iterate over, and a hash part where
+  -- each group name is indexed by itself. Eg.
   -- {
   --   [1] = "users",
   --   [2] = "admins",
@@ -257,8 +257,8 @@ local function new(self)
   --   admins = "admins",
   -- }
   -- @usage
-  -- local groups, err = kong.client.get_authenticated_groups()
-  -- if not err then
+  -- local groups = kong.client.get_authenticated_groups()
+  -- if not groups then
   --   for i = 1, #groups_to_check do
   --     if groups[i] == 'group1' then
   --       return true
@@ -270,7 +270,7 @@ local function new(self)
 
     local authenticated_groups = ngx.ctx.authenticated_groups
     if authenticated_groups == nil then
-      return {}
+      return nil
     end
 
     assert(type(authenticated_groups) == "table",

--- a/kong/pdk/client.lua
+++ b/kong/pdk/client.lua
@@ -270,12 +270,11 @@ local function new(self)
 
     local authenticated_groups = ngx.ctx.authenticated_groups
     if authenticated_groups == nil then
-      return nil
+      return {}
     end
 
-    if type(authenticated_groups) ~= "table" then
-      return nil, "invalid authenticated_groups, a table was expected"
-    end
+    assert(type(authenticated_groups) == "table",
+           "invalid authenticated_groups, a table was expected")
 
     local groups = {}
     for i = 1, #authenticated_groups do

--- a/kong/plugins/acl/groups.lua
+++ b/kong/plugins/acl/groups.lua
@@ -5,7 +5,6 @@ local EMPTY = tablex.readonly {}
 
 
 local kong = kong
-local type = type
 local mt_cache = { __mode = "k" }
 local setmetatable = setmetatable
 local consumer_groups_cache = setmetatable({}, mt_cache)

--- a/kong/plugins/acl/groups.lua
+++ b/kong/plugins/acl/groups.lua
@@ -124,45 +124,10 @@ local function get_current_consumer_id()
 end
 
 
---- Returns a table with all group names.
--- The table will have an array part to iterate over, and a hash part
--- where each group name is indexed by itself. Eg.
--- {
---   [1] = "users",
---   [2] = "admins",
---   users = "users",
---   admins = "admins",
--- }
--- If there are no authenticated_groups defined, it will return nil
--- @return table with groups or nil
-local function get_authenticated_groups()
-  local authenticated_groups = kong.ctx.shared.authenticated_groups
-  if type(authenticated_groups) ~= "table" then
-    authenticated_groups = ngx.ctx.authenticated_groups
-    if authenticated_groups == nil then
-      return nil
-    end
-
-    if type(authenticated_groups) ~= "table" then
-      kong.log.warn("invalid authenticated_groups, a table was expected")
-      return nil
-    end
-  end
-
-  local groups = {}
-  for i = 1, #authenticated_groups do
-    groups[i] = authenticated_groups[i]
-    groups[authenticated_groups[i]] = authenticated_groups[i]
-  end
-
-  return groups
-end
-
-
 --- checks whether a group-list is part of a given list of groups.
 -- @param groups_to_check (table) an array of group names.
 -- @param groups (table) list of groups (result from
--- `get_authenticated_groups`)
+-- `kong.client.get_authenticated_groups`)
 -- @return (boolean) whether the authenticated group is part of any of the
 -- groups.
 local function group_in_groups(groups_to_check, groups)
@@ -177,7 +142,6 @@ end
 return {
   get_current_consumer_id = get_current_consumer_id,
   get_consumer_groups = get_consumer_groups,
-  get_authenticated_groups = get_authenticated_groups,
   consumer_in_groups = consumer_in_groups,
   group_in_groups = group_in_groups,
 }

--- a/kong/plugins/acl/handler.lua
+++ b/kong/plugins/acl/handler.lua
@@ -64,10 +64,7 @@ function ACLHandler:access(conf)
   local consumer_id = groups.get_current_consumer_id()
   local authenticated_groups, err
   if not consumer_id then
-    authenticated_groups, err = kong.client.get_authenticated_groups()
-    if err then
-      kong.log.warn(err)
-    end
+    authenticated_groups = kong.client.get_authenticated_groups()
 
     if not authenticated_groups then
       kong.log.err("Cannot identify the consumer, add an authentication ",
@@ -85,10 +82,7 @@ function ACLHandler:access(conf)
     local authenticated_groups
     if not kong.client.get_credential() then
       -- authenticated groups overrides anonymous groups
-      authenticated_groups, err = kong.client.get_authenticated_groups()
-      if err then
-        kong.log.warn(err)
-      end
+      authenticated_groups = kong.client.get_authenticated_groups()
     end
 
     if authenticated_groups then

--- a/kong/plugins/acl/handler.lua
+++ b/kong/plugins/acl/handler.lua
@@ -62,7 +62,7 @@ function ACLHandler:access(conf)
 
   -- get the consumer/credentials
   local consumer_id = groups.get_current_consumer_id()
-  local authenticated_groups, err
+  local authenticated_groups
   if not consumer_id then
     authenticated_groups = kong.client.get_authenticated_groups()
 

--- a/kong/plugins/acl/handler.lua
+++ b/kong/plugins/acl/handler.lua
@@ -62,8 +62,13 @@ function ACLHandler:access(conf)
 
   -- get the consumer/credentials
   local consumer_id = groups.get_current_consumer_id()
+  local authenticated_groups, err
   if not consumer_id then
-    local authenticated_groups = groups.get_authenticated_groups()
+    authenticated_groups, err = kong.client.get_authenticated_groups()
+    if err then
+      kong.log.warn(err)
+    end
+
     if not authenticated_groups then
       kong.log.err("Cannot identify the consumer, add an authentication ",
                    "plugin to use the ACL plugin")
@@ -80,7 +85,10 @@ function ACLHandler:access(conf)
     local authenticated_groups
     if not kong.client.get_credential() then
       -- authenticated groups overrides anonymous groups
-      authenticated_groups = groups.get_authenticated_groups()
+      authenticated_groups, err = kong.client.get_authenticated_groups()
+      if err then
+        kong.log.warn(err)
+      end
     end
 
     if authenticated_groups then

--- a/spec/03-plugins/18-acl/02-access_spec.lua
+++ b/spec/03-plugins/18-acl/02-access_spec.lua
@@ -135,7 +135,7 @@ for _, strategy in helpers.each_strategy() do
         name = "ctx-checker",
         route = { id = route2b.id },
         config = {
-          ctx_kind      = "kong.ctx.shared",
+          ctx_kind      = "ngx.ctx",
           ctx_set_field = "authenticated_groups",
           ctx_set_array = { "admin" },
         }
@@ -157,7 +157,7 @@ for _, strategy in helpers.each_strategy() do
         name = "ctx-checker",
         route = { id = route2c.id },
         config = {
-          ctx_kind      = "kong.ctx.shared",
+          ctx_kind      = "ngx.ctx",
           ctx_set_field = "authenticated_groups",
           ctx_set_array = { },
         }
@@ -197,7 +197,7 @@ for _, strategy in helpers.each_strategy() do
         name = "ctx-checker",
         route = { id = route3b.id },
         config = {
-          ctx_kind      = "kong.ctx.shared",
+          ctx_kind      = "ngx.ctx",
           ctx_set_field = "authenticated_groups",
           ctx_set_array = { },
         }
@@ -219,7 +219,7 @@ for _, strategy in helpers.each_strategy() do
         name = "ctx-checker",
         route = { id = route3c.id },
         config = {
-          ctx_kind      = "kong.ctx.shared",
+          ctx_kind      = "ngx.ctx",
           ctx_set_field = "authenticated_groups",
           ctx_set_array = { "admin" },
         }
@@ -259,7 +259,7 @@ for _, strategy in helpers.each_strategy() do
         name = "ctx-checker",
         route = { id = route4b.id },
         config = {
-          ctx_kind      = "kong.ctx.shared",
+          ctx_kind      = "ngx.ctx",
           ctx_set_field = "authenticated_groups",
           ctx_set_array = { "pro", "hello" },
         }
@@ -281,7 +281,7 @@ for _, strategy in helpers.each_strategy() do
         name = "ctx-checker",
         route = { id = route4c.id },
         config = {
-          ctx_kind      = "kong.ctx.shared",
+          ctx_kind      = "ngx.ctx",
           ctx_set_field = "authenticated_groups",
           ctx_set_array = { "free", "hello" },
         }
@@ -321,7 +321,7 @@ for _, strategy in helpers.each_strategy() do
         name = "ctx-checker",
         route = { id = route5b.id },
         config = {
-          ctx_kind      = "kong.ctx.shared",
+          ctx_kind      = "ngx.ctx",
           ctx_set_field = "authenticated_groups",
           ctx_set_array = { "pro", "hello" },
         }
@@ -343,7 +343,7 @@ for _, strategy in helpers.each_strategy() do
         name = "ctx-checker",
         route = { id = route5c.id },
         config = {
-          ctx_kind      = "kong.ctx.shared",
+          ctx_kind      = "ngx.ctx",
           ctx_set_field = "authenticated_groups",
           ctx_set_array = { "free", "hello" },
         }
@@ -383,7 +383,7 @@ for _, strategy in helpers.each_strategy() do
         name = "ctx-checker",
         route = { id = route6b.id },
         config = {
-          ctx_kind      = "kong.ctx.shared",
+          ctx_kind      = "ngx.ctx",
           ctx_set_field = "authenticated_groups",
           ctx_set_array = { "free", "hello" },
         }
@@ -405,7 +405,7 @@ for _, strategy in helpers.each_strategy() do
         name = "ctx-checker",
         route = { id = route6c.id },
         config = {
-          ctx_kind      = "kong.ctx.shared",
+          ctx_kind      = "ngx.ctx",
           ctx_set_field = "authenticated_groups",
           ctx_set_array = { "pro", "hello" },
         }
@@ -445,7 +445,7 @@ for _, strategy in helpers.each_strategy() do
         name = "ctx-checker",
         route = { id = route7b.id },
         config = {
-          ctx_kind      = "kong.ctx.shared",
+          ctx_kind      = "ngx.ctx",
           ctx_set_field = "authenticated_groups",
           ctx_set_array = { "free", "hello" },
         }
@@ -495,7 +495,7 @@ for _, strategy in helpers.each_strategy() do
         name = "ctx-checker",
         route = { id = route8b.id },
         config = {
-          ctx_kind      = "kong.ctx.shared",
+          ctx_kind      = "ngx.ctx",
           ctx_set_field = "authenticated_groups",
           ctx_set_array = { "anonymous" },
         }
@@ -537,7 +537,7 @@ for _, strategy in helpers.each_strategy() do
         name = "ctx-checker",
         route = { id = route9b.id },
         config = {
-          ctx_kind      = "kong.ctx.shared",
+          ctx_kind      = "ngx.ctx",
           ctx_set_field = "authenticated_groups",
           ctx_set_array = { "admin" },
         }
@@ -579,7 +579,7 @@ for _, strategy in helpers.each_strategy() do
         name = "ctx-checker",
         route = { id = route10b.id },
         config = {
-          ctx_kind      = "kong.ctx.shared",
+          ctx_kind      = "ngx.ctx",
           ctx_set_field = "authenticated_groups",
           ctx_set_array = { "admin" },
         }
@@ -610,7 +610,7 @@ for _, strategy in helpers.each_strategy() do
         name = "ctx-checker",
         route = { id = route11.id },
         config = {
-          ctx_kind      = "kong.ctx.shared",
+          ctx_kind      = "ngx.ctx",
           ctx_set_field = "authenticated_groups",
           ctx_set_array = { "admin" },
         }
@@ -641,7 +641,7 @@ for _, strategy in helpers.each_strategy() do
         name = "ctx-checker",
         route = { id = route12.id },
         config = {
-          ctx_kind      = "kong.ctx.shared",
+          ctx_kind      = "ngx.ctx",
           ctx_set_field = "authenticated_groups",
           ctx_set_array = { "anonymous" },
         }
@@ -672,7 +672,7 @@ for _, strategy in helpers.each_strategy() do
         name = "ctx-checker",
         route = { id = route13.id },
         config = {
-          ctx_kind      = "kong.ctx.shared",
+          ctx_kind      = "ngx.ctx",
           ctx_set_field = "authenticated_groups",
           ctx_set_array = { "admin" },
         }
@@ -1192,7 +1192,7 @@ for _, strategy in helpers.each_strategy() do
               name  = "ctx-checker",
               route = { id = json.id },
               config = {
-                ctx_kind      = "kong.ctx.shared",
+                ctx_kind      = "ngx.ctx",
                 ctx_set_field = "authenticated_groups",
                 ctx_set_array = { "admin" .. i },
               }

--- a/t/01-pdk/05-client/00-phase_checks.t
+++ b/t/01-pdk/05-client/00-phase_checks.t
@@ -118,6 +118,17 @@ qq{
                 body_filter   = true,
                 log           = true,
                 admin_api     = "forced false",
+            }, {
+                method        = "get_authenticated_groups",
+                args          = {},
+                init_worker   = "forced false",
+                certificate   = "pending",
+                rewrite       = "forced false",
+                access        = true,
+                header_filter = true,
+                body_filter   = true,
+                log           = true,
+                admin_api     = "forced false",
             },
         }
 

--- a/t/01-pdk/05-client/09-get_authenticated_groups.t
+++ b/t/01-pdk/05-client/09-get_authenticated_groups.t
@@ -52,6 +52,6 @@ GET /t
 --- request
 GET /t
 --- response_body chop
-{"groups":{}}
+{}
 --- no_error_log
 [error]

--- a/t/01-pdk/05-client/09-get_authenticated_groups.t
+++ b/t/01-pdk/05-client/09-get_authenticated_groups.t
@@ -1,0 +1,37 @@
+use strict;
+use warnings FATAL => 'all';
+use Test::Nginx::Socket::Lua;
+use t::Util;
+
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
+
+plan tests => repeat_each() * (blocks() * 3);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: client.get_authenticated_groups() returns groups
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            ngx.ctx.authenticated_groups = {
+              [1] = "users",
+              [2] = "admins",
+              users = "users",
+              admins = "admins",
+            }
+
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            pdk.response.exit(200, { groups = pdk.client.get_authenticated_groups() })
+        }
+    }
+--- request
+GET /t
+--- response_body chop
+{"groups":{"1":"users","2":"admins","admins":"admins","users":"users"}}
+--- no_error_log
+[error]

--- a/t/01-pdk/05-client/09-get_authenticated_groups.t
+++ b/t/01-pdk/05-client/09-get_authenticated_groups.t
@@ -35,3 +35,23 @@ GET /t
 {"groups":{"1":"users","2":"admins","admins":"admins","users":"users"}}
 --- no_error_log
 [error]
+
+
+
+=== TEST 2: client.get_authenticated_groups() returns empty if no groups
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            pdk.response.exit(200, { groups = pdk.client.get_authenticated_groups() })
+        }
+    }
+--- request
+GET /t
+--- response_body chop
+{"groups":{}}
+--- no_error_log
+[error]


### PR DESCRIPTION
### Summary
Add authenticated groups to pdk kong.client.

Pulling get_authenticated_groups functionality out of acl plugin to be
used in other plugins that need access to groups (e.g. canary, session)

### Issues resolved

Fixes INTF-1954
