### PR TITLE
fix(balancer) don't set health if target is not created yet

### DIFF
--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -194,7 +194,9 @@ local function populate_healthchecker(hc, balancer)
         -- Get existing health status which may have been initialized
         -- with data from another worker, and apply to the new balancer.
         local tgt_status = hc:get_target_status(ipaddr, port, hostname)
-        balancer:setAddressStatus(tgt_status, ipaddr, port, hostname)
+        if tgt_status ~= nil then
+          balancer:setAddressStatus(tgt_status, ipaddr, port, hostname)
+        end
 
       else
         log(ERR, "[healthchecks] failed adding target: ", err)


### PR DESCRIPTION
`populate_healthchecker` function was trying to set peers status with data that might be set by a worker that ran before but was not checking if said data was actually available, eventually causing lua-resty-dns-client to execute callbacks with invalid values.
