### PR TITLE
feat(schema) make `ca_certificates.cert` field unique

### DIFF
--- a/kong/db/migrations/core/005_120_to_130.lua
+++ b/kong/db/migrations/core/005_120_to_130.lua
@@ -14,7 +14,7 @@ return {
       CREATE TABLE IF NOT EXISTS "ca_certificates" (
         "id"          UUID                       PRIMARY KEY,
         "created_at"  TIMESTAMP WITH TIME ZONE   DEFAULT (CURRENT_TIMESTAMP(0) AT TIME ZONE 'UTC'),
-        "cert"        TEXT NOT NULL,
+        "cert"        TEXT NOT NULL              UNIQUE,
         "tags"        TEXT[]
       );
 
@@ -103,6 +103,8 @@ return {
         tags set<text>,
         PRIMARY KEY (partition, id)
       );
+
+      CREATE INDEX IF NOT EXISTS ca_certificates_cert_idx ON ca_certificates(cert);
 
 
 

--- a/kong/db/schema/entities/ca_certificates.lua
+++ b/kong/db/schema/entities/ca_certificates.lua
@@ -8,7 +8,7 @@ return {
   fields = {
     { id = typedefs.uuid, },
     { created_at = typedefs.auto_timestamp_s },
-    { cert = typedefs.certificate { required = true }, },
+    { cert = typedefs.certificate { required = true, unique = true, }, },
     { tags = typedefs.tags },
   },
 

--- a/spec/02-integration/03-db/02-db_core_entities_spec.lua
+++ b/spec/02-integration/03-db/02-db_core_entities_spec.lua
@@ -2,6 +2,7 @@ local Errors  = require "kong.db.errors"
 local utils   = require "kong.tools.utils"
 local helpers = require "spec.helpers"
 local cjson   = require "cjson"
+local ssl_fixtures = require "spec.fixtures.ssl"
 
 
 local fmt      = string.format
@@ -23,6 +24,7 @@ for _, strategy in helpers.each_strategy() do
         "upstreams",
         "targets",
         "certificates",
+        "ca_certificates",
         "snis",
       })
     end)
@@ -2157,6 +2159,32 @@ for _, strategy in helpers.each_strategy() do
           assert.equal('["example.org"]', json)
           assert.equal(cjson.array_mt, getmetatable(snis))
         end)
+      end)
+    end)
+
+    describe("CA Certificates", function()
+      it("cannot create a CA Certificate with an existing cert content", function()
+        -- insert 1
+        local _, _, err_t = db.ca_certificates:insert {
+          cert = ssl_fixtures.cert_ca,
+        }
+        assert.is_nil(err_t)
+
+        -- insert 2
+        local ca, _, err_t = db.ca_certificates:insert {
+          cert = ssl_fixtures.cert_ca,
+        }
+
+        assert.is_nil(ca)
+        assert.same({
+          code     = Errors.codes.UNIQUE_VIOLATION,
+          name     = "unique constraint violation",
+          message  = "UNIQUE violation detected on '{cert=[[" .. ssl_fixtures.cert_ca .. "]]}'",
+          strategy = strategy,
+          fields   = {
+            cert = ssl_fixtures.cert_ca,
+          }
+        }, err_t)
       end)
     end)
   end) -- kong.db [strategy]

--- a/spec/02-integration/04-admin_api/16-ca_certificates_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/16-ca_certificates_routes_spec.lua
@@ -229,6 +229,8 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       it("creates new cert when uuid does not exist", function()
+        db:truncate("ca_certificates")
+
         local res = client:put("/ca_certificates/123e4567-e89b-12d3-a456-426655440000", {
           body    = {
             cert = ssl_fixtures.cert_ca,


### PR DESCRIPTION
Thanks @hbagdi for pointing it out!

This is a very small change and ideally goes out in 1.3.0 to avoid any future migration pains.