### PR TITLE
docs(admin-api) document the fourth level of auto-generated admin apis

### DIFF
--- a/autodoc/data/admin-api.lua
+++ b/autodoc/data/admin-api.lua
@@ -1527,11 +1527,11 @@ return {
     endpoint_w_ek = [[
       ##### ${Active_verb} ${Entity}
 
-      <div class="endpoint ${method}">/${entities_url}/{${endpoint_key} or id}</div>
+      <div class="endpoint ${method}">/${entities_url}/{${entity} ${endpoint_key} or id}</div>
 
       Attributes | Description
       ---:| ---
-      `${endpoint_key} or id`<br>**required** | The unique identifier **or** the ${endpoint_key} of the ${Entity} to ${active_verb}.
+      `${entity} ${endpoint_key} or id`<br>**required** | The unique identifier **or** the ${endpoint_key} of the ${Entity} to ${active_verb}.
     ]],
     fk_endpoint_w_ek = [[
       ##### ${Active_verb} ${ForeignEntity} Associated to a Specific ${Entity}
@@ -1559,6 +1559,46 @@ return {
       Attributes | Description
       ---:| ---
       `${entity} id`<br>**required** | The unique identifier of the ${Entity} associated to the ${ForeignEntity} to be ${passive_verb}.
+    ]],
+    nested_endpoint_w_eks = [[
+      ##### ${Active_verb} ${Entity} Associated to a Specific ${ForeignEntity}
+
+      <div class="endpoint ${method}">/${foreign_entities_url}/{${foreign_entity} ${foreign_endpoint_key} or id}/${entities_url}/{${entity} ${endpoint_key} or id}</div>
+
+      Attributes | Description
+      ---:| ---
+      `${foreign_entity} ${foreign_endpoint_key} or id`<br>**required** | The unique identifier **or** the ${foreign_endpoint_key} of the ${ForeignEntity} to ${active_verb}.
+      `${entity} ${endpoint_key} or id`<br>**required** | The unique identifier **or** the ${endpoint_key} of the ${Entity} to ${active_verb}.
+    ]],
+    nested_endpoint_w_ek = [[
+      ##### ${Active_verb} ${Entity} Associated to a Specific ${ForeignEntity}
+
+      <div class="endpoint ${method}">/${foreign_entities_url}/{${foreign_entity} id}/${entities_url}/{${entity} ${endpoint_key} or id}</div>
+
+      Attributes | Description
+      ---:| ---
+      `${foreign_entity} id`<br>**required** | The unique identifier of the ${ForeignEntity} to ${active_verb}.
+      `${entity} ${endpoint_key} or id`<br>**required** | The unique identifier **or** the ${endpoint_key} of the ${Entity} to ${active_verb}.
+    ]],
+    nested_endpoint_w_fek = [[
+      ##### ${Active_verb} ${Entity} Associated to a Specific ${ForeignEntity}
+
+      <div class="endpoint ${method}">/${foreign_entities_url}/{${foreign_entity} ${foreign_endpoint_key} or id}/${entities_url}/{${entity} id}</div>
+
+      Attributes | Description
+      ---:| ---
+      `${foreign_entity} ${foreign_endpoint_key} or id`<br>**required** | The unique identifier **or** the ${foreign_endpoint_key} of the ${ForeignEntity} to ${active_verb}.
+      `${entity} id`<br>**required** | The unique identifier of the ${Entity} to ${active_verb}.
+    ]],
+    nested_endpoint = [[
+      ##### ${Active_verb} ${Entity} Associated to a Specific ${ForeignEntity}
+
+      <div class="endpoint ${method}">/${foreign_entities_url}/{${foreign_entity} id}/${entities_url}/{${entity} id}</div>
+
+      Attributes | Description
+      ---:| ---
+      `${foreign_entity} id`<br>**required** | The unique identifier of the ${ForeignEntity} to ${active_verb}.
+      `${entity} id`<br>**required** | The unique identifier of the ${Entity} to ${active_verb}.
     ]],
     GET = {
       title = [[Retrieve ${Entity}]],

--- a/scripts/autodoc-admin-api
+++ b/scripts/autodoc-admin-api
@@ -621,37 +621,39 @@ local function gen_fk_endpoint(edata, templates, subs, parent_endpoint, method, 
   table.insert(fk_endpoints, render(tpl, subs))
 end
 
-local function gen_template_subs_table(edata, plural, schema, fedata, fplural)
+local function gen_template_subs_table(edata, plural, schema, fedata, fplural, fschema, fname)
+  local api = edata.entity_url_collection_name or schema.admin_api_name or schema.name or plural
   local singular = to_singular(plural)
   local subs = {
     ["Entity"] = edata.entity_title or utils.titleize(singular),
     ["Entities"] = edata.entity_title_plural or utils.titleize(plural),
     ["entity"] = edata.entity_lower or singular:lower(),
     ["entities"] = edata.entity_lower_plural or plural:lower(),
-    ["entities_url"] = edata.entity_url_collection_name or plural,
+    ["entities_url"] = api,
     ["entity_url"] = edata.entity_url_name or singular,
     ["endpoint_key"] = edata.entity_endpoint_key or schema.endpoint_key or "name",
   }
   if fedata then
+    local fapi = fedata.entity_url_collection_name or fschema.admin_api_name or fschema.name or fplural
     local fsingular = to_singular(fplural)
     subs["ForeignEntity"] = fedata.entity_title or utils.titleize(fsingular)
     subs["ForeignEntities"] = fedata.entity_title_plural or utils.titleize(fplural)
     subs["foreign_entity"] = fedata.entity_lower or fsingular:lower()
     subs["foreign_entities"] = fedata.entity_lower_plural or fplural:lower()
-    subs["foreign_entities_url"] = fedata.entity_url_collection_name or fplural
-    subs["foreign_entity_url"] = fedata.entity_url_name or fsingular
+    subs["foreign_entities_url"] = fapi
+    subs["foreign_entity_url"] = fedata.entity_url_name or fname or fsingular
   end
   return subs
 end
 
-local function prepare_entity(data, plural, entity_data)
+local function prepare_entity(data, entity_file, entity_data)
   local out = {}
 
   assert_data(entity_data.description,
-              "'description' field for " .. plural)
+              "'description' field for " .. entity_file)
 
-  local schema = assert(loadfile(KONG_PATH .. "/" .. entity_to_schema_path(plural)))()
-  local subs = gen_template_subs_table(entity_data, plural, schema)
+  local schema = assert(loadfile(KONG_PATH .. "/" .. entity_to_schema_path(entity_file)))()
+  local subs = gen_template_subs_table(entity_data, entity_file, schema)
 
   local title = entity_data.title or (subs.Entity .. " Object")
 
@@ -672,15 +674,18 @@ local function prepare_entity(data, plural, entity_data)
     table.insert(out, "\n\n")
   end
 
-  local filename = "kong/api/routes/" .. plural .. ".lua"
+  local filename = "kong/api/routes/" .. entity_file .. ".lua"
   local modtbl = loadfile(KONG_PATH .. "/" .. filename)
   local mod = modtbl and modtbl() or {}
 
-  local collection_endpoint = "/" .. plural
+  local ename = schema.admin_api_name or schema.name
+  local eapi = entity_data.admin_api_name or ename
+
+  local collection_endpoint = "/" .. eapi
   gen_endpoint(entity_data, data.collection_templates, subs, collection_endpoint, "GET")
   gen_endpoint(entity_data, data.collection_templates, subs, collection_endpoint, "POST")
 
-  local entity_endpoint = "/" .. plural .. "/:" .. plural
+  local entity_endpoint = "/" .. eapi .. "/:" .. ename
   local has_ek = schema.endpoint_key ~= nil
   gen_endpoint(entity_data, data.entity_templates, subs, entity_endpoint, "GET", has_ek)
   gen_endpoint(entity_data, data.entity_templates, subs, entity_endpoint, "PUT", has_ek)
@@ -689,7 +694,7 @@ local function prepare_entity(data, plural, entity_data)
 
   return {
     filename = filename,
-    entity = plural,
+    entity = entity_file,
     schema = schema,
     title = title,
     intro = table.concat(out),
@@ -716,7 +721,7 @@ local function prepare_foreign_key_endpoints(data, entity_infos, entity)
     if finfo.type == "foreign" and not data.known.nodoc_entities[foreigns] then
       local feinfo = entity_infos[foreigns]
       local fedata = feinfo.data
-      local subs = gen_template_subs_table(einfo.data, entity, einfo.schema, fedata, foreigns)
+      local subs = gen_template_subs_table(einfo.data, entity, einfo.schema, fedata, foreigns, feinfo.schema, fname)
       local has_ek = einfo.schema.endpoint_key ~= nil
 
       local function gen_fk_endpoints(parent_endpoint, endpoint, meths, templates, srcdata, dstdata)
@@ -729,16 +734,25 @@ local function prepare_foreign_key_endpoints(data, entity_infos, entity)
         end
       end
 
+      local ename  = einfo.schema.name
+      local eapi   = einfo.schema.admin_api_name        or ename
+      local enapi  = einfo.schema.admin_api_nested_name or eapi
+      local fename = feinfo.schema.name
+      local feapi  = feinfo.schema.admin_api_name       or fename
+
+      -- /services/example/routes
       gen_fk_endpoints(
-        "/" .. entity,
-        "/" .. foreigns .. "/:" .. foreigns .. "/" .. entity,
+        "/" .. eapi,
+        "/" .. feapi .. "/:" .. fename .. "/" .. enapi,
         {"GET", "POST"},
         data.collection_templates,
         fedata, edata
       )
+
+      -- /routes/example/service
       gen_fk_endpoints(
-        "/" .. foreigns .. "/:" .. foreigns,
-        "/" .. entity .. "/:" .. entity .. "/" .. fname,
+        "/" .. feapi .. "/:" .. fename,
+        "/" .. eapi .. "/:" .. ename .. "/" .. fname,
         {"GET", "PUT", "PATCH", "DELETE"},
         data.entity_templates,
         edata, fedata

--- a/scripts/autodoc-admin-api
+++ b/scripts/autodoc-admin-api
@@ -604,14 +604,43 @@ do
   end
 end
 
-local function gen_fk_endpoint(edata, templates, subs, parent_endpoint, method, has_ek)
+local function gen_fk_endpoint(edata, templates, subs, parent_endpoint, method, has_ek, has_fek, nested)
   local ep_data = assert_data(edata[parent_endpoint],
                               "entity data for endpoint " .. parent_endpoint)
-  local meth_data = assert(ep_data[method]) -- get_or_create(ep_data, method)
+
+  local meth_data
+  if nested then
+    meth_data = ep_data[method]
+    if not meth_data then
+      return
+    end
+  else
+    meth_data = assert(ep_data[method]) -- get_or_create(ep_data, method)
+  end
+
   assert_data(templates, "templates definition for " .. parent_endpoint)
   local meth_tpls = templates[method]
   assert_data(meth_tpls, "templates definition for " .. method .. " " .. parent_endpoint)
-  local tk = has_ek and "fk_endpoint_w_ek" or "fk_endpoint"
+  local tk
+  if nested then
+    if has_ek and has_fek then
+      tk = "nested_endpoint_w_eks"
+    elseif has_ek then
+      tk = "nested_endpoint_w_ek"
+    elseif has_fek then
+      tk = "nested_endpoint_w_fek"
+    else
+      tk = "nested_endpoint"
+    end
+
+  else
+    if has_ek then
+      tk = "fk_endpoint_w_ek"
+    else
+      tk = "fk_endpoint"
+    end
+  end
+
   local tpl = meth_tpls[tk] or templates[tk]
   assert_data(tpl, tk .. " template for " .. method .. " " .. parent_endpoint)
   adjust_for_method(subs, method)
@@ -620,6 +649,7 @@ local function gen_fk_endpoint(edata, templates, subs, parent_endpoint, method, 
   local fk_endpoints = get_or_create(meth_data, "fk_endpoints")
   table.insert(fk_endpoints, render(tpl, subs))
 end
+
 
 local function gen_template_subs_table(edata, plural, schema, fedata, fplural, fschema, fname)
   local api = edata.entity_url_collection_name or schema.admin_api_name or schema.name or plural
@@ -642,6 +672,7 @@ local function gen_template_subs_table(edata, plural, schema, fedata, fplural, f
     subs["foreign_entities"] = fedata.entity_lower_plural or fplural:lower()
     subs["foreign_entities_url"] = fapi
     subs["foreign_entity_url"] = fedata.entity_url_name or fname or fsingular
+    subs["foreign_endpoint_key"] = fedata.entity_endpoint_key or fschema.endpoint_key or "name"
   end
   return subs
 end
@@ -681,10 +712,12 @@ local function prepare_entity(data, entity_file, entity_data)
   local ename = schema.admin_api_name or schema.name
   local eapi = entity_data.admin_api_name or ename
 
+  -- e.g. /services
   local collection_endpoint = "/" .. eapi
   gen_endpoint(entity_data, data.collection_templates, subs, collection_endpoint, "GET")
   gen_endpoint(entity_data, data.collection_templates, subs, collection_endpoint, "POST")
 
+  -- e.g. /services/{name or id}
   local entity_endpoint = "/" .. eapi .. "/:" .. ename
   local has_ek = schema.endpoint_key ~= nil
   gen_endpoint(entity_data, data.entity_templates, subs, entity_endpoint, "GET", has_ek)
@@ -723,11 +756,12 @@ local function prepare_foreign_key_endpoints(data, entity_infos, entity)
       local fedata = feinfo.data
       local subs = gen_template_subs_table(einfo.data, entity, einfo.schema, fedata, foreigns, feinfo.schema, fname)
       local has_ek = einfo.schema.endpoint_key ~= nil
+      local has_fek = feinfo.schema.endpoint_key ~= nil
 
-      local function gen_fk_endpoints(parent_endpoint, endpoint, meths, templates, srcdata, dstdata)
+      local function gen_fk_endpoints(parent_endpoint, endpoint, meths, templates, srcdata, dstdata, nested)
         for _, method in ipairs(meths) do
           if not skip_fk_endpoint(edata, endpoint, method) then
-            gen_fk_endpoint(dstdata, templates, subs, parent_endpoint, method, has_ek)
+            gen_fk_endpoint(dstdata, templates, subs, parent_endpoint, method, has_ek, has_fek, nested)
             local ep_data = get_or_create(srcdata, endpoint)
             ep_data.done = true
           end
@@ -740,7 +774,7 @@ local function prepare_foreign_key_endpoints(data, entity_infos, entity)
       local fename = feinfo.schema.name
       local feapi  = feinfo.schema.admin_api_name       or fename
 
-      -- /services/example/routes
+      -- e.g. /services/{service name or id}/routes
       gen_fk_endpoints(
         "/" .. eapi,
         "/" .. feapi .. "/:" .. fename .. "/" .. enapi,
@@ -749,7 +783,16 @@ local function prepare_foreign_key_endpoints(data, entity_infos, entity)
         fedata, edata
       )
 
-      -- /routes/example/service
+      -- e.g. /services/{service name or id}/routes/{route name or id}
+      gen_fk_endpoints(
+        "/" .. eapi .. "/:" .. ename,
+        "/" .. feapi .. "/:" .. fename .. "/" .. enapi .. "/:" .. ename,
+        {"GET", "PUT", "PATCH", "DELETE"},
+        data.entity_templates,
+        fedata, edata, true
+      )
+
+      -- e.g. /routes/{route name or id}/service
       gen_fk_endpoints(
         "/" .. feapi .. "/:" .. fename,
         "/" .. eapi .. "/:" .. ename .. "/" .. fname,
@@ -757,6 +800,7 @@ local function prepare_foreign_key_endpoints(data, entity_infos, entity)
         data.entity_templates,
         edata, fedata
       )
+
     end
   end
 


### PR DESCRIPTION
### Summary

This PR adds the following:

1. a generic description about auto-generated endpoint
2. support for `admin_api_name` and `admin_api_nested_name` schema parameters
3. support for the fourth level of entity endpoint