### PR TITLE
fix(cors) handle empty list of allowed methods

### DIFF
--- a/kong/plugins/cors/handler.lua
+++ b/kong/plugins/cors/handler.lua
@@ -214,7 +214,7 @@ function CorsHandler:access(conf)
     end
   end
 
-  local methods = conf.methods and concat(conf.methods, ",")
+  local methods = conf.methods and #conf.methods > 0 and concat(conf.methods, ",")
                   or "GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS,TRACE,CONNECT"
 
   set_header("Access-Control-Allow-Methods", methods)


### PR DESCRIPTION
### Summary

An empty list of 'headers' or of 'exposed headers' is treated like a
null list by the CORS plugin.  The same should be done for the list
of 'methods'.

This is valuable because some frontends for Kong automatically create
an empty list for methods instead of a null list.  I saw this with
pantsel/Konga version 0.14.1, which is the latest version at this time.
Although this could be seen as a bug of the frontend, the CORS plugin 
should treat the 'methods' list just like for 'headers' and 'exposed-headers'.
