### PR TITLE
fix(dao) remove options.ttl and options.tags context checks

### DIFF
--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -138,13 +138,7 @@ local function validate_options_value(options, schema, context)
   local errors = {}
 
   if schema.ttl == true and options.ttl ~= nil then
-    if context ~= "insert" and
-       context ~= "update" and
-       context ~= "upsert" then
-      errors.ttl = fmt("option can only be used with inserts, updates and upserts, not with '%ss'",
-                       context)
-
-    elseif floor(options.ttl) ~= options.ttl or
+    if floor(options.ttl) ~= options.ttl or
                  options.ttl < 0 or
                  options.ttl > 100000000 then
       -- a bit over three years maximum to make it more safe against

--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -151,10 +151,7 @@ local function validate_options_value(options, schema, context)
   end
 
   if schema.fields.tags and options.tags ~= nil then
-    if context ~= "select" then
-      errors.tags = fmt("option can only be used with selects and pages, not with '%ss'",
-                       tostring(context))
-    elseif type(options.tags) ~= "table" then
+    if type(options.tags) ~= "table" then
       if not options.tags_cond then
         -- If options.tags is not a table and options.tags_cond is nil at the same time
         -- it means arguments.lua gets an invalid tags arg from the Admin API


### PR DESCRIPTION
# Summary

This PR removes `options.ttl` and `options.tags` context validity checks (ie: failing a select with ttl on the options). These checks will fail, for instance, during an update of an entity, when options are being proxied from the update to a select during a `read_before_write`. 

Since there's already magic in place on the dao for checking these options depending on the context, these checks are an extra safeguard. What this proposes is to silently ignore options that do not make sense on a given context.

### Full changelog
* Remove `options.ttl` context checks on options validation from dao
* Remove `options.tags` context checks on options validation from dao

### Issues resolved
Makes it possible to include `ttl` on compound update queries
