### PR TITLE
feat: accept consumer username for anonymous configuration

### DIFF
--- a/kong/pdk/private/phases.lua
+++ b/kong/pdk/private/phases.lua
@@ -57,7 +57,7 @@ end
 
 
 local function check_phase(accepted_phases)
-  if not kong then
+  if not kong or not kong.ctx then
     -- no _G.kong, we are likely in tests
     return
   end
@@ -86,7 +86,7 @@ end
 
 
 local function check_not_phase(rejected_phases)
-  if not kong then
+  if not kong or not kong.ctx then
     -- no _G.kong, we are likely in tests
     return
   end

--- a/kong/plugins/basic-auth/access.lua
+++ b/kong/plugins/basic-auth/access.lua
@@ -104,17 +104,6 @@ local function load_credential_from_db(username)
   return credential
 end
 
-local function load_consumer_into_memory(consumer_id, anonymous)
-  local result, err = kong.db.consumers:select { id = consumer_id }
-  if not result then
-    if anonymous and not err then
-      err = 'anonymous consumer "' .. consumer_id .. '" not found'
-    end
-    return nil, err
-  end
-  return result
-end
-
 local function set_consumer(consumer, credential)
   local set_header = kong.service.request.set_header
   local clear_header = kong.service.request.clear_header
@@ -185,7 +174,7 @@ local function do_authentication(conf)
   -- Retrieve consumer
   local consumer_cache_key = kong.db.consumers:cache_key(credential.consumer.id)
   local consumer, err      = kong.cache:get(consumer_cache_key, nil,
-                                            load_consumer_into_memory,
+                                            kong.client.load_consumer,
                                             credential.consumer.id)
   if err then
     kong.log.err(err)
@@ -211,10 +200,10 @@ function _M.execute(conf)
       -- get anonymous user
       local consumer_cache_key = kong.db.consumers:cache_key(conf.anonymous)
       local consumer, err      = kong.cache:get(consumer_cache_key, nil,
-                                                load_consumer_into_memory,
+                                                kong.client.load_consumer,
                                                 conf.anonymous, true)
       if err then
-        kong.log.err(err)
+        kong.log.err("failed to load anonymous consumer:", err)
         return kong.response.exit(500, { message = "An unexpected error occurred" })
       end
 

--- a/kong/plugins/hmac-auth/access.lua
+++ b/kong/plugins/hmac-auth/access.lua
@@ -235,18 +235,6 @@ local function validate_body()
 end
 
 
-local function load_consumer_into_memory(consumer_id, anonymous)
-  local result, err = kong.db.consumers:select { id = consumer_id }
-  if not result then
-    if anonymous and not err then
-      err = 'anonymous consumer "' .. consumer_id .. '" not found'
-    end
-    return nil, err
-  end
-  return result
-end
-
-
 local function set_consumer(consumer, credential)
   local set_header = kong.service.request.set_header
   local clear_header = kong.service.request.clear_header
@@ -349,7 +337,7 @@ local function do_authentication(conf)
   local consumer_cache_key, consumer
   consumer_cache_key = kong.db.consumers:cache_key(credential.consumer.id)
   consumer, err      = kong.cache:get(consumer_cache_key, nil,
-                                      load_consumer_into_memory,
+                                      kong.client.load_consumer,
                                       credential.consumer.id)
   if err then
     kong.log.err(err)
@@ -378,10 +366,10 @@ function _M.execute(conf)
       -- get anonymous user
       local consumer_cache_key = kong.db.consumers:cache_key(conf.anonymous)
       local consumer, err      = kong.cache:get(consumer_cache_key, nil,
-                                                load_consumer_into_memory,
+                                                kong.client.load_consumer,
                                                 conf.anonymous, true)
       if err then
-        kong.log.err(err)
+        kong.log.err("failed to load anonymous consumer:", err)
         return kong.response.exit(500, { message = "An unexpected error occurred" })
       end
 

--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -76,18 +76,6 @@ local function load_credential(jwt_secret_key)
 end
 
 
-local function load_consumer(consumer_id, anonymous)
-  local result, err = kong.db.consumers:select { id = consumer_id }
-  if not result then
-    if anonymous and not err then
-      err = 'anonymous consumer "' .. consumer_id .. '" not found'
-    end
-    return nil, err
-  end
-  return result
-end
-
-
 local function set_consumer(consumer, credential, token)
   local set_header = kong.service.request.set_header
   local clear_header = kong.service.request.clear_header
@@ -216,10 +204,9 @@ local function do_authentication(conf)
   -- Retrieve the consumer
   local consumer_cache_key = kong.db.consumers:cache_key(jwt_secret.consumer.id)
   local consumer, err      = kong.cache:get(consumer_cache_key, nil,
-                                            load_consumer,
+                                            kong.client.load_consumer,
                                             jwt_secret.consumer.id, true)
   if err then
-    kong.log.err(err)
     return kong.response.exit(500, { message = "An unexpected error occurred" })
   end
 
@@ -255,10 +242,10 @@ function JwtHandler:access(conf)
       -- get anonymous user
       local consumer_cache_key = kong.db.consumers:cache_key(conf.anonymous)
       local consumer, err      = kong.cache:get(consumer_cache_key, nil,
-                                                load_consumer,
+                                                kong.client.load_consumer,
                                                 conf.anonymous, true)
       if err then
-        kong.log.err(err)
+        kong.log.err("failed to load anonymous consumer:", err)
         return kong.response.exit(500, { message = "An unexpected error occurred" })
       end
 

--- a/kong/plugins/key-auth/handler.lua
+++ b/kong/plugins/key-auth/handler.lua
@@ -24,20 +24,6 @@ local function load_credential(key)
 end
 
 
-local function load_consumer(consumer_id, anonymous)
-  local result, err = kong.db.consumers:select({ id = consumer_id })
-  if not result then
-    if anonymous and not err then
-      err = 'anonymous consumer "' .. consumer_id .. '" not found'
-    end
-
-    return nil, err
-  end
-
-  return result
-end
-
-
 local function set_consumer(consumer, credential)
   local set_header = kong.service.request.set_header
   local clear_header = kong.service.request.clear_header
@@ -168,7 +154,8 @@ local function do_authentication(conf)
   -- retrieve the consumer linked to this API key, to set appropriate headers
   local consumer_cache_key, consumer
   consumer_cache_key = kong.db.consumers:cache_key(credential.consumer.id)
-  consumer, err      = cache:get(consumer_cache_key, nil, load_consumer,
+  consumer, err      = cache:get(consumer_cache_key, nil,
+                                 kong.client.load_consumer,
                                  credential.consumer.id)
   if err then
     kong.log.err(err)
@@ -199,9 +186,10 @@ function KeyAuthHandler:access(conf)
       -- get anonymous user
       local consumer_cache_key = kong.db.consumers:cache_key(conf.anonymous)
       local consumer, err = kong.cache:get(consumer_cache_key, nil,
-                                           load_consumer, conf.anonymous, true)
+                                           kong.client.load_consumer,
+                                           conf.anonymous, true)
       if err then
-        kong.log.err(err)
+        kong.log.err("failed to load anonymous consumer:", err)
         return kong.response.exit(500, { message = "An unexpected error occurred" })
       end
 

--- a/kong/plugins/ldap-auth/access.lua
+++ b/kong/plugins/ldap-auth/access.lua
@@ -156,19 +156,6 @@ local function authenticate(conf, given_credentials)
 end
 
 
-local function load_consumer(consumer_id, anonymous)
-  local result, err = kong.db.consumers:select { id = consumer_id }
-  if not result then
-    if anonymous and not err then
-      err = 'anonymous consumer "' .. consumer_id .. '" not found'
-    end
-    return nil, err
-  end
-
-  return result
-end
-
-
 local function set_consumer(consumer, credential)
   kong.client.authenticate(consumer, credential)
 
@@ -267,10 +254,10 @@ function _M.execute(conf)
       -- get anonymous user
       local consumer_cache_key = kong.db.consumers:cache_key(conf.anonymous)
       local consumer, err      = singletons.cache:get(consumer_cache_key, nil,
-                                                      load_consumer,
+                                                      kong.client.load_consumer,
                                                       conf.anonymous, true)
       if err then
-        kong.log.err(err)
+        kong.log.err("failed to load anonymous consumer:", err)
         return kong.response.exit(500, { message = "An unexpected error occurred" })
       end
 

--- a/t/01-pdk/05-client/00-phase_checks.t
+++ b/t/01-pdk/05-client/00-phase_checks.t
@@ -25,7 +25,18 @@ qq{
     }
 
     init_worker_by_lua_block {
-
+        _G.kong = {
+          db = {
+            consumers = {
+              select = function(self, query)
+                return { username = "bob" }, nil
+              end,
+              select_by_username = function(self, query)
+                return { username = "bob" }, nil
+              end,
+            },
+          },
+        }
         phases = require("kong.pdk.private.phases").phases
 
         phase_check_module = "client"
@@ -110,6 +121,17 @@ qq{
             }, {
                 method        = "get_protocol",
                 args          = {},
+                init_worker   = "forced false",
+                certificate   = "pending",
+                rewrite       = "forced false",
+                access        = true,
+                header_filter = true,
+                body_filter   = true,
+                log           = true,
+                admin_api     = "forced false",
+            }, {
+                method        = "load_consumer",
+                args          = { "bob", true },
                 init_worker   = "forced false",
                 certificate   = "pending",
                 rewrite       = "forced false",

--- a/t/01-pdk/05-client/09-load-consumer.t
+++ b/t/01-pdk/05-client/09-load-consumer.t
@@ -1,0 +1,129 @@
+use strict;
+use warnings FATAL => 'all';
+use Test::Nginx::Socket::Lua;
+use t::Util;
+
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
+
+plan tests => repeat_each() * (blocks() * 3);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: client.load_consumer() loads a consumer by id.
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            _G.kong = {
+              ctx = {
+                core = {
+                  phase = 0x00000020,
+                },
+              },
+              db = {
+                consumers = {
+                  select = function(self, query)
+                    return { username = "bob" }, nil
+                  end,
+                },
+              },
+            }
+
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            local consumer, err = pdk.client.load_consumer("5a61a36e-6133-4be7-b8be-6431d6e98019")
+            ngx.say("consumer: " .. consumer.username)
+        }
+    }
+--- request
+GET /t
+--- response_body
+consumer: bob
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: client.load_consumer() loads a consumer by username
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            _G.kong = {
+              ctx = {
+                core = {
+                  phase = 0x00000020,
+                },
+              },
+              db = {
+                consumers = {
+                  select = function()
+                    return
+                  end,
+                  select_by_username = function(self, query)
+                    return { username = "bob" }, nil
+                  end,
+                },
+              },
+            }
+
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            local consumer, err = pdk.client.load_consumer("bob", true)
+            ngx.say("consumer: " .. consumer.username)
+        }
+    }
+--- request
+GET /t
+--- response_body
+consumer: bob
+--- no_error_log
+[error]
+
+
+
+=== TEST 3: client.load_consumer() returns an error
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            local consumer, err = pcall(pdk.client.load_consumer)
+            ngx.say(tostring(err))
+        }
+    }
+--- request
+GET /t
+--- response_body
+consumer_id must be a string
+--- no_error_log
+[error]
+
+
+
+=== TEST 4: client.load_consumer() errors for a non-uuid ID based search
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            local consumer, err = pcall(pdk.client.load_consumer, "bob", false)
+            --local consumer, err = pcall(pdk.client.load_consumer)
+            ngx.say(tostring(err))
+        }
+    }
+--- request
+GET /t
+--- response_body
+cannot load a consumer with an id that is not a uuid
+--- no_error_log
+[error]
+

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -74,8 +74,6 @@ our $HttpConfig = <<_EOC_;
                 end
             end
 
-            kong = nil
-
             local entries = {}
             for _, entry in ipairs(phase_check_data) do
                 entries[entry.method] = true
@@ -102,7 +100,10 @@ our $HttpConfig = <<_EOC_;
                             fname .. " expected "
 
                 -- Run function with phase checked disabled
-                kong = nil
+		if kong then
+		  kong.ctx = nil
+		end
+		-- kong = nil
 
                 local expected = fdata[phases[phase]]
 
@@ -132,7 +133,10 @@ our $HttpConfig = <<_EOC_;
                 end
 
                 -- Re-enable phase checking and compare results
-                kong = { ctx = { core = { phase = phase } } }
+		if not kong then
+		  kong = {}
+		end
+                kong.ctx = { core = { phase = phase } }
 
                 if forced_false then
                     ok1, err1 = false, ""


### PR DESCRIPTION
### Summary

Anonymous consumer previously could be configured using only the `ID` of the consumer, with this change, the plugin configuration can use the `username` in addition to `ID`.

### Issues resolved

Fix https://github.com/Kong/kubernetes-ingress-controller/issues/265
