### PR TITLE
feat: implemented a new status interface

### DIFF
--- a/autodoc/data/admin-api.lua
+++ b/autodoc/data/admin-api.lua
@@ -13,6 +13,7 @@ return {
   known = {
     general_files = {
       "kong/api/routes/kong.lua",
+      "kong/api/routes/health.lua",
       "kong/api/routes/config.lua",
       "kong/api/routes/tags.lua",
     },
@@ -148,6 +149,10 @@ return {
           ]],
         },
       },
+    },
+    health = {
+      title = [[Health routes]],
+      description = "",
       ["/status"] = {
         GET = {
           title = [[Retrieve node status]],

--- a/kong-1.3.0-0.rockspec
+++ b/kong-1.3.0-0.rockspec
@@ -118,6 +118,8 @@ build = {
     ["kong.api.routes.snis"] = "kong/api/routes/snis.lua",
     ["kong.api.routes.tags"] = "kong/api/routes/tags.lua",
 
+    ["kong.status"] = "kong/status/init.lua",
+
     ["kong.tools.cluster_ca"] = "kong/tools/cluster_ca.lua",
     ["kong.tools.dns"] = "kong/tools/dns.lua",
     ["kong.tools.utils"] = "kong/tools/utils.lua",

--- a/kong-1.3.0-0.rockspec
+++ b/kong-1.3.0-0.rockspec
@@ -105,6 +105,7 @@ build = {
     ["kong.api.arguments"] = "kong/api/arguments.lua",
     ["kong.api.endpoints"] = "kong/api/endpoints.lua",
     ["kong.api.routes.kong"] = "kong/api/routes/kong.lua",
+    ["kong.api.routes.health"] = "kong/api/routes/health.lua",
     ["kong.api.routes.config"] = "kong/api/routes/config.lua",
     ["kong.api.routes.consumers"] = "kong/api/routes/consumers.lua",
     ["kong.api.routes.plugins"] = "kong/api/routes/plugins.lua",

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -59,6 +59,19 @@
                                           # is adjusted by the `log_level`
                                           # property.
 
+#status_access_log = off                  # Path for Status API request access
+                                          # logs. The default value of `off`
+                                          # implies that loggin for this API
+                                          # is disabled by default.
+                                          # If this value is a relative path,
+                                          # it will be placed under the
+                                          # `prefix` location.
+
+#status_error_log = logs/status_error.log # Path for Status API request error
+                                          # logs. The granularity of these logs
+                                          # is adjusted by the `log_level`
+                                          # property.
+
 #plugins = bundled               # Comma-separated list of plugins this node
                                  # should load. By default, only plugins
                                  # bundled in official distributions are
@@ -234,7 +247,20 @@
                          # capabilities) pulling its configuration changes
                          # from the database.
                          #
-                         # Example: `stream_listen = 127.0.0.1:8444 http2 ssl`
+                         # Example: `admin_listen = 127.0.0.1:8444 http2 ssl`
+
+ #status_listen = off    # Comma-separated list of addresses and ports on
+                         # which the Status API should listen.
+                         # The Status API is a read-only endpoint
+                         # allowing monitoring tools to retrieve metrics,
+                         # healthiness, and other non-sensitive information
+                         # of the current Kong node.
+                         #
+                         # This value can be set to `off`, disabling
+                         # the Status API for this node.
+                         #
+                         # Example: `status_listen = 0.0.0.0:8100`
+
 
 #nginx_user = nobody nobody      # Defines user and group credentials used by
                                  # worker processes. If group is omitted, a

--- a/kong/api/api_helpers.lua
+++ b/kong/api/api_helpers.lua
@@ -1,10 +1,21 @@
 local utils = require "kong.tools.utils"
 local cjson = require "cjson"
+local pl_pretty = require "pl.pretty"
+local tablex = require "pl.tablex"
+local app_helpers = require "lapis.application"
+local arguments = require "kong.api.arguments"
+local Errors = require "kong.db.errors"
+local singletons = require "kong.singletons"
 
-local type = type
-local pairs = pairs
+local ngx      = ngx
+local sub      = string.sub
+local find     = string.find
+local type     = type
+local pairs    = pairs
+local ipairs   = ipairs
 
 local _M = {}
+local NO_ARRAY_INDEX_MARK = {}
 
 -- Parses a form value, handling multipart/data values
 -- @param `v` The value object
@@ -13,7 +24,6 @@ local function parse_value(v)
   return type(v) == "table" and v.content or v -- Handle multipart
 end
 
-local NO_ARRAY_INDEX_MARK = {}
 
 -- given a string like "x[1].y", return an array of indices like {"x", 1, "y"}
 -- the path parameter is an output-only param. the keys are added to it in order
@@ -191,6 +201,229 @@ do
     return { fields = fields }
   end
   _M.schema_to_jsonable = schema_to_jsonable
+end
+
+
+local NEEDS_BODY = tablex.readonly({ PUT = 1, POST = 2, PATCH = 3 })
+
+
+function _M.before_filter(self)
+  if not NEEDS_BODY[ngx.req.get_method()] then
+    return
+  end
+
+  local content_type = self.req.headers["content-type"]
+  if not content_type then
+    local content_length = self.req.headers["content-length"]
+    if content_length == "0" then
+      return
+    end
+
+    if not content_length then
+      local _, err = ngx.req.socket()
+      if err == "no body" then
+        return
+      end
+    end
+
+  elseif sub(content_type, 1, 16) == "application/json"                  or
+         sub(content_type, 1, 19) == "multipart/form-data"               or
+         sub(content_type, 1, 33) == "application/x-www-form-urlencoded" then
+    return
+  end
+
+  return kong.response.exit(415)
+end
+
+
+local function parse_params(fn)
+  return app_helpers.json_params(function(self, ...)
+    if NEEDS_BODY[ngx.req.get_method()] then
+      local content_type = self.req.headers["content-type"]
+      if content_type then
+        content_type = content_type:lower()
+
+        if find(content_type, "application/json", 1, true) and not self.json then
+          return kong.response.exit(400, { message = "Cannot parse JSON body" })
+
+        elseif find(content_type, "application/x-www-form-urlencode", 1, true) then
+          self.params = utils.decode_args(self.params)
+        end
+      end
+    end
+
+    self.params = _M.normalize_nested_params(self.params)
+
+    local res, err = fn(self, ...)
+
+    if err then
+      kong.log.err(err)
+      return ngx.exit(500)
+    end
+
+    if res == nil and ngx.status >= 200 then
+      return ngx.exit(0)
+    end
+
+    return res
+  end)
+end
+
+
+-- new DB
+local function new_db_on_error(self)
+  local err = self.errors[1]
+
+  if type(err) ~= "table" then
+    kong.log.err(err)
+    return kong.response.exit(500, { message = "An unexpected error occurred" })
+  end
+
+  if err.strategy then
+    err.strategy = nil
+  end
+
+  if err.code == Errors.codes.SCHEMA_VIOLATION
+  or err.code == Errors.codes.INVALID_PRIMARY_KEY
+  or err.code == Errors.codes.FOREIGN_KEY_VIOLATION
+  or err.code == Errors.codes.INVALID_OFFSET
+  or err.code == Errors.codes.FOREIGN_KEYS_UNRESOLVED
+  then
+    return kong.response.exit(400, err)
+  end
+
+  if err.code == Errors.codes.NOT_FOUND then
+    return kong.response.exit(404, err)
+  end
+
+  if err.code == Errors.codes.OPERATION_UNSUPPORTED then
+    kong.log.err(err)
+    return kong.response.exit(405, err)
+  end
+
+  if err.code == Errors.codes.PRIMARY_KEY_VIOLATION
+  or err.code == Errors.codes.UNIQUE_VIOLATION
+  then
+    return kong.response.exit(409, err)
+  end
+
+  kong.log.err(err)
+  return kong.response.exit(500, { message = "An unexpected error occurred" })
+end
+
+
+-- old DAO
+local function on_error(self)
+  local err = self.errors[1]
+
+  if type(err) ~= "table" then
+    kong.log.err(err)
+    return kong.response.exit(500, { message = "An unexpected error occurred" })
+  end
+
+  if err.name then
+    return new_db_on_error(self)
+  end
+
+  if err.db then
+    kong.log.err(err.message)
+    return kong.response.exit(500, { message = "An unexpected error occurred" })
+  end
+
+  if err.unique then
+    return kong.response.exit(409, err.tbl)
+  end
+
+  if err.foreign then
+    return kong.response.exit(404, err.tbl or { message = "Not found" })
+  end
+
+  return kong.response.exit(400, err.tbl or err.message)
+end
+
+
+local handler_helpers = {
+  yield_error = app_helpers.yield_error
+}
+
+
+function _M.attach_routes(app, routes)
+  for route_path, methods in pairs(routes) do
+    methods.on_error = methods.on_error or on_error
+
+    for method_name, method_handler in pairs(methods) do
+      local wrapped_handler = function(self)
+        return method_handler(self, {}, handler_helpers)
+      end
+
+      methods[method_name] = parse_params(wrapped_handler)
+    end
+
+    app:match(route_path, route_path, app_helpers.respond_to(methods))
+  end
+end
+
+
+function _M.attach_new_db_routes(app, routes)
+  for route_path, definition in pairs(routes) do
+    local schema  = definition.schema
+    local methods = definition.methods
+
+    methods.on_error = methods.on_error or new_db_on_error
+
+    for method_name, method_handler in pairs(methods) do
+      local wrapped_handler = function(self)
+        self.args = arguments.load({
+          schema  = schema,
+          request = self.req,
+        })
+
+        return method_handler(self, singletons.db, handler_helpers)
+      end
+
+      methods[method_name] = parse_params(wrapped_handler)
+    end
+
+    app:match(route_path, route_path, app_helpers.respond_to(methods))
+  end
+end
+
+
+function _M.default_route(self)
+  local path = self.req.parsed_url.path:match("^(.*)/$")
+
+  if path and self.app.router:resolve(path, self) then
+    return
+
+  elseif self.app.router:resolve(self.req.parsed_url.path .. "/", self) then
+    return
+  end
+
+  return self.app.handle_404(self)
+end
+
+
+
+function _M.handle_404(self)
+  return kong.response.exit(404, { message = "Not found" })
+end
+
+
+function _M.handle_error(self, err, trace)
+  if err then
+    if type(err) ~= "string" then
+      err = pl_pretty.write(err)
+    end
+    if find(err, "don't know how to respond to", nil, true) then
+      return kong.response.exit(405, { message = "Method not allowed" })
+    end
+  end
+
+  ngx.log(ngx.ERR, err, "\n", trace)
+
+  -- We just logged the error so no need to give it to responses and log it
+  -- twice
+  return kong.response.exit(500, { message = "An unexpected error occurred" })
 end
 
 

--- a/kong/api/init.lua
+++ b/kong/api/init.lua
@@ -1,18 +1,11 @@
 local lapis       = require "lapis"
 local utils       = require "kong.tools.utils"
-local tablex      = require "pl.tablex"
-local pl_pretty   = require "pl.pretty"
 local singletons  = require "kong.singletons"
-local app_helpers = require "lapis.application"
 local api_helpers = require "kong.api.api_helpers"
 local Endpoints   = require "kong.api.endpoints"
-local arguments   = require "kong.api.arguments"
-local Errors      = require "kong.db.errors"
 
 
 local ngx      = ngx
-local sub      = string.sub
-local find     = string.find
 local type     = type
 local pairs    = pairs
 local ipairs   = ipairs
@@ -21,235 +14,19 @@ local ipairs   = ipairs
 local app = lapis.Application()
 
 
-local NEEDS_BODY = tablex.readonly({ PUT = 1, POST = 2, PATCH = 3 })
-
-
-local function parse_params(fn)
-  return app_helpers.json_params(function(self, ...)
-    if NEEDS_BODY[ngx.req.get_method()] then
-      local content_type = self.req.headers["content-type"]
-      if content_type then
-        content_type = content_type:lower()
-
-        if find(content_type, "application/json", 1, true) and not self.json then
-          return kong.response.exit(400, { message = "Cannot parse JSON body" })
-
-        elseif find(content_type, "application/x-www-form-urlencode", 1, true) then
-          self.params = utils.decode_args(self.params)
-        end
-      end
-    end
-
-    self.params = api_helpers.normalize_nested_params(self.params)
-
-    local res, err = fn(self, ...)
-
-    if err then
-      kong.log.err(err)
-      return ngx.exit(500)
-    end
-
-    if res == nil and ngx.status >= 200 then
-      return ngx.exit(0)
-    end
-
-    return res
-  end)
-end
-
-
--- new DB
-local function new_db_on_error(self)
-  local err = self.errors[1]
-
-  if type(err) ~= "table" then
-    kong.log.err(err)
-    return kong.response.exit(500, { message = "An unexpected error occurred" })
-  end
-
-  if err.strategy then
-    err.strategy = nil
-  end
-
-  if err.code == Errors.codes.SCHEMA_VIOLATION
-  or err.code == Errors.codes.INVALID_PRIMARY_KEY
-  or err.code == Errors.codes.FOREIGN_KEY_VIOLATION
-  or err.code == Errors.codes.INVALID_OFFSET
-  or err.code == Errors.codes.FOREIGN_KEYS_UNRESOLVED
-  then
-    return kong.response.exit(400, err)
-  end
-
-  if err.code == Errors.codes.NOT_FOUND then
-    return kong.response.exit(404, err)
-  end
-
-  if err.code == Errors.codes.OPERATION_UNSUPPORTED then
-    kong.log.err(err)
-    return kong.response.exit(405, err)
-  end
-
-  if err.code == Errors.codes.PRIMARY_KEY_VIOLATION
-  or err.code == Errors.codes.UNIQUE_VIOLATION
-  then
-    return kong.response.exit(409, err)
-  end
-
-  kong.log.err(err)
-  return kong.response.exit(500, { message = "An unexpected error occurred" })
-end
-
-
--- old DAO
-local function on_error(self)
-  local err = self.errors[1]
-
-  if type(err) ~= "table" then
-    kong.log.err(err)
-    return kong.response.exit(500, { message = "An unexpected error occurred" })
-  end
-
-  if err.name then
-    return new_db_on_error(self)
-  end
-
-  if err.db then
-    kong.log.err(err.message)
-    return kong.response.exit(500, { message = "An unexpected error occurred" })
-  end
-
-  if err.unique then
-    return kong.response.exit(409, err.tbl)
-  end
-
-  if err.foreign then
-    return kong.response.exit(404, err.tbl or { message = "Not found" })
-  end
-
-  return kong.response.exit(400, err.tbl or err.message)
-end
-
-
-app.default_route = function(self)
-  local path = self.req.parsed_url.path:match("^(.*)/$")
-
-  if path and self.app.router:resolve(path, self) then
-    return
-
-  elseif self.app.router:resolve(self.req.parsed_url.path .. "/", self) then
-    return
-  end
-
-  return self.app.handle_404(self)
-end
-
-
-app.handle_404 = function(self)
-  return kong.response.exit(404, { message = "Not found" })
-end
-
-
-app.handle_error = function(self, err, trace)
-  if err then
-    if type(err) ~= "string" then
-      err = pl_pretty.write(err)
-    end
-    if find(err, "don't know how to respond to", nil, true) then
-      return kong.response.exit(405, { message = "Method not allowed" })
-    end
-  end
-
-  ngx.log(ngx.ERR, err, "\n", trace)
-
-  -- We just logged the error so no need to give it to responses and log it
-  -- twice
-  return kong.response.exit(500, { message = "An unexpected error occurred" })
-end
-
-
-app:before_filter(function(self)
-  if not NEEDS_BODY[ngx.req.get_method()] then
-    return
-  end
-
-  local content_type = self.req.headers["content-type"]
-  if not content_type then
-    local content_length = self.req.headers["content-length"]
-    if content_length == "0" then
-      return
-    end
-
-    if not content_length then
-      local _, err = ngx.req.socket()
-      if err == "no body" then
-        return
-      end
-    end
-
-  elseif sub(content_type, 1, 16) == "application/json"                  or
-         sub(content_type, 1, 19) == "multipart/form-data"               or
-         sub(content_type, 1, 33) == "application/x-www-form-urlencoded" then
-    return
-  end
-
-  return kong.response.exit(415)
-end)
-
-
-local handler_helpers = {
-  yield_error = app_helpers.yield_error
-}
-
-
-local function attach_routes(routes)
-  for route_path, methods in pairs(routes) do
-    methods.on_error = methods.on_error or on_error
-
-    for method_name, method_handler in pairs(methods) do
-      local wrapped_handler = function(self)
-        return method_handler(self, {}, handler_helpers)
-      end
-
-      methods[method_name] = parse_params(wrapped_handler)
-    end
-
-    app:match(route_path, route_path, app_helpers.respond_to(methods))
-  end
-end
-
-
-local function attach_new_db_routes(routes)
-  for route_path, definition in pairs(routes) do
-    local schema  = definition.schema
-    local methods = definition.methods
-
-    methods.on_error = methods.on_error or new_db_on_error
-
-    for method_name, method_handler in pairs(methods) do
-      local wrapped_handler = function(self)
-        self.args = arguments.load({
-          schema  = schema,
-          request = self.req,
-        })
-
-        return method_handler(self, singletons.db, handler_helpers)
-      end
-
-      methods[method_name] = parse_params(wrapped_handler)
-    end
-
-    app:match(route_path, route_path, app_helpers.respond_to(methods))
-  end
-end
+app.default_route = api_helpers.default_route
+app.handle_404 = api_helpers.handle_404
+app.handle_error = api_helpers.handle_error
+app:before_filter(api_helpers.before_filter)
 
 
 ngx.log(ngx.DEBUG, "Loading Admin API endpoints")
 
 
 -- Load core routes
-for _, v in ipairs({"kong", "cache", "config"}) do
+for _, v in ipairs({"kong", "health", "cache", "config"}) do
   local routes = require("kong.api.routes." .. v)
-  attach_routes(routes)
+  api_helpers.attach_routes(app, routes)
 end
 
 
@@ -295,7 +72,7 @@ do
     end
   end
 
-  attach_new_db_routes(routes)
+  api_helpers.attach_new_db_routes(app, routes)
 end
 
 
@@ -316,9 +93,9 @@ if singletons.configuration and singletons.configuration.loaded_plugins then
     if loaded then
       ngx.log(ngx.DEBUG, "Loading API endpoints for plugin: ", k)
       if is_new_db_routes(mod) then
-        attach_new_db_routes(mod)
+        api_helpers.attach_new_db_routes(app, mod)
       else
-        attach_routes(mod)
+        api_helpers.attach_routes(app, mod)
       end
 
     else

--- a/kong/api/routes/health.lua
+++ b/kong/api/routes/health.lua
@@ -1,0 +1,80 @@
+local utils = require "kong.tools.utils"
+
+local find = string.find
+local select = select
+local tonumber = tonumber
+local kong = kong
+local knode  = (kong and kong.node) and kong.node or
+               require "kong.pdk.node".new()
+
+
+local select = select
+local tonumber = tonumber
+local kong = kong
+
+
+return {
+  ["/status"] = {
+    GET = function(self, dao, helpers)
+      local query = self.req.params_get
+      local unit = "m"
+      local scale
+
+      if query then
+        if query.unit then
+          unit = query.unit
+        end
+
+        if query.scale then
+          scale = tonumber(query.scale)
+        end
+
+        -- validate unit and scale arguments
+
+        local pok, perr = pcall(utils.bytes_to_str, 0, unit, scale)
+        if not pok then
+          return kong.response.exit(400, { message = perr })
+        end
+      end
+
+      -- nginx stats
+
+      local r = ngx.location.capture "/nginx_status"
+      if r.status ~= 200 then
+        kong.log.err(r.body)
+        return kong.response.exit(500, { message = "An unexpected error happened" })
+      end
+
+      local var = ngx.var
+      local accepted, handled, total = select(3, find(r.body, "accepts handled requests\n (%d*) (%d*) (%d*)"))
+
+      local status_response = {
+        memory = knode.get_memory_stats(unit, scale),
+        server = {
+          connections_active = tonumber(var.connections_active),
+          connections_reading = tonumber(var.connections_reading),
+          connections_writing = tonumber(var.connections_writing),
+          connections_waiting = tonumber(var.connections_waiting),
+          connections_accepted = tonumber(accepted),
+          connections_handled = tonumber(handled),
+          total_requests = tonumber(total)
+        },
+        database = {
+          reachable = true,
+        },
+      }
+
+      -- TODO: no way to bypass connection pool
+      local ok, err = kong.db:connect()
+      if not ok then
+        ngx.log(ngx.ERR, "failed to connect to ", kong.db.infos.strategy,
+                         " during /status endpoint check: ", err)
+        status_response.database.reachable = false
+      end
+
+      kong.db:close() -- ignore errors
+
+      return kong.response.exit(200, status_response)
+    end
+  },
+}

--- a/kong/api/routes/kong.lua
+++ b/kong/api/routes/kong.lua
@@ -7,9 +7,6 @@ local Schema = require "kong.db.schema"
 local Errors = require "kong.db.errors"
 
 local sub = string.sub
-local find = string.find
-local select = select
-local tonumber = tonumber
 local kong = kong
 local knode  = (kong and kong.node) and kong.node or
                require "kong.pdk.node".new()
@@ -93,69 +90,6 @@ return {
         configuration = conf_loader.remove_sensitive(singletons.configuration),
         prng_seeds = prng_seeds,
       })
-    end
-  },
-  ["/status"] = {
-    GET = function(self, dao, helpers)
-      local query = self.req.params_get
-      local unit = "m"
-      local scale
-
-      if query then
-        if query.unit then
-          unit = query.unit
-        end
-
-        if query.scale then
-          scale = tonumber(query.scale)
-        end
-
-        -- validate unit and scale arguments
-
-        local pok, perr = pcall(utils.bytes_to_str, 0, unit, scale)
-        if not pok then
-          return kong.response.exit(400, { message = perr })
-        end
-      end
-
-      -- nginx stats
-
-      local r = ngx.location.capture "/nginx_status"
-      if r.status ~= 200 then
-        kong.log.err(r.body)
-        return kong.response.exit(500, { message = "An unexpected error happened" })
-      end
-
-      local var = ngx.var
-      local accepted, handled, total = select(3, find(r.body, "accepts handled requests\n (%d*) (%d*) (%d*)"))
-
-      local status_response = {
-        memory = knode.get_memory_stats(unit, scale),
-        server = {
-          connections_active = tonumber(var.connections_active),
-          connections_reading = tonumber(var.connections_reading),
-          connections_writing = tonumber(var.connections_writing),
-          connections_waiting = tonumber(var.connections_waiting),
-          connections_accepted = tonumber(accepted),
-          connections_handled = tonumber(handled),
-          total_requests = tonumber(total)
-        },
-        database = {
-          reachable = true,
-        },
-      }
-
-      -- TODO: no way to bypass connection pool
-      local ok, err = kong.db:connect()
-      if not ok then
-        ngx.log(ngx.ERR, "failed to connect to ", kong.db.infos.strategy,
-                         " during /status endpoint check: ", err)
-        status_response.database.reachable = false
-      end
-
-      kong.db:close() -- ignore errors
-
-      return kong.response.exit(200, status_response)
     end
   },
   ["/schemas/:name"] = {

--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -47,6 +47,10 @@ local HEADER_KEY_TO_NAME = {
 
 local DYNAMIC_KEY_NAMESPACES = {
   {
+    injected_conf_name = "nginx_http_status_directives",
+    prefix = "nginx_http_status_",
+  },
+  {
     injected_conf_name = "nginx_http_upstream_directives",
     prefix = "nginx_http_upstream_",
   },
@@ -111,6 +115,7 @@ local CONF_INFERENCES = {
   -- forced string inferences (or else are retrieved as numbers)
   proxy_listen = { typ = "array" },
   admin_listen = { typ = "array" },
+  status_listen = { typ = "array" },
   stream_listen = { typ = "array" },
   origins = { typ = "array" },
   db_update_frequency = {  typ = "number"  },
@@ -209,6 +214,8 @@ local CONF_INFERENCES = {
   proxy_error_log = { typ = "string" },
   admin_access_log = { typ = "string" },
   admin_error_log = { typ = "string" },
+  status_access_log = { typ = "string" },
+  status_error_log = { typ = "string" },
   log_level = { enum = {
                   "debug",
                   "info",
@@ -1003,6 +1010,13 @@ local function load(path, custom_conf, opts)
         break
       end
     end
+
+    conf.status_listeners, err = parse_listeners(conf.status_listen, { "ssl" })
+    if err then
+      return nil, "status_listen " .. err
+    end
+
+    setmetatable(conf.status_listeners, _nop_tostring_mt)
   end
 
   do

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -1085,7 +1085,7 @@ function Kong.handle_error()
 end
 
 
-function Kong.admin_content(options)
+local function serve_content(module, options)
   kong_global.set_phase(kong, PHASES.admin_api)
 
   local ctx = ngx.ctx
@@ -1110,11 +1110,16 @@ function Kong.admin_content(options)
     return ngx.exit(204)
   end
 
-  lapis.serve("kong.api")
+  lapis.serve(module)
 
   ctx.KONG_ADMIN_CONTENT_ENDED_AT = get_now_ms()
   ctx.KONG_ADMIN_CONTENT_TIME = ctx.KONG_ADMIN_CONTENT_ENDED_AT - ctx.KONG_ADMIN_CONTENT_START
   ctx.KONG_ADMIN_LATENCY = ctx.KONG_ADMIN_CONTENT_ENDED_AT - ctx.KONG_PROCESSING_START
+end
+
+
+function Kong.admin_content(options)
+  return serve_content("kong.api", options)
 end
 
 
@@ -1150,6 +1155,14 @@ function Kong.admin_header_filter()
   --ctx.KONG_ADMIN_HEADER_FILTER_ENDED_AT = get_now_ms()
   --ctx.KONG_ADMIN_HEADER_FILTER_TIME = ctx.KONG_ADMIN_HEADER_FILTER_ENDED_AT - ctx.KONG_ADMIN_HEADER_FILTER_START
 end
+
+
+function Kong.status_content()
+  return serve_content("kong.status")
+end
+
+
+Kong.status_header_filter = Kong.admin_header_filter
 
 
 return Kong

--- a/kong/status/init.lua
+++ b/kong/status/init.lua
@@ -1,0 +1,43 @@
+local lapis       = require "lapis"
+local utils       = require "kong.tools.utils"
+local singletons  = require "kong.singletons"
+local api_helpers = require "kong.api.api_helpers"
+
+
+local ngx      = ngx
+local pairs    = pairs
+
+
+local app = lapis.Application()
+
+
+app.default_route = api_helpers.default_route
+app.handle_404 = api_helpers.handle_404
+app.handle_error = api_helpers.handle_error
+app:before_filter(api_helpers.before_filter)
+
+
+ngx.log(ngx.DEBUG, "Loading Status API endpoints")
+
+
+-- Load core health route
+api_helpers.attach_routes(app, require "kong.api.routes.health")
+
+
+-- Load plugins status routes
+if singletons.configuration and singletons.configuration.loaded_plugins then
+  for k in pairs(singletons.configuration.loaded_plugins) do
+    local loaded, mod = utils.load_module_if_exists("kong.plugins." ..
+                                                    k .. ".status_api")
+
+    if loaded then
+      ngx.log(ngx.DEBUG, "Loading Status API endpoints for plugin: ", k)
+      api_helpers.attach_routes(app, mod)
+    else
+      ngx.log(ngx.DEBUG, "No Status API endpoints loaded for plugin: ", k)
+    end
+  end
+end
+
+
+return app

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -5,12 +5,15 @@ proxy_access_log = logs/access.log
 proxy_error_log = logs/error.log
 admin_access_log = logs/admin_access.log
 admin_error_log = logs/error.log
+status_access_log = off
+status_error_log = logs/status_error.log
 plugins = bundled
 anonymous_reports = on
 
 proxy_listen = 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
 stream_listen = off
 admin_listen = 127.0.0.1:8001, 127.0.0.1:8444 http2 ssl
+status_listen = off
 origins = NONE
 nginx_user = nobody nobody
 nginx_worker_processes = auto

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -293,6 +293,8 @@ describe("Configuration loader", function()
 
       assert.True(search_directive(conf.nginx_admin_directives,
                                    "server_tokens", "build"))
+      assert.True(search_directive(conf.nginx_http_status_directives,
+                                   "client_body_buffer_size", "8k"))
     end)
   end)
 

--- a/spec/02-integration/08-status_api/01-core_routes_spec.lua
+++ b/spec/02-integration/08-status_api/01-core_routes_spec.lua
@@ -1,0 +1,62 @@
+local helpers = require "spec.helpers"
+local cjson = require "cjson"
+
+local strategies = {}
+for _, strategy in helpers.each_strategy() do
+  table.insert(strategies, strategy)
+end
+table.insert(strategies, "off")
+for _, strategy in pairs(strategies) do
+describe("Status API - with strategy #" .. strategy, function()
+  local client
+
+  lazy_setup(function()
+    helpers.get_db_utils(nil, {}) -- runs migrations
+    assert(helpers.start_kong {
+      status_listen = "127.0.0.1:9500",
+      plugins = "admin-api-method",
+    })
+    client = helpers.http_client("127.0.0.1", 9500, 20000)
+  end)
+
+  lazy_teardown(function()
+    if client then client:close() end
+    helpers.stop_kong()
+  end)
+
+  describe("core", function()
+    it("/status returns status info", function()
+      local res = assert(client:send {
+        method = "GET",
+        path = "/status"
+      })
+      local body = assert.res_status(200, res)
+      local json = cjson.decode(body)
+      assert.is_table(json.database)
+      assert.is_table(json.server)
+
+      assert.is_boolean(json.database.reachable)
+
+      assert.is_number(json.server.connections_accepted)
+      assert.is_number(json.server.connections_active)
+      assert.is_number(json.server.connections_handled)
+      assert.is_number(json.server.connections_reading)
+      assert.is_number(json.server.connections_writing)
+      assert.is_number(json.server.connections_waiting)
+      assert.is_number(json.server.total_requests)
+    end)
+  end)
+
+  describe("plugins", function()
+    it("can add endpoints", function()
+      local res = assert(client:send {
+        method = "GET",
+        path = "/hello"
+      })
+      local body = assert.res_status(200, res)
+      local json = cjson.decode(body)
+      assert.same(json, { hello = "from status api" })
+    end)
+  end)
+end)
+end

--- a/spec/fixtures/custom_plugins/kong/plugins/admin-api-method/status_api.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/admin-api-method/status_api.lua
@@ -1,0 +1,7 @@
+return {
+ ["/hello"] = {
+    GET = function()
+      kong.response.exit(200, { hello = "from status api" })
+    end,
+  },
+}

--- a/spec/fixtures/nginx-directives.conf
+++ b/spec/fixtures/nginx-directives.conf
@@ -5,3 +5,4 @@ nginx_stream_lua_shared_dict = custom_cache 5m
 nginx_proxy_proxy_bind = 127.0.0.1 transparent
 nginx_sproxy_proxy_bind = 127.0.0.1 transparent
 nginx_admin_server_tokens = off
+nginx_http_status_client_body_buffer_size = 8k


### PR DESCRIPTION
Problem
-------

Kong's Admin API exposes `/status` endpoint, which is consumed by other
services in the infrastructure to monitor Kong's health.

While this has worked for Kong for a long time,
we run into following issues with the current design:
- Users want to health-check Kong and also protect Kong's Admin API at
  the same time. If Kong's Admin API is protected using an auth plugin,
  health-checking becomes difficult. The reason being not all
  orchestration/platform tools performing health-checks support adding
  arbitrary headers to health-check requests.
- Users want to expose Kong's health outside a private network but keep
  the Admin API locked down.
- It is hard to perform HTTP based health-checks for a Kong node running
  only the proxy interface i.e. the Admin interface is disabled.
- A plugin could also potentially need to expose an endpoint which should not
  protected by any authentication.
  Prometheus plugin wants to expose `/metrics`, which should be not
  protected by any auth.
- Provision Kong Enterprise with RBAC enabled (health check won't pass):
  With Kong Enterprise, users want to enable RBAC from the get go,
  meaning when Kong is deployed, RBAC should be enabled. When this is
  done, health-checks for Kong using the current `/status` would fail
  (as we don't have any RBAC user while provisioning). This creates a
  chicken and egg where Kong needs to be up and running but that won't
  happen if status check is failing.

To work around this, users have resorted to injecting a custom server block
inside Kong using the NGINX directive injection feature, which adds
complexity and overhead in setting up Kong in a production environment.
Kong's Ingress Controller creates an additional file, mounts that as a volume
in the Docker container and then enables health-checking.

Health-checks and observability are common enough
(and simple for most deployments) that they should supported
out of the box and not require customizations.

Solution
--------

We introduce a `health` listener in Kong, which exposes insensitive health,
metrics and error read-only information from Kong.
Out of the box, only `/status` endpoint from Admin interface is available,
but plugins can add endpoints to this interface, as they can do for the Admin
interface.
This endpoint is strictly meant for machine-to-machine communication and
should not require any authentication/authorization.

The health server is disabled by default for
backwards-compatibility and not surprise existing users.