### PR TITLE
feat(key-auth) support auto-expiring keys through dao ttl

### DIFF
--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1063,6 +1063,7 @@ validate_fields = function(self, input)
   for k, v in pairs(input) do
     local err
     local field = self.fields[tostring(k)]
+    local is_ttl = k == "ttl" and self.ttl
     if field and field.type == "self" then
       local pok
       pok, err, errors[k] = pcall(self.validate_field, self, input, v)
@@ -1070,6 +1071,8 @@ validate_fields = function(self, input)
         errors[k] = validation_errors.SCHEMA_CANNOT_VALIDATE
         kong.log.debug(errors[k], ": ", err)
       end
+    elseif is_ttl then
+      kong.log.debug("ignoring validation on ttl field")
     else
       field, err = resolve_field(self, k, field, subschema)
       if field then
@@ -1604,8 +1607,11 @@ function Schema:process_auto_fields(data, context, nulls)
 
   elseif context == "select" then
     for key in pairs(data) do
+      -- set non defined fields to nil, except meta fields (ttl) if enabled
       if not self.fields[key] then
-        data[key] = nil
+        if not self.ttl or key ~= "ttl" then
+          data[key] = nil
+        end
       end
     end
   end

--- a/kong/db/strategies/cassandra/init.lua
+++ b/kong/db/strategies/cassandra/init.lua
@@ -127,6 +127,10 @@ local function build_queries(self)
     return nil, err
   end
 
+  if schema.ttl == true then
+    select_columns = select_columns .. fmt(", TTL(%s) as ttl", self.ttl_field())
+  end
+
   if partitioned then
     return {
       insert = fmt([[
@@ -512,6 +516,7 @@ function _M.new(connector, schema, errors)
 
   local each_pk_field
   local each_non_pk_field
+  local ttl_field
 
   do
     local non_pk_fields = new_tab(n_fields - n_pk, 0)
@@ -547,6 +552,10 @@ function _M.new(connector, schema, errors)
     each_non_pk_field = function()
       return iter, non_pk_fields, 0
     end
+
+    ttl_field = function()
+      return schema.ttl and non_pk_fields[1] and non_pk_fields[1].field_name
+    end
   end
 
   -- self instanciation
@@ -557,6 +566,7 @@ function _M.new(connector, schema, errors)
     errors                  = errors,
     each_pk_field           = each_pk_field,
     each_non_pk_field       = each_non_pk_field,
+    ttl_field               = ttl_field,
     foreign_keys_db_columns = {},
     queries                 = nil,
   }

--- a/kong/db/strategies/postgres/init.lua
+++ b/kong/db/strategies/postgres/init.lua
@@ -1325,6 +1325,13 @@ function _M.new(connector, schema, errors)
 
     upsert_expressions = concat(upsert_expressions, ", ")
 
+    select_expressions = concat {
+      select_expressions, ",",
+      "FLOOR(EXTRACT(EPOCH FROM (",
+        ttl_escaped, " AT TIME ZONE 'UTC' - CURRENT_TIMESTAMP AT TIME ZONE 'UTC'",
+      "))) AS ", ttl_escaped
+    }
+
     create_statement = concat {
       "CREATE TABLE IF NOT EXISTS ", table_name_escaped, " (\n",
       "  ",   concat(create_expressions, ",\n  "), "\n",

--- a/kong/plugins/key-auth/daos.lua
+++ b/kong/plugins/key-auth/daos.lua
@@ -2,6 +2,7 @@ local typedefs = require "kong.db.schema.typedefs"
 
 return {
   keyauth_credentials = {
+    ttl = true,
     primary_key = { "id" },
     name = "keyauth_credentials",
     endpoint_key = "key",

--- a/kong/plugins/key-auth/handler.lua
+++ b/kong/plugins/key-auth/handler.lua
@@ -20,7 +20,8 @@ local function load_credential(key)
   if not cred then
     return nil, err
   end
-  return cred
+
+  return cred, nil, cred.ttl
 end
 
 

--- a/kong/plugins/key-auth/migrations/002_130_to_140.lua
+++ b/kong/plugins/key-auth/migrations/002_130_to_140.lua
@@ -27,6 +27,13 @@ return {
         -- Do nothing, accept existing state
       END$$;
 
+      DO $$
+      BEGIN
+        ALTER TABLE IF EXISTS ONLY "keyauth_credentials" ADD "ttl" TIMESTAMP WITH TIME ZONE;
+      EXCEPTION WHEN DUPLICATE_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
+
     ]],
   },
   cassandra = {

--- a/kong/plugins/key-auth/migrations/002_130_to_140.lua
+++ b/kong/plugins/key-auth/migrations/002_130_to_140.lua
@@ -34,6 +34,13 @@ return {
         -- Do nothing, accept existing state
       END$$;
 
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS keyauth_credentials_ttl_idx ON keyauth_credentials (ttl);
+      EXCEPTION WHEN UNDEFINED_TABLE THEN
+        -- Do nothing, accept existing state
+      END$$;
+
     ]],
   },
   cassandra = {

--- a/kong/plugins/oauth2/migrations/003_130_to_140.lua
+++ b/kong/plugins/oauth2/migrations/003_130_to_140.lua
@@ -27,6 +27,20 @@ return {
         -- Do nothing, accept existing state
       END$$;
 
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS oauth2_authorization_codes_ttl_idx ON oauth2_authorization_codes (ttl);
+      EXCEPTION WHEN UNDEFINED_TABLE THEN
+        -- Do nothing, accept existing state
+      END$$;
+
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS oauth2_tokens_ttl_idx ON oauth2_tokens (ttl);
+      EXCEPTION WHEN UNDEFINED_TABLE THEN
+        -- Do nothing, accept existing state
+      END$$;
+
     ]],
   },
   cassandra = {

--- a/spec/03-plugins/09-key-auth/01-api_spec.lua
+++ b/spec/03-plugins/09-key-auth/01-api_spec.lua
@@ -119,6 +119,31 @@ for _, strategy in helpers.each_strategy() do
           assert.equal("tag1", json.tags[1])
           assert.equal("tag2", json.tags[2])
         end)
+        it("creates a key-auth credential with a ttl", function()
+          local res = assert(admin_client:send {
+            method  = "POST",
+            path    = "/consumers/bob/key-auth",
+            body    = {
+              ttl = 1,
+            },
+            headers = {
+              ["Content-Type"] = "application/json"
+            }
+          })
+          local body = assert.res_status(201, res)
+          local json = cjson.decode(body)
+          assert.equal(consumer.id, json.consumer.id)
+          assert.is_string(json.key)
+
+          ngx.sleep(3)
+
+          local id = json.consumer.id
+          local res = assert(admin_client:send {
+            method  = "GET",
+            path    = "/consumers/bob/key-auth/" .. id,
+          })
+          assert.res_status(404, res)
+        end)
       end)
 
       describe("GET", function()

--- a/spec/03-plugins/09-key-auth/02-access_spec.lua
+++ b/spec/03-plugins/09-key-auth/02-access_spec.lua
@@ -826,7 +826,8 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     describe("auto-expiring keys", function()
-      local ttl = 3
+      -- Give a bit of time to reduce test flakyness on slow setups
+      local ttl = 4
       local inserted_at
 
       lazy_setup(function()
@@ -889,7 +890,7 @@ for _, strategy in helpers.each_strategy() do
 
         ngx.update_time()
         local elapsed = ngx.now() - inserted_at
-        ngx.sleep(ttl - elapsed + 0.5) -- 0.5: jitter
+        ngx.sleep(ttl - elapsed + 1) -- 1: jitter
 
         res = assert(proxy_client:send {
           method  = "GET",


### PR DESCRIPTION
### Summary

Add support for keyauth credentials expiration by using metaschema ttl. Mainly based on https://github.com/Kong/kong/pull/4239, rebased and with the approach recommended on the comments.

The downside is the impossibility to differentiate between an invalid and an expired token. 

### Full changelog
> [ p0pr0ck5 commented on Jan 24](https://github.com/Kong/kong/pull/4239#issue-247234145)
> * Add ttl = true to keyauth credentials schema
> * Add migration for Postgres to add TTL column
> * Add API spec for added behavior
* Add dao support to return ttl on select queries for strategies
* Return entity ttl on keyauth cache callback
* Add API spec for listing ttl on keyauth admin endpoint

### Issues resolved

Fix #87
