### PR TITLE
feat(reports) add h2, h2c, tcp, and tls reports + removal of GRPC_MODES

### DIFF
--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -62,11 +62,6 @@ for p,_ in pairs(protocols_with_subsystem) do
 end
 table.sort(protocols)
 
-local grpc_proxy_modes = {
-  grpc = true,
-  grpcs = true,
-}
-
 return {
   BUNDLED_PLUGINS = plugin_map,
   DEPRECATED_PLUGINS = deprecated_plugin_map,
@@ -142,7 +137,6 @@ return {
   },
   PROTOCOLS = protocols,
   PROTOCOLS_WITH_SUBSYSTEM = protocols_with_subsystem,
-  GRPC_PROXY_MODES = grpc_proxy_modes,
   DEFAULT_ITERATION_SIZE = 1000,
   DEFAULT_PAGE_SIZE = 100,
   DEFAULT_CLUSTER_EVENTS_PAGE_SIZE = 1000,

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -113,8 +113,6 @@ local ffi = require "ffi"
 local cast = ffi.cast
 local voidpp = ffi.typeof("void**")
 
-local GRPC_PROXY_MODES = constants.GRPC_PROXY_MODES
-
 local TLS_SCHEMES = {
   https = true,
   tls = true,
@@ -670,7 +668,7 @@ function Kong.rewrite()
     log_init_worker_errors()
   end
 
-  if GRPC_PROXY_MODES[var.kong_proxy_mode] then
+  if var.kong_proxy_mode == "grpc" then
     kong_resty_ctx.apply_ref() -- if kong_proxy_mode is gRPC, this is executing
     kong_resty_ctx.stash_ref() -- after an internal redirect. Restore (and restash)
                                -- context to avoid re-executing phases

--- a/kong/reports.lua
+++ b/kong/reports.lua
@@ -4,13 +4,18 @@ local constants = require "kong.constants"
 
 
 local kong_dict = ngx.shared.kong
+local ngx = ngx
 local udp_sock = ngx.socket.udp
 local timer_at = ngx.timer.at
 local ngx_log = ngx.log
+local var = ngx.var
+local subsystem = ngx.config.subsystem
 local concat = table.concat
 local tostring = tostring
 local lower = string.lower
+local ipairs = ipairs
 local pairs = pairs
+local error = error
 local type = type
 local WARN = ngx.WARN
 local sub = string.sub
@@ -18,13 +23,23 @@ local sub = string.sub
 
 local PING_INTERVAL = 3600
 local PING_KEY = "events:reports"
+
+
 local REQUEST_COUNT_KEY       = "events:requests"
 local HTTP_REQUEST_COUNT_KEY  = "events:requests:http"
 local HTTPS_REQUEST_COUNT_KEY = "events:requests:https"
+local H2C_REQUEST_COUNT_KEY   = "events:requests:h2c"
+local H2_REQUEST_COUNT_KEY    = "events:requests:h2"
 local GRPC_REQUEST_COUNT_KEY  = "events:requests:grpc"
 local GRPCS_REQUEST_COUNT_KEY = "events:requests:grpcs"
 local WS_REQUEST_COUNT_KEY    = "events:requests:ws"
 local WSS_REQUEST_COUNT_KEY   = "events:requests:wss"
+
+
+local STREAM_COUNT_KEY        = "events:streams"
+local TCP_STREAM_COUNT_KEY    = "events:streams:tcp"
+local TLS_STREAM_COUNT_KEY    = "events:streams:tls"
+
 
 local _buffer = {}
 local _ping_infos = {}
@@ -199,29 +214,51 @@ local function incr_counter(key)
 end
 
 
--- returns a string indicating the "kind" of the current request:
--- "ws", "http", "https", "grpc", "grpcs"
+-- returns a string indicating the "kind" of the current request/stream:
+-- "http", "https", "h2c", "h2", "grpc", "grpcs", "ws", "wss", "tcp", "tls"
 -- or nil + error message if the suffix could not be determined
-local function get_current_request_suffix()
-  local var = ngx.var
-  local proxy_mode = var.kong_proxy_mode
+local function get_current_suffix()
+  if subsystem == "stream" then
+    if var.ssl_preread_protocol then
+      return "tls"
+    end
 
-  if proxy_mode == "grpc" or proxy_mode == "grpcs" then
-    return proxy_mode
+    return "tcp"
   end
 
   local scheme = var.scheme
-  local http_upgrade = var.http_upgrade
-  if http_upgrade and lower(http_upgrade) == "websocket" then
-    if scheme == "http" then
-      return "ws"
-    elseif scheme == "https" then
-      return "wss"
-    end
-  end
-
   if scheme == "http" or scheme == "https" then
-    return scheme
+    local proxy_mode = var.kong_proxy_mode
+    if proxy_mode == "http" then
+      local http_upgrade = var.http_upgrade
+      if http_upgrade and lower(http_upgrade) == "websocket" then
+        if scheme == "http" then
+          return "ws"
+        end
+
+        return "wss"
+      end
+
+      if ngx.req.http_version() == 2 then
+        if scheme == "http" then
+          return "h2c"
+        end
+
+        return "h2"
+      end
+
+      return scheme
+    end
+
+    if proxy_mode == "grpc" then
+      if scheme == "http" then
+        return "grpc"
+      end
+
+      if scheme == "https" then
+        return "grpcs"
+      end
+    end
   end
 
   return nil, "unknown request scheme: " .. tostring(scheme)
@@ -231,9 +268,25 @@ end
 local function send_ping(host, port)
   _ping_infos.unique_id = _unique_str
 
+  if subsystem == "stream" then
+    _ping_infos.streams     = get_counter(STREAM_COUNT_KEY)
+    _ping_infos.tcp_streams = get_counter(TCP_STREAM_COUNT_KEY)
+    _ping_infos.tls_streams = get_counter(TLS_STREAM_COUNT_KEY)
+
+    send_report("ping", _ping_infos, host, port)
+
+    reset_counter(STREAM_COUNT_KEY, _ping_infos.streams)
+    reset_counter(TCP_STREAM_COUNT_KEY, _ping_infos.tcp_streams)
+    reset_counter(TLS_STREAM_COUNT_KEY, _ping_infos.tls_streams)
+
+    return
+  end
+
   _ping_infos.requests   = get_counter(REQUEST_COUNT_KEY)
   _ping_infos.http_reqs  = get_counter(HTTP_REQUEST_COUNT_KEY)
   _ping_infos.https_reqs = get_counter(HTTPS_REQUEST_COUNT_KEY)
+  _ping_infos.h2c_reqs   = get_counter(H2C_REQUEST_COUNT_KEY)
+  _ping_infos.h2_reqs    = get_counter(H2_REQUEST_COUNT_KEY)
   _ping_infos.grpc_reqs  = get_counter(GRPC_REQUEST_COUNT_KEY)
   _ping_infos.grpcs_reqs = get_counter(GRPCS_REQUEST_COUNT_KEY)
   _ping_infos.ws_reqs    = get_counter(WS_REQUEST_COUNT_KEY)
@@ -244,6 +297,8 @@ local function send_ping(host, port)
   reset_counter(REQUEST_COUNT_KEY,       _ping_infos.requests)
   reset_counter(HTTP_REQUEST_COUNT_KEY,  _ping_infos.http_reqs)
   reset_counter(HTTPS_REQUEST_COUNT_KEY, _ping_infos.https_reqs)
+  reset_counter(H2C_REQUEST_COUNT_KEY,   _ping_infos.h2c_reqs)
+  reset_counter(H2_REQUEST_COUNT_KEY,    _ping_infos.h2_reqs)
   reset_counter(GRPC_REQUEST_COUNT_KEY,  _ping_infos.grpc_reqs)
   reset_counter(GRPCS_REQUEST_COUNT_KEY, _ping_infos.grpcs_reqs)
   reset_counter(WS_REQUEST_COUNT_KEY,    _ping_infos.ws_reqs)
@@ -317,8 +372,6 @@ local retrieve_redis_version
 
 do
   local _retrieved_redis_version = false
-
-
   retrieve_redis_version = function(red)
     if not _enabled or _retrieved_redis_version then
       return
@@ -369,10 +422,13 @@ return {
       return
     end
 
-    incr_counter(REQUEST_COUNT_KEY)
-    local suffix, err = get_current_request_suffix()
+    local count_key = subsystem == "stream" and STREAM_COUNT_KEY
+                                             or REQUEST_COUNT_KEY
+
+    incr_counter(count_key)
+    local suffix, err = get_current_suffix()
     if suffix then
-      incr_counter(REQUEST_COUNT_KEY .. ":" .. suffix)
+      incr_counter(count_key .. ":" .. suffix)
     else
       log(WARN, err)
     end

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -865,7 +865,13 @@ return {
 
   init_worker = {
     before = function()
-      reports.init_worker()
+      if kong.configuration.anonymous_reports then
+        reports.configure_ping(kong.configuration)
+        reports.add_ping_value("database_version", kong.db.infos.db_ver)
+        reports.toggle(true)
+        reports.init_worker()
+      end
+
       update_lua_mem(true)
 
       register_events()
@@ -1511,7 +1517,9 @@ return {
     after = function(ctx)
       update_lua_mem()
 
-      reports.log()
+      if kong.configuration.anonymous_reports then
+        reports.log()
+      end
 
       if not ctx.KONG_PROXIED then
         return

--- a/kong/runloop/plugins_iterator.lua
+++ b/kong/runloop/plugins_iterator.lua
@@ -1,6 +1,5 @@
 local BasePlugin   = require "kong.plugins.base_plugin"
 local constants    = require "kong.constants"
-local reports      = require "kong.reports"
 
 
 local kong         = kong
@@ -41,20 +40,7 @@ local loaded_plugins
 
 
 local function get_loaded_plugins()
-  local loaded = assert(kong.db.plugins:get_handlers())
-
-  if kong.configuration.anonymous_reports then
-    reports.configure_ping(kong.configuration)
-    reports.add_ping_value("database_version", kong.db.infos.db_ver)
-    reports.toggle(true)
-
-    loaded[#loaded + 1] = {
-      name = "reports",
-      handler = reports,
-    }
-  end
-
-  return loaded
+  return assert(kong.db.plugins:get_handlers())
 end
 
 

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -177,14 +177,14 @@ server {
     location @grpc {
         internal;
 
-        set $kong_proxy_mode       'grpc';
+        set $kong_proxy_mode  'grpc';
         grpc_pass grpc://kong_upstream;
     }
 
     location @grpcs {
         internal;
 
-        set $kong_proxy_mode       'grpcs';
+        set $kong_proxy_mode  'grpc';
         grpc_pass grpcs://kong_upstream;
     }
 

--- a/kong/templates/nginx_kong_stream.lua
+++ b/kong/templates/nginx_kong_stream.lua
@@ -1,4 +1,8 @@
 return [[
+> if anonymous_reports then
+${{SYSLOG_REPORTS}}
+> end
+
 log_format basic '$remote_addr [$time_local] '
                  '$protocol $status $bytes_sent $bytes_received '
                  '$session_time';

--- a/spec/fixtures/1.2_custom_nginx.template
+++ b/spec/fixtures/1.2_custom_nginx.template
@@ -195,30 +195,6 @@ http {
                 Kong.log()
             }
         }
-
-        location @grpc {
-            internal;
-            rewrite_by_lua_block       { Kong.rewrite() }
-            access_by_lua_block        { Kong.access() }
-            header_filter_by_lua_block { Kong.header_filter() }
-            body_filter_by_lua_block   { Kong.body_filter() }
-            log_by_lua_block           { Kong.log() }
-
-            set $kong_proxy_mode       'grpc';
-            grpc_pass grpc://kong_upstream;
-        }
-
-        location @grpcs {
-            internal;
-            rewrite_by_lua_block       { Kong.rewrite() }
-            access_by_lua_block        { Kong.access() }
-            header_filter_by_lua_block { Kong.header_filter() }
-            body_filter_by_lua_block   { Kong.body_filter() }
-            log_by_lua_block           { Kong.log() }
-
-            set $kong_proxy_mode       'grpcs';
-            grpc_pass grpcs://kong_upstream;
-        }
     }
 > end
 

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -485,6 +485,10 @@ http {
 
 > if #stream_listeners > 0 then
 stream {
+> if anonymous_reports then
+    ${{SYSLOG_REPORTS}}
+> end
+
     log_format basic '$remote_addr [$time_local] '
                      '$protocol $status $bytes_sent $bytes_received '
                      '$session_time';

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -160,6 +160,7 @@ http {
             set $upstream_x_forwarded_proto  '';
             set $upstream_x_forwarded_host   '';
             set $upstream_x_forwarded_port   '';
+            set $kong_proxy_mode             'http';
 
             proxy_http_version 1.1;
             proxy_set_header   Host              $upstream_host;
@@ -192,14 +193,14 @@ http {
         location @grpc {
             internal;
 
-            set $kong_proxy_mode       'grpc';
+            set $kong_proxy_mode  'grpc';
             grpc_pass grpc://kong_upstream;
         }
 
         location @grpcs {
             internal;
 
-            set $kong_proxy_mode       'grpcs';
+            set $kong_proxy_mode  'grpc';
             grpc_pass grpcs://kong_upstream;
         }
     }

--- a/spec/fixtures/custom_plugins/kong/plugins/reports-api/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/reports-api/handler.lua
@@ -1,5 +1,13 @@
-local ReportsApiHandler = {}
+local ReportsApiHandler = {
+  PRIORITY = 1000
+}
 
-ReportsApiHandler.PRIORITY = 1000
+function ReportsApiHandler:preread()
+  local reports = require "kong.reports"
+  reports.send_ping()
+  ngx.print("ok")
+  ngx.exit(200)
+end
+
 
 return ReportsApiHandler

--- a/spec/fixtures/custom_plugins/kong/plugins/reports-api/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/reports-api/schema.lua
@@ -1,4 +1,12 @@
 return {
   name = "reports-api",
-  fields = {},
+  fields = {
+    {
+      config = {
+        type = "record",
+        fields = {
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
### Summary

#### feat(reports) add h2, h2c, tcp, and tls reports 

- Adds stream reports and makes h2 and h2c reports available
- Also makes kong.reports safe for running it with stream module
- Removes excess code from plugins iterator where "reports" plugin was added to loaded plugins (it is not used) and moved reports initialization code to runloop

#### refactor(conf) change grpc proxy modes always to be just grpc

Removes need to have GRPC_PROXY_MODES, e.g. "grpc" and "grpcs", and makes the mode consistent on what we have for "http" where we don't have "https", "h2" or "h2c".

### Fixes

Fixes issue where `kong.reports` didn't work correctly on `stream`, as pointed out in this comment: https://github.com/Kong/kong/issues/4975#issue-486338205