### PR TITLE
jwt credential does not have "username" but "key"

### DIFF
--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -80,6 +80,7 @@ return {
     CONSUMER_CUSTOM_ID = "X-Consumer-Custom-ID",
     CONSUMER_USERNAME = "X-Consumer-Username",
     CREDENTIAL_USERNAME = "X-Credential-Username",
+    CREDENTIAL_IDENTIFIER = "X-Credential-Identifier",
     RATELIMIT_LIMIT = "X-RateLimit-Limit",
     RATELIMIT_REMAINING = "X-RateLimit-Remaining",
     CONSUMER_GROUPS = "X-Consumer-Groups",

--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -116,7 +116,7 @@ local function set_consumer(consumer, credential, token)
     kong.ctx.shared.authenticated_jwt_token = token -- TODO: wrap in a PDK function?
     ngx.ctx.authenticated_jwt_token = token  -- backward compatibilty only
 
-    if credential.username then
+    if credential.key then
       set_header(constants.HEADERS.CREDENTIAL_USERNAME, credential.key)
     else
       clear_header(constants.HEADERS.CREDENTIAL_USERNAME)

--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -117,7 +117,7 @@ local function set_consumer(consumer, credential, token)
     ngx.ctx.authenticated_jwt_token = token  -- backward compatibilty only
 
     if credential.username then
-      set_header(constants.HEADERS.CREDENTIAL_USERNAME, credential.username)
+      set_header(constants.HEADERS.CREDENTIAL_USERNAME, credential.key)
     else
       clear_header(constants.HEADERS.CREDENTIAL_USERNAME)
     end

--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -117,15 +117,15 @@ local function set_consumer(consumer, credential, token)
     ngx.ctx.authenticated_jwt_token = token  -- backward compatibilty only
 
     if credential.key then
-      set_header(constants.HEADERS.CREDENTIAL_USERNAME, credential.key)
+      set_header(constants.HEADERS.CREDENTIAL_IDENTIFIER, credential.key)
     else
-      clear_header(constants.HEADERS.CREDENTIAL_USERNAME)
+      clear_header(constants.HEADERS.CREDENTIAL_IDENTIFIER)
     end
 
     clear_header(constants.HEADERS.ANONYMOUS)
 
   else
-    clear_header(constants.HEADERS.CREDENTIAL_USERNAME)
+    clear_header(constants.HEADERS.CREDENTIAL_IDENTIFIER)
     set_header(constants.HEADERS.ANONYMOUS, true)
   end
 end


### PR DESCRIPTION
### Summary

The jwt credential according to its database definition, does not have username but key. The key can be used to represents the authenticated jwt_credential.

### Full changelog

* X-Credential-Username is correctly set

### Issues resolved
X-Credential-Username is correctly set with jwt credential.key (i.e. iss - jwt issuer) which represents the authenticated jwt credential. Therefore other plugins relying on X-Credential-Username will work.

Fix #XXX
