### PR TITLE
refactor(proxy) make latency header counting more robust and consistent

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1,12 +1,5 @@
 -- Kong runloop
---
--- This consists of local_events that need to
--- be ran at the very beginning and very end of the lua-nginx-module contexts.
--- It mainly carries information related to a request from one context to the next one,
--- through the `ngx.ctx` table.
---
--- In the `access_by_lua` phase, it is responsible for retrieving the route being proxied by
--- a consumer. Then it is responsible for loading the plugins to execute on this request.
+
 local ck           = require "resty.cookie"
 local meta         = require "kong.meta"
 local utils        = require "kong.tools.utils"
@@ -33,19 +26,15 @@ local find         = string.find
 local lower        = string.lower
 local fmt          = string.format
 local ngx          = ngx
-local arg          = ngx.arg
 local var          = ngx.var
 local log          = ngx.log
 local exit         = ngx.exit
 local header       = ngx.header
-local ngx_now      = ngx.now
 local timer_at     = ngx.timer.at
 local timer_every  = ngx.timer.every
 local re_match     = ngx.re.match
 local re_find      = ngx.re.find
-local update_time  = ngx.update_time
 local subsystem    = ngx.config.subsystem
-local start_time   = ngx.req.start_time
 local clear_header = ngx.req.clear_header
 local starttls     = ngx.req.starttls -- luacheck: ignore
 local unpack       = unpack
@@ -109,12 +98,6 @@ do
       last = ngx.time()
     end
   end
-end
-
-
-local function get_now()
-  update_time()
-  return ngx_now() * 1000 -- time is kept in seconds with millisecond resolution.
 end
 
 
@@ -952,8 +935,6 @@ return {
   },
   rewrite = {
     before = function(ctx)
-      ctx.KONG_REWRITE_START = get_now()
-
       -- special handling for proxy-authorization and te headers in case
       -- the plugin(s) want to specify them (store the original)
       ctx.http_proxy_authorization = var.http_proxy_authorization
@@ -961,9 +942,6 @@ return {
 
       mesh.rewrite(ctx)
     end,
-    after = function(ctx)
-      ctx.KONG_REWRITE_TIME = get_now() - ctx.KONG_REWRITE_START -- time spent in Kong's rewrite_by_lua
-    end
   },
   preread = {
     before = function(ctx)
@@ -1012,8 +990,6 @@ return {
         return exit(ERROR)
       end
 
-      ctx.KONG_PREREAD_START = get_now()
-
       local route = match_t.route
       local service = match_t.service
       local upstream_url_t = match_t.upstream_url_t
@@ -1044,16 +1020,6 @@ return {
         local body = utils.get_default_exit_body(errcode, err)
         return kong.response.exit(errcode, body)
       end
-
-      local now = get_now()
-
-      -- time spent in Kong's preread_by_lua
-      ctx.KONG_PREREAD_TIME     = now - ctx.KONG_PREREAD_START
-      ctx.KONG_PREREAD_ENDED_AT = now
-      -- time spent in Kong before sending the request to upstream
-      -- start_time() is kept in seconds with millisecond resolution.
-      ctx.KONG_PROXY_LATENCY   = now - start_time() * 1000
-      ctx.KONG_PROXIED         = true
     end
   },
   access = {
@@ -1068,9 +1034,6 @@ return {
 
       -- routing request
       local router = get_updated_router()
-
-      ctx.KONG_ACCESS_START = get_now()
-
       local match_t = router.exec()
       if not match_t then
         return kong.response.exit(404, { message = "no Route matched with those values" })
@@ -1389,34 +1352,6 @@ return {
          proxy_authorization == var.http_proxy_authorization then
         clear_header("Proxy-Authorization")
       end
-
-      local now = get_now()
-
-      -- time spent in Kong's access_by_lua
-      ctx.KONG_ACCESS_TIME     = now - ctx.KONG_ACCESS_START
-      ctx.KONG_ACCESS_ENDED_AT = now
-      -- time spent in Kong before sending the request to upstream
-      -- start_time() is kept in seconds with millisecond resolution.
-      ctx.KONG_PROXY_LATENCY   = now - start_time() * 1000
-      ctx.KONG_PROXIED         = true
-    end
-  },
-  balancer = {
-    before = function(ctx)
-      local balancer_data = ctx.balancer_data
-      local current_try = balancer_data.tries[balancer_data.try_count]
-      current_try.balancer_start = get_now()
-    end,
-    after = function(ctx)
-      local balancer_data = ctx.balancer_data
-      local current_try = balancer_data.tries[balancer_data.try_count]
-
-      -- record try-latency
-      local try_latency = get_now() - current_try.balancer_start
-      current_try.balancer_latency = try_latency
-
-      -- record overall latency
-      ctx.KONG_BALANCER_TIME = (ctx.KONG_BALANCER_TIME or 0) + try_latency
     end
   },
   header_filter = {
@@ -1424,11 +1359,6 @@ return {
       if not ctx.KONG_PROXIED then
         return
       end
-
-      local now = get_now()
-      -- time spent waiting for a response from upstream
-      ctx.KONG_WAITING_TIME             = now - ctx.KONG_ACCESS_ENDED_AT
-      ctx.KONG_HEADER_FILTER_STARTED_AT = now
 
       -- clear hop-by-hop response headers:
       for _, header_name in csv(var.upstream_http_connection) do
@@ -1493,23 +1423,6 @@ return {
         else
           header[constants.HEADERS.SERVER] = nil
         end
-      end
-    end
-  },
-  body_filter = {
-    after = function(ctx)
-      if not arg[2] then
-        return
-      end
-
-      local now = get_now()
-      ctx.KONG_BODY_FILTER_ENDED_AT = now
-
-      if ctx.KONG_PROXIED then
-        -- time spent receiving the response (header_filter + body_filter)
-        -- we could use $upstream_response_time but we need to distinguish the waiting time
-        -- from the receiving time in our logging plugins (especially ALF serializer).
-        ctx.KONG_RECEIVE_TIME = now - ctx.KONG_HEADER_FILTER_STARTED_AT
       end
     end
   },

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -84,6 +84,8 @@ do
   local LUA_MEM_SAMPLE_RATE = 10 -- seconds
   local last = ngx.time()
 
+  local collectgarbage = collectgarbage
+
   update_lua_mem = function(force)
     local time = ngx.time()
 
@@ -418,8 +420,6 @@ local function register_events()
       cache:flip()
     end, "declarative", "flip_config")
   end
-
-
 end
 
 
@@ -519,6 +519,7 @@ do
   local router
   local router_version
 
+
   local function should_process_route(route)
     for _, protocol in ipairs(route.protocols) do
       if SUBSYSTEMS[protocol] == subsystem then
@@ -603,6 +604,7 @@ do
 
     return service
   end
+
 
   build_router = function(version)
     local db = kong.db
@@ -928,21 +930,6 @@ return {
 
     end
   },
-  certificate = {
-    before = function(_)
-      certificate.execute()
-    end
-  },
-  rewrite = {
-    before = function(ctx)
-      -- special handling for proxy-authorization and te headers in case
-      -- the plugin(s) want to specify them (store the original)
-      ctx.http_proxy_authorization = var.http_proxy_authorization
-      ctx.http_te                  = var.http_te
-
-      mesh.rewrite(ctx)
-    end,
-  },
   preread = {
     before = function(ctx)
       local router = get_updated_router()
@@ -1021,6 +1008,21 @@ return {
         return kong.response.exit(errcode, body)
       end
     end
+  },
+  certificate = {
+    before = function(_)
+      certificate.execute()
+    end
+  },
+  rewrite = {
+    before = function(ctx)
+      -- special handling for proxy-authorization and te headers in case
+      -- the plugin(s) want to specify them (store the original)
+      ctx.http_proxy_authorization = var.http_proxy_authorization
+      ctx.http_te                  = var.http_te
+
+      mesh.rewrite(ctx)
+    end,
   },
   access = {
     before = function(ctx)


### PR DESCRIPTION
### Summary

This PR moves latency counting from `handler.lua` to `init.lua` to provide a more consistent counting of latency headers as more and more stuff has been added to `init.lua` which is not accounted in latency counting. Also proxy-latency counting now takes the balancer phase in
counting too, which was not a case before this PR.

The PR tries to make header counting resilient on errors, ngx.exec / ngx.exit, etc. too, and that's why it might look a bit strange why a lot of this counting is re-checked on later phases.

Part of this refactoring some of the code was moved from `handler.lua` to `init.lua`, most notable it didn't make sense to keep `balancer.before` and `balancer.after` anymore in `handler.lua`.

It also contains other commit:

**refactor(proxy) chronological order the functions in init/handler.lua**

Makes it easier to follow the code when the functions in init.lua and handler.lua are ordered chronologically according to Nginx rules of phase execution. Less going back and forth with code.

### Fixes

#4785

**DO NOT MERGE YET, BUT PLEASE REVIEW AS THIS IS NOW BASED TO `fix/grpc-modes` (I will change it to be based on `next` after #4989 gets merged.**