### PR TITLE
fix(cmd) make sure to load the configuration from kong.conf file.

### DIFF
--- a/kong/cmd/reload.lua
+++ b/kong/cmd/reload.lua
@@ -15,7 +15,7 @@ local function execute(args)
          "no such prefix: " .. default_conf.prefix)
 
   -- load <PREFIX>/kong.conf containing running node's config
-  local conf = assert(conf_loader(default_conf.kong_env, {
+  local conf = assert(conf_loader(args.conf, {
     prefix = args.prefix
   }))
   assert(prefix_handler.prepare_prefix(conf, args.nginx_conf))


### PR DESCRIPTION
### Summary

Originally only reloaded configuration from the .kong.env file, if modify the contents of the kong.conf file,  only regenerate .kong.env file through kong prepare command, and then execute kong reload command to reload.

This PR will simplify the process, kong reload command can regenerate .kong.env file and auto reload it, no need to execute kong prepare command.


