### PR TITLE
fix(admin) allow put requests to nonexistent foreign entities

### DIFF
--- a/kong/api/endpoints.lua
+++ b/kong/api/endpoints.lua
@@ -210,24 +210,26 @@ local function query_entity(context, self, db, schema, method)
   end
 
   local key = self.params[schema.name]
-  if type(key) ~= "table" then
-    if type(key) == "string" then
-      key = { id = unescape_uri(key) }
-    else
-      key = { id = key }
-    end
-  end
-
-  if not utils.is_valid_uuid(key.id) then
-    local endpoint_key = schema.endpoint_key
-    if endpoint_key then
-      local field = schema.fields[endpoint_key]
-      local inferred_value = arguments.infer_value(key.id, field)
-      if is_update then
-        return dao[method or context .. "_by_" .. endpoint_key](dao, inferred_value, args, opts)
+  if key then
+    if type(key) ~= "table" then
+      if type(key) == "string" then
+        key = { id = unescape_uri(key) }
+      else
+        key = { id = key }
       end
+    end
 
-      return dao[method or context .. "_by_" .. endpoint_key](dao, inferred_value, opts)
+    if key.id and not utils.is_valid_uuid(key.id) then
+      local endpoint_key = schema.endpoint_key
+      if endpoint_key then
+        local field = schema.fields[endpoint_key]
+        local inferred_value = arguments.infer_value(key.id, field)
+        if is_update then
+          return dao[method or context .. "_by_" .. endpoint_key](dao, inferred_value, args, opts)
+        end
+
+        return dao[method or context .. "_by_" .. endpoint_key](dao, inferred_value, opts)
+      end
     end
   end
 
@@ -491,30 +493,53 @@ local function put_entity_endpoint(schema, foreign_schema, foreign_field_name, m
       return not_found()
     end
 
+    local associate
     local inverse = not foreign_schema.fields[foreign_field_name] and
                                 schema.fields[foreign_field_name]
 
     if inverse then
       local pk = entity[foreign_field_name]
-      if not pk or pk == null then
-        return not_found()
+      if pk and pk ~= null then
+        self.params[foreign_schema.name] = pk
+      else
+        associate = true
+        self.params[foreign_schema.name] = utils.uuid()
       end
 
-      self.params[foreign_schema.name] = pk
     else
       self.args.post[foreign_field_name] = schema:extract_pk_values(entity)
     end
 
-    entity, _, err_t = upsert_entity(self, db, foreign_schema, method)
+    local foreign_entity
+    foreign_entity, _, err_t = upsert_entity(self, db, foreign_schema, method)
     if err_t then
       return handle_error(err_t)
     end
 
-    if not entity then
+    if not foreign_entity then
       return not_found()
     end
 
-    return ok(entity)
+    if associate then
+      local pk = schema:extract_pk_values(entity)
+      local data = {
+        [foreign_field_name] = foreign_schema:extract_pk_values(foreign_entity)
+      }
+
+      _, _, err_t = db[schema.name]:update(pk, data)
+      if err_t then
+        return handle_error(err_t)
+      end
+
+      --if not entity then
+        -- route was deleted after service was created,
+        -- so we cannot associate anymore. perhaps not
+        -- worth it to handle, the service on the other
+        -- hand was updates just fine.
+      --end
+    end
+
+    return ok(foreign_entity)
   end
 end
 


### PR DESCRIPTION
[Issue]

PUT method is not working as documented when creating a Service object.

[Details]

Per following document, it is supposed that users could create a Service associated to a Route object using the PUT method:

– Create Or Update Service Associated to a Specific Route
https://docs.konghq.com/1.2.x/admin-api/#create-or-update-service-associated-to-a-specific-route

However, the Admin API returns 404 when trying to perform the above operation.

[Steps to reproduce]

Create a new Route object

```
$ http POST http://sanfrancisco:36201/routes name=testrt001 paths:='["/testrt001"]'
HTTP/1.1 201 Created
Access-Control-Allow-Credentials: true
Access-Control-Allow-Origin: http://sanfrancisco:36202
Connection: keep-alive
Content-Length: 359
Content-Type: application/json; charset=utf-8
Date: Fri, 30 Aug 2019 04:00:08 GMT
Server: kong/0.36-2-internal-preview-enterprise-edition
Vary: Origin
X-Kong-Admin-Request-ID: XyW7oJpIvY6ILXCCbPXexCt5kVBRcVUi

{
    "created_at": 1567137608,
    "destinations": null,
    "hosts": null,
    "https_redirect_status_code": 426,
    "id": "18653402-75ba-4502-bb05-59447410acda",
    "methods": null,
    "name": "testrt001",
    "paths": [
        "/testrt001"
    ],
    "preserve_host": false,
    "protocols": [
        "http",
        "https"
    ],
    "regex_priority": 0,
    "service": null,
    "snis": null,
    "sources": null,
    "strip_path": true,
    "tags": null,
    "updated_at": 1567137608
}
```

Create a new Service associated to this Route using the PUT method fails

```
$ http PUT http://sanfrancisco:36201/routes/testrt001/service name=demoapp url=http://httpbin.org/
HTTP/1.1 404 Not Found
Access-Control-Allow-Credentials: true
Access-Control-Allow-Origin: http://sanfrancisco:36202
Connection: keep-alive
Content-Length: 23
Content-Type: application/json; charset=utf-8
Date: Fri, 30 Aug 2019 04:01:18 GMT
Server: kong/0.36-2-internal-preview-enterprise-edition
Vary: Origin
X-Kong-Admin-Request-ID: XX8RXYlth0DMUOnrmppCRNij9QsUihSk

{
    "message": "Not found"
}
$ http PUT http://sanfrancisco:36201/routes/18653402-75ba-4502-bb05-59447410acda/service name=demoapp url=http://httpbin.org/
HTTP/1.1 404 Not Found
Access-Control-Allow-Credentials: true
Access-Control-Allow-Origin: http://sanfrancisco:36202
Connection: keep-alive
Content-Length: 23
Content-Type: application/json; charset=utf-8
Date: Fri, 30 Aug 2019 04:01:39 GMT
Server: kong/0.36-2-internal-preview-enterprise-edition
Vary: Origin
X-Kong-Admin-Request-ID: eTw28IcLpAAikk48vM2V9rxWYZHzSeQ8

{
    "message": "Not found"
}
```

### Summary

fix(admin) allow put requests to nonexistent foreign entities

e.g. `PUT /routes/my-route/service` in case the `my-route` has
no `service` association currently (the service being set to `null`).

tests(admin) allow put requests to nonexistent foreign entities

### Full changelog

* allow put requests to nonexistent foreign entities
* add tests to see if put requests are allowed to nonexistent foreign entities

### Issues resolved

Fix FT-944
