### PR TITLE
feat(api) list available endpoints

### DIFF
--- a/kong/api/routes/kong.lua
+++ b/kong/api/routes/kong.lua
@@ -92,6 +92,23 @@ return {
       })
     end
   },
+  ["/endpoints"] = {
+    GET = function(self, dao, helpers)
+      local endpoints = setmetatable({}, cjson.array_mt)
+      local lapis_endpoints = require("kong.api").ordered_routes
+
+      for k, v in pairs(lapis_endpoints) do
+        if type(k) == "string" then -- skip numeric indices
+          endpoints[#endpoints + 1] = k:gsub(":([^/:]+)", function(m)
+              return "{" .. m .. "}"
+            end)
+        end
+      end
+      table.sort(endpoints)
+
+      return kong.response.exit(200, endpoints)
+    end
+  },
   ["/schemas/:name"] = {
     GET = function(self, db, helpers)
       local entity = kong.db[self.params.name]

--- a/kong/api/routes/kong.lua
+++ b/kong/api/routes/kong.lua
@@ -104,7 +104,20 @@ return {
             end)
         end
       end
-      table.sort(endpoints)
+      table.sort(endpoints, function(a, b)
+        -- when sorting use lower-ascii char for "/" to enable segment based
+        -- sorting, so not this:
+        --   /a
+        --   /ab
+        --   /ab/a
+        --   /a/z
+        -- But this:
+        --   /a
+        --   /a/z
+        --   /ab
+        --   /ab/a
+        return a:gsub("/", "\x00") < b:gsub("/", "\x00")
+      end)
 
       return kong.response.exit(200, endpoints)
     end


### PR DESCRIPTION
All endpoints will be listed under the "/endpoints" path of the
management API.

With auto-generated endpoints it might not always be clear what
is available. By listing the user can see what the system has
available. Especially when adding additional plugins, that might
not always be properly documented.

here's an example of the additional output:
```json
    [
        "/",
        "/acls",
        "/acls/{acls}",
        "/acls/{acls}/consumer",
        "/basic-auths",
        "/basic-auths/{basicauth_credentials}",
        "/basic-auths/{basicauth_credentials}/consumer",
        "/ca_certificates",
        "/ca_certificates/{ca_certificates}",
        "/cache",
        "/cache/{key}",
        "/certificates",
        "/certificates/{certificates}",
        "/certificates/{certificates}/services",
        "/certificates/{certificates}/services/{services}",
        "/certificates/{certificates}/snis",
        "/certificates/{certificates}/snis/{snis}",
        "/config",
        "/consumers",
        "/consumers/{consumers}",
        "/consumers/{consumers}/acls",
        "/consumers/{consumers}/acls/{acls}",
        "/consumers/{consumers}/basic-auth",
        "/consumers/{consumers}/basic-auth/{basicauth_credentials}",
        "/consumers/{consumers}/hmac-auth",
        "/consumers/{consumers}/hmac-auth/{hmacauth_credentials}",
        "/consumers/{consumers}/jwt",
        "/consumers/{consumers}/jwt/{jwt_secrets}",
        "/consumers/{consumers}/key-auth",
        "/consumers/{consumers}/key-auth/{keyauth_credentials}",
        "/consumers/{consumers}/oauth2",
        "/consumers/{consumers}/oauth2/{oauth2_credentials}",
        "/consumers/{consumers}/plugins",
        "/consumers/{consumers}/plugins/{plugins}",
        "/hmac-auths",
        "/hmac-auths/{hmacauth_credentials}",
        "/hmac-auths/{hmacauth_credentials}/consumer",
        "/jwts",
        "/jwts/{jwt_secrets}",
        "/jwts/{jwt_secrets}/consumer",
        "/key-auths",
        "/key-auths/{keyauth_credentials}",
        "/key-auths/{keyauth_credentials}/consumer",
        "/kubernetes-sidecar-injector",
        "/metrics",
        "/oauth2",
        "/oauth2/{oauth2_credentials}",
        "/oauth2/{oauth2_credentials}/consumer",
        "/oauth2/{oauth2_credentials}/oauth2_tokens",
        "/oauth2/{oauth2_credentials}/oauth2_tokens/{oauth2_tokens}",
        "/oauth2_tokens",
        "/oauth2_tokens/{oauth2_tokens}",
        "/oauth2_tokens/{oauth2_tokens}/credential",
        "/oauth2_tokens/{oauth2_tokens}/service",
        "/plugins",
        "/plugins/enabled",
        "/plugins/schema/{name}",
        "/plugins/{plugins}",
        "/plugins/{plugins}/consumer",
        "/plugins/{plugins}/route",
        "/plugins/{plugins}/service",
        "/proxy-cache",
        "/proxy-cache/{cache_key}",
        "/proxy-cache/{plugin_id}/caches/{cache_key}",
        "/routes",
        "/routes/{routes}",
        "/routes/{routes}/plugins",
        "/routes/{routes}/plugins/{plugins}",
        "/routes/{routes}/service",
        "/schemas/plugins/{name}",
        "/schemas/{db_entity_name}/validate",
        "/schemas/{name}",
        "/services",
        "/services/{services}",
        "/services/{services}/client_certificate",
        "/services/{services}/oauth2_tokens",
        "/services/{services}/oauth2_tokens/{oauth2_tokens}",
        "/services/{services}/plugins",
        "/services/{services}/plugins/{plugins}",
        "/services/{services}/routes",
        "/services/{services}/routes/{routes}",
        "/sessions",
        "/sessions/{sessions}",
        "/snis",
        "/snis/{snis}",
        "/snis/{snis}/certificate",
        "/status",
        "/tags",
        "/tags/{tags}",
        "/targets",
        "/targets/{targets}",
        "/targets/{targets}/upstream",
        "/upstreams",
        "/upstreams/{upstreams}",
        "/upstreams/{upstreams}/health",
        "/upstreams/{upstreams}/targets",
        "/upstreams/{upstreams}/targets/all",
        "/upstreams/{upstreams}/targets/{targets}",
        "/upstreams/{upstreams}/targets/{targets}/healthy",
        "/upstreams/{upstreams}/targets/{targets}/unhealthy",
        "/upstreams/{upstreams}/targets/{targets}/{address}/healthy",
        "/upstreams/{upstreams}/targets/{targets}/{address}/unhealthy"
    ]
```

UPDATE: adjusted the description from `/` to `/endpoints` after review comments