### PR TITLE
chore(ci) add the ability to use the Kong CI setup from external repositories

### DIFF
--- a/.ci/setup_env.sh
+++ b/.ci/setup_env.sh
@@ -6,7 +6,11 @@
 #---------
 
 DEPS_HASH=$(cat .ci/setup_env.sh .travis.yml | md5sum | awk '{ print $1 }')
+DOWNLOAD_ROOT=${DOWNLOAD_ROOT:=/download-root}
 BUILD_TOOLS_DOWNLOAD=$DOWNLOAD_ROOT/openresty-build-tools
+
+KONG_NGINX_MODULE_BRANCH=${KONG_NGINX_MODULE_BRANCH:=master}
+OPENRESTY_PATCHES_BRANCH=${OPENRESTY_PATCHES_BRANCH:=master}
 
 git clone https://github.com/Kong/openresty-build-tools.git $DOWNLOAD_ROOT/openresty-build-tools
 export PATH=$BUILD_TOOLS_DOWNLOAD:$PATH
@@ -14,7 +18,10 @@ export PATH=$BUILD_TOOLS_DOWNLOAD:$PATH
 #--------
 # Install
 #--------
+INSTALL_CACHE=${INSTALL_CACHE:=/install-cache}
 INSTALL_ROOT=$INSTALL_CACHE/$DEPS_HASH
+
+ln -s $INSTALL_CACHE/$DEPS_HASH $HOME/kong
 
 kong-ngx-build \
     --work $DOWNLOAD_ROOT \

--- a/.ci/setup_env.sh
+++ b/.ci/setup_env.sh
@@ -21,8 +21,6 @@ export PATH=$BUILD_TOOLS_DOWNLOAD:$PATH
 INSTALL_CACHE=${INSTALL_CACHE:=/install-cache}
 INSTALL_ROOT=$INSTALL_CACHE/$DEPS_HASH
 
-ln -s $INSTALL_CACHE/$DEPS_HASH $HOME/kong
-
 kong-ngx-build \
     --work $DOWNLOAD_ROOT \
     --prefix $INSTALL_ROOT \

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,8 @@ addons:
 
 env:
   global:
-    - LUAROCKS=3.1.3
-    - OPENSSL=1.1.1c
-    - OPENRESTY=1.15.8.1
-    - DOWNLOAD_ROOT=$HOME/download-root
     - INSTALL_CACHE=$HOME/install-cache
-    - OPENRESTY_PATCHES_BRANCH=master
-    - KONG_NGINX_MODULE_BRANCH=master
+    - DOWNLOAD_ROOT=$HOME/download-root
     - KONG_TEST_PG_DATABASE=travis
     - KONG_TEST_PG_USER=postgres
     - JOBS=2
@@ -48,12 +43,12 @@ env:
     - TEST_SUITE=pdk
 
 install:
+  - make setup-ci
   - source .ci/setup_env.sh
   - make dev
 
 cache:
   apt: true
-  pip: true
   directories:
     - $INSTALL_CACHE
     - $HOME/.ccm/repository

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,17 @@ RESTY_OPENSSL_VERSION ?= `grep RESTY_OPENSSL_VERSION $(KONG_SOURCE_LOCATION)/.re
 RESTY_PCRE_VERSION ?= `grep RESTY_PCRE_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
 KONG_BUILD_TOOLS ?= '2.0.1'
 KONG_VERSION ?= `cat $(KONG_SOURCE_LOCATION)/kong-*.rockspec | grep tag | awk '{print $$3}' | sed 's/"//g'`
+OPENRESTY_PATCHES_BRANCH ?= master
+KONG_NGINX_MODULE_BRANCH ?= master
+
+.PHONY: setup-ci
+setup-ci:
+	OPENRESTY=$(RESTY_VERSION) \
+	LUAROCKS=$(RESTY_LUAROCKS_VERSION) \
+	OPENSSL=$(RESTY_OPENSSL_VERSION) \
+	OPENRESTY_PATCHES_BRANCH=$($OPENRESTY_PATCHES_BRANCH) \
+	KONG_NGINX_MODULE_BRANCH=$(KONG_NGINX_MODULE_BRANCH) \
+	.ci/setup_env.sh
 
 setup-kong-build-tools:
 	-rm -rf kong-build-tools; \

--- a/spec/02-integration/05-proxy/02-router_spec.lua
+++ b/spec/02-integration/05-proxy/02-router_spec.lua
@@ -386,7 +386,7 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       it("restricts a route to its 'hosts' if specified", function()
-        local ok, resp = proxy_client_grpc({
+        local ok, resp = assert(proxy_client_grpc({
           service = "hello.HelloService.SayHello",
           body = {
             greeting = "world!"
@@ -396,7 +396,7 @@ for _, strategy in helpers.each_strategy() do
             ["-H"] = "'kong-debug: 1'",
             ["-authority"] = "grpc1",
           }
-        })
+        }))
         assert.truthy(ok)
         assert.truthy(resp)
         assert.matches("kong-route-id: " .. routes[1].id, resp, nil, true)

--- a/spec/02-integration/05-proxy/02-router_spec.lua
+++ b/spec/02-integration/05-proxy/02-router_spec.lua
@@ -386,7 +386,7 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       it("restricts a route to its 'hosts' if specified", function()
-        local ok, resp = assert(proxy_client_grpc({
+        local ok, resp = proxy_client_grpc({
           service = "hello.HelloService.SayHello",
           body = {
             greeting = "world!"
@@ -396,7 +396,7 @@ for _, strategy in helpers.each_strategy() do
             ["-H"] = "'kong-debug: 1'",
             ["-authority"] = "grpc1",
           }
-        }))
+        })
         assert.truthy(ok)
         assert.truthy(resp)
         assert.matches("kong-route-id: " .. routes[1].id, resp, nil, true)


### PR DESCRIPTION
Purpose of this cut / paste is to relocate the setup CI logic into a Make task such that it can be reused in other repositories.

Applied sensible defaults in the bash script which can be overridden by environment variables to keep backwards compatibility

Reference: https://github.com/Kong/openresty-patches/pull/55