### PR TITLE
fix(declarative) reduce events while loading declarative configs

### DIFF
--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -298,41 +298,6 @@ local function remove_nulls(tbl)
 end
 
 
-local function nil_fn()
-  return nil
-end
-
-
-local function post_upstream_crud_delete_events()
-  local upstreams = kong.cache:get("upstreams|list", nil, nil_fn)
-  if upstreams then
-    for _, id in ipairs(upstreams) do
-      local ok = kong.worker_events.post("crud", "upstreams", {
-        operation = "delete",
-        entity = {
-          id = id,
-          name = "?", -- only used for error messages
-        },
-      })
-      if not ok then
-        kong.log.err("failed posting invalidation event for upstream ", id)
-      end
-    end
-  end
-end
-
-
-local function post_crud_create_event(entity_name, item)
-  local ok = kong.worker_events.post("crud", entity_name, {
-    operation = "create",
-    entity = item,
-  })
-  if not ok then
-    kong.log.err("failed posting crud event for ", entity_name, " ", entity_name.id)
-  end
-end
-
-
 function declarative.get_current_hash()
   return ngx.shared.kong:get("declarative_config:hash")
 end
@@ -494,7 +459,13 @@ function declarative.load_into_cache_with_events(entities, hash)
     return nil, err
   end
 
-  post_upstream_crud_delete_events()
+  ok, err = kong.worker_events.post("balancer", "upstreams", {
+    operation = "delete_all",
+    entity = { id = "all", name = "all" }
+  })
+  if not ok then
+    return nil, err
+  end
 
   ok, err = declarative.load_into_cache(entities, hash, SHADOW)
 
@@ -513,12 +484,20 @@ function declarative.load_into_cache_with_events(entities, hash)
 
   kong.cache:invalidate("router:version")
 
-  for _, entity_name in ipairs({"upstreams", "targets"}) do
-    if entities[entity_name] then
-      for _, item in pairs(entities[entity_name]) do
-        post_crud_create_event(entity_name, item)
-      end
-    end
+  ok, err = kong.worker_events.post("balancer", "upstreams", {
+    operation = "reset",
+    entity = { id = "all", name = "all" }
+  })
+  if not ok then
+    return nil, err
+  end
+
+  ok, err = kong.worker_events.post("balancer", "targets", {
+    operation = "reset",
+    entity = { id = "all", name = "all" }
+  })
+  if not ok then
+    return nil, err
   end
 
   return true

--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -599,12 +599,7 @@ end
 --==============================================================================
 
 
---------------------------------------------------------------------------------
--- Called on any changes to a target.
--- @param operation "create", "update" or "delete"
--- @param target Target table with `upstream.id` field
-local function on_target_event(operation, target)
-  local upstream_id = target.upstream.id
+local function do_target_event(operation, upstream_id, upstream_name)
   singletons.cache:invalidate_local("balancer:targets:" .. upstream_id)
 
   local upstream = get_upstream_by_id(upstream_id)
@@ -613,68 +608,32 @@ local function on_target_event(operation, target)
     return
   end
 
-  local balancer = balancers[upstream.id]
+  local balancer = balancers[upstream_id]
   if not balancer then
-    log(ERR, "target ", operation, ": balancer not found for ", upstream.name)
+    log(ERR, "target ", operation, ": balancer not found for ", upstream_name)
     return
   end
 
   local ok, err = check_target_history(upstream, balancer)
   if not ok then
-    log(ERR, "failed checking target history for ", upstream.name, ":  ", err)
+    log(ERR, "failed checking target history for ", upstream_name, ":  ", err)
   end
 end
 
-
 --------------------------------------------------------------------------------
--- Called on any changes to an upstream.
+-- Called on any changes to a target.
 -- @param operation "create", "update" or "delete"
--- @param upstream_data table with `id` and `name` fields
-local function on_upstream_event(operation, upstream_data)
-  local upstream_id = upstream_data.id
-  local upstream_name = upstream_data.name
+-- @param target Target table with `upstream.id` field
+local function on_target_event(operation, target)
 
-  if operation == "create" then
-
-    singletons.cache:invalidate_local("balancer:upstreams")
-
-    local upstream = get_upstream_by_id(upstream_id)
-    if not upstream then
-      log(ERR, "upstream not found for ", upstream_id)
-      return
+  if operation == "reset" then
+    local upstreams = get_all_upstreams()
+    for name, id in pairs(upstreams) do
+      do_target_event("create", id, name)
     end
 
-    local _, err = create_balancer(upstream)
-    if err then
-      log(CRIT, "failed creating balancer for ", upstream_name, ": ", err)
-    end
-
-  elseif operation == "delete" or operation == "update" then
-
-    singletons.cache:invalidate_local("balancer:upstreams")
-    singletons.cache:invalidate_local("balancer:upstreams:" .. upstream_id)
-    singletons.cache:invalidate_local("balancer:targets:"   .. upstream_id)
-
-    local balancer = balancers[upstream_id]
-    if balancer then
-      stop_healthchecker(balancer)
-    end
-
-    if operation == "delete" then
-      set_balancer(upstream_id, nil)
-
-    else
-      local upstream = get_upstream_by_id(upstream_id)
-      if not upstream then
-        log(ERR, "upstream not found for ", upstream_id)
-        return
-      end
-
-      local _, err = create_balancer(upstream, true)
-      if err then
-        log(ERR, "failed recreating balancer for ", upstream_name, ": ", err)
-      end
-    end
+  else
+    do_target_event(operation, target.upstream.id, target.upstream.name)
 
   end
 
@@ -775,6 +734,79 @@ local function init()
     end
   end
   log(DEBUG, "initialized ", oks, " balancer(s), ", errs, " error(s)")
+
+end
+
+
+local function do_upstream_event(operation, upstream_id, upstream_name)
+  if operation == "create" then
+
+    singletons.cache:invalidate_local("balancer:upstreams")
+
+    local upstream = get_upstream_by_id(upstream_id)
+    if not upstream then
+      log(ERR, "upstream not found for ", upstream_id)
+      return
+    end
+
+    local _, err = create_balancer(upstream)
+    if err then
+      log(CRIT, "failed creating balancer for ", upstream_name, ": ", err)
+    end
+
+  elseif operation == "delete" or operation == "update" then
+
+    if singletons.db.strategy ~= "off" then
+      singletons.cache:invalidate_local("balancer:upstreams")
+      singletons.cache:invalidate_local("balancer:upstreams:" .. upstream_id)
+      singletons.cache:invalidate_local("balancer:targets:"   .. upstream_id)
+    end
+
+    local balancer = balancers[upstream_id]
+    if balancer then
+      stop_healthchecker(balancer)
+    end
+
+    if operation == "delete" then
+      set_balancer(upstream_id, nil)
+
+    else
+      local upstream = get_upstream_by_id(upstream_id)
+      if not upstream then
+        log(ERR, "upstream not found for ", upstream_id)
+        return
+      end
+
+      local _, err = create_balancer(upstream, true)
+      if err then
+        log(ERR, "failed recreating balancer for ", upstream_name, ": ", err)
+      end
+    end
+
+  end
+
+end
+
+
+--------------------------------------------------------------------------------
+-- Called on any changes to an upstream.
+-- @param operation "create", "update" or "delete"
+-- @param upstream_data table with `id` and `name` fields
+local function on_upstream_event(operation, upstream_data)
+
+  if operation == "reset" then
+    init()
+
+  elseif operation == "delete_all" then
+    local upstreams = get_all_upstreams()
+    for name, id in pairs(upstreams) do
+      do_upstream_event("delete", id, name)
+    end
+
+  else
+    do_upstream_event(operation, upstream_data.id, upstream_data.name)
+
+  end
 
 end
 

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -335,12 +335,18 @@ local function register_events()
   -- cluster_events handler
   cluster_events:subscribe("balancer:targets", function(data)
     local operation, key = unpack(utils.split(data, ":"))
+    local entity
+    if key ~= "all" then
+      entity = {
+        upstream = { id = key },
+      }
+    else
+      entity = "all"
+    end
     -- => to worker_events node handler
     local ok, err = worker_events.post("balancer", "targets", {
         operation = operation,
-        entity = {
-          upstream = { id = key },
-        }
+        entity = entity
       })
     if not ok then
       log(ERR, "failed broadcasting target ", operation, " to workers: ", err)
@@ -398,13 +404,14 @@ local function register_events()
 
   cluster_events:subscribe("balancer:upstreams", function(data)
     local operation, id, name = unpack(utils.split(data, ":"))
+    local entity = {
+      id = id,
+      name = name,
+    }
     -- => to worker_events node handler
     local ok, err = worker_events.post("balancer", "upstreams", {
         operation = operation,
-        entity = {
-          id = id,
-          name = name,
-        }
+        entity = entity
       })
     if not ok then
       log(ERR, "failed broadcasting upstream ", operation, " to workers: ", err)

--- a/spec/fixtures/burst.yml
+++ b/spec/fixtures/burst.yml
@@ -1,0 +1,23744 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  host: something-static.4test-any.svc
+  name: 4test-any.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-any.example.test
+    name: 4test-any.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-any.svc
+  name: 4test-any.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-any.example.test
+    name: 4test-any.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-any.svc
+  name: 4test-any.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-any-admin.example.test
+    name: 4test-any.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-any.example.test
+    name: 4test-any.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-any.svc
+  name: 4test-any.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-any-admin.example.test
+    name: 4test-any.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-any.svc
+  name: 4test-any.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-any.example.test
+    name: 4test-any.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-athing1-otherthing.svc
+  name: 4test-athing1-otherthing.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing1-otherthing.example.test
+    name: 4test-athing1-otherthing.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-athing1-otherthing.svc
+  name: 4test-athing1-otherthing.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing1-otherthing.example.test
+    name: 4test-athing1-otherthing.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-athing1-otherthing.svc
+  name: 4test-athing1-otherthing.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing1-otherthing-admin.example.test
+    name: 4test-athing1-otherthing.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-athing1-otherthing.example.test
+    name: 4test-athing1-otherthing.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-athing1-otherthing.svc
+  name: 4test-athing1-otherthing.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing1-otherthing-admin.example.test
+    name: 4test-athing1-otherthing.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-athing1-otherthing.svc
+  name: 4test-athing1-otherthing.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing1-otherthing.example.test
+    name: 4test-athing1-otherthing.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-athing1-name.svc
+  name: 4test-athing1-name.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing1-name.example.test
+    name: 4test-athing1-name.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-athing1-name.svc
+  name: 4test-athing1-name.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing1-name.example.test
+    name: 4test-athing1-name.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-athing1-name.svc
+  name: 4test-athing1-name.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing1-name-admin.example.test
+    name: 4test-athing1-name.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-athing1-name.example.test
+    name: 4test-athing1-name.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-athing1-name.svc
+  name: 4test-athing1-name.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing1-name-admin.example.test
+    name: 4test-athing1-name.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-athing1-name.svc
+  name: 4test-athing1-name.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing1-name.example.test
+    name: 4test-athing1-name.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-athing1-othername.svc
+  name: 4test-athing1-othername.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing1-othername.example.test
+    name: 4test-athing1-othername.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-athing1-othername.svc
+  name: 4test-athing1-othername.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing1-othername.example.test
+    name: 4test-athing1-othername.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-athing1-othername.svc
+  name: 4test-athing1-othername.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing1-othername-admin.example.test
+    name: 4test-athing1-othername.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-athing1-othername.example.test
+    name: 4test-athing1-othername.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-athing1-othername.svc
+  name: 4test-athing1-othername.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing1-othername-admin.example.test
+    name: 4test-athing1-othername.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-athing1-othername.svc
+  name: 4test-athing1-othername.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing1-othername.example.test
+    name: 4test-athing1-othername.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-athing1-morenames.svc
+  name: 4test-athing1-morenames.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing1-morenames.example.test
+    name: 4test-athing1-morenames.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-athing1-morenames.svc
+  name: 4test-athing1-morenames.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing1-morenames.example.test
+    name: 4test-athing1-morenames.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-athing1-morenames.svc
+  name: 4test-athing1-morenames.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing1-morenames-admin.example.test
+    name: 4test-athing1-morenames.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-athing1-morenames.example.test
+    name: 4test-athing1-morenames.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-athing1-morenames.svc
+  name: 4test-athing1-morenames.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing1-morenames-admin.example.test
+    name: 4test-athing1-morenames.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-athing1-morenames.svc
+  name: 4test-athing1-morenames.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing1-morenames.example.test
+    name: 4test-athing1-morenames.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-thatthing.svc
+  name: 4test-thatthing.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-thatthing.example.test
+    name: 4test-thatthing.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-thatthing.svc
+  name: 4test-thatthing.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-thatthing.example.test
+    name: 4test-thatthing.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-thatthing.svc
+  name: 4test-thatthing.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-thatthing-admin.example.test
+    name: 4test-thatthing.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-thatthing.example.test
+    name: 4test-thatthing.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-thatthing.svc
+  name: 4test-thatthing.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-thatthing-admin.example.test
+    name: 4test-thatthing.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-thatthing.svc
+  name: 4test-thatthing.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-thatthing.example.test
+    name: 4test-thatthing.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-athing2-suchthing.svc
+  name: 4test-athing2-suchthing.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing2-suchthing.example.test
+    name: 4test-athing2-suchthing.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-athing2-suchthing.svc
+  name: 4test-athing2-suchthing.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing2-suchthing.example.test
+    name: 4test-athing2-suchthing.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-athing2-suchthing.svc
+  name: 4test-athing2-suchthing.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing2-suchthing-admin.example.test
+    name: 4test-athing2-suchthing.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-athing2-suchthing.example.test
+    name: 4test-athing2-suchthing.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-athing2-suchthing.svc
+  name: 4test-athing2-suchthing.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing2-suchthing-admin.example.test
+    name: 4test-athing2-suchthing.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-athing2-suchthing.svc
+  name: 4test-athing2-suchthing.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing2-suchthing.example.test
+    name: 4test-athing2-suchthing.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-athing2-wow.svc
+  name: 4test-athing2-wow.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing2-wow.example.test
+    name: 4test-athing2-wow.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-athing2-wow.svc
+  name: 4test-athing2-wow.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing2-wow.example.test
+    name: 4test-athing2-wow.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-athing2-wow.svc
+  name: 4test-athing2-wow.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing2-wow-admin.example.test
+    name: 4test-athing2-wow.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-athing2-wow.example.test
+    name: 4test-athing2-wow.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-athing2-wow.svc
+  name: 4test-athing2-wow.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing2-wow-admin.example.test
+    name: 4test-athing2-wow.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-athing2-wow.svc
+  name: 4test-athing2-wow.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing2-wow.example.test
+    name: 4test-athing2-wow.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-manythings.svc
+  name: 4test-manythings.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-manythings.example.test
+    name: 4test-manythings.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-manythings.svc
+  name: 4test-manythings.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-manythings.example.test
+    name: 4test-manythings.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-manythings.svc
+  name: 4test-manythings.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-manythings-admin.example.test
+    name: 4test-manythings.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-manythings.example.test
+    name: 4test-manythings.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-manythings.svc
+  name: 4test-manythings.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-manythings-admin.example.test
+    name: 4test-manythings.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-manythings.svc
+  name: 4test-manythings.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-manythings.example.test
+    name: 4test-manythings.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-verythings.svc
+  name: 4test-verythings.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-verythings.example.test
+    name: 4test-verythings.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-verythings.svc
+  name: 4test-verythings.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-verythings.example.test
+    name: 4test-verythings.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-verythings.svc
+  name: 4test-verythings.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-verythings-admin.example.test
+    name: 4test-verythings.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-verythings.example.test
+    name: 4test-verythings.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-verythings.svc
+  name: 4test-verythings.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-verythings-admin.example.test
+    name: 4test-verythings.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-verythings.svc
+  name: 4test-verythings.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-verythings.example.test
+    name: 4test-verythings.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-athing3-tester2.svc
+  name: 4test-athing3-tester2.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing3-tester2.example.test
+    name: 4test-athing3-tester2.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-athing3-tester2.svc
+  name: 4test-athing3-tester2.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing3-tester2.example.test
+    name: 4test-athing3-tester2.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-athing3-tester2.svc
+  name: 4test-athing3-tester2.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing3-tester2-admin.example.test
+    name: 4test-athing3-tester2.testing-ingress-admin.01
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-athing3-tester2.example.test
+    name: 4test-athing3-tester2.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static.4test-athing3-tester2.svc
+  name: 4test-athing3-tester2.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing3-tester2-admin.example.test
+    name: 4test-athing3-tester2.testing-ingress-admin.00
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-athing3-tester2.example.test
+    name: 4test-athing3-tester2.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-athing3-oldthings.svc
+  name: 4test-athing3-oldthings.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing3-oldthings.example.test
+    name: 4test-athing3-oldthings.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-athing3-oldthings.svc
+  name: 4test-athing3-oldthings.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing3-oldthings.example.test
+    name: 4test-athing3-oldthings.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-athing3-oldthings.svc
+  name: 4test-athing3-oldthings.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing3-oldthings-admin.example.test
+    name: 4test-athing3-oldthings.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-athing3-oldthings.example.test
+    name: 4test-athing3-oldthings.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-athing3-oldthings.svc
+  name: 4test-athing3-oldthings.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing3-oldthings-admin.example.test
+    name: 4test-athing3-oldthings.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-athing3-oldthings.svc
+  name: 4test-athing3-oldthings.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing3-oldthings.example.test
+    name: 4test-athing3-oldthings.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-demo1.svc
+  name: 4test-demo1.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-demo1.example.test
+    name: 4test-demo1.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-demo1.svc
+  name: 4test-demo1.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-demo1.example.test
+    name: 4test-demo1.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-demo1.svc
+  name: 4test-demo1.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-demo1-admin.example.test
+    name: 4test-demo1.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-demo1.example.test
+    name: 4test-demo1.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-demo1.svc
+  name: 4test-demo1.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-demo1-admin.example.test
+    name: 4test-demo1.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-demo1.svc
+  name: 4test-demo1.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-demo1.example.test
+    name: 4test-demo1.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-demo2.svc
+  name: 4test-demo2.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-demo2.example.test
+    name: 4test-demo2.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-demo2.svc
+  name: 4test-demo2.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-demo2.example.test
+    name: 4test-demo2.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-demo2.svc
+  name: 4test-demo2.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-demo2-admin.example.test
+    name: 4test-demo2.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-demo2.example.test
+    name: 4test-demo2.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-demo2.svc
+  name: 4test-demo2.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-demo2-admin.example.test
+    name: 4test-demo2.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-demo2.svc
+  name: 4test-demo2.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-demo2.example.test
+    name: 4test-demo2.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-dev.svc
+  name: 4test-dev.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-dev.example.test
+    name: 4test-dev.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-dev.svc
+  name: 4test-dev.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-dev.example.test
+    name: 4test-dev.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-dev.svc
+  name: 4test-dev.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-dev-admin.example.test
+    name: 4test-dev.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-dev.example.test
+    name: 4test-dev.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-dev.svc
+  name: 4test-dev.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-dev-admin.example.test
+    name: 4test-dev.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-dev.svc
+  name: 4test-dev.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-dev.example.test
+    name: 4test-dev.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-athing4-sothings.svc
+  name: 4test-athing4-sothings.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing4-sothings.example.test
+    name: 4test-athing4-sothings.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-athing4-sothings.svc
+  name: 4test-athing4-sothings.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing4-sothings.example.test
+    name: 4test-athing4-sothings.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-athing4-sothings.svc
+  name: 4test-athing4-sothings.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing4-sothings-admin.example.test
+    name: 4test-athing4-sothings.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-athing4-sothings.example.test
+    name: 4test-athing4-sothings.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-athing4-sothings.svc
+  name: 4test-athing4-sothings.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing4-sothings-admin.example.test
+    name: 4test-athing4-sothings.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-athing4-sothings.svc
+  name: 4test-athing4-sothings.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing4-sothings.example.test
+    name: 4test-athing4-sothings.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-athing5-cousin.svc
+  name: 4test-athing5-cousin.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing5-cousin.example.test
+    name: 4test-athing5-cousin.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-athing5-cousin.svc
+  name: 4test-athing5-cousin.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing5-cousin.example.test
+    name: 4test-athing5-cousin.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-athing5-cousin.svc
+  name: 4test-athing5-cousin.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing5-cousin-admin.example.test
+    name: 4test-athing5-cousin.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-athing5-cousin.example.test
+    name: 4test-athing5-cousin.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-athing5-cousin.svc
+  name: 4test-athing5-cousin.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing5-cousin-admin.example.test
+    name: 4test-athing5-cousin.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-athing5-cousin.svc
+  name: 4test-athing5-cousin.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing5-cousin.example.test
+    name: 4test-athing5-cousin.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-athing5-verythings.svc
+  name: 4test-athing5-verythings.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing5-verythings.example.test
+    name: 4test-athing5-verythings.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-athing5-verythings.svc
+  name: 4test-athing5-verythings.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing5-verythings.example.test
+    name: 4test-athing5-verythings.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-athing5-verythings.svc
+  name: 4test-athing5-verythings.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing5-verythings-admin.example.test
+    name: 4test-athing5-verythings.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-athing5-verythings.example.test
+    name: 4test-athing5-verythings.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-athing5-verythings.svc
+  name: 4test-athing5-verythings.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing5-verythings-admin.example.test
+    name: 4test-athing5-verythings.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-athing5-verythings.svc
+  name: 4test-athing5-verythings.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing5-verythings.example.test
+    name: 4test-athing5-verythings.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-athing5-ygbkm.svc
+  name: 4test-athing5-ygbkm.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing5-ygbkm.example.test
+    name: 4test-athing5-ygbkm.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-athing5-ygbkm.svc
+  name: 4test-athing5-ygbkm.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing5-ygbkm.example.test
+    name: 4test-athing5-ygbkm.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-athing5-ygbkm.svc
+  name: 4test-athing5-ygbkm.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing5-ygbkm-admin.example.test
+    name: 4test-athing5-ygbkm.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-athing5-ygbkm.example.test
+    name: 4test-athing5-ygbkm.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-athing5-ygbkm.svc
+  name: 4test-athing5-ygbkm.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing5-ygbkm-admin.example.test
+    name: 4test-athing5-ygbkm.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-athing5-ygbkm.svc
+  name: 4test-athing5-ygbkm.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing5-ygbkm.example.test
+    name: 4test-athing5-ygbkm.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-athing5-gothings.svc
+  name: 4test-athing5-gothings.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing5-gothings.example.test
+    name: 4test-athing5-gothings.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-athing5-gothings.svc
+  name: 4test-athing5-gothings.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing5-gothings.example.test
+    name: 4test-athing5-gothings.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-athing5-gothings.svc
+  name: 4test-athing5-gothings.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing5-gothings-admin.example.test
+    name: 4test-athing5-gothings.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-athing5-gothings.example.test
+    name: 4test-athing5-gothings.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-athing5-gothings.svc
+  name: 4test-athing5-gothings.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing5-gothings-admin.example.test
+    name: 4test-athing5-gothings.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-athing5-gothings.svc
+  name: 4test-athing5-gothings.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing5-gothings.example.test
+    name: 4test-athing5-gothings.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-athing5-clever.svc
+  name: 4test-athing5-clever.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing5-clever.example.test
+    name: 4test-athing5-clever.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-athing5-clever.svc
+  name: 4test-athing5-clever.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing5-clever.example.test
+    name: 4test-athing5-clever.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-athing5-clever.svc
+  name: 4test-athing5-clever.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing5-clever-admin.example.test
+    name: 4test-athing5-clever.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-athing5-clever.example.test
+    name: 4test-athing5-clever.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-athing5-clever.svc
+  name: 4test-athing5-clever.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing5-clever-admin.example.test
+    name: 4test-athing5-clever.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-athing5-clever.svc
+  name: 4test-athing5-clever.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing5-clever.example.test
+    name: 4test-athing5-clever.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-athing6-itis.svc
+  name: 4test-athing6-itis.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing6-itis.example.test
+    name: 4test-athing6-itis.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-athing6-itis.svc
+  name: 4test-athing6-itis.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing6-itis.example.test
+    name: 4test-athing6-itis.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-athing6-itis.svc
+  name: 4test-athing6-itis.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing6-itis-admin.example.test
+    name: 4test-athing6-itis.testing-ingress-admin.01
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-athing6-itis.example.test
+    name: 4test-athing6-itis.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static.4test-athing6-itis.svc
+  name: 4test-athing6-itis.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing6-itis-admin.example.test
+    name: 4test-athing6-itis.testing-ingress-admin.00
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-athing6-itis.example.test
+    name: 4test-athing6-itis.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-tldr.svc
+  name: 4test-tldr.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-tldr.example.test
+    name: 4test-tldr.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-tldr.svc
+  name: 4test-tldr.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-tldr.example.test
+    name: 4test-tldr.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-tldr.svc
+  name: 4test-tldr.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-tldr-admin.example.test
+    name: 4test-tldr.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-tldr.example.test
+    name: 4test-tldr.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-tldr.svc
+  name: 4test-tldr.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-tldr-admin.example.test
+    name: 4test-tldr.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-tldr.svc
+  name: 4test-tldr.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-tldr.example.test
+    name: 4test-tldr.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-shock.svc
+  name: 4test-shock.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-shock.example.test
+    name: 4test-shock.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-shock.svc
+  name: 4test-shock.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-shock.example.test
+    name: 4test-shock.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-shock.svc
+  name: 4test-shock.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-shock-admin.example.test
+    name: 4test-shock.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-shock.example.test
+    name: 4test-shock.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-shock.svc
+  name: 4test-shock.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-shock-admin.example.test
+    name: 4test-shock.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-shock.svc
+  name: 4test-shock.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-shock.example.test
+    name: 4test-shock.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-local.svc
+  name: 4test-local.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-local.example.test
+    name: 4test-local.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-local.svc
+  name: 4test-local.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-local.example.test
+    name: 4test-local.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-local.svc
+  name: 4test-local.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-local-admin.example.test
+    name: 4test-local.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-local.example.test
+    name: 4test-local.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-local.svc
+  name: 4test-local.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-local-admin.example.test
+    name: 4test-local.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-local.svc
+  name: 4test-local.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-local.example.test
+    name: 4test-local.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-newthings.svc
+  name: 4test-newthings.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-newthings.example.test
+    name: 4test-newthings.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-newthings.svc
+  name: 4test-newthings.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-newthings.example.test
+    name: 4test-newthings.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-newthings.svc
+  name: 4test-newthings.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-newthings-admin.example.test
+    name: 4test-newthings.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-newthings.example.test
+    name: 4test-newthings.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-newthings.svc
+  name: 4test-newthings.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-newthings-admin.example.test
+    name: 4test-newthings.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-newthings.svc
+  name: 4test-newthings.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-newthings.example.test
+    name: 4test-newthings.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-athing7-halftest.svc
+  name: 4test-athing7-halftest.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing7-halftest.example.test
+    name: 4test-athing7-halftest.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-athing7-halftest.svc
+  name: 4test-athing7-halftest.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing7-halftest.example.test
+    name: 4test-athing7-halftest.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-athing7-halftest.svc
+  name: 4test-athing7-halftest.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing7-halftest-admin.example.test
+    name: 4test-athing7-halftest.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-athing7-halftest.example.test
+    name: 4test-athing7-halftest.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-athing7-halftest.svc
+  name: 4test-athing7-halftest.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing7-halftest-admin.example.test
+    name: 4test-athing7-halftest.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-athing7-halftest.svc
+  name: 4test-athing7-halftest.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing7-halftest.example.test
+    name: 4test-athing7-halftest.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-athing7-moartests.svc
+  name: 4test-athing7-moartests.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing7-moartests.example.test
+    name: 4test-athing7-moartests.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-athing7-moartests.svc
+  name: 4test-athing7-moartests.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing7-moartests.example.test
+    name: 4test-athing7-moartests.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-athing7-moartests.svc
+  name: 4test-athing7-moartests.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing7-moartests-admin.example.test
+    name: 4test-athing7-moartests.testing-ingress-admin.01
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-athing7-moartests.example.test
+    name: 4test-athing7-moartests.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static.4test-athing7-moartests.svc
+  name: 4test-athing7-moartests.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing7-moartests-admin.example.test
+    name: 4test-athing7-moartests.testing-ingress-admin.00
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-athing7-moartests.example.test
+    name: 4test-athing7-moartests.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-athing7-gettests.svc
+  name: 4test-athing7-gettests.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing7-gettests.example.test
+    name: 4test-athing7-gettests.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-athing7-gettests.svc
+  name: 4test-athing7-gettests.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing7-gettests.example.test
+    name: 4test-athing7-gettests.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-athing7-gettests.svc
+  name: 4test-athing7-gettests.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing7-gettests-admin.example.test
+    name: 4test-athing7-gettests.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-athing7-gettests.example.test
+    name: 4test-athing7-gettests.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-athing7-gettests.svc
+  name: 4test-athing7-gettests.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing7-gettests-admin.example.test
+    name: 4test-athing7-gettests.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-athing7-gettests.svc
+  name: 4test-athing7-gettests.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing7-gettests.example.test
+    name: 4test-athing7-gettests.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-gottests.svc
+  name: 4test-gottests.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-gottests.example.test
+    name: 4test-gottests.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-gottests.svc
+  name: 4test-gottests.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-gottests.example.test
+    name: 4test-gottests.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-gottests.svc
+  name: 4test-gottests.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-gottests-admin.example.test
+    name: 4test-gottests.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-gottests.example.test
+    name: 4test-gottests.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-gottests.svc
+  name: 4test-gottests.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-gottests-admin.example.test
+    name: 4test-gottests.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-gottests.svc
+  name: 4test-gottests.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-gottests.example.test
+    name: 4test-gottests.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-fam.svc
+  name: 4test-fam.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-fam.example.test
+    name: 4test-fam.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-fam.svc
+  name: 4test-fam.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-fam.example.test
+    name: 4test-fam.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-fam.svc
+  name: 4test-fam.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-fam-admin.example.test
+    name: 4test-fam.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-fam.example.test
+    name: 4test-fam.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-fam.svc
+  name: 4test-fam.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-fam-admin.example.test
+    name: 4test-fam.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-fam.svc
+  name: 4test-fam.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-fam.example.test
+    name: 4test-fam.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-athing8-2007.svc
+  name: 4test-athing8-2007.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing8-2007.example.test
+    name: 4test-athing8-2007.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-athing8-2007.svc
+  name: 4test-athing8-2007.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing8-2007.example.test
+    name: 4test-athing8-2007.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-athing8-2007.svc
+  name: 4test-athing8-2007.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing8-2007-admin.example.test
+    name: 4test-athing8-2007.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-athing8-2007.example.test
+    name: 4test-athing8-2007.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-athing8-2007.svc
+  name: 4test-athing8-2007.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing8-2007-admin.example.test
+    name: 4test-athing8-2007.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-athing8-2007.svc
+  name: 4test-athing8-2007.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing8-2007.example.test
+    name: 4test-athing8-2007.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-grantests.svc
+  name: 4test-grantests.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-grantests.example.test
+    name: 4test-grantests.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-grantests.svc
+  name: 4test-grantests.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-grantests.example.test
+    name: 4test-grantests.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-grantests.svc
+  name: 4test-grantests.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-grantests-admin.example.test
+    name: 4test-grantests.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-grantests.example.test
+    name: 4test-grantests.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-grantests.svc
+  name: 4test-grantests.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-grantests-admin.example.test
+    name: 4test-grantests.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-grantests.svc
+  name: 4test-grantests.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-grantests.example.test
+    name: 4test-grantests.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-btests.svc
+  name: 4test-btests.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-btests.example.test
+    name: 4test-btests.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-btests.svc
+  name: 4test-btests.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-btests.example.test
+    name: 4test-btests.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-btests.svc
+  name: 4test-btests.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-btests-admin.example.test
+    name: 4test-btests.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-btests.example.test
+    name: 4test-btests.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-btests.svc
+  name: 4test-btests.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-btests-admin.example.test
+    name: 4test-btests.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-btests.svc
+  name: 4test-btests.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-btests.example.test
+    name: 4test-btests.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-lttl.svc
+  name: 4test-lttl.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-lttl.example.test
+    name: 4test-lttl.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-lttl.svc
+  name: 4test-lttl.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-lttl.example.test
+    name: 4test-lttl.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-lttl.svc
+  name: 4test-lttl.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-lttl-admin.example.test
+    name: 4test-lttl.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-lttl.example.test
+    name: 4test-lttl.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-lttl.svc
+  name: 4test-lttl.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-lttl-admin.example.test
+    name: 4test-lttl.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-lttl.svc
+  name: 4test-lttl.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-lttl.example.test
+    name: 4test-lttl.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-athing9-valid.svc
+  name: 4test-athing9-valid.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing9-valid.example.test
+    name: 4test-athing9-valid.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-athing9-valid.svc
+  name: 4test-athing9-valid.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing9-valid.example.test
+    name: 4test-athing9-valid.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-athing9-valid.svc
+  name: 4test-athing9-valid.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing9-valid-admin.example.test
+    name: 4test-athing9-valid.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-athing9-valid.example.test
+    name: 4test-athing9-valid.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-athing9-valid.svc
+  name: 4test-athing9-valid.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing9-valid-admin.example.test
+    name: 4test-athing9-valid.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-athing9-valid.svc
+  name: 4test-athing9-valid.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing9-valid.example.test
+    name: 4test-athing9-valid.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-athing9-morevalid.svc
+  name: 4test-athing9-morevalid.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing9-morevalid.example.test
+    name: 4test-athing9-morevalid.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-athing9-morevalid.svc
+  name: 4test-athing9-morevalid.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing9-morevalid.example.test
+    name: 4test-athing9-morevalid.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-athing9-morevalid.svc
+  name: 4test-athing9-morevalid.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing9-morevalid-admin.example.test
+    name: 4test-athing9-morevalid.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-athing9-morevalid.example.test
+    name: 4test-athing9-morevalid.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-athing9-morevalid.svc
+  name: 4test-athing9-morevalid.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing9-morevalid-admin.example.test
+    name: 4test-athing9-morevalid.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-athing9-morevalid.svc
+  name: 4test-athing9-morevalid.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing9-morevalid.example.test
+    name: 4test-athing9-morevalid.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-athing9-wanttotest.svc
+  name: 4test-athing9-wanttotest.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing9-wanttotest.example.test
+    name: 4test-athing9-wanttotest.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-athing9-wanttotest.svc
+  name: 4test-athing9-wanttotest.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing9-wanttotest.example.test
+    name: 4test-athing9-wanttotest.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-athing9-wanttotest.svc
+  name: 4test-athing9-wanttotest.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing9-wanttotest-admin.example.test
+    name: 4test-athing9-wanttotest.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-athing9-wanttotest.example.test
+    name: 4test-athing9-wanttotest.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-athing9-wanttotest.svc
+  name: 4test-athing9-wanttotest.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing9-wanttotest-admin.example.test
+    name: 4test-athing9-wanttotest.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-athing9-wanttotest.svc
+  name: 4test-athing9-wanttotest.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing9-wanttotest.example.test
+    name: 4test-athing9-wanttotest.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-athing9-whichtest.svc
+  name: 4test-athing9-whichtest.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing9-whichtest.example.test
+    name: 4test-athing9-whichtest.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-athing9-whichtest.svc
+  name: 4test-athing9-whichtest.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing9-whichtest.example.test
+    name: 4test-athing9-whichtest.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-athing9-whichtest.svc
+  name: 4test-athing9-whichtest.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing9-whichtest-admin.example.test
+    name: 4test-athing9-whichtest.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-athing9-whichtest.example.test
+    name: 4test-athing9-whichtest.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-athing9-whichtest.svc
+  name: 4test-athing9-whichtest.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing9-whichtest-admin.example.test
+    name: 4test-athing9-whichtest.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-athing9-whichtest.svc
+  name: 4test-athing9-whichtest.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing9-whichtest.example.test
+    name: 4test-athing9-whichtest.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-athing9-frank.svc
+  name: 4test-athing9-frank.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing9-frank.example.test
+    name: 4test-athing9-frank.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-athing9-nsf.svc
+  name: 4test-athing9-nsf.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing9-nsf.example.test
+    name: 4test-athing9-nsf.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-athing9-nsf.svc
+  name: 4test-athing9-nsf.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing9-nsf.example.test
+    name: 4test-athing9-nsf.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-athing9-nsf.svc
+  name: 4test-athing9-nsf.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing9-nsf-admin.example.test
+    name: 4test-athing9-nsf.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-athing9-nsf.example.test
+    name: 4test-athing9-nsf.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-athing9-nsf.svc
+  name: 4test-athing9-nsf.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing9-nsf-admin.example.test
+    name: 4test-athing9-nsf.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-athing9-nsf.svc
+  name: 4test-athing9-nsf.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing9-nsf.example.test
+    name: 4test-athing9-nsf.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-athing10-jnk.svc
+  name: 4test-athing10-jnk.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing10-jnk.example.test
+    name: 4test-athing10-jnk.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-athing10-jnk.svc
+  name: 4test-athing10-jnk.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing10-jnk.example.test
+    name: 4test-athing10-jnk.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-athing10-jnk.svc
+  name: 4test-athing10-jnk.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing10-jnk-admin.example.test
+    name: 4test-athing10-jnk.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-athing10-jnk.example.test
+    name: 4test-athing10-jnk.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-athing10-jnk.svc
+  name: 4test-athing10-jnk.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing10-jnk-admin.example.test
+    name: 4test-athing10-jnk.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-athing10-jnk.svc
+  name: 4test-athing10-jnk.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing10-jnk.example.test
+    name: 4test-athing10-jnk.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-athing10-local.svc
+  name: 4test-athing10-local.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing10-local.example.test
+    name: 4test-athing10-local.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-athing10-local.svc
+  name: 4test-athing10-local.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing10-local.example.test
+    name: 4test-athing10-local.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-athing10-local.svc
+  name: 4test-athing10-local.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing10-local-admin.example.test
+    name: 4test-athing10-local.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-athing10-local.example.test
+    name: 4test-athing10-local.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-athing10-local.svc
+  name: 4test-athing10-local.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing10-local-admin.example.test
+    name: 4test-athing10-local.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-athing10-local.svc
+  name: 4test-athing10-local.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing10-local.example.test
+    name: 4test-athing10-local.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-athing10-bbitw.svc
+  name: 4test-athing10-bbitw.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing10-bbitw.example.test
+    name: 4test-athing10-bbitw.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-athing10-bbitw.svc
+  name: 4test-athing10-bbitw.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing10-bbitw.example.test
+    name: 4test-athing10-bbitw.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-athing10-bbitw.svc
+  name: 4test-athing10-bbitw.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing10-bbitw-admin.example.test
+    name: 4test-athing10-bbitw.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-athing10-bbitw.example.test
+    name: 4test-athing10-bbitw.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-athing10-bbitw.svc
+  name: 4test-athing10-bbitw.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing10-bbitw-admin.example.test
+    name: 4test-athing10-bbitw.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-athing10-bbitw.svc
+  name: 4test-athing10-bbitw.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing10-bbitw.example.test
+    name: 4test-athing10-bbitw.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-athing10-gettests.svc
+  name: 4test-athing10-gettests.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing10-gettests.example.test
+    name: 4test-athing10-gettests.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-athing10-gettests.svc
+  name: 4test-athing10-gettests.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing10-gettests.example.test
+    name: 4test-athing10-gettests.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-athing10-gettests.svc
+  name: 4test-athing10-gettests.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing10-gettests-admin.example.test
+    name: 4test-athing10-gettests.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-athing10-gettests.example.test
+    name: 4test-athing10-gettests.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-athing10-gettests.svc
+  name: 4test-athing10-gettests.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing10-gettests-admin.example.test
+    name: 4test-athing10-gettests.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-athing10-gettests.svc
+  name: 4test-athing10-gettests.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing10-gettests.example.test
+    name: 4test-athing10-gettests.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-athing10-phn.svc
+  name: 4test-athing10-phn.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing10-phn.example.test
+    name: 4test-athing10-phn.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-athing10-phn.svc
+  name: 4test-athing10-phn.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing10-phn.example.test
+    name: 4test-athing10-phn.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-athing10-phn.svc
+  name: 4test-athing10-phn.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing10-tim-admin.example.test
+    name: 4test-athing10-phn.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-athing10-phn.example.test
+    name: 4test-athing10-phn.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-athing10-phn.svc
+  name: 4test-athing10-phn.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing10-tim-admin.example.test
+    name: 4test-athing10-phn.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-athing10-phn.svc
+  name: 4test-athing10-phn.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-athing10-phn.example.test
+    name: 4test-athing10-phn.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-test1.svc
+  name: 4test-test1.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-test1.example.test
+    name: 4test-test1.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-test1.svc
+  name: 4test-test1.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-test1.example.test
+    name: 4test-test1.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-test1.svc
+  name: 4test-test1.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-test1-admin.example.test
+    name: 4test-test1.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-test1.example.test
+    name: 4test-test1.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-test1.svc
+  name: 4test-test1.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-test1-admin.example.test
+    name: 4test-test1.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-test1.svc
+  name: 4test-test1.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-test1.example.test
+    name: 4test-test1.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: something-static.4test-test2.svc
+  name: 4test-test2.something-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-test2.example.test
+    name: 4test-test2.something-ingress-static.00
+    paths:
+    - /something/4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing-ws.4test-test2.svc
+  name: 4test-test2.testing-testing-ws.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-test2.example.test
+    name: 4test-test2.testing-ingress-app.01
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/ws
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-testing.4test-test2.svc
+  name: 4test-test2.testing-testing.8000
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-test2-admin.example.test
+    name: 4test-test2.testing-ingress-admin.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+  - hosts:
+    - 4test-test2.example.test
+    name: 4test-test2.testing-ingress-app.00
+    methods:
+    - POST
+    - GET
+    - PATCH
+    - PUT
+    - DELETE
+    paths:
+    - /4test/api
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: false
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: testing-static-admin.4test-test2.svc
+  name: 4test-test2.testing-static-admin.80
+  path: /static/admin
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-test2-admin.example.test
+    name: 4test-test2.testing-ingress-admin-static.00
+    methods:
+    - GET
+    paths:
+    - /4test/static/admin
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+    plugins:
+    - name: ip-restriction
+      config:
+        blacklist: null
+        whitelist:
+        - 0.0.0.0/0
+      enabled: true
+      run_on: first
+      protocols:
+      - grpc
+      - grpcs
+      - http
+      - https
+- connect_timeout: 60000
+  host: testing-static.4test-test2.svc
+  name: 4test-test2.testing-static.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - 4test-test2.example.test
+    name: 4test-test2.testing-ingress-static.00
+    paths:
+    - /4test
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: konga.kong.svc
+  name: kong.konga.http
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - konga-k8s-demo01-kong.example.test
+    name: kong.konga.00
+    paths:
+    - /
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: grafana.monitoring.svc
+  name: monitoring.grafana.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - monitor-k8s-demo01-kong.example.test
+    name: monitoring.grafana.00
+    paths:
+    - /
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+- connect_timeout: 60000
+  host: prometheus-alertmanager.monitoring.svc
+  name: monitoring.prometheus-alertmanager.80
+  path: /
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  routes:
+  - hosts:
+    - alerts-k8s-demo01.example.test
+    name: monitoring.prometheus-alertmanager.00
+    paths:
+    - /
+    preserve_host: true
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true
+    https_redirect_status_code: 426
+upstreams:
+- name: grafana.monitoring.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.121.148.48:3000
+    weight: 100
+- name: konga.kong.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.127.223.36:1337
+    weight: 100
+- name: prometheus-alertmanager.monitoring.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.121.228.142:9093
+    weight: 100
+- name: something-static.4test-any.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.114.171.117:80
+    weight: 100
+- name: something-static.4test-athing1-otherthing.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.112.197.249:80
+    weight: 100
+- name: something-static.4test-athing1-name.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.100.77.172:80
+    weight: 100
+- name: something-static.4test-athing1-othername.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.96.92.92:80
+    weight: 100
+- name: something-static.4test-athing1-morenames.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.98.136.209:80
+    weight: 100
+- name: something-static.4test-thatthing.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.113.31.239:80
+    weight: 100
+- name: something-static.4test-athing2-suchthing.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.123.1.134:80
+    weight: 100
+- name: something-static.4test-athing2-wow.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.123.1.159:80
+    weight: 100
+- name: something-static.4test-manythings.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.122.180.113:80
+    weight: 100
+- name: something-static.4test-verythings.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.112.140.52:80
+    weight: 100
+- name: something-static.4test-athing3-tester2.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.115.236.20:80
+    weight: 100
+- name: something-static.4test-athing3-oldthings.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.105.222.132:80
+    weight: 100
+- name: something-static.4test-demo1.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.115.236.35:80
+    weight: 100
+- name: something-static.4test-demo2.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.98.136.235:80
+    weight: 100
+- name: something-static.4test-dev.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.121.228.172:80
+    weight: 100
+- name: something-static.4test-athing4-sothings.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.122.91.74:80
+    weight: 100
+- name: something-static.4test-athing5-cousin.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.114.85.47:80
+    weight: 100
+- name: something-static.4test-athing5-verythings.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.114.171.126:80
+    weight: 100
+- name: something-static.4test-athing5-ygbkm.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.123.141.107:80
+    weight: 100
+- name: something-static.4test-athing5-gothings.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.112.140.30:80
+    weight: 100
+- name: something-static.4test-athing5-clever.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.122.91.72:80
+    weight: 100
+- name: something-static.4test-athing6-itis.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.127.101.121:80
+    weight: 100
+- name: something-static.4test-tldr.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.114.171.100:80
+    weight: 100
+- name: something-static.4test-shock.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.105.108.171:80
+    weight: 100
+- name: something-static.4test-local.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.107.57.110:80
+    weight: 100
+- name: something-static.4test-newthings.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.114.85.49:80
+    weight: 100
+- name: something-static.4test-athing7-halftest.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.105.108.152:80
+    weight: 100
+- name: something-static.4test-athing7-moartests.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.119.243.142:80
+    weight: 100
+- name: something-static.4test-athing7-gettests.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.107.57.83:80
+    weight: 100
+- name: something-static.4test-gottests.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.121.148.20:80
+    weight: 100
+- name: something-static.4test-fam.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.96.92.105:80
+    weight: 100
+- name: something-static.4test-athing8-2007.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.123.1.132:80
+    weight: 100
+- name: something-static.4test-grantests.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.113.229.89:80
+    weight: 100
+- name: something-static.4test-btests.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.98.136.205:80
+    weight: 100
+- name: something-static.4test-lttl.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.119.243.166:80
+    weight: 100
+- name: something-static.4test-athing9-valid.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.105.108.150:80
+    weight: 100
+- name: something-static.4test-athing9-morevalid.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.122.91.100:80
+    weight: 100
+- name: something-static.4test-athing9-wanttotest.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.113.229.121:80
+    weight: 100
+- name: something-static.4test-athing9-whichtest.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.114.171.119:80
+    weight: 100
+- name: something-static.4test-athing9-frank.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.105.108.141:80
+    weight: 100
+- name: something-static.4test-athing9-nsf.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.105.108.187:80
+    weight: 100
+- name: something-static.4test-athing10-jnk.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.121.148.40:80
+    weight: 100
+- name: something-static.4test-athing10-local.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.99.213.12:80
+    weight: 100
+- name: something-static.4test-athing10-bbitw.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.114.85.5:80
+    weight: 100
+- name: something-static.4test-athing10-gettests.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.114.171.69:80
+    weight: 100
+- name: something-static.4test-athing10-phn.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.97.79.106:80
+    weight: 100
+- name: something-static.4test-test1.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.127.223.44:80
+    weight: 100
+- name: something-static.4test-test2.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.121.228.136:80
+    weight: 100
+- name: testing-testing-ws.4test-any.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.112.140.24:8000
+    weight: 100
+- name: testing-testing-ws.4test-athing1-otherthing.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.121.228.169:8000
+    weight: 100
+- name: testing-testing-ws.4test-athing1-name.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.123.1.174:8000
+    weight: 100
+- name: testing-testing-ws.4test-athing1-othername.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.97.79.91:8000
+    weight: 100
+- name: testing-testing-ws.4test-athing1-morenames.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.122.180.74:8000
+    weight: 100
+- name: testing-testing-ws.4test-thatthing.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.98.136.216:8000
+    weight: 100
+- name: testing-testing-ws.4test-athing2-suchthing.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.122.91.85:8000
+    weight: 100
+- name: testing-testing-ws.4test-athing2-wow.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.100.77.179:8000
+    weight: 100
+- name: testing-testing-ws.4test-manythings.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.114.171.108:8000
+    weight: 100
+- name: testing-testing-ws.4test-verythings.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.113.229.92:8000
+    weight: 100
+- name: testing-testing-ws.4test-athing3-tester2.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.122.91.105:8000
+    weight: 100
+- name: testing-testing-ws.4test-athing3-oldthings.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.97.79.109:8000
+    weight: 100
+- name: testing-testing-ws.4test-demo1.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.112.140.15:8000
+    weight: 100
+- name: testing-testing-ws.4test-demo2.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.107.57.97:8000
+    weight: 100
+- name: testing-testing-ws.4test-dev.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.127.21.148:8000
+    weight: 100
+- name: testing-testing-ws.4test-athing4-sothings.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.114.85.12:8000
+    weight: 100
+- name: testing-testing-ws.4test-athing5-cousin.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.121.148.17:8000
+    weight: 100
+- name: testing-testing-ws.4test-athing5-verythings.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.122.91.99:8000
+    weight: 100
+- name: testing-testing-ws.4test-athing5-ygbkm.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.105.108.172:8000
+    weight: 100
+- name: testing-testing-ws.4test-athing5-gothings.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.105.222.165:8000
+    weight: 100
+- name: testing-testing-ws.4test-athing5-clever.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.105.108.173:8000
+    weight: 100
+- name: testing-testing-ws.4test-athing6-itis.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.115.236.23:8000
+    weight: 100
+- name: testing-testing-ws.4test-tldr.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.119.243.162:8000
+    weight: 100
+- name: testing-testing-ws.4test-shock.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.107.57.114:8000
+    weight: 100
+- name: testing-testing-ws.4test-local.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.112.197.221:8000
+    weight: 100
+- name: testing-testing-ws.4test-newthings.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.122.180.117:8000
+    weight: 100
+- name: testing-testing-ws.4test-athing7-halftest.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.113.31.196:8000
+    weight: 100
+- name: testing-testing-ws.4test-athing7-moartests.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.97.79.71:8000
+    weight: 100
+- name: testing-testing-ws.4test-athing7-gettests.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.105.108.147:8000
+    weight: 100
+- name: testing-testing-ws.4test-gottests.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.121.228.179:8000
+    weight: 100
+- name: testing-testing-ws.4test-fam.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.103.246.60:8000
+    weight: 100
+- name: testing-testing-ws.4test-athing8-2007.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.96.92.72:8000
+    weight: 100
+- name: testing-testing-ws.4test-grantests.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.121.228.151:8000
+    weight: 100
+- name: testing-testing-ws.4test-btests.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.112.197.232:8000
+    weight: 100
+- name: testing-testing-ws.4test-lttl.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.123.1.166:8000
+    weight: 100
+- name: testing-testing-ws.4test-athing9-valid.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.103.246.15:8000
+    weight: 100
+- name: testing-testing-ws.4test-athing9-morevalid.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.103.246.63:8000
+    weight: 100
+- name: testing-testing-ws.4test-athing9-wanttotest.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.113.229.106:8000
+    weight: 100
+- name: testing-testing-ws.4test-athing9-whichtest.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.123.141.88:8000
+    weight: 100
+- name: testing-testing-ws.4test-athing9-nsf.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.113.229.115:8000
+    weight: 100
+- name: testing-testing-ws.4test-athing10-jnk.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.113.31.225:8000
+    weight: 100
+- name: testing-testing-ws.4test-athing10-local.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.99.213.13:8000
+    weight: 100
+- name: testing-testing-ws.4test-athing10-bbitw.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.123.1.179:8000
+    weight: 100
+- name: testing-testing-ws.4test-athing10-gettests.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.120.185.28:8000
+    weight: 100
+- name: testing-testing-ws.4test-athing10-phn.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.99.213.46:8000
+    weight: 100
+- name: testing-testing-ws.4test-test1.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.121.228.137:8000
+    weight: 100
+- name: testing-testing-ws.4test-test2.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.127.223.49:8000
+    weight: 100
+- name: testing-testing.4test-any.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.114.85.54:8000
+    weight: 100
+- name: testing-testing.4test-athing1-otherthing.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.100.77.169:8000
+    weight: 100
+- name: testing-testing.4test-athing1-name.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.127.101.70:8000
+    weight: 100
+- name: testing-testing.4test-athing1-othername.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.114.85.11:8000
+    weight: 100
+- name: testing-testing.4test-athing1-morenames.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.96.92.101:8000
+    weight: 100
+- name: testing-testing.4test-thatthing.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.121.148.11:8000
+    weight: 100
+- name: testing-testing.4test-athing2-suchthing.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.98.136.202:8000
+    weight: 100
+- name: testing-testing.4test-athing2-wow.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.122.180.98:8000
+    weight: 100
+- name: testing-testing.4test-manythings.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.122.91.81:8000
+    weight: 100
+- name: testing-testing.4test-verythings.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.100.77.168:8000
+    weight: 100
+- name: testing-testing.4test-athing3-tester2.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.127.21.161:8000
+    weight: 100
+- name: testing-testing.4test-athing3-oldthings.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.127.21.152:8000
+    weight: 100
+- name: testing-testing.4test-demo1.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.119.243.153:8000
+    weight: 100
+- name: testing-testing.4test-demo2.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.107.57.116:8000
+    weight: 100
+- name: testing-testing.4test-dev.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.115.236.26:8000
+    weight: 100
+- name: testing-testing.4test-athing4-sothings.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.119.243.159:8000
+    weight: 100
+- name: testing-testing.4test-athing5-cousin.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.114.171.127:8000
+    weight: 100
+- name: testing-testing.4test-athing5-verythings.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.123.141.109:8000
+    weight: 100
+- name: testing-testing.4test-athing5-ygbkm.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.127.101.122:8000
+    weight: 100
+- name: testing-testing.4test-athing5-gothings.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.115.236.59:8000
+    weight: 100
+- name: testing-testing.4test-athing5-clever.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.121.228.184:8000
+    weight: 100
+- name: testing-testing.4test-athing6-itis.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.127.21.179:8000
+    weight: 100
+- name: testing-testing.4test-tldr.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.121.148.29:8000
+    weight: 100
+- name: testing-testing.4test-shock.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.112.197.225:8000
+    weight: 100
+- name: testing-testing.4test-local.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.103.246.34:8000
+    weight: 100
+  - target: 100.114.171.74:8000
+    weight: 100
+- name: testing-testing.4test-newthings.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.121.148.36:8000
+    weight: 100
+- name: testing-testing.4test-athing7-halftest.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.127.101.113:8000
+    weight: 100
+- name: testing-testing.4test-athing7-moartests.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.96.92.109:8000
+    weight: 100
+- name: testing-testing.4test-athing7-gettests.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.105.222.188:8000
+    weight: 100
+- name: testing-testing.4test-gottests.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.119.243.160:8000
+    weight: 100
+- name: testing-testing.4test-fam.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.103.246.59:8000
+    weight: 100
+- name: testing-testing.4test-athing8-2007.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.96.92.117:8000
+    weight: 100
+- name: testing-testing.4test-grantests.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.115.236.58:8000
+    weight: 100
+- name: testing-testing.4test-btests.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.112.197.237:8000
+    weight: 100
+- name: testing-testing.4test-lttl.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.105.222.146:8000
+    weight: 100
+- name: testing-testing.4test-athing9-valid.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.103.246.18:8000
+    weight: 100
+- name: testing-testing.4test-athing9-morevalid.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.98.136.255:8000
+    weight: 100
+- name: testing-testing.4test-athing9-wanttotest.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.123.141.99:8000
+    weight: 100
+- name: testing-testing.4test-athing9-whichtest.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.115.236.36:8000
+    weight: 100
+- name: testing-testing.4test-athing9-nsf.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.113.229.114:8000
+    weight: 100
+- name: testing-testing.4test-athing10-jnk.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.120.185.31:8000
+    weight: 100
+- name: testing-testing.4test-athing10-local.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.99.213.15:8000
+    weight: 100
+- name: testing-testing.4test-athing10-bbitw.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.120.185.24:8000
+    weight: 100
+- name: testing-testing.4test-athing10-gettests.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.120.185.27:8000
+    weight: 100
+- name: testing-testing.4test-athing10-phn.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.99.213.47:8000
+    weight: 100
+- name: testing-testing.4test-test1.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.127.223.25:8000
+    weight: 100
+- name: testing-testing.4test-test2.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.100.77.165:8000
+    weight: 100
+- name: testing-static-admin.4test-any.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.114.171.98:80
+    weight: 100
+- name: testing-static-admin.4test-athing1-otherthing.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.112.197.251:80
+    weight: 100
+- name: testing-static-admin.4test-athing1-name.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.100.77.147:80
+    weight: 100
+- name: testing-static-admin.4test-athing1-othername.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.97.79.72:80
+    weight: 100
+- name: testing-static-admin.4test-athing1-morenames.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.100.77.132:80
+    weight: 100
+- name: testing-static-admin.4test-thatthing.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.114.171.95:80
+    weight: 100
+- name: testing-static-admin.4test-athing2-suchthing.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.122.91.87:80
+    weight: 100
+- name: testing-static-admin.4test-athing2-wow.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.122.91.71:80
+    weight: 100
+- name: testing-static-admin.4test-manythings.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.122.180.73:80
+    weight: 100
+- name: testing-static-admin.4test-verythings.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.112.140.17:80
+    weight: 100
+- name: testing-static-admin.4test-athing3-oldthings.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.127.21.183:80
+    weight: 100
+- name: testing-static-admin.4test-demo1.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.115.236.32:80
+    weight: 100
+- name: testing-static-admin.4test-demo2.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.112.140.50:80
+    weight: 100
+- name: testing-static-admin.4test-dev.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.100.77.167:80
+    weight: 100
+- name: testing-static-admin.4test-athing4-sothings.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.105.222.157:80
+    weight: 100
+- name: testing-static-admin.4test-athing5-cousin.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.114.171.89:80
+    weight: 100
+- name: testing-static-admin.4test-athing5-verythings.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.114.171.118:80
+    weight: 100
+- name: testing-static-admin.4test-athing5-ygbkm.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.123.141.105:80
+    weight: 100
+- name: testing-static-admin.4test-athing5-gothings.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.114.85.27:80
+    weight: 100
+- name: testing-static-admin.4test-athing5-clever.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.98.136.237:80
+    weight: 100
+- name: testing-static-admin.4test-tldr.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.114.171.94:80
+    weight: 100
+- name: testing-static-admin.4test-shock.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.105.222.170:80
+    weight: 100
+- name: testing-static-admin.4test-local.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.97.79.125:80
+    weight: 100
+- name: testing-static-admin.4test-newthings.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.114.85.51:80
+    weight: 100
+- name: testing-static-admin.4test-athing7-halftest.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.105.108.132:80
+    weight: 100
+- name: testing-static-admin.4test-athing7-gettests.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.121.148.44:80
+    weight: 100
+- name: testing-static-admin.4test-gottests.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.98.136.207:80
+    weight: 100
+- name: testing-static-admin.4test-fam.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.123.1.149:80
+    weight: 100
+- name: testing-static-admin.4test-athing8-2007.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.112.140.34:80
+    weight: 100
+- name: testing-static-admin.4test-grantests.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.112.140.13:80
+    weight: 100
+- name: testing-static-admin.4test-btests.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.112.197.222:80
+    weight: 100
+- name: testing-static-admin.4test-lttl.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.98.136.244:80
+    weight: 100
+- name: testing-static-admin.4test-athing9-valid.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.103.246.5:80
+    weight: 100
+- name: testing-static-admin.4test-athing9-morevalid.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.105.108.178:80
+    weight: 100
+- name: testing-static-admin.4test-athing9-wanttotest.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.123.141.100:80
+    weight: 100
+- name: testing-static-admin.4test-athing9-whichtest.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.114.171.77:80
+    weight: 100
+- name: testing-static-admin.4test-athing9-nsf.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.113.229.116:80
+    weight: 100
+- name: testing-static-admin.4test-athing10-jnk.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.113.31.222:80
+    weight: 100
+- name: testing-static-admin.4test-athing10-local.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.99.213.14:80
+    weight: 100
+- name: testing-static-admin.4test-athing10-bbitw.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.112.140.38:80
+    weight: 100
+- name: testing-static-admin.4test-athing10-gettests.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.120.185.29:80
+    weight: 100
+- name: testing-static-admin.4test-athing10-phn.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.114.171.79:80
+    weight: 100
+- name: testing-static-admin.4test-test1.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.98.136.228:80
+    weight: 100
+- name: testing-static-admin.4test-test2.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.100.77.189:80
+    weight: 100
+- name: testing-static.4test-any.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.114.171.98:80
+    weight: 100
+- name: testing-static.4test-athing1-otherthing.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.112.197.251:80
+    weight: 100
+- name: testing-static.4test-athing1-name.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.100.77.147:80
+    weight: 100
+- name: testing-static.4test-athing1-othername.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.97.79.72:80
+    weight: 100
+- name: testing-static.4test-athing1-morenames.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.100.77.132:80
+    weight: 100
+- name: testing-static.4test-thatthing.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.114.171.95:80
+    weight: 100
+- name: testing-static.4test-athing2-suchthing.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.122.91.87:80
+    weight: 100
+- name: testing-static.4test-athing2-wow.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.122.91.71:80
+    weight: 100
+- name: testing-static.4test-manythings.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.122.180.73:80
+    weight: 100
+- name: testing-static.4test-verythings.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.112.140.17:80
+    weight: 100
+- name: testing-static.4test-athing3-tester2.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.127.21.160:80
+    weight: 100
+- name: testing-static.4test-athing3-oldthings.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.127.21.183:80
+    weight: 100
+- name: testing-static.4test-demo1.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.115.236.32:80
+    weight: 100
+- name: testing-static.4test-demo2.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.112.140.50:80
+    weight: 100
+- name: testing-static.4test-dev.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.100.77.167:80
+    weight: 100
+- name: testing-static.4test-athing4-sothings.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.105.222.157:80
+    weight: 100
+- name: testing-static.4test-athing5-cousin.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.114.171.89:80
+    weight: 100
+- name: testing-static.4test-athing5-verythings.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.114.171.118:80
+    weight: 100
+- name: testing-static.4test-athing5-ygbkm.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.123.141.105:80
+    weight: 100
+- name: testing-static.4test-athing5-gothings.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.114.85.27:80
+    weight: 100
+- name: testing-static.4test-athing5-clever.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.98.136.237:80
+    weight: 100
+- name: testing-static.4test-athing6-itis.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.115.236.22:80
+    weight: 100
+- name: testing-static.4test-tldr.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.114.171.94:80
+    weight: 100
+- name: testing-static.4test-shock.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.105.222.170:80
+    weight: 100
+- name: testing-static.4test-local.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.97.79.125:80
+    weight: 100
+- name: testing-static.4test-newthings.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.114.85.51:80
+    weight: 100
+- name: testing-static.4test-athing7-halftest.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.105.108.132:80
+    weight: 100
+- name: testing-static.4test-athing7-moartests.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.122.180.94:80
+    weight: 100
+- name: testing-static.4test-athing7-gettests.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.121.148.44:80
+    weight: 100
+- name: testing-static.4test-gottests.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.98.136.207:80
+    weight: 100
+- name: testing-static.4test-fam.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.123.1.149:80
+    weight: 100
+- name: testing-static.4test-athing8-2007.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.112.140.34:80
+    weight: 100
+- name: testing-static.4test-grantests.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.112.140.13:80
+    weight: 100
+- name: testing-static.4test-btests.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.112.197.222:80
+    weight: 100
+- name: testing-static.4test-lttl.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.98.136.244:80
+    weight: 100
+- name: testing-static.4test-athing9-valid.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.103.246.5:80
+    weight: 100
+- name: testing-static.4test-athing9-morevalid.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.105.108.178:80
+    weight: 100
+- name: testing-static.4test-athing9-wanttotest.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.123.141.100:80
+    weight: 100
+- name: testing-static.4test-athing9-whichtest.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.114.171.77:80
+    weight: 100
+- name: testing-static.4test-athing9-nsf.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.113.229.116:80
+    weight: 100
+- name: testing-static.4test-athing10-jnk.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.113.31.222:80
+    weight: 100
+- name: testing-static.4test-athing10-local.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.99.213.14:80
+    weight: 100
+- name: testing-static.4test-athing10-bbitw.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.112.140.38:80
+    weight: 100
+- name: testing-static.4test-athing10-gettests.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.120.185.29:80
+    weight: 100
+- name: testing-static.4test-athing10-phn.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.114.171.79:80
+    weight: 100
+- name: testing-static.4test-test1.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.98.136.228:80
+    weight: 100
+- name: testing-static.4test-test2.svc
+  algorithm: round-robin
+  slots: 10000
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      type: http
+      timeout: 1
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        tcp_failures: 0
+        timeouts: 0
+        interval: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+  hash_on: none
+  hash_fallback: none
+  hash_on_cookie_path: /
+  targets:
+  - target: 100.100.77.189:80
+    weight: 100
+plugins:
+- name: prometheus
+  enabled: true
+  run_on: first
+  protocols:
+  - grpc
+  - grpcs
+  - http
+  - https


### PR DESCRIPTION
When loading declarative configs, there were excessive events being fired up, overflowing lua-resty-worker-events queue, and losing some of them. 

This change creates a new keyword for upstreams and targets, which means that all of those entities must be processed, avoiding to create one event per entity.