### PR TITLE
fix(declarative) Lua input parsing and error handling

### DIFF
--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -101,12 +101,14 @@ function Config:parse_string(contents, filename, accept, old_hash)
     dc_table, err = cjson.decode(contents)
 
   elseif accept.lua and filename:match("lua$") then
-    local chunk = loadstring(contents)
-    setfenv(chunk, {})
+    local chunk, pok
+    chunk, err = loadstring(contents)
     if chunk then
-      local pok, dc_table = pcall(chunk)
+      setfenv(chunk, {})
+      pok, dc_table = pcall(chunk)
       if not pok then
         err = dc_table
+        dc_table = nil
       end
     end
 


### PR DESCRIPTION
This borrows from JSONschema and OpenAPI. Any value can now have a `$ref` entry, eg. json:

```json
  "my_key": { "$ref": "#/components/some/value" }
```
A new top level entry `components` is introduced to hold reusable objects and values.

An additional commit fixes the Lua declarative input parsing and error handling.