### PR TITLE
fix(plugins) check if log filename is valid

### DIFF
--- a/kong/plugins/file-log/schema.lua
+++ b/kong/plugins/file-log/schema.lua
@@ -1,18 +1,4 @@
-local pl_file = require "pl.file"
-local pl_path = require "pl.path"
 local typedefs = require "kong.db.schema.typedefs"
-
-local function validate_file(value)
-  -- create file in case it doesn't exist
-  if not pl_path.exists(value) then
-    local ok, err = pl_file.write(value, "")
-    if not ok then
-      return nil, string.format("Cannot create file: %s", err)
-    end
-  end
-
-  return true
-end
 
 return {
   name = "file-log",
@@ -23,7 +9,8 @@ return {
         fields = {
           { path = { type = "string",
                      required = true,
-                     custom_validator = validate_file,
+                     match = [[^[^*&%%\`]+$]],
+                     err = "not a valid filename",
           }, },
           { reopen = { type = "boolean", default = false }, },
     }, }, },

--- a/spec/03-plugins/04-file-log/02-schema_spec.lua
+++ b/spec/03-plugins/04-file-log/02-schema_spec.lua
@@ -1,0 +1,60 @@
+local Schema = require("kong.db.schema")
+
+describe("Plugin: file-log (schema)", function()
+
+  local tests = {
+    {
+      name = "path is required",
+      input = {
+        reopen = true
+      },
+      output = nil,
+      error = {
+        config = {
+          path = "required field missing"
+        }
+      }
+    },
+    ----------------------------------------
+    {
+      name = "rejects invalid filename",
+      input = {
+        path = "/ovo*",
+        reopen = true
+      },
+      output = nil,
+      error = {
+        config = {
+          path = "not a valid filename"
+        }
+      }
+    },
+    ----------------------------------------
+    {
+      name = "accepts valid filename",
+      input = {
+        path = "/tmp/log.txt",
+        reopen = true
+      },
+      output = true,
+      error = nil,
+    },
+  }
+
+  local file_log_schema
+
+  lazy_setup(function()
+    file_log_schema = Schema.new(require("kong.plugins.file-log.schema"))
+  end)
+
+  for _, t in ipairs(tests) do
+    it(t.name, function()
+      local output, err = file_log_schema:validate({
+        protocols = { "http" },
+        config = t.input
+      })
+      assert.same(t.output, output)
+      assert.same(t.error, err)
+    end)
+  end
+end)


### PR DESCRIPTION
file-log plugin was creating the log file when validating filename. As declarative config parsing runs earlier, the file was being created with master process owner permissions. 

This change validates only if the filename used is valid and gives file-log plugin responsibility on creating the log file, using worker process owner permissions.