### PR TITLE
feat(rate-limiting) set ttl for local policy counters

### DIFF
--- a/kong/globalpatches.lua
+++ b/kong/globalpatches.lua
@@ -69,10 +69,10 @@ return function(options)
       -- See https://github.com/openresty/resty-cli/pull/12
       -- for a definitive solution of using shms in CLI
       local SharedDict = {}
-      local function set(data, key, value)
+      local function set(data, key, value, expire_at)
         data[key] = {
           value = value,
-          info = {expired = false}
+          info = {expire_at = expire_at}
         }
       end
       function SharedDict:new()
@@ -98,13 +98,16 @@ return function(options)
           return false, "exists", false
         end
 
+        local expire_at = nil
+
         if exptime then
           ngx.timer.at(exptime, function()
             self.data[key] = nil
           end)
+          expire_at = ngx.now() + exptime
         end
 
-        set(self.data, key, value)
+        set(self.data, key, value, expire_at)
         return true, nil, false
       end
       SharedDict.safe_add = SharedDict.add
@@ -121,12 +124,18 @@ return function(options)
         end
         return true
       end
-      function SharedDict:incr(key, value, init)
+      function SharedDict:incr(key, value, init, init_ttl)
         if not self.data[key] then
           if not init then
             return nil, "not found"
           else
-            self.data[key] = { value = init }
+            self.data[key] = { value = init, info = {} }
+            if init_ttl then
+              self.data[key].info.expire_at = ngx.now() + init_ttl
+              ngx.timer.at(init_ttl, function()
+                self.data[key] = nil
+              end)
+            end
           end
         elseif type(self.data[key].value) ~= "number" then
           return nil, "not a number"
@@ -136,7 +145,7 @@ return function(options)
       end
       function SharedDict:flush_all()
         for _, item in pairs(self.data) do
-          item.info.expired = true
+          item.info.expire_at = ngx.now()
         end
       end
       function SharedDict:flush_expired(n)
@@ -144,7 +153,7 @@ return function(options)
         local flushed = 0
 
         for key, item in pairs(self.data) do
-          if item.info.expired then
+          if item.info.expire_at and item.info.expire_at <= ngx.now() then
             data[key] = nil
             flushed = flushed + 1
             if n and flushed == n then
@@ -167,6 +176,24 @@ return function(options)
           end
         end
         return keys
+      end
+      function SharedDict:ttl(key)
+        local item = self.data[key]
+        if item == nil then
+          return nil, "not found"
+        else
+          local expire_at = item.info.expire_at
+          if expire_at == nil then
+            return 0
+          else
+            local remaining = expire_at - ngx.now()
+            if remaining < 0 then
+              return nil, "not found"
+            else
+              return remaining
+            end
+          end
+        end
       end
 
       -- hack

--- a/kong/plugins/rate-limiting/policies/init.lua
+++ b/kong/plugins/rate-limiting/policies/init.lua
@@ -65,7 +65,7 @@ return {
       for period, period_date in pairs(periods) do
         if limits[period] then
           local cache_key = get_local_key(conf, identifier, period, period_date)
-          local newval, err = shm:incr(cache_key, value, 0)
+          local newval, err = shm:incr(cache_key, value, 0, EXPIRATIONS[period])
           if not newval then
             kong.log.err("could not increment counter for period '", period, "': ", err)
             return nil, err

--- a/spec/03-plugins/23-rate-limiting/02-policies_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/02-policies_spec.lua
@@ -44,6 +44,18 @@ describe("Plugin: rate-limiting (policies)", function()
       assert(minute_key_ttl > 55 and minute_key_ttl <= 60)
       assert(hour_key_ttl > 3555 and hour_key_ttl <= 3600)
     end)
+
+    it("expires after due time", function ()
+      local timestamp = 569000048000
+
+      assert(policies['local'].increment(conf, {second=100}, identifier, timestamp+20, 1))
+      local v = shm:ttl(get_local_key(conf, identifier, 'second', timestamp))
+      assert(v and v > 0, "wrong value")
+      ngx.sleep(1.020)
+
+      v = shm:ttl(get_local_key(conf, identifier, 'second', timestamp))
+      assert(v == nil, "still there")
+    end)
   end)
 
   for _, strategy in helpers.each_strategy() do


### PR DESCRIPTION
The "local" policy now sets the TTL on the counter to be equal to one period
length (e.g. if the counter is for requests in the current minute, the
TTL is set to one minute).

This supersedes #4422, bringing @cb372's contribution to a mergeable state.