### PR TITLE
feat(rate-limiting) at service level

### DIFF
--- a/kong/plugins/rate-limiting/handler.lua
+++ b/kong/plugins/rate-limiting/handler.lua
@@ -25,7 +25,9 @@ RateLimitingHandler.VERSION = "2.0.0"
 local function get_identifier(conf)
   local identifier
 
-  if conf.limit_by == "consumer" then
+  if conf.limit_by == "service" then
+    identifier = ""
+  elseif conf.limit_by == "consumer" then
     identifier = (kong.client.get_consumer() or
                   kong.client.get_credential() or
                   EMPTY).id

--- a/kong/plugins/rate-limiting/schema.lua
+++ b/kong/plugins/rate-limiting/schema.lua
@@ -40,7 +40,7 @@ return {
           { limit_by = {
               type = "string",
               default = "consumer",
-              one_of = { "consumer", "credential", "ip" },
+              one_of = { "consumer", "credential", "ip", "service" },
           }, },
           { policy = {
               type = "string",


### PR DESCRIPTION
Add service-level support for the rate-limiting plugin, in addition to the existing consumer, credential and IP levels.

This supersedes #4749 to merge @wuguangkuo's contribution into the `next` branch instead of `master`