### PR TITLE
fix(core) make sure that cassandra handles cluster event consistency

### DIFF
--- a/kong/cluster_events/strategies/cassandra.lua
+++ b/kong/cluster_events/strategies/cassandra.lua
@@ -78,7 +78,6 @@ function _M:select_interval(channels, min_at, max_at)
     prepared      = true,
     page_size     = self.page_size,
     consistencies = cassandra.consistencies[kong.configuration.cassandra_consistency:lower()],
-
   }
 
   local iter, b, c = self.cluster:iterate(SELECT_INTERVAL_QUERY, args, opts)

--- a/kong/cluster_events/strategies/cassandra.lua
+++ b/kong/cluster_events/strategies/cassandra.lua
@@ -3,6 +3,7 @@ local cassandra = require "cassandra"
 
 local fmt          = string.format
 local setmetatable = setmetatable
+local kong         = kong
 
 
 local INSERT_QUERY = [[
@@ -58,7 +59,7 @@ function _M:insert(node_id, channel, at, data, nbf)
     c_nbf,
   }, {
     prepared    = true,
-    consistency = cassandra.consistencies.local_one,
+    consistency = cassandra.consistencies[kong.configuration.cassandra_consistency:lower()],
   })
   if not res then
     return nil, "could not insert invalidation row: " .. err
@@ -76,7 +77,8 @@ function _M:select_interval(channels, min_at, max_at)
   local opts = {
     prepared      = true,
     page_size     = self.page_size,
-    consistencies = cassandra.consistencies.local_one,
+    consistencies = cassandra.consistencies[kong.configuration.cassandra_consistency:lower()],
+
   }
 
   local iter, b, c = self.cluster:iterate(SELECT_INTERVAL_QUERY, args, opts)


### PR DESCRIPTION
### Summary

The default is local_one, which does not match the strong consistency of cassandra, which may result in inaccurate data.

This PR takes the consistent configuration from the configuration of kong to ensure that it meets the user's expectations.