### PR TITLE
chore(deps) bump prometheus plugin to 0.5

### DIFF
--- a/kong-1.3.0-0.rockspec
+++ b/kong-1.3.0-0.rockspec
@@ -41,7 +41,7 @@ dependencies = {
   "kong-plugin-kubernetes-sidecar-injector ~> 0.2",
   "kong-plugin-zipkin ~> 0.1",
   "kong-plugin-serverless-functions ~> 0.3",
-  "kong-prometheus-plugin ~> 0.4",
+  "kong-prometheus-plugin ~> 0.5",
   "kong-proxy-cache-plugin ~> 1.2",
   "kong-plugin-request-transformer ~> 1.2",
   "kong-plugin-session ~> 2.1",

--- a/spec/01-unit/12-plugins_order_spec.lua
+++ b/spec/01-unit/12-plugins_order_spec.lua
@@ -12,6 +12,10 @@ describe("Plugins", function()
       plugins = "bundled",
     }))
 
+    local kong_global = require "kong.global"
+    _G.kong = kong_global.new()
+    kong_global.init_pdk(kong, conf, nil)
+
     plugins = {}
 
     for plugin in pairs(conf.loaded_plugins) do

--- a/spec/01-unit/13-plugins_version_spec.lua
+++ b/spec/01-unit/13-plugins_version_spec.lua
@@ -9,6 +9,10 @@ describe("Plugins", function()
 
     plugins = {}
 
+    local kong_global = require "kong.global"
+    _G.kong = kong_global.new()
+    kong_global.init_pdk(kong, conf, nil)
+
     for plugin in pairs(conf.loaded_plugins) do
       local handler = require("kong.plugins." .. plugin .. ".handler")
       table.insert(plugins, {


### PR DESCRIPTION
Changelog:
https://github.com/Kong/kong-plugin-prometheus/blob/master/CHANGELOG.md#050---20190916

Summary:
- **Route based metrics:**  All proxy metrics now contain a tag with the name
  or ID of the route.
- **New metrics releated to Kong's memory usage:**
  New metrics related to Kong's shared dictionaries
  and Lua VMs are now available
- Performance has been improved by avoiding unnecessary timer creation.
  This will lower the impact of the plugin on Kong's overall latency.