### PR TITLE
feat(response-transformer) add support to rename response headers

### DIFF
--- a/kong/plugins/response-transformer/header_transformer.lua
+++ b/kong/plugins/response-transformer/header_transformer.lua
@@ -53,7 +53,7 @@ _M.is_body_transform_set = is_body_transform_set
 ---
 --   # Example:
 --   ngx.headers = header_filter.transform_headers(conf, ngx.headers)
--- We run transformations in following order: remove, replace, add, append.
+-- We run transformations in following order: remove, rename, replace, add, append.
 -- @param[type=table] conf Plugin configuration.
 -- @param[type=table] ngx_headers Table of headers, that should be `ngx.headers`
 -- @return table A table containing the new headers.
@@ -61,6 +61,15 @@ function _M.transform_headers(conf, headers)
   -- remove headers
   for _, header_name in iter(conf.remove.headers) do
       kong.response.clear_header(header_name)
+  end
+
+  -- rename headers(s)
+  for _, old_name, new_name in iter(conf.rename.headers) do
+    if headers[old_name] ~= nil and new_name then
+      local value = headers[old_name]
+      kong.response.set_header(new_name, value)
+      kong.response.clear_header(old_name)
+    end
   end
 
   -- replace headers

--- a/kong/plugins/response-transformer/schema.lua
+++ b/kong/plugins/response-transformer/schema.lua
@@ -1,5 +1,25 @@
 local typedefs = require "kong.db.schema.typedefs"
+local validate_header_name = require("kong.tools.utils").validate_header_name
 
+
+local function validate_headers(pair, validate_value)
+  local name, value = pair:match("^([^:]+):*(.-)$")
+  if validate_header_name(name) == nil then
+    return nil, string.format("'%s' is not a valid header", tostring(name))
+  end
+
+  if validate_value then
+    if validate_header_name(value) == nil then
+      return nil, string.format("'%s' is not a valid header", tostring(value))
+    end
+  end
+  return true
+end
+
+
+local function validate_colon_headers(pair)
+  return validate_headers(pair, true)
+end
 
 local string_array = {
   type = "array",
@@ -13,7 +33,6 @@ local colon_string_array = {
   default = {},
   elements = { type = "string", match = "^[^:]+:.*$" },
 }
-
 
 
 local string_record = {
@@ -41,6 +60,20 @@ local colon_string_record = {
   },
 }
 
+local colon_headers_array = {
+  type = "array",
+  default = {},
+  elements = { type = "string", match = "^[^:]+:.*$", custom_validator = validate_colon_headers },
+}
+
+
+local colon_rename_strings_array_record = {
+  type = "record",
+  fields = {
+    { headers = colon_headers_array }
+  },
+}
+
 
 return {
   name = "response-transformer",
@@ -51,6 +84,7 @@ return {
         type = "record",
         fields = {
           { remove = string_record },
+          { rename  = colon_rename_strings_array_record },
           { replace = colon_string_record },
           { add = colon_string_record },
           { append = colon_string_record },

--- a/spec/01-unit/01-db/01-schema/07-plugins_spec.lua
+++ b/spec/01-unit/01-db/01-schema/07-plugins_spec.lua
@@ -138,6 +138,9 @@ describe("plugins", function()
         headers = {},
         json = {}
       },
+      rename = {
+        headers = {},
+      },
       replace = {
         headers = {},
         json = {},

--- a/spec/03-plugins/15-response-transformer/01-header_transformer_spec.lua
+++ b/spec/03-plugins/15-response-transformer/01-header_transformer_spec.lua
@@ -57,6 +57,9 @@ describe("Plugin: response-transformer", function()
         remove    = {
           headers = {"h1", "h2", "h3"}
         },
+        rename   = {
+          headers = {}
+        },
         replace   = {
           headers = {}
         },
@@ -79,9 +82,55 @@ describe("Plugin: response-transformer", function()
         assert.is_nil(headers[CONTENT_LENGTH])
       end)
     end)
+    describe("rename", function()
+      local conf  = {
+        remove    = {
+          json = {},
+          headers = {}
+        },
+        rename   = {
+          headers = {"h1:h2", "h3:h4"}
+        },
+        replace   = {
+          json    = {},
+          headers = {}
+        },
+        add       = {
+          json    = {},
+          headers = {}
+        },
+        append    = {
+          json    = {},
+          headers = {}
+        }
+      }
+      it("header if the header exists", function()
+        local headers = get_headers({ h1 = "v1", h3 = "v3"})
+        header_transformer.transform_headers(conf, headers)
+        assert.same({h2 = "v1", h4 = "v3"}, headers)
+      end)
+      it("header if the header exists and is empty", function()
+        local headers = get_headers({ h1 = ""})
+        header_transformer.transform_headers(conf, headers)
+        assert.same({h2 = " "}, headers)
+      end)
+      it("does not add as new header if header is nil", function()
+        local headers = get_headers({ h1 = nil})
+        header_transformer.transform_headers(conf, headers)
+        assert.same({h1 = nil}, headers)
+      end)
+      it("does not add as new header if header is not present", function()
+        local headers = get_headers({})
+        header_transformer.transform_headers(conf, headers)
+        assert.same({}, headers)
+      end)
+    end)
     describe("replace", function()
       local conf  = {
         remove    = {
+          headers = {}
+        },
+        rename   = {
           headers = {}
         },
         replace   = {
@@ -116,6 +165,9 @@ describe("Plugin: response-transformer", function()
         remove    = {
           headers = {}
         },
+        rename   = {
+          headers = {}
+        },
         replace   = {
           headers = {}
         },
@@ -146,6 +198,9 @@ describe("Plugin: response-transformer", function()
     describe("append", function()
       local conf  = {
         remove    = {
+          headers = {}
+        },
+        rename   = {
           headers = {}
         },
         replace   = {
@@ -180,6 +235,9 @@ describe("Plugin: response-transformer", function()
         remove    = {
           headers = {"h1:v1"}
         },
+        rename   = {
+          headers = {}
+        },
         replace   = {
           headers = {"h2:v3"}
         },
@@ -208,6 +266,9 @@ describe("Plugin: response-transformer", function()
           remove    = {
             json    = {"p1"},
             headers = {"h1", "h2"}
+          },
+          rename   = {
+            headers = {}
           },
           replace   = {
             json    = {},
@@ -248,6 +309,9 @@ describe("Plugin: response-transformer", function()
         local conf  = {
           remove    = {
             json    = {},
+            headers = {}
+          },
+          rename   = {
             headers = {}
           },
           replace   = {
@@ -291,6 +355,9 @@ describe("Plugin: response-transformer", function()
             json    = {},
             headers = {}
           },
+          rename   = {
+            headers = {}
+          },
           replace   = {
             json    = {},
             headers = {}
@@ -330,6 +397,9 @@ describe("Plugin: response-transformer", function()
         local conf  = {
           remove    = {
             json    = {},
+            headers = {}
+          },
+          rename   = {
             headers = {}
           },
           replace   = {

--- a/spec/03-plugins/15-response-transformer/03-api_spec.lua
+++ b/spec/03-plugins/15-response-transformer/03-api_spec.lua
@@ -48,6 +48,82 @@ for _, strategy in helpers.each_strategy() do
           local body = assert.response(res).has.jsonbody()
           assert.equals("just_a_key", body.config.remove.headers[1])
           assert.equals("just_a_key", body.config.remove.json[1])
+
+          admin_client:send {
+            method  = "DELETE",
+            path    = "/plugins/" .. body.id,
+          }
+        end)
+        it("rename succeeds with colons", function()
+          local rename_header = "x-request-id:x-custom-request-id"
+          local res = assert(admin_client:send {
+            method  = "POST",
+            path    = "/plugins",
+            body    = {
+              name   = "response-transformer",
+              config = {
+                rename = {
+                  headers = { rename_header },
+                },
+              },
+            },
+            headers = {
+              ["Content-Type"] = "application/json",
+            },
+          })
+          assert.response(res).has.status(201)
+          local body = assert.response(res).has.jsonbody()
+          assert.equals(rename_header, body.config.rename.headers[1])
+
+          admin_client:send {
+            method  = "DELETE",
+            path    = "/plugins/" .. body.id,
+          }
+        end)
+        it("rename fails with missing colons for header old_name/new_name separation", function()
+          local no_colons_header = "x-request-idx-custom-request-id"
+          local res = assert(admin_client:send {
+            method  = "POST",
+            path    = "/plugins",
+            body    = {
+              name   = "response-transformer",
+              config = {
+                rename = {
+                  headers = { no_colons_header },
+                },
+              },
+            },
+            headers = {
+              ["Content-Type"] = "application/json",
+            },
+          })
+          local body = assert.response(res).has.status(400)
+          local json = cjson.decode(body)
+          assert.same("schema violation", json.name)
+          assert.same({ "invalid value: " .. no_colons_header }, json.fields.config.rename.headers)
+        end)
+        it("rename fails with invalid header name for old_name or new_name separation", function()
+          local invalid_header = "x-requ,est-id"
+          local rename_header = invalid_header .. ":x-custom-request-id"
+          local res = assert(admin_client:send {
+            method  = "POST",
+            path    = "/plugins",
+            body    = {
+              name   = "response-transformer",
+              config = {
+                rename = {
+                  headers = { rename_header },
+                },
+              },
+            },
+            headers = {
+              ["Content-Type"] = "application/json",
+            },
+          })
+          local body = assert.response(res).has.status(400)
+          local json = cjson.decode(body)
+          assert.same("schema violation", json.name)
+          assert.same({ "'" .. invalid_header .. "' is not a valid header" }, json.fields.config.rename.headers)
         end)
         it("add fails with missing colons for key/value separation", function()
           local res = assert(admin_client:send {


### PR DESCRIPTION
### Summary

Add support to rename response headers in response-transformer plugin

### Full changelog

- Modify the schema of the response-transformer plugin to add
configuration related to rename headers. In addition, a function to
validate headers names through Kong method has been added.
- Modify _M.transform_headers response-transformer plugin function to
rename response headers.
- Add test for the rename response headers in response-transformer plugin.

Since request-transformer plugin support modify rename headers it is
necessary that response-tranformer plugin has it. For example, map the
value to internal header and expose public header.
