### PR TITLE
remove hardcoded charset #5044

### DIFF
--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -1,6 +1,4 @@
 return [[
-charset UTF-8;
-
 > if anonymous_reports then
 ${{SYSLOG_REPORTS}}
 > end


### PR DESCRIPTION
### Summary

When we set the environment variable nginx_http_charset, a message of duplicated entry is raised.
When this environment varibale is set, kongs set it on nginx.conf, but the charset is hardcoded on nginx_kong.conf.
With this approach, we are not abble to use a charset difrerent of UTF-8

The default value of nginx is off.

This behaviour broke applications who uses eg iso-8859-1 charsets.

### Full changelog

* Use the default nginx charset (default none)
* Stop with issue when we set a environment variable to set charset.

### Issues resolved

Fix #5044 
