### PR TITLE
fix(cluster_events) set LOCAL_ONE consistency in C* polling query

### DIFF
--- a/kong/cluster_events/strategies/cassandra.lua
+++ b/kong/cluster_events/strategies/cassandra.lua
@@ -74,9 +74,9 @@ function _M:select_interval(channels, min_at, max_at)
 
   local args = { cassandra.set(channels), c_min_at, c_max_at }
   local opts = {
-    prepared      = true,
-    page_size     = self.page_size,
-    consistencies = cassandra.consistencies.local_one,
+    prepared    = true,
+    page_size   = self.page_size,
+    consistency = cassandra.consistencies.local_one,
   }
 
   local iter, b, c = self.cluster:iterate(SELECT_INTERVAL_QUERY, args, opts)


### PR DESCRIPTION
The proper name for this option is `consistency`. Specifying
`consistencies` as prior to this patch causes the pagination queries to
use the default consistency setting of `ONE`, instead of the desired
`LOCAL_ONE`.