### PR TITLE
feat(conf) add handle_errors to config

### DIFF
--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -236,6 +236,8 @@ local CONF_INFERENCES = {
   lua_ssl_verify_depth = { typ = "number" },
   lua_socket_pool_size = { typ = "number" },
   service_mesh = { typ = "boolean" },
+
+  handle_errors = { typ = "boolean" },
 }
 
 

--- a/kong/pdk/response.lua
+++ b/kong/pdk/response.lua
@@ -485,6 +485,12 @@ local function new(self, major_version)
       error("headers have already been sent", 2)
     end
 
+    if self.configuration.handle_errors and self.ctx.core.phase ~= phase_checker.phases.admin_api and ngx.config.subsystem == "http" and status >= 400 then
+      ngx.ctx.error_body = body
+      ngx.ctx.error_headers = headers
+      return ngx.exit(status)
+    end
+
     ngx.status = status
 
     if self.ctx.core.phase == phase_checker.phases.admin_api then

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -97,4 +97,6 @@ lua_ssl_trusted_certificate = NONE
 lua_ssl_verify_depth = 1
 lua_package_path = ./?.lua;./?/init.lua;
 lua_package_cpath = NONE
+
+handle_errors = false
 ]]


### PR DESCRIPTION
### Summary

We would like to able to present errors resulting from Kong (and ultimately upstreams) in a consistent manner. 

Currently, internal/NGINX errors are handled via https://github.com/Kong/kong/blob/next/kong/error_handlers.lua through use of the `error_page` directives at https://github.com/Kong/kong/blob/ce43f03d67c52c1b8612240cfce6e26438ffb783/kong/templates/nginx_kong.lua#L87-L88

This nicely wraps up the error and returns it in the format specified via the `accept` header. However, any plugins, including core Kong code (e.g. route matching) make use of `kong.response.exit()` instead which results in the response being returned directly to the calling application through use of `ngx.print(body)`. 

For our own plugins, we could adjust the response we send via `kong.response.send` however, it is unfeasible to do this for all responses on all plugins we may use. Thus, for us to be able to handle, and return, errors to a calling application in a consistent manner we would need to override both `error_handlers.lua` and `pdk/response.lua`. By introducing a new config item `handle_errors` where, when set, Kong would not make use of `ngx.print`, we can ensure that any HTTP error (set in the `error_page` directives) are ultimately handled by `error_handlers.lua`. `error_handlers.lua` can, in turn,  easily be customised and overriden to provide a consistent error response for any 400+ status generated within Kong. 

In addition, it becomes fairly trivial to handle upstream errors in the same fashion through use of a plugin operating on `header_filter`. E.g. 

```
function ProxyErrorsHandler:header_filter(conf)
  ProxyErrorsHandler.super.header_filter(self)

  local status = kong.response.get_status()
  if kong.configuration.handle_errors and status >= 400 and not ngx.ctx.ERROR_HANDLED then
    local error_message = kong.response.get_header(conf.custom_error_header)

    if error_message then
      ngx.ctx.error_body = { message = error_message }
    end

    return ngx.exit(status)
  end
end
```

In doing so, this enables us present consistent errors for all requests proxied via Kong and, to be able to pass error context from the upstream to a standard error handler - something that is not possible using the standard nginx directive `proxy_intercept_errors`.

### Full changelog

* Add boolean config option `handle_errors` - defaulted to `false/off`
* Before sending response, check `handle_errors` config. If set to `true` and `ngx.config.subsystem == "http"` and `status >= 400` then set `ctx.error_body` and `ctx.error_headers` and exit without writing to response.
* Attempt to read `ctx.error_body` and `ctx.error_headers` within error handling and set message and headers accordingly if these are populated.