### PR TITLE
chore(reports) sends reports with tcp instead of udp

### DIFF
--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -115,7 +115,7 @@ return {
   REPORTS = {
     ADDRESS = "kong-hf.konghq.com",
     SYSLOG_PORT = 61828,
-    STATS_PORT = 61829
+    STATS_PORT = 61830
   },
   DICTS = {
     "kong",

--- a/spec/01-unit/11-reports_spec.lua
+++ b/spec/01-unit/11-reports_spec.lua
@@ -14,8 +14,8 @@ describe("reports", function()
       package.loaded["kong.reports"] = nil
     end)
 
-    it("sends report over UDP", function()
-      local thread = helpers.udp_server(8189)
+    it("sends report over TCP", function()
+      local thread = helpers.tcp_server(8189)
 
       reports.send("stub", {
         hello = "world",
@@ -46,22 +46,21 @@ describe("reports", function()
     it("doesn't send if not enabled", function()
       reports.toggle(false)
 
-      local thread = helpers.udp_server(8189, 1, 0.1)
+      local thread = helpers.tcp_server(8189, { requests = 1, timeout = 0.1 })
 
       reports.send({
         foo = "bar"
       }, "127.0.0.1", 8189)
 
-      local ok, res, err = thread:join()
+      local ok, res = thread:join()
       assert.True(ok)
-      assert.is_nil(res)
-      assert.equal("timeout", err)
+      assert.equal("timeout", res)
     end)
 
     it("accepts custom immutable items", function()
       reports.toggle(true)
 
-      local thread = helpers.udp_server(8189)
+      local thread = helpers.tcp_server(8189)
 
       reports.add_immutable_value("imm1", "fooval")
       reports.add_immutable_value("imm2", "barval")
@@ -92,7 +91,7 @@ describe("reports", function()
         }))
         reports.configure_ping(conf)
 
-        local thread = helpers.udp_server(8189)
+        local thread = helpers.tcp_server(8189)
         reports.send_ping("127.0.0.1", 8189)
 
         local _, res = assert(thread:join())
@@ -105,7 +104,7 @@ describe("reports", function()
         }))
         reports.configure_ping(conf)
 
-        local thread = helpers.udp_server(8189)
+        local thread = helpers.tcp_server(8189)
         reports.send_ping("127.0.0.1", 8189)
 
         local _, res = assert(thread:join())
@@ -118,7 +117,7 @@ describe("reports", function()
         }))
         reports.configure_ping(conf)
 
-        local thread = helpers.udp_server(8189)
+        local thread = helpers.tcp_server(8189)
         reports.send_ping("127.0.0.1", 8189)
 
         local _, res = assert(thread:join())
@@ -133,7 +132,7 @@ describe("reports", function()
         }))
         reports.configure_ping(conf)
 
-        local thread = helpers.udp_server(8189)
+        local thread = helpers.tcp_server(8189)
         reports.send_ping("127.0.0.1", 8189)
 
         local _, res = assert(thread:join())
@@ -146,7 +145,7 @@ describe("reports", function()
         }))
         reports.configure_ping(conf)
 
-        local thread = helpers.udp_server(8189)
+        local thread = helpers.tcp_server(8189)
         reports.send_ping("127.0.0.1", 8189)
 
         local _, res = assert(thread:join())
@@ -161,7 +160,7 @@ describe("reports", function()
         }))
         reports.configure_ping(conf)
 
-        local thread = helpers.udp_server(8189)
+        local thread = helpers.tcp_server(8189)
         reports.send_ping("127.0.0.1", 8189)
 
         local _, res = assert(thread:join())
@@ -174,7 +173,7 @@ describe("reports", function()
         }))
         reports.configure_ping(conf)
 
-        local thread = helpers.udp_server(8189)
+        local thread = helpers.tcp_server(8189)
         reports.send_ping("127.0.0.1", 8189)
 
         local _, res = assert(thread:join())
@@ -189,7 +188,7 @@ describe("reports", function()
         }))
         reports.configure_ping(conf)
 
-        local thread = helpers.udp_server(8189)
+        local thread = helpers.tcp_server(8189)
         reports.send_ping("127.0.0.1", 8189)
 
         local _, res = assert(thread:join())
@@ -202,7 +201,7 @@ describe("reports", function()
         }))
         reports.configure_ping(conf)
 
-        local thread = helpers.udp_server(8189)
+        local thread = helpers.tcp_server(8189)
         reports.send_ping("127.0.0.1", 8189)
 
         local _, res = assert(thread:join())
@@ -217,7 +216,7 @@ describe("reports", function()
         }))
         reports.configure_ping(conf)
 
-        local thread = helpers.udp_server(8189)
+        local thread = helpers.tcp_server(8189)
         reports.send_ping("127.0.0.1", 8189)
 
         local _, res = assert(thread:join())
@@ -230,7 +229,7 @@ describe("reports", function()
         }))
         reports.configure_ping(conf)
 
-        local thread = helpers.udp_server(8189)
+        local thread = helpers.tcp_server(8189)
         reports.send_ping("127.0.0.1", 8189)
 
         local _, res = assert(thread:join())
@@ -245,7 +244,7 @@ describe("reports", function()
         }))
         reports.configure_ping(conf)
 
-        local thread = helpers.udp_server(8189)
+        local thread = helpers.tcp_server(8189)
         reports.send_ping("127.0.0.1", 8189)
 
         local _, res = assert(thread:join())
@@ -258,7 +257,7 @@ describe("reports", function()
         }))
         reports.configure_ping(conf)
 
-        local thread = helpers.udp_server(8189)
+        local thread = helpers.tcp_server(8189)
         reports.send_ping("127.0.0.1", 8189)
 
         local _, res = assert(thread:join())
@@ -271,7 +270,7 @@ describe("reports", function()
         }))
         reports.configure_ping(conf)
 
-        local thread = helpers.udp_server(8189)
+        local thread = helpers.tcp_server(8189)
         reports.send_ping("127.0.0.1", 8189)
 
         local _, res = assert(thread:join())
@@ -283,7 +282,7 @@ describe("reports", function()
         local conf = assert(conf_loader())
         reports.configure_ping(conf)
 
-        local thread = helpers.udp_server(8189)
+        local thread = helpers.tcp_server(8189)
         reports.send_ping("127.0.0.1", 8189)
 
         local _, res = assert(thread:join())

--- a/spec/02-integration/02-cmd/11-config_spec.lua
+++ b/spec/02-integration/02-cmd/11-config_spec.lua
@@ -80,7 +80,7 @@ describe("kong config", function()
       anonymous_reports = "on",
     }))
 
-    local thread = helpers.udp_server(constants.REPORTS.STATS_PORT)
+    local thread = helpers.tcp_server(constants.REPORTS.STATS_PORT)
 
     assert(helpers.kong_exec("config db_import " .. filename, {
       prefix = helpers.test_conf.prefix,

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -553,7 +553,7 @@ local function tcp_server(port, opts)
     function(port, opts)
       local socket = require "socket"
       local server = assert(socket.tcp())
-      server:settimeout(360)
+      server:settimeout(opts.timeout or 360)
       assert(server:setoption("reuseaddr", true))
       assert(server:bind("*", port))
       assert(server:listen())
@@ -562,7 +562,20 @@ local function tcp_server(port, opts)
       local handshake_done = false
       local n = opts.requests or 1
       for _ = 1, n + 1 do
-        local client = assert(server:accept())
+        local client, err
+        if opts.timeout then
+          client, err = server:accept()
+          if err == "timeout" then
+            line = "timeout"
+            break
+
+          else
+            assert(client, err)
+          end
+
+        else
+          client = assert(server:accept())
+        end
 
         if opts.tls and handshake_done then
           local ssl = require "ssl"
@@ -577,7 +590,6 @@ local function tcp_server(port, opts)
           client:dohandshake()
         end
 
-        local err
         line, err = client:receive()
         if err == "closed" then
           fails = fails + 1
@@ -751,71 +763,98 @@ local function udp_server(port, n, timeout)
 end
 
 
-local function mock_reports_server()
+local function mock_reports_server(opts)
   local localhost = "127.0.0.1"
   local threads = require "llthreads2.ex"
   local server_port = constants.REPORTS.STATS_PORT
+  opts = opts or {}
 
   local thread = threads.new({
-    function(port, localhost)
+    function(port, host, opts)
       local socket = require "socket"
-
-      local server = assert(socket.udp())
-      server:settimeout(1)
-      server:setoption("reuseaddr", true)
-      server:setsockname(localhost, port)
+      local server = assert(socket.tcp())
+      server:settimeout(360)
+      assert(server:setoption("reuseaddr", true))
+      assert(server:bind(host, port))
+      assert(server:listen())
       local data = {}
-      local started = false
-      while true do
-        local packet, recvip, recvport = server:receivefrom()
-        if packet then
-          if packet == "\\START" then
-            if not started then
-              started = true
-              server:sendto("\\OK", recvip, recvport)
-            end
-          elseif packet == "\\STOP" then
-            break
+      local handshake_done = false
+      local n = opts.requests or math.huge
+      for _ = 1, n + 1 do
+        local client = assert(server:accept())
+
+        if opts.tls and handshake_done then
+          local ssl = require "ssl"
+          local params = {
+            mode = "server",
+            protocol = "any",
+            key = "spec/fixtures/kong_spec.key",
+            certificate = "spec/fixtures/kong_spec.crt",
+          }
+
+          client = ssl.wrap(client, params)
+          client:dohandshake()
+        end
+
+        local line, err = client:receive()
+        if err ~= "closed" then
+          if not handshake_done then
+            assert(line == "\\START")
+            client:send("\\OK\n")
+            handshake_done = true
+
           else
-            table.insert(data, packet)
+            if line == "@DIE@" then
+              client:close()
+              break
+            end
+
+            table.insert(data, line)
           end
+
+          client:close()
         end
       end
       server:close()
+
       return data
     end
-  }, server_port, localhost)
-  thread:start()
+  }, server_port, localhost, opts)
 
-  local handshake_skt = assert(ngx.socket.udp())
-  handshake_skt:setpeername(localhost, server_port)
-  handshake_skt:settimeout(0.1)
+  thread:start()
 
   -- not necessary for correctness because we do the handshake,
   -- but avoids harmless "connection error" messages in the wait loop
   -- in case the client is ready before the server below.
-  ngx.sleep(0.05)
+  ngx.sleep(0.001)
 
+  local sock = ngx.socket.tcp()
+  sock:settimeout(0.01)
   while true do
-    handshake_skt:send("\\START")
-    local ok = handshake_skt:receive()
-    if ok == "\\OK" then
-      break
+    if sock:connect(localhost, server_port) then
+      sock:send("\\START\n")
+      local ok = sock:receive()
+      sock:close()
+      if ok == "\\OK" then
+        break
+      end
     end
   end
-  handshake_skt:close()
+  sock:close()
 
   return {
     stop = function()
-      local skt = assert(ngx.socket.udp())
-      skt:setpeername(localhost, server_port)
-      skt:send("\\STOP")
+      local skt = assert(ngx.socket.tcp())
+      sock:settimeout(0.01)
+      skt:connect(localhost, server_port)
+      skt:send("@DIE@\n")
       skt:close()
 
       return thread:join()
     end
   }
 end
+
 
 --------------------
 -- Custom assertions


### PR DESCRIPTION
### Summary

Sends reports with `tcp` instead of `udp`. Also changes the port where the reports are sent from 61829 to 61830.