### PR TITLE
feat(datadog) add overloaded_service_name and common_tags parameters

### DIFF
--- a/kong/plugins/datadog/schema.lua
+++ b/kong/plugins/datadog/schema.lua
@@ -100,6 +100,8 @@ return {
           { host = typedefs.host({ required = true, default = "localhost" }), },
           { port = typedefs.port({ required = true, default = 8125 }), },
           { prefix = { type = "string", default = "kong" }, },
+          { common_tags = { type = "array", elements = { type = "string", match = "^.*[^:]$" }, }, },
+          { overloaded_service_name = { type = "string"}, },
           { metrics = {
               type     = "array",
               required = true,


### PR DESCRIPTION
# Summary

These two parameters are optional and do not change the current behavior by default.

```overloaded_service_name``` allows to force the string used in place of the service name when building  the metrics name. This is useful when several kong services actually implement the same "conceptual" service, for instance when several upstreams provide the same API. For cases like this, datadog encourages the usage of a common metric with tags to filter the subsets when required.
    
```common_tags``` allows to specify a collection of tags at service level that will be used by all metrics. The common tags are added to the metrics-level tags. This is actually a sugar parameter to avoid redefining all the default metrics just to apply the same tag to all of them. This helps keep the configuration logic simple and the configuration files (when using DB-less mode) more readable.

# Example of use in DB-less mode

```yaml
- name: myVHost1-loginService
  plugins:
  - config:
      common_tags:
      - vhost:v1
      overloaded_service_name: loginService
    name: datadog
  routes:
  - hosts:
    - myvhost1.mydomain.com
    methods:
    - POST
    paths:
    - /login
    protocols:
    - https
  url: http://localhost:8080/login
- name: myVHost2-loginService
  plugins:
  - config:
      common_tags:
      - vhost:v2
      overloaded_service_name: loginService
    name: datadog
  routes:
  - hosts:
    - myvhost2.mydomain.com
    methods:
    - POST
    paths:
    - /login
    protocols:
    - https
  url: http://localhost:8081/login
```
