### PR TITLE
chore(ci) fix dependency hash

### DIFF
--- a/.ci/setup_env.sh
+++ b/.ci/setup_env.sh
@@ -1,11 +1,20 @@
 #!/usr/bin/env bash
 # set -e
 
+dep_version() {
+    grep $1 .requirements | sed -e 's/.*=//' | tr -d '\n'
+}
+
+OPENRESTY=$(dep_version RESTY_VERSION)
+LUAROCKS=$(dep_version RESTY_LUAROCKS_VERSION)
+OPENSSL=$(dep_version RESTY_OPENSSL_VERSION)
+
+
 #---------
 # Download
 #---------
 
-DEPS_HASH=$(cat .ci/setup_env.sh .travis.yml | md5sum | awk '{ print $1 }')
+DEPS_HASH=$(cat .ci/setup_env.sh .travis.yml .requirements | md5sum | awk '{ print $1 }')
 DOWNLOAD_ROOT=${DOWNLOAD_ROOT:=/download-root}
 BUILD_TOOLS_DOWNLOAD=$DOWNLOAD_ROOT/openresty-build-tools
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,6 @@ env:
     - TEST_SUITE=pdk
 
 install:
-  - make setup-ci
   - source .ci/setup_env.sh
   - make dev
 


### PR DESCRIPTION
### Summary

DEPS_HASH on .travis.yml didn't depend on .requirements file. This PR makes .requirements part of it, and also removes `make setup-ci`, which has already been removed in `next` branch. Also makes setup_env.sh to pick deps from .requirements file (fixing the failure in https://travis-ci.org/Kong/kong/jobs/588551598#L284)

### Full changelog


* .requirements has to be part of the DEPS_HASH to be aware of changes
  on deps

* Removing `make setup-ci` step from .travis.yml and making setup_env
  find the dependency versions from .requirements file.  Previous to
  this, the build was tried twice (the second one failing due to not
  having the variables set)

