### PR TITLE
feat(cassandra) refresh cluster topology 

### DIFF
--- a/kong-1.3.0-0.rockspec
+++ b/kong-1.3.0-0.rockspec
@@ -20,7 +20,7 @@ dependencies = {
   "multipart == 0.5.5",
   "version == 1.0.1",
   "kong-lapis == 1.7.0.1",
-  "lua-cassandra == 1.4.0",
+  "lua-cassandra == 1.5.0",
   "pgmoon == 1.10.0",
   "luatz == 0.4",
   "http == 0.3",

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -667,6 +667,14 @@
                                  # of the local (closest) datacenter for this
                                  # Kong node.
 
+#cassandra_refresh_frequency = 60          # Frequency (in seconds) at which
+                                           # the cluster topology will be
+                                           # checked for new or decommissioned
+                                           # nodes.
+                                           # A value of `0` will disable this
+                                           # check, and the cluster topology
+                                           # will never be refreshed.
+
 #cassandra_repl_strategy = SimpleStrategy  # When migrating for the first time,
                                            # Kong will use this setting to
                                            # create your keyspace.

--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -188,6 +188,7 @@ local CONF_INFERENCES = {
                           }
                         },
   cassandra_local_datacenter = { typ = "string" },
+  cassandra_refresh_frequency = { typ = "number" },
   cassandra_repl_strategy = { enum = {
                                 "SimpleStrategy",
                                 "NetworkTopologyStrategy",
@@ -343,6 +344,10 @@ local function check_and_infer(conf)
     then
       errors[#errors + 1] = "must specify 'cassandra_local_datacenter' when " ..
                             conf.cassandra_lb_policy .. " policy is in use"
+    end
+
+    if conf.cassandra_refresh_frequency < 0 then
+      errors[#errors + 1] = "cassandra_refresh_frequency must be 0 or greater"
     end
 
     for _, contact_point in ipairs(conf.cassandra_contact_points) do

--- a/kong/db/strategies/cassandra/connector.lua
+++ b/kong/db/strategies/cassandra/connector.lua
@@ -199,6 +199,7 @@ function CassandraConnector.new(kong_config)
         cassandra.consistencies[kong_config.cassandra_consistency:lower()],
       serial_consistency = serial_consistency,
     },
+    refresh_frequency = kong_config.cassandra_refresh_frequency,
     connection = nil, -- created by connect()
   }
 
@@ -255,6 +256,36 @@ function CassandraConnector:init()
 
   self.major_version = major_version
   self.major_minor_version = major_minor_version
+
+  return true
+end
+
+
+function CassandraConnector:init_worker()
+  if self.refresh_frequency > 0 then
+    local hdl, err = ngx.timer.every(self.refresh_frequency, function()
+      local ok, err, topology = self.cluster:refresh(self.refresh_frequency)
+      if not ok then
+        ngx.log(ngx.ERR, "[cassandra] failed to refresh cluster topology: ",
+                         err)
+
+      elseif topology then
+        if #topology.added > 0 then
+          ngx.log(ngx.NOTICE, "[cassandra] peers added to cluster topology: ",
+                              table.concat(topology.added, ", "))
+        end
+
+        if #topology.removed > 0 then
+          ngx.log(ngx.NOTICE, "[cassandra] peers removed from cluster topology: ",
+                              table.concat(topology.removed, ", "))
+        end
+      end
+    end)
+    if not hdl then
+      return nil, "failed to initialize Cassandra topology refresh timer: " ..
+                  err
+    end
+  end
 
   return true
 end

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -66,6 +66,7 @@ cassandra_password = NONE
 cassandra_consistency = ONE
 cassandra_lb_policy = RequestRoundRobin
 cassandra_local_datacenter = NONE
+cassandra_refresh_frequency = 60
 cassandra_repl_strategy = SimpleStrategy
 cassandra_repl_factor = 1
 cassandra_data_centers = dc1:2,dc2:3

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -563,6 +563,14 @@ describe("Configuration loader", function()
       assert.equal([[bad cassandra contact point 'some/really\bad/host\name': invalid hostname: some/really\bad/host\name]], err)
       assert.is_nil(conf)
     end)
+    it("errors cassandra_refresh_frequency is < 0", function()
+      local conf, err = conf_loader(nil, {
+          database                    = "cassandra",
+          cassandra_refresh_frequency = -1,
+      })
+      assert.equal("cassandra_refresh_frequency must be 0 or greater", err)
+      assert.is_nil(conf)
+    end)
     it("errors when specifying a port in cassandra_contact_points", function()
       local conf, err = conf_loader(nil, {
           database                 = "cassandra",


### PR DESCRIPTION
### Summary

A new `cassandra_refresh_frequency` property schedules a recurring background timer calling lua-cassandra's [cluster:refresh()](https://thibaultcha.github.io/lua-cassandra/modules/resty.cassandra.cluster.html#_Cluster:refresh) method in the background. In lua-cassandra 1.5.0, this method has been refactored to be safe to call at runtime.

When `cassandra_refresh_frequency` is `0`, no topology refresh timer will be scheduled. A restart of Kong is necessary for lua-cassandra to consider new nodes (decommissioned nodes are blacklisted by the retry policy). The default value for this timer is chosen to be `60`.

No Admin API endpoint has been implemented as part of this PR for the time being. Subsequent patches welcome if a manual refresh feature turns out to be desired.

**Note:** a more consequent refactor of lua-cassandra's CQL binary protocol implementation would allow for REGISTERing a connection, and interpreting [TOPOLOGY_CHANGE](https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v5.spec#L794) events, which would be a more efficient approach.  

### Full changelog

* Bump lua-cassandra to 1.5.0 ([Changelog](https://github.com/thibaultcha/lua-cassandra/blob/master/CHANGELOG.md#150))
* Add a new property: `cassandra_refresh_frequency`

### Issues resolved

Fix #2674
