### PR TITLE
fix(log-serializer) log correct request properties on NGINX-produced errors

### DIFF
--- a/kong/pdk/init.lua
+++ b/kong/pdk/init.lua
@@ -211,7 +211,7 @@ assert(package.loaded["resty.core"])
 
 local MAJOR_VERSIONS = {
   [1] = {
-    version = "1.2.0",
+    version = "1.3.0",
     modules = {
       "table",
       "node",

--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -264,6 +264,14 @@ local function new(self)
   function _REQUEST.get_method()
     check_phase(PHASES.request)
 
+    if ngx.ctx.KONG_UNEXPECTED and _REQUEST.get_http_version() < 2 then
+      local req_line = ngx.var.request
+      local idx = find(req_line, " ", 1, true)
+      if idx then
+        return sub(req_line, 1, idx - 1)
+      end
+    end
+
     return ngx.req.get_method()
   end
 
@@ -397,19 +405,36 @@ local function new(self)
     check_phase(PHASES.request)
 
     if max_args == nil then
-      return ngx.req.get_uri_args(MAX_QUERY_ARGS_DEFAULT)
+      max_args = MAX_QUERY_ARGS_DEFAULT
+
+    else
+      if type(max_args) ~= "number" then
+        error("max_args must be a number", 2)
+      end
+
+      if max_args < MIN_QUERY_ARGS then
+        error("max_args must be >= " .. MIN_QUERY_ARGS, 2)
+      end
+
+      if max_args > MAX_QUERY_ARGS then
+        error("max_args must be <= " .. MAX_QUERY_ARGS, 2)
+      end
     end
 
-    if type(max_args) ~= "number" then
-      error("max_args must be a number", 2)
-    end
+    if ngx.ctx.KONG_UNEXPECTED and _REQUEST.get_http_version() < 2 then
+      local req_line = ngx.var.request
+      local qidx = find(req_line, "?", 1, true)
+      if not qidx then
+        return {}
+      end
 
-    if max_args < MIN_QUERY_ARGS then
-      error("max_args must be >= " .. MIN_QUERY_ARGS, 2)
-    end
+      local eidx = find(req_line, " ", qidx + 1, true)
+      if not eidx then
+        -- HTTP 414, req_line is too long
+        return {}
+      end
 
-    if max_args > MAX_QUERY_ARGS then
-      error("max_args must be <= " .. MAX_QUERY_ARGS, 2)
+      return ngx.decode_args(sub(req_line, qidx + 1, eidx - 1), max_args)
     end
 
     return ngx.req.get_uri_args(max_args)

--- a/kong/plugins/log-serializers/basic.lua
+++ b/kong/plugins/log-serializers/basic.lua
@@ -1,14 +1,19 @@
 local tablex = require "pl.tablex"
 local ngx_ssl = require "ngx.ssl"
+local gkong = kong
 
 local _M = {}
 
 local EMPTY = tablex.readonly({})
 
-function _M.serialize(ngx)
+function _M.serialize(ngx, kong)
   local ctx = ngx.ctx
   local var = ngx.var
   local req = ngx.req
+
+  if not kong then
+    kong = gkong
+  end
 
   local authenticated_entity
   if ctx.authenticated_credential ~= nil then
@@ -34,9 +39,9 @@ function _M.serialize(ngx)
     request = {
       uri = request_uri,
       url = var.scheme .. "://" .. var.host .. ":" .. var.server_port .. request_uri,
-      querystring = req.get_uri_args(), -- parameters, as a table
-      method = req.get_method(), -- http method
-      headers = req.get_headers(),
+      querystring = kong.request.get_query(), -- parameters, as a table
+      method = kong.request.get_method(), -- http method
+      headers = kong.request.get_headers(),
       size = var.request_length,
       tls = request_tls
     },

--- a/spec/02-integration/05-proxy/04-plugins_triggering_spec.lua
+++ b/spec/02-integration/05-proxy/04-plugins_triggering_spec.lua
@@ -694,9 +694,7 @@ for _, strategy in helpers.each_strategy() do
       end)
 
 
-      pending("log plugins sees same request in error_page handler (HTTP 502)", function()
-        -- PENDING: waiting on Nginx error_patch_preserve_method patch
-
+      it("log plugins sees same request in error_page handler (HTTP 502)", function()
         -- triggers error_page directive
         local uuid = utils.uuid()
 
@@ -791,7 +789,7 @@ for _, strategy in helpers.each_strategy() do
       end)
 
 
-      pending("log plugins sees same request in error_page handler (HTTP 504)", function()
+      it("log plugins sees same request in error_page handler (HTTP 504)", function()
         -- triggers error_page directive
         local uuid = utils.uuid()
 
@@ -859,9 +857,7 @@ for _, strategy in helpers.each_strategy() do
       end)
 
 
-      pending("log plugins sees same request in error_page handler (HTTP 494)", function()
-        -- PENDING: waiting on Nginx error_patch_preserve_method patch
-
+      it("log plugins sees same request in error_page handler (HTTP 494)", function()
         -- triggers error_page directive
         local uuid = utils.uuid()
 
@@ -893,9 +889,9 @@ for _, strategy in helpers.each_strategy() do
         local log_message = cjson.decode(pl_stringx.strip(log))
         assert.equal("POST", log_message.request.method)
         assert.equal("bar", log_message.request.querystring.foo)
-        assert.equal("/status/200?foo=bar", log_message.upstream_uri)
+        assert.equal("", log_message.upstream_uri) -- no URI here since Nginx could not parse request
         assert.equal(uuid, log_message.request.headers["x-uuid"])
-        assert.equal("unavailable", log_message.request.headers.host)
+        assert.is_nil(log_message.request.headers.host) -- none as well
       end)
 
 
@@ -929,9 +925,7 @@ for _, strategy in helpers.each_strategy() do
       end)
 
 
-      pending("log plugins sees same request in error_page handler (HTTP 414)", function()
-        -- PENDING: waiting on Nginx error_patch_preserve_method patch
-
+      it("log plugins sees same request in error_page handler (HTTP 414)", function()
         -- triggers error_page directive
         local uuid = utils.uuid()
 
@@ -960,8 +954,6 @@ for _, strategy in helpers.each_strategy() do
 
         local log = pl_file.read(FILE_LOG_PATH)
         local log_message = cjson.decode(pl_stringx.strip(log))
-        local ins = require "inspect"
-        print(ins(log_message))
         assert.equal("POST", log_message.request.method)
         assert.equal("", log_message.upstream_uri) -- no URI here since Nginx could not parse request
         assert.is_nil(log_message.request.headers["x-uuid"]) -- none since Nginx could not parse request

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -112,6 +112,7 @@ local conf = assert(conf_loader(TEST_CONF_PATH))
 
 _G.kong = kong_global.new()
 kong_global.init_pdk(_G.kong, conf, nil) -- nil: latest PDK
+kong_global.set_phase(kong, kong_global.phases.access)
 
 local db = assert(DB.new(conf))
 assert(db:init_connector())


### PR DESCRIPTION
This PR fixes the outstanding caveat of using logging plugins to log NGINX-produced errors. The caveat - described in e709c95 - causes some request properties (i.e. method and uri args) to be incorrectly logged.

Since e709c95, Kong executes plugins on NGINX-produced errors. However, as described in the mentioned commit's message, a caveat with the approach (note: the sanest one) is that the request method is overridden by the `error_page` directive during the internal redirect (and the uri args do not survive the redirect either).

This approach chooses to rely on the PDK to fix this limitation, and manually parses the request headers when necessary (and possible).

Fix #4025
Fix #4751