### PR TITLE
fix(db) reentrant migrations with added tests

### DIFF
--- a/kong/db/migrations/core/001_14_to_15.lua
+++ b/kong/db/migrations/core/001_14_to_15.lua
@@ -397,53 +397,69 @@ return {
       ]]))
 
       local _, err = connector:query("CREATE INDEX IF NOT EXISTS ON plugins(name)")
-      if err and not (string.find(err, "Column .- was not found in table") or
-                      string.find(err, "[Ii]nvalid column name")           or
-                      string.find(err, "[Uu]ndefined column name")) then
+      if err and not (string.find(err, "Column .- was not found in table")       or
+                      string.find(err, "[Ii]nvalid column name")                 or
+                      string.find(err, "[Uu]ndefined column name")               or
+                      string.find(err, "No column definition found for column")  or
+                      string.find(err, "Undefined name .- in selection clause")) then
         return nil, err
       end
 
       _, err = connector:query("CREATE INDEX IF NOT EXISTS ON plugins(api_id)")
-      if err and not (string.find(err, "Column .- was not found in table") or
-                      string.find(err, "[Ii]nvalid column name")           or
-                      string.find(err, "[Uu]ndefined column name")) then
+      if err and not (string.find(err, "Column .- was not found in table")       or
+                      string.find(err, "[Ii]nvalid column name")                 or
+                      string.find(err, "[Uu]ndefined column name")               or
+                      string.find(err, "No column definition found for column")  or
+                      string.find(err, "Undefined name .- in selection clause")) then
         return nil, err
       end
 
       _, err = connector:query("CREATE INDEX IF NOT EXISTS ON plugins(route_id)")
-      if err and not (string.find(err, "Column .- was not found in table") or
-                      string.find(err, "[Ii]nvalid column name")           or
-                      string.find(err, "[Uu]ndefined column name")) then
+      if err and not (string.find(err, "Column .- was not found in table")       or
+                      string.find(err, "[Ii]nvalid column name")                 or
+                      string.find(err, "[Uu]ndefined column name")               or
+                      string.find(err, "No column definition found for column")  or
+                      string.find(err, "Undefined name .- in selection clause")) then
         return nil, err
       end
 
       _, err = connector:query("CREATE INDEX IF NOT EXISTS ON plugins(service_id)")
-      if err and not (string.find(err, "Column .- was not found in table") or
-                      string.find(err, "[Ii]nvalid column name")           or
-                      string.find(err, "[Uu]ndefined column name")) then
+      if err and not (string.find(err, "Column .- was not found in table")       or
+                      string.find(err, "[Ii]nvalid column name")                 or
+                      string.find(err, "[Uu]ndefined column name")               or
+                      string.find(err, "No column definition found for column")  or
+                      string.find(err, "Undefined name .- in selection clause")) then
         return nil, err
       end
 
       _, err = connector:query("CREATE INDEX IF NOT EXISTS ON plugins(consumer_id)")
-      if err and not (string.find(err, "Column .- was not found in table") or
-                      string.find(err, "[Ii]nvalid column name")           or
-                      string.find(err, "[Uu]ndefined column name")) then
+      if err and not (string.find(err, "Column .- was not found in table")       or
+                      string.find(err, "[Ii]nvalid column name")                 or
+                      string.find(err, "[Uu]ndefined column name")               or
+                      string.find(err, "No column definition found for column")  or
+                      string.find(err, "Undefined name .- in selection clause")) then
         return nil, err
       end
 
       _, err = connector:query("CREATE INDEX IF NOT EXISTS ON plugins(cache_key)")
-      if err and not (string.find(err, "Column .- was not found in table") or
-                      string.find(err, "[Ii]nvalid column name")           or
-                      string.find(err, "[Uu]ndefined column name")) then
+      if err and not (string.find(err, "Column .- was not found in table")       or
+                      string.find(err, "[Ii]nvalid column name")                 or
+                      string.find(err, "[Uu]ndefined column name")               or
+                      string.find(err, "No column definition found for column")  or
+                      string.find(err, "Undefined name .- in selection clause")) then
         return nil, err
       end
 
+
       _, err = connector:query("CREATE INDEX IF NOT EXISTS ON plugins(run_on)")
-      if err and not (string.find(err, "Column .- was not found in table") or
-                      string.find(err, "[Ii]nvalid column name")           or
-                      string.find(err, "[Uu]ndefined column name")) then
+      if err and not (string.find(err, "Column .- was not found in table")       or
+                      string.find(err, "[Ii]nvalid column name")                 or
+                      string.find(err, "[Uu]ndefined column name")               or
+                      string.find(err, "No column definition found for column")  or
+                      string.find(err, "Undefined name .- in selection clause")) then
         return nil, err
       end
+
 
       plugins_def = {
         name    = "plugins",

--- a/kong/db/migrations/core/005_120_to_130.lua
+++ b/kong/db/migrations/core/005_120_to_130.lua
@@ -18,6 +18,8 @@ return {
         "tags"        TEXT[]
       );
 
+      DROP TRIGGER IF EXISTS ca_certificates_sync_tags_trigger ON ca_certificates;
+
       DO $$
       BEGIN
         CREATE TRIGGER ca_certificates_sync_tags_trigger

--- a/kong/db/strategies/cassandra/connector.lua
+++ b/kong/db/strategies/cassandra/connector.lua
@@ -944,9 +944,12 @@ do
       if cql ~= "" then
         local res, err = conn:execute(cql)
         if not res then
-          if string.find(err, "Column .- was not found in table") or
-             string.find(err, "[Ii]nvalid column name")           or
-             string.find(err, "[Uu]ndefined column name") then
+          if string.find(err, "Column .- was not found in table")
+          or string.find(err, "[Ii]nvalid column name")
+          or string.find(err, "[Uu]ndefined column name")
+          or string.find(err, "No column definition found for column")
+          or string.find(err, "Undefined name .- in selection clause")
+          then
             log.warn("ignored error while running '%s' migration: %s (%s)",
                      name, err, cql:gsub("\n", " "):gsub("%s%s+", " "))
           else

--- a/kong/plugins/oauth2/migrations/001_14_to_15.lua
+++ b/kong/plugins/oauth2/migrations/001_14_to_15.lua
@@ -194,10 +194,11 @@ return {
       for rows, err in coordinator:iterate([[
         SELECT id, redirect_uri FROM oauth2_credentials]]) do
         if err then
-          if string.find(err, "Column .- was not found in table") or
-             string.find(err, "[Ii]nvalid column name")           or
-             string.find(err, "[Uu]ndefined column name")
-          then
+          if string.find(err, "Column .- was not found in table")      or
+             string.find(err, "[Ii]nvalid column name")                or
+             string.find(err, "[Uu]ndefined column name")              or
+             string.find(err, "No column definition found for column") or
+             string.find(err, "Undefined name .- in selection clause") then
             return
           end
 

--- a/kong/plugins/oauth2/migrations/002_15_to_10.lua
+++ b/kong/plugins/oauth2/migrations/002_15_to_10.lua
@@ -42,16 +42,20 @@ return {
 
       local _, err = connector:query([[
         ALTER TABLE oauth2_authorization_codes DROP api_id]])
-      if err and not (string.find(err, "Column .- was not found in table") or
-                      string.find(err, "[Ii]nvalid column name")           or
-                      string.find(err, "[Uu]ndefined column name")) then
+      if err and not (string.find(err, "Column .- was not found in table")       or
+                      string.find(err, "[Ii]nvalid column name")                 or
+                      string.find(err, "[Uu]ndefined column name")               or
+                      string.find(err, "No column definition found for column")  or
+                      string.find(err, "Undefined name .- in selection clause")) then
         return nil, err
       end
 
       _, err = connector:query("ALTER TABLE oauth2_tokens DROP api_id")
-      if err and not (string.find(err, "Column .- was not found in table") or
-                      string.find(err, "[Ii]nvalid column name")           or
-                      string.find(err, "[Uu]ndefined column name")) then
+      if err and not (string.find(err, "Column .- was not found in table")       or
+                      string.find(err, "[Ii]nvalid column name")                 or
+                      string.find(err, "[Uu]ndefined column name")               or
+                      string.find(err, "No column definition found for column")  or
+                      string.find(err, "Undefined name .- in selection clause")) then
         return nil, err
       end
     end,


### PR DESCRIPTION
### Summary

Whenever we add migrations we may endup with a migration that is not reentrant. This PR fixes one such case, and now adds some tests too to make it less likely to happen again.