### PR TITLE
chore(deps) bump prometheus plugin to 0.6

### DIFF
--- a/kong-1.3.0-0.rockspec
+++ b/kong-1.3.0-0.rockspec
@@ -41,7 +41,7 @@ dependencies = {
   "kong-plugin-kubernetes-sidecar-injector ~> 0.2",
   "kong-plugin-zipkin ~> 0.1",
   "kong-plugin-serverless-functions ~> 0.3",
-  "kong-prometheus-plugin ~> 0.5",
+  "kong-prometheus-plugin ~> 0.6",
   "kong-proxy-cache-plugin ~> 1.2",
   "kong-plugin-request-transformer ~> 1.2",
   "kong-plugin-session ~> 2.1",


### PR DESCRIPTION
Changelog:
https://github.com/Kong/kong-plugin-prometheus/blob/master/CHANGELOG.md#060---20190929

Summary:
Metrics are now be available on the Status API