### PR TITLE
key-auth option to let backend handle HTTP 401

### DIFF
--- a/kong/plugins/key-auth/handler.lua
+++ b/kong/plugins/key-auth/handler.lua
@@ -154,9 +154,14 @@ local function do_authentication(conf)
     return kong.response.exit(500, "An unexpected error occurred")
   end
 
-  -- no credential in DB, for this key, it is invalid, HTTP 401
+  -- no credential in DB, for this key, it is invalid
   if not credential then
-    return nil, { status = 401, message = "Invalid authentication credentials" }
+    -- return HTTP 401 unless allow_unauthorized is set
+    if conf.allow_unauthorized then
+      return true
+    else
+      return nil, { status = 401, message = "Invalid authentication credentials" }
+    end
   end
 
   -----------------------------------------

--- a/kong/plugins/key-auth/schema.lua
+++ b/kong/plugins/key-auth/schema.lua
@@ -20,6 +20,7 @@ return {
           { anonymous = { type = "string", uuid = true, legacy = true }, },
           { key_in_body = { type = "boolean", default = false }, },
           { run_on_preflight = { type = "boolean", default = true }, },
+          { allow_unauthorized = { type = "boolean", default = false }, },
         },
     }, },
   },


### PR DESCRIPTION
### Summary

Sometimes we would like to see/handle unauthorized requests at the service behind kong. Return our own responses via the service for unauthorized requests. Currently there is no way to pass back unauthorized requests since key-auth always returns its own 401 prematurely (in some cases). 

This change is also handy if kong is not the source of record for api keys since individual consumers can be defined in kong that need to be rate-limited transparently without affecting other users.

### Full changelog

* New config.allow_unauthorized config option
