### PR TITLE
fix(tests) new attribute host_header in upstream entity

### DIFF
--- a/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
+++ b/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
@@ -1361,6 +1361,7 @@ describe("declarative config: flatten", function()
                     }
                   }
                 },
+                host_header = null,
                 id = "UUID",
                 name = "first-upstream",
                 slots = 10000,
@@ -1409,6 +1410,7 @@ describe("declarative config: flatten", function()
                     }
                   }
                 },
+                host_header = null,
                 id = "UUID",
                 name = "second-upstream",
                 slots = 10000,


### PR DESCRIPTION
Attribute `host_header` was missing in declarative config unit tests.