### PR TITLE
feat(db) add support for read transformations

### DIFF
--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -259,7 +259,7 @@ local function check_insert(self, entity, options)
     return nil, tostring(err_t), err_t
   end
 
-  entity_to_insert, err = self.schema:transform(entity_to_insert, entity)
+  entity_to_insert, err = self.schema:transform(entity_to_insert, entity, "insert")
   if not entity_to_insert then
     err_t = self.errors:transformation_error(err)
     return nil, tostring(err_t), err_t
@@ -331,7 +331,7 @@ local function check_update(self, key, entity, options, name)
     return nil, nil, tostring(err_t), err_t
   end
 
-  entity_to_update, err = self.schema:transform(entity_to_update, entity)
+  entity_to_update, err = self.schema:transform(entity_to_update, entity, "update")
   if not entity_to_update then
     err_t = self.errors:transformation_error(err)
     return nil, nil, tostring(err_t), err_t
@@ -379,7 +379,7 @@ local function check_upsert(self, entity, options, name, value)
     entity_to_upsert[name] = nil
   end
 
-  entity_to_upsert, err = self.schema:transform(entity_to_upsert, entity)
+  entity_to_upsert, err = self.schema:transform(entity_to_upsert, entity, "upsert")
   if not entity_to_upsert then
     err_t = self.errors:transformation_error(err)
     return nil, tostring(err_t), err_t
@@ -1080,7 +1080,13 @@ function DAO:row_to_entity(row, options)
     return nil, tostring(err_t), err_t
   end
 
-  return entity
+  local transformed_entity, err = self.schema:transform(entity, row, "select")
+  if not transformed_entity then
+    local err_t = self.errors:transformation_error(err)
+    return nil, tostring(err_t), err_t
+  end
+
+  return transformed_entity
 end
 
 

--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -120,7 +120,21 @@ local transformations_array = {
       {
         on_write = {
           type = "function",
-          required = true,
+          required = false,
+        },
+      },
+      {
+        on_read = {
+          type = "function",
+          required = false,
+        },
+      },
+    },
+    entity_checks = {
+      {
+        at_least_one_of = {
+          "on_write",
+          "on_read",
         },
       },
     },

--- a/spec/01-unit/01-db/01-schema/01-schema_spec.lua
+++ b/spec/01-unit/01-db/01-schema/01-schema_spec.lua
@@ -3598,6 +3598,42 @@ describe("schema", function()
       assert.equal("TEST1", transformed_entity.name)
     end)
 
+    it("transforms fields on write and read", function()
+      local test_schema = {
+        name = "test",
+        fields = {
+          {
+            name = {
+              type = "string"
+            },
+          },
+        },
+        transformations = {
+          {
+            input = { "name" },
+            on_write = function(name)
+              return { name = name:upper() }
+            end,
+            on_read = function(name)
+              return { name = name:lower() }
+            end,
+          },
+        },
+      }
+      local entity = { name = "TeSt1" }
+
+      local TestEntities = Schema.new(test_schema)
+      local transformed_entity, _ = TestEntities:transform(entity)
+
+      assert.truthy(transformed_entity)
+      assert.equal("TEST1", transformed_entity.name)
+
+      transformed_entity, _ = TestEntities:transform(transformed_entity, nil, "select")
+
+      assert.truthy(transformed_entity)
+      assert.equal("test1", transformed_entity.name)
+    end)
+
     it("transforms fields with input table", function()
       local test_schema = {
         name = "test",
@@ -3781,7 +3817,7 @@ describe("schema", function()
       assert.equal("transformation failed: unable to transform name", err)
     end)
 
-    it("does not skip transformation if needs are not fulfilled (this is handled by validation)", function()
+    it("skips transformation if needs are not fulfilled", function()
       local test_schema = {
         name = "test",
         fields = {
@@ -3810,7 +3846,7 @@ describe("schema", function()
       local transformed_entity, _ = TestEntities:transform(entity)
 
       assert.truthy(transformed_entity)
-      assert.equal("TEST1", transformed_entity.name)
+      assert.equal("test1", transformed_entity.name)
     end)
 
 

--- a/spec/01-unit/01-db/01-schema/02-metaschema_spec.lua
+++ b/spec/01-unit/01-db/01-schema/02-metaschema_spec.lua
@@ -578,6 +578,66 @@ describe("metaschema", function()
     assert.truthy(MetaSchema:validate(MetaSchema))
   end)
 
+  it("validates transformation has transformation function specified (positive)", function()
+    assert.truthy(MetaSchema:validate({
+      name = "test",
+      primary_key = { "test" },
+      fields = {
+        { test = { type = "string" } },
+      },
+      transformations = {
+        {
+          input = { "test" },
+          on_write = function() return true end,
+        },
+      },
+    }))
+
+    assert.truthy(MetaSchema:validate({
+      name = "test",
+      primary_key = { "test" },
+      fields = {
+        { test = { type = "string" } },
+      },
+      transformations = {
+        {
+          input = { "test" },
+          on_read = function() return true end,
+        },
+      },
+    }))
+
+    assert.truthy(MetaSchema:validate({
+      name = "test",
+      primary_key = { "test" },
+      fields = {
+        { test = { type = "string" } },
+      },
+      transformations = {
+        {
+          input = { "test" },
+          on_read = function() return true end,
+          on_write = function() return true end,
+        },
+      },
+    }))
+  end)
+
+  it("validates transformation has transformation function specified (negative)", function()
+    assert.falsy(MetaSchema:validate({
+      name = "test",
+      primary_key = { "test" },
+      fields = {
+        { test = { type = "string" } },
+      },
+      transformations = {
+        {
+          input = { "test" },
+        },
+      },
+    }))
+  end)
+
   it("validates transformation input fields exists (positive)", function()
     assert.truthy(MetaSchema:validate({
       name = "test",


### PR DESCRIPTION
### Summary

This is continuation of the dao transformations. This time the PR adds read transformations to DAOs, and opens a door for encryption of data at rest.