### PR TITLE
Feat/match port

### DIFF
--- a/kong/db/schema/entities/services.lua
+++ b/kong/db/schema/entities/services.lua
@@ -22,7 +22,7 @@ return {
     { retries            = { type = "integer", default = 5, between = { 0, 32767 } }, },
     -- { tags             = { type = "array", array = { type = "string" } }, },
     { protocol           = typedefs.protocol { required = true, default = "http" } },
-    { host               = typedefs.host { required = true } },
+    { host               = typedefs.host_with_optional_port { required = true } },
     { port               = typedefs.port { required = true, default = 80 }, },
     { path               = typedefs.path },
     { connect_timeout    = nonzero_timeout { default = 60000 }, },

--- a/kong/db/schema/entities/upstreams.lua
+++ b/kong/db/schema/entities/upstreams.lua
@@ -171,7 +171,7 @@ local r =  {
         fields = healthchecks_fields,
     }, },
     { tags = typedefs.tags },
-    { host_header = typedefs.host },
+    { host_header = typedefs.host_with_optional_port },
   },
   entity_checks = {
     -- hash_on_header must be present when hashing on header

--- a/kong/db/schema/typedefs.lua
+++ b/kong/db/schema/typedefs.lua
@@ -32,6 +32,12 @@ local function validate_host(host)
 end
 
 
+local function validate_host_with_optional_port(host)
+  local res, err_or_port = utils.normalize_ip(host)
+  return (res and true or nil), err_or_port
+end
+
+
 local function validate_ip(ip)
   local res, err = utils.normalize_ip(ip)
   if not res then
@@ -212,6 +218,12 @@ typedefs.protocol = Schema.define {
 typedefs.host = Schema.define {
   type = "string",
   custom_validator = validate_host,
+}
+
+
+typedefs.host_with_optional_port = Schema.define {
+  type = "string",
+  custom_validator = validate_host_with_optional_port,
 }
 
 
@@ -400,7 +412,7 @@ typedefs.protocols_http = Schema.define {
 
 local function validate_host_with_wildcards(host)
   local no_wildcards = string.gsub(host, "%*", "abc")
-  return typedefs.host.custom_validator(no_wildcards)
+  return typedefs.host_with_optional_port.custom_validator(no_wildcards)
 end
 
 local function validate_path_with_regexes(path)

--- a/kong/router.lua
+++ b/kong/router.lua
@@ -15,9 +15,11 @@ local var           = ngx.var
 local ngx_log       = ngx.log
 local insert        = table.insert
 local sort          = table.sort
+local byte          = string.byte
 local upper         = string.upper
 local lower         = string.lower
 local find          = string.find
+local format        = string.format
 local sub           = string.sub
 local tonumber      = tonumber
 local ipairs        = ipairs
@@ -50,6 +52,99 @@ do
     end
   end
 end
+
+
+local split_port
+do
+  local function safe_add_port(host, port)
+    if not port then
+      return host
+    end
+
+    return host .. ':' .. port
+  end
+
+  local ZERO, NINE, LEFTBRACKET, RIGHTBRACKET = ("09[]"):byte(1, -1)
+
+  local function onlydigits(s, begin)
+    for i = begin or 1, #s do
+      local c = byte(s, i)
+      if c < ZERO or c > NINE then
+        return false
+      end
+    end
+    return true
+  end
+
+  --- splits an optional ':port' section from a hostname
+  -- the port section must be decimal digits only.
+  -- brackets ('[]') are peeled off the hostname if present.
+  -- if there's more than one colon and no brackets, no split is possible.
+  -- on non-parseable input, returns name unchanged,
+  -- every string input produces at least one string output.
+  -- @tparam name string the string to split.
+  -- @tparam default_port number default port number
+  -- @treturn string hostname without port
+  -- @treturn string hostname with port
+  -- @treturn boolean true if input had a port number
+  local function l_split_port(name, default_port)
+    if byte(name, 1) == LEFTBRACKET then
+      if byte(name, -1) == RIGHTBRACKET then
+        return sub(name, 2, -2), safe_add_port(name, default_port), false
+      end
+
+      local splitpos = find(name, "]:", 2, true)
+      if splitpos then
+        if splitpos == #name - 1 then
+          return sub(name, 2, splitpos - 1), name .. (default_port or ''), false
+        end
+
+        if onlydigits(name, splitpos + 2) then
+          return sub(name, 2, splitpos - 1), name, true
+        end
+      end
+
+      return name, safe_add_port(name, default_port), false
+    end
+
+    local firstcolon = find(name, ":", 1, true)
+    if not firstcolon then
+      return name, safe_add_port(name, default_port), false
+    end
+
+    if firstcolon == #name then
+      local host = sub(name, 1, firstcolon - 1)
+      return host, safe_add_port(host, default_port), false
+    end
+
+    if not onlydigits(name, firstcolon + 1) then
+      if default_port then
+        return name, format("[%s]:%s", name, default_port), false
+      end
+
+      return name, name, false
+    end
+
+    return sub(name, 1, firstcolon - 1), name, true
+  end
+
+  -- split_port is a pure function, so we can memoize it.
+  local memo_h = setmetatable({}, {__mode = 'k'})
+  local memo_hp = setmetatable({}, {__mode = 'k'})
+  local memo_p = setmetatable({}, {__mode = 'k'})
+
+  function split_port(name, default_port)
+    local k = name .. '#' .. (default_port or '')
+    local h, hp, p = memo_h[k], memo_hp[k], memo_p[k]
+    if not h then
+      h, hp, p = l_split_port(name, default_port)
+      memo_h[k], memo_hp[k], memo_p[k] = h, hp, p
+    end
+
+    return h, hp, p
+  end
+end
+
 
 
 --[[
@@ -88,6 +183,7 @@ end)
 local MATCH_SUBRULES = {
   HAS_REGEX_URI    = 0x01,
   PLAIN_HOSTS_ONLY = 0x02,
+  HAS_HOST_PORT    = 0x04,
 }
 
 local EMPTY_T = {}
@@ -216,6 +312,7 @@ local function marshall_route(r)
 
     local has_host_wildcard
     local has_host_plain
+    local has_port
 
     for _, host in ipairs(hosts) do
       if type(host) ~= "string" then
@@ -228,6 +325,12 @@ local function marshall_route(r)
 
         local wildcard_host_regex = host:gsub("%.", "\\.")
                                         :gsub("%*", ".+") .. "$"
+
+        _, _, has_port = split_port(host)
+        if not has_port then
+          wildcard_host_regex = wildcard_host_regex:gsub("%$$", [[(?::\d+)?$]])
+        end
+
         insert(route_t.hosts, {
           wildcard = true,
           value    = host,
@@ -254,6 +357,11 @@ local function marshall_route(r)
     if not has_host_wildcard then
       route_t.submatch_weight = bor(route_t.submatch_weight,
                                     MATCH_SUBRULES.PLAIN_HOSTS_ONLY)
+    end
+
+    if has_port then
+      route_t.submatch_weight = bor(route_t.submatch_weight,
+                                    MATCH_SUBRULES.HAS_HOST_PORT)
     end
   end
 
@@ -661,7 +769,9 @@ end
 do
   local matchers = {
     [MATCH_RULES.HOST] = function(route_t, ctx)
-      local host = route_t.hosts[ctx.hits.host or ctx.req_host]
+      local req_host = ctx.hits.host or ctx.req_host
+      local host = route_t.hosts[req_host]
+        or route_t.hosts[split_port(req_host)]
       if host then
         ctx.matches.host = host
         return true
@@ -671,7 +781,7 @@ do
         local host_t = route_t.hosts[i]
 
         if host_t.wildcard then
-          local from, _, err = re_find(ctx.req_host, host_t.regex, "ajo")
+          local from, _, err = re_find(ctx.host_with_port, host_t.regex, "ajo")
           if err then
             log(ERR, "could not evaluate wildcard host regex: ", err)
             return
@@ -995,6 +1105,7 @@ _M.has_capturing_groups = has_capturing_groups
 
 -- for unit-testing purposes only
 _M._set_ngx = _set_ngx
+_M.split_port = split_port
 
 
 function _M.new(routes)
@@ -1167,7 +1278,7 @@ function _M.new(routes)
 
   local grab_req_headers = #plain_indexes.headers > 0
 
-  local function find_route(req_method, req_uri, req_host,
+  local function find_route(req_method, req_uri, req_host, req_scheme,
                             src_ip, src_port,
                             dst_ip, dst_port,
                             sni, req_headers)
@@ -1179,6 +1290,9 @@ function _M.new(routes)
     end
     if req_host and type(req_host) ~= "string" then
       error("host must be a string", 2)
+    end
+    if req_scheme and type(req_scheme) ~= "string" then
+      error("scheme must be a string", 2)
     end
     if src_ip and type(src_ip) ~= "string" then
       error("src_ip must be a string", 2)
@@ -1236,13 +1350,13 @@ function _M.new(routes)
 
     req_method = upper(req_method)
 
-    if req_host ~= "" then
-      -- strip port number if given because matching ignores ports
-      local idx = find(req_host, ":", 2, true)
-      if idx then
-        ctx.req_host = sub(req_host, 1, idx - 1)
-      end
-    end
+    -- req_host might have port or maybe not, host_no_port definitely doesn't
+    -- if there wasn't a port, req_port is assumed to be the default port
+    -- according the protocol scheme
+    local host_no_port, host_with_port = split_port(
+        req_host, req_scheme == 'https' and 443 or 80)
+
+    ctx.host_with_port = host_with_port
 
     local hits         = ctx.hits
     local req_category = 0x00
@@ -1255,12 +1369,14 @@ function _M.new(routes)
 
     -- host match
 
-    if plain_indexes.hosts[ctx.req_host] then
+    if plain_indexes.hosts[host_with_port]
+      or plain_indexes.hosts[host_no_port]
+    then
       req_category = bor(req_category, MATCH_RULES.HOST)
 
     elseif ctx.req_host then
       for i = 1, #wildcard_hosts do
-        local from, _, err = re_find(ctx.req_host, wildcard_hosts[i].regex, "ajo")
+        local from, _, err = re_find(host_with_port, wildcard_hosts[i].regex, "ajo")
         if err then
           log(ERR, "could not match wildcard host: ", err)
           return
@@ -1485,6 +1601,7 @@ function _M.new(routes)
       local req_method = get_method()
       local req_uri = var.request_uri
       local req_host = var.http_host or ""
+      local req_scheme = var.scheme
       local sni = var.ssl_server_name
 
       local headers
@@ -1507,7 +1624,7 @@ function _M.new(routes)
         end
       end
 
-      local match_t = find_route(req_method, req_uri, req_host,
+      local match_t = find_route(req_method, req_uri, req_host, req_scheme,
                                  nil, nil, -- src_ip, src_port
                                  nil, nil, -- dst_ip, dst_port
                                  sni, headers)
@@ -1550,7 +1667,7 @@ function _M.new(routes)
       local dst_port = tonumber(var.server_port, 10)
       local sni = var.ssl_preread_server_name
 
-      return find_route(nil, nil, nil,
+      return find_route(nil, nil, nil, "tcp",
                         src_ip, src_port,
                         dst_ip, dst_port,
                         sni)

--- a/spec/01-unit/01-db/01-schema/05-services_spec.lua
+++ b/spec/01-unit/01-db/01-schema/05-services_spec.lua
@@ -337,18 +337,8 @@ describe("services", function()
 
         local ok, err = Services:validate(service)
         assert.falsy(ok)
-        assert.equal("invalid value: " .. invalid_hosts[i], err.host)
+        assert.equal("invalid hostname: " .. invalid_hosts[i], err.host)
       end
-    end)
-
-    it("rejects values with a valid port", function()
-      local service = {
-        host = "example.com:80",
-      }
-
-      local ok, err = Services:validate(service)
-      assert.falsy(ok)
-      assert.equal("must not have a port", err.host)
     end)
 
     it("rejects values with an invalid port", function()
@@ -358,7 +348,7 @@ describe("services", function()
 
       local ok, err = Services:validate(service)
       assert.falsy(ok)
-      assert.equal("must not have a port", err.host)
+      assert.equal("invalid port number", err.host)
     end)
 
     -- acceptance

--- a/spec/01-unit/01-db/01-schema/06-routes_spec.lua
+++ b/spec/01-unit/01-db/01-schema/06-routes_spec.lua
@@ -401,19 +401,8 @@ describe("routes schema", function()
 
         local ok, err = Routes:validate(route)
         assert.falsy(ok)
-        assert.equal("invalid value: " .. invalid_hosts[i], err.hosts[1])
+        assert.equal("invalid hostname: " .. invalid_hosts[i], err.hosts[1])
       end
-    end)
-
-    it("rejects values with a valid port", function()
-      local route = {
-        hosts = { "example.com:80" },
-        protocols = { "http" },
-      }
-
-      local ok, err = Routes:validate(route)
-      assert.falsy(ok)
-      assert.equal("must not have a port", err.hosts[1])
     end)
 
     it("rejects values with an invalid port", function()
@@ -424,7 +413,7 @@ describe("routes schema", function()
 
       local ok, err = Routes:validate(route)
       assert.falsy(ok)
-      assert.equal("must not have a port", err.hosts[1])
+      assert.equal("invalid port number", err.hosts[1])
     end)
 
     it("rejects invalid wildcard placement", function()
@@ -482,6 +471,8 @@ describe("routes schema", function()
         "hello.abcd",
         "example_api.com",
         "localhost",
+        "example.com:80",
+        "example.com:8080",
         -- below:
         -- punycode examples from RFC3492;
         -- https://tools.ietf.org/html/rfc3492#page-14
@@ -515,6 +506,7 @@ describe("routes schema", function()
       local valid_hosts = {
         "example.*",
         "*.example.org",
+        "*.example.org:321",
       }
 
       for i = 1, #valid_hosts do

--- a/spec/01-unit/01-db/01-schema/09-upstreams_spec.lua
+++ b/spec/01-unit/01-db/01-schema/09-upstreams_spec.lua
@@ -219,33 +219,28 @@ describe("load upstreams", function()
   describe("upstream attribute", function()
     -- refusals
     it("requires a valid hostname", function()
-      local ok, err = Upstreams:validate({
-        name = "host.test",
-        host_header = "ahostname:80" }
-      )
-      assert.falsy(ok)
-      assert.same({ host_header = "must not have a port" }, err)
+      local ok, err
 
       ok, err = Upstreams:validate({
         name = "host.test",
         host_header = "http://ahostname.test" }
       )
       assert.falsy(ok)
-      assert.same({ host_header = "invalid value: http://ahostname.test" }, err)
+      assert.same({ host_header = "invalid hostname: http://ahostname.test" }, err)
 
       ok, err = Upstreams:validate({
         name = "host.test",
         host_header = "ahostname-" }
       )
       assert.falsy(ok)
-      assert.same({ host_header = "invalid value: ahostname-" }, err)
+      assert.same({ host_header = "invalid hostname: ahostname-" }, err)
 
       ok, err = Upstreams:validate({
         name = "host.test",
         host_header = "a hostname" }
       )
       assert.falsy(ok)
-      assert.same({ host_header = "invalid value: a hostname" }, err)
+      assert.same({ host_header = "invalid hostname: a hostname" }, err)
     end)
 
     -- acceptance

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -185,9 +185,62 @@ local use_case = {
       },
     },
   },
+  -- 13. host + port
+  {
+    service = service,
+    route   = {
+      hosts = {
+        "domain-1.org:321",
+        "domain-2.org"
+      },
+    },
+  },
+  -- 14. no "any-port" route
+  {
+    service = service,
+    route   = {
+      hosts = {
+        "domain-3.org:321",
+      },
+    },
+  },
 }
 
 describe("Router", function()
+  describe("split_port()", function()
+    it("splits port number", function()
+      for _, case in ipairs({
+        { {''}, { '', '', false } },
+        { {'localhost'}, { 'localhost', 'localhost', false } },
+        { {'localhost:'}, { 'localhost', 'localhost', false } },
+        { {'localhost:80'}, { 'localhost', 'localhost:80', true } },
+        { {'localhost:23h'}, { 'localhost:23h', 'localhost:23h', false } },
+        { {'localhost/24'}, { 'localhost/24', 'localhost/24', false } },
+        { {'::1'}, { '::1', '::1', false } },
+        { {'[::1]'}, { '::1', '[::1]', false } },
+        { {'[::1]:'}, { '::1', '[::1]:', false } },
+        { {'[::1]:80'}, { '::1', '[::1]:80', true } },
+        { {'[::1]:80b'}, { '[::1]:80b', '[::1]:80b', false } },
+        { {'[::1]/96'}, { '[::1]/96', '[::1]/96', false } },
+
+        { {'', 88}, { '', ':88', false } },
+        { {'localhost', 88}, { 'localhost', 'localhost:88', false } },
+        { {'localhost:', 88}, { 'localhost', 'localhost:88', false } },
+        { {'localhost:80', 88}, { 'localhost', 'localhost:80', true } },
+        { {'localhost:23h', 88}, { 'localhost:23h', '[localhost:23h]:88', false } },
+        { {'localhost/24', 88}, { 'localhost/24', 'localhost/24:88', false } },
+        { {'::1', 88}, { '::1', '[::1]:88', false } },
+        { {'[::1]', 88}, { '::1', '[::1]:88', false } },
+        { {'[::1]:', 88}, { '::1', '[::1]:88', false } },
+        { {'[::1]:80', 88}, { '::1', '[::1]:80', true } },
+        { {'[::1]:80b', 88}, { '[::1]:80b', '[::1]:80b:88', false } },
+        { {'[::1]/96', 88}, { '[::1]/96', '[::1]/96:88', false } },
+      }) do
+        assert.same(case[2], { Router.split_port(unpack(case[1])) })
+      end
+    end)
+  end)
+
   describe("new()", function()
     describe("[errors]", function()
       it("enforces args types", function()
@@ -227,8 +280,18 @@ describe("Router", function()
       assert.same(nil, match_t.matches.uri_captures)
     end)
 
-    it("[host] ignores port", function()
+    it("[host] ignores default port", function()
       -- host
+      local match_t = router.select("GET", "/", "domain-1.org:80")
+      assert.truthy(match_t)
+      assert.equal(use_case[1].route, match_t.route)
+      assert.same(use_case[1].route.hosts[1], match_t.matches.host)
+      assert.same(nil, match_t.matches.method)
+      assert.same(nil, match_t.matches.uri)
+      assert.same(nil, match_t.matches.uri_captures)
+    end)
+
+    it("[host] weird port matches no-port route", function()
       local match_t = router.select("GET", "/", "domain-1.org:123")
       assert.truthy(match_t)
       assert.equal(use_case[1].route, match_t.route)
@@ -236,6 +299,34 @@ describe("Router", function()
       assert.same(nil, match_t.matches.method)
       assert.same(nil, match_t.matches.uri)
       assert.same(nil, match_t.matches.uri_captures)
+    end)
+
+    it("[host] matches specific port", function()
+      -- host
+      local match_t = router.select("GET", "/", "domain-1.org:321")
+      assert.truthy(match_t)
+      assert.equal(use_case[13].route, match_t.route)
+      assert.same(use_case[13].route.hosts[1], match_t.matches.host)
+      assert.same(nil, match_t.matches.method)
+      assert.same(nil, match_t.matches.uri)
+      assert.same(nil, match_t.matches.uri_captures)
+    end)
+
+    it("[host] matches specific port on port-only route", function()
+      -- host
+      local match_t = router.select("GET", "/", "domain-3.org:321")
+      assert.truthy(match_t)
+      assert.equal(use_case[14].route, match_t.route)
+      assert.same(use_case[14].route.hosts[1], match_t.matches.host)
+      assert.same(nil, match_t.matches.method)
+      assert.same(nil, match_t.matches.uri)
+      assert.same(nil, match_t.matches.uri_captures)
+    end)
+
+    it("[host] fails just because of port on port-only route", function()
+      -- host
+      local match_t = router.select("GET", "/", "domain-3.org:123")
+      assert.falsy(match_t)
     end)
 
     it("[uri]", function()
@@ -319,7 +410,7 @@ describe("Router", function()
 
     it("single [headers] value", function()
       -- headers (single)
-      local match_t = router.select("GET", "/", nil, nil, nil, nil, nil, nil, {
+      local match_t = router.select("GET", "/", nil, "http", nil, nil, nil, nil, nil, {
         location = "my-location-1"
       })
       assert.truthy(match_t)
@@ -329,7 +420,7 @@ describe("Router", function()
       assert.same(nil, match_t.matches.uri_captures)
       assert.same({ location = "my-location-1" }, match_t.matches.headers)
 
-      local match_t = router.select("GET", "/", nil, nil, nil, nil, nil, nil, {
+      local match_t = router.select("GET", "/", nil, "http", nil, nil, nil, nil, nil, {
         location = "my-location-2"
       })
       assert.truthy(match_t)
@@ -339,7 +430,7 @@ describe("Router", function()
       assert.same(nil, match_t.matches.uri_captures)
       assert.same({ location = "my-location-2" }, match_t.matches.headers)
 
-      local match_t = router.select("GET", "/", nil, nil, nil, nil, nil, nil, {
+      local match_t = router.select("GET", "/", nil, "http", nil, nil, nil, nil, nil, {
         location = { "my-location-3", "my-location-2" }
       })
       assert.truthy(match_t)
@@ -349,12 +440,12 @@ describe("Router", function()
       assert.same(nil, match_t.matches.uri_captures)
       assert.same({ location = "my-location-2" }, match_t.matches.headers)
 
-      local match_t = router.select("GET", "/", nil, nil, nil, nil, nil, nil, {
+      local match_t = router.select("GET", "/", nil, "http", nil, nil, nil, nil, nil, {
         location = "my-location-3"
       })
       assert.is_nil(match_t)
 
-      local match_t = router.select("GET", "/", nil, nil, nil, nil, nil, nil, {
+      local match_t = router.select("GET", "/", nil, "http", nil, nil, nil, nil, nil, {
         location = { "my-location-3", "foo" }
       })
       assert.is_nil(match_t)
@@ -362,7 +453,7 @@ describe("Router", function()
 
     it("multiple [headers] values", function()
       -- headers (multiple)
-      local match_t = router.select("GET", "/", nil, nil, nil, nil, nil, nil, {
+      local match_t = router.select("GET", "/", nil, "http", nil, nil, nil, nil, nil, {
         location = "my-location-1",
         version = "v1",
       })
@@ -374,7 +465,7 @@ describe("Router", function()
       assert.same({ location = "my-location-1", version = "v1", },
                   match_t.matches.headers)
 
-      local match_t = router.select("GET", "/", nil, nil, nil, nil, nil, nil, {
+      local match_t = router.select("GET", "/", nil, "http", nil, nil, nil, nil, nil, {
         location = "my-location-1",
         version = "v2",
       })
@@ -386,7 +477,7 @@ describe("Router", function()
       assert.same({ location = "my-location-1", version = "v2", },
                   match_t.matches.headers)
 
-      local match_t = router.select("GET", "/", nil, nil, nil, nil, nil, nil, {
+      local match_t = router.select("GET", "/", nil, "http", nil, nil, nil, nil, nil, {
         location = { "my-location-3", "my-location-1" },
         version = "v2",
       })
@@ -398,7 +489,7 @@ describe("Router", function()
       assert.same({ location = "my-location-1", version = "v2", },
                   match_t.matches.headers)
 
-      local match_t = router.select("GET", "/", nil, nil, nil, nil, nil, nil, {
+      local match_t = router.select("GET", "/", nil, "http", nil, nil, nil, nil, nil, {
         location = { "my-location-3", "my-location-2" },
         version = "v2",
       })
@@ -413,7 +504,7 @@ describe("Router", function()
 
     it("[headers + uri]", function()
       -- headers + uri
-      local match_t = router.select("GET", "/headers-uri", nil, nil, nil, nil,
+      local match_t = router.select("GET", "/headers-uri", nil, "http", nil, nil, nil,
                                     nil, nil, { location = "my-location-2" })
       assert.truthy(match_t)
       assert.same(use_case[11].route, match_t.route)
@@ -426,7 +517,7 @@ describe("Router", function()
     it("[host + headers + uri + method]", function()
       -- host + headers + uri + method
       local match_t = router.select("PUT", "/headers-host-uri-method",
-                                    "domain-with-headers-1.org",
+                                    "domain-with-headers-1.org", "http",
                                     nil, nil, nil, nil, nil, {
                                       location = "my-location-2",
                                     })
@@ -447,6 +538,81 @@ describe("Router", function()
       assert.is_nil(match_t.matches.uri_captures)
       assert.equal(use_case[8].route, match_t.route)
       assert.same(use_case[8].route.paths[1], match_t.matches.uri)
+    end)
+
+    describe("[IPv6 #literal host]", function()
+      local use_case = {
+        -- 1: no port, with and without brackets, unique IPs
+        {
+          service = service,
+          route = {
+            hosts = { "::11", "[::12]" },
+          },
+        },
+
+        -- 2: no port, with and without brackets, same hosts as 4
+        {
+          service = service,
+          route = {
+            hosts = { "::21", "[::22]" },
+          },
+        },
+
+        -- 3: unique IPs, with port
+        {
+          service = service,
+          route = {
+            hosts = { "[::31]:321", "[::32]:321" },
+          },
+        },
+
+        -- 4: same hosts as 2, with port, needs brackets
+        {
+          service = service,
+          route = {
+            hosts = { "[::21]:321", "[::22]:321" },
+          },
+        },
+      }
+      local router = assert(Router.new(use_case))
+
+      describe("no-port route is any-port", function()
+        describe("no-port request", function()
+          it("plain match", function()
+            local match_t = assert(router.select("GET", "/", "::11"))
+            assert.equal(use_case[1].route, match_t.route)
+          end)
+          it("with brackets", function()
+            local match_t = assert(router.select("GET", "/", "[::11]"))
+            assert.equal(use_case[1].route, match_t.route)
+          end)
+        end)
+
+        it("explicit port still matches", function()
+          local match_t = assert(router.select("GET", "/", "[::11]:654"))
+          assert.equal(use_case[1].route, match_t.route)
+        end)
+      end)
+
+      describe("port-specific route", function()
+        it("matches by port", function()
+          local match_t = assert(router.select("GET", "/", "[::21]:321"))
+          assert.equal(use_case[4].route, match_t.route)
+
+          local match_t = assert(router.select("GET", "/", "[::31]:321"))
+          assert.equal(use_case[3].route, match_t.route)
+        end)
+
+        it("matches other ports to any-port fallback", function()
+          local match_t = assert(router.select("GET", "/", "[::21]:654"))
+          assert.equal(use_case[2].route, match_t.route)
+        end)
+
+        it("fails if there's no any-port route", function()
+          local match_t = router.select("GET", "/", "[::31]:654")
+          assert.falsy(match_t)
+        end)
+      end)
     end)
 
     describe("[uri prefix]", function()
@@ -777,6 +943,105 @@ describe("Router", function()
         assert.equal(use_case[2].route, match_t.route)
       end)
 
+      it("matches any port in request", function()
+        local match_t = router.select("GET", "/", "route.org:123")
+        assert.truthy(match_t)
+        assert.equal(use_case[2].route, match_t.route)
+
+        local match_t = router.select("GET", "/", "foo.route.com:123", "domain.org")
+        assert.truthy(match_t)
+        assert.equal(use_case[1].route, match_t.route)
+      end)
+
+      it("matches port-specific routes", function()
+        table.insert(use_case, {
+          service = service,
+          route   = {
+            hosts = { "*.route.net:123" },
+          },
+        })
+        table.insert(use_case, {
+          service = service,
+          route   = {
+            hosts = { "route.*:123" },    -- same as [2] but port-specific
+          },
+        })
+        router = assert(Router.new(use_case))
+
+        finally(function()
+          table.remove(use_case)
+          table.remove(use_case)
+          router = assert(Router.new(use_case))
+        end)
+
+        -- match the right port
+        local match_t = router.select("GET", "/", "foo.route.net:123")
+        assert.truthy(match_t)
+        assert.equal(use_case[3].route, match_t.route)
+
+        -- fail different port
+        assert.is_nil(router.select("GET", "/", "foo.route.net:456"))
+
+        -- port-specific is higher priority
+        local match_t = router.select("GET", "/", "route.org:123")
+        assert.truthy(match_t)
+        assert.equal(use_case[4].route, match_t.route)
+      end)
+
+      it("prefers port-specific even for http default port", function()
+        table.insert(use_case, {
+          service = service,
+          route   = {
+            hosts = { "route.*:80" },    -- same as [2] but port-specific
+          },
+        })
+        router = assert(Router.new(use_case))
+
+        finally(function()
+          table.remove(use_case)
+          router = assert(Router.new(use_case))
+        end)
+
+        -- non-port matches any
+        local match_t = assert(router.select("GET", "/", "route.org:123"))
+        assert.equal(use_case[2].route, match_t.route)
+
+        -- port 80 goes to port-specific route
+        local match_t = assert(router.select("GET", "/", "route.org:80"))
+        assert.equal(use_case[3].route, match_t.route)
+
+        -- even if it's implicit port 80
+        local match_t = assert(router.select("GET", "/", "route.org"))
+        assert.equal(use_case[3].route, match_t.route)
+      end)
+
+      it("prefers port-specific even for https default port", function()
+        table.insert(use_case, {
+          service = service,
+          route   = {
+            hosts = { "route.*:443" },    -- same as [2] but port-specific
+          },
+        })
+        router = assert(Router.new(use_case))
+
+        finally(function()
+          table.remove(use_case)
+          router = assert(Router.new(use_case))
+        end)
+
+        -- non-port matches any
+        local match_t = assert(router.select("GET", "/", "route.org:123"))
+        assert.equal(use_case[2].route, match_t.route)
+
+        -- port 80 goes to port-specific route
+        local match_t = assert(router.select("GET", "/", "route.org:443"))
+        assert.equal(use_case[3].route, match_t.route)
+
+        -- even if it's implicit port 80
+        local match_t = assert(router.select("GET", "/", "route.org", "https"))
+        assert.equal(use_case[3].route, match_t.route)
+      end)
+
       it("does not take precedence over a plain host", function()
         table.insert(use_case, 1, {
           service = service,
@@ -982,7 +1247,7 @@ describe("Router", function()
 
         local router = assert(Router.new(use_case))
 
-        local match_t = router.select("GET", "/", nil, nil, nil, nil, nil, nil,
+        local match_t = router.select("GET", "/", nil, "http", nil, nil, nil, nil, nil,
                                       {
                                         version = "v1",
                                         user_agent = "foo",
@@ -1014,7 +1279,7 @@ describe("Router", function()
 
         local router = assert(Router.new(use_case))
 
-        local match_t = router.select("GET", "/", nil, nil, nil, nil, nil, nil,
+        local match_t = router.select("GET", "/", nil, "http", nil, nil, nil, nil, nil,
                                       setmetatable({
                                         user_agent = "foo",
                                       }, headers_mt))
@@ -1022,7 +1287,7 @@ describe("Router", function()
         assert.equal(use_case[1].route, match_t.route)
         assert.same({ user_agent = "foo" }, match_t.matches.headers)
 
-        local match_t = router.select("GET", "/", nil, nil, nil, nil, nil, nil,
+        local match_t = router.select("GET", "/", nil, "http", nil, nil, nil, nil, nil,
                                       setmetatable({
                                         ["USER_AGENT"] = "baz",
                                       }, headers_mt))
@@ -1053,7 +1318,7 @@ describe("Router", function()
 
         local router = assert(Router.new(use_case))
 
-        local match_t = router.select("GET", "/", nil, nil, nil, nil, nil, nil,
+        local match_t = router.select("GET", "/", nil, "http", nil, nil, nil, nil, nil,
                                       {
                                         user_agent = "FOO",
                                       })
@@ -1061,7 +1326,7 @@ describe("Router", function()
         assert.equal(use_case[1].route, match_t.route)
         assert.same({ user_agent = "foo" }, match_t.matches.headers)
 
-        local match_t = router.select("GET", "/", nil, nil, nil, nil, nil, nil,
+        local match_t = router.select("GET", "/", nil, "http", nil, nil, nil, nil, nil,
                                       {
                                         user_agent = "baz",
                                       })
@@ -1073,7 +1338,97 @@ describe("Router", function()
 
     describe("edge-cases", function()
       it("[host] and [uri] have higher priority than [method]", function()
-        -- host
+        local use_case = {
+          -- 1. host
+          {
+            service = service,
+            route   = {
+              hosts = {
+                "domain-1.org",
+                "domain-2.org"
+              },
+            },
+          },
+          -- 2. method
+          {
+            service = service,
+            route   = {
+              methods = {
+                "TRACE"
+              },
+            }
+          },
+          -- 3. uri
+          {
+            service = service,
+            route   = {
+              paths = {
+                "/my-route"
+              },
+            }
+          },
+          -- 4. host + uri
+          {
+            service = service,
+            route   = {
+              paths = {
+                "/route-4"
+              },
+              hosts = {
+                "domain-1.org",
+                "domain-2.org"
+              },
+            },
+          },
+          -- 5. host + method
+          {
+            service = service,
+            route   = {
+              hosts = {
+                "domain-1.org",
+                "domain-2.org"
+              },
+              methods = {
+                "POST",
+                "PUT",
+                "PATCH"
+              },
+            },
+          },
+          -- 6. uri + method
+          {
+            service = service,
+            route   = {
+              methods = {
+                "POST",
+                "PUT",
+                "PATCH",
+              },
+              paths   = {
+                "/route-6"
+              },
+            }
+          },
+          -- 7. host + uri + method
+          {
+            service = service,
+            route   = {
+              hosts = {
+                "domain-with-uri-1.org",
+                "domain-with-uri-2.org"
+              },
+              methods = {
+                "POST",
+                "PUT",
+                "PATCH",
+              },
+              paths   = {
+                "/my-route-uri"
+              },
+            },
+          },
+        }
+        local router = assert(Router.new(use_case))
         local match_t = router.select("TRACE", "/", "domain-2.org")
         assert.truthy(match_t)
         assert.equal(use_case[1].route, match_t.route)
@@ -1350,7 +1705,7 @@ describe("Router", function()
 
         local router = assert(Router.new(use_case))
 
-        local match_t = router.select("GET", "/my-route/hello", "domain.org",
+        local match_t = router.select("GET", "/my-route/hello", "domain.org", "http",
                                       nil, nil, nil, nil, nil, {
                                         version = "v1",
                                         location = "us-east",
@@ -1361,7 +1716,7 @@ describe("Router", function()
         assert.same({ version = "v1", location = "us-east" },
                     match_t.matches.headers)
 
-        local match_t = router.select("GET", "/my-route/hello/world",
+        local match_t = router.select("GET", "/my-route/hello/world", "http",
                                       "domain.org", nil, nil, nil, nil, nil, {
                                         version = "v1",
                                         location = "us-east",
@@ -1403,25 +1758,25 @@ describe("Router", function()
       end)
 
       it("invalid [headers]", function()
-        assert.is_nil(router.select("GET", "/", nil, nil, nil, nil, nil, nil,
+        assert.is_nil(router.select("GET", "/", nil, "http", nil, nil, nil, nil, nil,
                                     { location = "invalid-location" }))
       end)
 
       it("invalid headers in [headers + uri]", function()
         assert.is_nil(router.select("GET", "/headers-uri",
-                                    nil, nil, nil, nil, nil, nil,
+                                    nil, "http", nil, nil, nil, nil, nil,
                                     { location = "invalid-location" }))
       end)
 
       it("invalid headers in [headers + uri + method]", function()
         assert.is_nil(router.select("PUT", "/headers-uri-method",
-                                    nil, nil, nil, nil, nil, nil,
+                                    nil, "http", nil, nil, nil, nil, nil,
                                     { location = "invalid-location" }))
       end)
 
       it("invalid headers in [headers + host + uri + method]", function()
         assert.is_nil(router.select("PUT", "/headers-host-uri-method",
-                                    nil, nil, nil, nil, nil, nil,
+                                    nil, "http", nil, nil, nil, nil, nil,
                                     { location = "invalid-location",
                                       host = "domain-with-headers-1.org" }))
       end)
@@ -1534,7 +1889,7 @@ describe("Router", function()
 
           it("takes < 1ms", function()
             local match_t = router.select("GET", "/",
-                                          nil, nil, nil, nil, nil, nil,
+                                          nil, "http", nil, nil, nil, nil, nil,
                                           { location = target_location })
             assert.truthy(match_t)
             assert.same(benchmark_use_cases[#benchmark_use_cases].route,
@@ -1569,7 +1924,7 @@ describe("Router", function()
 
           it("takes < 1ms", function()
             local match_t = router.select("GET", "/",
-                                          nil, nil, nil, nil, nil, nil,
+                                          nil, "http", nil, nil, nil, nil, nil,
                                           { [target_key] = target_val })
             assert.truthy(match_t)
             assert.same(benchmark_use_cases[#benchmark_use_cases].route,
@@ -1666,7 +2021,7 @@ describe("Router", function()
         end)
 
         it("takes < 1ms", function()
-          local match_t = router.select("POST", target_uri, target_domain,
+          local match_t = router.select("POST", target_uri, target_domain, "http",
                                         nil, nil, nil, nil, nil, {
             location = target_location,
           })
@@ -1693,26 +2048,30 @@ describe("Router", function()
 
         assert.error_matches(function()
           router.select("GET", "/", "", 1)
+        end, "scheme must be a string", nil, true)
+
+        assert.error_matches(function()
+          router.select("GET", "/", "", "http", 1)
         end, "src_ip must be a string", nil, true)
 
         assert.error_matches(function()
-          router.select("GET", "/", "", nil, "")
+          router.select("GET", "/", "", "http", nil, "")
         end, "src_port must be a number", nil, true)
 
         assert.error_matches(function()
-          router.select("GET", "/", "", nil, nil, 1)
+          router.select("GET", "/", "", "http", nil, nil, 1)
         end, "dst_ip must be a string", nil, true)
 
         assert.error_matches(function()
-          router.select("GET", "/", "", nil, nil, nil, "")
+          router.select("GET", "/", "", "http", nil, nil, nil, "")
         end, "dst_port must be a number", nil, true)
 
         assert.error_matches(function()
-          router.select("GET", "/", "", nil, nil, nil, nil, 1)
+          router.select("GET", "/", "", "http", nil, nil, nil, nil, 1)
         end, "sni must be a string", nil, true)
 
         assert.error_matches(function()
-          router.select("GET", "/", "", nil, nil, nil, nil, nil, 1)
+          router.select("GET", "/", "", "http", nil, nil, nil, nil, nil, 1)
         end, "headers must be a table", nil, true)
       end)
     end)
@@ -2641,44 +3000,44 @@ describe("Router", function()
       local router = assert(Router.new(use_case))
 
       it("[src_ip]", function()
-        local match_t = router.select(nil, nil, nil, "127.0.0.1")
+        local match_t = router.select(nil, nil, nil, "tcp", "127.0.0.1")
         assert.truthy(match_t)
         assert.equal(use_case[1].route, match_t.route)
 
-        match_t = router.select(nil, nil, nil, "127.0.0.1")
+        match_t = router.select(nil, nil, nil, "tcp", "127.0.0.1")
         assert.truthy(match_t)
         assert.equal(use_case[1].route, match_t.route)
       end)
 
       it("[src_port]", function()
-        local match_t = router.select(nil, nil, nil, "127.0.0.3", 65001)
+        local match_t = router.select(nil, nil, nil, "tcp", "127.0.0.3", 65001)
         assert.truthy(match_t)
         assert.equal(use_case[2].route, match_t.route)
       end)
 
       it("[src_ip] range match", function()
-        local match_t = router.select(nil, nil, nil, "127.168.0.1")
+        local match_t = router.select(nil, nil, nil, "tcp", "127.168.0.1")
         assert.truthy(match_t)
         assert.equal(use_case[3].route, match_t.route)
       end)
 
       it("[src_ip] + [src_port]", function()
-        local match_t = router.select(nil, nil, nil, "127.0.0.1", 65001)
+        local match_t = router.select(nil, nil, nil, "tcp", "127.0.0.1", 65001)
         assert.truthy(match_t)
         assert.equal(use_case[4].route, match_t.route)
       end)
 
       it("[src_ip] range match + [src_port]", function()
-        local match_t = router.select(nil, nil, nil, "127.168.10.1", 65301)
+        local match_t = router.select(nil, nil, nil, "tcp", "127.168.10.1", 65301)
         assert.truthy(match_t)
         assert.equal(use_case[5].route, match_t.route)
       end)
 
       it("[src_ip] no match", function()
-        local match_t = router.select(nil, nil, nil, "10.0.0.1")
+        local match_t = router.select(nil, nil, nil, "tcp", "10.0.0.1")
         assert.falsy(match_t)
 
-        match_t = router.select(nil, nil, nil, "10.0.0.2", 65301)
+        match_t = router.select(nil, nil, nil, "tcp", "10.0.0.2", 65301)
         assert.falsy(match_t)
       end)
     end)
@@ -2737,51 +3096,51 @@ describe("Router", function()
       local router = assert(Router.new(use_case))
 
       it("[dst_ip]", function()
-        local match_t = router.select(nil, nil, nil, nil, nil,
+        local match_t = router.select(nil, nil, nil, "tcp", nil, nil,
                                       "127.0.0.1")
         assert.truthy(match_t)
         assert.equal(use_case[1].route, match_t.route)
 
-        match_t = router.select(nil, nil, nil, nil, nil,
+        match_t = router.select(nil, nil, nil, "tcp", nil, nil,
                                 "127.0.0.1")
         assert.truthy(match_t)
         assert.equal(use_case[1].route, match_t.route)
       end)
 
       it("[dst_port]", function()
-        local match_t = router.select(nil, nil, nil, nil, nil,
+        local match_t = router.select(nil, nil, nil, "tcp", nil, nil,
                                       "127.0.0.3", 65001)
         assert.truthy(match_t)
         assert.equal(use_case[2].route, match_t.route)
       end)
 
       it("[dst_ip] range match", function()
-        local match_t = router.select(nil, nil, nil, nil, nil,
+        local match_t = router.select(nil, nil, nil, "tcp", nil, nil,
                                       "127.168.0.1")
         assert.truthy(match_t)
         assert.equal(use_case[3].route, match_t.route)
       end)
 
       it("[dst_ip] + [dst_port]", function()
-        local match_t = router.select(nil, nil, nil, nil, nil,
+        local match_t = router.select(nil, nil, nil, "tcp", nil, nil,
                                       "127.0.0.1", 65001)
         assert.truthy(match_t)
         assert.equal(use_case[4].route, match_t.route)
       end)
 
       it("[dst_ip] range match + [dst_port]", function()
-        local match_t = router.select(nil, nil, nil, nil, nil,
+        local match_t = router.select(nil, nil, nil, "tcp", nil, nil,
                                       "127.168.10.1", 65301)
         assert.truthy(match_t)
         assert.equal(use_case[5].route, match_t.route)
       end)
 
       it("[dst_ip] no match", function()
-        local match_t = router.select(nil, nil, nil, nil, nil,
+        local match_t = router.select(nil, nil, nil, "tcp", nil, nil,
                                       "10.0.0.1")
         assert.falsy(match_t)
 
-        match_t = router.select(nil, nil, nil, nil, nil,
+        match_t = router.select(nil, nil, nil, "tcp", nil, nil,
                                 "10.0.0.2", 65301)
         assert.falsy(match_t)
       end)
@@ -2801,7 +3160,7 @@ describe("Router", function()
       local router = assert(Router.new(use_case))
 
       it("[sni]", function()
-        local match_t = router.select(nil, nil, nil, nil, nil, nil, nil,
+        local match_t = router.select(nil, nil, nil, "tcp", nil, nil, nil, nil,
                                       "www.example.org")
         assert.truthy(match_t)
         assert.equal(use_case[1].route, match_t.route)
@@ -2837,12 +3196,12 @@ describe("Router", function()
 
       local router = assert(Router.new(use_case))
 
-      local match_t = router.select(nil, nil, nil, "127.0.0.1", nil,
+      local match_t = router.select(nil, nil, nil, "tcp", "127.0.0.1", nil,
                                     nil, nil, "www.example.org")
       assert.truthy(match_t)
       assert.equal(use_case[1].route, match_t.route)
 
-      match_t = router.select(nil, nil, nil, nil, nil,
+      match_t = router.select(nil, nil, nil, "tcp", nil, nil,
                               "172.168.0.1", nil, "www.example.org")
       assert.truthy(match_t)
       assert.equal(use_case[1].route, match_t.route)
@@ -2871,7 +3230,7 @@ describe("Router", function()
 
       local router = assert(Router.new(use_case))
 
-      local match_t = router.select(nil, nil, nil, "127.0.0.1", nil,
+      local match_t = router.select(nil, nil, nil, "tcp", "127.0.0.1", nil,
                                     "172.168.0.1", nil, "www.example.org")
       assert.truthy(match_t)
       assert.equal(use_case[2].route, match_t.route)

--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -438,7 +438,7 @@ describe("kong start/stop #" .. strategy, function()
               in 'routes':
                 - in entry 1 of 'routes':
                   in 'hosts':
-                    - in entry 2 of 'hosts': invalid value: \\99
+                    - in entry 2 of 'hosts': invalid hostname: \\99
         ]], err, nil, true)
       end)
     end

--- a/spec/02-integration/05-proxy/02-router_spec.lua
+++ b/spec/02-integration/05-proxy/02-router_spec.lua
@@ -352,12 +352,20 @@ for _, strategy in helpers.each_strategy() do
         routes = insert_routes(bp, {
           {
             protocols = { "grpc", "grpcs" },
-            hosts = { "grpc1" },
+            hosts = {
+              "grpc1",
+              "grpc1:" .. helpers.get_proxy_port(false, true),
+              "grpc1:"..helpers.get_proxy_port(true, true),
+            },
             service = service,
           },
           {
             protocols = { "grpc", "grpcs" },
-            hosts = { "grpc2" },
+            hosts = {
+              "grpc2",
+              "grpc2:" .. helpers.get_proxy_port(false, true),
+              "grpc2:"..helpers.get_proxy_port(true, true),
+            },
             service = service,
           },
           {
@@ -865,7 +873,7 @@ for _, strategy in helpers.each_strategy() do
         routes = insert_routes(bp, {
           {
             preserve_host = true,
-            hosts         = { "preserved.com" },
+            hosts         = { "preserved.com", "preserved.com:123" },
             service       = {
               path        = "/request"
             },

--- a/spec/02-integration/05-proxy/02-router_spec.lua
+++ b/spec/02-integration/05-proxy/02-router_spec.lua
@@ -355,7 +355,7 @@ for _, strategy in helpers.each_strategy() do
             hosts = {
               "grpc1",
               "grpc1:" .. helpers.get_proxy_port(false, true),
-              "grpc1:"..helpers.get_proxy_port(true, true),
+              "grpc1:" .. helpers.get_proxy_port(true, true),
             },
             service = service,
           },
@@ -364,7 +364,7 @@ for _, strategy in helpers.each_strategy() do
             hosts = {
               "grpc2",
               "grpc2:" .. helpers.get_proxy_port(false, true),
-              "grpc2:"..helpers.get_proxy_port(true, true),
+              "grpc2:" .. helpers.get_proxy_port(true, true),
             },
             service = service,
           },

--- a/spec/02-integration/05-proxy/10-balancer/01-ring-balancer_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer/01-ring-balancer_spec.lua
@@ -1874,7 +1874,11 @@ for _, strategy in helpers.each_strategy() do
 
             add_target(bp, upstream_id, localhost, port1)
             add_target(bp, upstream_id, localhost, port2)
-            local _, service_id, route_id = add_api(bp, upstream_name, 500, 500, nil, nil, "tcp")
+            local _, service_id, route_id = add_api(bp, upstream_name, {
+              read_timeout = 500,
+              write_timeout = 500,
+              route_protocol = "tcp",
+            })
             end_testcase_setup(strategy, bp)
 
             finally(function()

--- a/spec/02-integration/05-proxy/19-grpc_proxy_spec.lua
+++ b/spec/02-integration/05-proxy/19-grpc_proxy_spec.lua
@@ -57,7 +57,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     it("proxies grpc", function()
-      local ok, resp = proxy_client_grpc({
+      local ok, resp = assert(proxy_client_grpc({
         service = "hello.HelloService.SayHello",
         body = {
           greeting = "world!"
@@ -65,13 +65,13 @@ for _, strategy in helpers.each_strategy() do
         opts = {
           ["-authority"] = "grpc",
         }
-      })
+      }))
       assert.truthy(ok)
       assert.truthy(resp)
     end)
 
     it("proxies grpcs", function()
-      local ok, resp = proxy_client_grpcs({
+      local ok, resp = assert(proxy_client_grpcs({
         service = "hello.HelloService.SayHello",
         body = {
           greeting = "world!"
@@ -79,7 +79,7 @@ for _, strategy in helpers.each_strategy() do
         opts = {
           ["-authority"] = "grpcs",
         }
-      })
+      }))
       assert.truthy(ok)
       assert.truthy(resp)
     end)


### PR DESCRIPTION
### Summary

Allow routes to specify a port in the host parameter.  If present, it matches only requests to that
specific port.  If absent, requests to any port matches.  Requests without explicit port are handled as if they included the appropriate default port (80 for HTTP, 443 for HTTPS).  Routes with port have higher priority than those that those without; even for requests without explicit port.
