### PR TITLE
Fix tag-filtered GET issues for Cassandra-backed nodes

### DIFF
--- a/kong/db/strategies/cassandra/init.lua
+++ b/kong/db/strategies/cassandra/init.lua
@@ -1131,8 +1131,8 @@ do
           clear_tab(current_entity_ids)
           current_entity_count = 0
           for i, row in ipairs(rows) do
-            current_entity_ids[i] = row.entity_id
             current_entity_count = current_entity_count + 1
+            current_entity_ids[current_entity_count] = row.entity_id
           end
         end
       end

--- a/kong/db/strategies/cassandra/init.lua
+++ b/kong/db/strategies/cassandra/init.lua
@@ -1008,6 +1008,7 @@ do
     if not entity_ids then
       return {}, nil, nil
     end
+    local entity_index = 0
     entity_count = entity_count or #entity_ids
     local entities = new_tab(entity_count, 0)
     -- TODO: send one query using IN
@@ -1017,7 +1018,10 @@ do
       if err then
         return nil, err, err_t
       end
-      entities[i] = entity
+      if entity then
+        entity_index = entity_index + 1
+        entities[entity_index] = entity
+      end
     end
     return entities, nil, nil
   end


### PR DESCRIPTION
### Summary

Fixes issues with tag-filtered GETs on Cassandra-backed nodes.

### Full changelog

* Modify table index within Cassandra tag query handling to allow passing a subset of all entities found, rather than all entities found, to the next phase.
* When dereferencing entity IDs found during a Cassandra tag query, skip entities that no longer exist.

### Issues resolved

This addresses two fatal errors that appear during admin API GET requests filtered by tags on Cassandra-backed nodes:
* Kong Enterprise filters the list of tagged entities retrieved to remove entities that are not in the correct workspace (or whose workspace cannot be determined, because the entity has been deleted). Without [this change](https://github.com/Kong/kong/commit/330129b3320ba0dd7c7975c27a1aba998ea0c741), table indices for filtered entities will have no value, causing the following error when they are later passed to `dereference_rows`:
```
2019/09/24 00:52:26 [error] 32#0: *10316 lua coroutine: runtime error: ...ocal/share/lua/5.1/kong/db/strategies/cassandra/init.lua:315: bad argument #1 to 'uuid()' (got nil)
```
* Entities are retrieved in a non-atomic two-step process, and entities can be deleted before the second step. This causes `dereference_rows` to return null values for some entity IDs, later breaking the admin API's attempts to serialize them to JSON:
```
2019/09/30 20:25:26 [error] 7055#0: *20111 lua coroutine: runtime error: /usr/local/share/lua/5.1/kong/db/schema/init.lua:1463: attempt to index local 'data' (a nil value
)
stack traceback:
coroutine 0:
        /usr/local/share/lua/5.1/kong/db/schema/init.lua: in function 'process_auto_fields'
        /usr/local/share/lua/5.1/kong/db/dao/init.lua:1490: in function 'row_to_entity'
        /usr/local/share/lua/5.1/kong/db/dao/init.lua:1471: in function 'rows_to_entities'
        /usr/local/share/lua/5.1/kong/db/dao/init.lua:1064: in function 'page_collection'
        /usr/local/share/lua/5.1/kong/api/endpoints.lua:303: in function 'fn'
        /usr/local/share/lua/5.1/kong/api/init.lua:50: in function </usr/local/share/lua/5.1/kong/api/init.lua:33>
```