### PR TITLE
docs(changelog) document the release asset name change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@
 
 > Released on 2019/09/25
 
+### Installation
+
+  - :warning: All Bintray assets have been renamed from `.all.` / `.noarch.` to be
+    architecture specific namely `.arm64.` and `.amd64.`
+
 ### Additions
 
 ##### Core


### PR DESCRIPTION
Adding a note that the release assets on bintray are now by target architecture

`1.3.0` was released such that it was backwards compatible so that will allow automation to switch while still pinned to `1.3.0` and then upgrade to `1.4.0` with no loss of functionality

![Capture](https://user-images.githubusercontent.com/697188/66424599-ea541780-e9db-11e9-9ba6-3aa9abbef87d.PNG)
