### PR TITLE
refactor(core) client cache separation

### DIFF
--- a/kong/api/routes/cache.lua
+++ b/kong/api/routes/cache.lua
@@ -16,6 +16,16 @@ return {
         return kong.response.exit(200, type(value) == "table" and value or { message = value })
       end
 
+      ttl, err, value = kong.core_cache:probe(self.params.key)
+      if err then
+        kong.log.err(err)
+        return kong.response.exit(500, { message = "An unexpected error happened" })
+      end
+
+      if ttl then
+        return kong.response.exit(200, type(value) == "table" and value or { message = value })
+      end
+
       return kong.response.exit(404, { message = "Not found" })
     end,
 
@@ -29,6 +39,7 @@ return {
   ["/cache"] = {
     DELETE = function()
       kong.cache:purge()
+      kong.core_cache:purge()
 
       return kong.response.exit(204) -- no content
     end,

--- a/kong/cache_warmup.lua
+++ b/kong/cache_warmup.lua
@@ -1,4 +1,5 @@
 local utils = require "kong.tools.utils"
+local constants = require "kong.constants"
 
 
 local cache_warmup = {}
@@ -39,6 +40,8 @@ end
 local function cache_warmup_single_entity(dao)
   local entity_name = dao.schema.name
 
+  local cache = constants.CORE_ENTITIES[entity_name] and kong.core_cache or kong.cache
+
   ngx.log(ngx.NOTICE, "Preloading '", entity_name, "' into the cache ...")
 
   local start = ngx.now()
@@ -66,7 +69,7 @@ local function cache_warmup_single_entity(dao)
 
     local cache_key = dao:cache_key(entity)
 
-    local ok, err = kong.cache:safe_set(cache_key, entity)
+    local ok, err = cache:safe_set(cache_key, entity)
     if not ok then
       return nil, err
     end
@@ -87,7 +90,7 @@ end
 -- Loads entities from the database into the cache, for rapid subsequent
 -- access. This function is intented to be used during worker initialization.
 function cache_warmup.execute(entities)
-  if not kong.cache then
+  if not kong.cache or not kong.core_cache then
     return true
   end
 

--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -100,6 +100,17 @@ return {
     "cluster_ca",
     "tags",
     "ca_certificates",
+    consumers = true,
+    certificates = true,
+    services = true,
+    routes = true,
+    snis = true,
+    upstreams = true,
+    targets = true,
+    plugins = true,
+    cluster_ca = true,
+    tags = true,
+    ca_certificates = true,
   },
   RATELIMIT = {
     PERIODS = {

--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -348,14 +348,14 @@ function declarative.load_into_cache(entities, hash, shadow_page)
 
       local cache_key = dao:cache_key(id)
       item = schema:transform(remove_nulls(item))
-      local ok, err = kong.cache:safe_set(cache_key, item, shadow_page)
+      local ok, err = kong.core_cache:safe_set(cache_key, item, shadow_page)
       if not ok then
         return nil, err
       end
 
       if schema.cache_key then
         local cache_key = dao:cache_key(item)
-        ok, err = kong.cache:safe_set(cache_key, item, shadow_page)
+        ok, err = kong.core_cache:safe_set(cache_key, item, shadow_page)
         if not ok then
           return nil, err
         end
@@ -371,7 +371,7 @@ function declarative.load_into_cache(entities, hash, shadow_page)
           end
 
           local cache_key = entity_name .. "|" .. unique .. ":" .. unique_key
-          ok, err = kong.cache:safe_set(cache_key, item, shadow_page)
+          ok, err = kong.core_cache:safe_set(cache_key, item, shadow_page)
           if not ok then
             return nil, err
           end
@@ -401,7 +401,7 @@ function declarative.load_into_cache(entities, hash, shadow_page)
       end
     end
 
-    local ok, err = kong.cache:safe_set(entity_name .. "|list", ids, shadow_page)
+    local ok, err = kong.core_cache:safe_set(entity_name .. "|list", ids, shadow_page)
     if not ok then
       return nil, err
     end
@@ -409,7 +409,7 @@ function declarative.load_into_cache(entities, hash, shadow_page)
     for ref, fids in pairs(page_for) do
       for fid, entries in pairs(fids) do
         local key = entity_name .. "|" .. ref .. "|" .. fid .. "|list"
-        ok, err = kong.cache:safe_set(key, entries, shadow_page)
+        ok, err = kong.core_cache:safe_set(key, entries, shadow_page)
         if not ok then
           return nil, err
         end
@@ -428,7 +428,7 @@ function declarative.load_into_cache(entities, hash, shadow_page)
       end
       -- stay consistent with pagination
       table.sort(arr)
-      ok, err = kong.cache:safe_set(key, arr, shadow_page)
+      ok, err = kong.core_cache:safe_set(key, arr, shadow_page)
       if not ok then
         return nil, err
       end
@@ -439,7 +439,7 @@ function declarative.load_into_cache(entities, hash, shadow_page)
     -- tags:admin|list -> all tags tagged "admin", regardless of the entity type
     -- each tag is encoded as a string with the format "admin|services|uuid", where uuid is the service uuid
     local key = "tags:" .. tag_name .. "|list"
-    local ok, err = kong.cache:safe_set(key, tags, shadow_page)
+    local ok, err = kong.core_cache:safe_set(key, tags, shadow_page)
     if not ok then
       return nil, err
     end
@@ -447,7 +447,7 @@ function declarative.load_into_cache(entities, hash, shadow_page)
 
   -- tags|list -> all tags, with no distinction of tag name or entity type.
   -- each tag is encoded as a string with the format "admin|services|uuid", where uuid is the service uuid
-  local ok, err = kong.cache:safe_set("tags|list", tags, shadow_page)
+  local ok, err = kong.core_cache:safe_set("tags|list", tags, shadow_page)
   if not ok then
     return nil, err
   end
@@ -486,13 +486,13 @@ function declarative.load_into_cache_with_events(entities, hash)
     end
   end
 
-  kong.cache:purge(SHADOW)
+  kong.core_cache:purge(SHADOW)
 
   if not ok then
     return nil, err
   end
 
-  kong.cache:invalidate("router:version")
+  kong.core_cache:invalidate("router:version")
 
   ok, err = kong.worker_events.post("balancer", "upstreams", {
     operation = "reset",

--- a/kong/db/strategies/off/init.lua
+++ b/kong/db/strategies/off/init.lua
@@ -34,7 +34,7 @@ end
 -- @tparam string|nil tags_cond either "or", "and". `nil` means "or"
 -- @treturn table|nil returns a table with entity_ids as values, and `true` as keys
 local function get_entity_ids_tagged(key, tag_names, tags_cond)
-  local cache = kong.cache
+  local cache = kong.core_cache
   local tag_name, list, err
   local dict = {} -- keys are entity_ids, values are true
 
@@ -105,7 +105,7 @@ local function page_for_key(self, key, size, offset, options)
     offset = 1
   end
 
-  local cache = kong.cache
+  local cache = kong.core_cache
   if not cache then
     return {}
   end
@@ -161,11 +161,11 @@ end
 
 
 local function select_by_key(self, key)
-  if not kong.cache then
+  if not kong.core_cache then
     return nil
   end
 
-  return kong.cache:get(key, nil, nil_cb)
+  return kong.core_cache:get(key, nil, nil_cb)
 end
 
 

--- a/kong/global.lua
+++ b/kong/global.lua
@@ -158,6 +158,7 @@ do
     end
 
     return kong_cache.new {
+      shm_name          = "kong_db_cache",
       cluster_events    = cluster_events,
       worker_events     = worker_events,
       propagation_delay = kong_config.db_update_propagation,
@@ -172,6 +173,30 @@ do
     }
   end
 
+
+  function _GLOBAL.init_core_cache(kong_config, cluster_events, worker_events)
+    local db_cache_ttl = kong_config.db_cache_ttl
+    local cache_pages = 1
+    if kong_config.database == "off" then
+      db_cache_ttl = 0
+      cache_pages = 2
+    end
+
+    return kong_cache.new {
+      shm_name          = "kong_core_db_cache",
+      cluster_events    = cluster_events,
+      worker_events     = worker_events,
+      propagation_delay = kong_config.db_update_propagation,
+      ttl               = db_cache_ttl,
+      neg_ttl           = db_cache_ttl,
+      resurrect_ttl     = kong_config.resurrect_ttl,
+      cache_pages       = cache_pages,
+      resty_lock_opts   = {
+        exptime = 10,
+        timeout = 5,
+      },
+    }
+  end
 end
 
 

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -537,6 +537,14 @@ function Kong.init_worker()
   end
   kong.cache = cache
 
+  local core_cache, err = kong_global.init_core_cache(kong.configuration, cluster_events, worker_events)
+  if not cache then
+    stash_init_worker_error("failed to instantiate 'kong.core_cache' module: " ..
+                            err)
+    return
+  end
+  kong.core_cache = core_cache
+
   ok, err = runloop.set_init_versions_in_cache()
   if not ok then
     stash_init_worker_error(err) -- 'err' fully formatted
@@ -545,6 +553,7 @@ function Kong.init_worker()
 
   -- LEGACY
   singletons.cache          = cache
+  singletons.core_cache     = core_cache
   singletons.worker_events  = worker_events
   singletons.cluster_events = cluster_events
   -- /LEGACY

--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -108,7 +108,7 @@ do
 
   get_upstream_by_id = function(upstream_id)
     local upstream_cache_key = "balancer:upstreams:" .. upstream_id
-    return singletons.cache:get(upstream_cache_key, nil,
+    return singletons.core_cache:get(upstream_cache_key, nil,
                                 load_upstream_into_memory, upstream_id)
   end
 end
@@ -149,7 +149,7 @@ do
   -- @return The target history array, with target entity tables.
   fetch_target_history = function(upstream)
     local targets_cache_key = "balancer:targets:" .. upstream.id
-    return singletons.cache:get(targets_cache_key, nil,
+    return singletons.core_cache:get(targets_cache_key, nil,
                                 load_targets_into_memory, upstream.id)
   end
 end
@@ -390,8 +390,8 @@ do
   end
 
   local function invalidate_upstream_caches(upstream_id)
-    singletons.cache:invalidate_local("balancer:upstreams:" .. upstream_id)
-    singletons.cache:invalidate_local("balancer:targets:" .. upstream_id)
+    singletons.core_cache:invalidate_local("balancer:upstreams:" .. upstream_id)
+    singletons.core_cache:invalidate_local("balancer:targets:" .. upstream_id)
   end
 
   ------------------------------------------------------------------------------
@@ -540,7 +540,7 @@ do
   -- @return The upstreams dictionary (a map with upstream names as string keys
   -- and upstream entity tables as values), or nil+error
   get_all_upstreams = function()
-    local upstreams_dict, err = singletons.cache:get("balancer:upstreams", opts,
+    local upstreams_dict, err = singletons.core_cache:get("balancer:upstreams", opts,
                                                 load_upstreams_dict_into_memory)
     if err then
       return nil, err
@@ -611,7 +611,7 @@ end
 
 
 local function do_target_event(operation, upstream_id, upstream_name)
-  singletons.cache:invalidate_local("balancer:targets:" .. upstream_id)
+  singletons.core_cache:invalidate_local("balancer:targets:" .. upstream_id)
 
   local upstream = get_upstream_by_id(upstream_id)
   if not upstream then
@@ -752,7 +752,7 @@ end
 local function do_upstream_event(operation, upstream_id, upstream_name)
   if operation == "create" then
 
-    singletons.cache:invalidate_local("balancer:upstreams")
+    singletons.core_cache:invalidate_local("balancer:upstreams")
 
     local upstream = get_upstream_by_id(upstream_id)
     if not upstream then
@@ -768,9 +768,9 @@ local function do_upstream_event(operation, upstream_id, upstream_name)
   elseif operation == "delete" or operation == "update" then
 
     if singletons.db.strategy ~= "off" then
-      singletons.cache:invalidate_local("balancer:upstreams")
-      singletons.cache:invalidate_local("balancer:upstreams:" .. upstream_id)
-      singletons.cache:invalidate_local("balancer:targets:"   .. upstream_id)
+      singletons.core_cache:invalidate_local("balancer:upstreams")
+      singletons.core_cache:invalidate_local("balancer:upstreams:" .. upstream_id)
+      singletons.core_cache:invalidate_local("balancer:targets:"   .. upstream_id)
     end
 
     local balancer = balancers[upstream_id]

--- a/kong/runloop/certificate.lua
+++ b/kong/runloop/certificate.lua
@@ -156,7 +156,7 @@ end
 
 
 local function get_certificate(pk, sni_name)
-  return kong.cache:get("certificates:" .. pk.id,
+  return kong.core_cache:get("certificates:" .. pk.id,
                         get_certificate_opts, fetch_certificate,
                         pk, sni_name)
 end
@@ -182,7 +182,7 @@ local function find_certificate(sni)
     bulk:add("snis:" .. sni_wild_suf, nil, fetch_sni, sni_wild_suf)
   end
 
-  local res, err = kong.cache:get_bulk(bulk)
+  local res, err = kong.core_cache:get_bulk(bulk)
   if err then
     return nil, err
   end

--- a/kong/runloop/plugins_iterator.lua
+++ b/kong/runloop/plugins_iterator.lua
@@ -84,10 +84,10 @@ local function load_configuration(ctx,
                                         route_id,
                                         service_id,
                                         consumer_id)
-  local plugin, err = kong.cache:get(key,
-                                     nil,
-                                     load_plugin_from_db,
-                                     key)
+  local plugin, err = kong.core_cache:get(key,
+                                          nil,
+                                          load_plugin_from_db,
+                                          key)
   if err then
     ctx.delay_response = false
     ngx.log(ngx.ERR, tostring(err))

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -29,15 +29,25 @@ lua_package_cpath '${{LUA_PACKAGE_CPATH}};;';
 lua_socket_pool_size ${{LUA_SOCKET_POOL_SIZE}};
 lua_max_running_timers 4096;
 lua_max_pending_timers 16384;
+
 lua_shared_dict kong                5m;
+
+
+lua_shared_dict kong_core_db_cache  ${{MEM_CACHE_SIZE}};
 lua_shared_dict kong_db_cache       ${{MEM_CACHE_SIZE}};
+
+lua_shared_dict kong_core_db_cache_miss   12m;
+lua_shared_dict kong_db_cache_miss   12m;
+
 > if database == "off" then
+lua_shared_dict kong_core_db_cache_2     ${{MEM_CACHE_SIZE}};
 lua_shared_dict kong_db_cache_2     ${{MEM_CACHE_SIZE}};
 > end
-lua_shared_dict kong_db_cache_miss   12m;
 > if database == "off" then
+lua_shared_dict kong_core_db_cache_miss_2     ${{MEM_CACHE_SIZE}};
 lua_shared_dict kong_db_cache_miss_2 12m;
 > end
+
 lua_shared_dict kong_locks          8m;
 lua_shared_dict kong_process_events 5m;
 lua_shared_dict kong_cluster_events 5m;

--- a/kong/templates/nginx_kong_stream.lua
+++ b/kong/templates/nginx_kong_stream.lua
@@ -9,15 +9,25 @@ log_format basic '$remote_addr [$time_local] '
 
 lua_package_path '${{LUA_PACKAGE_PATH}};;';
 lua_package_cpath '${{LUA_PACKAGE_CPATH}};;';
+
 lua_shared_dict stream_kong                5m;
+
+lua_shared_dict stream_kong_core_db_cache  ${{MEM_CACHE_SIZE}};
 lua_shared_dict stream_kong_db_cache       ${{MEM_CACHE_SIZE}};
+
+lua_shared_dict stream_kong_core_db_cache_miss   12m;
+lua_shared_dict stream_kong_db_cache_miss   12m;
+
 > if database == "off" then
+lua_shared_dict stream_kong_core_db_cache_2     ${{MEM_CACHE_SIZE}};
 lua_shared_dict stream_kong_db_cache_2     ${{MEM_CACHE_SIZE}};
 > end
-lua_shared_dict stream_kong_db_cache_miss   12m;
+
 > if database == "off" then
+lua_shared_dict stream_kong_core_db_cache_miss_2     ${{MEM_CACHE_SIZE}};
 lua_shared_dict stream_kong_db_cache_miss_2 12m;
 > end
+
 lua_shared_dict stream_kong_locks          8m;
 lua_shared_dict stream_kong_process_events 5m;
 lua_shared_dict stream_kong_cluster_events 5m;

--- a/spec/01-unit/09-balancer_spec.lua
+++ b/spec/01-unit/09-balancer_spec.lua
@@ -244,7 +244,7 @@ describe("Balancer", function()
       },
     }
 
-    singletons.cache = {
+    singletons.core_cache = {
       _cache = {},
       get = function(self, key, _, loader, arg)
         local v = self._cache[key]

--- a/spec/01-unit/14-dns_spec.lua
+++ b/spec/01-unit/14-dns_spec.lua
@@ -12,7 +12,7 @@ describe("DNS", function()
     stub(ngx, "log")
     singletons = require "kong.singletons"
 
-    singletons.cache = {
+    singletons.core_cache = {
       get = function() return {} end
     }
 

--- a/spec/01-unit/16-runloop_handler_spec.lua
+++ b/spec/01-unit/16-runloop_handler_spec.lua
@@ -41,7 +41,7 @@ local function setup_it_block()
       db = {
         strategy = "dummy",
       },
-      cache = {
+      core_cache = {
         _cache = my_cache,
         get = function(_, k)
           return my_cache[k] or "1"
@@ -192,7 +192,7 @@ describe("runloop handler", function()
       local latest_router
 
       local build_router_spy = spy.new(function()
-        handler._set_router_version(kong.cache:get("router:version"))
+        handler._set_router_version(kong.core_cache:get("router:version"))
         latest_router = {
           exec = function()
             return nil
@@ -211,7 +211,7 @@ describe("runloop handler", function()
 
       local saved_router = latest_router
 
-      kong.cache._cache["router:version"] = "new_version"
+      kong.core_cache._cache["router:version"] = "new_version"
 
       handler.access.before({})
 
@@ -230,7 +230,7 @@ describe("runloop handler", function()
       local latest_router
 
       local build_router_spy = spy.new(function()
-        handler._set_router_version(kong.cache:get("router:version"))
+        handler._set_router_version(kong.core_cache:get("router:version"))
         latest_router = {
           exec = function()
             return nil

--- a/spec/02-integration/04-admin_api/15-off_spec.lua
+++ b/spec/02-integration/04-admin_api/15-off_spec.lua
@@ -803,7 +803,7 @@ describe("Admin API #off with Unique Foreign #unique", function()
 
     mocker.setup(finally, {
       kong = {
-        cache = cache,
+        core_cache = cache,
       }
     })
 
@@ -827,7 +827,7 @@ describe("Admin API #off with Unique Foreign #unique", function()
           end
 
           if n == "kong" then
-            v.cache = cache
+            v.core_cache = cache
             break
           end
 

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -43,15 +43,26 @@ http {
     lua_socket_pool_size ${{LUA_SOCKET_POOL_SIZE}};
     lua_max_running_timers 4096;
     lua_max_pending_timers 16384;
+
     lua_shared_dict kong                5m;
+
+
+    lua_shared_dict kong_core_db_cache  ${{MEM_CACHE_SIZE}};
     lua_shared_dict kong_db_cache       ${{MEM_CACHE_SIZE}};
+
+    lua_shared_dict kong_core_db_cache_miss   12m;
+    lua_shared_dict kong_db_cache_miss   12m;
+
 > if database == "off" then
+    lua_shared_dict kong_core_db_cache_2     ${{MEM_CACHE_SIZE}};
     lua_shared_dict kong_db_cache_2     ${{MEM_CACHE_SIZE}};
 > end
-    lua_shared_dict kong_db_cache_miss   12m;
+
 > if database == "off" then
+    lua_shared_dict kong_core_db_cache_miss_2     ${{MEM_CACHE_SIZE}};
     lua_shared_dict kong_db_cache_miss_2 12m;
 > end
+
     lua_shared_dict kong_locks          8m;
     lua_shared_dict kong_process_events 5m;
     lua_shared_dict kong_cluster_events 5m;
@@ -498,15 +509,25 @@ stream {
 
     lua_package_path '${{LUA_PACKAGE_PATH}};;';
     lua_package_cpath '${{LUA_PACKAGE_CPATH}};;';
+
     lua_shared_dict stream_kong                5m;
+
+    lua_shared_dict stream_kong_core_db_cache  ${{MEM_CACHE_SIZE}};
     lua_shared_dict stream_kong_db_cache       ${{MEM_CACHE_SIZE}};
+
+    lua_shared_dict stream_kong_core_db_cache_miss   12m;
+    lua_shared_dict stream_kong_db_cache_miss   12m;
+
 > if database == "off" then
+    lua_shared_dict stream_kong_core_db_cache_2     ${{MEM_CACHE_SIZE}};
     lua_shared_dict stream_kong_db_cache_2     ${{MEM_CACHE_SIZE}};
 > end
-    lua_shared_dict stream_kong_db_cache_miss    12m;
+
 > if database == "off" then
+    lua_shared_dict stream_kong_core_db_cache_miss_2     ${{MEM_CACHE_SIZE}};
     lua_shared_dict stream_kong_db_cache_miss_2  12m;
 > end
+
     lua_shared_dict stream_kong_locks          8m;
     lua_shared_dict stream_kong_process_events 5m;
     lua_shared_dict stream_kong_cluster_events 5m;


### PR DESCRIPTION
### Summary

New cache `kong.core_cache` is meant for core usage, while the existing
`kong.cache` is used in, e.g., plugins.

