### PR TITLE
chore(Github) multiple issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,9 @@
+---
+name: "Bug report"
+about: Create a report to help improve the project
+
+---
+
 <!--
 Please read the CONTRIBUTING.md guidelines to learn on which channels you can
 seek for help and ask general questions:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,15 @@
+---
+name: "Feature request"
+about: Suggest an idea that will improve the project
+
+---
+
+<!--
+Please read the CONTRIBUTING.md guidelines to learn on which channels you can
+seek for help and ask general questions:
+https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#where-to-seek-for-help
+-->
+
+### Summary
+
+SUMMARY_GOES_HERE

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ more than willing to assist you on those channels!
 
 ## Where to report bugs?
 
-Feel free to [submit an issue](https://github.com/Kong/kong/issues/new) on
+Feel free to [submit an issue](https://github.com/Kong/kong/issues/new/choose) on
 the GitHub repository, we would be grateful to hear about it! Please make sure
 to respect the GitHub issue template, and include:
 
@@ -85,7 +85,7 @@ on how to best do so.
 
 ## Where to submit feature requests?
 
-You can [submit an issue](https://github.com/Kong/kong/issues/new) for feature
+You can [submit an issue](https://github.com/Kong/kong/issues/new/choose) for feature
 requests. Please add as much detail as you can when doing so.
 
 You are also welcome to propose patches adding new features. See the section


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Existing single GitHub template for issues is planned to be deprecated in the future and Github itself recommends updating the repo to _new issue template workflow_.

<img width="1002" alt="Screenshot 2019-10-10 10 19 26" src="https://user-images.githubusercontent.com/3473617/66553387-47221000-eb4b-11e9-902a-77eba9ee4ae6.png">

The existing issue template was removed and replaced with two new templates: bug report and feature request.

### Full changelog

* removed existing single issue template
* added issue template for bug report with proper label
* added issue template for feature request with proper label
* updated `CONTRIBUTING.md` to link to issue template chooser

### Issues resolved

N/A
