### PR TITLE
fix(db) cluster events deadlock as reported by #4986

### DIFF
--- a/kong/db/migrations/core/006_130_to_140.lua
+++ b/kong/db/migrations/core/006_130_to_140.lua
@@ -8,6 +8,10 @@ return {
         -- Do nothing, accept existing state
       END;
       $$;
+
+
+      DROP TRIGGER IF EXISTS "delete_expired_cluster_events_trigger" ON "cluster_events";
+      DROP FUNCTION IF EXISTS "delete_expired_cluster_events" ();
     ]],
   },
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

The original `cluster events` cleanup routine was executed within a transaction provided by a trigger when inserting new events. This removes the function and trigger (and thus transaction) and moves `cluster_events` cleanup as part of our generic cleanup routine. It should fix the issue #4986, but it is quite hard to reproduce, thus no tests where added.

### Issues resolved

Fix #4986
