### PR TITLE
Suggestion for fix attributes consideration for ldap

### DIFF
--- a/kong/plugins/ldap-auth/access.lua
+++ b/kong/plugins/ldap-auth/access.lua
@@ -91,7 +91,31 @@ local function ldap_authenticate(given_username, given_password, conf)
     end
   end
 
-  local who = conf.attribute .. "=" .. given_username .. "," .. conf.base_dn
+  -- Get Domain base from base_dn
+  base_dn = conf.base_dn
+  base_dn = string.upper(base_dn)
+
+  domain=""
+  for word in string.gmatch(base_dn, 'DC=([^,]+)') do
+    domain = domain .. "." .. word
+  end
+  domain = string.sub(domain, 2)
+
+  -- Case attribute is Common Name
+  if conf.attribute == "cn" then
+    local who = conf.attribute .. "=" .. given_username .. "," .. conf.base_dn
+  end
+
+  -- Case attribute is Common Name
+  if conf.attribute == "sAMAccountName" then
+    local who = user .. "@" .. domain
+  end
+
+  -- Case attribute is Common Name
+  if conf.attribute == "userPrincipalName" then
+    local who = given_username
+  end
+
   is_authenticated, err = ldap.bind_request(sock, who, given_password)
 
   ok, suppressed_err = sock:setkeepalive(conf.keepalive)

--- a/kong/plugins/ldap-auth/access.lua
+++ b/kong/plugins/ldap-auth/access.lua
@@ -108,7 +108,7 @@ local function ldap_authenticate(given_username, given_password, conf)
 
   -- Case attribute is sAMAccountName
   if conf.attribute == "sAMAccountName" then
-    who = user .. "@" .. domain
+    who = given_username .. "@" .. domain
   end
 
   -- Case attribute is UPN

--- a/kong/plugins/ldap-auth/access.lua
+++ b/kong/plugins/ldap-auth/access.lua
@@ -103,17 +103,17 @@ local function ldap_authenticate(given_username, given_password, conf)
 
   -- Case attribute is Common Name
   if conf.attribute == "cn" then
-    local who = conf.attribute .. "=" .. given_username .. "," .. conf.base_dn
+    who = conf.attribute .. "=" .. given_username .. "," .. conf.base_dn
   end
 
   -- Case attribute is sAMAccountName
   if conf.attribute == "sAMAccountName" then
-    local who = user .. "@" .. domain
+    who = user .. "@" .. domain
   end
 
   -- Case attribute is UPN
   if conf.attribute == "userPrincipalName" then
-    local who = given_username
+    who = given_username
   end
 
   is_authenticated, err = ldap.bind_request(sock, who, given_password)

--- a/kong/plugins/ldap-auth/access.lua
+++ b/kong/plugins/ldap-auth/access.lua
@@ -106,12 +106,12 @@ local function ldap_authenticate(given_username, given_password, conf)
     local who = conf.attribute .. "=" .. given_username .. "," .. conf.base_dn
   end
 
-  -- Case attribute is Common Name
+  -- Case attribute is sAMAccountName
   if conf.attribute == "sAMAccountName" then
     local who = user .. "@" .. domain
   end
 
-  -- Case attribute is Common Name
+  -- Case attribute is UPN
   if conf.attribute == "userPrincipalName" then
     local who = given_username
   end

--- a/kong/plugins/ldap-auth/access.lua
+++ b/kong/plugins/ldap-auth/access.lua
@@ -46,6 +46,9 @@ local function ldap_authenticate(given_username, given_password, conf)
   local is_authenticated
   local err, suppressed_err, ok, _
 
+  local base_dn
+  local domain
+  local who
   local sock = tcp()
 
   sock:settimeout(conf.timeout)
@@ -101,10 +104,7 @@ local function ldap_authenticate(given_username, given_password, conf)
   end
   domain = string.sub(domain, 2)
 
-  -- Case attribute is Common Name
-  if conf.attribute == "cn" then
-    who = conf.attribute .. "=" .. given_username .. "," .. conf.base_dn
-  end
+  who = conf.attribute .. "=" .. given_username .. "," .. conf.base_dn
 
   -- Case attribute is sAMAccountName
   if conf.attribute == "sAMAccountName" then


### PR DESCRIPTION
### Summary

Attributes in LDAP can be used to bind and user. In case of LDAP Auth plugins of Kong, only the CN is working. Other attributes like sAMAccountName and UPN cannot be used regardless the code that consider only a binding based on DN syntax.

### Full changelog

* Add consideration to differents attributes for binding

### Issues resolved

https://github.com/Kong/kong/issues/5121

### IMPORTANT NOTE
I'm note a LUA developper. I just wanted to propose a workarround fix. Consider this pull request with caution.
