### PR TITLE
fix(jwt) handle empty string claims

### DIFF
--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -114,7 +114,7 @@ local function set_consumer(consumer, credential, token)
 
   if credential then
     kong.ctx.shared.authenticated_jwt_token = token -- TODO: wrap in a PDK function?
-    ngx.ctx.authenticated_jwt_token = token  -- backward compatibilty only
+    ngx.ctx.authenticated_jwt_token = token  -- backward compatibility only
 
     if credential.username then
       set_header(constants.HEADERS.CREDENTIAL_USERNAME, credential.username)
@@ -161,6 +161,8 @@ local function do_authentication(conf)
   local jwt_secret_key = claims[conf.key_claim_name] or header[conf.key_claim_name]
   if not jwt_secret_key then
     return false, { status = 401, message = "No mandatory '" .. conf.key_claim_name .. "' in claims" }
+  elseif jwt_secret_key == "" then
+    return false, { status = 401, message = "Invalid '" .. conf.key_claim_name .. "' in claims" }
   end
 
   -- Retrieve the secret

--- a/spec/03-plugins/16-jwt/03-access_spec.lua
+++ b/spec/03-plugins/16-jwt/03-access_spec.lua
@@ -221,6 +221,22 @@ for _, strategy in helpers.each_strategy() do
         local json = cjson.decode(body)
         assert.same({ message = "No mandatory 'iss' in claims" }, json)
       end)
+      it("returns 401 if the claims do not contain a valid key to identify a secret", function()
+        PAYLOAD.iss = ""
+        local jwt = jwt_encoder.encode(PAYLOAD, "foo")
+        local authorization = "Bearer " .. jwt
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/request",
+          headers = {
+            ["Authorization"] = authorization,
+            ["Host"]          = "jwt1.com",
+          }
+        })
+        local body = assert.res_status(401, res)
+        local json = cjson.decode(body)
+        assert.same({ message = "Invalid 'iss' in claims" }, json)
+      end)
       it("returns 401 Unauthorized if the iss does not match a credential", function()
         PAYLOAD.iss = "123456789"
         local jwt = jwt_encoder.encode(PAYLOAD, jwt_secret.secret)


### PR DESCRIPTION
### Summary

Pretty straight forward, fixes jwt plugin from throwing for example:
```
{"message": "An unexpected error occurred"}
```

to

```
{"message":"Invalid 'iss' in claims"}
```

When folks decide to go a little crazy and not provide a valid value on a claim, kinda edge case but a consumer leveraging the gateway did bring it up so here I am 🍻 .

Sample testing it in my dev environment, but I included an updated unit test for good measure too. I know yall dig those 😁. 

![image](https://user-images.githubusercontent.com/31913027/66731125-afab0e80-ee23-11e9-888c-b98e845e2847.png)

Least I can do after the awesome conference you folks put on. More to come! I have 3-4 ideas to PR that might be cool. 

### Full changelog

* Implemented: /kong/plugins/jwt/handler.lua checking for the empty string claims
* Updated: /spec/03-plugins/16-jwt/03-access_spec.lua to include case for the empty string claims

### Issues resolved

Fix #4976 