### PR TITLE
fix(proxy) disable service mesh by default and show a deprecation

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -118,6 +118,15 @@
 #anonymous_reports = on          # Send anonymous usage data such as error
                                  # stack traces to help improve Kong.
 
+#service_mesh = off              # When `on`, enable the built-in Service Mesh
+                                 # support of Kong.
+                                 #
+                                 # **Note:** Enabling service mesh causes
+                                 # upstream requests to HTTPS services to
+                                 # behave incorrectly. Service Mesh has been
+                                 # deprecated and will be removed in the next
+                                 # release of Kong.
+
 #------------------------------------------------------------------------------
 # NGINX
 #------------------------------------------------------------------------------

--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -235,6 +235,7 @@ local CONF_INFERENCES = {
 
   lua_ssl_verify_depth = { typ = "number" },
   lua_socket_pool_size = { typ = "number" },
+  service_mesh = { typ = "boolean" },
 }
 
 
@@ -545,6 +546,13 @@ local function check_and_infer(conf)
 
   if conf.router_update_frequency <= 0 then
     errors[#errors + 1] = "router_update_frequency must be greater than 0"
+  end
+
+  if conf.service_mesh then
+    log.warn("You enabled the deprecated Service Mesh feature of " ..
+             "the Kong Gateway, which will cause upstream HTTPS request " ..
+             "to behave incorrectly. Service Mesh support" ..
+             "in Kong Gateway will be removed in the next release.")
   end
 
   return #errors == 0, errors[1], errors

--- a/kong/pdk/client.lua
+++ b/kong/pdk/client.lua
@@ -280,7 +280,9 @@ local function new(self)
     -- else subsystem is stream
 
     local balancer_data = ngx.ctx.balancer_data
-    local is_tls = balancer_data and balancer_data.scheme == "tls" and balancer_data.ssl_ctx
+    local is_tls = balancer_data and balancer_data.scheme == "tls" and
+                   (kong.configuration.service_mesh and
+                    balancer_data.ssl_ctx or true)
 
     return is_tls and "tls" or "tcp"
   end

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -952,7 +952,7 @@ return {
       local ssl_preread_alpn_protocols = var.ssl_preread_alpn_protocols
       -- ssl_preread_alpn_protocols is a comma separated list
       -- see https://trac.nginx.org/nginx/ticket/1616
-      if ssl_preread_alpn_protocols and
+      if kong.configuration.service_mesh and ssl_preread_alpn_protocols and
          ssl_preread_alpn_protocols:find(mesh.get_mesh_alpn(), 1, true) then
         -- Is probably an incoming service mesh connection
         -- terminate service-mesh Mutual TLS
@@ -1028,7 +1028,9 @@ return {
       ctx.http_proxy_authorization = var.http_proxy_authorization
       ctx.http_te                  = var.http_te
 
-      mesh.rewrite(ctx)
+      if kong.configuration.service_mesh then
+        mesh.rewrite(ctx)
+      end
     end,
   },
   access = {

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -9,6 +9,7 @@ status_access_log = off
 status_error_log = logs/status_error.log
 plugins = bundled
 anonymous_reports = on
+service_mesh = off
 
 proxy_listen = 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
 stream_listen = off

--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -469,6 +469,29 @@ describe("kong start/stop #" .. strategy, function()
         assert.matches("Kong stopped", stdout, nil, true)
         assert.equal("", stderr)
       end)
+
+      it("'service_mesh'", function()
+        local opts = {
+          prefix = helpers.test_conf.prefix,
+          database = helpers.test_conf.database,
+          pg_database = helpers.test_conf.pg_database,
+          cassandra_keyspace = helpers.test_conf.cassandra_keyspace,
+          service_mesh = "on",
+        }
+
+        local _, stderr, stdout = assert(helpers.kong_exec("start", opts))
+        assert.matches("Kong started", stdout, nil, true)
+        print(stderr)
+        assert.matches("You enabled the deprecated Service Mesh feature of " ..
+                       "the Kong Gateway, which will cause upstream HTTPS request " ..
+                       "to behave incorrectly. Service Mesh support" ..
+                       "in Kong Gateway will be removed in the next release."
+        , stderr, nil, true)
+
+        local _, stderr, stdout = assert(helpers.kong_exec("stop", opts))
+        assert.matches("Kong stopped", stdout, nil, true)
+        assert.equal("", stderr)
+      end)
     end)
   end)
 end)

--- a/spec/02-integration/05-proxy/04-plugins_triggering_spec.lua
+++ b/spec/02-integration/05-proxy/04-plugins_triggering_spec.lua
@@ -163,6 +163,7 @@ for _, strategy in helpers.each_strategy() do
       assert(helpers.start_kong({
         database   = strategy,
         nginx_conf = "spec/fixtures/custom_nginx.template",
+        service_mesh = "on",
       }))
 
       proxy_client = helpers.proxy_client()
@@ -1486,6 +1487,7 @@ for _, strategy in helpers.each_strategy() do
             prefix       = "servroot1",
             database     = strategy,
             nginx_conf = "spec/fixtures/custom_nginx.template",
+            service_mesh = "on",
           })
 
           assert(helpers.start_kong {
@@ -1493,6 +1495,7 @@ for _, strategy in helpers.each_strategy() do
             database     = strategy,
             proxy_listen = "0.0.0.0:18000, 0.0.0.0:18443 ssl",
             admin_listen = "off",
+            service_mesh = "on",
           })
 
           proxy_client = helpers.proxy_client()
@@ -2170,6 +2173,7 @@ for _, strategy in helpers.each_strategy() do
                             "0.0.0.0:18007,0.0.0.0:18447,0.0.0.0:18008,0.0.0.0:18448",
             proxy_listen  = "off",
             admin_listen  = "off",
+            service_mesh  = "on",
           })
 
           assert(helpers.start_kong {
@@ -2178,6 +2182,7 @@ for _, strategy in helpers.each_strategy() do
             stream_listen = "0.0.0.0:19444,0.0.0.0:19445,0.0.0.0:19448",
             proxy_listen  = "off",
             admin_listen  = "off",
+            service_mesh  = "on",
           })
         end)
 

--- a/spec/02-integration/05-proxy/20-serviceless_proxying_spec.lua
+++ b/spec/02-integration/05-proxy/20-serviceless_proxying_spec.lua
@@ -335,7 +335,8 @@ for _, strategy in helpers.each_strategy() do
           origins       = "tcp://127.0.0.1:19000=" ..
                           "tcp://" .. STREAM_UPSTREAM_HOST ..  ":" .. STREAM_UPSTREAM_PORT .. "," ..
                           "tls://127.0.0.1:19443=" ..
-                          "tls://" .. STREAM_UPSTREAM_HOST ..  ":" .. STREAM_UPSTREAM_SSL_PORT
+                          "tls://" .. STREAM_UPSTREAM_HOST ..  ":" .. STREAM_UPSTREAM_SSL_PORT,
+          service_mesh  = "on",
         }))
       end)
 

--- a/spec/02-integration/05-proxy/22-reports_spec.lua
+++ b/spec/02-integration/05-proxy/22-reports_spec.lua
@@ -188,6 +188,7 @@ for _, strategy in helpers.each_strategy() do
         stream_listen = helpers.get_proxy_ip(false) .. ":19000," ..
                         helpers.get_proxy_ip(false) .. ":19001," ..
                         helpers.get_proxy_ip(true)  .. ":19443",
+        service_mesh = "on",
 
       }))
 

--- a/t/01-pdk/05-client/08-get_protocol.t
+++ b/t/01-pdk/05-client/08-get_protocol.t
@@ -267,6 +267,10 @@ qq{
         listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock proxy_protocol;
 
         content_by_lua_block {
+            kong = {
+              configuration = {},
+            }
+
             ngx.ctx.route = {
               protocols = { "tcp", "tls" }
             }


### PR DESCRIPTION
warning when attempting to enable it

Service Mesh causes upstream HTTPS request to ignore `proxy_ssl_*`
directives due to its replacement of the Nginx `SSL_CTX` data
structure (#5112, #4955). This PR disables Service Mesh by default and
adds a test to confirm normal upstream TLS behavior. Enabling it
requires additional configuration `service_mesh = on` or environment
variable `KONG_SERVICE_MESH=on` and will cause a deprecation warning on
startup.

Service Mesh (alongside patches to OpenResty) will be completely removed
in the next major release.

Fixes #5112.
Fixes #4955.