### PR TITLE
chore(deps) update penlight from 1.5.4 to 1.7.0

### DIFF
--- a/kong-1.3.0-0.rockspec
+++ b/kong-1.3.0-0.rockspec
@@ -14,7 +14,7 @@ dependencies = {
   "inspect == 3.1.1",
   "luasec == 0.8",
   "luasocket == 3.0-rc1",
-  "penlight == 1.5.4",
+  "penlight == 1.7.0",
   "lua-resty-http == 0.15",
   "lua-resty-jit-uuid == 0.0.7",
   "multipart == 0.5.5",

--- a/spec/01-unit/01-db/02-db-errors_spec.lua
+++ b/spec/01-unit/01-db/02-db-errors_spec.lua
@@ -52,7 +52,7 @@ describe("DB Errors", function()
           code = Errors.codes.INVALID_PRIMARY_KEY,
           name = "invalid primary key",
           strategy = "some_strategy",
-          message = [[invalid primary key: '{id2="missing2",id="missing"}']],
+          message = [[invalid primary key: '{id="missing",id2="missing2"}']],
           fields = pk,
         }, err_t)
       end)
@@ -77,7 +77,7 @@ describe("DB Errors", function()
           code = Errors.codes.INVALID_FOREIGN_KEY,
           name = "invalid foreign key",
           strategy = "some_strategy",
-          message = [[invalid foreign key: '{id2="missing2",id="missing"}']],
+          message = [[invalid foreign key: '{id="missing",id2="missing2"}']],
           fields = pk,
         }, err_t)
       end)

--- a/spec/02-integration/03-db/03-plugins_spec.lua
+++ b/spec/02-integration/03-db/03-plugins_spec.lua
@@ -76,9 +76,9 @@ for _, strategy in helpers.each_strategy() do
           assert.falsy(plugin)
           assert.match("UNIQUE violation", err)
           assert.same("unique constraint violation", err_t.name)
-          assert.same([[UNIQUE violation detected on '{service=null,]] ..
-                      [[name="key-auth",route={id="]] .. route.id ..
-                      [["},consumer=null}']], err_t.message)
+          assert.same([[UNIQUE violation detected on '{consumer=null,name="key-auth",]] ..
+                      [[route={id="]] .. route.id ..
+                      [["},service=null}']], err_t.message)
         end)
 
         it("does not validate when associated to an incompatible route, or a service with only incompatible routes", function()
@@ -149,9 +149,9 @@ for _, strategy in helpers.each_strategy() do
           assert.falsy(plugin)
           assert.match("UNIQUE violation", err)
           assert.same("unique constraint violation", err_t.name)
-          assert.same([[UNIQUE violation detected on '{service=null,]] ..
-                      [[name="key-auth",route={id="]] .. route.id ..
-                      [["},consumer=null}']], err_t.message)
+          assert.same([[UNIQUE violation detected on '{consumer=null,name="key-auth",]] ..
+                      [[route={id="]] .. route.id ..
+                      [["},service=null}']], err_t.message)
         end)
       end)
 

--- a/spec/02-integration/04-admin_api/03-consumers_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/03-consumers_routes_spec.lua
@@ -673,9 +673,8 @@ describe("Admin API (#" .. strategy .. "): ", function()
             assert.same({
               code = Errors.codes.UNIQUE_VIOLATION,
               name = "unique constraint violation",
-              message = [[UNIQUE violation detected on '{service=null,]] ..
-                        [[name="rewriter",route=null,consumer={id="]] ..
-                        consumer.id .. [["}}']],
+              message = [[UNIQUE violation detected on '{consumer={id="]] .. consumer.id ..
+                        [["},name="rewriter",route=null,service=null}']],
               fields = {
                 name = "rewriter",
                 consumer = {

--- a/spec/02-integration/04-admin_api/09-routes_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/09-routes_routes_spec.lua
@@ -1717,9 +1717,9 @@ for _, strategy in helpers.each_strategy() do
                     },
                     service = ngx.null,
                   },
-                  message = [[UNIQUE violation detected on '{]] ..
-                            [[service=null,name="basic-auth",route={id="]] ..
-                            route.id .. [["},consumer=null}']],
+                  message = [[UNIQUE violation detected on '{consumer=null,]] ..
+                            [[name="basic-auth",route={id="]] ..
+                            route.id .. [["},service=null}']],
                   name = "unique constraint violation",
                 }, json)
               end

--- a/spec/02-integration/04-admin_api/10-services_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/10-services_routes_spec.lua
@@ -523,9 +523,9 @@ for _, strategy in helpers.each_strategy() do
                       id = service.id,
                     }
                   },
-                  message = [[UNIQUE violation detected on '{]] ..
-                            [[service={id="]] .. service.id ..
-                            [["},name="basic-auth",route=null,consumer=null}']],
+                  message = [[UNIQUE violation detected on '{consumer=null,name="basic-auth",]] ..
+                            [[route=null,service={id="]] .. service.id ..
+                            [["}}']],
                 }, json)
               end
             end)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

#### 1.7.0 (2019-10-14)

##### New features

- utils.quote_arg will now optionally take an array of arguments and escape them all into a single string.
- app.parse_args now accepts a 3rd parameter with a list of valid flags and aliases
- app.script_name returns the name of the current script (previously a private function)

##### Changes

- Documentation updates
- utils.quit: exit message is no longer required, and closes the Lua state (on 5.2+).
- utils.assert_arg and utils.assert_string: now return the validated value
- pl.compat: now exports the jit and jit52 flags
- pretty.write: now sorts the output for easier diffs #293

##### Fixes

- utils.raise changed the global on_error-level when passing in bad arguments
- utils.writefile now checks and returns errors when writing
- compat.execute now handles the Windows exitcode -1 properly
- types.is_empty would return true on spaces always, indepedent of the parameter
- types.to_bool will now compare case-insensitive for the extra passed strings
- app.require_here will now properly handle an absolute base path
- stringx.split will no longer append an empty match if the number of requested elements has already been reached #295
- path.common_prefix and path.relpath return the result in the original casing (only impacted Windows) #297
- dir.copyfile, dir.movefile, and dir.makepath create the new file/path with the requested casing, and no longer force lowercase (only impacted Windows) #297
- added a missing assertion on path.getmtime #291
- stringx.rpartition returned bad results on a not-found #299

#### 1.6.0 (2018-11-23)

##### New features

- pl.compat now provides unpack as table.unpack on Lua 5.1

##### Changes

- utils.unpack is now documented and respects .n field of its argument.
- tablex.deepcopy and tablex.deepcompare are now cycle aware (#262)
- Installing through LuaRocks will now include the full rendered documentation

##### Fixes

- Fixed seq.last returning nil instead of an empty list when given an empty iterator (#253).
- pl.template now applies tostring when substituting values in templates, avoiding errors when they are not strings or numbers (#256).
- Fixed pl.import_into not importing some Penlight modules (#268).
- Fixed version number stuck at 1.5.2 (#260).
- Fixed types.is_empty returning true on tables containing false key (#267).
- Fixed test.assertraise throwing an error when passed an array with a function to call plus its arguments (#272).
- Fixed test.assertraise not throwing an error when given function does not error but instead returns a string matching given error pattern.
- Fixed placeholder expressions being evaluated with wrong precedence of binary and unary negation.
- Fixed placeholder expressions being evaluated assuming wrong binary operator associativity (e.g. _1-(_2+_3) was evaluated as (_1-_2)+_3.
- Fixed placeholder expressions being evaluated as if unary operators take precedence over power operator (e.g. (-_1)^_2) was evaluated as -(_1^2)).
- Fixed vulnerable backtracking pattern in pl.stringx.strip (#4847 
