### PR TITLE
feat(declarative) enable support for lua configuration (Kong#5021)

### DIFF
--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -104,7 +104,7 @@ function Config:parse_string(contents, filename, accept, old_hash)
     local chunk, pok
     chunk, err = loadstring(contents)
     if chunk then
-      setfenv(chunk, {_G.os = _G.os})
+      setfenv(chunk, { os = { getenv = os.getenv } })
       pok, dc_table = pcall(chunk)
       if not pok then
         err = dc_table

--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -86,7 +86,7 @@ function Config:parse_string(contents, filename, accept, old_hash)
   end
 
   -- do not accept Lua by default
-  accept = accept or { yaml = true, json = true }
+  accept = accept or { yaml = true, json = true, lua = true }
 
   local dc_table, err
   if accept.yaml and ((not filename) or filename:match("ya?ml$")) then
@@ -104,7 +104,7 @@ function Config:parse_string(contents, filename, accept, old_hash)
     local chunk, pok
     chunk, err = loadstring(contents)
     if chunk then
-      setfenv(chunk, {})
+      setfenv(chunk, {_G.os = _G.os})
       pok, dc_table = pcall(chunk)
       if not pok then
         err = dc_table


### PR DESCRIPTION
Enables `.lua` support for `kong config db_import`.
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

This enables the already present support for lua declarative configuration
 as per these [comments](https://github.com/Kong/kong/issues/5021#issuecomment-530715593).


### Full changelog

* Enables lua support in `accept`
* Passes `_G.os` instead of empty environment

### Issues resolved

Fix #5021
