### PR TITLE
hotfix(tests) initialize global `kong` for PDK based plugins

### DIFF
--- a/spec/01-unit/01-db/01-schema/07-plugins_spec.lua
+++ b/spec/01-unit/01-db/01-schema/07-plugins_spec.lua
@@ -1,3 +1,4 @@
+require "spec.helpers" -- initializes 'kong' global for plugins
 local Entity = require "kong.db.schema.entity"
 local typedefs = require "kong.db.schema.typedefs"
 local utils = require "kong.tools.utils"

--- a/spec/01-unit/12-plugins_order_spec.lua
+++ b/spec/01-unit/12-plugins_order_spec.lua
@@ -1,3 +1,4 @@
+require "spec.helpers" -- initializes 'kong' global for plugins
 local conf_loader = require "kong.conf_loader"
 
 

--- a/spec/01-unit/13-plugins_version_spec.lua
+++ b/spec/01-unit/13-plugins_version_spec.lua
@@ -1,3 +1,4 @@
+require "spec.helpers" -- initializes 'kong' global for plugins
 local conf_loader = require "kong.conf_loader"
 
 


### PR DESCRIPTION
Fix build error triggered by update of response-transformer plugin.