### PR TITLE
chore(ci) fix nightly arm builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,7 @@ functional-tests: setup-kong-build-tools
 nightly-release: setup-kong-build-tools
 	sed -i -e '/return string\.format/,/\"\")/c\return "$(KONG_VERSION)\"' kong/meta.lua && \
 	cd $(KONG_BUILD_TOOLS_LOCATION); \
-	$(MAKE) setup-build && \
-	$(MAKE) build-kong && \
+	$(MAKE) package-kong && \
 	$(MAKE) release-kong
 
 release: setup-kong-build-tools


### PR DESCRIPTION
`.travis.yml` calls `setup-ci` which in turn calls `setup-build`. Calling `setup-build` twice when using EC2 arm build workers more often then not leads to the worker not being available when we try and build the arm asset

Chaning `build-kong` to `package-kong` is just to align the `nightly-release` make task with the `release` make task they are identical tasks in kong-build-tools repository

One can see the result of this by searching for `make setup-build` on https://travis-ci.org/Kong/kong/jobs/599203538