### PR TITLE
Updated the .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,12 @@
 .buildpath
 .project
 .idea
+thumbs.db
+.vscode
+ehthumbs.db
+._*
+.Trashes
+$RECYCLE.BIN/
 
 servroot*
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Added the following to `.gitignore`

```
thumbs.db
.vscode
ehthumbs.db
._*
.Trashes
$RECYCLE.BIN/
```

Now windows users without a global gitignore will not be able to Push these files.