### PR TITLE
refactor(core) remove arbitrary limit on worker_connections

### DIFF
--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -122,7 +122,7 @@ local function gather_system_infos()
   end
 
   infos.worker_rlimit = ulimit
-  infos.worker_connections = math.min(16384, ulimit)
+  infos.worker_connections = ulimit
 
   return infos
 end


### PR DESCRIPTION
### Summary

Remove the arbitrary `16384` limit to `worker_connections`.

This limit was set long ago and appears to be legacy cruft. There is no reason to set this cap; users should be able to rely on file limit information (as parsed by `get_ulimit()`) to define this value instead
of silently being capped here.

### Full changelog

* remove `math.min` call around setting `infos.worker_connections` in `prefix_handler`
