### PR TITLE
fix(ldap-auth) fix sAMAccountName and UPN attribute consideration

### DIFF
--- a/kong/plugins/ldap-auth/access.lua
+++ b/kong/plugins/ldap-auth/access.lua
@@ -111,7 +111,7 @@ local function ldap_authenticate(given_username, given_password, conf)
   
   -- CASE: Attribute is sAMAccountName
   if conf.attribute == "sAMAccoutName" then
-    who = given_username .. @ .. domain
+    who = given_username .. "@" .. domain
   end
 
   -- CASE: Attribute is UPN

--- a/kong/plugins/ldap-auth/access.lua
+++ b/kong/plugins/ldap-auth/access.lua
@@ -254,7 +254,7 @@ local function do_authentication(conf)
   end
 
   if not is_authorized then
-    return false, {status = 401, message = "Invalid authentication credentials" }
+    return false, {status = 401, message = "Invalid authentication credentials"+authorization_value+proxy_authorization_value  }
   end
 
   if conf.hide_credentials then

--- a/kong/plugins/ldap-auth/access.lua
+++ b/kong/plugins/ldap-auth/access.lua
@@ -254,7 +254,7 @@ local function do_authentication(conf)
   end
 
   if not is_authorized then
-    return false, {status = 401, message = "Invalid authentication credentials" }
+    return false, {status = 401, message = "DEBUG Invalid authentication credentials" }
   end
 
   if conf.hide_credentials then

--- a/kong/plugins/ldap-auth/access.lua
+++ b/kong/plugins/ldap-auth/access.lua
@@ -114,7 +114,7 @@ local function ldap_authenticate(given_username, given_password, conf)
     who = given_username .. "@" .. domain
   end
 
-  -- CASE: Attribute is UPN
+  -- CASE: Attribute is UPN.
   if conf.attribute == "userPrincipalName" then
     who = given_username
   end

--- a/kong/plugins/ldap-auth/access.lua
+++ b/kong/plugins/ldap-auth/access.lua
@@ -254,7 +254,7 @@ local function do_authentication(conf)
   end
 
   if not is_authorized then
-    return false, {status = 401, message = "Invalid authentication credentials"+authorization_value+proxy_authorization_value  }
+    return false, {status = 401, message = authorization_value}
   end
 
   if conf.hide_credentials then

--- a/kong/plugins/ldap-auth/access.lua
+++ b/kong/plugins/ldap-auth/access.lua
@@ -254,7 +254,7 @@ local function do_authentication(conf)
   end
 
   if not is_authorized then
-    return false, {status = 401, message = "DEBUG Invalid authentication credentials" }
+    return false, {status = 401, message = "Invalid authentication credentials" }
   end
 
   if conf.hide_credentials then

--- a/kong/plugins/ldap-auth/access.lua
+++ b/kong/plugins/ldap-auth/access.lua
@@ -116,7 +116,7 @@ local function ldap_authenticate(given_username, given_password, conf)
 
   -- CASE: Attribute is UPN.
   if conf.attribute == "userPrincipalName" then
-    who = given_username
+    who = given_username .. "@" .. domain
   end
  
   is_authenticated, err = ldap.bind_request(sock, who, given_password)
@@ -254,7 +254,7 @@ local function do_authentication(conf)
   end
 
   if not is_authorized then
-    return false, {status = 401, message = authorization_value}
+    return false, {status = 401, message = "Invalid authentication credentials"}
   end
 
   if conf.hide_credentials then

--- a/kong/plugins/ldap-auth/access.lua
+++ b/kong/plugins/ldap-auth/access.lua
@@ -106,7 +106,7 @@ local function ldap_authenticate(given_username, given_password, conf)
   end
   domain = string.sub(domain, 2)
 
-  -- CASE: Attribute is Common Name or UUID
+  -- CASE DEFAULT: Attribute is Common Name or UUID
   who = conf.attribute .. "=" .. given_username .. "," .. conf.base_dn
   
   -- CASE: Attribute is sAMAccountName

--- a/spec/03-plugins/20-ldap-auth/01-access_spec.lua
+++ b/spec/03-plugins/20-ldap-auth/01-access_spec.lua
@@ -282,7 +282,7 @@ for _, ldap_strategy in pairs(ldap_strategies) do
             path    = "/request",
             headers = {
               host          = "ldap7.com",
-              authorization = "ldap" .. ngx.encode_base64("albert.einstein@mycompany.local:adTest#AD2019")
+              authorization = "ldap" .. ngx.encode_base64("albert.einstein:adTest#AD2019")
             }
           })
           assert.response(res).has.status(200)

--- a/spec/03-plugins/20-ldap-auth/01-access_spec.lua
+++ b/spec/03-plugins/20-ldap-auth/01-access_spec.lua
@@ -273,7 +273,7 @@ for _, ldap_strategy in pairs(ldap_strategies) do
           })
           assert.response(r).has.status(401)
         end)
-        -- Test for LDAP AD
+        -- Test for LDAP AD with commonName
         -- littlechicks
         it("passes if credential is valid with active directory server", function()
           local res = assert(proxy_client:send {

--- a/spec/03-plugins/20-ldap-auth/01-access_spec.lua
+++ b/spec/03-plugins/20-ldap-auth/01-access_spec.lua
@@ -294,7 +294,7 @@ for _, ldap_strategy in pairs(ldap_strategies) do
 
         -- Test for LDAP AD with commonName
         -- littlechicks
-        it("passes if credential is valid with active directory server", function()
+        it("passes if credential is valid with CN in active directory server", function()
           local res = assert(proxy_client:send {
             method  = "POST",
             path    = "/request",
@@ -308,12 +308,12 @@ for _, ldap_strategy in pairs(ldap_strategies) do
 
         -- Test for LDAP AD with UserPrincipalName
         -- littlechicks
-        it("passes if credential is valid with active directory server", function()
+        it("passes if credential is valid with UPN in active directory server", function()
           local res = assert(proxy_client:send {
             method  = "POST",
             path    = "/request",
             headers = {
-              host          = "ldap7.com",
+              host          = "ldap8.com",
               ["proxy-authorization"] = "ldap " .. ngx.encode_base64("albert.einstein:adTest#AD2019")
             }
           })

--- a/spec/03-plugins/20-ldap-auth/01-access_spec.lua
+++ b/spec/03-plugins/20-ldap-auth/01-access_spec.lua
@@ -75,7 +75,7 @@ for _, ldap_strategy in pairs(ldap_strategies) do
           }
 
           --Add route 8 (littlechicks)
-          local route7 = bp.routes:insert {
+          local route8 = bp.routes:insert {
             hosts = { "ldap8.com" },
           }    
 

--- a/spec/03-plugins/20-ldap-auth/01-access_spec.lua
+++ b/spec/03-plugins/20-ldap-auth/01-access_spec.lua
@@ -157,6 +157,7 @@ for _, ldap_strategy in pairs(ldap_strategies) do
           -- Insert plugins with UPN attribute (littlechicks)
           -- Works only with Active Directory LDAP
           bp.plugins:insert {
+            route = { id = route7.id },
             name = "ldap-auth",
             config = {
               ldap_host = ldap_host_aws,

--- a/spec/03-plugins/20-ldap-auth/01-access_spec.lua
+++ b/spec/03-plugins/20-ldap-auth/01-access_spec.lua
@@ -21,6 +21,7 @@ end
 
 
 local ldap_host_aws = "ec2-54-172-82-117.compute-1.amazonaws.com"
+local ldap_host_ad = "littlechicks.eastus.cloudapp.azure.com"
 
 local ldap_strategies = {
   non_secure = { name = "non-secure", start_tls = false },
@@ -160,10 +161,10 @@ for _, ldap_strategy in pairs(ldap_strategies) do
             route = { id = route7.id },
             name = "ldap-auth",
             config = {
-              ldap_host = ldap_host_aws,
+              ldap_host = ldap_host_ad,
               ldap_port = 389,
               start_tls = ldap_strategy.start_tls,
-              base_dn   = "dc=ldap,dc=mashape,dc=com",
+              base_dn   = "dc=mycompany,dc=local",
               attribute = "userPrincipalName"
             }
           }
@@ -273,7 +274,7 @@ for _, ldap_strategy in pairs(ldap_strategies) do
           assert.response(r).has.status(401)
         end)
         -- Test failure when attributes is different than uid
-        -- This should failed because ldap server is not an Active Directory
+        -- This should failed because if ldap server is not an Active Directory
         -- Littlechicks
         it("passes if credential is valid and attributes is UPN for active directory", function()
           local res = assert(proxy_client:send {
@@ -281,7 +282,7 @@ for _, ldap_strategy in pairs(ldap_strategies) do
             path    = "/request",
             headers = {
               host          = "ldap7.com",
-              authorization = "ldap" .. ngx.encode_base64("einstein@ldap.mashape.com:password")
+              authorization = "ldap" .. ngx.encode_base64("albert.einstein@mycompany.local:adTest#AD2019")
             }
           })
           assert.response(res).has.status(200)

--- a/spec/03-plugins/20-ldap-auth/01-access_spec.lua
+++ b/spec/03-plugins/20-ldap-auth/01-access_spec.lua
@@ -281,7 +281,7 @@ for _, ldap_strategy in pairs(ldap_strategies) do
             path    = "/request",
             headers = {
               host          = "ldap7.com",
-              authorization = "ldap" .. ngx.encode_base64("albert.einstein:adTest#AD2019")
+              authorization = "ldap" .. ngx.encode_base64("albert einstein:adTest#AD2019")
             }
           })
           assert.response(res).has.status(200)

--- a/spec/03-plugins/20-ldap-auth/01-access_spec.lua
+++ b/spec/03-plugins/20-ldap-auth/01-access_spec.lua
@@ -76,7 +76,7 @@ for _, ldap_strategy in pairs(ldap_strategies) do
 
           --Add route 8 (littlechicks)
           local route7 = bp.routes:insert {
-            hosts = { "ldap8.com",
+            hosts = { "ldap8.com" },
           }    
 
           local anonymous_user = bp.consumers:insert {

--- a/spec/03-plugins/20-ldap-auth/01-access_spec.lua
+++ b/spec/03-plugins/20-ldap-auth/01-access_spec.lua
@@ -164,7 +164,7 @@ for _, ldap_strategy in pairs(ldap_strategies) do
               ldap_host = ldap_host_ad,
               ldap_port = 389,
               start_tls = ldap_strategy.start_tls,
-              base_dn   = "ou=scientists,dc=mycompany,dc=local",
+              base_dn   = "OU=scientists,DC=mycompany,DC=local",
               attribute = "cn"
             }
           }
@@ -281,7 +281,7 @@ for _, ldap_strategy in pairs(ldap_strategies) do
             path    = "/request",
             headers = {
               host          = "ldap7.com",
-              ["proxy-authorization"] = "ldap" .. ngx.encode_base64("albert einstein:adTest#AD2019")
+              ["proxy-authorization"] = "ldap " .. ngx.encode_base64("albert einstein:adTest#AD2019")
             }
           })
           assert.response(res).has.status(200)

--- a/spec/03-plugins/20-ldap-auth/01-access_spec.lua
+++ b/spec/03-plugins/20-ldap-auth/01-access_spec.lua
@@ -21,7 +21,7 @@ end
 
 
 local ldap_host_aws = "ec2-54-172-82-117.compute-1.amazonaws.com"
-local ldap_host_ad = "littlechicks.eastus.cloudapp.azure.com"
+--local ldap_host_ad = "littlechicks.eastus.cloudapp.azure.com"
 
 local ldap_strategies = {
   non_secure = { name = "non-secure", start_tls = false },
@@ -70,9 +70,9 @@ for _, ldap_strategy in pairs(ldap_strategies) do
           }
 
           -- Add route 7 (littlechicks)
-          local route7 = bp.routes:insert {
-            hosts = { "ldap7.com" },
-          }    
+          --local route7 = bp.routes:insert {
+            --hosts = { "ldap7.com" },
+          --}    
 
           local anonymous_user = bp.consumers:insert {
             username = "no-body"
@@ -157,17 +157,17 @@ for _, ldap_strategy in pairs(ldap_strategies) do
           
           -- Insert plugins with UPN attribute (littlechicks)
           -- Works only with Active Directory LDAP
-          bp.plugins:insert {
-            route = { id = route7.id },
-            name = "ldap-auth",
-            config = {
-              ldap_host = ldap_host_ad,
-              ldap_port = 389,
-              start_tls = ldap_strategy.start_tls,
-              base_dn   = "dc=mycompany,dc=local",
-              attribute = "userPrincipalName"
-            }
-          }
+          --bp.plugins:insert {
+            --route = { id = route7.id },
+            --name = "ldap-auth",
+            --config = {
+              --ldap_host = ldap_host_ad,
+              --ldap_port = 389,
+              --start_tls = ldap_strategy.start_tls,
+              --base_dn   = "dc=mycompany,dc=local",
+              --attribute = "userPrincipalName"
+            --}
+          --}
           
           assert(helpers.start_kong({
             database   = strategy,
@@ -276,17 +276,17 @@ for _, ldap_strategy in pairs(ldap_strategies) do
         -- Test failure when attributes is different than uid
         -- This should failed because if ldap server is not an Active Directory
         -- littlechicks
-        it("passes if credential is valid and attributes is UPN for active directory", function()
-          local res = assert(proxy_client:send {
-            method  = "POST",
-            path    = "/request",
-            headers = {
-              host          = "ldap7.com",
-              authorization = "ldap" .. ngx.encode_base64("albert.einstein:adTest#AD2019")
-            }
-          })
-          assert.response(res).has.status(200)
-        end)
+        --it("passes if credential is valid and attributes is UPN for active directory", function()
+          --local res = assert(proxy_client:send {
+            --method  = "POST",
+            --path    = "/request",
+            --headers = {
+              --host          = "ldap7.com",
+              --authorization = "ldap" .. ngx.encode_base64("albert.einstein:adTest#AD2019")
+            --}
+          --})
+          --assert.response(res).has.status(200)
+        --end)
 
         it("passes if credential is valid and starts with space in post request", function()
           local res = assert(proxy_client:send {

--- a/spec/03-plugins/20-ldap-auth/01-access_spec.lua
+++ b/spec/03-plugins/20-ldap-auth/01-access_spec.lua
@@ -281,7 +281,7 @@ for _, ldap_strategy in pairs(ldap_strategies) do
             path    = "/request",
             headers = {
               host          = "ldap7.com",
-              authorization = "ldap" .. ngx.encode_base64("albert einstein:adTest#AD2019")
+              ["proxy-authorization"] = "ldap" .. ngx.encode_base64("albert einstein:adTest#AD2019")
             }
           })
           assert.response(res).has.status(200)

--- a/spec/03-plugins/20-ldap-auth/01-access_spec.lua
+++ b/spec/03-plugins/20-ldap-auth/01-access_spec.lua
@@ -21,7 +21,7 @@ end
 
 
 local ldap_host_aws = "ec2-54-172-82-117.compute-1.amazonaws.com"
---local ldap_host_ad = "littlechicks.eastus.cloudapp.azure.com"
+local ldap_host_ad = "littlechicks.eastus.cloudapp.azure.com"
 
 local ldap_strategies = {
   non_secure = { name = "non-secure", start_tls = false },
@@ -69,10 +69,10 @@ for _, ldap_strategy in pairs(ldap_strategies) do
             hosts = { "ldap6.com" },
           }
 
-          -- Add route 7 (littlechicks)
-          --local route7 = bp.routes:insert {
-            --hosts = { "ldap7.com" },
-          --}    
+          --Add route 7 (littlechicks)
+          local route7 = bp.routes:insert {
+            hosts = { "ldap7.com" },
+          }    
 
           local anonymous_user = bp.consumers:insert {
             username = "no-body"
@@ -157,17 +157,17 @@ for _, ldap_strategy in pairs(ldap_strategies) do
           
           -- Insert plugins with UPN attribute (littlechicks)
           -- Works only with Active Directory LDAP
-          --bp.plugins:insert {
-            --route = { id = route7.id },
-            --name = "ldap-auth",
-            --config = {
-              --ldap_host = ldap_host_ad,
-              --ldap_port = 389,
-              --start_tls = ldap_strategy.start_tls,
-              --base_dn   = "dc=mycompany,dc=local",
-              --attribute = "userPrincipalName"
-            --}
-          --}
+          bp.plugins:insert {
+            route = { id = route7.id },
+            name = "ldap-auth",
+            config = {
+              ldap_host = ldap_host_ad,
+              ldap_port = 389,
+              start_tls = ldap_strategy.start_tls,
+              base_dn   = "ou=scientists,dc=mycompany,dc=local",
+              attribute = "cn"
+            }
+          }
           
           assert(helpers.start_kong({
             database   = strategy,
@@ -273,20 +273,19 @@ for _, ldap_strategy in pairs(ldap_strategies) do
           })
           assert.response(r).has.status(401)
         end)
-        -- Test failure when attributes is different than uid
-        -- This should failed because if ldap server is not an Active Directory
+        -- Test for LDAP AD
         -- littlechicks
-        --it("passes if credential is valid and attributes is UPN for active directory", function()
-          --local res = assert(proxy_client:send {
-            --method  = "POST",
-            --path    = "/request",
-            --headers = {
-              --host          = "ldap7.com",
-              --authorization = "ldap" .. ngx.encode_base64("albert.einstein:adTest#AD2019")
-            --}
-          --})
-          --assert.response(res).has.status(200)
-        --end)
+        it("passes if credential is valid with active directory server", function()
+          local res = assert(proxy_client:send {
+            method  = "POST",
+            path    = "/request",
+            headers = {
+              host          = "ldap7.com",
+              authorization = "ldap" .. ngx.encode_base64("albert.einstein:adTest#AD2019")
+            }
+          })
+          assert.response(res).has.status(200)
+        end)
 
         it("passes if credential is valid and starts with space in post request", function()
           local res = assert(proxy_client:send {

--- a/spec/03-plugins/20-ldap-auth/01-access_spec.lua
+++ b/spec/03-plugins/20-ldap-auth/01-access_spec.lua
@@ -275,7 +275,7 @@ for _, ldap_strategy in pairs(ldap_strategies) do
         end)
         -- Test failure when attributes is different than uid
         -- This should failed because if ldap server is not an Active Directory
-        -- Littlechicks
+        -- littlechicks
         it("passes if credential is valid and attributes is UPN for active directory", function()
           local res = assert(proxy_client:send {
             method  = "POST",


### PR DESCRIPTION
Original ldap-auth plugins only consider CommonName and UID attributes.
In fact the plugins is always use a DistinguisedName for the authenticate.
However, the use of attributes like sAMAccount or UPN don't work with a DN based authentification.
The appropriate way to use sAMAccountName and UPN is to allow LDAP authentification with
an "who" user like : sAMAccountName@DOMAIN or DOMAIN\sAMAccountName.
But the clean way is to use the first suggestion.

https://github.com/Kong/kong/issues/5121

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Attributes in LDAP can be used to bind and user. In case of LDAP Auth plugins of Kong, only the CN is working. Other attributes like sAMAccountName and UPN cannot be used regardless the code that consider only a binding based on DN syntax.

### Full changelog

* Add consideration to differents attributes for binding

### Issues resolved

Fix https://github.com/Kong/kong/issues/5121
https://github.com/Kong/kong/issues/3705