### PR TITLE
chore(ci) bump kong-build-tools dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ RESTY_VERSION ?= `grep RESTY_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk
 RESTY_LUAROCKS_VERSION ?= `grep RESTY_LUAROCKS_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
 RESTY_OPENSSL_VERSION ?= `grep RESTY_OPENSSL_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
 RESTY_PCRE_VERSION ?= `grep RESTY_PCRE_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
-KONG_BUILD_TOOLS ?= '2.0.3'
+KONG_BUILD_TOOLS ?= '2.0.4'
 KONG_VERSION ?= `cat $(KONG_SOURCE_LOCATION)/kong-*.rockspec | grep tag | awk '{print $$3}' | sed 's/"//g'`
 OPENRESTY_PATCHES_BRANCH ?= master
 KONG_NGINX_MODULE_BRANCH ?= master
@@ -54,12 +54,9 @@ functional-tests: setup-kong-build-tools
 	$(MAKE) build-kong && \
 	$(MAKE) test
 
-nightly-release: setup-kong-build-tools
-	sed -i -e '/return string\.format/,/\"\")/c\return "$(KONG_VERSION)\"' kong/meta.lua && \
-	cd $(KONG_BUILD_TOOLS_LOCATION); \
-	$(MAKE) setup-build && \
-	$(MAKE) build-kong && \
-	$(MAKE) release-kong
+nightly-release:
+	sed -i -e '/return string\.format/,/\"\")/c\return "$(KONG_VERSION)\"' kong/meta.lua
+	$(MAKE) release
 
 release: setup-kong-build-tools
 	cd $(KONG_BUILD_TOOLS_LOCATION); \


### PR DESCRIPTION
Full diff: https://github.com/Kong/kong-build-tools/compare/2.0.3...2.0.4

Notable changes:
- use centos packages for redhat
- capable of buildling centos/redhat 8
- cache the images

Also updated the Kong make task. Recycling the `release` task as part of `nightly-release` keeps the two tasks sync'd and we'll catch `release` challenges earlier