### PR TITLE
feat (datadog) plugin report metrics with tags

### DIFF
--- a/kong/plugins/datadog/schema.lua
+++ b/kong/plugins/datadog/schema.lua
@@ -4,12 +4,8 @@ local STAT_NAMES = {
   "kong_latency",
   "latency",
   "request_count",
-  "request_per_user",
   "request_size",
   "response_size",
-  "status_count",
-  "status_count_per_user",
-  "unique_users",
   "upstream_latency",
 }
 
@@ -33,59 +29,39 @@ local DEFAULT_METRICS = {
     name        = "request_count",
     stat_type   = "counter",
     sample_rate = 1,
-    tags        = {"app:kong"}
+    tags        = {"app:kong" },
+    consumer_identifier = "custom_id"
   },
   {
     name      = "latency",
     stat_type = "timer",
-    tags      = {"app:kong"}
+    tags      = {"app:kong"},
+    consumer_identifier = "custom_id"
   },
   {
     name      = "request_size",
     stat_type = "timer",
-    tags      = {"app:kong"}
-  },
-  {
-    name        = "status_count",
-    stat_type   = "counter",
-    sample_rate = 1,
-    tags        = {"app:kong"}
+    tags      = {"app:kong"},
+    consumer_identifier = "custom_id"
   },
   {
     name      = "response_size",
     stat_type = "timer",
-    tags      = {"app:kong"}
-  },
-  {
-    name                = "unique_users",
-    stat_type           = "set",
-    consumer_identifier = "custom_id",
-    tags                = {"app:kong"}
-  },
-  {
-    name                = "request_per_user",
-    stat_type           = "counter",
-    sample_rate         = 1,
-    consumer_identifier = "custom_id",
-    tags                = {"app:kong"}
+    tags      = {"app:kong"},
+    consumer_identifier = "custom_id"
   },
   {
     name      = "upstream_latency",
     stat_type = "timer",
-    tags      = {"app:kong"}
+    tags      = {"app:kong"},
+    consumer_identifier = "custom_id"
   },
   {
     name      = "kong_latency",
     stat_type = "timer",
-    tags      = {"app:kong"}
+    tags      = {"app:kong"},
+    consumer_identifier = "custom_id"
   },
-  {
-    name                = "status_count_per_user",
-    stat_type           = "counter",
-    sample_rate         = 1,
-    consumer_identifier = "custom_id",
-    tags                = {"app:kong"}
-  }
 }
 
 
@@ -115,29 +91,10 @@ return {
                 },
                 entity_checks = {
                   { conditional = {
-                    if_field = "name", if_match = { eq = "unique_users" },
-                    then_field = "stat_type", then_match = { eq = "set" },
-                  }, },
-
-                  { conditional = {
                     if_field = "stat_type",
                     if_match = { one_of = { "counter", "gauge" }, },
                     then_field = "sample_rate",
                     then_match = { required = true },
-                  }, },
-
-                  { conditional = {
-                    if_field = "name",
-                    if_match = { one_of = { "status_count_per_user", "request_per_user", "unique_users" }, },
-                    then_field = "consumer_identifier",
-                    then_match = { required = true },
-                  }, },
-
-                  { conditional = {
-                    if_field = "name",
-                    if_match = { one_of = { "status_count", "status_count_per_user", "request_per_user" }, },
-                    then_field = "stat_type",
-                    then_match = { eq = "counter" },
                   }, },
   }, }, }, }, }, }, }, },
 }

--- a/spec/03-plugins/08-datadog/01-log_spec.lua
+++ b/spec/03-plugins/08-datadog/01-log_spec.lua
@@ -67,11 +67,6 @@ for _, strategy in helpers.each_strategy() do
           port    = 9999,
           metrics = {
             {
-              name        = "status_count",
-              stat_type   = "counter",
-              sample_rate = 1,
-            },
-            {
               name        = "request_count",
               stat_type   = "counter",
               sample_rate = 1,
@@ -87,12 +82,6 @@ for _, strategy in helpers.each_strategy() do
           host    = "127.0.0.1",
           port    = 9999,
           metrics = {
-            {
-              name        = "status_count",
-              stat_type   = "counter",
-              sample_rate = 1,
-              tags        = {"T1:V1"},
-            },
             {
               name        = "request_count",
               stat_type   = "counter",
@@ -140,7 +129,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     it("logs metrics over UDP", function()
-      local thread = helpers.udp_server(9999, 12)
+      local thread = helpers.udp_server(9999, 6)
 
       local res = assert(proxy_client:send {
         method  = "GET",
@@ -153,25 +142,17 @@ for _, strategy in helpers.each_strategy() do
 
       local ok, gauges = thread:join()
       assert.True(ok)
-      assert.equal(12, #gauges)
-      assert.contains("kong.dd1.request.count:1|c|#app:kong", gauges)
-      assert.contains("kong.dd1.latency:%d+|ms|#app:kong", gauges, true)
-      assert.contains("kong.dd1.request.size:%d+|ms|#app:kong", gauges, true)
-      assert.contains("kong.dd1.request.status.200:1|c|#app:kong", gauges)
-      assert.contains("kong.dd1.request.status.total:1|c|#app:kong", gauges)
-      assert.contains("kong.dd1.response.size:%d+|ms|#app:kong", gauges, true)
-      assert.contains("kong.dd1.upstream_latency:%d+|ms|#app:kong", gauges, true)
-      assert.contains("kong.dd1.kong_latency:%d*|ms|#app:kong", gauges, true)
-      assert.contains("kong.dd1.user.uniques:.*|s|#app:kong", gauges, true)
-      assert.contains("kong.dd1.user.*.request.count:1|c|#app:kong", gauges, true)
-      assert.contains("kong.dd1.user.*.request.status.total:1|c|#app:kong",
-                      gauges, true)
-      assert.contains("kong.dd1.user.*.request.status.200:1|c|#app:kong",
-                      gauges, true)
+      assert.equal(6, #gauges)
+      assert.contains("kong.request.count:1|c|#name:dd1,status:200,consumer:bar,app:kong" , gauges)
+      assert.contains("kong.latency:%d+|ms|#name:dd1,status:200,consumer:bar,app:kong", gauges, true)
+      assert.contains("kong.request.size:%d+|ms|#name:dd1,status:200,consumer:bar,app:kong", gauges, true)
+      assert.contains("kong.response.size:%d+|ms|#name:dd1,status:200,consumer:bar,app:kong", gauges, true)
+      assert.contains("kong.upstream_latency:%d+|ms|#name:dd1,status:200,consumer:bar,app:kong", gauges, true)
+      assert.contains("kong.kong_latency:%d*|ms|#name:dd1,status:200,consumer:bar,app:kong", gauges, true)
     end)
 
     it("logs metrics over UDP with custom prefix", function()
-      local thread = helpers.udp_server(9999, 12)
+      local thread = helpers.udp_server(9999, 6)
 
       local res = assert(proxy_client:send {
         method  = "GET",
@@ -184,26 +165,17 @@ for _, strategy in helpers.each_strategy() do
 
       local ok, gauges = thread:join()
       assert.True(ok)
-      assert.equal(12, #gauges)
-      assert.contains("prefix.dd4.request.count:1|c|#app:kong",gauges)
-      assert.contains("prefix.dd4.latency:%d+|ms|#app:kong", gauges, true)
-      assert.contains("prefix.dd4.request.size:%d+|ms|#app:kong", gauges, true)
-      assert.contains("prefix.dd4.request.status.200:1|c|#app:kong", gauges)
-      assert.contains("prefix.dd4.request.status.total:1|c|#app:kong", gauges)
-      assert.contains("prefix.dd4.response.size:%d+|ms|#app:kong", gauges, true)
-      assert.contains("prefix.dd4.upstream_latency:%d+|ms|#app:kong", gauges, true)
-      assert.contains("prefix.dd4.kong_latency:%d*|ms|#app:kong", gauges, true)
-      assert.contains("prefix.dd4.user.uniques:.*|s|#app:kong", gauges, true)
-      assert.contains("prefix.dd4.user.*.request.count:1|c|#app:kong",
-                      gauges, true)
-      assert.contains("prefix.dd4.user.*.request.status.total:1|c|#app:kong",
-                      gauges, true)
-      assert.contains("prefix.dd4.user.*.request.status.200:1|c|#app:kong",
-                      gauges, true)
+      assert.equal(6, #gauges)
+      assert.contains("prefix.request.count:1|c|#name:dd4,status:200,consumer:bar,app:kong",gauges)
+      assert.contains("prefix.latency:%d+|ms|#name:dd4,status:200,consumer:bar,app:kong", gauges, true)
+      assert.contains("prefix.request.size:%d+|ms|#name:dd4,status:200,consumer:bar,app:kong", gauges, true)
+      assert.contains("prefix.response.size:%d+|ms|#name:dd4,status:200,consumer:bar,app:kong", gauges, true)
+      assert.contains("prefix.upstream_latency:%d+|ms|#name:dd4,status:200,consumer:bar,app:kong", gauges, true)
+      assert.contains("prefix.kong_latency:%d*|ms|#name:dd4,status:200,consumer:bar,app:kong", gauges, true)
     end)
 
     it("logs only given metrics", function()
-      local thread = helpers.udp_server(9999, 3)
+      local thread = helpers.udp_server(9999, 1)
 
       local res = assert(proxy_client:send {
         method  = "GET",
@@ -216,14 +188,13 @@ for _, strategy in helpers.each_strategy() do
 
       local ok, gauges = thread:join()
       assert.True(ok)
-      assert.equal(3, #gauges)
-      assert.contains("kong.dd2.request.count:1|c", gauges)
-      assert.contains("kong.dd2.request.status.200:1|c", gauges)
-      assert.contains("kong.dd2.request.status.total:1|c", gauges)
+      gauges = { gauges } -- as thread:join() returns a string in case of 1
+      assert.equal(1, #gauges)
+      assert.contains("kong.request.count:1|c|#name:dd2,status:200", gauges)
     end)
 
     it("logs metrics with tags", function()
-      local thread = helpers.udp_server(9999, 4)
+      local thread = helpers.udp_server(9999, 2)
 
       local res = assert(proxy_client:send {
         method  = "GET",
@@ -236,10 +207,8 @@ for _, strategy in helpers.each_strategy() do
 
       local ok, gauges = thread:join()
       assert.True(ok)
-      assert.contains("kong.dd3.request.count:1|c|#T2:V2,T3:V3,T4", gauges)
-      assert.contains("kong.dd3.request.status.200:1|c|#T1:V1", gauges)
-      assert.contains("kong.dd3.request.status.total:1|c|#T1:V1", gauges)
-      assert.contains("kong.dd3.latency:%d+|g|#T2:V2:V3,T4", gauges, true)
+      assert.contains("kong.request.count:1|c|#name:dd3,status:200,T2:V2,T3:V3,T4", gauges)
+      assert.contains("kong.latency:%d+|g|#name:dd3,status:200,T2:V2:V3,T4", gauges, true)
     end)
 
     it("should not return a runtime error (regression)", function()

--- a/spec/03-plugins/08-datadog/02-schema_spec.lua
+++ b/spec/03-plugins/08-datadog/02-schema_spec.lua
@@ -43,7 +43,7 @@ describe("Plugin: datadog (schema)", function()
       }
     }
     _, err = v({ metrics = metrics_input }, schema_def)
-    assert.same({ { name = "field required for entity check" } }, err.config.metrics)
+    assert.same({ { name = "required field missing" } }, err.config.metrics)
   end)
   it("rejects counters without sample rate", function()
     local metrics_input = {
@@ -76,42 +76,10 @@ describe("Plugin: datadog (schema)", function()
     local _, err = v({ metrics = metrics_input }, schema_def)
     assert.match("expected one of: counter", err.config.metrics[1].stat_type)
   end)
-  it("rejects if customer identifier missing", function()
-    local metrics_input = {
-      {
-        name = "status_count_per_user",
-        stat_type = "counter",
-        sample_rate = 1
-      }
-    }
-    local _, err = v({ metrics = metrics_input }, schema_def)
-    assert.equals("required field missing", err.config.metrics[1].consumer_identifier)
-  end)
-  it("rejects if metric has wrong stat type", function()
-    local metrics_input = {
-      {
-        name = "unique_users",
-        stat_type = "counter"
-      }
-    }
-    local _, err = v({ metrics = metrics_input }, schema_def)
-    assert.not_nil(err)
-    assert.equals("required field missing", err.config.metrics[1].sample_rate)
-    metrics_input = {
-      {
-        name = "status_count",
-        stat_type = "set",
-        sample_rate = 1
-      }
-    }
-    _, err = v({ metrics = metrics_input }, schema_def)
-    assert.not_nil(err)
-    assert.equal("value must be counter", err.config.metrics[1].stat_type)
-  end)
   it("rejects if tags malformed", function()
     local metrics_input = {
       {
-        name = "status_count",
+        name = "request_count",
         stat_type = "counter",
         sample_rate = 1,
         tags = {"T1:"}
@@ -120,10 +88,10 @@ describe("Plugin: datadog (schema)", function()
     local _, err = v({ metrics = metrics_input }, schema_def)
     assert.same({ { tags = { "invalid value: T1:" } } }, err.config.metrics)
   end)
-  it("accept if tags is aempty list", function()
+  it("accept if tags is an empty list", function()
     local metrics_input = {
       {
-        name = "status_count",
+        name = "request_count",
         stat_type = "counter",
         sample_rate = 1,
         tags = {}


### PR DESCRIPTION
### Summary
The plugin will now report metrics with `name`, `status` and `consumer` tags for:

- upstream_latency
- kong_latency
- latency
- request_count
- request_size
- response_size

The tags `name` and `status` will have the value of the service name and http status code respectively.  The tag `consumer` is only added if the `consumer_identifier` is specified.

As a result, only 6 metrics are reported to datadog:

- kong.upstream_latency
- kong.kong_latency
- kong.latency
- kong.request.count
- kong.request.size
- kong.response.size

These tags make the following metrics redundant and are no longer reported:

-  status_count
-  status_count_per_user
-  unique_users
-  request_per_user

If you have datadog dashboards and alerts based on the old-style metrics, you need to change them to use the new tag based metrics.

For instance the following query:
```
	avg:kong.sample_service.latency.avg{*}
```
would need to change to:
```
	avg:kong.latency.avg{name:sample_service}`
```
for efficiency purposes, we suggest to use only configure the latency metric, if required with the consumer identification configured. It will carry all the information: response times, status code, consumer and volume.


### Full changelog

* changed metric to include tags for service name, http status and consumer
* removed metric status_count, status_count_per_user, unique_users, request_per_user
* changed unit tests

### Issues resolved

Fix #5147 
