### PR TITLE
feat(api) expose arbitrary plugin data from a schema-meta.lua

### DIFF
--- a/autodoc/data/admin-api.lua
+++ b/autodoc/data/admin-api.lua
@@ -16,6 +16,7 @@ return {
       "kong/api/routes/health.lua",
       "kong/api/routes/config.lua",
       "kong/api/routes/tags.lua",
+      "kong/api/routes/metadata.lua",
     },
     nodoc_files = {
       "kong/api/routes/cache.lua", -- FIXME should we document this?
@@ -387,6 +388,33 @@ return {
             }
             ```
           ]]
+        },
+      },
+    },
+    metadata = {
+      title = [[ Metadata ]],
+      description = [[ Developer-supplied data. ]],
+      ["/metadata/plugins/:name"] = {
+        GET = {
+          title = [[ A plugin's metadata. ]],
+          endpoint = [[<div class="endpoint get">/metadata/plugins/:name</div>]],
+          description = [[
+            Returns a JSON representation of the value returned by the `metadata.lua` module
+            in the named plugin directory.
+          ]],
+          response = [[
+            ```
+            HTTP 200 OK
+            ```
+
+            ```json
+            {
+              "name": "sample plugin",
+              "description": "Just a sample of what can be.",
+              "icon": "http://example.com/plugin-icon.png"
+            }
+            ```
+          ]],
         },
       },
     },
@@ -819,23 +847,6 @@ return {
                 ]
             }
             ```
-          ]]
-        }
-      },
-      ["/plugins/:name/metadata"] = {
-        GET = {
-          title = [[Retrieve plugin's custom metadata]],
-          description = [[Retrieve a JSON representation of Lua data in a `schema-meta.lua` module]],
-          endpoint = [[<div class="endpoint get">/plugins/meta/{plugin name}</div>]],
-          response = [[
-            ```
-            HTTP 200 OK
-            ```
-            ```json
-            {
-              "description": "This is what the plugin developer intends",
-              "icon": <url of a nice pic>
-            }
           ]]
         }
       },

--- a/autodoc/data/admin-api.lua
+++ b/autodoc/data/admin-api.lua
@@ -822,7 +822,7 @@ return {
           ]]
         }
       },
-      ["/plugins/meta/:name"] = {
+      ["/plugins/:name/metadata"] = {
         GET = {
           title = [[Retrieve plugin's custom metadata]],
           description = [[Retrieve a JSON representation of Lua data in a `schema-meta.lua` module]],

--- a/autodoc/data/admin-api.lua
+++ b/autodoc/data/admin-api.lua
@@ -822,6 +822,23 @@ return {
           ]]
         }
       },
+      ["/plugins/meta/:name"] = {
+        GET = {
+          title = [[Retrieve plugin's custom metadata]],
+          description = [[Retrieve a JSON representation of Lua data in a `schema-meta.lua` module]],
+          endpoint = [[<div class="endpoint get">/plugins/meta/{plugin name}</div>]],
+          response = [[
+            ```
+            HTTP 200 OK
+            ```
+            ```json
+            {
+              "description": "This is what the plugin developer intends",
+              "icon": <url of a nice pic>
+            }
+          ]]
+        }
+      },
 
       -- While these endpoints actually support DELETE (deleting the entity and
       -- cascade-deleting the plugin), we do not document them, as this operation

--- a/kong-1.4.0-0.rockspec
+++ b/kong-1.4.0-0.rockspec
@@ -117,6 +117,7 @@ build = {
     ["kong.api.routes.certificates"] = "kong/api/routes/certificates.lua",
     ["kong.api.routes.snis"] = "kong/api/routes/snis.lua",
     ["kong.api.routes.tags"] = "kong/api/routes/tags.lua",
+    ["kong.api.routes.metadata"] = "kong/api/routes/metadata.lua",
 
     ["kong.status"] = "kong/status/init.lua",
 

--- a/kong/api/init.lua
+++ b/kong/api/init.lua
@@ -24,7 +24,7 @@ ngx.log(ngx.DEBUG, "Loading Admin API endpoints")
 
 
 -- Load core routes
-for _, v in ipairs({"kong", "health", "cache", "config"}) do
+for _, v in ipairs({"kong", "health", "cache", "config", "metadata"}) do
   local routes = require("kong.api.routes." .. v)
   api_helpers.attach_routes(app, routes)
 end

--- a/kong/api/routes/metadata.lua
+++ b/kong/api/routes/metadata.lua
@@ -1,0 +1,25 @@
+local cjson = require "cjson"
+local utils = require "kong.tools.utils"
+
+local kong = kong
+local ngx = ngx
+
+return {
+  ["/metadata/plugins/:name"] = {
+    GET = function(self, db, helpers, parent)
+      ngx.log(ngx.DEBUG, "self.params: ", cjson.encode(self.params))
+      local name = self.params.name
+      if not name then
+        return kong.response.exit(400, { message = "Bad query" })
+      end
+
+      -- TODO: either unload module or use loadfile() instead
+      local ok, meta = utils.load_module_if_exists("kong.plugins." .. name .. ".metadata")
+      if not ok or not meta then
+        return kong.response.exit(404, { message = "Not found" })
+      end
+
+      return kong.response.exit(200, meta)
+    end,
+  },
+}

--- a/kong/api/routes/plugins.lua
+++ b/kong/api/routes/plugins.lua
@@ -196,7 +196,7 @@ return {
     end
   },
 
-  ["/plugins/meta/:name"] = {
+  ["/plugins/:name/metadata"] = {
     GET = function(self, db, helpers, parent)
       ngx.log(ngx.DEBUG, "self.params: ", cjson.encode(self.params))
       local name = self.params.name
@@ -205,7 +205,7 @@ return {
       end
 
       -- TODO: either unload module or use loadfile() instead
-      local ok, meta = utils.load_module_if_exists("kong.plugins." .. name .. ".schema-meta")
+      local ok, meta = utils.load_module_if_exists("kong.plugins." .. name .. ".metadata")
       if not ok or not meta then
         return kong.response.exit(404, { message = "Not found" })
       end

--- a/kong/api/routes/plugins.lua
+++ b/kong/api/routes/plugins.lua
@@ -196,24 +196,6 @@ return {
     end
   },
 
-  ["/plugins/:name/metadata"] = {
-    GET = function(self, db, helpers, parent)
-      ngx.log(ngx.DEBUG, "self.params: ", cjson.encode(self.params))
-      local name = self.params.name
-      if not name then
-        return kong.response.exit(400, { message = "Bad query" })
-      end
-
-      -- TODO: either unload module or use loadfile() instead
-      local ok, meta = utils.load_module_if_exists("kong.plugins." .. name .. ".metadata")
-      if not ok or not meta then
-        return kong.response.exit(404, { message = "Not found" })
-      end
-
-      return kong.response.exit(200, meta)
-    end,
-  },
-
   -- Available for backward compatibility
   ["/consumers/:consumers/plugins/:plugins"] = {
     before = before_plugin_for_entity("consumers", "consumer"),

--- a/kong/api/routes/plugins.lua
+++ b/kong/api/routes/plugins.lua
@@ -196,6 +196,24 @@ return {
     end
   },
 
+  ["/plugins/meta/:name"] = {
+    GET = function(self, db, helpers, parent)
+      ngx.log(ngx.DEBUG, "self.params: ", cjson.encode(self.params))
+      local name = self.params.name
+      if not name then
+        return kong.response.exit(400, { message = "Bad query" })
+      end
+
+      -- TODO: either unload module or use loadfile() instead
+      local ok, meta = utils.load_module_if_exists("kong.plugins." .. name .. ".schema-meta")
+      if not ok or not meta then
+        return kong.response.exit(404, { message = "Not found" })
+      end
+
+      return kong.response.exit(200, meta)
+    end,
+  },
+
   -- Available for backward compatibility
   ["/consumers/:consumers/plugins/:plugins"] = {
     before = before_plugin_for_entity("consumers", "consumer"),


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Adds a `/plugins/meta/:name` endpoint that returns a JSON representation of the value returned by a (optional) schema-meta.lua module in the plugin directory.

Any case of wrong plugin name, missing schema-meta or bad Lua syntax results in a 404 response.  If no name is given, returns a 400 response

### Issues resolved

PoC for Trello card: https://trello.com/c/ut8gMx93

