### PR TITLE
feat(migrations) add 'kong migrations migrate-apis' command

### DIFF
--- a/kong/cmd/migrations.lua
+++ b/kong/cmd/migrations.lua
@@ -25,6 +25,9 @@ The available commands are:
 
   reset                             Reset the database.
 
+  migrate-apis                      Migrates API entities to Routes and
+                                    Services.
+
 Options:
  -y,--yes                           Assume "yes" to prompts and run
                                     non-interactively.
@@ -33,6 +36,10 @@ Options:
 
  -f,--force                         Run migrations even if database reports
                                     as already executed.
+
+                                    With 'migrate-apis' command, it also forces
+                                    migration of APIs that have custom plugins
+                                    applied, and which are otherwise skipped.
 
  --db-timeout     (default 60)      Timeout, in seconds, for all database
                                     operations (including schema consensus for
@@ -211,6 +218,12 @@ local function execute(args)
       force = args.force,
     })
 
+  elseif args.command == "migrate-apis" then
+    migrations_utils.migrate_apis(schema_state, db, {
+      ttl = args.lock_timeout,
+      force = args.force,
+    })
+
   else
     error("unreachable")
   end
@@ -226,5 +239,6 @@ return {
     finish = true,
     list = true,
     reset = true,
+    ["migrate-apis"] = true,
   }
 }

--- a/kong/cmd/utils/migrations.lua
+++ b/kong/cmd/utils/migrations.lua
@@ -105,9 +105,10 @@ local function up(schema_state, db, opts)
       end
 
       if present then
-        error("Cannot run migrations: you have `api` entities in your database; " ..
-              "please convert them to `routes` and `services` prior to " ..
-              "migrating to Kong 1.0")
+        error("Cannot run migrations: you have `api` entities in your database.\n" ..
+              "Please convert them to `routes` and `services` prior to migrating " ..
+              "to Kong 1.0.\n\nRun 'kong migrations migrate-apis' to migrate "     ..
+              "automatically.")
       end
 
       -- legacy: migration from 0.14 to 1.0 can be performed
@@ -272,10 +273,77 @@ local function reset(schema_state, db, ttl)
 end
 
 
+local function migrate_apis(schema_state, db, opts)
+  if schema_state.needs_bootstrap then
+    if schema_state.legacy_invalid_state then
+      -- legacy: migration from 0.14 to 1.0 cannot be performed
+      if schema_state.legacy_missing_component then
+        error(fmt("Migration of APIs can only be performed from a 0.14 %s " ..
+                  "%s, but the current %s seems to be older (missing "      ..
+                   "migrations for '%s'). Migrate to 0.14 first.",
+                   db.strategy,  db.infos.db_desc, db.infos.db_desc,
+                   schema_state.legacy_missing_component, db.infos.db_desc))
+      end
+
+      if schema_state.legacy_missing_migration then
+        error(fmt("Migration of APIs can only be performed from a 0.14 %s " ..
+                  "%s, but the current %s seems to be older (missing "      ..
+                  "migration '%s' for '%s'). Migrate to 0.14 first.",
+                  db.strategy, db.infos.db_desc, db.infos.db_desc,
+                  schema_state.legacy_missing_migration,
+                  schema_state.legacy_missing_component, db.infos.db_desc))
+      end
+
+      error(fmt("Migration of APIs can only be performed from a 0.14 %s " ..
+                "%s, but the current %s seems to be older (missing "      ..
+                "migrations). Migrate to 0.14 first.",
+                db.strategy, db.infos.db_desc, db.infos.db_desc,
+                db.infos.db_desc), 2)
+    end
+  end
+
+  if not schema_state.legacy_is_014 then
+    error(fmt("APIs can only be migrated on Kong 0.14 %s %s, but the current " ..
+              "%s seems to be more recent.", db.strategy, db.infos.db_desc,
+              db.infos.db_desc))
+  end
+
+  local present, err = db:are_014_apis_present()
+  if err then
+    error(err, 2)
+  end
+
+  if not present then
+    log("No APIs found for migration")
+    return true
+  end
+
+  if schema_state.needs_bootstrap then
+    -- legacy: migration from 0.14 to 1.0 can be performed
+    log("Upgrading from 0.14, bootstrapping database...")
+    assert(db:schema_bootstrap())
+  end
+
+  local ok, err = db:cluster_mutex(MIGRATIONS_MUTEX_KEY, opts, function()
+    assert(db:run_api_migrations(opts))
+  end)
+  if err then
+    error(err)
+  end
+
+  if not ok then
+    log(NOT_LEADER_MSG)
+  end
+
+  return ok
+end
+
+
 return {
   up = up,
   reset = reset,
   finish = finish,
   bootstrap = bootstrap,
   check_state = check_state,
+  migrate_apis = migrate_apis,
 }

--- a/kong/db/init.lua
+++ b/kong/db/init.lua
@@ -631,6 +631,15 @@ do
     return true
   end
 
+  function DB:run_api_migrations(opts)
+    local ok, err = self.connector:connect_migrations()
+    if not ok then
+      return nil, prefix_err(self, err)
+    end
+
+    return self.connector:run_api_migrations(opts)
+  end
+
 
   --[[
   function DB:load_pending_migrations(migrations)

--- a/kong/db/strategies/cassandra/connector.lua
+++ b/kong/db/strategies/cassandra/connector.lua
@@ -956,6 +956,440 @@ do
   end
 
 
+  function CassandraConnector:run_api_migrations(opts)
+    local conn = self:get_stored_connection()
+    if not conn then
+      error("no connection")
+    end
+
+    local migrated, skipped, failed = 0, 0, 0
+
+    local results = {
+      migrated = {},
+      skipped  = {},
+      failed   = {},
+    }
+
+    local constants = require "kong.constants"
+    local null = ngx.null
+
+    local apis = { n = 0 }
+    for rows, err in self.cluster:iterate([[
+    SELECT id,
+           created_at,
+           name,
+           upstream_url,
+           preserve_host,
+           retries,
+           https_only,
+           http_if_terminated,
+           hosts,
+           uris,
+           methods,
+           strip_uri,
+           upstream_connect_timeout,
+           upstream_send_timeout,
+           upstream_read_timeout
+      FROM apis]]) do
+      if not rows then
+        return nil, err
+      end
+
+      for i = 1, #rows do
+        local api = rows[i]
+        if api.created_at and api.created_at ~= null then
+          api.created_at = math.floor(api.created_at / 1000)
+        end
+
+        apis.n = apis.n + 1
+        apis[apis.n] = api
+      end
+    end
+
+    if apis.n == 0 then
+      return results
+    end
+
+    table.sort(apis, function(api_a, api_b)
+      return api_a.created_at < api_b.created_at
+    end)
+
+    local plugins = {}
+    for rows, err in self.cluster:iterate([[
+    SELECT id,
+           name,
+           api_id
+      FROM plugins]]) do
+      if not rows then
+        return nil, err
+      end
+
+      for i = 1, #rows do
+        local plugin = rows[i]
+        local api_id = plugin.api_id
+        if api_id ~= nil and
+           api_id ~= null then
+          if not plugins[api_id] then
+            plugins[api_id] = { n = 0 }
+          end
+
+          plugins[api_id].n = plugins[api_id].n + 1
+          plugins[api_id][plugins[api_id].n] = plugin
+        end
+      end
+    end
+
+    local cjson = require "cjson.safe"
+    local utils = require "kong.tools.utils"
+    local url   = require "socket.url"
+
+    local migrations = { n = apis.n }
+    for i = 1, apis.n do
+      local api = apis[i]
+
+      local created_at
+      local updated_at
+      if api.created_at ~= nil and
+         api.created_at ~= null then
+        created_at = math.floor(api.created_at)
+        updated_at = created_at
+      else
+        created_at = ngx.time()
+        updated_at = created_at
+      end
+
+      local protocol
+      local host
+      local port
+      local path
+      if api.upstream_url ~= nil and
+         api.upstream_url ~= null then
+        local parsed_url = url.parse(api.upstream_url)
+
+        if parsed_url.scheme then
+          protocol = parsed_url.scheme
+        end
+
+        if parsed_url.host then
+          host = parsed_url.host
+        end
+
+        if parsed_url.port then
+          port = tonumber(parsed_url.port, 10)
+        end
+
+        if not port and protocol then
+          if protocol == "http" then
+            port = 80
+          elseif protocol == "https" then
+            port = 443
+          end
+        end
+
+        if parsed_url.path then
+          path = parsed_url.path
+        end
+      end
+
+      local name
+      if api.name ~= nil and
+         api.name ~= null then
+        name = api.name
+      end
+
+      local retries
+      local connect_timeout
+      local write_timeout
+      local read_timeout
+
+      if api.retries ~= nil and
+         api.retries ~= null then
+        retries = tonumber(api.retries, 10)
+      end
+
+      if api.upstream_connect_timeout ~= nil and
+         api.upstream_connect_timeout ~= null then
+        connect_timeout = tonumber(api.upstream_connect_timeout, 10)
+      end
+
+      if api.upstream_send_timeout ~= nil and
+         api.upstream_send_timeout ~= null then
+        write_timeout = tonumber(api.upstream_send_timeout, 10)
+      end
+
+      if api.upstream_read_timeout ~= nil and
+         api.upstream_read_timeout ~= null then
+        read_timeout = tonumber(api.upstream_read_timeout, 10)
+      end
+
+      local service_id = utils.uuid()
+      local service = {
+        id              = service_id,
+        name            = name,
+        created_at      = created_at,
+        updated_at      = updated_at,
+        retries         = retries,
+        protocol        = protocol,
+        host            = host,
+        port            = port,
+        path            = path,
+        connect_timeout = connect_timeout,
+        write_timeout   = write_timeout,
+        read_timeout    = read_timeout,
+      }
+
+      local route_id = utils.uuid()
+
+      local methods
+      if api.methods ~= nil and
+         api.methods ~= null then
+        methods = cjson.decode(api.methods)
+      end
+
+      local hosts
+      if api.hosts ~= nil and
+         api.hosts ~= null then
+        hosts = cjson.decode(api.hosts)
+      end
+
+      local paths
+      if api.uris ~= nil and
+         api.uris ~= null then
+        paths = cjson.decode(api.uris)
+      end
+
+      local regex_priority = 0
+
+      local strip_path
+      local preserve_host
+      local https_only
+
+      if api.strip_uri ~= nil and
+         api.strip_uri ~= null then
+        strip_path = not not api.strip_uri
+      end
+
+      if api.preserve_host ~= nil and
+         api.preserve_host ~= null then
+        preserve_host = not not api.preserve_host
+      end
+
+      if api.https_only ~= nil and
+         api.https_only ~= null then
+        https_only = not not api.https_only
+      end
+
+      local protocols = https_only and { "https" } or { "http", "https" }
+
+      local route = {
+        id             = route_id,
+        created_at     = created_at,
+        updated_at     = updated_at,
+        service_id     = service_id,
+        protocols      = protocols,
+        methods        = methods,
+        hosts          = hosts,
+        paths          = paths,
+        regex_priority = regex_priority,
+        strip_path     = strip_path,
+        preserve_host  = preserve_host,
+      }
+
+      migrations[i] = {
+        api     = api,
+        route   = route,
+        service = service,
+        plugins = plugins[api.id]
+      }
+    end
+
+    local escape = function(literal, type)
+      if literal == nil or literal == null then
+        return cassandra.null
+      end
+
+      if type == "string" then
+        return cassandra.text(literal)
+      end
+
+      if type == "boolean" then
+        return cassandra.boolean(literal)
+      end
+
+      if type == "integer" then
+        return cassandra.int(literal)
+      end
+
+      if type == "timestamp" then
+        return cassandra.timestamp(literal * 1000)
+      end
+
+      if type == "uuid" then
+        return cassandra.uuid(literal)
+      end
+
+      if type == "array" then
+        local t = {}
+
+        for i = 1, #literal do
+          if literal[i] == nil or literal[i] == null then
+            t[i] = cassandra.null
+          else
+            t[i] = cassandra.text(literal[i])
+          end
+        end
+
+        return cassandra.list(t)
+      end
+
+      return self:escape_literal(literal)
+    end
+
+    local force
+    if opts then
+      force = not not opts.force
+    end
+
+    for i = 1, migrations.n do
+      local migration = migrations[i]
+      local service   = migration.service
+      local route     = migration.route
+      local api       = migration.api
+      local api_name  = api.name or api.id
+
+      local custom_plugins_count = 0
+      local custom_plugins = {}
+
+      local queries = 3
+
+      local cql = { { [[
+  INSERT INTO services (partition, id, created_at, updated_at, name, retries, protocol, host, port, path, connect_timeout, write_timeout, read_timeout)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)]], {
+            escape("services", "string"),
+            escape(service.id, "uuid"),
+            escape(service.created_at, "timestamp"),
+            escape(service.updated_at, "timestamp"),
+            escape(service.name, "string"),
+            escape(service.retries, "integer"),
+            escape(service.protocol, "string"),
+            escape(service.host, "string"),
+            escape(service.port, "integer"),
+            escape(service.path, "string"),
+            escape(service.connect_timeout, "integer"),
+            escape(service.write_timeout, "integer"),
+            escape(service.read_timeout, "integer"),
+          },
+        }, { [[
+  INSERT INTO routes (partition, id, created_at, updated_at, service_id, protocols, methods, hosts, paths, regex_priority, strip_path, preserve_host)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)]], {
+            escape("routes", "string"),
+            escape(route.id, "uuid"),
+            escape(route.created_at, "timestamp"),
+            escape(route.updated_at, "timestamp"),
+            escape(route.service_id, "uuid"),
+            escape(route.protocols, "array"),
+            escape(route.methods, "array"),
+            escape(route.hosts, "array"),
+            escape(route.paths, "array"),
+            escape(route.regex_priority, "integer"),
+            escape(route.strip_path, "boolean"),
+            escape(route.preserve_host, "boolean"),
+          },
+        },
+      }
+
+      if migration.plugins then
+        queries = queries + migration.plugins.n
+        for j = 1, migration.plugins.n do
+          local plugin = migration.plugins[j]
+          if not constants.BUNDLED_PLUGINS[plugin.name] then
+            custom_plugins_count = custom_plugins_count + 1
+            custom_plugins[custom_plugins_count] = true
+          end
+
+          -- just future proofing
+          if plugin.name ~= nil and
+             plugin.name ~= null then
+            cql[j + 2] = { [[
+       UPDATE plugins
+          SET route_id = ?, api_id = ?
+        WHERE id   = ?
+          AND name = ?]], {
+                escape(route.id, "uuid"),
+                escape(nil),
+                escape(plugin.id, "uuid"),
+                escape(plugin.name, "string"),
+              },
+            }
+          else
+            cql[j + 2] = { [[
+       UPDATE plugins
+          SET route_id = ?, api_id = ?
+        WHERE id = ?]], {
+                escape(route.id, "uuid"),
+                escape(nil),
+                escape(plugin.id, "uuid"),
+              },
+            }
+          end
+        end
+      end
+
+      cql[queries] = { [[
+  DELETE FROM apis
+        WHERE id = ?]], {
+          escape(api.id, "uuid")
+        },
+      }
+
+      log("migrating api '%s' ...", api_name)
+      --log.debug(cql)
+
+      if not force and custom_plugins_count > 0 then
+        log("migrating api '%s' skipped (use -f to migrate apis with " ..
+            "custom plugins", api_name)
+        skipped = skipped + 1
+        results.skipped[skipped] = {
+          api = api,
+          custom_plugins = custom_plugins,
+        }
+
+      else
+        local res, err = self:batch(cql, nil, "write", true)
+        if not res then
+          log("migrating api '%s' failed (%s)", api_name, err)
+          failed = failed + 1
+          results.failed[failed] = {
+            api = api,
+            err = err,
+          }
+
+        else
+          log("migrating api '%s' done", api_name)
+          migrated = migrated + 1
+          results.migrated[migrated] = {
+            api = api,
+          }
+        end
+      end
+    end
+
+    if migrated > 0 then
+      log("%d/%d migrations succeeded", migrated, migrations.n)
+    end
+
+    if skipped > 0 then
+      log("%d/%d migrations skipped", skipped, migrations.n)
+    end
+
+    if failed > 0 then
+      log("%d/%d migrations failed", skipped, migrations.n)
+    end
+
+    return results
+  end
+
+
   function CassandraConnector:run_up_migration(name, up_cql)
     if type(name) ~= "string" then
       error("name must be a string", 2)

--- a/kong/db/strategies/connector.lua
+++ b/kong/db/strategies/connector.lua
@@ -151,6 +151,12 @@ function Connector:run_up_migration()
 end
 
 
+function Connector:run_api_migrations()
+  error(fmt("run_api_migrations() not implemented for '%s' strategy",
+            self.database))
+end
+
+
 function Connector:wait_for_schema_consensus()
   return true
 end

--- a/kong/db/strategies/postgres/connector.lua
+++ b/kong/db/strategies/postgres/connector.lua
@@ -778,6 +778,402 @@ function _mt:schema_reset()
 end
 
 
+function _mt:run_api_migrations(opts)
+  local conn = self:get_stored_connection()
+  if not conn then
+    error("no connection")
+  end
+
+  local migrated, skipped, failed = 0, 0, 0
+
+  local results = {
+    migrated = {},
+    skipped  = {},
+    failed   = {},
+  }
+
+  local apis = { n = 0 }
+  for api, err in self:iterate([[
+    SELECT id,
+           EXTRACT(EPOCH FROM created_at AT TIME ZONE 'UTC') AS created_at,
+           name,
+           upstream_url,
+           preserve_host,
+           retries,
+           https_only,
+           http_if_terminated,
+           hosts,
+           uris,
+           methods,
+           strip_uri,
+           upstream_connect_timeout,
+           upstream_send_timeout,
+           upstream_read_timeout
+      FROM apis;]]) do
+    if not api then
+      return nil, err
+    end
+
+    apis.n = apis.n + 1
+    apis[apis.n] = api
+  end
+
+  if apis.n == 0 then
+    return results
+  end
+
+  table.sort(apis, function(api_a, api_b)
+    return api_a.created_at < api_b.created_at
+  end)
+
+  local plugins = {}
+  for plugin, err in self:iterate([[
+    SELECT id,
+           name,
+           api_id
+      FROM plugins;]]) do
+    if not plugin then
+      return nil, err
+    end
+
+    local api_id = plugin.api_id
+    if api_id ~= nil and
+       api_id ~= null then
+      if not plugins[api_id] then
+        plugins[api_id] = { n = 0 }
+      end
+
+      plugins[api_id].n = plugins[api_id].n + 1
+      plugins[api_id][plugins[api_id].n] = plugin
+    end
+  end
+
+  local constants = require "kong.constants"
+  local cjson     = require "cjson.safe"
+  local utils     = require "kong.tools.utils"
+  local url       = require "socket.url"
+
+  local migrations = { n = apis.n }
+  for i = 1, apis.n do
+    local api = apis[i]
+
+    local created_at
+    local updated_at
+    if api.created_at ~= nil and
+       api.created_at ~= null then
+      created_at = floor(api.created_at)
+      updated_at = created_at
+    else
+      created_at = ngx.time()
+      updated_at = created_at
+    end
+
+    local protocol
+    local host
+    local port
+    local path
+    if api.upstream_url ~= nil and
+       api.upstream_url ~= null then
+      local parsed_url = url.parse(api.upstream_url)
+
+      if parsed_url.scheme then
+        protocol = parsed_url.scheme
+      end
+
+      if parsed_url.host then
+        host = parsed_url.host
+      end
+
+      if parsed_url.port then
+        port = tonumber(parsed_url.port, 10)
+      end
+
+      if not port and protocol then
+        if protocol == "http" then
+          port = 80
+        elseif protocol == "https" then
+          port = 443
+        end
+      end
+
+      if parsed_url.path then
+        path = parsed_url.path
+      end
+    end
+
+    local name
+    if api.name ~= nil and
+       api.name ~= null then
+      name = api.name
+    end
+
+    local retries
+    local connect_timeout
+    local write_timeout
+    local read_timeout
+
+    if api.retries ~= nil and
+       api.retries ~= null then
+      retries = tonumber(api.retries, 10)
+    end
+
+    if api.upstream_connect_timeout ~= nil and
+       api.upstream_connect_timeout ~= null then
+      connect_timeout = tonumber(api.upstream_connect_timeout, 10)
+    end
+
+    if api.upstream_send_timeout ~= nil and
+       api.upstream_send_timeout ~= null then
+      write_timeout = tonumber(api.upstream_send_timeout, 10)
+    end
+
+    if api.upstream_read_timeout ~= nil and
+       api.upstream_read_timeout ~= null then
+      read_timeout = tonumber(api.upstream_read_timeout, 10)
+    end
+
+    local service_id = utils.uuid()
+    local service = {
+      id              = service_id,
+      name            = name,
+      created_at      = created_at,
+      updated_at      = updated_at,
+      retries         = retries,
+      protocol        = protocol,
+      host            = host,
+      port            = port,
+      path            = path,
+      connect_timeout = connect_timeout,
+      write_timeout   = write_timeout,
+      read_timeout    = read_timeout,
+    }
+
+    local route_id = utils.uuid()
+
+    local methods
+    if api.methods ~= nil and
+       api.methods ~= null then
+      methods = cjson.decode(api.methods)
+    end
+
+    local hosts
+    if api.hosts ~= nil and
+       api.hosts ~= null then
+      hosts = cjson.decode(api.hosts)
+    end
+
+    local paths
+    if api.uris ~= nil and
+       api.uris ~= null then
+      paths = cjson.decode(api.uris)
+    end
+
+    local regex_priority = 0
+
+    local strip_path
+    local preserve_host
+    local https_only
+
+    if api.strip_uri ~= nil and
+       api.strip_uri ~= null then
+      strip_path = not not api.strip_uri
+    end
+
+    if api.preserve_host ~= nil and
+       api.preserve_host ~= null then
+      preserve_host = not not api.preserve_host
+    end
+
+    if api.https_only ~= nil and
+       api.https_only ~= null then
+      https_only = not not api.https_only
+    end
+
+    local protocols = https_only and { "https" } or { "http", "https" }
+
+    local route = {
+      id             = route_id,
+      created_at     = created_at,
+      updated_at     = updated_at,
+      service_id     = service_id,
+      protocols      = protocols,
+      methods        = methods,
+      hosts          = hosts,
+      paths          = paths,
+      regex_priority = regex_priority,
+      strip_path     = strip_path,
+      preserve_host  = preserve_host,
+    }
+
+    migrations[i] = {
+      api     = api,
+      route   = route,
+      service = service,
+      plugins = plugins[api.id]
+    }
+  end
+
+  local escape = function(literal, type)
+    if literal == nil or
+       literal == null then
+      return "NULL"
+    end
+
+    if type == "timestamp" then
+      return concat {
+        "TO_TIMESTAMP(", self:escape_literal(tonumber(fmt("%.3f", literal))),
+        ") AT TIME ZONE 'UTC'"
+      }
+    end
+
+    if type == "array" then
+      if not literal[1] then
+        return self:escape_literal("{}")
+      end
+
+      return encode_array(literal)
+    end
+
+    return self:escape_literal(literal)
+  end
+
+  local force
+  if opts then
+    force = not not opts.force
+  end
+
+  for i = 1, migrations.n do
+    local migration = migrations[i]
+    local service   = migration.service
+    local route     = migration.route
+    local api       = migration.api
+    local api_name  = api.name or api.id
+
+    local custom_plugins_count = 0
+    local custom_plugins = {}
+
+    local plugins_sql = {}
+    if migration.plugins then
+      for j = 1, migration.plugins.n do
+        local plugin = migration.plugins[j]
+        if not constants.BUNDLED_PLUGINS[plugin.name] then
+          custom_plugins_count = custom_plugins_count + 1
+          custom_plugins[custom_plugins_count] = true
+        end
+
+        if plugin.name ~= nil and
+          plugin.name ~= null then
+          plugins_sql[j] = fmt([[
+
+       UPDATE plugins
+          SET route_id = %s, api_id = %s
+        WHERE id   = %s
+          AND name = %s;
+]],
+          escape(route.id),
+          escape(nil),
+          escape(plugin.id),
+          escape(plugin.name))
+        else
+          plugins_sql[j] = fmt([[
+
+       UPDATE plugins
+          SET route_id = %s, api_id = %s
+        WHERE id   = %s;
+]],
+          escape(route.id),
+          escape(nil),
+          escape(plugin.id))
+        end
+      end
+    end
+
+    local sql = fmt([[
+BEGIN;
+  INSERT INTO services (id, created_at, updated_at, name, retries, protocol, host, port, path, connect_timeout, write_timeout, read_timeout)
+       VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
+
+  INSERT INTO routes (id, created_at, updated_at, service_id, protocols, methods, hosts, paths, regex_priority, strip_path, preserve_host)
+       VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
+%s
+  DELETE FROM apis
+        WHERE id = %s;
+COMMIT;]],
+      escape(service.id),
+      escape(service.created_at, "timestamp"),
+      escape(service.updated_at, "timestamp"),
+      escape(service.name),
+      escape(service.retries),
+      escape(service.protocol),
+      escape(service.host),
+      escape(service.port),
+      escape(service.path),
+      escape(service.connect_timeout),
+      escape(service.write_timeout),
+      escape(service.read_timeout),
+      escape(route.id),
+      escape(route.created_at, "timestamp"),
+      escape(route.updated_at, "timestamp"),
+      escape(route.service_id),
+      escape(route.protocols, "array"),
+      escape(route.methods, "array"),
+      escape(route.hosts, "array"),
+      escape(route.paths, "array"),
+      escape(route.regex_priority),
+      escape(route.strip_path),
+      escape(route.preserve_host),
+      concat(plugins_sql),
+      escape(api.id)
+    )
+
+    logger("migrating api '%s' ...", api_name)
+    logger.debug(sql)
+
+    if not force and custom_plugins_count > 0 then
+      logger("migrating api '%s' skipped (use -f to migrate apis with " ..
+             "custom plugins", api_name)
+      skipped = skipped + 1
+      results.skipped[skipped] = {
+        api = api,
+        custom_plugins = custom_plugins,
+      }
+
+    else
+      local res, err = self:query(sql)
+      if not res then
+        logger("migrating api '%s' failed (%s)", api_name, err)
+        failed = failed + 1
+        results.failed[failed] = {
+          api = api,
+          err = err,
+        }
+
+      else
+        logger("migrating api '%s' done", api_name)
+        migrated = migrated + 1
+        results.migrated[migrated] = {
+          api = api,
+        }
+      end
+    end
+  end
+
+  if migrated > 0 then
+    logger("%d/%d migrations succeeded", migrated, migrations.n)
+  end
+
+  if skipped > 0 then
+    logger("%d/%d migrations skipped", skipped, migrations.n)
+  end
+
+  if failed > 0 then
+    logger("%d/%d migrations failed", skipped, migrations.n)
+  end
+
+  return results
+end
+
+
 function _mt:run_up_migration(name, up_sql)
   if type(name) ~= "string" then
     error("name must be a string", 2)


### PR DESCRIPTION
### Summary

This was originally implemented as #4615, but we closed it. The decision was revisited after feedback from community, so here it goes again.

Add `kong migrations migrate-apis` command for automated `API`s to `Routes` and `Services` migration.

The command `kong migrations migrate-apis` will by default migrate apis with bundled plugins to routes and services, but it will skip migrating apis with custom plugin(s). To migrate apis with custom plugins you can add `-f` or `--force` option.  Verbose (debug) `--vv` will with Postgres also output each SQL transaction SQL statements when executing migration.

The requirement is a database of `0.14` for migration to work.

The migrations transaction (postgres) / batch (cassandra) structure is (here is postgres example, but Cassandra follows the same):

```sql
BEGIN;
  INSERT INTO services (id, created_at, updated_at, name, retries, protocol, host, port, path, connect_timeout, write_timeout, read_timeout)
       VALUES ('be288ba6-b90e-47a7-a93b-d6289c66c947', TO_TIMESTAMP(1557939665) AT TIME ZONE 'UTC', TO_TIMESTAMP(1557939665) AT TIME ZONE 'UTC', 'test3', 5, 'http', 'httpbin.org', 80, '/anything', 60000, 60000, 60000);

  INSERT INTO routes (id, created_at, updated_at, service_id, protocols, methods, hosts, paths, regex_priority, strip_path, preserve_host)
       VALUES ('28a19a6e-7f87-4171-8bb6-e602fd8b2168', TO_TIMESTAMP(1557939665) AT TIME ZONE 'UTC', TO_TIMESTAMP(1557939665) AT TIME ZONE 'UTC', 'be288ba6-b90e-47a7-a93b-d6289c66c947', ARRAY['http','https'], NULL, NULL, ARRAY['/test3'], 0, TRUE, FALSE);

       UPDATE plugins
          SET route_id = '28a19a6e-7f87-4171-8bb6-e602fd8b2168', api_id = NULL
        WHERE id   = '0dfdf824-f9b6-4c31-8106-5e84054c2789'
          AND name = 'key-auth';

       UPDATE plugins
          SET route_id = '28a19a6e-7f87-4171-8bb6-e602fd8b2168', api_id = NULL
        WHERE id   = 'f072332c-8c12-41ae-b80e-4b3a78b036a8'
          AND name = 'basic-auth';

  DELETE FROM apis
        WHERE id = '3ac9d9b8-3b68-4738-bfe7-3b1a740e6f79';
COMMIT;
```

Running the command looks like this:
```
$ kong migrations migrate-apis
Upgrading from 0.14, bootstrapping database...
migrating api 'test1' ...
migrating api 'test1' done
migrating api 'test2' ...
migrating api 'test2' done
migrating api 'test3' ...
migrating api 'test3' done
3/3 migrations succeeded
```