### PR TITLE
hotfix(api) return endpoints inside a property

### DIFF
--- a/kong/api/routes/kong.lua
+++ b/kong/api/routes/kong.lua
@@ -119,7 +119,7 @@ return {
         return a:gsub("/", "\x00") < b:gsub("/", "\x00")
       end)
 
-      return kong.response.exit(200, endpoints)
+      return kong.response.exit(200, { data = endpoints })
     end
   },
   ["/schemas/:name"] = {

--- a/spec/02-integration/04-admin_api/02-kong_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/02-kong_routes_spec.lua
@@ -123,7 +123,7 @@ describe("Admin API - Kong routes with strategy #" .. strategy, function()
       local json = cjson.decode(body)
 
       local function find(endpoint)
-        for _, ep in ipairs(json) do
+        for _, ep in ipairs(json.data) do
           if ep == endpoint then
             return true
           end


### PR DESCRIPTION
Every list endpoint in Kong returns back data inside a `data` property
in the JSON response.

This small change follows the (informal) API convention.
This also makes it easy to parse the response in typed languages where
one wants to provide an "Object" to decode the response into.