### PR TITLE
perf(reports) use lock-free lua-resty-counter in reports

### DIFF
--- a/kong-1.4.2-0.rockspec
+++ b/kong-1.4.2-0.rockspec
@@ -36,6 +36,7 @@ dependencies = {
   "lua-resty-healthcheck == 1.1.1",
   "lua-resty-cookie == 0.1.0",
   "lua-resty-mlcache == 2.4.0",
+  "lua-resty-counter == 0.1.0",
   -- external Kong plugins
   "kong-plugin-azure-functions ~> 0.4",
   "kong-plugin-kubernetes-sidecar-injector ~> 0.2",

--- a/kong-1.4.2-0.rockspec
+++ b/kong-1.4.2-0.rockspec
@@ -36,7 +36,7 @@ dependencies = {
   "lua-resty-healthcheck == 1.1.1",
   "lua-resty-cookie == 0.1.0",
   "lua-resty-mlcache == 2.4.0",
-  "lua-resty-counter == 0.1.0",
+  "lua-resty-counter == 0.2.0",
   -- external Kong plugins
   "kong-plugin-azure-functions ~> 0.4",
   "kong-plugin-kubernetes-sidecar-injector ~> 0.2",

--- a/kong/reports.lua
+++ b/kong/reports.lua
@@ -183,25 +183,7 @@ local function get_counter(key)
   return count or 0
 end
 
--- For counter resetting we use `incr` instead of `set` because we want to
--- preserve measurements which might get received while we send the
--- report from worker A:
---
---                   Flow of Time
---                       |||
---                       VVV
---
---         Worker A       |     Worker B
---                        |
---   get_counter -> 100   |
---                        |
---                        |  <log phase> incr_counter(1) -> 101
---                        |
---   reset_counter(-100)  |
---
--- Final counter value after reset: 1 (correct, the worker B increment was preserved)
--- `reset_counter` was set to 0 (with `kong_dict:set(key, 0)` we would lose the increment
--- done by Worker B.
+
 local function reset_counter(key, amount)
   local ok, err = report_counter:reset(key, amount)
   if not ok then

--- a/kong/reports.lua
+++ b/kong/reports.lua
@@ -166,7 +166,7 @@ local function create_timer(...)
   end
 end
 
--- interval interval is exposed for unit test
+-- @param interval exposed for unit test only
 local function create_counter(interval)
   local err
   -- create a counter instance which syncs to `kong` shdict every 10 minutes

--- a/kong/reports.lua
+++ b/kong/reports.lua
@@ -433,4 +433,6 @@ return {
   retrieve_redis_version = retrieve_redis_version,
   -- exposed for unit test
   _create_counter = create_counter,
+  -- exposed for integration test
+  _sync_counter = function() report_counter:sync() end,
 }

--- a/kong/reports.lua
+++ b/kong/reports.lua
@@ -450,5 +450,5 @@ return {
   send = send_report,
   retrieve_redis_version = retrieve_redis_version,
   -- exposed for unit test
-  create_counter = create_counter,
+  _create_counter = create_counter,
 }

--- a/spec/01-unit/11-reports_spec.lua
+++ b/spec/01-unit/11-reports_spec.lua
@@ -8,7 +8,6 @@ describe("reports", function()
   describe("send()", function()
     lazy_setup(function()
       reports.toggle(true)
-      reports.create_counter(1)
     end)
 
     lazy_teardown(function()
@@ -83,7 +82,7 @@ describe("reports", function()
       package.loaded["kong.reports"] = nil
       reports = require "kong.reports"
       reports.toggle(true)
-      reports.create_counter(1)
+      reports._create_counter()
     end)
 
     describe("sends 'database'", function()
@@ -310,7 +309,7 @@ describe("reports", function()
       package.loaded["kong.reports"] = nil
       reports = require "kong.reports"
       reports.toggle(true)
-      reports.create_counter(1)
+      reports._create_counter()
     end)
 
     it("does not query Redis if not enabled", function()

--- a/spec/01-unit/11-reports_spec.lua
+++ b/spec/01-unit/11-reports_spec.lua
@@ -8,6 +8,7 @@ describe("reports", function()
   describe("send()", function()
     lazy_setup(function()
       reports.toggle(true)
+      reports.create_counter(1)
     end)
 
     lazy_teardown(function()
@@ -82,6 +83,7 @@ describe("reports", function()
       package.loaded["kong.reports"] = nil
       reports = require "kong.reports"
       reports.toggle(true)
+      reports.create_counter(1)
     end)
 
     describe("sends 'database'", function()
@@ -308,6 +310,7 @@ describe("reports", function()
       package.loaded["kong.reports"] = nil
       reports = require "kong.reports"
       reports.toggle(true)
+      reports.create_counter(1)
     end)
 
     it("does not query Redis if not enabled", function()

--- a/spec/fixtures/custom_plugins/kong/plugins/reports-api/api.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/reports-api/api.lua
@@ -3,6 +3,7 @@ local reports = require "kong.reports"
 return {
   ["/reports/send-ping"] = {
     POST = function()
+      reports._sync_counter()
       reports.send_ping()
       kong.response.exit(200, { message = "ok" })
     end,

--- a/spec/fixtures/custom_plugins/kong/plugins/reports-api/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/reports-api/handler.lua
@@ -4,6 +4,7 @@ local ReportsApiHandler = {
 
 function ReportsApiHandler:preread()
   local reports = require "kong.reports"
+  reports._sync_counter()
   reports.send_ping()
   ngx.print("ok")
   ngx.exit(200)


### PR DESCRIPTION
### Summary

Previously counters in anonymous reports are implemented with shm
counters. Multiple shm operations happen with request, and each
requires shm level lock across all workers. The lock overhead is
especially noticable while running Kong with large amount of cores.

To improve performance, reports now uses [lua-resty-counter](https://github.com/kong/lua-resty-counter).
It replaces per request shm operation with cheaper worker level Lua
numbers and sync to shm timely.

### Full changelog

* use lock-free lua-resty-counter in reports

### Issues resolved
