### PR TITLE
fix(admin-api) change detection of foreign entity endpoints to explicit

### DIFF
--- a/spec/02-integration/04-admin_api/17-foreign-entity_spec.lua
+++ b/spec/02-integration/04-admin_api/17-foreign-entity_spec.lua
@@ -1,0 +1,256 @@
+local helpers = require "spec.helpers"
+local cjson = require "cjson"
+local utils = require "kong.tools.utils"
+local Errors = require "kong.db.errors"
+
+
+local function it_content_types(title, fn)
+  local test_form_encoded = fn("application/x-www-form-urlencoded")
+  local test_multipart = fn("multipart/form-data")
+  local test_json = fn("application/json")
+
+  it(title .. " with application/www-form-urlencoded", test_form_encoded)
+  it(title .. " with multipart/form-data", test_multipart)
+  it(title .. " with application/json", test_json)
+end
+
+
+for _, strategy in helpers.each_strategy() do
+  describe("Admin API #" .. strategy, function()
+    local client
+    local db
+
+    lazy_setup(function()
+      local env = {}
+      env.database = strategy
+      env.plugins = env.plugins or "foreign-entity"
+
+      local lua_path = [[ KONG_LUA_PATH_OVERRIDE="./spec/fixtures/migrations/?.lua;]] ..
+        [[./spec/fixtures/migrations/?/init.lua;]]..
+        [[./spec/fixtures/custom_plugins/?.lua;]]..
+        [[./spec/fixtures/custom_plugins/?/init.lua;" ]]
+
+      local cmdline = "migrations up -c " .. helpers.test_conf_path
+      local _, code, _, stderr = helpers.kong_exec(cmdline, env, true, lua_path)
+      assert.same(0, code)
+      assert.equal("", stderr)
+
+      local _
+      _, db = helpers.get_db_utils(strategy, {
+        "foreign_entities",
+        "foreign_references",
+      }, {
+        "foreign-entity",
+      })
+
+      assert(helpers.start_kong {
+        database = strategy,
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+        plugins = "foreign-entity",
+      })
+    end)
+
+    lazy_teardown(function()
+      helpers.stop_kong(nil, true)
+    end)
+
+    before_each(function()
+      client = assert(helpers.admin_client())
+    end)
+
+    after_each(function()
+      if client then
+        client:close()
+      end
+    end)
+
+    describe("/foreign-references/{foreign-reference}/same", function()
+      describe("GET", function()
+        it("retrieves by id", function()
+          local foreign_entity = assert(db.foreign_entities:insert({ name = "foreign-entity" }, { nulls = true }))
+          local foreign_reference = assert(db.foreign_references:insert({ name = "foreign-reference", same = foreign_entity }))
+
+          local res  = client:get("/foreign-references/" .. foreign_reference.id .. "/same")
+          local body = assert.res_status(200, res)
+
+          local json = cjson.decode(body)
+          assert.same(foreign_entity, json)
+
+          assert(db.foreign_references:delete({ id = foreign_reference.id }))
+          assert(db.foreign_entities:delete({ id = foreign_entity.id }))
+        end)
+
+        it("retrieves by name", function()
+          local foreign_entity = assert(db.foreign_entities:insert({ name = "foreign-entity" }, { nulls = true }))
+          local foreign_reference = assert(db.foreign_references:insert({ name = "foreign-reference", same = foreign_entity }))
+
+          local res  = client:get("/foreign-references/foreign-reference/same")
+          local body = assert.res_status(200, res)
+
+          local json = cjson.decode(body)
+          assert.same(foreign_entity, json)
+
+          assert(db.foreign_references:delete({ id = foreign_reference.id }))
+          assert(db.foreign_entities:delete({ id = foreign_entity.id }))
+        end)
+
+        it("returns 404 if not found", function()
+          local res = client:get("/foreign-references/" .. utils.uuid() .. "/same")
+          assert.res_status(404, res)
+        end)
+
+        it("returns 404 if not found by name", function()
+          local res = client:get("/foreign-references/my-in-existent-foreign-reference/same")
+          assert.res_status(404, res)
+        end)
+
+        it("ignores an invalid body", function()
+          local foreign_entity = assert(db.foreign_entities:insert({ name = "foreign-entity" }, { nulls = true }))
+          local foreign_reference = assert(db.foreign_references:insert({ name = "foreign-reference", same = foreign_entity }))
+
+          local res = client:get("/foreign-references/" .. foreign_reference.id .. "/same", {
+            headers = {
+              ["Content-Type"] = "application/json"
+            },
+            body = "this fails if decoded as json",
+          })
+          assert.res_status(200, res)
+
+          assert(db.foreign_references:delete({ id = foreign_reference.id }))
+          assert(db.foreign_entities:delete({ id = foreign_entity.id }))
+        end)
+      end)
+
+      describe("PATCH", function()
+        it_content_types("updates if found", function(content_type)
+          return function()
+            if content_type == "multipart/form-data" then
+              -- the client doesn't play well with this
+              return
+            end
+
+            local foreign_entity = assert(db.foreign_entities:insert({ name = "foreign-entity" }, { nulls = true }))
+            local foreign_reference = assert(db.foreign_references:insert({ name = "foreign-reference", same = foreign_entity }))
+
+            local edited_name = "name-" .. foreign_entity.name
+            local res = client:patch("/foreign-references/" .. foreign_reference.id .. "/same", {
+              headers = {
+                ["Content-Type"] = content_type
+              },
+              body = {
+                name  = edited_name,
+              },
+            })
+            local body = assert.res_status(200, res)
+            local json = cjson.decode(body)
+            assert.equal(edited_name, json.name)
+
+            local in_db = assert(db.foreign_entities:select({ id = foreign_entity.id }, { nulls = true }))
+            assert.same(json, in_db)
+
+            assert(db.foreign_references:delete({ id = foreign_reference.id }))
+            assert(db.foreign_entities:delete({ id = foreign_entity.id }))
+          end
+        end)
+
+        it_content_types("updates if found by name", function(content_type)
+          return function()
+            if content_type == "multipart/form-data" then
+              -- the client doesn't play well with this
+              return
+            end
+
+            local foreign_entity = assert(db.foreign_entities:insert({ name = "foreign-entity" }, { nulls = true }))
+            local foreign_reference = assert(db.foreign_references:insert({ name = "foreign-reference", same = foreign_entity }))
+            local edited_name = "name-" .. foreign_entity.name
+            local res = client:patch("/foreign-references/foreign-reference/same", {
+              headers = {
+                ["Content-Type"] = content_type
+              },
+              body = {
+                name  = edited_name,
+              },
+            })
+            local body = assert.res_status(200, res)
+            local json = cjson.decode(body)
+            assert.equal(edited_name, json.name)
+
+            local in_db = assert(db.foreign_entities:select({ id = foreign_entity.id }, { nulls = true }))
+            assert.same(json, in_db)
+
+            assert(db.foreign_references:delete({ id = foreign_reference.id }))
+            assert(db.foreign_entities:delete({ id = foreign_entity.id }))
+          end
+        end)
+
+        describe("errors", function()
+          it_content_types("returns 404 if not found", function(content_type)
+            return function()
+              local res = client:patch("/foreign-references/" .. utils.uuid() .. "/same", {
+                headers = {
+                  ["Content-Type"] = content_type
+                },
+                body = {
+                  name  = "edited",
+                },
+              })
+              assert.res_status(404, res)
+            end
+          end)
+
+          it_content_types("handles invalid input", function(content_type)
+            return function()
+              local foreign_entity = assert(db.foreign_entities:insert({ name = "foreign-entity" }))
+              local foreign_reference = assert(db.foreign_references:insert({ name = "foreign-reference", same = foreign_entity }))
+              local res = client:patch("/foreign-references/" .. foreign_reference.id .. "/same", {
+                headers = {
+                  ["Content-Type"] = content_type
+                },
+                body = {
+                  same = "foobar"
+                },
+              })
+              local body = assert.res_status(400, res)
+              assert.same({
+                code    = Errors.codes.SCHEMA_VIOLATION,
+                name    = "schema violation",
+                message = "schema violation (same: expected a valid UUID)",
+                fields  = {
+                  same = "expected a valid UUID",
+                },
+              }, cjson.decode(body))
+
+              assert(db.foreign_references:delete({ id = foreign_reference.id }))
+              assert(db.foreign_entities:delete({ id = foreign_entity.id }))
+            end
+          end)
+        end)
+      end)
+
+      describe("DELETE", function()
+        describe("errors", function()
+          it("returns HTTP 405 when trying to delete a foreign entity that is referenced", function()
+            local foreign_entity = assert(db.foreign_entities:insert({ name = "foreign-entity" }))
+            local foreign_reference = assert(db.foreign_references:insert({ name = "foreign-reference", same = foreign_entity }))
+            local res  = client:delete("/foreign-references/" .. foreign_reference.id .. "/same")
+            local body = assert.res_status(405, res)
+            assert.same({ message = 'Method not allowed' }, cjson.decode(body))
+
+            assert(db.foreign_references:delete({ id = foreign_reference.id }))
+            assert(db.foreign_entities:delete({ id = foreign_entity.id }))
+          end)
+
+          it("returns HTTP 404 with non-existing foreign reference", function()
+            local res = client:delete("/foreign-references/" .. utils.uuid() .. "/same")
+            assert.res_status(404, res)
+          end)
+
+          it("returns HTTP 404 with non-existing foreign reference by name", function()
+            local res = client:delete("/foreign-references/in-existent-route/same")
+            assert.res_status(404, res)
+          end)
+        end)
+      end)
+    end)
+  end)
+end

--- a/spec/fixtures/custom_plugins/kong/plugins/foreign-entity/daos.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/foreign-entity/daos.lua
@@ -1,0 +1,27 @@
+local typedefs = require "kong.db.schema.typedefs"
+
+
+return {
+  {
+    name = "foreign_entities",
+    primary_key = { "id" },
+    endpoint_key = "name",
+    admin_api_name = "foreign-entities",
+    fields = {
+      { id = typedefs.uuid },
+      { name = { type = "string", unique = true } },
+      { same = typedefs.uuid },
+    },
+  },
+  {
+    name = "foreign_references",
+    primary_key = { "id" },
+    endpoint_key = "name",
+    admin_api_name = "foreign-references",
+    fields = {
+      { id = typedefs.uuid },
+      { name = { type = "string", unique = true } },
+      { same = { type = "foreign", reference = "foreign_entities", on_delete = "cascade" } },
+    },
+  },
+}

--- a/spec/fixtures/custom_plugins/kong/plugins/foreign-entity/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/foreign-entity/handler.lua
@@ -1,0 +1,3 @@
+return {
+  PRIORITY = 1
+}

--- a/spec/fixtures/custom_plugins/kong/plugins/foreign-entity/migrations/000_base_foreign_entity.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/foreign-entity/migrations/000_base_foreign_entity.lua
@@ -1,0 +1,45 @@
+return {
+  postgres = {
+    up = [[
+      CREATE TABLE IF NOT EXISTS "foreign_entities" (
+        "id"    UUID   PRIMARY KEY,
+        "name"  TEXT   UNIQUE,
+        "same"  UUID
+      );
+
+      CREATE TABLE IF NOT EXISTS "foreign_references" (
+        "id"       UUID   PRIMARY KEY,
+        "name"     TEXT   UNIQUE,
+        "same_id"  UUID   REFERENCES "foreign_entities" ("id") ON DELETE CASCADE
+      );
+
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS "foreign_references_fkey_same" ON "foreign_references" ("same_id");
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
+    ]],
+  },
+
+  cassandra = {
+    up = [[
+      CREATE TABLE IF NOT EXISTS foreign_entities (
+        id    uuid   PRIMARY KEY,
+        name  text,
+        same  uuid
+      );
+
+      CREATE INDEX IF NOT EXISTS ON foreign_entities(name);
+
+      CREATE TABLE IF NOT EXISTS foreign_references (
+        id       uuid   PRIMARY KEY,
+        name     text,
+        same_id  uuid
+      );
+
+      CREATE INDEX IF NOT EXISTS ON foreign_references (name);
+      CREATE INDEX IF NOT EXISTS ON foreign_references (same_id);
+    ]],
+  },
+}

--- a/spec/fixtures/custom_plugins/kong/plugins/foreign-entity/migrations/init.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/foreign-entity/migrations/init.lua
@@ -1,0 +1,3 @@
+return {
+  "000_base_foreign_entity",
+}

--- a/spec/fixtures/custom_plugins/kong/plugins/foreign-entity/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/foreign-entity/schema.lua
@@ -1,0 +1,12 @@
+return {
+  name = "foreign-entity",
+  fields = {
+    {
+      config = {
+        type = "record",
+        fields = {
+        },
+      },
+    },
+  },
+}


### PR DESCRIPTION
### Summary

The original detection worked like this:

```
local inverse = not foreign_schema.fields[foreign_field_name] and
                            schema.fields[foreign_field_name]
```

This worked great, but it held an assumption that can go wrong.

Example:

Routes DAO has foreign key to servive, specified by the field with name `service`.

So `routes_schema.fields["service"]` is specified (see schema.fields[foreign_field_name]).

All good so far. But then there is another check that I would say is flaky: `not service_schema.fields["service"]`. Service schema does not obviously have field called `service` currently, but if we ever add a field to service schema with a name of `service` this assumption turns up-side-down, and we have introduced a bug.

I though if we could make this more clever, but I ended up with an explicit function argument that specifies wheter the autogenerator should generate the foreign entity endpoint or entity endpoint.

foreign entity endpoint:
- `/routes/:routes/service`

entity endpoints:
- `/routes/:routes`
- `/services/:services/routes/:routes`

This PR fixes this.