### PR TITLE
fix(admin-api) fix plugins fill-data to not infer json input

### DIFF
--- a/spec/02-integration/04-admin_api/04-plugins_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/04-plugins_routes_spec.lua
@@ -201,7 +201,17 @@ for _, strategy in helpers.each_strategy() do
             local in_db = assert(db.plugins:select({ id = plugins[2].id }, { nulls = true }))
             assert.same(json, in_db)
           end)
-
+          it("does not infer json input", function()
+            local res = assert(client:send {
+              method = "PATCH",
+              path = "/plugins/" .. plugins[2].id,
+              body = {
+                tags = cjson.null,
+              },
+              headers = { ["Content-Type"] = "application/json" }
+            })
+            assert.res_status(200, res)
+          end)
           describe("errors", function()
             it("handles invalid input", function()
               local before = assert(db.plugins:select({ id = plugins[1].id }, { nulls = true }))


### PR DESCRIPTION
### Summary

JSON input should be kept as is, but our customized plugin endpoint did always infer the input, even with JSON input. This PR changes the code to only infer with `application/x-www-form-urlencoded` and `multipart/form-data`.

### Issues resolved

Fix FT-1066 (reported through customer support channels).
