### PR TITLE
fix(db) only returns a null ttl if nulls is given

### DIFF
--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1659,6 +1659,10 @@ function Schema:process_auto_fields(data, context, nulls)
     end
   end
 
+  if self.ttl and context == "select" and data.ttl == null and not nulls then
+    data.ttl = nil
+  end
+
   --[[
   if context ~= "select" and self.translations then
     for _, translation in ipairs(self.translations) do

--- a/spec/02-integration/02-cmd/11-config_spec.lua
+++ b/spec/02-integration/02-cmd/11-config_spec.lua
@@ -115,7 +115,7 @@ describe("kong config", function()
     local filename = helpers.make_yaml_file([[
       _format_version: "1.1"
       services:
-      - name: foo
+      - name: foobar
         host: example.com
         protocol: https
         _comment: my comment
@@ -332,6 +332,8 @@ describe("kong config", function()
     local consumer = bp.consumers:insert()
     local acls = bp.acls:insert({ consumer = consumer })
 
+    local keyauth = bp.keyauth_credentials:insert({ consumer = consumer, key = "hello" })
+
     assert(helpers.kong_exec("config db_export " .. filename, {
       prefix = helpers.test_conf.prefix,
     }))
@@ -354,6 +356,7 @@ describe("kong config", function()
       "_format_version",
       "acls",
       "consumers",
+      "keyauth_credentials",
       "plugins",
       "routes",
       "services",
@@ -395,6 +398,10 @@ describe("kong config", function()
     assert.equals(1, #yaml.acls)
     assert.equals(acls.group, yaml.acls[1].group)
     assert.equals(consumer.id, yaml.acls[1].consumer)
+
+    assert.equals(1, #yaml.keyauth_credentials)
+    assert.equals(keyauth.key, yaml.keyauth_credentials[1].key)
+    assert.equals(consumer.id, yaml.keyauth_credentials[1].consumer)
   end)
 
   it("#db config db_import works when foreign keys need to be resolved", function()


### PR DESCRIPTION
Fixes issue with `kong config db_export` when trying to read
entities that are ttl-enabled and whose ttl value is `null`.

Contains regression tests both at unit and integration level.

FIxes #5185.
