### PR TITLE
hotfix(tests) fix a test that broke when we removed json inferring from plugins

### DIFF
--- a/spec/02-integration/06-invalidations/03-plugins_iterator_invalidation_spec.lua
+++ b/spec/02-integration/06-invalidations/03-plugins_iterator_invalidation_spec.lua
@@ -216,7 +216,9 @@ for _, strategy in helpers.each_strategy() do
           method = "PATCH",
           path   = "/plugins/" .. service_plugin_id,
           body   = {
-            ["config.resp_header_value"] = "2",
+            config = {
+              resp_header_value = "2"
+            }
           },
           headers = {
             ["Content-Type"] = "application/json",


### PR DESCRIPTION
### Summary

The PR #5191 introduced a breakage in one test that was wrongly written.

This PR fixes the test so that we get `green` `master` again.