### PR TITLE
fix(request-termination) add check for content object

### DIFF
--- a/kong/plugins/request-termination/handler.lua
+++ b/kong/plugins/request-termination/handler.lua
@@ -40,7 +40,8 @@ function RequestTerminationHandler:access(conf)
     return kong.response.exit(status, content, headers)
   end
 
-  return kong.response.exit(status, { message = conf.message or DEFAULT_RESPONSE[status] })
+  local message = conf.message or DEFAULT_RESPONSE[status]
+  return kong.response.exit(status, message and { message = message } or nil)
 end
 
 

--- a/spec/03-plugins/14-request-termination/02-access_spec.lua
+++ b/spec/03-plugins/14-request-termination/02-access_spec.lua
@@ -46,6 +46,10 @@ for _, strategy in helpers.each_strategy() do
         hosts = { "api7.request-termination.com" },
       })
 
+      local route8 = bp.routes:insert({
+        hosts = { "api8.request-termination.com" },
+      })
+
       bp.plugins:insert {
         name   = "request-termination",
         route  = { id = route1.id },
@@ -100,6 +104,14 @@ for _, strategy in helpers.each_strategy() do
         name   = "request-termination",
         route  = { id = route7.id },
         config = {},
+      }
+
+      bp.plugins:insert {
+        name   = "request-termination",
+        route  = { id = route8.id },
+        config = {
+          status_code = 204
+        },
       }
 
       assert(helpers.start_kong({
@@ -171,6 +183,19 @@ for _, strategy in helpers.each_strategy() do
         local body = assert.res_status(406, res)
         local json = cjson.decode(body)
         assert.same({ message = "Invalid" }, json)
+      end)
+
+      it("returns 204 without content length header", function()
+        local res = assert(proxy_client:send {
+          method = "GET",
+          path = "/status/204",
+          headers = {
+            ["Host"] = "api8.request-termination.com"
+          }
+        })
+
+        assert.res_status(204, res)
+        assert.is_nil(res.headers["Content-Length"])
       end)
 
     end)


### PR DESCRIPTION
### Summary

When you apply plugin for any `route` or `service` and set response code `204` without providing a message and you try to send a request to that route it responds with status code `204` and `Content-Length: 2` which is not good and tools such as `Postman` hangs on it.

This PR propose a solution to fix this issue by checking if `conf.message` is provided if not then just don't `exit` with empty body object just set `nil` to avoid any possible issues.

### Full changelog

* add additional check for `conf.message` before sending response back with `body` object included.
