### PR TITLE
chore(deps) bump luasec from 0.8 to 0.9

### DIFF
--- a/kong-1.4.0-0.rockspec
+++ b/kong-1.4.0-0.rockspec
@@ -12,7 +12,7 @@ description = {
 }
 dependencies = {
   "inspect == 3.1.1",
-  "luasec == 0.8",
+  "luasec == 0.9",
   "luasocket == 3.0-rc1",
   "penlight == 1.7.0",
   "lua-resty-http == 0.15",


### PR DESCRIPTION
### Summary

##### LuaSec 0.9

- Add DNS-based Authentication of Named Entities (DANE) support
- Add __close() metamethod
- Fix deprecation warnings with OpenSSL 1.1
- Fix special case listing of TLS 1.3 EC curves
- Fix general_name leak in cert:extensions()
- Fix unexported 'ssl.config' table
- Replace $(LD) with $(CCLD) variable
- Remove multiple definitions of 'ssl_options' variable
- Use tag in git format: v0.9

##### LuaSec 0.8.2

- Fix unexported 'ssl.config' table (backported)

##### LuaSec 0.8.1

- Fix general_name leak in cert:extensions() (backported)