### PR TITLE
fix(helpers) remove unnecessary plugin override from `helpers.start_kong`

### DIFF
--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -1518,12 +1518,6 @@ local function kong_exec(cmd, env, pl_returns, env_vars)
 
   env.lua_package_path = env.lua_package_path .. ";" .. conf.lua_package_path
 
-  if not env.plugins then
-    env.plugins = "bundled,dummy,cache,rewriter,error-handler-log," ..
-                  "error-generator,error-generator-last," ..
-                  "short-circuit,short-circuit-last"
-  end
-
   -- build Kong environment variables
   env_vars = env_vars or ""
   for k, v in pairs(env) do


### PR DESCRIPTION
### Summary

This PR resolves a minor annoyance in the plugin testing process by removing the requirement to explicitly specify enabled plugins when calling `helpers.start_kong`.

Currently, when writing plugin tests, one first needs to ensure that all plugins are enabled via `KONG_TEST_PLUGINS` or DB/blueprint methods such as `bp.plugins:insert({ ... name = "my-plugin", config = { ... } })` called prior to starting Kong will result in the error `schema violation (name: plugin 'my-plugin' not enabled; add it to the 'plugins' configuration property)`. One then has to re-specify all enabled plugins when calling `helpers.start_kong` - i.e. `helpers.start_kong( { plugins = "bundled,my-plugin" })` or the code at https://github.com/Kong/kong/blob/0ff3dea2dec36085ddf90bcf3dc87de2303cc49d/spec/helpers.lua#L1512 will effectively disable any plugins you have already enabled by overriding the `env.plugins` with the built-in set of plugins. This results in an error like `nginx: [error] ... my-plugin plugin is in use but not enabled.`. This override ultimately goes against the parameter description on the method where it states: "@param env (**optional**) table with kong parameters to set as environment variables, **overriding** the test config". 

By removing the forced override if `env.plugins` is not specified, the default test config is applied and one no longer needs to explictly set the enabled plugins in both places. Of course, one is still able to override the enabled plugins by setting `env.plugins`. Thus, I don't believe anything should break and, folks still have the option to test an explicit scenario where a different set/subset of plugins are enabled.

### Full changelog

* Remove plugin override when calling `helpers.start_kong`