### PR TITLE
chore(deps) bump lua-resty-dns-client to 4.1.1

### DIFF
--- a/kong-1.4.0-0.rockspec
+++ b/kong-1.4.0-0.rockspec
@@ -30,7 +30,7 @@ dependencies = {
   "luaossl == 20190731",
   "luasyslog == 1.0.0",
   "lua_pack == 1.0.5",
-  "lua-resty-dns-client == 4.1.0",
+  "lua-resty-dns-client == 4.1.1",
   "lua-resty-worker-events == 1.0.0",
   "lua-resty-mediador == 0.1.2",
   "lua-resty-healthcheck == 1.1.0",


### PR DESCRIPTION
### Summary

Bump lua-resty-dns-client to 4.1.1.

Changelog:
    Fix: added logging of try-list to the TCP/UDP wrappers, see PR 75.
    Fix: reduce logging noise of the requery timer