### PR TITLE
fix(grpc) preserve_host behavior

### DIFF
--- a/kong/router.lua
+++ b/kong/router.lua
@@ -1,3 +1,4 @@
+local constants     = require "kong.constants"
 local lrucache      = require "resty.lrucache"
 local utils         = require "kong.tools.utils"
 local px            = require "resty.mediador.proxy"
@@ -156,12 +157,8 @@ local function has_capturing_groups(subj)
 end
 
 
-local protocol_subsystem = {
-  http = "http",
-  https = "http",
-  tcp = "stream",
-  tls = "stream",
-}
+local protocol_subsystem = constants.PROTOCOLS_WITH_SUBSYSTEM
+
 
 local function marshall_route(r)
   local route        = r.route

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -176,15 +176,29 @@ server {
 
     location @grpc {
         internal;
-
         set $kong_proxy_mode  'grpc';
+
+        grpc_set_header    Host              $upstream_host;
+        grpc_set_header    X-Forwarded-For   $upstream_x_forwarded_for;
+        grpc_set_header    X-Forwarded-Proto $upstream_x_forwarded_proto;
+        grpc_set_header    X-Forwarded-Host  $upstream_x_forwarded_host;
+        grpc_set_header    X-Forwarded-Port  $upstream_x_forwarded_port;
+        grpc_set_header    X-Real-IP         $remote_addr;
+
         grpc_pass grpc://kong_upstream;
     }
 
     location @grpcs {
         internal;
-
         set $kong_proxy_mode  'grpc';
+
+        grpc_set_header    Host              $upstream_host;
+        grpc_set_header    X-Forwarded-For   $upstream_x_forwarded_for;
+        grpc_set_header    X-Forwarded-Proto $upstream_x_forwarded_proto;
+        grpc_set_header    X-Forwarded-Host  $upstream_x_forwarded_host;
+        grpc_set_header    X-Forwarded-Port  $upstream_x_forwarded_port;
+        grpc_set_header    X-Real-IP         $remote_addr;
+
         grpc_pass grpcs://kong_upstream;
     }
 


### PR DESCRIPTION
### Summary

Fix issue preventing `preserve_host` behavior from
taking effect on gRPC.

Fixes #5053, #5217.

### Known Limitations

Due to Nginx gRPC module behavior, the `Host` header is not translated to the pseudo-header `:authority`, but instead sent as `Host`.