### PR TITLE
fix(router) slashes -- take 2

### DIFF
--- a/kong/router.lua
+++ b/kong/router.lua
@@ -1539,7 +1539,15 @@ function _M.new(routes)
               if byte(upstream_base, -1) == SLASH then
                 -- ends with / and strip_uri = true
                 if matched_route.strip_uri then
-                  if byte(request_postfix, 1, 1) == SLASH then
+                  if request_postfix == "" then
+                    -- leave the slash if that's all there is, but remove the slash otherwise
+                    -- (i.e leave "/" but transform "/foo/bar/" into "/foo/bar")
+                    if upstream_base == "/" then
+                      upstream_uri = "/"
+                    else
+                      upstream_uri = sub(upstream_base, 1, -2)
+                    end
+                  elseif byte(request_postfix, 1, 1) == SLASH then
                     -- double "/", so drop the first
                     upstream_uri = sub(upstream_base, 1, -2) .. request_postfix
                   else -- ends with / and strip_uri = true, no double slash
@@ -1557,7 +1565,7 @@ function _M.new(routes)
                 if matched_route.strip_uri then
                   if request_postfix == "" then
                     upstream_uri = upstream_base
-                  elseif request_postfix == "/" then
+                  elseif byte(request_postfix, 1, 1) == SLASH then
                     upstream_uri = upstream_base .. request_postfix
                   else
                     upstream_uri = upstream_base .. "/" .. request_postfix

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -2780,24 +2780,26 @@ describe("Router", function()
         {  "/fee/bor",     "/foo/bar",     "/foo/bar",     "/fee/bor",             true      }, -- 10
         {  "/fee/bor",     "/foo/bar",     "/foo/bar/",    "/fee/bor/",            true      },
         {  "/fee/bor",     "/foo/bar/",    "/foo/bar/",    "/fee/bor",             true      },
-        {  "/fee/bor/",    "/",            "/",            "/fee/bor/",            true      },
+        {  "/fee/bor/",    "/",            "/",            "/fee/bor",             true      },
         {  "/fee/bor/",    "/",            "/foo/bar",     "/fee/bor/foo/bar",     true      },
         {  "/fee/bor/",    "/",            "/foo/bar/",    "/fee/bor/foo/bar/",    true      },
-        {  "/fee/bor/",    "/foo/bar",     "/foo/bar",     "/fee/bor/",            true      },
+        {  "/fee/bor/",    "/foo/bar",     "/foo/bar",     "/fee/bor",             true      },
         {  "/fee/bor/",    "/foo/bar",     "/foo/bar/",    "/fee/bor/",            true      },
-        {  "/fee/bor/",    "/foo/bar/",    "/foo/bar/",    "/fee/bor/",            true      },
+        {  "/fee/bor/",    "/foo/bar/",    "/foo/bar/",    "/fee/bor",             true      },
+        {  "/fee",         "/foo",         "/foobar",      "/fee/bar",             true      }, -- 20
+        {  "/fee/",        "/foo",         "/foo",         "/fee",                 true      },
         {  "/",            "/",            "/",            "/",                    false     },
-        {  "/",            "/",            "/foo/bar",     "/foo/bar",             false     }, -- 20
+        {  "/",            "/",            "/foo/bar",     "/foo/bar",             false     },
         {  "/",            "/",            "/foo/bar/",    "/foo/bar/",            false     },
         {  "/",            "/foo/bar",     "/foo/bar",     "/foo/bar",             false     },
         {  "/",            "/foo/bar",     "/foo/bar/",    "/foo/bar/",            false     },
         {  "/",            "/foo/bar/",    "/foo/bar/",    "/foo/bar/",            false     },
         {  "/fee/bor",     "/",            "/",            "/fee/bor",             false     },
         {  "/fee/bor",     "/",            "/foo/bar",     "/fee/bor/foo/bar",     false     },
-        {  "/fee/bor",     "/",            "/foo/bar/",    "/fee/bor/foo/bar/",    false     },
+        {  "/fee/bor",     "/",            "/foo/bar/",    "/fee/bor/foo/bar/",    false     }, -- 30
         {  "/fee/bor",     "/foo/bar",     "/foo/bar",     "/fee/bor/foo/bar",     false     },
         {  "/fee/bor",     "/foo/bar",     "/foo/bar/",    "/fee/bor/foo/bar/",    false     },
-        {  "/fee/bor",     "/foo/bar/",    "/foo/bar/",    "/fee/bor/foo/bar/",    false     }, -- 30
+        {  "/fee/bor",     "/foo/bar/",    "/foo/bar/",    "/fee/bor/foo/bar/",    false     },
         {  "/fee/bor/",    "/",            "/",            "/fee/bor/",            false     },
         {  "/fee/bor/",    "/",            "/foo/bar",     "/fee/bor/foo/bar",     false     },
         {  "/fee/bor/",    "/",            "/foo/bar/",    "/fee/bor/foo/bar/",    false     },
@@ -2807,30 +2809,30 @@ describe("Router", function()
         -- the following block runs the same tests, but with a request path that is longer
         -- than the matched part, so either matches in the middle of a segment, or has an
         -- additional segment.
-        {  "/",            "/",            "/foo/bars",    "/foo/bars",            true      },
+        {  "/",            "/",            "/foo/bars",    "/foo/bars",            true      }, -- 40
         {  "/",            "/",            "/foo/bar/s",   "/foo/bar/s",           true      },
         {  "/",            "/foo/bar",     "/foo/bars",    "/s",                   true      },
-        {  "/",            "/foo/bar/",    "/foo/bar/s",   "/s",                   true      }, -- 40
+        {  "/",            "/foo/bar/",    "/foo/bar/s",   "/s",                   true      },
         {  "/fee/bor",     "/",            "/foo/bars",    "/fee/bor/foo/bars",    true      },
         {  "/fee/bor",     "/",            "/foo/bar/s",   "/fee/bor/foo/bar/s",   true      },
         {  "/fee/bor",     "/foo/bar",     "/foo/bars",    "/fee/bor/s",           true      },
         {  "/fee/bor",     "/foo/bar/",    "/foo/bar/s",   "/fee/bor/s",           true      },
         {  "/fee/bor/",    "/",            "/foo/bars",    "/fee/bor/foo/bars",    true      },
         {  "/fee/bor/",    "/",            "/foo/bar/s",   "/fee/bor/foo/bar/s",   true      },
-        {  "/fee/bor/",    "/foo/bar",     "/foo/bars",    "/fee/bor/s",           true      },
+        {  "/fee/bor/",    "/foo/bar",     "/foo/bars",    "/fee/bor/s",           true      }, -- 50
         {  "/fee/bor/",    "/foo/bar/",    "/foo/bar/s",   "/fee/bor/s",           true      },
         {  "/",            "/",            "/foo/bars",    "/foo/bars",            false     },
-        {  "/",            "/",            "/foo/bar/s",   "/foo/bar/s",           false     }, -- 50
+        {  "/",            "/",            "/foo/bar/s",   "/foo/bar/s",           false     },
         {  "/",            "/foo/bar",     "/foo/bars",    "/foo/bars",            false     },
         {  "/",            "/foo/bar/",    "/foo/bar/s",   "/foo/bar/s",           false     },
         {  "/fee/bor",     "/",            "/foo/bars",    "/fee/bor/foo/bars",    false     },
         {  "/fee/bor",     "/",            "/foo/bar/s",   "/fee/bor/foo/bar/s",   false     },
         {  "/fee/bor",     "/foo/bar",     "/foo/bars",    "/fee/bor/foo/bars",    false     },
         {  "/fee/bor",     "/foo/bar/",    "/foo/bar/s",   "/fee/bor/foo/bar/s",   false     },
-        {  "/fee/bor/",    "/",            "/foo/bars",    "/fee/bor/foo/bars",    false     },
+        {  "/fee/bor/",    "/",            "/foo/bars",    "/fee/bor/foo/bars",    false     }, -- 60
         {  "/fee/bor/",    "/",            "/foo/bar/s",   "/fee/bor/foo/bar/s",   false     },
         {  "/fee/bor/",    "/foo/bar",     "/foo/bars",    "/fee/bor/foo/bars",    false     },
-        {  "/fee/bor/",    "/foo/bar/",    "/foo/bar/s",   "/fee/bor/foo/bar/s",   false     }, -- 60
+        {  "/fee/bor/",    "/foo/bar/",    "/foo/bar/s",   "/fee/bor/foo/bar/s",   false     },
         -- the following block matches on host, instead of path
         {  "/",            nil,            "/",            "/",                    false     },
         {  "/",            nil,            "/foo/bar",     "/foo/bar",             false     },
@@ -2838,18 +2840,18 @@ describe("Router", function()
         {  "/fee/bor",     nil,            "/",            "/fee/bor",             false     },
         {  "/fee/bor",     nil,            "/foo/bar",     "/fee/bor/foo/bar",     false     },
         {  "/fee/bor",     nil,            "/foo/bar/",    "/fee/bor/foo/bar/",    false     },
-        {  "/fee/bor/",    nil,            "/",            "/fee/bor/",            false     },
+        {  "/fee/bor/",    nil,            "/",            "/fee/bor/",            false     }, -- 70
         {  "/fee/bor/",    nil,            "/foo/bar",     "/fee/bor/foo/bar",     false     },
         {  "/fee/bor/",    nil,            "/foo/bar/",    "/fee/bor/foo/bar/",    false     },
-        {  "/",            nil,            "/",            "/",                    true      }, -- 70
+        {  "/",            nil,            "/",            "/",                    true      },
         {  "/",            nil,            "/foo/bar",     "/foo/bar",             true      },
         {  "/",            nil,            "/foo/bar/",    "/foo/bar/",            true      },
         {  "/fee/bor",     nil,            "/",            "/fee/bor",             true      },
         {  "/fee/bor",     nil,            "/foo/bar",     "/fee/bor/foo/bar",     true      },
         {  "/fee/bor",     nil,            "/foo/bar/",    "/fee/bor/foo/bar/",    true      },
-        {  "/fee/bor/",    nil,            "/",            "/fee/bor/",            true      },
+        {  "/fee/bor/",    nil,            "/",            "/fee/bor",             true      },
         {  "/fee/bor/",    nil,            "/foo/bar",     "/fee/bor/foo/bar",     true      },
-        {  "/fee/bor/",    nil,            "/foo/bar/",    "/fee/bor/foo/bar/",    true      },
+        {  "/fee/bor/",    nil,            "/foo/bar/",    "/fee/bor/foo/bar/",    true      }, -- 80
       }
 
       for i, args in ipairs(checks) do

--- a/spec/02-integration/05-proxy/02-router_spec.lua
+++ b/spec/02-integration/05-proxy/02-router_spec.lua
@@ -1477,24 +1477,26 @@ for _, strategy in helpers.each_strategy() do
         {  "/fee/bor",     "/foo/bar",     "/foo/bar",     "/fee/bor",             true      }, -- 10
         {  "/fee/bor",     "/foo/bar",     "/foo/bar/",    "/fee/bor/",            true      },
         {  "/fee/bor",     "/foo/bar/",    "/foo/bar/",    "/fee/bor",             true      },
-        {  "/fee/bor/",    "/",            "/",            "/fee/bor/",            true      },
+        {  "/fee/bor/",    "/",            "/",            "/fee/bor",             true      },
         {  "/fee/bor/",    "/",            "/foo/bar",     "/fee/bor/foo/bar",     true      },
         {  "/fee/bor/",    "/",            "/foo/bar/",    "/fee/bor/foo/bar/",    true      },
-        {  "/fee/bor/",    "/foo/bar",     "/foo/bar",     "/fee/bor/",            true      },
+        {  "/fee/bor/",    "/foo/bar",     "/foo/bar",     "/fee/bor",             true      },
         {  "/fee/bor/",    "/foo/bar",     "/foo/bar/",    "/fee/bor/",            true      },
-        {  "/fee/bor/",    "/foo/bar/",    "/foo/bar/",    "/fee/bor/",            true      },
+        {  "/fee/bor/",    "/foo/bar/",    "/foo/bar/",    "/fee/bor",             true      },
+        {  "/fee",         "/foo",         "/foobar",      "/fee/bar",             true      }, -- 20
+        {  "/fee/",        "/foo",         "/foo",         "/fee",                 true      },
         {  "/",            "/",            "/",            "/",                    false     },
-        {  "/",            "/",            "/foo/bar",     "/foo/bar",             false     }, -- 20
+        {  "/",            "/",            "/foo/bar",     "/foo/bar",             false     },
         {  "/",            "/",            "/foo/bar/",    "/foo/bar/",            false     },
         {  "/",            "/foo/bar",     "/foo/bar",     "/foo/bar",             false     },
         {  "/",            "/foo/bar",     "/foo/bar/",    "/foo/bar/",            false     },
         {  "/",            "/foo/bar/",    "/foo/bar/",    "/foo/bar/",            false     },
         {  "/fee/bor",     "/",            "/",            "/fee/bor",             false     },
         {  "/fee/bor",     "/",            "/foo/bar",     "/fee/bor/foo/bar",     false     },
-        {  "/fee/bor",     "/",            "/foo/bar/",    "/fee/bor/foo/bar/",    false     },
+        {  "/fee/bor",     "/",            "/foo/bar/",    "/fee/bor/foo/bar/",    false     }, -- 30
         {  "/fee/bor",     "/foo/bar",     "/foo/bar",     "/fee/bor/foo/bar",     false     },
         {  "/fee/bor",     "/foo/bar",     "/foo/bar/",    "/fee/bor/foo/bar/",    false     },
-        {  "/fee/bor",     "/foo/bar/",    "/foo/bar/",    "/fee/bor/foo/bar/",    false     }, -- 30
+        {  "/fee/bor",     "/foo/bar/",    "/foo/bar/",    "/fee/bor/foo/bar/",    false     },
         {  "/fee/bor/",    "/",            "/",            "/fee/bor/",            false     },
         {  "/fee/bor/",    "/",            "/foo/bar",     "/fee/bor/foo/bar",     false     },
         {  "/fee/bor/",    "/",            "/foo/bar/",    "/fee/bor/foo/bar/",    false     },
@@ -1504,30 +1506,30 @@ for _, strategy in helpers.each_strategy() do
         -- the following block runs the same tests, but with a request path that is longer
         -- than the matched part, so either matches in the middle of a segment, or has an
         -- additional segment.
-        {  "/",            "/",            "/foo/bars",    "/foo/bars",            true      },
+        {  "/",            "/",            "/foo/bars",    "/foo/bars",            true      }, -- 40
         {  "/",            "/",            "/foo/bar/s",   "/foo/bar/s",           true      },
         {  "/",            "/foo/bar",     "/foo/bars",    "/s",                   true      },
-        {  "/",            "/foo/bar/",    "/foo/bar/s",   "/s",                   true      }, -- 40
+        {  "/",            "/foo/bar/",    "/foo/bar/s",   "/s",                   true      },
         {  "/fee/bor",     "/",            "/foo/bars",    "/fee/bor/foo/bars",    true      },
         {  "/fee/bor",     "/",            "/foo/bar/s",   "/fee/bor/foo/bar/s",   true      },
         {  "/fee/bor",     "/foo/bar",     "/foo/bars",    "/fee/bor/s",           true      },
         {  "/fee/bor",     "/foo/bar/",    "/foo/bar/s",   "/fee/bor/s",           true      },
         {  "/fee/bor/",    "/",            "/foo/bars",    "/fee/bor/foo/bars",    true      },
         {  "/fee/bor/",    "/",            "/foo/bar/s",   "/fee/bor/foo/bar/s",   true      },
-        {  "/fee/bor/",    "/foo/bar",     "/foo/bars",    "/fee/bor/s",           true      },
+        {  "/fee/bor/",    "/foo/bar",     "/foo/bars",    "/fee/bor/s",           true      }, -- 50
         {  "/fee/bor/",    "/foo/bar/",    "/foo/bar/s",   "/fee/bor/s",           true      },
         {  "/",            "/",            "/foo/bars",    "/foo/bars",            false     },
-        {  "/",            "/",            "/foo/bar/s",   "/foo/bar/s",           false     }, -- 50
+        {  "/",            "/",            "/foo/bar/s",   "/foo/bar/s",           false     },
         {  "/",            "/foo/bar",     "/foo/bars",    "/foo/bars",            false     },
         {  "/",            "/foo/bar/",    "/foo/bar/s",   "/foo/bar/s",           false     },
         {  "/fee/bor",     "/",            "/foo/bars",    "/fee/bor/foo/bars",    false     },
         {  "/fee/bor",     "/",            "/foo/bar/s",   "/fee/bor/foo/bar/s",   false     },
         {  "/fee/bor",     "/foo/bar",     "/foo/bars",    "/fee/bor/foo/bars",    false     },
         {  "/fee/bor",     "/foo/bar/",    "/foo/bar/s",   "/fee/bor/foo/bar/s",   false     },
-        {  "/fee/bor/",    "/",            "/foo/bars",    "/fee/bor/foo/bars",    false     },
+        {  "/fee/bor/",    "/",            "/foo/bars",    "/fee/bor/foo/bars",    false     }, -- 60
         {  "/fee/bor/",    "/",            "/foo/bar/s",   "/fee/bor/foo/bar/s",   false     },
         {  "/fee/bor/",    "/foo/bar",     "/foo/bars",    "/fee/bor/foo/bars",    false     },
-        {  "/fee/bor/",    "/foo/bar/",    "/foo/bar/s",   "/fee/bor/foo/bar/s",   false     }, -- 60
+        {  "/fee/bor/",    "/foo/bar/",    "/foo/bar/s",   "/fee/bor/foo/bar/s",   false     },
         -- the following block matches on host, instead of path
         {  "/",            nil,            "/",            "/",                    false     },
         {  "/",            nil,            "/foo/bar",     "/foo/bar",             false     },
@@ -1535,18 +1537,18 @@ for _, strategy in helpers.each_strategy() do
         {  "/fee/bor",     nil,            "/",            "/fee/bor",             false     },
         {  "/fee/bor",     nil,            "/foo/bar",     "/fee/bor/foo/bar",     false     },
         {  "/fee/bor",     nil,            "/foo/bar/",    "/fee/bor/foo/bar/",    false     },
-        {  "/fee/bor/",    nil,            "/",            "/fee/bor/",            false     },
+        {  "/fee/bor/",    nil,            "/",            "/fee/bor/",            false     }, -- 70
         {  "/fee/bor/",    nil,            "/foo/bar",     "/fee/bor/foo/bar",     false     },
         {  "/fee/bor/",    nil,            "/foo/bar/",    "/fee/bor/foo/bar/",    false     },
-        {  "/",            nil,            "/",            "/",                    true      }, -- 70
+        {  "/",            nil,            "/",            "/",                    true      },
         {  "/",            nil,            "/foo/bar",     "/foo/bar",             true      },
         {  "/",            nil,            "/foo/bar/",    "/foo/bar/",            true      },
         {  "/fee/bor",     nil,            "/",            "/fee/bor",             true      },
         {  "/fee/bor",     nil,            "/foo/bar",     "/fee/bor/foo/bar",     true      },
         {  "/fee/bor",     nil,            "/foo/bar/",    "/fee/bor/foo/bar/",    true      },
-        {  "/fee/bor/",    nil,            "/",            "/fee/bor/",            true      },
+        {  "/fee/bor/",    nil,            "/",            "/fee/bor",             true      },
         {  "/fee/bor/",    nil,            "/foo/bar",     "/fee/bor/foo/bar",     true      },
-        {  "/fee/bor/",    nil,            "/foo/bar/",    "/fee/bor/foo/bar/",    true      },
+        {  "/fee/bor/",    nil,            "/foo/bar/",    "/fee/bor/foo/bar/",    true      }, -- 80
       }
 
       describe("(plain)", function()


### PR DESCRIPTION
This is a continuation of #5216. It further reverts some breaking changes introduced by #3780, involving the handling of slashes inside the router.

Related with #4469. Related with #4538.
