### PR TITLE
Update License file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1083,6 +1083,8 @@ A summary of the changes introduced in the new Admin API:
 
 - Pagination has been included in all "multi-record" endpoints, and pagination
   control fields are different than in 0.14.x.
+- The changelog for Kong 0.14.x mentions breaking changes to the /consumers endpoint as a result of moving to the new DAO, as                   
+  part of #3437
 - Filtering now happens via URL path changes (`/consumers/x/plugins`) instead
   of querystring fields (`/plugins?consumer_id=x`).
 - Array values can't be coerced from comma-separated strings anymore. They must

--- a/LICENSE
+++ b/LICENSE
@@ -15,7 +15,7 @@
 
       "Legal Entity" shall mean the union of the acting entity and all
       other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
+      control with that entity. For this definition,
       "control" means (i) the power, direct or indirect, to cause the
       direction or management of such entity, whether by contract or
       otherwise, or (ii) ownership of fifty percent (50%) or more of the
@@ -51,12 +51,12 @@
       to that Work or Derivative Works thereof, that is intentionally
       submitted to Licensor for inclusion in the Work by the copyright owner
       or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
+      the copyright owner. For this definition, "submitted"
       means any form of electronic, verbal, or written communication sent
       to the Licensor or its representatives, including but not limited to
       communication on electronic mailing lists, source code control systems,
       and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
+      Licensor to discuss and improve and improving the Work, but
       excluding communication that is conspicuously marked or otherwise
       designated in writing by the copyright owner as "Not a Contribution."
 
@@ -125,7 +125,7 @@
       may provide additional or different license terms and conditions
       for use, reproduction, or distribution of Your modifications, or
       for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
+      reproduction and distribution of the Work otherwise complies with
       the conditions stated in this License.
 
    5. Submission of Contributions. Unless You explicitly state otherwise,


### PR DESCRIPTION
Fixed Grammatical and spelling error


### Summary

* Removed some of the useless words like "the purposes of" in the sentence.
* Changed the word for "for the purpose of discussing" to "to discuss and improve" in the sentence for the simplicity of reading the file. 



