### PR TITLE
fix(balancer): remove old balancer from upstream_ids

### DIFF
--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -68,6 +68,7 @@ local function set_balancer(upstream_id, balancer)
     healthcheckers[prev] = nil
     healthchecker_callbacks[prev] = nil
     target_histories[prev] = nil
+    upstream_ids[prev] = nil
   end
   balancers[upstream_id] = balancer
 end


### PR DESCRIPTION
### Summary

Remove old balancers from upstream_ids. 

The big `upstream_ids` table may cause memory leak on upstream/target events.

Memory usage of Kong
before
![image](https://user-images.githubusercontent.com/3369662/69055701-5f8a2200-0a49-11ea-88fb-519381d44237.png)

after
![image](https://user-images.githubusercontent.com/3369662/69055722-6b75e400-0a49-11ea-81af-96df055279a4.png)

### Issues resolved

(Maybe) Fix #5203
