### PR TITLE
Create "kong" global before executing "kong config" subcommands

### DIFF
--- a/kong/cmd/config.lua
+++ b/kong/cmd/config.lua
@@ -23,16 +23,6 @@ local function db_export(filename, conf)
     error(filename .. " already exists. Will not overwrite it.")
   end
 
-  _G.kong = kong_global.new()
-  kong_global.init_pdk(_G.kong, conf, nil) -- nil: latest PDK
-
-  local db = assert(DB.new(conf))
-  assert(db:init_connector())
-  assert(db:connect())
-  assert(db.plugins:load_plugin_schemas(conf.loaded_plugins))
-
-  _G.kong.db = db
-
   local fd, err = io.open(filename, "w")
   if not fd then
     return nil, err
@@ -96,6 +86,16 @@ local function execute(args)
     error(err)
   end
 
+  _G.kong = kong_global.new()
+  kong_global.init_pdk(_G.kong, conf, nil) -- nil: latest PDK
+
+  local db = assert(DB.new(conf))
+  assert(db:init_connector())
+  assert(db:connect())
+  assert(db.plugins:load_plugin_schemas(conf.loaded_plugins))
+
+  _G.kong.db = db
+
   if args.command == "db_export" then
     return db_export(args[1] or "kong.yml", conf)
   end
@@ -113,16 +113,6 @@ local function execute(args)
 
     if args.command == "db_import" then
       log("parse successful, beginning import")
-
-      _G.kong = kong_global.new()
-      kong_global.init_pdk(_G.kong, conf, nil) -- nil: latest PDK
-
-      local db = assert(DB.new(conf))
-      assert(db:init_connector())
-      assert(db:connect())
-      assert(db.plugins:load_plugin_schemas(conf.loaded_plugins))
-
-      _G.kong.db = db
 
       local ok, err = declarative.load_into_db(dc_table)
       if not ok then


### PR DESCRIPTION
### Summary

Initialize the kong global and database before running any `kong config` subcommand.

### Full changelog

* Move initialization of `kong` global and database prior to subcommand-specific code for `kong config` CLI command.
* Remove existing `kong` global and database initialization specific to `db_export`.

### Issues resolved

The `db_import` and `parse` subcommands invoke `parse_file`, which runs entity checks. Entity checks can require database access, and the `rbac_user` Enterprise entity does currently. If the `kong` global is not present and/or `kong.db` is not initialized, `db_import` and `parse` will fail.