### PR TITLE
Add regression test for ambiguous router matching

### DIFF
--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -740,6 +740,42 @@ describe("Router", function()
         assert.equal(use_case[1].route, match_t.route)
       end)
 
+      it("does not supersede another route with a longer [uri] when a better [uri] match exists for another [host]", function()
+        local use_case = {
+          {
+            service   = service,
+            route     = {
+              hosts   = { "example.com" },
+              paths   = { "/my-route" },
+            },
+          },
+          {
+            service   = service,
+            route     = {
+              hosts   = { "example.com" },
+              paths   = { "/my-route/hello" },
+            },
+          },
+          {
+            service   = service,
+            route     = {
+              hosts   = { "example.net" },
+              paths   = { "/my-route/hello/world" },
+            },
+          },
+        }
+
+        local router = assert(Router.new(use_case))
+
+        local match_t = router.select("GET", "/my-route/hello/world", "example.com")
+        assert.truthy(match_t)
+        assert.equal(use_case[2].route, match_t.route)
+
+        local match_t = router.select("GET", "/my-route/hello/world/and/goodnight", "example.com")
+        assert.truthy(match_t)
+        assert.equal(use_case[2].route, match_t.route)
+      end)
+
       it("only matches [uri prefix] as a prefix (anchored mode)", function()
         local use_case = {
           {


### PR DESCRIPTION
### Summary

Add regression test for an ambiguous router match case involving matching prefixes on non-matching hostnames. 2683b86c2f7680238e3fe85da224d6f077e3425d fixed this issue, but was designed to address a different issue, and did not have tests for this case.

### Full changelog

* Add regression test to router unit tests.