### PR TITLE
feat(acl) reject anonymous consumer

### DIFF
--- a/kong/plugins/acl/handler.lua
+++ b/kong/plugins/acl/handler.lua
@@ -53,12 +53,21 @@ function ACLHandler:access(conf)
       type = config_type,
       groups = config_type == BLACK and conf.blacklist or conf.whitelist,
       cache = setmetatable({}, mt_cache),
+      reject_anonymous = conf.reject_anonymous
     }
 
     config_cache[conf] = config
   end
 
   local to_be_blocked
+
+  -- reject anonymous consumer
+  if config.reject_anonymous then
+    local credential = kong.client.get_credential()
+    if credential and credential.consumer_id == config.reject_anonymous then
+      return kong.response.exit(401, { message = "Unauthorized" })
+    end
+  end
 
   -- get the consumer/credentials
   local consumer_id = groups.get_current_consumer_id()

--- a/kong/plugins/acl/schema.lua
+++ b/kong/plugins/acl/schema.lua
@@ -13,6 +13,7 @@ return {
           { whitelist = { type = "array", elements = { type = "string" }, }, },
           { blacklist = { type = "array", elements = { type = "string" }, }, },
           { hide_groups_header = { type = "boolean", default = false }, },
+          { reject_anonymous = { type = "string", uuid = true }, },
         }
       }
     }


### PR DESCRIPTION
### Summary

We started looking into leveraging the anonymous user functionality in Kong thats native for helping use multiple auth patterns on a given service/route:
https://docs.konghq.com/0.14.x/auth/#multiple-authentication

But we wanted to use OAuth2 + JWT programmatic auth, alongside the ACL plugin to control the proper authorization of given authenticated consumers. This is nice because different consumers can call the same proxy with preferred authentication patterns.

Out of the box what happens when a user is either missing or a bad token when doing the anonymous user pattern with OAuth2 + JWT + ACL plugins is a HTTP Status 403: "You cannot consume this service" response. Which to a client is not technically correct from their perspective with a bad/missing/expired  tokens.

One idea we had would be as the docs state to throw on the request termination plugin to return the error to the anonymous user as the docs mention, but the ACL plugin runs before request termination so thats not possible in our situation unless Kong deems moving priorities of request-termination to come before ACL the appropriate fix and not this pr enhancement(at risk of breaking some other odd flow teams are using that involve both ACL + Request termination now and rely on current orders). Could be a potential breaking change for some folks too. 

Besides the ^, it also isn't ideal because to support OAuth + JWT + ACL is 3 plugins per proxy, and implementing it where the request-termination returns the error message before ACL means a 4th plugin too. Feels kinda odd that the request-termination plugin was where the Kong anonymous user logic was implemented the first time, doesn't it make more sense an ACL plugin would be a more appropriate plugin for user management(such as anonymous user functionality)? 

So ultimately what this enhancement does is says if I see the anonymous user present in the ctx of this transaction then return what a REST client would expect on a missing/expired token request. Whereas a 403 isn't necessarily appropriate to return to a client in the scenario I have described. It makes sense to me that to the calling client, anonymous user functionality should be as transparent as possible.

I had pondered an implementation where we keep the context of the original auth plugin errors even with the anonymous functionality allowing a continuation and then returning their errors but then I realized with multiple auth plugins running on the proxy you can't really know which auth pattern is the right error to return to the consumer so here we are 😀 .

Happy for discussion/feedback!

-Jeremy

### Full changelog

* Implement: reject_anonymous user functionality to return appropriate HTTP Status + Error.
* Testcase Added: /spec/03-plugins/18-acl/02-access_spec.lua