### PR TITLE
chore(deps) update zipkin plugin from 0.1 to 0.2

### DIFF
--- a/kong-1.4.0-0.rockspec
+++ b/kong-1.4.0-0.rockspec
@@ -38,7 +38,7 @@ dependencies = {
   "lua-resty-mlcache == 2.4.0",
   -- external Kong plugins
   "kong-plugin-azure-functions ~> 0.4",
-  "kong-plugin-zipkin ~> 0.1",
+  "kong-plugin-zipkin ~> 0.2",
   "kong-plugin-serverless-functions ~> 0.3",
   "kong-prometheus-plugin ~> 0.6",
   "kong-proxy-cache-plugin ~> 1.2",


### PR DESCRIPTION
### Summary

- Remove dependency on BasePlugin
- Rename `component` tag to `lc`
- Restructure of Kong generated spans
- Change the name of spans for http traffic to `GET`
- Remove the no-longer supported `run_on` field from plugin config schema

Please review, but do not merge yet! I am not sure how removal `run_on` could affect `1.5.0`.