### PR TITLE
chore(ci) build nightly releases from jenkins instead of travis-ci (#…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,6 @@ cache:
 stages:
   - lint and unit
   - test
-  - Deploy daily build
   - Release
 
 jobs:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,236 @@
+pipeline {
+    agent none
+    environment {
+        UPDATE_CACHE = "true"
+        DOCKER_CREDENTIALS = credentials('dockerhub')
+        DOCKER_USERNAME = "${env.DOCKER_CREDENTIALS_USR}"
+        DOCKER_PASSWORD = "${env.DOCKER_CREDENTIALS_PSW}"
+        KONG_PACKAGE_NAME = 'kong'
+        REPOSITORY_OS_NAME = "${env.BRANCH_NAME}"
+    }
+    triggers {
+        cron('@daily')
+    }
+    stages {
+        stage('Build Kong') {
+            agent {
+                node {
+                    label 'docker-compose'
+                }
+            }
+            environment {
+                KONG_SOURCE_LOCATION = "${env.WORKSPACE}"
+                KONG_BUILD_TOOLS_LOCATION = "${env.WORKSPACE}/../kong-build-tools"
+            }
+            steps {
+                sh 'make setup-kong-build-tools'
+                sh 'echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin || true'
+                dir('../kong-build-tools') { sh 'make kong-test-container' }
+            }
+        }
+        stage('Integration Tests') {
+            parallel {
+                stage('dbless') {
+                    agent {
+                        node {
+                            label 'docker-compose'
+                        }
+                    }
+                    environment {
+                        KONG_SOURCE_LOCATION = "${env.WORKSPACE}"
+                        KONG_BUILD_TOOLS_LOCATION = "${env.WORKSPACE}/../kong-build-tools"
+                        TEST_DATABASE = "off"
+                        TEST_SUITE = "dbless"
+                    }
+                    steps {
+                        sh 'make setup-kong-build-tools'
+                        dir('../kong-build-tools') {
+                            sh 'make test-kong'
+                        }
+                    }
+                }
+                stage('postgres') {
+                    agent {
+                        node {
+                            label 'docker-compose'
+                        }
+                    }
+                    environment {
+                        KONG_SOURCE_LOCATION = "${env.WORKSPACE}"
+                        KONG_BUILD_TOOLS_LOCATION = "${env.WORKSPACE}/../kong-build-tools"
+                        TEST_DATABASE = 'postgres'
+                    }
+                    steps {
+                        sh 'make setup-kong-build-tools'
+                        dir('../kong-build-tools') {
+                            sh 'make test-kong'
+                        }
+                    }
+                }
+                stage('postgres plugins') {
+                    agent {
+                        node {
+                            label 'docker-compose'
+                        }
+                    }
+                    environment {
+                        KONG_SOURCE_LOCATION = "${env.WORKSPACE}"
+                        KONG_BUILD_TOOLS_LOCATION = "${env.WORKSPACE}/../kong-build-tools"
+                        TEST_DATABASE = 'postgres'
+                        TEST_SUITE = 'plugins'
+                    }
+                    steps {
+                        sh 'make setup-kong-build-tools'
+                        dir('../kong-build-tools'){
+                            sh 'make test-kong'
+                        }
+                    }
+                }
+                stage('cassandra') {
+                    agent {
+                        node {
+                            label 'docker-compose'
+                        }
+                    }
+                    environment {
+                        KONG_SOURCE_LOCATION = "${env.WORKSPACE}"
+                        KONG_BUILD_TOOLS_LOCATION = "${env.WORKSPACE}/../kong-build-tools"
+                        TEST_DATABASE = 'cassandra'
+                    }
+                    steps {
+                        sh 'make setup-kong-build-tools'
+                        dir('../kong-build-tools'){
+                            sh 'make test-kong'
+                        }
+                    }
+                }
+            }
+        }
+        stage('Nightly Releases') {
+            when {
+                allOf {
+                    triggeredBy 'TimerTrigger'
+                    anyOf { branch 'master'; branch 'next' }
+                }
+            }
+            parallel {
+                stage('Ubuntu Xenial Release') {
+                    agent {
+                        node {
+                            label 'docker-compose'
+                        }
+                    }
+                    options {
+                        retry(2)
+                    }
+                    environment {
+                        PACKAGE_TYPE = 'deb'
+                        RESTY_IMAGE_BASE = 'ubuntu'
+                        RESTY_IMAGE_TAG = 'xenial'
+                        CACHE = 'false'
+                        UPDATE_CACHE = 'true'
+                        USER = 'travis'
+                        KONG_SOURCE_LOCATION = "${env.WORKSPACE}"
+                        KONG_BUILD_TOOLS_LOCATION = "${env.WORKSPACE}/../kong-build-tools"
+                        BINTRAY_USR = 'kong-inc_travis-ci@kong'
+                        BINTRAY_KEY = credentials('bintray_travis_key')
+                        AWS_ACCESS_KEY = credentials('AWS_ACCESS_KEY')
+                        AWS_SECRET_ACCESS_KEY = credentials('AWS_SECRET_ACCESS_KEY')
+                        DOCKER_MACHINE_ARM64_NAME = "jenkins-kong-${env.BUILD_NUMBER}"
+                    }
+                    steps {
+                        sh 'make setup-kong-build-tools'
+                        sh 'mkdir -p $HOME/bin'
+                        sh 'sudo ln -s $HOME/bin/kubectl /usr/local/bin/kubectl'
+                        sh 'sudo ln -s $HOME/bin/kind /usr/local/bin/kind'
+                        dir('../kong-build-tools'){ sh 'make setup-ci' }
+                        sh 'REPOSITORY_NAME=`basename ${GIT_URL%.*}`-nightly KONG_VERSION=`date +%Y-%m-%d` make nightly-release'
+                    }
+                    post {
+                        always {
+                            dir('../kong-build-tools'){ sh 'make cleanup_build' }
+                        }
+                    }
+                }
+                stage('Ubuntu Releases') {
+                    agent {
+                        node {
+                            label 'docker-compose'
+                        }
+                    }
+                    environment {
+                        PACKAGE_TYPE = 'deb'
+                        RESTY_IMAGE_BASE = 'ubuntu'
+                        RESTY_IMAGE_TAG = 'xenial'
+                        KONG_SOURCE_LOCATION = "${env.WORKSPACE}"
+                        KONG_BUILD_TOOLS_LOCATION = "${env.WORKSPACE}/../kong-build-tools"
+                        BINTRAY_USR = 'kong-inc_travis-ci@kong'
+                        BINTRAY_KEY = credentials('bintray_travis_key')
+                        DOCKER_MACHINE_ARM64_NAME = "jenkins-kong-${env.BUILD_NUMBER}"
+                    }
+                    steps {
+                        sh 'make setup-kong-build-tools'
+                        sh 'mkdir -p $HOME/bin'
+                        sh 'sudo ln -s $HOME/bin/kubectl /usr/local/bin/kubectl'
+                        sh 'sudo ln -s $HOME/bin/kind /usr/local/bin/kind'
+                        dir('../kong-build-tools'){ sh 'make setup-ci' }
+                        sh 'REPOSITORY_NAME=`basename ${GIT_URL%.*}`-nightly KONG_VERSION=`date +%Y-%m-%d` RESTY_IMAGE_TAG=trusty BUILDX=false make nightly-release'
+                        sh 'REPOSITORY_NAME=`basename ${GIT_URL%.*}`-nightly KONG_VERSION=`date +%Y-%m-%d` RESTY_IMAGE_TAG=bionic BUILDX=false make nightly-release'
+                    }
+                }
+                stage('Centos Releases') {
+                    agent {
+                        node {
+                            label 'docker-compose'
+                        }
+                    }
+                    environment {
+                        PACKAGE_TYPE = 'rpm'
+                        RESTY_IMAGE_BASE = 'centos'
+                        KONG_SOURCE_LOCATION = "${env.WORKSPACE}"
+                        KONG_BUILD_TOOLS_LOCATION = "${env.WORKSPACE}/../kong-build-tools"
+                        REDHAT_CREDENTIALS = credentials('redhat')
+                        REDHAT_USERNAME = "${env.REDHAT_USR}"
+                        REDHAT_PASSWORD = "${env.REDHAT_PSW}"
+                        BINTRAY_USR = 'kong-inc_travis-ci@kong'
+                        BINTRAY_KEY = credentials('bintray_travis_key')
+                    }
+                    steps {
+                        sh 'make setup-kong-build-tools'
+                        sh 'mkdir -p $HOME/bin'
+                        sh 'sudo ln -s $HOME/bin/kubectl /usr/local/bin/kubectl'
+                        sh 'sudo ln -s $HOME/bin/kind /usr/local/bin/kind'
+                        dir('../kong-build-tools'){ sh 'make setup-ci' }
+                        sh 'REPOSITORY_NAME=`basename ${GIT_URL%.*}`-nightly KONG_VERSION=`date +%Y-%m-%d` RESTY_IMAGE_TAG=6 make nightly-release'
+                        sh 'REPOSITORY_NAME=`basename ${GIT_URL%.*}`-nightly KONG_VERSION=`date +%Y-%m-%d` RESTY_IMAGE_TAG=7 make nightly-release'
+                    }
+                }
+                stage('Debian Releases') {
+                    agent {
+                        node {
+                            label 'docker-compose'
+                        }
+                    }
+                    environment {
+                        PACKAGE_TYPE = 'deb'
+                        RESTY_IMAGE_BASE = 'debian'
+                        KONG_SOURCE_LOCATION = "${env.WORKSPACE}"
+                        KONG_BUILD_TOOLS_LOCATION = "${env.WORKSPACE}/../kong-build-tools"
+                        BINTRAY_USR = 'kong-inc_travis-ci@kong'
+                        BINTRAY_KEY = credentials('bintray_travis_key')
+                    }
+                    steps {
+                        sh 'make setup-kong-build-tools'
+                        sh 'mkdir -p $HOME/bin'
+                        sh 'sudo ln -s $HOME/bin/kubectl /usr/local/bin/kubectl'
+                        sh 'sudo ln -s $HOME/bin/kind /usr/local/bin/kind'
+                        dir('../kong-build-tools'){ sh 'make setup-ci' }
+                        sh 'REPOSITORY_NAME=`basename ${GIT_URL%.*}`-nightly KONG_VERSION=`date +%Y-%m-%d` RESTY_IMAGE_TAG=jessie make nightly-release'
+                        sh 'REPOSITORY_NAME=`basename ${GIT_URL%.*}`-nightly KONG_VERSION=`date +%Y-%m-%d` RESTY_IMAGE_TAG=stretch make nightly-release'
+                        sh 'REPOSITORY_NAME=`basename ${GIT_URL%.*}`-nightly KONG_VERSION=`date +%Y-%m-%d` RESTY_IMAGE_TAG=buster make nightly-release'
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ RESTY_VERSION ?= `grep RESTY_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk
 RESTY_LUAROCKS_VERSION ?= `grep RESTY_LUAROCKS_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
 RESTY_OPENSSL_VERSION ?= `grep RESTY_OPENSSL_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
 RESTY_PCRE_VERSION ?= `grep RESTY_PCRE_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
-KONG_BUILD_TOOLS ?= '2.0.3'
+KONG_BUILD_TOOLS ?= '2.0.5'
 KONG_VERSION ?= `cat $(KONG_SOURCE_LOCATION)/kong-*.rockspec | grep tag | awk '{print $$3}' | sed 's/"//g'`
 OPENRESTY_PATCHES_BRANCH ?= master
 KONG_NGINX_MODULE_BRANCH ?= master
@@ -43,8 +43,8 @@ setup-ci:
 	.ci/setup_env.sh
 
 setup-kong-build-tools:
-	-rm -rf kong-build-tools; \
-	git clone https://github.com/Kong/kong-build-tools.git $(KONG_BUILD_TOOLS_LOCATION); fi
+	-rm -rf $(KONG_BUILD_TOOLS_LOCATION)
+	-git clone https://github.com/Kong/kong-build-tools.git $(KONG_BUILD_TOOLS_LOCATION)
 	cd $(KONG_BUILD_TOOLS_LOCATION); \
 	git reset --hard $(KONG_BUILD_TOOLS); \
 

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -783,7 +783,14 @@ local function mock_reports_server(opts)
       local server = assert(socket.tcp())
       server:settimeout(360)
       assert(server:setoption("reuseaddr", true))
-      assert(server:bind(host, port))
+      local counter = 0
+      while not server:bind(host, port) do
+        counter = counter + 1
+        if counter > 5 then
+          error('could not bind successfully')
+        end
+        socket.sleep(1)
+      end
       assert(server:listen())
       local data = {}
       local handshake_done = false
@@ -839,7 +846,9 @@ local function mock_reports_server(opts)
   local sock = ngx.socket.tcp()
   sock:settimeout(0.01)
   while true do
-    if sock:connect(localhost, server_port) then
+    if not thread:alive() then
+      error('the reports thread died')
+    elseif sock:connect(localhost, server_port) then
       sock:send("\\START\n")
       local ok = sock:receive()
       sock:close()


### PR DESCRIPTION
Moves the kong nightly builds off of travis-ci onto a internal private jenkins instance.

This has been running on a Kong fork for about a week successfully and jenkins is configured in such a way that it will not report failures back to github

![Capture](https://user-images.githubusercontent.com/697188/69359364-72257680-0c56-11ea-8948-619fb37e614f.PNG)
