### PR TITLE
fix(cluster-events) make cluster events more robust and more consistent

### DIFF
--- a/kong/cache.lua
+++ b/kong/cache.lua
@@ -4,7 +4,6 @@ local resty_mlcache = require "resty.mlcache"
 local type    = type
 local max     = math.max
 local ngx_log = ngx.log
-local ngx_now = ngx.now
 local ERR     = ngx.ERR
 local NOTICE  = ngx.NOTICE
 local DEBUG   = ngx.DEBUG
@@ -314,15 +313,15 @@ function _M:invalidate(key)
 
   self:invalidate_local(key)
 
-  local nbf
+  local delay
   if self.propagation_delay > 0 then
-    nbf = ngx_now() + self.propagation_delay
+    delay = self.propagation_delay
   end
 
   log(DEBUG, "broadcasting (cluster) invalidation for key: '", key, "' ",
-             "with nbf: '", nbf or "none", "'")
+             "with delay: '", delay or "none", "'")
 
-  local ok, err = self.cluster_events:broadcast("invalidations", key, nbf)
+  local ok, err = self.cluster_events:broadcast("invalidations", key, delay)
   if not ok then
     log(ERR, "failed to broadcast cached entity invalidation: ", err)
   end

--- a/kong/cluster_events/strategies/cassandra.lua
+++ b/kong/cluster_events/strategies/cassandra.lua
@@ -7,15 +7,30 @@ local setmetatable = setmetatable
 
 local INSERT_QUERY = [[
 INSERT INTO cluster_events(channel, node_id, at, data, id, nbf)
- VALUES(?, ?, ?, ?, uuid(), ?)
- USING TTL %d
+     VALUES (?, ?, %s, ?, uuid(), ?)
+      USING TTL %d
 ]]
 
+
 local SELECT_INTERVAL_QUERY = [[
-SELECT * FROM cluster_events
+SELECT id,
+       node_id,
+       at,
+       nbf,
+       channel,
+       data,
+       toTimestamp(now()) as now
+  FROM cluster_events
  WHERE channel IN ?
-   AND at  >  ?
-   AND at  <= ?
+   AND at >  ?
+   AND at <= %s
+]]
+
+
+local SERVER_TIME_QUERY = [[
+SELECT toTimestamp(now()) as now
+  FROM system.local
+ LIMIT 1
 ]]
 
 
@@ -42,25 +57,38 @@ function _M.should_use_polling()
   return true
 end
 
-
-function _M:insert(node_id, channel, at, data, nbf)
+function _M:insert(node_id, channel, at, data, delay)
   local c_nbf
-  if nbf then
+  if delay then
+    local nbf = self:server_time() + delay
     c_nbf = cassandra.timestamp(nbf * 1000)
 
   else
     c_nbf = cassandra.unset
   end
 
-  local q = fmt(INSERT_QUERY, self.event_ttl)
+  local q, args
+  if at then
+    q = fmt(INSERT_QUERY, "?", self.event_ttl)
+    args = {
+      channel,
+      cassandra.uuid(node_id),
+      cassandra.timestamp(at * 1000),
+      data,
+      c_nbf,
+    }
+  else
 
-  local res, err = self.cluster:execute(q, {
-    channel,
-    cassandra.uuid(node_id),
-    cassandra.timestamp(at * 1000),
-    data,
-    c_nbf,
-  }, {
+    q = fmt(INSERT_QUERY, "toTimestamp(now())", self.event_ttl)
+    args = {
+      channel,
+      cassandra.uuid(node_id),
+      data,
+      c_nbf,
+    }
+  end
+
+  local res, err = self.cluster:execute(q, args, {
     prepared    = true,
     consistency = cassandra.consistencies.local_one,
   })
@@ -73,26 +101,38 @@ end
 
 
 function _M:select_interval(channels, min_at, max_at)
-  local c_min_at = cassandra.timestamp(min_at * 1000)
-  local c_max_at = cassandra.timestamp(max_at * 1000)
-
-  local args = { cassandra.set(channels), c_min_at, c_max_at }
   local opts = {
     prepared    = true,
     page_size   = self.page_size,
     consistency = cassandra.consistencies.local_one,
   }
 
-  local iter, b, c = self.cluster:iterate(SELECT_INTERVAL_QUERY, args, opts)
+  local c_min_at = cassandra.timestamp((min_at or 0) * 1000)
+
+  local query, args
+  if max_at then
+    local c_max_at = cassandra.timestamp(max_at * 1000)
+    args  = { cassandra.set(channels), c_min_at, c_max_at }
+    query = fmt(SELECT_INTERVAL_QUERY, "?")
+  else
+    args  = { cassandra.set(channels), c_min_at }
+    query = fmt(SELECT_INTERVAL_QUERY, "toTimestamp(now())")
+  end
+
+  local iter, b, c  = self.cluster:iterate(query, args, opts)
 
   return function (_, p_rows)
     local rows, err, page = iter(_, p_rows)
 
     if rows then
       for i = 1, #rows do
+        rows[i].at = rows[i].at / 1000
+
         if rows[i].nbf then
           rows[i].nbf = rows[i].nbf / 1000
         end
+
+        rows[i].now = rows[i].now / 1000
       end
     end
 
@@ -103,6 +143,16 @@ end
 
 function _M:truncate_events()
   return self.cluster:execute("TRUNCATE cluster_events")
+end
+
+
+function _M:server_time()
+  local res, err = self.cluster:execute(SERVER_TIME_QUERY)
+  if res then
+    return res[1].now / 1000
+  end
+
+  return nil, err
 end
 
 

--- a/kong/cluster_events/strategies/off.lua
+++ b/kong/cluster_events/strategies/off.lua
@@ -10,7 +10,7 @@ function OffStrategy.should_use_polling()
 end
 
 
-function OffStrategy:insert(node_id, channel, at, data, nbf)
+function OffStrategy:insert(node_id, channel, at, data, delay)
   return true
 end
 
@@ -23,6 +23,11 @@ end
 
 function OffStrategy:truncate_events()
   return true
+end
+
+
+function OffStrategy:server_time()
+  return ngx.now()
 end
 
 

--- a/kong/cluster_events/strategies/postgres.lua
+++ b/kong/cluster_events/strategies/postgres.lua
@@ -1,9 +1,10 @@
 local utils  = require "kong.tools.utils"
 
 
-local max          = math.max
 local fmt          = string.format
+local type         = type
 local null         = ngx.null
+local error        = error
 local concat       = table.concat
 local tonumber     = tonumber
 local setmetatable = setmetatable
@@ -31,9 +32,9 @@ INSERT INTO cluster_events (
 ) VALUES (
   %s,
   %s,
-  TO_TIMESTAMP(%s) AT TIME ZONE 'UTC',
-  TO_TIMESTAMP(%s) AT TIME ZONE 'UTC',
-  TO_TIMESTAMP(%s) AT TIME ZONE 'UTC',
+  %s,
+  %s,
+  CURRENT_TIMESTAMP(3) AT TIME ZONE 'UTC' + INTERVAL '%d second',
   %s,
   %s
 )
@@ -46,14 +47,20 @@ local SELECT_INTERVAL_QUERY = [[
          "channel",
          "data",
          EXTRACT(EPOCH FROM "at"  AT TIME ZONE 'UTC') AS "at",
-         EXTRACT(EPOCH FROM "nbf" AT TIME ZONE 'UTC') AS "nbf"
+         EXTRACT(EPOCH FROM "nbf" AT TIME ZONE 'UTC') AS "nbf",
+         EXTRACT(EPOCH FROM CURRENT_TIMESTAMP(3) AT TIME ZONE 'UTC') AS "now"
     FROM "cluster_events"
    WHERE "channel" IN (%s)
      AND "at" >  TO_TIMESTAMP(%s) AT TIME ZONE 'UTC'
-     AND "at" <= TO_TIMESTAMP(%s) AT TIME ZONE 'UTC'
+     AND "at" <= %s
 ORDER BY "at"
    LIMIT %s
   OFFSET %s
+]]
+
+
+local SERVER_TIME_QUERY = [[
+SELECT EXTRACT(EPOCH FROM CURRENT_TIMESTAMP(3) AT TIME ZONE 'UTC') AS "now"
 ]]
 
 
@@ -83,14 +90,20 @@ function _M.should_use_polling()
 end
 
 
-function _M:insert(node_id, channel, at, data, nbf)
-  local expire_at = max(at + self.event_ttl, at)
-  expire_at = self.connector:escape_literal(tonumber(fmt("%.3f", expire_at)))
+function _M:insert(node_id, channel, at, data, delay)
+  if at then
+    at = fmt("TO_TIMESTAMP(%s) AT TIME ZONE 'UTC'",
+             self.connector:escape_literal(tonumber(fmt("%.3f", at))))
 
-  if not nbf then
-    nbf = "NULL"
   else
-    nbf = self.connector:escape_literal(tonumber(fmt("%.3f", nbf)))
+    at = "CURRENT_TIMESTAMP(3) AT TIME ZONE 'UTC'"
+  end
+
+  local nbf
+  if delay then
+    nbf = fmt("CURRENT_TIMESTAMP(3) AT TIME ZONE 'UTC' + INTERVAL '%d second'", delay)
+  else
+    nbf = "NULL"
   end
 
   local pg_id      = self.connector:escape_literal(utils.uuid())
@@ -98,8 +111,8 @@ function _M:insert(node_id, channel, at, data, nbf)
   local pg_channel = self.connector:escape_literal(channel)
   local pg_data    = self.connector:escape_literal(data)
 
-  local q = fmt(INSERT_QUERY, pg_id, pg_node_id, at, nbf, expire_at,
-                pg_channel, pg_data)
+  local q = fmt(INSERT_QUERY, pg_id, pg_node_id, at, nbf, self.event_ttl,
+                              pg_channel, pg_data)
 
   local res, err = self.connector:query(q)
   if not res then
@@ -113,23 +126,35 @@ end
 function _M:select_interval(channels, min_at, max_at)
   local n_chans = #channels
   local p_chans = new_tab(n_chans, 0)
-  local p_minat = self.connector:escape_literal(tonumber(fmt("%.3f", min_at)))
-  local p_maxat = self.connector:escape_literal(tonumber(fmt("%.3f", max_at)))
 
   for i = 1, n_chans do
     p_chans[i] = self.connector:escape_literal(channels[i])
   end
 
-  local query_template = fmt(SELECT_INTERVAL_QUERY,
-                             concat(p_chans, ", "),
-                             p_minat,
-                             p_maxat,
-                             self.page_size,
-                             "%s")
+  p_chans = concat(p_chans, ", ")
+
+  local p_minat = self.connector:escape_literal(tonumber(fmt("%.3f", min_at or 0)))
+  local p_maxat
+  if max_at then
+    p_maxat = fmt("TO_TIMESTAMP(%s) AT TIME ZONE 'UTC'",
+                  self.connector:escape_literal(tonumber(fmt("%.3f", max_at))))
+  else
+    p_maxat = "CURRENT_TIMESTAMP(3) AT TIME ZONE 'UTC'"
+  end
+
+  local query_template = fmt(SELECT_INTERVAL_QUERY, p_chans,
+                                                    p_minat,
+                                                    p_maxat,
+                                                    self.page_size,
+                                                    "%s")
 
   local page = 0
-
+  local last_page
   return function()
+    if last_page then
+      return nil
+    end
+
     local offset = page * self.page_size
     local q = fmt(query_template, offset)
 
@@ -144,10 +169,13 @@ function _M:select_interval(channels, min_at, max_at)
     end
 
     for i = 1, len do
-      local row = res[i]
-      if row.nbf == null then
-        row.nbf = nil
+      if res[i].nbf == null then
+        res[i].nbf = nil
       end
+    end
+
+    if len < self.page_size then
+      last_page = true
     end
 
     page = page + 1
@@ -159,6 +187,16 @@ end
 
 function _M:truncate_events()
   return self.connector:query("TRUNCATE cluster_events")
+end
+
+
+function _M:server_time()
+  local res, err = self.connector:query(SERVER_TIME_QUERY)
+  if res then
+    return res[1].now
+  end
+
+  return nil, err
 end
 
 

--- a/spec/02-integration/06-invalidations/01-cluster_events_spec.lua
+++ b/spec/02-integration/06-invalidations/01-cluster_events_spec.lua
@@ -284,7 +284,7 @@ for _, strategy in helpers.each_strategy() do
         end)
       end)
 
-      it("broadcasts an event with a `nbf` (not before) field", function()
+      it("broadcasts an event with a delay", function()
         local cluster_events_1 = assert(kong_cluster_events.new {
           db = db,
           node_id = uuid_1,
@@ -298,9 +298,8 @@ for _, strategy in helpers.each_strategy() do
         assert(cluster_events_1:subscribe("nbf_channel", cb, false)) -- false to not start auto polling
 
         local delay = 1
-        local nbf = ngx.now() + delay
 
-        assert(cluster_events_2:broadcast("nbf_channel", "hello world", nbf))
+        assert(cluster_events_2:broadcast("nbf_channel", "hello world", delay))
 
         assert(cluster_events_1:poll())
         assert.spy(spy_func).was_not_called() -- not called yet


### PR DESCRIPTION
### Summary

The current implementation of cluster events (before this PR) uses `ngx.now()` a lot when inserting and reading data from `cluster_events`. This can lead to various hard to debug issues as there can be a clock skew between the nodes.

Issues like:

1. writer being in future making the readers not to pick events
2. writer being in past making the readers skip events
3. cleanup routine may delete entries the readers have not applied

This PR changes the cluster events to use `cassandra` or `postgres` server time on `inserting` and on `selects`. There is some fall-back code to `ngx.now()` but they should almost never be used (only in cases where there is a temporary communication issue with db).

This also makes nodes, even with clock skew, more consistent.

Unfortunately it is hard to write test cases for this, but the changes do pass the current test suite.

There is one slight change in interface of `cluter_events:broadcast` to be noted:

Previous:
```
function _M:broadcast(channel, data, nbf)
```

New:
```
function _M:broadcast(channel, data, delay)
```

Where `nbf` is exact time, but `delay` is relative. This was AFAIK only used internally.

This issue was reported internally on an environment that did not implement proper clock syncs across the cluster.