### PR TITLE
feat(runloop) upstream redirects

### DIFF
--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -298,6 +298,7 @@ http {
                         ["/basic-auth/:user/:pass"]     = "Performs HTTP basic authentication with the given credentials",
                         ["/status/:code"]               = "Returns a response with the specified <status code>",
                         ["/stream/:num"]                = "Stream <num> chunks of JSON data via chunked Transfer Encoding",
+                        ["/redirect/:num"]              = "Returns a redirect code with <num> status. Responds with the request's location header",
                     },
                 })
             }
@@ -488,6 +489,28 @@ http {
             content_by_lua_block {
                 local mu = require "spec.fixtures.mock_upstream"
                 return mu.reset_log(ngx.var.logname)
+            }
+        }
+
+
+        location ~ "^/redirect/(?<code>\d{3})$" {
+            content_by_lua_block {
+                local code = tonumber(ngx.var.code)
+                if not code then
+                    return ngx.exit(ngx.HTTP_NOT_FOUND)
+                end
+                ngx.status = code
+
+                local response_headers = {}
+                local h = ngx.req.get_headers()
+                if h.location then
+                  response_headers.location = h.location
+                end
+
+                local mu = require "spec.fixtures.mock_upstream"
+                return mu.send_default_json_response({
+                  code = code,
+                }, response_headers)
             }
         }
     }


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Alters the Location response header returned by Upstreams in a very specific case, when the host:port coincides with the matched one by the router.

### Full changelog

In addition to the `feat` change itself, this PR includes a couple changes in the tests.

### Issues resolved

Fixes (partially) #839
