### PR TITLE
fix(migrations) oauth2 tokens ttl was incorrectly migrated

### DIFF
--- a/kong/plugins/oauth2/migrations/001_14_to_15.lua
+++ b/kong/plugins/oauth2/migrations/001_14_to_15.lua
@@ -43,7 +43,8 @@ return {
       DO $$
       BEGIN
         UPDATE "oauth2_tokens"
-           SET "ttl" = "created_at" + (COALESCE("expires_in", 0)::TEXT || ' seconds')::INTERVAL;
+           SET "ttl" = "created_at" + (COALESCE("expires_in", 0)::TEXT || ' seconds')::INTERVAL
+         WHERE "expires_in" > 0;
       EXCEPTION WHEN UNDEFINED_COLUMN OR UNDEFINED_TABLE THEN
         -- Do nothing, accept existing state
       END$$;


### PR DESCRIPTION
### Summary

This PR was originally send as #4588, but merge conflict was probably wrongly resolved, so this change got missing. Here is another try to get this in.

### Issues resolved

Fix #4572, #5242