### PR TITLE
feat(release) setup signed rpm packages on daily releases

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -194,6 +194,8 @@ pipeline {
                         REDHAT_PASSWORD = "${env.REDHAT_PSW}"
                         BINTRAY_USR = 'kong-inc_travis-ci@kong'
                         BINTRAY_KEY = credentials('bintray_travis_key')
+                        PRIVATE_KEY_FILE = credentials('kong.private.gpg-key.asc')
+                        PRIVATE_KEY_PASSPHRASE = credentials('kong.private.gpg-key.asc.password')
                     }
                     steps {
                         sh 'make setup-kong-build-tools'
@@ -201,6 +203,7 @@ pipeline {
                         sh 'sudo ln -s $HOME/bin/kubectl /usr/local/bin/kubectl'
                         sh 'sudo ln -s $HOME/bin/kind /usr/local/bin/kind'
                         dir('../kong-build-tools'){ sh 'make setup-ci' }
+                        sh 'cp $PRIVATE_KEY_FILE ../kong-build-tools/kong.private.gpg-key.asc'
                         sh 'REPOSITORY_NAME=`basename ${GIT_URL%.*}`-nightly KONG_VERSION=`date +%Y-%m-%d` RESTY_IMAGE_TAG=6 make nightly-release'
                         sh 'REPOSITORY_NAME=`basename ${GIT_URL%.*}`-nightly KONG_VERSION=`date +%Y-%m-%d` RESTY_IMAGE_TAG=7 make nightly-release'
                     }

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ functional-tests: setup-kong-build-tools
 	$(MAKE) build-kong && \
 	$(MAKE) test
 
-nightly-release: setup-kong-build-tools
+nightly-release:
 	sed -i -e '/return string\.format/,/\"\")/c\return "$(KONG_VERSION)\"' kong/meta.lua && \
 	cd $(KONG_BUILD_TOOLS_LOCATION); \
 	$(MAKE) package-kong && \


### PR DESCRIPTION
By dropping the signing key in the right place and setting the `PRIVATE_KEY_PASSPHRASE` we now have signed releases.

```
hutchic@colin-usb:~/Downloads$ rpm -K kong-2019-11-26.el6.amd64.rpm 
kong-2019-11-26.el6.amd64.rpm: RSA sha1 ((MD5) PGP) md5 NOT OK (MISSING KEYS: (MD5) PGP#1d5f3726) 
hutchic@colin-usb:~/Downloads$ curl -o kong.key https://bintray.com/user/downloadSubjectPublicKey?username=kong
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3173    0  3173    0     0   5873      0 --:--:-- --:--:-- --:--:--  5865
hutchic@colin-usb:~/Downloads$ rpm --import kong.
kong.key                  kong.private.gpg-key.asc  kong.rpm                  
hutchic@colin-usb:~/Downloads$ rpm --import kong.key 
hutchic@colin-usb:~/Downloads$ rpm -K kong-2019-11-26.el6.amd64.rpm 
kong-2019-11-26.el6.amd64.rpm: rsa sha1 (md5) pgp md5 OK
```

Right now this only applies to our daily releases