### PR TITLE
feat(oauth2) add ability to persist refresh tokens

### DIFF
--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -52,10 +52,9 @@ end
 
 
 local function generate_token(conf, service, credential, authenticated_userid,
-                              scope, state, existing_token, expiration,
-                              disable_refresh)
+                              scope, state, disable_refresh, existing_token)
 
-  local token_expiration = expiration or conf.token_expiration
+  local token_expiration = conf.token_expiration
 
   local refresh_token_ttl
   if conf.refresh_token_ttl and conf.refresh_token_ttl > 0 then
@@ -289,7 +288,7 @@ local function authorize(conf)
           response_params = generate_token(conf, kong.router.get_service(),
                                            client,
                                            parameters[AUTHENTICATED_USERID],
-                                           scopes, state, nil, nil, true)
+                                           scopes, state, true)
           is_implicit_grant = true
         end
       end
@@ -507,7 +506,7 @@ local function issue_token(conf)
             response_params = generate_token(conf, kong.router.get_service(),
                                              client,
                                              parameters.authenticated_userid,
-                                             scope, state, nil, nil, true)
+                                             scope, state, true)
           end
         end
 
@@ -570,7 +569,7 @@ local function issue_token(conf)
             response_params = generate_token(conf, kong.router.get_service(),
                                              client,
                                              token.authenticated_userid,
-                                             token.scope, state, token)
+                                             token.scope, state, false, token)
             -- Delete old token if refresh token not persisted
             if not conf.persistent_refresh_token then
               kong.db.oauth2_tokens:delete({ id = token.id })

--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -68,7 +68,7 @@ local function generate_token(conf, service, credential, authenticated_userid,
 
   local refresh_token
   local token, err
-  if existing_token and conf.persistent_refresh_token then
+  if existing_token and conf.reuse_refresh_token then
     token, err = kong.db.oauth2_tokens:update({
       id = existing_token.id
     }, {
@@ -571,7 +571,7 @@ local function issue_token(conf)
                                              token.authenticated_userid,
                                              token.scope, state, false, token)
             -- Delete old token if refresh token not persisted
-            if not conf.persistent_refresh_token then
+            if not conf.reuse_refresh_token then
               kong.db.oauth2_tokens:delete({ id = token.id })
             end
           end

--- a/kong/plugins/oauth2/schema.lua
+++ b/kong/plugins/oauth2/schema.lua
@@ -34,7 +34,7 @@ return {
           { global_credentials = { type = "boolean", default = false }, },
           { auth_header_name = { type = "string", default = "authorization" }, },
           { refresh_token_ttl = { type = "number", default = 1209600, required = true }, },
-          { persistent_refresh_token = { type = "boolean", default = false, required = false }, },
+          { reuse_refresh_token = { type = "boolean", default = false, required = false }, },
         },
         custom_validator = validate_flows,
         entity_checks = {

--- a/kong/plugins/oauth2/schema.lua
+++ b/kong/plugins/oauth2/schema.lua
@@ -34,6 +34,7 @@ return {
           { global_credentials = { type = "boolean", default = false }, },
           { auth_header_name = { type = "string", default = "authorization" }, },
           { refresh_token_ttl = { type = "number", default = 1209600, required = true }, },
+          { persistent_refresh_token = { type = "boolean", default = false, required = false }, },
         },
         custom_validator = validate_flows,
         entity_checks = {

--- a/spec/03-plugins/25-oauth2/01-schema_spec.lua
+++ b/spec/03-plugins/25-oauth2/01-schema_spec.lua
@@ -72,6 +72,13 @@ for _, strategy in helpers.each_strategy() do
       assert.is_falsy(errors)
       assert.equal(1209600, t2.config.refresh_token_ttl)
     end)
+    it("defaults to non-persistent refresh tokens", function()
+      local t = {enable_authorization_code = true, mandatory_scope = false}
+      local t2, errors = v(t, schema_def)
+      assert.truthy(t2)
+      assert.is_falsy(errors)
+      assert.equal(false, t2.config.persistent_refresh_token)
+    end)
 
     describe("errors", function()
       it("requires at least one flow", function()

--- a/spec/03-plugins/25-oauth2/01-schema_spec.lua
+++ b/spec/03-plugins/25-oauth2/01-schema_spec.lua
@@ -77,7 +77,7 @@ for _, strategy in helpers.each_strategy() do
       local t2, errors = v(t, schema_def)
       assert.truthy(t2)
       assert.is_falsy(errors)
-      assert.equal(false, t2.config.persistent_refresh_token)
+      assert.equal(false, t2.config.reuse_refresh_token)
     end)
 
     describe("errors", function()

--- a/spec/03-plugins/25-oauth2/03-access_spec.lua
+++ b/spec/03-plugins/25-oauth2/03-access_spec.lua
@@ -380,7 +380,7 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
         config   = {
           scopes                   = { "email", "profile", "user.email" },
           global_credentials       = true,
-          persistent_refresh_token = true,
+          reuse_refresh_token = true,
         },
       })
 


### PR DESCRIPTION
### Summary
Add support for persisting oauth2 refresh tokens. Follows guidelines in [RFC6749](https://tools.ietf.org/html/rfc6749#section-6) to allow for the optional persistence of the refresh token when refreshing an access token.

### Related discussion
https://discuss.konghq.com/t/long-lived-refresh-tokens/659
https://discuss.konghq.com/t/long-lived-oauth-2-refresh-tokens/3005
