### PR TITLE
chore(release) drop trusty as a release target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,12 +81,6 @@ jobs:
       - make setup-kong-build-tools
       - pushd ../kong-build-tools && make setup-ci && popd
       - make release
-      env: PACKAGE_TYPE=deb RESTY_IMAGE_BASE=ubuntu RESTY_IMAGE_TAG=trusty KONG_PACKAGE_NAME=${PWD##*/} KONG_VERSION=${TRAVIS_TAG}
-      if: tag IS present AND tag ~= 1.
-    - script:
-      - make setup-kong-build-tools
-      - pushd ../kong-build-tools && make setup-ci && popd
-      - make release
       env: PACKAGE_TYPE=deb RESTY_IMAGE_BASE=ubuntu RESTY_IMAGE_TAG=xenial KONG_PACKAGE_NAME=${PWD##*/} KONG_VERSION=${TRAVIS_TAG}
       if: tag IS present AND tag ~= 1.
     - script:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -174,7 +174,6 @@ pipeline {
                         sh 'sudo ln -s $HOME/bin/kubectl /usr/local/bin/kubectl'
                         sh 'sudo ln -s $HOME/bin/kind /usr/local/bin/kind'
                         dir('../kong-build-tools'){ sh 'make setup-ci' }
-                        sh 'REPOSITORY_NAME=`basename ${GIT_URL%.*}`-nightly KONG_VERSION=`date +%Y-%m-%d` RESTY_IMAGE_TAG=trusty BUILDX=false make nightly-release'
                         sh 'REPOSITORY_NAME=`basename ${GIT_URL%.*}`-nightly KONG_VERSION=`date +%Y-%m-%d` RESTY_IMAGE_TAG=bionic BUILDX=false make nightly-release'
                     }
                 }


### PR DESCRIPTION
Trusty standard support ended on April 2019 ( https://wiki.ubuntu.com/Releases ) it's time we stop building Kong trusty packages

hold until https://github.com/Kong/kong-build-tools/pull/167 is merged / released