### PR TITLE
fix(acl) reject anonymous consumer

### DIFF
--- a/kong/plugins/acl/handler.lua
+++ b/kong/plugins/acl/handler.lua
@@ -39,7 +39,7 @@ local ACLHandler = {}
 
 
 ACLHandler.PRIORITY = 950
-ACLHandler.VERSION = "2.1.0"
+ACLHandler.VERSION = "2.2.0"
 
 
 function ACLHandler:access(conf)
@@ -59,6 +59,10 @@ function ACLHandler:access(conf)
   end
 
   local to_be_blocked
+
+  if not kong.client.get_credential() and not ngx.ctx.authenticated_groups then
+    return kong.response.exit(401, { message = "Unauthorized" })
+  end
 
   -- get the consumer/credentials
   local consumer_id = groups.get_current_consumer_id()

--- a/spec/03-plugins/18-acl/02-access_spec.lua
+++ b/spec/03-plugins/18-acl/02-access_spec.lua
@@ -758,9 +758,9 @@ for _, strategy in helpers.each_strategy() do
             ["Host"] = "acl1.com"
           }
         }))
-        local body = assert.res_status(403, res)
+        local body = assert.res_status(401, res)
         local json = cjson.decode(body)
-        assert.same({ message = "You cannot consume this service" }, json)
+        assert.same({ message = "Unauthorized" }, json)
       end)
 
       it("should fail when not in whitelist", function()
@@ -1259,9 +1259,9 @@ for _, strategy in helpers.each_strategy() do
             ["Host"] = "acl13.com"
           }
         }))
-        local body = assert.res_status(403, res)
+        local body = assert.res_status(401, res)
         local json = cjson.decode(body)
-        assert.same({ message = "You cannot consume this service" }, json)
+        assert.same({ message = "Unauthorized" }, json)
       end)
     end)
   end)


### PR DESCRIPTION
Previous PR related: https://github.com/Kong/kong/pull/5236

Summary(Copied from prior PR)
We started looking into leveraging the anonymous user functionality in Kong thats native for helping use multiple auth patterns on a given service/route:
https://docs.konghq.com/0.14.x/auth/#multiple-authentication

But we wanted to use OAuth2 + JWT programmatic auth, alongside the ACL plugin to control the proper authorization of given authenticated consumers. This is nice because different consumers can call the same proxy with preferred authentication patterns.

Out of the box what happens when a user is either missing or a bad token when doing the anonymous user pattern with OAuth2 + JWT + ACL plugins is a HTTP Status 403: "You cannot consume this service" response. Which to a client is not technically correct from their perspective with a bad/missing/expired tokens.

Full changelog
Implement: Modified handler.lua to change ACL behavior to support 401 for no credentials and no authenticated groups(Such as the anon user)
Testcases Modified: /spec/03-plugins/18-acl/02-access_spec.lua

Fix #4480

cc @hishamhm @bungle 