### PR TITLE
fix(balancer): old_history can be nil

### DIFF
--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -468,7 +468,7 @@ local function check_target_history(upstream, balancer)
     return nil, err
   end
 
-  local old_history = target_histories[balancer]
+  local old_history = target_histories[balancer] or {}
 
   -- check history state
   local old_size = #old_history


### PR DESCRIPTION
# Summary

Fix an exception that's caused by the nil `old_history`in the balancer.

### Issues resolved
Related error log:
```log
*25658569 [lua] events.lua:194: do_handlerlist(): worker-events: event callback failed; source=balancer, event=targets, pid=1321 error='/usr/local/share/lua/5.1/kong/runloop/balancer.lua:474: attempt to get length of local 'old_history' (a nil value)
stack traceback:
	/usr/local/share/lua/5.1/kong/runloop/balancer.lua:474: in function 'check_target_history'
	/usr/local/share/lua/5.1/kong/runloop/balancer.lua:629: in function 'do_target_event'
	/usr/local/share/lua/5.1/kong/runloop/balancer.lua:648: in function 'on_target_event'
	/usr/local/share/lua/5.1/kong/runloop/handler.lua:331: in function </usr/local/share/lua/5.1/kong/runloop/handler.lua:326>
	[C]: in function 'xpcall'
	/usr/local/share/lua/5.1/resty/worker/events.lua:185: in function 'do_handlerlist'
	/usr/local/share/lua/5.1/resty/worker/events.lua:219: in function 'do_event_json'
	/usr/local/share/lua/5.1/resty/worker/events.lua:361: in function 'post'
	/usr/local/share/lua/5.1/kong/runloop/handler.lua:347: in function </usr/local/share/lua/5.1/kong/runloop/handler.lua:336>
	[C]: in function 'pcall'
	/usr/local/share/lua/5.1/kong/cluster_events/init.lua:267: in function </usr/local/share/lua/5.1/kong/cluster_events/init.lua:209>
	[C]: in function 'pcall'
	/usr/local/share/lua/5.1/kong/cluster_events/init.lua:360: in function </usr/local/share/lua/5.1/kong/cluster_events/init.lua:343>', data={"operation":"create","entity":{"upstream":{"id":"3b147967-b173-43a9-9b61-eef204cffe76"}}}, context: ngx.timer
```

(Maybe) the cause of the nil target_history:

Under some concurrent circumstances, for some balancer, the item in the `target_histories` table is nil while the one in the `balancers` is not, then the `attempt to get length of local 'old_history' (a nil value)` error happened, causing the target event not handled properly.

```lua
local function set_balancer(upstream_id, balancer)
  local prev = balancers[upstream_id]
  if prev then
    healthcheckers[prev] = nil
    healthchecker_callbacks[prev] = nil
    target_histories[prev] = nil <-- target_histories updated here
    upstream_ids[prev] = nil
  end
  balancers[upstream_id] = balancer <-- balancer updated later
end
```
