### PR TITLE
fix(http-log) do not impose a retry delay on successful sends

### DIFF
--- a/kong/tools/batch_queue.lua
+++ b/kong/tools/batch_queue.lua
@@ -173,9 +173,9 @@ process = function(premature, self, batch)
   local next_retry_delay
 
   local ok, err = self.process(batch.entries)
-  if ok then -- success, set retry_delays to 1
+  if ok then -- success, reset retry delays
     self.retry_delay = 1
-    next_retry_delay = 1
+    next_retry_delay = 0
 
   else
     batch.retries = batch.retries + 1


### PR DESCRIPTION
The exponential backoff should only be applied in case of failures to send. Starting the delay value from 1 was forcing a 1 second delay between sends (even in non-batched mode).
