### PR TITLE
fix(balancer) handle errors when creating balancer properly

### DIFF
--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -161,7 +161,6 @@ end
 -- @param rb ring balancer object
 -- @param history list of targets/transactions to be applied
 -- @param start the index where to start in the `history` parameter
--- @return true
 local function apply_history(rb, history, start)
 
   for i = start, #history do
@@ -180,8 +179,6 @@ local function apply_history(rb, history, start)
       order = target.order,
     }
   end
-
-  return true
 end
 
 
@@ -231,6 +228,9 @@ do
     -- @param hostname string
     local function ring_balancer_callback(balancer, action, address, ip, port, hostname)
       local healthchecker = healthcheckers[balancer]
+      if not healthchecker then
+        return
+      end
 
       if action == "health" then
         local balancer_status
@@ -356,7 +356,6 @@ do
       })
 
       if not healthchecker then
-        log(ERR, "[healthchecks] error creating health checker: ", err)
         return nil, err
       end
 
@@ -366,6 +365,8 @@ do
 
       -- only enable the callback after the target history has been replayed.
       balancer:setCallback(ring_balancer_callback)
+
+      return true
     end
   end
 
@@ -390,12 +391,56 @@ do
     return nil, "timeout"
   end
 
-  local function invalidate_upstream_caches(upstream_id)
-    singletons.cache:invalidate_local("balancer:upstreams:" .. upstream_id)
-    singletons.cache:invalidate_local("balancer:targets:" .. upstream_id)
+  ------------------------------------------------------------------------------
+  -- The mutually-exclusive section used internally by the
+  -- 'create_balancer' operation.
+  -- @param upstream (table) A db.upstreams entity
+  -- @param history (table, optional) history of target updates
+  -- @param start (integer, optional) from where to start reading the history
+  -- @return The new balancer object, or nil+error
+  local function create_balancer_exclusive(upstream, history, start)
+    local balancer, err = balancer_types[upstream.algorithm].new({
+      wheelSize = upstream.slots,  -- will be ignored by least-connections
+      dns = dns_client,
+    })
+    if not balancer then
+      return nil, "failed creating balancer:" .. err
+    end
+
+    singletons.cache:invalidate_local("balancer:upstreams:" .. upstream.id)
+    singletons.cache:invalidate_local("balancer:targets:" .. upstream.id)
+
+    target_histories[balancer] = {}
+
+    if not history then
+      history, err = fetch_target_history(upstream)
+      if not history then
+        return nil, "failed fetching target history:" .. err
+      end
+      start = 1
+    end
+
+    apply_history(balancer, history, start)
+
+    upstream_ids[balancer] = upstream.id
+
+    local ok, err = create_healthchecker(balancer, upstream)
+    if not ok then
+      log(ERR, "[healthchecks] error creating health checker: ", err)
+    end
+
+    -- only make the new balancer available for other requests after it
+    -- is fully set up.
+    set_balancer(upstream.id, balancer)
+
+    return balancer
   end
 
   ------------------------------------------------------------------------------
+  -- Create a balancer object, its healthchecker and attach them to the
+  -- necessary data structures. The creation of the balancer happens in a
+  -- per-worker mutual exclusion section, such that no two requests create the
+  -- same balancer at the same time.
   -- @param upstream (table) A db.upstreams entity
   -- @param recreate (boolean, optional) create new balancer even if one exists
   -- @param history (table, optional) history of target updates
@@ -417,40 +462,11 @@ do
 
     creating[upstream.id] = true
 
-    local balancer, err = balancer_types[upstream.algorithm].new({
-      wheelSize = upstream.slots,  -- will be ignored by least-connections
-      dns = dns_client,
-    })
-
-    if not balancer then
-      return nil, err
-    end
-
-    invalidate_upstream_caches(upstream.id)
-
-    target_histories[balancer] = {}
-
-    if not history then
-      history, err = fetch_target_history(upstream)
-      if not history then
-        return nil, err
-      end
-      start = 1
-    end
-
-    apply_history(balancer, history, start)
-
-    upstream_ids[balancer] = upstream.id
-
-    create_healthchecker(balancer, upstream)
-
-    -- only make the new balancer available for other requests after it
-    -- is fully set up.
-    set_balancer(upstream.id, balancer)
+    local balancer, err = create_balancer_exclusive(upstream, history, start)
 
     creating[upstream.id] = nil
 
-    return balancer
+    return balancer, err
   end
 end
 


### PR DESCRIPTION
* Do not leave the `creating` flag behind when the balancer fails to create.
  This includes a refactor to ensure that the mutually-exclusive section of the
  balancer creation always releases the flag, so that this doesn't happen again.
* Make more explicit the fact that we carry on if the healthchecker fails, by
  logging it on `create_balancer`
* Add a sanity check in the ring balancer callback to ensure balancers and
  healthcheckers are in sync, as already happens in other parts of the code.

Fix #5189
Fix #5283
