### PR TITLE
fix(cache) same invalidation sent multiple times

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -188,20 +188,24 @@ local function register_events()
     -- caching key
 
     local cache_key = db[data.schema.name]:cache_key(data.entity)
+    local cache_obj
+    if constants.CORE_ENTITIES[data.schema.name] then
+      cache_obj = core_cache
+    else
+      cache_obj = cache
+    end
 
     if cache_key then
-      cache:invalidate(cache_key)
-      core_cache:invalidate(cache_key)
+      cache_obj:invalidate(cache_key)
     end
 
     -- if we had an update, but the cache key was part of what was updated,
     -- we need to invalidate the previous entity as well
 
     if data.old_entity then
-      cache_key = db[data.schema.name]:cache_key(data.old_entity)
-      if cache_key then
-        cache:invalidate(cache_key)
-        core_cache:invalidate(cache_key)
+      local old_cache_key = db[data.schema.name]:cache_key(data.old_entity)
+      if old_cache_key and cache_key ~= old_cache_key then
+        cache_obj:invalidate(old_cache_key)
       end
     end
 

--- a/spec/fixtures/custom_plugins/kong/plugins/invalidations/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/invalidations/handler.lua
@@ -1,0 +1,25 @@
+local kong = kong
+local assert = assert
+
+
+local counts = {}
+
+
+local Invalidations = {
+  PRIORITY = 0
+}
+
+
+function Invalidations:init_worker()
+  assert(kong.cluster_events:subscribe("invalidations", function(key)
+    counts[key] = (counts[key] or 0) + 1
+  end))
+end
+
+
+function Invalidations:access(_)
+  return kong.response.exit(200, counts)
+end
+
+
+return Invalidations

--- a/spec/fixtures/custom_plugins/kong/plugins/invalidations/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/invalidations/schema.lua
@@ -1,0 +1,27 @@
+local typedefs = require "kong.db.schema.typedefs"
+
+
+return {
+  name = "invalidations",
+  fields = {
+    {
+      protocols = typedefs.protocols {
+        default = {
+          "http",
+          "https",
+          "tcp",
+          "tls",
+          "grpc",
+          "grpcs"
+        },
+      },
+    },
+    {
+      config = {
+        type = "record",
+        fields = {
+        },
+      },
+    },
+  },
+}


### PR DESCRIPTION
### Summary

A single `patch` on e.g. `service` entity may cause four cluster events fired, out of which all four are the same. This was doubled because the #5114 introduced the core cache / plugins cache split.

This PR also adds a guard on `patches`: when the entity and old entity cache keys are the same, only one invalidation event is sent.