### PR TITLE
chore(ci) small Makefile command typo

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -148,7 +148,7 @@ pipeline {
                     }
                     post {
                         always {
-                            dir('../kong-build-tools'){ sh 'make cleanup_build' }
+                            dir('../kong-build-tools'){ sh 'make cleanup-build' }
                         }
                     }
                 }


### PR DESCRIPTION
kong-build-tools uses dashes instead of underscores consistently now