### PR TITLE
fix(schema) service host cannot have port

### DIFF
--- a/kong/db/schema/entities/services.lua
+++ b/kong/db/schema/entities/services.lua
@@ -31,7 +31,7 @@ return {
     { retries            = { type = "integer", default = 5, between = { 0, 32767 } }, },
     -- { tags             = { type = "array", array = { type = "string" } }, },
     { protocol           = typedefs.protocol { required = true, default = default_protocol } },
-    { host               = typedefs.host_with_optional_port { required = true } },
+    { host               = typedefs.host { required = true } },
     { port               = typedefs.port { required = true, default = default_port }, },
     { path               = typedefs.path },
     { connect_timeout    = nonzero_timeout { default = 60000 }, },

--- a/spec/01-unit/01-db/01-schema/05-services_spec.lua
+++ b/spec/01-unit/01-db/01-schema/05-services_spec.lua
@@ -337,8 +337,18 @@ describe("services", function()
 
         local ok, err = Services:validate(service)
         assert.falsy(ok)
-        assert.equal("invalid hostname: " .. invalid_hosts[i], err.host)
+        assert.equal("invalid value: " .. invalid_hosts[i], err.host)
       end
+    end)
+
+    it("rejects values with a valid port", function()
+      local service = {
+        host = "example.com:80",
+      }
+
+      local ok, err = Services:validate(service)
+      assert.falsy(ok)
+      assert.equal("must not have a port", err.host)
     end)
 
     it("rejects values with an invalid port", function()
@@ -348,7 +358,7 @@ describe("services", function()
 
       local ok, err = Services:validate(service)
       assert.falsy(ok)
-      assert.equal("invalid port number", err.host)
+      assert.equal("must not have a port", err.host)
     end)
 
     -- acceptance


### PR DESCRIPTION
### Summary

PR #5102 changed service entity where it added optional `port` to `service.host`. This is not actually used, and is wrong as the service also has `service.port` for that. Thus this PR returns that back to original, that is `service.host` cannot contain `port`.
