### PR TITLE
fix(schema) service url should cleanup existing url components

### DIFF
--- a/kong/db/schema/entities/services.lua
+++ b/kong/db/schema/entities/services.lua
@@ -3,10 +3,19 @@ local Schema = require "kong.db.schema"
 local url = require "socket.url"
 
 
+local tostring = tostring
+local tonumber = tonumber
+local null = ngx.null
+
+
 local nonzero_timeout = Schema.define {
   type = "integer",
   between = { 1, math.pow(2, 31) - 2 },
 }
+
+
+local default_protocol = "http"
+local default_port = 80
 
 
 return {
@@ -21,9 +30,9 @@ return {
     { name               = typedefs.name },
     { retries            = { type = "integer", default = 5, between = { 0, 32767 } }, },
     -- { tags             = { type = "array", array = { type = "string" } }, },
-    { protocol           = typedefs.protocol { required = true, default = "http" } },
+    { protocol           = typedefs.protocol { required = true, default = default_protocol } },
     { host               = typedefs.host_with_optional_port { required = true } },
-    { port               = typedefs.port { required = true, default = 80 }, },
+    { port               = typedefs.port { required = true, default = default_port }, },
     { path               = typedefs.path },
     { connect_timeout    = nonzero_timeout { default = 60000 }, },
     { write_timeout      = nonzero_timeout { default = 60000 }, },
@@ -37,11 +46,11 @@ return {
     { conditional = { if_field = "protocol",
                       if_match = { one_of = { "tcp", "tls", "grpc", "grpcs" }},
                       then_field = "path",
-                      then_match = { eq = ngx.null }}},
+                      then_match = { eq = null }}},
     { conditional = { if_field = "protocol",
                       if_match = { ne = "https" },
                       then_field = "client_certificate",
-                      then_match = { eq = ngx.null }}},
+                      then_match = { eq = null }}},
   },
 
   shorthands = {
@@ -51,15 +60,26 @@ return {
                 return
               end
 
+              local port = tonumber(parsed_url.port)
+
+              local prot
+              if port == 80 then
+                prot = "http"
+              elseif port == 443 then
+                prot = "https"
+              end
+
+              local protocol = parsed_url.scheme or prot or default_protocol
+
               return {
-                protocol = parsed_url.scheme,
-                host = parsed_url.host,
-                port = tonumber(parsed_url.port) or
+                protocol = protocol,
+                host = parsed_url.host or null,
+                port = port or
                        parsed_url.port or
-                       (parsed_url.scheme == "http" and 80) or
-                       (parsed_url.scheme == "https" and 443) or
-                       nil,
-                path = parsed_url.path,
+                       (protocol == "http"  and 80)  or
+                       (protocol == "https" and 443) or
+                       default_port,
+                path = parsed_url.path or null,
               }
             end },
   }


### PR DESCRIPTION
### Summary

Issue #5313 opened by @granularmike1 describes a bug in admin api where patching a service with `service.url` does not cleanup existing data.

E.g.

```
http PATCH :8001/services/my-service url=http://example.test
```

Doesn't clean `service.path` if it was previously specified. This is unexpected when the `url` sugar parameter is used.

### Issues resolved

Fix #5313