### PR TITLE
fix(acl) get acl by group fails when more consumers share the same group

### DIFF
--- a/kong-1.4.2-0.rockspec
+++ b/kong-1.4.2-0.rockspec
@@ -297,6 +297,7 @@ build = {
     ["kong.plugins.acl.daos"] = "kong/plugins/acl/daos.lua",
     ["kong.plugins.acl.groups"] = "kong/plugins/acl/groups.lua",
     ["kong.plugins.acl.acls"] = "kong/plugins/acl/acls.lua",
+    ["kong.plugins.acl.api"] = "kong/plugins/acl/api.lua",
 
     ["kong.plugins.correlation-id.handler"] = "kong/plugins/correlation-id/handler.lua",
     ["kong.plugins.correlation-id.schema"] = "kong/plugins/correlation-id/schema.lua",

--- a/kong/plugins/acl/api.lua
+++ b/kong/plugins/acl/api.lua
@@ -1,0 +1,60 @@
+local endpoints   = require "kong.api.endpoints"
+local utils       = require "kong.tools.utils"
+
+
+local ngx = ngx
+local kong = kong
+local escape_uri = ngx.escape_uri
+local unescape_uri = ngx.unescape_uri
+
+
+return {
+  ["/consumers/:consumers/acls/:acls"] = {
+    schema = kong.db.acls.schema,
+    before = function(self, db, helpers)
+      local group = unescape_uri(self.params.acls)
+      if not utils.is_valid_uuid(group) then
+        local consumer_id = unescape_uri(self.params.consumers)
+
+        if not utils.is_valid_uuid(consumer_id) then
+          local consumer, _, err_t = endpoints.select_entity(self, db, db.consumers.schema)
+          if err_t then
+            return endpoints.handle_error(err_t)
+          end
+
+          if not consumer then
+            return kong.response.exit(404, { message = "Not found" })
+          end
+
+          consumer_id = consumer.id
+        end
+
+        local cache_key = db.acls:cache_key(consumer_id, group)
+        local acl, _, err_t = db.acls:select_by_cache_key(cache_key)
+        if err_t then
+          return endpoints.handle_error(err_t)
+        end
+
+        if acl then
+          self.params.acls = escape_uri(acl.id)
+        else
+          if self.req.method ~= "PUT" then
+            return kong.response.exit(404, { message = "Not found" })
+          end
+
+          self.params.acls = utils.uuid()
+        end
+
+        self.params.group = group
+      end
+    end,
+
+    PUT = function(self, db, helpers, parent)
+      if not self.args.post.group and self.params.group then
+        self.args.post.group = self.params.group
+      end
+
+      return parent()
+    end
+  }
+}

--- a/kong/plugins/acl/daos.lua
+++ b/kong/plugins/acl/daos.lua
@@ -5,7 +5,6 @@ return {
     dao = "kong.plugins.acl.acls",
     name = "acls",
     primary_key = { "id" },
-    endpoint_key = "group",
     cache_key = { "consumer", "group" },
     fields = {
       { id = typedefs.uuid },


### PR DESCRIPTION
### Summary

@albertored reported issue here #5280.

This PR removes `endpoint_key` from `acls` dao, as it is not `unique`,
and using non-unique endpoint keys leads to strange results.

And of course it fixes the issue reported:

```
http POST :8001/consumers username=alice
http POST :8001/consumers username=bob
http POST :8001/consumers/alice/acls group=foo
http POST :8001/consumers/bob/acls group=foo
http GET :8001/consumers/alice/acls/foo
http GET :8001/consumers/bob/acls/foo
```

All returning `200`/`201` as expected.

### Issues Resolved

Fix #5280