### PR TITLE
fix(http-log) do not use a queue when queue_size is 1

### DIFF
--- a/kong/tools/batch_queue.lua
+++ b/kong/tools/batch_queue.lua
@@ -267,6 +267,13 @@ function Queue:add(entry)
     return nil, "entry must be a non-nil Lua value"
   end
 
+  if self.batch_max_size == 1 then
+    -- no batching
+    local batch = { entries = { entry }, retries = 0 }
+    schedule_process(self, batch, 0)
+    return true
+  end
+
   local cb = self.current_batch
   local new_size = #cb.entries + 1
   cb.entries[new_size] = entry


### PR DESCRIPTION
This avoids memory issues with an ever growing queue in Lua memory when the http-log queue handling is slower than the number of incoming requests, essentially restoring the pre-queueing behavior of http-log when queuing settings are not enabled.

Without this patch, running http-log under load (e.g. testing with `wrk`) displays an ever-increasing memory consumption, up until the Lua VM panics with an "out of memory" error. With this patch, running the same test with `wrk` shows stable memory consumption.

We still need to address the memory growth issues for when queueing is enabled and the flushing is too slow, but for now this is a useful fix to make the default settings usable.
