### PR TITLE
feat(balancer) async change upstreams

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -998,11 +998,14 @@
 # TUNING & BEHAVIOR
 #------------------------------------------------------------------------------
 
-#router_consistency = strict     # Defines whether this node should rebuild its
-                                 # router synchronously or asynchronously (the
-                                 # router is rebuilt every time a Route or a
-                                 # Service is updated via the Admin API or
-                                 # loading a declarative configuration file).
+#worker_consistency = strict
+                                 # Defines whether this node should rebuild its
+                                 # state synchronously or asynchronously (the
+                                 # balancers and the router are rebuilt on
+                                 # updates that affects them, e.g. updates to
+                                 # Routes, Services or Upstreams, via the Admin
+                                 # API or loading a declarative configuration
+                                 # file).
                                  #
                                  # Accepted values are:
                                  #
@@ -1026,14 +1029,15 @@
                                  # for a short period of time after Routes and
                                  # Services updates.
 
-#router_update_frequency = 1     # Defines how often the router changes are
+#worker_state_update_frequency = 5
+                                 # Defines how often the worker state changes are
                                  # checked with a background job. When a change
-                                 # is detected, a new router will be built. By
-                                 # default we check for changes every second.
-                                 # Raising this value will decrease the load on
-                                 # database servers and result in less jitter
-                                 # in proxy latency, with downside of longer
-                                 # converge time for router updates.
+                                 # is detected, a new router or balancer will be
+                                 # built, as needed. Raising this value will
+                                 # decrease the load on database servers and
+                                 # result in less jitter in proxy latency, but
+                                 # it might take more time to propagate changes
+                                 # to each individual worker.
 
 #------------------------------------------------------------------------------
 # DEVELOPMENT & MISCELLANEOUS

--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -364,9 +364,32 @@ local CONF_INFERENCES = {
   dns_not_found_ttl = { typ = "number" },
   dns_error_ttl = { typ = "number" },
   dns_no_sync = { typ = "boolean" },
-
-  router_consistency = { enum = { "strict", "eventual" } },
-  router_update_frequency = { typ = "number" },
+  worker_consistency = { enum = { "strict", "eventual" } },
+  router_consistency = {
+    enum = { "strict", "eventual" },
+    deprecated = {
+      replacement = "worker_consistency",
+      alias = function(conf)
+        if conf.worker_consistency == nil and
+           conf.router_consistency ~= nil then
+          conf.worker_consistency = conf.router_consistency
+        end
+      end,
+    }
+  },
+  worker_state_update_frequency = { typ = "number" },
+  router_update_frequency = {
+    typ = "number",
+    deprecated = {
+      replacement = "worker_state_update_frequency",
+      alias = function(conf)
+        if conf.worker_state_update_frequency == nil and
+           conf.router_update_frequency ~= nil then
+          conf.worker_state_update_frequency = conf.router_update_frequency
+        end
+      end,
+    }
+  },
 
   ssl_protocols = {
     typ = "string",
@@ -713,8 +736,8 @@ local function check_and_infer(conf)
     errors[#errors + 1] = "pg_semaphore_timeout must be an integer greater than 0"
   end
 
-  if conf.router_update_frequency <= 0 then
-    errors[#errors + 1] = "router_update_frequency must be greater than 0"
+  if conf.worker_state_update_frequency <= 0 then
+    errors[#errors + 1] = "worker_state_update_frequency must be greater than 0"
   end
 
   if conf.role == "control_plane" then

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -500,7 +500,7 @@ do
 
 
   get_updated_plugins_iterator = function()
-    if kong.configuration.router_consistency == "strict" then
+    if kong.configuration.worker_consistency == "strict" then
       local ok, err = rebuild_plugins_iterator(PLUGINS_ITERATOR_SYNC_OPTS)
       if not ok then
         -- If an error happens while updating, log it and return non-updated
@@ -722,7 +722,7 @@ do
 
 
   get_updated_router = function()
-    if kong.configuration.router_consistency == "strict" then
+    if kong.configuration.worker_consistency == "strict" then
       local ok, err = rebuild_router(ROUTER_SYNC_OPTS)
       if not ok then
         -- If an error happens while updating, log it and return non-updated
@@ -894,9 +894,9 @@ return {
         balancer.init()
       end)
 
-      local router_update_frequency = kong.configuration.router_update_frequency or 1
+      local worker_state_update_frequency = kong.configuration.worker_state_update_frequency or 1
 
-      timer_every(router_update_frequency, function(premature)
+      timer_every(worker_state_update_frequency, function(premature)
         if premature then
           return
         end
@@ -911,7 +911,7 @@ return {
         end
       end)
 
-      timer_every(router_update_frequency, function(premature)
+      timer_every(worker_state_update_frequency, function(premature)
         if premature then
           return
         end

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -128,8 +128,8 @@ dns_not_found_ttl = 30
 dns_error_ttl = 1
 dns_no_sync = off
 
-router_consistency = strict
-router_update_frequency = 1
+worker_consistency = strict
+worker_state_update_frequency = 5
 
 lua_socket_pool_size = 30
 lua_ssl_trusted_certificate = NONE

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -510,9 +510,9 @@ describe("Configuration loader", function()
       assert.is_nil(conf)
 
       local conf, err = conf_loader(nil, {
-        router_consistency = "magical"
+        worker_consistency = "magical"
       })
-      assert.equal("router_consistency has an invalid value: 'magical' (strict, eventual)", err)
+      assert.equal("worker_consistency has an invalid value: 'magical' (strict, eventual)", err)
       assert.is_nil(conf)
 
       conf, err = conf_loader(nil, {
@@ -937,26 +937,26 @@ describe("Configuration loader", function()
     end)
   end)
 
-  describe("router_update_frequency option", function()
+  describe("worker_state_update_frequency option", function()
     it("is rejected with a zero", function()
       local conf, err = conf_loader(nil, {
-        router_update_frequency = 0,
+        worker_state_update_frequency = 0,
       })
       assert.is_nil(conf)
-      assert.equal("router_update_frequency must be greater than 0", err)
+      assert.equal("worker_state_update_frequency must be greater than 0", err)
     end)
     it("is rejected with a negative number", function()
       local conf, err = conf_loader(nil, {
-        router_update_frequency = -1,
+        worker_state_update_frequency = -1,
       })
       assert.is_nil(conf)
-      assert.equal("router_update_frequency must be greater than 0", err)
+      assert.equal("worker_state_update_frequency must be greater than 0", err)
     end)
     it("accepts decimal numbers", function()
       local conf, err = conf_loader(nil, {
-        router_update_frequency = 0.01,
+        worker_state_update_frequency = 0.01,
       })
-      assert.equal(conf.router_update_frequency, 0.01)
+      assert.equal(conf.worker_state_update_frequency, 0.01)
       assert.is_nil(err)
     end)
   end)

--- a/spec/01-unit/09-balancer_spec.lua
+++ b/spec/01-unit/09-balancer_spec.lua
@@ -1,620 +1,629 @@
 local utils = require "kong.tools.utils"
+local mocker = require "spec.fixtures.mocker"
 
-describe("Balancer", function()
-  local singletons, balancer
-  local UPSTREAMS_FIXTURES
-  local TARGETS_FIXTURES
-  local crc32 = ngx.crc32_short
-  local uuid = require("kong.tools.utils").uuid
-  local upstream_hc
-  local upstream_ph
-  local upstream_ote
+local function setup_it_block(consistency)
+  local cache_table = {}
 
-  lazy_teardown(function()
-    ngx.log:revert() -- luacheck: ignore
-  end)
-
-
-  lazy_setup(function()
-    stub(ngx, "log")
-
-    balancer = require "kong.runloop.balancer"
-    singletons = require "kong.singletons"
-    singletons.worker_events = require "resty.worker.events"
-    singletons.db = {}
-
-    singletons.worker_events.configure({
-      shm = "kong_process_events", -- defined by "lua_shared_dict"
-      timeout = 5,            -- life time of event data in shm
-      interval = 1,           -- poll interval (seconds)
-
-      wait_interval = 0.010,  -- wait before retry fetching event data
-      wait_max = 0.5,         -- max wait time before discarding event
-    })
-
-    local hc_defaults = {
-      active = {
-        timeout = 1,
-        concurrency = 10,
-        http_path = "/",
-        healthy = {
-          interval = 0,  -- 0 = probing disabled by default
-          http_statuses = { 200, 302 },
-          successes = 0, -- 0 = disabled by default
-        },
-        unhealthy = {
-          interval = 0, -- 0 = probing disabled by default
-          http_statuses = { 429, 404,
-                            500, 501, 502, 503, 504, 505 },
-          tcp_failures = 0,  -- 0 = disabled by default
-          timeouts = 0,      -- 0 = disabled by default
-          http_failures = 0, -- 0 = disabled by default
-        },
-      },
-      passive = {
-        healthy = {
-          http_statuses = { 200, 201, 202, 203, 204, 205, 206, 207, 208, 226,
-                            300, 301, 302, 303, 304, 305, 306, 307, 308 },
-          successes = 0,
-        },
-        unhealthy = {
-          http_statuses = { 429, 500, 503 },
-          tcp_failures = 0,  -- 0 = circuit-breaker disabled by default
-          timeouts = 0,      -- 0 = circuit-breaker disabled by default
-          http_failures = 0, -- 0 = circuit-breaker disabled by default
-        },
-      },
-    }
-
-    local passive_hc = utils.deep_copy(hc_defaults)
-    passive_hc.passive.healthy.successes = 1
-    passive_hc.passive.unhealthy.http_failures = 1
-
-    UPSTREAMS_FIXTURES = {
-      [1] = { id = "a", name = "mashape", slots = 10, healthchecks = hc_defaults, algorithm = "round-robin" },
-      [2] = { id = "b", name = "kong",    slots = 10, healthchecks = hc_defaults, algorithm = "round-robin" },
-      [3] = { id = "c", name = "gelato",  slots = 20, healthchecks = hc_defaults, algorithm = "round-robin" },
-      [4] = { id = "d", name = "galileo", slots = 20, healthchecks = hc_defaults, algorithm = "round-robin" },
-      [5] = { id = "e", name = "upstream_e", slots = 10, healthchecks = hc_defaults, algorithm = "round-robin" },
-      [6] = { id = "f", name = "upstream_f", slots = 10, healthchecks = hc_defaults, algorithm = "round-robin" },
-      [7] = { id = "hc", name = "upstream_hc", slots = 10, healthchecks = passive_hc, algorithm = "round-robin" },
-      [8] = { id = "ph", name = "upstream_ph", slots = 10, healthchecks = passive_hc, algorithm = "round-robin" },
-      [9] = { id = "ote", name = "upstream_ote", slots = 10, healthchecks = hc_defaults, algorithm = "round-robin" },
-    }
-    upstream_hc = UPSTREAMS_FIXTURES[7]
-    upstream_ph = UPSTREAMS_FIXTURES[8]
-    upstream_ote = UPSTREAMS_FIXTURES[9]
-
-    TARGETS_FIXTURES = {
-      -- 1st upstream; a
-      {
-        id = "a1",
-        created_at = "003",
-        upstream = { id = "a" },
-        target = "localhost:80",
-        weight = 10,
-      },
-      {
-        id = "a2",
-        created_at = "002",
-        upstream = { id = "a" },
-        target = "localhost:80",
-        weight = 10,
-      },
-      {
-        id = "a3",
-        created_at = "001",
-        upstream = { id = "a" },
-        target = "localhost:80",
-        weight = 10,
-      },
-      {
-        id = "a4",
-        created_at = "002",  -- same timestamp as "a2"
-        upstream = { id = "a" },
-        target = "localhost:80",
-        weight = 10,
-      },
-      -- 2nd upstream; b
-      {
-        id = "b1",
-        created_at = "003",
-        upstream = { id = "b" },
-        target = "localhost:80",
-        weight = 10,
-      },
-      -- 3rd upstream: e (removed and re-added)
-      {
-        id = "e1",
-        created_at = "001",
-        upstream = { id = "e" },
-        target = "127.0.0.1:2112",
-        weight = 10,
-      },
-      {
-        id = "e2",
-        created_at = "002",
-        upstream = { id = "e" },
-        target = "127.0.0.1:2112",
-        weight = 0,
-      },
-      {
-        id = "e3",
-        created_at = "003",
-        upstream = { id = "e" },
-        target = "127.0.0.1:2112",
-        weight = 10,
-      },
-      -- 4th upstream: f (removed and not re-added)
-      {
-        id = "f1",
-        created_at = "001",
-        upstream = { id = "f" },
-        target = "127.0.0.1:5150",
-        weight = 10,
-      },
-      {
-        id = "f2",
-        created_at = "002",
-        upstream = { id = "f" },
-        target = "127.0.0.1:5150",
-        weight = 0,
-      },
-      {
-        id = "f3",
-        created_at = "003",
-        upstream = { id = "f" },
-        target = "127.0.0.1:2112",
-        weight = 10,
-      },
-      -- upstream_hc
-      {
-        id = "hc1",
-        created_at = "001",
-        upstream = { id = "hc" },
-        target = "localhost:1111",
-        weight = 10,
-      },
-      -- upstream_ph
-      {
-        id = "ph1",
-        created_at = "001",
-        upstream = { id = "ph" },
-        target = "localhost:1111",
-        weight = 10,
-      },
-      {
-        id = "ph2",
-        created_at = "001",
-        upstream = { id = "ph" },
-        target = "127.0.0.1:2222",
-        weight = 10,
-      },
-      -- upstream_ote
-      {
-        id = "ote1",
-        created_at = "001",
-        upstream = { id = "ote" },
-        target = "localhost:1111",
-        weight = 10,
-      },
-    }
-
-    local function each(fixture)
-      return function()
-        local i = 0
-        return function(self)
-          i = i + 1
-          return fixture[i]
-        end
-      end
-    end
-
-    local function select(fixture)
-      return function(self, pk)
-        for item in self:each() do
-          if item.id == pk.id then
-            return item
+  local function mock_cache(cache_table, limit)
+    return {
+      safe_set = function(self, k, v)
+        if limit then
+          local n = 0
+          for _, _ in pairs(cache_table) do
+            n = n + 1
+          end
+          if n >= limit then
+            return nil, "no memory"
           end
         end
-      end
-    end
-
-    singletons.db = {
-      targets = {
-        each = each(TARGETS_FIXTURES),
-        select_by_upstream_raw = function(self, upstream_pk)
-          local upstream_id = upstream_pk.id
-          local res, len = {}, 0
-          for tgt in self:each() do
-            if tgt.upstream.id == upstream_id then
-              tgt.order = string.format("%d:%s", tgt.created_at * 1000, tgt.id)
-              len = len + 1
-              res[len] = tgt
-            end
-          end
-
-          table.sort(res, function(a, b) return a.order < b.order end)
-          return res
-        end
-      },
-      upstreams = {
-        each = each(UPSTREAMS_FIXTURES),
-        select = select(UPSTREAMS_FIXTURES),
-      },
-    }
-
-    singletons.core_cache = {
-      _cache = {},
-      get = function(self, key, _, loader, arg)
-        local v = self._cache[key]
-        if v == nil then
-          v = loader(arg)
-          self._cache[key] = v
-        end
-        return v
+        cache_table[k] = v
+        return true
       end,
-      invalidate_local = function(self, key)
-        self._cache[key] = nil
-      end
+      get = function(self, k, _, fn, arg)
+        if cache_table[k] == nil then
+          cache_table[k] = fn(arg)
+        end
+        return cache_table[k]
+      end,
     }
+  end
 
+  mocker.setup(finally, {
+    kong = {
+      configuration = {
+        worker_consistency = consistency,
+        worker_state_update_frequency = 0.1,
+      },
+      core_cache = mock_cache(cache_table),
+    }
+  })
+end
 
-  end)
-
-  describe("create_balancer()", function()
-    local dns_client = require("resty.dns.client")
-    dns_client.init()
-
-    it("creates a balancer with a healthchecker", function()
-      local my_balancer = assert(balancer._create_balancer(UPSTREAMS_FIXTURES[1]))
-      local hc = assert(balancer._get_healthchecker(my_balancer))
-      local target_history = {
-        { name = "localhost", port = 80, order = "1000:a3", weight = 10 },
-        { name = "localhost", port = 80, order = "2000:a2", weight = 10 },
-        { name = "localhost", port = 80, order = "2000:a4", weight = 10 },
-        { name = "localhost", port = 80, order = "3000:a1", weight = 10 },
-      }
-      assert.same(target_history, balancer._get_target_history(my_balancer))
-      hc:stop()
-    end)
-
-    it("reuses a balancer by default", function()
-      local b1 = assert(balancer._create_balancer(UPSTREAMS_FIXTURES[1]))
-      local hc1 = balancer._get_healthchecker(b1)
-      local b2 = balancer._create_balancer(UPSTREAMS_FIXTURES[1])
-      assert.equal(b1, b2)
-      assert(hc1:stop())
-    end)
-
-    it("re-creates a balancer if told to", function()
-      local b1 = assert(balancer._create_balancer(UPSTREAMS_FIXTURES[1], true))
-      local hc1 = balancer._get_healthchecker(b1)
-      assert(hc1:stop())
-      local b1_target_history = balancer._get_target_history(b1)
-      local b2 = assert(balancer._create_balancer(UPSTREAMS_FIXTURES[1], true))
-      local hc2 = balancer._get_healthchecker(b2)
-      assert(hc2:stop())
-      local target_history = {
-        { name = "localhost", port = 80, order = "1000:a3", weight = 10 },
-        { name = "localhost", port = 80, order = "2000:a2", weight = 10 },
-        { name = "localhost", port = 80, order = "2000:a4", weight = 10 },
-        { name = "localhost", port = 80, order = "3000:a1", weight = 10 },
-      }
-      assert.not_same(b1, b2)
-      assert.same(target_history, b1_target_history)
-      assert.same(target_history, balancer._get_target_history(b2))
-    end)
-  end)
-
-  describe("get_balancer()", function()
-    local dns_client = require("resty.dns.client")
-    dns_client.init()
-
-    lazy_setup(function()
-      -- In these tests, we pass `true` to get_balancer
-      -- to ensure that the upstream was created by `balancer.init()`
-      balancer.init()
-    end)
-
-    it("balancer and healthchecker match; remove and re-add", function()
-      local my_balancer = assert(balancer._get_balancer({
-        host = "upstream_e"
-      }, true))
-      local target_history = {
-        { name = "127.0.0.1", port = 2112, order = "1000:e1", weight = 10 },
-        { name = "127.0.0.1", port = 2112, order = "2000:e2", weight = 0  },
-        { name = "127.0.0.1", port = 2112, order = "3000:e3", weight = 10 },
-      }
-      assert.same(target_history, balancer._get_target_history(my_balancer))
-      local hc = assert(balancer._get_healthchecker(my_balancer))
-      assert.same(1, #hc.targets)
-      assert.truthy(hc.targets["127.0.0.1"])
-      assert.truthy(hc.targets["127.0.0.1"][2112])
-    end)
-
-    it("balancer and healthchecker match; remove and not re-add", function()
-      local my_balancer = assert(balancer._get_balancer({
-        host = "upstream_f"
-      }, true))
-      local target_history = {
-        { name = "127.0.0.1", port = 5150, order = "1000:f1", weight = 10 },
-        { name = "127.0.0.1", port = 5150, order = "2000:f2", weight = 0  },
-        { name = "127.0.0.1", port = 2112, order = "3000:f3", weight = 10 },
-      }
-      assert.same(target_history, balancer._get_target_history(my_balancer))
-      local hc = assert(balancer._get_healthchecker(my_balancer))
-      assert.same(1, #hc.targets)
-      assert.truthy(hc.targets["127.0.0.1"])
-      assert.truthy(hc.targets["127.0.0.1"][2112])
-    end)
-  end)
-
-  describe("load_upstreams_dict_into_memory()", function()
-    local upstreams_dict
-    lazy_setup(function()
-      upstreams_dict = balancer._load_upstreams_dict_into_memory()
-    end)
-
-    it("retrieves all upstreams as a dictionary", function()
-      assert.is.table(upstreams_dict)
-      for _, u in ipairs(UPSTREAMS_FIXTURES) do
-        assert.equal(upstreams_dict[u.name], u.id)
-        upstreams_dict[u.name] = nil -- remove each match
-      end
-      assert.is_nil(next(upstreams_dict)) -- should be empty now
-    end)
-  end)
-
-  describe("get_all_upstreams()", function()
-    it("gets a map of all upstream names to ids", function()
-      local upstreams_dict = balancer.get_all_upstreams()
-
-      local fixture_dict = {}
-      for _, upstream in ipairs(UPSTREAMS_FIXTURES) do
-        fixture_dict[upstream.name] = upstream.id
-      end
-
-      assert.same(fixture_dict, upstreams_dict)
-    end)
-  end)
-
-  describe("get_upstream_by_name()", function()
-    it("retrieves a complete upstream based on its name", function()
-      for _, fixture in ipairs(UPSTREAMS_FIXTURES) do
-        local upstream = balancer.get_upstream_by_name(fixture.name)
-        assert.same(fixture, upstream)
-      end
-    end)
-  end)
-
-  describe("load_targets_into_memory()", function()
-    local targets
-    local upstream
-    lazy_setup(function()
-      upstream = "a"
-      targets = balancer._load_targets_into_memory(upstream)
-    end)
-
-    it("retrieves all targets per upstream, ordered", function()
-      assert.equal(4, #targets)
-      assert(targets[1].id == "a3")
-      assert(targets[2].id == "a2")
-      assert(targets[3].id == "a4")
-      assert(targets[4].id == "a1")
-    end)
-  end)
-
-  describe("on_target_event()", function()
-    lazy_setup(function()
-      balancer._load_targets_into_memory("ote")
-    end)
-
-    it("adding a target does not recreate a balancer", function()
-      local b1 = balancer._create_balancer(upstream_ote)
-      assert.same(1, #(balancer._get_target_history(b1)))
-
-      table.insert(TARGETS_FIXTURES, {
-        id = "ote2",
-        created_at = "002",
-        upstream = { id = "ote" },
-        target = "localhost:1112",
-        weight = 10,
-      })
-      balancer.on_target_event("create", { upstream = { id = "ote" } })
-
-      local b2 = balancer._create_balancer(upstream_ote)
-      assert.same(2, #(balancer._get_target_history(b2)))
-
-      assert(b1 == b2)
-    end)
-  end)
-
-  describe("post_health()", function()
-    local hc, my_balancer
-
-    lazy_setup(function()
-      my_balancer = assert(balancer._create_balancer(upstream_ph))
-      hc = assert(balancer._get_healthchecker(my_balancer))
-    end)
+for _, consistency in ipairs({"strict", "eventual"}) do
+  describe("Balancer (worker_consistency = " .. consistency .. ")", function()
+    local singletons, balancer
+    local UPSTREAMS_FIXTURES
+    local TARGETS_FIXTURES
+    local crc32 = ngx.crc32_short
+    local uuid = require("kong.tools.utils").uuid
+    local upstream_hc
+    local upstream_ph
+    local upstream_otes
+    local upstream_otee
 
     lazy_teardown(function()
-      if hc then
-        hc:stop()
-      end
+      ngx.log:revert() -- luacheck: ignore
     end)
 
-    it("posts healthy/unhealthy using IP and hostname", function()
-      local tests = {
-        { host = "127.0.0.1", port = 2222, health = true },
-        { host = "127.0.0.1", port = 2222, health = false },
-        { host = "localhost", port = 1111, health = true },
-        { host = "localhost", port = 1111, health = false },
+
+    lazy_setup(function()
+      stub(ngx, "log")
+
+      balancer = require "kong.runloop.balancer"
+      singletons = require "kong.singletons"
+      singletons.worker_events = require "resty.worker.events"
+      singletons.db = {}
+
+      singletons.worker_events.configure({
+        shm = "kong_process_events", -- defined by "lua_shared_dict"
+        timeout = 5,            -- life time of event data in shm
+        interval = 1,           -- poll interval (seconds)
+
+        wait_interval = 0.010,  -- wait before retry fetching event data
+        wait_max = 0.5,         -- max wait time before discarding event
+      })
+
+      local hc_defaults = {
+        active = {
+          timeout = 1,
+          concurrency = 10,
+          http_path = "/",
+          healthy = {
+            interval = 0,  -- 0 = probing disabled by default
+            http_statuses = { 200, 302 },
+            successes = 0, -- 0 = disabled by default
+          },
+          unhealthy = {
+            interval = 0, -- 0 = probing disabled by default
+            http_statuses = { 429, 404,
+                              500, 501, 502, 503, 504, 505 },
+            tcp_failures = 0,  -- 0 = disabled by default
+            timeouts = 0,      -- 0 = disabled by default
+            http_failures = 0, -- 0 = disabled by default
+          },
+        },
+        passive = {
+          healthy = {
+            http_statuses = { 200, 201, 202, 203, 204, 205, 206, 207, 208, 226,
+                              300, 301, 302, 303, 304, 305, 306, 307, 308 },
+            successes = 0,
+          },
+          unhealthy = {
+            http_statuses = { 429, 500, 503 },
+            tcp_failures = 0,  -- 0 = circuit-breaker disabled by default
+            timeouts = 0,      -- 0 = circuit-breaker disabled by default
+            http_failures = 0, -- 0 = circuit-breaker disabled by default
+          },
+        },
       }
-      for _, t in ipairs(tests) do
-        assert(balancer.post_health(upstream_ph, t.host, nil, t.port, t.health))
-        local health_info = assert(balancer.get_upstream_health("ph"))
-        local response = t.health and "HEALTHY" or "UNHEALTHY"
-        assert.same(response,
-                    health_info[t.host .. ":" .. t.port].addresses[1].health)
+
+      local passive_hc = utils.deep_copy(hc_defaults)
+      passive_hc.passive.healthy.successes = 1
+      passive_hc.passive.unhealthy.http_failures = 1
+
+      UPSTREAMS_FIXTURES = {
+        [1] = { id = "a", name = "mashape", slots = 10, healthchecks = hc_defaults, algorithm = "round-robin" },
+        [2] = { id = "b", name = "kong",    slots = 10, healthchecks = hc_defaults, algorithm = "round-robin" },
+        [3] = { id = "c", name = "gelato",  slots = 20, healthchecks = hc_defaults, algorithm = "round-robin" },
+        [4] = { id = "d", name = "galileo", slots = 20, healthchecks = hc_defaults, algorithm = "round-robin" },
+        [5] = { id = "e", name = "upstream_e", slots = 10, healthchecks = hc_defaults, algorithm = "round-robin" },
+        [6] = { id = "f", name = "upstream_f", slots = 10, healthchecks = hc_defaults, algorithm = "round-robin" },
+        [7] = { id = "hc_" .. consistency, name = "upstream_hc_" .. consistency, slots = 10, healthchecks = passive_hc, algorithm = "round-robin" },
+        [8] = { id = "ph", name = "upstream_ph", slots = 10, healthchecks = passive_hc, algorithm = "round-robin" },
+        [9] = { id = "otes", name = "upstream_otes", slots = 10, healthchecks = hc_defaults, algorithm = "round-robin" },
+        [10] = { id = "otee", name = "upstream_otee", slots = 10, healthchecks = hc_defaults, algorithm = "round-robin" },
+      }
+      upstream_hc = UPSTREAMS_FIXTURES[7]
+      upstream_ph = UPSTREAMS_FIXTURES[8]
+      upstream_otes = UPSTREAMS_FIXTURES[9]
+      upstream_otee = UPSTREAMS_FIXTURES[10]
+
+      TARGETS_FIXTURES = {
+        -- 1st upstream; a
+        {
+          id = "a1",
+          created_at = "003",
+          upstream = { id = "a" },
+          target = "localhost:80",
+          weight = 10,
+        },
+        {
+          id = "a2",
+          created_at = "002",
+          upstream = { id = "a" },
+          target = "localhost:80",
+          weight = 10,
+        },
+        {
+          id = "a3",
+          created_at = "001",
+          upstream = { id = "a" },
+          target = "localhost:80",
+          weight = 10,
+        },
+        {
+          id = "a4",
+          created_at = "002",  -- same timestamp as "a2"
+          upstream = { id = "a" },
+          target = "localhost:80",
+          weight = 10,
+        },
+        -- 2nd upstream; b
+        {
+          id = "b1",
+          created_at = "003",
+          upstream = { id = "b" },
+          target = "localhost:80",
+          weight = 10,
+        },
+        -- 3rd upstream: e (removed and re-added)
+        {
+          id = "e1",
+          created_at = "001",
+          upstream = { id = "e" },
+          target = "127.0.0.1:2112",
+          weight = 10,
+        },
+        {
+          id = "e2",
+          created_at = "002",
+          upstream = { id = "e" },
+          target = "127.0.0.1:2112",
+          weight = 0,
+        },
+        {
+          id = "e3",
+          created_at = "003",
+          upstream = { id = "e" },
+          target = "127.0.0.1:2112",
+          weight = 10,
+        },
+        -- 4th upstream: f (removed and not re-added)
+        {
+          id = "f1",
+          created_at = "001",
+          upstream = { id = "f" },
+          target = "127.0.0.1:5150",
+          weight = 10,
+        },
+        {
+          id = "f2",
+          created_at = "002",
+          upstream = { id = "f" },
+          target = "127.0.0.1:5150",
+          weight = 0,
+        },
+        {
+          id = "f3",
+          created_at = "003",
+          upstream = { id = "f" },
+          target = "127.0.0.1:2112",
+          weight = 10,
+        },
+        -- upstream_hc
+        {
+          id = "hc1" .. consistency,
+          created_at = "001",
+          upstream = { id = "hc_" .. consistency },
+          target = "localhost:1111",
+          weight = 10,
+        },
+        -- upstream_ph
+        {
+          id = "ph1",
+          created_at = "001",
+          upstream = { id = "ph" },
+          target = "localhost:1111",
+          weight = 10,
+        },
+        {
+          id = "ph2",
+          created_at = "001",
+          upstream = { id = "ph" },
+          target = "127.0.0.1:2222",
+          weight = 10,
+        },
+        -- upstream_otes
+        {
+          id = "otes1",
+          created_at = "001",
+          upstream = { id = "otes" },
+          target = "localhost:1111",
+          weight = 10,
+        },
+        -- upstream_otee
+        {
+          id = "otee1",
+          created_at = "001",
+          upstream = { id = "otee" },
+          target = "localhost:1111",
+          weight = 10,
+        },
+      }
+
+      local function each(fixture)
+        return function()
+          local i = 0
+          return function(self)
+            i = i + 1
+            return fixture[i]
+          end
+        end
       end
+
+      local function select(fixture)
+        return function(self, pk)
+          for item in self:each() do
+            if item.id == pk.id then
+              return item
+            end
+          end
+        end
+      end
+
+      singletons.db = {
+        targets = {
+          each = each(TARGETS_FIXTURES),
+          select_by_upstream_raw = function(self, upstream_pk)
+            local upstream_id = upstream_pk.id
+            local res, len = {}, 0
+            for tgt in self:each() do
+              if tgt.upstream.id == upstream_id then
+                tgt.order = string.format("%d:%s", tgt.created_at * 1000, tgt.id)
+                len = len + 1
+                res[len] = tgt
+              end
+            end
+
+            table.sort(res, function(a, b) return a.order < b.order end)
+            return res
+          end
+        },
+        upstreams = {
+          each = each(UPSTREAMS_FIXTURES),
+          select = select(UPSTREAMS_FIXTURES),
+        },
+      }
+
+      singletons.core_cache = {
+        _cache = {},
+        get = function(self, key, _, loader, arg)
+          local v = self._cache[key]
+          if v == nil then
+            v = loader(arg)
+            self._cache[key] = v
+          end
+          return v
+        end,
+        invalidate_local = function(self, key)
+          self._cache[key] = nil
+        end
+      }
+
+
     end)
 
-    it("requires hostname if that was used in the Target", function()
-      local ok, err = balancer.post_health(upstream_ph, "127.0.0.1", nil, 1111, true)
-      assert.falsy(ok)
-      assert.match(err, "No host found by: '127.0.0.1:1111'")
-    end)
+    describe("create_balancer()", function()
+      local dns_client = require("resty.dns.client")
+      dns_client.init()
 
-    it("fails if upstream/balancer doesn't exist", function()
-      local bad = { name = "invalid", id = "bad" }
-      local ok, err = balancer.post_health(bad, "127.0.0.1", 1111, true)
-      assert.falsy(ok)
-      assert.match(err, "Upstream invalid has no balancer")
-    end)
-  end)
-
-  describe("(un)subscribe_to_healthcheck_events()", function()
-    local my_balancer = assert(balancer._create_balancer(upstream_hc))
-    local hc = assert(balancer._get_healthchecker(my_balancer))
-    local data = {}
-    local cb = function(upstream_id, ip, port, hostname, health)
-      table.insert(data, {
-        upstream_id = upstream_id,
-        ip = ip,
-        port = port,
-        hostname = hostname,
-        health = health,
-      })
-    end
-    balancer.subscribe_to_healthcheck_events(cb)
-    my_balancer.report_http_status({
-      address = {
-        ip = "127.0.0.1",
-        port = 1111,
-        host = {hostname = "localhost"},
-      }}, 429)
-    my_balancer.report_http_status({
-      address = {
-        ip = "127.0.0.1",
-        port = 1111,
-        host = {hostname = "localhost"},
-      }}, 200)
-    balancer.unsubscribe_from_healthcheck_events(cb)
-    my_balancer.report_http_status({
-      address = {
-        ip = "127.0.0.1",
-        port = 1111,
-        host = {hostname = "localhost"},
-      }}, 429)
-    hc:stop()
-    assert.same({
-      upstream_id = "hc",
-      ip = "127.0.0.1",
-      port = 1111,
-      hostname = "localhost",
-      health = "unhealthy"
-    }, data[1])
-    assert.same({
-      upstream_id = "hc",
-      ip = "127.0.0.1",
-      port = 1111,
-      hostname = "localhost",
-      health = "healthy"
-    }, data[2])
-    assert.same(nil, data[3])
-  end)
-
-  describe("creating hash values", function()
-    local headers
-    local backup
-    before_each(function()
-      headers = setmetatable({}, {
-          __newindex = function(self, key, value)
-            rawset(self, key:upper(), value)
-          end,
-          __index = function(self, key)
-            return rawget(self, key:upper())
-          end,
-      })
-      backup = { ngx.req, ngx.var, ngx.ctx }
-      ngx.req = { get_headers = function() return headers end } -- luacheck: ignore
-      ngx.var = {}
-      ngx.ctx = {}
-    end)
-    after_each(function()
-      ngx.req = backup[1] -- luacheck: ignore
-      ngx.var = backup[2]
-      ngx.ctx = backup[3]
-    end)
-    it("none", function()
-      local hash = balancer._create_hash({
-          hash_on = "none",
-      })
-      assert.is_nil(hash)
-    end)
-    it("consumer", function()
-      local value = uuid()
-      ngx.ctx.authenticated_consumer = { id = value }
-      local hash = balancer._create_hash({
-          hash_on = "consumer",
-      })
-      assert.are.same(crc32(value), hash)
-    end)
-    it("ip", function()
-      local value = "1.2.3.4"
-      ngx.var.remote_addr = value
-      local hash = balancer._create_hash({
-          hash_on = "ip",
-      })
-      assert.are.same(crc32(value), hash)
-    end)
-    it("header", function()
-      local value = "some header value"
-      headers.HeaderName = value
-      local hash = balancer._create_hash({
-          hash_on = "header",
-          hash_on_header = "HeaderName",
-      })
-      assert.are.same(crc32(value), hash)
-    end)
-    describe("cookie", function()
-      it("uses the cookie when present in the request", function()
-        local value = "some cookie value"
-        ngx.var.cookie_Foo = value
-        ngx.ctx.balancer_data = {}
-        local hash = balancer._create_hash({
-          hash_on = "cookie",
-          hash_on_cookie = "Foo",
-        })
-        assert.are.same(crc32(value), hash)
-        assert.is_nil(ngx.ctx.balancer_data.hash_cookie)
+      it("creates a balancer with a healthchecker", function()
+        setup_it_block(consistency)
+        local my_balancer = assert(balancer._create_balancer(UPSTREAMS_FIXTURES[1]))
+        local hc = assert(balancer._get_healthchecker(my_balancer))
+        local target_history = {
+          { name = "localhost", port = 80, order = "1000:a3", weight = 10 },
+          { name = "localhost", port = 80, order = "2000:a2", weight = 10 },
+          { name = "localhost", port = 80, order = "2000:a4", weight = 10 },
+          { name = "localhost", port = 80, order = "3000:a1", weight = 10 },
+        }
+        assert.same(target_history, balancer._get_target_history(my_balancer))
+        hc:stop()
       end)
-      it("creates the cookie when not present in the request", function()
-        ngx.ctx.balancer_data = {}
-        balancer._create_hash({
-          hash_on = "cookie",
-          hash_on_cookie = "Foo",
-          hash_on_cookie_path = "/",
-        })
-        assert.are.same(ngx.ctx.balancer_data.hash_cookie.key, "Foo")
-        assert.are.same(ngx.ctx.balancer_data.hash_cookie.path, "/")
+
+      it("reuses a balancer by default", function()
+        local b1 = assert(balancer._create_balancer(UPSTREAMS_FIXTURES[1]))
+        local hc1 = balancer._get_healthchecker(b1)
+        local b2 = balancer._create_balancer(UPSTREAMS_FIXTURES[1])
+        assert.equal(b1, b2)
+        assert(hc1:stop())
+      end)
+
+      it("re-creates a balancer if told to", function()
+        setup_it_block(consistency)
+        balancer.init()
+        local b1 = assert(balancer._create_balancer(UPSTREAMS_FIXTURES[1], true))
+        local hc1 = balancer._get_healthchecker(b1)
+        assert(hc1:stop())
+        local b1_target_history = balancer._get_target_history(b1)
+        local b2 = assert(balancer._create_balancer(UPSTREAMS_FIXTURES[1], true))
+        local hc2 = balancer._get_healthchecker(b2)
+        assert(hc2:stop())
+        local target_history = {
+          { name = "localhost", port = 80, order = "1000:a3", weight = 10 },
+          { name = "localhost", port = 80, order = "2000:a2", weight = 10 },
+          { name = "localhost", port = 80, order = "2000:a4", weight = 10 },
+          { name = "localhost", port = 80, order = "3000:a1", weight = 10 },
+        }
+        assert.not_same(b1, b2)
+        assert.same(target_history, b1_target_history)
+        assert.same(target_history, balancer._get_target_history(b2))
       end)
     end)
-    it("multi-header", function()
-      local value = { "some header value", "another value" }
-      headers.HeaderName = value
-      local hash = balancer._create_hash({
-          hash_on = "header",
-          hash_on_header = "HeaderName",
-      })
-      assert.are.same(crc32(table.concat(value)), hash)
+
+    describe("get_balancer()", function()
+      local dns_client = require("resty.dns.client")
+      dns_client.init()
+
+      it("balancer and healthchecker match; remove and re-add", function()
+        setup_it_block(consistency)
+        local my_balancer = assert(balancer._get_balancer({
+          host = "upstream_e"
+        }, true))
+        local target_history = {
+          { name = "127.0.0.1", port = 2112, order = "1000:e1", weight = 10 },
+          { name = "127.0.0.1", port = 2112, order = "2000:e2", weight = 0  },
+          { name = "127.0.0.1", port = 2112, order = "3000:e3", weight = 10 },
+        }
+        assert.same(target_history, balancer._get_target_history(my_balancer))
+        local hc = assert(balancer._get_healthchecker(my_balancer))
+        assert.same(1, #hc.targets)
+        assert.truthy(hc.targets["127.0.0.1"])
+        assert.truthy(hc.targets["127.0.0.1"][2112])
+      end)
+
+      it("balancer and healthchecker match; remove and not re-add", function()
+        setup_it_block(consistency)
+        local my_balancer = assert(balancer._get_balancer({
+          host = "upstream_f"
+        }, true))
+        local target_history = {
+          { name = "127.0.0.1", port = 5150, order = "1000:f1", weight = 10 },
+          { name = "127.0.0.1", port = 5150, order = "2000:f2", weight = 0  },
+          { name = "127.0.0.1", port = 2112, order = "3000:f3", weight = 10 },
+        }
+        assert.same(target_history, balancer._get_target_history(my_balancer))
+        local hc = assert(balancer._get_healthchecker(my_balancer))
+        assert.same(1, #hc.targets)
+        assert.truthy(hc.targets["127.0.0.1"])
+        assert.truthy(hc.targets["127.0.0.1"][2112])
+      end)
     end)
-    describe("fallback", function()
+
+    describe("load_upstreams_dict_into_memory()", function()
+      local upstreams_dict
+      lazy_setup(function()
+        upstreams_dict = balancer._load_upstreams_dict_into_memory()
+      end)
+
+      it("retrieves all upstreams as a dictionary", function()
+        assert.is.table(upstreams_dict)
+        for _, u in ipairs(UPSTREAMS_FIXTURES) do
+          assert.equal(upstreams_dict[u.name], u.id)
+          upstreams_dict[u.name] = nil -- remove each match
+        end
+        assert.is_nil(next(upstreams_dict)) -- should be empty now
+      end)
+    end)
+
+    describe("get_all_upstreams()", function()
+      it("gets a map of all upstream names to ids", function()
+        setup_it_block(consistency)
+        local upstreams_dict = balancer.get_all_upstreams()
+
+        local fixture_dict = {}
+        for _, upstream in ipairs(UPSTREAMS_FIXTURES) do
+          fixture_dict[upstream.name] = upstream.id
+        end
+
+        assert.same(fixture_dict, upstreams_dict)
+      end)
+    end)
+
+    describe("get_upstream_by_name()", function()
+      it("retrieves a complete upstream based on its name", function()
+        setup_it_block(consistency)
+        for _, fixture in ipairs(UPSTREAMS_FIXTURES) do
+          local upstream = balancer.get_upstream_by_name(fixture.name)
+          assert.same(fixture, upstream)
+        end
+      end)
+    end)
+
+    describe("load_targets_into_memory()", function()
+      local targets
+      local upstream
+
+      it("retrieves all targets per upstream, ordered", function()
+        setup_it_block(consistency)
+        upstream = "a"
+        targets = balancer._load_targets_into_memory(upstream)
+        assert.equal(4, #targets)
+        assert(targets[1].id == "a3")
+        assert(targets[2].id == "a2")
+        assert(targets[3].id == "a4")
+        assert(targets[4].id == "a1")
+      end)
+    end)
+
+    describe("on_target_event()", function()
+      it("adding a target does not recreate a balancer", function()
+        if consistency == "strict" then
+          setup_it_block(consistency)
+          balancer._load_targets_into_memory("otes")
+          local b1 = balancer._create_balancer(upstream_otes)
+          assert.same(1, #(balancer._get_target_history(b1)))
+
+          table.insert(TARGETS_FIXTURES, {
+            id = "otes2",
+            created_at = "002",
+            upstream = { id = "otes" },
+            target = "localhost:1112",
+            weight = 10,
+          })
+          balancer.on_target_event("create", { upstream = { id = "otes" } })
+
+          local b2 = balancer._create_balancer(upstream_otes)
+          assert.same(2, #(balancer._get_target_history(b2)))
+
+          assert(b1 == b2)
+        else
+          setup_it_block(consistency)
+          balancer._load_targets_into_memory("otee")
+          local b1 = balancer._create_balancer(upstream_otee)
+          assert.same(1, #(balancer._get_target_history(b1)))
+
+          table.insert(TARGETS_FIXTURES, {
+            id = "otee2",
+            created_at = "002",
+            upstream = { id = "otee" },
+            target = "localhost:1112",
+            weight = 10,
+          })
+          balancer.on_target_event("create", { upstream = { id = "otee" } })
+
+          local b2 = balancer._create_balancer(upstream_otee)
+          assert.same(2, #(balancer._get_target_history(b2)))
+
+          assert(b1 == b2)
+        end
+      end)
+    end)
+
+    describe("post_health()", function()
+      local hc, my_balancer
+
+      lazy_setup(function()
+        my_balancer = assert(balancer._create_balancer(upstream_ph))
+        hc = assert(balancer._get_healthchecker(my_balancer))
+      end)
+
+      lazy_teardown(function()
+        if hc then
+          hc:stop()
+        end
+      end)
+
+      it("posts healthy/unhealthy using IP and hostname", function()
+        setup_it_block(consistency)
+        local tests = {
+          { host = "127.0.0.1", port = 2222, health = true },
+          { host = "127.0.0.1", port = 2222, health = false },
+          { host = "localhost", port = 1111, health = true },
+          { host = "localhost", port = 1111, health = false },
+        }
+        for _, t in ipairs(tests) do
+          assert(balancer.post_health(upstream_ph, t.host, nil, t.port, t.health))
+          local health_info = assert(balancer.get_upstream_health("ph"))
+          local response = t.health and "HEALTHY" or "UNHEALTHY"
+          assert.same(response,
+                      health_info[t.host .. ":" .. t.port].addresses[1].health)
+        end
+      end)
+
+      it("requires hostname if that was used in the Target", function()
+        local ok, err = balancer.post_health(upstream_ph, "127.0.0.1", nil, 1111, true)
+        assert.falsy(ok)
+        assert.match(err, "No host found by: '127.0.0.1:1111'")
+      end)
+
+      it("fails if upstream/balancer doesn't exist", function()
+        local bad = { name = "invalid", id = "bad" }
+        local ok, err = balancer.post_health(bad, "127.0.0.1", 1111, true)
+        assert.falsy(ok)
+        assert.match(err, "Upstream invalid has no balancer")
+      end)
+    end)
+
+    describe("healthcheck events", function()
+      it("(un)subscribe_to_healthcheck_events()", function()
+        setup_it_block(consistency)
+        local my_balancer = assert(balancer._create_balancer(upstream_hc))
+        local hc = assert(balancer._get_healthchecker(my_balancer))
+        local data = {}
+        local cb = function(upstream_id, ip, port, hostname, health)
+          table.insert(data, {
+            upstream_id = upstream_id,
+            ip = ip,
+            port = port,
+            hostname = hostname,
+            health = health,
+          })
+        end
+        balancer.subscribe_to_healthcheck_events(cb)
+        my_balancer.report_http_status({
+          address = {
+            ip = "127.0.0.1",
+            port = 1111,
+            host = {hostname = "localhost"},
+          }}, 429)
+        my_balancer.report_http_status({
+          address = {
+            ip = "127.0.0.1",
+            port = 1111,
+            host = {hostname = "localhost"},
+          }}, 200)
+        balancer.unsubscribe_from_healthcheck_events(cb)
+        my_balancer.report_http_status({
+          address = {
+            ip = "127.0.0.1",
+            port = 1111,
+            host = {hostname = "localhost"},
+          }}, 429)
+        hc:stop()
+        assert.same({
+          upstream_id = "hc_" .. consistency,
+          ip = "127.0.0.1",
+          port = 1111,
+          hostname = "localhost",
+          health = "unhealthy"
+        }, data[1])
+        assert.same({
+          upstream_id = "hc_" .. consistency,
+          ip = "127.0.0.1",
+          port = 1111,
+          hostname = "localhost",
+          health = "healthy"
+        }, data[2])
+        assert.same(nil, data[3])
+      end)
+    end)
+
+    describe("creating hash values", function()
+      local headers
+      local backup
+      before_each(function()
+        headers = setmetatable({}, {
+            __newindex = function(self, key, value)
+              rawset(self, key:upper(), value)
+            end,
+            __index = function(self, key)
+              return rawget(self, key:upper())
+            end,
+        })
+        backup = { ngx.req, ngx.var, ngx.ctx }
+        ngx.req = { get_headers = function() return headers end } -- luacheck: ignore
+        ngx.var = {}
+        ngx.ctx = {}
+      end)
+      after_each(function()
+        ngx.req = backup[1] -- luacheck: ignore
+        ngx.var = backup[2]
+        ngx.ctx = backup[3]
+      end)
       it("none", function()
         local hash = balancer._create_hash({
-            hash_on = "consumer",
-            hash_fallback = "none",
+            hash_on = "none",
         })
         assert.is_nil(hash)
       end)
@@ -622,9 +631,7 @@ describe("Balancer", function()
         local value = uuid()
         ngx.ctx.authenticated_consumer = { id = value }
         local hash = balancer._create_hash({
-            hash_on = "header",
-            hash_on_header = "non-existing",
-            hash_fallback = "consumer",
+            hash_on = "consumer",
         })
         assert.are.same(crc32(value), hash)
       end)
@@ -632,8 +639,7 @@ describe("Balancer", function()
         local value = "1.2.3.4"
         ngx.var.remote_addr = value
         local hash = balancer._create_hash({
-            hash_on = "consumer",
-            hash_fallback = "ip",
+            hash_on = "ip",
         })
         assert.are.same(crc32(value), hash)
       end)
@@ -641,21 +647,10 @@ describe("Balancer", function()
         local value = "some header value"
         headers.HeaderName = value
         local hash = balancer._create_hash({
-            hash_on = "consumer",
-            hash_fallback = "header",
-            hash_fallback_header = "HeaderName",
+            hash_on = "header",
+            hash_on_header = "HeaderName",
         })
         assert.are.same(crc32(value), hash)
-      end)
-      it("multi-header", function()
-        local value = { "some header value", "another value" }
-        headers.HeaderName = value
-        local hash = balancer._create_hash({
-            hash_on = "consumer",
-            hash_fallback = "header",
-            hash_fallback_header = "HeaderName",
-        })
-        assert.are.same(crc32(table.concat(value)), hash)
       end)
       describe("cookie", function()
         it("uses the cookie when present in the request", function()
@@ -663,8 +658,7 @@ describe("Balancer", function()
           ngx.var.cookie_Foo = value
           ngx.ctx.balancer_data = {}
           local hash = balancer._create_hash({
-            hash_on = "consumer",
-            hash_fallback = "cookie",
+            hash_on = "cookie",
             hash_on_cookie = "Foo",
           })
           assert.are.same(crc32(value), hash)
@@ -673,8 +667,7 @@ describe("Balancer", function()
         it("creates the cookie when not present in the request", function()
           ngx.ctx.balancer_data = {}
           balancer._create_hash({
-            hash_on = "consumer",
-            hash_fallback = "cookie",
+            hash_on = "cookie",
             hash_on_cookie = "Foo",
             hash_on_cookie_path = "/",
           })
@@ -682,7 +675,89 @@ describe("Balancer", function()
           assert.are.same(ngx.ctx.balancer_data.hash_cookie.path, "/")
         end)
       end)
+      it("multi-header", function()
+        local value = { "some header value", "another value" }
+        headers.HeaderName = value
+        local hash = balancer._create_hash({
+            hash_on = "header",
+            hash_on_header = "HeaderName",
+        })
+        assert.are.same(crc32(table.concat(value)), hash)
+      end)
+      describe("fallback", function()
+        it("none", function()
+          local hash = balancer._create_hash({
+              hash_on = "consumer",
+              hash_fallback = "none",
+          })
+          assert.is_nil(hash)
+        end)
+        it("consumer", function()
+          local value = uuid()
+          ngx.ctx.authenticated_consumer = { id = value }
+          local hash = balancer._create_hash({
+              hash_on = "header",
+              hash_on_header = "non-existing",
+              hash_fallback = "consumer",
+          })
+          assert.are.same(crc32(value), hash)
+        end)
+        it("ip", function()
+          local value = "1.2.3.4"
+          ngx.var.remote_addr = value
+          local hash = balancer._create_hash({
+              hash_on = "consumer",
+              hash_fallback = "ip",
+          })
+          assert.are.same(crc32(value), hash)
+        end)
+        it("header", function()
+          local value = "some header value"
+          headers.HeaderName = value
+          local hash = balancer._create_hash({
+              hash_on = "consumer",
+              hash_fallback = "header",
+              hash_fallback_header = "HeaderName",
+          })
+          assert.are.same(crc32(value), hash)
+        end)
+        it("multi-header", function()
+          local value = { "some header value", "another value" }
+          headers.HeaderName = value
+          local hash = balancer._create_hash({
+              hash_on = "consumer",
+              hash_fallback = "header",
+              hash_fallback_header = "HeaderName",
+          })
+          assert.are.same(crc32(table.concat(value)), hash)
+        end)
+        describe("cookie", function()
+          it("uses the cookie when present in the request", function()
+            local value = "some cookie value"
+            ngx.var.cookie_Foo = value
+            ngx.ctx.balancer_data = {}
+            local hash = balancer._create_hash({
+              hash_on = "consumer",
+              hash_fallback = "cookie",
+              hash_on_cookie = "Foo",
+            })
+            assert.are.same(crc32(value), hash)
+            assert.is_nil(ngx.ctx.balancer_data.hash_cookie)
+          end)
+          it("creates the cookie when not present in the request", function()
+            ngx.ctx.balancer_data = {}
+            balancer._create_hash({
+              hash_on = "consumer",
+              hash_fallback = "cookie",
+              hash_on_cookie = "Foo",
+              hash_on_cookie_path = "/",
+            })
+            assert.are.same(ngx.ctx.balancer_data.hash_cookie.key, "Foo")
+            assert.are.same(ngx.ctx.balancer_data.hash_cookie.path, "/")
+          end)
+        end)
+      end)
     end)
-  end)
 
-end)
+  end)
+end

--- a/spec/01-unit/14-dns_spec.lua
+++ b/spec/01-unit/14-dns_spec.lua
@@ -1,3 +1,44 @@
+local mocker = require "spec.fixtures.mocker"
+local balancer = require "kong.runloop.balancer"
+
+local function setup_it_block()
+  local cache_table = {}
+
+  local function mock_cache(cache_table, limit)
+    return {
+      safe_set = function(self, k, v)
+        if limit then
+          local n = 0
+          for _, _ in pairs(cache_table) do
+            n = n + 1
+          end
+          if n >= limit then
+            return nil, "no memory"
+          end
+        end
+        cache_table[k] = v
+        return true
+      end,
+      get = function(self, k, _, fn, arg)
+        if cache_table[k] == nil then
+          cache_table[k] = fn(arg)
+        end
+        return cache_table[k]
+      end,
+    }
+  end
+
+  mocker.setup(finally, {
+    kong = {
+      configuration = {
+        worker_consistency = "strict",
+      },
+      core_cache = mock_cache(cache_table),
+    }
+  })
+  balancer.init()
+end
+
 -- simple debug function
 local function dump(...)
   print(require("pl.pretty").write({...}))
@@ -5,7 +46,7 @@ end
 
 
 describe("DNS", function()
-  local balancer, resolver, query_func, old_new
+  local resolver, query_func, old_new
   local mock_records, singletons, client
 
   lazy_setup(function()
@@ -23,8 +64,7 @@ describe("DNS", function()
     }
     --]]
 
-    balancer = require "kong.runloop.balancer"
-    balancer.init()
+    singletons.origins = {}
 
     resolver = require "resty.dns.resolver"
     client = require "resty.dns.client"
@@ -86,6 +126,7 @@ describe("DNS", function()
   end)
 
   it("returns an error and 503 on a Name Error (3)", function()
+    setup_it_block()
     mock_records = {
       ["konghq.com:" .. resolver.TYPE_A] = { errcode = 3, errstr = "name error" },
       ["konghq.com:" .. resolver.TYPE_AAAA] = { errcode = 3, errstr = "name error" },
@@ -104,22 +145,25 @@ describe("DNS", function()
     assert.equals(503, code)
   end)
 
-  it("returns an error and 503 on an empty record", function()
-    mock_records = {
-      ["konghq.com:" .. resolver.TYPE_A] = {},
-      ["konghq.com:" .. resolver.TYPE_AAAA] = {},
-      ["konghq.com:" .. resolver.TYPE_CNAME] = {},
-      ["konghq.com:" .. resolver.TYPE_SRV] = {},
-    }
+  for _, consistency in ipairs({"strict", "eventual"}) do
+    it("returns an error and 503 on an empty record", function()
+      setup_it_block(consistency)
+      mock_records = {
+        ["konghq.com:" .. resolver.TYPE_A] = {},
+        ["konghq.com:" .. resolver.TYPE_AAAA] = {},
+        ["konghq.com:" .. resolver.TYPE_CNAME] = {},
+        ["konghq.com:" .. resolver.TYPE_SRV] = {},
+      }
 
-    local ip, port, code = balancer.execute({
-      type = "name",
-      port = nil,
-      host = "konghq.com",
-      try_count = 0,
-    })
-    assert.is_nil(ip)
-    assert.equals("name resolution failed", port)
-    assert.equals(503, code)
-  end)
+      local ip, port, code = balancer.execute({
+        type = "name",
+        port = nil,
+        host = "konghq.com",
+        try_count = 0,
+      })
+      assert.is_nil(ip)
+      assert.equals("name resolution failed", port)
+      assert.equals(503, code)
+    end)
+  end
 end)

--- a/spec/01-unit/16-runloop_handler_spec.lua
+++ b/spec/01-unit/16-runloop_handler_spec.lua
@@ -36,7 +36,7 @@ local function setup_it_block()
       },
       configuration = {
         database = "dummy",
-        router_consistency = "strict",
+        worker_consistency = "strict",
       },
       db = {
         strategy = "dummy",
@@ -163,10 +163,10 @@ describe("runloop handler", function()
       assert.equal(1, semaphores[1].value)
     end)
 
-    it("does not call update_router if router_consistency is eventual", function()
+    it("does not call update_router if worker_consistency is eventual", function()
       setup_it_block()
 
-      kong.configuration.router_consistency = "eventual"
+      kong.configuration.worker_consistency = "eventual"
 
       local handler = require "kong.runloop.handler"
 
@@ -182,10 +182,10 @@ describe("runloop handler", function()
       assert.equal(mock_router, handler._get_updated_router())
     end)
 
-    it("calls build_router if router version changes and router_consistency is strict", function()
+    it("calls build_router if router version changes and worker_consistency is strict", function()
       setup_it_block()
 
-      kong.configuration.router_consistency = "strict"
+      kong.configuration.worker_consistency = "strict"
 
       local handler = require "kong.runloop.handler"
 
@@ -220,10 +220,10 @@ describe("runloop handler", function()
       assert.not_equal(saved_router, latest_router)
     end)
 
-    it("does not call build_router if router version does not change and router_consistency is strict", function()
+    it("does not call build_router if router version does not change and worker_consistency is strict", function()
       setup_it_block()
 
-      kong.configuration.router_consistency = "strict"
+      kong.configuration.worker_consistency = "strict"
 
       local handler = require "kong.runloop.handler"
 

--- a/spec/02-integration/05-proxy/10-balancer/01-ring-balancer_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer/01-ring-balancer_spec.lua
@@ -9,6 +9,7 @@ local cjson = require "cjson"
 local FIRST_PORT = 20000
 local SLOTS = 10
 local HEALTHCHECK_INTERVAL = 0.01
+local CONSISTENCY_FREQ = 1
 
 local healthchecks_defaults = {
   active = {
@@ -457,7 +458,7 @@ local function begin_testcase_setup_update(strategy, bp)
 end
 
 
-local function end_testcase_setup(strategy, bp)
+local function end_testcase_setup(strategy, bp, consistency)
   if strategy == "off" then
     local cfg = bp.done()
     local yaml = declarative.to_yaml_string(cfg)
@@ -474,6 +475,9 @@ local function end_testcase_setup(strategy, bp)
     })
     assert.res_status(201, res)
     admin_client:close()
+  end
+  if consistency == "eventual" then
+    ngx.sleep(CONSISTENCY_FREQ*2) -- wait for proxy state consistency timer
   end
 end
 
@@ -494,824 +498,1642 @@ local localhosts = {
 }
 
 
-for _, strategy in helpers.each_strategy() do
+for _, consistency in ipairs({"strict", "eventual"}) do
+  for _, strategy in helpers.each_strategy() do
 
-  local bp
+    local bp
 
-  describe("Ring-balancer resolution #" .. strategy, function()
-
-    lazy_setup(function()
-      bp = get_db_utils_for_dc_and_admin_api(strategy, {
-        "routes",
-        "services",
-        "plugins",
-        "upstreams",
-        "targets",
-      })
-
-      local fixtures = {
-        dns_mock = helpers.dns_mock.new()
-      }
-
-      fixtures.dns_mock:SRV {
-        name = "my.srv.test.com",
-        target = "a.my.srv.test.com",
-        port = 80,  -- port should fail to connect
-      }
-      fixtures.dns_mock:A {
-        name = "a.my.srv.test.com",
-        address = "127.0.0.1",
-      }
-
-      fixtures.dns_mock:A {
-        name = "multiple-ips.test",
-        address = "127.0.0.1",
-      }
-      fixtures.dns_mock:A {
-        name = "multiple-ips.test",
-        address = "127.0.0.2",
-      }
-
-      fixtures.dns_mock:SRV {
-        name = "srv-changes-port.test",
-        target = "a-changes-port.test",
-        port = 90,  -- port should fail to connect
-      }
-
-      fixtures.dns_mock:A {
-        name = "a-changes-port.test",
-        address = "127.0.0.3",
-      }
-      fixtures.dns_mock:A {
-        name = "another.multiple-ips.test",
-        address = "127.0.0.1",
-      }
-      fixtures.dns_mock:A {
-        name = "another.multiple-ips.test",
-        address = "127.0.0.2",
-      }
-
-      assert(helpers.start_kong({
-        database   = strategy,
-        nginx_conf = "spec/fixtures/custom_nginx.template",
-        db_update_frequency = 0.1,
-      }, nil, nil, fixtures))
-
-    end)
-
-    lazy_teardown(function()
-      helpers.stop_kong()
-    end)
-
-    it("2-level dns sets the proper health-check", function()
-
-      -- Issue is that 2 level dns hits a mismatch between a name
-      -- in the second level, and the IP address that failed.
-      -- Typically an SRV pointing to an A record will result in a
-      -- internal balancer structure Address that hold a name rather
-      -- than an IP. So when Kong reports IP xyz failed to connect,
-      -- and the healthchecker marks it as down. That IP will not be
-      -- found in the balancer (since its only known by name), and hence
-      -- and error is returned that the target could not be disabled.
-
-      -- configure healthchecks
-      begin_testcase_setup(strategy, bp)
-      local upstream_name, upstream_id = add_upstream(bp, {
-        healthchecks = healthchecks_config {
-          passive = {
-            unhealthy = {
-              tcp_failures = 1,
-            }
-          }
-        }
-      })
-      -- the following port will not be used, will be overwritten by
-      -- the mocked SRV record.
-      add_target(bp, upstream_id, "my.srv.test.com", 80)
-      local api_host = add_api(bp, upstream_name)
-      end_testcase_setup(strategy, bp)
-
-      -- we do not set up servers, since we want the connection to get refused
-      -- Go hit the api with requests, 1x round the balancer
-      local oks, fails, last_status = client_requests(SLOTS, api_host)
-      assert.same(0, oks)
-      assert.same(10, fails)
-      assert.same(503, last_status)
-
-      local health = get_upstream_health(upstream_name)
-      assert.is.table(health)
-      assert.is.table(health.data)
-      assert.is.table(health.data[1])
-      assert.equals("UNHEALTHY", health.data[1].health)
-    end)
-
-    it("a target that resolves to 2 IPs reports health separately", function()
-
-      -- configure healthchecks
-      begin_testcase_setup(strategy, bp)
-      local upstream_name, upstream_id = add_upstream(bp, {
-        healthchecks = healthchecks_config {
-          passive = {
-            unhealthy = {
-              tcp_failures = 1,
-            }
-          }
-        }
-      })
-      -- the following port will not be used, will be overwritten by
-      -- the mocked SRV record.
-      add_target(bp, upstream_id, "multiple-ips.test", 80)
-      local api_host = add_api(bp, upstream_name)
-      end_testcase_setup(strategy, bp)
-
-      -- we do not set up servers, since we want the connection to get refused
-      -- Go hit the api with requests, 1x round the balancer
-      local oks, fails, last_status = client_requests(SLOTS, api_host)
-      assert.same(0, oks)
-      assert.same(10, fails)
-      assert.same(503, last_status)
-
-      local health = get_upstream_health(upstream_name)
-      assert.is.table(health)
-      assert.is.table(health.data)
-      assert.is.table(health.data[1])
-      assert.same("127.0.0.1", health.data[1].data.addresses[1].ip)
-      assert.same("127.0.0.2", health.data[1].data.addresses[2].ip)
-      assert.equals("UNHEALTHY", health.data[1].health)
-      assert.equals("UNHEALTHY", health.data[1].data.addresses[1].health)
-      assert.equals("UNHEALTHY", health.data[1].data.addresses[2].health)
-
-      local status = post_target_address_health(upstream_id, "multiple-ips.test:80", "127.0.0.2:80", "healthy")
-      assert.same(204, status)
-
-      health = get_upstream_health(upstream_name)
-      assert.is.table(health)
-      assert.is.table(health.data)
-      assert.is.table(health.data[1])
-      assert.same("127.0.0.1", health.data[1].data.addresses[1].ip)
-      assert.same("127.0.0.2", health.data[1].data.addresses[2].ip)
-      assert.equals("HEALTHY", health.data[1].health)
-      assert.equals("UNHEALTHY", health.data[1].data.addresses[1].health)
-      assert.equals("HEALTHY", health.data[1].data.addresses[2].health)
-
-      local status = post_target_address_health(upstream_id, "multiple-ips.test:80", "127.0.0.2:80", "unhealthy")
-      assert.same(204, status)
-
-      health = get_upstream_health(upstream_name)
-      assert.is.table(health)
-      assert.is.table(health.data)
-      assert.is.table(health.data[1])
-      assert.same("127.0.0.1", health.data[1].data.addresses[1].ip)
-      assert.same("127.0.0.2", health.data[1].data.addresses[2].ip)
-      assert.equals("UNHEALTHY", health.data[1].health)
-      assert.equals("UNHEALTHY", health.data[1].data.addresses[1].health)
-      assert.equals("UNHEALTHY", health.data[1].data.addresses[2].health)
-
-    end)
-
-    it("a target that resolves to 2 IPs reports health separately (upstream with hostname set)", function()
-
-      -- configure healthchecks
-      begin_testcase_setup(strategy, bp)
-      local upstream_name, upstream_id = add_upstream(bp, {
-        host_header = "another.multiple-ips.test",
-        healthchecks = healthchecks_config {
-          passive = {
-            unhealthy = {
-              tcp_failures = 1,
-            }
-          }
-        }
-      })
-      -- the following port will not be used, will be overwritten by
-      -- the mocked SRV record.
-      add_target(bp, upstream_id, "multiple-ips.test", 80)
-      local api_host = add_api(bp, upstream_name)
-      end_testcase_setup(strategy, bp)
-
-      -- we do not set up servers, since we want the connection to get refused
-      -- Go hit the api with requests, 1x round the balancer
-      local oks, fails, last_status = client_requests(SLOTS, api_host)
-      assert.same(0, oks)
-      assert.same(10, fails)
-      assert.same(503, last_status)
-
-      local health = get_upstream_health(upstream_name)
-      assert.is.table(health)
-      assert.is.table(health.data)
-      assert.is.table(health.data[1])
-
-      assert.same("127.0.0.1", health.data[1].data.addresses[1].ip)
-      assert.same("127.0.0.2", health.data[1].data.addresses[2].ip)
-      assert.equals("UNHEALTHY", health.data[1].health)
-      assert.equals("UNHEALTHY", health.data[1].data.addresses[1].health)
-      assert.equals("UNHEALTHY", health.data[1].data.addresses[2].health)
-
-      local status = post_target_address_health(upstream_id, "multiple-ips.test:80", "127.0.0.2:80", "healthy")
-      assert.same(204, status)
-
-      health = get_upstream_health(upstream_name)
-      assert.is.table(health)
-      assert.is.table(health.data)
-      assert.is.table(health.data[1])
-      assert.same("127.0.0.1", health.data[1].data.addresses[1].ip)
-      assert.same("127.0.0.2", health.data[1].data.addresses[2].ip)
-      assert.equals("HEALTHY", health.data[1].health)
-      assert.equals("UNHEALTHY", health.data[1].data.addresses[1].health)
-      assert.equals("HEALTHY", health.data[1].data.addresses[2].health)
-
-      local status = post_target_address_health(upstream_id, "multiple-ips.test:80", "127.0.0.2:80", "unhealthy")
-      assert.same(204, status)
-
-      health = get_upstream_health(upstream_name)
-      assert.is.table(health)
-      assert.is.table(health.data)
-      assert.is.table(health.data[1])
-      assert.same("127.0.0.1", health.data[1].data.addresses[1].ip)
-      assert.same("127.0.0.2", health.data[1].data.addresses[2].ip)
-      assert.equals("UNHEALTHY", health.data[1].health)
-      assert.equals("UNHEALTHY", health.data[1].data.addresses[1].health)
-      assert.equals("UNHEALTHY", health.data[1].data.addresses[2].health)
-
-    end)
-
-    it("a target that resolves to an SRV record that changes port", function()
-
-      -- configure healthchecks
-      begin_testcase_setup(strategy, bp)
-      local upstream_name, upstream_id = add_upstream(bp, {
-        healthchecks = healthchecks_config {
-          passive = {
-            unhealthy = {
-              tcp_failures = 1,
-            }
-          }
-        }
-      })
-      -- the following port will not be used, will be overwritten by
-      -- the mocked SRV record.
-      add_target(bp, upstream_id, "srv-changes-port.test", 80)
-      local api_host = add_api(bp, upstream_name)
-      end_testcase_setup(strategy, bp)
-
-      -- we do not set up servers, since we want the connection to get refused
-      -- Go hit the api with requests, 1x round the balancer
-      local oks, fails, last_status = client_requests(SLOTS, api_host)
-      assert.same(0, oks)
-      assert.same(10, fails)
-      assert.same(503, last_status)
-
-      local health = get_upstream_health(upstream_name)
-      assert.is.table(health)
-      assert.is.table(health.data)
-      assert.is.table(health.data[1])
-
-      assert.same("a-changes-port.test", health.data[1].data.addresses[1].ip)
-      assert.same(90, health.data[1].data.addresses[1].port)
-
-      assert.equals("UNHEALTHY", health.data[1].health)
-      assert.equals("UNHEALTHY", health.data[1].data.addresses[1].health)
-
-      local status = post_target_address_health(upstream_id, "srv-changes-port.test:80", "a-changes-port.test:90", "healthy")
-      assert.same(204, status)
-
-      health = get_upstream_health(upstream_name)
-      assert.is.table(health)
-      assert.is.table(health.data)
-      assert.is.table(health.data[1])
-
-      assert.same("a-changes-port.test", health.data[1].data.addresses[1].ip)
-      assert.same(90, health.data[1].data.addresses[1].port)
-
-      assert.equals("HEALTHY", health.data[1].health)
-      assert.equals("HEALTHY", health.data[1].data.addresses[1].health)
-    end)
-
-    it("a target that has healthchecks disabled", function()
-      -- configure healthchecks
-      begin_testcase_setup(strategy, bp)
-      local upstream_name, upstream_id = add_upstream(bp, {
-        healthchecks = healthchecks_config {
-          passive = {
-            unhealthy = {
-              http_failures = 0,
-              tcp_failures = 0,
-              timeouts = 0,
-            },
-          },
-          active = {
-            healthy = {
-              interval = 0,
-            },
-            unhealthy = {
-              interval = 0,
-            },
-          },
-        }
-      })
-      add_target(bp, upstream_id, "multiple-ips.test", 80)
-      add_api(bp, upstream_name)
-      end_testcase_setup(strategy, bp)
-      local health = get_upstream_health(upstream_name)
-      assert.is.table(health)
-      assert.is.table(health.data)
-      assert.is.table(health.data[1])
-      assert.equals("HEALTHCHECKS_OFF", health.data[1].health)
-      assert.equals("HEALTHCHECKS_OFF", health.data[1].data.addresses[1].health)
-    end)
-
-  end)
-
-  describe("Ring-balancer #" .. strategy, function()
-
-    lazy_setup(function()
-      bp = get_db_utils_for_dc_and_admin_api(strategy, {
-        "services",
-        "routes",
-        "upstreams",
-        "targets",
-      })
-
-      assert(helpers.start_kong({
-        database   = strategy,
-        nginx_conf = "spec/fixtures/custom_nginx.template",
-        lua_ssl_trusted_certificate = "spec/fixtures/kong_spec.crt",
-        stream_listen = "0.0.0.0:9100",
-        db_update_frequency = 0.1,
-        plugins = "bundled,fail-once-auth",
-      }))
-    end)
-
-    lazy_teardown(function()
-      helpers.stop_kong()
-    end)
-
-    describe("#healthchecks (#cluster #db)", function()
-
-      -- second node ports are Kong test ports + 10
-      local proxy_port_1 = 9000
-      local admin_port_1 = 9001
-      local proxy_port_2 = 9010
-      local admin_port_2 = 9011
+    describe("Ring-balancer resolution #" .. strategy .. " #" .. consistency, function()
 
       lazy_setup(function()
-        -- start a second Kong instance
-        helpers.start_kong({
-          database   = strategy,
-          admin_listen = "127.0.0.1:" .. admin_port_2,
-          proxy_listen = "127.0.0.1:" .. proxy_port_2,
-          stream_listen = "off",
-          prefix = "servroot2",
-          log_level = "debug",
-          db_update_frequency = 0.1,
+        bp = get_db_utils_for_dc_and_admin_api(strategy, {
+          "routes",
+          "services",
+          "plugins",
+          "upstreams",
+          "targets",
         })
+
+        local fixtures = {
+          dns_mock = helpers.dns_mock.new()
+        }
+
+        fixtures.dns_mock:SRV {
+          name = "my.srv.test.com",
+          target = "a.my.srv.test.com",
+          port = 80,  -- port should fail to connect
+        }
+        fixtures.dns_mock:A {
+          name = "a.my.srv.test.com",
+          address = "127.0.0.1",
+        }
+
+        fixtures.dns_mock:A {
+          name = "multiple-ips.test",
+          address = "127.0.0.1",
+        }
+        fixtures.dns_mock:A {
+          name = "multiple-ips.test",
+          address = "127.0.0.2",
+        }
+
+        fixtures.dns_mock:SRV {
+          name = "srv-changes-port.test",
+          target = "a-changes-port.test",
+          port = 90,  -- port should fail to connect
+        }
+
+        fixtures.dns_mock:A {
+          name = "a-changes-port.test",
+          address = "127.0.0.3",
+        }
+        fixtures.dns_mock:A {
+          name = "another.multiple-ips.test",
+          address = "127.0.0.1",
+        }
+        fixtures.dns_mock:A {
+          name = "another.multiple-ips.test",
+          address = "127.0.0.2",
+        }
+
+        assert(helpers.start_kong({
+          database   = strategy,
+          nginx_conf = "spec/fixtures/custom_nginx.template",
+          db_update_frequency = 0.1,
+          worker_consistency = consistency,
+          worker_state_update_frequency = CONSISTENCY_FREQ,
+        }, nil, nil, fixtures))
+
       end)
 
       lazy_teardown(function()
-        helpers.stop_kong("servroot2")
+        helpers.stop_kong()
+      end)
+
+      it("2-level dns sets the proper health-check", function()
+
+        -- Issue is that 2 level dns hits a mismatch between a name
+        -- in the second level, and the IP address that failed.
+        -- Typically an SRV pointing to an A record will result in a
+        -- internal balancer structure Address that hold a name rather
+        -- than an IP. So when Kong reports IP xyz failed to connect,
+        -- and the healthchecker marks it as down. That IP will not be
+        -- found in the balancer (since its only known by name), and hence
+        -- and error is returned that the target could not be disabled.
+
+        -- configure healthchecks
+        begin_testcase_setup(strategy, bp)
+        local upstream_name, upstream_id = add_upstream(bp, {
+          healthchecks = healthchecks_config {
+            passive = {
+              unhealthy = {
+                tcp_failures = 1,
+              }
+            }
+          }
+        })
+        -- the following port will not be used, will be overwritten by
+        -- the mocked SRV record.
+        add_target(bp, upstream_id, "my.srv.test.com", 80)
+        local api_host = add_api(bp, upstream_name)
+        end_testcase_setup(strategy, bp, consistency)
+
+        -- we do not set up servers, since we want the connection to get refused
+        -- Go hit the api with requests, 1x round the balancer
+        local oks, fails, last_status = client_requests(SLOTS, api_host)
+        assert.same(0, oks)
+        assert.same(10, fails)
+        assert.same(503, last_status)
+
+        local health = get_upstream_health(upstream_name)
+        assert.is.table(health)
+        assert.is.table(health.data)
+        assert.is.table(health.data[1])
+        assert.equals("UNHEALTHY", health.data[1].health)
+      end)
+
+      it("a target that resolves to 2 IPs reports health separately", function()
+
+        -- configure healthchecks
+        begin_testcase_setup(strategy, bp)
+        local upstream_name, upstream_id = add_upstream(bp, {
+          healthchecks = healthchecks_config {
+            passive = {
+              unhealthy = {
+                tcp_failures = 1,
+              }
+            }
+          }
+        })
+        -- the following port will not be used, will be overwritten by
+        -- the mocked SRV record.
+        add_target(bp, upstream_id, "multiple-ips.test", 80)
+        local api_host = add_api(bp, upstream_name)
+        end_testcase_setup(strategy, bp, consistency)
+
+        -- we do not set up servers, since we want the connection to get refused
+        -- Go hit the api with requests, 1x round the balancer
+        local oks, fails, last_status = client_requests(SLOTS, api_host)
+        assert.same(0, oks)
+        assert.same(10, fails)
+        assert.same(503, last_status)
+
+        local health = get_upstream_health(upstream_name)
+        assert.is.table(health)
+        assert.is.table(health.data)
+        assert.is.table(health.data[1])
+        assert.same("127.0.0.1", health.data[1].data.addresses[1].ip)
+        assert.same("127.0.0.2", health.data[1].data.addresses[2].ip)
+        assert.equals("UNHEALTHY", health.data[1].health)
+        assert.equals("UNHEALTHY", health.data[1].data.addresses[1].health)
+        assert.equals("UNHEALTHY", health.data[1].data.addresses[2].health)
+
+        local status = post_target_address_health(upstream_id, "multiple-ips.test:80", "127.0.0.2:80", "healthy")
+        assert.same(204, status)
+
+        health = get_upstream_health(upstream_name)
+        assert.is.table(health)
+        assert.is.table(health.data)
+        assert.is.table(health.data[1])
+        assert.same("127.0.0.1", health.data[1].data.addresses[1].ip)
+        assert.same("127.0.0.2", health.data[1].data.addresses[2].ip)
+        assert.equals("HEALTHY", health.data[1].health)
+        assert.equals("UNHEALTHY", health.data[1].data.addresses[1].health)
+        assert.equals("HEALTHY", health.data[1].data.addresses[2].health)
+
+        local status = post_target_address_health(upstream_id, "multiple-ips.test:80", "127.0.0.2:80", "unhealthy")
+        assert.same(204, status)
+
+        health = get_upstream_health(upstream_name)
+        assert.is.table(health)
+        assert.is.table(health.data)
+        assert.is.table(health.data[1])
+        assert.same("127.0.0.1", health.data[1].data.addresses[1].ip)
+        assert.same("127.0.0.2", health.data[1].data.addresses[2].ip)
+        assert.equals("UNHEALTHY", health.data[1].health)
+        assert.equals("UNHEALTHY", health.data[1].data.addresses[1].health)
+        assert.equals("UNHEALTHY", health.data[1].data.addresses[2].health)
+
+      end)
+
+      it("a target that resolves to 2 IPs reports health separately (upstream with hostname set)", function()
+
+        -- configure healthchecks
+        begin_testcase_setup(strategy, bp)
+        local upstream_name, upstream_id = add_upstream(bp, {
+          host_header = "another.multiple-ips.test",
+          healthchecks = healthchecks_config {
+            passive = {
+              unhealthy = {
+                tcp_failures = 1,
+              }
+            }
+          }
+        })
+        -- the following port will not be used, will be overwritten by
+        -- the mocked SRV record.
+        add_target(bp, upstream_id, "multiple-ips.test", 80)
+        local api_host = add_api(bp, upstream_name)
+        end_testcase_setup(strategy, bp, consistency)
+
+        -- we do not set up servers, since we want the connection to get refused
+        -- Go hit the api with requests, 1x round the balancer
+        local oks, fails, last_status = client_requests(SLOTS, api_host)
+        assert.same(0, oks)
+        assert.same(10, fails)
+        assert.same(503, last_status)
+
+        local health = get_upstream_health(upstream_name)
+        assert.is.table(health)
+        assert.is.table(health.data)
+        assert.is.table(health.data[1])
+
+        assert.same("127.0.0.1", health.data[1].data.addresses[1].ip)
+        assert.same("127.0.0.2", health.data[1].data.addresses[2].ip)
+        assert.equals("UNHEALTHY", health.data[1].health)
+        assert.equals("UNHEALTHY", health.data[1].data.addresses[1].health)
+        assert.equals("UNHEALTHY", health.data[1].data.addresses[2].health)
+
+        local status = post_target_address_health(upstream_id, "multiple-ips.test:80", "127.0.0.2:80", "healthy")
+        assert.same(204, status)
+
+        health = get_upstream_health(upstream_name)
+        assert.is.table(health)
+        assert.is.table(health.data)
+        assert.is.table(health.data[1])
+        assert.same("127.0.0.1", health.data[1].data.addresses[1].ip)
+        assert.same("127.0.0.2", health.data[1].data.addresses[2].ip)
+        assert.equals("HEALTHY", health.data[1].health)
+        assert.equals("UNHEALTHY", health.data[1].data.addresses[1].health)
+        assert.equals("HEALTHY", health.data[1].data.addresses[2].health)
+
+        local status = post_target_address_health(upstream_id, "multiple-ips.test:80", "127.0.0.2:80", "unhealthy")
+        assert.same(204, status)
+
+        health = get_upstream_health(upstream_name)
+        assert.is.table(health)
+        assert.is.table(health.data)
+        assert.is.table(health.data[1])
+        assert.same("127.0.0.1", health.data[1].data.addresses[1].ip)
+        assert.same("127.0.0.2", health.data[1].data.addresses[2].ip)
+        assert.equals("UNHEALTHY", health.data[1].health)
+        assert.equals("UNHEALTHY", health.data[1].data.addresses[1].health)
+        assert.equals("UNHEALTHY", health.data[1].data.addresses[2].health)
+
+      end)
+
+      it("a target that resolves to an SRV record that changes port", function()
+
+        -- configure healthchecks
+        begin_testcase_setup(strategy, bp)
+        local upstream_name, upstream_id = add_upstream(bp, {
+          healthchecks = healthchecks_config {
+            passive = {
+              unhealthy = {
+                tcp_failures = 1,
+              }
+            }
+          }
+        })
+        -- the following port will not be used, will be overwritten by
+        -- the mocked SRV record.
+        add_target(bp, upstream_id, "srv-changes-port.test", 80)
+        local api_host = add_api(bp, upstream_name)
+        end_testcase_setup(strategy, bp, consistency)
+
+        -- we do not set up servers, since we want the connection to get refused
+        -- Go hit the api with requests, 1x round the balancer
+        local oks, fails, last_status = client_requests(SLOTS, api_host)
+        assert.same(0, oks)
+        assert.same(10, fails)
+        assert.same(503, last_status)
+
+        local health = get_upstream_health(upstream_name)
+        assert.is.table(health)
+        assert.is.table(health.data)
+        assert.is.table(health.data[1])
+
+        assert.same("a-changes-port.test", health.data[1].data.addresses[1].ip)
+        assert.same(90, health.data[1].data.addresses[1].port)
+
+        assert.equals("UNHEALTHY", health.data[1].health)
+        assert.equals("UNHEALTHY", health.data[1].data.addresses[1].health)
+
+        local status = post_target_address_health(upstream_id, "srv-changes-port.test:80", "a-changes-port.test:90", "healthy")
+        assert.same(204, status)
+
+        health = get_upstream_health(upstream_name)
+        assert.is.table(health)
+        assert.is.table(health.data)
+        assert.is.table(health.data[1])
+
+        assert.same("a-changes-port.test", health.data[1].data.addresses[1].ip)
+        assert.same(90, health.data[1].data.addresses[1].port)
+
+        assert.equals("HEALTHY", health.data[1].health)
+        assert.equals("HEALTHY", health.data[1].data.addresses[1].health)
+      end)
+
+      it("a target that has healthchecks disabled", function()
+        -- configure healthchecks
+        begin_testcase_setup(strategy, bp)
+        local upstream_name, upstream_id = add_upstream(bp, {
+          healthchecks = healthchecks_config {
+            passive = {
+              unhealthy = {
+                http_failures = 0,
+                tcp_failures = 0,
+                timeouts = 0,
+              },
+            },
+            active = {
+              healthy = {
+                interval = 0,
+              },
+              unhealthy = {
+                interval = 0,
+              },
+            },
+          }
+        })
+        add_target(bp, upstream_id, "multiple-ips.test", 80)
+        add_api(bp, upstream_name)
+        end_testcase_setup(strategy, bp, consistency)
+        local health = get_upstream_health(upstream_name)
+        assert.is.table(health)
+        assert.is.table(health.data)
+        assert.is.table(health.data[1])
+        assert.equals("HEALTHCHECKS_OFF", health.data[1].health)
+        assert.equals("HEALTHCHECKS_OFF", health.data[1].data.addresses[1].health)
+      end)
+
+    end)
+
+    describe("Ring-balancer #" .. strategy .. " #" .. consistency, function()
+
+      lazy_setup(function()
+        bp = get_db_utils_for_dc_and_admin_api(strategy, {
+          "services",
+          "routes",
+          "upstreams",
+          "targets",
+        })
+
+        assert(helpers.start_kong({
+          database   = strategy,
+          nginx_conf = "spec/fixtures/custom_nginx.template",
+          lua_ssl_trusted_certificate = "spec/fixtures/kong_spec.crt",
+          stream_listen = "off",
+          db_update_frequency = 0.1,
+          plugins = "bundled,fail-once-auth",
+          worker_consistency = consistency,
+          worker_state_update_frequency = CONSISTENCY_FREQ,
+        }))
+      end)
+
+      lazy_teardown(function()
+        helpers.stop_kong()
+      end)
+
+      describe("#healthchecks (#cluster #db)", function()
+
+        -- second node ports are Kong test ports + 10
+        local proxy_port_1 = 9000
+        local admin_port_1 = 9001
+        local proxy_port_2 = 9010
+        local admin_port_2 = 9011
+
+        lazy_setup(function()
+          -- start a second Kong instance
+          helpers.start_kong({
+            database   = strategy,
+            admin_listen = "127.0.0.1:" .. admin_port_2,
+            proxy_listen = "127.0.0.1:" .. proxy_port_2,
+            stream_listen = "off",
+            prefix = "servroot2",
+            log_level = "debug",
+            db_update_frequency = 0.1,
+            worker_consistency = consistency,
+            worker_state_update_frequency = CONSISTENCY_FREQ,
+          })
+        end)
+
+        lazy_teardown(function()
+          helpers.stop_kong("servroot2")
+        end)
+
+        for mode, localhost in pairs(localhosts) do
+
+          describe("#" .. mode, function()
+
+            it("does not perform health checks when disabled (#3304)", function()
+
+              begin_testcase_setup(strategy, bp)
+              local old_rv = get_router_version(admin_port_2)
+              local upstream_name, upstream_id = add_upstream(bp)
+              local port = add_target(bp, upstream_id, localhost)
+              local api_host = add_api(bp, upstream_name)
+              wait_for_router_update(bp, old_rv, localhost, proxy_port_2, admin_port_2)
+              end_testcase_setup(strategy, bp, consistency)
+
+              -- server responds, then fails, then responds again
+              local server = http_server(localhost, port, { 20, 20, 20 })
+
+              local seq = {
+                { port = proxy_port_2, oks = 10, fails = 0, last_status = 200 },
+                { port = proxy_port_1, oks = 10, fails = 0, last_status = 200 },
+                { port = proxy_port_2, oks = 0, fails = 10, last_status = 500 },
+                { port = proxy_port_1, oks = 0, fails = 10, last_status = 500 },
+                { port = proxy_port_2, oks = 10, fails = 0, last_status = 200 },
+                { port = proxy_port_1, oks = 10, fails = 0, last_status = 200 },
+              }
+              for i, test in ipairs(seq) do
+                local oks, fails, last_status = client_requests(10, api_host, "127.0.0.1", test.port)
+                assert.same(test.oks, oks, "iteration " .. tostring(i))
+                assert.same(test.fails, fails, "iteration " .. tostring(i))
+                assert.same(test.last_status, last_status, "iteration " .. tostring(i))
+              end
+
+              -- collect server results
+              local _, server_oks, server_fails = server:done()
+              assert.same(40, server_oks)
+              assert.same(20, server_fails)
+
+            end)
+
+            it("propagates posted health info #flaky", function()
+
+              begin_testcase_setup(strategy, bp)
+              local old_rv = get_router_version(admin_port_2)
+              local _, upstream_id = add_upstream(bp, {
+                healthchecks = healthchecks_config {}
+              })
+              local port = add_target(bp, upstream_id, localhost)
+              wait_for_router_update(old_rv, localhost, proxy_port_2, admin_port_2)
+              end_testcase_setup(strategy, bp, consistency)
+
+              local health1 = get_upstream_health(upstream_id, admin_port_1)
+              local health2 = get_upstream_health(upstream_id, admin_port_2)
+
+              assert.same("HEALTHY", health1.data[1].health)
+              assert.same("HEALTHY", health2.data[1].health)
+
+              post_target_endpoint(upstream_id, localhost, port, "unhealthy")
+
+              poll_wait_health(upstream_id, localhost, port, "UNHEALTHY", admin_port_1)
+              poll_wait_health(upstream_id, localhost, port, "UNHEALTHY", admin_port_2)
+
+            end)
+
+          end)
+        end
       end)
 
       for mode, localhost in pairs(localhosts) do
 
         describe("#" .. mode, function()
 
-          it("does not perform health checks when disabled (#3304)", function()
+          describe("Upstream entities", function()
 
-            begin_testcase_setup(strategy, bp)
-            local old_rv = get_router_version(admin_port_2)
-            local upstream_name, upstream_id = add_upstream(bp)
-            local port = add_target(bp, upstream_id, localhost)
-            local api_host = add_api(bp, upstream_name)
-            wait_for_router_update(bp, old_rv, localhost, proxy_port_2, admin_port_2)
-            end_testcase_setup(strategy, bp)
+            -- Regression test for a missing invalidation in 0.12rc1
+            it("created via the API are functional", function()
+              begin_testcase_setup(strategy, bp)
+              local upstream_name, upstream_id = add_upstream(bp)
+              local target_port = add_target(bp, upstream_id, localhost)
+              local api_host = add_api(bp, upstream_name)
+              end_testcase_setup(strategy, bp, consistency)
 
-            -- server responds, then fails, then responds again
-            local server = http_server(localhost, port, { 20, 20, 20 })
+              local server = http_server(localhost, target_port, { 1 })
 
-            local seq = {
-              { port = proxy_port_2, oks = 10, fails = 0, last_status = 200 },
-              { port = proxy_port_1, oks = 10, fails = 0, last_status = 200 },
-              { port = proxy_port_2, oks = 0, fails = 10, last_status = 500 },
-              { port = proxy_port_1, oks = 0, fails = 10, last_status = 500 },
-              { port = proxy_port_2, oks = 10, fails = 0, last_status = 200 },
-              { port = proxy_port_1, oks = 10, fails = 0, last_status = 200 },
-            }
-            for i, test in ipairs(seq) do
-              local oks, fails, last_status = client_requests(10, api_host, "127.0.0.1", test.port)
-              assert.same(test.oks, oks, "iteration " .. tostring(i))
-              assert.same(test.fails, fails, "iteration " .. tostring(i))
-              assert.same(test.last_status, last_status, "iteration " .. tostring(i))
-            end
+              local oks, fails, last_status = client_requests(1, api_host)
+              assert.same(200, last_status)
+              assert.same(1, oks)
+              assert.same(0, fails)
 
-            -- collect server results
-            local _, server_oks, server_fails = server:done()
-            assert.same(40, server_oks)
-            assert.same(20, server_fails)
+              local _, server_oks, server_fails = server:done()
+              assert.same(1, server_oks)
+              assert.same(0, server_fails)
+            end)
 
-          end)
-
-          it("propagates posted health info #flaky", function()
-
-            begin_testcase_setup(strategy, bp)
-            local old_rv = get_router_version(admin_port_2)
-            local _, upstream_id = add_upstream(bp, {
-              healthchecks = healthchecks_config {}
-            })
-            local port = add_target(bp, upstream_id, localhost)
-            wait_for_router_update(old_rv, localhost, proxy_port_2, admin_port_2)
-            end_testcase_setup(strategy, bp)
-
-            local health1 = get_upstream_health(upstream_id, admin_port_1)
-            local health2 = get_upstream_health(upstream_id, admin_port_2)
-
-            assert.same("HEALTHY", health1.data[1].health)
-            assert.same("HEALTHY", health2.data[1].health)
-
-            post_target_endpoint(upstream_id, localhost, port, "unhealthy")
-
-            poll_wait_health(upstream_id, localhost, port, "UNHEALTHY", admin_port_1)
-            poll_wait_health(upstream_id, localhost, port, "UNHEALTHY", admin_port_2)
-
-          end)
-
-        end)
-      end
-    end)
-
-    for mode, localhost in pairs(localhosts) do
-
-      describe("#" .. mode, function()
-
-        describe("Upstream entities", function()
-
-          -- Regression test for a missing invalidation in 0.12rc1
-          it("created via the API are functional", function()
-            begin_testcase_setup(strategy, bp)
-            local upstream_name, upstream_id = add_upstream(bp)
-            local target_port = add_target(bp, upstream_id, localhost)
-            local api_host = add_api(bp, upstream_name)
-            end_testcase_setup(strategy, bp)
-
-            local server = http_server(localhost, target_port, { 1 })
-
-            local oks, fails, last_status = client_requests(1, api_host)
-            assert.same(200, last_status)
-            assert.same(1, oks)
-            assert.same(0, fails)
-
-            local _, server_oks, server_fails = server:done()
-            assert.same(1, server_oks)
-            assert.same(0, server_fails)
-          end)
-
-          it("created via the API are functional #grpc", function()
-            begin_testcase_setup(strategy, bp)
-            local upstream_name, upstream_id = add_upstream(bp)
-            add_target(bp, upstream_id, localhost, 15002)
-            local api_host = add_api(bp, upstream_name, {
-              service_protocol = "grpc",
-              route_protocol = "grpc",
-            })
-            end_testcase_setup(strategy, bp)
-
-            local grpc_client = helpers.proxy_client_grpc()
-            local ok, resp = grpc_client({
-              service = "hello.HelloService.SayHello",
-              opts = {
-                ["-authority"] = api_host,
-              }
-            })
-            assert.Truthy(ok)
-            assert.Truthy(resp)
-          end)
-
-          it("properly set the host header", function()
-            begin_testcase_setup(strategy, bp)
-            local upstream_name, upstream_id = add_upstream(bp, { host_header = "localhost" })
-            local target_port = add_target(bp, upstream_id, localhost)
-            local api_host = add_api(bp, upstream_name)
-            end_testcase_setup(strategy, bp)
-
-            local server = http_server("localhost", target_port, { 5 }, "false", "http", "true")
-
-            local oks, fails, last_status = client_requests(5, api_host)
-            assert.same(200, last_status)
-            assert.same(5, oks)
-            assert.same(0, fails)
-
-            local _, server_oks, server_fails = server:done()
-            assert.same(5, server_oks)
-            assert.same(0, server_fails)
-          end)
-
-          it("fail with wrong host header", function()
-            begin_testcase_setup(strategy, bp)
-            local upstream_name, upstream_id = add_upstream(bp, { host_header = "localhost" })
-            local target_port = add_target(bp, upstream_id, "localhost")
-            local api_host = add_api(bp, upstream_name)
-            end_testcase_setup(strategy, bp)
-            local server = http_server("127.0.0.1", target_port, { 5 }, "false", "http", "true")
-            local oks, fails, last_status = client_requests(5, api_host)
-            assert.same(400, last_status)
-            assert.same(0, oks)
-            assert.same(5, fails)
-
-            -- oks and fails must be 0 as localhost should not receive any request
-            local _, server_oks, server_fails = server:done()
-            assert.same(0, server_oks)
-            assert.same(0, server_fails)
-          end)
-
-          -- #db == disabled for database=off, because it tests
-          -- for a PATCH operation
-          it("#db can have their config partially updated", function()
-            begin_testcase_setup(strategy, bp)
-            local _, upstream_id = add_upstream(bp)
-            end_testcase_setup(strategy, bp)
-
-            begin_testcase_setup_update(strategy, bp)
-            patch_upstream(upstream_id, {
-              healthchecks = {
-                active = {
-                  http_path = "/status",
-                  healthy = {
-                    interval = 0,
-                    successes = 1,
-                  },
-                  unhealthy = {
-                    interval = 0,
-                    http_failures = 1,
-                  },
-                }
-              }
-            })
-            end_testcase_setup(strategy, bp)
-
-            local updated = {
-              active = {
-                type = "http",
-                concurrency = 10,
-                healthy = {
-                  http_statuses = { 200, 302 },
-                  interval = 0,
-                  successes = 1
-                },
-                http_path = "/status",
-                https_sni = cjson.null,
-                https_verify_certificate = true,
-                timeout = 1,
-                unhealthy = {
-                  http_failures = 1,
-                  http_statuses = { 429, 404, 500, 501, 502, 503, 504, 505 },
-                  interval = 0,
-                  tcp_failures = 0,
-                  timeouts = 0
-                }
-              },
-              passive = {
-                type = "http",
-                healthy = {
-                  http_statuses = { 200, 201, 202, 203, 204, 205, 206, 207, 208, 226,
-                                    300, 301, 302, 303, 304, 305, 306, 307, 308 },
-                  successes = 0
-                },
-                unhealthy = {
-                  http_failures = 0,
-                  http_statuses = { 429, 500, 503 },
-                  tcp_failures = 0,
-                  timeouts = 0
-                }
-              },
-              threshold = 0
-            }
-
-            local upstream_data = get_upstream(upstream_id)
-            assert.same(updated, upstream_data.healthchecks)
-          end)
-
-          -- #db == disabled for database=off, because it tests
-          -- for a PATCH operation.
-          -- TODO produce an equivalent test when upstreams are preserved
-          -- (not rebuilt) across declarative config updates.
-          it("#db can be renamed without producing stale cache", function()
-            -- create two upstreams, each with a target pointing to a server
-            begin_testcase_setup(strategy, bp)
-            local upstreams = {}
-            for i = 1, 2 do
-              upstreams[i] = {}
-              upstreams[i].name = add_upstream(bp, {
-                healthchecks = healthchecks_config {}
+            it("created via the API are functional #grpc", function()
+              begin_testcase_setup(strategy, bp)
+              local upstream_name, upstream_id = add_upstream(bp)
+              add_target(bp, upstream_id, localhost, 15002)
+              local api_host = add_api(bp, upstream_name, {
+                service_protocol = "grpc",
+                route_protocol = "grpc",
               })
-              upstreams[i].port = add_target(bp, upstreams[i].name, localhost)
-              upstreams[i].api_host = add_api(bp, upstreams[i].name)
-            end
-            end_testcase_setup(strategy, bp)
+              end_testcase_setup(strategy, bp, consistency)
 
-            -- start two servers
-            local server1 = http_server(localhost, upstreams[1].port, { 1 })
-            local server2 = http_server(localhost, upstreams[2].port, { 1 })
-
-            -- rename upstream 2
-            local new_name = upstreams[2].name .. "_new"
-            patch_upstream(upstreams[2].name, {
-              name = new_name,
-            })
-
-            -- rename upstream 1 to upstream 2's original name
-            patch_upstream(upstreams[1].name, {
-              name = upstreams[2].name,
-            })
-
-            -- hit a request through upstream 1 using the new name
-            local oks, fails, last_status = client_requests(1, upstreams[2].api_host)
-            assert.same(200, last_status)
-            assert.same(1, oks)
-            assert.same(0, fails)
-
-            -- rename upstream 2
-            patch_upstream(new_name, {
-              name = upstreams[1].name,
-            })
-
-            -- a single request to upstream 2 just to make server 2 shutdown
-            client_requests(1, upstreams[1].api_host)
-
-            -- collect results
-            local _, server1_oks, server1_fails = server1:done()
-            local _, server2_oks, server2_fails = server2:done()
-            assert.same({1, 0}, { server1_oks, server1_fails })
-            assert.same({1, 0}, { server2_oks, server2_fails })
-          end)
-
-          -- #db == disabled for database=off, because it tests
-          -- for a PATCH operation.
-          -- TODO produce an equivalent test when upstreams are preserved
-          -- (not rebuilt) across declarative config updates.
-          it("#db do not leave a stale healthchecker when renamed", function()
-
-            begin_testcase_setup(strategy, bp)
-
-            -- create an upstream
-            local upstream_name, upstream_id = add_upstream(bp, {
-              healthchecks = healthchecks_config {
-                active = {
-                  http_path = "/status",
-                  healthy = {
-                    interval = HEALTHCHECK_INTERVAL,
-                    successes = 1,
-                  },
-                  unhealthy = {
-                    interval = HEALTHCHECK_INTERVAL,
-                    http_failures = 1,
-                  },
+              local grpc_client = helpers.proxy_client_grpc()
+              local ok, resp = grpc_client({
+                service = "hello.HelloService.SayHello",
+                opts = {
+                  ["-authority"] = api_host,
                 }
-              }
-            })
-            local port = add_target(bp, upstream_id, localhost)
-            local _, service_id = add_api(bp, upstream_name)
+              })
+              assert.Truthy(ok)
+              assert.Truthy(resp)
+            end)
 
-            end_testcase_setup(strategy, bp)
+            it("properly set the host header", function()
+              begin_testcase_setup(strategy, bp)
+              local upstream_name, upstream_id = add_upstream(bp, { host_header = "localhost" })
+              local target_port = add_target(bp, upstream_id, localhost)
+              local api_host = add_api(bp, upstream_name)
+              end_testcase_setup(strategy, bp, consistency)
 
-            -- rename upstream
-            local new_name = upstream_id .. "_new"
-            patch_upstream(upstream_id, {
-              name = new_name
-            })
+              local server = http_server("localhost", target_port, { 5 }, "false", "http", "true")
 
-            -- reconfigure healthchecks
-            patch_upstream(new_name, {
-              healthchecks = {
-                active = {
-                  http_path = "/status",
-                  healthy = {
-                    interval = 0,
-                    successes = 1,
-                  },
-                  unhealthy = {
-                    interval = 0,
-                    http_failures = 1,
-                  },
+              local oks, fails, last_status = client_requests(5, api_host)
+              assert.same(200, last_status)
+              assert.same(5, oks)
+              assert.same(0, fails)
+
+              local _, server_oks, server_fails = server:done()
+              assert.same(5, server_oks)
+              assert.same(0, server_fails)
+            end)
+
+            it("fail with wrong host header", function()
+              begin_testcase_setup(strategy, bp)
+              local upstream_name, upstream_id = add_upstream(bp, { host_header = "localhost" })
+              local target_port = add_target(bp, upstream_id, "localhost")
+              local api_host = add_api(bp, upstream_name)
+              end_testcase_setup(strategy, bp, consistency)
+
+              local server = http_server("127.0.0.1", target_port, { 5 }, "false", "http", "true")
+              local oks, fails, last_status = client_requests(5, api_host)
+              assert.same(400, last_status)
+              assert.same(0, oks)
+              assert.same(5, fails)
+
+              -- oks and fails must be 0 as localhost should not receive any request
+              local _, server_oks, server_fails = server:done()
+              assert.same(0, server_oks)
+              assert.same(0, server_fails)
+            end)
+
+            -- #db == disabled for database=off, because it tests
+            -- for a PATCH operation
+            it("#db can have their config partially updated", function()
+              begin_testcase_setup(strategy, bp)
+              local _, upstream_id = add_upstream(bp)
+              end_testcase_setup(strategy, bp, consistency)
+
+              begin_testcase_setup_update(strategy, bp)
+              patch_upstream(upstream_id, {
+                healthchecks = {
+                  active = {
+                    http_path = "/status",
+                    healthy = {
+                      interval = 0,
+                      successes = 1,
+                    },
+                    unhealthy = {
+                      interval = 0,
+                      http_failures = 1,
+                    },
+                  }
                 }
-              }
-            })
+              })
+              end_testcase_setup(strategy, bp, consistency)
 
-            -- start server
-            local server1 = http_server(localhost, port, { 1 })
-
-            -- give time for healthchecker to (not!) run
-            ngx.sleep(HEALTHCHECK_INTERVAL * 3)
-
-            begin_testcase_setup_update(strategy, bp)
-            patch_api(bp, service_id, "http://" .. new_name)
-            end_testcase_setup(strategy, bp)
-
-            -- collect results
-            local _, server1_oks, server1_fails, hcs = server1:done()
-            assert.same({0, 0}, { server1_oks, server1_fails })
-            assert.truthy(hcs < 2)
-          end)
-
-        end)
-
-        describe("#healthchecks", function()
-
-          local stream_it = (mode == "ipv6" or strategy == "off") and pending or it
-
-          it("do not count Kong-generated errors as failures", function()
-
-            begin_testcase_setup(strategy, bp)
-
-            -- configure healthchecks with a 1-error threshold
-            local upstream_name, upstream_id = add_upstream(bp, {
-              healthchecks = healthchecks_config {
+              local updated = {
+                active = {
+                  type = "http",
+                  concurrency = 10,
+                  healthy = {
+                    http_statuses = { 200, 302 },
+                    interval = 0,
+                    successes = 1
+                  },
+                  http_path = "/status",
+                  https_sni = cjson.null,
+                  https_verify_certificate = true,
+                  timeout = 1,
+                  unhealthy = {
+                    http_failures = 1,
+                    http_statuses = { 429, 404, 500, 501, 502, 503, 504, 505 },
+                    interval = 0,
+                    tcp_failures = 0,
+                    timeouts = 0
+                  }
+                },
                 passive = {
+                  type = "http",
                   healthy = {
-                    successes = 1,
+                    http_statuses = { 200, 201, 202, 203, 204, 205, 206, 207, 208, 226,
+                                      300, 301, 302, 303, 304, 305, 306, 307, 308 },
+                    successes = 0
                   },
                   unhealthy = {
-                    http_statuses = { 401, 500 },
-                    http_failures = 1,
-                    tcp_failures = 1,
-                    timeouts = 1,
-                  },
-                }
+                    http_failures = 0,
+                    http_statuses = { 429, 500, 503 },
+                    tcp_failures = 0,
+                    timeouts = 0
+                  }
+                },
+                threshold = 0
               }
-            })
-            local port1 = add_target(bp, upstream_id, localhost)
-            local port2 = add_target(bp, upstream_id, localhost)
-            local api_host, service_id = add_api(bp, upstream_name)
 
-            -- add a plugin
-            local plugin_id = utils.uuid()
-            bp.plugins:insert({
-              id = plugin_id,
-              service = { id = service_id },
-              name = "fail-once-auth",
-            })
+              local upstream_data = get_upstream(upstream_id)
+              assert.same(updated, upstream_data.healthchecks)
+            end)
 
-            end_testcase_setup(strategy, bp)
+            -- #db == disabled for database=off, because it tests
+            -- for a PATCH operation.
+            -- TODO produce an equivalent test when upstreams are preserved
+            -- (not rebuilt) across declarative config updates.
+            it("#db can be renamed without producing stale cache", function()
+              -- create two upstreams, each with a target pointing to a server
+              begin_testcase_setup(strategy, bp)
+              local upstreams = {}
+              for i = 1, 2 do
+                upstreams[i] = {}
+                upstreams[i].name = add_upstream(bp, {
+                  healthchecks = healthchecks_config {}
+                })
+                upstreams[i].port = add_target(bp, upstreams[i].name, localhost)
+                upstreams[i].api_host = add_api(bp, upstreams[i].name)
+              end
+              end_testcase_setup(strategy, bp, consistency)
 
-            -- run request: fails with 401, but doesn't hit the 1-error threshold
-            local oks, fails, last_status = client_requests(1, api_host)
-            assert.same(0, oks)
-            assert.same(1, fails)
-            assert.same(401, last_status)
+              -- start two servers
+              local server1 = http_server(localhost, upstreams[1].port, { 1 })
+              local server2 = http_server(localhost, upstreams[2].port, { 1 })
 
-            -- start servers, they are unaffected by the failure above
-            local server1 = http_server(localhost, port1, { SLOTS })
-            local server2 = http_server(localhost, port2, { SLOTS })
+              -- rename upstream 2
+              local new_name = upstreams[2].name .. "_new"
+              patch_upstream(upstreams[2].name, {
+                name = new_name,
+              })
 
-            oks, fails = client_requests(SLOTS * 2, api_host)
-            assert.same(SLOTS * 2, oks)
-            assert.same(0, fails)
+              -- rename upstream 1 to upstream 2's original name
+              patch_upstream(upstreams[1].name, {
+                name = upstreams[2].name,
+              })
 
-            -- collect server results
-            local _, ok1, fail1 = server1:done()
-            local _, ok2, fail2 = server2:done()
+              if consistency == "eventual" then
+                ngx.sleep(CONSISTENCY_FREQ) -- wait for proxy state consistency timer
+              end
 
-            -- both servers were fully operational
-            assert.same(SLOTS, ok1)
-            assert.same(SLOTS, ok2)
-            assert.same(0, fail1)
-            assert.same(0, fail2)
+              -- hit a request through upstream 1 using the new name
+              local oks, fails, last_status = client_requests(1, upstreams[2].api_host)
+              assert.same(200, last_status)
+              assert.same(1, oks)
+              assert.same(0, fails)
 
-          end)
+              -- rename upstream 2
+              patch_upstream(new_name, {
+                name = upstreams[1].name,
+              })
 
-          it("perform passive health checks", function()
+              if consistency == "eventual" then
+                ngx.sleep(CONSISTENCY_FREQ) -- wait for proxy state consistency timer
+              end
 
-            for nfails = 1, 3 do
+              -- a single request to upstream 2 just to make server 2 shutdown
+              client_requests(1, upstreams[1].api_host)
+
+              -- collect results
+              local _, server1_oks, server1_fails = server1:done()
+              local _, server2_oks, server2_fails = server2:done()
+              assert.same({1, 0}, { server1_oks, server1_fails })
+              assert.same({1, 0}, { server2_oks, server2_fails })
+            end)
+
+            -- #db == disabled for database=off, because it tests
+            -- for a PATCH operation.
+            -- TODO produce an equivalent test when upstreams are preserved
+            -- (not rebuilt) across declarative config updates.
+            it("#db do not leave a stale healthchecker when renamed", function()
 
               begin_testcase_setup(strategy, bp)
-              -- configure healthchecks
+
+              -- create an upstream
+              local upstream_name, upstream_id = add_upstream(bp, {
+                healthchecks = healthchecks_config {
+                  active = {
+                    http_path = "/status",
+                    healthy = {
+                      interval = HEALTHCHECK_INTERVAL,
+                      successes = 1,
+                    },
+                    unhealthy = {
+                      interval = HEALTHCHECK_INTERVAL,
+                      http_failures = 1,
+                    },
+                  }
+                }
+              })
+              local port = add_target(bp, upstream_id, localhost)
+              local _, service_id = add_api(bp, upstream_name)
+
+              end_testcase_setup(strategy, bp, consistency)
+
+              -- rename upstream
+              local new_name = upstream_id .. "_new"
+              patch_upstream(upstream_id, {
+                name = new_name
+              })
+
+              -- reconfigure healthchecks
+              patch_upstream(new_name, {
+                healthchecks = {
+                  active = {
+                    http_path = "/status",
+                    healthy = {
+                      interval = 0,
+                      successes = 1,
+                    },
+                    unhealthy = {
+                      interval = 0,
+                      http_failures = 1,
+                    },
+                  }
+                }
+              })
+
+              -- start server
+              local server1 = http_server(localhost, port, { 1 })
+
+              -- give time for healthchecker to (not!) run
+              ngx.sleep(HEALTHCHECK_INTERVAL * 3)
+
+              begin_testcase_setup_update(strategy, bp)
+              patch_api(bp, service_id, "http://" .. new_name)
+              end_testcase_setup(strategy, bp, consistency)
+
+              -- collect results
+              local _, server1_oks, server1_fails, hcs = server1:done()
+              assert.same({0, 0}, { server1_oks, server1_fails })
+              assert.truthy(hcs < 2)
+            end)
+
+          end)
+
+          describe("#healthchecks", function()
+
+            local stream_it = (mode == "ipv6" or strategy == "off") and pending or it
+
+            it("do not count Kong-generated errors as failures", function()
+
+              begin_testcase_setup(strategy, bp)
+
+              -- configure healthchecks with a 1-error threshold
               local upstream_name, upstream_id = add_upstream(bp, {
                 healthchecks = healthchecks_config {
                   passive = {
+                    healthy = {
+                      successes = 1,
+                    },
                     unhealthy = {
-                      http_failures = nfails,
-                    }
+                      http_statuses = { 401, 500 },
+                      http_failures = 1,
+                      tcp_failures = 1,
+                      timeouts = 1,
+                    },
                   }
                 }
               })
               local port1 = add_target(bp, upstream_id, localhost)
               local port2 = add_target(bp, upstream_id, localhost)
-              local api_host = add_api(bp, upstream_name)
-              end_testcase_setup(strategy, bp)
+              local api_host, service_id = add_api(bp, upstream_name)
 
-              local requests = SLOTS * 2 -- go round the balancer twice
+              -- add a plugin
+              local plugin_id = utils.uuid()
+              bp.plugins:insert({
+                id = plugin_id,
+                service = { id = service_id },
+                name = "fail-once-auth",
+              })
+
+              end_testcase_setup(strategy, bp, consistency)
+
+              -- run request: fails with 401, but doesn't hit the 1-error threshold
+              local oks, fails, last_status = client_requests(1, api_host)
+              assert.same(0, oks)
+              assert.same(1, fails)
+              assert.same(401, last_status)
+
+              -- start servers, they are unaffected by the failure above
+              local server1 = http_server(localhost, port1, { SLOTS })
+              local server2 = http_server(localhost, port2, { SLOTS })
+
+              oks, fails = client_requests(SLOTS * 2, api_host)
+              assert.same(SLOTS * 2, oks)
+              assert.same(0, fails)
+
+              -- collect server results
+              local _, ok1, fail1 = server1:done()
+              local _, ok2, fail2 = server2:done()
+
+              -- both servers were fully operational
+              assert.same(SLOTS, ok1)
+              assert.same(SLOTS, ok2)
+              assert.same(0, fail1)
+              assert.same(0, fail2)
+
+            end)
+
+            it("perform passive health checks", function()
+
+              for nfails = 1, 3 do
+
+                begin_testcase_setup(strategy, bp)
+                -- configure healthchecks
+                local upstream_name, upstream_id = add_upstream(bp, {
+                  healthchecks = healthchecks_config {
+                    passive = {
+                      unhealthy = {
+                        http_failures = nfails,
+                      }
+                    }
+                  }
+                })
+                local port1 = add_target(bp, upstream_id, localhost)
+                local port2 = add_target(bp, upstream_id, localhost)
+                local api_host = add_api(bp, upstream_name)
+                end_testcase_setup(strategy, bp, consistency)
+
+                local requests = SLOTS * 2 -- go round the balancer twice
+
+                -- setup target servers:
+                -- server2 will only respond for part of the test,
+                -- then server1 will take over.
+                local server2_oks = math.floor(requests / 4)
+                local server1 = http_server(localhost, port1, {
+                  requests - server2_oks - nfails
+                })
+                local server2 = http_server(localhost, port2, {
+                  server2_oks,
+                  nfails
+                })
+
+                -- Go hit them with our test requests
+                local client_oks, client_fails = client_requests(requests, api_host)
+
+                -- collect server results; hitcount
+                local _, ok1, fail1 = server1:done()
+                local _, ok2, fail2 = server2:done()
+
+                -- verify
+                assert.are.equal(requests - server2_oks - nfails, ok1)
+                assert.are.equal(server2_oks, ok2)
+                assert.are.equal(0, fail1)
+                assert.are.equal(nfails, fail2)
+
+                assert.are.equal(requests - nfails, client_oks)
+                assert.are.equal(nfails, client_fails)
+              end
+            end)
+
+            it("threshold for health checks", function()
+              local dns_mock_filename = helpers.test_conf.prefix .. "/dns_mock_records.lua"
+              finally(function()
+                os.remove(dns_mock_filename)
+              end)
+
+              local fixtures = {
+                dns_mock = helpers.dns_mock.new()
+              }
+              fixtures.dns_mock:A {
+                name = "health-threshold.test",
+                address = "127.0.0.1",
+              }
+              fixtures.dns_mock:A {
+                name = "health-threshold.test",
+                address = "127.0.0.2",
+              }
+              fixtures.dns_mock:A {
+                name = "health-threshold.test",
+                address = "127.0.0.3",
+              }
+              fixtures.dns_mock:A {
+                name = "health-threshold.test",
+                address = "127.0.0.4",
+              }
+
+              -- restart Kong
+              begin_testcase_setup_update(strategy, bp)
+              helpers.restart_kong({
+                database = strategy,
+                nginx_conf = "spec/fixtures/custom_nginx.template",
+                lua_ssl_trusted_certificate = "spec/fixtures/kong_spec.crt",
+                db_update_frequency = 0.1,
+                stream_listen = "off",
+                plugins = "bundled,fail-once-auth",
+                worker_consistency = consistency,
+                worker_state_update_frequency = CONSISTENCY_FREQ,
+              }, nil, fixtures)
+              end_testcase_setup(strategy, bp, consistency)
+              ngx.sleep(1)
+
+              local health_threshold = { 0, 25, 75, 99, 100 }
+              for i = 1, 5 do
+                -- configure healthchecks
+                begin_testcase_setup(strategy, bp)
+                local upstream_name, upstream_id = add_upstream(bp, {
+                  healthchecks = healthchecks_config {
+                    passive = {
+                      unhealthy = {
+                        tcp_failures = 1,
+                      }
+                    },
+                    threshold = health_threshold[i],
+                  }
+                })
+
+                add_target(bp, upstream_id, "health-threshold.test", 80, { weight = 25 })
+                end_testcase_setup(strategy, bp, consistency)
+
+                -- 100% healthy
+                post_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.1:80", "healthy")
+                post_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.2:80", "healthy")
+                post_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.3:80", "healthy")
+                post_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.4:80", "healthy")
+
+                local health = get_balancer_health(upstream_name)
+                assert.is.table(health)
+                assert.is.table(health.data)
+
+                if health_threshold[i] < 100 then
+                  assert.equals("HEALTHY", health.data.health)
+                else
+                  assert.equals("UNHEALTHY", health.data.health)
+                end
+
+                -- 75% healthy
+                post_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.1:80", "unhealthy")
+                health = get_balancer_health(upstream_name)
+                if health_threshold[i] < 75 then
+                  assert.equals("HEALTHY", health.data.health)
+                else
+                  assert.equals("UNHEALTHY", health.data.health)
+                end
+
+                -- 50% healthy
+                post_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.2:80", "unhealthy")
+                health = get_balancer_health(upstream_name)
+                if health_threshold[i] < 50 then
+                  assert.equals("HEALTHY", health.data.health)
+                else
+                  assert.equals("UNHEALTHY", health.data.health)
+                end
+
+                -- 25% healthy
+                post_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.3:80", "unhealthy")
+                health = get_balancer_health(upstream_name)
+                if health_threshold[i] < 25 then
+                  assert.equals("HEALTHY", health.data.health)
+                else
+                  assert.equals("UNHEALTHY", health.data.health)
+                end
+
+                -- 0% healthy
+                post_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.4:80", "unhealthy")
+                health = get_balancer_health(upstream_name)
+                assert.equals("UNHEALTHY", health.data.health)
+
+              end
+            end)
+
+            stream_it("#stream and http modules do not duplicate active health checks", function()
+
+              local port1 = gen_port()
+
+              local server1 = http_server(localhost, port1, { 1 })
+
+              -- configure healthchecks
+              begin_testcase_setup(strategy, bp)
+              local _, upstream_id = add_upstream(bp, {
+                healthchecks = healthchecks_config {
+                  active = {
+                    http_path = "/status",
+                    healthy = {
+                      -- using this interval to get the same results when using
+                      -- worker_consistency "strict" or "eventual"
+                      interval = CONSISTENCY_FREQ,
+                      successes = 1,
+                    },
+                    unhealthy = {
+                      interval = CONSISTENCY_FREQ,
+                      http_failures = 1,
+                    },
+                  }
+                }
+              })
+              add_target(bp, upstream_id, localhost, port1)
+              end_testcase_setup(strategy, bp, consistency)
+
+              if consistency == "strict" then
+                -- if consistency is "eventual", the test case already slept
+                ngx.sleep(CONSISTENCY_FREQ * 2)
+              end
+
+              -- collect server results; hitcount
+              local _, _, _, hcs1 = server1:done()
+              assert(hcs1 < 3)
+            end)
+
+            it("perform active health checks -- up then down", function()
+
+              for nfails = 1, 3 do
+
+                local requests = SLOTS * 2 -- go round the balancer twice
+                local port1 = gen_port()
+                local port2 = gen_port()
+
+                -- setup target servers:
+                -- server2 will only respond for part of the test,
+                -- then server1 will take over.
+                local server2_oks = math.floor(requests / 4)
+                local server1 = http_server(localhost, port1, { requests - server2_oks })
+                local server2 = http_server(localhost, port2, { server2_oks })
+
+                -- configure healthchecks
+                begin_testcase_setup(strategy, bp)
+                local upstream_name, upstream_id = add_upstream(bp, {
+                  healthchecks = healthchecks_config {
+                    active = {
+                      http_path = "/status",
+                      healthy = {
+                        interval = HEALTHCHECK_INTERVAL,
+                        successes = 1,
+                      },
+                      unhealthy = {
+                        interval = HEALTHCHECK_INTERVAL,
+                        http_failures = nfails,
+                      },
+                    }
+                  }
+                })
+                add_target(bp, upstream_id, localhost, port1)
+                add_target(bp, upstream_id, localhost, port2)
+                local api_host = add_api(bp, upstream_name)
+                end_testcase_setup(strategy, bp, consistency)
+
+                -- Phase 1: server1 and server2 take requests
+                local client_oks, client_fails = client_requests(server2_oks * 2, api_host)
+
+                -- Phase 2: server2 goes unhealthy
+                direct_request(localhost, port2, "/unhealthy")
+
+                -- Give time for healthchecker to detect
+                poll_wait_health(upstream_id, localhost, port2, "UNHEALTHY")
+
+                -- Phase 3: server1 takes all requests
+                do
+                  local p3oks, p3fails = client_requests(requests - (server2_oks * 2), api_host)
+                  client_oks = client_oks + p3oks
+                  client_fails = client_fails + p3fails
+                end
+
+                -- collect server results; hitcount
+                local _, ok1, fail1 = server1:done()
+                local _, ok2, fail2 = server2:done()
+
+                -- verify
+                assert.are.equal(requests - server2_oks, ok1)
+                assert.are.equal(server2_oks, ok2)
+                assert.are.equal(0, fail1)
+                assert.are.equal(0, fail2)
+
+                assert.are.equal(requests, client_oks)
+                assert.are.equal(0, client_fails)
+              end
+            end)
+
+            it("perform active health checks with upstream hostname", function()
+
+              for nfails = 1, 3 do
+
+                local requests = SLOTS * 2 -- go round the balancer twice
+                local port1 = gen_port()
+                local port2 = gen_port()
+
+                -- setup target servers:
+                -- server2 will only respond for part of the test,
+                -- then server1 will take over.
+                local server2_oks = math.floor(requests / 4)
+                local server1 = http_server("localhost", port1,
+                  { requests - server2_oks }, "false", "http", "true")
+                local server2 = http_server("localhost", port2, { server2_oks },
+                  "false", "http", "true")
+
+                -- configure healthchecks
+                begin_testcase_setup(strategy, bp)
+                local upstream_name, upstream_id = add_upstream(bp, {
+                  host_header = "localhost",
+                  healthchecks = healthchecks_config {
+                    active = {
+                      http_path = "/status",
+                      healthy = {
+                        interval = HEALTHCHECK_INTERVAL,
+                        successes = 1,
+                      },
+                      unhealthy = {
+                        interval = HEALTHCHECK_INTERVAL,
+                        http_failures = nfails,
+                      },
+                    }
+                  }
+                })
+                add_target(bp, upstream_id, localhost, port1)
+                add_target(bp, upstream_id, localhost, port2)
+                local api_host = add_api(bp, upstream_name)
+                end_testcase_setup(strategy, bp, consistency)
+
+                -- Phase 1: server1 and server2 take requests
+                local client_oks, client_fails = client_requests(server2_oks * 2, api_host)
+
+                -- Phase 2: server2 goes unhealthy
+                direct_request("localhost", port2, "/unhealthy")
+
+                -- Give time for healthchecker to detect
+                poll_wait_health(upstream_id, localhost, port2, "UNHEALTHY")
+
+                -- Phase 3: server1 takes all requests
+                do
+                  local p3oks, p3fails = client_requests(requests - (server2_oks * 2), api_host)
+                  client_oks = client_oks + p3oks
+                  client_fails = client_fails + p3fails
+                end
+
+                -- collect server results; hitcount
+                local _, ok1, fail1 = server1:done()
+                local _, ok2, fail2 = server2:done()
+
+                -- verify
+                assert.are.equal(requests - server2_oks, ok1)
+                assert.are.equal(server2_oks, ok2)
+                assert.are.equal(0, fail1)
+                assert.are.equal(0, fail2)
+
+                assert.are.equal(requests, client_oks)
+                assert.are.equal(0, client_fails)
+              end
+            end)
+
+            for _, protocol in ipairs({"http", "https"}) do
+              it("perform active health checks -- automatic recovery #" .. protocol, function()
+                for nchecks = 1, 3 do
+
+                  local port1 = gen_port()
+                  local port2 = gen_port()
+
+                  -- setup target servers:
+                  -- server2 will only respond for part of the test,
+                  -- then server1 will take over.
+                  local server1_oks = SLOTS * 2
+                  local server2_oks = SLOTS
+                  local server1 = http_server(localhost, port1, { server1_oks }, nil, protocol)
+                  local server2 = http_server(localhost, port2, { server2_oks }, nil, protocol)
+
+                  -- configure healthchecks
+                  begin_testcase_setup(strategy, bp)
+                  local upstream_name, upstream_id = add_upstream(bp, {
+                    healthchecks = healthchecks_config {
+                      active = {
+                        type = protocol,
+                        http_path = "/status",
+                        https_verify_certificate = (protocol == "https" and localhost == "localhost"),
+                        healthy = {
+                          interval = HEALTHCHECK_INTERVAL,
+                          successes = nchecks,
+                        },
+                        unhealthy = {
+                          interval = HEALTHCHECK_INTERVAL,
+                          http_failures = nchecks,
+                        },
+                      }
+                    }
+                  })
+                  add_target(bp, upstream_id, localhost, port1)
+                  add_target(bp, upstream_id, localhost, port2)
+                  local api_host = add_api(bp, upstream_name, {
+                    service_protocol = protocol
+                  })
+
+                  end_testcase_setup(strategy, bp, consistency)
+
+                  -- ensure it's healthy at the beginning of the test
+                  direct_request(localhost, port1, "/healthy", protocol)
+                  direct_request(localhost, port2, "/healthy", protocol)
+                  poll_wait_health(upstream_id, localhost, port1, "HEALTHY")
+                  poll_wait_health(upstream_id, localhost, port2, "HEALTHY")
+
+                  -- 1) server1 and server2 take requests
+                  local oks, fails = client_requests(SLOTS, api_host)
+
+                  -- server2 goes unhealthy
+                  direct_request(localhost, port2, "/unhealthy", protocol)
+                  -- Wait until healthchecker detects
+                  poll_wait_health(upstream_id, localhost, port2, "UNHEALTHY")
+
+                  -- 2) server1 takes all requests
+                  do
+                    local o, f = client_requests(SLOTS, api_host)
+                    oks = oks + o
+                    fails = fails + f
+                  end
+
+                  -- server2 goes healthy again
+                  direct_request(localhost, port2, "/healthy", protocol)
+                  -- Give time for healthchecker to detect
+                  poll_wait_health(upstream_id, localhost, port2, "HEALTHY")
+
+                  -- 3) server1 and server2 take requests again
+                  do
+                    local o, f = client_requests(SLOTS, api_host)
+                    oks = oks + o
+                    fails = fails + f
+                  end
+
+                  -- collect server results; hitcount
+                  local _, ok1, fail1 = server1:done()
+                  local _, ok2, fail2 = server2:done()
+
+                  -- verify
+                  assert.are.equal(SLOTS * 2, ok1)
+                  assert.are.equal(SLOTS, ok2)
+                  assert.are.equal(0, fail1)
+                  assert.are.equal(0, fail2)
+
+                  assert.are.equal(SLOTS * 3, oks)
+                  assert.are.equal(0, fails)
+                end
+              end)
+
+              it("perform active health checks on a target that resolves to multiple addresses -- automatic recovery #" .. protocol, function()
+                local hosts = {}
+
+                local dns_mock_filename = helpers.test_conf.prefix .. "/dns_mock_records.lua"
+                finally(function()
+                  os.remove(dns_mock_filename)
+                end)
+
+                local fixtures = {
+                  dns_mock = helpers.dns_mock.new()
+                }
+
+                for i = 1, 3 do
+                  hosts[i] = {
+                    hostname = gen_multi_host(),
+                    port1 = gen_port(),
+                    port2 = gen_port(),
+                  }
+                  fixtures.dns_mock:SRV {
+                    name = hosts[i].hostname,
+                    target = localhost,
+                    port = hosts[i].port1,
+                  }
+                  fixtures.dns_mock:SRV {
+                    name = hosts[i].hostname,
+                    target = localhost,
+                    port = hosts[i].port2,
+                  }
+                end
+
+                -- restart Kong
+                begin_testcase_setup_update(strategy, bp)
+                helpers.restart_kong({
+                  database = strategy,
+                  nginx_conf = "spec/fixtures/custom_nginx.template",
+                  lua_ssl_trusted_certificate = "spec/fixtures/kong_spec.crt",
+                  db_update_frequency = 0.1,
+                  stream_listen = "off",
+                  plugins = "bundled,fail-once-auth",
+                  worker_consistency = consistency,
+                  worker_state_update_frequency = CONSISTENCY_FREQ,
+                }, nil, fixtures)
+                end_testcase_setup(strategy, bp, consistency)
+                ngx.sleep(0.5)
+
+                for nchecks = 1, 3 do
+
+                  local port1 = hosts[nchecks].port1
+                  local port2 = hosts[nchecks].port2
+                  local hostname = hosts[nchecks].hostname
+
+                  -- setup target servers:
+                  -- server2 will only respond for part of the test,
+                  -- then server1 will take over.
+                  local server1_oks = SLOTS * 2
+                  local server2_oks = SLOTS
+                  local server1 = http_server(localhost, port1, { server1_oks }, nil, protocol)
+                  local server2 = http_server(localhost, port2, { server2_oks }, nil, protocol)
+
+                  -- configure healthchecks
+                  begin_testcase_setup(strategy, bp)
+                  local upstream_name, upstream_id = add_upstream(bp, {
+                    healthchecks = healthchecks_config {
+                      active = {
+                        type = protocol,
+                        http_path = "/status",
+                        https_verify_certificate = (protocol == "https" and hostname == "localhost"),
+                        healthy = {
+                          interval = HEALTHCHECK_INTERVAL,
+                          successes = nchecks,
+                        },
+                        unhealthy = {
+                          interval = HEALTHCHECK_INTERVAL,
+                          http_failures = nchecks,
+                        },
+                      }
+                    }
+                  })
+                  add_target(bp, upstream_id, hostname, port1) -- port gets overridden at DNS resolution
+                  local api_host = add_api(bp, upstream_name, {
+                    service_protocol = protocol
+                  })
+                  end_testcase_setup(strategy, bp, consistency)
+
+                  -- 1) server1 and server2 take requests
+                  local oks, fails = client_requests(SLOTS, api_host)
+                  -- server2 goes unhealthy
+                  direct_request(localhost, port2, "/unhealthy", protocol, hostname)
+                  -- Wait until healthchecker detects
+                  poll_wait_address_health(upstream_id, hostname, port1, localhost, port2, "UNHEALTHY")
+
+                  -- 2) server1 takes all requests
+                  do
+                    local o, f = client_requests(SLOTS, api_host)
+                    oks = oks + o
+                    fails = fails + f
+                  end
+
+                  -- server2 goes healthy again
+                  direct_request(localhost, port2, "/healthy", protocol, hostname)
+                  -- Give time for healthchecker to detect
+                  poll_wait_address_health(upstream_id, hostname, port1, localhost, port2, "HEALTHY")
+
+                  -- 3) server1 and server2 take requests again
+                  do
+                    local o, f = client_requests(SLOTS, api_host)
+                    oks = oks + o
+                    fails = fails + f
+                  end
+
+                  -- collect server results; hitcount
+                  local _, ok1, fail1 = server1:done(hostname)
+                  local _, ok2, fail2 = server2:done(hostname)
+
+                  -- verify
+                  assert.are.equal(SLOTS * 2, ok1)
+                  assert.are.equal(SLOTS, ok2)
+                  assert.are.equal(0, fail1)
+                  assert.are.equal(0, fail2)
+
+                  assert.are.equal(SLOTS * 3, oks)
+                  assert.are.equal(0, fails)
+                end
+              end)
+
+              it("perform active health checks on targets that resolve to the same IP -- automatic recovery #" .. protocol, function()
+                local dns_mock_filename = helpers.test_conf.prefix .. "/dns_mock_records.lua"
+                finally(function()
+                  os.remove(dns_mock_filename)
+                end)
+
+                local fixtures = {
+                  dns_mock = helpers.dns_mock.new()
+                }
+
+                fixtures.dns_mock:A {
+                  name = "target1.test",
+                  address = "127.0.0.1",
+                }
+                fixtures.dns_mock:A {
+                  name = "target2.test",
+                  address = "127.0.0.1",
+                }
+
+                -- restart Kong
+                begin_testcase_setup_update(strategy, bp)
+                helpers.restart_kong({
+                  database = strategy,
+                  nginx_conf = "spec/fixtures/custom_nginx.template",
+                  lua_ssl_trusted_certificate = "spec/fixtures/kong_spec.crt",
+                  db_update_frequency = 0.1,
+                  stream_listen = "off",
+                  plugins = "bundled,fail-once-auth",
+                  worker_consistency = consistency,
+                  worker_state_update_frequency = CONSISTENCY_FREQ,
+                }, nil, fixtures)
+                end_testcase_setup(strategy, bp, consistency)
+                ngx.sleep(1)
+
+                for nchecks = 1, 3 do
+
+                  local port1 = gen_port()
+                  local hostname = localhost
+
+                  -- setup target servers:
+                  -- server2 will only respond for part of the test,
+                  -- then server1 will take over.
+                  local target1_oks = SLOTS * 2
+                  local target2_oks = SLOTS
+                  local counts = {
+                    ["target1.test"] = { target1_oks },
+                    ["target2.test"] = { target2_oks },
+                  }
+                  local server1 = http_server(localhost, port1, counts, nil, protocol)
+
+                  -- configure healthchecks
+                  begin_testcase_setup(strategy, bp)
+                  local upstream_name, upstream_id = add_upstream(bp, {
+                    healthchecks = healthchecks_config {
+                      active = {
+                        type = protocol,
+                        http_path = "/status",
+                        https_verify_certificate = false,
+                        healthy = {
+                          interval = HEALTHCHECK_INTERVAL,
+                          successes = nchecks,
+                        },
+                        unhealthy = {
+                          interval = HEALTHCHECK_INTERVAL,
+                          http_failures = nchecks,
+                        },
+                      }
+                    }
+                  })
+                  add_target(bp, upstream_id, "target1.test", port1)
+                  add_target(bp, upstream_id, "target2.test", port1)
+                  local api_host = add_api(bp, upstream_name, {
+                    service_protocol = protocol
+                  })
+
+                  end_testcase_setup(strategy, bp, consistency)
+
+                  -- 1) target1 and target2 take requests
+                  local oks, fails = client_requests(SLOTS, api_host)
+
+                  -- target2 goes unhealthy
+                  direct_request(localhost, port1, "/unhealthy", protocol, "target2.test")
+                  -- Wait until healthchecker detects
+                  poll_wait_health(upstream_id, "target2.test", port1, "UNHEALTHY")
+
+                  -- 2) target1 takes all requests
+                  do
+                    local o, f = client_requests(SLOTS, api_host)
+                    oks = oks + o
+                    fails = fails + f
+                  end
+
+                  -- target2 goes healthy again
+                  direct_request(localhost, port1, "/healthy", protocol, "target2.test")
+                  -- Give time for healthchecker to detect
+                  poll_wait_health(upstream_id, "target2.test", port1, "HEALTHY")
+
+                  -- 3) server1 and server2 take requests again
+                  do
+                    local o, f = client_requests(SLOTS, api_host)
+                    oks = oks + o
+                    fails = fails + f
+                  end
+
+                  -- collect server results; hitcount
+                  local results1 = direct_request(localhost, port1, "/results", protocol, "target1.test")
+                  local results2 = direct_request(localhost, port1, "/results", protocol, "target2.test")
+
+                  local target1_results
+                  local target2_results
+                  if results1 then
+                    target1_results = assert(cjson.decode(results1))
+                  end
+                  if results2 then
+                    target2_results = assert(cjson.decode(results2))
+                  end
+
+                  server1:done(hostname)
+
+                  -- verify
+                  assert.are.equal(SLOTS * 2, target1_results.ok_responses)
+                  assert.are.equal(SLOTS, target2_results.ok_responses)
+                  assert.are.equal(0, target1_results.fail_responses)
+                  assert.are.equal(0, target2_results.fail_responses)
+
+                  assert.are.equal(SLOTS * 3, oks)
+                  assert.are.equal(0, fails)
+                end
+              end)
+            end
+
+            it("#flaky #db perform active health checks -- automatic recovery #stream", function()
+
+              local port1 = gen_port()
+              local port2 = gen_port()
 
               -- setup target servers:
               -- server2 will only respond for part of the test,
               -- then server1 will take over.
-              local server2_oks = math.floor(requests / 4)
-              local server1 = http_server(localhost, port1, {
-                requests - server2_oks - nfails
+              local server1 = helpers.tcp_server(port1, {
+                requests = 1000,
+                prefix = "1 ",
               })
-              local server2 = http_server(localhost, port2, {
-                server2_oks,
-                nfails
+              local server2 = helpers.tcp_server(port2, {
+                requests = 1000,
+                prefix = "2 ",
+              })
+              ngx.sleep(0.1)
+
+              -- configure healthchecks
+              begin_testcase_setup(strategy, bp)
+              local upstream_name, upstream_id = add_upstream(bp, {
+                healthchecks = healthchecks_config {
+                  active = {
+                    type = "tcp",
+                    healthy = {
+                      interval = HEALTHCHECK_INTERVAL,
+                      successes = 1,
+                    },
+                    unhealthy = {
+                      interval = HEALTHCHECK_INTERVAL,
+                      tcp_failures = 1,
+                    },
+                  }
+                }
               })
 
-              -- Go hit them with our test requests
+              add_target(bp, upstream_id, localhost, port1)
+              add_target(bp, upstream_id, localhost, port2)
+              local _, service_id, route_id = add_api(bp, upstream_name, {
+                read_timeout = 500,
+                write_timeout = 500,
+                route_protocol = "tcp",
+              })
+              end_testcase_setup(strategy, bp, consistency)
+
+              finally(function()
+                helpers.kill_tcp_server(port1)
+                helpers.kill_tcp_server(port2)
+                server1:join()
+                server2:join()
+
+                bp.routes:remove({ id = route_id })
+                bp.services:remove({ id = service_id })
+              end)
+
+              ngx.sleep(0.5)
+
+              -- 1) server1 and server2 take requests
+              local ok1, ok2 = tcp_client_requests(SLOTS * 2, localhost, 9100)
+              assert.same(SLOTS, ok1)
+              assert.same(SLOTS, ok2)
+
+              -- server2 goes unhealthy
+              helpers.kill_tcp_server(port2)
+              server2:join()
+
+              -- Wait until healthchecker detects
+              -- We cannot use poll_wait_health because health endpoints
+              -- are not currently available for stream routes.
+              ngx.sleep(strategy == "cassandra" and 2 or 1)
+
+              -- 2) server1 takes all requests
+              ok1, ok2 = tcp_client_requests(SLOTS * 2, localhost, 9100)
+              assert.same(SLOTS * 2, ok1)
+              assert.same(0, ok2)
+
+              -- server2 goes healthy again
+              server2 = helpers.tcp_server(port2, {
+                requests = 1000,
+                prefix = "2 ",
+              })
+
+              -- Give time for healthchecker to detect
+              -- Again, we cannot use poll_wait_health because health endpoints
+              -- are not currently available for stream routes.
+              ngx.sleep(strategy == "cassandra" and 2 or 1)
+
+              -- 3) server1 and server2 take requests again
+              ok1, ok2 = tcp_client_requests(SLOTS * 2, localhost, 9100)
+              assert.same(SLOTS, ok1)
+              assert.same(SLOTS, ok2)
+            end)
+
+            -- FIXME This is marked as #flaky because of Travis CI instability.
+            -- This runs fine on other environments. This should be re-checked
+            -- at a later time.
+            it("#flaky perform active health checks -- can detect before any proxy traffic", function()
+
+              local nfails = 2
+              local requests = SLOTS * 2 -- go round the balancer twice
+              local port1 = gen_port()
+              local port2 = gen_port()
+              -- setup target servers:
+              -- server1 will respond all requests
+              local server1 = http_server(localhost, port1, { requests })
+              local server2 = http_server(localhost, port2, { requests })
+              -- configure healthchecks
+              begin_testcase_setup(strategy, bp)
+              local upstream_name, upstream_id = add_upstream(bp, {
+                healthchecks = healthchecks_config {
+                  active = {
+                    http_path = "/status",
+                    healthy = {
+                      interval = HEALTHCHECK_INTERVAL,
+                      successes = 1,
+                    },
+                    unhealthy = {
+                      interval = HEALTHCHECK_INTERVAL,
+                      http_failures = nfails,
+                      tcp_failures = nfails,
+                    },
+                  }
+                }
+              })
+              add_target(bp, upstream_id, localhost, port1)
+              add_target(bp, upstream_id, localhost, port2)
+              local api_host = add_api(bp, upstream_name)
+              end_testcase_setup(strategy, bp, consistency)
+
+              -- server2 goes unhealthy before the first request
+              direct_request(localhost, port2, "/unhealthy")
+
+              -- restart Kong
+              begin_testcase_setup_update(strategy, bp)
+              helpers.restart_kong({
+                database   = strategy,
+                nginx_conf = "spec/fixtures/custom_nginx.template",
+                lua_ssl_trusted_certificate = "spec/fixtures/kong_spec.crt",
+                db_update_frequency = 0.1,
+                stream_listen = "off",
+                plugins = "bundled,fail-once-auth",
+                worker_consistency = consistency,
+                worker_state_update_frequency = CONSISTENCY_FREQ,
+              })
+              end_testcase_setup(strategy, bp, consistency)
+              ngx.sleep(1)
+
+              -- Give time for healthchecker to detect
+              poll_wait_health(upstream_id, localhost, port2, "UNHEALTHY")
+
+              -- server1 takes all requests
+
               local client_oks, client_fails = client_requests(requests, api_host)
 
               -- collect server results; hitcount
@@ -1319,364 +2141,63 @@ for _, strategy in helpers.each_strategy() do
               local _, ok2, fail2 = server2:done()
 
               -- verify
-              assert.are.equal(requests - server2_oks - nfails, ok1)
-              assert.are.equal(server2_oks, ok2)
+              assert.are.equal(requests, ok1)
+              assert.are.equal(0, ok2)
               assert.are.equal(0, fail1)
-              assert.are.equal(nfails, fail2)
+              assert.are.equal(0, fail2)
 
-              assert.are.equal(requests - nfails, client_oks)
-              assert.are.equal(nfails, client_fails)
-            end
-          end)
+              assert.are.equal(requests, client_oks)
+              assert.are.equal(0, client_fails)
 
-          it("threshold for health checks", function()
-            local dns_mock_filename = helpers.test_conf.prefix .. "/dns_mock_records.lua"
-            finally(function()
-              os.remove(dns_mock_filename)
             end)
 
-            local fixtures = {
-              dns_mock = helpers.dns_mock.new()
-            }
-            fixtures.dns_mock:A {
-              name = "health-threshold.test",
-              address = "127.0.0.1",
-            }
-            fixtures.dns_mock:A {
-              name = "health-threshold.test",
-              address = "127.0.0.2",
-            }
-            fixtures.dns_mock:A {
-              name = "health-threshold.test",
-              address = "127.0.0.3",
-            }
-            fixtures.dns_mock:A {
-              name = "health-threshold.test",
-              address = "127.0.0.4",
-            }
+            it("perform passive health checks -- manual recovery", function()
 
-            -- restart Kong
-            begin_testcase_setup_update(strategy, bp)
-            helpers.restart_kong({
-              database = strategy,
-              nginx_conf = "spec/fixtures/custom_nginx.template",
-              lua_ssl_trusted_certificate = "spec/fixtures/kong_spec.crt",
-              db_update_frequency = 0.1,
-              stream_listen = "0.0.0.0:9100",
-              plugins = "bundled,fail-once-auth",
-            }, nil, fixtures)
-            end_testcase_setup(strategy, bp)
-            ngx.sleep(1)
-
-            local health_threshold = { 0, 25, 75, 99, 100 }
-            for i = 1, 5 do
-              -- configure healthchecks
-              begin_testcase_setup(strategy, bp)
-              local upstream_name, upstream_id = add_upstream(bp, {
-                healthchecks = healthchecks_config {
-                  passive = {
-                    unhealthy = {
-                      tcp_failures = 1,
-                    }
-                  },
-                  threshold = health_threshold[i],
-                }
-              })
-
-              add_target(bp, upstream_id, "health-threshold.test", 80, { weight = 25 })
-              end_testcase_setup(strategy, bp)
-
-              -- 100% healthy
-              post_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.1:80", "healthy")
-              post_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.2:80", "healthy")
-              post_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.3:80", "healthy")
-              post_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.4:80", "healthy")
-
-              local health = get_balancer_health(upstream_name)
-              assert.is.table(health)
-              assert.is.table(health.data)
-
-              if health_threshold[i] < 100 then
-                assert.equals("HEALTHY", health.data.health)
-              else
-                assert.equals("UNHEALTHY", health.data.health)
-              end
-
-              -- 75% healthy
-              post_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.1:80", "unhealthy")
-              health = get_balancer_health(upstream_name)
-              if health_threshold[i] < 75 then
-                assert.equals("HEALTHY", health.data.health)
-              else
-                assert.equals("UNHEALTHY", health.data.health)
-              end
-
-              -- 50% healthy
-              post_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.2:80", "unhealthy")
-              health = get_balancer_health(upstream_name)
-              if health_threshold[i] < 50 then
-                assert.equals("HEALTHY", health.data.health)
-              else
-                assert.equals("UNHEALTHY", health.data.health)
-              end
-
-              -- 25% healthy
-              post_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.3:80", "unhealthy")
-              health = get_balancer_health(upstream_name)
-              if health_threshold[i] < 25 then
-                assert.equals("HEALTHY", health.data.health)
-              else
-                assert.equals("UNHEALTHY", health.data.health)
-              end
-
-              -- 0% healthy
-              post_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.4:80", "unhealthy")
-              health = get_balancer_health(upstream_name)
-              assert.equals("UNHEALTHY", health.data.health)
-
-            end
-          end)
-
-          stream_it("#stream and http modules do not duplicate active health checks", function()
-
-            local port1 = gen_port()
-
-            local server1 = http_server(localhost, port1, { 1 })
-
-            -- configure healthchecks
-            begin_testcase_setup(strategy, bp)
-            local _, upstream_id = add_upstream(bp, {
-              healthchecks = healthchecks_config {
-                active = {
-                  http_path = "/status",
-                  healthy = {
-                    interval = HEALTHCHECK_INTERVAL,
-                    successes = 1,
-                  },
-                  unhealthy = {
-                    interval = HEALTHCHECK_INTERVAL,
-                    http_failures = 1,
-                  },
-                }
-              }
-            })
-            add_target(bp, upstream_id, localhost, port1)
-            end_testcase_setup(strategy, bp)
-
-            ngx.sleep(HEALTHCHECK_INTERVAL * 5)
-
-            -- collect server results; hitcount
-            local _, _, _, hcs1 = server1:done()
-
-            assert(hcs1 < 8)
-          end)
-
-          it("perform active health checks -- up then down", function()
-
-            for nfails = 1, 3 do
-
-              local requests = SLOTS * 2 -- go round the balancer twice
-              local port1 = gen_port()
-              local port2 = gen_port()
-
-              -- setup target servers:
-              -- server2 will only respond for part of the test,
-              -- then server1 will take over.
-              local server2_oks = math.floor(requests / 4)
-              local server1 = http_server(localhost, port1, { requests - server2_oks })
-              local server2 = http_server(localhost, port2, { server2_oks })
-
-              -- configure healthchecks
-              begin_testcase_setup(strategy, bp)
-              local upstream_name, upstream_id = add_upstream(bp, {
-                healthchecks = healthchecks_config {
-                  active = {
-                    http_path = "/status",
-                    healthy = {
-                      interval = HEALTHCHECK_INTERVAL,
-                      successes = 1,
-                    },
-                    unhealthy = {
-                      interval = HEALTHCHECK_INTERVAL,
-                      http_failures = nfails,
-                    },
-                  }
-                }
-              })
-              add_target(bp, upstream_id, localhost, port1)
-              add_target(bp, upstream_id, localhost, port2)
-              local api_host = add_api(bp, upstream_name)
-              end_testcase_setup(strategy, bp)
-
-              -- Phase 1: server1 and server2 take requests
-              local client_oks, client_fails = client_requests(server2_oks * 2, api_host)
-
-              -- Phase 2: server2 goes unhealthy
-              direct_request(localhost, port2, "/unhealthy")
-
-              -- Give time for healthchecker to detect
-              poll_wait_health(upstream_id, localhost, port2, "UNHEALTHY")
-
-              -- Phase 3: server1 takes all requests
-              do
-                local p3oks, p3fails = client_requests(requests - (server2_oks * 2), api_host)
-                client_oks = client_oks + p3oks
-                client_fails = client_fails + p3fails
-              end
-
-              -- collect server results; hitcount
-              local _, ok1, fail1 = server1:done()
-              local _, ok2, fail2 = server2:done()
-
-              -- verify
-              assert.are.equal(requests - server2_oks, ok1)
-              assert.are.equal(server2_oks, ok2)
-              assert.are.equal(0, fail1)
-              assert.are.equal(0, fail2)
-
-              assert.are.equal(requests, client_oks)
-              assert.are.equal(0, client_fails)
-            end
-          end)
-
-          it("perform active health checks with upstream hostname", function()
-
-            for nfails = 1, 3 do
-
-              local requests = SLOTS * 2 -- go round the balancer twice
-              local port1 = gen_port()
-              local port2 = gen_port()
-
-              -- setup target servers:
-              -- server2 will only respond for part of the test,
-              -- then server1 will take over.
-              local server2_oks = math.floor(requests / 4)
-              local server1 = http_server("localhost", port1,
-                { requests - server2_oks }, "false", "http", "true")
-              local server2 = http_server("localhost", port2, { server2_oks },
-                "false", "http", "true")
-
-              -- configure healthchecks
-              begin_testcase_setup(strategy, bp)
-              local upstream_name, upstream_id = add_upstream(bp, {
-                host_header = "localhost",
-                healthchecks = healthchecks_config {
-                  active = {
-                    http_path = "/status",
-                    healthy = {
-                      interval = HEALTHCHECK_INTERVAL,
-                      successes = 1,
-                    },
-                    unhealthy = {
-                      interval = HEALTHCHECK_INTERVAL,
-                      http_failures = nfails,
-                    },
-                  }
-                }
-              })
-              add_target(bp, upstream_id, localhost, port1)
-              add_target(bp, upstream_id, localhost, port2)
-              local api_host = add_api(bp, upstream_name)
-              end_testcase_setup(strategy, bp)
-
-              -- Phase 1: server1 and server2 take requests
-              local client_oks, client_fails = client_requests(server2_oks * 2, api_host)
-
-              -- Phase 2: server2 goes unhealthy
-              direct_request("localhost", port2, "/unhealthy")
-
-              -- Give time for healthchecker to detect
-              poll_wait_health(upstream_id, localhost, port2, "UNHEALTHY")
-
-              -- Phase 3: server1 takes all requests
-              do
-                local p3oks, p3fails = client_requests(requests - (server2_oks * 2), api_host)
-                client_oks = client_oks + p3oks
-                client_fails = client_fails + p3fails
-              end
-
-              -- collect server results; hitcount
-              local _, ok1, fail1 = server1:done()
-              local _, ok2, fail2 = server2:done()
-
-              -- verify
-              assert.are.equal(requests - server2_oks, ok1)
-              assert.are.equal(server2_oks, ok2)
-              assert.are.equal(0, fail1)
-              assert.are.equal(0, fail2)
-
-              assert.are.equal(requests, client_oks)
-              assert.are.equal(0, client_fails)
-            end
-          end)
-
-          for _, protocol in ipairs({"http", "https"}) do
-            it("perform active health checks -- automatic recovery #" .. protocol, function()
-              for nchecks = 1, 3 do
-
-                local port1 = gen_port()
-                local port2 = gen_port()
-
-                -- setup target servers:
-                -- server2 will only respond for part of the test,
-                -- then server1 will take over.
-                local server1_oks = SLOTS * 2
-                local server2_oks = SLOTS
-                local server1 = http_server(localhost, port1, { server1_oks }, nil, protocol)
-                local server2 = http_server(localhost, port2, { server2_oks }, nil, protocol)
-
+              for nfails = 1, 3 do
                 -- configure healthchecks
                 begin_testcase_setup(strategy, bp)
                 local upstream_name, upstream_id = add_upstream(bp, {
                   healthchecks = healthchecks_config {
-                    active = {
-                      type = protocol,
-                      http_path = "/status",
-                      https_verify_certificate = (protocol == "https" and localhost == "localhost"),
-                      healthy = {
-                        interval = HEALTHCHECK_INTERVAL,
-                        successes = nchecks,
-                      },
+                    passive = {
                       unhealthy = {
-                        interval = HEALTHCHECK_INTERVAL,
-                        http_failures = nchecks,
-                      },
+                        http_failures = nfails,
+                      }
                     }
                   }
                 })
-                add_target(bp, upstream_id, localhost, port1)
-                add_target(bp, upstream_id, localhost, port2)
-                local api_host = add_api(bp, upstream_name, {
-                  service_protocol = protocol
+                local port1 = add_target(bp, upstream_id, localhost)
+                local port2 = add_target(bp, upstream_id, localhost)
+                local api_host = add_api(bp, upstream_name)
+                end_testcase_setup(strategy, bp, consistency)
+
+                -- setup target servers:
+                -- server2 will only respond for part of the test,
+                -- then server1 will take over.
+                local server1_oks = SLOTS * 2 - nfails
+                local server2_oks = SLOTS
+                local server1 = http_server(localhost, port1, {
+                  server1_oks
                 })
-
-                end_testcase_setup(strategy, bp)
-
-                -- ensure it's healthy at the beginning of the test
-                direct_request(localhost, port1, "/healthy", protocol)
-                direct_request(localhost, port2, "/healthy", protocol)
-                poll_wait_health(upstream_id, localhost, port1, "HEALTHY")
-                poll_wait_health(upstream_id, localhost, port2, "HEALTHY")
+                local server2 = http_server(localhost, port2, {
+                  server2_oks / 2,
+                  nfails,
+                  server2_oks / 2
+                })
 
                 -- 1) server1 and server2 take requests
                 local oks, fails = client_requests(SLOTS, api_host)
 
-                -- server2 goes unhealthy
-                direct_request(localhost, port2, "/unhealthy", protocol)
-                -- Wait until healthchecker detects
-                poll_wait_health(upstream_id, localhost, port2, "UNHEALTHY")
-
-                -- 2) server1 takes all requests
+                -- 2) server1 takes all requests once server2 produces
+                -- `nfails` failures (even though server2 will be ready
+                -- to respond 200 again after `nfails`)
                 do
                   local o, f = client_requests(SLOTS, api_host)
                   oks = oks + o
                   fails = fails + f
                 end
 
-                -- server2 goes healthy again
-                direct_request(localhost, port2, "/healthy", protocol)
-                -- Give time for healthchecker to detect
-                poll_wait_health(upstream_id, localhost, port2, "HEALTHY")
+                -- manually bring it back using the endpoint
+                post_target_endpoint(upstream_id, localhost, port2, "healthy")
 
                 -- 3) server1 and server2 take requests again
                 do
@@ -1690,447 +2211,25 @@ for _, strategy in helpers.each_strategy() do
                 local _, ok2, fail2 = server2:done()
 
                 -- verify
-                assert.are.equal(SLOTS * 2, ok1)
-                assert.are.equal(SLOTS, ok2)
+                assert.are.equal(server1_oks, ok1)
+                assert.are.equal(server2_oks, ok2)
                 assert.are.equal(0, fail1)
-                assert.are.equal(0, fail2)
+                assert.are.equal(nfails, fail2)
 
-                assert.are.equal(SLOTS * 3, oks)
-                assert.are.equal(0, fails)
+                assert.are.equal(SLOTS * 3 - nfails, oks)
+                assert.are.equal(nfails, fails)
               end
             end)
 
-            it("perform active health checks on a target that resolves to multiple addresses -- automatic recovery #" .. protocol, function()
-              local hosts = {}
+            it("perform passive health checks -- manual shutdown", function()
 
-              local dns_mock_filename = helpers.test_conf.prefix .. "/dns_mock_records.lua"
-              finally(function()
-                os.remove(dns_mock_filename)
-              end)
-
-              local fixtures = {
-                dns_mock = helpers.dns_mock.new()
-              }
-
-              for i = 1, 3 do
-                hosts[i] = {
-                  hostname = gen_multi_host(),
-                  port1 = gen_port(),
-                  port2 = gen_port(),
-                }
-                fixtures.dns_mock:SRV {
-                  name = hosts[i].hostname,
-                  target = localhost,
-                  port = hosts[i].port1,
-                }
-                fixtures.dns_mock:SRV {
-                  name = hosts[i].hostname,
-                  target = localhost,
-                  port = hosts[i].port2,
-                }
-              end
-
-              -- restart Kong
-              begin_testcase_setup_update(strategy, bp)
-              helpers.restart_kong({
-                database = strategy,
-                nginx_conf = "spec/fixtures/custom_nginx.template",
-                lua_ssl_trusted_certificate = "spec/fixtures/kong_spec.crt",
-                db_update_frequency = 0.1,
-                stream_listen = "0.0.0.0:9100",
-                plugins = "bundled,fail-once-auth",
-              }, nil, fixtures)
-              end_testcase_setup(strategy, bp)
-              ngx.sleep(0.5)
-
-              for nchecks = 1, 3 do
-
-                local port1 = hosts[nchecks].port1
-                local port2 = hosts[nchecks].port2
-                local hostname = hosts[nchecks].hostname
-
-                -- setup target servers:
-                -- server2 will only respond for part of the test,
-                -- then server1 will take over.
-                local server1_oks = SLOTS * 2
-                local server2_oks = SLOTS
-                local server1 = http_server(localhost, port1, { server1_oks }, nil, protocol)
-                local server2 = http_server(localhost, port2, { server2_oks }, nil, protocol)
-
-                -- configure healthchecks
-                begin_testcase_setup(strategy, bp)
-                local upstream_name, upstream_id = add_upstream(bp, {
-                  healthchecks = healthchecks_config {
-                    active = {
-                      type = protocol,
-                      http_path = "/status",
-                      https_verify_certificate = (protocol == "https" and hostname == "localhost"),
-                      healthy = {
-                        interval = HEALTHCHECK_INTERVAL,
-                        successes = nchecks,
-                      },
-                      unhealthy = {
-                        interval = HEALTHCHECK_INTERVAL,
-                        http_failures = nchecks,
-                      },
-                    }
-                  }
-                })
-                add_target(bp, upstream_id, hostname, port1) -- port gets overridden at DNS resolution
-                local api_host = add_api(bp, upstream_name, {
-                  service_protocol = protocol
-                })
-
-                end_testcase_setup(strategy, bp)
-
-                -- 1) server1 and server2 take requests
-                local oks, fails = client_requests(SLOTS, api_host)
-
-                -- server2 goes unhealthy
-                direct_request(localhost, port2, "/unhealthy", protocol, hostname)
-                -- Wait until healthchecker detects
-                poll_wait_address_health(upstream_id, hostname, port1, localhost, port2, "UNHEALTHY")
-
-                -- 2) server1 takes all requests
-                do
-                  local o, f = client_requests(SLOTS, api_host)
-                  oks = oks + o
-                  fails = fails + f
-                end
-
-                -- server2 goes healthy again
-                direct_request(localhost, port2, "/healthy", protocol, hostname)
-                -- Give time for healthchecker to detect
-                poll_wait_address_health(upstream_id, hostname, port1, localhost, port2, "HEALTHY")
-
-                -- 3) server1 and server2 take requests again
-                do
-                  local o, f = client_requests(SLOTS, api_host)
-                  oks = oks + o
-                  fails = fails + f
-                end
-
-                -- collect server results; hitcount
-                local _, ok1, fail1 = server1:done(hostname)
-                local _, ok2, fail2 = server2:done(hostname)
-
-                -- verify
-                assert.are.equal(SLOTS * 2, ok1)
-                assert.are.equal(SLOTS, ok2)
-                assert.are.equal(0, fail1)
-                assert.are.equal(0, fail2)
-
-                assert.are.equal(SLOTS * 3, oks)
-                assert.are.equal(0, fails)
-              end
-            end)
-
-            it("perform active health checks on targets that resolve to the same IP -- automatic recovery #" .. protocol, function()
-              local dns_mock_filename = helpers.test_conf.prefix .. "/dns_mock_records.lua"
-              finally(function()
-                os.remove(dns_mock_filename)
-              end)
-
-              local fixtures = {
-                dns_mock = helpers.dns_mock.new()
-              }
-
-              fixtures.dns_mock:A {
-                name = "target1.test",
-                address = "127.0.0.1",
-              }
-              fixtures.dns_mock:A {
-                name = "target2.test",
-                address = "127.0.0.1",
-              }
-
-              -- restart Kong
-              begin_testcase_setup_update(strategy, bp)
-              helpers.restart_kong({
-                database = strategy,
-                nginx_conf = "spec/fixtures/custom_nginx.template",
-                lua_ssl_trusted_certificate = "spec/fixtures/kong_spec.crt",
-                db_update_frequency = 0.1,
-                stream_listen = "0.0.0.0:9100",
-                plugins = "bundled,fail-once-auth",
-              }, nil, fixtures)
-              end_testcase_setup(strategy, bp)
-              ngx.sleep(1)
-
-              for nchecks = 1, 3 do
-
-                local port1 = gen_port()
-                local hostname = localhost
-
-                -- setup target servers:
-                -- server2 will only respond for part of the test,
-                -- then server1 will take over.
-                local target1_oks = SLOTS * 2
-                local target2_oks = SLOTS
-                local counts = {
-                  ["target1.test"] = { target1_oks },
-                  ["target2.test"] = { target2_oks },
-                }
-                local server1 = http_server(localhost, port1, counts, nil, protocol)
-
-                -- configure healthchecks
-                begin_testcase_setup(strategy, bp)
-                local upstream_name, upstream_id = add_upstream(bp, {
-                  healthchecks = healthchecks_config {
-                    active = {
-                      type = protocol,
-                      http_path = "/status",
-                      https_verify_certificate = false,
-                      healthy = {
-                        interval = HEALTHCHECK_INTERVAL,
-                        successes = nchecks,
-                      },
-                      unhealthy = {
-                        interval = HEALTHCHECK_INTERVAL,
-                        http_failures = nchecks,
-                      },
-                    }
-                  }
-                })
-                add_target(bp, upstream_id, "target1.test", port1)
-                add_target(bp, upstream_id, "target2.test", port1)
-                local api_host = add_api(bp, upstream_name, {
-                  service_protocol = protocol
-                })
-
-                end_testcase_setup(strategy, bp)
-
-                -- 1) target1 and target2 take requests
-                local oks, fails = client_requests(SLOTS, api_host)
-
-                -- target2 goes unhealthy
-                direct_request(localhost, port1, "/unhealthy", protocol, "target2.test")
-                -- Wait until healthchecker detects
-                poll_wait_health(upstream_id, "target2.test", port1, "UNHEALTHY")
-
-                -- 2) target1 takes all requests
-                do
-                  local o, f = client_requests(SLOTS, api_host)
-                  oks = oks + o
-                  fails = fails + f
-                end
-
-                -- target2 goes healthy again
-                direct_request(localhost, port1, "/healthy", protocol, "target2.test")
-                -- Give time for healthchecker to detect
-                poll_wait_health(upstream_id, "target2.test", port1, "HEALTHY")
-
-                -- 3) server1 and server2 take requests again
-                do
-                  local o, f = client_requests(SLOTS, api_host)
-                  oks = oks + o
-                  fails = fails + f
-                end
-
-                -- collect server results; hitcount
-                local results1 = direct_request(localhost, port1, "/results", protocol, "target1.test")
-                local results2 = direct_request(localhost, port1, "/results", protocol, "target2.test")
-
-                local target1_results
-                local target2_results
-                if results1 then
-                  target1_results = assert(cjson.decode(results1))
-                end
-                if results2 then
-                  target2_results = assert(cjson.decode(results2))
-                end
-
-                server1:done(hostname)
-
-                -- verify
-                assert.are.equal(SLOTS * 2, target1_results.ok_responses)
-                assert.are.equal(SLOTS, target2_results.ok_responses)
-                assert.are.equal(0, target1_results.fail_responses)
-                assert.are.equal(0, target2_results.fail_responses)
-
-                assert.are.equal(SLOTS * 3, oks)
-                assert.are.equal(0, fails)
-              end
-            end)
-          end
-
-          it("#flaky #db perform active health checks -- automatic recovery #stream", function()
-
-            local port1 = gen_port()
-            local port2 = gen_port()
-
-            -- setup target servers:
-            -- server2 will only respond for part of the test,
-            -- then server1 will take over.
-            local server1 = helpers.tcp_server(port1, {
-              requests = 1000,
-              prefix = "1 ",
-            })
-            local server2 = helpers.tcp_server(port2, {
-              requests = 1000,
-              prefix = "2 ",
-            })
-            ngx.sleep(0.1)
-
-            -- configure healthchecks
-            begin_testcase_setup(strategy, bp)
-            local upstream_name, upstream_id = add_upstream(bp, {
-              healthchecks = healthchecks_config {
-                active = {
-                  type = "tcp",
-                  healthy = {
-                    interval = HEALTHCHECK_INTERVAL,
-                    successes = 1,
-                  },
-                  unhealthy = {
-                    interval = HEALTHCHECK_INTERVAL,
-                    tcp_failures = 1,
-                  },
-                }
-              }
-            })
-
-            add_target(bp, upstream_id, localhost, port1)
-            add_target(bp, upstream_id, localhost, port2)
-            local _, service_id, route_id = add_api(bp, upstream_name, {
-              read_timeout = 500,
-              write_timeout = 500,
-              route_protocol = "tcp",
-            })
-            end_testcase_setup(strategy, bp)
-
-            finally(function()
-              helpers.kill_tcp_server(port1)
-              helpers.kill_tcp_server(port2)
-              server1:join()
-              server2:join()
-
-              bp.routes:remove({ id = route_id })
-              bp.services:remove({ id = service_id })
-            end)
-
-            ngx.sleep(0.5)
-
-            -- 1) server1 and server2 take requests
-            local ok1, ok2 = tcp_client_requests(SLOTS * 2, localhost, 9100)
-            assert.same(SLOTS, ok1)
-            assert.same(SLOTS, ok2)
-
-            -- server2 goes unhealthy
-            helpers.kill_tcp_server(port2)
-            server2:join()
-
-            -- Wait until healthchecker detects
-            -- We cannot use poll_wait_health because health endpoints
-            -- are not currently available for stream routes.
-            ngx.sleep(strategy == "cassandra" and 2 or 1)
-
-            -- 2) server1 takes all requests
-            ok1, ok2 = tcp_client_requests(SLOTS * 2, localhost, 9100)
-            assert.same(SLOTS * 2, ok1)
-            assert.same(0, ok2)
-
-            -- server2 goes healthy again
-            server2 = helpers.tcp_server(port2, {
-              requests = 1000,
-              prefix = "2 ",
-            })
-
-            -- Give time for healthchecker to detect
-            -- Again, we cannot use poll_wait_health because health endpoints
-            -- are not currently available for stream routes.
-            ngx.sleep(strategy == "cassandra" and 2 or 1)
-
-            -- 3) server1 and server2 take requests again
-            ok1, ok2 = tcp_client_requests(SLOTS * 2, localhost, 9100)
-            assert.same(SLOTS, ok1)
-            assert.same(SLOTS, ok2)
-          end)
-
-          -- FIXME This is marked as #flaky because of Travis CI instability.
-          -- This runs fine on other environments. This should be re-checked
-          -- at a later time.
-          it("#flaky perform active health checks -- can detect before any proxy traffic", function()
-
-            local nfails = 2
-            local requests = SLOTS * 2 -- go round the balancer twice
-            local port1 = gen_port()
-            local port2 = gen_port()
-            -- setup target servers:
-            -- server1 will respond all requests
-            local server1 = http_server(localhost, port1, { requests })
-            local server2 = http_server(localhost, port2, { requests })
-            -- configure healthchecks
-            begin_testcase_setup(strategy, bp)
-            local upstream_name, upstream_id = add_upstream(bp, {
-              healthchecks = healthchecks_config {
-                active = {
-                  http_path = "/status",
-                  healthy = {
-                    interval = HEALTHCHECK_INTERVAL,
-                    successes = 1,
-                  },
-                  unhealthy = {
-                    interval = HEALTHCHECK_INTERVAL,
-                    http_failures = nfails,
-                    tcp_failures = nfails,
-                  },
-                }
-              }
-            })
-            add_target(bp, upstream_id, localhost, port1)
-            add_target(bp, upstream_id, localhost, port2)
-            local api_host = add_api(bp, upstream_name)
-            end_testcase_setup(strategy, bp)
-
-            -- server2 goes unhealthy before the first request
-            direct_request(localhost, port2, "/unhealthy")
-
-            -- restart Kong
-            begin_testcase_setup_update(strategy, bp)
-            helpers.restart_kong({
-              database   = strategy,
-              nginx_conf = "spec/fixtures/custom_nginx.template",
-              lua_ssl_trusted_certificate = "spec/fixtures/kong_spec.crt",
-              db_update_frequency = 0.1,
-              stream_listen = "0.0.0.0:9100",
-              plugins = "bundled,fail-once-auth",
-            })
-            end_testcase_setup(strategy, bp)
-            ngx.sleep(1)
-
-            -- Give time for healthchecker to detect
-            poll_wait_health(upstream_id, localhost, port2, "UNHEALTHY")
-
-            -- server1 takes all requests
-
-            local client_oks, client_fails = client_requests(requests, api_host)
-
-            -- collect server results; hitcount
-            local _, ok1, fail1 = server1:done()
-            local _, ok2, fail2 = server2:done()
-
-            -- verify
-            assert.are.equal(requests, ok1)
-            assert.are.equal(0, ok2)
-            assert.are.equal(0, fail1)
-            assert.are.equal(0, fail2)
-
-            assert.are.equal(requests, client_oks)
-            assert.are.equal(0, client_fails)
-
-          end)
-
-          it("perform passive health checks -- manual recovery", function()
-
-            for nfails = 1, 3 do
               -- configure healthchecks
               begin_testcase_setup(strategy, bp)
               local upstream_name, upstream_id = add_upstream(bp, {
                 healthchecks = healthchecks_config {
                   passive = {
                     unhealthy = {
-                      http_failures = nfails,
+                      http_failures = 1,
                     }
                   }
                 }
@@ -2138,28 +2237,23 @@ for _, strategy in helpers.each_strategy() do
               local port1 = add_target(bp, upstream_id, localhost)
               local port2 = add_target(bp, upstream_id, localhost)
               local api_host = add_api(bp, upstream_name)
-              end_testcase_setup(strategy, bp)
+              end_testcase_setup(strategy, bp, consistency)
 
               -- setup target servers:
               -- server2 will only respond for part of the test,
               -- then server1 will take over.
-              local server1_oks = SLOTS * 2 - nfails
+              local server1_oks = SLOTS * 2
               local server2_oks = SLOTS
-              local server1 = http_server(localhost, port1, {
-                server1_oks
-              })
-              local server2 = http_server(localhost, port2, {
-                server2_oks / 2,
-                nfails,
-                server2_oks / 2
-              })
+              local server1 = http_server(localhost, port1, { server1_oks })
+              local server2 = http_server(localhost, port2, { server2_oks })
 
               -- 1) server1 and server2 take requests
               local oks, fails = client_requests(SLOTS, api_host)
 
-              -- 2) server1 takes all requests once server2 produces
-              -- `nfails` failures (even though server2 will be ready
-              -- to respond 200 again after `nfails`)
+              -- manually bring it down using the endpoint
+              post_target_endpoint(upstream_id, localhost, port2, "unhealthy")
+
+              -- 2) server1 takes all requests
               do
                 local o, f = client_requests(SLOTS, api_host)
                 oks = oks + o
@@ -2181,592 +2275,446 @@ for _, strategy in helpers.each_strategy() do
               local _, ok2, fail2 = server2:done()
 
               -- verify
+              assert.are.equal(SLOTS * 2, ok1)
+              assert.are.equal(SLOTS, ok2)
+              assert.are.equal(0, fail1)
+              assert.are.equal(0, fail2)
+
+              assert.are.equal(SLOTS * 3, oks)
+              assert.are.equal(0, fails)
+
+            end)
+
+            it("perform passive health checks -- connection #timeouts", function()
+
+              -- configure healthchecks
+              begin_testcase_setup(strategy, bp)
+              local upstream_name, upstream_id = add_upstream(bp, {
+                healthchecks = healthchecks_config {
+                  passive = {
+                    unhealthy = {
+                      timeouts = 1,
+                    }
+                  }
+                }
+              })
+              local port1 = add_target(bp, upstream_id, localhost)
+              local port2 = add_target(bp, upstream_id, localhost)
+              local api_host = add_api(bp, upstream_name, {
+                read_timeout = 50,
+                write_timeout = 50,
+              })
+              end_testcase_setup(strategy, bp, consistency)
+
+              -- setup target servers:
+              -- server2 will only respond for half of the test
+              -- then will timeout on the following request.
+              -- Then server1 will take over.
+              local server1_oks = SLOTS * 1.5
+              local server2_oks = SLOTS / 2
+              local server1 = http_server(localhost, port1, {
+                server1_oks
+              })
+              local server2 = http_server(localhost, port2, {
+                server2_oks,
+                TIMEOUT,
+              })
+
+              -- 1) server1 and server2 take requests
+              local oks, fails = client_requests(SLOTS, api_host)
+
+              -- 2) server1 takes all requests once server2 produces
+              -- `nfails` failures (even though server2 will be ready
+              -- to respond 200 again after `nfails`)
+              do
+                local o, f = client_requests(SLOTS, api_host)
+                oks = oks + o
+                fails = fails + f
+              end
+
+              -- collect server results; hitcount
+              local _, ok1, fail1 = server1:done()
+              local _, ok2, fail2 = server2:done()
+
+              -- verify
               assert.are.equal(server1_oks, ok1)
               assert.are.equal(server2_oks, ok2)
               assert.are.equal(0, fail1)
-              assert.are.equal(nfails, fail2)
+              assert.are.equal(1, fail2)
 
-              assert.are.equal(SLOTS * 3 - nfails, oks)
-              assert.are.equal(nfails, fails)
-            end
-          end)
-
-          it("perform passive health checks -- manual shutdown", function()
-
-            -- configure healthchecks
-            begin_testcase_setup(strategy, bp)
-            local upstream_name, upstream_id = add_upstream(bp, {
-              healthchecks = healthchecks_config {
-                passive = {
-                  unhealthy = {
-                    http_failures = 1,
-                  }
-                }
-              }
-            })
-            local port1 = add_target(bp, upstream_id, localhost)
-            local port2 = add_target(bp, upstream_id, localhost)
-            local api_host = add_api(bp, upstream_name)
-            end_testcase_setup(strategy, bp)
-
-            -- setup target servers:
-            -- server2 will only respond for part of the test,
-            -- then server1 will take over.
-            local server1_oks = SLOTS * 2
-            local server2_oks = SLOTS
-            local server1 = http_server(localhost, port1, { server1_oks })
-            local server2 = http_server(localhost, port2, { server2_oks })
-
-            -- 1) server1 and server2 take requests
-            local oks, fails = client_requests(SLOTS, api_host)
-
-            -- manually bring it down using the endpoint
-            post_target_endpoint(upstream_id, localhost, port2, "unhealthy")
-
-            -- 2) server1 takes all requests
-            do
-              local o, f = client_requests(SLOTS, api_host)
-              oks = oks + o
-              fails = fails + f
-            end
-
-            -- manually bring it back using the endpoint
-            post_target_endpoint(upstream_id, localhost, port2, "healthy")
-
-            -- 3) server1 and server2 take requests again
-            do
-              local o, f = client_requests(SLOTS, api_host)
-              oks = oks + o
-              fails = fails + f
-            end
-
-            -- collect server results; hitcount
-            local _, ok1, fail1 = server1:done()
-            local _, ok2, fail2 = server2:done()
-
-            -- verify
-            assert.are.equal(SLOTS * 2, ok1)
-            assert.are.equal(SLOTS, ok2)
-            assert.are.equal(0, fail1)
-            assert.are.equal(0, fail2)
-
-            assert.are.equal(SLOTS * 3, oks)
-            assert.are.equal(0, fails)
-
-          end)
-
-          it("perform passive health checks -- connection #timeouts", function()
-
-            -- configure healthchecks
-            begin_testcase_setup(strategy, bp)
-            local upstream_name, upstream_id = add_upstream(bp, {
-              healthchecks = healthchecks_config {
-                passive = {
-                  unhealthy = {
-                    timeouts = 1,
-                  }
-                }
-              }
-            })
-            local port1 = add_target(bp, upstream_id, localhost)
-            local port2 = add_target(bp, upstream_id, localhost)
-            local api_host = add_api(bp, upstream_name, {
-              read_timeout = 50,
-              write_timeout = 50,
-            })
-            end_testcase_setup(strategy, bp)
-
-            -- setup target servers:
-            -- server2 will only respond for half of the test
-            -- then will timeout on the following request.
-            -- Then server1 will take over.
-            local server1_oks = SLOTS * 1.5
-            local server2_oks = SLOTS / 2
-            local server1 = http_server(localhost, port1, {
-              server1_oks
-            })
-            local server2 = http_server(localhost, port2, {
-              server2_oks,
-              TIMEOUT,
-            })
-
-            -- 1) server1 and server2 take requests
-            local oks, fails = client_requests(SLOTS, api_host)
-
-            -- 2) server1 takes all requests once server2 produces
-            -- `nfails` failures (even though server2 will be ready
-            -- to respond 200 again after `nfails`)
-            do
-              local o, f = client_requests(SLOTS, api_host)
-              oks = oks + o
-              fails = fails + f
-            end
-
-            -- collect server results; hitcount
-            local _, ok1, fail1 = server1:done()
-            local _, ok2, fail2 = server2:done()
-
-            -- verify
-            assert.are.equal(server1_oks, ok1)
-            assert.are.equal(server2_oks, ok2)
-            assert.are.equal(0, fail1)
-            assert.are.equal(1, fail2)
-
-            assert.are.equal(SLOTS * 2, oks)
-            assert.are.equal(0, fails)
-          end)
-
-          stream_it("#flaky perform passive health checks -- #stream connection failure", function()
-
-            -- configure healthchecks
-            begin_testcase_setup(strategy, bp)
-            local upstream_name, upstream_id = add_upstream(bp, {
-              healthchecks = healthchecks_config {
-                passive = {
-                  unhealthy = {
-                    tcp_failures = 1,
-                  }
-                }
-              }
-            })
-            local port1 = add_target(bp, upstream_id, localhost)
-            local port2 = add_target(bp, upstream_id, localhost)
-            local _, service_id, route_id = add_api(bp, upstream_name, {
-              read_timeout = 50,
-              write_timeout = 50,
-              route_protocol = "tcp",
-            })
-            end_testcase_setup(strategy, bp)
-
-            finally(function()
-              bp.routes:remove({ id = route_id })
-              bp.services:remove({ id = service_id })
+              assert.are.equal(SLOTS * 2, oks)
+              assert.are.equal(0, fails)
             end)
 
-            -- setup target servers:
-            -- server2 will only respond for half of the test and will shutdown.
-            -- Then server1 will take over.
-            local server1_oks = SLOTS * 1.5
-            local server2_oks = SLOTS / 2
-            local server1 = helpers.tcp_server(port1, {
-              requests = server1_oks,
-              prefix = "1 ",
-            })
-            local server2 = helpers.tcp_server(port2, {
-              requests = server2_oks,
-              prefix = "2 ",
-            })
-            ngx.sleep(strategy == "cassandra" and 2 or 1)
+            stream_it("#flaky perform passive health checks -- #stream connection failure", function()
 
-            -- server1 and server2 take requests
-            -- server1 takes all requests once server2 fails
-            local ok1, ok2, fails = tcp_client_requests(SLOTS * 2, localhost, 9100)
-
-            -- finish up TCP server threads
-            server1:join()
-            server2:join()
-
-            -- verify
-            assert.are.equal(server1_oks, ok1)
-            assert.are.equal(server2_oks, ok2)
-            assert.are.equal(0, fails)
-          end)
-
-          -- #db == disabled for database=off, because healthcheckers
-          -- are currently reset when a new configuration is loaded
-          -- TODO enable this test when upstreams are preserved (not rebuild)
-          -- across a declarative config updates.
-          it("#db perform passive health checks -- send #timeouts", function()
-
-            -- configure healthchecks
-            begin_testcase_setup(strategy, bp)
-            local upstream_name, upstream_id = add_upstream(bp, {
-              healthchecks = healthchecks_config {
-                passive = {
-                  unhealthy = {
-                    http_failures = 0,
-                    timeouts = 1,
-                    tcp_failures = 0,
+              -- configure healthchecks
+              begin_testcase_setup(strategy, bp)
+              local upstream_name, upstream_id = add_upstream(bp, {
+                healthchecks = healthchecks_config {
+                  passive = {
+                    unhealthy = {
+                      tcp_failures = 1,
+                    }
                   }
                 }
-              }
-            })
-            local port1 = add_target(bp, upstream_id, localhost)
-            local api_host, service_id = add_api(bp, upstream_name, {
-              read_timeout = 10,
-              retries = 0,
-            })
-            end_testcase_setup(strategy, bp)
-
-            local server1 = http_server(localhost, port1, {
-              TIMEOUT,
-            })
-
-            local _, _, last_status = client_requests(1, api_host)
-            assert.same(504, last_status)
-
-            local _, oks1, fails1 = server1:done()
-            assert.same(1, oks1)
-            assert.same(0, fails1)
-
-            begin_testcase_setup_update(strategy, bp)
-            patch_api(bp, service_id, nil, 60000)
-            local port2 = add_target(bp, upstream_id, localhost)
-            end_testcase_setup(strategy, bp)
-
-            local server2 = http_server(localhost, port2, {
-              10,
-            })
-
-            _, _, last_status = client_requests(10, api_host)
-            assert.same(200, last_status)
-
-            local _, oks2, fails2 = server2:done()
-            assert.same(10, oks2)
-            assert.same(0, fails2)
-          end)
-
-        end)
-
-        describe("Balancing", function()
-
-          describe("with round-robin", function()
-
-            it("over multiple targets", function()
-
-              begin_testcase_setup(strategy, bp)
-              local upstream_name, upstream_id = add_upstream(bp)
-              local port1 = add_target(bp, upstream_id, localhost)
-              local port2 = add_target(bp, upstream_id, localhost)
-              local api_host = add_api(bp, upstream_name)
-              end_testcase_setup(strategy, bp)
-
-              local requests = SLOTS * 2 -- go round the balancer twice
-
-              -- setup target servers
-              local server1 = http_server(localhost, port1, { requests / 2 })
-              local server2 = http_server(localhost, port2, { requests / 2 })
-
-              -- Go hit them with our test requests
-              local oks = client_requests(requests, api_host)
-              assert.are.equal(requests, oks)
-
-              -- collect server results; hitcount
-              local _, count1 = server1:done()
-              local _, count2 = server2:done()
-
-              -- verify
-              assert.are.equal(requests / 2, count1)
-              assert.are.equal(requests / 2, count2)
-            end)
-
-            it("adding a target", function()
-
-              begin_testcase_setup(strategy, bp)
-              local upstream_name, upstream_id = add_upstream(bp)
-              local port1 = add_target(bp, upstream_id, localhost, nil, { weight = 10 })
-              local port2 = add_target(bp, upstream_id, localhost, nil, { weight = 10 })
-              local api_host = add_api(bp, upstream_name)
-              end_testcase_setup(strategy, bp)
-
-              local requests = SLOTS * 2 -- go round the balancer twice
-
-              -- setup target servers
-              local server1 = http_server(localhost, port1, { requests / 2 })
-              local server2 = http_server(localhost, port2, { requests / 2 })
-
-              -- Go hit them with our test requests
-              local oks = client_requests(requests, api_host)
-              assert.are.equal(requests, oks)
-
-              -- collect server results; hitcount
-              local _, count1 = server1:done()
-              local _, count2 = server2:done()
-
-              -- verify
-              assert.are.equal(requests / 2, count1)
-              assert.are.equal(requests / 2, count2)
-
-              -- add a new target 3
-              -- shift proportions from 50/50 to 40/40/20
-              begin_testcase_setup_update(strategy, bp)
-              local port3 = add_target(bp, upstream_id, localhost, nil, { weight = 5 })
-              end_testcase_setup(strategy, bp)
-
-              -- now go and hit the same balancer again
-              -----------------------------------------
-
-              -- setup target servers
-              local server3
-              server1 = http_server(localhost, port1, { requests * 0.4 })
-              server2 = http_server(localhost, port2, { requests * 0.4 })
-              server3 = http_server(localhost, port3, { requests * 0.2 })
-
-              -- Go hit them with our test requests
-              oks = client_requests(requests, api_host)
-              assert.are.equal(requests, oks)
-
-              -- collect server results; hitcount
-              _, count1 = server1:done()
-              _, count2 = server2:done()
-              local _, count3 = server3:done()
-
-              -- verify
-              assert.are.equal(requests * 0.4, count1)
-              assert.are.equal(requests * 0.4, count2)
-              assert.are.equal(requests * 0.2, count3)
-            end)
-
-            it("removing a target", function()
-              local requests = SLOTS * 2 -- go round the balancer twice
-
-              begin_testcase_setup(strategy, bp)
-              local upstream_name, upstream_id = add_upstream(bp)
-              local port1 = add_target(bp, upstream_id, localhost)
-              local port2 = add_target(bp, upstream_id, localhost)
-              local api_host = add_api(bp, upstream_name)
-              end_testcase_setup(strategy, bp)
-
-              -- setup target servers
-              local server1 = http_server(localhost, port1, { requests / 2 })
-              local server2 = http_server(localhost, port2, { requests / 2 })
-
-              -- Go hit them with our test requests
-              local oks = client_requests(requests, api_host)
-              assert.are.equal(requests, oks)
-
-              -- collect server results; hitcount
-              local _, count1 = server1:done()
-              local _, count2 = server2:done()
-
-              -- verify
-              assert.are.equal(requests / 2, count1)
-              assert.are.equal(requests / 2, count2)
-
-              -- modify weight for target 2, set to 0
-              begin_testcase_setup_update(strategy, bp)
-              add_target(bp, upstream_id, localhost, port2, {
-                weight = 0, -- disable this target
               })
-              end_testcase_setup(strategy, bp)
-
-              -- now go and hit the same balancer again
-              -----------------------------------------
-
-              -- setup target servers
-              server1 = http_server(localhost, port1, { requests })
-
-              -- Go hit them with our test requests
-              oks = client_requests(requests, api_host)
-              assert.are.equal(requests, oks)
-
-              -- collect server results; hitcount
-              _, count1 = server1:done()
-
-              -- verify all requests hit server 1
-              assert.are.equal(requests, count1)
-            end)
-            it("modifying target weight", function()
-              local requests = SLOTS * 2 -- go round the balancer twice
-
-              begin_testcase_setup(strategy, bp)
-              local upstream_name, upstream_id = add_upstream(bp)
               local port1 = add_target(bp, upstream_id, localhost)
               local port2 = add_target(bp, upstream_id, localhost)
-              local api_host = add_api(bp, upstream_name)
-              end_testcase_setup(strategy, bp)
-
-              -- setup target servers
-              local server1 = http_server(localhost, port1, { requests / 2 })
-              local server2 = http_server(localhost, port2, { requests / 2 })
-
-              -- Go hit them with our test requests
-              local oks = client_requests(requests, api_host)
-              assert.are.equal(requests, oks)
-
-              -- collect server results; hitcount
-              local _, count1 = server1:done()
-              local _, count2 = server2:done()
-
-              -- verify
-              assert.are.equal(requests / 2, count1)
-              assert.are.equal(requests / 2, count2)
-
-              -- modify weight for target 2
-              begin_testcase_setup_update(strategy, bp)
-              add_target(bp, upstream_id, localhost, port2, {
-                weight = 15,   -- shift proportions from 50/50 to 40/60
+              local _, service_id, route_id = add_api(bp, upstream_name, {
+                read_timeout = 50,
+                write_timeout = 50,
+                route_protocol = "tcp",
               })
-              end_testcase_setup(strategy, bp)
+              end_testcase_setup(strategy, bp, consistency)
 
-              -- now go and hit the same balancer again
-              -----------------------------------------
+              finally(function()
+                bp.routes:remove({ id = route_id })
+                bp.services:remove({ id = service_id })
+              end)
 
-              -- setup target servers
-              server1 = http_server(localhost, port1, { requests * 0.4 })
-              server2 = http_server(localhost, port2, { requests * 0.6 })
+              -- setup target servers:
+              -- server2 will only respond for half of the test and will shutdown.
+              -- Then server1 will take over.
+              local server1_oks = SLOTS * 1.5
+              local server2_oks = SLOTS / 2
+              local server1 = helpers.tcp_server(port1, {
+                requests = server1_oks,
+                prefix = "1 ",
+              })
+              local server2 = helpers.tcp_server(port2, {
+                requests = server2_oks,
+                prefix = "2 ",
+              })
+              ngx.sleep(strategy == "cassandra" and 2 or 1)
 
-              -- Go hit them with our test requests
-              oks = client_requests(requests, api_host)
-              assert.are.equal(requests, oks)
+              -- server1 and server2 take requests
+              -- server1 takes all requests once server2 fails
+              local ok1, ok2, fails = tcp_client_requests(SLOTS * 2, localhost, 9100)
 
-              -- collect server results; hitcount
-              _, count1 = server1:done()
-              _, count2 = server2:done()
+              -- finish up TCP server threads
+              server1:join()
+              server2:join()
 
               -- verify
-              assert.are.equal(requests * 0.4, count1)
-              assert.are.equal(requests * 0.6, count2)
+              assert.are.equal(server1_oks, ok1)
+              assert.are.equal(server2_oks, ok2)
+              assert.are.equal(0, fails)
             end)
 
-            it("failure due to targets all 0 weight", function()
-              local requests = SLOTS * 2 -- go round the balancer twice
+            -- #db == disabled for database=off, because healthcheckers
+            -- are currently reset when a new configuration is loaded
+            -- TODO enable this test when upstreams are preserved (not rebuild)
+            -- across a declarative config updates.
+            it("#db perform passive health checks -- send #timeouts", function()
 
+              -- configure healthchecks
               begin_testcase_setup(strategy, bp)
-              local upstream_name, upstream_id = add_upstream(bp)
+              local upstream_name, upstream_id = add_upstream(bp, {
+                healthchecks = healthchecks_config {
+                  passive = {
+                    unhealthy = {
+                      http_failures = 0,
+                      timeouts = 1,
+                      tcp_failures = 0,
+                    }
+                  }
+                }
+              })
               local port1 = add_target(bp, upstream_id, localhost)
-              local port2 = add_target(bp, upstream_id, localhost)
-              local api_host = add_api(bp, upstream_name)
-              end_testcase_setup(strategy, bp)
+              local api_host, service_id = add_api(bp, upstream_name, {
+                read_timeout = 10,
+                retries = 0,
+              })
+              end_testcase_setup(strategy, bp, consistency)
 
-              -- setup target servers
-              local server1 = http_server(localhost, port1, { requests / 2 })
-              local server2 = http_server(localhost, port2, { requests / 2 })
+              local server1 = http_server(localhost, port1, {
+                TIMEOUT,
+              })
 
-              -- Go hit them with our test requests
-              local oks = client_requests(requests, api_host)
-              assert.are.equal(requests, oks)
+              local _, _, last_status = client_requests(1, api_host)
+              assert.same(504, last_status)
 
-              -- collect server results; hitcount
-              local _, count1 = server1:done()
-              local _, count2 = server2:done()
+              local _, oks1, fails1 = server1:done()
+              assert.same(1, oks1)
+              assert.same(0, fails1)
 
-              -- verify
-              assert.are.equal(requests / 2, count1)
-              assert.are.equal(requests / 2, count2)
-
-              -- modify weight for both targets, set to 0
               begin_testcase_setup_update(strategy, bp)
-              add_target(bp, upstream_id, localhost, port1, { weight = 0 })
-              add_target(bp, upstream_id, localhost, port2, { weight = 0 })
-              end_testcase_setup(strategy, bp)
+              patch_api(bp, service_id, nil, 60000)
+              local port2 = add_target(bp, upstream_id, localhost)
+              end_testcase_setup(strategy, bp, consistency)
 
-              -- now go and hit the same balancer again
-              -----------------------------------------
+              local server2 = http_server(localhost, port2, {
+                10,
+              })
 
-              local _, _, status = client_requests(1, api_host)
-              assert.same(503, status)
+              _, _, last_status = client_requests(10, api_host)
+              assert.same(200, last_status)
+
+              local _, oks2, fails2 = server2:done()
+              assert.same(10, oks2)
+              assert.same(0, fails2)
             end)
 
           end)
 
-          describe("with consistent hashing", function()
+          describe("Balancing", function()
 
-            describe("over multiple targets", function()
+            describe("with round-robin", function()
 
-              it("hashing on header", function()
-                local requests = SLOTS * 2 -- go round the balancer twice
+              it("over multiple targets", function()
 
                 begin_testcase_setup(strategy, bp)
-                local upstream_name, upstream_id = add_upstream(bp, {
-                  hash_on = "header",
-                  hash_on_header = "hashme",
-                })
+                local upstream_name, upstream_id = add_upstream(bp)
                 local port1 = add_target(bp, upstream_id, localhost)
                 local port2 = add_target(bp, upstream_id, localhost)
                 local api_host = add_api(bp, upstream_name)
-                end_testcase_setup(strategy, bp)
+                end_testcase_setup(strategy, bp, consistency)
+
+                local requests = SLOTS * 2 -- go round the balancer twice
 
                 -- setup target servers
-                local server1 = http_server(localhost, port1, { requests })
-                local server2 = http_server(localhost, port2, { requests })
+                local server1 = http_server(localhost, port1, { requests / 2 })
+                local server2 = http_server(localhost, port2, { requests / 2 })
 
                 -- Go hit them with our test requests
-                local oks = client_requests(requests, {
-                  ["Host"] = api_host,
-                  ["hashme"] = "just a value",
-                })
+                local oks = client_requests(requests, api_host)
                 assert.are.equal(requests, oks)
 
                 -- collect server results; hitcount
-                -- one should get all the hits, the other 0
                 local _, count1 = server1:done()
                 local _, count2 = server2:done()
 
                 -- verify
-                assert(count1 == 0 or count1 == requests, "counts should either get 0 or ALL hits")
-                assert(count2 == 0 or count2 == requests, "counts should either get 0 or ALL hits")
-                assert(count1 + count2 == requests)
+                assert.are.equal(requests / 2, count1)
+                assert.are.equal(requests / 2, count2)
               end)
 
-              describe("hashing on cookie", function()
-                it("does not reply with Set-Cookie if cookie is already set", function()
-                  begin_testcase_setup(strategy, bp)
-                  local upstream_name, upstream_id = add_upstream(bp, {
-                    hash_on = "cookie",
-                    hash_on_cookie = "hashme",
-                  })
-                  local port = add_target(bp, upstream_id, localhost)
-                  local api_host = add_api(bp, upstream_name)
-                  end_testcase_setup(strategy, bp)
+              it("adding a target", function()
 
-                  -- setup target server
-                  local server = http_server(localhost, port, { 1 })
+                begin_testcase_setup(strategy, bp)
+                local upstream_name, upstream_id = add_upstream(bp)
+                local port1 = add_target(bp, upstream_id, localhost, nil, { weight = 10 })
+                local port2 = add_target(bp, upstream_id, localhost, nil, { weight = 10 })
+                local api_host = add_api(bp, upstream_name)
+                end_testcase_setup(strategy, bp, consistency)
 
-                  -- send request
-                  local client = helpers.proxy_client()
-                  local res = client:send {
-                    method = "GET",
-                    path = "/",
-                    headers = {
-                      ["Host"] = api_host,
-                      ["Cookie"] = "hashme=some-cookie-value",
-                    }
-                  }
-                  local set_cookie = res.headers["Set-Cookie"]
+                local requests = SLOTS * 2 -- go round the balancer twice
 
-                  client:close()
-                  server:done()
+                -- setup target servers
+                local server1 = http_server(localhost, port1, { requests / 2 })
+                local server2 = http_server(localhost, port2, { requests / 2 })
 
-                  -- verify
-                  assert.is_nil(set_cookie)
-                end)
+                -- Go hit them with our test requests
+                local oks = client_requests(requests, api_host)
+                assert.are.equal(requests, oks)
 
-                it("replies with Set-Cookie if cookie is not set", function()
+                -- collect server results; hitcount
+                local _, count1 = server1:done()
+                local _, count2 = server2:done()
+
+                -- verify
+                assert.are.equal(requests / 2, count1)
+                assert.are.equal(requests / 2, count2)
+
+                -- add a new target 3
+                -- shift proportions from 50/50 to 40/40/20
+                begin_testcase_setup_update(strategy, bp)
+                local port3 = add_target(bp, upstream_id, localhost, nil, { weight = 5 })
+                end_testcase_setup(strategy, bp, consistency)
+
+                -- now go and hit the same balancer again
+                -----------------------------------------
+
+                -- setup target servers
+                local server3
+                server1 = http_server(localhost, port1, { requests * 0.4 })
+                server2 = http_server(localhost, port2, { requests * 0.4 })
+                server3 = http_server(localhost, port3, { requests * 0.2 })
+
+                -- Go hit them with our test requests
+                oks = client_requests(requests, api_host)
+                assert.are.equal(requests, oks)
+
+                -- collect server results; hitcount
+                _, count1 = server1:done()
+                _, count2 = server2:done()
+                local _, count3 = server3:done()
+
+                -- verify
+                assert.are.equal(requests * 0.4, count1)
+                assert.are.equal(requests * 0.4, count2)
+                assert.are.equal(requests * 0.2, count3)
+              end)
+
+              it("removing a target", function()
+                local requests = SLOTS * 2 -- go round the balancer twice
+
+                begin_testcase_setup(strategy, bp)
+                local upstream_name, upstream_id = add_upstream(bp)
+                local port1 = add_target(bp, upstream_id, localhost)
+                local port2 = add_target(bp, upstream_id, localhost)
+                local api_host = add_api(bp, upstream_name)
+                end_testcase_setup(strategy, bp, consistency)
+
+                -- setup target servers
+                local server1 = http_server(localhost, port1, { requests / 2 })
+                local server2 = http_server(localhost, port2, { requests / 2 })
+
+                -- Go hit them with our test requests
+                local oks = client_requests(requests, api_host)
+                assert.are.equal(requests, oks)
+
+                -- collect server results; hitcount
+                local _, count1 = server1:done()
+                local _, count2 = server2:done()
+
+                -- verify
+                assert.are.equal(requests / 2, count1)
+                assert.are.equal(requests / 2, count2)
+
+                -- modify weight for target 2, set to 0
+                begin_testcase_setup_update(strategy, bp)
+                add_target(bp, upstream_id, localhost, port2, {
+                  weight = 0, -- disable this target
+                })
+                end_testcase_setup(strategy, bp, consistency)
+
+                -- now go and hit the same balancer again
+                -----------------------------------------
+
+                -- setup target servers
+                server1 = http_server(localhost, port1, { requests })
+
+                -- Go hit them with our test requests
+                oks = client_requests(requests, api_host)
+                assert.are.equal(requests, oks)
+
+                -- collect server results; hitcount
+                _, count1 = server1:done()
+
+                -- verify all requests hit server 1
+                assert.are.equal(requests, count1)
+              end)
+              it("modifying target weight", function()
+                local requests = SLOTS * 2 -- go round the balancer twice
+
+                begin_testcase_setup(strategy, bp)
+                local upstream_name, upstream_id = add_upstream(bp)
+                local port1 = add_target(bp, upstream_id, localhost)
+                local port2 = add_target(bp, upstream_id, localhost)
+                local api_host = add_api(bp, upstream_name)
+                end_testcase_setup(strategy, bp, consistency)
+
+                -- setup target servers
+                local server1 = http_server(localhost, port1, { requests / 2 })
+                local server2 = http_server(localhost, port2, { requests / 2 })
+
+                -- Go hit them with our test requests
+                local oks = client_requests(requests, api_host)
+                assert.are.equal(requests, oks)
+
+                -- collect server results; hitcount
+                local _, count1 = server1:done()
+                local _, count2 = server2:done()
+
+                -- verify
+                assert.are.equal(requests / 2, count1)
+                assert.are.equal(requests / 2, count2)
+
+                -- modify weight for target 2
+                begin_testcase_setup_update(strategy, bp)
+                add_target(bp, upstream_id, localhost, port2, {
+                  weight = 15,   -- shift proportions from 50/50 to 40/60
+                })
+                end_testcase_setup(strategy, bp, consistency)
+
+                -- now go and hit the same balancer again
+                -----------------------------------------
+
+                -- setup target servers
+                server1 = http_server(localhost, port1, { requests * 0.4 })
+                server2 = http_server(localhost, port2, { requests * 0.6 })
+
+                -- Go hit them with our test requests
+                oks = client_requests(requests, api_host)
+                assert.are.equal(requests, oks)
+
+                -- collect server results; hitcount
+                _, count1 = server1:done()
+                _, count2 = server2:done()
+
+                -- verify
+                assert.are.equal(requests * 0.4, count1)
+                assert.are.equal(requests * 0.6, count2)
+              end)
+
+              it("failure due to targets all 0 weight", function()
+                local requests = SLOTS * 2 -- go round the balancer twice
+
+                begin_testcase_setup(strategy, bp)
+                local upstream_name, upstream_id = add_upstream(bp)
+                local port1 = add_target(bp, upstream_id, localhost)
+                local port2 = add_target(bp, upstream_id, localhost)
+                local api_host = add_api(bp, upstream_name)
+                end_testcase_setup(strategy, bp, consistency)
+
+                -- setup target servers
+                local server1 = http_server(localhost, port1, { requests / 2 })
+                local server2 = http_server(localhost, port2, { requests / 2 })
+
+                -- Go hit them with our test requests
+                local oks = client_requests(requests, api_host)
+                assert.are.equal(requests, oks)
+
+                -- collect server results; hitcount
+                local _, count1 = server1:done()
+                local _, count2 = server2:done()
+
+                -- verify
+                assert.are.equal(requests / 2, count1)
+                assert.are.equal(requests / 2, count2)
+
+                -- modify weight for both targets, set to 0
+                begin_testcase_setup_update(strategy, bp)
+                add_target(bp, upstream_id, localhost, port1, { weight = 0 })
+                add_target(bp, upstream_id, localhost, port2, { weight = 0 })
+                end_testcase_setup(strategy, bp, consistency)
+
+                -- now go and hit the same balancer again
+                -----------------------------------------
+
+                local _, _, status = client_requests(1, api_host)
+                assert.same(503, status)
+              end)
+
+            end)
+
+            describe("with consistent hashing", function()
+
+              describe("over multiple targets", function()
+
+                it("hashing on header", function()
                   local requests = SLOTS * 2 -- go round the balancer twice
 
                   begin_testcase_setup(strategy, bp)
                   local upstream_name, upstream_id = add_upstream(bp, {
-                    hash_on = "cookie",
-                    hash_on_cookie = "hashme",
+                    hash_on = "header",
+                    hash_on_header = "hashme",
                   })
                   local port1 = add_target(bp, upstream_id, localhost)
                   local port2 = add_target(bp, upstream_id, localhost)
                   local api_host = add_api(bp, upstream_name)
-                  end_testcase_setup(strategy, bp)
+                  end_testcase_setup(strategy, bp, consistency)
 
                   -- setup target servers
                   local server1 = http_server(localhost, port1, { requests })
                   local server2 = http_server(localhost, port2, { requests })
 
-                  -- initial request without the `hash_on` cookie
-                  local client = helpers.proxy_client()
-                  local res = client:send {
-                    method = "GET",
-                    path = "/",
-                    headers = {
-                      ["Host"] = api_host,
-                      ["Cookie"] = "some-other-cooke=some-other-value",
-                    }
-                  }
-                  local cookie = res.headers["Set-Cookie"]:match("hashme%=(.*)%;")
-
-                  client:close()
-
-                  -- subsequent requests add the cookie that was set by the first response
-                  local oks = 1 + client_requests(requests - 1, {
+                  -- Go hit them with our test requests
+                  local oks = client_requests(requests, {
                     ["Host"] = api_host,
-                    ["Cookie"] = "hashme=" .. cookie,
+                    ["hashme"] = "just a value",
                   })
                   assert.are.equal(requests, oks)
 
@@ -2776,38 +2724,121 @@ for _, strategy in helpers.each_strategy() do
                   local _, count2 = server2:done()
 
                   -- verify
-                  assert(count1 == 0 or count1 == requests,
-                         "counts should either get 0 or ALL hits, but got " .. count1 .. " of " .. requests)
-                  assert(count2 == 0 or count2 == requests,
-                         "counts should either get 0 or ALL hits, but got " .. count2 .. " of " .. requests)
+                  assert(count1 == 0 or count1 == requests, "counts should either get 0 or ALL hits")
+                  assert(count2 == 0 or count2 == requests, "counts should either get 0 or ALL hits")
                   assert(count1 + count2 == requests)
+                end)
+
+                describe("hashing on cookie", function()
+                  it("does not reply with Set-Cookie if cookie is already set", function()
+                    begin_testcase_setup(strategy, bp)
+                    local upstream_name, upstream_id = add_upstream(bp, {
+                      hash_on = "cookie",
+                      hash_on_cookie = "hashme",
+                    })
+                    local port = add_target(bp, upstream_id, localhost)
+                    local api_host = add_api(bp, upstream_name)
+                    end_testcase_setup(strategy, bp, consistency)
+
+                    -- setup target server
+                    local server = http_server(localhost, port, { 1 })
+
+                    -- send request
+                    local client = helpers.proxy_client()
+                    local res = client:send {
+                      method = "GET",
+                      path = "/",
+                      headers = {
+                        ["Host"] = api_host,
+                        ["Cookie"] = "hashme=some-cookie-value",
+                      }
+                    }
+                    local set_cookie = res.headers["Set-Cookie"]
+
+                    client:close()
+                    server:done()
+
+                    -- verify
+                    assert.is_nil(set_cookie)
+                  end)
+
+                  it("replies with Set-Cookie if cookie is not set", function()
+                    local requests = SLOTS * 2 -- go round the balancer twice
+
+                    begin_testcase_setup(strategy, bp)
+                    local upstream_name, upstream_id = add_upstream(bp, {
+                      hash_on = "cookie",
+                      hash_on_cookie = "hashme",
+                    })
+                    local port1 = add_target(bp, upstream_id, localhost)
+                    local port2 = add_target(bp, upstream_id, localhost)
+                    local api_host = add_api(bp, upstream_name)
+                    end_testcase_setup(strategy, bp, consistency)
+
+                    -- setup target servers
+                    local server1 = http_server(localhost, port1, { requests })
+                    local server2 = http_server(localhost, port2, { requests })
+
+                    -- initial request without the `hash_on` cookie
+                    local client = helpers.proxy_client()
+                    local res = client:send {
+                      method = "GET",
+                      path = "/",
+                      headers = {
+                        ["Host"] = api_host,
+                        ["Cookie"] = "some-other-cooke=some-other-value",
+                      }
+                    }
+                    local cookie = res.headers["Set-Cookie"]:match("hashme%=(.*)%;")
+
+                    client:close()
+
+                    -- subsequent requests add the cookie that was set by the first response
+                    local oks = 1 + client_requests(requests - 1, {
+                      ["Host"] = api_host,
+                      ["Cookie"] = "hashme=" .. cookie,
+                    })
+                    assert.are.equal(requests, oks)
+
+                    -- collect server results; hitcount
+                    -- one should get all the hits, the other 0
+                    local _, count1 = server1:done()
+                    local _, count2 = server2:done()
+
+                    -- verify
+                    assert(count1 == 0 or count1 == requests,
+                           "counts should either get 0 or ALL hits, but got " .. count1 .. " of " .. requests)
+                    assert(count2 == 0 or count2 == requests,
+                           "counts should either get 0 or ALL hits, but got " .. count2 .. " of " .. requests)
+                    assert(count1 + count2 == requests)
+                  end)
+
                 end)
 
               end)
 
             end)
 
-          end)
+            describe("with no targets", function()
 
-          describe("with no targets", function()
+              it("failure due to no targets", function()
 
-            it("failure due to no targets", function()
+                begin_testcase_setup(strategy, bp)
+                local upstream_name = add_upstream(bp)
+                local api_host = add_api(bp, upstream_name)
+                end_testcase_setup(strategy, bp, consistency)
 
-              begin_testcase_setup(strategy, bp)
-              local upstream_name = add_upstream(bp)
-              local api_host = add_api(bp, upstream_name)
-              end_testcase_setup(strategy, bp)
+                -- Go hit it with a request
+                local _, _, status = client_requests(1, api_host)
+                assert.same(503, status)
 
-              -- Go hit it with a request
-              local _, _, status = client_requests(1, api_host)
-              assert.same(503, status)
+              end)
 
             end)
-
           end)
         end)
-      end)
-    end -- for 'localhost'
-  end)
-end -- for each_strategy
+      end -- for 'localhost'
+    end)
+  end -- for each_strategy
+end -- for worker_consistency
 


### PR DESCRIPTION
This change adds the option to change upstreams asynchronously, i.e. upstreams will not be updated on every call to Admin API, but rather when a timer expires. This improves the performance when Kong is configured with a large number of upstreams and/or when upstreams are frequently changed.