### PR TITLE
Fix: #233. Add generic X-RateLimit-* and X-RateLimit-Reset too.

### DIFF
--- a/kong/plugins/rate-limiting/handler.lua
+++ b/kong/plugins/rate-limiting/handler.lua
@@ -1,4 +1,5 @@
 -- Copyright (C) Kong Inc.
+local timestamp = require "kong.tools.timestamp"
 local policies = require "kong.plugins.rate-limiting.policies"
 
 
@@ -6,14 +7,18 @@ local kong = kong
 local ngx = ngx
 local max = math.max
 local time = ngx.time
+local floor = math.floor
 local pairs = pairs
 local tostring = tostring
 local timer_at = ngx.timer.at
 
 
 local EMPTY = {}
+local EXPIRATIONS = policies.EXPIRATIONS
 local RATELIMIT_LIMIT = "X-RateLimit-Limit"
 local RATELIMIT_REMAINING = "X-RateLimit-Remaining"
+local RETRY_AFTER = "Retry-After"
+
 
 local RateLimitingHandler = {}
 
@@ -107,15 +112,28 @@ function RateLimitingHandler:access(conf)
 
   if usage then
     -- Adding headers
+    local reset
     if not conf.hide_client_headers then
       local headers = {}
+      local timestamps
       for k, v in pairs(usage) do
         if stop == nil or stop == k then
           v.remaining = v.remaining - 1
         end
 
+        local remaining = max(0, v.remaining)
+
         headers[RATELIMIT_LIMIT .. "-" .. k] = v.limit
-        headers[RATELIMIT_REMAINING .. "-" .. k] = max(0, v.remaining)
+        headers[RATELIMIT_REMAINING .. "-" .. k] = remaining
+
+        if stop and remaining == 0 then
+          if not timestamps then
+            timestamps = timestamp.get_timestamps(current_timestamp)
+          end
+
+          reset = max(reset or 0, EXPIRATIONS[k] - floor((current_timestamp -
+                                                          timestamps[k]) / 1000))
+        end
       end
 
       kong.ctx.plugin.headers = headers
@@ -123,7 +141,14 @@ function RateLimitingHandler:access(conf)
 
     -- If limit is exceeded, terminate the request
     if stop then
-      return kong.response.exit(429, { message = "API rate limit exceeded" })
+      local headers
+      if reset then
+        headers = {
+          [RETRY_AFTER] = reset
+        }
+      end
+
+      return kong.response.exit(429, { message = "API rate limit exceeded" }, headers)
     end
   end
 

--- a/kong/plugins/rate-limiting/policies/init.lua
+++ b/kong/plugins/rate-limiting/policies/init.lua
@@ -59,6 +59,7 @@ local EXPIRATIONS = {
 
 
 return {
+  ["EXPIRATIONS"] = EXPIRATIONS,
   ["local"] = {
     increment = function(conf, limits, identifier, current_timestamp, value)
       local periods = timestamp.get_timestamps(current_timestamp)


### PR DESCRIPTION
### Summary

Return the lowest limit header as X-RateLimit-Remaining and
the associate X-RateLimit-Reset.

This implements this I-D  https://tools.ietf.org/html/draft-polli-ratelimit-headers-01
which has been recently discussed at [IETF106](http://bit.ly/2qWhwwD)


### Full changelog

* Add X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset using the lower values between the configured ones

### Issues resolved

Fix #233 
