### PR TITLE
feat: enable `reuseport` option for Nginx `listen` directive by default

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -122,7 +122,7 @@
 # NGINX
 #------------------------------------------------------------------------------
 
-#proxy_listen = 0.0.0.0:8000, 0.0.0.0:8443 ssl
+#proxy_listen = 0.0.0.0:8000 reuseport backlog=16384, 0.0.0.0:8443 ssl reuseport backlog=16384
                          # Comma-separated list of addresses and ports on
                          # which the proxy server should listen for
                          # HTTP/HTTPS traffic.
@@ -149,8 +149,19 @@
                          #   for a given address:port pair.
                          # - `reuseport` instructs to create an individual
                          #   listening socket for each worker process
-                         #   allowing a kernel to distribute incoming
+                         #   allowing the Kernel to better distribute incoming
                          #   connections between worker processes
+                         # - `backlog=N` sets the maximum length for the queue
+                         #   of pending TCP connections. This number should
+                         #   not be too small in order to prevent clients
+                         #   seeing "Connection refused" error connecting to
+                         #   a busy Kong instance.
+                         #   **Note:** on Linux, this value is limited by the
+                         #   setting of `net.core.somaxconn` Kernel parameter.
+                         #   In order for the larger `backlog` set here to take
+                         #   effect it is necessary to raise
+                         #   `net.core.somaxconn` at the same time to match or
+                         #   exceed the `backlog` number set.
                          #
                          # This value can be set to `off`, thus disabling
                          # the HTTP/HTTPS proxy port for this node.
@@ -190,8 +201,19 @@
                          #   for a given address:port pair.
                          # - `reuseport` instructs to create an individual
                          #   listening socket for each worker process
-                         #   allowing a kernel to distribute incoming
+                         #   allowing the Kernel to better distribute incoming
                          #   connections between worker processes
+                         # - `backlog=N` sets the maximum length for the queue
+                         #   of pending TCP connections. This number should
+                         #   not be too small in order to prevent clients
+                         #   seeing "Connection refused" error connecting to
+                         #   a busy Kong instance.
+                         #   **Note:** on Linux, this value is limited by the
+                         #   setting of `net.core.somaxconn` Kernel parameter.
+                         #   In order for the larger `backlog` set here to take
+                         #   effect it is necessary to raise
+                         #   `net.core.somaxconn` at the same time to match or
+                         #   exceed the `backlog` number set.
                          #
                          # **Note:** The `ssl` suffix is not supported,
                          # and each address/port will accept TCP with or
@@ -200,9 +222,9 @@
                          # Examples:
                          #
                          # ```
-                         # stream_listen = 127.0.0.1:7000
-                         # stream_listen = 0.0.0.0:989, 0.0.0.0:20
-                         # stream_listen = [::1]:1234
+                         # stream_listen = 127.0.0.1:7000 reuseport backlog=16384
+                         # stream_listen = 0.0.0.0:989 reuseport backlog=65536, 0.0.0.0:20
+                         # stream_listen = [::1]:1234 backlog=16384
                          # ```
                          #
                          # By default this value is set to `off`, thus
@@ -211,7 +233,7 @@
 # See http://nginx.org/en/docs/stream/ngx_stream_core_module.html#listen
 # for a description of the formats that Kong might accept in stream_listen.
 
-#admin_listen = 127.0.0.1:8001, 127.0.0.1:8444 ssl
+#admin_listen = 127.0.0.1:8001 reuseport backlog=16384, 127.0.0.1:8444 ssl reuseport backlog=16384
                          # Comma-separated list of addresses and ports on
                          # which the Admin interface should listen.
                          # The Admin interface is the API allowing you to
@@ -238,8 +260,19 @@
                          #   for a given address:port pair.
                          # - `reuseport` instructs to create an individual
                          #   listening socket for each worker process
-                         #   allowing a kernel to distribute incoming
+                         #   allowing the Kernel to better distribute incoming
                          #   connections between worker processes
+                         # - `backlog=N` sets the maximum length for the queue
+                         #   of pending TCP connections. This number should
+                         #   not be too small in order to prevent clients
+                         #   seeing "Connection refused" error connecting to
+                         #   a busy Kong instance.
+                         #   **Note:** on Linux, this value is limited by the
+                         #   setting of `net.core.somaxconn` Kernel parameter.
+                         #   In order for the larger `backlog` set here to take
+                         #   effect it is necessary to raise
+                         #   `net.core.somaxconn` at the same time to match or
+                         #   exceed the `backlog` number set.
                          #
                          # This value can be set to `off`, thus disabling
                          # the Admin interface for this node, enabling a

--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -621,7 +621,13 @@ local function parse_option_flags(value, flags)
 
   for _, flag in ipairs(flags) do
     local count
-    local patt = "%s" .. flag .. "%s"
+    local patt = "%s(" .. flag .. ")%s"
+
+    local found = value:match(patt)
+    if found then
+      -- replace pattern like `backlog=%d+` with actual values
+      flag = found
+    end
 
     value, count = value:gsub(patt, " ")
 
@@ -987,7 +993,7 @@ local function load(path, custom_conf, opts)
 
   do
     local http_flags = { "ssl", "http2", "proxy_protocol", "transparent",
-                         "deferred", "bind", "reuseport" }
+                         "deferred", "bind", "reuseport", "backlog=%d+" }
     local stream_flags = { "proxy_protocol", "transparent", "bind",
                            "reuseport" }
 

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -10,9 +10,9 @@ status_error_log = logs/status_error.log
 plugins = bundled
 anonymous_reports = on
 
-proxy_listen = 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+proxy_listen = 0.0.0.0:8000 reuseport backlog=16384, 0.0.0.0:8443 http2 ssl reuseport backlog=16384
 stream_listen = off
-admin_listen = 127.0.0.1:8001, 127.0.0.1:8444 http2 ssl
+admin_listen = 127.0.0.1:8001 reuseport backlog=16384, 127.0.0.1:8444 http2 ssl reuseport backlog=16384
 status_listen = off
 origins = NONE
 nginx_user = nobody nobody

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -21,8 +21,8 @@ describe("Configuration loader", function()
     assert.is_string(conf.lua_package_path)
     assert.is_nil(conf.nginx_user)
     assert.equal("auto", conf.nginx_worker_processes)
-    assert.same({"127.0.0.1:8001", "127.0.0.1:8444 http2 ssl"}, conf.admin_listen)
-    assert.same({"0.0.0.0:8000", "0.0.0.0:8443 http2 ssl"}, conf.proxy_listen)
+    assert.same({"127.0.0.1:8001 reuseport backlog=16384", "127.0.0.1:8444 http2 ssl reuseport backlog=16384"}, conf.admin_listen)
+    assert.same({"0.0.0.0:8000 reuseport backlog=16384", "0.0.0.0:8443 http2 ssl reuseport backlog=16384"}, conf.proxy_listen)
     assert.is_nil(conf.ssl_cert) -- check placeholder value
     assert.is_nil(conf.ssl_cert_key)
     assert.is_nil(conf.admin_ssl_cert)
@@ -100,25 +100,25 @@ describe("Configuration loader", function()
     assert.equal(8001, conf.admin_listeners[1].port)
     assert.equal(false, conf.admin_listeners[1].ssl)
     assert.equal(false, conf.admin_listeners[1].http2)
-    assert.equal("127.0.0.1:8001", conf.admin_listeners[1].listener)
+    assert.equal("127.0.0.1:8001 reuseport backlog=16384", conf.admin_listeners[1].listener)
 
     assert.equal("127.0.0.1", conf.admin_listeners[2].ip)
     assert.equal(8444, conf.admin_listeners[2].port)
     assert.equal(true, conf.admin_listeners[2].ssl)
     assert.equal(true, conf.admin_listeners[2].http2)
-    assert.equal("127.0.0.1:8444 ssl http2", conf.admin_listeners[2].listener)
+    assert.equal("127.0.0.1:8444 ssl http2 reuseport backlog=16384", conf.admin_listeners[2].listener)
 
     assert.equal("0.0.0.0", conf.proxy_listeners[1].ip)
     assert.equal(8000, conf.proxy_listeners[1].port)
     assert.equal(false, conf.proxy_listeners[1].ssl)
     assert.equal(false, conf.proxy_listeners[1].http2)
-    assert.equal("0.0.0.0:8000", conf.proxy_listeners[1].listener)
+    assert.equal("0.0.0.0:8000 reuseport backlog=16384", conf.proxy_listeners[1].listener)
 
     assert.equal("0.0.0.0", conf.proxy_listeners[2].ip)
     assert.equal(8443, conf.proxy_listeners[2].port)
     assert.equal(true, conf.proxy_listeners[2].ssl)
     assert.equal(true, conf.proxy_listeners[2].http2)
-    assert.equal("0.0.0.0:8443 ssl http2", conf.proxy_listeners[2].listener)
+    assert.equal("0.0.0.0:8443 ssl http2 reuseport backlog=16384", conf.proxy_listeners[2].listener)
   end)
   it("parses IPv6 from proxy_listen/admin_listen", function()
     local conf = assert(conf_loader(nil, {
@@ -533,26 +533,26 @@ describe("Configuration loader", function()
         admin_listen = "127.0.0.1"
       })
       assert.is_nil(conf)
-      assert.equal("admin_listen must be of form: [off] | <ip>:<port> [ssl] [http2] [proxy_protocol] [transparent] [deferred] [bind] [reuseport], [... next entry ...]", err)
+      assert.equal("admin_listen must be of form: [off] | <ip>:<port> [ssl] [http2] [proxy_protocol] [transparent] [deferred] [bind] [reuseport] [backlog=%d+], [... next entry ...]", err)
 
       conf, err = conf_loader(nil, {
         proxy_listen = "127.0.0.1"
       })
       assert.is_nil(conf)
-      assert.equal("proxy_listen must be of form: [off] | <ip>:<port> [ssl] [http2] [proxy_protocol] [transparent] [deferred] [bind] [reuseport], [... next entry ...]", err)
+      assert.equal("proxy_listen must be of form: [off] | <ip>:<port> [ssl] [http2] [proxy_protocol] [transparent] [deferred] [bind] [reuseport] [backlog=%d+], [... next entry ...]", err)
     end)
     it("rejects empty string in listen addresses", function()
       local conf, err = conf_loader(nil, {
         admin_listen = ""
       })
       assert.is_nil(conf)
-      assert.equal("admin_listen must be of form: [off] | <ip>:<port> [ssl] [http2] [proxy_protocol] [transparent] [deferred] [bind] [reuseport], [... next entry ...]", err)
+      assert.equal("admin_listen must be of form: [off] | <ip>:<port> [ssl] [http2] [proxy_protocol] [transparent] [deferred] [bind] [reuseport] [backlog=%d+], [... next entry ...]", err)
 
       conf, err = conf_loader(nil, {
         proxy_listen = ""
       })
       assert.is_nil(conf)
-      assert.equal("proxy_listen must be of form: [off] | <ip>:<port> [ssl] [http2] [proxy_protocol] [transparent] [deferred] [bind] [reuseport], [... next entry ...]", err)
+      assert.equal("proxy_listen must be of form: [off] | <ip>:<port> [ssl] [http2] [proxy_protocol] [transparent] [deferred] [bind] [reuseport] [backlog=%d+], [... next entry ...]", err)
     end)
     it("errors when dns_resolver is not a list in ipv4/6[:port] format", function()
       local conf, err = conf_loader(nil, {


### PR DESCRIPTION
and allow specifying `backlog=N` options in listener flags

This enables the `reuseport` flag by default, and use a higher `backlog` to help with high traffic servers.

It should have no impact on existing use case, only that server with lots of worker now sees more evenly distributed load and connection across workers. it also reduces issue such as https://discuss.konghq.com/t/concurrent-websocket-connections/4854 from occurring.

Note on the `backlog` value. It is set to a fairly high value `16384` to help handle burst of TCP connections better. The `backlog` is by default set to unlimited on BSD systems and `511` on Linux, which is on the lower end and Kernel can easily handle more connections than that.

However, note that from the man page of `listen`:

> If the backlog argument is greater than the value in
> /proc/sys/net/core/somaxconn, then it is silently truncated to that
> value; the default value in this file is 128.  In kernels before
> 2.4.25, this limit was a hard coded value, SOMAXCONN, with the value
> 128.

Which means that it is also limited by the `somaxconn` Kernel param on Linux. `somaxconn` is set fairly low by default, and we document in `kong.conf` to make sure people is aware the necessity of bumping `somaxconn` at the same time in order for the config to take effect.

As a reference, in Kubernetes Ingress Controller, they always fetch the current value of `somaxconn` and use that as the `backlog` argument, but for us that is not necessary. The Kernel will handle it.

Note that raising `backlog` would not cause any increase of memory usage for normal users, as the TCP connection backlogs are not pre-allocated but rather stored in a dynamically growing/shrinking linked list on demand (https://elixir.bootlin.com/linux/latest/source/include/net/sock.h#L924, https://elixir.bootlin.com/linux/latest/source/include/net/sock.h#L897).