### PR TITLE
feat(rate-limiting) add support for draft-rfc rate-limiting headers

### DIFF
--- a/spec/03-plugins/23-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/04-access_spec.lua
@@ -269,6 +269,10 @@ for _, strategy in helpers.each_strategy() do
 
             assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
             assert.are.same(6 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
+            assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
+            assert.are.same(6 - i, tonumber(res.headers["ratelimit-remaining"]))
+            local reset = tonumber(res.headers["ratelimit-reset"])
+            assert.equal(true, reset <= 60 and reset >= 0)
           end
 
           -- Additonal request, while limit is 6/minute
@@ -276,8 +280,14 @@ for _, strategy in helpers.each_strategy() do
             headers = { Host = "test1.com" },
           }, 429)
 
+          assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
+          assert.are.same(0, tonumber(res.headers["ratelimit-remaining"]))
+
           local retry = tonumber(res.headers["retry-after"])
-          assert.equal(true, retry <= 60 and retry >= 0)
+          assert.equal(true, retry <= 60 and retry > 0)
+
+          local reset = tonumber(res.headers["ratelimit-reset"])
+          assert.equal(true, reset <= 60 and reset > 0)
 
           local json = cjson.decode(body)
           assert.same({ message = "API rate limit exceeded" }, json)
@@ -291,6 +301,10 @@ for _, strategy in helpers.each_strategy() do
 
             assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
             assert.are.same(6 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
+            assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
+            assert.are.same(6 - i, tonumber(res.headers["ratelimit-remaining"]))
+            local reset = tonumber(res.headers["ratelimit-reset"])
+            assert.equal(true, reset <= 60 and reset > 0)
           end
 
           for i = 4, 6 do
@@ -300,6 +314,10 @@ for _, strategy in helpers.each_strategy() do
 
             assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
             assert.are.same(6 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
+            assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
+            assert.are.same(6 - i, tonumber(res.headers["ratelimit-remaining"]))
+            local reset = tonumber(res.headers["ratelimit-reset"])
+            assert.equal(true, reset <= 60 and reset > 0)
           end
 
           -- Additonal request, while limit is 6/minute
@@ -307,8 +325,14 @@ for _, strategy in helpers.each_strategy() do
             headers = { Host = "test-service1.com" },
           }, 429)
 
+          assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
+          assert.are.same(0, tonumber(res.headers["ratelimit-remaining"]))
+
           local retry = tonumber(res.headers["retry-after"])
-          assert.equal(true, retry <= 60 and retry >= 0)
+          assert.equal(true, retry <= 60 and retry > 0)
+
+          local reset = tonumber(res.headers["ratelimit-reset"])
+          assert.equal(true, reset <= 60 and reset > 0)
 
           local json = cjson.decode(body)
           assert.same({ message = "API rate limit exceeded" }, json)
@@ -329,6 +353,10 @@ for _, strategy in helpers.each_strategy() do
             assert.are.same(limits.minute - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
             assert.are.same(limits.hour, tonumber(res.headers["x-ratelimit-limit-hour"]))
             assert.are.same(limits.hour - i, tonumber(res.headers["x-ratelimit-remaining-hour"]))
+            assert.are.same(limits.minute, tonumber(res.headers["ratelimit-limit"]))
+            assert.are.same(limits.minute - i, tonumber(res.headers["ratelimit-remaining"]))
+            local reset = tonumber(res.headers["ratelimit-reset"])
+            assert.equal(true, reset <= 60 and reset > 0)
           end
 
           local res, body = GET("/status/200", {
@@ -336,10 +364,16 @@ for _, strategy in helpers.each_strategy() do
             headers = { Host = "test2.com" },
           }, 429)
 
-          local retry = tonumber(res.headers["retry-after"])
-          assert.equal(true, retry <= 60 and retry >= 0)
+          assert.are.same(limits.minute, tonumber(res.headers["ratelimit-limit"]))
+          assert.are.same(0, tonumber(res.headers["ratelimit-remaining"]))
           assert.equal(2, tonumber(res.headers["x-ratelimit-remaining-hour"]))
           assert.equal(0, tonumber(res.headers["x-ratelimit-remaining-minute"]))
+
+          local retry = tonumber(res.headers["retry-after"])
+          assert.equal(true, retry <= 60 and retry > 0)
+
+          local reset = tonumber(res.headers["ratelimit-reset"])
+          assert.equal(true, reset <= 60 and reset > 0)
 
           local json = cjson.decode(body)
           assert.same({ message = "API rate limit exceeded" }, json)
@@ -355,6 +389,10 @@ for _, strategy in helpers.each_strategy() do
 
               assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
               assert.are.same(6 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
+              assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
+              assert.are.same(6 - i, tonumber(res.headers["ratelimit-remaining"]))
+              local reset = tonumber(res.headers["ratelimit-reset"])
+              assert.equal(true, reset <= 60 and reset > 0)
             end
 
             -- Third query, while limit is 2/minute
@@ -362,8 +400,14 @@ for _, strategy in helpers.each_strategy() do
               headers = { Host = "test3.com" },
             }, 429)
 
+            assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
+            assert.are.same(0, tonumber(res.headers["ratelimit-remaining"]))
+
             local retry = tonumber(res.headers["retry-after"])
-            assert.equal(true, retry <= 60 and retry >= 0)
+            assert.equal(true, retry <= 60 and retry > 0)
+
+            local reset = tonumber(res.headers["ratelimit-reset"])
+            assert.equal(true, reset <= 60 and reset > 0)
 
             local json = cjson.decode(body)
             assert.same({ message = "API rate limit exceeded" }, json)
@@ -383,14 +427,24 @@ for _, strategy in helpers.each_strategy() do
 
               assert.are.same(8, tonumber(res.headers["x-ratelimit-limit-minute"]))
               assert.are.same(8 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
+              assert.are.same(8, tonumber(res.headers["ratelimit-limit"]))
+              assert.are.same(8 - i, tonumber(res.headers["ratelimit-remaining"]))
+              local reset = tonumber(res.headers["ratelimit-reset"])
+              assert.equal(true, reset <= 60 and reset > 0)
             end
 
             local res, body = GET("/status/200?apikey=apikey122", {
               headers = { Host = "test3.com" },
             }, 429)
 
+            assert.are.same(8, tonumber(res.headers["ratelimit-limit"]))
+            assert.are.same(0, tonumber(res.headers["ratelimit-remaining"]))
+
             local retry = tonumber(res.headers["retry-after"])
-            assert.equal(true, retry <= 60 and retry >= 0)
+            assert.equal(true, retry <= 60 and retry > 0)
+
+            local reset = tonumber(res.headers["ratelimit-reset"])
+            assert.equal(true, reset <= 60 and reset > 0)
 
             local json = cjson.decode(body)
             assert.same({ message = "API rate limit exceeded" }, json)
@@ -404,14 +458,24 @@ for _, strategy in helpers.each_strategy() do
 
               assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
               assert.are.same(6 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
+              assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
+              assert.are.same(6 - i, tonumber(res.headers["ratelimit-remaining"]))
+              local reset = tonumber(res.headers["ratelimit-reset"])
+              assert.equal(true, reset <= 60 and reset > 0)
             end
 
             local res, body = GET("/status/200?apikey=apikey122", {
               headers = { Host = "test4.com" },
             }, 429)
 
+            assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
+            assert.are.same(0, tonumber(res.headers["ratelimit-remaining"]))
+
             local retry = tonumber(res.headers["retry-after"])
-            assert.equal(true, retry <= 60 and retry >= 0)
+            assert.equal(true, retry <= 60 and retry > 0)
+
+            local reset = tonumber(res.headers["ratelimit-reset"])
+            assert.equal(true, reset <= 60 and reset > 0)
 
             local json = cjson.decode(body)
             assert.same({ message = "API rate limit exceeded" }, json)
@@ -427,6 +491,10 @@ for _, strategy in helpers.each_strategy() do
 
           assert.is_nil(res.headers["x-ratelimit-limit-minute"])
           assert.is_nil(res.headers["x-ratelimit-remaining-minute"])
+          assert.is_nil(res.headers["ratelimit-limit"])
+          assert.is_nil(res.headers["ratelimit-remaining"])
+          assert.is_nil(res.headers["ratelimit-reset"])
+          assert.is_nil(res.headers["retry-after"])
         end)
       end)
 
@@ -475,6 +543,10 @@ for _, strategy in helpers.each_strategy() do
 
             assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
             assert.are.same(5, tonumber(res.headers["x-ratelimit-remaining-minute"]))
+            assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
+            assert.are.same(5, tonumber(res.headers["ratelimit-remaining"]))
+            local reset = tonumber(res.headers["ratelimit-reset"])
+            assert.equal(true, reset <= 60 and reset > 0)
 
             -- Simulate an error on the database
             assert(db.connector:query("DROP TABLE ratelimiting_metrics"))
@@ -498,6 +570,10 @@ for _, strategy in helpers.each_strategy() do
 
             assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
             assert.are.same(5, tonumber(res.headers["x-ratelimit-remaining-minute"]))
+            assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
+            assert.are.same(5, tonumber(res.headers["ratelimit-remaining"]))
+            local reset = tonumber(res.headers["ratelimit-reset"])
+            assert.equal(true, reset <= 60 and reset > 0)
 
             -- Simulate an error on the database
             assert(db.connector:query("DROP TABLE ratelimiting_metrics"))
@@ -509,6 +585,9 @@ for _, strategy in helpers.each_strategy() do
 
             assert.falsy(res.headers["x-ratelimit-limit-minute"])
             assert.falsy(res.headers["x-ratelimit-remaining-minute"])
+            assert.falsy(res.headers["ratelimit-limit"])
+            assert.falsy(res.headers["ratelimit-remaining"])
+            assert.falsy(res.headers["ratelimit-reset"])
 
             db:reset()
             bp, db = helpers.get_db_utils(strategy)
@@ -578,6 +657,9 @@ for _, strategy in helpers.each_strategy() do
 
             assert.falsy(res.headers["x-ratelimit-limit-minute"])
             assert.falsy(res.headers["x-ratelimit-remaining-minute"])
+            assert.falsy(res.headers["ratelimit-limit"])
+            assert.falsy(res.headers["ratelimit-remaining"])
+            assert.falsy(res.headers["ratelimit-reset"])
           end)
         end)
       end
@@ -622,6 +704,10 @@ for _, strategy in helpers.each_strategy() do
 
           assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
           assert.are.same(5, tonumber(res.headers["x-ratelimit-remaining-minute"]))
+          assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
+          assert.are.same(5, tonumber(res.headers["ratelimit-remaining"]))
+          local reset = tonumber(res.headers["ratelimit-reset"])
+          assert.equal(true, reset <= 60 and reset > 0)
 
           ngx.sleep(t) -- Wait for minute to expire
 
@@ -631,6 +717,11 @@ for _, strategy in helpers.each_strategy() do
 
           assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
           assert.are.same(5, tonumber(res.headers["x-ratelimit-remaining-minute"]))
+          assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
+          assert.are.same(5, tonumber(res.headers["ratelimit-remaining"]))
+          local reset = tonumber(res.headers["ratelimit-reset"])
+          assert.equal(true, reset <= 60 and reset > 0)
+
         end)
       end)
     end)
@@ -693,6 +784,10 @@ for _, strategy in helpers.each_strategy() do
 
           assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
           assert.are.same(6 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
+          assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
+          assert.are.same(6 - i, tonumber(res.headers["ratelimit-remaining"]))
+          local reset = tonumber(res.headers["ratelimit-reset"])
+          assert.equal(true, reset <= 60 and reset > 0)
         end
 
         -- Additonal request, while limit is 6/minute
@@ -700,8 +795,14 @@ for _, strategy in helpers.each_strategy() do
           headers = { Host = "test1.com" },
         }, 429)
 
+        assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
+        assert.are.same(0, tonumber(res.headers["ratelimit-remaining"]))
+
         local retry = tonumber(res.headers["retry-after"])
-        assert.equal(true, retry <= 60 and retry >= 0)
+        assert.equal(true, retry <= 60 and retry > 0)
+
+        local reset = tonumber(res.headers["ratelimit-reset"])
+        assert.equal(true, reset <= 60 and reset > 0)
 
         local json = cjson.decode(body)
         assert.same({ message = "API rate limit exceeded" }, json)
@@ -754,6 +855,10 @@ for _, strategy in helpers.each_strategy() do
 
           assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
           assert.are.same(6 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
+          assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
+          assert.are.same(6 - i, tonumber(res.headers["ratelimit-remaining"]))
+          local reset = tonumber(res.headers["ratelimit-reset"])
+          assert.equal(true, reset <= 60 and reset > 0)
         end
 
         -- Additonal request, while limit is 6/minute
@@ -761,8 +866,14 @@ for _, strategy in helpers.each_strategy() do
           headers = { Host = "test1.com" },
         }, 429)
 
+        assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
+        assert.are.same(0, tonumber(res.headers["ratelimit-remaining"]))
+
         local retry = tonumber(res.headers["retry-after"])
-        assert.equal(true, retry <= 60 and retry >= 0)
+        assert.equal(true, retry <= 60 and retry > 0)
+
+        local reset = tonumber(res.headers["ratelimit-reset"])
+        assert.equal(true, reset <= 60 and reset > 0)
 
         local json = cjson.decode(body)
         assert.same({ message = "API rate limit exceeded" }, json)
@@ -814,6 +925,10 @@ for _, strategy in helpers.each_strategy() do
 
           assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
           assert.are.same(6 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
+          assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
+          assert.are.same(6 - i, tonumber(res.headers["ratelimit-remaining"]))
+          local reset = tonumber(res.headers["ratelimit-reset"])
+          assert.equal(true, reset <= 60 and reset > 0)
         end
 
         -- Additonal request, while limit is 6/minute
@@ -821,8 +936,14 @@ for _, strategy in helpers.each_strategy() do
           headers = { Host = "test1.com" },
         }, 429)
 
+        assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
+        assert.are.same(0, tonumber(res.headers["ratelimit-remaining"]))
+
         local retry = tonumber(res.headers["retry-after"])
-        assert.equal(true, retry <= 60 and retry >= 0)
+        assert.equal(true, retry <= 60 and retry > 0)
+
+        local reset = tonumber(res.headers["ratelimit-reset"])
+        assert.equal(true, reset <= 60 and reset > 0)
 
         local json = cjson.decode(body)
         assert.same({ message = "API rate limit exceeded" }, json)


### PR DESCRIPTION
### Summary

This PR adds support for the following headers specified in
https://tools.ietf.org/html/draft-polli-ratelimit-headers-01:

- RateLimit-Limit
- RateLimit-Remaining
- RateLimit-Reset

For `RateLimit-Limit` this does not implement multiple windows support (I removed it for now):
https://tools.ietf.org/html/draft-polli-ratelimit-headers-01#section-6.2.4

All this work was done by @ioggstream (give him a t-shirt or two!) on
several attempts: #5330 and #3451, and btw. @ioggstream is the author
of that draft rfc, which I hope gets promoted to a proposed standard!
Great stuff! And sure we want to support it.

I (@bungle) gathered the ideas and feedback from the previous PRs
(including #2735) and tried to make all these in a state where we
can agree and merge. I have refactored the code a bit when adding
these new headers. And I also added a bunch of tests.

This PR does not touch the previous `proprietary` headers the plugin
has sent for a long time, namely:
- X-RateLimit-Limit-*
- X-RateLimit-Remaining-*

We can later on decide, perhaps when this is standardized (or some time
after that), if we want to drop support on these, but at this point
they remain.

### Issues Resolved

Fix #233

### Note

Lets review and merge #5329 before this.

Also if we keep all rights to change headers if the `RFC` changes.