### PR TITLE
fix(schema) default entities with empty fields

### DIFF
--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -204,7 +204,12 @@ end
 
 
 local function load_plugin_subschemas(fields, plugin_set, indent)
+  if not fields then
+    return true
+  end
+
   indent = indent or 0
+
   for _, f in ipairs(fields) do
     local fname, fdata = next(f)
 


### PR DESCRIPTION
### Summary

Entities defining a field that is a record and abstract fail to be loaded unless they define an empty fields on the record.

* `{ config = { type = "record", abstract = true } }` will try to ipairs through nil.
* `{ config = { type = "record", abstract = true, fields = {} } }` would load fine


For instance, the test schema on https://github.com/Kong/kong/blob/7b8b41508430ad4c63c5ee832c50576623c47e5d/spec/01-unit/01-db/01-schema/01-schema_spec.lua#L1039-L1067 would not work as an entity.

Not sure what would be the better place to add a test for this scenario that is not an integration test so we can hit this function. The unit test on subschemas does not go through `load_plugin_subschemas`.

Also confused about why an entity goes through `load_plugin_subschemas`.

### Full changelog

* Default to empty fields when fields are nil on `load_plugin_subschemas`

