### PR TITLE
feat(core) check the existence of `lua_ssl_trusted_certificate` and use

### DIFF
--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -471,6 +471,13 @@ local function check_and_infer(conf)
     end
   end
 
+  if conf.lua_ssl_trusted_certificate and
+     not pl_path.exists(conf.lua_ssl_trusted_certificate)
+  then
+    errors[#errors + 1] = "lua_ssl_trusted_certificate: no such file at " ..
+                        conf.lua_ssl_trusted_certificate
+  end
+
   if conf.ssl_cipher_suite ~= "custom" then
     local suite = cipher_suites[conf.ssl_cipher_suite]
     if suite then
@@ -1146,6 +1153,11 @@ local function load(path, custom_conf, opts)
   if conf.admin_ssl_cert and conf.admin_ssl_cert_key then
     conf.admin_ssl_cert = pl_path.abspath(conf.admin_ssl_cert)
     conf.admin_ssl_cert_key = pl_path.abspath(conf.admin_ssl_cert_key)
+  end
+
+  if conf.lua_ssl_trusted_certificate then
+    conf.lua_ssl_trusted_certificate =
+      pl_path.abspath(conf.lua_ssl_trusted_certificate)
   end
 
   -- attach prefix files paths

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -689,6 +689,14 @@ describe("Configuration loader", function()
           assert.contains("ssl_cert_key: no such file at /path/cert_key.pem", errors)
           assert.is_nil(conf)
         end)
+        it("requires trusted CA cert file to exist", function()
+          local conf, _, errors = conf_loader(nil, {
+            lua_ssl_trusted_certificate = "/path/cert.pem",
+          })
+          assert.equal(1, #errors)
+          assert.contains("lua_ssl_trusted_certificate: no such file at /path/cert.pem", errors)
+          assert.is_nil(conf)
+        end)
         it("resolves SSL cert/key to absolute path", function()
           local conf, err = conf_loader(nil, {
             ssl_cert = "spec/fixtures/kong_spec.crt",

--- a/spec/01-unit/04-prefix_handler_spec.lua
+++ b/spec/01-unit/04-prefix_handler_spec.lua
@@ -213,10 +213,10 @@ describe("NGINX conf compiler", function()
     end)
     it("sets lua_ssl_trusted_certificate", function()
       local conf = assert(conf_loader(helpers.test_conf_path, {
-        lua_ssl_trusted_certificate = "/path/to/ca.cert",
+        lua_ssl_trusted_certificate = "spec/fixtures/kong_spec.crt",
       }))
       local kong_nginx_conf = prefix_handler.compile_kong_conf(conf)
-      assert.matches("lua_ssl_trusted_certificate '/path/to/ca.cert';", kong_nginx_conf, nil, true)
+      assert.matches("lua_ssl_trusted_certificate.*spec/fixtures/kong_spec.key", kong_nginx_conf)
     end)
     it("compiles without anonymous reports", function()
       local conf = assert(conf_loader(nil, {

--- a/spec/02-integration/05-proxy/10-balancer/01-ring-balancer_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer/01-ring-balancer_spec.lua
@@ -835,7 +835,7 @@ for _, strategy in helpers.each_strategy() do
       assert(helpers.start_kong({
         database   = strategy,
         nginx_conf = "spec/fixtures/custom_nginx.template",
-        lua_ssl_trusted_certificate = "../spec/fixtures/kong_spec.crt",
+        lua_ssl_trusted_certificate = "spec/fixtures/kong_spec.crt",
         stream_listen = "0.0.0.0:9100",
         db_update_frequency = 0.1,
         plugins = "bundled,fail-once-auth",
@@ -1360,7 +1360,7 @@ for _, strategy in helpers.each_strategy() do
             helpers.restart_kong({
               database = strategy,
               nginx_conf = "spec/fixtures/custom_nginx.template",
-              lua_ssl_trusted_certificate = "../spec/fixtures/kong_spec.crt",
+              lua_ssl_trusted_certificate = "spec/fixtures/kong_spec.crt",
               db_update_frequency = 0.1,
               stream_listen = "0.0.0.0:9100",
               plugins = "bundled,fail-once-auth",
@@ -1735,7 +1735,7 @@ for _, strategy in helpers.each_strategy() do
               helpers.restart_kong({
                 database = strategy,
                 nginx_conf = "spec/fixtures/custom_nginx.template",
-                lua_ssl_trusted_certificate = "../spec/fixtures/kong_spec.crt",
+                lua_ssl_trusted_certificate = "spec/fixtures/kong_spec.crt",
                 db_update_frequency = 0.1,
                 stream_listen = "0.0.0.0:9100",
                 plugins = "bundled,fail-once-auth",
@@ -1849,7 +1849,7 @@ for _, strategy in helpers.each_strategy() do
               helpers.restart_kong({
                 database = strategy,
                 nginx_conf = "spec/fixtures/custom_nginx.template",
-                lua_ssl_trusted_certificate = "../spec/fixtures/kong_spec.crt",
+                lua_ssl_trusted_certificate = "spec/fixtures/kong_spec.crt",
                 db_update_frequency = 0.1,
                 stream_listen = "0.0.0.0:9100",
                 plugins = "bundled,fail-once-auth",
@@ -2091,7 +2091,7 @@ for _, strategy in helpers.each_strategy() do
             helpers.restart_kong({
               database   = strategy,
               nginx_conf = "spec/fixtures/custom_nginx.template",
-              lua_ssl_trusted_certificate = "../spec/fixtures/kong_spec.crt",
+              lua_ssl_trusted_certificate = "spec/fixtures/kong_spec.crt",
               db_update_frequency = 0.1,
               stream_listen = "0.0.0.0:9100",
               plugins = "bundled,fail-once-auth",


### PR DESCRIPTION
absolute path to avoid relative path resolve issues

For user-friendless reasons. This ensures `lua_ssl_trusted_certificate` is handled similarly like other configs such as `admin_ssl_cert` which already has this check.