### PR TITLE
feat(route)path regex matches support req_uri with args, disable route cache

### DIFF
--- a/kong/router.lua
+++ b/kong/router.lua
@@ -1479,7 +1479,7 @@ function _M.new(routes)
     -- no match :'(
   end
 
-  find_route = function(req_method, req_uri, req_host, src_ip, src_port, dst_ip, dst_port, sni, req_headers)
+  local function find_route (req_method, req_uri, req_host, src_ip, src_port, dst_ip, dst_port, sni, req_headers)
     return find_route_ng(req_method, req_uri, req_uri, req_host, src_ip, src_port, dst_ip, dst_port, sni, req_headers)
   end
 

--- a/kong/router.lua
+++ b/kong/router.lua
@@ -1164,6 +1164,7 @@ function _M.new(routes)
 
   local grab_req_headers = #plain_indexes.headers > 0
 
+  -- add new func to pass orig_req_uri for regex path matching.
   local function find_route_ng(req_method, req_uri, orig_req_uri, req_host,
                             src_ip, src_port,
                             dst_ip, dst_port,


### PR DESCRIPTION
### Summary
add path regex matches support request uri with args, disable route cache for head mapping with uri issue
refer the feature link: https://github.com/Kong/kong/issues/5301

### Full changelog

/kong/router.lua

### Issues resolved
1. Add path regex matches support request uri with args
2. disable cache for route matches to avoid the header route issue.

All above changes tested(including stress testing) and the result is OK.

For point 2, I need to explain as below: a simple case, Please tell me if I get wrong, thank you very much.

there are two routing with different service:
route a: path: /api/xxx/one, with head matches: x-token=foo
route b: path: /api/xxx/one

while any request match a, then the rest of request take the cache logic with below code:

``` lua
-- cache lookup (except for headers-matched Routes)
    local cache_key = req_method .. "|" .. req_uri .. "|" .. req_host ..
                      "|" .. ctx.src_ip .. "|" .. ctx.src_port ..
                      "|" .. ctx.dst_ip .. "|" .. ctx.dst_port ..
                      "|" .. ctx.sni
    do
      local match_t = cache:get(cache_key)
      if match_t then
        return match_t
      end
    end
```

NOTE: the general way, last five args in cache key is empty. which means the cache key is decided by req_method, req_uri and req_host.

which means the requests which should be matched with route b, but by this cache logic, it would match the cache a(no change to check the head parts).

Another point, involve the args with request uri support, we should not support cache, otherwise, the cache would have a low hit rate.