### PR TITLE
fix delete targets larger then (1-cleanup_factor)*targets-count

### DIFF
--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -505,7 +505,7 @@ local function check_target_history(upstream, balancer)
     end
   end
 
-  if last_equal_index == new_size and new_size > 0 then
+  if last_equal_index == new_size and new_size > 0 and new_size == old_size then
     -- No history update is necessary in the balancer object.
     return true
   elseif last_equal_index == old_size then


### PR DESCRIPTION
This pr try to fix when delete targets larger then (1-cleanup_factor<db/dao/targets.lua:32>) at a short time ; and the deleted targets are the last (1-cleanup_factor) targets of targets table in pgsql , it will cause the new_size(which has rebuild in db) less then old_size,and not create balancer correctly.