### PR TITLE
tests(rate-limiting) wait for minute flip when retrying a test

### DIFF
--- a/spec/03-plugins/23-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/04-access_spec.lua
@@ -24,6 +24,7 @@ local proxy_client = helpers.proxy_client
 local function it_with_retry(desc, test)
   return it(desc, function(...)
     if not pcall(test, ...) then
+      ngx.sleep(61 - (ngx.now() % 60))  -- Wait for minute to expire
       test(...)
     end
   end)


### PR DESCRIPTION
The state of a previous run may leak into a retry because the tests don't
setup their dependencies in an isolated manner.

Given that all tests use minute counters, a quick solution is to wait for the
minute flip in between the attempt and the retry.

Local testing has demonstrated this to be effective (first-attempt failures
have resulted in successful retries, whereas without it the retries for the
test in line 755 also fail.)