### PR TITLE
chore(deps) bump acme plugin to 0.2.x

### DIFF
--- a/kong-1.4.2-0.rockspec
+++ b/kong-1.4.2-0.rockspec
@@ -44,7 +44,7 @@ dependencies = {
   "kong-plugin-request-transformer ~> 1.2",
   "kong-plugin-session ~> 2.2",
   "kong-plugin-aws-lambda ~> 3.0",
-  "kong-plugin-acme ~> 0.1",
+  "kong-plugin-acme ~> 0.2",
 }
 build = {
   type = "builtin",


### PR DESCRIPTION
Changelog:
https://github.com/Kong/kong-plugin-acme/blob/master/CHANGELOG.md#020---20191218

Summary:
- Breaking change: this plugin now can only configured as global plugin.
- Add support for dbless mode.
- Add `tos_accepted` to plugin config if using Let's Encrypt.
- Add `domains` to plugin config to include domains that needs certificate.