### PR TITLE
feat(router) path handling algorithms, with migrations

### DIFF
--- a/autodoc/data/admin-api.lua
+++ b/autodoc/data/admin-api.lua
@@ -517,6 +517,32 @@ return {
         * For `tls`, at least one of `sources`, `destinations` or `snis`;
         * For `grpc`, at least one of `hosts`, `headers` or `paths`;
         * For `grpcs`, at least one of `hosts`, `headers`, `paths` or `snis`.
+
+        #### Path handling algorithms
+
+        `"v0"` is the behavior used in Kong 0.x and 2.x. It treats `service.path`, `route.path` and request path as
+        *segments* of a url. It will always join them via slashes. Given a service path `/s`, route path `/r`
+        and request path `/re`, the concatenated path will be `/s/re`. If the resulting path is a single slash,
+        no further transformation is done to it. If it's longer, then the trailing slash is removed.
+
+        `"v1"` is the behavior used in Kong 1.x. It treats `service.path` as a *prefix*, and ignores the initial
+        slashes of the request and route paths. Given service path `/s`, route path `/r` and request path `/re`,
+        the concatenated path will be `/sre`.
+
+        Both versions of the algorithm detect "double slashes" when combining paths, replacing them by single
+        slashes.
+
+        | `service.path` | `route.path` | `route.strip_path` | `route.path_handling` | request path | proxied path  |
+        |----------------|--------------|--------------------|-----------------------|--------------|---------------|
+        | `/s`           | `/fv0`       | `false`            | `v0`                  | `/fv0req`    | `/s/fv0req`   |
+        | `/s`           | `/fv1`       | `false`            | `v1`                  | `/fv1req`    | `/sfv1req`    |
+        | `/s`           | `/tv0`       | `true`             | `v0`                  | `/tv0req`    | `/s/req`      |
+        | `/s`           | `/tv1`       | `true`             | `v1`                  | `/tv1req`    | `/sreq`       |
+        | `/s`           | `/fv0/`      | `false`            | `v0`                  | `/fv0/req`   | `/s/fv0/req`  |
+        | `/s`           | `/fv1/`      | `false`            | `v1`                  | `/fv1/req`   | `/sfv1/req`   |
+        | `/s`           | `/tv0/`      | `true`             | `v0`                  | `/tv0/req`   | `/s/req`      |
+        | `/s`           | `/tv1/`      | `true`             | `v1`                  | `/tv1/req    | `/sreq`       |
+
       ]],
       fields = {
         id = { skip = true },
@@ -609,6 +635,12 @@ return {
           description = [[
             When matching a Route via one of the `paths`,
             strip the matching prefix from the upstream request URL.
+          ]]
+        },
+        path_handling = {
+          description = [[
+            Controls how the Service path, Route path and requested path are combined when sending a request to the
+            upstream. See above for a detailed description of each behavior.
           ]]
         },
         preserve_host = {

--- a/kong/db/migrations/core/001_14_to_15.lua
+++ b/kong/db/migrations/core/001_14_to_15.lua
@@ -249,6 +249,16 @@ return {
         "key"   TEXT     NOT NULL,
         "cert"  TEXT     NOT NULL
       );
+
+
+      -- Migrating from 0.14.1 into 2.0: add path_handling with v0 as default
+      DO $$
+      BEGIN
+        ALTER TABLE IF EXISTS ONLY "routes" ADD "path_handling" TEXT DEFAULT 'v0';
+      EXCEPTION WHEN DUPLICATE_COLUMN THEN
+        -- Do nothing, accept existing state
+      END;
+      $$;
     ]],
 
     teardown = function(connector, helpers)
@@ -311,9 +321,25 @@ return {
         key text,
         cert text
       );
+
+      ALTER TABLE plugins ADD path_handling text;
     ]],
 
     teardown = function(connector, helpers)
+      local coordinator = assert(connector:connect_migrations())
+
+      for rows, err in coordinator:iterate([[SELECT * FROM routes]]) do
+        if err then
+          return nil, err
+        end
+
+        for _, row in ipairs(rows) do
+          assert(connector:query([[
+            UPDATE routes SET path_handling = 'v0'
+            WHERE partition = 'routes' AND id = ]] .. row.id))
+        end
+      end
+
       local plugins_def = {
         name = "plugins",
         columns = {

--- a/kong/db/migrations/core/007_140_to_200.lua
+++ b/kong/db/migrations/core/007_140_to_200.lua
@@ -1,13 +1,16 @@
 return {
   postgres = {
     up = [[
+      -- If migrating from 1.x, the "path_handling" column does not exist yet.
+      -- Create it with a default of 'v1' to fill existing rows, then change the default.
       DO $$
       BEGIN
-        ALTER TABLE IF EXISTS ONLY "routes" ADD "path_handling" TEXT;
+        ALTER TABLE IF EXISTS ONLY "routes" ADD "path_handling" TEXT DEFAULT 'v1';
       EXCEPTION WHEN DUPLICATE_COLUMN THEN
         -- Do nothing, accept existing state
       END;
       $$;
+      ALTER TABLE IF EXISTS ONLY "routes" ALTER COLUMN "path_handling" SET DEFAULT 'v0';
     ]],
 
     teardown = function(connector)
@@ -36,6 +39,22 @@ return {
     ]],
 
     teardown = function(connector)
+      local coordinator = assert(connector:connect_migrations())
+
+      for rows, err in coordinator:iterate([[SELECT * FROM routes]]) do
+        if err then
+          return nil, err
+        end
+
+        for _, row in ipairs(rows) do
+          if row.path_handling ~= "v0" then
+            assert(connector:query([[
+              UPDATE routes SET path_handling = 'v1'
+              WHERE partition = 'routes' AND id = ]] .. row.id))
+          end
+        end
+      end
+
       assert(connector:query([[
         DROP INDEX IF EXISTS plugins_run_on_idx;
         ALTER TABLE plugins DROP run_on;

--- a/kong/db/migrations/core/007_140_to_200.lua
+++ b/kong/db/migrations/core/007_140_to_200.lua
@@ -1,6 +1,14 @@
 return {
   postgres = {
-    up = [[]],
+    up = [[
+      DO $$
+      BEGIN
+        ALTER TABLE IF EXISTS ONLY "routes" ADD "path_handling" TEXT;
+      EXCEPTION WHEN DUPLICATE_COLUMN THEN
+        -- Do nothing, accept existing state
+      END;
+      $$;
+    ]],
 
     teardown = function(connector)
       assert(connector:query([[
@@ -23,7 +31,9 @@ return {
   },
 
   cassandra = {
-    up = [[]],
+    up = [[
+      ALTER TABLE routes ADD path_handling text;
+    ]],
 
     teardown = function(connector)
       assert(connector:query([[

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -33,6 +33,7 @@ return {
                                    }, },
     { regex_priority = { type = "integer", default = 0 }, },
     { strip_path     = { type = "boolean", default = true }, },
+    { path_handling  = { type = "string", default = "v0", one_of = { "v0", "v1" }, }, },
     { preserve_host  = { type = "boolean", default = false }, },
     { snis = { type = "set",
                elements = typedefs.sni }, },

--- a/kong/plugins/acl/migrations/001_14_to_15.lua
+++ b/kong/plugins/acl/migrations/001_14_to_15.lua
@@ -39,23 +39,20 @@ return {
     teardown = function(connector, helpers)
       assert(connector:connect_migrations())
 
-      for rows, err in connector:iterate('SELECT * FROM "acls" ORDER BY "created_at";') do
+      for row, err in connector:iterate('SELECT * FROM "acls" ORDER BY "created_at";') do
         if err then
           return nil, err
         end
 
-        for i = 1, #rows do
-          local row = rows[i]
-          local cache_key = string.format("%s:%s:%s:::", "acls",
-                                          row.consumer_id or "",
-                                          row.group or "")
+        local cache_key = string.format("%s:%s:%s:::", "acls",
+                                        row.consumer_id or "",
+                                        row.group or "")
 
-          local sql = string.format([[
-            UPDATE "acls" SET "cache_key" = '%s' WHERE "id" = '%s';
-          ]], cache_key, row.id)
+        local sql = string.format([[
+          UPDATE "acls" SET "cache_key" = '%s' WHERE "id" = '%s';
+        ]], cache_key, row.id)
 
-          assert(connector:query(sql))
-        end
+        assert(connector:query(sql))
       end
     end,
   },

--- a/kong/router.lua
+++ b/kong/router.lua
@@ -1533,46 +1533,71 @@ function _M.new(routes)
               local request_postfix = matches.uri_postfix or sub(req_uri, 2, -1)
               local upstream_base = upstream_url_t.path or "/"
 
-              if byte(upstream_base, -1) == SLASH then
-                -- ends with / and strip_uri = true
+
+              if matched_route.route.path_handling == "v1" then
                 if matched_route.strip_uri then
-                  if request_postfix == "" then
-                    -- leave the slash if that's all there is, but remove the slash otherwise
-                    -- (i.e leave "/" but transform "/foo/bar/" into "/foo/bar")
-                    if upstream_base == "/" then
-                      upstream_uri = "/"
-                    else
-                      upstream_uri = sub(upstream_base, 1, -2)
-                    end
-                  elseif byte(request_postfix, 1, 1) == SLASH then
+                  -- we drop the matched part, replacing it with the upstream path
+                  if byte(upstream_base, -1) == SLASH and
+                     byte(request_postfix, 1) == SLASH then
                     -- double "/", so drop the first
                     upstream_uri = sub(upstream_base, 1, -2) .. request_postfix
-                  else -- ends with / and strip_uri = true, no double slash
+
+                  else
                     upstream_uri = upstream_base .. request_postfix
                   end
 
-                else -- ends with / and strip_uri = false
+                else
                   -- we retain the incoming path, just prefix it with the upstream
                   -- path, but skip the initial slash
-                  upstream_uri = upstream_base .. sub(req_uri, 2)
+                  upstream_uri = upstream_base .. sub(req_uri, 2, -1)
                 end
 
-              else -- does not end with /
-                -- does not end with / and strip_uri = true
-                if matched_route.strip_uri then
-                  if request_postfix == "" then
-                    upstream_uri = upstream_base
-                  elseif byte(request_postfix, 1, 1) == SLASH then
-                    upstream_uri = upstream_base .. request_postfix
-                  else
-                    upstream_uri = upstream_base .. "/" .. request_postfix
+              else -- matched_route.route.path_handling == "v0"
+                if byte(upstream_base, -1) == SLASH then
+                  -- ends with / and strip_uri = true
+                  if matched_route.strip_uri then
+                    if request_postfix == "" then
+                      if upstream_base == "/" then
+                        upstream_uri = "/"
+                      elseif byte(req_uri, -1) == SLASH then
+                        upstream_uri = upstream_base
+                      else
+                        upstream_uri = sub(upstream_base, 1, -2)
+                      end
+                    elseif byte(request_postfix, 1, 1) == SLASH then
+                      -- double "/", so drop the first
+                      upstream_uri = sub(upstream_base, 1, -2) .. request_postfix
+                    else -- ends with / and strip_uri = true, no double slash
+                      upstream_uri = upstream_base .. request_postfix
+                    end
+
+                  else -- ends with / and strip_uri = false
+                    -- we retain the incoming path, just prefix it with the upstream
+                    -- path, but skip the initial slash
+                    upstream_uri = upstream_base .. sub(req_uri, 2)
                   end
 
-                else -- does not end with / and strip_uri = false
-                  if req_uri == "/" then
-                    upstream_uri = upstream_base
-                  else
-                    upstream_uri = upstream_base .. req_uri
+                else -- does not end with /
+                  -- does not end with / and strip_uri = true
+                  if matched_route.strip_uri then
+                    if request_postfix == "" then
+                      if #req_uri > 1 and byte(req_uri, -1) == SLASH then
+                        upstream_uri = upstream_base .. "/"
+                      else
+                        upstream_uri = upstream_base
+                      end
+                    elseif byte(request_postfix, 1, 1) == SLASH then
+                      upstream_uri = upstream_base .. request_postfix
+                    else
+                      upstream_uri = upstream_base .. "/" .. request_postfix
+                    end
+
+                  else -- does not end with / and strip_uri = false
+                    if req_uri == "/" then
+                      upstream_uri = upstream_base
+                    else
+                      upstream_uri = upstream_base .. req_uri
+                    end
                   end
                 end
               end

--- a/spec/01-unit/01-db/01-schema/11-declarative_config/02-process_auto_fields_spec.lua
+++ b/spec/01-unit/01-db/01-schema/11-declarative_config/02-process_auto_fields_spec.lua
@@ -396,16 +396,20 @@ describe("declarative config: process_auto_fields", function()
               host: example.com
               protocol: https
               routes:
-                - paths:
+                - path_handling: v1
+                  paths:
                   - /path
-                - hosts:
+                - path_handling: v1
+                  hosts:
                   - example.com
-                - methods: ["GET", "POST"]
+                - path_handling: v1
+                  methods: ["GET", "POST"]
             - name: bar
               host: example.test
               port: 3000
               routes:
-                - paths:
+                - path_handling: v1
+                  paths:
                   - /path
                   hosts:
                   - example.com
@@ -430,6 +434,7 @@ describe("declarative config: process_auto_fields", function()
                     preserve_host = false,
                     regex_priority = 0,
                     strip_path = true,
+                    path_handling = "v1",
                     protocols = { "http", "https" },
                     https_redirect_status_code = 426,
                   },
@@ -438,6 +443,7 @@ describe("declarative config: process_auto_fields", function()
                     preserve_host = false,
                     regex_priority = 0,
                     strip_path = true,
+                    path_handling = "v1",
                     protocols = { "http", "https" },
                     https_redirect_status_code = 426,
                   },
@@ -446,6 +452,7 @@ describe("declarative config: process_auto_fields", function()
                     preserve_host = false,
                     regex_priority = 0,
                     strip_path = true,
+                    path_handling = "v1",
                     protocols = { "http", "https" },
                     https_redirect_status_code = 426,
                   },
@@ -468,6 +475,7 @@ describe("declarative config: process_auto_fields", function()
                     preserve_host = false,
                     regex_priority = 0,
                     strip_path = true,
+                    path_handling = "v1",
                     protocols = { "http", "https" },
                     https_redirect_status_code = 426,
                   },
@@ -488,6 +496,7 @@ describe("declarative config: process_auto_fields", function()
               protocol: https
               routes:
               - name: foo
+                path_handling: v1
                 methods: ["GET"]
                 plugins:
           ]]))
@@ -510,6 +519,7 @@ describe("declarative config: process_auto_fields", function()
                     methods = { "GET" },
                     preserve_host = false,
                     strip_path = true,
+                    path_handling = "v1",
                     protocols = { "http", "https" },
                     regex_priority = 0,
                     https_redirect_status_code = 426,
@@ -530,6 +540,7 @@ describe("declarative config: process_auto_fields", function()
               protocol: https
               routes:
               - name: foo
+                path_handling: v1
                 methods: ["GET"]
                 plugins:
                   - name: key-auth
@@ -541,6 +552,7 @@ describe("declarative config: process_auto_fields", function()
               port: 3000
               routes:
               - name: bar
+                path_handling: v1
                 paths:
                 - /
                 plugins:
@@ -569,6 +581,7 @@ describe("declarative config: process_auto_fields", function()
                     methods = { "GET" },
                     preserve_host = false,
                     strip_path = true,
+                    path_handling = "v1",
                     protocols = { "http", "https" },
                     regex_priority = 0,
                     https_redirect_status_code = 426,
@@ -618,6 +631,7 @@ describe("declarative config: process_auto_fields", function()
                     paths = { "/" },
                     preserve_host = false,
                     strip_path = true,
+                    path_handling = "v1",
                     protocols = { "http", "https" },
                     regex_priority = 0,
                     https_redirect_status_code = 426,

--- a/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
+++ b/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
@@ -160,6 +160,7 @@ describe("declarative config: flatten", function()
           _format_version: "1.1"
           routes:
           - name: foo
+            path_handling: v1
             protocols: ["tls"]
             snis:
             - "example.com"
@@ -185,6 +186,7 @@ describe("declarative config: flatten", function()
               snis = { "example.com" },
               sources = null,
               strip_path = true,
+              path_handling = "v1",
               updated_at = 1234567890
             }
           }
@@ -323,6 +325,7 @@ describe("declarative config: flatten", function()
               host: example.com
           routes:
             - name: r1
+              path_handling: v1
               paths: [/]
               service: svc1
           consumers:
@@ -415,6 +418,7 @@ describe("declarative config: flatten", function()
               snis = null,
               sources = null,
               strip_path = true,
+              path_handling = "v1",
               updated_at = 1234567890
             }
           },
@@ -656,7 +660,8 @@ describe("declarative config: flatten", function()
               host: example.com
               protocol: https
               routes:
-                - paths:
+                - path_handling: v1
+                  paths:
                   - /path
           ]]))
           config = DeclarativeConfig:flatten(config)
@@ -680,6 +685,7 @@ describe("declarative config: flatten", function()
                 snis = null,
                 sources = null,
                 strip_path = true,
+                path_handling = "v1",
                 tags = null,
                 updated_at = 1234567890
               } },
@@ -710,19 +716,23 @@ describe("declarative config: flatten", function()
               host: example.com
               protocol: https
               routes:
-                - paths:
+                - path_handling: v1
+                  paths:
                   - /path
                   name: r1
-                - hosts:
+                - path_handling: v1
+                  hosts:
                   - example.com
                   name: r2
-                - methods: ["GET", "POST"]
+                - path_handling: v1
+                  methods: ["GET", "POST"]
                   name: r3
             - name: bar
               host: example.test
               port: 3000
               routes:
-                - paths:
+                - path_handling: v1
+                  paths:
                   - /path
                   hosts:
                   - example.com
@@ -750,6 +760,7 @@ describe("declarative config: flatten", function()
                 snis = null,
                 sources = null,
                 strip_path = true,
+                path_handling = "v1",
                 tags = null,
                 updated_at = 1234567890
               }, {
@@ -771,6 +782,7 @@ describe("declarative config: flatten", function()
                 snis = null,
                 sources = null,
                 strip_path = true,
+                path_handling = "v1",
                 tags = null,
                 updated_at = 1234567890
               }, {
@@ -792,6 +804,7 @@ describe("declarative config: flatten", function()
                 snis = null,
                 sources = null,
                 strip_path = true,
+                path_handling = "v1",
                 tags = null,
                 updated_at = 1234567890
               }, {
@@ -813,6 +826,7 @@ describe("declarative config: flatten", function()
                 snis = null,
                 sources = null,
                 strip_path = true,
+                path_handling = "v1",
                 tags = null,
                 updated_at = 1234567890
               } },
@@ -861,6 +875,7 @@ describe("declarative config: flatten", function()
               protocol: https
               routes:
               - name: foo
+                path_handling: v1
                 methods: ["GET"]
                 plugins:
           ]]))
@@ -887,6 +902,7 @@ describe("declarative config: flatten", function()
                 snis = null,
                 sources = null,
                 strip_path = true,
+                path_handling = "v1",
                 updated_at = 1234567890
               }
             },
@@ -920,6 +936,7 @@ describe("declarative config: flatten", function()
               protocol: https
               routes:
               - name: foo
+                path_handling: v1
                 methods: ["GET"]
                 plugins:
                   - name: key-auth
@@ -931,6 +948,7 @@ describe("declarative config: flatten", function()
               port: 3000
               routes:
               - name: bar
+                path_handling: v1
                 paths:
                 - /
                 plugins:
@@ -1039,6 +1057,7 @@ describe("declarative config: flatten", function()
                 snis = null,
                 sources = null,
                 strip_path = true,
+                path_handling = "v1",
                 tags = null,
                 updated_at = 1234567890
               }, {
@@ -1060,6 +1079,7 @@ describe("declarative config: flatten", function()
                 snis = null,
                 sources = null,
                 strip_path = true,
+                path_handling = "v1",
                 tags = null,
                 updated_at = 1234567890
               } },

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -2951,57 +2951,20 @@ describe("Router", function()
     end)
 
 
-    describe("slash handling", function()
+    describe("#slash handling", function()
 
-      for i, test in ipairs(path_handling_tests) do
-        local strip = test.strip_path and "on" or "off"
-        local route_uri_or_host
-        if test.route_path then
-          route_uri_or_host = "uri " .. test.route_path
-        else
-          route_uri_or_host = "host localbin-" .. i .. ".com"
-        end
-
-        local description = string.format("(%d) plain, %s with %s, strip = %s, %s. req: %s",
-          i, test.service_path, route_uri_or_host, strip, test.path_handling, test.request_path)
-
-        it(description, function()
-          local use_case_routes = {
-            {
-              service      = {
-                protocol   = "http",
-                name       = "service-invalid",
-                path       = test.service_path,
-              },
-              route        = {
-                strip_path = test.strip_path,
-                path_handling = test.path_handling,
-                -- only add the header is no path is provided
-                hosts      = test.service_path == nil and nil or { "localbin-" .. i .. ".com" },
-                paths      = { test.route_path },
-              },
-            }
-          }
-
-          local router = assert(Router.new(use_case_routes) )
-          local _ngx = mock_ngx("GET", test.request_path, { host = "localbin-" .. i .. ".com" })
-          router._set_ngx(_ngx)
-          local match_t = router.exec()
-          assert.equal(use_case_routes[1].route, match_t.route)
-          assert.equal(test.service_path, match_t.upstream_url_t.path)
-          assert.equal(test.expected_path, match_t.upstream_uri)
-        end)
-      end
-
-      -- this is identical to the tests above, except that for the path we match
-      -- with an injected regex sequence, effectively transforming the path
-      -- match into a regex match
-      for i, test in ipairs(path_handling_tests) do
-        if test.route_path then -- skip test cases which match on host
+      for i, line in ipairs(path_handling_tests) do
+        for j, test in ipairs(line:expand()) do
           local strip = test.strip_path and "on" or "off"
-          local regex = "/[0]?" .. test.route_path:sub(2, -1)
-          local description = string.format("(%d) regex, %s with %s, strip = %s, %s. req: %s",
-            i, test.service_path, regex, strip, test.path_handling, test.request_path)
+          local route_uri_or_host
+          if test.route_path then
+            route_uri_or_host = "uri " .. test.route_path
+          else
+            route_uri_or_host = "host localbin-" .. i .. "-" .. j .. ".com"
+          end
+
+          local description = string.format("(%d-%d) plain, %s with %s, strip = %s, %s. req: %s",
+            i, j, test.service_path, route_uri_or_host, strip, test.path_handling, test.request_path)
 
           it(description, function()
             local use_case_routes = {
@@ -3013,22 +2976,63 @@ describe("Router", function()
                 },
                 route        = {
                   strip_path = test.strip_path,
-                  -- only add the header is no path is provided
                   path_handling = test.path_handling,
-                  hosts      = { "localbin-" .. i .. ".com" },
-                  paths      = { regex },
+                  -- only add the header is no path is provided
+                  hosts      = test.service_path == nil and nil or { "localbin-" .. i .. "-" .. j .. ".com" },
+                  paths      = { test.route_path },
                 },
               }
             }
 
             local router = assert(Router.new(use_case_routes) )
-            local _ngx = mock_ngx("GET", test.request_path, { host = "localbin-" .. i .. ".com" })
+            local _ngx = mock_ngx("GET", test.request_path, { host = "localbin-" .. i .. "-" .. j .. ".com" })
             router._set_ngx(_ngx)
             local match_t = router.exec()
             assert.equal(use_case_routes[1].route, match_t.route)
             assert.equal(test.service_path, match_t.upstream_url_t.path)
             assert.equal(test.expected_path, match_t.upstream_uri)
           end)
+        end
+      end
+
+      -- this is identical to the tests above, except that for the path we match
+      -- with an injected regex sequence, effectively transforming the path
+      -- match into a regex match
+      for i, line in ipairs(path_handling_tests) do
+        if line.route_path then -- skip test cases which match on host
+          for j, test in ipairs(line:expand()) do
+            local strip = test.strip_path and "on" or "off"
+            local regex = "/[0]?" .. test.route_path:sub(2, -1)
+            local description = string.format("(%d-%d) regex, %s with %s, strip = %s, %s. req: %s",
+              i, j, test.service_path, regex, strip, test.path_handling, test.request_path)
+
+            it(description, function()
+              local use_case_routes = {
+                {
+                  service      = {
+                    protocol   = "http",
+                    name       = "service-invalid",
+                    path       = test.service_path,
+                  },
+                  route        = {
+                    strip_path = test.strip_path,
+                    -- only add the header is no path is provided
+                    path_handling = test.path_handling,
+                    hosts      = { "localbin-" .. i .. ".com" },
+                    paths      = { regex },
+                  },
+                }
+              }
+
+              local router = assert(Router.new(use_case_routes) )
+              local _ngx = mock_ngx("GET", test.request_path, { host = "localbin-" .. i .. ".com" })
+              router._set_ngx(_ngx)
+              local match_t = router.exec()
+              assert.equal(use_case_routes[1].route, match_t.route)
+              assert.equal(test.service_path, match_t.upstream_url_t.path)
+              assert.equal(test.expected_path, match_t.upstream_uri)
+            end)
+          end
         end
       end
     end)

--- a/spec/02-integration/03-db/02-db_core_entities_spec.lua
+++ b/spec/02-integration/03-db/02-db_core_entities_spec.lua
@@ -654,6 +654,7 @@ for _, strategy in helpers.each_strategy() do
             protocols = { "http" },
             hosts = { "example.com" },
             service = assert(db.services:insert({ host = "service.com" })),
+            path_handling = "v1",
           }, { nulls = true })
           assert.is_nil(err_t)
           assert.is_nil(err)
@@ -679,6 +680,7 @@ for _, strategy in helpers.each_strategy() do
             regex_priority  = 0,
             preserve_host   = false,
             strip_path      = true,
+            path_handling   = "v1",
             tags            = ngx.null,
             service         = route.service,
             https_redirect_status_code = 426,
@@ -693,6 +695,7 @@ for _, strategy in helpers.each_strategy() do
             paths           = { "/example" },
             regex_priority  = 3,
             strip_path      = true,
+            path_handling   = "v1",
             service         = bp.services:insert(),
           }, { nulls = true })
           assert.is_nil(err_t)
@@ -718,6 +721,7 @@ for _, strategy in helpers.each_strategy() do
             destinations    = ngx.null,
             regex_priority  = 3,
             strip_path      = true,
+            path_handling   = "v1",
             tags            = ngx.null,
             preserve_host   = false,
             service         = route.service,
@@ -732,6 +736,7 @@ for _, strategy in helpers.each_strategy() do
             paths           = { "/example" },
             regex_priority  = 3,
             strip_path      = true,
+            path_handling   = "v1",
           }, { nulls = true })
           assert.is_nil(err_t)
           assert.is_nil(err)
@@ -757,6 +762,7 @@ for _, strategy in helpers.each_strategy() do
             tags            = ngx.null,
             regex_priority  = 3,
             strip_path      = true,
+            path_handling   = "v1",
             preserve_host   = false,
             service         = ngx.null,
             https_redirect_status_code = 426,
@@ -1053,6 +1059,7 @@ for _, strategy in helpers.each_strategy() do
             protocols = { "https" },
             hosts = { "example.com" },
             regex_priority = 5,
+            path_handling = "v1"
           })
           assert.is_nil(err_t)
           assert.is_nil(err)
@@ -1066,6 +1073,7 @@ for _, strategy in helpers.each_strategy() do
             paths           = route.paths,
             regex_priority  = 5,
             strip_path      = route.strip_path,
+            path_handling   = "v1",
             preserve_host   = route.preserve_host,
             tags            = route.tags,
             service         = route.service,
@@ -1082,6 +1090,7 @@ for _, strategy in helpers.each_strategy() do
             local route = bp.routes:insert({
               hosts   = { "example.com" },
               methods = { "GET" },
+              path_handling = "v1",
             })
 
             local new_route, err, err_t = db.routes:update({ id = route.id }, {
@@ -1097,6 +1106,7 @@ for _, strategy in helpers.each_strategy() do
               hosts           = route.hosts,
               regex_priority  = route.regex_priority,
               strip_path      = route.strip_path,
+              path_handling   = "v1",
               preserve_host   = route.preserve_host,
               tags            = route.tags,
               service         = route.service,
@@ -1846,6 +1856,7 @@ for _, strategy in helpers.each_strategy() do
           protocols = { "http" },
           hosts     = { "example.com" },
           service   = service,
+          path_handling = "v1",
         }, { nulls = true })
         assert.is_nil(err_t)
         assert.is_nil(err)
@@ -1864,6 +1875,7 @@ for _, strategy in helpers.each_strategy() do
           destinations     = ngx.null,
           regex_priority   = 0,
           strip_path       = true,
+          path_handling    = "v1",
           preserve_host    = false,
           tags             = ngx.null,
           service          = {

--- a/spec/02-integration/05-proxy/02-router_spec.lua
+++ b/spec/02-integration/05-proxy/02-router_spec.lua
@@ -1551,6 +1551,7 @@ for _, strategy in helpers.each_strategy() do
           for i, test in ipairs(path_handling_tests) do
             routes[i] = {
               strip_path   = test.strip_path,
+              path_handling = test.path_handling,
               paths        = test.route_path and { test.route_path } or nil,
               hosts        = { "localbin-" .. i .. ".com" },
               service = {
@@ -1570,16 +1571,16 @@ for _, strategy in helpers.each_strategy() do
         end)
 
         for i, test in ipairs(path_handling_tests) do
-          local config = string.format("route.strip_path=%s", test.strip_path and "on" or "off")
-
-          local description
+          local strip = test.strip_path and "on" or "off"
+          local route_uri_or_host
           if test.route_path then
-            description = string.format("(%d) (%s) %s with uri %s when requesting %s",
-                                        i, config, test.service_path, test.route_path, test.request_path)
+            route_uri_or_host = "uri " .. test.route_path
           else
-            description = string.format("(%d) (%s) %s with host %s when requesting %s",
-                                        i, config, test.service_path, "localbin-" .. i .. ".com", test.request_path)
+            route_uri_or_host = "host localbin-" .. i .. ".com"
           end
+
+          local description = string.format("(%d) %s with %s, strip = %s, %s when requesting %s",
+            i, test.service_path, route_uri_or_host, strip, test.path_handling, test.request_path)
 
           it(description, function()
             local res = assert(proxy_client:get(test.request_path, {
@@ -1608,6 +1609,7 @@ for _, strategy in helpers.each_strategy() do
             routes[i] = {
               strip_path   = test.strip_path,
               paths        = test.route_path and { make_a_regex(test.route_path) } or nil,
+              path_handling = test.path_handling,
               hosts        = { "localbin-" .. i .. ".com" },
               service = {
                 name = "make_regex_" .. i,
@@ -1626,10 +1628,10 @@ for _, strategy in helpers.each_strategy() do
         for i, test in ipairs(path_handling_tests) do
           if test.route_path then  -- skip if hostbased match
 
-            local config = string.format("route.strip_path=%s", test.strip_path and "on" or "off")
+            local strip = test.strip_path and "on" or "off"
 
-            local description = string.format("(%d) (%s) %s with uri %s when requesting %s",
-              i, config, test.service_path, make_a_regex(test.route_path), test.request_path)
+            local description = string.format("(%d) %s with uri %s, strip = %s, %s when requesting %s",
+              i, test.service_path, make_a_regex(test.route_path), strip, test.path_handling, test.request_path)
 
             it(description, function()
               local res = assert(proxy_client:get(test.request_path, {

--- a/spec/fixtures/router_path_handling_tests.lua
+++ b/spec/fixtures/router_path_handling_tests.lua
@@ -1,3 +1,5 @@
+local utils = require "kong.tools.utils"
+
 -- The following tests are used by unit and integration tests
 -- to test the router path handling. Putting them here avoids
 -- copy-pasting them in several places.
@@ -5,190 +7,155 @@
 -- The tests can obtain this table by requiring
 -- "spec.fixtures.router_path_handling_tests"
 --
--- Note that the tests are parsed into a hash form at the end
--- of this file before they are returned
+-- The rows are sorted by service_path, route_path, strip_path, path_handling and request_path.
 --
--- All the tests where v1 differs from v0 are marked with !
+-- Notes:
+-- * The tests are parsed into a hash form at the end
+--   of this file before they are returned.
+-- * Before a test can be executed, it needs to be "expanded".
+--   For example, a test with {"v0", "v1"} must be converted
+--   into two tests, one with "v0" and one with "v1". Each line
+--   can be expanded using the `line:expand()` method.
 
 local tests = {
-  -- service_path    route_path   strip_path  path_handling  request_path    expected_path           --    0
-  {  "/",            "/",         true,       "v0",          "/",            "/",                  },
-  {  "/",            "/",         true,       "v1",          "/",            "/",                  },
-  {  "/",            "/",         true,       "v0",          "/foo/bar",     "/foo/bar",           },
-  {  "/",            "/",         true,       "v1",          "/foo/bar",     "/foo/bar",           },
-  {  "/",            "/",         true,       "v0",          "/foo/bar/",    "/foo/bar/",          },
-  {  "/",            "/",         true,       "v1",          "/foo/bar/",    "/foo/bar/",          },
-  {  "/",            "/foo/bar",  true,       "v0",          "/foo/bar",     "/",                  },
-  {  "/",            "/foo/bar",  true,       "v1",          "/foo/bar",     "/",                  },
-  {  "/",            "/foo/bar",  true,       "v0",          "/foo/bar/",    "/",                  },
-  {  "/",            "/foo/bar",  true,       "v1",          "/foo/bar/",    "/",                  }, --  10
-  {  "/",            "/foo/bar/", true,       "v0",          "/foo/bar/",    "/",                  },
-  {  "/",            "/foo/bar/", true,       "v1",          "/foo/bar/",    "/",                  },
-  {  "/fee/bor",     "/",         true,       "v0",          "/",            "/fee/bor",           },
-  {  "/fee/bor",     "/",         true,       "v1",          "/",            "/fee/bor",           },
-  {  "/fee/bor",     "/",         true,       "v0",          "/foo/bar",     "/fee/bor/foo/bar",   },
-  {  "/fee/bor",     "/",         true,       "v1",          "/foo/bar",     "/fee/borfoo/bar",    }, -- !
-  {  "/fee/bor",     "/",         true,       "v0",          "/foo/bar/",    "/fee/bor/foo/bar/",  },
-  {  "/fee/bor",     "/",         true,       "v1",          "/foo/bar/",    "/fee/borfoo/bar/",   }, -- !
-  {  "/fee/bor",     "/foo/bar",  true,       "v0",          "/foo/bar",     "/fee/bor",           },
-  {  "/fee/bor",     "/foo/bar",  true,       "v1",          "/foo/bar",     "/fee/bor",           }, --  20
-  {  "/fee/bor",     "/foo/bar",  true,       "v0",          "/foo/bar/",    "/fee/bor/",          },
-  {  "/fee/bor",     "/foo/bar",  true,       "v1",          "/foo/bar/",    "/fee/bor/",          },
-  {  "/fee/bor",     "/foo/bar/", true,       "v0",          "/foo/bar/",    "/fee/bor",           },
-  {  "/fee/bor",     "/foo/bar/", true,       "v1",          "/foo/bar/",    "/fee/bor",           },
-  {  "/fee/bor/",    "/",         true,       "v0",          "/",            "/fee/bor",           },
-  {  "/fee/bor/",    "/",         true,       "v1",          "/",            "/fee/bor/",          },
-  {  "/fee/bor/",    "/",         true,       "v0",          "/foo/bar",     "/fee/bor/foo/bar",   },
-  {  "/fee/bor/",    "/",         true,       "v1",          "/foo/bar",     "/fee/bor/foo/bar",   },
-  {  "/fee/bor/",    "/",         true,       "v0",          "/foo/bar/",    "/fee/bor/foo/bar/",  },
-  {  "/fee/bor/",    "/",         true,       "v1",          "/foo/bar/",    "/fee/bor/foo/bar/",  }, --  30
-  {  "/fee/bor/",    "/foo/bar",  true,       "v0",          "/foo/bar",     "/fee/bor",           },
-  {  "/fee/bor/",    "/foo/bar",  true,       "v1",          "/foo/bar",     "/fee/bor/",          }, -- !
-  {  "/fee/bor/",    "/foo/bar",  true,       "v0",          "/foo/bar/",    "/fee/bor/",          },
-  {  "/fee/bor/",    "/foo/bar",  true,       "v1",          "/foo/bar/",    "/fee/bor/",          },
-  {  "/fee/bor/",    "/foo/bar/", true,       "v0",          "/foo/bar/",    "/fee/bor",           },
-  {  "/fee/bor/",    "/foo/bar/", true,       "v1",          "/foo/bar/",    "/fee/bor/"           }, -- !
-  {  "/fee",         "/foo",      true,       "v0",          "/foobar",      "/fee/bar",           },
-  {  "/fee",         "/foo",      true,       "v1",          "/foobar",      "/feebar",            }, -- !
-  {  "/fee/",        "/foo",      true,       "v0",          "/foo",         "/fee",               },
-  {  "/fee/",        "/foo",      true,       "v1",          "/foo",         "/fee/",              }, -- !40
-  {  "/",            "/",         false,      "v0",          "/",            "/",                  },
-  {  "/",            "/",         false,      "v1",          "/",            "/",                  },
-  {  "/",            "/",         false,      "v0",          "/foo/bar",     "/foo/bar",           },
-  {  "/",            "/",         false,      "v1",          "/foo/bar",     "/foo/bar",           },
-  {  "/",            "/",         false,      "v0",          "/foo/bar/",    "/foo/bar/",          },
-  {  "/",            "/",         false,      "v1",          "/foo/bar/",    "/foo/bar/",          },
-  {  "/",            "/foo/bar",  false,      "v0",          "/foo/bar",     "/foo/bar",           },
-  {  "/",            "/foo/bar",  false,      "v1",          "/foo/bar",     "/foo/bar",           },
-  {  "/",            "/foo/bar",  false,      "v0",          "/foo/bar/",    "/foo/bar/",          },
-  {  "/",            "/foo/bar",  false,      "v1",          "/foo/bar/",    "/foo/bar/",          }, --  50
-  {  "/",            "/foo/bar/", false,      "v0",          "/foo/bar/",    "/foo/bar/",          },
-  {  "/",            "/foo/bar/", false,      "v1",          "/foo/bar/",    "/foo/bar/",          },
-  {  "/fee/bor",     "/",         false,      "v0",          "/",            "/fee/bor",           },
-  {  "/fee/bor",     "/",         false,      "v1",          "/",            "/fee/bor",           },
-  {  "/fee/bor",     "/",         false,      "v0",          "/foo/bar",     "/fee/bor/foo/bar",   },
-  {  "/fee/bor",     "/",         false,      "v1",          "/foo/bar",     "/fee/borfoo/bar",    },
-  {  "/fee/bor",     "/",         false,      "v0",          "/foo/bar/",    "/fee/bor/foo/bar/",  },
-  {  "/fee/bor",     "/",         false,      "v1",          "/foo/bar/",    "/fee/borfoo/bar/",   },
-  {  "/fee/bor",     "/foo/bar",  false,      "v0",          "/foo/bar",     "/fee/bor/foo/bar",   },
-  {  "/fee/bor",     "/foo/bar",  false,      "v1",          "/foo/bar",     "/fee/borfoo/bar",    }, --  60
-  {  "/fee/bor",     "/foo/bar",  false,      "v0",          "/foo/bar/",    "/fee/bor/foo/bar/",  },
-  {  "/fee/bor",     "/foo/bar",  false,      "v1",          "/foo/bar/",    "/fee/borfoo/bar/",   },
-  {  "/fee/bor",     "/foo/bar/", false,      "v0",          "/foo/bar/",    "/fee/bor/foo/bar/",  },
-  {  "/fee/bor",     "/foo/bar/", false,      "v1",          "/foo/bar/",    "/fee/borfoo/bar/",   },
-  {  "/fee/bor/",    "/",         false,      "v0",          "/",            "/fee/bor/",          },
-  {  "/fee/bor/",    "/",         false,      "v1",          "/",            "/fee/bor/",          },
-  {  "/fee/bor/",    "/",         false,      "v0",          "/foo/bar",     "/fee/bor/foo/bar",   },
-  {  "/fee/bor/",    "/",         false,      "v1",          "/foo/bar",     "/fee/bor/foo/bar",   },
-  {  "/fee/bor/",    "/",         false,      "v0",          "/foo/bar/",    "/fee/bor/foo/bar/",  },
-  {  "/fee/bor/",    "/",         false,      "v1",          "/foo/bar/",    "/fee/bor/foo/bar/",  }, --  70
-  {  "/fee/bor/",    "/foo/bar",  false,      "v0",          "/foo/bar",     "/fee/bor/foo/bar",   },
-  {  "/fee/bor/",    "/foo/bar",  false,      "v1",          "/foo/bar",     "/fee/bor/foo/bar",   },
-  {  "/fee/bor/",    "/foo/bar",  false,      "v0",          "/foo/bar/",    "/fee/bor/foo/bar/",  },
-  {  "/fee/bor/",    "/foo/bar",  false,      "v1",          "/foo/bar/",    "/fee/bor/foo/bar/",  },
-  {  "/fee/bor/",    "/foo/bar/", false,      "v0",          "/foo/bar/",    "/fee/bor/foo/bar/",  },
-  {  "/fee/bor/",    "/foo/bar/", false,      "v1",          "/foo/bar/",    "/fee/bor/foo/bar/",  },
-  -- the following block runs the same tests, but with a request path that is longer
-  -- than the matched part, so either matches in the middle of a segment, or has an
-  -- additional segment.
-  {  "/",            "/",         true,       "v0",          "/foo/bars",    "/foo/bars",          },
-  {  "/",            "/",         true,       "v1",          "/foo/bars",    "/foo/bars",          },
-  {  "/",            "/",         true,       "v0",          "/foo/bar/s",   "/foo/bar/s",         },
-  {  "/",            "/",         true,       "v1",          "/foo/bar/s",   "/foo/bar/s",         }, --  80
-  {  "/",            "/foo/bar",  true,       "v0",          "/foo/bars",    "/s",                 },
-  {  "/",            "/foo/bar",  true,       "v1",          "/foo/bars",    "/s",                 },
-  {  "/",            "/foo/bar/", true,       "v0",          "/foo/bar/s",   "/s",                 },
-  {  "/",            "/foo/bar/", true,       "v1",          "/foo/bar/s",   "/s",                 },
-  {  "/fee/bor",     "/",         true,       "v0",          "/foo/bars",    "/fee/bor/foo/bars",  },
-  {  "/fee/bor",     "/",         true,       "v1",          "/foo/bars",    "/fee/borfoo/bars",   }, -- !
-  {  "/fee/bor",     "/",         true,       "v0",          "/foo/bar/s",   "/fee/bor/foo/bar/s", },
-  {  "/fee/bor",     "/",         true,       "v1",          "/foo/bar/s",   "/fee/borfoo/bar/s",  }, -- !
-  {  "/fee/bor",     "/foo/bar",  true,       "v0",          "/foo/bars",    "/fee/bor/s",         },
-  {  "/fee/bor",     "/foo/bar",  true,       "v1",          "/foo/bars",    "/fee/bors",          }, -- ! 90
-  {  "/fee/bor",     "/foo/bar/", true,       "v0",          "/foo/bar/s",   "/fee/bor/s",         },
-  {  "/fee/bor",     "/foo/bar/", true,       "v1",          "/foo/bar/s",   "/fee/bors",          }, -- !
-  {  "/fee/bor/",    "/",         true,       "v0",          "/foo/bars",    "/fee/bor/foo/bars",  },
-  {  "/fee/bor/",    "/",         true,       "v1",          "/foo/bars",    "/fee/bor/foo/bars",  },
-  {  "/fee/bor/",    "/",         true,       "v0",          "/foo/bar/s",   "/fee/bor/foo/bar/s", },
-  {  "/fee/bor/",    "/",         true,       "v1",          "/foo/bar/s",   "/fee/bor/foo/bar/s", },
-  {  "/fee/bor/",    "/foo/bar",  true,       "v0",          "/foo/bars",    "/fee/bor/s",         },
-  {  "/fee/bor/",    "/foo/bar",  true,       "v1",          "/foo/bars",    "/fee/bor/s",         },
-  {  "/fee/bor/",    "/foo/bar/", true,       "v0",          "/foo/bar/s",   "/fee/bor/s",         },
-  {  "/fee/bor/",    "/foo/bar/", true,       "v1",          "/foo/bar/s",   "/fee/bor/s",         }, -- 100
-  {  "/",            "/",         false,      "v0",          "/foo/bars",    "/foo/bars",          },
-  {  "/",            "/",         false,      "v1",          "/foo/bars",    "/foo/bars",          },
-  {  "/",            "/",         false,      "v0",          "/foo/bar/s",   "/foo/bar/s",         },
-  {  "/",            "/",         false,      "v1",          "/foo/bar/s",   "/foo/bar/s",         },
-  {  "/",            "/foo/bar",  false,      "v0",          "/foo/bars",    "/foo/bars",          },
-  {  "/",            "/foo/bar",  false,      "v1",          "/foo/bars",    "/foo/bars",          },
-  {  "/",            "/foo/bar/", false,      "v0",          "/foo/bar/s",   "/foo/bar/s",         },
-  {  "/",            "/foo/bar/", false,      "v1",          "/foo/bar/s",   "/foo/bar/s",         },
-  {  "/fee/bor",     "/",         false,      "v0",          "/foo/bars",    "/fee/bor/foo/bars",  },
-  {  "/fee/bor",     "/",         false,      "v1",          "/foo/bars",    "/fee/borfoo/bars",   }, -- ! 110
-  {  "/fee/bor",     "/",         false,      "v0",          "/foo/bar/s",   "/fee/bor/foo/bar/s", },
-  {  "/fee/bor",     "/",         false,      "v1",          "/foo/bar/s",   "/fee/borfoo/bar/s",  }, -- !
-  {  "/fee/bor",     "/foo/bar",  false,      "v0",          "/foo/bars",    "/fee/bor/foo/bars",  },
-  {  "/fee/bor",     "/foo/bar",  false,      "v1",          "/foo/bars",    "/fee/borfoo/bars",   }, -- !
-  {  "/fee/bor",     "/foo/bar/", false,      "v0",          "/foo/bar/s",   "/fee/bor/foo/bar/s", },
-  {  "/fee/bor",     "/foo/bar/", false,      "v1",          "/foo/bar/s",   "/fee/borfoo/bar/s",  }, -- !
-  {  "/fee/bor/",    "/",         false,      "v0",          "/foo/bars",    "/fee/bor/foo/bars",  },
-  {  "/fee/bor/",    "/",         false,      "v1",          "/foo/bars",    "/fee/bor/foo/bars",  },
-  {  "/fee/bor/",    "/",         false,      "v0",          "/foo/bar/s",   "/fee/bor/foo/bar/s", },
-  {  "/fee/bor/",    "/",         false,      "v1",          "/foo/bar/s",   "/fee/bor/foo/bar/s", }, -- 120
-  {  "/fee/bor/",    "/foo/bar",  false,      "v0",          "/foo/bars",    "/fee/bor/foo/bars",  },
-  {  "/fee/bor/",    "/foo/bar",  false,      "v1",          "/foo/bars",    "/fee/bor/foo/bars",  },
-  {  "/fee/bor/",    "/foo/bar/", false,      "v0",          "/foo/bar/s",   "/fee/bor/foo/bar/s", },
-  {  "/fee/bor/",    "/foo/bar/", false,      "v1",          "/foo/bar/s",   "/fee/bor/foo/bar/s", },
-  -- the following block matches on host, instead of path
-  {  "/",            nil,         false,      "v0",          "/",            "/",                  },
-  {  "/",            nil,         false,      "v1",          "/",            "/",                  },
-  {  "/",            nil,         false,      "v0",          "/foo/bar",     "/foo/bar",           },
-  {  "/",            nil,         false,      "v1",          "/foo/bar",     "/foo/bar",           },
-  {  "/",            nil,         false,      "v0",          "/foo/bar/",    "/foo/bar/",          },
-  {  "/",            nil,         false,      "v1",          "/foo/bar/",    "/foo/bar/",          }, -- 130
-  {  "/fee/bor",     nil,         false,      "v0",          "/",            "/fee/bor",           },
-  {  "/fee/bor",     nil,         false,      "v1",          "/",            "/fee/bor",           },
-  {  "/fee/bor",     nil,         false,      "v0",          "/foo/bar",     "/fee/bor/foo/bar",   },
-  {  "/fee/bor",     nil,         false,      "v1",          "/foo/bar",     "/fee/borfoo/bar",    }, -- !
-  {  "/fee/bor",     nil,         false,      "v0",          "/foo/bar/",    "/fee/bor/foo/bar/",  },
-  {  "/fee/bor",     nil,         false,      "v1",          "/foo/bar/",    "/fee/borfoo/bar/",   }, -- !
-  {  "/fee/bor/",    nil,         false,      "v0",          "/",            "/fee/bor/",          },
-  {  "/fee/bor/",    nil,         false,      "v1",          "/",            "/fee/bor/",          },
-  {  "/fee/bor/",    nil,         false,      "v0",          "/foo/bar",     "/fee/bor/foo/bar",   },
-  {  "/fee/bor/",    nil,         false,      "v1",          "/foo/bar",     "/fee/bor/foo/bar",   }, -- 140
-  {  "/fee/bor/",    nil,         false,      "v0",          "/foo/bar/",    "/fee/bor/foo/bar/",  },
-  {  "/fee/bor/",    nil,         false,      "v1",          "/foo/bar/",    "/fee/bor/foo/bar/",  },
-  {  "/",            nil,         true,       "v0",          "/",            "/",                  },
-  {  "/",            nil,         true,       "v1",          "/",            "/",                  },
-  {  "/",            nil,         true,       "v0",          "/foo/bar",     "/foo/bar",           },
-  {  "/",            nil,         true,       "v1",          "/foo/bar",     "/foo/bar",           },
-  {  "/",            nil,         true,       "v0",          "/foo/bar/",    "/foo/bar/",          },
-  {  "/",            nil,         true,       "v1",          "/foo/bar/",    "/foo/bar/",          },
-  {  "/fee/bor",     nil,         true,       "v0",          "/",            "/fee/bor",           },
-  {  "/fee/bor",     nil,         true,       "v1",          "/",            "/fee/bor",           }, -- 150
-  {  "/fee/bor",     nil,         true,       "v0",          "/foo/bar",     "/fee/bor/foo/bar",   },
-  {  "/fee/bor",     nil,         true,       "v1",          "/foo/bar",     "/fee/borfoo/bar",    }, -- !
-  {  "/fee/bor",     nil,         true,       "v0",          "/foo/bar/",    "/fee/bor/foo/bar/",  },
-  {  "/fee/bor",     nil,         true,       "v1",          "/foo/bar/",    "/fee/borfoo/bar/",   }, -- !
-  {  "/fee/bor/",    nil,         true,       "v0",          "/",            "/fee/bor",           },
-  {  "/fee/bor/",    nil,         true,       "v1",          "/",            "/fee/bor/",          }, -- !
-  {  "/fee/bor/",    nil,         true,       "v0",          "/foo/bar",     "/fee/bor/foo/bar",   },
-  {  "/fee/bor/",    nil,         true,       "v1",          "/foo/bar",     "/fee/bor/foo/bar",   },
-  {  "/fee/bor/",    nil,         true,       "v0",          "/foo/bar/",    "/fee/bor/foo/bar/",  },
-  {  "/fee/bor/",    nil,         true,       "v1",          "/foo/bar/",    "/fee/bor/foo/bar/",  }, -- 160
+  -- service_path    route_path  strip_path     path_handling  request_path     expected_path
+  {  "/",            "/",        {false, true}, {"v0", "v1"},  "/",             "/",                  },
+  {  "/",            "/",        {false, true}, {"v0", "v1"},  "/route",        "/route",             },
+  {  "/",            "/",        {false, true}, {"v0", "v1"},  "/route/",       "/route/",            },
+  {  "/",            "/",        {false, true}, {"v0", "v1"},  "/routereq",     "/routereq",          },
+  {  "/",            "/",        {false, true}, {"v0", "v1"},  "/route/req",    "/route/req",         },
+  -- 5
+  {  "/",            "/route",   false,         {"v0", "v1"},  "/route",        "/route",             },
+  {  "/",            "/route",   false,         {"v0", "v1"},  "/route/",       "/route/",            },
+  {  "/",            "/route",   false,         {"v0", "v1"},  "/routereq",     "/routereq",          },
+  {  "/",            "/route",   true,          {"v0", "v1"},  "/route",        "/",                  },
+  {  "/",            "/route",   true,          {"v0", "v1"},  "/route/",       "/",                  },
+  {  "/",            "/route",   true,          {"v0", "v1"},  "/routereq",     "/req",               },
+  -- 11
+  {  "/",            "/route/",  false,         {"v0", "v1"},  "/route/",       "/route/",            },
+  {  "/",            "/route/",  false,         {"v0", "v1"},  "/route/req",    "/route/req",         },
+  {  "/",            "/route/",  true,          {"v0", "v1"},  "/route/",       "/",                  },
+  {  "/",            "/route/",  true,          {"v0", "v1"},  "/route/req",    "/req",               },
+  -- 15
+  {  "/srv",         "/rou",     false,         "v0",          "/roureq",       "/srv/roureq",        },
+  {  "/srv",         "/rou",     false,         "v1",          "/roureq",       "/srvroureq",         },
+  {  "/srv",         "/rou",     true,          "v0",          "/roureq",       "/srv/req",           },
+  {  "/srv",         "/rou",     true,          "v1",          "/roureq",       "/srvreq",            },
+  -- 19
+  {  "/srv/",        "/rou",     false,         {"v0", "v1"},  "/rou",          "/srv/rou",           },
+  {  "/srv/",        "/rou",     true,          "v0",          "/rou",          "/srv",               },
+  {  "/srv/",        "/rou",     true,          "v1",          "/rou",          "/srv/",              },
+  -- 22
+  {  "/service",     "/",        {false, true}, {"v0", "v1"},  "/",             "/service",           },
+  {  "/service",     "/",        {false, true}, "v0",          "/route",        "/service/route",     },
+  {  "/service",     "/",        {false, true}, "v1",          "/route",        "/serviceroute",      },
+  {  "/service",     "/",        {false, true}, "v0",          "/route/",       "/service/route/",    },
+  {  "/service",     "/",        {false, true}, "v1",          "/route/",       "/serviceroute/",     },
+  -- 27
+  {  "/service",     "/",        {false, true}, "v0",          "/routereq",     "/service/routereq",  },
+  {  "/service",     "/",        {false, true}, "v1",          "/routereq",     "/serviceroutereq",   },
+  {  "/service",     "/",        {false, true}, "v0",          "/route/req",    "/service/route/req", },
+  {  "/service",     "/",        {false, true}, "v1",          "/route/req",    "/serviceroute/req",  },
+  -- 31
+  {  "/service",     "/route",   false,         "v0",          "/route",        "/service/route",     },
+  {  "/service",     "/route",   false,         "v1",          "/route",        "/serviceroute",      },
+  {  "/service",     "/route",   false,         "v0",          "/route/",       "/service/route/",    },
+  {  "/service",     "/route",   false,         "v1",          "/route/",       "/serviceroute/",     },
+  {  "/service",     "/route",   false,         "v0",          "/routereq",     "/service/routereq",  },
+  {  "/service",     "/route",   false,         "v1",          "/routereq",     "/serviceroutereq",   },
+  {  "/service",     "/route",   true,          {"v0", "v1"},  "/route",        "/service",           },
+  {  "/service",     "/route",   true,          {"v0", "v1"},  "/route/",       "/service/",          },
+  {  "/service",     "/route",   true,          "v0",          "/routereq",     "/service/req",       },
+  {  "/service",     "/route",   true,          "v1",          "/routereq",     "/servicereq",        },
+  -- 41
+  {  "/service",     "/route/",  false,         "v0",          "/route/",       "/service/route/",    },
+  {  "/service",     "/route/",  false,         "v1",          "/route/",       "/serviceroute/",     },
+  {  "/service",     "/route/",  false,         "v0",          "/route/req",    "/service/route/req", },
+  {  "/service",     "/route/",  false,         "v1",          "/route/req",    "/serviceroute/req",  },
+  {  "/service",     "/route/",  true,          "v0",          "/route/",       "/service/",          },
+  {  "/service",     "/route/",  true,          "v1",          "/route/",       "/service",           },
+  {  "/service",     "/route/",  true,          "v0",          "/route/req",    "/service/req",       },
+  {  "/service",     "/route/",  true,          "v1",          "/route/req",    "/servicereq",        },
+  -- 49
+  {  "/service/",    "/",        {false, true}, "v0",          "/route/",       "/service/route/",    },
+  {  "/service/",    "/",        {false, true}, "v1",          "/route/",       "/service/route/",    },
+  {  "/service/",    "/",        {false, true}, {"v0", "v1"},  "/",             "/service/",          },
+  {  "/service/",    "/",        {false, true}, {"v0", "v1"},  "/route",        "/service/route",     },
+  {  "/service/",    "/",        {false, true}, {"v0", "v1"},  "/routereq",     "/service/routereq",  },
+  {  "/service/",    "/",        {false, true}, {"v0", "v1"},  "/route/req",    "/service/route/req", },
+  -- 55
+  {  "/service/",    "/route",   false,         {"v0", "v1"},  "/route",        "/service/route",      },
+  {  "/service/",    "/route",   false,         {"v0", "v1"},  "/route/",       "/service/route/",     },
+  {  "/service/",    "/route",   false,         {"v0", "v1"},  "/routereq",     "/service/routereq",   },
+  {  "/service/",    "/route",   true,          "v0",          "/route",        "/service",            },
+  {  "/service/",    "/route",   true,          "v1",          "/route",        "/service/",           },
+  {  "/service/",    "/route",   true,          {"v0", "v1"},  "/route/",       "/service/",           },
+  {  "/service/",    "/route",   true,          {"v0", "v1"},  "/routereq",     "/service/req",        },
+  -- 62
+  {  "/service/",    "/route/",  false,         {"v0", "v1"},  "/route/",       "/service/route/",     },
+  {  "/service/",    "/route/",  false,         {"v0", "v1"},  "/route/req",    "/service/route/req",  },
+  {  "/service/",    "/route/",  true,          {"v0", "v1"},  "/route/",       "/service/",           },
+  {  "/service/",    "/route/",  true,          {"v0", "v1"},  "/route/req",    "/service/req",        },
+  -- 66
+  -- The following cases match on host (not paths)
+  {  "/",            nil,        {false, true}, {"v0", "v1"},  "/",             "/",                  },
+  {  "/",            nil,        {false, true}, {"v0", "v1"},  "/route",        "/route",             },
+  {  "/",            nil,        {false, true}, {"v0", "v1"},  "/route/",       "/route/",            },
+  -- 69
+  {  "/service",     nil,        {false, true}, {"v0", "v1"},  "/",             "/service",           },
+  {  "/service",     nil,        {false, true}, "v0",          "/route",        "/service/route",     },
+  {  "/service",     nil,        {false, true}, "v1",          "/route",        "/serviceroute",      },
+  {  "/service",     nil,        {false, true}, "v0",          "/route/",       "/service/route/",    },
+  {  "/service",     nil,        {false, true}, "v1",          "/route/",       "/serviceroute/",     },
+  -- 74
+  {  "/service/",    nil,        {false, true}, {"v0", "v1"},  "/",             "/service/",          },
+  {  "/service/",    nil,        {false, true}, {"v0", "v1"},  "/route",        "/service/route",     },
+  {  "/service/",    nil,        {false, true}, {"v0", "v1"},  "/route/",       "/service/route/",    },
 }
+
+
+local function expand(root_test)
+  local expanded_tests = { root_test }
+
+  for _, field_name in ipairs({ "strip_path", "path_handling" }) do
+    local new_tests = {}
+    for _, test in ipairs(expanded_tests) do
+      if type(test[field_name]) == "table" then
+        for _, field_value in ipairs(test[field_name]) do
+          local et = utils.deep_copy(test)
+          et[field_name] = field_value
+          new_tests[#new_tests + 1] = et
+        end
+
+      else
+        new_tests[#new_tests + 1] = test
+      end
+    end
+    expanded_tests = new_tests
+  end
+
+  return expanded_tests
+end
+
+
+local tests_mt = {
+  __index = {
+    expand = expand
+  }
+}
+
 
 local parsed_tests = {}
 for i = 1, #tests do
   local test = tests[i]
-  parsed_tests[i] = {
+  parsed_tests[i] = setmetatable({
     service_path  = test[1],
     route_path    = test[2],
     strip_path    = test[3],
     path_handling = test[4],
     request_path  = test[5],
     expected_path = test[6],
-  }
+  }, tests_mt)
 end
 
 return parsed_tests

--- a/spec/fixtures/router_path_handling_tests.lua
+++ b/spec/fixtures/router_path_handling_tests.lua
@@ -7,93 +7,175 @@
 --
 -- Note that the tests are parsed into a hash form at the end
 -- of this file before they are returned
+--
+-- All the tests where v1 differs from v0 are marked with !
 
 local tests = {
-  -- service_path    route_path   strip_path  request_path    expected_path
-  {  "/",            "/",         true,       "/",            "/",                  }, -- 1
-  {  "/",            "/",         true,       "/foo/bar",     "/foo/bar",           },
-  {  "/",            "/",         true,       "/foo/bar/",    "/foo/bar/",          },
-  {  "/",            "/foo/bar",  true,       "/foo/bar",     "/",                  },
-  {  "/",            "/foo/bar",  true,       "/foo/bar/",    "/",                  },
-  {  "/",            "/foo/bar/", true,       "/foo/bar/",    "/",                  },
-  {  "/fee/bor",     "/",         true,       "/",            "/fee/bor",           },
-  {  "/fee/bor",     "/",         true,       "/foo/bar",     "/fee/bor/foo/bar",   },
-  {  "/fee/bor",     "/",         true,       "/foo/bar/",    "/fee/bor/foo/bar/",  },
-  {  "/fee/bor",     "/foo/bar",  true,       "/foo/bar",     "/fee/bor",           }, -- 10
-  {  "/fee/bor",     "/foo/bar",  true,       "/foo/bar/",    "/fee/bor/",          },
-  {  "/fee/bor",     "/foo/bar/", true,       "/foo/bar/",    "/fee/bor",           },
-  {  "/fee/bor/",    "/",         true,       "/",            "/fee/bor",           },
-  {  "/fee/bor/",    "/",         true,       "/foo/bar",     "/fee/bor/foo/bar",   },
-  {  "/fee/bor/",    "/",         true,       "/foo/bar/",    "/fee/bor/foo/bar/",  },
-  {  "/fee/bor/",    "/foo/bar",  true,       "/foo/bar",     "/fee/bor",           },
-  {  "/fee/bor/",    "/foo/bar",  true,       "/foo/bar/",    "/fee/bor/",          },
-  {  "/fee/bor/",    "/foo/bar/", true,       "/foo/bar/",    "/fee/bor",           },
-  {  "/fee",         "/foo",      true,       "/foobar",      "/fee/bar",           }, -- 20
-  {  "/fee/",        "/foo",      true,       "/foo",         "/fee",               },
-  {  "/",            "/",         false,      "/",            "/",                  },
-  {  "/",            "/",         false,      "/foo/bar",     "/foo/bar",           },
-  {  "/",            "/",         false,      "/foo/bar/",    "/foo/bar/",          },
-  {  "/",            "/foo/bar",  false,      "/foo/bar",     "/foo/bar",           },
-  {  "/",            "/foo/bar",  false,      "/foo/bar/",    "/foo/bar/",          },
-  {  "/",            "/foo/bar/", false,      "/foo/bar/",    "/foo/bar/",          },
-  {  "/fee/bor",     "/",         false,      "/",            "/fee/bor",           },
-  {  "/fee/bor",     "/",         false,      "/foo/bar",     "/fee/bor/foo/bar",   },
-  {  "/fee/bor",     "/",         false,      "/foo/bar/",    "/fee/bor/foo/bar/",  }, -- 30
-  {  "/fee/bor",     "/foo/bar",  false,      "/foo/bar",     "/fee/bor/foo/bar",   },
-  {  "/fee/bor",     "/foo/bar",  false,      "/foo/bar/",    "/fee/bor/foo/bar/",  },
-  {  "/fee/bor",     "/foo/bar/", false,      "/foo/bar/",    "/fee/bor/foo/bar/",  },
-  {  "/fee/bor/",    "/",         false,      "/",            "/fee/bor/",          },
-  {  "/fee/bor/",    "/",         false,      "/foo/bar",     "/fee/bor/foo/bar",   },
-  {  "/fee/bor/",    "/",         false,      "/foo/bar/",    "/fee/bor/foo/bar/",  },
-  {  "/fee/bor/",    "/foo/bar",  false,      "/foo/bar",     "/fee/bor/foo/bar",   },
-  {  "/fee/bor/",    "/foo/bar",  false,      "/foo/bar/",    "/fee/bor/foo/bar/",  },
-  {  "/fee/bor/",    "/foo/bar/", false,      "/foo/bar/",    "/fee/bor/foo/bar/",  },
+  -- service_path    route_path   strip_path  path_handling  request_path    expected_path           --    0
+  {  "/",            "/",         true,       "v0",          "/",            "/",                  },
+  {  "/",            "/",         true,       "v1",          "/",            "/",                  },
+  {  "/",            "/",         true,       "v0",          "/foo/bar",     "/foo/bar",           },
+  {  "/",            "/",         true,       "v1",          "/foo/bar",     "/foo/bar",           },
+  {  "/",            "/",         true,       "v0",          "/foo/bar/",    "/foo/bar/",          },
+  {  "/",            "/",         true,       "v1",          "/foo/bar/",    "/foo/bar/",          },
+  {  "/",            "/foo/bar",  true,       "v0",          "/foo/bar",     "/",                  },
+  {  "/",            "/foo/bar",  true,       "v1",          "/foo/bar",     "/",                  },
+  {  "/",            "/foo/bar",  true,       "v0",          "/foo/bar/",    "/",                  },
+  {  "/",            "/foo/bar",  true,       "v1",          "/foo/bar/",    "/",                  }, --  10
+  {  "/",            "/foo/bar/", true,       "v0",          "/foo/bar/",    "/",                  },
+  {  "/",            "/foo/bar/", true,       "v1",          "/foo/bar/",    "/",                  },
+  {  "/fee/bor",     "/",         true,       "v0",          "/",            "/fee/bor",           },
+  {  "/fee/bor",     "/",         true,       "v1",          "/",            "/fee/bor",           },
+  {  "/fee/bor",     "/",         true,       "v0",          "/foo/bar",     "/fee/bor/foo/bar",   },
+  {  "/fee/bor",     "/",         true,       "v1",          "/foo/bar",     "/fee/borfoo/bar",    }, -- !
+  {  "/fee/bor",     "/",         true,       "v0",          "/foo/bar/",    "/fee/bor/foo/bar/",  },
+  {  "/fee/bor",     "/",         true,       "v1",          "/foo/bar/",    "/fee/borfoo/bar/",   }, -- !
+  {  "/fee/bor",     "/foo/bar",  true,       "v0",          "/foo/bar",     "/fee/bor",           },
+  {  "/fee/bor",     "/foo/bar",  true,       "v1",          "/foo/bar",     "/fee/bor",           }, --  20
+  {  "/fee/bor",     "/foo/bar",  true,       "v0",          "/foo/bar/",    "/fee/bor/",          },
+  {  "/fee/bor",     "/foo/bar",  true,       "v1",          "/foo/bar/",    "/fee/bor/",          },
+  {  "/fee/bor",     "/foo/bar/", true,       "v0",          "/foo/bar/",    "/fee/bor",           },
+  {  "/fee/bor",     "/foo/bar/", true,       "v1",          "/foo/bar/",    "/fee/bor",           },
+  {  "/fee/bor/",    "/",         true,       "v0",          "/",            "/fee/bor",           },
+  {  "/fee/bor/",    "/",         true,       "v1",          "/",            "/fee/bor/",          },
+  {  "/fee/bor/",    "/",         true,       "v0",          "/foo/bar",     "/fee/bor/foo/bar",   },
+  {  "/fee/bor/",    "/",         true,       "v1",          "/foo/bar",     "/fee/bor/foo/bar",   },
+  {  "/fee/bor/",    "/",         true,       "v0",          "/foo/bar/",    "/fee/bor/foo/bar/",  },
+  {  "/fee/bor/",    "/",         true,       "v1",          "/foo/bar/",    "/fee/bor/foo/bar/",  }, --  30
+  {  "/fee/bor/",    "/foo/bar",  true,       "v0",          "/foo/bar",     "/fee/bor",           },
+  {  "/fee/bor/",    "/foo/bar",  true,       "v1",          "/foo/bar",     "/fee/bor/",          }, -- !
+  {  "/fee/bor/",    "/foo/bar",  true,       "v0",          "/foo/bar/",    "/fee/bor/",          },
+  {  "/fee/bor/",    "/foo/bar",  true,       "v1",          "/foo/bar/",    "/fee/bor/",          },
+  {  "/fee/bor/",    "/foo/bar/", true,       "v0",          "/foo/bar/",    "/fee/bor",           },
+  {  "/fee/bor/",    "/foo/bar/", true,       "v1",          "/foo/bar/",    "/fee/bor/"           }, -- !
+  {  "/fee",         "/foo",      true,       "v0",          "/foobar",      "/fee/bar",           },
+  {  "/fee",         "/foo",      true,       "v1",          "/foobar",      "/feebar",            }, -- !
+  {  "/fee/",        "/foo",      true,       "v0",          "/foo",         "/fee",               },
+  {  "/fee/",        "/foo",      true,       "v1",          "/foo",         "/fee/",              }, -- !40
+  {  "/",            "/",         false,      "v0",          "/",            "/",                  },
+  {  "/",            "/",         false,      "v1",          "/",            "/",                  },
+  {  "/",            "/",         false,      "v0",          "/foo/bar",     "/foo/bar",           },
+  {  "/",            "/",         false,      "v1",          "/foo/bar",     "/foo/bar",           },
+  {  "/",            "/",         false,      "v0",          "/foo/bar/",    "/foo/bar/",          },
+  {  "/",            "/",         false,      "v1",          "/foo/bar/",    "/foo/bar/",          },
+  {  "/",            "/foo/bar",  false,      "v0",          "/foo/bar",     "/foo/bar",           },
+  {  "/",            "/foo/bar",  false,      "v1",          "/foo/bar",     "/foo/bar",           },
+  {  "/",            "/foo/bar",  false,      "v0",          "/foo/bar/",    "/foo/bar/",          },
+  {  "/",            "/foo/bar",  false,      "v1",          "/foo/bar/",    "/foo/bar/",          }, --  50
+  {  "/",            "/foo/bar/", false,      "v0",          "/foo/bar/",    "/foo/bar/",          },
+  {  "/",            "/foo/bar/", false,      "v1",          "/foo/bar/",    "/foo/bar/",          },
+  {  "/fee/bor",     "/",         false,      "v0",          "/",            "/fee/bor",           },
+  {  "/fee/bor",     "/",         false,      "v1",          "/",            "/fee/bor",           },
+  {  "/fee/bor",     "/",         false,      "v0",          "/foo/bar",     "/fee/bor/foo/bar",   },
+  {  "/fee/bor",     "/",         false,      "v1",          "/foo/bar",     "/fee/borfoo/bar",    },
+  {  "/fee/bor",     "/",         false,      "v0",          "/foo/bar/",    "/fee/bor/foo/bar/",  },
+  {  "/fee/bor",     "/",         false,      "v1",          "/foo/bar/",    "/fee/borfoo/bar/",   },
+  {  "/fee/bor",     "/foo/bar",  false,      "v0",          "/foo/bar",     "/fee/bor/foo/bar",   },
+  {  "/fee/bor",     "/foo/bar",  false,      "v1",          "/foo/bar",     "/fee/borfoo/bar",    }, --  60
+  {  "/fee/bor",     "/foo/bar",  false,      "v0",          "/foo/bar/",    "/fee/bor/foo/bar/",  },
+  {  "/fee/bor",     "/foo/bar",  false,      "v1",          "/foo/bar/",    "/fee/borfoo/bar/",   },
+  {  "/fee/bor",     "/foo/bar/", false,      "v0",          "/foo/bar/",    "/fee/bor/foo/bar/",  },
+  {  "/fee/bor",     "/foo/bar/", false,      "v1",          "/foo/bar/",    "/fee/borfoo/bar/",   },
+  {  "/fee/bor/",    "/",         false,      "v0",          "/",            "/fee/bor/",          },
+  {  "/fee/bor/",    "/",         false,      "v1",          "/",            "/fee/bor/",          },
+  {  "/fee/bor/",    "/",         false,      "v0",          "/foo/bar",     "/fee/bor/foo/bar",   },
+  {  "/fee/bor/",    "/",         false,      "v1",          "/foo/bar",     "/fee/bor/foo/bar",   },
+  {  "/fee/bor/",    "/",         false,      "v0",          "/foo/bar/",    "/fee/bor/foo/bar/",  },
+  {  "/fee/bor/",    "/",         false,      "v1",          "/foo/bar/",    "/fee/bor/foo/bar/",  }, --  70
+  {  "/fee/bor/",    "/foo/bar",  false,      "v0",          "/foo/bar",     "/fee/bor/foo/bar",   },
+  {  "/fee/bor/",    "/foo/bar",  false,      "v1",          "/foo/bar",     "/fee/bor/foo/bar",   },
+  {  "/fee/bor/",    "/foo/bar",  false,      "v0",          "/foo/bar/",    "/fee/bor/foo/bar/",  },
+  {  "/fee/bor/",    "/foo/bar",  false,      "v1",          "/foo/bar/",    "/fee/bor/foo/bar/",  },
+  {  "/fee/bor/",    "/foo/bar/", false,      "v0",          "/foo/bar/",    "/fee/bor/foo/bar/",  },
+  {  "/fee/bor/",    "/foo/bar/", false,      "v1",          "/foo/bar/",    "/fee/bor/foo/bar/",  },
   -- the following block runs the same tests, but with a request path that is longer
   -- than the matched part, so either matches in the middle of a segment, or has an
   -- additional segment.
-  {  "/",            "/",         true,       "/foo/bars",    "/foo/bars",          }, -- 40
-  {  "/",            "/",         true,       "/foo/bar/s",   "/foo/bar/s",         },
-  {  "/",            "/foo/bar",  true,       "/foo/bars",    "/s",                 },
-  {  "/",            "/foo/bar/", true,       "/foo/bar/s",   "/s",                 },
-  {  "/fee/bor",     "/",         true,       "/foo/bars",    "/fee/bor/foo/bars",  },
-  {  "/fee/bor",     "/",         true,       "/foo/bar/s",   "/fee/bor/foo/bar/s", },
-  {  "/fee/bor",     "/foo/bar",  true,       "/foo/bars",    "/fee/bor/s",         },
-  {  "/fee/bor",     "/foo/bar/", true,       "/foo/bar/s",   "/fee/bor/s",         },
-  {  "/fee/bor/",    "/",         true,       "/foo/bars",    "/fee/bor/foo/bars",  },
-  {  "/fee/bor/",    "/",         true,       "/foo/bar/s",   "/fee/bor/foo/bar/s", },
-  {  "/fee/bor/",    "/foo/bar",  true,       "/foo/bars",    "/fee/bor/s",         }, -- 50
-  {  "/fee/bor/",    "/foo/bar/", true,       "/foo/bar/s",   "/fee/bor/s",         },
-  {  "/",            "/",         false,      "/foo/bars",    "/foo/bars",          },
-  {  "/",            "/",         false,      "/foo/bar/s",   "/foo/bar/s",         },
-  {  "/",            "/foo/bar",  false,      "/foo/bars",    "/foo/bars",          },
-  {  "/",            "/foo/bar/", false,      "/foo/bar/s",   "/foo/bar/s",         },
-  {  "/fee/bor",     "/",         false,      "/foo/bars",    "/fee/bor/foo/bars",  },
-  {  "/fee/bor",     "/",         false,      "/foo/bar/s",   "/fee/bor/foo/bar/s", },
-  {  "/fee/bor",     "/foo/bar",  false,      "/foo/bars",    "/fee/bor/foo/bars",  },
-  {  "/fee/bor",     "/foo/bar/", false,      "/foo/bar/s",   "/fee/bor/foo/bar/s", },
-  {  "/fee/bor/",    "/",         false,      "/foo/bars",    "/fee/bor/foo/bars",  }, -- 60
-  {  "/fee/bor/",    "/",         false,      "/foo/bar/s",   "/fee/bor/foo/bar/s", },
-  {  "/fee/bor/",    "/foo/bar",  false,      "/foo/bars",    "/fee/bor/foo/bars",  },
-  {  "/fee/bor/",    "/foo/bar/", false,      "/foo/bar/s",   "/fee/bor/foo/bar/s", },
+  {  "/",            "/",         true,       "v0",          "/foo/bars",    "/foo/bars",          },
+  {  "/",            "/",         true,       "v1",          "/foo/bars",    "/foo/bars",          },
+  {  "/",            "/",         true,       "v0",          "/foo/bar/s",   "/foo/bar/s",         },
+  {  "/",            "/",         true,       "v1",          "/foo/bar/s",   "/foo/bar/s",         }, --  80
+  {  "/",            "/foo/bar",  true,       "v0",          "/foo/bars",    "/s",                 },
+  {  "/",            "/foo/bar",  true,       "v1",          "/foo/bars",    "/s",                 },
+  {  "/",            "/foo/bar/", true,       "v0",          "/foo/bar/s",   "/s",                 },
+  {  "/",            "/foo/bar/", true,       "v1",          "/foo/bar/s",   "/s",                 },
+  {  "/fee/bor",     "/",         true,       "v0",          "/foo/bars",    "/fee/bor/foo/bars",  },
+  {  "/fee/bor",     "/",         true,       "v1",          "/foo/bars",    "/fee/borfoo/bars",   }, -- !
+  {  "/fee/bor",     "/",         true,       "v0",          "/foo/bar/s",   "/fee/bor/foo/bar/s", },
+  {  "/fee/bor",     "/",         true,       "v1",          "/foo/bar/s",   "/fee/borfoo/bar/s",  }, -- !
+  {  "/fee/bor",     "/foo/bar",  true,       "v0",          "/foo/bars",    "/fee/bor/s",         },
+  {  "/fee/bor",     "/foo/bar",  true,       "v1",          "/foo/bars",    "/fee/bors",          }, -- ! 90
+  {  "/fee/bor",     "/foo/bar/", true,       "v0",          "/foo/bar/s",   "/fee/bor/s",         },
+  {  "/fee/bor",     "/foo/bar/", true,       "v1",          "/foo/bar/s",   "/fee/bors",          }, -- !
+  {  "/fee/bor/",    "/",         true,       "v0",          "/foo/bars",    "/fee/bor/foo/bars",  },
+  {  "/fee/bor/",    "/",         true,       "v1",          "/foo/bars",    "/fee/bor/foo/bars",  },
+  {  "/fee/bor/",    "/",         true,       "v0",          "/foo/bar/s",   "/fee/bor/foo/bar/s", },
+  {  "/fee/bor/",    "/",         true,       "v1",          "/foo/bar/s",   "/fee/bor/foo/bar/s", },
+  {  "/fee/bor/",    "/foo/bar",  true,       "v0",          "/foo/bars",    "/fee/bor/s",         },
+  {  "/fee/bor/",    "/foo/bar",  true,       "v1",          "/foo/bars",    "/fee/bor/s",         },
+  {  "/fee/bor/",    "/foo/bar/", true,       "v0",          "/foo/bar/s",   "/fee/bor/s",         },
+  {  "/fee/bor/",    "/foo/bar/", true,       "v1",          "/foo/bar/s",   "/fee/bor/s",         }, -- 100
+  {  "/",            "/",         false,      "v0",          "/foo/bars",    "/foo/bars",          },
+  {  "/",            "/",         false,      "v1",          "/foo/bars",    "/foo/bars",          },
+  {  "/",            "/",         false,      "v0",          "/foo/bar/s",   "/foo/bar/s",         },
+  {  "/",            "/",         false,      "v1",          "/foo/bar/s",   "/foo/bar/s",         },
+  {  "/",            "/foo/bar",  false,      "v0",          "/foo/bars",    "/foo/bars",          },
+  {  "/",            "/foo/bar",  false,      "v1",          "/foo/bars",    "/foo/bars",          },
+  {  "/",            "/foo/bar/", false,      "v0",          "/foo/bar/s",   "/foo/bar/s",         },
+  {  "/",            "/foo/bar/", false,      "v1",          "/foo/bar/s",   "/foo/bar/s",         },
+  {  "/fee/bor",     "/",         false,      "v0",          "/foo/bars",    "/fee/bor/foo/bars",  },
+  {  "/fee/bor",     "/",         false,      "v1",          "/foo/bars",    "/fee/borfoo/bars",   }, -- ! 110
+  {  "/fee/bor",     "/",         false,      "v0",          "/foo/bar/s",   "/fee/bor/foo/bar/s", },
+  {  "/fee/bor",     "/",         false,      "v1",          "/foo/bar/s",   "/fee/borfoo/bar/s",  }, -- !
+  {  "/fee/bor",     "/foo/bar",  false,      "v0",          "/foo/bars",    "/fee/bor/foo/bars",  },
+  {  "/fee/bor",     "/foo/bar",  false,      "v1",          "/foo/bars",    "/fee/borfoo/bars",   }, -- !
+  {  "/fee/bor",     "/foo/bar/", false,      "v0",          "/foo/bar/s",   "/fee/bor/foo/bar/s", },
+  {  "/fee/bor",     "/foo/bar/", false,      "v1",          "/foo/bar/s",   "/fee/borfoo/bar/s",  }, -- !
+  {  "/fee/bor/",    "/",         false,      "v0",          "/foo/bars",    "/fee/bor/foo/bars",  },
+  {  "/fee/bor/",    "/",         false,      "v1",          "/foo/bars",    "/fee/bor/foo/bars",  },
+  {  "/fee/bor/",    "/",         false,      "v0",          "/foo/bar/s",   "/fee/bor/foo/bar/s", },
+  {  "/fee/bor/",    "/",         false,      "v1",          "/foo/bar/s",   "/fee/bor/foo/bar/s", }, -- 120
+  {  "/fee/bor/",    "/foo/bar",  false,      "v0",          "/foo/bars",    "/fee/bor/foo/bars",  },
+  {  "/fee/bor/",    "/foo/bar",  false,      "v1",          "/foo/bars",    "/fee/bor/foo/bars",  },
+  {  "/fee/bor/",    "/foo/bar/", false,      "v0",          "/foo/bar/s",   "/fee/bor/foo/bar/s", },
+  {  "/fee/bor/",    "/foo/bar/", false,      "v1",          "/foo/bar/s",   "/fee/bor/foo/bar/s", },
   -- the following block matches on host, instead of path
-  {  "/",            nil,         false,      "/",            "/",                  },
-  {  "/",            nil,         false,      "/foo/bar",     "/foo/bar",           },
-  {  "/",            nil,         false,      "/foo/bar/",    "/foo/bar/",          },
-  {  "/fee/bor",     nil,         false,      "/",            "/fee/bor",           },
-  {  "/fee/bor",     nil,         false,      "/foo/bar",     "/fee/bor/foo/bar",   },
-  {  "/fee/bor",     nil,         false,      "/foo/bar/",    "/fee/bor/foo/bar/",  },
-  {  "/fee/bor/",    nil,         false,      "/",            "/fee/bor/",          }, -- 70
-  {  "/fee/bor/",    nil,         false,      "/foo/bar",     "/fee/bor/foo/bar",   },
-  {  "/fee/bor/",    nil,         false,      "/foo/bar/",    "/fee/bor/foo/bar/",  },
-  {  "/",            nil,         true,       "/",            "/",                  },
-  {  "/",            nil,         true,       "/foo/bar",     "/foo/bar",           },
-  {  "/",            nil,         true,       "/foo/bar/",    "/foo/bar/",          },
-  {  "/fee/bor",     nil,         true,       "/",            "/fee/bor",           },
-  {  "/fee/bor",     nil,         true,       "/foo/bar",     "/fee/bor/foo/bar",   },
-  {  "/fee/bor",     nil,         true,       "/foo/bar/",    "/fee/bor/foo/bar/",  },
-  {  "/fee/bor/",    nil,         true,       "/",            "/fee/bor",           },
-  {  "/fee/bor/",    nil,         true,       "/foo/bar",     "/fee/bor/foo/bar",   },
-  {  "/fee/bor/",    nil,         true,       "/foo/bar/",    "/fee/bor/foo/bar/",  }, -- 80
+  {  "/",            nil,         false,      "v0",          "/",            "/",                  },
+  {  "/",            nil,         false,      "v1",          "/",            "/",                  },
+  {  "/",            nil,         false,      "v0",          "/foo/bar",     "/foo/bar",           },
+  {  "/",            nil,         false,      "v1",          "/foo/bar",     "/foo/bar",           },
+  {  "/",            nil,         false,      "v0",          "/foo/bar/",    "/foo/bar/",          },
+  {  "/",            nil,         false,      "v1",          "/foo/bar/",    "/foo/bar/",          }, -- 130
+  {  "/fee/bor",     nil,         false,      "v0",          "/",            "/fee/bor",           },
+  {  "/fee/bor",     nil,         false,      "v1",          "/",            "/fee/bor",           },
+  {  "/fee/bor",     nil,         false,      "v0",          "/foo/bar",     "/fee/bor/foo/bar",   },
+  {  "/fee/bor",     nil,         false,      "v1",          "/foo/bar",     "/fee/borfoo/bar",    }, -- !
+  {  "/fee/bor",     nil,         false,      "v0",          "/foo/bar/",    "/fee/bor/foo/bar/",  },
+  {  "/fee/bor",     nil,         false,      "v1",          "/foo/bar/",    "/fee/borfoo/bar/",   }, -- !
+  {  "/fee/bor/",    nil,         false,      "v0",          "/",            "/fee/bor/",          },
+  {  "/fee/bor/",    nil,         false,      "v1",          "/",            "/fee/bor/",          },
+  {  "/fee/bor/",    nil,         false,      "v0",          "/foo/bar",     "/fee/bor/foo/bar",   },
+  {  "/fee/bor/",    nil,         false,      "v1",          "/foo/bar",     "/fee/bor/foo/bar",   }, -- 140
+  {  "/fee/bor/",    nil,         false,      "v0",          "/foo/bar/",    "/fee/bor/foo/bar/",  },
+  {  "/fee/bor/",    nil,         false,      "v1",          "/foo/bar/",    "/fee/bor/foo/bar/",  },
+  {  "/",            nil,         true,       "v0",          "/",            "/",                  },
+  {  "/",            nil,         true,       "v1",          "/",            "/",                  },
+  {  "/",            nil,         true,       "v0",          "/foo/bar",     "/foo/bar",           },
+  {  "/",            nil,         true,       "v1",          "/foo/bar",     "/foo/bar",           },
+  {  "/",            nil,         true,       "v0",          "/foo/bar/",    "/foo/bar/",          },
+  {  "/",            nil,         true,       "v1",          "/foo/bar/",    "/foo/bar/",          },
+  {  "/fee/bor",     nil,         true,       "v0",          "/",            "/fee/bor",           },
+  {  "/fee/bor",     nil,         true,       "v1",          "/",            "/fee/bor",           }, -- 150
+  {  "/fee/bor",     nil,         true,       "v0",          "/foo/bar",     "/fee/bor/foo/bar",   },
+  {  "/fee/bor",     nil,         true,       "v1",          "/foo/bar",     "/fee/borfoo/bar",    }, -- !
+  {  "/fee/bor",     nil,         true,       "v0",          "/foo/bar/",    "/fee/bor/foo/bar/",  },
+  {  "/fee/bor",     nil,         true,       "v1",          "/foo/bar/",    "/fee/borfoo/bar/",   }, -- !
+  {  "/fee/bor/",    nil,         true,       "v0",          "/",            "/fee/bor",           },
+  {  "/fee/bor/",    nil,         true,       "v1",          "/",            "/fee/bor/",          }, -- !
+  {  "/fee/bor/",    nil,         true,       "v0",          "/foo/bar",     "/fee/bor/foo/bar",   },
+  {  "/fee/bor/",    nil,         true,       "v1",          "/foo/bar",     "/fee/bor/foo/bar",   },
+  {  "/fee/bor/",    nil,         true,       "v0",          "/foo/bar/",    "/fee/bor/foo/bar/",  },
+  {  "/fee/bor/",    nil,         true,       "v1",          "/foo/bar/",    "/fee/bor/foo/bar/",  }, -- 160
 }
 
 local parsed_tests = {}
@@ -103,8 +185,9 @@ for i = 1, #tests do
     service_path  = test[1],
     route_path    = test[2],
     strip_path    = test[3],
-    request_path  = test[4],
-    expected_path = test[5],
+    path_handling = test[4],
+    request_path  = test[5],
+    expected_path = test[6],
   }
 end
 

--- a/spec/fixtures/router_path_handling_tests.lua
+++ b/spec/fixtures/router_path_handling_tests.lua
@@ -1,0 +1,111 @@
+-- The following tests are used by unit and integration tests
+-- to test the router path handling. Putting them here avoids
+-- copy-pasting them in several places.
+--
+-- The tests can obtain this table by requiring
+-- "spec.fixtures.router_path_handling_tests"
+--
+-- Note that the tests are parsed into a hash form at the end
+-- of this file before they are returned
+
+local tests = {
+  -- service_path    route_path   strip_path  request_path    expected_path
+  {  "/",            "/",         true,       "/",            "/",                  }, -- 1
+  {  "/",            "/",         true,       "/foo/bar",     "/foo/bar",           },
+  {  "/",            "/",         true,       "/foo/bar/",    "/foo/bar/",          },
+  {  "/",            "/foo/bar",  true,       "/foo/bar",     "/",                  },
+  {  "/",            "/foo/bar",  true,       "/foo/bar/",    "/",                  },
+  {  "/",            "/foo/bar/", true,       "/foo/bar/",    "/",                  },
+  {  "/fee/bor",     "/",         true,       "/",            "/fee/bor",           },
+  {  "/fee/bor",     "/",         true,       "/foo/bar",     "/fee/bor/foo/bar",   },
+  {  "/fee/bor",     "/",         true,       "/foo/bar/",    "/fee/bor/foo/bar/",  },
+  {  "/fee/bor",     "/foo/bar",  true,       "/foo/bar",     "/fee/bor",           }, -- 10
+  {  "/fee/bor",     "/foo/bar",  true,       "/foo/bar/",    "/fee/bor/",          },
+  {  "/fee/bor",     "/foo/bar/", true,       "/foo/bar/",    "/fee/bor",           },
+  {  "/fee/bor/",    "/",         true,       "/",            "/fee/bor",           },
+  {  "/fee/bor/",    "/",         true,       "/foo/bar",     "/fee/bor/foo/bar",   },
+  {  "/fee/bor/",    "/",         true,       "/foo/bar/",    "/fee/bor/foo/bar/",  },
+  {  "/fee/bor/",    "/foo/bar",  true,       "/foo/bar",     "/fee/bor",           },
+  {  "/fee/bor/",    "/foo/bar",  true,       "/foo/bar/",    "/fee/bor/",          },
+  {  "/fee/bor/",    "/foo/bar/", true,       "/foo/bar/",    "/fee/bor",           },
+  {  "/fee",         "/foo",      true,       "/foobar",      "/fee/bar",           }, -- 20
+  {  "/fee/",        "/foo",      true,       "/foo",         "/fee",               },
+  {  "/",            "/",         false,      "/",            "/",                  },
+  {  "/",            "/",         false,      "/foo/bar",     "/foo/bar",           },
+  {  "/",            "/",         false,      "/foo/bar/",    "/foo/bar/",          },
+  {  "/",            "/foo/bar",  false,      "/foo/bar",     "/foo/bar",           },
+  {  "/",            "/foo/bar",  false,      "/foo/bar/",    "/foo/bar/",          },
+  {  "/",            "/foo/bar/", false,      "/foo/bar/",    "/foo/bar/",          },
+  {  "/fee/bor",     "/",         false,      "/",            "/fee/bor",           },
+  {  "/fee/bor",     "/",         false,      "/foo/bar",     "/fee/bor/foo/bar",   },
+  {  "/fee/bor",     "/",         false,      "/foo/bar/",    "/fee/bor/foo/bar/",  }, -- 30
+  {  "/fee/bor",     "/foo/bar",  false,      "/foo/bar",     "/fee/bor/foo/bar",   },
+  {  "/fee/bor",     "/foo/bar",  false,      "/foo/bar/",    "/fee/bor/foo/bar/",  },
+  {  "/fee/bor",     "/foo/bar/", false,      "/foo/bar/",    "/fee/bor/foo/bar/",  },
+  {  "/fee/bor/",    "/",         false,      "/",            "/fee/bor/",          },
+  {  "/fee/bor/",    "/",         false,      "/foo/bar",     "/fee/bor/foo/bar",   },
+  {  "/fee/bor/",    "/",         false,      "/foo/bar/",    "/fee/bor/foo/bar/",  },
+  {  "/fee/bor/",    "/foo/bar",  false,      "/foo/bar",     "/fee/bor/foo/bar",   },
+  {  "/fee/bor/",    "/foo/bar",  false,      "/foo/bar/",    "/fee/bor/foo/bar/",  },
+  {  "/fee/bor/",    "/foo/bar/", false,      "/foo/bar/",    "/fee/bor/foo/bar/",  },
+  -- the following block runs the same tests, but with a request path that is longer
+  -- than the matched part, so either matches in the middle of a segment, or has an
+  -- additional segment.
+  {  "/",            "/",         true,       "/foo/bars",    "/foo/bars",          }, -- 40
+  {  "/",            "/",         true,       "/foo/bar/s",   "/foo/bar/s",         },
+  {  "/",            "/foo/bar",  true,       "/foo/bars",    "/s",                 },
+  {  "/",            "/foo/bar/", true,       "/foo/bar/s",   "/s",                 },
+  {  "/fee/bor",     "/",         true,       "/foo/bars",    "/fee/bor/foo/bars",  },
+  {  "/fee/bor",     "/",         true,       "/foo/bar/s",   "/fee/bor/foo/bar/s", },
+  {  "/fee/bor",     "/foo/bar",  true,       "/foo/bars",    "/fee/bor/s",         },
+  {  "/fee/bor",     "/foo/bar/", true,       "/foo/bar/s",   "/fee/bor/s",         },
+  {  "/fee/bor/",    "/",         true,       "/foo/bars",    "/fee/bor/foo/bars",  },
+  {  "/fee/bor/",    "/",         true,       "/foo/bar/s",   "/fee/bor/foo/bar/s", },
+  {  "/fee/bor/",    "/foo/bar",  true,       "/foo/bars",    "/fee/bor/s",         }, -- 50
+  {  "/fee/bor/",    "/foo/bar/", true,       "/foo/bar/s",   "/fee/bor/s",         },
+  {  "/",            "/",         false,      "/foo/bars",    "/foo/bars",          },
+  {  "/",            "/",         false,      "/foo/bar/s",   "/foo/bar/s",         },
+  {  "/",            "/foo/bar",  false,      "/foo/bars",    "/foo/bars",          },
+  {  "/",            "/foo/bar/", false,      "/foo/bar/s",   "/foo/bar/s",         },
+  {  "/fee/bor",     "/",         false,      "/foo/bars",    "/fee/bor/foo/bars",  },
+  {  "/fee/bor",     "/",         false,      "/foo/bar/s",   "/fee/bor/foo/bar/s", },
+  {  "/fee/bor",     "/foo/bar",  false,      "/foo/bars",    "/fee/bor/foo/bars",  },
+  {  "/fee/bor",     "/foo/bar/", false,      "/foo/bar/s",   "/fee/bor/foo/bar/s", },
+  {  "/fee/bor/",    "/",         false,      "/foo/bars",    "/fee/bor/foo/bars",  }, -- 60
+  {  "/fee/bor/",    "/",         false,      "/foo/bar/s",   "/fee/bor/foo/bar/s", },
+  {  "/fee/bor/",    "/foo/bar",  false,      "/foo/bars",    "/fee/bor/foo/bars",  },
+  {  "/fee/bor/",    "/foo/bar/", false,      "/foo/bar/s",   "/fee/bor/foo/bar/s", },
+  -- the following block matches on host, instead of path
+  {  "/",            nil,         false,      "/",            "/",                  },
+  {  "/",            nil,         false,      "/foo/bar",     "/foo/bar",           },
+  {  "/",            nil,         false,      "/foo/bar/",    "/foo/bar/",          },
+  {  "/fee/bor",     nil,         false,      "/",            "/fee/bor",           },
+  {  "/fee/bor",     nil,         false,      "/foo/bar",     "/fee/bor/foo/bar",   },
+  {  "/fee/bor",     nil,         false,      "/foo/bar/",    "/fee/bor/foo/bar/",  },
+  {  "/fee/bor/",    nil,         false,      "/",            "/fee/bor/",          }, -- 70
+  {  "/fee/bor/",    nil,         false,      "/foo/bar",     "/fee/bor/foo/bar",   },
+  {  "/fee/bor/",    nil,         false,      "/foo/bar/",    "/fee/bor/foo/bar/",  },
+  {  "/",            nil,         true,       "/",            "/",                  },
+  {  "/",            nil,         true,       "/foo/bar",     "/foo/bar",           },
+  {  "/",            nil,         true,       "/foo/bar/",    "/foo/bar/",          },
+  {  "/fee/bor",     nil,         true,       "/",            "/fee/bor",           },
+  {  "/fee/bor",     nil,         true,       "/foo/bar",     "/fee/bor/foo/bar",   },
+  {  "/fee/bor",     nil,         true,       "/foo/bar/",    "/fee/bor/foo/bar/",  },
+  {  "/fee/bor/",    nil,         true,       "/",            "/fee/bor",           },
+  {  "/fee/bor/",    nil,         true,       "/foo/bar",     "/fee/bor/foo/bar",   },
+  {  "/fee/bor/",    nil,         true,       "/foo/bar/",    "/fee/bor/foo/bar/",  }, -- 80
+}
+
+local parsed_tests = {}
+for i = 1, #tests do
+  local test = tests[i]
+  parsed_tests[i] = {
+    service_path  = test[1],
+    route_path    = test[2],
+    strip_path    = test[3],
+    request_path  = test[4],
+    expected_path = test[5],
+  }
+end
+
+return parsed_tests


### PR DESCRIPTION
> This PR supersedes the previous ones on this topic, see below.

This PR introduces a new Routes attribute called `path_handling`.

It complements #5216 and #5227 by making it possible to select the behavior the router will have when combining the Service path, Route path and the request path into a single path sent to the upstream.

For now `path_handling` accepts two values:

* `"v0"` (the default from now on) makes paths in the router behave like in Kong 0.x (like they did  before #3780)
* `"v1"` makes paths behave like in Kong 1.x (like they did after #3780)

Migrations are adaptive, ensuring that when migrating routes from 0.14.1, they get `path_handling = "v0"`, and when migrating from 1.x, they get `path_handling = "v1"`. This way, routes continue working the same way after a migration.

Closes #5292 
Closes #5341
Fixes #4469