### PR TITLE
Feat/proc mgmt

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -115,6 +115,10 @@
                                  # cache (i.e. when the configured
                                  # `mem_cache_size`) is full.
 
+#go_pluginserver_exe = /usr/local/bin/go-pluginserver
+                                 # Path for the go-pluginserver executable,
+                                 # used for running Kong plugins written in Go.
+
 #go_plugins_dir = off            # Directory for installing Kong plugins
                                  # written in Go.
                                  #

--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -1151,6 +1151,8 @@ local function load(path, custom_conf, opts)
   -- load absolute paths
   conf.prefix = pl_path.abspath(conf.prefix)
 
+  conf.go_pluginserver_exe = pl_path.abspath(conf.go_pluginserver_exe)
+
   if conf.go_plugins_dir ~= "off" then
     conf.go_plugins_dir = pl_path.abspath(conf.go_plugins_dir)
   end

--- a/kong/db/dao/plugins/go.lua
+++ b/kong/db/dao/plugins/go.lua
@@ -193,14 +193,7 @@ do
       return ffi_sock(go.socket_path())
     end
 
-    local conn, err = ngx.socket.connect("unix:" .. go.socket_path())
-    if not conn and err == "connection refused" then
-      go.manage_pluginserver()
-      ngx.sleep(0.1)
-      conn, err = ngx.socket.connect("unix:" .. go.socket_path())
-    end
-
-    return conn, err
+    return ngx.socket.connect("unix:" .. go.socket_path())
   end
 end
 go.get_connection = get_connection

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -415,15 +415,6 @@ function Kong.init()
     certificate.init()
   end
 
-  if go.is_on() then
-    local conn, err = go.get_connection()
-    if not conn then
-      kong.log.err("failure connecting to go plugin server socket: ", err)
-    else
-      conn:setkeepalive()
-    end
-  end
-
   clustering.init(config)
 
   -- Load plugins as late as possible so that everything is set up
@@ -550,6 +541,10 @@ function Kong.init_worker()
 
   local plugins_iterator = runloop.get_plugins_iterator()
   execute_plugins_iterator(plugins_iterator, "init_worker")
+
+  if go.is_on() then
+    go.manage_pluginserver()
+  end
 
   clustering.init_worker(kong.configuration)
 end

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -8,6 +8,7 @@ admin_error_log = logs/error.log
 status_access_log = off
 status_error_log = logs/status_error.log
 plugins = bundled
+go_pluginserver_exe = /usr/local/bin/go-pluginserver
 go_plugins_dir = off
 anonymous_reports = on
 


### PR DESCRIPTION
### Summary
process management to make the running of go-pluginserver transparent to the user

- starts it when needed
- restarts if it dies
- it's killed when nginx quits.

TODOs:

- ~~the server is started on the first request that tries to connect to it.~~
  - ~~it would be nice to do it proactively~~
  - ~~after starting, it sleeps for a while before retrying the connection.  would be best to wait until an event instead of a "reasonable delay"~~
  - ~~the process management is tied to worker #0, if that first request goes to a different worker, it won't start the pluginserver and the request would fail.  this would happen a few times until worker #0 gets one of those requests.~~
- throttle the respawning to avoid 100% lockup if the pluginserver fails to start
