### PR TITLE
chore(deps) bump kong-plugin-azure-functions(0.4.2) and kong-plugin-z…

### DIFF
--- a/kong-2.0.0rc1-0.rockspec
+++ b/kong-2.0.0rc1-0.rockspec
@@ -38,8 +38,8 @@ dependencies = {
   "lua-messagepack == 0.5.2",
   "lua-resty-openssl == 0.3.0",
   -- external Kong plugins
-  "kong-plugin-azure-functions ~> 0.4",
-  "kong-plugin-zipkin ~> 0.2",
+  "kong-plugin-azure-functions ~> 0.4.2",
+  "kong-plugin-zipkin ~> 0.2.1",
   "kong-plugin-serverless-functions ~> 0.3",
   "kong-prometheus-plugin ~> 0.7",
   "kong-proxy-cache-plugin ~> 1.2",


### PR DESCRIPTION
…ipkin(0.2.1)



### Summary

Bump the version of the external plugins.

Got this from the old developer environment:
```
kong start -c kong.conf
2019/12/23 17:36:42 [warn] ulimit is currently set to “1024”. For better performance set it to at least “4096" using “ulimit -n”
Error: ./kong/cmd/start.lua:64: nginx: [error] init_by_lua error: ./kong/tools/utils.lua:620: error loading module ‘kong.plugins.azure-functions.schema’:
...ks/share/lua/5.1/kong/plugins/azure-functions/schema.lua:7: schema typedef error: definition run_on_first does not exist
stack traceback:
    [C]: in function ‘error’
    ./kong/db/schema/typedefs.lua:524: in function ‘__index’
    ...ks/share/lua/5.1/kong/plugins/azure-functions/schema.lua:7: in main chunk
    [C]: at 0x7fa2f3c73c20
    [C]: in function ‘xpcall’
    ./kong/tools/utils.lua:611: in function ‘load_module_if_exists’
    ./kong/db/schema/plugin_loader.lua:183: in function ‘load_subschema’
    ./kong/db/dao/plugins.lua:228: in function ‘load_plugin’
    ./kong/db/dao/plugins.lua:270: in function ‘load_plugin_schemas’
    ./kong/init.lua:430: in function ‘init’
    init_by_lua:3: in main chunk
stack traceback:
    [C]: in function ‘error’
    ./kong/tools/utils.lua:620: in function ‘load_module_if_exists’
    ./kong/db/schema/plugin_loader.lua:183: in function ‘load_subschema’
    ./kong/db/dao/plugins.lua:228: in function ‘load_plugin’
    ./kong/db/dao/plugins.lua:270: in function ‘load_plugin_schemas’
    ./kong/init.lua:430: in function ‘init’
    init_by_lua:3: in main chunk

```
