### PR TITLE
fix(router) longest path routes are no longer matched as expected

### DIFF
--- a/kong/router.lua
+++ b/kong/router.lua
@@ -1283,29 +1283,32 @@ function _M.new(routes)
 
     -- uri match
 
-    if plain_indexes.uris[req_uri] then
-      req_category = bor(req_category, MATCH_RULES.URI)
-
-    else
-      for i = 1, #prefix_uris do
-        if find(req_uri, prefix_uris[i].value, nil, true) == 1 then
-          hits.uri     = prefix_uris[i].value
-          req_category = bor(req_category, MATCH_RULES.URI)
-          break
-        end
+    for i = 1, #regex_uris do
+      local from, _, err = re_find(req_uri, regex_uris[i].regex, "ajo")
+      if err then
+        log(ERR, "could not evaluate URI regex: ", err)
+        return
       end
 
-      for i = 1, #regex_uris do
-        local from, _, err = re_find(req_uri, regex_uris[i].regex, "ajo")
-        if err then
-          log(ERR, "could not evaluate URI regex: ", err)
-          return
-        end
+      if from then
+        hits.uri     = regex_uris[i].value
+        req_category = bor(req_category, MATCH_RULES.URI)
+        break
+      end
+    end
 
-        if from then
-          hits.uri     = regex_uris[i].value
-          req_category = bor(req_category, MATCH_RULES.URI)
-          break
+    if not hits.uri then
+      if plain_indexes.uris[req_uri] then
+        hits.uri     = req_uri
+        req_category = bor(req_category, MATCH_RULES.URI)
+
+      else
+        for i = 1, #prefix_uris do
+          if find(req_uri, prefix_uris[i].value, nil, true) == 1 then
+            hits.uri     = prefix_uris[i].value
+            req_category = bor(req_category, MATCH_RULES.URI)
+            break
+          end
         end
       end
     end

--- a/spec/02-integration/05-proxy/02-router_spec.lua
+++ b/spec/02-integration/05-proxy/02-router_spec.lua
@@ -1422,12 +1422,12 @@ for _, strategy in helpers.each_strategy() do
           {
             strip_path = true,
             hosts      = { "route.com" },
-            paths      = { "/root" },
+            paths      = { "/root/fixture", "/root/fixture/non-matching-but-longer" },
           },
           {
             strip_path = true,
             hosts      = { "route.com" },
-            paths      = { "/root/fixture" },
+            paths      = { "/root/fixture/get" },
           },
         })
       end)


### PR DESCRIPTION
### Summary

This bug was introduced on `1.3.0` that added header based routing, and was reported in #5371.

### Issues Resolved

Fix #5371