### PR TITLE
chore(deps) bump lua-resty-openssl to 0.4.1

### DIFF
--- a/kong-1.4.2-0.rockspec
+++ b/kong-1.4.2-0.rockspec
@@ -36,7 +36,7 @@ dependencies = {
   "lua-resty-cookie == 0.1.0",
   "lua-resty-mlcache == 2.4.0",
   "lua-messagepack == 0.5.2",
-  "lua-resty-openssl == 0.3.0",
+  "lua-resty-openssl == 0.4.1",
   -- external Kong plugins
   "kong-plugin-azure-functions ~> 0.4",
   "kong-plugin-zipkin ~> 0.2",


### PR DESCRIPTION
### Summary

Bumps `lua-resty-openssl` from `0.3.0` to `0.4.1`.