### PR TITLE
feat(cache) Allow configuring neg_ttl for caching database entities

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -770,6 +770,12 @@
                                  # If set to 0 (default), such cached entities
                                  # or misses never expire.
 
+#db_cache_neg_ttl = 0            # Time-to-live (in seconds) of database misses
+                                 # where no entity is returned and nil is cached.
+                                 #
+                                 # If set to 0 (default), such nil entities
+                                 # never expire.
+
 #db_resurrect_ttl = 30           # Time (in seconds) for which stale entities
                                  # from the datastore should be resurrected for
                                  # when they cannot be refreshed (e.g., the

--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -121,6 +121,7 @@ local CONF_INFERENCES = {
   db_update_frequency = {  typ = "number"  },
   db_update_propagation = {  typ = "number"  },
   db_cache_ttl = {  typ = "number"  },
+  db_cache_neg_ttl = {  typ = "number"  },
   db_resurrect_ttl = {  typ = "number"  },
   db_cache_warmup_entities = { typ = "array" },
   nginx_user = { typ = "string" },

--- a/kong/global.lua
+++ b/kong/global.lua
@@ -151,9 +151,11 @@ do
 
   function _GLOBAL.init_cache(kong_config, cluster_events, worker_events)
     local db_cache_ttl = kong_config.db_cache_ttl
+    local db_cache_neg_ttl = kong_config.db_cache_neg_ttl
     local cache_pages = 1
     if kong_config.database == "off" then
       db_cache_ttl = 0
+      db_cache_neg_ttl = 0
       cache_pages = 2
     end
 
@@ -162,7 +164,7 @@ do
       worker_events     = worker_events,
       propagation_delay = kong_config.db_update_propagation,
       ttl               = db_cache_ttl,
-      neg_ttl           = db_cache_ttl,
+      neg_ttl           = db_cache_neg_ttl,
       resurrect_ttl     = kong_config.resurrect_ttl,
       cache_pages       = cache_pages,
       resty_lock_opts   = {

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -77,6 +77,7 @@ declarative_config = NONE
 db_update_frequency = 5
 db_update_propagation = 0
 db_cache_ttl = 0
+db_cache_neg_ttl = 0
 db_resurrect_ttl = 30
 db_cache_warmup_entities = services, plugins
 


### PR DESCRIPTION
### Summary

The database cache allows to configure both ttl and neg_ttl but kong imposes that the values are equal. With this change both values may be set externally when this is needed.
For example any can configure a neg_ttl to be lower than ttl that is more useful in most of the cases:

- When the datase is down and a nil value is cached, this stay cached until normal ttl expires and this may lead to long time in recovering when database is down.
- To prevent brutte force attacks a value lower thant ttl is enough.

### Full changelog

* add a new 'db_cache_neg_ttl' config option
