### PR TITLE
fix(router) do not ignore header-matched routes when retrieving matches from cache

### DIFF
--- a/kong/router.lua
+++ b/kong/router.lua
@@ -1211,20 +1211,6 @@ function _M.new(routes)
     ctx.dst_port       = dst_port or ""
     ctx.sni            = sni or ""
 
-    -- cache lookup (except for headers-matched Routes)
-
-    local cache_key = req_method .. "|" .. req_uri .. "|" .. req_host ..
-                      "|" .. ctx.src_ip .. "|" .. ctx.src_port ..
-                      "|" .. ctx.dst_ip .. "|" .. ctx.dst_port ..
-                      "|" .. ctx.sni
-
-    do
-      local match_t = cache:get(cache_key)
-      if match_t then
-        return match_t
-      end
-    end
-
     -- input sanitization for matchers
 
     -- hosts
@@ -1250,6 +1236,31 @@ function _M.new(routes)
     --
     -- determine which category this request *might* be targeting
 
+    -- header match
+
+    for _, header_name in ipairs(plain_indexes.headers) do
+      if req_headers[header_name] then
+        req_category = bor(req_category, MATCH_RULES.HEADER)
+        hits.header_name = header_name
+        break
+      end
+    end
+
+    -- cache lookup (except for headers-matched Routes)
+    -- if trigger headers match rule, ignore routes cache
+
+    local cache_key = req_method .. "|" .. req_uri .. "|" .. req_host ..
+                      "|" .. ctx.src_ip .. "|" .. ctx.src_port ..
+                      "|" .. ctx.dst_ip .. "|" .. ctx.dst_port ..
+                      "|" .. ctx.sni
+
+    do
+      local match_t = cache:get(cache_key)
+      if match_t and (hits.header_name == nil and hits.header_name == '') then
+        return match_t
+      end
+    end
+
     -- host match
 
     if plain_indexes.hosts[ctx.req_host] then
@@ -1268,16 +1279,6 @@ function _M.new(routes)
           req_category = bor(req_category, MATCH_RULES.HOST)
           break
         end
-      end
-    end
-
-    -- header match
-
-    for _, header_name in ipairs(plain_indexes.headers) do
-      if req_headers[header_name] then
-        req_category = bor(req_category, MATCH_RULES.HEADER)
-        hits.header_name = header_name
-        break
       end
     end
 

--- a/kong/router.lua
+++ b/kong/router.lua
@@ -1256,7 +1256,7 @@ function _M.new(routes)
 
     do
       local match_t = cache:get(cache_key)
-      if match_t and (hits.header_name == nil and hits.header_name == '') then
+      if match_t and hits.header_name == nil then
         return match_t
       end
     end

--- a/spec/02-integration/05-proxy/02-router_spec.lua
+++ b/spec/02-integration/05-proxy/02-router_spec.lua
@@ -1240,6 +1240,71 @@ for _, strategy in helpers.each_strategy() do
         assert.equal(routes[3].service.id,   res.headers["kong-service-id"])
         assert.equal(routes[3].service.name, res.headers["kong-service-name"])
       end)
+
+      it("caching do not ignore headers (regression)", function()
+        routes = insert_routes(bp, {
+          {
+            service    = {
+              name     = "first",
+            },
+            hosts      = { "example.test" },
+            paths      = { "/test" },
+            headers    = { headertest = { "itsatest" } },
+          },
+          {
+            service    = {
+              name     = "second",
+            },
+            hosts      = { "example.test" },
+            paths      = { "/test" },
+          },
+        })
+
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = routes[1].paths[1],
+          headers = {
+            ["Host"]       = routes[1].hosts[1],
+            ["headertest"] = "itsatest",
+            ["kong-debug"] = 1,
+          }
+        })
+
+        assert.res_status(200, res)
+        assert.equal(routes[1].id,           res.headers["kong-route-id"])
+        assert.equal(routes[1].service.id,   res.headers["kong-service-id"])
+        assert.equal(routes[1].service.name, res.headers["kong-service-name"])
+
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = routes[2].paths[1],
+          headers = {
+            ["Host"]       = routes[2].hosts[1],
+            ["kong-debug"] = 1,
+          }
+        })
+
+        assert.res_status(200, res)
+        assert.equal(routes[2].id,           res.headers["kong-route-id"])
+        assert.equal(routes[2].service.id,   res.headers["kong-service-id"])
+        assert.equal(routes[2].service.name, res.headers["kong-service-name"])
+
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = routes[1].paths[1],
+          headers = {
+            ["Host"]       = routes[1].hosts[1],
+            ["headertest"] = "itsatest",
+            ["kong-debug"] = 1,
+          }
+        })
+
+        assert.res_status(200, res)
+        assert.equal(routes[1].id,           res.headers["kong-route-id"])
+        assert.equal(routes[1].service.id,   res.headers["kong-service-id"])
+        assert.equal(routes[1].service.name, res.headers["kong-service-name"])
+
+      end)
     end)
 
     describe("[paths] + [headers]", function()


### PR DESCRIPTION
When retrieving routes matches from the cache, header matches were being ignored.

Fix #5260
Close #5267 