### PR TITLE
fix(schema) add empty string handling on updates for auto generated f…

### DIFF
--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1597,7 +1597,8 @@ function Schema:process_auto_fields(data, context, nulls)
         end
 
       elseif field.type == "string" then
-        if (context == "insert" or context == "upsert") and data[key] == nil then
+        if (context == "insert" or context == "upsert" or context == "update")
+          and (data[key] == nil or data[key] == null) then
           data[key] = utils.random_string()
         end
 


### PR DESCRIPTION
### Summary

Add check for PATCH requests on empty string field which is being set up
to `ngx.null` and is not handled properly, which let users to set `nil`
value to `auto` generated `string` fields.

Empty string conversion to `ngx.null` happens here:
https://github.com/Kong/kong/blob/bf525dcc8e731a3de208f4c19b17916946b9fa4c/kong/tools/utils.lua#L401

I couldn't add test for this fix because there is no such plugin or functionality in CE which would let you to PATCH such field and test the change, I only did manual check with a custom plugin.

### Full changelog

* Add check for PATCH request on `auto` generated field with empty value
