### PR TITLE
chore(deps) bump lua-resty-openssl to 0.4.2

### DIFF
--- a/kong-1.4.2-0.rockspec
+++ b/kong-1.4.2-0.rockspec
@@ -35,7 +35,7 @@ dependencies = {
   "lua-resty-cookie == 0.1.0",
   "lua-resty-mlcache == 2.4.0",
   "lua-messagepack == 0.5.2",
-  "lua-resty-openssl == 0.4.1",
+  "lua-resty-openssl == 0.4.2",
   -- external Kong plugins
   "kong-plugin-azure-functions ~> 0.4",
   "kong-plugin-zipkin ~> 0.2",


### PR DESCRIPTION
### Summary

Some memory leak issues are identified and fixed

Changelog https://github.com/fffonion/lua-resty-openssl/blob/master/CHANGELOG.md

### Full changelog

* bump lua-resty-openssl to 0.4.2
