### PR TITLE
feat(runloop) dynamic default certificate

### DIFF
--- a/kong/runloop/certificate.lua
+++ b/kong/runloop/certificate.lua
@@ -19,6 +19,7 @@ local set_priv_key = ngx_ssl.set_priv_key
 
 local default_cert_and_key
 
+local DEFAULT_SNI = "*"
 
 local function log(lvl, ...)
   ngx_log(lvl, "[ssl] ", ...)
@@ -156,7 +157,7 @@ local function find_certificate(sni)
 
   local sni_wild_pref, sni_wild_suf = produce_wild_snis(sni)
 
-  local bulk = mlcache.new_bulk(3)
+  local bulk = mlcache.new_bulk(4)
 
   bulk:add("snis:" .. sni, nil, fetch_sni, sni)
 
@@ -167,6 +168,8 @@ local function find_certificate(sni)
   if sni_wild_suf then
     bulk:add("snis:" .. sni_wild_suf, nil, fetch_sni, sni_wild_suf)
   end
+
+  bulk:add("snis:" .. DEFAULT_SNI, nil, fetch_sni, DEFAULT_SNI)
 
   local res, err = kong.core_cache:get_bulk(bulk)
   if err then

--- a/spec/01-unit/01-db/01-schema/11-snis_spec.lua
+++ b/spec/01-unit/01-db/01-schema/11-snis_spec.lua
@@ -25,6 +25,16 @@ describe("snis", function()
       end
     end)
 
+    it("accepts a * for default certificate", function()
+      local names = { "*" }
+
+      for _, name in ipairs(names) do
+        local ok, err = validate({ name = name, certificate = certificate })
+        assert.is_nil(err)
+        assert.is_true(ok)
+      end
+    end)
+
     it("accepts wildcards", function()
       local names = { "*.wildcard.com", "wildcard.*", "test.wildcard.*",
                       "foo.test.wildcard.*", "*.test.wildcard.com" }

--- a/spec/02-integration/05-proxy/22-reports_spec.lua
+++ b/spec/02-integration/05-proxy/22-reports_spec.lua
@@ -68,6 +68,8 @@ for _, strategy in helpers.each_strategy() do
         "services",
         "routes",
         "plugins",
+        "certificates",
+        "snis",
       }, { "reports-api" }))
 
       local http_srv = assert(bp.services:insert {


### PR DESCRIPTION
### Summary

The default certificate for the proxy can now be configured via Admin API using the `/certificates` endpoint. A special '*' SNI has been introduced which stands for the default certificate.

The order in which Kong serves a certificate is:
- Exact SNI match
- Search by prefix wildcard
- Search by suffix wildcard
- Look for a cert associated with the SNI `*`
- The default certificate on file-system

This is an effort in the direction to make Kong more dynamic and minimize static configuration that is put in when the process is started.