### PR TITLE
chore(ci) [skip travis] signed centos nightly releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ nightly-release:
 	sed -i -e '/return string\.format/,/\"\")/c\return "$(KONG_VERSION)\"' kong/meta.lua
 	$(MAKE) release
 
-release: setup-kong-build-tools
+release:
 	cd $(KONG_BUILD_TOOLS_LOCATION); \
 	$(MAKE) package-kong && \
 	$(MAKE) release-kong


### PR DESCRIPTION
Signed daily releases work as follows ( https://github.com/Kong/kong/blob/0cf5bfa2c9ba7b24e52e8904981233b8adce3eac/Jenkinsfile#L199-L208 )

- run setup-kong-build-tools which clones the pinned kong-build-tools repository
- overwrite the empty private key file with one that is securely stored in Jenkins
- run nightly-release
- nightly-release in turn runs release

An unintended side effect of having the `release` step run `setup-kong-build-tools` as a prerequisite is it resets the kong-build-tools directory such that the private key file has been reset to empty