### PR TITLE
fix(declarative) remove a leftover print for security reasons

### DIFF
--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -152,7 +152,6 @@ function Config:parse_table(dc_table, hash)
   end
 
   if not hash then
-    print(cjson.encode(dc_table))
     hash = md5(cjson.encode(dc_table))
   end
 


### PR DESCRIPTION


### Summary

This print was left over for debugging reasons but leaks all the
sensitive credentials in logs.
