### PR TITLE
fix(router) split paths to properly sort for routing priority

### DIFF
--- a/kong/router.lua
+++ b/kong/router.lua
@@ -1051,7 +1051,16 @@ function _M.new(routes)
         return nil, err
       end
 
-      marshalled_routes[i] = route_t
+      if route_t.route.paths ~= nil and #route_t.route.paths > 1 then
+        -- split routes by paths to sort properly
+        for j = 1, #route_t.route.paths do
+          local index = #marshalled_routes + 1
+          marshalled_routes[index] = route_t
+          marshalled_routes[index].route.paths = { route_t.route.paths[j] }
+        end
+      else
+        marshalled_routes[#marshalled_routes + 1] = route_t
+      end
     end
 
     -- sort wildcard hosts and uri regexes since those rules

--- a/spec/02-integration/05-proxy/02-router_spec.lua
+++ b/spec/02-integration/05-proxy/02-router_spec.lua
@@ -1448,12 +1448,20 @@ for _, strategy in helpers.each_strategy() do
           {
             strip_path = true,
             methods    = { "GET" },
-            paths      = { "/root" },
+            paths      = { "/unrelated/longer/uri/that/should/not/match", "/root/fixture" },
+            hosts      = { "ahost.test" },
           },
           {
             strip_path = true,
             methods    = { "GET" },
-            paths      = { "/root/fixture" },
+            paths      = { "/root/fixture/get" },
+            hosts      = { "ahost.test" },
+          },
+          {
+            strip_path = true,
+            methods    = { "GET" },
+            paths      = { "/root/fixture/get" },
+            hosts      = { "anotherhost.test" },
           },
         })
       end)
@@ -1468,6 +1476,7 @@ for _, strategy in helpers.each_strategy() do
           path    = "/root/fixture/get",
           headers = {
             ["kong-debug"] = 1,
+            ["host"] = "ahost.test",
           }
         })
 


### PR DESCRIPTION
Unrelated longer paths were messing with the routing priority, so they must be evaluated alone when choosing by the longest path.

Fix #5418
