### PR TITLE
fix(router) detect changes on router/plugins iterator while rebuilding (backported)

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -298,7 +298,7 @@ local function load_declarative_config(kong_config, entities)
     kong.log.notice("declarative config loaded from ",
                     kong_config.declarative_config)
 
-    ok, err = runloop.build_plugins_iterator(utils.uuid())
+    ok, err = runloop.build_plugins_iterator("init")
     if not ok then
       error("error building initial plugins iterator: " .. err)
     end

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -616,6 +616,11 @@ do
   end
 
 
+  local function get_router_version()
+    return kong.cache:get("router:version", TTL_ZERO, utils.uuid)
+  end
+
+
   build_router = function(version)
     local db = kong.db
     local routes, i = {}, 0
@@ -632,9 +637,22 @@ do
       end
     end
 
+    local counter = 0
+    local page_size = constants.DEFAULT_ITERATION_SIZE
     for route, err in db.routes:each() do
       if err then
         return nil, "could not load routes: " .. err
+      end
+
+      if kong.cache and counter > 0 and counter % page_size == 0 then
+        local new_version, err = get_router_version()
+        if err then
+          return nil, "failed to retrieve router version: " .. err
+        end
+
+        if new_version ~= version then
+          return nil, "router was changed while rebuilding it"
+        end
       end
 
       if should_process_route(route) then
@@ -651,6 +669,8 @@ do
         i = i + 1
         routes[i] = r
       end
+
+      counter = counter + 1
     end
 
     local new_router, err = Router.new(routes)
@@ -674,7 +694,7 @@ do
     -- we might not need to rebuild the router (if we were not
     -- the first request in this process to enter this code path)
     -- check again and rebuild only if necessary
-    local version, err = kong.cache:get("router:version", TTL_ZERO, utils.uuid)
+    local version, err = get_router_version()
     if err then
       return nil, "failed to retrieve router version: " .. err
     end


### PR DESCRIPTION
### Summary

There is a slight edge case reported on #5374. I originally tried to propose a fix to this on my original `async rebuilds` work, but when it was refactored, the fix was dropped out.

The issue is that our `routes:each` / `plugins:each` does actually multiple calls to db, each of which can `yield`, thus making it possible for rows to be added / deleted between different pages of data. This will in some cases make our router invalid.

My original fix used recursive rebuilding, but this new will just terminate the rebuild, which means the router / plugins iterator is not updated, and so the previous one will be used. The next async rebuild or request (non-async) will start a new try.

This is a back-port of for `master` branch:
https://github.com/Kong/kong/pull/5429

### Issues

See #5374 (might be a fix)
