### PR TITLE
fix(go) don't try to check members of non-table results

### DIFF
--- a/kong/db/dao/plugins/go.lua
+++ b/kong/db/dao/plugins/go.lua
@@ -245,7 +245,7 @@ do
       return "plugin.StepError", pdk_err
     end
 
-    return ((pdk_res and pdk_res._method)
+    return ((type(pdk_res) == "table" and pdk_res._method)
         or by_pdk_method[step_in.Data.Method]
         or "plugin.Step"), pdk_res
   end


### PR DESCRIPTION
needed for go-pdk functions that return non-indexable values (i.e: numbers)