### PR TITLE
chore(deps) bump lua-resty-openssl to 0.4.3

### DIFF
--- a/kong-1.4.3-0.rockspec
+++ b/kong-1.4.3-0.rockspec
@@ -35,7 +35,7 @@ dependencies = {
   "lua-resty-cookie == 0.1.0",
   "lua-resty-mlcache == 2.4.0",
   "lua-messagepack == 0.5.2",
-  "lua-resty-openssl == 0.4.2",
+  "lua-resty-openssl == 0.4.3",
   "lua-resty-counter == 0.2.0",
   -- external Kong plugins
   "kong-plugin-azure-functions ~> 0.4",


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Fixes a upstream library bug that will behave incorrectly when
certificate has not_after time later than year 2100.

### Full changelog

* Bump lua-resty-openssl to 0.4.3

### Issues resolved

Fix #5446
