### PR TITLE
tests(fixtures) allow custom port in reporter plugin

### DIFF
--- a/spec/fixtures/custom_plugins/kong/plugins/reports-api/api.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/reports-api/api.lua
@@ -1,8 +1,16 @@
 local reports = require "kong.reports"
+local constants = require "kong.constants"
+
 
 return {
   ["/reports/send-ping"] = {
-    POST = function()
+    POST = function(self)
+      -- if a port was passed, patch it in constants.REPORTS so
+      -- that tests can change the default reports port
+      if self.params.port then
+        constants.REPORTS.STATS_PORT = self.params.port
+      end
+
       reports._sync_counter()
       reports.send_ping()
       kong.response.exit(200, { message = "ok" })


### PR DESCRIPTION
Extend the reporter-api fixture plugin so it accepts a custom
stats port. Doing so allows tests to select a random port for
the mock stats server, reducing flakiness.

As an example, the tests for Go plugins reports are updated to
leverage this addition and select a random port for its mock
stats server.
