### PR TITLE
fix(pdk) kong.ctx.plugin.* may be flaky

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -184,7 +184,7 @@ end
 local function execute_plugins_iterator(plugins_iterator, phase, ctx)
   for plugin, configuration in plugins_iterator:iterate(phase, ctx) do
     if ctx then
-      kong_global.set_named_ctx(kong, "plugin", configuration)
+      kong_global.set_named_ctx(kong, "plugin", plugin.handler)
     end
 
     kong_global.set_namespaced_log(kong, plugin.name)
@@ -677,7 +677,7 @@ function Kong.access()
     end
 
     if not ctx.delayed_response then
-      kong_global.set_named_ctx(kong, "plugin", plugin_conf)
+      kong_global.set_named_ctx(kong, "plugin", plugin.handler)
       kong_global.set_namespaced_log(kong, plugin.name)
 
       local err = coroutine.wrap(plugin.handler.access)(plugin.handler, plugin_conf)

--- a/kong/pdk/ctx.lua
+++ b/kong/pdk/ctx.lua
@@ -19,16 +19,16 @@ local _CTX_CORE_KEY = {}
 -- Since only relevant in the context of a request, this table cannot be
 -- accessed from the top-level chunk of Lua modules. Instead, it can only be
 -- accessed in request phases, which are represented by the `rewrite`,
--- `access`, `header_filter`, `body_filter`, and `log` phases of the plugin
--- interfaces.  Accessing this table in those functions (and their callees) is
--- fine.
+-- `access`, `header_filter`, `body_filter`, `log`, and `preread` phases of
+-- the plugin interfaces. Accessing this table in those functions (and their
+-- callees) is fine.
 --
 -- Values inserted in this table by a plugin will be visible by all other
 -- plugins.  One must use caution when interacting with its values, as a naming
 -- conflict could result in the overwrite of data.
 --
 -- @table kong.ctx.shared
--- @phases rewrite, access, header_filter, body_filter, log
+-- @phases rewrite, access, header_filter, body_filter, log, preread
 -- @usage
 -- -- Two plugins A and B, and if plugin A has a higher priority than B's
 -- -- (it executes before B):
@@ -51,28 +51,28 @@ local _CTX_CORE_KEY = {}
 
 ---
 -- A table that has the lifetime of the current request - Unlike
--- `kong.ctx.shared`, this table is **not** shared between plugins.  Instead,
--- it is only visible for the current plugin _instance_. That is, if several
--- instances of the rate-limiting plugin are configured (e.g. on different
--- Services), each instance has its own table, for every request.
+-- `kong.ctx.shared`, this table is **not** shared between plugins. Instead,
+-- it is only visible for the current plugin.
 --
 -- Because of its namespaced nature, this table is safer for a plugin to use
 -- than `kong.ctx.shared` since it avoids potential naming conflicts, which
--- could lead to several plugins unknowingly overwrite each other's data.
+-- could lead to different plugins unknowingly overwrite each other's data.
 --
 -- Since only relevant in the context of a request, this table cannot be
 -- accessed from the top-level chunk of Lua modules. Instead, it can only be
 -- accessed in request phases, which are represented by the `rewrite`,
--- `access`, `header_filter`, `body_filter`, and `log` phases of the plugin
--- interfaces.  Accessing this table in those functions (and their callees) is
--- fine.
+-- `access`, `header_filter`, `body_filter`, `log`, and `preread` phases
+-- of the plugin interfaces. Accessing this table in those functions (and
+-- their callees) is fine.
 --
--- Values inserted in this table by a plugin will be visible in successful
--- phases of this plugin's instance only. For example, if a plugin wants to
--- save some value for post-processing during the `log` phase:
+-- Values inserted in this table by a plugin will be visible in succeeding
+-- phases (please note that the plugin configuration, that is passed to phase
+-- handler function, may change between the phases of the request).
+-- The following example illustrates how a plugin can save a value on access
+-- phase for post-processing on log phase:
 --
 -- @table kong.ctx.plugin
--- @phases rewrite, access, header_filter, body_filter, log
+-- @phases rewrite, access, header_filter, body_filter, log, preread
 -- @usage
 -- -- plugin handler.lua
 --


### PR DESCRIPTION
### Summary

It came to my knowledge that our users have evidenced a following problem:
```
function plugin:access(conf)
  kong.ctx.plugin.key = "value"
  kong.ctx.shared.cfg = tostring(conf)
end

function plugin:header_filter(conf)
  if not kong.ctx.plugin.key then
    -- the bug!
  end

  local cfg2 = tostring(conf)
  if kong.ctx.shared.cfg ~= cfg2 then
    -- also illustrates reason for a bug!
  end
end
```

Before running the plugin (before this PR) we called this:
```
kong_global.set_named_ctx(kong, "plugin", conf)
```

So the `conf` table ended up as a key in `ngx.ctx`, but there are
cases when this `conf` table may change, I believe, between say
`access` and `header_filter` phases. Possible reasons being:

1. new plugin iterator being built between the phases
2. conf table gets cache evicted, and appears again as a new table
3. **plugin config change between phases** (e.g. plugin mapped to `route` changes to a plugin mapped to consumer)

This PR changes the problematic calls to something more stable:
```
kong_global.set_named_ctx(kong, "plugin", plugin.handler)
```

The `handler` should stay the same as long as Kong is running.