### PR TITLE
feat(rate-limiting) remove timer and phase handlers

### DIFF
--- a/spec/03-plugins/23-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/04-access_spec.lua
@@ -32,8 +32,6 @@ end
 
 
 local function GET(url, opts, res_status)
-  ngx.sleep(0.010)
-
   local client = proxy_client()
   local res, err  = client:get(url, opts)
   if not res then


### PR DESCRIPTION
### Summary

Context:

- starting `timers` on busy servers on each request will just move  the load elsewhere
- there is little chance that upstream sets rate-limiting headers, so we can just set them on access

So this PR removes timers and all the phase handlers except `access` from rate-limiting plugin. Yes, it might add some latency to request, but on a bright side we have more accurate rate-limits.

### Issues Resolved

This might fix #5311