### PR TITLE
chore(deps) bump lua-resty-mlcache to 2.4.1

### DIFF
--- a/kong-1.4.3-0.rockspec
+++ b/kong-1.4.3-0.rockspec
@@ -35,7 +35,7 @@ dependencies = {
   "lua-resty-mediador == 0.1.2",
   "lua-resty-healthcheck == 1.1.2",
   "lua-resty-cookie == 0.1.0",
-  "lua-resty-mlcache == 2.4.0",
+  "lua-resty-mlcache == 2.4.1",
   "lua-resty-counter == 0.2.0",
   -- external Kong plugins
   "kong-plugin-azure-functions ~> 0.4",


### PR DESCRIPTION
Fixed:

- The IPC module now avoids replaying all events when spawning new workers, and
  gets initialized with the latest event index instead.
  [#88](https://github.com/thibaultcha/lua-resty-mlcache/pull/88)

Changelog:

https://github.com/thibaultcha/lua-resty-mlcache/blob/master/CHANGELOG.md#241