### PR TITLE
fix(core) Usage of ngx.ERROR instead of ngx.ERR when logging a out of memory

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -94,7 +94,7 @@ do
 
       local ok, err = kong_shm:safe_set("kong:mem:" .. pid(), count)
       if not ok then
-        log(ERROR, "could not record Lua VM allocated memory: ", err)
+        log(ERR, "could not record Lua VM allocated memory: ", err)
       end
 
       last = ngx.time()


### PR DESCRIPTION
### Summary

Trying to run Kong in Docker image with a limited amount of memory, the following error has been raised:
```
2020/01/20 21:44:18 [alert] 27#0: worker process 27129 exited on signal 9
2020/01/20 21:44:18 [error] 27142#0: init_worker_by_lua error: /usr/local/share/lua/5.1/kong/runloop/handler.lua:97: bad argument #1 to 'log' (bad log level: -1)
stack traceback:
[C]: in function 'log'
/usr/local/share/lua/5.1/kong/runloop/handler.lua:97: in function 'update_lua_mem'
/usr/local/share/lua/5.1/kong/runloop/handler.lua:870: in function 'before'
/usr/local/share/lua/5.1/kong/init.lua:565: in function 'init_worker'
init_worker_by_lua:2: in main chunk
2020/01/20 21:44:18 [debug] 27157#0: *99929 [lua] globalpatches.lua:243: randomseed(): seeding PRNG from OpenSSL RAND_bytes()
2020/01/20 21:44:18 [debug] 27157#0: *99929 [lua] globalpatches.lua:269: randomseed(): random seed: 230246231243 for worker nb 20
2020/01/20 21:44:18 [warn] 27157#0: *99929 [lua] globalpatches.lua:275: randomseed(): could not store PRNG seed in kong shm: no memory, context: init_worker_by_lua*
2020/01/20 21:44:18 [notice] 27#0: start worker process 27164
2020/01/20 21:44:18 [error] 27140#0: init_worker_by_lua error: /usr/local/share/lua/5.1/kong/runloop/handler.lua:97: bad argument #1 to 'log' (bad log level: -1)
stack traceback:
[C]: in function 'log'
/usr/local/share/lua/5.1/kong/runloop/handler.lua:97: in function 'update_lua_mem'
/usr/local/share/lua/5.1/kong/runloop/handler.lua:870: in function 'before'
/usr/local/share/lua/5.1/kong/init.lua:565: in function 'init_worker'
init_worker_by_lua:2: in main chunk
2020/01/20 21:44:18 [debug] 27161#0: *99930 [lua] globalpatches.lua:243: randomseed(): seeding PRNG from OpenSSL RAND_bytes()
2020/01/20 21:44:18 [debug] 27161#0: *99930 [lua] globalpatches.lua:269: randomseed(): random seed: 819113871502 for worker nb 4
```
Indeed, Kong was about to write a log mentioning the out of memory (here: https://github.com/Kong/kong/blob/master/kong/runloop/handler.lua#L97)... but the `ngx.ERROR` is used instead of the `ngx.ERR`, thus generating the stack trace above!

### Full changelog

* Replace `ngx.ERROR` with `ngx.ERR` in https://github.com/Kong/kong/blob/master/kong/runloop/handler.lua#L97

### Issues resolved

