### PR TITLE
chore(tests) remove api related code

### DIFF
--- a/spec/02-integration/01-helpers/02-blueprints_spec.lua
+++ b/spec/02-integration/01-helpers/02-blueprints_spec.lua
@@ -84,14 +84,6 @@ for _, strategy in helpers.each_strategy() do
   end)
 
   describe(string.format("blueprints for #%s", strategy), function()
-    pending("inserts apis", function()
-      -- TODO: remove this test when APIs are removed
-      local a = bp.apis:insert({ hosts = { "localhost" } })
-      assert.matches(UUID_PATTERN, a.id)
-      assert.equal("number", type(a.created_at))
-      assert.equal(helpers.mock_upstream_url, a.upstream_url)
-    end)
-
     it("inserts oauth2 plugins", function()
       local s = bp.services:insert()
       local p = bp.oauth2_plugins:insert({ service = { id = s.id } })

--- a/spec/02-integration/05-proxy/04-plugins_triggering_spec.lua
+++ b/spec/02-integration/05-proxy/04-plugins_triggering_spec.lua
@@ -18,7 +18,6 @@ for _, strategy in helpers.each_strategy() do
 
     lazy_setup(function()
       bp, db = helpers.get_db_utils(strategy, {
-        "apis",
         "routes",
         "services",
         "plugins",

--- a/spec/02-integration/05-proxy/11-handler_spec.lua
+++ b/spec/02-integration/05-proxy/11-handler_spec.lua
@@ -9,7 +9,6 @@ for _, strategy in helpers.each_strategy() do
 
         lazy_setup(function()
           local bp = helpers.get_db_utils(strategy, {
-            "apis",
             "routes",
             "services",
             "plugins",
@@ -67,7 +66,6 @@ for _, strategy in helpers.each_strategy() do
 
         lazy_setup(function()
           local bp = helpers.get_db_utils(strategy, {
-            "apis",
             "routes",
             "services",
             "plugins",
@@ -125,7 +123,6 @@ for _, strategy in helpers.each_strategy() do
 
         lazy_setup(function()
           local bp = helpers.get_db_utils(strategy, {
-            "apis",
             "routes",
             "services",
             "plugins",

--- a/spec/02-integration/06-invalidations/03-plugins_iterator_invalidation_spec.lua
+++ b/spec/02-integration/06-invalidations/03-plugins_iterator_invalidation_spec.lua
@@ -54,7 +54,6 @@ for _, strategy in helpers.each_strategy() do
 
     lazy_setup(function()
       local bp = helpers.get_db_utils(strategy, {
-        "apis",
         "routes",
         "services",
         "plugins",

--- a/spec/02-integration/07-sdk/01-ctx_spec.lua
+++ b/spec/02-integration/07-sdk/01-ctx_spec.lua
@@ -7,7 +7,6 @@ describe("SDK: kong.ctx", function()
 
   before_each(function()
     bp, db = helpers.get_db_utils(nil, {
-      "apis",
       "routes",
       "plugins",
     }, {

--- a/spec/02-integration/07-sdk/02-log_spec.lua
+++ b/spec/02-integration/07-sdk/02-log_spec.lua
@@ -23,7 +23,6 @@ describe("SDK: kong.log", function()
 
   before_each(function()
     bp, db = helpers.get_db_utils(nil, {
-      "apis",
       "routes",
       "services",
       "plugins",


### PR DESCRIPTION
### Summary

Some `APIs` related code was still found on our test suite. This PR removes that. APIs were removed on Kong 1.0.