### PR TITLE
chore(log plugins) make log plugins use pdk especially kong.log

### DIFF
--- a/kong/plugins/file-log/handler.lua
+++ b/kong/plugins/file-log/handler.lua
@@ -64,11 +64,10 @@ local function log(conf, message)
 end
 
 
-local FileLogHandler = {}
-
-
-FileLogHandler.PRIORITY = 9
-FileLogHandler.VERSION = "2.0.2"
+local FileLogHandler = {
+  PRIORITY = 9,
+  VERSION = "2.0.2",
+}
 
 
 function FileLogHandler:log(conf)

--- a/kong/plugins/file-log/handler.lua
+++ b/kong/plugins/file-log/handler.lua
@@ -2,7 +2,12 @@
 local ffi = require "ffi"
 local cjson = require "cjson"
 local system_constants = require "lua_system_constants"
-local basic_serializer = require "kong.plugins.log-serializers.basic"
+local serializer = require "kong.plugins.log-serializers.basic"
+
+
+local kong = kong
+local ngx = ngx
+
 
 local O_CREAT = system_constants.O_CREAT()
 local O_WRONLY = system_constants.O_WRONLY()
@@ -12,16 +17,18 @@ local S_IWUSR = system_constants.S_IWUSR()
 local S_IRGRP = system_constants.S_IRGRP()
 local S_IROTH = system_constants.S_IROTH()
 
-local oflags = bit.bor(O_WRONLY, O_CREAT, O_APPEND)
 
+local oflags = bit.bor(O_WRONLY, O_CREAT, O_APPEND)
 local mode = bit.bor(S_IRUSR, S_IWUSR, S_IRGRP, S_IROTH)
 
-local C = ffi.C
-local serialize = basic_serializer.serialize
 
-ffi.cdef[[
+local C = ffi.C
+
+
+ffi.cdef [[
 int write(int fd, const void * ptr, int numbytes);
 ]]
+
 
 -- fd tracking utility functions
 local file_descriptors = {}
@@ -32,7 +39,6 @@ local file_descriptors = {}
 -- @param `message`  Message to be logged
 local function log(conf, message)
   local msg = cjson.encode(message) .. "\n"
-
   local fd = file_descriptors[conf.path]
 
   if fd and conf.reopen then
@@ -47,7 +53,8 @@ local function log(conf, message)
     fd = C.open(conf.path, oflags, mode)
     if fd < 0 then
       local errno = ffi.errno()
-      ngx.log(ngx.ERR, "[file-log] failed to open the file: ", ffi.string(C.strerror(errno)))
+      kong.log.err("failed to open the file: ", ffi.string(C.strerror(errno)))
+
     else
       file_descriptors[conf.path] = fd
     end
@@ -56,15 +63,18 @@ local function log(conf, message)
   C.write(fd, msg, #msg)
 end
 
+
 local FileLogHandler = {}
 
+
 FileLogHandler.PRIORITY = 9
-FileLogHandler.VERSION = "2.0.1"
+FileLogHandler.VERSION = "2.0.2"
+
 
 function FileLogHandler:log(conf)
-  local message = serialize(ngx)
-
+  local message = serializer.serialize(ngx)
   log(conf, message)
 end
+
 
 return FileLogHandler

--- a/kong/plugins/http-log/handler.lua
+++ b/kong/plugins/http-log/handler.lua
@@ -1,25 +1,20 @@
-local basic_serializer = require "kong.plugins.log-serializers.basic"
+local serializer = require "kong.plugins.log-serializers.basic"
 local BatchQueue = require "kong.tools.batch_queue"
 local cjson = require "cjson"
 local url = require "socket.url"
 local http = require "resty.http"
 
 
-local cjson_encode = cjson.encode
-local ngx_encode_base64 = ngx.encode_base64
-local table_concat = table.concat
+local kong = kong
+local ngx = ngx
+local encode_base64 = ngx.encode_base64
+local tostring = tostring
+local tonumber = tonumber
+local concat = table.concat
 local fmt = string.format
 
 
-local HttpLogHandler = {}
-
-
-HttpLogHandler.PRIORITY = 12
-HttpLogHandler.VERSION = "2.0.0"
-
-
 local queues = {} -- one queue per unique plugin config
-
 local parsed_urls_cache = {}
 
 
@@ -91,7 +86,7 @@ local function send_payload(self, conf, payload)
       ["Content-Type"] = content_type,
       ["Content-Length"] = #payload,
       ["Authorization"] = parsed_url.userinfo and (
-        "Basic " .. ngx_encode_base64(parsed_url.userinfo)
+        "Basic " .. encode_base64(parsed_url.userinfo)
       ),
     },
     body = payload,
@@ -123,7 +118,7 @@ end
 
 
 local function json_array_concat(entries)
-  return "[" .. table_concat(entries, ",") .. "]"
+  return "[" .. concat(entries, ",") .. "]"
 end
 
 
@@ -140,8 +135,14 @@ local function get_queue_id(conf)
 end
 
 
+local HttpLogHandler = {
+  PRIORITY = 12,
+  VERSION = "2.0.1",
+}
+
+
 function HttpLogHandler:log(conf)
-  local entry = cjson_encode(basic_serializer.serialize(ngx))
+  local entry = cjson.encode(serializer.serialize(ngx))
 
   local queue_id = get_queue_id(conf)
   local q = queues[queue_id]
@@ -173,5 +174,6 @@ function HttpLogHandler:log(conf)
 
   q:add(entry)
 end
+
 
 return HttpLogHandler

--- a/kong/plugins/loggly/handler.lua
+++ b/kong/plugins/loggly/handler.lua
@@ -1,30 +1,28 @@
-local basic_serializer = require "kong.plugins.log-serializers.basic"
+local serializer = require "kong.plugins.log-serializers.basic"
 local cjson = require "cjson"
 
-local LogglyLogHandler = {}
 
-LogglyLogHandler.PRIORITY = 6
-LogglyLogHandler.VERSION = "2.0.0"
-
-local os_date = os.date
+local kong = kong
+local ngx = ngx
+local date = os.date
 local tostring = tostring
-local ngx_log = ngx.log
-local ngx_timer_at = ngx.timer.at
-local ngx_socket_udp = ngx.socket.udp
-local table_concat = table.concat
-local table_insert = table.insert
+local timer_at = ngx.timer.at
+local udp = ngx.socket.udp
+local concat = table.concat
+local insert = table.insert
 
-local function getHostname()
-  local f = io.popen ("/bin/hostname")
+
+local function get_host_name()
+  local f = io.popen("/bin/hostname")
   local hostname = f:read("*a") or ""
   f:close()
   hostname = string.gsub(hostname, "\n$", "")
   return hostname
 end
 
-local HOSTNAME = getHostname()
-local SENDER_NAME = "kong"
 
+local HOSTNAME = get_host_name()
+local SENDER_NAME = "kong"
 local LOG_LEVELS = {
   debug = 7,
   info = 6,
@@ -36,56 +34,65 @@ local LOG_LEVELS = {
   emerg = 0
 }
 
+
 local function merge(conf, message, pri)
   local tags_list = conf.tags
   local tags = {}
   for i = 1, #tags_list do
-    table_insert(tags, "tag=" .. "\"" .. tags_list[i] .. "\"")
+    insert(tags, "tag=" .. '"' .. tags_list[i] .. '"')
   end
 
   local udp_message = {
     "<" .. pri .. ">1",
-    os_date("!%Y-%m-%dT%XZ"),
+    date("!%Y-%m-%dT%XZ"),
     HOSTNAME,
     SENDER_NAME,
     "-",
     "-",
-    "[" .. conf.key .. "@41058", table_concat(tags, " ") .. "]",
+    "[" .. conf.key .. "@41058", concat(tags, " ") .. "]",
     cjson.encode(message)
   }
-  return table_concat(udp_message, " ")
+
+  return concat(udp_message, " ")
 end
+
 
 local function send_to_loggly(conf, message, pri)
   local host = conf.host
   local port = conf.port
   local timeout = conf.timeout
+
   local udp_message = merge(conf, message, pri)
-  local sock = ngx_socket_udp()
+
+  local sock = udp()
+
   sock:settimeout(timeout)
 
   local ok, err = sock:setpeername(host, port)
   if not ok then
-    ngx_log(ngx.ERR, "failed to connect to " .. host .. ":" .. tostring(port) .. ": ", err)
+    kong.log.err("failed to connect to ", host, ":", tostring(port), ": ", err)
     return
   end
+
   local ok, err = sock:send(udp_message)
   if not ok then
-    ngx_log(ngx.ERR, "failed to send data to " .. host .. ":" .. tostring(port) .. ": ", err)
+    kong.log.err("failed to send data to ", host, ":", tostring(port), ": ", err)
   end
 
   local ok, err = sock:close()
   if not ok then
-    ngx_log(ngx.ERR, "failed to close connection from " .. host .. ":" .. tostring(port) .. ": ", err)
+    kong.log.err("failed to close connection from ", host, ":", tostring(port), ": ", err)
     return
   end
 end
 
 local function decide_severity(conf, severity, message)
-  if LOG_LEVELS[severity] <= LOG_LEVELS[conf.log_level] then
-    local pri = 8 + LOG_LEVELS[severity]
-    return send_to_loggly(conf, message, pri)
+  if LOG_LEVELS[severity] > LOG_LEVELS[conf.log_level] then
+    return
   end
+
+  local pri = 8 + LOG_LEVELS[severity]
+  return send_to_loggly(conf, message, pri)
 end
 
 local function log(premature, conf, message)
@@ -95,20 +102,30 @@ local function log(premature, conf, message)
 
   if message.response.status >= 500 then
     return decide_severity(conf, conf.server_errors_severity, message)
-  elseif message.response.status >= 400 then
-    return decide_severity(conf, conf.client_errors_severity, message)
-  else
-    return decide_severity(conf, conf.successful_severity, message)
   end
+
+  if message.response.status >= 400 then
+    return decide_severity(conf, conf.client_errors_severity, message)
+  end
+
+  return decide_severity(conf, conf.successful_severity, message)
 end
+
+
+local LogglyLogHandler = {
+  PRIORITY = 6,
+  VERSION = "2.0.1",
+}
+
 
 function LogglyLogHandler:log(conf)
-  local message = basic_serializer.serialize(ngx)
+  local message = serializer.serialize(ngx)
 
-  local ok, err = ngx_timer_at(0, log, conf, message)
+  local ok, err = timer_at(0, log, conf, message)
   if not ok then
-    ngx_log(ngx.ERR, "failed to create timer: ", err)
+    kong.log.err("failed to create timer: ", err)
   end
 end
+
 
 return LogglyLogHandler

--- a/kong/plugins/statsd/handler.lua
+++ b/kong/plugins/statsd/handler.lua
@@ -1,28 +1,23 @@
-local basic_serializer = require "kong.plugins.log-serializers.basic"
-local statsd_logger    = require "kong.plugins.statsd.statsd_logger"
+local serializer    = require "kong.plugins.log-serializers.basic"
+local statsd_logger = require "kong.plugins.statsd.statsd_logger"
 
 
-local ngx_log       = ngx.log
-local ngx_timer_at  = ngx.timer.at
-local string_gsub   = string.gsub
-local pairs         = pairs
-local string_format = string.format
-local NGX_ERR       = ngx.ERR
-
-
-local StatsdHandler = {}
-StatsdHandler.PRIORITY = 11
-StatsdHandler.VERSION = "2.0.0"
+local kong     = kong
+local ngx      = ngx
+local timer_at = ngx.timer.at
+local pairs    = pairs
+local gsub     = string.gsub
+local fmt      = string.format
 
 
 local get_consumer_id = {
   consumer_id = function(consumer)
-    return consumer and string_gsub(consumer.id, "-", "_")
+    return consumer and gsub(consumer.id, "-", "_")
   end,
-  custom_id   = function(consumer)
+  custom_id = function(consumer)
     return consumer and consumer.custom_id
   end,
-  username    = function(consumer)
+  username = function(consumer)
     return consumer and consumer.username
   end
 }
@@ -30,13 +25,13 @@ local get_consumer_id = {
 
 local metrics = {
   status_count = function (service_name, message, metric_config, logger)
-    local fmt = string_format("%s.request.status", service_name,
+    local format = fmt("%s.request.status", service_name,
                        message.response.status)
 
-    logger:send_statsd(string_format("%s.%s", fmt, message.response.status),
+    logger:send_statsd(fmt("%s.%s", format, message.response.status),
                        1, logger.stat_types.counter, metric_config.sample_rate)
 
-    logger:send_statsd(string_format("%s.%s", fmt, "total"), 1,
+    logger:send_statsd(fmt("%s.%s", format, "total"), 1,
                        logger.stat_types.counter, metric_config.sample_rate)
   end,
   unique_users = function (service_name, message, metric_config, logger)
@@ -44,7 +39,7 @@ local metrics = {
     local consumer_id     = get_consumer_id(message.consumer)
 
     if consumer_id then
-      local stat = string_format("%s.user.uniques", service_name)
+      local stat = fmt("%s.user.uniques", service_name)
 
       logger:send_statsd(stat, consumer_id, logger.stat_types.set)
     end
@@ -54,7 +49,7 @@ local metrics = {
     local consumer_id     = get_consumer_id(message.consumer)
 
     if consumer_id then
-      local stat = string_format("%s.user.%s.request.count", service_name, consumer_id)
+      local stat = fmt("%s.user.%s.request.count", service_name, consumer_id)
 
       logger:send_statsd(stat, 1, logger.stat_types.counter,
                          metric_config.sample_rate)
@@ -65,13 +60,13 @@ local metrics = {
     local consumer_id     = get_consumer_id(message.consumer)
 
     if consumer_id then
-      local fmt = string_format("%s.user.%s.request.status", service_name, consumer_id)
+      local format = fmt("%s.user.%s.request.status", service_name, consumer_id)
 
-      logger:send_statsd(string_format("%s.%s", fmt, message.response.status),
+      logger:send_statsd(fmt("%s.%s", format, message.response.status),
                          1, logger.stat_types.counter,
                          metric_config.sample_rate)
 
-      logger:send_statsd(string_format("%s.%s", fmt,  "total"),
+      logger:send_statsd(fmt("%s.%s", format,  "total"),
                          1, logger.stat_types.counter,
                          metric_config.sample_rate)
     end
@@ -84,9 +79,9 @@ local function log(premature, conf, message)
     return
   end
 
-  local name = string_gsub(message.service.name ~= ngx.null and
-                           message.service.name or message.service.host,
-                           "%.", "_")
+  local name = gsub(message.service.name ~= ngx.null and
+                    message.service.name or message.service.host,
+                    "%.", "_")
 
   local stat_name  = {
     request_size     = name .. ".request.size",
@@ -107,7 +102,7 @@ local function log(premature, conf, message)
 
   local logger, err = statsd_logger:new(conf)
   if err then
-    ngx_log(NGX_ERR, "failed to create Statsd logger: ", err)
+    kong.log.err("failed to create Statsd logger: ", err)
     return
   end
 
@@ -131,16 +126,22 @@ local function log(premature, conf, message)
 end
 
 
+local StatsdHandler = {
+  PRIORITY = 11,
+  VERSION = "2.0.1",
+}
+
+
 function StatsdHandler:log(conf)
   if not ngx.ctx.service then
     return
   end
 
-  local message = basic_serializer.serialize(ngx)
+  local message = serializer.serialize(ngx)
 
-  local ok, err = ngx_timer_at(0, log, conf, message)
+  local ok, err = timer_at(0, log, conf, message)
   if not ok then
-    ngx_log(NGX_ERR, "failed to create timer: ", err)
+    kong.log.err("failed to create timer: ", err)
   end
 end
 

--- a/kong/plugins/syslog/handler.lua
+++ b/kong/plugins/syslog/handler.lua
@@ -1,20 +1,15 @@
 local lsyslog = require "lsyslog"
 local cjson = require "cjson"
-local basic_serializer = require "kong.plugins.log-serializers.basic"
-local ngx_log = ngx.log
-local ngx_timer_at = ngx.timer.at
-local l_open = lsyslog.open
-local l_log = lsyslog.log
-local string_upper = string.upper
+local serializer = require "kong.plugins.log-serializers.basic"
 
 
-local SysLogHandler = {}
+local kong = kong
+local ngx = ngx
+local timer_at = ngx.timer.at
+local upper = string.upper
 
-SysLogHandler.PRIORITY = 4
-SysLogHandler.VERSION = "2.0.0"
 
 local SENDER_NAME = "kong"
-
 local LOG_LEVELS = {
   debug = 7,
   info = 6,
@@ -26,12 +21,14 @@ local LOG_LEVELS = {
   emerg = 0
 }
 
+
 local function send_to_syslog(log_level, severity, message)
   if LOG_LEVELS[severity] <= LOG_LEVELS[log_level] then
-    l_open(SENDER_NAME, lsyslog.FACILITY_USER)
-    l_log(lsyslog["LOG_" .. string_upper(severity)], cjson.encode(message))
+    lsyslog.open(SENDER_NAME, lsyslog.FACILITY_USER)
+    lsyslog.log(lsyslog["LOG_" .. upper(severity)], cjson.encode(message))
   end
 end
+
 
 local function log(premature, conf, message)
   if premature then
@@ -40,19 +37,29 @@ local function log(premature, conf, message)
 
   if message.response.status >= 500 then
     send_to_syslog(conf.log_level, conf.server_errors_severity, message)
+
   elseif message.response.status >= 400 then
     send_to_syslog(conf.log_level, conf.client_errors_severity, message)
+
   else
     send_to_syslog(conf.log_level, conf.successful_severity, message)
   end
 end
 
+
+local SysLogHandler = {
+  PRIORITY = 4,
+  VERSION = "2.0.1",
+}
+
+
 function SysLogHandler:log(conf)
-  local message = basic_serializer.serialize(ngx)
-  local ok, err = ngx_timer_at(0, log, conf, message)
+  local message = serializer.serialize(ngx)
+  local ok, err = timer_at(0, log, conf, message)
   if not ok then
-    ngx_log(ngx.ERR, "failed to create timer: ", err)
+    kong.log.err("failed to create timer: ", err)
   end
 end
+
 
 return SysLogHandler

--- a/kong/plugins/tcp-log/handler.lua
+++ b/kong/plugins/tcp-log/handler.lua
@@ -1,17 +1,17 @@
-local basic_serializer = require "kong.plugins.log-serializers.basic"
+local serializer = require "kong.plugins.log-serializers.basic"
 local cjson = require "cjson"
 
-local TcpLogHandler = {}
 
-TcpLogHandler.PRIORITY = 7
-TcpLogHandler.VERSION = "2.0.0"
+local kong = kong
+local ngx = ngx
+local timer_at = ngx.timer.at
+
 
 local function log(premature, conf, message)
   if premature then
     return
   end
 
-  local ok, err
   local host = conf.host
   local port = conf.port
   local timeout = conf.timeout
@@ -20,39 +20,46 @@ local function log(premature, conf, message)
   local sock = ngx.socket.tcp()
   sock:settimeout(timeout)
 
-  ok, err = sock:connect(host, port)
+  local ok, err = sock:connect(host, port)
   if not ok then
-    ngx.log(ngx.ERR, "[tcp-log] failed to connect to " .. host .. ":" .. tostring(port) .. ": ", err)
+    kong.log.err("failed to connect to ", host, ":", tostring(port), ": ", err)
     return
   end
 
   if conf.tls then
     ok, err = sock:sslhandshake(true, conf.tls_sni, false)
     if not ok then
-      ngx.log(ngx.ERR, "[tcp-log] failed to perform TLS handshake to ",
-                       host, ":", port, ": ", err)
+      kong.log.err("failed to perform TLS handshake to ", host, ":", port, ": ", err)
       return
     end
   end
 
   ok, err = sock:send(cjson.encode(message) .. "\n")
   if not ok then
-    ngx.log(ngx.ERR, "[tcp-log] failed to send data to " .. host .. ":" .. tostring(port) .. ": ", err)
+    kong.log.err("failed to send data to ", host, ":", tostring(port), ": ", err)
   end
 
   ok, err = sock:setkeepalive(keepalive)
   if not ok then
-    ngx.log(ngx.ERR, "[tcp-log] failed to keepalive to " .. host .. ":" .. tostring(port) .. ": ", err)
+    kong.log.err("failed to keepalive to ", host, ":", tostring(port), ": ", err)
     return
   end
 end
 
+
+local TcpLogHandler = {
+  PRIORITY = 7,
+  VERSION = "2.0.1",
+}
+
+
 function TcpLogHandler:log(conf)
-  local message = basic_serializer.serialize(ngx)
-  local ok, err = ngx.timer.at(0, log, conf, message)
+  local message = serializer.serialize(ngx)
+  local ok, err = timer_at(0, log, conf, message)
   if not ok then
-    ngx.log(ngx.ERR, "[tcp-log] failed to create timer: ", err)
+    kong.log.err("failed to create timer: ", err)
   end
 end
+
 
 return TcpLogHandler

--- a/kong/plugins/udp-log/handler.lua
+++ b/kong/plugins/udp-log/handler.lua
@@ -1,13 +1,12 @@
 local serializer = require "kong.plugins.log-serializers.basic"
 local cjson = require "cjson"
 
+
+local kong = kong
+local ngx = ngx
 local timer_at = ngx.timer.at
 local udp = ngx.socket.udp
 
-local UdpLogHandler = {}
-
-UdpLogHandler.PRIORITY = 8
-UdpLogHandler.VERSION = "2.0.0"
 
 local function log(premature, conf, str)
   if premature then
@@ -19,28 +18,37 @@ local function log(premature, conf, str)
 
   local ok, err = sock:setpeername(conf.host, conf.port)
   if not ok then
-    ngx.log(ngx.ERR, "[udp-log] could not connect to ", conf.host, ":", conf.port, ": ", err)
+    kong.log.err("could not connect to ", conf.host, ":", conf.port, ": ", err)
     return
   end
 
   ok, err = sock:send(str)
   if not ok then
-    ngx.log(ngx.ERR, " [udp-log] could not send data to ", conf.host, ":", conf.port, ": ", err)
+    kong.log.err("could not send data to ", conf.host, ":", conf.port, ": ", err)
+
   else
-    ngx.log(ngx.DEBUG, "[udp-log] sent: ", str)
+    kong.log.debug("sent: ", str)
   end
 
   ok, err = sock:close()
   if not ok then
-    ngx.log(ngx.ERR, "[udp-log] could not close ", conf.host, ":", conf.port, ": ", err)
+    kong.log.err("could not close ", conf.host, ":", conf.port, ": ", err)
   end
 end
+
+
+local UdpLogHandler = {
+  PRIORITY = 8,
+  VERSION = "2.0.1",
+}
+
 
 function UdpLogHandler:log(conf)
   local ok, err = timer_at(0, log, conf, cjson.encode(serializer.serialize(ngx)))
   if not ok then
-    ngx.log(ngx.ERR, "[udp-log] could not create timer: ", err)
+    kong.log.err("could not create timer: ", err)
   end
 end
+
 
 return UdpLogHandler


### PR DESCRIPTION
### Summary

Just some choring to make our log plugins use more PDK niceness (especially replaces `ngx.log` with `kong.log`). And while doing so, I changed the code to be more similar across log plugins, and updated a style to match more our current.