### PR TITLE
chore(proxy-cache) bump plugin from 1.2 to 1.3

### DIFF
--- a/kong-2.0.0-0.rockspec
+++ b/kong-2.0.0-0.rockspec
@@ -42,7 +42,7 @@ dependencies = {
   "kong-plugin-zipkin ~> 0.2",
   "kong-plugin-serverless-functions ~> 0.3",
   "kong-prometheus-plugin ~> 0.7",
-  "kong-proxy-cache-plugin ~> 1.2",
+  "kong-proxy-cache-plugin ~> 1.3",
   "kong-plugin-request-transformer ~> 1.2",
   "kong-plugin-session ~> 2.2",
   "kong-plugin-aws-lambda ~> 3.1",


### PR DESCRIPTION
### Summary

Proxy cache changelog:

- remove api related code from the plugin
- use kong pdk and localize vars
- fix https://github.com/Kong/kong-plugin-proxy-cache/pull/17
- close https://github.com/Kong/kong-plugin-proxy-cache/pull/18