### PR TITLE
fix(ldap-auth) credential rate-limiting and hashing of cache key

### DIFF
--- a/kong/plugins/ldap-auth/handler.lua
+++ b/kong/plugins/ldap-auth/handler.lua
@@ -10,7 +10,7 @@ end
 
 
 LdapAuthHandler.PRIORITY = 1002
-LdapAuthHandler.VERSION = "2.0.0"
+LdapAuthHandler.VERSION = "2.0.1"
 
 
 return LdapAuthHandler

--- a/kong/plugins/ldap-auth/handler.lua
+++ b/kong/plugins/ldap-auth/handler.lua
@@ -10,7 +10,7 @@ end
 
 
 LdapAuthHandler.PRIORITY = 1002
-LdapAuthHandler.VERSION = "2.0.1"
+LdapAuthHandler.VERSION = "2.1.0"
 
 
 return LdapAuthHandler

--- a/spec/03-plugins/20-ldap-auth/02-invalidations_spec.lua
+++ b/spec/03-plugins/20-ldap-auth/02-invalidations_spec.lua
@@ -1,7 +1,8 @@
 local helpers = require "spec.helpers"
 local fmt = string.format
 local lower = string.lower
-local md5 = ngx.md5
+local sha1_bin = ngx.sha1_bin
+local to_hex = require "resty.string".to_hex
 
 local ldap_host_aws = "ec2-54-172-82-117.compute-1.amazonaws.com"
 
@@ -17,18 +18,18 @@ for _, ldap_strategy in pairs(ldap_strategies) do
         local admin_client
         local proxy_client
         local plugin
-    
+
         lazy_setup(function()
           local bp = helpers.get_db_utils(strategy, {
             "routes",
             "services",
             "plugins",
           })
-    
+
           local route = bp.routes:insert {
             hosts = { "ldapauth.com" },
           }
-    
+
           plugin = bp.plugins:insert {
             route = { id = route.id },
             name     = "ldap-auth",
@@ -41,18 +42,18 @@ for _, ldap_strategy in pairs(ldap_strategies) do
               cache_ttl = 1,
             }
           }
-    
+
           assert(helpers.start_kong({
             database   = strategy,
             nginx_conf = "spec/fixtures/custom_nginx.template",
           }))
         end)
-    
+
         before_each(function()
           admin_client = helpers.admin_client()
           proxy_client = helpers.proxy_client()
         end)
-    
+
         after_each(function()
           if admin_client then
             admin_client:close()
@@ -61,24 +62,24 @@ for _, ldap_strategy in pairs(ldap_strategies) do
             proxy_client:close()
           end
         end)
-    
+
         lazy_teardown(function()
           helpers.stop_kong(nil, true)
         end)
-    
+
         local function cache_key(conf, username, password)
-            local ldap_config_cache = md5(fmt("%s:%u:%s:%s:%u",
-              lower(conf.ldap_host),
-              conf.ldap_port,
-              conf.base_dn,
-              conf.attribute,
-              conf.cache_ttl
-            ))
-    
-          return fmt("ldap_auth_cache:%s:%s:%s", ldap_config_cache,
-                     username, password)
+          local hash = to_hex(sha1_bin(fmt("%s:%u:%s:%s:%u:%s:%s",
+                                           lower(conf.ldap_host),
+                                           conf.ldap_port,
+                                           conf.base_dn,
+                                           conf.attribute,
+                                           conf.cache_ttl,
+                                           username,
+                                           password)))
+
+          return "ldap_auth_cache:" .. hash
         end
-    
+
         describe("authenticated LDAP user get cached", function()
           it("should cache invalid credential", function()
             local res = assert(proxy_client:send {
@@ -91,7 +92,7 @@ for _, ldap_strategy in pairs(ldap_strategies) do
               }
             })
             assert.res_status(401, res)
-    
+
             local cache_key = cache_key(plugin.config, "einstein", "wrongpassword")
             res = assert(admin_client:send {
               method = "GET",
@@ -102,7 +103,7 @@ for _, ldap_strategy in pairs(ldap_strategies) do
           end)
           it("should invalidate negative cache once ttl expires", function()
             local cache_key = cache_key(plugin.config, "einstein", "wrongpassword")
-    
+
             helpers.wait_until(function()
               local res = assert(admin_client:send {
                 method = "GET",
@@ -125,9 +126,10 @@ for _, ldap_strategy in pairs(ldap_strategies) do
               }
             })
             assert.res_status(200, res)
-    
+
             -- Check that cache is populated
             local cache_key = cache_key(plugin.config, "einstein", "password")
+
             res = assert(admin_client:send {
               method = "GET",
               path   = "/cache/" .. cache_key,
@@ -137,7 +139,7 @@ for _, ldap_strategy in pairs(ldap_strategies) do
           end)
           it("should invalidate cache once ttl expires", function()
             local cache_key = cache_key(plugin.config, "einstein", "password")
-    
+
             helpers.wait_until(function()
               local res = assert(admin_client:send {
                 method = "GET",


### PR DESCRIPTION
### Summary

#### fix(ldap-auth) credential to have id for rate-limiting

Currently `ldap-auth` does set virtual credential in context on authentication, but that virtual credential does not have `id` which means that rate-limiting plugin cannot rate-limit by the credential, and thus fall-backs to rate-limit by ip.

This commit adds `cache_key` as id for that virtual credential.

#### fix(ldap-auth) hash cache key

Currently `ldap-auth` does seem to use `username` and `password` in a `cache_key` in plain. This is potentially dangerous and may be leaked through it to different places:

- memory
- admin api
  - logs

This commit fixes that by calling `sha1_bin` on that when generating a cache key. It also drops the use of `md5`.

### Issues resolved

Fix #4129