### PR TITLE
chore(deps) update dns client to 4.1.3

### DIFF
--- a/kong-2.0.0-0.rockspec
+++ b/kong-2.0.0-0.rockspec
@@ -28,7 +28,7 @@ dependencies = {
   "lua-resty-iputils == 0.3.0",
   "luasyslog == 1.0.0",
   "lua_pack == 1.0.5",
-  "lua-resty-dns-client == 4.1.2",
+  "lua-resty-dns-client == 4.1.3",
   "lua-resty-worker-events == 1.0.0",
   "lua-resty-mediador == 0.1.2",
   "lua-resty-healthcheck == 1.1.2",


### PR DESCRIPTION
fixes #5477 ,  issues with DNS records having `ttl=0`.

See https://github.com/Kong/lua-resty-dns-client/pull/83 for details