### PR TITLE
fix(oauth2) hash cache key

### DIFF
--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -15,6 +15,8 @@ local check_https = utils.check_https
 local encode_args = utils.encode_args
 local random_string = utils.random_string
 local table_contains = utils.table_contains
+local sha1_bin = ngx.sha1_bin
+local to_hex = require "resty.string".to_hex
 
 
 local ngx_decode_args = ngx.decode_args
@@ -605,7 +607,8 @@ local function retrieve_token(conf, access_token)
   local token, err
 
   if access_token then
-    local token_cache_key = kong.db.oauth2_tokens:cache_key(access_token)
+    local token_hash = to_hex(sha1_bin(access_token))
+    local token_cache_key = kong.db.oauth2_tokens:cache_key(token_hash)
     token, err = kong.cache:get(token_cache_key, nil,
                                 load_token, conf,
                                 kong.router.get_service(),

--- a/kong/plugins/oauth2/daos.lua
+++ b/kong/plugins/oauth2/daos.lua
@@ -62,7 +62,6 @@ local oauth2_tokens = {
   primary_key = { "id" },
   name = "oauth2_tokens",
   endpoint_key = "access_token",
-  cache_key = { "access_token" },
   ttl = true,
   fields = {
     { id = typedefs.uuid },

--- a/kong/plugins/oauth2/handler.lua
+++ b/kong/plugins/oauth2/handler.lua
@@ -1,12 +1,43 @@
 local access = require "kong.plugins.oauth2.access"
 
-local OAuthHandler = {}
+
+local kong = kong
+local type = type
+local sha1_bin = ngx.sha1_bin
+local to_hex = require "resty.string".to_hex
+
+
+local function invalidate(entity)
+  if not entity or type(entity.access_token) ~= "string" then
+    return
+  end
+
+  local token_hash = to_hex(sha1_bin(entity.access_token))
+  local cache_key = kong.db.oauth2_tokens:cache_key(token_hash)
+  kong.cache:invalidate_local(cache_key)
+end
+
+
+local OAuthHandler = {
+  PRIORITY = 1004,
+  VERSION = "2.0.1",
+}
+
+
+function OAuthHandler:init_worker()
+  kong.worker_events.register(function(data)
+    invalidate(data.old_entity)
+  end, "crud", "oauth2_tokens:update")
+
+  kong.worker_events.register(function(data)
+    invalidate(data.entity)
+  end, "crud", "oauth2_tokens:delete")
+end
+
 
 function OAuthHandler:access(conf)
   access.execute(conf)
 end
 
-OAuthHandler.PRIORITY = 1004
-OAuthHandler.VERSION = "2.0.0"
 
 return OAuthHandler

--- a/spec/03-plugins/25-oauth2/04-invalidations_spec.lua
+++ b/spec/03-plugins/25-oauth2/04-invalidations_spec.lua
@@ -3,6 +3,10 @@ local helpers = require "spec.helpers"
 local admin_api = require "spec.fixtures.admin_api"
 
 
+local sha1_bin = ngx.sha1_bin
+local to_hex = require "resty.string".to_hex
+
+
 for _, strategy in helpers.each_strategy() do
   describe("Plugin: oauth2 (invalidations) [#" .. strategy .. "]", function()
     local admin_client
@@ -348,7 +352,8 @@ for _, strategy in helpers.each_strategy() do
         assert.res_status(200, res)
 
         -- Check that cache is populated
-        local cache_key = db.oauth2_tokens:cache_key(token.access_token)
+        local cache_key = db.oauth2_tokens:cache_key(to_hex(sha1_bin(token.access_token)))
+
         local res = assert(admin_client:send {
           method  = "GET",
           path    = "/cache/" .. cache_key,
@@ -415,7 +420,7 @@ for _, strategy in helpers.each_strategy() do
         assert.res_status(200, res)
 
         -- Check that cache is populated
-        local cache_key = db.oauth2_tokens:cache_key(token.access_token)
+        local cache_key = db.oauth2_tokens:cache_key(to_hex(sha1_bin(token.access_token)))
 
         local res = assert(admin_client:send {
           method  = "GET",
@@ -500,7 +505,7 @@ for _, strategy in helpers.each_strategy() do
         assert.res_status(200, res)
 
         -- Check that cache is populated
-        local cache_key = db.oauth2_tokens:cache_key(token.access_token)
+        local cache_key = db.oauth2_tokens:cache_key(to_hex(sha1_bin(token.access_token)))
 
         local res = assert(admin_client:send {
           method  = "GET",


### PR DESCRIPTION
### Summary

Currently `oauth2` plugin does seem to use `access token` in a `cache_key` in plain. This is potentially dangerous and may be leaked through it to different places:
- memory
- admin api
  - logs

This commit fixes that by calling `sha1_bin` on that when generating a cache key.