### PR TITLE
feat(ldap-auth) add ldaps support

### DIFF
--- a/kong/plugins/ldap-auth/access.lua
+++ b/kong/plugins/ldap-auth/access.lua
@@ -81,7 +81,9 @@ local function ldap_authenticate(given_username, given_password, conf)
         return nil, err
       end
     end
+  end
 
+  if conf.start_tls or conf.ldaps then
     _, err = sock:sslhandshake(true, conf.ldap_host, conf.verify_ldap_host)
     if err ~= nil then
       return false, fmt("failed to do SSL handshake with %s:%s: %s",

--- a/kong/plugins/ldap-auth/schema.lua
+++ b/kong/plugins/ldap-auth/schema.lua
@@ -14,6 +14,7 @@ return {
         fields = {
           { ldap_host = typedefs.host({ required = true }), },
           { ldap_port = typedefs.port({ required = true }), },
+          { ldaps = { required = true, type = "boolean", default = false } },
           { start_tls = { type = "boolean", required = true, default = false }, },
           { verify_ldap_host = { type = "boolean", required = true, default = false }, },
           { base_dn = { type = "string", required = true }, },
@@ -25,6 +26,13 @@ return {
           { anonymous = { type = "string", uuid = true, legacy = true }, },
           { header_type = { type = "string", default = "ldap" }, },
         },
+        entity_checks = {
+          { conditional = {
+            if_field   = "ldaps",     if_match   = { eq = true },
+            then_field = "start_tls", then_match = { eq = false },
+            then_err   = "'ldaps' and 'start_tls' cannot be enabled simultaneously"
+          } },
+        }
     }, },
   },
 }

--- a/spec/03-plugins/20-ldap-auth/02-schema_spec.lua
+++ b/spec/03-plugins/20-ldap-auth/02-schema_spec.lua
@@ -1,0 +1,14 @@
+local schema_def = require "kong.plugins.ldap-auth.schema"
+local v = require("spec.helpers").validate_plugin_config_schema
+
+describe("Plugin: ldap-auth (schema)", function()
+  describe("errors", function()
+    it("requires ldaps and start_tls to be mutually exclusive", function()
+      local ok, err = v({ldap_host = "none", ldap_port = 389, ldaps = true, start_tls = true, base_dn="ou=users", attribute="cn"}, schema_def)
+      assert.falsy(ok)
+      assert.equals("'ldaps' and 'start_tls' cannot be enabled simultaneously", err.config["@entity"][1])
+    end)
+  end)
+end)
+
+


### PR DESCRIPTION
STARTTLS encrypts the existing connection and that what usually advised to use
for securing the data. But some LDAP servers are only configured to use LDAPS
on port 636.

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

SUMMARY_GOES_HERE

### Full changelog

* [Implement ...]
* [Add related tests]
* ...

### Issues resolved

Fix #XXX

- [ ] 