### PR TITLE
fix(oauth2) hash oauth2_tokens cache key via the DAO

### DIFF
--- a/kong-2.0.0-0.rockspec
+++ b/kong-2.0.0-0.rockspec
@@ -227,6 +227,7 @@ build = {
     ["kong.plugins.oauth2.access"] = "kong/plugins/oauth2/access.lua",
     ["kong.plugins.oauth2.schema"] = "kong/plugins/oauth2/schema.lua",
     ["kong.plugins.oauth2.daos"] = "kong/plugins/oauth2/daos.lua",
+    ["kong.plugins.oauth2.daos.oauth2_tokens"] = "kong/plugins/oauth2/daos/oauth2_tokens.lua",
 
 
     ["kong.plugins.log-serializers.basic"] = "kong/plugins/log-serializers/basic.lua",

--- a/kong/plugins/oauth2/daos.lua
+++ b/kong/plugins/oauth2/daos.lua
@@ -63,6 +63,7 @@ local oauth2_tokens = {
   name = "oauth2_tokens",
   endpoint_key = "access_token",
   cache_key = { "access_token" },
+  dao = "kong.plugins.oauth2.daos.oauth2_tokens",
   ttl = true,
   fields = {
     { id = typedefs.uuid },

--- a/kong/plugins/oauth2/daos/oauth2_tokens.lua
+++ b/kong/plugins/oauth2/daos/oauth2_tokens.lua
@@ -1,0 +1,13 @@
+local oauth2_tokens = {}
+
+
+local sha1_bin = ngx.sha1_bin
+local to_hex = require "resty.string".to_hex
+
+
+function oauth2_tokens:cache_key(access_token)
+  return "oauth2_tokens:" .. to_hex(sha1_bin(self.super.cache_key(self, access_token)))
+end
+
+
+return oauth2_tokens


### PR DESCRIPTION
Currently oauth2 plugins use access token in plaintext in cache keys.
This can potentially cause the token to appear in debug-level logs
and in Admin API access logs if the cache keys are manipulated
directly via the `/cache/` endpoint.

This commit hashes the cache key extending the `:cache_key` operation
of the DAO for `oauth2_tokens`.

This is hopefully a simpler alternative alternative to #5500.