### PR TITLE
fix(migrations) include configured Lua path

### DIFF
--- a/kong/cmd/migrations.lua
+++ b/kong/cmd/migrations.lua
@@ -81,6 +81,8 @@ local function execute(args)
 
   local conf = assert(conf_loader(args.conf))
 
+  package.path = conf.lua_package_path .. ";" .. package.path
+
   conf.pg_timeout = args.db_timeout -- connect + send + read
 
   conf.cassandra_timeout = args.db_timeout -- connect + send + read


### PR DESCRIPTION
### Summary

Include lua_package_path in the package.path when running migrations.

This ensures that Kong runs migrations for plugins installed in
locations indicated by lua_package_path outside the standard Lua path.

### Full changelog

* Update `package.path` with `lua_package_path` locations in `cmd.migrations:execute()`

### Issues resolved

This was initially discovered while working on https://github.com/Kong/charts/pull/24

The Helm chart mounts all plugin files under `/opt/kong/plugins`. While testing, we observed that plugin files were mounted correctly and that `KONG_PLUGINS` included them, but that no migrations were detected.
