### PR TITLE
Remove upstream ACAO header if no match is found

### DIFF
--- a/kong/plugins/cors/handler.lua
+++ b/kong/plugins/cors/handler.lua
@@ -153,6 +153,7 @@ local function configure_origin(conf)
     end
   end
 
+  kong.response.clear_header("Access-Control-Allow-Origin")
   return false
 end
 


### PR DESCRIPTION
### Summary

This is a fix for an issue filed as a task/feature at
https://github.com/Kong/kong/issues/4886

Upon closer inspection, this behavior is closer to a bug, and probably
creates unexpected behavior for all users of the CORS plugin.

The plugin logic accounts for all cases where it shuould add an ACAO
header to enable CORS.
- If the plugin is enabled but no allowed domains are defined, ACAO: *
- If allowed domains =  *, ACAO: *
- If one or more specific domains/regexes is defined and request Origin
header matches, ACAO: <request Origin header value>

However, if (and only if) a specific list of domains is defined and the
request Origin header FAILS to match, then the upstream header is passed
through. If your upstream server returns ACAO: *, there is no way to
implement a more restrictive CORS behavior with Kong.

This change implements a behavior in which while the CORS plugin is
enabled, Kong is always responsible for the content of the ACAO header.
This is much more clear and predictable. The only situation that this
behavior modification would prevent would be if an admin wants to allow
specific CORS URLs in Kong, and also allow a different list of specific
URLs at the upstream server, whitelisting both. I think the declarative
behavior in the Kong plugin is much more sensible.

The precedent for removing upstream headers is already set by the logic
for Access-Control-Allow-Headers.

### Full changelog

* Remove upstream Access-Control-Allow-Origin if Origin doesn't match the list of URLs set in the CORS plugin.

### Issues resolved

Fix #4886 
