### PR TITLE
fix(oauth2) handle missing token

### DIFF
--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -725,7 +725,7 @@ end
 
 local function do_authentication(conf)
   local access_token = parse_access_token(conf);
-  if not access_token then
+  if not access_token or access_token == "" then
     return nil, {
       status = 401,
       message = {

--- a/spec/03-plugins/25-oauth2/03-access_spec.lua
+++ b/spec/03-plugins/25-oauth2/03-access_spec.lua
@@ -1772,6 +1772,17 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
         })
         assert.res_status(200, res)
       end)
+      it("fails when missing access_token is being sent in the custom header", function()
+        local res = assert(proxy_ssl_client:send {
+          method = "GET",
+          path = "/request",
+          headers = {
+            ["Host"] = "oauth2_11.com",
+            ["custom_header_name"] = "",
+          }
+        })
+        assert.res_status(401, res)
+      end)
       it("fails when a correct access_token is being sent in the wrong header", function()
         local token = provision_token("oauth2_11.com",nil,"clientid1011","secret1011")
 


### PR DESCRIPTION
### Summary

Currently the OAuth2.0 plugin is not handling the passing of the empty ```Authorization``` or custom header set with the bearer <access_token> not present. 

### Full changelog

* Modify access.lua
* Add 1 related test in 03-access_spec.lua
* ...

### Issues resolved

Fixes: #5513