### PR TITLE
ci(github) use GitHub Actions as CI for Kong OSS

### DIFF
--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -21,8 +21,23 @@ else
 fi
 
 if [ "$TEST_SUITE" == "integration" ]; then
-    eval "$TEST_CMD" spec/02-integration/
+    if [[ "$TEST_SPLIT" == first* ]]; then
+        # GitHub Actions, run first batch of integration tests
+        eval "$TEST_CMD" $(ls -d spec/02-integration/* | head -n4)
+
+    elif [[ "$TEST_SPLIT" == second* ]]; then
+        # GitHub Actions, run second batch of integration tests
+        # Note that the split here is chosen carefully to result
+        # in a similar run time between the two batches, and should
+        # be adjusted if imbalance become significant in the future
+        eval "$TEST_CMD" $(ls -d spec/02-integration/* | tail -n+5)
+
+    else
+        # Non GitHub Actions
+        eval "$TEST_CMD" spec/02-integration/
+    fi
 fi
+
 if [ "$TEST_SUITE" == "dbless" ]; then
     eval "$TEST_CMD" spec/02-integration/02-cmd \
                      spec/02-integration/05-proxy \
@@ -77,5 +92,5 @@ if [ "$TEST_SUITE" == "plugins" ]; then
     fi
 fi
 if [ "$TEST_SUITE" == "pdk" ]; then
-    TEST_NGINX_RANDOMIZE=1 prove -I. -j$JOBS -r t/01-pdk
+    TEST_NGINX_RANDOMIZE=1 prove -I. -r t/01-pdk
 fi

--- a/.ci/setup_env_github.sh
+++ b/.ci/setup_env_github.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# set -e
+
+dep_version() {
+    grep $1 .requirements | sed -e 's/.*=//' | tr -d '\n'
+}
+
+OPENRESTY=$(dep_version RESTY_VERSION)
+LUAROCKS=$(dep_version RESTY_LUAROCKS_VERSION)
+OPENSSL=$(dep_version RESTY_OPENSSL_VERSION)
+GO_PLUGINSERVER=$(dep_version KONG_GO_PLUGINSERVER_VERSION)
+
+
+#---------
+# Download
+#---------
+
+DOWNLOAD_ROOT=${DOWNLOAD_ROOT:=/download-root}
+BUILD_TOOLS_DOWNLOAD=$GITHUB_WORKSPACE/kong-build-tools
+GO_PLUGINSERVER_DOWNLOAD=$GITHUB_WORKSPACE/go-pluginserver
+
+KONG_NGINX_MODULE_BRANCH=${KONG_NGINX_MODULE_BRANCH:=master}
+
+#--------
+# Install
+#--------
+INSTALL_ROOT=${INSTALL_ROOT:=/install-cache}
+
+pushd $GO_PLUGINSERVER_DOWNLOAD
+  go get ./...
+  make
+
+  mkdir -p $INSTALL_ROOT/go-pluginserver
+  cp go-pluginserver $INSTALL_ROOT/go-pluginserver/
+popd
+
+kong-ngx-build \
+    --work $DOWNLOAD_ROOT \
+    --prefix $INSTALL_ROOT \
+    --openresty $OPENRESTY \
+    --kong-nginx-module $KONG_NGINX_MODULE_BRANCH \
+    --luarocks $LUAROCKS \
+    --openssl $OPENSSL
+
+OPENSSL_INSTALL=$INSTALL_ROOT/openssl
+OPENRESTY_INSTALL=$INSTALL_ROOT/openresty
+LUAROCKS_INSTALL=$INSTALL_ROOT/luarocks
+
+eval `luarocks path`
+
+nginx -V
+resty -V
+luarocks --version
+openssl version

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,361 @@
+name: Build & Test
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build dependencies
+    runs-on: ubuntu-18.04
+
+    env:
+      DOWNLOAD_ROOT: $HOME/download-root
+
+    steps:
+    - name: Set environment variables
+      run: |
+          echo "::set-env name=INSTALL_ROOT::$HOME/install-root"
+          echo "::set-env name=DOWNLOAD_ROOT::$HOME/download-root"
+          echo "::set-env name=LD_LIBRARY_PATH::$INSTALL_ROOT/openssl/lib:$LD_LIBRARY_PATH"
+    - name: Checkout Kong source code
+      uses: actions/checkout@v2
+
+    - name: Lookup build cache
+      uses: actions/cache@v1
+      id: cache-deps
+      with:
+        path: ${{ env.INSTALL_ROOT }}
+        key: ${{ hashFiles('.ci/setup_env_github.sh') }}-${{ hashFiles('.github/workflows/build_and_test.yml') }}-${{ hashFiles('.requirements') }}
+
+    - name: Checkout kong-build-tools
+      if: steps.cache-deps.outputs.cache-hit != 'true'
+      uses: actions/checkout@v2
+      with:
+        repository: Kong/kong-build-tools
+        path: kong-build-tools
+        ref: next
+
+    - name: Checkout go-pluginserver
+      if: steps.cache-deps.outputs.cache-hit != 'true'
+      uses: actions/checkout@v2
+      with:
+        repository: Kong/go-pluginserver
+        path: go-pluginserver
+
+    - name: Add to Path
+      if: steps.cache-deps.outputs.cache-hit != 'true'
+      run: echo "::add-path::$INSTALL_ROOT/openssl/bin:$INSTALL_ROOT/openresty/nginx/sbin:$INSTALL_ROOT/openresty/bin:$INSTALL_ROOT/luarocks/bin:$GITHUB_WORKSPACE/kong-build-tools/openresty-build-tools"
+
+    - name: Install packages
+      if: steps.cache-deps.outputs.cache-hit != 'true'
+      run: sudo apt update && sudo apt install libyaml-dev
+
+    - name: Build Kong dependencies
+      if: steps.cache-deps.outputs.cache-hit != 'true'
+      run: |
+          source .ci/setup_env_github.sh
+          make dev
+
+  lint-and-unit-tests:
+    name: Lint & Unit tests
+    runs-on: ubuntu-18.04
+    needs: build
+
+    env:
+      KONG_TEST_PG_DATABASE: kong
+      KONG_TEST_PG_USER: postgres
+
+    services:
+      postgres:
+        image: postgres:10
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_DB: kong
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 5s --health-timeout 5s --health-retries 8
+
+    steps:
+    - name: Set environment variables
+      run: |
+          echo "::set-env name=INSTALL_ROOT::$HOME/install-root"
+          echo "::set-env name=DOWNLOAD_ROOT::$HOME/download-root"
+          echo "::set-env name=LD_LIBRARY_PATH::$HOME/install-root/openssl/lib:$LD_LIBRARY_PATH"
+
+    - name: Checkout Kong source code
+      uses: actions/checkout@v2
+
+    - name: Lookup build cache
+      uses: actions/cache@v1
+      id: cache-deps
+      with:
+        path: ${{ env.INSTALL_ROOT }}
+        key: ${{ hashFiles('.ci/setup_env_github.sh') }}-${{ hashFiles('.github/workflows/build_and_test.yml') }}-${{ hashFiles('.requirements') }}
+
+    - name: Add to Path
+      run: echo "::add-path::$INSTALL_ROOT/openssl/bin:$INSTALL_ROOT/openresty/nginx/sbin:$INSTALL_ROOT/openresty/bin:$INSTALL_ROOT/luarocks/bin"
+
+    - name: Lint Lua code
+      run: |
+          eval `luarocks path`
+          luacheck -q .
+
+    - name: Check admin API documentation
+      run: |
+          eval `luarocks path`
+          scripts/autodoc-admin-api
+
+    - name: Unit tests
+      run: |
+          eval `luarocks path`
+          bin/busted -v -o gtest spec/01-unit
+
+  integration-tests-postgres:
+    name: Postgres ${{ matrix.suite }} - ${{ matrix.split }} tests
+    runs-on: ubuntu-18.04
+    needs: lint-and-unit-tests
+
+    strategy:
+      matrix:
+        suite: [integration, plugins]
+        split: [all, first (01-04), second (>= 05)]
+        exclude:
+          - suite: plugins
+            split: first (01-04)
+          - suite: plugins
+            split: second (>= 05)
+          - suite: integration
+            split: all
+
+    env:
+      KONG_TEST_PG_DATABASE: kong
+      KONG_TEST_PG_USER: postgres
+      KONG_TEST_DATABASE: postgres
+      TEST_SUITE: ${{ matrix.suite }}
+      TEST_SPLIT: ${{ matrix.split }}
+
+    services:
+      postgres:
+        image: postgres:10
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_DB: kong
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 5s --health-timeout 5s --health-retries 8
+
+      grpcbin:
+        image: moul/grpcbin
+        ports:
+          - 15002:9000
+          - 15003:9001
+
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+        options: --entrypoint redis-server
+
+    steps:
+    - name: Set environment variables
+      run: |
+          echo "::set-env name=INSTALL_ROOT::$HOME/install-root"
+          echo "::set-env name=DOWNLOAD_ROOT::$HOME/download-root"
+          echo "::set-env name=LD_LIBRARY_PATH::$HOME/install-root/openssl/lib:$LD_LIBRARY_PATH"
+
+    - name: Checkout Kong source code
+      uses: actions/checkout@v2
+
+    - name: Lookup build cache
+      uses: actions/cache@v1
+      id: cache-deps
+      with:
+        path: ${{ env.INSTALL_ROOT }}
+        key: ${{ hashFiles('.ci/setup_env_github.sh') }}-${{ hashFiles('.github/workflows/build_and_test.yml') }}-${{ hashFiles('.requirements') }}
+
+    - name: Add to Path
+      run: echo "::add-path::$INSTALL_ROOT/openssl/bin:$INSTALL_ROOT/openresty/nginx/sbin:$INSTALL_ROOT/openresty/bin:$INSTALL_ROOT/luarocks/bin:$INSTALL_ROOT/go-pluginserver"
+
+    - name: Add gRPC test host names
+      run: |
+          echo "127.0.0.1 grpcs_1.test" | sudo tee -a /etc/hosts
+          echo "127.0.0.1 grpcs_2.test" | sudo tee -a /etc/hosts
+
+    - name: Tests
+      run: |
+          eval `luarocks path`
+          make dev
+          .ci/run_tests.sh
+
+  integration-tests-dbless:
+    name: DB-less integration tests
+    runs-on: ubuntu-18.04
+    needs: lint-and-unit-tests
+
+    env:
+      KONG_TEST_PG_DATABASE: kong
+      KONG_TEST_PG_USER: postgres
+      KONG_TEST_DATABASE: 'off'
+      TEST_SUITE: dbless
+
+    services:
+      grpcbin:
+        image: moul/grpcbin
+        ports:
+          - 15002:9000
+          - 15003:9001
+
+    steps:
+    - name: Set environment variables
+      run: |
+          echo "::set-env name=INSTALL_ROOT::$HOME/install-root"
+          echo "::set-env name=DOWNLOAD_ROOT::$HOME/download-root"
+          echo "::set-env name=LD_LIBRARY_PATH::$HOME/install-root/openssl/lib:$LD_LIBRARY_PATH"
+
+    - name: Checkout Kong source code
+      uses: actions/checkout@v2
+
+    - name: Lookup build cache
+      uses: actions/cache@v1
+      id: cache-deps
+      with:
+        path: ${{ env.INSTALL_ROOT }}
+        key: ${{ hashFiles('.ci/setup_env_github.sh') }}-${{ hashFiles('.github/workflows/build_and_test.yml') }}-${{ hashFiles('.requirements') }}
+
+    - name: Add to Path
+      run: echo "::add-path::$INSTALL_ROOT/openssl/bin:$INSTALL_ROOT/openresty/nginx/sbin:$INSTALL_ROOT/openresty/bin:$INSTALL_ROOT/luarocks/bin:$INSTALL_ROOT/go-pluginserver"
+
+    - name: Add gRPC test host names
+      run: |
+          echo "127.0.0.1 grpcs_1.test" | sudo tee -a /etc/hosts
+          echo "127.0.0.1 grpcs_2.test" | sudo tee -a /etc/hosts
+
+    - name: Tests
+      run: |
+          eval `luarocks path`
+          make dev
+          .ci/run_tests.sh
+
+  integration-tests-cassandra:
+    name: C* ${{ matrix.cassandra_version }} ${{ matrix.suite }} - ${{ matrix.split }} tests
+    runs-on: ubuntu-18.04
+    needs: lint-and-unit-tests
+
+    strategy:
+      matrix:
+        suite: [integration, plugins]
+        cassandra_version: [2, 3]
+        split: [all, first (01-04), second (>= 05)]
+        exclude:
+          - suite: plugins
+            split: first (01-04)
+          - suite: plugins
+            split: second (>= 05)
+          - suite: integration
+            split: all
+
+    env:
+      KONG_TEST_DATABASE: cassandra
+      TEST_SUITE: ${{ matrix.suite }}
+      TEST_SPLIT: ${{ matrix.split }}
+
+    services:
+      cassandra:
+        image: cassandra:${{ matrix.cassandra_version }}
+        ports:
+          - 7199:7199
+          - 7000:7000
+          - 9160:9160
+          - 9042:9042
+        options: --health-cmd "cqlsh -e 'describe cluster'" --health-interval 5s --health-timeout 5s --health-retries 8
+
+      grpcbin:
+        image: moul/grpcbin
+        ports:
+          - 15002:9000
+          - 15003:9001
+
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+        options: --entrypoint redis-server
+
+    steps:
+    - name: Set environment variables
+      run: |
+          echo "::set-env name=INSTALL_ROOT::$HOME/install-root"
+          echo "::set-env name=DOWNLOAD_ROOT::$HOME/download-root"
+          echo "::set-env name=LD_LIBRARY_PATH::$HOME/install-root/openssl/lib:$LD_LIBRARY_PATH"
+
+    - name: Checkout Kong source code
+      uses: actions/checkout@v2
+
+    - name: Lookup build cache
+      uses: actions/cache@v1
+      id: cache-deps
+      with:
+        path: ${{ env.INSTALL_ROOT }}
+        key: ${{ hashFiles('.ci/setup_env_github.sh') }}-${{ hashFiles('.github/workflows/build_and_test.yml') }}-${{ hashFiles('.requirements') }}
+
+    - name: Add to Path
+      run: echo "::add-path::$INSTALL_ROOT/openssl/bin:$INSTALL_ROOT/openresty/nginx/sbin:$INSTALL_ROOT/openresty/bin:$INSTALL_ROOT/luarocks/bin:$INSTALL_ROOT/go-pluginserver"
+
+    - name: Add gRPC test host names
+      run: |
+          echo "127.0.0.1 grpcs_1.test" | sudo tee -a /etc/hosts
+          echo "127.0.0.1 grpcs_2.test" | sudo tee -a /etc/hosts
+
+    - name: Tests
+      run: |
+          eval `luarocks path`
+          make dev
+          .ci/run_tests.sh
+
+  pdk-tests:
+    name: PDK tests
+    runs-on: ubuntu-18.04
+    needs: lint-and-unit-tests
+
+    env:
+      TEST_SUITE: pdk
+
+    steps:
+    - name: Set environment variables
+      run: |
+          echo "::set-env name=INSTALL_ROOT::$HOME/install-root"
+          echo "::set-env name=DOWNLOAD_ROOT::$HOME/download-root"
+          echo "::set-env name=LD_LIBRARY_PATH::$HOME/install-root/openssl/lib:$LD_LIBRARY_PATH"
+
+    - name: Checkout Kong source code
+      uses: actions/checkout@v2
+
+    - name: Lookup build cache
+      uses: actions/cache@v1
+      id: cache-deps
+      with:
+        path: ${{ env.INSTALL_ROOT }}
+        key: ${{ hashFiles('.ci/setup_env_github.sh') }}-${{ hashFiles('.github/workflows/build_and_test.yml') }}-${{ hashFiles('.requirements') }}
+
+    - name: Add to Path
+      run: echo "::add-path::$INSTALL_ROOT/openssl/bin:$INSTALL_ROOT/openresty/nginx/sbin:$INSTALL_ROOT/openresty/bin:$INSTALL_ROOT/luarocks/bin:$INSTALL_ROOT/go-pluginserver:$DOWNLOAD_ROOT/cpanm"
+
+    - name: Install Test::Nginx
+      run: |
+          CPAN_DOWNLOAD=$DOWNLOAD_ROOT/cpanm
+          mkdir -p $CPAN_DOWNLOAD
+          curl -o $CPAN_DOWNLOAD/cpanm https://cpanmin.us
+          chmod +x $CPAN_DOWNLOAD/cpanm
+
+          echo "Installing CPAN dependencies..."
+          cpanm --notest --local-lib=$HOME/perl5 local::lib && eval $(perl -I $HOME/perl5/lib/perl5/ -Mlocal::lib)
+          cpanm --notest Test::Nginx
+
+    - name: Tests
+      run: |
+          eval `luarocks path`
+          make dev
+
+          eval $(perl -I $HOME/perl5/lib/perl5/ -Mlocal::lib)
+          .ci/run_tests.sh

--- a/spec/02-integration/02-cmd/08-quit_spec.lua
+++ b/spec/02-integration/02-cmd/08-quit_spec.lua
@@ -31,6 +31,6 @@ describe("kong quit", function()
     assert(helpers.kong_exec("quit --wait 2 --prefix " .. helpers.test_conf.prefix))
     ngx.update_time()
     local duration = ngx.now() - start
-    assert.is.near(2, duration, 0.5)
+    assert.is.near(2, duration, 1)
   end)
 end)

--- a/spec/02-integration/02-cmd/08-quit_spec.lua
+++ b/spec/02-integration/02-cmd/08-quit_spec.lua
@@ -31,6 +31,6 @@ describe("kong quit", function()
     assert(helpers.kong_exec("quit --wait 2 --prefix " .. helpers.test_conf.prefix))
     ngx.update_time()
     local duration = ngx.now() - start
-    assert.is.near(2, duration, 1)
+    assert.is.near(2, duration, 1.5)
   end)
 end)

--- a/spec/02-integration/03-db/09-query-semaphore_spec.lua
+++ b/spec/02-integration/03-db/09-query-semaphore_spec.lua
@@ -1,7 +1,7 @@
 local helpers = require "spec.helpers"
 local cjson = require "cjson"
 
-describe("Postgres query locks", function()
+describe("Postgres query locks #postgres", function()
   local client
 
   setup(function()

--- a/spec/02-integration/05-proxy/05-dns_spec.lua
+++ b/spec/02-integration/05-proxy/05-dns_spec.lua
@@ -108,7 +108,7 @@ for _, strategy in helpers.each_strategy() do
 
         local service = bp.services:insert {
           name     = "tests-retries",
-          host     = "now.this.does.not",
+          host     = "nowthisdoesnotexistatall",
           path     = "/exist",
           port     = 80,
           protocol = "http"


### PR DESCRIPTION
This commit allows us to use GitHub Actions as CI solution. It provides
more concurrency and provides ease for excessive run time and queue
length we have been experiencing with Travis CI so far.

This commit makes Kong able to run on GitHub Actions, but still kept the
Travis CI files around so that we could use both at the same time during
the transitional period. Eventually Travis CI support will be removed.

This PR further splits Kong core integration tests into two halves on
GitHub Actions to further reduce the run time by utilizing all the
concurrency we have access to, as the core integration tests has
consistently been the long tail of all the jobs, running 2x slower than
the second slowest job. Splitting is not done on Travis as the
concurrency limit makes doing so pointless.