### PR TITLE
fix(proxy) fix broken SNI based routing in L4 proxy mode, closes #5501

### DIFF
--- a/kong/router.lua
+++ b/kong/router.lua
@@ -1739,12 +1739,15 @@ function _M.new(routes)
     end
 
   else -- stream
-    function self.exec(ctx)
+    local server_name = require("ngx.ssl").server_name
+
+    function self.exec()
       local src_ip = var.remote_addr
       local src_port = tonumber(var.remote_port, 10)
       local dst_ip = var.server_addr
       local dst_port = tonumber(var.server_port, 10)
-      local sni = ctx.sni_server_name
+      -- error value for non-TLS connections ignored intentionally
+      local sni, _ = server_name()
 
       return find_route(nil, nil, nil, nil,
                         src_ip, src_port,

--- a/kong/runloop/certificate.lua
+++ b/kong/runloop/certificate.lua
@@ -186,14 +186,12 @@ local function find_certificate(sni)
 end
 
 
-local function execute(ctx)
+local function execute()
   local sn, err = server_name()
   if err then
     log(ERR, "could not retrieve SNI: ", err)
     return ngx.exit(ngx.ERROR)
   end
-
-  ctx.sni_server_name = sn
 
   local cert_and_key, err = find_certificate(sn)
   if err then

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -961,7 +961,7 @@ return {
     before = function(ctx)
       local router = get_updated_router()
 
-      local match_t = router.exec(ctx)
+      local match_t = router.exec()
       if not match_t then
         log(ERR, "no Route found with those values")
         return exit(500)
@@ -986,8 +986,8 @@ return {
     end
   },
   certificate = {
-    before = function(ctx)
-      certificate.execute(ctx)
+    before = function(_)
+      certificate.execute()
     end
   },
   rewrite = {

--- a/spec/02-integration/05-proxy/06-ssl_spec.lua
+++ b/spec/02-integration/05-proxy/06-ssl_spec.lua
@@ -514,4 +514,68 @@ for _, strategy in helpers.each_strategy() do
       end)
     end)
   end)
+
+  describe("TLS proxy [#" .. strategy .. "]", function()
+    local https_client
+
+    lazy_setup(function()
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "certificates",
+        "snis",
+      })
+
+      local service = bp.services:insert {
+        name = "svc-http",
+        protocol = "tcp",
+        host = helpers.get_proxy_ip(),
+        port = helpers.get_proxy_port(),
+      }
+
+      bp.routes:insert {
+        protocols = { "tls" },
+        snis     = { "example.com" },
+        service   = service,
+      }
+
+      local cert = bp.certificates:insert {
+        cert  = ssl_fixtures.cert,
+        key   = ssl_fixtures.key,
+      }
+
+      bp.snis:insert {
+        name = "example.com",
+        certificate = cert,
+      }
+
+      assert(helpers.start_kong {
+        database    = strategy,
+        stream_listen = "127.0.0.1:9020 ssl"
+      })
+
+    https_client = helpers.http_client("127.0.0.1", 9020, 60000)
+    assert(https_client:ssl_handshake(nil, "example.com", false)) -- explicit no-verify
+    end)
+
+    lazy_teardown(function()
+      helpers.stop_kong()
+      https_client:close()
+    end)
+
+    describe("can route normally", function()
+      it("sets the default certificate of '*' SNI", function()
+        local res = assert(https_client:send {
+          method  = "GET",
+          path    = "/",
+        })
+
+        assert.res_status(404, res)
+
+        local cert = get_cert("example.com")
+        -- this fails if the "example.com" SNI wasn't inserted above
+        assert.cn("ssl-example.com", cert)
+      end)
+    end)
+  end)
 end


### PR DESCRIPTION
The `stream_lua` per-connection doesn't exist yet during
`ssl_certificate_by_lua` phase. As a result saving the SNI into the
`ngx.ctx` object wouldn't preserve into later phases, causing SNI
routing failure.

This PR uses the `ngx.ssl.server_name` method to obtain the SNI
`server_name` instead which is guaranteed to work in the later phases.

Thanks @hbagdi for the report!