### PR TITLE
tests(grpc) verify streaming methods

### DIFF
--- a/spec/02-integration/05-proxy/19-grpc_proxy_spec.lua
+++ b/spec/02-integration/05-proxy/19-grpc_proxy_spec.lua
@@ -70,6 +70,52 @@ for _, strategy in helpers.each_strategy() do
       assert.truthy(resp)
     end)
 
+    it("proxies grpc, streaming response", function()
+      local ok, resp = assert(proxy_client_grpc({
+        service = "hello.HelloService.LotsOfReplies",
+        body = {
+          greeting = "world!"
+        },
+        opts = {
+          ["-authority"] = "grpc",
+        }
+      }))
+      assert.truthy(ok)
+      assert.truthy(resp)
+    end)
+
+    it("proxies grpc, streaming request", function()
+      local ok, resp = assert(proxy_client_grpc({
+        service = "hello.HelloService.LotsOfGreetings",
+        body = [[
+            { "greeting": "world!" }
+            { "greeting": "people!" }
+            { "greeting": "y`all!" }
+        ]],
+        opts = {
+          ["-authority"] = "grpc",
+        }
+      }))
+      assert.truthy(ok)
+      assert.truthy(resp)
+    end)
+
+    it("proxies grpc, streaming request/response", function()
+      local ok, resp = assert(proxy_client_grpc({
+        service = "hello.HelloService.BidiHello",
+        body = [[
+            { "greeting": "world!" }
+            { "greeting": "people!" }
+            { "greeting": "y`all!" }
+        ]],
+        opts = {
+          ["-authority"] = "grpc",
+        }
+      }))
+      assert.truthy(ok)
+      assert.truthy(resp)
+    end)
+
     it("proxies grpcs", function()
       local ok, resp = assert(proxy_client_grpcs({
         service = "hello.HelloService.SayHello",


### PR DESCRIPTION
### Summary

Add tests for gRPC streaming responses and requests.  They do work in the sense that all content is passed as expected and in order.

The requests are buffered, so the service doesn't receive any content until the last message is sent by the client.  This could broke an application that depends on a "ping-pong" behaviour during a single RPC call.