### PR TITLE
fix(healthchecks) fix propagation of posted health across workers

### DIFF
--- a/kong-2.0.1-0.rockspec
+++ b/kong-2.0.1-0.rockspec
@@ -31,7 +31,7 @@ dependencies = {
   "lua-resty-dns-client == 4.1.3",
   "lua-resty-worker-events == 1.0.0",
   "lua-resty-mediador == 0.1.2",
-  "lua-resty-healthcheck == 1.1.2",
+  "lua-resty-healthcheck == 1.2.0",
   "lua-resty-cookie == 0.1.0",
   "lua-resty-mlcache == 2.4.1",
   "lua-messagepack == 0.5.2",

--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -961,11 +961,19 @@ local function post_health(upstream, hostname, ip, port, is_healthy)
     return nil, "no healthchecker found for " .. tostring(upstream.name)
   end
 
+  local ok, err
   if ip then
-    return balancer:setAddressStatus(is_healthy, ip, port, hostname)
+    ok, err = healthchecker:set_target_status(ip, port, hostname, is_healthy)
+  else
+    ok, err = healthchecker:set_all_target_statuses_for_hostname(hostname, port, is_healthy)
   end
 
-  return balancer:setHostStatus(is_healthy, hostname, port)
+  -- adjust API because the healthchecker always returns a second argument
+  if ok then
+    err = nil
+  end
+
+  return ok, err
 end
 
 

--- a/spec/02-integration/05-proxy/10-balancer/01-ring-balancer_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer/01-ring-balancer_spec.lua
@@ -918,7 +918,7 @@ for _, strategy in helpers.each_strategy() do
               healthchecks = healthchecks_config {}
             })
             local port = add_target(bp, upstream_id, localhost)
-            wait_for_router_update(old_rv, localhost, proxy_port_2, admin_port_2)
+            wait_for_router_update(bp, old_rv, localhost, proxy_port_2, admin_port_2)
             end_testcase_setup(strategy, bp)
 
             local health1 = get_upstream_health(upstream_id, admin_port_1)


### PR DESCRIPTION
When I post the health explicitly via the Admin API (/upstreams/U/targets/T/healthy) the health status is updating in only one worker (giving me flappy results in the Admin API response as workers become inconsistent).

I'm tracking down the problem and I found some inconsistencies: the `post_health` operation calls straight into the balancer of the worker that responded to the Admin API call to update it and then propagates health via `cluster_events` only, skipping `worker_events` altogether. At first I thought this was the problem, but as I went hunting down I found a comment in `balancer.post_health` code that says `-- Update health status and broadcast to workers`, so using `cluster_events` only _should_ have worked.

The issue then is that, when healthcheck-by-address was introduced, `post_health` was changed from poking the `healthchecker` with `healthchecker:set_target_status(ip, port, is_healthy)` (which _does_ broadcast to all workers' healthcheckers via its own internal event system) into `balancer:setPeerStatus` and `balancer:setHostStatus` (which does not).

This PR changes it to trigger `healthchecker:set_target_status` calls again, but since there's now a mode where it can set health per IP address or for all IPs that a hostname resolves, I had to extend lua-resty-healthcheck in https://github.com/Kong/lua-resty-healthcheck/pull/39 with a new function for that to work (`healthchecker:set_all_target_statuses_for_hostname`) which just loops over the IPs of a hostname+port combo. This update is now released as lua-resty-healthcheck 1.2.0; the dependency bump for Kong is included in this PR.