### PR TITLE
fix(plugins) enable acme by default

### DIFF
--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -33,6 +33,7 @@ local plugins = {
   "prometheus",
   "proxy-cache",
   "session",
+  "acme",
 }
 
 local plugin_map = {}

--- a/spec/01-unit/12-plugins_order_spec.lua
+++ b/spec/01-unit/12-plugins_order_spec.lua
@@ -63,6 +63,7 @@ describe("Plugins", function()
       "ldap-auth",
       "basic-auth",
       "hmac-auth",
+      "acme",
       "ip-restriction",
       "request-size-limiting",
       "acl",


### PR DESCRIPTION
Out-of-tree plugins bundled by default are also enabled by default. The Acme plugin was recently bundled to Kong, but not enabled by default. 