### PR TITLE
reducing the scope of the opts variable from thread level to light th…

### DIFF
--- a/kong/db/strategies/cassandra/init.lua
+++ b/kong/db/strategies/cassandra/init.lua
@@ -943,7 +943,6 @@ end
 
 
 do
-  local opts = new_tab(0, 2)
 
   local function execute_page(self, cql, args, offset, opts)
     local rows, err = self.connector:query(cql, args, opts, "read")
@@ -966,7 +965,7 @@ do
     return rows, nil, next_offset
   end
 
-  local function query_page(self, offset, foreign_key, foreign_key_db_columns)
+  local function query_page(self, offset, foreign_key, foreign_key_db_columns, opts)
     local cql
     local args
     local err
@@ -1045,7 +1044,7 @@ do
     return entities, nil, nil
   end
 
-  local function query_page_for_tags(self, size, offset, tags, cond)
+  local function query_page_for_tags(self, size, offset, tags, cond, opts)
     -- TODO: if we don't sort, we can have a performance guidance to user
     -- to "always put tags with less entity at the front of query"
     table.sort(tags)
@@ -1202,6 +1201,7 @@ do
   end
 
   function _mt:page(size, offset, options, foreign_key, foreign_key_db_columns)
+    local opts = new_tab(0, 2)
     if not size then
       size = self.connector:get_page_size(options)
     end
@@ -1219,10 +1219,10 @@ do
     opts.paging_state = offset
 
     if options and options.tags then
-      return query_page_for_tags(self, size, offset, options.tags, options.tags_cond)
+      return query_page_for_tags(self, size, offset, options.tags, options.tags_cond, opts)
     end
 
-    return query_page(self, offset, foreign_key, foreign_key_db_columns)
+    return query_page(self, offset, foreign_key, foreign_key_db_columns, opts)
   end
 end
 


### PR DESCRIPTION
### Summary

Some time Kong is returning 404 even though the routes are valid and registered. We have found that it is due to the wrong paging_state sent by Kong to Cassandra. Due to the partition handling logic in Cassandra, it is returning success response with 0 rows for routes table (because route table has a partition key). The same behavior can also be observed in plugins rebuild as well because the plugin table doesn't have partition key so it is getting null pointer exception from Cassandra.

In case of null pointer exception for plugin rebuild, Kong is considering it as a failed case and reusing the old cache but in case of routes rebuild as Kong is getting success response from Cassandra, Kong is updating the cache with empty data.


After looking at the code of select each method, we have observerd that kong/db/strategies/cassandra/init.lua page method is sharing opts variable on thread level. In Kong to when we use router_consistency as eventual, we saw that we are using ngx.semaphore to create two different light threads to rebuild routes and plugins at the same time (only when routes and plugins are updated at the same time),  these light threads are not using the same opts variable to store page_state, due to race condition the page_state stored in opts can get overridden by other light thread. 
We have observed that some times routes page state is being used by plugin query and plugin page state is being used by route query which is causing unexpected behavior (404 in some cases).

steps to reproduce
- Start Kong with 16 worker threads
- Create more than 1000 routes and plugins
- Set router_consistency to eventual
- Modify a plugin and a route at the same time (it is very hard to change at same time, please  consider using router_update_frequency to 10 secs and also change the plugin update frequency to 10 secs as well)
- Print the cached router length, there should be some page missing entirely on the length of routes and also some null pointer exceptions can be observed on the plugin rebuild.

### Full changelog

* reducing the scope of the opts variable from thread level to light thread level

### Issues resolved

Fix #4769 , #5374 
