### PR TITLE
fix(db) read-before-write always on updates and upserts

### DIFF
--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -38,6 +38,18 @@ local DAO   = {}
 DAO.__index = DAO
 
 
+local function remove_nulls(tbl)
+  for k,v in pairs(tbl) do
+    if v == null then
+      tbl[k] = nil
+    elseif type(v) == "table" then
+      tbl[k] = remove_nulls(v)
+    end
+  end
+  return tbl
+end
+
+
 local function validate_size_type(size)
   if type(size) ~= "number" then
     error("size must be a number", 3)
@@ -360,7 +372,7 @@ end
 
 
 local function check_update(self, key, entity, options, name)
-  local entity_to_update, err, read_before_write, check_immutable_fields =
+  local entity_to_update, err, check_immutable_fields =
     self.schema:process_auto_fields(entity, "update")
   if not entity_to_update then
     local err_t = self.errors:schema_violation(err)
@@ -368,34 +380,30 @@ local function check_update(self, key, entity, options, name)
   end
 
   local rbw_entity
-  if read_before_write then
-    local err, err_t
-    if name then
-       rbw_entity, err, err_t = self["select_by_" .. name](self, key, options)
-    else
-       rbw_entity, err, err_t = self:select(key, options)
-    end
-    if err then
-      return nil, nil, err, err_t
-    end
+  local err, err_t
+  if name then
+     rbw_entity, err, err_t = self["select_by_" .. name](self, key, options)
+  else
+     rbw_entity, err, err_t = self:select(key, options)
+  end
+  if err then
+    return nil, nil, err, err_t
+  end
 
-    if rbw_entity and check_immutable_fields then
-      local ok, errors = self.schema:validate_immutable_fields(entity_to_update, rbw_entity)
-
-      if not ok then
-        local err_t = self.errors:schema_violation(errors)
-        return nil, nil, tostring(err_t), err_t
-      end
-    end
-
-    if rbw_entity then
-      entity_to_update = self.schema:merge_values(entity_to_update, rbw_entity)
-    else
-      local err_t = name
-                    and self.errors:not_found_by_field({ [name] = key })
-                    or  self.errors:not_found(key)
+  if rbw_entity and check_immutable_fields then
+    local ok, errors = self.schema:validate_immutable_fields(entity_to_update, rbw_entity)
+    if not ok then
+      local err_t = self.errors:schema_violation(errors)
       return nil, nil, tostring(err_t), err_t
     end
+  end
+
+  if rbw_entity then
+    entity_to_update = self.schema:merge_values(entity_to_update, rbw_entity)
+  else
+    local err_t = name and self.errors:not_found_by_field({ [name] = key })
+                        or self.errors:not_found(key)
+    return nil, nil, tostring(err_t), err_t
   end
 
   local ok, err, err_t = resolve_foreign(self, entity_to_update)
@@ -431,26 +439,38 @@ local function check_update(self, key, entity, options, name)
 end
 
 
-local function check_upsert(self, entity, options, name, value)
-  local entity_to_upsert, err = self.schema:process_auto_fields(entity, "upsert")
+local function check_upsert(self, key, entity, options, name)
+  local entity_to_upsert, err =
+    self.schema:process_auto_fields(entity, "upsert")
   if not entity_to_upsert then
     local err_t = self.errors:schema_violation(err)
-    return nil, tostring(err_t), err_t
+    return nil, nil, tostring(err_t), err_t
+  end
+
+  local rbw_entity
+  local err, err_t
+  if name then
+     rbw_entity, err, err_t = self["select_by_" .. name](self, key, options)
+  else
+     rbw_entity, err, err_t = self:select(key, options)
+  end
+  if err then
+    return nil, nil, err, err_t
   end
 
   if name then
-    entity_to_upsert[name] = value
+    entity_to_upsert[name] = key
   end
 
   local ok, err, err_t = resolve_foreign(self, entity_to_upsert)
   if not ok then
-    return nil, err, err_t
+    return nil, nil, err, err_t
   end
 
   local ok, errors = self.schema:validate_upsert(entity_to_upsert, entity)
   if not ok then
     local err_t = self.errors:schema_violation(errors)
-    return nil, tostring(err_t), err_t
+    return nil, nil, tostring(err_t), err_t
   end
 
   if name then
@@ -460,14 +480,14 @@ local function check_upsert(self, entity, options, name, value)
   entity_to_upsert, err = self.schema:transform(entity_to_upsert, entity, "upsert")
   if not entity_to_upsert then
     err_t = self.errors:transformation_error(err)
-    return nil, tostring(err_t), err_t
+    return nil, nil, tostring(err_t), err_t
   end
 
   if options ~= nil then
     local ok, errors = validate_options_value(self, options)
     if not ok then
       local err_t = self.errors:invalid_options(errors)
-      return nil, tostring(err_t), err_t
+      return nil, nil, tostring(err_t), err_t
     end
   end
 
@@ -475,7 +495,7 @@ local function check_upsert(self, entity, options, name, value)
     entity_to_upsert.cache_key = self:cache_key(entity_to_upsert)
   end
 
-  return entity_to_upsert
+  return entity_to_upsert, rbw_entity
 end
 
 
@@ -721,8 +741,11 @@ local function generate_foreign_key_methods(schema)
           return nil, tostring(err_t), err_t
         end
 
-        local entity_to_upsert, err, err_t = check_upsert(self, entity, options,
-                                                          name, unique_value)
+        local entity_to_upsert, rbw_entity, err, err_t = check_upsert(self,
+                                                                      unique_value,
+                                                                      entity,
+                                                                      options,
+                                                                      name)
         if not entity_to_upsert then
           return nil, err, err_t
         end
@@ -738,7 +761,11 @@ local function generate_foreign_key_methods(schema)
           return nil, err, err_t
         end
 
-        self:post_crud_event("update", row, nil, options)
+        if rbw_entity then
+          self:post_crud_event("update", row, rbw_entity, options)
+        else
+          self:post_crud_event("create", row, nil, options)
+        end
 
         return row
       end
@@ -1016,7 +1043,10 @@ function DAO:upsert(primary_key, entity, options)
     return nil, tostring(err_t), err_t
   end
 
-  local entity_to_upsert, err, err_t = check_upsert(self, entity, options)
+  local entity_to_upsert, rbw_entity, err, err_t = check_upsert(self,
+                                                                primary_key,
+                                                                entity,
+                                                                options)
   if not entity_to_upsert then
     return nil, err, err_t
   end
@@ -1031,7 +1061,11 @@ function DAO:upsert(primary_key, entity, options)
     return nil, err, err_t
   end
 
-  self:post_crud_event("update", row, nil, options)
+  if rbw_entity then
+    self:post_crud_event("update", row, rbw_entity, options)
+  else
+    self:post_crud_event("create", row, nil, options)
+  end
 
   return row
 end
@@ -1159,11 +1193,21 @@ function DAO:post_crud_event(operation, entity, old_entity, options)
   end
 
   if self.events then
+    local entity_without_nulls
+    if entity then
+      entity_without_nulls = remove_nulls(utils.deep_copy(entity, false))
+    end
+
+    local old_entity_without_nulls
+    if old_entity then
+      old_entity_without_nulls = remove_nulls(utils.deep_copy(old_entity, false))
+    end
+
     local ok, err = self.events.post_local("dao:crud", operation, {
       operation  = operation,
       schema     = self.schema,
-      entity     = entity,
-      old_entity = old_entity,
+      entity     = entity_without_nulls,
+      old_entity = old_entity_without_nulls,
     })
     if not ok then
       log(ERR, "[db] failed to propagate CRUD operation: ", err)

--- a/spec/01-unit/01-db/01-schema/01-schema_spec.lua
+++ b/spec/01-unit/01-db/01-schema/01-schema_spec.lua
@@ -3210,51 +3210,6 @@ describe("schema", function()
       end
     end)
 
-    it("sets 'read_before_write' to true when updating field type record", function()
-      local Test = Schema.new({
-        name = "test",
-        fields = {
-          { config = { type = "record", fields = { foo = { type = "string" } } } },
-        }
-      })
-
-      for _, operation in pairs{ "insert", "update", "select", "delete" } do
-        local assertion = assert.falsy
-
-        if operation == "update" then
-          assertion = assert.truthy
-        end
-
-        local _, _, process_auto_fields = Test:process_auto_fields({
-          config = {
-            foo = "dog"
-          }
-        }, operation)
-
-        assertion(process_auto_fields)
-      end
-    end)
-
-    it("sets 'read_before_write' to false when not updating field type record", function()
-      local Test = Schema.new({
-        name = "test",
-        fields = {
-          { config = { type = "record", fields = { foo = { type = "string" } } } },
-          { name = { type = "string" } }
-        }
-      })
-
-      for _, operation in pairs{ "insert", "update", "select", "delete" } do
-        local assertion = assert.falsy
-
-        local _, _, process_auto_fields = Test:process_auto_fields({
-          name = "cat"
-        }, operation)
-
-        assertion(process_auto_fields)
-      end
-    end)
-
     it("correctly flags check_immutable_fields when immutable present in schema", function()
       local test_schema = {
         name = "test",
@@ -3266,7 +3221,7 @@ describe("schema", function()
       local test_entity = { name = "bob" }
 
       local TestEntities = Schema.new(test_schema)
-      local _, _, _, check_immutable_fields =
+      local _, _, check_immutable_fields =
         TestEntities:process_auto_fields(test_entity, "update")
 
       assert.truthy(check_immutable_fields)
@@ -3283,7 +3238,7 @@ describe("schema", function()
       local test_entity = { name = "bob" }
 
       local TestEntities = Schema.new(test_schema)
-      local _, _, _, check_immutable_fields =
+      local _, _, check_immutable_fields =
         TestEntities:process_auto_fields(test_entity, "update")
 
       assert.falsy(check_immutable_fields)

--- a/spec/01-unit/01-db/04-dao_spec.lua
+++ b/spec/01-unit/01-db/04-dao_spec.lua
@@ -164,7 +164,7 @@ describe("DAO", function()
 
   describe("update", function()
 
-    it("does not pre-apply defaults on partial update if field is nullable in schema", function()
+    it("does pre-apply defaults on partial update if field is nullable in schema", function()
       local schema = assert(Schema.new(nullable_schema_definition))
 
       -- mock strategy
@@ -174,8 +174,8 @@ describe("DAO", function()
           return data
         end,
         update = function(_, _, value)
-          -- no defaults pre-applied before partial update
-          assert(value.b == nil)
+          -- defaults pre-applied before partial update
+          assert(value.b == "hello")
           data = utils.deep_merge(data, value)
           return data
         end,
@@ -184,7 +184,7 @@ describe("DAO", function()
       local dao = DAO.new(mock_db, schema, strategy, errors)
 
       data = { a = 42, b = nil, u = nil, r = nil }
-      local row, err = dao:update({ a = 43 }, { u = "foo" })
+      local row, err = dao:update({ a = 42 }, { u = "foo" })
       assert.falsy(err)
       assert.same({ a = 42, b = "hello", u = "foo" }, row)
     end)
@@ -209,7 +209,7 @@ describe("DAO", function()
       local dao = DAO.new(mock_db, schema, strategy, errors)
 
       data = { a = 42, b = nil, u = nil, r = nil }
-      local row, err = dao:update({ a = 43 }, { u = "foo", r = { f1 = 10 } })
+      local row, err = dao:update({ a = 42 }, { u = "foo", r = { f1 = 10 } })
       assert.falsy(err)
       assert.same({ a = 42, b = "hello", u = "foo", r = { f1 = 10, f2 = "world" } }, row)
     end)
@@ -224,9 +224,12 @@ describe("DAO", function()
           return data
         end,
         update = function(_, _, value)
-          -- no defaults pre-applied before partial update
-          assert(value.b == nil)
-          assert(value.r == nil or value.r.f2 == nil)
+          -- defaults pre-applied before partial update
+          assert.equal("hello", value.b)
+          assert.same({
+            f1 = null,
+            f2 = "world",
+          }, value.r)
           data = utils.deep_merge(data, value)
           return data
         end,
@@ -240,16 +243,19 @@ describe("DAO", function()
       assert.same({ a = 42, b = "hello", u = "foo", r = { f1 = ngx.null, f2 = "world" } }, row)
     end)
 
-    it("does not apply defaults on entity if record is nullable in schema", function()
+    it("does apply defaults on entity if record is nullable in schema", function()
       local schema = assert(Schema.new(non_nullable_schema_definition))
 
       -- mock strategy
       local data
       local strategy = {
+        select = function()
+          return data
+        end,
         update = function(_, _, value)
-          -- no defaults pre-applied before partial update
-          assert(value.b == nil)
-          assert(value.r == nil or value.r.f2 == nil)
+          -- defaults pre-applied before partial update
+          assert.equal("hello", value.b)
+          assert.same(null, value.r)
           data = utils.deep_merge(data, value)
           return data
         end,
@@ -300,13 +306,15 @@ describe("DAO", function()
 
       -- mock strategy
       local strategy = {
+        select = function()
+          return {}
+        end,
         update = function()
           return { a = 42, b = null, r = { f1 = 10, f2 = null } }
         end,
       }
 
       local dao = DAO.new(mock_db, schema, strategy, errors)
-
       local row = dao:update({ a = 42 }, { u = "foo" })
       assert.same(42, row.a)
       assert.same("hello", row.b)
@@ -320,6 +328,9 @@ describe("DAO", function()
       -- mock strategy
       local data
       local strategy = {
+        select = function()
+          return data
+        end,
         update = function(_, _, value)
           data = utils.deep_merge(data, value)
           return data

--- a/spec/02-integration/04-admin_api/18-worker-events.lua
+++ b/spec/02-integration/04-admin_api/18-worker-events.lua
@@ -1,0 +1,242 @@
+local helpers = require "spec.helpers"
+local cjson = require "cjson"
+
+
+local pairs = pairs
+local type = type
+local null = ngx.null
+
+
+local function remove_nulls(tbl)
+  for k,v in pairs(tbl) do
+    if v == null then
+      tbl[k] = nil
+    elseif type(v) == "table" then
+      tbl[k] = remove_nulls(v)
+    end
+  end
+  return tbl
+end
+
+
+local headers = {
+  ["Content-Type"] = "application/json"
+}
+
+
+for _, strategy in helpers.each_strategy() do
+  describe("Admin API #" .. strategy, function()
+    local admin_client
+    local proxy_client
+
+    lazy_setup(function()
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+      }, {
+        "worker-events",
+      })
+
+      bp.plugins:insert({
+        name = "worker-events",
+      })
+
+      bp.routes:insert({
+        paths = { "/" }
+      })
+
+      assert(helpers.start_kong {
+        database = strategy,
+        db_update_frequency = 0.1,
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+        plugins = "worker-events",
+      })
+    end)
+
+    lazy_teardown(function()
+      helpers.stop_kong(nil, true)
+    end)
+
+    before_each(function()
+      admin_client = helpers.admin_client()
+      proxy_client = helpers.proxy_client()
+    end)
+
+    after_each(function()
+      if admin_client then
+        admin_client:close()
+      end
+
+      if proxy_client then
+        proxy_client:close()
+      end
+    end)
+
+    describe("worker events", function()
+      it("triggers create event on creation", function()
+        local res = admin_client:post("/routes", {
+          headers = headers,
+          body    = {
+            hosts = {
+              "example.test",
+            },
+          },
+        })
+
+        local body = assert.res_status(201, res)
+        local entity = remove_nulls(cjson.decode(body))
+
+        res  = proxy_client:get("/")
+        body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+
+        assert.same({
+          operation = "create",
+          entity    = entity,
+        }, json)
+      end)
+
+      it("triggers update event with old entity on update", function()
+        local res = admin_client:put("/routes/test-update", {
+          headers = headers,
+          body    = {
+            hosts = {
+              "example.test",
+            },
+          },
+        })
+
+        -- TODO: it should really be 201, but Kong's PUT has always been 200,
+        --       we can change it later (as we now know the difference).
+        local body = assert.res_status(200, res)
+        local entity = remove_nulls(cjson.decode(body))
+
+        res  = proxy_client:get("/")
+        body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+
+        assert.same({
+          operation = "create",
+          entity    = entity,
+        }, json)
+
+        local old_entity = entity
+
+        res = admin_client:patch("/routes/test-update", {
+          headers = headers,
+          body    = {
+            hosts = {
+              "example2.test",
+            },
+          },
+        })
+
+        body = assert.res_status(200, res)
+        entity = remove_nulls(cjson.decode(body))
+
+        res  = proxy_client:get("/")
+        body = assert.res_status(200, res)
+
+        local json = cjson.decode(body)
+
+        assert.same({
+          operation  = "update",
+          entity     = entity,
+          old_entity = old_entity,
+        }, json)
+      end)
+
+      it("triggers update event with old entity on upsert", function()
+        local res = admin_client:put("/routes/test-upsert", {
+          headers = headers,
+          body    = {
+            hosts = {
+              "example.test",
+            },
+          },
+        })
+
+        -- TODO: it should really be 201, but Kong's PUT has always been 200,
+        --       we can change it later (as we now know the difference).
+        local body = assert.res_status(200, res)
+        local entity = remove_nulls(cjson.decode(body))
+
+        res  = proxy_client:get("/")
+        body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+
+        assert.same({
+          operation = "create",
+          entity    = entity,
+        }, json)
+
+        local old_entity = entity
+
+        res = admin_client:put("/routes/test-upsert", {
+          headers = headers,
+          body    = {
+            hosts = {
+              "example2.test",
+            },
+          },
+        })
+
+        body = assert.res_status(200, res)
+        entity = remove_nulls(cjson.decode(body))
+
+        res  = proxy_client:get("/")
+        body = assert.res_status(200, res)
+
+        local json = cjson.decode(body)
+
+        assert.same({
+          operation  = "update",
+          entity     = entity,
+          old_entity = old_entity,
+        }, json)
+      end)
+
+      it("triggers delete event on delete", function()
+        local res = admin_client:put("/routes/test-delete", {
+          headers = headers,
+          body    = {
+            hosts = {
+              "example.test",
+            },
+          },
+        })
+
+        -- TODO: it should really be 201, but Kong's PUT has always been 200,
+        --       we can change it later (as we now know the difference).
+        local body = assert.res_status(200, res)
+        local entity = remove_nulls(cjson.decode(body))
+
+        res  = proxy_client:get("/")
+        body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+
+        assert.same({
+          operation = "create",
+          entity    = entity,
+        }, json)
+
+        res = admin_client:delete("/routes/test-delete", {
+          headers = headers,
+        })
+
+        assert.res_status(204, res)
+
+        res  = proxy_client:get("/")
+        body = assert.res_status(200, res)
+
+        local json = cjson.decode(body)
+
+        assert.same({
+          operation = "delete",
+          entity    = entity,
+        }, json)
+      end)
+    end)
+  end)
+end

--- a/spec/fixtures/custom_plugins/kong/plugins/worker-events/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/worker-events/handler.lua
@@ -1,0 +1,64 @@
+local semaphore = require "ngx.semaphore"
+local cjson = require "cjson"
+
+
+local ngx = ngx
+local kong = kong
+local table = table
+
+
+local worker_events = {}
+local sema
+
+
+local function load_data()
+  local ok, err = sema:wait(5)
+  if ok then
+    local data = table.remove(worker_events, 1)
+    if data then
+      return data
+    end
+
+    return {
+      error = "worker event data not found"
+    }
+  end
+
+  return {
+    error = err
+  }
+end
+
+
+local WorkerEventsHandler = {
+  PRIORITY = 500,
+}
+
+
+function WorkerEventsHandler.init_worker()
+  sema = semaphore.new()
+  kong.worker_events.register(function(data)
+    worker_events[#worker_events+1] = {
+      operation  = data.operation,
+      entity     = data.entity,
+      old_entity = data.old_entity,
+    }
+    sema:post()
+  end, "dao:crud")
+end
+
+
+function WorkerEventsHandler:preread()
+  local data = load_data()
+  local json = cjson.encode(data)
+  ngx.print(json)
+  return ngx.exit(200)
+end
+
+
+function WorkerEventsHandler:access()
+  return kong.response.exit(200, load_data())
+end
+
+
+return WorkerEventsHandler

--- a/spec/fixtures/custom_plugins/kong/plugins/worker-events/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/worker-events/schema.lua
@@ -1,0 +1,17 @@
+local typedefs = require "kong.db.schema.typedefs"
+
+return {
+  name = "worker-events",
+  fields = {
+    {
+      protocols = typedefs.protocols { default = { "http", "https", "tcp", "tls", "grpc", "grpcs" } },
+    },
+    {
+      config = {
+        type = "record",
+        fields = {
+        },
+      },
+    },
+  },
+}


### PR DESCRIPTION
### Summary

I know this is controversial. But It turns out that currently with `upsert` the invalidations do not send the `old entity`, while in _most_ (I think it always should) cases with `update` it does so.

Because there is `old_entity` in `update` (which `upsert` uses too) invalidations and we do have code that relies on it and perhaps 3rd party code in plugins that relies on it, this commit changes our DAOs so that `read-before-write` is always enabled for `update` and `upsert`.

This is for correctness (even when it might mean race condition between read and write). And bugs caused by not having this commit are really hard to investigate. I know that we tried hard to avoid `read-before-write` especially with Cassandra, but we also have had to loosen that and more and more code already does `read-before-write` on `updates`, almost to the point it was going to happen, no matter what. In that sense this does not make things that much different.