### PR TITLE
fix(cassandra) use proper units for timeouts

### DIFF
--- a/kong/db/strategies/cassandra/connector.lua
+++ b/kong/db/strategies/cassandra/connector.lua
@@ -52,7 +52,11 @@ function CassandraConnector.new(kong_config)
                 end
 
                 return tcp.send(tcp, ...)
+
+              elseif k == "settimeout" then
+                return tcp.settimeout(tcp, select(1, ...)/1000)
               end
+
 
               return tcp[k](tcp, ...)
             end
@@ -79,6 +83,10 @@ function CassandraConnector.new(kong_config)
                 end
 
                 return udp.send(udp, ...)
+              end
+
+              elseif k == "settimeout" then
+                return udp.settimeout(udp, select(1, ...)/1000)
               end
 
               return udp[k](udp, ...)

--- a/kong/db/strategies/cassandra/connector.lua
+++ b/kong/db/strategies/cassandra/connector.lua
@@ -82,7 +82,6 @@ function CassandraConnector.new(kong_config)
                 end
 
                 return udp.send(udp, ...)
-              end
 
               elseif k == "settimeout" then
                 return udp.settimeout(udp, select(1, ...)/1000)

--- a/kong/db/strategies/cassandra/connector.lua
+++ b/kong/db/strategies/cassandra/connector.lua
@@ -57,7 +57,6 @@ function CassandraConnector.new(kong_config)
                 return tcp.settimeout(tcp, select(1, ...)/1000)
               end
 
-
               return tcp[k](tcp, ...)
             end
           end


### PR DESCRIPTION
fixes https://discuss.konghq.com/t/kong-pongo-hangs-with-kong-plugin/5517/9

The patch in use allows Cassaandra contactpoints to be resolved in the init phases, but did not patch the `settimeout` method. In OpenResty is uses milliseconds, but in LuaSocket it uses seconds. This ended up that the default timeout of 2000ms turned into 2000s (appr. 33 mins).

This fix will also convert the timeouts to the proper units.