### PR TITLE
tests(proxy) speed up plugin triggering tests

### DIFF
--- a/spec/02-integration/05-proxy/04-plugins_triggering_spec.lua
+++ b/spec/02-integration/05-proxy/04-plugins_triggering_spec.lua
@@ -839,6 +839,10 @@ for _, strategy in helpers.each_strategy() do
         })
         assert.res_status(494, res)
 
+        -- close and reopen to flush the request
+        proxy_client:close()
+        proxy_client = helpers.proxy_client()
+
         -- TEST: ensure that our logging plugin was executed and wrote
         -- something to disk.
 
@@ -875,6 +879,10 @@ for _, strategy in helpers.each_strategy() do
         })
         assert.res_status(494, res)
 
+        -- close and reopen to flush the request
+        proxy_client:close()
+        proxy_client = helpers.proxy_client()
+
         -- TEST: ensure that our logging plugin was executed and wrote
         -- something to disk.
 
@@ -906,6 +914,10 @@ for _, strategy in helpers.each_strategy() do
           }
         })
         assert.res_status(414, res)
+
+        -- close and reopen to flush the request
+        proxy_client:close()
+        proxy_client = helpers.proxy_client()
 
         -- TEST: ensure that our logging plugin was executed and wrote
         -- something to disk.
@@ -941,6 +953,10 @@ for _, strategy in helpers.each_strategy() do
           --]]
         })
         assert.res_status(414, res)
+
+        -- close and reopen to flush the request
+        proxy_client:close()
+        proxy_client = helpers.proxy_client()
 
         -- TEST: ensure that our logging plugin was executed and wrote
         -- something to disk.


### PR DESCRIPTION
The file spec/02-integration/05-proxy/04-plugins_triggering_spec.lua
is currently taking 20s waiting for timeouts (5s timeouts across 4 tests).
By closing the client connections right away, the tests proceeed immediately.

This shaves 20s off each run of this file (for a single database strategy).