### PR TITLE
docs(admin-api) check for and add documentation to missing endpoints

### DIFF
--- a/autodoc/data/admin-api.lua
+++ b/autodoc/data/admin-api.lua
@@ -150,6 +150,136 @@ return {
           ]],
         },
       },
+      ["/endpoints"] = {
+        GET = {
+          title = [[List available endpoints]],
+          endpoint = [[<div class="endpoint get">/endpoints</div>]],
+          description = [[List all available endpoints provided by the Admin API.]],
+          response =[[
+            ```
+            HTTP 200 OK
+            ```
+
+            ```json
+            {
+                "data": [
+                    "/",
+                    "/acls",
+                    "/acls/{acls}",
+                    "/acls/{acls}/consumer",
+                    "/basic-auths",
+                    "/basic-auths/{basicauth_credentials}",
+                    "/basic-auths/{basicauth_credentials}/consumer",
+                    "/ca_certificates",
+                    "/ca_certificates/{ca_certificates}",
+                    "/cache",
+                    "/cache/{key}",
+                    "..."
+                ]
+            }
+            ```
+          ]],
+        },
+      },
+      ["/schemas/:db_entity_name/validate"] = {
+        POST = {
+          title = [[Validate a configuration against a schema]],
+          endpoint = [[<div class="endpoint post">/schemas/{entity}/validate</div>]],
+          description = [[
+            Check validity of a configuration against its entity schema.
+            This allows you to test your input before submitting a request
+            to the entity endpoints of the Admin API.
+
+            Note that this only performs the schema validation checks,
+            checking that the input configuration is well-formed.
+            A requests to the entity endpoint using the given configuration
+            may still fail due to other reasons, such as invalid foreign
+            key relationships or uniqueness check failures against the
+            contents of the data store.
+          ]],
+          response =[[
+            ```
+            HTTP 200 OK
+            ```
+
+            ```json
+            {
+                "message": "schema validation successful"
+            }
+            ```
+          ]],
+        },
+      },
+      ["/schemas/:name"] = {
+        GET = {
+          title = [[Retrieve Entity Schema]],
+          endpoint = [[<div class="endpoint get">/schemas/{entity name}</div>]],
+          description = [[
+            Retrieve the schema of an entity. This is useful to
+            understand what fields an entity accepts, and can be used for building
+            third-party integrations to the Kong.
+          ]],
+          response = [[
+            ```
+            HTTP 200 OK
+            ```
+
+            ```json
+            {
+                "fields": [
+                    {
+                        "id": {
+                            "auto": true,
+                            "type": "string",
+                            "uuid": true
+                        }
+                    },
+                    {
+                        "created_at": {
+                            "auto": true,
+                            "timestamp": true,
+                            "type": "integer"
+                        }
+                    },
+                    ...
+                ]
+            }
+            ```
+          ]],
+        },
+      },
+      ["/schemas/plugins/:name"] = {
+        GET = {
+          title = [[Retrieve Plugin Schema]],
+          endpoint = [[<div class="endpoint get">/schemas/plugins/{plugin name}</div>]],
+          description = [[
+            Retrieve the schema of a plugin's configuration. This is useful to
+            understand what fields a plugin accepts, and can be used for building
+            third-party integrations to the Kong's plugin system.
+          ]],
+          response = [[
+            ```
+            HTTP 200 OK
+            ```
+
+            ```json
+            {
+                "fields": {
+                    "hide_credentials": {
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "key_names": {
+                        "default": "function",
+                        "required": true,
+                        "type": "array"
+                    }
+                }
+            }
+            ```
+          ]],
+        },
+      },
     },
     health = {
       title = [[Health routes]],
@@ -359,7 +489,7 @@ return {
       ["/tags/:tags"] = {
         GET = {
           title = [[ List entity IDs by tag ]],
-          endpoint = [[<div class="endpoint get">/tags/:tags</div>]],
+          endpoint = [[<div class="endpoint get">/tags/{tags}</div>]],
           description = [[
             Returns the entities that have been tagged with the specified tag.
 
@@ -779,37 +909,9 @@ return {
         would have otherwise matched config B.
       ]],
 
+      -- deprecated
       ["/plugins/schema/:name"] = {
-        GET = {
-          title = [[Retrieve Plugin Schema]],
-          endpoint = [[<div class="endpoint get">/plugins/schema/{plugin name}</div>]],
-          description = [[
-            Retrieve the schema of a plugin's configuration. This is useful to
-            understand what fields a plugin accepts, and can be used for building
-            third-party integrations to the Kong's plugin system.
-          ]],
-          response = [[
-            ```
-            HTTP 200 OK
-            ```
-
-            ```json
-            {
-                "fields": {
-                    "hide_credentials": {
-                        "default": false,
-                        "type": "boolean"
-                    },
-                    "key_names": {
-                        "default": "function",
-                        "required": true,
-                        "type": "array"
-                    }
-                }
-            }
-            ```
-          ]],
-        }
+        skip = true,
       },
 
       ["/plugins/enabled"] = {

--- a/scripts/autodoc-admin-api
+++ b/scripts/autodoc-admin-api
@@ -568,6 +568,8 @@ local function write_general_section(outfd, filename, all_endpoints, name, data_
   }
 
   write_endpoints(outfd, info, all_endpoints, data_general.methods)
+
+  return info
 end
 
 local active_verbs = {
@@ -868,6 +870,19 @@ local function check_admin_api_modules(data)
   end
 end
 
+local function check_endpoints(all_endpoints, infos)
+  for _, info in ipairs(infos) do
+    for endpoint, handler in pairs(info.mod) do
+      if handler ~= Endpoints.not_found then
+        assert_data(all_endpoints[endpoint],
+                    "data for implemented endpoint " .. endpoint)
+        assert_data(all_endpoints[endpoint].done or all_endpoints[endpoint].skip,
+                    "done or skip mark in endpoint " .. endpoint)
+      end
+    end
+  end
+end
+
 --------------------------------------------------------------------------------
 
 local function write_admin_api(filename, data, title)
@@ -900,9 +915,13 @@ local function write_admin_api(filename, data, title)
 
   local all_endpoints = {}
 
+  local general_infos = {}
+
   for _, fullname in ipairs(data.known.general_files) do
     local name = fullname:match("/([^/]+)%.lua$")
-    write_general_section(outfd, fullname, all_endpoints, name, data.general)
+    local ginfo = write_general_section(outfd, fullname, all_endpoints, name, data.general)
+    table.insert(general_infos, ginfo)
+    general_infos[name] = ginfo
   end
 
   local entity_infos = {}
@@ -924,16 +943,8 @@ local function write_admin_api(filename, data, title)
   end
 
   -- Check that all endpoints were traversed
-  for _, info in ipairs(entity_infos) do
-    for endpoint, handler in pairs(info.mod) do
-      if handler ~= Endpoints.not_found then
-        assert_data(all_endpoints[endpoint],
-                    "data for implemented endpoint " .. endpoint)
-        assert_data(all_endpoints[endpoint].done or all_endpoints[endpoint].skip,
-                    "done or skip mark in endpoint " .. endpoint)
-      end
-    end
-  end
+  check_endpoints(all_endpoints, entity_infos)
+  check_endpoints(all_endpoints, general_infos)
 
   outfd:write(unindent(assert_data(data.footer, "footer string")))
 


### PR DESCRIPTION
Our check for missing endpoint documentation was checking for
missing _entity_ documentation only, and not to the general
files such as `kong/api/routes/kong.lua`.

This commit:

* adds the check to those files
* adds the missing documentation so that the check passes
* removes a deprecated endpoint (which is now documented in
  the non-deprecated style)