### PR TITLE
tests(*) use busted-htest for shorter color output

### DIFF
--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -8,7 +8,7 @@ function red() {
     echo -e "\033[1;31m$*\033[0m"
 }
 
-export BUSTED_ARGS="-o gtest -v --exclude-tags=flaky,ipv6"
+export BUSTED_ARGS="-o htest -v --exclude-tags=flaky,ipv6"
 
 if [ "$KONG_TEST_DATABASE" == "postgres" ]; then
     export TEST_CMD="bin/busted $BUSTED_ARGS,cassandra,off"

--- a/.ci/setup_env.sh
+++ b/.ci/setup_env.sh
@@ -107,12 +107,14 @@ if [[ "$TEST_SUITE" == "pdk" ]]; then
   cpanm --notest --local-lib=$TRAVIS_BUILD_DIR/perl5 local::lib && eval $(perl -I $TRAVIS_BUILD_DIR/perl5/lib/perl5/ -Mlocal::lib)
 fi
 
-# ----------------
-# Run gRPC server |
-# ----------------
+# ---------------
+# Run gRPC server
+# ---------------
 if [[ "$TEST_SUITE" =~ integration|dbless|plugins ]]; then
   docker run -d --name grpcbin -p 15002:9000 -p 15003:9001 moul/grpcbin
 fi
+
+luarocks install busted-htest 1.0.0
 
 nginx -V
 resty -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ jobs:
       script:
       - luacheck -q .
       - scripts/autodoc-admin-api
-      - bin/busted -v -o gtest spec/01-unit
+      - bin/busted -v -o htest spec/01-unit
       env:
         - KONG_DATABASE=none
 


### PR DESCRIPTION
Use https://github.com/hishamhm/busted-htest as a default for shorter and nicer-looking test outputs in CI.