### PR TITLE
chore(ci) make sure tags dont get built by the nightly cron

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,6 +59,12 @@ pipeline {
                     }
                 }
             }
+            /* the above when statement evaluates to:
+                if (
+                  ( buildingtag && not cron ) ||
+                  ( ( branch = master || branch = next) && cron )
+                )
+            */
             parallel {
                 stage('dbless') {
                     agent {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,13 @@
 pipeline {
     agent none
+    triggers {
+        cron(env.BRANCH_NAME == 'master' | env.BRANCH_NAME == 'next' ? '@daily' : '')
+    }
+    options {
+        retry(1)
+        parallelsAlwaysFailFast()
+        timeout(time: 2, unit: 'HOURS')
+    }
     environment {
         UPDATE_CACHE = "true"
         DOCKER_CREDENTIALS = credentials('dockerhub')
@@ -7,11 +15,21 @@ pipeline {
         DOCKER_PASSWORD = "${env.DOCKER_CREDENTIALS_PSW}"
         KONG_PACKAGE_NAME = "kong"
     }
-    triggers {
-        cron('@daily')
-    }
     stages {
         stage('Build Kong') {
+            when {
+                beforeAgent true
+                anyOf {
+                    allOf {
+                        buildingTag()
+                        not { triggeredBy 'TimerTrigger' }
+                    }
+                    allOf {
+                        triggeredBy 'TimerTrigger'
+                        anyOf { branch 'master'; branch 'next' }
+                    }
+                }
+            }
             agent {
                 node {
                     label 'docker-compose'
@@ -22,13 +40,25 @@ pipeline {
                 KONG_BUILD_TOOLS_LOCATION = "${env.WORKSPACE}/../kong-build-tools"
             }
             steps {
-                sh 'printenv'
                 sh 'echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin || true'
                 sh 'make setup-kong-build-tools'
                 dir('../kong-build-tools') { sh 'make kong-test-container' }
             }
         }
         stage('Integration Tests') {
+            when {
+                beforeAgent true
+                anyOf {
+                    allOf {
+                        buildingTag()
+                        not { triggeredBy 'TimerTrigger' }
+                    }
+                    allOf {
+                        triggeredBy 'TimerTrigger'
+                        anyOf { branch 'master'; branch 'next' }
+                    }
+                }
+            }
             parallel {
                 stage('dbless') {
                     agent {
@@ -43,6 +73,7 @@ pipeline {
                         TEST_SUITE = "dbless"
                     }
                     steps {
+                        sh 'echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin || true'
                         sh 'make setup-kong-build-tools'
                         dir('../kong-build-tools') {
                             sh 'make test-kong'
@@ -61,6 +92,7 @@ pipeline {
                         TEST_DATABASE = 'postgres'
                     }
                     steps {
+                        sh 'echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin || true'
                         sh 'make setup-kong-build-tools'
                         dir('../kong-build-tools') {
                             sh 'make test-kong'
@@ -80,6 +112,7 @@ pipeline {
                         TEST_SUITE = 'plugins'
                     }
                     steps {
+                        sh 'echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin || true'
                         sh 'make setup-kong-build-tools'
                         dir('../kong-build-tools'){
                             sh 'make test-kong'
@@ -98,6 +131,7 @@ pipeline {
                         TEST_DATABASE = 'cassandra'
                     }
                     steps {
+                        sh 'echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin || true'
                         sh 'make setup-kong-build-tools'
                         dir('../kong-build-tools'){
                             sh 'make test-kong'
@@ -108,6 +142,7 @@ pipeline {
         }
         stage('Nightly Releases') {
             when {
+                beforeAgent true
                 allOf {
                     triggeredBy 'TimerTrigger'
                     anyOf { branch 'master'; branch 'next' }
@@ -135,12 +170,10 @@ pipeline {
                         AWS_SECRET_ACCESS_KEY = credentials('AWS_SECRET_ACCESS_KEY')
                         DOCKER_MACHINE_ARM64_NAME = "jenkins-kong-${env.BUILD_NUMBER}"
                         REPOSITORY_OS_NAME = "${env.BRANCH_NAME}"
-                        PATH = "/home/ubuntu/bin/:${env.PATH}"
                         KONG_PACKAGE_NAME = "kong-${env.BRANCH_NAME}"
                     }
                     steps {
                         sh 'make setup-kong-build-tools'
-                        sh 'mkdir -p $HOME/bin'
                         dir('../kong-build-tools'){ sh 'make setup-ci' }
                         sh 'REPOSITORY_NAME=`basename ${GIT_URL%.*}`-nightly KONG_VERSION=`date +%Y-%m-%d` make nightly-release'
                     }
@@ -165,12 +198,10 @@ pipeline {
                         BINTRAY_USR = 'kong-inc_travis-ci@kong'
                         BINTRAY_KEY = credentials('bintray_travis_key')
                         REPOSITORY_OS_NAME = "${env.BRANCH_NAME}"
-                        PATH = "/home/ubuntu/bin/:${env.PATH}"
                         KONG_PACKAGE_NAME = "kong-${env.BRANCH_NAME}"
                     }
                     steps {
                         sh 'make setup-kong-build-tools'
-                        sh 'mkdir -p $HOME/bin'
                         dir('../kong-build-tools'){ sh 'make setup-ci' }
                         sh 'REPOSITORY_NAME=`basename ${GIT_URL%.*}`-nightly KONG_VERSION=`date +%Y-%m-%d` RESTY_IMAGE_TAG=bionic BUILDX=false make nightly-release'
                     }
@@ -191,12 +222,10 @@ pipeline {
                         PRIVATE_KEY_FILE = credentials('kong.private.gpg-key.asc')
                         PRIVATE_KEY_PASSPHRASE = credentials('kong.private.gpg-key.asc.password')
                         REPOSITORY_OS_NAME = "${env.BRANCH_NAME}"
-                        PATH = "/home/ubuntu/bin/:${env.PATH}"
                         KONG_PACKAGE_NAME = "kong-${env.BRANCH_NAME}"
                     }
                     steps {
                         sh 'make setup-kong-build-tools'
-                        sh 'mkdir -p $HOME/bin'
                         dir('../kong-build-tools'){ sh 'make setup-ci' }
                         sh 'cp $PRIVATE_KEY_FILE ../kong-build-tools/kong.private.gpg-key.asc'
                         sh 'REPOSITORY_NAME=`basename ${GIT_URL%.*}`-nightly KONG_VERSION=`date +%Y-%m-%d` RESTY_IMAGE_TAG=6 make nightly-release'
@@ -223,12 +252,10 @@ pipeline {
                         PRIVATE_KEY_FILE = credentials('kong.private.gpg-key.asc')
                         PRIVATE_KEY_PASSPHRASE = credentials('kong.private.gpg-key.asc.password')
                         REPOSITORY_OS_NAME = "${env.BRANCH_NAME}"
-                        PATH = "/home/ubuntu/bin/:${env.PATH}"
                         KONG_PACKAGE_NAME = "kong-${env.BRANCH_NAME}"
                     }
                     steps {
                         sh 'make setup-kong-build-tools'
-                        sh 'mkdir -p $HOME/bin'
                         dir('../kong-build-tools'){ sh 'make setup-ci' }
                         sh 'cp $PRIVATE_KEY_FILE ../kong-build-tools/kong.private.gpg-key.asc'
                         sh 'REPOSITORY_NAME=`basename ${GIT_URL%.*}`-nightly KONG_VERSION=`date +%Y-%m-%d` RESTY_IMAGE_TAG=7 make nightly-release'
@@ -249,12 +276,10 @@ pipeline {
                         BINTRAY_USR = 'kong-inc_travis-ci@kong'
                         BINTRAY_KEY = credentials('bintray_travis_key')
                         REPOSITORY_OS_NAME = "${env.BRANCH_NAME}"
-                        PATH = "/home/ubuntu/bin/:${env.PATH}"
                         KONG_PACKAGE_NAME = "kong-${env.BRANCH_NAME}"
                     }
                     steps {
                         sh 'make setup-kong-build-tools'
-                        sh 'mkdir -p $HOME/bin'
                         dir('../kong-build-tools'){ sh 'make setup-ci' }
                         sh 'REPOSITORY_NAME=`basename ${GIT_URL%.*}`-nightly KONG_VERSION=`date +%Y-%m-%d` RESTY_IMAGE_TAG=jessie make nightly-release'
                         sh 'REPOSITORY_NAME=`basename ${GIT_URL%.*}`-nightly KONG_VERSION=`date +%Y-%m-%d` RESTY_IMAGE_TAG=stretch make nightly-release'
@@ -275,12 +300,10 @@ pipeline {
                         KONG_BUILD_TOOLS_LOCATION = "${env.WORKSPACE}/../kong-build-tools"
                         BINTRAY_USR = 'kong-inc_travis-ci@kong'
                         BINTRAY_KEY = credentials('bintray_travis_key')
-                        PATH = "/home/ubuntu/bin/:${env.PATH}"
                         KONG_PACKAGE_NAME = "kong-${env.BRANCH_NAME}"
                     }
                     steps {
                         sh 'make setup-kong-build-tools'
-                        sh 'mkdir -p $HOME/bin'
                         dir('../kong-build-tools'){ sh 'make setup-ci' }
                         sh 'REPOSITORY_NAME=`basename ${GIT_URL%.*}`-nightly PACKAGE_TYPE=src RESTY_IMAGE_BASE=src KONG_VERSION=`date +%Y-%m-%d` make nightly-release'
                         sh 'REPOSITORY_NAME=`basename ${GIT_URL%.*}`-nightly PACKAGE_TYPE=apk RESTY_IMAGE_BASE=alpine RESTY_IMAGE_TAG=1 KONG_VERSION=`date +%Y-%m-%d` make nightly-release'
@@ -291,7 +314,11 @@ pipeline {
         }
         stage('Release') {
             when {
-                buildingTag()
+                beforeAgent true
+                allOf {
+                    buildingTag()
+                    not { triggeredBy 'TimerTrigger' }
+                }
             }
             parallel {
                 stage('Ubuntu Xenial Release') {
@@ -313,11 +340,9 @@ pipeline {
                         BINTRAY_KEY = credentials('bintray_travis_key')
                         AWS_ACCESS_KEY = credentials('AWS_ACCESS_KEY')
                         AWS_SECRET_ACCESS_KEY = credentials('AWS_SECRET_ACCESS_KEY')
-                        PATH = "/home/ubuntu/bin/:${env.PATH}"
                     }
                     steps {
                         sh 'make setup-kong-build-tools'
-                        sh 'mkdir -p $HOME/bin'
                         dir('../kong-build-tools'){ sh 'make setup-ci' }
                         sh 'make release'
                     }
@@ -341,11 +366,9 @@ pipeline {
                         KONG_BUILD_TOOLS_LOCATION = "${env.WORKSPACE}/../kong-build-tools"
                         BINTRAY_USR = 'kong-inc_travis-ci@kong'
                         BINTRAY_KEY = credentials('bintray_travis_key')
-                        PATH = "/home/ubuntu/bin/:${env.PATH}"
                     }
                     steps {
                         sh 'make setup-kong-build-tools'
-                        sh 'mkdir -p $HOME/bin'
                         dir('../kong-build-tools'){ sh 'make setup-ci' }
                         sh 'RESTY_IMAGE_TAG=bionic make release'
                     }
@@ -365,11 +388,9 @@ pipeline {
                         BINTRAY_KEY = credentials('bintray_travis_key')
                         PRIVATE_KEY_FILE = credentials('kong.private.gpg-key.asc')
                         PRIVATE_KEY_PASSPHRASE = credentials('kong.private.gpg-key.asc.password')
-                        PATH = "/home/ubuntu/bin/:${env.PATH}"
                     }
                     steps {
                         sh 'make setup-kong-build-tools'
-                        sh 'mkdir -p $HOME/bin'
                         dir('../kong-build-tools'){ sh 'make setup-ci' }
                         sh 'cp $PRIVATE_KEY_FILE ../kong-build-tools/kong.private.gpg-key.asc'
                         sh 'RESTY_IMAGE_TAG=6 make release'
@@ -392,11 +413,9 @@ pipeline {
                         BINTRAY_KEY = credentials('bintray_travis_key')
                         PRIVATE_KEY_FILE = credentials('kong.private.gpg-key.asc')
                         PRIVATE_KEY_PASSPHRASE = credentials('kong.private.gpg-key.asc.password')
-                        PATH = "/home/ubuntu/bin/:${env.PATH}"
                     }
                     steps {
                         sh 'make setup-kong-build-tools'
-                        sh 'mkdir -p $HOME/bin'
                         dir('../kong-build-tools'){ sh 'make setup-ci' }
                         sh 'cp $PRIVATE_KEY_FILE ../kong-build-tools/kong.private.gpg-key.asc'
                         sh 'RESTY_IMAGE_TAG=7 make release'
@@ -416,11 +435,9 @@ pipeline {
                         KONG_BUILD_TOOLS_LOCATION = "${env.WORKSPACE}/../kong-build-tools"
                         BINTRAY_USR = 'kong-inc_travis-ci@kong'
                         BINTRAY_KEY = credentials('bintray_travis_key')
-                        PATH = "/home/ubuntu/bin/:${env.PATH}"
                     }
                     steps {
                         sh 'make setup-kong-build-tools'
-                        sh 'mkdir -p $HOME/bin'
                         dir('../kong-build-tools'){ sh 'make setup-ci' }
                         sh 'RESTY_IMAGE_TAG=jessie make release'
                         sh 'RESTY_IMAGE_TAG=stretch make release'
@@ -441,11 +458,9 @@ pipeline {
                         KONG_BUILD_TOOLS_LOCATION = "${env.WORKSPACE}/../kong-build-tools"
                         BINTRAY_USR = 'kong-inc_travis-ci@kong'
                         BINTRAY_KEY = credentials('bintray_travis_key')
-                        PATH = "/home/ubuntu/bin/:${env.PATH}"
                     }
                     steps {
                         sh 'make setup-kong-build-tools'
-                        sh 'mkdir -p $HOME/bin'
                         dir('../kong-build-tools'){ sh 'make setup-ci' }
                         sh 'PACKAGE_TYPE=src RESTY_IMAGE_BASE=src make release'
                         sh 'PACKAGE_TYPE=apk RESTY_IMAGE_BASE=alpine RESTY_IMAGE_TAG=1 make release'


### PR DESCRIPTION
There's only two conditions in which Jenkins should be doing anything

Release:
- run from SCM don't run from cron

Nightly Release:
- run from timer don't run from SCM
- only run on master and next


SCM push to next / master is a noop
![Capture](https://user-images.githubusercontent.com/697188/75071493-749ca400-54c3-11ea-8793-8f352651f2fd.PNG)

cron event runs build, test and nightly release stages
![Capture2](https://user-images.githubusercontent.com/697188/75071491-74040d80-54c3-11ea-9b03-45cf21e38cd1.PNG)

SCM tag runs build, test and nightly release stage also the tag doesn't attempt to re-run every 24hrs
![Capture3](https://user-images.githubusercontent.com/697188/75071494-749ca400-54c3-11ea-8ff1-c1766b985122.PNG)
