### PR TITLE
Bugfix: instances of same go-plugin on different routes get mixed.

### DIFF
--- a/kong/runloop/plugins_iterator.lua
+++ b/kong/runloop/plugins_iterator.lua
@@ -66,12 +66,6 @@ local function load_plugin_from_db(key)
     return nil, tostring(err)
   end
 
-  if type(row) == 'table' then
-    row.__key__ = key
-    row.__seq__ = next_seq
-    next_seq = next_seq + 1
-  end
-
   return row
 end
 
@@ -108,6 +102,12 @@ local function load_configuration(ctx,
   end
 
   local cfg = plugin.config or {}
+
+  if not cfg.__key__ then
+    cfg.__key__ = key
+    cfg.__seq__ = next_seq
+    next_seq = next_seq + 1
+  end
 
   cfg.route_id    = plugin.route and plugin.route.id
   cfg.service_id  = plugin.service and plugin.service.id


### PR DESCRIPTION
### Summary
When using declarative configuration, the cache object holding the plugin configs doesn't
seem to call the `load_plugin_from_db()` function.  (maybe it's preloaded some other way?)
This makes they never get the full DB key injected in the config, so the
`go.get_instance()` function falls back to using just the plugin name as the key to the
instance ID table.  Hilarity ensues.

This patch moves the injection of the `__key__` and `__seq__` fields from the
`load_plugin_from_db()` function to the outer `load_configuration()` function, so it works
on any DB strategy.

fix: https://discuss.konghq.com/t/the-go-plugin-may-not-work-right/5545