### PR TITLE
chore(deps) bump lua-resty-openssl to 0.5.3

### DIFF
--- a/kong-2.0.0-0.rockspec
+++ b/kong-2.0.0-0.rockspec
@@ -35,7 +35,7 @@ dependencies = {
   "lua-resty-cookie == 0.1.0",
   "lua-resty-mlcache == 2.4.1",
   "lua-messagepack == 0.5.2",
-  "lua-resty-openssl == 0.4.3",
+  "lua-resty-openssl == 0.5.3",
   "lua-resty-counter == 0.2.0",
   -- external Kong plugins
   "kong-plugin-azure-functions ~> 0.4",


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Bump lua-resty-openssl to 0.5.3.
Needed by https://github.com/Kong/lua-kong-nginx-module/pull/11
and https://github.com/Kong/kong/issues/5549

Full changelog https://github.com/fffonion/lua-resty-openssl/compare/0.4.3...0.5.3

### Full changelog

* Bump lua-resty-openssl to 0.5.3 to support x509 store functions and lua-resty-hmac compat mode.

### Issues resolved

Fix #5549
