### PR TITLE
tests(balancer) reduce the flakiness of the test suite by forcing router

### DIFF
--- a/kong/api/routes/cache.lua
+++ b/kong/api/routes/cache.lua
@@ -31,6 +31,7 @@ return {
 
     DELETE = function(self)
       kong.cache:invalidate_local(self.params.key)
+      kong.core_cache:invalidate_local(self.params.key)
 
       return kong.response.exit(204) -- no content
     end,


### PR DESCRIPTION
invalidation on Kong instance 2 after route update on Kong instance 1

Also make sure the `DELETE /cache/<cache_key>` invalidates both core
and user facing cache, just like `DELETE /cache`

This should make `next` run consistently green. Before it was like this: https://travis-ci.org/Kong/kong/builds/653089923?utm_source=github_status&utm_medium=notification

We are tracking the router rebuild issue in the particular test setup elsewhere, as it is not related to the balancer tests in any way.