### PR TITLE
fix(migrations) do not error if desired state is achieved

### DIFF
--- a/kong/cmd/utils/migrations.lua
+++ b/kong/cmd/utils/migrations.lua
@@ -170,7 +170,7 @@ end
 local function reset(schema_state, db, ttl)
   if schema_state.needs_bootstrap then
     log("Database not bootstrapped, nothing to reset")
-    return false
+    return true
   end
 
   local opts = {

--- a/spec/02-integration/02-cmd/10-migrations_spec.lua
+++ b/spec/02-integration/02-cmd/10-migrations_spec.lua
@@ -98,7 +98,7 @@ for _, strategy in helpers.each_strategy() do
       it("does not reset twice", function()
         run_kong("migrations reset --yes")
         local code, stdout = run_kong("migrations reset --yes")
-        assert.same(1, code)
+        assert.same(0, code)
         assert.match("nothing to reset", stdout, 1, true)
       end)
     end)
@@ -308,7 +308,7 @@ for _, strategy in helpers.each_strategy() do
         code, _, stderr = run_kong("migrations reset --yes", {
           plugins = "bundled"
         }, true)
-        assert.equal(1, code)
+        assert.equal(0, code)
         assert.equal("", stderr)
 
         code, _, stderr = run_kong("migrations bootstrap", {
@@ -364,7 +364,7 @@ for _, strategy in helpers.each_strategy() do
         code, _, stderr = run_kong("migrations reset --yes", {
           plugins = "bundled"
         }, true)
-        assert.equal(1, code)
+        assert.equal(0, code)
         assert.equal("", stderr)
 
         code, _, stderr = run_kong("migrations bootstrap", {


### PR DESCRIPTION
resetting a database while not bootstrapped essentially means
that the database is already in the desired state. So issue
the same message, but exit without an error code.

fixes #5605
