### PR TITLE
fix(clustering) fix an issue that when running CP with multiple workers,

### DIFF
--- a/kong/clustering.lua
+++ b/kong/clustering.lua
@@ -405,13 +405,23 @@ function _M.init_worker(conf)
     -- ROLE = "control_plane"
 
     kong.worker_events.register(function(data)
+      -- we have to re-broadcast event using `post` because the dao
+      -- events were sent using `post_local` which means not all workers
+      -- can receive it
+      local res, err = kong.worker_events.post("clustering", "push_config")
+      if not res then
+        ngx_log(ngx_ERR, "unable to broadcast event: " .. err)
+      end
+    end, "dao:crud")
+
+    kong.worker_events.register(function(data)
       local res, err = declarative.export_config()
       if not res then
         ngx_log(ngx_ERR, "unable to export config from database: " .. err)
       end
 
       push_config(res)
-    end, "dao:crud")
+    end, "clustering", "push_config")
   end
 end
 


### PR DESCRIPTION
CRUD events generated by Admin API may not be propagated to other
workers correctly, causing sync delays

Note: I manually tested this locally by running 12 workers for the CP and make Admin API changes, each change now generates 12 log entry with different PIDs for each, which means all the workers received the event correctly.

```
2020/02/25 09:03:10 [debug] 5191#0: *7056 [lua] clustering.lua:309: push_config(): config pushed to 1 clients
2020/02/25 09:03:10 [debug] 5200#0: *7057 [lua] clustering.lua:309: push_config(): config pushed to 0 clients
2020/02/25 09:03:10 [debug] 5196#0: *7058 [lua] clustering.lua:309: push_config(): config pushed to 0 clients
2020/02/25 09:03:12 [debug] 5197#0: *7167 [lua] clustering.lua:309: push_config(): config pushed to 0 clients
2020/02/25 09:03:13 [debug] 5190#0: *7204 [lua] clustering.lua:309: push_config(): config pushed to 0 clients
2020/02/25 09:03:13 [debug] 5189#0: *7206 [lua] clustering.lua:309: push_config(): config pushed to 0 clients
2020/02/25 09:03:13 [debug] 5199#0: *7207 [lua] clustering.lua:309: push_config(): config pushed to 0 clients
2020/02/25 09:03:13 [debug] 5198#0: *7209 [lua] clustering.lua:309: push_config(): config pushed to 0 clients
2020/02/25 09:03:13 [debug] 5195#0: *7208 [lua] clustering.lua:309: push_config(): config pushed to 0 clients
2020/02/25 09:03:13 [debug] 5194#0: *7210 [lua] clustering.lua:309: push_config(): config pushed to 0 clients
2020/02/25 09:03:13 [debug] 5192#0: *7211 [lua] clustering.lua:309: push_config(): config pushed to 0 clients
2020/02/25 09:03:13 [debug] 5193#0: *7212 [lua] clustering.lua:309: push_config(): config pushed to 0 clients
```