### PR TITLE
chore(ci) github actions via kbt

### DIFF
--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -12,7 +12,7 @@ export BUSTED_ARGS="--no-k -o htest  -v --exclude-tags=flaky,ipv6"
 
 if [ "$KONG_TEST_DATABASE" == "postgres" ]; then
     export TEST_CMD="bin/busted $BUSTED_ARGS,cassandra,off"
-    psql -v ON_ERROR_STOP=1 -h ${KONG_PG_HOST} -U ${KONG_PG_USER} -d ${KONG_PG_DATABASE} <<-EOSQL
+    psql -v ON_ERROR_STOP=1 -h ${KONG_TEST_PG_HOST} -U ${KONG_TEST_PG_USER} -d ${KONG_TEST_PG_DATABASE} <<-EOSQL
         CREATE user ${KONG_TEST_PG_USER}_ro;
         GRANT CONNECT ON DATABASE $KONG_TEST_PG_DATABASE TO ${KONG_TEST_PG_USER}_ro;
         \c $KONG_TEST_PG_DATABASE;

--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -92,7 +92,7 @@ if [ "$TEST_SUITE" == "plugins" ]; then
     fi
 fi
 if [ "$TEST_SUITE" == "pdk" ]; then
-    TEST_NGINX_RANDOMIZE=1 prove -I. -j$JOBS -r t/01-pdk/
+    TEST_NGINX_RANDOMIZE=1 prove -I. -j$JOBS -r t/01-pdk
 fi
 if [ "$TEST_SUITE" == "unit" ]; then
     unset KONG_TEST_NGINX_USER KONG_PG_PASSWORD KONG_TEST_PG_PASSWORD

--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -ex
 
 function cyan() {
     echo -e "\033[1;36m$*\033[0m"

--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -101,6 +101,9 @@ fi
 if [ "$TEST_SUITE" == "pdk" ]; then
     TEST_NGINX_RANDOMIZE=1 prove -I. -j$JOBS -r t/01-pdk
 fi
+if [ "$TEST_SUITE" == "lint" ]; then
+    make lint
+fi
 if [ "$TEST_SUITE" == "unit" ]; then
     scripts/autodoc-admin-api
     bin/busted -v -o gtest spec/01-unit

--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -101,11 +101,9 @@ fi
 if [ "$TEST_SUITE" == "pdk" ]; then
     TEST_NGINX_RANDOMIZE=1 prove -I. -j$JOBS -r t/01-pdk
 fi
-if [ "$TEST_SUITE" == "lint" ]; then
-    make lint
-fi
 if [ "$TEST_SUITE" == "unit" ]; then
     unset KONG_TEST_NGINX_USER KONG_PG_PASSWORD KONG_TEST_PG_PASSWORD
     scripts/autodoc-admin-api
     bin/busted -v -o gtest spec/01-unit
+    make lint
 fi

--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -105,6 +105,7 @@ if [ "$TEST_SUITE" == "lint" ]; then
     make lint
 fi
 if [ "$TEST_SUITE" == "unit" ]; then
+    unset KONG_TEST_NGINX_USER KONG_PG_PASSWORD KONG_TEST_PG_PASSWORD
     scripts/autodoc-admin-api
     bin/busted -v -o gtest spec/01-unit
 fi

--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -12,6 +12,13 @@ export BUSTED_ARGS="--no-k -o htest  -v --exclude-tags=flaky,ipv6"
 
 if [ "$KONG_TEST_DATABASE" == "postgres" ]; then
     export TEST_CMD="bin/busted $BUSTED_ARGS,cassandra,off"
+    psql -v ON_ERROR_STOP=1 -h $KONG_PG_HOST --username "$KONG_TEST_PG_USER" <<-EOSQL
+        CREATE user ${KONG_TEST_PG_USER}_ro;
+        GRANT CONNECT ON DATABASE $KONG_TEST_PG_DATABASE TO ${KONG_TEST_PG_USER}_ro;
+        \c $KONG_TEST_PG_DATABASE;
+        GRANT USAGE ON SCHEMA public TO ${KONG_TEST_PG_USER}_ro;
+        ALTER DEFAULT PRIVILEGES FOR ROLE $KONG_TEST_PG_USER IN SCHEMA public GRANT SELECT ON TABLES TO ${KONG_TEST_PG_USER}_ro;
+EOSQL
 elif [ "$KONG_TEST_DATABASE" == "cassandra" ]; then
     export KONG_TEST_CASSANDRA_KEYSPACE=kong_tests
     export KONG_TEST_DB_UPDATE_PROPAGATION=1
@@ -95,8 +102,6 @@ if [ "$TEST_SUITE" == "pdk" ]; then
     TEST_NGINX_RANDOMIZE=1 prove -I. -j$JOBS -r t/01-pdk
 fi
 if [ "$TEST_SUITE" == "unit" ]; then
-    unset KONG_TEST_NGINX_USER KONG_PG_PASSWORD KONG_TEST_PG_PASSWORD
-    luacheck -q .
     scripts/autodoc-admin-api
     bin/busted -v -o gtest spec/01-unit
 fi

--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -12,7 +12,7 @@ export BUSTED_ARGS="--no-k -o htest  -v --exclude-tags=flaky,ipv6"
 
 if [ "$KONG_TEST_DATABASE" == "postgres" ]; then
     export TEST_CMD="bin/busted $BUSTED_ARGS,cassandra,off"
-    psql -v ON_ERROR_STOP=1 -h $KONG_PG_HOST --username "$KONG_TEST_PG_USER" <<-EOSQL
+    psql -v ON_ERROR_STOP=1 -h ${KONG_PG_HOST} -U ${KONG_PG_USER} -d ${KONG_PG_DATABASE} <<-EOSQL
         CREATE user ${KONG_TEST_PG_USER}_ro;
         GRANT CONNECT ON DATABASE $KONG_TEST_PG_DATABASE TO ${KONG_TEST_PG_USER}_ro;
         \c $KONG_TEST_PG_DATABASE;

--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -8,7 +8,7 @@ function red() {
     echo -e "\033[1;31m$*\033[0m"
 }
 
-export BUSTED_ARGS="-o htest -v --exclude-tags=flaky,ipv6"
+export BUSTED_ARGS="--no-k -o htest  -v --exclude-tags=flaky,ipv6"
 
 if [ "$KONG_TEST_DATABASE" == "postgres" ]; then
     export TEST_CMD="bin/busted $BUSTED_ARGS,cassandra,off"
@@ -21,8 +21,23 @@ else
 fi
 
 if [ "$TEST_SUITE" == "integration" ]; then
-    eval "$TEST_CMD" spec/02-integration/
+    if [[ "$TEST_SPLIT" == first* ]]; then
+        # GitHub Actions, run first batch of integration tests
+        eval "$TEST_CMD" $(ls -d spec/02-integration/* | head -n4)
+
+    elif [[ "$TEST_SPLIT" == second* ]]; then
+        # GitHub Actions, run second batch of integration tests
+        # Note that the split here is chosen carefully to result
+        # in a similar run time between the two batches, and should
+        # be adjusted if imbalance become significant in the future
+        eval "$TEST_CMD" $(ls -d spec/02-integration/* | tail -n+5)
+
+    else
+        # Non GitHub Actions
+        eval "$TEST_CMD" spec/02-integration/
+    fi
 fi
+
 if [ "$TEST_SUITE" == "dbless" ]; then
     eval "$TEST_CMD" spec/02-integration/02-cmd \
                      spec/02-integration/05-proxy \
@@ -77,5 +92,11 @@ if [ "$TEST_SUITE" == "plugins" ]; then
     fi
 fi
 if [ "$TEST_SUITE" == "pdk" ]; then
-    TEST_NGINX_RANDOMIZE=1 prove -I. -j$JOBS -r t/01-pdk
+    TEST_NGINX_RANDOMIZE=1 prove -I. -j$JOBS -r t/01-pdk/
+fi
+if [ "$TEST_SUITE" == "unit" ]; then
+    unset KONG_TEST_NGINX_USER KONG_PG_PASSWORD KONG_TEST_PG_PASSWORD
+    luacheck -q .
+    scripts/autodoc-admin-api
+    bin/busted -v -o gtest spec/01-unit
 fi

--- a/.ci/setup_env.sh
+++ b/.ci/setup_env.sh
@@ -110,20 +110,6 @@ if [[ "$TEST_SUITE" =~ integration|dbless|plugins ]]; then
   docker run -d --name grpcbin -p 15002:9000 -p 15003:9001 moul/grpcbin
 fi
 
-luarocks install busted-htest 1.0.0
-
-if [[ "$KONG_TEST_DATABASE" == "postgres" ]]; then
-  psql -v ON_ERROR_STOP=1 --username "$KONG_TEST_PG_USER" <<-EOSQL
-      CREATE user ${KONG_TEST_PG_USER}_ro;
-
-      GRANT CONNECT ON DATABASE $KONG_TEST_PG_DATABASE TO ${KONG_TEST_PG_USER}_ro;
-      \c $KONG_TEST_PG_DATABASE;
-      GRANT USAGE ON SCHEMA public TO ${KONG_TEST_PG_USER}_ro;
-      ALTER DEFAULT PRIVILEGES FOR ROLE $KONG_TEST_PG_USER IN SCHEMA public GRANT SELECT ON TABLES TO ${KONG_TEST_PG_USER}_ro;
-EOSQL
-fi
-
-
 nginx -V
 resty -V
 luarocks --version

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -27,10 +27,43 @@ jobs:
     - name: Build Test Image
       run: pushd $KONG_BUILD_TOOLS_LOCATION && make kong-test-container && popd
 
+  lint-and-unit-tests:
+    name: Lint & Unit tests
+    runs-on: ubuntu-18.04
+    needs: build
+
+    strategy:
+      matrix:
+        suite: [unit, pdk]
+
+    env:
+      TEST_SUITE: ${{ matrix.suite }}
+      DEBUG: 1
+
+    steps:
+    - name: Set env
+      run: |
+          echo "::set-env name=KONG_SOURCE_LOCATION::$GITHUB_WORKSPACE"
+          echo "::set-env name=KONG_BUILD_TOOLS_LOCATION::$HOME/kong-build-tools"
+        
+    - uses: azure/docker-login@v1
+      with:
+        username: ${{ secrets.KONG_USERNAME }}
+        password: ${{ secrets.KONG_PASSWORD }}
+
+    - name: Checkout Kong source code
+      uses: actions/checkout@v2
+
+    - name: Setup Kong Build Tools
+      run: make setup-kong-build-tools
+
+    - name: Run Tests
+      run: pushd $KONG_BUILD_TOOLS_LOCATION && make test-kong && popd
+
   integration-tests-dbless:
     name: DB-less integration tests
     runs-on: ubuntu-18.04
-    needs: build
+    needs: lint-and-unit-tests
 
     env:
       TEST_DATABASE: 'off'
@@ -59,7 +92,7 @@ jobs:
   integration-tests-with-databases:
     name: ${{matrix.database}} (${{ matrix.suite }}) ${{ matrix.split }} integration tests
     runs-on: ubuntu-18.04
-    needs: build
+    needs: lint-and-unit-tests
 
     strategy:
       matrix:
@@ -78,39 +111,6 @@ jobs:
       TEST_DATABASE: ${{ matrix.database }}
       TEST_SUITE: ${{ matrix.suite }}
       TEST_SPLIT: ${{ matrix.split }}
-
-    steps:
-    - name: Set env
-      run: |
-          echo "::set-env name=KONG_SOURCE_LOCATION::$GITHUB_WORKSPACE"
-          echo "::set-env name=KONG_BUILD_TOOLS_LOCATION::$HOME/kong-build-tools"
-        
-    - uses: azure/docker-login@v1
-      with:
-        username: ${{ secrets.KONG_USERNAME }}
-        password: ${{ secrets.KONG_PASSWORD }}
-
-    - name: Checkout Kong source code
-      uses: actions/checkout@v2
-
-    - name: Setup Kong Build Tools
-      run: make setup-kong-build-tools
-
-    - name: Run Tests
-      run: pushd $KONG_BUILD_TOOLS_LOCATION && make test-kong && popd
-
-  tests-without-a-database:
-    name: Tests without a datastore
-    runs-on: ubuntu-18.04
-    needs: build
-
-    strategy:
-      matrix:
-        suite: [unit, pdk]
-
-    env:
-      TEST_SUITE: ${{ matrix.suite }}
-      DEBUG: 1
 
     steps:
     - name: Set env

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,132 @@
+name: Build & Test
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-18.04
+
+    steps:
+    - name: Set env
+      run: |
+          echo "::set-env name=KONG_SOURCE_LOCATION::$GITHUB_WORKSPACE"
+          echo "::set-env name=KONG_BUILD_TOOLS_LOCATION::$HOME/kong-build-tools"
+        
+    - uses: azure/docker-login@v1
+      with:
+        username: ${{ secrets.KONG_USERNAME }}
+        password: ${{ secrets.KONG_PASSWORD }}
+
+    - name: Checkout Kong source code
+      uses: actions/checkout@v2
+
+    - name: Setup Kong Build Tools
+      run: make setup-kong-build-tools
+
+    - name: Build Test Image
+      run: pushd $KONG_BUILD_TOOLS_LOCATION && make kong-test-container && popd
+
+  integration-tests-dbless:
+    name: DB-less tests
+    runs-on: ubuntu-18.04
+    needs: build
+
+    env:
+      TEST_DATABASE: 'off'
+      TEST_SUITE: dbless
+      
+    steps:
+    - name: Set env
+      run: |
+          echo "::set-env name=KONG_SOURCE_LOCATION::$GITHUB_WORKSPACE"
+          echo "::set-env name=KONG_BUILD_TOOLS_LOCATION::$HOME/kong-build-tools"
+        
+    - uses: azure/docker-login@v1
+      with:
+        username: ${{ secrets.KONG_USERNAME }}
+        password: ${{ secrets.KONG_PASSWORD }}
+
+    - name: Checkout Kong source code
+      uses: actions/checkout@v2
+
+    - name: Setup Kong Build Tools
+      run: make setup-kong-build-tools
+
+    - name: Run Tests
+      run: pushd $KONG_BUILD_TOOLS_LOCATION && make test-kong && popd
+
+  integration-tests-with-databases:
+    name: ${{matrix.database}} (${{ matrix.suite }}) ${{ matrix.split }} integration tests
+    runs-on: ubuntu-18.04
+    needs: build
+
+    strategy:
+      matrix:
+        split: [first, second, all]
+        suite: [integration, plugins]
+        database: [cassandra, postgres]
+        exclude:
+          - SUITE: plugins
+            split: first
+          - suite: plugins
+            split: second
+          - suite: integration
+            split: all
+
+    env:
+      TEST_DATABASE: ${{ matrix.database }}
+      TEST_SUITE: ${{ matrix.suite }}
+      TEST_SPLIT: ${{ matrix.split }}
+
+    steps:
+    - name: Set env
+      run: |
+          echo "::set-env name=KONG_SOURCE_LOCATION::$GITHUB_WORKSPACE"
+          echo "::set-env name=KONG_BUILD_TOOLS_LOCATION::$HOME/kong-build-tools"
+        
+    - uses: azure/docker-login@v1
+      with:
+        username: ${{ secrets.KONG_USERNAME }}
+        password: ${{ secrets.KONG_PASSWORD }}
+
+    - name: Checkout Kong source code
+      uses: actions/checkout@v2
+
+    - name: Setup Kong Build Tools
+      run: make setup-kong-build-tools
+
+    - name: Run Tests
+      run: pushd $KONG_BUILD_TOOLS_LOCATION && make test-kong && popd
+
+  tests-without-a-database:
+    name: Tests without a datastore
+    runs-on: ubuntu-18.04
+    needs: build
+
+    strategy:
+      matrix:
+        suite: [unit, pdk]
+
+    env:
+      TEST_SUITE: ${{ matrix.suite }}
+
+    steps:
+    - name: Set env
+      run: |
+          echo "::set-env name=KONG_SOURCE_LOCATION::$GITHUB_WORKSPACE"
+          echo "::set-env name=KONG_BUILD_TOOLS_LOCATION::$HOME/kong-build-tools"
+        
+    - uses: azure/docker-login@v1
+      with:
+        username: ${{ secrets.KONG_USERNAME }}
+        password: ${{ secrets.KONG_PASSWORD }}
+
+    - name: Checkout Kong source code
+      uses: actions/checkout@v2
+
+    - name: Setup Kong Build Tools
+      run: make setup-kong-build-tools
+
+    - name: Run Tests
+      run: pushd $KONG_BUILD_TOOLS_LOCATION && make test-kong && popd

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -27,17 +27,45 @@ jobs:
     - name: Build Test Image
       run: pushd $KONG_BUILD_TOOLS_LOCATION && make kong-test-container && popd
 
-  pdk-lint-unit-tests:
-    name: Unit & PDK
+  lint-unit-tests:
+    name: Lint & Unit
     runs-on: ubuntu-18.04
     needs: build
 
     strategy:
       matrix:
-        suite: [unit, pdk, lint]
+        suite: [unit, lint]
 
     env:
       TEST_SUITE: ${{ matrix.suite }}
+
+    steps:
+    - name: Set env
+      run: |
+          echo "::set-env name=KONG_SOURCE_LOCATION::$GITHUB_WORKSPACE"
+          echo "::set-env name=KONG_BUILD_TOOLS_LOCATION::$HOME/kong-build-tools"
+        
+    - uses: azure/docker-login@v1
+      with:
+        username: ${{ secrets.KONG_USERNAME }}
+        password: ${{ secrets.KONG_PASSWORD }}
+
+    - name: Checkout Kong source code
+      uses: actions/checkout@v2
+
+    - name: Setup Kong Build Tools
+      run: make setup-kong-build-tools
+
+    - name: Run Tests
+      run: pushd $KONG_BUILD_TOOLS_LOCATION && make test-kong && popd
+
+  pdk:
+    name: PDK
+    runs-on: ubuntu-18.04
+    needs: build
+
+    env:
+      TEST_SUITE: pdk
       DEBUG: 1
 
     steps:
@@ -63,7 +91,7 @@ jobs:
   integration-tests-dbless:
     name: DB-less integration tests
     runs-on: ubuntu-18.04
-    needs: pdk-lint-unit-tests
+    needs: lint-unit-tests
 
     env:
       TEST_DATABASE: 'off'
@@ -92,7 +120,7 @@ jobs:
   integration-tests-with-databases:
     name: ${{matrix.database}} (${{ matrix.suite }}) ${{ matrix.split }} integration tests
     runs-on: ubuntu-18.04
-    needs: pdk-lint-unit-tests
+    needs: lint-unit-tests
 
     strategy:
       matrix:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -27,8 +27,33 @@ jobs:
     - name: Build Test Image
       run: pushd $KONG_BUILD_TOOLS_LOCATION && make kong-test-container && popd
 
-  lint-and-unit-tests:
-    name: Lint & Unit tests
+  lint:
+    name: Unit & PDK
+    runs-on: ubuntu-18.04
+    needs: build
+
+    steps:
+    - name: Set env
+      run: |
+          echo "::set-env name=KONG_SOURCE_LOCATION::$GITHUB_WORKSPACE"
+          echo "::set-env name=KONG_BUILD_TOOLS_LOCATION::$HOME/kong-build-tools"
+        
+    - uses: azure/docker-login@v1
+      with:
+        username: ${{ secrets.KONG_USERNAME }}
+        password: ${{ secrets.KONG_PASSWORD }}
+
+    - name: Checkout Kong source code
+      uses: actions/checkout@v2
+
+    - name: Setup Kong Build Tools
+      run: make setup-kong-build-tools
+
+    - name: Run Tests
+      run: docker run -it --rm mashape/kong-build-tools:test make lint
+
+  pdk-and-unit-tests:
+    name: Unit & PDK
     runs-on: ubuntu-18.04
     needs: build
 
@@ -63,7 +88,7 @@ jobs:
   integration-tests-dbless:
     name: DB-less integration tests
     runs-on: ubuntu-18.04
-    needs: lint-and-unit-tests
+    needs: [pdk-and-unit-tests, lint]
 
     env:
       TEST_DATABASE: 'off'
@@ -92,7 +117,7 @@ jobs:
   integration-tests-with-databases:
     name: ${{matrix.database}} (${{ matrix.suite }}) ${{ matrix.split }} integration tests
     runs-on: ubuntu-18.04
-    needs: lint-and-unit-tests
+    needs: [pdk-and-unit-tests, lint]
 
     strategy:
       matrix:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -110,6 +110,7 @@ jobs:
 
     env:
       TEST_SUITE: ${{ matrix.suite }}
+      DEBUG: 1
 
     steps:
     - name: Set env

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -27,39 +27,14 @@ jobs:
     - name: Build Test Image
       run: pushd $KONG_BUILD_TOOLS_LOCATION && make kong-test-container && popd
 
-  lint:
-    name: Lint
-    runs-on: ubuntu-18.04
-    needs: build
-
-    steps:
-    - name: Set env
-      run: |
-          echo "::set-env name=KONG_SOURCE_LOCATION::$GITHUB_WORKSPACE"
-          echo "::set-env name=KONG_BUILD_TOOLS_LOCATION::$HOME/kong-build-tools"
-        
-    - uses: azure/docker-login@v1
-      with:
-        username: ${{ secrets.KONG_USERNAME }}
-        password: ${{ secrets.KONG_PASSWORD }}
-
-    - name: Checkout Kong source code
-      uses: actions/checkout@v2
-
-    - name: Setup Kong Build Tools
-      run: make setup-kong-build-tools
-
-    - name: Run Tests
-      run: docker run -t --rm mashape/kong-build-tools:test make lint
-
-  pdk-and-unit-tests:
+  pdk-lint-unit-tests:
     name: Unit & PDK
     runs-on: ubuntu-18.04
     needs: build
 
     strategy:
       matrix:
-        suite: [unit, pdk]
+        suite: [unit, pdk, lint]
 
     env:
       TEST_SUITE: ${{ matrix.suite }}
@@ -88,7 +63,7 @@ jobs:
   integration-tests-dbless:
     name: DB-less integration tests
     runs-on: ubuntu-18.04
-    needs: [pdk-and-unit-tests, lint]
+    needs: pdk-lint-unit-tests
 
     env:
       TEST_DATABASE: 'off'
@@ -117,7 +92,7 @@ jobs:
   integration-tests-with-databases:
     name: ${{matrix.database}} (${{ matrix.suite }}) ${{ matrix.split }} integration tests
     runs-on: ubuntu-18.04
-    needs: [pdk-and-unit-tests, lint]
+    needs: pdk-lint-unit-tests
 
     strategy:
       matrix:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -67,7 +67,7 @@ jobs:
         suite: [integration, plugins]
         database: [cassandra, postgres]
         exclude:
-          - SUITE: plugins
+          - suite: plugins
             split: first
           - suite: plugins
             split: second

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -32,12 +32,8 @@ jobs:
     runs-on: ubuntu-18.04
     needs: build
 
-    strategy:
-      matrix:
-        suite: [unit, lint]
-
     env:
-      TEST_SUITE: ${{ matrix.suite }}
+      TEST_SUITE: unit
 
     steps:
     - name: Set env
@@ -62,7 +58,7 @@ jobs:
   pdk:
     name: PDK
     runs-on: ubuntu-18.04
-    needs: build
+    needs: lint-unit-tests
 
     env:
       TEST_SUITE: pdk

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -28,7 +28,7 @@ jobs:
       run: pushd $KONG_BUILD_TOOLS_LOCATION && make kong-test-container && popd
 
   lint:
-    name: Unit & PDK
+    name: Lint
     runs-on: ubuntu-18.04
     needs: build
 
@@ -50,7 +50,7 @@ jobs:
       run: make setup-kong-build-tools
 
     - name: Run Tests
-      run: docker run -it --rm mashape/kong-build-tools:test make lint
+      run: docker run -t --rm mashape/kong-build-tools:test make lint
 
   pdk-and-unit-tests:
     name: Unit & PDK

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -28,7 +28,7 @@ jobs:
       run: pushd $KONG_BUILD_TOOLS_LOCATION && make kong-test-container && popd
 
   integration-tests-dbless:
-    name: DB-less tests
+    name: DB-less integration tests
     runs-on: ubuntu-18.04
     needs: build
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ env:
     - KONG_TEST_PG_DATABASE=travis
     - KONG_TEST_PG_USER=travis
     - KONG_TEST_PG_RO_USER=travis_ro
+    - KONG_TEST_PG_HOST=localhost
     - JOBS=2
     - DOCKER_MACHINE_ARM64_NAME=travis-ci-kong-${TRAVIS_JOB_ID}
   matrix:

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ RESTY_VERSION ?= `grep RESTY_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk
 RESTY_LUAROCKS_VERSION ?= `grep RESTY_LUAROCKS_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
 RESTY_OPENSSL_VERSION ?= `grep RESTY_OPENSSL_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
 RESTY_PCRE_VERSION ?= `grep RESTY_PCRE_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
-KONG_BUILD_TOOLS ?= 'origin/pdk'
+KONG_BUILD_TOOLS ?= 'origin/psql'
 KONG_VERSION ?= `cat $(KONG_SOURCE_LOCATION)/kong-*.rockspec | grep tag | awk '{print $$3}' | sed 's/"//g'`
 OPENRESTY_PATCHES_BRANCH ?= master
 KONG_NGINX_MODULE_BRANCH ?= master

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ RESTY_VERSION ?= `grep RESTY_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk
 RESTY_LUAROCKS_VERSION ?= `grep RESTY_LUAROCKS_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
 RESTY_OPENSSL_VERSION ?= `grep RESTY_OPENSSL_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
 RESTY_PCRE_VERSION ?= `grep RESTY_PCRE_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
-KONG_BUILD_TOOLS ?= 'origin/psql'
+KONG_BUILD_TOOLS ?= 'origin/pdk'
 KONG_VERSION ?= `cat $(KONG_SOURCE_LOCATION)/kong-*.rockspec | grep tag | awk '{print $$3}' | sed 's/"//g'`
 OPENRESTY_PATCHES_BRANCH ?= master
 KONG_NGINX_MODULE_BRANCH ?= master

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ RESTY_VERSION ?= `grep RESTY_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk
 RESTY_LUAROCKS_VERSION ?= `grep RESTY_LUAROCKS_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
 RESTY_OPENSSL_VERSION ?= `grep RESTY_OPENSSL_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
 RESTY_PCRE_VERSION ?= `grep RESTY_PCRE_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
-KONG_BUILD_TOOLS ?= '3.1.4'
+KONG_BUILD_TOOLS ?= 'origin/pdk'
 KONG_VERSION ?= `cat $(KONG_SOURCE_LOCATION)/kong-*.rockspec | grep tag | awk '{print $$3}' | sed 's/"//g'`
 OPENRESTY_PATCHES_BRANCH ?= master
 KONG_NGINX_MODULE_BRANCH ?= master

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ RESTY_VERSION ?= `grep RESTY_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk
 RESTY_LUAROCKS_VERSION ?= `grep RESTY_LUAROCKS_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
 RESTY_OPENSSL_VERSION ?= `grep RESTY_OPENSSL_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
 RESTY_PCRE_VERSION ?= `grep RESTY_PCRE_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
-KONG_BUILD_TOOLS ?= 'origin/pdk'
+KONG_BUILD_TOOLS ?= 'origin/feat/devtools-cache'
 KONG_VERSION ?= `cat $(KONG_SOURCE_LOCATION)/kong-*.rockspec | grep tag | awk '{print $$3}' | sed 's/"//g'`
 OPENRESTY_PATCHES_BRANCH ?= master
 KONG_NGINX_MODULE_BRANCH ?= master

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ RESTY_VERSION ?= `grep RESTY_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk
 RESTY_LUAROCKS_VERSION ?= `grep RESTY_LUAROCKS_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
 RESTY_OPENSSL_VERSION ?= `grep RESTY_OPENSSL_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
 RESTY_PCRE_VERSION ?= `grep RESTY_PCRE_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
-KONG_BUILD_TOOLS ?= 'origin/feat/dev-cache'
+KONG_BUILD_TOOLS ?= '4.2.0'
 KONG_VERSION ?= `cat $(KONG_SOURCE_LOCATION)/kong-*.rockspec | grep tag | awk '{print $$3}' | sed 's/"//g'`
 OPENRESTY_PATCHES_BRANCH ?= master
 KONG_NGINX_MODULE_BRANCH ?= master

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ RESTY_VERSION ?= `grep RESTY_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk
 RESTY_LUAROCKS_VERSION ?= `grep RESTY_LUAROCKS_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
 RESTY_OPENSSL_VERSION ?= `grep RESTY_OPENSSL_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
 RESTY_PCRE_VERSION ?= `grep RESTY_PCRE_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
-KONG_BUILD_TOOLS ?= 'origin/feat/devtools-cache'
+KONG_BUILD_TOOLS ?= 'origin/feat/dev-cache'
 KONG_VERSION ?= `cat $(KONG_SOURCE_LOCATION)/kong-*.rockspec | grep tag | awk '{print $$3}' | sed 's/"//g'`
 OPENRESTY_PATCHES_BRANCH ?= master
 KONG_NGINX_MODULE_BRANCH ?= master

--- a/spec/01-unit/02-rockspec_meta_spec.lua
+++ b/spec/01-unit/02-rockspec_meta_spec.lua
@@ -68,7 +68,7 @@ describe("rockspec/meta", function()
   end)
 
   describe("modules", function()
-    it("are all included in rockspec", function()
+    it("are all included in rockspec #flaky", function()
       for _, src in ipairs(lua_srcs) do
         local rel_src = src:sub(3) -- strip './'
         local found

--- a/spec/01-unit/02-rockspec_meta_spec.lua
+++ b/spec/01-unit/02-rockspec_meta_spec.lua
@@ -68,19 +68,6 @@ describe("rockspec/meta", function()
   end)
 
   describe("modules", function()
-    it("are all included in rockspec #flaky", function()
-      for _, src in ipairs(lua_srcs) do
-        local rel_src = src:sub(3) -- strip './'
-        local found
-        for mod_name, mod_path in pairs(rock.build.modules) do
-          if mod_path == rel_src then
-            found = true
-            break
-          end
-        end
-        assert(found, "could not find module entry for Lua file: " .. src)
-      end
-    end)
 
     it("all modules named as their path", function()
       for mod_name, mod_path in pairs(rock.build.modules) do

--- a/spec/02-integration/05-proxy/05-dns_spec.lua
+++ b/spec/02-integration/05-proxy/05-dns_spec.lua
@@ -108,7 +108,7 @@ for _, strategy in helpers.each_strategy() do
 
         local service = bp.services:insert {
           name     = "tests-retries",
-          host     = "now.this.does.not",
+          host     = "nowthisdoesnotexistatall",
           path     = "/exist",
           port     = 80,
           protocol = "http"


### PR DESCRIPTION
This commit makes Kong able to run on GitHub Actions, but still kept the
Travis CI files around so that we could use both at the same time during
the transitional period. Eventually Travis CI support will be removed.

This PR further splits Kong core integration tests into two halves on
GitHub Actions to further reduce the run time by utilizing all the
concurrency we have access to, as the core integration tests has
consistently been the long tail of all the jobs, running 2x slower than
the second slowest job. Splitting is not done on Travis as the
concurrency limit makes doing so pointless.

Todo:
- [ ] merge the kong-build-tools branch
- [ ] release a kong-build-tools version
- [ ] update the pinned kong-build-tools version