### PR TITLE
chore(deps) bump lua-resty-openssl to 0.4.4

### DIFF
--- a/kong-2.0.1-0.rockspec
+++ b/kong-2.0.1-0.rockspec
@@ -35,7 +35,7 @@ dependencies = {
   "lua-resty-cookie == 0.1.0",
   "lua-resty-mlcache == 2.4.1",
   "lua-messagepack == 0.5.2",
-  "lua-resty-openssl == 0.4.3",
+  "lua-resty-openssl == 0.4.4",
   "lua-resty-counter == 0.2.0",
   -- external Kong plugins
   "kong-plugin-azure-functions ~> 0.4",


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Clean an extra error log when jwt plugin is applied on a service
which connects to https upstream.

### Full changelog

* Bump up lua-resty-openssl to 0.4.4

### Issues resolved

Fix #5614

This commit should only goes to 2.0.x releases, if there's any. In `next` we already have used lua-resty-openssl 0.5.3 which includes this patch.