### PR TITLE
feat(proxy/pdk) add support for X-Forwarded-Prefix

### DIFF
--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -123,31 +123,33 @@ server {
     }
 
     location / {
-        default_type                    '';
+        default_type                     '';
 
-        set $ctx_ref                    '';
-        set $upstream_te                '';
-        set $upstream_host              '';
-        set $upstream_upgrade           '';
-        set $upstream_connection        '';
-        set $upstream_scheme            '';
-        set $upstream_uri               '';
-        set $upstream_x_forwarded_for   '';
-        set $upstream_x_forwarded_proto '';
-        set $upstream_x_forwarded_host  '';
-        set $upstream_x_forwarded_port  '';
-        set $kong_proxy_mode            'http';
+        set $ctx_ref                     '';
+        set $upstream_te                 '';
+        set $upstream_host               '';
+        set $upstream_upgrade            '';
+        set $upstream_connection         '';
+        set $upstream_scheme             '';
+        set $upstream_uri                '';
+        set $upstream_x_forwarded_for    '';
+        set $upstream_x_forwarded_proto  '';
+        set $upstream_x_forwarded_host   '';
+        set $upstream_x_forwarded_port   '';
+        set $upstream_x_forwarded_prefix '';
+        set $kong_proxy_mode             'http';
 
         proxy_http_version    1.1;
-        proxy_set_header      TE                $upstream_te;
-        proxy_set_header      Host              $upstream_host;
-        proxy_set_header      Upgrade           $upstream_upgrade;
-        proxy_set_header      Connection        $upstream_connection;
-        proxy_set_header      X-Forwarded-For   $upstream_x_forwarded_for;
-        proxy_set_header      X-Forwarded-Proto $upstream_x_forwarded_proto;
-        proxy_set_header      X-Forwarded-Host  $upstream_x_forwarded_host;
-        proxy_set_header      X-Forwarded-Port  $upstream_x_forwarded_port;
-        proxy_set_header      X-Real-IP         $remote_addr;
+        proxy_set_header      TE                 $upstream_te;
+        proxy_set_header      Host               $upstream_host;
+        proxy_set_header      Upgrade            $upstream_upgrade;
+        proxy_set_header      Connection         $upstream_connection;
+        proxy_set_header      X-Forwarded-For    $upstream_x_forwarded_for;
+        proxy_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
+        proxy_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
+        proxy_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
+        proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
+        proxy_set_header      X-Real-IP          $remote_addr;
         proxy_pass_header     Server;
         proxy_pass_header     Date;
         proxy_ssl_name        $upstream_host;
@@ -164,13 +166,14 @@ server {
         default_type         '';
         set $kong_proxy_mode 'grpc';
 
-        grpc_set_header      TE                $upstream_te;
-        grpc_set_header      Host              $upstream_host;
-        grpc_set_header      X-Forwarded-For   $upstream_x_forwarded_for;
-        grpc_set_header      X-Forwarded-Proto $upstream_x_forwarded_proto;
-        grpc_set_header      X-Forwarded-Host  $upstream_x_forwarded_host;
-        grpc_set_header      X-Forwarded-Port  $upstream_x_forwarded_port;
-        grpc_set_header      X-Real-IP         $remote_addr;
+        grpc_set_header      TE                 $upstream_te;
+        grpc_set_header      Host               $upstream_host;
+        grpc_set_header      X-Forwarded-For    $upstream_x_forwarded_for;
+        grpc_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
+        grpc_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
+        grpc_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
+        grpc_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
+        grpc_set_header      X-Real-IP          $remote_addr;
         grpc_pass_header     Server;
         grpc_pass_header     Date;
         grpc_pass            grpc://kong_upstream;
@@ -181,13 +184,14 @@ server {
         default_type         '';
         set $kong_proxy_mode 'grpc';
 
-        grpc_set_header      TE                $upstream_te;
-        grpc_set_header      Host              $upstream_host;
-        grpc_set_header      X-Forwarded-For   $upstream_x_forwarded_for;
-        grpc_set_header      X-Forwarded-Proto $upstream_x_forwarded_proto;
-        grpc_set_header      X-Forwarded-Host  $upstream_x_forwarded_host;
-        grpc_set_header      X-Forwarded-Port  $upstream_x_forwarded_port;
-        grpc_set_header      X-Real-IP         $remote_addr;
+        grpc_set_header      TE                 $upstream_te;
+        grpc_set_header      Host               $upstream_host;
+        grpc_set_header      X-Forwarded-For    $upstream_x_forwarded_for;
+        grpc_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
+        grpc_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
+        grpc_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
+        grpc_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
+        grpc_set_header      X-Real-IP          $remote_addr;
         grpc_pass_header     Server;
         grpc_pass_header     Date;
         grpc_ssl_name        $upstream_host;
@@ -211,15 +215,16 @@ server {
         log_by_lua_block           {;}
 
         proxy_http_version 1.1;
-        proxy_set_header      TE                $upstream_te;
-        proxy_set_header      Host              $upstream_host;
-        proxy_set_header      Upgrade           $upstream_upgrade;
-        proxy_set_header      Connection        $upstream_connection;
-        proxy_set_header      X-Forwarded-For   $upstream_x_forwarded_for;
-        proxy_set_header      X-Forwarded-Proto $upstream_x_forwarded_proto;
-        proxy_set_header      X-Forwarded-Host  $upstream_x_forwarded_host;
-        proxy_set_header      X-Forwarded-Port  $upstream_x_forwarded_port;
-        proxy_set_header      X-Real-IP         $remote_addr;
+        proxy_set_header      TE                 $upstream_te;
+        proxy_set_header      Host               $upstream_host;
+        proxy_set_header      Upgrade            $upstream_upgrade;
+        proxy_set_header      Connection         $upstream_connection;
+        proxy_set_header      X-Forwarded-For    $upstream_x_forwarded_for;
+        proxy_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
+        proxy_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
+        proxy_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
+        proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
+        proxy_set_header      X-Real-IP          $remote_addr;
         proxy_pass_header     Server;
         proxy_pass_header     Date;
         proxy_ssl_name        $upstream_host;

--- a/spec/02-integration/05-proxy/03-upstream_headers_spec.lua
+++ b/spec/02-integration/05-proxy/03-upstream_headers_spec.lua
@@ -284,6 +284,25 @@ for _, strategy in helpers.each_strategy() do
         end)
       end)
 
+      describe("X-Forwarded-Prefix", function()
+        it("should be added if not present in request", function()
+          local headers = request_headers {
+            ["Host"] = "headers-inspect.com",
+          }
+
+          assert.equal("/", headers["x-forwarded-prefix"])
+        end)
+
+        it("should be replaced if present in request", function()
+          local headers = request_headers {
+            ["Host"]               = "headers-inspect.com",
+            ["X-Forwarded-Prefix"] = "/replaced",
+          }
+
+          assert.equal("/", headers["x-forwarded-prefix"])
+        end)
+      end)
+
       describe("with the downstream host preserved", function()
         it("should be added if not present in request while preserving the downstream host", function()
           local headers = request_headers {
@@ -296,6 +315,7 @@ for _, strategy in helpers.each_strategy() do
           assert.equal("http", headers["x-forwarded-proto"])
           assert.equal("preserved.com", headers["x-forwarded-host"])
           assert.equal(helpers.get_proxy_port(false), tonumber(headers["x-forwarded-port"]))
+          assert.equal("/", headers["x-forwarded-prefix"])
         end)
 
         it("should be added if present in request while preserving the downstream host", function()
@@ -314,6 +334,7 @@ for _, strategy in helpers.each_strategy() do
           assert.equal("http", headers["x-forwarded-proto"])
           assert.equal("preserved.com", headers["x-forwarded-host"])
           assert.equal(helpers.get_proxy_port(false), tonumber(headers["x-forwarded-port"]))
+          assert.equal("/", headers["x-forwarded-prefix"])
         end)
       end)
 
@@ -331,6 +352,7 @@ for _, strategy in helpers.each_strategy() do
           assert.equal("http", headers["x-forwarded-proto"])
           assert.equal("headers-inspect.com", headers["x-forwarded-host"])
           assert.equal(helpers.get_proxy_port(false), tonumber(headers["x-forwarded-port"]))
+          assert.equal("/", headers["x-forwarded-prefix"])
         end)
 
         it("if present in request while discarding the downstream host", function()
@@ -351,6 +373,7 @@ for _, strategy in helpers.each_strategy() do
           assert.equal("http", headers["x-forwarded-proto"])
           assert.equal("headers-inspect.com", headers["x-forwarded-host"])
           assert.equal(helpers.get_proxy_port(false), tonumber(headers["x-forwarded-port"]))
+          assert.equal("/", headers["x-forwarded-prefix"])
         end)
       end)
 
@@ -461,7 +484,25 @@ for _, strategy in helpers.each_strategy() do
 
           assert.equal("80", headers["x-forwarded-port"])
         end)
+      end)
 
+      describe("X-Forwarded-Prefix", function()
+        it("should be added if not present in request", function()
+          local headers = request_headers {
+            ["Host"] = "headers-inspect.com",
+          }
+
+          assert.equal("/", headers["x-forwarded-prefix"])
+        end)
+
+        it("should be forwarded if present in request", function()
+          local headers = request_headers {
+            ["Host"]             = "headers-inspect.com",
+            ["X-Forwarded-Prefix"] = "/original-path",
+          }
+
+          assert.equal("/original-path", headers["x-forwarded-prefix"])
+        end)
       end)
 
     end)
@@ -570,6 +611,25 @@ for _, strategy in helpers.each_strategy() do
           }
 
           assert.equal(helpers.get_proxy_port(false), tonumber(headers["x-forwarded-port"]))
+        end)
+      end)
+
+      describe("X-Forwarded-Prefix", function()
+        it("should be added if not present in request", function()
+          local headers = request_headers {
+            ["Host"] = "headers-inspect.com",
+          }
+
+          assert.equal("/", headers["x-forwarded-prefix"])
+        end)
+
+        it("should be replaced if present in request", function()
+          local headers = request_headers {
+            ["Host"]             = "headers-inspect.com",
+            ["X-Forwarded-Prefix"] = "/untrusted",
+          }
+
+          assert.equal("/", headers["x-forwarded-prefix"])
         end)
       end)
     end)

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -143,31 +143,33 @@ http {
         }
 
         location / {
-            default_type                    '';
+            default_type                     '';
 
-            set $ctx_ref                    '';
-            set $upstream_te                '';
-            set $upstream_host              '';
-            set $upstream_upgrade           '';
-            set $upstream_connection        '';
-            set $upstream_scheme            '';
-            set $upstream_uri               '';
-            set $upstream_x_forwarded_for   '';
-            set $upstream_x_forwarded_proto '';
-            set $upstream_x_forwarded_host  '';
-            set $upstream_x_forwarded_port  '';
-            set $kong_proxy_mode            'http';
+            set $ctx_ref                     '';
+            set $upstream_te                 '';
+            set $upstream_host               '';
+            set $upstream_upgrade            '';
+            set $upstream_connection         '';
+            set $upstream_scheme             '';
+            set $upstream_uri                '';
+            set $upstream_x_forwarded_for    '';
+            set $upstream_x_forwarded_proto  '';
+            set $upstream_x_forwarded_host   '';
+            set $upstream_x_forwarded_port   '';
+            set $upstream_x_forwarded_prefix '';
+            set $kong_proxy_mode             'http';
 
             proxy_http_version    1.1;
-            proxy_set_header      TE                $upstream_te;
-            proxy_set_header      Host              $upstream_host;
-            proxy_set_header      Upgrade           $upstream_upgrade;
-            proxy_set_header      Connection        $upstream_connection;
-            proxy_set_header      X-Forwarded-For   $upstream_x_forwarded_for;
-            proxy_set_header      X-Forwarded-Proto $upstream_x_forwarded_proto;
-            proxy_set_header      X-Forwarded-Host  $upstream_x_forwarded_host;
-            proxy_set_header      X-Forwarded-Port  $upstream_x_forwarded_port;
-            proxy_set_header      X-Real-IP         $remote_addr;
+            proxy_set_header      TE                 $upstream_te;
+            proxy_set_header      Host               $upstream_host;
+            proxy_set_header      Upgrade            $upstream_upgrade;
+            proxy_set_header      Connection         $upstream_connection;
+            proxy_set_header      X-Forwarded-For    $upstream_x_forwarded_for;
+            proxy_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
+            proxy_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
+            proxy_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
+            proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
+            proxy_set_header      X-Real-IP          $remote_addr;
             proxy_pass_header     Server;
             proxy_pass_header     Date;
             proxy_ssl_name        $upstream_host;
@@ -184,13 +186,14 @@ http {
             default_type         '';
             set $kong_proxy_mode 'grpc';
 
-            grpc_set_header      TE                $upstream_te;
-            grpc_set_header      Host              $upstream_host;
-            grpc_set_header      X-Forwarded-For   $upstream_x_forwarded_for;
-            grpc_set_header      X-Forwarded-Proto $upstream_x_forwarded_proto;
-            grpc_set_header      X-Forwarded-Host  $upstream_x_forwarded_host;
-            grpc_set_header      X-Forwarded-Port  $upstream_x_forwarded_port;
-            grpc_set_header      X-Real-IP         $remote_addr;
+            grpc_set_header      TE                 $upstream_te;
+            grpc_set_header      Host               $upstream_host;
+            grpc_set_header      X-Forwarded-For    $upstream_x_forwarded_for;
+            grpc_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
+            grpc_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
+            grpc_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
+            grpc_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
+            grpc_set_header      X-Real-IP          $remote_addr;
             grpc_pass_header     Server;
             grpc_pass_header     Date;
             grpc_pass            grpc://kong_upstream;
@@ -201,13 +204,14 @@ http {
             default_type         '';
             set $kong_proxy_mode 'grpc';
 
-            grpc_set_header      TE                $upstream_te;
-            grpc_set_header      Host              $upstream_host;
-            grpc_set_header      X-Forwarded-For   $upstream_x_forwarded_for;
-            grpc_set_header      X-Forwarded-Proto $upstream_x_forwarded_proto;
-            grpc_set_header      X-Forwarded-Host  $upstream_x_forwarded_host;
-            grpc_set_header      X-Forwarded-Port  $upstream_x_forwarded_port;
-            grpc_set_header      X-Real-IP         $remote_addr;
+            grpc_set_header      TE                 $upstream_te;
+            grpc_set_header      Host               $upstream_host;
+            grpc_set_header      X-Forwarded-For    $upstream_x_forwarded_for;
+            grpc_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
+            grpc_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
+            grpc_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
+            grpc_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
+            grpc_set_header      X-Real-IP          $remote_addr;
             grpc_pass_header     Server;
             grpc_pass_header     Date;
             grpc_ssl_name        $upstream_host;
@@ -231,15 +235,16 @@ http {
             log_by_lua_block           {;}
 
             proxy_http_version    1.1;
-            proxy_set_header      TE                $upstream_te;
-            proxy_set_header      Host              $upstream_host;
-            proxy_set_header      Upgrade           $upstream_upgrade;
-            proxy_set_header      Connection        $upstream_connection;
-            proxy_set_header      X-Forwarded-For   $upstream_x_forwarded_for;
-            proxy_set_header      X-Forwarded-Proto $upstream_x_forwarded_proto;
-            proxy_set_header      X-Forwarded-Host  $upstream_x_forwarded_host;
-            proxy_set_header      X-Forwarded-Port  $upstream_x_forwarded_port;
-            proxy_set_header      X-Real-IP         $remote_addr;
+            proxy_set_header      TE                 $upstream_te;
+            proxy_set_header      Host               $upstream_host;
+            proxy_set_header      Upgrade            $upstream_upgrade;
+            proxy_set_header      Connection         $upstream_connection;
+            proxy_set_header      X-Forwarded-For    $upstream_x_forwarded_for;
+            proxy_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
+            proxy_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
+            proxy_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
+            proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
+            proxy_set_header      X-Real-IP          $remote_addr;
             proxy_pass_header     Server;
             proxy_pass_header     Date;
             proxy_ssl_name        $upstream_host;

--- a/t/01-pdk/04-request/00-phase_checks.t
+++ b/t/01-pdk/04-request/00-phase_checks.t
@@ -97,6 +97,17 @@ qq{
                 log           = true,
                 admin_api     = true,
             }, {
+                method        = "get_forwarded_path",
+                args          = {},
+                init_worker   = false,
+                certificate   = "pending",
+                rewrite       = true,
+                access        = true,
+                header_filter = true,
+                body_filter   = true,
+                log           = true,
+                admin_api     = true,
+            }, {
                 method        = "get_http_version",
                 args          = {},
                 init_worker   = false,

--- a/t/01-pdk/04-request/18-get_forwarded_path.t
+++ b/t/01-pdk/04-request/18-get_forwarded_path.t
@@ -1,0 +1,147 @@
+use strict;
+use warnings FATAL => 'all';
+use Test::Nginx::Socket::Lua;
+use t::Util;
+
+$ENV{TEST_NGINX_CERT_DIR} ||= File::Spec->catdir(server_root(), '..', 'certs');
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
+
+plan tests => repeat_each() * (blocks() * 3);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: request.get_forwarded_path() considers X-Forwarded-Prefix when trusted
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location /t {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new({ trusted_ips = { "0.0.0.0/0", "::/0" } })
+
+            ngx.say("path: ", pdk.request.get_forwarded_path())
+            ngx.say("type: ", type(pdk.request.get_forwarded_path()))
+        }
+    }
+--- request
+GET /t/request-path
+--- more_headers
+X-Forwarded-Prefix: /trusted
+--- response_body
+path: /trusted
+type: string
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: request.get_forwarded_path() doesn't considers X-Forwarded-Prefix when not trusted
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location /t {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            ngx.say("path: ", pdk.request.get_forwarded_path())
+        }
+    }
+--- request
+GET /t/request-path
+--- more_headers
+X-Forwarded-Prefix: /not-trusted
+--- response_body
+path: /t/request-path
+--- no_error_log
+[error]
+
+
+
+=== TEST 3: request.get_forwarded_path() considers first X-Forwarded-Prefix if multiple when trusted
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new({ trusted_ips = { "0.0.0.0/0", "::/0" } })
+
+            ngx.say("path: ", pdk.request.get_forwarded_path())
+        }
+    }
+--- request
+GET /t
+--- more_headers
+X-Forwarded-Prefix: /first
+X-Forwarded-Prefix: /second
+--- response_body
+path: /first
+--- no_error_log
+[error]
+
+
+
+=== TEST 4: request.get_forwarded_path() doesn't considers any X-Forwarded-Prefix headers when not trusted
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location /t {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            ngx.say("path: ", pdk.request.get_forwarded_path())
+        }
+    }
+--- request
+GET /t/request-uri
+--- more_headers
+X-Forwarded-Prefix: /first
+X-Forwarded-Prefix: /second
+--- response_body
+path: /t/request-uri
+--- no_error_log
+[error]
+
+
+
+=== TEST 5: request.get_forwarded_path() removes query and fragment when not trusted
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location /t {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            ngx.say("path: ", pdk.request.get_forwarded_path())
+        }
+    }
+--- request
+GET /t/request-uri?query&field=value#here
+--- more_headers
+X-Forwarded-Prefix: /first
+--- response_body
+path: /t/request-uri
+--- no_error_log
+[error]
+
+
+
+=== TEST 6: request.get_forwarded_path() does not remove query and fragment when trusted
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location /t {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new({ trusted_ips = { "0.0.0.0/0", "::/0" } })
+
+            ngx.say("path: ", pdk.request.get_forwarded_path())
+        }
+    }
+--- request
+GET /t/request-uri?query&field=value#here
+--- more_headers
+X-Forwarded-Prefix: /first?query&field=value#here
+--- response_body
+path: /first?query&field=value#here
+--- no_error_log
+[error]


### PR DESCRIPTION
### Summary

Kong currently adds these headers to upstream request:
```
X-Forwarded-For
X-Forwarded-Port
X-Forwarded-Proto
X-Forwarded-Host
X-Real-IP
```

@erikgb mentioned that he would like to have `X-Forwarded-Prefix`
added on #5602.

This PR adds that, and additionally introduces a new PDK function:
```lua
local path = kong.request.get_forwarded_path()
```

### Issues Resolved

Close #5602