### PR TITLE
Strip Authorization value from logged headers

### DIFF
--- a/kong/plugins/log-serializers/basic.lua
+++ b/kong/plugins/log-serializers/basic.lua
@@ -35,13 +35,18 @@ function _M.serialize(ngx, kong)
 
   local request_uri = var.request_uri or ""
 
+  local req_headers = kong.request.get_headers()
+  if req_headers["authorization"] then
+    req_headers["authorization"] = "REDACTED"
+  end
+
   return {
     request = {
       uri = request_uri,
       url = var.scheme .. "://" .. var.host .. ":" .. var.server_port .. request_uri,
       querystring = kong.request.get_query(), -- parameters, as a table
       method = kong.request.get_method(), -- http method
-      headers = kong.request.get_headers(),
+      headers = req_headers,
       size = var.request_length,
       tls = request_tls
     },

--- a/spec/01-unit/10-log_serializer_spec.lua
+++ b/spec/01-unit/10-log_serializer_spec.lua
@@ -32,7 +32,7 @@ describe("Log Serializer", function()
         start_time = function() return 3 end
       },
       resp = {
-        get_headers = function() return {"respheader1", "respheader2"} end
+        get_headers = function() return {header1 = "respheader1", header2 = "respheader2", ["set-cookie"] = "delicious=delicacy"} end
       }
     }
 
@@ -68,7 +68,7 @@ describe("Log Serializer", function()
 
       -- Response
       assert.is_table(res.response)
-      assert.same({"respheader1", "respheader2"}, res.response.headers)
+      assert.same({header1 = "respheader1", header2 = "respheader2", ["set-cookie"] = "delicious=delicacy"}, res.response.headers)
       assert.equal(99, res.response.size)
 
       assert.is_nil(res.api)

--- a/spec/01-unit/10-log_serializer_spec.lua
+++ b/spec/01-unit/10-log_serializer_spec.lua
@@ -28,7 +28,7 @@ describe("Log Serializer", function()
       req = {
         get_uri_args = function() return {"arg1", "arg2"} end,
         get_method = function() return "POST" end,
-        get_headers = function() return {"header1", "header2"} end,
+        get_headers = function() return {header1 = "header1", header2 = "header2", authorization = "authorization"} end,
         start_time = function() return 3 end
       },
       resp = {
@@ -58,7 +58,7 @@ describe("Log Serializer", function()
 
       -- Request
       assert.is_table(res.request)
-      assert.same({"header1", "header2"}, res.request.headers)
+      assert.same({header1 = "header1", header2 = "header2", authorization = "REDACTED"}, res.request.headers)
       assert.equal("POST", res.request.method)
       assert.same({"arg1", "arg2"}, res.request.querystring)
       assert.equal("http://test.com:80/request_uri", res.request.url)


### PR DESCRIPTION
### Summary

Replace the value of the `Authorization` header with `REDACTED` in the basic serializer.

### Full changelog

* Updated the basic serializer to replace the value of the `Authorization` header with the string `REDACTED` if present. This still indicates whether the client sent the header while not recording the actual credential in the log system.
* Update serializer unit tests to confirm this behavior and use a more realistic header table.

### Notes
As this is technically a new feature, and modifies existing existing functionality, PRing to next, though I think we could reasonably apply it to master and count it as bugfix instead depending on whether we think anyone relies on the existing behavior here (I don't think anyone should). The diff applies equally on either.

Including the actual value of `Authorization` is risky, as it will persist credentials to some log store. That store is not necessarily encrypted (and even if is, may be storing credentials normally stored in a one-way hash with reversible encryption) and may have different access controls than the normal credential store.

We furthermore already log the credential ID in .authenticated_entity.id for Kong-managed credentials, so at least some of the information lost with this change is available via other means.
