### PR TITLE
feat(stream) basic serializer to work on streams

### DIFF
--- a/kong/plugins/datadog/schema.lua
+++ b/kong/plugins/datadog/schema.lua
@@ -68,7 +68,7 @@ local DEFAULT_METRICS = {
 return {
   name = "datadog",
   fields = {
-    { protocols = typedefs.protocols_http },
+    { protocols = typedefs.protocols },
     { config = {
         type = "record",
         default = { metrics = DEFAULT_METRICS },

--- a/kong/plugins/file-log/schema.lua
+++ b/kong/plugins/file-log/schema.lua
@@ -3,7 +3,7 @@ local typedefs = require "kong.db.schema.typedefs"
 return {
   name = "file-log",
   fields = {
-    { protocols = typedefs.protocols_http },
+    { protocols = typedefs.protocols },
     { config = {
         type = "record",
         fields = {

--- a/kong/plugins/http-log/schema.lua
+++ b/kong/plugins/http-log/schema.lua
@@ -3,7 +3,7 @@ local typedefs = require "kong.db.schema.typedefs"
 return {
   name = "http-log",
   fields = {
-    { protocols = typedefs.protocols_http },
+    { protocols = typedefs.protocols },
     { config = {
         type = "record",
         fields = {

--- a/kong/plugins/log-serializers/basic.lua
+++ b/kong/plugins/log-serializers/basic.lua
@@ -1,88 +1,146 @@
 local tablex = require "pl.tablex"
 local ngx_ssl = require "ngx.ssl"
+
+
 local gkong = kong
+local subsystem = ngx.config.subsystem
+local tonumber = tonumber
+
 
 local _M = {}
+
 
 local EMPTY = tablex.readonly({})
 local REDACTED_REQUEST_HEADERS = { "authorization", "proxy-authorization" }
 local REDACTED_RESPONSE_HEADERS = {}
 
-function _M.serialize(ngx, kong)
-  local ctx = ngx.ctx
-  local var = ngx.var
-  local req = ngx.req
+if subsystem == "http" then
+  function _M.serialize(ngx, kong)
+    local ctx = ngx.ctx
+    local var = ngx.var
+    local req = ngx.req
 
-  if not kong then
-    kong = gkong
-  end
+    if not kong then
+      kong = gkong
+    end
 
-  local authenticated_entity
-  if ctx.authenticated_credential ~= nil then
-    authenticated_entity = {
-      id = ctx.authenticated_credential.id,
-      consumer_id = ctx.authenticated_credential.consumer_id
+    local authenticated_entity
+    if ctx.authenticated_credential ~= nil then
+      authenticated_entity = {
+        id = ctx.authenticated_credential.id,
+        consumer_id = ctx.authenticated_credential.consumer_id
+      }
+    end
+
+    local request_tls
+    local request_tls_ver = ngx_ssl.get_tls1_version_str()
+    if request_tls_ver then
+      request_tls = {
+        version = request_tls_ver,
+        cipher = var.ssl_cipher,
+        client_verify = var.ssl_client_verify,
+      }
+    end
+
+    local request_uri = var.request_uri or ""
+
+    local req_headers = kong.request.get_headers()
+    for _, header in ipairs(REDACTED_REQUEST_HEADERS) do
+      if req_headers[header] then
+        req_headers[header] = "REDACTED"
+      end
+    end
+
+    local resp_headers = ngx.resp.get_headers()
+    for _, header in ipairs(REDACTED_RESPONSE_HEADERS) do
+      if resp_headers[header] then
+        resp_headers[header] = "REDACTED"
+      end
+    end
+
+    return {
+      request = {
+        uri = request_uri,
+        url = var.scheme .. "://" .. var.host .. ":" .. var.server_port .. request_uri,
+        querystring = kong.request.get_query(), -- parameters, as a table
+        method = kong.request.get_method(), -- http method
+        headers = req_headers,
+        size = var.request_length,
+        tls = request_tls,
+      },
+      upstream_uri = var.upstream_uri,
+      response = {
+        status = ngx.status,
+        headers = resp_headers,
+        size = var.bytes_sent,
+      },
+      tries = (ctx.balancer_data or EMPTY).tries,
+      latencies = {
+        kong = (ctx.KONG_REWRITE_TIME or 0) +
+               (ctx.KONG_ACCESS_TIME or 0) +
+               (ctx.KONG_BALANCER_TIME or 0) +
+               (ctx.KONG_RECEIVE_TIME or 0),
+        proxy = ctx.KONG_WAITING_TIME or -1,
+        request = var.request_time * 1000,
+      },
+      authenticated_entity = authenticated_entity,
+      route = ctx.route,
+      service = ctx.service,
+      consumer = ctx.authenticated_consumer,
+      client_ip = var.remote_addr,
+      started_at = req.start_time() * 1000,
     }
   end
 
-  local request_tls
-  local request_tls_ver = ngx_ssl.get_tls1_version_str()
-  if request_tls_ver then
-    request_tls = {
-      version = request_tls_ver,
-      cipher = var.ssl_cipher,
-      client_verify = var.ssl_client_verify,
+elseif subsystem == "stream" then
+  function _M.serialize(ngx, kong)
+    local ctx = ngx.ctx
+    local var = ngx.var
+
+    --if not kong then
+    --  kong = gkong
+    --end
+
+    local authenticated_entity
+    if ctx.authenticated_credential ~= nil then
+      authenticated_entity = {
+        id = ctx.authenticated_credential.id,
+        consumer_id = ctx.authenticated_credential.consumer_id
+      }
+    end
+
+    local request_tls
+    local request_tls_ver = ngx_ssl.get_tls1_version_str()
+    if request_tls_ver then
+      request_tls = {
+        version = request_tls_ver,
+        cipher = var.ssl_cipher,
+        client_verify = var.ssl_client_verify,
+      }
+    end
+
+    return {
+      session = {
+        upstream_bytes = tonumber(var.bytes_received, 10),
+        downstream_bytes = tonumber(var.bytes_sent, 10),
+        duration = tonumber(var.session_time, 10),
+        status = tonumber(var.status, 10),
+        tls = request_tls,
+      },
+      tries = (ctx.balancer_data or EMPTY).tries,
+      latencies = {
+        kong = (ctx.KONG_PREREAD_TIME or 0) +
+               (ctx.KONG_BALANCER_TIME or 0),
+      },
+      authenticated_entity = authenticated_entity,
+      route = ctx.route,
+      service = ctx.service,
+      consumer = ctx.authenticated_consumer,
+      client_ip = var.remote_addr,
+      started_at = ctx.KONG_PROCESSING_START,
     }
   end
-
-  local request_uri = var.request_uri or ""
-
-  local req_headers = kong.request.get_headers()
-  for _, header in ipairs(REDACTED_REQUEST_HEADERS) do
-    if req_headers[header] then
-      req_headers[header] = "REDACTED"
-    end
-  end
-
-  local resp_headers = ngx.resp.get_headers()
-  for _, header in ipairs(REDACTED_RESPONSE_HEADERS) do
-    if resp_headers[header] then
-      resp_headers[header] = "REDACTED"
-    end
-  end
-
-  return {
-    request = {
-      uri = request_uri,
-      url = var.scheme .. "://" .. var.host .. ":" .. var.server_port .. request_uri,
-      querystring = kong.request.get_query(), -- parameters, as a table
-      method = kong.request.get_method(), -- http method
-      headers = req_headers,
-      size = var.request_length,
-      tls = request_tls
-    },
-    upstream_uri = var.upstream_uri,
-    response = {
-      status = ngx.status,
-      headers = resp_headers,
-      size = var.bytes_sent
-    },
-    tries = (ctx.balancer_data or EMPTY).tries,
-    latencies = {
-      kong = (ctx.KONG_ACCESS_TIME or 0) +
-             (ctx.KONG_RECEIVE_TIME or 0) +
-             (ctx.KONG_REWRITE_TIME or 0) +
-             (ctx.KONG_BALANCER_TIME or 0),
-      proxy = ctx.KONG_WAITING_TIME or -1,
-      request = var.request_time * 1000
-    },
-    authenticated_entity = authenticated_entity,
-    route = ctx.route,
-    service = ctx.service,
-    consumer = ctx.authenticated_consumer,
-    client_ip = var.remote_addr,
-    started_at = req.start_time() * 1000
-  }
 end
+
 
 return _M

--- a/kong/plugins/loggly/schema.lua
+++ b/kong/plugins/loggly/schema.lua
@@ -9,7 +9,7 @@ local severity = {
 return {
   name = "loggly",
   fields = {
-    { protocols = typedefs.protocols_http },
+    { protocols = typedefs.protocols },
     { config = {
         type = "record",
         fields = {

--- a/kong/plugins/statsd/schema.lua
+++ b/kong/plugins/statsd/schema.lua
@@ -72,7 +72,7 @@ local DEFAULT_METRICS = {
 return {
   name = "statsd",
   fields = {
-    { protocols = typedefs.protocols_http },
+    { protocols = typedefs.protocols },
     { config = {
         type = "record",
         fields = {

--- a/kong/plugins/syslog/schema.lua
+++ b/kong/plugins/syslog/schema.lua
@@ -9,7 +9,7 @@ local severity = {
 return {
   name = "syslog",
   fields = {
-    { protocols = typedefs.protocols_http },
+    { protocols = typedefs.protocols },
     { config = {
         type = "record",
         fields = {

--- a/kong/plugins/tcp-log/schema.lua
+++ b/kong/plugins/tcp-log/schema.lua
@@ -3,7 +3,7 @@ local typedefs = require "kong.db.schema.typedefs"
 return {
   name = "tcp-log",
   fields = {
-    { protocols = typedefs.protocols_http },
+    { protocols = typedefs.protocols },
     { config = {
         type = "record",
         fields = {

--- a/kong/plugins/udp-log/schema.lua
+++ b/kong/plugins/udp-log/schema.lua
@@ -3,7 +3,7 @@ local typedefs = require "kong.db.schema.typedefs"
 return {
   name = "udp-log",
   fields = {
-    { protocols = typedefs.protocols_http },
+    { protocols = typedefs.protocols },
     { config = {
         type = "record",
         fields = {


### PR DESCRIPTION
### Summary

Kong logging plugins in general use so called `basic serializer`. This serializer has been written originally for `http`. This PR makes the serializer work with `streams`. It means that all our logging plugins will start to work with `streams` as well.

There is one caveat though. As streams run `log` phase after the stream is closed, it means that `streams` that are kept open, never log. We can perhaps pursue this later in separate PR.