### PR TITLE
chore(ci) load htest output handler in the Makefile

### DIFF
--- a/.ci/setup_env.sh
+++ b/.ci/setup_env.sh
@@ -114,8 +114,6 @@ if [[ "$TEST_SUITE" =~ integration|dbless|plugins ]]; then
   docker run -d --name grpcbin -p 15002:9000 -p 15003:9001 moul/grpcbin
 fi
 
-luarocks install busted-htest 1.0.0
-
 nginx -V
 resty -V
 luarocks --version

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 OS := $(shell uname | awk '{print tolower($$0)}')
 MACHINE := $(shell uname -m)
 
-DEV_ROCKS = "busted 2.0.0" "luacheck 0.23.0" "lua-llthreads2 0.1.5" "http 0.3"
+DEV_ROCKS = "busted 2.0.0" "busted-htest 1.0.0" "luacheck 0.23.0" "lua-llthreads2 0.1.5" "http 0.3"
 WIN_SCRIPTS = "bin/busted" "bin/kong"
 BUSTED_ARGS ?= -v
 TEST_CMD ?= bin/busted $(BUSTED_ARGS)


### PR DESCRIPTION
Make sure we load the htest handler for runs via the Makefile, which is agnostic to the CI environment, instead of setup_env.sh, which is specific to Travis.
