### PR TITLE
feat(ip-restriction) add support for IPv6

### DIFF
--- a/kong-2.0.2-0.rockspec
+++ b/kong-2.0.2-0.rockspec
@@ -37,6 +37,7 @@ dependencies = {
   "lua-messagepack == 0.5.2",
   "lua-resty-openssl == 0.5.3",
   "lua-resty-counter == 0.2.0",
+  "lua-resty-ipmatcher == 0.5",
   -- external Kong plugins
   "kong-plugin-azure-functions ~> 0.4",
   "kong-plugin-zipkin ~> 0.2",

--- a/kong-2.0.2-0.rockspec
+++ b/kong-2.0.2-0.rockspec
@@ -37,7 +37,7 @@ dependencies = {
   "lua-messagepack == 0.5.2",
   "lua-resty-openssl == 0.5.3",
   "lua-resty-counter == 0.2.0",
-  "lua-resty-ipmatcher == 0.5",
+  "lua-resty-ipmatcher == 0.6",
   -- external Kong plugins
   "kong-plugin-azure-functions ~> 0.4",
   "kong-plugin-zipkin ~> 0.2",

--- a/kong/db/schema/typedefs.lua
+++ b/kong/db/schema/typedefs.lua
@@ -8,7 +8,6 @@ local Schema = require("kong.db.schema")
 local socket_url = require("socket.url")
 local constants = require "kong.constants"
 local px = require "resty.mediador.proxy"
-local ipmatcher = require "resty.ipmatcher"
 
 
 local pairs = pairs
@@ -70,17 +69,6 @@ local function validate_cidr_v4(ip)
   -- It's an error only if the second variable is a string
   if type(err) == "string" then
     return nil, "invalid cidr range: " .. err
-  end
-
-  return true
-end
-
-
-local function validate_cidr_v4_v6(ip)
-  local _, err = ipmatcher.new({ ip })
-
-  if err then
-    return nil, "failed to create new ipmatcher instance: " .. err
   end
 
   return true
@@ -256,11 +244,6 @@ typedefs.ip_or_cidr = Schema.define {
 typedefs.cidr_v4 = Schema.define {
   type = "string",
   custom_validator = validate_cidr_v4,
-}
-
-typedefs.cidr_v4_v6 = Schema.define {
-  type = "string",
-  custom_validator = validate_cidr_v4_v6,
 }
 
 -- deprecated alias

--- a/kong/db/schema/typedefs.lua
+++ b/kong/db/schema/typedefs.lua
@@ -8,6 +8,7 @@ local Schema = require("kong.db.schema")
 local socket_url = require("socket.url")
 local constants = require "kong.constants"
 local px = require "resty.mediador.proxy"
+local ipmatcher = require "resty.ipmatcher"
 
 
 local pairs = pairs
@@ -69,6 +70,17 @@ local function validate_cidr_v4(ip)
   -- It's an error only if the second variable is a string
   if type(err) == "string" then
     return nil, "invalid cidr range: " .. err
+  end
+
+  return true
+end
+
+
+local function validate_cidr_v4_v6(ip)
+  local _, err = ipmatcher.new({ ip })
+
+  if err then
+    return nil, "failed to create new ipmatcher instance: " .. err
   end
 
   return true
@@ -244,6 +256,11 @@ typedefs.ip_or_cidr = Schema.define {
 typedefs.cidr_v4 = Schema.define {
   type = "string",
   custom_validator = validate_cidr_v4,
+}
+
+typedefs.cidr_v4_v6 = Schema.define {
+  type = "string",
+  custom_validator = validate_cidr_v4_v6,
 }
 
 -- deprecated alias

--- a/kong/plugins/ip-restriction/handler.lua
+++ b/kong/plugins/ip-restriction/handler.lua
@@ -37,8 +37,8 @@ function IpRestrictionHandler:access(conf)
   end
 
   if err then
-    block = true
-    kong.log.err("invalid binary IP address: " .. err)
+    kong.log.err("Invalid binary IP address: " .. err)
+    return kong.response.exit(500, { message = "An unexpected error occurred" })
   end
 
   if block then

--- a/kong/plugins/ip-restriction/handler.lua
+++ b/kong/plugins/ip-restriction/handler.lua
@@ -17,25 +17,22 @@ function IpRestrictionHandler:access(conf)
   local block = false
   local err = false
   local binary_remote_addr = ngx.var.binary_remote_addr
+  local ip
 
   if not binary_remote_addr then
     return kong.response.exit(FORBIDDEN, { message = "Cannot identify the client IP address, unix domain sockets are not supported." })
   end
 
   if conf.blacklist and #conf.blacklist > 0 then
-    if not kong.ctx.plugin.blacklist then
-      kong.ctx.plugin.blacklist = ipmatcher.new(conf.blacklist)
-    end
+    ip = ipmatcher.new(conf.blacklist)
 
-    block, err = kong.ctx.plugin.blacklist:match_bin(binary_remote_addr)
+    block, err = ip:match_bin(binary_remote_addr)
   end
 
   if conf.whitelist and #conf.whitelist > 0 then
-    if not kong.ctx.plugin.whitelist then
-      kong.ctx.plugin.whitelist = ipmatcher.new(conf.whitelist)
-    end
+    ip = ipmatcher.new(conf.whitelist)
 
-    block, err = kong.ctx.plugin.whitelist:match_bin(binary_remote_addr)
+    block, err = ip:match_bin(binary_remote_addr)
     block = not block
   end
 

--- a/kong/plugins/ip-restriction/handler.lua
+++ b/kong/plugins/ip-restriction/handler.lua
@@ -6,6 +6,7 @@ local ipmatcher = require "resty.ipmatcher"
 
 
 local FORBIDDEN = 403
+local INTERNAL_SERVER_ERROR = 500
 
 
 local IpRestrictionHandler = {}
@@ -13,36 +14,46 @@ local IpRestrictionHandler = {}
 IpRestrictionHandler.PRIORITY = 990
 IpRestrictionHandler.VERSION = "2.0.0"
 
+
+local function match_bin(list, binary_remote_addr)
+  local ip, err = ipmatcher.new(list)
+
+  if err then
+    kong.log.err("Failed to create a new ipmatcher instance: " .. err)
+    return kong.response.exit(INTERNAL_SERVER_ERROR, { message = "An unexpected error occurred" })
+  end
+
+  ip, err = ip:match_bin(binary_remote_addr)
+
+  if err then
+    kong.log.err("Invalid binary IP address: " .. err)
+    return kong.response.exit(INTERNAL_SERVER_ERROR, { message = "An unexpected error occurred" })
+  end
+
+  return ip
+end
+
 function IpRestrictionHandler:access(conf)
-  local block = false
-  local err = false
   local binary_remote_addr = ngx.var.binary_remote_addr
-  local ip
 
   if not binary_remote_addr then
     return kong.response.exit(FORBIDDEN, { message = "Cannot identify the client IP address, unix domain sockets are not supported." })
   end
 
   if conf.blacklist and #conf.blacklist > 0 then
-    ip = ipmatcher.new(conf.blacklist)
+    local blocked_blacklist = match_bin(conf.blacklist, binary_remote_addr)
 
-    block, err = ip:match_bin(binary_remote_addr)
+    if blocked_blacklist then
+      return kong.response.exit(FORBIDDEN, { message = "Your IP address is not allowed" })
+    end
   end
 
   if conf.whitelist and #conf.whitelist > 0 then
-    ip = ipmatcher.new(conf.whitelist)
+    local allowed_whitelist = match_bin(conf.whitelist, binary_remote_addr)
 
-    block, err = ip:match_bin(binary_remote_addr)
-    block = not block
-  end
-
-  if err then
-    kong.log.err("Invalid binary IP address: " .. err)
-    return kong.response.exit(500, { message = "An unexpected error occurred" })
-  end
-
-  if block then
-    return kong.response.exit(FORBIDDEN, { message = "Your IP address is not allowed" })
+    if not allowed_whitelist then
+      return kong.response.exit(FORBIDDEN, { message = "Your IP address is not allowed" })
+    end
   end
 end
 

--- a/kong/plugins/ip-restriction/schema.lua
+++ b/kong/plugins/ip-restriction/schema.lua
@@ -8,8 +8,8 @@ return {
     { config = {
         type = "record",
         fields = {
-          { whitelist = { type = "array", elements = typedefs.cidr_v4_v6, }, },
-          { blacklist = { type = "array", elements = typedefs.cidr_v4_v6, }, },
+          { whitelist = { type = "array", elements = typedefs.ip_or_cidr, }, },
+          { blacklist = { type = "array", elements = typedefs.ip_or_cidr, }, },
         },
       },
     },

--- a/kong/plugins/ip-restriction/schema.lua
+++ b/kong/plugins/ip-restriction/schema.lua
@@ -8,8 +8,8 @@ return {
     { config = {
         type = "record",
         fields = {
-          { whitelist = { type = "array", elements = typedefs.cidr_v4, }, },
-          { blacklist = { type = "array", elements = typedefs.cidr_v4, }, },
+          { whitelist = { type = "array", elements = typedefs.cidr_v4_v6, }, },
+          { blacklist = { type = "array", elements = typedefs.cidr_v4_v6, }, },
         },
       },
     },

--- a/kong/plugins/ip-restriction/schema.lua
+++ b/kong/plugins/ip-restriction/schema.lua
@@ -15,7 +15,6 @@ return {
     },
   },
   entity_checks = {
-    { only_one_of = { "config.whitelist", "config.blacklist" }, },
     { at_least_one_of = { "config.whitelist", "config.blacklist" }, },
   },
 }

--- a/spec/03-plugins/17-ip-restriction/01-schema_spec.lua
+++ b/spec/03-plugins/17-ip-restriction/01-schema_spec.lua
@@ -22,11 +22,15 @@ describe("Plugin: ip-restriction (schema)", function()
     it("whitelist should not accept invalid IPs", function()
       local ok, err = v({ whitelist = { "hello" } }, schema_def)
       assert.falsy(ok)
-      assert.same({ whitelist = { "failed to create new ipmatcher instance: invalid ip address: hello" } }, err.config)
+      assert.same({
+        whitelist = { "invalid ip or cidr range: 'hello'" }
+      }, err.config)
 
       ok, err = v({ whitelist = { "127.0.0.1", "127.0.0.2", "hello" } }, schema_def)
       assert.falsy(ok)
-      assert.same({ whitelist = { [3] = "failed to create new ipmatcher instance: invalid ip address: hello" } }, err.config)
+      assert.same({
+        whitelist = { [3] = "invalid ip or cidr range: 'hello'" }
+      }, err.config)
     end)
     it("blacklist should not accept invalid types", function()
       local ok, err = v({ blacklist = 12 }, schema_def)
@@ -36,11 +40,15 @@ describe("Plugin: ip-restriction (schema)", function()
     it("blacklist should not accept invalid IPs", function()
       local ok, err = v({ blacklist = { "hello" } }, schema_def)
       assert.falsy(ok)
-      assert.same({ blacklist = { "failed to create new ipmatcher instance: invalid ip address: hello" } }, err.config)
+      assert.same({
+        blacklist = { "invalid ip or cidr range: 'hello'" }
+      }, err.config)
 
       ok, err = v({ blacklist = { "127.0.0.1", "127.0.0.2", "hello" } }, schema_def)
       assert.falsy(ok)
-      assert.same({ blacklist = { [3] = "failed to create new ipmatcher instance: invalid ip address: hello" } }, err.config)
+      assert.same({
+        blacklist = { [3] = "invalid ip or cidr range: 'hello'" }
+      }, err.config)
     end)
     it("should not accept both a whitelist and a blacklist", function()
       local t = { blacklist = { "127.0.0.1" }, whitelist = { "127.0.0.2" } }
@@ -59,34 +67,31 @@ describe("Plugin: ip-restriction (schema)", function()
       assert.same(expected, err["@entity"])
     end)
 
-    -- TODO: the ipmatcher library doesn't validate cidr ranges
-    --
-    --it("should not accept invalid cidr ranges", function()
-    --  local ok, err = v({ whitelist = { "0.0.0.0/a", "0.0.0.0/-1", "0.0.0.0/33" } }, schema_def)
-    --  assert.falsy(ok)
-    --  assert.same({
-    --    whitelist = {
-    --     "invalid cidr range: Invalid prefix: /a",
-    --      "invalid cidr range: Invalid prefix: /-1",
-    --      "invalid cidr range: Invalid prefix: /33",
-    --    }
-    --  }, err.config)
-    --
-    --end)
-    --it("should not accept invalid ipv6 cidr ranges", function()
-    --  local ok, err = v({ whitelist = { "::/a", "::/-1", "::/129", "::1/a", "::1/-1", "::1/129" } }, schema_def)
-    --  assert.falsy(ok)
-    --  assert.same({
-    --    whitelist = {
-    --      "invalid cidr range: Invalid prefix: /a",
-    --      "invalid cidr range: Invalid prefix: /-1",
-    --      "invalid cidr range: Invalid prefix: /129",
-    --      "invalid cidr range: Invalid prefix: /a",
-    --      "invalid cidr range: Invalid prefix: /-1",
-    --      "invalid cidr range: Invalid prefix: /129",
-    --    }
-    --  }, err.config)
-    --end)
+    it("should not accept invalid cidr ranges", function()
+      local ok, err = v({ whitelist = { "0.0.0.0/a", "0.0.0.0/-1", "0.0.0.0/33" } }, schema_def)
+      assert.falsy(ok)
+      assert.same({
+        whitelist = {
+          "invalid ip or cidr range: '0.0.0.0/a'",
+          "invalid ip or cidr range: '0.0.0.0/-1'",
+          "invalid ip or cidr range: '0.0.0.0/33'",
+        }
+      }, err.config)
+    end)
+    it("should not accept invalid ipv6 cidr ranges", function()
+      local ok, err = v({ whitelist = { "::/a", "::/-1", "::/129", "::1/a", "::1/-1", "::1/129" } }, schema_def)
+      assert.falsy(ok)
+      assert.same({
+        whitelist = {
+          "invalid ip or cidr range: '::/a'",
+          "invalid ip or cidr range: '::/-1'",
+          "invalid ip or cidr range: '::/129'",
+          "invalid ip or cidr range: '::1/a'",
+          "invalid ip or cidr range: '::1/-1'",
+          "invalid ip or cidr range: '::1/129'",
+        }
+      }, err.config)
+    end)
 
     it("should accept valid ipv6 cidr ranges", function()
       local ok = v({ whitelist = { "::/0",  "::/1", "::/128"  } }, schema_def)

--- a/spec/03-plugins/17-ip-restriction/01-schema_spec.lua
+++ b/spec/03-plugins/17-ip-restriction/01-schema_spec.lua
@@ -12,6 +12,17 @@ describe("Plugin: ip-restriction (schema)", function()
   it("should accept a valid blacklist", function()
     assert(v({ blacklist = { "127.0.0.1", "127.0.0.2" } }, schema_def))
   end)
+  it("should accept both non-empty whitelist and blacklist", function()
+    local schema = {
+      blacklist = {
+        "127.0.0.2"
+      },
+      whitelist = {
+        "127.0.0.1"
+      },
+    }
+    assert(v(schema, schema_def))
+  end)
 
   describe("errors", function()
     it("whitelist should not accept invalid types", function()
@@ -50,18 +61,11 @@ describe("Plugin: ip-restriction (schema)", function()
         blacklist = { [3] = "invalid ip or cidr range: 'hello'" }
       }, err.config)
     end)
-    it("should not accept both a whitelist and a blacklist", function()
-      local t = { blacklist = { "127.0.0.1" }, whitelist = { "127.0.0.2" } }
-      local ok, err = v(t, schema_def)
-      assert.falsy(ok)
-      assert.same({ "only one of these fields must be non-empty: 'config.whitelist', 'config.blacklist'" }, err["@entity"])
-    end)
     it("should not accept both empty whitelist and blacklist", function()
       local t = { blacklist = {}, whitelist = {} }
       local ok, err = v(t, schema_def)
       assert.falsy(ok)
       local expected = {
-        "only one of these fields must be non-empty: 'config.whitelist', 'config.blacklist'",
         "at least one of these fields must be non-empty: 'config.whitelist', 'config.blacklist'",
       }
       assert.same(expected, err["@entity"])

--- a/spec/03-plugins/17-ip-restriction/01-schema_spec.lua
+++ b/spec/03-plugins/17-ip-restriction/01-schema_spec.lua
@@ -22,11 +22,11 @@ describe("Plugin: ip-restriction (schema)", function()
     it("whitelist should not accept invalid IPs", function()
       local ok, err = v({ whitelist = { "hello" } }, schema_def)
       assert.falsy(ok)
-      assert.same({ whitelist = { "invalid cidr range: Invalid IP" } }, err.config)
+      assert.same({ whitelist = { "failed to create new ipmatcher instance: invalid ip address: hello" } }, err.config)
 
       ok, err = v({ whitelist = { "127.0.0.1", "127.0.0.2", "hello" } }, schema_def)
       assert.falsy(ok)
-      assert.same({ whitelist = { [3] = "invalid cidr range: Invalid IP" } }, err.config)
+      assert.same({ whitelist = { [3] = "failed to create new ipmatcher instance: invalid ip address: hello" } }, err.config)
     end)
     it("blacklist should not accept invalid types", function()
       local ok, err = v({ blacklist = 12 }, schema_def)
@@ -36,11 +36,11 @@ describe("Plugin: ip-restriction (schema)", function()
     it("blacklist should not accept invalid IPs", function()
       local ok, err = v({ blacklist = { "hello" } }, schema_def)
       assert.falsy(ok)
-      assert.same({ blacklist = { "invalid cidr range: Invalid IP" } }, err.config)
+      assert.same({ blacklist = { "failed to create new ipmatcher instance: invalid ip address: hello" } }, err.config)
 
       ok, err = v({ blacklist = { "127.0.0.1", "127.0.0.2", "hello" } }, schema_def)
       assert.falsy(ok)
-      assert.same({ blacklist = { [3] = "invalid cidr range: Invalid IP" } }, err.config)
+      assert.same({ blacklist = { [3] = "failed to create new ipmatcher instance: invalid ip address: hello" } }, err.config)
     end)
     it("should not accept both a whitelist and a blacklist", function()
       local t = { blacklist = { "127.0.0.1" }, whitelist = { "127.0.0.2" } }
@@ -58,42 +58,39 @@ describe("Plugin: ip-restriction (schema)", function()
       }
       assert.same(expected, err["@entity"])
     end)
-    it("should not accept invalid cidr ranges", function()
-      local ok, err = v({ whitelist = { "0.0.0.0/a", "0.0.0.0/-1", "0.0.0.0/33" } }, schema_def)
-      assert.falsy(ok)
-      assert.same({
-        whitelist = {
-          "invalid cidr range: Invalid prefix: /a",
-          "invalid cidr range: Invalid prefix: /-1",
-          "invalid cidr range: Invalid prefix: /33",
-        }
-      }, err.config)
 
-    end)
-    it("should not accept invalid ipv6 cidr ranges", function()
-      local ok, err = v({ whitelist = { "::/a", "::/-1", "::/129", "::1/a", "::1/-1", "::1/129" } }, schema_def)
-      assert.falsy(ok)
-      assert.same({
-        whitelist = {
-          "invalid cidr range: Invalid prefix: /a",
-          "invalid cidr range: Invalid prefix: /-1",
-          "invalid cidr range: Invalid prefix: /129",
-          "invalid cidr range: Invalid prefix: /a",
-          "invalid cidr range: Invalid prefix: /-1",
-          "invalid cidr range: Invalid prefix: /129",
-        }
-      }, err.config)
-    end)
-    it("should not accept valid ipv6 cidr ranges", function()
-      local ok, err = v({ whitelist = { "::/0",  "::/1", "::/128"  } }, schema_def)
-      assert.falsy(ok)
-      assert.same({
-        whitelist = {
-          "invalid cidr range: Invalid IP",
-          "invalid cidr range: Invalid IP",
-          "invalid cidr range: Invalid prefix: /128",
-        }
-      }, err.config)
+    -- TODO: the ipmatcher library doesn't validate cidr ranges
+    --
+    --it("should not accept invalid cidr ranges", function()
+    --  local ok, err = v({ whitelist = { "0.0.0.0/a", "0.0.0.0/-1", "0.0.0.0/33" } }, schema_def)
+    --  assert.falsy(ok)
+    --  assert.same({
+    --    whitelist = {
+    --     "invalid cidr range: Invalid prefix: /a",
+    --      "invalid cidr range: Invalid prefix: /-1",
+    --      "invalid cidr range: Invalid prefix: /33",
+    --    }
+    --  }, err.config)
+    --
+    --end)
+    --it("should not accept invalid ipv6 cidr ranges", function()
+    --  local ok, err = v({ whitelist = { "::/a", "::/-1", "::/129", "::1/a", "::1/-1", "::1/129" } }, schema_def)
+    --  assert.falsy(ok)
+    --  assert.same({
+    --    whitelist = {
+    --      "invalid cidr range: Invalid prefix: /a",
+    --      "invalid cidr range: Invalid prefix: /-1",
+    --      "invalid cidr range: Invalid prefix: /129",
+    --      "invalid cidr range: Invalid prefix: /a",
+    --      "invalid cidr range: Invalid prefix: /-1",
+    --      "invalid cidr range: Invalid prefix: /129",
+    --    }
+    --  }, err.config)
+    --end)
+
+    it("should accept valid ipv6 cidr ranges", function()
+      local ok = v({ whitelist = { "::/0",  "::/1", "::/128"  } }, schema_def)
+      assert.truthy(ok)
     end)
   end)
 end)

--- a/spec/03-plugins/17-ip-restriction/02-access_spec.lua
+++ b/spec/03-plugins/17-ip-restriction/02-access_spec.lua
@@ -49,6 +49,18 @@ for _, strategy in helpers.each_strategy() do
         hosts = { "ip-restriction8.com" },
       }
 
+      local route9 = bp.routes:insert {
+        hosts = { "ip-restriction9.com" },
+      }
+
+      local route10 = bp.routes:insert {
+        hosts = { "ip-restriction10.com" },
+      }
+
+      local route11 = bp.routes:insert {
+        hosts = { "ip-restriction11.com" },
+      }
+
       bp.plugins:insert {
         name     = "ip-restriction",
         route = { id = route1.id },
@@ -113,6 +125,33 @@ for _, strategy in helpers.each_strategy() do
         },
       })
 
+      assert(db.plugins:insert {
+        name     = "ip-restriction",
+        route = { id = route9.id },
+        config   = {
+          whitelist = { "127.0.0.1" },
+          blacklist = { "127.0.0.1" },
+        },
+      })
+
+      assert(db.plugins:insert {
+        name     = "ip-restriction",
+        route = { id = route10.id },
+        config   = {
+          whitelist = { "127.0.0.0/24" },
+          blacklist = { "127.0.0.1" },
+        },
+      })
+
+      assert(db.plugins:insert {
+        name     = "ip-restriction",
+        route = { id = route11.id },
+        config   = {
+          whitelist = { "127.0.0.0/24" },
+          blacklist = { "127.0.0.0/24" },
+        },
+      })
+
       assert(helpers.start_kong {
         database          = strategy,
         real_ip_header    = "X-Forwarded-For",
@@ -165,6 +204,42 @@ for _, strategy in helpers.each_strategy() do
           path    = "/status/200",
           headers = {
             ["Host"] = "ip-restriction5.com"
+          }
+        })
+        local body = assert.res_status(403, res)
+        local json = cjson.decode(body)
+        assert.same({ message = "Your IP address is not allowed" }, json)
+      end)
+      it("blocks an IP on a whitelisted CIDR range", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/status/200",
+          headers = {
+            ["Host"] = "ip-restriction10.com"
+          }
+        })
+        local body = assert.res_status(403, res)
+        local json = cjson.decode(body)
+        assert.same({ message = "Your IP address is not allowed" }, json)
+      end)
+      it("takes precedence over an whitelisted IP", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/status/200",
+          headers = {
+            ["Host"] = "ip-restriction9.com"
+          }
+        })
+        local body = assert.res_status(403, res)
+        local json = cjson.decode(body)
+        assert.same({ message = "Your IP address is not allowed" }, json)
+      end)
+      it("takes precedence over an whitelisted CIDR range", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/status/200",
+          headers = {
+            ["Host"] = "ip-restriction11.com"
           }
         })
         local body = assert.res_status(403, res)
@@ -386,6 +461,18 @@ for _, strategy in helpers.each_strategy() do
         hosts = { "ip-restriction6.com" },
       }
 
+      local route7 = bp.routes:insert {
+        hosts = { "ip-restriction7.com" },
+      }
+
+      local route8 = bp.routes:insert {
+        hosts = { "ip-restriction8.com" },
+      }
+
+      local route9 = bp.routes:insert {
+        hosts = { "ip-restriction9.com" },
+      }
+
       bp.plugins:insert {
         name     = "ip-restriction",
         route = { id = route1.id },
@@ -432,6 +519,33 @@ for _, strategy in helpers.each_strategy() do
         route = { id = route6.id },
         config   = {
           whitelist = { "::/0" },
+        },
+      })
+
+      assert(db.plugins:insert {
+        name     = "ip-restriction",
+        route = { id = route7.id },
+        config   = {
+          whitelist = { "::1" },
+          blacklist = { "::1" },
+        },
+      })
+
+      assert(db.plugins:insert {
+        name     = "ip-restriction",
+        route = { id = route8.id },
+        config   = {
+          whitelist = { "::1/128" },
+          blacklist = { "::1" },
+        },
+      })
+
+      assert(db.plugins:insert {
+        name     = "ip-restriction",
+        route = { id = route9.id },
+        config   = {
+          whitelist = { "::1/128" },
+          blacklist = { "::1/128" },
         },
       })
 
@@ -489,6 +603,44 @@ for _, strategy in helpers.each_strategy() do
           headers = {
             ["Host"] = "ip-restriction3.com",
             ["X-Real-IP"] = "fe80::1",
+          }
+        })
+        local body = assert.res_status(403, res)
+        local json = cjson.decode(body)
+        assert.same({ message = "Your IP address is not allowed" }, json)
+      end)
+      it("blocks an IPv6 on a whitelisted IPv6 CIDR range", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/status/200",
+          headers = {
+            ["Host"] = "ip-restriction8.com",
+            ["X-Real-IP"] = "::1",
+          }
+        })
+        local body = assert.res_status(403, res)
+        local json = cjson.decode(body)
+        assert.same({ message = "Your IP address is not allowed" }, json)
+      end)
+      it("takes precedence over an whitelisted IPv6", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/status/200",
+          headers = {
+            ["Host"] = "ip-restriction7.com",
+            ["X-Real-IP"] = "::1",
+          }
+        })
+        local body = assert.res_status(403, res)
+        local json = cjson.decode(body)
+        assert.same({ message = "Your IP address is not allowed" }, json)
+      end)
+      it("takes precedence over an whitelisted IPv6 CIDR range", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/status/200",
+          headers = {
+            ["Host"] = "ip-restriction9.com"
           }
         })
         local body = assert.res_status(403, res)

--- a/spec/03-plugins/17-ip-restriction/02-access_spec.lua
+++ b/spec/03-plugins/17-ip-restriction/02-access_spec.lua
@@ -213,7 +213,7 @@ for _, strategy in helpers.each_strategy() do
         end)
       end)
     end)
-
+    
     describe("whitelist", function()
       it("blocks a request when the IP is not whitelisted", function()
         local res = assert(proxy_client:send {
@@ -344,6 +344,418 @@ for _, strategy in helpers.each_strategy() do
           }
         })
         assert.res_status(200, res)
+      end)
+    end)
+  end)
+
+  describe("Plugin: ip-restriction (access) [#" .. strategy .. "]", function()
+    local plugin
+    local proxy_client
+    local admin_client
+    local db
+
+    lazy_setup(function()
+      local bp
+      bp, db = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+      })
+
+      local route1 = bp.routes:insert {
+        hosts = { "ip-restriction1.com" },
+      }
+
+      local route2 = bp.routes:insert {
+        hosts = { "ip-restriction2.com" },
+      }
+
+      local route3 = bp.routes:insert {
+        hosts = { "ip-restriction3.com" },
+      }
+
+      local route4 = bp.routes:insert {
+        hosts = { "ip-restriction4.com" },
+      }
+
+      local route5 = bp.routes:insert {
+        hosts = { "ip-restriction5.com" },
+      }
+
+      local route6 = bp.routes:insert {
+        hosts = { "ip-restriction6.com" },
+      }
+
+      bp.plugins:insert {
+        name     = "ip-restriction",
+        route = { id = route1.id },
+        config   = {
+          blacklist = { "::1", "::2" }
+        },
+      }
+
+      plugin = assert(db.plugins:insert {
+        name     = "ip-restriction",
+        route = { id = route2.id },
+        config   = {
+          blacklist = { "::2" },
+        },
+      })
+
+      assert(db.plugins:insert {
+        name     = "ip-restriction",
+        route = { id = route3.id },
+        config   = {
+          blacklist = { "fe80::/8" },
+        },
+      })
+
+
+      assert(db.plugins:insert {
+        name     = "ip-restriction",
+        route = { id = route4.id },
+        config   = {
+          whitelist = { "::2" },
+        },
+      })
+
+      assert(db.plugins:insert {
+        name     = "ip-restriction",
+        route = { id = route5.id },
+        config   = {
+          whitelist = { "::1" },
+        },
+      })
+
+      assert(db.plugins:insert {
+        name     = "ip-restriction",
+        route = { id = route6.id },
+        config   = {
+          whitelist = { "::/0" },
+        },
+      })
+
+      assert(helpers.start_kong {
+        database          = strategy,
+        real_ip_recursive = "on",
+        trusted_ips       = "0.0.0.0/0, ::/0",
+        nginx_conf        = "spec/fixtures/custom_nginx.template",
+      })
+
+      proxy_client = helpers.proxy_client()
+      admin_client = helpers.admin_client()
+    end)
+
+    lazy_teardown(function()
+      if proxy_client and admin_client then
+        proxy_client:close()
+        admin_client:close()
+      end
+
+      helpers.stop_kong()
+    end)
+
+    describe("blacklist", function()
+      it("blocks a request when the IPv6 is blacklisted", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/status/200",
+          headers = {
+            ["Host"] = "ip-restriction1.com",
+            ["X-Real-IP"] = "::1",
+          }
+        })
+        local body = assert.res_status(403, res)
+        local json = cjson.decode(body)
+        assert.same({ message = "Your IP address is not allowed" }, json)
+      end)
+      it("allows a request when the IPv6 is not blacklisted", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/request",
+          headers = {
+            ["Host"] = "ip-restriction2.com",
+            ["X-Real-IP"] = "::1",
+          }
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.equal("::1", json.vars.remote_addr)
+      end)
+      it("blocks the IPv6 with CIDR", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/status/200",
+          headers = {
+            ["Host"] = "ip-restriction3.com",
+            ["X-Real-IP"] = "fe80::1",
+          }
+        })
+        local body = assert.res_status(403, res)
+        local json = cjson.decode(body)
+        assert.same({ message = "Your IP address is not allowed" }, json)
+      end)
+    end)
+
+    describe("whitelist", function()
+      it("blocks a request when the IPv6 is not whitelisted", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/status/200",
+          headers = {
+            ["Host"] = "ip-restriction4.com",
+            ["X-Real-IP"] = "::1",
+          }
+        })
+        local body = assert.res_status(403, res)
+        local json = cjson.decode(body)
+        assert.same({ message = "Your IP address is not allowed" }, json)
+      end)
+      it("allows a whitelisted IPv6", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/status/200",
+          headers = {
+            ["Host"] = "ip-restriction5.com",
+            ["X-Real-IP"] = "::1",
+          }
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.equal("::1", json.vars.remote_addr)
+      end)
+    end)
+
+    it("supports config changes without restarting", function()
+      local res = assert(proxy_client:send {
+        method  = "GET",
+        path    = "/request",
+        headers = {
+          ["Host"] = "ip-restriction2.com",
+          ["X-Real-IP"] = "::1",
+        }
+      })
+      local body = assert.res_status(200, res)
+      local json = cjson.decode(body)
+      assert.equal("::1", json.vars.remote_addr)
+
+      res = assert(admin_client:send {
+        method  = "PATCH",
+        path    = "/plugins/" .. plugin.id,
+        body    = {
+          config = { blacklist = { "::1", "::2" } },
+        },
+        headers = {
+          ["Content-Type"] = "application/json"
+        }
+      })
+      assert.res_status(200, res)
+
+      local cache_key = db.plugins:cache_key(plugin)
+
+      helpers.wait_until(function()
+        res = assert(admin_client:send {
+          method = "GET",
+          path   = "/cache/" .. cache_key
+        })
+        res:read_body()
+        return res.status ~= 200
+      end)
+
+      local res = assert(proxy_client:send {
+        method  = "GET",
+        path    = "/request",
+        headers = {
+          ["Host"] = "ip-restriction2.com",
+          ["X-Real-IP"] = "::1",
+        }
+      })
+      local body = assert.res_status(403, res)
+      local json = cjson.decode(body)
+      assert.same({ message = "Your IP address is not allowed" }, json)
+    end)
+
+    describe("#regression", function()
+      it("handles a CIDR entry with ::/0", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/status/200",
+          headers = {
+            ["Host"] = "ip-restriction6.com",
+            ["X-Real-IP"] = "::1",
+          }
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.equal("::1", json.vars.remote_addr)
+      end)
+    end)
+  end)
+
+  describe("Plugin: ip-restriction (access) [#" .. strategy .. "]", function()
+    local proxy_client
+    local admin_client
+
+    lazy_setup(function()
+      local bp
+      bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+      })
+
+      local route1 = bp.routes:insert {
+        hosts = { "ip-restriction1.com" },
+      }
+
+      local route2 = bp.routes:insert {
+        hosts = { "ip-restriction2.com" },
+      }
+
+      bp.plugins:insert {
+        name     = "ip-restriction",
+        route = { id = route1.id },
+        config   = {
+          blacklist = { "::4" }
+        },
+      }
+
+      bp.plugins:insert {
+        name     = "ip-restriction",
+        route = { id = route2.id },
+        config   = {
+          whitelist = { "::4" }
+        },
+      }
+
+      assert(helpers.start_kong {
+        database          = strategy,
+        real_ip_header    = "X-Forwarded-For",
+        real_ip_recursive = "on",
+        trusted_ips       = "0.0.0.0/0, ::/0",
+        nginx_conf        = "spec/fixtures/custom_nginx.template",
+      })
+
+      proxy_client = helpers.proxy_client()
+      admin_client = helpers.admin_client()
+    end)
+
+    lazy_teardown(function()
+      if proxy_client and admin_client then
+        proxy_client:close()
+        admin_client:close()
+      end
+
+      helpers.stop_kong()
+    end)
+
+    describe("blacklist", function()
+      it("allows with allowed X-Forwarded-For header", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/request",
+          headers = {
+            ["Host"]            = "ip-restriction1.com",
+            ["X-Forwarded-For"] = "::3",
+          }
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.equal("::3", json.vars.remote_addr)
+      end)
+      it("blocks with not allowed X-Forwarded-For header", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/status/200",
+          headers = {
+            ["Host"]            = "ip-restriction1.com",
+            ["X-Forwarded-For"] = "::4"
+          }
+        })
+        local body = assert.res_status(403, res)
+        local json = cjson.decode(body)
+        assert.same({ message = "Your IP address is not allowed" }, json)
+      end)
+      it("blocks with blocked complex X-Forwarded-For header", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/status/200",
+          headers = {
+            ["Host"]            = "ip-restriction1.com",
+            ["X-Forwarded-For"] = "::4, ::3"
+          }
+        })
+        local body = assert.res_status(403, res)
+        local json = cjson.decode(body)
+        assert.same({ message = "Your IP address is not allowed" }, json)
+      end)
+      it("allows with allowed complex X-Forwarded-For header", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/status/200",
+          headers = {
+            ["Host"]            = "ip-restriction1.com",
+            ["X-Forwarded-For"] = "::3, ::4"
+          }
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.equal("::3", json.vars.remote_addr)
+      end)
+    end)
+
+    describe("whitelist", function()
+      it("block with not allowed X-Forwarded-For header", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/status/200",
+          headers = {
+            ["Host"]            = "ip-restriction2.com",
+            ["X-Forwarded-For"] = "::3"
+          }
+        })
+        local body = assert.res_status(403, res)
+        local json = cjson.decode(body)
+        assert.same({ message = "Your IP address is not allowed" }, json)
+      end)
+      it("allows with allowed X-Forwarded-For header", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/status/200",
+          headers = {
+            ["Host"]            = "ip-restriction2.com",
+            ["X-Forwarded-For"] = "::4"
+          }
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.equal("::4", json.vars.remote_addr)
+      end)
+      it("allows with allowed complex X-Forwarded-For header", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/status/200",
+          headers = {
+            ["Host"]            = "ip-restriction2.com",
+            ["X-Forwarded-For"] = "::4, ::3"
+          }
+        })
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.equal("::4", json.vars.remote_addr)
+      end)
+      it("blocks with blocked complex X-Forwarded-For header", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/status/200",
+          headers = {
+            ["Host"]            = "ip-restriction2.com",
+            ["X-Forwarded-For"] = "::3, ::4"
+          }
+        })
+        local body = assert.res_status(403, res)
+        local json = cjson.decode(body)
+        assert.same({ message = "Your IP address is not allowed" }, json)
       end)
     end)
   end)


### PR DESCRIPTION
Add IPv6 support for the ip-restriction plugin.

Looking for feedback so I can see if it would be a good idea to replace the 'lua-resty-iputils' and 'lua-resty-mediador' libraries by the 'lua-resty-ipmatcher' one.

The iputils lib is only used for typedef validations and the mediador lib is used for trusted ips on the pdk side and for sources and destinations on the router side.

- [feat(ip-restriction) add support for IPv6](https://github.com/Kong/kong/pull/5640/commits/fb76a01bfcea55e50353402204be6b2c62eebd3a)