### PR TITLE
#5641: add fastcgi support for kong

### DIFF
--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -55,6 +55,7 @@ local protocols_with_subsystem = {
   tls = "stream",
   grpc = "http",
   grpcs = "http",
+  fcgi = "http",
 }
 local protocols = {}
 for p,_ in pairs(protocols_with_subsystem) do

--- a/kong/db/schema/entities/upstreams.lua
+++ b/kong/db/schema/entities/upstreams.lua
@@ -52,7 +52,7 @@ local positive_int_or_zero = Schema.define {
 
 local check_type = Schema.define {
   type = "string",
-  one_of = { "tcp", "http", "https", "grpc", "grpcs" },
+  one_of = { "tcp", "http", "https", "grpc", "grpcs", "fcgi" },
   default = "http",
 }
 

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -159,6 +159,41 @@ server {
         proxy_pass            $upstream_scheme://kong_upstream$upstream_uri;
     }
 
+    location @fcgi {
+        internal;
+        default_type         '';
+        set $upstream_path   '';
+        set $kong_proxy_mode 'fcgi';
+
+	fastcgi_param  SCRIPT_FILENAME    $upstream_path;
+	fastcgi_param  QUERY_STRING       $query_string;
+	fastcgi_param  REQUEST_METHOD     $request_method;
+	fastcgi_param  CONTENT_TYPE       $content_type;
+	fastcgi_param  CONTENT_LENGTH     $content_length;
+
+	fastcgi_param  SCRIPT_NAME        $fastcgi_script_name;
+	fastcgi_param  REQUEST_URI        $request_uri;
+	fastcgi_param  DOCUMENT_URI       $document_uri;
+	fastcgi_param  DOCUMENT_ROOT      $document_root;
+	fastcgi_param  SERVER_PROTOCOL    $server_protocol;
+	fastcgi_param  HTTPS              $https if_not_empty;
+
+	fastcgi_param  GATEWAY_INTERFACE  CGI/1.1;
+	fastcgi_param  SERVER_SOFTWARE    nginx/$nginx_version;
+
+	fastcgi_param  REMOTE_ADDR        $remote_addr;
+	fastcgi_param  REMOTE_PORT        $remote_port;
+	fastcgi_param  SERVER_ADDR        $server_addr;
+	fastcgi_param  SERVER_PORT        $server_port;
+	fastcgi_param  SERVER_NAME        $server_name;
+
+	# PHP only, required if PHP was built with --enable-force-cgi-redirect
+	fastcgi_param  REDIRECT_STATUS    200;
+
+	fastcgi_index index.php;
+        fastcgi_pass kong_upstream;
+    }
+
     location @grpc {
         internal;
         default_type         '';

--- a/spec/01-unit/01-db/01-schema/11-declarative_config/01-validate_spec.lua
+++ b/spec/01-unit/01-db/01-schema/11-declarative_config/01-validate_spec.lua
@@ -186,7 +186,7 @@ describe("declarative config: validate", function()
               ["host"] = "expected a string",
               ["path"] = "must not have empty segments",
               ["port"] = "value should be between 0 and 65535",
-              ["protocol"] = "expected one of: grpc, grpcs, http, https, tcp, tls",
+              ["protocol"] = "expected one of: fcgi, grpc, grpcs, http, https, tcp, tls",
               ["retries"] = "value should be between 0 and 32767",
             }
           }

--- a/spec/01-unit/01-db/01-schema/11-declarative_config/02-process_auto_fields_spec.lua
+++ b/spec/01-unit/01-db/01-schema/11-declarative_config/02-process_auto_fields_spec.lua
@@ -141,7 +141,7 @@ describe("declarative config: process_auto_fields", function()
               _ignore = { { foo = "bar" } },
               name = "key-auth",
               enabled = true,
-              protocols = { "grpc", "grpcs", "http", "https" },
+              protocols = { "fcgi", "grpc", "grpcs", "http", "https" },
               config = {
                 hide_credentials = false,
                 key_in_body = false,
@@ -154,7 +154,7 @@ describe("declarative config: process_auto_fields", function()
               _ignore = { { foo = "bar" } },
               name = "http-log",
               enabled = true,
-              protocols = { "grpc", "grpcs", "http", "https" },
+              protocols = { "fcgi", "grpc", "grpcs", "http", "https" },
               config = {
                 http_endpoint = "https://example.com",
                 content_type = "application/json",
@@ -190,7 +190,7 @@ describe("declarative config: process_auto_fields", function()
               route = "foo",
               name = "key-auth",
               enabled = true,
-              protocols = { "grpc", "grpcs", "http", "https" },
+              protocols = { "fcgi", "grpc", "grpcs", "http", "https" },
               config = {
                 hide_credentials = false,
                 key_in_body = false,
@@ -203,7 +203,7 @@ describe("declarative config: process_auto_fields", function()
               consumer = "my-consumer",
               name = "http-log",
               enabled = true,
-              protocols = { "grpc", "grpcs", "http", "https" },
+              protocols = { "fcgi", "grpc", "grpcs", "http", "https" },
               config = {
                 http_endpoint = "https://example.com",
                 content_type = "application/json",
@@ -298,7 +298,7 @@ describe("declarative config: process_auto_fields", function()
                     _ignore = { { foo = "bar" } },
                     name = "key-auth",
                     enabled = true,
-                    protocols = { "grpc", "grpcs", "http", "https" },
+                    protocols = { "fcgi", "grpc", "grpcs", "http", "https" },
                     config = {
                       hide_credentials = false,
                       key_in_body = false,
@@ -309,7 +309,7 @@ describe("declarative config: process_auto_fields", function()
                   {
                     name = "http-log",
                     enabled = true,
-                    protocols = { "grpc", "grpcs", "http", "https" },
+                    protocols = { "fcgi", "grpc", "grpcs", "http", "https" },
                     config = {
                       http_endpoint = "https://example.com",
                       content_type = "application/json",
@@ -336,7 +336,7 @@ describe("declarative config: process_auto_fields", function()
                   {
                     name = "basic-auth",
                     enabled = true,
-                    protocols = { "grpc", "grpcs", "http", "https" },
+                    protocols = { "fcgi", "grpc", "grpcs", "http", "https" },
                     config = {
                       hide_credentials = false,
                     }
@@ -344,7 +344,7 @@ describe("declarative config: process_auto_fields", function()
                   {
                     name = "tcp-log",
                     enabled = true,
-                    protocols = { "grpc", "grpcs", "http", "https" },
+                    protocols = { "fcgi", "grpc", "grpcs", "http", "https" },
                     config = {
                       host = "127.0.0.1",
                       port = 10000,
@@ -589,7 +589,7 @@ describe("declarative config: process_auto_fields", function()
                       {
                         name = "key-auth",
                         enabled = true,
-                        protocols = { "grpc", "grpcs", "http", "https" },
+                        protocols = { "fcgi", "grpc", "grpcs", "http", "https" },
                         config = {
                           hide_credentials = false,
                           key_in_body = false,
@@ -600,7 +600,7 @@ describe("declarative config: process_auto_fields", function()
                       {
                         name = "http-log",
                         enabled = true,
-                        protocols = { "grpc", "grpcs", "http", "https" },
+                        protocols = { "fcgi", "grpc", "grpcs", "http", "https" },
                         config = {
                           http_endpoint = "https://example.com",
                           content_type = "application/json",
@@ -639,7 +639,7 @@ describe("declarative config: process_auto_fields", function()
                       {
                         name = "basic-auth",
                         enabled = true,
-                        protocols = { "grpc", "grpcs", "http", "https" },
+                        protocols = { "fcgi", "grpc", "grpcs", "http", "https" },
                         config = {
                           hide_credentials = false,
                         }
@@ -647,7 +647,7 @@ describe("declarative config: process_auto_fields", function()
                       {
                         name = "tcp-log",
                         enabled = true,
-                        protocols = { "grpc", "grpcs", "http", "https" },
+                        protocols = { "fcgi", "grpc", "grpcs", "http", "https" },
                         config = {
                           host = "127.0.0.1",
                           port = 10000,

--- a/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
+++ b/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
@@ -262,7 +262,7 @@ describe("declarative config: flatten", function()
               route = null,
               name = "http-log",
               enabled = true,
-              protocols = { "grpc", "grpcs", "http", "https" },
+              protocols = { "fcgi", "grpc", "grpcs", "http", "https" },
               config = {
                 http_endpoint = "https://example.com",
                 content_type = "application/json",
@@ -283,7 +283,7 @@ describe("declarative config: flatten", function()
               route = null,
               name = "key-auth",
               enabled = true,
-              protocols = { "grpc", "grpcs", "http", "https" },
+              protocols = { "fcgi", "grpc", "grpcs", "http", "https" },
               config = {
                 anonymous = null,
                 hide_credentials = false,
@@ -371,7 +371,7 @@ describe("declarative config: flatten", function()
               id = "UUID",
               name = "http-log",
               route = null,
-              protocols = { "grpc", "grpcs", "http", "https" },
+              protocols = { "fcgi", "grpc", "grpcs", "http", "https" },
               service = {
                 id = "UUID"
               }
@@ -393,7 +393,7 @@ describe("declarative config: flatten", function()
               route = {
                 id = "UUID"
               },
-              protocols = { "grpc", "grpcs", "http", "https" },
+              protocols = { "fcgi", "grpc", "grpcs", "http", "https" },
               service = null
             },
           },
@@ -517,7 +517,7 @@ describe("declarative config: flatten", function()
                 enabled = true,
                 id = "UUID",
                 name = "basic-auth",
-                protocols = { "grpc", "grpcs", "http", "https" },
+                protocols = { "fcgi", "grpc", "grpcs", "http", "https" },
                 route = null,
                 service = {
                   id = "UUID"
@@ -539,7 +539,7 @@ describe("declarative config: flatten", function()
                 enabled = true,
                 id = "UUID",
                 name = "http-log",
-                protocols = { "grpc", "grpcs", "http", "https" },
+                protocols = { "fcgi", "grpc", "grpcs", "http", "https" },
                 route = null,
                 service = {
                   id = "UUID"
@@ -558,7 +558,7 @@ describe("declarative config: flatten", function()
                 enabled = true,
                 id = "UUID",
                 name = "key-auth",
-                protocols = { "grpc", "grpcs", "http", "https" },
+                protocols = { "fcgi", "grpc", "grpcs", "http", "https" },
                 route = null,
                 service = {
                   id = "UUID"
@@ -578,7 +578,7 @@ describe("declarative config: flatten", function()
                 enabled = true,
                 id = "UUID",
                 name = "tcp-log",
-                protocols = { "grpc", "grpcs", "http", "https" },
+                protocols = { "fcgi", "grpc", "grpcs", "http", "https" },
                 route = null,
                 service = {
                   id = "UUID"
@@ -970,7 +970,7 @@ describe("declarative config: flatten", function()
                 enabled = true,
                 id = "UUID",
                 name = "basic-auth",
-                protocols = { "grpc", "grpcs", "http", "https" },
+                protocols = { "fcgi", "grpc", "grpcs", "http", "https" },
                 route = {
                   id = "UUID"
                 },
@@ -992,7 +992,7 @@ describe("declarative config: flatten", function()
                 enabled = true,
                 id = "UUID",
                 name = "http-log",
-                protocols = { "grpc", "grpcs", "http", "https" },
+                protocols = { "fcgi", "grpc", "grpcs", "http", "https" },
                 route = {
                   id = "UUID"
                 },
@@ -1011,7 +1011,7 @@ describe("declarative config: flatten", function()
                 enabled = true,
                 id = "UUID",
                 name = "key-auth",
-                protocols = { "grpc", "grpcs", "http", "https" },
+                protocols = { "fcgi", "grpc", "grpcs", "http", "https" },
                 route = {
                   id = "UUID"
                 },
@@ -1031,7 +1031,7 @@ describe("declarative config: flatten", function()
                 enabled = true,
                 id = "UUID",
                 name = "tcp-log",
-                protocols = { "grpc", "grpcs", "http", "https" },
+                protocols = { "fcgi", "grpc", "grpcs", "http", "https" },
                 route = {
                   id = "UUID"
                 },

--- a/spec/02-integration/03-db/03-plugins_spec.lua
+++ b/spec/02-integration/03-db/03-plugins_spec.lua
@@ -59,7 +59,7 @@ for _, strategy in helpers.each_strategy() do
               key_in_body = false,
               key_names = { "apikey" },
             },
-            protocols = { "grpc", "grpcs", "http", "https" },
+            protocols = { "fcgi", "grpc", "grpcs", "http", "https" },
             enabled = true,
             name = "key-auth",
             route = {
@@ -131,7 +131,7 @@ for _, strategy in helpers.each_strategy() do
               key_in_body = false,
               key_names = { "apikey" },
             },
-            protocols = { "grpc", "grpcs", "http", "https" },
+            protocols = { "fcgi", "grpc", "grpcs", "http", "https" },
             enabled = true,
             name = "key-auth",
             route = {

--- a/spec/02-integration/04-admin_api/09-routes_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/09-routes_routes_spec.lua
@@ -348,9 +348,9 @@ for _, strategy in helpers.each_strategy() do
                 code    = Errors.codes.SCHEMA_VIOLATION,
                 name    = "schema violation",
                 message = "schema violation " ..
-                          "(protocols.1: expected one of: grpc, grpcs, http, https, tcp, tls)",
+                          "(protocols.1: expected one of: fcgi, grpc, grpcs, http, https, tcp, tls)",
                 fields = {
-                  protocols = { "expected one of: grpc, grpcs, http, https, tcp, tls" },
+                  protocols = { "expected one of: fcgi, grpc, grpcs, http, https, tcp, tls" },
                 }
               }, cjson.decode(body))
 
@@ -368,10 +368,10 @@ for _, strategy in helpers.each_strategy() do
                 code    = Errors.codes.SCHEMA_VIOLATION,
                 name    = "schema violation",
                 message = "2 schema violations " ..
-                  "(protocols.1: expected one of: grpc, grpcs, http, https, tcp, tls; " ..
+                  "(protocols.1: expected one of: fcgi, grpc, grpcs, http, https, tcp, tls; " ..
                   [[service.name: invalid value '\o/': it must only contain alphanumeric and '., -, _, ~' characters)]],
                 fields = {
-                  protocols = { "expected one of: grpc, grpcs, http, https, tcp, tls" },
+                  protocols = { "expected one of: fcgi, grpc, grpcs, http, https, tcp, tls" },
                   service = {
                     name = [[invalid value '\o/': it must only contain alphanumeric and '., -, _, ~' characters]]
                   }
@@ -880,9 +880,9 @@ for _, strategy in helpers.each_strategy() do
                   code    = Errors.codes.SCHEMA_VIOLATION,
                   name    = "schema violation",
                   message = "schema violation " ..
-                    "(protocols.1: expected one of: grpc, grpcs, http, https, tcp, tls)",
+                    "(protocols.1: expected one of: fcgi, grpc, grpcs, http, https, tcp, tls)",
                   fields  = {
-                    protocols = { "expected one of: grpc, grpcs, http, https, tcp, tls" },
+                    protocols = { "expected one of: fcgi, grpc, grpcs, http, https, tcp, tls" },
                   }
                 }, cjson.decode(body))
 

--- a/spec/02-integration/04-admin_api/10-services_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/10-services_routes_spec.lua
@@ -807,7 +807,7 @@ for _, strategy in helpers.each_strategy() do
               })
             body = assert.res_status(400, res)
             json = cjson.decode(body)
-            assert.same({ protocol = "expected one of: grpc, grpcs, http, https, tcp, tls" }, json.fields)
+            assert.same({ protocol = "expected one of: fcgi, grpc, grpcs, http, https, tcp, tls" }, json.fields)
           end
         end)
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

we use kong as our api-gateway, while we have quite a lot php-fpm running with nginx as service using fastcgi protocol. As u can see, the only purpose of nginx is to transform http to fastcgi, and I'd like to remove such middle layer via moving such function into kong, since resty can easily proxy fastcgi program using fastcgi_pass

### Full changelog

* [Implement]
support for service using fastcgi protocol

* [Unit Test]
pass all unit test

add service via
`curl -i -X POST --url http://localhost:8001/services/  --data 'name=example-service' --data 'url=fcgi://{fcgi_host}:{fcgi_port}/{fcgi_script_filename}'`

### Issues resolved

Fix #5641 