### PR TITLE
perf(clustering) set larger allowance for WebSocket frame

### DIFF
--- a/kong/clustering.lua
+++ b/kong/clustering.lua
@@ -26,7 +26,7 @@ local ngx_var = ngx.var
 local io_open = io.open
 
 
-local MAX_PAYLOAD = 65536 -- 64KB
+local MAX_PAYLOAD = 8 * 1024 * 1024 -- 8MB
 local PING_INTERVAL = 30 -- 30 seconds
 local WS_OPTS = {
   max_payload_len = MAX_PAYLOAD,


### PR DESCRIPTION
According to @fffonion's quick benchmark, 1000 services and routes results in
a JSON size of around 560KB, therefore, 8MB should allow for ~14000
service/route pairs, which should be sufficient for majority of the use
cases out there.