### PR TITLE
perf(clustering) use Gzip when transferring and saving declarative configurations

### DIFF
--- a/kong-2.0.2-0.rockspec
+++ b/kong-2.0.2-0.rockspec
@@ -17,6 +17,7 @@ dependencies = {
   "penlight == 1.7.0",
   "lua-resty-http == 0.15",
   "lua-resty-jit-uuid == 0.0.7",
+  "lua-ffi-zlib == 0.5",
   "multipart == 0.5.6",
   "version == 1.0.1",
   "kong-lapis == 1.7.0.1",

--- a/spec/01-unit/05-utils_spec.lua
+++ b/spec/01-unit/05-utils_spec.lua
@@ -676,4 +676,32 @@ describe("Utils", function()
       end, "scale must be equal or greater than 0")
     end)
   end)
+
+  describe("gzip_[de_in]flate()", function()
+    it("empty string", function()
+      local gz = assert(utils.deflate_gzip(""))
+      assert.equal(utils.inflate_gzip(gz), "")
+    end)
+
+    it("small string (< 1 buffer)", function()
+      local gz = assert(utils.deflate_gzip("aabbccddeeffgg"))
+      assert.equal(utils.inflate_gzip(gz), "aabbccddeeffgg")
+    end)
+
+    it("long string (> 1 buffer)", function()
+      local s = string.rep("a", 70000) -- > 64KB
+
+      local gz = assert(utils.deflate_gzip(s))
+
+      assert(#gz < #s)
+
+      assert.equal(utils.inflate_gzip(gz), s)
+    end)
+
+    it("bad gzipped data", function()
+      local res, err = utils.inflate_gzip("bad")
+      assert.is_nil(res)
+      assert.equal(err, "INFLATE: data error")
+    end)
+  end)
 end)


### PR DESCRIPTION
Thanks to some quick benchmark work by @fffonion, it it clear that the declarative config can be easily compressed to achieve a much smaller footprint.

According to data provided by @fffonion :

Before Gzip, 1000 Service/Route pairs resulted in a JSON that is 560KB. After Gzipping that size is reduced down to 11KB. Obviously test data has a lot of redundancies, but even for random data a size saving of ~50% can still be achieved, which makes Hybrid mode sync faster and consumes less bandwidth.

Also we bumped the maximum payload size to 4MB, with Gzip that should easily allow tens of thousands of Service/Route pairs which should be sufficient for most of the user's requirments.