### PR TITLE
 chore(ci) use 'make lint' for linting instead of luacheck only 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ jobs:
   include:
     - stage: lint and unit
       script:
-      - luacheck -q .
+      - make lint
       - scripts/autodoc-admin-api
       - bin/busted -v -o htest spec/01-unit
       env:

--- a/spec/03-plugins/10-basic-auth/03-access_spec.lua
+++ b/spec/03-plugins/10-basic-auth/03-access_spec.lua
@@ -351,7 +351,7 @@ for _, strategy in helpers.each_strategy() do
         assert.equal('no-body', body.headers["x-consumer-username"])
       end)
 
-      it("works with wrong #only credentials and username in anonymous", function()
+      it("works with wrong credentials and username in anonymous", function()
         local res = assert(proxy_client:send {
           method  = "GET",
           path    = "/request",


### PR DESCRIPTION
The `lint` target performs additional checks on the codebase.