### PR TITLE
fix(admin) PUT on certificates could error with sni is duplicated

### DIFF
--- a/spec/02-integration/04-admin_api/06-certificates_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/06-certificates_routes_spec.lua
@@ -330,6 +330,29 @@ describe("Admin API: #" .. strategy, function()
         assert.same(json, in_db)
       end)
 
+      it("creates a new sni when provided in the url (with sni duplicated in url and body)", function()
+        local n1 = get_name()
+        local n2 = get_name()
+        local res = client:put("/certificates/" .. n1, {
+          body = {
+            cert = ssl_fixtures.cert,
+            key = ssl_fixtures.key,
+            snis = { n1, n2 },
+          },
+          headers = { ["Content-Type"] = "application/json" },
+        })
+
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.same(ssl_fixtures.cert, json.cert)
+
+        assert.same({ n1, n2 }, json.snis)
+        json.snis = nil
+
+        local in_db = assert(db.certificates:select({ id = json.id }, { nulls = true }))
+        assert.same(json, in_db)
+      end)
+
       it("upserts if found", function()
         local certificate = add_certificate()
 


### PR DESCRIPTION
### Summary

If you send multiple `SNIs` as body argument AND also an `SNI` on URL matching one of the `SNIs` in body, it leads to `sni is duplicated` error.

This bug was introduced with #5321, so it affects Kong 1.5+ (including 1.5).

This PR fixes the issue and the duplicate is not reported anymore as an error (url SNI is only appended to `snis` if not already found on `snis`).

### Issues Resolved

Fix #5652 (at least partly)