### PR TITLE
chore(deps) update lua-resty-openssl from 0.5.3 to 0.6.0

### DIFF
--- a/kong-2.0.2-0.rockspec
+++ b/kong-2.0.2-0.rockspec
@@ -36,7 +36,7 @@ dependencies = {
   "lua-resty-cookie == 0.1.0",
   "lua-resty-mlcache == 2.4.1",
   "lua-messagepack == 0.5.2",
-  "lua-resty-openssl == 0.5.3",
+  "lua-resty-openssl == 0.6.0",
   "lua-resty-counter == 0.2.0",
   -- external Kong plugins
   "kong-plugin-azure-functions ~> 0.4",


### PR DESCRIPTION
### Summary

#### feat

- altname: RFC822 alias to email 37467fc
- bn: mathematics, bit shift and comparasion operations 87bf557
- kdf: use give id as type parameter 0e767d0
- kdf: kdf.derive in luaossl compat mode 45788b6
- kdf: add key derivation functions support d78835e