### PR TITLE
fix(key-auth) consumers get cached to core_cache

### DIFF
--- a/kong/plugins/key-auth/handler.lua
+++ b/kong/plugins/key-auth/handler.lua
@@ -131,11 +131,10 @@ local function do_authentication(conf)
 
   -- retrieve our consumer linked to this API key
 
-  local cache = kong.cache
-
   local credential_cache_key = kong.db.keyauth_credentials:cache_key(key)
-  local credential, err = cache:get(credential_cache_key, nil, load_credential,
-                                    key)
+  local credential, err      = kong.cache:get(credential_cache_key, nil,
+                                              load_credential, key)
+
   if err then
     kong.log.err(err)
     return kong.response.exit(500, {
@@ -155,9 +154,9 @@ local function do_authentication(conf)
   -- retrieve the consumer linked to this API key, to set appropriate headers
   local consumer_cache_key, consumer
   consumer_cache_key = kong.db.consumers:cache_key(credential.consumer.id)
-  consumer, err      = cache:get(consumer_cache_key, nil,
-                                 kong.client.load_consumer,
-                                 credential.consumer.id)
+  consumer, err      = kong.core_cache:get(consumer_cache_key, nil,
+                                           kong.client.load_consumer,
+                                           credential.consumer.id)
   if err then
     kong.log.err(err)
     return nil, { status = 500, message = "An unexpected error occurred" }


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

The plugin was forcing accesses to DB on the first request after restart
even when `db_cache_warmup` was set.

That's because the plugin was using kong.cache to get the consumers
cache key, when consumers get cached to kong.core_cache.

### Full changelog

* [fix(key-auth) consumers get cached to core_cache](https://github.com/Kong/kong/commit/fb25b04fb36af3e61f8a4c57161162b17e161aec)