### PR TITLE
fix(proxy) prioritize longer regex path matches

### DIFF
--- a/kong/router.lua
+++ b/kong/router.lua
@@ -450,6 +450,7 @@ local function marshall_route(r)
           route_t.uris[path] = uri_t
           insert(route_t.uris, uri_t)
 
+          route_t.max_uri_length = max(route_t.max_uri_length, #path)
           route_t.submatch_weight = bor(route_t.submatch_weight,
                                         MATCH_SUBRULES.HAS_REGEX_URI)
         end


### PR DESCRIPTION
### Summary

Let’s say we have two Routes, each with a single path and otherwise identically-configured:

* `/api/users/(?<userId>\w+)`
* `/api/users/(?<userId>\w+)/profile`

In the current behavior, unless `regex_priority` is set, a request coming in to `/api/users/30/profile` will match the former route (the one _without_ the profile suffix) if it was created first—so the current behavior is to fallback to prioritizing based on created-time.

With non-regex paths, Kong currently (very helpfully) defaults to giving precedence/priority to longer paths. This is a great default.

This change simply makes the same true for regex paths, which is a more reasonable/predictable default (compared to created-time based priority, which is implicit and undesirable).

### Full changelog

* Update `router.lua` to include regex paths in calculating `max_uri_length` for routes