### PR TITLE
fix(cache-warmup) move consumers and tags from core cache to cache

### DIFF
--- a/kong/cache_warmup.lua
+++ b/kong/cache_warmup.lua
@@ -40,9 +40,10 @@ end
 local function cache_warmup_single_entity(dao)
   local entity_name = dao.schema.name
 
-  local cache = constants.CORE_ENTITIES[entity_name] and kong.core_cache or kong.cache
+  local cache_store = constants.ENTITY_CACHE_STORE[entity_name]
+  local cache = kong[cache_store]
 
-  ngx.log(ngx.NOTICE, "Preloading '", entity_name, "' into the cache ...")
+  ngx.log(ngx.NOTICE, "Preloading '", entity_name, "' into the ", cache_store, "...")
 
   local start = ngx.now()
 
@@ -82,7 +83,7 @@ local function cache_warmup_single_entity(dao)
   local elapsed = math.floor((ngx.now() - start) * 1000)
 
   ngx.log(ngx.NOTICE, "finished preloading '", entity_name,
-                      "' into the cache (in ", tostring(elapsed), "ms)")
+                      "' into the ", cache_store, " (in ", tostring(elapsed), "ms)")
   return true
 end
 

--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -109,10 +109,25 @@ return {
     upstreams = true,
     targets = true,
     plugins = true,
-    cluster_ca = true,
     tags = true,
     ca_certificates = true,
   },
+  ENTITY_CACHE_STORE = setmetatable({
+    consumers = "cache",
+    certificates = "core_cache",
+    services = "core_cache",
+    routes = "core_cache",
+    snis = "core_cache",
+    upstreams = "core_cache",
+    targets = "core_cache",
+    plugins = "core_cache",
+    tags = "cache",
+    ca_certificates = "core_cache",
+  }, {
+    __index = function()
+      return "cache"
+    end
+  }),
   RATELIMIT = {
     PERIODS = {
       "second",

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -161,7 +161,6 @@ end
 local function register_events()
   -- initialize local local_events hooks
   local db             = kong.db
-  local cache          = kong.cache
   local core_cache     = kong.core_cache
   local worker_events  = kong.worker_events
   local cluster_events = kong.cluster_events
@@ -185,12 +184,7 @@ local function register_events()
     -- caching key
 
     local cache_key = db[data.schema.name]:cache_key(data.entity)
-    local cache_obj
-    if constants.CORE_ENTITIES[data.schema.name] then
-      cache_obj = core_cache
-    else
-      cache_obj = cache
-    end
+    local cache_obj = kong[constants.ENTITY_CACHE_STORE[data.schema.name]]
 
     if cache_key then
       cache_obj:invalidate(cache_key)

--- a/spec/01-unit/01-db/08-cache_warmup_spec.lua
+++ b/spec/01-unit/01-db/08-cache_warmup_spec.lua
@@ -59,6 +59,21 @@ end
 
 describe("cache_warmup", function()
 
+  it("uses right entity cache store", function()
+    local store = require "kong.constants".ENTITY_CACHE_STORE
+    assert.equal("cache", store.consumers)
+    assert.equal("core_cache", store.certificates)
+    assert.equal("core_cache", store.services)
+    assert.equal("core_cache", store.routes)
+    assert.equal("core_cache", store.snis)
+    assert.equal("core_cache", store.upstreams)
+    assert.equal("core_cache", store.targets)
+    assert.equal("core_cache", store.plugins)
+    assert.equal("cache", store.tags)
+    assert.equal("core_cache", store.ca_certificates)
+    assert.equal("cache", store.keyauth_credentials)
+  end)
+
   it("caches entities", function()
     local cache_table = {}
     local db_data = {


### PR DESCRIPTION
### Summary

TLDR; Moves `consumers` and `tags` on cache warmup from `kong.core_cache` to `kong.cache`.

It was found out that our plugins in general tend to call `kong.cache:get`, and they never use `kong.core_cache:get`. This is also for historical reasons as we didn't have `core_cache` before recently. When we did the split we did put so called `core entities` into `core_cache` on cache warmup. This included things like `consumers` and `tags` too. But we didn't change the
plugins. The common case for authentication plugins was to fetch consumers from `kong.cache:get` while the warmup now warmed them up in `kong.core_cache`. Thus the entities weren't warmed up in a right cache from plugin perspective.

In #5665 it was proposed to fix this by changing `key-auth` plugin to use `core_cache`. I personally didn't like this approach as there are a lot of plugins that need to be changed beyond `key-auth`. Also possible 3rd party ones. I checked our core code, and I found practically no use of consumers. Consumers is also something that I don't think we want polluting the core cache.

I know that plugins is also connected to consumers, so that can make plugins entity a bit similar to consumers in a size in a worst case. Plugin iterator is on the other hand on our hot path and it was already using `core_cache`.

### Issues Resolved

Replaces #5665