### PR TITLE
Pass copied header tables to exit() in error handler

### DIFF
--- a/kong/error_handlers.lua
+++ b/kong/error_handlers.lua
@@ -1,6 +1,7 @@
 local kong = kong
 local find = string.find
 local fmt  = string.format
+local tablex = require "pl.tablex"
 
 
 local CONTENT_TYPE    = "Content-Type"
@@ -96,22 +97,22 @@ return function(ctx)
   local headers
   if find(accept_header, TYPE_JSON, nil, true) == 1 then
     message = fmt(JSON_TEMPLATE, message)
-    headers = HEADERS_JSON
+    headers = tablex.copy(HEADERS_JSON)
 
   elseif find(accept_header, TYPE_GRPC, nil, true) == 1 then
     message = { message = message }
 
   elseif find(accept_header, TYPE_HTML, nil, true) == 1 then
     message = fmt(HTML_TEMPLATE, message)
-    headers = HEADERS_HTML
+    headers = tablex.copy(HEADERS_HTML)
 
   elseif find(accept_header, TYPE_XML, nil, true) == 1 then
     message = fmt(XML_TEMPLATE, message)
-    headers = HEADERS_XML
+    headers = tablex.copy(HEADERS_XML)
 
   else
     message = fmt(PLAIN_TEMPLATE, message)
-    headers = HEADERS_PLAIN
+    headers = tablex.copy(HEADERS_PLAIN)
   end
 
   -- Reset relevant context values


### PR DESCRIPTION
### Summary
Copy error response header tables before passing them to `kong.response.exit()`. The exit-transformer plugin can modify these tables, and the current pass by reference allows those modifications to persist for other requests on the same worker.

### Full changelog

* Copy response header tables before passing them to `kong.response.exit()` in error handler.

### Issues resolved

Fix an issue where modifying the `headers` variable in exit-transformer functions resulted in unrelated requests seeing the same header modification.
