### PR TITLE
chore(deps) update aws lambda plugin from 3.1 to 3.2

### DIFF
--- a/kong-2.0.2-0.rockspec
+++ b/kong-2.0.2-0.rockspec
@@ -46,7 +46,7 @@ dependencies = {
   "kong-proxy-cache-plugin ~> 1.3",
   "kong-plugin-request-transformer ~> 1.2",
   "kong-plugin-session ~> 2.2",
-  "kong-plugin-aws-lambda ~> 3.1",
+  "kong-plugin-aws-lambda ~> 3.2",
   "kong-plugin-acme ~> 0.2",
   "kong-plugin-grpc-web ~> 0.1",
 }


### PR DESCRIPTION
### Summary

Sync up with latest release, contains:

- Enable the enterprise encryption of aws secrets.