### PR TITLE
chore(ci) bump kong-build-tools dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ RESTY_VERSION ?= `grep RESTY_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk
 RESTY_LUAROCKS_VERSION ?= `grep RESTY_LUAROCKS_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
 RESTY_OPENSSL_VERSION ?= `grep RESTY_OPENSSL_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
 RESTY_PCRE_VERSION ?= `grep RESTY_PCRE_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
-KONG_BUILD_TOOLS ?= '3.1.2'
+KONG_BUILD_TOOLS ?= '3.1.4'
 KONG_VERSION ?= `cat $(KONG_SOURCE_LOCATION)/kong-*.rockspec | grep tag | awk '{print $$3}' | sed 's/"//g'`
 OPENRESTY_PATCHES_BRANCH ?= master
 KONG_NGINX_MODULE_BRANCH ?= master


### PR DESCRIPTION
Full diff https://github.com/Kong/kong-build-tools/compare/3.1.2...3.1.4

Notable changes:
- use our official docker images when testing build assets
- build with `--replace` fpm flag
- fix a broken test when building daily images
- fix mac compatibility of kong-build-tools