### PR TITLE
fix(proxy) the plugins might not be fully collected on error on one plugin

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -681,20 +681,15 @@ function Kong.access()
       kong_global.set_namespaced_log(kong, plugin.name)
 
       local err = coroutine.wrap(plugin.handler.access)(plugin.handler, plugin_conf)
+      if err then
+        kong.log.err(err)
+        ctx.delayed_response = {
+          status_code = 500,
+          content     = { message  = "An unexpected error occurred" },
+        }
+      end
 
       kong_global.reset_log(kong)
-
-      if err then
-        ctx.delay_response = false
-
-        kong.log.err(err)
-
-        ctx.KONG_ACCESS_ENDED_AT = get_now_ms()
-        ctx.KONG_ACCESS_TIME = ctx.KONG_ACCESS_ENDED_AT - ctx.KONG_ACCESS_START
-        ctx.KONG_RESPONSE_LATENCY = ctx.KONG_ACCESS_ENDED_AT - ctx.KONG_PROCESSING_START
-
-        return kong.response.exit(500, { message  = "An unexpected error occurred" })
-      end
     end
   end
 


### PR DESCRIPTION
### Summary

The plugin iterator builds the list of plugins. If the first plugin errors on plugins iterator build on access phase there is a chance that the plugins iterator may not be built completely. E.g. it might be missing all the log plugins. This PR delays the response so that the plugins iterator will still be fully built.

It basically also allows plugins to do:

```lua
if err then
  return error(err)
end
```

instead of:

```lua
if err then
  kong.log.err(err)
  return kong.response.exit(500, { message = "An unexpected error occurred" })
end
```

Or that those two are the `same`.

In separate commit I also changed the plugins to use `error(err)`, but I decided to move that to another PR: #5696.

@Tieske, isn't this what you suggested at some point?