### PR TITLE
refactor(plugins) use error(err) instead of kong.response.exit on 500 errors

### DIFF
--- a/kong/plugins/acl/handler.lua
+++ b/kong/plugins/acl/handler.lua
@@ -5,6 +5,7 @@ local groups = require "kong.plugins.acl.groups"
 
 local setmetatable = setmetatable
 local concat = table.concat
+local error = error
 local kong = kong
 
 
@@ -97,11 +98,8 @@ function ACLHandler:access(conf)
       -- get the consumer groups, since we need those as cache-keys to make sure
       -- we invalidate properly if they change
       local consumer_groups, err = groups.get_consumer_groups(consumer_id)
-      if err then
-        kong.log.err(err)
-        return kong.response.exit(500, {
-          message = "An unexpected error occurred"
-        })
+       if err then
+        return error(err)
       end
 
       if not consumer_groups then

--- a/kong/plugins/basic-auth/access.lua
+++ b/kong/plugins/basic-auth/access.lua
@@ -5,6 +5,7 @@ local constants = require "kong.constants"
 local decode_base64 = ngx.decode_base64
 local re_gmatch = ngx.re.gmatch
 local re_match = ngx.re.match
+local error = error
 local kong = kong
 
 
@@ -100,8 +101,7 @@ local function load_credential_from_db(username)
                                               load_credential_into_memory,
                                               username)
   if err then
-    kong.log.err(err)
-    return kong.response.exit(500, { message = "An unexpected error occurred" })
+    return error(err)
   end
 
   return credential
@@ -182,8 +182,7 @@ local function do_authentication(conf)
                                             kong.client.load_consumer,
                                             credential.consumer.id)
   if err then
-    kong.log.err(err)
-    return kong.response.exit(500, { message = "An unexpected error occurred" })
+    return error(err)
   end
 
   set_consumer(consumer, credential)
@@ -208,8 +207,7 @@ function _M.execute(conf)
                                                 kong.client.load_consumer,
                                                 conf.anonymous, true)
       if err then
-        kong.log.err("failed to load anonymous consumer:", err)
-        return kong.response.exit(500, { message = "An unexpected error occurred" })
+        return error(err)
       end
 
       set_consumer(consumer)

--- a/kong/plugins/hmac-auth/access.lua
+++ b/kong/plugins/hmac-auth/access.lua
@@ -6,6 +6,7 @@ local utils = require "kong.tools.utils"
 
 local ngx = ngx
 local kong = kong
+local error = error
 local time = ngx.time
 local abs = math.abs
 local decode_base64 = ngx.decode_base64
@@ -186,8 +187,7 @@ local function load_credential(username)
   end
 
   if err then
-    kong.log.err(err)
-    return kong.response.exit(500, { message = "An unexpected error occurred" })
+    return error(err)
   end
 
   return credential
@@ -340,8 +340,7 @@ local function do_authentication(conf)
                                       kong.client.load_consumer,
                                       credential.consumer.id)
   if err then
-    kong.log.err(err)
-    return kong.response.exit(500, { message = "An unexpected error occurred" })
+    return error(err)
   end
 
   set_consumer(consumer, credential)
@@ -369,8 +368,7 @@ function _M.execute(conf)
                                                 kong.client.load_consumer,
                                                 conf.anonymous, true)
       if err then
-        kong.log.err("failed to load anonymous consumer:", err)
-        return kong.response.exit(500, { message = "An unexpected error occurred" })
+        return error(err)
       end
 
       set_consumer(consumer)

--- a/kong/plugins/ip-restriction/handler.lua
+++ b/kong/plugins/ip-restriction/handler.lua
@@ -1,60 +1,53 @@
-local ngx = ngx
-local kong = kong
-local require = require
-
 local ipmatcher = require "resty.ipmatcher"
 
 
-local FORBIDDEN = 403
-local INTERNAL_SERVER_ERROR = 500
+local ngx = ngx
+local kong = kong
+local error = error
 
 
-local IpRestrictionHandler = {}
-
-IpRestrictionHandler.PRIORITY = 990
-IpRestrictionHandler.VERSION = "2.0.0"
+local IpRestrictionHandler = {
+  PRIORITY = 990,
+  VERSION = "2.0.0",
+}
 
 
 local function match_bin(list, binary_remote_addr)
   local ip, err = ipmatcher.new(list)
-
   if err then
-    kong.log.err("Failed to create a new ipmatcher instance: " .. err)
-    return kong.response.exit(INTERNAL_SERVER_ERROR, { message = "An unexpected error occurred" })
+    return error("failed to create a new ipmatcher instance: " .. err)
   end
 
-  ip, err = ip:match_bin(binary_remote_addr)
-
+  local is_match
+  is_match, err = ip:match_bin(binary_remote_addr)
   if err then
-    kong.log.err("Invalid binary IP address: " .. err)
-    return kong.response.exit(INTERNAL_SERVER_ERROR, { message = "An unexpected error occurred" })
+    return error("invalid binary ip address: " .. err)
   end
 
-  return ip
+  return is_match
 end
+
 
 function IpRestrictionHandler:access(conf)
   local binary_remote_addr = ngx.var.binary_remote_addr
-
   if not binary_remote_addr then
-    return kong.response.exit(FORBIDDEN, { message = "Cannot identify the client IP address, unix domain sockets are not supported." })
+    return kong.response.exit(403, { message = "Cannot identify the client IP address, unix domain sockets are not supported." })
   end
 
   if conf.blacklist and #conf.blacklist > 0 then
     local blocked_blacklist = match_bin(conf.blacklist, binary_remote_addr)
-
     if blocked_blacklist then
-      return kong.response.exit(FORBIDDEN, { message = "Your IP address is not allowed" })
+      return kong.response.exit(403, { message = "Your IP address is not allowed" })
     end
   end
 
   if conf.whitelist and #conf.whitelist > 0 then
     local allowed_whitelist = match_bin(conf.whitelist, binary_remote_addr)
-
     if not allowed_whitelist then
-      return kong.response.exit(FORBIDDEN, { message = "Your IP address is not allowed" })
+      return kong.response.exit(403, { message = "Your IP address is not allowed" })
     end
   end
 end
+
 
 return IpRestrictionHandler

--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -5,6 +5,7 @@ local jwt_decoder = require "kong.plugins.jwt.jwt_parser"
 local fmt = string.format
 local kong = kong
 local type = type
+local error = error
 local ipairs = ipairs
 local tostring = tostring
 local re_gmatch = ngx.re.gmatch
@@ -126,8 +127,7 @@ end
 local function do_authentication(conf)
   local token, err = retrieve_token(conf)
   if err then
-    kong.log.err(err)
-    return kong.response.exit(500, { message = "An unexpected error occurred" })
+    return error(err)
   end
 
   local token_type = type(token)
@@ -162,8 +162,7 @@ local function do_authentication(conf)
   local jwt_secret, err      = kong.cache:get(jwt_secret_cache_key, nil,
                                               load_credential, jwt_secret_key)
   if err then
-    kong.log.err(err)
-    return kong.response.exit(500, { message = "An unexpected error occurred" })
+    return error(err)
   end
 
   if not jwt_secret then
@@ -213,7 +212,7 @@ local function do_authentication(conf)
                                             kong.client.load_consumer,
                                             jwt_secret.consumer.id, true)
   if err then
-    return kong.response.exit(500, { message = "An unexpected error occurred" })
+    return error(err)
   end
 
   -- However this should not happen
@@ -251,8 +250,7 @@ function JwtHandler:access(conf)
                                                 kong.client.load_consumer,
                                                 conf.anonymous, true)
       if err then
-        kong.log.err("failed to load anonymous consumer:", err)
-        return kong.response.exit(500, { message = "An unexpected error occurred" })
+        return error(err)
       end
 
       set_consumer(consumer)

--- a/kong/plugins/key-auth/handler.lua
+++ b/kong/plugins/key-auth/handler.lua
@@ -3,6 +3,7 @@ local constants = require "kong.constants"
 
 local kong = kong
 local type = type
+local error = error
 
 
 local KeyAuthHandler = {
@@ -136,10 +137,7 @@ local function do_authentication(conf)
   local credential, err = cache:get(credential_cache_key, nil, load_credential,
                                     key)
   if err then
-    kong.log.err(err)
-    return kong.response.exit(500, {
-      message = "An unexpected error occurred"
-    })
+    return error(err)
   end
 
   -- no credential in DB, for this key, it is invalid, HTTP 401
@@ -189,8 +187,7 @@ function KeyAuthHandler:access(conf)
                                            kong.client.load_consumer,
                                            conf.anonymous, true)
       if err then
-        kong.log.err("failed to load anonymous consumer:", err)
-        return kong.response.exit(500, { message = "An unexpected error occurred" })
+        return error(err)
       end
 
       set_consumer(consumer)

--- a/kong/plugins/ldap-auth/access.lua
+++ b/kong/plugins/ldap-auth/access.lua
@@ -4,6 +4,7 @@ local ldap = require "kong.plugins.ldap-auth.ldap"
 
 
 local kong = kong
+local error = error
 local decode_base64 = ngx.decode_base64
 local sha1_bin = ngx.sha1_bin
 local to_hex = require "resty.string".to_hex
@@ -150,8 +151,7 @@ local function authenticate(conf, given_credentials)
   }, load_credential, given_username, given_password, conf)
 
   if err or credential == nil then
-    kong.log.err(err)
-    return kong.response.exit(500, { message = "An unexpected error occurred" })
+    return error(err)
   end
 
 
@@ -255,8 +255,7 @@ function _M.execute(conf)
                                                       kong.client.load_consumer,
                                                       conf.anonymous, true)
       if err then
-        kong.log.err("failed to load anonymous consumer:", err)
-        return kong.response.exit(500, { message = "An unexpected error occurred" })
+        return error(err)
       end
 
       set_consumer(consumer)

--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -8,6 +8,7 @@ local kong = kong
 local type = type
 local next = next
 local table = table
+local error = error
 local split = utils.split
 local strip = utils.strip
 local string_find = string.find
@@ -43,12 +44,6 @@ local GRANT_REFRESH_TOKEN = "refresh_token"
 local GRANT_PASSWORD = "password"
 local ERROR = "error"
 local AUTHENTICATED_USERID = "authenticated_userid"
-
-
-local function internal_server_error(err)
-  kong.log.err(err)
-  return kong.response.exit(500, { message = "An unexpected error occurred" })
-end
 
 
 local function generate_token(conf, service, credential, authenticated_userid,
@@ -100,7 +95,7 @@ local function generate_token(conf, service, credential, authenticated_userid,
   end
 
   if err then
-    return internal_server_error(err)
+    return error(err)
   end
 
   return {
@@ -131,7 +126,7 @@ local function get_redirect_uris(client_id)
                                  load_oauth2_credential_by_client_id,
                                  client_id)
     if err then
-      return internal_server_error(err)
+      return error(err)
     end
   end
 
@@ -276,7 +271,7 @@ local function authorize(conf)
           })
 
           if err then
-            return internal_server_error(err)
+            error(err)
           end
 
           response_params = {
@@ -637,7 +632,7 @@ local function retrieve_token(conf, access_token)
                                 kong.router.get_service(),
                                 access_token)
     if err then
-      return internal_server_error(err)
+      return error(err)
     end
   end
 
@@ -833,7 +828,7 @@ local function do_authentication(conf)
                                          load_oauth2_credential_into_memory,
                                          token.credential.id)
   if err then
-    return internal_server_error(err)
+    return error(err)
   end
 
   -- Retrieve the consumer from the credential
@@ -843,7 +838,7 @@ local function do_authentication(conf)
                                       kong.client.load_consumer,
                                       credential.consumer.id)
   if err then
-    return internal_server_error(err)
+    return error(err)
   end
 
   set_consumer(consumer, credential, token)
@@ -882,8 +877,7 @@ function _M.execute(conf)
                                                 kong.client.load_consumer,
                                                 conf.anonymous, true)
       if err then
-        kong.log.err("failed to load anonymous consumer:", err)
-        return kong.response.exit(500, { message = "An unexpected error occurred" })
+        return error(err)
       end
 
       set_consumer(consumer)

--- a/kong/plugins/rate-limiting/handler.lua
+++ b/kong/plugins/rate-limiting/handler.lua
@@ -9,6 +9,7 @@ local max = math.max
 local time = ngx.time
 local floor = math.floor
 local pairs = pairs
+local error = error
 local tostring = tostring
 local timer_at = ngx.timer.at
 
@@ -124,12 +125,11 @@ function RateLimitingHandler:access(conf)
 
   local usage, stop, err = get_usage(conf, identifier, current_timestamp, limits)
   if err then
-    if fault_tolerant then
-      kong.log.err("failed to get usage: ", tostring(err))
-    else
-      kong.log.err(err)
-      return kong.response.exit(500, { message = "An unexpected error occurred" })
+    if not fault_tolerant then
+      return error(err)
     end
+
+    kong.log.err("failed to get usage: ", tostring(err))
   end
 
   if usage then

--- a/kong/plugins/response-ratelimiting/access.lua
+++ b/kong/plugins/response-ratelimiting/access.lua
@@ -5,11 +5,11 @@ local timestamp = require "kong.tools.timestamp"
 local kong = kong
 local next = next
 local pairs = pairs
+local error = error
 local tostring = tostring
 
 
 local EMPTY = {}
-local HTTP_INTERNAL_SERVER_ERROR = 500
 local HTTP_TOO_MANY_REQUESTS = 429
 local RATELIMIT_REMAINING = "X-RateLimit-Remaining"
 
@@ -75,14 +75,12 @@ function _M.execute(conf)
   -- Load current metric for configured period
   local usage, err = get_usage(conf, identifier, conf.limits, current_timestamp)
   if err then
-    if conf.fault_tolerant then
-      kong.log.err("failed to get usage: ", tostring(err))
-      return
-    else
-      return kong.response.exit(HTTP_INTERNAL_SERVER_ERROR, {
-        message = "An unexpected error occurred"
-      })
+    if not conf.fault_tolerant then
+      return error(err)
     end
+
+    kong.log.err("failed to get usage: ", tostring(err))
+    return
   end
 
   -- Append usage headers to the upstream request. Also checks "block_on_first_violation".


### PR DESCRIPTION
### Summary

Makes plugins to do:

```
local ok, err = func()
if not ok then
  return error(err)
end
```

instead of:

```
local ok, err = func()
if not ok then
  kong.log.err(err)
  return kong.response.exit(500, { message = "An unexpected error occurred" })
end
```

This PR is a continuation of #5692 (this is applied to `next` so that when #5692 is merged to master, that needs to then be merged to next, so please not merge this until then).