### PR TITLE
Fix/target.balancer==nil

### DIFF
--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -509,7 +509,7 @@ local function check_target_history(upstream, balancer)
     end
   end
 
-  if last_equal_index == new_size and new_size == old_size then
+  if last_equal_index == new_size and new_size == old_size and new_size > 0 then
     -- No history update is necessary in the balancer object.
     return true
   elseif last_equal_index == old_size then


### PR DESCRIPTION
### Summary

A previous fix (Kong/kong@5d8c879) removed a test for zero size; some reports seem to indicate it was actually needed.

### Issues resolved
Kong/kubernetes-ingress-controller#560
Fix #5455
