### PR TITLE
fix(dao/targets) don't remove the last target in history

### DIFF
--- a/kong/db/dao/targets.lua
+++ b/kong/db/dao/targets.lua
@@ -53,7 +53,9 @@ local function clean_history(self, upstream_pk)
     else
       -- haven't got this one, so this is the current state for this target
       seen[entry.target] = true
-      if entry.weight == 0 then
+      -- we can delete this entry if its weight == 0, but let's keep it if the
+      -- target list is almost empty, so the upstream still exists after cleaning up
+      if entry.weight == 0 and #targets > 2 then
         delete[#delete+1] = entry
       end
     end

--- a/spec/02-integration/05-proxy/10-balancer/02-least-connections_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer/02-least-connections_spec.lua
@@ -1,3 +1,4 @@
+local cjson   = require "cjson"
 local helpers = require "spec.helpers"
 
 -- create two servers, one double the delay of the other
@@ -44,6 +45,7 @@ for _, strategy in helpers.each_strategy() do
   describe("Balancer: least-connections [#" .. strategy .. "]", function()
     local proxy_client
     local admin_client
+    local upstream1_id
 
     lazy_setup(function()
       local bp = helpers.get_db_utils(strategy, {
@@ -66,6 +68,7 @@ for _, strategy in helpers.each_strategy() do
         name = "lcupstream",
         algorithm = "least-connections",
       }))
+      upstream1_id = upstream1.id
 
       assert(bp.targets:insert({
         upstream = upstream1,
@@ -143,5 +146,168 @@ for _, strategy in helpers.each_strategy() do
       local ratio = results[100]/results[200]
       assert.near(2, ratio, 0.8)
     end)
+
+    if strategy ~= "off" then
+      it("add and remove targets", function()
+        local api_client = helpers.admin_client()
+
+        -- create a new target
+        local res = assert(api_client:send({
+          method = "POST",
+          path = "/upstreams/" .. upstream1_id .. "/targets",
+          headers = {
+            ["Content-Type"] = "application/json",
+          },
+          body = {
+            target = "127.0.0.1:10003",
+            weight = 100
+          },
+        }))
+        api_client:close()
+        assert.same(201, res.status)
+
+        -- check if it is available
+        api_client = helpers.admin_client()
+        local res, err = api_client:send({
+          method = "GET",
+          path = "/upstreams/" .. upstream1_id .. "/targets/all",
+        })
+        assert.is_nil(err)
+
+        local body = cjson.decode((res:read_body()))
+        api_client:close()
+        local found = false
+        for _, entry in ipairs(body.data) do
+          if entry.target == "127.0.0.1:10003" and entry.weight == 100 then
+            found = true
+            break
+          end
+        end
+        assert.is_true(found)
+
+        -- delete the target and assert that it still exists with weight == 0
+        api_client = helpers.admin_client()
+        res, err = api_client:send({
+          method = "DELETE",
+          path = "/upstreams/" .. upstream1_id .. "/targets/127.0.0.1:10003",
+        })
+        assert.is_nil(err)
+        assert.same(204, res.status)
+        api_client:close()
+
+        api_client = helpers.admin_client()
+        local res, err = api_client:send({
+          method = "GET",
+          path = "/upstreams/" .. upstream1_id .. "/targets/all",
+        })
+        assert.is_nil(err)
+
+        local body = cjson.decode((res:read_body()))
+        api_client:close()
+        local found = false
+        for _, entry in ipairs(body.data) do
+          if entry.target == "127.0.0.1:10003" and entry.weight == 0 then
+            found = true
+            break
+          end
+        end
+        assert.is_true(found)
+      end)
+    end
   end)
+
+  if strategy ~= "off" then
+    describe("Balancer: add and remove a single target to a least-connection upstream [#" .. strategy .. "]", function()
+      local bp
+
+      lazy_setup(function()
+        bp = helpers.get_db_utils(strategy, {
+          "routes",
+          "services",
+          "upstreams",
+          "targets",
+        })
+
+        assert(helpers.start_kong({
+          database   = strategy,
+          nginx_conf = "spec/fixtures/custom_nginx.template",
+        }, nil, nil, fixtures))
+      end)
+
+      lazy_teardown(function()
+        helpers.stop_kong()
+      end)
+
+      it("add and remove targets", function()
+        local an_upstream = assert(bp.upstreams:insert({
+          name = "anupstream",
+          algorithm = "least-connections",
+        }))
+
+        local api_client = helpers.admin_client()
+
+        -- create a new target
+        local res = assert(api_client:send({
+          method = "POST",
+          path = "/upstreams/" .. an_upstream.id .. "/targets",
+          headers = {
+            ["Content-Type"] = "application/json",
+          },
+          body = {
+            target = "127.0.0.1:10001",
+            weight = 100
+          },
+        }))
+        api_client:close()
+        assert.same(201, res.status)
+
+        -- check if it is available
+        api_client = helpers.admin_client()
+        local res, err = api_client:send({
+          method = "GET",
+          path = "/upstreams/" .. an_upstream.id .. "/targets/all",
+        })
+        assert.is_nil(err)
+
+        local body = cjson.decode((res:read_body()))
+        api_client:close()
+        local found = false
+        for _, entry in ipairs(body.data) do
+          if entry.target == "127.0.0.1:10001" and entry.weight == 100 then
+            found = true
+            break
+          end
+        end
+        assert.is_true(found)
+
+        -- delete the target and assert that it still exists with weight == 0
+        api_client = helpers.admin_client()
+        res, err = api_client:send({
+          method = "DELETE",
+          path = "/upstreams/" .. an_upstream.id .. "/targets/127.0.0.1:10001",
+        })
+        assert.is_nil(err)
+        assert.same(204, res.status)
+        api_client:close()
+
+        api_client = helpers.admin_client()
+        local res, err = api_client:send({
+          method = "GET",
+          path = "/upstreams/" .. an_upstream.id .. "/targets/all",
+        })
+        assert.is_nil(err)
+
+        local body = cjson.decode((res:read_body()))
+        api_client:close()
+        local found = false
+        for _, entry in ipairs(body.data) do
+          if entry.target == "127.0.0.1:10001" and entry.weight == 0 then
+            found = true
+            break
+          end
+        end
+        assert.is_true(found)
+      end)
+    end)
+  end
 end


### PR DESCRIPTION
When cleaning up targets history, the last existing one could be removed and then the upstream would be empty and also removed.

Fix #5593
