### PR TITLE
[RFC] feat(JWT plugin) Pass through extra JWTs

### DIFF
--- a/kong/plugins/jwt/schema.lua
+++ b/kong/plugins/jwt/schema.lua
@@ -1,4 +1,5 @@
 local typedefs = require "kong.db.schema.typedefs"
+local is_regex = require("kong.db.schema").validators.is_regex
 
 
 return {
@@ -20,6 +21,12 @@ return {
           }, },
           { key_claim_name = { type = "string", default = "iss" }, },
           { secret_is_base64 = { type = "boolean", default = false }, },
+          { subjects = {
+              type = "array",
+              elements = {
+                type = "string",
+                custom_validator = is_regex,
+          }, }, },
           { claims_to_verify = {
               type = "set",
               elements = {


### PR DESCRIPTION
### Summary

This (RFC) PR introduces the ability for the JWT plugin to ignore JWTs that aren't addressed to a service directly behind Kong (via the `sub` claim). The objective is to allow upstream services to process their own JWTs. For instance, if a proxied service requires a user OAuth token, the requester could append it to the `Authorization` header; currently this would trip up the regex in `request_token`.

This PR currently contains only a draft implementation of the proposal in hopes of ascertaining whether this is something that the community would accept (and thus prevent wasted work adding tests+docs).

### Full changelog

* Untested, undocumented implementation of proposal