### PR TITLE
Remove fixture for Lambda + bump version

### DIFF
--- a/kong-2.0.3-0.rockspec
+++ b/kong-2.0.3-0.rockspec
@@ -47,7 +47,7 @@ dependencies = {
   "kong-proxy-cache-plugin ~> 1.3",
   "kong-plugin-request-transformer ~> 1.2",
   "kong-plugin-session ~> 2.3",
-  "kong-plugin-aws-lambda ~> 3.2",
+  "kong-plugin-aws-lambda ~> 3.3",
   "kong-plugin-acme ~> 0.2",
   "kong-plugin-grpc-web ~> 0.1",
 }

--- a/spec/fixtures/hosts
+++ b/spec/fixtures/hosts
@@ -1,1 +1,1 @@
-127.0.0.1 localhost lambda.us-east-1.amazonaws.com
+127.0.0.1 localhost


### PR DESCRIPTION
NOTE: this can only be merged after updating the Lambda plugin to a newer version than 3.2.0.