### PR TITLE
chore(deps) bump pgmoon from 1.10.0 to 1.11.0

### DIFF
--- a/kong-2.0.2-0.rockspec
+++ b/kong-2.0.2-0.rockspec
@@ -22,7 +22,7 @@ dependencies = {
   "version == 1.0.1",
   "kong-lapis == 1.7.0.1",
   "lua-cassandra == 1.5.0",
-  "pgmoon == 1.10.0",
+  "pgmoon == 1.11.0",
   "luatz == 0.4",
   "lua_system_constants == 0.1.4",
   "lyaml == 6.2.4",


### PR DESCRIPTION
### Summary

- Minor update
- Allow for TLS v1.2 when using LuaSec (Miles Elam)