### PR TITLE
chore(deps) bump lua-resty-dns-client from 4.1.3 to 4.2.0

### DIFF
--- a/kong-2.0.2-0.rockspec
+++ b/kong-2.0.2-0.rockspec
@@ -29,7 +29,7 @@ dependencies = {
   "lua-resty-iputils == 0.3.0",
   "luasyslog == 1.0.0",
   "lua_pack == 1.0.5",
-  "lua-resty-dns-client == 4.1.3",
+  "lua-resty-dns-client == 4.2.0",
   "lua-resty-worker-events == 1.0.0",
   "lua-resty-mediador == 0.1.2",
   "lua-resty-healthcheck == 1.2.0",


### PR DESCRIPTION
### Summary

- Change: export DNS source type on status report.
  See [PR 86](https://github.com/Kong/lua-resty-dns-client/pull/86).