### PR TITLE
feat(dns) export more data for balancer health

### DIFF
--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -1248,6 +1248,7 @@ local function get_balancer_health(upstream_id)
   end
 
   local healthchecker
+  local balancer_status
   local health = "HEALTHCHECKS_OFF"
   if is_upstream_using_healthcheck(upstream) then
     healthchecker = healthcheckers[balancer]
@@ -1255,13 +1256,14 @@ local function get_balancer_health(upstream_id)
       return nil, "healthchecker not found"
     end
 
-    local balancer_status = balancer:getStatus()
+    balancer_status = balancer:getStatus()
     health = balancer_status.healthy and "HEALTHY" or "UNHEALTHY"
   end
 
   return {
     health = health,
     id = upstream_id,
+    details = balancer_status,
   }
 end
 

--- a/spec/02-integration/05-proxy/10-balancer/01-healthchecks_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer/01-healthchecks_spec.lua
@@ -912,6 +912,12 @@ for _, strategy in helpers.each_strategy() do
                 assert.is.table(health)
                 assert.is.table(health.data)
 
+                assert.same({
+                  available = 100,
+                  unavailable = 0,
+                  total = 100,
+                }, health.data.details.weight)
+
                 if health_threshold[i] < 100 then
                   assert.equals("HEALTHY", health.data.health)
                 else
@@ -921,6 +927,13 @@ for _, strategy in helpers.each_strategy() do
                 -- 75% healthy
                 bu.post_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.1:80", "unhealthy")
                 health = bu.get_balancer_health(upstream_name)
+
+                assert.same({
+                  available = 75,
+                  unavailable = 25,
+                  total = 100,
+                }, health.data.details.weight)
+
                 if health_threshold[i] < 75 then
                   assert.equals("HEALTHY", health.data.health)
                 else
@@ -930,6 +943,13 @@ for _, strategy in helpers.each_strategy() do
                 -- 50% healthy
                 bu.post_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.2:80", "unhealthy")
                 health = bu.get_balancer_health(upstream_name)
+
+                assert.same({
+                  available = 50,
+                  unavailable = 50,
+                  total = 100,
+                }, health.data.details.weight)
+
                 if health_threshold[i] < 50 then
                   assert.equals("HEALTHY", health.data.health)
                 else
@@ -939,6 +959,13 @@ for _, strategy in helpers.each_strategy() do
                 -- 25% healthy
                 bu.post_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.3:80", "unhealthy")
                 health = bu.get_balancer_health(upstream_name)
+
+                assert.same({
+                  available = 25,
+                  unavailable = 75,
+                  total = 100,
+                }, health.data.details.weight)
+
                 if health_threshold[i] < 25 then
                   assert.equals("HEALTHY", health.data.health)
                 else
@@ -948,6 +975,13 @@ for _, strategy in helpers.each_strategy() do
                 -- 0% healthy
                 bu.post_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.4:80", "unhealthy")
                 health = bu.get_balancer_health(upstream_name)
+
+                assert.same({
+                  available = 0,
+                  unavailable = 100,
+                  total = 100,
+                }, health.data.details.weight)
+
                 assert.equals("UNHEALTHY", health.data.health)
 
               end


### PR DESCRIPTION
This was previously in #5712 

The added field will contain the report as created by the balancer, containing the balancer structure (targets, addresses, statusses, etc.).

This includes number of resolved addresses, DNS results, and record types.
