### PR TITLE
perf(balancer) load upstreams before cleaning cache

### DIFF
--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -839,13 +839,18 @@ local function update_balancer_state(premature)
 
   concurrency.with_coroutine_mutex(opts, function()
     if is_worker_state_stale() then
-      singletons.core_cache:invalidate_local("balancer:upstreams")
-      local _, err = singletons.core_cache:get("balancer:upstreams",
-                      { neg_ttl = 10 }, load_upstreams_dict_into_memory)
-      if err then
-        log(CRIT, "failed updating list of upstreams: ", err)
-      else
-        set_worker_state_updated()
+      -- load the upstreams before invalidating cache
+      local updated_upstreams_dict = load_upstreams_dict_into_memory()
+      if updated_upstreams_dict ~= nil then
+        singletons.core_cache:invalidate_local("balancer:upstreams")
+        local _, err = singletons.core_cache:get("balancer:upstreams",
+                      { neg_ttl = 10 }, function() return updated_upstreams_dict end)
+        if err then
+          log(CRIT, "failed updating list of upstreams: ", err)
+        else
+          set_worker_state_updated()
+        end
+
       end
     end
   end)


### PR DESCRIPTION
When there are a large number of upstreams in the database or the database is under heavy load, loading upstreams will take longer and, sometimes, unacceptably longer. This change addresses said issue by keeping the stale cache until the new data is loaded from the database. As there might be stale content with this change, this behavior only exists when worker consistency is set to eventual.
