### PR TITLE
chore(test) exclude 'squid'-tagged tests

### DIFF
--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -8,7 +8,7 @@ function red() {
     echo -e "\033[1;31m$*\033[0m"
 }
 
-export BUSTED_ARGS="-o htest -v --exclude-tags=flaky,ipv6"
+export BUSTED_ARGS="-o htest -v --exclude-tags=flaky,ipv6,squid"
 
 if [ "$KONG_TEST_DATABASE" == "postgres" ]; then
     export TEST_CMD="bin/busted $BUSTED_ARGS,cassandra,off"


### PR DESCRIPTION
Pongo has the option to use Squid as a test dependency (a forward
proxy). This is used by some plugin tests, but not supported in
the Kong CI tests. Hence we need to exclude those tests.
