### PR TITLE
fix(schema) allow boolean `false` overrides with Schema.define

### DIFF
--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -2236,7 +2236,7 @@ function Schema.define(tbl)
     __call = function(t, arg)
       arg = arg or {}
       for k,v in pairs(t) do
-        if not arg[k] then
+        if arg[k] == nil then
           arg[k] = v
         end
       end

--- a/spec/01-unit/01-db/01-schema/03-typedefs_spec.lua
+++ b/spec/01-unit/01-db/01-schema/03-typedefs_spec.lua
@@ -185,5 +185,13 @@ describe("typedefs", function()
     assert.truthy(Test:validate({ f = { ["hostname"]  = { "example.com" } } }))
   end)
 
+  it("allows overriding typedefs with boolean false", function()
+    local uuid = typedefs.uuid()
+    assert.equal(true, uuid.auto)
+    local uuid2 = typedefs.uuid({
+      auto = false,
+    })
+    assert.equal(false, uuid2.auto)
+ end)
 
 end)


### PR DESCRIPTION
### Summary

Schema.define used `not value` where it should have used `value == nil`.