### PR TITLE
fix(declarative) fix memory leaks when loading a declarative config that

### DIFF
--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -632,16 +632,14 @@ function DeclarativeConfig.load(plugin_set, include_foreign)
 
   local known_entities = utils.deep_copy(core_entities, false)
 
-  if not all_schemas then
-    all_schemas = {}
-    for _, entity in ipairs(core_entities) do
-      local mod = require("kong.db.schema.entities." .. entity)
-      local definition = utils.deep_copy(mod, false)
-      all_schemas[entity] = Entity.new(definition)
+  all_schemas = {}
+  for _, entity in ipairs(core_entities) do
+    local mod = require("kong.db.schema.entities." .. entity)
+    local definition = utils.deep_copy(mod, false)
+    all_schemas[entity] = Entity.new(definition)
 
-      -- load core entities subschemas
-      assert(load_entity_subschemas(entity, all_schemas[entity]))
-    end
+    -- load core entities subschemas
+    assert(load_entity_subschemas(entity, all_schemas[entity]))
   end
 
   for plugin in pairs(plugin_set) do


### PR DESCRIPTION
fails schema validation

When a declarative config fails schema validation, we attempts to
re-load the config again after populating the foreign keys
(see `kong.db.schema.others.declarative_config.flatten`).

Inside `flatten` we call the `kong.db.schema.others.declarative_config.load`
function, which reloads the schema objects and insert them into
the `all_schemas` global table without first clearing it.
The result is that the `all_schemas` table will keep growing
indefinitely and eventually causes Nginx to be OOM killed.

This PR attempts to fix the issue by clearing the `all_schemas` table
every time `load` is called, which according to my test indeed prevents
the memory from leaking anymore.

closes #5732