### PR TITLE
chore(deps) bump serverless-functions to 1.0.0

### DIFF
--- a/kong-2.0.3-0.rockspec
+++ b/kong-2.0.3-0.rockspec
@@ -42,7 +42,7 @@ dependencies = {
   -- external Kong plugins
   "kong-plugin-azure-functions ~> 0.4",
   "kong-plugin-zipkin ~> 1.0",
-  "kong-plugin-serverless-functions ~> 0.3",
+  "kong-plugin-serverless-functions ~> 1.0",
   "kong-prometheus-plugin ~> 0.7",
   "kong-proxy-cache-plugin ~> 1.3",
   "kong-plugin-request-transformer ~> 1.2",


### PR DESCRIPTION
backward compatible release. Adds functions for other phases than access.

(major bump is only to indicate feature complete and start of SemVer)