### PR TITLE
feat(config) add "kic" configuration for reporting

### DIFF
--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -397,6 +397,7 @@ local CONF_INFERENCES = {
   cluster_control_plane = { typ = "string", },
   cluster_cert = { typ = "string" },
   cluster_cert_key = { typ = "string" },
+  kic = { typ = "boolean" },
 }
 
 

--- a/kong/reports.lua
+++ b/kong/reports.lua
@@ -336,6 +336,7 @@ local function configure_ping(kong_conf)
 
   add_immutable_value("database", kong_conf.database)
   add_immutable_value("role", kong_conf.role)
+  add_immutable_value("kic", kong_conf.kic)
   add_immutable_value("_admin", #kong_conf.admin_listeners > 0 and 1 or 0)
   add_immutable_value("_proxy", #kong_conf.proxy_listeners > 0 and 1 or 0)
   add_immutable_value("_stream", #kong_conf.stream_listeners > 0 and 1 or 0)

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -120,4 +120,5 @@ lua_package_path = ./?.lua;./?/init.lua;
 lua_package_cpath = NONE
 
 role = traditional
+kic = off
 ]]

--- a/spec/01-unit/11-reports_spec.lua
+++ b/spec/01-unit/11-reports_spec.lua
@@ -170,6 +170,32 @@ describe("reports", function()
       end)
     end)
 
+    describe("sends 'kic'", function()
+      it("default (off)", function()
+        local conf = assert(conf_loader(nil))
+        reports.configure_ping(conf)
+
+        local thread = helpers.tcp_server(8189)
+        reports.send_ping("127.0.0.1", 8189)
+
+        local _, res = assert(thread:join())
+        assert._matches("kic=false", res, nil, true)
+      end)
+
+      it("enabled", function()
+        local conf = assert(conf_loader(nil, {
+          kic = "on",
+        }))
+        reports.configure_ping(conf)
+
+        local thread = helpers.tcp_server(8189)
+        reports.send_ping("127.0.0.1", 8189)
+
+        local _, res = assert(thread:join())
+        assert.matches("kic=true", res, nil, true)
+      end)
+    end)
+
     describe("sends '_admin' for 'admin_listen'", function()
       it("off", function()
         local conf = assert(conf_loader(nil, {


### PR DESCRIPTION
### Summary

Add a `kic` configuration setting for reporting purposes. This is not documented in kong.conf.default, as we don't intend for users to set it manually. It should only be set by our Kubernetes tooling.

### Full changelog

* Add `kic` configuration, default `off`.
* Add `kic` to reporting data.
* Add tests for reporting.
