### PR TITLE
feat(schema) add hidden field feature to hide selected schema fields

### DIFF
--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1214,7 +1214,9 @@ end
 local function run_self_check(self, input, errors)
   local ok = true
   for fname, field in self:each_field() do
-    if input[fname] == nil and not field.nilable then
+    if input[fname] == nil
+      and not field.nilable
+      and not field.hidden then
       local err = validation_errors.REQUIRED_FOR_ENTITY_CHECK:format(fname)
       errors[fname] = err
       ok = false
@@ -1656,6 +1658,10 @@ function Schema:process_auto_fields(data, context, nulls)
       end
 
       check_immutable_fields = true
+    end
+
+    if field.hidden then
+      data[key] = nil
     end
   end
 

--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -70,6 +70,7 @@ local field_schema = {
   { legacy = { type = "boolean" }, },
   { immutable = { type = "boolean" }, },
   { err = { type = "string" } },
+  { hidden = { type = "boolean" }, },
 }
 
 for _, field in ipairs(validators) do
@@ -300,6 +301,9 @@ local attribute_types = {
   legacy = {
     ["string"] = true,
   },
+  hidden = {
+    ["string"] = true,
+  },
   unique = {
     ["string"] = true,
     ["number"] = true,
@@ -501,6 +505,12 @@ local MetaSchema = Schema.new({
     },
     {
       legacy = {
+        type = "boolean",
+        nilable = true,
+      },
+    },
+    {
+      hidden = {
         type = "boolean",
         nilable = true,
       },

--- a/spec/01-unit/01-db/01-schema/02-metaschema_spec.lua
+++ b/spec/01-unit/01-db/01-schema/02-metaschema_spec.lua
@@ -1067,6 +1067,40 @@ describe("metasubschema", function()
     assert.match("'set' cannot have attribute 'unique'", err.set)
   end)
 
+  it("supports the hidden attribute with a string type", function()
+    local s = {
+      name = "test",
+      fields = {
+        { str = { type = "string", hidden = true } },
+      },
+    }
+    assert.truthy(MetaSchema.MetaSubSchema:validate(s))
+  end)
+
+  it("rejects a hidden attribute in complex and number types", function()
+    local s = {
+      name = "test",
+      fields = {
+        { id  = { type = "string" } },
+        { num = { type = "number", hidden = true } },
+        { int = { type = "integer", hidden = true } },
+        { arr = { type = "array", hidden = true } },
+        { map = { type = "map", hidden = true } },
+        { rec = { type = "record", hidden = true } },
+        { set = { type = "set", hidden = true } },
+      },
+    }
+    local ok, err = MetaSchema.MetaSubSchema:validate(s)
+    assert.falsy(ok)
+    print(require("inspect")(err))
+    assert.match("'number' cannot have attribute 'hidden'", err.num)
+    assert.match("'integer' cannot have attribute 'hidden'", err.int)
+    assert.match("'array' cannot have attribute 'hidden'", err.arr)
+    assert.match("'map' cannot have attribute 'hidden'", err.map)
+    assert.match("'record' cannot have attribute 'hidden'", err.rec)
+    assert.match("'set' cannot have attribute 'hidden'", err.set)
+  end)
+
   it("a schema cannot have a field of type 'any'", function()
     local s = {
       name = "hello",


### PR DESCRIPTION
### Summary

Add feature that enables engineers to hide chosen fields in schema from
the clients that use API. There are a couple of reasons to have this feature, one of
the examples would be to hide "operational" system fields from the end
client like calculating digest values of certain fields that is only used internally.

### Full changelog

* Add new metaschema attribute `hidden` boolean type
* Add related tests
