### PR TITLE
fix(balancer) set a proper log prefix with upstream name

### DIFF
--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -291,7 +291,7 @@ do
         end
 
         if not ok then
-          log(ERR, "[healthchecks] failed setting peer status: ", err)
+          log(ERR, "[healthchecks] failed setting peer status (upstream: ", hc.name, "): ", err)
         end
       end
 
@@ -403,6 +403,7 @@ do
                               upstream.healthchecks.threshold or nil
 
     local balancer, err = balancer_types[upstream.algorithm].new({
+      log_prefix = "upstream:" .. upstream.name,
       wheelSize = upstream.slots,  -- will be ignored by least-connections
       dns = dns_client,
       healthThreshold = health_threshold,


### PR DESCRIPTION
instead of the balancers creating logs like `[balancer 1]`, a balancer create from upstream `myupstream` will now log with a prefix `[upstream:myupstream 1]` making correlating the logs a lot easier.

The default for `log_prefix` is `"balancer"` but was never set/overridden by Kong.