### PR TITLE
fix(declarative) send config updates to stream subsystem via Unix domain

### DIFF
--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -10,7 +10,10 @@ local deepcopy = tablex.deepcopy
 local null = ngx.null
 local SHADOW = true
 local md5 = ngx.md5
+local ngx_socket_tcp = ngx.socket.tcp
 local REMOVE_FIRST_LINE_PATTERN = "^[^\n]+\n(.+)$"
+local PREFIX = ngx.config.prefix()
+local SUBSYS = ngx.config.subsystem
 
 
 local declarative = {}
@@ -519,6 +522,26 @@ function declarative.load_into_cache_with_events(entities, hash)
   local ok, err = kong.worker_events.poll()
   if not ok then
     return nil, err
+  end
+
+  if SUBSYS == "http" and #kong.configuration.stream_listeners > 0 and
+     ngx.get_phase() ~= "init_worker"
+  then
+    -- update stream if necessary
+    -- TODO: remove this once shdict can be shared between subsystems
+
+    local sock = ngx_socket_tcp()
+    ok, err = sock:connect("unix:" .. PREFIX .. "/stream_config.sock")
+    if not ok then
+      return nil, err
+    end
+
+    ok, err = sock:send(cjson.encode({ entities, hash, }))
+    sock:close()
+
+    if not ok then
+      return nil, err
+    end
   end
 
   ok, err = kong.worker_events.post("balancer", "upstreams", {

--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -536,12 +536,16 @@ function declarative.load_into_cache_with_events(entities, hash)
       return nil, err
     end
 
-    ok, err = sock:send(cjson.encode({ entities, hash, }))
+    local json = cjson.encode({ entities, hash, })
+    local bytes
+    bytes, err = sock:send(json)
     sock:close()
 
-    if not ok then
+    if not bytes then
       return nil, err
     end
+
+    assert(bytes == #json, "incomplete config sent to the stream subsystem")
   end
 
   ok, err = kong.worker_events.post("balancer", "upstreams", {

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -419,7 +419,9 @@ function Kong.init()
     certificate.init()
   end
 
-  clustering.init(config)
+  if subsystem == "http" then
+    clustering.init(config)
+  end
 
   -- Load plugins as late as possible so that everything is set up
   assert(db.plugins:load_plugin_schemas(config.loaded_plugins))
@@ -550,7 +552,9 @@ function Kong.init_worker()
     go.manage_pluginserver()
   end
 
-  clustering.init_worker(kong.configuration)
+  if subsystem == "http" then
+    clustering.init_worker(kong.configuration)
+  end
 end
 
 
@@ -1152,6 +1156,41 @@ function Kong.serve_cluster_listener(options)
   kong_global.set_phase(kong, PHASES.cluster_listener)
 
   return clustering.handle_cp_websocket()
+end
+
+
+do
+  local declarative = require("kong.db.declarative")
+  local cjson = require("cjson.safe")
+
+  function Kong.stream_config_listener()
+    local sock = ngx.req.socket()
+    if not sock then
+      ngx_log(ngx_CRIT, "unable to obtain request socket")
+      return
+    end
+
+    local data, err = sock:receive("*a")
+    if err then
+      ngx_log(ngx_CRIT, "unable to receive new config: ", err)
+      return
+    end
+
+    local parsed = cjson.decode(data)
+
+    local ok, err = concurrency.with_worker_mutex({ name = "dbless-worker" }, function()
+      return declarative.load_into_cache_with_events(parsed[1], parsed[2])
+    end)
+
+    if err == "no memory" then
+      kong.log.err("not enough cache space for declarative config")
+      return
+    end
+
+    if not ok then
+      kong.log.err("failed loading declarative config into cache: ", err)
+    end
+  end
 end
 
 

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -1171,7 +1171,7 @@ do
     end
 
     local data, err = sock:receive("*a")
-    if err then
+    if not data then
       ngx_log(ngx_CRIT, "unable to receive new config: ", err)
       return
     end

--- a/kong/templates/nginx_kong_stream.lua
+++ b/kong/templates/nginx_kong_stream.lua
@@ -120,6 +120,7 @@ server {
     }
 }
 
+> if strategy == "off" then
 server {
     listen unix:${{PREFIX}}/stream_config.sock;
 
@@ -129,5 +130,6 @@ server {
         Kong.stream_config_listener()
     }
 }
+> end -- strategy == "off"
 > end -- #stream_listeners > 0
 ]]

--- a/kong/templates/nginx_kong_stream.lua
+++ b/kong/templates/nginx_kong_stream.lua
@@ -120,7 +120,7 @@ server {
     }
 }
 
-> if strategy == "off" then
+> if database == "off" then
 server {
     listen unix:${{PREFIX}}/stream_config.sock;
 
@@ -130,6 +130,6 @@ server {
         Kong.stream_config_listener()
     }
 }
-> end -- strategy == "off"
+> end -- database == "off"
 > end -- #stream_listeners > 0
 ]]

--- a/kong/templates/nginx_kong_stream.lua
+++ b/kong/templates/nginx_kong_stream.lua
@@ -119,5 +119,15 @@ server {
         Kong.log()
     }
 }
+
+server {
+    listen unix:${{PREFIX}}/stream_config.sock;
+
+    error_log  ${{ADMIN_ERROR_LOG}} ${{LOG_LEVEL}};
+
+    content_by_lua_block {
+        Kong.stream_config_listener()
+    }
+}
 > end -- #stream_listeners > 0
 ]]

--- a/spec/02-integration/04-admin_api/15-off_spec.lua
+++ b/spec/02-integration/04-admin_api/15-off_spec.lua
@@ -208,6 +208,7 @@ describe("Admin API #off", function()
 
         assert.response(res).has.status(201)
       end)
+
       it("accepts configuration as a JSON string", function()
         local res = assert(client:send {
           method = "POST",
@@ -498,41 +499,6 @@ describe("Admin API #off", function()
           message = "expected a declarative configuration",
         }, json)
       end)
-
-      it("updates stream subsystem config", function()
-        local res = assert(client:send {
-          method = "POST",
-          path = "/config",
-          body = {
-            config = [[
-            _format_version: "1.1"
-            services:
-            - connect_timeout: 60000
-              host: 127.0.0.1
-              name: mock
-              port: 15557
-              protocol: tcp
-              routes:
-              - name: mock_route
-                protocols:
-                - tcp
-                destinations:
-                - port: 9011
-            ]],
-          },
-          headers = {
-            ["Content-Type"] = "application/json"
-          }
-        })
-
-        assert.response(res).has.status(201)
-
-        local sock = ngx.socket.tcp()
-        assert(sock:connect("127.0.0.1", 9011))
-        assert(sock:send("hi\n"))
-        assert.equals(sock:receive(), "hi")
-        sock:close()
-      end)
     end)
 
     describe("GET", function()
@@ -587,6 +553,41 @@ describe("Admin API #off", function()
       })
 
       assert.response(res).has.status(201)
+    end)
+
+    it("updates stream subsystem config", function()
+      local res = assert(client:send {
+        method = "POST",
+        path = "/config",
+        body = {
+          config = [[
+          _format_version: "1.1"
+          services:
+          - connect_timeout: 60000
+            host: 127.0.0.1
+            name: mock
+            port: 15557
+            protocol: tcp
+            routes:
+            - name: mock_route
+              protocols:
+              - tcp
+              destinations:
+              - port: 9011
+          ]],
+        },
+        headers = {
+          ["Content-Type"] = "application/json"
+        }
+      })
+
+      assert.response(res).has.status(201)
+
+      local sock = ngx.socket.tcp()
+      assert(sock:connect("127.0.0.1", 9011))
+      assert(sock:send("hi\n"))
+      assert.equals(sock:receive(), "hi")
+      sock:close()
     end)
   end)
 

--- a/spec/02-integration/04-admin_api/15-off_spec.lua
+++ b/spec/02-integration/04-admin_api/15-off_spec.lua
@@ -25,6 +25,8 @@ describe("Admin API #off", function()
     assert(helpers.start_kong({
       database = "off",
       mem_cache_size = "10m",
+      stream_listen = "127.0.0.1:9011",
+      nginx_conf = "spec/fixtures/custom_nginx.template",
     }))
   end)
 
@@ -495,6 +497,41 @@ describe("Admin API #off", function()
         assert.same({
           message = "expected a declarative configuration",
         }, json)
+      end)
+
+      it("updates stream subsystem config", function()
+        local res = assert(client:send {
+          method = "POST",
+          path = "/config",
+          body = {
+            config = [[
+            _format_version: "1.1"
+            services:
+            - connect_timeout: 60000
+              host: 127.0.0.1
+              name: mock
+              port: 15557
+              protocol: tcp
+              routes:
+              - name: mock_route
+                protocols:
+                - tcp
+                destinations:
+                - port: 9011
+            ]],
+          },
+          headers = {
+            ["Content-Type"] = "application/json"
+          }
+        })
+
+        assert.response(res).has.status(201)
+
+        local sock = ngx.socket.tcp()
+        assert(sock:connect("127.0.0.1", 9011))
+        assert(sock:send("hi\n"))
+        assert.equals(sock:receive(), "hi")
+        sock:close()
       end)
     end)
 

--- a/spec/02-integration/05-proxy/01-proxy_spec.lua
+++ b/spec/02-integration/05-proxy/01-proxy_spec.lua
@@ -15,9 +15,9 @@ local function get_listeners(filename)
   local file = assert(utils.readfile(filename))
   local result = {}
   for block in file:gmatch("[%\n%s]+server%s+(%b{})") do
-    local server = {}
     local server_name = block:match("[%\n%s]server_name%s(.-);")
     server_name = server_name and stringx.strip(server_name) or "stream"
+    local server = result[server_name] or {}
     result[server_name] = server
     for listen in block:gmatch("[%\n%s]listen%s(.-);") do
       listen = stringx.strip(listen)
@@ -98,12 +98,16 @@ describe("#stream proxy interface listeners", function()
       stream_listen = "127.0.0.1:9011, 127.0.0.1:9012",
     }))
 
-    assert.equals(1, count_server_blocks(helpers.test_conf.nginx_kong_stream_conf))
+    assert.equals(2, count_server_blocks(helpers.test_conf.nginx_kong_stream_conf))
+
+    local stream_config_sock_path = "unix:" .. helpers.test_conf.prefix .. "/stream_config.sock"
     assert.same({
       ["127.0.0.1:9011"] = 1,
       ["127.0.0.1:9012"] = 2,
+      [stream_config_sock_path] = 3,
       [1] = "127.0.0.1:9011",
       [2] = "127.0.0.1:9012",
+      [3] = stream_config_sock_path,
     }, get_listeners(helpers.test_conf.nginx_kong_stream_conf).stream)
 
     for i = 9011, 9012 do

--- a/spec/02-integration/05-proxy/01-proxy_spec.lua
+++ b/spec/02-integration/05-proxy/01-proxy_spec.lua
@@ -15,9 +15,9 @@ local function get_listeners(filename)
   local file = assert(utils.readfile(filename))
   local result = {}
   for block in file:gmatch("[%\n%s]+server%s+(%b{})") do
+    local server = {}
     local server_name = block:match("[%\n%s]server_name%s(.-);")
     server_name = server_name and stringx.strip(server_name) or "stream"
-    local server = result[server_name] or {}
     result[server_name] = server
     for listen in block:gmatch("[%\n%s]listen%s(.-);") do
       listen = stringx.strip(listen)
@@ -98,16 +98,12 @@ describe("#stream proxy interface listeners", function()
       stream_listen = "127.0.0.1:9011, 127.0.0.1:9012",
     }))
 
-    assert.equals(2, count_server_blocks(helpers.test_conf.nginx_kong_stream_conf))
-
-    local stream_config_sock_path = "unix:" .. helpers.test_conf.prefix .. "/stream_config.sock"
+    assert.equals(1, count_server_blocks(helpers.test_conf.nginx_kong_stream_conf))
     assert.same({
       ["127.0.0.1:9011"] = 1,
       ["127.0.0.1:9012"] = 2,
-      [stream_config_sock_path] = 3,
       [1] = "127.0.0.1:9011",
       [2] = "127.0.0.1:9012",
-      [3] = stream_config_sock_path,
     }, get_listeners(helpers.test_conf.nginx_kong_stream_conf).stream)
 
     for i = 9011, 9012 do

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -728,6 +728,16 @@ stream {
             Kong.log()
         }
     }
+
+    server {
+        listen unix:${{PREFIX}}/stream_config.sock;
+
+        error_log  ${{PROXY_ERROR_LOG}} ${{LOG_LEVEL}};
+
+        content_by_lua_block {
+            Kong.stream_config_listener()
+        }
+    }
 > end -- #stream_listeners > 0
 
     server {

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -729,6 +729,7 @@ stream {
         }
     }
 
+> if database == "off" then
     server {
         listen unix:${{PREFIX}}/stream_config.sock;
 
@@ -738,6 +739,7 @@ stream {
             Kong.stream_config_listener()
         }
     }
+> end -- database == "off"
 > end -- #stream_listeners > 0
 
     server {


### PR DESCRIPTION
socket

Currently, the stream subsystem receives the declarative config from
the filesystem only. Once Kong is running, updating the declarative config
through `/config` admin API no longer propagates to the stream
subsystem. In the long term we will have shared shdict between `http`
and `stream` subsystem which solves the problem. However this PR
provides a temporary and clean solution for getting around the issue without
introducing new OpenResty patches, and can be reverted in the future
easily once situation changes.

Fixes #5656