### PR TITLE
Fix/basic auth hybrid mode

### DIFF
--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -248,9 +248,13 @@ function declarative.export_from_db(fd)
 
     local name = schema.name
     local fks = {}
+    local export_as_fields = {}
     for name, field in schema:each_field() do
       if field.type == "foreign" then
         table.insert(fks, name)
+      end
+      if field.export_as then
+        export_as_fields[name] = field.export_as
       end
     end
 
@@ -263,6 +267,11 @@ function declarative.export_from_db(fd)
             row[fname] = id
           end
         end
+      end
+
+      for old_name, export_as_name in pairs(export_as_fields) do
+        row[export_as_name] = row[old_name]
+        row[old_name] = nil
       end
 
       local yaml = declarative.to_yaml_string({ [name] = { row } })
@@ -300,9 +309,13 @@ function declarative.export_config()
 
     local name = schema.name
     local fks = {}
+    local export_as_fields = {}
     for name, field in schema:each_field() do
       if field.type == "foreign" then
         table.insert(fks, name)
+      end
+      if field.export_as then
+        export_as_fields[name] = field.export_as
       end
     end
 
@@ -314,6 +327,11 @@ function declarative.export_config()
             row[fname] = id
           end
         end
+      end
+
+      for old_name, export_as_name in pairs(export_as_fields) do
+        out[export_as_name] = out[old_name]
+        out[old_name] = nil
       end
 
       if not out[name] then

--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -69,6 +69,7 @@ local field_schema = {
   { generate_admin_api = { type = "boolean" }, },
   { legacy = { type = "boolean" }, },
   { immutable = { type = "boolean" }, },
+  { export_as = { type = "string" }, },
   { err = { type = "string" } },
 }
 
@@ -315,6 +316,15 @@ local attribute_types = {
     ["set"] = true,
     ["map"] = true,
   },
+  export_as = {
+    ["string"] = true,
+    ["number"] = true,
+    ["integer"] = true,
+    ["record"] = true,
+    ["array"] = true,
+    ["set"] = true,
+    ["map"] = true,
+  }
 }
 
 

--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -400,6 +400,15 @@ local function has_schema_field(schema, name)
       end
     end
 
+    if schema.shorthands then
+      for _, shorthand in ipairs(schema.shorthands) do
+        local k = next(shorthand)
+        if k == name then
+          return true
+        end
+      end
+    end
+
     return false
   end
 

--- a/kong/plugins/basic-auth/daos.lua
+++ b/kong/plugins/basic-auth/daos.lua
@@ -8,9 +8,6 @@ return {
     primary_key = { "id" },
     cache_key = { "username" },
     endpoint_key = "username",
-    -- Passwords are hashed, so the exported passwords would contain the hashes.
-    -- Importing them back would require "plain" non-hashed passwords instead.
-    db_export = false,
     admin_api_name = "basic-auths",
     admin_api_nested_name = "basic-auth",
     fields = {
@@ -18,15 +15,30 @@ return {
       { created_at = typedefs.auto_timestamp_s },
       { consumer = { type = "foreign", reference = "consumers", required = true, on_delete = "cascade" }, },
       { username = { type = "string", required = true, unique = true }, },
-      { password = { type = "string", required = true }, },
+      { password = { type = "string", required = true, export_as = "encrypted_password" }, },
       { tags     = typedefs.tags },
     },
-    transformations = {
+    shorthands = {
       {
+        encrypted_password = function(encrypted_password)
+          return { password = encrypted_password }
+        end
+      }
+    },
+    transformations = {
+      { -- First transformation
         input = { "password" },
         needs = { "consumer.id" },
         on_write = function(password, consumer_id)
           return { password = crypto.hash(consumer_id, password) }
+        end,
+      },
+      { -- The following transformation needs to be declared after password encryption
+        -- The first transformation encrypts them password, and this one overrides
+        -- the encryption if an "encrypted password" was found
+        input = { "encrypted_password" },
+        on_write = function(encrypted_password)
+          return { password = encrypted_password }
         end,
       },
     },

--- a/spec/01-unit/01-db/01-schema/02-metaschema_spec.lua
+++ b/spec/01-unit/01-db/01-schema/02-metaschema_spec.lua
@@ -743,6 +743,44 @@ describe("metaschema", function()
     }))
   end)
 
+  it("validates transformation input fields exists as a shorthand (positive)", function()
+    assert.truthy(MetaSchema:validate({
+      name = "test",
+      primary_key = { "test" },
+      fields = {
+        { test = { type = "string" } },
+      },
+      shorthands = {
+        { short = function() end }
+      },
+      transformations = {
+        {
+          input = { "short" },
+          on_write = function() return true end,
+        },
+      },
+    }))
+  end)
+
+  it("validates transformation input fields exists as a shorthand (negative)", function()
+    assert.falsy(MetaSchema:validate({
+      name = "test",
+      primary_key = { "test" },
+      fields = {
+        { test = { type = "string" } },
+      },
+      shorthands = {
+        { short = function() end }
+      },
+      transformations = {
+        {
+          input = { "nonexisting" },
+          on_write = function() return true end,
+        },
+      },
+    }))
+  end)
+
   it("validates transformation needs fields exists (positive)", function()
     assert.truthy(MetaSchema:validate({
       name = "test",

--- a/spec/02-integration/03-db/08-declarative_spec.lua
+++ b/spec/02-integration/03-db/08-declarative_spec.lua
@@ -2,6 +2,7 @@ local declarative = require "kong.db.declarative"
 local ssl_fixtures = require "spec.fixtures.ssl"
 local helpers = require "spec.helpers"
 local lyaml = require "lyaml"
+local crypto = require "kong.plugins.basic-auth.crypto"
 
 for _, strategy in helpers.each_strategy() do
   describe("declarative config #" .. strategy, function()
@@ -98,6 +99,25 @@ for _, strategy in helpers.each_strategy() do
       consumer = { id = consumer_def.id },
       group = "The A Team"
     }
+
+    local basicauth_credential_def = {
+      id = "ad06b77c-0d2f-407a-8d6d-07f272a92d9a",
+      consumer = {
+        id = consumer_def.id,
+      },
+      username = "james",
+      password = "secret",
+    }
+
+    local basicauth_encrypted_credential_def = {
+      id = "caa33a6f-8e6b-4b02-9f55-0e2cffd26fb5",
+      consumer = {
+        id = consumer_def.id,
+      },
+      username = "bond",
+      encrypted_password = crypto.hash(consumer_def.id, "MI6"),
+    }
+
     before_each(function()
       db.acls:truncate()
       db.plugins:truncate()
@@ -106,6 +126,7 @@ for _, strategy in helpers.each_strategy() do
       db.snis:truncate()
       db.certificates:truncate()
       db.consumers:truncate()
+      db.basicauth_credentials:truncate()
 
       assert(declarative.load_into_db({
         snis = { [sni_def.id] = sni_def },
@@ -115,6 +136,10 @@ for _, strategy in helpers.each_strategy() do
         consumers = { [consumer_def.id] = consumer_def },
         plugins = { [plugin_def.id] = plugin_def },
         acls = { [acl_def.id] = acl_def  },
+        basicauth_credentials = {
+          [basicauth_credential_def.id] = basicauth_credential_def,
+          [basicauth_encrypted_credential_def.id] = basicauth_encrypted_credential_def,
+        },
       }))
     end)
 
@@ -154,19 +179,23 @@ for _, strategy in helpers.each_strategy() do
         local acl = assert(db.acls:select({ id = acl_def.id }))
         assert.equals(consumer_def.id, acl.consumer.id)
         assert.equals("The A Team", acl.group)
+
+        local basicauth_credential = assert(db.basicauth_credentials:select({ id = basicauth_credential_def.id }))
+        assert.equals(basicauth_credential_def.id, basicauth_credential.id)
+        assert.equals(consumer.id, basicauth_credential.consumer.id)
+        assert.equals("james", basicauth_credential.username)
+        assert.equals(crypto.hash(consumer.id, "secret"), basicauth_credential.password)
+
+        local basicauth_encrypted_credential = assert(db.basicauth_credentials:select({ id = basicauth_encrypted_credential_def.id }))
+        assert.equals(basicauth_encrypted_credential_def.id, basicauth_encrypted_credential.id)
+        assert.equals(consumer.id, basicauth_encrypted_credential.consumer.id)
+        assert.equals("bond", basicauth_encrypted_credential.username)
+        assert.equals(basicauth_encrypted_credential_def.encrypted_password, basicauth_encrypted_credential.password)
       end)
     end)
 
     describe("export_from_db", function()
       it("exports base and custom entities with associations", function()
-
-        -- Add a basicauth_credential to make sure it is not exported
-        db.basicauth_credentials:insert({
-          username = "some_username",
-          password = "secret",
-          consumer = { id = consumer_def.id },
-        })
-
         local fake_file = {
           buffer = {},
           write = function(self, str)
@@ -188,6 +217,7 @@ for _, strategy in helpers.each_strategy() do
         assert.same({
           "_format_version",
           "acls",
+          "basicauth_credentials",
           "certificates",
           "consumers",
           "plugins",
@@ -242,6 +272,21 @@ for _, strategy in helpers.each_strategy() do
         local acl = assert(yaml.acls[1])
         assert.equals(consumer_def.id, acl.consumer)
         assert.equals("The A Team", acl.group)
+
+        assert.equals(2, #yaml.basicauth_credentials)
+        table.sort(yaml.basicauth_credentials, function(a, b)
+          return a.username > b.username
+        end)
+
+        local bac1 = assert(yaml.basicauth_credentials[1])
+        assert.equals(consumer_def.id, bac1.consumer)
+        assert.equals("james", bac1.username)
+        assert.equals(crypto.hash(consumer_def.id, "secret"), bac1.encrypted_password)
+
+        local bac2 = assert(yaml.basicauth_credentials[2])
+        assert.equals(consumer_def.id, bac2.consumer)
+        assert.equals("bond", bac2.username)
+        assert.equals(crypto.hash(consumer_def.id, "MI6"), bac2.encrypted_password)
       end)
     end)
   end)


### PR DESCRIPTION
The main idea in this change is adding a new "pseudo-attribute" to the basicauth_credentials table.

* When exporting, the password is allways called `encrypted_password`.
* When importing, unencrypted passwords can be specified via the `password` field, and encrypted passwords can be specified via the `encrypted_password` field.

In order to do this, a new `export_as` field attribute has been added to the fields. This just renames the field.

The only other needed structural change was making transformations aware of "shorthands" (AKA pseudo-fields) so the encryption transformation could be undone when loading credentials from declarative conf.

fixes #5649