### PR TITLE
chore(deps) bump lua-resty-counter from 0.2.0 to 0.2.1

### DIFF
--- a/kong-2.0.3-0.rockspec
+++ b/kong-2.0.3-0.rockspec
@@ -37,7 +37,7 @@ dependencies = {
   "lua-resty-mlcache == 2.4.1",
   "lua-messagepack == 0.5.2",
   "lua-resty-openssl == 0.6.0",
-  "lua-resty-counter == 0.2.0",
+  "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6",
   -- external Kong plugins
   "kong-plugin-azure-functions ~> 0.4",


### PR DESCRIPTION
### Summary

- optimize: use `table.clear` to clear table object.
- optimize: local cache.
- change: compat mode for `table.clear` .