### PR TITLE
fix(cache) disable JIT mlcache:get_bulk() on ARM64

### DIFF
--- a/kong/runloop/certificate.lua
+++ b/kong/runloop/certificate.lua
@@ -3,6 +3,11 @@ local ngx_ssl = require "ngx.ssl"
 local pl_utils = require "pl.utils"
 local mlcache = require "resty.mlcache"
 
+if jit.arch == 'arm64' then
+  jit.off(mlcache.get_bulk)        -- "temporary" workaround for issue #5748 on ARM
+end
+
+
 
 local ngx_log     = ngx.log
 local ERR         = ngx.ERR


### PR DESCRIPTION
The loop inside this function can trigger a trace restart that results
in a wrong value in the local index variable.   (#5748)

until this is fixed in LuaJIT, disabling JIT for this function
avoids the problem.

