### PR TITLE
chore(dependency) bump the kong-build-tools dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ RESTY_VERSION ?= `grep RESTY_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk
 RESTY_LUAROCKS_VERSION ?= `grep RESTY_LUAROCKS_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
 RESTY_OPENSSL_VERSION ?= `grep RESTY_OPENSSL_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
 RESTY_PCRE_VERSION ?= `grep RESTY_PCRE_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
-KONG_BUILD_TOOLS ?= '4.2.2'
+KONG_BUILD_TOOLS ?= '4.3.1'
 KONG_VERSION ?= `cat $(KONG_SOURCE_LOCATION)/kong-*.rockspec | grep tag | awk '{print $$3}' | sed 's/"//g'`
 OPENRESTY_PATCHES_BRANCH ?= master
 KONG_NGINX_MODULE_BRANCH ?= master


### PR DESCRIPTION
full diff: https://github.com/Kong/kong-build-tools/compare/4.2.2...4.3.1

Notable changes:
- https://github.com/Kong/kong-build-tools/pull/244 build a companion go docker image
- https://github.com/Kong/kong-build-tools/pull/255 order the openresty patches
- https://github.com/Kong/kong-build-tools/pull/256 only push cache images if tests suceeds
- https://github.com/Kong/kong-build-tools/pull/259 unconditionally setup systemd / logrotate