### PR TITLE
fix(release) let the release continue even if parts of it fail

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,6 @@ pipeline {
     }
     options {
         retry(1)
-        parallelsAlwaysFailFast()
         timeout(time: 2, unit: 'HOURS')
     }
     environment {


### PR DESCRIPTION
AWS is having challenges with providing functioning ARM hardware. This change will allow other builds to continue even if the Ubuntu Xenial arm build fails