### PR TITLE
fix(conf_loader) do not apply additional processing when loading from

### DIFF
--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -441,11 +441,13 @@ local function check_and_infer(conf, opts)
     local v_schema = CONF_INFERENCES[k] or {}
     local typ = v_schema.typ
 
-    if type(value) == "string" and not opts.from_kong_env then
-      -- remove trailing comment, if any
-      -- and remove escape chars from octothorpes
-      value = string.gsub(value, "[^\\]#.-$", "")
-      value = string.gsub(value, "\\#", "#")
+    if type(value) == "string" then
+      if not opts.from_kong_env then
+        -- remove trailing comment, if any
+        -- and remove escape chars from octothorpes
+        value = string.gsub(value, "[^\\]#.-$", "")
+        value = string.gsub(value, "\\#", "#")
+      end
 
       value = pl_stringx.strip(value)
     end

--- a/kong/conf_loader.lua
+++ b/kong/conf_loader.lua
@@ -434,14 +434,14 @@ local _nop_tostring_mt = {
 
 -- Validate properties (type/enum/custom) and infer their type.
 -- @param[type=table] conf The configuration table to treat.
-local function check_and_infer(conf)
+local function check_and_infer(conf, opts)
   local errors = {}
 
   for k, value in pairs(conf) do
     local v_schema = CONF_INFERENCES[k] or {}
     local typ = v_schema.typ
 
-    if type(value) == "string" then
+    if type(value) == "string" and not opts.from_kong_env then
       -- remove trailing comment, if any
       -- and remove escape chars from octothorpes
       value = string.gsub(value, "[^\\]#.-$", "")
@@ -1108,7 +1108,7 @@ local function load(path, custom_conf, opts)
                               user_conf)
 
   -- validation
-  local ok, err, errors = check_and_infer(conf)
+  local ok, err, errors = check_and_infer(conf, opts)
 
   if not opts.starting then
     log.enable()

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -87,6 +87,18 @@ describe("Configuration loader", function()
     assert.True(conf.loaded_plugins["foo"])
     assert.True(conf.loaded_plugins["bar"])
   end)
+  it("apply # transformations when loading from config file directly", function()
+    local conf = assert(conf_loader(nil, {
+      pg_password = "!abCDefGHijKL4\\#1MN2OP3",
+    }))
+    assert.same("!abCDefGHijKL4#1MN2OP3", conf.pg_password)
+  end)
+  it("no longer applies # transformations when loading from .kong_env (issue #5761)", function()
+    local conf = assert(conf_loader(nil, {
+      pg_password = "!abCDefGHijKL4\\#1MN2OP3",
+    }, { from_kong_env = true, }))
+    assert.same("!abCDefGHijKL4\\#1MN2OP3", conf.pg_password)
+  end)
   it("loads custom plugins surrounded by spaces", function()
     local conf = assert(conf_loader(nil, {
       plugins = " hello-world ,   another-one  "


### PR DESCRIPTION
`.kong_env` file

Doing so could cause failures such as ones described in #5761, where a
value of `"!abCDefGHijKL4\#1MN2OP3"` was first transformed to
`"!abCDefGHijKL4#1MN2OP3"` and written to `.kong_env`. If we apply
transformation to `"!abCDefGHijKL4#1MN2OP3"` again when loading from
`.kong_env`, then it becomes `"!abCDefGHijKL4` which results in
different value used by the CLI and worker.

fixes #5761