### PR TITLE
fix: reload old go-plugin configuratin if new exists

### DIFF
--- a/kong/db/dao/plugins/go.lua
+++ b/kong/db/dao/plugins/go.lua
@@ -385,7 +385,7 @@ do
 
     if instance_info
       and instance_info.id
-      and instance_info.seq == instance_info.conf.__seq__
+      and instance_info.seq == conf.__seq__
     then
       -- exact match, return it
       return instance_info.id
@@ -417,6 +417,7 @@ do
     end
 
     instance_info.id = status.Id
+    instance_info.seq = conf.__seq__
     instance_info.Config = status.Config
 
     if old_instance_id then

--- a/kong/db/dao/plugins/go.lua
+++ b/kong/db/dao/plugins/go.lua
@@ -417,6 +417,7 @@ do
     end
 
     instance_info.id = status.Id
+    instance_info.conf = conf
     instance_info.seq = conf.__seq__
     instance_info.Config = status.Config
 


### PR DESCRIPTION
### Summary

When KongPlugin instance is updated go-plugin server still have old plugins instance with incorrect configuration. Thanks to this fix old instance will be closed and new will be created.

### Full changelog

* Fixes go-plugin configuration reload

### Issues resolved

https://github.com/Kong/go-pluginserver/issues/25
