### PR TITLE
fix(pdk) stop request processing on body encoding error

### DIFF
--- a/kong/pdk/response.lua
+++ b/kong/pdk/response.lua
@@ -556,7 +556,7 @@ local function new(self, major_version)
         local err
         json, err = cjson.encode(body)
         if err then
-          return nil, err
+          error(fmt("body encoding failed while flushing response: %s", err), 2)
         end
       end
     end


### PR DESCRIPTION
When flushing delayed responses, if there was a body encoding error, the request's processing continued and unexpected errors could show up. This change stops the request's processing, returning a 500 status.