### PR TITLE
fix(balancer) don't cache an empty upstream name dict

### DIFF
--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -546,6 +546,8 @@ local get_all_upstreams
 do
   local function load_upstreams_dict_into_memory()
     local upstreams_dict = {}
+    local found = nil
+
     -- build a dictionary, indexed by the upstream name
     for up, err in singletons.db.upstreams:each() do
       if err then
@@ -554,8 +556,10 @@ do
       end
 
       upstreams_dict[up.name] = up.id
+      found = true
     end
-    return upstreams_dict
+
+    return found and upstreams_dict
   end
   _load_upstreams_dict_into_memory = load_upstreams_dict_into_memory
 


### PR DESCRIPTION
### Summary

Issue #5455 reports Kong instances getting stuck with DNS resolution errors when using Kubernetes Ingress Controller.  In those cases, the DNS query won't work, but it should've been resolved first by the `get_balancer()` function.

Since this function can't be called at `balance` phase, if it didn't work earlier (at `access` phase), there's no other option than reporting failure.  It seems that there's some intermittent failure on reading the upstreams list, and once it returns an empty list, it's stored in the cache.

This patch avoids saving in the cache an empty upstream list, in the hope that a subsequent query will find the real content.

Fix #5455
