### PR TITLE
fix(declarative) fix race condition when reloading config by making sure

### DIFF
--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -363,8 +363,8 @@ function declarative.load_into_cache(entities, hash, shadow_page)
   -- but filtered for a given tag
   local tags_by_name = {}
 
-  kong.core_cache:purge()
-  kong.cache:purge()
+  kong.core_cache:purge(SHADOW)
+  kong.cache:purge(SHADOW)
 
   for entity_name, items in pairs(entities) do
     local dao = kong.db[entity_name]
@@ -563,11 +563,8 @@ function declarative.load_into_cache_with_events(entities, hash)
     if ok ~= "done" then
       return nil, "failed to flip declarative config cache pages: " .. (err or ok)
     end
-  end
 
-  kong.core_cache:purge(SHADOW)
-
-  if not ok then
+  else
     return nil, err
   end
 

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -174,6 +174,19 @@ do
     ngx.shared.kong:flush_all()
     ngx.shared.kong:flush_expired(0)
 
+    local db_cache = {
+      "kong_core_db_cache",
+      "kong_db_cache",
+      -- no need to purge the second page for DB-less mode, as when reload
+      -- happens Kong always uses the first page afterwards
+    }
+    for _, shm in ipairs(db_cache) do
+      ngx.shared[shm]:flush_all()
+      ngx.shared[shm]:flush_expired(0)
+      ngx.shared[shm .. "_miss"]:flush_all()
+      ngx.shared[shm .. "_miss"]:flush_expired(0)
+    end
+
     for _, key in ipairs(preserve_keys) do
       ngx.shared.kong:set(key, preserved[key])
     end


### PR DESCRIPTION
the correct config page is purged during load

The issue is only present when Kong is running with multiple workers.
Use #5789 as an example, the following events happens:

1. A new declarative config is uploaded via the Admin API
2. Kong is on cache page 2, `kong.core_cache:purge()` is called without
the shadow flag, causes the page `1` to be purged immediately
3. New config is loaded into page 1
4. Kong switches to use page 1, then page 2 is purged immediately.
The switch to use page 1 is not immediate and some
workers may keep using the now empty page 2 for a short period of time. This may cause
page 2 to be poisoned with an incorrect negative match. Which for #5789,
is the `sni:example.com` for looking up certificate matches. This
will cause `sni:example.com` to forever return `false` when next time switch
to page 2 happens.

This commit fixes the semantics of atomic page switching. With this
commit the issue described inside #5789 no longer happens, and that
the race window that Kong presents the default certificate between page
flips because page 1 is sometimes purged prematurely while in use no longer happens.

fixes #5789

Unfortunately we can't test this change directly on CI because this requires multiple workers to achieve a very small race window. However my extensive local testing has yielded consistent good results.