### PR TITLE
feat/basic auth hybrid mode (take 2)

### DIFF
--- a/kong/api/routes/config.lua
+++ b/kong/api/routes/config.lua
@@ -111,6 +111,7 @@ return {
       end
 
       _reports.decl_fmt_version = dc_table._format_version
+      _reports.decl_transform   = dc_table._transform
 
       ngx.timer.at(0, reports_timer)
 

--- a/kong/clustering.lua
+++ b/kong/clustering.lua
@@ -55,8 +55,8 @@ local function update_config(config_table, update_cache)
     declarative_config = declarative.new_config(kong.configuration)
   end
 
-  local entities, _, _, _, new_hash = declarative_config:parse_table(config_table)
-  if not entities then
+  local dc_table, new_hash = declarative_config:parse_table(config_table)
+  if not dc_table then
     return nil, "bad config received from control plane"
   end
 
@@ -68,7 +68,8 @@ local function update_config(config_table, update_cache)
 
   -- NOTE: no worker mutex needed as this code can only be
   -- executed by worker 0
-  local res, err = declarative.load_into_cache_with_events(entities, new_hash)
+  local res, err =
+    declarative.load_into_cache_with_events(dc_table, new_hash)
   if not res then
     return nil, err
   end

--- a/kong/cmd/config.lua
+++ b/kong/cmd/config.lua
@@ -128,6 +128,7 @@ local function execute(args)
 
         local report = {
           decl_fmt_version = dc_table._format_version,
+          decl_transform = dc_table._transform,
         }
         kong_reports.send("config-db-import", report)
       end

--- a/kong/cmd/config.lua
+++ b/kong/cmd/config.lua
@@ -105,7 +105,7 @@ local function execute(args)
     end
     filename = pl_path.abspath(filename)
 
-    local dc_table, err, _, vers = dc:parse_file(filename, accepted_formats)
+    local dc_table, err = dc:parse_file(filename, accepted_formats)
     if not dc_table then
       error("Failed parsing:\n" .. err)
     end
@@ -126,7 +126,9 @@ local function execute(args)
         kong_reports.configure_ping(conf)
         kong_reports.toggle(true)
 
-        local report = { decl_fmt_version = vers }
+        local report = {
+          decl_fmt_version = dc_table._format_version,
+        }
         kong_reports.send("config-db-import", report)
       end
 

--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -80,7 +80,7 @@ end
 
 -- first return item: a table with the following format:
 --   {
---     _format_version: 1.1,
+--     _format_version: 1.2,
 --     _transform: true,
 --     services: {
 --       ["<uuid>"] = { ... },
@@ -159,7 +159,7 @@ end
 
 -- first return item: a table with the following format:
 --   {
---     _format_version: 1.1,
+--     _format_version: 1.2,
 --     _transform: true,
 --     services: {
 --       ["<uuid>"] = { ... },
@@ -275,7 +275,7 @@ function declarative.export_from_db(fd)
   end
 
   fd:write(declarative.to_yaml_string({
-    _format_version = "1.1",
+    _format_version = "1.2",
     _transform = false,
   }))
 
@@ -330,7 +330,7 @@ function declarative.export_config()
   end
 
   local out = {
-    _format_version = "1.1",
+    _format_version = "1.2",
     _transform = false,
   }
 
@@ -391,7 +391,7 @@ end
 
 -- dc_table format:
 --   {
---     _format_version: 1.1,
+--     _format_version: 1.2,
 --     _transform: true,
 --     services: {
 --       ["<uuid>"] = { ... },

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -194,6 +194,7 @@ end
 local function build_fields(entities, include_foreign)
   local fields = {
     { _format_version = { type = "string", required = true, eq = "1.1" } },
+    { _transform = { type = "boolean", default = true } },
   }
   add_extra_attributes(fields, {
     _comment = true,
@@ -555,6 +556,13 @@ end
 
 
 local function flatten(self, input)
+  -- manually set transform here
+  -- we can't do this in the schema with a `default` because validate
+  -- needs to happen before process_auto_fields, which
+  -- is the one in charge of filling out default values
+  if input._transform == nil then
+    input._transform = true
+  end
 
   local ok, err = self:validate(input)
   if not ok then

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -555,7 +555,6 @@ end
 
 
 local function flatten(self, input)
-  local output = {}
 
   local ok, err = self:validate(input)
   if not ok then
@@ -577,6 +576,13 @@ local function flatten(self, input)
   local by_id, by_key = validate_references(self, processed)
   if not by_id then
     return nil, by_key
+  end
+
+  local output = {}
+  for key, value in pairs(processed) do
+    if key:sub(1,1) == "_" then
+      output[key] = value
+    end
   end
 
   for entity, entries in pairs(by_id) do

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -193,7 +193,7 @@ end
 
 local function build_fields(entities, include_foreign)
   local fields = {
-    { _format_version = { type = "string", required = true, eq = "1.1" } },
+    { _format_version = { type = "string", required = true, one_of = {"1.1", "1.2"} } },
     { _transform = { type = "boolean", default = true } },
   }
   add_extra_attributes(fields, {

--- a/kong/plugins/basic-auth/daos.lua
+++ b/kong/plugins/basic-auth/daos.lua
@@ -8,9 +8,6 @@ return {
     primary_key = { "id" },
     cache_key = { "username" },
     endpoint_key = "username",
-    -- Passwords are hashed, so the exported passwords would contain the hashes.
-    -- Importing them back would require "plain" non-hashed passwords instead.
-    db_export = false,
     admin_api_name = "basic-auths",
     admin_api_nested_name = "basic-auth",
     fields = {

--- a/kong/templates/kong_yml.lua
+++ b/kong/templates/kong_yml.lua
@@ -12,6 +12,15 @@ return [[
 
 _format_version: "1.1"
 
+# _transform is optional, defaulting to true.
+# It specifies whether schema transformations should be applied when importing this file
+# as a rule of thumb, leave this setting to true if you are importing credentials
+# with plain passwords, which need to be encrypted/hashed before storing on the database.
+# On the other hand, if you are reimporting a database with passwords already encrypted/hashed,
+# set it to false.
+
+_transform: true
+
 # Each Kong entity (core entity or custom entity introduced by a plugin)
 # can be listed in the top-level as an array of objects:
 

--- a/kong/templates/kong_yml.lua
+++ b/kong/templates/kong_yml.lua
@@ -10,7 +10,7 @@ return [[
 # _format_version is mandatory,
 # it specifies the minimum version of Kong that supports the format
 
-_format_version: "1.1"
+_format_version: "1.2"
 
 # _transform is optional, defaulting to true.
 # It specifies whether schema transformations should be applied when importing this file

--- a/spec/01-unit/01-db/01-schema/11-declarative_config/01-validate_spec.lua
+++ b/spec/01-unit/01-db/01-schema/11-declarative_config/01-validate_spec.lua
@@ -25,7 +25,7 @@ describe("declarative config: validate", function()
   end)
 
   describe("_format_version", function()
-    it("requires version 1.1", function()
+    it("requires version 1.1 or 1.2", function()
 
       local ok, err = DeclarativeConfig:validate(lyaml.load([[
         _format_version: 1.1
@@ -36,15 +36,19 @@ describe("declarative config: validate", function()
       }, err)
 
       ok, err = DeclarativeConfig:validate(lyaml.load([[
-        _format_version: "1.2"
+        _format_version: "foobar"
       ]]))
       assert.falsy(ok)
       assert.same({
-        ["_format_version"] = "value must be 1.1"
+        ["_format_version"] = "expected one of: 1.1, 1.2"
       }, err)
 
       assert(DeclarativeConfig:validate(lyaml.load([[
         _format_version: "1.1"
+      ]])))
+
+      assert(DeclarativeConfig:validate(lyaml.load([[
+        _format_version: "1.2"
       ]])))
     end)
   end)

--- a/spec/01-unit/01-db/01-schema/11-declarative_config/02-process_auto_fields_spec.lua
+++ b/spec/01-unit/01-db/01-schema/11-declarative_config/02-process_auto_fields_spec.lua
@@ -23,6 +23,7 @@ describe("declarative config: process_auto_fields", function()
         config = DeclarativeConfig:process_auto_fields(config, "select", false)
         assert.same({
           _format_version = "1.1",
+          _transform = true,
           services = {}
         }, config)
       end)
@@ -47,6 +48,7 @@ describe("declarative config: process_auto_fields", function()
         config = DeclarativeConfig:process_auto_fields(config, "select", false)
         assert.same({
           _format_version = "1.1",
+          _transform = true,
           services = {
             {
               name = "foo",
@@ -87,6 +89,7 @@ describe("declarative config: process_auto_fields", function()
         config = DeclarativeConfig:process_auto_fields(config, "select", false)
         assert.same({
           _format_version = "1.1",
+          _transform = true,
           services = {
             {
               name = "foo",
@@ -113,6 +116,7 @@ describe("declarative config: process_auto_fields", function()
         config = DeclarativeConfig:process_auto_fields(config, "select", false)
         assert.same({
           _format_version = "1.1",
+          _transform = true,
           plugins = {}
         }, config)
       end)
@@ -135,6 +139,7 @@ describe("declarative config: process_auto_fields", function()
         config = DeclarativeConfig:process_auto_fields(config, "select", false)
         assert.same({
           _format_version = "1.1",
+          _transform = true,
           plugins = {
             {
               _comment = "my comment",
@@ -185,6 +190,7 @@ describe("declarative config: process_auto_fields", function()
         config = DeclarativeConfig:process_auto_fields(config, "select", false)
         assert.same({
           _format_version = "1.1",
+          _transform = true,
           plugins = {
             {
               route = "foo",
@@ -233,6 +239,7 @@ describe("declarative config: process_auto_fields", function()
           config = DeclarativeConfig:process_auto_fields(config, "select", false)
           assert.same({
             _format_version = "1.1",
+            _transform = true,
             services = {
               {
                 name = "foo",
@@ -280,6 +287,7 @@ describe("declarative config: process_auto_fields", function()
           config = DeclarativeConfig:process_auto_fields(config, "select", false)
           assert.same({
             _format_version = "1.1",
+            _transform = true,
             services = {
               {
                 name = "foo",
@@ -372,6 +380,7 @@ describe("declarative config: process_auto_fields", function()
           config = DeclarativeConfig:process_auto_fields(config, "select", false)
           assert.same({
             _format_version = "1.1",
+            _transform = true,
             services = {
               {
                 name = "foo",
@@ -418,6 +427,7 @@ describe("declarative config: process_auto_fields", function()
           config = DeclarativeConfig:process_auto_fields(config, "select", false)
           assert.same({
             _format_version = "1.1",
+            _transform = true,
             services = {
               {
                 name = "foo",
@@ -503,6 +513,7 @@ describe("declarative config: process_auto_fields", function()
           config = DeclarativeConfig:process_auto_fields(config, "select", false)
           assert.same({
             _format_version = "1.1",
+            _transform = true,
             services = {
               {
                 name = "foo",
@@ -565,6 +576,7 @@ describe("declarative config: process_auto_fields", function()
           config = DeclarativeConfig:process_auto_fields(config, "select", false)
           assert.same({
             _format_version = "1.1",
+            _transform = true,
             services = {
               {
                 name = "foo",
@@ -677,6 +689,7 @@ describe("declarative config: process_auto_fields", function()
         config = DeclarativeConfig:process_auto_fields(config, "select", false)
         assert.same({
           _format_version = "1.1",
+          _transform = true,
           oauth2_credentials = {}
         }, config)
       end)
@@ -696,6 +709,7 @@ describe("declarative config: process_auto_fields", function()
         config = DeclarativeConfig:process_auto_fields(config, "select", false)
         assert.same({
           _format_version = "1.1",
+          _transform = true,
           oauth2_credentials = {
             {
               client_type = "confidential",
@@ -727,6 +741,7 @@ describe("declarative config: process_auto_fields", function()
           config = DeclarativeConfig:process_auto_fields(config, "select", false)
           assert.same({
             _format_version = "1.1",
+            _transform = true,
             consumers = {
               {
                 username = "bob",
@@ -752,6 +767,7 @@ describe("declarative config: process_auto_fields", function()
           config = DeclarativeConfig:process_auto_fields(config, "select", false)
           assert.same({
             _format_version = "1.1",
+            _transform = true,
             consumers = {
               {
                 username = "bob",
@@ -788,6 +804,7 @@ describe("declarative config: process_auto_fields", function()
           config = DeclarativeConfig:process_auto_fields(config, "select", false)
           assert.same({
             _format_version = "1.1",
+            _transform = true,
             oauth2_credentials = {
               {
                 client_type = "confidential",
@@ -815,6 +832,7 @@ describe("declarative config: process_auto_fields", function()
           config = DeclarativeConfig:process_auto_fields(config, "select", false)
           assert.same({
             _format_version = "1.1",
+            _transform = true,
             oauth2_credentials = {
               {
                 client_type = "confidential",

--- a/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
+++ b/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
@@ -37,11 +37,16 @@ local function idempotent(tbl, err)
   assert.table(tbl, err)
 
   for entity, items in sortedpairs(tbl) do
-    local new = {}
-    for _, item in sortedpairs(items, sort_by_key) do
-      table.insert(new, item)
+    if entity:sub(1,1) ~= "_" and type(items) == "table" then
+      local new = {}
+      for _, item in sortedpairs(items, sort_by_key) do
+        table.insert(new, item)
+      end
+
+      tbl[entity] = new
+    else
+      tbl[entity] = nil
     end
-    tbl[entity] = new
   end
 
   local function recurse_fields(t)

--- a/spec/02-integration/02-cmd/11-config_spec.lua
+++ b/spec/02-integration/02-cmd/11-config_spec.lua
@@ -401,6 +401,7 @@ describe("kong config", function()
     table.sort(toplevel_keys)
     assert.same({
       "_format_version",
+      "_transform",
       "acls",
       "consumers",
       "keyauth_credentials",
@@ -410,6 +411,7 @@ describe("kong config", function()
     }, toplevel_keys)
 
     assert.equals("1.1", yaml._format_version)
+    assert.equals(false, yaml._transform)
 
     assert.equals(2, #yaml.services)
     table.sort(yaml.services, sort_by_name)

--- a/spec/02-integration/02-cmd/11-config_spec.lua
+++ b/spec/02-integration/02-cmd/11-config_spec.lua
@@ -410,7 +410,7 @@ describe("kong config", function()
       "services",
     }, toplevel_keys)
 
-    assert.equals("1.1", yaml._format_version)
+    assert.equals("1.2", yaml._format_version)
     assert.equals(false, yaml._transform)
 
     assert.equals(2, #yaml.services)

--- a/spec/02-integration/03-db/08-declarative_spec.lua
+++ b/spec/02-integration/03-db/08-declarative_spec.lua
@@ -230,7 +230,7 @@ for _, strategy in helpers.each_strategy() do
           "snis"
         }, toplevel_keys)
 
-        assert.equals("1.1", yaml._format_version)
+        assert.equals("1.2", yaml._format_version)
         assert.equals(false, yaml._transform)
 
         assert.equals(1, #yaml.snis)

--- a/spec/02-integration/04-admin_api/15-off_spec.lua
+++ b/spec/02-integration/04-admin_api/15-off_spec.lua
@@ -4,6 +4,7 @@ local pl_utils = require "pl.utils"
 local helpers  = require "spec.helpers"
 local Errors   = require "kong.db.errors"
 local mocker   = require("spec.fixtures.mocker")
+local lyaml    = require "lyaml"
 
 local WORKER_SYNC_TIMEOUT = 10
 
@@ -602,14 +603,17 @@ describe("Admin API #off", function()
 
         local body = assert.response(res).has.status(200)
         local json = cjson.decode(body)
-        local expected_config =
-          "_transform: false\n" ..
-          "_format_version: '1.1'\n" ..
-          "consumers:\n" ..
-          "- created_at: 1566863706\n" ..
-          "  username: bobo\n" ..
-          "  id: d885e256-1abe-5e24-80b6-8f68fe59ea8e\n"
-        assert.same(expected_config, json.config)
+        local config = assert(lyaml.load(json.config))
+        assert.same({
+          _format_version = "1.2",
+          _transform = false,
+          consumers = {
+            { id = "d885e256-1abe-5e24-80b6-8f68fe59ea8e",
+              created_at = 1566863706,
+              username = "bobo",
+            },
+          },
+        }, config)
       end)
     end)
 

--- a/spec/02-integration/04-admin_api/15-off_spec.lua
+++ b/spec/02-integration/04-admin_api/15-off_spec.lua
@@ -602,7 +602,9 @@ describe("Admin API #off", function()
 
         local body = assert.response(res).has.status(200)
         local json = cjson.decode(body)
-        local expected_config = "_format_version: '1.1'\n" ..
+        local expected_config =
+          "_transform: false\n" ..
+          "_format_version: '1.1'\n" ..
           "consumers:\n" ..
           "- created_at: 1566863706\n" ..
           "  username: bobo\n" ..


### PR DESCRIPTION
Alternative name for this PR: feat/declarative config _transform.

This change fixes #5649 (basic-auth credentials not working on hybrid mode).

It is an alternative to #5792 where the proposed fix involves adding a new pseudo-field called `encrypted_password` to the entities.

The main drawback of that approach is that it requires manually changing all the entities which have transformations. Moreover, the change seems to be nearly identical in all cases: making a pseudo-field which in effect deactivates the transformation.

On this take, we add a new parameter to the declarative config file itself. The field is called `_transform`. When this field is present and set to `false`, the transformations are not executed when exporting. If the field is not present, or if it is, but it's set to `true`, the transformations are executed (which is the current behavior).

This approach does not require individual changes to any entities - a single flag in the top-level yaml is enough.

However, since this flag is new, the yaml version needed to be bumped up.

Also, this approach assumes that *on export*, we never want to do transformations (`_transform` is `false` on all exports). If we ever encounter a situation in which we *do* want to have transformations even after a straight db export, we will need to find a different way.
