### PR TITLE
docs(admin-api) add examples using arrays

### DIFF
--- a/autodoc/data/admin-api.lua
+++ b/autodoc/data/admin-api.lua
@@ -78,6 +78,32 @@ return {
         config.limit=10&config.period=seconds
         ```
 
+        When specifying arrays send the values in order, or use square brackets (numbering
+        inside the brackets is optional but if provided it must be 1-indexed, and
+        consecutive). An example route added to a service named `test-service`:
+
+        ```
+        curl -i -X POST http://localhost:8001/services/test-service/routes \
+             -d "name=test-route" \
+             -d "paths[1]=/path/one" \
+             -d "paths[2]=/path/two"
+        ```
+
+        The following two are identical to the one above, but less explicit:
+        ```
+        curl -i -X POST http://localhost:8001/services/test-service/routes \
+             -d "name=test-route" \
+             -d "paths[]=/path/one" \
+             -d "paths[]=/path/two"
+
+        curl -i -X POST http://localhost:8001/services/test-service/routes \
+            -d "name=test-route" \
+            -d "paths=/path/one" \
+            -d "paths=/path/two"
+        ```
+
+
+
         - **application/json**
 
         Handy for complex bodies (ex: complex plugin configuration), in that case simply send
@@ -90,6 +116,14 @@ return {
                 "period": "seconds"
             }
         }
+        ```
+
+        An example adding a route to a service named `test-service`:
+
+        ```
+        curl -i -X POST http://localhost:8001/services/test-service/routes \
+             -H "Content-Type: application/json" \
+             -d '{"name": "test-route", "paths": [ "/path/one", "/path/two" ]}'
         ```
       ]]
     },

--- a/autodoc/data/admin-api.lua
+++ b/autodoc/data/admin-api.lua
@@ -66,7 +66,29 @@ return {
     }, {
       title = [[Supported Content Types]],
       text = [[
-        The Admin API accepts 2 content types on every endpoint:
+        The Admin API accepts 3 content types on every endpoint:
+
+        - **application/json**
+
+        Handy for complex bodies (ex: complex plugin configuration), in that case simply send
+        a JSON representation of the data you want to send. Example:
+
+        ```json
+        {
+            "config": {
+                "limit": 10,
+                "period": "seconds"
+            }
+        }
+        ```
+
+        An example adding a route to a service named `test-service`:
+
+        ```
+        curl -i -X POST http://localhost:8001/services/test-service/routes \
+             -H "Content-Type: application/json" \
+             -d '{"name": "test-route", "paths": [ "/path/one", "/path/two" ]}'
+        ```
 
         - **application/x-www-form-urlencoded**
 
@@ -103,27 +125,25 @@ return {
         ```
 
 
+        - **multipart/form-data**
 
-        - **application/json**
+        Similar to url-encoded, this content type uses dotted keys to reference nested
+        objects. Here is an example of sending a Lua file to the pre-function Kong plugin:
 
-        Handy for complex bodies (ex: complex plugin configuration), in that case simply send
-        a JSON representation of the data you want to send. Example:
-
-        ```json
-        {
-            "config": {
-                "limit": 10,
-                "period": "seconds"
-            }
-        }
+        ```
+        curl -i -X POST http://localhost:8001/services/plugin-testing/plugins \
+             -F "name=pre-function" \
+             -F "config.access=@custom-auth.lua"
         ```
 
-        An example adding a route to a service named `test-service`:
+        When specifying arrays for this content-type the array indices must be specified.
+        An example route added to a service named `test-service`:
 
         ```
         curl -i -X POST http://localhost:8001/services/test-service/routes \
-             -H "Content-Type: application/json" \
-             -d '{"name": "test-route", "paths": [ "/path/one", "/path/two" ]}'
+             -F "name=test-route" \
+             -F "paths[1]=/path/one" \
+             -F "paths[2]=/path/two"
         ```
       ]]
     },


### PR DESCRIPTION
most pressing issue: example of array usage on the command line