### PR TITLE
chore(deps) bump Zipkin plugin to 1.1

### DIFF
--- a/kong-2.0.3-0.rockspec
+++ b/kong-2.0.3-0.rockspec
@@ -41,7 +41,7 @@ dependencies = {
   "lua-resty-ipmatcher == 0.6",
   -- external Kong plugins
   "kong-plugin-azure-functions ~> 0.4",
-  "kong-plugin-zipkin ~> 1.0",
+  "kong-plugin-zipkin ~> 1.1",
   "kong-plugin-serverless-functions ~> 1.0",
   "kong-prometheus-plugin ~> 0.8",
   "kong-proxy-cache-plugin ~> 1.3",


### PR DESCRIPTION
This is conditional on:

* Merging https://github.com/Kong/kong-plugin-zipkin/pull/78
* Releasing a new version of the rock to Luarocks
