### PR TITLE
fix(declarative) use correct cache page when worker respawns

### DIFF
--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -568,6 +568,11 @@ function declarative.load_into_cache_with_events(entities, hash)
     return nil, err
   end
 
+  ok, err = kong.core_cache:save_curr_page()
+  if not ok then
+    return nil, "failed to persist cache page number inside shdict: " .. err
+  end
+
   kong.core_cache:invalidate("router:version")
 
   ok, err = kong.worker_events.post("balancer", "upstreams", {

--- a/spec/02-integration/11-dbless/01-respawn_spec.lua
+++ b/spec/02-integration/11-dbless/01-respawn_spec.lua
@@ -1,0 +1,87 @@
+local helpers = require "spec.helpers"
+
+describe("worker respawn", function()
+  local admin_client, proxy_client
+
+  lazy_setup(function()
+    assert(helpers.start_kong({
+      database   = "off",
+    }))
+  end)
+
+  lazy_teardown(function()
+    helpers.stop_kong(nil, true)
+  end)
+
+  before_each(function()
+    admin_client = assert(helpers.admin_client())
+    proxy_client = assert(helpers.proxy_client())
+  end)
+
+  after_each(function()
+    if admin_client then
+      admin_client:close()
+    end
+
+    if proxy_client then
+      proxy_client:close()
+    end
+  end)
+
+  it("lands on the correct cache page #5799", function()
+    local res = assert(admin_client:send {
+      method = "POST",
+      path = "/config",
+      body = {
+        config = [[
+        _format_version: "1.1"
+        services:
+        - name: my-service
+          url: https://example.com
+          plugins:
+          - name: key-auth
+          routes:
+          - name: my-route
+            paths:
+            - /
+
+        consumers:
+        - username: my-user
+          keyauth_credentials:
+          - key: my-key
+        ]],
+      },
+      headers = {
+        ["Content-Type"] = "application/json"
+      }
+    })
+
+    assert.response(res).has.status(201)
+
+    local res = assert(proxy_client:get("/"))
+    assert.res_status(401, res)
+
+    res = assert(proxy_client:get("/", {
+      headers = {
+        apikey = "my-key"
+      }
+    }))
+    assert.res_status(200, res)
+
+    -- kill all the workers forcing all of them to respawn
+    helpers.signal_workers(nil, "-TERM")
+
+    proxy_client:close()
+    proxy_client = assert(helpers.proxy_client())
+
+    res = assert(proxy_client:get("/"))
+    assert.res_status(401, res)
+
+    res = assert(proxy_client:get("/", {
+      headers = {
+        apikey = "my-key"
+      }
+    }))
+    assert.res_status(200, res)
+  end)
+end)

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -2606,4 +2606,20 @@ end
 
     return kill.kill(pid_path, signal)
   end,
+  -- send signal to all Nginx workers, not including the master
+  signal_workers = function(prefix, signal, pid_path)
+    if not pid_path then
+      local running_conf = get_running_conf(prefix)
+      if not running_conf then
+        error("no config file found at prefix: " .. prefix)
+      end
+
+      pid_path = running_conf.nginx_pid
+    end
+
+    local cmd = string.format("pkill %s -P `cat %s`", signal, pid_path)
+    local _, code = pl_utils.execute(cmd)
+
+    return code
+  end,
 }


### PR DESCRIPTION
When worker respawns under DB-less mode, the `core_cache` is always uses
the first cache page. If the current page in use is the second page,
then the newly spawned worker will not be getting the correct view of
the configurations, causing undefined behaviors such as unexpected 404s
in router. This commit saves the `core_cache` page information inside
`shdict` so that new workers can always find the correct page to use.

fix #5799