### PR TITLE
fix(pdk) kong.ctx.plugin.* must be stored in ngx.ctx

### DIFF
--- a/kong/global.lua
+++ b/kong/global.lua
@@ -55,7 +55,7 @@ function _GLOBAL.set_named_ctx(self, name, key)
     error("ctx PDK module not initialized", 2)
   end
 
-  self.ctx.keys[name] = key
+  self.ctx.set(name, key)
 end
 
 

--- a/t/01-pdk/11-ctx.t
+++ b/t/01-pdk/11-ctx.t
@@ -65,3 +65,32 @@ GET /t
 world
 --- no_error_log
 [error]
+
+
+
+=== TEST 3: ctx.plugin namespace should be resetted between requests
+--- http_config
+    init_by_lua_block {
+        local PDK = require "kong.pdk"
+        pdk = PDK.new()
+    }
+--- config
+    location = /t {
+        content_by_lua_block {
+          pdk.ctx.set("plugin", "plugin")
+
+          ngx.exec("/a")
+        }
+    }
+
+    location = /a {
+        content_by_lua_block {
+          ngx.say(pdk.ctx.plugin)
+        }
+    }
+--- request
+GET /t
+--- response_body
+nil
+--- no_error_log
+[error]


### PR DESCRIPTION
### **Summary**

I'm working on a custom plugin that involves `redis.incr` and `redis.get` (almost same process than the rate-limiting plugin ).
I was surprised to see my redis key not follows my requests number (difference between 10% to 30%) when traffic increase.

This problem occurs when `syslog` or `prometheus` plugin are activated.

seems to be related to https://github.com/Kong/kong/issues/4379

### **Context**

In my plugin I set log in access phase: 

```
function plugin:access(plugin_conf)
  ...
  kong.log.inspect(kong.ctx)
  ...
end
```

**Run apachebench `ab -n 5 -c 1 ...` :**

everything ok, i see 5 times my plugin.

```
[kong] handler.lua:?:67 {                                                                                               
  keys = {                                                                                                              
    plugin = {                                                                                                          
      PRIORITY = 10,                                                                                                    
      VERSION = "0.1",                                                                                                  
      access = <function 1>,                                                                                            
      header_filter = <function 2>,                                                                                     
      log = <function 3>                                                                                                
    },                                                                                                                  
    <metatable> = {                                                                                                     
      __mode = "v"                                                                                                      
    }                                                                                                                   
  },                                                                                                                    
  <metatable> = {                                                                                                       
    __index = <function 4>                                                                                              
  }                                                                                                                     
}
```

**Run apachebench `ab -n 80 -c 50 ...` :**

Like previous, i see many log with plugin `PRIORITY = 10`.
But now, i also have some plugin `PRIORITY = 4` (which corresponds to syslog plugin)
```
[kong] handler.lua:?:67 {                                                                          
  keys = {                                                                                         
    plugin = {                                                                                     
      PRIORITY = 4,                                                                                
      VERSION = "2.0.0",                                                                           
      log = <function 1>                                                                           
    },                                                                                             
    <metatable> = {                                                                                
      __mode = "v"                                                                                 
    }                                                                                              
  },                                                                                               
  <metatable> = {                                                                                  
    __index = <function 2>                                                                         
  }                                                                                                
}
```

### **PDK problem research**

`kong.ctx.keys` which stores plugin is a VM-local variable and will be shared across multiple requests being handled by different coroutines.

### **Proposal**

Store plugin key in `ngx.ctx` because it isn't shared across requests.


