### PR TITLE
chore(makefile) make grpcurl part of dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ install:
 remove:
 	-@luarocks remove kong
 
-dependencies:
+dependencies: grpcurl
 	@for rock in $(DEV_ROCKS) ; do \
 	  if luarocks list --porcelain $$rock | grep -q "installed" ; then \
 	    echo $$rock already installed, skipping ; \
@@ -83,7 +83,7 @@ grpcurl:
 		https://github.com/fullstorydev/grpcurl/releases/download/v1.3.0/grpcurl_1.3.0_$(GRPCURL_OS)_$(MACHINE).tar.gz | tar xz -C bin;
 	@rm bin/LICENSE
 
-dev: remove install dependencies grpcurl
+dev: remove install dependencies
 
 lint:
 	@luacheck -q .


### PR DESCRIPTION
Our `make dev` "uninstall and then reinstall" phase makes it a bit
unfriendly to certain build systems (like pongo) which prefer to use
`make dependencies` instead.

One difference between `make dev` and `make dependencies` is
that the former installs grpcurl, but not the later.

This change moves the installation of grpcurl to `make dependencies`,
so it becomes "like `make dev` but without uninstalling and reinstalling".
