### PR TITLE
chore(conf) worker_rlimit_nofile & worker_connections "auto" == max 16384

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -653,6 +653,26 @@
 #   `nginx_admin_ssl_protocols`, both of which taking precedence over the
 #   `http {}` block.
 
+#nginx_main_worker_rlimit_nofile = auto
+                                 # Changes the limit on the maximum number of open files
+                                 # for worker processes.
+                                 #
+                                 # The special and default value of `auto` sets this
+                                 # value to `ulimit -n` with the upper bound limited to
+                                 # 16384 as a measure to protect against excess memory use.
+                                 #
+                                 # See http://nginx.org/en/docs/ngx_core_module.html#worker_rlimit_nofile
+
+#nginx_events_worker_connections = auto
+                                 # Sets the maximum number of simultaneous
+                                 # connections that can be opened by a worker process.
+                                 #
+                                 # The special and default value of `auto` sets this
+                                 # value to `ulimit -n` with the upper bound limited to
+                                 # 16384 as a measure to protect against excess memory use.
+                                 #
+                                 # See http://nginx.org/en/docs/ngx_core_module.html#worker_connections
+
 #nginx_upstream_keepalive = 60   # Sets the maximum number of idle keepalive
                                  # connections to upstream servers that are
                                  # preserved in the cache of each worker

--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -134,31 +134,31 @@ local function compile_conf(kong_config, conf_template)
   end
 
   do
-    local worker_rlimit_nofile
+    local worker_rlimit_nofile_auto
     if kong_config.nginx_main_directives then
       for _, directive in pairs(kong_config.nginx_main_directives) do
         if directive.name == "worker_rlimit_nofile" then
           if directive.value == "auto" then
-            worker_rlimit_nofile = directive
+            worker_rlimit_nofile_auto = directive
           end
           break
         end
       end
     end
 
-    local worker_connections
+    local worker_connections_auto
     if kong_config.nginx_events_directives then
       for _, directive in pairs(kong_config.nginx_events_directives) do
         if directive.name == "worker_connections" then
           if directive.value == "auto" then
-            worker_connections = directive
+            worker_connections_auto = directive
           end
           break
         end
       end
     end
 
-    if worker_connections or worker_rlimit_nofile then
+    if worker_connections_auto or worker_rlimit_nofile_auto then
       local value, err = get_ulimit()
       if not value then
         return nil, err
@@ -166,12 +166,12 @@ local function compile_conf(kong_config, conf_template)
 
       value = math.min(value, 16384)
 
-      if worker_rlimit_nofile then
-        worker_rlimit_nofile.value = value
+      if worker_rlimit_nofile_auto then
+        worker_rlimit_nofile_auto.value = value
       end
 
-      if worker_connections then
-        worker_connections.value = value
+      if worker_connections_auto then
+        worker_connections_auto.value = value
       end
     end
   end
@@ -392,6 +392,7 @@ local function prepare_prefix(kong_config, nginx_custom_template_path)
 end
 
 return {
+  get_ulimit = get_ulimit,
   prepare_prefix = prepare_prefix,
   compile_conf = compile_conf,
   compile_kong_conf = compile_kong_conf,

--- a/spec/01-unit/04-prefix_handler_spec.lua
+++ b/spec/01-unit/04-prefix_handler_spec.lua
@@ -643,6 +643,19 @@ describe("NGINX conf compiler", function()
       assert.matches("worker_connections%s+%d+;", nginx_conf)
       assert.matches("multi_accept%s+on;", nginx_conf)
     end)
+    it("compiles with correct auto values", function()
+      local conf = assert(conf_loader(nil, {
+        nginx_main_worker_rlimit_nofile = "auto",
+        nginx_events_worker_connections = "auto",
+      }))
+
+      local ulimit = prefix_handler.get_ulimit()
+      ulimit = math.min(ulimit, 16384)
+
+      local nginx_conf = prefix_handler.compile_nginx_conf(conf)
+      assert.matches("worker_rlimit_nofile%s+" .. ulimit .. ";", nginx_conf)
+      assert.matches("worker_connections%s+" .. ulimit .. ";", nginx_conf)
+    end)
     it("converts dns_resolver to string", function()
       local nginx_conf = prefix_handler.compile_nginx_conf({
         dns_resolver = { "8.8.8.8", "8.8.4.4" }


### PR DESCRIPTION
### Summary

- Adds a test for `nginx_main_worker_rlimit_nofile=auto` and
  `nginx_events_worker_connections=auto`
- Adds documentation for `nginx_main_worker_rlimit_nofile=auto` and
  `nginx_events_worker_connections=auto`
- Renames some variables to avoid further confusion