### PR TITLE
fix(globalpatches) increase the limit when encoding sparse array in Kong

### DIFF
--- a/kong/globalpatches.lua
+++ b/kong/globalpatches.lua
@@ -15,6 +15,9 @@ return function(options)
   local meta = require "kong.meta"
 
 
+  require("cjson.safe").encode_sparse_array(nil, nil, 512)
+
+
   if options.cli then
     -- disable the _G write guard alert log introduced in OpenResty 1.15.8.1
     -- when in CLI or when running tests in resty-cli

--- a/kong/globalpatches.lua
+++ b/kong/globalpatches.lua
@@ -15,7 +15,7 @@ return function(options)
   local meta = require "kong.meta"
 
 
-  require("cjson.safe").encode_sparse_array(nil, nil, 512)
+  require("cjson.safe").encode_sparse_array(nil, nil, 2^15)
 
 
   if options.cli then

--- a/spec/02-integration/04-admin_api/15-off_spec.lua
+++ b/spec/02-integration/04-admin_api/15-off_spec.lua
@@ -499,6 +499,78 @@ describe("Admin API #off", function()
           message = "expected a declarative configuration",
         }, json)
       end)
+
+      it("sparse responses are correctly generated", function()
+        local res = assert(client:send {
+          method = "POST",
+          path = "/config",
+          body = {
+            config = [[
+            {
+              "_format_version" : "1.1",
+              "plugins": [{
+                "name": "key-auth",
+                "enabled": true,
+                "protocols": ["http", "https"]
+              }, {
+                "name": "key-auth",
+                "enabled": true,
+                "protocols": ["http", "https"]
+              }, {
+                "name": "key-auth",
+                "enabled": true,
+                "protocols": ["http", "https"]
+              }, {
+                "name": "key-auth",
+                "enabled": true,
+                "protocols": ["http", "https"]
+              }, {
+                "name": "key-auth",
+                "enabled": true,
+                "protocols": ["http", "https"]
+              }, {
+                "name": "key-auth",
+                "enabled": true,
+                "protocols": ["http", "https"]
+              }, {
+                "name": "key-auth",
+                "enabled": true,
+                "protocols": ["http", "https"]
+              }, {
+                "name": "key-auth",
+                "enabled": true,
+                "protocols": ["http", "https"]
+              }, {
+                "name": "key-auth",
+                "enabled": true,
+                "protocols": ["http", "https"]
+              }, {
+                "name": "key-auth",
+                "enabled": true,
+                "protocols": ["http", "https"]
+              }, {
+                "name": "cors",
+                "config": {
+                  "credentials": true,
+                  "exposed_headers": ["*"],
+                  "headers": ["*"],
+                  "methods": ["*"],
+                  "origins": ["*"],
+                  "preflight_continue": true
+                },
+                "enabled": true,
+                "protocols": ["http", "https"]
+              }]
+            }
+            ]],
+          },
+          headers = {
+            ["Content-Type"] = "application/json"
+          }
+        })
+
+        assert.response(res).has.status(400)
+      end)
     end)
 
     describe("GET", function()


### PR DESCRIPTION
When Kong parses a declarative config, and when the declarative config
has a lot of entities and one of the high index entity has validation
errors, Kong may generate a JSON response message like this:

```
plugins = {
    [12] = {
        <schema errors>
    }
}
```

Unfortunately this causes the lua-cjson library to throw the
"Cannot serialise table: excessively sparse array" error. This PR
increases the limit of cjson so that these error won't happen with small
number of configurations.

fixes #5768

For discussion:

Is this the best way to solve it? cJSON provides another mode for dealing with excessively sparse arrays which is to convert numeric indices to hash tables. See: https://www.kyne.com.au/~mark/software/lua-cjson-manual.html#encode_sparse_array. That way we would never fail to encode the JSON object. However, once the excessively sparse threshold is reaches, the response is no longer in the format user expects and I suspect nobody will handle it correctly.