### PR TITLE
chore(deps) bump session plugin from 2.3.0 to 2.4.0

### DIFF
--- a/kong-2.0.4-0.rockspec
+++ b/kong-2.0.4-0.rockspec
@@ -46,7 +46,7 @@ dependencies = {
   "kong-prometheus-plugin ~> 0.8",
   "kong-proxy-cache-plugin ~> 1.3",
   "kong-plugin-request-transformer ~> 1.2",
-  "kong-plugin-session ~> 2.3",
+  "kong-plugin-session ~> 2.4",
   "kong-plugin-aws-lambda ~> 3.3",
   "kong-plugin-acme ~> 0.2",
   "kong-plugin-grpc-web ~> 0.1",


### PR DESCRIPTION
### Summary

- Fix Kong storage adapter to use `regenerate` strategy.
- Bumps `lua-resty-session` to `3.3`.