### PR TITLE
chore(targets) allow weight 0-65535 to match SRV records

### DIFF
--- a/kong/db/schema/entities/targets.lua
+++ b/kong/db/schema/entities/targets.lua
@@ -21,7 +21,7 @@ return {
     { created_at = typedefs.auto_timestamp_ms },
     { upstream   = { type = "foreign", reference = "upstreams", required = true, on_delete = "cascade" }, },
     { target     = { type = "string", required = true, custom_validator = validate_target, }, },
-    { weight     = { type = "integer", default = 100, between = { 0, 1000 }, }, },
+    { weight     = { type = "integer", default = 100, between = { 0, 65535 }, }, },
     { tags       = typedefs.tags },
   },
 }

--- a/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -26,7 +26,7 @@ describe("Admin API #" .. strategy, function()
   local bp
   local db
   local client
-  local weight_default, weight_min, weight_max = 100, 0, 1000
+  local weight_default, weight_min, weight_max = 100, 0, 65535
   local default_port = 8000
 
   lazy_setup(function()
@@ -224,7 +224,7 @@ describe("Admin API #" .. strategy, function()
             body = assert.response(res).has.status(400)
             local json = cjson.decode(body)
             assert.equal("schema violation", json.name)
-            assert.same({ weight = "value should be between 0 and 1000" }, json.fields)
+            assert.same({ weight = "value should be between 0 and " .. weight_max }, json.fields)
           end
         end)
 


### PR DESCRIPTION
The loadbalancer will honour SRV provided weights, and hence it makes sense for Kong to support the same range.

The "weight" range for targets was 0-1000, as enforced by Kong. The balancer will take those, and in case of an SRV it will override the given weights with the values retrieved from the SRV record (reason: Kong trusts the DNS server).

Now since SRV records have a 2-byte weight setting (0-65535), it would pick up a weight of 65535, if given in an SRV record, despite that the target definition only allows up to 1000.

Hence it makes sense for targets to also allow 0-65535 as a range.