### PR TITLE
fix(pdk) ensure 'kong.ctx.plugin' and 'kong.log' are light-threads safe

### DIFF
--- a/kong/global.lua
+++ b/kong/global.lua
@@ -91,7 +91,7 @@ function _GLOBAL.set_phase(self, phase)
 
   local kctx = self.ctx
   if not kctx then
-    error("ctx SDK module not initialized", 2)
+    error("ctx PDK module not initialized", 2)
   end
 
   kctx.core.phase = phase
@@ -136,94 +136,94 @@ do
 
     self.ctx.core.log = self.core_log
   end
+end
 
 
-  function _GLOBAL.init_pdk(self, kong_config, pdk_major_version)
-    if not self then
-      error("arg #1 cannot be nil", 2)
-    end
-
-    PDK.new(kong_config, pdk_major_version, self)
+function _GLOBAL.init_pdk(self, kong_config, pdk_major_version)
+  if not self then
+    error("arg #1 cannot be nil", 2)
   end
 
+  PDK.new(kong_config, pdk_major_version, self)
+end
 
-  function _GLOBAL.init_worker_events()
-    -- Note: worker_events will not work correctly if required at the top of the file.
-    --       It must be required right here, inside the init function
-    local worker_events = require "resty.worker.events"
 
-    local ok, err = worker_events.configure {
-      shm = "kong_process_events", -- defined by "lua_shared_dict"
-      timeout = 5,            -- life time of event data in shm
-      interval = 1,           -- poll interval (seconds)
+function _GLOBAL.init_worker_events()
+  -- Note: worker_events will not work correctly if required at the top of the file.
+  --       It must be required right here, inside the init function
+  local worker_events = require "resty.worker.events"
 
-      wait_interval = 0.010,  -- wait before retry fetching event data
-      wait_max = 0.5,         -- max wait time before discarding event
-    }
-    if not ok then
-      return nil, err
-    end
+  local ok, err = worker_events.configure {
+    shm = "kong_process_events", -- defined by "lua_shared_dict"
+    timeout = 5,            -- life time of event data in shm
+    interval = 1,           -- poll interval (seconds)
 
-    return worker_events
+    wait_interval = 0.010,  -- wait before retry fetching event data
+    wait_max = 0.5,         -- max wait time before discarding event
+  }
+  if not ok then
+    return nil, err
   end
 
+  return worker_events
+end
 
-  function _GLOBAL.init_cluster_events(kong_config, db)
-    return kong_cluster_events.new({
-      db            = db,
-      poll_interval = kong_config.db_update_frequency,
-      poll_offset   = kong_config.db_update_propagation,
-      poll_delay    = kong_config.db_update_propagation,
-    })
+
+function _GLOBAL.init_cluster_events(kong_config, db)
+  return kong_cluster_events.new({
+    db            = db,
+    poll_interval = kong_config.db_update_frequency,
+    poll_offset   = kong_config.db_update_propagation,
+    poll_delay    = kong_config.db_update_propagation,
+  })
+end
+
+
+function _GLOBAL.init_cache(kong_config, cluster_events, worker_events)
+  local db_cache_ttl = kong_config.db_cache_ttl
+  local cache_pages = 1
+  if kong_config.database == "off" then
+    db_cache_ttl = 0
+    cache_pages = 2
   end
 
+  return kong_cache.new {
+    shm_name          = "kong_db_cache",
+    cluster_events    = cluster_events,
+    worker_events     = worker_events,
+    ttl               = db_cache_ttl,
+    neg_ttl           = db_cache_ttl,
+    resurrect_ttl     = kong_config.resurrect_ttl,
+    cache_pages       = cache_pages,
+    resty_lock_opts   = {
+      exptime = 10,
+      timeout = 5,
+    },
+  }
+end
 
-  function _GLOBAL.init_cache(kong_config, cluster_events, worker_events)
-    local db_cache_ttl = kong_config.db_cache_ttl
-    local cache_pages = 1
-    if kong_config.database == "off" then
-      db_cache_ttl = 0
-      cache_pages = 2
-    end
 
-    return kong_cache.new {
-      shm_name          = "kong_db_cache",
-      cluster_events    = cluster_events,
-      worker_events     = worker_events,
-      ttl               = db_cache_ttl,
-      neg_ttl           = db_cache_ttl,
-      resurrect_ttl     = kong_config.resurrect_ttl,
-      cache_pages       = cache_pages,
-      resty_lock_opts   = {
-        exptime = 10,
-        timeout = 5,
-      },
-    }
+function _GLOBAL.init_core_cache(kong_config, cluster_events, worker_events)
+  local db_cache_ttl = kong_config.db_cache_ttl
+  local cache_pages = 1
+  if kong_config.database == "off" then
+    db_cache_ttl = 0
+    cache_pages = 2
   end
 
-
-  function _GLOBAL.init_core_cache(kong_config, cluster_events, worker_events)
-    local db_cache_ttl = kong_config.db_cache_ttl
-    local cache_pages = 1
-    if kong_config.database == "off" then
-      db_cache_ttl = 0
-      cache_pages = 2
-    end
-
-    return kong_cache.new {
-      shm_name          = "kong_core_db_cache",
-      cluster_events    = cluster_events,
-      worker_events     = worker_events,
-      ttl               = db_cache_ttl,
-      neg_ttl           = db_cache_ttl,
-      resurrect_ttl     = kong_config.resurrect_ttl,
-      cache_pages       = cache_pages,
-      resty_lock_opts   = {
-        exptime = 10,
-        timeout = 5,
-      },
-    }
-  end
+  return kong_cache.new {
+    shm_name          = "kong_core_db_cache",
+    cluster_events    = cluster_events,
+    worker_events     = worker_events,
+    ttl               = db_cache_ttl,
+    neg_ttl           = db_cache_ttl,
+    resurrect_ttl     = kong_config.resurrect_ttl,
+    cache_pages       = cache_pages,
+    resty_lock_opts   = {
+      exptime = 10,
+      timeout = 5,
+    },
+  }
 end
 
 

--- a/kong/global.lua
+++ b/kong/global.lua
@@ -99,10 +99,7 @@ end
 
 
 do
-  local log_facilities = {
-    core = nil,
-    namespaced = setmetatable({}, { __index = "k" }),
-  }
+  local log_facilities = setmetatable({}, { __index = "k" })
 
 
   function _GLOBAL.set_namespaced_log(self, namespace)
@@ -114,13 +111,17 @@ do
       error("namespace (arg #2) must be a string", 2)
     end
 
-    local log = log_facilities.namespaced[namespace]
-    if not log then
-      log = self.log.new(namespace) -- use default namespaced format
-      log_facilities.namespaced[namespace] = log
+    if not self.ctx then
+      error("ctx PDK module not initialized", 2)
     end
 
-    self.log = log
+    local log = log_facilities[namespace]
+    if not log then
+      log = self.core_log.new(namespace) -- use default namespaced format
+      log_facilities[namespace] = log
+    end
+
+    self.ctx.core.log = log
   end
 
 
@@ -129,7 +130,11 @@ do
       error("arg #1 cannot be nil", 2)
     end
 
-    self.log = log_facilities.core
+    if not self.ctx then
+      error("ctx PDK module not initialized", 2)
+    end
+
+    self.ctx.core.log = self.core_log
   end
 
 
@@ -139,8 +144,6 @@ do
     end
 
     PDK.new(kong_config, pdk_major_version, self)
-
-    log_facilities.core = self.log
   end
 
 

--- a/kong/global.lua
+++ b/kong/global.lua
@@ -51,11 +51,36 @@ function _GLOBAL.set_named_ctx(self, name, key)
     error("name cannot be an empty string", 2)
   end
 
+  if key == nil then
+    error("key cannot be nil", 2)
+  end
+
   if not self.ctx then
     error("ctx PDK module not initialized", 2)
   end
 
-  self.ctx.keys[name] = key
+  self.ctx.__set_namespace(name, key)
+end
+
+
+function _GLOBAL.del_named_ctx(self, name)
+  if not self then
+    error("arg #1 cannot be nil", 2)
+  end
+
+  if type(name) ~= "string" then
+    error("name must be a string", 2)
+  end
+
+  if #name == 0 then
+    error("name cannot be an empty string", 2)
+  end
+
+  if not self.ctx then
+    error("ctx PDK module not initialized", 2)
+  end
+
+  self.ctx.__del_namespace(name)
 end
 
 

--- a/kong/pdk/ctx.lua
+++ b/kong/pdk/ctx.lua
@@ -4,11 +4,16 @@
 
 
 local ngx = ngx
+local ngx_get_phase = ngx.get_phase
 
 
 -- shared between all global instances
 local _CTX_SHARED_KEY = {}
 local _CTX_CORE_KEY = {}
+
+
+-- dynamic namespaces, also shared between global instances
+local _CTX_NAMESPACES_KEY = {}
 
 
 ---
@@ -86,19 +91,58 @@ local _CTX_CORE_KEY = {}
 --
 --   kong.log(value) -- "hello world"
 -- end
+
+
 local function new(self)
-  local _CTX = {
-    -- those would be visible on the *.ctx namespace for now
-    -- TODO: hide them in a private table shared between this
-    -- module and the global.lua one
-    keys = setmetatable({}, { __mode = "v" }),
-  }
-
-
+  local _CTX = {}
   local _ctx_mt = {}
+  local _ns_mt = { __mode = "v" }
+
+
+  local function get_namespaces(nctx)
+    local namespaces = nctx[_CTX_NAMESPACES_KEY]
+    if not namespaces then
+      -- 4 namespaces for request, i.e. ~4 plugins
+      namespaces = self.table.new(0, 4)
+      nctx[_CTX_NAMESPACES_KEY] = setmetatable(namespaces, _ns_mt)
+    end
+
+    return namespaces
+  end
+
+
+  local function set_namespace(namespace, namespace_key)
+    local nctx = ngx.ctx
+    local namespaces = get_namespaces(nctx)
+
+    local ns = namespaces[namespace]
+    if ns and ns == namespace_key then
+      return
+    end
+
+    namespaces[namespace] = namespace_key
+  end
+
+
+  local function del_namespace(namespace)
+    local nctx = ngx.ctx
+    local namespaces = get_namespaces(nctx)
+    namespaces[namespace] = nil
+  end
 
 
   function _ctx_mt.__index(t, k)
+    if k == "__set_namespace" then
+      return set_namespace
+
+    elseif k == "__del_namespace" then
+      return del_namespace
+    end
+
+    if ngx_get_phase() == "init" then
+      return
+    end
+
     local nctx = ngx.ctx
     local key
 
@@ -109,7 +153,8 @@ local function new(self)
       key = _CTX_SHARED_KEY
 
     else
-      key = t.keys[k]
+      local namespaces = get_namespaces(nctx)
+      key = namespaces[k]
     end
 
     if key then

--- a/kong/pdk/init.lua
+++ b/kong/pdk/init.lua
@@ -211,7 +211,7 @@ assert(package.loaded["resty.core"])
 
 local MAJOR_VERSIONS = {
   [1] = {
-    version = "1.3.0",
+    version = "1.3.1",
     modules = {
       "table",
       "node",

--- a/kong/pdk/init.lua
+++ b/kong/pdk/init.lua
@@ -294,7 +294,24 @@ function _PDK.new(kong_config, major_version, self)
     parent[child] = mod.new(self)
   end
 
-  return self
+  self._log = self.log
+  self.log = nil
+
+  return setmetatable(self, {
+    __index = function(t, k)
+      if k == "core_log" then
+        return rawget(t, "_log")
+      end
+
+      if k == "log" then
+        if t.ctx.core and t.ctx.core.log then
+          return t.ctx.core.log
+        end
+
+        return rawget(t, "_log")
+      end
+    end
+  })
 end
 
 

--- a/kong/pdk/log.lua
+++ b/kong/pdk/log.lua
@@ -442,7 +442,9 @@ do
       self.print = nop
     end
 
+
     self.on()
+
 
     return setmetatable(self, _inspect_mt)
   end

--- a/t/01-pdk/05-client/09-load-consumer.t
+++ b/t/01-pdk/05-client/09-load-consumer.t
@@ -126,4 +126,3 @@ GET /t
 cannot load a consumer with an id that is not a uuid
 --- no_error_log
 [error]
-


### PR DESCRIPTION
This PR replaces #5851 because it provides a more robust implementation and fixes several other issues.

### kong.ctx

* Store namespace keys in `ngx.ctx` to ensure all dynamically generated namespaces are isolated on a per-request basis.
* Introduce a new global API (which is a private API for use by core only) to explicitly delete a namespace.

A note on the benefits of this new implementation compared to #5851:

* By using a table to keep track of namespaces in `ngx.ctx`, we ensure that users of `ngx.ctx` cannot access the table namespaces, thus properly isolating it and avoiding polluting `ngx.ctx` for core and/or plugins. We can think of it as a double-pointer reference to the namespace. Each request gets a pre-allocated table for 4 namespaces (of course not limited to 4), with the assumption that most instances do not execute more than 4 plugins using `kong.ctx.plugin` at a time.
* We ensure that namespace key references cannot be `nil` to ensure a safe usage from the core.
* All namespace key references are still weak when assigned to a namespace, thus tying the lifetime of the namespace to that of its key reference. Similarly to the previous implementation, this is done to
ensure we avoid potential memory leaks. That said, the `kong.ctx.plugin` namespace does use the plugin's conf for that purpose anymore (See 40dc146), which alleviates such concerns in the current usage of this API.
* All tables allocated for namespace key references and namespaces keys themselves will be released when `ngx.ctx` will be GC'ed.
* We also ensure than `kong.ctx.*` returns `nil` when `ngx.ctx` is not supported ("init" phase).

### kong.log

* Store current logging facility in `kong.ctx.core` to ensure that multiple concurrent request do not share the same `kong.log` Lua global facility.
* Log facilities are still cached in a local upvalue to avoid re-recreating them for every incoming request.

A note on the current implementation: unlike the `kong.ctx` PDK module, the `kong.log` module does not encapsulate its namespacing capabilities. Doing so would be more efficient, as we would avoid having to create multiple `kong.log` instances. Instead, a singleton instance could keep track of the different namespaces (and their assigned logging formats) itself.

Fix #4379
Fix #5853
Fix #5057
See #5851
See #5459