### PR TITLE
refactor(plugins) rate-limiting/response-ratelimiting

### DIFF
--- a/kong/plugins/rate-limiting/schema.lua
+++ b/kong/plugins/rate-limiting/schema.lua
@@ -43,7 +43,7 @@ return {
           }, },
           { policy = {
               type = "string",
-              default = "cluster",
+              default = "local",
               len_min = 0,
               one_of = { "local", "cluster", "redis" },
           }, },

--- a/kong/plugins/response-ratelimiting/schema.lua
+++ b/kong/plugins/response-ratelimiting/schema.lua
@@ -36,7 +36,7 @@ return {
                          one_of = { "consumer", "credential", "ip" },
           }, },
           { policy = { type = "string",
-                       default = "cluster",
+                       default = "local",
                        one_of = { "local", "cluster", "redis" },
           }, },
           { fault_tolerant = { type = "boolean", default = true }, },

--- a/spec/03-plugins/23-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/04-access_spec.lua
@@ -512,7 +512,7 @@ for _, strategy in helpers.each_strategy() do
 
             bp.rate_limiting_plugins:insert {
               route = { id = route1.id },
-              config   = { minute = 6, fault_tolerant = false }
+              config   = { minute = 6, fault_tolerant = false, policy = policy }
             }
 
             local route2 = bp.routes:insert {
@@ -522,7 +522,7 @@ for _, strategy in helpers.each_strategy() do
             bp.rate_limiting_plugins:insert {
               name     = "rate-limiting",
               route = { id = route2.id },
-              config   = { minute = 6, fault_tolerant = true },
+              config   = { minute = 6, fault_tolerant = true, policy = policy },
             }
 
             assert(helpers.start_kong({


### PR DESCRIPTION
rate-limiting/response-ratelimiting update default policy to 'local'

Whether there is a database, 'local' can run very well.

Use db-less mode will be more and more.