### PR TITLE
fix(plugins) config.anonymous = "" in auth plugins

### DIFF
--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1560,7 +1560,7 @@ function Schema:process_auto_fields(data, context, nulls)
 
   for key, field in self:each_field(data) do
 
-    if field.legacy and field.uuid and data[key] == "" then
+    if field.type == "string" and field.legacy and data[key] == "" then
       data[key] = null
     end
 

--- a/kong/plugins/basic-auth/schema.lua
+++ b/kong/plugins/basic-auth/schema.lua
@@ -9,7 +9,7 @@ return {
     { config = {
         type = "record",
         fields = {
-          { anonymous = { type = "string" }, },
+          { anonymous = { type = "string", legacy = true }, },
           { hide_credentials = { type = "boolean", default = false }, },
     }, }, },
   },

--- a/kong/plugins/hmac-auth/schema.lua
+++ b/kong/plugins/hmac-auth/schema.lua
@@ -19,7 +19,7 @@ return {
         fields = {
           { hide_credentials = { type = "boolean", default = false }, },
           { clock_skew = { type = "number", default = 300, gt = 0 }, },
-          { anonymous = { type = "string" }, },
+          { anonymous = { type = "string", legacy = true }, },
           { validate_request_body = { type = "boolean", default = false }, },
           { enforce_headers = {
               type = "array",

--- a/kong/plugins/jwt/schema.lua
+++ b/kong/plugins/jwt/schema.lua
@@ -26,7 +26,7 @@ return {
                 type = "string",
                 one_of = { "exp", "nbf" },
           }, }, },
-          { anonymous = { type = "string" }, },
+          { anonymous = { type = "string", legacy = true }, },
           { run_on_preflight = { type = "boolean", default = true }, },
           { maximum_expiration = {
             type = "number",

--- a/kong/plugins/key-auth/schema.lua
+++ b/kong/plugins/key-auth/schema.lua
@@ -16,7 +16,7 @@ return {
               default = { "apikey" },
           }, },
           { hide_credentials = { type = "boolean", default = false }, },
-          { anonymous = { type = "string" }, },
+          { anonymous = { type = "string", legacy = true }, },
           { key_in_body = { type = "boolean", default = false }, },
           { run_on_preflight = { type = "boolean", default = true }, },
         },

--- a/kong/plugins/ldap-auth/schema.lua
+++ b/kong/plugins/ldap-auth/schema.lua
@@ -22,7 +22,7 @@ return {
           { hide_credentials = { type = "boolean", default = false }, },
           { timeout = { type = "number", default = 10000 }, },
           { keepalive = { type = "number", default = 60000 }, },
-          { anonymous = { type = "string" }, },
+          { anonymous = { type = "string", legacy = true }, },
           { header_type = { type = "string", default = "ldap" }, },
         },
         entity_checks = {

--- a/kong/plugins/oauth2/schema.lua
+++ b/kong/plugins/oauth2/schema.lua
@@ -30,7 +30,7 @@ return {
           { enable_password_grant = { type = "boolean", default = false, required = true }, },
           { hide_credentials = { type = "boolean", default = false, required = true }, },
           { accept_http_if_already_terminated = { type = "boolean", default = false }, },
-          { anonymous = { type = "string" }, },
+          { anonymous = { type = "string", legacy = true }, },
           { global_credentials = { type = "boolean", default = false }, },
           { auth_header_name = { type = "string", default = "authorization" }, },
           { refresh_token_ttl = { type = "number", default = 1209600, required = true }, },

--- a/spec/03-plugins/09-key-auth/02-access_spec.lua
+++ b/spec/03-plugins/09-key-auth/02-access_spec.lua
@@ -72,6 +72,10 @@ for _, strategy in helpers.each_strategy() do
         hosts = { "key-auth10.com" },
       }
 
+      local route11 = bp.routes:insert {
+        hosts = { "key-auth11.com" },
+      }
+
       bp.plugins:insert {
         name     = "key-auth",
         route = { id = route1.id },
@@ -152,6 +156,14 @@ for _, strategy in helpers.each_strategy() do
         route = { id = route10.id },
         config = {
           anonymous = anonymous_user.username,
+        },
+      }
+
+      bp.plugins:insert {
+        name     = "key-auth",
+        route = { id = route11.id },
+        config = {
+          anonymous = "",
         },
       }
 
@@ -618,6 +630,16 @@ for _, strategy in helpers.each_strategy() do
         local body = cjson.decode(assert.res_status(200, res))
         assert.equal('true', body.headers["x-anonymous-consumer"])
         assert.equal('no-body', body.headers["x-consumer-username"])
+      end)
+      it("config.anonymous = '' (empty string) fails with #401", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/request",
+          headers = {
+            ["Host"] = "key-auth11.com"
+          }
+        })
+        assert.res_status(401, res)
       end)
       it("errors when anonymous user doesn't exist", function()
         local res = assert(proxy_client:send {

--- a/spec/03-plugins/10-basic-auth/03-access_spec.lua
+++ b/spec/03-plugins/10-basic-auth/03-access_spec.lua
@@ -45,6 +45,10 @@ for _, strategy in helpers.each_strategy() do
         hosts = { "basic-auth5.com" },
       }
 
+      local route6 = bp.routes:insert {
+        hosts = { "basic-auth6.com" },
+      }
+
       bp.plugins:insert {
         name     = "basic-auth",
         route = { id = route1.id },
@@ -97,6 +101,14 @@ for _, strategy in helpers.each_strategy() do
         route = { id = route5.id },
         config   = {
           anonymous = anonymous_user.username,
+        },
+      }
+
+      bp.plugins:insert {
+        name     = "basic-auth",
+        route = { id = route6.id },
+        config   = {
+          anonymous = "",
         },
       }
 
@@ -362,6 +374,17 @@ for _, strategy in helpers.each_strategy() do
         local body = cjson.decode(assert.res_status(200, res))
         assert.equal('true', body.headers["x-anonymous-consumer"])
         assert.equal('no-body', body.headers["x-consumer-username"])
+      end)
+
+      it("config.anonymous = '' (empty string) fails with #401", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/request",
+          headers = {
+            ["Host"] = "basic-auth6.com"
+          }
+        })
+        assert.res_status(401, res)
       end)
 
       it("errors when anonymous user doesn't exist", function()

--- a/spec/03-plugins/16-jwt/03-access_spec.lua
+++ b/spec/03-plugins/16-jwt/03-access_spec.lua
@@ -38,7 +38,7 @@ for _, strategy in helpers.each_strategy() do
 
       local routes = {}
 
-      for i = 1, 13 do
+      for i = 1, 14 do
         routes[i] = bp.routes:insert {
           hosts = { "jwt" .. i .. ".com" },
         }
@@ -133,6 +133,12 @@ for _, strategy in helpers.each_strategy() do
         name     = "jwt",
         route = { id = routes[13].id },
         config   = { anonymous = anonymous_user.username },
+      })
+
+      plugins:insert({
+        name     = "jwt",
+        route = { id = routes[14].id },
+        config   = { anonymous = "" },
       })
 
       plugins:insert({
@@ -788,6 +794,16 @@ for _, strategy in helpers.each_strategy() do
         assert.equal('true', body.headers["x-anonymous-consumer"])
         assert.equal('no-body', body.headers["x-consumer-username"])
         assert.equal(nil, body.headers["x-credential-identifier"])
+      end)
+      it("config.anonymous = '' (empty string) fails with #401", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/request",
+          headers = {
+            ["Host"] = "jwt14.com"
+          }
+        })
+        assert.res_status(401, res)
       end)
       it("errors when anonymous user doesn't exist", function()
         local res = assert(proxy_client:send {

--- a/spec/03-plugins/25-oauth2/03-access_spec.lua
+++ b/spec/03-plugins/25-oauth2/03-access_spec.lua
@@ -170,6 +170,7 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
       local service11   = admin_api.services:insert()
       local service12   = admin_api.services:insert()
       local service13   = admin_api.services:insert()
+      local service14   = admin_api.services:insert()
 
       local route1 = assert(admin_api.routes:insert({
         hosts     = { "oauth2.com" },
@@ -253,6 +254,12 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
         hosts       = { "oauth2_13.com" },
         protocols   = { "http", "https" },
         service     = service13,
+      }))
+
+      local route14 = assert(admin_api.routes:insert({
+        hosts       = { "oauth2_14.com" },
+        protocols   = { "http", "https" },
+        service     = service14,
       }))
 
       admin_api.oauth2_plugins:insert({
@@ -357,6 +364,14 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
         config   = {
           scopes    = { "email", "profile", "user.email" },
           anonymous = anonymous_user.username,
+        },
+      })
+
+      admin_api.oauth2_plugins:insert({
+        route = { id = route14.id },
+        config   = {
+          scopes    = { "email", "profile", "user.email" },
+          anonymous = "",
         },
       })
 
@@ -1986,6 +2001,16 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
         assert.are.equal("true", body.headers["x-anonymous-consumer"])
         assert.equal('no-body', body.headers["x-consumer-username"])
       end)
+      it("config.anonymous = '' (empty string) fails with #401", function()
+        local res = assert(proxy_ssl_client:send {
+          method  = "POST",
+          path    = "/request",
+          headers = {
+            ["Host"] = "oauth2_14.com"
+          }
+        })
+        assert.res_status(401, res)
+      end)  
       it("errors when anonymous user doesn't exist", function()
         finally(function()
           if proxy_ssl_client then


### PR DESCRIPTION
Fix https://github.com/Kong/kong/issues/5653

We could not configure an auth plugin with config.anonymous="" in CE 2.0
or EE 1.5.

It also broke users that had config.anonymous="" configured in legacy. To
reproduce, create an auth plugin with config.anonymous="" (empty string)
in 0.13, then upgrade all the way to 2.0.

This is the breaking change: https://github.com/Kong/kong/pull/5552

---

We have three options to fix it:

(a) a migration;
(b) start special-casing "" to mean null for this field in the code of
these plugins;
(c) add legacy back to those anonymous fields of string type fields,
meaning that in legacy fields "" auto-translates to null

This is the execution of (c).

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

