### PR TITLE
feat(balancer): expose balancer_health even when healthchecks are off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,14 @@
 - Allow configuring custom error templates
   [#10374](https://github.com/Kong/kong/pull/10374)
 
+#### Admin API
+
+- The `/upstreams/<upstream>/health?balancer_health=1` endpoint always shows the balancer health,
+  through a new attribute balancer_health, which always returns HEALTHY or UNHEALTHY (reporting
+  the true state of the balancer), even if the overall upstream health status is HEALTHCHECKS_OFF.
+  This is useful for debugging.
+  [#5885](https://github.com/Kong/kong/pull/5885)
+
 #### Plugins
 
 - **ACME**: acme plugin now supports configuring an `account_key` in `keys` and `key_sets`

--- a/kong/runloop/balancer/healthcheckers.lua
+++ b/kong/runloop/balancer/healthcheckers.lua
@@ -358,7 +358,10 @@ function healthcheckers_M.get_balancer_health(upstream_id)
   end
 
   local healthchecker
-  local balancer_status
+
+  local balancer_status = balancer:getStatus()
+  local balancer_health = balancer_status.healthy and "HEALTHY" or "UNHEALTHY"
+
   local health = "HEALTHCHECKS_OFF"
   if is_upstream_using_healthcheck(upstream) then
     healthchecker = balancer.healthchecker
@@ -366,12 +369,12 @@ function healthcheckers_M.get_balancer_health(upstream_id)
       return nil, "healthchecker not found"
     end
 
-    balancer_status = balancer:getStatus()
-    health = balancer_status.healthy and "HEALTHY" or "UNHEALTHY"
+    health = balancer_health
   end
 
   return {
     health = health,
+    balancer_health = balancer_health,
     id = upstream_id,
     details = balancer_status,
   }

--- a/spec/02-integration/05-proxy/10-balancer/01-healthchecks_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer/01-healthchecks_spec.lua
@@ -381,8 +381,13 @@ for _, strategy in helpers.each_strategy() do
         assert.is.table(health.data[1])
         assert.equals("HEALTHCHECKS_OFF", health.data[1].health)
         assert.equals("HEALTHCHECKS_OFF", health.data[1].data.addresses[1].health)
-      end, 15)
 
+        local balancer_health = bu.get_balancer_health(upstream_name)
+        assert.is.table(balancer_health)
+        assert.is.table(balancer_health.data)
+        assert.equals("HEALTHCHECKS_OFF", balancer_health.data.health)
+        assert.equals("HEALTHY", balancer_health.data.balancer_health)
+      end, 15)
     end)
 
     it("an upstream that is removed and readed keeps the health status", function()
@@ -1207,7 +1212,7 @@ for _, strategy in helpers.each_strategy() do
                   name = "pre-function",
                   service = { id = service_id },
                   config = {
-                    header_filter ={ 
+                    header_filter ={
                       [[
                         ngx.exit(200)
                     ]],
@@ -1329,8 +1334,10 @@ for _, strategy in helpers.each_strategy() do
 
                 if health_threshold[i] < 100 then
                   assert.equals("HEALTHY", health.data.health)
+                  assert.equals("HEALTHY", health.data.balancer_health)
                 else
                   assert.equals("UNHEALTHY", health.data.health)
+                  assert.equals("UNHEALTHY", health.data.balancer_health)
                 end
 
                 -- 75% healthy
@@ -1348,8 +1355,10 @@ for _, strategy in helpers.each_strategy() do
 
                 if health_threshold[i] < 75 then
                   assert.equals("HEALTHY", health.data.health)
+                  assert.equals("HEALTHY", health.data.balancer_health)
                 else
                   assert.equals("UNHEALTHY", health.data.health)
+                  assert.equals("UNHEALTHY", health.data.balancer_health)
                 end
 
                 -- 50% healthy
@@ -1489,7 +1498,7 @@ for _, strategy in helpers.each_strategy() do
                   local requests = bu.SLOTS * 2 -- go round the balancer twice
                   local port1 = helpers.get_available_port()
                   local port2 = helpers.get_available_port()
-  
+
                   -- setup target servers:
                   -- server2 will only respond for part of the test,
                   -- then server1 will take over.
@@ -1498,7 +1507,7 @@ for _, strategy in helpers.each_strategy() do
                   local server2 = https_server.new(port2, "localhost", "http", true)
                   server1:start()
                   server2:start()
-  
+
                   -- configure healthchecks
                   bu.begin_testcase_setup(strategy, bp)
                   local upstream_name, upstream_id = bu.add_upstream(bp, {


### PR DESCRIPTION
The Kong load balancer has concepts of upstream health, which is managed by the healthchecker, and balancer health, which is affected by the healthchecker but also affected by the balancer "health threshold" setting. This means a _balancer_ can be unhealthy (and return HTTP 503) even when healthchecks for the upstream are disabled.

The endpoint `/upstreams/<upstream>/health?balancer_health=1` is an "advanced mode" for viewing health, which shows the _balancer health_ as opposed to upstream health. (It is hidden behind a query argument to avoid confusion, as for most cases the upstream health is sufficient and the "balancer" terminology referring to a mostly internal Kong object may also be unclear to end-users.) This endpoint, however, only returns the balancer health, when healthchecks for upstream health are enabled. 

This PR changes this behavior so that using `?balancer_health=1` we can always see the balancer health, through a new attribute `balancer_health`, which always returns `HEALTHY` or `UNHEALTHY` (reporting the true state of the balancer), even if the overall upstream health status is `HEALTHCHECKS_OFF`. This is useful for debugging.

The original attribute `health` is preserved with the existing semantics for backward compatibility, returning `HEALTHY`, `UNHEALTHY` or `HEALTHCHECKS_OFF`.
