### PR TITLE
chore(deps) bump kong-lapis to from 1.8.1.1 to 1.8.1.2

### DIFF
--- a/kong-2.0.4-0.rockspec
+++ b/kong-2.0.4-0.rockspec
@@ -20,7 +20,7 @@ dependencies = {
   "lua-ffi-zlib == 0.5",
   "multipart == 0.5.6",
   "version == 1.0.1",
-  "kong-lapis == 1.8.1.1",
+  "kong-lapis == 1.8.1.2",
   "lua-cassandra == 1.5.0",
   "pgmoon == 1.11.0",
   "luatz == 0.4",


### PR DESCRIPTION
### Summary

- uses `lua-resty-openssl` instead of `luaossl` fixes kong start issue
  with `next` packages.