### PR TITLE
feat(pdk) add the client.tls PDK module to provide downstream mTLS re…

### DIFF
--- a/kong-2.0.4-0.rockspec
+++ b/kong-2.0.4-0.rockspec
@@ -194,6 +194,7 @@ build = {
     ["kong.pdk.private.checks"] = "kong/pdk/private/checks.lua",
     ["kong.pdk.private.phases"] = "kong/pdk/private/phases.lua",
     ["kong.pdk.client"] = "kong/pdk/client.lua",
+    ["kong.pdk.client.tls"] = "kong/pdk/client/tls.lua",
     ["kong.pdk.ctx"] = "kong/pdk/ctx.lua",
     ["kong.pdk.ip"] = "kong/pdk/ip.lua",
     ["kong.pdk.log"] = "kong/pdk/log.lua",

--- a/kong/pdk/client/tls.lua
+++ b/kong/pdk/client/tls.lua
@@ -1,0 +1,110 @@
+---
+-- The client.tls module provides functions for interacting with TLS
+-- connections from client.
+--
+-- @module kong.client.tls
+
+
+local phase_checker = require "kong.pdk.private.phases"
+local kong_tls = require "resty.kong.tls"
+
+
+local check_phase = phase_checker.check
+
+
+local PHASES = phase_checker.phases
+local REWRITE_AND_LATER = phase_checker.new(PHASES.rewrite,
+                                            PHASES.access,
+                                            PHASES.balancer,
+                                            PHASES.log)
+
+
+local function new()
+  local _TLS = {}
+
+
+  ---
+  -- Requests client to present its client-side certificate to initiate mutual
+  -- TLS authentication between server and client.
+  --
+  -- This function only *requests*, but does not *require* the client to start
+  -- the mTLS process. Even if the client did not present a client certificate
+  -- the TLS handshake will still complete (obviously not being mTLS in that
+  -- case). Whether the client honored the request can be determined using
+  -- get_full_client_certificate_chain in later phases.
+  --
+  -- @function kong.client.tls.request_client_certificate
+  -- @phases certificate
+  -- @treturn true|nil true if request was received, nil if request failed
+  -- @treturn nil|err nil if success, or error message if failure
+  --
+  -- @usage
+  -- local res, err = kong.client.tls.request_client_certificate()
+  -- if not res then
+  --   -- do something with err
+  -- end
+  function _TLS.request_client_certificate()
+    check_phase(PHASES.certificate)
+
+    return kong_tls.request_client_certificate()
+  end
+
+
+  ---
+  -- Prevents the TLS session for the current connection from being reused
+  -- by disabling session ticket and session ID for the current TLS connection.
+  --
+  -- @function kong.client.tls.disable_session_reuse
+  -- @phases certificate
+  -- @treturn true|nil true if success, nil if failed
+  -- @treturn nil|err nil if success, or error message if failure
+  --
+  -- @usage
+  -- local res, err = kong.client.tls.disable_session_reuse()
+  -- if not res then
+  --   -- do something with err
+  -- end
+  function _TLS.disable_session_reuse()
+    check_phase(PHASES.certificate)
+
+    return kong_tls.disable_session_reuse()
+  end
+
+
+  ---
+  -- Returns the PEM encoded downstream client certificate chain with the
+  -- client certificate at the top and intermediate certificates
+  -- (if any) at the bottom.
+  --
+  -- @function kong.client.tls.get_full_client_certificate_chain
+  -- @phases rewrite, access, balancer, header_filter, body_filter, log
+  -- @treturn string|nil PEM-encoded client certificate if mTLS handshake
+  -- was completed, nil if an error occurred or client did not present
+  -- its certificate
+  -- @treturn nil|err nil if success, or error message if failure
+  --
+  -- @usage
+  -- local cert, err = kong.client.get_full_client_certificate_chain()
+  -- if err then
+  --   -- do something with err
+  -- end
+  --
+  -- if not cert then
+  --   -- client did not complete mTLS
+  -- end
+  --
+  -- -- do something with cert
+  function _TLS.get_full_client_certificate_chain()
+    check_phase(REWRITE_AND_LATER)
+
+    return kong_tls.get_full_client_certificate_chain()
+  end
+
+
+  return _TLS
+end
+
+
+return {
+  new = new,
+}

--- a/kong/pdk/init.lua
+++ b/kong/pdk/init.lua
@@ -232,6 +232,9 @@ local MAJOR_VERSIONS = {
   latest = 1,
 }
 
+if ngx.config.subsystem == 'http' then
+  table.insert(MAJOR_VERSIONS[1].modules, 'client.tls')
+end
 
 local _PDK = {
   major_versions = MAJOR_VERSIONS,

--- a/t/01-pdk/14-client-tls/00-phase_checks.t
+++ b/t/01-pdk/14-client-tls/00-phase_checks.t
@@ -1,0 +1,109 @@
+use strict;
+use warnings FATAL => 'all';
+use Test::Nginx::Socket::Lua;
+use t::Util;
+
+$ENV{TEST_NGINX_CERT_DIR} ||= File::Spec->catdir(server_root(), '..', 'certs');
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
+
+plan tests => repeat_each() * (blocks() * 2);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: verify phase checking in kong.client.tls
+--- http_config eval
+qq{
+    $t::Util::HttpConfig
+
+    server {
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock ssl;
+        ssl_certificate $ENV{TEST_NGINX_CERT_DIR}/test.crt;
+        ssl_certificate_key $ENV{TEST_NGINX_CERT_DIR}/test.key;
+
+        ssl_certificate_by_lua_block {
+            phase_check_functions(phases.certificate)
+        }
+
+        location / {
+            set \$upstream_uri '/t';
+            set \$upstream_scheme 'https';
+
+            rewrite_by_lua_block {
+                phase_check_functions(phases.rewrite)
+            }
+
+            access_by_lua_block {
+                phase_check_functions(phases.access)
+                phase_check_functions(phases.admin_api)
+            }
+
+            header_filter_by_lua_block {
+                phase_check_functions(phases.header_filter)
+            }
+
+            body_filter_by_lua_block {
+                phase_check_functions(phases.body_filter)
+            }
+
+            log_by_lua_block {
+                phase_check_functions(phases.log)
+            }
+
+            return 200;
+        }
+    }
+
+    init_worker_by_lua_block {
+        phases = require("kong.pdk.private.phases").phases
+
+        phase_check_module = "client.tls"
+        phase_check_data = {
+            {
+                method        = "request_client_certificate",
+                args          = {},
+                init_worker   = false,
+                certificate   = true,
+                rewrite       = false,
+                access        = false,
+                header_filter = false,
+                body_filter   = false,
+                log           = false,
+                admin_api     = false,
+            }, {
+                method        = "disable_session_reuse",
+                args          = {},
+                init_worker   = false,
+                certificate   = true,
+                rewrite       = false,
+                access        = false,
+                header_filter = false,
+                body_filter   = false,
+                log           = false,
+                admin_api     = false,
+            }, {
+                method        = "get_full_client_certificate_chain",
+                args          = {},
+                init_worker   = false,
+                certificate   = false,
+                rewrite       = true,
+                access        = true,
+                header_filter = false,
+                body_filter   = false,
+                log           = true,
+                admin_api     = false,
+            },
+        }
+
+        phase_check_functions(phases.init_worker)
+    }
+}
+--- config
+    location /t {
+        proxy_pass https://unix:$TEST_NGINX_NXSOCK/nginx.sock;
+    }
+--- request
+GET /t
+--- no_error_log
+[error]


### PR DESCRIPTION
…lated functions

This module initially provides function bindings to functions inside the
lua-kong-nginx-module C module. Simple phase check tests are
added. No need to individually test the functions themselves since they
were already extensively tested inside lua-kong-nginx-module and the PDK
functions are simply a wrapper around them.