### PR TITLE
chore(deps) bump aws-lambda plugin to 3.4.0

### DIFF
--- a/kong-2.0.4-0.rockspec
+++ b/kong-2.0.4-0.rockspec
@@ -47,7 +47,7 @@ dependencies = {
   "kong-proxy-cache-plugin ~> 1.3",
   "kong-plugin-request-transformer ~> 1.2",
   "kong-plugin-session ~> 2.4",
-  "kong-plugin-aws-lambda ~> 3.3",
+  "kong-plugin-aws-lambda ~> 3.4",
   "kong-plugin-acme ~> 0.2",
   "kong-plugin-grpc-web ~> 0.1",
 }


### PR DESCRIPTION
## aws-lambda 3.4.0 12-May-2020

- Change `luaossl` to `lua-resty-openssl`
- fix: do not validate region name against hardcoded list of regions
- feat: add `host` configuration to allow for custom Lambda endpoints