### PR TITLE
fix(schema) transformation validation is skipped when it should not

### DIFF
--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1326,11 +1326,9 @@ local function run_transformation_checks(self, input, original_input, rbw_entity
       for _, input_field_name in ipairs(transformation.needs) do
         if rbw_entity and not needs_changed then
           local value = get_field(original_input or input, input_field_name)
-          if is_nonempty(value) then
-            local rbw_value = get_field(rbw_entity, input_field_name)
-            if value ~= rbw_value then
-              needs_changed = true
-            end
+          local rbw_value = get_field(rbw_entity, input_field_name)
+          if value ~= rbw_value then
+            needs_changed = true
           end
         end
 

--- a/spec/02-integration/03-db/11-db_transformations_spec.lua
+++ b/spec/02-integration/03-db/11-db_transformations_spec.lua
@@ -1,0 +1,71 @@
+local helpers = require "spec.helpers"
+
+
+local fmt = string.format
+
+
+for _, strategy in helpers.each_strategy() do
+  describe("kong.db [#" .. strategy .. "]", function()
+    local _, db
+
+    lazy_setup(function()
+      _, db = helpers.get_db_utils(strategy, {
+        "transformations",
+      }, {
+        "transformations"
+      })
+
+      local env = {}
+      env.database = strategy
+      env.plugins = env.plugins or "transformations"
+
+      local lua_path = [[ KONG_LUA_PATH_OVERRIDE="./spec/fixtures/migrations/?.lua;]] ..
+                       [[./spec/fixtures/migrations/?/init.lua;]]                     ..
+                       [[./spec/fixtures/custom_plugins/?.lua;]]                      ..
+                       [[./spec/fixtures/custom_plugins/?/init.lua;" ]]
+
+      local cmdline = "migrations up -c " .. helpers.test_conf_path
+      local _, code, _, stderr = helpers.kong_exec(cmdline, env, true, lua_path)
+      assert.same(0, code)
+      assert.equal("", stderr)
+    end)
+
+    describe("Transformations", function()
+      describe(":update()", function()
+        local errmsg = fmt("[%s] schema violation (all or none of these fields must be set: 'hash_secret', 'secret')",
+                           strategy)
+
+        it("updating secret requires hash_secret", function()
+          local dao = assert(db.transformations:insert({
+            name = "test"
+          }))
+
+          local newdao, err = db.transformations:update({ id = dao.id }, {
+            secret = "dog",
+          })
+
+          assert.equal(nil, newdao)
+          assert.equal(errmsg, err)
+
+          assert(db.transformations:delete({ id = dao.id }))
+        end)
+
+        it("updating hash_secret requires secret", function()
+          local dao = assert(db.transformations:insert({
+            name = "test"
+          }))
+
+          local newdao, err = db.transformations:update({ id = dao.id }, {
+            hash_secret = true,
+          })
+
+          assert.equal(nil, newdao)
+          assert.equal(errmsg, err)
+
+          assert(db.transformations:delete({ id = dao.id }))
+        end)
+      end)
+    end)
+
+  end) -- kong.db [strategy]
+end

--- a/spec/fixtures/custom_plugins/kong/plugins/transformations/daos.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/transformations/daos.lua
@@ -1,0 +1,31 @@
+local typedefs = require "kong.db.schema.typedefs"
+
+
+return {
+  {
+    name = "transformations",
+    primary_key = { "id" },
+    endpoint_key = "name",
+    fields = {
+      { id = typedefs.uuid },
+      { name = { type = "string" }, },
+      { secret = { type = "string", required = false, auto = true }, },
+      { hash_secret = { type = "boolean", required = true, default = false }, },
+    },
+    transformations = {
+      {
+        input = { "hash_secret" },
+        needs = { "secret" },
+        on_write = function(hash_secret, client_secret)
+          if not hash_secret then
+            return {}
+          end
+          local hash = assert(ngx.md5(client_secret))
+          return {
+            secret = hash,
+          }
+        end,
+      },
+    },
+  },
+}

--- a/spec/fixtures/custom_plugins/kong/plugins/transformations/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/transformations/handler.lua
@@ -1,0 +1,3 @@
+return {
+  PRIORITY = 1
+}

--- a/spec/fixtures/custom_plugins/kong/plugins/transformations/migrations/000_base_transformations.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/transformations/migrations/000_base_transformations.lua
@@ -1,0 +1,23 @@
+return {
+  postgres = {
+    up = [[
+      CREATE TABLE IF NOT EXISTS "transformations" (
+        "id"          UUID  PRIMARY KEY,
+        "name"        TEXT,
+        "secret"      TEXT,
+        "hash_secret" BOOLEAN
+      );
+    ]],
+  },
+
+  cassandra = {
+    up = [[
+      CREATE TABLE IF NOT EXISTS transformations (
+        id          uuid PRIMARY KEY,
+        name        text,
+        secret      text,
+        hash_secret boolean
+      );
+    ]],
+  },
+}

--- a/spec/fixtures/custom_plugins/kong/plugins/transformations/migrations/init.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/transformations/migrations/init.lua
@@ -1,0 +1,3 @@
+return {
+  "000_base_transformations",
+}

--- a/spec/fixtures/custom_plugins/kong/plugins/transformations/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/transformations/schema.lua
@@ -1,0 +1,12 @@
+return {
+  name = "transformations",
+  fields = {
+    {
+      config = {
+        type = "record",
+        fields = {
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Summary

This fixes issue when trying to merge master to next. The problem is because `next` now has read-before-write on updates, but it also added oauth2 credentials transformation and related tests. One of those tests starts to fail if trying to merge master to next. The test itself is fine.

The problematic test is this:
https://github.com/Kong/kong/blob/next/spec/03-plugins/25-oauth2/02-api_spec.lua#L522-L540

```lua
it("updating client_secret requires hash_secret", function()
  local res = assert(admin_client:send {
    method  = "PATCH",
    path    = "/consumers/bob/oauth2/" .. credential.id,
    body    = {
      client_secret = "test",
    },
    headers = {
      ["Content-Type"] = "application/json"
    }
  })
  local body = assert.res_status(400, res)
  local json = cjson.decode(body)
  assert.same({
    ["@entity"] = {
      "all or none of these fields must be set: 'hash_secret', 'client_secret'"
    }
  }, json.fields)
end)
```

The `status` code there is actually `200`, so the implicit transformations validation is skipped in that case.

This commit fixes that issue and allows us then to merge master to next without this test failing.