### PR TITLE
fix(schema) make process auto fields to remove empty strings on select

### DIFF
--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1614,8 +1614,18 @@ function Schema:process_auto_fields(data, context, nulls)
     end
 
     for key in pairs(data) do
-      -- set non defined fields to nil, except meta fields (ttl) if enabled
-      if not self.fields[key] then
+      local field = self.fields[key]
+      if field then
+        if not field.legacy
+           and field.type == "string"
+           and (field.len_min or 1) > 0
+           and data[key] == ""
+        then
+          data[key] = nulls and null or nil
+        end
+
+      else
+        -- set non defined fields to nil, except meta fields (ttl) if enabled
         if not self.ttl or key ~= "ttl" then
           data[key] = nil
         end

--- a/spec/01-unit/01-db/01-schema/01-schema_spec.lua
+++ b/spec/01-unit/01-db/01-schema/01-schema_spec.lua
@@ -2692,6 +2692,109 @@ describe("schema", function()
       assert.same(ngx.null, data.i)
     end)
 
+    it("produces nil for empty string fields with selects", function()
+      local Test = Schema.new({
+        fields = {
+          { str = { type = "string" }, },
+          { rec = { type = "record", fields = { {
+            str = { type = "string" }, }, {
+            arr = { type = "array", elements = { type = "string" } }, }, {
+            set = { type = "set", elements = { type = "string" } }, }, {
+            map = { type = "map", keys = { type = "string" }, values = { type = "string" } }, }, {
+            est = { type = "string", len_min = 0 }, }, {
+            lst = { type = "string", legacy = true }, }, } } },
+          { arr = { type = "array", elements = { type = "string" } }, },
+          { set = { type = "set", elements = { type = "string" } }, },
+          { map = { type = "map", keys = { type = "string" }, values = { type = "string" } }, },
+          { est = { type = "string", len_min = 0 }, },
+          { lst = { type = "string", legacy = true }, },
+        }
+      })
+      local data, err = Test:process_auto_fields({
+        str = "",
+        rec = {
+          str = "",
+          arr = { "", "a", "" },
+          set = { "", "a", "" },
+          map = { key = "" },
+          est = "",
+          lst = "",
+        },
+        arr = { "", "a", "" },
+        set = { "", "a", "" },
+        map = { key = "" },
+        est = "",
+        lst = "",
+      }, "select")
+
+      assert.is_nil(err)
+      assert.equal(nil, data.str)              -- string
+      assert.same({"", "a", ""}, data.arr)     -- array, TODO: should we remove empty strings from arrays?
+      assert.same({"", "a" }, data.set)        -- set,   TODO: should we remove empty strings from sets?
+      assert.same({ key = "" }, data.map)      -- map,   TODO: should we remove empty strings from maps?
+      assert.equal("", data.est)
+      assert.equal("", data.lst)
+
+      -- record
+      assert.equal(nil, data.rec.str)          -- string
+      assert.same({"", "a", ""}, data.rec.arr) -- array, TODO: should we remove empty strings from arrays?
+      assert.same({"", "a" }, data.rec.set)    -- set,   TODO: should we remove empty strings from sets?
+      assert.same({ key = "" }, data.rec.map)  -- map,   TODO: should we remove empty strings from maps?
+      assert.equal("", data.rec.est)
+      assert.equal("", data.rec.lst)
+    end)
+
+    it("produces ngx.null (when asked) for empty string fields with selects", function()
+      local Test = Schema.new({
+        fields = {
+          { str = { type = "string" }, },
+          { rec = { type = "record", fields = { {
+            str = { type = "string" }, }, {
+            arr = { type = "array", elements = { type = "string" } }, }, {
+            set = { type = "set", elements = { type = "string" } }, }, {
+            map = { type = "map", keys = { type = "string" }, values = { type = "string" } }, }, {
+            est = { type = "string", len_min = 0 }, }, {
+            lst = { type = "string", legacy = true }, }, } } },
+          { arr = { type = "array", elements = { type = "string" } }, },
+          { set = { type = "set", elements = { type = "string" } }, },
+          { map = { type = "map", keys = { type = "string" }, values = { type = "string" } }, },
+          { est = { type = "string", len_min = 0 }, },
+          { lst = { type = "string", legacy = true }, },
+        }
+      })
+      local data, err = Test:process_auto_fields({
+        str = "",
+        rec = {
+          str = "",
+          arr = { "", "a", "" },
+          set = { "", "a", "" },
+          map = { key = "" },
+          est = "",
+          lst = "",
+        },
+        arr = { "", "a", "" },
+        set = { "", "a", "" },
+        map = { key = "" },
+        est = "",
+        lst = "",
+      }, "select", true)
+      assert.is_nil(err)
+      assert.equal(cjson.null, data.str)       -- string
+      assert.same({"", "a", ""}, data.arr)     -- array, TODO: should we set null empty strings from arrays?
+      assert.same({"", "a" }, data.set)        -- set,   TODO: should we set null empty strings from sets?
+      assert.same({ key = "" }, data.map)      -- map,   TODO: should we set null empty strings from maps?
+      assert.equal("", data.est)
+      assert.equal("", data.lst)
+
+      -- record
+      assert.equal(cjson.null, data.rec.str)   -- string
+      assert.same({"", "a", ""}, data.rec.arr) -- array, TODO: should we set null empty strings from arrays?
+      assert.same({"", "a" }, data.rec.set)    -- set,   TODO: should we set null empty strings from sets?
+      assert.same({ key = "" }, data.rec.map)  -- map,   TODO: should we set null empty strings from maps?
+      assert.equal("", data.rec.est)
+      assert.equal("", data.rec.lst)
+    end)
+
     it("does not produce non-required fields on 'update'", function()
       local Test = Schema.new({
         fields = {


### PR DESCRIPTION
### Summary

On PR #5879 @murillopaula proposed a fix to a common but arbitrary plugin field called `config.anonymous`. The PR tried to tackle two things at the same time. It tried to infer `JSON` input (which we don't do), and it tried to fix issue where upgraded databases still contained empty strings `""` stored to `config.anonymous` (instead of `null`). This only fixes the issue for this field. It also added `legacy` flag to that field, which in my opinion the field is not, or that it is not any special to any other field that could contain empty string `""`. So I didn't think it was a good idea to start flagging fields to `legacy` one by one.

Thus I discussed this with @murillopaula and out of those discussions came one winner that we both agreed upon. The solution is to run automatic transformation on `select` to database fields that are not legacy, and convert the value to `nil` (remove field) or `null` (when nulls were requested). This is implemented directly in `process_auto_fields` which we call automatically on daos. The solution looks like this:

```lua
if context == "select"
   and not field.legacy
   and field.type == "string"
   and (field.len_min or 1) > 0
   and data[key] == ""
then
  data[key] = nulls and null or nil
end
```

This fixes the issue for all the fields that are updated to new schema which if not `len_min=0` will not accept `""` as input, and thus are auto-translated to `nil`/`null` on read if they exists as `""` in db.

### Issues resolved

Fix #5653 (the database `""`)
Close #5879 (previous attempt)