### PR TITLE
fix(declarative) when loading declarative config, remove null values

### DIFF
--- a/kong/api/routes/config.lua
+++ b/kong/api/routes/config.lua
@@ -14,8 +14,7 @@ local tostring = tostring
 -- Do not accept Lua configurations from the Admin API
 -- because it is Turing-complete.
 local accept = {
-  yaml = true,
-  json = true,
+  yaml_and_json = true,
 }
 
 local _reports = {

--- a/kong/cmd/config.lua
+++ b/kong/cmd/config.lua
@@ -12,8 +12,7 @@ local DEFAULT_FILE = "./kong.yml"
 
 
 local accepted_formats = {
-  yaml = true,
-  json = true,
+  yaml_and_json = true,
   lua = true,
 }
 

--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -18,6 +18,7 @@ local next         = next
 local log          = ngx.log
 local fmt          = string.format
 local match        = string.match
+local remove_nulls = utils.remove_nulls
 
 
 local ERR          = ngx.ERR
@@ -36,18 +37,6 @@ end
 local _M    = {}
 local DAO   = {}
 DAO.__index = DAO
-
-
-local function remove_nulls(tbl)
-  for k,v in pairs(tbl) do
-    if v == null then
-      tbl[k] = nil
-    elseif type(v) == "table" then
-      tbl[k] = remove_nulls(v)
-    end
-  end
-  return tbl
-end
 
 
 local function validate_size_type(size)

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -8,6 +8,7 @@ local plugin_loader = require("kong.db.schema.plugin_loader")
 
 
 local null = ngx.null
+local remove_nulls = utils.remove_nulls
 
 
 local DeclarativeConfig = {}
@@ -556,6 +557,8 @@ end
 
 local function flatten(self, input)
   local output = {}
+
+  remove_nulls(input)
 
   local ok, err = self:validate(input)
   if not ok then


### PR DESCRIPTION
properly

When declarative config with `null` value is passed in YAML or JSON, the
lyaml parser will return it's own variant of `null` representation that
is different from cJSON. Causing schema validations to fail with type
error.

This commit adds `lyaml.null` support to the `remove_nulls` helper to
make sure they are always properly removed from the input.

This commit also removes the use of `cjson` when parsing JSON input and
instead always use the lyaml library. Because when user specifies a
string payload inside the `config` parameter when POSTing to the
`/config` admin API endpoint, the lyaml parser has always been used.
Note the [YAML Specification](https://yaml.org/spec/1.2/spec.html)
specifically calls "The primary objective of this revision is to bring
YAML into compliance with JSON as an official subset."

Because JSON is a subset of YAML and libyaml supports parsing JSON out
of the box, we can use lyaml for both YAML and JSON config when parsing
declarative config. This avoids different code path when loading JSON
encoded declarative config using the CLI and using the admin API to make
sure they always present the same result and fail with the same messages
for the user.

fixes #5834