### PR TITLE
[proposal] perf(basic-auth-v2) introduces basic-auth-v2 plugin with better performance

### DIFF
--- a/kong-2.0.4-0.rockspec
+++ b/kong-2.0.4-0.rockspec
@@ -219,6 +219,14 @@ build = {
     ["kong.plugins.basic-auth.schema"] = "kong/plugins/basic-auth/schema.lua",
     ["kong.plugins.basic-auth.daos"] = "kong/plugins/basic-auth/daos.lua",
 
+    ["kong.plugins.basic-auth-v2.migrations"] = "kong/plugins/basic-auth-v2/migrations/init.lua",
+    ["kong.plugins.basic-auth-v2.migrations.000_base_basic_auth_v2"] = "kong/plugins/basic-auth-v2/migrations/000_base_basic_auth_v2.lua",
+    ["kong.plugins.basic-auth-v2.crypto"] = "kong/plugins/basic-auth-v2/crypto.lua",
+    ["kong.plugins.basic-auth-v2.handler"] = "kong/plugins/basic-auth-v2/handler.lua",
+    ["kong.plugins.basic-auth-v2.access"] = "kong/plugins/basic-auth-v2/access.lua",
+    ["kong.plugins.basic-auth-v2.schema"] = "kong/plugins/basic-auth-v2/schema.lua",
+    ["kong.plugins.basic-auth-v2.daos"] = "kong/plugins/basic-auth-v2/daos.lua",
+
     ["kong.plugins.key-auth.migrations"] = "kong/plugins/key-auth/migrations/init.lua",
     ["kong.plugins.key-auth.migrations.000_base_key_auth"] = "kong/plugins/key-auth/migrations/000_base_key_auth.lua",
     ["kong.plugins.key-auth.migrations.002_130_to_140"] = "kong/plugins/key-auth/migrations/002_130_to_140.lua",

--- a/kong/plugins/basic-auth-v2/access.lua
+++ b/kong/plugins/basic-auth-v2/access.lua
@@ -1,0 +1,222 @@
+local crypto = require "kong.plugins.basic-auth-v2.crypto"
+local constants = require "kong.constants"
+
+
+local decode_base64 = ngx.decode_base64
+local re_gmatch = ngx.re.gmatch
+local re_match = ngx.re.match
+local error = error
+local kong = kong
+
+
+local realm = 'Basic realm="' .. _KONG._NAME .. '"'
+
+
+local _M = {}
+
+
+-- Fast lookup for credential retrieval depending on the type of the authentication
+--
+-- All methods must respect:
+--
+-- @param request ngx request object
+-- @param {table} conf Plugin config
+-- @return {string} public_key
+-- @return {string} private_key
+local function retrieve_credentials(header_name, conf)
+  local username, password
+  local authorization_header = kong.request.get_header(header_name)
+
+  if authorization_header then
+    local iterator, iter_err = re_gmatch(authorization_header, "\\s*[Bb]asic\\s*(.+)")
+    if not iterator then
+      kong.log.err(iter_err)
+      return
+    end
+
+    local m, err = iterator()
+    if err then
+      kong.log.err(err)
+      return
+    end
+
+    if m and m[1] then
+      local decoded_basic = decode_base64(m[1])
+      if decoded_basic then
+        local basic_parts, err = re_match(decoded_basic, "([^:]+):(.*)", "oj")
+        if err then
+          kong.log.err(err)
+          return
+        end
+
+        if not basic_parts then
+          kong.log.err("header has unrecognized format")
+          return
+        end
+
+        username = basic_parts[1]
+        password = basic_parts[2]
+      end
+    end
+  end
+
+  if conf.hide_credentials then
+    kong.service.request.clear_header(header_name)
+  end
+
+  return username, password
+end
+
+
+--- Validate a credential in the Authorization header against one fetched from the database.
+-- @param credential The retrieved credential from the username passed in the request
+-- @param given_password The password as given in the Authorization header
+-- @return Success of authentication
+local function validate_credentials(credential, given_password)
+  local digest, err = crypto.hash(credential.consumer.id, given_password)
+  if err then
+    kong.log.err(err)
+  end
+
+  return credential.password == digest
+end
+
+
+local function load_credential_into_memory(username)
+  local credential, err = kong.db.basicauth_credentials_v2:select_by_username(username)
+  if err then
+    return nil, err
+  end
+  return credential
+end
+
+
+local function load_credential_from_db(username)
+  if not username then
+    return
+  end
+
+  local credential_cache_key = kong.db.basicauth_credentials_v2:cache_key(username)
+  local credential, err      = kong.cache:get(credential_cache_key, nil,
+                                              load_credential_into_memory,
+                                              username)
+  if err then
+    return error(err)
+  end
+
+  return credential
+end
+
+
+local function set_consumer(consumer, credential)
+  kong.client.authenticate(consumer, credential)
+
+  local set_header = kong.service.request.set_header
+  local clear_header = kong.service.request.clear_header
+
+  if consumer and consumer.id then
+    set_header(constants.HEADERS.CONSUMER_ID, consumer.id)
+  else
+    clear_header(constants.HEADERS.CONSUMER_ID)
+  end
+
+  if consumer and consumer.custom_id then
+    set_header(constants.HEADERS.CONSUMER_CUSTOM_ID, consumer.custom_id)
+  else
+    clear_header(constants.HEADERS.CONSUMER_CUSTOM_ID)
+  end
+
+  if consumer and consumer.username then
+    set_header(constants.HEADERS.CONSUMER_USERNAME, consumer.username)
+  else
+    clear_header(constants.HEADERS.CONSUMER_USERNAME)
+  end
+
+  if credential and credential.username then
+    set_header(constants.HEADERS.CREDENTIAL_IDENTIFIER, credential.username)
+    set_header(constants.HEADERS.CREDENTIAL_USERNAME, credential.username)
+  else
+    clear_header(constants.HEADERS.CREDENTIAL_IDENTIFIER)
+    clear_header(constants.HEADERS.CREDENTIAL_USERNAME)
+  end
+
+  if credential then
+    clear_header(constants.HEADERS.ANONYMOUS)
+  else
+    set_header(constants.HEADERS.ANONYMOUS, true)
+  end
+end
+
+
+local function do_authentication(conf)
+  -- If both headers are missing, return 401
+  if not (kong.request.get_header("authorization") or kong.request.get_header("proxy-authorization")) then
+    return false, {
+      status = 401,
+      message = "Unauthorized",
+      headers = {
+        ["WWW-Authenticate"] = realm
+      }
+    }
+  end
+
+  local credential
+  local username, password = retrieve_credentials("proxy-authorization", conf)
+  if username then
+    credential = load_credential_from_db(username)
+  end
+
+  -- Try with the authorization header
+  if not credential then
+    username, password = retrieve_credentials("authorization", conf)
+    credential = load_credential_from_db(username)
+  end
+
+  if not credential or not validate_credentials(credential, password) then
+    return false, { status = 401, message = "Invalid authentication credentials" }
+  end
+
+  -- Retrieve consumer
+  local consumer_cache_key = kong.db.consumers:cache_key(credential.consumer.id)
+  local consumer, err      = kong.cache:get(consumer_cache_key, nil,
+                                            kong.client.load_consumer,
+                                            credential.consumer.id)
+  if err then
+    return error(err)
+  end
+
+  set_consumer(consumer, credential)
+
+  return true
+end
+
+
+function _M.execute(conf)
+  if conf.anonymous and kong.client.get_credential() then
+    -- we're already authenticated, and we're configured for using anonymous,
+    -- hence we're in a logical OR between auth methods and we're already done.
+    return
+  end
+
+  local ok, err = do_authentication(conf)
+  if not ok then
+    if conf.anonymous then
+      -- get anonymous user
+      local consumer_cache_key = kong.db.consumers:cache_key(conf.anonymous)
+      local consumer, err      = kong.cache:get(consumer_cache_key, nil,
+                                                kong.client.load_consumer,
+                                                conf.anonymous, true)
+      if err then
+        return error(err)
+      end
+
+      set_consumer(consumer)
+
+    else
+      return kong.response.error(err.status, err.message, err.headers)
+    end
+  end
+end
+
+
+return _M

--- a/kong/plugins/basic-auth-v2/crypto.lua
+++ b/kong/plugins/basic-auth-v2/crypto.lua
@@ -1,0 +1,29 @@
+-- Module to hash the basic-auth-v2 credentials password field
+local sha1 = require "resty.sha1"
+local to_hex = require "resty.string".to_hex
+local assert = assert
+
+
+--- Salt the password
+-- Password is salted with the credential's consumer_id (long enough, unique)
+-- @param credential The basic auth credential table
+local function salt_password(consumer_id, password)
+  if password == nil or password == ngx.null then
+    password = ""
+  end
+
+  return password .. consumer_id
+end
+
+
+return {
+  --- Hash the password field credential table
+  -- @param credential The basic auth credential table
+  -- @return hash of the salted credential's password
+  hash = function(consumer_id, password)
+    local salted = salt_password(consumer_id, password)
+    local digest = sha1:new()
+    assert(digest:update(salted))
+    return to_hex(digest:final())
+  end
+}

--- a/kong/plugins/basic-auth-v2/daos.lua
+++ b/kong/plugins/basic-auth-v2/daos.lua
@@ -1,0 +1,34 @@
+local typedefs = require "kong.db.schema.typedefs"
+local crypto = require "kong.plugins.basic-auth-v2.crypto"
+
+
+return {
+  basicauth_credentials_v2 = {
+    name = "basicauth_credentials_v2",
+    primary_key = { "username","id" },
+    cache_key = { "username" },
+    endpoint_key = "username",
+    -- Passwords are hashed, so the exported passwords would contain the hashes.
+    -- Importing them back would require "plain" non-hashed passwords instead.
+    db_export = false,
+    admin_api_name = "basic-auths-v2",
+    admin_api_nested_name = "basic-auth-v2",
+    fields = {
+      { id = typedefs.uuid },
+      { created_at = typedefs.auto_timestamp_s },
+      { consumer = { type = "foreign", reference = "consumers", required = true, on_delete = "cascade" }, },
+      { username = { type = "string", required = true, unique = true }, },
+      { password = { type = "string", required = true }, },
+      { tags     = typedefs.tags },
+    },
+    transformations = {
+      {
+        input = { "password" },
+        needs = { "consumer.id" },
+        on_write = function(password, consumer_id)
+          return { password = crypto.hash(consumer_id, password) }
+        end,
+      },
+    },
+  },
+}

--- a/kong/plugins/basic-auth-v2/handler.lua
+++ b/kong/plugins/basic-auth-v2/handler.lua
@@ -1,0 +1,16 @@
+-- Copyright (C) Kong Inc.
+local access = require "kong.plugins.basic-auth-v2.access"
+
+
+local BasicAuthHandler = {
+  PRIORITY = 1001,
+  VERSION = "1.0.0",
+}
+
+
+function BasicAuthHandler:access(conf)
+  access.execute(conf)
+end
+
+
+return BasicAuthHandler

--- a/kong/plugins/basic-auth-v2/migrations/000_base_basic_auth_v2.lua
+++ b/kong/plugins/basic-auth-v2/migrations/000_base_basic_auth_v2.lua
@@ -1,0 +1,38 @@
+return {
+  postgres = {
+    up = [[
+      CREATE TABLE IF NOT EXISTS "basicauth_credentials_v2" (
+        "id"           UUID,
+        "created_at"   TIMESTAMP WITH TIME ZONE     DEFAULT (CURRENT_TIMESTAMP(0) AT TIME ZONE 'UTC'),
+        "consumer_id"  UUID                         REFERENCES "consumers" ("id") ON DELETE CASCADE,
+        "username"     TEXT                         UNIQUE,
+        "password"     TEXT,
+        "tags"         TEXT[],
+        PRIMARY KEY("username", "id")
+      );
+
+      DO $$
+      BEGIN
+        CREATE INDEX IF NOT EXISTS "basicauth_consumer_id_idx" ON "basicauth_credentials_v2" ("consumer_id");
+        CREATE INDEX IF NOT EXISTS "basicauth_x_tags_idx" ON "basicauth_credentials_v2" USING GIN ("tags");
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
+    ]],
+  },
+
+  cassandra = {
+    up = [[
+      CREATE TABLE IF NOT EXISTS basicauth_credentials_v2 (
+        id          uuid,
+        created_at  timestamp,
+        consumer_id uuid,
+        password    text,
+        username    text,
+        tags        set<text>,
+        PRIMARY KEY(username, id)
+      );
+      CREATE INDEX IF NOT EXISTS ON basicauth_credentials_v2(consumer_id);
+    ]],
+  },
+}

--- a/kong/plugins/basic-auth-v2/migrations/init.lua
+++ b/kong/plugins/basic-auth-v2/migrations/init.lua
@@ -1,0 +1,3 @@
+return {
+  "000_base_basic_auth_v2",
+}

--- a/kong/plugins/basic-auth-v2/schema.lua
+++ b/kong/plugins/basic-auth-v2/schema.lua
@@ -1,0 +1,16 @@
+local typedefs = require "kong.db.schema.typedefs"
+
+
+return {
+  name = "basic-auth-v2",
+  fields = {
+    { consumer = typedefs.no_consumer },
+    { protocols = typedefs.protocols_http },
+    { config = {
+        type = "record",
+        fields = {
+          { anonymous = { type = "string" }, },
+          { hide_credentials = { type = "boolean", default = false }, },
+    }, }, },
+  },
+}


### PR DESCRIPTION
### Summary

The original `basic-auth` plugin has `id` as the primary key, with a
secondary index on `username`. While this works well with postgres,
there are performance issues with cassandra as lookups always happen
on `username` and secondary indexes on cassandra are inefficient.

A new plugin is introduced as changing the primary key in cassandra
is non-trivial and hence updating the existing plugin is not possible.

This plugin makes `username` as the partition key and `id` as the
clustering in cassandra. In case of postgres, both form composite
primary key.

Signed-off-by: Abhishek Varshney <abhishek.varshney@razorpay.com>

### Issues resolved

https://discuss.konghq.com/t/primary-key-for-cassandra-in-basic-auth-plugin/6169