### PR TITLE
chore(deps) bump dns client/balancer to 5.0.1

### DIFF
--- a/kong-2.0.4-0.rockspec
+++ b/kong-2.0.4-0.rockspec
@@ -28,7 +28,7 @@ dependencies = {
   "lua-resty-iputils == 0.3.0",
   "luasyslog == 1.0.0",
   "lua_pack == 1.0.5",
-  "lua-resty-dns-client == 4.1.3",
+  "lua-resty-dns-client == 5.0.1",
   "lua-resty-worker-events == 1.0.0",
   "lua-resty-mediador == 0.1.2",
   "lua-resty-healthcheck == 1.2.0",

--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -921,6 +921,7 @@ local function execute(target, ctx)
       (port == "No peers are available" or port == "Balancer is unhealthy") then
       return nil, "failure to get a peer from the ring-balancer", 503
     end
+    hostname = hostname or ip
     target.hash_value = hash_value
     target.balancer_handle = handle
 


### PR DESCRIPTION
Breaking change in lib is: if the "target" was an IP, then it will
no longer be returned as `host`, but `nil` instead.
This behaviour is now catered for on Kong side, so overall no
changes in behaviour for Kong.

### Issues resolved

Fix #5869 
