### PR TITLE
chore/bump zipkin 1.1.0

### DIFF
--- a/kong-2.0.4-0.rockspec
+++ b/kong-2.0.4-0.rockspec
@@ -41,7 +41,7 @@ dependencies = {
   "lua-resty-ipmatcher == 0.6",
   -- external Kong plugins
   "kong-plugin-azure-functions ~> 0.4",
-  "kong-plugin-zipkin ~> 1.0",
+  "kong-plugin-zipkin ~> 1.1",
   "kong-plugin-serverless-functions ~> 1.0",
   "kong-prometheus-plugin ~> 0.8",
   "kong-proxy-cache-plugin ~> 1.3",


### PR DESCRIPTION
This PR depends on Kong/kong-plugin-zipkin#78
being merged and a new rockspec being pushed to Luarocks.

Update: the other PR is done and the Luarock is released. This PR should be good to go now.