### PR TITLE
fix(declarative) misleading errors and validation errors

### DIFF
--- a/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
+++ b/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
@@ -2010,5 +2010,27 @@ describe("declarative config: flatten", function()
           },
         }, idempotent(err))
     end)
+    it("fixes #5920 - validation error on valid input", function()
+      local config = assert(lyaml.load([[
+        _format_version: "1.1"
+
+        services:
+        - name: test-service
+          routes:
+          - paths:
+            - /test/path
+            plugins:
+            - name: key-auth
+          url: https://example.com
+
+        consumers:
+        - username: test-user
+          basicauth_credentials:
+          - username: test-username
+            password: test-password
+      ]]))
+      local _, err = DeclarativeConfig:flatten(config)
+      assert.equal(nil, err)
+    end)
   end)
 end)

--- a/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
+++ b/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
@@ -1,8 +1,9 @@
 local declarative_config = require "kong.db.schema.others.declarative_config"
 local helpers = require "spec.helpers"
 local lyaml = require "lyaml"
+local cjson = require "cjson"
 local tablex = require "pl.tablex"
-
+local utils = require "kong.tools.utils"
 
 local null = ngx.null
 
@@ -46,7 +47,7 @@ local function idempotent(tbl, err)
 
   local function recurse_fields(t)
     for k,v in sortedpairs(t) do
-      if k == "id" then
+      if k == "id" and utils.is_valid_uuid(v) then
         t[k] = "UUID"
       end
       if k == "client_id" or k == "client_secret" or k == "access_token" then
@@ -1420,6 +1421,9 @@ describe("declarative config: flatten", function()
               ["@entity"] = {
                 "all or none of these fields must be set: 'password', 'consumer.id'",
               },
+              ["consumer"] = {
+                ["id"] = "missing primary key"
+              },
             },
           },
         }, idempotent(err))
@@ -1480,6 +1484,9 @@ describe("declarative config: flatten", function()
             {
               ["@entity"] = {
                 "all or none of these fields must be set: 'password', 'consumer.id'",
+              },
+              ["consumer"] = {
+                ["id"] = "missing primary key"
               },
             },
           },
@@ -1929,4 +1936,79 @@ describe("declarative config: flatten", function()
     end)
   end)
 
+  describe("issues", function()
+    it("fixes #5750 - misleading error messages", function()
+      local config = assert(cjson.decode([[
+        {
+          "_format_version": "1.1",
+          "consumers": [
+            {
+              "username": "consumer-test",
+              "basicauth_credentials": [
+                {
+                  "username": "some_user",
+                  "password": "some_password"
+                }
+              ]
+            }
+          ],
+          "plugins": [
+            {
+              "name": "request-transformer",
+              "config": {
+                "add": {
+                  "body": [],
+                  "headers": [],
+                  "querystring": []
+                },
+                "append": {
+                  "body": [],
+                  "headers": [
+                    "X-Another-Header:foo"
+                  ],
+                  "querystring": []
+                },
+                "remove": {
+                  "body": [],
+                  "headers": [
+                    "X-Another-Header"
+                  ],
+                  "querystring": []
+                },
+                "rename": {
+                  "body": [],
+                  "headers": [],
+                  "querystring": []
+                },
+                "replace": {
+                  "body": [],
+                  "headers": [],
+                  "querystring": [],
+                  "uri": null
+                }
+              },
+              "route": "does-not-exist",
+              "enabled": true,
+              "protocols": [
+                "http",
+                "https"
+              ]
+            }
+          ]
+        }
+      ]]))
+      local err
+      config, err = DeclarativeConfig:flatten(config)
+      assert.equal(nil, config)
+      assert.same({
+        plugins = {
+            {
+              ["route"] = {
+                ["id"] = "missing primary key"
+              },
+            },
+          },
+        }, idempotent(err))
+    end)
+  end)
 end)


### PR DESCRIPTION
### Summary

#### fix(declarative) misleading error may be returned in certain cases

The declarative config validation may return misleading error messages in some cases, see #5750.

#### fix(declarative) validation errors because non-filled primary keys

The validation of declarative configuration could fail when presenting configuration that did not have ids or names or didn't have a cache key.

Here is such configuration:

```yaml
_format_version: "1.1"

services:
- name: test-service
  routes:
  - paths:
    - /test/path
    plugins:
    - name: key-auth
  url: https://example.com

consumers:
- username: test-user
  basicauth_credentials:
  - username: test-username
    password: test-password
```

See #5920

### Issues resolved

Fix #5750
Fix #5920

