### PR TITLE
chore(balancer) update ERR to WARN for missing peers in the balancer

### DIFF
--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -291,7 +291,7 @@ do
         end
 
         if not ok then
-          log(ERR, "[healthchecks] failed setting peer status (upstream: ", hc.name, "): ", err)
+          log(WARN, "[healthchecks] failed setting peer status (upstream: ", hc.name, "): ", err)
         end
       end
 


### PR DESCRIPTION
see #5589, mitigates the messages, but final resolution should probably
be based on better tracking of targets/addresses.
