### PR TITLE
fix/declarative config bump

### DIFF
--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -80,7 +80,7 @@ end
 
 -- first return item: a table with the following format:
 --   {
---     _format_version: 1.2,
+--     _format_version: 2.1,
 --     _transform: true,
 --     services: {
 --       ["<uuid>"] = { ... },
@@ -159,7 +159,7 @@ end
 
 -- first return item: a table with the following format:
 --   {
---     _format_version: 1.2,
+--     _format_version: 2.1,
 --     _transform: true,
 --     services: {
 --       ["<uuid>"] = { ... },
@@ -275,7 +275,7 @@ function declarative.export_from_db(fd)
   end
 
   fd:write(declarative.to_yaml_string({
-    _format_version = "1.2",
+    _format_version = "2.1",
     _transform = false,
   }))
 
@@ -330,7 +330,7 @@ function declarative.export_config()
   end
 
   local out = {
-    _format_version = "1.2",
+    _format_version = "2.1",
     _transform = false,
   }
 
@@ -391,7 +391,7 @@ end
 
 -- dc_table format:
 --   {
---     _format_version: 1.2,
+--     _format_version: 2.1,
 --     _transform: true,
 --     services: {
 --       ["<uuid>"] = { ... },

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -193,7 +193,7 @@ end
 
 local function build_fields(entities, include_foreign)
   local fields = {
-    { _format_version = { type = "string", required = true, one_of = {"1.1", "1.2"} } },
+    { _format_version = { type = "string", required = true, one_of = {"1.1", "2.1"} } },
     { _transform = { type = "boolean", default = true } },
   }
   add_extra_attributes(fields, {

--- a/kong/templates/kong_yml.lua
+++ b/kong/templates/kong_yml.lua
@@ -10,7 +10,7 @@ return [[
 # _format_version is mandatory,
 # it specifies the minimum version of Kong that supports the format
 
-_format_version: "1.2"
+_format_version: "2.1"
 
 # _transform is optional, defaulting to true.
 # It specifies whether schema transformations should be applied when importing this file

--- a/spec/01-unit/01-db/01-schema/11-declarative_config/01-validate_spec.lua
+++ b/spec/01-unit/01-db/01-schema/11-declarative_config/01-validate_spec.lua
@@ -25,7 +25,7 @@ describe("declarative config: validate", function()
   end)
 
   describe("_format_version", function()
-    it("requires version 1.1 or 1.2", function()
+    it("requires version 1.1 or 2.1", function()
 
       local ok, err = DeclarativeConfig:validate(lyaml.load([[
         _format_version: 1.1
@@ -40,7 +40,7 @@ describe("declarative config: validate", function()
       ]]))
       assert.falsy(ok)
       assert.same({
-        ["_format_version"] = "expected one of: 1.1, 1.2"
+        ["_format_version"] = "expected one of: 1.1, 2.1"
       }, err)
 
       assert(DeclarativeConfig:validate(lyaml.load([[
@@ -48,7 +48,7 @@ describe("declarative config: validate", function()
       ]])))
 
       assert(DeclarativeConfig:validate(lyaml.load([[
-        _format_version: "1.2"
+        _format_version: "2.1"
       ]])))
     end)
   end)

--- a/spec/02-integration/02-cmd/11-config_spec.lua
+++ b/spec/02-integration/02-cmd/11-config_spec.lua
@@ -410,7 +410,7 @@ describe("kong config", function()
       "services",
     }, toplevel_keys)
 
-    assert.equals("1.2", yaml._format_version)
+    assert.equals("2.1", yaml._format_version)
     assert.equals(false, yaml._transform)
 
     assert.equals(2, #yaml.services)

--- a/spec/02-integration/03-db/08-declarative_spec.lua
+++ b/spec/02-integration/03-db/08-declarative_spec.lua
@@ -230,7 +230,7 @@ for _, strategy in helpers.each_strategy() do
           "snis"
         }, toplevel_keys)
 
-        assert.equals("1.2", yaml._format_version)
+        assert.equals("2.1", yaml._format_version)
         assert.equals(false, yaml._transform)
 
         assert.equals(1, #yaml.snis)

--- a/spec/02-integration/04-admin_api/15-off_spec.lua
+++ b/spec/02-integration/04-admin_api/15-off_spec.lua
@@ -605,7 +605,7 @@ describe("Admin API #off", function()
         local json = cjson.decode(body)
         local config = assert(lyaml.load(json.config))
         assert.same({
-          _format_version = "1.2",
+          _format_version = "2.1",
           _transform = false,
           consumers = {
             { id = "d885e256-1abe-5e24-80b6-8f68fe59ea8e",


### PR DESCRIPTION
The guidelines we'll be following for this field are:

> The `_format_version` number does not necessarily change on every Kong release
> It represents the lowest Kong version that is able to read the file without a parse error unrelated to Kong entity schemas.
> The `_format_version` does not change whenever the schema of Kong entities change.
> The `_format_version` is independent of schemas: having a compatible _format_version does not mean a Kong version will successfully load a declarative config semantically.
> The semantic guarantee would be impossible, because any Kong cluster or version can have different custom plugins installed and therefore incompatible entities. Every different combination of custom plugins is effectively a different declarative config schema. That is why Option 1 is not effective and why schemas are not accounted as part of the version.

Updating it to 1.2 was incorrect, since the first version of Kong able
to read it will be 2.1. I am thus updating it to 2.1
