### PR TITLE
feat(plugins) add grpc-gateway plugin

### DIFF
--- a/kong-2.0.4-0.rockspec
+++ b/kong-2.0.4-0.rockspec
@@ -50,6 +50,7 @@ dependencies = {
   "kong-plugin-aws-lambda ~> 3.4",
   "kong-plugin-acme ~> 0.2",
   "kong-plugin-grpc-web ~> 0.1",
+  "kong-plugin-grpc-gateway ~> 0.1",
 }
 build = {
   type = "builtin",

--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -34,6 +34,8 @@ local plugins = {
   "proxy-cache",
   "session",
   "acme",
+  "grpc-web",
+  "grpc-gateway",
 }
 
 local plugin_map = {}

--- a/spec/01-unit/12-plugins_order_spec.lua
+++ b/spec/01-unit/12-plugins_order_spec.lua
@@ -64,6 +64,7 @@ describe("Plugins", function()
       "basic-auth",
       "hmac-auth",
       "acme",
+      "grpc-gateway",
       "ip-restriction",
       "request-size-limiting",
       "acl",

--- a/spec/01-unit/12-plugins_order_spec.lua
+++ b/spec/01-unit/12-plugins_order_spec.lua
@@ -84,6 +84,7 @@ describe("Plugins", function()
       "tcp-log",
       "loggly",
       "syslog",
+      "grpc-web",
       "request-termination",
       "correlation-id",
       "post-function",

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -777,6 +777,11 @@ local function http2_client(host, port, tls)
   local port = assert(port)
   tls = tls or false
 
+  -- if Kong/lua-pack is loaded, unload it first
+  -- so lua-http can use implementation from compat53.string
+  package.loaded.string.unpack = nil
+  package.loaded.string.pack = nil
+
   local request = require "http.request"
   local req = request.new_from_uri({
     scheme = tls and "https" or "http",


### PR DESCRIPTION
### Summary

Add the [grpc-gateway plugin](https://github.com/Kong/kong-plugin-grpc-gateway) and enable grpc plugins by default (following the pattern as #5555).

### Full changelog

* Add the grpc-gateway plugin to rockspec
* Enable grpc-web and grpc-gateway plugin by default

