### PR TITLE
chore(deps) bump lua-resty-openssl from 0.6.0 to 0.6.2

### DIFF
--- a/kong-2.0.4-0.rockspec
+++ b/kong-2.0.4-0.rockspec
@@ -36,7 +36,7 @@ dependencies = {
   "lua-resty-cookie == 0.1.0",
   "lua-resty-mlcache == 2.4.1",
   "lua-messagepack == 0.5.2",
-  "lua-resty-openssl == 0.6.0",
+  "lua-resty-openssl == 0.6.2",
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6",
   -- external Kong plugins


### PR DESCRIPTION
### Summary

#### [0.6.2] - 2020-05-13
##### feat
- **cipher:** AEAD modes with authentication
- **pkey:** support one shot sign/verify for Ed25519 and Ed448 keys
- **pkey:** support key derivation for EC, X25519 and X448 keys
- **pkey:** output pkey to DER and JWK format
- **pkey:** load EC key from JWK format
- **pkey:** set/get_parameters for EC key
- **pkey:** load RSA key from JWK format
- **pkey:** add function to set rsa parameter

##### fix
- ***:** add prefix to all error messages

#### [0.6.1] - 2020-05-08
##### fix
- **x509:** fail soft when CRL is not set