### PR TITLE
fix(ci) adjust plugin tests for some plugin naming inconsistencies

### DIFF
--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -77,7 +77,8 @@ if [ "$TEST_SUITE" == "plugins" ]; then
         cyan "--------------------------------------"
         echo
 
-        git clone https://github.com/Kong/$REPOSITORY.git --branch $VERSION --single-branch /tmp/test-$REPOSITORY
+        git clone https://github.com/Kong/$REPOSITORY.git --branch $VERSION --single-branch /tmp/test-$REPOSITORY || \
+        git clone https://github.com/Kong/$REPOSITORY.git --branch v$VERSION --single-branch /tmp/test-$REPOSITORY
         cp -R /tmp/test-$REPOSITORY/spec/fixtures/* spec/fixtures/ || true
         pushd /tmp/test-$REPOSITORY
         luarocks make


### PR DESCRIPTION
some bundled kong plugins prefix their tags with `v`