### PR TITLE
fix(declarative) convert lyaml.nulls to ngx.nulls

### DIFF
--- a/spec/01-unit/01-db/10-declarative_spec.lua
+++ b/spec/01-unit/01-db/10-declarative_spec.lua
@@ -1,0 +1,25 @@
+local declarative = require "kong.db.declarative"
+local conf_loader = require "kong.conf_loader"
+
+
+local null = ngx.null
+
+
+describe("declarative", function()
+  describe("parse_string", function()
+    it("converts lyaml.null to ngx.null", function()
+      local dc = declarative.new_config(conf_loader())
+      local entities, err = dc:parse_string [[
+_format_version: "1.1"
+routes:
+  - name: null
+    paths:
+    - /
+]]
+      assert.equal(nil, err)
+      local _, route = next(entities.routes)
+      assert.equal(null,   route.name)
+      assert.same({ "/" }, route.paths)
+    end)
+  end)
+end)


### PR DESCRIPTION
### Summary

Contains a fix that converts `lyaml.null`s to `ngx.null` when parsing declarative configuration.