### PR TITLE
chore(pdk) bump version to 1.4.0

### DIFF
--- a/kong/pdk/init.lua
+++ b/kong/pdk/init.lua
@@ -211,7 +211,7 @@ assert(package.loaded["resty.core"])
 
 local MAJOR_VERSIONS = {
   [1] = {
-    version = "1.3.1",
+    version = "1.4.0",
     modules = {
       "table",
       "node",


### PR DESCRIPTION
As commit da707f0f9 introduced a new PDK submodule, minor version needs
a bump.
