### PR TITLE
fix(declarative) fix missing nulls on read

### DIFF
--- a/kong/db/strategies/off/init.lua
+++ b/kong/db/strategies/off/init.lua
@@ -28,6 +28,7 @@ local function nil_cb()
   return nil
 end
 
+
 -- Returns a dict of entity_ids tagged according to the given criteria.
 -- Currently only the following kinds of keys are supported:
 -- * A key like `services|list` will only return service ids
@@ -153,6 +154,10 @@ local function page_for_key(self, key, size, offset, options)
       item = cache:get(schema_name .. ":" .. item .. "::::", nil, nil_cb)
     end
 
+    item = self.schema:process_auto_fields(item, "select", true, {
+      no_defaults = true
+    })
+
     ret[i - offset + 1] = item
   end
 
@@ -169,7 +174,16 @@ local function select_by_key(self, key)
     return nil
   end
 
-  return kong.core_cache:get(key, nil, nil_cb)
+  local entity, err = kong.core_cache:get(key, nil, nil_cb)
+  if not entity then
+    return nil, err
+  end
+
+  entity =  self.schema:process_auto_fields(entity, "select", true, {
+    no_defaults = true
+  })
+
+  return entity
 end
 
 

--- a/spec/02-integration/04-admin_api/15-off_spec.lua
+++ b/spec/02-integration/04-admin_api/15-off_spec.lua
@@ -1,4 +1,5 @@
 local cjson    = require "cjson"
+local lyaml    = require "lyaml"
 local utils    = require "kong.tools.utils"
 local pl_utils = require "pl.utils"
 local helpers  = require "spec.helpers"
@@ -604,12 +605,15 @@ describe("Admin API #off", function()
 
         local body = assert.response(res).has.status(200)
         local json = cjson.decode(body)
-        local expected_config = "_format_version: '1.1'\n" ..
-          "consumers:\n" ..
-          "- created_at: 1566863706\n" ..
-          "  username: bobo\n" ..
-          "  id: d885e256-1abe-5e24-80b6-8f68fe59ea8e\n"
-        assert.same(expected_config, json.config)
+        local yaml_config = lyaml.load(json.config)
+        local expected_config = lyaml.load [[
+_format_version: "1.1"
+consumers:
+- created_at: 1566863706
+  username: bobo
+  id: d885e256-1abe-5e24-80b6-8f68fe59ea8e
+]]
+        assert.same(expected_config, yaml_config)
       end)
     end)
 


### PR DESCRIPTION
### Summary

Both Postgres and Cassandra strategies return `null` on fields that have `null` value stored in database. The DBless stores entities directly to cache where we don't keep `nulls`. But it has a problem that this PR tries to fix. This PR changes `off` strategy to fill `nulls` when the entities are accessed via `DAO`, the `nulls` are then later removed (again) by DAO when it calls `process_auto_fields`. This extra `fill nulls` is added to avoid the DAO `process_auto_fields` to fill explicit `null` values with possible `default` values.

### Issues Resolved

Fix #5834