### PR TITLE
refactor(db-less) change the `flatten` return types

### DIFF
--- a/kong/api/routes/config.lua
+++ b/kong/api/routes/config.lua
@@ -72,10 +72,9 @@ return {
       end
       self.params.check_hash = nil
 
-      local dc_table, new_hash, err_t
+      local entities, _, err_t, meta, new_hash
       if self.params._format_version then
-        dc_table, new_hash, err_t =
-          dc:parse_table(self.params)
+        entities, _, err_t, meta, new_hash = dc:parse_table(self.params)
       else
         local config = self.params.config
         if not config then
@@ -83,11 +82,11 @@ return {
             message = "expected a declarative configuration"
           })
         end
-        dc_table, new_hash, err_t =
+        entities, _, err_t, meta, new_hash =
           dc:parse_string(config, nil, accept, old_hash)
       end
 
-      if not dc_table then
+      if not entities then
         if check_hash and err_t and err_t.error == "configuration is identical" then
           return kong.response.exit(304)
         end
@@ -95,7 +94,7 @@ return {
       end
 
       local ok, err = concurrency.with_worker_mutex({ name = "dbless-worker" }, function()
-        return declarative.load_into_cache_with_events(dc_table, new_hash)
+        return declarative.load_into_cache_with_events(entities, meta, new_hash)
       end)
 
       if err == "no memory" then
@@ -110,17 +109,9 @@ return {
         return kong.response.exit(500, { message = "An unexpected error occurred" })
       end
 
-      _reports.decl_fmt_version = dc_table._format_version
-      _reports.decl_transform   = dc_table._transform
+      _reports.decl_fmt_version = meta._format_version
 
       ngx.timer.at(0, reports_timer)
-
-      local entities = {}
-      for k, v in pairs(dc_table) do
-        if k:sub(1,1) ~= "_" then
-          entities[k] = v
-        end
-      end
 
       return kong.response.exit(201, entities)
     end,

--- a/kong/clustering.lua
+++ b/kong/clustering.lua
@@ -55,9 +55,9 @@ local function update_config(config_table, update_cache)
     declarative_config = declarative.new_config(kong.configuration)
   end
 
-  local dc_table, new_hash = declarative_config:parse_table(config_table)
-  if not dc_table then
-    return nil, "bad config received from control plane"
+  local entities, err, _, meta, new_hash = declarative_config:parse_table(config_table)
+  if not entities then
+    return nil, "bad config received from control plane " .. err
   end
 
   if declarative.get_current_hash() == new_hash then
@@ -69,7 +69,7 @@ local function update_config(config_table, update_cache)
   -- NOTE: no worker mutex needed as this code can only be
   -- executed by worker 0
   local res, err =
-    declarative.load_into_cache_with_events(dc_table, new_hash)
+    declarative.load_into_cache_with_events(entities, meta, new_hash)
   if not res then
     return nil, err
   end

--- a/kong/cmd/config.lua
+++ b/kong/cmd/config.lua
@@ -105,15 +105,15 @@ local function execute(args)
     end
     filename = pl_path.abspath(filename)
 
-    local dc_table, err = dc:parse_file(filename, accepted_formats)
-    if not dc_table then
+    local entities, err, _, meta = dc:parse_file(filename, accepted_formats)
+    if not entities then
       error("Failed parsing:\n" .. err)
     end
 
     if args.command == "db_import" then
       log("parse successful, beginning import")
 
-      local ok, err = declarative.load_into_db(dc_table)
+      local ok, err = declarative.load_into_db(entities, meta)
       if not ok then
         error("Failed importing:\n" .. err)
       end
@@ -127,8 +127,7 @@ local function execute(args)
         kong_reports.toggle(true)
 
         local report = {
-          decl_fmt_version = dc_table._format_version,
-          decl_transform = dc_table._transform,
+          decl_fmt_version = meta._format_version,
         }
         kong_reports.send("config-db-import", report)
       end

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -586,16 +586,17 @@ local function flatten(self, input)
     return nil, by_key
   end
 
-  local output = {}
+  local meta = {}
   for key, value in pairs(processed) do
     if key:sub(1,1) == "_" then
-      output[key] = value
+      meta[key] = value
     end
   end
 
+  local entities = {}
   for entity, entries in pairs(by_id) do
     local schema = all_schemas[entity]
-    output[entity] = {}
+    entities[entity] = {}
     for id, entry in pairs(entries) do
       local flat_entry = {}
       for name, field in schema:each_field(entry) do
@@ -610,11 +611,11 @@ local function flatten(self, input)
         end
       end
 
-      output[entity][id] = flat_entry
+      entities[entity][id] = flat_entry
     end
   end
 
-  return output
+  return entities, nil, meta
 end
 
 

--- a/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
+++ b/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
@@ -37,16 +37,11 @@ local function idempotent(tbl, err)
   assert.table(tbl, err)
 
   for entity, items in sortedpairs(tbl) do
-    if entity:sub(1,1) ~= "_" and type(items) == "table" then
-      local new = {}
-      for _, item in sortedpairs(items, sort_by_key) do
-        table.insert(new, item)
-      end
-
-      tbl[entity] = new
-    else
-      tbl[entity] = nil
+    local new = {}
+    for _, item in sortedpairs(items, sort_by_key) do
+      table.insert(new, item)
     end
+    tbl[entity] = new
   end
 
   local function recurse_fields(t)

--- a/spec/02-integration/03-db/08-declarative_spec.lua
+++ b/spec/02-integration/03-db/08-declarative_spec.lua
@@ -137,13 +137,12 @@ for _, strategy in helpers.each_strategy() do
         plugins = { [plugin_def.id] = plugin_def },
         acls = { [acl_def.id] = acl_def  },
         basicauth_credentials = { [basicauth_credential_def.id] = basicauth_credential_def },
-      }))
+      }, { _transform = true }))
 
       -- import without performing transformations
       assert(declarative.load_into_db({
-        _transform = false,
         basicauth_credentials = { [basicauth_hashed_credential_def.id] = basicauth_hashed_credential_def },
-      }))
+      }, { _transform = false }))
     end)
 
     describe("load_into_db", function()

--- a/spec/03-plugins/10-basic-auth/05-declarative_spec.lua
+++ b/spec/03-plugins/10-basic-auth/05-declarative_spec.lua
@@ -102,12 +102,11 @@ for _, strategy in helpers.each_strategy() do
         consumers = { [consumer_def.id] = consumer_def },
         plugins = { [plugin_def.id] = plugin_def },
         basicauth_credentials = { [basicauth_credential_def.id] = basicauth_credential_def },
-      }))
+      }, { _transform = true }))
 
       assert(declarative.load_into_db({
-        _transform = false,
         basicauth_credentials = { [basicauth_hashed_credential_def.id] = basicauth_hashed_credential_def },
-      }))
+      }, { _transform = false }))
     end)
 
     describe("load_into_db", function()


### PR DESCRIPTION
This PR modifies some of the changes introduced by #5835.

In particular, the `flatten` function now returns two separate
tables, `entities` and `meta`, instead of a single one.

This is done in order to is simplify a future merge with Kong EE.

The `_transform` field is also removed from the reports as it isn't
needed.

