### PR TITLE
fix(wait_pid) logic error in the pid_dead spec helper

### DIFF
--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -2193,7 +2193,7 @@ local function pid_dead(pid, timeout)
 
   repeat
     if not pl_utils.execute("ps -p " .. pid .. " >/dev/null 2>&1") then
-      return
+      return true
     end
     -- still running, wait some more
     ngx.sleep(0.05)


### PR DESCRIPTION
`return` will return `nil` when what we need here is `true`