### PR TITLE
feat(tcp-log) add a switch to log request/response body

### DIFF
--- a/kong/pdk/log.lua
+++ b/kong/pdk/log.lua
@@ -572,11 +572,11 @@ do
         response_size = tonumber(response_size, 10)
       end
 
-      local request_body
-      local response_body
-      if kong.ctx.plugin then
-        request_body = kong.ctx.plugin.request_body
-        response_body = table.concat(kong.ctx.plugin.response_body)
+      local request_body, response_body
+      local ctx_plugin = kong.ctx.plugin
+      if ctx_plugin and ctx_plugin.response_body then
+        request_body = ctx_plugin.request_body
+        response_body = table.concat(ctx_plugin.response_body)
       end
 
       return {

--- a/kong/pdk/log.lua
+++ b/kong/pdk/log.lua
@@ -572,6 +572,13 @@ do
         response_size = tonumber(response_size, 10)
       end
 
+      local request_body
+      local response_body
+      if kong.ctx.plugin then
+        request_body = kong.ctx.plugin.request_body
+        response_body = table.concat(kong.ctx.plugin.response_body)
+      end
+
       return {
         request = {
           uri = request_uri,
@@ -580,6 +587,7 @@ do
           method = okong.request.get_method(), -- http method
           headers = req_headers,
           size = request_size,
+          body = request_body,
           tls = request_tls
         },
         upstream_uri = var.upstream_uri,
@@ -587,6 +595,7 @@ do
           status = ongx.status,
           headers = resp_headers,
           size = response_size,
+          body = response_body,
         },
         tries = (ctx.balancer_data or {}).tries,
         latencies = {

--- a/kong/plugins/tcp-log/handler.lua
+++ b/kong/plugins/tcp-log/handler.lua
@@ -52,6 +52,29 @@ local TcpLogHandler = {
 }
 
 
+function TcpLogHandler:access(conf)
+  if conf.log_body then
+    local body, err = kong.request.get_raw_body()
+    if err then
+      kong.log.err(err)
+      kong.ctx.plugin.request_body = ""
+    else
+      kong.ctx.plugin.request_body = body
+    end
+    kong.ctx.plugin.response_body = {}
+  end
+end
+
+
+function TcpLogHandler:body_filter(conf)
+  if conf.log_body then
+    local chunk = ngx.arg[1]
+    local body = kong.ctx.plugin.response_body
+    body[#body + 1] = chunk
+  end
+end
+
+
 function TcpLogHandler:log(conf)
   local message = kong.log.serialize()
   local ok, err = timer_at(0, log, conf, message)

--- a/kong/plugins/tcp-log/schema.lua
+++ b/kong/plugins/tcp-log/schema.lua
@@ -13,6 +13,7 @@ return {
           { keepalive = { type = "number", default = 60000 }, },
           { tls = { type = "boolean", default = false }, },
           { tls_sni = { type = "string" }, },
+          { log_body = { default = false, type = "boolean" }, },
         },
     }, },
   }

--- a/spec/01-unit/01-db/01-schema/11-declarative_config/02-process_auto_fields_spec.lua
+++ b/spec/01-unit/01-db/01-schema/11-declarative_config/02-process_auto_fields_spec.lua
@@ -359,6 +359,7 @@ describe("declarative config: process_auto_fields", function()
                       keepalive = 60000,
                       timeout = 10000,
                       tls = false,
+                      log_body = false,
                     }
                   },
                 }
@@ -680,6 +681,7 @@ describe("declarative config: process_auto_fields", function()
                           keepalive = 60000,
                           timeout = 10000,
                           tls = false,
+                          log_body = false,
                         }
                       }
                     }

--- a/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
+++ b/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
@@ -591,7 +591,8 @@ describe("declarative config: flatten", function()
                   port = 10000,
                   timeout = 10000,
                   tls = false,
-                  tls_sni = null
+                  tls_sni = null,
+                  log_body = false,
                 },
                 consumer = null,
                 created_at = 1234567890,
@@ -1077,7 +1078,8 @@ describe("declarative config: flatten", function()
                   port = 10000,
                   timeout = 10000,
                   tls = false,
-                  tls_sni = null
+                  tls_sni = null,
+                  log_body = false,
                 },
                 consumer = null,
                 created_at = 1234567890,

--- a/spec/01-unit/10-log_serializer_spec.lua
+++ b/spec/01-unit/10-log_serializer_spec.lua
@@ -196,7 +196,7 @@ describe("kong.log.serialize", function()
       it("serializes request and response bodies present in the ngx context", function()
         kong.ctx.plugin = {
           request_body = "request body",
-          response_body = "response body",
+          response_body = {"response body"},
         }
 
         local res = kong.log.serialize({ngx = ngx, kong = kong, })

--- a/spec/01-unit/10-log_serializer_spec.lua
+++ b/spec/01-unit/10-log_serializer_spec.lua
@@ -192,6 +192,19 @@ describe("kong.log.serialize", function()
 
         kong.log.warn = orig_warn
       end)
+
+      it("serializes request and response bodies present in the ngx context", function()
+        kong.ctx.plugin = {
+          request_body = "request body",
+          response_body = "response body",
+        }
+
+        local res = kong.log.serialize({ngx = ngx, kong = kong, })
+        assert.is_table(res)
+
+        assert.equal(res.request.body, "request body")
+        assert.equal(res.response.body, "response body")
+      end)
     end)
   end)
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

This PR adds an optional switch to log the request and response body for tcp-log plugin.

### Full changelog

*  Add request/response body variables in pdk function `kong.log.serialize`
*  Get request/response body during access and body_filter phase respectively and store them in kong plugin storages
*  Add related tests

### Issues resolved
Similar #3028 (the previous attempt by others, closed but not merged)

### Backgroud
I see many people hope to collect the request and response body in tcp/udp/http log plugin, including myself. If this PR is acceptable, I will continue to add this option for udp and http log plugins.

### Additional Explanation
Currently, for grpc requests using http2, no matter how large the `client_body_buffer_size` is set, nginx will store the request body in a temporary file. In order to reduce the consumption of reading files, and considering that the grpc request body is in a binary format and is not easy to read, this switch currently only supports logging http(actually http1.x) request body. See [here](https://github.com/Kong/kong/pull/5968#discussion_r435916465) for more specific analysis.