### PR TITLE
feat: Custom Header as identifier for Rate-Limiting

### DIFF
--- a/kong/plugins/rate-limiting/handler.lua
+++ b/kong/plugins/rate-limiting/handler.lua
@@ -63,6 +63,9 @@ local function get_identifier(conf)
   elseif conf.limit_by == "credential" then
     identifier = (kong.client.get_credential() or
                   EMPTY).id
+
+  elseif conf.limit_by == "header" then
+    identifier = kong.request.get_header(conf.header_name)
   end
 
   return identifier or kong.client.get_forwarded_ip()

--- a/kong/plugins/rate-limiting/schema.lua
+++ b/kong/plugins/rate-limiting/schema.lua
@@ -39,8 +39,9 @@ return {
           { limit_by = {
               type = "string",
               default = "consumer",
-              one_of = { "consumer", "credential", "ip", "service" },
+              one_of = { "consumer", "credential", "ip", "service", "header" },
           }, },
+          { header_name = typedefs.header_name },
           { policy = {
               type = "string",
               default = "cluster",
@@ -68,6 +69,10 @@ return {
     { conditional = {
       if_field = "config.policy", if_match = { eq = "redis" },
       then_field = "config.redis_port", then_match = { required = true },
+    } },
+    { conditional = {
+      if_field = "config.limit_by", if_match = { eq = "header" },
+      then_field = "config.header_name", then_match = { required = true },
     } },
     { conditional = {
       if_field = "config.policy", if_match = { eq = "redis" },

--- a/spec/03-plugins/23-rate-limiting/01-schema_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/01-schema_spec.lua
@@ -9,8 +9,16 @@ describe("Plugin: rate-limiting (schema)", function()
     assert.truthy(ok)
     assert.is_nil(err)
   end)
+
   it("proper config validates (bis)", function()
     local config = { second = 10, minute = 20, hour = 30, day = 40, month = 50, year = 60 }
+    local ok, _, err = v(config, schema_def)
+    assert.truthy(ok)
+    assert.is_nil(err)
+  end)
+
+  it("proper config validates (header)", function()
+    local config = { second = 10, limit_by = "header", header_name = "X-App-Version" }
     local ok, _, err = v(config, schema_def)
     assert.truthy(ok)
     assert.is_nil(err)
@@ -23,6 +31,7 @@ describe("Plugin: rate-limiting (schema)", function()
       assert.falsy(ok)
       assert.equal("The limit for hour(10.0) cannot be lower than the limit for second(20.0)", err.config)
     end)
+
     it("limits: smaller unit is less than bigger unit (bis)", function()
       local config = { second = 10, minute = 20, hour = 30, day = 40, month = 60, year = 50 }
       local ok, err = v(config, schema_def)
@@ -36,6 +45,13 @@ describe("Plugin: rate-limiting (schema)", function()
       assert.falsy(ok)
       assert.same({"at least one of these fields must be non-empty: 'config.second', 'config.minute', 'config.hour', 'config.day', 'config.month', 'config.year'" },
                   err["@entity"])
+    end)
+
+    it("is limited by header but the header_name field is missing", function()
+      local config = { second = 10, limit_by = "header", header_name = nil }
+      local ok, err = v(config, schema_def)
+      assert.falsy(ok)
+      assert.equal("required field missing", err.config.header_name)
     end)
   end)
 end)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Feature: Use a custom header value as an identifier for Rate-Limiting.  
This feature can be used when consumers cannot be inputted to Kong Consumers, e.g. Header "X-App-Version: 0.0.1" is present in every request, and the App-Versions are too dynamic to create Kong Consumers, then it is possible to use the header value of "X-App-Version" as an identifier.

### Full changelog

* Use a custom header value as identifier for Rate-Limiting. 

