### PR TITLE
fix(dbless) actually release memory when purging the cache

### DIFF
--- a/kong/cache.lua
+++ b/kong/cache.lua
@@ -337,7 +337,7 @@ function _M:purge(shadow_page)
     page = (self.curr_mlcache == 1) and 2 or 1
   end
 
-  local ok, err = self.mlcaches[page]:purge()
+  local ok, err = self.mlcaches[page]:purge(true)
   if not ok then
     log(ERR, "failed to purge cache: ", err)
   end

--- a/spec/02-integration/04-admin_api/15-off_spec.lua
+++ b/spec/02-integration/04-admin_api/15-off_spec.lua
@@ -5,7 +5,9 @@ local helpers  = require "spec.helpers"
 local Errors   = require "kong.db.errors"
 local mocker   = require("spec.fixtures.mocker")
 
+
 local WORKER_SYNC_TIMEOUT = 10
+local MEM_CACHE_SIZE = "5m"
 
 
 local function it_content_types(title, fn)
@@ -24,7 +26,7 @@ describe("Admin API #off", function()
   lazy_setup(function()
     assert(helpers.start_kong({
       database = "off",
-      mem_cache_size = "10m",
+      mem_cache_size = MEM_CACHE_SIZE,
       stream_listen = "127.0.0.1:9011",
       nginx_conf = "spec/fixtures/custom_nginx.template",
     }))
@@ -751,7 +753,7 @@ describe("Admin API (concurrency tests) #off", function()
     assert(helpers.start_kong({
       database = "off",
       nginx_worker_processes = 8,
-      mem_cache_size = "10m",
+      mem_cache_size = MEM_CACHE_SIZE,
     }))
 
     client = assert(helpers.admin_client())
@@ -874,7 +876,7 @@ describe("Admin API #off with Unique Foreign #unique", function()
       database = "off",
       plugins = "unique-foreign",
       nginx_worker_processes = 1,
-      mem_cache_size = "10m",
+      mem_cache_size = MEM_CACHE_SIZE,
     }))
   end)
 


### PR DESCRIPTION
This change makes it actually all items from the cache (not only
mark them as "expired"), so that `safe_set` used in a subsequent
declarative config load can work if the previous one failed with
"memory full" (due to a too-large configuration that returned
HTTP 413).

This fixes some flakiness previously observed in tests, where
tests would pass when running individually but fail when running
in sequence with a smaller `mem_cache_size` configuration.
