### PR TITLE
fix(dbless) flip both kong.cache and kong.core_cache

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -422,6 +422,7 @@ local function register_events()
 
   if db.strategy == "off" then
     worker_events.register(function()
+      kong.cache:flip()
       core_cache:flip()
     end, "declarative", "flip_config")
   end


### PR DESCRIPTION
I noticed this when looking at the logs and spotting that when `kong.db.declarative.init` purges the shadow page, of both `kong.cache` and `kong.core_cache`, the page numbers for each were not in sync.
