### PR TITLE
fix(declarative) null handling

### DIFF
--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -248,7 +248,7 @@ function declarative.load_into_db(dc_table)
 end
 
 
-function declarative.export_from_db(fd)
+local function export_from_db(emitter)
   local schemas = {}
   for _, dao in pairs(kong.db.daos) do
     table.insert(schemas, dao.schema)
@@ -258,9 +258,9 @@ function declarative.export_from_db(fd)
     return nil, err
   end
 
-  fd:write(declarative.to_yaml_string({
+  emitter:emit_toplevel({
     _format_version = "1.1",
-  }))
+  })
 
   for _, schema in ipairs(sorted_schemas) do
     if schema.db_export == false then
@@ -269,94 +269,92 @@ function declarative.export_from_db(fd)
 
     local name = schema.name
     local fks = {}
-    for name, field in schema:each_field() do
+    for field_name, field in schema:each_field() do
       if field.type == "foreign" then
-        table.insert(fks, name)
+        table.insert(fks, field_name)
       end
     end
 
-    local first_row = true
     for row, err in kong.db[name]:each(nil, { nulls = true }) do
       if err then
         return nil, err
       end
 
-      for _, fname in ipairs(fks) do
-        if type(row[fname]) == "table" then
-          local id = row[fname].id
+      for _, foreign_name in ipairs(fks) do
+        if type(row[foreign_name]) == "table" then
+          local id = row[foreign_name].id
           if id ~= nil then
-            row[fname] = id
+            row[foreign_name] = id
           end
         end
       end
 
-      local yaml = declarative.to_yaml_string({ [name] = { row } })
-      if not first_row then
-        yaml = assert(yaml:match(REMOVE_FIRST_LINE_PATTERN))
-      end
-      first_row = false
-
-      fd:write(yaml)
+      emitter:emit_entity(name, row)
     end
 
     ::continue::
   end
 
-  return true
+  return emitter:done()
+end
+
+
+local fd_emitter = {
+  emit_toplevel = function(self, tbl)
+    self.fd:write(declarative.to_yaml_string(tbl))
+  end,
+
+  emit_entity = function(self, entity_name, entity_data)
+    local yaml = declarative.to_yaml_string({ [entity_name] = { entity_data } })
+    if entity_name == self.current_entity then
+      yaml = assert(yaml:match(REMOVE_FIRST_LINE_PATTERN))
+    end
+    self.fd:write(yaml)
+    self.current_entity = entity_name
+  end,
+
+  done = function()
+    return true
+  end,
+}
+
+
+function fd_emitter.new(fd)
+  return setmetatable({ fd = fd }, { __index = fd_emitter })
+end
+
+
+function declarative.export_from_db(fd)
+  return export_from_db(fd_emitter.new(fd))
+end
+
+
+local table_emitter = {
+  emit_toplevel = function(self, tbl)
+    self.out = tbl
+  end,
+
+  emit_entity = function(self, entity_name, entity_data)
+    if not self.out[entity_name] then
+      self.out[entity_name] = { entity_data }
+    else
+      table.insert(self.out[entity_name], entity_data)
+    end
+  end,
+
+  done = function(self)
+    return self.out
+  end,
+}
+
+
+function table_emitter.new()
+  return setmetatable({}, { __index = table_emitter })
 end
 
 
 function declarative.export_config()
-  local schemas = {}
-  for _, dao in pairs(kong.db.daos) do
-    table.insert(schemas, dao.schema)
-  end
-  local sorted_schemas, err = topological_sort(schemas)
-  if not sorted_schemas then
-    return nil, err
-  end
-
-  local out = { _format_version = "1.1" }
-
-  for _, schema in ipairs(sorted_schemas) do
-    if schema.db_export == false then
-      goto continue
-    end
-
-    local name = schema.name
-    local fks = {}
-    for name, field in schema:each_field() do
-      if field.type == "foreign" then
-        table.insert(fks, name)
-      end
-    end
-
-    for row, err in kong.db[name]:each() do
-      if err then
-        return nil, err
-      end
-
-      for _, fname in ipairs(fks) do
-        if type(row[fname]) == "table" then
-          local id = row[fname].id
-          if id ~= nil then
-            row[fname] = id
-          end
-        end
-      end
-
-      if not out[name] then
-        out[name] = { row }
-
-      else
-        table.insert(out[name], row)
-      end
-    end
-
-    ::continue::
-  end
-
-  return out
+  return export_from_db(table_emitter.new())
 end
 
 

--- a/kong/db/iteration.lua
+++ b/kong/db/iteration.lua
@@ -84,7 +84,7 @@ function iteration.by_row(self, pager, size, options)
       return row, nil, page
     end
 
-    row, err, err_t = self:row_to_entity(row)
+    row, err, err_t = self:row_to_entity(row, options)
     if not row then
       failed = true
       return false, err, err_t

--- a/kong/db/strategies/off/init.lua
+++ b/kong/db/strategies/off/init.lua
@@ -28,6 +28,7 @@ local function nil_cb()
   return nil
 end
 
+
 -- Returns a dict of entity_ids tagged according to the given criteria.
 -- Currently only the following kinds of keys are supported:
 -- * A key like `services|list` will only return service ids
@@ -153,6 +154,10 @@ local function page_for_key(self, key, size, offset, options)
       item = cache:get(schema_name .. ":" .. item .. "::::", nil, nil_cb)
     end
 
+    item = self.schema:process_auto_fields(item, "select", true, {
+      no_defaults = true
+    })
+
     ret[i - offset + 1] = item
   end
 
@@ -169,7 +174,16 @@ local function select_by_key(self, key)
     return nil
   end
 
-  return kong.core_cache:get(key, nil, nil_cb)
+  local entity, err = kong.core_cache:get(key, nil, nil_cb)
+  if not entity then
+    return nil, err
+  end
+
+  entity =  self.schema:process_auto_fields(entity, "select", true, {
+    no_defaults = true
+  })
+
+  return entity
 end
 
 

--- a/spec/02-integration/02-cmd/11-config_spec.lua
+++ b/spec/02-integration/02-cmd/11-config_spec.lua
@@ -72,7 +72,13 @@ describe("kong config", function()
           config:
             port: 10000
             host: 127.0.0.1
-
+      plugins:
+      - name: correlation-id
+        id: 467f719f-a544-4a8f-bc4b-7cd12913a9d4
+        config:
+          header_name: null
+          generator: "uuid"
+          echo_downstream: false
     ]])
 
     finally(function()
@@ -113,6 +119,26 @@ describe("kong config", function()
     local body = assert.res_status(200, res)
     local json = cjson.decode(body)
     assert.equals(2, #json.data)
+
+    local res = client:get("/plugins/467f719f-a544-4a8f-bc4b-7cd12913a9d4")
+    local body = assert.res_status(200, res)
+    local json = cjson.decode(body)
+    json.created_at = nil
+    json.protocols = nil
+    assert.same({
+      name = "correlation-id",
+      id = "467f719f-a544-4a8f-bc4b-7cd12913a9d4",
+      route = ngx.null,
+      service = ngx.null,
+      consumer = ngx.null,
+      enabled = true,
+      config = {
+        header_name = ngx.null,
+        generator = "uuid",
+        echo_downstream = false,
+      },
+      tags = ngx.null,
+    }, json)
 
     assert(helpers.stop_kong())
   end)

--- a/spec/02-integration/03-db/08-declarative_spec.lua
+++ b/spec/02-integration/03-db/08-declarative_spec.lua
@@ -91,6 +91,22 @@ for _, strategy in helpers.each_strategy() do
       }
     }
 
+    --[[ FIXME this case is known to cause an issue
+    local plugin_with_null_def = {
+      _tags = ngx.null,
+      created_at = 1547047308,
+      id = "57f5af80-8a44-4fbe-bd00-43ab58e2e5a5",
+      service = { id = service_def.id },
+      enabled = true,
+      name = "correlation-id",
+      config = {
+        header_name = ngx.null,
+        generator = "uuid",
+        echo_downstream = false,
+      }
+    }
+    --]]
+
     local acl_def = {
       _tags = ngx.null,
       created_at = 154796740,
@@ -113,7 +129,9 @@ for _, strategy in helpers.each_strategy() do
         routes = { [route_def.id] = route_def },
         services = { [service_def.id] = service_def },
         consumers = { [consumer_def.id] = consumer_def },
-        plugins = { [plugin_def.id] = plugin_def },
+        plugins = { [plugin_def.id] = plugin_def,
+        -- [plugin_with_null_def.id] = plugin_with_null_def,
+        },
         acls = { [acl_def.id] = acl_def  },
       }))
     end)
@@ -237,6 +255,14 @@ for _, strategy in helpers.each_strategy() do
         assert.equals(service.id, plugin.service)
         assert.equals("acl", plugin.name)
         assert.same(plugin_def.config, plugin.config)
+
+        --[[ FIXME this case is known to cause an issue
+        local plugin_with_null = assert(db.plugins:select({ id = plugin_with_null_def.id }, { nulls = true }))
+        assert.equals(plugin_with_null_def.id, plugin_with_null.id)
+        assert.equals(service.id, plugin_with_null.service.id)
+        assert.equals("correlation-id", plugin_with_null.name)
+        assert.same(plugin_with_null_def.config, plugin_with_null.config
+        --]]
 
         assert.equals(1, #yaml.acls)
         local acl = assert(yaml.acls[1])

--- a/spec/02-integration/03-db/08-declarative_spec.lua
+++ b/spec/02-integration/03-db/08-declarative_spec.lua
@@ -86,6 +86,7 @@ for _, strategy in helpers.each_strategy() do
       enabled = true,
       name = "acl",
       config = {
+        blacklist = ngx.null,
         whitelist = { "*" },
         hide_groups_header = false,
       }
@@ -163,7 +164,7 @@ for _, strategy in helpers.each_strategy() do
         assert.equals("andru", consumer_def.username)
         assert.equals("donalds", consumer_def.custom_id)
 
-        local plugin = assert(db.plugins:select({ id = plugin_def.id }))
+        local plugin = assert(db.plugins:select({ id = plugin_def.id }, { nulls = true }))
         assert.equals(plugin_def.id, plugin.id)
         assert.equals(service.id, plugin.service.id)
         assert.equals("acl", plugin.name)
@@ -254,6 +255,11 @@ for _, strategy in helpers.each_strategy() do
         assert.equals(plugin_def.id, plugin.id)
         assert.equals(service.id, plugin.service)
         assert.equals("acl", plugin.name)
+
+        -- lyaml.load above returns null as its own format
+        assert(plugin.config.blacklist == lyaml.null)
+        plugin.config.blacklist = ngx.null
+
         assert.same(plugin_def.config, plugin.config)
 
         --[[ FIXME this case is known to cause an issue

--- a/spec/02-integration/04-admin_api/15-off_spec.lua
+++ b/spec/02-integration/04-admin_api/15-off_spec.lua
@@ -346,6 +346,27 @@ describe("Admin API #off", function()
         assert.response(res).has.status(201)
       end)
 
+      it("accepts configuration containing null as a YAML string", function()
+        local res = assert(client:send {
+          method = "POST",
+          path = "/config",
+          body = {
+            config = [[
+            _format_version: "1.1"
+            routes:
+            - paths:
+              - "/"
+              service: null
+            ]],
+          },
+          headers = {
+            ["Content-Type"] = "application/json"
+          }
+        })
+
+        assert.response(res).has.status(201)
+      end)
+
       it("can reload upstreams (regression test)", function()
         local config = [[
           _format_version: "1.1"

--- a/spec/02-integration/04-admin_api/15-off_spec.lua
+++ b/spec/02-integration/04-admin_api/15-off_spec.lua
@@ -7,7 +7,7 @@ local mocker   = require("spec.fixtures.mocker")
 
 
 local WORKER_SYNC_TIMEOUT = 10
-local MEM_CACHE_SIZE = "5m"
+local MEM_CACHE_SIZE = "15m"
 
 
 local function it_content_types(title, fn)

--- a/spec/02-integration/04-admin_api/15-off_spec.lua
+++ b/spec/02-integration/04-admin_api/15-off_spec.lua
@@ -1,4 +1,5 @@
 local cjson    = require "cjson"
+local lyaml    = require "lyaml"
 local utils    = require "kong.tools.utils"
 local pl_utils = require "pl.utils"
 local helpers  = require "spec.helpers"
@@ -625,12 +626,17 @@ describe("Admin API #off", function()
 
         local body = assert.response(res).has.status(200)
         local json = cjson.decode(body)
-        local expected_config = "_format_version: '1.1'\n" ..
-          "consumers:\n" ..
-          "- created_at: 1566863706\n" ..
-          "  username: bobo\n" ..
-          "  id: d885e256-1abe-5e24-80b6-8f68fe59ea8e\n"
-        assert.same(expected_config, json.config)
+        local yaml_config = lyaml.load(json.config)
+        local expected_config = lyaml.load [[
+_format_version: "1.1"
+consumers:
+- created_at: 1566863706
+  username: bobo
+  id: d885e256-1abe-5e24-80b6-8f68fe59ea8e
+  custom_id: ~
+  tags: ~
+]]
+        assert.same(expected_config, yaml_config)
       end)
     end)
 


### PR DESCRIPTION
### Summary

#### fix(declarative) convert lyaml.null to ngx.null

The lyaml library uses its own representation for null. We need to preserve nulls for schema correctness.

#### fix(db) respect options when returning iteration values
#### tests(declarative) checks for null support
#### tests(dbless) increase memory size for dbless test 

The previous value caused a failure running locally. Add some more leeway to avoid flaky tests.

#### fix(declarative) ensure export_from_db exports nulls explicitly
#### refactor(declarative) dedup code in export_from_db and export_config 

Both functions need the same change to export nulls.

#### tests(db_export) verify it exports nulls
#### fix(declarative) fix missing nulls on read

Both Postgres and Cassandra strategies return null on fields that have null value stored in database. The DBless stores entities directly to cache where we don't keep nulls. But it has a problem that this commit tries to fix. This commit changes off strategy to fill nulls when the entities are accessed via DAO, the nulls are then later removed (again) by DAO when it calls process_auto_fields. This extra fill nulls is added to avoid the DAO process_auto_fields to fill explicit null values with possible default values.

### Issues Resolved

Fix #5834