### PR TITLE
fix(schema) validate_primary_key to check for invalid input

### DIFF
--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1361,13 +1361,15 @@ end
 -- entries.
 -- @return True on success; nil, error message and error table otherwise.
 function Schema:validate_primary_key(pk, ignore_others)
+  local pk_is_table = type(pk) == "table"
+
   local pk_set = {}
   local errors = {}
 
   for _, k in ipairs(self.primary_key) do
     pk_set[k] = true
     local field = self.fields[k]
-    local v = pk[k]
+    local v = pk_is_table and pk[k]
 
     if not v then
       errors[k] = validation_errors.MISSING_PK
@@ -1381,7 +1383,7 @@ function Schema:validate_primary_key(pk, ignore_others)
     end
   end
 
-  if not ignore_others then
+  if not ignore_others and pk_is_table then
     for k, _ in pairs(pk) do
       if not pk_set[k] then
         errors[k] = validation_errors.NOT_PK

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -560,19 +560,21 @@ local function populate_ids_for_validation(input, known_entities, parent_entity,
 end
 
 
-local function extract_null_errors(err)
+local function extract_pk_errors(err)
   local ret = {}
   for k, v in pairs(err) do
     local t = type(v)
     if t == "table" then
-      local res = extract_null_errors(v)
+      local res = extract_pk_errors(v)
       if not next(res) then
         ret[k] = nil
       else
         ret[k] = res
       end
 
-    elseif t == "string" and v ~= "value must be null" then
+    elseif t == "string" and v ~= "value must be null"
+                         and v ~= "expected a string"
+    then
       ret[k] = nil
     else
       ret[k] = v
@@ -597,7 +599,7 @@ local function flatten(self, input)
 
     local ok2, err2 = schema:validate(input_copy)
     if not ok2 then
-      local err3 = utils.deep_merge(err2, extract_null_errors(err))
+      local err3 = utils.deep_merge(err2, extract_pk_errors(err))
       return nil, err3
     end
   end

--- a/spec/01-unit/01-db/01-schema/01-schema_spec.lua
+++ b/spec/01-unit/01-db/01-schema/01-schema_spec.lua
@@ -1687,6 +1687,23 @@ describe("schema", function()
       }))
     end)
 
+    it("fails on invalid input", function()
+      local Test = Schema.new({
+        fields = {
+          { a = { type = "string"  }, },
+          { b = { type = "number" }, },
+          { c = { type = "number", default = 110 }, },
+        }
+      })
+      Test.primary_key = { "a", "c" }
+      local ok, err = Test:validate_primary_key(1234)
+      assert.falsy(ok)
+      assert.same({
+        a = 'missing primary key',
+        c = 'missing primary key' ,
+      }, err)
+    end)
+
   end)
 
   describe("validate_insert", function()

--- a/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
+++ b/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
@@ -2032,5 +2032,52 @@ describe("declarative config: flatten", function()
       local _, err = DeclarativeConfig:flatten(config)
       assert.equal(nil, err)
     end)
+
+    it("fixes #5974 - validation error on invalid input", function()
+      local config = assert(lyaml.load([[
+        _format_version: "1.1"
+
+        routes:
+        - hosts: [example.com]
+          methods: [GET]
+          paths: [/test]
+          name: 1585809442270
+          service: 1585809442270
+
+        services:
+        - {connect_timeout: 20000, name: '1585809442270', url: 'http://example.com'}
+      ]]))
+
+      local _, err = DeclarativeConfig:flatten(config)
+      assert.same({
+        routes = {
+          {
+            name = 'expected a string',
+            service = 'expected a string',
+          }
+        }
+      }, err)
+    end)
+
+    it("fixes #5974 - validation error on invalid input (with valid input)", function()
+      local config = assert(lyaml.load([[
+        _format_version: "1.1"
+
+        routes:
+        - hosts: [example.com]
+          methods: [GET]
+          paths: [/test]
+          name: "1585809442270"
+          service: "1585809442270"
+
+        services:
+        - {connect_timeout: 20000, name: '1585809442270', url: 'http://example.com'}
+      ]]))
+
+      local ok, err = DeclarativeConfig:flatten(config)
+      assert.truthy(ok)
+      assert.is_nil(err)
+    end)
+
   end)
 end)


### PR DESCRIPTION
### Summary

It was reported on #5974 that our code crashes with:

```
kong/db/schema/init.lua:1371: attempt to index local 'pk' (a number value)
```

On invalid input, in this case it was a declarative config with `number`
as pk instead of string.

This commit fixes the `schema:validate_primary_key` to check the input value
of `pk`.

(second try, as test didn't run on #6004)

### Issues Resolved

Fix #5974