### PR TITLE
fix(runloop) a more robust plugins iterator on init worker

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -550,16 +550,15 @@ function Kong.init_worker()
 
   runloop.init_worker.before()
 
+  local init_worker_plugins_iterator = runloop.build_plugins_iterator_for_init_worker_phase()
+  execute_plugins_iterator(init_worker_plugins_iterator, "init_worker")
 
   -- run plugins init_worker context
-  ok, err = runloop.update_plugins_iterator()
+  local retries = 5
+  ok, err = runloop.update_plugins_iterator(retries)
   if not ok then
-    stash_init_worker_error("failed to build the plugins iterator: " .. err)
-    return
+    ngx_log(ngx_ERR, "failed to build the plugins iterator: ", err)
   end
-
-  local plugins_iterator = runloop.get_plugins_iterator()
-  execute_plugins_iterator(plugins_iterator, "init_worker")
 
   if go.is_on() then
     go.manage_pluginserver()

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -109,6 +109,7 @@ local get_last_failure = ngx_balancer.get_last_failure
 local set_current_peer = ngx_balancer.set_current_peer
 local set_timeouts     = ngx_balancer.set_timeouts
 local set_more_tries   = ngx_balancer.set_more_tries
+local TTL_ZERO         = { ttl = 0 }
 
 
 local declarative_entities
@@ -273,7 +274,12 @@ local function load_declarative_config(kong_config, entities)
 
   if not kong_config.declarative_config then
     -- no configuration yet, just build empty plugins iterator
-    local ok, err = runloop.build_plugins_iterator(utils.uuid())
+    local new_version, err = kong.core_cache:get("plugins_iterator:version", TTL_ZERO, utils.uuid)
+    if err then
+      return nil, "failed to retrieve plugins iterator version: " .. err
+    end
+
+    local ok, err = runloop.build_plugins_iterator(new_version)
     if not ok then
       error("error building initial plugins iterator: " .. err)
     end

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -849,11 +849,17 @@ local function set_init_versions_in_cache()
   return true
 end
 
+local function build_plugins_iterator_for_init_worker_phase()
+  return PluginsIterator.new_for_init_worker_phase()
+end
+
 
 -- in the table below the `before` and `after` is to indicate when they run:
 -- before or after the plugins
 return {
   build_router = build_router,
+
+  build_plugins_iterator_for_init_worker_phase = build_plugins_iterator_for_init_worker_phase,
 
   build_plugins_iterator = build_plugins_iterator,
   update_plugins_iterator = update_plugins_iterator,

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -493,22 +493,30 @@ do
                    plugins_iterator_version, timeout)
   end
 
-
-  get_updated_plugins_iterator = function()
-    if kong.configuration.router_consistency == "strict" then
-      local ok, err = rebuild_plugins_iterator(PLUGINS_ITERATOR_SYNC_OPTS)
+  local build_initial_plugins_iterator = function()
+     local ok, err = rebuild_plugins_iterator(PLUGINS_ITERATOR_SYNC_OPTS)
       if not ok then
         -- If an error happens while updating, log it and return non-updated
         -- version
         log(ERR, "could not rebuild plugins iterator: ", err,
-                 " (stale plugins iterator will be used)")
+                 " (stale plugins iterator will be used if available)")
       end
+  end
+
+  get_updated_plugins_iterator = function()
+    if kong.configuration.router_consistency == "strict"
+    or not plugins_iterator
+    then
+      build_initial_plugins_iterator()
     end
     return plugins_iterator
   end
 
 
   get_plugins_iterator = function()
+    if not plugins_iterator then
+      build_initial_plugins_iterator()
+    end
     return plugins_iterator
   end
 

--- a/spec/02-integration/11-dbless/02-workers_spec.lua
+++ b/spec/02-integration/11-dbless/02-workers_spec.lua
@@ -1,0 +1,68 @@
+local helpers = require "spec.helpers"
+
+local fmt = string.format
+
+local SERVICE_YML = [[
+- name: my-service-%d
+  url: https://example%d.dev
+  plugins:
+  - name: key-auth
+  routes:
+  - name: my-route-%d
+    paths:
+    - /%d
+]]
+
+describe("Workers initialization #off", function()
+  local admin_client, proxy_client
+
+  lazy_setup(function()
+    helpers.get_db_utils("off", {
+      "routes",
+      "services",
+      "plugins",
+    })
+
+    assert(helpers.start_kong({
+      database   = "off",
+      nginx_worker_processes = 2,
+    }))
+
+    admin_client = assert(helpers.admin_client())
+    proxy_client = assert(helpers.proxy_client())
+  end)
+
+  lazy_teardown(function()
+    admin_client:close()
+    proxy_client:close()
+    helpers.stop_kong(nil, true)
+  end)
+
+  it("restarts worker correctly without issues on the init_worker phase when config includes 1000+ plugins", function()
+    local buffer = {"_format_version: '1.1'", "services:"}
+    for i = 1, 1001 do
+      buffer[#buffer + 1] = fmt(SERVICE_YML, i, i, i, i)
+    end
+    local config = table.concat(buffer, "\n")
+
+    local res = admin_client:post("/config",{
+      body = { config = config },
+      headers = {
+        ["Content-Type"] = "application/json"
+      }
+    })
+    assert.res_status(201, res)
+
+    -- make a request to ensure that proxying is working
+    -- (and to make some time for the worker to respawn)
+    res = assert(proxy_client:get("/1", { headers = { host = "example1.dev" } }))
+    assert.res_status(401, res)
+
+    local conf = helpers.get_running_conf()
+    local _, code = helpers.execute("grep -F 'error building initial plugins iterator: plugins iterator was changed while rebuilding it' " ..
+                                     conf.nginx_err_logs, true)
+    local not_found = 1
+    assert.equal(not_found, code)
+  end)
+end)
+

--- a/spec/02-integration/11-dbless/02-workers_spec.lua
+++ b/spec/02-integration/11-dbless/02-workers_spec.lua
@@ -17,15 +17,9 @@ describe("Workers initialization #off", function()
   local admin_client, proxy_client
 
   lazy_setup(function()
-    helpers.get_db_utils("off", {
-      "routes",
-      "services",
-      "plugins",
-    })
-
     assert(helpers.start_kong({
       database   = "off",
-      nginx_worker_processes = 2,
+      nginx_worker_processes = 1,
     }))
 
     admin_client = assert(helpers.admin_client())
@@ -53,16 +47,21 @@ describe("Workers initialization #off", function()
     })
     assert.res_status(201, res)
 
-    -- make a request to ensure that proxying is working
-    -- (and to make some time for the worker to respawn)
-    res = assert(proxy_client:get("/1", { headers = { host = "example1.dev" } }))
-    assert.res_status(401, res)
+    helpers.signal_workers(nil, "-TERM")
+
+    proxy_client:close()
+    proxy_client = assert(helpers.proxy_client())
 
     local conf = helpers.get_running_conf()
     local _, code = helpers.execute("grep -F 'error building initial plugins iterator: plugins iterator was changed while rebuilding it' " ..
                                      conf.nginx_err_logs, true)
     local not_found = 1
     assert.equal(not_found, code)
+
+    -- make a request to ensure that proxying is working
+    -- (and to make some time for the worker to respawn)
+    res = assert(proxy_client:get("/1", { headers = { host = "example1.dev" } }))
+    assert.res_status(401, res)
   end)
 end)
 


### PR DESCRIPTION
This PR includes two changes:
* It handles the creation of a Plugins Iterator on the Init Worker phase on a separate step, which fails less frequently.
* It changes the `get_*_plugin_iterator` functions so they don't assume that the plugins iterator is ready. They now check that the plugins iterator is there before using it, and attempt to recreate it once per request.

The reason we don't re-attempt to create the plugins iterator many times (at startup or on each request) is because we want to avoid a scenario in which two workers "compite with each other" by continuously re-creating the plugins iterator.