### PR TITLE
fix(dao) target dao and endpoints

### DIFF
--- a/kong/api/routes/upstreams.lua
+++ b/kong/api/routes/upstreams.lua
@@ -6,6 +6,7 @@ local kong = kong
 local escape_uri = ngx.escape_uri
 local unescape_uri = ngx.unescape_uri
 local null = ngx.null
+local tostring = tostring
 local fmt = string.format
 
 
@@ -44,6 +45,64 @@ local function post_health(self, db, is_healthy)
   end
 
   return kong.response.exit(204)
+end
+
+
+local function select_target_cb(self, db, upstream, target)
+  if target and target.weight ~= 0 then
+    return kong.response.exit(200, target)
+  end
+
+  return kong.response.exit(404, { message = "Not found" })
+end
+
+
+local function update_target_cb(self, db, upstream, target)
+  return kong.response.exit(405, { message = "Method not allowed" })
+end
+
+
+local function delete_target_cb(self, db, upstream, target)
+  self.params.targets = db.targets.schema:extract_pk_values(target)
+  local _, _, err_t = endpoints.delete_entity(self, db, db.targets.schema)
+  if err_t then
+    return endpoints.handle_error(err_t)
+  end
+
+  return kong.response.exit(204) -- no content
+end
+
+
+local function target_endpoint(self, db, callback)
+  local upstream, _, err_t = endpoints.select_entity(self, db, db.upstreams.schema)
+  if err_t then
+    return endpoints.handle_error(err_t)
+  end
+
+  if not upstream then
+    return kong.response.exit(404, { message = "Not found" })
+  end
+
+  local target
+  if utils.is_valid_uuid(unescape_uri(self.params.targets)) then
+    target, _, err_t = endpoints.select_entity(self, db, db.targets.schema)
+
+  else
+    local opts = endpoints.extract_options(self.args.uri, db.targets.schema, "select")
+    local upstream_pk = db.upstreams.schema:extract_pk_values(upstream)
+    local filter = { target = unescape_uri(self.params.targets) }
+    target, _, err_t = db.targets:select_by_upstream_filter(upstream_pk, filter, opts)
+  end
+
+  if err_t then
+    return endpoints.handle_error(err_t)
+  end
+
+  if not target or target.upstream.id ~= upstream.id then
+    return kong.response.exit(404, { message = "Not found" })
+  end
+
+  return callback(self, db, upstream, target)
 end
 
 
@@ -135,42 +194,14 @@ return {
 
   ["/upstreams/:upstreams/targets/:targets"] = {
     DELETE = function(self, db)
-      local upstream, _, err_t = endpoints.select_entity(self, db, db.upstreams.schema)
-      if err_t then
-        return endpoints.handle_error(err_t)
-      end
-
-      if not upstream then
-        return kong.response.exit(404, { message = "Not found" })
-      end
-
-      local target
-      if utils.is_valid_uuid(unescape_uri(self.params.targets)) then
-        target, _, err_t = endpoints.select_entity(self, db, db.targets.schema)
-
-      else
-        local opts = endpoints.extract_options(self.args.uri, db.targets.schema, "select")
-        local upstream_pk = db.upstreams.schema:extract_pk_values(upstream)
-        local filter = { target = unescape_uri(self.params.targets) }
-        target, _, err_t = db.targets:select_by_upstream_filter(upstream_pk, filter, opts)
-      end
-
-      if err_t then
-        return endpoints.handle_error(err_t)
-      end
-
-      if not target or target.upstream.id ~= upstream.id then
-        return kong.response.exit(404, { message = "Not found" })
-      end
-
-      self.params.targets = db.upstreams.schema:extract_pk_values(target)
-      _, _, err_t = endpoints.delete_entity(self, db, db.targets.schema)
-      if err_t then
-        return endpoints.handle_error(err_t)
-      end
-
-      return kong.response.exit(204) -- no content
-    end
+      return target_endpoint(self, db, delete_target_cb)
+    end,
+    GET = function(self, db)
+      return target_endpoint(self, db, select_target_cb)
+    end,
+    PATCH = function(self, db)
+      return target_endpoint(self, db, update_target_cb)
+    end,
   },
 }
 

--- a/kong/db/dao/targets.lua
+++ b/kong/db/dao/targets.lua
@@ -111,6 +111,18 @@ function _TARGETS:insert(entity, options)
 end
 
 
+function _TARGETS:upsert(pk, entity, options)
+  entity.id = pk.id
+  return self:insert(entity, options)
+end
+
+
+function _TARGETS:upsert_by_target(unique_key, entity, options)
+  entity.target = unique_key
+  return self:insert(entity, options)
+end
+
+
 function _TARGETS:delete(pk)
   local target, err, err_t = self:select(pk)
   if err then
@@ -335,7 +347,8 @@ function _TARGETS:select_by_upstream_filter(upstream_pk, filter, options)
     return nil, err, err_t
   end
 
-  for _, t in ipairs(targets) do
+  for i = #targets, 1, -1 do
+    local t = targets[i]
     if t.id == filter.id or t.target == filter.target then
       return t
     end

--- a/kong/db/dao/targets.lua
+++ b/kong/db/dao/targets.lua
@@ -92,7 +92,7 @@ local function format_target(target)
 end
 
 
-function _TARGETS:insert(entity)
+function _TARGETS:insert(entity, options)
   if entity.target then
     local formatted_target, err = format_target(entity.target)
     if not formatted_target then
@@ -106,9 +106,8 @@ function _TARGETS:insert(entity)
   -- entry AFTER the cleanup, such that the cleanup will be picked up by the
   -- other nodes based on the event of the newly added entry
   clean_history(self, entity.upstream)
-  local row, err, err_t = self.super.insert(self, entity)
 
-  return row, err, err_t
+  return self.super.insert(self, entity, options)
 end
 
 
@@ -126,8 +125,8 @@ function _TARGETS:delete(pk)
 end
 
 
-function _TARGETS:select(pk)
-  local target, err, err_t = self.super.select(self, pk)
+function _TARGETS:select(pk, options)
+  local target, err, err_t = self.super.select(self, pk, options)
   if err then
     return nil, err, err_t
   end
@@ -144,7 +143,7 @@ function _TARGETS:select(pk)
 end
 
 
-function _TARGETS:delete_by_target(tgt)
+function _TARGETS:delete_by_target(tgt, options)
   local target, err, err_t = self:select_by_target(tgt)
   if err then
     return nil, err, err_t
@@ -154,7 +153,7 @@ function _TARGETS:delete_by_target(tgt)
     target   = target.target,
     upstream = target.upstream,
     weight   = 0,
-  })
+  }, options)
 end
 
 

--- a/kong/db/iteration.lua
+++ b/kong/db/iteration.lua
@@ -2,6 +2,7 @@ local connector = require "kong.db.strategies.connector"
 
 
 local tostring = tostring
+local type = type
 
 
 local iteration = {}

--- a/spec/02-integration/03-db/02-db_core_entities_spec.lua
+++ b/spec/02-integration/03-db/02-db_core_entities_spec.lua
@@ -2359,6 +2359,14 @@ for _, strategy in helpers.each_strategy() do
           assert.not_nil(page)
           assert.is_string(offset)
         end)
+
+        it("respects nulls=true on targets too", function()
+          local page = db.targets:page_for_upstream({
+            id = upstream.id,
+          }, 1, nil, { nulls = true })
+          assert.not_nil(page)
+          assert.equal(cjson.null, page[1].tags)
+        end)
       end)
     end)
 

--- a/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -750,6 +750,136 @@ describe("Admin API #" .. strategy, function()
   end)
 
   describe("/upstreams/{upstream}/targets/{target}", function()
+    describe("GET", function()
+      local target
+      local upstream
+
+      before_each(function()
+        upstream = bp.upstreams:insert {}
+
+        bp.targets:insert {
+          target = "api-1:80",
+          weight = 10,
+          upstream = { id = upstream.id },
+        }
+
+        target = bp.targets:insert {
+          target = "api-2:80",
+          weight = 10,
+          upstream = { id = upstream.id },
+        }
+      end)
+
+      it("returns target entity", function()
+        local res = client:get("/upstreams/" .. upstream.name .. "/targets/" .. target.target)
+        assert.response(res).has.status(200)
+        local json = assert.response(res).has.jsonbody()
+        json.tags = nil
+        assert.same(target, json)
+      end)
+    end)
+
+    describe("PATCH", function()
+      local target
+      local upstream
+
+      before_each(function()
+        upstream = bp.upstreams:insert {}
+
+        bp.targets:insert {
+          target = "api-1:80",
+          weight = 10,
+          upstream = { id = upstream.id },
+        }
+
+        -- predefine the target to mock delete
+        target = bp.targets:insert {
+          target = "api-2:80",
+          weight = 10,
+          upstream = { id = upstream.id },
+        }
+      end)
+
+      it("is disallowed", function()
+        local res = client:patch("/upstreams/" .. upstream.name .. "/targets/" .. target.target, {
+          body = {
+            weight = 100,
+          },
+          headers = { ["Content-Type"] = "application/json" }
+        })
+
+        assert.response(res).has.status(405)
+        local json = assert.response(res).has.jsonbody()
+        assert.same({ message = "Method not allowed" }, json)
+      end)
+    end)
+
+    describe("PUT", function()
+      local target
+      local upstream
+
+      before_each(function()
+        upstream = bp.upstreams:insert {}
+
+        bp.targets:insert {
+          target = "api-1:80",
+          weight = 10,
+          upstream = { id = upstream.id },
+        }
+
+        target = bp.targets:insert {
+          target = "api-2:80",
+          weight = 10,
+          upstream = { id = upstream.id },
+        }
+      end)
+
+      it("acts as a sugar method to POST (by id)", function()
+        local res = client:put("/upstreams/" .. upstream.name .. "/targets/" .. target.id, {
+          body = {
+            target = target.target
+          },
+          headers = { ["Content-Type"] = "application/json" }
+        })
+
+        -- the targets cannot be updated nor deleted, they are only rotated
+        assert.response(res).has.status(400)
+        local err = assert.response(res).has.jsonbody()
+        assert.equal("primary key violation on key '{id=\"" .. target.id .. "\"}'", err.message)
+
+        res = client:get("/upstreams/" .. upstream.name .. "/targets/" .. target.id)
+        assert.response(res).has.status(200)
+        local json = assert.response(res).has.jsonbody()
+        json.tags = nil
+        assert.same(target, json)
+
+        local uuid = utils.uuid()
+        local res = client:put("/upstreams/" .. upstream.name .. "/targets/" .. uuid, {
+          body = {
+            target = target.target
+          },
+          headers = { ["Content-Type"] = "application/json" }
+        })
+        assert.response(res).has.status(200)
+        local tgt = assert.response(res).has.jsonbody()
+
+        res = client:get("/upstreams/" .. upstream.name .. "/targets/" .. uuid)
+        assert.response(res).has.status(200)
+        local json = assert.response(res).has.jsonbody()
+        assert.same(tgt, json)
+      end)
+
+      it("acts as a sugar method to POST (by target)", function()
+        local res = client:put("/upstreams/" .. upstream.name .. "/targets/" .. target.target)
+        assert.response(res).has.status(200)
+        local tgt = assert.response(res).has.jsonbody()
+        res = client:get("/upstreams/" .. upstream.name .. "/targets/" .. target.target)
+        assert.response(res).has.status(200)
+        local json = assert.response(res).has.jsonbody()
+        assert.same(tgt, json)
+      end)
+    end)
+
     describe("DELETE", function()
       local target
 


### PR DESCRIPTION
### Summary

#### fix(dao) iteration to pass options to row to entity 

Iterator had issue that it did not pass options to when it called
`dao:row_to_entity`.

E.g. `http :8001/upstreams/upstream/targets` returned:

```
{
    "data": [
        {
            "created_at": 1591010002.497,
            "id": "06f8e88f-f874-44ab-a6bf-989e58a505ba",
            "target": "127.0.0.1:8000",
            "upstream": {
                "id": "5f3a5828-7e09-4d80-b899-41b0111510cd"
            },
            "weight": 100
        }
    ],
    "next": null
}
```

Instead of:
```
{
    "data": [
        {
            "created_at": 1591010002.497,
            "id": "06f8e88f-f874-44ab-a6bf-989e58a505ba",
            "tags": null,
            "target": "127.0.0.1:8000",
            "upstream": {
                "id": "5f3a5828-7e09-4d80-b899-41b0111510cd"
            },
            "weight": 100
        }
    ],
    "next": null
}
```

On Admin API (see the missing `tags=null`).

#### fix(dao) targets to pass options on custom dao methods 

Targets did not pass the options on custom dao calls, this
commit fixes that.

#### fix(dao) implement upserts as synonym to inserts on targets

Targets gave `500` error on:
```
http PUT :8001/upstreams/example.com/targets/127.0.0.1
```

This commit fixes that.

#### fix(api) upstream targets endpoints fixes

1. disallow (405) PATCH on /upstreams/:upstreams/targets/:targets
2. make GET to do proper pre-checks on /upstreams/:upstreams/targets/:targets
3. make PUT to do proper pre-checks on /upstreams/:upstreams/targets/:targets