### PR TITLE
fix(balancer) remove redundant call on upstream delete

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -322,8 +322,14 @@ local function register_events()
     local operation = data.operation
     local target = data.entity
 
-    -- => to balancer update
-    balancer.on_target_event(operation, target)
+    local upstream_id = target.upstream.id
+    local upstream_cache_key = "balancer:upstreams:" .. upstream_id
+    local upstream = core_cache:get(upstream_cache_key, nil, function() end)
+
+    if upstream then
+      -- => to balancer update
+      balancer.on_target_event(operation, target)
+    end
   end, "balancer", "targets")
 
 


### PR DESCRIPTION
Remove a superfluous call to `on_target_event` when we delete an
upstream that has targets associated with it.

This ensures that the function `on_target_event` won't be called when we
delete an upstream with its targets since we already invalidate the
upstream's targets cache in the `on_upstream_event` function (also on the
db by the dao), so we shouldn't be calling `on_target_event` after that.

To reproduce:
```
http :8001/upstreams name=six
http :8001/upstreams/six/targets target=localhost:80
http DELETE :8001/upstreams/59e4b2a8-1bb1-45af-9105-672d80882e1b

2020/06/16 21:40:38 [error] 57008#0: *313 [lua] balancer.lua:670: cb(): target delete: upstream not found for 59e4b2a8-1bb1-45af-9105-672d80882e1b, client: 127.0.0.1, server: kong_admin, request: "DELETE /upstreams/59e4b2a8-1bb1-45af-9105-672d80882e1b HTTP/1.1", host: "localhost:8001"
```

The above error log is misleading as we already deleted the upstream and
its target cache at `on_upstream_event` (we also deleted it from the db).

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->