### PR TITLE
feat(pdk) log serializer can not be used in stream subsystem

### DIFF
--- a/kong/pdk/log.lua
+++ b/kong/pdk/log.lua
@@ -25,6 +25,7 @@ local concat = table.concat
 local getinfo = debug.getinfo
 local reverse = string.reverse
 local tostring = tostring
+local tonumber = tonumber
 local setmetatable = setmetatable
 local ngx = ngx
 local kong = kong
@@ -477,84 +478,141 @@ do
   -- @phases log
   -- @usage
   -- kong.log.serialize()
-  function serialize(options)
-    check_phase(PHASES_LOG)
+  if ngx.config.subsystem == "http" then
+    function serialize(options)
+      check_phase(PHASES_LOG)
 
-    local ongx = (options or {}).ngx or ngx
-    local okong = (options or {}).kong or kong
+      local ongx = (options or {}).ngx or ngx
+      local okong = (options or {}).kong or kong
 
-    local ctx = ongx.ctx
-    local var = ongx.var
-    local req = ongx.req
+      local ctx = ongx.ctx
+      local var = ongx.var
+      local req = ongx.req
 
-    local authenticated_entity
-    if ctx.authenticated_credential ~= nil then
-      authenticated_entity = {
-        id = ctx.authenticated_credential.id,
-        consumer_id = ctx.authenticated_credential.consumer_id
+      local authenticated_entity
+      if ctx.authenticated_credential ~= nil then
+        authenticated_entity = {
+          id = ctx.authenticated_credential.id,
+          consumer_id = ctx.authenticated_credential.consumer_id
+        }
+      end
+
+      local request_tls
+      local request_tls_ver = ngx_ssl.get_tls1_version_str()
+      if request_tls_ver then
+        request_tls = {
+          version = request_tls_ver,
+          cipher = var.ssl_cipher,
+          client_verify = ngx.ctx.CLIENT_VERIFY_OVERRIDE or var.ssl_client_verify,
+        }
+      end
+
+      local request_uri = var.request_uri or ""
+
+      local req_headers = okong.request.get_headers()
+      for _, header in ipairs(REDACTED_REQUEST_HEADERS) do
+        if req_headers[header] then
+          req_headers[header] = "REDACTED"
+        end
+      end
+
+      local resp_headers = ongx.resp.get_headers()
+      for _, header in ipairs(REDACTED_RESPONSE_HEADERS) do
+        if resp_headers[header] then
+          resp_headers[header] = "REDACTED"
+        end
+      end
+
+      local host_port = ctx.host_port or var.server_port
+
+      return {
+        request = {
+          uri = request_uri,
+          url = var.scheme .. "://" .. var.host .. ":" .. host_port .. request_uri,
+          querystring = okong.request.get_query(), -- parameters, as a table
+          method = okong.request.get_method(), -- http method
+          headers = req_headers,
+          size = var.request_length,
+          tls = request_tls
+        },
+        upstream_uri = var.upstream_uri,
+        response = {
+          status = ongx.status,
+          headers = resp_headers,
+          size = var.bytes_sent
+        },
+        tries = (ctx.balancer_data or {}).tries,
+        latencies = {
+          kong = (ctx.KONG_ACCESS_TIME or 0) +
+                 (ctx.KONG_RECEIVE_TIME or 0) +
+                 (ctx.KONG_REWRITE_TIME or 0) +
+                 (ctx.KONG_BALANCER_TIME or 0),
+          proxy = ctx.KONG_WAITING_TIME or -1,
+          request = var.request_time * 1000
+        },
+        authenticated_entity = authenticated_entity,
+        route = ctx.route,
+        service = ctx.service,
+        consumer = ctx.authenticated_consumer,
+        client_ip = var.remote_addr,
+        started_at = req.start_time() * 1000
       }
     end
 
-    local request_tls
-    local request_tls_ver = ngx_ssl.get_tls1_version_str()
-    if request_tls_ver then
-      request_tls = {
-        version = request_tls_ver,
-        cipher = var.ssl_cipher,
-        client_verify = ngx.ctx.CLIENT_VERIFY_OVERRIDE or var.ssl_client_verify,
+  else
+    function serialize(options)
+      check_phase(PHASES_LOG)
+
+      local ongx = (options or {}).ngx or ngx
+
+      local ctx = ongx.ctx
+      local var = ongx.var
+      local req = ongx.req
+
+      local authenticated_entity
+      if ctx.authenticated_credential ~= nil then
+        authenticated_entity = {
+          id = ctx.authenticated_credential.id,
+          consumer_id = ctx.authenticated_credential.consumer_id
+        }
+      end
+
+      local session_tls
+      local session_tls_ver = ngx_ssl.get_tls1_version_str()
+      if session_tls_ver then
+        session_tls = {
+          version = session_tls_ver,
+          cipher = var.ssl_cipher,
+          client_verify = ngx.ctx.CLIENT_VERIFY_OVERRIDE or var.ssl_client_verify,
+        }
+      end
+
+      return {
+        session = {
+          tls = session_tls,
+          received = tonumber(var.bytes_received, 10),
+          sent = tonumber(var.bytes_sent, 10),
+          status = ongx.status,
+          server_port = tonumber(var.server_port, 10),
+        },
+        upstream = {
+          received = tonumber(var.upstream_bytes_received, 10),
+          sent = tonumber(var.upstream_bytes_sent, 10),
+        },
+        tries = (ctx.balancer_data or {}).tries,
+        latencies = {
+          kong = (ctx.KONG_PREREAD_TIME or 0) +
+                 (ctx.KONG_BALANCER_TIME or 0),
+          session = var.session_time * 1000,
+        },
+        authenticated_entity = authenticated_entity,
+        route = ctx.route,
+        service = ctx.service,
+        consumer = ctx.authenticated_consumer,
+        client_ip = var.remote_addr,
+        started_at = req.start_time() * 1000
       }
     end
-
-    local request_uri = var.request_uri or ""
-
-    local req_headers = okong.request.get_headers()
-    for _, header in ipairs(REDACTED_REQUEST_HEADERS) do
-      if req_headers[header] then
-        req_headers[header] = "REDACTED"
-      end
-    end
-
-    local resp_headers = ongx.resp.get_headers()
-    for _, header in ipairs(REDACTED_RESPONSE_HEADERS) do
-      if resp_headers[header] then
-        resp_headers[header] = "REDACTED"
-      end
-    end
-
-    local host_port = ctx.host_port or var.server_port
-
-    return {
-      request = {
-        uri = request_uri,
-        url = var.scheme .. "://" .. var.host .. ":" .. host_port .. request_uri,
-        querystring = okong.request.get_query(), -- parameters, as a table
-        method = okong.request.get_method(), -- http method
-        headers = req_headers,
-        size = var.request_length,
-        tls = request_tls
-      },
-      upstream_uri = var.upstream_uri,
-      response = {
-        status = ongx.status,
-        headers = resp_headers,
-        size = var.bytes_sent
-      },
-      tries = (ctx.balancer_data or {}).tries,
-      latencies = {
-        kong = (ctx.KONG_ACCESS_TIME or 0) +
-               (ctx.KONG_RECEIVE_TIME or 0) +
-               (ctx.KONG_REWRITE_TIME or 0) +
-               (ctx.KONG_BALANCER_TIME or 0),
-        proxy = ctx.KONG_WAITING_TIME or -1,
-        request = var.request_time * 1000
-      },
-      authenticated_entity = authenticated_entity,
-      route = ctx.route,
-      service = ctx.service,
-      consumer = ctx.authenticated_consumer,
-      client_ip = var.remote_addr,
-      started_at = req.start_time() * 1000
-    }
   end
 end
 

--- a/kong/pdk/log.lua
+++ b/kong/pdk/log.lua
@@ -587,13 +587,15 @@ do
         }
       end
 
+      local host_port = ctx.host_port or var.server_port
+
       return {
         session = {
           tls = session_tls,
           received = tonumber(var.bytes_received, 10),
           sent = tonumber(var.bytes_sent, 10),
           status = ongx.status,
-          server_port = tonumber(var.server_port, 10),
+          server_port = tonumber(host_port, 10),
         },
         upstream = {
           received = tonumber(var.upstream_bytes_received, 10),

--- a/kong/plugins/datadog/schema.lua
+++ b/kong/plugins/datadog/schema.lua
@@ -68,7 +68,7 @@ local DEFAULT_METRICS = {
 return {
   name = "datadog",
   fields = {
-    { protocols = typedefs.protocols_http },
+    { protocols = typedefs.protocols },
     { config = {
         type = "record",
         default = { metrics = DEFAULT_METRICS },

--- a/kong/plugins/file-log/schema.lua
+++ b/kong/plugins/file-log/schema.lua
@@ -3,7 +3,7 @@ local typedefs = require "kong.db.schema.typedefs"
 return {
   name = "file-log",
   fields = {
-    { protocols = typedefs.protocols_http },
+    { protocols = typedefs.protocols },
     { config = {
         type = "record",
         fields = {

--- a/kong/plugins/http-log/schema.lua
+++ b/kong/plugins/http-log/schema.lua
@@ -3,7 +3,7 @@ local typedefs = require "kong.db.schema.typedefs"
 return {
   name = "http-log",
   fields = {
-    { protocols = typedefs.protocols_http },
+    { protocols = typedefs.protocols },
     { config = {
         type = "record",
         fields = {

--- a/kong/plugins/log-serializers/basic.lua
+++ b/kong/plugins/log-serializers/basic.lua
@@ -6,16 +6,18 @@ local kong = kong
 
 local WARNING_SHOWN = false
 
+-- stream log serializer is new, so no one should be depending on this proxy...
+if ngx.config.subsystem == "http" then
+  function _M.serialize(ongx, okong)
+    if not WARNING_SHOWN then
+      kong.log.warn("basic log serializer has been deprecated, please modify " ..
+                    "your plugin to use the kong.log.serialize PDK function " ..
+                    "instead")
+      WARNING_SHOWN = true
+    end
 
-function _M.serialize(ongx, okong)
-  if not WARNING_SHOWN then
-    kong.log.warn("basic log serializer has been deprecated, please modify " ..
-                  "your plugin to use the kong.log.serialize PDK function " ..
-                  "instead")
-    WARNING_SHOWN = true
+    return kong.log.serialize({ ngx = ongx, kong = okong, })
   end
-
-  return kong.log.serialize({ ngx = ongx, kong = okong, })
 end
 
 

--- a/kong/plugins/loggly/schema.lua
+++ b/kong/plugins/loggly/schema.lua
@@ -9,7 +9,7 @@ local severity = {
 return {
   name = "loggly",
   fields = {
-    { protocols = typedefs.protocols_http },
+    { protocols = typedefs.protocols },
     { config = {
         type = "record",
         fields = {

--- a/kong/plugins/statsd/schema.lua
+++ b/kong/plugins/statsd/schema.lua
@@ -72,7 +72,7 @@ local DEFAULT_METRICS = {
 return {
   name = "statsd",
   fields = {
-    { protocols = typedefs.protocols_http },
+    { protocols = typedefs.protocols },
     { config = {
         type = "record",
         fields = {

--- a/kong/plugins/syslog/schema.lua
+++ b/kong/plugins/syslog/schema.lua
@@ -9,7 +9,7 @@ local severity = {
 return {
   name = "syslog",
   fields = {
-    { protocols = typedefs.protocols_http },
+    { protocols = typedefs.protocols },
     { config = {
         type = "record",
         fields = {

--- a/kong/plugins/tcp-log/schema.lua
+++ b/kong/plugins/tcp-log/schema.lua
@@ -3,7 +3,7 @@ local typedefs = require "kong.db.schema.typedefs"
 return {
   name = "tcp-log",
   fields = {
-    { protocols = typedefs.protocols_http },
+    { protocols = typedefs.protocols },
     { config = {
         type = "record",
         fields = {

--- a/kong/plugins/udp-log/schema.lua
+++ b/kong/plugins/udp-log/schema.lua
@@ -3,7 +3,7 @@ local typedefs = require "kong.db.schema.typedefs"
 return {
   name = "udp-log",
   fields = {
-    { protocols = typedefs.protocols_http },
+    { protocols = typedefs.protocols },
     { config = {
         type = "record",
         fields = {

--- a/spec/01-unit/10-log_serializer_spec.lua
+++ b/spec/01-unit/10-log_serializer_spec.lua
@@ -2,191 +2,351 @@ require("spec.helpers")
 local basic = require("kong.plugins.log-serializers.basic")
 local LOG_PHASE = require("kong.pdk.private.phases").phases.log
 
-describe("Log Serializer", function()
-  before_each(function()
-    _G.ngx = {
-      ctx = {
-        balancer_data = {
-          tries = {
-            {
-              ip = "127.0.0.1",
-              port = 8000,
+describe("kong.log.serialize", function()
+  describe("#http", function()
+    before_each(function()
+      _G.ngx = {
+        config = {
+          subsystem = "http",
+        },
+        ctx = {
+          balancer_data = {
+            tries = {
+              {
+                ip = "127.0.0.1",
+                port = 8000,
+              },
             },
           },
         },
-      },
-      var = {
-        request_uri = "/request_uri",
-        upstream_uri = "/upstream_uri",
-        scheme = "http",
-        host = "test.com",
-        server_port = 80,
-        request_length = 200,
-        bytes_sent = 99,
-        request_time = 2,
-        remote_addr = "1.1.1.1"
-      },
-      update_time = ngx.update_time,
-      sleep = ngx.sleep,
-      time = ngx.time,
-      req = {
-        get_uri_args = function() return {"arg1", "arg2"} end,
-        get_method = function() return "POST" end,
-        get_headers = function() return {header1 = "header1", header2 = "header2", authorization = "authorization"} end,
-        start_time = function() return 3 end
-      },
-      resp = {
-        get_headers = function() return {header1 = "respheader1", header2 = "respheader2", ["set-cookie"] = "delicious=delicacy"} end
-      },
-    }
-
-    package.loaded["kong.pdk.request"] = nil
-    local pdk_request = require "kong.pdk.request"
-    kong.request = pdk_request.new(kong)
-    kong.ctx.core.phase = LOG_PHASE
-  end)
-
-  describe("Basic", function()
-    it("serializes without API, Consumer or Authenticated entity", function()
-      local res = kong.log.serialize({ngx = ngx, kong = kong, })
-      assert.is_table(res)
-
-      -- Simple properties
-      assert.equals("1.1.1.1", res.client_ip)
-      assert.equals(3000, res.started_at)
-
-      -- Latencies
-      assert.is_table(res.latencies)
-      assert.equal(0, res.latencies.kong)
-      assert.equal(-1, res.latencies.proxy)
-      assert.equal(2000, res.latencies.request)
-
-      -- Request
-      assert.is_table(res.request)
-      assert.same({header1 = "header1", header2 = "header2", authorization = "REDACTED"}, res.request.headers)
-      assert.equal("POST", res.request.method)
-      assert.same({"arg1", "arg2"}, res.request.querystring)
-      assert.equal("http://test.com:80/request_uri", res.request.url)
-      assert.equal("/upstream_uri", res.upstream_uri)
-      assert.equal(200, res.request.size)
-      assert.equal("/request_uri", res.request.uri)
-
-      -- Response
-      assert.is_table(res.response)
-      assert.same({header1 = "respheader1", header2 = "respheader2", ["set-cookie"] = "delicious=delicacy"}, res.response.headers)
-      assert.equal(99, res.response.size)
-
-      assert.is_nil(res.api)
-      assert.is_nil(res.consumer)
-      assert.is_nil(res.authenticated_entity)
-
-      -- Tries
-      assert.is_table(res.tries)
-    end)
-
-    it("uses port map (ngx.ctx.host_port) for request url ", function()
-      ngx.ctx.host_port = 5000
-      local res = kong.log.serialize({ngx = ngx, kong = kong, })
-      assert.is_table(res)
-      assert.is_table(res.request)
-      assert.equal("http://test.com:5000/request_uri", res.request.url)
-    end)
-
-    it("serializes the matching Route and Services", function()
-      ngx.ctx.route = { id = "my_route" }
-      ngx.ctx.service = { id = "my_service" }
-
-      local res = kong.log.serialize({ngx = ngx, kong = kong, })
-      assert.is_table(res)
-
-      assert.equal("my_route", res.route.id)
-      assert.equal("my_service", res.service.id)
-      assert.is_nil(res.consumer)
-      assert.is_nil(res.authenticated_entity)
-    end)
-
-    it("serializes the Consumer object", function()
-      ngx.ctx.authenticated_consumer = {id = "someconsumer"}
-
-      local res = kong.log.serialize({ngx = ngx, kong = kong, })
-      assert.is_table(res)
-
-      assert.equal("someconsumer", res.consumer.id)
-      assert.is_nil(res.api)
-      assert.is_nil(res.authenticated_entity)
-    end)
-
-    it("serializes the Authenticated Entity object", function()
-      ngx.ctx.authenticated_credential = {id = "somecred",
-                                          consumer_id = "user1"}
-
-      local res = kong.log.serialize({ngx = ngx, kong = kong, })
-      assert.is_table(res)
-
-      assert.same({id = "somecred", consumer_id = "user1"},
-                  res.authenticated_entity)
-      assert.is_nil(res.consumer)
-      assert.is_nil(res.api)
-    end)
-
-    it("serializes the tries and failure information", function()
-      ngx.ctx.balancer_data.tries = {
-        { ip = "127.0.0.1", port = 1234, state = "next",   code = 502 },
-        { ip = "127.0.0.1", port = 1234, state = "failed", code = nil },
-        { ip = "127.0.0.1", port = 1234 },
+        var = {
+          request_uri = "/request_uri",
+          upstream_uri = "/upstream_uri",
+          scheme = "http",
+          host = "test.com",
+          server_port = 80,
+          request_length = 200,
+          bytes_sent = 99,
+          request_time = 2,
+          remote_addr = "1.1.1.1"
+        },
+        update_time = ngx.update_time,
+        sleep = ngx.sleep,
+        time = ngx.time,
+        req = {
+          get_uri_args = function() return {"arg1", "arg2"} end,
+          get_method = function() return "POST" end,
+          get_headers = function() return {header1 = "header1", header2 = "header2", authorization = "authorization"} end,
+          start_time = function() return 3 end
+        },
+        resp = {
+          get_headers = function() return {header1 = "respheader1", header2 = "respheader2", ["set-cookie"] = "delicious=delicacy"} end
+        },
       }
 
-      local res = kong.log.serialize({ngx = ngx, kong = kong, })
-      assert.is_table(res)
+      package.loaded["kong.pdk.request"] = nil
+      local pdk_request = require "kong.pdk.request"
+      kong.request = pdk_request.new(kong)
+      kong.ctx.core.phase = LOG_PHASE
+    end)
 
-      assert.same({
-          {
-            code  = 502,
-            ip    = '127.0.0.1',
-            port  = 1234,
-            state = 'next',
-          }, {
-            ip    = '127.0.0.1',
-            port  = 1234,
-            state = 'failed',
-          }, {
-            ip    = '127.0.0.1',
-            port  = 1234,
+    describe("Basic", function()
+      it("serializes without API, Consumer or Authenticated entity", function()
+        local res = kong.log.serialize({ngx = ngx, kong = kong, })
+        assert.is_table(res)
+
+        -- Simple properties
+        assert.equals("1.1.1.1", res.client_ip)
+        assert.equals(3000, res.started_at)
+
+        -- Latencies
+        assert.is_table(res.latencies)
+        assert.equal(0, res.latencies.kong)
+        assert.equal(-1, res.latencies.proxy)
+        assert.equal(2000, res.latencies.request)
+
+        -- Request
+        assert.is_table(res.request)
+        assert.same({header1 = "header1", header2 = "header2", authorization = "REDACTED"}, res.request.headers)
+        assert.equal("POST", res.request.method)
+        assert.same({"arg1", "arg2"}, res.request.querystring)
+        assert.equal("http://test.com:80/request_uri", res.request.url)
+        assert.equal("/upstream_uri", res.upstream_uri)
+        assert.equal(200, res.request.size)
+        assert.equal("/request_uri", res.request.uri)
+
+        -- Response
+        assert.is_table(res.response)
+        assert.same({header1 = "respheader1", header2 = "respheader2", ["set-cookie"] = "delicious=delicacy"}, res.response.headers)
+        assert.equal(99, res.response.size)
+
+        assert.is_nil(res.api)
+        assert.is_nil(res.consumer)
+        assert.is_nil(res.authenticated_entity)
+
+        -- Tries
+        assert.is_table(res.tries)
+      end)
+
+      it("uses port map (ngx.ctx.host_port) for request url ", function()
+        ngx.ctx.host_port = 5000
+        local res = kong.log.serialize({ngx = ngx, kong = kong, })
+        assert.is_table(res)
+        assert.is_table(res.request)
+        assert.equal("http://test.com:5000/request_uri", res.request.url)
+      end)
+
+      it("serializes the matching Route and Services", function()
+        ngx.ctx.route = { id = "my_route" }
+        ngx.ctx.service = { id = "my_service" }
+
+        local res = kong.log.serialize({ngx = ngx, kong = kong, })
+        assert.is_table(res)
+
+        assert.equal("my_route", res.route.id)
+        assert.equal("my_service", res.service.id)
+        assert.is_nil(res.consumer)
+        assert.is_nil(res.authenticated_entity)
+      end)
+
+      it("serializes the Consumer object", function()
+        ngx.ctx.authenticated_consumer = {id = "someconsumer"}
+
+        local res = kong.log.serialize({ngx = ngx, kong = kong, })
+        assert.is_table(res)
+
+        assert.equal("someconsumer", res.consumer.id)
+        assert.is_nil(res.api)
+        assert.is_nil(res.authenticated_entity)
+      end)
+
+      it("serializes the Authenticated Entity object", function()
+        ngx.ctx.authenticated_credential = {id = "somecred",
+                                            consumer_id = "user1"}
+
+        local res = kong.log.serialize({ngx = ngx, kong = kong, })
+        assert.is_table(res)
+
+        assert.same({id = "somecred", consumer_id = "user1"},
+                    res.authenticated_entity)
+        assert.is_nil(res.consumer)
+        assert.is_nil(res.api)
+      end)
+
+      it("serializes the tries and failure information", function()
+        ngx.ctx.balancer_data.tries = {
+          { ip = "127.0.0.1", port = 1234, state = "next",   code = 502 },
+          { ip = "127.0.0.1", port = 1234, state = "failed", code = nil },
+          { ip = "127.0.0.1", port = 1234 },
+        }
+
+        local res = kong.log.serialize({ngx = ngx, kong = kong, })
+        assert.is_table(res)
+
+        assert.same({
+            {
+              code  = 502,
+              ip    = '127.0.0.1',
+              port  = 1234,
+              state = 'next',
+            }, {
+              ip    = '127.0.0.1',
+              port  = 1234,
+              state = 'failed',
+            }, {
+              ip    = '127.0.0.1',
+              port  = 1234,
+            },
+          }, res.tries)
+      end)
+
+      it("does not fail when the 'balancer_data' structure is missing", function()
+        ngx.ctx.balancer_data = nil
+
+        local res = kong.log.serialize({ngx = ngx, kong = kong, })
+        assert.is_table(res)
+
+        assert.is_nil(res.tries)
+      end)
+
+      it("basic serializer proxy works with a deprecation warning", function()
+        local warned = false
+        local orig_warn = kong.log.warn
+
+        kong.log.warn = function(msg)
+          assert.is_false(warned, "duplicate warning")
+
+          warned = true
+
+          return orig_warn(msg)
+        end
+
+        local res = basic.serialize(ngx, kong)
+        assert.is_table(res)
+
+        assert.equals("1.1.1.1", res.client_ip)
+
+        -- 2nd time
+        res = basic.serialize(ngx, kong)
+        assert.is_table(res)
+
+        kong.log.warn = orig_warn
+      end)
+    end)
+  end)
+
+  describe("#stream", function()
+    before_each(function()
+      _G.ngx = {
+        config = {
+          subsystem = "stream",
+        },
+        ctx = {
+          balancer_data = {
+            tries = {
+              {
+                ip = "127.0.0.1",
+                port = 8000,
+              },
+            },
           },
-        }, res.tries)
+        },
+        var = {
+          bytes_received = 99,
+          bytes_sent = 100,
+          upstream_bytes_received = 200,
+          upstream_bytes_sent = 300,
+          session_time = "2.123",
+          remote_addr = "1.1.1.1",
+          server_port = "12345"
+        },
+        update_time = ngx.update_time,
+        sleep = ngx.sleep,
+        time = ngx.time,
+        req = {
+          start_time = function() return 3 end
+        },
+        status = 200,
+      }
+
+      package.loaded["kong.pdk.request"] = nil
+      local pdk_request = require "kong.pdk.request"
+      kong.request = pdk_request.new(kong)
+      kong.ctx.core.phase = LOG_PHASE
+
+      -- reload log module, after ngx.config.subsystem has been patched
+      -- to make sure the correct variant is used
+      package.loaded["kong.pdk.log"] = nil
+      local pdk_log = require "kong.pdk.log"
+      kong.log = pdk_log.new(kong)
     end)
 
-    it("does not fail when the 'balancer_data' structure is missing", function()
-      ngx.ctx.balancer_data = nil
+    describe("Basic", function()
+      it("serializes without API, Consumer or Authenticated entity", function()
+        local res = kong.log.serialize({ngx = ngx, kong = kong, })
+        assert.is_table(res)
 
-      local res = kong.log.serialize({ngx = ngx, kong = kong, })
-      assert.is_table(res)
+        -- Simple properties
+        assert.equals("1.1.1.1", res.client_ip)
+        assert.equals(3000, res.started_at)
 
-      assert.is_nil(res.tries)
-    end)
+        -- Latencies
+        assert.is_table(res.latencies)
+        assert.equal(0, res.latencies.kong)
+        assert.equal(2123, res.latencies.session)
 
-    it("basic serializer proxy works with a deprecation warning", function()
-      local warned = false
-      local orig_warn = kong.log.warn
+        -- Session
+        assert.is_table(res.session)
+        assert.equal(99, res.session.received)
+        assert.equal(100, res.session.sent)
+        assert.equal(200, res.session.status)
+        assert.equal(12345, res.session.server_port)
 
-      kong.log.warn = function(msg)
-        assert.is_false(warned, "duplicate warning")
+        -- Upstream
+        assert.is_table(res.upstream)
+        assert.equal(300, res.upstream.sent)
+        assert.equal(200, res.upstream.received)
 
-        warned = true
+        assert.is_nil(res.api)
+        assert.is_nil(res.consumer)
+        assert.is_nil(res.authenticated_entity)
 
-        return orig_warn(msg)
-      end
+        -- Tries
+        assert.is_table(res.tries)
+      end)
 
-      local res = basic.serialize(ngx, kong)
-      assert.is_table(res)
+      it("serializes the matching Route and Services", function()
+        ngx.ctx.route = { id = "my_route" }
+        ngx.ctx.service = { id = "my_service" }
 
-      assert.equals("1.1.1.1", res.client_ip)
+        local res = kong.log.serialize({ngx = ngx, kong = kong, })
+        assert.is_table(res)
 
-      -- 2nd time
-      res = basic.serialize(ngx, kong)
-      assert.is_table(res)
+        assert.equal("my_route", res.route.id)
+        assert.equal("my_service", res.service.id)
+        assert.is_nil(res.consumer)
+        assert.is_nil(res.authenticated_entity)
+      end)
 
-      kong.log.warn = orig_warn
+      it("serializes the Consumer object", function()
+        ngx.ctx.authenticated_consumer = {id = "someconsumer"}
+
+        local res = kong.log.serialize({ngx = ngx, kong = kong, })
+        assert.is_table(res)
+
+        assert.equal("someconsumer", res.consumer.id)
+        assert.is_nil(res.api)
+        assert.is_nil(res.authenticated_entity)
+      end)
+
+      it("serializes the Authenticated Entity object", function()
+        ngx.ctx.authenticated_credential = {id = "somecred",
+                                            consumer_id = "user1"}
+
+        local res = kong.log.serialize({ngx = ngx, kong = kong, })
+        assert.is_table(res)
+
+        assert.same({id = "somecred", consumer_id = "user1"},
+                    res.authenticated_entity)
+        assert.is_nil(res.consumer)
+        assert.is_nil(res.api)
+      end)
+
+      it("serializes the tries and failure information", function()
+        ngx.ctx.balancer_data.tries = {
+          { ip = "127.0.0.1", port = 1234, state = "next",   code = 502 },
+          { ip = "127.0.0.1", port = 1234, state = "failed", code = nil },
+          { ip = "127.0.0.1", port = 1234 },
+        }
+
+        local res = kong.log.serialize({ngx = ngx, kong = kong, })
+        assert.is_table(res)
+
+        assert.same({
+            {
+              code  = 502,
+              ip    = '127.0.0.1',
+              port  = 1234,
+              state = 'next',
+            }, {
+              ip    = '127.0.0.1',
+              port  = 1234,
+              state = 'failed',
+            }, {
+              ip    = '127.0.0.1',
+              port  = 1234,
+            },
+          }, res.tries)
+      end)
+
+      it("does not fail when the 'balancer_data' structure is missing", function()
+        ngx.ctx.balancer_data = nil
+
+        local res = kong.log.serialize({ngx = ngx, kong = kong, })
+        assert.is_table(res)
+
+        assert.is_nil(res.tries)
+      end)
     end)
   end)
 end)


### PR DESCRIPTION
In #5995, we refactored the basic log serializer into a proper PDK function. @bungle kindly provided #5629 which allows stream subsystem to call the log serializer function as well, which this PR is heavily based upon. It allows various logging plugin to work under TCP and TLS proxy mode.