### PR TITLE
chore(deps) update multipart library from 0.5.6 to 0.5.8

### DIFF
--- a/kong-2.0.4-0.rockspec
+++ b/kong-2.0.4-0.rockspec
@@ -18,7 +18,7 @@ dependencies = {
   "lua-resty-http == 0.15",
   "lua-resty-jit-uuid == 0.0.7",
   "lua-ffi-zlib == 0.5",
-  "multipart == 0.5.6",
+  "multipart == 0.5.8",
   "version == 1.0.1",
   "kong-lapis == 1.8.1.2",
   "lua-cassandra == 1.5.0",

--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -729,14 +729,22 @@ local function new(self)
         return nil, err, CONTENT_TYPE_FORM_DATA
       end
 
-      -- TODO: multipart library doesn't support multiple fields with same name
-      return multipart(body, content_type):get_all(), nil, CONTENT_TYPE_FORM_DATA
+      local parts = multipart(body, content_type)
+      if not parts then
+        return nil, "unable to decode multipart body", CONTENT_TYPE_FORM_DATA
+      end
+
+      local margs = parts:get_all_with_arrays()
+      if not margs then
+        return nil, "unable to read multipart values", CONTENT_TYPE_FORM_DATA
+      end
+
+      return margs, nil, CONTENT_TYPE_FORM_DATA
 
     else
       return nil, "unsupported content type '" .. content_type .. "'", content_type_lower
     end
   end
-
 
   return _REQUEST
 end

--- a/kong/pdk/service/response.lua
+++ b/kong/pdk/service/response.lua
@@ -352,8 +352,17 @@ local function new(pdk, major_version)
     elseif find(content_type_lower, CONTENT_TYPE_FORM_DATA, 1, true) == 1 then
       local body = response.get_raw_body()
 
-      -- TODO: multipart library doesn't support multiple fields with same name
-      return multipart(body, content_type):get_all(), nil, CONTENT_TYPE_FORM_DATA
+      local parts = multipart(body, content_type)
+      if not parts then
+        return nil, "unable to decode multipart body", CONTENT_TYPE_FORM_DATA
+      end
+
+      local margs = parts:get_all_with_arrays()
+      if not margs then
+        return nil, "unable to read multipart values", CONTENT_TYPE_FORM_DATA
+      end
+
+      return margs, nil, CONTENT_TYPE_FORM_DATA
 
     else
       return nil, "unsupported content type '" .. content_type .. "'", content_type_lower

--- a/t/01-pdk/04-request/16-get_body.t
+++ b/t/01-pdk/04-request/16-get_body.t
@@ -663,3 +663,44 @@ Content-Type: application/x-www-form-urlencoded
 error: request body in temp file not supported
 --- no_error_log
 [error]
+
+
+
+=== TEST 25: request.get_body() returns arguments with multipart/form-data (same part name multiple times)
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            local args, err, mime = pdk.request.get_body()
+
+            ngx.say("type=", type(args))
+            ngx.say("type=", type(args.test))
+            ngx.say("test=", args.test[1])
+            ngx.say("test=", args.test[2])
+            ngx.say("mime=", mime)
+        }
+    }
+--- request
+POST /t
+--AaB03x
+Content-Disposition: form-data; name="test"
+
+form
+--AaB03x
+Content-Disposition: form-data; name="test"
+
+data
+--AaB03x--
+--- more_headers
+Content-Type: multipart/form-data; boundary=AaB03x
+--- response_body
+type=table
+type=table
+test=form
+test=data
+mime=multipart/form-data
+--- no_error_log
+[error]


### PR DESCRIPTION
### Summary

Adds support for parts with same name.

Also updates PDK functions to take advantage of this new functionality.

Thanks @nikolaydubina for providing us https://github.com/Kong/lua-multipart/pull/28.