### PR TITLE
feat(proxy) add route.request|response_buffering

### DIFF
--- a/autodoc/admin-api/data/admin-api.lua
+++ b/autodoc/admin-api/data/admin-api.lua
@@ -866,6 +866,13 @@ return {
             the Service's `host`.
           ]]
         },
+        request_buffering = {
+          description = [[
+            Whether to enable request body buffering or not. With HTTP 1.1, it
+            may make sense to turn this off on services that receive data with
+            chunked transfer encoding.
+          ]]
+        },
         service = {
           description = [[
             The Service this Route is associated to.

--- a/autodoc/admin-api/data/admin-api.lua
+++ b/autodoc/admin-api/data/admin-api.lua
@@ -873,6 +873,13 @@ return {
             chunked transfer encoding.
           ]]
         },
+        response_buffering = {
+          description = [[
+            Whether to enable response body buffering or not. With HTTP 1.1, it
+            may make sense to turn this off on services that send data with chunked
+            transfer encoding.
+          ]]
+        },
         service = {
           description = [[
             The Service this Route is associated to.

--- a/kong/db/migrations/core/012_213_to_220.lua
+++ b/kong/db/migrations/core/012_213_to_220.lua
@@ -16,6 +16,14 @@ return {
         -- Do nothing, accept existing state
       END;
       $$;
+
+      DO $$
+      BEGIN
+        ALTER TABLE IF EXISTS ONLY "routes" ADD "response_buffering" BOOLEAN;
+      EXCEPTION WHEN DUPLICATE_COLUMN THEN
+        -- Do nothing, accept existing state
+      END;
+      $$;
     ]],
   },
   cassandra = {
@@ -30,6 +38,7 @@ return {
       );
 
       ALTER TABLE routes ADD request_buffering boolean;
+      ALTER TABLE routes ADD response_buffering boolean;
     ]],
   }
 }

--- a/kong/db/migrations/core/012_213_to_220.lua
+++ b/kong/db/migrations/core/012_213_to_220.lua
@@ -8,6 +8,14 @@ return {
         last_seen      TIMESTAMP WITH TIME ZONE DEFAULT (CURRENT_TIMESTAMP(0) AT TIME ZONE 'UTC'),
         config_hash    TEXT NOT NULL
       );
+
+      DO $$
+      BEGIN
+        ALTER TABLE IF EXISTS ONLY "routes" ADD "request_buffering" BOOLEAN;
+      EXCEPTION WHEN DUPLICATE_COLUMN THEN
+        -- Do nothing, accept existing state
+      END;
+      $$;
     ]],
   },
   cassandra = {
@@ -20,6 +28,8 @@ return {
         config_hash text,
         PRIMARY KEY (id)
       );
+
+      ALTER TABLE routes ADD request_buffering boolean;
     ]],
   }
 }

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -37,6 +37,7 @@ return {
     { path_handling  = { type = "string", default = "v0", one_of = { "v0", "v1" }, }, },
     { preserve_host  = { type = "boolean", default = false }, },
     { request_buffering  = { type = "boolean", required = true, default = true }, },
+    { response_buffering  = { type = "boolean", required = true, default = true }, },
     { snis = { type = "set",
                elements = typedefs.sni }, },
     { sources = typedefs.sources },

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -36,6 +36,7 @@ return {
     { strip_path     = { type = "boolean", default = true }, },
     { path_handling  = { type = "string", default = "v0", one_of = { "v0", "v1" }, }, },
     { preserve_host  = { type = "boolean", default = false }, },
+    { request_buffering  = { type = "boolean", required = true, default = true }, },
     { snis = { type = "set",
                elements = typedefs.sni }, },
     { sources = typedefs.sources },

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -659,8 +659,9 @@ end
 
 
 function Kong.rewrite()
-  if var.kong_proxy_mode == "grpc" then
-    kong_resty_ctx.apply_ref() -- if kong_proxy_mode is gRPC, this is executing
+  local proxy_mode = var.kong_proxy_mode
+  if proxy_mode == "grpc" or proxy_mode == "unbuffered"  then
+    kong_resty_ctx.apply_ref() -- if kong_proxy_mode is gRPC/unbuffered, this is executing
     kong_resty_ctx.stash_ref() -- after an internal redirect. Restore (and restash)
                                -- context to avoid re-executing phases
 

--- a/kong/reports.lua
+++ b/kong/reports.lua
@@ -213,7 +213,7 @@ function get_current_suffix(ctx)
   local scheme = var.scheme
   local proxy_mode = var.kong_proxy_mode
   if scheme == "http" or scheme == "https" then
-    if proxy_mode == "http" then
+    if proxy_mode == "http" or proxy_mode == "unbuffered" then
       local http_upgrade = var.http_upgrade
       if http_upgrade and lower(http_upgrade) == "websocket" then
         if scheme == "http" then

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1258,6 +1258,10 @@ return {
         if service.protocol == "grpcs" then
           return ngx.exec("@grpcs")
         end
+
+        if route.request_buffering == false and http_version == 1.1 then
+          return ngx.exec("@unbuffered")
+        end
       end
     end,
     -- Only executed if the `router` module found a route and allows nginx to proxy it.

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1259,8 +1259,18 @@ return {
           return ngx.exec("@grpcs")
         end
 
-        if route.request_buffering == false and http_version == 1.1 then
-          return ngx.exec("@unbuffered")
+        if http_version == 1.1 then
+          if route.request_buffering == false then
+            if route.response_buffering == false then
+              return ngx.exec("@unbuffered")
+            end
+
+            return ngx.exec("@unbuffered_request")
+          end
+
+          if route.response_buffering == false then
+            return ngx.exec("@unbuffered_response")
+          end
         end
       end
     end,

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -136,7 +136,8 @@ server {
         set $kong_proxy_mode             'http';
 
         proxy_http_version      1.1;
-        proxy_request_buffering on;
+        proxy_buffering          on;
+        proxy_request_buffering  on;
 
         proxy_set_header      TE                 $upstream_te;
         proxy_set_header      Host               $upstream_host;
@@ -166,7 +167,70 @@ server {
         set $kong_proxy_mode 'unbuffered';
 
         proxy_http_version      1.1;
+        proxy_buffering         off;
         proxy_request_buffering off;
+
+        proxy_set_header      TE                 $upstream_te;
+        proxy_set_header      Host               $upstream_host;
+        proxy_set_header      Upgrade            $upstream_upgrade;
+        proxy_set_header      Connection         $upstream_connection;
+        proxy_set_header      X-Forwarded-For    $upstream_x_forwarded_for;
+        proxy_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
+        proxy_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
+        proxy_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
+        proxy_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
+        proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
+        proxy_set_header      X-Real-IP          $remote_addr;
+        proxy_pass_header     Server;
+        proxy_pass_header     Date;
+        proxy_ssl_name        $upstream_host;
+        proxy_ssl_server_name on;
+> if client_ssl then
+        proxy_ssl_certificate ${{CLIENT_SSL_CERT}};
+        proxy_ssl_certificate_key ${{CLIENT_SSL_CERT_KEY}};
+> end
+        proxy_pass            $upstream_scheme://kong_upstream$upstream_uri;
+    }
+
+    location @unbuffered_request {
+        internal;
+        default_type         '';
+        set $kong_proxy_mode 'unbuffered';
+
+        proxy_http_version      1.1;
+        proxy_buffering          on;
+        proxy_request_buffering off;
+
+        proxy_set_header      TE                 $upstream_te;
+        proxy_set_header      Host               $upstream_host;
+        proxy_set_header      Upgrade            $upstream_upgrade;
+        proxy_set_header      Connection         $upstream_connection;
+        proxy_set_header      X-Forwarded-For    $upstream_x_forwarded_for;
+        proxy_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
+        proxy_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
+        proxy_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
+        proxy_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
+        proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
+        proxy_set_header      X-Real-IP          $remote_addr;
+        proxy_pass_header     Server;
+        proxy_pass_header     Date;
+        proxy_ssl_name        $upstream_host;
+        proxy_ssl_server_name on;
+> if client_ssl then
+        proxy_ssl_certificate ${{CLIENT_SSL_CERT}};
+        proxy_ssl_certificate_key ${{CLIENT_SSL_CERT_KEY}};
+> end
+        proxy_pass            $upstream_scheme://kong_upstream$upstream_uri;
+    }
+
+    location @unbuffered_response {
+        internal;
+        default_type         '';
+        set $kong_proxy_mode 'unbuffered';
+
+        proxy_http_version      1.1;
+        proxy_buffering         off;
+        proxy_request_buffering  on;
 
         proxy_set_header      TE                 $upstream_te;
         proxy_set_header      Host               $upstream_host;

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -135,7 +135,39 @@ server {
         set $upstream_x_forwarded_prefix '';
         set $kong_proxy_mode             'http';
 
-        proxy_http_version    1.1;
+        proxy_http_version      1.1;
+        proxy_request_buffering on;
+
+        proxy_set_header      TE                 $upstream_te;
+        proxy_set_header      Host               $upstream_host;
+        proxy_set_header      Upgrade            $upstream_upgrade;
+        proxy_set_header      Connection         $upstream_connection;
+        proxy_set_header      X-Forwarded-For    $upstream_x_forwarded_for;
+        proxy_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
+        proxy_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
+        proxy_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
+        proxy_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
+        proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
+        proxy_set_header      X-Real-IP          $remote_addr;
+        proxy_pass_header     Server;
+        proxy_pass_header     Date;
+        proxy_ssl_name        $upstream_host;
+        proxy_ssl_server_name on;
+> if client_ssl then
+        proxy_ssl_certificate ${{CLIENT_SSL_CERT}};
+        proxy_ssl_certificate_key ${{CLIENT_SSL_CERT_KEY}};
+> end
+        proxy_pass            $upstream_scheme://kong_upstream$upstream_uri;
+    }
+
+    location @unbuffered {
+        internal;
+        default_type         '';
+        set $kong_proxy_mode 'unbuffered';
+
+        proxy_http_version      1.1;
+        proxy_request_buffering off;
+
         proxy_set_header      TE                 $upstream_te;
         proxy_set_header      Host               $upstream_host;
         proxy_set_header      Upgrade            $upstream_upgrade;

--- a/spec/01-unit/01-db/01-schema/11-declarative_config/02-process_auto_fields_spec.lua
+++ b/spec/01-unit/01-db/01-schema/11-declarative_config/02-process_auto_fields_spec.lua
@@ -448,6 +448,7 @@ describe("declarative config: process_auto_fields", function()
                     protocols = { "http", "https" },
                     https_redirect_status_code = 426,
                     request_buffering = true,
+                    response_buffering = true,
                   },
                   {
                     hosts = { "example.com" },
@@ -458,6 +459,7 @@ describe("declarative config: process_auto_fields", function()
                     protocols = { "http", "https" },
                     https_redirect_status_code = 426,
                     request_buffering = true,
+                    response_buffering = true,
                   },
                   {
                     methods = { "GET", "POST" },
@@ -468,6 +470,7 @@ describe("declarative config: process_auto_fields", function()
                     protocols = { "http", "https" },
                     https_redirect_status_code = 426,
                     request_buffering = true,
+                    response_buffering = true,
                   },
                 }
               },
@@ -492,6 +495,7 @@ describe("declarative config: process_auto_fields", function()
                     protocols = { "http", "https" },
                     https_redirect_status_code = 426,
                     request_buffering = true,
+                    response_buffering = true,
                   },
                 }
               }
@@ -539,6 +543,7 @@ describe("declarative config: process_auto_fields", function()
                     regex_priority = 0,
                     https_redirect_status_code = 426,
                     request_buffering = true,
+                    response_buffering = true,
                     plugins = {},
                   }
                 }
@@ -603,6 +608,7 @@ describe("declarative config: process_auto_fields", function()
                     regex_priority = 0,
                     https_redirect_status_code = 426,
                     request_buffering = true,
+                    response_buffering = true,
                     plugins = {
                       {
                         name = "key-auth",
@@ -654,6 +660,7 @@ describe("declarative config: process_auto_fields", function()
                     regex_priority = 0,
                     https_redirect_status_code = 426,
                     request_buffering = true,
+                    response_buffering = true,
                     plugins = {
                       {
                         name = "basic-auth",

--- a/spec/01-unit/01-db/01-schema/11-declarative_config/02-process_auto_fields_spec.lua
+++ b/spec/01-unit/01-db/01-schema/11-declarative_config/02-process_auto_fields_spec.lua
@@ -447,6 +447,7 @@ describe("declarative config: process_auto_fields", function()
                     path_handling = "v1",
                     protocols = { "http", "https" },
                     https_redirect_status_code = 426,
+                    request_buffering = true,
                   },
                   {
                     hosts = { "example.com" },
@@ -456,6 +457,7 @@ describe("declarative config: process_auto_fields", function()
                     path_handling = "v1",
                     protocols = { "http", "https" },
                     https_redirect_status_code = 426,
+                    request_buffering = true,
                   },
                   {
                     methods = { "GET", "POST" },
@@ -465,6 +467,7 @@ describe("declarative config: process_auto_fields", function()
                     path_handling = "v1",
                     protocols = { "http", "https" },
                     https_redirect_status_code = 426,
+                    request_buffering = true,
                   },
                 }
               },
@@ -488,6 +491,7 @@ describe("declarative config: process_auto_fields", function()
                     path_handling = "v1",
                     protocols = { "http", "https" },
                     https_redirect_status_code = 426,
+                    request_buffering = true,
                   },
                 }
               }
@@ -534,7 +538,8 @@ describe("declarative config: process_auto_fields", function()
                     protocols = { "http", "https" },
                     regex_priority = 0,
                     https_redirect_status_code = 426,
-                    plugins = {}
+                    request_buffering = true,
+                    plugins = {},
                   }
                 }
               }
@@ -597,6 +602,7 @@ describe("declarative config: process_auto_fields", function()
                     protocols = { "http", "https" },
                     regex_priority = 0,
                     https_redirect_status_code = 426,
+                    request_buffering = true,
                     plugins = {
                       {
                         name = "key-auth",
@@ -647,6 +653,7 @@ describe("declarative config: process_auto_fields", function()
                     protocols = { "http", "https" },
                     regex_priority = 0,
                     https_redirect_status_code = 426,
+                    request_buffering = true,
                     plugins = {
                       {
                         name = "basic-auth",

--- a/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
+++ b/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
@@ -195,6 +195,7 @@ describe("declarative config: flatten", function()
               strip_path = true,
               path_handling = "v1",
               updated_at = 1234567890,
+              request_buffering = true,
             }
           }
         }, idempotent(config))
@@ -429,7 +430,8 @@ describe("declarative config: flatten", function()
               sources = null,
               strip_path = true,
               path_handling = "v1",
-              updated_at = 1234567890
+              updated_at = 1234567890,
+              request_buffering = true,
             }
           },
           services = {
@@ -713,6 +715,7 @@ describe("declarative config: flatten", function()
                 path_handling = "v1",
                 tags = null,
                 updated_at = 1234567890,
+                request_buffering = true,
               } },
             services = { {
                 connect_timeout = 60000,
@@ -791,6 +794,7 @@ describe("declarative config: flatten", function()
                 path_handling = "v1",
                 tags = null,
                 updated_at = 1234567890,
+                request_buffering = true,
               }, {
                 created_at = 1234567890,
                 destinations = null,
@@ -813,6 +817,7 @@ describe("declarative config: flatten", function()
                 path_handling = "v1",
                 tags = null,
                 updated_at = 1234567890,
+                request_buffering = true,
               }, {
                 created_at = 1234567890,
                 destinations = null,
@@ -835,6 +840,7 @@ describe("declarative config: flatten", function()
                 path_handling = "v1",
                 tags = null,
                 updated_at = 1234567890,
+                request_buffering = true,
               }, {
                 created_at = 1234567890,
                 destinations = null,
@@ -857,6 +863,7 @@ describe("declarative config: flatten", function()
                 path_handling = "v1",
                 tags = null,
                 updated_at = 1234567890,
+                request_buffering = true,
               } },
             services = { {
                 connect_timeout = 60000,
@@ -938,6 +945,7 @@ describe("declarative config: flatten", function()
                 strip_path = true,
                 path_handling = "v1",
                 updated_at = 1234567890,
+                request_buffering = true,
               }
             },
             services = {
@@ -1096,7 +1104,8 @@ describe("declarative config: flatten", function()
                 strip_path = true,
                 path_handling = "v1",
                 tags = null,
-                updated_at = 1234567890
+                updated_at = 1234567890,
+                request_buffering = true,
               }, {
                 created_at = 1234567890,
                 destinations = null,
@@ -1118,7 +1127,8 @@ describe("declarative config: flatten", function()
                 strip_path = true,
                 path_handling = "v1",
                 tags = null,
-                updated_at = 1234567890
+                updated_at = 1234567890,
+                request_buffering = true,
               } },
             services = { {
                 connect_timeout = 60000,

--- a/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
+++ b/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
@@ -196,6 +196,7 @@ describe("declarative config: flatten", function()
               path_handling = "v1",
               updated_at = 1234567890,
               request_buffering = true,
+              response_buffering = true,
             }
           }
         }, idempotent(config))
@@ -432,6 +433,7 @@ describe("declarative config: flatten", function()
               path_handling = "v1",
               updated_at = 1234567890,
               request_buffering = true,
+              response_buffering = true,
             }
           },
           services = {
@@ -716,6 +718,7 @@ describe("declarative config: flatten", function()
                 tags = null,
                 updated_at = 1234567890,
                 request_buffering = true,
+                response_buffering = true,
               } },
             services = { {
                 connect_timeout = 60000,
@@ -795,6 +798,7 @@ describe("declarative config: flatten", function()
                 tags = null,
                 updated_at = 1234567890,
                 request_buffering = true,
+                response_buffering = true,
               }, {
                 created_at = 1234567890,
                 destinations = null,
@@ -818,6 +822,7 @@ describe("declarative config: flatten", function()
                 tags = null,
                 updated_at = 1234567890,
                 request_buffering = true,
+                response_buffering = true,
               }, {
                 created_at = 1234567890,
                 destinations = null,
@@ -841,6 +846,7 @@ describe("declarative config: flatten", function()
                 tags = null,
                 updated_at = 1234567890,
                 request_buffering = true,
+                response_buffering = true,
               }, {
                 created_at = 1234567890,
                 destinations = null,
@@ -864,6 +870,7 @@ describe("declarative config: flatten", function()
                 tags = null,
                 updated_at = 1234567890,
                 request_buffering = true,
+                response_buffering = true,
               } },
             services = { {
                 connect_timeout = 60000,
@@ -946,6 +953,7 @@ describe("declarative config: flatten", function()
                 path_handling = "v1",
                 updated_at = 1234567890,
                 request_buffering = true,
+                response_buffering = true,
               }
             },
             services = {
@@ -1106,6 +1114,7 @@ describe("declarative config: flatten", function()
                 tags = null,
                 updated_at = 1234567890,
                 request_buffering = true,
+                response_buffering = true,
               }, {
                 created_at = 1234567890,
                 destinations = null,
@@ -1129,6 +1138,7 @@ describe("declarative config: flatten", function()
                 tags = null,
                 updated_at = 1234567890,
                 request_buffering = true,
+                response_buffering = true,
               } },
             services = { {
                 connect_timeout = 60000,

--- a/spec/02-integration/03-db/02-db_core_entities_spec.lua
+++ b/spec/02-integration/03-db/02-db_core_entities_spec.lua
@@ -706,6 +706,7 @@ for _, strategy in helpers.each_strategy() do
             tags            = ngx.null,
             service         = route.service,
             https_redirect_status_code = 426,
+            request_buffering = true,
           }, route)
         end)
 
@@ -748,6 +749,7 @@ for _, strategy in helpers.each_strategy() do
             preserve_host   = false,
             service         = route.service,
             https_redirect_status_code = 426,
+            request_buffering = true,
           }, route)
         end)
 
@@ -788,6 +790,7 @@ for _, strategy in helpers.each_strategy() do
             preserve_host   = false,
             service         = ngx.null,
             https_redirect_status_code = 426,
+            request_buffering = true,
           }, route)
         end)
 
@@ -1100,6 +1103,7 @@ for _, strategy in helpers.each_strategy() do
             tags            = route.tags,
             service         = route.service,
             https_redirect_status_code = 426,
+            request_buffering = true,
           }, new_route)
 
 
@@ -1133,6 +1137,7 @@ for _, strategy in helpers.each_strategy() do
               tags            = route.tags,
               service         = route.service,
               https_redirect_status_code = 426,
+              request_buffering = true,
             }, new_route)
           end)
 
@@ -1976,6 +1981,7 @@ for _, strategy in helpers.each_strategy() do
             id = service.id
           },
           https_redirect_status_code = 426,
+          request_buffering = true,
         }, route)
 
         local route_in_db, err, err_t = db.routes:select({ id = route.id }, { nulls = true })

--- a/spec/02-integration/03-db/02-db_core_entities_spec.lua
+++ b/spec/02-integration/03-db/02-db_core_entities_spec.lua
@@ -707,6 +707,7 @@ for _, strategy in helpers.each_strategy() do
             service         = route.service,
             https_redirect_status_code = 426,
             request_buffering = true,
+            response_buffering = true,
           }, route)
         end)
 
@@ -750,6 +751,7 @@ for _, strategy in helpers.each_strategy() do
             service         = route.service,
             https_redirect_status_code = 426,
             request_buffering = true,
+            response_buffering = true,
           }, route)
         end)
 
@@ -791,6 +793,7 @@ for _, strategy in helpers.each_strategy() do
             service         = ngx.null,
             https_redirect_status_code = 426,
             request_buffering = true,
+            response_buffering = true,
           }, route)
         end)
 
@@ -1104,6 +1107,7 @@ for _, strategy in helpers.each_strategy() do
             service         = route.service,
             https_redirect_status_code = 426,
             request_buffering = true,
+            response_buffering = true,
           }, new_route)
 
 
@@ -1138,6 +1142,7 @@ for _, strategy in helpers.each_strategy() do
               service         = route.service,
               https_redirect_status_code = 426,
               request_buffering = true,
+              response_buffering = true,
             }, new_route)
           end)
 
@@ -1982,6 +1987,7 @@ for _, strategy in helpers.each_strategy() do
           },
           https_redirect_status_code = 426,
           request_buffering = true,
+          response_buffering = true,
         }, route)
 
         local route_in_db, err, err_t = db.routes:select({ id = route.id }, { nulls = true })

--- a/spec/02-integration/05-proxy/27-unbuffered_spec.lua
+++ b/spec/02-integration/05-proxy/27-unbuffered_spec.lua
@@ -1,0 +1,195 @@
+local helpers = require "spec.helpers"
+local random = require "resty.random"
+local rstring = require "resty.string"
+
+
+-- HTTP 1.1 Chunked Body (5 MB)
+local function body()
+  local chunk = "2000" .."\r\n" .. rstring.to_hex(random.bytes(4096)) .. "\r\n"
+  local i = 0
+  return function()
+    i = i + 1
+
+    if i == 641 then
+      return "0\r\n\r\n"
+    end
+
+    if i == 642 then
+      return nil
+    end
+
+    return chunk
+  end
+end
+
+
+for _, strategy in helpers.each_strategy() do
+  describe("HTTP 1.1 Chunked [#" .. strategy .. "]", function()
+    local proxy_client
+    local warmup_client
+
+    lazy_setup(function()
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services"
+      })
+
+      local service = bp.services:insert()
+
+      bp.routes:insert({
+        protocols = { "http", "https" },
+        paths = { "/buffered" },
+        request_buffering = true,
+        response_buffering = true,
+        service = service,
+      })
+
+      bp.routes:insert({
+        protocols = { "http", "https" },
+        paths = { "/unbuffered" },
+        request_buffering = false,
+        response_buffering = false,
+        service = service,
+      })
+
+      bp.routes:insert({
+        protocols = { "http", "https" },
+        paths = { "/unbuffered-request" },
+        request_buffering = false,
+        response_buffering = true,
+        service = service,
+      })
+
+      bp.routes:insert({
+        protocols = { "http", "https" },
+        paths = { "/unbuffered-response" },
+        request_buffering = true,
+        response_buffering = false,
+        service = service,
+      })
+
+      assert(helpers.start_kong {
+        database = strategy,
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+      })
+
+    end)
+
+    lazy_teardown(function()
+      helpers.stop_kong()
+    end)
+
+    before_each(function()
+      warmup_client = helpers.proxy_client()
+      proxy_client = helpers.proxy_client()
+    end)
+
+    after_each(function ()
+      warmup_client:close()
+      proxy_client:close()
+    end)
+
+    describe("request latency", function()
+      local buffered_latency
+      local unbuffered_latency
+      local unbuffered_request_latency
+      local unbuffered_response_latency
+
+      it("is calculated for buffered", function()
+        warmup_client:post("/buffered/post", { body = "warmup" })
+
+        local res = proxy_client:send({
+          method = "POST",
+          path = "/buffered/post",
+          body = body(),
+          headers = {
+            ["Transfer-Encoding"] = "chunked",
+            ["Content-Type"] = "application/octet-stream",
+          }
+        })
+
+        assert.equal(200, res.status)
+
+        buffered_latency = tonumber(res.headers["X-Kong-Proxy-Latency"])
+
+        assert.is_number(buffered_latency)
+      end)
+
+      it("is calculated for unbuffered", function()
+        warmup_client:post("/unbuffered/post", { body = "warmup" })
+
+        local res = proxy_client:send({
+          method = "POST",
+          path = "/unbuffered/post",
+          body = body(),
+          headers = {
+            ["Transfer-Encoding"] = "chunked",
+            ["Content-Type"] = "application/octet-stream",
+          }
+        })
+
+        assert.equal(200, res.status)
+
+        unbuffered_latency = tonumber(res.headers["X-Kong-Proxy-Latency"])
+
+        assert.is_number(unbuffered_latency)
+      end)
+
+      it("is calculated for unbuffered request", function()
+        warmup_client:post("/unbuffered-request/post", { body = "warmup" })
+
+        local res = proxy_client:send({
+          method = "POST",
+          path = "/unbuffered-request/post",
+          body = body(),
+          headers = {
+            ["Transfer-Encoding"] = "chunked",
+            ["Content-Type"] = "application/octet-stream",
+          }
+        })
+
+        assert.equal(200, res.status)
+
+        unbuffered_request_latency = tonumber(res.headers["X-Kong-Proxy-Latency"])
+
+        assert.is_number(unbuffered_request_latency)
+      end)
+
+      it("is calculated for unbuffered response", function()
+        warmup_client:post("/unbuffered-response/post", { body = "warmup" })
+
+        local res = proxy_client:send({
+          method = "POST",
+          path = "/unbuffered-response/post",
+          body = body(),
+          headers = {
+            ["Transfer-Encoding"] = "chunked",
+            ["Content-Type"] = "application/octet-stream",
+          }
+        })
+
+        assert.equal(200, res.status)
+
+        unbuffered_response_latency = tonumber(res.headers["X-Kong-Proxy-Latency"])
+
+        assert.is_number(unbuffered_response_latency)
+      end)
+
+      it("is greater for buffered than unbuffered", function()
+        assert.equal(true, buffered_latency > unbuffered_latency)
+      end)
+
+      it("is greater for buffered than unbuffered request", function()
+        assert.equal(true, buffered_latency > unbuffered_request_latency)
+      end)
+
+      it("is greater for unbuffered response than unbuffered", function()
+        assert.equal(true, unbuffered_response_latency > unbuffered_latency)
+      end)
+
+      it("is greater for unbuffered response than unbuffered request", function()
+        assert.equal(true, unbuffered_response_latency > unbuffered_request_latency)
+      end)
+    end)
+  end)
+end

--- a/spec/02-integration/05-proxy/27-unbuffered_spec.lua
+++ b/spec/02-integration/05-proxy/27-unbuffered_spec.lua
@@ -191,5 +191,108 @@ for _, strategy in helpers.each_strategy() do
         assert.equal(true, unbuffered_response_latency > unbuffered_request_latency)
       end)
     end)
+
+    describe("number of response chunks", function()
+      local buffered_chunks = 0
+      local unbuffered_chunks = 0
+      local unbuffered_request_chunks = 0
+      local unbuffered_response_chunks = 0
+
+      it("is calculated for buffered", function()
+        warmup_client:get("/buffered/stream/1")
+
+        local res = proxy_client:get("/buffered/stream/1000")
+
+        assert.equal(200, res.status)
+
+        local reader = res.body_reader
+
+        repeat
+          local chunk, err = reader(8192 * 640)
+
+          assert.equal(nil, err)
+
+          if chunk then
+            buffered_chunks = buffered_chunks + 1
+          end
+        until not chunk
+      end)
+
+      it("is calculated for unbuffered", function()
+        warmup_client:get("/unbuffered/stream/1")
+
+        local res = proxy_client:get("/unbuffered/stream/1000")
+
+        assert.equal(200, res.status)
+
+        local reader = res.body_reader
+
+        repeat
+          local chunk, err = reader(8192 * 640)
+
+          assert.equal(nil, err)
+
+          if chunk then
+            unbuffered_chunks = unbuffered_chunks + 1
+          end
+        until not chunk
+      end)
+
+      it("is calculated for unbuffered request", function()
+        warmup_client:get("/unbuffered-request/stream/1")
+
+        local res = proxy_client:get("/unbuffered-request/stream/1000")
+
+        assert.equal(200, res.status)
+
+        local reader = res.body_reader
+
+        repeat
+          local chunk, err = reader(8192 * 640)
+
+          assert.equal(nil, err)
+
+          if chunk then
+            unbuffered_request_chunks = unbuffered_request_chunks + 1
+          end
+        until not chunk
+      end)
+
+      it("is calculated for unbuffered response", function()
+        warmup_client:get("/unbuffered-response/stream/1")
+
+        local res = proxy_client:get("/unbuffered-response/stream/1000")
+
+        assert.equal(200, res.status)
+
+        local reader = res.body_reader
+
+        repeat
+          local chunk, err = reader(8192 * 640)
+
+          assert.equal(nil, err)
+
+          if chunk then
+            unbuffered_response_chunks = unbuffered_response_chunks + 1
+          end
+        until not chunk
+      end)
+
+      it("is greater for unbuffered than buffered", function()
+        assert.equal(true, unbuffered_chunks > buffered_chunks)
+      end)
+
+      it("is greater for unbuffered than unbuffered request", function()
+        assert.equal(true, unbuffered_chunks > unbuffered_request_chunks)
+      end)
+
+      it("is greater for unbuffered response than buffered", function()
+        assert.equal(true, unbuffered_response_chunks > buffered_chunks)
+      end)
+
+      it("is greater for unbuffered response than unbuffered request", function()
+        assert.equal(true, unbuffered_response_chunks > unbuffered_request_chunks)
+      end)
+    end)
   end)
 end

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -157,7 +157,39 @@ http {
             set $upstream_x_forwarded_prefix '';
             set $kong_proxy_mode             'http';
 
-            proxy_http_version    1.1;
+            proxy_http_version      1.1;
+            proxy_request_buffering on;
+
+            proxy_set_header      TE                 $upstream_te;
+            proxy_set_header      Host               $upstream_host;
+            proxy_set_header      Upgrade            $upstream_upgrade;
+            proxy_set_header      Connection         $upstream_connection;
+            proxy_set_header      X-Forwarded-For    $upstream_x_forwarded_for;
+            proxy_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
+            proxy_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
+            proxy_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
+            proxy_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
+            proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
+            proxy_set_header      X-Real-IP          $remote_addr;
+            proxy_pass_header     Server;
+            proxy_pass_header     Date;
+            proxy_ssl_name        $upstream_host;
+            proxy_ssl_server_name on;
+> if client_ssl then
+            proxy_ssl_certificate ${{CLIENT_SSL_CERT}};
+            proxy_ssl_certificate_key ${{CLIENT_SSL_CERT_KEY}};
+> end
+            proxy_pass            $upstream_scheme://kong_upstream$upstream_uri;
+        }
+
+        location @unbuffered {
+            internal;
+            default_type         '';
+            set $kong_proxy_mode 'unbuffered';
+
+            proxy_http_version      1.1;
+            proxy_request_buffering off;
+
             proxy_set_header      TE                 $upstream_te;
             proxy_set_header      Host               $upstream_host;
             proxy_set_header      Upgrade            $upstream_upgrade;

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -158,7 +158,8 @@ http {
             set $kong_proxy_mode             'http';
 
             proxy_http_version      1.1;
-            proxy_request_buffering on;
+            proxy_buffering          on;
+            proxy_request_buffering  on;
 
             proxy_set_header      TE                 $upstream_te;
             proxy_set_header      Host               $upstream_host;
@@ -188,6 +189,7 @@ http {
             set $kong_proxy_mode 'unbuffered';
 
             proxy_http_version      1.1;
+            proxy_buffering         off;
             proxy_request_buffering off;
 
             proxy_set_header      TE                 $upstream_te;
@@ -199,6 +201,66 @@ http {
             proxy_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
             proxy_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
             proxy_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
+            proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
+            proxy_set_header      X-Real-IP          $remote_addr;
+            proxy_pass_header     Server;
+            proxy_pass_header     Date;
+            proxy_ssl_name        $upstream_host;
+            proxy_ssl_server_name on;
+> if client_ssl then
+            proxy_ssl_certificate ${{CLIENT_SSL_CERT}};
+            proxy_ssl_certificate_key ${{CLIENT_SSL_CERT_KEY}};
+> end
+            proxy_pass            $upstream_scheme://kong_upstream$upstream_uri;
+        }
+
+        location @unbuffered_request {
+            internal;
+            default_type         '';
+            set $kong_proxy_mode 'unbuffered';
+
+            proxy_http_version      1.1;
+            proxy_buffering          on;
+            proxy_request_buffering off;
+
+            proxy_set_header      TE                 $upstream_te;
+            proxy_set_header      Host               $upstream_host;
+            proxy_set_header      Upgrade            $upstream_upgrade;
+            proxy_set_header      Connection         $upstream_connection;
+            proxy_set_header      X-Forwarded-For    $upstream_x_forwarded_for;
+            proxy_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
+            proxy_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
+            proxy_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
+            proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
+            proxy_set_header      X-Real-IP          $remote_addr;
+            proxy_pass_header     Server;
+            proxy_pass_header     Date;
+            proxy_ssl_name        $upstream_host;
+            proxy_ssl_server_name on;
+> if client_ssl then
+            proxy_ssl_certificate ${{CLIENT_SSL_CERT}};
+            proxy_ssl_certificate_key ${{CLIENT_SSL_CERT_KEY}};
+> end
+            proxy_pass            $upstream_scheme://kong_upstream$upstream_uri;
+        }
+
+        location @unbuffered_response {
+            internal;
+            default_type         '';
+            set $kong_proxy_mode 'unbuffered';
+
+            proxy_http_version      1.1;
+            proxy_buffering         off;
+            proxy_request_buffering  on;
+
+            proxy_set_header      TE                 $upstream_te;
+            proxy_set_header      Host               $upstream_host;
+            proxy_set_header      Upgrade            $upstream_upgrade;
+            proxy_set_header      Connection         $upstream_connection;
+            proxy_set_header      X-Forwarded-For    $upstream_x_forwarded_for;
+            proxy_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
+            proxy_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
+            proxy_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
             proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
             proxy_set_header      X-Real-IP          $remote_addr;
             proxy_pass_header     Server;


### PR DESCRIPTION
### Summary

#### Request Buffering

By default Kong does buffer the request. This is not ideal when proxying bigger payloads with HTTP 1.1 chunked encoding.

This PR adds a new property to route entity:
```
request_buffering = <true/false>
```

By default that is `true` (which is the same as before). Users can now turn the request buffering `off` by route-by-route manner by setting `route.request_buffering=false`.

#### Response Buffering

By default Kong does buffer the response. This is not ideal when upstream is sending payloads with HTTP 1.1 chunked encoding.

This PR adds a new property to route entity:
```
response_buffering = <true/false>
```

By default that is `true` (which is the same as before). Users can now turn off the response buffering on route-by-route manner by setting `route.response_buffering=false`.