### PR TITLE
docs(admin) update max weight on targets to 65535

### DIFF
--- a/autodoc/data/admin-api.lua
+++ b/autodoc/data/admin-api.lua
@@ -1652,7 +1652,7 @@ return {
         },
         weight = {
           description = [[
-            The weight this target gets within the upstream loadbalancer (`0`-`1000`).
+            The weight this target gets within the upstream loadbalancer (`0`-`65535`).
             If the hostname resolves to an SRV record, the `weight` value will be
             overridden by the value from the DNS record.
           ]]


### PR DESCRIPTION
### Summary

Just updates auto-generator to produce max target weight of 65535 as updated with #5871.