### PR TITLE
chore(plugins) bump rate-limiting plugin version

### DIFF
--- a/kong/plugins/rate-limiting/handler.lua
+++ b/kong/plugins/rate-limiting/handler.lua
@@ -47,7 +47,7 @@ local RateLimitingHandler = {}
 
 
 RateLimitingHandler.PRIORITY = 901
-RateLimitingHandler.VERSION = "2.1.0"
+RateLimitingHandler.VERSION = "2.2.0"
 
 
 local function get_identifier(conf)


### PR DESCRIPTION
New feature "rate-limiting by header" was introduced (7c449842a),
so a minor bump in said plugin is required.
