### PR TITLE
fix(declarative) keep the `ttl` definitions so that schema validator

### DIFF
--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -103,7 +103,6 @@ local function add_top_level_entities(fields, entities)
     definition.endpoint_key = nil
     definition.cache_key = nil
     definition.cache_key_set = nil
-    definition.ttl = nil
     records[entity] = definition
     add_extra_attributes(records[entity].fields, {
       _comment = true,

--- a/spec/01-unit/01-db/10-declarative_spec.lua
+++ b/spec/01-unit/01-db/10-declarative_spec.lua
@@ -1,3 +1,4 @@
+require("spec.helpers") -- for kong.log
 local declarative = require "kong.db.declarative"
 local conf_loader = require "kong.conf_loader"
 
@@ -21,5 +22,28 @@ routes:
       assert.equal(null,   route.name)
       assert.same({ "/" }, route.paths)
     end)
+  end)
+
+  it("ttl fields are accepted in DB-less schema validation", function()
+    local dc = declarative.new_config(conf_loader())
+    local entities, err = dc:parse_string([[
+_format_version: '2.1'
+consumers:
+- custom_id: ~
+  id: e150d090-4d53-4e55-bff8-efaaccd34ec4
+  tags: ~
+  username: bar@example.com
+services:
+keyauth_credentials:
+- created_at: 1593624542
+  id: 3f9066ef-b91b-4d1d-a05a-28619401c1ad
+  tags: ~
+  ttl: ~
+  key: test
+  consumer: e150d090-4d53-4e55-bff8-efaaccd34ec4
+]])
+    assert.equal(nil, err)
+
+    assert.is_nil(entities.keyauth_credentials['3f9066ef-b91b-4d1d-a05a-28619401c1ad'].ttl)
   end)
 end)


### PR DESCRIPTION
knows to skip trying to validate it

Otherwise entities containing the `ttl` field will cause "unknwon field"
validation failures

fixes #6063