### PR TITLE
feat(router) add header regex matching method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,9 @@
 - Customizable transparent dynamic TLS SNI name.
   Thanks, [@zhangshuaiNB](https://github.com/zhangshuaiNB)!
   [#8196](https://github.com/Kong/kong/pull/8196)
+- Routes now support matching headers with regular expressions
+  Thanks, [@vanhtuan0409](https://github.com/vanhtuan0409)!
+  [#6079](https://github.com/Kong/kong/pull/6079)
 
 #### Performance
 

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -206,6 +206,17 @@ local use_case = {
       },
     },
   },
+  -- 15. headers (regex)
+  {
+    service = service,
+    route = {
+      headers = {
+        user_agent = {
+          "~*windows|linux|os\\s+x\\s*[\\d\\._]+|solaris|bsd",
+        },
+      },
+    },
+  },
 }
 
 describe("Router", function()
@@ -451,6 +462,16 @@ describe("Router", function()
         location = { "my-location-3", "foo" }
       })
       assert.is_nil(match_t)
+
+      local match_t = router.select("GET", "/", nil, "http", nil, nil, nil, nil, nil, {
+        user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36"
+      })
+      assert.truthy(match_t)
+      assert.same(use_case[15].route, match_t.route)
+      assert.same(nil, match_t.matches.method)
+      assert.same(nil, match_t.matches.uri)
+      assert.same(nil, match_t.matches.uri_captures)
+      assert.same({ user_agent = "mozilla/5.0 (x11; linux x86_64) applewebkit/537.36 (khtml, like gecko) chrome/83.0.4103.116 safari/537.36" }, match_t.matches.headers)
     end)
 
     it("multiple [headers] values", function()


### PR DESCRIPTION
### Summary

Add header regex matching method for routing decision. Based on this issue created before

https://github.com/Kong/kong/issues/5666

### Full changelog

For avoiding behavior changes, only header with 1 value and prefixed with `~*` is checked against `re_find`

Unit test added as

```
  -- 15. headers (regex)
  {
    service = service,
    route = {
      headersRegex = true,
      headers = {
        user_agent = {
          "~*windows|linux|os\\s+x\\s*[\\d\\._]+|solaris|bsd",
        },
      },
    },
  },

```

### Issues resolved

Fix https://github.com/Kong/kong/issues/5666
