### PR TITLE
chore(makefile) speed up `make dev` command by avoid downloading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ install:
 remove:
 	-@luarocks remove kong
 
-dependencies: grpcurl
+dependencies: bin/grpcurl
 	@for rock in $(DEV_ROCKS) ; do \
 	  if luarocks list --porcelain $$rock | grep -q "installed" ; then \
 	    echo $$rock already installed, skipping ; \
@@ -118,7 +118,7 @@ dependencies: grpcurl
 	  fi \
 	done;
 
-grpcurl:
+bin/grpcurl:
 	@curl -s -S -L \
 		https://github.com/fullstorydev/grpcurl/releases/download/v1.3.0/grpcurl_1.3.0_$(GRPCURL_OS)_$(MACHINE).tar.gz | tar xz -C bin;
 	@rm bin/LICENSE


### PR DESCRIPTION
`grpcurl` every time

Before the change, every time `make dev` is called `grpcurl` has to be re-downloaded. This took 17 sec on my network:

```shell
time make.dev
...
real	0m17.512s
user	0m1.587s
sys	0m1.202s
```

After the change, once `grpcurl` is already present, subsequent `make dev` takes only seconds to complete:

```shell
real	0m2.804s
user	0m1.426s
sys	0m1.141s
```

since `grpcurl` does not release that frequently (and we don't need the latest version for the tests), this should be a worthy tradeoff.