### PR TITLE
fix(declarative) make reload atomic and properly clean the needed caches

### DIFF
--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -504,7 +504,7 @@ end
 --     _format_version: "2.1",
 --     _transform: true,
 --   }
-function declarative.load_into_cache(entities, meta, hash, shadow_page)
+function declarative.load_into_cache(entities, meta, hash, shadow)
   -- Array of strings with this format:
   -- "<tag_name>|<entity_name>|<uuid>".
   -- For example, a service tagged "admin" would produce
@@ -522,8 +522,8 @@ function declarative.load_into_cache(entities, meta, hash, shadow_page)
   -- but filtered for a given tag
   local tags_by_name = {}
 
-  kong.core_cache:purge(SHADOW)
-  kong.cache:purge(SHADOW)
+  kong.core_cache:purge(shadow)
+  kong.cache:purge(shadow)
 
   local transform = meta._transform == nil and true or meta._transform
 
@@ -597,13 +597,13 @@ function declarative.load_into_cache(entities, meta, hash, shadow_page)
         end
       end
 
-      local ok, err = kong.core_cache:safe_set(cache_key, item, shadow_page)
+      local ok, err = kong.core_cache:safe_set(cache_key, item, shadow)
       if not ok then
         return nil, err
       end
 
       local global_query_cache_key = dao:cache_key(id, nil, nil, nil, nil, "*")
-      local ok, err = kong.core_cache:safe_set(global_query_cache_key, item, shadow_page)
+      local ok, err = kong.core_cache:safe_set(global_query_cache_key, item, shadow)
       if not ok then
         return nil, err
       end
@@ -620,7 +620,7 @@ function declarative.load_into_cache(entities, meta, hash, shadow_page)
 
       if schema.cache_key then
         local cache_key = dao:cache_key(item)
-        ok, err = kong.core_cache:safe_set(cache_key, item, shadow_page)
+        ok, err = kong.core_cache:safe_set(cache_key, item, shadow)
         if not ok then
           return nil, err
         end
@@ -641,7 +641,7 @@ function declarative.load_into_cache(entities, meta, hash, shadow_page)
           end
 
           local unique_cache_key = prefix .. "|" .. unique .. ":" .. unique_key
-          ok, err = kong.core_cache:safe_set(unique_cache_key, item, shadow_page)
+          ok, err = kong.core_cache:safe_set(unique_cache_key, item, shadow)
           if not ok then
             return nil, err
           end
@@ -685,7 +685,7 @@ function declarative.load_into_cache(entities, meta, hash, shadow_page)
     for ws_id, keys in pairs(keys_by_ws) do
       local entity_prefix = entity_name .. "|" .. (schema.workspaceable and ws_id or "")
 
-      local ok, err = kong.core_cache:safe_set(entity_prefix .. "|@list", keys, shadow_page)
+      local ok, err = kong.core_cache:safe_set(entity_prefix .. "|@list", keys, shadow)
       if not ok then
         return nil, err
       end
@@ -695,7 +695,7 @@ function declarative.load_into_cache(entities, meta, hash, shadow_page)
         if fids then
           for fid, entries in pairs(fids) do
             local key = entity_prefix .. "|" .. ref .. "|" .. fid .. "|@list"
-            local ok, err = kong.core_cache:safe_set(key, entries, shadow_page)
+            local ok, err = kong.core_cache:safe_set(key, entries, shadow)
             if not ok then
               return nil, err
             end
@@ -718,7 +718,7 @@ function declarative.load_into_cache(entities, meta, hash, shadow_page)
         end
         -- stay consistent with pagination
         table.sort(arr)
-        local ok, err = kong.core_cache:safe_set(key, arr, shadow_page)
+        local ok, err = kong.core_cache:safe_set(key, arr, shadow)
         if not ok then
           return nil, err
         end
@@ -730,7 +730,7 @@ function declarative.load_into_cache(entities, meta, hash, shadow_page)
     -- tags:admin|@list -> all tags tagged "admin", regardless of the entity type
     -- each tag is encoded as a string with the format "admin|services|uuid", where uuid is the service uuid
     local key = "tags:" .. tag_name .. "|@list"
-    local ok, err = kong.core_cache:safe_set(key, tags, shadow_page)
+    local ok, err = kong.core_cache:safe_set(key, tags, shadow)
     if not ok then
       return nil, err
     end
@@ -738,7 +738,7 @@ function declarative.load_into_cache(entities, meta, hash, shadow_page)
 
   -- tags||@list -> all tags, with no distinction of tag name or entity type.
   -- each tag is encoded as a string with the format "admin|services|uuid", where uuid is the service uuid
-  local ok, err = kong.core_cache:safe_set("tags||@list", tags, shadow_page)
+  local ok, err = kong.core_cache:safe_set("tags||@list", tags, shadow)
   if not ok then
     return nil, err
   end
@@ -755,7 +755,6 @@ end
 
 
 function declarative.load_into_cache_with_events(entities, meta, hash)
-
   -- ensure any previous update finished (we're flipped to the latest page)
   local ok, err = kong.worker_events.poll()
   if not ok then
@@ -786,17 +785,8 @@ function declarative.load_into_cache_with_events(entities, meta, hash)
     assert(bytes == #json, "incomplete config sent to the stream subsystem")
   end
 
-  ok, err = kong.worker_events.post("balancer", "upstreams", {
-    operation = "delete_all",
-    entity = { id = "all", name = "all" }
-  })
-  if not ok then
-    return nil, err
-  end
-
   local default_ws
   ok, err, default_ws = declarative.load_into_cache(entities, meta, hash, SHADOW)
-
   if ok then
     ok, err = kong.worker_events.post("declarative", "flip_config", default_ws)
     if ok ~= "done" then
@@ -810,24 +800,6 @@ function declarative.load_into_cache_with_events(entities, meta, hash)
   ok, err = kong.core_cache:save_curr_page()
   if not ok then
     return nil, "failed to persist cache page number inside shdict: " .. err
-  end
-
-  kong.core_cache:invalidate("router:version")
-
-  ok, err = kong.worker_events.post("balancer", "upstreams", {
-    operation = "reset",
-    entity = { id = "all", name = "all" }
-  })
-  if not ok then
-    return nil, err
-  end
-
-  ok, err = kong.worker_events.post("balancer", "targets", {
-    operation = "reset",
-    entity = { id = "all", name = "all" }
-  })
-  if not ok then
-    return nil, err
   end
 
   return true

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -591,7 +591,7 @@ end
 
 
 local function insert_default_workspace_if_not_given(self, entities)
-  local default_workspace = find_default_ws(entities) or utils.uuid()
+  local default_workspace = find_default_ws(entities) or "0dc6f45b-8f8d-40d2-a504-473544ee190b"
 
   if not entities.workspaces then
     entities.workspaces = {}

--- a/kong/db/strategies/off/init.lua
+++ b/kong/db/strategies/off/init.lua
@@ -176,6 +176,10 @@ local function page_for_key(self, key, size, offset, options)
       item = cache:get(item, nil, nil_cb)
     end
 
+    if not item then
+      return nil, "stale data detected while paginating"
+    end
+
     item = self.schema:process_auto_fields(item, "select", true, {
       no_defaults = true,
       show_ws_id = true,

--- a/kong/runloop/plugins_iterator.lua
+++ b/kong/runloop/plugins_iterator.lua
@@ -145,68 +145,112 @@ local function load_configuration_through_combos(ctx, combos, plugin)
   local  service_id = service  and  service.id or nil
   local consumer_id = consumer and consumer.id or nil
 
-  if route_id and service_id and consumer_id and combos[COMBO_RSC]
-    and combos.both[route_id] == service_id
-  then
-    plugin_configuration = load_configuration(ctx, name, route_id, service_id,
-                                              consumer_id)
-    if plugin_configuration then
-      return plugin_configuration
+  if kong.db.strategy == "off" then
+    if route_id and service_id and consumer_id and combos[COMBO_RSC]
+      and combos.rsc[route_id] and combos.rsc[route_id][service_id]
+      and combos.rsc[route_id][service_id][consumer_id]
+    then
+      return combos.rsc[route_id][service_id][consumer_id]
     end
-  end
 
-  if route_id and consumer_id and combos[COMBO_RC]
-    and combos.routes[route_id]
-  then
-    plugin_configuration = load_configuration(ctx, name, route_id, nil,
-                                              consumer_id)
-    if plugin_configuration then
-      return plugin_configuration
+    if route_id and consumer_id and combos[COMBO_RC]
+      and combos.rc[route_id] and combos.rc[route_id][consumer_id]
+    then
+      return combos.rc[route_id][consumer_id]
     end
-  end
 
-  if service_id and consumer_id and combos[COMBO_SC]
-    and combos.services[service_id]
-  then
-    plugin_configuration = load_configuration(ctx, name, nil, service_id,
-                                              consumer_id)
-    if plugin_configuration then
-      return plugin_configuration
+    if service_id and consumer_id and combos[COMBO_SC]
+      and combos.sc[service_id] and combos.sc[service_id][consumer_id]
+    then
+      return combos.sc[service_id][consumer_id]
     end
-  end
 
-  if route_id and service_id and combos[COMBO_RS]
-    and combos.both[route_id] == service_id
-  then
-    plugin_configuration = load_configuration(ctx, name, route_id, service_id)
-    if plugin_configuration then
-      return plugin_configuration
+    if route_id and service_id and combos[COMBO_RS]
+      and combos.rs[route_id] and combos.rs[route_id][service_id]
+    then
+      return combos.rs[route_id][service_id]
     end
-  end
 
-  if consumer_id and combos[COMBO_C] then
-    plugin_configuration = load_configuration(ctx, name, nil, nil, consumer_id)
-    if plugin_configuration then
-      return plugin_configuration
+    if consumer_id and combos[COMBO_C] and combos.c[consumer_id] then
+      return combos.c[consumer_id]
     end
-  end
 
-  if route_id and combos[COMBO_R] and combos.routes[route_id] then
-    plugin_configuration = load_configuration(ctx, name, route_id)
-    if plugin_configuration then
-      return plugin_configuration
+    if route_id and combos[COMBO_R] and combos.r[route_id] then
+      return combos.r[route_id]
     end
-  end
 
-  if service_id and combos[COMBO_S] and combos.services[service_id] then
-    plugin_configuration = load_configuration(ctx, name, nil, service_id)
-    if plugin_configuration then
-      return plugin_configuration
+    if service_id and combos[COMBO_S] and combos.s[service_id] then
+      return combos.s[service_id]
     end
-  end
 
-  if combos[COMBO_GLOBAL] then
-    return load_configuration(ctx, name)
+    if combos[COMBO_GLOBAL] then
+      return combos[COMBO_GLOBAL]
+    end
+
+  else
+    if route_id and service_id and consumer_id and combos[COMBO_RSC]
+      and combos.both[route_id] == service_id
+    then
+      plugin_configuration = load_configuration(ctx, name, route_id, service_id,
+                                                consumer_id)
+      if plugin_configuration then
+        return plugin_configuration
+      end
+    end
+
+    if route_id and consumer_id and combos[COMBO_RC]
+      and combos.routes[route_id]
+    then
+      plugin_configuration = load_configuration(ctx, name, route_id, nil,
+                                                consumer_id)
+      if plugin_configuration then
+        return plugin_configuration
+      end
+    end
+
+    if service_id and consumer_id and combos[COMBO_SC]
+      and combos.services[service_id]
+    then
+      plugin_configuration = load_configuration(ctx, name, nil, service_id,
+                                                consumer_id)
+      if plugin_configuration then
+        return plugin_configuration
+      end
+    end
+
+    if route_id and service_id and combos[COMBO_RS]
+      and combos.both[route_id] == service_id
+    then
+      plugin_configuration = load_configuration(ctx, name, route_id, service_id)
+      if plugin_configuration then
+        return plugin_configuration
+      end
+    end
+
+    if consumer_id and combos[COMBO_C] then
+      plugin_configuration = load_configuration(ctx, name, nil, nil, consumer_id)
+      if plugin_configuration then
+        return plugin_configuration
+      end
+    end
+
+    if route_id and combos[COMBO_R] and combos.routes[route_id] then
+      plugin_configuration = load_configuration(ctx, name, route_id)
+      if plugin_configuration then
+        return plugin_configuration
+      end
+    end
+
+    if service_id and combos[COMBO_S] and combos.services[service_id] then
+      plugin_configuration = load_configuration(ctx, name, nil, service_id)
+      if plugin_configuration then
+        return plugin_configuration
+      end
+    end
+
+    if combos[COMBO_GLOBAL] then
+      return load_configuration(ctx, name)
+    end
   end
 end
 
@@ -331,6 +375,8 @@ function PluginsIterator.new(version)
     [kong.default_workspace] = new_ws_data()
   }
 
+  local ws_id = workspaces.get_workspace_id() or kong.default_workspace
+
   local counter = 0
   local page_size = kong.db.plugins.pagination.page_size
   for plugin, err in kong.db.plugins:each(nil, GLOBAL_QUERY_OPTS) do
@@ -366,21 +412,90 @@ function PluginsIterator.new(version)
                       + (plugin.service  and 2 or 0)
                       + (plugin.consumer and 4 or 0)
 
-      combos[name]          = combos[name]          or {}
-      combos[name].both     = combos[name].both     or {}
-      combos[name].routes   = combos[name].routes   or {}
-      combos[name].services = combos[name].services or {}
 
-      combos[name][combo_key] = true
 
-      if plugin.route and plugin.service then
-        combos[name].both[plugin.route.id] = plugin.service.id
+      if kong.db.strategy == "off" then
+        if plugin.enabled then
+          local cfg = plugin.config or {}
 
-      elseif plugin.route then
-        combos[name].routes[plugin.route.id] = true
+          cfg.route_id    = plugin.route    and plugin.route.id
+          cfg.service_id  = plugin.service  and plugin.service.id
+          cfg.consumer_id = plugin.consumer and plugin.consumer.id
 
-      elseif plugin.service then
-        combos[name].services[plugin.service.id] = true
+          local key = kong.db.plugins:cache_key(name,
+                                               cfg.route_id,
+                                               cfg.service_id,
+                                               cfg.consumer_id,
+                                               nil,
+                                               ws_id)
+
+          if not cfg.__key__ then
+            cfg.__key__ = key
+            cfg.__seq__ = next_seq
+            next_seq = next_seq + 1
+          end
+
+          combos[name]     = combos[name]     or {}
+          combos[name].rsc = combos[name].rsc or {}
+          combos[name].rc  = combos[name].rc  or {}
+          combos[name].sc  = combos[name].sc  or {}
+          combos[name].rs  = combos[name].rs  or {}
+          combos[name].c   = combos[name].c   or {}
+          combos[name].r   = combos[name].r   or {}
+          combos[name].s   = combos[name].s   or {}
+
+          combos[name][combo_key] = cfg
+
+          if cfg.route_id and cfg.service_id and cfg.consumer_id then
+            combos[name].rsc[cfg.route_id] =
+            combos[name].rsc[cfg.route_id] or {}
+            combos[name].rsc[cfg.route_id][cfg.service_id] =
+            combos[name].rsc[cfg.route_id][cfg.service_id] or {}
+            combos[name].rsc[cfg.route_id][cfg.service_id][cfg.consumer_id] = cfg
+
+          elseif cfg.route_id and cfg.consumer_id then
+            combos[name].rc[cfg.route_id] =
+            combos[name].rc[cfg.route_id] or {}
+            combos[name].rc[cfg.route_id][cfg.consumer_id] = cfg
+
+          elseif cfg.service_id and cfg.consumer_id then
+            combos[name].sc[cfg.service_id] =
+            combos[name].sc[cfg.service_id] or {}
+            combos[name].sc[cfg.service_id][cfg.consumer_id] = cfg
+
+          elseif cfg.route_id and cfg.service_id then
+            combos[name].rs[cfg.route_id] =
+            combos[name].rs[cfg.route_id] or {}
+            combos[name].rs[cfg.route_id][cfg.service_id] = cfg
+
+          elseif cfg.consumer_id then
+            combos[name].c[cfg.consumer_id] = cfg
+
+          elseif cfg.route_id then
+            combos[name].r[cfg.route_id] = cfg
+
+          elseif cfg.service_id then
+            combos[name].s[cfg.service_id] = cfg
+          end
+        end
+
+      else
+        combos[name]          = combos[name]          or {}
+        combos[name].both     = combos[name].both     or {}
+        combos[name].routes   = combos[name].routes   or {}
+        combos[name].services = combos[name].services or {}
+
+        combos[name][combo_key] = true
+
+        if plugin.route and plugin.service then
+          combos[name].both[plugin.route.id] = plugin.service.id
+
+        elseif plugin.route then
+          combos[name].routes[plugin.route.id] = true
+
+        elseif plugin.service then
+          combos[name].services[plugin.service.id] = true
+        end
       end
     end
 

--- a/kong/runloop/plugins_iterator.lua
+++ b/kong/runloop/plugins_iterator.lua
@@ -334,6 +334,10 @@ function PluginsIterator.new(version)
   local counter = 0
   local page_size = kong.db.plugins.pagination.page_size
   for plugin, err in kong.db.plugins:each(nil, GLOBAL_QUERY_OPTS) do
+    if err then
+      return nil, err
+    end
+
     local data = ws[plugin.ws_id]
     if not data then
       data = new_ws_data()
@@ -342,11 +346,7 @@ function PluginsIterator.new(version)
     local map = data.map
     local combos = data.combos
 
-    if err then
-      return nil, err
-    end
-
-    if kong.core_cache and counter > 0 and counter % page_size == 0 then
+    if kong.core_cache and counter > 0 and counter % page_size == 0 and kong.db.strategy ~= "off" then
       local new_version, err = kong.core_cache:get("plugins_iterator:version", TTL_ZERO, utils.uuid)
       if err then
         return nil, "failed to retrieve plugins iterator version: " .. err

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -25,10 +25,6 @@ cluster_cert_key = NONE
 cluster_mtls = shared
 cluster_ca_cert = NONE
 cluster_server_name = NONE
-nginx_user = nobody nobody
-nginx_worker_processes = auto
-nginx_optimizations = on
-nginx_daemon = on
 mem_cache_size = 128m
 ssl_cert = NONE
 ssl_cert_key = NONE
@@ -48,10 +44,15 @@ status_ssl_cert_key = NONE
 headers = server_tokens, latency_tokens
 trusted_ips = NONE
 error_default_type = text/plain
+upstream_keepalive = 60
 upstream_keepalive_pool_size = 60
 upstream_keepalive_max_requests = 100
 upstream_keepalive_idle_timeout = 60
 
+nginx_user = nobody nobody
+nginx_worker_processes = auto
+nginx_optimizations = on
+nginx_daemon = on
 nginx_main_daemon = on
 nginx_main_user = nobody nobody
 nginx_main_worker_processes = auto
@@ -73,21 +74,17 @@ nginx_proxy_real_ip_recursive = off
 nginx_upstream_keepalive = 60
 nginx_upstream_keepalive_requests = 100
 nginx_upstream_keepalive_timeout = 60s
-
-nginx_daemon = on
-nginx_user = nobody nobody
-nginx_worker_processes = auto
-nginx_optimizations = on
-client_max_body_size = 0
-client_body_buffer_size = 8k
-real_ip_header = X-Real-IP
-real_ip_recursive = off
-upstream_keepalive = 60
 nginx_http_upstream_keepalive = 60
 nginx_http_upstream_keepalive_requests = 100
 nginx_http_upstream_keepalive_timeout = 60s
 
+client_max_body_size = 0
+client_body_buffer_size = 8k
+real_ip_header = X-Real-IP
+real_ip_recursive = off
+
 database = postgres
+
 pg_host = 127.0.0.1
 pg_port = 5432
 pg_database = kong
@@ -130,6 +127,7 @@ cassandra_repl_strategy = SimpleStrategy
 cassandra_repl_factor = 1
 cassandra_data_centers = dc1:2,dc2:3
 cassandra_schema_consensus_timeout = 10000
+
 declarative_config = NONE
 
 db_update_frequency = 5


### PR DESCRIPTION
### Summary

Before this commit, it was really hard to understand how the `POST /config` worked with dbless and was it correct. While figuring out how to make this depend less on events, and be more atomic, I also found couple of issues.

Let me try to explain changes here.

**`declarative/init.lua`**:

This file had following code:
```lua
kong.core_cache:purge(SHADOW)
kong.cache:purge(SHADOW)
```

The function also had parameter to which `page` to load configuration, so this was for obvious reasons changed to:
```lua
kong.core_cache:purge(shadow) --using the function argument
kong.cache:purge(shadow) --using the function argument
```

So that `load` will always clear the page where it is loading the config to (that workers need to be able to clear their LRUs).

The `load_into_cache_with_events` also relied to events, both before and after flipping the page, like `delete_all` on upstreams (before flipping) and `reset` on both targets and upstreams after flipping the cache. I removed these events
and moved the code to the `flip_config` event handler to make it easier to understand the code and also to make it generate a lot fewer events. There was even a case where these events generated more events in a loop, which
also generated new lru cleanup events. So it was really quite bad.

**`runloop/handler.lua`**:

As mentioned before we moved the code from multiple events to a single place, so the `flip_config` code was changed, here is the old one:

```lua
kong.cache:flip()
core_cache:flip()
kong.default_workspace = default_ws
ngx.ctx.workspace = kong.default_workspace
```

And here is a new one:
```lua
local ok, err = concurrency.with_coroutine_mutex(FLIP_CONFIG_OPTS, function()
  balancer.stop_healthcheckers()

  kong.cache:flip()
  core_cache:flip()

  kong.default_workspace = default_ws
  ngx.ctx.workspace = kong.default_workspace

  rebuild_plugins_iterator(PLUGINS_ITERATOR_SYNC_OPTS)
  rebuild_router(ROUTER_SYNC_OPTS)

  balancer.init()

  return true
end)

if not ok then
  log(ERR, "config flip failed: ", err)
end
```

This code always runs synchronously on dbless and it does not yield -> Edit: it seems to be yielding still, :-(.

As you can see there is some code that runs `before flipping`, aka removal of healthcheckers, and deletion on balancer caches that will cause other workers to clear their LRUs. Then there is code that runs after the flipping. Previously that code relied on `reset` events and `router:version` invalidation. This made the whole flip possibly non-atomic (but I am not 100% sure of it). At least it made code very hard to follow: what happens in what order. Now the order is visible there in a single place, and it does not raise huge amounts of events (still some, but order of magnitude less than before).

I tested the code against memory leaks with multiple workers and multiple simultaneous uploads of new configs. But it worked as expected, and I saw no memory been leaking.

**`cache.lua`**:

Just some style changes as I tried to understand the code better.

**`init.lua`**:

While doing this I also spotted another issue on reloads that happened in `reset_kong_shm` function. I added more cache entries to be reserved and also made it more intelligent to detect which page it should keep and which one to clear on `reload`. Some of that `reset`ing is unnecessary in some scenarios, but on those scenarios it is more than likely that the `shms` that it tries to reset are already empty, so the impact of resetting them will be small. And well, we did it before these additions too, it justs preserves and resets more.

Reviewing this, you need to have your head wrapped to:
1. kong can run on dbless and with db
2. reload/restart may happen on dbless and with db
3. reload may contain a new declarative configuration
4. we need to be extra careful to not leak memory in worker level LRUs or SHMs on configuration changes, also both L1 and L2 caches need to be cleared properly  across all the workers so that old configs don't pop-up from those. Also when reloading dbless nodes without explicit declarative configuration, the nodes need to preserve their current caches.

Thanks @dndx and @locao for helping me on this.