### PR TITLE
fix(balancer) protect against empty upstreams_dict on eventual

### DIFF
--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -644,7 +644,7 @@ local opts = { neg_ttl = 10 }
 -- and upstream entity tables as values), or nil+error
 local function get_all_upstreams()
   if kong.configuration.worker_consistency == "eventual" then
-    return singletons.core_cache:get("balancer:upstreams", opts, noop)
+    return singletons.core_cache:get("balancer:upstreams", opts, noop) or {}
   end
   local upstreams_dict, err = singletons.core_cache:get("balancer:upstreams", opts,
                                                         load_upstreams_dict_into_memory)


### PR DESCRIPTION
### Summary

When using `"eventual"` `worker_consistency`, `get_all_upstreams()` may be called before any balancer object is created. This is not an error, so we should return an empty table instead of `nil`.

Fixes the following error:

```
2020/07/10 15:44:48 [error] 215#0: *5954 lua entry thread aborted: runtime error: /usr/local/share/lua/5.1/kong/runloop/balancer.lua:662: attempt to index local 'upstreams_dict' (a nil value)
stack traceback:
coroutine 0:
        /usr/local/share/lua/5.1/kong/runloop/balancer.lua: in function 'get_upstream_by_name'
        /usr/local/share/lua/5.1/kong/runloop/balancer.lua:683: in function 'get_balancer'
        /usr/local/share/lua/5.1/kong/runloop/balancer.lua:1101: in function 'execute'
        /usr/local/share/lua/5.1/kong/runloop/handler.lua:870: in function 'balancer_execute'
        /usr/local/share/lua/5.1/kong/runloop/handler.lua:1242: in function 'after'
        /usr/local/share/lua/5.1/kong/init.lua:761: in function 'access'
        access_by_lua(nginx-kong.conf:88):2: in main chunk, client: 11.0.0.1, server: kong, request: "GET /one HTTP/1.1", host: "localhost:32781"
```

### Issues resolved

Fix #6302
