### PR TITLE
fix(api) issue with double inferring with plugins

### DIFF
--- a/kong/api/arguments.lua
+++ b/kong/api/arguments.lua
@@ -175,7 +175,7 @@ local function infer_value(value, field)
     return value
   end
 
-  if value == "" then
+  if value == "" or value == ngx.null then
     return ngx.null
   end
 

--- a/kong/api/routes/plugins.lua
+++ b/kong/api/routes/plugins.lua
@@ -76,8 +76,6 @@ local function patch_plugin(self, db, _, parent)
 
     plugin = plugin or {}
 
-    local post = self.args.post
-
     post.name = post.name or plugin.name
 
     -- Only now we can decode the 'config' table for form-encoded values


### PR DESCRIPTION
### Summary

Plugins did double inferring for arguments. First without schema and
second time with the schema. This all worked rather fine, except when
the `PATCH` call also included `name` attribute. This caused a double
inferring bug for `ngx.null`

`""` -> changed to `ngx.null` and then `ngx.null` inferred again turning
it in some cases to `{ ngx.null }`.