### PR TITLE
fix(migrations) fix composite cache keys in Cassandra

### DIFF
--- a/kong/db/migrations/operations/200_to_210.lua
+++ b/kong/db/migrations/operations/200_to_210.lua
@@ -304,7 +304,7 @@ local cassandra = {
         end
 
         for _, row in ipairs(rows) do
-          if not row.cache_key:match(":$") then
+          if row.cache_key:match(":$") then
             local cql = render([[
               UPDATE $(TABLE) SET cache_key = '$(CACHE_KEY)' WHERE $(PARTITION) id = $(ID)
             ]], {


### PR DESCRIPTION
There's a mismatch between the way PostgreSQL migrates
composite cache keys in Postgresql which end with ':':

```
UPDATE "$(TABLE)"
SET cache_key = CONCAT(cache_key, ':',
                       (SELECT id FROM workspaces WHERE name = 'default'))
WHERE cache_key LIKE '%:';
```

Cassandra did the opposite, updating the cache keys which did *not*
end with ':' :
```
for _, row in ipairs(rows) do
  if not row.cache_key:match(":$")
    local cql = ...
```

This change was masked because of the plugins cache warmup, which
ignores the cache_key field. But it was visible if Kong was started
with cache warmup deactivated for plugins, after migrating
plugins from an older version of Kong in Cassandra.