### PR TITLE
fix(balancer) make balancer flip config atomic by waiting for workers to finish

### DIFF
--- a/kong/api/routes/config.lua
+++ b/kong/api/routes/config.lua
@@ -97,13 +97,13 @@ return {
       if not ok then
         if err == "busy" or err == "locked" then
           return kong.response.exit(429, {
-            message = "Currently loading previous configuration."
-          }, { ["Retry-After"] = ttl or 60 })
+            message = "Currently loading previous configuration"
+          }, { ["Retry-After"] = ttl })
         end
 
         if err == "timeout" then
           return kong.response.exit(504, {
-            message = "Timed out while loading configuration."
+            message = "Timed out while loading configuration"
           })
         end
 

--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -160,6 +160,11 @@ local constants = {
   },
   PROTOCOLS = protocols,
   PROTOCOLS_WITH_SUBSYSTEM = protocols_with_subsystem,
+
+  DECLARATIVE_FLIPS = {
+    name = "declarative:flips",
+    ttl = 60,
+  }
 }
 
 

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -1301,10 +1301,7 @@ do
       return
     end
 
-    local ok, err = concurrency.with_worker_mutex({ name = "dbless-worker" }, function()
-      return declarative.load_into_cache_with_events(parsed[1], parsed[2])
-    end)
-
+    local ok, err = declarative.load_into_cache_with_events(parsed[1], parsed[2])
     if not ok then
       if err == "no memory" then
         kong.log.err("not enough cache space for declarative config, " ..

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -11,7 +11,6 @@ local singletons   = require "kong.singletons"
 local certificate  = require "kong.runloop.certificate"
 local concurrency  = require "kong.concurrency"
 local PluginsIterator = require "kong.runloop.plugins_iterator"
-local declarative  = require "kong.db.declarative"
 
 
 local kong         = kong
@@ -444,8 +443,7 @@ local function register_events()
 
         balancer.init()
 
-        ngx.shared.kong:incr(declarative.SHARED_COUNTER_NAME,
-            1, 0, declarative.SHARED_COUNTER_TTL)
+        ngx.shared.kong:incr(constants.DECLARATIVE_FLIPS.name, 1, 0, constants.DECLARATIVE_FLIPS.ttl)
 
         return true
       end)

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -11,6 +11,7 @@ local singletons   = require "kong.singletons"
 local certificate  = require "kong.runloop.certificate"
 local concurrency  = require "kong.concurrency"
 local PluginsIterator = require "kong.runloop.plugins_iterator"
+local declarative  = require "kong.db.declarative"
 
 
 local kong         = kong

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -443,6 +443,8 @@ local function register_events()
 
         balancer.init()
 
+        ngx.shared.kong:incr("declarative:flips", 1, 0, 60)
+
         return true
       end)
 

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -443,7 +443,8 @@ local function register_events()
 
         balancer.init()
 
-        ngx.shared.kong:incr("declarative:flips", 1, 0, 60)
+        ngx.shared.kong:incr(declarative.SHARED_COUNTER_NAME,
+            1, 0, declarative.SHARED_COUNTER_TTL)
 
         return true
       end)


### PR DESCRIPTION
### Summary

With this patch the same node can receive new config at `:8001/config` only one at the time, and it waits for other workers to flip before allowing a new config to be uploaded. It makes `:8001/config` endpoint essentially serializable.

There is 60 seconds timeout, so that it will not be held forever.

@hishamhm knows that I tried this on the previous atomic (#6092), but as it was not causing issues anymore with router and plugins iterator, I removed it. Further testing showed that balancer has still issues with this. So I set up the flip-serializer again.