### PR TITLE
tests(migrations) migration tests for 140_to_150 and 200_to_210

### DIFF
--- a/kong/db/init.lua
+++ b/kong/db/init.lua
@@ -389,9 +389,10 @@ do
   local last_schema_state
 
 
-  function DB:schema_state()
+  function DB:schema_state(stop_namespace, stop_migration)
     local err
-    last_schema_state, err = MigrationsState.load(self)
+    last_schema_state, err = MigrationsState.load(
+      self, stop_namespace, stop_migration)
     return last_schema_state, err
   end
 

--- a/kong/db/migrations/operations/200_to_210.lua
+++ b/kong/db/migrations/operations/200_to_210.lua
@@ -174,6 +174,7 @@ local postgres = {
 
     ------------------------------------------------------------------------------
     -- General function to fixup a plugin configuration
+    --
     fixup_plugin_config = function(_, connector, plugin_name, fixup_fn)
       local pgmoon_json = require("pgmoon.json")
 

--- a/kong/db/migrations/state.lua
+++ b/kong/db/migrations/state.lua
@@ -48,9 +48,18 @@ local Migrations_mt = {
 }
 
 
-local function load_subsystems(db, plugin_names)
+local function load_subsystems(db, plugin_names, stop_namespace, stop_migration)
   if type(plugin_names) ~= "table" then
     error("plugin_names must be a table", 2)
+  end
+
+  if type(stop_namespace) ~= "nil" or type(stop_migration) ~= "nil" then
+    if type(stop_namespace) ~= "string" then
+      error("stop_subsystem must be a string if stop_migration is present, or nil")
+    end
+    if type(stop_namespace) ~= "string" then
+      error("stop_migration must be a string if stop_subsystem is present, or nil")
+    end
   end
 
   local subsystems = require("kong.db.migrations.subsystems")
@@ -88,25 +97,37 @@ local function load_subsystems(db, plugin_names)
   for _, subsys in ipairs(res) do
     subsys.migrations = {}
 
+    local stop_migration_found = false
+    if stop_namespace == "kong.db.migrations.core"
+    and subsys.namespace ~= stop_namespace
+    then
+      stop_migration_found = true
+    end
     for _, mig_name in ipairs(subsys.migrations_index) do
-      local mig_module = fmt("%s.%s", subsys.namespace, mig_name)
-
-      local ok, migration = utils.load_module_if_exists(mig_module)
-      if not ok then
-        return nil, fmt_err(db, "failed to load migration '%s' of '%s' subsystem",
-                            mig_module, subsys.name)
+      if subsys.namespace == stop_namespace and
+         mig_name == stop_migration then
+         stop_migration_found = true
       end
+      if not stop_migration_found then
+        local mig_module = fmt("%s.%s", subsys.namespace, mig_name)
 
-      migration.name = mig_name
+        local ok, migration = utils.load_module_if_exists(mig_module)
+        if not ok then
+          return nil, fmt_err(db, "failed to load migration '%s' of '%s' subsystem",
+                              mig_module, subsys.name)
+        end
 
-      local ok, errors = MigrationSchema:validate(migration)
-      if not ok then
-        local err_t = Errors:schema_violation(errors)
-        return nil, fmt_err(db, "migration '%s' of '%s' subsystem is invalid: %s",
-                            mig_module, subsys.name, tostring(err_t))
+        migration.name = mig_name
+
+        local ok, errors = MigrationSchema:validate(migration)
+        if not ok then
+          local err_t = Errors:schema_violation(errors)
+          return nil, fmt_err(db, "migration '%s' of '%s' subsystem is invalid: %s",
+                              mig_module, subsys.name, tostring(err_t))
+        end
+
+        table.insert(subsys.migrations, migration)
       end
-
-      table.insert(subsys.migrations, migration)
     end
   end
 
@@ -146,6 +167,16 @@ local function value_or_empty_table(value)
 end
 
 
+-- @tparam stop_subsystem string|nil optional subsystem where migrations will stop.
+--         Example: "kong.db.migrations.core" or "kong.plugins.key_auth.migrations"
+-- @tparam stop_migration string|nil optional migration name at which point migrations will stop.
+--         requires the subsystem attribute to be set
+--         Example: "007_140_to_150" (with "kong.db.migrations.core")
+--         This means core migrations will only execute until migration 006 in core
+--         When core migrations are stopped, other migrations (like plugins) are all stopped
+--         Example: "000_base_key_auth" (with "kong.plugins.key_auth.migrations")
+--         Key-auth migrations will not be executed at all, but the rest (core and
+--         plugins) will.
 -- @return a table with the following structure:
 -- {
 --   executed_migrations = Subsystem[] | nil
@@ -167,11 +198,12 @@ end
 --    },
 -- }
 --
-function State.load(db)
+function State.load(db, stop_subsystem, stop_migration)
 
   log.debug("loading subsystems migrations...")
 
-  local subsystems, err = load_subsystems(db, db.kong_config.loaded_plugins)
+  local subsystems, err = load_subsystems(db, db.kong_config.loaded_plugins,
+                                          stop_subsystem, stop_migration)
   if not subsystems then
     return nil, prefix_err(db, err)
   end

--- a/spec/02-integration/03-db/13-migrations/007_140_to_150_spec.lua
+++ b/spec/02-integration/03-db/13-migrations/007_140_to_150_spec.lua
@@ -1,0 +1,91 @@
+local helpers = require "spec.helpers"
+local fmt = string.format
+
+describe("#db migration core/007_140_to_150 spec", function()
+  local _, db
+
+  after_each(function()
+    -- Clean up the database schema after each exercise.
+    -- This prevents failed migration tests impacting other tests in the CI
+    assert(db:schema_reset())
+  end)
+
+  it("#postgres", function()
+    _, db = helpers.get_db_utils("postgres", nil, nil, {
+      stop_namespace = "kong.db.migrations.core",
+      stop_migration = "007_140_to_150"
+    })
+
+    local cn = db.connector
+    local res = assert(cn:query([[
+      SELECT *
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+      AND table_name     = 'routes'
+      AND column_name    = 'path_handling';
+    ]]))
+    assert.same({}, res)
+
+    -- kong migrations up
+    assert(helpers.run_up_migration(db, "core", "kong.db.migrations.core", "007_140_to_150"))
+
+    res = assert(cn:query([[
+      SELECT *
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+      AND table_name     = 'routes'
+      AND column_name    = 'path_handling';
+    ]]))
+    assert.equals(1, #res)
+    assert.equals("routes", res[1].table_name)
+    assert.equals("path_handling", res[1].column_name)
+    -- migration has no `teardown` in postgres, no further tests needed
+  end)
+
+  it("#cassandra", function()
+    local uuid = "c37d661d-7e61-49ea-96a5-68c34e83db3a"
+
+    _, db = helpers.get_db_utils("cassandra", nil, nil, {
+      stop_namespace = "kong.db.migrations.core",
+      stop_migration = "007_140_to_150"
+    })
+
+    local cn = db.connector
+
+    -- BEFORE
+    assert(cn:query(fmt([[
+      INSERT INTO
+      routes (partition, id, name, paths)
+      VALUES('routes', %s, 'test', ['/']);
+    ]], uuid)))
+
+    local res = assert(cn:query(fmt([[
+      SELECT * FROM routes WHERE partition = 'routes' AND id = %s;
+    ]], uuid)))
+    assert.same(1, #res)
+    assert.same(uuid, res[1].id)
+    assert.is_nil(res[1].path_handling)
+
+    -- kong migrations up
+    assert(helpers.run_up_migration(db, "core", "kong.db.migrations.core", "007_140_to_150"))
+
+    -- MIGRATING
+    res = assert(cn:query(fmt([[
+      SELECT * FROM routes WHERE partition = 'routes' AND id = %s;
+    ]], uuid)))
+    assert.same(1, #res)
+    assert.same(uuid, res[1].id)
+    assert.is_nil(res[1].path_handling)
+
+    -- kong migrations finish
+    assert(helpers.run_teardown_migration(db, "core", "kong.db.migrations.core", "007_140_to_150"))
+
+    -- AFTER
+    res = assert(cn:query(fmt([[
+      SELECT * FROM routes WHERE partition = 'routes' AND id = %s;
+    ]], uuid)))
+    assert.same(1, #res)
+    assert.same(uuid, res[1].id)
+    assert.same("v1", res[1].path_handling)
+  end)
+end)

--- a/spec/02-integration/03-db/13-migrations/009_200_to_210_spec.lua
+++ b/spec/02-integration/03-db/13-migrations/009_200_to_210_spec.lua
@@ -1,0 +1,860 @@
+local openssl_x509  = require "resty.openssl.x509"
+local str           = require "resty.string"
+local fixtures_ssl  = require "spec.fixtures.ssl"
+
+local helpers = require "spec.helpers"
+local fmt = string.format
+local utils = require "kong.tools.utils"
+local cassandra = require "cassandra"
+
+
+local fixtures_cert = fixtures_ssl.cert
+local expected_digest = str.to_hex(openssl_x509.new(fixtures_cert):digest("sha256"))
+
+local uuid = utils.uuid
+
+local PG_HAS_COLUMN_SQL = [[
+  SELECT *
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+  AND table_name     = '%s'
+  AND column_name    = '%s';
+]]
+
+local PG_HAS_CONSTRAINT_SQL = [[
+  SELECT *
+  FROM pg_catalog.pg_constraint
+  WHERE conname = '%s';
+]]
+
+local PG_HAS_INDEX_SQL = [[
+  SELECT *
+  FROM pg_indexes
+  WHERE indexname = '%s';
+]]
+
+local PG_HAS_TABLE_SQL = [[
+  SELECT *
+  FROM pg_catalog.pg_tables
+  WHERE schemaname = 'public'
+  AND tablename = '%s';
+]]
+
+local function assert_pg_has_column(cn, table_name, column_name, data_type)
+  local res = assert(cn:query(fmt(PG_HAS_COLUMN_SQL, table_name, column_name)))
+
+  assert.equals(1, #res)
+  assert.equals(column_name, res[1].column_name)
+  assert.equals(string.lower(data_type), string.lower(res[1].data_type))
+end
+
+
+local function assert_not_pg_has_column(cn, table_name, column_name, data_type)
+  local res = assert(cn:query(fmt(PG_HAS_COLUMN_SQL, table_name, column_name)))
+  assert.same({}, res)
+end
+
+
+local function assert_pg_has_constraint(cn, constraint_name)
+  local res = assert(cn:query(fmt(PG_HAS_CONSTRAINT_SQL, constraint_name)))
+
+  assert.equals(1, #res)
+  assert.equals(constraint_name, res[1].conname)
+end
+
+
+local function assert_not_pg_has_constraint(cn, constraint_name)
+  local res = assert(cn:query(fmt(PG_HAS_CONSTRAINT_SQL, constraint_name)))
+  assert.same({}, res)
+end
+
+
+local function assert_pg_has_index(cn, index_name)
+  local res = assert(cn:query(fmt(PG_HAS_INDEX_SQL, index_name)))
+
+  assert.equals(1, #res)
+  assert.equals(index_name, res[1].indexname)
+end
+
+
+local function assert_not_pg_has_index(cn, index_name)
+  local res = assert(cn:query(fmt(PG_HAS_INDEX_SQL, index_name)))
+  assert.same({}, res)
+end
+
+
+local function assert_pg_has_fkey(cn, table_name, column_name)
+  assert_pg_has_column(cn, table_name, column_name, "uuid")
+  assert_pg_has_constraint(cn, table_name .. "_" .. column_name .. "_fkey")
+end
+
+
+local function assert_not_pg_has_fkey(cn, table_name, column_name)
+  assert_not_pg_has_column(cn, table_name, column_name, "uuid")
+  assert_not_pg_has_constraint(cn, table_name .. "_" .. column_name .. "_fkey")
+end
+
+
+local function assert_pg_has_table(cn, table_name)
+  local res = assert(cn:query(fmt(PG_HAS_TABLE_SQL, table_name)))
+
+  assert.equals(1, #res)
+  assert.equals(table_name, res[1].tablename)
+end
+
+
+local function assert_not_pg_has_table(cn, table_name)
+  local res = assert(cn:query(fmt(PG_HAS_TABLE_SQL, table_name)))
+  assert.same({}, res)
+end
+
+
+local function pg_insert(cn, table_name, tbl)
+  local columns, values = {},{}
+  for k,_ in pairs(tbl) do
+    columns[#columns + 1] = k
+  end
+  table.sort(columns)
+  for i, c in ipairs(columns) do
+    local v = tbl[c]
+    v = type(v) == "string" and "'" .. v .. "'" or v
+    values[i] = tostring(v)
+  end
+  local sql = fmt([[
+    INSERT INTO %s (%s) VALUES (%s)
+  ]],
+    table_name,
+    table.concat(columns, ","),
+    table.concat(values, ",")
+  )
+
+  local res = assert(cn:query(sql))
+
+  assert.same({ affected_rows = 1 }, res)
+
+  return assert(cn:query(fmt("SELECT * FROM %s WHERE id='%s'", table_name, tbl.id)))[1]
+end
+
+---------------------
+
+local C_TABLE_HAS_COLUMN_CQL = [[
+  SELECT * FROM system_schema.columns
+  WHERE keyspace_name = '%s'
+  AND table_name = '%s'
+  AND column_name = '%s'
+  ALLOW FILTERING;
+]]
+
+local C_HAS_INDEX_CQL = [[
+  SELECT * FROM system_schema.indexes
+  WHERE keyspace_name='%s'
+  AND table_name='%s'
+  AND index_name='%s'
+]]
+
+local C_HAS_TABLE_CQL = [[
+  SELECT * FROM system_schema.tables
+  WHERE keyspace_name='%s'
+  AND table_name = '%s';
+]]
+
+
+local function assert_not_c_has_column(cn, table_name, column_name)
+  local res = assert(cn:query(fmt(C_TABLE_HAS_COLUMN_CQL, cn.keyspace, table_name, column_name)))
+  assert.equals(0, #res)
+  assert.same({ has_more_pages = false }, res.meta)
+end
+
+
+local function assert_c_has_column(cn, table_name, column_name, column_type)
+  local res = assert(cn:query(fmt(C_TABLE_HAS_COLUMN_CQL, cn.keyspace, table_name, column_name)))
+  assert.equals(1, #res)
+  assert.equals(column_name, res[1].column_name)
+  assert.equals(column_type, res[1].type)
+  assert.same({ has_more_pages = false }, res.meta)
+  return res[1]
+end
+
+
+local function assert_not_c_has_index(cn, table_name, index_name)
+  local res = assert(cn:query(fmt(C_HAS_INDEX_CQL, cn.keyspace, table_name, index_name)))
+  assert.equals(0, #res)
+  assert.same({ has_more_pages = false }, res.meta)
+end
+
+
+local function assert_c_has_index(cn, table_name, index_name)
+  local cql = fmt(C_HAS_INDEX_CQL, cn.keyspace, table_name, index_name)
+  local res = assert(cn:query(cql))
+  assert.equals(1, #res)
+  assert.equals(index_name, res[1].index_name)
+  assert.same({ has_more_pages = false }, res.meta)
+  return res[1]
+end
+
+
+local function assert_not_c_has_fkey(cn, table_name, column_name)
+  assert_not_c_has_column(cn, table_name, column_name, "uuid")
+  assert_not_c_has_index(cn, table_name, table_name .. "_" .. column_name .. "_idx")
+end
+
+
+local function assert_c_has_fkey(cn, table_name, column_name)
+  local res = assert_c_has_column(cn, table_name, column_name, "uuid")
+  assert_c_has_index(cn, table_name, table_name .. "_" .. column_name .. "_idx")
+  return res
+end
+
+
+local function assert_not_c_has_table(cn, table_name)
+  local res = assert(cn:query(fmt(C_HAS_TABLE_CQL, cn.keyspace, table_name)))
+  assert.equals(0, #res)
+  assert.same({ has_more_pages = false }, res.meta)
+end
+
+
+local function assert_c_has_table(cn, table_name)
+  local res = assert(cn:query(fmt(C_HAS_TABLE_CQL, cn.keyspace, table_name)))
+  assert.equals(1, #res)
+  assert.equals(table_name, res[1].table_name)
+  assert.same({ has_more_pages = false }, res.meta)
+  return res[1]
+end
+
+
+local function c_insert(cn, table_name, tbl)
+  local columns, bindings, values = {},{},{}
+  for k,_ in pairs(tbl) do
+    columns[#columns + 1] = k
+  end
+  table.sort(columns)
+  for i, c in ipairs(columns) do
+    bindings[#bindings + 1] = "?"
+    local v = tbl[c]
+    if c ~= "custom_id" and c:sub(-2) == "id" then
+      v = cassandra.uuid(v)
+    end
+    values[i] = v
+  end
+
+  local cql = fmt([[
+    INSERT INTO %s(%s) VALUES(%s)
+  ]],
+    table_name,
+    table.concat(columns, ", "),
+    table.concat(bindings, ", ")
+  )
+  local res = assert(cn:query(cql, values))
+
+  assert.same({ type = "VOID" }, res)
+
+  if tbl.partition then
+    return assert(cn:query(fmt("SELECT * FROM %s WHERE partition=? AND id=?", table_name),
+                           { tbl.partition, cassandra.uuid(tbl.id) }))[1]
+  end
+
+  return assert(cn:query(fmt("SELECT * FROM %s WHERE id=?", table_name),
+                         { cassandra.uuid(tbl.id) }))[1]
+end
+
+describe("#db migration core/009_200_to_210 spec", function()
+  local _, db
+
+  after_each(function()
+    -- Clean up the database schema after each exercise.
+    -- This prevents failed migration tests impacting other tests in the CI
+    assert(db:schema_reset())
+  end)
+
+  describe("#postgres", function()
+    before_each(function()
+      _, db = helpers.get_db_utils("postgres", nil, nil, {
+        stop_namespace = "kong.db.migrations.core",
+        stop_migration = "009_200_to_210",
+      })
+    end)
+
+    it("adds/removes columns and constraints", function()
+      local cn = db.connector
+      assert_pg_has_constraint(cn, "ca_certificates_cert_key")
+      assert_not_pg_has_column(cn, "ca_certificates", "cert_digest", "text")
+      assert_not_pg_has_column(cn, "services", "tls_verify", "boolean")
+      assert_not_pg_has_column(cn, "services", "tls_verify_depth", "smallint")
+      assert_not_pg_has_column(cn, "services", "ca_certificates", "array")
+      assert_not_pg_has_fkey(cn, "upstreams", "client_certificate_id")
+      assert_not_pg_has_index(cn, "upstreams_fkey_client_certificate")
+
+      -- kong migrations up
+      assert(helpers.run_up_migration(db, "core", "kong.db.migrations.core", "009_200_to_210"))
+
+      -- MIGRATING/AFTER
+      assert_not_pg_has_constraint(cn, "ca_certificates_cert_key")
+      assert_pg_has_column(cn, "ca_certificates", "cert_digest", "text")
+      assert_pg_has_column(cn, "services", "tls_verify", "boolean")
+      assert_pg_has_column(cn, "services", "ca_certificates", "array")
+      assert_pg_has_fkey(cn, "upstreams", "client_certificate_id")
+      assert_pg_has_index(cn, "upstreams_fkey_client_certificate")
+    end)
+
+    it("initializes ca_certificates.cert_digest", function()
+      local cn = db.connector
+
+      pg_insert(cn, "ca_certificates", { id = uuid(), cert = fixtures_cert })
+
+      -- kong migrations up
+      assert(helpers.run_up_migration(db, "core", "kong.db.migrations.core", "009_200_to_210"))
+
+      -- MIGRATING
+
+      -- expect ca_certificates.cert_digest to be empty
+      local cc = assert(cn:query("SELECT * FROM ca_certificates;"))[1]
+      assert.equals(ngx.null, cc.cert_digest)
+
+      -- kong migrations finish
+      assert(helpers.run_teardown_migration(db, "core", "kong.db.migrations.core", "009_200_to_210"))
+
+      -- AFTER
+      local cc = assert(cn:query("SELECT * FROM ca_certificates;"))[1]
+      assert.equals(expected_digest, cc.cert_digest)
+    end)
+
+    it("adds workspaces table, index and ws_id", function()
+      local cn = db.connector
+      assert_not_pg_has_table(cn, "workspaces")
+      assert_not_pg_has_index(cn, "workspaces_name_idx")
+      assert_not_pg_has_fkey(cn, "upstreams", "ws_id")
+      assert_not_pg_has_fkey(cn, "targets", "ws_id")
+      assert_not_pg_has_fkey(cn, "consumers", "ws_id")
+      assert_not_pg_has_fkey(cn, "certificates", "ws_id")
+      assert_not_pg_has_fkey(cn, "snis", "ws_id")
+      assert_not_pg_has_fkey(cn, "services", "ws_id")
+      assert_not_pg_has_fkey(cn, "routes", "ws_id")
+      assert_not_pg_has_fkey(cn, "plugins", "ws_id")
+
+      -- kong migrations up
+      assert(helpers.run_up_migration(db, "core", "kong.db.migrations.core", "009_200_to_210"))
+
+      -- MIGRATING
+      assert_pg_has_table(cn, "workspaces")
+      assert_pg_has_index(cn, "workspaces_name_idx")
+      assert_pg_has_fkey(cn, "upstreams", "ws_id")
+      assert_pg_has_fkey(cn, "targets", "ws_id")
+      assert_pg_has_fkey(cn, "consumers", "ws_id")
+      assert_pg_has_fkey(cn, "certificates", "ws_id")
+      assert_pg_has_fkey(cn, "snis", "ws_id")
+      assert_pg_has_fkey(cn, "services", "ws_id")
+      assert_pg_has_fkey(cn, "routes", "ws_id")
+      assert_pg_has_fkey(cn, "plugins", "ws_id")
+    end)
+
+    it("correctly handles ws_id", function()
+      local cn = db.connector
+      -- BEFORE
+      -- old node, there isn't even a ws_id column here
+      local u = pg_insert(cn, "upstreams", { id = uuid(), name = 'before-upstream', slots = 1 })
+      pg_insert(cn, "targets",   { id = uuid(), upstream_id = u.id, target = 'before-target', weight = 1 })
+      pg_insert(cn, "consumers", { id = uuid(), username = "before-consumer" })
+      local cc = pg_insert(cn, "certificates", { id = uuid(), cert = "before-cert", key = "key" })
+      pg_insert(cn, "snis", { id = uuid(), certificate_id = cc.id, name = "before-sni" })
+      local s = pg_insert(cn, "services", { id = uuid(), name = "before-service" })
+      pg_insert(cn, "routes", { id = uuid(), service_id = s.id })
+      pg_insert(cn, "plugins", { id = uuid(), name="key-auth", service_id = s.id, config="{}", enabled = true })
+
+      -- kong migrations up
+      assert(helpers.run_up_migration(db, "core", "kong.db.migrations.core", "009_200_to_210"))
+
+      -- MIGRATING
+      -- check default workspace exists and get its id
+      local res = assert(cn:query("SELECT * FROM workspaces"))
+      assert.equals(1, #res)
+      assert.equals("default", res[1].name)
+      assert.truthy(utils.is_valid_uuid(res[1].id))
+      local default_ws_id = res[1].id
+
+      -- ensure that the entities created by the old node get the default ws_id
+      local u = assert(cn:query("SELECT * FROM upstreams"))[1]
+      local t = assert(cn:query("SELECT * FROM targets"))[1]
+      local c = assert(cn:query("SELECT * FROM consumers"))[1]
+      local cc = assert(cn:query("SELECT * FROM certificates"))[1]
+      local sni = assert(cn:query("SELECT * FROM snis"))[1]
+      local s = assert(cn:query("SELECT * FROM services"))[1]
+      local r = assert(cn:query("SELECT * FROM routes"))[1]
+      local p = assert(cn:query("SELECT * FROM plugins"))[1]
+      assert.equals(default_ws_id, u.ws_id)
+      assert.equals(default_ws_id, t.ws_id)
+      assert.equals(default_ws_id, c.ws_id)
+      assert.equals(default_ws_id, cc.ws_id)
+      assert.equals(default_ws_id, sni.ws_id)
+      assert.equals(default_ws_id, s.ws_id)
+      assert.equals(default_ws_id, r.ws_id)
+      assert.equals(default_ws_id, p.ws_id)
+
+      -- create entities without specifying default ws_id.
+      -- it simulates an "old" kong node inserting entities
+      -- expect them to have a workspace id
+      local u = pg_insert(cn, "upstreams", { id = uuid(), name = 'old-migrating-upstream', slots = 1 })
+      local t = pg_insert(cn, "targets",   { id = uuid(), upstream_id = u.id, target = 'old-migrating-target', weight = 1 })
+      local c = pg_insert(cn, "consumers", { id = uuid(), username = "old-migrating-consumer" })
+      local cc = pg_insert(cn, "certificates", { id = uuid(), cert = "old-migrating-cert", key = "key" })
+      local sni = pg_insert(cn, "snis", { id = uuid(), certificate_id = cc.id, name = "old-migrating-sni" })
+      local s = pg_insert(cn, "services", { id = uuid(), name = "old-migrating-service" })
+      local r = pg_insert(cn, "routes", { id = uuid(), service_id = s.id })
+      local p = pg_insert(cn, "plugins", { id = uuid(), name="key-auth", service_id = s.id, config="{}", enabled = true })
+      assert.equals(default_ws_id, u.ws_id)
+      assert.equals(default_ws_id, t.ws_id)
+      assert.equals(default_ws_id, c.ws_id)
+      assert.equals(default_ws_id, cc.ws_id)
+      assert.equals(default_ws_id, sni.ws_id)
+      assert.equals(default_ws_id, s.ws_id)
+      assert.equals(default_ws_id, r.ws_id)
+      assert.equals(default_ws_id, p.ws_id)
+
+      -- create those entities specifying ws_id. Simulates a new kong node inserting entities
+      -- expect them to have ws_id as well
+      local u = pg_insert(cn, "upstreams", { id = uuid(), name = 'new-migrating-upstream', slots = 1, ws_id = default_ws_id })
+      local t = pg_insert(cn, "targets",   { id = uuid(), upstream_id = u.id, target = 'new-migrating-target', weight = 1, ws_id = default_ws_id })
+      local c = pg_insert(cn, "consumers", { id = uuid(), username = "new-migrating-consumer", ws_id = default_ws_id})
+      local cc = pg_insert(cn, "certificates", { id = uuid(), cert = "new-migrating-cert", key = "key", ws_id = default_ws_id })
+      local sni = pg_insert(cn, "snis", { id = uuid(), certificate_id = cc.id, name = "new-migrating-sni", ws_id = default_ws_id })
+      local s = pg_insert(cn, "services", { id = uuid(), name = "new-migrating-service", ws_id = default_ws_id })
+      local r = pg_insert(cn, "routes", { id = uuid(), service_id = s.id, ws_id = default_ws_id })
+      local p = pg_insert(cn, "plugins", { id = uuid(), name="key-auth", service_id = s.id, config="{}", enabled = true, ws_id = default_ws_id })
+      assert.equals(default_ws_id, u.ws_id)
+      assert.equals(default_ws_id, t.ws_id)
+      assert.equals(default_ws_id, c.ws_id)
+      assert.equals(default_ws_id, cc.ws_id)
+      assert.equals(default_ws_id, sni.ws_id)
+      assert.equals(default_ws_id, s.ws_id)
+      assert.equals(default_ws_id, r.ws_id)
+      assert.equals(default_ws_id, p.ws_id)
+
+      -- kong migrations finish
+      assert(helpers.run_teardown_migration(db, "core", "kong.db.migrations.core", "009_200_to_210"))
+
+      -- AFTER
+
+      -- create entities without specifying default ws_id.
+      -- at this point this should never happen any more (only "new nodes" create entities from now on, and they always should specify ws_id)
+      -- but this is a convenient way to test that the default has changed to ngx.null
+      local u = pg_insert(cn, "upstreams", { id = uuid(), name = 'old-after-upstream', slots = 1 })
+      local t = pg_insert(cn, "targets",   { id = uuid(), upstream_id = u.id, target = 'old-after-target', weight = 1 })
+      local c = pg_insert(cn, "consumers", { id = uuid(), username = "old-after-consumer" })
+      local cc = pg_insert(cn, "certificates", { id = uuid(), cert = "old-after-cert", key = "key" })
+      local sni = pg_insert(cn, "snis", { id = uuid(), certificate_id = cc.id, name = "old-after-sni" })
+      local s = pg_insert(cn, "services", { id = uuid(), name = "old-after-service" })
+      local r = pg_insert(cn, "routes", { id = uuid(), service_id = s.id })
+      local p = pg_insert(cn, "plugins", { id = uuid(), name="key-auth", service_id = s.id, config="{}", enabled = true })
+      assert.equals(ngx.null, u.ws_id)
+      assert.equals(ngx.null, t.ws_id)
+      assert.equals(ngx.null, c.ws_id)
+      assert.equals(ngx.null, cc.ws_id)
+      assert.equals(ngx.null, sni.ws_id)
+      assert.equals(ngx.null, s.ws_id)
+      assert.equals(ngx.null, r.ws_id)
+      assert.equals(ngx.null, p.ws_id)
+
+      -- create those entities specifying ws_id, simulating a new kong node inserting entities
+      -- expect them to have ws_id as well
+      local u = pg_insert(cn, "upstreams", { id = uuid(), name = 'new-after-upstream', slots = 1, ws_id = default_ws_id })
+      local t = pg_insert(cn, "targets",   { id = uuid(), upstream_id = u.id, target = 'new-after-target', weight = 1, ws_id = default_ws_id })
+      local c = pg_insert(cn, "consumers", { id = uuid(), username = "new-after-consumer", ws_id = default_ws_id})
+      local cc = pg_insert(cn, "certificates", { id = uuid(), cert = "new-after-cert", key = "key", ws_id = default_ws_id })
+      local sni = pg_insert(cn, "snis", { id = uuid(), certificate_id = cc.id, name = "new-after-sni", ws_id = default_ws_id })
+      local s = pg_insert(cn, "services", { id = uuid(), name = "new-after-service", ws_id = default_ws_id })
+      local r = pg_insert(cn, "routes", { id = uuid(), service_id = s.id, ws_id = default_ws_id })
+      local p = pg_insert(cn, "plugins", { id = uuid(), name="key-auth", service_id = s.id, config="{}", enabled = true, ws_id = default_ws_id })
+      assert.equals(default_ws_id, u.ws_id)
+      assert.equals(default_ws_id, t.ws_id)
+      assert.equals(default_ws_id, c.ws_id)
+      assert.equals(default_ws_id, cc.ws_id)
+      assert.equals(default_ws_id, sni.ws_id)
+      assert.equals(default_ws_id, s.ws_id)
+      assert.equals(default_ws_id, r.ws_id)
+      assert.equals(default_ws_id, p.ws_id)
+    end)
+
+    it("correctly migrates plugins composite keys", function()
+      -- Assumption on this test: old nodes plugin cache keys will always end in ":"
+      -- This has been checked by visually inspecting the call to cache_key, which uses 4 params at most:
+      --   https://github.com/Kong/kong/blob/2.0.2/kong/runloop/plugins_iterator.lua#L92-L95
+      -- And the implementation of cache_key which concatenates 5 parameters:
+      --   https://github.com/Kong/kong/blob/2.0.2/kong/db/dao/init.lua#L1175
+      local cn = db.connector
+      local s = pg_insert(cn, "services", { id = uuid(), name = "before-srv" })
+      local p1 = pg_insert(cn, "plugins", { id = uuid(), name="key-auth", service_id = s.id, config="{}", enabled = true, cache_key="before-cache-key:"})
+      assert.same("before-cache-key:", p1.cache_key)
+
+      -- kong migrations up
+      assert(helpers.run_up_migration(db, "core", "kong.db.migrations.core", "009_200_to_210"))
+
+      -- MIGRATING
+      -- get default ws_id (tested further above)
+      local res = assert(cn:query("SELECT * FROM workspaces"))
+      local default_ws_id = assert(res[1].id)
+
+      -- simulate an old node creating a service and plugin
+      local s = pg_insert(cn, "services", { id = uuid(), name = "old-migrating-srv" })
+      local p2 = pg_insert(cn, "plugins", { id = uuid(), name="key-auth", service_id = s.id, config="{}", enabled = true, cache_key="old-migrating-cache-key:"})
+      assert.same("old-migrating-cache-key:", p2.cache_key)
+
+      -- simulate a new node creating a service and plugin.
+      -- The plugin cache key is expected to already include ws_id
+      -- and it is expected to not end in ":"
+      local s = pg_insert(cn, "services", { id = uuid(), name = "new-migrating-srv" })
+      local p3 = pg_insert(cn, "plugins", { id = uuid(), name="key-auth", service_id = s.id, config="{}", enabled = true, cache_key="new-migrating-cache-key:" .. default_ws_id})
+      assert.same("new-migrating-cache-key:" .. default_ws_id, p3.cache_key)
+
+      -- kong migrations teardown
+      assert(helpers.run_teardown_migration(db, "core", "kong.db.migrations.core", "009_200_to_210"))
+
+      -- AFTER
+
+      -- the before plugin cache has been updated with ws_id
+      local res = assert(cn:query(fmt("SELECT * FROM plugins WHERE cache_key = 'before-cache-key::%s';", default_ws_id)))
+
+      assert.same(p1.id, res[1].id)
+
+      -- the old-migrating cache has been updated with ws_id
+      local res = assert(cn:query(fmt("SELECT * FROM plugins WHERE cache_key = 'old-migrating-cache-key::%s';", default_ws_id)))
+      assert.same(p2.id, res[1].id)
+
+      -- the new-migrating cache remains the same (ws_id was not added twice)
+      local res = assert(cn:query(fmt("SELECT * FROM plugins WHERE cache_key = 'new-migrating-cache-key:%s';", default_ws_id)))
+      assert.same(p3.id, res[1].id)
+    end)
+  end)
+
+  describe("#cassandra", function()
+    before_each(function()
+      _, db = helpers.get_db_utils("cassandra", nil, nil, {
+        stop_namespace = "kong.db.migrations.core",
+        stop_migration = "009_200_to_210",
+      })
+    end)
+
+    it("adds/removes columns and constraints", function()
+      local cn = db.connector
+      -- BEFORE
+      assert_not_c_has_column(cn, "ca_certificates", "cert_digest", "text")
+      assert_not_c_has_column(cn, "services", "tls_verify", "boolean")
+      assert_not_c_has_column(cn, "services", "tls_verify_depth", "smallint")
+      assert_not_c_has_column(cn, "services", "ca_certificates", "set<uuid>")
+      assert_not_c_has_fkey(cn, "upstreams", "client_certificate_id")
+
+      -- kong migrations up
+      assert(helpers.run_up_migration(db, "core", "kong.db.migrations.core", "009_200_to_210"))
+
+      -- MIGRATING/AFTER
+      assert_c_has_column(cn, "ca_certificates", "cert_digest", "text")
+      assert_c_has_column(cn, "services", "tls_verify", "boolean")
+      assert_c_has_column(cn, "services", "ca_certificates", "set<uuid>")
+      assert_c_has_fkey(cn, "upstreams", "client_certificate_id")
+    end)
+
+    it("initializes ca_certificates.cert_digest", function()
+      local cn = db.connector
+
+      c_insert(cn, "ca_certificates", { id = uuid(), cert = fixtures_cert, partition = "ca_certificates" })
+
+      -- kong migrations up
+      assert(helpers.run_up_migration(db, "core", "kong.db.migrations.core", "009_200_to_210"))
+
+      -- MIGRATING
+
+      -- expect ca_certificates.cert_digest to be empty
+      local cc = assert(cn:query("SELECT * FROM ca_certificates;"))[1]
+      assert.is_nil(cc.cert_digest)
+
+      -- kong migrations finish
+      assert(helpers.run_teardown_migration(db, "core", "kong.db.migrations.core", "009_200_to_210"))
+
+      -- AFTER
+      local cc = assert(cn:query("SELECT * FROM ca_certificates;"))[1]
+      assert.equals(expected_digest, cc.cert_digest)
+    end)
+
+    it("adds workspaces table, index and ws_id", function()
+      local cn = db.connector
+      assert_not_c_has_table(cn, "workspaces")
+      assert_not_c_has_index(cn, "workspaces", "workspaces_name_idx")
+      assert_not_c_has_fkey(cn, "upstreams", "ws_id")
+      assert_not_c_has_fkey(cn, "targets", "ws_id")
+      assert_not_c_has_fkey(cn, "consumers", "ws_id")
+      assert_not_c_has_fkey(cn, "certificates", "ws_id")
+      assert_not_c_has_fkey(cn, "snis", "ws_id")
+      assert_not_c_has_fkey(cn, "services", "ws_id")
+      assert_not_c_has_fkey(cn, "routes", "ws_id")
+      assert_not_c_has_fkey(cn, "plugins", "ws_id")
+
+      -- kong migrations up
+      assert(helpers.run_up_migration(db, "core", "kong.db.migrations.core", "009_200_to_210"))
+
+      -- MIGRATING
+      assert_c_has_table(cn, "workspaces")
+      assert_c_has_index(cn, "workspaces", "workspaces_name_idx")
+      assert_c_has_fkey(cn, "upstreams", "ws_id")
+      assert_c_has_fkey(cn, "targets", "ws_id")
+      assert_c_has_fkey(cn, "consumers", "ws_id")
+      assert_c_has_fkey(cn, "certificates", "ws_id")
+      assert_c_has_fkey(cn, "snis", "ws_id")
+      assert_c_has_fkey(cn, "services", "ws_id")
+      assert_c_has_fkey(cn, "routes", "ws_id")
+      assert_c_has_fkey(cn, "plugins", "ws_id")
+    end)
+
+    it("correctly handles ws_id", function()
+      local cn = db.connector
+      -- BEFORE
+      -- old node, there isn't even a ws_id column here
+      local u = c_insert(cn, "upstreams", { id = uuid(), name = 'before-upstream', slots = 1 })
+      c_insert(cn, "targets", { id = uuid(), upstream_id = u.id, target = 'before-target', weight = 1 })
+      c_insert(cn, "consumers", { id = uuid(), username = "before-consumer", custom_id = "before-consumer" })
+      local cc = c_insert(cn, "certificates", {
+        partition = "certificates", id = uuid(), cert = "before-cert", key = "key"
+      })
+      c_insert(cn, "snis", {
+        partition = "snis", id = uuid(), certificate_id = cc.id, name = "before-sni" })
+      local s = c_insert(cn, "services", {
+        partition = "services", id = uuid(), name = "before-service"
+      })
+      c_insert(cn, "routes", {
+        partition = "routes", id = uuid(), service_id = s.id, name = "before-route",
+      })
+      c_insert(cn, "plugins", {
+        id = uuid(), name="key-auth", service_id = s.id, config="{}", enabled = true,
+        cache_key="before-p",
+      })
+
+      -- kong migrations up
+      assert(helpers.run_up_migration(db, "core", "kong.db.migrations.core", "009_200_to_210"))
+
+      -- MIGRATING
+      -- check default workspace exists and get its id
+      local res = assert(cn:query("SELECT * FROM workspaces"))
+      assert.equals(1, #res)
+      assert.equals("default", res[1].name)
+      assert.truthy(utils.is_valid_uuid(res[1].id))
+      local default_ws_id = res[1].id
+
+      -- in Cassandra, entities created by the old node don't have ws_id at this point
+      -- Old nodes can keep working with the data as before
+      -- New nodes have workarounds for dealing with old-style entities at the DAO level
+      local bu = assert(cn:query("SELECT * FROM upstreams"))[1]
+      local bt = assert(cn:query("SELECT * FROM targets"))[1]
+      local bc = assert(cn:query("SELECT * FROM consumers"))[1]
+      local bcc = assert(cn:query("SELECT * FROM certificates"))[1]
+      local bsni = assert(cn:query("SELECT * FROM snis"))[1]
+      local bs = assert(cn:query("SELECT * FROM services"))[1]
+      local br = assert(cn:query("SELECT * FROM routes"))[1]
+      local bp = assert(cn:query("SELECT * FROM plugins"))[1]
+      assert.is_nil(bu.ws_id)
+      assert.is_nil(bt.ws_id)
+      assert.is_nil(bc.ws_id)
+      assert.is_nil(bcc.ws_id)
+      assert.is_nil(bsni.ws_id)
+      assert.is_nil(bs.ws_id)
+      assert.is_nil(br.ws_id)
+      assert.is_nil(bp.ws_id)
+
+      -- In Cassandra, old kong nodes inserting entities don't fill up the ws_id
+      local omu = c_insert(cn, "upstreams", { id = uuid(), name = 'old-migrating-upstream', slots = 1 })
+      local omt = c_insert(cn, "targets", { id = uuid(), upstream_id = omu.id, target = 'old-migrating-target', weight = 1 })
+      local omc = c_insert(cn, "consumers", { id = uuid(), username = "old-migrating-consumer", custom_id = "old-migrating-consumer" })
+      local omcc = c_insert(cn, "certificates", {
+        partition = "certificates", id = uuid(), cert = "old-migrating-cert", key = "key"
+      })
+      local omsni = c_insert(cn, "snis", {
+        partition = "snis", id = uuid(), certificate_id = omcc.id, name = "old-migrating-sni" })
+      local oms = c_insert(cn, "services", {
+        partition = "services", id = uuid(), name = "old-migrating-service"
+      })
+      local omr = c_insert(cn, "routes", {
+        partition = "routes", id = uuid(), service_id = oms.id, name = "old-migrating-route",
+      })
+      local omp = c_insert(cn, "plugins", {
+        id = uuid(), name="key-auth", service_id = oms.id, config="{}", enabled = true,
+        cache_key = "omp:",
+      })
+      assert.is_nil(omu.ws_id)
+      assert.is_nil(omt.ws_id)
+      assert.is_nil(omc.ws_id)
+      assert.is_nil(omcc.ws_id)
+      assert.is_nil(omsni.ws_id)
+      assert.is_nil(oms.ws_id)
+      assert.is_nil(omr.ws_id)
+      assert.is_nil(omp.ws_id)
+
+      -- create those entities specifying ws_id. Simulates a new kong node inserting entities
+      -- expect them to have ws_id as well
+      local nmu = c_insert(cn, "upstreams", { id = uuid(), name = 'new-migrating-upstream', slots = 1, ws_id = default_ws_id })
+      local nmt = c_insert(cn, "targets", { id = uuid(), upstream_id = nmu.id, target = 'new-migrating-target', weight = 1, ws_id = default_ws_id })
+      local nmc = c_insert(cn, "consumers", { id = uuid(), username = "new-migrating-consumer", custom_id = "new-migrating-consumer", ws_id = default_ws_id })
+      local nmcc = c_insert(cn, "certificates", {
+        partition = "certificates", id = uuid(), cert = "new-migrating-cert", key = "key", ws_id = default_ws_id
+      })
+      local nmsni = c_insert(cn, "snis", {
+        partition = "snis", id = uuid(), certificate_id = nmcc.id, name = "new-migrating-sni", ws_id = default_ws_id })
+      local nms = c_insert(cn, "services", {
+        partition = "services", id = uuid(), name = "new-migrating-service", ws_id = default_ws_id
+      })
+      local nmr = c_insert(cn, "routes", {
+        partition = "routes", id = uuid(), service_id = nms.id, ws_id = default_ws_id, name = "new-migrating-route",
+      })
+      -- notice that the cache_key used by the new nodes contains the ws_id
+      local nmp = c_insert(cn, "plugins", {
+        id = uuid(), name="key-auth", service_id = nms.id, config="{}", enabled = true, ws_id = default_ws_id,
+        cache_key = "nmp:" .. default_ws_id,
+      })
+      assert.equals(default_ws_id, nmu.ws_id)
+      assert.equals(default_ws_id, nmt.ws_id)
+      assert.equals(default_ws_id, nmc.ws_id)
+      assert.equals(default_ws_id, nmcc.ws_id)
+      assert.equals(default_ws_id, nmsni.ws_id)
+      assert.equals(default_ws_id, nms.ws_id)
+      assert.equals(default_ws_id, nmr.ws_id)
+      assert.equals(default_ws_id, nmp.ws_id)
+
+      -- kong migrations finish
+      assert(helpers.run_teardown_migration(db, "core", "kong.db.migrations.core", "009_200_to_210"))
+
+      -- AFTER
+      -- check that all entities with unike keys have been modified with the ws_id
+      bu = assert(cn:query(fmt("SELECT * from upstreams where id=%s", bu.id)))[1]
+      assert.same(default_ws_id, bu.ws_id)
+      assert.same(default_ws_id .. ":before-upstream", bu.name)
+
+      bt = assert(cn:query(fmt("SELECT * from targets where id=%s", bt.id)))[1]
+      assert.same(default_ws_id, bt.ws_id)
+
+      bc = assert(cn:query(fmt("SELECT * from consumers where id=%s", bc.id)))[1]
+      assert.same(default_ws_id, bc.ws_id)
+      assert.same(default_ws_id .. ":before-consumer", bc.username)
+      assert.same(default_ws_id .. ":before-consumer", bc.custom_id)
+
+      bcc = assert(cn:query(fmt("SELECT * from certificates where partition='certificates' and id=%s", bcc.id)))[1]
+      assert.same(default_ws_id, bcc.ws_id)
+
+      bsni = assert(cn:query(fmt("SELECT * from snis where partition='snis' and id=%s", bsni.id)))[1]
+      assert.same(default_ws_id, bsni.ws_id)
+
+      bs = assert(cn:query(fmt("SELECT * from services where partition='services' and id=%s", bs.id)))[1]
+      assert.same(default_ws_id, bs.ws_id)
+      assert.same(default_ws_id .. ":before-service", bs.name)
+
+      br = assert(cn:query(fmt("SELECT * from routes where partition='routes' and id=%s", br.id)))[1]
+      assert.same(default_ws_id, br.ws_id)
+      assert.same(default_ws_id .. ":before-route", br.name)
+
+      bp = assert(cn:query(fmt("SELECT * from plugins where id=%s", bp.id)))[1]
+      assert.same(default_ws_id, bp.ws_id)
+
+      omu = assert(cn:query(fmt("SELECT * from upstreams where id=%s", omu.id)))[1]
+      assert.same(default_ws_id, omu.ws_id)
+      assert.same(default_ws_id .. ":old-migrating-upstream", omu.name)
+
+      omt = assert(cn:query(fmt("SELECT * from targets where id=%s", omt.id)))[1]
+      assert.same(default_ws_id, omt.ws_id)
+
+      omc = assert(cn:query(fmt("SELECT * from consumers where id=%s", omc.id)))[1]
+      assert.same(default_ws_id, omc.ws_id)
+      assert.same(default_ws_id .. ":old-migrating-consumer", omc.username)
+      assert.same(default_ws_id .. ":old-migrating-consumer", omc.custom_id)
+
+      omcc = assert(cn:query(fmt("SELECT * from certificates where partition='certificates' and id=%s", omcc.id)))[1]
+      assert.same(default_ws_id, omcc.ws_id)
+
+      omsni = assert(cn:query(fmt("SELECT * from snis where partition='snis' and id=%s", omsni.id)))[1]
+      assert.same(default_ws_id, omsni.ws_id)
+
+      oms = assert(cn:query(fmt("SELECT * from services where partition='services' and id=%s", oms.id)))[1]
+      assert.same(default_ws_id, oms.ws_id)
+      assert.same(default_ws_id .. ":old-migrating-service", oms.name)
+
+      omr = assert(cn:query(fmt("SELECT * from routes where partition='routes' and id=%s", omr.id)))[1]
+      assert.same(default_ws_id, omr.ws_id)
+      assert.same(default_ws_id .. ":old-migrating-route", omr.name)
+
+      omp = assert(cn:query(fmt("SELECT * from plugins where id=%s", omp.id)))[1]
+      assert.same(default_ws_id, omp.ws_id)
+
+      nmu = assert(cn:query(fmt("SELECT * from upstreams where id=%s", nmu.id)))[1]
+      assert.same(default_ws_id, nmu.ws_id)
+      assert.same(default_ws_id .. ":new-migrating-upstream", nmu.name)
+
+      nmt = assert(cn:query(fmt("SELECT * from targets where id=%s", nmt.id)))[1]
+      assert.same(default_ws_id, nmt.ws_id)
+
+      nmc = assert(cn:query(fmt("SELECT * from consumers where id=%s", nmc.id)))[1]
+      assert.same(default_ws_id, nmc.ws_id)
+      assert.same(default_ws_id .. ":new-migrating-consumer", nmc.username)
+      assert.same(default_ws_id .. ":new-migrating-consumer", nmc.custom_id)
+
+      nmcc = assert(cn:query(fmt("SELECT * from certificates where partition='certificates' and id=%s", nmcc.id)))[1]
+      assert.same(default_ws_id, nmcc.ws_id)
+
+      nmsni = assert(cn:query(fmt("SELECT * from snis where partition='snis' and id=%s", nmsni.id)))[1]
+      assert.same(default_ws_id, nmsni.ws_id)
+
+      nms = assert(cn:query(fmt("SELECT * from services where partition='services' and id=%s", nms.id)))[1]
+      assert.same(default_ws_id, nms.ws_id)
+      assert.same(default_ws_id .. ":new-migrating-service", nms.name)
+
+      nmr = assert(cn:query(fmt("SELECT * from routes where partition='routes' and id=%s", nmr.id)))[1]
+      assert.same(default_ws_id, nmr.ws_id)
+      assert.same(default_ws_id .. ":new-migrating-route", nmr.name)
+
+      nmp = assert(cn:query(fmt("SELECT * from plugins where id=%s", nmp.id)))[1]
+      assert.same(default_ws_id, nmp.ws_id)
+
+    end)
+
+    it("migrates plugins composite keys", function()
+      -- Assumption on this test: old nodes plugin cache keys will always end in ":"
+      -- This has been checked by visually inspecting the call to cache_key, which uses 4 params at most:
+      --   https://github.com/Kong/kong/blob/2.0.2/kong/runloop/plugins_iterator.lua#L92-L95
+      -- And the implementation of cache_key which concatenates 5 parameters:
+      --   https://github.com/Kong/kong/blob/2.0.2/kong/db/dao/init.lua#L1175
+      local cn = db.connector
+      local s = c_insert(cn, "services", { partition="services", id = uuid(), name = "before-srv" })
+      local p1 = c_insert(cn, "plugins", { id = uuid(), name="key-auth", service_id = s.id, config="{}", enabled = true, cache_key="before-cache-key:"})
+      assert.same("before-cache-key:", p1.cache_key)
+
+      -- kong migrations up
+      assert(helpers.run_up_migration(db, "core", "kong.db.migrations.core", "009_200_to_210"))
+
+      -- MIGRATING
+      -- get default ws_id (tested further above)
+      local res = assert(cn:query("SELECT * FROM workspaces"))
+      local default_ws_id = assert(res[1].id)
+
+      -- simulate an old node creating a service and plugin
+      local s = c_insert(cn, "services", { partition = "services", id = uuid(), name = "old-migrating-srv" })
+      local p2 = c_insert(cn, "plugins", { id = uuid(), name="key-auth", service_id = s.id, config="{}", enabled = true, cache_key="old-migrating-cache-key:"})
+      assert.same("old-migrating-cache-key:", p2.cache_key)
+
+      -- simulate a new node creating a service and plugin.
+      -- The plugin cache key is expected to already include ws_id
+      -- and it is expected to not end in ":"
+      local s = c_insert(cn, "services", { partition = "services", id = uuid(), name = "new-migrating-srv" })
+      local p3 = c_insert(cn, "plugins", { id = uuid(), name="key-auth", service_id = s.id, config="{}", enabled = true, cache_key="new-migrating-cache-key:" .. default_ws_id})
+      assert.same("new-migrating-cache-key:" .. default_ws_id, p3.cache_key)
+
+      -- kong migrations teardown
+      assert(helpers.run_teardown_migration(db, "core", "kong.db.migrations.core", "009_200_to_210"))
+
+      -- AFTER
+
+      -- the before plugin cache has been updated with ws_id
+      local res = assert(cn:query(fmt("SELECT * FROM plugins WHERE cache_key = 'before-cache-key::%s';", default_ws_id)))
+      assert.same(p1.id, res[1].id)
+
+      -- the old-migrating cache has been updated with ws_id
+      local res = assert(cn:query(fmt("SELECT * FROM plugins WHERE cache_key = 'old-migrating-cache-key::%s';", default_ws_id)))
+      assert.same(p2.id, res[1].id)
+
+      -- the new-migrating cache remains the same (ws_id was not added twice)
+      local res = assert(cn:query(fmt("SELECT * FROM plugins WHERE cache_key = 'new-migrating-cache-key:%s';", default_ws_id)))
+      assert.same(p3.id, res[1].id)
+    end)
+  end)
+end)

--- a/spec/02-integration/03-db/13-migrations/009_200_to_210_spec.lua
+++ b/spec/02-integration/03-db/13-migrations/009_200_to_210_spec.lua
@@ -3,259 +3,15 @@ local str           = require "resty.string"
 local fixtures_ssl  = require "spec.fixtures.ssl"
 
 local helpers = require "spec.helpers"
+local h = require "spec.migration_helpers.200_to_210"
 local fmt = string.format
 local utils = require "kong.tools.utils"
-local cassandra = require "cassandra"
 
 
 local fixtures_cert = fixtures_ssl.cert
 local expected_digest = str.to_hex(openssl_x509.new(fixtures_cert):digest("sha256"))
 
 local uuid = utils.uuid
-
-local PG_HAS_COLUMN_SQL = [[
-  SELECT *
-  FROM information_schema.columns
-  WHERE table_schema = 'public'
-  AND table_name     = '%s'
-  AND column_name    = '%s';
-]]
-
-local PG_HAS_CONSTRAINT_SQL = [[
-  SELECT *
-  FROM pg_catalog.pg_constraint
-  WHERE conname = '%s';
-]]
-
-local PG_HAS_INDEX_SQL = [[
-  SELECT *
-  FROM pg_indexes
-  WHERE indexname = '%s';
-]]
-
-local PG_HAS_TABLE_SQL = [[
-  SELECT *
-  FROM pg_catalog.pg_tables
-  WHERE schemaname = 'public'
-  AND tablename = '%s';
-]]
-
-local function assert_pg_has_column(cn, table_name, column_name, data_type)
-  local res = assert(cn:query(fmt(PG_HAS_COLUMN_SQL, table_name, column_name)))
-
-  assert.equals(1, #res)
-  assert.equals(column_name, res[1].column_name)
-  assert.equals(string.lower(data_type), string.lower(res[1].data_type))
-end
-
-
-local function assert_not_pg_has_column(cn, table_name, column_name, data_type)
-  local res = assert(cn:query(fmt(PG_HAS_COLUMN_SQL, table_name, column_name)))
-  assert.same({}, res)
-end
-
-
-local function assert_pg_has_constraint(cn, constraint_name)
-  local res = assert(cn:query(fmt(PG_HAS_CONSTRAINT_SQL, constraint_name)))
-
-  assert.equals(1, #res)
-  assert.equals(constraint_name, res[1].conname)
-end
-
-
-local function assert_not_pg_has_constraint(cn, constraint_name)
-  local res = assert(cn:query(fmt(PG_HAS_CONSTRAINT_SQL, constraint_name)))
-  assert.same({}, res)
-end
-
-
-local function assert_pg_has_index(cn, index_name)
-  local res = assert(cn:query(fmt(PG_HAS_INDEX_SQL, index_name)))
-
-  assert.equals(1, #res)
-  assert.equals(index_name, res[1].indexname)
-end
-
-
-local function assert_not_pg_has_index(cn, index_name)
-  local res = assert(cn:query(fmt(PG_HAS_INDEX_SQL, index_name)))
-  assert.same({}, res)
-end
-
-
-local function assert_pg_has_fkey(cn, table_name, column_name)
-  assert_pg_has_column(cn, table_name, column_name, "uuid")
-  assert_pg_has_constraint(cn, table_name .. "_" .. column_name .. "_fkey")
-end
-
-
-local function assert_not_pg_has_fkey(cn, table_name, column_name)
-  assert_not_pg_has_column(cn, table_name, column_name, "uuid")
-  assert_not_pg_has_constraint(cn, table_name .. "_" .. column_name .. "_fkey")
-end
-
-
-local function assert_pg_has_table(cn, table_name)
-  local res = assert(cn:query(fmt(PG_HAS_TABLE_SQL, table_name)))
-
-  assert.equals(1, #res)
-  assert.equals(table_name, res[1].tablename)
-end
-
-
-local function assert_not_pg_has_table(cn, table_name)
-  local res = assert(cn:query(fmt(PG_HAS_TABLE_SQL, table_name)))
-  assert.same({}, res)
-end
-
-
-local function pg_insert(cn, table_name, tbl)
-  local columns, values = {},{}
-  for k,_ in pairs(tbl) do
-    columns[#columns + 1] = k
-  end
-  table.sort(columns)
-  for i, c in ipairs(columns) do
-    local v = tbl[c]
-    v = type(v) == "string" and "'" .. v .. "'" or v
-    values[i] = tostring(v)
-  end
-  local sql = fmt([[
-    INSERT INTO %s (%s) VALUES (%s)
-  ]],
-    table_name,
-    table.concat(columns, ","),
-    table.concat(values, ",")
-  )
-
-  local res = assert(cn:query(sql))
-
-  assert.same({ affected_rows = 1 }, res)
-
-  return assert(cn:query(fmt("SELECT * FROM %s WHERE id='%s'", table_name, tbl.id)))[1]
-end
-
----------------------
-
-local C_TABLE_HAS_COLUMN_CQL = [[
-  SELECT * FROM system_schema.columns
-  WHERE keyspace_name = '%s'
-  AND table_name = '%s'
-  AND column_name = '%s'
-  ALLOW FILTERING;
-]]
-
-local C_HAS_INDEX_CQL = [[
-  SELECT * FROM system_schema.indexes
-  WHERE keyspace_name='%s'
-  AND table_name='%s'
-  AND index_name='%s'
-]]
-
-local C_HAS_TABLE_CQL = [[
-  SELECT * FROM system_schema.tables
-  WHERE keyspace_name='%s'
-  AND table_name = '%s';
-]]
-
-
-local function assert_not_c_has_column(cn, table_name, column_name)
-  local res = assert(cn:query(fmt(C_TABLE_HAS_COLUMN_CQL, cn.keyspace, table_name, column_name)))
-  assert.equals(0, #res)
-  assert.same({ has_more_pages = false }, res.meta)
-end
-
-
-local function assert_c_has_column(cn, table_name, column_name, column_type)
-  local res = assert(cn:query(fmt(C_TABLE_HAS_COLUMN_CQL, cn.keyspace, table_name, column_name)))
-  assert.equals(1, #res)
-  assert.equals(column_name, res[1].column_name)
-  assert.equals(column_type, res[1].type)
-  assert.same({ has_more_pages = false }, res.meta)
-  return res[1]
-end
-
-
-local function assert_not_c_has_index(cn, table_name, index_name)
-  local res = assert(cn:query(fmt(C_HAS_INDEX_CQL, cn.keyspace, table_name, index_name)))
-  assert.equals(0, #res)
-  assert.same({ has_more_pages = false }, res.meta)
-end
-
-
-local function assert_c_has_index(cn, table_name, index_name)
-  local cql = fmt(C_HAS_INDEX_CQL, cn.keyspace, table_name, index_name)
-  local res = assert(cn:query(cql))
-  assert.equals(1, #res)
-  assert.equals(index_name, res[1].index_name)
-  assert.same({ has_more_pages = false }, res.meta)
-  return res[1]
-end
-
-
-local function assert_not_c_has_fkey(cn, table_name, column_name)
-  assert_not_c_has_column(cn, table_name, column_name, "uuid")
-  assert_not_c_has_index(cn, table_name, table_name .. "_" .. column_name .. "_idx")
-end
-
-
-local function assert_c_has_fkey(cn, table_name, column_name)
-  local res = assert_c_has_column(cn, table_name, column_name, "uuid")
-  assert_c_has_index(cn, table_name, table_name .. "_" .. column_name .. "_idx")
-  return res
-end
-
-
-local function assert_not_c_has_table(cn, table_name)
-  local res = assert(cn:query(fmt(C_HAS_TABLE_CQL, cn.keyspace, table_name)))
-  assert.equals(0, #res)
-  assert.same({ has_more_pages = false }, res.meta)
-end
-
-
-local function assert_c_has_table(cn, table_name)
-  local res = assert(cn:query(fmt(C_HAS_TABLE_CQL, cn.keyspace, table_name)))
-  assert.equals(1, #res)
-  assert.equals(table_name, res[1].table_name)
-  assert.same({ has_more_pages = false }, res.meta)
-  return res[1]
-end
-
-
-local function c_insert(cn, table_name, tbl)
-  local columns, bindings, values = {},{},{}
-  for k,_ in pairs(tbl) do
-    columns[#columns + 1] = k
-  end
-  table.sort(columns)
-  for i, c in ipairs(columns) do
-    bindings[#bindings + 1] = "?"
-    local v = tbl[c]
-    if c ~= "custom_id" and c:sub(-2) == "id" then
-      v = cassandra.uuid(v)
-    end
-    values[i] = v
-  end
-
-  local cql = fmt([[
-    INSERT INTO %s(%s) VALUES(%s)
-  ]],
-    table_name,
-    table.concat(columns, ", "),
-    table.concat(bindings, ", ")
-  )
-  local res = assert(cn:query(cql, values))
-
-  assert.same({ type = "VOID" }, res)
-
-  if tbl.partition then
-    return assert(cn:query(fmt("SELECT * FROM %s WHERE partition=? AND id=?", table_name),
-                           { tbl.partition, cassandra.uuid(tbl.id) }))[1]
-  end
-
-  return assert(cn:query(fmt("SELECT * FROM %s WHERE id=?", table_name),
-                         { cassandra.uuid(tbl.id) }))[1]
-end
 
 describe("#db migration core/009_200_to_210 spec", function()
   local _, db
@@ -276,30 +32,30 @@ describe("#db migration core/009_200_to_210 spec", function()
 
     it("adds/removes columns and constraints", function()
       local cn = db.connector
-      assert_pg_has_constraint(cn, "ca_certificates_cert_key")
-      assert_not_pg_has_column(cn, "ca_certificates", "cert_digest", "text")
-      assert_not_pg_has_column(cn, "services", "tls_verify", "boolean")
-      assert_not_pg_has_column(cn, "services", "tls_verify_depth", "smallint")
-      assert_not_pg_has_column(cn, "services", "ca_certificates", "array")
-      assert_not_pg_has_fkey(cn, "upstreams", "client_certificate_id")
-      assert_not_pg_has_index(cn, "upstreams_fkey_client_certificate")
+      h.assert_pg_has_constraint(cn, "ca_certificates_cert_key")
+      h.assert_not_pg_has_column(cn, "ca_certificates", "cert_digest", "text")
+      h.assert_not_pg_has_column(cn, "services", "tls_verify", "boolean")
+      h.assert_not_pg_has_column(cn, "services", "tls_verify_depth", "smallint")
+      h.assert_not_pg_has_column(cn, "services", "ca_certificates", "array")
+      h.assert_not_pg_has_fkey(cn, "upstreams", "client_certificate_id")
+      h.assert_not_pg_has_index(cn, "upstreams_fkey_client_certificate")
 
       -- kong migrations up
       assert(helpers.run_up_migration(db, "core", "kong.db.migrations.core", "009_200_to_210"))
 
       -- MIGRATING/AFTER
-      assert_not_pg_has_constraint(cn, "ca_certificates_cert_key")
-      assert_pg_has_column(cn, "ca_certificates", "cert_digest", "text")
-      assert_pg_has_column(cn, "services", "tls_verify", "boolean")
-      assert_pg_has_column(cn, "services", "ca_certificates", "array")
-      assert_pg_has_fkey(cn, "upstreams", "client_certificate_id")
-      assert_pg_has_index(cn, "upstreams_fkey_client_certificate")
+      h.assert_not_pg_has_constraint(cn, "ca_certificates_cert_key")
+      h.assert_pg_has_column(cn, "ca_certificates", "cert_digest", "text")
+      h.assert_pg_has_column(cn, "services", "tls_verify", "boolean")
+      h.assert_pg_has_column(cn, "services", "ca_certificates", "array")
+      h.assert_pg_has_fkey(cn, "upstreams", "client_certificate_id")
+      h.assert_pg_has_index(cn, "upstreams_fkey_client_certificate")
     end)
 
     it("initializes ca_certificates.cert_digest", function()
       local cn = db.connector
 
-      pg_insert(cn, "ca_certificates", { id = uuid(), cert = fixtures_cert })
+      h.pg_insert(cn, "ca_certificates", { id = uuid(), cert = fixtures_cert })
 
       -- kong migrations up
       assert(helpers.run_up_migration(db, "core", "kong.db.migrations.core", "009_200_to_210"))
@@ -320,45 +76,45 @@ describe("#db migration core/009_200_to_210 spec", function()
 
     it("adds workspaces table, index and ws_id", function()
       local cn = db.connector
-      assert_not_pg_has_table(cn, "workspaces")
-      assert_not_pg_has_index(cn, "workspaces_name_idx")
-      assert_not_pg_has_fkey(cn, "upstreams", "ws_id")
-      assert_not_pg_has_fkey(cn, "targets", "ws_id")
-      assert_not_pg_has_fkey(cn, "consumers", "ws_id")
-      assert_not_pg_has_fkey(cn, "certificates", "ws_id")
-      assert_not_pg_has_fkey(cn, "snis", "ws_id")
-      assert_not_pg_has_fkey(cn, "services", "ws_id")
-      assert_not_pg_has_fkey(cn, "routes", "ws_id")
-      assert_not_pg_has_fkey(cn, "plugins", "ws_id")
+      h.assert_not_pg_has_table(cn, "workspaces")
+      h.assert_not_pg_has_index(cn, "workspaces_name_idx")
+      h.assert_not_pg_has_fkey(cn, "upstreams", "ws_id")
+      h.assert_not_pg_has_fkey(cn, "targets", "ws_id")
+      h.assert_not_pg_has_fkey(cn, "consumers", "ws_id")
+      h.assert_not_pg_has_fkey(cn, "certificates", "ws_id")
+      h.assert_not_pg_has_fkey(cn, "snis", "ws_id")
+      h.assert_not_pg_has_fkey(cn, "services", "ws_id")
+      h.assert_not_pg_has_fkey(cn, "routes", "ws_id")
+      h.assert_not_pg_has_fkey(cn, "plugins", "ws_id")
 
       -- kong migrations up
       assert(helpers.run_up_migration(db, "core", "kong.db.migrations.core", "009_200_to_210"))
 
       -- MIGRATING
-      assert_pg_has_table(cn, "workspaces")
-      assert_pg_has_index(cn, "workspaces_name_idx")
-      assert_pg_has_fkey(cn, "upstreams", "ws_id")
-      assert_pg_has_fkey(cn, "targets", "ws_id")
-      assert_pg_has_fkey(cn, "consumers", "ws_id")
-      assert_pg_has_fkey(cn, "certificates", "ws_id")
-      assert_pg_has_fkey(cn, "snis", "ws_id")
-      assert_pg_has_fkey(cn, "services", "ws_id")
-      assert_pg_has_fkey(cn, "routes", "ws_id")
-      assert_pg_has_fkey(cn, "plugins", "ws_id")
+      h.assert_pg_has_table(cn, "workspaces")
+      h.assert_pg_has_index(cn, "workspaces_name_idx")
+      h.assert_pg_has_fkey(cn, "upstreams", "ws_id")
+      h.assert_pg_has_fkey(cn, "targets", "ws_id")
+      h.assert_pg_has_fkey(cn, "consumers", "ws_id")
+      h.assert_pg_has_fkey(cn, "certificates", "ws_id")
+      h.assert_pg_has_fkey(cn, "snis", "ws_id")
+      h.assert_pg_has_fkey(cn, "services", "ws_id")
+      h.assert_pg_has_fkey(cn, "routes", "ws_id")
+      h.assert_pg_has_fkey(cn, "plugins", "ws_id")
     end)
 
     it("correctly handles ws_id", function()
       local cn = db.connector
       -- BEFORE
       -- old node, there isn't even a ws_id column here
-      local u = pg_insert(cn, "upstreams", { id = uuid(), name = 'before-upstream', slots = 1 })
-      pg_insert(cn, "targets",   { id = uuid(), upstream_id = u.id, target = 'before-target', weight = 1 })
-      pg_insert(cn, "consumers", { id = uuid(), username = "before-consumer" })
-      local cc = pg_insert(cn, "certificates", { id = uuid(), cert = "before-cert", key = "key" })
-      pg_insert(cn, "snis", { id = uuid(), certificate_id = cc.id, name = "before-sni" })
-      local s = pg_insert(cn, "services", { id = uuid(), name = "before-service" })
-      pg_insert(cn, "routes", { id = uuid(), service_id = s.id })
-      pg_insert(cn, "plugins", { id = uuid(), name="key-auth", service_id = s.id, config="{}", enabled = true })
+      local u = h.pg_insert(cn, "upstreams", { id = uuid(), name = 'before-upstream', slots = 1 })
+      h.pg_insert(cn, "targets",   { id = uuid(), upstream_id = u.id, target = 'before-target', weight = 1 })
+      h.pg_insert(cn, "consumers", { id = uuid(), username = "before-consumer" })
+      local cc = h.pg_insert(cn, "certificates", { id = uuid(), cert = "before-cert", key = "key" })
+      h.pg_insert(cn, "snis", { id = uuid(), certificate_id = cc.id, name = "before-sni" })
+      local s = h.pg_insert(cn, "services", { id = uuid(), name = "before-service" })
+      h.pg_insert(cn, "routes", { id = uuid(), service_id = s.id })
+      h.pg_insert(cn, "plugins", { id = uuid(), name="key-auth", service_id = s.id, config="{}", enabled = true })
 
       -- kong migrations up
       assert(helpers.run_up_migration(db, "core", "kong.db.migrations.core", "009_200_to_210"))
@@ -392,14 +148,14 @@ describe("#db migration core/009_200_to_210 spec", function()
       -- create entities without specifying default ws_id.
       -- it simulates an "old" kong node inserting entities
       -- expect them to have a workspace id
-      local u = pg_insert(cn, "upstreams", { id = uuid(), name = 'old-migrating-upstream', slots = 1 })
-      local t = pg_insert(cn, "targets",   { id = uuid(), upstream_id = u.id, target = 'old-migrating-target', weight = 1 })
-      local c = pg_insert(cn, "consumers", { id = uuid(), username = "old-migrating-consumer" })
-      local cc = pg_insert(cn, "certificates", { id = uuid(), cert = "old-migrating-cert", key = "key" })
-      local sni = pg_insert(cn, "snis", { id = uuid(), certificate_id = cc.id, name = "old-migrating-sni" })
-      local s = pg_insert(cn, "services", { id = uuid(), name = "old-migrating-service" })
-      local r = pg_insert(cn, "routes", { id = uuid(), service_id = s.id })
-      local p = pg_insert(cn, "plugins", { id = uuid(), name="key-auth", service_id = s.id, config="{}", enabled = true })
+      local u = h.pg_insert(cn, "upstreams", { id = uuid(), name = 'old-migrating-upstream', slots = 1 })
+      local t = h.pg_insert(cn, "targets",   { id = uuid(), upstream_id = u.id, target = 'old-migrating-target', weight = 1 })
+      local c = h.pg_insert(cn, "consumers", { id = uuid(), username = "old-migrating-consumer" })
+      local cc = h.pg_insert(cn, "certificates", { id = uuid(), cert = "old-migrating-cert", key = "key" })
+      local sni = h.pg_insert(cn, "snis", { id = uuid(), certificate_id = cc.id, name = "old-migrating-sni" })
+      local s = h.pg_insert(cn, "services", { id = uuid(), name = "old-migrating-service" })
+      local r = h.pg_insert(cn, "routes", { id = uuid(), service_id = s.id })
+      local p = h.pg_insert(cn, "plugins", { id = uuid(), name="key-auth", service_id = s.id, config="{}", enabled = true })
       assert.equals(default_ws_id, u.ws_id)
       assert.equals(default_ws_id, t.ws_id)
       assert.equals(default_ws_id, c.ws_id)
@@ -411,14 +167,14 @@ describe("#db migration core/009_200_to_210 spec", function()
 
       -- create those entities specifying ws_id. Simulates a new kong node inserting entities
       -- expect them to have ws_id as well
-      local u = pg_insert(cn, "upstreams", { id = uuid(), name = 'new-migrating-upstream', slots = 1, ws_id = default_ws_id })
-      local t = pg_insert(cn, "targets",   { id = uuid(), upstream_id = u.id, target = 'new-migrating-target', weight = 1, ws_id = default_ws_id })
-      local c = pg_insert(cn, "consumers", { id = uuid(), username = "new-migrating-consumer", ws_id = default_ws_id})
-      local cc = pg_insert(cn, "certificates", { id = uuid(), cert = "new-migrating-cert", key = "key", ws_id = default_ws_id })
-      local sni = pg_insert(cn, "snis", { id = uuid(), certificate_id = cc.id, name = "new-migrating-sni", ws_id = default_ws_id })
-      local s = pg_insert(cn, "services", { id = uuid(), name = "new-migrating-service", ws_id = default_ws_id })
-      local r = pg_insert(cn, "routes", { id = uuid(), service_id = s.id, ws_id = default_ws_id })
-      local p = pg_insert(cn, "plugins", { id = uuid(), name="key-auth", service_id = s.id, config="{}", enabled = true, ws_id = default_ws_id })
+      local u = h.pg_insert(cn, "upstreams", { id = uuid(), name = 'new-migrating-upstream', slots = 1, ws_id = default_ws_id })
+      local t = h.pg_insert(cn, "targets",   { id = uuid(), upstream_id = u.id, target = 'new-migrating-target', weight = 1, ws_id = default_ws_id })
+      local c = h.pg_insert(cn, "consumers", { id = uuid(), username = "new-migrating-consumer", ws_id = default_ws_id})
+      local cc = h.pg_insert(cn, "certificates", { id = uuid(), cert = "new-migrating-cert", key = "key", ws_id = default_ws_id })
+      local sni = h.pg_insert(cn, "snis", { id = uuid(), certificate_id = cc.id, name = "new-migrating-sni", ws_id = default_ws_id })
+      local s = h.pg_insert(cn, "services", { id = uuid(), name = "new-migrating-service", ws_id = default_ws_id })
+      local r = h.pg_insert(cn, "routes", { id = uuid(), service_id = s.id, ws_id = default_ws_id })
+      local p = h.pg_insert(cn, "plugins", { id = uuid(), name="key-auth", service_id = s.id, config="{}", enabled = true, ws_id = default_ws_id })
       assert.equals(default_ws_id, u.ws_id)
       assert.equals(default_ws_id, t.ws_id)
       assert.equals(default_ws_id, c.ws_id)
@@ -436,14 +192,14 @@ describe("#db migration core/009_200_to_210 spec", function()
       -- create entities without specifying default ws_id.
       -- at this point this should never happen any more (only "new nodes" create entities from now on, and they always should specify ws_id)
       -- but this is a convenient way to test that the default has changed to ngx.null
-      local u = pg_insert(cn, "upstreams", { id = uuid(), name = 'old-after-upstream', slots = 1 })
-      local t = pg_insert(cn, "targets",   { id = uuid(), upstream_id = u.id, target = 'old-after-target', weight = 1 })
-      local c = pg_insert(cn, "consumers", { id = uuid(), username = "old-after-consumer" })
-      local cc = pg_insert(cn, "certificates", { id = uuid(), cert = "old-after-cert", key = "key" })
-      local sni = pg_insert(cn, "snis", { id = uuid(), certificate_id = cc.id, name = "old-after-sni" })
-      local s = pg_insert(cn, "services", { id = uuid(), name = "old-after-service" })
-      local r = pg_insert(cn, "routes", { id = uuid(), service_id = s.id })
-      local p = pg_insert(cn, "plugins", { id = uuid(), name="key-auth", service_id = s.id, config="{}", enabled = true })
+      local u = h.pg_insert(cn, "upstreams", { id = uuid(), name = 'old-after-upstream', slots = 1 })
+      local t = h.pg_insert(cn, "targets",   { id = uuid(), upstream_id = u.id, target = 'old-after-target', weight = 1 })
+      local c = h.pg_insert(cn, "consumers", { id = uuid(), username = "old-after-consumer" })
+      local cc = h.pg_insert(cn, "certificates", { id = uuid(), cert = "old-after-cert", key = "key" })
+      local sni = h.pg_insert(cn, "snis", { id = uuid(), certificate_id = cc.id, name = "old-after-sni" })
+      local s = h.pg_insert(cn, "services", { id = uuid(), name = "old-after-service" })
+      local r = h.pg_insert(cn, "routes", { id = uuid(), service_id = s.id })
+      local p = h.pg_insert(cn, "plugins", { id = uuid(), name="key-auth", service_id = s.id, config="{}", enabled = true })
       assert.equals(ngx.null, u.ws_id)
       assert.equals(ngx.null, t.ws_id)
       assert.equals(ngx.null, c.ws_id)
@@ -455,14 +211,14 @@ describe("#db migration core/009_200_to_210 spec", function()
 
       -- create those entities specifying ws_id, simulating a new kong node inserting entities
       -- expect them to have ws_id as well
-      local u = pg_insert(cn, "upstreams", { id = uuid(), name = 'new-after-upstream', slots = 1, ws_id = default_ws_id })
-      local t = pg_insert(cn, "targets",   { id = uuid(), upstream_id = u.id, target = 'new-after-target', weight = 1, ws_id = default_ws_id })
-      local c = pg_insert(cn, "consumers", { id = uuid(), username = "new-after-consumer", ws_id = default_ws_id})
-      local cc = pg_insert(cn, "certificates", { id = uuid(), cert = "new-after-cert", key = "key", ws_id = default_ws_id })
-      local sni = pg_insert(cn, "snis", { id = uuid(), certificate_id = cc.id, name = "new-after-sni", ws_id = default_ws_id })
-      local s = pg_insert(cn, "services", { id = uuid(), name = "new-after-service", ws_id = default_ws_id })
-      local r = pg_insert(cn, "routes", { id = uuid(), service_id = s.id, ws_id = default_ws_id })
-      local p = pg_insert(cn, "plugins", { id = uuid(), name="key-auth", service_id = s.id, config="{}", enabled = true, ws_id = default_ws_id })
+      local u = h.pg_insert(cn, "upstreams", { id = uuid(), name = 'new-after-upstream', slots = 1, ws_id = default_ws_id })
+      local t = h.pg_insert(cn, "targets",   { id = uuid(), upstream_id = u.id, target = 'new-after-target', weight = 1, ws_id = default_ws_id })
+      local c = h.pg_insert(cn, "consumers", { id = uuid(), username = "new-after-consumer", ws_id = default_ws_id})
+      local cc = h.pg_insert(cn, "certificates", { id = uuid(), cert = "new-after-cert", key = "key", ws_id = default_ws_id })
+      local sni = h.pg_insert(cn, "snis", { id = uuid(), certificate_id = cc.id, name = "new-after-sni", ws_id = default_ws_id })
+      local s = h.pg_insert(cn, "services", { id = uuid(), name = "new-after-service", ws_id = default_ws_id })
+      local r = h.pg_insert(cn, "routes", { id = uuid(), service_id = s.id, ws_id = default_ws_id })
+      local p = h.pg_insert(cn, "plugins", { id = uuid(), name="key-auth", service_id = s.id, config="{}", enabled = true, ws_id = default_ws_id })
       assert.equals(default_ws_id, u.ws_id)
       assert.equals(default_ws_id, t.ws_id)
       assert.equals(default_ws_id, c.ws_id)
@@ -480,8 +236,8 @@ describe("#db migration core/009_200_to_210 spec", function()
       -- And the implementation of cache_key which concatenates 5 parameters:
       --   https://github.com/Kong/kong/blob/2.0.2/kong/db/dao/init.lua#L1175
       local cn = db.connector
-      local s = pg_insert(cn, "services", { id = uuid(), name = "before-srv" })
-      local p1 = pg_insert(cn, "plugins", { id = uuid(), name="key-auth", service_id = s.id, config="{}", enabled = true, cache_key="before-cache-key:"})
+      local s = h.pg_insert(cn, "services", { id = uuid(), name = "before-srv" })
+      local p1 = h.pg_insert(cn, "plugins", { id = uuid(), name="key-auth", service_id = s.id, config="{}", enabled = true, cache_key="before-cache-key:"})
       assert.same("before-cache-key:", p1.cache_key)
 
       -- kong migrations up
@@ -493,15 +249,15 @@ describe("#db migration core/009_200_to_210 spec", function()
       local default_ws_id = assert(res[1].id)
 
       -- simulate an old node creating a service and plugin
-      local s = pg_insert(cn, "services", { id = uuid(), name = "old-migrating-srv" })
-      local p2 = pg_insert(cn, "plugins", { id = uuid(), name="key-auth", service_id = s.id, config="{}", enabled = true, cache_key="old-migrating-cache-key:"})
+      local s = h.pg_insert(cn, "services", { id = uuid(), name = "old-migrating-srv" })
+      local p2 = h.pg_insert(cn, "plugins", { id = uuid(), name="key-auth", service_id = s.id, config="{}", enabled = true, cache_key="old-migrating-cache-key:"})
       assert.same("old-migrating-cache-key:", p2.cache_key)
 
       -- simulate a new node creating a service and plugin.
       -- The plugin cache key is expected to already include ws_id
       -- and it is expected to not end in ":"
-      local s = pg_insert(cn, "services", { id = uuid(), name = "new-migrating-srv" })
-      local p3 = pg_insert(cn, "plugins", { id = uuid(), name="key-auth", service_id = s.id, config="{}", enabled = true, cache_key="new-migrating-cache-key:" .. default_ws_id})
+      local s = h.pg_insert(cn, "services", { id = uuid(), name = "new-migrating-srv" })
+      local p3 = h.pg_insert(cn, "plugins", { id = uuid(), name="key-auth", service_id = s.id, config="{}", enabled = true, cache_key="new-migrating-cache-key:" .. default_ws_id})
       assert.same("new-migrating-cache-key:" .. default_ws_id, p3.cache_key)
 
       -- kong migrations teardown
@@ -535,26 +291,26 @@ describe("#db migration core/009_200_to_210 spec", function()
     it("adds/removes columns and constraints", function()
       local cn = db.connector
       -- BEFORE
-      assert_not_c_has_column(cn, "ca_certificates", "cert_digest", "text")
-      assert_not_c_has_column(cn, "services", "tls_verify", "boolean")
-      assert_not_c_has_column(cn, "services", "tls_verify_depth", "smallint")
-      assert_not_c_has_column(cn, "services", "ca_certificates", "set<uuid>")
-      assert_not_c_has_fkey(cn, "upstreams", "client_certificate_id")
+      h.assert_not_c_has_column(cn, "ca_certificates", "cert_digest", "text")
+      h.assert_not_c_has_column(cn, "services", "tls_verify", "boolean")
+      h.assert_not_c_has_column(cn, "services", "tls_verify_depth", "smallint")
+      h.assert_not_c_has_column(cn, "services", "ca_certificates", "set<uuid>")
+      h.assert_not_c_has_fkey(cn, "upstreams", "client_certificate_id")
 
       -- kong migrations up
       assert(helpers.run_up_migration(db, "core", "kong.db.migrations.core", "009_200_to_210"))
 
       -- MIGRATING/AFTER
-      assert_c_has_column(cn, "ca_certificates", "cert_digest", "text")
-      assert_c_has_column(cn, "services", "tls_verify", "boolean")
-      assert_c_has_column(cn, "services", "ca_certificates", "set<uuid>")
-      assert_c_has_fkey(cn, "upstreams", "client_certificate_id")
+      h.assert_c_has_column(cn, "ca_certificates", "cert_digest", "text")
+      h.assert_c_has_column(cn, "services", "tls_verify", "boolean")
+      h.assert_c_has_column(cn, "services", "ca_certificates", "set<uuid>")
+      h.assert_c_has_fkey(cn, "upstreams", "client_certificate_id")
     end)
 
     it("initializes ca_certificates.cert_digest", function()
       local cn = db.connector
 
-      c_insert(cn, "ca_certificates", { id = uuid(), cert = fixtures_cert, partition = "ca_certificates" })
+      h.c_insert(cn, "ca_certificates", { id = uuid(), cert = fixtures_cert, partition = "ca_certificates" })
 
       -- kong migrations up
       assert(helpers.run_up_migration(db, "core", "kong.db.migrations.core", "009_200_to_210"))
@@ -575,52 +331,52 @@ describe("#db migration core/009_200_to_210 spec", function()
 
     it("adds workspaces table, index and ws_id", function()
       local cn = db.connector
-      assert_not_c_has_table(cn, "workspaces")
-      assert_not_c_has_index(cn, "workspaces", "workspaces_name_idx")
-      assert_not_c_has_fkey(cn, "upstreams", "ws_id")
-      assert_not_c_has_fkey(cn, "targets", "ws_id")
-      assert_not_c_has_fkey(cn, "consumers", "ws_id")
-      assert_not_c_has_fkey(cn, "certificates", "ws_id")
-      assert_not_c_has_fkey(cn, "snis", "ws_id")
-      assert_not_c_has_fkey(cn, "services", "ws_id")
-      assert_not_c_has_fkey(cn, "routes", "ws_id")
-      assert_not_c_has_fkey(cn, "plugins", "ws_id")
+      h.assert_not_c_has_table(cn, "workspaces")
+      h.assert_not_c_has_index(cn, "workspaces", "workspaces_name_idx")
+      h.assert_not_c_has_fkey(cn, "upstreams", "ws_id")
+      h.assert_not_c_has_fkey(cn, "targets", "ws_id")
+      h.assert_not_c_has_fkey(cn, "consumers", "ws_id")
+      h.assert_not_c_has_fkey(cn, "certificates", "ws_id")
+      h.assert_not_c_has_fkey(cn, "snis", "ws_id")
+      h.assert_not_c_has_fkey(cn, "services", "ws_id")
+      h.assert_not_c_has_fkey(cn, "routes", "ws_id")
+      h.assert_not_c_has_fkey(cn, "plugins", "ws_id")
 
       -- kong migrations up
       assert(helpers.run_up_migration(db, "core", "kong.db.migrations.core", "009_200_to_210"))
 
       -- MIGRATING
-      assert_c_has_table(cn, "workspaces")
-      assert_c_has_index(cn, "workspaces", "workspaces_name_idx")
-      assert_c_has_fkey(cn, "upstreams", "ws_id")
-      assert_c_has_fkey(cn, "targets", "ws_id")
-      assert_c_has_fkey(cn, "consumers", "ws_id")
-      assert_c_has_fkey(cn, "certificates", "ws_id")
-      assert_c_has_fkey(cn, "snis", "ws_id")
-      assert_c_has_fkey(cn, "services", "ws_id")
-      assert_c_has_fkey(cn, "routes", "ws_id")
-      assert_c_has_fkey(cn, "plugins", "ws_id")
+      h.assert_c_has_table(cn, "workspaces")
+      h.assert_c_has_index(cn, "workspaces", "workspaces_name_idx")
+      h.assert_c_has_fkey(cn, "upstreams", "ws_id")
+      h.assert_c_has_fkey(cn, "targets", "ws_id")
+      h.assert_c_has_fkey(cn, "consumers", "ws_id")
+      h.assert_c_has_fkey(cn, "certificates", "ws_id")
+      h.assert_c_has_fkey(cn, "snis", "ws_id")
+      h.assert_c_has_fkey(cn, "services", "ws_id")
+      h.assert_c_has_fkey(cn, "routes", "ws_id")
+      h.assert_c_has_fkey(cn, "plugins", "ws_id")
     end)
 
     it("correctly handles ws_id", function()
       local cn = db.connector
       -- BEFORE
       -- old node, there isn't even a ws_id column here
-      local u = c_insert(cn, "upstreams", { id = uuid(), name = 'before-upstream', slots = 1 })
-      c_insert(cn, "targets", { id = uuid(), upstream_id = u.id, target = 'before-target', weight = 1 })
-      c_insert(cn, "consumers", { id = uuid(), username = "before-consumer", custom_id = "before-consumer" })
-      local cc = c_insert(cn, "certificates", {
+      local u = h.c_insert(cn, "upstreams", { id = uuid(), name = 'before-upstream', slots = 1 })
+      h.c_insert(cn, "targets", { id = uuid(), upstream_id = u.id, target = 'before-target', weight = 1 })
+      h.c_insert(cn, "consumers", { id = uuid(), username = "before-consumer", custom_id = "before-consumer" })
+      local cc = h.c_insert(cn, "certificates", {
         partition = "certificates", id = uuid(), cert = "before-cert", key = "key"
       })
-      c_insert(cn, "snis", {
+      h.c_insert(cn, "snis", {
         partition = "snis", id = uuid(), certificate_id = cc.id, name = "before-sni" })
-      local s = c_insert(cn, "services", {
+      local s = h.c_insert(cn, "services", {
         partition = "services", id = uuid(), name = "before-service"
       })
-      c_insert(cn, "routes", {
+      h.c_insert(cn, "routes", {
         partition = "routes", id = uuid(), service_id = s.id, name = "before-route",
       })
-      c_insert(cn, "plugins", {
+      h.c_insert(cn, "plugins", {
         id = uuid(), name="key-auth", service_id = s.id, config="{}", enabled = true,
         cache_key="before-p",
       })
@@ -657,21 +413,21 @@ describe("#db migration core/009_200_to_210 spec", function()
       assert.is_nil(bp.ws_id)
 
       -- In Cassandra, old kong nodes inserting entities don't fill up the ws_id
-      local omu = c_insert(cn, "upstreams", { id = uuid(), name = 'old-migrating-upstream', slots = 1 })
-      local omt = c_insert(cn, "targets", { id = uuid(), upstream_id = omu.id, target = 'old-migrating-target', weight = 1 })
-      local omc = c_insert(cn, "consumers", { id = uuid(), username = "old-migrating-consumer", custom_id = "old-migrating-consumer" })
-      local omcc = c_insert(cn, "certificates", {
+      local omu = h.c_insert(cn, "upstreams", { id = uuid(), name = 'old-migrating-upstream', slots = 1 })
+      local omt = h.c_insert(cn, "targets", { id = uuid(), upstream_id = omu.id, target = 'old-migrating-target', weight = 1 })
+      local omc = h.c_insert(cn, "consumers", { id = uuid(), username = "old-migrating-consumer", custom_id = "old-migrating-consumer" })
+      local omcc = h.c_insert(cn, "certificates", {
         partition = "certificates", id = uuid(), cert = "old-migrating-cert", key = "key"
       })
-      local omsni = c_insert(cn, "snis", {
+      local omsni = h.c_insert(cn, "snis", {
         partition = "snis", id = uuid(), certificate_id = omcc.id, name = "old-migrating-sni" })
-      local oms = c_insert(cn, "services", {
+      local oms = h.c_insert(cn, "services", {
         partition = "services", id = uuid(), name = "old-migrating-service"
       })
-      local omr = c_insert(cn, "routes", {
+      local omr = h.c_insert(cn, "routes", {
         partition = "routes", id = uuid(), service_id = oms.id, name = "old-migrating-route",
       })
-      local omp = c_insert(cn, "plugins", {
+      local omp = h.c_insert(cn, "plugins", {
         id = uuid(), name="key-auth", service_id = oms.id, config="{}", enabled = true,
         cache_key = "omp:",
       })
@@ -686,22 +442,22 @@ describe("#db migration core/009_200_to_210 spec", function()
 
       -- create those entities specifying ws_id. Simulates a new kong node inserting entities
       -- expect them to have ws_id as well
-      local nmu = c_insert(cn, "upstreams", { id = uuid(), name = 'new-migrating-upstream', slots = 1, ws_id = default_ws_id })
-      local nmt = c_insert(cn, "targets", { id = uuid(), upstream_id = nmu.id, target = 'new-migrating-target', weight = 1, ws_id = default_ws_id })
-      local nmc = c_insert(cn, "consumers", { id = uuid(), username = "new-migrating-consumer", custom_id = "new-migrating-consumer", ws_id = default_ws_id })
-      local nmcc = c_insert(cn, "certificates", {
+      local nmu = h.c_insert(cn, "upstreams", { id = uuid(), name = 'new-migrating-upstream', slots = 1, ws_id = default_ws_id })
+      local nmt = h.c_insert(cn, "targets", { id = uuid(), upstream_id = nmu.id, target = 'new-migrating-target', weight = 1, ws_id = default_ws_id })
+      local nmc = h.c_insert(cn, "consumers", { id = uuid(), username = "new-migrating-consumer", custom_id = "new-migrating-consumer", ws_id = default_ws_id })
+      local nmcc = h.c_insert(cn, "certificates", {
         partition = "certificates", id = uuid(), cert = "new-migrating-cert", key = "key", ws_id = default_ws_id
       })
-      local nmsni = c_insert(cn, "snis", {
+      local nmsni = h.c_insert(cn, "snis", {
         partition = "snis", id = uuid(), certificate_id = nmcc.id, name = "new-migrating-sni", ws_id = default_ws_id })
-      local nms = c_insert(cn, "services", {
+      local nms = h.c_insert(cn, "services", {
         partition = "services", id = uuid(), name = "new-migrating-service", ws_id = default_ws_id
       })
-      local nmr = c_insert(cn, "routes", {
+      local nmr = h.c_insert(cn, "routes", {
         partition = "routes", id = uuid(), service_id = nms.id, ws_id = default_ws_id, name = "new-migrating-route",
       })
       -- notice that the cache_key used by the new nodes contains the ws_id
-      local nmp = c_insert(cn, "plugins", {
+      local nmp = h.c_insert(cn, "plugins", {
         id = uuid(), name="key-auth", service_id = nms.id, config="{}", enabled = true, ws_id = default_ws_id,
         cache_key = "nmp:" .. default_ws_id,
       })
@@ -815,8 +571,8 @@ describe("#db migration core/009_200_to_210 spec", function()
       -- And the implementation of cache_key which concatenates 5 parameters:
       --   https://github.com/Kong/kong/blob/2.0.2/kong/db/dao/init.lua#L1175
       local cn = db.connector
-      local s = c_insert(cn, "services", { partition="services", id = uuid(), name = "before-srv" })
-      local p1 = c_insert(cn, "plugins", { id = uuid(), name="key-auth", service_id = s.id, config="{}", enabled = true, cache_key="before-cache-key:"})
+      local s = h.c_insert(cn, "services", { partition="services", id = uuid(), name = "before-srv" })
+      local p1 = h.c_insert(cn, "plugins", { id = uuid(), name="key-auth", service_id = s.id, config="{}", enabled = true, cache_key="before-cache-key:"})
       assert.same("before-cache-key:", p1.cache_key)
 
       -- kong migrations up
@@ -828,15 +584,15 @@ describe("#db migration core/009_200_to_210 spec", function()
       local default_ws_id = assert(res[1].id)
 
       -- simulate an old node creating a service and plugin
-      local s = c_insert(cn, "services", { partition = "services", id = uuid(), name = "old-migrating-srv" })
-      local p2 = c_insert(cn, "plugins", { id = uuid(), name="key-auth", service_id = s.id, config="{}", enabled = true, cache_key="old-migrating-cache-key:"})
+      local s = h.c_insert(cn, "services", { partition = "services", id = uuid(), name = "old-migrating-srv" })
+      local p2 = h.c_insert(cn, "plugins", { id = uuid(), name="key-auth", service_id = s.id, config="{}", enabled = true, cache_key="old-migrating-cache-key:"})
       assert.same("old-migrating-cache-key:", p2.cache_key)
 
       -- simulate a new node creating a service and plugin.
       -- The plugin cache key is expected to already include ws_id
       -- and it is expected to not end in ":"
-      local s = c_insert(cn, "services", { partition = "services", id = uuid(), name = "new-migrating-srv" })
-      local p3 = c_insert(cn, "plugins", { id = uuid(), name="key-auth", service_id = s.id, config="{}", enabled = true, cache_key="new-migrating-cache-key:" .. default_ws_id})
+      local s = h.c_insert(cn, "services", { partition = "services", id = uuid(), name = "new-migrating-srv" })
+      local p3 = h.c_insert(cn, "plugins", { id = uuid(), name="key-auth", service_id = s.id, config="{}", enabled = true, cache_key="new-migrating-cache-key:" .. default_ws_id})
       assert.same("new-migrating-cache-key:" .. default_ws_id, p3.cache_key)
 
       -- kong migrations teardown

--- a/spec/03-plugins/09-key-auth/00-migrations/003_200_to_210_spec.lua
+++ b/spec/03-plugins/09-key-auth/00-migrations/003_200_to_210_spec.lua
@@ -1,0 +1,128 @@
+local helpers = require "spec.helpers"
+local h = require "spec.migration_helpers.200_to_210"
+local utils = require "kong.tools.utils"
+
+local fmt = string.format
+
+describe("#db migration key-auth/003_200_to_210 spec", function()
+  local _, db
+
+  after_each(function()
+    -- Clean up the database schema after each exercise.
+    -- This prevents failed migration tests impacting other tests in the CI
+    assert(db:schema_reset())
+  end)
+
+  describe("#postgres", function()
+    before_each(function()
+      _, db = helpers.get_db_utils("postgres", nil, nil, {
+        stop_namespace = "kong.plugins.key-auth.migrations",
+        stop_migration = "003_200_to_210",
+      })
+    end)
+
+    it("adds and sets ws_id", function()
+      local cn = db.connector
+      h.assert_not_pg_has_fkey(cn, "keyauth_credentials", "ws_id")
+      -- kong migrations up
+      assert(helpers.run_up_migration(db, "key-auth",
+                                      "kong.plugins.key-auth.migrations",
+                                      "003_200_to_210"))
+
+      h.pg_insert(cn, "keyauth_credentials", { id = utils.uuid() })
+
+      -- MIGRATING
+      h.assert_pg_has_fkey(cn, "keyauth_credentials", "ws_id")
+
+      -- check default workspace exists and get its id
+      local res = assert(cn:query("SELECT * FROM workspaces"))
+      assert.equals(1, #res)
+      assert.equals("default", res[1].name)
+      assert.truthy(utils.is_valid_uuid(res[1].id))
+      local default_ws_id = res[1].id
+
+      -- ensure that the entities created by the old node get the default ws_id
+      local bc = assert(cn:query("SELECT * FROM keyauth_credentials"))[1]
+      assert.equals(default_ws_id, bc.ws_id)
+
+      -- create entities without specifying default ws_id (simulate old node)
+      local omc = h.pg_insert(cn, "keyauth_credentials", { id = utils.uuid() })
+      assert.equals(default_ws_id, omc.ws_id)
+
+      -- create specifying default ws_id.(simulate new node)
+      local nmc = h.pg_insert(cn, "keyauth_credentials", { id = utils.uuid(), ws_id = default_ws_id })
+      assert.equals(default_ws_id, nmc.ws_id)
+
+      -- kong migrations finish
+      assert(helpers.run_teardown_migration(db, "key-auth",
+                                            "kong.plugins.key-auth.migrations",
+                                            "003_200_to_210"))
+
+      -- create specifying default ws_id.(simulate new node)
+      local ac = h.pg_insert(cn, "keyauth_credentials", { id = utils.uuid(), ws_id = default_ws_id })
+      assert.equals(default_ws_id, ac.ws_id)
+
+      -- check that previous credentials still have ws_id
+      local bc = assert(cn:query(fmt("SELECT * FROM keyauth_credentials WHERE id = '%s'", bc.id)))[1]
+      assert.equals(default_ws_id, bc.ws_id)
+
+      local omc = assert(cn:query(fmt("SELECT * FROM keyauth_credentials WHERE id = '%s'", omc.id)))[1]
+      assert.equals(default_ws_id, omc.ws_id)
+
+      local nmc = assert(cn:query(fmt("SELECT * FROM keyauth_credentials WHERE id = '%s'", nmc.id)))[1]
+      assert.equals(default_ws_id, nmc.ws_id)
+    end)
+  end)
+
+  describe("#cassandra", function()
+    before_each(function()
+      _, db = helpers.get_db_utils("cassandra", nil, nil, {
+        stop_namespace = "kong.plugins.key-auth.migrations",
+        stop_migration = "003_200_to_210",
+      })
+    end)
+
+    it("adds and sets ws_id", function()
+      local cn = db.connector
+      h.assert_not_c_has_fkey(cn, "keyauth-credentials", "ws_id")
+      -- kong migrations up
+      assert(helpers.run_up_migration(db, "keyauth-credentials",
+                                      "kong.plugins.key-auth.migrations",
+                                      "003_200_to_210"))
+
+      h.c_insert(cn, "keyauth_credentials", { id = utils.uuid() })
+
+      -- MIGRATING
+      h.assert_c_has_fkey(cn, "keyauth_credentials", "ws_id")
+
+      -- check default workspace exists and get its id
+      local res = assert(cn:query("SELECT * FROM workspaces"))
+      assert.equals(1, #res)
+      assert.equals("default", res[1].name)
+      assert.truthy(utils.is_valid_uuid(res[1].id))
+      local default_ws_id = res[1].id
+
+      -- entities created by the old node don't get the default id in C*
+      -- (this is handled in the DAO)
+      local a = assert(cn:query("SELECT * FROM keyauth_credentials"))[1]
+      assert.is_nil(a.ws_id)
+
+      -- create entities without specifying default ws_id (simulate old node)
+      local a = h.c_insert(cn, "keyauth_credentials", { id = utils.uuid() })
+      assert.is_nil(a.ws_id)
+
+      -- create specifying default ws_id.(simulate new node)
+      local a = h.c_insert(cn, "keyauth_credentials", { id = utils.uuid(), ws_id = default_ws_id })
+      assert.equals(default_ws_id, a.ws_id)
+
+      -- kong migrations finish
+      assert(helpers.run_teardown_migration(db, "key-auth",
+                                            "kong.plugins.key-auth.migrations",
+                                            "003_200_to_210"))
+
+      -- create specifying default ws_id.(simulate new node)
+      local a = h.c_insert(cn, "keyauth_credentials", { id = utils.uuid(), ws_id = default_ws_id })
+      assert.equals(default_ws_id, a.ws_id)
+    end)
+  end)
+end)

--- a/spec/03-plugins/10-basic-auth/00-migrations/003_200_to_210_spec.lua
+++ b/spec/03-plugins/10-basic-auth/00-migrations/003_200_to_210_spec.lua
@@ -1,0 +1,128 @@
+local helpers = require "spec.helpers"
+local h = require "spec.migration_helpers.200_to_210"
+local utils = require "kong.tools.utils"
+
+local fmt = string.format
+
+describe("#db migration basic-auth/003_200_to_210 spec", function()
+  local _, db
+
+  after_each(function()
+    -- Clean up the database schema after each exercise.
+    -- This prevents failed migration tests impacting other tests in the CI
+    assert(db:schema_reset())
+  end)
+
+  describe("#postgres", function()
+    before_each(function()
+      _, db = helpers.get_db_utils("postgres", nil, nil, {
+        stop_namespace = "kong.plugins.basic-auth.migrations",
+        stop_migration = "003_200_to_210",
+      })
+    end)
+
+    it("adds and sets ws_id", function()
+      local cn = db.connector
+      h.assert_not_pg_has_fkey(cn, "basicauth_credentials", "ws_id")
+      -- kong migrations up
+      assert(helpers.run_up_migration(db, "basic-auth",
+                                      "kong.plugins.basic-auth.migrations",
+                                      "003_200_to_210"))
+
+      h.pg_insert(cn, "basicauth_credentials", { id = utils.uuid() })
+
+      -- MIGRATING
+      h.assert_pg_has_fkey(cn, "basicauth_credentials", "ws_id")
+
+      -- check default workspace exists and get its id
+      local res = assert(cn:query("SELECT * FROM workspaces"))
+      assert.equals(1, #res)
+      assert.equals("default", res[1].name)
+      assert.truthy(utils.is_valid_uuid(res[1].id))
+      local default_ws_id = res[1].id
+
+      -- ensure that the entities created by the old node get the default ws_id
+      local bc = assert(cn:query("SELECT * FROM basicauth_credentials"))[1]
+      assert.equals(default_ws_id, bc.ws_id)
+
+      -- create entities without specifying default ws_id (simulate old node)
+      local omc = h.pg_insert(cn, "basicauth_credentials", { id = utils.uuid() })
+      assert.equals(default_ws_id, omc.ws_id)
+
+      -- create entities specifying default ws_id.(simulate new node)
+      local nmc = h.pg_insert(cn, "basicauth_credentials", { id = utils.uuid(), ws_id = default_ws_id })
+      assert.equals(default_ws_id, nmc.ws_id)
+
+      -- kong migrations finish
+      assert(helpers.run_teardown_migration(db, "basic-auth",
+                                            "kong.plugins.basic-auth.migrations",
+                                            "003_200_to_210"))
+
+      -- create specifying default ws_id.(simulate new node)
+      local ac = h.pg_insert(cn, "basicauth_credentials", { id = utils.uuid(), ws_id = default_ws_id })
+      assert.equals(default_ws_id, ac.ws_id)
+
+      -- check that previous entities still have ws_id
+      local bc = assert(cn:query(fmt("SELECT * FROM basicauth_credentials WHERE id = '%s'", bc.id)))[1]
+      assert.equals(default_ws_id, bc.ws_id)
+
+      local omc = assert(cn:query(fmt("SELECT * FROM basicauth_credentials WHERE id = '%s'", omc.id)))[1]
+      assert.equals(default_ws_id, omc.ws_id)
+
+      local nmc = assert(cn:query(fmt("SELECT * FROM basicauth_credentials WHERE id = '%s'", nmc.id)))[1]
+      assert.equals(default_ws_id, nmc.ws_id)
+    end)
+  end)
+
+  describe("#cassandra", function()
+    before_each(function()
+      _, db = helpers.get_db_utils("cassandra", nil, nil, {
+        stop_namespace = "kong.plugins.basic-auth.migrations",
+        stop_migration = "003_200_to_210",
+      })
+    end)
+
+    it("adds and sets ws_id", function()
+      local cn = db.connector
+      h.assert_not_c_has_fkey(cn, "basicauth-credentials", "ws_id")
+      -- kong migrations up
+      assert(helpers.run_up_migration(db, "basicauth-credentials",
+                                      "kong.plugins.basic-auth.migrations",
+                                      "003_200_to_210"))
+
+      h.c_insert(cn, "basicauth_credentials", { id = utils.uuid() })
+
+      -- MIGRATING
+      h.assert_c_has_fkey(cn, "basicauth_credentials", "ws_id")
+
+      -- check default workspace exists and get its id
+      local res = assert(cn:query("SELECT * FROM workspaces"))
+      assert.equals(1, #res)
+      assert.equals("default", res[1].name)
+      assert.truthy(utils.is_valid_uuid(res[1].id))
+      local default_ws_id = res[1].id
+
+      -- entities created by the old node don't get the default id in C*
+      -- (this is handled in the DAO)
+      local a = assert(cn:query("SELECT * FROM basicauth_credentials"))[1]
+      assert.is_nil(a.ws_id)
+
+      -- create entities without specifying default ws_id (simulate old node)
+      local a = h.c_insert(cn, "basicauth_credentials", { id = utils.uuid() })
+      assert.is_nil(a.ws_id)
+
+      -- create specifying default ws_id.(simulate new node)
+      local a = h.c_insert(cn, "basicauth_credentials", { id = utils.uuid(), ws_id = default_ws_id })
+      assert.equals(default_ws_id, a.ws_id)
+
+      -- kong migrations finish
+      assert(helpers.run_teardown_migration(db, "basic-auth",
+                                            "kong.plugins.basic-auth.migrations",
+                                            "003_200_to_210"))
+
+      -- create specifying default ws_id.(simulate new node)
+      local a = h.c_insert(cn, "basicauth_credentials", { id = utils.uuid(), ws_id = default_ws_id })
+      assert.equals(default_ws_id, a.ws_id)
+    end)
+  end)
+end)

--- a/spec/03-plugins/16-jwt/00-migrations/003_200_to_210_spec.lua
+++ b/spec/03-plugins/16-jwt/00-migrations/003_200_to_210_spec.lua
@@ -1,0 +1,129 @@
+local helpers = require "spec.helpers"
+local h = require "spec.migration_helpers.200_to_210"
+local utils = require "kong.tools.utils"
+
+local fmt = string.format
+
+describe("#db migration jwt/003_200_to_210 spec", function()
+  local _, db
+
+  after_each(function()
+    -- Clean up the database schema after each exercise.
+    -- This prevents failed migration tests impacting other tests in the CI
+    assert(db:schema_reset())
+  end)
+
+  describe("#postgres", function()
+    before_each(function()
+      _, db = helpers.get_db_utils("postgres", nil, nil, {
+        stop_namespace = "kong.plugins.jwt.migrations",
+        stop_migration = "003_200_to_210",
+      })
+    end)
+
+    it("adds and sets ws_id", function()
+      local cn = db.connector
+      h.assert_not_pg_has_fkey(cn, "jwt_secrets", "ws_id")
+      -- kong migrations up
+      assert(helpers.run_up_migration(db, "jwt",
+                                      "kong.plugins.jwt.migrations",
+                                      "003_200_to_210"))
+
+      h.pg_insert(cn, "jwt_secrets", { id = utils.uuid() })
+
+      -- MIGRATING
+      h.assert_pg_has_fkey(cn, "jwt_secrets", "ws_id")
+
+      -- check default workspace exists and get its id
+      local res = assert(cn:query("SELECT * FROM workspaces"))
+      assert.equals(1, #res)
+      assert.equals("default", res[1].name)
+      assert.truthy(utils.is_valid_uuid(res[1].id))
+      local default_ws_id = res[1].id
+
+      -- ensure that the entities created by the old node get the default ws_id
+      local bs = assert(cn:query("SELECT * FROM jwt_secrets"))[1]
+      assert.equals(default_ws_id, bs.ws_id)
+
+      -- create entities without specifying default ws_id (simulate old node)
+      local oms = h.pg_insert(cn, "jwt_secrets", { id = utils.uuid() })
+      assert.equals(default_ws_id, oms.ws_id)
+
+      -- create specifying default ws_id.(simulate new node)
+      local nms = h.pg_insert(cn, "jwt_secrets", { id = utils.uuid(), ws_id = default_ws_id })
+      assert.equals(default_ws_id, nms.ws_id)
+
+      -- kong migrations finish
+      assert(helpers.run_teardown_migration(db, "jwt",
+                                            "kong.plugins.jwt.migrations",
+                                            "003_200_to_210"))
+
+      -- create specifying default ws_id.(simulate new node)
+      local as = h.pg_insert(cn, "jwt_secrets", { id = utils.uuid(), ws_id = default_ws_id })
+      assert.equals(default_ws_id, as.ws_id)
+
+
+      -- check that entities created previosly still have ws_id
+      local bs = assert(cn:query(fmt("SELECT * FROM jwt_secrets WHERE id = '%s'", bs.id)))[1]
+      assert.equals(default_ws_id, bs.ws_id)
+
+      local oms = assert(cn:query(fmt("SELECT * FROM jwt_secrets WHERE id = '%s'", oms.id)))[1]
+      assert.equals(default_ws_id, oms.ws_id)
+
+      local nms = assert(cn:query(fmt("SELECT * FROM jwt_secrets WHERE id = '%s'", nms.id)))[1]
+      assert.equals(default_ws_id, nms.ws_id)
+    end)
+  end)
+
+  describe("#cassandra", function()
+    before_each(function()
+      _, db = helpers.get_db_utils("cassandra", nil, nil, {
+        stop_namespace = "kong.plugins.jwt.migrations",
+        stop_migration = "003_200_to_210",
+      })
+    end)
+
+    it("adds and sets ws_id", function()
+      local cn = db.connector
+      h.assert_not_c_has_fkey(cn, "jwt_secrets", "ws_id")
+      -- kong migrations up
+      assert(helpers.run_up_migration(db, "jwt",
+                                      "kong.plugins.jwt.migrations",
+                                      "003_200_to_210"))
+
+      h.c_insert(cn, "jwt_secrets", { id = utils.uuid() })
+
+      -- MIGRATING
+      h.assert_c_has_fkey(cn, "jwt_secrets", "ws_id")
+
+      -- check default workspace exists and get its id
+      local res = assert(cn:query("SELECT * FROM workspaces"))
+      assert.equals(1, #res)
+      assert.equals("default", res[1].name)
+      assert.truthy(utils.is_valid_uuid(res[1].id))
+      local default_ws_id = res[1].id
+
+      -- entities created by the old node don't get the default id in C*
+      -- (this is handled in the DAO)
+      local a = assert(cn:query("SELECT * FROM jwt_secrets"))[1]
+      assert.is_nil(a.ws_id)
+
+      -- create entities without specifying default ws_id (simulate old node)
+      local a = h.c_insert(cn, "jwt_secrets", { id = utils.uuid() })
+      assert.is_nil(a.ws_id)
+
+      -- create specifying default ws_id.(simulate new node)
+      local a = h.c_insert(cn, "jwt_secrets", { id = utils.uuid(), ws_id = default_ws_id })
+      assert.equals(default_ws_id, a.ws_id)
+
+      -- kong migrations finish
+      assert(helpers.run_teardown_migration(db, "jwt",
+                                            "kong.plugins.jwt.migrations",
+                                            "003_200_to_210"))
+
+      -- create specifying default ws_id.(simulate new node)
+      local a = h.c_insert(cn, "jwt_secrets", { id = utils.uuid(), ws_id = default_ws_id })
+      assert.equals(default_ws_id, a.ws_id)
+    end)
+  end)
+end)

--- a/spec/03-plugins/17-ip-restriction/00-migrations/001_200_to_210_spec.lua
+++ b/spec/03-plugins/17-ip-restriction/00-migrations/001_200_to_210_spec.lua
@@ -1,0 +1,81 @@
+local helpers = require "spec.helpers"
+local h = require "spec.migration_helpers.200_to_210"
+local utils = require "kong.tools.utils"
+local cjson = require "cjson"
+
+describe("#db migration ip-restriction/001_200_to_210 spec", function()
+  local _, db
+
+  after_each(function()
+    -- Clean up the database schema after each exercise.
+    -- This prevents failed migration tests impacting other tests in the CI
+    assert(db:schema_reset())
+  end)
+
+  describe("#postgres", function()
+    before_each(function()
+      _, db = helpers.get_db_utils("postgres", nil, nil, {
+        stop_namespace = "kong.plugins.ip-restriction.migrations",
+        stop_migration = "001_200_to_210",
+      })
+    end)
+
+    it("renames whitelist/blacklist to allow/deny", function()
+      local cn = db.connector
+      h.pg_insert(cn, "plugins", { id = utils.uuid(),
+                                   name = "ip-restriction",
+                                   enabled = true,
+                                   config = '{"whitelist":["foo"],"blacklist":["bar"]}'
+                                 })
+      -- kong migrations up
+      assert(helpers.run_up_migration(db, "ip-restriction",
+                                      "kong.plugins.ip-restriction.migrations",
+                                      "001_200_to_210"))
+
+      -- MIGRATING
+      -- no changes to test
+
+      -- kong migrations finish
+      assert(helpers.run_teardown_migration(db, "basic-auth",
+                                            "kong.plugins.ip-restriction.migrations",
+                                            "001_200_to_210"))
+
+      local p = assert(cn:query("SELECT * from plugins"))[1]
+      assert.same({ allow = { "foo" }, deny = { "bar" } }, p.config)
+    end)
+  end)
+
+  describe("#cassandra", function()
+    before_each(function()
+      _, db = helpers.get_db_utils("cassandra", nil, nil, {
+        stop_namespace = "kong.plugins.ip-restriction.migrations",
+        stop_migration = "001_200_to_210",
+      })
+    end)
+
+    it("renames whitelist/blacklist to allow/deny", function()
+      local cn = db.connector
+      h.c_insert(cn, "plugins", { id = utils.uuid(),
+                                   name = "ip-restriction",
+                                   enabled = true,
+                                   config = '{"whitelist":["foo"],"blacklist":["bar"]}'
+                                 })
+      -- kong migrations up
+      assert(helpers.run_up_migration(db, "ip-restriction",
+                                      "kong.plugins.ip-restriction.migrations",
+                                      "001_200_to_210"))
+
+      -- MIGRATING
+      -- no changes to test
+
+      -- kong migrations finish
+      assert(helpers.run_teardown_migration(db, "basic-auth",
+                                            "kong.plugins.ip-restriction.migrations",
+                                            "001_200_to_210"))
+
+      local p = assert(cn:query("SELECT * from plugins"))[1]
+      local new_config = cjson.decode(p.config)
+      assert.same({ allow = { "foo" }, deny = { "bar" } }, new_config)
+    end)
+  end)
+end)

--- a/spec/03-plugins/18-acl/00-migrations/003_200_to_210_spec.lua
+++ b/spec/03-plugins/18-acl/00-migrations/003_200_to_210_spec.lua
@@ -1,0 +1,128 @@
+local helpers = require "spec.helpers"
+local h = require "spec.migration_helpers.200_to_210"
+local utils = require "kong.tools.utils"
+
+local fmt = string.format
+
+describe("#db migration acl/003_200_to_210 spec", function()
+  local _, db
+
+  after_each(function()
+    -- Clean up the database schema after each exercise.
+    -- This prevents failed migration tests impacting other tests in the CI
+    assert(db:schema_reset())
+  end)
+
+  describe("#postgres", function()
+    before_each(function()
+      _, db = helpers.get_db_utils("postgres", nil, nil, {
+        stop_namespace = "kong.plugins.acl.migrations",
+        stop_migration = "003_200_to_210",
+      })
+    end)
+
+    it("adds and sets ws_id", function()
+      local cn = db.connector
+      h.assert_not_pg_has_fkey(cn, "acls", "ws_id")
+      -- kong migrations up
+      assert(helpers.run_up_migration(db, "acl",
+                                      "kong.plugins.acl.migrations",
+                                      "003_200_to_210"))
+
+      h.pg_insert(cn, "acls", { id = utils.uuid() })
+
+      -- MIGRATING
+      h.assert_pg_has_fkey(cn, "acls", "ws_id")
+
+      -- check default workspace exists and get its id
+      local res = assert(cn:query("SELECT * FROM workspaces"))
+      assert.equals(1, #res)
+      assert.equals("default", res[1].name)
+      assert.truthy(utils.is_valid_uuid(res[1].id))
+      local default_ws_id = res[1].id
+
+      -- ensure that the entities created by the old node get the default ws_id
+      local ba = assert(cn:query("SELECT * FROM acls"))[1]
+      assert.equals(default_ws_id, ba.ws_id)
+
+      -- create entities without specifying default ws_id (simulate old node)
+      local oma = h.pg_insert(cn, "acls", { id = utils.uuid() })
+      assert.equals(default_ws_id, oma.ws_id)
+
+      -- create specifying default ws_id.(simulate new node)
+      local nma = h.pg_insert(cn, "acls", { id = utils.uuid(), ws_id = default_ws_id })
+      assert.equals(default_ws_id, nma.ws_id)
+
+      -- kong migrations finish
+      assert(helpers.run_teardown_migration(db, "acl",
+                                            "kong.plugins.acl.migrations",
+                                            "003_200_to_210"))
+
+      -- create specifying default ws_id.(simulate new node)
+      local a = h.pg_insert(cn, "acls", { id = utils.uuid(), ws_id = default_ws_id })
+      assert.equals(default_ws_id, a.ws_id)
+
+      -- check that the old entities still have ws_id
+      local ba = assert(cn:query(fmt("SELECT * FROM acls WHERE id = '%s'", ba.id)))[1]
+      assert.equals(default_ws_id, ba.ws_id)
+
+      local oma = assert(cn:query(fmt("SELECT * FROM acls WHERE id = '%s'", oma.id)))[1]
+      assert.equals(default_ws_id, oma.ws_id)
+
+      local nma = assert(cn:query(fmt("SELECT * FROM acls WHERE id = '%s'", nma.id)))[1]
+      assert.equals(default_ws_id, nma.ws_id)
+    end)
+  end)
+
+  describe("#cassandra", function()
+    before_each(function()
+      _, db = helpers.get_db_utils("cassandra", nil, nil, {
+        stop_namespace = "kong.plugins.acl.migrations",
+        stop_migration = "003_200_to_210",
+      })
+    end)
+
+    it("adds and sets ws_id", function()
+      local cn = db.connector
+      h.assert_not_c_has_fkey(cn, "acls", "ws_id")
+      -- kong migrations up
+      assert(helpers.run_up_migration(db, "acl",
+                                      "kong.plugins.acl.migrations",
+                                      "003_200_to_210"))
+
+      h.c_insert(cn, "acls", { id = utils.uuid() })
+
+      -- MIGRATING
+      h.assert_c_has_fkey(cn, "acls", "ws_id")
+
+      -- check default workspace exists and get its id
+      local res = assert(cn:query("SELECT * FROM workspaces"))
+      assert.equals(1, #res)
+      assert.equals("default", res[1].name)
+      assert.truthy(utils.is_valid_uuid(res[1].id))
+      local default_ws_id = res[1].id
+
+      -- entities created by the old node don't get the default id in C*
+      -- (this is handled in the DAO)
+      local a = assert(cn:query("SELECT * FROM acls"))[1]
+      assert.is_nil(a.ws_id)
+
+      -- create entities without specifying default ws_id (simulate old node)
+      local a = h.c_insert(cn, "acls", { id = utils.uuid() })
+      assert.is_nil(a.ws_id)
+
+      -- create specifying default ws_id.(simulate new node)
+      local a = h.c_insert(cn, "acls", { id = utils.uuid(), ws_id = default_ws_id })
+      assert.equals(default_ws_id, a.ws_id)
+
+      -- kong migrations finish
+      assert(helpers.run_teardown_migration(db, "acl",
+                                            "kong.plugins.acl.migrations",
+                                            "003_200_to_210"))
+
+      -- create specifying default ws_id.(simulate new node)
+      local a = h.c_insert(cn, "acls", { id = utils.uuid(), ws_id = default_ws_id })
+      assert.equals(default_ws_id, a.ws_id)
+    end)
+  end)
+end)

--- a/spec/03-plugins/19-hmac-auth/00-migrations/003_200_to_210_spec.lua
+++ b/spec/03-plugins/19-hmac-auth/00-migrations/003_200_to_210_spec.lua
@@ -1,0 +1,128 @@
+local helpers = require "spec.helpers"
+local h = require "spec.migration_helpers.200_to_210"
+local utils = require "kong.tools.utils"
+
+local fmt = string.format
+
+describe("#db migration hmac-auth/003_200_to_210 spec", function()
+  local _, db
+
+  after_each(function()
+    -- Clean up the database schema after each exercise.
+    -- This prevents failed migration tests impacting other tests in the CI
+    assert(db:schema_reset())
+  end)
+
+  describe("#postgres", function()
+    before_each(function()
+      _, db = helpers.get_db_utils("postgres", nil, nil, {
+        stop_namespace = "kong.plugins.hmac-auth.migrations",
+        stop_migration = "003_200_to_210",
+      })
+    end)
+
+    it("adds and sets ws_id", function()
+      local cn = db.connector
+      h.assert_not_pg_has_fkey(cn, "hmacauth_credentials", "ws_id")
+      -- kong migrations up
+      assert(helpers.run_up_migration(db, "hmac-auth",
+                                      "kong.plugins.hmac-auth.migrations",
+                                      "003_200_to_210"))
+
+      h.pg_insert(cn, "hmacauth_credentials", { id = utils.uuid() })
+
+      -- MIGRATING
+      h.assert_pg_has_fkey(cn, "hmacauth_credentials", "ws_id")
+
+      -- check default workspace exists and get its id
+      local res = assert(cn:query("SELECT * FROM workspaces"))
+      assert.equals(1, #res)
+      assert.equals("default", res[1].name)
+      assert.truthy(utils.is_valid_uuid(res[1].id))
+      local default_ws_id = res[1].id
+
+      -- ensure that the entities created by the old node get the default ws_id
+      local bc = assert(cn:query("SELECT * FROM hmacauth_credentials"))[1]
+      assert.equals(default_ws_id, bc.ws_id)
+
+      -- create entities without specifying default ws_id (simulate old node)
+      local omc = h.pg_insert(cn, "hmacauth_credentials", { id = utils.uuid() })
+      assert.equals(default_ws_id, omc.ws_id)
+
+      -- create specifying default ws_id.(simulate new node)
+      local nmc = h.pg_insert(cn, "hmacauth_credentials", { id = utils.uuid(), ws_id = default_ws_id })
+      assert.equals(default_ws_id, nmc.ws_id)
+
+      -- kong migrations finish
+      assert(helpers.run_teardown_migration(db, "hmac-auth",
+                                            "kong.plugins.hmac-auth.migrations",
+                                            "003_200_to_210"))
+
+      -- create specifying default ws_id.(simulate new node)
+      local ac = h.pg_insert(cn, "hmacauth_credentials", { id = utils.uuid(), ws_id = default_ws_id })
+      assert.equals(default_ws_id, ac.ws_id)
+
+      -- check that the previous entities still have ws_id
+      local bc = assert(cn:query(fmt("SELECT * FROM hmacauth_credentials WHERE id = '%s'", bc.id)))[1]
+      assert.equals(default_ws_id, bc.ws_id)
+
+      local omc = assert(cn:query(fmt("SELECT * FROM hmacauth_credentials WHERE id = '%s'", omc.id)))[1]
+      assert.equals(default_ws_id, omc.ws_id)
+
+      local nmc = assert(cn:query(fmt("SELECT * FROM hmacauth_credentials WHERE id = '%s'", nmc.id)))[1]
+      assert.equals(default_ws_id, nmc.ws_id)
+    end)
+  end)
+
+  describe("#cassandra", function()
+    before_each(function()
+      _, db = helpers.get_db_utils("cassandra", nil, nil, {
+        stop_namespace = "kong.plugins.hmac-auth.migrations",
+        stop_migration = "003_200_to_210",
+      })
+    end)
+
+    it("adds and sets ws_id", function()
+      local cn = db.connector
+      h.assert_not_c_has_fkey(cn, "hmacauth-credentials", "ws_id")
+      -- kong migrations up
+      assert(helpers.run_up_migration(db, "hmacauth-credentials",
+                                      "kong.plugins.hmac-auth.migrations",
+                                      "003_200_to_210"))
+
+      h.c_insert(cn, "hmacauth_credentials", { id = utils.uuid() })
+
+      -- MIGRATING
+      h.assert_c_has_fkey(cn, "hmacauth_credentials", "ws_id")
+
+      -- check default workspace exists and get its id
+      local res = assert(cn:query("SELECT * FROM workspaces"))
+      assert.equals(1, #res)
+      assert.equals("default", res[1].name)
+      assert.truthy(utils.is_valid_uuid(res[1].id))
+      local default_ws_id = res[1].id
+
+      -- entities created by the old node don't get the default id in C*
+      -- (this is handled in the DAO)
+      local a = assert(cn:query("SELECT * FROM hmacauth_credentials"))[1]
+      assert.is_nil(a.ws_id)
+
+      -- create entities without specifying default ws_id (simulate old node)
+      local a = h.c_insert(cn, "hmacauth_credentials", { id = utils.uuid() })
+      assert.is_nil(a.ws_id)
+
+      -- create specifying default ws_id.(simulate new node)
+      local a = h.c_insert(cn, "hmacauth_credentials", { id = utils.uuid(), ws_id = default_ws_id })
+      assert.equals(default_ws_id, a.ws_id)
+
+      -- kong migrations finish
+      assert(helpers.run_teardown_migration(db, "hmac-auth",
+                                            "kong.plugins.hmac-auth.migrations",
+                                            "003_200_to_210"))
+
+      -- create specifying default ws_id.(simulate new node)
+      local a = h.c_insert(cn, "hmacauth_credentials", { id = utils.uuid(), ws_id = default_ws_id })
+      assert.equals(default_ws_id, a.ws_id)
+    end)
+  end)
+end)

--- a/spec/03-plugins/21-bot-detection/00-migrations/001_200_to_210_spec.lua
+++ b/spec/03-plugins/21-bot-detection/00-migrations/001_200_to_210_spec.lua
@@ -1,0 +1,81 @@
+local helpers = require "spec.helpers"
+local h = require "spec.migration_helpers.200_to_210"
+local utils = require "kong.tools.utils"
+local cjson = require "cjson"
+
+describe("#db migration bot-detection/001_200_to_210 spec", function()
+  local _, db
+
+  after_each(function()
+    -- Clean up the database schema after each exercise.
+    -- This prevents failed migration tests impacting other tests in the CI
+    assert(db:schema_reset())
+  end)
+
+  describe("#postgres", function()
+    before_each(function()
+      _, db = helpers.get_db_utils("postgres", nil, nil, {
+        stop_namespace = "kong.plugins.bot-detection.migrations",
+        stop_migration = "001_200_to_210",
+      })
+    end)
+
+    it("renames whitelist/blacklist to allow/deny", function()
+      local cn = db.connector
+      h.pg_insert(cn, "plugins", { id = utils.uuid(),
+                                   name = "bot-detection",
+                                   enabled = true,
+                                   config = '{"whitelist":["foo"],"blacklist":["bar"]}'
+                                 })
+      -- kong migrations up
+      assert(helpers.run_up_migration(db, "bot-detection",
+                                      "kong.plugins.bot-detection.migrations",
+                                      "001_200_to_210"))
+
+      -- MIGRATING
+      -- no changes to test
+
+      -- kong migrations finish
+      assert(helpers.run_teardown_migration(db, "basic-auth",
+                                            "kong.plugins.bot-detection.migrations",
+                                            "001_200_to_210"))
+
+      local p = assert(cn:query("SELECT * from plugins"))[1]
+      assert.same({ allow = { "foo" }, deny = { "bar" } }, p.config)
+    end)
+  end)
+
+  describe("#cassandra", function()
+    before_each(function()
+      _, db = helpers.get_db_utils("cassandra", nil, nil, {
+        stop_namespace = "kong.plugins.bot-detection.migrations",
+        stop_migration = "001_200_to_210",
+      })
+    end)
+
+    it("renames whitelist/blacklist to allow/deny", function()
+      local cn = db.connector
+      h.c_insert(cn, "plugins", { id = utils.uuid(),
+                                   name = "bot-detection",
+                                   enabled = true,
+                                   config = '{"whitelist":["foo"],"blacklist":["bar"]}'
+                                 })
+      -- kong migrations up
+      assert(helpers.run_up_migration(db, "bot-detection",
+                                      "kong.plugins.bot-detection.migrations",
+                                      "001_200_to_210"))
+
+      -- MIGRATING
+      -- no changes to test
+
+      -- kong migrations finish
+      assert(helpers.run_teardown_migration(db, "basic-auth",
+                                            "kong.plugins.bot-detection.migrations",
+                                            "001_200_to_210"))
+
+      local p = assert(cn:query("SELECT * from plugins"))[1]
+      local new_config = cjson.decode(p.config)
+      assert.same({ allow = { "foo" }, deny = { "bar" } }, new_config)
+    end)
+  end)
+end)

--- a/spec/03-plugins/23-rate-limiting/00-migrations/004_200_to_210_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/00-migrations/004_200_to_210_spec.lua
@@ -1,0 +1,38 @@
+local helpers = require "spec.helpers"
+local h = require "spec.migration_helpers.200_to_210"
+
+describe("#db migration rate-limiting/004_200_to_210 spec", function()
+  local _, db
+
+  after_each(function()
+    -- Clean up the database schema after each exercise.
+    -- This prevents failed migration tests impacting other tests in the CI
+    assert(db:schema_reset())
+  end)
+
+  describe("#postgres", function()
+    before_each(function()
+      _, db = helpers.get_db_utils("postgres", nil, nil, {
+        stop_namespace = "kong.plugins.rate-limiting.migrations",
+        stop_migration = "004_200_to_210",
+      })
+    end)
+
+    it("adds columns", function()
+      local cn = db.connector
+      h.assert_not_pg_has_column(cn, "ratelimiting_metrics", "ttl", "timestamp with time zome")
+      h.assert_not_pg_has_index(cn, "ratelimiting_metrics_ttl_idx")
+
+      -- kong migrations up
+      assert(helpers.run_up_migration(db, "rate-limiting",
+                                      "kong.plugins.rate-limiting.migrations",
+                                      "004_200_to_210"))
+
+      h.assert_pg_has_column(cn, "ratelimiting_metrics", "ttl", "timestamp with time zone")
+      h.assert_pg_has_index(cn, "ratelimiting_metrics_ttl_idx")
+    end)
+  end)
+
+  -- This migration's cassandra actions are empty
+
+end)

--- a/spec/03-plugins/25-oauth2/00-migrations/004_200_to_210_spec.lua
+++ b/spec/03-plugins/25-oauth2/00-migrations/004_200_to_210_spec.lua
@@ -1,0 +1,277 @@
+local helpers = require "spec.helpers"
+local h = require "spec.migration_helpers.200_to_210"
+local utils = require "kong.tools.utils"
+
+local fmt = string.format
+
+describe("#db migration oauth2/004_200_to_210 spec", function()
+  local _, db
+
+  after_each(function()
+    -- Clean up the database schema after each exercise.
+    -- This prevents failed migration tests impacting other tests in the CI
+    assert(db:schema_reset())
+  end)
+
+  describe("#postgres", function()
+    before_each(function()
+      _, db = helpers.get_db_utils("postgres", nil, nil, {
+        stop_namespace = "kong.plugins.oauth2.migrations",
+        stop_migration = "004_200_to_210",
+      })
+    end)
+
+    it("adds columns", function()
+      local cn = db.connector
+      h.assert_not_pg_has_column(cn, "oauth2_authorization_codes", "challenge", "text")
+      h.assert_not_pg_has_column(cn, "oauth2_authorization_codes", "challenge_method", "text")
+      h.assert_not_pg_has_column(cn, "oauth2_credentials", "client_type", "text")
+      h.assert_not_pg_has_column(cn, "oauth2_credentials", "hash_secret", "boolean")
+
+      -- kong migrations up
+      assert(helpers.run_up_migration(db, "oauth2",
+                                      "kong.plugins.oauth2.migrations",
+                                      "004_200_to_210"))
+
+      h.assert_pg_has_column(cn, "oauth2_authorization_codes", "challenge", "text")
+      h.assert_pg_has_column(cn, "oauth2_authorization_codes", "challenge_method", "text")
+      h.assert_pg_has_column(cn, "oauth2_credentials", "client_type", "text")
+      h.assert_pg_has_column(cn, "oauth2_credentials", "hash_secret", "boolean")
+    end)
+
+    it("adds and sets ws_id", function()
+      local cn = db.connector
+      h.assert_not_pg_has_fkey(cn, "oauth2_credentials", "ws_id")
+      h.assert_not_pg_has_fkey(cn, "oauth2_authorization_codes", "ws_id")
+      h.assert_not_pg_has_fkey(cn, "oauth2_tokens", "ws_id")
+      -- kong migrations up
+      assert(helpers.run_up_migration(db, "oauth2",
+                                      "kong.plugins.oauth2.migrations",
+                                      "004_200_to_210"))
+
+      h.pg_insert(cn, "oauth2_credentials", { id = utils.uuid(), client_id = "before-cred" })
+      h.pg_insert(cn, "oauth2_authorization_codes", { id = utils.uuid(), code = "before-code" })
+      h.pg_insert(cn, "oauth2_tokens", { id = utils.uuid(), access_token="before-token", refresh_token="before-token" })
+
+      -- MIGRATING
+      h.assert_pg_has_fkey(cn, "oauth2_credentials", "ws_id")
+      h.assert_pg_has_fkey(cn, "oauth2_authorization_codes", "ws_id")
+
+      -- check default workspace exists and get its id
+      local res = assert(cn:query("SELECT * FROM workspaces"))
+      assert.equals(1, #res)
+      assert.equals("default", res[1].name)
+      assert.truthy(utils.is_valid_uuid(res[1].id))
+      local default_ws_id = res[1].id
+
+      -- ensure that the entities created by the old node get the default ws_id
+      local bc = assert(cn:query("SELECT * FROM oauth2_credentials"))[1]
+      assert.equals(default_ws_id, bc.ws_id)
+
+      local bac = assert(cn:query("SELECT * FROM oauth2_authorization_codes"))[1]
+      assert.equals(default_ws_id, bac.ws_id)
+
+      local bt = assert(cn:query("SELECT * FROM oauth2_tokens"))[1]
+      assert.equals(default_ws_id, bt.ws_id)
+
+      -- create entities without specifying default ws_id (simulate old node)
+      local omc = h.pg_insert(cn, "oauth2_credentials", { id = utils.uuid(), client_id="old-migrating-cred" })
+      assert.equals(default_ws_id, omc.ws_id)
+
+      local omac = h.pg_insert(cn, "oauth2_authorization_codes", { id = utils.uuid(), code = "old-migrating-code" })
+      assert.equals(default_ws_id, omac.ws_id)
+
+      local omt = h.pg_insert(cn, "oauth2_tokens", { id = utils.uuid(), access_token = "old-migrating-token", refresh_token = "old-migrating-token"  })
+      assert.equals(default_ws_id, omt.ws_id)
+
+      -- create specifying default ws_id.(simulate new node)
+      local nmc = h.pg_insert(cn, "oauth2_credentials", { id = utils.uuid(), ws_id = default_ws_id, client_id = "new-migrating-cred" })
+      assert.equals(default_ws_id, nmc.ws_id)
+
+      local nmac = h.pg_insert(cn, "oauth2_authorization_codes", { id = utils.uuid(), ws_id = default_ws_id, code = "new-migrating-code" })
+      assert.equals(default_ws_id, nmac.ws_id)
+
+      local nmt = h.pg_insert(cn, "oauth2_tokens", { id = utils.uuid(), ws_id = default_ws_id, access_token="new-migrating-token", refresh_token="new-migrating-token"  })
+      assert.equals(default_ws_id, nmt.ws_id)
+
+      -- kong migrations finish
+      assert(helpers.run_teardown_migration(db, "oauth2",
+                                            "kong.plugins.oauth2.migrations",
+                                            "004_200_to_210"))
+
+      local amc = h.pg_insert(cn, "oauth2_credentials", { id = utils.uuid(), ws_id = default_ws_id, client_id = "after-cred" })
+      assert.equals(default_ws_id, amc.ws_id)
+
+      local aac = h.pg_insert(cn, "oauth2_authorization_codes", { id = utils.uuid(), ws_id = default_ws_id, code = "after-code" })
+      assert.equals(default_ws_id, aac.ws_id)
+
+      local at = h.pg_insert(cn, "oauth2_tokens", { id = utils.uuid(), ws_id = default_ws_id, access_token="after-token", refresh_token="after-token"  })
+      assert.equals(default_ws_id, at.ws_id)
+
+      -- check that previous entities still have ws_id
+      local bc = assert(cn:query(fmt("SELECT * FROM oauth2_credentials WHERE id = '%s'", bc.id)))[1]
+      assert.equals(default_ws_id, bc.ws_id)
+
+      local omc = assert(cn:query(fmt("SELECT * FROM oauth2_credentials WHERE id = '%s'", omc.id)))[1]
+      assert.equals(default_ws_id, omc.ws_id)
+
+      local nmc = assert(cn:query(fmt("SELECT * FROM oauth2_credentials WHERE id = '%s'", nmc.id)))[1]
+      assert.equals(default_ws_id, nmc.ws_id)
+
+      local bac = assert(cn:query(fmt("SELECT * FROM oauth2_authorization_codes WHERE id = '%s'", bac.id)))[1]
+      assert.equals(default_ws_id, bac.ws_id)
+
+      local omac = assert(cn:query(fmt("SELECT * FROM oauth2_authorization_codes WHERE id = '%s'", omac.id)))[1]
+      assert.equals(default_ws_id, omac.ws_id)
+
+      local nmac = assert(cn:query(fmt("SELECT * FROM oauth2_authorization_codes WHERE id = '%s'", nmac.id)))[1]
+      assert.equals(default_ws_id, nmac.ws_id)
+
+      local bt = assert(cn:query(fmt("SELECT * FROM oauth2_tokens WHERE id = '%s'", bt.id)))[1]
+      assert.equals(default_ws_id, bt.ws_id)
+
+      local omt = assert(cn:query(fmt("SELECT * FROM oauth2_tokens WHERE id = '%s'", omt.id)))[1]
+      assert.equals(default_ws_id, omt.ws_id)
+
+      local nmt = assert(cn:query(fmt("SELECT * FROM oauth2_tokens WHERE id = '%s'", nmt.id)))[1]
+      assert.equals(default_ws_id, nmt.ws_id)
+    end)
+  end)
+
+  describe("#cassandra", function()
+    before_each(function()
+      _, db = helpers.get_db_utils("cassandra", nil, nil, {
+        stop_namespace = "kong.plugins.oauth2.migrations",
+        stop_migration = "004_200_to_210",
+      })
+    end)
+
+    it("adds columns", function()
+      local cn = db.connector
+      h.assert_not_c_has_column(cn, "oauth2_authorization_codes", "challenge", "text")
+      h.assert_not_c_has_column(cn, "oauth2_authorization_codes", "challenge_method", "text")
+      h.assert_not_c_has_column(cn, "oauth2_credentials", "client_type", "text")
+      h.assert_not_c_has_column(cn, "oauth2_credentials", "hash_secret", "boolean")
+
+      -- kong migrations up
+      assert(helpers.run_up_migration(db, "oauth2",
+                                      "kong.plugins.oauth2.migrations",
+                                      "004_200_to_210"))
+
+      h.assert_c_has_column(cn, "oauth2_authorization_codes", "challenge", "text")
+      h.assert_c_has_column(cn, "oauth2_authorization_codes", "challenge_method", "text")
+      h.assert_c_has_column(cn, "oauth2_credentials", "client_type", "text")
+      h.assert_c_has_column(cn, "oauth2_credentials", "hash_secret", "boolean")
+    end)
+
+    it("adds and sets ws_id", function()
+      local cn = db.connector
+      h.assert_not_c_has_fkey(cn, "basicauth-credentials", "ws_id")
+      -- kong migrations up
+      assert(helpers.run_up_migration(db, "basicauth-credentials",
+                                      "kong.plugins.oauth2.migrations",
+                                      "004_200_to_210"))
+
+      h.c_insert(cn, "oauth2_credentials", { id = utils.uuid(), client_id = "before-cred" })
+      h.c_insert(cn, "oauth2_authorization_codes", { id = utils.uuid(), code = "before-code" })
+      h.c_insert(cn, "oauth2_tokens", { id = utils.uuid(), refresh_token = "before-token", access_token = "before-token"  })
+
+      -- MIGRATING
+      h.assert_c_has_fkey(cn, "oauth2_credentials", "ws_id")
+
+      -- check default workspace exists and get its id
+      local res = assert(cn:query("SELECT * FROM workspaces"))
+      assert.equals(1, #res)
+      assert.equals("default", res[1].name)
+      assert.truthy(utils.is_valid_uuid(res[1].id))
+      local default_ws_id = res[1].id
+
+      -- the entities created by the old node don't get the ws_id (this is handled in DAO)
+      local bc = assert(cn:query("SELECT * FROM oauth2_credentials"))[1]
+      assert.is_nil(bc.ws_id)
+
+      local bac = assert(cn:query("SELECT * FROM oauth2_authorization_codes"))[1]
+      assert.is_nil(bac.ws_id)
+
+      local bt = assert(cn:query("SELECT * FROM oauth2_tokens"))[1]
+      assert.is_nil(bt.ws_id)
+
+      -- entities created by the old node don't get the default id in C*
+      -- (this is handled in the DAO)
+      local omc = h.c_insert(cn, "oauth2_credentials", { id = utils.uuid(), client_id = "old-migrating-cred" })
+      assert.is_nil(omc.ws_id)
+
+      local omac = h.c_insert(cn, "oauth2_authorization_codes", { id = utils.uuid(), code = "old-migrating-code" })
+      assert.is_nil(omac.ws_id)
+
+      local omt = h.c_insert(cn, "oauth2_tokens", { id = utils.uuid(), refresh_token = "old-migrating-token", access_token = "old-migrating-token"  })
+      assert.is_nil(omt.ws_id)
+
+      -- create specifying default ws_id.(simulate new node)
+      local nmc = h.c_insert(cn, "oauth2_credentials", { id = utils.uuid(), ws_id = default_ws_id, client_id = "new-migrating-cred" })
+      assert.equals(default_ws_id, nmc.ws_id)
+
+      local nmac = h.c_insert(cn, "oauth2_authorization_codes", { id = utils.uuid(), code = "new-migrating-code", ws_id = default_ws_id })
+      assert.equals(default_ws_id, nmac.ws_id)
+
+      local nmt = h.c_insert(cn, "oauth2_tokens", { id = utils.uuid(), refresh_token = "new-migrating-token", access_token = "new-migrating-token", ws_id = default_ws_id  })
+      assert.equals(default_ws_id, nmt.ws_id)
+
+      -- kong migrations finish
+      assert(helpers.run_teardown_migration(db, "oauth2",
+                                            "kong.plugins.oauth2.migrations",
+                                            "004_200_to_210"))
+
+      -- AFTER
+      -- create specifying default ws_id.(simulate new node)
+      local ac = h.c_insert(cn, "oauth2_credentials", { id = utils.uuid(), ws_id = default_ws_id, client_id="after-cred" })
+      assert.equals(default_ws_id, ac.ws_id)
+
+      local aac = h.c_insert(cn, "oauth2_authorization_codes", { id = utils.uuid(), ws_id = default_ws_id, code="after-code" })
+      assert.equals(default_ws_id, aac.ws_id)
+
+      local at = h.c_insert(cn, "oauth2_tokens", { id = utils.uuid(), ws_id = default_ws_id, access_token="after-token", refresh_token="after-token" })
+      assert.equals(default_ws_id, at.ws_id)
+
+      -- check all the entities with unique keys have been modified with the ws_id
+      bc = assert(cn:query(fmt("SELECT * from oauth2_credentials where id=%s", bc.id)))[1]
+      assert.same(default_ws_id, bc.ws_id)
+      assert.same(default_ws_id .. ":before-cred", bc.client_id)
+
+      bac = assert(cn:query(fmt("SELECT * from oauth2_authorization_codes where id=%s", bac.id)))[1]
+      assert.same(default_ws_id, bac.ws_id)
+      assert.same(default_ws_id .. ":before-code", bac.code)
+
+      bt = assert(cn:query(fmt("SELECT * from oauth2_tokens where id=%s", bt.id)))[1]
+      assert.same(default_ws_id, bt.ws_id)
+      assert.same(default_ws_id .. ":before-token", bt.access_token)
+      assert.same(default_ws_id .. ":before-token", bt.refresh_token)
+
+      omc = assert(cn:query(fmt("SELECT * from oauth2_credentials where id=%s", omc.id)))[1]
+      assert.same(default_ws_id, omc.ws_id)
+      assert.same(default_ws_id .. ":old-migrating-cred", omc.client_id)
+
+      omac = assert(cn:query(fmt("SELECT * from oauth2_authorization_codes where id=%s", omac.id)))[1]
+      assert.same(default_ws_id, omac.ws_id)
+      assert.same(default_ws_id .. ":old-migrating-code", omac.code)
+
+      omt = assert(cn:query(fmt("SELECT * from oauth2_tokens where id=%s", omt.id)))[1]
+      assert.same(default_ws_id, omt.ws_id)
+      assert.same(default_ws_id .. ":old-migrating-token", omt.access_token)
+      assert.same(default_ws_id .. ":old-migrating-token", omt.refresh_token)
+
+      nmc = assert(cn:query(fmt("SELECT * from oauth2_credentials where id=%s", nmc.id)))[1]
+      assert.same(default_ws_id, nmc.ws_id)
+      assert.same(default_ws_id .. ":new-migrating-cred", nmc.client_id)
+
+      nmac = assert(cn:query(fmt("SELECT * from oauth2_authorization_codes where id=%s", nmac.id)))[1]
+      assert.same(default_ws_id, nmac.ws_id)
+      assert.same(default_ws_id .. ":new-migrating-code", nmac.code)
+
+      nmt = assert(cn:query(fmt("SELECT * from oauth2_tokens where id=%s", nmt.id)))[1]
+      assert.same(default_ws_id, nmt.ws_id)
+      assert.same(default_ws_id .. ":new-migrating-token", nmt.access_token)
+      assert.same(default_ws_id .. ":new-migrating-token", nmt.refresh_token)
+    end)
+  end)
+end)

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -233,8 +233,22 @@ local function truncate_tables(db, tables)
   end
 end
 
-local function bootstrap_database(db)
-  local schema_state = assert(db:schema_state())
+-- @param stop_namespace string|nil A migrations namespace to stop at (example: "kong.db.migrations.core")
+--                                  Note that when the namespace is "kong.db.migrations.core", all other
+--                                  namespaces are not run (as plugin migrations might depend on non-existing
+--                                  core migrations).
+-- @param stop_migration string|nil A migrations name to stop at (example: "007_140_to_150")
+-- If stop_namespace/migration are not present, this will execute all available migrations and plugins
+-- that have not been executed
+local function bootstrap_database(db, stop_namespace, stop_migration)
+  -- If we are not migrating completely, start by removing all migrations
+  if stop_namespace then
+    assert(db:schema_reset())
+  end
+
+  -- if stop_namespace/migration are present, this will set schema_state.new_migrations
+  -- so that it only contains migrations up to (but not including) stop_migration.
+  local schema_state = assert(db:schema_state(stop_namespace, stop_migration))
   if schema_state.needs_bootstrap then
     assert(db:schema_bootstrap())
   end
@@ -247,6 +261,31 @@ local function bootstrap_database(db)
   end
 end
 
+
+local function run_migration(db, subsystem, namespace, mig_name, options)
+  return db:run_migrations(
+    {
+      {
+        subsystem = subsystem,
+        namespace = namespace,
+        migrations = {
+          { name = mig_name }
+        }
+      }
+    }, options)
+end
+
+
+local function run_up_migration(db, subsystem, namespace, mig_name)
+  return run_migration(db, subsystem, namespace, mig_name, { run_up = true })
+end
+
+
+local function run_teardown_migration(db, subsystem, namespace, mig_name)
+  return run_migration(db, subsystem, namespace, mig_name, { run_teardown = true })
+end
+
+
 --- Gets the database utility helpers and prepares the database for a testrun.
 -- This will a.o. bootstrap the datastore and truncate the existing data that
 -- migth be in it. The BluePrint returned can be used to create test entities
@@ -257,6 +296,9 @@ end
 -- @param tables (optional) tables to truncate, this can be used to accelarate
 -- tests if only a few tables are used. By default all tables will be truncated.
 -- @param plugins (optional) array of plugins to mark as loaded. Since kong will load all the bundled plugins by default, this is useful for mostly for marking custom plugins as loaded.
+-- @param options (optional) hash with the following entries:
+--        * `stop_namespace` migration namespace where migrations should stop (see boostrap_database)
+--        * `stop_migration` migration name where migrations should stop (see bootstrap_database)
 -- @return BluePrint, DB
 -- @usage
 -- local PLUGIN_NAME = "my_fancy_plugin"
@@ -273,8 +315,9 @@ end
 --   route = { id = route1.id },
 --   config = {},
 -- }
-local function get_db_utils(strategy, tables, plugins)
+local function get_db_utils(strategy, tables, plugins, options)
   strategy = strategy or conf.database
+  options = options or {}
   if tables ~= nil and type(tables) ~= "table" then
     error("arg #2 must be a list of tables to truncate", 2)
   end
@@ -298,7 +341,7 @@ local function get_db_utils(strategy, tables, plugins)
   local db = assert(DB.new(conf, strategy))
   assert(db:init_connector())
 
-  bootstrap_database(db)
+  bootstrap_database(db, options.stop_namespace, options.stop_migration)
 
   do
     local database = conf.database
@@ -2545,6 +2588,8 @@ end
   get_db_utils = get_db_utils,
   get_cache = get_cache,
   bootstrap_database = bootstrap_database,
+  run_up_migration = run_up_migration,
+  run_teardown_migration = run_teardown_migration,
   bin_path = BIN_PATH,
   test_conf = conf,
   test_conf_path = TEST_CONF_PATH,

--- a/spec/migration_helpers/200_to_210.lua
+++ b/spec/migration_helpers/200_to_210.lua
@@ -1,0 +1,259 @@
+-- Helper module for testing 200_to_210 migration operations.
+--
+-- Operations are versioned and specific to a migration so they remain
+-- fixed in time and are not modified for use in future migrations.
+--
+-- If you want to reuse these operations in a future migration,
+-- copy the functions over to a new versioned helper module.
+
+local fmt = string.format
+local cassandra = require "cassandra"
+local assert = require "luassert"
+
+local PG_HAS_COLUMN_SQL = [[
+  SELECT *
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+  AND table_name     = '%s'
+  AND column_name    = '%s';
+]]
+
+local PG_HAS_CONSTRAINT_SQL = [[
+  SELECT *
+  FROM pg_catalog.pg_constraint
+  WHERE conname = '%s';
+]]
+
+local PG_HAS_INDEX_SQL = [[
+  SELECT *
+  FROM pg_indexes
+  WHERE indexname = '%s';
+]]
+
+local PG_HAS_TABLE_SQL = [[
+  SELECT *
+  FROM pg_catalog.pg_tables
+  WHERE schemaname = 'public'
+  AND tablename = '%s';
+]]
+
+local _M = {}
+
+function _M.assert_pg_has_column(cn, table_name, column_name, data_type)
+  local res = assert(cn:query(fmt(PG_HAS_COLUMN_SQL, table_name, column_name)))
+
+  assert.equals(1, #res)
+  assert.equals(column_name, res[1].column_name)
+  assert.equals(string.lower(data_type), string.lower(res[1].data_type))
+end
+
+
+function _M.assert_not_pg_has_column(cn, table_name, column_name, data_type)
+  local res = assert(cn:query(fmt(PG_HAS_COLUMN_SQL, table_name, column_name)))
+  assert.same({}, res)
+end
+
+
+function _M.assert_pg_has_constraint(cn, constraint_name)
+  local res = assert(cn:query(fmt(PG_HAS_CONSTRAINT_SQL, constraint_name)))
+
+  assert.equals(1, #res)
+  assert.equals(constraint_name, res[1].conname)
+end
+
+
+function _M.assert_not_pg_has_constraint(cn, constraint_name)
+  local res = assert(cn:query(fmt(PG_HAS_CONSTRAINT_SQL, constraint_name)))
+  assert.same({}, res)
+end
+
+
+function _M.assert_pg_has_index(cn, index_name)
+  local res = assert(cn:query(fmt(PG_HAS_INDEX_SQL, index_name)))
+
+  assert.equals(1, #res)
+  assert.equals(index_name, res[1].indexname)
+end
+
+
+function _M.assert_not_pg_has_index(cn, index_name)
+  local res = assert(cn:query(fmt(PG_HAS_INDEX_SQL, index_name)))
+  assert.same({}, res)
+end
+
+
+function _M.assert_pg_has_fkey(cn, table_name, column_name)
+  _M.assert_pg_has_column(cn, table_name, column_name, "uuid")
+  _M.assert_pg_has_constraint(cn, table_name .. "_" .. column_name .. "_fkey")
+end
+
+
+function _M.assert_not_pg_has_fkey(cn, table_name, column_name)
+  _M.assert_not_pg_has_column(cn, table_name, column_name, "uuid")
+  _M.assert_not_pg_has_constraint(cn, table_name .. "_" .. column_name .. "_fkey")
+end
+
+
+function _M.assert_pg_has_table(cn, table_name)
+  local res = assert(cn:query(fmt(PG_HAS_TABLE_SQL, table_name)))
+
+  assert.equals(1, #res)
+  assert.equals(table_name, res[1].tablename)
+end
+
+
+function _M.assert_not_pg_has_table(cn, table_name)
+  local res = assert(cn:query(fmt(PG_HAS_TABLE_SQL, table_name)))
+  assert.same({}, res)
+end
+
+
+function _M.pg_insert(cn, table_name, tbl)
+  local columns, values = {},{}
+  for k,_ in pairs(tbl) do
+    columns[#columns + 1] = k
+  end
+  table.sort(columns)
+  for i, c in ipairs(columns) do
+    local v = tbl[c]
+    v = type(v) == "string" and "'" .. v .. "'" or v
+    values[i] = tostring(v)
+  end
+  local sql = fmt([[
+    INSERT INTO %s (%s) VALUES (%s)
+  ]],
+    table_name,
+    table.concat(columns, ","),
+    table.concat(values, ",")
+  )
+
+  local res = assert(cn:query(sql))
+
+  assert.same({ affected_rows = 1 }, res)
+
+  return assert(cn:query(fmt("SELECT * FROM %s WHERE id='%s'", table_name, tbl.id)))[1]
+end
+
+---------------------
+
+local C_TABLE_HAS_COLUMN_CQL = [[
+  SELECT * FROM system_schema.columns
+  WHERE keyspace_name = '%s'
+  AND table_name = '%s'
+  AND column_name = '%s'
+  ALLOW FILTERING;
+]]
+
+local C_HAS_INDEX_CQL = [[
+  SELECT * FROM system_schema.indexes
+  WHERE keyspace_name='%s'
+  AND table_name='%s'
+  AND index_name='%s'
+]]
+
+local C_HAS_TABLE_CQL = [[
+  SELECT * FROM system_schema.tables
+  WHERE keyspace_name='%s'
+  AND table_name = '%s';
+]]
+
+
+function _M.assert_not_c_has_column(cn, table_name, column_name)
+  local res = assert(cn:query(fmt(C_TABLE_HAS_COLUMN_CQL, cn.keyspace, table_name, column_name)))
+  assert.equals(0, #res)
+  assert.same({ has_more_pages = false }, res.meta)
+end
+
+
+function _M.assert_c_has_column(cn, table_name, column_name, column_type)
+  local res = assert(cn:query(fmt(C_TABLE_HAS_COLUMN_CQL, cn.keyspace, table_name, column_name)))
+  assert.equals(1, #res)
+  assert.equals(column_name, res[1].column_name)
+  assert.equals(column_type, res[1].type)
+  assert.same({ has_more_pages = false }, res.meta)
+  return res[1]
+end
+
+
+function _M.assert_not_c_has_index(cn, table_name, index_name)
+  local res = assert(cn:query(fmt(C_HAS_INDEX_CQL, cn.keyspace, table_name, index_name)))
+  assert.equals(0, #res)
+  assert.same({ has_more_pages = false }, res.meta)
+end
+
+
+function _M.assert_c_has_index(cn, table_name, index_name)
+  local cql = fmt(C_HAS_INDEX_CQL, cn.keyspace, table_name, index_name)
+  local res = assert(cn:query(cql))
+  assert.equals(1, #res)
+  assert.equals(index_name, res[1].index_name)
+  assert.same({ has_more_pages = false }, res.meta)
+  return res[1]
+end
+
+
+function _M.assert_not_c_has_fkey(cn, table_name, column_name)
+  _M.assert_not_c_has_column(cn, table_name, column_name, "uuid")
+  _M.assert_not_c_has_index(cn, table_name, table_name .. "_" .. column_name .. "_idx")
+end
+
+
+function _M.assert_c_has_fkey(cn, table_name, column_name)
+  local res = _M.assert_c_has_column(cn, table_name, column_name, "uuid")
+  _M.assert_c_has_index(cn, table_name, table_name .. "_" .. column_name .. "_idx")
+  return res
+end
+
+
+function _M.assert_not_c_has_table(cn, table_name)
+  local res = assert(cn:query(fmt(C_HAS_TABLE_CQL, cn.keyspace, table_name)))
+  assert.equals(0, #res)
+  assert.same({ has_more_pages = false }, res.meta)
+end
+
+
+function _M.assert_c_has_table(cn, table_name)
+  local res = assert(cn:query(fmt(C_HAS_TABLE_CQL, cn.keyspace, table_name)))
+  assert.equals(1, #res)
+  assert.equals(table_name, res[1].table_name)
+  assert.same({ has_more_pages = false }, res.meta)
+  return res[1]
+end
+
+
+function _M.c_insert(cn, table_name, tbl)
+  local columns, bindings, values = {},{},{}
+  for k,_ in pairs(tbl) do
+    columns[#columns + 1] = k
+  end
+  table.sort(columns)
+  for i, c in ipairs(columns) do
+    bindings[#bindings + 1] = "?"
+    local v = tbl[c]
+    if c ~= "custom_id" and c:sub(-2) == "id" then
+      v = cassandra.uuid(v)
+    end
+    values[i] = v
+  end
+
+  local cql = fmt([[
+    INSERT INTO %s(%s) VALUES(%s)
+  ]],
+    table_name,
+    table.concat(columns, ", "),
+    table.concat(bindings, ", ")
+  )
+  local res = assert(cn:query(cql, values))
+
+  assert.same({ type = "VOID" }, res)
+
+  if tbl.partition then
+    return assert(cn:query(fmt("SELECT * FROM %s WHERE partition=? AND id=?", table_name),
+                           { tbl.partition, cassandra.uuid(tbl.id) }))[1]
+  end
+
+  return assert(cn:query(fmt("SELECT * FROM %s WHERE id=?", table_name),
+                         { cassandra.uuid(tbl.id) }))[1]
+end
+
+return _M

--- a/spec/migration_helpers/200_to_210.lua
+++ b/spec/migration_helpers/200_to_210.lua
@@ -230,7 +230,7 @@ function _M.c_insert(cn, table_name, tbl)
   for i, c in ipairs(columns) do
     bindings[#bindings + 1] = "?"
     local v = tbl[c]
-    if c ~= "custom_id" and c:sub(-2) == "id" then
+    if c ~= "custom_id" and c ~= "client_id" and c:sub(-2) == "id" then
       v = cassandra.uuid(v)
     end
     values[i] = v


### PR DESCRIPTION
This PR aglutinates several things into one.

* Introduces a way to partially migrate the database, and introduces a couple helper functions
* Adds "unit tests" for the core/007 migration, as a "proof of concept"
* Adds "unit tests" for the 200_to_210 migrations, for core and for the plugins

This way of testing has two big disadvantages:
* We are _testing mocks_ here. We are not testing how Kong behaves, but how *we think* kong behaves, by putting what we _think_ it does in the database, then running the migrations, and checking what we _think_ should be in the database is there.
* We are not capable of testing what Kong does on the DAO-level in order to work in tandem with the migrations; only direct changes to the database are testable.

A much more thorough way to do this would be to instantiate one (or several!) nodes of kong in 2.0.0 and 2.1.0, and use the Admin API exclusively to do tests. This is in fact what we have done in the past, in https://github.com/Kong/kong-upgrade-tests. But this way of testing had problems of its own:
* It required pushing code to a branch in order to test migrations
* Tests run very slowly and had lots of infra dependencies (gojira, which in turn needs docker)

In contrast, this way of testing:
* Is very fast to run (seconds vs minutes).
* You can write tests while you write migrations, no change of environment, writing tests as you are used to.
* Fast feedback as a result.
* Helps avoiding "stupid mistakes" (e.g. a typo in a column name) quickly.
* Can be used in conjunction with the other tests. In fact, since you don't need to write all migration tests as integration tests any more (no need to test that a column was added), it makes the migration tests faster to run.

