### PR TITLE
docs(clustering) add settings defined by Hybrid Mode PKI

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -195,7 +195,7 @@
                                  # between control and data plane nodes.
                                  # You can use the `kong hybrid` command to
                                  # generate the certificate/key pair.
-                                 # Under `shared` mode, is must be the same
+                                 # Under `shared` mode, it must be the same
                                  # for all nodes.  Under `pki` mode it
                                  # should be a different certificate for each
                                  # DP node.

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -205,7 +205,7 @@
                                  # between control and data plane nodes.
                                  # You can use the `kong hybrid` command to
                                  # generate the certificate/key pair.
-                                 # Under `shared` mode, is must be the same
+                                 # Under `shared` mode, it must be the same
                                  # for all nodes.  Under `pki` mode it
                                  # should be a different certificate for each
                                  # DP node.

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -184,11 +184,12 @@
                                  #   Note that CP and DP nodes have to present
                                  #   the same certificate to establish mTLS
                                  #   connections.
-                                 # - `pki`: use `cluster_ca_cert` and
-                                 #   `cluster_server_name` for verification,
-                                 #   these are different certificates for each
+                                 # - `pki`: use `cluster_ca_cert`,
+                                 #   `cluster_server_name` and `cluster_cert`
+                                 #   for verification.
+                                 #   These are different certificates for each
                                  #   DP node, but issued by a cluster-wide
-                                 #   common CA certificate: `cluster_ca_cert`
+                                 #   common CA certificate: `cluster_ca_cert`.
 
 #cluster_cert =                  # Filename of the cluster certificate to use
                                  # when establishing secure communication

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -173,17 +173,56 @@
                                  #   It runs DB-less and receives configuration
                                  #   updates from a control plane node.
 
+#cluster_mtls = shared           # Sets the verification between nodes of the
+                                 # cluster.
+                                 #
+                                 # Valid values to this setting are:
+                                 #
+                                 # - `shared`: use a shared certificate/key
+                                 #   pair specified with the `cluster_cert`
+                                 #   and `cluster_cert_key` settings.
+                                 #   Note that CP and DP nodes have to present
+                                 #   the same certificate to establish mTLS
+                                 #   connections.
+                                 # - `pki`: use `cluster_ca_cert` and
+                                 #   `cluster_server_name` for verification,
+                                 #   these are different certificates for each
+                                 #   DP node, but issued by a cluster-wide
+                                 #   common CA certificate: `cluster_ca_cert`
+
 #cluster_cert =                  # Filename of the cluster certificate to use
                                  # when establishing secure communication
                                  # between control and data plane nodes.
                                  # You can use the `kong hybrid` command to
                                  # generate the certificate/key pair.
+                                 # Under `shared` mode, is must be the same
+                                 # for all nodes.  Under `pki` mode it
+                                 # should be a different certificate for each
+                                 # DP node.
 
 #cluster_cert_key =              # Filename of the cluster certificate key to
                                  # use when establishing secure communication
                                  # between control and data plane nodes.
                                  # You can use the `kong hybrid` command to
                                  # generate the certificate/key pair.
+                                 # Under `shared` mode, is must be the same
+                                 # for all nodes.  Under `pki` mode it
+                                 # should be a different certificate for each
+                                 # DP node.
+
+#cluster_ca_cert =               # The trusted CA certificate file in PEM
+                                 # format used to verify the `cluster_cert`.
+                                 # Required if `cluster_mtls` is set to `pki`,
+                                 # ignored otherwise.
+
+#cluster_server_name =           # The server name used in the SNI of the TLS
+                                 # connection from a DP node to a CP node.
+                                 # Must match the Common Name (CN) or Subject
+                                 # Alternative Name (SAN) found in the CP
+                                 # certificate.
+                                 # If `cluster_mtls` is set to
+                                 # `shared`, this setting is ignored and
+                                 # `kong_clustering` is used.
 
 #cluster_control_plane =         # To be used by data plane nodes only:
                                  # address of the control plane node from


### PR DESCRIPTION
Document new settings for Hybrid Mode PKI

Shamelessly copied from https://github.com/Kong/docs.konghq.com/compare/docs/hybrid-mode-pki
