### PR TITLE
fix(rate-limit) perform atomic redis increments

### DIFF
--- a/kong/plugins/rate-limiting/policies/init.lua
+++ b/kong/plugins/rate-limiting/policies/init.lua
@@ -51,6 +51,52 @@ local sock_opts = {}
 local EXPIRATION = require "kong.plugins.rate-limiting.expiration"
 
 
+local function get_redis_connection(conf)
+  local red = redis:new()
+  red:set_timeout(conf.redis_timeout)
+  -- use a special pool name only if redis_database is set to non-zero
+  -- otherwise use the default pool name host:port
+  sock_opts.pool = conf.redis_database and
+                    conf.redis_host .. ":" .. conf.redis_port ..
+                    ":" .. conf.redis_database
+  local ok, err = red:connect(conf.redis_host, conf.redis_port,
+                              sock_opts)
+  if not ok then
+    kong.log.err("failed to connect to Redis: ", err)
+    return nil, err
+  end
+
+  local times, err = red:get_reused_times()
+  if err then
+    kong.log.err("failed to get connect reused times: ", err)
+    return nil, err
+  end
+
+  if times == 0 then
+    if is_present(conf.redis_password) then
+      local ok, err = red:auth(conf.redis_password)
+      if not ok then
+        kong.log.err("failed to auth Redis: ", err)
+        return nil, err
+      end
+    end
+
+    if conf.redis_database ~= 0 then
+      -- Only call select first time, since we know the connection is shared
+      -- between instances that use the same redis database
+
+      local ok, err = red:select(conf.redis_database)
+      if not ok then
+        kong.log.err("failed to change Redis database: ", err)
+        return nil, err
+      end
+    end
+  end
+
+  return red
+end
+
+
 return {
   ["local"] = {
     increment = function(conf, limits, identifier, current_timestamp, value)
@@ -118,79 +164,29 @@ return {
   },
   ["redis"] = {
     increment = function(conf, limits, identifier, current_timestamp, value)
-      local red = redis:new()
-      red:set_timeout(conf.redis_timeout)
-      -- use a special pool name only if redis_database is set to non-zero
-      -- otherwise use the default pool name host:port
-      sock_opts.pool = conf.redis_database and
-                       conf.redis_host .. ":" .. conf.redis_port ..
-                       ":" .. conf.redis_database
-      local ok, err = red:connect(conf.redis_host, conf.redis_port,
-                                  sock_opts)
-      if not ok then
-        kong.log.err("failed to connect to Redis: ", err)
+      local red, err = get_redis_connection(conf)
+      if not red then
         return nil, err
       end
 
-      local times, err = red:get_reused_times()
-      if err then
-        kong.log.err("failed to get connect reused times: ", err)
-        return nil, err
-      end
-
-      if times == 0 then
-        if is_present(conf.redis_password) then
-          local ok, err = red:auth(conf.redis_password)
-          if not ok then
-            kong.log.err("failed to auth Redis: ", err)
-            return nil, err
-          end
-        end
-
-        if conf.redis_database ~= 0 then
-          -- Only call select first time, since we know the connection is shared
-          -- between instances that use the same redis database
-
-          local ok, err = red:select(conf.redis_database)
-          if not ok then
-            kong.log.err("failed to change Redis database: ", err)
-            return nil, err
-          end
-        end
-      end
-
-      local keys = {}
-      local expirations = {}
-      local idx = 0
       local periods = timestamp.get_timestamps(current_timestamp)
+      red:init_pipeline()
       for period, period_date in pairs(periods) do
         if limits[period] then
           local cache_key = get_local_key(conf, identifier, period, period_date)
-          local exists, err = red:exists(cache_key)
-          if err then
-            kong.log.err("failed to query Redis: ", err)
-            return nil, err
-          end
 
-          idx = idx + 1
-          keys[idx] = cache_key
-          if not exists or exists == 0 then
-            expirations[idx] = EXPIRATION[period]
-          end
+          red:eval([[
+            local key, value, expiration = KEYS[1], tonumber(ARGV[1]), ARGV[2]
+
+            if redis.call("incrby", key, value) == value then
+              redis.call("expire", key, expiration)
+            end
+          ]], 1, cache_key, value, EXPIRATION[period])
         end
       end
-
-      red:init_pipeline()
-      for i = 1, idx do
-        red:incrby(keys[i], value)
-        if expirations[i] then
-          red:expire(keys[i], expirations[i])
-        end
-      end
-
       local _, err = red:commit_pipeline()
       if err then
-        kong.log.err("failed to commit pipeline in Redis: ", err)
+        kong.log.err("failed to commit pipeline in Resit: ", err)
         return nil, err
       end
 
@@ -203,46 +199,9 @@ return {
       return true
     end,
     usage = function(conf, identifier, period, current_timestamp)
-      local red = redis:new()
-
-      red:set_timeout(conf.redis_timeout)
-      -- use a special pool name only if redis_database is set to non-zero
-      -- otherwise use the default pool name host:port
-      sock_opts.pool = conf.redis_database and
-                       conf.redis_host .. ":" .. conf.redis_port ..
-                       ":" .. conf.redis_database
-      local ok, err = red:connect(conf.redis_host, conf.redis_port,
-                                  sock_opts)
-      if not ok then
-        kong.log.err("failed to connect to Redis: ", err)
+      local red, err = get_redis_connection(conf)
+      if not red then
         return nil, err
-      end
-
-      local times, err = red:get_reused_times()
-      if err then
-        kong.log.err("failed to get connect reused times: ", err)
-        return nil, err
-      end
-
-      if times == 0 then
-        if is_present(conf.redis_password) then
-          local ok, err = red:auth(conf.redis_password)
-          if not ok then
-            kong.log.err("failed to auth Redis: ", err)
-            return nil, err
-          end
-        end
-
-        if conf.redis_database ~= 0 then
-          -- Only call select first time, since we know the connection is shared
-          -- between instances that use the same redis database
-
-          local ok, err = red:select(conf.redis_database)
-          if not ok then
-            kong.log.err("failed to change Redis database: ", err)
-            return nil, err
-          end
-        end
       end
 
       reports.retrieve_redis_version(red)


### PR DESCRIPTION
The increment function of the Redis policy first gathers which relevant
keys actually exist, and then executes all the INCRBY/EXPIRE operations.
This has a window of error between the existence check and the
(optional) EXPIRE operation.

A solution documented in the Redis documentation
(https://redis.io/commands/incr) is to use a Lua operation in the Redis
server, which operates atomically.

Fixes #5763
