### PR TITLE
Fix to be made 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,6 @@ pipeline {
     }
     options {
         retry(1)
-        parallelsAlwaysFailFast()
         timeout(time: 2, unit: 'HOURS')
     }
     environment {


### PR DESCRIPTION
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all will be helpful:

https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing

Summary
This PR is an extension.
Extended the plugin to enabled proxy option for enterprises where requests are routed via enterprise proxy.

Full changelog
Added plugins config flag proxy_url and proxy_scheme to kong.plugins.aws-lambda.schema
Added self_check function to check whether proxy_url is set, if yes, check whether proxy_scheme is set.
Updated kong.plugins.v4.lua to use openssl library instead of crpto
Updated kong.plugins.iam-role-credentials.lua to make 169.254.169.254 to go via proxy only.
Added check for proxy url. if set, http connect uses connect_proxy else uses normal connect. Also changed the upstream_body attributes to match/align that of aws lambda implementations i.e upstream_body.httpMethod, upstream_body.headers, upstream_body.path, upstream_body.queryStringParameters and upstream_body.body