### PR TITLE
feat(oauth2) authenticate consumer on token provision

### DIFF
--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -86,6 +86,36 @@ do
   end
 end
 
+local function load_oauth2_credential_into_memory(credential_id)
+  local result, err = kong.db.oauth2_credentials:select { id = credential_id }
+  if err then
+    return nil, err
+  end
+
+  return result
+end
+
+local function load_credential_and_consumer_into_memory_from_credential(credential)
+  -- Retrieve the credential from the token credentials
+  local credential_cache_key =
+    kong.db.oauth2_credentials:cache_key(credential.id)
+
+  local cred, err = kong.cache:get(credential_cache_key, nil,
+                                   load_oauth2_credential_into_memory,
+                                   credential.id)
+  if err then
+    return nil, nil, err
+  end
+
+  -- Retrieve the consumer from the credential
+  local consumer_cache_key, consumer
+  consumer_cache_key = kong.db.consumers:cache_key(cred.consumer.id)
+  consumer, err      = kong.cache:get(consumer_cache_key, nil,
+                                      kong.client.load_consumer,
+                                      cred.consumer.id)
+
+  return cred, consumer, err
+end
 
 local function generate_token(conf, service, credential, authenticated_userid,
                               scope, state, disable_refresh, existing_token)
@@ -137,6 +167,14 @@ local function generate_token(conf, service, credential, authenticated_userid,
 
   if err then
     return error(err)
+  end
+
+  --Authenticate the consumer and credentials generating the token
+  local cred, consumer, err2 =
+  load_credential_and_consumer_into_memory_from_credential(credential)
+
+  if not err2 then
+    kong.client.authenticate(consumer, cred)
   end
 
   return {
@@ -1011,23 +1049,10 @@ local function do_authentication(conf)
     end
   end
 
-  -- Retrieve the credential from the token
-  local credential_cache_key =
-    kong.db.oauth2_credentials:cache_key(token.credential.id)
+  -- Retrieve the credential from the token credential
+  local credential, consumer, err =
+  load_credential_and_consumer_into_memory_from_credential(token.credential)
 
-  local credential, err = kong.cache:get(credential_cache_key, nil,
-                                         load_oauth2_credential_into_memory,
-                                         token.credential.id)
-  if err then
-    return error(err)
-  end
-
-  -- Retrieve the consumer from the credential
-  local consumer_cache_key, consumer
-  consumer_cache_key = kong.db.consumers:cache_key(credential.consumer.id)
-  consumer, err      = kong.cache:get(consumer_cache_key, nil,
-                                      kong.client.load_consumer,
-                                      credential.consumer.id)
   if err then
     return error(err)
   end

--- a/spec/03-plugins/25-oauth2/03-access_spec.lua
+++ b/spec/03-plugins/25-oauth2/03-access_spec.lua
@@ -15,6 +15,7 @@ local ngx_encode_base64 = ngx.encode_base64
 
 local kong = {
   table = require("kong.pdk.table").new()
+  client = require("kong.pdk.client").new()
 }
 
 
@@ -83,6 +84,8 @@ local function provision_token(host, extra_headers, client_id, client_secret, co
   assert.response(res).has.status(200)
   local token = assert.response(res).has.jsonbody()
   assert.is_table(token)
+  --Validate authenticated consumer context post token provision
+  assert.is_table(kong.client.get_consumer())
   request_client:close()
   return token
 end


### PR DESCRIPTION
### Summary

Old Related PR: #4197

Would really like this functionality to make it into mainstream Kong so I can stop maintaining a side patch file of ```access.lua``` I drop into our code every time to achieve this enhanced functionality for token generation around finding which customers abuse token generation. Cool with renaming functions or w/e is necessary too. Unsure if the unit test will work(didn't test it, but I know the code works currently as we run it in production).  

### Full changelog

* Implement authenticating the consumer during the token provision process which helps with logging analytics on who generates too many tokens.
* Validate the consumer context post token generation in unit tests using the ```kong.client``` pdk.

### Issues resolved

Fix #5958