### PR TITLE
feat(oauth2) authenticate consumer on token provision

### DIFF
--- a/spec/03-plugins/25-oauth2/03-access_spec.lua
+++ b/spec/03-plugins/25-oauth2/03-access_spec.lua
@@ -14,7 +14,8 @@ local ngx_encode_base64 = ngx.encode_base64
 
 
 local kong = {
-  table = require("kong.pdk.table").new()
+  table = require("kong.pdk.table").new(),
+  client = require("kong.pdk.client").new(),
 }
 
 
@@ -83,6 +84,8 @@ local function provision_token(host, extra_headers, client_id, client_secret, co
   assert.response(res).has.status(200)
   local token = assert.response(res).has.jsonbody()
   assert.is_table(token)
+  --Validate authenticated consumer context post token provision
+  assert.is_table(kong.client.get_consumer())
   request_client:close()
   return token
 end


### PR DESCRIPTION
### Summary

Old Related PR: #4197

Would really like this functionality to make it into mainstream Kong so I can stop maintaining a side patch file of ```access.lua``` I drop into our code every time to achieve this enhanced functionality for token generation around finding which customers abuse token generation. Cool with renaming functions or w/e is necessary too. Unsure if the unit test will work(didn't test it, but I know the code works currently as we run it in production).  

### Full changelog

* Implement authenticating the consumer during the token provision process which helps with logging analytics on who generates too many tokens.
* Validate the consumer context post token generation in unit tests using the ```kong.client``` pdk.

### Issues resolved

Fix #5958