### PR TITLE
fix(handler) convert collectgarbage output to bytes

### DIFF
--- a/kong/pdk/node.lua
+++ b/kong/pdk/node.lua
@@ -199,6 +199,7 @@ local function new(self)
                   pid .. "): reported value is corrupted"
 
         else
+          count = count * 1024 -- reported value is in kb
           w.http_allocated_gc = convert_bytes(count, unit, scale)
         end
 

--- a/t/01-pdk/12-node/02-get_memory_stats.t
+++ b/t/01-pdk/12-node/02-get_memory_stats.t
@@ -109,8 +109,8 @@ lua_shared_dicts
   \S+: \d+\/2[45]\d{3}
   \S+: \d+\/3[23]\d{3}
 workers_lua_vms
-  1: 1234
-  2: 1234
+  1: 1263616
+  2: 1263616
   (?:\d+: \d+\s*){1,2}
 --- no_error_log
 [error]
@@ -434,5 +434,49 @@ GET /t
 --- response_body_like chomp
 \Alua_shared_dicts
 workers_lua_vms\Z
+--- no_error_log
+[error]
+
+
+
+=== TEST 10: node.get_memory_stats() converts count to bytes
+--- http_config eval
+qq{
+    $t::Util::HttpConfig
+
+    lua_shared_dict kong 24k;
+
+    init_worker_by_lua_block {
+        -- mock collectgarbage returning 1kb as total memory in use by the Lua VM
+        old_collect_garbage = collectgarbage
+        collectgarbage = function(opt)
+          if opt == "count" then return 1 end
+          return old_collect_garbage
+        end
+
+        local runloop_handler = require "kong.runloop.handler"
+        runloop_handler._update_lua_mem(true)
+    }
+}
+--- config
+    location = /t {
+        content_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            local res = pdk.node.get_memory_stats()
+
+            ngx.say("workers_lua_vms")
+            for _, worker_info in ipairs(res.workers_lua_vms) do
+                ngx.say("  ", worker_info.pid, ": ",
+                        worker_info.http_allocated_gc or worker_info.err)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body_like chomp
+workers_lua_vms
+  (?:\d+: 1024\s*){1,2}\Z
 --- no_error_log
 [error]


### PR DESCRIPTION
Fix issue where memory in use as reported by the `/status`
endpoint would be treated as `bytes`, while the output of
`collectgarbage("count")` is given in kbytes.

CHANGELOG:
- Fix issue where consumed worker memory as reported by `/status` would be incorrectly reported