### PR TITLE
fix(schema) add RFC 3986 "sub-delims" characters as valid inside path…

### DIFF
--- a/kong/db/schema/typedefs.lua
+++ b/kong/db/schema/typedefs.lua
@@ -76,7 +76,10 @@ end
 
 
 local function validate_path(path)
-  if not match(path, "^/[%w%.%-%_~%/%%]*$") then
+  if not match(path, "^/[%w%.%-%_%~%/%%%:%@" ..
+                     "%!%$%&%'%(%)%*%+%,%;%=" .. -- RFC 3986 "sub-delims"
+                     "]*$")
+  then
     return nil,
            "invalid path: '" .. path ..
            "' (characters outside of the reserved list of RFC 3986 found)",
@@ -89,7 +92,7 @@ local function validate_path(path)
 
     if raw:find("%", nil, true) then
       local err = raw:sub(raw:find("%%.?.?"))
-      return nil, "invalid url-encoded value: '" .. err .. "'"
+      return nil, "invalid url-encoded value: '" .. err .. "'", "percent"
     end
   end
 
@@ -394,14 +397,21 @@ end
 
 local function validate_path_with_regexes(path)
 
-
   local ok, err, err_code = typedefs.path.custom_validator(path)
 
-  if ok or err_code ~= "rfc3986" then
+  if err_code == "percent" then
     return ok, err, err_code
   end
 
-  -- URI contains characters outside of the reserved list of RFC 3986:
+  -- We can't take an ok from validate_path as a success just yet,
+  -- because the router is currently more strict than RFC 3986 for
+  -- non-regex paths:
+  if ngx.re.find(path, [[^[a-zA-Z0-9\.\-_~/%]*$]]) then
+    return true
+  end
+
+  -- URI contains characters outside of the list recognized by the
+  -- router as valid non-regex paths.
   -- the value will be interpreted as a regex by the router; but is it a
   -- valid one? Let's dry-run it with the same options as our router.
   local _, _, err = ngx.re.find("", path, "aj")

--- a/spec/01-unit/01-db/01-schema/05-services_spec.lua
+++ b/spec/01-unit/01-db/01-schema/05-services_spec.lua
@@ -190,9 +190,8 @@ describe("services", function()
 
     it("rejects regular expressions & other non-rfc 3986 chars", function()
       local invalid_paths = {
-        [[/users/(foo/profile]],
-        [[/users/(foo/profile)]],
-        [[/users/*/foo]],
+        [[/users/|foo/profile]],
+        [[/users/(this|foo/profile)]],
       }
 
       for i = 1, #invalid_paths do
@@ -207,6 +206,19 @@ describe("services", function()
                      "' (characters outside of the reserved list of RFC 3986 found)",
                      err.path)
       end
+    end)
+
+    it("accepts \"sub-delims\" characters from RFC 3986 (#6125)", function()
+      local service = {
+        host = "example.com",
+        port = 80,
+        protocol = "http",
+        path = "/hello/path$with$!&'()*+,;=stuff",
+      }
+
+      local ok, err = Services:validate(service)
+      assert.is_nil(err)
+      assert.is_true(ok)
     end)
 
     it("rejects badly percent-encoded values", function()


### PR DESCRIPTION
… segments

fixes #6125

New concerns:

Currently Kong doesn't explicitly distinguish between regex and plain paths. That is, we guess whether a path is regex or plain path by using this regex: https://github.com/Kong/kong/blob/master/kong/router.lua#L425. If the path didn't match it is considered as regex path and fed into the PCRE engine.

With this change, a lot of these urls will be considered as "plain" path and no longer go through PCRE. So this will be a breaking change (test failures inside `spec/01-unit/08-router_spec.lua` as well), which makes me hesitate if there is a better way to do it.

Use Nginx as an example, the matching between regex and plain paths are explicit by the `~` operator like this:
* `location /foo` (Plain)
* `location ~ /foo` (Regex)

I wonder if we should start doing the same. If not, adding just the characters that has no special meanings in regexs is a safer route at this moment.