### PR TITLE
chore(deps) bump penlight from 1.7.0 to 1.9.2

### DIFF
--- a/kong-2.1.4-0.rockspec
+++ b/kong-2.1.4-0.rockspec
@@ -14,7 +14,7 @@ dependencies = {
   "inspect == 3.1.1",
   "luasec == 0.9",
   "luasocket == 3.0-rc1",
-  "penlight == 1.7.0",
+  "penlight == 1.8.0",
   "lua-resty-http == 0.15",
   "lua-resty-jit-uuid == 0.0.7",
   "lua-ffi-zlib == 0.5",

--- a/kong-2.1.4-0.rockspec
+++ b/kong-2.1.4-0.rockspec
@@ -14,7 +14,7 @@ dependencies = {
   "inspect == 3.1.1",
   "luasec == 0.9",
   "luasocket == 3.0-rc1",
-  "penlight == 1.8.0",
+  "penlight == 1.9.2",
   "lua-resty-http == 0.15",
   "lua-resty-jit-uuid == 0.0.7",
   "lua-ffi-zlib == 0.5",


### PR DESCRIPTION
### Summary  1.8.0 -> 1.9.2

#### Fixes
  
  - In pl.class, _init can now be inherited from grandparent (or older ancestor) classes. #289
  - Fixes dir, lexer, and permute to no longer use coroutines. #344


### Summary  1.7.0 -> 1.8.0

#### New features

  - `pretty.debug` quickly dumps a set of values to stdout for debug purposes

#### Changes

  - `pretty.write`: now also sorts non-string keys [#319](https://github.com/Tieske/Penlight/pull/319)
  - `stringx.count` has an extra option to allow overlapping matches [#326](https://github.com/Tieske/Penlight/pull/326)
  - added an extra changelog entry for `types.is_empty` on the 1.6.0 changelog, due to additional fixed behaviour not called out appropriately [#313](https://github.com/Tieske/Penlight/pull/313)
  - `path.packagepath` now returns a proper error message with names tried if it fails

#### Fixes

  - Fix: `stringx.rfind` now properly works with overlapping matches [#314](https://github.com/Tieske/Penlight/pull/314)
  - Fix: `package.searchpath` (in module `pl.compat`) [#328](https://github.com/Tieske/Penlight/pull/328)
  - Fix: `path.isabs` now reports drive + relative-path as `false`, eg. "c:some/path" (Windows only)
  - Fix: OpenResty coroutines, used by `dir.dirtree`, `pl.lexer`, `pl.permute`. If available the original coroutine functions are now used [#329](https://github.com/Tieske/Penlight/pull/329)
  - Fix: in `pl.strict` also predefine global `_PROMPT2`
  - Fix: in `pl.strict` apply `tostring` to the given name, in case it is not a string.
  - Fix: the lexer would not recognize numbers without leading zero; "-.123", see [#315](https://github.com/Tieske/Penlight/issues/315)