### PR TITLE
fix(proxy/pdk) X-Forwarded-Prefix / X-Forwarded-Path fix

### DIFF
--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -85,6 +85,7 @@ local constants = {
     CONSUMER_GROUPS = "X-Consumer-Groups",
     AUTHENTICATED_GROUPS = "X-Authenticated-Groups",
     FORWARDED_HOST = "X-Forwarded-Host",
+    FORWARDED_PATH = "X-Forwarded-Path",
     FORWARDED_PREFIX = "X-Forwarded-Prefix",
     ANONYMOUS = "X-Anonymous-Consumer",
     VIA = "Via",

--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -54,6 +54,7 @@ local function new(self)
   local X_FORWARDED_PROTO      = "X-Forwarded-Proto"
   local X_FORWARDED_HOST       = "X-Forwarded-Host"
   local X_FORWARDED_PORT       = "X-Forwarded-Port"
+  local X_FORWARDED_PATH       = "X-Forwarded-Path"
   local X_FORWARDED_PREFIX     = "X-Forwarded-Prefix"
 
 
@@ -252,18 +253,17 @@ local function new(self)
 
   ---
   -- Returns the path component of the request's URL, but also considers
-  -- `X-Forwarded-Prefix` if it comes from a trusted source. The value
+  -- `X-Forwarded-Path` if it comes from a trusted source. The value
   -- is returned as a Lua string.
   --
-  -- Whether this function considers `X-Forwarded-Prefix` or not depends on
+  -- Whether this function considers `X-Forwarded-Path` or not depends on
   -- several Kong configuration parameters:
   --
   -- * [trusted\_ips](https://getkong.org/docs/latest/configuration/#trusted_ips)
   -- * [real\_ip\_header](https://getkong.org/docs/latest/configuration/#real_ip_header)
   -- * [real\_ip\_recursive](https://getkong.org/docs/latest/configuration/#real_ip_recursive)
   --
-  -- **Note**: we do not currently do any normalization on the request
-  --           path except return `"/"` on empty path.
+  -- **Note**: we do not currently do any normalization on the request path.
   --
   -- @function kong.request.get_forwarded_path
   -- @phases rewrite, access, header_filter, body_filter, log, admin_api
@@ -274,14 +274,14 @@ local function new(self)
     check_phase(PHASES.request)
 
     if self.ip.is_trusted(self.client.get_ip()) then
-      local prefix = _REQUEST.get_header(X_FORWARDED_PREFIX)
-      if prefix then
-        return prefix
+      local path = _REQUEST.get_header(X_FORWARDED_PATH)
+      if path then
+        return path
       end
     end
 
     local path = _REQUEST.get_path()
-    return path == "" and "/" or path
+    return path
   end
 
 

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1111,7 +1111,7 @@ return {
       local forwarded_proto
       local forwarded_host
       local forwarded_port
-      local forwarded_prefix
+      local forwarded_path
 
       -- X-Forwarded-* Headers Parsing
       --
@@ -1127,7 +1127,7 @@ return {
         forwarded_proto  = var.http_x_forwarded_proto  or scheme
         forwarded_host   = var.http_x_forwarded_host   or host
         forwarded_port   = var.http_x_forwarded_port   or port
-        forwarded_prefix = var.http_x_forwarded_prefix
+        forwarded_path   = var.http_x_forwarded_path
 
       else
         forwarded_proto  = scheme
@@ -1135,15 +1135,11 @@ return {
         forwarded_port   = port
       end
 
-      if not forwarded_prefix then
-        forwarded_prefix = var.request_uri
-        local p = find(forwarded_prefix, "?", 2, true)
+      if not forwarded_path then
+        forwarded_path = var.request_uri
+        local p = find(forwarded_path, "?", 2, true)
         if p then
-          forwarded_prefix = sub(forwarded_prefix, 1, p - 1)
-        end
-
-        if forwarded_prefix == "" then
-          forwarded_prefix = "/"
+          forwarded_path = sub(forwarded_path, 1, p - 1)
         end
       end
 
@@ -1234,7 +1230,7 @@ return {
       var.upstream_x_forwarded_proto  = forwarded_proto
       var.upstream_x_forwarded_host   = forwarded_host
       var.upstream_x_forwarded_port   = forwarded_port
-      var.upstream_x_forwarded_prefix = forwarded_prefix
+      var.upstream_x_forwarded_path   = forwarded_path
 
       -- At this point, the router and `balancer_setup_stage1` have been
       -- executed; detect requests that need to be redirected from `proxy_pass`

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1112,6 +1112,7 @@ return {
       local forwarded_host
       local forwarded_port
       local forwarded_path
+      local forwarded_prefix
 
       -- X-Forwarded-* Headers Parsing
       --
@@ -1128,6 +1129,7 @@ return {
         forwarded_host   = var.http_x_forwarded_host   or host
         forwarded_port   = var.http_x_forwarded_port   or port
         forwarded_path   = var.http_x_forwarded_path
+        forwarded_prefix = var.http_x_forwarded_prefix
 
       else
         forwarded_proto  = scheme
@@ -1140,6 +1142,14 @@ return {
         local p = find(forwarded_path, "?", 2, true)
         if p then
           forwarded_path = sub(forwarded_path, 1, p - 1)
+        end
+      end
+
+      if not forwarded_prefix then
+        forwarded_prefix = match_t.prefix
+
+        if not forwarded_prefix or forwarded_prefix == "" then
+          forwarded_prefix = "/"
         end
       end
 
@@ -1231,6 +1241,7 @@ return {
       var.upstream_x_forwarded_host   = forwarded_host
       var.upstream_x_forwarded_port   = forwarded_port
       var.upstream_x_forwarded_path   = forwarded_path
+      var.upstream_x_forwarded_prefix = forwarded_prefix
 
       -- At this point, the router and `balancer_setup_stage1` have been
       -- executed; detect requests that need to be redirected from `proxy_pass`

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -134,6 +134,7 @@ server {
         set $upstream_x_forwarded_proto  '';
         set $upstream_x_forwarded_host   '';
         set $upstream_x_forwarded_port   '';
+        set $upstream_x_forwarded_path   '';
         set $upstream_x_forwarded_prefix '';
         set $kong_proxy_mode             'http';
 
@@ -146,6 +147,7 @@ server {
         proxy_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
         proxy_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
         proxy_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
+        proxy_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
         proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
         proxy_set_header      X-Real-IP          $remote_addr;
         proxy_pass_header     Server;
@@ -170,6 +172,7 @@ server {
         grpc_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
         grpc_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
         grpc_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
+        grpc_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
         grpc_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
         grpc_set_header      X-Real-IP          $remote_addr;
         grpc_pass_header     Server;
@@ -188,6 +191,7 @@ server {
         grpc_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
         grpc_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
         grpc_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
+        grpc_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
         grpc_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
         grpc_set_header      X-Real-IP          $remote_addr;
         grpc_pass_header     Server;
@@ -221,6 +225,7 @@ server {
         proxy_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
         proxy_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
         proxy_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
+        proxy_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
         proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
         proxy_set_header      X-Real-IP          $remote_addr;
         proxy_pass_header     Server;

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -2498,7 +2498,7 @@ describe("Router", function()
       assert.equal("/endel%C3%B8st", match_t.upstream_uri)
     end)
 
-    describe("stripped paths", function()
+    describe("stripped paths #strip", function()
       local router
       local use_case_routes = {
         {
@@ -2516,6 +2516,7 @@ describe("Router", function()
             id         = uuid(),
             methods    = { "POST" },
             paths      = { "/my-route", "/this-route" },
+            strip_path = false,
           },
         },
       }
@@ -2530,6 +2531,7 @@ describe("Router", function()
         router._set_ngx(_ngx)
         local match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
+        assert.equal("/my-route", match_t.prefix)
         assert.equal("/hello/world", match_t.upstream_uri)
       end)
 
@@ -2538,6 +2540,7 @@ describe("Router", function()
         router._set_ngx(_ngx)
         local match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
+        assert.equal("/my-route", match_t.prefix)
         assert.equal("/", match_t.upstream_uri)
       end)
 
@@ -2547,6 +2550,7 @@ describe("Router", function()
         router._set_ngx(_ngx)
         local match_t = router.exec()
         assert.same(use_case_routes[2].route, match_t.route)
+        assert.equal("/", match_t.prefix)
         assert.equal("/my-route/hello/world", match_t.upstream_uri)
       end)
 
@@ -2568,6 +2572,7 @@ describe("Router", function()
         router._set_ngx(_ngx)
         local match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
+        assert.equal("/", match_t.prefix)
         assert.equal("/my-route/hello/world", match_t.upstream_uri)
       end)
 
@@ -2576,12 +2581,14 @@ describe("Router", function()
         router._set_ngx(_ngx)
         local match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
+        assert.equal("/my-route", match_t.prefix)
         assert.equal("/", match_t.upstream_uri)
 
         _ngx = mock_ngx("GET", "/my-route", { host = "domain.org" })
         router._set_ngx(_ngx)
         match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
+        assert.equal("/my-route", match_t.prefix)
         assert.equal("/", match_t.upstream_uri)
       end)
 
@@ -2590,24 +2597,28 @@ describe("Router", function()
         router._set_ngx(_ngx)
         local match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
+        assert.equal("/my-route", match_t.prefix)
         assert.equal("/", match_t.upstream_uri)
 
         _ngx = mock_ngx("GET", "/this-route", { host = "domain.org" })
         router._set_ngx(_ngx)
         match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
+        assert.equal("/this-route", match_t.prefix)
         assert.equal("/", match_t.upstream_uri)
 
         _ngx = mock_ngx("GET", "/my-route", { host = "domain.org" })
         router._set_ngx(_ngx)
         match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
+        assert.equal("/my-route", match_t.prefix)
         assert.equal("/", match_t.upstream_uri)
 
         _ngx = mock_ngx("GET", "/this-route", { host = "domain.org" })
         router._set_ngx(_ngx)
         match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
+        assert.equal("/this-route", match_t.prefix)
         assert.equal("/", match_t.upstream_uri)
       end)
 
@@ -2627,6 +2638,7 @@ describe("Router", function()
         router._set_ngx(_ngx)
         local match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
+        assert.equal("/endel%C3%B8st", match_t.prefix)
         assert.equal("/", match_t.upstream_uri)
       end)
 
@@ -2646,6 +2658,7 @@ describe("Router", function()
                               { host = "domain.org" })
         router._set_ngx(_ngx)
         local match_t = router.exec()
+        assert.equal("/users/123/profile", match_t.prefix)
         assert.equal("/hello/world", match_t.upstream_uri)
       end)
 
@@ -2665,6 +2678,7 @@ describe("Router", function()
                               { host = "domain.org" })
         router._set_ngx(_ngx)
         local match_t = router.exec()
+        assert.equal("/users/123/profile", match_t.prefix)
         assert.equal("/hello/world", match_t.upstream_uri)
       end)
     end)

--- a/spec/02-integration/05-proxy/03-upstream_headers_spec.lua
+++ b/spec/02-integration/05-proxy/03-upstream_headers_spec.lua
@@ -284,22 +284,22 @@ for _, strategy in helpers.each_strategy() do
         end)
       end)
 
-      describe("X-Forwarded-Prefix", function()
+      describe("X-Forwarded-Path", function()
         it("should be added if not present in request", function()
           local headers = request_headers {
             ["Host"] = "headers-inspect.com",
           }
 
-          assert.equal("/", headers["x-forwarded-prefix"])
+          assert.equal("/", headers["x-forwarded-path"])
         end)
 
         it("should be replaced if present in request", function()
           local headers = request_headers {
-            ["Host"]               = "headers-inspect.com",
-            ["X-Forwarded-Prefix"] = "/replaced",
+            ["Host"]             = "headers-inspect.com",
+            ["X-Forwarded-Path"] = "/replaced",
           }
 
-          assert.equal("/", headers["x-forwarded-prefix"])
+          assert.equal("/", headers["x-forwarded-path"])
         end)
       end)
 
@@ -315,7 +315,7 @@ for _, strategy in helpers.each_strategy() do
           assert.equal("http", headers["x-forwarded-proto"])
           assert.equal("preserved.com", headers["x-forwarded-host"])
           assert.equal(helpers.get_proxy_port(false), tonumber(headers["x-forwarded-port"]))
-          assert.equal("/", headers["x-forwarded-prefix"])
+          assert.equal("/", headers["x-forwarded-path"])
         end)
 
         it("should be added if present in request while preserving the downstream host", function()
@@ -334,7 +334,7 @@ for _, strategy in helpers.each_strategy() do
           assert.equal("http", headers["x-forwarded-proto"])
           assert.equal("preserved.com", headers["x-forwarded-host"])
           assert.equal(helpers.get_proxy_port(false), tonumber(headers["x-forwarded-port"]))
-          assert.equal("/", headers["x-forwarded-prefix"])
+          assert.equal("/", headers["x-forwarded-path"])
         end)
       end)
 
@@ -352,7 +352,7 @@ for _, strategy in helpers.each_strategy() do
           assert.equal("http", headers["x-forwarded-proto"])
           assert.equal("headers-inspect.com", headers["x-forwarded-host"])
           assert.equal(helpers.get_proxy_port(false), tonumber(headers["x-forwarded-port"]))
-          assert.equal("/", headers["x-forwarded-prefix"])
+          assert.equal("/", headers["x-forwarded-path"])
         end)
 
         it("if present in request while discarding the downstream host", function()
@@ -373,7 +373,7 @@ for _, strategy in helpers.each_strategy() do
           assert.equal("http", headers["x-forwarded-proto"])
           assert.equal("headers-inspect.com", headers["x-forwarded-host"])
           assert.equal(helpers.get_proxy_port(false), tonumber(headers["x-forwarded-port"]))
-          assert.equal("/", headers["x-forwarded-prefix"])
+          assert.equal("/", headers["x-forwarded-path"])
         end)
       end)
 
@@ -486,22 +486,22 @@ for _, strategy in helpers.each_strategy() do
         end)
       end)
 
-      describe("X-Forwarded-Prefix", function()
+      describe("X-Forwarded-Path", function()
         it("should be added if not present in request", function()
           local headers = request_headers {
             ["Host"] = "headers-inspect.com",
           }
 
-          assert.equal("/", headers["x-forwarded-prefix"])
+          assert.equal("/", headers["x-forwarded-path"])
         end)
 
         it("should be forwarded if present in request", function()
           local headers = request_headers {
             ["Host"]             = "headers-inspect.com",
-            ["X-Forwarded-Prefix"] = "/original-path",
+            ["X-Forwarded-Path"] = "/original-path",
           }
 
-          assert.equal("/original-path", headers["x-forwarded-prefix"])
+          assert.equal("/original-path", headers["x-forwarded-path"])
         end)
       end)
 
@@ -614,22 +614,22 @@ for _, strategy in helpers.each_strategy() do
         end)
       end)
 
-      describe("X-Forwarded-Prefix", function()
+      describe("X-Forwarded-Path", function()
         it("should be added if not present in request", function()
           local headers = request_headers {
             ["Host"] = "headers-inspect.com",
           }
 
-          assert.equal("/", headers["x-forwarded-prefix"])
+          assert.equal("/", headers["x-forwarded-path"])
         end)
 
         it("should be replaced if present in request", function()
           local headers = request_headers {
             ["Host"]             = "headers-inspect.com",
-            ["X-Forwarded-Prefix"] = "/untrusted",
+            ["X-Forwarded-Path"] = "/untrusted",
           }
 
-          assert.equal("/", headers["x-forwarded-prefix"])
+          assert.equal("/", headers["x-forwarded-path"])
         end)
       end)
     end)

--- a/spec/02-integration/05-proxy/03-upstream_headers_spec.lua
+++ b/spec/02-integration/05-proxy/03-upstream_headers_spec.lua
@@ -303,6 +303,25 @@ for _, strategy in helpers.each_strategy() do
         end)
       end)
 
+      describe("X-Forwarded-Prefix", function()
+        it("should be added if not present in request", function()
+          local headers = request_headers {
+            ["Host"] = "headers-inspect.com",
+          }
+
+          assert.equal("/", headers["x-forwarded-prefix"])
+        end)
+
+        it("should be replaced if present in request", function()
+          local headers = request_headers {
+            ["Host"]               = "headers-inspect.com",
+            ["X-Forwarded-Prefix"] = "/replaced",
+          }
+
+          assert.equal("/", headers["x-forwarded-prefix"])
+        end)
+      end)
+
       describe("with the downstream host preserved", function()
         it("should be added if not present in request while preserving the downstream host", function()
           local headers = request_headers {
@@ -316,6 +335,7 @@ for _, strategy in helpers.each_strategy() do
           assert.equal("preserved.com", headers["x-forwarded-host"])
           assert.equal(helpers.get_proxy_port(false), tonumber(headers["x-forwarded-port"]))
           assert.equal("/", headers["x-forwarded-path"])
+          assert.equal("/", headers["x-forwarded-prefix"])
         end)
 
         it("should be added if present in request while preserving the downstream host", function()
@@ -335,6 +355,7 @@ for _, strategy in helpers.each_strategy() do
           assert.equal("preserved.com", headers["x-forwarded-host"])
           assert.equal(helpers.get_proxy_port(false), tonumber(headers["x-forwarded-port"]))
           assert.equal("/", headers["x-forwarded-path"])
+          assert.equal("/", headers["x-forwarded-prefix"])
         end)
       end)
 
@@ -353,6 +374,7 @@ for _, strategy in helpers.each_strategy() do
           assert.equal("headers-inspect.com", headers["x-forwarded-host"])
           assert.equal(helpers.get_proxy_port(false), tonumber(headers["x-forwarded-port"]))
           assert.equal("/", headers["x-forwarded-path"])
+          assert.equal("/", headers["x-forwarded-prefix"])
         end)
 
         it("if present in request while discarding the downstream host", function()
@@ -374,6 +396,7 @@ for _, strategy in helpers.each_strategy() do
           assert.equal("headers-inspect.com", headers["x-forwarded-host"])
           assert.equal(helpers.get_proxy_port(false), tonumber(headers["x-forwarded-port"]))
           assert.equal("/", headers["x-forwarded-path"])
+          assert.equal("/", headers["x-forwarded-prefix"])
         end)
       end)
 
@@ -505,6 +528,25 @@ for _, strategy in helpers.each_strategy() do
         end)
       end)
 
+      describe("X-Forwarded-Prefix", function()
+        it("should be added if not present in request", function()
+          local headers = request_headers {
+            ["Host"] = "headers-inspect.com",
+          }
+
+          assert.equal("/", headers["x-forwarded-prefix"])
+        end)
+
+        it("should be forwarded if present in request", function()
+          local headers = request_headers {
+            ["Host"] = "headers-inspect.com",
+            ["X-Forwarded-Prefix"] = "/original-path",
+          }
+
+          assert.equal("/original-path", headers["x-forwarded-prefix"])
+        end)
+      end)
+
     end)
 
     describe("(using the non-trusted configuration values)", function()
@@ -630,6 +672,25 @@ for _, strategy in helpers.each_strategy() do
           }
 
           assert.equal("/", headers["x-forwarded-path"])
+        end)
+      end)
+
+      describe("X-Forwarded-Prefix", function()
+        it("should be added if not present in request", function()
+          local headers = request_headers {
+            ["Host"] = "headers-inspect.com",
+          }
+
+          assert.equal("/", headers["x-forwarded-prefix"])
+        end)
+
+        it("should be replaced if present in request", function()
+          local headers = request_headers {
+            ["Host"]             = "headers-inspect.com",
+            ["X-Forwarded-Prefix"] = "/untrusted",
+          }
+
+          assert.equal("/", headers["x-forwarded-prefix"])
         end)
       end)
     end)

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -153,6 +153,7 @@ http {
             set $upstream_x_forwarded_proto  '';
             set $upstream_x_forwarded_host   '';
             set $upstream_x_forwarded_port   '';
+            set $upstream_x_forwarded_path   '';
             set $upstream_x_forwarded_prefix '';
             set $kong_proxy_mode             'http';
 
@@ -165,6 +166,7 @@ http {
             proxy_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
             proxy_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
             proxy_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
+            proxy_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
             proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
             proxy_set_header      X-Real-IP          $remote_addr;
             proxy_pass_header     Server;
@@ -189,6 +191,7 @@ http {
             grpc_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
             grpc_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
             grpc_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
+            grpc_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
             grpc_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
             grpc_set_header      X-Real-IP          $remote_addr;
             grpc_pass_header     Server;
@@ -207,6 +210,7 @@ http {
             grpc_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
             grpc_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
             grpc_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
+            grpc_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
             grpc_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
             grpc_set_header      X-Real-IP          $remote_addr;
             grpc_pass_header     Server;
@@ -240,6 +244,7 @@ http {
             proxy_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
             proxy_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
             proxy_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
+            proxy_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
             proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
             proxy_set_header      X-Real-IP          $remote_addr;
             proxy_pass_header     Server;

--- a/t/01-pdk/04-request/00-phase_checks.t
+++ b/t/01-pdk/04-request/00-phase_checks.t
@@ -108,6 +108,17 @@ qq{
                 log           = true,
                 admin_api     = true,
             }, {
+                method        = "get_forwarded_prefix",
+                args          = {},
+                init_worker   = false,
+                certificate   = "pending",
+                rewrite       = true,
+                access        = true,
+                header_filter = true,
+                body_filter   = true,
+                log           = true,
+                admin_api     = true,
+            }, {
                 method        = "get_http_version",
                 args          = {},
                 init_worker   = false,

--- a/t/01-pdk/04-request/18-get_forwarded_path.t
+++ b/t/01-pdk/04-request/18-get_forwarded_path.t
@@ -12,7 +12,7 @@ run_tests();
 
 __DATA__
 
-=== TEST 1: request.get_forwarded_path() considers X-Forwarded-Prefix when trusted
+=== TEST 1: request.get_forwarded_path() considers X-Forwarded-Path when trusted
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location /t {
@@ -27,7 +27,7 @@ __DATA__
 --- request
 GET /t/request-path
 --- more_headers
-X-Forwarded-Prefix: /trusted
+X-Forwarded-Path: /trusted
 --- response_body
 path: /trusted
 type: string
@@ -36,7 +36,7 @@ type: string
 
 
 
-=== TEST 2: request.get_forwarded_path() doesn't considers X-Forwarded-Prefix when not trusted
+=== TEST 2: request.get_forwarded_path() doesn't considers X-Forwarded-Path when not trusted
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location /t {
@@ -50,7 +50,7 @@ type: string
 --- request
 GET /t/request-path
 --- more_headers
-X-Forwarded-Prefix: /not-trusted
+X-Forwarded-Path: /not-trusted
 --- response_body
 path: /t/request-path
 --- no_error_log
@@ -58,7 +58,7 @@ path: /t/request-path
 
 
 
-=== TEST 3: request.get_forwarded_path() considers first X-Forwarded-Prefix if multiple when trusted
+=== TEST 3: request.get_forwarded_path() considers first X-Forwarded-Path if multiple when trusted
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -72,8 +72,8 @@ path: /t/request-path
 --- request
 GET /t
 --- more_headers
-X-Forwarded-Prefix: /first
-X-Forwarded-Prefix: /second
+X-Forwarded-Path: /first
+X-Forwarded-Path: /second
 --- response_body
 path: /first
 --- no_error_log
@@ -81,7 +81,7 @@ path: /first
 
 
 
-=== TEST 4: request.get_forwarded_path() doesn't considers any X-Forwarded-Prefix headers when not trusted
+=== TEST 4: request.get_forwarded_path() doesn't considers any X-Forwarded-Path headers when not trusted
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location /t {
@@ -95,8 +95,8 @@ path: /first
 --- request
 GET /t/request-uri
 --- more_headers
-X-Forwarded-Prefix: /first
-X-Forwarded-Prefix: /second
+X-Forwarded-Path: /first
+X-Forwarded-Path: /second
 --- response_body
 path: /t/request-uri
 --- no_error_log
@@ -118,7 +118,7 @@ path: /t/request-uri
 --- request
 GET /t/request-uri?query&field=value#here
 --- more_headers
-X-Forwarded-Prefix: /first
+X-Forwarded-Path: /first
 --- response_body
 path: /t/request-uri
 --- no_error_log
@@ -140,7 +140,7 @@ path: /t/request-uri
 --- request
 GET /t/request-uri?query&field=value#here
 --- more_headers
-X-Forwarded-Prefix: /first?query&field=value#here
+X-Forwarded-Path: /first?query&field=value#here
 --- response_body
 path: /first?query&field=value#here
 --- no_error_log

--- a/t/01-pdk/04-request/19-get_forwarded_prefix.t
+++ b/t/01-pdk/04-request/19-get_forwarded_prefix.t
@@ -1,0 +1,147 @@
+use strict;
+use warnings FATAL => 'all';
+use Test::Nginx::Socket::Lua;
+use t::Util;
+
+$ENV{TEST_NGINX_CERT_DIR} ||= File::Spec->catdir(server_root(), '..', 'certs');
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
+
+plan tests => repeat_each() * (blocks() * 3);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: request.get_forwarded_prefix() considers X-Forwarded-Prefix when trusted
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location /t {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new({ trusted_ips = { "0.0.0.0/0", "::/0" } })
+
+            ngx.say("prefix: ", pdk.request.get_forwarded_prefix())
+            ngx.say("type: ", type(pdk.request.get_forwarded_prefix()))
+        }
+    }
+--- request
+GET /t/request-path
+--- more_headers
+X-Forwarded-Prefix: /trusted
+--- response_body
+prefix: /trusted
+type: string
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: request.get_forwarded_prefix() doesn't considers X-Forwarded-Prefix when not trusted
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location /t {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            ngx.say("prefix: ", pdk.request.get_forwarded_prefix())
+        }
+    }
+--- request
+GET /t/request-path
+--- more_headers
+X-Forwarded-Prefix: /
+--- response_body
+prefix: /
+--- no_error_log
+[error]
+
+
+
+=== TEST 3: request.get_forwarded_prefix() considers first X-Forwarded-Prefix if multiple when trusted
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new({ trusted_ips = { "0.0.0.0/0", "::/0" } })
+
+            ngx.say("prefix: ", pdk.request.get_forwarded_prefix())
+        }
+    }
+--- request
+GET /t
+--- more_headers
+X-Forwarded-Prefix: /first
+X-Forwarded-Prefix: /second
+--- response_body
+prefix: /first
+--- no_error_log
+[error]
+
+
+
+=== TEST 4: request.get_forwarded_prefix() doesn't considers any X-Forwarded-Prefix headers when not trusted
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location /t {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            ngx.say("prefix: ", pdk.request.get_forwarded_prefix())
+        }
+    }
+--- request
+GET /t/request-uri
+--- more_headers
+X-Forwarded-Prefix: /first
+X-Forwarded-Prefix: /second
+--- response_body
+prefix: /
+--- no_error_log
+[error]
+
+
+
+=== TEST 5: request.get_forwarded_prefix() removes query and fragment when not trusted
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location /t {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            ngx.say("prefix: ", pdk.request.get_forwarded_prefix())
+        }
+    }
+--- request
+GET /t/request-uri?query&field=value#here
+--- more_headers
+X-Forwarded-Prefix: /first
+--- response_body
+prefix: /
+--- no_error_log
+[error]
+
+
+
+=== TEST 6: request.get_forwarded_prefix() does not remove query and fragment when trusted
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location /t {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new({ trusted_ips = { "0.0.0.0/0", "::/0" } })
+
+            ngx.say("prefix: ", pdk.request.get_forwarded_prefix())
+        }
+    }
+--- request
+GET /t/request-uri?query&field=value#here
+--- more_headers
+X-Forwarded-Prefix: /first?query&field=value#here
+--- response_body
+prefix: /first?query&field=value#here
+--- no_error_log
+[error]


### PR DESCRIPTION
### Summary

This PR comes with 2 commits:

#### fix(proxy/pdk) turn X-Forwarded-Prefix to X-Forwarded-Path

The PR #5620 implemented `X-Forwarded-Prefix` wrong. The implementation looks more like proprietary `X-Forwarded-Path`. This commit changes that accordingly. Next commit in this PR will re-introduce X-Forwarded-Prefix correctly.

I decided to keep the current behavior as it is already used in some code with PDK `kong.request.get_forwarded_path` (e.g. if the plugin needs to get the original request path, the one that is perhaps rewritten by Kong or a proxy before Kong, perhaps Kong as well).

#### fix(proxy/pdk) re-implement X-Forwarded-Prefix / kong.request.get_forwarded_prefix

The PR #5620 implemented `X-Forwarded-Prefix` wrong as reported in these:
- #6190
- Kong/kubernetes-ingress-controller#784
- #6132

And also by some other sources.

This commit re-implements `X-Forwarded-Prefix`:

1. Is there trusted `X-Forwarded-Prefix` header in request? If yes, then set that as the `X-Forwarded-Prefix` (note: at this point we don't support    multi-value `X-Forwarded-Prefix` headers, e.g. appending. We don't support multi-value in `X-Forwarded-Host/-Port/-Proto` either.
2. Has Kong router stripped the prefix of the request URI before proxying, if yes, then set `X-Forwarded-Prefix` to match the stripped prefix.
3. If 1 or 2 didn't set the header, set it to `/`.

### Issues Resolved

Fix #6190
Fix Kong/kubernetes-ingress-controller#784
Fix #6132