### PR TITLE
fix(init) set the default workspace before using it

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -341,6 +341,9 @@ local function load_declarative_config(kong_config, entities, meta)
   end)
 
   if ok then
+    local default_ws = kong.db.workspaces:select_by_name("default")
+    kong.default_workspace = default_ws and default_ws.id or kong.default_workspace
+
     ok, err = runloop.build_plugins_iterator("init")
     if not ok then
       return nil, "error building initial plugins iterator: " .. err
@@ -350,9 +353,6 @@ local function load_declarative_config(kong_config, entities, meta)
     if not ok then
       return nil, "error building initial router: " .. err
     end
-
-    local default_ws = kong.db.workspaces:select_by_name("default")
-    kong.default_workspace = default_ws and default_ws.id or kong.default_workspace
   end
 
   return ok, err

--- a/kong/runloop/plugins_iterator.lua
+++ b/kong/runloop/plugins_iterator.lua
@@ -373,11 +373,10 @@ function PluginsIterator.new(version)
   end
   loaded_plugins = loaded_plugins or get_loaded_plugins()
 
-  local ws = {
-    [kong.default_workspace] = new_ws_data()
-  }
-
   local ws_id = workspaces.get_workspace_id() or kong.default_workspace
+  local ws = {
+    [ws_id] = new_ws_data()
+  }
 
   local counter = 0
   local page_size = kong.db.plugins.pagination.page_size


### PR DESCRIPTION
The plugins iterator was being built before setting the default workspace id, therefore indexing the plugins under the wrong workspace.

Fix #6160, fix #6204
