### PR TITLE
fix(cors) send HTTP 204 on Preflight request

### DIFF
--- a/kong/plugins/cors/handler.lua
+++ b/kong/plugins/cors/handler.lua
@@ -10,7 +10,7 @@ local tostring = tostring
 local ipairs   = ipairs
 
 
-local HTTP_OK = 200
+local HTTP_OK = 204
 
 
 local CorsHandler = {}


### PR DESCRIPTION
### Summary

The appropriate status code for a preflight request is 204 as per the updated Mozilla guidelines (https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request). We previously used to send HTTP 200.

### Full changelog

* return 204 for preflight response instead of 200

### Issues resolved

Fix #6051
