### PR TITLE
fix(cors) send HTTP 204 on Preflight request

### DIFF
--- a/kong/plugins/cors/handler.lua
+++ b/kong/plugins/cors/handler.lua
@@ -10,7 +10,7 @@ local tostring = tostring
 local ipairs   = ipairs
 
 
-local HTTP_OK = 200
+local HTTP_OK = 204
 
 
 local CorsHandler = {}

--- a/kong/plugins/cors/handler.lua
+++ b/kong/plugins/cors/handler.lua
@@ -10,7 +10,7 @@ local tostring = tostring
 local ipairs   = ipairs
 
 
-local HTTP_OK = 204
+local HTTP_NO_CONTENT = 204
 
 
 local CorsHandler = {}
@@ -232,7 +232,7 @@ function CorsHandler:access(conf)
     set_header("Access-Control-Max-Age", tostring(conf.max_age))
   end
 
-  return kong.response.exit(HTTP_OK)
+  return kong.response.exit(HTTP_NO_CONTENT)
 end
 
 

--- a/spec/03-plugins/13-cors/01-access_spec.lua
+++ b/spec/03-plugins/13-cors/01-access_spec.lua
@@ -536,7 +536,7 @@ for _, strategy in helpers.each_strategy() do
               }
             })
 
-            assert.res_status(200, res)
+            assert.res_status(204, res)
 
             if accept then
               assert.equal(CORS_DEFAULT_METHODS, res.headers["Access-Control-Allow-Methods"])
@@ -562,7 +562,7 @@ for _, strategy in helpers.each_strategy() do
             ["Access-Control-Request-Method"] = "GET",
           }
         })
-        assert.res_status(200, res)
+        assert.res_status(204, res)
         assert.equal("0", res.headers["Content-Length"])
         assert.equal(CORS_DEFAULT_METHODS, res.headers["Access-Control-Allow-Methods"])
         assert.equal("*", res.headers["Access-Control-Allow-Origin"])
@@ -588,7 +588,7 @@ for _, strategy in helpers.each_strategy() do
             ["Access-Control-Request-Method"] = "GET",
           }
         })
-        assert.res_status(200, res)
+        assert.res_status(204, res)
         assert.equal("0", res.headers["Content-Length"])
         assert.equal(CORS_DEFAULT_METHODS, res.headers["Access-Control-Allow-Methods"])
         assert.equal("*", res.headers["Access-Control-Allow-Origin"])
@@ -608,7 +608,7 @@ for _, strategy in helpers.each_strategy() do
             ["Access-Control-Request-Method"] = "GET",
           }
         })
-        assert.res_status(200, res)
+        assert.res_status(204, res)
         assert.equal("0", res.headers["Content-Length"])
         assert.equal(CORS_DEFAULT_METHODS, res.headers["Access-Control-Allow-Methods"])
         assert.equal("origin5.com", res.headers["Access-Control-Allow-Origin"])
@@ -628,7 +628,7 @@ for _, strategy in helpers.each_strategy() do
             ["Access-Control-Request-Method"] = "GET",
           }
         })
-        assert.res_status(200, res)
+        assert.res_status(204, res)
         assert.equal("0", res.headers["Content-Length"])
         assert.equal("GET", res.headers["Access-Control-Allow-Methods"])
         assert.equal("example.com", res.headers["Access-Control-Allow-Origin"])
@@ -663,7 +663,7 @@ for _, strategy in helpers.each_strategy() do
           }
         })
 
-        assert.res_status(200, res)
+        assert.res_status(204, res)
         assert.equal("0", res.headers["Content-Length"])
         assert.equal("origin,accepts", res.headers["Access-Control-Allow-Headers"])
       end)
@@ -678,7 +678,7 @@ for _, strategy in helpers.each_strategy() do
           }
         })
 
-        assert.res_status(200, res)
+        assert.res_status(204 res)
         assert.equal("http://my-site.com", res.headers["Access-Control-Allow-Origin"])
 
         -- Illegitimate origins
@@ -690,7 +690,7 @@ for _, strategy in helpers.each_strategy() do
           }
         })
 
-        assert.res_status(200, res)
+        assert.res_status(204, res)
         assert.is_nil(res.headers["Access-Control-Allow-Origin"])
 
         -- Tricky illegitimate origins
@@ -702,7 +702,7 @@ for _, strategy in helpers.each_strategy() do
           }
         })
 
-        assert.res_status(200, res)
+        assert.res_status(204, res)
         assert.is_nil(res.headers["Access-Control-Allow-Origin"])
       end)
     end)
@@ -733,7 +733,7 @@ for _, strategy in helpers.each_strategy() do
             ["Host"] = "cors1.com"
           }
         })
-        local body = assert.res_status(200, res)
+        local body = assert.res_status(204, res)
         local json = cjson.decode(body)
         assert.equal("OPTIONS", json.vars.request_method)
         assert.equal("*", res.headers["Access-Control-Allow-Origin"])

--- a/spec/03-plugins/13-cors/01-access_spec.lua
+++ b/spec/03-plugins/13-cors/01-access_spec.lua
@@ -736,7 +736,7 @@ for _, strategy in helpers.each_strategy() do
             ["Host"] = "cors1.com"
           }
         })
-        local body = assert.res_status(204, res)
+        local body = assert.res_status(200, res)
         local json = cjson.decode(body)
         assert.equal("OPTIONS", json.vars.request_method)
         assert.equal("*", res.headers["Access-Control-Allow-Origin"])

--- a/spec/03-plugins/13-cors/01-access_spec.lua
+++ b/spec/03-plugins/13-cors/01-access_spec.lua
@@ -678,7 +678,7 @@ for _, strategy in helpers.each_strategy() do
           }
         })
 
-        assert.res_status(204 res)
+        assert.res_status(204, res)
         assert.equal("http://my-site.com", res.headers["Access-Control-Allow-Origin"])
 
         -- Illegitimate origins

--- a/spec/03-plugins/13-cors/01-access_spec.lua
+++ b/spec/03-plugins/13-cors/01-access_spec.lua
@@ -563,9 +563,9 @@ for _, strategy in helpers.each_strategy() do
           }
         })
         assert.res_status(204, res)
-        assert.equal("0", res.headers["Content-Length"])
         assert.equal(CORS_DEFAULT_METHODS, res.headers["Access-Control-Allow-Methods"])
         assert.equal("*", res.headers["Access-Control-Allow-Origin"])
+        assert.is_nil(res.headers["Content-Length"])
         assert.is_nil(res.headers["Access-Control-Allow-Headers"])
         assert.is_nil(res.headers["Access-Control-Expose-Headers"])
         assert.is_nil(res.headers["Access-Control-Allow-Credentials"])
@@ -589,9 +589,9 @@ for _, strategy in helpers.each_strategy() do
           }
         })
         assert.res_status(204, res)
-        assert.equal("0", res.headers["Content-Length"])
         assert.equal(CORS_DEFAULT_METHODS, res.headers["Access-Control-Allow-Methods"])
         assert.equal("*", res.headers["Access-Control-Allow-Origin"])
+        assert.is_nil(res.headers["Content-Length"])
         assert.is_nil(res.headers["Access-Control-Allow-Headers"])
         assert.is_nil(res.headers["Access-Control-Expose-Headers"])
         assert.is_nil(res.headers["Access-Control-Allow-Credentials"])
@@ -609,11 +609,11 @@ for _, strategy in helpers.each_strategy() do
           }
         })
         assert.res_status(204, res)
-        assert.equal("0", res.headers["Content-Length"])
         assert.equal(CORS_DEFAULT_METHODS, res.headers["Access-Control-Allow-Methods"])
         assert.equal("origin5.com", res.headers["Access-Control-Allow-Origin"])
         assert.equal("true", res.headers["Access-Control-Allow-Credentials"])
         assert.equal("Origin", res.headers["Vary"])
+        assert.is_nil(res.headers["Content-Length"])
         assert.is_nil(res.headers["Access-Control-Allow-Headers"])
         assert.is_nil(res.headers["Access-Control-Expose-Headers"])
         assert.is_nil(res.headers["Access-Control-Max-Age"])
@@ -629,13 +629,13 @@ for _, strategy in helpers.each_strategy() do
           }
         })
         assert.res_status(204, res)
-        assert.equal("0", res.headers["Content-Length"])
         assert.equal("GET", res.headers["Access-Control-Allow-Methods"])
         assert.equal("example.com", res.headers["Access-Control-Allow-Origin"])
         assert.equal("23", res.headers["Access-Control-Max-Age"])
         assert.equal("true", res.headers["Access-Control-Allow-Credentials"])
         assert.equal("origin,type,accepts", res.headers["Access-Control-Allow-Headers"])
         assert.equal("Origin", res.headers["Vary"])
+        assert.is_nil(res.headers["Content-Length"])
         assert.is_nil(res.headers["Access-Control-Expose-Headers"])
       end)
 
@@ -664,8 +664,8 @@ for _, strategy in helpers.each_strategy() do
         })
 
         assert.res_status(204, res)
-        assert.equal("0", res.headers["Content-Length"])
         assert.equal("origin,accepts", res.headers["Access-Control-Allow-Headers"])
+        assert.is_nil(res.headers["Content-Length"])
       end)
 
       it("properly validates flat strings", function()

--- a/spec/03-plugins/13-cors/01-access_spec.lua
+++ b/spec/03-plugins/13-cors/01-access_spec.lua
@@ -674,7 +674,8 @@ for _, strategy in helpers.each_strategy() do
           method  = "OPTIONS",
           headers = {
             ["Host"]   = "cors10.com",
-            ["Origin"] = "http://my-site.com"
+            ["Origin"] = "http://my-site.com",
+            ["Access-Control-Request-Method"] = "GET",
           }
         })
 
@@ -686,7 +687,8 @@ for _, strategy in helpers.each_strategy() do
           method  = "OPTIONS",
           headers = {
             ["Host"]   = "cors10.com",
-            ["Origin"] = "http://bad-guys.com"
+            ["Origin"] = "http://bad-guys.com",
+            ["Access-Control-Request-Method"] = "GET",
           }
         })
 
@@ -698,7 +700,8 @@ for _, strategy in helpers.each_strategy() do
           method  = "OPTIONS",
           headers = {
             ["Host"]   = "cors10.com",
-            ["Origin"] = "http://my-site.com.bad-guys.com"
+            ["Origin"] = "http://my-site.com.bad-guys.com",
+            ["Access-Control-Request-Method"] = "GET",
           }
         })
 


### PR DESCRIPTION
### Summary

The appropriate status code for a preflight request is 204 as per the updated Mozilla guidelines (https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request). We previously used to send HTTP 200.

### Full changelog

* return 204 for preflight response instead of 200
* update tests to accommodate status code change

### Issues resolved

Fix #6051
