### PR TITLE
fix(alpine) adjust the alpine repository name when doing official releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,9 @@ ifneq ($(TAG),)
 		# We're building a semver release tag
 		OFFICIAL_RELEASE = true
 		KONG_VERSION ?= `cat $(KONG_SOURCE_LOCATION)/kong-*.rockspec | grep -m1 tag | awk '{print $$3}' | sed 's/"//g'`
+		ifeq ($(PACKAGE_TYPE),apk)
+		    REPOSITORY_NAME = kong-alpine-tar
+		endif
 	endif
 else
 	OFFICIAL_RELEASE = false


### PR DESCRIPTION
In the future we should migrate alpine to match the naming convention of our other repositories until then we need this exception in our Makefile logic 😢 