### PR TITLE
docs(conf) default for pg_ro_host is not "NONE"

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -862,9 +862,7 @@
                                  # Detailed discussion of this behavior is
                                  # available in the online documentation.
 
-#pg_ro_host = NONE               # Same as `pg_host`, but for the
-                                 # read-only connection.
-                                 # Value of `NONE` disables
+#pg_ro_host =                    # Same as `pg_host`, but for the
                                  # read-only connection.
                                  # **Note:** Refer to the documentation
                                  # section above for detailed usage.


### PR DESCRIPTION
NONE is an internal value meant to refer that the value was not given, it
should not be passed explicitly (and indeed it will be interpreted as a domain
name).

Fixes #6205.
