### PR TITLE
fix(handler) forward stripped prefix as x-forwarded-prefix

### DIFF
--- a/kong/router.lua
+++ b/kong/router.lua
@@ -846,8 +846,10 @@ do
               ctx.matches.uri = uri_t.value
 
               if m.uri_postfix then
+                ctx.matches.uri_prefix = sub(ctx.req_uri, 1, -(#m.uri_postfix + 1))
+
                 -- remove the uri_postfix group
-                m[#m]          = nil
+                m[#m] = nil
                 m.uri_postfix = nil
               end
 
@@ -860,6 +862,7 @@ do
           end
 
           -- plain or prefix match from the index
+          ctx.matches.uri_prefix = sub(ctx.req_uri, 1, #uri_t.value)
           ctx.matches.uri_postfix = sub(ctx.req_uri, #uri_t.value + 1)
           ctx.matches.uri = uri_t.value
 
@@ -882,8 +885,10 @@ do
             ctx.matches.uri = uri_t.value
 
             if m.uri_postfix then
+              ctx.matches.uri_prefix = sub(ctx.req_uri, 1, -(#m.uri_postfix + 1))
+
               -- remove the uri_postfix group
-              m[#m]          = nil
+              m[#m] = nil
               m.uri_postfix = nil
             end
 
@@ -898,6 +903,7 @@ do
           -- plain or prefix match (not from the index)
           local from, to = find(ctx.req_uri, uri_t.value, nil, true)
           if from == 1 then
+            ctx.matches.uri_prefix = sub(ctx.req_uri, 1, to)
             ctx.matches.uri_postfix = sub(ctx.req_uri, to + 1)
             ctx.matches.uri = uri_t.value
 
@@ -1560,9 +1566,13 @@ function _M.new(routes)
               matched_route.route = routes_by_id[matched_route.route.id].route
             end
 
+            local request_prefix
+
             -- Path construction
 
             if matched_route.type == "http" then
+              request_prefix = matched_route.strip_uri and matches.uri_prefix or nil
+
               -- if we do not have a path-match, then the postfix is simply the
               -- incoming path, without the initial slash
               local request_postfix = matches.uri_postfix or sub(req_uri, 2, -1)
@@ -1651,6 +1661,7 @@ function _M.new(routes)
               upstream_scheme = upstream_url_t.scheme,
               upstream_uri    = upstream_uri,
               upstream_host   = upstream_host,
+              prefix          = request_prefix,
               matches         = {
                 uri_captures  = matches.uri_captures,
                 uri           = matches.uri,

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1135,16 +1135,8 @@ return {
         forwarded_port   = port
       end
 
-      if not forwarded_prefix then
-        forwarded_prefix = var.request_uri
-        local p = find(forwarded_prefix, "?", 2, true)
-        if p then
-          forwarded_prefix = sub(forwarded_prefix, 1, p - 1)
-        end
-
-        if forwarded_prefix == "" then
-          forwarded_prefix = "/"
-        end
+      if not forwarded_prefix and match_t.prefix ~= "/" then
+        forwarded_prefix = match_t.prefix
       end
 
       local protocols = route.protocols

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -2498,7 +2498,7 @@ describe("Router", function()
       assert.equal("/endel%C3%B8st", match_t.upstream_uri)
     end)
 
-    describe("stripped paths", function()
+    describe("stripped paths #strip", function()
       local router
       local use_case_routes = {
         {
@@ -2516,6 +2516,7 @@ describe("Router", function()
             id         = uuid(),
             methods    = { "POST" },
             paths      = { "/my-route", "/this-route" },
+            strip_path = false,
           },
         },
       }
@@ -2530,6 +2531,7 @@ describe("Router", function()
         router._set_ngx(_ngx)
         local match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
+        assert.equal("/my-route", match_t.prefix)
         assert.equal("/hello/world", match_t.upstream_uri)
       end)
 
@@ -2538,6 +2540,7 @@ describe("Router", function()
         router._set_ngx(_ngx)
         local match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
+        assert.equal("/my-route", match_t.prefix)
         assert.equal("/", match_t.upstream_uri)
       end)
 
@@ -2547,6 +2550,7 @@ describe("Router", function()
         router._set_ngx(_ngx)
         local match_t = router.exec()
         assert.same(use_case_routes[2].route, match_t.route)
+        assert.is_nil(match_t.prefix)
         assert.equal("/my-route/hello/world", match_t.upstream_uri)
       end)
 
@@ -2568,6 +2572,7 @@ describe("Router", function()
         router._set_ngx(_ngx)
         local match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
+        assert.equal("/", match_t.prefix)
         assert.equal("/my-route/hello/world", match_t.upstream_uri)
       end)
 
@@ -2576,12 +2581,14 @@ describe("Router", function()
         router._set_ngx(_ngx)
         local match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
+        assert.equal("/my-route", match_t.prefix)
         assert.equal("/", match_t.upstream_uri)
 
         _ngx = mock_ngx("GET", "/my-route", { host = "domain.org" })
         router._set_ngx(_ngx)
         match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
+        assert.equal("/my-route", match_t.prefix)
         assert.equal("/", match_t.upstream_uri)
       end)
 
@@ -2590,24 +2597,28 @@ describe("Router", function()
         router._set_ngx(_ngx)
         local match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
+        assert.equal("/my-route", match_t.prefix)
         assert.equal("/", match_t.upstream_uri)
 
         _ngx = mock_ngx("GET", "/this-route", { host = "domain.org" })
         router._set_ngx(_ngx)
         match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
+        assert.equal("/this-route", match_t.prefix)
         assert.equal("/", match_t.upstream_uri)
 
         _ngx = mock_ngx("GET", "/my-route", { host = "domain.org" })
         router._set_ngx(_ngx)
         match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
+        assert.equal("/my-route", match_t.prefix)
         assert.equal("/", match_t.upstream_uri)
 
         _ngx = mock_ngx("GET", "/this-route", { host = "domain.org" })
         router._set_ngx(_ngx)
         match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
+        assert.equal("/this-route", match_t.prefix)
         assert.equal("/", match_t.upstream_uri)
       end)
 
@@ -2627,6 +2638,7 @@ describe("Router", function()
         router._set_ngx(_ngx)
         local match_t = router.exec()
         assert.same(use_case_routes[1].route, match_t.route)
+        assert.equal("/endel%C3%B8st", match_t.prefix)
         assert.equal("/", match_t.upstream_uri)
       end)
 
@@ -2646,6 +2658,7 @@ describe("Router", function()
                               { host = "domain.org" })
         router._set_ngx(_ngx)
         local match_t = router.exec()
+        assert.equal("/users/123/profile", match_t.prefix)
         assert.equal("/hello/world", match_t.upstream_uri)
       end)
 
@@ -2665,6 +2678,7 @@ describe("Router", function()
                               { host = "domain.org" })
         router._set_ngx(_ngx)
         local match_t = router.exec()
+        assert.equal("/users/123/profile", match_t.prefix)
         assert.equal("/hello/world", match_t.upstream_uri)
       end)
     end)

--- a/spec/02-integration/05-proxy/03-upstream_headers_spec.lua
+++ b/spec/02-integration/05-proxy/03-upstream_headers_spec.lua
@@ -24,10 +24,10 @@ for _, strategy in helpers.each_strategy() do
       end
     end
 
-    local function request_headers(headers)
+    local function request_headers(headers, path)
       local res = assert(proxy_client:send {
         method  = "GET",
-        path    = "/",
+        path    = path or "/",
         headers = headers,
       })
 
@@ -50,6 +50,21 @@ for _, strategy in helpers.each_strategy() do
             protocols     = { "http" },
             hosts         = { "preserved.com" },
             preserve_host = true,
+          },
+          {
+            protocols     = { "http" },
+            paths         = { "/foo" },
+            strip_path    = true,
+          },
+          {
+            protocols     = { "http" },
+            paths         = { "/status/200" },
+            strip_path    = false,
+          },
+          {
+            protocols     = { "http" },
+            paths         = { "/" },
+            strip_path    = true,
           },
         }
 
@@ -285,21 +300,30 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       describe("X-Forwarded-Prefix", function()
-        it("should be added if not present in request", function()
-          local headers = request_headers {
-            ["Host"] = "headers-inspect.com",
-          }
+        it("should be added if path was stripped", function()
+          local headers = request_headers({}, "/foo/status/200")
 
-          assert.equal("/", headers["x-forwarded-prefix"])
+          assert.equal("/foo", headers["x-forwarded-prefix"])
         end)
 
-        it("should be replaced if present in request", function()
-          local headers = request_headers {
-            ["Host"]               = "headers-inspect.com",
+        it("should be replaced if present in request and path was stripped", function()
+          local headers = request_headers({
             ["X-Forwarded-Prefix"] = "/replaced",
-          }
+          }, "/foo")
 
-          assert.equal("/", headers["x-forwarded-prefix"])
+          assert.equal("/foo", headers["x-forwarded-prefix"])
+        end)
+
+        it("should not be added if path was not stripped", function()
+          local headers = request_headers({}, "/status/200")
+
+          assert.is_nil(headers["x-forwarded-prefix"])
+        end)
+
+        it("should not be added if / was stripped", function()
+          local headers = request_headers({}, "/")
+
+          assert.is_nil(headers["x-forwarded-prefix"])
         end)
       end)
 
@@ -315,7 +339,6 @@ for _, strategy in helpers.each_strategy() do
           assert.equal("http", headers["x-forwarded-proto"])
           assert.equal("preserved.com", headers["x-forwarded-host"])
           assert.equal(helpers.get_proxy_port(false), tonumber(headers["x-forwarded-port"]))
-          assert.equal("/", headers["x-forwarded-prefix"])
         end)
 
         it("should be added if present in request while preserving the downstream host", function()
@@ -334,7 +357,6 @@ for _, strategy in helpers.each_strategy() do
           assert.equal("http", headers["x-forwarded-proto"])
           assert.equal("preserved.com", headers["x-forwarded-host"])
           assert.equal(helpers.get_proxy_port(false), tonumber(headers["x-forwarded-port"]))
-          assert.equal("/", headers["x-forwarded-prefix"])
         end)
       end)
 
@@ -352,7 +374,6 @@ for _, strategy in helpers.each_strategy() do
           assert.equal("http", headers["x-forwarded-proto"])
           assert.equal("headers-inspect.com", headers["x-forwarded-host"])
           assert.equal(helpers.get_proxy_port(false), tonumber(headers["x-forwarded-port"]))
-          assert.equal("/", headers["x-forwarded-prefix"])
         end)
 
         it("if present in request while discarding the downstream host", function()
@@ -373,7 +394,6 @@ for _, strategy in helpers.each_strategy() do
           assert.equal("http", headers["x-forwarded-proto"])
           assert.equal("headers-inspect.com", headers["x-forwarded-host"])
           assert.equal(helpers.get_proxy_port(false), tonumber(headers["x-forwarded-port"]))
-          assert.equal("/", headers["x-forwarded-prefix"])
         end)
       end)
 
@@ -487,24 +507,22 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       describe("X-Forwarded-Prefix", function()
-        it("should be added if not present in request", function()
-          local headers = request_headers {
-            ["Host"] = "headers-inspect.com",
-          }
+        it("should be preserved even if path was stripped", function()
+          local headers = request_headers({
+            ["x-forwarded-prefix"] = "/preserved",
+          }, "/foo/status/200")
 
-          assert.equal("/", headers["x-forwarded-prefix"])
+          assert.equal("/preserved", headers["x-forwarded-prefix"])
         end)
 
-        it("should be forwarded if present in request", function()
-          local headers = request_headers {
-            ["Host"]             = "headers-inspect.com",
-            ["X-Forwarded-Prefix"] = "/original-path",
-          }
+        it("should be preserved even if path was stripped", function()
+          local headers = request_headers({
+            ["x-forwarded-prefix"] = "/preserved",
+          }, "/status/200")
 
-          assert.equal("/original-path", headers["x-forwarded-prefix"])
+          assert.equal("/preserved", headers["x-forwarded-prefix"])
         end)
       end)
-
     end)
 
     describe("(using the non-trusted configuration values)", function()
@@ -615,21 +633,30 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       describe("X-Forwarded-Prefix", function()
-        it("should be added if not present in request", function()
-          local headers = request_headers {
-            ["Host"] = "headers-inspect.com",
-          }
+        it("should be added if path was stripped", function()
+          local headers = request_headers({}, "/foo/status/200")
 
-          assert.equal("/", headers["x-forwarded-prefix"])
+          assert.equal("/foo", headers["x-forwarded-prefix"])
         end)
 
-        it("should be replaced if present in request", function()
-          local headers = request_headers {
-            ["Host"]             = "headers-inspect.com",
-            ["X-Forwarded-Prefix"] = "/untrusted",
-          }
+        it("should be replaced if present in request and path was stripped", function()
+          local headers = request_headers({
+            ["X-Forwarded-Prefix"] = "/replaced",
+          }, "/foo")
 
-          assert.equal("/", headers["x-forwarded-prefix"])
+          assert.equal("/foo", headers["x-forwarded-prefix"])
+        end)
+
+        it("should not be added if path was not stripped", function()
+          local headers = request_headers({}, "/status/200")
+
+          assert.is_nil(headers["x-forwarded-prefix"])
+        end)
+
+        it("should not be added if / was stripped", function()
+          local headers = request_headers({}, "/")
+
+          assert.is_nil(headers["x-forwarded-prefix"])
         end)
       end)
     end)


### PR DESCRIPTION
Pick non-breaking parts of fix https://github.com/Kong/kong/pull/6201 into master and add a few more tests.

New behavior:
- Stripped portion of path is added as X-Forwarded-Prefix 
- Stripped portion of path is *not* added as X-Forwarded-Prefix if it is `/`
- Stripped portion of path is *not* added as X-Forwarded-Prefix if a X-Forwarded-Prefix is received from a trusted client 