### PR TITLE
fix(migrations) make cassandra ws_update_keys re-entrant

### DIFF
--- a/kong/db/migrations/operations/200_to_210.lua
+++ b/kong/db/migrations/operations/200_to_210.lua
@@ -343,29 +343,31 @@ local cassandra = {
         end
 
         for _, row in ipairs(rows) do
-          local set_list = { "ws_id = " .. default_ws }
-          for _, key in ipairs(unique_keys) do
-            if row[key] then
-              table.insert(set_list, render([[$(KEY) = '$(WS):$(VALUE)']], {
-                KEY = key,
-                WS = default_ws,
-                VALUE = row[key],
-              }))
+          if row.ws_id == nil then
+            local set_list = { "ws_id = " .. default_ws }
+            for _, key in ipairs(unique_keys) do
+              if row[key] then
+                table.insert(set_list, render([[$(KEY) = '$(WS):$(VALUE)']], {
+                  KEY = key,
+                  WS = default_ws,
+                  VALUE = row[key],
+                }))
+              end
             end
+
+            local cql = render([[
+              UPDATE $(TABLE) SET $(SET_LIST) WHERE $(PARTITION) id = $(ID)
+            ]], {
+              PARTITION = is_partitioned
+                          and "partition = '" .. table_name .. "' AND"
+                          or  "",
+              TABLE = table_name,
+              SET_LIST = table.concat(set_list, ", "),
+              ID = row.id,
+            })
+
+            assert(connector:query(cql))
           end
-
-          local cql = render([[
-            UPDATE $(TABLE) SET $(SET_LIST) WHERE $(PARTITION) id = $(ID)
-          ]], {
-            PARTITION = is_partitioned
-                        and "partition = '" .. table_name .. "' AND"
-                        or  "",
-            TABLE = table_name,
-            SET_LIST = table.concat(set_list, ", "),
-            ID = row.id,
-          })
-
-          assert(connector:query(cql))
         end
       end
     end,


### PR DESCRIPTION
### Summary

When running migrations with `force`, e.g.:

```
kong migrations up -f
```

OR

```
kong migrations finish -f
```

Cassandra could ran `ws_update_keys` multiple times, even on a
row that was already updated. This commit makes it not to do that
for already updated rows.

It was noted that when migrations fail without `force` and they
are ran again without `force` there is re-entrancy problem too,
that this fixes.

This was added as a quick fix for upcoming 2.1.2.