### PR TITLE
feat(datadog) add support for distribution metric type

### DIFF
--- a/kong/plugins/datadog/handler.lua
+++ b/kong/plugins/datadog/handler.lua
@@ -87,7 +87,7 @@ end
 
 local DatadogHandler = {
   PRIORITY = 10,
-  VERSION = "3.0.1",
+  VERSION = "3.0.2",
 }
 
 

--- a/kong/plugins/datadog/schema.lua
+++ b/kong/plugins/datadog/schema.lua
@@ -16,6 +16,7 @@ local STAT_TYPES = {
   "meter",
   "set",
   "timer",
+  "distribution",
 }
 
 local CONSUMER_IDENTIFIERS = {

--- a/kong/plugins/datadog/statsd_logger.lua
+++ b/kong/plugins/datadog/statsd_logger.lua
@@ -7,12 +7,13 @@ local tostring     = tostring
 
 
 local stat_types = {
-  gauge     = "g",
-  counter   = "c",
-  timer     = "ms",
-  histogram = "h",
-  meter     = "m",
-  set       = "s",
+  gauge        = "g",
+  counter      = "c",
+  timer        = "ms",
+  histogram    = "h",
+  meter        = "m",
+  set          = "s",
+  distribution = "d",
 }
 
 

--- a/spec/03-plugins/08-datadog/01-log_spec.lua
+++ b/spec/03-plugins/08-datadog/01-log_spec.lua
@@ -94,6 +94,12 @@ for _, strategy in helpers.each_strategy() do
               sample_rate = 1,
               tags        = {"T2:V2:V3", "T4"},
             },
+            {
+              name        = "request_size",
+              stat_type   = "distribution",
+              sample_rate = 1,
+              tags        = {},
+            },
           },
         },
       }
@@ -194,7 +200,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     it("logs metrics with tags", function()
-      local thread = helpers.udp_server(9999, 2)
+      local thread = helpers.udp_server(9999, 3)
 
       local res = assert(proxy_client:send {
         method  = "GET",
@@ -209,6 +215,7 @@ for _, strategy in helpers.each_strategy() do
       assert.True(ok)
       assert.contains("kong.request.count:1|c|#name:dd3,status:200,T2:V2,T3:V3,T4", gauges)
       assert.contains("kong.latency:%d+|g|#name:dd3,status:200,T2:V2:V3,T4", gauges, true)
+      assert.contains("kong.request.size:%d+|d|#name:dd3,status:200", gauges, true)
     end)
 
     it("should not return a runtime error (regression)", function()


### PR DESCRIPTION
### Summary

This PR adds support for the [distribution metric type](https://docs.datadoghq.com/developers/metrics/types/?tab=distribution#metric-types) in Datadog as per the [datagram format documentation](https://docs.datadoghq.com/developers/dogstatsd/datagram_shell?tab=metrics)

```
<TYPE> | Yes | c for COUNT, g for GAUGE, ms for TIMER, h for HISTOGRAM, s for SET, d for DISTRIBUTION. See the metric type documentation.
-- | -- | --
```

### Full changelog

* Add `stat_type` `distribution` to schema validation
* Use type `d` on datagram packet for distribution metrics
* None of the existing tests specifically address different stat types so I have simply extended an existing test to confirm that this works (incidentally also testing a previously untested edge scenario for that test - i.e. tags explicitly set to empty). 

