### PR TITLE
feat(datadog) add optional uri tag

### DIFF
--- a/kong/plugins/datadog/handler.lua
+++ b/kong/plugins/datadog/handler.lua
@@ -22,13 +22,16 @@ local get_consumer_id = {
 }
 
 
-local function compose_tags(conf, service_name, status, consumer_id, tags)
+local function compose_tags(conf, service_name, status, consumer_id, request_uri, tags)
   local result = {
     conf.service_name_tag..":"..service_name,
     conf.status_tag..":"..status
   }
   if consumer_id ~= nil then
     insert(result, conf.consumer_tag..":" ..consumer_id)
+  end
+  if conf.uri_tag then
+    insert(result, conf.uri_tag..":" ..request_uri)
   end
   if tags ~= nil then
     for _, v in pairs(tags) do
@@ -76,7 +79,7 @@ local function log(premature, conf, message)
     local stat_value      = stat_value[metric_config.name]
     local get_consumer_id = get_consumer_id[metric_config.consumer_identifier]
     local consumer_id     = get_consumer_id and get_consumer_id(message.consumer) or nil
-    local tags            = compose_tags(conf, name, message.response.status, consumer_id, metric_config.tags)
+    local tags            = compose_tags(conf, name, message.response.status, consumer_id, message.request.uri, metric_config.tags)
 
     if stat_name ~= nil then
       logger:send_statsd(stat_name, stat_value,
@@ -90,7 +93,7 @@ end
 
 local DatadogHandler = {
   PRIORITY = 10,
-  VERSION = "3.0.2",
+  VERSION = "3.0.3",
 }
 
 

--- a/kong/plugins/datadog/handler.lua
+++ b/kong/plugins/datadog/handler.lua
@@ -22,10 +22,13 @@ local get_consumer_id = {
 }
 
 
-local function compose_tags(service_name, status, consumer_id, tags)
-  local result = {"name:" ..service_name, "status:"..status}
+local function compose_tags(conf, service_name, status, consumer_id, tags)
+  local result = {
+    conf.service_name_tag..":"..service_name,
+    conf.status_tag..":"..status
+  }
   if consumer_id ~= nil then
-    insert(result, "consumer:" ..consumer_id)
+    insert(result, conf.consumer_tag..":" ..consumer_id)
   end
   if tags ~= nil then
     for _, v in pairs(tags) do
@@ -73,7 +76,7 @@ local function log(premature, conf, message)
     local stat_value      = stat_value[metric_config.name]
     local get_consumer_id = get_consumer_id[metric_config.consumer_identifier]
     local consumer_id     = get_consumer_id and get_consumer_id(message.consumer) or nil
-    local tags            = compose_tags(name, message.response.status, consumer_id, metric_config.tags)
+    local tags            = compose_tags(conf, name, message.response.status, consumer_id, metric_config.tags)
 
     if stat_name ~= nil then
       logger:send_statsd(stat_name, stat_value,
@@ -87,7 +90,7 @@ end
 
 local DatadogHandler = {
   PRIORITY = 10,
-  VERSION = "3.0.1",
+  VERSION = "3.0.2",
 }
 
 

--- a/kong/plugins/datadog/schema.lua
+++ b/kong/plugins/datadog/schema.lua
@@ -76,6 +76,9 @@ return {
           { host = typedefs.host({ required = true, default = "localhost" }), },
           { port = typedefs.port({ required = true, default = 8125 }), },
           { prefix = { type = "string", default = "kong" }, },
+          { service_name_tag = { type = "string", default = "name" }, },
+          { status_tag = { type = "string", default = "status" }, },
+          { consumer_tag = { type = "string", default = "consumer" }, },
           { metrics = {
               type     = "array",
               required = true,

--- a/kong/plugins/datadog/schema.lua
+++ b/kong/plugins/datadog/schema.lua
@@ -79,6 +79,7 @@ return {
           { service_name_tag = { type = "string", default = "name" }, },
           { status_tag = { type = "string", default = "status" }, },
           { consumer_tag = { type = "string", default = "consumer" }, },
+          { uri_tag = { type = "string" }, },
           { metrics = {
               type     = "array",
               required = true,

--- a/spec/03-plugins/08-datadog/01-log_spec.lua
+++ b/spec/03-plugins/08-datadog/01-log_spec.lua
@@ -45,6 +45,11 @@ for _, strategy in helpers.each_strategy() do
         service = bp.services:insert { name = "dd4" }
       }
 
+      local route5 = bp.routes:insert {
+        hosts   = { "datadog5.com" },
+        service = bp.services:insert { name = "dd5" }
+      }
+
       bp.plugins:insert {
         name     = "key-auth",
         route = { id = route1.id },
@@ -113,6 +118,23 @@ for _, strategy in helpers.each_strategy() do
         },
       }
 
+      bp.plugins:insert {
+        name     = "key-auth",
+        route = { id = route5.id },
+      }
+
+      bp.plugins:insert {
+        name     = "datadog",
+        route = { id = route5.id },
+        config   = {
+          host             = "127.0.0.1",
+          port             = 9999,
+          service_name_tag = "upstream",
+          status_tag       = "http_status",
+          consumer_tag     = "user",
+        },
+      }
+
       assert(helpers.start_kong({
         database   = strategy,
         nginx_conf = "spec/fixtures/custom_nginx.template",
@@ -172,6 +194,29 @@ for _, strategy in helpers.each_strategy() do
       assert.contains("prefix.response.size:%d+|ms|#name:dd4,status:200,consumer:bar,app:kong", gauges, true)
       assert.contains("prefix.upstream_latency:%d+|ms|#name:dd4,status:200,consumer:bar,app:kong", gauges, true)
       assert.contains("prefix.kong_latency:%d*|ms|#name:dd4,status:200,consumer:bar,app:kong", gauges, true)
+    end)
+
+    it("logs metrics over UDP with custom tag names", function()
+      local thread = helpers.udp_server(9999, 6)
+
+      local res = assert(proxy_client:send {
+        method  = "GET",
+        path    = "/status/200?apikey=kong",
+        headers = {
+          ["Host"] = "datadog5.com"
+        }
+      })
+      assert.res_status(200, res)
+
+      local ok, gauges = thread:join()
+      assert.True(ok)
+      assert.equal(6, #gauges)
+      assert.contains("kong.request.count:1|c|#upstream:dd5,http_status:200,user:bar,app:kong",gauges)
+      assert.contains("kong.latency:%d+|ms|#upstream:dd5,http_status:200,user:bar,app:kong", gauges, true)
+      assert.contains("kong.request.size:%d+|ms|#upstream:dd5,http_status:200,user:bar,app:kong", gauges, true)
+      assert.contains("kong.response.size:%d+|ms|#upstream:dd5,http_status:200,user:bar,app:kong", gauges, true)
+      assert.contains("kong.upstream_latency:%d+|ms|#upstream:dd5,http_status:200,user:bar,app:kong", gauges, true)
+      assert.contains("kong.kong_latency:%d*|ms|#upstream:dd5,http_status:200,user:bar,app:kong", gauges, true)
     end)
 
     it("logs only given metrics", function()


### PR DESCRIPTION
### Summary

This PR adds the ability to tag metrics exported by the `datadog` plugin with the request uri reported by the log.

### Full changelog

* add schema element `uri_tag` to `datadog` plugin. When set this will add the request uri as a tag on metrics exported by the plugin
* Add test to ensure tag is successfully exported when config is set. Negative case (i.e. tag is not exported when config is not set) is implicitly tested in existing test suite
* Note: currently rebased off of https://github.com/Kong/kong/pull/6230 for the purposes of code re-usage. Happy to adjust as needed.