### PR TITLE
chore(automation) automate additional steps that dont need to be human ran

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -443,6 +443,33 @@ pipeline {
                         }
                     }
                 }
+                stage('Release to luarocks') {
+                    agent {
+                        node {
+                            label 'bionic'
+                        }
+                    }
+                    environment {
+                        SLACK_WEBHOOK = credentials('core_team_slack_webhook')
+                        LUAROCKS_API_KEY = credentials('luarocks_api_key')
+                    }
+                    steps {
+                        sh './scripts/setup-ci.sh'
+                        sh 'echo "y" | ./scripts/make-patch-release $TAG_NAME luarocks $LUAROCKS_API_KEY'
+                    }
+                    post {
+                        failure {
+                            script {
+                                sh 'SLACK_MESSAGE="releasing to luarocks failed" ./scripts/send-slack-message.sh'
+                            }
+                        }
+                        success {
+                            script {
+                                sh 'SLACK_MESSAGE="updating luarocks succeeded. No action i./s necessary this message is informational only" ./scripts/send-slack-message.sh'
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -318,5 +318,27 @@ pipeline {
                 }
             }
         }
+        stage('Post Release') {
+            when {
+                beforeAgent true
+                allOf {
+                    buildingTag()
+                    not { triggeredBy 'TimerTrigger' }
+                }
+            }
+            stage('Post Release Steps'){
+                agent {
+                    node {
+                        label 'bionic'
+                    }
+                }
+                steps {
+                    sh './scripts/make-patch-release $TAG_NAME update_docker'
+                    sh './scripts/make-patch-release $TAG_NAME homebrew'
+                    sh './scripts/make-patch-release $TAG_NAME vagrant'
+                    sh './scripts/make-patch-release $TAG_NAME pongo'
+                }
+            }
+        }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -318,7 +318,7 @@ pipeline {
                 }
             }
         }
-        stage('Post Release') {
+        stage('Post Packaging Steps') {
             when {
                 beforeAgent true
                 allOf {
@@ -326,17 +326,122 @@ pipeline {
                     not { triggeredBy 'TimerTrigger' }
                 }
             }
-            stage('Post Release Steps'){
-                agent {
-                    node {
-                        label 'bionic'
+            parallel {
+                stage('PR Docker') {
+                    agent {
+                        node {
+                            label 'bionic'
+                        }
+                    }
+                    environment {
+                        GITHUB_TOKEN = credentials('github_bot_access_token')
+                        GITHUB_SSH_KEY = credentials('github_bot_ssh_key')
+                        SLACK_WEBHOOK = credentials('core_team_slack_webhook')
+                        GITHUB_USER = "mashapedeployment"
+                    }
+                    steps {
+                        sh './scripts/setup-ci.sh'
+                        sh 'echo "y" | ./scripts/make-patch-release $TAG_NAME update_docker'
+                    }
+                    post {
+                        failure {
+                            script {
+                                sh 'SLACK_MESSAGE="updating docker-kong failed" ./scripts/send-slack-message.sh'
+                            }
+                        }
+                        success {
+                            script {
+                                sh 'SLACK_MESSAGE="updating docker-kong succeeded. Please review and approve the release PR" ./scripts/send-slack-message.sh'
+                            }
+                        }
                     }
                 }
-                steps {
-                    sh './scripts/make-patch-release $TAG_NAME update_docker'
-                    sh './scripts/make-patch-release $TAG_NAME homebrew'
-                    sh './scripts/make-patch-release $TAG_NAME vagrant'
-                    sh './scripts/make-patch-release $TAG_NAME pongo'
+                stage('PR Homebrew') {
+                    agent {
+                        node {
+                            label 'bionic'
+                        }
+                    }
+                    environment {
+                        GITHUB_TOKEN = credentials('github_bot_access_token')
+                        GITHUB_SSH_KEY = credentials('github_bot_ssh_key')
+                        SLACK_WEBHOOK = credentials('core_team_slack_webhook')
+                        GITHUB_USER = "mashapedeployment"
+                    }
+                    steps {
+                        sh './scripts/setup-ci.sh'
+                        sh 'echo "y" | ./scripts/make-patch-release $TAG_NAME homebrew'
+                    }
+                    post {
+                        failure {
+                            script {
+                                sh 'SLACK_MESSAGE="updating homebrew-kong failed" ./scripts/send-slack-message.sh'
+                            }
+                        }
+                        success {
+                            script {
+                                sh 'SLACK_MESSAGE="updating homebrew-kong succeeded. Please review and approve the release PR" ./scripts/send-slack-message.sh'
+                            }
+                        }
+                    }
+                }
+                stage('PR Vagrant') {
+                    agent {
+                        node {
+                            label 'bionic'
+                        }
+                    }
+                    environment {
+                        GITHUB_TOKEN = credentials('github_bot_access_token')
+                        GITHUB_SSH_KEY = credentials('github_bot_ssh_key')
+                        SLACK_WEBHOOK = credentials('core_team_slack_webhook')
+                        GITHUB_USER = "mashapedeployment"
+                    }
+                    steps {
+                        sh './scripts/setup-ci.sh'
+                        sh 'echo "y" | ./scripts/make-patch-release $TAG_NAME vagrant'
+                    }
+                    post {
+                        failure {
+                            script {
+                                sh 'SLACK_MESSAGE="updating kong-vagrant failed" ./scripts/send-slack-message.sh'
+                            }
+                        }
+                        success {
+                            script {
+                                sh 'SLACK_MESSAGE="updating kong-vagrant succeeded. Please review and approve the release PR" ./scripts/send-slack-message.sh'
+                            }
+                        }
+                    }
+                }
+                stage('PR Pongo') {
+                    agent {
+                        node {
+                            label 'bionic'
+                        }
+                    }
+                    environment {
+                        GITHUB_TOKEN = credentials('github_bot_access_token')
+                        GITHUB_SSH_KEY = credentials('github_bot_ssh_key')
+                        SLACK_WEBHOOK = credentials('core_team_slack_webhook')
+                        GITHUB_USER = "mashapedeployment"
+                    }
+                    steps {
+                        sh './scripts/setup-ci.sh'
+                        sh 'echo "y" | ./scripts/make-patch-release $TAG_NAME pongo'
+                    }
+                    post {
+                        failure {
+                            script {
+                                sh 'SLACK_MESSAGE="updating kong-pongo failed" ./scripts/send-slack-message.sh'
+                            }
+                        }
+                        success {
+                            script {
+                                sh 'SLACK_MESSAGE="updating kong-pongo succeeded. Please review and approve the release PR" ./scripts/send-slack-message.sh'
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -210,6 +210,9 @@ function update_docker {
         cd docker-kong
     fi
     
+    git pull
+    git checkout -B "release/$1"
+    
     set -e
     ./update.sh "$1"
 }

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,0 +1,266 @@
+#!/bin/bash
+
+#-------------------------------------------------------------------------------
+function commit_changelog() {
+    if ! git status CHANGELOG.md | grep -q "modified:"
+        then
+            die "No changes in CHANGELOG.md to commit. Did you write the changelog?"
+        fi
+    
+        git diff CHANGELOG.md
+    
+        CONFIRM "If everything looks all right, press Enter to commit" \
+                  "or Ctrl-C to cancel."
+    
+        set -e
+        git add CHANGELOG.md
+        git commit -m "docs(changelog) add $1 changes"
+        git log -n 1
+}
+
+#-------------------------------------------------------------------------------
+function bump_homebrew() {
+   curl -L -o "kong-$version.tar.gz" "https://bintray.com/kong/kong-src/download_file?file_path=kong-$version.tar.gz"
+   sum=$(sha256sum "kong-$version.tar.gz" | awk '{print $1}')
+   sed -i 's/kong-[0-9.]*.tar.gz/kong-'$version'.tar.gz/' Formula/kong.rb
+   sed -i 's/sha256 ".*"/sha256 "'$sum'"/' Formula/kong.rb
+}
+
+#-------------------------------------------------------------------------------
+function bump_vagrant() {
+   sed -i 's/version = "[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*"/version = "'$version'"/' Vagrantfile
+   sed -i 's/`[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*`/`'$version'`/' README.md
+}
+
+#-------------------------------------------------------------------------------
+function ensure_recent_luarocks() {
+   if ! ( luarocks upload --help | grep -q temp-key )
+   then
+      if [ `uname -s` = "Linux" ]
+      then
+         set -e
+         source .requirements
+         lv=3.2.1
+         pushd /tmp
+         rm -rf luarocks-$lv
+         mkdir -p luarocks-$lv
+         cd luarocks-$lv
+         curl -L -o "luarocks-$lv-linux-x86_64.zip" https://luarocks.github.io/luarocks/releases/luarocks-$lv-linux-x86_64.zip
+         unzip luarocks-$lv-linux-x86_64.zip
+         export PATH=/tmp/luarocks-$lv/luarocks-$lv-linux-x86_64:$PATH
+         popd
+      else
+         die "Your LuaRocks version is too old. Please upgrade LuaRocks."
+      fi
+   fi
+}
+
+#-------------------------------------------------------------------------------
+function make_github_release_file() {
+   versionlink=$(echo $version | tr -d .)
+   cat <<EOF > release-$version.txt
+$version
+
+**Download Kong $version and run it now:**
+
+- https://konghq.com/install/
+- [Docker Image](https://hub.docker.com/_/kong/)
+
+Links:
+- [$version Changelog](https://github.com/Kong/kong/blob/master/CHANGELOG.md#$versionlink)
+EOF
+}
+
+#-------------------------------------------------------------------------------
+function bump_docs_kong_versions() {
+   $LUA -e '
+      local fd_in = io.open("app/_data/kong_versions.yml", "r")
+      local fd_out = io.open("app/_data/kong_versions.yml.new", "w")
+      local version = "'$version'"
+
+      local state = "start"
+      local version_line
+      for line in fd_in:lines() do
+         if state == "start" then
+            if line:match("^  release: \"'$major'.'$minor'.x\"") then
+               state = "version"
+            end
+            fd_out:write(line .. "\n")
+         elseif state == "version" then
+            if line:match("^  version: \"") then
+               version_line = line
+               state = "edition"
+            end
+         elseif state == "edition" then
+            if line:match("^  edition.*community.*") then
+               fd_out:write("  version: \"'$version'\"\n")
+               state = "wait_for_luarocks_version"
+            else
+               fd_out:write(version_line .. "\n")
+               state = "start"
+            end
+            fd_out:write(line .. "\n")
+         elseif state == "wait_for_luarocks_version" then
+            if line:match("^  luarocks_version: \"") then
+               fd_out:write("  luarocks_version: \"'$version'-0\"\n")
+               state = "last"
+            else
+               fd_out:write(line .. "\n")
+            end
+         elseif state == "last" then
+            fd_out:write(line .. "\n")
+         end
+      end
+      fd_in:close()
+      fd_out:close()
+   '
+   mv app/_data/kong_versions.yml.new app/_data/kong_versions.yml
+}
+
+#-------------------------------------------------------------------------------
+function prepare_changelog() {
+   $LUA -e '
+      local fd_in = io.open("CHANGELOG.md", "r")
+      local fd_out = io.open("CHANGELOG.md.new", "w")
+      local version = "'$version'"
+
+      local state = "start"
+      for line in fd_in:lines() do
+         if state == "start" then
+            if line:match("^%- %[") then
+               fd_out:write("- [" .. version .. "](#" .. version:gsub("%.", "") .. ")\n")
+               state = "toc"
+            end
+         elseif state == "toc" then
+            if not line:match("^%- %[") then
+               state = "start_log"
+            end
+         elseif state == "start_log" then
+            fd_out:write("\n")
+            fd_out:write("## [" .. version .. "]\n")
+            fd_out:write("\n")
+            local today = os.date("*t")
+            fd_out:write(("> Released %04d/%02d/%02d\n"):format(today.year, today.month, today.day))
+            fd_out:write("\n")
+            fd_out:write("<<< TODO Introduction, plus any sections below >>>\n")
+            fd_out:write("\n")
+            fd_out:write("### Fixes\n")
+            fd_out:write("\n")
+            fd_out:write("##### Core\n")
+            fd_out:write("\n")
+            fd_out:write("##### CLI\n")
+            fd_out:write("\n")
+            fd_out:write("##### Configuration\n")
+            fd_out:write("\n")
+            fd_out:write("##### Admin API\n")
+            fd_out:write("\n")
+            fd_out:write("##### PDK\n")
+            fd_out:write("\n")
+            fd_out:write("##### Plugins\n")
+            fd_out:write("\n")
+            fd_out:write("\n")
+            fd_out:write("[Back to TOC](#table-of-contents)\n")
+            fd_out:write("\n")
+            state = "log"
+         elseif state == "log" then
+            local prev_version = line:match("^%[(%d+%.%d+%.%d+)%]: ")
+            if prev_version then
+               fd_out:write("[" .. version .. "]: https://github.com/Kong/kong/compare/" .. prev_version .."..." .. version .. "\n")
+               state = "last"
+            end
+         end
+
+         fd_out:write(line .. "\n")
+      end
+      fd_in:close()
+      fd_out:close()
+   '
+   mv CHANGELOG.md.new CHANGELOG.md
+}
+
+#-------------------------------------------------------------------------------	
+function step() {	
+   box="   "	
+   color="$nocolor"	
+   if [ "$version" != "<x.y.z>" ]	
+   then	
+      if [ -e "/tmp/.step-$1-$version" ]	
+      then	
+         color="$green"	
+         box="[x]"	
+      else	
+         color="$bold"	
+         box="[ ]"	
+      fi	
+   fi	
+   echo -e "$color $box Step $c) $2"	
+   echo "        $0 $version $1 $3"	
+   echo -e "$nocolor"	
+   c="$[c+1]"	
+}
+
+#-------------------------------------------------------------------------------
+function update_docker {
+    if [ -d ../docker-kong ]
+    then
+        cd ../docker-kong
+    else
+        cd ..
+        git clone https://github.com/kong/docker-kong
+        cd docker-kong
+    fi
+    
+    set -e
+    ./update.sh "$1"
+}
+
+#-------------------------------------------------------------------------------
+function die() {
+   echo
+   echo -e "$red$bold*** $@$nocolor"
+   echo "See also: $0 --help"
+   echo
+   exit 1
+}
+
+#-------------------------------------------------------------------------------
+function SUCCESS() {
+   echo
+   echo -e "$green$bold****************************************$nocolor$bold"
+   for line in "$@"
+   do
+      echo "$line"
+   done
+   echo -e "$green$bold****************************************$nocolor"
+   echo
+   touch /tmp/.step-$step-$version
+   exit 0
+}
+
+#-------------------------------------------------------------------------------
+function CONFIRM() {
+   echo
+   echo -e "$cyan$bold----------------------------------------$nocolor$bold"
+   for line in "$@"
+   do
+      echo "$line"
+   done
+   echo -e "$cyan$bold----------------------------------------$nocolor"
+   read
+}
+
+#-------------------------------------------------------------------------------
+# Dependency checks
+#-------------------------------------------------------------------------------
+
+hub --version &> /dev/null || die "hub is not in PATH. Get it from https://github.com/github/hub"
+
+if resty -v &> /dev/null
+then
+   LUA=resty
+elif lua -v &> /dev/null
+then
+   LUA=lua
+else
+   die "Lua interpreter is not in PATH. Install any Lua or OpenResty to run this script."
+fi

--- a/scripts/make-patch-release
+++ b/scripts/make-patch-release
@@ -6,26 +6,7 @@ cyan="\033[0;36m"
 bold="\033[1m"
 nocolor="\033[0m"
 
-#-------------------------------------------------------------------------------
-function step() {
-   box="   "
-   color="$nocolor"
-   if [ "$version" != "<x.y.z>" ]
-   then
-      if [ -e "/tmp/.step-$1-$version" ]
-      then
-         color="$green"
-         box="[x]"
-      else
-         color="$bold"
-         box="[ ]"
-      fi
-   fi
-   echo -e "$color $box Step $c) $2"
-   echo "        $0 $version $1 $3"
-   echo -e "$nocolor"
-   c="$[c+1]"
-}
+source $(dirname "$0")/common.sh
 
 #-------------------------------------------------------------------------------
 function usage() {
@@ -55,57 +36,6 @@ function usage() {
    step "pongo"            "bump version and submit a PR to kong-pongo"
    exit 0
 }
-
-#-------------------------------------------------------------------------------
-function die() {
-   echo
-   echo -e "$red$bold*** $@$nocolor"
-   echo "See also: $0 --help"
-   echo
-   exit 1
-}
-
-#-------------------------------------------------------------------------------
-function SUCCESS() {
-   echo
-   echo -e "$green$bold****************************************$nocolor$bold"
-   for line in "$@"
-   do
-      echo "$line"
-   done
-   echo -e "$green$bold****************************************$nocolor"
-   echo
-   touch /tmp/.step-$step-$version
-   exit 0
-}
-
-#-------------------------------------------------------------------------------
-function CONFIRM() {
-   echo
-   echo -e "$cyan$bold----------------------------------------$nocolor$bold"
-   for line in "$@"
-   do
-      echo "$line"
-   done
-   echo -e "$cyan$bold----------------------------------------$nocolor"
-   read
-}
-
-#-------------------------------------------------------------------------------
-# Dependency checks
-#-------------------------------------------------------------------------------
-
-hub --version &> /dev/null || die "hub is not in PATH. Get it from https://github.com/github/hub"
-
-if resty -v &> /dev/null
-then
-   LUA=resty
-elif lua -v &> /dev/null
-then
-   LUA=lua
-else
-   die "Lua interpreter is not in PATH. Install any Lua or OpenResty to run this script."
-fi
 
 #-------------------------------------------------------------------------------
 # Default help
@@ -142,166 +72,6 @@ then
 fi
 
 EDITOR="${EDITOR-$VISUAL}"
-
-#-------------------------------------------------------------------------------
-function prepare_changelog() {
-   $LUA -e '
-      local fd_in = io.open("CHANGELOG.md", "r")
-      local fd_out = io.open("CHANGELOG.md.new", "w")
-      local version = "'$version'"
-
-      local state = "start"
-      for line in fd_in:lines() do
-         if state == "start" then
-            if line:match("^%- %[") then
-               fd_out:write("- [" .. version .. "](#" .. version:gsub("%.", "") .. ")\n")
-               state = "toc"
-            end
-         elseif state == "toc" then
-            if not line:match("^%- %[") then
-               state = "start_log"
-            end
-         elseif state == "start_log" then
-            fd_out:write("\n")
-            fd_out:write("## [" .. version .. "]\n")
-            fd_out:write("\n")
-            local today = os.date("*t")
-            fd_out:write(("> Released %04d/%02d/%02d\n"):format(today.year, today.month, today.day))
-            fd_out:write("\n")
-            fd_out:write("<<< TODO Introduction, plus any sections below >>>\n")
-            fd_out:write("\n")
-            fd_out:write("### Fixes\n")
-            fd_out:write("\n")
-            fd_out:write("##### Core\n")
-            fd_out:write("\n")
-            fd_out:write("##### CLI\n")
-            fd_out:write("\n")
-            fd_out:write("##### Configuration\n")
-            fd_out:write("\n")
-            fd_out:write("##### Admin API\n")
-            fd_out:write("\n")
-            fd_out:write("##### PDK\n")
-            fd_out:write("\n")
-            fd_out:write("##### Plugins\n")
-            fd_out:write("\n")
-            fd_out:write("\n")
-            fd_out:write("[Back to TOC](#table-of-contents)\n")
-            fd_out:write("\n")
-            state = "log"
-         elseif state == "log" then
-            local prev_version = line:match("^%[(%d+%.%d+%.%d+)%]: ")
-            if prev_version then
-               fd_out:write("[" .. version .. "]: https://github.com/Kong/kong/compare/" .. prev_version .."..." .. version .. "\n")
-               state = "last"
-            end
-         end
-
-         fd_out:write(line .. "\n")
-      end
-      fd_in:close()
-      fd_out:close()
-   '
-   mv CHANGELOG.md.new CHANGELOG.md
-}
-
-#-------------------------------------------------------------------------------
-function bump_docs_kong_versions() {
-   $LUA -e '
-      local fd_in = io.open("app/_data/kong_versions.yml", "r")
-      local fd_out = io.open("app/_data/kong_versions.yml.new", "w")
-      local version = "'$version'"
-
-      local state = "start"
-      local version_line
-      for line in fd_in:lines() do
-         if state == "start" then
-            if line:match("^  release: \"'$major'.'$minor'.x\"") then
-               state = "version"
-            end
-            fd_out:write(line .. "\n")
-         elseif state == "version" then
-            if line:match("^  version: \"") then
-               version_line = line
-               state = "edition"
-            end
-         elseif state == "edition" then
-            if line:match("^  edition.*community.*") then
-               fd_out:write("  version: \"'$version'\"\n")
-               state = "wait_for_luarocks_version"
-            else
-               fd_out:write(version_line .. "\n")
-               state = "start"
-            end
-            fd_out:write(line .. "\n")
-         elseif state == "wait_for_luarocks_version" then
-            if line:match("^  luarocks_version: \"") then
-               fd_out:write("  luarocks_version: \"'$version'-0\"\n")
-               state = "last"
-            else
-               fd_out:write(line .. "\n")
-            end
-         elseif state == "last" then
-            fd_out:write(line .. "\n")
-         end
-      end
-      fd_in:close()
-      fd_out:close()
-   '
-   mv app/_data/kong_versions.yml.new app/_data/kong_versions.yml
-}
-
-#-------------------------------------------------------------------------------
-function make_github_release_file() {
-   versionlink=$(echo $version | tr -d .)
-   cat <<EOF > release-$version.txt
-$version
-
-**Download Kong $version and run it now:**
-
-- https://konghq.com/install/
-- [Docker Image](https://hub.docker.com/_/kong/)
-
-Links:
-- [$version Changelog](https://github.com/Kong/kong/blob/master/CHANGELOG.md#$versionlink)
-EOF
-}
-
-#-------------------------------------------------------------------------------
-function bump_homebrew() {
-   curl -L -o "kong-$version.tar.gz" "https://bintray.com/kong/kong-src/download_file?file_path=kong-$version.tar.gz"
-   sum=$(sha256sum "kong-$version.tar.gz" | awk '{print $1}')
-   sed -i 's/kong-[0-9.]*.tar.gz/kong-'$version'.tar.gz/' Formula/kong.rb
-   sed -i 's/sha256 ".*"/sha256 "'$sum'"/' Formula/kong.rb
-}
-
-#-------------------------------------------------------------------------------
-function bump_vagrant() {
-   sed -i 's/version = "[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*"/version = "'$version'"/' Vagrantfile
-   sed -i 's/`[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*`/`'$version'`/' README.md
-}
-
-#-------------------------------------------------------------------------------
-function ensure_recent_luarocks() {
-   if ! ( luarocks upload --help | grep -q temp-key )
-   then
-      if [ `uname -s` = "Linux" ]
-      then
-         set -e
-         source .requirements
-         lv=3.2.1
-         pushd /tmp
-         rm -rf luarocks-$lv
-         mkdir -p luarocks-$lv
-         cd luarocks-$lv
-         curl -L -o "luarocks-$lv-linux-x86_64.zip" https://luarocks.github.io/luarocks/releases/luarocks-$lv-linux-x86_64.zip
-         unzip luarocks-$lv-linux-x86_64.zip
-         export PATH=/tmp/luarocks-$lv/luarocks-$lv-linux-x86_64:$PATH
-         popd
-      else
-         die "Your LuaRocks version is too old. Please upgrade LuaRocks."
-      fi
-   fi
-}
 
 case "$step" in
    #---------------------------------------------------------------------------
@@ -340,20 +110,7 @@ case "$step" in
       ;;
    #---------------------------------------------------------------------------
    commit_changelog)
-      if ! git status CHANGELOG.md | grep -q "modified:"
-      then
-         die "No changes in CHANGELOG.md to commit. Did you write the changelog?"
-      fi
-
-      git diff
-
-      CONFIRM "If everything looks all right, press Enter to commit" \
-              "or Ctrl-C to cancel."
-
-      set -e
-      git add CHANGELOG.md
-      git commit -m "docs(changelog) add $version changes"
-      git log -n 1
+      commit_changelog "$version"
 
       SUCCESS "The changelog is now committed locally." \
               "You are ready to run the next step:" \
@@ -471,17 +228,7 @@ case "$step" in
       ;;
    #---------------------------------------------------------------------------
    update_docker)
-      if [ -d ../docker-kong ]
-      then
-         cd ../docker-kong
-      else
-         cd ..
-         git clone https://github.com/kong/docker-kong
-         cd docker-kong
-      fi
-
-      set -e
-      ./update.sh "$version"
+      update_docker "$version"
 
       SUCCESS "Make sure you get the PR above approved and merged" \
               "before continuing to the step 'merge_docker'."

--- a/scripts/make-prerelease-release
+++ b/scripts/make-prerelease-release
@@ -6,26 +6,7 @@ cyan="\033[0;36m"
 bold="\033[1m"
 nocolor="\033[0m"
 
-#-------------------------------------------------------------------------------
-function step() {
-   box="   "
-   color="$nocolor"
-   if [ "$version" != "<x.y.z-alpha.n>" ]
-   then
-      if [ -e "/tmp/.step-$1-$version" ]
-      then
-         color="$green"
-         box="[x]"
-      else
-         color="$bold"
-         box="[ ]"
-      fi
-   fi
-   echo -e "$color $box Step $c) $2"
-   echo "        $0 -v $version -s $1 $3"
-   echo -e "$nocolor"
-   c="$[c+1]"
-}
+source $(dirname "$0")/common.sh
 
 #-------------------------------------------------------------------------------
 function usage() {
@@ -56,60 +37,6 @@ function usage() {
    fi
    exit 0
 }
-
-#-------------------------------------------------------------------------------
-function die() {
-   echo
-   for line in "$@"
-   do
-      echo -e "$red$bold*** $line$nocolor"
-   done
-   echo "See also: $0 -h"
-   echo
-   exit 1
-}
-
-#-------------------------------------------------------------------------------
-function SUCCESS() {
-   echo
-   echo -e "$green$bold****************************************$nocolor$bold"
-   for line in "$@"
-   do
-      echo "$line"
-   done
-   echo -e "$green$bold****************************************$nocolor"
-   echo
-   touch /tmp/.step-$step-$version
-   exit 0
-}
-
-#-------------------------------------------------------------------------------
-function CONFIRM() {
-   echo
-   echo -e "$cyan$bold----------------------------------------$nocolor$bold"
-   for line in "$@"
-   do
-      echo -e "$line"
-   done
-   echo -e "$cyan$bold----------------------------------------$nocolor"
-   read
-}
-
-#-------------------------------------------------------------------------------
-# Dependency checks
-#-------------------------------------------------------------------------------
-
-hub --version &> /dev/null || die "hub is not in PATH. Get it from https://github.com/github/hub"
-
-if resty -v &> /dev/null
-then
-   LUA=resty
-elif lua -v &> /dev/null
-then
-   LUA=lua
-else
-   die "Lua interpreter is not in PATH. Install any Lua or OpenResty to run this script."
-fi
 
 #-------------------------------------------------------------------------------
 # Variables
@@ -165,110 +92,6 @@ fi
 
 EDITOR="${EDITOR-$VISUAL}"
 
-#-------------------------------------------------------------------------------
-function prepare_changelog() {
-   $LUA -e '
-      local fd_in = io.open("CHANGELOG.md", "r")
-      local fd_out = io.open("CHANGELOG.md.new", "w")
-      local version = "'$xyzversion' UNRELEASED"
-
-      local state = "start"
-      for line in fd_in:lines() do
-         if state == "start" then
-            if line:match("^%- %[") then
-               fd_out:write("- [" .. version .. "](#" .. version:gsub("%.", "") .. ")\n")
-               state = "toc"
-            end
-         elseif state == "toc" then
-            if not line:match("^%- %[") then
-               state = "start_log"
-            end
-         elseif state == "start_log" then
-            fd_out:write("\n")
-            fd_out:write("## [" .. version .. "]\n")
-            fd_out:write("\n")
-            local today = os.date("*t")
-            fd_out:write("> Released TBD\n")
-            fd_out:write("\n")
-            fd_out:write("<<< TODO Introduction, plus any sections below >>>\n")
-            fd_out:write("\n")
-            fd_out:write("### Fixes\n")
-            fd_out:write("\n")
-            fd_out:write("##### Core\n")
-            fd_out:write("\n")
-            fd_out:write("##### CLI\n")
-            fd_out:write("\n")
-            fd_out:write("##### Configuration\n")
-            fd_out:write("\n")
-            fd_out:write("##### Admin API\n")
-            fd_out:write("\n")
-            fd_out:write("##### PDK\n")
-            fd_out:write("\n")
-            fd_out:write("##### Plugins\n")
-            fd_out:write("\n")
-            fd_out:write("\n")
-            fd_out:write("[Back to TOC](#table-of-contents)\n")
-            fd_out:write("\n")
-            state = "log"
-         elseif state == "log" then
-            local prev_version = line:match("^%[(%d+%.%d+%.%d+)%]: ")
-            if prev_version then
-               fd_out:write("[" .. version .. "]: https://github.com/Kong/kong/compare/" .. prev_version .."..." .. version .. "\n")
-               state = "last"
-            end
-         end
-
-         fd_out:write(line .. "\n")
-      end
-      fd_in:close()
-      fd_out:close()
-   '
-   mv CHANGELOG.md.new CHANGELOG.md
-}
-
-#-------------------------------------------------------------------------------
-function bump_docs_kong_versions() {
-cat <<EOF >> app/_data/kong_versions.yml
--
-  release: "$xyxversion"
-  version: "$xyzversion"
-  edition: "community"
-  luarocks_version: "$xyzversion-0"
-  dependencies:
-    luajit: "2.1.0-beta3"
-    luarocks: "$RESTY_LUAROCKS_VERSION"
-    cassandra: "3.x.x"
-    postgres: "9.5+"
-    openresty: "$RESTY_VERSION"
-EOF
-}
-
-#-------------------------------------------------------------------------------
-function make_github_release_file() {
-   versionlink=$(echo $version | tr -d .)
-   cat <<EOF > release-$version.txt
-$version
-
-**Download Kong $version and run it now:**
-
-- https://konghq.com/install/
-- [Docker Image](https://hub.docker.com/r/kong/kong)
-
-Links:
-- [$version Changelog](https://github.com/Kong/kong/blob/$version/CHANGELOG.md#$versionlink)
-EOF
-}
-
-#-------------------------------------------------------------------------------
-function try_to_commit() {
-   if git status | grep -q "no changes added to commit"
-   then
-      return
-   fi
-   should_push=1
-   git commit "$@"
-}
-
 case "$step" in
    #---------------------------------------------------------------------------
    switch)
@@ -302,20 +125,7 @@ case "$step" in
       ;;
    #---------------------------------------------------------------------------
    commit_changelog)
-      if ! git status CHANGELOG.md | grep -q "modified:"
-      then
-         die "No changes in CHANGELOG.md to commit. Did you write the changelog?"
-      fi
-
-      git diff CHANGELOG.md
-
-      CONFIRM "If everything looks all right, press Enter to commit" \
-              "or Ctrl-C to cancel."
-
-      set -e
-      git add CHANGELOG.md
-      git commit -m "docs(changelog) add $version changes"
-      git log -n 1
+      commit_changelog "$version"
 
       SUCCESS "The changelog is now committed locally." \
               "You are ready to run the next step:" \
@@ -428,17 +238,7 @@ case "$step" in
       ;;
    #---------------------------------------------------------------------------
    update_docker)
-      if [ -d ../docker-kong ]
-      then
-         cd ../docker-kong
-      else
-         cd ..
-         git clone https://github.com/kong/docker-kong
-         cd docker-kong
-      fi
-
-      set -e
-      ./update.sh "$version"
+      update_docker "$version"
 
       SUCCESS "Make sure you get the PR above approved and merged" \
               "before continuing to the step 'merge_docker'."

--- a/scripts/send-slack-message.sh
+++ b/scripts/send-slack-message.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -ex
+
+echo "${SLACK_MESSAGE}"
+curl -X POST -H 'Content-type: application/json' --data '{"text": '"'${SLACK_MESSAGE}'"'}' "${SLACK_WEBHOOK}"
+

--- a/scripts/setup-ci.sh
+++ b/scripts/setup-ci.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+command -v ssh-agent >/dev/null || ( sudo apt-get update -y && sudo apt-get install openssh-client -y )
+eval $(ssh-agent -s)
+
+mkdir -p ~/.ssh
+chmod 700 ~/.ssh
+mv $GITHUB_SSH_KEY ~/.ssh/id_rsa
+chmod 600 ~/.ssh/id_rsa
+ssh-add ~/.ssh/id_rsa
+ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
+
+git config --global user.email colin@konghq.com
+git config --global user.name hutchic
+git config --global url.ssh://git@github.com/.insteadOf https://github.com/
+
+curl -fsSLo hub.tar.gz https://github.com/github/hub/releases/download/v2.14.2/hub-linux-amd64-2.14.2.tgz
+tar -xzf hub.tar.gz -C /tmp
+sudo mv /tmp/hub*/bin/hub /usr/local/bin/hub
+sudo apt-get update
+sudo apt-get install -yf lua5.2 liblua5.2

--- a/scripts/setup-ci.sh
+++ b/scripts/setup-ci.sh
@@ -10,8 +10,8 @@ chmod 600 ~/.ssh/id_rsa
 ssh-add ~/.ssh/id_rsa
 ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
 
-git config --global user.email colin@konghq.com
-git config --global user.name hutchic
+git config --global user.email office@mashape.com
+git config --global user.name mashapedeployment
 git config --global url.ssh://git@github.com/.insteadOf https://github.com/
 
 curl -fsSLo hub.tar.gz https://github.com/github/hub/releases/download/v2.14.2/hub-linux-amd64-2.14.2.tgz


### PR DESCRIPTION
combined common elements of `make-patch-release` and `make-prerelease-release` into `common.sh`

moved `update_docker`, `homebrew`, `vagrant`, `pongo` to be ran after the release stage successfully runs. The steps announce their success / failure in #team-core slack channel

Sample PR opened by the bot account
![image](https://user-images.githubusercontent.com/697188/90288445-e4269700-de47-11ea-87bf-26023c7c7c71.png)

Sample slack notification
![Capture1](https://user-images.githubusercontent.com/697188/90288461-edafff00-de47-11ea-85af-68f1888ae742.PNG)

All secrets are stored securely in 1password and as jenkins credentials
