### PR TITLE
feat(*) x-forwarded-path and request.get_forwarded_prefix

### DIFF
--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -85,6 +85,7 @@ local constants = {
     CONSUMER_GROUPS = "X-Consumer-Groups",
     AUTHENTICATED_GROUPS = "X-Authenticated-Groups",
     FORWARDED_HOST = "X-Forwarded-Host",
+    FORWARDED_PATH = "X-Forwarded-Path",
     FORWARDED_PREFIX = "X-Forwarded-Prefix",
     ANONYMOUS = "X-Anonymous-Consumer",
     VIA = "Via",

--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -16,6 +16,7 @@ local find = string.find
 local lower = string.lower
 local type = type
 local error = error
+local pcall = pcall
 local tonumber = tonumber
 local check_phase = phase_checker.check
 local check_not_phase = phase_checker.check_not
@@ -54,6 +55,7 @@ local function new(self)
   local X_FORWARDED_PROTO      = "X-Forwarded-Proto"
   local X_FORWARDED_HOST       = "X-Forwarded-Host"
   local X_FORWARDED_PORT       = "X-Forwarded-Port"
+  local X_FORWARDED_PATH       = "X-Forwarded-Path"
   local X_FORWARDED_PREFIX     = "X-Forwarded-Prefix"
 
 
@@ -252,18 +254,17 @@ local function new(self)
 
   ---
   -- Returns the path component of the request's URL, but also considers
-  -- `X-Forwarded-Prefix` if it comes from a trusted source. The value
+  -- `X-Forwarded-Path` if it comes from a trusted source. The value
   -- is returned as a Lua string.
   --
-  -- Whether this function considers `X-Forwarded-Prefix` or not depends on
+  -- Whether this function considers `X-Forwarded-Path` or not depends on
   -- several Kong configuration parameters:
   --
   -- * [trusted\_ips](https://getkong.org/docs/latest/configuration/#trusted_ips)
   -- * [real\_ip\_header](https://getkong.org/docs/latest/configuration/#real_ip_header)
   -- * [real\_ip\_recursive](https://getkong.org/docs/latest/configuration/#real_ip_recursive)
   --
-  -- **Note**: we do not currently do any normalization on the request
-  --           path except return `"/"` on empty path.
+  -- **Note**: we do not currently do any normalization on the request path.
   --
   -- @function kong.request.get_forwarded_path
   -- @phases rewrite, access, header_filter, body_filter, log, admin_api
@@ -274,14 +275,62 @@ local function new(self)
     check_phase(PHASES.request)
 
     if self.ip.is_trusted(self.client.get_ip()) then
+      local path = _REQUEST.get_header(X_FORWARDED_PATH)
+      if path then
+        return path
+      end
+    end
+
+    local path = _REQUEST.get_path()
+    return path
+  end
+
+
+  ---
+  -- Returns the prefix path component of the request's URL that Kong stripped
+  -- before proxying to upstream. It also checks if `X-Forwarded-Prefix` comes
+  -- from a trusted source, and uses it as is when given. The value is returned
+  -- as a Lua string.
+  --
+  -- In general, this function should be called after Kong has ran its router,
+  -- as the Kong router may strip the prefix of the request path. That stripped
+  -- path will become the return value of this function, unless there was already
+  -- a trusted `X-Forwarded-Prefix` header in the request.
+  --
+  -- Whether this function considers `X-Forwarded-Prefix` or not depends on
+  -- several Kong configuration parameters:
+  --
+  -- * [trusted\_ips](https://getkong.org/docs/latest/configuration/#trusted_ips)
+  -- * [real\_ip\_header](https://getkong.org/docs/latest/configuration/#real_ip_header)
+  -- * [real\_ip\_recursive](https://getkong.org/docs/latest/configuration/#real_ip_recursive)
+  --
+  -- **Note**: we do not currently do any normalization on the request path prefix
+  --           except return `"/"` on empty prefix.
+  --
+  -- @function kong.request.get_forwarded_prefix
+  -- @phases access, header_filter, body_filter, log, admin_api
+  -- @treturn string the forwarded path prefix
+  -- @usage
+  -- kong.request.get_forwarded_prefix() -- /prefix
+  function _REQUEST.get_forwarded_prefix()
+    check_phase(PHASES.request)
+
+    if self.ip.is_trusted(self.client.get_ip()) then
       local prefix = _REQUEST.get_header(X_FORWARDED_PREFIX)
       if prefix then
         return prefix
       end
     end
 
-    local path = _REQUEST.get_path()
-    return path == "" and "/" or path
+    local ok, prefix = pcall(function()
+      return ngx.var.upstream_x_forwarded_prefix
+    end)
+
+    if not ok or not prefix then
+      return "/"
+    end
+
+    return prefix == "" and "/" or prefix
   end
 
 

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1111,6 +1111,7 @@ return {
       local forwarded_proto
       local forwarded_host
       local forwarded_port
+      local forwarded_path
       local forwarded_prefix
 
       -- X-Forwarded-* Headers Parsing
@@ -1127,12 +1128,21 @@ return {
         forwarded_proto  = var.http_x_forwarded_proto  or scheme
         forwarded_host   = var.http_x_forwarded_host   or host
         forwarded_port   = var.http_x_forwarded_port   or port
+        forwarded_path   = var.http_x_forwarded_path
         forwarded_prefix = var.http_x_forwarded_prefix
 
       else
         forwarded_proto  = scheme
         forwarded_host   = host
         forwarded_port   = port
+      end
+
+      if not forwarded_path then
+        forwarded_path = var.request_uri
+        local p = find(forwarded_path, "?", 2, true)
+        if p then
+          forwarded_path = sub(forwarded_path, 1, p - 1)
+        end
       end
 
       if not forwarded_prefix and match_t.prefix ~= "/" then
@@ -1226,6 +1236,7 @@ return {
       var.upstream_x_forwarded_proto  = forwarded_proto
       var.upstream_x_forwarded_host   = forwarded_host
       var.upstream_x_forwarded_port   = forwarded_port
+      var.upstream_x_forwarded_path   = forwarded_path
       var.upstream_x_forwarded_prefix = forwarded_prefix
 
       -- At this point, the router and `balancer_setup_stage1` have been

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -134,6 +134,7 @@ server {
         set $upstream_x_forwarded_proto  '';
         set $upstream_x_forwarded_host   '';
         set $upstream_x_forwarded_port   '';
+        set $upstream_x_forwarded_path   '';
         set $upstream_x_forwarded_prefix '';
         set $kong_proxy_mode             'http';
 
@@ -146,6 +147,7 @@ server {
         proxy_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
         proxy_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
         proxy_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
+        proxy_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
         proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
         proxy_set_header      X-Real-IP          $remote_addr;
         proxy_pass_header     Server;
@@ -170,6 +172,7 @@ server {
         grpc_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
         grpc_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
         grpc_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
+        grpc_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
         grpc_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
         grpc_set_header      X-Real-IP          $remote_addr;
         grpc_pass_header     Server;
@@ -188,6 +191,7 @@ server {
         grpc_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
         grpc_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
         grpc_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
+        grpc_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
         grpc_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
         grpc_set_header      X-Real-IP          $remote_addr;
         grpc_pass_header     Server;
@@ -221,6 +225,7 @@ server {
         proxy_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
         proxy_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
         proxy_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
+        proxy_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
         proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
         proxy_set_header      X-Real-IP          $remote_addr;
         proxy_pass_header     Server;

--- a/spec/02-integration/05-proxy/03-upstream_headers_spec.lua
+++ b/spec/02-integration/05-proxy/03-upstream_headers_spec.lua
@@ -299,6 +299,25 @@ for _, strategy in helpers.each_strategy() do
         end)
       end)
 
+      describe("X-Forwarded-Path", function()
+        it("should be added if not present in request", function()
+          local headers = request_headers {
+            ["Host"] = "headers-inspect.com",
+          }
+
+          assert.equal("/", headers["x-forwarded-path"])
+        end)
+
+        it("should be replaced if present in request", function()
+          local headers = request_headers {
+            ["Host"]             = "headers-inspect.com",
+            ["X-Forwarded-Path"] = "/replaced",
+          }
+
+          assert.equal("/", headers["x-forwarded-path"])
+        end)
+      end)
+
       describe("X-Forwarded-Prefix", function()
         it("should be added if path was stripped", function()
           local headers = request_headers({}, "/foo/status/200")
@@ -338,6 +357,7 @@ for _, strategy in helpers.each_strategy() do
           assert.equal("127.0.0.1", headers["x-forwarded-for"])
           assert.equal("http", headers["x-forwarded-proto"])
           assert.equal("preserved.com", headers["x-forwarded-host"])
+          assert.equal("/", headers["x-forwarded-path"])
           assert.equal(helpers.get_proxy_port(false), tonumber(headers["x-forwarded-port"]))
         end)
 
@@ -357,6 +377,7 @@ for _, strategy in helpers.each_strategy() do
           assert.equal("http", headers["x-forwarded-proto"])
           assert.equal("preserved.com", headers["x-forwarded-host"])
           assert.equal(helpers.get_proxy_port(false), tonumber(headers["x-forwarded-port"]))
+          assert.equal("/", headers["x-forwarded-path"])
         end)
       end)
 
@@ -374,6 +395,7 @@ for _, strategy in helpers.each_strategy() do
           assert.equal("http", headers["x-forwarded-proto"])
           assert.equal("headers-inspect.com", headers["x-forwarded-host"])
           assert.equal(helpers.get_proxy_port(false), tonumber(headers["x-forwarded-port"]))
+          assert.equal("/", headers["x-forwarded-path"])
         end)
 
         it("if present in request while discarding the downstream host", function()
@@ -394,6 +416,7 @@ for _, strategy in helpers.each_strategy() do
           assert.equal("http", headers["x-forwarded-proto"])
           assert.equal("headers-inspect.com", headers["x-forwarded-host"])
           assert.equal(helpers.get_proxy_port(false), tonumber(headers["x-forwarded-port"]))
+          assert.equal("/", headers["x-forwarded-path"])
         end)
       end)
 
@@ -503,6 +526,25 @@ for _, strategy in helpers.each_strategy() do
           }
 
           assert.equal("80", headers["x-forwarded-port"])
+        end)
+      end)
+
+      describe("X-Forwarded-Path", function()
+        it("should be added if not present in request", function()
+          local headers = request_headers {
+            ["Host"] = "headers-inspect.com",
+          }
+
+          assert.equal("/", headers["x-forwarded-path"])
+        end)
+
+        it("should be forwarded if present in request", function()
+          local headers = request_headers {
+            ["Host"]             = "headers-inspect.com",
+            ["X-Forwarded-Path"] = "/original-path",
+          }
+
+          assert.equal("/original-path", headers["x-forwarded-path"])
         end)
       end)
 
@@ -629,6 +671,25 @@ for _, strategy in helpers.each_strategy() do
           }
 
           assert.equal(helpers.get_proxy_port(false), tonumber(headers["x-forwarded-port"]))
+        end)
+      end)
+
+      describe("X-Forwarded-Path", function()
+        it("should be added if not present in request", function()
+          local headers = request_headers {
+            ["Host"] = "headers-inspect.com",
+          }
+
+          assert.equal("/", headers["x-forwarded-path"])
+        end)
+
+        it("should be replaced if present in request", function()
+          local headers = request_headers {
+            ["Host"]             = "headers-inspect.com",
+            ["X-Forwarded-Path"] = "/untrusted",
+          }
+
+          assert.equal("/", headers["x-forwarded-path"])
         end)
       end)
 

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -153,6 +153,7 @@ http {
             set $upstream_x_forwarded_proto  '';
             set $upstream_x_forwarded_host   '';
             set $upstream_x_forwarded_port   '';
+            set $upstream_x_forwarded_path   '';
             set $upstream_x_forwarded_prefix '';
             set $kong_proxy_mode             'http';
 
@@ -165,6 +166,7 @@ http {
             proxy_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
             proxy_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
             proxy_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
+            proxy_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
             proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
             proxy_set_header      X-Real-IP          $remote_addr;
             proxy_pass_header     Server;
@@ -189,6 +191,7 @@ http {
             grpc_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
             grpc_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
             grpc_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
+            grpc_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
             grpc_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
             grpc_set_header      X-Real-IP          $remote_addr;
             grpc_pass_header     Server;
@@ -207,6 +210,7 @@ http {
             grpc_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
             grpc_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
             grpc_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
+            grpc_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
             grpc_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
             grpc_set_header      X-Real-IP          $remote_addr;
             grpc_pass_header     Server;
@@ -240,6 +244,7 @@ http {
             proxy_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
             proxy_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
             proxy_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
+            proxy_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
             proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
             proxy_set_header      X-Real-IP          $remote_addr;
             proxy_pass_header     Server;

--- a/t/01-pdk/04-request/00-phase_checks.t
+++ b/t/01-pdk/04-request/00-phase_checks.t
@@ -108,6 +108,17 @@ qq{
                 log           = true,
                 admin_api     = true,
             }, {
+                method        = "get_forwarded_prefix",
+                args          = {},
+                init_worker   = false,
+                certificate   = "pending",
+                rewrite       = true,
+                access        = true,
+                header_filter = true,
+                body_filter   = true,
+                log           = true,
+                admin_api     = true,
+            }, {
                 method        = "get_http_version",
                 args          = {},
                 init_worker   = false,

--- a/t/01-pdk/04-request/18-get_forwarded_path.t
+++ b/t/01-pdk/04-request/18-get_forwarded_path.t
@@ -12,7 +12,7 @@ run_tests();
 
 __DATA__
 
-=== TEST 1: request.get_forwarded_path() considers X-Forwarded-Prefix when trusted
+=== TEST 1: request.get_forwarded_path() considers X-Forwarded-Path when trusted
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location /t {
@@ -27,7 +27,7 @@ __DATA__
 --- request
 GET /t/request-path
 --- more_headers
-X-Forwarded-Prefix: /trusted
+X-Forwarded-Path: /trusted
 --- response_body
 path: /trusted
 type: string
@@ -36,7 +36,7 @@ type: string
 
 
 
-=== TEST 2: request.get_forwarded_path() doesn't considers X-Forwarded-Prefix when not trusted
+=== TEST 2: request.get_forwarded_path() doesn't considers X-Forwarded-Path when not trusted
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location /t {
@@ -50,7 +50,7 @@ type: string
 --- request
 GET /t/request-path
 --- more_headers
-X-Forwarded-Prefix: /not-trusted
+X-Forwarded-Path: /not-trusted
 --- response_body
 path: /t/request-path
 --- no_error_log
@@ -58,7 +58,7 @@ path: /t/request-path
 
 
 
-=== TEST 3: request.get_forwarded_path() considers first X-Forwarded-Prefix if multiple when trusted
+=== TEST 3: request.get_forwarded_path() considers first X-Forwarded-Path if multiple when trusted
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -72,8 +72,8 @@ path: /t/request-path
 --- request
 GET /t
 --- more_headers
-X-Forwarded-Prefix: /first
-X-Forwarded-Prefix: /second
+X-Forwarded-Path: /first
+X-Forwarded-Path: /second
 --- response_body
 path: /first
 --- no_error_log
@@ -81,7 +81,7 @@ path: /first
 
 
 
-=== TEST 4: request.get_forwarded_path() doesn't considers any X-Forwarded-Prefix headers when not trusted
+=== TEST 4: request.get_forwarded_path() doesn't considers any X-Forwarded-Path headers when not trusted
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location /t {
@@ -95,8 +95,8 @@ path: /first
 --- request
 GET /t/request-uri
 --- more_headers
-X-Forwarded-Prefix: /first
-X-Forwarded-Prefix: /second
+X-Forwarded-Path: /first
+X-Forwarded-Path: /second
 --- response_body
 path: /t/request-uri
 --- no_error_log
@@ -118,7 +118,7 @@ path: /t/request-uri
 --- request
 GET /t/request-uri?query&field=value#here
 --- more_headers
-X-Forwarded-Prefix: /first
+X-Forwarded-Path: /first
 --- response_body
 path: /t/request-uri
 --- no_error_log
@@ -140,7 +140,7 @@ path: /t/request-uri
 --- request
 GET /t/request-uri?query&field=value#here
 --- more_headers
-X-Forwarded-Prefix: /first?query&field=value#here
+X-Forwarded-Path: /first?query&field=value#here
 --- response_body
 path: /first?query&field=value#here
 --- no_error_log

--- a/t/01-pdk/04-request/19-get_forwarded_prefix.t
+++ b/t/01-pdk/04-request/19-get_forwarded_prefix.t
@@ -1,0 +1,98 @@
+use strict;
+use warnings FATAL => 'all';
+use Test::Nginx::Socket::Lua;
+use t::Util;
+
+$ENV{TEST_NGINX_CERT_DIR} ||= File::Spec->catdir(server_root(), '..', 'certs');
+$ENV{TEST_NGINX_NXSOCK}   ||= html_dir();
+
+plan tests => repeat_each() * (blocks() * 3);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: request.get_forwarded_prefix() considers X-Forwarded-Prefix when trusted
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location /t {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new({ trusted_ips = { "0.0.0.0/0", "::/0" } })
+            ngx.say("prefix: ", pdk.request.get_forwarded_prefix())
+            ngx.say("type: ", type(pdk.request.get_forwarded_prefix()))
+        }
+    }
+--- request
+GET /t/request-path
+--- more_headers
+X-Forwarded-Prefix: /trusted
+--- response_body
+prefix: /trusted
+type: string
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: request.get_forwarded_prefix() doesn't consider X-Forwarded-Prefix when not trusted
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location /t {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+            ngx.say("prefix: ", pdk.request.get_forwarded_prefix())
+        }
+    }
+--- request
+GET /t/request-path
+--- more_headers
+X-Forwarded-Prefix: /trusted
+--- response_body
+prefix: nil
+--- no_error_log
+[error]
+
+
+
+=== TEST 3: request.get_forwarded_prefix() considers first X-Forwarded-Prefix if multiple when trusted
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new({ trusted_ips = { "0.0.0.0/0", "::/0" } })
+            ngx.say("prefix: ", pdk.request.get_forwarded_prefix())
+        }
+    }
+--- request
+GET /t
+--- more_headers
+X-Forwarded-Prefix: /first
+X-Forwarded-Prefix: /second
+--- response_body
+prefix: /first
+--- no_error_log
+[error]
+
+
+
+=== TEST 4: request.get_forwarded_prefix() does not remove query and fragment when trusted
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location /t {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new({ trusted_ips = { "0.0.0.0/0", "::/0" } })
+            ngx.say("prefix: ", pdk.request.get_forwarded_prefix())
+        }
+    }
+--- request
+GET /t/request-uri?query&field=value#here
+--- more_headers
+X-Forwarded-Prefix: /first?query&field=value#here
+--- response_body
+prefix: /first?query&field=value#here
+--- no_error_log
+[error]


### PR DESCRIPTION
### Summary

Picks breaking portions of https://github.com/Kong/kong/pull/6201 into `next`.

**feat(pdk) add request.get_forwarded_prefix**

* **Breaking change**: existing `request.get_forwarded_path` method was
modified to return the request's `X-Forwarded-Path` header (if any,
and coming from a trusted client) or the request's path, as obtained by
`request.get_path`, rather than the request's prefix path stripped by
Kong
* New method `request.get_forwarded_prefix` was introduced; it returns
the request's prefix path component, as stripped by Kong. It also checks
if a `X-Forwarded-Prefix` header comes from a trusted source and uses
the given value

**feat(handler) add x-forwarded-path header**

* If a trusted source provides a `X-Forwarded-Path` header, it's
proxied as-is
* Otherwise, Kong will set the content of said header to the request's
URI



