### PR TITLE
chore(migrations) remove a left-over debug statement

### DIFF
--- a/kong/db/migrations/operations/212_to_213.lua
+++ b/kong/db/migrations/operations/212_to_213.lua
@@ -82,17 +82,6 @@ local postgres = {
     ------------------------------------------------------------------------------
     -- Update composite cache keys to workspace-aware formats
     ws_update_composite_cache_key = function(_, connector, table_name, is_partitioned)
-      local sql = render([[
-        UPDATE "$(TABLE)"
-        SET cache_key = CONCAT(cache_key, ':',
-                               (SELECT id FROM workspaces WHERE name = 'default'))
-        WHERE cache_key LIKE '%:';
-      ]], {
-        TABLE = table_name,
-      })
-
-      print(sql)
-
       local _, err = connector:query(render([[
         UPDATE "$(TABLE)"
         SET cache_key = CONCAT(cache_key, ':',


### PR DESCRIPTION
### Summary

When testing the migrations I used some debug statements in migrations, but they slipped
through the review process, and I forgot them there. This PR just removes them.
