### PR TITLE
chore(deps) bump prometheus plugin to 1.0.0

### DIFF
--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -79,6 +79,8 @@ if [ "$TEST_SUITE" == "plugins" ]; then
 
         git clone https://github.com/Kong/$REPOSITORY.git --branch $VERSION --single-branch /tmp/test-$REPOSITORY || \
         git clone https://github.com/Kong/$REPOSITORY.git --branch v$VERSION --single-branch /tmp/test-$REPOSITORY
+        sed -i 's/grpcbin:9000/localhost:15002/g' /tmp/test-$REPOSITORY/spec/*.lua
+        sed -i 's/grpcbin:9001/localhost:15003/g' /tmp/test-$REPOSITORY/spec/*.lua
         cp -R /tmp/test-$REPOSITORY/spec/fixtures/* spec/fixtures/ || true
         pushd /tmp/test-$REPOSITORY
         luarocks make

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ addons:
   hosts:
     - grpcs_1.test
     - grpcs_2.test
+    - grpcbin
 
 env:
   global:

--- a/kong-2.1.3-0.rockspec
+++ b/kong-2.1.3-0.rockspec
@@ -43,7 +43,7 @@ dependencies = {
   "kong-plugin-azure-functions ~> 0.4",
   "kong-plugin-zipkin ~> 1.1",
   "kong-plugin-serverless-functions ~> 1.0",
-  "kong-prometheus-plugin ~> 0.9",
+  "kong-prometheus-plugin ~> 1.0",
   "kong-proxy-cache-plugin ~> 1.3",
   "kong-plugin-request-transformer ~> 1.2",
   "kong-plugin-session ~> 2.4",


### PR DESCRIPTION
### Summary

It removes `WARN` log entry that we have seen with Kong `2.1.x` series, and reported by @michaelhsk on #6247.