### PR TITLE
feat(hybrid) Improve CP connection broken error

### DIFF
--- a/kong/clustering.lua
+++ b/kong/clustering.lua
@@ -140,7 +140,7 @@ local function communicate(premature, conf)
   if not res then
     local delay = math.random(5, 10)
 
-    ngx_log(ngx_ERR, "connection to control plane broken: ", err,
+    ngx_log(ngx_ERR, "connection to control plane ", uri, " broken: ", err,
             " retrying after ", delay , " seconds")
     assert(ngx.timer.at(delay, communicate, conf))
     return


### PR DESCRIPTION
### Summary

Currently, when the data plane cannot connect to the control plane it will print an error message like this:

```
2020/08/20 22:52:38 [error] 24#0: *3664 [lua] clustering.lua:245: connection to control plane broken: failed to connect: connection refused retrying after 7 seconds, context: ngx.timer
```

It can be hard to know what exactly is happening without more information. In my concrete case, it was trying to connect to `127.0.0.1:8006` which had nothing running on it.

This PR adds the URI to the error message to read:

```
2020/08/21 12:33:11 [error] 109#0: *145339 [lua] clustering.lua:245: connection to control plane wss://127.0.0.1:8006/v1/ingest?node_id=50cd5b07-8a8a-47a2-a319-4df55c26887f&node_hostname=kong-data-plane-1 broken: failed to connect: connection refused retrying after 6 seconds, context: ngx.timer
```

When debugging the issue this change helped me immensely and made it immediately clear what the problem is.

/cc @fffonion 