### PR TITLE
fix(key-auth) If the body or the content type is not valid, ignore,continue to process

### DIFF
--- a/kong/plugins/key-auth/handler.lua
+++ b/kong/plugins/key-auth/handler.lua
@@ -83,7 +83,6 @@ local function do_authentication(conf)
 
     if err then
       kong.log.err("Cannot process request body: ", err)
-      return nil, { status = 400, message = "Cannot process request body" }
     end
   end
 
@@ -97,7 +96,7 @@ local function do_authentication(conf)
     end
 
     -- search the body, if we asked to
-    if not v and conf.key_in_body then
+    if not v and conf.key_in_body and body then
       v = body[name]
     end
 
@@ -109,7 +108,7 @@ local function do_authentication(conf)
         kong.service.request.set_query(query)
         kong.service.request.clear_header(name)
 
-        if conf.key_in_body then
+        if conf.key_in_body and body then
           body[name] = nil
           kong.service.request.set_body(body)
         end

--- a/spec/03-plugins/09-key-auth/02-access_spec.lua
+++ b/spec/03-plugins/09-key-auth/02-access_spec.lua
@@ -602,19 +602,17 @@ for _, strategy in helpers.each_strategy() do
         end)
       end
 
-      it("fails with 'key_in_body' and unsupported content type", function()
+      it("works with 'key_in_body' and unsupported content type if key was given in query string", function()
         local res = assert(proxy_client:send {
-          path = "/status/200",
+          method  = "GET",
+          path    = "/request?apikey=kong",
           headers = {
             ["Host"] = "key-auth6.com",
             ["Content-Type"] = "text/plain",
           },
-          body = "foobar",
         })
 
-        local body = assert.res_status(400, res)
-        local json = cjson.decode(body)
-        assert.same({ message = "Cannot process request body" }, json)
+        assert.res_status(200, res)
       end)
     end)
 


### PR DESCRIPTION
Summary
plugins-key-auth

Issues resolved
Fix #5893 for plugins-key-auth