### PR TITLE
feat(hybrid) use timer to send changes to dp nodes instead of on every change

### DIFF
--- a/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
@@ -17,8 +17,10 @@ for _, strategy in helpers.each_strategy() do
         cluster_cert_key = "spec/fixtures/kong_clustering.key",
         lua_ssl_trusted_certificate = "spec/fixtures/kong_clustering.crt",
         database = strategy,
+        db_update_frequency = 1,
         cluster_listen = "127.0.0.1:9005",
         nginx_conf = "spec/fixtures/custom_nginx.template",
+
       }))
 
       assert(helpers.start_kong({
@@ -125,7 +127,7 @@ for _, strategy in helpers.each_strategy() do
           if status == 404 then
             return true
           end
-        end, 5)
+        end, 10)
       end)
     end)
   end)

--- a/spec/02-integration/09-hybrid_mode/03-pki_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/03-pki_spec.lua
@@ -16,6 +16,7 @@ for _, strategy in helpers.each_strategy() do
         cluster_cert = "spec/fixtures/kong_clustering.crt",
         cluster_cert_key = "spec/fixtures/kong_clustering.key",
         lua_ssl_trusted_certificate = "spec/fixtures/kong_clustering.crt",
+        db_update_frequency = 1,
         database = strategy,
         cluster_listen = "127.0.0.1:9005",
         nginx_conf = "spec/fixtures/custom_nginx.template",
@@ -131,7 +132,7 @@ for _, strategy in helpers.each_strategy() do
           if status == 404 then
             return true
           end
-        end, 5)
+        end, 10)
       end)
     end)
   end)


### PR DESCRIPTION
### Summary

Tools like `decK` etc. can make a lot of changes to `CP`. At the moment the `CP` notifies the workers that have connected to it on each change. This may cause huge amounts of changes on a cluster:

1. There is 1 CP
2. decK makes 10 changes to database  (in 200 ms)
3. There are 20 DPs connected to that CP
4. The config is sent 200 times

This commit changes it so that the changes are sent every `x seconds`, controlable with
`db_update_frequency`.

1. There is 1 CP
2. decK makes 10 changes to database (in 200 ms)
3. There are 20 DPs connected to that CP
4. The config is sent 20 times

This of course adds latency for changes to appear in DP nodes.