### PR TITLE
feat(rate-limiting) implement rate limiting by path. 

### DIFF
--- a/kong/plugins/rate-limiting/handler.lua
+++ b/kong/plugins/rate-limiting/handler.lua
@@ -71,7 +71,7 @@ local function get_identifier(conf)
   elseif conf.limit_by == "path" then
     local req_path = kong.request.get_path()
     if req_path == conf.path then
-      identifier = kong.request.get_path()
+      identifier = req_path
     end
   end
 

--- a/kong/plugins/rate-limiting/handler.lua
+++ b/kong/plugins/rate-limiting/handler.lua
@@ -67,6 +67,9 @@ local function get_identifier(conf)
 
   elseif conf.limit_by == "header" then
     identifier = kong.request.get_header(conf.header_name)
+
+  elseif conf.limit_by == "path" then
+    identifier = kong.request.get_path(conf.path)
   end
 
   return identifier or kong.client.get_forwarded_ip()

--- a/kong/plugins/rate-limiting/handler.lua
+++ b/kong/plugins/rate-limiting/handler.lua
@@ -69,7 +69,10 @@ local function get_identifier(conf)
     identifier = kong.request.get_header(conf.header_name)
 
   elseif conf.limit_by == "path" then
-    identifier = kong.request.get_path(conf.path)
+    local req_path = kong.request.get_path()
+    if req_path == conf.path then
+      identifier = kong.request.get_path()
+    end
   end
 
   return identifier or kong.client.get_forwarded_ip()

--- a/kong/plugins/rate-limiting/schema.lua
+++ b/kong/plugins/rate-limiting/schema.lua
@@ -39,9 +39,10 @@ return {
           { limit_by = {
               type = "string",
               default = "consumer",
-              one_of = { "consumer", "credential", "ip", "service", "header" },
+              one_of = { "consumer", "credential", "ip", "service", "header", "path" },
           }, },
           { header_name = typedefs.header_name },
+          { path = typedefs.path },
           { policy = {
               type = "string",
               default = "cluster",
@@ -73,6 +74,10 @@ return {
     { conditional = {
       if_field = "config.limit_by", if_match = { eq = "header" },
       then_field = "config.header_name", then_match = { required = true },
+    } },
+    { conditional = {
+      if_field = "config.limit_by", if_match = { eq = "path" },
+      then_field = "config.path", then_match = { required = true },
     } },
     { conditional = {
       if_field = "config.policy", if_match = { eq = "redis" },

--- a/spec/03-plugins/23-rate-limiting/01-schema_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/01-schema_spec.lua
@@ -24,6 +24,13 @@ describe("Plugin: rate-limiting (schema)", function()
     assert.is_nil(err)
   end)
 
+  it("proper config validates (path)", function()
+    local config = { second = 10, limit_by = "path", path = "/request" }
+    local ok, _, err = v(config, schema_def)
+    assert.truthy(ok)
+    assert.is_nil(err)
+  end)
+
   describe("errors", function()
     it("limits: smaller unit is less than bigger unit", function()
       local config = { second = 20, hour = 10 }
@@ -52,6 +59,13 @@ describe("Plugin: rate-limiting (schema)", function()
       local ok, err = v(config, schema_def)
       assert.falsy(ok)
       assert.equal("required field missing", err.config.header_name)
+    end)
+
+    it("is limited by path but the path field is missing", function()
+      local config = { second = 10, limit_by = "path", path =  nil }
+      local ok, err = v(config, schema_def)
+      assert.falsy(ok)
+      assert.equal("required field missing", err.config.path)
     end)
   end)
 end)

--- a/spec/03-plugins/23-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/04-access_spec.lua
@@ -249,6 +249,27 @@ for _, strategy in helpers.each_strategy() do
           }
         })
 
+        local service = bp.services:insert()
+        bp.routes:insert {
+          hosts = { "test-path.com" },
+          service = service,
+        }
+
+        bp.rate_limiting_plugins:insert({
+          service = { id = service.id },
+          config = {
+            limit_by       = "path",
+            path           = "/status/200",
+            policy         = policy,
+            minute         = 6,
+            fault_tolerant = false,
+            redis_host     = REDIS_HOST,
+            redis_port     = REDIS_PORT,
+            redis_password = REDIS_PASSWORD,
+            redis_database = REDIS_DATABASE,
+          }
+        })
+
         assert(helpers.start_kong({
           database   = strategy,
           nginx_conf = "spec/fixtures/custom_nginx.template",
@@ -278,6 +299,66 @@ for _, strategy in helpers.each_strategy() do
           -- Additonal request, while limit is 6/minute
           local res, body = GET("/status/200", {
             headers = { Host = "test1.com" },
+          }, 429)
+
+          assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
+          assert.are.same(0, tonumber(res.headers["ratelimit-remaining"]))
+
+          local retry = tonumber(res.headers["retry-after"])
+          assert.equal(true, retry <= 60 and retry > 0)
+
+          local reset = tonumber(res.headers["ratelimit-reset"])
+          assert.equal(true, reset <= 60 and reset > 0)
+
+          local json = cjson.decode(body)
+          assert.same({ message = "API rate limit exceeded" }, json)
+        end)
+
+        it_with_retry("blocks if exceeding limit, only if done via same path", function()
+          for i = 1, 3 do
+            local res = GET("/status/200", {
+              headers = { Host = "test-path.com" },
+            }, 200)
+
+            assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
+            assert.are.same(6 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
+            assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
+            assert.are.same(6 - i, tonumber(res.headers["ratelimit-remaining"]))
+            local reset = tonumber(res.headers["ratelimit-reset"])
+            assert.equal(true, reset <= 60 and reset > 0)
+          end
+
+          -- Try a different path on the same host. This should reset the timers
+          for i = 1, 3 do
+            local res = GET("/status/201", {
+              headers = { Host = "test-path.com" },
+            }, 201)
+
+            assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
+            assert.are.same(6 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
+            assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
+            assert.are.same(6 - i, tonumber(res.headers["ratelimit-remaining"]))
+            local reset = tonumber(res.headers["ratelimit-reset"])
+            assert.equal(true, reset <= 60 and reset > 0)
+          end
+
+          -- Continue doing requests on the path which "blocks"
+          for i = 4, 6 do
+            local res = GET("/status/200", {
+              headers = { Host = "test-path.com" },
+            }, 200)
+
+            assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
+            assert.are.same(6 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
+            assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
+            assert.are.same(6 - i, tonumber(res.headers["ratelimit-remaining"]))
+            local reset = tonumber(res.headers["ratelimit-reset"])
+            assert.equal(true, reset <= 60 and reset > 0)
+          end
+
+          -- Additonal request, while limit is 6/minute
+          local res, body = GET("/status/200", {
+            headers = { Host = "test-path.com" },
           }, 429)
 
           assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
@@ -1011,6 +1092,82 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       it_with_retry("blocks if exceeding limit", function()
+        for i = 1, 6 do
+          local res = GET("/status/200", {
+            headers = { Host = fmt("test%d.com", i) },
+          }, 200)
+
+          assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
+          assert.are.same(6 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
+          assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
+          assert.are.same(6 - i, tonumber(res.headers["ratelimit-remaining"]))
+          local reset = tonumber(res.headers["ratelimit-reset"])
+          assert.equal(true, reset <= 60 and reset > 0)
+        end
+
+        -- Additonal request, while limit is 6/minute
+        local res, body = GET("/status/200", {
+          headers = { Host = "test1.com" },
+        }, 429)
+
+        assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
+        assert.are.same(0, tonumber(res.headers["ratelimit-remaining"]))
+
+        local retry = tonumber(res.headers["retry-after"])
+        assert.equal(true, retry <= 60 and retry > 0)
+
+        local reset = tonumber(res.headers["ratelimit-reset"])
+        assert.equal(true, reset <= 60 and reset > 0)
+
+        local json = cjson.decode(body)
+        assert.same({ message = "API rate limit exceeded" }, json)
+      end)
+    end)
+
+    describe(fmt("Plugin: rate-limiting (access - global) with policy: %s [#%s] by path", policy, strategy), function()
+      local bp
+      local db
+
+      lazy_setup(function()
+        helpers.kill_all()
+        flush_redis()
+        bp, db = helpers.get_db_utils(strategy)
+
+        -- global plugin (not attached to route, service or consumer)
+        bp.rate_limiting_plugins:insert({
+          config = {
+            policy         = policy,
+            minute         = 6,
+            fault_tolerant = false,
+            redis_host     = REDIS_HOST,
+            redis_port     = REDIS_PORT,
+            redis_password = REDIS_PASSWORD,
+            redis_database = REDIS_DATABASE,
+          }
+        })
+
+        -- hosts with services
+        for i = 1, 3 do
+          bp.routes:insert({ service = bp.services:insert(), hosts = { fmt("test%d.com", i) } })
+        end
+
+        -- serviceless routes
+        for i = 4, 6 do
+          bp.routes:insert({ hosts = { fmt("test%d.com", i) } })
+        end
+
+        assert(helpers.start_kong({
+          database   = strategy,
+          nginx_conf = "spec/fixtures/custom_nginx.template",
+        }))
+      end)
+
+      lazy_teardown(function()
+        helpers.kill_all()
+        assert(db:truncate())
+      end)
+
+      it_with_retry("maintains the counters for a path through different services and routes", function()
         for i = 1, 6 do
           local res = GET("/status/200", {
             headers = { Host = fmt("test%d.com", i) },


### PR DESCRIPTION
This PR expands #6234 (by @fairyqb) with a couple integration tests as well as changing the way the ratelimiting is calculated (in the original PR `conf.path` was just ignored by `kong.request.get_path`).

Left my changes as separate commits for easier review, but this PR should be Squashed and Merged into a single commit when approved.

Closes #6234. Closes #6202