### PR TITLE
feat(pdk) kong.service.response.get_upstream

### DIFF
--- a/kong/pdk/service/response.lua
+++ b/kong/pdk/service/response.lua
@@ -150,9 +150,11 @@ local function new(pdk, major_version)
   function response.get_upstream()
     check_phase(header_body_log)
 
-    local addrs = split(ngx.var.upstream_addr, ',')
-    if #addrs > 0 then
-        return strip(addrs[#addrs])
+    if ngx.var.upstream_addr then
+      local addrs = split(ngx.var.upstream_addr, ',')
+      if #addrs > 0 then
+          return strip(addrs[#addrs])
+      end
     end
 
     return nil

--- a/t/01-pdk/07-service-response/00-phase_checks.t
+++ b/t/01-pdk/07-service-response/00-phase_checks.t
@@ -42,6 +42,17 @@ qq{
                 log           = true,
                 admin_api     = "forced false",
             }, {
+                method        = "get_upstream",
+                args          = {},
+                init_worker   = false,
+                certificate   = false,
+                rewrite       = "forced false",
+                access        = "forced false",
+                header_filter = true,
+                body_filter   = true,
+                log           = true,
+                admin_api     = "forced false",
+            }, {
                 method        = "get_headers",
                 args          = {},
                 init_worker   = false,

--- a/t/01-pdk/07-service-response/06-get_upstream.t
+++ b/t/01-pdk/07-service-response/06-get_upstream.t
@@ -36,7 +36,7 @@ qq{
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
 
-            ngx.arg[1] = pdk.service.response.get_upstream() .. "\n" .. 
+            ngx.arg[1] = string.sub(pdk.service.response.get_upstream(),-10) .. "\n" .. 
                          pdk.service.response.get_status()
             ngx.arg[2] = true
         }
@@ -44,7 +44,7 @@ qq{
 --- request
 GET /t
 --- response_body chop
-unix:/root/kong/t/servroot/html/nginx.sock
+nginx.sock
 200
 --- no_error_log
 [error]

--- a/t/01-pdk/07-service-response/06-get_upstream.t
+++ b/t/01-pdk/07-service-response/06-get_upstream.t
@@ -1,0 +1,50 @@
+use strict;
+use warnings FATAL => 'all';
+use Test::Nginx::Socket::Lua;
+use t::Util;
+
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
+
+plan tests => repeat_each() * (blocks() * 3);
+
+run_tests();
+
+__DATA__
+
+=== TEST : service.response.get_upstream() returns upstream
+--- http_config eval
+qq{
+    $t::Util::HttpConfig
+
+    server {
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
+
+        location / {
+            return 200;
+        }
+    }
+}
+--- config
+    location /t {
+        proxy_pass http://unix:$TEST_NGINX_NXSOCK/nginx.sock;
+
+        header_filter_by_lua_block {
+            ngx.header.content_length = nil
+        }
+
+        body_filter_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            ngx.arg[1] = pdk.service.response.get_upstream() .. "\n" .. 
+                         pdk.service.response.get_status()
+            ngx.arg[2] = true
+        }
+    }
+--- request
+GET /t
+--- response_body chop
+unix:/root/kong/t/servroot/html/nginx.sock
+200
+--- no_error_log
+[error]

--- a/t/01-pdk/07-service-response/06-get_upstream.t
+++ b/t/01-pdk/07-service-response/06-get_upstream.t
@@ -36,7 +36,7 @@ qq{
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
 
-            ngx.arg[1] = string.sub(pdk.service.response.get_upstream(),-10) .. "\n" .. 
+            ngx.arg[1] = string.sub(pdk.service.response.get_upstream(), -10) .. "\n" .. 
                          pdk.service.response.get_status()
             ngx.arg[2] = true
         }


### PR DESCRIPTION
### Summary

PDK: 
**kong.service.response.get_upstream**
return upstream server IP address and port or the path to the UNIX-domain socket

The upstream service has multiple target nodes, when one of them has a business problem, it is useful to quickly resolve the issue by returning the response header to the client.

