### PR TITLE
chore(deps) bump grpc-web plugin to 0.2

### DIFF
--- a/kong-2.1.3-0.rockspec
+++ b/kong-2.1.3-0.rockspec
@@ -49,7 +49,7 @@ dependencies = {
   "kong-plugin-session ~> 2.4",
   "kong-plugin-aws-lambda ~> 3.4",
   "kong-plugin-acme ~> 0.2",
-  "kong-plugin-grpc-web ~> 0.1",
+  "kong-plugin-grpc-web ~> 0.2",
   "kong-plugin-grpc-gateway ~> 0.1",
 }
 build = {


### PR DESCRIPTION
### CHANGELOG

* Introduce configuration `pass_stripped_path`, which, if set to true, causes the plugin to pass the stripped request path (see the `strip_path` Route attribute) to the upstream gRPC service.