### PR TITLE
tests(*) plugins grpc 2

### DIFF
--- a/spec/03-plugins/23-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/04-access_spec.lua
@@ -130,6 +130,28 @@ for _, strategy in helpers.each_strategy() do
           }
         })
 
+        local route_grpc_1 = assert(bp.routes:insert {
+          protocols = { "grpc" },
+          paths = { "/hello.HelloService/" },
+          service = assert(bp.services:insert {
+            name = "grpc",
+            url = "grpc://localhost:15002",
+          }),
+        })
+
+        bp.rate_limiting_plugins:insert({
+          route = { id = route_grpc_1.id },
+          config = {
+            policy         = policy,
+            minute         = 6,
+            fault_tolerant = false,
+            redis_host     = REDIS_HOST,
+            redis_port     = REDIS_PORT,
+            redis_password = REDIS_PASSWORD,
+            redis_database = REDIS_DATABASE,
+          }
+        })
+
         local route2 = bp.routes:insert {
           hosts      = { "test2.com" },
         }
@@ -377,6 +399,48 @@ for _, strategy in helpers.each_strategy() do
 
           local json = cjson.decode(body)
           assert.same({ message = "API rate limit exceeded" }, json)
+        end)
+      end)
+      describe("Without authentication (IP address)", function()
+        it_with_retry("blocks if exceeding limit #grpc", function()
+          for i = 1, 6 do
+            local ok, res = helpers.proxy_client_grpc(){
+              service = "hello.HelloService.SayHello",
+              opts = {
+                ["-v"] = true,
+              },
+            }
+            assert.truthy(ok)
+
+            assert.matches("x%-ratelimit%-limit%-minute: 6", res)
+            assert.matches("x%-ratelimit%-remaining%-minute: " .. (6 - i), res)
+            assert.matches("ratelimit%-limit: 6", res)
+            assert.matches("ratelimit%-remaining: " .. (6 - i), res)
+
+            local reset = tonumber(string.match(res, "ratelimit%-reset: (%d+)"))
+            assert.equal(true, reset <= 60 and reset >= 0)
+
+          end
+
+          -- Additonal request, while limit is 6/minute
+          local ok, res = helpers.proxy_client_grpc(){
+            service = "hello.HelloService.SayHello",
+            opts = {
+              ["-v"] = true,
+            },
+          }
+          assert.falsy(ok)
+          assert.matches("Code: ResourceExhausted", res)
+
+          assert.matches("ratelimit%-limit: 6", res)
+          assert.matches("ratelimit%-remaining: 0", res)
+
+          local retry = tonumber(string.match(res, "retry%-after: (%d+)"))
+          assert.equal(true, retry <= 60 and retry > 0)
+
+
+          local reset = tonumber(string.match(res, "ratelimit%-reset: (%d+)"))
+          assert.equal(true, reset <= 60 and reset > 0)
         end)
       end)
       describe("With authentication", function()

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -887,12 +887,12 @@ local function grpc_client(host, port, opts)
       end
 
       local opts = gen_grpcurl_opts(pl_tablex.merge(t.opts, args.opts, true))
-      local ok, err, out = exec(string.format(t.cmd_template, opts, service))
+      local ok, _, out, err = exec(string.format(t.cmd_template, opts, service), true)
 
       if ok then
-        return ok, out
+        return ok, ("%s%s"):format(out or "", err or "")
       else
-        return nil, err
+        return nil, ("%s%s"):format(out or "", err or "")
       end
     end
   })


### PR DESCRIPTION
### Summary

Add grpc test cases testing basic plugin functionality:
- request-termination
- rate-limiting
- response-rate-limiting: for this plugin, only rate-limiting headers
were tested, as the tests rely on manipulating response headers, which
is not currently possible with our mock grpc service