### PR TITLE
feat(hybrid) do not queue updates on dp nodes 

### DIFF
--- a/kong/clustering.lua
+++ b/kong/clustering.lua
@@ -155,7 +155,7 @@ local function communicate(premature, conf)
   -- connection established
   -- ping thread
   ngx.thread.spawn(function()
-    while true do
+    while not exiting() do
       if not send_ping(c) then
         return
       end
@@ -166,7 +166,7 @@ local function communicate(premature, conf)
 
   -- update config thread
   ngx.thread.spawn(function()
-    while true do
+    while not exiting() do
       local ok, err = update_config_semaphore:wait(1)
       if ok then
         local config_table = next_config
@@ -193,7 +193,7 @@ local function communicate(premature, conf)
     end
   end)
 
-  while true do
+  while not exiting() do
     local data, typ, err = c:recv_frame()
     if err then
       ngx.log(ngx.ERR, "error while receiving frame from control plane: ", err)
@@ -295,7 +295,7 @@ function _M.handle_cp_websocket()
   -- connection established
   -- ping thread
   ngx.thread.spawn(function()
-    while true do
+    while not exiting() do
       local data, typ, err = wb:recv_frame()
       if not data then
         ngx_log(ngx_ERR, "did not receive ping frame from data plane: ", err)


### PR DESCRIPTION
### Summary

Currently when CP sends new config to DP the DP will apply that config even in case it is already applying a config, and even in case when CP sends a new config (which means 2 configs queued). Only the last config is needed. This PR changes it so that DP drops the unnecessary configs that it knows are going to be replaced right after.

This commit is continuation of the work that started with #6293 that made the CP skip the configs that it knows are already going to be replaced. This just makes the same thing on DP side.

You might wonder why is that? With huge configs, it can take a lot of time for DP to apply the configuration, @cwurm told us delays like 77 seconds in this message: #6280 (comment)

That's why the CP can send multiple new configs during the time DP is applying the previous ones. This commit is to fix that.
