### PR TITLE
fix(init) do not flush kong_process_events dict

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -199,7 +199,6 @@ do
       "kong",
       "kong_locks",
       "kong_healthchecks",
-      "kong_process_events",
       "kong_cluster_events",
       "kong_rate_limiting_counters",
       "kong_core_db_cache" .. suffix,


### PR DESCRIPTION
When resetting kong shms, we should not flush kong_process_events, as other workers may rely on its contents to keep working. This shm is always full, so there's no use on flushing it anyway.

### Issues resolved

Fix #6269
