### PR TITLE
chore(template) grpc_pass now has support for variables 

### DIFF
--- a/kong/meta.lua
+++ b/kong/meta.lua
@@ -20,6 +20,6 @@ return {
   -- third-party dependencies' required version, as they would be specified
   -- to lua-version's `set()` in the form {from, to}
   _DEPENDENCIES = {
-    nginx = { "1.15.8.1", "1.17.8.2" },
+    nginx = { "1.17.8.2" },
   }
 }

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1251,12 +1251,8 @@ return {
       -- executed; detect requests that need to be redirected from `proxy_pass`
       -- to `grpc_pass`. After redirection, this function will return early
       if service and var.kong_proxy_mode == "http" then
-        if service.protocol == "grpc" then
+        if service.protocol == "grpc" or service.protocol == "grpcs" then
           return ngx.exec("@grpc")
-        end
-
-        if service.protocol == "grpcs" then
-          return ngx.exec("@grpcs")
         end
 
         if http_version == 1.1 then

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -270,32 +270,13 @@ server {
         grpc_set_header      X-Real-IP          $remote_addr;
         grpc_pass_header     Server;
         grpc_pass_header     Date;
-        grpc_pass            grpc://kong_upstream;
-    }
-
-    location @grpcs {
-        internal;
-        default_type         '';
-        set $kong_proxy_mode 'grpc';
-
-        grpc_set_header      TE                 $upstream_te;
-        grpc_set_header      Host               $upstream_host;
-        grpc_set_header      X-Forwarded-For    $upstream_x_forwarded_for;
-        grpc_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
-        grpc_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
-        grpc_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
-        grpc_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
-        grpc_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
-        grpc_set_header      X-Real-IP          $remote_addr;
-        grpc_pass_header     Server;
-        grpc_pass_header     Date;
         grpc_ssl_name        $upstream_host;
         grpc_ssl_server_name on;
 > if client_ssl then
         grpc_ssl_certificate ${{CLIENT_SSL_CERT}};
         grpc_ssl_certificate_key ${{CLIENT_SSL_CERT_KEY}};
 > end
-        grpc_pass            grpcs://kong_upstream;
+        grpc_pass            $upstream_scheme://kong_upstream;
     }
 
     location = /kong_buffered_http {

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -290,32 +290,13 @@ http {
             grpc_set_header      X-Real-IP          $remote_addr;
             grpc_pass_header     Server;
             grpc_pass_header     Date;
-            grpc_pass            grpc://kong_upstream;
-        }
-
-        location @grpcs {
-            internal;
-            default_type         '';
-            set $kong_proxy_mode 'grpc';
-
-            grpc_set_header      TE                 $upstream_te;
-            grpc_set_header      Host               $upstream_host;
-            grpc_set_header      X-Forwarded-For    $upstream_x_forwarded_for;
-            grpc_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
-            grpc_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
-            grpc_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
-            grpc_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
-            grpc_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
-            grpc_set_header      X-Real-IP          $remote_addr;
-            grpc_pass_header     Server;
-            grpc_pass_header     Date;
             grpc_ssl_name        $upstream_host;
             grpc_ssl_server_name on;
 > if client_ssl then
             grpc_ssl_certificate ${{CLIENT_SSL_CERT}};
             grpc_ssl_certificate_key ${{CLIENT_SSL_CERT_KEY}};
 > end
-            grpc_pass            grpcs://kong_upstream;
+            grpc_pass            $upstream_scheme://kong_upstream;
         }
 
         location = /kong_buffered_http {


### PR DESCRIPTION
### Summary

With latest OpenResty based on Nginx `1.7.x` series we can now use variables in `scheme` part of `grpc_pass`, thus we can now remove some repetition from our templates.

There is one additional commit in this PR that removes support for `1.15.8.x` series of OpenResty, because after this PR, the templates won't work anymore with the earlier version.