### PR TITLE
feat(conf) improved lua_ssl_trusted_certificate

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1213,12 +1213,13 @@
 # See the lua-nginx-module documentation for more information:
 # https://github.com/openresty/lua-nginx-module
 
-#lua_ssl_trusted_certificate =   # Absolute path to the certificate
-                                 # authority file for Lua cosockets in PEM
-                                 # format. This certificate will be the one
-                                 # used for verifying Kong's database
-                                 # connections, when `pg_ssl_verify` or
-                                 # `cassandra_ssl_verify` are enabled.
+
+#lua_ssl_trusted_certificate =   # Comma-separated list of paths to certificate
+                                 # authority files for Lua cosockets in PEM format.
+                                 #
+                                 # When `pg_ssl_verify` or `cassandra_ssl_verify`
+                                 # are enabled, these certificate authority files will be
+                                 # used for verifying Kong's database connections.
                                  #
                                  # See https://github.com/openresty/lua-nginx-module#lua_ssl_trusted_certificate
 

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1217,6 +1217,25 @@
 #lua_ssl_trusted_certificate =   # Comma-separated list of paths to certificate
                                  # authority files for Lua cosockets in PEM format.
                                  #
+                                 # The special value `system` attempts to search for the
+                                 # "usual default" provided by each distro, according
+                                 # to an arbitrary heuristic. In the current implementation,
+                                 # The following pathnames will be tested in order,
+                                 # and the first one found will be used:
+                                 #
+                                 # * /etc/ssl/certs/ca-certificates.crt (Debian/Ubuntu/Gentoo)
+                                 # * /etc/pki/tls/certs/ca-bundle.crt (Fedora/RHEL 6)
+                                 # * /etc/ssl/ca-bundle.pem (OpenSUSE)
+                                 # * /etc/pki/tls/cacert.pem (OpenELEC)
+                                 # * /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem (CentOS/RHEL 7)
+                                 # * /etc/ssl/cert.pem (OpenBSD, Alpine)
+                                 #
+                                 # If no file is found on any of these paths, an error will
+                                 # be raised.
+                                 #
+                                 # `system` can be used by itself or in conjunction with other
+                                 # CA filepaths.
+                                 #
                                  # When `pg_ssl_verify` or `cassandra_ssl_verify`
                                  # are enabled, these certificate authority files will be
                                  # used for verifying Kong's database connections.

--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -103,6 +103,23 @@ local function gen_default_ssl_cert(kong_config, target)
   return true
 end
 
+
+local function gen_trusted_certs_combined_file(combined_filepath, paths)
+
+  log.verbose("generating trusted certs combined file in ",
+              combined_filepath)
+
+  local fd = assert(io.open(combined_filepath, "w"))
+
+  for _, path in ipairs(paths) do
+    fd:write(pl_file.read(path))
+    fd:write("\n")
+  end
+
+  io.close(fd)
+end
+
+
 local function get_ulimit()
   local ok, _, stdout, stderr = pl_utils.executeex "ulimit -n"
   if not ok then
@@ -302,6 +319,13 @@ local function prepare_prefix(kong_config, nginx_custom_template_path)
     end
     kong_config.status_ssl_cert = kong_config.status_ssl_cert_default
     kong_config.status_ssl_cert_key = kong_config.status_ssl_cert_key_default
+  end
+
+  if kong_config.lua_ssl_trusted_certificate_combined then
+    gen_trusted_certs_combined_file(
+      kong_config.lua_ssl_trusted_certificate_combined,
+      kong_config.lua_ssl_trusted_certificate
+    )
   end
 
   -- check ulimit

--- a/kong/db/strategies/cassandra/connector.lua
+++ b/kong/db/strategies/cassandra/connector.lua
@@ -141,7 +141,7 @@ function CassandraConnector.new(kong_config)
     max_schema_consensus_wait = kong_config.cassandra_schema_consensus_timeout,
     ssl                       = kong_config.cassandra_ssl,
     verify                    = kong_config.cassandra_ssl_verify,
-    cafile                    = kong_config.lua_ssl_trusted_certificate,
+    cafile                    = kong_config.lua_ssl_trusted_certificate_combined,
     lock_timeout              = 30,
     silent                    = ngx.IS_CLI,
   }

--- a/kong/db/strategies/postgres/connector.lua
+++ b/kong/db/strategies/postgres/connector.lua
@@ -925,7 +925,7 @@ function _M.new(kong_config)
     schema      = kong_config.pg_schema or "",
     ssl         = kong_config.pg_ssl,
     ssl_verify  = kong_config.pg_ssl_verify,
-    cafile      = kong_config.lua_ssl_trusted_certificate,
+    cafile      = kong_config.lua_ssl_trusted_certificate_combined,
     sem_max     = kong_config.pg_max_concurrent_queries or 0,
     sem_timeout = (kong_config.pg_semaphore_timeout or 60000) / 1000,
   }
@@ -962,7 +962,7 @@ function _M.new(kong_config)
       schema      = kong_config.pg_ro_schema,
       ssl         = kong_config.pg_ro_ssl,
       ssl_verify  = kong_config.pg_ro_ssl_verify,
-      cafile      = kong_config.lua_ssl_trusted_certificate,
+      cafile      = kong_config.lua_ssl_trusted_certificate_combined,
       sem_max     = kong_config.pg_ro_max_concurrent_queries,
       sem_timeout = kong_config.pg_ro_semaphore_timeout and
                     (kong_config.pg_ro_semaphore_timeout / 1000) or nil,

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -11,8 +11,8 @@ lua_socket_log_errors  off;
 lua_max_running_timers 4096;
 lua_max_pending_timers 16384;
 lua_ssl_verify_depth   ${{LUA_SSL_VERIFY_DEPTH}};
-> if lua_ssl_trusted_certificate then
-lua_ssl_trusted_certificate '${{LUA_SSL_TRUSTED_CERTIFICATE}}';
+> if lua_ssl_trusted_certificate_combined then
+lua_ssl_trusted_certificate '${{LUA_SSL_TRUSTED_CERTIFICATE_COMBINED}}';
 > end
 
 lua_shared_dict kong                        5m;

--- a/kong/templates/nginx_kong_stream.lua
+++ b/kong/templates/nginx_kong_stream.lua
@@ -11,8 +11,8 @@ lua_socket_log_errors  off;
 lua_max_running_timers 4096;
 lua_max_pending_timers 16384;
 lua_ssl_verify_depth   ${{LUA_SSL_VERIFY_DEPTH}};
-> if lua_ssl_trusted_certificate then
-lua_ssl_trusted_certificate '${{LUA_SSL_TRUSTED_CERTIFICATE}}';
+> if lua_ssl_trusted_certificate_combined then
+lua_ssl_trusted_certificate '${{LUA_SSL_TRUSTED_CERTIFICATE_COMBINED}}';
 > end
 
 lua_shared_dict stream_kong                        5m;

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -12,6 +12,8 @@ local ffi = require "ffi"
 local uuid = require "resty.jit-uuid"
 local pl_stringx = require "pl.stringx"
 local pl_stringio = require "pl.stringio"
+local pl_utils = require "pl.utils"
+local pl_path = require "pl.path"
 local zlib = require "ffi-zlib"
 
 local C             = ffi.C
@@ -109,8 +111,6 @@ function _M.get_hostname()
 end
 
 do
-  local pl_utils = require "pl.utils"
-
   local _system_infos
 
   function _M.get_system_infos()
@@ -135,6 +135,33 @@ do
     return _system_infos
   end
 end
+
+do
+  local trusted_certs_paths = {
+    "/etc/ssl/certs/ca-certificates.crt",                -- Debian/Ubuntu/Gentoo
+    "/etc/pki/tls/certs/ca-bundle.crt",                  -- Fedora/RHEL 6
+    "/etc/ssl/ca-bundle.pem",                            -- OpenSUSE
+    "/etc/pki/tls/cacert.pem",                           -- OpenELEC
+    "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", -- CentOS/RHEL 7
+    "/etc/ssl/cert.pem",                                 -- OpenBSD, Alpine
+  }
+
+  function _M.get_system_trusted_certs_filepath()
+    for _, path in ipairs(trusted_certs_paths) do
+      if pl_path.exists(path) then
+        return path
+      end
+    end
+
+    return nil,
+           "Could not find trusted certs file in " ..
+           "any of the `system`-predefined locations. " ..
+           "Please install a certs file there or set " ..
+           "lua_ssl_trusted_certificate to an " ..
+           "specific filepath instead of `auto`"
+  end
+end
+
 
 local get_rand_bytes
 

--- a/spec/01-unit/04-prefix_handler_spec.lua
+++ b/spec/01-unit/04-prefix_handler_spec.lua
@@ -206,14 +206,20 @@ describe("NGINX conf compiler", function()
       local kong_nginx_conf = prefix_handler.compile_kong_conf(conf)
       assert.not_matches("lua_ssl_trusted_certificate", kong_nginx_conf, nil, true)
     end)
-    it("sets lua_ssl_trusted_certificate", function()
+    it("sets lua_ssl_trusted_certificate to a combined file (single entry)", function()
       local conf = assert(conf_loader(helpers.test_conf_path, {
         lua_ssl_trusted_certificate = "spec/fixtures/kong_spec.crt",
       }))
       local kong_nginx_conf = prefix_handler.compile_kong_conf(conf)
-      assert.matches("lua_ssl_trusted_certificate%s+.*spec/fixtures/kong_spec%.key", kong_nginx_conf)
+      assert.matches("lua_ssl_trusted_certificate%s+.*ca_combined", kong_nginx_conf)
     end)
-
+    it("sets lua_ssl_trusted_certificate to a combined file (multiple entries)", function()
+      local conf = assert(conf_loader(helpers.test_conf_path, {
+        lua_ssl_trusted_certificate = "spec/fixtures/kong_clustering_ca.crt,spec/fixtures/kong_clustering.crt",
+      }))
+      local kong_nginx_conf = prefix_handler.compile_kong_conf(conf)
+      assert.matches("lua_ssl_trusted_certificate%s+.*ca_combined", kong_nginx_conf)
+    end)
     it("defines the client_max_body_size by default", function()
       local conf = assert(conf_loader(nil, {}))
       local nginx_conf = prefix_handler.compile_kong_conf(conf)

--- a/spec/02-integration/05-proxy/27-lua-ssl-trusted-cert_spec.lua
+++ b/spec/02-integration/05-proxy/27-lua-ssl-trusted-cert_spec.lua
@@ -1,0 +1,78 @@
+local helpers = require "spec.helpers"
+
+for _, strategy in helpers.each_strategy() do
+  local bp
+
+  describe("lua_ssl_trusted_cert #" .. strategy, function()
+    before_each(function()
+      bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "plugins",
+      })
+
+      local r = bp.routes:insert({ hosts = {"test.dev"} })
+
+      bp.plugins:insert({
+        name = "pre-function",
+        route = { id = r.id },
+        config = {
+          access = {
+            string.format([[
+                local tcpsock = ngx.socket.tcp()
+                assert(tcpsock:connect("%s", %d))
+
+                assert(tcpsock:sslhandshake(
+                  nil,         -- reused_session
+                  nil,         -- server_name
+                  true         -- ssl_verify
+                ))
+
+                assert(tcpsock:close())
+              ]],
+              helpers.mock_upstream_ssl_host,
+              helpers.mock_upstream_ssl_port
+            )
+          },
+        },
+      })
+    end)
+
+    after_each(function()
+      assert(helpers.stop_kong())
+    end)
+
+    it("works with single entry", function()
+      assert(helpers.start_kong({
+        database   = strategy,
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+        lua_ssl_trusted_certificate = "spec/fixtures/kong_spec.crt",
+      }))
+
+      local proxy_client = helpers.proxy_client()
+
+      local res = proxy_client:get("/", {
+        headers = { host = "test.dev" },
+      })
+      assert.res_status(200, res)
+    end)
+
+    it("works with multiple entries", function()
+      assert(helpers.start_kong({
+        database   = strategy,
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+        lua_ssl_trusted_certificate = "spec/fixtures/kong_clustering_ca.crt,spec/fixtures/kong_clustering.crt",
+        ssl_cert = "spec/fixtures/kong_clustering.crt",
+        ssl_cert_key = "spec/fixtures/kong_clustering.key",
+      }))
+
+      local proxy_client = helpers.proxy_client()
+
+      local res = proxy_client:get("/", {
+        headers = { host = "test.dev" },
+      })
+      assert.res_status(200, res)
+    end)
+  end)
+end
+
+

--- a/spec/fixtures/1.2_custom_nginx.template
+++ b/spec/fixtures/1.2_custom_nginx.template
@@ -56,8 +56,8 @@ http {
     lua_shared_dict kong_cassandra      5m;
 > end
     lua_socket_log_errors off;
-> if lua_ssl_trusted_certificate then
-    lua_ssl_trusted_certificate '${{LUA_SSL_TRUSTED_CERTIFICATE}}';
+> if lua_ssl_trusted_certificate_combined then
+    lua_ssl_trusted_certificate '${{LUA_SSL_TRUSTED_CERTIFICATE_COMBINED}}';
 > end
     lua_ssl_verify_depth ${{LUA_SSL_VERIFY_DEPTH}};
 

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -29,8 +29,8 @@ http {
     lua_max_running_timers 4096;
     lua_max_pending_timers 16384;
     lua_ssl_verify_depth   ${{LUA_SSL_VERIFY_DEPTH}};
-> if lua_ssl_trusted_certificate then
-    lua_ssl_trusted_certificate '${{LUA_SSL_TRUSTED_CERTIFICATE}}';
+> if lua_ssl_trusted_certificate_combined then
+    lua_ssl_trusted_certificate '${{LUA_SSL_TRUSTED_CERTIFICATE_COMBINED}}';
 > end
 
     lua_shared_dict kong                        5m;
@@ -732,8 +732,8 @@ stream {
     lua_max_running_timers 4096;
     lua_max_pending_timers 16384;
     lua_ssl_verify_depth   ${{LUA_SSL_VERIFY_DEPTH}};
-> if lua_ssl_trusted_certificate then
-    lua_ssl_trusted_certificate '${{LUA_SSL_TRUSTED_CERTIFICATE}}';
+> if lua_ssl_trusted_certificate_combined then
+    lua_ssl_trusted_certificate '${{LUA_SSL_TRUSTED_CERTIFICATE_COMBINED}}';
 > end
 
     lua_shared_dict stream_kong                        5m;


### PR DESCRIPTION
This PR adds two features to the `lua_ssl_trusted_certificate` option:
* It is now a comma-separated list instead of a single item. All the paths on the list are concatenated into a single file in a fixed location (`$PREFIX/.ca_combined`).
* It accepts a special `system` value, which is expanded to the "system default". This follows a very simple heuristic to try to use the most common cert in most popular distros. `system` can be used in conjunction with other paths.

Note that this PR involves modifying Kong's template - as a result, the UPGRADE.md file should include such changes when a new version is released.