### PR TITLE
feat(upstream) When `Service.client_certificate` is not set, use

### DIFF
--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -1093,6 +1093,28 @@ local function execute(target, ctx)
         hash_value = create_hash(upstream, ctx)
         target.hash_value = hash_value
       end
+
+      if not ctx.service.client_certificate then
+        -- service level client_certificate is not set
+        local cert, res, err
+        local client_certificate = upstream.client_certificate
+
+        -- does the upstream object contains a client certificate?
+        if client_certificate then
+          cert, err = get_certificate(client_certificate)
+          if not cert then
+            log(ERR, "unable to fetch upstream client TLS certificate ",
+                     client_certificate.id, ": ", err)
+            return
+          end
+
+          res, err = kong.service.set_tls_cert_key(cert.cert, cert.key)
+          if not res then
+            log(ERR, "unable to apply upstream client TLS certificate ",
+                     client_certificate.id, ": ", err)
+          end
+        end
+      end
     end
   end
 

--- a/spec/02-integration/05-proxy/18-upstream_tls_spec.lua
+++ b/spec/02-integration/05-proxy/18-upstream_tls_spec.lua
@@ -54,7 +54,9 @@ for _, strategy in helpers.each_strategy() do
     local proxy_client, admin_client
     local bp
     local service_mtls, service_tls
-    local certificate, ca_certificate
+    local certificate, certificate_bad, ca_certificate
+    local upstream
+    local service_mtls_upstream
 
     lazy_setup(function()
       bp = helpers.get_db_utils(strategy, {
@@ -62,6 +64,8 @@ for _, strategy in helpers.each_strategy() do
         "services",
         "certificates",
         "ca_certificates",
+        "upstreams",
+        "targets",
       })
 
       service_mtls = assert(bp.services:insert({
@@ -74,9 +78,28 @@ for _, strategy in helpers.each_strategy() do
         url = "https://example.com:16799/", -- domain name needed for hostname check
       }))
 
+      upstream = assert(bp.upstreams:insert({
+        name = "backend-mtls",
+      }))
+
+      assert(bp.targets:insert({
+        upstream = { id = upstream.id, },
+        target = "127.0.0.1:16798",
+      }))
+
+      service_mtls_upstream = assert(bp.services:insert({
+        name = "protected-service-mtls-upstream",
+        url = "https://backend-mtls/",
+      }))
+
       certificate = assert(bp.certificates:insert({
         cert = ssl_fixtures.cert_client,
         key = ssl_fixtures.key_client,
+      }))
+
+      certificate_bad = assert(bp.certificates:insert({
+        cert = ssl_fixtures.cert, -- this cert is *not* trusted by upstream
+        key = ssl_fixtures.key,
       }))
 
       ca_certificate = assert(bp.ca_certificates:insert({
@@ -93,6 +116,12 @@ for _, strategy in helpers.each_strategy() do
         service = { id = service_tls.id, },
         hosts = { "example.com", },
         paths = { "/tls", },
+      }))
+
+      assert(bp.routes:insert({
+        service = { id = service_mtls_upstream.id, },
+        hosts = { "example.com", },
+        paths = { "/mtls-upstream", },
       }))
 
       assert(helpers.start_kong({
@@ -112,7 +141,7 @@ for _, strategy in helpers.each_strategy() do
       helpers.stop_kong()
     end)
 
-    describe("mutual TLS authentication against upstream", function()
+    describe("mutual TLS authentication against upstream with Service object", function()
       describe("no client certificate supplied", function()
         it("accessing protected upstream", function()
           local res = assert(proxy_client:send {
@@ -170,6 +199,102 @@ for _, strategy in helpers.each_strategy() do
 
           local body = assert.res_status(400, res)
           assert.matches("400 No required SSL certificate was sent", body, nil, true)
+        end)
+      end)
+    end)
+
+    describe("mutual TLS authentication against upstream with Upstream object", function()
+      describe("no client certificate supplied", function()
+        it("accessing protected upstream", function()
+          local res = assert(proxy_client:send {
+            path    = "/mtls-upstream",
+            headers = {
+              ["Host"] = "example.com",
+            }
+          })
+
+          local body = assert.res_status(400, res)
+          assert.matches("400 No required SSL certificate was sent", body, nil, true)
+        end)
+      end)
+
+      describe("#db client certificate supplied via upstream.client_certificate", function()
+        lazy_setup(function()
+          local res = assert(admin_client:patch("/upstreams/" .. upstream.id, {
+            body = {
+              client_certificate = { id = certificate.id, },
+            },
+            headers = { ["Content-Type"] = "application/json" },
+          }))
+
+          assert.res_status(200, res)
+        end)
+
+        it("accessing protected upstream", function()
+          local res = assert(proxy_client:send {
+            path    = "/mtls-upstream",
+            headers = {
+              ["Host"] = "example.com",
+            }
+          })
+
+          local body = assert.res_status(200, res)
+          assert.equals("it works", body)
+        end)
+
+        it("remove client_certificate removes access", function()
+          local res = assert(admin_client:patch("/upstreams/" .. upstream.id, {
+            body = {
+              client_certificate = ngx.null,
+            },
+            headers = { ["Content-Type"] = "application/json" },
+          }))
+
+          assert.res_status(200, res)
+
+          res = assert(proxy_client:send {
+            path    = "/mtls-upstream",
+            headers = {
+              ["Host"] = "example.com",
+            }
+          })
+
+          local body = assert.res_status(400, res)
+          assert.matches("400 No required SSL certificate was sent", body, nil, true)
+        end)
+      end)
+
+      describe("#db when both Service.client_certificate and Upstream.client_certificate are set, Service.client_certificate takes precedence", function()
+        lazy_setup(function()
+          local res = assert(admin_client:patch("/upstreams/" .. upstream.id, {
+            body = {
+              client_certificate = { id = certificate_bad.id, },
+            },
+            headers = { ["Content-Type"] = "application/json" },
+          }))
+
+          assert.res_status(200, res)
+
+          res = assert(admin_client:patch("/services/" .. service_mtls_upstream.id, {
+            body = {
+              client_certificate = { id = certificate.id, },
+            },
+            headers = { ["Content-Type"] = "application/json" },
+          }))
+
+          assert.res_status(200, res)
+        end)
+
+        it("access is allowed because Service.client_certificate overrides Upstream.client_certificate", function()
+          local res = assert(proxy_client:send {
+            path    = "/mtls-upstream",
+            headers = {
+              ["Host"] = "example.com",
+            }
+          })
+
+          local body = assert.res_status(200, res)
+          assert.equals("it works", body)
         end)
       end)
     end)

--- a/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
@@ -10,6 +10,9 @@ for _, strategy in helpers.each_strategy() do
         "routes",
         "services",
         "clustering_data_planes",
+        "upstreams",
+        "targets",
+        "certificates",
       }) -- runs migrations
 
       assert(helpers.start_kong({


### PR DESCRIPTION
`Upstream.client_certificate` instead.

This allows `client_certificate` setting used for mTLS handshaking with
the `Upstream` server to be shared easily among different Services.
However, `Service.client_certificate` will take precedence over
`Upstream.client_certificate` if both are set simultaneously.