### PR TITLE
fix(schema) infer shorthands

### DIFF
--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1,5 +1,6 @@
 local tablex       = require "pl.tablex"
 local pretty       = require "pl.pretty"
+local arguments    = require "kong.api.arguments"
 local utils        = require "kong.tools.utils"
 local cjson        = require "cjson"
 
@@ -1551,7 +1552,12 @@ function Schema:process_auto_fields(data, context, nulls, opts)
         local new_values = sfunc(value)
         if new_values then
           for k, v in pairs(new_values) do
-            data[k] = v
+            local f = self.fields[k]
+            if f then
+              data[k] = arguments.infer_value(v, f)
+            else
+              data[k] = v
+            end
           end
         end
       end

--- a/spec/01-unit/01-db/01-schema/01-schema_spec.lua
+++ b/spec/01-unit/01-db/01-schema/01-schema_spec.lua
@@ -3347,6 +3347,44 @@ describe("schema", function()
       assert.falsy(check_immutable_fields)
     end)
 
+    it("infers shorthands", function()
+      local test_schema = {
+        name = "test",
+        fields = {
+          {
+            allow = {
+              type = "array",
+              elements = {
+                type = "string"
+              },
+            },
+          },
+        },
+        shorthands = {
+          {
+            whitelist = function(value)
+              return {
+                allow = value
+              }
+            end
+          },
+        },
+      }
+
+      local test_entity = { name = "bob", whitelist = "privileged" }
+
+      local TestEntities = Schema.new(test_schema)
+
+      local test_data = TestEntities:process_auto_fields(test_entity, "update")
+
+      assert.same({
+        name = "bob",
+        allow = {
+          "privileged",
+        },
+      }, test_data)
+    end)
+
     describe("in subschemas", function()
       it("a specialized field can set a default", function()
         local Test = Schema.new({

--- a/spec/01-unit/01-db/01-schema/11-declarative_config/02-process_auto_fields_spec.lua
+++ b/spec/01-unit/01-db/01-schema/11-declarative_config/02-process_auto_fields_spec.lua
@@ -105,6 +105,21 @@ describe("declarative config: process_auto_fields", function()
           }
         }, config)
       end)
+
+      it("infers shorthands", function()
+        local config = lyaml.load([[
+          _format_version: "1.1"
+          plugins:
+          - name: acl
+            config:
+              whitelist: privileged
+        ]])
+        config = DeclarativeConfig:process_auto_fields(config, "insert", false)
+        assert.same({
+          "privileged",
+        }, config.plugins[1].config.allow)
+      end)
+
     end)
 
     describe("plugins:", function()


### PR DESCRIPTION
### Summary

In issue #6272 it was reported that some of our new shorthands that were added to `2.1.x` (whitelist/blacklist -> allow/deny) do not behave correctly with `application/x-www-form-urlencoded` or `multipart/form-data`.

I considered several options to fix these, including:

1. Fix each shorthands function to change the types (to arrays in this case):
   felt like just repetitive code, and a bug waiting to happen again
2. Change arguments parser to call shorthand functions and infer results:
   would fix it only for code that uses arguments parser
3. Infer shorthands return values according to schema field:
   Does always the inferring for shorthands return values if there is a matching field
4. Change plugins api to do inferring there only to config table values:
   is not universal solution, and makes plugins config behave differently than rest

 Out of those I went with 3.

 While inferring values in general should happen only for  `application/x-www-form-urlencoded` and `multipart/form-data`, I don't think  inferring the shorthand function return values is all that bad. It is a little bit magical, but I could not think it being problematic.

 ### Issues Resolved

 Fix #6272