### PR TITLE
fix(acl) deny should not deny proxying if denied group does not match

### DIFF
--- a/kong/plugins/acl/handler.lua
+++ b/kong/plugins/acl/handler.lua
@@ -40,7 +40,7 @@ local ACLHandler = {}
 
 
 ACLHandler.PRIORITY = 950
-ACLHandler.VERSION = "3.0.0"
+ACLHandler.VERSION = "3.0.1"
 
 
 function ACLHandler:access(conf)
@@ -99,7 +99,7 @@ function ACLHandler:access(conf)
       end
 
       if not consumer_groups then
-        if config.type == DENY and credential then
+        if config.type == DENY then
           consumer_groups = EMPTY
 
         else


### PR DESCRIPTION
### Summary

It was reported with #6281 that ACL plugin with `config.deny=do-not-deny-anyone`
does not work in all scenarios. I found two possible scenarios:

1. The user was authenticated but did not have consumer nor did not set authenticated groups
2. The user was not authenticated at all (no auth plugins added)
3. There was authentication but the authenticated user was anonymous and thus didn't have credential

All of this lead to `401`s.

This is more about semantics. Loosening the verification on anonymous and non-authenticated
users will make this plugin a bit more flexible, but then I can see that this might open some
security issues.

What does `nil` `authenticated_groups` mean (or empty `{}`) when using ACL plugin with `config.deny`?
1. the groups cannot be determined, deny the request
2. we didn't match any deny groups

I think `2.` is more correct and expected. The plugin is just verifying `deny` OR `allow` groups
and that's it. DENY: empty groups = `nothing to deny`, ALLOW: empty groups = `do not ever allow`.

As this changes the behavior a bit, I rebased this to `next`.

### Issues Resolved

Fix #6281