### PR TITLE
fix(key-auth) do not error with 400 when body cannot be decoded

### DIFF
--- a/spec/03-plugins/09-key-auth/02-access_spec.lua
+++ b/spec/03-plugins/09-key-auth/02-access_spec.lua
@@ -311,6 +311,33 @@ for _, strategy in helpers.each_strategy() do
             })
             assert.res_status(200, res)
           end)
+          it("authenticates valid credentials in query", function()
+            local res = assert(proxy_client:send {
+              path    = "/request?apikey=kong",
+              headers = {
+                ["Host"]         = "key-auth5.com",
+                ["Content-Type"] = type,
+              },
+              body    = {
+                non_apikey = "kong",
+              }
+            })
+            assert.res_status(200, res)
+          end)
+          it("authenticates valid credentials in header", function()
+            local res = assert(proxy_client:send {
+              path    = "/request?apikey=kong",
+              headers = {
+                ["Host"]         = "key-auth5.com",
+                ["Content-Type"] = type,
+                ["apikey"]       = "kong",
+              },
+              body    = {
+                non_apikey = "kong",
+              }
+            })
+            assert.res_status(200, res)
+          end)
           it("returns 401 Unauthorized on invalid key", function()
             local res = assert(proxy_client:send {
               path    = "/status/200",
@@ -614,9 +641,9 @@ for _, strategy in helpers.each_strategy() do
           body = "foobar",
         })
 
-        local body = assert.res_status(400, res)
+        local body = assert.res_status(401, res)
         local json = cjson.decode(body)
-        assert.same({ message = "Cannot process request body" }, json)
+        assert.same({ message = "No API key found in request" }, json)
       end)
     end)
 


### PR DESCRIPTION
### Summary

Issue #5893 pointed out that `key-auth` plugin returns `400` and "Cannot process request body" message in case the body decoding fails. This happens even in case the key is found in other places like `query` of `headers`.

### Issues Resolved

Fix #5893