### PR TITLE
feat(schema) typed shorthand_fields, deprecate shorthands

### DIFF
--- a/kong/api/arguments.lua
+++ b/kong/api/arguments.lua
@@ -224,6 +224,16 @@ local function infer_value(value, field)
             end
           end
         end
+
+        if field.shorthand_fields then
+          for _, item in ipairs(field.shorthand_fields) do
+            local key = next(item)
+            local fld = item[key]
+            if k == key then
+              value[k] = infer_value(v, fld)
+            end
+          end
+        end
       end
     end
   end
@@ -245,6 +255,18 @@ infer = function(args, schema)
     local value = args[field_name]
     if value then
       args[field_name] = infer_value(value, field)
+    end
+  end
+
+  if schema.shorthand_fields then
+    for _, v in ipairs(schema.shorthand_fields) do
+      local field_name = next(v)
+      local field = v[field_name]
+
+      local value = args[field_name]
+      if value then
+        args[field_name] = infer_value(value, field)
+      end
     end
   end
 

--- a/kong/db/schema/entities/services.lua
+++ b/kong/db/schema/entities/services.lua
@@ -69,34 +69,37 @@ return {
                       then_match = { eq = null }}},
   },
 
-  shorthands = {
-    { url = function(sugar_url)
-              local parsed_url = url.parse(tostring(sugar_url))
-              if not parsed_url then
-                return
-              end
+  shorthand_fields = {
+    { url = {
+      type = "string",
+      func = function(sugar_url)
+        local parsed_url = url.parse(tostring(sugar_url))
+        if not parsed_url then
+          return
+        end
 
-              local port = tonumber(parsed_url.port)
+        local port = tonumber(parsed_url.port)
 
-              local prot
-              if port == 80 then
-                prot = "http"
-              elseif port == 443 then
-                prot = "https"
-              end
+        local prot
+        if port == 80 then
+          prot = "http"
+        elseif port == 443 then
+          prot = "https"
+        end
 
-              local protocol = parsed_url.scheme or prot or default_protocol
+        local protocol = parsed_url.scheme or prot or default_protocol
 
-              return {
-                protocol = protocol,
-                host = parsed_url.host or null,
-                port = port or
-                       parsed_url.port or
-                       (protocol == "http"  and 80)  or
-                       (protocol == "https" and 443) or
-                       default_port,
-                path = parsed_url.path or null,
-              }
-            end },
+        return {
+          protocol = protocol,
+          host = parsed_url.host or null,
+          port = port or
+                 parsed_url.port or
+                 (protocol == "http"  and 80)  or
+                 (protocol == "https" and 443) or
+                 default_port,
+          path = parsed_url.path or null,
+        }
+      end
+    }, },
   }
 }

--- a/kong/db/schema/entities/upstreams.lua
+++ b/kong/db/schema/entities/upstreams.lua
@@ -233,8 +233,10 @@ local r =  {
   -- This is a hack to preserve backwards compatibility with regard to the
   -- behavior of the hash_on field, and have it take place both in the Admin API
   -- and via declarative configuration.
-  shorthands = {
-    { algorithm = function(value)
+  shorthand_fields = {
+    { algorithm = {
+      type = "string",
+      func = function(value)
         if value == "least-connections" then
           return {
             algorithm = value,
@@ -245,11 +247,13 @@ local r =  {
             algorithm = value,
           }
         end
-      end
-    },
+      end,
+    }, },
     -- Then, if hash_on is set to some non-null value, adjust the algorithm
     -- field accordingly.
-    { hash_on = function(value)
+    { hash_on = {
+      type = "string",
+      func = function(value)
         if value == null then
           return {
             hash_on = "none"
@@ -266,7 +270,7 @@ local r =  {
           }
         end
       end
-    },
+    }, },
   },
 }
 

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1154,7 +1154,8 @@ local function run_entity_check(self, name, input, arg, full_check, errors)
     local value = get_field(input, fname)
     if value == nil then
       if (not checker.run_with_missing_fields) and
-         (required_fields and required_fields[fname]) then
+         (required_fields and required_fields[fname]) and
+         (not get_schema_field(self, fname).nilable) then
         missing = missing or {}
         insert(missing, fname)
       end

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1543,6 +1543,32 @@ function Schema:process_auto_fields(data, context, nulls, opts)
 
   data = tablex.deepcopy(data)
 
+  if self.shorthand_fields then
+    local errs = {}
+    for _, shorthand in ipairs(self.shorthand_fields) do
+      local sname, sdata = next(shorthand)
+      local value = data[sname]
+      if value ~= nil then
+        local _, err = self:validate_field(sdata, value)
+        if err then
+          errs[sname] = err
+        else
+          data[sname] = nil
+          local new_values = sdata.func(value)
+          if new_values then
+            for k, v in pairs(new_values) do
+              data[k] = v
+            end
+          end
+        end
+      end
+    end
+    if next(errs) then
+      return nil, errs
+    end
+  end
+
+  -- deprecated
   if self.shorthands then
     for _, shorthand in ipairs(self.shorthands) do
       local sname, sfunc = next(shorthand)

--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -104,6 +104,7 @@ local fields_array = {
   },
 }
 
+
 local transformations_array = {
   type = "array",
   nilable = true,
@@ -247,8 +248,21 @@ local shorthands_array = {
   nilable = true,
 }
 
+local shorthand_fields_array = {
+  type = "array",
+  elements = {
+    type = "map",
+    keys = { type = "string" },
+    -- values are defined below after field_schema definition is complete
+    required = true,
+    len_eq = 1,
+  },
+  nilable = true,
+}
+
 table.insert(field_schema, { entity_checks = entity_checks_schema })
 table.insert(field_schema, { shorthands = shorthands_array })
+table.insert(field_schema, { shorthand_fields = shorthand_fields_array })
 
 local meta_errors = {
   ATTRIBUTE = "field of type '%s' cannot have attribute '%s'",
@@ -440,6 +454,44 @@ local function has_schema_field(schema, name)
 end
 
 
+-- Build a variant of the field_schema, adding a 'func' attribute
+-- and restricting the set of valid types.
+local function make_shorthand_field_schema()
+  local shorthand_field_schema = {}
+  for k, v in pairs(field_schema) do
+    shorthand_field_schema[k] = v
+  end
+
+  -- do not accept complex/recursive types
+  -- which require additional schema processing as shorthands
+  local invalid_as_shorthand = {
+    record = true,
+    foreign = true,
+    ["function"] = true,
+  }
+
+  local shorthand_field_types = {}
+  for k, _ in pairs(Schema.valid_types) do
+    if not invalid_as_shorthand[k] then
+      table.insert(shorthand_field_types, k)
+    end
+  end
+
+  assert(next(shorthand_field_schema[1]) == "type")
+  shorthand_field_schema[1] = { type = { type = "string", one_of = shorthand_field_types, required = true }, }
+
+  table.insert(shorthand_field_schema, { func = { type = "function", required = true } })
+  return shorthand_field_schema
+end
+
+
+shorthand_fields_array.elements.values = {
+  type = "record",
+  fields = make_shorthand_field_schema(),
+  entity_checks = field_entity_checks
+}
+
+
 local MetaSchema = Schema.new({
 
   name = "metaschema",
@@ -539,6 +591,9 @@ local MetaSchema = Schema.new({
       shorthands = shorthands_array,
     },
     {
+      shorthand_fields = shorthand_fields_array,
+    },
+    {
       check = {
         type = "function",
         nilable = true
@@ -553,6 +608,10 @@ local MetaSchema = Schema.new({
     {
       transformations = transformations_array,
     },
+  },
+
+  entity_checks = {
+    { only_one_of = { "shorthands", "shorthand_fields" } },
   },
 
   check = function(schema)

--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -85,10 +85,12 @@ end
 
 local field_entity_checks = {
   -- if 'unique_across_ws' is set, then 'unique' must be set too
-  conditional = {
-    if_field = "unique_across_ws", if_match = { eq = true },
-    then_field = "unique", then_match = { eq = true, required = true },
-  }
+  {
+    conditional = {
+      if_field = "unique_across_ws", if_match = { eq = true },
+      then_field = "unique", then_match = { eq = true, required = true },
+    }
+  },
 }
 
 local fields_array = {

--- a/kong/plugins/acl/schema.lua
+++ b/kong/plugins/acl/schema.lua
@@ -13,14 +13,22 @@ return {
           { deny = { type = "array", elements = { type = "string" }, }, },
           { hide_groups_header = { type = "boolean", default = false }, },
         },
-        shorthands = {
+        shorthand_fields = {
           -- deprecated forms, to be removed in Kong 3.0
-          { blacklist = function(value)
-              return { deny = value }
-            end },
-          { whitelist = function(value)
-              return { allow = value }
-            end },
+          { blacklist = {
+              type = "array",
+              elements = { type = "string", is_regex = true },
+              func = function(value)
+                return { deny = value }
+              end,
+          }, },
+          { whitelist = {
+              type = "array",
+              elements = { type = "string", is_regex = true },
+              func = function(value)
+                return { allow = value }
+              end,
+          }, },
         },
       }
     }

--- a/kong/plugins/bot-detection/schema.lua
+++ b/kong/plugins/bot-detection/schema.lua
@@ -19,14 +19,22 @@ return {
               default = {},
           }, },
         },
-        shorthands = {
+        shorthand_fields = {
           -- deprecated forms, to be removed in Kong 3.0
-          { blacklist = function(value)
-              return { deny = value }
-            end },
-          { whitelist = function(value)
-              return { allow = value }
-            end },
+          { blacklist = {
+              type = "array",
+              elements = { type = "string", is_regex = true },
+              func = function(value)
+                return { deny = value }
+              end,
+          }, },
+          { whitelist = {
+              type = "array",
+              elements = { type = "string", is_regex = true },
+              func = function(value)
+                return { allow = value }
+              end,
+          }, },
         },
     }, },
   },

--- a/kong/plugins/ip-restriction/schema.lua
+++ b/kong/plugins/ip-restriction/schema.lua
@@ -11,14 +11,22 @@ return {
           { allow = { type = "array", elements = typedefs.ip_or_cidr, }, },
           { deny = { type = "array", elements = typedefs.ip_or_cidr, }, },
         },
-        shorthands = {
+        shorthand_fields = {
           -- deprecated forms, to be removed in Kong 3.0
-          { blacklist = function(value)
-              return { deny = value }
-            end },
-          { whitelist = function(value)
-              return { allow = value }
-            end },
+          { blacklist = {
+              type = "array",
+              elements = { type = "string", is_regex = true },
+              func = function(value)
+                return { deny = value }
+              end,
+          }, },
+          { whitelist = {
+              type = "array",
+              elements = { type = "string", is_regex = true },
+              func = function(value)
+                return { allow = value }
+              end,
+          }, },
         },
       },
     },

--- a/spec/01-unit/01-db/01-schema/01-schema_spec.lua
+++ b/spec/01-unit/01-db/01-schema/01-schema_spec.lua
@@ -3627,6 +3627,145 @@ describe("schema", function()
     end)
   end)
 
+  describe("shorthand_fields", function()
+    it("converts fields", function()
+      local TestSchema = Schema.new({
+        name = "test",
+        fields = {
+          { name = { type = "string" } },
+        },
+        shorthand_fields = {
+          {
+            username = {
+              type = "string",
+              func = function(value)
+                return {
+                  name = value
+                }
+              end,
+            },
+          },
+        },
+      })
+
+      local input = { username = "test1" }
+      local output, _ = TestSchema:process_auto_fields(input)
+      assert.same({ name = "test1" }, output)
+    end)
+
+    it("can produce multiple fields", function()
+      local TestSchema = Schema.new({
+        name = "test",
+        fields = {
+          { name = { type = "string" } },
+          { address = { type = "string" } },
+        },
+        shorthand_fields = {
+          {
+            username = {
+              type = "string",
+              func = function(value)
+                return {
+                  name = value,
+                  address = value:upper(),
+                }
+              end,
+            },
+          },
+        },
+      })
+
+      local input = { username = "test1" }
+      local output, _ = TestSchema:process_auto_fields(input)
+      assert.same({ name = "test1", address = "TEST1" }, output)
+    end)
+
+    it("type checks", function()
+      local TestSchema = Schema.new({
+        name = "test",
+        fields = {
+          { name = { type = "string" } },
+          { address = { type = "string" } },
+        },
+        shorthand_fields = {
+          {
+            username = {
+              type = "string",
+              func = function(value)
+                return {
+                  name = value,
+                  address = value:upper(),
+                }
+              end,
+            },
+          },
+        },
+      })
+
+      local input = { username = 123 }
+      local ok, err = TestSchema:process_auto_fields(input)
+      assert.falsy(ok)
+      assert.same({ username = "expected a string" }, err)
+    end)
+
+    it("accepts arrays", function()
+      local TestSchema = Schema.new({
+        name = "test",
+        fields = {
+          { name = { type = "string" } },
+          { address = { type = "string" } },
+        },
+        shorthand_fields = {
+          {
+            user = {
+              type = "array",
+              elements = { type = "string" },
+              func = function(value)
+                return {
+                  name = value[1] or "mario",
+                  address = value[2] or "world",
+                }
+              end,
+            },
+          },
+        },
+      })
+
+      local input = { user = { "luigi", "land" } }
+      local output, _ = TestSchema:process_auto_fields(input)
+      assert.same({ name = "luigi", address = "land" }, output)
+    end)
+
+    it("type checks arrays", function()
+      local TestSchema = Schema.new({
+        name = "test",
+        fields = {
+          { name = { type = "string" } },
+          { address = { type = "string" } },
+        },
+        shorthand_fields = {
+          {
+            user = {
+              type = "array",
+              elements = { type = "string" },
+              func = function(value)
+                return {
+                  name = value[1] or "mario",
+                  address = value[2] or "world",
+                }
+              end,
+            },
+          },
+        },
+      })
+
+      local input = { user = "luigi,land" }
+      local ok, err = TestSchema:process_auto_fields(input)
+      assert.falsy(ok)
+      assert.same({ user = "expected an array" }, err)
+    end)
+  end)
+
   describe("transform", function()
     it("transforms fields", function()
       local test_schema = {

--- a/spec/01-unit/01-db/03-arguments_spec.lua
+++ b/spec/01-unit/01-db/03-arguments_spec.lua
@@ -102,6 +102,33 @@ describe("arguments.infer", function()
       comments = ngx.null
     }, infer(args, schema))
   end)
+
+  it("infers shorthand_fields but does not run the func", function()
+    local schema = Schema.new({
+      fields = {
+        { name = { type = "string" } },
+        { another_array = { type = "array", elements = { type = { "string" } } } },
+      },
+      shorthand_fields = {
+        { an_array = {
+            type = "array",
+            elements = { type = { "string" } },
+            func = function(value)
+              return { another_array = value:upper() }
+            end,
+          }
+        },
+      }
+    })
+
+    local args = { name = "peter",
+                   an_array = "something" }
+    assert.same({
+      name = "peter",
+      an_array = { "something" },
+    }, infer(args, schema))
+  end)
+
 end)
 
 describe("arguments.combine", function()


### PR DESCRIPTION
This is a "second shot" at the design of the shorthands feature, based on comments by @bungle, who correctly pointed out that we were missing type information.

This also fixes #6352 by making the form-encoded inference system in the Admin API aware of shorthand_fields.

The feature has been renamed from `shorthands` to `shorthand_fields` to avoid a "polymorphic" state in between the deprecated and new form.
