### PR TITLE
fix(headers) admin api and proxy server headers adjustment

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -67,6 +67,7 @@ _G.kong = kong_global.new() -- no versioned PDK for plugins for now
 
 local DB = require "kong.db"
 local dns = require "kong.tools.dns"
+local meta = require "kong.meta"
 local lapis = require "lapis"
 local runloop = require "kong.runloop.handler"
 local clustering = require "kong.clustering"
@@ -1330,8 +1331,18 @@ function Kong.admin_header_filter()
     end
   end
 
-  if kong.configuration.enabled_headers[constants.HEADERS.ADMIN_LATENCY] then
-    header[constants.HEADERS.ADMIN_LATENCY] = ctx.KONG_ADMIN_LATENCY
+  local enabled_headers = kong.configuration.enabled_headers
+  local headers = constants.HEADERS
+
+  if enabled_headers[headers.ADMIN_LATENCY] then
+    header[headers.ADMIN_LATENCY] = ctx.KONG_ADMIN_LATENCY
+  end
+
+  if enabled_headers[headers.SERVER] then
+    header[headers.SERVER] = meta._SERVER_TOKENS
+
+  else
+    header[headers.SERVER] = nil
   end
 
   -- this is not used for now, but perhaps we need it later?

--- a/kong/pdk/response.lua
+++ b/kong/pdk/response.lua
@@ -13,7 +13,6 @@
 
 
 local cjson = require "cjson.safe"
-local meta = require "kong.meta"
 local checks = require "kong.pdk.private.checks"
 local phase_checker = require "kong.pdk.private.phases"
 local utils = require "kong.tools.utils"
@@ -67,9 +66,6 @@ local function new(self, major_version)
   local MIN_STATUS_CODE      = 100
   local MAX_STATUS_CODE      = 599
   local MIN_ERR_STATUS_CODE  = 400
-
-  local SERVER_HEADER_NAME   = "Server"
-  local SERVER_HEADER_VALUE  = meta._NAME .. "/" .. meta._VERSION
 
   local GRPC_STATUS_UNKNOWN  = 2
   local GRPC_STATUS_NAME     = "grpc-status"
@@ -544,12 +540,6 @@ local function new(self, major_version)
     end
 
     ngx.status = status
-
-    if self.ctx.core.phase == phase_checker.phases.error or
-       self.ctx.core.phase == phase_checker.phases.admin_api
-    then
-      ngx.header[SERVER_HEADER_NAME] = SERVER_HEADER_VALUE
-    end
 
     local has_content_type
     if headers ~= nil then

--- a/kong/plugins/request-termination/handler.lua
+++ b/kong/plugins/request-termination/handler.lua
@@ -1,10 +1,4 @@
-local singletons = require "kong.singletons"
-local constants = require "kong.constants"
-local meta = require "kong.meta"
-
-
 local kong = kong
-local server_header = meta._SERVER_TOKENS
 
 
 local DEFAULT_RESPONSE = {
@@ -21,7 +15,7 @@ local RequestTerminationHandler = {}
 
 
 RequestTerminationHandler.PRIORITY = 2
-RequestTerminationHandler.VERSION = "2.0.0"
+RequestTerminationHandler.VERSION = "2.0.1"
 
 
 function RequestTerminationHandler:access(conf)
@@ -32,10 +26,6 @@ function RequestTerminationHandler:access(conf)
     local headers = {
       ["Content-Type"] = conf.content_type
     }
-
-    if singletons.configuration.enabled_headers[constants.HEADERS.SERVER] then
-      headers[constants.HEADERS.SERVER] = server_header
-    end
 
     return kong.response.exit(status, content, headers)
   end

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1411,29 +1411,35 @@ return {
     end,
     after = function(ctx)
       local enabled_headers = kong.configuration.enabled_headers
+      local headers = constants.HEADERS
       if ctx.KONG_PROXIED then
-        if enabled_headers[constants.HEADERS.UPSTREAM_LATENCY] then
-          header[constants.HEADERS.UPSTREAM_LATENCY] = ctx.KONG_WAITING_TIME
+        if enabled_headers[headers.UPSTREAM_LATENCY] then
+          header[headers.UPSTREAM_LATENCY] = ctx.KONG_WAITING_TIME
         end
 
-        if enabled_headers[constants.HEADERS.PROXY_LATENCY] then
-          header[constants.HEADERS.PROXY_LATENCY] = ctx.KONG_PROXY_LATENCY
+        if enabled_headers[headers.PROXY_LATENCY] then
+          header[headers.PROXY_LATENCY] = ctx.KONG_PROXY_LATENCY
         end
 
-        if enabled_headers[constants.HEADERS.VIA] then
-          header[constants.HEADERS.VIA] = server_header
+        if enabled_headers[headers.VIA] then
+          header[headers.VIA] = server_header
         end
 
       else
-        if enabled_headers[constants.HEADERS.RESPONSE_LATENCY] then
-          header[constants.HEADERS.RESPONSE_LATENCY] = ctx.KONG_RESPONSE_LATENCY
+        if enabled_headers[headers.RESPONSE_LATENCY] then
+          header[headers.RESPONSE_LATENCY] = ctx.KONG_RESPONSE_LATENCY
         end
 
-        if enabled_headers[constants.HEADERS.SERVER] then
-          header[constants.HEADERS.SERVER] = server_header
+        -- Some plugins short-circuit the request with Via-header, and in those cases
+        -- we don't want to set the Server-header, if the Via-header matches with
+        -- the Kong server header.
+        if not (enabled_headers[headers.VIA] and header[headers.VIA] == server_header) then
+          if enabled_headers[headers.SERVER] then
+            header[headers.SERVER] = server_header
 
-        else
-          header[constants.HEADERS.SERVER] = nil
+          else
+            header[headers.SERVER] = nil
+          end
         end
       end
     end

--- a/t/01-pdk/08-response/11-exit.t
+++ b/t/01-pdk/08-response/11-exit.t
@@ -260,58 +260,7 @@ GET /t
 
 
 
-=== TEST 9: response.exit() adds Server header if in admin_api phase
---- http_config eval: $t::Util::HttpConfig
---- config
-    location = /t {
-        default_type '';
-        access_by_lua_block {
-            local PDK = require "kong.pdk"
-            local pdk = PDK.new()
-            local phases = require("kong.pdk.private.phases")
-            kong = pdk
-            kong.ctx.core.phase = phases.phases.admin_api
-
-            pdk.response.exit(ngx.HTTP_NO_CONTENT)
-        }
-    }
---- request
-GET /t
---- error_code: 204
---- response_headers_like
-Server: kong/\d+\.\d+\.\d+(rc.\d|alpha\.\d|beta\.\d)?
---- response_body chop
-
---- no_error_log
-[error]
-
-
-
-=== TEST 10: response.exit() does not add Server header if not in admin_api phase
---- http_config eval: $t::Util::HttpConfig
---- config
-    location = /t {
-        default_type '';
-        access_by_lua_block {
-            local PDK = require "kong.pdk"
-            local pdk = PDK.new()
-
-            pdk.response.exit(ngx.HTTP_NO_CONTENT)
-        }
-    }
---- request
-GET /t
---- error_code: 204
---- response_headers_like
-Server: openresty/.*
---- response_body chop
-
---- no_error_log
-[error]
-
-
-
-=== TEST 11: response.exit() errors if headers is not a table
+=== TEST 9: response.exit() errors if headers is not a table
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -333,7 +282,7 @@ headers must be a nil or table
 
 
 
-=== TEST 12: response.exit() errors if header name is not a string
+=== TEST 10: response.exit() errors if header name is not a string
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -356,7 +305,7 @@ invalid header name "2": got number, expected string
 
 
 
-=== TEST 13: response.exit() errors if header value is of a bad type
+=== TEST 11: response.exit() errors if header value is of a bad type
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -378,7 +327,7 @@ invalid header value for "foo": got function, expected string, number, boolean o
 
 
 
-=== TEST 14: response.exit() errors if header value array element is of a bad type
+=== TEST 12: response.exit() errors if header value array element is of a bad type
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -401,7 +350,7 @@ invalid header value in array "foo": got function, expected string
 
 
 
-=== TEST 15: response.exit() sends "text/plain" response
+=== TEST 13: response.exit() sends "text/plain" response
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -424,7 +373,7 @@ hello
 
 
 
-=== TEST 16: response.exit() sends no content-type header by default
+=== TEST 14: response.exit() sends no content-type header by default
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -448,7 +397,7 @@ hello
 
 
 
-=== TEST 17: response.exit() sends json response when body is table
+=== TEST 15: response.exit() sends json response when body is table
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -472,7 +421,7 @@ Content-Type: application/json; charset=utf-8
 
 
 
-=== TEST 18: response.exit() sends json response when body is table, but does not override content-type
+=== TEST 16: response.exit() sends json response when body is table, but does not override content-type
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -498,7 +447,7 @@ Content-Type: application/jwk+json; charset=utf-8
 
 
 
-=== TEST 19: response.exit() sets content-length header
+=== TEST 17: response.exit() sets content-length header
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -525,7 +474,7 @@ Content-Length: 0
 
 
 
-=== TEST 20: response.exit() sets content-length header even when no body
+=== TEST 18: response.exit() sets content-length header even when no body
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -553,7 +502,7 @@ Content-Length: 0
 
 
 
-=== TEST 21: response.exit() sets content-length header with text body
+=== TEST 19: response.exit() sets content-length header with text body
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -581,7 +530,7 @@ a
 
 
 
-=== TEST 22: response.exit() sets content-length header with table body
+=== TEST 20: response.exit() sets content-length header with table body
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -609,7 +558,7 @@ Content-Length: 19
 
 
 
-=== TEST 23: response.exit() does not send body with gRPC
+=== TEST 21: response.exit() does not send body with gRPC
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -636,7 +585,7 @@ grpc-message: hello
 
 
 
-=== TEST 24: response.exit() sends body with gRPC when asked (explicit)
+=== TEST 22: response.exit() sends body with gRPC when asked (explicit)
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -664,7 +613,7 @@ hello
 
 
 
-=== TEST 25: response.exit() sends body with gRPC when asked (implicit)
+=== TEST 23: response.exit() sends body with gRPC when asked (implicit)
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -691,7 +640,7 @@ hello
 
 
 
-=== TEST 26: response.exit() body replaces grpc-message
+=== TEST 24: response.exit() body replaces grpc-message
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -722,7 +671,7 @@ grpc-message: OK
 
 
 
-=== TEST 27: response.exit() body does not replace grpc-message with content-type specified (explicit)
+=== TEST 25: response.exit() body does not replace grpc-message with content-type specified (explicit)
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -751,7 +700,7 @@ OK
 
 
 
-=== TEST 28: response.exit() body does not replace grpc-message with content-type specified (implicit)
+=== TEST 26: response.exit() body does not replace grpc-message with content-type specified (implicit)
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -780,7 +729,7 @@ OK
 
 
 
-=== TEST 29: response.exit() nil body does not replace grpc-message with default message
+=== TEST 27: response.exit() nil body does not replace grpc-message with default message
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -808,7 +757,7 @@ grpc-message: SHOW ME
 
 
 
-=== TEST 30: response.exit() sends default grpc-message (200)
+=== TEST 28: response.exit() sends default grpc-message (200)
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -837,7 +786,7 @@ grpc-message: OK
 
 
 
-=== TEST 31: response.exit() sends default grpc-message (403)
+=== TEST 29: response.exit() sends default grpc-message (403)
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -866,7 +815,7 @@ grpc-message: PermissionDenied
 
 
 
-=== TEST 32: response.exit() sends default grpc-message when specifying content-type (explicit)
+=== TEST 30: response.exit() sends default grpc-message when specifying content-type (explicit)
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -893,7 +842,7 @@ grpc-message: Unauthenticated
 
 
 
-=== TEST 33: response.exit() sends default grpc-message when specifying content-type (implicit)
+=== TEST 31: response.exit() sends default grpc-message when specifying content-type (implicit)
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -919,7 +868,7 @@ grpc-message: Unauthenticated
 
 
 
-=== TEST 34: response.exit() errors with grpc using table body with content-type specified (explicit)
+=== TEST 32: response.exit() errors with grpc using table body with content-type specified (explicit)
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -940,7 +889,7 @@ GET /t
 
 
 
-=== TEST 35: response.exit() errors with grpc using table body with content-type specified (implicit)
+=== TEST 33: response.exit() errors with grpc using table body with content-type specified (implicit)
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -960,7 +909,7 @@ GET /t
 
 
 
-=== TEST 36: response.exit() errors with grpc using special table body with content-type specified (explicit)
+=== TEST 34: response.exit() errors with grpc using special table body with content-type specified (explicit)
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -981,7 +930,7 @@ GET /t
 
 
 
-=== TEST 37: response.exit() errors with grpc using special table body with content-type specified (implicit)
+=== TEST 35: response.exit() errors with grpc using special table body with content-type specified (implicit)
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -1001,7 +950,7 @@ GET /t
 
 
 
-=== TEST 38: response.exit() logs warning with grpc using table body without content-type specified
+=== TEST 36: response.exit() logs warning with grpc using table body without content-type specified
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -1029,7 +978,7 @@ grpc-message: Unauthenticated
 
 
 
-=== TEST 39: response.exit() does not log warning with grpc using special table body without content-type specified
+=== TEST 37: response.exit() does not log warning with grpc using special table body without content-type specified
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -1058,7 +1007,7 @@ grpc-message: Hello
 
 
 
-=== TEST 40: response.exit() works under stream subsystem in preread
+=== TEST 38: response.exit() works under stream subsystem in preread
 --- stream_server_config
     preread_by_lua_block {
         local PDK = require "kong.pdk"
@@ -1077,7 +1026,7 @@ finalize stream session: 200
 
 
 
-=== TEST 41: response.exit() rejects invalid status code
+=== TEST 39: response.exit() rejects invalid status code
 --- stream_server_config
     preread_by_lua_block {
         local PDK = require "kong.pdk"
@@ -1095,7 +1044,7 @@ unacceptable code, only 200, 400, 403, 500, 502 and 503 are accepted
 
 
 
-=== TEST 42: response.exit() logs 5xx error instead of returning it to the client
+=== TEST 40: response.exit() logs 5xx error instead of returning it to the client
 --- stream_server_config
     preread_by_lua_block {
         local PDK = require "kong.pdk"
@@ -1112,7 +1061,7 @@ unable to proxy stream connection, status: 500, err: error message
 
 
 
-=== TEST 43: response.exit() logs 4xx error instead of returning it to the client
+=== TEST 41: response.exit() logs 4xx error instead of returning it to the client
 --- stream_server_config
     preread_by_lua_block {
         local PDK = require "kong.pdk"


### PR DESCRIPTION
### Summary

This commit contains following things:
1. it removes `Server` header setting from `kong.response.exit`
2. admin api now sets `Server` header according to `conf.headers` on `header_filter`
3. proxy does not add `Server` header in case `Via` header contains the same value and request is short-circuited (this is for `aws-lambda`, `azure-functions` etc. plugins that kinda proxy, but do not use the proxy module, and skip balancer)

### Issues Resolved

Fix #6367