### PR TITLE
feat(clustering) automatically purge entries from the cluster_data_planes table so it won't grow uncontained

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -242,6 +242,17 @@
                          # This setting has no effect if `role` is not set to
                          # `control_plane`.
 
+#cluster_data_plane_purge_delay = 1209600
+                         # How many seconds must pass from the time a DP node
+                         # becomes offline to the time its entry gets removed
+                         # from the database, as returned by the
+                         # /clustering/data_planes Admin API endpoint.
+                         #
+                         # This is to prevent the cluster data plane table from
+                         # growing indefinitely. The default is set to
+                         # 14 days. That is, if CP haven't heard from a DP for
+                         # 14 days, its entry will be removed.
+
 #------------------------------------------------------------------------------
 # NGINX
 #------------------------------------------------------------------------------

--- a/kong/clustering.lua
+++ b/kong/clustering.lua
@@ -324,7 +324,7 @@ function _M.handle_cp_websocket()
           data ~= "" and data or nil,
         hostname = node_hostname,
         ip = node_ip,
-      })
+      }, { ttl = kong.configuration.cluster_data_plane_purge_delay, })
       if not ok then
         ngx_log(ngx_ERR, "unable to update clustering data plane status: ", err)
       end

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -576,6 +576,7 @@ local CONF_INFERENCES = {
   cluster_mtls = { enum = { "shared", "pki" } },
   cluster_ca_cert = { typ = "string" },
   cluster_server_name = { typ = "string" },
+  cluster_data_plane_purge_delay = { typ = "number" },
   kic = { typ = "boolean" },
 }
 
@@ -938,6 +939,10 @@ local function check_and_infer(conf, opts)
       errors[#errors + 1] = "only in-memory storage can be used when role = \"data_plane\"\n" ..
                             "Hint: set database = off in your kong.conf"
     end
+  end
+
+  if conf.cluster_data_plane_purge_delay < 60 then
+    errors[#errors + 1] = "cluster_data_plane_purge_delay must be 60 or greater"
   end
 
   if conf.role == "control_plane" or conf.role == "data_plane" then

--- a/kong/db/migrations/core/012_213_to_220.lua
+++ b/kong/db/migrations/core/012_213_to_220.lua
@@ -6,8 +6,10 @@ return {
         hostname       TEXT NOT NULL,
         ip             TEXT NOT NULL,
         last_seen      TIMESTAMP WITH TIME ZONE DEFAULT (CURRENT_TIMESTAMP(0) AT TIME ZONE 'UTC'),
-        config_hash    TEXT NOT NULL
+        config_hash    TEXT NOT NULL,
+        ttl            TIMESTAMP WITH TIME ZONE
       );
+      CREATE INDEX IF NOT EXISTS clustering_data_planes_ttl_idx ON clustering_data_planes (ttl);
 
       DO $$
       BEGIN
@@ -35,7 +37,7 @@ return {
         last_seen timestamp,
         config_hash text,
         PRIMARY KEY (id)
-      );
+      ) WITH default_time_to_live = 1209600;
 
       ALTER TABLE routes ADD request_buffering boolean;
       ALTER TABLE routes ADD response_buffering boolean;

--- a/kong/db/schema/entities/clustering_data_planes.lua
+++ b/kong/db/schema/entities/clustering_data_planes.lua
@@ -5,6 +5,7 @@ return {
   primary_key        = { "id" },
   db_export          = false,
   generate_admin_api = false,
+  ttl                = true,
 
   fields = {
     { id = typedefs.uuid { required = true, }, },

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -25,6 +25,7 @@ cluster_cert_key = NONE
 cluster_mtls = shared
 cluster_ca_cert = NONE
 cluster_server_name = NONE
+cluster_data_plane_purge_delay = 1209600
 mem_cache_size = 128m
 ssl_cert = NONE
 ssl_cert_key = NONE

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -1009,6 +1009,28 @@ describe("Configuration loader", function()
     end)
   end)
 
+  describe("clustering properties", function()
+    it("cluster_data_plane_purge_delay is accepted", function()
+      local conf = assert(conf_loader(nil, {
+        cluster_data_plane_purge_delay = 100,
+      }))
+      assert.equal(100, conf.cluster_data_plane_purge_delay)
+
+      conf = assert(conf_loader(nil, {
+        cluster_data_plane_purge_delay = 60,
+      }))
+      assert.equal(60, conf.cluster_data_plane_purge_delay)
+    end)
+
+    it("cluster_data_plane_purge_delay < 60 is rejected", function()
+      local conf, err = conf_loader(nil, {
+        cluster_data_plane_purge_delay = 59,
+      })
+      assert.is_nil(conf)
+      assert.equal("cluster_data_plane_purge_delay must be 60 or greater", err)
+    end)
+  end)
+
   describe("upstream keepalive properties", function()
     it("are accepted", function()
       local conf = assert(conf_loader(nil, {

--- a/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
@@ -57,6 +57,8 @@ for _, strategy in helpers.each_strategy() do
 
           for _, v in pairs(json.data) do
             if v.ip == "127.0.0.1" then
+              assert.near(14 * 86400, v.ttl, 3)
+
               return true
             end
           end


### PR DESCRIPTION
cluster_data_planes table so it won't grow uncontained

Also adds new config option `conf.cluster_status_ttl`, that allows the
TTL of cluster status entries to be overwritten by user. The default TTL
is 14 days.