### PR TITLE
chore(deps) bump AWS Lambda plugin to 3.5.0

### DIFF
--- a/kong-2.1.4-0.rockspec
+++ b/kong-2.1.4-0.rockspec
@@ -47,7 +47,7 @@ dependencies = {
   "kong-proxy-cache-plugin ~> 1.3",
   "kong-plugin-request-transformer ~> 1.2",
   "kong-plugin-session ~> 2.4",
-  "kong-plugin-aws-lambda ~> 3.4",
+  "kong-plugin-aws-lambda ~> 3.5",
   "kong-plugin-acme ~> 0.2",
   "kong-plugin-grpc-web ~> 0.2",
   "kong-plugin-grpc-gateway ~> 0.1",


### PR DESCRIPTION
## aws-lambda 3.5.0 22-Sep-2020

- feat: adding support for 'isBase64Encoded' flag in Lambda function responses
- fix: respect `skip_large_bodies` config setting even when not using
  AWS API Gateway compatibility
