### PR TITLE
chore(deps) bump luacheck (used for tests) from 0.23 to 0.24

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 OS := $(shell uname | awk '{print tolower($$0)}')
 MACHINE := $(shell uname -m)
 
-DEV_ROCKS = "busted 2.0.0" "busted-htest 1.0.0" "luacheck 0.23.0" "lua-llthreads2 0.1.5" "http 0.3" "ldoc 1.4.6"
+DEV_ROCKS = "busted 2.0.0" "busted-htest 1.0.0" "luacheck 0.24.0" "lua-llthreads2 0.1.5" "http 0.3" "ldoc 1.4.6"
 WIN_SCRIPTS = "bin/busted" "bin/kong"
 BUSTED_ARGS ?= -v
 TEST_CMD ?= bin/busted $(BUSTED_ARGS)


### PR DESCRIPTION
### Summary

#### Changes

* Caching now uses files in a global directory instead of local
  `.luacheckcache` file. Default cache directory is
  `%LOCALAPPDATA%\Luacheck\Cache` on Windows,
  `~/Library/Caches/Luacheck` on OS X/macOS, and
  `$XDG_CACHE_HOME/luacheck` or `~/.config/luacheck` on other systems.

#### Fixes

* Fixes for using Luacheck with Lua 5.4:
  - Parse 5.4 attributes in `local` declarations (but ignores them for now)
  - Luacheck itself can also run with Lua 5.4
* Fixed `randomize` missing from `busted` set of standard globals (#183).
* Added additional `table` and `thread` definitions for `ngx_lua`.
* Added additional `match` definition for `busted`.

#### Miscellaneous

* Upgraded Windows binary components: Lua 5.3.4 -> 5.3.5,
  LuaFileSystem 1.6.3 -> 1.7.0.