### PR TITLE
chore(tests) include kong*.rockspec to cache hash calculation on travis

### DIFF
--- a/.ci/setup_env.sh
+++ b/.ci/setup_env.sh
@@ -10,7 +10,7 @@ LUAROCKS=$(dep_version RESTY_LUAROCKS_VERSION)
 OPENSSL=$(dep_version RESTY_OPENSSL_VERSION)
 GO_PLUGINSERVER=$(dep_version KONG_GO_PLUGINSERVER_VERSION)
 
-DEPS_HASH=$(cat .ci/setup_env.sh .travis.yml .requirements | md5sum | awk '{ print $1 }')
+DEPS_HASH=$({ cat .ci/setup_env.sh .travis.yml .requirements Makefile; cat kong-*.rockspec | awk '/dependencies/,/}/'; } | md5sum | awk '{ print $1 }')
 INSTALL_CACHE=${INSTALL_CACHE:=/install-cache}
 INSTALL_ROOT=$INSTALL_CACHE/$DEPS_HASH
 


### PR DESCRIPTION
### Summary

If it is not included in cache hash calculation, dependencies that are updated in .rockspec are leaked to other tests / builds.
