### PR TITLE
make kong.log.serialize message `tries` with cjson.empty_array_mt

### DIFF
--- a/kong/pdk/log.lua
+++ b/kong/pdk/log.lua
@@ -15,6 +15,7 @@ local ngx_re = require "ngx.re"
 local inspect = require "inspect"
 local ngx_ssl = require "ngx.ssl"
 local phase_checker = require "kong.pdk.private.phases"
+local cjson = require "cjson"
 
 
 local sub = string.sub
@@ -559,6 +560,9 @@ do
     end
 
     local host_port = ctx.host_port or var.server_port
+    
+    tries = (ctx.balancer_data or {tries = {}}).tries
+    setmetatable(tries, cjson.array_mt)
 
     return {
       request = {
@@ -576,7 +580,7 @@ do
         headers = resp_headers,
         size = var.bytes_sent
       },
-      tries = (ctx.balancer_data or {}).tries,
+      tries = tries,
       latencies = {
         kong = (ctx.KONG_ACCESS_TIME or 0) +
                (ctx.KONG_RECEIVE_TIME or 0) +

--- a/kong/pdk/log.lua
+++ b/kong/pdk/log.lua
@@ -561,7 +561,7 @@ do
 
     local host_port = ctx.host_port or var.server_port
     
-    tries = (ctx.balancer_data or {tries = {}}).tries
+    local tries = (ctx.balancer_data or {}).tries or {}
     setmetatable(tries, cjson.array_mt)
 
     return {

--- a/spec/01-unit/10-log_serializer_spec.lua
+++ b/spec/01-unit/10-log_serializer_spec.lua
@@ -162,7 +162,7 @@ describe("Log Serializer", function()
       local res = kong.log.serialize({ngx = ngx, kong = kong, })
       assert.is_table(res)
 
-      assert.is_nil(res.tries)
+      assert.is_table(res.tries)
     end)
 
     it("basic serializer proxy works with a deprecation warning", function()


### PR DESCRIPTION
### Summary

Make kong.log.serialize message `tries` with cjson.empty_array_mt.
All log plugins use this method to genarate log message, but they don't handle `tries` emtpy.
So the json log is really difficult for other languages to decode.

### Full changelog
only four line:
```
cjson = require "cjson"
local tries = (ctx.balancer_data or {}).tries or {}
setmetatable(tries, cjson.array_mt)
tries=tries,
```

### Issues resolved

Fix #XXX
