### PR TITLE
Always count KONG_WAITING_TIME

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -1081,6 +1081,10 @@ function Kong.body_filter()
                                                              ctx.KONG_BALANCER_ENDED_AT or
                                                              ctx.KONG_BALANCER_START or
                                                              ctx.KONG_ACCESS_ENDED_AT)
+    if not ctx.KONG_WAITING_TIME then
+      ctx.KONG_WAITING_TIME = ctx.KONG_BODY_FILTER_START -
+                              (ctx.KONG_BALANCER_ENDED_AT or ctx.KONG_ACCESS_ENDED_AT)
+    end
   end
 end
 
@@ -1141,6 +1145,11 @@ function Kong.log()
                                           ctx.KONG_LOG_START
         ctx.KONG_HEADER_FILTER_TIME = ctx.KONG_HEADER_FILTER_ENDED_AT -
                                       ctx.KONG_HEADER_FILTER_START
+      end
+
+      if ctx.KONG_PROXIED and not ctx.KONG_WAITING_TIME then
+        ctx.KONG_WAITING_TIME = ctx.KONG_LOG_START -
+                                (ctx.KONG_BALANCER_ENDED_AT or ctx.KONG_ACCESS_ENDED_AT)
       end
     end
   end

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -1081,10 +1081,6 @@ function Kong.body_filter()
                                                              ctx.KONG_BALANCER_ENDED_AT or
                                                              ctx.KONG_BALANCER_START or
                                                              ctx.KONG_ACCESS_ENDED_AT)
-    if not ctx.KONG_WAITING_TIME then
-      ctx.KONG_WAITING_TIME = ctx.KONG_BODY_FILTER_START -
-                              (ctx.KONG_BALANCER_ENDED_AT or ctx.KONG_ACCESS_ENDED_AT)
-    end
   end
 end
 


### PR DESCRIPTION
On errors (especially 499), it's possible that some phases are skipped.
Even on those cases, Kong spent time waiting, so it should be accounted
not only on header-filter but on body-filter (unlikely!) or log phase.

Fix #6180 
