### PR TITLE
chore(deps) remove resty.iputils dependency

### DIFF
--- a/kong-2.1.4-0.rockspec
+++ b/kong-2.1.4-0.rockspec
@@ -26,7 +26,6 @@ dependencies = {
   "luatz == 0.4",
   "lua_system_constants == 0.1.4",
   "lyaml == 6.2.5",
-  "lua-resty-iputils == 0.3.0",
   "luasyslog == 1.0.0",
   "lua_pack == 1.0.5",
   "lua-resty-dns-client == 5.0.1",

--- a/kong/db/schema/typedefs.lua
+++ b/kong/db/schema/typedefs.lua
@@ -3,19 +3,22 @@
 local utils = require "kong.tools.utils"
 local openssl_pkey = require "resty.openssl.pkey"
 local openssl_x509 = require "resty.openssl.x509"
-local iputils = require "resty.iputils"
-local Schema = require("kong.db.schema")
-local socket_url = require("socket.url")
+local Schema = require "kong.db.schema"
+local socket_url = require "socket.url"
 local constants = require "kong.constants"
 local px = require "resty.mediador.proxy"
+local ipmatcher = require "resty.ipmatcher"
 
 
+local tostring = tostring
 local pairs = pairs
 local pcall = pcall
 local match = string.match
 local gsub = string.gsub
+local find = string.find
 local null = ngx.null
 local type = type
+local sub = string.sub
 
 
 local function validate_host(host)
@@ -63,15 +66,32 @@ local function validate_ip_or_cidr(ip)
 end
 
 
-local function validate_cidr_v4(ip)
-  local _, err = iputils.parse_cidr(ip)
-
-  -- It's an error only if the second variable is a string
-  if type(err) == "string" then
-    return nil, "invalid cidr range: " .. err
+local validate_cidr_v4
+do
+  local ip4_cidrs = {}
+  for i = 0, 32 do
+    ip4_cidrs[tostring(i)] = true
   end
 
-  return true
+  validate_cidr_v4 = function(ip_or_cidr)
+    local is_ipv4 = ipmatcher.parse_ipv4(ip_or_cidr)
+    if is_ipv4 then
+      return true
+    end
+
+    local p = find(ip_or_cidr, "/", 1, true)
+    if not p then
+      return nil, "invalid ipv4 cidr range: '" .. ip_or_cidr .. "'"
+    end
+
+    local ip = sub(ip_or_cidr, 1, p - 1)
+    local block = sub(ip_or_cidr, p + 1)
+    if ipmatcher.parse_ipv4(ip) and ip4_cidrs[block] then
+      return true
+    end
+
+    return nil, "invalid ipv4 cidr range: '" .. ip_or_cidr .. "'"
+  end
 end
 
 


### PR DESCRIPTION
### Summary

The resty.iputils lacks ipv6 support and we don't use it anymore. This change removes the last dependency to it and removes the dependency from luarocks.
