### PR TITLE
chore(deps) remove resty.mediador dependency

### DIFF
--- a/kong-2.1.4-0.rockspec
+++ b/kong-2.1.4-0.rockspec
@@ -30,7 +30,6 @@ dependencies = {
   "lua_pack == 1.0.5",
   "lua-resty-dns-client == 5.1.0",
   "lua-resty-worker-events == 1.0.0",
-  "lua-resty-mediador == 0.1.2",
   "lua-resty-healthcheck == 1.3.0",
   "lua-resty-cookie == 0.1.0",
   "lua-resty-mlcache == 2.4.1",

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -11,7 +11,6 @@ local tablex = require "pl.tablex"
 local utils = require "kong.tools.utils"
 local log = require "kong.cmd.utils.log"
 local env = require "kong.cmd.utils.env"
-local ip = require "resty.mediador.ip"
 
 
 local fmt = string.format
@@ -887,7 +886,7 @@ local function check_and_infer(conf, opts)
 
   -- checking the trusted ips
   for _, address in ipairs(conf.trusted_ips) do
-    if not ip.valid(address) and address ~= "unix:" then
+    if not utils.is_valid_ip_or_cidr(address) and address ~= "unix:" then
       errors[#errors + 1] = "trusted_ips must be a comma separated list in " ..
                             "the form of IPv4 or IPv6 address or CIDR "      ..
                             "block or 'unix:', got '" .. address .. "'"

--- a/kong/db/schema/typedefs.lua
+++ b/kong/db/schema/typedefs.lua
@@ -6,19 +6,13 @@ local openssl_x509 = require "resty.openssl.x509"
 local Schema = require "kong.db.schema"
 local socket_url = require "socket.url"
 local constants = require "kong.constants"
-local px = require "resty.mediador.proxy"
-local ipmatcher = require "resty.ipmatcher"
 
 
-local tostring = tostring
 local pairs = pairs
-local pcall = pcall
 local match = string.match
 local gsub = string.gsub
-local find = string.find
 local null = ngx.null
 local type = type
-local sub = string.sub
 
 
 local function validate_host(host)
@@ -42,56 +36,29 @@ end
 
 
 local function validate_ip(ip)
-  local res, err = utils.normalize_ip(ip)
-  if not res then
-    return nil, err
-  end
-
-  if res.type == "name" then
-    return nil, "not an ip address: " .. ip
-  end
-
-  return true
-end
-
-
-local function validate_ip_or_cidr(ip)
-  local pok, perr = pcall(px.compile, ip)
-
-  if pok and type(perr) == "function" then
+  if utils.is_valid_ip(ip) then
     return true
   end
 
-  return nil, "invalid ip or cidr range: '" .. ip .. "'"
+  return nil, "not an ip address: " .. ip
 end
 
 
-local validate_cidr_v4
-do
-  local ip4_cidrs = {}
-  for i = 0, 32 do
-    ip4_cidrs[tostring(i)] = true
+local function validate_ip_or_cidr(ip_or_cidr)
+  if utils.is_valid_ip_or_cidr(ip_or_cidr) then
+    return true
   end
 
-  validate_cidr_v4 = function(ip_or_cidr)
-    local is_ipv4 = ipmatcher.parse_ipv4(ip_or_cidr)
-    if is_ipv4 then
-      return true
-    end
+  return nil, "invalid ip or cidr range: '" .. ip_or_cidr .. "'"
+end
 
-    local p = find(ip_or_cidr, "/", 1, true)
-    if not p then
-      return nil, "invalid ipv4 cidr range: '" .. ip_or_cidr .. "'"
-    end
 
-    local ip = sub(ip_or_cidr, 1, p - 1)
-    local block = sub(ip_or_cidr, p + 1)
-    if ipmatcher.parse_ipv4(ip) and ip4_cidrs[block] then
-      return true
-    end
-
-    return nil, "invalid ipv4 cidr range: '" .. ip_or_cidr .. "'"
+local function validate_ip_or_cidr_v4(ip_or_cidr_v4)
+  if utils.is_valid_ip_or_cidr_v4(ip_or_cidr_v4) then
+    return true
   end
+
+  return nil, "invalid ipv4 cidr range: '" .. ip_or_cidr_v4 .. "'"
 end
 
 
@@ -264,9 +231,10 @@ typedefs.ip_or_cidr = Schema.define {
   custom_validator = validate_ip_or_cidr,
 }
 
+-- TODO: this seems to allow ipv4s too, should it?
 typedefs.cidr_v4 = Schema.define {
   type = "string",
-  custom_validator = validate_cidr_v4,
+  custom_validator = validate_ip_or_cidr_v4,
 }
 
 -- deprecated alias

--- a/kong/router.lua
+++ b/kong/router.lua
@@ -1,7 +1,7 @@
 local constants     = require "kong.constants"
+local ipmatcher     = require "resty.ipmatcher"
 local lrucache      = require "resty.lrucache"
 local utils         = require "kong.tools.utils"
-local px            = require "resty.mediador.proxy"
 local bit           = require "bit"
 
 
@@ -497,7 +497,8 @@ local function marshall_route(r)
         local range_f
 
         if source.ip and find(source.ip, "/", nil, true) then
-          range_f = px.compile(source.ip)
+          local matcher = ipmatcher.new({ source.ip })
+          range_f = function(ip) return matcher:match(ip) end
         end
 
         insert(route_t.sources, {
@@ -530,7 +531,8 @@ local function marshall_route(r)
         local range_f
 
         if destination.ip and find(destination.ip, "/", nil, true) then
-          range_f = px.compile(destination.ip)
+          local matcher = ipmatcher.new({ destination.ip })
+          range_f = function(ip) return matcher:match(ip) end
         end
 
         insert(route_t.destinations, {

--- a/spec/01-unit/01-db/01-schema/06-routes_spec.lua
+++ b/spec/01-unit/01-db/01-schema/06-routes_spec.lua
@@ -930,8 +930,7 @@ describe("routes schema", function()
 
         it("'" .. v .. "' accepts valid 'ip cidr' values", function()
           -- valid CIDRs
-          for _, ip_val in ipairs({ "1/0", "2130706433/2", "4294967295/3",
-                                    "0.0.0.0/0", "::/0", "0.0.0.0/1", "::/1",
+          for _, ip_val in ipairs({ "0.0.0.0/0", "::/0", "0.0.0.0/1", "::/1",
                                     "0.0.0.0/32", "::/128" }) do
             for _, protocol in ipairs({ "tcp", "tls", "udp" }) do
               local route = Routes:process_auto_fields({
@@ -951,7 +950,8 @@ describe("routes schema", function()
 
         it("'" .. v .. "' rejects invalid 'ip cidr' values", function()
           -- invalid CIDRs
-          for _, ip_val in ipairs({ "-1/0", "4294967296/2", "0.0.0.0/a",
+          for _, ip_val in ipairs({ "1/0", "2130706433/2", "4294967295/3",
+                                    "-1/0", "4294967296/2", "0.0.0.0/a",
                                     "::/a", "0.0.0.0/-1", "::/-1",
                                     "0.0.0.0/33", "::/129" }) do
             for _, protocol in ipairs({ "tcp", "tls", "udp" }) do


### PR DESCRIPTION
### Summary

The resty.mediador dependency can be replaced with ipmatcher, and that's what this commit does.