### PR TITLE
chore(admin) poll worker events before and after the changes

### DIFF
--- a/kong/api/api_helpers.lua
+++ b/kong/api/api_helpers.lua
@@ -257,6 +257,8 @@ local function parse_params(fn)
 
     local res, err = fn(self, ...)
 
+    kong.worker_events.poll()
+
     if err then
       kong.log.err(err)
       return ngx.exit(500)

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -1298,6 +1298,8 @@ end
 
 
 function Kong.admin_content(options)
+  kong.worker_events.poll()
+
   local ctx = ngx.ctx
   if not ctx.workspace then
     ctx.workspace = kong.default_workspace

--- a/kong/pdk/response.lua
+++ b/kong/pdk/response.lua
@@ -775,6 +775,10 @@ local function new(self, major_version)
     -- return kong.response.exit(200, "Success")
     -- ```
     function _RESPONSE.exit(status, body, headers)
+      if self.worker_events and ngx.get_phase() == "content" then
+        self.worker_events.poll()
+      end
+
       check_phase(rewrite_access_header)
 
       if ngx.headers_sent then
@@ -947,6 +951,10 @@ local function new(self, major_version)
   --
   -- return kong.response.error(403)
   function _RESPONSE.error(status, message, headers)
+    if self.worker_events and ngx.get_phase() == "content" then
+      self.worker_events.poll()
+    end
+
     check_phase(rewrite_access_header)
 
     if ngx.headers_sent then


### PR DESCRIPTION
### Summary

This PR makes admin api calls to poll worker events before and after actually executing the admin api call function. It makes admin api less dependent on background timers, and makes usage of admin api more predictable.