### PR TITLE
feat(db) check MIN and DEPRECATED versions on connector init

### DIFF
--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -152,7 +152,6 @@ local constants = {
     "kong_rate_limiting_counters",
   },
   DATABASE = {
-    -- These constants are not used anywhere in the Kong code. They're here as a useful reference
     POSTGRES = {
       MIN = "9.5",
     },

--- a/spec/01-unit/01-db/07-db_spec.lua
+++ b/spec/01-unit/01-db/07-db_spec.lua
@@ -105,4 +105,115 @@ describe("DB", function()
 
   end)
 
+  describe(":check_version_compat()", function()
+    local db = {
+      strategy = "foobar",
+      connector = { },
+    }
+
+    lazy_setup(function()
+      local DB = require("kong.db")
+      db.check_version_compat = DB.check_version_compat
+    end)
+
+    describe("db_ver < min", function()
+      it("errors", function()
+        local versions_to_test = {
+          "1.0",
+          "9.0",
+          "9.3",
+        }
+
+        for _, v in ipairs(versions_to_test) do
+          db.connector.major_minor_version = v
+
+          local ok, err = db:check_version_compat("10.0")
+          assert.is_false(ok)
+          assert.equal("Kong requires " .. db.strategy .. " 10.0 or greater " ..
+                       "(currently using " .. v .. ")", err)
+        end
+      end)
+    end)
+
+    describe("db_ver < deprecated < min", function()
+      it("errors", function()
+        local versions_to_test = {
+          "1.0",
+          "9.0",
+          "9.3",
+        }
+
+        for _, v in ipairs(versions_to_test) do
+          db.connector.major_minor_version = v
+
+          local ok, err = db:check_version_compat("10.0", "9.4")
+          assert.is_false(ok)
+          assert.equal("Kong requires " .. db.strategy .. " 10.0 or greater " ..
+                       "(currently using " .. v .. ")", err)
+        end
+      end)
+    end)
+
+    describe("deprecated <= db_ver < min", function()
+      it("logs deprecation warning", function()
+        local log = require "kong.cmd.utils.log"
+        local s = spy.on(log, "warn")
+
+        local versions_to_test = {
+          "9.3",
+          "9.4",
+        }
+
+        for _, v in ipairs(versions_to_test) do
+          db.connector.major_minor_version = v
+
+          local ok, err = db:check_version_compat("9.5", "9.3")
+          assert.is_nil(err)
+          assert.is_true(ok) -- no error on deprecation notices
+          assert.spy(s).was_called_with(
+            "Currently using %s %s which is considered deprecated, " ..
+            "please use %s or greater", db.strategy, v, "9.5")
+        end
+      end)
+    end)
+
+    describe("min < deprecated <= db_ver", function()
+      -- Note: constants should not be configured in this fashion, but this
+      -- test is for robustness's sake
+      it("fine", function()
+        local versions_to_test = {
+          "10.0",
+          "11.1",
+        }
+
+        for _, v in ipairs(versions_to_test) do
+          db.connector.major_minor_version = v
+
+          local ok, err = db:check_version_compat("9.4", "10.0")
+          assert.is_nil(err)
+          assert.is_true(ok)
+        end
+      end)
+    end)
+
+    describe("deprecated < min <= db_ver", function()
+      it("fine", function()
+        local versions_to_test = {
+          "9.5",
+          "10.0",
+          "11.1",
+        }
+
+        for _, v in ipairs(versions_to_test) do
+          db.connector.major_minor_version = v
+
+          local ok, err = db:check_version_compat("9.5", "9.4")
+          assert.is_nil(err)
+          assert.is_true(ok)
+        end
+      end)
+    end)
+
+  end)
+
 end)

--- a/spec/02-integration/03-db/01-db_spec.lua
+++ b/spec/02-integration/03-db/01-db_spec.lua
@@ -189,6 +189,20 @@ for _, strategy in helpers.each_strategy() do
         db_readonly = false,
       }, infos)
     end)
+
+    if strategy ~= "off" then
+      it("calls :check_version_compat with constants", function()
+        local constants = require "kong.constants"
+        local versions = constants.DATABASE[strategy:upper()]
+
+        local db, _ = DB.new(helpers.test_conf, strategy)
+        local s = spy.on(db, "check_version_compat")
+        assert(db:init_connector())
+        -- called_with goes on forever when checking for self
+        assert.equal(versions.MIN, s.calls[1].refs[2])
+        assert.equal(versions.DEPRECATED, s.calls[1].refs[3])
+      end)
+    end
   end)
 
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

This PR adds a version check on db connector initialization. Any version lower that `MIN` will throw an error, unless it's greater or equal to `DEPRECATED`, on which case a warning is shown. 

It's a direct port of the feature that was present on old DAO (https://github.com/Kong/kong/pull/6167 and https://github.com/Kong/kong/commit/a9f5af1a53a701bd74c9ed6683390c3f1b43fc6b). Moved some of the specs to be unit tests instead of integration by mocking related data structures.