### PR TITLE
fix(balancer) protect against nil request context data

### DIFF
--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -1094,7 +1094,7 @@ local function execute(target, ctx)
         target.hash_value = hash_value
       end
 
-      if not ctx.service.client_certificate then
+      if ctx and ctx.service and not ctx.service.client_certificate then
         -- service level client_certificate is not set
         local cert, res, err
         local client_certificate = upstream.client_certificate


### PR DESCRIPTION
Fix errors like these:

```
2020/10/01 14:09:57 [debug] 5632#0: *95 [lua] base_plugin.lua:26: access(): executing plugin "canary": access
2020/10/01 14:09:57 [error] 5632#0: *95 [kong] init.lua:266 [canary] /kong/kong/runloop/balancer.lua:1097: attempt to index local 'ctx' (a nil value), client: 127.0.0.1, server: kong, request: "GET / HTTP/1.1", host: "canary5.com"
2020/10/01 14:09:57 [debug] 5632#0: *95 [lua] base_plugin.lua:26: access(): executing plugin "canary": access
2020/10/01 14:09:57 [error] 5632#0: *95 [kong] init.lua:266 [canary] /kong/kong/runloop/balancer.lua:1097: attempt to index local 'ctx' (a nil value), client: 127.0.0.1, server: kong, request: "GET / HTTP/1.1", host: "canary5.com"'
```