### PR TITLE
feat(tracked-periods) resp ratelimiting persist only tracked periods

### DIFF
--- a/kong/plugins/response-ratelimiting/policies/cluster.lua
+++ b/kong/plugins/response-ratelimiting/policies/cluster.lua
@@ -13,8 +13,8 @@ local tonumber = tonumber
 
 return {
   cassandra = {
-    increment = function(connector, identifier, name, current_timestamp, service_id, route_id, value)
-      local periods = timestamp.get_timestamps(current_timestamp)
+    increment = function(connector, identifier, name, current_timestamp, service_id, route_id, value, tracked_periods)
+      local periods = timestamp.get_timestamps(current_timestamp, tracked_periods)
 
       for period, period_date in pairs(periods) do
         local res, err = connector:query([[
@@ -41,8 +41,8 @@ return {
 
       return true
     end,
-    find = function(connector, identifier, name, period, current_timestamp, service_id, route_id)
-      local periods = timestamp.get_timestamps(current_timestamp)
+    find = function(connector, identifier, name, period, current_timestamp, service_id, route_id, tracked_periods)
+      local periods = timestamp.get_timestamps(current_timestamp, tracked_periods)
 
       local rows, err = connector:query([[
         SELECT value
@@ -72,10 +72,10 @@ return {
     end,
   },
   postgres = {
-    increment = function(connector, identifier, name, current_timestamp, service_id, route_id, value)
+    increment = function(connector, identifier, name, current_timestamp, service_id, route_id, value, tracked_periods)
       local buf = { "BEGIN" }
       local len = 1
-      local periods = timestamp.get_timestamps(current_timestamp)
+      local periods = timestamp.get_timestamps(current_timestamp, tracked_periods)
 
       for _, period in ipairs(timestamp.timestamp_table_fields) do
         local period_date = periods[period]
@@ -112,8 +112,8 @@ return {
 
       return true
     end,
-    find = function(connector, identifier, name, period, current_timestamp, service_id, route_id)
-      local periods = timestamp.get_timestamps(current_timestamp)
+    find = function(connector, identifier, name, period, current_timestamp, service_id, route_id, tracked_periods)
+      local periods = timestamp.get_timestamps(current_timestamp, tracked_periods)
 
       local q = fmt([[
         SELECT "value"

--- a/kong/tools/timestamp.lua
+++ b/kong/tools/timestamp.lua
@@ -40,31 +40,46 @@ local function get_timetable(now)
   return tt_from_timestamp(timestamp)
 end
 
+
 --- Creates a timestamp table containing time by different precision levels.
 -- @param now (optional) Time to generate timestamps from, if omitted current UTC time will be used
+-- @param tracked_timestamp (optional) Timestamp tracked, pairs of key/value in : {["second"]= true, ["minute"]= true, ["hour"]= true, ["day"]= true, ["month"]= true, ["year"]= true}
 -- @return Timestamp table containing fields/precisions; second, minute, hour, day, month, year
-local function get_timestamps(now)
+local function get_timestamps(now, tracked_timestamp)
   local timetable = get_timetable(now)
+  local tracked_timestamp = tracked_timestamp or {["second"]= true, ["minute"]= true, ["hour"]= true, ["day"]= true, ["month"]= true, ["year"]= true}
   local stamps = {}
 
   timetable.sec = math_floor(timetable.sec)   -- reduce to second precision
-  stamps.second = timetable:timestamp() * 1000
+  if tracked_timestamp["second"] ~= nil  then
+    stamps.second = timetable:timestamp() * 1000
+  end
 
   timetable.sec = 0
-  stamps.minute = timetable:timestamp() * 1000
-
+  if tracked_timestamp["minute"] ~= nil then
+    stamps.minute = timetable:timestamp() * 1000
+  end
+  
   timetable.min = 0
-  stamps.hour = timetable:timestamp() * 1000
-
+  if tracked_timestamp["hour"] ~= nil then
+    stamps.hour = timetable:timestamp() * 1000
+  end
+  
   timetable.hour = 0
-  stamps.day = timetable:timestamp() * 1000
+  if tracked_timestamp["day"] ~= nil then
+    stamps.day = timetable:timestamp() * 1000
+  end
 
   timetable.day = 1
-  stamps.month = timetable:timestamp() * 1000
+  if tracked_timestamp["month"] ~= nil then
+    stamps.month = timetable:timestamp() * 1000
+  end
 
   timetable.month = 1
-  stamps.year = timetable:timestamp() * 1000
-
+  if tracked_timestamp["year"] ~= nil then
+    stamps.year = timetable:timestamp() * 1000
+  end
+  
   return stamps
 end
 


### PR DESCRIPTION
### Summary

Plugin response-ratelimiting persist in database each calls value for all following periods : second, minute, hour, day, month, year.
For minimize database size impact, only persist tracked periods. Take all limits and track only periods which have a limit.

### Full changelog

* Response ratelimiting plugin now persist only tracked periods

### Issues resolved

Fix https://github.com/Kong/kong/issues/6413
