### PR TITLE
fix(utils) typo in error message

### DIFF
--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -158,7 +158,7 @@ do
            "any of the `system`-predefined locations. " ..
            "Please install a certs file there or set " ..
            "lua_ssl_trusted_certificate to an " ..
-           "specific filepath instead of `auto`"
+           "specific filepath instead of `system`"
   end
 end
 


### PR DESCRIPTION
I believe we call these "hotfixes" since it fixes a feature introduced in the current release.