### PR TITLE
fix(conf) default nginx_user to kong, not nobody

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -438,12 +438,17 @@
                          # Example: `status_listen = 0.0.0.0:8100`
 
 
-#nginx_user = nobody nobody      # Defines user and group credentials used by
+#nginx_user = kong kong          # Defines user and group credentials used by
                                  # worker processes. If group is omitted, a
                                  # group whose name equals that of user is
                                  # used.
                                  #
                                  # Example: `nginx_user = nginx www`
+                                 #
+                                 # **Note**: If the `kong` user and the `kong`
+                                 # group are not available, the default user
+                                 # and group credentials will be
+                                 # `nobody nobody`.
 
 #nginx_worker_processes = auto   # Determines the number of worker processes
                                  # spawned by Nginx.

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -11,11 +11,18 @@ local tablex = require "pl.tablex"
 local utils = require "kong.tools.utils"
 local log = require "kong.cmd.utils.log"
 local env = require "kong.cmd.utils.env"
+local ffi = require "ffi"
 local ip = require "resty.mediador.ip"
 
 
 local fmt = string.format
 local concat = table.concat
+local C = ffi.C
+
+ffi.cdef([[
+  struct group *getgrnam(const char *name);
+  struct passwd *getpwnam(const char *name);
+]])
 
 
 -- Version 5: https://wiki.mozilla.org/Security/Server_Side_TLS
@@ -1339,16 +1346,30 @@ local function load(path, custom_conf, opts)
 
   conf = tablex.merge(conf, defaults) -- intersection (remove extraneous properties)
 
+  local default_nginx_main_user = false
+  local default_nginx_user = false
+
   do
     -- nginx 'user' directive
     local user = utils.strip(conf.nginx_main_user):gsub("%s+", " ")
     if user == "nobody" or user == "nobody nobody" then
       conf.nginx_main_user = nil
+    elseif user == "kong" or user == "kong kong" then
+      default_nginx_main_user = true
     end
 
     local user = utils.strip(conf.nginx_user):gsub("%s+", " ")
     if user == "nobody" or user == "nobody nobody" then
       conf.nginx_user = nil
+    elseif user == "kong" or user == "kong kong" then
+      default_nginx_user = true
+    end
+  end
+
+  if C.getpwnam("kong") == nil or C.getgrnam("kong") == nil then
+    if default_nginx_main_user == true and default_nginx_user == true then
+      conf.nginx_user = nil
+      conf.nginx_main_user = nil
     end
   end
 

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -1362,6 +1362,7 @@ local function load(path, custom_conf, opts)
     local user = utils.strip(conf.nginx_user):gsub("%s+", " ")
     if user == "nobody" or user == "nobody nobody" then
       conf.nginx_user = nil
+
     elseif user == "kong" or user == "kong kong" then
       default_nginx_user = true
     end

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -1354,6 +1354,7 @@ local function load(path, custom_conf, opts)
     local user = utils.strip(conf.nginx_main_user):gsub("%s+", " ")
     if user == "nobody" or user == "nobody nobody" then
       conf.nginx_main_user = nil
+
     elseif user == "kong" or user == "kong kong" then
       default_nginx_main_user = true
     end

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -50,12 +50,12 @@ upstream_keepalive_pool_size = 60
 upstream_keepalive_max_requests = 100
 upstream_keepalive_idle_timeout = 60
 
-nginx_user = nobody nobody
+nginx_user = kong kong
 nginx_worker_processes = auto
 nginx_optimizations = on
 nginx_daemon = on
 nginx_main_daemon = on
-nginx_main_user = nobody nobody
+nginx_main_user = kong kong
 nginx_main_worker_processes = auto
 nginx_main_worker_rlimit_nofile = auto
 nginx_events_worker_connections = auto

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -3,6 +3,25 @@ local utils = require "kong.tools.utils"
 local helpers = require "spec.helpers"
 local tablex = require "pl.tablex"
 local pl_path = require "pl.path"
+local ffi = require "ffi"
+
+
+local C = ffi.C
+
+
+ffi.cdef([[
+  struct group *getgrnam(const char *name);
+  struct passwd *getpwnam(const char *name);
+]])
+
+
+local function kong_user_group_exists()
+  if C.getpwnam("kong") == nil or C.getgrnam("kong") == nil then
+    return false
+  else
+    return true
+  end
+end
 
 
 local function search_directive(tbl, directive_name, directive_value)
@@ -21,7 +40,11 @@ describe("Configuration loader", function()
   it("loads the defaults", function()
     local conf = assert(conf_loader())
     assert.is_string(conf.lua_package_path)
-    assert.is_nil(conf.nginx_main_user)
+    if kong_user_group_exists() == true then
+      assert.equal("kong kong", conf.nginx_main_user)
+    else
+      assert.is_nil(conf.nginx_main_user)
+    end
     assert.equal("auto", conf.nginx_main_worker_processes)
     assert.same({"127.0.0.1:8001 reuseport backlog=16384", "127.0.0.1:8444 http2 ssl reuseport backlog=16384"}, conf.admin_listen)
     assert.same({"0.0.0.0:8000 reuseport backlog=16384", "0.0.0.0:8443 http2 ssl reuseport backlog=16384"}, conf.proxy_listen)
@@ -36,7 +59,11 @@ describe("Configuration loader", function()
     -- defaults
     assert.equal("on", conf.nginx_main_daemon)
     -- overrides
-    assert.is_nil(conf.nginx_main_user)
+    if kong_user_group_exists() == true then
+      assert.equal("kong kong", conf.nginx_main_user)
+    else
+      assert.is_nil(conf.nginx_main_user)
+    end
     assert.equal("1", conf.nginx_main_worker_processes)
     assert.same({"127.0.0.1:9001"}, conf.admin_listen)
     assert.same({"0.0.0.0:9000", "0.0.0.0:9443 http2 ssl",
@@ -55,7 +82,11 @@ describe("Configuration loader", function()
     -- defaults
     assert.equal("on", conf.nginx_main_daemon)
     -- overrides
-    assert.is_nil(conf.nginx_main_user)
+    if kong_user_group_exists() == true then
+      assert.equal("kong kong", conf.nginx_main_user)
+    else
+      assert.is_nil(conf.nginx_main_user)
+    end
     assert.equal("auto", conf.nginx_main_worker_processes)
     assert.same({"127.0.0.1:9001"}, conf.admin_listen)
     assert.same({"0.0.0.0:9000", "0.0.0.0:9443 http2 ssl",
@@ -402,9 +433,13 @@ describe("Configuration loader", function()
   end)
 
   describe("nginx_main_user", function()
-    it("is nil by default", function()
+    it("is 'kong kong' by default if the kong user/group exist", function()
       local conf = assert(conf_loader(helpers.test_conf_path))
-      assert.is_nil(conf.nginx_main_user)
+      if kong_user_group_exists() == true then
+        assert.equal("kong kong", conf.nginx_main_user)
+      else
+        assert.is_nil(conf.nginx_main_user)
+      end
     end)
     it("is nil when 'nobody'", function()
       local conf = assert(conf_loader(helpers.test_conf_path, {
@@ -427,6 +462,15 @@ describe("Configuration loader", function()
   end)
 
   describe("nginx_user", function()
+    it("is 'kong kong' by default if the kong user/group exist", function()
+      local conf = assert(conf_loader(helpers.test_conf_path))
+      if kong_user_group_exists() == true then
+        assert.equal("kong kong", conf.nginx_user)
+      else
+        assert.is_nil(conf.nginx_user)
+      end
+    end)
+
     it("is nil when 'nobody'", function()
       local conf = assert(conf_loader(helpers.test_conf_path, {
         nginx_user = "nobody"

--- a/spec/01-unit/04-prefix_handler_spec.lua
+++ b/spec/01-unit/04-prefix_handler_spec.lua
@@ -316,7 +316,7 @@ describe("NGINX conf compiler", function()
         local nginx_conf = prefix_handler.compile_nginx_conf(conf)
         assert.not_matches("user%s+[^;]*;", nginx_conf)
       end)
-      it("is included when otherwise #b", function()
+      it("is included when otherwise", function()
         local conf = assert(conf_loader(helpers.test_conf_path, {
           nginx_main_user = "www_data www_data"
         }))
@@ -1028,4 +1028,3 @@ describe("NGINX conf compiler", function()
     end)
   end)
 end)
-

--- a/spec/01-unit/04-prefix_handler_spec.lua
+++ b/spec/01-unit/04-prefix_handler_spec.lua
@@ -1,9 +1,28 @@
 local helpers = require "spec.helpers"
 local conf_loader = require "kong.conf_loader"
 local prefix_handler = require "kong.cmd.utils.prefix_handler"
+local ffi = require "ffi"
 
 local exists = helpers.path.exists
 local join = helpers.path.join
+
+local C = ffi.C
+
+
+ffi.cdef([[
+  struct group *getgrnam(const char *name);
+  struct passwd *getpwnam(const char *name);
+]])
+
+
+local function kong_user_group_exists()
+  if C.getpwnam("kong") == nil or C.getgrnam("kong") == nil then
+    return false
+  else
+    return true
+  end
+end
+
 
 describe("NGINX conf compiler", function()
   describe("gen_default_ssl_cert()", function()
@@ -274,10 +293,14 @@ describe("NGINX conf compiler", function()
     end)
 
     describe("user directive", function()
-      it("is not included by default", function()
+      it("is included by default if the kong user/group exist", function()
         local conf = assert(conf_loader(helpers.test_conf_path))
         local nginx_conf = prefix_handler.compile_nginx_conf(conf)
-        assert.not_matches("user%s+[^;]*;", nginx_conf)
+        if kong_user_group_exists() == true then
+          assert.matches("user kong kong;", nginx_conf)
+        else
+          assert.not_matches("user%s+[^;]*;", nginx_conf)
+        end
       end)
       it("is not included when 'nobody'", function()
         local conf = assert(conf_loader(helpers.test_conf_path, {
@@ -293,7 +316,7 @@ describe("NGINX conf compiler", function()
         local nginx_conf = prefix_handler.compile_nginx_conf(conf)
         assert.not_matches("user%s+[^;]*;", nginx_conf)
       end)
-      it("is included when otherwise", function()
+      it("is included when otherwise #b", function()
         local conf = assert(conf_loader(helpers.test_conf_path, {
           nginx_main_user = "www_data www_data"
         }))


### PR DESCRIPTION
If we install and run Kong with everything default, whenever Kong tries to write something to the Kong prefix, things will break and we will get a permission denied error. This applies to:

- DP nodes trying to write the config.json.gz file to the Kong prefix

- go pluginserver trying to write the go.lua file write to the Kong prefix

- Lua plugins trying to write files to the Kong prefix

And other cases. This is because, by default, the Kong prefix is owned by `root`. When we do a `apt-get install` or `yum install`, the `/usr/local/kong/` prefix (default) is owned by `root` by default. After that, if we do a `kong start` without changing our operating system's `$USER`, the nginx master process will be run as `root` and the nginx workers processes will be run as `nobody`. It means that if we do everything default, the nginx workers processes can’t write anything to the Kong prefix and we’ll get the permission denied errors.

There are a few immediate workarounds for this:

- add the `nginx_user` to the `root` group; or

- change the file system permissions to allow the `nginx_user` the ability to write the cache file to `/usr/local/kong`; or

- allow every user to write to `/usr/local/kong`

All of these workarounds are dangerous and hacky and we don’t document any of these as recommended fixes. We should fix the main cause of the issue. Here are the possibilities:

1) write files somewhere where any user has permissions, like `/tmp`. Maybe even create a `kong_prefix/tmp` folder where it's explicitly said that anyone has permissions over it;

2) set `nginx_user` to `kong` by default (instead of `nobody`), but drop to `nobody` if the `kong` user/group credentials are unavailble. This requires the non-root capability that was implemented at the packaging level [1]. The `nginx_user` configuration will only be changed for environments that have the `kong` user available, so we don't break the source based installs and don't change the default for developers;

3) pre-open all descriptors we need from the master process like nginx seem to do with its logs (e.g. error.log);

4) ship a `kong.conf` with `nginx_user` set to `kong` at the packaging level;

Option 1) is a hack, we’d need to repeat it everywhere we write files in the Kong prefix (Kong codebase, Lua plugins, Go pluginserver, etc). It is also dangerous. The worst option.

Option 2) is a general solution and the one we are going with. Since nginx worker processes will be owned by the `kong` user, and since the default prefix `/usr/local/kong` is now also owned by the `kong` user [1], things that try to write to the Kong prefix won't fail. User can still specify `nobody nobody` if they don't use Hybrid mode or Go plugins and the kong exists on their system and we do not introduce breakages for these users. This may be an obscure use case, but running Kong as nobody is not an uncommon use case. Thanks @dndx for suggesting improvements to this option.

Option 3) is more difficult. Currently there are technical issues that prevent it. We can pre-open all descriptors from the master process in the `init` phase, but it requires passing file descriptors around the codebase. In the `init` phase we have restricted access to some of the important data-sharing mechanisms between workers running in different phases. Also remember that it's not just hybrid mode that is broken, it's also Go plugins and custom Lua plugins that write things to the prefix. Go plugins do not have `init` phases.

Option 4) would mean essentially applying the patch [2] after package installation. Shipping a `/etc/kong/kong.conf.default` with `nginx_user` set to `kong` by default there and also overriding the environment variables. The problem is that the breaking change risk increases if people have `nginx_user` set to something other than the default `nobody`. This is difficult to get it right and it's a breaking change.

The idea of this PR is to fix the permission denied errors when running Kong with the default settings without causing breaking changes by implementing option 2). If the `kong` user does not exist, the user will be dropped to `nobody` as it was before. If the `nginx_user` configuration is set to something else other than `kong` (now the default), we won't change anything and the configuration value will be preserved. If it's set to `nobody` the behavior will be the same as before.

[1] Kong/kong-build-tools#339
[2] https://github.com/Kong/kong/pull/6422/files

Co-authored-by: Datong Sun <datong.sun@konghq.com>

Fix https://github.com/Kong/kong/issues/6591