### PR TITLE
Link is in snippet in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,8 +271,7 @@ Copyright 2016-2020 Kong Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
-You may obtain a copy of the [License](http://www.apache.org/licenses/LICENSE-2.0)
-
+You may obtain a copy of the [License](http://www.apache.org/licenses/LICENSE-2.0).
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/README.md
+++ b/README.md
@@ -266,22 +266,17 @@ Enterprise](https://konghq.com/kong-enterprise-edition/).
 
 ## License
 
-```
+
 Copyright 2016-2020 Kong Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-```
-   [Licence](http://www.apache.org/licenses/LICENSE-2.0)
-   
-```
+You may obtain a copy of the [License](http://www.apache.org/licenses/LICENSE-2.0)
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-```
 
 [kong-url]: https://konghq.com/
 [kong-logo]: https://konghq.com/wp-content/uploads/2018/05/kong-logo-github-readme.png

--- a/README.md
+++ b/README.md
@@ -162,8 +162,7 @@ You can use a Vagrant box running Kong and Postgres that you can find at
 
 Kong mostly is an OpenResty application made of Lua source files, but also
 requires some additional third-party dependencies. We recommend installing
-those by following the source install instructions at
-https://docs.konghq.com/install/source/.
+those by following the [source install instructions](https://docs.konghq.com/install/source/).
 
 Instead of following the second step (Install Kong), clone this repository
 and install the latest Lua sources instead of the currently released ones:
@@ -272,6 +271,7 @@ Copyright 2016-2020 Kong Inc.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the [License](http://www.apache.org/licenses/LICENSE-2.0).
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ Copyright 2016-2020 Kong Inc.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the [License](http://www.apache.org/licenses/LICENSE-2.0)
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/README.md
+++ b/README.md
@@ -272,9 +272,10 @@ Copyright 2016-2020 Kong Inc.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
+```
+   [Licence](http://www.apache.org/licenses/LICENSE-2.0)
+   
+```
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Link is in snippet in readme file under license section by which one can't redirect to the page
Also direct link is is converted under sources installation instructions


### Issues resolved

Fix #6427 
