### PR TITLE
[go-plugin]: kong.ctx.shared can get in log phase #6426

### DIFF
--- a/kong/db/dao/plugins/go.lua
+++ b/kong/db/dao/plugins/go.lua
@@ -231,7 +231,7 @@ do
   local exposed_api = {
     kong = kong,
     ["kong.log.serialize"] = function()
-      return cjson_encode(preloaded_stuff.basic_serializer or basic_serializer.serialize(ngx))
+      return cjson_encode(preloaded_stuff.basic_serializer or basic_serializer.serialize(ngx, kong))
     end,
 
     ["kong.nginx.get_var"] = function(v)
@@ -481,7 +481,7 @@ local get_plugin do
     for _, phase in ipairs(plugin_info.Phases) do
       if phase == "log" then
         plugin[phase] = function(self, conf)
-          preloaded_stuff.basic_serializer = basic_serializer.serialize(ngx)
+          preloaded_stuff.basic_serializer = basic_serializer.serialize(ngx, kong)
           ngx_timer_at(0, function()
             local instance_id = get_instance(plugin_name, conf)
             local _, err = bridge_loop(instance_id, phase)

--- a/kong/pdk/log.lua
+++ b/kong/pdk/log.lua
@@ -590,7 +590,8 @@ do
       service = ctx.service,
       consumer = ctx.authenticated_consumer,
       client_ip = var.remote_addr,
-      started_at = req.start_time() * 1000
+      started_at = req.start_time() * 1000,
+      shared = okong.ctx.shared
     }
   end
 end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

now go-plugin can't get kong.ctx.shared set by other phase,
throw add shared in  log.serialize() return value got the shared value

### Full changelog

* [Implement ...]
* [Add related tests]
* ...

### Issues resolved

Fix #6430
