### PR TITLE
chore(migrations) deprecate migration helpers

### DIFF
--- a/kong/db/migrations/helpers.lua
+++ b/kong/db/migrations/helpers.lua
@@ -1,5 +1,6 @@
 --local json_decode = require("cjson.safe").decode
 local cassandra = require("cassandra")
+local log = require "kong.cmd.utils.log"
 --local utils = require "kong.tools.utils"
 
 
@@ -159,6 +160,11 @@ Note: In Cassandra, INSERT does "insert if not exists or update using pks if exi
 function _M:copy_cassandra_records(source_table_def,
                                    destination_table_def,
                                    columns_to_copy)
+
+  log.warn("migration helpers are deprecated: ",
+           "copy_cassandra_records function may not be available on a next major version")
+
+
   local coordinator, err = self.connector:connect_migrations()
   if not coordinator then
     return nil, err


### PR DESCRIPTION
### Summary

We have never documented this properly and we don't use it in any of the current
migrations. This was needed for pre `1.0.0` migrations.

With this deprecation, we have option to either:
1. remove it with `3.0.0`
2. if feedback demands that we need to keep it:
   then remove the warning and properly document it