### PR TITLE
fix(db) do not export ratelimiting_metrics

### DIFF
--- a/kong/plugins/rate-limiting/daos.lua
+++ b/kong/plugins/rate-limiting/daos.lua
@@ -4,6 +4,7 @@ return {
     primary_key        = { "identifier", "period", "period_date", "service_id", "route_id" },
     generate_admin_api = false,
     ttl                = true,
+    db_export          = false,
     fields             = {
       {
         identifier = {


### PR DESCRIPTION
### Summary

Rate-limiting metrics is problematic on db exports / imports as reported by @jeremyjpj0916 on #6310.

There are several issues on that, but it seems like the main issue is that Cassandra schema specifies the value of ratelimiting_metrics as `COUNTER`. Also it probably does not make sense to export these anyway as agreed on that issue.

### Issues Resolved

Fix #6310