### PR TITLE
fix(cli) no stack trace when running migration up while having pending migrations

### DIFF
--- a/kong/cmd/utils/migrations.lua
+++ b/kong/cmd/utils/migrations.lua
@@ -60,6 +60,10 @@ local function up(schema_state, db, opts)
     error("Cannot run migrations: " .. NEEDS_BOOTSTRAP_MSG)
   end
 
+  if not opts.force and schema_state.pending_migrations then
+    error("Database has pending migrations; run 'kong migrations finish'")
+  end
+
   local ok, err = db:cluster_mutex(MIGRATIONS_MUTEX_KEY, opts, function()
     schema_state = assert(db:schema_state())
 

--- a/kong/cmd/utils/migrations.lua
+++ b/kong/cmd/utils/migrations.lua
@@ -60,6 +60,9 @@ local function up(schema_state, db, opts)
     error("Cannot run migrations: " .. NEEDS_BOOTSTRAP_MSG)
   end
 
+  -- see #6105 for background, this is a workaround that gives a better
+  -- error message (one w/o the long stacktrace) when the pending
+  -- migration checks failed
   if not opts.force and schema_state.pending_migrations then
     error("Database has pending migrations; run 'kong migrations finish'")
   end


### PR DESCRIPTION
### Summary

Fixes issue reported in #6105 by @jeremyjpj0916.

Before this commit:
```
$ kong migrations up
Error: [PostgreSQL error] cluster_mutex callback threw an error: kong/cmd/utils/migrations.lua:67: Database has pending migrations; run 'kong migrations finish'
stack traceback:
	[C]: in function 'error'
	kong/cmd/utils/migrations.lua:67: in function <kong/cmd/utils/migrations.lua:63>
	[C]: in function 'xpcall'
	kong/db/init.lua:364: in function <kong/db/init.lua:314>
	[C]: in function 'pcall'
	kong/concurrency.lua:45: in function 'cluster_mutex'
	kong/cmd/utils/migrations.lua:63: in function 'up'
	kong/cmd/migrations.lua:177: in function 'cmd_exec'
	kong/cmd/init.lua:88: in function <kong/cmd/init.lua:88>
	[C]: in function 'xpcall'
	kong/cmd/init.lua:88: in function <kong/cmd/init.lua:45>
	bin/kong:9: in function 'file_gen'
	init_worker_by_lua:47: in function <init_worker_by_lua:45>
	[C]: in function 'xpcall'
	init_worker_by_lua:54: in function <init_worker_by_lua:52>

  Run with --v (verbose) or --vv (debug) for more details
```

After this commit:
```
$ kong migrations up
Error: Database has pending migrations; run 'kong migrations finish'

  Run with --v (verbose) or --vv (debug) for more details
```

### Issues Resolved

Fix #6105