### PR TITLE
chore(deps) bump resty.dns.client from 5.1.0 to 5.1.1

### DIFF
--- a/kong-2.2.0-0.rockspec
+++ b/kong-2.2.0-0.rockspec
@@ -28,7 +28,7 @@ dependencies = {
   "lyaml == 6.2.5",
   "luasyslog == 1.0.0",
   "lua_pack == 1.0.5",
-  "lua-resty-dns-client == 5.1.0",
+  "lua-resty-dns-client == 5.1.1",
   "lua-resty-worker-events == 1.0.0",
   "lua-resty-healthcheck == 1.3.0",
   "lua-resty-cookie == 0.1.0",


### PR DESCRIPTION
### Summary

Only bumps its own dependency on `lua-resty-timer`. This has become an issue with `lua-resty-healtchecks` bump that also has `lua-resty-timer` dependency now, but for different version. LuaRocks loader has been found flaky on a platform when there are more than two versions of the same library installed. Luarocks also does not seem to handle downgrades well, or cleanups with updates in our use case.