### PR TITLE
feat(http-log) add custom header for authorization

### DIFF
--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -27,7 +27,16 @@ return {
     { methods        = typedefs.methods },
     { hosts          = typedefs.hosts },
     { paths          = typedefs.paths },
-    { headers        = typedefs.headers },
+    { headers = typedefs.headers {
+      keys = typedefs.header_name {
+        match_none = {
+          {
+            pattern = "^[Hh][Oo][Ss][Tt]$",
+            err = "cannot contain 'host' header, which must be specified in the 'hosts' attribute",
+          },
+        },
+      },
+    } },
     { https_redirect_status_code = { type = "integer",
                                      one_of = { 426, 301, 302, 307, 308 },
                                      default = 426, required = true,

--- a/kong/db/schema/typedefs.lua
+++ b/kong/db/schema/typedefs.lua
@@ -508,15 +508,7 @@ typedefs.no_paths = Schema.define(typedefs.paths { eq = null })
 
 typedefs.headers = Schema.define {
   type = "map",
-  keys = {
-    type = "string",
-    match_none = {
-      {
-        pattern = "^[Hh][Oo][Ss][Tt]$",
-        err = "cannot contain 'host' header, which must be specified in the 'hosts' attribute",
-      },
-    },
-  },
+  keys = typedefs.header_name,
   values = {
     type = "array",
     elements = {

--- a/kong/plugins/http-log/handler.lua
+++ b/kong/plugins/http-log/handler.lua
@@ -2,6 +2,7 @@ local BatchQueue = require "kong.tools.batch_queue"
 local cjson = require "cjson"
 local url = require "socket.url"
 local http = require "resty.http"
+local table_clear = require "table.clear"
 
 
 local kong = kong
@@ -11,10 +12,15 @@ local tostring = tostring
 local tonumber = tonumber
 local concat = table.concat
 local fmt = string.format
+local pairs = pairs
 
 
 local queues = {} -- one queue per unique plugin config
 local parsed_urls_cache = {}
+local headers_cache = {}
+local params_cache = {
+  headers = headers_cache,
+}
 
 
 -- Parse host url.
@@ -76,20 +82,28 @@ local function send_payload(self, conf, payload)
     end
   end
 
-  local res, err = httpc:request({
-    method = method,
-    path = parsed_url.path,
-    query = parsed_url.query,
-    headers = {
-      ["Host"] = parsed_url.host,
-      ["Content-Type"] = content_type,
-      ["Content-Length"] = #payload,
-      ["Authorization"] = parsed_url.userinfo and (
-        "Basic " .. encode_base64(parsed_url.userinfo)
-      ),
-    },
-    body = payload,
-  })
+  table_clear(headers_cache)
+  if conf.headers then
+    for h, v in pairs(conf.headers) do
+      headers_cache[h] = v
+    end
+  end
+
+  headers_cache["Host"] = parsed_url.host
+  headers_cache["Content-Type"] = content_type
+  headers_cache["Content-Length"] = #payload
+  if parsed_url.userinfo then
+    headers_cache["Authorization"] = "Basic " .. encode_base64(parsed_url.userinfo)
+  end
+
+  params_cache.method = method
+  params_cache.path = parsed_url.path
+  params_cache.query = parsed_url.query
+  params_cache.body = payload
+
+  -- note: `httpc:request` makes a deep copy of `params_cache`, so it will be
+  -- fine to reuse the table here
+  local res, err = httpc:request(params_cache)
   if not res then
     return nil, "failed request to " .. host .. ":" .. tostring(port) .. ": " .. err
   end

--- a/kong/plugins/http-log/schema.lua
+++ b/kong/plugins/http-log/schema.lua
@@ -1,4 +1,5 @@
 local typedefs = require "kong.db.schema.typedefs"
+local url = require "socket.url"
 
 return {
   name = "http-log",
@@ -16,6 +17,38 @@ return {
           { retry_count = { type = "integer", default = 10 }, },
           { queue_size = { type = "integer", default = 1 }, },
           { flush_timeout = { type = "number", default = 2 }, },
-    }, }, },
+          { headers = typedefs.headers {
+            keys = typedefs.header_name {
+              match_none = {
+                {
+                  pattern = "^[Hh][Oo][Ss][Tt]$",
+                  err = "cannot contain 'Host' header",
+                },
+                {
+                  pattern = "^[Cc][Oo][Nn][Tt][Ee][Nn][Tt]%-[Ll][Ee][nn][Gg][Tt][Hh]$",
+                  err = "cannot contain 'Content-Length' header",
+                },
+                {
+                  pattern = "^[Cc][Oo][Nn][Tt][Ee][Nn][Tt]%-[Tt][Yy][Pp][Ee]$",
+                  err = "cannot contain 'Content-Type' header",
+                },
+              },
+            },
+          } },
+        },
+        custom_validator = function(config)
+          -- check no double userinfo + authorization header
+          local parsed_url = url.parse(config.http_endpoint)
+          if parsed_url.userinfo and config.headers then
+            for hname, hvalue in pairs(config.headers) do
+              if hname:lower() == "authorization" then
+                return false, "specifying both an 'Authorization' header and user info in 'http_endpoint' is not allowed"
+              end
+            end
+          end
+          return true
+        end,
+      },
+    },
   },
 }

--- a/spec/01-unit/01-db/01-schema/03-typedefs_spec.lua
+++ b/spec/01-unit/01-db/01-schema/03-typedefs_spec.lua
@@ -175,16 +175,6 @@ describe("typedefs", function()
     assert.falsy(Test:validate({ f = 123 }))
   end)
 
-  it("headers rejects 'host' but accepts 'host' substring", function()
-    local Test = Schema.new({
-      fields = {
-        { f = typedefs.headers() }
-      }
-    })
-    assert.falsy(Test:validate({ f = { ["host"]  = { "example.com" } } }))
-    assert.truthy(Test:validate({ f = { ["hostname"]  = { "example.com" } } }))
-  end)
-
   it("allows overriding typedefs with boolean false", function()
     local uuid = typedefs.uuid()
     assert.equal(true, uuid.auto)

--- a/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
+++ b/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
@@ -284,6 +284,7 @@ describe("declarative config: flatten", function()
                 queue_size = 1,
                 retry_count = 10,
                 timeout = 10000,
+                headers = null,
               }
             },
             {
@@ -375,7 +376,8 @@ describe("declarative config: flatten", function()
                 method = "POST",
                 queue_size = 1,
                 retry_count = 10,
-                timeout = 10000
+                timeout = 10000,
+                headers = null,
               },
               consumer = {
                 id = "UUID"
@@ -556,7 +558,8 @@ describe("declarative config: flatten", function()
                   method = "POST",
                   queue_size = 1,
                   retry_count = 10,
-                  timeout = 10000
+                  timeout = 10000,
+                  headers = null,
                 },
                 consumer = null,
                 created_at = 1234567890,
@@ -1044,7 +1047,8 @@ describe("declarative config: flatten", function()
                   method = "POST",
                   queue_size = 1,
                   retry_count = 10,
-                  timeout = 10000
+                  timeout = 10000,
+                  headers = null,
                 },
                 consumer = null,
                 created_at = 1234567890,

--- a/spec/03-plugins/03-http-log/02-schema_spec.lua
+++ b/spec/03-plugins/03-http-log/02-schema_spec.lua
@@ -1,0 +1,98 @@
+local PLUGIN_NAME = "http-log"
+
+
+-- helper function to validate data against a schema
+local validate do
+  local validate_entity = require("spec.helpers").validate_plugin_config_schema
+  local plugin_schema = require("kong.plugins."..PLUGIN_NAME..".schema")
+
+  function validate(data)
+    return validate_entity(data, plugin_schema)
+  end
+end
+
+
+describe(PLUGIN_NAME .. ": (schema)", function()
+
+
+  it("accepts minimal config with defaults", function()
+    local ok, err = validate({
+        http_endpoint = "http://myservice.com/path",
+      })
+    assert.is_nil(err)
+    assert.is_truthy(ok)
+  end)
+
+
+  it("does accept allowed headers", function()
+    local ok, err = validate({
+        http_endpoint = "http://myservice.com/path",
+        headers = {
+          ["X-My-Header"] = { "123" }
+        }
+      })
+    assert.is_nil(err)
+    assert.is_truthy(ok)
+  end)
+
+
+  it("does not accept Host header", function()
+    local ok, err = validate({
+        http_endpoint = "http://myservice.com/path",
+        headers = {
+          Host = { "MyHost" }
+        }
+      })
+      assert.same({
+        config = {
+          headers = "cannot contain 'Host' header"
+        } }, err)
+      assert.is_falsy(ok)
+    end)
+
+
+  it("does not accept Content-Length header", function()
+    local ok, err = validate({
+        http_endpoint = "http://myservice.com/path",
+        headers = {
+          ["coNTEnt-Length"] = { "123" }  -- also validate casing
+        }
+      })
+    assert.same({
+      config = {
+        headers = "cannot contain 'Content-Length' header"
+      } }, err)
+    assert.is_falsy(ok)
+  end)
+
+
+  it("does not accept Content-Type header", function()
+    local ok, err = validate({
+        http_endpoint = "http://myservice.com/path",
+        headers = {
+          ["coNTEnt-Type"] = { "bad" }  -- also validate casing
+        }
+      })
+      assert.same({
+        config = {
+          headers = "cannot contain 'Content-Type' header"
+        } }, err)
+      assert.is_falsy(ok)
+    end)
+
+
+    it("does not accept userinfo in URL and 'Authorization' header", function()
+      local ok, err = validate({
+          http_endpoint = "http://hi:there@myservice.com/path",
+          headers = {
+            ["AuthoRIZATion"] = { "bad" }  -- also validate casing
+          }
+        })
+        assert.same({
+            config = "specifying both an 'Authorization' header and user info in 'http_endpoint' is not allowed"
+          }, err)
+        assert.is_falsy(ok)
+      end)
+
+
+  end)


### PR DESCRIPTION
Adds an option to provide a custom header, and value to add to the log request. Typically required for Splunk for example.