### PR TITLE
chore(arm) build workers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -152,11 +152,15 @@ pipeline {
                 CACHE = false
                 UPDATE_CACHE = true
                 DEBUG = 0
+                RELEASE_DOCKER_ONLY=true
+                PACKAGE_TYPE=apk
+                RESTY_IMAGE_BASE=alpine
+                RESTY_IMAGE_TAG=latest
             }
             steps {
                 sh 'echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin || true'
                 sh 'make setup-kong-build-tools'
-                sh 'KONG_VERSION=`git rev-parse --short HEAD` RELEASE_DOCKER_ONLY=true PACKAGE_TYPE=apk RESTY_IMAGE_BASE=alpine RESTY_IMAGE_TAG=latest make release'
+                sh 'KONG_VERSION=`git rev-parse --short HEAD` DOCKER_MACHINE_ARM64_NAME="jenkins-kong-"`cat /proc/sys/kernel/random/uuid` make release'
             }
         }
         stage('Release') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -147,6 +147,10 @@ pipeline {
                 KONG_BUILD_TOOLS_LOCATION = "${env.WORKSPACE}/../kong-build-tools"
                 BINTRAY_USR = 'kong-inc_travis-ci@kong'
                 BINTRAY_KEY = credentials('bintray_travis_key')
+                AWS_ACCESS_KEY = credentials('AWS_ACCESS_KEY')
+                AWS_SECRET_ACCESS_KEY = credentials('AWS_SECRET_ACCESS_KEY')
+                CACHE = false
+                UPDATE_CACHE = true
                 DEBUG = 0
             }
             steps {


### PR DESCRIPTION
The arm build workers require randomized names so the ssh keys dont collide

The only ENV I added was `DOCKER_MACHINE_ARM64_NAME="jenkins-kong-"`cat /proc/sys/kernel/random/uuid`` the rest was a copy / paste to move some values