### PR TITLE
chore(*) bump lua-resty-openssl to 0.6.7

### DIFF
--- a/kong-2.1.4-0.rockspec
+++ b/kong-2.1.4-0.rockspec
@@ -34,7 +34,7 @@ dependencies = {
   "lua-resty-cookie == 0.1.0",
   "lua-resty-mlcache == 2.4.1",
   "lua-messagepack == 0.5.2",
-  "lua-resty-openssl == 0.6.5",
+  "lua-resty-openssl == 0.6.7",
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6",
   -- external Kong plugins


### PR DESCRIPTION
Full diff: https://github.com/fffonion/lua-resty-openssl/compare/0.6.5...0.6.7

Changelog: https://github.com/fffonion/lua-resty-openssl/blob/master/CHANGELOG.md