### PR TITLE
fix(template): nginx conf parse error when access_log set off in stream subsystem

### DIFF
--- a/kong/templates/nginx_kong_stream.lua
+++ b/kong/templates/nginx_kong_stream.lua
@@ -79,7 +79,11 @@ server {
     listen $(entry.listener);
 > end
 
+> if proxy_access_log == "off" then
+    access_log off;
+> else
     access_log ${{PROXY_ACCESS_LOG}} basic;
+> end
     error_log  ${{PROXY_ERROR_LOG}} ${{LOG_LEVEL}};
 
 > for _, ip in ipairs(trusted_ips) do


### PR DESCRIPTION
When stream_listen is on, and  `proxy_access_log` is set `off`, Kong will generate `access_log off basic;`.
Error `nginx: [emerg] invalid parameter "basic" in /usr/local/kong/nginx-kong-stream.conf:63` occurs.