### PR TITLE
hotfix(admin) add /clustering/status back with deprecation header

### DIFF
--- a/kong/api/routes/clustering.lua
+++ b/kong/api/routes/clustering.lua
@@ -1,6 +1,9 @@
 local endpoints = require "kong.api.endpoints"
 
 
+local kong = kong
+
+
 local dp_collection_endpoint = endpoints.get_collection_endpoint(kong.db.clustering_data_planes.schema)
 
 
@@ -17,6 +20,38 @@ return {
         end
 
         return dp_collection_endpoint(self, dao, helpers)
+      end,
+    },
+  },
+
+  ["/clustering/status"] = {
+    schema = kong.db.clustering_data_planes.schema,
+    methods = {
+      GET = function(self, db, helpers)
+        if kong.configuration.role ~= "control_plane" then
+          return kong.response.exit(400, {
+            message = "this endpoint is only available when Kong is " ..
+                      "configured to run as Control Plane for the cluster"
+          })
+        end
+
+        local data = {}
+
+        for row, err in kong.db.clustering_data_planes:each() do
+          if err then
+            kong.log.err(err)
+            return kong.response.exit(500, { message = "An unexpected error happened" })
+          end
+
+          local id = row.id
+          row.id = nil
+
+          data[id] = row
+        end
+
+        return kong.response.exit(200, data, {
+          ["Deprecation"] = "true" -- see: https://tools.ietf.org/html/draft-dalal-deprecation-header-03
+        })
       end,
     },
   },

--- a/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
@@ -65,6 +65,25 @@ for _, strategy in helpers.each_strategy() do
         end, 5)
       end)
 
+      it("shows DP status (#deprecated)", function()
+        helpers.wait_until(function()
+          local admin_client = helpers.admin_client()
+          finally(function()
+            admin_client:close()
+          end)
+
+          local res = assert(admin_client:get("/clustering/status"))
+          local body = assert.res_status(200, res)
+          local json = cjson.decode(body)
+
+          for _, v in pairs(json) do
+            if v.ip == "127.0.0.1" then
+              return true
+            end
+          end
+        end, 5)
+      end)
+
       it("disallow updates on the status endpoint", function()
         helpers.wait_until(function()
           local admin_client = helpers.admin_client()

--- a/spec/02-integration/09-hybrid_mode/03-pki_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/03-pki_spec.lua
@@ -64,6 +64,24 @@ for _, strategy in helpers.each_strategy() do
           end
         end, 5)
       end)
+      it("shows DP status (#deprecated)", function()
+        helpers.wait_until(function()
+          local admin_client = helpers.admin_client()
+          finally(function()
+            admin_client:close()
+          end)
+
+          local res = assert(admin_client:get("/clustering/status"))
+          local body = assert.res_status(200, res)
+          local json = cjson.decode(body)
+
+          for _, v in pairs(json) do
+            if v.ip == "127.0.0.1" then
+              return true
+            end
+          end
+        end, 5)
+      end)
     end)
 
     describe("sync works", function()


### PR DESCRIPTION
### Summary

Adds /clustering/status back for backward compatibility with a `Deprecation` header as described in https://tools.ietf.org/html/draft-dalal-deprecation-header-03.