### PR TITLE
fix(api) use the standard status when patching targets

### DIFF
--- a/kong/api/routes/upstreams.lua
+++ b/kong/api/routes/upstreams.lua
@@ -59,12 +59,12 @@ end
 
 local function update_target_cb(self, db, upstream, target)
   self.params.targets = db.targets.schema:extract_pk_values(target)
-  local _, _, err_t = endpoints.update_entity(self, db, db.targets.schema)
+  local entity, _, err_t = endpoints.update_entity(self, db, db.targets.schema)
   if err_t then
     return endpoints.handle_error(err_t)
   end
 
-  return kong.response.exit(204) -- no content
+  return kong.response.exit(200, entity)
 end
 
 

--- a/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -753,14 +753,18 @@ describe("Admin API #" .. strategy, function()
           },
           headers = { ["Content-Type"] = "application/json" }
         })
-        assert.response(res).has.status(204)
+        assert.response(res).has.status(200)
+        local json = assert.response(res).has.jsonbody()
+        assert.is_string(json.id)
+        assert.are.equal(target.target, json.target)
+        assert.are.equal(659, json.weight)
 
         local res = assert(client:send {
           method = "GET",
           path = "/upstreams/" .. upstream.name .. "/targets/"  .. target.target,
         })
         assert.response(res).has.status(200)
-        local json = assert.response(res).has.jsonbody()
+        json = assert.response(res).has.jsonbody()
         assert.is_string(json.id)
         assert.are.equal(659, json.weight)
 

--- a/spec/02-integration/05-proxy/10-balancer/02-least-connections_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer/02-least-connections_spec.lua
@@ -198,7 +198,11 @@ for _, strategy in helpers.each_strategy() do
           },
         })
         assert.is_nil(err)
-        assert.same(204, res.status)
+        assert.same(200, res.status)
+        local json = assert.response(res).has.jsonbody()
+        assert.is_string(json.id)
+        assert.are.equal("127.0.0.1:10003", json.target)
+        assert.are.equal(0, json.weight)
         api_client:close()
 
         api_client = helpers.admin_client()


### PR DESCRIPTION
`PATCH` requests to Kong admin API return `200` and the entity as the response body when succeeded. This change fixes the behavior for target entities to the standard, instead of returning `204`.