### PR TITLE
perf(migrations) store workspace id after first retrieval

### DIFF
--- a/kong/db/migrations/operations/200_to_210.lua
+++ b/kong/db/migrations/operations/200_to_210.lua
@@ -33,7 +33,6 @@ local function cassandra_get_default_ws(coordinator)
     return nil, err
   end
 
-  if not rows
   if not rows or not rows[1] or not rows[1].id then
     return nil
   end

--- a/kong/db/migrations/operations/200_to_210.lua
+++ b/kong/db/migrations/operations/200_to_210.lua
@@ -34,9 +34,7 @@ local function cassandra_get_default_ws(coordinator)
   end
 
   if not rows
-  or not rows[1]
-  or not rows[1].id
-  then
+  if not rows or not rows[1] or not rows[1].id then
     return nil
   end
 

--- a/kong/db/migrations/operations/200_to_210.lua
+++ b/kong/db/migrations/operations/200_to_210.lua
@@ -13,6 +13,7 @@ local cassandra = require "cassandra"
 
 
 local default_ws_id = uuid.generate_v4()
+local ws_id
 
 
 local function render(template, keys)
@@ -21,6 +22,10 @@ end
 
 
 local function cassandra_get_default_ws(coordinator)
+  if ws_id then
+    return ws_id
+  end
+
   local rows, err = coordinator:execute("SELECT id FROM workspaces WHERE name='default'", nil, {
     consistency = cassandra.consistencies.serial,
   })
@@ -29,13 +34,15 @@ local function cassandra_get_default_ws(coordinator)
   end
 
   if not rows
-     or not rows[1]
-     or not rows[1].id
+  or not rows[1]
+  or not rows[1].id
   then
     return nil
   end
 
-  return rows[1].id
+  ws_id = rows[1].id
+
+  return ws_id
 end
 
 


### PR DESCRIPTION
### Summary

On issue #6403 we have tried to chase the reason for why selecting default workspace id sometimes fail. This commit tries to make it so that if we ever get workspace id, we will store it in module level variable for further migrations that might need it, and not trying to do select each time, which seems flaky according to #6403.

We labeled this as `perf` as that is one thing that it surely does, but we are not sure if it fixes the #6403, and even if it does, we still do not fully understand the root cause of it.
