### PR TITLE
fix(dao) no_{consumer,route,service} usage

### DIFF
--- a/kong/db/dao/plugins.lua
+++ b/kong/db/dao/plugins.lua
@@ -234,14 +234,18 @@ local function load_plugin(self, plugin)
     return nil, err
   end
 
-  if schema.fields.consumer and schema.fields.consumer.eq == null then
-    plugin.no_consumer = true
-  end
-  if schema.fields.route and schema.fields.route.eq == null then
-    plugin.no_route = true
-  end
-  if schema.fields.service and schema.fields.service.eq == null then
-    plugin.no_service = true
+  for _, field in ipairs(schema.fields) do
+    if field.consumer and field.consumer.eq == null then
+      handler.no_consumer = true
+    end
+
+    if field.route and field.route.eq == null then
+      handler.no_route = true
+    end
+
+    if field.service and field.service.eq == null then
+      handler.no_service = true
+    end
   end
 
   ngx_log(ngx_DEBUG, "Loading plugin: ", plugin)

--- a/kong/runloop/plugins_iterator.lua
+++ b/kong/runloop/plugins_iterator.lua
@@ -131,13 +131,13 @@ local function load_configuration_through_combos(ctx, combos, plugin)
   local service  = ctx.service
   local consumer = ctx.authenticated_consumer
 
-  if route and plugin.no_route then
+  if route and plugin.handler.no_route then
     route = nil
   end
-  if service and plugin.no_service then
+  if service and plugin.handler.no_service then
     service = nil
   end
-  if consumer and plugin.no_consumer then
+  if consumer and plugin.handler.no_consumer then
     consumer = nil
   end
 


### PR DESCRIPTION
Schemas are not associative arrays, indexed by the field name,
but arrays of fields; therefore, one needs to iterate over the
top-level `fields` to check for the presence of specific fields.