### PR TITLE
Save context tables for the Go log phase timer.

### DIFF
--- a/kong/db/dao/plugins/go.lua
+++ b/kong/db/dao/plugins/go.lua
@@ -18,7 +18,7 @@ local go = {}
 local reset_instances   -- forward declaration
 local reset_instance
 local reset_and_get_instance
-local preloaded_stuff = {}
+local save_for_later = {}
 
 
 -- add MessagePack empty array/map
@@ -230,7 +230,8 @@ do
   local exposed_api = {
     kong = kong,
     ["kong.log.serialize"] = function()
-      return cjson_encode(preloaded_stuff[coroutine.running()] or kong.log.serialize())
+      local saved = save_for_later[coroutine.running()]
+      return cjson_encode(saved and saved.serialize_data or kong.log.serialize())
     end,
 
     ["kong.nginx.get_var"] = function(v)
@@ -240,19 +241,27 @@ do
     ["kong.nginx.get_tls1_version_str"] = ngx_ssl.get_tls1_version_str,
 
     ["kong.nginx.get_ctx"] = function(k)
-      return ngx.ctx[k]
+      local saved = save_for_later[coroutine.running()]
+      local ngx_ctx = saved and saved.ngx_ctx or ngx.ctx
+      return ngx_ctx[k]
     end,
 
     ["kong.nginx.set_ctx"] = function(k, v)
-      ngx.ctx[k] = v
+      local saved = save_for_later[coroutine.running()]
+      local ngx_ctx = saved and saved.ngx_ctx or ngx.ctx
+      ngx_ctx[k] = v
     end,
 
     ["kong.ctx.shared.get"] = function(k)
-      return kong.ctx.shared[k]
+      local saved = save_for_later[coroutine.running()]
+      local ctx_shared = saved and saved.ctx_shared or kong.ctx.shared
+      return ctx_shared[k]
     end,
 
     ["kong.ctx.shared.set"] = function(k, v)
-      kong.ctx.shared[k] = v
+      local saved = save_for_later[coroutine.running()]
+      local ctx_shared = saved and saved.ctx_shared or kong.ctx.shared
+      ctx_shared[k] = v
     end,
 
     ["kong.nginx.req_start_time"] = ngx.req.start_time,
@@ -478,11 +487,15 @@ local get_plugin do
     for _, phase in ipairs(plugin_info.Phases) do
       if phase == "log" then
         plugin[phase] = function(self, conf)
-          local serialize_data = kong.log.serialize()
+          local saved = {
+            serialize_data = kong.log.serialize(),
+            ngx_ctx = ngx.ctx,
+            ctx_shared = kong.ctx.shared,
+          }
 
           ngx_timer_at(0, function()
             local co = coroutine.running()
-            preloaded_stuff[co] = serialize_data
+            save_for_later[co] = saved
 
             local instance_id = get_instance(plugin_name, conf)
             local _, err = bridge_loop(instance_id, phase)
@@ -491,7 +504,7 @@ local get_plugin do
               bridge_loop(instance_id, phase)
             end
 
-            preloaded_stuff[co] = nil
+            save_for_later[co] = nil
           end)
         end
 

--- a/spec/02-integration/10-go_plugins/01-reports_spec.lua
+++ b/spec/02-integration/10-go_plugins/01-reports_spec.lua
@@ -1,7 +1,7 @@
 local helpers = require "spec.helpers"
 local constants = require "kong.constants"
 local cjson = require "cjson"
-
+local pl_file = require "pl.file"
 
 for _, strategy in helpers.each_strategy() do
   local admin_client
@@ -141,5 +141,28 @@ for _, strategy in helpers.each_strategy() do
       assert.equal("got from server 'openresty'", res.headers['x-hello-from-go-at-response'])
 
     end)
+
+    describe("log phase has access to stuff", function()
+      it("puts that stuff in the log", function()
+        local proxy_client = assert(helpers.proxy_client())
+        local res = proxy_client:get("/", {
+          headers = { host  = "http-service.test" }
+        })
+        assert.res_status(200, res)
+        proxy_client:close()
+
+        local cfg = helpers.test_conf
+        local logs = pl_file.read(cfg.prefix .. "/" .. cfg.proxy_error_log)
+
+        for _, logpat in ipairs{
+          "access_start: %d%d+\n",
+          "shared_msg: Kong!\n",
+          "serialized:%b{}\n",
+        } do
+          assert.match(logpat, logs)
+        end
+      end)
+    end)
+
   end)
 end

--- a/spec/fixtures/go/go-hello.go
+++ b/spec/fixtures/go/go-hello.go
@@ -27,6 +27,29 @@ func (conf Config) Access(kong *pdk.PDK) {
 		message = "hello"
 	}
 	kong.Response.SetHeader("x-hello-from-go", fmt.Sprintf("Go says %s to %s", message, host))
+	kong.Ctx.SetShared("shared_msg", message)
+}
+
+func (conf Config) Log(kong *pdk.PDK) {
+	access_start, err := kong.Nginx.GetCtxFloat("KONG_ACCESS_START")
+	if err != nil {
+		kong.Log.Err(err.Error())
+	}
+	kong.Log.Debug("access_start: ", access_start)
+
+	shared_msg, err := kong.Ctx.GetSharedString("shared_msg")
+	if err != nil {
+		kong.Log.Err(err.Error())
+	}
+
+	kong.Log.Debug("shared_msg: ", shared_msg)
+
+	serialized, err := kong.Log.Serialize()
+	if err != nil {
+		kong.Log.Err(err.Error())
+	}
+
+	kong.Log.Debug("serialized:", serialized)
 }
 
 func (conf Config) Response(kong *pdk.PDK) {


### PR DESCRIPTION
Once again, having Go log phase run in a timer means less access to
request-relative information.

This patch stores `ngx.ctx` and `kong.ctx.shared` tables, prolonging
their lifetimes until timer execution time.  Note: these _must_ be
removed before finishing the timer, or it would create a memory leak.

### Issues resolved

Fix #6426 
Replace #6430 
