### PR TITLE
docs(README) update the building badge with Github Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![][kong-logo]][kong-url]
 
-[![Build Status][badge-travis-image]][badge-travis-url]
+[![Build Status][badge-action-image]][badge-action-url]
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/Kong/kong/blob/master/LICENSE)
 [![Twitter](https://img.shields.io/twitter/follow/thekonginc.svg?style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=thekonginc)
 
@@ -286,8 +286,8 @@ limitations under the License.
 [kong-logo]: https://konghq.com/wp-content/uploads/2018/05/kong-logo-github-readme.png
 [kong-benefits]: https://konghq.com/wp-content/uploads/2018/05/kong-benefits-github-readme.png
 [kong-nightly-master]: https://bintray.com/kong/kong-nightly/master
-[badge-travis-url]: https://travis-ci.org/Kong/kong/branches
-[badge-travis-image]: https://travis-ci.org/Kong/kong.svg?branch=master
+[badge-action-url]: https://github.com/Kong/kong/actions
+[badge-action-image]: https://github.com/Kong/kong/workflows/Build%20&%20Test/badge.svg
 
 [busted]: https://github.com/Olivine-Labs/busted
 [luacheck]: https://github.com/mpeterv/luacheck


### PR DESCRIPTION
Replace the building badge since we switch to the Github Action.