### PR TITLE
fix instance restarting fight.

### DIFF
--- a/kong/db/dao/plugins/go.lua
+++ b/kong/db/dao/plugins/go.lua
@@ -154,7 +154,7 @@ do
       local ok, data = reader()
       if not ok then
         c:setkeepalive()
-        return nil, data
+        return nil, "no data"
       end
 
       if data[1] == 2 then
@@ -393,9 +393,7 @@ do
     while instance_info and not instance_info.id do
       -- some other thread is already starting an instance
       ngx.sleep(0)
-      if not instances[key] then
-        break
-      end
+      instance_info = instances[key]
     end
 
     if instance_info


### PR DESCRIPTION
When a Lua coroutine (thread) finds that another thread is starting an
instance, it waits until the other either succeeds or fails.  In case of
failure, the original thread fails the request, and the second one
tries again.  This retry was wrongly being stored in the old intance
info table which is removed by the failing thread, and never stored
back in the general table by the retrying thread.  This fix ensures
that on the failing case the second thread doesn't hold the old info,
but creates a new one.

### Issues resolved

Fix #6432 #6500 
