### PR TITLE
feat(conf) change *ssl_cert* to arrays and autogenerate ecdsa cert

### DIFF
--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -176,18 +176,24 @@ local PREFIX_PATHS = {
 
   kong_env = {".kong_env"},
 
+  ssl_cert_csr_default = {"ssl", "kong-default.csr"},
   ssl_cert_default = {"ssl", "kong-default.crt"},
   ssl_cert_key_default = {"ssl", "kong-default.key"},
-  ssl_cert_csr_default = {"ssl", "kong-default.csr"},
+  ssl_cert_default_ecdsa = {"ssl", "kong-default-ecdsa.crt"},
+  ssl_cert_key_default_ecdsa = {"ssl", "kong-default-ecdsa.key"},
 
   client_ssl_cert_default = {"ssl", "kong-default.crt"},
   client_ssl_cert_key_default = {"ssl", "kong-default.key"},
 
   admin_ssl_cert_default = {"ssl", "admin-kong-default.crt"},
   admin_ssl_cert_key_default = {"ssl", "admin-kong-default.key"},
+  admin_ssl_cert_default_ecdsa = {"ssl", "admin-kong-default-ecdsa.crt"},
+  admin_ssl_cert_key_default_ecdsa = {"ssl", "admin-kong-default-ecdsa.key"},
 
   status_ssl_cert_default = {"ssl", "status-kong-default.crt"},
   status_ssl_cert_key_default = {"ssl", "status-kong-default.key"},
+  status_ssl_cert_default_ecdsa = {"ssl", "status-kong-default-ecdsa.crt"},
+  status_ssl_cert_key_default_ecdsa = {"ssl", "status-kong-default-ecdsa.key"},
 }
 
 
@@ -283,6 +289,12 @@ local CONF_INFERENCES = {
   status_listen = { typ = "array" },
   stream_listen = { typ = "array" },
   cluster_listen = { typ = "array" },
+  ssl_cert = { typ = "array" },
+  ssl_cert_key = { typ = "array" },
+  admin_ssl_cert = { typ = "array" },
+  admin_ssl_cert_key = { typ = "array" },
+  status_ssl_cert = { typ = "array" },
+  status_ssl_cert_key = { typ = "array" },
   db_update_frequency = {  typ = "number"  },
   db_update_propagation = {  typ = "number"  },
   db_cache_ttl = {  typ = "number"  },
@@ -767,20 +779,50 @@ local function check_and_infer(conf, opts)
     end
   end
 
-  if (concat(conf.proxy_listen, ",") .. " "):find("%sssl[%s,]") then
-    if conf.ssl_cert and not conf.ssl_cert_key then
-      errors[#errors + 1] = "ssl_cert_key must be specified"
+  for _, prefix in ipairs({ "proxy_", "admin_", "status_" }) do
+    local listen = conf[prefix .. "listen"]
 
-    elseif conf.ssl_cert_key and not conf.ssl_cert then
-      errors[#errors + 1] = "ssl_cert must be specified"
+    local ssl_enabled = (concat(listen, ",") .. " "):find("%sssl[%s,]") ~= nil
+    if not ssl_enabled and prefix == "proxy_" then
+      ssl_enabled = (concat(conf.stream_listen, ",") .. " "):find("%sssl[%s,]") ~= nil
     end
 
-    if conf.ssl_cert and not pl_path.exists(conf.ssl_cert) then
-      errors[#errors + 1] = "ssl_cert: no such file at " .. conf.ssl_cert
+    if prefix == "proxy_" then
+      prefix = ""
     end
 
-    if conf.ssl_cert_key and not pl_path.exists(conf.ssl_cert_key) then
-      errors[#errors + 1] = "ssl_cert_key: no such file at " .. conf.ssl_cert_key
+    if ssl_enabled then
+      conf.ssl_enabled = true
+
+      local ssl_cert = conf[prefix .. "ssl_cert"]
+      local ssl_cert_key = conf[prefix .. "ssl_cert_key"]
+
+      if #ssl_cert > 0 and #ssl_cert_key == 0 then
+        errors[#errors + 1] = prefix .. "ssl_cert_key must be specified"
+
+      elseif #ssl_cert_key > 0 and #ssl_cert == 0 then
+        errors[#errors + 1] = prefix .. "ssl_cert must be specified"
+
+      elseif #ssl_cert ~= #ssl_cert_key then
+        errors[#errors + 1] = prefix .. "ssl_cert was specified " .. #ssl_cert .. " times while " ..
+          prefix .. "ssl_cert_key was specified " .. #ssl_cert_key .. " times"
+      end
+
+      if ssl_cert then
+        for _, cert in ipairs(ssl_cert) do
+          if not pl_path.exists(cert) then
+            errors[#errors + 1] = prefix .. "ssl_cert: no such file at " .. cert
+          end
+        end
+      end
+
+      if ssl_cert_key then
+        for _, cert_key in ipairs(ssl_cert_key) do
+          if not pl_path.exists(cert_key) then
+            errors[#errors + 1] = prefix .. "ssl_cert_key: no such file at " .. cert_key
+          end
+        end
+      end
     end
   end
 
@@ -800,25 +842,6 @@ local function check_and_infer(conf, opts)
     if conf.client_ssl_cert_key and not pl_path.exists(conf.client_ssl_cert_key) then
       errors[#errors + 1] = "client_ssl_cert_key: no such file at " ..
                           conf.client_ssl_cert_key
-    end
-  end
-
-  if (concat(conf.admin_listen, ",") .. " "):find("%sssl[%s,]") then
-    if conf.admin_ssl_cert and not conf.admin_ssl_cert_key then
-      errors[#errors + 1] = "admin_ssl_cert_key must be specified"
-
-    elseif conf.admin_ssl_cert_key and not conf.admin_ssl_cert then
-      errors[#errors + 1] = "admin_ssl_cert must be specified"
-    end
-
-    if conf.admin_ssl_cert and not pl_path.exists(conf.admin_ssl_cert) then
-      errors[#errors + 1] = "admin_ssl_cert: no such file at " ..
-                          conf.admin_ssl_cert
-    end
-
-    if conf.admin_ssl_cert_key and not pl_path.exists(conf.admin_ssl_cert_key) then
-      errors[#errors + 1] = "admin_ssl_cert_key: no such file at " ..
-                          conf.admin_ssl_cert_key
     end
   end
 
@@ -1562,19 +1585,33 @@ local function load(path, custom_conf, opts)
     conf.go_plugins_dir = pl_path.abspath(conf.go_plugins_dir)
   end
 
-  if conf.ssl_cert and conf.ssl_cert_key then
-    conf.ssl_cert = pl_path.abspath(conf.ssl_cert)
-    conf.ssl_cert_key = pl_path.abspath(conf.ssl_cert_key)
+  for _, prefix in ipairs({ "ssl", "admin_ssl", "status_ssl", "client_ssl", "cluster" }) do
+    local ssl_cert = conf[prefix .. "_cert"]
+    local ssl_cert_key = conf[prefix .. "_cert_key"]
+
+    if ssl_cert and ssl_cert_key then
+      if type(ssl_cert) == "table" then
+        for i, cert in ipairs(ssl_cert) do
+          ssl_cert[i] = pl_path.abspath(cert)
+        end
+
+      else
+        conf[prefix .. "_cert"] = pl_path.abspath(ssl_cert)
+      end
+
+      if type(ssl_cert) == "table" then
+        for i, key in ipairs(ssl_cert_key) do
+          ssl_cert_key[i] = pl_path.abspath(key)
+        end
+
+      else
+        conf[prefix .. "_cert_key"] = pl_path.abspath(ssl_cert_key)
+      end
+    end
   end
 
-  if conf.client_ssl_cert and conf.client_ssl_cert_key then
-    conf.client_ssl_cert = pl_path.abspath(conf.client_ssl_cert)
-    conf.client_ssl_cert_key = pl_path.abspath(conf.client_ssl_cert_key)
-  end
-
-  if conf.admin_ssl_cert and conf.admin_ssl_cert_key then
-    conf.admin_ssl_cert = pl_path.abspath(conf.admin_ssl_cert)
-    conf.admin_ssl_cert_key = pl_path.abspath(conf.admin_ssl_cert_key)
+  if conf.cluster_ca_cert then
+    conf.cluster_ca_cert = pl_path.abspath(conf.cluster_ca_cert)
   end
 
   local ssl_enabled = conf.proxy_ssl_enabled or
@@ -1609,15 +1646,6 @@ local function load(path, custom_conf, opts)
 
     conf.lua_ssl_trusted_certificate_combined =
       pl_path.abspath(pl_path.join(conf.prefix, ".ca_combined"))
-  end
-
-  if conf.cluster_cert and conf.cluster_cert_key then
-    conf.cluster_cert = pl_path.abspath(conf.cluster_cert)
-    conf.cluster_cert_key = pl_path.abspath(conf.cluster_cert_key)
-  end
-
-  if conf.cluster_ca_cert then
-    conf.cluster_ca_cert = pl_path.abspath(conf.cluster_ca_cert)
   end
 
   -- attach prefix files paths

--- a/kong/runloop/certificate.lua
+++ b/kong/runloop/certificate.lua
@@ -172,10 +172,12 @@ local get_ca_store_opts = {
 
 
 local function init()
-  default_cert_and_key = parse_key_and_cert {
-    cert = assert(pl_utils.readfile(singletons.configuration.ssl_cert)),
-    key = assert(pl_utils.readfile(singletons.configuration.ssl_cert_key)),
-  }
+  if singletons.configuration.ssl_cert[1] then
+    default_cert_and_key = parse_key_and_cert {
+      cert = assert(pl_utils.readfile(singletons.configuration.ssl_cert[1])),
+      key = assert(pl_utils.readfile(singletons.configuration.ssl_cert_key[1])),
+    }
+  end
 end
 
 

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -81,8 +81,10 @@ server {
     error_log  ${{PROXY_ERROR_LOG}} ${{LOG_LEVEL}};
 
 > if proxy_ssl_enabled then
-    ssl_certificate     ${{SSL_CERT}};
-    ssl_certificate_key ${{SSL_CERT_KEY}};
+> for i = 1, #ssl_cert do
+    ssl_certificate     $(ssl_cert[i]);
+    ssl_certificate_key $(ssl_cert_key[i]);
+> end
     ssl_session_cache   shared:SSL:10m;
     ssl_certificate_by_lua_block {
         Kong.ssl_certificate()
@@ -343,8 +345,10 @@ server {
     client_body_buffer_size 10m;
 
 > if admin_ssl_enabled then
-    ssl_certificate     ${{ADMIN_SSL_CERT}};
-    ssl_certificate_key ${{ADMIN_SSL_CERT_KEY}};
+> for i = 1, #admin_ssl_cert do
+    ssl_certificate     $(admin_ssl_cert[i]);
+    ssl_certificate_key $(admin_ssl_cert_key[i]);
+> end
     ssl_session_cache   shared:AdminSSL:10m;
 > end
 
@@ -386,8 +390,10 @@ server {
     error_log  ${{STATUS_ERROR_LOG}} ${{LOG_LEVEL}};
 
 > if status_ssl_enabled then
-    ssl_certificate     ${{STATUS_SSL_CERT}};
-    ssl_certificate_key ${{STATUS_SSL_CERT_KEY}};
+> for i = 1, #status_ssl_cert do
+    ssl_certificate     $(status_ssl_cert[i]);
+    ssl_certificate_key $(status_ssl_cert_key[i]);
+> end
     ssl_session_cache   shared:StatusSSL:1m;
 > end
 

--- a/kong/templates/nginx_kong_stream.lua
+++ b/kong/templates/nginx_kong_stream.lua
@@ -96,8 +96,10 @@ server {
 > end
 
 > if stream_proxy_ssl_enabled then
-    ssl_certificate     ${{SSL_CERT}};
-    ssl_certificate_key ${{SSL_CERT_KEY}};
+> for i = 1, #ssl_cert do
+    ssl_certificate     $(ssl_cert[i]);
+    ssl_certificate_key $(ssl_cert_key[i]);
+> end
     ssl_session_cache   shared:StreamSSL:10m;
     ssl_certificate_by_lua_block {
         Kong.ssl_certificate()

--- a/spec/01-unit/04-prefix_handler_spec.lua
+++ b/spec/01-unit/04-prefix_handler_spec.lua
@@ -13,6 +13,8 @@ describe("NGINX conf compiler", function()
       ssl_cert_key = "spec/fixtures/kong_spec.key",
       admin_ssl_cert = "spec/fixtures/kong_spec.crt",
       admin_ssl_cert_key = "spec/fixtures/kong_spec.key",
+      status_cert = "spec/fixtures/kong_spec.crt",
+      status_cert_key = "spec/fixtures/kong_spec.key",
     }))
     before_each(function()
       helpers.dir.makepath("ssl_tmp")
@@ -23,46 +25,58 @@ describe("NGINX conf compiler", function()
     describe("proxy", function()
       it("auto-generates SSL certificate and key", function()
         assert(prefix_handler.gen_default_ssl_cert(conf))
-        assert(exists(conf.ssl_cert_default))
-        assert(exists(conf.ssl_cert_key_default))
+        for _, suffix in ipairs({ "", "_ecdsa" }) do
+          assert(exists(conf["ssl_cert_default" .. suffix]))
+          assert(exists(conf["ssl_cert_key_default" .. suffix]))
+        end
       end)
       it("does not re-generate if they already exist", function()
         assert(prefix_handler.gen_default_ssl_cert(conf))
-        local cer = helpers.file.read(conf.ssl_cert_default)
-        local key = helpers.file.read(conf.ssl_cert_key_default)
-        assert(prefix_handler.gen_default_ssl_cert(conf))
-        assert.equal(cer, helpers.file.read(conf.ssl_cert_default))
-        assert.equal(key, helpers.file.read(conf.ssl_cert_key_default))
+        for _, suffix in ipairs({ "", "_ecdsa" }) do
+          local cer = helpers.file.read(conf["ssl_cert_default" .. suffix])
+          local key = helpers.file.read(conf["ssl_cert_key_default" .. suffix])
+          assert(prefix_handler.gen_default_ssl_cert(conf))
+          assert.equal(cer, helpers.file.read(conf["ssl_cert_default" .. suffix]))
+          assert.equal(key, helpers.file.read(conf["ssl_cert_key_default" .. suffix]))
+        end
       end)
     end)
     describe("admin", function()
       it("auto-generates SSL certificate and key", function()
         assert(prefix_handler.gen_default_ssl_cert(conf, "admin"))
-        assert(exists(conf.admin_ssl_cert_default))
-        assert(exists(conf.admin_ssl_cert_key_default))
+        for _, suffix in ipairs({ "", "_ecdsa" }) do
+          assert(exists(conf["admin_ssl_cert_default" .. suffix]))
+          assert(exists(conf["admin_ssl_cert_key_default" .. suffix]))
+        end
       end)
       it("does not re-generate if they already exist", function()
         assert(prefix_handler.gen_default_ssl_cert(conf, "admin"))
-        local cer = helpers.file.read(conf.admin_ssl_cert_default)
-        local key = helpers.file.read(conf.admin_ssl_cert_key_default)
-        assert(prefix_handler.gen_default_ssl_cert(conf, "admin"))
-        assert.equal(cer, helpers.file.read(conf.admin_ssl_cert_default))
-        assert.equal(key, helpers.file.read(conf.admin_ssl_cert_key_default))
+        for _, suffix in ipairs({ "", "_ecdsa" }) do
+          local cer = helpers.file.read(conf["admin_ssl_cert_default" .. suffix])
+          local key = helpers.file.read(conf["admin_ssl_cert_key_default" .. suffix])
+          assert(prefix_handler.gen_default_ssl_cert(conf, "admin"))
+          assert.equal(cer, helpers.file.read(conf["admin_ssl_cert_default" .. suffix]))
+          assert.equal(key, helpers.file.read(conf["admin_ssl_cert_key_default" .. suffix]))
+        end
       end)
     end)
     describe("status", function()
       it("auto-generates SSL certificate and key", function()
         assert(prefix_handler.gen_default_ssl_cert(conf, "status"))
-        assert(exists(conf.status_ssl_cert_default))
-        assert(exists(conf.status_ssl_cert_key_default))
+        for _, suffix in ipairs({ "", "_ecdsa" }) do
+          assert(exists(conf["status_ssl_cert_default" .. suffix]))
+          assert(exists(conf["status_ssl_cert_key_default" .. suffix]))
+        end
       end)
       it("does not re-generate if they already exist", function()
         assert(prefix_handler.gen_default_ssl_cert(conf, "status"))
-        local cer = helpers.file.read(conf.status_ssl_cert_default)
-        local key = helpers.file.read(conf.status_ssl_cert_key_default)
-        assert(prefix_handler.gen_default_ssl_cert(conf, "status"))
-        assert.equal(cer, helpers.file.read(conf.status_ssl_cert_default))
-        assert.equal(key, helpers.file.read(conf.status_ssl_cert_key_default))
+        for _, suffix in ipairs({ "", "_ecdsa" }) do
+          local cer = helpers.file.read(conf["status_ssl_cert_default" .. suffix])
+          local key = helpers.file.read(conf["status_ssl_cert_key_default" .. suffix])
+          assert(prefix_handler.gen_default_ssl_cert(conf, "status"))
+          assert.equal(cer, helpers.file.read(conf["status_ssl_cert_default" .. suffix]))
+          assert.equal(key, helpers.file.read(conf["status_ssl_cert_key_default" .. suffix]))
+        end
       end)
     end)
   end)
@@ -168,6 +182,7 @@ describe("NGINX conf compiler", function()
       assert.not_matches("ssl_certificate", kong_nginx_conf)
       assert.not_matches("ssl_certificate_key", kong_nginx_conf)
       assert.not_matches("ssl_certificate_by_lua_block", kong_nginx_conf)
+      assert.not_matches("ssl_dhparam", kong_nginx_conf)
     end)
     describe("handles client_ssl", function()
       it("on", function()
@@ -759,11 +774,14 @@ describe("NGINX conf compiler", function()
           prefix = tmp_config.prefix,
           proxy_listen = "127.0.0.1:8000 ssl",
           admin_listen = "127.0.0.1:8001 ssl",
+          status_listen = "127.0.0.1:8002 ssl",
           ssl_cipher_suite = "custom",
           ssl_cert = "spec/fixtures/kong_spec.crt",
           ssl_cert_key = "spec/fixtures/kong_spec.key",
           admin_ssl_cert = "spec/fixtures/kong_spec.crt",
           admin_ssl_cert_key = "spec/fixtures/kong_spec.key",
+          status_ssl_cert = "spec/fixtures/kong_spec.crt",
+          status_ssl_cert_key = "spec/fixtures/kong_spec.key",
         })
 
         assert(prefix_handler.prepare_prefix(conf))
@@ -779,12 +797,14 @@ describe("NGINX conf compiler", function()
 
         assert(prefix_handler.prepare_prefix(conf))
         assert.truthy(exists(join(conf.prefix, "ssl")))
-        assert.truthy(exists(conf.ssl_cert_default))
-        assert.truthy(exists(conf.ssl_cert_key_default))
-        assert.truthy(exists(conf.admin_ssl_cert_default))
-        assert.truthy(exists(conf.admin_ssl_cert_key_default))
-        assert.truthy(exists(conf.status_ssl_cert_default))
-        assert.truthy(exists(conf.status_ssl_cert_key_default))
+        for _, suffix in ipairs({ "", "_ecdsa" }) do
+          assert.truthy(exists(conf["ssl_cert_default" .. suffix]))
+          assert.truthy(exists(conf["ssl_cert_key_default" .. suffix]))
+          assert.truthy(exists(conf["admin_ssl_cert_default" .. suffix]))
+          assert.truthy(exists(conf["admin_ssl_cert_key_default" .. suffix]))
+          assert.truthy(exists(conf["status_ssl_cert_default" .. suffix]))
+          assert.truthy(exists(conf["status_ssl_cert_key_default" .. suffix]))
+        end
       end)
       it("generates default SSL DH params", function()
         local conf = conf_loader(nil, {

--- a/spec/01-unit/04-prefix_handler_spec.lua
+++ b/spec/01-unit/04-prefix_handler_spec.lua
@@ -806,6 +806,29 @@ describe("NGINX conf compiler", function()
           assert.truthy(exists(conf["status_ssl_cert_key_default" .. suffix]))
         end
       end)
+      it("generates default SSL certs with correct permissions", function()
+        local conf = conf_loader(nil, {
+          prefix = tmp_config.prefix,
+          proxy_listen  = "127.0.0.1:8000 ssl",
+          admin_listen  = "127.0.0.1:8001 ssl",
+          status_listen = "127.0.0.1:8002 ssl",
+        })
+
+        assert(prefix_handler.prepare_prefix(conf))
+        for _, prefix in ipairs({ "", "status_", "admin_" }) do
+          for _, suffix in ipairs({ "", "_ecdsa" }) do
+            local handle = io.popen("ls -l " .. conf[prefix .. "ssl_cert_default" .. suffix])
+            local result = handle:read("*a")
+            handle:close()
+            assert.matches("-rw-r--r--", result, nil, true)
+
+            handle = io.popen("ls -l " .. conf[prefix .. "ssl_cert_key_default" .. suffix])
+            result = handle:read("*a")
+            handle:close()
+            assert.matches("-rw-------", result, nil, true)
+          end
+        end
+      end)
       it("generates default SSL DH params", function()
         local conf = conf_loader(nil, {
           prefix = tmp_config.prefix,

--- a/spec/fixtures/1.2_custom_nginx.template
+++ b/spec/fixtures/1.2_custom_nginx.template
@@ -99,8 +99,10 @@ http {
         access_log logs/access.log;
 
 > if proxy_ssl_enabled then
-        ssl_certificate ${{SSL_CERT}};
-        ssl_certificate_key ${{SSL_CERT_KEY}};
+> for i = 1, #ssl_cert do
+        ssl_certificate     $(ssl_cert[i]);
+        ssl_certificate_key $(ssl_cert_key[i]);
+> end
         ssl_protocols TLSv1.1 TLSv1.2 TLSv1.3;
         ssl_certificate_by_lua_block {
             Kong.ssl_certificate()
@@ -201,8 +203,10 @@ http {
         client_body_buffer_size 10m;
 
 > if admin_ssl_enabled then
-        ssl_certificate ${{ADMIN_SSL_CERT}};
-        ssl_certificate_key ${{ADMIN_SSL_CERT_KEY}};
+> for i = 1, #admin_ssl_cert do
+        ssl_certificate     $(admin_ssl_cert[i]);
+        ssl_certificate_key $(admin_ssl_cert_key[i]);
+> end
         ssl_protocols TLSv1.1 TLSv1.2 TLSv1.3;
 > end
 
@@ -236,8 +240,10 @@ http {
         listen 15555;
         listen 15556 ssl;
 
-        ssl_certificate ${{SSL_CERT}};
-        ssl_certificate_key ${{SSL_CERT_KEY}};
+> for i = 1, #ssl_cert do
+        ssl_certificate     $(ssl_cert[i]);
+        ssl_certificate_key $(ssl_cert_key[i]);
+> end
         ssl_protocols TLSv1.1 TLSv1.2 TLSv1.3;
 
         set_real_ip_from 127.0.0.1;
@@ -558,8 +564,10 @@ stream {
         listen 15557;
         listen 15558 ssl;
 
-        ssl_certificate ${{SSL_CERT}};
-        ssl_certificate_key ${{SSL_CERT_KEY}};
+> for i = 1, #ssl_cert do
+        ssl_certificate     $(ssl_cert[i]);
+        ssl_certificate_key $(ssl_cert_key[i]);
+> end
         ssl_protocols TLSv1.1 TLSv1.2;
 
         content_by_lua_block {

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -103,8 +103,10 @@ http {
         error_log  ${{PROXY_ERROR_LOG}} ${{LOG_LEVEL}};
 
 > if proxy_ssl_enabled then
-        ssl_certificate     ${{SSL_CERT}};
-        ssl_certificate_key ${{SSL_CERT_KEY}};
+> for i = 1, #ssl_cert do
+        ssl_certificate     $(ssl_cert[i]);
+        ssl_certificate_key $(ssl_cert_key[i]);
+> end
         ssl_session_cache   shared:SSL:10m;
         ssl_certificate_by_lua_block {
             Kong.ssl_certificate()
@@ -363,8 +365,10 @@ http {
         client_body_buffer_size 10m;
 
 > if admin_ssl_enabled then
-        ssl_certificate     ${{ADMIN_SSL_CERT}};
-        ssl_certificate_key ${{ADMIN_SSL_CERT_KEY}};
+> for i = 1, #admin_ssl_cert do
+        ssl_certificate     $(admin_ssl_cert[i]);
+        ssl_certificate_key $(admin_ssl_cert_key[i]);
+> end
         ssl_session_cache   shared:AdminSSL:10m;
 > end
 
@@ -406,8 +410,10 @@ http {
         error_log  ${{STATUS_ERROR_LOG}} ${{LOG_LEVEL}};
 
 > if status_ssl_enabled then
-        ssl_certificate     ${{STATUS_SSL_CERT}};
-        ssl_certificate_key ${{STATUS_SSL_CERT_KEY}};
+> for i = 1, #status_ssl_cert do
+        ssl_certificate     $(status_ssl_cert[i]);
+        ssl_certificate_key $(status_ssl_cert_key[i]);
+> end
         ssl_session_cache   shared:StatusSSL:1m;
 > end
 
@@ -466,8 +472,10 @@ http {
         listen 15555;
         listen 15556 ssl;
 
-        ssl_certificate ${{SSL_CERT}};
-        ssl_certificate_key ${{SSL_CERT_KEY}};
+> for i = 1, #ssl_cert do
+        ssl_certificate     $(ssl_cert[i]);
+        ssl_certificate_key $(ssl_cert_key[i]);
+> end
         ssl_protocols TLSv1.1 TLSv1.2 TLSv1.3;
 
         set_real_ip_from 127.0.0.1;
@@ -701,7 +709,6 @@ http {
 
 > if #stream_listeners > 0 then
 stream {
-
     log_format basic '$remote_addr [$time_local] '
                      '$protocol $status $bytes_sent $bytes_received '
                      '$session_time';
@@ -793,8 +800,10 @@ stream {
 > end
 
 > if stream_proxy_ssl_enabled then
-        ssl_certificate     ${{SSL_CERT}};
-        ssl_certificate_key ${{SSL_CERT_KEY}};
+> for i = 1, #ssl_cert do
+        ssl_certificate     $(ssl_cert[i]);
+        ssl_certificate_key $(ssl_cert_key[i]);
+> end
         ssl_session_cache   shared:StreamSSL:10m;
         ssl_certificate_by_lua_block {
             Kong.ssl_certificate()
@@ -835,8 +844,10 @@ stream {
         listen 15558 ssl;
         listen 15557 udp;
 
-        ssl_certificate ${{SSL_CERT}};
-        ssl_certificate_key ${{SSL_CERT_KEY}};
+> for i = 1, #ssl_cert do
+        ssl_certificate     $(ssl_cert[i]);
+        ssl_certificate_key $(ssl_cert_key[i]);
+> end
         ssl_protocols TLSv1.1 TLSv1.2 TLSv1.3;
 
         content_by_lua_block {


### PR DESCRIPTION
### Summary

Previously you could just set a single value to:

- `ssl_cert` and `ssl_cert_key`
- `admin_ssl_cert` and `admin_ssl_cert_key`
- `status_ssl_cert` and `status_ssl_cert_key`

This commit makes them arrays.

Previously we only generated RSA certificate by default which didn't allow certain ciphers on default cipher suites. This commit now also generates ECDSA certificate by default. On modern and intermediate cipher suites the ECDSA certificate is set as the default fallback certificate, on old cipher suite the RSA certificate remains the default fallback certificate. When specifying the custom certificates (with a custom cipher suite), the first specified in array is considered the default fallback certificate.