### PR TITLE
fix(router) ignore SNI matcher when request `protocol` is not `https`…

### DIFF
--- a/kong/router.lua
+++ b/kong/router.lua
@@ -545,7 +545,6 @@ local function marshall_route(r)
 
   -- snis
 
-
   if snis then
     if type(snis) ~= "table" then
       return nil, "snis field must be a table"
@@ -974,7 +973,7 @@ do
 
     [MATCH_RULES.SNI] = function(route_t, ctx)
       local sni = route_t.snis[ctx.sni]
-      if sni then
+      if sni or ctx.req_scheme == "http" then
         ctx.matches.sni = ctx.sni
         return true
       end
@@ -1236,6 +1235,10 @@ function _M.new(routes)
         return r1.max_uri_length > r2.max_uri_length
       end
 
+      --if #r1.route.protocols ~= #r2.route.protocols then
+      --  return #r1.route.protocols < #r2.route.protocols
+      --end
+
       if r1.route.created_at ~= nil and r2.route.created_at ~= nil then
         return r1.route.created_at < r2.route.created_at
       end
@@ -1354,6 +1357,7 @@ function _M.new(routes)
     ctx.req_method     = req_method
     ctx.req_uri        = req_uri
     ctx.req_host       = req_host
+    ctx.req_scheme     = req_scheme
     ctx.req_headers    = req_headers
     ctx.src_ip         = src_ip or ""
     ctx.src_port       = src_port or ""

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -3361,7 +3361,7 @@ describe("Router", function()
         assert.same(use_case[1].route, match_t.route)
       end)
 
-      it("[sni] is ignored for http request but does not shadow `protocols={'http'}` only routes", function()
+      it("[sni] is ignored for http request without shadowing routes with `protocols={'http'}`. Fixes #6425", function()
         local match_t = router_ignore_sni.select(nil, nil, "sni.example.com",
                                                  "http", nil, nil, nil, nil,
                                                  nil)


### PR DESCRIPTION
…. fixes #6425


Originally I thought https://github.com/Kong/kong/pull/6517/files#diff-1958886e00e07e58fb444abe5b024fa98ba0c67c902d4c017fb41d97928de428R1238-R1240 is needed to achieve behavior described by @hishamhm in https://github.com/Kong/kong/issues/6425#issuecomment-710225801, but the test shows that it seems to be unnecessary.