### PR TITLE
fix(dao) nil kong global variable

### DIFF
--- a/kong/cmd/config.lua
+++ b/kong/cmd/config.lua
@@ -79,13 +79,13 @@ local function execute(args)
 
   package.path = conf.lua_package_path .. ";" .. package.path
 
+  _G.kong = kong_global.new()
+  kong_global.init_pdk(_G.kong, conf, nil) -- nil: latest PDK
+
   local dc, err = declarative.new_config(conf, true)
   if not dc then
     error(err)
   end
-
-  _G.kong = kong_global.new()
-  kong_global.init_pdk(_G.kong, conf, nil) -- nil: latest PDK
 
   local db = assert(DB.new(conf))
   assert(db:init_connector())


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

`declarative.new_config()` calls `go.is_on()`, which depends on the `kong` global variable, which is still `nil` because it is not yet initialized.

This moves `declarative.new_config()` after `kong` global variable assignment.

### Full changelog

* fix(dao) nil kong global variable

### Issues resolved

Fix #6437
