### PR TITLE
feat(db) certificates to have cert_alt and key_alt fields

### DIFF
--- a/autodoc/admin-api/data/admin-api.lua
+++ b/autodoc/admin-api/data/admin-api.lua
@@ -1167,6 +1167,23 @@ return {
           description = [[PEM-encoded private key of the SSL key pair.]],
           example = "-----BEGIN RSA PRIVATE KEY-----..."
         },
+        cert_alt = {
+          description = [[
+            PEM-encoded public certificate chain of the alternate SSL key pair.
+            This should only be set if you have both RSA and ECDSA types of
+            certificate available and would like Kong to prefer serving using
+            ECDSA certs when client advertises support for it.
+          ]],
+          example = "-----BEGIN CERTIFICATE-----...",
+        },
+        key_alt = {
+          description = [[PEM-encoded private key of the alternate SSL key pair.
+            This should only be set if you have both RSA and ECDSA types of
+            certificate available and would like Kong to prefer serving using
+            ECDSA certs when client advertises support for it.
+          ]],
+          example = "-----BEGIN EC PRIVATE KEY-----..."
+        },
         tags = {
           description = [[
             An optional set of strings associated with the Certificate for grouping and filtering.

--- a/kong/db/migrations/core/013_220_to_230.lua
+++ b/kong/db/migrations/core/013_220_to_230.lua
@@ -15,6 +15,22 @@ return {
 
       INSERT INTO parameters (key, value) VALUES('cluster_id', '%s')
       ON CONFLICT DO NOTHING;
+
+      DO $$
+      BEGIN
+        ALTER TABLE IF EXISTS ONLY "certificates" ADD "cert_alt" TEXT;
+      EXCEPTION WHEN DUPLICATE_COLUMN THEN
+        -- Do nothing, accept existing state
+      END;
+      $$;
+
+      DO $$
+      BEGIN
+        ALTER TABLE IF EXISTS ONLY "certificates" ADD "key_alt" TEXT;
+      EXCEPTION WHEN DUPLICATE_COLUMN THEN
+        -- Do nothing, accept existing state
+      END;
+      $$;
     ]], CLUSTER_ID),
   },
   cassandra = {
@@ -28,6 +44,9 @@ return {
 
       INSERT INTO parameters (key, value) VALUES('cluster_id', '%s')
       IF NOT EXISTS;
+
+      ALTER TABLE certificates ADD cert_alt TEXT;
+      ALTER TABLE certificates ADD key_alt TEXT;
     ]], CLUSTER_ID),
   }
 }

--- a/kong/db/schema/entities/certificates.lua
+++ b/kong/db/schema/entities/certificates.lua
@@ -2,6 +2,10 @@ local typedefs = require "kong.db.schema.typedefs"
 local openssl_pkey = require "resty.openssl.pkey"
 local openssl_x509 = require "resty.openssl.x509"
 
+
+local type = type
+
+
 return {
   name        = "certificates",
   primary_key = { "id" },
@@ -13,10 +17,13 @@ return {
     { created_at     = typedefs.auto_timestamp_s },
     { cert           = typedefs.certificate { required = true }, },
     { key            = typedefs.key         { required = true }, },
+    { cert_alt       = typedefs.certificate { required = false }, },
+    { key_alt        = typedefs.key         { required = false }, },
     { tags           = typedefs.tags },
   },
 
   entity_checks = {
+    { mutually_required = { "cert_alt", "key_alt" } },
     { custom_entity_check = {
       field_sources = { "cert", "key" },
       fn = function(entity)
@@ -29,6 +36,39 @@ return {
 
         return true
       end,
-    } }
+    } },
+    { custom_entity_check = {
+      field_sources = { "cert_alt", "key_alt" },
+      fn = function(entity)
+        if type(entity.cert_alt) == "string" and type(entity.key_alt) == "string" then
+          local cert_alt = openssl_x509.new(entity.cert_alt)
+          local key_alt = openssl_pkey.new(entity.key_alt)
+
+          if cert_alt:get_pubkey():to_PEM() ~= key_alt:to_PEM("public") then
+            return nil, "alternative certificate does not match key"
+          end
+        end
+
+        return true
+      end,
+    } },
+    { custom_entity_check = {
+      field_sources = { "cert", "cert_alt" },
+      fn = function(entity)
+        if type(entity.cert) == "string" and type(entity.cert_alt) == "string" then
+          local cert = openssl_x509.new(entity.cert)
+          local cert_alt = openssl_x509.new(entity.cert_alt)
+          local cert_type = cert:get_pubkey():get_key_type()
+          local cert_alt_type = cert_alt:get_pubkey():get_key_type()
+          if cert_type.id == cert_alt_type.id then
+            return nil, "certificate and alternative certificate need to have " ..
+                        "different type (e.g. RSA and ECDSA), the provided " ..
+                        "certificates were both of the same type"
+          end
+        end
+
+        return true
+      end,
+    } },
   }
 }

--- a/kong/runloop/certificate.lua
+++ b/kong/runloop/certificate.lua
@@ -55,9 +55,25 @@ local function parse_key_and_cert(row)
     return nil, "could not parse PEM private key: " .. err
   end
 
+  local cert_alt
+  local key_alt
+  if row.cert_alt and row.key_alt then
+    cert_alt, err = parse_pem_cert(row.cert_alt)
+    if not cert_alt then
+      return nil, "could not parse alternate PEM certificate: " .. err
+    end
+
+    key_alt, err = parse_pem_priv_key(row.key_alt)
+    if not key_alt then
+      return nil, "could not parse alternate PEM private key: " .. err
+    end
+  end
+
   return {
     cert = cert,
     key = key,
+    cert_alt = cert_alt,
+    key_alt = key_alt,
   }
 end
 
@@ -264,6 +280,20 @@ local function execute()
   if not ok then
     log(ERR, "could not set configured private key: ", err)
     return ngx.exit(ngx.ERROR)
+  end
+
+  if cert_and_key.cert_alt and cert_and_key.key_alt then
+    ok, err = set_cert(cert_and_key.cert_alt)
+    if not ok then
+      log(ERR, "could not set alternate configured certificate: ", err)
+      return ngx.exit(ngx.ERROR)
+    end
+
+    ok, err = set_priv_key(cert_and_key.key_alt)
+    if not ok then
+      log(ERR, "could not set alternate configured private key: ", err)
+      return ngx.exit(ngx.ERROR)
+    end
   end
 end
 

--- a/spec/02-integration/05-proxy/06-ssl_spec.lua
+++ b/spec/02-integration/05-proxy/06-ssl_spec.lua
@@ -146,8 +146,11 @@ for _, strategy in helpers.each_strategy() do
       })
 
       local cert = bp.certificates:insert {
-        cert  = ssl_fixtures.cert,
-        key   = ssl_fixtures.key,
+        cert     = ssl_fixtures.cert,
+        key      = ssl_fixtures.key,
+        cert_alt = ssl_fixtures.cert_ecdsa,
+        key_alt  = ssl_fixtures.key_ecdsa,
+
       }
 
       bp.snis:insert {
@@ -170,6 +173,8 @@ for _, strategy in helpers.each_strategy() do
       local certificate_alt_alt = bp.certificates:insert {
         cert = ssl_fixtures.cert_alt_alt,
         key = ssl_fixtures.key_alt_alt,
+        cert_alt = ssl_fixtures.cert_alt_alt_ecdsa,
+        key_alt = ssl_fixtures.key_alt_alt_ecdsa,
       }
 
       bp.snis:insert {
@@ -562,8 +567,10 @@ for _, strategy in helpers.each_strategy() do
       }
 
       local cert = bp.certificates:insert {
-        cert  = ssl_fixtures.cert,
-        key   = ssl_fixtures.key,
+        cert     = ssl_fixtures.cert,
+        key      = ssl_fixtures.key,
+        cert_alt = ssl_fixtures.cert_ecdsa,
+        key_alt  = ssl_fixtures.key_ecdsa,
       }
 
       bp.snis:insert {
@@ -622,8 +629,10 @@ for _, strategy in helpers.each_strategy() do
       }
 
       local cert = bp.certificates:insert {
-        cert  = ssl_fixtures.cert,
-        key   = ssl_fixtures.key,
+        cert     = ssl_fixtures.cert,
+        key      = ssl_fixtures.key,
+        cert_alt = ssl_fixtures.cert_ecdsa,
+        key_alt  = ssl_fixtures.key_ecdsa,
       }
 
       bp.snis:insert {

--- a/spec/fixtures/ssl.lua
+++ b/spec/fixtures/ssl.lua
@@ -1,16 +1,16 @@
 return {
-  -- Version: 1 (0x0)
-  -- ...
-  -- Issuer: C = US, ST = California, L = San Francisco, O = Kong, OU = Core, CN = ssl-example.com
-  -- Validity
-  --    Not Before: Apr 24 14:36:29 2020 GMT
-  --    Not After : Feb  7 14:36:29 2294 GMT
-  -- ...
-  --
-  -- Note: Version 1 was accomplished by using a openssl.cnf file
-  -- with the x509_extensions line commented out.
-  -- See https://stackoverflow.com/questions/26788244/how-to-create-a-legacy-v1-or-v2-x-509-cert-for-testing
-  -- and this line's commit message for more info
+  --[[
+  Version: 1 (0x0)
+  Issuer: C = US, ST = California, L = San Francisco, O = Kong, OU = Core, CN = ssl-example.com
+  Validity
+      Not Before: Apr 24 14:36:29 2020 GMT
+      Not After : Feb  7 14:36:29 2294 GMT
+
+  Note: Version 1 was accomplished by using a openssl.cnf file
+  with the x509_extensions line commented out.
+  See https://stackoverflow.com/questions/26788244/how-to-create-a-legacy-v1-or-v2-x-509-cert-for-testing
+  and this line's commit message for more info
+  --]]
   cert = [[-----BEGIN CERTIFICATE-----
 MIIFbTCCA1UCFGjFyapVZYpvpKuYDJbLA1YJip++MA0GCSqGSIb3DQEBCwUAMHIx
 CzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1TYW4g
@@ -95,17 +95,46 @@ N7D4w5wpK/SHbjZBvSNp5kNlnqfDPjmfAwlGW1J6CBDcWWaEHWIcc4n3l2bCg3At
 LTLKB76sourXcEDVvZA6xrYv9GJukUqmc5SlHhJZQOhu48ITKXH18U7iuy8=
 -----END RSA PRIVATE KEY-----]],
 
-  -- Issuer: C = US, ST = California, O = Kong Testing, CN = Kong Testing Intermidiate CA
-  --     Validity
-  --         Not Before: May  2 20:03:11 2019 GMT
-  --         Not After : Apr 28 20:03:11 2029 GMT
-  --     Subject: C = US, ST = California, O = Kong Testing, CN = foo@example.com
-  -- X509v3 Key Usage: critical
-  --     Digital Signature, Non Repudiation, Key Encipherment
-  -- X509v3 Extended Key Usage:
-  --     TLS Web Client Authentication, E-mail Protection
-  -- X509v3 Subject Alternative Name:
-  --     email:foo@example.com, email:bar@example.com
+  --[[
+  Signature Algorithm: ecdsa-with-SHA256
+  Issuer: C = US, ST = California, L = San Francisco, O = Kong, OU = Core, CN = ssl-example.com
+  Validity
+       Not Before: Nov 18 16:17:30 2020 GMT
+       Not After : Sep  3 16:17:30 2294 GMT
+  --]]
+  cert_ecdsa = [[-----BEGIN CERTIFICATE-----
+MIICPDCCAeGgAwIBAgIUOIK1sCtPyUL5h7vHdxpN5PhpukMwCgYIKoZIzj0EAwIw
+cjELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDVNh
+biBGcmFuY2lzY28xDTALBgNVBAoMBEtvbmcxDTALBgNVBAsMBENvcmUxGDAWBgNV
+BAMMD3NzbC1leGFtcGxlLmNvbTAgFw0yMDExMTgxNjE3MzBaGA8yMjk0MDkwMzE2
+MTczMFowcjELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNV
+BAcMDVNhbiBGcmFuY2lzY28xDTALBgNVBAoMBEtvbmcxDTALBgNVBAsMBENvcmUx
+GDAWBgNVBAMMD3NzbC1leGFtcGxlLmNvbTBZMBMGByqGSM49AgEGCCqGSM49AwEH
+A0IABDFm7D+CfVzbkRyRTR/2DI4o1sOxDCdc1UEdbQkA5e6j5b4smyuW4xlZjVwV
+CXeADYvtpBaykzZ+NC5Zlf3EAkWjUzBRMB0GA1UdDgQWBBQcXSBVifOMnYaC632X
+NzdazHkuEjAfBgNVHSMEGDAWgBQcXSBVifOMnYaC632XNzdazHkuEjAPBgNVHRMB
+Af8EBTADAQH/MAoGCCqGSM49BAMCA0kAMEYCIQDbSwXZ15UJ0hX/7KTKxd/mER7b
+s5oBurNijw1iPMyi+wIhALixa/LN3i+AykB4Jxj89scpXilIH+6q5fJI9exuaLtv
+-----END CERTIFICATE-----]],
+  key_ecdsa = [[-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIDCpckzH9Z6YpE48cmSIqcNXDZ29peoeMkFP2NqZb/MUoAoGCCqGSM49
+AwEHoUQDQgAEMWbsP4J9XNuRHJFNH/YMjijWw7EMJ1zVQR1tCQDl7qPlviybK5bj
+GVmNXBUJd4ANi+2kFrKTNn40LlmV/cQCRQ==
+-----END EC PRIVATE KEY-----]],
+
+  --[[
+  Issuer: C = US, ST = California, O = Kong Testing, CN = Kong Testing Intermidiate CA
+      Validity
+          Not Before: May  2 20:03:11 2019 GMT
+          Not After : Apr 28 20:03:11 2029 GMT
+      Subject: C = US, ST = California, O = Kong Testing, CN = foo@example.com
+  X509v3 Key Usage: critical
+      Digital Signature, Non Repudiation, Key Encipherment
+  X509v3 Extended Key Usage:
+      TLS Web Client Authentication, E-mail Protection
+  X509v3 Subject Alternative Name:
+      email:foo@example.com, email:bar@example.com
+  --]]
   cert_client = [[-----BEGIN CERTIFICATE-----
 MIIFIjCCAwqgAwIBAgICIAEwDQYJKoZIhvcNAQELBQAwYDELMAkGA1UEBhMCVVMx
 EzARBgNVBAgMCkNhbGlmb3JuaWExFTATBgNVBAoMDEtvbmcgVGVzdGluZzElMCMG
@@ -197,11 +226,11 @@ utJFRkc3FvrrkkeWHnyDQrPmAHjar94/xq1k1Vo+KQHQVQOrvtQt6KXK
 -----END RSA PRIVATE KEY-----]],
 
   --[[
-    Issuer: C = US, ST = California, O = Kong Testing, CN = Kong Testing Root CA
-    Validity
-        Not Before: Apr 13 23:48:41 2020 GMT
-        Not After : Apr 11 23:48:41 2030 GMT
-    Subject: C = US, ST = CA, O = Kong Testing, CN = example2.com
+  Issuer: C = US, ST = California, O = Kong Testing, CN = Kong Testing Root CA
+  Validity
+      Not Before: Apr 13 23:48:41 2020 GMT
+      Not After : Apr 11 23:48:41 2030 GMT
+  Subject: C = US, ST = CA, O = Kong Testing, CN = example2.com
   --]]
   cert_client2 = [[-----BEGIN CERTIFICATE-----
 MIIEJzCCAg8CFAQ6oTnLBUHbumx1bxyY9kV0W21BMA0GCSqGSIb3DQEBCwUAMFgx
@@ -258,13 +287,13 @@ LTsbLleJTc8CX0bI4SukQ7MVQsiHimzyEzx3eyLt1S8aBdJuRFZ2mg==
 
   --[[
   Issuer: C=US, ST=California, L=San Francisco, O=Mashape, OU=Kong, CN=ssl-alt.com
-        Validity
-            Not Before: May 24 23:46:58 2017 GMT
-            Not After : Jun 23 23:46:58 2017 GMT
-        Subject: C=US, ST=California, L=San Francisco, O=Mashape, OU=Kong, CN=ssl-alt.com
-        Subject Public Key Info:
-            Public Key Algorithm: rsaEncryption
-                Public-Key: (4096 bit)
+  Validity
+      Not Before: May 24 23:46:58 2017 GMT
+      Not After : Jun 23 23:46:58 2017 GMT
+  Subject: C=US, ST=California, L=San Francisco, O=Mashape, OU=Kong, CN=ssl-alt.com
+  Subject Public Key Info:
+      Public Key Algorithm: rsaEncryption
+          Public-Key: (4096 bit)
   --]]
   cert_alt = [[-----BEGIN CERTIFICATE-----
 MIIFXjCCA0YCCQCsb6B5OWdHXDANBgkqhkiG9w0BAQsFADBxMQswCQYDVQQGEwJV
@@ -351,14 +380,41 @@ MRz5bk6HBaxa2Twpa6yra+pobyWhRyU/X40wV7nUs3wd1vZNMjn0i8vXwnT6zdNv
 -----END RSA PRIVATE KEY-----]],
 
   --[[
+  Signature Algorithm: ecdsa-with-SHA256
+  Issuer: C = US, ST = California, L = San Francisco, O = Kong, OU = Core, CN = ssl-example.com
+  Validity
+      Not Before: Nov 18 16:49:53 2020 GMT
+      Not After : Sep  3 16:49:53 2294 GMT
+  --]]
+  cert_alt_ecdsa =  [[-----BEGIN CERTIFICATE-----
+MIICOjCCAeGgAwIBAgIUbsAIMsTeD3F1oNLKOyRabSN6O9EwCgYIKoZIzj0EAwIw
+cjELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDVNh
+biBGcmFuY2lzY28xDTALBgNVBAoMBEtvbmcxDTALBgNVBAsMBENvcmUxGDAWBgNV
+BAMMD3NzbC1leGFtcGxlLmNvbTAgFw0yMDExMTgxNjQ5NTNaGA8yMjk0MDkwMzE2
+NDk1M1owcjELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNV
+BAcMDVNhbiBGcmFuY2lzY28xDTALBgNVBAoMBEtvbmcxDTALBgNVBAsMBENvcmUx
+GDAWBgNVBAMMD3NzbC1leGFtcGxlLmNvbTBZMBMGByqGSM49AgEGCCqGSM49AwEH
+A0IABCwjAZ7WZIwBJQOER5LB6g554ecpBVUnHKjYq8xiWU2+giX5pg4ros6rf3tv
+MMkc3aPYz87B7bwQlZ0Z2NC7iUujUzBRMB0GA1UdDgQWBBQzR6or+QaEVZxXrX5/
+BhgA7y5mjTAfBgNVHSMEGDAWgBQzR6or+QaEVZxXrX5/BhgA7y5mjTAPBgNVHRMB
+Af8EBTADAQH/MAoGCCqGSM49BAMCA0cAMEQCIEDzO105JmNu3RLib3DyIZ4TqDTF
+/iEr+t+W6+rZqiHuAiBvhIxGlLfkypQa9p4iNKRLmFcEk/S/shQ4d0hzd9SDbg==
+-----END CERTIFICATE-----]],
+  key_alt_ecdsa = [[-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIECo5oNJH83ZUFUm3SfjRHyPyRU5pJ5D1V0zk4KtrlNZoAoGCCqGSM49
+AwEHoUQDQgAELCMBntZkjAElA4RHksHqDnnh5ykFVSccqNirzGJZTb6CJfmmDiui
+zqt/e28wyRzdo9jPzsHtvBCVnRnY0LuJSw==
+-----END EC PRIVATE KEY-----]],
+
+  --[[
   Issuer: C = US, ST = California, L = San Francico, O = Kong Inc., CN = ssl-alt-alt.com
-        Validity
-            Not Before: Nov 18 07:28:56 2018 GMT
-            Not After : Dec 18 07:28:56 2018 GMT
-        Subject: C = US, ST = California, L = San Francico, O = Kong Inc., CN = ssl-alt-alt.com
-        Subject Public Key Info:
-            Public Key Algorithm: rsaEncryption
-                Public-Key: (2048 bit)
+  Validity
+      Not Before: Nov 18 07:28:56 2018 GMT
+      Not After : Dec 18 07:28:56 2018 GMT
+  Subject: C = US, ST = California, L = San Francico, O = Kong Inc., CN = ssl-alt-alt.com
+  Subject Public Key Info:
+      Public Key Algorithm: rsaEncryption
+          Public-Key: (2048 bit)
   --]]
   cert_alt_alt = [[-----BEGIN CERTIFICATE-----
 MIIDpDCCAoygAwIBAgIJAIAQMZH+2V26MA0GCSqGSIb3DQEBCwUAMGcxCzAJBgNV
@@ -412,15 +468,46 @@ IqGzqSWne1tW86drBcfSip714wsZOoF8PT6iUCa0LC1sum1P4vS2cnRw8jXwIL6g
 gEuhDrQHJ5V1U/Qc1HrqWYH4cA==
 -----END PRIVATE KEY-----]],
 
-  -- Issuer: C = US, ST = California, O = Kong Testing, CN = Kong Testing Root CA
-  -- Validity
-  --     Not Before: May  2 19:34:42 2019 GMT
-  --     Not After : Apr 27 19:34:42 2039 GMT
-  -- Subject: C = US, ST = California, O = Kong Testing, CN = Kong Testing Root CA
-  -- X509v3 Basic Constraints: critical
-  --     CA:TRUE
-  -- X509v3 Key Usage: critical
-  --     Digital Signature, Certificate Sign, CRL Sign
+  --[[
+  Signature Algorithm: ecdsa-with-SHA256
+  Issuer: C = US, ST = California, L = San Francisco, O = Kong, OU = Core, CN = ssl-alt-alt.com
+  Validity
+      Not Before: Nov 25 14:47:53 2020 GMT
+      Not After : Sep 10 14:47:53 2294 GMT
+  Subject: C = US, ST = California, L = San Francisco, O = Kong, OU = Core, CN = ssl-alt-alt.com
+  --]]
+  cert_alt_alt_ecdsa = [[-----BEGIN CERTIFICATE-----
+MIICPDCCAeGgAwIBAgIUUN+dYLgQkk8az6KLufNic5LFKrYwCgYIKoZIzj0EAwIw
+cjELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDVNh
+biBGcmFuY2lzY28xDTALBgNVBAoMBEtvbmcxDTALBgNVBAsMBENvcmUxGDAWBgNV
+BAMMD3NzbC1hbHQtYWx0LmNvbTAgFw0yMDExMjUxNDQ3NTNaGA8yMjk0MDkxMDE0
+NDc1M1owcjELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNV
+BAcMDVNhbiBGcmFuY2lzY28xDTALBgNVBAoMBEtvbmcxDTALBgNVBAsMBENvcmUx
+GDAWBgNVBAMMD3NzbC1hbHQtYWx0LmNvbTBZMBMGByqGSM49AgEGCCqGSM49AwEH
+A0IABKnmBOy/odm9rUNVTz2vMzGtXVnodngWFY7wf2W99aLcDLz32WNg10oYdGKW
+MuPCtO6vwWGgOi+/mYSToEU7U0qjUzBRMB0GA1UdDgQWBBQtbY0EZpt9Nlf2spRC
+IfphGjYmijAfBgNVHSMEGDAWgBQtbY0EZpt9Nlf2spRCIfphGjYmijAPBgNVHRMB
+Af8EBTADAQH/MAoGCCqGSM49BAMCA0kAMEYCIQC7MFmBMdan3DIsgzLDDwTOLkOI
++Vj2qMdBL4XRWt9c6gIhAMAbZ8M3kMTxPuI+bjZ31Zuu+bGg0Quo4EgU8yMmhJLt
+-----END CERTIFICATE-----]],
+
+  key_alt_alt_ecdsa = [[-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEILefTUI90Vsu3JV1WZVrYgl82HbAICC/9/sMIL6j1RThoAoGCCqGSM49
+AwEHoUQDQgAEqeYE7L+h2b2tQ1VPPa8zMa1dWeh2eBYVjvB/Zb31otwMvPfZY2DX
+Shh0YpYy48K07q/BYaA6L7+ZhJOgRTtTSg==
+-----END EC PRIVATE KEY-----]],
+
+  --[[
+  Issuer: C = US, ST = California, O = Kong Testing, CN = Kong Testing Root CA
+  Validity
+      Not Before: May  2 19:34:42 2019 GMT
+      Not After : Apr 27 19:34:42 2039 GMT
+  Subject: C = US, ST = California, O = Kong Testing, CN = Kong Testing Root CA
+  X509v3 Basic Constraints: critical
+      CA:TRUE
+  X509v3 Key Usage: critical
+      Digital Signature, Certificate Sign, CRL Sign
+  --]]
   cert_ca = [[-----BEGIN CERTIFICATE-----
 MIIFoTCCA4mgAwIBAgIUQDBLwIychoRbVRO44IzBBk9R4oYwDQYJKoZIhvcNAQEL
 BQAwWDELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFTATBgNVBAoM


### PR DESCRIPTION
### Summary

The PR #6509 added support for static configuration to be able to set multiple certificates and keys with:

- `ssl_cert` and `ssl_cert_key`
- `admin_ssl_cert` and `admin_ssl_cert_key`
- `status_ssl_cert` and `status_ssl_cert_key`

But it didn't yet allow `certificates entity` to contain multiple certificates. This PR changes `certificates entity` to contain two new fields:

- `cert_alt`
- `key_alt`

Where you can configure alternative certificate and the matching key, this way you can use `cert` and `key` to store ECDSA certificate and `cert_alt` and `cert_key` to store RSA certificate.