### PR TITLE
fix(cli) more atomic reload with dbless

### DIFF
--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -818,7 +818,7 @@ do
       return nil, err
     end
 
-    ok, err = kong.core_cache:save_curr_page()
+    ok, err = kong.cache:save_curr_page()
     if not ok then
       return nil, "failed to persist cache page number inside shdict: " .. err
     end


### PR DESCRIPTION
### Summary

On #6464 it was reported that on reload we might affect old workers that
are still processing requests, that were started before reload happened.

This PR tries to make it more atomic by always clearing the shadow caches
only, and loading the config to shadow cache and then flipping the cache.
Previously it was always clearing the current page and loading new config
there, which as the #6464 describes, makes old workers in empty state.

### Issues Resolved

Fix #6464