### PR TITLE
feat(async) new kong.async library and changes to utilise it

### DIFF
--- a/kong-2.7.0-0.rockspec
+++ b/kong-2.7.0-0.rockspec
@@ -47,6 +47,7 @@ build = {
   modules = {
     ["kong"] = "kong/init.lua",
     ["kong.meta"] = "kong/meta.lua",
+    ["kong.async"] = "kong/async.lua",
     ["kong.cache"] = "kong/cache/init.lua",
     ["kong.cache.warmup"] = "kong/cache/warmup.lua",
     ["kong.cache.marshall"] = "kong/cache/marshall.lua",

--- a/kong/api/routes/config.lua
+++ b/kong/api/routes/config.lua
@@ -4,7 +4,6 @@ local errors = require("kong.db.errors")
 
 
 local kong = kong
-local ngx = ngx
 local dc = declarative.new_config(kong.configuration)
 local table = table
 local tostring = tostring
@@ -131,7 +130,10 @@ return {
 
       _reports.decl_fmt_version = meta._format_version
 
-      ngx.timer.at(0, reports_timer)
+      local ok, err = kong.async:run(reports_timer)
+      if not ok then
+        kong.log.err("reports timer error: ", err)
+      end
 
       declarative.sanitize_output(entities)
       return kong.response.exit(201, entities)

--- a/kong/api/routes/kong.lua
+++ b/kong/api/routes/kong.lua
@@ -100,6 +100,11 @@ return {
           running = ngx.timer.running_count(),
           pending = ngx.timer.pending_count()
         },
+        async = kong.async:stats({
+          all    = true,
+          minute = true,
+          hour   = true,
+        }),
         plugins = {
           available_on_server = singletons.configuration.loaded_plugins,
           enabled_in_cluster = distinct_plugins

--- a/kong/api/routes/plugins.lua
+++ b/kong/api/routes/plugins.lua
@@ -44,7 +44,10 @@ end
 
 
 local function post_process(data)
-  ngx.timer.at(0, reports_timer, data)
+  local ok, err = kong.async:run(reports_timer, data)
+  if not ok then
+    kong.log.err("reports timer error: ", err)
+  end
   return data
 end
 

--- a/kong/async.lua
+++ b/kong/async.lua
@@ -227,16 +227,16 @@ end
 
 local function create_job(func, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, ...)
   local argc = select("#", ...)
-  local args = argc > 0 and { ... }
-
-  if not args then
+  if argc == 0 then
     return function()
       return pcall(func, ngx.worker.exiting(), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)
     end
   end
 
+  local args = { ... }
   return function()
-    local pok, res, err = pcall(func, ngx.worker.exiting(), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, unpack(args, 1, argc))
+    local pok, res, err = pcall(func, ngx.worker.exiting(), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10,
+                                unpack(args, 1, argc))
     if not pok then
       return nil, res
     end

--- a/kong/async.lua
+++ b/kong/async.lua
@@ -434,6 +434,12 @@ function async:start()
     return nil, "nginx worker is exiting"
   end
 
+  if self.started then
+    return nil, "already started"
+  end
+
+  self.started = ngx.now()
+
   local ok, err = ngx.timer.at(0, job_timer, self)
   if not ok then
     return nil, err

--- a/kong/async.lua
+++ b/kong/async.lua
@@ -1,0 +1,161 @@
+local semaphore = require "ngx.semaphore"
+
+
+local ngx = ngx
+local kong = kong
+local pcall = pcall
+local select = select
+local unpack = unpack
+local setmetatable = setmetatable
+
+
+local QUEUE_SIZE = 100000
+
+
+local function get_pending(self)
+  local head = self.head
+  local tail = self.tail
+  if head < tail then
+    head = head + QUEUE_SIZE
+  end
+  return head - tail
+end
+
+
+local function job_thread(self, index)
+  while not ngx.worker.exiting() do
+    local ok, err = self.work:wait(1)
+    if ok then
+      if self.head ~= self.tail then
+        local tail = self.tail == QUEUE_SIZE and 1 or self.tail + 1
+        local job = self.jobs[tail]
+        self.tail = tail
+        self.jobs[tail] = nil
+        ok, err = job()
+        if not ok then
+          kong.log.err("async thread #", index, " job error: ", err)
+        end
+      end
+
+    elseif err ~= "timeout" then
+      kong.log.err("async thread #", index, " wait error: ", err)
+    end
+  end
+
+  return true
+end
+
+
+local function job_timer(premature, self)
+  if premature then
+    return true
+  end
+
+  local t = kong.table.new(100, 0)
+
+  for i = 1, 100 do
+    t[i] = ngx.thread.spawn(job_thread, self, i)
+  end
+
+  local ok, err = ngx.thread.wait(t[1],  t[2],  t[3],  t[4],  t[5],  t[6],  t[7],  t[8],  t[9],  t[10],
+                                  t[11], t[12], t[13], t[14], t[15], t[16], t[17], t[18], t[19], t[20],
+                                  t[21], t[22], t[23], t[24], t[25], t[26], t[27], t[28], t[29], t[30],
+                                  t[31], t[32], t[33], t[34], t[35], t[36], t[37], t[38], t[39], t[40],
+                                  t[41], t[42], t[43], t[44], t[45], t[46], t[47], t[48], t[49], t[50],
+                                  t[51], t[52], t[53], t[54], t[55], t[56], t[57], t[58], t[59], t[60],
+                                  t[61], t[62], t[63], t[64], t[65], t[66], t[67], t[68], t[69], t[70],
+                                  t[71], t[72], t[73], t[74], t[75], t[76], t[77], t[78], t[79], t[80],
+                                  t[81], t[82], t[83], t[84], t[85], t[86], t[87], t[88], t[89], t[90],
+                                  t[91], t[92], t[93], t[94], t[95], t[96], t[97], t[98], t[99], t[100])
+
+  if not ok then
+    kong.log.err("async thread error: ", err)
+  end
+
+  for i = 100, 1, -1 do
+    ngx.thread.kill(t[i])
+  end
+
+  return job_timer(ngx.worker.exiting(), self)
+end
+
+
+local function create_job(func, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, ...)
+  local argc = select("#", ...)
+  local args = argc > 0 and { ... }
+
+  if not args then
+    return function()
+      return pcall(func, ngx.worker.exiting(), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)
+    end
+  end
+
+  return function()
+    local pok, res, err = pcall(func, ngx.worker.exiting(), a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, unpack(args, 1, argc))
+    if not pok then
+      return nil, res
+    end
+
+    if not err then
+      return true
+    end
+
+    return nil, err
+  end
+end
+
+
+local async = {}
+async.__index = async
+
+
+---
+-- Creates a new instance of `kong.async`
+--
+-- @treturn table an instance of `kong.async`
+function async.new()
+  return setmetatable({
+    jobs = kong.table.new(QUEUE_SIZE, 0),
+    work = semaphore.new(),
+    head = 0,
+    tail = 0,
+  }, async)
+end
+
+
+---
+-- Start `kong.async` timers
+--
+-- @treturn boolean|nil `true` on success, `nil` on error
+-- @treturn string|nil  `nil` on success, error message `string` on error
+function async:start()
+  local ok, err = ngx.timer.at(0, job_timer, self)
+  if not ok then
+    return nil, err
+  end
+
+  return true
+end
+
+
+---
+-- Run a function asynchronously
+--
+-- @tparam  function   a function to run asynchronously
+-- @tparam  ...[opt]   function arguments
+-- @treturn true|nil   `true` on success, `nil` on error
+-- @treturn string|nil `nil` on success, error message `string` on error
+function async:run(func, ...)
+  if get_pending(self) == QUEUE_SIZE then
+    return nil, "async queue is full"
+  end
+
+  self.head = self.head == QUEUE_SIZE and 1 or self.head + 1
+  self.jobs[self.head] = create_job(func, ...)
+  self.work:post()
+
+  return true
+end
+
+
+return async

--- a/kong/async.lua
+++ b/kong/async.lua
@@ -550,9 +550,11 @@ function async:start()
     return nil, err
   end
 
-  ok, err = timer_every(self.opts.log_interval, log_timer, self)
-  if not ok then
-    return nil, err
+  if self.opts.log_interval > 0 then
+    ok, err = timer_every(self.opts.log_interval, log_timer, self)
+    if not ok then
+      return nil, err
+    end
   end
 
   return true

--- a/kong/cache/warmup.lua
+++ b/kong/cache/warmup.lua
@@ -137,7 +137,10 @@ function cache_warmup.single_dao(dao)
   end
 
   if entity_name == "services" and host_count > 0 then
-    ngx.timer.at(0, warmup_dns, hosts_array, host_count)
+    local ok, err = kong.async:run(warmup_dns, hosts_array, host_count)
+    if not ok then
+      ngx.log(ngx.NOTICE, "dns warmup failed: ", err)
+    end
   end
 
   local elapsed = floor((now() - start) * 1000)

--- a/kong/db/dao/plugins/go.lua
+++ b/kong/db/dao/plugins/go.lua
@@ -512,7 +512,7 @@ local get_plugin do
             ctx_shared = kong.ctx.shared,
           }
 
-          ngx_timer_at(0, function()
+          local ok, err = kong.async:run(function()
             local co = coroutine.running()
             save_for_later[co] = saved
 
@@ -525,6 +525,9 @@ local get_plugin do
 
             save_for_later[co] = nil
           end)
+          if not ok then
+            kong.log.err("failed to execute log phase on go plugin: ", err)
+          end
         end
 
       else

--- a/kong/db/strategies/cassandra/connector.lua
+++ b/kong/db/strategies/cassandra/connector.lua
@@ -272,7 +272,7 @@ end
 
 function CassandraConnector:init_worker()
   if self.refresh_frequency > 0 then
-    local hdl, err = ngx.timer.every(self.refresh_frequency, function()
+    local ok, err = kong.async:every(self.refresh_frequency, function()
       local ok, err, topology = self.cluster:refresh(self.refresh_frequency)
       if not ok then
         ngx.log(ngx.ERR, "[cassandra] failed to refresh cluster topology: ",
@@ -290,7 +290,7 @@ function CassandraConnector:init_worker()
         end
       end
     end)
-    if not hdl then
+    if not ok then
       return nil, "failed to initialize Cassandra topology refresh timer: " ..
                   err
     end

--- a/kong/db/strategies/postgres/connector.lua
+++ b/kong/db/strategies/postgres/connector.lua
@@ -19,7 +19,6 @@ local error        = error
 local floor        = math.floor
 local type         = type
 local ngx          = ngx
-local timer_every  = ngx.timer.every
 local update_time  = ngx.update_time
 local get_phase    = ngx.get_phase
 local null         = ngx.null
@@ -324,7 +323,7 @@ function _mt:init_worker(strategies)
 
     local cleanup_statement = concat(cleanup_statements, "\n")
 
-    return timer_every(60, function(premature)
+    return kong.async:every("minute", function(premature)
       if premature then
         return
       end

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -72,6 +72,7 @@ local DB = require "kong.db"
 local dns = require "kong.tools.dns"
 local meta = require "kong.meta"
 local lapis = require "lapis"
+local async = require "kong.async"
 local runloop = require "kong.runloop.handler"
 local stream_api = require "kong.tools.stream_api"
 local singletons = require "kong.singletons"
@@ -584,10 +585,18 @@ function Kong.init_worker()
   math.randomseed()
 
 
+  kong.async = async.new()
+  local ok, err = kong.async:start()
+  if not ok then
+    stash_init_worker_error("failed to instantiate 'kong.async' module: " .. err)
+    return
+  end
+
+
   -- init DB
 
 
-  local ok, err = kong.db:init_worker()
+  ok, err = kong.db:init_worker()
   if not ok then
     stash_init_worker_error("failed to instantiate 'kong.db' module: " .. err)
     return

--- a/kong/plugins/acme/handler.lua
+++ b/kong/plugins/acme/handler.lua
@@ -55,7 +55,7 @@ ACMEHandler.build_domain_matcher = build_domain_matcher
 function ACMEHandler:init_worker()
   local worker_id = ngx.worker.id()
   kong.log.info("acme renew timer started on worker ", worker_id)
-  ngx.timer.every(86400, client.renew_certificate)
+  kong.async:every(86400, client.renew_certificate)
 end
 
 function ACMEHandler:certificate(conf)
@@ -112,7 +112,7 @@ function ACMEHandler:certificate(conf)
       return
     end
 
-    ngx.timer.at(0, function()
+    kong.async:run(function()
       local ok, err = client.update_certificate(conf, host, nil)
       if err then
         kong.log.err("failed to update certificate: ", err)

--- a/kong/plugins/datadog/handler.lua
+++ b/kong/plugins/datadog/handler.lua
@@ -3,7 +3,6 @@ local statsd_logger = require "kong.plugins.datadog.statsd_logger"
 
 local kong     = kong
 local ngx      = ngx
-local timer_at = ngx.timer.at
 local insert   = table.insert
 local gsub     = string.gsub
 local pairs    = pairs
@@ -105,7 +104,7 @@ function DatadogHandler:log(conf)
   end
 
   local message = kong.log.serialize()
-  local ok, err = timer_at(0, log, conf, message)
+  local ok, err = kong.async:run(log, conf, message)
   if not ok then
     kong.log.err("failed to create timer: ", err)
   end

--- a/kong/plugins/loggly/handler.lua
+++ b/kong/plugins/loggly/handler.lua
@@ -6,7 +6,6 @@ local kong = kong
 local ngx = ngx
 local date = os.date
 local tostring = tostring
-local timer_at = ngx.timer.at
 local udp = ngx.socket.udp
 local concat = table.concat
 local insert = table.insert
@@ -139,7 +138,7 @@ function LogglyLogHandler:log(conf)
 
   local message = kong.log.serialize()
 
-  local ok, err = timer_at(0, log, conf, message)
+  local ok, err = kong.async:run(log, conf, message)
   if not ok then
     kong.log.err("failed to create timer: ", err)
   end

--- a/kong/plugins/rate-limiting/handler.lua
+++ b/kong/plugins/rate-limiting/handler.lua
@@ -11,7 +11,6 @@ local floor = math.floor
 local pairs = pairs
 local error = error
 local tostring = tostring
-local timer_at = ngx.timer.at
 
 
 local EMPTY = {}
@@ -197,7 +196,7 @@ function RateLimitingHandler:access(conf)
     end
   end
 
-  local ok, err = timer_at(0, increment, conf, limits, identifier, current_timestamp, 1)
+  local ok, err = kong.async:run(increment, conf, limits, identifier, current_timestamp, 1)
   if not ok then
     kong.log.err("failed to create timer: ", err)
   end

--- a/kong/plugins/response-ratelimiting/log.lua
+++ b/kong/plugins/response-ratelimiting/log.lua
@@ -1,4 +1,7 @@
 local policies = require "kong.plugins.response-ratelimiting.policies"
+
+
+local kong = kong
 local pairs = pairs
 
 
@@ -20,7 +23,7 @@ end
 
 
 function _M.execute(conf, identifier, current_timestamp, increments, usage)
-  local ok, err = ngx.timer.at(0, log, conf, identifier, current_timestamp, increments, usage)
+  local ok, err = kong.async:run(log, conf, identifier, current_timestamp, increments, usage)
   if not ok then
     kong.log.err("failed to create timer: ", err)
   end

--- a/kong/plugins/statsd/handler.lua
+++ b/kong/plugins/statsd/handler.lua
@@ -3,7 +3,6 @@ local statsd_logger = require "kong.plugins.statsd.statsd_logger"
 
 local kong     = kong
 local ngx      = ngx
-local timer_at = ngx.timer.at
 local pairs    = pairs
 local gsub     = string.gsub
 local fmt      = string.format
@@ -139,7 +138,7 @@ function StatsdHandler:log(conf)
 
   local message = kong.log.serialize()
 
-  local ok, err = timer_at(0, log, conf, message)
+  local ok, err = kong.async:run(log, conf, message)
   if not ok then
     kong.log.err("failed to create timer: ", err)
   end

--- a/kong/plugins/syslog/handler.lua
+++ b/kong/plugins/syslog/handler.lua
@@ -5,7 +5,6 @@ local sandbox = require "kong.tools.sandbox".sandbox
 
 local kong = kong
 local ngx = ngx
-local timer_at = ngx.timer.at
 
 
 local SENDER_NAME = "kong"
@@ -102,7 +101,7 @@ function SysLogHandler:log(conf)
   end
 
   local message = kong.log.serialize()
-  local ok, err = timer_at(0, log, conf, message)
+  local ok, err = kong.async:run(log, conf, message)
   if not ok then
     kong.log.err("failed to create timer: ", err)
   end

--- a/kong/plugins/tcp-log/handler.lua
+++ b/kong/plugins/tcp-log/handler.lua
@@ -4,7 +4,6 @@ local sandbox = require "kong.tools.sandbox".sandbox
 
 local kong = kong
 local ngx = ngx
-local timer_at = ngx.timer.at
 
 
 local sandbox_opts = { env = { kong = kong, ngx = ngx } }
@@ -65,7 +64,7 @@ function TcpLogHandler:log(conf)
   end
 
   local message = kong.log.serialize()
-  local ok, err = timer_at(0, log, conf, message)
+  local ok, err = kong.async:run(log, conf, message)
   if not ok then
     kong.log.err("failed to create timer: ", err)
   end

--- a/kong/plugins/udp-log/handler.lua
+++ b/kong/plugins/udp-log/handler.lua
@@ -4,7 +4,6 @@ local sandbox = require "kong.tools.sandbox".sandbox
 
 local kong = kong
 local ngx = ngx
-local timer_at = ngx.timer.at
 local udp = ngx.socket.udp
 
 
@@ -54,7 +53,7 @@ function UdpLogHandler:log(conf)
     end
   end
 
-  local ok, err = timer_at(0, log, conf, cjson.encode(kong.log.serialize()))
+  local ok, err = kong.async:run(log, conf, cjson.encode(kong.log.serialize()))
   if not ok then
     kong.log.err("could not create timer: ", err)
   end

--- a/kong/reports.lua
+++ b/kong/reports.lua
@@ -9,7 +9,6 @@ local knode = (kong and kong.node) and kong.node or
 local kong_dict = ngx.shared.kong
 local ngx = ngx
 local tcp_sock = ngx.socket.tcp
-local timer_at = ngx.timer.at
 local ngx_log = ngx.log
 local var = ngx.var
 local subsystem = ngx.config.subsystem
@@ -179,7 +178,7 @@ end
 
 
 local function create_timer(...)
-  local ok, err = timer_at(...)
+  local ok, err = kong.async:every(...)
   if not ok then
     log(WARN, "could not create ping timer: ", err)
   end
@@ -335,10 +334,6 @@ local function ping_handler(premature)
   if premature then
     return
   end
-
-  -- all workers need to register a recurring timer, in case one of them
-  -- crashes. Hence, this must be called before the `get_lock()` call.
-  create_timer(PING_INTERVAL, ping_handler)
 
   if not get_lock(PING_KEY, PING_INTERVAL) then
     return

--- a/spec/01-unit/01-db/08-cache_warmup_spec.lua
+++ b/spec/01-unit/01-db/08-cache_warmup_spec.lua
@@ -200,6 +200,11 @@ describe("cache_warmup", function()
         my_entity = mock_entity(db_data, "my_entity", "aaa"),
         services = mock_entity(db_data, "services", "name"),
       },
+      async = {
+        run = function(_, func, ...)
+          return func(false, ...)
+        end
+      },
       core_cache = mock_cache(cache_table),
       cache = mock_cache({}),
       dns = {

--- a/spec/01-unit/01-db/08-cache_warmup_spec.lua
+++ b/spec/01-unit/01-db/08-cache_warmup_spec.lua
@@ -1,6 +1,13 @@
 local cache_warmup = require("kong.cache.warmup")
 
 
+local async = {
+  run = function(_, func, ...)
+    return func(false, ...)
+  end
+}
+
+
 local function mock_entity(db_data, entity_name, cache_key)
   return {
     schema = {
@@ -94,6 +101,7 @@ describe("cache_warmup", function()
       },
       core_cache = mock_cache(cache_table),
       cache = mock_cache({}),
+      async = async,
     }
 
     cache_warmup._mock_kong(kong)
@@ -128,6 +136,7 @@ describe("cache_warmup", function()
       core_cache = mock_cache(cache_table),
       cache = mock_cache({}),
       log = mock_log(nil, logged_notices),
+      async = async,
     }
 
     cache_warmup._mock_kong(kong)
@@ -165,6 +174,7 @@ describe("cache_warmup", function()
       core_cache = mock_cache(cache_table),
       cache = mock_cache({}),
       log = mock_log(nil, logged_notices),
+      async = async,
     }
 
     cache_warmup._mock_kong(kong)
@@ -200,11 +210,7 @@ describe("cache_warmup", function()
         my_entity = mock_entity(db_data, "my_entity", "aaa"),
         services = mock_entity(db_data, "services", "name"),
       },
-      async = {
-        run = function(_, func, ...)
-          return func(false, ...)
-        end
-      },
+      async = async,
       core_cache = mock_cache(cache_table),
       cache = mock_cache({}),
       dns = {
@@ -264,7 +270,8 @@ describe("cache_warmup", function()
         toip = function(query)
           table.insert(dns_queries, query)
         end,
-      }
+      },
+      async = async,
     }
 
     cache_warmup._mock_kong(kong)
@@ -295,6 +302,7 @@ describe("cache_warmup", function()
       core_cache = {},
       cache = {},
       log = mock_log(logged_warnings),
+      async = async,
     }
 
     cache_warmup._mock_kong(kong)
@@ -330,6 +338,7 @@ describe("cache_warmup", function()
       configuration = {
         mem_cache_size = 12345,
       },
+      async = async,
     }
 
     cache_warmup._mock_kong(kong)

--- a/spec/01-unit/16-runloop_handler_spec.lua
+++ b/spec/01-unit/16-runloop_handler_spec.lua
@@ -27,6 +27,10 @@ local function setup_it_block()
         err = function() end,
         warn = function() end,
       },
+      async = {
+        run = function(...) end,
+        every = function(...) end,
+      },
       response = {
         exit = function() end,
       },

--- a/spec/fixtures/custom_plugins/kong/plugins/slow-query/api.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/slow-query/api.lua
@@ -2,12 +2,19 @@ return {
   ["/slow-resource"] = {
     GET = function(self)
       if self.params.prime then
-        ngx.timer.at(0, function()
+        local ok, err = kong.async:run(function(premature)
+          if premature then
+            return true
+          end
           local _, err = kong.db.connector:query("SELECT pg_sleep(1)")
           if err then
-            ngx.log(ngx.ERR, err)
+            kong.log.err(err)
           end
         end)
+
+        if not ok then
+          kong.log.err(err)
+        end
 
         return kong.response.exit(204)
       end


### PR DESCRIPTION
### Summary

This PR comes with several commits:

#### fix(tests) fix a flaky test of kong quit

This has been a small problem on our test suite, that seems to trigger more often today. This just changes the somewhat flaky test to be bit more relaxed on small amount of time variance.

#### feat(async) implement kong.async:run function

Kong async library was written to replace `ngx.timer.*` apis with a lighter constructs based on `ngx.threads`.

This initial commit adds following methods:
- `local async = kong.async.new()` (used to prepare an instance of `kong.async` and prepare some of the data structures)
- `ok, err = kong.async:init_worker` (used to start the timers that this library needs)
- `kong.async:run(func, ...)` (used to run a function asynchronously from the thread that calls it)

#### feat(async) implement kong.async:every function

The difference between `kong.async:every` and `ngx.timer.every` is that `kong.async:every` collects recurring functions in buckets (by delay) and then executes them with `kong.async:run` on each interval.

So, if you have 2 functions that run on every minute, we will only create a single timer instead of two that you would need with `ngx.timer.every`. We still run them in parallel (co-operatively), thanks to `kong.async:run`
that this uses behind the scenes.

#### feat(async) add periodic logging to kong.async library

This commit will make `kong.async` library to log state of the async calls to Nginx error log with varyint log levels related to pending queue size.

#### refactor(async) add a local reusable job queuing function

Just consolidates similar code from two places in `kong.async` library to a function.

#### feat(async) collect the metrics with kong.async library 

Collects some metrics with `kong.async` library:
1. time when job was queued
2. time when job was started
3. time when job was finished

With this we can calculate:
1. latency
2. execution time
3. and queue to finish time

#### feat(async) implement kong.async:data function

The data function return raw data metric collected by `kong.async` library. Each item in the returned data
array contains a array with three values:

1. job queue time
2. job start time
3. job end time

#### feat(async) implement kong.async:stats function

Return stats from the library, for example:

```lua
{
  done = 5,
  pending = 4,
  running = 3,
  errored = 0,
  refused = 0,
  latency = {
    all = {
      size   = 20,
      mean   = 1,
      median = 2,
      p95    = 12,
      p99    = 20,
      p999   = 150,
      max    = 200,
      min    = 0,
    },
    hour = {
      size   = 10,
      mean   = 1,
      median = 2,
      p95    = 12,
      p99    = 20,
      p999   = 150,
      max    = 200,
      min    = 0,
    },
    minute = {
      size   = 1,
      mean   = 1,
      median = 2,
      p95    = 12,
      p99    = 20,
      p999   = 150,
      max    = 200,
      min    = 0,
    },
  },
  runtime = {
    all = {
      size   = 20,
      mean   = 1,
      median = 2,
      p95    = 12,
      p99    = 20,
      p999   = 150,
      max    = 200,
      min    = 0,
    },
    hour = {
      size   = 10,
      mean   = 1,
      median = 2,
      p95    = 12,
      p99    = 20,
      p999   = 150,
      max    = 200,
      min    = 0,
    },
    minute = {
      size   = 1,
      mean   = 1,
      median = 2,
      p95    = 12,
      p99    = 20,
      p999   = 150,
      max    = 200,
      min    = 0,
    },
  }
}
```

#### feat(core) initialize kong.async library on init worker

Initialized `kong.async` library on `init worker` phase.

#### feat(api) export kong.async library statistics on admin api 

Exports `kong.async` library statistics on Kong admin api.

#### chore(plugins) use kong.async:run instead of ngx.timer.at

Many of our plugins that execute post-content phase (such as `logging plugins`) also need cosockets, and to exit the limitation of the post-content phases they also tend to execute `ngx.timer.at`. This can in high traffic server exhaust the timer resources, and start to error.

The `kong.async:run(func, ...)` was written to replace the `ngx.timer.at(0, func, ...)`, and this commit does so to the plugins.

#### chore(db) use kong.async:run to warmup dns cache instead of ngx.timer.at

Replaces `ngx.timer.at` with `kong.async:run` on DNS cache warmup.

#### chore(balancer) use kong.async:every with balancer 

Replaces `ngx.timer.at` calls with `kong.async:every` on balancer.

#### chore(reports) use kong.async:every with reports

Changes `kong.reports` to use `kong.async:every` instead of recursive calls to `ngx.timer.at`.

#### chore(api) reports timers to use kong.async:run instead of ngx.timer.at

Replaces `ngx.timer.at` calls with `kong.async:at` on api where reports timer was called.

#### chore(handler) use kong.async instead of ngx.timer.*

This updates `kong.runloop.handler` to use `kong.async` instead of `ngx.timer` api.

#### chore(db) pg/c* connector to use kong.async:every instead of ngx.timer.every

This updates Postgres and Cassandra connector to use `kong.async:every` instead of using `ngx.timer.every`.

#### chore(go) run go plugins log phase with kong.run:async instead of ngx.timer.at

Uses `kong.run:async` to run Go plugins' log phase instead of spawning new timer for each with `ngx.timer.at(0, ...)`.

#### feat(async) implement kong.async:after function

This commit implements the last missing function `kong.async:after`. This function runs with 100 ms interval (with `ngx.timer.every`), though it can be adjusted by changing module level constant. The timer is implement
roughly by following: https://arxiv.org/pdf/1906.10860.pdf.

With this function you can queue a job to be executed after x seconds, but you can use millisecond granularity e.g. with `0.001`. Because there is `100ms` interval (preconfigured), it means that it will add 0 - 100 ms latency to function call.

Internally this function also executes the functions using `kong.async:run` that could add small amount of latency as well.

#### chore(tests) make slow-query test plugin to use kong.async:run

Just changes custom test plugin `slow-query` to use `kong.async:run` instead of `ngx.timer.at`.