### PR TITLE
minimal inter-modules RPC 

### DIFF
--- a/kong-2.2.0-0.rockspec
+++ b/kong-2.2.0-0.rockspec
@@ -129,6 +129,7 @@ build = {
     ["kong.tools.dns"] = "kong/tools/dns.lua",
     ["kong.tools.utils"] = "kong/tools/utils.lua",
     ["kong.tools.timestamp"] = "kong/tools/timestamp.lua",
+    ["kong.tools.stream_api"] = "kong/tools/stream_api.lua",
     ["kong.tools.batch_queue"] = "kong/tools/batch_queue.lua",
 
     ["kong.runloop.handler"] = "kong/runloop/handler.lua",

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -467,6 +467,10 @@ function Kong.init()
   -- Load plugins as late as possible so that everything is set up
   assert(db.plugins:load_plugin_schemas(config.loaded_plugins))
 
+  if subsystem == "stream" then
+    stream_api.load_handlers()
+  end
+
   if kong.configuration.database == "off" then
 
     local err
@@ -1376,22 +1380,7 @@ function Kong.serve_cluster_listener(options)
 end
 
 
-local stream_plugins_api_loaded = false
 function Kong.stream_api()
-  if not stream_plugins_api_loaded then
-    local utils = require "kong.tools.utils"
-
-    for plugin_name in pairs(kong.configuration.loaded_plugins) do
-      local loaded, custom_endpoints = utils.load_module_if_exists("kong.plugins." .. plugin_name .. ".api")
-      if loaded and custom_endpoints._stream then
-        ngx.log(ngx.DEBUG, "Register stream api for plugin: ", plugin_name)
-        stream_api.register(plugin_name, custom_endpoints._stream)
-        custom_endpoints._stream = nil
-      end
-    end
-    stream_plugins_api_loaded = true
-  end
-
   stream_api.handle()
 end
 

--- a/kong/templates/nginx_kong_stream.lua
+++ b/kong/templates/nginx_kong_stream.lua
@@ -132,13 +132,14 @@ server {
     }
 }
 > end -- database == "off"
-> end -- #stream_listeners > 0
 
-server {
+server {        # ignore (and close }, to ignore content)
     listen unix:${{PREFIX}}/stream_rpc.sock udp;
     error_log  ${{ADMIN_ERROR_LOG}} ${{LOG_LEVEL}};
     content_by_lua_block {
         Kong.stream_api()
     }
 }
+
+> end -- #stream_listeners > 0
 ]]

--- a/kong/templates/nginx_kong_stream.lua
+++ b/kong/templates/nginx_kong_stream.lua
@@ -133,4 +133,12 @@ server {
 }
 > end -- database == "off"
 > end -- #stream_listeners > 0
+
+server {
+    listen unix:${{PREFIX}}/stream_rpc.sock udp;
+    error_log  ${{ADMIN_ERROR_LOG}} ${{LOG_LEVEL}};
+    content_by_lua_block {
+        Kong.stream_api()
+    }
+}
 ]]

--- a/kong/tools/stream_api.lua
+++ b/kong/tools/stream_api.lua
@@ -1,6 +1,7 @@
---- this module implements a rudimentary RPC interface between the `http` and `stream`
+--- NOTE: this module implements a experimental RPC interface between the `http` and `stream`
 -- subsystem plugins. It is intended for internal use only by Kong, and this interface
--- may changed or be removed in the future.
+-- may changed or be removed in the future Kong releases once a better mechanism
+-- for intra subsystem communication in OpenResty became available.
 
 require "lua_pack"
 

--- a/kong/tools/stream_api.lua
+++ b/kong/tools/stream_api.lua
@@ -1,7 +1,7 @@
 --- NOTE: this module implements a experimental RPC interface between the `http` and `stream`
 -- subsystem plugins. It is intended for internal use only by Kong, and this interface
 -- may changed or be removed in the future Kong releases once a better mechanism
--- for intra subsystem communication in OpenResty became available.
+-- for inter subsystem communication in OpenResty became available.
 
 require "lua_pack"
 

--- a/kong/tools/stream_api.lua
+++ b/kong/tools/stream_api.lua
@@ -33,6 +33,7 @@ function stream_api.request(key, data, socket_path)
     error("key and data must be strings")
     return
   end
+
   if #data > MAX_DATA_LEN then
     error("too much data")
   end

--- a/kong/tools/stream_api.lua
+++ b/kong/tools/stream_api.lua
@@ -1,0 +1,77 @@
+
+require "lua_pack"
+
+
+local kong       = kong
+local st_pack    = string.pack      -- luacheck: ignore string
+local st_unpack  = string.unpack    -- luacheck: ignore string
+local st_format  = string.format
+
+local PREFIX = ngx.config.prefix()
+
+local stream_api = {}
+
+local _handlers  = {}
+
+
+function stream_api.register(k, f)
+  _handlers[k] = f
+end
+
+function stream_api.request(key, data, socket_path)
+  local socket = assert(ngx.socket.udp())
+  assert(socket:setpeername(socket_path or "unix:" .. PREFIX .. "/stream_rpc.sock"))
+
+  local ok, err = socket:send(st_pack("=PP", key, data))
+  if not ok then
+    socket:close()
+    return ok, err
+  end
+
+  data, err = socket:receive()
+  if not data then
+    socket:close()
+    return data, err
+  end
+
+  local _, status, payload = st_unpack(data, "=SP")
+  if status == 0 then
+    socket:close()
+    return nil, payload
+  end
+
+  socket:close()
+  return payload
+end
+
+
+function stream_api.handle()
+
+  local socket = ngx.req.socket()
+  local data, err = socket:receive()
+  if not data then
+    kong.log.error(err)
+    return
+  end
+
+  local _, key, payload = st_unpack(data, "=PP")
+
+  local f = _handlers[key]
+  if not f then
+    socket:send(st_pack("=SP", 0, "no handler"))
+    return
+  end
+
+  local res
+  res, err = f(payload)
+  if not res then
+    kong.log.error(st_format("stream_api handler %q returned error: %q", key, err))
+    socket:send(st_pack("=SP", 0, tostring(err)))
+    return
+  end
+
+  socket:send(st_pack("=SP", 1, tostring(res)))
+end
+
+
+return stream_api

--- a/kong/tools/stream_api.lua
+++ b/kong/tools/stream_api.lua
@@ -6,6 +6,7 @@ local kong       = kong
 local st_pack    = string.pack      -- luacheck: ignore string
 local st_unpack  = string.unpack    -- luacheck: ignore string
 local st_format  = string.format
+local assert     = assert
 
 local MAX_DATA_LEN = 8000
 local PREFIX = ngx.config.prefix()
@@ -76,7 +77,7 @@ function stream_api.handle()
 
   local f = _handlers[key]
   if not f then
-    socket:send(st_pack("=SP", 1, "no handler"))
+    assert(socket:send(st_pack("=SP", 1, "no handler")))
     return
   end
 
@@ -84,7 +85,7 @@ function stream_api.handle()
   res, err = f(payload)
   if not res then
     kong.log.error(st_format("stream_api handler %q returned error: %q", key, err))
-    socket:send(st_pack("=SP", 2, tostring(err)))
+    assert(socket:send(st_pack("=SP", 2, tostring(err))))
     return
   end
 
@@ -98,7 +99,7 @@ function stream_api.handle()
       key, #res, MAX_DATA_LEN))
   end
 
-  socket:send(st_pack("=SP", 0, res))
+  assert(socket:send(st_pack("=SP", 0, res)))
 end
 
 

--- a/kong/tools/stream_api.lua
+++ b/kong/tools/stream_api.lua
@@ -1,3 +1,6 @@
+--- this module implements a rudimentary RPC interface between the `http` and `stream`
+-- subsystem plugins. It is intended for internal use only by Kong, and this interface
+-- may changed or be removed in the future.
 
 require "lua_pack"
 

--- a/spec/02-integration/05-proxy/01-proxy_spec.lua
+++ b/spec/02-integration/05-proxy/01-proxy_spec.lua
@@ -6,7 +6,7 @@ local http = require "resty.http"
 
 local function count_server_blocks(filename)
   local file = assert(utils.readfile(filename))
-  local _, count = file:gsub("[%\n%s]+server%s{","")
+  local _, count = file:gsub("[%\n%s]+server%s{%s*\n","")
   return count
 end
 

--- a/spec/02-integration/12-stream_api/01-stream_api_endpoint_spec.lua
+++ b/spec/02-integration/12-stream_api/01-stream_api_endpoint_spec.lua
@@ -1,0 +1,36 @@
+local helpers = require "spec.helpers"
+local stream_api = require "kong.tools.stream_api"
+
+describe("Stream module API endpoint", function()
+
+  local socket_path
+
+  lazy_setup(function()
+    helpers.get_db_utils(nil, {}) -- runs migrations
+    assert(helpers.start_kong {
+      stream_listen = "127.0.0.1:8008",
+      plugins = "stream-api-echo",
+    })
+
+    socket_path = "unix:" .. helpers.get_running_conf().prefix .. "/stream_rpc.sock"
+  end)
+
+  lazy_teardown(function()
+    helpers.stop_kong()
+  end)
+
+  describe("creates listener", function()
+    it("error response for unknown path", function()
+      local res, err = stream_api.request("not-this", "nope", socket_path)
+      assert.is.falsy(res)
+      assert.equal("no handler", err)
+    end)
+
+    it("calls an echo handler", function ()
+      local res, err = stream_api.request("stream-api-echo", "ping!", socket_path)
+      assert.equal("back: ping!", res)
+      assert.is_nil(err)
+    end)
+
+  end)
+end)

--- a/spec/fixtures/custom_plugins/kong/plugins/stream-api-echo/api.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/stream-api-echo/api.lua
@@ -1,0 +1,7 @@
+
+
+return {
+  _stream = function(data)
+    return "back: " .. data
+  end,
+}

--- a/spec/fixtures/custom_plugins/kong/plugins/stream-api-echo/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/stream-api-echo/handler.lua
@@ -1,0 +1,4 @@
+
+return {
+  PRIORITY = 1000,
+}

--- a/spec/fixtures/custom_plugins/kong/plugins/stream-api-echo/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/stream-api-echo/schema.lua
@@ -1,0 +1,4 @@
+
+return {
+  fields = {}
+}


### PR DESCRIPTION
### Summary

OpenResty http and stream modules keep Lua code in separate spaces; and for the time being, the shared dictionaries are shared only between the spaces of the same module.

This feature adds a simple RPC on top of a datagram-mode unix domain socket.  Just a call/result with a single string on each direction.

#### Register handler

From the `api.lua` module in a plugin directory, return a table with a `_stream` field.  For example:

```lua
return {
  _stream = function(data)
    return "back: " .. data
  end,
}
```

The handler will receive a single string in the `data` parameter, and should return a single string or `nil, err` on error.

#### Request:

Use `stream_api.request(<plugin name>, <data>)`  to call the handler registered by the named plugin.  On success, it will return the string returned by the handler.  On error it will return `nil, err`.



Replaces #6374 