### PR TITLE
feat(*) utf-8 names for Routes and Services

### DIFF
--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -12,7 +12,7 @@ return {
     { id             = typedefs.uuid, },
     { created_at     = typedefs.auto_timestamp_s },
     { updated_at     = typedefs.auto_timestamp_s },
-    { name           = typedefs.name },
+    { name           = typedefs.utf8_name },
     { protocols      = { type     = "set",
                          len_min  = 1,
                          required = true,

--- a/kong/db/schema/entities/services.lua
+++ b/kong/db/schema/entities/services.lua
@@ -28,7 +28,7 @@ return {
     { id                 = typedefs.uuid, },
     { created_at         = typedefs.auto_timestamp_s },
     { updated_at         = typedefs.auto_timestamp_s },
-    { name               = typedefs.name },
+    { name               = typedefs.utf8_name },
     { retries            = { type = "integer", default = 5, between = { 0, 32767 } }, },
     -- { tags             = { type = "array", array = { type = "string" } }, },
     { protocol           = typedefs.protocol { required = true, default = default_protocol } },

--- a/kong/db/schema/typedefs.lua
+++ b/kong/db/schema/typedefs.lua
@@ -98,6 +98,18 @@ local function validate_name(name)
 end
 
 
+local function validate_utf8_name(name)
+
+  local ok, index = utils.validate_utf8(name)
+
+  if not ok then
+    return nil, "invalid utf-8 character sequence detected at position " .. tostring(index)
+  end
+
+  return true
+end
+
+
 local function validate_sni(host)
   local res, err_or_port = utils.normalize_ip(host)
   if type(err_or_port) == "string" and err_or_port ~= "invalid port number" then
@@ -320,6 +332,13 @@ typedefs.name = Schema.define {
   type = "string",
   unique = true,
   custom_validator = validate_name
+}
+
+
+typedefs.utf8_name = Schema.define {
+  type = "string",
+  unique = true,
+  custom_validator = validate_utf8_name
 }
 
 

--- a/spec/01-unit/01-db/01-schema/05-services_spec.lua
+++ b/spec/01-unit/01-db/01-schema/05-services_spec.lua
@@ -439,24 +439,14 @@ describe("services", function()
     end)
 
     it("rejects invalid names", function()
-      local invalid_names = {
-        "examp:le",
-        "examp;le",
-        "examp/le",
-        "examp le",
+      -- see tests for utils.validate_utf8 for more invalid values
+      local service = {
+        name = string.char(105, 213, 205, 149),
       }
 
-      for i = 1, #invalid_names do
-        local service = {
-          name = invalid_names[i],
-        }
-
-        local ok, err = Services:validate(service)
-        assert.falsy(ok)
-        assert.equal(
-          "invalid value '" .. invalid_names[i] .. "': it must only contain alphanumeric and '., -, _, ~' characters",
-          err.name)
-      end
+      local ok, err = Services:validate(service)
+      assert.falsy(ok)
+      assert.matches("invalid utf%-8 character sequence detected", err.name)
     end)
 
     -- acceptance
@@ -470,6 +460,9 @@ describe("services", function()
         "3x4_mp_13",
         "~3x4~mp~13",
         "~3..x4~.M-p~1__3_",
+        "孔",
+        "Конг",
+        "🦍",
       }
 
       for i = 1, #valid_names do

--- a/spec/01-unit/01-db/01-schema/06-routes_spec.lua
+++ b/spec/01-unit/01-db/01-schema/06-routes_spec.lua
@@ -691,25 +691,14 @@ describe("routes schema", function()
     end)
 
     it("rejects invalid names", function()
-      local invalid_names = {
-        "examp:le",
-        "examp;le",
-        "examp/le",
-        "examp le",
+      -- see tests for utils.validate_utf8 for more invalid values
+      local route = {
+        name = string.char(105, 213, 205, 149),
+        protocols = {"http"}
       }
-
-      for i = 1, #invalid_names do
-        local route = {
-          name = invalid_names[i],
-          protocols = {"http"}
-        }
-
-        local ok, err = Routes:validate(route)
-        assert.falsy(ok)
-        assert.equal(
-          "invalid value '" .. invalid_names[i] .. "': it must only contain alphanumeric and '., -, _, ~' characters",
-          err.name)
-      end
+      local ok, err = Routes:validate(route)
+      assert.falsy(ok)
+      assert.matches("invalid utf%-8 character sequence detected", err.name)
     end)
 
     -- acceptance
@@ -723,6 +712,9 @@ describe("routes schema", function()
         "3x4_mp_13",
         "~3x4~mp~13",
         "~3..x4~.M-p~1__3_",
+        "孔",
+        "Конг",
+        "🦍",
       }
 
       for i = 1, #valid_names do

--- a/spec/01-unit/05-utils_spec.lua
+++ b/spec/01-unit/05-utils_spec.lua
@@ -194,6 +194,12 @@ describe("Utils", function()
       assert.True(utils.validate_utf8(123))
       assert.True(utils.validate_utf8(true))
       assert.False(utils.validate_utf8(string.char(105, 213, 205, 149)))
+      assert.False(utils.validate_utf8(string.char(128))) -- unexpected continuation byte
+      assert.False(utils.validate_utf8(string.char(192, 32))) -- 2-byte sequence 0xc0 followed by space
+      assert.False(utils.validate_utf8(string.char(192))) -- 2-byte sequence with last byte missing
+      assert.False(utils.validate_utf8(string.char(254))) -- impossible byte
+      assert.False(utils.validate_utf8(string.char(255))) -- impossible byte
+      assert.False(utils.validate_utf8(string.char(237, 160, 128))) -- Single UTF-16 surrogate
     end)
     describe("random_string()", function()
       it("should return a random string", function()

--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -469,7 +469,8 @@ describe("kong start/stop #" .. strategy, function()
           _format_version: "1.1"
           services:
           - name: "@gobo"
-            url: http://mockbin.org
+            protocol: foo
+            host: mockbin.org
           - name: my-service
             url: http://mockbin.org
             routes:
@@ -492,7 +493,7 @@ describe("kong start/stop #" .. strategy, function()
         assert.matches(helpers.unindent[[
           in 'services':
             - in entry 1 of 'services':
-              in 'name': invalid value '@gobo': it must only contain alphanumeric and '., -, _, ~' characters
+              in 'protocol': expected one of: grpc, grpcs, http, https, tcp, tls, udp
             - in entry 2 of 'services':
               in 'routes':
                 - in entry 1 of 'routes':

--- a/spec/02-integration/04-admin_api/09-routes_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/09-routes_routes_spec.lua
@@ -359,7 +359,7 @@ for _, strategy in helpers.each_strategy() do
                 body = {
                   methods   = { "GET" },
                   protocols = { "foo", "http" },
-                  service = { name = [[\o/]] },
+                  service = { protocol = "foo" },
                 },
                 headers = { ["Content-Type"] = content_type }
               })
@@ -369,11 +369,11 @@ for _, strategy in helpers.each_strategy() do
                 name    = "schema violation",
                 message = "2 schema violations " ..
                   "(protocols.1: expected one of: grpc, grpcs, http, https, tcp, tls, udp; " ..
-                  [[service.name: invalid value '\o/': it must only contain alphanumeric and '., -, _, ~' characters)]],
+                  "service.protocol: expected one of: grpc, grpcs, http, https, tcp, tls, udp)",
                 fields = {
                   protocols = { "expected one of: grpc, grpcs, http, https, tcp, tls, udp" },
                   service = {
-                    name = [[invalid value '\o/': it must only contain alphanumeric and '., -, _, ~' characters]]
+                    protocol = "expected one of: grpc, grpcs, http, https, tcp, tls, udp"
                   }
                 }
               }, cjson.decode(body))
@@ -616,6 +616,21 @@ for _, strategy in helpers.each_strategy() do
             local body = assert.res_status(200, res)
 
             local json = cjson.decode(body)
+            assert.same(route, json)
+          end)
+
+          it("retrieves by utf-8 name and percent-escaped utf-8 name", function()
+            local route = bp.routes:insert({ methods = {"GET"}, name = "円" }, { nulls = true })
+            local res  = client:get("/routes/" .. route.name)
+            local body = assert.res_status(200, res)
+
+            local json = cjson.decode(body)
+            assert.same(route, json)
+
+            res  = client:get("/routes/%E5%86%86")
+            body = assert.res_status(200, res)
+
+            json = cjson.decode(body)
             assert.same(route, json)
           end)
 

--- a/spec/02-integration/04-admin_api/10-services_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/10-services_routes_spec.lua
@@ -247,6 +247,21 @@ for _, strategy in helpers.each_strategy() do
             assert.same(service, json)
           end)
 
+          it("retrieves by utf-8 name and percent-escaped utf-8 name", function()
+            local service = bp.services:insert({ name = "円" }, { nulls = true })
+            local res  = client:get("/services/" .. service.name)
+            local body = assert.res_status(200, res)
+
+            local json = cjson.decode(body)
+            assert.same(service, json)
+
+            res  = client:get("/services/%E5%86%86")
+            body = assert.res_status(200, res)
+
+            json = cjson.decode(body)
+            assert.same(service, json)
+          end)
+
           it("returns 404 if not found", function()
             local res = client:get("/services/" .. utils.uuid())
             assert.res_status(404, res)


### PR DESCRIPTION
This PR adds utf-8 capabilities to the names of Routes and Services.

Some tests which assumed ASCII-only had to be modified.

Tests which check that utf-8 strings can be used in the Admin API have been added.
