### PR TITLE
(fix)make get_balancer() always find upstream_dict while changing an upstream with "eventual" worker_consistency

### DIFF
--- a/kong/cache.lua
+++ b/kong/cache.lua
@@ -256,6 +256,28 @@ function _M:get(key, opts, cb, ...)
   return v
 end
 
+function _M:set(key, opts, value)
+  if type(key) ~= "string" then
+    error("key must be a string", 2)
+  end 
+
+  local shadow = (opts or {}).shadow
+
+  local current_page = self.curr_mlcache or 1
+  local get_page
+  if shadow and #self.mlcaches == 2 then
+    get_page = current_page == 1 and 2 or 1
+  else
+    get_page = current_page
+  end 
+
+  local res, err = self.mlcaches[get_page]:set(key, opts, value) 
+  if err then
+    return nil, "failed to set from node cache: " .. err 
+  end 
+
+  return res 
+end
 
 function _M:get_bulk(bulk, opts)
   if type(bulk) ~= "table" then

--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -912,7 +912,7 @@ local function do_upstream_event(operation, upstream_id, upstream_name)
             return
         end  
 
-        local res, err = singletons.core_cache:set(upstream_cache_key, nil, upstream_db)
+        local _, err = singletons.core_cache:set(upstream_cache_key, nil, upstream_db)
         if err then 
             log(ERR, "failed to set core cache!", err) 
             return

--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -809,11 +809,9 @@ local function update_balancer_state(premature)
       -- load the upstreams before invalidating cache
       local updated_upstreams_dict = load_upstreams_dict_into_memory()
       if updated_upstreams_dict ~= nil then
-        singletons.core_cache:invalidate_local("balancer:upstreams")
-        local _, err = singletons.core_cache:get("balancer:upstreams",
-                      { neg_ttl = 10 }, function() return updated_upstreams_dict end)
+        local _, err = singletons.core_cache:set("balancer:upstreams", { neg_ttl = 10 }, updated_upstreams_dict)
         if err then
-          log(CRIT, "failed updating list of upstreams: ", err)
+            log(CRIT, "failed setting list of upstreams: ", err)
         else
           set_worker_state_updated()
         end
@@ -902,14 +900,28 @@ local function do_upstream_event(operation, upstream_id, upstream_name)
   elseif operation == "delete" or operation == "update" then
     local upstream_cache_key = "balancer:upstreams:" .. upstream_id
     local target_cache_key = "balancer:targets:"   .. upstream_id
+
+    local upstream_db, err
     if singletons.db.strategy ~= "off" then
       if kong.configuration.worker_consistency == "eventual" then
         set_worker_state_stale()
+
+        upstream_db, err = load_upstream_into_memory(upstream_id)
+        if err then 
+            log(ERR, "failed to query db by load_upstream_into_memory!", err) 
+            return
+        end  
+
+        local res, err = singletons.core_cache:set(upstream_cache_key, nil, upstream_db)
+        if err then 
+            log(ERR, "failed to set core cache!", err) 
+            return
+        end  
       else
         singletons.core_cache:invalidate_local("balancer:upstreams")
+        singletons.core_cache:invalidate_local(upstream_cache_key)
       end
 
-      singletons.core_cache:invalidate_local(upstream_cache_key)
       singletons.core_cache:invalidate_local(target_cache_key)
     end
 
@@ -924,9 +936,7 @@ local function do_upstream_event(operation, upstream_id, upstream_name)
     else
       local upstream
       if kong.configuration.worker_consistency == "eventual" then
-        -- force loading the upstream to the cache
-        upstream = singletons.core_cache:get(upstream_cache_key, nil,
-                                  load_upstream_into_memory, upstream_id)
+        upstream = upstream_db
       else
         upstream = get_upstream_by_id(upstream_id)
       end
@@ -1174,7 +1184,6 @@ end
 -- * if healthchecks are disabled, nil;
 -- * in case of errors, nil and an error message.
 local function get_upstream_health(upstream_id)
-
   local upstream = get_upstream_by_id(upstream_id)
   if not upstream then
     return nil, "upstream not found"


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Hi， clients requests return 500 while using admin API to change an upstream with "eventual" worker_consistency .although (#6104) fix this bug ，clients requests return 503 instead of return 500.But either 500 or 503 are not acceptable on protection environment.
The reason is singletons.core_cache:invalidate_local("balancer:upstreams") and singletons.core_cache:get("balancer:upstreams") are not atomic in do_upstream_event() and update_balancer_state(). When clients requests are coming between this two steps,kong throws stack traceback. As below:
1.2020/11/10 14:36:27 [error] 2625#0: *8424 lua entry thread aborted: runtime error: /usr/local/share/lua/5.1/kong/runloop/balancer.lua:672: attempt to index local 'upstreams_dict' (a nil value)
stack traceback:
coroutine 0:
/usr/local/share/lua/5.1/kong/runloop/balancer.lua: in function 'get_upstream_by_name'
/usr/local/share/lua/5.1/kong/runloop/balancer.lua:693: in function 'get_balancer'
/usr/local/share/lua/5.1/kong/runloop/balancer.lua:1090: in function 'execute'
/usr/local/share/lua/5.1/kong/runloop/handler.lua:891: in function 'balancer_execute'
/usr/local/share/lua/5.1/kong/runloop/handler.lua:1264: in function 'after'
/usr/local/share/lua/5.1/kong/init.lua:788: in function 'access'
access_by_lua(nginx-kong.conf:80):2: in main chunk, client: 127.0.0.1, server: kong, request: "GET / HTTP/1.1", host: "www.test500a.com"

2.2020/11/10 18:17:10 [error] 20512#0: *1783168 [lua] events.lua:194: do_handlerlist(): worker-events: event callback failed; source=balancer, event=upstreams, pid=20513 error='/usr/local/share/lua/5.1/kong/runloop/balancer.lua:519: attempt to index local 'upstream' (a nil value)
stack traceback:
/usr/local/share/lua/5.1/kong/runloop/balancer.lua:519: in function 'create_balancer'
/usr/local/share/lua/5.1/kong/runloop/balancer.lua:1050: in function 'do_upstream_event'
/usr/local/share/lua/5.1/kong/runloop/balancer.lua:1066: in function 'on_upstream_event'
/usr/local/share/lua/5.1/kong/runloop/handler.lua:406: in function </usr/local/share/lua/5.1/kong/runloop/handler.lua:401>
[C]: in function 'xpcall'
/usr/local/share/lua/5.1/resty/worker/events.lua:185: in function 'do_handlerlist'
/usr/local/share/lua/5.1/resty/worker/events.lua:219: in function 'do_event_json'
/usr/local/share/lua/5.1/resty/worker/events.lua:361: in function 'poll'
/usr/local/share/lua/5.1/resty/worker/events.lua:380: in function </usr/local/share/lua/5.1/resty/worker/events.lua:375>', data={"operation":"update","entity":{"created_at":1604923597,"hash_on":"none","id":"cee3bfb3-fcd8-4f87-aa7a-2086c361d025","algorithm":"round-robin","name":"test500a","hash_on_cookie_path":"/","healthchecks":{"threshold":0,"active":{"unhealthy":{"http_statuses":[429,404,500,501,502,503,504,505],"tcp_failures":0,"timeouts":0,"http_failures":0,"interval":0},"http_path":"/","timeout":1,"type":"http","healthy":{"successes":0,"interval":0,"http_statuses":[200,302]},"https_verify_certificate":true,"concurrency":10},"passive":{"unhealthy":{"http_failures":0,"http_statuses":[429,500,503],"tcp_failures":0,"timeouts":0},"healthy":{"http_statuses":[200,201,202,203,204,205,206,207,208,226,300,301,302,303,304,305,306,307,308],"successes":0},"type":"http"}},"hash_fallback":"none","slots":2800}}, context: ngx.timer

### Full changelog
we defined "singletons.core_cache:set()" interface in cache.lua . And used it instead of singletons.core_cache:invalidate_local("balancer:upstreams") and singletons.core_cache:get("balancer:upstreams") .

### Issues resolved
#6561


