### PR TITLE
chore(*) prevent lua_pack from leaking to globals

### DIFF
--- a/kong/plugins/ldap-auth/asn1.lua
+++ b/kong/plugins/ldap-auth/asn1.lua
@@ -1,14 +1,13 @@
 local bpack, bunpack
 do
-  local string_pack = string.pack
-  local string_unpack = string.unpack
+  local string_pack = string.pack     -- luacheck: ignore
+  local string_unpack = string.unpack -- luacheck: ignore
+  package.loaded.lua_pack = nil
   require "lua_pack"
-  bpack = string.pack
-  bunpack = string.unpack
-  -- luacheck: globals string.unpack
-  string.unpack = string_unpack
-  -- luacheck: globals string.pack
-  string.pack = string_pack
+  bpack = string.pack                 -- luacheck: ignore
+  bunpack = string.unpack             -- luacheck: ignore
+  string.unpack = string_unpack       -- luacheck: ignore
+  string.pack = string_pack           -- luacheck: ignore
 end
 
 


### PR DESCRIPTION
### Summary

`lua_pack` is especially bad as it monkey patches the `string` in Lua. This means that whenever you require the `lua_pack` the `string` is modified. We don't want this to happen, thus we have this special construct there. We should replace `lua_pack` or modify `lua_pack` at some point.