### PR TITLE
chore(deps) bump azure-function to 1.0.0

### DIFF
--- a/kong-2.2.0-0.rockspec
+++ b/kong-2.2.0-0.rockspec
@@ -39,7 +39,7 @@ dependencies = {
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6",
   -- external Kong plugins
-  "kong-plugin-azure-functions ~> 0.4",
+  "kong-plugin-azure-functions ~> 1.0",
   "kong-plugin-zipkin ~> 1.1",
   "kong-plugin-serverless-functions ~> 1.0",
   "kong-prometheus-plugin ~> 1.0",


### PR DESCRIPTION
The update only contains a single fix, but since the version is stable it was promoted to 1.0.0.
