### PR TITLE
feat(key-auth) add config.key_in_header and config.key_in_query

### DIFF
--- a/kong/plugins/key-auth/handler.lua
+++ b/kong/plugins/key-auth/handler.lua
@@ -8,7 +8,7 @@ local error = error
 
 local KeyAuthHandler = {
   PRIORITY = 1003,
-  VERSION = "2.3.0",
+  VERSION = "2.4.0",
 }
 
 
@@ -93,8 +93,13 @@ local function do_authentication(conf)
   -- search in headers & querystring
   for i = 1, #conf.key_names do
     local name = conf.key_names[i]
-    local v = headers[name]
-    if not v then
+    local v
+
+    if conf.key_in_header then
+      v = headers[name]
+    end
+
+    if not v and conf.key_in_query then
       -- search in querystring
       v = query[name]
     end

--- a/kong/plugins/key-auth/schema.lua
+++ b/kong/plugins/key-auth/schema.lua
@@ -17,6 +17,8 @@ return {
           }, },
           { hide_credentials = { type = "boolean", default = false }, },
           { anonymous = { type = "string" }, },
+          { key_in_header = { type = "boolean", default = true }, },
+          { key_in_query = { type = "boolean", default = true }, },
           { key_in_body = { type = "boolean", default = false }, },
           { run_on_preflight = { type = "boolean", default = true }, },
         },

--- a/spec/01-unit/01-db/01-schema/07-plugins_spec.lua
+++ b/spec/01-unit/01-db/01-schema/07-plugins_spec.lua
@@ -120,6 +120,8 @@ describe("plugins", function()
       key_names = { "apikey" },
       hide_credentials = false,
       anonymous = ngx.null,
+      key_in_header = true,
+      key_in_query = true,
       key_in_body = false,
       run_on_preflight = true,
     }, plugin.config)

--- a/spec/01-unit/01-db/01-schema/11-declarative_config/02-process_auto_fields_spec.lua
+++ b/spec/01-unit/01-db/01-schema/11-declarative_config/02-process_auto_fields_spec.lua
@@ -149,6 +149,8 @@ describe("declarative config: process_auto_fields", function()
               protocols = { "grpc", "grpcs", "http", "https" },
               config = {
                 hide_credentials = false,
+                key_in_header = true,
+                key_in_query = true,
                 key_in_body = false,
                 key_names = { "apikey" },
                 run_on_preflight = true,
@@ -199,6 +201,8 @@ describe("declarative config: process_auto_fields", function()
               protocols = { "grpc", "grpcs", "http", "https" },
               config = {
                 hide_credentials = false,
+                key_in_header = true,
+                key_in_query = true,
                 key_in_body = false,
                 key_names = { "apikey" },
                 run_on_preflight = true,
@@ -309,6 +313,8 @@ describe("declarative config: process_auto_fields", function()
                     protocols = { "grpc", "grpcs", "http", "https" },
                     config = {
                       hide_credentials = false,
+                      key_in_header = true,
+                      key_in_query = true,
                       key_in_body = false,
                       key_names = { "apikey" },
                       run_on_preflight = true,
@@ -616,6 +622,8 @@ describe("declarative config: process_auto_fields", function()
                         protocols = { "grpc", "grpcs", "http", "https" },
                         config = {
                           hide_credentials = false,
+                          key_in_header = true,
+                          key_in_query = true,
                           key_in_body = false,
                           key_names = { "apikey" },
                           run_on_preflight = true,

--- a/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
+++ b/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
@@ -299,6 +299,8 @@ describe("declarative config: flatten", function()
               config = {
                 anonymous = null,
                 hide_credentials = false,
+                key_in_header = true,
+                key_in_query = true,
                 key_in_body = false,
                 key_names = { "apikey" },
                 run_on_preflight = true,
@@ -393,6 +395,8 @@ describe("declarative config: flatten", function()
               config = {
                 anonymous = null,
                 hide_credentials = false,
+                key_in_header = true,
+                key_in_query = true,
                 key_in_body = false,
                 key_names = { "apikey" },
                 run_on_preflight = true
@@ -569,6 +573,8 @@ describe("declarative config: flatten", function()
                 config = {
                   anonymous = null,
                   hide_credentials = false,
+                  key_in_header = true,
+                  key_in_query = true,
                   key_in_body = false,
                   key_names = { "apikey" },
                   run_on_preflight = true
@@ -1055,6 +1061,8 @@ describe("declarative config: flatten", function()
                 config = {
                   anonymous = null,
                   hide_credentials = false,
+                  key_in_header = true,
+                  key_in_query = true,
                   key_in_body = false,
                   key_names = { "apikey" },
                   run_on_preflight = true

--- a/spec/02-integration/03-db/03-plugins_spec.lua
+++ b/spec/02-integration/03-db/03-plugins_spec.lua
@@ -56,6 +56,8 @@ for _, strategy in helpers.each_strategy() do
             config = {
               hide_credentials = false,
               run_on_preflight = true,
+              key_in_header = true,
+              key_in_query = true,
               key_in_body = false,
               key_names = { "apikey" },
             },
@@ -128,6 +130,8 @@ for _, strategy in helpers.each_strategy() do
             config = {
               hide_credentials = false,
               run_on_preflight = true,
+              key_in_header = true,
+              key_in_query = true,
               key_in_body = false,
               key_names = { "apikey" },
             },


### PR DESCRIPTION
### Summary

Adds new two new plugin config fields to `key-auth` plugin:

1. `config.key_in_header=<true|false>` (default `true`)
2. `config.key_in_query=<true|false>` (default `true`)

To complement already existing config field:
`config.key_in_body=<true|false>` (default `false`)