### PR TITLE
fix(oauth2) handle more client invalid token generation cases

### DIFF
--- a/kong/plugins/oauth2/handler.lua
+++ b/kong/plugins/oauth2/handler.lua
@@ -3,7 +3,7 @@ local access = require "kong.plugins.oauth2.access"
 
 local OAuthHandler = {
   PRIORITY = 1004,
-  VERSION = "2.1.0",
+  VERSION = "2.1.1",
 }
 
 

--- a/spec/03-plugins/25-oauth2/03-access_spec.lua
+++ b/spec/03-plugins/25-oauth2/03-access_spec.lua
@@ -1319,6 +1319,39 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
           local json = cjson.decode(body)
           assert.same({ error_description = "Invalid client authentication", error = "invalid_client" }, json)
         end)
+        it("returns an error when missing client_id and missing client_secret is sent", function()
+          local res = assert(proxy_ssl_client:send {
+            method  = "POST",
+            path    = "/oauth2/token",
+            body    = {
+              scope            = "email",
+              response_type    = "token",
+              grant_type       = "client_credentials",
+            },
+            headers = {
+              ["Host"]         = "oauth2_4.com",
+              ["Content-Type"] = "application/json"
+            }
+          })
+          local body = assert.res_status(400, res)
+          local json = cjson.decode(body)
+          assert.same({ error_description = "Invalid client authentication", error = "invalid_client" }, json)
+        end)
+        it("returns an error when empty client_id and empty client_secret is sent regardless of method", function()
+          local res = assert(proxy_ssl_client:send {
+            method  = "GET",
+            path    = "/oauth2/token?client_id&grant_type=client_credentials&client_secret",
+            body    = {},
+            headers = {
+              ["Host"]         = "oauth2_4.com",
+              ["Content-Type"] = "application/json"
+            }
+          })
+          local body = assert.res_status(405, res)
+          local json = cjson.decode(body)
+          assert.same({ error_description = "The HTTP method GET is invalid for the token endpoint",
+                        error = "invalid_method" }, json)
+        end)
         it("returns an error when grant_type is not sent", function()
           local res = assert(proxy_ssl_client:send {
             method  = "POST",


### PR DESCRIPTION
### Summary

@jeremyjpj0916, sorry I tried to push to your PR https://github.com/Kong/kong/pull/6337, but I just don't seem to handle `git` too well. And that got closed. I reopened it here with some small changes.

Fixes: https://github.com/Kong/kong/issues/6311

^^ Full discussion and examples over here. My changes fix 2 scenarios I can see Kong not responding as I would expect to an end user. 1 was type error fix(by validating a scenario where bad user input yields a boolean reference not a string), other requires thinking about it a little deeper to return the right response to clients. 

### Full changelog

* Add better handling in ```get_redirect_uris``` when fields are not present ```client_id``` ends up being a boolean parameter. Potentially fixes could have been done alternatively in the ```retrieve_parameters``` or ```retrieve_client_credentials``` functions.

* Removed the check for ```POST``` method to decide if we are calling the proxy vs calling the token generation pathings, URI alone should help dictate it imo and thus the response customers get from Kong will be more accurate to what proxy clients were attempting to do.  

* 2 edge cases tests I fixed added.

### Issues resolved

Fix #6311