### PR TITLE
Fix/go plugin vs db import export

### DIFF
--- a/kong/cmd/config.lua
+++ b/kong/cmd/config.lua
@@ -79,13 +79,13 @@ local function execute(args)
 
   package.path = conf.lua_package_path .. ";" .. package.path
 
+  _G.kong = kong_global.new()
+  kong_global.init_pdk(_G.kong, conf, nil) -- nil: latest PDK
+
   local dc, err = declarative.new_config(conf, true)
   if not dc then
     error(err)
   end
-
-  _G.kong = kong_global.new()
-  kong_global.init_pdk(_G.kong, conf, nil) -- nil: latest PDK
 
   local db = assert(DB.new(conf))
   assert(db:init_connector())

--- a/kong/db/dao/plugins/go.lua
+++ b/kong/db/dao/plugins/go.lua
@@ -38,6 +38,7 @@ end
 
 --- is_on(): returns true if Go plugins is enabled
 function go.is_on()
+  kong = kong or _G.kong    -- some CLI cmds set the global after loading the module.
   return kong.configuration.go_plugins_dir ~= "off"
 end
 


### PR DESCRIPTION
the `db_import` and `db_export` have some issues about the exact moment in which the `kong` global is set.  The #6533 PR gets the right order but needed to refresh the local in the go module.


Fix #6437
Close #6533 