### PR TITLE
fix/utf-8 in core entities tweaks

### DIFF
--- a/kong/db/schema/entities/workspaces.lua
+++ b/kong/db/schema/entities/workspaces.lua
@@ -10,7 +10,7 @@ return {
 
   fields = {
     { id          = typedefs.uuid },
-    { name        = typedefs.name { required = true } },
+    { name        = typedefs.utf8_name { required = true } },
     { comment     = { type = "string" } },
     { created_at  = typedefs.auto_timestamp_s },
     { meta        = { type = "record", fields = {} } },

--- a/kong/db/schema/typedefs.lua
+++ b/kong/db/schema/typedefs.lua
@@ -106,6 +106,12 @@ local function validate_utf8_name(name)
     return nil, "invalid utf-8 character sequence detected at position " .. tostring(index)
   end
 
+  if not match(name, "^[%w%.%-%_~\128-\244]+$") then
+    return nil,
+    "invalid value '" .. name ..
+      "': the only accepted ascii characters are alphanumerics or ., -, _, and ~"
+  end
+
   return true
 end
 

--- a/spec/01-unit/01-db/01-schema/05-services_spec.lua
+++ b/spec/01-unit/01-db/01-schema/05-services_spec.lua
@@ -439,14 +439,24 @@ describe("services", function()
     end)
 
     it("rejects invalid names", function()
-      -- see tests for utils.validate_utf8 for more invalid values
-      local service = {
-        name = string.char(105, 213, 205, 149),
+      local invalid_names = {
+        "examp:le",
+        "examp;le",
+        "examp/le",
+        "examp le",
+        -- see tests for utils.validate_utf8 for more invalid values
+        string.char(105, 213, 205, 149),
       }
 
-      local ok, err = Services:validate(service)
-      assert.falsy(ok)
-      assert.matches("invalid utf%-8 character sequence detected", err.name)
+      for i = 1, #invalid_names do
+        local service = {
+          url = "http://example.com",
+          name = invalid_names[i]
+        }
+        local ok, err = Services:validate(service)
+        assert.falsy(ok)
+        assert.matches("invalid", err.name)
+      end
     end)
 
     -- acceptance

--- a/spec/01-unit/01-db/01-schema/06-routes_spec.lua
+++ b/spec/01-unit/01-db/01-schema/06-routes_spec.lua
@@ -691,14 +691,24 @@ describe("routes schema", function()
     end)
 
     it("rejects invalid names", function()
-      -- see tests for utils.validate_utf8 for more invalid values
-      local route = {
-        name = string.char(105, 213, 205, 149),
-        protocols = {"http"}
+      local invalid_names = {
+        "examp:le",
+        "examp;le",
+        "examp/le",
+        "examp le",
+        -- see tests for utils.validate_utf8 for more invalid values
+        string.char(105, 213, 205, 149),
       }
-      local ok, err = Routes:validate(route)
-      assert.falsy(ok)
-      assert.matches("invalid utf%-8 character sequence detected", err.name)
+
+      for i = 1, #invalid_names do
+        local route = {
+          name = invalid_names[i],
+          protocols = {"http"}
+        }
+        local ok, err = Routes:validate(route)
+        assert.falsy(ok)
+        assert.matches("invalid", err.name)
+      end
     end)
 
     -- acceptance

--- a/spec/01-unit/01-db/01-schema/14-consumers_spec.lua
+++ b/spec/01-unit/01-db/01-schema/14-consumers_spec.lua
@@ -1,0 +1,33 @@
+local consumers = require "kong.db.schema.entities.consumers"
+local Entity       = require "kong.db.schema.entity"
+
+local Consumers = assert(Entity.new(consumers))
+
+describe("consumers schema", function()
+  describe("username attribute", function()
+    -- acceptance
+    it("accepts valid names", function()
+      local valid_names = {
+        "example",
+        "EXAMPLE",
+        "exa.mp.le",
+        "3x4mp13",
+        "3x4-mp-13",
+        "3x4_mp_13",
+        "~3x4~mp~13",
+        "~3..x4~.M-p~1__3_",
+        "孔",
+        "Конг",
+        "🦍",
+      }
+
+      for i = 1, #valid_names do
+        local ok, err = Consumers:validate({
+          username = valid_names[i],
+        })
+        assert.is_nil(err)
+        assert.is_true(ok)
+      end
+    end)
+  end)
+end)

--- a/spec/01-unit/01-db/01-schema/15-workspaces_spec.lua
+++ b/spec/01-unit/01-db/01-schema/15-workspaces_spec.lua
@@ -1,0 +1,57 @@
+local workspaces = require "kong.db.schema.entities.workspaces"
+local Entity       = require "kong.db.schema.entity"
+
+local Workspaces = assert(Entity.new(workspaces))
+
+describe("workspaces schema", function()
+  describe("name attribute", function()
+    -- refusals
+    it("rejects invalid names", function()
+      local invalid_names = {
+        "examp:le",
+        "examp;le",
+        "examp/le",
+        "examp le",
+        -- see tests for utils.validate_utf8 for more invalid values
+        string.char(105, 213, 205, 149),
+      }
+
+      for i = 1, #invalid_names do
+        local ok, err = Workspaces:validate({
+          name = invalid_names[i],
+          config = {},
+          meta = {},
+        })
+        assert.falsy(ok)
+        assert.matches("invalid", err.name)
+      end
+    end)
+
+    -- acceptance
+    it("accepts valid names", function()
+      local valid_names = {
+        "example",
+        "EXAMPLE",
+        "exa.mp.le",
+        "3x4mp13",
+        "3x4-mp-13",
+        "3x4_mp_13",
+        "~3x4~mp~13",
+        "~3..x4~.M-p~1__3_",
+        "孔",
+        "Конг",
+        "🦍",
+      }
+
+      for i = 1, #valid_names do
+        local ok, err = Workspaces:validate({
+          name = valid_names[i],
+          config = {},
+          meta = {},
+        })
+        assert.is_nil(err)
+        assert.is_true(ok)
+      end
+    end)
+  end)
+end)

--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -494,6 +494,7 @@ describe("kong start/stop #" .. strategy, function()
           in 'services':
             - in entry 1 of 'services':
               in 'protocol': expected one of: grpc, grpcs, http, https, tcp, tls, udp
+              in 'name': invalid value '@gobo': the only accepted ascii characters are alphanumerics or ., -, _, and ~
             - in entry 2 of 'services':
               in 'routes':
                 - in entry 1 of 'routes':

--- a/spec/02-integration/04-admin_api/03-consumers_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/03-consumers_routes_spec.lua
@@ -322,6 +322,20 @@ describe("Admin API (#" .. strategy .. "): ", function()
           local json = cjson.decode(body)
           assert.same(consumer, json)
         end)
+        it("retrieves by utf-8 name and encoded utf-8 name", function()
+          local consumer = bp.consumers:insert({ username = "円" }, { nulls = true })
+          local res  = client:get("/consumers/" .. consumer.username)
+          local body = assert.res_status(200, res)
+
+          local json = cjson.decode(body)
+          assert.same(consumer, json)
+
+          res  = client:get("/consumers/" .. escape(consumer.username))
+          body = assert.res_status(200, res)
+
+          json = cjson.decode(body)
+          assert.same(consumer, json)
+        end)
         it("returns 404 if not found", function()
           local res = assert(client:send {
             method = "GET",


### PR DESCRIPTION
* We accept all the range of utf-8 in certain Core entities now, but some parts of the ASCII range are restricted in order to avoid problems (such as "/" in urls)
* Added utf-8 support to workspace names
* Consumer.username had no restrictions whatsoever (`type="string"`), so it was possible that people were already adding characters there which `typedefs.utf8_name` would consider invalid. Because of this, we have added tests which check that it is compatible with utf-8, without adding the typedef on the schema, in order to prevent backwards breakage. The test is there so that if we add restrictions which prevent utf-8 in Consumers in the future it will fail and that will warn us.

Another important thing to notice here is what is *not* included on the PR: `upstreams.name` and `targets.target` could potentially be considered "names" (since they are used in Admin Api URLs, e.g. `/upstreams/myupstream.dev`. In both of these cases utf-8 was not implemented because Upstreams and Targets need to be valid hostnames. Automatic translation into punicode was considered, but there is no readily-available punicode library which we can use "off the shelf".

Finally, we didn't add utf-8 support to `tags.name` because the parsing of tags is coupled with parsing of querystrings on the Admin Api, and separating/expanding those was not in scope for this task, and on top of that there is no high demand of utf8 in tags at the moment.