### PR TITLE
feat(clustering) version checks between CP and DP

### DIFF
--- a/kong/clustering.lua
+++ b/kong/clustering.lua
@@ -11,6 +11,7 @@ local utils = require("kong.tools.utils")
 local openssl_x509 = require("resty.openssl.x509")
 local system_constants = require("lua_system_constants")
 local ffi = require("ffi")
+local pl_tablex = require("pl.tablex")
 local string = string
 local assert = assert
 local setmetatable = setmetatable
@@ -33,8 +34,10 @@ local table_insert = table.insert
 local table_remove = table.remove
 local inflate_gzip = utils.inflate_gzip
 local deflate_gzip = utils.deflate_gzip
+local pl_tablex_compare = pl_tablex.compare
 
 
+local KONG_VERSION = kong.version
 local MAX_PAYLOAD = 4 * 1024 * 1024 -- 4MB
 local PING_INTERVAL = 30 -- 30 seconds
 local PING_WAIT = PING_INTERVAL * 1.5
@@ -51,6 +54,7 @@ local ngx_NOTICE = ngx.NOTICE
 local WEAK_KEY_MT = { __mode = "k", }
 local CERT_DIGEST
 local CERT, CERT_KEY
+local PLUGINS_LIST
 local clients = setmetatable({}, WEAK_KEY_MT)
 local prefix = ngx.config.prefix()
 local CONFIG_CACHE = prefix .. "/config.cache.json.gz"
@@ -137,7 +141,9 @@ local function communicate(premature, conf)
 
   local c = assert(ws_client:new(WS_OPTS))
   local uri = "wss://" .. address .. "/v1/outlet?node_id=" ..
-              kong.node.get_id() .. "&node_hostname=" .. kong.node.get_hostname()
+              kong.node.get_id() ..
+              "&node_hostname=" .. kong.node.get_hostname() ..
+              "&node_version=" .. KONG_VERSION
 
   local opts = {
     ssl_verify = true,
@@ -164,6 +170,20 @@ local function communicate(premature, conf)
   end
 
   -- connection established
+  -- first, send out the plugin list to CP so it can make decision on whether
+  -- sync will be allowed later
+  local _
+  _, err = c:send_binary(cjson_encode({ type = "basic_info",
+                                        plugins = PLUGINS_LIST, }))
+  if err then
+    ngx_log(ngx_ERR, "unable to send basic information to control plane: ", uri,
+                     " err: ", err,
+                     " (retrying after ", reconnection_delay, " seconds)")
+
+    c:close()
+    assert(ngx.timer.at(reconnection_delay, communicate, conf))
+    return
+  end
 
   local config_semaphore = semaphore.new(0)
 
@@ -312,6 +332,39 @@ local function validate_shared_cert()
 end
 
 
+local function plugin_entry_comparator(a, b)
+  return a.name == b.name and a.version == b.version
+end
+
+
+local MAJOR_MINOR_PATTERN = "^(%d+%.%d+)%.%d+"
+local function should_send_config_update(node_version, node_plugins)
+  if not node_version or not node_plugins then
+    return false, "your DP did not provide version information to the CP, " ..
+                  "Kong CP after 2.3 requires such information in order to " ..
+                  "ensure generated config is compatible with DPs. " ..
+                  "Sync is suspended for this DP and will resume " ..
+                  "automatically once this DP also upgrades to 2.3 or later"
+  end
+
+  local minor_cp = KONG_VERSION:match(MAJOR_MINOR_PATTERN)
+  local minor_node = node_version:match(MAJOR_MINOR_PATTERN)
+  if minor_cp ~= minor_node then
+    return false, "version mismatches, CP version: " .. minor_cp ..
+                  " DP version: " .. minor_node
+  end
+
+  if not pl_tablex_compare(PLUGINS_LIST, node_plugins,
+                           plugin_entry_comparator)
+  then
+    return false, "CP and DP does not have same set of plugins installed" ..
+                  " or their versions might differ"
+  end
+
+  return true
+end
+
+
 function _M.handle_cp_websocket()
   -- use mutual TLS authentication
   if kong.configuration.cluster_mtls == "shared" then
@@ -325,6 +378,8 @@ function _M.handle_cp_websocket()
 
   local node_hostname = ngx_var.arg_node_hostname
   local node_ip = ngx_var.remote_addr
+  local node_version = ngx_var.arg_node_version
+  local node_plugins
 
   local wb, err = ws_server:new(WS_OPTS)
   if not wb then
@@ -333,6 +388,19 @@ function _M.handle_cp_websocket()
   end
 
   -- connection established
+  -- receive basic_info
+  local data, typ
+  data, typ, err = wb:recv_frame()
+  if err then
+    ngx_log(ngx_ERR, "failed to receive WebSocket basic_info frame: ", err)
+    wb:close()
+    return ngx_exit(444)
+
+  elseif typ == "binary" then
+    data = cjson_decode(data)
+    assert(data.type =="basic_info")
+    node_plugins = assert(data.plugins)
+  end
 
   local queue
   do
@@ -349,7 +417,9 @@ function _M.handle_cp_websocket()
 
   clients[wb] = queue
 
-  do
+  local res
+  res, err = should_send_config_update(node_version, node_plugins)
+  if res then
     local config_table
     -- unconditionally send config update to new clients to
     -- ensure they have latest version running
@@ -365,8 +435,13 @@ function _M.handle_cp_websocket()
     else
       ngx_log(ngx_ERR, "unable to export config from database: ".. err)
     end
-  end
 
+  else
+    ngx_log(ngx_WARN, "unable to send updated configuration to " ..
+                      "DP node with hostname: " .. node_hostname ..
+                      " ip: " .. node_ip ..
+                      " reason: " .. err)
+  end
   -- how CP connection management works:
   -- two threads are spawned, when any of these threads exits,
   -- it means a fatal error has occurred on the connection,
@@ -397,7 +472,8 @@ function _M.handle_cp_websocket()
 
         local waited = ngx_time() - last_seen
         if waited > PING_WAIT then
-          return nil, "did not receive ping frame from data plane within " .. PING_WAIT .. " seconds"
+          return nil, "did not receive ping frame from data plane within " ..
+                      PING_WAIT .. " seconds"
         end
 
       else
@@ -426,6 +502,7 @@ function _M.handle_cp_websocket()
           config_hash = data ~= "" and data or nil,
           hostname = node_hostname,
           ip = node_ip,
+          version = node_version,
         }, { ttl = kong.configuration.cluster_data_plane_purge_delay, })
         if not ok then
           ngx_log(ngx_ERR, "unable to update clustering data plane status: ", err)
@@ -459,17 +536,27 @@ function _M.handle_cp_websocket()
             ngx_log(ngx_DEBUG, "sent PONG packet to data plane")
           end
 
-        else -- config update
-          local _, err = wb:send_binary(payload)
-          if err then
-            if not is_timeout(err) then
-              return nil, "unable to send updated configuration to node: " .. err
+        else
+          ok, err = should_send_config_update(node_version, node_plugins)
+          if ok then
+            -- config update
+            local _, err = wb:send_binary(payload)
+            if err then
+              if not is_timeout(err) then
+                return nil, "unable to send updated configuration to node: " .. err
+              end
+
+              ngx_log(ngx_NOTICE, "unable to send updated configuration to node: ", err)
+
+            else
+              ngx_log(ngx_DEBUG, "sent config update to node")
             end
 
-            ngx_log(ngx_NOTICE, "unable to send updated configuration to node: ", err)
-
           else
-            ngx_log(ngx_DEBUG, "sent config update to node")
+            ngx_log(ngx_WARN, "unable to send updated configuration to " ..
+                              "DP node with hostname: " .. node_hostname ..
+                              " ip: " .. node_ip ..
+                              " reason: " .. err)
           end
         end
 
@@ -626,6 +713,15 @@ end
 
 function _M.init_worker(conf)
   assert(conf, "conf can not be nil", 2)
+
+  PLUGINS_LIST = assert(kong.db.plugins:get_handlers())
+  table.sort(PLUGINS_LIST, function(a, b)
+    return a.name:lower() < b.name:lower()
+  end)
+
+  PLUGINS_LIST = pl_tablex.map(function(p)
+    return { name = p.name, version = p.handler.VERSION, }
+  end, PLUGINS_LIST)
 
   if conf.role == "data_plane" then
     -- ROLE = "data_plane"

--- a/kong/db/migrations/core/013_220_to_230.lua
+++ b/kong/db/migrations/core/013_220_to_230.lua
@@ -31,6 +31,14 @@ return {
         -- Do nothing, accept existing state
       END;
       $$;
+
+      DO $$
+      BEGIN
+        ALTER TABLE IF EXISTS ONLY "clustering_data_planes" ADD "version" TEXT;
+      EXCEPTION WHEN DUPLICATE_COLUMN THEN
+        -- Do nothing, accept existing state
+      END;
+      $$;
     ]], CLUSTER_ID),
   },
   cassandra = {
@@ -47,6 +55,7 @@ return {
 
       ALTER TABLE certificates ADD cert_alt TEXT;
       ALTER TABLE certificates ADD key_alt TEXT;
+      ALTER TABLE clustering_data_planes ADD version text;
     ]], CLUSTER_ID),
   }
 }

--- a/kong/db/schema/entities/clustering_data_planes.lua
+++ b/kong/db/schema/entities/clustering_data_planes.lua
@@ -14,5 +14,6 @@ return {
     { ip = typedefs.ip { required = true, } },
     { config_hash = { type = "string", len_eq = 32, } },
     { hostname = typedefs.host { required = true, } },
+    { version = typedefs.semantic_version },
   },
 }

--- a/kong/db/schema/typedefs.lua
+++ b/kong/db/schema/typedefs.lua
@@ -525,6 +525,20 @@ typedefs.headers = Schema.define {
 
 typedefs.no_headers = Schema.define(typedefs.headers { eq = null } )
 
+typedefs.semantic_version = Schema.define {
+  type = "string",
+  match_any = {
+    patterns = { "^%d+[%.%d]*$", "^%d+[%.%d]*%-?.*$", },
+    err = "invalid version number: must be in format of X.Y.Z",
+  },
+  match_none = {
+    {
+      pattern = "%.%.",
+      err = "must not have empty version segments"
+    },
+  },
+}
+
 setmetatable(typedefs, {
   __index = function(_, k)
     error("schema typedef error: definition " .. k .. " does not exist", 2)

--- a/spec/01-unit/01-db/01-schema/03-typedefs_spec.lua
+++ b/spec/01-unit/01-db/01-schema/03-typedefs_spec.lua
@@ -136,6 +136,25 @@ describe("typedefs", function()
     assert.falsy(Test:validate({ f = 123 }))
   end)
 
+  it("features semantic_version typedef", function()
+    local Test = Schema.new({
+      fields = {
+        { f = typedefs.semantic_version }
+      }
+    })
+    assert.truthy(Test:validate({ f = "1" }))
+    assert.truthy(Test:validate({ f = "1.2" }))
+    assert.truthy(Test:validate({ f = "1.2.3" }))
+    assert.truthy(Test:validate({ f = "100.200.300" }))
+    assert.truthy(Test:validate({ f = "1.2.3-rc.1" }))
+    assert.truthy(Test:validate({ f = "1.2.3-alpha.1" }))
+    assert.truthy(Test:validate({ f = "1.2.3-beta.1" }))
+    assert.truthy(Test:validate({ f = "1.2.3.4-enterprise-edition" }))
+    assert.falsy(Test:validate({ f = "hello" }))
+    assert.falsy(Test:validate({ f = ".1" }))
+    assert.falsy(Test:validate({ f = "1..1" }))
+  end)
+
   it("features http_method typedef", function()
     local Test = Schema.new({
       fields = {

--- a/spec/02-integration/05-proxy/04-plugins_triggering_spec.lua
+++ b/spec/02-integration/05-proxy/04-plugins_triggering_spec.lua
@@ -179,6 +179,7 @@ for _, strategy in helpers.each_strategy() do
       bp.plugins:insert {
         name     = "error-handler-log",
         service  = { id = service_error.id },
+        config   = {},
       }
 
       assert(helpers.start_kong({

--- a/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
@@ -1,5 +1,10 @@
 local helpers = require "spec.helpers"
+local utils = require "kong.tools.utils"
 local cjson = require "cjson.safe"
+local _VERSION_TABLE = require "kong.meta" ._VERSION_TABLE
+local MAJOR = _VERSION_TABLE.major
+local MINOR = _VERSION_TABLE.minor
+local PATCH = _VERSION_TABLE.patch
 
 
 for _, strategy in helpers.each_strategy() do
@@ -58,6 +63,7 @@ for _, strategy in helpers.each_strategy() do
           for _, v in pairs(json.data) do
             if v.ip == "127.0.0.1" then
               assert.near(14 * 86400, v.ttl, 3)
+              assert.matches("^(%d+%.%d+)%.%d+", v.version)
 
               return true
             end
@@ -205,6 +211,274 @@ for _, strategy in helpers.each_strategy() do
     end)
   end)
 
+  describe("CP/DP version check works with #" .. strategy, function()
+    -- for these tests, we do not need a real DP, but rather use the fake DP
+    -- client so we can mock various values (e.g. node_version)
+    describe("checks major.minor, bugfix and suffix can be different", function()
+      local db
+
+      lazy_setup(function()
+        _, db = helpers.get_db_utils(strategy, {
+          "routes",
+          "services",
+          "clustering_data_planes",
+        }) -- runs migrations
+
+        assert(helpers.start_kong({
+          role = "control_plane",
+          cluster_cert = "spec/fixtures/kong_clustering.crt",
+          cluster_cert_key = "spec/fixtures/kong_clustering.key",
+          lua_ssl_trusted_certificate = "spec/fixtures/kong_clustering.crt",
+          database = strategy,
+          db_update_frequency = 3,
+          cluster_listen = "127.0.0.1:9005",
+          nginx_conf = "spec/fixtures/custom_nginx.template",
+          cluster_version_check = "major_minor",
+        }))
+      end)
+
+      lazy_teardown(function()
+        helpers.stop_kong()
+      end)
+
+      it("CP and DP version and plugins matches", function()
+        local uuid = utils.uuid()
+
+        local res = assert(helpers.clustering_client({
+          host = "127.0.0.1",
+          port = 9005,
+          cert = "spec/fixtures/kong_clustering.crt",
+          cert_key = "spec/fixtures/kong_clustering.key",
+          node_id = uuid,
+        }))
+
+        assert.equals("reconfigure", res.type)
+        assert.is_table(res.config_table)
+
+        -- needs wait_until for C* convergence
+        helpers.wait_until(function()
+          local admin_client = helpers.admin_client()
+
+          res = assert(admin_client:get("/clustering/data-planes"))
+          local body = assert.res_status(200, res)
+
+          admin_client:close()
+          local json = cjson.decode(body)
+
+          for _, v in pairs(json.data) do
+            if v.id == uuid then
+              assert.equal(tostring(_VERSION_TABLE), v.version)
+              return true
+            end
+          end
+        end, 5)
+      end)
+
+      it("CP and DP minor version mismatches, sync is still allowed", function()
+        local uuid = utils.uuid()
+        local version = string.format("%d.%d.%d", MAJOR, MINOR, PATCH + 1)
+
+        local res = assert(helpers.clustering_client({
+          host = "127.0.0.1",
+          port = 9005,
+          cert = "spec/fixtures/kong_clustering.crt",
+          cert_key = "spec/fixtures/kong_clustering.key",
+          node_version = version,
+          node_id = uuid,
+        }))
+
+        assert.equals("reconfigure", res.type)
+        assert.is_table(res.config_table)
+
+        -- needs wait_until for C* convergence
+        helpers.wait_until(function()
+          local admin_client = helpers.admin_client()
+
+          res = assert(admin_client:get("/clustering/data-planes"))
+          local body = assert.res_status(200, res)
+
+          admin_client:close()
+          local json = cjson.decode(body)
+
+          for _, v in pairs(json.data) do
+            if v.id == uuid then
+              assert.equal(version, v.version)
+              return true
+            end
+          end
+        end, 5)
+      end)
+
+      it("CP and DP suffix mismatches, sync is still allowed", function()
+        local uuid = utils.uuid()
+        local version = tostring(_VERSION_TABLE) .. "-enterprise-version"
+
+        local res = assert(helpers.clustering_client({
+          host = "127.0.0.1",
+          port = 9005,
+          cert = "spec/fixtures/kong_clustering.crt",
+          cert_key = "spec/fixtures/kong_clustering.key",
+          node_version = version,
+          node_id = uuid,
+        }))
+
+        assert.equals("reconfigure", res.type)
+        assert.is_table(res.config_table)
+
+        -- needs wait_until for c* convergence
+        helpers.wait_until(function()
+          local admin_client = helpers.admin_client()
+
+          res = assert(admin_client:get("/clustering/data-planes"))
+          local body = assert.res_status(200, res)
+
+          admin_client:close()
+          local json = cjson.decode(body)
+
+          for _, v in pairs(json.data) do
+            if v.id == uuid then
+              assert.equal(version, v.version)
+              return true
+            end
+          end
+        end, 5)
+      end)
+
+      it("CP and DP minor version mismatches, sync is blocked", function()
+        local uuid = utils.uuid()
+
+        local res = assert(helpers.clustering_client({
+          host = "127.0.0.1",
+          port = 9005,
+          cert = "spec/fixtures/kong_clustering.crt",
+          cert_key = "spec/fixtures/kong_clustering.key",
+          node_version = "1.0.0",
+          node_id = uuid,
+        }))
+
+        assert.equals("PONG", res)
+
+        -- needs wait_until for c* convergence
+        helpers.wait_until(function()
+          local admin_client = helpers.admin_client()
+
+          res = assert(admin_client:get("/clustering/data-planes"))
+          local body = assert.res_status(200, res)
+
+          admin_client:close()
+          local json = cjson.decode(body)
+
+          for _, v in pairs(json.data) do
+            if v.id == uuid then
+              assert.equal("1.0.0", v.version)
+              return true
+            end
+          end
+        end, 5)
+      end)
+
+      it("CP and CP plugin version mismatches, sync is blocked", function()
+        local uuid = utils.uuid()
+        local plugins_list = helpers.get_plugins_list()
+        -- this tampers with the bugfix version
+        plugins_list[1].version = plugins_list[1].version .. "1"
+
+        local res = assert(helpers.clustering_client({
+          host = "127.0.0.1",
+          port = 9005,
+          cert = "spec/fixtures/kong_clustering.crt",
+          cert_key = "spec/fixtures/kong_clustering.key",
+          node_id = uuid,
+          node_plugins_list = plugins_list,
+        }))
+
+        assert.equals("PONG", res)
+
+        -- needs wait_until for c* convergence
+        helpers.wait_until(function()
+          local admin_client = helpers.admin_client()
+
+          res = assert(admin_client:get("/clustering/data-planes"))
+          local body = assert.res_status(200, res)
+
+          admin_client:close()
+          local json = cjson.decode(body)
+
+          for _, v in pairs(json.data) do
+            if v.id == uuid then
+              assert.equal(tostring(_VERSION_TABLE), v.version)
+              return true
+            end
+          end
+        end, 5)
+      end)
+
+      it("CP and DP plugin set mismatches, sync is blocked", function()
+        assert(db:truncate("clustering_data_planes"))
+        assert(db:truncate("routes"))
+        assert(db:truncate("services"))
+
+        assert(helpers.start_kong({
+          role = "data_plane",
+          database = "off",
+          prefix = "servroot2",
+          cluster_cert = "spec/fixtures/kong_clustering.crt",
+          cluster_cert_key = "spec/fixtures/kong_clustering.key",
+          lua_ssl_trusted_certificate = "spec/fixtures/kong_clustering.crt",
+          cluster_control_plane = "127.0.0.1:9005",
+          proxy_listen = "0.0.0.0:9002",
+          plugins = "bundled", -- differs from CP plugins
+        }))
+
+        local admin_client = helpers.admin_client(10000)
+
+        finally(function()
+          helpers.stop_kong("servroot2")
+          admin_client:close()
+        end)
+
+
+        local res = assert(admin_client:post("/services", {
+          body = { name = "mockbin-service", url = "https://127.0.0.1:15556/request", },
+          headers = {["Content-Type"] = "application/json"}
+        }))
+        assert.res_status(201, res)
+
+        assert(admin_client:post("/services/mockbin-service/routes", {
+          body = { paths = { "/shouldnotexist" }, },
+          headers = {["Content-Type"] = "application/json"}
+        }))
+
+        helpers.wait_until(function()
+          local proxy_client = helpers.http_client("127.0.0.1", 9002)
+          local admin_client = helpers.admin_client(10000)
+
+          local res = assert(admin_client:get("/clustering/data-planes"))
+          local body = assert.res_status(200, res)
+          local json = cjson.decode(body)
+          admin_client:close()
+
+          for _, v in pairs(json.data) do
+            if v.ip == "127.0.0.1" then
+              assert.near(14 * 86400, v.ttl, 10)
+              assert.equals(tostring(_VERSION_TABLE), v.version)
+
+              res = proxy_client:send({
+                method  = "GET",
+                path    = "/shouldnotexist",
+              })
+
+              local status = res and res.status
+              proxy_client:close()
+              if status == 404 then
+                return true
+              end
+            end
+          end
+        end, 10)
+      end)
+    end)
+  end)
 
   describe("CP/DP sync works with #" .. strategy .. " backend", function()
     lazy_setup(function()

--- a/spec/fixtures/custom_plugins/kong/plugins/cache/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/cache/schema.lua
@@ -1,3 +1,10 @@
 return {
-  fields = {}
+  name = "cache",
+  fields = {
+    { config = {
+        type = "record",
+        fields = { },
+      }
+    }
+  }
 }

--- a/spec/fixtures/custom_plugins/kong/plugins/error-generator-last/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/error-generator-last/handler.lua
@@ -1,28 +1,17 @@
-local BasePlugin = require "kong.plugins.base_plugin"
-
-
 local error = error
 
 
-local ErrorGeneratorLastHandler = BasePlugin:extend()
+local ErrorGeneratorLastHandler = {}
 
 
 ErrorGeneratorLastHandler.PRIORITY = -math.huge
 
 
-function ErrorGeneratorLastHandler:new()
-  ErrorGeneratorLastHandler.super.new(self, "error-generator-last")
-end
-
-
 function ErrorGeneratorLastHandler:init_worker()
-  ErrorGeneratorLastHandler.super.init_worker(self)
 end
 
 
 function ErrorGeneratorLastHandler:certificate(conf)
-  ErrorGeneratorLastHandler.super.certificate(self)
-
   if conf.certificate then
     error("[error-generator-last] certificate")
   end
@@ -30,8 +19,6 @@ end
 
 
 function ErrorGeneratorLastHandler:rewrite(conf)
-  ErrorGeneratorLastHandler.super.rewrite(self)
-
   if conf.rewrite then
     error("[error-generator-last] rewrite")
   end
@@ -39,8 +26,6 @@ end
 
 
 function ErrorGeneratorLastHandler:preread(conf)
-  ErrorGeneratorLastHandler.super.preread(self)
-
   if conf.preread then
     error("[error-generator-last] preread")
   end
@@ -49,8 +34,6 @@ end
 
 
 function ErrorGeneratorLastHandler:access(conf)
-  ErrorGeneratorLastHandler.super.access(self)
-
   if conf.access then
     error("[error-generator-last] access")
   end
@@ -58,8 +41,6 @@ end
 
 
 function ErrorGeneratorLastHandler:header_filter(conf)
-  ErrorGeneratorLastHandler.super.header_filter(self)
-
   if conf.header_filter then
     error("[error-generator-last] header_filter")
   end
@@ -67,8 +48,6 @@ end
 
 
 function ErrorGeneratorLastHandler:body_filter(conf)
-  ErrorGeneratorLastHandler.super.body_filter(self)
-
   if conf.header_filter then
     error("[error-generator-last] body_filter")
   end
@@ -76,8 +55,6 @@ end
 
 
 function ErrorGeneratorLastHandler:log(conf)
-  ErrorGeneratorLastHandler.super.log(self)
-
   if conf.log then
     error("[error-generator] body_filter")
   end

--- a/spec/fixtures/custom_plugins/kong/plugins/error-generator-last/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/error-generator-last/schema.lua
@@ -1,11 +1,18 @@
 return {
+  name = "error-generator-last",
   fields = {
-    certificate   = { type = "boolean", required = false, default = false },
-    rewrite       = { type = "boolean", required = false, default = false },
-    preread       = { type = "boolean", required = false, default = false },
-    access        = { type = "boolean", required = false, default = false },
-    header_filter = { type = "boolean", required = false, default = false },
-    body_filter   = { type = "boolean", required = false, default = false },
-    log           = { type = "boolean", required = false, default = false },
+    { config = {
+        type = "record",
+        fields = {
+          { certificate   = { type = "boolean", required = false, default = false }, },
+          { rewrite       = { type = "boolean", required = false, default = false }, },
+          { preread       = { type = "boolean", required = false, default = false }, },
+          { access        = { type = "boolean", required = false, default = false }, },
+          { header_filter = { type = "boolean", required = false, default = false }, },
+          { body_filter   = { type = "boolean", required = false, default = false }, },
+          { log           = { type = "boolean", required = false, default = false }, },
+        },
+      }
+    }
   }
 }

--- a/spec/fixtures/custom_plugins/kong/plugins/error-generator/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/error-generator/schema.lua
@@ -1,11 +1,23 @@
+local typedefs = require "kong.db.schema.typedefs"
+
+
 return {
+  name = "error-generator",
   fields = {
-    certificate   = { type = "boolean", required = false, default = false },
-    rewrite       = { type = "boolean", required = false, default = false },
-    preread       = { type = "boolean", required = false, default = false },
-    access        = { type = "boolean", required = false, default = false },
-    header_filter = { type = "boolean", required = false, default = false },
-    body_filter   = { type = "boolean", required = false, default = false },
-    log           = { type = "boolean", required = false, default = false },
+    { consumer = typedefs.no_consumer },
+    { protocols = typedefs.protocols_http },
+    { config = {
+        type = "record",
+        fields = {
+          { certificate   = { type = "boolean", required = false, default = false }, },
+          { rewrite       = { type = "boolean", required = false, default = false }, },
+          { preread       = { type = "boolean", required = false, default = false }, },
+          { access        = { type = "boolean", required = false, default = false }, },
+          { header_filter = { type = "boolean", required = false, default = false }, },
+          { body_filter   = { type = "boolean", required = false, default = false }, },
+          { log           = { type = "boolean", required = false, default = false }, },
+        },
+      }
+    }
   }
 }

--- a/spec/fixtures/custom_plugins/kong/plugins/error-handler-log/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/error-handler-log/schema.lua
@@ -1,3 +1,10 @@
 return {
-  fields = {}
+  name = "error-handler-log",
+  fields = {
+    { config = {
+        type = "record",
+        fields = { },
+      }
+    }
+  }
 }

--- a/spec/kong_tests.conf
+++ b/spec/kong_tests.conf
@@ -29,7 +29,7 @@ nginx_main_worker_rlimit_nofile = NONE
 nginx_events_worker_connections = NONE
 nginx_events_multi_accept = off
 
-plugins=bundled,dummy,rewriter
+plugins=bundled,dummy,cache,rewriter,error-handler-log,error-generator,error-generator-last,short-circuit
 
 prefix = servroot
 log_level = debug


### PR DESCRIPTION
Previously, Hybrid mode did not have any capabilities for checking the
version compatibility between CP and DP (aside from the
`_format_version` field in the declarative config generated) and this
will cause some operational safety issues when people are running a
cluster of diverse Kong versions as Kong CP may be pushing out configs
DP could not understand without knowing.

After this commit, DP node will start reporting their Kong version
running to the CP. CP will then store this information onto the
database in the new `version` field of the `/clustering/data-planes`
Admin API endpoint.

DPs will also report the installed plugins and their version upon
connecting to the CP.

CP uses the Kong version and plugin information reported by DP to make
decision on whether new config should be pushed. Under the following
circumstance, sync will be stopped:

1. If the major minor version between CP and DP differs (note bugfix
version is not used for checking), or
2. If the installed plugins, or their version between CP and DP differs

Also some of the test fixtures needs upgrading to be compatible with
the 2.x schema format. This is because in order to produce the correct
plugin versions table, the busted runner needs to load all the plugins
(including those from the `spec/fixtures` directory) like the spawned CP does.