### PR TITLE
chore(deps) bump resty.mlcache from 2.4.1 to 2.5.0

### DIFF
--- a/kong-2.2.1-0.rockspec
+++ b/kong-2.2.1-0.rockspec
@@ -32,7 +32,7 @@ dependencies = {
   "lua-resty-worker-events == 1.0.0",
   "lua-resty-healthcheck == 1.3.0",
   "lua-resty-cookie == 0.1.0",
-  "lua-resty-mlcache == 2.4.1",
+  "lua-resty-mlcache == 2.5.0",
   "lua-messagepack == 0.5.2",
   "lua-resty-openssl == 0.6.9",
   "lua-resty-counter == 0.2.1",


### PR DESCRIPTION
### Summary

#### 2.5.0 Released on: 2020/11/18

#### Added

- `get()` callback functions are now optional. Without a callback, `get()` now still performs on-cpu L1/L2 lookups (no yielding). This allows implementing new cache lookup patterns guaranteed to be on-cpu for a more constant, smoother latency tail end (e.g. values are refreshed in background timers with `set()`). Thanks Hamish Forbes and Corina Purcarea for proposing this feature and participating in its development! [#96](https://github.com/thibaultcha/lua-resty-mlcache/pull/96)

#### Fixed

- Improve `update()` robustness to worker crashes. Now, the library behind  `cache:update()` is much more robust to re-spawned workers when initialized in  the `init_by_lua` phase. [#97](https://github.com/thibaultcha/lua-resty-mlcache/pull/97)
- Document the `peek()` method `stale` argument which was not mentioned, as well as the possibility of negative TTL return values for expired items.