### PR TITLE
chore(deps) bump lyaml from 6.2.5 to 6.2.7

### DIFF
--- a/kong-2.2.1-0.rockspec
+++ b/kong-2.2.1-0.rockspec
@@ -25,7 +25,7 @@ dependencies = {
   "pgmoon == 1.11.0",
   "luatz == 0.4",
   "lua_system_constants == 0.1.4",
-  "lyaml == 6.2.5",
+  "lyaml == 6.2.7",
   "luasyslog == 1.0.0",
   "lua_pack == 1.0.5",
   "lua-resty-dns-client == 5.1.0",


### PR DESCRIPTION
### Summary

#### Bug fixes

- Don't skip YAML entries from mixed key Lua tables.
- `luke` really propagates `LDFLAGS` to module compilation commands.