### PR TITLE
chore(build) remove centos6 from build matrix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -248,7 +248,6 @@ pipeline {
                         sh 'echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin || true'
                         sh 'make setup-kong-build-tools'
                         sh 'cp $PRIVATE_KEY_FILE ../kong-build-tools/kong.private.gpg-key.asc'
-                        sh 'RESTY_IMAGE_TAG=6 make release'
                         sh 'RESTY_IMAGE_TAG=7 make release'
                         sh 'RESTY_IMAGE_TAG=8 make release'
                     }


### PR DESCRIPTION
Centos 6 is EOL as of Nov 30 - https://endoflife.software/operating-systems/linux/centos