### PR TITLE
fix(clustering) do not include the new fields in the deprecated

### DIFF
--- a/kong/api/routes/clustering.lua
+++ b/kong/api/routes/clustering.lua
@@ -43,10 +43,12 @@ return {
             return kong.response.exit(500, { message = "An unexpected error happened" })
           end
 
-          local id = row.id
-          row.id = nil
-
-          data[id] = row
+          data[row.id] = {
+            config_hash = row.config_hash,
+            hostname    = row.hostname,
+            ip          = row.ip,
+            last_seen   = row.last_seen,
+          }
         end
 
         return kong.response.exit(200, data, {


### PR DESCRIPTION
`/clustering/status` endpoint

Since we have announced the deprecation of the `/clustering/status` endpoint,
we should not make new database fields available from it. This
encourages people to switch over, but also because we no longer provide any
documentation update to the old endpoint.