### PR TITLE
fix(conf) prepare prefix to combine trusted certs

### DIFF
--- a/kong/cmd/migrations.lua
+++ b/kong/cmd/migrations.lua
@@ -4,6 +4,7 @@ local tty = require "kong.cmd.utils.tty"
 local meta = require "kong.meta"
 local conf_loader = require "kong.conf_loader"
 local kong_global = require "kong.global"
+local prefix_handler = require "kong.cmd.utils.prefix_handler"
 local migrations_utils = require "kong.cmd.utils.migrations"
 
 
@@ -87,6 +88,8 @@ local function execute(args)
 
   conf.cassandra_timeout = args.db_timeout -- connect + send + read
   conf.cassandra_schema_consensus_timeout = args.db_timeout
+
+  assert(prefix_handler.prepare_prefix(conf, args.nginx_conf))
 
   _G.kong = kong_global.new()
   kong_global.init_pdk(_G.kong, conf, nil) -- nil: latest PDK

--- a/kong/cmd/start.lua
+++ b/kong/cmd/start.lua
@@ -21,6 +21,8 @@ local function execute(args)
   conf.cassandra_timeout = args.db_timeout -- connect + send + read
   conf.cassandra_schema_consensus_timeout = args.db_timeout
 
+  assert(prefix_handler.prepare_prefix(conf, args.nginx_conf))
+
   assert(not kill.is_running(conf.nginx_pid),
          "Kong is already running in " .. conf.prefix)
 
@@ -34,8 +36,6 @@ local function execute(args)
   local err
 
   xpcall(function()
-    assert(prefix_handler.prepare_prefix(conf, args.nginx_conf))
-
     if not schema_state:is_up_to_date() and args.run_migrations then
       migrations_utils.up(schema_state, db, {
         ttl = args.lock_timeout,


### PR DESCRIPTION
The commit 1e6afa171272a12a1577c7f7e172a5a0cac4ca30 introduced a
regression for a case where we want to enable verification of database
certificates when doing SSL handshake connections. For example, if we
wanted to specify `pg_ssl = on` and `pg_ssl_verify = on` to enable
verification of the postgres certificate, the following error would be
thrown:

```
Error:
/usr/local/share/lua/5.1/kong/cmd/migrations.lua:220: [PostgreSQL error] failed to retrieve PostgreSQL server_version_num: error loading CA locations (No such file or directory)
stack traceback:
[C]: in function 'assert'
/usr/local/share/lua/5.1/kong/cmd/migrations.lua:220: in function 'cmd_exec'
/usr/local/share/lua/5.1/kong/cmd/init.lua:96: in function </usr/local/share/lua/5.1/kong/cmd/init.lua:96>
[C]: in function 'xpcall'
/usr/local/share/lua/5.1/kong/cmd/init.lua:96: in function </usr/local/share/lua/5.1/kong/cmd/init.lua:53>
/usr/local/bin/kong:9: in function 'file_gen'
init_worker_by_lua:48: in function <init_worker_by_lua:46>
[C]: in function 'xpcall'
init_worker_by_lua:55: in function <init_worker_by_lua:53>
```

The aforementioned commit added support for configuring a list of
`lua_ssl_trusted_certificate` and the paths on the list are
concatenated into a single file in a fixed location (`$PREFIX/.
ca_combined`). The configuration used for enabling verification of
database certificates was defined by the new
`lua_ssl_trusted_certificate_combined` property.

Commands such as `kong migrations bootstrap` would fail because they
don't use the `prefix_handler` module. We should call the
`prepare_function` that's inside the `prefix_handler` module in the
`cmd.migrations.lua` module. Also we need to call it earlier in the
`cmd.start.lua` since it tries to initiate a connection to the DB
before preparing the prefix in order for us to generate the
`lua_ssl_trusted_certificate_combined` configuration with the list of
all CAs before the DB connection happens.

Fix #6682 