### PR TITLE
feat(request-size) option to require content-length header

### DIFF
--- a/kong/plugins/request-size-limiting/handler.lua
+++ b/kong/plugins/request-size-limiting/handler.lua
@@ -45,7 +45,7 @@ function RequestSizeLimitingHandler:access(conf)
     check_size(tonumber(cl), conf.allowed_payload_size, headers, conf.size_unit)
   else
     if conf.require_content_length then
-      return kong.response.error(413, "A valid Content-Length header is required")
+      return kong.response.error(411, "A valid Content-Length header is required")
     end
     -- If the request body is too big, this could consume too much memory (to check)
     local data = kong.request.get_raw_body()

--- a/kong/plugins/request-size-limiting/handler.lua
+++ b/kong/plugins/request-size-limiting/handler.lua
@@ -44,6 +44,9 @@ function RequestSizeLimitingHandler:access(conf)
   if cl and tonumber(cl) then
     check_size(tonumber(cl), conf.allowed_payload_size, headers, conf.size_unit)
   else
+    if conf.require_content_length then
+      return kong.response.error(413, "A valid Content-Length header is required")
+    end
     -- If the request body is too big, this could consume too much memory (to check)
     local data = kong.request.get_raw_body()
     if data then

--- a/kong/plugins/request-size-limiting/handler.lua
+++ b/kong/plugins/request-size-limiting/handler.lua
@@ -44,7 +44,7 @@ function RequestSizeLimitingHandler:access(conf)
   if cl and tonumber(cl) then
     check_size(tonumber(cl), conf.allowed_payload_size, headers, conf.size_unit)
   else
-    if conf.require_content_length then
+    if conf.require_content_length and headers["Transfer-Encoding"] ~= "chunked" then
       return kong.response.error(411, "A valid Content-Length header is required")
     end
     -- If the request body is too big, this could consume too much memory (to check)

--- a/kong/plugins/request-size-limiting/schema.lua
+++ b/kong/plugins/request-size-limiting/schema.lua
@@ -14,6 +14,7 @@ return {
         fields = {
           { allowed_payload_size = { type = "integer", default = 128 }, },
           { size_unit = { type = "string", required = true, default = size_units[1], one_of = size_units }, },
+          { require_content_length = { type = "boolean", default = false }, },
         },
       },
     },

--- a/spec/03-plugins/12-request-size-limiting/01-access_spec.lua
+++ b/spec/03-plugins/12-request-size-limiting/01-access_spec.lua
@@ -180,7 +180,8 @@ for _, strategy in helpers.each_strategy() do
       it("works if size is lower than limit", function()
         local body = string.rep("a", (TEST_SIZE * MB))
         local res = assert(proxy_client:request {
-          method  = "POST",
+          dont_add_content_length = true,
+          method  = "GET", -- if POST, then lua-rsty-http adds content-length anyway
           path    = "/request",
           body    = body,
           headers = {
@@ -193,7 +194,8 @@ for _, strategy in helpers.each_strategy() do
       it("works if size is lower than limit and Expect header", function()
         local body = string.rep("a", (TEST_SIZE * MB))
         local res = assert(proxy_client:request {
-          method  = "POST",
+          dont_add_content_length = true,
+          method  = "GET", -- if POST, then lua-rsty-http adds content-length anyway
           path    = "/request",
           body    = body,
           headers = {
@@ -207,7 +209,8 @@ for _, strategy in helpers.each_strategy() do
       it("blocks if size is greater than limit", function()
         local body = string.rep("a", (TEST_SIZE * MB) + 1)
         local res = assert(proxy_client:request {
-          method  = "POST",
+          dont_add_content_length = true,
+          method  = "GET", -- if POST, then lua-rsty-http adds content-length anyway
           path    = "/request",
           body    = body,
           headers = {
@@ -222,7 +225,8 @@ for _, strategy in helpers.each_strategy() do
       it("blocks if size is greater than limit and Expect header", function()
         local body = string.rep("a", (TEST_SIZE * MB) + 1)
         local res = assert(proxy_client:request {
-          method  = "POST",
+          dont_add_content_length = true,
+          method  = "GET", -- if POST, then lua-rsty-http adds content-length anyway
           path    = "/request",
           body    = body,
           headers = {
@@ -239,7 +243,8 @@ for _, strategy in helpers.each_strategy() do
         it("blocks if size is greater than limit when unit in " .. unit, function()
           local body = string.rep("a", (TEST_SIZE * unit_multiplication_factor[unit]) + 1)
           local res = assert(proxy_client:request {
-            method  = "POST",
+            dont_add_content_length = true,
+            method  = "GET", -- if POST, then lua-rsty-http adds content-length anyway
             path    = "/request",
             body    = body,
             headers = {
@@ -256,7 +261,8 @@ for _, strategy in helpers.each_strategy() do
         it("works if size is less than limit when unit in " .. unit, function()
           local body = string.rep("a", (TEST_SIZE * unit_multiplication_factor[unit]))
           local res = assert(proxy_client:request {
-            method  = "POST",
+            dont_add_content_length = true,
+            method  = "GET", -- if POST, then lua-rsty-http adds content-length anyway
             path    = "/request",
             body    = body,
             headers = {
@@ -271,10 +277,11 @@ for _, strategy in helpers.each_strategy() do
     describe("Content-Length header required", function()
       it("blocks if header is not provided", function()
         local res = assert(proxy_client:request {
-          method  = "POST",
+          dont_add_content_length = true,
+          method  = "GET", -- if POST, then lua-rsty-http adds content-length anyway
           path    = "/request",
           headers = {
-            ["Host"] = "required.com"
+            ["Host"] = "required.com",
           }
         })
         assert.response(res).has.status(411)

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -688,7 +688,7 @@ function resty_http_proxy_mt:send(opts)
     end
 
     local clength = lookup(headers, "content-length")
-    if not clength then
+    if not clength and not opts.dont_add_content_length then
       headers["content-length"] = #body
     end
 


### PR DESCRIPTION
Adds an option to the "request-size-limit" plugin to require the "content-length" header. If this is set it will prevent the plugin from trying to read the full body, which actually is behaviour counter to what the plugin is supposed to do. So this new option provides better protection.