### PR TITLE
fix(cli) reset kong shm rework on reload

### DIFF
--- a/kong/api/routes/config.lua
+++ b/kong/api/routes/config.lua
@@ -107,6 +107,12 @@ return {
           })
         end
 
+        if err == "exiting" then
+          return kong.response.exit(503, {
+            message = "Kong currently exiting"
+          })
+        end
+
         if err == "no memory" then
           kong.log.err("not enough cache space for declarative config")
           return kong.response.exit(413, {

--- a/kong/api/routes/kong.lua
+++ b/kong/api/routes/kong.lua
@@ -5,7 +5,6 @@ local api_helpers = require "kong.api.api_helpers"
 local Schema = require "kong.db.schema"
 local Errors = require "kong.db.errors"
 
-local sub = string.sub
 local kong = kong
 local knode  = (kong and kong.node) and kong.node or
                require "kong.pdk.node".new()
@@ -51,17 +50,38 @@ return {
 
       do
         local kong_shm = ngx.shared.kong
-        local shm_prefix = "pid: "
-        local keys, err = kong_shm:get_keys()
-        if not keys then
-          ngx.log(ngx.ERR, "could not get kong shm keys: ", err)
+
+        local master_pid, err = kong_shm:get("pids:master")
+        if not master_pid then
+          err = err or "not found"
+          ngx.log(ngx.ERR, "could not get master process id: ", err)
+
         else
-          for i = 1, #keys do
-            if sub(keys[i], 1, #shm_prefix) == shm_prefix then
-              prng_seeds[keys[i]], err = kong_shm:get(keys[i])
-              if err then
-                ngx.log(ngx.ERR, "could not get PRNG seed from kong shm")
-              end
+          local master_seed, err = kong_shm:get("seeds:" .. master_pid)
+          if not master_seed then
+            err = err or "not found"
+            ngx.log(ngx.ERR, "could not get process id for master process: ", err)
+
+          else
+            prng_seeds["pid: " .. master_pid] = master_seed
+          end
+        end
+
+        local worker_count = ngx.worker.count() - 1
+        for i = 0, worker_count do
+          local worker_pid, err = kong_shm:get("pids:" .. i)
+          if not worker_pid then
+            err = err or "not found"
+            ngx.log(ngx.ERR, "could not get worker process id for worker #", i , ": ", err)
+
+          else
+            local worker_seed, err = kong_shm:get("seeds:" .. worker_pid)
+            if not worker_seed then
+              err = err or "not found"
+              ngx.log(ngx.ERR, "could not get PRNG seed for worker #", i, ":", err)
+
+            else
+              prng_seeds["pid: " .. worker_pid] = worker_seed
             end
           end
         end

--- a/kong/cache/init.lua
+++ b/kong/cache/init.lua
@@ -79,9 +79,9 @@ function _M.new(opts)
   local shm_names = {}
 
   for i = 1, opts.cache_pages or 1 do
-    local channel_name  = (i == 1) and "mlcache"                 or "mlcache_2"
-    local shm_name      = (i == 1) and opts.shm_name             or opts.shm_name .. "_2"
-    local shm_miss_name = (i == 1) and opts.shm_name .. "_miss"  or opts.shm_name .. "_miss_2"
+    local channel_name  = i == 1 and "mlcache"                 or "mlcache_2"
+    local shm_name      = i == 1 and opts.shm_name             or opts.shm_name .. "_2"
+    local shm_miss_name = i == 1 and opts.shm_name .. "_miss"  or opts.shm_name .. "_miss_2"
 
     if not ngx.shared[shm_name] then
       log(ERR, "shared dictionary ", shm_name, " not found")
@@ -126,18 +126,13 @@ function _M.new(opts)
     end
   end
 
-  local curr_mlcache = 1
-
-  if opts.cache_pages == 2 then
-    curr_mlcache = ngx.shared.kong:get("kong:cache:" .. opts.shm_name .. ":curr_mlcache") or 1
-  end
-
-  local self          = {
-    cluster_events    = opts.cluster_events,
-    mlcache           = mlcaches[curr_mlcache],
-    mlcaches          = mlcaches,
-    shm_names         = shm_names,
-    curr_mlcache      = curr_mlcache,
+  local page = opts.cache_pages == 2 and opts.page or 1
+  local self       = {
+    cluster_events = opts.cluster_events,
+    mlcache        = mlcaches[page],
+    mlcaches       = mlcaches,
+    shm_names      = shm_names,
+    page           = page,
   }
 
   local ok, err = self.cluster_events:subscribe("invalidations", function(key)
@@ -155,9 +150,12 @@ function _M.new(opts)
 end
 
 
-function _M:save_curr_page()
-  return ngx.shared.kong:set(
-    "kong:cache:" .. self.shm_names[1] .. ":curr_mlcache", self.curr_mlcache)
+function _M:get_page(shadow)
+  if #self.mlcaches == 2 and shadow then
+    return self.page == 2 and 1 or 2
+  end
+
+  return self.page or 1
 end
 
 
@@ -166,17 +164,8 @@ function _M:get(key, opts, cb, ...)
     error("key must be a string", 2)
   end
 
-  local shadow = (opts or {}).shadow
-
-  local current_page = self.curr_mlcache or 1
-  local get_page
-  if shadow and #self.mlcaches == 2 then
-    get_page = current_page == 1 and 2 or 1
-  else
-    get_page = current_page
-  end
-
-  local v, err = self.mlcaches[get_page]:get(key, opts, cb, ...)
+  local page = self:get_page((opts or {}).shadow)
+  local v, err = self.mlcaches[page]:get(key, opts, cb, ...)
   if err then
     return nil, "failed to get from node cache: " .. err
   end
@@ -194,17 +183,8 @@ function _M:get_bulk(bulk, opts)
     error("opts must be a table", 2)
   end
 
-  local shadow = (opts or {}).shadow
-
-  local current_page = self.curr_mlcache or 1
-  local get_bulk_page
-  if shadow and #self.mlcaches == 2 then
-    get_bulk_page = current_page == 1 and 2 or 1
-  else
-    get_bulk_page = current_page
-  end
-
-  local res, err = self.mlcaches[get_bulk_page]:get_bulk(bulk, opts)
+  local page = self:get_page((opts or {}).shadow)
+  local res, err = self.mlcaches[page]:get_bulk(bulk, opts)
   if err then
     return nil, "failed to get_bulk from node cache: " .. err
   end
@@ -220,16 +200,8 @@ function _M:safe_set(key, value, shadow)
     return nil, err
   end
 
-  local current_page = self.curr_mlcache or 1
-
-  local set_page
-  if shadow and #self.mlcaches == 2 then
-    set_page = current_page == 1 and 2 or 1
-  else
-    set_page = current_page
-  end
-
-  local shm_name = self.shm_names[set_page]
+  local page = self:get_page(shadow)
+  local shm_name = self.shm_names[page]
   return ngx.shared[shm_name]:safe_set(shm_name .. key, str_marshalled)
 end
 
@@ -239,15 +211,8 @@ function _M:probe(key, shadow)
     error("key must be a string", 2)
   end
 
-  local current_page = self.curr_mlcache or 1
-  local probe_page
-  if shadow and #self.mlcaches == 2 then
-    probe_page = current_page == 1 and 2 or 1
-  else
-    probe_page = current_page
-  end
-
-  local ttl, err, v = self.mlcaches[probe_page]:peek(key)
+  local page = self:get_page(shadow)
+  local ttl, err, v = self.mlcaches[page]:peek(key)
   if err then
     return nil, "failed to probe from node cache: " .. err
   end
@@ -263,15 +228,8 @@ function _M:invalidate_local(key, shadow)
 
   log(DEBUG, "invalidating (local): '", key, "'")
 
-  local current_page = self.curr_mlcache or 1
-  local delete_page
-  if shadow and #self.mlcaches == 2 then
-    delete_page = current_page == 1 and 2 or 1
-  else
-    delete_page = current_page
-  end
-
-  local ok, err = self.mlcaches[delete_page]:delete(key)
+  local page = self:get_page(shadow)
+  local ok, err = self.mlcaches[page]:delete(key)
   if not ok then
     log(ERR, "failed to delete entity from node cache: ", err)
   end
@@ -301,15 +259,8 @@ end
 function _M:purge(shadow)
   log(NOTICE, "purging (local) cache")
 
-  local current_page = self.curr_mlcache or 1
-  local purge_page
-  if shadow and #self.mlcaches == 2 then
-    purge_page = current_page == 1 and 2 or 1
-  else
-    purge_page = current_page
-  end
-
-  local ok, err = self.mlcaches[purge_page]:purge(true)
+  local page = self:get_page(shadow)
+  local ok, err = self.mlcaches[page]:purge(true)
   if not ok then
     log(ERR, "failed to purge cache: ", err)
   end
@@ -322,12 +273,8 @@ function _M:flip()
   end
 
   log(DEBUG, "flipping current cache")
-
-  local current_page = self.curr_mlcache or 1
-  local next_page = current_page == 1 and 2 or 1
-
-  self.curr_mlcache = next_page
-  self.mlcache = self.mlcaches[next_page]
+  self.page = self:get_page() == 2 and 1 or 2
+  self.mlcache = self.mlcaches[self.page]
 end
 
 

--- a/kong/cmd/reload.lua
+++ b/kong/cmd/reload.lua
@@ -29,6 +29,10 @@ local function execute(args)
     prefix = args.prefix
   }))
 
+  if not new_config.declarative_config then
+    conf.declarative_config = nil
+  end
+
   assert(prefix_handler.prepare_prefix(conf, args.nginx_conf))
   assert(nginx_signals.reload(conf))
 

--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -170,6 +170,8 @@ local constants = {
   },
 
   DECLARATIVE_PAGE_KEY = "declarative:page",
+  DECLARATIVE_LOAD_KEY = "declarative_config:loaded",
+  DECLARATIVE_HASH_KEY = "declarative_config:hash",
 
   CLUSTER_ID_PARAM_KEY = "cluster_id",
 

--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -169,6 +169,8 @@ local constants = {
     ttl = 60,
   },
 
+  DECLARATIVE_PAGE_KEY = "declarative:page",
+
   CLUSTER_ID_PARAM_KEY = "cluster_id",
 
   CLUSTERING_SYNC_STATUS = {

--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -834,6 +834,12 @@ do
       return nil, "failed to persist core cache page number inside shdict: " .. err
     end
 
+    ok, err = kong.cache:save_curr_page()
+    if not ok then
+      ngx.shared.kong:delete(DECLARATIVE_FLIPS_NAME)
+      return nil, "failed to persist kong cache page number inside shdict: " .. err
+    end
+
     if ngx.worker.exiting() then
       ngx.shared.kong:delete(DECLARATIVE_FLIPS_NAME)
       return nil, "exiting"

--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -761,6 +761,10 @@ do
   local DECLARATIVE_FLIPS_TTL = constants.DECLARATIVE_FLIPS.ttl
 
   function declarative.load_into_cache_with_events(entities, meta, hash)
+    if ngx.worker.exiting() then
+      return nil, "exiting"
+    end
+
     local ok, err = ngx.shared.kong:add(DECLARATIVE_FLIPS_NAME, 0, DECLARATIVE_FLIPS_TTL)
     if not ok then
       if err == "exists" then
@@ -805,6 +809,11 @@ do
       assert(bytes == #json, "incomplete config sent to the stream subsystem")
     end
 
+    if ngx.worker.exiting() then
+      ngx.shared.kong:delete(DECLARATIVE_FLIPS_NAME)
+      return nil, "exiting"
+    end
+
     local default_ws
     ok, err, default_ws = declarative.load_into_cache(entities, meta, hash, SHADOW)
     if ok then
@@ -825,6 +834,11 @@ do
       return nil, "failed to persist core cache page number inside shdict: " .. err
     end
 
+    if ngx.worker.exiting() then
+      ngx.shared.kong:delete(DECLARATIVE_FLIPS_NAME)
+      return nil, "exiting"
+    end
+
     local sleep_left = DECLARATIVE_FLIPS_TTL
     local sleep_time = 0.0375
 
@@ -840,8 +854,13 @@ do
       end
 
       ngx.sleep(sleep_time)
-      sleep_left = sleep_left - sleep_time
 
+      if ngx.worker.exiting() then
+        ngx.shared.kong:delete(DECLARATIVE_FLIPS_NAME)
+        return nil, "exiting"
+      end
+
+      sleep_left = sleep_left - sleep_time
     end
 
     ngx.shared.kong:delete(DECLARATIVE_FLIPS_NAME)

--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -810,6 +810,7 @@ do
     if ok then
       ok, err = kong.worker_events.post("declarative", "flip_config", default_ws)
       if ok ~= "done" then
+        ngx.shared.kong:delete(DECLARATIVE_FLIPS_NAME)
         return nil, "failed to flip declarative config cache pages: " .. (err or ok)
       end
 
@@ -820,7 +821,8 @@ do
 
     ok, err = kong.core_cache:save_curr_page()
     if not ok then
-      return nil, "failed to persist cache page number inside shdict: " .. err
+      ngx.shared.kong:delete(DECLARATIVE_FLIPS_NAME)
+      return nil, "failed to persist core cache page number inside shdict: " .. err
     end
 
     local sleep_left = DECLARATIVE_FLIPS_TTL

--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -759,6 +759,7 @@ end
 do
   local DECLARATIVE_FLIPS_NAME = constants.DECLARATIVE_FLIPS.name
   local DECLARATIVE_FLIPS_TTL = constants.DECLARATIVE_FLIPS.ttl
+  local DECLARATIVE_PAGE_KEY = constants.DECLARATIVE_PAGE_KEY
 
   function declarative.load_into_cache_with_events(entities, meta, hash)
     if ngx.worker.exiting() then
@@ -828,16 +829,10 @@ do
       return nil, err
     end
 
-    ok, err = kong.core_cache:save_curr_page()
+    ok, err = ngx.shared.kong:set(DECLARATIVE_PAGE_KEY, kong.cache:get_page())
     if not ok then
       ngx.shared.kong:delete(DECLARATIVE_FLIPS_NAME)
-      return nil, "failed to persist core cache page number inside shdict: " .. err
-    end
-
-    ok, err = kong.cache:save_curr_page()
-    if not ok then
-      ngx.shared.kong:delete(DECLARATIVE_FLIPS_NAME)
-      return nil, "failed to persist kong cache page number inside shdict: " .. err
+      return nil, "failed to persist cache page number: " .. err
     end
 
     if ngx.worker.exiting() then

--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -18,7 +18,7 @@ local REMOVE_FIRST_LINE_PATTERN = "^[^\n]+\n(.+)$"
 local PREFIX = ngx.config.prefix()
 local SUBSYS = ngx.config.subsystem
 local WORKER_COUNT = ngx.worker.count()
-
+local DECLARATIVE_HASH_KEY = constants.DECLARATIVE_HASH_KEY
 
 local declarative = {}
 
@@ -480,7 +480,7 @@ end
 
 
 function declarative.get_current_hash()
-  return ngx.shared.kong:get("declarative_config:hash")
+  return ngx.shared.kong:get(DECLARATIVE_HASH_KEY)
 end
 
 
@@ -745,9 +745,9 @@ function declarative.load_into_cache(entities, meta, hash, shadow)
     return nil, err
   end
 
-  local ok, err = ngx.shared.kong:safe_set("declarative_config:hash", hash or true)
+  local ok, err = ngx.shared.kong:safe_set(DECLARATIVE_HASH_KEY, hash or true)
   if not ok then
-    return nil, "failed to set declarative_config:hash in shm: " .. err
+    return nil, "failed to set " .. DECLARATIVE_HASH_KEY .. " in shm: " .. err
   end
 
 

--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -845,7 +845,7 @@ do
 
     while sleep_left > 0 do
       local flips = ngx.shared.kong:get(DECLARATIVE_FLIPS_NAME)
-      if  flips == nil or flips == WORKER_COUNT then
+      if flips == nil or flips >= WORKER_COUNT then
         break
       end
 

--- a/kong/global.lua
+++ b/kong/global.lua
@@ -17,6 +17,12 @@ local KONG_VERSION_NUM = tonumber(string.format("%d%.2d%.2d",
                                   meta._VERSION_TABLE.patch))
 
 
+local LOCK_OPTS = {
+  exptime = 10,
+  timeout = 5,
+}
+
+
 -- Runloop interface
 
 
@@ -215,10 +221,7 @@ function _GLOBAL.init_cache(kong_config, cluster_events, worker_events)
     resurrect_ttl   = kong_config.resurrect_ttl,
     page            = page,
     cache_pages     = cache_pages,
-    resty_lock_opts = {
-      exptime = 10,
-      timeout = 5,
-    },
+    resty_lock_opts = LOCK_OPTS,
   }
 end
 
@@ -244,10 +247,7 @@ function _GLOBAL.init_core_cache(kong_config, cluster_events, worker_events)
     resurrect_ttl   = kong_config.resurrect_ttl,
     page            = page,
     cache_pages     = cache_pages,
-    resty_lock_opts = {
-      exptime = 10,
-      timeout = 5,
-    },
+    resty_lock_opts = LOCK_OPTS,
   }
 end
 

--- a/kong/global.lua
+++ b/kong/global.lua
@@ -4,7 +4,7 @@ local PDK = require "kong.pdk"
 local phase_checker = require "kong.pdk.private.phases"
 local kong_cache = require "kong.cache"
 local kong_cluster_events = require "kong.cluster_events"
-
+local kong_constants = require "kong.constants"
 
 local type = type
 local setmetatable = setmetatable
@@ -196,22 +196,26 @@ end
 function _GLOBAL.init_cache(kong_config, cluster_events, worker_events)
   local db_cache_ttl = kong_config.db_cache_ttl
   local db_cache_neg_ttl = kong_config.db_cache_neg_ttl
+  local page = 1
   local cache_pages = 1
+
   if kong_config.database == "off" then
     db_cache_ttl = 0
     db_cache_neg_ttl = 0
     cache_pages = 2
+    page = ngx.shared.kong:get(kong_constants.DECLARATIVE_PAGE_KEY) or page
   end
 
   return kong_cache.new {
-    shm_name          = "kong_db_cache",
-    cluster_events    = cluster_events,
-    worker_events     = worker_events,
-    ttl               = db_cache_ttl,
-    neg_ttl           = db_cache_neg_ttl or db_cache_ttl,
-    resurrect_ttl     = kong_config.resurrect_ttl,
-    cache_pages       = cache_pages,
-    resty_lock_opts   = {
+    shm_name        = "kong_db_cache",
+    cluster_events  = cluster_events,
+    worker_events   = worker_events,
+    ttl             = db_cache_ttl,
+    neg_ttl         = db_cache_neg_ttl or db_cache_ttl,
+    resurrect_ttl   = kong_config.resurrect_ttl,
+    page            = page,
+    cache_pages     = cache_pages,
+    resty_lock_opts = {
       exptime = 10,
       timeout = 5,
     },
@@ -222,22 +226,25 @@ end
 function _GLOBAL.init_core_cache(kong_config, cluster_events, worker_events)
   local db_cache_ttl = kong_config.db_cache_ttl
   local db_cache_neg_ttl = kong_config.db_cache_neg_ttl
+  local page = 1
   local cache_pages = 1
   if kong_config.database == "off" then
     db_cache_ttl = 0
     db_cache_neg_ttl = 0
     cache_pages = 2
+    page = ngx.shared.kong:get(kong_constants.DECLARATIVE_PAGE_KEY) or page
   end
 
   return kong_cache.new {
-    shm_name          = "kong_core_db_cache",
-    cluster_events    = cluster_events,
-    worker_events     = worker_events,
-    ttl               = db_cache_ttl,
-    neg_ttl           = db_cache_neg_ttl or db_cache_ttl,
-    resurrect_ttl     = kong_config.resurrect_ttl,
-    cache_pages       = cache_pages,
-    resty_lock_opts   = {
+    shm_name        = "kong_core_db_cache",
+    cluster_events  = cluster_events,
+    worker_events   = worker_events,
+    ttl             = db_cache_ttl,
+    neg_ttl         = db_cache_neg_ttl or db_cache_ttl,
+    resurrect_ttl   = kong_config.resurrect_ttl,
+    page            = page,
+    cache_pages     = cache_pages,
+    resty_lock_opts = {
       exptime = 10,
       timeout = 5,
     },

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -188,6 +188,14 @@ do
   }
 
   reset_kong_shm = function()
+    local old_page = ngx.shared.kong:get("kong:cache:kong_db_cache:curr_mlcache")
+    if old_page == nil then
+      -- fresh node, just storing the initial page
+      ngx.shared.kong:set("kong:cache:kong_db_cache:curr_mlcache", 1)
+      ngx.shared.kong:set("kong:cache:kong_core_db_cache:curr_mlcache", 1)
+      return
+    end
+
     local preserved = {}
 
     for _, key in ipairs(preserve_keys) do

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -167,10 +167,10 @@ end
 
 local reset_kong_shm
 do
+  local DECLARATIVE_PAGE_KEY = constants.DECLARATIVE_PAGE_KEY
   local preserve_keys = {
     "kong:node_id",
-    "kong:cache:kong_db_cache:curr_mlcache",
-    "kong:cache:kong_core_db_cache:curr_mlcache",
+    DECLARATIVE_PAGE_KEY,
     "cluster_events:at",
     "events:requests",
     "events:requests:http",
@@ -188,11 +188,10 @@ do
   }
 
   reset_kong_shm = function()
-    local old_page = ngx.shared.kong:get("kong:cache:kong_db_cache:curr_mlcache")
-    if old_page == nil then
+    local old_cache_page = ngx.shared.kong:get(DECLARATIVE_PAGE_KEY)
+    if old_cache_page == nil then
       -- fresh node, just storing the initial page
-      ngx.shared.kong:set("kong:cache:kong_db_cache:curr_mlcache", 1)
-      ngx.shared.kong:set("kong:cache:kong_core_db_cache:curr_mlcache", 1)
+      ngx.shared.kong:set(DECLARATIVE_PAGE_KEY, 1)
       return
     end
 
@@ -202,7 +201,7 @@ do
       preserved[key] = ngx.shared.kong:get(key) -- ignore errors
     end
 
-    local current_page = preserved["kong:cache:kong_db_cache:curr_mlcache"] or 1
+    local current_page = preserved[DECLARATIVE_PAGE_KEY] or 1
     local suffix = current_page == 1 and "" or "_2"
 
     local shms = {

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -119,6 +119,9 @@ if not enable_keepalive then
 end
 
 
+local DECLARATIVE_LOAD_KEY = constants.DECLARATIVE_LOAD_KEY
+
+
 local declarative_entities
 local declarative_meta
 local schema_state
@@ -348,7 +351,7 @@ local function load_declarative_config(kong_config, entities, meta)
   }
 
   local ok, err = concurrency.with_worker_mutex(opts, function()
-    local value = ngx.shared.kong:get("declarative_config:loaded")
+    local value = ngx.shared.kong:get(DECLARATIVE_LOAD_KEY)
     if value then
       return true
     end
@@ -363,7 +366,7 @@ local function load_declarative_config(kong_config, entities, meta)
                       kong_config.declarative_config)
     end
 
-    ok, err = ngx.shared.kong:safe_set("declarative_config:loaded", true)
+    ok, err = ngx.shared.kong:safe_set(DECLARATIVE_LOAD_KEY, true)
     if not ok then
       kong.log.warn("failed marking declarative_config as loaded: ", err)
     end

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -119,7 +119,11 @@ if not enable_keepalive then
 end
 
 
+local WORKER_COUNT = ngx.worker.count()
 local DECLARATIVE_LOAD_KEY = constants.DECLARATIVE_LOAD_KEY
+local DECLARATIVE_HASH_KEY = constants.DECLARATIVE_HASH_KEY
+local DECLARATIVE_FLIPS_KEY = constants.DECLARATIVE_FLIPS.name
+local DECLARATIVE_FLIPS_TTL = constants.DECLARATIVE_FLIPS.ttl
 
 
 local declarative_entities
@@ -173,8 +177,6 @@ do
   local DECLARATIVE_PAGE_KEY = constants.DECLARATIVE_PAGE_KEY
   local preserve_keys = {
     "kong:node_id",
-    DECLARATIVE_PAGE_KEY,
-    "cluster_events:at",
     "events:requests",
     "events:requests:http",
     "events:requests:https",
@@ -184,53 +186,56 @@ do
     "events:requests:grpcs",
     "events:requests:ws",
     "events:requests:wss",
+    "events:requests:go_plugins",
     "events:streams",
     "events:streams:tcp",
     "events:streams:tls",
-    "events:requests:go_plugins",
   }
 
-  reset_kong_shm = function()
-    local old_cache_page = ngx.shared.kong:get(DECLARATIVE_PAGE_KEY)
-    if old_cache_page == nil then
-      -- fresh node, just storing the initial page
-      ngx.shared.kong:set(DECLARATIVE_PAGE_KEY, 1)
+  reset_kong_shm = function(config)
+    local kong_shm = ngx.shared.kong
+    local dbless = config.database == "off"
+    local declarative_config = dbless and config.declarative_config
+
+    if dbless then -- prevent POST /config from happening while initializing
+      kong_shm:add(DECLARATIVE_FLIPS_KEY, 0, DECLARATIVE_FLIPS_TTL)
+    end
+
+    local old_page = kong_shm:get(DECLARATIVE_PAGE_KEY)
+    if old_page == nil then -- fresh node, just storing the initial page
+      kong_shm:set(DECLARATIVE_PAGE_KEY, 1)
       return
     end
 
     local preserved = {}
 
-    for _, key in ipairs(preserve_keys) do
-      preserved[key] = ngx.shared.kong:get(key) -- ignore errors
-    end
+    local new_page
+    if declarative_config then
+      new_page = old_page == 1 and 2 or 1
 
-    local current_page = preserved[DECLARATIVE_PAGE_KEY] or 1
-    local suffix = current_page == 1 and "" or "_2"
+    else
+      new_page = old_page
 
-    local shms = {
-      "kong",
-      "kong_locks",
-      "kong_healthchecks",
-      "kong_cluster_events",
-      "kong_rate_limiting_counters",
-      "kong_core_db_cache" .. suffix,
-      "kong_core_db_cache_miss" .. suffix,
-      "kong_db_cache" .. suffix,
-      "kong_db_cache_miss" .. suffix,
-      "kong_clustering",
-    }
-
-    for _, shm in ipairs(shms) do
-      local dict = ngx.shared[shm]
-      if dict then
-        dict:flush_all()
-        dict:flush_expired(0)
+      if dbless then
+        preserved[DECLARATIVE_LOAD_KEY] = kong_shm:get(DECLARATIVE_LOAD_KEY)
+        preserved[DECLARATIVE_HASH_KEY] = kong_shm:get(DECLARATIVE_HASH_KEY)
       end
     end
 
+    preserved[DECLARATIVE_PAGE_KEY] = new_page
+
     for _, key in ipairs(preserve_keys) do
-      ngx.shared.kong:set(key, preserved[key])
+      preserved[key] = kong_shm:get(key) -- ignore errors
     end
+
+    kong_shm:flush_all()
+    if dbless then
+      kong_shm:add(DECLARATIVE_FLIPS_KEY, 0, DECLARATIVE_FLIPS_TTL)
+    end
+    for key, value in pairs(preserved) do
+      kong_shm:set(key, value)
+    end
+    kong_shm:flush_expired(0)
   end
 end
 
@@ -350,8 +355,9 @@ local function load_declarative_config(kong_config, entities, meta)
     name = "declarative_config",
   }
 
+  local kong_shm = ngx.shared.kong
   local ok, err = concurrency.with_worker_mutex(opts, function()
-    local value = ngx.shared.kong:get(DECLARATIVE_LOAD_KEY)
+    local value = kong_shm:get(DECLARATIVE_LOAD_KEY)
     if value then
       return true
     end
@@ -366,7 +372,7 @@ local function load_declarative_config(kong_config, entities, meta)
                       kong_config.declarative_config)
     end
 
-    ok, err = ngx.shared.kong:safe_set(DECLARATIVE_LOAD_KEY, true)
+    ok, err = kong_shm:safe_set(DECLARATIVE_LOAD_KEY, true)
     if not ok then
       kong.log.warn("failed marking declarative_config as loaded: ", err)
     end
@@ -375,6 +381,13 @@ local function load_declarative_config(kong_config, entities, meta)
   end)
 
   if ok then
+    if kong_shm:get(DECLARATIVE_FLIPS_KEY) then
+      local flips = kong_shm:incr(DECLARATIVE_FLIPS_KEY, 1)
+      if flips and flips >= WORKER_COUNT then
+        kong_shm:delete(DECLARATIVE_FLIPS_KEY)
+      end
+    end
+
     local default_ws = kong.db.workspaces:select_by_name("default")
     kong.default_workspace = default_ws and default_ws.id or kong.default_workspace
 
@@ -414,13 +427,6 @@ local Kong = {}
 
 
 function Kong.init()
-  reset_kong_shm()
-
-  -- special math.randomseed from kong.globalpatches not taking any argument.
-  -- Must only be called in the init or init_worker phases, to avoid
-  -- duplicated seeds.
-  math.randomseed()
-
   local pl_path = require "pl.path"
   local conf_loader = require "kong.conf_loader"
 
@@ -433,6 +439,13 @@ function Kong.init()
   -- retrieve kong_config
   local conf_path = pl_path.join(ngx.config.prefix(), ".kong_env")
   local config = assert(conf_loader(conf_path, nil, { from_kong_env = true }))
+
+  reset_kong_shm(config)
+
+  -- special math.randomseed from kong.globalpatches not taking any argument.
+  -- Must only be called in the init or init_worker phases, to avoid
+  -- duplicated seeds.
+  math.randomseed()
 
   kong_global.init_pdk(kong, config, nil) -- nil: latest PDK
 

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -43,6 +43,7 @@ local NOOP = function() end
 
 local ERR   = ngx.ERR
 local CRIT  = ngx.CRIT
+local NOTICE = ngx.NOTICE
 local WARN  = ngx.WARN
 local DEBUG = ngx.DEBUG
 local COMMA = byte(",")
@@ -434,6 +435,11 @@ local function register_events()
 
   if db.strategy == "off" then
     worker_events.register(function(default_ws)
+      if ngx.worker.exiting() then
+        log(NOTICE, "declarative flip config canceled: process exiting")
+        return true
+      end
+
       local ok, err = concurrency.with_coroutine_mutex(FLIP_CONFIG_OPTS, function()
         balancer.stop_healthcheckers()
 

--- a/spec/02-integration/02-cmd/03-reload_spec.lua
+++ b/spec/02-integration/02-cmd/03-reload_spec.lua
@@ -316,7 +316,9 @@ describe("kong reload #" .. strategy, function()
             - example.test
       ]], yaml_file)
 
-      assert(kong_reload(strategy, "reload --prefix " .. helpers.test_conf.prefix))
+      assert(kong_reload(strategy, "reload --prefix " .. helpers.test_conf.prefix, {
+        declarative_config = yaml_file,
+      }))
 
       helpers.wait_until(function()
         pok, admin_client = pcall(helpers.admin_client)
@@ -384,7 +386,102 @@ describe("kong reload #" .. strategy, function()
         return true
       end)
 
+      assert(kong_reload(strategy, "reload --prefix " .. helpers.test_conf.prefix))
+
       admin_client = assert(helpers.admin_client())
+      local res = assert(admin_client:send {
+        method = "GET",
+        path = "/services",
+      })
+      assert.res_status(200, res)
+
+      local body = assert.res_status(200, res)
+      local json = cjson.decode(body)
+      assert.same(1, #json.data)
+      assert.same(ngx.null, json.next)
+      admin_client:close()
+
+      return "my-service" == json.data[1].name
+    end)
+
+    it("preserves declarative config from memory even when kong was started with a declarative_config", function()
+      local yaml_file = helpers.make_yaml_file [[
+        _format_version: "1.1"
+        services:
+        - name: my-service-on-start
+          url: http://127.0.0.1:15555
+          routes:
+          - name: example-route
+            hosts:
+            - example.test
+      ]]
+
+      local pok, admin_client
+
+      finally(function()
+        helpers.stop_kong(helpers.test_conf.prefix, true)
+        if admin_client then
+          admin_client:close()
+        end
+      end)
+
+      assert(helpers.start_kong({
+        database = "off",
+        nginx_worker_processes = 1,
+        declarative_config = yaml_file,
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+      }))
+
+      helpers.wait_until(function()
+        pok, admin_client = pcall(helpers.admin_client)
+        if not pok then
+          return false
+        end
+
+        local res = assert(admin_client:send {
+          method = "GET",
+          path = "/services",
+        })
+        assert.res_status(200, res)
+
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.same(1, #json.data)
+        assert.same(ngx.null, json.next)
+
+        admin_client:close()
+
+        return "my-service-on-start" == json.data[1].name
+      end, 10)
+
+      helpers.wait_until(function()
+        pok, admin_client = pcall(helpers.admin_client)
+        if not pok then
+          return false
+        end
+
+        local res = assert(admin_client:send {
+          method = "POST",
+          path = "/config",
+          headers = {
+            ["Content-Type"] = "application/json",
+          },
+          body = {
+            _format_version = "1.1",
+            services = {
+              {
+                name = "my-service",
+                url = "http://127.0.0.1:15555",
+              }
+            }
+          },
+        }, 10)
+        assert.res_status(201, res)
+
+        admin_client:close()
+
+        return true
+      end)
 
       assert(kong_reload(strategy, "reload --prefix " .. helpers.test_conf.prefix))
 
@@ -477,7 +574,9 @@ describe("kong reload #" .. strategy, function()
             weight: 100
       ]], yaml_file)
 
-      assert(kong_reload(strategy, "reload --prefix " .. helpers.test_conf.prefix))
+      assert(kong_reload(strategy, "reload --prefix " .. helpers.test_conf.prefix, {
+        declarative_config = yaml_file,
+      }))
 
       helpers.wait_until(function()
         pok, admin_client = pcall(helpers.admin_client)
@@ -608,8 +707,9 @@ describe("key-auth plugin invalidation on dbless reload #off", function()
         keyauth_credentials:
         - key: my-new-key
     ]], yaml_file)
-    assert(kong_reload("off", "reload --prefix " .. helpers.test_conf.prefix))
-
+    assert(kong_reload("off", "reload --prefix " .. helpers.test_conf.prefix, {
+      declarative_config = yaml_file,
+    }))
 
     local res
 


### PR DESCRIPTION
### Summary

The `reset_kong_shm` logic was reworked after finding out multiple issues with it. One of such issue was reported here: #6464

And there are instructions how to reproduce it. We found further issues when doing parallel reloads, uploads of new configs and crashing workers at the same time.

This also removes flushing of non-paged shared dictionaries as that is problematic with reloads, as there can be old and new workers at the same time. It also prevents the usage of `:8001/config` during the reload.

There are some commits before this final fix for the issues that were found during fixing the main issue or along the way (I will make another PR for other issues that I also found during this work).

### Issues Resolved

Fix #6464