### PR TITLE
feat(clustering) add more fields on Control Plane API that returns the

### DIFF
--- a/kong/clustering.lua
+++ b/kong/clustering.lua
@@ -12,6 +12,7 @@ local openssl_x509 = require("resty.openssl.x509")
 local system_constants = require("lua_system_constants")
 local ffi = require("ffi")
 local pl_tablex = require("pl.tablex")
+local kong_constants = require("kong.constants")
 local string = string
 local assert = assert
 local setmetatable = setmetatable
@@ -34,7 +35,6 @@ local table_insert = table.insert
 local table_remove = table.remove
 local inflate_gzip = utils.inflate_gzip
 local deflate_gzip = utils.deflate_gzip
-local pl_tablex_compare = pl_tablex.compare
 
 
 local KONG_VERSION = kong.version
@@ -58,6 +58,7 @@ local PLUGINS_LIST
 local clients = setmetatable({}, WEAK_KEY_MT)
 local prefix = ngx.config.prefix()
 local CONFIG_CACHE = prefix .. "/config.cache.json.gz"
+local CLUSTERING_SYNC_STATUS = kong_constants.CLUSTERING_SYNC_STATUS
 local declarative_config
 local next_config
 
@@ -332,11 +333,6 @@ local function validate_shared_cert()
 end
 
 
-local function plugin_entry_comparator(a, b)
-  return a.name == b.name and a.version == b.version
-end
-
-
 local MAJOR_MINOR_PATTERN = "^(%d+%.%d+)%.%d+"
 local function should_send_config_update(node_version, node_plugins)
   if not node_version or not node_plugins then
@@ -351,14 +347,23 @@ local function should_send_config_update(node_version, node_plugins)
   local minor_node = node_version:match(MAJOR_MINOR_PATTERN)
   if minor_cp ~= minor_node then
     return false, "version mismatches, CP version: " .. minor_cp ..
-                  " DP version: " .. minor_node
+                  " DP version: " .. minor_node,
+                  CLUSTERING_SYNC_STATUS.KONG_VERSION_INCOMPATIBLE
   end
 
-  if not pl_tablex_compare(PLUGINS_LIST, node_plugins,
-                           plugin_entry_comparator)
-  then
-    return false, "CP and DP does not have same set of plugins installed" ..
-                  " or their versions might differ"
+  for i, p in ipairs(PLUGINS_LIST) do
+    local np = node_plugins[i]
+    if p.name ~= np.name then
+      return false, "CP and DP does not have same set of plugins installed",
+                    CLUSTERING_SYNC_STATUS.PLUGIN_SET_INCOMPATIBLE
+    end
+
+    if p.version ~= np.version then
+      return false, "plugin \"" .. p.name .. "\" version differs between " ..
+                    "CP and DP, CP has version " .. tostring(p.version) ..
+                    " while DP has version " .. tostring(np.version),
+                    CLUSTERING_SYNC_STATUS.PLUGIN_VERSION_INCOMPATIBLE
+    end
   end
 
   return true
@@ -417,9 +422,10 @@ function _M.handle_cp_websocket()
 
   clients[wb] = queue
 
-  local res
-  res, err = should_send_config_update(node_version, node_plugins)
+  local res, sync_status
+  res, err, sync_status = should_send_config_update(node_version, node_plugins)
   if res then
+    sync_status = CLUSTERING_SYNC_STATUS.NORMAL
     local config_table
     -- unconditionally send config update to new clients to
     -- ensure they have latest version running
@@ -503,6 +509,7 @@ function _M.handle_cp_websocket()
           hostname = node_hostname,
           ip = node_ip,
           version = node_version,
+          sync_status = sync_status,
         }, { ttl = kong.configuration.cluster_data_plane_purge_delay, })
         if not ok then
           ngx_log(ngx_ERR, "unable to update clustering data plane status: ", err)

--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -170,8 +170,20 @@ local constants = {
   },
 
   CLUSTER_ID_PARAM_KEY = "cluster_id",
+
+  CLUSTERING_SYNC_STATUS = {
+    { UNKNOWN                     = "unknown", },
+    { NORMAL                      = "normal", },
+    { KONG_VERSION_INCOMPATIBLE   = "kong_version_incompatible", },
+    { PLUGIN_SET_INCOMPATIBLE     = "plugin_set_incompatible", },
+    { PLUGIN_VERSION_INCOMPATIBLE = "plugin_version_incompatible", },
+  },
 }
 
+for _, v in ipairs(constants.CLUSTERING_SYNC_STATUS) do
+  local k, v = next(v)
+  constants.CLUSTERING_SYNC_STATUS[k] = v
+end
 
 -- Make the CORE_ENTITIES table usable both as an ordered array and as a set
 for _, v in ipairs(constants.CORE_ENTITIES) do

--- a/kong/db/migrations/core/013_220_to_230.lua
+++ b/kong/db/migrations/core/013_220_to_230.lua
@@ -39,6 +39,14 @@ return {
         -- Do nothing, accept existing state
       END;
       $$;
+
+      DO $$
+      BEGIN
+        ALTER TABLE IF EXISTS ONLY "clustering_data_planes" ADD "sync_status" TEXT NOT NULL DEFAULT 'unknown';
+      EXCEPTION WHEN DUPLICATE_COLUMN THEN
+        -- Do nothing, accept existing state
+      END;
+      $$;
     ]], CLUSTER_ID),
   },
   cassandra = {
@@ -56,6 +64,7 @@ return {
       ALTER TABLE certificates ADD cert_alt TEXT;
       ALTER TABLE certificates ADD key_alt TEXT;
       ALTER TABLE clustering_data_planes ADD version text;
+      ALTER TABLE clustering_data_planes ADD sync_status text;
     ]], CLUSTER_ID),
   }
 }

--- a/kong/db/schema/entities/clustering_data_planes.lua
+++ b/kong/db/schema/entities/clustering_data_planes.lua
@@ -1,4 +1,13 @@
 local typedefs      = require "kong.db.schema.typedefs"
+local CLUSTERING_SYNC_STATUS = require "kong.constants".CLUSTERING_SYNC_STATUS
+local SYNC_STATUS_CHOICES = {}
+
+
+for _, v in ipairs(CLUSTERING_SYNC_STATUS) do
+  _, v = next(v)
+  table.insert(SYNC_STATUS_CHOICES, v)
+end
+
 
 return {
   name               = "clustering_data_planes",
@@ -15,5 +24,11 @@ return {
     { config_hash = { type = "string", len_eq = 32, } },
     { hostname = typedefs.host { required = true, } },
     { version = typedefs.semantic_version },
+    { sync_status = { type = "string",
+                      required = true,
+                      one_of = SYNC_STATUS_CHOICES,
+                      default = "unknown",
+                    }
+    },
   },
 }

--- a/spec/01-unit/01-db/01-schema/13-cluster_status_spec.lua
+++ b/spec/01-unit/01-db/01-schema/13-cluster_status_spec.lua
@@ -41,6 +41,13 @@ describe("plugins", function()
     assert.equal("length must be 32", err.config_hash)
   end)
 
+  it("rejects incorrect sync status", function()
+    local ok, err = validate({ sync_status = "aaa", })
+    assert.is_nil(ok)
+
+    assert.equal("expected one of: unknown, normal, kong_version_incompatible, plugin_set_incompatible, plugin_version_incompatible", err.sync_status)
+  end)
+
   it("accepts correct value", function()
     local ok, err = validate({ ip = "127.0.0.1", hostname = "dp.example.com", })
     assert.is_true(ok)

--- a/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
@@ -64,6 +64,7 @@ for _, strategy in helpers.each_strategy() do
             if v.ip == "127.0.0.1" then
               assert.near(14 * 86400, v.ttl, 3)
               assert.matches("^(%d+%.%d+)%.%d+", v.version)
+              assert.equal("normal", v.sync_status)
 
               return true
             end
@@ -268,6 +269,7 @@ for _, strategy in helpers.each_strategy() do
           for _, v in pairs(json.data) do
             if v.id == uuid then
               assert.equal(tostring(_VERSION_TABLE), v.version)
+              assert.equal("normal", v.sync_status)
               return true
             end
           end
@@ -303,6 +305,7 @@ for _, strategy in helpers.each_strategy() do
           for _, v in pairs(json.data) do
             if v.id == uuid then
               assert.equal(version, v.version)
+              assert.equal("normal", v.sync_status)
               return true
             end
           end
@@ -338,6 +341,7 @@ for _, strategy in helpers.each_strategy() do
           for _, v in pairs(json.data) do
             if v.id == uuid then
               assert.equal(version, v.version)
+              assert.equal("normal", v.sync_status)
               return true
             end
           end
@@ -371,6 +375,7 @@ for _, strategy in helpers.each_strategy() do
           for _, v in pairs(json.data) do
             if v.id == uuid then
               assert.equal("1.0.0", v.version)
+              assert.equal("kong_version_incompatible", v.sync_status)
               return true
             end
           end
@@ -407,6 +412,7 @@ for _, strategy in helpers.each_strategy() do
           for _, v in pairs(json.data) do
             if v.id == uuid then
               assert.equal(tostring(_VERSION_TABLE), v.version)
+              assert.equal("plugin_version_incompatible", v.sync_status)
               return true
             end
           end
@@ -462,6 +468,7 @@ for _, strategy in helpers.each_strategy() do
             if v.ip == "127.0.0.1" then
               assert.near(14 * 86400, v.ttl, 10)
               assert.equals(tostring(_VERSION_TABLE), v.version)
+              assert.equal("plugin_set_incompatible", v.sync_status)
 
               res = proxy_client:send({
                 method  = "GET",


### PR DESCRIPTION
status of CP-DP sync and reasons for failing the compatibility check

Now the `/clustering/data-planes` endpoint includes a new field - `sync_status`. Which will contain values that represents if sync is allowed between CP and DP and if not, the reason for the failure.