### PR TITLE
fix(cmd) usage of ffi.C.write and -c flag on reload

### DIFF
--- a/kong/cmd/utils/nginx_signals.lua
+++ b/kong/cmd/utils/nginx_signals.lua
@@ -143,7 +143,7 @@ function _M.stop(kong_conf)
   return send_signal(kong_conf, "TERM")
 end
 
-function _M.quit(kong_conf, graceful)
+function _M.quit(kong_conf)
   return send_signal(kong_conf, "QUIT")
 end
 

--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -422,5 +422,6 @@ return {
   compile_kong_conf = compile_kong_conf,
   compile_kong_stream_conf = compile_kong_stream_conf,
   compile_nginx_conf = compile_nginx_conf,
-  gen_default_ssl_cert = gen_default_ssl_cert
+  gen_default_ssl_cert = gen_default_ssl_cert,
+  write_env_file = write_env_file,
 }

--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -204,6 +204,8 @@ local function compile_conf(kong_config, conf_template)
 end
 
 local function write_env_file(path, data)
+  os.remove(path)
+
   local c = require "lua_system_constants"
 
   local flags = bit.bor(c.O_CREAT(), c.O_WRONLY())
@@ -216,18 +218,24 @@ local function write_env_file(path, data)
                 ffi.string(ffi.C.strerror(errno)) .. ")"
   end
 
-  local n  = #data
-  local sz = ffi.C.write(fd, data, n)
-  if sz ~= n then
-    ffi.C.close(fd)
-    return nil, "wrote " .. sz .. " bytes, expected to write " .. n
-  end
-
   local ok = ffi.C.close(fd)
   if ok ~= 0 then
     local errno = ffi.errno()
     return nil, "failed to close fd (" ..
                 ffi.string(ffi.C.strerror(errno)) .. ")"
+  end
+
+  local file, err = io.open(path, "w+")
+  if not file then
+    return nil, "unable to open env path " .. path .. " (" .. err .. ")"
+  end
+
+  local ok, err = file:write(data)
+
+  file:close()
+
+  if not ok then
+    return nil, "unable to write env path " .. path .. " (" .. err .. ")"
   end
 
   return true

--- a/spec/fixtures/reload.conf
+++ b/spec/fixtures/reload.conf
@@ -1,0 +1,3 @@
+prefix = servroot
+nginx_main_worker_processes = 1
+proxy_listen = 0.0.0.0:9000


### PR DESCRIPTION
### Summary

#### fix(cmd) make -c flag of kong reload to actually work 

Originally this issue seemed to be fixed in:
https://github.com/Kong/kong/commit/1b4780345002d77513e1342d35c17867d45df1e7

But that only fixed it to work with environment variables. This PR now fixes the `kong reload -c <config>` to work too.

#### fix(cmd) usage of ffi.C.write could result corrupted .kong_env

On my machine (and I have seen this elsewhere too) sometimes a corrupted `.kong_env` gets generated. This is most probably because of usage of `ffi.C.write`. It is hard to reproduce, but it requires multiple reloads and passing `-c` (confs).

I changed the code to use plain Lua, which seemed to mitigate the issue fully.