### PR TITLE
handle old config styles

### DIFF
--- a/kong/runloop/plugin_servers/process.lua
+++ b/kong/runloop/plugin_servers/process.lua
@@ -1,6 +1,8 @@
 local cjson = require "cjson.safe"
 local pl_path = require "pl.path"
 local raw_log = require "ngx.errlog".raw_log
+local msgpack = require "MessagePack"
+
 local _, ngx_pipe = pcall(require, "ngx.pipe")
 
 
@@ -53,14 +55,28 @@ local function get_server_defs()
 
   if not _servers then
     _servers = {}
-    for i, name in ipairs(config.pluginserver_names or {}) do
-      kong.log.debug("search config for pluginserver named: ", name)
-      local env_prefix = "pluginserver_" .. name:gsub("-", "_")
-      _servers[i] = {
-        name = name,
-        socket = config[env_prefix .. "_socket"] or "/usr/local/kong/" .. name .. ".socket",
-        start_command = config[env_prefix .. "_start_cmd"] or ifexists("/usr/local/bin/"..name),
-        query_command = config[env_prefix .. "_query_cmd"] or ifexists("/usr/local/bin/query_"..name),
+
+    if config.pluginserver_names then
+      for i, name in ipairs(config.pluginserver_names) do
+        kong.log.debug("search config for pluginserver named: ", name)
+        local env_prefix = "pluginserver_" .. name:gsub("-", "_")
+        _servers[i] = {
+          name = name,
+          socket = config[env_prefix .. "_socket"] or "/usr/local/kong/" .. name .. ".socket",
+          start_command = config[env_prefix .. "_start_cmd"] or ifexists("/usr/local/bin/"..name),
+          query_command = config[env_prefix .. "_query_cmd"] or ifexists("/usr/local/bin/query_"..name),
+        }
+      end
+
+    elseif config.go_plugins_dir ~= "off" then
+      kong.log.info("old go_pluginserver style")
+      _servers[1] = {
+        name = "go-pluginserver",
+        socket = config.prefix .. "/go_pluginserver.sock",
+        start_command = ("%s -kong-prefix %q -plugins-directory %q"):format(
+            config.go_pluginserver_exe, config.prefix, config.go_plugins_dir),
+        info_command = ("%s -plugins-directory %q -dump-plugin-info %%q"):format(
+            config.go_pluginserver_exe, config.go_plugins_dir),
       }
     end
   end
@@ -148,12 +164,36 @@ local function ask_info(server_def)
   end
 end
 
+local function ask_info_plugin(server_def, plugin_name)
+  if not server_def.info_command then
+    return
+  end
+
+  local fd, err = io.popen(server_def.info_command:format(plugin_name))
+  if not fd then
+    local msg = string.format("asking [%s] info of [%s", server_def.name, plugin_name)
+    kong.log.err(msg, err)
+    return
+  end
+
+  local info_dump = fd:read("*a")
+  fd:close()
+  local info = assert(msgpack.unpack(info_dump))
+  register_plugin_info(server_def, info)
+end
+
 function proc_mgmt.get_plugin_info(plugin_name)
   if not _plugin_infos then
     _plugin_infos = {}
 
     for _, server_def in ipairs(get_server_defs()) do
       ask_info(server_def)
+    end
+  end
+
+  if not _plugin_infos[plugin_name] then
+    for _, server_def in ipairs(get_server_defs()) do
+      ask_info_plugin(server_def, plugin_name)
     end
   end
 

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -11,6 +11,8 @@ plugins = bundled
 port_maps = NONE
 host_ports = NONE
 anonymous_reports = on
+go_pluginserver_exe = /usr/local/bin/go-pluginserver
+go_plugins_dir = off
 
 proxy_listen = 0.0.0.0:8000 reuseport backlog=16384, 0.0.0.0:8443 http2 ssl reuseport backlog=16384
 stream_listen = off


### PR DESCRIPTION
The multi-pluginserver feature (AKA external-plugins, #6600 ) requires a new configuration style to allow the user to define how to run several pluginserver processes.  This patch provides backwards compatibility by detecting the old settings (`go_plugins_dir` and `go_pluginserver_exe`) and reading as if the equivalent "new style" was written.

It also restores compatibility with the old go-pluginserver (v0.5.0) which didn't have the `-dump-all-plugins` feature.  Instead it asks for each configured plugin.