### PR TITLE
feat(kong) add sandbox and sandbox_helpers

### DIFF
--- a/kong-2.2.1-0.rockspec
+++ b/kong-2.2.1-0.rockspec
@@ -1,4 +1,5 @@
 package = "kong"
+rockspec_format = "3.0"
 version = "2.2.1-0"
 supported_platforms = {"linux", "macosx"}
 source = {
@@ -27,6 +28,7 @@ dependencies = {
   "lua_system_constants == 0.1.4",
   "lyaml == 6.2.7",
   "luasyslog == 1.0.0",
+  "kikito/sandbox == 1.0.1",
   "lua_pack == 1.0.5",
   "lua-resty-dns-client == 5.1.0",
   "lua-resty-worker-events == 1.0.0",
@@ -132,6 +134,7 @@ build = {
     ["kong.tools.timestamp"] = "kong/tools/timestamp.lua",
     ["kong.tools.stream_api"] = "kong/tools/stream_api.lua",
     ["kong.tools.batch_queue"] = "kong/tools/batch_queue.lua",
+    ["kong.tools.sandbox"] = "kong/tools/sandbox.lua",
 
     ["kong.runloop.handler"] = "kong/runloop/handler.lua",
     ["kong.runloop.certificate"] = "kong/runloop/certificate.lua",

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1334,3 +1334,59 @@
                                  # server.
                                  #
                                  # See https://github.com/openresty/lua-nginx-module#lua_socket_pool_size
+
+#untrusted_lua = sandbox
+                                 # Accepted values are:
+                                 #
+                                 # - `off`: disallow any loading of Lua functions
+                                 #          from admin supplied sources (such as via the Admin API).
+                                 #
+                                 #          Note using the `off` option will render plugins such as
+                                 #          Serverless Functions unusable.
+                                 # - `sandbox`: allow loading of Lua functions from admin
+                                 #              supplied sources, but use a sandbox when
+                                 #              executing them. The sandboxed
+                                 #              function will have restricted access
+                                 #              to the global environment and only
+                                 #              have access to standard Lua functions
+                                 #              that will generally not cause harm to
+                                 #              the Kong node.
+                                 #
+                                 #              In this mode, the `require` function inside
+                                 #              the sandbox only allows loading external Lua
+                                 #              modules that are explicitly listed in
+                                 #              `untrusted_lua_sandbox_requires` below.
+                                 #
+                                 #              LuaJIT bytecode loading is disabled.
+                                 #
+                                 #              Warning: LuaJIT is not designed as a secure
+                                 #              runtime for running malicious code, therefore,
+                                 #              you should properly protect your Admin API endpoint
+                                 #              even with sandboxing enabled. The sandbox only
+                                 #              provides protection against trivial attackers or
+                                 #              unintentional modification of the Kong global
+                                 #              environment.
+                                 # - `on`: allow loading of Lua functions from admin
+                                 #         supplied sources and do not use a sandbox when
+                                 #         executing them. Functions will have unrestricted
+                                 #         access to global environment and able to load any
+                                 #         Lua modules. This is similar to the behavior in Kong
+                                 #         prior to 2.3.0.
+                                 #
+                                 #         LuaJIT bytecode loading is disabled.
+
+#untrusted_lua_sandbox_requires =
+                                 # Comma-separated list of modules allowed to be loaded
+                                 # with `require` inside the sandboxed environment. Ignored
+                                 # if `untrusted_lua` is not `sandbox`.
+                                 #
+                                 # Note: certain modules, when allowed, may cause sandbox
+                                 # escaping trivial.
+
+#untrusted_lua_sandbox_environment =
+                                 # Comma-separated list of global Lua variables
+                                 # that should be made available inside the sandboxed
+                                 # environment. Ignored if `untrusted_lua` is not `sandbox`.
+                                 #
+                                 # Note: certain variables, when made available,
+                                 # may cause sandbox escaping trivial.

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -623,6 +623,10 @@ local CONF_INFERENCES = {
   cluster_data_plane_purge_delay = { typ = "number" },
   kic = { typ = "boolean" },
   pluginserver_names = { typ = "array" },
+
+  untrusted_lua = { enum = { "on", "off", "sandbox" } },
+  untrusted_lua_sandbox_requires = { typ = "array" },
+  untrusted_lua_sandbox_environment = { typ = "array" },
 }
 
 

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -164,4 +164,8 @@ lua_package_cpath = NONE
 role = traditional
 kic = off
 pluginserver_names = NONE
+
+untrusted_lua = sandbox
+untrusted_lua_sandbox_requires =
+untrusted_lua_sandbox_environment =
 ]]

--- a/kong/tools/sandbox.lua
+++ b/kong/tools/sandbox.lua
@@ -1,0 +1,201 @@
+local _sandbox = require "sandbox"
+
+local table = table
+local fmt = string.format
+local setmetatable = setmetatable
+local require = require
+local ipairs = ipairs
+local pcall = pcall
+local type = type
+local error = error
+local rawset = rawset
+local assert = assert
+local kong = kong
+
+
+-- deep copy tables using dot notation, like
+-- one: { foo = { bar = { hello = {}, ..., baz = 42 } } }
+-- target: { hey = { "hello } }
+-- link("foo.bar.baz", one, target)
+-- target -> { hey = { "hello" }, foo = { bar = { baz = 42 } } }
+local function link(q, o, target)
+  if not q then return end
+
+  local h, r = q:match("([^%.]+)%.?(.*)")
+  local mod = o[h]
+
+  if not mod then return end
+
+  if r == "" then
+    if type(mod) == 'table' then
+      -- changes on target[h] won't affect mod
+      target[h] = setmetatable({}, { __index = mod })
+
+    else
+      target[h] = mod
+    end
+
+    return
+  end
+
+  if not target[h] then target[h] = {} end
+
+  link(r, o[h], target[h])
+end
+
+
+local lazy_conf_methods = {
+  enabled = function(self)
+    return kong and
+           kong.configuration and
+           kong.configuration.untrusted_lua and
+           kong.configuration.untrusted_lua ~= 'off'
+  end,
+  sandbox_enabled = function(self)
+    return kong and
+           kong.configuration and
+           kong.configuration.untrusted_lua and
+           kong.configuration.untrusted_lua == 'sandbox'
+  end,
+  requires = function(self)
+    local conf_r = kong and
+                   kong.configuration and
+                   kong.configuration.untrusted_lua_sandbox_requires or {}
+    local requires = {}
+    for _, r in ipairs(conf_r) do requires[r] = true end
+    return requires
+  end,
+  env_vars = function(self)
+    return kong and
+           kong.configuration and
+           kong.configuration.untrusted_lua_sandbox_environment or {}
+  end,
+  environment = function(self)
+    local env = {
+        -- home brewed require function that only requires what we consider
+        -- safe :)
+        ["require"] = function(m)
+          if not self.requires[m] then
+            error(fmt("require '%s' not allowed within sandbox", m))
+          end
+
+          return require(m)
+        end,
+    }
+
+    for _, m in ipairs(self.env_vars) do link(m, _G, env) end
+
+    return env
+  end,
+}
+
+
+local conf_values = {
+  clear = table.clear,
+  reload = table.clear,
+  err_msg = "loading of untrusted Lua code disabled because " ..
+            "'untrusted_lua' config option is set to 'off'"
+}
+
+
+local configuration = setmetatable({}, {
+  __index = function(self, key)
+    local l = lazy_conf_methods[key]
+
+    if not l then
+      return conf_values[key]
+    end
+
+    local value = l(self)
+    rawset(self, key, value)
+
+    return value
+  end,
+})
+
+
+local sandbox = function(fn, opts)
+  if not configuration.enabled then
+    error(configuration.err_msg)
+  end
+
+  opts = opts or {}
+
+  local opts = {
+    -- default set load string mode to only 'text chunks'
+    mode = opts.mode or 't',
+    env = opts.env or {},
+    chunk_name = opts.chunk_name,
+  }
+
+  if not configuration.sandbox_enabled then
+    -- sandbox disabled, all arbitrary Lua code can execute unrestricted
+    setmetatable(opts.env, { __index = _G})
+
+    return assert(load(fn, opts.chunk_name, opts.mode, opts.env))
+  end
+
+  -- set (discard-able) function context
+  setmetatable(opts.env, { __index = configuration.environment })
+
+  return _sandbox(fn, opts)
+end
+
+
+local function validate_function(fun, opts)
+  local ok, func1 = pcall(sandbox, fun, opts)
+  if not ok then
+    return false, "Error parsing function: " .. func1
+  end
+
+  local success, func2 = pcall(func1)
+
+  if success and type(func2) == "function" then
+    return func2
+  end
+
+  -- the code returned something unknown
+  return false, "Bad return value from function, expected function type, got "
+                .. type(func2)
+end
+
+
+local function parse(fn_str, opts)
+  return assert(validate_function(fn_str, opts))
+end
+
+
+local _M = {}
+
+
+_M.validate_function = validate_function
+
+
+_M.validate = function(fn_str, opts)
+  local _, err = validate_function(fn_str, opts)
+  if err then return false, err end
+
+  return true
+end
+
+
+-- meant for schema, do not execute arbitrary lua!
+-- https://github.com/Kong/kong/issues/5110
+_M.validate_safe = function(fn_str, opts)
+  local ok, func1 = pcall(sandbox, fn_str, opts)
+
+  if not ok then
+    return false, "Error parsing function: " .. func1
+  end
+
+  return true
+end
+
+
+_M.sandbox = sandbox
+_M.parse = parse
+-- useful for testing
+_M.configuration = configuration
+
+
+return _M

--- a/spec/01-unit/020-sandbox_spec.lua
+++ b/spec/01-unit/020-sandbox_spec.lua
@@ -1,0 +1,351 @@
+local utils = require "kong.tools.utils"
+
+
+local deep_copy = utils.deep_copy
+local fmt = string.format
+
+describe("sandbox functions wrapper", function()
+
+  local _sandbox, sandbox, load_s
+
+  local base_conf = {
+    untrusted_lua_sandbox_requires = {},
+    untrusted_lua_sandbox_environment = {},
+  }
+
+  _G.kong = {
+    configuration = {},
+  }
+
+  lazy_setup(function()
+    _G.kong.configuration = deep_copy(base_conf)
+
+    -- load and reference module we can spy on
+    load_s = spy.new(load)
+    _G.load = load_s
+    _sandbox = spy.new(require "sandbox")
+    package.loaded["sandbox"] = _sandbox
+    sandbox = require "kong.tools.sandbox"
+  end)
+
+  before_each(function()
+    _sandbox:clear()
+    load_s:clear()
+    sandbox.configuration:clear()
+  end)
+
+  lazy_teardown(function()
+    load_s:revert()
+    _sandbox:revert()
+  end)
+
+  describe("sandbox.validate_safe", function()
+    for _, u in ipairs({'on', 'sandbox'}) do describe(("untrusted_lua = '%s'"):format(u), function()
+      lazy_setup(function()
+        _G.kong.configuration.untrusted_lua = u
+      end)
+
+      lazy_teardown(function()
+        _G.kong.configuration = deep_copy(base_conf)
+      end)
+
+      -- https://github.com/Kong/kong/issues/5110
+      it("does not execute the code itself", function()
+        local env = { do_it = spy.new(function() end) }
+        local ok = sandbox.validate_safe([[ do_it() ]], { env = env })
+        assert.is_true(ok)
+        assert.spy(env.do_it).not_called()
+
+        -- and now, of course, for the control group!
+        sandbox.sandbox([[ do_it() ]], { env = env })()
+        assert.spy(env.do_it).called()
+      end)
+    end) end
+  end)
+
+  describe("sandbox.validate", function()
+    for _, u in ipairs({'on', 'sandbox'}) do describe(("untrusted_lua = '%s'"):format(u), function()
+      lazy_setup(function()
+        _G.kong.configuration.untrusted_lua = u
+      end)
+
+      lazy_teardown(function()
+        _G.kong.configuration = deep_copy(base_conf)
+      end)
+
+      it("validates input is lua that returns a function", function()
+        assert.is_true(sandbox.validate("return function() end"))
+      end)
+
+      it("returns false and error when some string is not some code", function()
+        local ok, err = sandbox.validate("here come the warm jets")
+        assert.is_false(ok)
+        assert.matches("Error parsing function", err, nil, true)
+      end)
+
+      it("returns false and error when input is lua that does not return a function", function()
+        local ok, err = sandbox.validate("return 42")
+        assert.is_false(ok)
+        assert.matches("Bad return value from function, expected function type, got number", err)
+      end)
+    end) end
+
+    describe("untrusted_lua = 'off'", function()
+      lazy_setup(function()
+        _G.kong.configuration.untrusted_lua = 'off'
+      end)
+
+      lazy_teardown(function()
+        _G.kong.configuration = deep_copy(base_conf)
+      end)
+
+      it("errors", function()
+        local ok, err = sandbox.validate("return function() end")
+        assert.is_false(ok)
+        assert.matches(sandbox.configuration.err_msg, err, nil, true)
+      end)
+    end)
+  end)
+
+  describe("sandbox.sandbox", function()
+    local setting
+
+    before_each(function()
+      _G.kong.configuration.untrusted_lua = setting
+    end)
+
+    lazy_teardown(function()
+      _G.kong.configuration = deep_copy(base_conf)
+    end)
+
+    describe("untrusted_lua = 'off'", function()
+      lazy_setup(function() setting = 'off' end)
+
+      it("errors", function()
+        sandbox.configuration:clear()
+        assert.error(function() sandbox.sandbox("return 42") end)
+      end)
+    end)
+
+    describe("untrusted_lua = 'on'", function()
+      lazy_setup(function() setting = 'on' end)
+
+      it("does not use sandbox", function()
+        assert(sandbox.sandbox('return 42')())
+        assert.spy(_sandbox).was_not.called()
+      end)
+
+      it("calls load with mode t (text only)", function()
+        sandbox.sandbox("return 42")
+        assert.spy(load_s).was.called()
+        assert.equal("t", load_s.calls[1].vals[3])
+      end)
+
+      it("does not load binary strings (text only)", function()
+        assert.error(function()
+          sandbox.sandbox(string.dump(function() end))
+        end)
+      end)
+
+      describe("environment", function()
+        lazy_setup(function()
+          _G.hello_world = "Hello World"
+        end)
+
+        lazy_teardown(function()
+          _G.hello_world = nil
+        end)
+
+        it("has _G access", function()
+          assert.same(_G.hello_world, sandbox.sandbox('return hello_world')())
+        end)
+
+        it("does not write _G", function()
+          local r = sandbox.sandbox('hello_world = "foobar" return hello_world')()
+          assert.same("foobar", r)
+          assert.same("Hello World", _G.hello_world)
+        end)
+
+        it("does use an environment too", function()
+          local env = { foo = 0}
+          local fn = sandbox.parse([[
+            return function(inc)
+              foo = foo + inc
+            end
+          ]], { env = env })
+          fn(10) fn(20) fn(30)
+          assert.equal(60, env.foo)
+        end)
+      end)
+    end)
+
+    describe("untrusted_lua = 'sandbox'", function()
+      lazy_setup(function() setting = 'sandbox' end)
+
+      it("calls sandbox.lua behind the scenes", function()
+        sandbox.sandbox("return 42")
+        assert.spy(_sandbox).was.called()
+      end)
+
+      it("calls load with mode t (text only)", function()
+        sandbox.sandbox("return 42")
+        assert.spy(load_s).was.called()
+        assert.equal("t", load_s.calls[1].vals[3])
+      end)
+
+      it("does not load binary strings (text only)", function()
+        assert.error(function()
+          sandbox.sandbox(string.dump(function() end))
+        end)
+      end)
+
+      -- XXX These could be more or less more attractive to the eyes
+      describe("environment", function()
+        local requires = { "foo", "bar", "baz" }
+        local modules = {
+          "foo.bar",
+          "bar",
+          "baz.fuzz.answer",
+          "fizz.fizz", "fizz.buzz", "fizz.zap",
+        }
+
+        local function find(q, o)
+          if q == "" then return o end
+          local h, r = q:match("([^%.]+)%.?(.*)")
+          return find(r, o[h])
+        end
+
+        lazy_setup(function()
+          _G.foo = { bar = { hello = "world" }, baz = "fuzz" }
+          _G.bar = { "baz", "fuzz", { bye = "world" } }
+          _G.baz = { foo = _G.foo, fuzz = { question = "everything", answer = 42 } }
+          _G.fizz = { fizz = _G.foo, buzz = _G.bar, zap = _G.baz }
+
+          _G.kong.configuration.untrusted_lua_sandbox_requires = requires
+          _G.kong.configuration.untrusted_lua_sandbox_environment = modules
+        end)
+
+        lazy_teardown(function()
+          _G.foo = nil
+          _G.bar = nil
+          _G.baz = nil
+          _G.fizz = nil
+
+          _G.kong.configuration = deep_copy(base_conf)
+        end)
+
+        it("has access to config.untrusted_lua_sandbox_environment", function()
+          for _, m in ipairs(modules) do
+            assert.same(find(m, _G), sandbox.sandbox(fmt("return %s", m))())
+          end
+        end)
+
+        it("does not have access to anything else on the modules", function()
+          for _, m in ipairs({ "foo.baz", "baz.foo", "baz.fuzz.question"}) do
+            assert.is_nil(sandbox.sandbox(fmt("return %s", m))())
+          end
+        end)
+
+        it("tables are read only", function()
+          sandbox.sandbox([[ foo.bar.something = 'hello' ]])()
+          assert.is_nil(_G.foo.bar.something)
+        end)
+
+        it("tables are unmutable on all levels", function()
+          sandbox.sandbox([[ baz.fuzz.hallo = 'hello' ]])()
+          assert.is_nil(_G.baz.fuzz.hallo)
+        end)
+
+        it("configuration.untrusted_lua_sandbox_environment is composable", function()
+          local s_fizz = sandbox.sandbox([[ return fizz ]])()
+          assert.same(_G.fizz, s_fizz)
+        end)
+
+        pending("opts.env is composable with sandbox_environment", function()
+          local some_env = {
+            foo = {
+              something = { fun = function() end },
+            }
+          }
+          local s_foo = sandbox.sandbox([[
+            return foo
+          ]], { env = some_env })()
+
+          assert.same({
+            bar = { hello = "world" },
+            something = some_env.foo.something,
+          }, s_foo)
+        end)
+
+        describe("fake require", function()
+          it("can require config.untrusted_lua_sandbox_requires", function()
+            for _, mod in ipairs(requires) do
+                local mock = function() end
+                local _o = package.loaded[mod]
+                package.loaded[mod] = mock
+
+                local fn = string.format("return require('%s')", mod)
+                assert.equal(mock, sandbox.sandbox(fn)())
+
+                finally(function() package.loaded[mod] = _o end)
+            end
+          end)
+
+          it("cannot require anything else", function()
+            local fn = sandbox.sandbox("return require('something-else')")
+            local _, err = pcall(fn)
+            assert.matches("require 'something-else' not allowed", err, nil, true)
+          end)
+        end)
+      end)
+    end)
+
+  end)
+
+  describe("sandbox.parse", function()
+    for _, u in ipairs({'on', 'sandbox'}) do describe(("untrusted_lua = '%s'"):format(u), function()
+      lazy_setup(function()
+        _G.kong.configuration.untrusted_lua = u
+      end)
+
+      lazy_teardown(function()
+        _G.kong.configuration = deep_copy(base_conf)
+      end)
+
+      it("returns a function when it gets code returning a function", function()
+        local fn = sandbox.parse([[
+          return function(something)
+            return something
+          end
+        ]])
+        assert.equal("function", type(fn))
+        assert.equal("foobar", fn("foobar"))
+      end)
+
+      describe("errs with invalid input:", function()
+        it("bad code", function()
+          assert.error(function() sandbox.parse("foo bar baz") end)
+        end)
+
+        it("code that does not return a function", function()
+          assert.error(function() sandbox.parse("return 42") end)
+        end)
+      end)
+    end) end
+
+    describe("untrusted_lua = 'off'", function()
+      lazy_setup(function()
+        _G.kong.configuration.untrusted_lua = 'off'
+      end)
+
+      lazy_teardown(function()
+        _G.kong.configuration = deep_copy(base_conf)
+      end)
+
+      it("errors", function()
+        assert.error(function() sandbox.parse("return 42") end)
+      end)
+    end)
+  end)
+
+end)


### PR DESCRIPTION
### Summary

Some Kong functionality (present and future) and plugins uses arbitrary lua code, which provides the most definitive way of extending usage. This comes with its own security problems:

* Not all users will use this feature
* Every kong part and plugin loads arbitrary lua differently
* On unsecured kong deploys, opens up a security door depending on what environment context is allowed to the lua code.

Point is, there's no silver bullet to accept or disable this functionality, and it will depend on what every kong user wants or expects from their installation.

This PR proposes:
* Adding `sandbox.lua` as a dependency https://github.com/kikito/sandbox.lua/pull/2 (currently embedded on this PR with some modifications) to run these on a restricted sandbox. We can add that as a requirement on the luarocks when / if it gets published, or we can go with a simpler sandbox, like: https://github.com/Kong/kong-plugin-serverless-functions/blob/0addd34396136bbf2479a390e2c9faa41d5accb9/kong/plugins/pre-function/_handler.lua#L4-L71
* Providing sandbox_helpers that wrap `whatever we use for sandboxing`, and get a common usage through kong codebase. It provides methods for parsing functions, validating (for plugins schema), etc. This will de dupe lots of code and will make sure that it all behaves as expected. It also makes sure we have a set of defaults on how we use the `load` function, like using `mode = t` and not allowing binary text.
* Providing a set of kong configuration values to control how does arbitrary lua run, as:

```
KONG_UNTRUSTED_LUA=on,off,sandbox
KONG_UNTRUSTED_LUA_SANDBOX_REQUIRES=some,modules,you,are,allowed,to,require,on,sandbox,mode
KONG_UNTRUSTED_LUA_SANDBOX_MODULES=G,modules,you,want,accessible,on,the,sandbox,like,kong.request
```

These settings mean the following:

- `KONG_UNTRUSTED_LUA = off` completely disables running arbitrary lua code no matter what.
- `KONG_UNTRUSTED_LUA = sandbox`  uses a sandbox to run arbitrary lua
    - `KONG_UNTRUSTED_LUA_SANDBOX_REQUIRES` is a comma separated list of allowed requires within the sandbox
    - `KONG_UNTRUSTED_LUA_SANDBOX_ENVIRONMENT` is a comma separated list of available global variables on the sandbox context. For example, adding `kong.request` would make `kong.request` available within the sandbox and `kong.request.get_header('foo')` woud be possible.
- `KONG_UNTRUSTED_LUA = off` will run arbitrary lua code without any restriction.

This might look like lots of settings, but again, there's no silver bullet for these features, some users will want something on their environment that others won't.

At the moment, the defaults are:

```
KONG_UNTRUSTED_LUA = on
KONG_UNTRUSTED_LUA_SANDBOX_REQUIRES = (empty)
KONG_UNTRUSTED_LUA_SANDBOX_ENVIRONMENT = (empty)
```


### Full changelog

* Add sandbox_helpers and kong configuration settings for it
