### PR TITLE
fix(core): RPC - test config template, array of strings, better errors

### DIFF
--- a/kong/tools/stream_api.lua
+++ b/kong/tools/stream_api.lua
@@ -10,6 +10,7 @@ local kong       = kong
 local st_pack    = string.pack      -- luacheck: ignore string
 local st_unpack  = string.unpack    -- luacheck: ignore string
 local st_format  = string.format
+local table_concat = table.concat
 local assert     = assert
 
 local MAX_DATA_LEN = 8000
@@ -97,7 +98,7 @@ function stream_api.handle()
   end
 
   if type(res) == "table" then
-    res = table.concat(res)
+    res = table_concat(res)
   end
 
   if type(res) ~= "string" then

--- a/spec/02-integration/12-stream_api/01-stream_api_endpoint_spec.lua
+++ b/spec/02-integration/12-stream_api/01-stream_api_endpoint_spec.lua
@@ -23,7 +23,7 @@ describe("Stream module API endpoint", function()
     it("error response for unknown path", function()
       local res, err = stream_api.request("not-this", "nope", socket_path)
       assert.is.falsy(res)
-      assert.equal("no handler", err)
+      assert.equal("stream-api errmsg: no handler", err)
     end)
 
     it("calls an echo handler", function ()

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -862,5 +862,14 @@ stream {
     }
 
     include '*.stream_mock';
+
+    server {        # ignore (and close }, to ignore content)
+        listen unix:${{PREFIX}}/stream_rpc.sock udp;
+        error_log  ${{ADMIN_ERROR_LOG}} ${{LOG_LEVEL}};
+        content_by_lua_block {
+            Kong.stream_api()
+        }
+    }
+
 }
 > end


### PR DESCRIPTION
- the config template used for tests was missing the inter-module RPC
socket

- to reuse the data-gathering function on both HTTP and Stream modules,
the RPC message should support array of strings, just like `ngx.print()`.

- prefix errors with the intent.  "connection closed" is far too
ambiguous.
