### PR TITLE
fix(ext-plugin): msg_id scope per-connection, not per-pluginserver

### DIFF
--- a/kong/runloop/plugin_servers/mp_rpc.lua
+++ b/kong/runloop/plugin_servers/mp_rpc.lua
@@ -61,6 +61,7 @@ end
 
 function Rpc:call(method, ...)
   self.msg_id = self.msg_id + 1
+  local msg_id = self.msg_id
 
   local c, err = ngx.socket.connect("unix:" .. self.socket_path)
   if not c then
@@ -69,7 +70,7 @@ function Rpc:call(method, ...)
   end
 
   -- request: [ 0, msg_id, method, args ]
-  local bytes, err = c:send(mp_pack({0, self.msg_id, method, {...}}))
+  local bytes, err = c:send(mp_pack({0, msg_id, method, {...}}))
   if not bytes then
     c:setkeepalive()
     return nil, err
@@ -94,7 +95,7 @@ function Rpc:call(method, ...)
     else
       -- response: [ 1, msg_id, error, result ]
       assert(data[1] == 1, "RPC response expected from Go plugin server")
-      assert(data[2] == self.msg_id,
+      assert(data[2] == msg_id,
              "unexpected RPC response ID from Go plugin server")
 
       -- it's our answer


### PR DESCRIPTION
the `msg_id` field in every packet helps associate call and return packets.  Each call increments a counter, but the result should be local during the call/return cycle to avoid interference from concurrent HTTP requests.