### PR TITLE
fix(response-transformer) do not allow nulls in arrays

### DIFF
--- a/kong/plugins/response-transformer/handler.lua
+++ b/kong/plugins/response-transformer/handler.lua
@@ -9,7 +9,10 @@ local kong = kong
 local ngx = ngx
 
 
-local ResponseTransformerHandler = {}
+local ResponseTransformerHandler = {
+  PRIORITY = 800,
+  VERSION = "2.0.1",
+}
 
 
 function ResponseTransformerHandler:header_filter(conf)
@@ -37,10 +40,6 @@ function ResponseTransformerHandler:body_filter(conf)
     end
   end
 end
-
-
-ResponseTransformerHandler.PRIORITY = 800
-ResponseTransformerHandler.VERSION = "2.0.0"
 
 
 return ResponseTransformerHandler

--- a/kong/plugins/response-transformer/schema.lua
+++ b/kong/plugins/response-transformer/schema.lua
@@ -24,6 +24,7 @@ end
 local string_array = {
   type = "array",
   default = {},
+  required = true,
   elements = { type = "string" },
 }
 
@@ -31,6 +32,7 @@ local string_array = {
 local colon_string_array = {
   type = "array",
   default = {},
+  required = true,
   elements = { type = "string", match = "^[^:]+:.*$" },
 }
 
@@ -51,6 +53,7 @@ local colon_string_record = {
     { json_types = {
       type = "array",
       default = {},
+      required = true,
       elements = {
         type = "string",
         one_of = { "boolean", "number", "string" }
@@ -63,6 +66,7 @@ local colon_string_record = {
 local colon_headers_array = {
   type = "array",
   default = {},
+  required = true,
   elements = { type = "string", match = "^[^:]+:.*$", custom_validator = validate_colon_headers },
 }
 

--- a/spec/03-plugins/15-response-transformer/03-api_spec.lua
+++ b/spec/03-plugins/15-response-transformer/03-api_spec.lua
@@ -188,6 +188,68 @@ for _, strategy in helpers.each_strategy() do
           assert.same("schema violation", json.name)
           assert.same({ "invalid value: just_a_key" }, json.fields.config.append.headers)
         end)
+        it("it does not allow null value for arrays", function()
+          local res = assert(admin_client:send {
+            method  = "POST",
+            path    = "/plugins",
+            body    = {
+              name   = "response-transformer",
+              config = {
+                remove    = {
+                  headers    = cjson.null,
+                  json       = cjson.null,
+                },
+                rename = {
+                  headers    = cjson.null,
+                },
+                replace = {
+                  headers    = cjson.null,
+                  json       = cjson.null,
+                  json_types = cjson.null,
+                },
+                add = {
+                  headers    = cjson.null,
+                  json       = cjson.null,
+                  json_types = cjson.null,
+                },
+                append = {
+                  headers    = cjson.null,
+                  json       = cjson.null,
+                  json_types = cjson.null,
+                },
+              },
+            },
+            headers = {
+              ["Content-Type"] = "application/json",
+            },
+          })
+          assert.response(res).has.status(400)
+          local body = assert.response(res).has.jsonbody()
+          assert.same({
+            remove = {
+              headers = "required field missing",
+              json = "required field missing",
+            },
+            rename = {
+              headers = "required field missing",
+            },
+            replace = {
+              headers = "required field missing",
+              json = "required field missing",
+              json_types = "required field missing",
+            },
+            add = {
+              headers = "required field missing",
+              json = "required field missing",
+              json_types = "required field missing",
+            },
+            append = {
+              headers = "required field missing",
+              json = "required field missing",
+              json_types = "required field missing",
+            },
+          }, body.fields.config)
+        end)
       end)
     end)
   end)


### PR DESCRIPTION
### Summary

It was reported by @rmlodzikowski-nokia on issue #6707 that you can configure `response-transformer` with settings that
can lead for runtime error. There were two possible fixes:

1. handle `nulls` on runtime
2. do not allow `nulls` in config

For this PR I picked the `2.` as I think it is better to make arrays `required` rather than adding `null` handling code in
code. The arrays default to empty array `{}`, so `required` here does not mean that you need to actively give a value,
it just means that you cannot actively give `null`.

Similar PR will be opened on `request-transformer`.

### Issues Resolved

Fix #6707