### PR TITLE
fix(proxy) return 502 on connectivity errors with buffered proxying

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -824,9 +824,12 @@ do
 
     local res = ngx.location.capture("/kong_buffered_http", options)
     if res.truncated then
+      kong_global.set_phase(kong, PHASES.error)
       ngx.status = 502
       return kong_error_handlers(ngx)
     end
+
+    kong_global.set_phase(kong, PHASES.response)
 
     local status = res.status
     local headers = res.header
@@ -855,8 +858,6 @@ do
     if not ctx.KONG_PROXY_LATENCY then
       ctx.KONG_PROXY_LATENCY = ctx.KONG_RESPONSE_START - ctx.KONG_PROCESSING_START
     end
-
-    kong_global.set_phase(kong, PHASES.response)
 
     kong.response.set_status(status)
     kong.response.set_headers(headers)


### PR DESCRIPTION
### Summary

In #6726 @danielki33 reported that on upstream connection errors with buffered proxying we return `500` instead of `501` and that runtime error was logged. This PR fixes that.

### Issues Resolved

Fix #6726