### PR TITLE
fix(fixtures) listen for ipv6 in mock webserver

### DIFF
--- a/spec/fixtures/https_server.lua
+++ b/spec/fixtures/https_server.lua
@@ -18,6 +18,7 @@ math.randomseed(os.time())
 
 
 local tmp_root = os.getenv("TMPDIR") or "/tmp"
+local host_regex = [[([a-z0-9\-._~%!$&'()*+,;=]+@)?([a-z0-9\-._~%]+|\[[a-z0-9\-._~%!$&'()*+,;=:]+\])(:?[0-9]+)*]]
 
 
 local function create_temp_dir(copy_cert_and_key)
@@ -87,7 +88,10 @@ local function count_results(logs_dir)
       local status = m[2]
       local host = m[3]
       if host then
-        host = string.match(m[3], "[^:]+")
+        local host_no_port = ngx.re.match(m[3], host_regex)
+        if host_no_port then
+          host = host_no_port[1]
+        end
       else
         host = "nonamehost"
       end

--- a/spec/fixtures/mock_webserver_tpl.lua
+++ b/spec/fixtures/mock_webserver_tpl.lua
@@ -28,9 +28,11 @@ http {
 
   server {
 # if protocol ~= 'https' then
-    listen ${http_port};
+    listen 127.0.0.1:${http_port};
+    listen [0000:0000:0000:0000:0000:0000:0000:0001]:${http_port};
 # else
-    listen ${http_port} ssl;
+    listen 127.0.0.1:${http_port} ssl;
+    listen [0000:0000:0000:0000:0000:0000:0000:0001]:${http_port} ssl;
     ssl_certificate     ${cert_path}/kong_spec.crt;
     ssl_certificate_key ${cert_path}/kong_spec.key;
     ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
@@ -43,7 +45,12 @@ http {
     location = /healthy {
       access_by_lua_block {
         local host = ngx.req.get_headers()["host"] or "localhost"
-        host = string.match(host, "[^:]+")
+        local host_no_port = ngx.re.match(host, [=[([a-z0-9\-._~%!$&'()*+,;=]+@)?([a-z0-9\-._~%]+|\[[a-z0-9\-._~%!$&'()*+,;=:]+\])(:?[0-9]+)*]=])
+        if host_no_port == nil then
+          return ngx.exit(ngx.HTTP_INTERNAL_SERVER_ERROR)
+        else
+          host = host_no_port[2]
+        end
         ngx.shared.server_values:set(host .. "_healthy", true)
         ngx.shared.server_values:set(host .. "_timeout", false)
         ngx.log(ngx.INFO, "Host ", host, " is now healthy")
@@ -58,7 +65,12 @@ http {
     location = /unhealthy {
       access_by_lua_block {
         local host = ngx.req.get_headers()["host"] or "localhost"
-        host = string.match(host, "[^:]+")
+        local host_no_port = ngx.re.match(host, [=[([a-z0-9\-._~%!$&'()*+,;=]+@)?([a-z0-9\-._~%]+|\[[a-z0-9\-._~%!$&'()*+,;=:]+\])(:?[0-9]+)*]=])
+        if host_no_port == nil then
+          return ngx.exit(ngx.HTTP_INTERNAL_SERVER_ERROR)
+        else
+          host = host_no_port[2]
+        end
         ngx.shared.server_values:set(host .. "_healthy", false)
         ngx.log(ngx.INFO, "Host ", host, " is now unhealthy")
       }
@@ -72,7 +84,12 @@ http {
     location = /timeout {
       access_by_lua_block {
         local host = ngx.req.get_headers()["host"] or "localhost"
-        host = string.match(host, "[^:]+")
+        local host_no_port = ngx.re.match(host, [=[([a-z0-9\-._~%!$&'()*+,;=]+@)?([a-z0-9\-._~%]+|\[[a-z0-9\-._~%!$&'()*+,;=:]+\])(:?[0-9]+)*]=])
+        if host_no_port == nil then
+          return ngx.exit(ngx.HTTP_INTERNAL_SERVER_ERROR)
+        else
+          host = host_no_port[2]
+        end
         ngx.shared.server_values:set(host .. "_timeout", true)
         ngx.log(ngx.INFO, "Host ", host, " is timeouting now")
       }
@@ -86,7 +103,12 @@ http {
     location = /status {
       access_by_lua_block {
         local host = ngx.req.get_headers()["host"] or "localhost"
-        host = string.match(host, "[^:]+")
+        local host_no_port = ngx.re.match(host, [=[([a-z0-9\-._~%!$&'()*+,;=]+@)?([a-z0-9\-._~%]+|\[[a-z0-9\-._~%!$&'()*+,;=:]+\])(:?[0-9]+)*]=])
+        if host_no_port == nil then
+          return ngx.exit(ngx.HTTP_INTERNAL_SERVER_ERROR)
+        else
+          host = host_no_port[2]
+        end
         local server_values = ngx.shared.server_values
 
         local status = server_values:get(host .. "_healthy") and
@@ -109,7 +131,13 @@ http {
           local cjson = require("cjson")
           local server_values = ngx.shared.server_values
           local host = ngx.req.get_headers()["host"] or "localhost"
-          host = string.match(host, "[^:]+")
+          local host_no_port = ngx.re.match(host, [=[([a-z0-9\-._~%!$&'()*+,;=]+@)?([a-z0-9\-._~%]+|\[[a-z0-9\-._~%!$&'()*+,;=:]+\])(:?[0-9]+)*]=])
+          ngx.log(ngx.ERR, "host no port: ", require'inspect'(host_no_port))
+          if host_no_port == nil then
+            return ngx.exit(ngx.HTTP_INTERNAL_SERVER_ERROR)
+          else
+            host = host_no_port[2]
+          end
           local status
 
           local status = server_values:get(host .. "_healthy") and
@@ -129,7 +157,8 @@ http {
   }
 # if check_hostname then
   server {
-    listen ${http_port} default_server;
+    listen 127.0.0.1:${http_port} default_server;
+    listen [0000:0000:0000:0000:0000:0000:0000:0001]:${http_port} default_server;
     server_name _;
     return 400;
   }

--- a/spec/fixtures/mock_webserver_tpl.lua
+++ b/spec/fixtures/mock_webserver_tpl.lua
@@ -29,10 +29,10 @@ http {
   server {
 # if protocol ~= 'https' then
     listen 127.0.0.1:${http_port};
-    listen [0000:0000:0000:0000:0000:0000:0000:0001]:${http_port};
+    listen [::1]:${http_port};
 # else
-    listen 127.0.0.1:${http_port} ssl;
-    listen [0000:0000:0000:0000:0000:0000:0000:0001]:${http_port} ssl;
+    listen 127.0.0.1:${http_port} ssl http2;
+    listen [::1]:${http_port} ssl http2;
     ssl_certificate     ${cert_path}/kong_spec.crt;
     ssl_certificate_key ${cert_path}/kong_spec.key;
     ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
@@ -158,7 +158,7 @@ http {
 # if check_hostname then
   server {
     listen 127.0.0.1:${http_port} default_server;
-    listen [0000:0000:0000:0000:0000:0000:0000:0001]:${http_port} default_server;
+    listen [::1]:${http_port} default_server;
     server_name _;
     return 400;
   }


### PR DESCRIPTION
The new HTTPS mock server based on Nginx was not being properly configured for IPv6 addresses.