### PR TITLE
chore(deps) bump pgmoon to 1.12.0

### DIFF
--- a/kong-2.3.0-0.rockspec
+++ b/kong-2.3.0-0.rockspec
@@ -23,7 +23,7 @@ dependencies = {
   "version == 1.0.1",
   "kong-lapis == 1.8.1.2",
   "lua-cassandra == 1.5.0",
-  "pgmoon == 1.11.0",
+  "pgmoon == 1.12.0",
   "luatz == 0.4",
   "lua_system_constants == 0.1.4",
   "lyaml == 6.2.7",


### PR DESCRIPTION
### Summary

This update is required for the latest version of OpenResty: A compatibility change with how a number is converted from a pattern has caused a issue with how queries with an affected row count return.

- Lua pattern to number compatibility fix (John Regan @jprjr)
- Support for Lua 5.1 through 5.4 (John Regan @jprjr)
- Fix bug where SSL version was not being passed when using LuaSec (Murillo Paula @murillopaula)
- Default to TLS v1.2 when using LuaSec
- Luabitop is no longer automatically installed as a default dependency (for Lua version compatibility)
- Migrate test suite from Travis to GitHub actions. Test suite now uses docker to spawn test postgres servers