### PR TITLE
chore(deps) bump lua-resty-dns-client to 5.2.1

### DIFF
--- a/kong-2.3.0-0.rockspec
+++ b/kong-2.3.0-0.rockspec
@@ -30,7 +30,7 @@ dependencies = {
   "luasyslog == 1.0.0",
   "kikito/sandbox == 1.0.1",
   "lua_pack == 1.0.5",
-  "lua-resty-dns-client == 5.2.0",
+  "lua-resty-dns-client == 5.2.1",
   "lua-resty-worker-events == 1.0.0",
   "lua-resty-healthcheck == 1.4.0",
   "lua-resty-cookie == 0.1.0",


### PR DESCRIPTION
### Summary

@RyouZhang reported with #6739 that Kong starts to spin CPUs 100% with `2.3.0` when healthchecks are enabled. @murillopaula confirmed it and gave additional information and we could reproduce it easily.

We identified an issue in lua-resty-dns-client 5.2.1 together with @Tieske and @locao, fixed it.

This PR bumps the Kong dependency to the fixed version of the library.

### Issues Resolved

Fix #6739
