### PR TITLE
chore(ci) fix jenkins conditional stage failure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -335,7 +335,7 @@ pipeline {
                 allOf {
                     buildingTag()
                     not { triggeredBy 'TimerTrigger' }
-                    tag pattern: '^\\d+\\.\\d+\\.\\d+$', comparator: "REGEXP"
+                    expression { env.TAG_NAME ==~ /^\d+\.\d+\.\d+$/ }
                 }
             }
             parallel {


### PR DESCRIPTION
`tag pattern` is not working in the context of `when` / `allOf`