### PR TITLE
feat(tags) allow utf-8 in tags

### DIFF
--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -223,8 +223,8 @@ local function validate_options_value(self, options)
       end
     elseif #options.tags > 5 then
       errors.tags = "cannot query more than 5 tags"
-    elseif not match(concat(options.tags), "^[%w%.%-%_~]+$") then
-      errors.tags = "must only contain alphanumeric and '., -, _, ~' characters"
+    elseif not match(concat(options.tags), "^[\033-\043\045\046\048-\126\128-\244]+$") then
+      errors.tags = "must only contain printable ascii (except `,` and `/`) or valid utf-8"
     elseif #options.tags > 1 and options.tags_cond ~= "and" and options.tags_cond ~= "or" then
       errors.tags_cond = "must be a either 'and' or 'or' when more than one tag is specified"
     end

--- a/kong/db/schema/typedefs.lua
+++ b/kong/db/schema/typedefs.lua
@@ -98,12 +98,41 @@ local function validate_name(name)
 end
 
 
-local function validate_utf8_name(name)
-
-  local ok, index = utils.validate_utf8(name)
+local function validate_utf8_string(str)
+  local ok, index = utils.validate_utf8(str)
 
   if not ok then
     return nil, "invalid utf-8 character sequence detected at position " .. tostring(index)
+  end
+
+  return true
+end
+
+
+local function validate_tag(tag)
+
+  local ok, err = validate_utf8_string(tag)
+  if not ok then
+    return nil, err
+  end
+
+  -- printable ASCII (33-126 except ','(44) and '/'(47),
+  -- plus non-ASCII utf8 (128-244)
+  if not match(tag, "^[\033-\043\045\046\048-\126\128-\244]+$") then
+    return nil,
+    "invalid tag '" .. tag ..
+      "': expected printable ascii (except `,` and `/`) or valid utf-8 sequences"
+  end
+
+  return true
+end
+
+
+local function validate_utf8_name(name)
+
+  local ok, err = validate_utf8_string(name)
+  if not ok then
+    return nil, err
   end
 
   if not match(name, "^[%w%.%-%_~\128-\244]+$") then
@@ -369,8 +398,9 @@ typedefs.key = Schema.define {
 typedefs.tag = Schema.define {
   type = "string",
   required = true,
-  match = "^[%w%.%-%_~]+$",
+  custom_validator = validate_tag,
 }
+
 
 typedefs.tags = Schema.define {
   type = "set",

--- a/spec/02-integration/03-db/07-tags_spec.lua
+++ b/spec/02-integration/03-db/07-tags_spec.lua
@@ -392,9 +392,9 @@ for _, strategy in helpers.each_strategy() do
         assert.is_nil(rows)
         assert.match([[tags: must be a table]], err)
 
-        rows, err, _, _ = db.services:page(nil, nil, { tags = { "oops", "@_@" }, tags_cond = 'and' })
+        rows, err, _, _ = db.services:page(nil, nil, { tags = { "oops", string.char(255) }, tags_cond = 'and' })
         assert.is_nil(rows)
-        assert.match([[tags: must only contain alphanumeric and]], err)
+        assert.match([[tags: must only contain printable ascii]], err)
 
         rows, err, _, _ = db.services:page(nil, nil, { tags = { "1", "2", "3", "4", "5", "6" } })
         assert.is_nil(rows)
@@ -407,22 +407,38 @@ for _, strategy in helpers.each_strategy() do
 
     end)
 
-    describe("#db errors if tag value is invalid", function()
-      assert.has_error(function()
-        bp.services:insert({
-          host = "invalid-tag.com",
-          name = "service-invalid-tag",
-          tags = { "invalid tag" }
-        })
-      end, string.format('[%s] schema violation (tags.1: invalid value: invalid tag)', strategy))
+    it("#db errors if tag value is invalid", function()
+      local ok, err = pcall(bp.services.insert, bp.services, {
+        host = "invalid-tag.com",
+        name = "service-invalid-tag",
+        tags = { "tag with spaces" }
+      })
+      assert.is_falsy(ok)
+      assert.matches("invalid tag", err)
 
-      assert.has_error(function()
-        bp.services:insert({
-          host = "invalid-tag.com",
-          name = "service-invalid-tag",
-          tags = { "foo,bar" }
-        })
-      end, string.format('[%s] schema violation (tags.1: invalid value: foo,bar)', strategy))
+      local ok, err = pcall(bp.services.insert, bp.services, {
+        host = "invalid-tag.com",
+        name = "service-invalid-tag",
+        tags = { "tag,with,commas" }
+      })
+      assert.is_falsy(ok)
+      assert.matches("invalid tag", err)
+
+      local ok, err = pcall(bp.services.insert, bp.services, {
+        host = "invalid-tag.com",
+        name = "service-invalid-tag",
+        tags = { "tag/with/slashes" }
+      })
+      assert.is_falsy(ok)
+      assert.matches("invalid tag", err)
+
+      local ok, err = pcall(bp.services.insert, bp.services, {
+        host = "invalid-tag.com",
+        name = "service-invalid-tag",
+        tags = { "tag-with-invalid-utf8" .. string.char(255) }
+      })
+      assert.is_falsy(ok)
+      assert.matches("invalid utf%-8", err)
     end)
 
 


### PR DESCRIPTION
This change expands the range of accepted characters in tags from a limited set of ASCII characters to almost all utf-8 sequences.

Exceptions:
* ',' and '/' are reserved for filtering tags with "and" and "or" and are not allowed in tags
* Non-printable ASCII (like the space character, ' ') is not allowed

Attempting to tag an entity with an invalid utf-8 sequence will raise an error.

Closes #5451 
