### PR TITLE
Fix/patch release script requirements

### DIFF
--- a/scripts/make-patch-release
+++ b/scripts/make-patch-release
@@ -38,6 +38,27 @@ function usage() {
 }
 
 #-------------------------------------------------------------------------------
+function need() {
+  req="$1"
+
+  if [ -z $(which "$req") ]; then
+     echo "Required command $req not found."
+     exit 1
+  fi
+}
+
+function check_requirements() {
+   need git
+   need hub
+   need sed
+
+   if [[ ! "$(sed --version)" =~ "GNU sed" ]]; then
+      echo "FAIL: sed command isn't GNU."
+      exit 1
+   fi
+}
+
+#-------------------------------------------------------------------------------
 # Default help
 #-------------------------------------------------------------------------------
 
@@ -50,6 +71,8 @@ fi
 #-------------------------------------------------------------------------------
 # Variables
 #-------------------------------------------------------------------------------
+
+check_requirements
 
 version="$1"
 step="$2"

--- a/scripts/make-patch-release
+++ b/scripts/make-patch-release
@@ -196,7 +196,7 @@ case "$step" in
          cd ../docs.konghq.com
       else
          cd ..
-         git clone https://github.com/kong/docs.konghq.com
+         git clone git@github.com:Kong/docs.konghq.com.git
          cd docs.konghq.com
       fi
       git checkout master
@@ -206,7 +206,7 @@ case "$step" in
 
       git diff
 
-      CONFIRM "If everything looks all right, press Enter to commit and send a PR to https://github.com/kong/docs.konghq.com" \
+      CONFIRM "If everything looks all right, press Enter to commit and send a PR to git@github.com:Kong/docs.konghq.com.git" \
               "or Ctrl-C to cancel."
 
       set -e
@@ -263,7 +263,7 @@ case "$step" in
          cd ../docker-kong
       else
          cd ..
-         git clone https://github.com/kong/docker-kong
+         git clone git@github.com:Kong/docker-kong.git
          cd docker-kong
       fi
 
@@ -287,7 +287,7 @@ case "$step" in
          cd ../docker-kong
       else
          cd ..
-         git clone https://github.com/kong/docker-kong
+         git clone git@github.com:Kong/docker-kong.git
          cd docker-kong
       fi
 
@@ -304,7 +304,7 @@ case "$step" in
          cd ../homebrew-kong
       else
          cd ..
-         git clone https://github.com/kong/homebrew-kong
+         git clone git@github.com:Kong/homebrew-kong.git
          cd homebrew-kong
       fi
 
@@ -315,7 +315,7 @@ case "$step" in
 
       git diff
 
-      CONFIRM "If everything looks all right, press Enter to commit and send a PR to https://github.com/kong/homebrew-kong" \
+      CONFIRM "If everything looks all right, press Enter to commit and send a PR to git@github.com:Kong/homebrew-kong" \
               "or Ctrl-C to cancel."
 
       set -e
@@ -334,7 +334,7 @@ case "$step" in
          cd ../kong-pongo
       else
          cd ..
-         git clone https://github.com/kong/kong-pongo
+         git clone git@github.com:Kong/kong-pongo.git
          cd kong-pongo
       fi
 
@@ -353,7 +353,7 @@ case "$step" in
          cd ../kong-vagrant
       else
          cd ..
-         git clone https://github.com/kong/kong-vagrant
+         git clone git@github.com:Kong/kong-vagrant.git
          cd kong-vagrant
       fi
 
@@ -364,7 +364,7 @@ case "$step" in
 
       git diff
 
-      CONFIRM "If everything looks all right, press Enter to commit and send a PR to https://github.com/kong/kong-vagrant" \
+      CONFIRM "If everything looks all right, press Enter to commit and send a PR to git@github.com:Kong/kong-vagrant" \
               "or Ctrl-C to cancel."
 
       set -e


### PR DESCRIPTION
Tried to avoid system dependencies by running inside a Docker container, but using SSH for git requires the user's SSH credentials.  As it turns out, the "right" way to do it is very system dependent and very fragile.

It was noted that the `hub` command, which we already require, is installed via homebrew, so requiring the GNU version of `sed` is a very small extra step for the user.

Added checks for the presence and compatibility for the required tools.  It's much better to fail with a readable message before doing something and potentially mess the user's setup.