### PR TITLE
fix(pdk) fix incorrect module name for `kong.pdk.cluster`, which caused

### DIFF
--- a/kong/pdk/cluster.lua
+++ b/kong/pdk/cluster.lua
@@ -1,6 +1,6 @@
---- Node-level utilities
+--- Cluster-level utilities
 --
--- @module kong.node
+-- @module kong.cluster
 
 
 local kong = kong


### PR DESCRIPTION
autodoc tool to not generate the corresponding documentation for it
