### PR TITLE
review.me

### DIFF
--- a/plugins/response-ratelimiting/header_filter.lua
+++ b/plugins/response-ratelimiting/header_filter.lua
@@ -1,0 +1,7 @@
+if not conf.hide_client_headers then
+        ngx.header[RATELIMIT_LIMIT.."-"..limit_name.."-"..period_name] = lv.limit
+        ngx.header[RATELIMIT_REMAINING.."-"..limit_name.."-"..period_name] = math_max(0, lv.remaining - (increments[limit_name] and increments[limit_name] or 0)) -- increment_value for this current request
+      end
+
+      if increments[limit_name] and increments[limit_name] > 0 and lv.remaining <= 0 then
+        stop = true -- No more


### PR DESCRIPTION
One thought here: should exit early out of this loop (via break) if we are omitting headers, and we've reached this condition? Once we've assigned stop = true, we're not doing any other work aside from assigning headers, so breakingnoit early would save some work. Don't know if this is worth it though, so this isn't a blocker to me, just a thought.

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

SUMMARY_GOES_HERE

### Full changelog

* [Implement ...]
* [Add related tests]
* ...

### Issues resolved

Fix #XXX
