### PR TITLE
fix(cmd) `kong migrations` should accept the `-p` or `--prefix` option

### DIFF
--- a/kong/cmd/migrations.lua
+++ b/kong/cmd/migrations.lua
@@ -45,6 +45,8 @@ Options:
 
  -c,--conf        (optional string) Configuration file.
 
+ -p,--prefix      (optional string)   Override prefix directory.
+
 ]]
 
 
@@ -80,7 +82,9 @@ local function execute(args)
     log.disable()
   end
 
-  local conf = assert(conf_loader(args.conf))
+  local conf = assert(conf_loader(args.conf, {
+    prefix = args.prefix
+  }))
 
   package.path = conf.lua_package_path .. ";" .. package.path
 

--- a/spec/02-integration/02-cmd/10-migrations_spec.lua
+++ b/spec/02-integration/02-cmd/10-migrations_spec.lua
@@ -155,6 +155,13 @@ for _, strategy in helpers.each_strategy() do
         assert.same(0, #stdout)
         assert.same(0, #stderr)
       end)
+
+      it("-p accepts a prefix override", function()
+        local code, stdout, stderr = run_kong("migrations bootstrap -p /dev/null")
+        assert.equal(1, code)
+        assert.equal(0, #stdout)
+        assert.match("/dev/null is not a directory", stderr, 1, true)
+      end)
     end)
 
     describe("list", function()


### PR DESCRIPTION
to override the default prefix

In https://github.com/Kong/kong/pull/6650 we decided to create the combined cert under the prefix directory. However, we forgot to add the `-p` or `--prefix` option support which means when user runs `kong migrations` command as non-privileged user, the following error will be shown with no way to get around (unless run as `root`):

```
prefix directory /usr/local/kong not found, trying to create it
Error: Permission denied
```