### PR TITLE
fix(hmac-auth) fix issue with validation if-statement

### DIFF
--- a/kong/plugins/hmac-auth/access.lua
+++ b/kong/plugins/hmac-auth/access.lua
@@ -55,7 +55,7 @@ end
 
 local function validate_params(params, conf)
   -- check username and signature are present
-  if not params.username and params.signature then
+  if not params.username or not params.signature then
     return nil, "username or signature missing"
   end
 

--- a/kong/plugins/hmac-auth/handler.lua
+++ b/kong/plugins/hmac-auth/handler.lua
@@ -4,7 +4,7 @@ local access = require "kong.plugins.hmac-auth.access"
 
 local HMACAuthHandler = {
   PRIORITY = 1000,
-  VERSION = "2.2.0",
+  VERSION = "2.2.1",
 }
 
 


### PR DESCRIPTION
### Summary

It was reported as part of the issue #6804 that `hmac-auth` plugin has a bug in one if statement. This commit fixes that.

It didn't cause any security issues as it was catched later on, but still it is good to fix this.