### PR TITLE
feat(cassandra) expose TLS encryption version from lua-cassandra

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1020,6 +1020,10 @@
 #cassandra_ssl = off             # Toggles client-to-node TLS connections
                                  # between Kong and Cassandra.
 
+#cassandra_ssl_encryption_protocol = tlsv1      # When using ssl between Kong and Cassandra,
+                                                # the version of tls to use. Accepted values are
+                                                # `tlsv1` or `tlsv1_2`
+
 #cassandra_ssl_verify = off      # Toggles server certificate verification if
                                  # `cassandra_ssl` is enabled.
                                  # See the `lua_ssl_trusted_certificate`

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -456,6 +456,7 @@ local CONF_INFERENCES = {
   cassandra_password = { typ = "string" },
   cassandra_timeout = { typ = "number" },
   cassandra_ssl = { typ = "boolean" },
+  cassandra_ssl_encryption_protocol = { typ = "string" },
   cassandra_ssl_verify = { typ = "boolean" },
   cassandra_write_consistency = { enum = {
                                   "ALL",

--- a/kong/db/strategies/cassandra/connector.lua
+++ b/kong/db/strategies/cassandra/connector.lua
@@ -143,6 +143,7 @@ function CassandraConnector.new(kong_config)
     timeout_read              = kong_config.cassandra_timeout,
     max_schema_consensus_wait = kong_config.cassandra_schema_consensus_timeout,
     ssl                       = kong_config.cassandra_ssl,
+    encryption_protocol       = kong_config.cassandra_ssl_encryption_protocol,
     verify                    = kong_config.cassandra_ssl_verify,
     cafile                    = kong_config.lua_ssl_trusted_certificate_combined,
     lock_timeout              = 30,

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -120,6 +120,7 @@ cassandra_port = 9042
 cassandra_keyspace = kong
 cassandra_timeout = 5000
 cassandra_ssl = off
+cassandra_ssl_encryption_protocol = tlsv1
 cassandra_ssl_verify = off
 cassandra_username = kong
 cassandra_password = NONE


### PR DESCRIPTION
Relies on this PR to merge and ship first: https://github.com/thibaultcha/lua-cassandra/pull/141

Closes FTI-2249

Signed-off-by: Jeremy J. Miller <jeremy.miller@konghq.com>
