### PR TITLE
fix(docs) remove note on ssl on stream_listen

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -372,10 +372,6 @@
                          #   `net.core.somaxconn` at the same time to match or
                          #   exceed the `backlog` number set.
                          #
-                         # **Note:** The `ssl` suffix is not supported,
-                         # and each address/port will accept TCP with or
-                         # without TLS enabled.
-                         #
                          # Examples:
                          #
                          # ```


### PR DESCRIPTION
### Summary

@juumixx reported on #6823 about a left-over note in our configuration docs. This commit removes the note.

### Issues Resolved

Fix #6823