### PR TITLE
fix(admin) do not send prng_seeds but instead send pids

### DIFF
--- a/kong/globalpatches.lua
+++ b/kong/globalpatches.lua
@@ -228,92 +228,96 @@ return function(options)
     -- This patched method will create a unique seed per worker process,
     -- using a combination of both time and the worker's pid.
     local util = require "kong.tools.utils"
-    local seeds = {}
+    local seeded = {}
     local randomseed = math.randomseed
 
     _G.math.randomseed = function()
       local pid = ngx.worker.pid()
-      local seed = seeds[pid]
-      if not seed then
-        local phase = ngx.get_phase()
-        if not options.cli and (phase ~= "init_worker" and phase ~= "init") then
-          ngx.log(ngx.WARN, debug.traceback("math.randomseed() must be " ..
-                                            "called in init or init_worker context", 2))
+      local id
+      local is_seeded
+      local phase = ngx.get_phase()
+      if phase == "init" then
+        id = "master"
+        is_seeded = seeded.master
+
+      else
+        id = ngx.worker.id()
+        is_seeded = seeded[pid]
+      end
+
+
+      if is_seeded then
+        ngx.log(ngx.DEBUG, debug.traceback("attempt to seed already seeded random number " ..
+                                           "generator on process #" .. tostring(pid), 2))
+        return
+      end
+
+      if not options.cli and (phase ~= "init_worker" and phase ~= "init") then
+        ngx.log(ngx.WARN, debug.traceback("math.randomseed() must be called in " ..
+                                          "init or init_worker context", 2))
+      end
+
+      local seed
+      local bytes, err = util.get_rand_bytes(8)
+      if bytes then
+        ngx.log(ngx.DEBUG, "seeding PRNG from OpenSSL RAND_bytes()")
+
+        local t = {}
+        for i = 1, #bytes do
+          local byte = string.byte(bytes, i)
+          t[#t+1] = byte
         end
 
-        local bytes, err = util.get_rand_bytes(8)
-        if bytes then
-          ngx.log(ngx.DEBUG, "seeding PRNG from OpenSSL RAND_bytes()")
-
-          local t = {}
-          for i = 1, #bytes do
-            local byte = string.byte(bytes, i)
-            t[#t+1] = byte
-          end
-
-          local str = table.concat(t)
-          if #str > 12 then
-            -- truncate the final number to prevent integer overflow,
-            -- since math.randomseed() could get cast to a platform-specific
-            -- integer with a different size and get truncated, hence, lose
-            -- randomness.
-            -- double-precision floating point should be able to represent numbers
-            -- without rounding with up to 15/16 digits but let's use 12 of them.
-            str = string.sub(str, 1, 12)
-          end
-
-          seed = tonumber(str)
-
-        else
-          ngx.log(ngx.ERR, "could not seed from OpenSSL RAND_bytes, seeding ",
-                           "PRNG with time and worker pid instead (this can ",
-                           "result to duplicated seeds): ", err)
-
-          seed = ngx.now() * 1000 + pid
+        local str = table.concat(t)
+        if #str > 12 then
+          -- truncate the final number to prevent integer overflow,
+          -- since math.randomseed() could get cast to a platform-specific
+          -- integer with a different size and get truncated, hence, lose
+          -- randomness.
+          -- double-precision floating point should be able to represent numbers
+          -- without rounding with up to 15/16 digits but let's use 12 of them.
+          str = string.sub(str, 1, 12)
         end
 
-        local id
-        if phase == "init" then
-          id = "master"
-          ngx.log(ngx.DEBUG, "random seed: ", seed, " for master process")
+        seed = tonumber(str)
 
-        else
-          id = ngx.worker.id()
-          ngx.log(ngx.DEBUG, "random seed: ", seed, " for worker process #", id)
-        end
+      else
+        ngx.log(ngx.ERR, "could not seed from OpenSSL RAND_bytes, seeding ",
+                         "PRNG with time and process id instead (this can ",
+                         "result to duplicated seeds): ", err)
 
-        if not options.cli then
-          local kong_shm = ngx.shared.kong
-          if id == "master" then
-            local old_master_pid = kong_shm:get("pids:master")
-            if old_master_pid then
-              kong_shm:delete("seeds:" .. old_master_pid)
-            end
+        seed = ngx.now() * 1000 + pid
+      end
 
-            local worker_count = ngx.worker.count()
-            local old_worker_count = kong_shm:get("worker:count")
-            if old_worker_count and old_worker_count > worker_count then
-              for i = worker_count, old_worker_count - 1 do
-                local old_worker_pid = kong_shm:get("pids:" .. i)
-                if old_worker_pid then
-                  kong_shm:delete("pids:" .. i)
-                  kong_shm:delete("seeds:" .. old_worker_pid)
-                  kong_shm:delete("kong:mem:" .. old_worker_pid)
-                end
-              end
-            end
-
-            if old_worker_count ~= worker_count then
-              local ok, err = kong_shm:safe_set("worker:count", worker_count)
-              if not ok then
-                ngx.log(ngx.WARN, "could not store worker count in kong shm: ", err)
+      if not options.cli then
+        local kong_shm = ngx.shared.kong
+        if id == "master" then
+          local worker_count = ngx.worker.count()
+          local old_worker_count = kong_shm:get("worker:count")
+          if old_worker_count and old_worker_count > worker_count then
+            for i = worker_count, old_worker_count - 1 do
+              local old_worker_pid = kong_shm:get("pids:" .. i)
+              if old_worker_pid then
+                seeded[old_worker_pid] = nil
+                kong_shm:delete("pids:" .. i)
+                kong_shm:delete("kong:mem:" .. old_worker_pid)
               end
             end
           end
 
+          if old_worker_count ~= worker_count then
+            local ok, err = kong_shm:safe_set("worker:count", worker_count)
+            if not ok then
+              ngx.log(ngx.WARN, "could not store worker count in kong shm: ", err)
+            end
+          end
+
+          seeded.master = true
+
+        else
           local old_worker_pid = kong_shm:get("pids:" .. id)
           if old_worker_pid then
-            kong_shm:delete("seeds:" .. old_worker_pid)
+            seeded[old_worker_pid] = nil
             kong_shm:delete("kong:mem:" .. old_worker_pid)
           end
 
@@ -322,20 +326,11 @@ return function(options)
             ngx.log(ngx.WARN, "could not store process id in kong shm: ", err)
           end
 
-          local ok, err = kong_shm:safe_set("seeds:" .. pid, seed)
-          if not ok then
-            ngx.log(ngx.WARN, "could not store PRNG seed in kong shm: ", err)
-          end
+          seeded[pid] = true
         end
-
-        randomseed(seed)
-        seeds[ngx.worker.pid()] = seed
-      else
-        ngx.log(ngx.DEBUG, debug.traceback("attempt to seed random number " ..
-            "generator, but already seeded with: " .. tostring(seed), 2))
       end
 
-      return seed
+      return randomseed(seed)
     end
   end
 

--- a/spec/02-integration/04-admin_api/02-kong_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/02-kong_routes_spec.lua
@@ -97,18 +97,28 @@ describe("Admin API - Kong routes with strategy #" .. strategy, function()
       assert.is_string(json.configuration.pg_password)
       assert.not_equal("hide_me", json.configuration.pg_password)
     end)
-    it("returns PRNG seeds", function()
+    it("returns process ids", function()
       local res = assert(client:send {
         method = "GET",
         path = "/",
       })
       local body = assert.response(res).has.status(200)
       local json = cjson.decode(body)
-      assert.is_table(json.prng_seeds)
-      for k in pairs(json.prng_seeds) do
-        assert.matches("pid: %d+", k)
-        assert.matches("%d+", k)
+      assert.is_table(json.pids)
+      assert.matches("%d+", json.pids.master)
+      for _, v in pairs(json.pids.workers) do
+        assert.matches("%d+", v)
       end
+    end)
+
+    it("does not return PRNG seeds", function()
+      local res = assert(client:send {
+        method = "GET",
+        path = "/",
+      })
+      local body = assert.response(res).has.status(200)
+      local json = cjson.decode(body)
+      assert.is_nil(json.prng_seeds)
     end)
   end)
 


### PR DESCRIPTION
### Summary

- Removes `prng_seeds` from shared dictionaries
- Removes `prng_seeds` from local variable
- Removes `prng_seeds` from `:8001/`
- Adds `pids` to `:8001/`