### PR TITLE
chore(rockspec) bump lua-resty-healthcheck to 1.4.1

### DIFF
--- a/kong-2.3.2-0.rockspec
+++ b/kong-2.3.2-0.rockspec
@@ -32,7 +32,7 @@ dependencies = {
   "lua_pack == 1.0.5",
   "lua-resty-dns-client == 5.2.1",
   "lua-resty-worker-events == 1.0.0",
-  "lua-resty-healthcheck == 1.4.0",
+  "lua-resty-healthcheck == 1.4.1",
   "lua-resty-cookie == 0.1.0",
   "lua-resty-mlcache == 2.5.0",
   "lua-messagepack == 0.5.2",


### PR DESCRIPTION
### Issues resolved

Fix #6788 #6801
