### PR TITLE
fix(external_plugins) exec on the spawned plugin server

### DIFF
--- a/kong/runloop/plugin_servers/process.lua
+++ b/kong/runloop/plugin_servers/process.lua
@@ -235,9 +235,13 @@ function proc_mgmt.pluginserver_timer(premature, server_def)
     return
   end
 
+  if ngx.config.subsystem ~= "http" then
+    return
+  end
+
   while not ngx.worker.exiting() do
     kong.log.notice("Starting " .. server_def.name or "")
-    server_def.proc = assert(ngx_pipe.spawn(server_def.start_command, {
+    server_def.proc = assert(ngx_pipe.spawn("exec " .. server_def.start_command, {
       merge_stderr = true,
     }))
     server_def.proc:set_timeouts(nil, nil, nil, 0)     -- block until something actually happens


### PR DESCRIPTION
and not start plugin server in unsupported stream subsystem


### Summary

The current mode of `spawn` will left the plugin server alive after Kong exits. This PR prefix command
with `exec` so that `sh` is replaced by the actual process.
This can be alternatively done by providing a table to `ngx_pipe.spawn`, which may be more ideal (but is
also harder to do right since we will then need to seperate argument by spaces).

Also the plugin server is now not started in stream subsystem as ngx.pipe seems not supported in stream
subsystem.

### Full changelog

* Use exec on the spawned plugin server
* Don't start plugin server in unsupported stream subsystem

See also https://github.com/openresty/lua-nginx-module/issues/1855