### PR TITLE
fix(balancer) pass ctx to balancer.execute

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -950,7 +950,7 @@ function Kong.balancer()
       end
     end
 
-    local ok, err, errcode = balancer_execute(balancer_data)
+    local ok, err, errcode = balancer_execute(balancer_data, ctx)
     if not ok then
       ngx_log(ngx_ERR, "failed to retry the dns/balancer resolver for ",
               tostring(balancer_data.host), "' with: ", tostring(err))

--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -11,6 +11,7 @@ local dns_client = require "resty.dns.client"
 
 
 local toip = dns_client.toip
+local ngx = ngx
 local log = ngx.log
 local sleep = ngx.sleep
 local null = ngx.null
@@ -1002,6 +1003,10 @@ local function execute(target, ctx)
     end
 
     if balancer then
+      if not ctx then
+        ctx = ngx.ctx
+      end
+
       -- store for retries
       target.balancer = balancer
 


### PR DESCRIPTION
### Summary

There seems to be a bug where we didn't pass `ctx` always to `balancer.execute`, this should fix it.