### PR TITLE
fix(admin-api) declarative config json/yaml loading

### DIFF
--- a/kong/api/api_helpers.lua
+++ b/kong/api/api_helpers.lua
@@ -206,6 +206,9 @@ end
 
 
 local NEEDS_BODY = tablex.readonly({ PUT = 1, POST = 2, PATCH = 3 })
+local ACCEPTS_YAML = tablex.readonly({
+  ["/config"] = true,
+})
 
 
 function _M.before_filter(self)
@@ -227,9 +230,11 @@ function _M.before_filter(self)
       end
     end
 
-  elseif sub(content_type, 1, 16) == "application/json"                  or
-         sub(content_type, 1, 19) == "multipart/form-data"               or
-         sub(content_type, 1, 33) == "application/x-www-form-urlencoded" then
+  elseif sub(content_type, 1, 16) == "application/json"
+      or sub(content_type, 1, 19) == "multipart/form-data"
+      or sub(content_type, 1, 33) == "application/x-www-form-urlencoded"
+      or (ACCEPTS_YAML[self.route_name] and sub(content_type, 1,  9) == "text/yaml")
+  then
     return
   end
 

--- a/kong/api/routes/config.lua
+++ b/kong/api/routes/config.lua
@@ -77,9 +77,14 @@ return {
       else
         local config = self.params.config
         if not config then
-          return kong.response.exit(400, {
-            message = "expected a declarative configuration"
-          })
+          local body = kong.request.get_raw_body()
+          if type(body) == "string" and #body > 0 then
+            config = body
+          else
+            return kong.response.exit(400, {
+              message = "expected a declarative configuration"
+            })
+          end
         end
         entities, _, err_t, meta, new_hash =
           dc:parse_string(config, nil, accept, old_hash)

--- a/spec/02-integration/04-admin_api/15-off_spec.lua
+++ b/spec/02-integration/04-admin_api/15-off_spec.lua
@@ -200,19 +200,36 @@ describe("Admin API #off", function()
             _format_version = "1.1",
             consumers = {
               {
-                username = "bobby",
+                username = "bobby_in_json_body",
               },
             },
           },
           headers = {
             ["Content-Type"] = "application/json"
-          }
+          },
         })
 
         assert.response(res).has.status(201)
       end)
 
-      it("accepts configuration as a JSON string", function()
+      it("accepts configuration as YAML body", function()
+        local res = assert(client:send {
+          method = "POST",
+          path = "/config",
+          body = helpers.unindent([[
+            _format_version: "1.1"
+            consumers:
+              - username: "bobby_in_yaml_body"
+          ]]),
+          headers = {
+            ["Content-Type"] = "text/yaml"
+          },
+        })
+
+        assert.response(res).has.status(201)
+      end)
+
+      it("accepts configuration as a JSON string under `config` JSON key", function()
         local res = assert(client:send {
           method = "POST",
           path = "/config",
@@ -222,15 +239,34 @@ describe("Admin API #off", function()
               "_format_version" : "1.1",
               "consumers" : [
                 {
-                  "username" : "bobby",
-                },
-              ],
+                  "username" : "bobby_in_json_under_config"
+                }
+              ]
             }
             ]],
           },
           headers = {
             ["Content-Type"] = "application/json"
-          }
+          },
+        })
+
+        assert.response(res).has.status(201)
+      end)
+
+      it("accepts configuration as a YAML string under `config` JSON key", function()
+        local res = assert(client:send {
+          method = "POST",
+          path = "/config",
+          body = {
+            config = helpers.unindent([[
+              _format_version: "1.1"
+              consumers:
+                - username: "bobby_in_yaml_under_config"
+            ]]),
+          },
+          headers = {
+            ["Content-Type"] = "application/json"
+          },
         })
 
         assert.response(res).has.status(201)
@@ -246,15 +282,16 @@ describe("Admin API #off", function()
               "_format_version" : "1.1",
               "consumers" : [
                 {
-                  "username" : "previous",
-                },
-              ],
+                  "username" : "previous"
+                }
+              ]
             }
             ]],
+            type = "json",
           },
           headers = {
             ["Content-Type"] = "application/json"
-          }
+          },
         })
 
         assert.response(res).has.status(201)
@@ -282,7 +319,7 @@ describe("Admin API #off", function()
         for i = 1, 20000 do
           table.insert(consumers, [[
             {
-              "username" : "bobby-]] .. i .. [[",
+              "username" : "bobby-]] .. i .. [["
             }
           ]])
         end
@@ -325,25 +362,6 @@ describe("Admin API #off", function()
           end
         end, WORKER_SYNC_TIMEOUT)
 
-      end)
-
-      it("accepts configuration as a YAML string", function()
-        local res = assert(client:send {
-          method = "POST",
-          path = "/config",
-          body = {
-            config = [[
-            _format_version: "1.1"
-            consumers:
-            - username: bobby
-            ]],
-          },
-          headers = {
-            ["Content-Type"] = "application/json"
-          }
-        })
-
-        assert.response(res).has.status(201)
       end)
 
       it("accepts configuration containing null as a YAML string", function()


### PR DESCRIPTION
This PR adds a way to load declarative config as an inline YAML file.

Previously it was possible only as a YAML string inside the the `config` JSON payload. Now JSON and YAML have parity of ways to being loaded.

In addition to that fix, the reading algorithm has been changed so that JSON is always tried first, then YAML, then Lua (when enabled).

This fixes a previous problem in which the YAML parser was used erroneously to parse JSON configs.

This last fix is what made us make those slight changes in the tests. Things like trailing commas were accepted by the YAML parser but are not valid JSON.