### PR TITLE
chore(deps) bump lua-cassandra to 1.5.1 (FTI-2249)

### DIFF
--- a/kong-2.3.2-0.rockspec
+++ b/kong-2.3.2-0.rockspec
@@ -22,7 +22,7 @@ dependencies = {
   "multipart == 0.5.9",
   "version == 1.0.1",
   "kong-lapis == 1.8.1.2",
-  "lua-cassandra == 1.5.0",
+  "lua-cassandra == 1.5.1",
   "pgmoon == 1.12.0",
   "luatz == 0.4",
   "lua_system_constants == 0.1.4",


### PR DESCRIPTION
This bumps the lua-cassandra dep. The new lua-cassandra changes [1]
impact the selection of SSL/TLS protocol chosen during the handshake
negotiation. Prior, the version was hardcoded to 'tlsv1'. Now, the
client will select the highest version available out of the following
allowable values: 'tlsv1_1', 'tlsv1_2', 'tlsv1_3'.

This fixes https://konghq.atlassian.net/browse/FTI-2249

[1] - https://github.com/thibaultcha/lua-cassandra/commit/d742d5ca844a23da487b8f33e67559ff369e62a9

Signed-off-by: Jeremy J. Miller <jeremy.miller@konghq.com>
