### PR TITLE
fix(router) sanitize path postfix

### DIFF
--- a/kong/router.lua
+++ b/kong/router.lua
@@ -770,6 +770,27 @@ local function categorize_route_t(route_t, bit_category, categories)
 end
 
 
+local function sanitize_uri_postfix(uri_postfix)
+  if not uri_postfix or uri_postfix == "" then
+    return uri_postfix
+  end
+
+  if uri_postfix == "." or uri_postfix == ".." then
+    return ""
+  end
+
+  if sub(uri_postfix, 1, 2) == "./" then
+    return sub(uri_postfix, 3)
+  end
+
+  if sub(uri_postfix, 1, 3) == "../" then
+    return sub(uri_postfix, 4)
+  end
+
+  return uri_postfix
+end
+
+
 do
   local matchers = {
     [MATCH_RULES.HOST] = function(route_t, ctx)
@@ -844,16 +865,19 @@ do
             end
 
             if m then
-              ctx.matches.uri_postfix = m.uri_postfix
-              ctx.matches.uri = uri_t.value
-
-              if m.uri_postfix then
-                ctx.matches.uri_prefix = sub(ctx.req_uri, 1, -(#m.uri_postfix + 1))
+              local uri_postfix = m.uri_postfix
+              if uri_postfix then
+                ctx.matches.uri_prefix = sub(ctx.req_uri, 1, -(#uri_postfix + 1))
 
                 -- remove the uri_postfix group
                 m[#m] = nil
                 m.uri_postfix = nil
+
+                uri_postfix = sanitize_uri_postfix(uri_postfix)
               end
+
+              ctx.matches.uri = uri_t.value
+              ctx.matches.uri_postfix = uri_postfix
 
               if uri_t.has_captures then
                 ctx.matches.uri_captures = m
@@ -865,7 +889,7 @@ do
 
           -- plain or prefix match from the index
           ctx.matches.uri_prefix = sub(ctx.req_uri, 1, #uri_t.value)
-          ctx.matches.uri_postfix = sub(ctx.req_uri, #uri_t.value + 1)
+          ctx.matches.uri_postfix = sanitize_uri_postfix(sub(ctx.req_uri, #uri_t.value + 1))
           ctx.matches.uri = uri_t.value
 
           return true
@@ -883,16 +907,19 @@ do
           end
 
           if m then
-            ctx.matches.uri_postfix = m.uri_postfix
-            ctx.matches.uri = uri_t.value
-
-            if m.uri_postfix then
-              ctx.matches.uri_prefix = sub(ctx.req_uri, 1, -(#m.uri_postfix + 1))
+            local uri_postfix = m.uri_postfix
+            if uri_postfix then
+              ctx.matches.uri_prefix = sub(ctx.req_uri, 1, -(#uri_postfix + 1))
 
               -- remove the uri_postfix group
               m[#m] = nil
               m.uri_postfix = nil
+
+              uri_postfix = sanitize_uri_postfix(uri_postfix)
             end
+
+            ctx.matches.uri = uri_t.value
+            ctx.matches.uri_postfix = uri_postfix
 
             if uri_t.has_captures then
               ctx.matches.uri_captures = m
@@ -906,7 +933,7 @@ do
           local from, to = find(ctx.req_uri, uri_t.value, nil, true)
           if from == 1 then
             ctx.matches.uri_prefix = sub(ctx.req_uri, 1, to)
-            ctx.matches.uri_postfix = sub(ctx.req_uri, to + 1)
+            ctx.matches.uri_postfix = sanitize_uri_postfix(sub(ctx.req_uri, to + 1))
             ctx.matches.uri = uri_t.value
 
             return true


### PR DESCRIPTION
### Summary

The PR #6821 by @dndx implemented path normalization, but there is another case with path stripping where
the uri postfix is not sanitized correctly for a better security. This commit fixes that.