### PR TITLE
fix(pdk) kong.log.serialize to use KONG_PROXY_LATENCY

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -99,6 +99,7 @@ local ngx_WARN         = ngx.WARN
 local ngx_INFO         = ngx.INFO
 local ngx_DEBUG        = ngx.DEBUG
 local subsystem        = ngx.config.subsystem
+local start_time       = ngx.req.start_time
 local type             = type
 local error            = error
 local ipairs           = ipairs
@@ -637,11 +638,11 @@ end
 function Kong.preread()
   local ctx = ngx.ctx
   if not ctx.KONG_PROCESSING_START then
-    ctx.KONG_PROCESSING_START = get_now_ms()
+    ctx.KONG_PROCESSING_START = start_time() * 1000
   end
 
   if not ctx.KONG_PREREAD_START then
-    ctx.KONG_PREREAD_START = ctx.KONG_PROCESSING_START
+    ctx.KONG_PREREAD_START = get_now_ms()
   end
 
   kong_global.set_phase(kong, PHASES.preread)
@@ -656,6 +657,7 @@ function Kong.preread()
   if not ctx.service then
     ctx.KONG_PREREAD_ENDED_AT = get_now_ms()
     ctx.KONG_PREREAD_TIME = ctx.KONG_PREREAD_ENDED_AT - ctx.KONG_PREREAD_START
+    ctx.KONG_RESPONSE_LATENCY = ctx.KONG_PREREAD_ENDED_AT - ctx.KONG_PROCESSING_START
 
     ngx_log(ngx_WARN, "no Service found with those values")
     return ngx.exit(503)
@@ -705,7 +707,7 @@ function Kong.rewrite()
 
   local ctx = ngx.ctx
   if not ctx.KONG_PROCESSING_START then
-    ctx.KONG_PROCESSING_START = ngx.req.start_time() * 1000
+    ctx.KONG_PROCESSING_START = start_time() * 1000
   end
 
   if not ctx.KONG_REWRITE_START then
@@ -1049,7 +1051,7 @@ end
 function Kong.header_filter()
   local ctx = ngx.ctx
   if not ctx.KONG_PROCESSING_START then
-    ctx.KONG_PROCESSING_START = ngx.req.start_time() * 1000
+    ctx.KONG_PROCESSING_START = start_time() * 1000
   end
 
   if not ctx.workspace then
@@ -1199,6 +1201,10 @@ function Kong.log()
   if not ctx.KONG_LOG_START then
     ctx.KONG_LOG_START = get_now_ms()
     if subsystem == "stream" then
+      if not ctx.KONG_PROCESSING_START then
+        ctx.KONG_PROCESSING_START = start_time() * 1000
+      end
+
       if ctx.KONG_PREREAD_START and not ctx.KONG_PREREAD_ENDED_AT then
         ctx.KONG_PREREAD_ENDED_AT = ctx.KONG_LOG_START
         ctx.KONG_PREREAD_TIME = ctx.KONG_PREREAD_ENDED_AT -
@@ -1209,6 +1215,17 @@ function Kong.log()
         ctx.KONG_BALANCER_ENDED_AT = ctx.KONG_LOG_START
         ctx.KONG_BALANCER_TIME = ctx.KONG_BALANCER_ENDED_AT -
                                  ctx.KONG_BALANCER_START
+      end
+
+      if ctx.KONG_PROXIED then
+        if not ctx.KONG_PROXY_LATENCY then
+          ctx.KONG_PROXY_LATENCY = ctx.KONG_LOG_START -
+                                   ctx.KONG_PROCESSING_START
+        end
+
+      elseif not ctx.KONG_RESPONSE_LATENCY then
+        ctx.KONG_RESPONSE_LATENCY = ctx.KONG_LOG_START -
+                                    ctx.KONG_PROCESSING_START
       end
 
     else
@@ -1302,7 +1319,7 @@ local function serve_content(module, options)
   kong_global.set_phase(kong, PHASES.admin_api)
 
   local ctx = ngx.ctx
-  ctx.KONG_PROCESSING_START = ngx.req.start_time() * 1000
+  ctx.KONG_PROCESSING_START = start_time() * 1000
   ctx.KONG_ADMIN_CONTENT_START = ctx.KONG_ADMIN_CONTENT_START or get_now_ms()
 
 
@@ -1351,7 +1368,7 @@ function Kong.admin_header_filter()
   local ctx = ngx.ctx
 
   if not ctx.KONG_PROCESSING_START then
-    ctx.KONG_PROCESSING_START = ngx.req.start_time() * 1000
+    ctx.KONG_PROCESSING_START = start_time() * 1000
   end
 
   if not ctx.KONG_ADMIN_HEADER_FILTER_START then

--- a/kong/pdk/log.lua
+++ b/kong/pdk/log.lua
@@ -737,10 +737,8 @@ do
         },
         tries = (ctx.balancer_data or {}).tries,
         latencies = {
-          kong = (ctx.KONG_ACCESS_TIME or 0) +
-                 (ctx.KONG_RECEIVE_TIME or 0) +
-                 (ctx.KONG_REWRITE_TIME or 0) +
-                 (ctx.KONG_BALANCER_TIME or 0),
+          kong = (ctx.KONG_PROXY_LATENCY or ctx.KONG_RESPONSE_LATENCY or 0) +
+                 (ctx.KONG_RECEIVE_TIME or 0),
           proxy = ctx.KONG_WAITING_TIME or -1,
           request = var.request_time * 1000
         },
@@ -749,7 +747,7 @@ do
         service = ctx.service,
         consumer = ctx.authenticated_consumer,
         client_ip = var.remote_addr,
-        started_at = req.start_time() * 1000
+        started_at = ctx.KONG_PROCESSING_START or (req.start_time() * 1000)
       })
     end
 
@@ -777,7 +775,7 @@ do
         session_tls = {
           version = session_tls_ver,
           cipher = var.ssl_cipher,
-          client_verify = ngx.ctx.CLIENT_VERIFY_OVERRIDE or var.ssl_client_verify,
+          client_verify = ctx.CLIENT_VERIFY_OVERRIDE or var.ssl_client_verify,
         }
       end
 
@@ -797,8 +795,7 @@ do
         },
         tries = (ctx.balancer_data or {}).tries,
         latencies = {
-          kong = (ctx.KONG_PREREAD_TIME or 0) +
-                 (ctx.KONG_BALANCER_TIME or 0),
+          kong = ctx.KONG_PROXY_LATENCY or ctx.KONG_RESPONSE_LATENCY or 0,
           session = var.session_time * 1000,
         },
         authenticated_entity = authenticated_entity,
@@ -806,7 +803,7 @@ do
         service = ctx.service,
         consumer = ctx.authenticated_consumer,
         client_ip = var.remote_addr,
-        started_at = req.start_time() * 1000
+        started_at = ctx.KONG_PROCESSING_START or (req.start_time() * 1000)
       })
     end
   end

--- a/spec/fixtures/custom_plugins/kong/plugins/ctx-tests/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/ctx-tests/handler.lua
@@ -4,6 +4,7 @@ local type = type
 local assert = assert
 local subsystem = ngx.config.subsystem
 local math = math
+local get_phase = ngx.get_phase
 
 
 local function is_nil(ctx, name)
@@ -135,6 +136,13 @@ local function has_correct_proxy_latency(ctx)
     latency = ctx.KONG_BALANCER_ENDED_AT - ngx.req.start_time() * 1000
     if ctx.KONG_PROXY_LATENCY ~= latency then
       return false, "[ctx-tests] KONG_PROXY_LATENCY is not calculated correctly (request start time)"
+    end
+  end
+
+  if get_phase() == "log" then
+    local log = kong.log.serialize()
+    if ctx.KONG_PROXY_LATENCY > log.latencies.kong then
+      return false, "[ctx-tests] kong.log.serialize() latency is less than KONG_PROXY_LATENCY"
     end
   end
 


### PR DESCRIPTION
### Summary


`kong.log.serialize()` did its own calculation of Kong proxy latency that didn't account all the latencies (e.g. SSL).
