### PR TITLE
feat(template) allow os.getenv in the template renderer

### DIFF
--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -210,7 +210,10 @@ local function compile_conf(kong_config, conf_template)
     _escape = ">",
     pairs = pairs,
     ipairs = ipairs,
-    tostring = tostring
+    tostring = tostring,
+    os = {
+      getenv = os.getenv,
+    }
   }
 
   do


### PR DESCRIPTION
This enables code like this in the templates:

```
some_directive $(os.getenv("SOME_ENV_VAR"));
```

Fixes: #6546