### PR TITLE
 feat(proxy) enable ssl_certificate phase on plugins with stream module

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -634,6 +634,24 @@ function Kong.init_worker()
 end
 
 
+function Kong.ssl_certificate()
+  kong_global.set_phase(kong, PHASES.certificate)
+
+  -- this doesn't really work across the phases currently (OpenResty 1.13.6.2),
+  -- but it returns a table (rewrite phase clears it)
+  local ctx = ngx.ctx
+  log_init_worker_errors(ctx)
+
+  -- this is the first phase to run on an HTTPS request
+  ctx.workspace = kong.default_workspace
+
+  runloop.certificate.before(ctx)
+  local plugins_iterator = runloop.get_updated_plugins_iterator()
+  execute_plugins_iterator(plugins_iterator, "certificate", ctx)
+  runloop.certificate.after(ctx)
+end
+
+
 function Kong.preread()
   local ctx = ngx.ctx
   if not ctx.KONG_PROCESSING_START then
@@ -668,24 +686,6 @@ function Kong.preread()
 
   -- we intent to proxy, though balancer may fail on that
   ctx.KONG_PROXIED = true
-end
-
-
-function Kong.ssl_certificate()
-  kong_global.set_phase(kong, PHASES.certificate)
-
-  -- this doesn't really work across the phases currently (OpenResty 1.13.6.2),
-  -- but it returns a table (rewrite phase clears it)
-  local ctx = ngx.ctx
-  log_init_worker_errors(ctx)
-
-  -- this is the first phase to run on an HTTPS request
-  ctx.workspace = kong.default_workspace
-
-  runloop.certificate.before(ctx)
-  local plugins_iterator = runloop.get_updated_plugins_iterator()
-  execute_plugins_iterator(plugins_iterator, "certificate", ctx)
-  runloop.certificate.after(ctx)
 end
 
 
@@ -792,94 +792,6 @@ function Kong.access()
 
   if ctx.buffered_proxying and ngx.req.http_version() < 2 then
     return Kong.response()
-  end
-end
-
-do
-  local HTTP_METHODS = {
-    GET       = ngx.HTTP_GET,
-    HEAD      = ngx.HTTP_HEAD,
-    PUT       = ngx.HTTP_PUT,
-    POST      = ngx.HTTP_POST,
-    DELETE    = ngx.HTTP_DELETE,
-    OPTIONS   = ngx.HTTP_OPTIONS,
-    MKCOL     = ngx.HTTP_MKCOL,
-    COPY      = ngx.HTTP_COPY,
-    MOVE      = ngx.HTTP_MOVE,
-    PROPFIND  = ngx.HTTP_PROPFIND,
-    PROPPATCH = ngx.HTTP_PROPPATCH,
-    LOCK      = ngx.HTTP_LOCK,
-    UNLOCK    = ngx.HTTP_UNLOCK,
-    PATCH     = ngx.HTTP_PATCH,
-    TRACE     = ngx.HTTP_TRACE,
-  }
-
-  function Kong.response()
-    local plugins_iterator = runloop.get_plugins_iterator()
-
-    local ctx = ngx.ctx
-
-    -- buffered proxying (that also executes the balancer)
-    ngx.req.read_body()
-
-    local options = {
-      always_forward_body = true,
-      share_all_vars      = true,
-      method              = HTTP_METHODS[ngx.req.get_method()],
-      ctx                 = ctx,
-    }
-
-    local res = ngx.location.capture("/kong_buffered_http", options)
-    if res.truncated then
-      kong_global.set_phase(kong, PHASES.error)
-      ngx.status = 502
-      return kong_error_handlers(ctx)
-    end
-
-    kong_global.set_phase(kong, PHASES.response)
-
-    local status = res.status
-    local headers = res.header
-    local body = res.body
-
-    ctx.buffered_status = status
-    ctx.buffered_headers = headers
-    ctx.buffered_body = body
-
-    -- fake response phase (this runs after the balancer)
-    if not ctx.KONG_RESPONSE_START then
-      ctx.KONG_RESPONSE_START = get_now_ms()
-
-      if ctx.KONG_BALANCER_START and not ctx.KONG_BALANCER_ENDED_AT then
-        ctx.KONG_BALANCER_ENDED_AT = ctx.KONG_RESPONSE_START
-        ctx.KONG_BALANCER_TIME = ctx.KONG_BALANCER_ENDED_AT -
-          ctx.KONG_BALANCER_START
-      end
-    end
-
-    if not ctx.KONG_WAITING_TIME then
-      ctx.KONG_WAITING_TIME = ctx.KONG_RESPONSE_START -
-        (ctx.KONG_BALANCER_ENDED_AT or ctx.KONG_ACCESS_ENDED_AT)
-    end
-
-    if not ctx.KONG_PROXY_LATENCY then
-      ctx.KONG_PROXY_LATENCY = ctx.KONG_RESPONSE_START - ctx.KONG_PROCESSING_START
-    end
-
-    kong.response.set_status(status)
-    kong.response.set_headers(headers)
-
-    runloop.response.before(ctx)
-    execute_plugins_iterator(plugins_iterator, "response", ctx)
-    runloop.response.after(ctx)
-
-    ctx.KONG_RESPONSE_ENDED_AT = get_now_ms()
-    ctx.KONG_RESPONSE_TIME = ctx.KONG_RESPONSE_ENDED_AT - ctx.KONG_RESPONSE_START
-
-    -- buffered response
-    ngx.print(body)
-    -- jump over the balancer to header_filter
-    ngx.exit(status)
   end
 end
 
@@ -1043,6 +955,95 @@ function Kong.balancer()
   -- time spent in Kong before sending the request to upstream
   -- start_time() is kept in seconds with millisecond resolution.
   ctx.KONG_PROXY_LATENCY = ctx.KONG_BALANCER_ENDED_AT - ctx.KONG_PROCESSING_START
+end
+
+
+do
+  local HTTP_METHODS = {
+    GET       = ngx.HTTP_GET,
+    HEAD      = ngx.HTTP_HEAD,
+    PUT       = ngx.HTTP_PUT,
+    POST      = ngx.HTTP_POST,
+    DELETE    = ngx.HTTP_DELETE,
+    OPTIONS   = ngx.HTTP_OPTIONS,
+    MKCOL     = ngx.HTTP_MKCOL,
+    COPY      = ngx.HTTP_COPY,
+    MOVE      = ngx.HTTP_MOVE,
+    PROPFIND  = ngx.HTTP_PROPFIND,
+    PROPPATCH = ngx.HTTP_PROPPATCH,
+    LOCK      = ngx.HTTP_LOCK,
+    UNLOCK    = ngx.HTTP_UNLOCK,
+    PATCH     = ngx.HTTP_PATCH,
+    TRACE     = ngx.HTTP_TRACE,
+  }
+
+  function Kong.response()
+    local plugins_iterator = runloop.get_plugins_iterator()
+
+    local ctx = ngx.ctx
+
+    -- buffered proxying (that also executes the balancer)
+    ngx.req.read_body()
+
+    local options = {
+      always_forward_body = true,
+      share_all_vars      = true,
+      method              = HTTP_METHODS[ngx.req.get_method()],
+      ctx                 = ctx,
+    }
+
+    local res = ngx.location.capture("/kong_buffered_http", options)
+    if res.truncated then
+      kong_global.set_phase(kong, PHASES.error)
+      ngx.status = 502
+      return kong_error_handlers(ctx)
+    end
+
+    kong_global.set_phase(kong, PHASES.response)
+
+    local status = res.status
+    local headers = res.header
+    local body = res.body
+
+    ctx.buffered_status = status
+    ctx.buffered_headers = headers
+    ctx.buffered_body = body
+
+    -- fake response phase (this runs after the balancer)
+    if not ctx.KONG_RESPONSE_START then
+      ctx.KONG_RESPONSE_START = get_now_ms()
+
+      if ctx.KONG_BALANCER_START and not ctx.KONG_BALANCER_ENDED_AT then
+        ctx.KONG_BALANCER_ENDED_AT = ctx.KONG_RESPONSE_START
+        ctx.KONG_BALANCER_TIME = ctx.KONG_BALANCER_ENDED_AT -
+          ctx.KONG_BALANCER_START
+      end
+    end
+
+    if not ctx.KONG_WAITING_TIME then
+      ctx.KONG_WAITING_TIME = ctx.KONG_RESPONSE_START -
+        (ctx.KONG_BALANCER_ENDED_AT or ctx.KONG_ACCESS_ENDED_AT)
+    end
+
+    if not ctx.KONG_PROXY_LATENCY then
+      ctx.KONG_PROXY_LATENCY = ctx.KONG_RESPONSE_START - ctx.KONG_PROCESSING_START
+    end
+
+    kong.response.set_status(status)
+    kong.response.set_headers(headers)
+
+    runloop.response.before(ctx)
+    execute_plugins_iterator(plugins_iterator, "response", ctx)
+    runloop.response.after(ctx)
+
+    ctx.KONG_RESPONSE_ENDED_AT = get_now_ms()
+    ctx.KONG_RESPONSE_TIME = ctx.KONG_RESPONSE_ENDED_AT - ctx.KONG_RESPONSE_START
+
+    -- buffered response
+    ngx.print(body)
+    -- jump over the balancer to header_filter
+    ngx.exit(status)
+  end
 end
 
 

--- a/kong/plugins/base_plugin.lua
+++ b/kong/plugins/base_plugin.lua
@@ -13,11 +13,11 @@ function BasePlugin:init_worker()
   ngx_log(DEBUG, "executing plugin \"", self._name, "\": init_worker")
 end
 
-if subsystem == "http" then
-  function BasePlugin:certificate()
-    ngx_log(DEBUG, "executing plugin \"", self._name, "\": certificate")
-  end
+function BasePlugin:certificate()
+  ngx_log(DEBUG, "executing plugin \"", self._name, "\": certificate")
+end
 
+if subsystem == "http" then
   function BasePlugin:rewrite()
     ngx_log(DEBUG, "executing plugin \"", self._name, "\": rewrite")
   end

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1053,6 +1053,12 @@ return {
     end,
     after = NOOP,
   },
+  certificate = {
+    before = function(_)
+      certificate.execute()
+    end,
+    after = NOOP,
+  },
   preread = {
     before = function(ctx)
       ctx.host_port = HOST_PORTS[var.server_port] or var.server_port
@@ -1084,12 +1090,6 @@ return {
         return kong.response.exit(errcode, body)
       end
     end
-  },
-  certificate = {
-    before = function(_)
-      certificate.execute()
-    end,
-    after = NOOP,
   },
   rewrite = {
     before = function(ctx)

--- a/kong/runloop/plugins_iterator.lua
+++ b/kong/runloop/plugins_iterator.lua
@@ -351,6 +351,7 @@ local function new_ws_data()
   if subsystem == "stream" then
     phases = {
       init_worker = {},
+      certificate = {},
       preread     = {},
       log         = {},
     }

--- a/spec/02-integration/05-proxy/28-stream_plugins_triggering_spec.lua
+++ b/spec/02-integration/05-proxy/28-stream_plugins_triggering_spec.lua
@@ -1,0 +1,152 @@
+local helpers = require "spec.helpers"
+local pl_file = require "pl.file"
+
+
+local TEST_CONF = helpers.test_conf
+local MESSAGE = "echo, ping, pong. echo, ping, pong. echo, ping, pong.\n"
+
+
+local function find_in_file(pat, cnt)
+  local f = assert(io.open(TEST_CONF.prefix .. "/" .. TEST_CONF.proxy_error_log, "r"))
+  local line = f:read("*l")
+  local count = 0
+
+  while line do
+    if line:match(pat) then
+      count = count + 1
+    end
+
+    line = f:read("*l")
+  end
+
+  return cnt == -1 and count >= 1 or count == cnt
+end
+
+
+local function wait()
+  -- wait for the second log phase to finish, otherwise it might not appear
+  -- in the logs when executing this
+  helpers.wait_until(function()
+    local logs = pl_file.read(TEST_CONF.prefix .. "/" .. TEST_CONF.proxy_error_log)
+    local _, count = logs:gsub([[executing plugin "logger": log]], "")
+
+    return count >= 1
+  end, 10)
+end
+
+-- Phases and counters for unary stream requests
+
+local phases = {
+  ["%[logger%] init_worker phase"] = 1,
+  ["%[logger%] preread phase"] = 1,
+  ["%[logger%] log phase"] = 1,
+}
+
+local phases_tls = {
+  ["%[logger%] init_worker phase"] = 1,
+  ["%[logger%] certificate phase"] = 1,
+  ["%[logger%] preread phase"] = 1,
+  ["%[logger%] log phase"] = 1,
+}
+
+local function assert_phases(phrases)
+  for phase, count in pairs(phrases) do
+    assert(find_in_file(phase, count))
+  end
+end
+
+for _, strategy in helpers.each_strategy() do
+
+  describe("#stream Proxying [#" .. strategy .. "]", function()
+    local bp
+
+    before_each(function()
+      bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+      }, {
+        "logger",
+      })
+
+      local tcp_srv = bp.services:insert({
+        name = "tcp",
+        host = helpers.mock_upstream_host,
+        port = helpers.mock_upstream_stream_port,
+        protocol = "tcp"
+      })
+
+      bp.routes:insert {
+        destinations = {
+          {
+            port = 19000,
+          },
+        },
+        protocols = {
+          "tcp",
+        },
+        service = tcp_srv,
+      }
+
+      local tls_srv = bp.services:insert({
+        name = "tls",
+        host = helpers.mock_upstream_host,
+        port = helpers.mock_upstream_stream_ssl_port,
+        protocol = "tls"
+      })
+
+      bp.routes:insert {
+        destinations = {
+          {
+            port = 19443,
+          },
+        },
+        protocols = {
+          "tls",
+        },
+        service = tls_srv,
+      }
+
+      assert(bp.plugins:insert {
+        name = "logger",
+      })
+
+      assert(helpers.start_kong({
+        database   = strategy,
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+        plugins = "logger",
+        proxy_listen = "off",
+        admin_listen = "off",
+        stream_listen = helpers.get_proxy_ip(false) .. ":19000," ..
+                        helpers.get_proxy_ip(false) .. ":19443 ssl"
+      }))
+    end)
+
+    after_each(function()
+      helpers.stop_kong()
+    end)
+
+    it("tcp", function()
+      local tcp = ngx.socket.tcp()
+      assert(tcp:connect(helpers.get_proxy_ip(false), 19000))
+      assert(tcp:send(MESSAGE))
+      local body = assert(tcp:receive("*a"))
+      assert.equal(MESSAGE, body)
+      tcp:close()
+      wait()
+      assert_phases(phases)
+    end)
+
+    it("tls", function()
+      local tcp = ngx.socket.tcp()
+      assert(tcp:connect(helpers.get_proxy_ip(true), 19443))
+      assert(tcp:sslhandshake(nil, "this-is-needed.test", false))
+      assert(tcp:send(MESSAGE))
+      local body = assert(tcp:receive("*a"))
+      assert.equal(MESSAGE, body)
+      tcp:close()
+      wait()
+      assert_phases(phases_tls)
+    end)
+  end)
+end

--- a/spec/fixtures/custom_plugins/kong/plugins/logger-last/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/logger-last/handler.lua
@@ -14,8 +14,9 @@ end
 
 LoggerLastHandler.init_worker   = LoggerHandler.init_worker
 LoggerLastHandler.certificate   = LoggerHandler.certificate
-LoggerLastHandler.access        = LoggerHandler.access
+LoggerLastHandler.preread       = LoggerHandler.preread
 LoggerLastHandler.rewrite       = LoggerHandler.rewrite
+LoggerLastHandler.access        = LoggerHandler.access
 LoggerLastHandler.header_filter = LoggerHandler.header_filter
 LoggerLastHandler.body_filter   = LoggerHandler.body_filter
 LoggerLastHandler.log           = LoggerHandler.log

--- a/spec/fixtures/custom_plugins/kong/plugins/logger/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/logger/handler.lua
@@ -26,6 +26,13 @@ function LoggerHandler:certificate(conf)
 end
 
 
+function LoggerHandler:preread(conf)
+  LoggerHandler.super.preread(self)
+
+  kong.log("preread phase")
+end
+
+
 function LoggerHandler:rewrite(conf)
   LoggerHandler.super.rewrite(self)
 

--- a/spec/fixtures/custom_plugins/kong/plugins/logger/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/logger/schema.lua
@@ -1,3 +1,17 @@
+local typedefs = require "kong.db.schema.typedefs"
+
 return {
-  fields = {}
+  name = "ctx-tests",
+  fields = {
+    {
+      protocols = typedefs.protocols { default = { "http", "https", "tcp", "tls", "grpc", "grpcs" } },
+    },
+    {
+      config = {
+        type = "record",
+        fields = {
+        },
+      },
+    },
+  },
 }


### PR DESCRIPTION
### Summary

For historical purposes (service mesh era) the stream module ssl phase was implemented differently. As we have dropped service mesh and moved to a more standard Nginx, we can re-enable the ssl_certificate phase on plugins in `stream` module. This commit does that.


