### PR TITLE
fix(db) topological sort prioritizes core

### DIFF
--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -1,5 +1,5 @@
 local declarative_config = require "kong.db.schema.others.declarative_config"
-local topological_sort = require "kong.db.schema.topological_sort"
+local schema_topological_sort = require "kong.db.schema.topological_sort"
 local workspaces = require "kong.workspaces"
 local pl_file = require "pl.file"
 local lyaml = require "lyaml"
@@ -341,7 +341,7 @@ function declarative.load_into_db(entities, meta)
       return nil, "unknown entity: " .. entity_name
     end
   end
-  local sorted_schemas, err = topological_sort(schemas)
+  local sorted_schemas, err = schema_topological_sort(schemas)
   if not sorted_schemas then
     return nil, err
   end
@@ -382,7 +382,7 @@ local function export_from_db(emitter, skip_ws)
       table.insert(schemas, dao.schema)
     end
   end
-  local sorted_schemas, err = topological_sort(schemas)
+  local sorted_schemas, err = schema_topological_sort(schemas)
   if not sorted_schemas then
     return nil, err
   end

--- a/kong/db/schema/topological_sort.lua
+++ b/kong/db/schema/topological_sort.lua
@@ -1,123 +1,80 @@
-local table_insert = table.insert
+local constants = require "kong.constants"
+local utils = require "kong.tools.utils"
 
--- Given an array of schemas, build a table were the keys are schemas and the values are
--- the list of schemas with foreign keys pointing to them
--- @tparam array schemas an array of schemas
--- @treturn table a map with schemas in the keys and arrays of neighbors in the values
--- @usage
--- local res = build_neighbors_map({ services, routes, plugins, consumers })
+local utils_toposort = utils.topological_sort
+
+
+local sort_core_first do
+  local CORE_SCORE = {}
+  for _, v in ipairs(constants.CORE_ENTITIES) do
+    CORE_SCORE[v] = 1
+  end
+  CORE_SCORE["workspaces"] = 2
+
+  sort_core_first = function(a, b)
+    local sa = CORE_SCORE[a.name] or 0
+    local sb = CORE_SCORE[b.name] or 0
+    if sa == sb then
+      -- reverse alphabetical order, so that items end up ordered alphabetically
+      -- (utils_toposort does "neighbors" before doing "current")
+      return a.name > b.name
+    end
+    return sa < sb
+  end
+end
+
+
+-- Given an array of schemas, return a copy of it sorted so that:
 --
--- assert.same({ [services] = { routes, plugins },
---               [routes] = { plugins },
---               [consumers] = { plugins }
---             }, res)
-local function build_neighbors_map(schemas)
-  local schemas_by_name = {}
-  local s
-  for i = 1, #schemas do
-    s = schemas[i]
-    schemas_by_name[s.name] = s
-  end
-
-  local res = {}
-  local source, destination
-
-  for i = 1, #schemas do
-    source = schemas[i] -- routes
-    for _, field in source:each_field() do
-      if field.type == "foreign"  then
-        destination = schemas_by_name[field.reference] -- services
-        if destination then
-          res[destination] = res[destination] or {}
-          table_insert(res[destination], source)
-        end
-      end
-    end
-  end
-
-  return res
-end
-
-
--- aux function for topological_sort
-local function visit(current, neighbors_map, visited, marked, sorted)
-  if visited[current] then
-    return true
-  end
-
-  if marked[current] then
-    return nil, "Cycle detected, cannot sort topologically"
-  end
-
-  marked[current] = true
-
-  local schemas_pointing_to_current = neighbors_map[current]
-  if schemas_pointing_to_current then
-    local neighbor, ok, err
-    for i = 1, #schemas_pointing_to_current do
-      neighbor = schemas_pointing_to_current[i]
-      ok, err = visit(neighbor, neighbors_map, visited, marked, sorted)
-      if not ok then
-        return nil, err
-      end
-    end
-  end
-
-  marked[current] = false
-
-  visited[current] = true
-
-  table_insert(sorted, 1, current)
-
-  return true
-end
-
-
-local function move_workspaces_to_front(sorted_schemas)
-  local workspaces_schema
-  for i, s in ipairs(sorted_schemas) do
-    if s.name == "workspaces" then
-      workspaces_schema = s
-      table.remove(sorted_schemas, i)
-      break
-    end
-  end
-  if workspaces_schema then
-    table.insert(sorted_schemas, 1, workspaces_schema)
-  end
-end
-
-
--- Given an array of schemas, return it sorted so that if
--- schema B has a foreign key to A, then B appears after A
+-- * If schema B has a foreign key to A, then B appears after A
+-- * When there's no foreign keys, core schemas appear before plugin entities
+-- * If none of the rules above apply, schemas are sorted alphabetically by name
+--
 -- The function returns an error if cycles are found in the schemas
 -- (i.e. A has a foreign key to B and B to A)
+--
 -- @tparam array schemas an array with zero or more schemas
 -- @treturn array|nil an array of schemas sorted topologically, or nil if cycle was found
 -- @treturn nil|string nil if the schemas were sorted, or a message if a cycle was found
 -- @usage
 -- local res = topological_sort({ services, routes, plugins, consumers })
 -- assert.same({ consumers, services, routes, plugins }, res)
-local function topological_sort(schemas)
-  local sorted = {}
-  local visited = {}
-  local marked = {}
-  local neighbors_map = build_neighbors_map(schemas)
+local declarative_topological_sort = function(schemas)
+  local s
+  local schemas_by_name = {}
+  local copy = {}
 
-  local current, ok, err
   for i = 1, #schemas do
-    current = schemas[i]
-    if not visited[current] and not marked[current] then
-      ok, err = visit(current, neighbors_map, visited, marked, sorted)
-      if not ok then
-        return nil, err
+    s = schemas[i]
+    schemas_by_name[s.name] = s
+    copy[i] = schemas[i]
+  end
+  schemas = copy
+
+  table.sort(schemas, sort_core_first)
+
+  -- given a schema, return all the schemas to which it has references
+  -- (and are in the list of the `schemas` provided)
+  local get_schema_neighbors = function(schema)
+    local neighbors = {}
+    local neighbors_len = 0
+    local neighbor
+
+    for _, field in schema:each_field() do
+      if field.type == "foreign"  then
+        neighbor = schemas_by_name[field.reference] -- services
+        if neighbor then
+          neighbors_len = neighbors_len + 1
+          neighbors[neighbors_len] = neighbor
+        end
+        -- else the neighbor points to an unknown/uninteresting schema. This happens in tests.
       end
     end
+
+    return neighbors
   end
 
-  move_workspaces_to_front(sorted)
-
-  return sorted
+  return utils_toposort(schemas, get_schema_neighbors)
 end
 
-return topological_sort
+return declarative_topological_sort

--- a/kong/db/strategies/postgres/connector.lua
+++ b/kong/db/strategies/postgres/connector.lua
@@ -5,6 +5,7 @@ local arrays       = require "pgmoon.arrays"
 local stringx      = require "pl.stringx"
 local semaphore    = require "ngx.semaphore"
 local kong_global = require "kong.global"
+local constants = require "kong.constants"
 
 
 local setmetatable = setmetatable
@@ -28,6 +29,8 @@ local match        = string.match
 local fmt          = string.format
 local sub          = string.sub
 local kong         = kong
+local utils_toposort = utils.topological_sort
+local insert       = table.insert
 
 
 local WARN                          = ngx.WARN
@@ -49,75 +52,12 @@ local OPERATIONS = {
 }
 local ADMIN_API_PHASE = kong_global.phases.admin_api
 local kong_get_phase = kong_global.get_phase
+local CORE_ENTITIES = constants.CORE_ENTITIES
 
 
 local function now_updated()
   update_time()
   return now()
-end
-
-
-local function visit(k, n, m, s)
-  if m[k] == 0 then return 1 end
-  if m[k] == 1 then return end
-  m[k] = 0
-  local f = n[k]
-  for i=1, #f do
-    if visit(f[i], n, m, s) then return 1 end
-  end
-  m[k] = 1
-  s[#s+1] = k
-end
-
-
-local tsort = {}
-tsort.__index = tsort
-
-
-function tsort.new()
-  return setmetatable({ n = {} }, tsort)
-end
-
-
-function tsort:add(...)
-  local p = { ... }
-  local c = #p
-  if c == 0 then return self end
-  if c == 1 then
-    p = p[1]
-    if type(p) == "table" then
-      c = #p
-    else
-      p = { p }
-    end
-  end
-  local n = self.n
-  for i=1, c do
-    local f = p[i]
-    if n[f] == nil then n[f] = {} end
-  end
-  for i=2, c, 1 do
-    local f = p[i]
-    local t = p[i-1]
-    local o = n[f]
-    o[#o+1] = t
-  end
-  return self
-end
-
-
-function tsort:sort()
-  local n  = self.n
-  local s = {}
-  local m  = {}
-  for k in pairs(n) do
-    if m[k] == nil then
-      if visit(k, n, m, s) then
-        return nil, "There is a circular dependency in the graph. It is not possible to derive a topological sort."
-      end
-    end
-  end
-  return s
 end
 
 
@@ -145,6 +85,72 @@ local function get_table_names(self, excluded)
   end
 
   return table_names
+end
+
+
+local get_names_of_tables_with_ttl
+do
+  local CORE_SCORE = {}
+  for _, v in ipairs(CORE_ENTITIES) do
+    CORE_SCORE[v] = 1
+  end
+  CORE_SCORE["workspaces"] = 2
+
+
+  local function sort_core_tables_first(a, b)
+    local sa = CORE_SCORE[a] or 0
+    local sb = CORE_SCORE[b] or 0
+    if sa == sb then
+      -- sort tables in reverse order so that they end up sorted alphabetically,
+      -- because utils_topological sort does "dependencies first" and then current.
+      return a > b
+    end
+    return sa < sb
+  end
+
+  local sort = table.sort
+  get_names_of_tables_with_ttl = function(strategies)
+    local s
+    local ttl_schemas_by_name = {}
+    local table_names = {}
+    for _, strategy in pairs(strategies) do
+      s = strategy.schema
+      if s.ttl then
+        table_names[#table_names + 1] = s.name
+        ttl_schemas_by_name[s.name] = s
+      end
+    end
+
+    sort(table_names, sort_core_tables_first)
+
+    local get_table_name_neighbors = function(table_name)
+      local neighbors = {}
+      local neighbors_len = 0
+      local neighbor
+      local schema = ttl_schemas_by_name[table_name]
+
+      for _, field in schema:each_field() do
+        if field.type == "foreign" and field.schema.ttl then
+          neighbor = field.reference
+          if ttl_schemas_by_name[neighbor] then -- the neighbor schema name is on table_names
+            neighbors_len = neighbors_len + 1
+            neighbors[neighbors_len] = neighbor
+          end
+          -- else the neighbor points to an unknown/uninteresting schema. This happens in tests.
+        end
+      end
+
+      return neighbors
+    end
+
+    local res, err = utils_toposort(table_names, get_table_name_neighbors)
+
+    if res then
+      insert(res, 1, "cluster_events")
+    end
+
+    return res, err
+  end
 end
 
 
@@ -299,30 +305,14 @@ end
 
 function _mt:init_worker(strategies)
   if ngx.worker.id() == 0 then
-    local graph = tsort.new()
 
-    graph:add("cluster_events")
-
-    for _, strategy in pairs(strategies) do
-      local schema = strategy.schema
-      if schema.ttl then
-        local name = schema.name
-        graph:add(name)
-        for _, field in schema:each_field() do
-          if field.type == "foreign" and field.schema.ttl then
-            graph:add(name, field.schema.name)
-          end
-        end
-      end
-    end
-
-    local sorted_strategies = graph:sort()
+    local table_names = get_names_of_tables_with_ttl(strategies)
     local ttl_escaped = self:escape_identifier("ttl")
     local expire_at_escaped = self:escape_identifier("expire_at")
     local cleanup_statements = {}
-    local cleanup_statements_count = #sorted_strategies
+    local cleanup_statements_count = #table_names
     for i = 1, cleanup_statements_count do
-      local table_name = sorted_strategies[i]
+      local table_name = table_names[i]
       local column_name = table_name == "cluster_events" and expire_at_escaped
                                                           or ttl_escaped
       cleanup_statements[i] = concat {
@@ -350,11 +340,11 @@ function _mt:init_worker(strategies)
             if not ok then
               if err then
                 log(WARN, "unable to clean expired rows from table '",
-                          sorted_strategies[i], "' on PostgreSQL database (",
+                          table_names[i], "' on PostgreSQL database (",
                           err, ")")
               else
                 log(WARN, "unable to clean expired rows from table '",
-                          sorted_strategies[i], "' on PostgreSQL database")
+                          table_names[i], "' on PostgreSQL database")
               end
             end
           end
@@ -987,6 +977,9 @@ function _M.new(kong_config)
 
   return setmetatable(self, _mt)
 end
+
+-- for tests only
+_mt._get_topologically_sorted_table_names = get_names_of_tables_with_ttl
 
 
 return _M

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -1354,4 +1354,73 @@ end
 _M.get_mime_type = get_mime_type
 _M.get_error_template = get_error_template
 
+
+local topological_sort do
+
+  local function visit(current, neighbors_map, visited, marked, sorted)
+    if visited[current] then
+      return true
+    end
+
+    if marked[current] then
+      return nil, "Cycle detected, cannot sort topologically"
+    end
+
+    marked[current] = true
+
+    local schemas_pointing_to_current = neighbors_map[current]
+    if schemas_pointing_to_current then
+      local neighbor, ok, err
+      for i = 1, #schemas_pointing_to_current do
+        neighbor = schemas_pointing_to_current[i]
+        ok, err = visit(neighbor, neighbors_map, visited, marked, sorted)
+        if not ok then
+          return nil, err
+        end
+      end
+    end
+
+    marked[current] = false
+
+    visited[current] = true
+
+    insert(sorted, 1, current)
+
+    return true
+  end
+
+  topological_sort = function(items, get_neighbors)
+    local neighbors_map = {}
+    local source, destination
+    local neighbors
+    for i = 1, #items do
+      source = items[i] -- services
+      neighbors = get_neighbors(source)
+      for j = 1, #neighbors do
+        destination = neighbors[j] --routes
+        neighbors_map[destination] = neighbors_map[destination] or {}
+        insert(neighbors_map[destination], source)
+      end
+    end
+
+    local sorted = {}
+    local visited = {}
+    local marked = {}
+
+    local current, ok, err
+    for i = 1, #items do
+      current = items[i]
+      if not visited[current] and not marked[current] then
+        ok, err = visit(current, neighbors_map, visited, marked, sorted)
+        if not ok then
+          return nil, err
+        end
+      end
+    end
+
+    return sorted
+  end
+end
+_M.topological_sort = topological_sort
+
 return _M

--- a/spec/01-unit/01-db/01-schema/12-topological_sort_spec.lua
+++ b/spec/01-unit/01-db/01-schema/12-topological_sort_spec.lua
@@ -1,39 +1,40 @@
 local Schema = require "kong.db.schema"
 local ts = require "kong.db.schema.topological_sort"
 
+describe("schemas_topological_sort", function()
 
-local function collect_names(schemas)
-  local names = {}
-  for i = 1, #schemas do
-    names[i] = schemas[i].name
+  local function collect_names(schemas)
+    local names = {}
+    for i = 1, #schemas do
+      names[i] = schemas[i].name
+    end
+    return names
   end
-  return names
-end
 
-describe("topological_sort", function()
+  local function schema_new(s)
+    return assert(Schema.new(s))
+  end
 
-  it("sorts an array of unrelated schemas", function()
-    local a = Schema.new({ name = "a", fields = { { a = { type = "string" } } } })
-    local b = Schema.new({ name = "b", fields = { { b = { type = "boolean" } } } })
-    local c = Schema.new({ name = "c", fields = { { c = { type = "integer" } } } })
+  it("sorts an array of unrelated schemas alphabetically by name", function()
+    local a = schema_new({ name = "a", fields = {} })
+    local b = schema_new({ name = "b", fields = {} })
+    local c = schema_new({ name = "c", fields = {} })
 
-    local x = ts({ a, b, c })
-    assert.same({"c", "b", "a"},  collect_names(x))
+    local x = ts({ c, a, b })
+    assert.same({"a", "b", "c"},  collect_names(x))
   end)
 
   it("it puts destinations first", function()
-    local a = Schema.new({ name = "a", fields = { { a = { type = "string" } } } })
-    local c = Schema.new({
+    local a = schema_new({ name = "a", fields = {} })
+    local c = schema_new({
       name = "c",
       fields = {
-        { c = { type = "integer" }, },
         { a = { type = "foreign", reference = "a" }, },
       }
     })
-    local b = Schema.new({
+    local b = schema_new({
       name = "b",
       fields = {
-        { b = { type = "boolean" }, },
         { a = { type = "foreign", reference = "a" }, },
         { c = { type = "foreign", reference = "c" }, },
       }
@@ -43,18 +44,69 @@ describe("topological_sort", function()
     assert.same({"a", "c", "b"},  collect_names(x))
   end)
 
+  it("puts core entities first, even when no relations", function()
+    local a = schema_new({ name = "a", fields = {} })
+    local routes = schema_new({ name = "routes", fields = {} })
+
+    local x = ts({ a, routes })
+    assert.same({"routes", "a"},  collect_names(x))
+  end)
+
+  it("puts workspaces before core and others, when no relations", function()
+    local a = schema_new({ name = "a", fields = {} })
+    local workspaces = schema_new({ name = "workspaces", fields = {} })
+    local routes = schema_new({ name = "routes", fields = {} })
+
+    local x = ts({ a, routes, workspaces })
+    assert.same({"workspaces", "routes", "a"},  collect_names(x))
+  end)
+
+  it("puts workspaces first, core entities second, and other entities afterwards, even with relations", function()
+    local a = schema_new({ name = "a", fields = {} })
+    local services = schema_new({ name = "services", fields = {} })
+    local b = schema_new({
+      name = "b",
+      fields = {
+        { service = { type = "foreign", reference = "services" }, },
+        { a = { type = "foreign", reference = "a" }, },
+      }
+    })
+    local routes = schema_new({
+      name = "routes",
+      fields = {
+        { service = { type = "foreign", reference = "services" }, },
+      }
+    })
+    local workspaces = schema_new({ name = "workspaces", fields = {} })
+    local x = ts({ services, b, a, workspaces, routes })
+    assert.same({ "workspaces", "services", "routes", "a", "b" },  collect_names(x))
+  end)
+
+  it("overrides core order if dependencies force it", function()
+    -- This scenario is here in case in the future we allow plugin entities to precede core entities
+    -- Not applicable today (kong 2.3.x) but maybe in future releases
+    local a = schema_new({ name = "a", fields = {} })
+    local services = schema_new({ name = "services", fields = {
+      { a = { type = "foreign", reference = "a" } } -- we somehow forced services to depend on a
+    }})
+    local workspaces = schema_new({ name = "workspaces", fields = {
+      { a = { type = "foreign", reference = "a" } } -- we somehow forced workspaces to depend on a
+    } })
+
+    local x = ts({ services, a, workspaces })
+    assert.same({ "a", "workspaces", "services" },  collect_names(x))
+  end)
+
   it("returns an error if cycles are found", function()
-    local a = Schema.new({
+    local a = schema_new({
       name = "a",
       fields = {
-        { a = { type = "string" }, },
         { b = { type = "foreign", reference = "b" }, },
       }
     })
-    local b = Schema.new({
+    local b = schema_new({
       name = "b",
       fields = {
-        { b = { type = "boolean" }, },
         { a = { type = "foreign", reference = "a" }, },
       }
     })

--- a/spec/01-unit/05-utils_spec.lua
+++ b/spec/01-unit/05-utils_spec.lua
@@ -826,4 +826,28 @@ describe("Utils", function()
       end, "bad argument #1 'str'")
     end)
   end)
+
+  describe("topological_sort", function()
+    local get_neighbors = function(x) return x end
+    local ts = utils.topological_sort
+
+    it("it puts destinations first", function()
+      local a = { id = "a" }
+      local b = { id = "b", a }
+      local c = { id = "c", a, b }
+      local d = { id = "d", c }
+
+      local x = ts({ c, d, a, b }, get_neighbors)
+      assert.same({ a, b, c, d }, x)
+    end)
+
+    it("returns an error if cycles are found", function()
+      local a = { id = "a" }
+      local b = { id = "b", a }
+      a[1] = b
+      local x, err = ts({ a, b }, get_neighbors)
+      assert.is_nil(x)
+      assert.equals("Cycle detected, cannot sort topologically", err)
+    end)
+  end)
 end)


### PR DESCRIPTION
This fix to the topological sort function introduces these changes:

* The main algorithm has been abstracted away into utils. It can now topologically sort anything, not just schemas.
* When sorting schemas, core entities will be considered before plugin entities - this avoid problems when plugin entities use core entities but don't explicitly depend on them.
* It will try to sort schemas alphabetically when possible
* The end result will still be topologically sorted, but now it will be constant.

We use topological sorting in two places:
* The PostgreSQL connector uses it to sort table names (it replaces a custom toposort implementation)
* Declarative Config uses it to sort entities for loading

Note that the previous "special treatment of workspaces" is now part of the "prioritize core over plugin entities" code.

