### PR TITLE
fix(conf) Fix formatting for sandbox properties

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1396,18 +1396,16 @@
                                  #
                                  #         LuaJIT bytecode loading is disabled.
 
-#untrusted_lua_sandbox_requires =
-                                 # Comma-separated list of modules allowed to be loaded
-                                 # with `require` inside the sandboxed environment. Ignored
-                                 # if `untrusted_lua` is not `sandbox`.
-                                 #
-                                 # Note: certain modules, when allowed, may cause sandbox
-                                 # escaping trivial.
+#untrusted_lua_sandbox_requires = # Comma-separated list of modules allowed to be loaded
+                                  # with `require` inside the sandboxed environment. Ignored
+                                  # if `untrusted_lua` is not `sandbox`.
+                                  #
+                                  # Note: certain modules, when allowed, may cause sandbox
+                                  # escaping trivial.
 
-#untrusted_lua_sandbox_environment =
-                                 # Comma-separated list of global Lua variables
-                                 # that should be made available inside the sandboxed
-                                 # environment. Ignored if `untrusted_lua` is not `sandbox`.
-                                 #
-                                 # Note: certain variables, when made available,
-                                 # may cause sandbox escaping trivial.
+#untrusted_lua_sandbox_environment = # Comma-separated list of global Lua variables
+                                     # that should be made available inside the sandboxed
+                                     # environment. Ignored if `untrusted_lua` is not `sandbox`.
+                                     #
+                                     # Note: certain variables, when made available,
+                                     # may cause sandbox escaping trivial.

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1357,52 +1357,98 @@
                                  # See https://github.com/openresty/lua-nginx-module#lua_socket_pool_size
 
 #untrusted_lua = sandbox
-                                 # Controls loading of Lua functions from admin supplied
-                                 # sources (such as via the Admin API). LuaJIT bytecode
+                                 # Controls loading of Lua functions from admin-supplied
+                                 # sources such as the Admin API. LuaJIT bytecode
                                  # loading is always disabled.
                                  #
-                                 # Warning: LuaJIT is not designed as a secure
-                                 # runtime for running malicious code, therefore,
+                                 # **Warning:** LuaJIT is not designed as a secure
+                                 # runtime for running malicious code, therefore
                                  # you should properly protect your Admin API endpoint
                                  # even with sandboxing enabled. The sandbox only
                                  # provides protection against trivial attackers or
                                  # unintentional modification of the Kong global
                                  # environment.
                                  #
-                                 # Accepted values are: `off`, `sandbox`, `on`
+                                 # Accepted values are: `off`, `sandbox`, or
+                                 # `on`:
                                  #
-                                 # - `off`: disallow loading of any Lua functions
+                                 # * `off`: Disallow loading of any arbitrary
+                                 #          Lua functions. The `off` option
+                                 #          disables any functionality that runs
+                                 #          arbitrary Lua code, including the
+                                 #          Serverless Functions plugins and any
+                                 #          transformation plugin that allows
+                                 #          custom Lua functions.
                                  #
-                                 #          Note using the `off` option will render plugins such as
-                                 #          Serverless Functions unusable.
+                                 # * `sandbox`: Allow loading of Lua functions,
+                                 #              but use a sandbox when executing
+                                 #              them. The sandboxed function has
+                                 #              restricted access to the global
+                                 #              environment and only has access
+                                 #              to standard Lua functions that
+                                 #              will generally not cause harm to
+                                 #              the Kong Gateway node.
                                  #
-                                 # - `sandbox`: allow loading of Lua functions, but use a
-                                 #              sandbox when executing them. The sandboxed
-                                 #              function will have restricted access
-                                 #              to the global environment and only
-                                 #              have access to standard Lua functions
-                                 #              that will generally not cause harm to
-                                 #              the Kong node.
+                                 # * `on`: Functions have unrestricted
+                                 #         access to the global environment and
+                                 #         can load any Lua modules. This is
+                                 #         similar to the behavior in
+                                 #         Kong Gateway prior to 2.3.0.
                                  #
-                                 #              See also `untrusted_lua_sandbox_requires` and
-                                 #              `untrusted_lua_sandbox_environment` below for
-                                 #              furrther customisation.
+                                 # The default `sandbox` environment does not
+                                 # allow importing other modules or libraries,
+                                 # or executing anything at the OS level (for
+                                 # example, file read/write). The global
+                                 # environment is also not accessible.
                                  #
-                                 # - `on`: functions will have unrestricted
-                                 #         access to global environment and able to load any
-                                 #         Lua modules. This is similar to the behavior in Kong
-                                 #         prior to 2.3.0.
+                                 # Examples of `untrusted_lua = sandbox`
+                                 # behavior:
+                                 #
+                                 # * You can't change global values such as
+                                 # `kong.license`.
+                                 # * You can run a local function:
+                                 # `local foo = 1 + 1`. However, running the
+                                 # same function at the OS level is not allowed:
+                                 # `os.execute('rm -rf /*')`.
+                                 #
+                                 # For a full allowed/disallowed list, see:
+                                 # https://github.com/kikito/sandbox.lua/blob/master/sandbox.lua
+                                 #
+                                 # To customize the sandbox environment, use
+                                 # the `untrusted_lua_sandbox_requires` and
+                                 # `untrusted_lua_sandbox_environment`
+                                 # parameters below.
 
-#untrusted_lua_sandbox_requires = # Comma-separated list of modules allowed to be loaded
-                                  # with `require` inside the sandboxed environment. Ignored
+#untrusted_lua_sandbox_requires = # Comma-separated list of modules allowed to
+                                  # be loaded with `require` inside the
+                                  # sandboxed environment. Ignored
                                   # if `untrusted_lua` is not `sandbox`.
                                   #
-                                  # Note: certain modules, when allowed, may cause sandbox
-                                  # escaping trivial.
+                                  # For example, say you have configured the
+                                  # Exit Transformer plugin and it contains the
+                                  # following `requires`:
+                                  #
+                                  # ```
+                                  # local template = require "resty.template"
+                                  # local split = require "kong.tools.utils".split
+                                  # ```
+                                  #
+                                  # To run the plugin, add the modules to the
+                                  # allowed list:
+                                  # ```
+                                  # untrusted_lua_sandbox_requires = resty.template, kong.tools.utils
+                                  # ```
+                                  #
+                                  # **Warning:** Allowing certain modules may
+                                  # create opportunities to escape the
+                                  # sandbox. For example, allowing `os` or
+                                  # `luaposix` may be unsafe.
 
-#untrusted_lua_sandbox_environment = # Comma-separated list of global Lua variables
-                                     # that should be made available inside the sandboxed
-                                     # environment. Ignored if `untrusted_lua` is not `sandbox`.
+#untrusted_lua_sandbox_environment = # Comma-separated list of global Lua
+                                     # variables that should be made available
+                                     # inside the sandboxed environment. Ignored
+                                     # if `untrusted_lua` is not `sandbox`.
                                      #
-                                     # Note: certain variables, when made available,
-                                     # may cause sandbox escaping trivial.
+                                     # **Warning**: Certain variables, when made
+                                     # available, may create opportunities to
+                                     # escape the sandbox.

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1425,8 +1425,8 @@
                                   # if `untrusted_lua` is not `sandbox`.
                                   #
                                   # For example, say you have configured the
-                                  # Exit Transformer plugin and it contains the
-                                  # following `requires`:
+                                  # Serverless pre-function plugin and it
+                                  # contains the following `requires`:
                                   #
                                   # ```
                                   # local template = require "resty.template"

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1357,44 +1357,41 @@
                                  # See https://github.com/openresty/lua-nginx-module#lua_socket_pool_size
 
 #untrusted_lua = sandbox
-                                 # Accepted values are:
+                                 # Controls loading of Lua functions from admin supplied
+                                 # sources (such as via the Admin API). LuaJIT bytecode
+                                 # loading is always disabled.
                                  #
-                                 # - `off`: disallow any loading of Lua functions
-                                 #          from admin supplied sources (such as via the Admin API).
+                                 # Warning: LuaJIT is not designed as a secure
+                                 # runtime for running malicious code, therefore,
+                                 # you should properly protect your Admin API endpoint
+                                 # even with sandboxing enabled. The sandbox only
+                                 # provides protection against trivial attackers or
+                                 # unintentional modification of the Kong global
+                                 # environment.
+                                 #
+                                 # Accepted values are: `off`, `sandbox`, `on`
+                                 #
+                                 # - `off`: disallow loading of any Lua functions
                                  #
                                  #          Note using the `off` option will render plugins such as
                                  #          Serverless Functions unusable.
-                                 # - `sandbox`: allow loading of Lua functions from admin
-                                 #              supplied sources, but use a sandbox when
-                                 #              executing them. The sandboxed
+                                 #
+                                 # - `sandbox`: allow loading of Lua functions, but use a
+                                 #              sandbox when executing them. The sandboxed
                                  #              function will have restricted access
                                  #              to the global environment and only
                                  #              have access to standard Lua functions
                                  #              that will generally not cause harm to
                                  #              the Kong node.
                                  #
-                                 #              In this mode, the `require` function inside
-                                 #              the sandbox only allows loading external Lua
-                                 #              modules that are explicitly listed in
-                                 #              `untrusted_lua_sandbox_requires` below.
+                                 #              See also `untrusted_lua_sandbox_requires` and
+                                 #              `untrusted_lua_sandbox_environment` below for
+                                 #              furrther customisation.
                                  #
-                                 #              LuaJIT bytecode loading is disabled.
-                                 #
-                                 #              Warning: LuaJIT is not designed as a secure
-                                 #              runtime for running malicious code, therefore,
-                                 #              you should properly protect your Admin API endpoint
-                                 #              even with sandboxing enabled. The sandbox only
-                                 #              provides protection against trivial attackers or
-                                 #              unintentional modification of the Kong global
-                                 #              environment.
-                                 # - `on`: allow loading of Lua functions from admin
-                                 #         supplied sources and do not use a sandbox when
-                                 #         executing them. Functions will have unrestricted
+                                 # - `on`: functions will have unrestricted
                                  #         access to global environment and able to load any
                                  #         Lua modules. This is similar to the behavior in Kong
                                  #         prior to 2.3.0.
-                                 #
-                                 #         LuaJIT bytecode loading is disabled.
 
 #untrusted_lua_sandbox_requires = # Comma-separated list of modules allowed to be loaded
                                   # with `require` inside the sandboxed environment. Ignored

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1404,11 +1404,11 @@
                                  # Examples of `untrusted_lua = sandbox`
                                  # behavior:
                                  #
-                                 # * You can't change global values such as
-                                 # `kong.license`.
-                                 # * You can run a local function:
-                                 # `local foo = 1 + 1`. However, running the
-                                 # same function at the OS level is not allowed:
+                                 # * You can't access or change global values
+                                 # such as `kong.configuration.pg_password`
+                                 # * You can run harmless lua:
+                                 # `local foo = 1 + 1`. However, OS level
+                                 # functions are not allowed, like:
                                  # `os.execute('rm -rf /*')`.
                                  #
                                  # For a full allowed/disallowed list, see:


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Fixing formatting so that autodoc scripts render the parameters correctly. 
At the moment, all three sandbox parameters render as one: https://docs.konghq.com/gateway-oss/2.3.x/configuration/#untrusted_lua

Improving descriptions for `untrusted_lua` and `untrusted_lua_sandbox_requires` based on input from Luis. 

Note, there is a link to https://github.com/kikito/sandbox.lua/blob/master/sandbox.lua for the full allowed/disallowed list, as I didn't want to duplicate all of that and have an doc update dependency. I think that's fine?

### Full changelog

N/A

### Issues resolved

N/A
