### PR TITLE
feat(plugins) role based defaults

### DIFF
--- a/kong/plugins/rate-limiting/schema.lua
+++ b/kong/plugins/rate-limiting/schema.lua
@@ -23,6 +23,42 @@ local function validate_periods_order(config)
 end
 
 
+local function is_dbless()
+  local _, database, role = pcall(function()
+    return kong.configuration.database,
+           kong.configuration.role
+  end)
+
+  return database == "off" or role == "control_plane"
+end
+
+
+local policy
+if is_dbless() then
+  policy = {
+    type = "string",
+    default = "local",
+    len_min = 0,
+    one_of = {
+      "local",
+      "redis",
+    },
+  }
+
+else
+  policy = {
+    type = "string",
+    default = "cluster",
+    len_min = 0,
+    one_of = {
+      "local",
+      "cluster",
+      "redis",
+    },
+  }
+end
+
+
 return {
   name = "rate-limiting",
   fields = {
@@ -43,12 +79,7 @@ return {
           }, },
           { header_name = typedefs.header_name },
           { path = typedefs.path },
-          { policy = {
-              type = "string",
-              default = "cluster",
-              len_min = 0,
-              one_of = { "local", "cluster", "redis" },
-          }, },
+          { policy = policy },
           { fault_tolerant = { type = "boolean", required = true, default = true }, },
           { redis_host = typedefs.host },
           { redis_port = typedefs.port({ default = 6379 }), },

--- a/kong/plugins/response-ratelimiting/schema.lua
+++ b/kong/plugins/response-ratelimiting/schema.lua
@@ -23,6 +23,40 @@ local function validate_periods_order(limit)
 end
 
 
+local function is_dbless()
+  local _, database, role = pcall(function()
+    return kong.configuration.database,
+           kong.configuration.role
+  end)
+
+  return database == "off" or role == "control_plane"
+end
+
+
+local policy
+if is_dbless() then
+  policy = {
+    type = "string",
+    default = "local",
+    one_of = {
+      "local",
+      "redis",
+    },
+  }
+
+else
+  policy = {
+    type = "string",
+    default = "cluster",
+    one_of = {
+      "local",
+      "cluster",
+      "redis",
+    },
+  }
+end
+
+
 return {
   name = "response-ratelimiting",
   fields = {
@@ -35,10 +69,7 @@ return {
                          default = "consumer",
                          one_of = { "consumer", "credential", "ip" },
           }, },
-          { policy = { type = "string",
-                       default = "cluster",
-                       one_of = { "local", "cluster", "redis" },
-          }, },
+          { policy = policy },
           { fault_tolerant = { type = "boolean", required = true, default = true }, },
           { redis_host = typedefs.host },
           { redis_port = typedefs.port({ default = 6379 }), },

--- a/spec/03-plugins/23-rate-limiting/03-api_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/03-api_spec.lua
@@ -1,5 +1,3 @@
-
-
 local cjson   = require "cjson"
 local helpers = require "spec.helpers"
 local Errors  = require "kong.db.errors"
@@ -91,6 +89,72 @@ for _, strategy in helpers.each_strategy() do
         local body = cjson.decode(assert.res_status(201, res))
         assert.equal(10, body.config.second)
       end)
+
+      if strategy == "off" then
+        it("sets policy to local by default on dbless", function()
+          local id = "bac2038a-205c-4013-8830-e6dde503a3e3"
+          local res = admin_client:post("/config", {
+            body = {
+              _format_version = "1.1",
+              plugins = {
+                {
+                  id = id,
+                  name = "rate-limiting",
+                  config = {
+                    second = 10
+                  }
+                }
+              }
+            },
+            headers = {
+              ["Content-Type"] = "application/json"
+            }
+          })
+          local body = cjson.decode(assert.res_status(201, res))
+          assert.equal("local", body.plugins[id].config.policy)
+        end)
+
+        it("does not allow setting policy to cluster on dbless", function()
+          local id = "bac2038a-205c-4013-8830-e6dde503a3e3"
+          local res = admin_client:post("/config", {
+            body = {
+              _format_version = "1.1",
+              plugins = {
+                {
+                  id = id,
+                  name = "rate-limiting",
+                  config = {
+                    policy = "cluster",
+                    second = 10
+                  }
+                }
+              }
+            },
+            headers = {
+              ["Content-Type"] = "application/json"
+            }
+          })
+          local body = cjson.decode(assert.res_status(400, res))
+          assert.equal("expected one of: local, redis", body.fields.plugins[1].config.policy)
+        end)
+
+      else
+        it("sets policy to cluster by default", function()
+          local res = admin_client:post("/plugins", {
+            body    = {
+              name  = "rate-limiting",
+              config = {
+                second = 10
+              }
+            },
+            headers = {
+              ["Content-Type"] = "application/json"
+            }
+          })
+          local body = cjson.decode(assert.res_status(201, res))
+          assert.equal("cluster", body.config.policy)
+        end)
+      end
     end)
   end)
 end


### PR DESCRIPTION
### Summary

Some plugins have default options that don't work well with `dbless` or `hybrid` deployments mostly because the database is not available on gateway nodes. This PR adjusts defaults and validation rules on those plugins.