### PR TITLE
perf(warmup) do not warmup upstream names

### DIFF
--- a/kong/cache/warmup.lua
+++ b/kong/cache/warmup.lua
@@ -35,8 +35,22 @@ local function warmup_dns(premature, hosts, count)
 
   local start = ngx.now()
 
+  local upstreams_dao = kong.db["upstreams"]
+  local upstreams_names = {}
+  if upstreams_dao then
+    for upstream, err in upstreams_dao:each(nil, GLOBAL_QUERY_OPTS) do
+      upstreams_names[upstream.name] = true
+    end
+  end
+
   for i = 1, count do
-    kong.dns.toip(hosts[i])
+    local host = hosts[i]
+    local must_warm_up = upstreams_names[host] == nil
+
+    -- warmup DNS entry only if host is not an upstream name
+    if must_warm_up then
+      kong.dns.toip(host)
+    end
   end
 
   local elapsed = floor((ngx.now() - start) * 1000)

--- a/spec/01-unit/01-db/08-cache_warmup_spec.lua
+++ b/spec/01-unit/01-db/08-cache_warmup_spec.lua
@@ -227,6 +227,61 @@ describe("cache_warmup", function()
     assert.same({ "example.com", "example.test" }, dns_queries)
   end)
 
+
+  it("does not warm up upstream names when caching services", function()
+    local cache_table = {}
+    local db_data = {
+      ["my_entity"] = {
+        { aaa = 111, bbb = 222 },
+        { aaa = 333, bbb = 444 },
+      },
+      ["services"] = {
+        { name = "a", host = "example.com", },
+        { name = "b", host = "1.2.3.4", }, -- should be skipped by DNS caching
+        { name = "c", host = "example.test", },
+        { name = "d", host = "thisisan.upstream.test", }, -- should be skipped by DNS caching
+      },
+      ["upstreams"] = {
+        { name = "thisisan.upstream.test", },
+      },
+    }
+    local dns_queries = {}
+
+    local kong = {
+      db = {
+        my_entity = mock_entity(db_data, "my_entity", "aaa"),
+        services = mock_entity(db_data, "services", "name"),
+        upstreams = mock_entity(db_data, "upstreams", "name"),
+      },
+      core_cache = mock_cache(cache_table),
+      cache = mock_cache({}),
+      dns = {
+        toip = function(query)
+          table.insert(dns_queries, query)
+        end,
+      }
+    }
+
+    cache_warmup._mock_kong(kong)
+
+    assert.truthy(cache_warmup.execute({"my_entity", "services"}))
+
+    ngx.sleep(0.001) -- yield so that async DNS caching happens
+
+    -- `my_entity` isn't a core entity; lookup is on client cache
+    assert.same(kong.cache:get("111").bbb, 222)
+    assert.same(kong.cache:get("333").bbb, 444)
+
+    assert.same(kong.core_cache:get("a").host, "example.com")
+    assert.same(kong.core_cache:get("b").host, "1.2.3.4")
+    assert.same(kong.core_cache:get("c").host, "example.test")
+    assert.same(kong.core_cache:get("d").host, "thisisan.upstream.test")
+
+    -- skipped IP entry
+    assert.same({ "example.com", "example.test" }, dns_queries)
+  end)
+
+
   it("logs a warning on bad entities", function()
     local logged_warnings = {}
 


### PR DESCRIPTION
When an upstream name is used as a service hosts entry, it should not be warmed-up, as it's not a real DNS entry.