### PR TITLE
chore(ci) disable kong-prometheus-plugin test suite

### DIFF
--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -65,7 +65,7 @@ if [ "$TEST_SUITE" == "plugins" ]; then
         $TEST_CMD $p || echo "* $p" >> .failed
     done
 
-    cat kong-*.rockspec | grep kong- | grep -v zipkin | grep -v sidecar | grep "~" | while read line ; do
+    cat kong-*.rockspec | grep kong- | grep -v zipkin | grep -v sidecar | grep "~" | grep -v kong-prometheus-plugin | while read line ; do
         REPOSITORY=`echo $line | sed "s/\"/ /g" | awk -F" " '{print $1}'`
         VERSION=`luarocks show $REPOSITORY | grep $REPOSITORY | head -1 | awk -F" " '{print $2}' | cut -f1 -d"-"`
         REPOSITORY=`echo $REPOSITORY | sed -e 's/kong-prometheus-plugin/kong-plugin-prometheus/g'`


### PR DESCRIPTION
The kong-prometheus-plugin test suite was disabled as it is flaky right now.
