### PR TITLE
chore(scripts) do not check for gnu sed

### DIFF
--- a/scripts/make-patch-release
+++ b/scripts/make-patch-release
@@ -51,11 +51,6 @@ function check_requirements() {
    need git
    need hub
    need sed
-
-   if [[ ! "$(sed --version)" =~ "GNU sed" ]]; then
-      echo "FAIL: sed command isn't GNU."
-      exit 1
-   fi
 }
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
This is no longer needed; current sed usage is compatible
with both GNU sed and BSD sed (as found in MacOS).
