### PR TITLE
fix(template) standardize access_log template config

### DIFF
--- a/kong/templates/nginx_kong_stream.lua
+++ b/kong/templates/nginx_kong_stream.lua
@@ -82,7 +82,7 @@ server {
 > if proxy_access_log == "off" then
     access_log off;
 > else
-    access_log ${{PROXY_ACCESS_LOG}} basic;
+    access_log ${{PROXY_ACCESS_LOG}};
 > end
     error_log  ${{PROXY_ERROR_LOG}} ${{LOG_LEVEL}};
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### 📓 Summary

This change fixes the stream template configuration to allow custom access logs formats.

### ☕ Issue

When using kong with TCP I can't use a custom log format. Since `PROXY_ACCESS_LOG` is used in the `nginx_kong_stream.lua` and `nginx_kong.lua` templates, I thought it would be nice to follow the same interpolation pattern in both places.

### ⚠️ Breaking Change

* The log format will stop using the [custom format](https://github.com/Kong/kong/blob/50b8405d02a3bcdf070033632ef0521db1219371/kong/templates/nginx_kong_stream.lua#L3] defined in the template and revert to nginx's default.

### ℹ️ More info

In my use case I have both TCP streams and HTTP request configured in Kong. 
When I try to customize my http access log with the example env vars:

```
NGINX_HTTP_LOG_FORMAT: custom 'any format'
PROXY_ACCESS_LOG: /dev/stdout custom
```

I get the following error because the rendered in by template is invalid `/dev/stdout custom basic`:
```
Error: could not prepare Kong prefix at /kong_prefix: nginx configuration is invalid (exit code 1):                                                                                               
nginx: [emerg] invalid parameter "basic" in /kong_prefix/nginx-kong-stream.conf:70                                                                                                                
nginx: configuration file /kong_prefix/nginx.conf test failed                                                                                                                                     
Run with --v (verbose) or --vv (debug) for more details                                                                                                                                         
stream closed
```

With this change I can simply define the format for the TCP stream covering both cases:
```
NGINX_HTTP_LOG_FORMAT: custom 'any format'
PROXY_ACCESS_LOG: /dev/stdout custom
KONG_NGINX_STREAM_LOG_FORMAT: custom 'any other format'
```