### PR TITLE
fix(template) standardize access_log template config

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -54,6 +54,9 @@
                                                  # If this value is a relative path,
                                                  # it will be placed under the
                                                  # `prefix` location.
+                                                 # `basic` is defined as `'$remote_addr [$time_local] '
+                                                 # '$protocol $status $bytes_sent $bytes_received '
+                                                 # '$session_time'`
 
 #proxy_stream_error_log = logs/error.log         # Path for tcp streams proxy port request error
                                                  # logs. The granularity of these logs

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -42,6 +42,12 @@
                                           # it will be placed under the
                                           # `prefix` location.
 
+
+#proxy_error_log = logs/error.log         # Path for proxy port request error
+                                          # logs. The granularity of these logs
+                                          # is adjusted by the `log_level`
+                                          # property.
+
 #proxy_stream_access_log = logs/access.log basic # Path for tcp streams proxy port access
                                                  # logs. Set this value to `off` to
                                                  # disable logging proxy requests.
@@ -49,10 +55,10 @@
                                                  # it will be placed under the
                                                  # `prefix` location.
 
-#proxy_error_log = logs/error.log         # Path for proxy port request error
-                                          # logs. The granularity of these logs
-                                          # is adjusted by the `log_level`
-                                          # property.
+#proxy_stream_error_log = logs/error.log         # Path for tcp streams proxy port request error
+                                                 # logs. The granularity of these logs
+                                                 # is adjusted by the `log_level`
+                                                 # property.
 
 #admin_access_log = logs/admin_access.log # Path for Admin API request access
                                           # logs. If Hybrid Mode is enabled

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -42,6 +42,13 @@
                                           # it will be placed under the
                                           # `prefix` location.
 
+#proxy_stream_access_log = logs/access.log basic # Path for tcp streams proxy port access
+                                                 # logs. Set this value to `off` to
+                                                 # disable logging proxy requests.
+                                                 # If this value is a relative path,
+                                                 # it will be placed under the
+                                                 # `prefix` location.
+
 #proxy_error_log = logs/error.log         # Path for proxy port request error
                                           # logs. The granularity of these logs
                                           # is adjusted by the `log_level`

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -586,6 +586,7 @@ local CONF_INFERENCES = {
   client_ssl = { typ = "boolean" },
 
   proxy_access_log = { typ = "string" },
+  proxy_stream_access_log = { typ = "string" },
   proxy_error_log = { typ = "string" },
   admin_access_log = { typ = "string" },
   admin_error_log = { typ = "string" },

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -586,8 +586,9 @@ local CONF_INFERENCES = {
   client_ssl = { typ = "boolean" },
 
   proxy_access_log = { typ = "string" },
-  proxy_stream_access_log = { typ = "string" },
   proxy_error_log = { typ = "string" },
+  proxy_stream_access_log = { typ = "string" },
+  proxy_stream_error_log = { typ = "string" },
   admin_access_log = { typ = "string" },
   admin_error_log = { typ = "string" },
   status_access_log = { typ = "string" },

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -2,12 +2,12 @@ return [[
 prefix = /usr/local/kong/
 log_level = notice
 proxy_access_log = logs/access.log
+proxy_stream_access_log = logs/access.log basic
 proxy_error_log = logs/error.log
 admin_access_log = logs/admin_access.log
 admin_error_log = logs/error.log
 status_access_log = off
 status_error_log = logs/status_error.log
-stream_access_log = logs/access.log basic
 plugins = bundled
 port_maps = NONE
 host_ports = NONE

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -2,8 +2,9 @@ return [[
 prefix = /usr/local/kong/
 log_level = notice
 proxy_access_log = logs/access.log
-proxy_stream_access_log = logs/access.log basic
 proxy_error_log = logs/error.log
+proxy_stream_access_log = logs/access.log basic
+proxy_stream_error_log = logs/error.log
 admin_access_log = logs/admin_access.log
 admin_error_log = logs/error.log
 status_access_log = off

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -7,6 +7,7 @@ admin_access_log = logs/admin_access.log
 admin_error_log = logs/error.log
 status_access_log = off
 status_error_log = logs/status_error.log
+stream_access_log = logs/access.log basic
 plugins = bundled
 port_maps = NONE
 host_ports = NONE

--- a/kong/templates/nginx_kong_stream.lua
+++ b/kong/templates/nginx_kong_stream.lua
@@ -80,7 +80,7 @@ server {
 > end
 
     access_log ${{PROXY_STREAM_ACCESS_LOG}};
-    error_log  ${{PROXY_STREAM_ERROR_LOG}} ${{LOG_LEVEL}};
+    error_log ${{PROXY_STREAM_ERROR_LOG}} ${{LOG_LEVEL}};
 
 > for _, ip in ipairs(trusted_ips) do
     set_real_ip_from $(ip);

--- a/kong/templates/nginx_kong_stream.lua
+++ b/kong/templates/nginx_kong_stream.lua
@@ -79,10 +79,13 @@ server {
     listen $(entry.listener);
 > end
 
+> _, count = proxy_access_log:gsub("%S+", "")
 > if proxy_access_log == "off" then
     access_log off;
-> else
+> elseif count == 1 then
     access_log ${{PROXY_ACCESS_LOG}} basic;
+> else
+    access_log ${{PROXY_ACCESS_LOG}};
 > end
     error_log  ${{PROXY_ERROR_LOG}} ${{LOG_LEVEL}};
 

--- a/kong/templates/nginx_kong_stream.lua
+++ b/kong/templates/nginx_kong_stream.lua
@@ -79,14 +79,7 @@ server {
     listen $(entry.listener);
 > end
 
-> _, count = proxy_access_log:gsub("%S+", "")
-> if proxy_access_log == "off" then
-    access_log off;
-> elseif count == 1 then
-    access_log ${{PROXY_ACCESS_LOG}} basic;
-> else
-    access_log ${{PROXY_ACCESS_LOG}};
-> end
+    access_log ${{STREAM_ACCESS_LOG}}
     error_log  ${{PROXY_ERROR_LOG}} ${{LOG_LEVEL}};
 
 > for _, ip in ipairs(trusted_ips) do

--- a/kong/templates/nginx_kong_stream.lua
+++ b/kong/templates/nginx_kong_stream.lua
@@ -80,7 +80,7 @@ server {
 > end
 
     access_log ${{PROXY_STREAM_ACCESS_LOG}};
-    error_log  ${{PROXY_ERROR_LOG}} ${{LOG_LEVEL}};
+    error_log  ${{PROXY_STREAM_ERROR_LOG}} ${{LOG_LEVEL}};
 
 > for _, ip in ipairs(trusted_ips) do
     set_real_ip_from $(ip);

--- a/kong/templates/nginx_kong_stream.lua
+++ b/kong/templates/nginx_kong_stream.lua
@@ -79,7 +79,7 @@ server {
     listen $(entry.listener);
 > end
 
-    access_log ${{STREAM_ACCESS_LOG}}
+    access_log ${{PROXY_STREAM_ACCESS_LOG}};
     error_log  ${{PROXY_ERROR_LOG}} ${{LOG_LEVEL}};
 
 > for _, ip in ipairs(trusted_ips) do

--- a/spec/01-unit/04-prefix_handler_spec.lua
+++ b/spec/01-unit/04-prefix_handler_spec.lua
@@ -488,6 +488,28 @@ describe("NGINX conf compiler", function()
         assert.matches("access_log%s/dev/stdout%scustom;", nginx_conf)
       end)
 
+      it("injects proxy_error_log directive", function()
+        local conf = assert(conf_loader(nil, {
+          proxy_error_log = "/dev/stdout",
+          stream_listen = "0.0.0.0:9100",
+          nginx_stream_tcp_nodelay = "on",
+        }))
+        local nginx_conf = prefix_handler.compile_kong_conf(conf)
+        assert.matches("error_log%s/dev/stdout;", nginx_conf)
+        local nginx_conf = prefix_handler.compile_kong_stream_conf(conf)
+        assert.matches("error_log%slogs/error.log;", nginx_conf)
+
+        local conf = assert(conf_loader(nil, {
+          proxy_stream_error_log = "/dev/stdout",
+          stream_listen = "0.0.0.0:9100",
+          nginx_stream_tcp_nodelay = "on",
+        }))
+        local nginx_conf = prefix_handler.compile_kong_conf(conf)
+        assert.matches("error_log%slogs/error.log;", nginx_conf)
+        local nginx_conf = prefix_handler.compile_kong_stream_conf(conf)
+        assert.matches("error_log%s/dev/stdout;", nginx_conf)
+      end)
+
       it("injects nginx_main_* directives", function()
         local conf = assert(conf_loader(nil, {
           nginx_main_pcre_jit = "on",

--- a/spec/01-unit/04-prefix_handler_spec.lua
+++ b/spec/01-unit/04-prefix_handler_spec.lua
@@ -485,6 +485,16 @@ describe("NGINX conf compiler", function()
         local nginx_conf = prefix_handler.compile_kong_conf(conf)
         assert.matches("access_log%s/dev/stdout%scustom;", nginx_conf)
         local nginx_conf = prefix_handler.compile_kong_stream_conf(conf)
+        assert.matches("access_log%s/dev/stdout%sbasic;", nginx_conf)
+
+        local conf = assert(conf_loader(nil, {
+          proxy_stream_access_log = "/dev/stdout custom",
+          stream_listen = "0.0.0.0:9100",
+          nginx_stream_tcp_nodelay = "on",
+        }))
+        local nginx_conf = prefix_handler.compile_kong_conf(conf)
+        assert.matches("access_log%s/dev/stdout;", nginx_conf)
+        local nginx_conf = prefix_handler.compile_kong_stream_conf(conf)
         assert.matches("access_log%s/dev/stdout%scustom;", nginx_conf)
       end)
 

--- a/spec/01-unit/04-prefix_handler_spec.lua
+++ b/spec/01-unit/04-prefix_handler_spec.lua
@@ -475,17 +475,7 @@ describe("NGINX conf compiler", function()
         local nginx_conf = prefix_handler.compile_kong_conf(conf)
         assert.matches("access_log%s/dev/stdout;", nginx_conf)
         local nginx_conf = prefix_handler.compile_kong_stream_conf(conf)
-        assert.matches("access_log%s/dev/stdout%sbasic;", nginx_conf)
-
-        local conf = assert(conf_loader(nil, {
-          proxy_access_log = "/dev/stdout custom",
-          stream_listen = "0.0.0.0:9100",
-          nginx_stream_tcp_nodelay = "on",
-        }))
-        local nginx_conf = prefix_handler.compile_kong_conf(conf)
-        assert.matches("access_log%s/dev/stdout%scustom;", nginx_conf)
-        local nginx_conf = prefix_handler.compile_kong_stream_conf(conf)
-        assert.matches("access_log%s/dev/stdout%sbasic;", nginx_conf)
+        assert.matches("access_log%slogs/access.log%sbasic;", nginx_conf)
 
         local conf = assert(conf_loader(nil, {
           proxy_stream_access_log = "/dev/stdout custom",
@@ -493,7 +483,7 @@ describe("NGINX conf compiler", function()
           nginx_stream_tcp_nodelay = "on",
         }))
         local nginx_conf = prefix_handler.compile_kong_conf(conf)
-        assert.matches("access_log%s/dev/stdout;", nginx_conf)
+        assert.matches("access_log%slogs/access.log;", nginx_conf)
         local nginx_conf = prefix_handler.compile_kong_stream_conf(conf)
         assert.matches("access_log%s/dev/stdout%scustom;", nginx_conf)
       end)

--- a/spec/01-unit/04-prefix_handler_spec.lua
+++ b/spec/01-unit/04-prefix_handler_spec.lua
@@ -469,20 +469,24 @@ describe("NGINX conf compiler", function()
       it("injects proxy_access_log directive", function()
         local conf = assert(conf_loader(nil, {
           proxy_access_log = "/dev/stdout",
+          stream_listen = "0.0.0.0:9100",
+          nginx_stream_tcp_nodelay = "on",
         }))
         local nginx_conf = prefix_handler.compile_kong_conf(conf)
         assert.matches("access_log%s/dev/stdout;", nginx_conf)
         local nginx_conf = prefix_handler.compile_kong_stream_conf(conf)
-        assert.matches("access_log%s/dev/stdout basic;", nginx_conf)
+        assert.matches("access_log%s/dev/stdout%sbasic;", nginx_conf)
 
         local conf = assert(conf_loader(nil, {
           proxy_access_log = "/dev/stdout custom",
+          stream_listen = "0.0.0.0:9100",
+          nginx_stream_tcp_nodelay = "on",
         }))
         local nginx_conf = prefix_handler.compile_kong_conf(conf)
-        assert.matches("access_log%s/dev/stdout custom;", nginx_conf)
+        assert.matches("access_log%s/dev/stdout%scustom;", nginx_conf)
         local nginx_conf = prefix_handler.compile_kong_stream_conf(conf)
-        assert.matches("access_log%s/dev/stdout custom;", nginx_conf)
-      )
+        assert.matches("access_log%s/dev/stdout%scustom;", nginx_conf)
+      end)
 
       it("injects nginx_main_* directives", function()
         local conf = assert(conf_loader(nil, {

--- a/spec/01-unit/04-prefix_handler_spec.lua
+++ b/spec/01-unit/04-prefix_handler_spec.lua
@@ -495,9 +495,9 @@ describe("NGINX conf compiler", function()
           nginx_stream_tcp_nodelay = "on",
         }))
         local nginx_conf = prefix_handler.compile_kong_conf(conf)
-        assert.matches("error_log%s/dev/stdout;", nginx_conf)
+        assert.matches("error_log%s/dev/stdout%snotice;", nginx_conf)
         local nginx_conf = prefix_handler.compile_kong_stream_conf(conf)
-        assert.matches("error_log%slogs/error.log;", nginx_conf)
+        assert.matches("error_log%slogs/error.log%snotice;", nginx_conf)
 
         local conf = assert(conf_loader(nil, {
           proxy_stream_error_log = "/dev/stdout",
@@ -505,9 +505,9 @@ describe("NGINX conf compiler", function()
           nginx_stream_tcp_nodelay = "on",
         }))
         local nginx_conf = prefix_handler.compile_kong_conf(conf)
-        assert.matches("error_log%slogs/error.log;", nginx_conf)
+        assert.matches("error_log%slogs/error.log%snotice;", nginx_conf)
         local nginx_conf = prefix_handler.compile_kong_stream_conf(conf)
-        assert.matches("error_log%s/dev/stdout;", nginx_conf)
+        assert.matches("error_log%s/dev/stdout%snotice;", nginx_conf)
       end)
 
       it("injects nginx_main_* directives", function()

--- a/spec/01-unit/04-prefix_handler_spec.lua
+++ b/spec/01-unit/04-prefix_handler_spec.lua
@@ -466,6 +466,24 @@ describe("NGINX conf compiler", function()
     end)
 
     describe("injected NGINX directives", function()
+      it("injects proxy_access_log directive", function()
+        local conf = assert(conf_loader(nil, {
+          proxy_access_log = "/dev/stdout",
+        }))
+        local nginx_conf = prefix_handler.compile_kong_conf(conf)
+        assert.matches("access_log%s/dev/stdout;", nginx_conf)
+        local nginx_conf = prefix_handler.compile_kong_stream_conf(conf)
+        assert.matches("access_log%s/dev/stdout basic;", nginx_conf)
+
+        local conf = assert(conf_loader(nil, {
+          proxy_access_log = "/dev/stdout custom",
+        }))
+        local nginx_conf = prefix_handler.compile_kong_conf(conf)
+        assert.matches("access_log%s/dev/stdout custom;", nginx_conf)
+        local nginx_conf = prefix_handler.compile_kong_stream_conf(conf)
+        assert.matches("access_log%s/dev/stdout custom;", nginx_conf)
+      )
+
       it("injects nginx_main_* directives", function()
         local conf = assert(conf_loader(nil, {
           nginx_main_pcre_jit = "on",


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### 📓 Summary

This change fixes the stream template configuration to allow custom access logs formats. To differente the HTTP proxy from the stream access logs I added the `PROXY_STREAM_ACCESS_LOG` keeping the current default.

### ☕ Issue

When using kong with TCP I can't use a custom log format. Since `PROXY_ACCESS_LOG` is used in the `nginx_kong_stream.lua` and `nginx_kong.lua` templates, I thought it would be nice to follow the same interpolation pattern in both places.

### ℹ️ More info

In my use case I have both TCP streams and HTTP request configured in Kong. 
When I try to customize my http access log with the example env vars:

```
NGINX_HTTP_LOG_FORMAT: custom 'any format'
PROXY_ACCESS_LOG: /dev/stdout custom
```

I get the following error because the rendered template is invalid `/dev/stdout custom basic`:
```
Error: could not prepare Kong prefix at /kong_prefix: nginx configuration is invalid (exit code 1):                                                                                               
nginx: [emerg] invalid parameter "basic" in /kong_prefix/nginx-kong-stream.conf:70                                                                                                                
nginx: configuration file /kong_prefix/nginx.conf test failed                                                                                                                                     
Run with --v (verbose) or --vv (debug) for more details                                                                                                                                         
stream closed
```

With this change I can simply define the format for the TCP stream covering both cases:
```
NGINX_HTTP_LOG_FORMAT: custom 'any format'
PROXY_ACCESS_LOG: /dev/stdout custom
PROXY_STREAM_ACCESS_LOG: /dev/stdout custom
KONG_NGINX_STREAM_LOG_FORMAT: custom 'any other format'
```