### PR TITLE
fix(migrations) sort subsystems alphabetically

### DIFF
--- a/kong/db/migrations/state.lua
+++ b/kong/db/migrations/state.lua
@@ -53,12 +53,18 @@ local function load_subsystems(db, plugin_names)
     error("plugin_names must be a table", 2)
   end
 
+  local sorted_plugin_names = {}
+  for name in pairs(plugin_names) do
+    sorted_plugin_names[#sorted_plugin_names + 1] = name
+  end
+  table.sort(sorted_plugin_names)
+
   local subsystems = require("kong.db.migrations.subsystems")
 
   local res = {}
   for _, ss in ipairs(subsystems) do
     if ss.name:match("%*") then
-      for plugin_name in pairs(plugin_names) do
+      for _, plugin_name in ipairs(sorted_plugin_names) do
         local namespace = ss.namespace:gsub("%*", plugin_name)
 
         local ok, mig_idx = utils.load_module_if_exists(namespace)

--- a/spec/02-integration/03-db/06-migrations_state_spec.lua
+++ b/spec/02-integration/03-db/06-migrations_state_spec.lua
@@ -3,6 +3,23 @@ local helpers = require "spec.helpers"
 
 for _, strategy in helpers.each_strategy() do
   describe("db.migrations.State", function()
+    describe("load", function()
+      it("loads subsystems in alphabetical order", function()
+        local _, db = helpers.get_db_utils(strategy)
+        local state = State.load(db)
+
+        local namespaces = {}
+        local sorted_namespaces = {}
+        for i, subsystem in ipairs(state.executed_migrations) do
+          namespaces[i] = subsystem.namespace
+          sorted_namespaces[i] = subsystem.namespace
+        end
+        table.sort(sorted_namespaces)
+
+        assert.same(namespaces, sorted_namespaces)
+      end)
+    end)
+
     describe("is_migration_executed", function()
       local db
       local state


### PR DESCRIPTION
The `pairs` iteration over `plugin_names` makes running migrations inconsistent - the order in which the subsystems are loaded changes randomly.

This PR stops the random order by sorting the subsystems alphabetically, so at least the order in which migrations are executed is constant.

Sorting things this way is better than having no order at all, but the ideal solution would be sorting plugins topologically (so a plugin having entities depending on another plugin will be loaded later).
