### PR TITLE
perf(balancer) use round_robin algorithm from dns-client

### DIFF
--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -463,7 +463,7 @@ do
       balancer_types = {
         ["consistent-hashing"] = require("resty.dns.balancer.consistent_hashing"),
         ["least-connections"] = require("resty.dns.balancer.least_connections"),
-        ["round-robin"] = require("resty.dns.balancer.ring"),
+        ["round-robin"] = require("resty.dns.balancer.round_robin"),
       }
     end
     local balancer, err = balancer_types[upstream.algorithm].new({


### PR DESCRIPTION
Use the new round-robin algorithm from lua-resty-dns-client. 

This requires the sister PR Kong/lua-resty-dns-client#123 (and a version bump)

### Issues resolved

Fix #6659
