### PR TITLE
fix(handler): Escape upstream_uri after a plugin

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1300,11 +1300,13 @@ return {
         -- stripping the empty querystring.
         -- We overcome this behavior with our own logic, to preserve user
         -- desired semantics.
-        local upstream_uri = var.upstream_uri
+        local upstream_uri = escape(var.upstream_uri)
 
         if var.is_args == "?" or sub(var.request_uri, -1) == "?" then
-          var.upstream_uri = upstream_uri .. "?" .. (var.args or "")
+          upstream_uri = upstream_uri .. "?" .. (var.args or "")
         end
+
+        var.upstream_uri = upstream_uri
       end
 
       local balancer_data = ctx.balancer_data


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Since the normalize feature on Kong (https://github.com/Kong/kong/pull/6821), we have strange behavior on uri that are decoded with special chars after the request-transformer plugin.

Here an example:

- Inital request: `store+banne+%C3%A9lectrique.json`
- After a transform_uri: `store+banne+électrique.json`

The goal of this merge request is to fix this issue and have the expected behavior:

- Initial request: `store+banne+%C3%A9lectrique.json`
- After a transform_uri: `store+banne+%C3%A9lectrique.json`

### Full changelog

* Add `escape` function on upstream_uri after plugin

