### PR TITLE
chore(deps) bump kong-lapis from 1.8.1.2 to 1.8.3.1

### DIFF
--- a/kong-2.3.3-0.rockspec
+++ b/kong-2.3.3-0.rockspec
@@ -21,7 +21,7 @@ dependencies = {
   "lua-ffi-zlib == 0.5",
   "multipart == 0.5.9",
   "version == 1.0.1",
-  "kong-lapis == 1.8.1.2",
+  "kong-lapis == 1.8.3.1",
   "lua-cassandra == 1.5.1",
   "pgmoon == 1.12.0",
   "luatz == 0.4",


### PR DESCRIPTION
### Summary

#### v1.8.3 — February 9 2021

##### Additions
- Support lazy loading route actions from route name to module name #710
- Add UTF8 helper module, lapis.utf8, for identifying single UTF8 chars and whitespace (lpeg patterns that can be used for trimming and sanitization)
- Add cascade option to postgres drop index schema function

##### Changes
- Remove unused mimetypes dependency
- If yield_error or assert_error are not captured by a outer coroutine then a hard error will happen
- Request\add_params does not need a name
- When searching for OpenResty installation, also accept a binary named openresty (for openresty install on mac with brew)
- pgmoon connection error messages are prefixed with “postgres” to make them easier to identify
- remove excess ; characters in generated SQL for some postgres schema functions
- Postgres create index schema function if_not_exists option will now use the sql clause if not exists instead of running a query to see if the entity exists

##### Misc
- Update test suite to GitHub actions, remove TravisCI. Test suite works across all versions of Lua
- Update docker test suite to latest postgres/mysql

#### v1.8.2 — September 21 2020

##### Additions
- db.delete can take additional arguments for RETURNING, Model\delete method also supports additional arguments to control returning clause
- get_X_paginated model relation method now supports passing where and order options to the paginator constructor

##### Fixes

- Using order and group at the same time with Model\include_in will no longer generate an invalid query
- When running lapis command, the environment is immediately loaded when checking what commands are available for the server, fixes #665
- lapis.nginx.cache can correctly serialize array and boolean types that can result from parameter parsing, fixes 683
- The substring - is no longer matched by accident for route pattern filters #696

#### Changes

- When running in busted, the test environment is set as the default environment any tests are run. It is not longer necessary to have a setup or use_test_env call to configure the environment
- Default buffer size and timout for parsing multipart form data has been increased to allow for slower connections (4k bytes per 5 seconds)
- All logging goes stdout when not running in Nginx
- Compatibility patches for Lua 5.2, 5.3, 5.4
- Improved error message for some lapis commands when using an incomplete configuration
- Improved error message when file can not be written when generating app files
 (Internal) default_environment function moved to lapis.environment module, added set_default_environment function
- Better error message when trying to use belongs_to with composite key (has_one should be used instead)
- Better error when trying to use default composite primary key with a has_one relation
- Misc
- Test suites run across on all versions of Lua on GitHub actions
- Added docs for how request parameters are parsed and merged
- Added docs for how the default environment works
- Fixed bug in docs generator where code snippets were not appearing
- The --trace option for the lapis command is enabled by default when running in test
- Fix minor typos in docs