### PR TITLE
docs(autodoc) Removing skip_read_time

### DIFF
--- a/autodoc/admin-api/generate.lua
+++ b/autodoc/admin-api/generate.lua
@@ -923,7 +923,6 @@ local function write_admin_api(filename, data, title)
   outfd:write("#  or its associated files instead.\n")
   outfd:write("#\n")
   outfd:write("title: " .. utils.titleize(title) .. "\n")
-  outfd:write("skip_read_time: true\n")
   outfd:write("toc: false\n\n")
   for _, entity in ipairs(data.known.entities) do
     local entity_data = assert_data(data.entities[entity],

--- a/autodoc/cli/data.lua
+++ b/autodoc/cli/data.lua
@@ -8,7 +8,6 @@ data.header = [[
 #  the files in https://github.com/Kong/kong/tree/master/autodoc/cli
 #
 title: CLI Reference
-skip_read_time: true
 ---
 
 ## Introduction

--- a/autodoc/conf/data.lua
+++ b/autodoc/conf/data.lua
@@ -8,7 +8,6 @@ data.header = [[
 #  the files in https://github.com/Kong/kong/tree/master/autodoc/conf
 #
 title: Configuration Reference
-skip_read_time: true
 ---
 
 ## Configuration loading


### PR DESCRIPTION
### Summary
Removing `skip_read_time` from autodoc files. 
As of https://github.com/Kong/docs.konghq.com/pull/2693, estimated read time is no longer included in the docs layout, so there's no need to skip it.

### Full changelog
N/A

### Issues resolved
N/A
