### PR TITLE
feat(file-log) add censoring capabilities

### DIFF
--- a/kong/plugins/file-log/attribute_remover.lua
+++ b/kong/plugins/file-log/attribute_remover.lua
@@ -1,0 +1,45 @@
+local attribute_remover = {}
+
+local function deep_copy(obj, seen)
+  if type(obj) ~= 'table' then return obj end
+  if seen and seen[obj] then return seen[obj] end
+
+  local s = seen or {}
+  local res = setmetatable({}, getmetatable(obj))
+  s[obj] = res
+  for k, v in pairs(obj) do
+    res[deep_copy(k, s)] = deep_copy(v, s)
+  end
+  return res
+end
+
+local function split_string(source, separator)
+  local result = { }
+  for s in source:gmatch(separator) do
+    result[#result + 1] = s
+  end
+  return result
+end
+
+local function delete_attribute(source, attribute)
+  local table = source
+  local segments = split_string(attribute, "([^.%s]+)")
+  for i = 1, (#segments-1) do
+    local segment = segments[i]
+    if type(table[segment]) ~= 'table' then
+      return
+    end
+    table = table[segment]
+  end
+  table[segments[#segments]] = nil
+end
+
+function attribute_remover.delete_attributes(source, attributes)
+  source = deep_copy(source)
+  for index, attribute in ipairs(attributes) do
+    delete_attribute(source, attribute)
+  end
+  return source
+end
+
+return attribute_remover

--- a/kong/plugins/file-log/handler.lua
+++ b/kong/plugins/file-log/handler.lua
@@ -2,6 +2,7 @@
 local ffi = require "ffi"
 local cjson = require "cjson"
 local system_constants = require "lua_system_constants"
+local attribute_remover = require "kong.plugins.file-log.attribute_remover"
 
 
 local kong = kong
@@ -70,7 +71,8 @@ local FileLogHandler = {
 
 function FileLogHandler:log(conf)
   local message = kong.log.serialize()
-  log(conf, message)
+  censored_message = attribute_remover.delete_attributes(message, conf.censored_fields)
+  log(conf, censored_message)
 end
 
 

--- a/kong/plugins/file-log/schema.lua
+++ b/kong/plugins/file-log/schema.lua
@@ -13,6 +13,11 @@ return {
                      err = "not a valid filename",
           }, },
           { reopen = { type = "boolean", required = true, default = false }, },
+          { censored_fields = { required = false,
+                                type = "array",
+                                elements = { type = 'string' },
+                                default = {},
+          }, },
     }, }, },
   }
 }

--- a/spec/03-plugins/04-file-log/03-attribute_remover_spec.lua
+++ b/spec/03-plugins/04-file-log/03-attribute_remover_spec.lua
@@ -1,0 +1,41 @@
+local subject = require('kong.plugins.file-log.attribute_remover')
+
+describe("Plugin: file-log (attribute_remover)", function()
+  it("removes the attributes specified at the censored_fields array from the log message", function()
+    local log = {
+      request = {
+        url = 'https://some-awesome-url.com/kong/rocks',
+        headers = {
+          ["x-kong-header"] = 'another-cool-header',
+          ["x-kong-api-key"] = 'some-api-key',
+        }
+      }
+    }
+    local censored_fields = {'request.headers.x-kong-api-key'}
+    local censored_message = subject.delete_attributes(log, censored_fields)
+    local expected = {
+      request = {
+        url = 'https://some-awesome-url.com/kong/rocks',
+        headers = {
+          ["x-kong-header"] = 'another-cool-header',
+        }
+      }
+    }
+    assert.are.same(censored_message, expected)
+  end)
+
+  it("does not remove attributes from the log message when no attributes were specified", function()
+    local log = {
+      request = {
+        url = 'https://some-awesome-url.com/kong/rocks',
+        headers = {
+          ["x-kong-header"] = 'another-cool-header',
+          ["x-kong-api-key"] = 'some-api-key',
+        }
+      }
+    }
+    local censored_fields = {}
+    local censored_message = subject.delete_attributes(log, censored_fields)
+    assert.are.same(log, censored_message)
+  end)
+end)


### PR DESCRIPTION
To avoid logging sensitive data, such as API keys, an attribute remover
is added. It enables the possibility of removing specific attributes
from the message that will be logged. A censored_fields field is added
to the schema were the path of the field should be specified separated
by periods.

* add an attribute remover to the file-log plugin
* add a censored_fields field to the file-log plugin schema
* add an unit test for the attribute remover in the file-log test suite
