### PR TITLE
feat(clustering) relax version compatibility check to allow DP lagging 2 minor versions behind

### DIFF
--- a/kong/clustering.lua
+++ b/kong/clustering.lua
@@ -398,7 +398,8 @@ do
 end
 
 
-local MAJOR_MINOR_PATTERN = "^(%d+%.%d+)%.%d+"
+local MAJOR_MINOR_PATTERN = "^(%d+)%.(%d+)%.%d+"
+
 local function should_send_config_update(node_version, node_plugins)
   if not node_version or not node_plugins then
     return false, "your DP did not provide version information to the CP, " ..
@@ -408,15 +409,21 @@ local function should_send_config_update(node_version, node_plugins)
                   "automatically once this DP also upgrades to 2.3 or later"
   end
 
-  local minor_cp = KONG_VERSION:match(MAJOR_MINOR_PATTERN)
-  local minor_node = node_version:match(MAJOR_MINOR_PATTERN)
-  if minor_cp ~= minor_node then
-    return false, "version mismatches, CP version: " .. minor_cp ..
-                  " DP version: " .. minor_node,
+  local major_cp, minor_cp = KONG_VERSION:match(MAJOR_MINOR_PATTERN)
+  local major_node, minor_node = node_version:match(MAJOR_MINOR_PATTERN)
+  minor_cp = tonumber(minor_cp)
+  minor_node = tonumber(minor_node)
+
+  if major_cp ~= major_node or minor_cp - 2 > minor_node or minor_cp < minor_node then
+    return false, "version incompatible, CP version: " .. KONG_VERSION ..
+                  " DP version: " .. node_version ..
+                  " DP versions acceptable are " ..
+                  major_cp .. "." .. math.max(0, minor_cp - 2) .. " to " ..
+                  major_cp .. "." .. minor_cp .. "(edges included)",
                   CLUSTERING_SYNC_STATUS.KONG_VERSION_INCOMPATIBLE
   end
 
-  -- XXX EE: allow DP to have a superset of CP's plugins
+  -- allow DP to have a superset of CP's plugins
   local p, np
   local i, j = #PLUGINS_LIST, #node_plugins
 
@@ -433,16 +440,20 @@ local function should_send_config_update(node_version, node_plugins)
       goto continue
     end
 
-    -- XXX EE
     -- ignore plugins without a version (route-by-header is deprecated)
-    if p.version and np.version and
-    -- major/minor check that ignores anything after the second digit
-       p.version:match("^(%d+%.%d+)") ~= np.version:match("^(%d+%.%d+)")
-    then
-      return false, "plugin \"" .. p.name .. "\" version differs between " ..
-                    "CP and DP, CP has version " .. tostring(p.version) ..
-                    " while DP has version " .. tostring(np.version),
-                    CLUSTERING_SYNC_STATUS.PLUGIN_VERSION_INCOMPATIBLE
+    if p.version and np.version then
+      -- major/minor check that ignores anything after the second digit
+      local major_minor_p = p.version:match("^(%d+%.%d+)") or "not_a_version"
+      local major_minor_np = np.version:match("^(%d+%.%d+)") or "still_not_a_version"
+
+      if major_minor_p ~= major_minor_np then
+        return false, "plugin \"" .. p.name .. "\" version incompatible, " ..
+                      "CP version: " .. tostring(p.version) ..
+                      " DP version: " .. tostring(np.version) ..
+                      " DP plugin version acceptable is "..
+                      major_minor_p .. ".x",
+                      CLUSTERING_SYNC_STATUS.PLUGIN_VERSION_INCOMPATIBLE
+      end
     end
 
     i = i - 1
@@ -452,7 +463,7 @@ local function should_send_config_update(node_version, node_plugins)
 
   if i > 0 then
     return false, "CP and DP does not have same set of plugins installed",
-                    CLUSTERING_SYNC_STATUS.PLUGIN_SET_INCOMPATIBLE
+                  CLUSTERING_SYNC_STATUS.PLUGIN_SET_INCOMPATIBLE
   end
 
   return true

--- a/kong/clustering.lua
+++ b/kong/clustering.lua
@@ -416,11 +416,21 @@ local function should_send_config_update(node_version, node_plugins)
                   CLUSTERING_SYNC_STATUS.KONG_VERSION_INCOMPATIBLE
   end
 
-  for i, p in ipairs(PLUGINS_LIST) do
-    local np = node_plugins[i]
+  -- XXX EE: allow DP to have a superset of CP's plugins
+  local p, np
+  local i, j = #PLUGINS_LIST, #node_plugins
+
+  if j < i then
+    return false, "CP and DP does not have same set of plugins installed",
+                  CLUSTERING_SYNC_STATUS.PLUGIN_SET_INCOMPATIBLE
+  end
+
+  while i > 0 and j > 0 do
+    p = PLUGINS_LIST[i]
+    np = node_plugins[j]
+
     if p.name ~= np.name then
-      return false, "CP and DP does not have same set of plugins installed",
-                    CLUSTERING_SYNC_STATUS.PLUGIN_SET_INCOMPATIBLE
+      goto continue
     end
 
     if p.version ~= np.version then
@@ -429,6 +439,15 @@ local function should_send_config_update(node_version, node_plugins)
                     " while DP has version " .. tostring(np.version),
                     CLUSTERING_SYNC_STATUS.PLUGIN_VERSION_INCOMPATIBLE
     end
+
+    i = i - 1
+    ::continue::
+    j = j - 1
+  end
+
+  if i > 0 then
+    return false, "CP and DP does not have same set of plugins installed",
+                    CLUSTERING_SYNC_STATUS.PLUGIN_SET_INCOMPATIBLE
   end
 
   return true

--- a/kong/clustering.lua
+++ b/kong/clustering.lua
@@ -433,7 +433,12 @@ local function should_send_config_update(node_version, node_plugins)
       goto continue
     end
 
-    if p.version ~= np.version then
+    -- XXX EE
+    -- ignore plugins without a version (route-by-header is deprecated)
+    if p.version and np.version and
+    -- major/minor check that ignores anything after the second digit
+       p.version:match("^(%d+%.%d+)") ~= np.version:match("^(%d+%.%d+)")
+    then
       return false, "plugin \"" .. p.name .. "\" version differs between " ..
                     "CP and DP, CP has version " .. tostring(p.version) ..
                     " while DP has version " .. tostring(np.version),

--- a/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
@@ -385,8 +385,16 @@ for _, strategy in helpers.each_strategy() do
       it("CP and CP plugin version mismatches, sync is blocked", function()
         local uuid = utils.uuid()
         local plugins_list = helpers.get_plugins_list()
-        -- this tampers with the bugfix version
-        plugins_list[1].version = plugins_list[1].version .. "1"
+        -- XXX EE
+        -- -- this tampers with the bugfix version
+        -- plugins_list[1].version = plugins_list[1].version .. "1"
+
+        -- this tampers with the minor version
+        plugins_list[1].version = string.format("%d.%d.%d",
+          tonumber(plugins_list[1].version:match("(%d+)")),
+          tonumber(plugins_list[1].version:match("%d+%.(%d+)")) + 1,
+          tonumber(plugins_list[1].version:match("%d+%.%d+%.(%d+)"))
+        )
 
         local res = assert(helpers.clustering_client({
           host = "127.0.0.1",

--- a/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
@@ -1,10 +1,16 @@
 local helpers = require "spec.helpers"
 local utils = require "kong.tools.utils"
 local cjson = require "cjson.safe"
+local pl_tablex = require "pl.tablex"
 local _VERSION_TABLE = require "kong.meta" ._VERSION_TABLE
 local MAJOR = _VERSION_TABLE.major
+-- make minor version always larger-equal than 3 so test cases are happy
+if _VERSION_TABLE.minor < 3 then
+  _VERSION_TABLE.minor = 3
+end
 local MINOR = _VERSION_TABLE.minor
 local PATCH = _VERSION_TABLE.patch
+local CLUSTERING_SYNC_STATUS = require("kong.constants").CLUSTERING_SYNC_STATUS
 
 
 for _, strategy in helpers.each_strategy() do
@@ -64,7 +70,7 @@ for _, strategy in helpers.each_strategy() do
             if v.ip == "127.0.0.1" then
               assert.near(14 * 86400, v.ttl, 3)
               assert.matches("^(%d+%.%d+)%.%d+", v.version)
-              assert.equal("normal", v.sync_status)
+              assert.equal(CLUSTERING_SYNC_STATUS.NORMAL, v.sync_status)
 
               return true
             end
@@ -215,11 +221,9 @@ for _, strategy in helpers.each_strategy() do
   describe("CP/DP version check works with #" .. strategy, function()
     -- for these tests, we do not need a real DP, but rather use the fake DP
     -- client so we can mock various values (e.g. node_version)
-    describe("checks major.minor, bugfix and suffix can be different", function()
-      local db
-
+    describe("relaxed compatibility check:", function()
       lazy_setup(function()
-        _, db = helpers.get_db_utils(strategy, {
+        helpers.get_db_utils(strategy, {
           "routes",
           "services",
           "clustering_data_planes",
@@ -242,256 +246,196 @@ for _, strategy in helpers.each_strategy() do
         helpers.stop_kong()
       end)
 
-      it("CP and DP version and plugins matches", function()
-        local uuid = utils.uuid()
+      -- STARTS allowed cases
+      local allowed_cases = {
+        ["CP and DP version and plugins matches"] = {},
+        ["CP and DP patch version mismatches"] = {
+          dp_version = string.format("%d.%d.%d", MAJOR, MINOR, 4),
+        },
+        ["CP and DP suffix mismatches"] = {
+          dp_version = tostring(_VERSION_TABLE) .. "-enterprise-version",
+        },
+        ["0 <= CP.minor - DP.minor <= 2"] = {
+          dp_version = tostring(_VERSION_TABLE) ,
+        },
+      }
 
-        local res = assert(helpers.clustering_client({
-          host = "127.0.0.1",
-          port = 9005,
-          cert = "spec/fixtures/kong_clustering.crt",
-          cert_key = "spec/fixtures/kong_clustering.key",
-          node_id = uuid,
-        }))
+      local pl1 = pl_tablex.deepcopy(helpers.get_plugins_list())
+      table.insert(pl1, 2, { name = "banana", version = "1.1.1" })
+      table.insert(pl1, { name = "pineapple", version = "1.1.2" })
+      allowed_cases["DP plugin set is a superset of CP"] = {
+        plugins_list = pl1
+      }
 
-        assert.equals("reconfigure", res.type)
-        assert.is_table(res.config_table)
+      local pl2 = pl_tablex.deepcopy(helpers.get_plugins_list())
+      for i, p in ipairs(pl2) do
+        local v = pl2[i].version
+        local patch = v and v:match("%d+%.%d+%.(%d+)")
+        -- find a plugin that has patch version mismatch
+        -- we hardcode `dummy` plugin to be 9.9.9 so there must be at least one
+        if patch and tonumber(patch) and tonumber(patch) > 2 then
+          pl2[i].version = string.format("%d.%d.%d",
+            tonumber(v:match("(%d+)")),
+            tonumber(v:match("%d+%.(%d+)")),
+            tonumber(patch - 2)
+          )
+          break
+        end
+      end
+      allowed_cases["CP and DP plugin version matches to major.minor"] = {
+        plugins_list = pl2
+      }
 
-        -- needs wait_until for C* convergence
-        helpers.wait_until(function()
-          local admin_client = helpers.admin_client()
+      for desc, harness in pairs(allowed_cases) do
+        it(desc .. ", sync is allowed", function()
+          local uuid = utils.uuid()
 
-          res = assert(admin_client:get("/clustering/data-planes"))
-          local body = assert.res_status(200, res)
+          local res = assert(helpers.clustering_client({
+            host = "127.0.0.1",
+            port = 9005,
+            cert = "spec/fixtures/kong_clustering.crt",
+            cert_key = "spec/fixtures/kong_clustering.key",
+            node_id = uuid,
+            node_version = harness.dp_version,
+            node_plugins_list = harness.plugins_list,
+          }))
 
-          admin_client:close()
-          local json = cjson.decode(body)
+          assert.equals("reconfigure", res.type)
+          assert.is_table(res.config_table)
 
-          for _, v in pairs(json.data) do
-            if v.id == uuid then
-              assert.equal(tostring(_VERSION_TABLE), v.version)
-              assert.equal("normal", v.sync_status)
-              return true
-            end
-          end
-        end, 5)
-      end)
+          -- needs wait_until for C* convergence
+          helpers.wait_until(function()
+            local admin_client = helpers.admin_client()
 
-      it("CP and DP minor version mismatches, sync is still allowed", function()
-        local uuid = utils.uuid()
-        local version = string.format("%d.%d.%d", MAJOR, MINOR, PATCH + 1)
+            res = assert(admin_client:get("/clustering/data-planes"))
+            local body = assert.res_status(200, res)
 
-        local res = assert(helpers.clustering_client({
-          host = "127.0.0.1",
-          port = 9005,
-          cert = "spec/fixtures/kong_clustering.crt",
-          cert_key = "spec/fixtures/kong_clustering.key",
-          node_version = version,
-          node_id = uuid,
-        }))
+            admin_client:close()
+            local json = cjson.decode(body)
 
-        assert.equals("reconfigure", res.type)
-        assert.is_table(res.config_table)
-
-        -- needs wait_until for C* convergence
-        helpers.wait_until(function()
-          local admin_client = helpers.admin_client()
-
-          res = assert(admin_client:get("/clustering/data-planes"))
-          local body = assert.res_status(200, res)
-
-          admin_client:close()
-          local json = cjson.decode(body)
-
-          for _, v in pairs(json.data) do
-            if v.id == uuid then
-              assert.equal(version, v.version)
-              assert.equal("normal", v.sync_status)
-              return true
-            end
-          end
-        end, 5)
-      end)
-
-      it("CP and DP suffix mismatches, sync is still allowed", function()
-        local uuid = utils.uuid()
-        local version = tostring(_VERSION_TABLE) .. "-enterprise-version"
-
-        local res = assert(helpers.clustering_client({
-          host = "127.0.0.1",
-          port = 9005,
-          cert = "spec/fixtures/kong_clustering.crt",
-          cert_key = "spec/fixtures/kong_clustering.key",
-          node_version = version,
-          node_id = uuid,
-        }))
-
-        assert.equals("reconfigure", res.type)
-        assert.is_table(res.config_table)
-
-        -- needs wait_until for c* convergence
-        helpers.wait_until(function()
-          local admin_client = helpers.admin_client()
-
-          res = assert(admin_client:get("/clustering/data-planes"))
-          local body = assert.res_status(200, res)
-
-          admin_client:close()
-          local json = cjson.decode(body)
-
-          for _, v in pairs(json.data) do
-            if v.id == uuid then
-              assert.equal(version, v.version)
-              assert.equal("normal", v.sync_status)
-              return true
-            end
-          end
-        end, 5)
-      end)
-
-      it("CP and DP minor version mismatches, sync is blocked", function()
-        local uuid = utils.uuid()
-
-        local res = assert(helpers.clustering_client({
-          host = "127.0.0.1",
-          port = 9005,
-          cert = "spec/fixtures/kong_clustering.crt",
-          cert_key = "spec/fixtures/kong_clustering.key",
-          node_version = "1.0.0",
-          node_id = uuid,
-        }))
-
-        assert.equals("PONG", res)
-
-        -- needs wait_until for c* convergence
-        helpers.wait_until(function()
-          local admin_client = helpers.admin_client()
-
-          res = assert(admin_client:get("/clustering/data-planes"))
-          local body = assert.res_status(200, res)
-
-          admin_client:close()
-          local json = cjson.decode(body)
-
-          for _, v in pairs(json.data) do
-            if v.id == uuid then
-              assert.equal("1.0.0", v.version)
-              assert.equal("kong_version_incompatible", v.sync_status)
-              return true
-            end
-          end
-        end, 5)
-      end)
-
-      it("CP and CP plugin version mismatches, sync is blocked", function()
-        local uuid = utils.uuid()
-        local plugins_list = helpers.get_plugins_list()
-        -- XXX EE
-        -- -- this tampers with the bugfix version
-        -- plugins_list[1].version = plugins_list[1].version .. "1"
-
-        -- this tampers with the minor version
-        plugins_list[1].version = string.format("%d.%d.%d",
-          tonumber(plugins_list[1].version:match("(%d+)")),
-          tonumber(plugins_list[1].version:match("%d+%.(%d+)")) + 1,
-          tonumber(plugins_list[1].version:match("%d+%.%d+%.(%d+)"))
-        )
-
-        local res = assert(helpers.clustering_client({
-          host = "127.0.0.1",
-          port = 9005,
-          cert = "spec/fixtures/kong_clustering.crt",
-          cert_key = "spec/fixtures/kong_clustering.key",
-          node_id = uuid,
-          node_plugins_list = plugins_list,
-        }))
-
-        assert.equals("PONG", res)
-
-        -- needs wait_until for c* convergence
-        helpers.wait_until(function()
-          local admin_client = helpers.admin_client()
-
-          res = assert(admin_client:get("/clustering/data-planes"))
-          local body = assert.res_status(200, res)
-
-          admin_client:close()
-          local json = cjson.decode(body)
-
-          for _, v in pairs(json.data) do
-            if v.id == uuid then
-              assert.equal(tostring(_VERSION_TABLE), v.version)
-              assert.equal("plugin_version_incompatible", v.sync_status)
-              return true
-            end
-          end
-        end, 5)
-      end)
-
-      it("CP and DP plugin set mismatches, sync is blocked", function()
-        assert(db:truncate("clustering_data_planes"))
-        assert(db:truncate("routes"))
-        assert(db:truncate("services"))
-
-        assert(helpers.start_kong({
-          role = "data_plane",
-          database = "off",
-          prefix = "servroot2",
-          cluster_cert = "spec/fixtures/kong_clustering.crt",
-          cluster_cert_key = "spec/fixtures/kong_clustering.key",
-          lua_ssl_trusted_certificate = "spec/fixtures/kong_clustering.crt",
-          cluster_control_plane = "127.0.0.1:9005",
-          proxy_listen = "0.0.0.0:9002",
-          plugins = "bundled", -- differs from CP plugins
-        }))
-
-        local admin_client = helpers.admin_client(10000)
-
-        finally(function()
-          helpers.stop_kong("servroot2")
-          admin_client:close()
-        end)
-
-
-        local res = assert(admin_client:post("/services", {
-          body = { name = "mockbin-service", url = "https://127.0.0.1:15556/request", },
-          headers = {["Content-Type"] = "application/json"}
-        }))
-        assert.res_status(201, res)
-
-        assert(admin_client:post("/services/mockbin-service/routes", {
-          body = { paths = { "/shouldnotexist" }, },
-          headers = {["Content-Type"] = "application/json"}
-        }))
-
-        helpers.wait_until(function()
-          local proxy_client = helpers.http_client("127.0.0.1", 9002)
-          local admin_client = helpers.admin_client(10000)
-
-          local res = assert(admin_client:get("/clustering/data-planes"))
-          local body = assert.res_status(200, res)
-          local json = cjson.decode(body)
-          admin_client:close()
-
-          for _, v in pairs(json.data) do
-            if v.ip == "127.0.0.1" then
-              assert.near(14 * 86400, v.ttl, 10)
-              assert.equals(tostring(_VERSION_TABLE), v.version)
-              assert.equal("plugin_set_incompatible", v.sync_status)
-
-              res = proxy_client:send({
-                method  = "GET",
-                path    = "/shouldnotexist",
-              })
-
-              local status = res and res.status
-              proxy_client:close()
-              if status == 404 then
+            for _, v in pairs(json.data) do
+              if v.id == uuid then
+                assert.equal(harness.dp_version or tostring(_VERSION_TABLE),
+                              v.version)
+                assert.equal(CLUSTERING_SYNC_STATUS.NORMAL, v.sync_status)
                 return true
               end
             end
-          end
-        end, 10)
-      end)
+          end, 5)
+        end)
+      end
+      -- ENDS allowed cases
+
+      -- STARTS blocked cases
+      local blocked_cases = {
+        ["CP and DP major version mismatches"] = {
+          dp_version = "1.0.0",
+          expected = CLUSTERING_SYNC_STATUS.KONG_VERSION_INCOMPATIBLE,
+        },
+        ["CP.minor - DP.minor > 2"] = {
+          dp_version = string.format("%d.%d.%d", MAJOR, MINOR-3, PATCH),
+          expected = CLUSTERING_SYNC_STATUS.KONG_VERSION_INCOMPATIBLE,
+        },
+        ["CP.minor - DP.minor < 0"] = {
+          dp_version = string.format("%d.%d.%d", MAJOR, MINOR+1, PATCH),
+          expected = CLUSTERING_SYNC_STATUS.KONG_VERSION_INCOMPATIBLE,
+        },
+      }
+
+      local pl1 = pl_tablex.deepcopy(helpers.get_plugins_list())
+      for i, p in ipairs(pl1) do
+        local v = pl1[i].version
+        local minor = v and v:match("%d+%.(%d+)")
+        -- find a plugin that has minor larger than 1 :joy:
+        -- we hardcode `dummy` plugin to be 9.9.9 so there must be at least one
+        if minor and tonumber(minor) and tonumber(minor) > 1 then
+          pl1[i].version = string.format("%d.%d.%d",
+            tonumber(v:match("(%d+)")),
+            tonumber(v:match("%d+%.(%d+)")) - 1,
+            tonumber(v:match("%d+%.%d+%.(%d+)"))
+          )
+          break
+        end
+      end
+      blocked_cases["CP and DP plugin minor version mismatch"] = {
+        plugins_list = pl1,
+        expected = CLUSTERING_SYNC_STATUS.PLUGIN_VERSION_INCOMPATIBLE,
+      }
+
+      local pl2 = pl_tablex.deepcopy(helpers.get_plugins_list())
+      for i, p in ipairs(pl2) do
+        local v = pl2[i].version
+        local major = v and v:match("(%d+)")
+        -- find a plugin that has major larger than 1 :joy:
+        -- we hardcode `dummy` plugin to be 9.9.9 so there must be at least one
+        if major and tonumber(major) and tonumber(major) > 1 then
+          pl2[i].version = string.format("%d.%d.%d",
+            tonumber(major - 1),
+            tonumber(v:match("%d+%.(%d+)")),
+            tonumber(v:match("%d+%.%d+%.(%d+)"))
+          )
+          break
+        end
+      end
+      blocked_cases["CP and DP plugin major version mismatch"] = {
+        plugins_list = pl2,
+        expected = CLUSTERING_SYNC_STATUS.PLUGIN_VERSION_INCOMPATIBLE,
+      }
+
+      local pl3 = pl_tablex.deepcopy(helpers.get_plugins_list())
+      table.remove(pl3, #pl3/2)
+      blocked_cases["DP plugin set is subset of CP"] = {
+        plugins_list = pl3,
+        expected = CLUSTERING_SYNC_STATUS.PLUGIN_SET_INCOMPATIBLE,
+      }
+
+      local pl4 = pl_tablex.deepcopy(helpers.get_plugins_list())
+      table.remove(pl4, 2)
+      table.insert(pl4, 4, { name = "banana", version = "1.1.1" })
+      table.insert(pl4, { name = "pineapple", version = "1.1.1" })
+      blocked_cases["CP and DP plugin set mismatch"] = {
+        plugins_list = pl4,
+        expected = CLUSTERING_SYNC_STATUS.PLUGIN_SET_INCOMPATIBLE,
+      }
+
+      for desc, harness in pairs(blocked_cases) do
+        it(desc ..", sync is blocked", function()
+          local uuid = utils.uuid()
+
+          local res = assert(helpers.clustering_client({
+            host = "127.0.0.1",
+            port = 9005,
+            cert = "spec/fixtures/kong_clustering.crt",
+            cert_key = "spec/fixtures/kong_clustering.key",
+            node_id = uuid,
+            node_version = harness.dp_version,
+            node_plugins_list = harness.plugins_list,
+          }))
+
+          assert.equals("PONG", res)
+
+          -- needs wait_until for c* convergence
+          helpers.wait_until(function()
+            local admin_client = helpers.admin_client()
+
+            res = assert(admin_client:get("/clustering/data-planes"))
+            local body = assert.res_status(200, res)
+
+            admin_client:close()
+            local json = cjson.decode(body)
+
+            for _, v in pairs(json.data) do
+              if v.id == uuid then
+                assert.equal(harness.dp_version or tostring(_VERSION_TABLE),
+                              v.version)
+                assert.equal(harness.expected, v.sync_status)
+                return true
+              end
+            end
+          end, 5)
+        end)
+      end
+      -- ENDS blocked cases
     end)
   end)
 

--- a/spec/fixtures/custom_plugins/kong/plugins/dummy/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/dummy/handler.lua
@@ -3,6 +3,8 @@ local BasePlugin = require "kong.plugins.base_plugin"
 
 local DummyHandler = BasePlugin:extend()
 
+DummyHandler.VERSION = "9.9.9"
+
 
 DummyHandler.PRIORITY = 1000
 

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -2612,7 +2612,7 @@ end
 -- @param opts Options to use, the `host`, `port`, `cert` and `cert_key` fields
 -- are required.
 -- Other fields that can be overwritten are:
--- `node_hostname`, `node_id`, `node_version`. If absent,
+-- `node_hostname`, `node_id`, `node_version`, `node_plugins_list`. If absent,
 -- they are automatically filled.
 -- @return msg if handshake succeeded and initial message received from CP or nil, err
 local function clustering_client(opts)
@@ -2627,14 +2627,14 @@ local function clustering_client(opts)
               "&node_hostname=" .. (opts.node_hostname or kong.node.get_hostname()) ..
               "&node_version=" .. (opts.node_version or KONG_VERSION)
 
-  local opts = {
+  local conn_opts = {
     ssl_verify = false, -- needed for busted tests as CP certs are not trusted by the CLI
     client_cert = assert(ssl.parse_pem_cert(assert(pl_file.read(opts.cert)))),
     client_priv_key = assert(ssl.parse_pem_priv_key(assert(pl_file.read(opts.cert_key)))),
     server_name = "kong_clustering",
   }
 
-  local res, err = c:connect(uri, opts)
+  local res, err = c:connect(uri, conn_opts)
   if not res then
     return nil, err
   end
@@ -2642,13 +2642,12 @@ local function clustering_client(opts)
                                         plugins = opts.node_plugins_list or
                                                   PLUGINS_LIST,
                                       }))
-
   assert(c:send_binary(payload))
 
   assert(c:send_ping(string.rep("0", 32)))
 
-  local data, typ
-  data, typ = c:recv_frame()
+  local data, typ, err
+  data, typ, err = c:recv_frame()
   c:close()
 
   if typ == "binary" then
@@ -2660,7 +2659,7 @@ local function clustering_client(opts)
     return "PONG"
   end
 
-  return nil, "unknown frame from CP: " .. typ
+  return nil, "unknown frame from CP: " .. (typ or err)
 end
 
 


### PR DESCRIPTION
### Summary

Hybrid mode version check is now changed into a relaxed form:

- DP is allowed to connect to CP that has at most two minor versions ahead
- Version check in plugins is same as Kong itself
- DP is allowed to have superset list of plugins to CP
- DP is not allowed to connect if major version mismatch, or it's newer than CP, or it misses plugins from CP.

### Full changelog

* Implement relaxed version compatibility check in hybrid mode allowing DP to lag two minor versions behind

### Issues resolved

Fix #XXX
