### PR TITLE
fix(conf) Added status code 405 to nginx config

### DIFF
--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -74,7 +74,7 @@ server {
     listen $(entry.listener);
 > end
 
-    error_page 400 404 408 411 412 413 414 417 494 /kong_error_handler;
+    error_page 400 404 405 408 411 412 413 414 417 494 /kong_error_handler;
     error_page 500 502 503 504                     /kong_error_handler;
 
     access_log ${{PROXY_ACCESS_LOG}};


### PR DESCRIPTION


<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Eg. Accessing kong using the "TRACE" method returns a standard nginx error page.
This is because nginx returns a status code of 405.
Adds 405 to the error page settings of nginx config and returns the kong error page.


