### PR TITLE
chore(deps) bump Zipkin to 1.3.0

### DIFF
--- a/kong-2.3.3-0.rockspec
+++ b/kong-2.3.3-0.rockspec
@@ -41,7 +41,7 @@ dependencies = {
   "lua-resty-ipmatcher == 0.6",
   -- external Kong plugins
   "kong-plugin-azure-functions ~> 1.0",
-  "kong-plugin-zipkin ~> 1.2",
+  "kong-plugin-zipkin ~> 1.3",
   "kong-plugin-serverless-functions ~> 2.1",
   "kong-prometheus-plugin ~> 1.1",
   "kong-proxy-cache-plugin ~> 1.3",


### PR DESCRIPTION
Zipkin 1.3.0 is totally backwards compatible with 1.2.0 but brings fixes
and new features.

Before this change can be merged,
* https://github.com/Kong/kong-plugin-zipkin/pull/107 needs to be approved and merged,
* A new tag of the plugin needs to be published in the zipkin repo
* A new version of the zipkin plugin needs to be published in Luarocks

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

SUMMARY_GOES_HERE

### Full changelog

* [Implement ...]
* [Add related tests]
* ...

### Issues resolved

Fix #XXX
