### PR TITLE
feat(clustering) resilient initial config on control plane database failures

### DIFF
--- a/kong/clustering.lua
+++ b/kong/clustering.lua
@@ -22,6 +22,7 @@ local type = type
 local math = math
 local pcall = pcall
 local pairs = pairs
+local tostring = tostring
 local ngx = ngx
 local ngx_log = ngx.log
 local ngx_sleep = ngx.sleep
@@ -31,6 +32,7 @@ local kong = kong
 local ngx_exit = ngx.exit
 local exiting = ngx.worker.exiting
 local ngx_time = ngx.time
+local ngx_now = ngx.now
 local ngx_var = ngx.var
 local io_open = io.open
 local table_insert = table.insert
@@ -62,6 +64,9 @@ local clients = setmetatable({}, WEAK_KEY_MT)
 local prefix = ngx.config.prefix()
 local CONFIG_CACHE = prefix .. "/config.cache.json.gz"
 local CLUSTERING_SYNC_STATUS = kong_constants.CLUSTERING_SYNC_STATUS
+local deflated_reconfigure_payload -- Contains a compressed (zlib) payload of the latest database export,
+                                   -- that can be used to send configuration to new clients even in a case
+                                   -- of a database outage.
 local declarative_config
 local next_config
 
@@ -264,6 +269,7 @@ local function communicate(premature, conf)
 
       else
         if typ == "close" then
+          ngx_log(ngx_DEBUG, "received CLOSE frame from control plane")
           return
         end
 
@@ -275,6 +281,13 @@ local function communicate(premature, conf)
           local msg = assert(cjson_decode(data))
 
           if msg.type == "reconfigure" then
+            if msg.timestamp then
+              ngx_log(ngx_DEBUG, "received RECONFIGURE frame from control plane with timestamp: ", msg.timestamp)
+
+            else
+              ngx_log(ngx_DEBUG, "received RECONFIGURE frame from control plane")
+            end
+
             next_config = assert(msg.config_table)
 
             if config_semaphore:count() <= 0 then
@@ -289,6 +302,9 @@ local function communicate(premature, conf)
 
         elseif typ == "pong" then
           ngx_log(ngx_DEBUG, "received PONG frame from control plane")
+
+        else
+          ngx_log(ngx_NOTICE, "received UNKNOWN (", tostring(typ), ") frame from control plane")
         end
       end
     end
@@ -470,6 +486,32 @@ local function should_send_config_update(node_version, node_plugins)
 end
 
 
+local function export_deflated_reconfigure_payload()
+  local config_table, err = declarative.export_config()
+  if not config_table then
+    return nil, err
+  end
+
+  local payload, err = cjson_encode({
+    type = "reconfigure",
+    timestamp = ngx_now(),
+    config_table = config_table,
+  })
+  if not payload then
+    return nil, err
+  end
+
+  payload, err = deflate_gzip(payload)
+  if not payload then
+    return nil, err
+  end
+
+  deflated_reconfigure_payload = payload
+
+  return payload
+end
+
+
 function _M.handle_cp_websocket()
   -- use mutual TLS authentication
   if kong.configuration.cluster_mtls == "shared" then
@@ -539,16 +581,12 @@ function _M.handle_cp_websocket()
   res, err, sync_status = should_send_config_update(node_version, node_plugins)
   if res then
     sync_status = CLUSTERING_SYNC_STATUS.NORMAL
-    local config_table
-    -- unconditionally send config update to new clients to
-    -- ensure they have latest version running
-    config_table, err = declarative.export_config()
-    if config_table then
-      local payload = cjson_encode({ type = "reconfigure",
-                                     config_table = config_table,
-                                   })
-      payload = assert(deflate_gzip(payload))
-      table_insert(queue, payload)
+    if not deflated_reconfigure_payload then
+      assert(export_deflated_reconfigure_payload())
+    end
+
+    if deflated_reconfigure_payload then
+      table_insert(queue, deflated_reconfigure_payload)
       queue.post()
 
     else
@@ -707,27 +745,17 @@ function _M.handle_cp_websocket()
 end
 
 
-local function push_config(config_table)
-  if not config_table then
-    local err
-    config_table, err = declarative.export_config()
-    if not config_table then
-      ngx_log(ngx_ERR, "unable to export config from database: " .. err)
-      return
-    end
+local function push_config()
+  local payload, err = export_deflated_reconfigure_payload()
+  if not payload then
+    ngx_log(ngx_ERR, "unable to export config from database: " .. err)
+    return
   end
 
-  local payload = cjson_encode({ type = "reconfigure",
-                                 config_table = config_table,
-                               })
-  payload = assert(deflate_gzip(payload))
-
   local n = 0
-
   for _, queue in pairs(clients) do
     table_insert(queue, payload)
     queue.post()
-
     n = n + 1
   end
 
@@ -735,13 +763,18 @@ local function push_config(config_table)
 end
 
 
-local function push_config_timer(premature, semaphore, delay)
+local function push_config_timer(premature, push_config_semaphore, delay)
   if premature then
     return
   end
 
+  local _, err = export_deflated_reconfigure_payload()
+  if err then
+    ngx_log(ngx_ERR, "unable to export initial config from database: " .. err)
+  end
+
   while not exiting() do
-    local ok, err = semaphore:wait(1)
+    local ok, err = push_config_semaphore:wait(1)
     if exiting() then
       return
     end


### PR DESCRIPTION
### Summary

@hutchic reported in #6935 that:

> When the control plane looses it's database connection it's currently unable to send updates to new data planes.

This PR is about to make control plane more resilient on database failures on such case.

### Issues Resolved

Fix #6935