### PR TITLE
feat(plugins) add log by lua capability

### DIFF
--- a/kong/db/schema/typedefs.lua
+++ b/kong/db/schema/typedefs.lua
@@ -569,6 +569,17 @@ typedefs.semantic_version = Schema.define {
   },
 }
 
+local function validate_lua_expression(expression)
+  local sandbox = require "kong.tools.sandbox"
+  return sandbox.validate_safe(expression)
+end
+
+typedefs.lua_code = Schema.define {
+  type = "map",
+  keys = { type = "string", len_min = 1, },
+  values = { type = "string", len_min = 1, custom_validator = validate_lua_expression },
+}
+
 setmetatable(typedefs, {
   __index = function(_, k)
     error("schema typedef error: definition " .. k .. " does not exist", 2)

--- a/kong/plugins/file-log/handler.lua
+++ b/kong/plugins/file-log/handler.lua
@@ -2,7 +2,7 @@
 local ffi = require "ffi"
 local cjson = require "cjson"
 local system_constants = require "lua_system_constants"
-local sandbox = require "kong.tools.sandbox"
+local sandbox = require "kong.tools.sandbox".sandbox
 
 
 local kong = kong
@@ -74,8 +74,9 @@ local FileLogHandler = {
 
 function FileLogHandler:log(conf)
   if conf.custom_fields_by_lua then
+    local set_serialize_value = kong.log.set_serialize_value
     for key, expression in pairs(conf.custom_fields_by_lua) do
-      kong.log.set_serialize_value(key, sandbox.sandbox(expression, sandbox_opts)())
+      set_serialize_value(key, sandbox(expression, sandbox_opts)())
     end
   end
 

--- a/kong/plugins/file-log/schema.lua
+++ b/kong/plugins/file-log/schema.lua
@@ -1,5 +1,6 @@
 local typedefs = require "kong.db.schema.typedefs"
 
+
 return {
   name = "file-log",
   fields = {
@@ -13,6 +14,8 @@ return {
                      err = "not a valid filename",
           }, },
           { reopen = { type = "boolean", required = true, default = false }, },
-    }, }, },
+          { custom_fields_by_lua = typedefs.lua_code },
+        },
+    }, },
   }
 }

--- a/kong/plugins/http-log/handler.lua
+++ b/kong/plugins/http-log/handler.lua
@@ -3,7 +3,7 @@ local cjson = require "cjson"
 local url = require "socket.url"
 local http = require "resty.http"
 local table_clear = require "table.clear"
-local sandbox = require "kong.tools.sandbox"
+local sandbox = require "kong.tools.sandbox".sandbox
 
 
 local kong = kong
@@ -160,8 +160,9 @@ local HttpLogHandler = {
 
 function HttpLogHandler:log(conf)
   if conf.custom_fields_by_lua then
+    local set_serialize_value = kong.log.set_serialize_value
     for key, expression in pairs(conf.custom_fields_by_lua) do
-      kong.log.set_serialize_value(key, sandbox.sandbox(expression, sandbox_opts)())
+      set_serialize_value(key, sandbox(expression, sandbox_opts)())
     end
   end
 

--- a/kong/plugins/http-log/schema.lua
+++ b/kong/plugins/http-log/schema.lua
@@ -35,6 +35,7 @@ return {
               },
             },
           } },
+          { custom_fields_by_lua = typedefs.lua_code },
         },
         custom_validator = function(config)
           -- check no double userinfo + authorization header

--- a/kong/plugins/loggly/handler.lua
+++ b/kong/plugins/loggly/handler.lua
@@ -1,4 +1,5 @@
 local cjson = require "cjson"
+local sandbox = require "kong.tools.sandbox"
 
 
 local kong = kong
@@ -9,6 +10,9 @@ local timer_at = ngx.timer.at
 local udp = ngx.socket.udp
 local concat = table.concat
 local insert = table.insert
+
+
+local sandbox_opts = { env = { kong = kong, ngx = ngx } }
 
 
 local function get_host_name()
@@ -126,6 +130,12 @@ local LogglyLogHandler = {
 
 
 function LogglyLogHandler:log(conf)
+  if conf.custom_fields_by_lua then
+    for key, expression in pairs(conf.custom_fields_by_lua) do
+      kong.log.set_serialize_value(key, sandbox.sandbox(expression, sandbox_opts)())
+    end
+  end
+
   local message = kong.log.serialize()
 
   local ok, err = timer_at(0, log, conf, message)

--- a/kong/plugins/loggly/handler.lua
+++ b/kong/plugins/loggly/handler.lua
@@ -1,5 +1,5 @@
 local cjson = require "cjson"
-local sandbox = require "kong.tools.sandbox"
+local sandbox = require "kong.tools.sandbox".sandbox
 
 
 local kong = kong
@@ -131,8 +131,9 @@ local LogglyLogHandler = {
 
 function LogglyLogHandler:log(conf)
   if conf.custom_fields_by_lua then
+    local set_serialize_value = kong.log.set_serialize_value
     for key, expression in pairs(conf.custom_fields_by_lua) do
-      kong.log.set_serialize_value(key, sandbox.sandbox(expression, sandbox_opts)())
+      set_serialize_value(key, sandbox(expression, sandbox_opts)())
     end
   end
 

--- a/kong/plugins/loggly/schema.lua
+++ b/kong/plugins/loggly/schema.lua
@@ -26,6 +26,7 @@ return {
           { client_errors_severity = severity },
           { server_errors_severity = severity },
           { timeout = { type = "number", default = 10000 }, },
+          { custom_fields_by_lua = typedefs.lua_code },
         },
       },
     },

--- a/kong/plugins/syslog/handler.lua
+++ b/kong/plugins/syslog/handler.lua
@@ -1,5 +1,6 @@
 local lsyslog = require "lsyslog"
 local cjson = require "cjson"
+local sandbox = require "kong.tools.sandbox"
 
 
 local kong = kong
@@ -19,6 +20,9 @@ local LOG_LEVELS = {
   alert = 1,
   emerg = 0
 }
+
+
+local sandbox_opts = { env = { kong = kong, ngx = ngx } }
 
 
 local function send_to_syslog(log_level, severity, message)
@@ -53,6 +57,12 @@ local SysLogHandler = {
 
 
 function SysLogHandler:log(conf)
+  if conf.custom_fields_by_lua then
+    for key, expression in pairs(conf.custom_fields_by_lua) do
+      kong.log.set_serialize_value(key, sandbox.sandbox(expression, sandbox_opts)())
+    end
+  end
+
   local message = kong.log.serialize()
   local ok, err = timer_at(0, log, conf, message)
   if not ok then

--- a/kong/plugins/syslog/handler.lua
+++ b/kong/plugins/syslog/handler.lua
@@ -1,6 +1,6 @@
 local lsyslog = require "lsyslog"
 local cjson = require "cjson"
-local sandbox = require "kong.tools.sandbox"
+local sandbox = require "kong.tools.sandbox".sandbox
 
 
 local kong = kong
@@ -58,8 +58,9 @@ local SysLogHandler = {
 
 function SysLogHandler:log(conf)
   if conf.custom_fields_by_lua then
+    local set_serialize_value = kong.log.set_serialize_value
     for key, expression in pairs(conf.custom_fields_by_lua) do
-      kong.log.set_serialize_value(key, sandbox.sandbox(expression, sandbox_opts)())
+      set_serialize_value(key, sandbox(expression, sandbox_opts)())
     end
   end
 

--- a/kong/plugins/syslog/schema.lua
+++ b/kong/plugins/syslog/schema.lua
@@ -17,6 +17,7 @@ return {
           { successful_severity = severity },
           { client_errors_severity = severity },
           { server_errors_severity = severity },
+          { custom_fields_by_lua = typedefs.lua_code },
     }, }, },
   },
 }

--- a/kong/plugins/tcp-log/handler.lua
+++ b/kong/plugins/tcp-log/handler.lua
@@ -1,5 +1,5 @@
 local cjson = require "cjson"
-local sandbox = require "kong.tools.sandbox"
+local sandbox = require "kong.tools.sandbox".sandbox
 
 
 local kong = kong
@@ -58,8 +58,9 @@ local TcpLogHandler = {
 
 function TcpLogHandler:log(conf)
   if conf.custom_fields_by_lua then
+    local set_serialize_value = kong.log.set_serialize_value
     for key, expression in pairs(conf.custom_fields_by_lua) do
-      kong.log.set_serialize_value(key, sandbox.sandbox(expression, sandbox_opts)())
+      set_serialize_value(key, sandbox(expression, sandbox_opts)())
     end
   end
 

--- a/kong/plugins/tcp-log/schema.lua
+++ b/kong/plugins/tcp-log/schema.lua
@@ -13,6 +13,7 @@ return {
           { keepalive = { type = "number", default = 60000 }, },
           { tls = { type = "boolean", required = true, default = false }, },
           { tls_sni = { type = "string" }, },
+          { custom_fields_by_lua = typedefs.lua_code },
         },
     }, },
   }

--- a/kong/plugins/udp-log/handler.lua
+++ b/kong/plugins/udp-log/handler.lua
@@ -1,5 +1,5 @@
 local cjson = require "cjson"
-local sandbox = require "kong.tools.sandbox"
+local sandbox = require "kong.tools.sandbox".sandbox
 
 
 local kong = kong
@@ -48,8 +48,9 @@ local UdpLogHandler = {
 
 function UdpLogHandler:log(conf)
   if conf.custom_fields_by_lua then
+    local set_serialize_value = kong.log.set_serialize_value
     for key, expression in pairs(conf.custom_fields_by_lua) do
-      kong.log.set_serialize_value(key, sandbox.sandbox(expression, sandbox_opts)())
+      set_serialize_value(key, sandbox(expression, sandbox_opts)())
     end
   end
 

--- a/kong/plugins/udp-log/schema.lua
+++ b/kong/plugins/udp-log/schema.lua
@@ -10,6 +10,7 @@ return {
           { host = typedefs.host({ required = true }) },
           { port = typedefs.port({ required = true }) },
           { timeout = { type = "number", default = 10000 }, },
+          { custom_fields_by_lua = typedefs.lua_code },
     }, }, },
   },
 }

--- a/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
+++ b/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
@@ -285,6 +285,7 @@ describe("declarative config: flatten", function()
                 retry_count = 10,
                 timeout = 10000,
                 headers = null,
+                custom_fields_by_lua = null,
               }
             },
             {
@@ -378,6 +379,7 @@ describe("declarative config: flatten", function()
                 retry_count = 10,
                 timeout = 10000,
                 headers = null,
+                custom_fields_by_lua = null,
               },
               consumer = {
                 id = "UUID"
@@ -560,6 +562,7 @@ describe("declarative config: flatten", function()
                   retry_count = 10,
                   timeout = 10000,
                   headers = null,
+                  custom_fields_by_lua = null,
                 },
                 consumer = null,
                 created_at = 1234567890,
@@ -600,7 +603,8 @@ describe("declarative config: flatten", function()
                   port = 10000,
                   timeout = 10000,
                   tls = false,
-                  tls_sni = null
+                  tls_sni = null,
+                  custom_fields_by_lua = null,
                 },
                 consumer = null,
                 created_at = 1234567890,
@@ -1049,6 +1053,7 @@ describe("declarative config: flatten", function()
                   retry_count = 10,
                   timeout = 10000,
                   headers = null,
+                  custom_fields_by_lua = null,
                 },
                 consumer = null,
                 created_at = 1234567890,
@@ -1089,7 +1094,8 @@ describe("declarative config: flatten", function()
                   port = 10000,
                   timeout = 10000,
                   tls = false,
-                  tls_sni = null
+                  tls_sni = null,
+                  custom_fields_by_lua = null,
                 },
                 consumer = null,
                 created_at = 1234567890,

--- a/spec/03-plugins/01-tcp-log/01-tcp-log_spec.lua
+++ b/spec/03-plugins/01-tcp-log/01-tcp-log_spec.lua
@@ -173,6 +173,23 @@ for _, strategy in helpers.each_strategy() do
         },
       }
 
+      local route6 = bp.routes:insert {
+        hosts = { "custom_tcp_logging.com" },
+      }
+
+      bp.plugins:insert {
+        route = { id = route6.id },
+        name     = "tcp-log",
+        config   = {
+          host   = "127.0.0.1",
+          port   = TCP_PORT,
+          custom_fields_by_lua = {
+            new_field = "return 123",
+            route = "return nil", -- unset route field
+          }
+        },
+      }
+
       assert(helpers.start_kong({
         database   = strategy,
         nginx_conf = "spec/fixtures/custom_nginx.template",
@@ -218,6 +235,60 @@ for _, strategy in helpers.each_strategy() do
 
       -- Since it's over HTTP, let's make sure there are no TLS information
       assert.is_nil(log_message.request.tls)
+    end)
+
+    describe("custom log values by lua", function()
+      it("logs custom values", function()
+        local thread = helpers.tcp_server(TCP_PORT) -- Starting the mock TCP server
+
+        -- Making the request
+        local r = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/request",
+          headers = {
+            host  = "custom_tcp_logging.com",
+          },
+        })
+        assert.response(r).has.status(200)
+
+        -- Getting back the TCP server input
+        local ok, res = thread:join()
+        assert.True(ok)
+        assert.is_string(res)
+
+        -- Making sure it's alright
+        local log_message = cjson.decode(res)
+        assert.equal("127.0.0.1", log_message.client_ip)
+
+        -- Since it's over HTTP, let's make sure there are no TLS information
+        assert.same(123, log_message.new_field)
+      end)
+
+      it("unsets existing log values", function()
+        local thread = helpers.tcp_server(TCP_PORT) -- Starting the mock TCP server
+
+        -- Making the request
+        local r = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/request",
+          headers = {
+            host  = "custom_tcp_logging.com",
+          },
+        })
+        assert.response(r).has.status(200)
+
+        -- Getting back the TCP server input
+        local ok, res = thread:join()
+        assert.True(ok)
+        assert.is_string(res)
+
+        -- Making sure it's alright
+        local log_message = cjson.decode(res)
+        assert.equal("127.0.0.1", log_message.client_ip)
+
+        -- Since it's over HTTP, let's make sure there are no TLS information
+        assert.same(nil, log_message.route)
+      end)
     end)
 
     it("logs to TCP (#grpc)", function()

--- a/spec/03-plugins/03-http-log/01-log_spec.lua
+++ b/spec/03-plugins/03-http-log/01-log_spec.lua
@@ -189,6 +189,32 @@ for _, strategy in helpers.each_strategy() do
         },
       }
 
+      local service9 = bp.services:insert{
+        protocol = "http",
+        host     = helpers.mock_upstream_host,
+        port     = helpers.mock_upstream_port,
+      }
+
+      local route9 = bp.routes:insert {
+        hosts   = { "custom_http_logging.test" },
+        service = service9
+      }
+
+      bp.plugins:insert {
+        route = { id = route9.id },
+        name     = "http-log",
+        config   = {
+          http_endpoint = "http://" .. helpers.mock_upstream_host
+                                    .. ":"
+                                    .. helpers.mock_upstream_port
+                                    .. "/post_log/custom_http",
+          custom_fields_by_lua = {
+            new_field = "return 123",
+            route = "return nil", -- unset route field
+          },
+        }
+      }
+
       assert(helpers.start_kong({
         database = strategy,
         nginx_conf = "spec/fixtures/custom_nginx.template",
@@ -240,6 +266,39 @@ for _, strategy in helpers.each_strategy() do
           return true
         end
       end, 10)
+    end)
+
+    describe("custom log values by lua", function()
+      it("logs custom values", function()
+        local res = assert(proxy_client:send({
+          method = "GET",
+          path = "/status/200",
+          headers = {
+            ["Host"] = "custom_http_logging.test"
+          }
+        }))
+        assert.res_status(200, res)
+
+        helpers.wait_until(function()
+          local client = assert(helpers.http_client(helpers.mock_upstream_host,
+          helpers.mock_upstream_port))
+          local res = assert(client:send {
+            method  = "GET",
+            path    = "/read_log/custom_http",
+            headers = {
+              Accept = "application/json"
+            }
+          })
+          local raw = assert.res_status(200, res)
+          local body = cjson.decode(raw)
+
+          if #body.entries == 1 then
+            assert.same("127.0.0.1", body.entries[1].client_ip)
+            assert.same(123, body.entries[1].new_field)
+            return true
+          end
+        end, 10)
+      end)
     end)
 
     it("logs to HTTP (#grpc)", function()

--- a/spec/03-plugins/03-http-log/02-schema_spec.lua
+++ b/spec/03-plugins/03-http-log/02-schema_spec.lua
@@ -23,6 +23,16 @@ describe(PLUGIN_NAME .. ": (schema)", function()
     assert.is_truthy(ok)
   end)
 
+  it("accepts custom fields by lua", function()
+    local ok, err = validate({
+        http_endpoint = "http://myservice.com/path",
+        custom_fields_by_lua = {
+          foo = "return 'bar'",
+        }
+      })
+    assert.is_nil(err)
+    assert.is_truthy(ok)
+  end)
 
   it("does accept allowed headers", function()
     local ok, err = validate({
@@ -93,6 +103,4 @@ describe(PLUGIN_NAME .. ": (schema)", function()
           }, err)
         assert.is_falsy(ok)
       end)
-
-
   end)

--- a/spec/03-plugins/04-file-log/02-schema_spec.lua
+++ b/spec/03-plugins/04-file-log/02-schema_spec.lua
@@ -39,11 +39,29 @@ describe("Plugin: file-log (schema)", function()
       output = true,
       error = nil,
     },
+    ----------------------------------------
+    {
+      name = "accepts custom fields set by lua code",
+      input = {
+        path = "/tmp/log.txt",
+        custom_fields_by_lua = {
+          foo = "return 'bar'",
+        }
+      },
+      output = true,
+      error = nil,
+    },
   }
 
   local file_log_schema
 
   lazy_setup(function()
+    _G.kong = {
+      configuration = {
+        untrusted_lua = "sandbox"
+      }
+    }
+
     file_log_schema = Schema.new(require("kong.plugins.file-log.schema"))
   end)
 
@@ -53,8 +71,8 @@ describe("Plugin: file-log (schema)", function()
         protocols = { "http" },
         config = t.input
       })
-      assert.same(t.output, output)
       assert.same(t.error, err)
+      assert.same(t.output, output)
     end)
   end
 end)

--- a/spec/03-plugins/07-loggly/01-log_spec.lua
+++ b/spec/03-plugins/07-loggly/01-log_spec.lua
@@ -33,6 +33,10 @@ for _, strategy in helpers.each_strategy() do
         hosts = { "logging3.com" },
       }
 
+      local route5 = bp.routes:insert {
+        hosts = { "logging4.com" },
+      }
+
       bp.plugins:insert {
         route = { id = route1.id },
         name     = "loggly",
@@ -78,6 +82,20 @@ for _, strategy in helpers.each_strategy() do
           host = "127.0.0.1",
           port = UDP_PORT,
           key  = "123456789"
+        }
+      }
+
+      bp.plugins:insert {
+        route = { id = route5.id },
+        name     = "loggly",
+        config   = {
+          host = "127.0.0.1",
+          port = UDP_PORT,
+          key  = "123456789",
+          custom_fields_by_lua = {
+            new_field = "return 123",
+            route = "return nil", -- unset route field
+          }
         }
       }
 
@@ -308,6 +326,31 @@ for _, strategy in helpers.each_strategy() do
       }, 500)
       assert.equal("14", pri)
       assert.equal("127.0.0.1", message.client_ip)
+    end)
+
+    describe("custom log values by lua", function()
+      it("logs custom values", function()
+        local pri, message = run({
+          method  = "GET",
+          path    = "/status/500",
+          headers = {
+            host  = "logging4.com"
+          }
+        }, 500)
+        assert.equal("14", pri)
+        assert.equal(123, message.new_field)
+      end)
+      it("unsets existing log values", function()
+        local pri, message = run({
+          method  = "GET",
+          path    = "/status/500",
+          headers = {
+            host  = "logging4.com"
+          }
+        }, 500)
+        assert.equal("14", pri)
+        assert.equal(nil, message.route)
+      end)
     end)
   end)
 end

--- a/spec/kong_tests.conf
+++ b/spec/kong_tests.conf
@@ -36,3 +36,6 @@ log_level = debug
 lua_package_path=./spec/fixtures/custom_plugins/?.lua
 
 go_plugins_dir = off
+
+untrusted_lua = sandbox
+


### PR DESCRIPTION
Add capability to set new log fields, or unset existing fields, by
executing custom Lua code in the Log phase.

This feature uses the new PDK method `kong.log.set_serialize_value`,
as well as the new sandbox capability, both introduced in Kong 2.3.

Currently supported logging plugins:
* file-log
* Loggly
* Syslog
* tcp-log
* udp-log
* http-log

Not included in:
* Datadog
*  Statsd