### PR TITLE
chore(tests) add stream_rpc listener to custom template

### DIFF
--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -849,6 +849,15 @@ stream {
         }
     }
 > end -- database == "off"
+
+server {        # ignore (and close }, to ignore content)
+    listen unix:${{PREFIX}}/stream_rpc.sock udp;
+    error_log  ${{ADMIN_ERROR_LOG}} ${{LOG_LEVEL}};
+    content_by_lua_block {
+        Kong.stream_api()
+    }
+}
+
 > end -- #stream_listeners > 0
 
     server {


### PR DESCRIPTION
Some plugin tests rely on the stream_api to pass

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

SUMMARY_GOES_HERE

### Full changelog

* [Implement ...]
* [Add related tests]
* ...

### Issues resolved

Fix #XXX
