### PR TITLE
deps(luasyslog) bump to 2.0.1 fixing a potential memory issue

### DIFF
--- a/kong-2.3.3-0.rockspec
+++ b/kong-2.3.3-0.rockspec
@@ -27,7 +27,7 @@ dependencies = {
   "luatz == 0.4",
   "lua_system_constants == 0.1.4",
   "lyaml == 6.2.7",
-  "luasyslog == 1.0.0",
+  "luasyslog == 2.0.1",
   "kikito/sandbox == 1.0.1",
   "lua_pack == 1.0.5",
   "lua-resty-dns-client == 5.2.3",

--- a/scripts/update-copyright
+++ b/scripts/update-copyright
@@ -103,10 +103,6 @@ local HARDCODED_ROCK_LICENSES = {
     url = "https://github.com/diegonehab/luasocket/blob/master/LICENSE",
     text = MIT_LICENSE:format("Copyright © 2004-2013 Diego Nehab"),
   },
-  ["luasyslog"] = {
-    url = "https://web.archive.org/web/20101223090603/http://lua.net-core.org/sputnik.lua?p=Telesto:About",
-    text = MIT_LICENSE:format("Copyright © 2007-2007 netcore.org, DarkGod"),
-  },
   ["mimetypes"] = {
     url = "https://bitbucket.org/leafstorm/lua-mimetypes/src/default/LICENSE",
     text = MIT_LICENSE:format('Copyright (c) 2011 Matthew "LeafStorm" Frazier') ..


### PR DESCRIPTION
Also a repo is now available, allowing to remove the special
case from the copyright-collecting script

Info here: https://github.com/lunarmodules/luasyslog#201-released-24-mar-2021