### PR TITLE
docs(pdk) fix kong.table.merge ldoc comment

### DIFF
--- a/kong/pdk/table.lua
+++ b/kong/pdk/table.lua
@@ -55,8 +55,10 @@ end
 --- Merges the contents of two tables together, producing a new one.
 -- The entries of both tables are copied non-recursively to the new one.
 -- If both tables have the same key, the second one takes precedence.
--- @tparam table t1 The first table
--- @tparam table t2 The second table
+-- If only one table is given, it returns a copy.
+-- @function kong.table.merge
+-- @tparam[opt] table t1 The first table
+-- @tparam[opt] table t2 The second table
 -- @treturn table The (new) merged table
 -- @usage
 -- local t1 = {1, 2, 3, foo = "f"}


### PR DESCRIPTION
Most likely the culprit is the missing `@function` tag

@lena-larionova @tlblessing fyi. Created PR here since docs are rendered from this file.