### PR TITLE
chore(deps) bump lua-resty-openssl from 0.7.0 to 0.7.2

### DIFF
--- a/kong-2.4.0beta.2-0.rockspec
+++ b/kong-2.4.0beta.2-0.rockspec
@@ -36,7 +36,7 @@ dependencies = {
   "lua-resty-cookie == 0.1.0",
   "lua-resty-mlcache == 2.5.0",
   "lua-messagepack == 0.5.2",
-  "lua-resty-openssl == 0.7.0",
+  "lua-resty-openssl == 0.7.2",
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6",
   -- external Kong plugins


### PR DESCRIPTION
### Summary

#### [0.7.2] - 2021-03-25
##### fix
- ***:** redefine callback functions to a style FFI will not overflow [f91202c](https://github.com/fffonion/lua-resty-openssl/commit/f91202c57b826d935d831ec452d2b90fc33277fa)

#### [0.7.1] - 2021-03-18
##### fix
- **altname:** return unsupported as value in not implemented types [ef5e1ed](https://github.com/fffonion/lua-resty-openssl/commit/ef5e1eda9eaea1fd4c8d7d65e438275fed10cdc6)
- **auxiliary/nginx:** typo in error message [4bd22d8](https://github.com/fffonion/lua-resty-openssl/commit/4bd22d81419ed160af1dcea16f42fd284f8f2ad5