### PR TITLE
fix(external-plugins) close pluginserver when exiting worker

### DIFF
--- a/kong/runloop/plugin_servers/process.lua
+++ b/kong/runloop/plugin_servers/process.lua
@@ -224,7 +224,7 @@ local function grab_logs(proc, name)
       raw_log(ngx_INFO, prefix .. line)
     end
 
-    if not data and err == "closed" then
+    if not data and (err == "closed" or ngx.worker.exiting()) then
       return
     end
   end
@@ -249,7 +249,7 @@ function proc_mgmt.pluginserver_timer(premature, server_def)
     while true do
       grab_logs(server_def.proc, server_def.name)
       local ok, reason, status = server_def.proc:wait()
-      if ok ~= nil or reason == "exited" then
+      if ok ~= nil or reason == "exited" or ngx.worker.exiting() then
         kong.log.notice("external pluginserver '", server_def.name, "' terminated: ", tostring(reason), " ", tostring(status))
         break
       end


### PR DESCRIPTION
On Kong reload or other graceful shutdown of the nginx workers, the
pluginservers were not closed, making the worker linger until explicitly
killed.

Now the log capture loop exits when the worker is exiting, allowing the
pluginserver to be killed when the pipe object is GC'ed

### Issues resolved

Fix #6904
Fix #6948 