### PR TITLE
feat(external-plugins) Protobuf include dirs as config setting

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -137,6 +137,9 @@
                                                             # dump info of all plugins it
                                                             # manages
 
+#protobuf_includes = /usr/include   # Comma-separated list of directories to search for
+                                    # Protocol Buffers definition files.
+
 #port_maps =                     # With this configuration parameter, you can
                                  # let the Kong to know about the port from
                                  # which the packets are forwarded to it. This

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -625,6 +625,7 @@ local CONF_INFERENCES = {
 
   kic = { typ = "boolean" },
   pluginserver_names = { typ = "array" },
+  protobuf_includes = { typ = "array" },
 
   untrusted_lua = { enum = { "on", "off", "sandbox" } },
   untrusted_lua_sandbox_requires = { typ = "array" },

--- a/kong/runloop/plugin_servers/pb_rpc.lua
+++ b/kong/runloop/plugin_servers/pb_rpc.lua
@@ -211,7 +211,10 @@ local function load_service()
   local p = protoc.new()
   --p:loadfile("kong/pluginsocket.proto")
 
-  p:addpath("/usr/include")
+  for _, path in ipairs(kong.configuration.protobuf_includes) do
+    kong.log.notice("ProtoBuf include path: ", path)
+    p:addpath(path)
+  end
   local parsed = p:parsefile("kong/pluginsocket.proto")
 
   local service = {}

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -166,6 +166,7 @@ lua_package_cpath = NONE
 role = traditional
 kic = off
 pluginserver_names = NONE
+protobuf_includes = /usr/include
 
 untrusted_lua = sandbox
 untrusted_lua_sandbox_requires =


### PR DESCRIPTION
Allows the user to specify where to find ProtoBuf definition files.
Currently the plugins protocol requires `google/protobuf/empty.proto`
and `google/protobuf/struct.proto`, which the `libprotobuf-dev` (at
least in Ubuntu) install in `/usr/include`.