### PR TITLE
fix(router) properly normalize paths inside Route object by running

### DIFF
--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -1,6 +1,4 @@
 local typedefs = require "kong.db.schema.typedefs"
-local normalize = require("kong.tools.uri").normalize
-local ipairs = ipairs
 
 
 return {
@@ -65,18 +63,4 @@ return {
                       then_err = "'snis' can only be set when 'protocols' is 'grpcs', 'https' or 'tls'",
                     }},
                   },
-
-  -- TODO: add migrations and remove this in 2.4.0
-  transformations = {
-    {
-      input = { "paths" },
-      on_read = function(paths)
-        for i, uri in ipairs(paths) do
-          paths[i] = normalize(paths[i], true)
-        end
-
-        return { paths = paths, }
-      end,
-    },
-  },
 }

--- a/kong/router.lua
+++ b/kong/router.lua
@@ -38,6 +38,64 @@ local ERR           = ngx.ERR
 local WARN          = ngx.WARN
 
 
+local normalize_regex
+do
+  local RESERVED_CHARACTERS = {
+    [0x21] = true, -- !
+    [0x23] = true, -- #
+    [0x24] = true, -- $
+    [0x25] = true, -- %
+    [0x26] = true, -- &
+    [0x27] = true, -- '
+    [0x28] = true, -- (
+    [0x29] = true, -- )
+    [0x2A] = true, -- *
+    [0x2B] = true, -- +
+    [0x2C] = true, -- ,
+    [0x2F] = true, -- /
+    [0x3A] = true, -- :
+    [0x3B] = true, -- ;
+    [0x3D] = true, -- =
+    [0x3F] = true, -- ?
+    [0x40] = true, -- @
+    [0x5B] = true, -- [
+    [0x5D] = true, -- ]
+  }
+  local REGEX_META_CHARACTERS = {
+    [0x2E] = true, -- .
+    [0x5E] = true, -- ^
+    -- $ in RESERVED_CHARACTERS
+    -- * in RESERVED_CHARACTERS
+    -- + in RESERVED_CHARACTERS
+    [0x2D] = true, -- -
+    -- ? in RESERVED_CHARACTERS
+    -- ( in RESERVED_CHARACTERS
+    -- ) in RESERVED_CHARACTERS
+    -- [ in RESERVED_CHARACTERS
+    -- ] in RESERVED_CHARACTERS
+    [0x7B] = true, -- {
+    [0x7D] = true, -- }
+    [0x5C] = true, -- \
+    [0x7C] = true, -- |
+  }
+  local ngx_re_gsub = ngx.re.gsub
+  local string_char = string.char
+
+  function normalize_regex(regex)
+    -- Decoding percent-encoded triplets of unreserved characters
+    return ngx_re_gsub(regex, "%([\\dA-F]{2})", function(m)
+      local hex = m[1]
+      local num = tonumber(hex, 16)
+      if RESERVED_CHARACTERS[num] then
+        return upper(m[0])
+      end
+
+      return (REGEX_META_CHARACTERS[num] and "\\" or "") .. string_char(num)
+    end, "joi")
+  end
+end
+
+
 local clear_tab
 local log
 do
@@ -428,7 +486,7 @@ local function marshall_route(r)
 
           local uri_t = {
             is_prefix = true,
-            value     = path,
+            value     = normalize(path, true),
           }
 
           route_t.uris[path] = uri_t
@@ -436,6 +494,8 @@ local function marshall_route(r)
           route_t.max_uri_length = max(route_t.max_uri_length, #path)
 
         else
+          local path = normalize_regex(path)
+
           -- regex URI
           local strip_regex  = path .. [[(?<uri_postfix>.*)]]
           local has_captures = has_capturing_groups(path)


### PR DESCRIPTION
regex detection first, then depending on the type of path use URI
normalization or regex normalization

Regex normalization is similar to URI normalization, except:
1. It does not merge slashes
2. If after percent decoding the character becomes a PCRE meta
character, then it will be escaped