### PR TITLE
fix(PDK) auto-escape characters that are not in the reserved and

### DIFF
--- a/kong/pdk/service/request.lua
+++ b/kong/pdk/service/request.lua
@@ -12,6 +12,7 @@ local ngx_var = ngx.var
 local table_insert = table.insert
 local table_sort = table.sort
 local table_concat = table.concat
+local type = type
 local string_find = string.find
 local string_sub = string.sub
 local string_lower = string.lower
@@ -20,6 +21,7 @@ local normalize_multi_header = checks.normalize_multi_header
 local validate_header = checks.validate_header
 local validate_headers = checks.validate_headers
 local check_phase = phase_checker.check
+local escape = require("kong.tools.uri").escape
 
 
 local PHASES = phase_checker.phases
@@ -118,11 +120,16 @@ local function new(self)
 
 
   ---
-  -- Sets the path component for the request to the service. It is not
-  -- normalized in any way and should **not** include the querystring.
+  -- Sets the path component for the request to the service.
+  --
+  -- The input accepts any valid *normalized* URI (including UTF-8 characters)
+  -- and this API will perform necessary escaping according to the RFC
+  -- to make the request valid.
+  --
+  -- Input should **not** include the querystring.
   -- @function kong.service.request.set_path
   -- @phases `access`
-  -- @tparam string path The path string. Example: "/v2/movies"
+  -- @tparam string path The path string. Special characters and UTF-8 characters are allowed. Example: "/v2/movies" or "/foo/😀"
   -- @return Nothing; throws an error on invalid inputs.
   -- @usage
   -- kong.service.request.set_path("/v2/movies")
@@ -137,9 +144,7 @@ local function new(self)
       error("path must start with /", 2)
     end
 
-    -- TODO: is this necessary in specific phases?
-    -- ngx.req.set_uri(path)
-    ngx_var.upstream_uri = path
+    ngx_var.upstream_uri = escape(path)
   end
 
 

--- a/t/01-pdk/06-service-request/04-set_path.t
+++ b/t/01-pdk/06-service-request/04-set_path.t
@@ -129,3 +129,79 @@ GET /t
 this is /foo
 --- no_error_log
 [error]
+
+
+
+=== TEST 5: service.request.set_path() escapes UTF-8 characters
+--- http_config eval
+qq{
+    $t::Util::HttpConfig
+
+    server {
+        server_name K0nG;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
+
+        location /foó/😀 {
+            content_by_lua_block {
+                ngx.say("this works!")
+            }
+        }
+    }
+}
+--- config
+    location = /t {
+        set $upstream_uri '/t';
+
+        rewrite_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            pdk.service.request.set_path("/foó/😀")
+        }
+
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock:$upstream_uri;
+    }
+--- request
+GET /t
+--- response_body
+this works!
+--- no_error_log
+[error]
+
+
+
+=== TEST 6: service.request.set_path() does not touch reserved characters
+--- http_config eval
+qq{
+    $t::Util::HttpConfig
+
+    server {
+        server_name K0nG;
+        listen unix:$ENV{TEST_NGINX_NXSOCK}/nginx.sock;
+
+        location /foo {
+            content_by_lua_block {
+                ngx.say("this works!")
+            }
+        }
+    }
+}
+--- config
+    location = /t {
+        set $upstream_uri '/t';
+
+        rewrite_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            pdk.service.request.set_path("/fo%6F")
+        }
+
+        proxy_pass http://unix:/$TEST_NGINX_NXSOCK/nginx.sock:$upstream_uri;
+    }
+--- request
+GET /t
+--- response_body
+this works!
+--- no_error_log
+[error]


### PR DESCRIPTION
unreserved list of RFC 3986 when calling `kong.service.request.set_path()`
to avoid proxy failures later