### PR TITLE
fix(external-plugins) - add macos include path

### DIFF
--- a/kong/runloop/plugin_servers/pb_rpc.lua
+++ b/kong/runloop/plugin_servers/pb_rpc.lua
@@ -212,6 +212,7 @@ local function load_service()
   --p:loadfile("kong/pluginsocket.proto")
 
   p:addpath("/usr/include")
+  p:addpath("/usr/local/opt/protobuf/include/")
   local parsed = p:parsefile("kong/pluginsocket.proto")
 
   local service = {}


### PR DESCRIPTION
seems most (all?) Linux variants use `/usr/include` for protobuf
"standard" files, but Homebrew uses `/usr/local/opt/protobuf/include`
