### PR TITLE
fix(go) - go-pluginserve config

### DIFF
--- a/kong/runloop/plugin_servers/process.lua
+++ b/kong/runloop/plugin_servers/process.lua
@@ -56,8 +56,9 @@ local function get_server_defs()
   if not _servers then
     _servers = {}
 
-    if config.pluginserver_names then
+    if config.pluginserver_names[1] then
       for i, name in ipairs(config.pluginserver_names) do
+        name = name:lower()
         kong.log.debug("search config for pluginserver named: ", name)
         local env_prefix = "pluginserver_" .. name:gsub("-", "_")
         _servers[i] = {


### PR DESCRIPTION
two related issues:

- the new config style is detected by the `pluginserver_names` setting,
but the default is an empty table, thus it's never falsy, and the old
configuration style is never attempted

- the pluginserver names serve to tie the other configuration fields,
but those fieldnames are lowercased, so the pluginserver names must be
lowered too.

Fix #6840

