### PR TITLE
fix(plugins) properly escape postgres sql parameters

### DIFF
--- a/kong/plugins/rate-limiting/handler.lua
+++ b/kong/plugins/rate-limiting/handler.lua
@@ -47,7 +47,7 @@ local RateLimitingHandler = {}
 
 
 RateLimitingHandler.PRIORITY = 901
-RateLimitingHandler.VERSION = "2.2.1"
+RateLimitingHandler.VERSION = "2.2.2"
 
 
 local function get_identifier(conf)

--- a/kong/plugins/response-ratelimiting/handler.lua
+++ b/kong/plugins/response-ratelimiting/handler.lua
@@ -27,7 +27,7 @@ end
 
 
 ResponseRateLimitingHandler.PRIORITY = 900
-ResponseRateLimitingHandler.VERSION = "2.0.0"
+ResponseRateLimitingHandler.VERSION = "2.0.1"
 
 
 return ResponseRateLimitingHandler


### PR DESCRIPTION
### Summary

Postgres parameters were not properly escaped with the following plugins:
- `rate-limiting`
- `response-ratelimiting`

This PR fixes that.