### PR TITLE
fix(migrations) don't assume '/?/init.lua' in the path

### DIFF
--- a/kong/db/migrations/state.lua
+++ b/kong/db/migrations/state.lua
@@ -67,7 +67,9 @@ local function load_subsystems(db, plugin_names)
       for _, plugin_name in ipairs(sorted_plugin_names) do
         local namespace = ss.namespace:gsub("%*", plugin_name)
 
-        local ok, mig_idx = utils.load_module_if_exists(namespace)
+        -- explicitly load using ".init" since "/?/init.lua" isn't always in a
+        -- Lua-path by default, see https://github.com/Kong/kong/issues/6867
+        local ok, mig_idx = utils.load_module_if_exists(namespace .. ".init")
         if ok then
           if type(mig_idx) ~= "table" then
             return nil, fmt_err(db, "migrations index from '%s' must be a table",

--- a/kong/db/migrations/state.lua
+++ b/kong/db/migrations/state.lua
@@ -67,9 +67,14 @@ local function load_subsystems(db, plugin_names)
       for _, plugin_name in ipairs(sorted_plugin_names) do
         local namespace = ss.namespace:gsub("%*", plugin_name)
 
-        -- explicitly load using ".init" since "/?/init.lua" isn't always in a
-        -- Lua-path by default, see https://github.com/Kong/kong/issues/6867
-        local ok, mig_idx = utils.load_module_if_exists(namespace .. ".init")
+        local ok, mig_idx = utils.load_module_if_exists(namespace)
+
+        if not ok then
+          -- fallback to using ".init" since "/?/init.lua" isn't always in a
+          -- Lua-path by default, see https://github.com/Kong/kong/issues/6867
+          ok, mig_idx = utils.load_module_if_exists(namespace .. ".init")
+        end
+
         if ok then
           if type(mig_idx) ~= "table" then
             return nil, fmt_err(db, "migrations index from '%s' must be a table",


### PR DESCRIPTION
When a custom plugin is loaded that is not located in the Kong tree
the user manually sets the Lua-path to locate the plugin. In that
case the assumption that the 'init' files will be found might be
wrong.

Fixes #6867
Fixes #7340 
