### PR TITLE
refactor(*) go pb rpc

### DIFF
--- a/kong-2.4.0beta.2-0.rockspec
+++ b/kong-2.4.0beta.2-0.rockspec
@@ -29,6 +29,7 @@ dependencies = {
   "lyaml == 6.2.7",
   "luasyslog == 1.0.0",
   "lua_pack == 1.0.5",
+  "lua-protobuf",
   "lua-resty-dns-client == 5.2.3",
   "lua-resty-worker-events == 1.0.0",
   "lua-resty-healthcheck == 1.4.1",

--- a/kong/runloop/plugin_servers/pb_rpc.lua
+++ b/kong/runloop/plugin_servers/pb_rpc.lua
@@ -213,7 +213,11 @@ local function load_service()
 
   p:addpath("/usr/include")
   p:addpath("/usr/local/opt/protobuf/include/")
-  local parsed = p:parsefile("kong/pluginsocket.proto")
+
+  p:addpath("/usr/local/kong/lib/")
+  p:addpath("kong")
+
+  local parsed = p:parsefile("pluginsocket.proto")
 
   local service = {}
   for i, s in ipairs(parsed.service) do
@@ -237,7 +241,7 @@ local function load_service()
 
   p:loadfile("google/protobuf/empty.proto")
   p:loadfile("google/protobuf/struct.proto")
-  p:loadfile("kong/pluginsocket.proto")
+  p:loadfile("pluginsocket.proto")
 
   return service
 end


### PR DESCRIPTION
- Add missing lua-protobuf to rockspec
- Refactor `parsefile`, so it looks in common development and production locations