### PR TITLE
fix(postgres) support connecting to Postgres >= 12 by disabling SSL/TLS < 1.2

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1360,6 +1360,17 @@
                                  #
                                  # See https://github.com/openresty/lua-nginx-module#lua_ssl_verify_depth
 
+#lua_ssl_protocols = TLSv1.1 TLSv1.2 TLSv1.3   # Defines the TLS versions supported
+                                               # when handshaking with OpenResty's
+                                               # TCP cosocket APIs.
+                                               #
+                                               # This affects connections made by Lua
+                                               # code, such as connections to the
+                                               # database Kong uses, or when sending logs
+                                               # using a logging plugin. It does *not*
+                                               # affect connections made to the upstream
+                                               # Service or from downstream clients.
+
 #lua_package_path = ./?.lua;./?/init.lua;  # Sets the Lua module search path
                                            # (LUA_PATH). Useful when developing
                                            # or using custom plugins not stored

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -611,6 +611,13 @@ local CONF_INFERENCES = {
 
   lua_ssl_trusted_certificate = { typ = "array" },
   lua_ssl_verify_depth = { typ = "number" },
+  lua_ssl_protocols = {
+    typ = "string",
+    directives = {
+      "nginx_http_lua_ssl_protocols",
+      "nginx_stream_lua_ssl_protocols",
+    },
+  },
   lua_socket_pool_size = { typ = "number" },
 
   role = { enum = { "data_plane", "control_plane", "traditional", }, },

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -160,6 +160,7 @@ worker_state_update_frequency = 5
 lua_socket_pool_size = 30
 lua_ssl_trusted_certificate = NONE
 lua_ssl_verify_depth = 1
+lua_ssl_protocols = TLSv1.1 TLSv1.2 TLSv1.3
 lua_package_path = ./?.lua;./?/init.lua;
 lua_package_cpath = NONE
 

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -1118,6 +1118,28 @@ describe("Configuration loader", function()
           end
         end)
       end)
+
+      describe("lua_ssl_protocls", function()
+        it("sets both lua_ssl_protocls in http and stream subsystem to TLS 1.2-1.3 by default", function()
+          local conf, err = conf_loader()
+          assert.is_nil(err)
+          assert.is_table(conf)
+
+          assert.equal("TLSv1.1 TLSv1.2 TLSv1.3", conf.nginx_http_lua_ssl_protocols)
+          assert.equal("TLSv1.1 TLSv1.2 TLSv1.3", conf.nginx_stream_lua_ssl_protocols)
+        end)
+
+        it("sets both lua_ssl_protocls in http and stream subsystem to user specified value", function()
+          local conf, err = conf_loader(nil, {
+            lua_ssl_protocols = "TLSv1.1"
+          })
+          assert.is_nil(err)
+          assert.is_table(conf)
+
+          assert.equal("TLSv1.1", conf.nginx_http_lua_ssl_protocols)
+          assert.equal("TLSv1.1", conf.nginx_stream_lua_ssl_protocols)
+        end)
+      end)
     end)
     it("honors path if provided even if a default file exists", function()
       conf_loader.add_default_path("spec/fixtures/to-strip.conf")


### PR DESCRIPTION
protocols < 1.2 in cosocket and bumping the pgmoon dependency to the
latest which includes the LuaSec TLS 1.2 support. fixes #6645

Postgres >= 12 requires TLS >= 1.2 to connect. Since TLS < 1.2 has known
vulnerabilities, we will disable older versions of support in OpenResty
cosocket by default, but leave the option for users to re-enable them
if so desire.

Tested locally with latest Postgres 13 with TLS enforced and both migrations as well as proxy features works well after the change.