### PR TITLE
fix(balancer) don't assume upstreams don't exist after init phases

### DIFF
--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -423,7 +423,7 @@ do
 
   local creating = {}
 
-  wait = function(id, name)
+  wait = function(id)
     local timeout = 30
     local step = 0.001
     local ratio = 2
@@ -431,18 +431,8 @@ do
     while timeout > 0 do
       sleep(step)
       timeout = timeout - step
-      if id ~= nil then
-        if not creating[id] then
-          return true
-        end
-      else
-        if upstream_by_name[name] ~= nil then
-          return true
-        end
-        local phase = get_phase()
-        if phase ~= "init_worker" and phase ~= "init" then
-          return false
-        end
+      if not creating[id] then
+        return true
       end
       if timeout <= 0 then
         break
@@ -586,26 +576,6 @@ local function get_upstream_by_name(upstream_name)
     return upstream_by_name[key]
   end
 
-  -- wait until upstream is loaded on init()
-  local ok = wait(nil, key)
-
-  if ok == false then
-    -- no upstream by this name
-    return false
-  end
-
-  if ok == nil then
-    return nil, "timeout waiting upstream to be loaded: " .. key
-  end
-
-  if upstream_by_name[key] then
-    return upstream_by_name[key]
-  end
-
-  -- couldn't find upstream at upstream_by_name[key] and there was no timeout
-  -- when waiting for the upstream to be loaded on init().
-  -- this is a worst-case scenario, so as a last option, we will try to load
-  -- all upstreams from the DB into memory to find the upstream
   local upstreams_dict, err = get_all_upstreams()
   if err then
     return nil, err


### PR DESCRIPTION
There may be cases where an upstream is not yet loaded on `init` and
`init_worker` phases (for example, failure on reading the upstreams
list in the `init()` function) and because of that, after these init
phases, we will just always return a `503` to the client with the error
`"name resolution failed"` since the dns-client lib will return a
`"dns server error: 3 name error"` to Kong. So we can't assume the
upstream doesn't exist just because we are past the init phases.

This applies to both the `strict` and `eventual` balancer worker
consistencies.

This is complementing https://github.com/Kong/kong/pull/7002

Fix #6812