### PR TITLE
docs(autodoc) autodoc tool for splitting upgrade.md doc

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -7,15 +7,14 @@ simply consult the [Suggested upgrade path](#suggested-upgrade-path).
 ## Suggested upgrade path
 
 Unless indicated otherwise in one of the upgrade paths of this document, it is
-possible to upgrade Kong **without downtime**:
+possible to upgrade Kong **without downtime**.
 
 Assuming that Kong is already running on your system, acquire the latest
-version from any of the available [installation
-methods](https://konghq.com/get-started/#install) and proceed to install it, overriding
-your previous installation.
+version from any of the available [installation methods](https://getkong.org/install/)
+and proceed to install it, overriding your previous installation.
 
-If you are planning to make modifications to your configuration, this is a
-good time to do so.
+**If you are planning to make modifications to your configuration, this is a
+good time to do so**.
 
 Then, run migration to upgrade your database schema:
 
@@ -25,7 +24,7 @@ $ kong migrations up [-c configuration_file]
 
 If the command is successful, and no migration ran
 (no output), then you only have to
-[reload](https://docs.konghq.com/1.0.x/cli/#kong-reload) Kong:
+[reload](https://docs.konghq.com/gateway-oss/2.3.x/cli/#kong-reload) Kong:
 
 ```shell
 $ kong reload [-c configuration_file]
@@ -36,23 +35,23 @@ starts new workers, which take over from old workers before those old workers
 are terminated. In this way, Kong will serve new requests via the new
 configuration, without dropping existing in-flight connections.
 
-## Upgrade to `2.3.0`
+## Upgrade to `2.3.x`
 
 Kong adheres to [semantic versioning](https://semver.org/), which makes a
 distinction between "major", "minor", and "patch" versions. The upgrade path
 will be different depending on which previous version from which you are migrating.
 
-If you are migrating from 2.0.0, 2.1.x, or 2.2.x upgrading into 2.3.x is a minor upgrade,
+If you are migrating from 2.0.x, 2.1.x, or 2.2.x, upgrading into 2.3.x is a minor upgrade,
 but read below for important instructions on database migration, especially
 for Cassandra users.
 
 If you are migrating from 1.x, upgrading into 2.3.x is a major upgrade,
-so, in addition, be aware of any [breaking changes](#breaking-changes-2.0.0)
+so, in addition, be aware of any [breaking changes](https://github.com/Kong/kong/blob/master/UPGRADE.md#breaking-changes-2.0)
 between the 1.x and 2.x series below, further detailed in the
-[CHANGELOG.md](https://github.com/Kong/kong/blob/2.0.0/CHANGELOG.md) document.
+[CHANGELOG.md](https://github.com/Kong/kong/blob/2.0.0/CHANGELOG.md#200) document.
 
 
-#### 1. Dependencies
+### Dependencies
 
 If you are using the provided binary packages, all necessary dependencies
 for the gateway are bundled and you can skip this section.
@@ -63,27 +62,25 @@ previous release, so you will need to rebuild them with the latest patches.
 The required OpenResty version for kong 2.3.x is
 [1.17.8.2](https://openresty.org/en/changelog-1017008.html). This is more recent
 than the version in Kong 2.1.0 (which used `1.15.8.3`). In addition to an upgraded
-OpenResty, you will need the correct [OpenResty
-patches](https://github.com/Kong/kong-build-tools/tree/master/openresty-build-tools/openresty-patches)
-for this new version, including the latest release of
-[lua-kong-nginx-module](https://github.com/Kong/lua-kong-nginx-module).
+OpenResty, you will need the correct [OpenResty patches](https://github.com/Kong/kong-build-tools/tree/master/openresty-build-tools/openresty-patches)
+for this new version, including the latest release of [lua-kong-nginx-module](https://github.com/Kong/lua-kong-nginx-module).
 The [kong-build-tools](https://github.com/Kong/kong-build-tools)
 repository contains [openresty-build-tools](https://github.com/Kong/kong-build-tools/tree/master/openresty-build-tools),
-which allows you to build OpenResty with the necessary patches
-and modules easily.
+which allows you to more easily build OpenResty with the necessary patches and modules.
 
-There is a new way to deploy Go using Plugin Servers. You can read more about it the [Go section of the docs](https://docs.konghq.com/2.3.x/go).
+There is a new way to deploy Go using Plugin Servers.
+For more information, see [Developing Go plugins](https://docs.konghq.com/gateway-oss/2.3.x/external-plugins/#developing-go-plugins).
 
-#### 2. Template Changes
+### Template changes
 
-There are **Changes in the Nginx configuration file**, between kong 2.0.0,
-2.1.0, 2.2.0 and 2.3.0.
+There are **Changes in the Nginx configuration file**, between kong 2.0.x,
+2.1.x, 2.2.x and 2.3.x.
 
 To view the configuration changes between versions, clone the
 [Kong repository](https://github.com/kong/kong) and run `git diff`
 on the configuration templates, using `-w` for greater readability.
 
-Here's how to see the differences between 2.0.0 and 2.3.0:
+Here's how to see the differences between 2.0.x and 2.1.x, or 2.2.x and 2.3.x:
 
 ```
 git clone https://github.com/kong/kong
@@ -91,36 +88,44 @@ cd kong
 git diff -w 2.0.0 2.3.0 kong/templates/nginx_kong*.lua
 ```
 
+**Note:** Adjust the starting version number
+(2.0.x, 2.1.x, or 2.2.x) to the version number you are currently using.
+
 To produce a patch file, use the following command:
 
 ```
 git diff 2.0.0 2.3.0 kong/templates/nginx_kong*.lua > kong_config_changes.diff
 ```
 
-#### 3. Suggested Upgrade Path
+**Note:** Adjust the starting version number
+(2.0.x, 2.1.x, or 2.2.x) to the version number you are currently using.
 
-##### Upgrade from `0.x` to `2.3.0`
 
-The lowest version that Kong 2.3.0 supports migrating from is 1.0.0.
+### Suggested upgrade path
+
+**Version prerequisites for migrating to version 2.3.x**
+
+The lowest version that Kong 2.3.x supports migrating from is 1.0.x.
 If you are migrating from a version lower than 0.14.1, you need to
 migrate to 0.14.1 first. Then, once you are migrating from 0.14.1,
-please migrate to 1.5.0 first.
+please migrate to 1.5.x first.
 
-The steps for upgrading from 0.14.1 to 1.5.0 are the same as upgrading
+The steps for upgrading from 0.14.1 to 1.5.x are the same as upgrading
 from 0.14.1 to Kong 1.0. Please follow the steps described in the
-"Migration Steps from 0.14" in the [Suggested Upgrade Path for Kong
-1.0](#kong-1-0-upgrade-path), with the addition of the `kong
-migrations migrate-apis` command, which you can use to migrate legacy
-`apis` configurations.
+"Migration Steps from 0.14" in the
 
-Once you migrated to 1.5.0, you can follow the instructions in the section
-below to migrate to 2.3.0.
+[Suggested Upgrade Path for Kong 1.0](https://github.com/Kong/kong/blob/master/UPGRADE.md#kong-1-0-upgrade-path)
+with the addition of the `kong migrations migrate-apis` command,
+which you can use to migrate legacy `apis` configurations.
 
-##### Upgrade from `1.0.0` - `2.2.0` to `2.3.0`
+Once you migrated to 1.5.x, you can follow the instructions in the section
+below to migrate to 2.3.x.
+
+### Upgrade from `1.0.x` - `2.2.x` to `2.3.x`
 
 **Postgres**
 
-Kong 2.3.0 supports a no-downtime migration model. This means that while the
+Kong 2.3.x supports a no-downtime migration model. This means that while the
 migration is ongoing, you will have two Kong clusters running, sharing the
 same database. (This is sometimes called the Blue/Green migration model.)
 
@@ -129,41 +134,41 @@ the database as it is migrated while the old Kong cluster keeps working until
 it is time to decommission it. For this reason, the migration is split into
 two steps, performed via commands `kong migrations up` (which does
 only non-destructive operations) and `kong migrations finish` (which puts the
-database in the final expected state for Kong 2.3.0).
+database in the final expected state for Kong 2.3.x).
 
-1. Download 2.3.0, and configure it to point to the same datastore
+1. Download 2.3.x, and configure it to point to the same datastore
    as your old (1.0 to 2.0) cluster. Run `kong migrations up`.
-2. Once that finishes running, both the old (pre-2.1) and new (2.3.0)
-   clusters can now run simultaneously. Start provisioning 2.3.0 nodes,
+2. After that finishes running, both the old (2.x.x) and new (2.3.x)
+   clusters can now run simultaneously. Start provisioning 2.3.x nodes,
    but do not use their Admin API yet. If you need to perform Admin API
    requests, these should be made to the old cluster's nodes. The reason
    is to prevent the new cluster from generating data that is not understood
    by the old cluster.
 3. Gradually divert traffic away from your old nodes, and into
-   your 2.3.0 cluster. Monitor your traffic to make sure everything
+   your 2.3.x cluster. Monitor your traffic to make sure everything
    is going smoothly.
-4. When your traffic is fully migrated to the 2.3.0 cluster,
+4. When your traffic is fully migrated to the 2.3.x cluster,
    decommission your old nodes.
-5. From your 2.3.0 cluster, run: `kong migrations finish`.
+5. From your 2.3.x cluster, run: `kong migrations finish`.
    From this point on, it will not be possible to start
    nodes in the old cluster pointing to the same datastore anymore. Only run
    this command when you are confident that your migration
    was successful. From now on, you can safely make Admin API
-   requests to your 2.3.0 nodes.
+   requests to your 2.3.x nodes.
 
 **Cassandra**
 
-Due to internal changes, the table schemas used by Kong 2.3.0 on Cassandra
-are incompatible with those used by Kong 2.0.0. Migrating using the usual commands
+Due to internal changes, the table schemas used by Kong 2.3.x on Cassandra
+are incompatible with those used by Kong 2.1.x (or lower). Migrating using the usual commands
 `kong migrations up` and `kong migrations finish` will require a small
 window of downtime, since the old and new versions cannot use the
 database at the same time. Alternatively, to keep your previous version fully
 operational while the new one initializes, you will need to transfer the
 data to a new keyspace via a database dump, as described below:
 
-1. Download 2.3.0, and configure it to point to a new keyspace.
+1. Download 2.3.x, and configure it to point to a new keyspace.
    Run `kong migrations bootstrap`.
-2. Once that finishes running, both the old (pre-2.1) and new (2.3.0)
+2. Once that finishes running, both the old (pre-2.1) and new (2.3.x)
    clusters can now run simultaneously, but the new cluster does not
    have any data yet.
 3. On the old cluster, run `kong config db_export`. This will create
@@ -171,14 +176,14 @@ data to a new keyspace via a database dump, as described below:
 4. Transfer the file to the new cluster and run
    `kong config db_import kong.yml`. This will load the data into the new cluster.
 5. Gradually divert traffic away from your old nodes, and into
-   your 2.3.0 cluster. Monitor your traffic to make sure everything
+   your 2.3.x cluster. Monitor your traffic to make sure everything
    is going smoothly.
-6. When your traffic is fully migrated to the 2.3.0 cluster,
+6. When your traffic is fully migrated to the 2.3.x cluster,
    decommission your old nodes.
 
-##### Installing 2.3.0 on a Fresh Datastore
+### Installing 2.3.x on a fresh datastore
 
-The following commands should be used to prepare a new 2.3.0 cluster from a
+The following commands should be used to prepare a new 2.3.x cluster from a
 fresh datastore. By default the `kong` CLI tool will load the configuration
 from `/etc/kong/kong.conf`, but you can optionally use the flag `-c` to
 indicate the path to your configuration file:

--- a/autodoc/upgrading/generate.lua
+++ b/autodoc/upgrading/generate.lua
@@ -1,0 +1,70 @@
+#!/usr/bin/env resty
+
+-- This file must be executed from the root folder, i.e.
+-- ./autodoc/upgrading/generate.lua
+setmetatable(_G, nil)
+
+local lfs = require("lfs")
+
+local header = [[
+---
+# Generated via autodoc/upgrading/generate.lua in the kong/kong repo
+title: Upgrade guide
+---
+
+This document guides you through the process of upgrading {{site.ce_product_name}} to the **latest version**.
+To upgrade to prior versions, find the version number in the
+[Upgrade doc in GitHub](https://github.com/Kong/kong/blob/master/UPGRADE.md).
+
+]]
+
+
+lfs.mkdir("autodoc")
+lfs.mkdir("autodoc/output")
+local outpath = "autodoc/output/upgrading.md"
+
+print("Building upgrading.md")
+
+local input = assert(io.open("UPGRADE.md", "r+"))
+
+-- Keep skipping lines until "## Suggested upgrade path"
+local line
+while true do
+  line = input:read()
+  if line == nil then
+    error("Could not find the `## Suggested upgrade path` line")
+  end
+  if line:match("## Suggested upgrade path") then
+    break
+  end
+end
+
+-- Read everything until THE SECOND "## Upgrade to xxx" line
+local buffer = { line }
+local upgrade_counter = 0
+
+while true do
+  line = input:read()
+  if line == nil then
+    error("Could not find two `## Upgrade to xxx` lines")
+  end
+
+
+  if line:match("## Upgrade to ") then
+    upgrade_counter = upgrade_counter + 1
+    if upgrade_counter == 2 then
+      break
+    end
+  end
+
+  buffer[#buffer + 1] = line
+end
+
+input:close()
+
+-- Write header + selected body to output
+local output = assert(io.open(outpath, "w+"))
+output:write(header)
+output:write(table.concat(buffer, "\n"))
+output:close()
+

--- a/scripts/autodoc
+++ b/scripts/autodoc
@@ -70,6 +70,7 @@ rm -rf ./autodoc/output
 ./autodoc/admin-api/generate.lua && \
 ./autodoc/cli/generate.lua && \
 ./autodoc/conf/generate.lua && \
+./autodoc/upgrading/generate.lua && \
 ./autodoc/pdk/generate.lua
 
 if [ -z "$DOCS_REPO" ] || [ -z "$DOCS_VERSION" ]
@@ -150,6 +151,9 @@ copy autodoc/output/nav/docs_nav.yml.admin-api.in "$DOCS_REPO/autodoc-nav/docs_n
 
 copy autodoc/output/configuration.md "$DOCS_APP/configuration.md"
 copy autodoc/output/cli.md "$DOCS_APP/cli.md"
+
+rm -rf "$DOCS_APP/upgrading.md"
+copy autodoc/output/upgrading.md "$DOCS_APP/upgrading.md"
 
 rm -rf "$DOCS_APP/pdk/"
 mkdir -p "$DOCS_APP/pdk"


### PR DESCRIPTION
This PR introduces a new autodoc tool which produces updating.md, a smaller version of UPGRADE.md used in docs.konghq.com.

The PR also modifies our 2.3.0 UPGRADE.md instructions so that they match the modifications in the updating.md made by the docs team, although there are some differences (some formatting had to be sacrificed in order for the doc to work in both the docs page and as as standalone markdown file)

We still need to create the installation instructions for 2.4.0, that will come in a separate PR, using this one as a base.