### PR TITLE
fix(pdk) do not replace underscores by slashes in kong.response.set_header

### DIFF
--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -36,6 +36,7 @@ lua_shared_dict kong_cassandra              5m;
 > end
 
 underscores_in_headers on;
+lua_transform_underscores_in_response_headers off;
 > if ssl_ciphers then
 ssl_ciphers ${{SSL_CIPHERS}};
 > end

--- a/spec/02-integration/07-sdk/04-response_spec.lua
+++ b/spec/02-integration/07-sdk/04-response_spec.lua
@@ -1,0 +1,65 @@
+local helpers = require "spec.helpers"
+
+describe("SDK: kong.response", function()
+  local proxy_client
+  local bp, db
+
+  before_each(function()
+    bp, db = helpers.get_db_utils(nil, {
+      "routes",
+      "services",
+      "plugins",
+    }, {
+      "response-transformer",
+    })
+  end)
+
+  after_each(function()
+    if proxy_client then
+      proxy_client:close()
+    end
+
+    helpers.stop_kong()
+
+    assert(db:truncate("routes"))
+    assert(db:truncate("services"))
+    db:truncate("plugins")
+  end)
+
+  it("preserves underscores in headers", function()
+    local service = bp.services:insert({
+      protocol = helpers.mock_upstream_ssl_protocol,
+      host     = helpers.mock_upstream_ssl_host,
+      port     = helpers.mock_upstream_ssl_port,
+    })
+    local r = bp.routes:insert({
+      service = service,
+      protocols = { "https" },
+      hosts = { "underscores_test.dev" }
+    })
+
+    bp.plugins:insert({
+      name = "response-transformer",
+      route = { id = r.id },
+      config = {
+        add = {
+          headers = {
+            "un_der_score:true"
+          }
+        }
+      }
+    })
+
+    assert(helpers.start_kong({
+      nginx_conf = "spec/fixtures/custom_nginx.template",
+    }))
+
+    proxy_client = helpers.proxy_ssl_client()
+
+    local res = proxy_client:get("/request", {
+      headers = { Host = "underscores_test.dev" }
+    })
+    assert.status(200, res)
+    assert.same("true", res.headers["un_der_score"])
+  end)
+end)

--- a/spec/fixtures/1.2_custom_nginx.template
+++ b/spec/fixtures/1.2_custom_nginx.template
@@ -32,6 +32,7 @@ http {
 
     proxy_ssl_server_name on;
     underscores_in_headers on;
+    lua_transform_underscores_in_response_headers off;
 
     lua_package_path '${{LUA_PACKAGE_PATH}};;';
     lua_package_cpath '${{LUA_PACKAGE_CPATH}};;';

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -58,6 +58,7 @@ http {
     lua_shared_dict kong_mock_upstream_loggers  10m;
 
     underscores_in_headers on;
+    lua_transform_underscores_in_response_headers off;
 > if ssl_ciphers then
     ssl_ciphers ${{SSL_CIPHERS}};
 > end


### PR DESCRIPTION
This PR sets the `lua_transform_underscores_in_response_headers` nginx config variable to `off` so that `kong.response.set_header` does not automatically transform underscores into slashes on response headers.

Solves #6995