### PR TITLE
fix(cli) don't overwrite config files on migration commands

### DIFF
--- a/kong/cmd/migrations.lua
+++ b/kong/cmd/migrations.lua
@@ -93,7 +93,7 @@ local function execute(args)
   conf.cassandra_timeout = args.db_timeout -- connect + send + read
   conf.cassandra_schema_consensus_timeout = args.db_timeout
 
-  assert(prefix_handler.prepare_prefix(conf, args.nginx_conf))
+  assert(prefix_handler.prepare_prefix(conf, args.nginx_conf, true))
 
   _G.kong = kong_global.new()
   kong_global.init_pdk(_G.kong, conf, nil) -- nil: latest PDK

--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -325,7 +325,7 @@ local function compile_nginx_conf(kong_config, template)
   return compile_conf(kong_config, template)
 end
 
-local function prepare_prefix(kong_config, nginx_custom_template_path)
+local function prepare_prefix(kong_config, nginx_custom_template_path, skip_write)
   log.verbose("preparing nginx prefix directory at %s", kong_config.prefix)
 
   if not pl_path.exists(kong_config.prefix) then
@@ -412,6 +412,10 @@ local function prepare_prefix(kong_config, nginx_custom_template_path)
   elseif ulimit < 4096 then
     log.warn([[ulimit is currently set to "%d". For better performance set it]] ..
              [[ to at least "4096" using "ulimit -n"]], ulimit)
+  end
+
+  if skip_write then
+    return true
   end
 
   -- compile Nginx configurations


### PR DESCRIPTION
The nginx configuration files are usually rewritten from configuration
and template on each restart/reload.  This also happens on `migration`
commands, as part of the configuration loading.  This can be
undesirable, especially when using a custom templace, since these
commands don't admit a `--nginx-conf` argument, so they always use the
default template, reverting customization.

Given that these commands don't restart/reload the nginx process,
there's no benefit in writing the config files.  This patch skips the
writing (and verifying) steps on those commands.


Fix #6917 
