### PR TITLE
feat(hmac-auth) add support for the "@request-target" field support

### DIFF
--- a/kong/plugins/hmac-auth/access.lua
+++ b/kong/plugins/hmac-auth/access.lua
@@ -95,7 +95,8 @@ local function retrieve_hmac_fields(authorization_header)
     local iterator, iter_err = re_gmatch(authorization_header,
                                          "\\s*[Hh]mac\\s*username=\"(.+)\"," ..
                                          "\\s*algorithm=\"(.+)\",\\s*header" ..
-                                         "s=\"(.+)\",\\s*signature=\"(.+)\"")
+                                         "s=\"(.+)\",\\s*signature=\"(.+)\"",
+                                         "jo")
     if not iterator then
       kong.log.err(iter_err)
       return

--- a/kong/plugins/hmac-auth/access.lua
+++ b/kong/plugins/hmac-auth/access.lua
@@ -16,6 +16,7 @@ local re_gmatch = ngx.re.gmatch
 local hmac_sha1 = ngx.hmac_sha1
 local ipairs = ipairs
 local fmt = string.format
+local string_lower = string.lower
 
 
 local AUTHORIZATION = "authorization"
@@ -132,13 +133,18 @@ local function create_hash(request_uri, hmac_params)
     local header_value = kong.request.get_header(header)
 
     if not header_value then
-      if header == "request-line" then
+      if header == "@request-target" then
+        local request_target = string_lower(kong.request.get_method()) .. " " .. request_uri
+        signing_string = signing_string .. header .. ": " .. request_target
+
+      elseif header == "request-line" then
         -- request-line in hmac headers list
         local request_line = fmt("%s %s HTTP/%.01f",
                                  kong.request.get_method(),
                                  request_uri,
                                  assert(kong.request.get_http_version()))
         signing_string = signing_string .. request_line
+
       else
         signing_string = signing_string .. header .. ":"
       end

--- a/spec/03-plugins/19-hmac-auth/03-access_spec.lua
+++ b/spec/03-plugins/19-hmac-auth/03-access_spec.lua
@@ -420,6 +420,24 @@ for _, strategy in helpers.each_strategy() do
         assert.same({ reply = "hello noname" }, cjson.decode(res))
       end)
 
+      it("accepts authorized gRPC calls with @request-target (HTTP/2 test), bug #3789", function()
+        local date = os.date("!%a, %d %b %Y %H:%M:%S GMT")
+        local encodedSignature   = ngx.encode_base64(hmac_sha1_binary("secret", "date: " .. date ..
+                                                                      "\n@request-target: " ..
+                                                                      "post /hello.HelloService/SayHello"))
+        local hmacAuth = [[hmac username="bob",algorithm="hmac-sha1",]]
+          .. [[headers="date @request-target",signature="]] .. encodedSignature .. [["]]
+
+        local ok, res = helpers.proxy_client_grpc(){
+          service = "hello.HelloService.SayHello",
+          opts = {
+            [""] = ("-H 'Date: %s' -H 'Authorization: %s'"):format(date, hmacAuth),
+          },
+        }
+        assert.truthy(ok)
+        assert.same({ reply = "hello noname" }, cjson.decode(res))
+      end)
+
       it("should pass with GET and proxy-authorization", function()
         local date = os.date("!%a, %d %b %Y %H:%M:%S GMT")
         local encodedSignature   = ngx.encode_base64(hmac_sha1_binary("secret", "date: " .. date))
@@ -527,6 +545,29 @@ for _, strategy in helpers.each_strategy() do
             .. date .. "\n" .. "content-md5: md5" .. "\nGET /request HTTP/1.1"))
         local hmacAuth = [[hmac username="bob",  algorithm="hmac-sha1", ]]
           .. [[headers="date content-md5 request-line", signature="]]
+          .. encodedSignature .. [["]]
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/request",
+          body    = {},
+          headers = {
+            ["HOST"]                = "hmacauth.com",
+            date                    = date,
+            ["proxy-authorization"] = hmacAuth,
+            authorization           = "hello",
+            ["content-md5"]         = "md5",
+          },
+        })
+        assert.res_status(200, res)
+      end)
+
+      it("should pass with GET with @request-target", function()
+        local date = os.date("!%a, %d %b %Y %H:%M:%S GMT")
+        local encodedSignature = ngx.encode_base64(
+          hmac_sha1_binary("secret", "date: "
+            .. date .. "\n" .. "content-md5: md5" .. "\n@request-target: get /request"))
+        local hmacAuth = [[hmac username="bob",  algorithm="hmac-sha1", ]]
+          .. [[headers="date content-md5 @request-target", signature="]]
           .. encodedSignature .. [["]]
         local res = assert(proxy_client:send {
           method  = "GET",


### PR DESCRIPTION
which is introduced in later versions of the "Signing HTTP Messages"
RFC. closes #3789

Previously the Kong implementation of the RFC included a signing
parameter "request-line" which contains the HTTP request method and
request URI plus the HTTP version number. This is not part of the RFC
draft, and has created issue such as #3789 where changing the HTTP
request version by intermediary proxy caused the signature validation to
fail.

In general, including the HTTP protocol version inside the signature
makes little sense, as the protocol does not identify the resource that
is being accessed, and can be changed by clients/proxies which still
preserving the original semantics of the request.

This PR adopts the "@request-target" field as described inside
https://tools.ietf.org/html/draft-ietf-httpbis-message-signatures-03
which only included the lowercased request method and request URI when
calculating the hash.

Note: we intentionally steered away from the
https://tools.ietf.org/html/draft-cavage-http-signatures-12 RFC
recommendation which uses the "request-target" field instead. This RFC
draft has expired due to long inactivity and the name also has slight
chance of conflict with HTTP headers named "Request-Target". Overall
the Kong hmac-auth plugin did not follow the RFC draft in the beginning,
and this change should not cause any compatibility issues for the users
that are relying on "request-line" today.
