### PR TITLE
fix(external-plugins)  response.getXXX() functions from log phase

### DIFF
--- a/kong/pdk/private/phases.lua
+++ b/kong/pdk/private/phases.lua
@@ -76,7 +76,8 @@ local function check_phase(accepted_phases)
       -- treat custom content blocks as the Admin API
       current_phase = PHASES.admin_api
     else
-      error("no phase in kong.ctx.core.phase")
+      error(fmt("no phase in kong.ctx.core.phase, (need one of %s)",
+                table.concat(get_phases_names(accepted_phases), ", ")))
     end
   end
 

--- a/kong/pdk/response.lua
+++ b/kong/pdk/response.lua
@@ -322,10 +322,11 @@ local function new(self, major_version)
   -- elseif kong.response.get_source() == "exit" then
   --   kong.log("There was an early exit while processing the request")
   -- end
-  function _RESPONSE.get_source()
-    check_phase(header_body_log)
-
-    local ctx = ngx.ctx
+  function _RESPONSE.get_source(ctx)
+    if ctx == nil then
+      check_phase(header_body_log)
+      ctx = ngx.ctx
+    end
 
     if ctx.KONG_UNEXPECTED then
       return "error"

--- a/kong/runloop/plugin_servers/init.lua
+++ b/kong/runloop/plugin_servers/init.lua
@@ -151,6 +151,8 @@ local function build_phases(plugin)
           serialize_data = kong.log.serialize(),
           ngx_ctx = ngx.ctx,
           ctx_shared = kong.ctx.shared,
+          response_headers = ngx.resp.get_headers(100),
+          response_status = ngx.status,
         }
 
         ngx_timer_at(0, function()

--- a/kong/runloop/plugin_servers/init.lua
+++ b/kong/runloop/plugin_servers/init.lua
@@ -1,8 +1,12 @@
 
 local proc_mgmt = require "kong.runloop.plugin_servers.process"
+local cjson = require "cjson.safe"
+local ngx_ssl = require "ngx.ssl"
 
 local ngx = ngx
 local kong = kong
+local ngx_var = ngx.var
+local coroutine_running = coroutine.running
 local get_plugin_info = proc_mgmt.get_plugin_info
 local ngx_timer_at = ngx.timer.at
 
@@ -15,6 +19,75 @@ local rpc_notifications = {}
 --- currently running plugin instances
 local running_instances = {}
 
+local exposed_api = {
+  kong = kong,
+
+  ["kong.log.serialize"] = function()
+    local saved = save_for_later[coroutine_running()]
+    return cjson.encode(saved and saved.serialize_data or kong.log.serialize())
+  end,
+
+  ["kong.nginx.get_var"] = function(v)
+    return ngx_var[v]
+  end,
+
+  ["kong.nginx.get_tls1_version_str"] = ngx_ssl.get_tls1_version_str,
+
+  ["kong.nginx.get_ctx"] = function(k)
+    local saved = save_for_later[coroutine_running()]
+    local ngx_ctx = saved and saved.ngx_ctx or ngx.ctx
+    return ngx_ctx[k]
+  end,
+
+  ["kong.nginx.set_ctx"] = function(k, v)
+    local saved = save_for_later[coroutine_running()]
+    local ngx_ctx = saved and saved.ngx_ctx or ngx.ctx
+    ngx_ctx[k] = v
+  end,
+
+  ["kong.ctx.shared.get"] = function(k)
+    local saved = save_for_later[coroutine_running()]
+    local ctx_shared = saved and saved.ctx_shared or kong.ctx.shared
+    return ctx_shared[k]
+  end,
+
+  ["kong.ctx.shared.set"] = function(k, v)
+    local saved = save_for_later[coroutine_running()]
+    local ctx_shared = saved and saved.ctx_shared or kong.ctx.shared
+    ctx_shared[k] = v
+  end,
+
+  ["kong.response.get_status"] = function()
+    local saved = save_for_later[coroutine_running()]
+    return saved and saved.response_status or kong.response.get_status()
+  end,
+
+  ["kong.response.get_headers"] = function(max)
+    local saved = save_for_later[coroutine_running()]
+    return saved and saved.response_headers or kong.response.get_headers(max)
+  end,
+
+  ["kong.response.get_header"] = function(name)
+    local saved = save_for_later[coroutine_running()]
+    if not saved then
+      return kong.response.get_header(name)
+    end
+
+    local header_value = saved.response_headers and saved.response_headers[name]
+    if type(header_value) == "table" then
+      header_value = header_value[1]
+    end
+
+    return header_value
+  end,
+
+  ["kong.response.get_source"] = function()
+    local saved = save_for_later[coroutine_running()]
+    return kong.response.get_source(saved and saved.ngx_ctx or nil)
+  end,
+
+  ["kong.nginx.req_start_time"] = ngx.req.start_time,
+}
 
 
 local get_instance_id
@@ -38,6 +111,7 @@ local function get_server_rpc(server_def)
     rpc.get_instance_id = rpc.get_instance_id or get_instance_id
     rpc.reset_instance = rpc.reset_instance or reset_instance
     rpc.save_for_later = rpc.save_for_later or save_for_later
+    rpc.exposed_api = rpc.exposed_api or exposed_api
 
     server_def.rpc = rpc.new(server_def.socket, rpc_notifications)
   end
@@ -156,7 +230,7 @@ local function build_phases(plugin)
         }
 
         ngx_timer_at(0, function()
-          local co = coroutine.running()
+          local co = coroutine_running()
           save_for_later[co] = saved
 
           server_rpc:handle_event(self.name, conf, phase)

--- a/kong/runloop/plugin_servers/mp_rpc.lua
+++ b/kong/runloop/plugin_servers/mp_rpc.lua
@@ -2,8 +2,6 @@ local kong_global = require "kong.global"
 local cjson = require "cjson.safe"
 local msgpack = require "MessagePack"
 
-local ngx_ssl = require "ngx.ssl"
-
 local ngx = ngx
 local kong = kong
 
@@ -66,7 +64,12 @@ local function fix_mmap(t)
   return o
 end
 
-
+local must_fix = {
+  ["kong.request.get_query"] = true,
+  ["kong.request.get_headers"] = true,
+  ["kong.response.get_headers"] = true,
+  ["kong.service.response.get_headers"] = true,
+}
 
 
 --[[
@@ -96,89 +99,6 @@ end
 
 local get_field
 do
-  local exposed_api = {
-    kong = kong,
-
-    ["kong.log.serialize"] = function()
-      local saved = Rpc.save_for_later[coroutine.running()]
-      return cjson_encode(saved and saved.serialize_data or kong.log.serialize())
-    end,
-
-    ["kong.nginx.get_var"] = function(v)
-      return ngx.var[v]
-    end,
-
-    ["kong.nginx.get_tls1_version_str"] = ngx_ssl.get_tls1_version_str,
-
-    ["kong.nginx.get_ctx"] = function(k)
-      local saved = Rpc.save_for_later[coroutine.running()]
-      local ngx_ctx = saved and saved.ngx_ctx or ngx.ctx
-      return ngx_ctx[k]
-    end,
-
-    ["kong.nginx.set_ctx"] = function(k, v)
-      local saved = Rpc.save_for_later[coroutine.running()]
-      local ngx_ctx = saved and saved.ngx_ctx or ngx.ctx
-      ngx_ctx[k] = v
-    end,
-
-    ["kong.ctx.shared.get"] = function(k)
-      local saved = Rpc.save_for_later[coroutine.running()]
-      local ctx_shared = saved and saved.ctx_shared or kong.ctx.shared
-      return ctx_shared[k]
-    end,
-
-    ["kong.ctx.shared.set"] = function(k, v)
-      local saved = Rpc.save_for_later[coroutine.running()]
-      local ctx_shared = saved and saved.ctx_shared or kong.ctx.shared
-      ctx_shared[k] = v
-    end,
-
-    ["kong.nginx.req_start_time"] = ngx.req.start_time,
-
-    ["kong.request.get_query"] = function(max)
-      return fix_mmap(kong.request.get_query(max))
-    end,
-
-    ["kong.request.get_headers"] = function(max)
-      return fix_mmap(kong.request.get_headers(max))
-    end,
-
-    ["kong.response.get_status"] = function()
-      local saved = Rpc.save_for_later[coroutine.running()]
-      return saved and saved.response_status or kong.response.get_status()
-    end,
-
-    ["kong.response.get_headers"] = function(max)
-      local saved = Rpc.save_for_later[coroutine.running()]
-      local headers = saved and saved.response_headers or kong.response.get_headers(max)
-      return fix_mmap(headers)
-    end,
-
-    ["kong.response.get_header"] = function(name)
-      local saved = Rpc.save_for_later[coroutine.running()]
-      if not saved then
-        return kong.response.get_header(name)
-      end
-
-      local header_value = saved.response_headers and saved.response_headers[name]
-      if type(header_value) == "table" then
-        header_value = header_value[1]
-      end
-
-      return header_value
-    end,
-
-    ["kong.service.response.get_headers"] = function(max)
-      return fix_mmap(kong.service.response.get_headers(max))
-    end,
-
-    ["kong.response.get_source"] = function()
-      local saved = Rpc.save_for_later[coroutine.running()]
-      return kong.response.get_source(saved and saved.ngx_ctx or nil)
-    end,
-  }
-
   local method_cache = {}
 
   function get_field(method)
@@ -186,7 +106,7 @@ do
       return method_cache[method]
 
     else
-      method_cache[method] = index_table(exposed_api, method)
+      method_cache[method] = index_table(Rpc.exposed_api, method)
       return method_cache[method]
     end
   end
@@ -206,7 +126,15 @@ local function call_pdk_method(cmd, args)
   end
 
   if type(args) == "table" then
+    if must_fix[cmd] then
+      return fix_mmap(method(unpack(args)))
+    end
+
     return method(unpack(args))
+  end
+
+  if must_fix[cmd] then
+    return fix_mmap(method(args))
   end
 
   return method(args)


### PR DESCRIPTION
The `kong.response.get_XXX()` functions require data from the response
object, which is no longer accessible in the "post-log" timer used to
call Log handlers in external plugins.

This patch allows those functions to work by adding the required data to
 the set saved at the start of the "real" log phase.


Fix Kong/go-pdk#61
