### PR TITLE
chore(deps) bump prometheus plugin to 1.2.1

### DIFF
--- a/kong-2.4.0-0.rockspec
+++ b/kong-2.4.0-0.rockspec
@@ -43,7 +43,7 @@ dependencies = {
   "kong-plugin-azure-functions ~> 1.0",
   "kong-plugin-zipkin ~> 1.3",
   "kong-plugin-serverless-functions ~> 2.1",
-  "kong-prometheus-plugin ~> 1.2",
+  "kong-prometheus-plugin ~> 1.2.1",
   "kong-proxy-cache-plugin ~> 1.3",
   "kong-plugin-request-transformer ~> 1.3",
   "kong-plugin-session ~> 2.4",


### PR DESCRIPTION
This PR needs Kong/kong-plugin-prometheus#125 to
be approved and merged, the new tag for prometheus created, and a new
rockspec pushed, before it can be merged.
