### PR TITLE
fix(sandbox) fix multi level requires

### DIFF
--- a/kong/tools/sandbox.lua
+++ b/kong/tools/sandbox.lua
@@ -57,29 +57,28 @@ local lazy_conf_methods = {
            kong.configuration.untrusted_lua and
            kong.configuration.untrusted_lua == 'sandbox'
   end,
-  requires = function(self)
-    local conf_r = kong and
-                   kong.configuration and
-                   kong.configuration.untrusted_lua_sandbox_requires or {}
-    local requires = {}
-    for _, r in ipairs(conf_r) do requires[r] = true end
-    return requires
-  end,
   env_vars = function(self)
     return kong and
            kong.configuration and
            kong.configuration.untrusted_lua_sandbox_environment or {}
   end,
   environment = function(self)
+    local conf_r = kong and
+                   kong.configuration and
+                   kong.configuration.untrusted_lua_sandbox_requires or {}
+
+    local requires = {}
+    for _, r in ipairs(conf_r) do requires[r] = require(r) end
+
     local env = {
         -- home brewed require function that only requires what we consider
         -- safe :)
         ["require"] = function(m)
-          if not self.requires[m] then
+          if not requires[m] then
             error(fmt("require '%s' not allowed within sandbox", m))
           end
 
-          return require(m)
+          return requires[m]
         end,
     }
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Fixes sandbox failing to require a file that requires functions disabled by the sandbox

### Changes

* fix lazy loaded conf requires method not being loaded until already within the sandbox
* fix not being able to require code that requires code containing "dangerous" lua.

### Caveats

This will still not fix a case where a function calls any disallowed global that has not been explicitly made local on a module, but greatly reduces the issue surface.

### Issues resolved

Fix #7062 
