### PR TITLE
fix(template) fix iterator in stream shdict

### DIFF
--- a/kong/templates/nginx_kong_stream.lua
+++ b/kong/templates/nginx_kong_stream.lua
@@ -55,7 +55,7 @@ init_by_lua_block {
                 local k, v = next(shared, i)
                 i = k
                 if k and k:sub(1, #stream_shdict_prefix) == stream_shdict_prefix then
-                    k = k:sub(#stream_shdict_prefix+1)
+                    k = k:sub(#stream_shdict_prefix + 1)
                 end
                 return k, v
             end

--- a/kong/templates/nginx_kong_stream.lua
+++ b/kong/templates/nginx_kong_stream.lua
@@ -47,9 +47,21 @@ $(el.name) $(el.value);
 init_by_lua_block {
     -- shared dictionaries conflict between stream/http modules. use a prefix.
     local shared = ngx.shared
+    local stream_shdict_prefix = "stream_"
     ngx.shared = setmetatable({}, {
+        __pairs = function()
+            local i
+            return function()
+                local k, v = next(shared, i)
+                i = k
+                if k and k:sub(1, #stream_shdict_prefix) == stream_shdict_prefix then
+                    k = k:sub(#stream_shdict_prefix+1)
+                end
+                return k, v
+            end
+        end,
         __index = function(t, k)
-            return shared["stream_" .. k]
+            return shared[stream_shdict_prefix .. k]
         end,
     })
 


### PR DESCRIPTION


### Summary

`kong.pdk.node` iterrates through ngx.shared magic table to
get list of shdict metrics, implement the __pairs metamethod so
it's happy.

### Full changelog

* fix(template) fix iterrator in stream shdict

### Issues resolved

See also https://github.com/Kong/kong-plugin-prometheus/pull/118
