### PR TITLE
fix(deps) pin dependencies for lua-protobuf and remove patch pinning from prometheus-plugin

### DIFF
--- a/kong-2.4.0-0.rockspec
+++ b/kong-2.4.0-0.rockspec
@@ -43,7 +43,7 @@ dependencies = {
   "kong-plugin-azure-functions ~> 1.0",
   "kong-plugin-zipkin ~> 1.3",
   "kong-plugin-serverless-functions ~> 2.1",
-  "kong-prometheus-plugin ~> 1.2.1",
+  "kong-prometheus-plugin ~> 1.2",
   "kong-proxy-cache-plugin ~> 1.3",
   "kong-plugin-request-transformer ~> 1.3",
   "kong-plugin-session ~> 2.4",

--- a/kong-2.4.0-0.rockspec
+++ b/kong-2.4.0-0.rockspec
@@ -30,7 +30,7 @@ dependencies = {
   "luasyslog == 2.0.1",
   "lua_pack == 1.0.5",
   "lua-resty-dns-client == 6.0.0",
-  "lua-protobuf",
+  "lua-protobuf == 0.3.2",
   "lua-resty-worker-events == 1.0.0",
   "lua-resty-healthcheck == 1.4.1",
   "lua-resty-cookie == 0.1.0",


### PR DESCRIPTION
### Summary

Fixes some small dependency version pinning issues.