### PR TITLE
fix(cli) prefix argument in stop cmd takes precedence before environm…

### DIFF
--- a/kong/cmd/stop.lua
+++ b/kong/cmd/stop.lua
@@ -20,7 +20,9 @@ local function execute(args, opts)
   end
 
   -- load <PREFIX>/kong.conf containing running node's config
-  local conf = assert(conf_loader(default_conf.kong_env))
+  local conf = assert(conf_loader(default_conf.kong_env, {
+    prefix = args.prefix
+  }))
   assert(nginx_signals.stop(conf))
 
   if opts.quiet then

--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -41,6 +41,12 @@ describe("kong start/stop #" .. strategy, function()
     assert(helpers.kong_exec("start --conf " .. helpers.test_conf_path))
     assert(helpers.kong_exec("stop --prefix " .. helpers.test_conf.prefix))
   end)
+  it("stop honors custom Kong prefix higher than environment variable", function()
+    assert(helpers.kong_exec("start --conf " .. helpers.test_conf_path))
+    helpers.setenv("KONG_PREFIX", "/tmp/dne")
+    finally(function() helpers.unsetenv("KONG_PREFIX") end)
+    assert(helpers.kong_exec("stop --prefix " .. helpers.test_conf.prefix))
+  end)
   it("start/stop Kong with only stream listeners enabled", function()
     assert(helpers.kong_exec("start ", {
       prefix = helpers.test_conf.prefix,


### PR DESCRIPTION
…ent variable

In `kong start` the prefix set by CLI argument take precendence
before environment variable, but `kong stop` does not. Specially,
the following command trying to stop Kong in one directory but
start it in another so it will always fail.

```
KONG_PREFIX=/kong/prefix1 kong restart -p /kong/prefix2
```