### PR TITLE
fix(*) skip upstreams/targets events on control planes

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -171,6 +171,136 @@ local function csv(s)
 end
 
 
+local function register_balancer_events(core_cache, worker_events, cluster_events)
+  -- target updates
+
+
+  -- worker_events local handler: event received from DAO
+  worker_events.register(function(data)
+    local operation = data.operation
+    local target = data.entity
+    -- => to worker_events node handler
+    local ok, err = worker_events.post("balancer", "targets", {
+        operation = data.operation,
+        entity = data.entity,
+      })
+    if not ok then
+      log(ERR, "failed broadcasting target ",
+        operation, " to workers: ", err)
+    end
+    -- => to cluster_events handler
+    local key = fmt("%s:%s", operation, target.upstream.id)
+    ok, err = cluster_events:broadcast("balancer:targets", key)
+    if not ok then
+      log(ERR, "failed broadcasting target ", operation, " to cluster: ", err)
+    end
+  end, "crud", "targets")
+
+
+  -- worker_events node handler
+  worker_events.register(function(data)
+    local operation = data.operation
+    local target = data.entity
+
+    -- => to balancer update
+    balancer.on_target_event(operation, target)
+  end, "balancer", "targets")
+
+
+  -- cluster_events handler
+  cluster_events:subscribe("balancer:targets", function(data)
+    local operation, key = unpack(utils.split(data, ":"))
+    local entity
+    if key ~= "all" then
+      entity = {
+        upstream = { id = key },
+      }
+    else
+      entity = "all"
+    end
+    -- => to worker_events node handler
+    local ok, err = worker_events.post("balancer", "targets", {
+        operation = operation,
+        entity = entity
+      })
+    if not ok then
+      log(ERR, "failed broadcasting target ", operation, " to workers: ", err)
+    end
+  end)
+
+
+  -- manual health updates
+  cluster_events:subscribe("balancer:post_health", function(data)
+    local pattern = "([^|]+)|([^|]*)|([^|]+)|([^|]+)|([^|]+)|(.*)"
+    local hostname, ip, port, health, id, name = data:match(pattern)
+    port = tonumber(port)
+    local upstream = { id = id, name = name }
+    if ip == "" then
+      ip = nil
+    end
+    local _, err = balancer.post_health(upstream, hostname, ip, port, health == "1")
+    if err then
+      log(ERR, "failed posting health of ", name, " to workers: ", err)
+    end
+  end)
+
+
+  -- upstream updates
+
+
+  -- worker_events local handler: event received from DAO
+  worker_events.register(function(data)
+    local operation = data.operation
+    local upstream = data.entity
+    -- => to worker_events node handler
+    local ok, err = worker_events.post("balancer", "upstreams", {
+        operation = data.operation,
+        entity = data.entity,
+      })
+    if not ok then
+      log(ERR, "failed broadcasting upstream ",
+        operation, " to workers: ", err)
+    end
+    -- => to cluster_events handler
+    local key = fmt("%s:%s:%s", operation, upstream.id, upstream.name)
+    local ok, err = cluster_events:broadcast("balancer:upstreams", key)
+    if not ok then
+      log(ERR, "failed broadcasting upstream ", operation, " to cluster: ", err)
+    end
+  end, "crud", "upstreams")
+
+
+  -- worker_events node handler
+  worker_events.register(function(data)
+    local operation = data.operation
+    local upstream = data.entity
+
+    singletons.core_cache:invalidate_local("balancer:upstreams")
+    singletons.core_cache:invalidate_local("balancer:upstreams:" .. upstream.id)
+
+    -- => to balancer update
+    balancer.on_upstream_event(operation, upstream)
+  end, "balancer", "upstreams")
+
+
+  cluster_events:subscribe("balancer:upstreams", function(data)
+    local operation, id, name = unpack(utils.split(data, ":"))
+    local entity = {
+      id = id,
+      name = name,
+    }
+    -- => to worker_events node handler
+    local ok, err = worker_events.post("balancer", "upstreams", {
+        operation = operation,
+        entity = entity
+      })
+    if not ok then
+      log(ERR, "failed broadcasting upstream ", operation, " to workers: ", err)
+    end
+  end)
+end
+
+
 local function register_events()
   -- initialize local local_events hooks
   local db             = kong.db
@@ -342,137 +472,9 @@ local function register_events()
   end, "crud", "certificates")
 
 
-  if kong.configuration.role == "control_plane" then
-    return
+  if kong.configuration.role ~= "control_plane" then
+    register_balancer_events(core_cache, worker_events, cluster_events)
   end
-
-
-  -- target updates
-
-
-  -- worker_events local handler: event received from DAO
-  worker_events.register(function(data)
-    local operation = data.operation
-    local target = data.entity
-    -- => to worker_events node handler
-    local ok, err = worker_events.post("balancer", "targets", {
-        operation = data.operation,
-        entity = data.entity,
-      })
-    if not ok then
-      log(ERR, "failed broadcasting target ",
-        operation, " to workers: ", err)
-    end
-    -- => to cluster_events handler
-    local key = fmt("%s:%s", operation, target.upstream.id)
-    ok, err = cluster_events:broadcast("balancer:targets", key)
-    if not ok then
-      log(ERR, "failed broadcasting target ", operation, " to cluster: ", err)
-    end
-  end, "crud", "targets")
-
-
-  -- worker_events node handler
-  worker_events.register(function(data)
-    local operation = data.operation
-    local target = data.entity
-
-    -- => to balancer update
-    balancer.on_target_event(operation, target)
-  end, "balancer", "targets")
-
-
-  -- cluster_events handler
-  cluster_events:subscribe("balancer:targets", function(data)
-    local operation, key = unpack(utils.split(data, ":"))
-    local entity
-    if key ~= "all" then
-      entity = {
-        upstream = { id = key },
-      }
-    else
-      entity = "all"
-    end
-    -- => to worker_events node handler
-    local ok, err = worker_events.post("balancer", "targets", {
-        operation = operation,
-        entity = entity
-      })
-    if not ok then
-      log(ERR, "failed broadcasting target ", operation, " to workers: ", err)
-    end
-  end)
-
-
-  -- manual health updates
-  cluster_events:subscribe("balancer:post_health", function(data)
-    local pattern = "([^|]+)|([^|]*)|([^|]+)|([^|]+)|([^|]+)|(.*)"
-    local hostname, ip, port, health, id, name = data:match(pattern)
-    port = tonumber(port)
-    local upstream = { id = id, name = name }
-    if ip == "" then
-      ip = nil
-    end
-    local _, err = balancer.post_health(upstream, hostname, ip, port, health == "1")
-    if err then
-      log(ERR, "failed posting health of ", name, " to workers: ", err)
-    end
-  end)
-
-
-  -- upstream updates
-
-
-  -- worker_events local handler: event received from DAO
-  worker_events.register(function(data)
-    local operation = data.operation
-    local upstream = data.entity
-    -- => to worker_events node handler
-    local ok, err = worker_events.post("balancer", "upstreams", {
-        operation = data.operation,
-        entity = data.entity,
-      })
-    if not ok then
-      log(ERR, "failed broadcasting upstream ",
-        operation, " to workers: ", err)
-    end
-    -- => to cluster_events handler
-    local key = fmt("%s:%s:%s", operation, upstream.id, upstream.name)
-    local ok, err = cluster_events:broadcast("balancer:upstreams", key)
-    if not ok then
-      log(ERR, "failed broadcasting upstream ", operation, " to cluster: ", err)
-    end
-  end, "crud", "upstreams")
-
-
-  -- worker_events node handler
-  worker_events.register(function(data)
-    local operation = data.operation
-    local upstream = data.entity
-
-    singletons.core_cache:invalidate_local("balancer:upstreams")
-    singletons.core_cache:invalidate_local("balancer:upstreams:" .. upstream.id)
-
-    -- => to balancer update
-    balancer.on_upstream_event(operation, upstream)
-  end, "balancer", "upstreams")
-
-
-  cluster_events:subscribe("balancer:upstreams", function(data)
-    local operation, id, name = unpack(utils.split(data, ":"))
-    local entity = {
-      id = id,
-      name = name,
-    }
-    -- => to worker_events node handler
-    local ok, err = worker_events.post("balancer", "upstreams", {
-        operation = operation,
-        entity = entity
-      })
-    if not ok then
-      log(ERR, "failed broadcasting upstream ", operation, " to workers: ", err)
-    end
-  end)
 end
 
 

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -342,6 +342,11 @@ local function register_events()
   end, "crud", "certificates")
 
 
+  if kong.configuration.role == "control_plane" then
+    return
+  end
+
+
   -- target updates
 
 

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -81,6 +81,7 @@ local _set_update_router
 local _set_build_router
 local _set_router
 local _set_router_version
+local _register_balancer_events
 
 
 local update_lua_mem
@@ -804,6 +805,11 @@ do
   _set_router_version = function(v)
     router_version = v
   end
+
+  -- for tests only
+  _register_balancer_events = function(f)
+    register_balancer_events = f
+  end
 end
 
 
@@ -958,6 +964,7 @@ return {
   _set_update_plugins_iterator = _set_update_plugins_iterator,
   _get_updated_router = get_updated_router,
   _update_lua_mem = update_lua_mem,
+  _register_balancer_events = _register_balancer_events,
 
   init_worker = {
     before = function()

--- a/spec/01-unit/16-runloop_handler_spec.lua
+++ b/spec/01-unit/16-runloop_handler_spec.lua
@@ -182,6 +182,42 @@ describe("runloop handler", function()
       assert.equal(mock_router, handler._get_updated_router())
     end)
 
+    it("does not call register_balancer_events if role is control_plane", function()
+      setup_it_block()
+
+      kong.configuration.role = "control_plane"
+
+      local handler = require "kong.runloop.handler"
+
+      local register_balancer_events_spy = spy.new(function() end)
+
+      handler._set_router(mock_router)
+
+      handler._register_balancer_events(register_balancer_events_spy)
+
+      handler.init_worker.before()
+
+      assert.spy(register_balancer_events_spy).was_called(0)
+    end)
+
+    it("call register_balancer_events if role is data_plane", function()
+      setup_it_block()
+
+      kong.configuration.role = "data_plane"
+
+      local handler = require "kong.runloop.handler"
+
+      local register_balancer_events_spy = spy.new(function() end)
+
+      handler._set_router(mock_router)
+
+      handler._register_balancer_events(register_balancer_events_spy)
+
+      handler.init_worker.before()
+
+      assert.spy(register_balancer_events_spy).was_called(1)
+    end)
+
     it("calls build_router if router version changes and worker_consistency is strict", function()
       setup_it_block()
 


### PR DESCRIPTION
Previously, the CP could still do health checks upon CRUD upstreams and targets events. The following logs would be shown on the CPs:

```
2021/04/22 13:00:31 [warn] 99#0: *5924 [lua] balancer.lua:259: callback(): [healthchecks] balancer 5349c4d4-0deb-4528-80e1-59bbfe176452:testUps6066_01 reported health status changed to UNHEALTHY, context: ngx.timer
```

This will disable health checks and balancers completely on CPs by not creating worker/cluster events on them.