### PR TITLE
fix(proxy) the context got shared between different tls keepalive requests

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -631,6 +631,7 @@ end
 
 
 function Kong.ssl_certificate()
+  -- Note: ctx here is for a connection (not for a single request)
   local ctx = ngx.ctx
 
   kong_global.set_phase(kong, PHASES.certificate)
@@ -644,6 +645,9 @@ function Kong.ssl_certificate()
   local plugins_iterator = runloop.get_updated_plugins_iterator()
   execute_plugins_iterator(plugins_iterator, "certificate", ctx)
   runloop.certificate.after(ctx)
+
+  -- TODO: do we want to keep connection context?
+  kong.table.clear(ngx.ctx)
 end
 
 

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1058,7 +1058,7 @@ return {
     after = NOOP,
   },
   certificate = {
-    before = function(_)
+    before = function(ctx) -- Note: ctx here is for a connection (not for a single request)
       certificate.execute()
     end,
     after = NOOP,


### PR DESCRIPTION
### Summary

@dsteinkopf reported on #7054 that when executing a plugins iterator with two subsequent tls keepalive request, the wrong plugin is executed. We found out that we do pass context in ssl phase to plugin iterator and that indeed creates a connection wide structures in that context, which are then shared between different keepalive requests, and thus a wrong plugin might be executed.

This commit changes it so that we do not pass context to plugin iterator with `certificate` phase and thus it won't store data in it.

Huge thanks for @dsteinkopf for reporting this!

### Issues Resolved

Fix #7054