### PR TITLE
fix(balancer) remove the correct upstream event from queue

### DIFF
--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -92,7 +92,6 @@ local healthcheck_subscribers = {}
 -- functions forward-declarations
 local create_balancers
 local set_upstream_events_queue
-local get_upstream_events_queue
 
 local function set_balancer(upstream_id, balancer)
   local prev = balancers[upstream_id]
@@ -853,11 +852,6 @@ do
     }
   end
 
-
-  get_upstream_events_queue = function()
-    return utils.deep_copy(upstream_events_queue)
-  end
-
 end
 
 
@@ -866,10 +860,8 @@ local function update_balancer_state(premature)
     return
   end
 
-  local events_queue = get_upstream_events_queue()
-
-  for i, v in ipairs(events_queue) do
-    -- handle the oldest (first) event from the queue
+  while upstream_events_queue[1] do
+    local v = upstream_events_queue[1]
     local _, err = do_upstream_event(v.operation, v.upstream_data, v.workspaces)
     if err then
       log(CRIT, "failed handling upstream event: ", err)
@@ -877,7 +869,7 @@ local function update_balancer_state(premature)
     end
 
     -- if no err, remove the upstream event from the queue
-    table_remove(upstream_events_queue, i)
+    table_remove(upstream_events_queue, 1)
   end
 
   local frequency = kong.configuration.worker_state_update_frequency or 1


### PR DESCRIPTION
 here the `i` variable is an index to a copy of the event queue, but
 then it's used to remove the event from the original queue.  As soon as
 one item is removed, the indexes don't match and the wrong event is
 removed.

 this patch works on the first event and then removes the first item on
 each iteration.

 If an event results in an error, the loop is aborted and it's not
 removed from the queue, just as previously.  If the error is
 persistent, no other event is processed.  Consider moving failed events
 to the tail of the queue.