### PR TITLE
fix(build) Do not hardcode grpcurl version when downloading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ dependencies: bin/grpcurl
 
 bin/grpcurl:
 	@curl -s -S -L \
-		https://github.com/fullstorydev/grpcurl/releases/download/v1.8.0/grpcurl_$(GRPCURL_VERSION)_$(GRPCURL_OS)_$(MACHINE).tar.gz | tar xz -C bin;
+		https://github.com/fullstorydev/grpcurl/releases/download/v$(GRPCURL_VERSION)/grpcurl_$(GRPCURL_VERSION)_$(GRPCURL_OS)_$(MACHINE).tar.gz | tar xz -C bin;
 	@rm bin/LICENSE
 
 dev: remove install dependencies


### PR DESCRIPTION
### Summary

As soon as we want to upgrade `grpcurl` this will need to not be hardcoded

### Full changelog

* fix(build) Do not hardcode grpcurl version when downloading

### Issues resolved

N/A
