### PR TITLE
fix(core) Bumping some plugins that got missed

### DIFF
--- a/kong/plugins/hmac-auth/handler.lua
+++ b/kong/plugins/hmac-auth/handler.lua
@@ -4,7 +4,7 @@ local access = require "kong.plugins.hmac-auth.access"
 
 local HMACAuthHandler = {
   PRIORITY = 1000,
-  VERSION = "2.2.1",
+  VERSION = "2.3.0",
 }
 
 

--- a/kong/plugins/syslog/handler.lua
+++ b/kong/plugins/syslog/handler.lua
@@ -85,7 +85,7 @@ end
 
 local SysLogHandler = {
   PRIORITY = 4,
-  VERSION = "2.1.0",
+  VERSION = "2.2.0",
 }
 
 


### PR DESCRIPTION
### Summary

These plugins should have been bumped in the listed PRs but were missed.

hmac-auth:
https://github.com/Kong/kong/pull/7037
New feature, minor version bump

syslog:
https://github.com/Kong/kong/pull/6081
New feature, minor version bump

### Full changelog

* Bumped hmac-auth plugin to 2.3.0
* Bumped syslog plugin to 2.2.0

### Issues resolved

N/A
