### PR TITLE
chore(deps) bump penlight from 1.9.2 to 1.10.0

### DIFF
--- a/kong-2.4.0-0.rockspec
+++ b/kong-2.4.0-0.rockspec
@@ -15,7 +15,7 @@ dependencies = {
   "inspect == 3.1.1",
   "luasec == 1.0",
   "luasocket == 3.0-rc1",
-  "penlight == 1.9.2",
+  "penlight == 1.10.0",
   "lua-resty-http == 0.15",
   "lua-resty-jit-uuid == 0.0.7",
   "lua-ffi-zlib == 0.5",


### PR DESCRIPTION
### Summary

 - deprecate: `permute.iter`, renamed to `permute.order_iter` (removal later)
   [#360](https://github.com/lunarmodules/Penlight/pull/360)
 - deprecate: `permute.table`, renamed to `permute.order_table` (removal later)
   [#360](https://github.com/lunarmodules/Penlight/pull/360)
 - deprecate: `Date` module (removal later)
   [#367](https://github.com/lunarmodules/Penlight/pull/367)
 - feat: `permute.list_iter` to iterate over different sets of values
   [#360](https://github.com/lunarmodules/Penlight/pull/360)
 - feat: `permute.list_table` generate table with different sets of values
   [#360](https://github.com/lunarmodules/Penlight/pull/360)
 - feat: Lua 5.4 'warn' compatibility function
   [#366](https://github.com/lunarmodules/Penlight/pull/366)
 - feat: deprecation functionality `utils.raise_deprecation`
   [#361](https://github.com/lunarmodules/Penlight/pull/361)
 - feat: `utils.splitv` now takes same args as `split`
   [#373](https://github.com/lunarmodules/Penlight/pull/373)
 - fix: `dir.rmtree` failed to remove symlinks to directories
   [#365](https://github.com/lunarmodules/Penlight/pull/365)
 - fix: `pretty.write` could error out on failing metamethods (Lua 5.3+)
   [#368](https://github.com/lunarmodules/Penlight/pull/368)
 - fix: `app.parse` now correctly parses values containing '=' or ':'
   [#373](https://github.com/lunarmodules/Penlight/pull/373)
 - fix: `dir.makepath` failed to create top-level directories
   [#372](https://github.com/lunarmodules/Penlight/pull/372)
 - overhaul: `array2d` module was updated, got additional tests and several
   documentation updates
   [#377](https://github.com/lunarmodules/Penlight/pull/377)
 - feat: `aray2d` now accepts negative indices
 - feat: `array2d.row` added to align with `column`
 - fix: bad error message in `array2d.map`
 - fix: `array2d.flatten` now ensures to deliver a 'square' result if `nil` is
   encountered
 - feat: `array2d.transpose` added
 - feat: `array2d.swap_rows` and `array2d.swap_cols` now return the array
 - fix: `aray2d.range` correctly recognizes `R` column in spreadsheet format, was
   mistaken for `R1C1` format.
 - fix: `aray2d.range` correctly recognizes 2 char column in spreadsheet format
 - feat: `array2d.default_range` added (previously private)
 - feat: `array2d.set` if used with a function now passes `i,j` to the function
   in line with the `new` implementation.
 - fix: `array2d.iter` didn't properly iterate the indices
   [#376](https://github.com/lunarmodules/Penlight/issues/376)
 - feat: `array2d.columns` now returns a second value; the column index
 - feat: `array2d.rows` added to be in line with `columns`