### PR TITLE
<style>(<file log>) <add timestamp prefix before each JSON entry for Splunk index>

### DIFF
--- a/kong/plugins/file-log/handler.lua
+++ b/kong/plugins/file-log/handler.lua
@@ -40,7 +40,7 @@ local file_descriptors = {}
 -- @param `conf`     Configuration table, holds http endpoint details
 -- @param `message`  Message to be logged
 local function log(conf, message)
-  local msg = cjson.encode(message) .. "\n"
+  local msg = os.date("%Y/%m/%d %X ") .. cjson.encode(message) .. "\n"
   local fd = file_descriptors[conf.path]
 
   if fd and conf.reopen then


### PR DESCRIPTION
<BLANK LINE>
<body> add timestamp before each log entry so that Splunk can index each request&response to a event correctly
<BLANK LINE>
<footer>

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Currently, Splunk cannot index the log from file log plugin properly because each line is just a JSON without timestamp as prefix, multiple requests and responses are grouped into one event, which is not easy to search particular log. This PR is to add the timestamp prefix in the log file so that Splunk can index the log correctly, which means each entry in the file log is an event in Splunk.

### Full changelog

* Add a timestamp prefix

### Issues resolved
