### PR TITLE
fix(external-plugins): use lowercase for comparing string in error condition

### DIFF
--- a/kong/db/dao/plugins/go.lua
+++ b/kong/db/dao/plugins/go.lua
@@ -518,7 +518,7 @@ local get_plugin do
 
             local instance_id = get_instance(plugin_name, conf)
             local _, err = bridge_loop(instance_id, phase)
-            if err and string.match(err, "No plugin instance") then
+            if err and string.match(err:lower(), "no plugin instance") then
               instance_id = reset_and_get_instance(plugin_name, conf)
               bridge_loop(instance_id, phase)
             end
@@ -531,7 +531,7 @@ local get_plugin do
         plugin[phase] = function(self, conf)
           local instance_id = get_instance(plugin_name, conf)
           local _, err = bridge_loop(instance_id, phase)
-          if err and string.match(err, "No plugin instance") then
+          if err and string.match(err:lower(), "no plugin instance") then
             instance_id = reset_and_get_instance(plugin_name, conf)
             bridge_loop(instance_id, phase)
           end

--- a/kong/runloop/plugin_servers/mp_rpc.lua
+++ b/kong/runloop/plugin_servers/mp_rpc.lua
@@ -307,7 +307,7 @@ function Rpc:handle_event(plugin_name, conf, phase)
   if err then
     kong.log.err(err)
 
-    if string.match(err, "No plugin instance") then
+    if string.match(err:lower(), "no plugin instance") then
       self.reset_instance(plugin_name, conf)
       return self:handle_event(plugin_name, conf, phase)
     end

--- a/kong/runloop/plugin_servers/pb_rpc.lua
+++ b/kong/runloop/plugin_servers/pb_rpc.lua
@@ -368,7 +368,7 @@ function Rpc:handle_event(plugin_name, conf, phase)
   if not res then
     kong.log.err(err)
 
-    if string.match(err, "No plugin instance") then
+    if string.match(err:lower(), "no plugin instance") then
       self.reset_instance(plugin_name, conf)
       return self:handle_event(plugin_name, conf, phase)
     end


### PR DESCRIPTION
### Summary

When an instance_id of a plugin external changes, the plugin instance pretended to be reseted and retried in the bridge event loop again.
This was failing and none was being retried, making the call to the plugin did not happen; it was due to a typo in the comparisson.
This has been identified and tested with heavy traffic when the kong balancer is refreshed and reload into memoy cache; it was not failing with low traffic.

### Issues resolved

Fix https://github.com/Kong/kong/issues/7148
