### PR TITLE
fix(router) limit path regex to a lower backtracking limit

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -904,9 +904,10 @@
 #nginx_admin_client_body_buffer_size = 10m  # Defines the buffer size for reading
                                             # the request body on Admin API.
 
-#nginx_http_lua_regex_match_limit = 100000  # Global MATCH_LIMIT for PCRE
-                                            # bounds most degenerate cases
-                                            # to less than 2 seconds.
+#nginx_http_lua_regex_match_limit = 100000  # Global `MATCH_LIMIT` for PCRE
+                                            # regex matching. The default of `100000` should ensure
+                                            # at worst any regex Kong executes could finish within
+                                            # roughly 2 seconds.
 
 #------------------------------------------------------------------------------
 # DATASTORE

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -904,6 +904,10 @@
 #nginx_admin_client_body_buffer_size = 10m  # Defines the buffer size for reading
                                             # the request body on Admin API.
 
+#nginx_http_lua_regex_match_limit = 100000  # Global MATCH_LIMIT for PCRE
+                                            # bounds most degenerate cases
+                                            # to less than 2 seconds.
+
 #------------------------------------------------------------------------------
 # DATASTORE
 #------------------------------------------------------------------------------

--- a/kong/router.lua
+++ b/kong/router.lua
@@ -32,6 +32,7 @@ local max           = math.max
 local band          = bit.band
 local bor           = bit.bor
 
+local REGEX_PREFIX  = "(*LIMIT_MATCH=10000)"
 local SLASH         = byte("/")
 
 local ERR           = ngx.ERR
@@ -497,7 +498,7 @@ local function marshall_route(r)
           local path = normalize_regex(path)
 
           -- regex URI
-          local strip_regex  = path .. [[(?<uri_postfix>.*)]]
+          local strip_regex  = REGEX_PREFIX .. path .. [[(?<uri_postfix>.*)]]
           local has_captures = has_capturing_groups(path)
 
           local uri_t    = {

--- a/kong/router.lua
+++ b/kong/router.lua
@@ -32,6 +32,7 @@ local max           = math.max
 local band          = bit.band
 local bor           = bit.bor
 
+-- limits regex degenerate times to the low miliseconds
 local REGEX_PREFIX  = "(*LIMIT_MATCH=10000)"
 local SLASH         = byte("/")
 

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -87,6 +87,7 @@ nginx_upstream_keepalive_timeout = NONE
 nginx_http_upstream_keepalive = NONE
 nginx_http_upstream_keepalive_requests = NONE
 nginx_http_upstream_keepalive_timeout = NONE
+nginx_http_lua_regex_match_limit = 100000
 
 client_max_body_size = 0
 client_body_buffer_size = 8k


### PR DESCRIPTION
TODO:
 - come up with DoS exploits that would be stopped by this limit
 - apply similar limits to other user-input regexes
