### PR TITLE
Fix relative links in admin-api.lua

### DIFF
--- a/autodoc/admin-api/data/admin-api.lua
+++ b/autodoc/admin-api/data/admin-api.lua
@@ -47,7 +47,7 @@ return {
           This page refers to the Admin API for running Kong configured with a
           database (Postgres or Cassandra). For using the Admin API for Kong
           in DB-less mode, please refer to the
-          <a href="/{{page.kong_version}}/db-less-admin-api">Admin API for DB-less Mode</a>
+          <a href="/gateway-oss/{{page.kong_version}}/db-less-admin-api">Admin API for DB-less Mode</a>
           page.
         </div>
 
@@ -2117,14 +2117,10 @@ return {
     },
 
     footer = [[
-      [clustering]: /{{page.kong_version}}/clustering
-      [cli]: /{{page.kong_version}}/cli
-      [active]: /{{page.kong_version}}/health-checks-circuit-breakers/#active-health-checks
-      [healthchecks]: /{{page.kong_version}}/health-checks-circuit-breakers
-      [secure-admin-api]: /{{page.kong_version}}/secure-admin-api
-      [proxy-reference]: /{{page.kong_version}}/proxy
-      [db-less]: /{{page.kong_version}}/db-less-and-declarative-config
-      [admin-api]: /{{page.kong_version}}/admin-api
+      [active]: /gateway-oss/{{page.kong_version}}/health-checks-circuit-breakers/#active-health-checks
+      [healthchecks]: /gateway-oss/{{page.kong_version}}/health-checks-circuit-breakers
+      [secure-admin-api]: /gateway-oss/{{page.kong_version}}/secure-admin-api
+      [proxy-reference]: /gateway-oss/{{page.kong_version}}/proxy
     ]],
 
     general = {


### PR DESCRIPTION
### Summary

The links on the [Admin API 2.4.x page](https://docs.konghq.com/gateway-oss/2.4.x/admin-api/) were broken. I checked [another page](https://github.com/Kong/docs.konghq.com/edit/main/app/gateway-oss/2.4.x/network.md) to see how the product URL was built and then copied the same format.

I also removed link references that are not used on this page (validated by searching for `[clustering]` etc in the source)


### Full changelog

* Fix links on Admin API page
