### PR TITLE
fix(sandbox) allow string.rep in sandboxed environments

### DIFF
--- a/spec/01-unit/020-sandbox_spec.lua
+++ b/spec/01-unit/020-sandbox_spec.lua
@@ -240,6 +240,11 @@ describe("sandbox functions wrapper", function()
           _G.kong.configuration = deep_copy(base_conf)
         end)
 
+        it("has access to string.rep", function()
+          assert.same("aaa", sandbox.sandbox("return string.rep('a', 3)")())
+          assert.is_true(sandbox.sandbox("return ('a'):rep(3) == 'aaa'")())
+        end)
+
         it("has access to config.untrusted_lua_sandbox_environment", function()
           for _, m in ipairs(modules) do
             assert.same(find(m, _G), sandbox.sandbox(fmt("return %s", m))())


### PR DESCRIPTION
Reasoning: the idea behind limiting access to string.rep was
disallowing a single operation from allocating too much memory.

Given that in LuaJIT there are no debug hooks, it is trivial to
implement a loop which allocates a lot of memory on every single
iteration.

Plus, given that the `string` table was global and obtainable via any
sandboxed string, its sandboxing provoked issues on the global state.

This change accepts string.rep in sandboxed environments as a practical
compromise.

Fixes #7062
Fixes #7133