### PR TITLE
feat(dc) implement KONG_DECLARATIVE_CONFIG_STRING

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1148,6 +1148,8 @@
                                 # to the Control Plane node as a user-controlled
                                 # fallback.
 
+#declarative_config_string =    # The declarative configuration as a string
+
 #------------------------------------------------------------------------------
 # DATASTORE CACHE
 #------------------------------------------------------------------------------

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -349,7 +349,7 @@ local function parse_declarative_config(kong_config)
     return entities, nil, meta
   end
 
-  local entities, err, meta
+  local entities, err, _, meta
   if kong_config.declarative_config ~= nil then
     entities, err, _, meta = dc:parse_file(kong_config.declarative_config)
   elseif kong_config.declarative_config_string ~= nil then

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -357,8 +357,13 @@ local function parse_declarative_config(kong_config)
   end
 
   if not entities then
-    return nil, "error parsing declarative config file " ..
-                kong_config.declarative_config .. ":\n" .. err
+    if kong_config.declarative_config ~= nil then
+      return nil, "error parsing declarative config file " ..
+                  kong_config.declarative_config .. ":\n" .. err
+    elseif kong_config.declarative_config_string ~= nil then
+      return nil, "error parsing declarative string " ..
+                  kong_config.declarative_config_string .. ":\n" .. err
+    end
   end
 
   return entities, nil, meta

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -139,6 +139,7 @@ cassandra_data_centers = dc1:2,dc2:3
 cassandra_schema_consensus_timeout = 10000
 
 declarative_config = NONE
+declarative_config_string = NONE
 
 db_update_frequency = 5
 db_update_propagation = 0

--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -367,6 +367,61 @@ describe("kong start/stop #" .. strategy, function()
           return ok
         end, 10)
       end)
+      it("starts with a valid declarative config string", function()
+        local config_string = [[{
+          "_format_version": "1.1",
+          "services": [
+            {
+              "name": "my-service",
+              "url": "http://127.0.0.1:15555",
+              "routes": [{
+                "name": "example-route",
+                "hosts": ["example.test"]
+              }]
+            }
+          ]
+        }]]
+        local proxy_client
+
+        finally(function()
+          helpers.stop_kong(helpers.test_conf.prefix)
+          if proxy_client then
+            proxy_client:close()
+          end
+        end)
+
+        assert(helpers.start_kong({
+          database = "off",
+          declarative_config_string = config_string,
+          nginx_worker_processes = 100, -- stress test initialization
+          nginx_conf = "spec/fixtures/custom_nginx.template",
+        }))
+
+        helpers.wait_until(function()
+          -- get a connection, retry until kong starts
+          helpers.wait_until(function()
+            local pok
+            pok, proxy_client = pcall(helpers.proxy_client)
+            return pok
+          end, 10)
+
+          local res = assert(proxy_client:send {
+            method = "GET",
+            path = "/",
+            headers = {
+              host = "example.test",
+            }
+          })
+          local ok = res.status == 200
+
+          if proxy_client then
+            proxy_client:close()
+            proxy_client = nil
+          end
+
+          return ok
+        end, 10)
+      end)
     end)
   end
 

--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -368,19 +368,7 @@ describe("kong start/stop #" .. strategy, function()
         end, 10)
       end)
       it("starts with a valid declarative config string", function()
-        local config_string = [[{
-          "_format_version": "1.1",
-          "services": [
-            {
-              "name": "my-service",
-              "url": "http://127.0.0.1:15555",
-              "routes": [{
-                "name": "example-route",
-                "hosts": ["example.test"]
-              }]
-            }
-          ]
-        }]]
+        local config_string = [[{"_format_version":"1.1","services":[{"name":"my-service","url":"http://127.0.0.1:15555","routes":[{"name":"example-route","hosts":["example.test"]}]}]}]]
         local proxy_client
 
         finally(function()
@@ -392,6 +380,7 @@ describe("kong start/stop #" .. strategy, function()
 
         assert(helpers.start_kong({
           database = "off",
+          declarative_config = nil,
           declarative_config_string = config_string,
           nginx_worker_processes = 100, -- stress test initialization
           nginx_conf = "spec/fixtures/custom_nginx.template",

--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -380,9 +380,7 @@ describe("kong start/stop #" .. strategy, function()
 
         assert(helpers.start_kong({
           database = "off",
-          declarative_config = nil,
           declarative_config_string = config_string,
-          nginx_worker_processes = 100, -- stress test initialization
           nginx_conf = "spec/fixtures/custom_nginx.template",
         }))
 

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -2571,7 +2571,7 @@ local function start_kong(env, tables, preserve_prefix, fixtures)
     nginx_conf = " --nginx-conf " .. env.nginx_conf
   end
 
-  if dcbp and not env.declarative_config then
+  if dcbp and not env.declarative_config and not env.declarative_config_string then
     if not config_yml then
       config_yml = prefix .. "/config.yml"
       local cfg = dcbp.done()


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Exploring the idea of passing declarative config as a string, rather than mounting in a file.

### Full changelog

* add new env var
* add condition to parse as string rather than file
* add error handling

### Discussion

https://github.com/Kong/kong/discussions/7344

### Testing instructions

```
docker run \
-e KONG_DATABASE=off \
-p 8000:8000 \
-v $HOME/git/kong/kong/db/declarative/init.lua:/usr/local/share/lua/5.1/kong/db/declarative/init.lua \
-e KONG_DECLARATIVE_CONFIG='{"_format_version":"1.1","services":[{"host":"mockbin.com","port":443,"protocol":"https","routes":[{"paths":["/"]}]}],"plugins":[{"name":"rate-limiting","config":{"policy":"local","limit_by":"ip","minute":3}}]}' \
kong:latest
```

```
http -b :8000/status/200
http -b :8000/status/200
http -b :8000/status/200
http -b :8000/status/200
```
should see "message": "API rate limit exceeded"