### PR TITLE
fix(workspace): do not allow reserved names

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -44,6 +44,13 @@ files["kong/hooks.lua"] = {
 }
 
 
+files["kong/db/schema/entities/workspaces.lua"] = {
+    read_globals = {
+        "table.unpack",
+    }
+}
+
+
 files["kong/plugins/ldap-auth/*.lua"] = {
     read_globals = {
         "bit.mod",

--- a/kong/db/schema/entities/workspaces.lua
+++ b/kong/db/schema/entities/workspaces.lua
@@ -1,5 +1,5 @@
 local typedefs = require "kong.db.schema.typedefs"
-
+local constants = require "kong.constants"
 
 return {
   name = "workspaces",
@@ -10,7 +10,7 @@ return {
 
   fields = {
     { id          = typedefs.uuid },
-    { name        = typedefs.utf8_name { required = true } },
+    { name        = typedefs.utf8_name { required = true, not_one_of = { table.unpack(constants.CORE_ENTITIES) }, } },
     { comment     = { type = "string" } },
     { created_at  = typedefs.auto_timestamp_s },
     { meta        = { type = "record", fields = {} } },

--- a/spec/01-unit/01-db/01-schema/15-workspaces_spec.lua
+++ b/spec/01-unit/01-db/01-schema/15-workspaces_spec.lua
@@ -27,6 +27,19 @@ describe("workspaces schema", function()
       end
     end)
 
+    it("rejects reserved names", function()
+      local core_entities = require "kong.constants".CORE_ENTITIES
+      for i = 1, #core_entities do
+        local ok, err = Workspaces:validate({
+          name = core_entities[i],
+          config = {},
+          meta = {},
+        })
+        assert.falsy(ok)
+        assert.matches("must not be one of: workspaces, consumers, certificates, services, routes, snis, upstreams, targets, plugins, tags, ca_certificates, clustering_data_planes, parameters", err.name)
+      end
+    end)
+
     -- acceptance
     it("accepts valid names", function()
       local valid_names = {


### PR DESCRIPTION
### Summary

You can create a workspace named "plugins" or "services" and nothing in the schema stops a user from doing that.  After which, Kong allows some further API interactions (POST /plugins/services is apparently valid although I couldn't find documentation on it so it may "look" like a valid workspace from within e.g. Manager but POST /plugins/consumers doesn't work (Method not allowed). It's rather hard to find the root cause for random looking issues that occur when using reserved workspace names.

### Full changelog

* Added workspace schema validation function
* Added tests

