### PR TITLE
chore(actions) remove use of KBT based build and caching for CI runs

### DIFF
--- a/.ci/setup_env_github.sh
+++ b/.ci/setup_env_github.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# set -e
+
+dep_version() {
+    grep $1 .requirements | sed -e 's/.*=//' | tr -d '\n'
+}
+
+OPENRESTY=$(dep_version RESTY_VERSION)
+LUAROCKS=$(dep_version RESTY_LUAROCKS_VERSION)
+OPENSSL=$(dep_version RESTY_OPENSSL_VERSION)
+GO_PLUGINSERVER=$(dep_version KONG_GO_PLUGINSERVER_VERSION)
+PCRE=$(dep_version RESTY_PCRE_VERSION)
+
+
+#---------
+# Download
+#---------
+
+DOWNLOAD_ROOT=${DOWNLOAD_ROOT:=/download-root}
+BUILD_TOOLS_DOWNLOAD=$GITHUB_WORKSPACE/kong-build-tools
+GO_PLUGINSERVER_DOWNLOAD=$GITHUB_WORKSPACE/go-pluginserver
+
+KONG_NGINX_MODULE_BRANCH=${KONG_NGINX_MODULE_BRANCH:=master}
+
+#--------
+# Install
+#--------
+INSTALL_ROOT=${INSTALL_ROOT:=/install-cache}
+
+pushd $GO_PLUGINSERVER_DOWNLOAD
+  go get ./...
+  make
+
+  mkdir -p $INSTALL_ROOT/go-pluginserver
+  cp go-pluginserver $INSTALL_ROOT/go-pluginserver/
+popd
+
+kong-ngx-build \
+    --work $DOWNLOAD_ROOT \
+    --prefix $INSTALL_ROOT \
+    --openresty $OPENRESTY \
+    --kong-nginx-module $KONG_NGINX_MODULE_BRANCH \
+    --luarocks $LUAROCKS \
+    --openssl $OPENSSL \
+    --pcre $PCRE \
+    --debug
+
+OPENSSL_INSTALL=$INSTALL_ROOT/openssl
+OPENRESTY_INSTALL=$INSTALL_ROOT/openresty
+LUAROCKS_INSTALL=$INSTALL_ROOT/luarocks
+
+eval `luarocks path`
+
+nginx -V
+resty -V
+luarocks --version
+openssl version

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -4,188 +4,365 @@ on: [push, pull_request]
 
 jobs:
   build:
-    name: Build
-    runs-on: ubuntu-18.04
+    name: Build dependencies
+    runs-on: ubuntu-20.04
+
+    env:
+      DOWNLOAD_ROOT: $HOME/download-root
 
     steps:
-    - name: Set env
+    - name: Set environment variables
       run: |
-          echo "KONG_SOURCE_LOCATION=$GITHUB_WORKSPACE" >> $GITHUB_ENV
-          echo "KONG_BUILD_TOOLS_LOCATION=$HOME/kong-build-tools" >> $GITHUB_ENV
-
-    - uses: azure/docker-login@v1
-      continue-on-error: true
-      with:
-        username: ${{ secrets.KONG_USERNAME }}
-        password: ${{ secrets.KONG_PASSWORD }}
-
+          echo "INSTALL_ROOT=$HOME/install-root" >> $GITHUB_ENV
+          echo "DOWNLOAD_ROOT=$HOME/download-root" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$INSTALL_ROOT/openssl/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
     - name: Checkout Kong source code
       uses: actions/checkout@v2
 
-    - name: Setup Kong Build Tools
-      run: make setup-kong-build-tools
+    - name: Lookup build cache
+      uses: actions/cache@v1
+      id: cache-deps
+      with:
+        path: ${{ env.INSTALL_ROOT }}
+        key: ${{ hashFiles('.ci/setup_env_github.sh') }}-${{ hashFiles('.github/workflows/build_and_test.yml') }}-${{ hashFiles('.requirements') }}-${{ hashFiles('kong-*.rockspec') }}
 
-    - name: Build Test Image
-      run: pushd $KONG_BUILD_TOOLS_LOCATION && make kong-test-container && popd
+    - name: Checkout kong-build-tools
+      if: steps.cache-deps.outputs.cache-hit != 'true'
+      uses: actions/checkout@v2
+      with:
+        repository: Kong/kong-build-tools
+        path: kong-build-tools
+        ref: master
 
-  lint-unit-tests:
-    name: Lint & Unit
-    runs-on: ubuntu-18.04
+    - name: Checkout go-pluginserver
+      if: steps.cache-deps.outputs.cache-hit != 'true'
+      uses: actions/checkout@v2
+      with:
+        repository: Kong/go-pluginserver
+        path: go-pluginserver
+
+    - name: Add to Path
+      if: steps.cache-deps.outputs.cache-hit != 'true'
+      run: echo "$INSTALL_ROOT/openssl/bin:$INSTALL_ROOT/openresty/nginx/sbin:$INSTALL_ROOT/openresty/bin:$INSTALL_ROOT/luarocks/bin:$GITHUB_WORKSPACE/kong-build-tools/openresty-build-tools" >> $GITHUB_PATH
+
+    - name: Install packages
+      if: steps.cache-deps.outputs.cache-hit != 'true'
+      run: sudo apt update && sudo apt install libyaml-dev valgrind
+
+    - name: Build Kong dependencies
+      if: steps.cache-deps.outputs.cache-hit != 'true'
+      run: |
+          source .ci/setup_env_github.sh
+          make dev
+
+  lint-and-unit-tests:
+    name: Lint & Unit tests
+    runs-on: ubuntu-20.04
     needs: build
 
     env:
-      TEST_SUITE: unit
+      KONG_TEST_PG_DATABASE: kong
+      KONG_TEST_PG_USER: kong
+
+    services:
+      postgres:
+        image: postgres:13
+        env:
+          POSTGRES_USER: kong
+          POSTGRES_DB: kong
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 5s --health-timeout 5s --health-retries 8
 
     steps:
-    - name: Set env
+    - name: Set environment variables
       run: |
-          echo "KONG_SOURCE_LOCATION=$GITHUB_WORKSPACE" >> $GITHUB_ENV
-          echo "KONG_BUILD_TOOLS_LOCATION=$HOME/kong-build-tools" >> $GITHUB_ENV
-
-    - uses: azure/docker-login@v1
-      continue-on-error: true
-      with:
-        username: ${{ secrets.KONG_USERNAME }}
-        password: ${{ secrets.KONG_PASSWORD }}
+          echo "INSTALL_ROOT=$HOME/install-root" >> $GITHUB_ENV
+          echo "DOWNLOAD_ROOT=$HOME/download-root" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$INSTALL_ROOT/openssl/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
     - name: Checkout Kong source code
       uses: actions/checkout@v2
 
-    - name: Setup Kong Build Tools
-      run: make setup-kong-build-tools
-
-    - name: Run Tests
-      run: pushd $KONG_BUILD_TOOLS_LOCATION && make test-kong && popd
-
-  pdk:
-    name: PDK
-    runs-on: ubuntu-18.04
-    needs: build
-
-    env:
-      TEST_SUITE: pdk
-      DEBUG: 1
-
-    steps:
-    - name: Set env
-      run: |
-          echo "KONG_SOURCE_LOCATION=$GITHUB_WORKSPACE" >> $GITHUB_ENV
-          echo "KONG_BUILD_TOOLS_LOCATION=$HOME/kong-build-tools" >> $GITHUB_ENV
-
-    - uses: azure/docker-login@v1
-      continue-on-error: true
-      with:
-        username: ${{ secrets.KONG_USERNAME }}
-        password: ${{ secrets.KONG_PASSWORD }}
-
-    - name: Checkout Kong source code
+    - name: Checkout docs.konghq.com
       uses: actions/checkout@v2
-
-    - name: Setup Kong Build Tools
-      run: make setup-kong-build-tools
-
-    - name: Run Tests
-      run: pushd $KONG_BUILD_TOOLS_LOCATION && make test-kong && popd
-
-  package-and-smoke-test:
-    name: Package and smoke test Kong
-    runs-on: ubuntu-18.04
-    needs: build
-
-    steps:
-    - name: Set env
-      run: |
-          echo "KONG_SOURCE_LOCATION=$GITHUB_WORKSPACE" >> $GITHUB_ENV
-          echo "KONG_BUILD_TOOLS_LOCATION=$HOME/kong-build-tools" >> $GITHUB_ENV
-
-    - uses: azure/docker-login@v1
-      continue-on-error: true
       with:
-        username: ${{ secrets.KONG_USERNAME }}
-        password: ${{ secrets.KONG_PASSWORD }}
+        repository: Kong/docs.konghq.com
+        path: docs.konghq.com
 
-    - name: Checkout Kong source code
-      uses: actions/checkout@v2
-
-    - name: Setup Kong Build Tools
-      run: make setup-kong-build-tools
-
-    - name: Package Kong
-      run: pushd $HOME/kong-build-tools && make package-kong
-
-    - name: Smoke Test Kong
-      run: pushd $HOME/kong-build-tools && make test
-
-  integration-tests-dbless:
-    name: DB-less integration tests
-    runs-on: ubuntu-18.04
-    needs: build
-
-    env:
-      TEST_DATABASE: 'off'
-      TEST_SUITE: dbless
-
-    steps:
-    - name: Set env
-      run: |
-          echo "KONG_SOURCE_LOCATION=$GITHUB_WORKSPACE" >> $GITHUB_ENV
-          echo "KONG_BUILD_TOOLS_LOCATION=$HOME/kong-build-tools" >> $GITHUB_ENV
-
-    - uses: azure/docker-login@v1
-      continue-on-error: true
+    - name: Lookup build cache
+      uses: actions/cache@v1
+      id: cache-deps
       with:
-        username: ${{ secrets.KONG_USERNAME }}
-        password: ${{ secrets.KONG_PASSWORD }}
+        path: ${{ env.INSTALL_ROOT }}
+        key: ${{ hashFiles('.ci/setup_env_github.sh') }}-${{ hashFiles('.github/workflows/build_and_test.yml') }}-${{ hashFiles('.requirements') }}-${{ hashFiles('kong-*.rockspec') }}
 
-    - name: Checkout Kong source code
-      uses: actions/checkout@v2
+    - name: Add to Path
+      run: echo "$INSTALL_ROOT/openssl/bin:$INSTALL_ROOT/openresty/nginx/sbin:$INSTALL_ROOT/openresty/bin:$INSTALL_ROOT/luarocks/bin:$GITHUB_WORKSPACE/kong-build-tools/openresty-build-tools" >> $GITHUB_PATH
 
-    - name: Setup Kong Build Tools
-      run: make setup-kong-build-tools
+    - name: Check autodoc generation
+      run: |
+          eval `luarocks path`
+          scripts/autodoc
+          rm -rf docs.konghq.com
 
-    - name: Run Tests
-      run: pushd $KONG_BUILD_TOOLS_LOCATION && make test-kong && popd
+    - name: Lint Lua code
+      run: |
+          eval `luarocks path`
+          luacheck -q .
 
-  integration-tests-with-databases:
-    name: ${{matrix.database}} (${{ matrix.suite }}) ${{ matrix.split }} integration tests
-    runs-on: ubuntu-18.04
+    - name: Unit tests
+      run: |
+          eval `luarocks path`
+          bin/busted -v -o gtest spec/01-unit
+
+  integration-tests-postgres:
+    name: Postgres ${{ matrix.suite }} - ${{ matrix.split }} tests
+    runs-on: ubuntu-20.04
     needs: build
 
     strategy:
       matrix:
-        split: [first, second, all]
         suite: [integration, plugins]
-        database: [cassandra, postgres]
+        split: [all, first (01-04), second (>= 05)]
         exclude:
           - suite: plugins
-            split: first
+            split: first (01-04)
           - suite: plugins
-            split: second
+            split: second (>= 05)
           - suite: integration
             split: all
 
     env:
-      TEST_DATABASE: ${{ matrix.database }}
+      KONG_TEST_PG_DATABASE: kong
+      KONG_TEST_PG_USER: kong
+      KONG_TEST_DATABASE: postgres
       TEST_SUITE: ${{ matrix.suite }}
       TEST_SPLIT: ${{ matrix.split }}
 
-    steps:
-    - name: Set env
-      run: |
-          echo "KONG_SOURCE_LOCATION=$GITHUB_WORKSPACE" >> $GITHUB_ENV
-          echo "KONG_BUILD_TOOLS_LOCATION=$HOME/kong-build-tools" >> $GITHUB_ENV
+    services:
+      postgres:
+        image: postgres:13
+        env:
+          POSTGRES_USER: kong
+          POSTGRES_DB: kong
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 5s --health-timeout 5s --health-retries 8
 
-    - uses: azure/docker-login@v1
-      continue-on-error: true
-      with:
-        username: ${{ secrets.KONG_USERNAME }}
-        password: ${{ secrets.KONG_PASSWORD }}
+      grpcbin:
+        image: moul/grpcbin
+        ports:
+          - 15002:9000
+          - 15003:9001
+
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+        options: --entrypoint redis-server
+
+    steps:
+    - name: Set environment variables
+      run: |
+          echo "INSTALL_ROOT=$HOME/install-root" >> $GITHUB_ENV
+          echo "DOWNLOAD_ROOT=$HOME/download-root" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$INSTALL_ROOT/openssl/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
     - name: Checkout Kong source code
       uses: actions/checkout@v2
 
-    - name: Setup Kong Build Tools
-      run: make setup-kong-build-tools
+    - name: Lookup build cache
+      uses: actions/cache@v1
+      id: cache-deps
+      with:
+        path: ${{ env.INSTALL_ROOT }}
+        key: ${{ hashFiles('.ci/setup_env_github.sh') }}-${{ hashFiles('.github/workflows/build_and_test.yml') }}-${{ hashFiles('.requirements') }}-${{ hashFiles('kong-*.rockspec') }}
 
-    - name: Run Tests
-      run: pushd $KONG_BUILD_TOOLS_LOCATION && make test-kong && popd
+    - name: Add to Path
+      run: echo "$INSTALL_ROOT/openssl/bin:$INSTALL_ROOT/openresty/nginx/sbin:$INSTALL_ROOT/openresty/bin:$INSTALL_ROOT/luarocks/bin:$GITHUB_WORKSPACE/kong-build-tools/openresty-build-tools:$INSTALL_ROOT/go-pluginserver" >> $GITHUB_PATH
+
+    - name: Add gRPC test host names
+      run: |
+          echo "127.0.0.1 grpcs_1.test" | sudo tee -a /etc/hosts
+          echo "127.0.0.1 grpcs_2.test" | sudo tee -a /etc/hosts
+
+    - name: Tests
+      run: |
+          eval `luarocks path`
+          make dev
+          .ci/run_tests.sh
+
+  integration-tests-dbless:
+    name: DB-less integration tests
+    runs-on: ubuntu-20.04
+    needs: build
+
+    env:
+      KONG_TEST_PG_DATABASE: kong
+      KONG_TEST_PG_USER: kong
+      KONG_TEST_DATABASE: 'off'
+      TEST_SUITE: dbless
+
+    services:
+      grpcbin:
+        image: moul/grpcbin
+        ports:
+          - 15002:9000
+          - 15003:9001
+
+    steps:
+    - name: Set environment variables
+      run: |
+          echo "INSTALL_ROOT=$HOME/install-root" >> $GITHUB_ENV
+          echo "DOWNLOAD_ROOT=$HOME/download-root" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$INSTALL_ROOT/openssl/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+
+    - name: Checkout Kong source code
+      uses: actions/checkout@v2
+
+    - name: Lookup build cache
+      uses: actions/cache@v1
+      id: cache-deps
+      with:
+        path: ${{ env.INSTALL_ROOT }}
+        key: ${{ hashFiles('.ci/setup_env_github.sh') }}-${{ hashFiles('.github/workflows/build_and_test.yml') }}-${{ hashFiles('.requirements') }}-${{ hashFiles('kong-*.rockspec') }}
+
+    - name: Add to Path
+      run: echo "$INSTALL_ROOT/openssl/bin:$INSTALL_ROOT/openresty/nginx/sbin:$INSTALL_ROOT/openresty/bin:$INSTALL_ROOT/luarocks/bin:$GITHUB_WORKSPACE/kong-build-tools/openresty-build-tools:$INSTALL_ROOT/go-pluginserver" >> $GITHUB_PATH
+
+    - name: Add gRPC test host names
+      run: |
+          echo "127.0.0.1 grpcs_1.test" | sudo tee -a /etc/hosts
+          echo "127.0.0.1 grpcs_2.test" | sudo tee -a /etc/hosts
+
+    - name: Tests
+      run: |
+          eval `luarocks path`
+          make dev
+          .ci/run_tests.sh
+
+  integration-tests-cassandra:
+    name: C* ${{ matrix.cassandra_version }} ${{ matrix.suite }} - ${{ matrix.split }} tests
+    runs-on: ubuntu-20.04
+    needs: build
+
+    strategy:
+      matrix:
+        suite: [integration, plugins]
+        cassandra_version: [3]
+        split: [all, first (01-04), second (>= 05)]
+        exclude:
+          - suite: plugins
+            split: first (01-04)
+          - suite: plugins
+            split: second (>= 05)
+          - suite: integration
+            split: all
+
+    env:
+      KONG_TEST_DATABASE: cassandra
+      TEST_SUITE: ${{ matrix.suite }}
+      TEST_SPLIT: ${{ matrix.split }}
+
+    services:
+      cassandra:
+        image: cassandra:${{ matrix.cassandra_version }}
+        ports:
+          - 7199:7199
+          - 7000:7000
+          - 9160:9160
+          - 9042:9042
+        options: --health-cmd "cqlsh -e 'describe cluster'" --health-interval 5s --health-timeout 5s --health-retries 8
+
+      grpcbin:
+        image: moul/grpcbin
+        ports:
+          - 15002:9000
+          - 15003:9001
+
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+        options: --entrypoint redis-server
+
+    steps:
+    - name: Set environment variables
+      run: |
+          echo "INSTALL_ROOT=$HOME/install-root" >> $GITHUB_ENV
+          echo "DOWNLOAD_ROOT=$HOME/download-root" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$INSTALL_ROOT/openssl/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+
+    - name: Checkout Kong source code
+      uses: actions/checkout@v2
+
+    - name: Lookup build cache
+      uses: actions/cache@v1
+      id: cache-deps
+      with:
+        path: ${{ env.INSTALL_ROOT }}
+        key: ${{ hashFiles('.ci/setup_env_github.sh') }}-${{ hashFiles('.github/workflows/build_and_test.yml') }}-${{ hashFiles('.requirements') }}-${{ hashFiles('kong-*.rockspec') }}
+
+    - name: Add to Path
+      run: echo "$INSTALL_ROOT/openssl/bin:$INSTALL_ROOT/openresty/nginx/sbin:$INSTALL_ROOT/openresty/bin:$INSTALL_ROOT/luarocks/bin:$GITHUB_WORKSPACE/kong-build-tools/openresty-build-tools:$INSTALL_ROOT/go-pluginserver" >> $GITHUB_PATH
+
+    - name: Add gRPC test host names
+      run: |
+          echo "127.0.0.1 grpcs_1.test" | sudo tee -a /etc/hosts
+          echo "127.0.0.1 grpcs_2.test" | sudo tee -a /etc/hosts
+
+    - name: Tests
+      run: |
+          eval `luarocks path`
+          make dev
+          .ci/run_tests.sh
+
+  pdk-tests:
+    name: PDK tests
+    runs-on: ubuntu-20.04
+    needs: build
+
+    env:
+      TEST_SUITE: pdk
+
+    steps:
+    - name: Set environment variables
+      run: |
+          echo "INSTALL_ROOT=$HOME/install-root" >> $GITHUB_ENV
+          echo "DOWNLOAD_ROOT=$HOME/download-root" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$INSTALL_ROOT/openssl/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+
+    - name: Checkout Kong source code
+      uses: actions/checkout@v2
+
+    - name: Lookup build cache
+      uses: actions/cache@v1
+      id: cache-deps
+      with:
+        path: ${{ env.INSTALL_ROOT }}
+        key: ${{ hashFiles('.ci/setup_env_github.sh') }}-${{ hashFiles('.github/workflows/build_and_test.yml') }}-${{ hashFiles('.requirements') }}-${{ hashFiles('kong-*.rockspec') }}
+
+    - name: Add to Path
+      run: echo "$INSTALL_ROOT/openssl/bin:$INSTALL_ROOT/openresty/nginx/sbin:$INSTALL_ROOT/openresty/bin:$INSTALL_ROOT/luarocks/bin:$GITHUB_WORKSPACE/kong-build-tools/openresty-build-tools:$DOWNLOAD_ROOT/cpanm" >> $GITHUB_PATH
+
+    - name: Install Test::Nginx
+      run: |
+          CPAN_DOWNLOAD=$DOWNLOAD_ROOT/cpanm
+          mkdir -p $CPAN_DOWNLOAD
+          curl -o $CPAN_DOWNLOAD/cpanm https://cpanmin.us
+          chmod +x $CPAN_DOWNLOAD/cpanm
+
+          echo "Installing CPAN dependencies..."
+          cpanm --notest --local-lib=$HOME/perl5 local::lib && eval $(perl -I $HOME/perl5/lib/perl5/ -Mlocal::lib)
+          cpanm --notest Test::Nginx
+
+    - name: Tests
+      run: |
+          eval `luarocks path`
+          make dev
+
+          eval $(perl -I $HOME/perl5/lib/perl5/ -Mlocal::lib)
+          .ci/run_tests.sh

--- a/spec/02-integration/02-cmd/10-migrations_spec.lua
+++ b/spec/02-integration/02-cmd/10-migrations_spec.lua
@@ -67,7 +67,7 @@ for _, strategy in helpers.each_strategy() do
     describe("#db reset", function()
       it("cannot run non-interactively without --yes", function()
         local cmd = string.format(helpers.unindent [[
-          echo y | %s KONG_DATABASE=%s %s migrations reset --v
+          echo y | %s KONG_DATABASE=%s %s migrations reset --v -c %s
         ]], lua_path, strategy, helpers.bin_path, helpers.test_conf_path)
         local ok, code, _, stderr = pl_utils.executeex(cmd)
         assert.falsy(ok)

--- a/spec/02-integration/03-db/07-tags_spec.lua
+++ b/spec/02-integration/03-db/07-tags_spec.lua
@@ -450,11 +450,15 @@ for _, strategy in helpers.each_strategy() do
       for entity_name, dao in pairs(db.daos) do
         if dao.schema.fields.tags then
           it(entity_name, function()
+            -- note: in Postgres 13, EXECUTE FUNCTION sync_tags()
+            -- is used instead of EXECUTE PROCEDURE sync_tags().
+            -- The LIKE operator makes the test compatible with both
+            -- old and new versions of Postgres
             local res, err = db.connector:query(string.format([[
               SELECT event_manipulation
                 FROM information_schema.triggers
               WHERE event_object_table='%s'
-                AND action_statement='EXECUTE PROCEDURE sync_tags()'
+                AND action_statement LIKE 'EXECUTE %% sync_tags()'
                 AND action_timing='AFTER'
                 AND action_orientation='ROW';
             ]], entity_name))

--- a/spec/02-integration/03-db/09-query-semaphore_spec.lua
+++ b/spec/02-integration/03-db/09-query-semaphore_spec.lua
@@ -1,7 +1,7 @@
 local helpers = require "spec.helpers"
 local cjson = require "cjson"
 
-describe("Postgres query locks", function()
+describe("#postgres Postgres query locks", function()
   local client
 
   setup(function()

--- a/spec/02-integration/05-proxy/25-upstream_keepalive_spec.lua
+++ b/spec/02-integration/05-proxy/25-upstream_keepalive_spec.lua
@@ -25,7 +25,7 @@ local fixtures = {
 }
 
 
-describe("upstream keepalive", function()
+describe("#postgres upstream keepalive", function()
   local proxy_client
 
   local function start_kong(opts)

--- a/spec/02-integration/10-go_plugins/01-reports_spec.lua
+++ b/spec/02-integration/10-go_plugins/01-reports_spec.lua
@@ -2,6 +2,8 @@ local helpers = require "spec.helpers"
 local constants = require "kong.constants"
 local cjson = require "cjson"
 local pl_file = require "pl.file"
+local pl_utils = require "pl.utils"
+local pl_stringx = require "pl.stringx"
 
 for _, strategy in helpers.each_strategy() do
   local admin_client
@@ -50,6 +52,9 @@ for _, strategy in helpers.each_strategy() do
         config = {}
       })
 
+      local _, _, path = pl_utils.executeex("which go-pluginserver")
+      path = pl_stringx.strip(path)
+
       assert(helpers.start_kong({
         nginx_conf = "spec/fixtures/custom_nginx.template",
         database = strategy,
@@ -57,8 +62,8 @@ for _, strategy in helpers.each_strategy() do
         plugins = "bundled,reports-api,go-hello",
         pluginserver_names = "test",
         pluginserver_test_socket = "/tmp/go_pluginserver.sock",
-        pluginserver_test_query_cmd = "go-pluginserver -plugins-directory " .. helpers.go_plugin_path .. " -dump-all-plugins",
-        pluginserver_test_start_cmd = "go-pluginserver -plugins-directory " .. helpers.go_plugin_path .. " -kong-prefix /tmp",
+        pluginserver_test_query_cmd = path .. " -plugins-directory " .. helpers.go_plugin_path .. " -dump-all-plugins",
+        pluginserver_test_start_cmd = path .. " -plugins-directory " .. helpers.go_plugin_path .. " -kong-prefix /tmp",
         anonymous_reports = true,
       }))
 


### PR DESCRIPTION
Couple of test cases needs to be fixed in order to run correctly. This is because KBT spawns all the dependencies when running even in cases those dependencies are not needed. For example, even in C* and DB-less test mode, Postgres servers are still started. In Actions we only spawns the external dependencies needed for each test scenario, thus exposing those issues.