### PR TITLE
chore(ci) remove docs.konghq.com checkout since it is not needed for

### DIFF
--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -110,6 +110,6 @@ fi
 if [ "$TEST_SUITE" == "unit" ]; then
     unset KONG_TEST_NGINX_USER KONG_PG_PASSWORD KONG_TEST_PG_PASSWORD
     scripts/autodoc
-    bin/busted -v -o gtest spec/01-unit
+    bin/busted -v -o htest spec/01-unit
     make lint
 fi

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -55,8 +55,8 @@ jobs:
           source .ci/setup_env_github.sh
           make dev
 
-  lint-and-unit-tests:
-    name: Lint & Unit tests
+  lint-doc-and-unit-tests:
+    name: Lint, Doc and Unit tests
     runs-on: ubuntu-20.04
     needs: build
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -85,12 +85,6 @@ jobs:
     - name: Checkout Kong source code
       uses: actions/checkout@v2
 
-    - name: Checkout docs.konghq.com
-      uses: actions/checkout@v2
-      with:
-        repository: Kong/docs.konghq.com
-        path: docs.konghq.com
-
     - name: Lookup build cache
       uses: actions/cache@v1
       id: cache-deps
@@ -105,7 +99,6 @@ jobs:
       run: |
           eval `luarocks path`
           scripts/autodoc
-          rm -rf docs.konghq.com
 
     - name: Lint Lua code
       run: |


### PR DESCRIPTION
docs generation tests

If docs repo is not found, the `autodoc` tool still runs generation, except skips `cp`ing the output files to the `docs.konghq.com` directory.