### PR TITLE
tests(plugins_triggering_spec) reduce flakiness when reading file-log

### DIFF
--- a/spec/02-integration/05-proxy/04-plugins_triggering_spec.lua
+++ b/spec/02-integration/05-proxy/04-plugins_triggering_spec.lua
@@ -3,11 +3,49 @@ local utils = require "kong.tools.utils"
 local cjson = require "cjson"
 local pl_path = require "pl.path"
 local pl_file = require "pl.file"
-local pl_stringx = require "pl.stringx"
 
 
 local LOG_WAIT_TIMEOUT = 10
 local TEST_CONF = helpers.test_conf
+
+
+local function find_log_line(FILE_LOG_PATH, uuid, custom_check)
+  if pl_path.exists(FILE_LOG_PATH) and pl_path.getsize(FILE_LOG_PATH) > 0 then
+    local f = assert(io.open(FILE_LOG_PATH, "r"))
+    local line = f:read("*line")
+
+    while line do
+      local log_message = assert(cjson.decode(line))
+      if log_message.client_ip == "127.0.0.1" then
+        if uuid and log_message.request.headers["x-uuid"] ~= uuid then
+          goto continue
+        end
+
+        if custom_check and not custom_check(log_message) then
+          goto continue
+        end
+
+        -- found
+        f:close()
+        return log_message
+      end
+
+      ::continue::
+      line = f:read("*line")
+    end
+
+    f:close()
+  end
+
+  return false
+end
+
+
+local function wait_for_log_line(FILE_LOG_PATH, uuid, custom_check)
+  helpers.wait_until(function()
+    return find_log_line(FILE_LOG_PATH, uuid, custom_check)
+  end, LOG_WAIT_TIMEOUT)
+end
 
 
 for _, strategy in helpers.each_strategy() do
@@ -392,14 +430,7 @@ for _, strategy in helpers.each_strategy() do
         -- TEST: ensure that our logging plugin was executed and wrote
         -- something to disk.
 
-        helpers.wait_until(function()
-          return pl_path.exists(FILE_LOG_PATH) and pl_path.getsize(FILE_LOG_PATH) > 0
-        end, LOG_WAIT_TIMEOUT)
-
-        local log = pl_file.read(FILE_LOG_PATH)
-        local log_message = cjson.decode(pl_stringx.strip(log):match("%b{}"))
-        assert.equal("127.0.0.1", log_message.client_ip)
-        assert.equal(uuid, log_message.request.headers["x-uuid"])
+        wait_for_log_line(FILE_LOG_PATH, uuid)
       end)
 
       it("execute a header_filter plugin", function()
@@ -461,14 +492,7 @@ for _, strategy in helpers.each_strategy() do
         assert.matches("obtained even with error", body, nil, true)
 
         -- access phase got a chance to inject the logging plugin
-        helpers.wait_until(function()
-          return pl_path.exists(FILE_LOG_PATH) and pl_path.getsize(FILE_LOG_PATH) > 0
-        end, LOG_WAIT_TIMEOUT)
-
-        local log = pl_file.read(FILE_LOG_PATH)
-        local log_message = cjson.decode(pl_stringx.strip(log):match("%b{}"))
-        assert.equal("127.0.0.1", log_message.client_ip)
-        assert.equal(uuid, log_message.request.headers["x-uuid"])
+        wait_for_log_line(FILE_LOG_PATH, uuid)
       end)
     end)
 
@@ -569,6 +593,12 @@ for _, strategy in helpers.each_strategy() do
 
 
       lazy_setup(function()
+        if proxy_client then
+          proxy_client:close()
+        end
+
+        helpers.stop_kong()
+
         db:truncate("routes")
         db:truncate("services")
         db:truncate("consumers")
@@ -719,15 +749,7 @@ for _, strategy in helpers.each_strategy() do
         -- TEST: ensure that our logging plugin was executed and wrote
         -- something to disk.
 
-        helpers.wait_until(function()
-          return pl_path.exists(FILE_LOG_PATH)
-                 and pl_path.getsize(FILE_LOG_PATH) > 0
-        end, LOG_WAIT_TIMEOUT)
-
-        local log = pl_file.read(FILE_LOG_PATH)
-        local log_message = cjson.decode(pl_stringx.strip(log):match("%b{}"))
-        assert.equal("127.0.0.1", log_message.client_ip)
-        assert.equal(uuid, log_message.request.headers["x-uuid"])
+        wait_for_log_line(FILE_LOG_PATH, uuid)
       end)
 
 
@@ -753,18 +775,12 @@ for _, strategy in helpers.each_strategy() do
         -- TEST: ensure that our logging plugin was executed and wrote
         -- something to disk.
 
-        helpers.wait_until(function()
-          return pl_path.exists(FILE_LOG_PATH)
-                 and pl_path.getsize(FILE_LOG_PATH) > 0
-        end, LOG_WAIT_TIMEOUT)
-
-        local log = pl_file.read(FILE_LOG_PATH)
-        local log_message = cjson.decode(pl_stringx.strip(log):match("%b{}"))
-        assert.equal(uuid, log_message.request.headers["x-uuid"])
-        assert.equal("refused", log_message.request.headers.host)
-        assert.equal("POST", log_message.request.method)
-        assert.equal("bar", log_message.request.querystring.foo)
-        assert.equal("/status/200?foo=bar", log_message.upstream_uri)
+        wait_for_log_line(FILE_LOG_PATH, uuid, function(log_message)
+        return "refused" == log_message.request.headers.host
+               and "POST" == log_message.request.method
+               and "bar" == log_message.request.querystring.foo
+               and "/status/200?foo=bar" == log_message.upstream_uri
+        end)
       end)
 
 
@@ -785,15 +801,7 @@ for _, strategy in helpers.each_strategy() do
         -- TEST: ensure that our logging plugin was executed and wrote
         -- something to disk.
 
-        helpers.wait_until(function()
-          return pl_path.exists(FILE_LOG_PATH)
-                 and pl_path.getsize(FILE_LOG_PATH) > 0
-        end, LOG_WAIT_TIMEOUT)
-
-        local log = pl_file.read(FILE_LOG_PATH)
-        local log_message = cjson.decode(pl_stringx.strip(log):match("%b{}"))
-        assert.equal("127.0.0.1", log_message.client_ip)
-        assert.equal(uuid, log_message.request.headers["x-uuid"])
+        wait_for_log_line(FILE_LOG_PATH, uuid)
       end)
 
 
@@ -814,15 +822,7 @@ for _, strategy in helpers.each_strategy() do
         -- TEST: ensure that our logging plugin was executed and wrote
         -- something to disk.
 
-        helpers.wait_until(function()
-          return pl_path.exists(FILE_LOG_PATH)
-                 and pl_path.getsize(FILE_LOG_PATH) > 0
-        end, LOG_WAIT_TIMEOUT)
-
-        local log = pl_file.read(FILE_LOG_PATH)
-        local log_message = cjson.decode(pl_stringx.strip(log):match("%b{}"))
-        assert.equal("127.0.0.1", log_message.client_ip)
-        assert.equal(uuid, log_message.request.headers["x-uuid"])
+        wait_for_log_line(FILE_LOG_PATH, uuid)
       end)
 
 
@@ -848,18 +848,12 @@ for _, strategy in helpers.each_strategy() do
         -- TEST: ensure that our logging plugin was executed and wrote
         -- something to disk.
 
-        helpers.wait_until(function()
-          return pl_path.exists(FILE_LOG_PATH)
-                 and pl_path.getsize(FILE_LOG_PATH) > 0
-        end, LOG_WAIT_TIMEOUT)
-
-        local log = pl_file.read(FILE_LOG_PATH)
-        local log_message = cjson.decode(pl_stringx.strip(log):match("%b{}"))
-        assert.equal(uuid, log_message.request.headers["x-uuid"])
-        assert.equal("connect_timeout", log_message.request.headers.host)
-        assert.equal("POST", log_message.request.method)
-        assert.equal("bar", log_message.request.querystring.foo)
-        assert.equal("/status/200?foo=bar", log_message.upstream_uri)
+        wait_for_log_line(FILE_LOG_PATH, uuid, function(log_message)
+          return "connect_timeout" == log_message.request.headers.host
+                 and "POST" == log_message.request.method
+                 and "bar" == log_message.request.querystring.foo
+                 and "/status/200?foo=bar" == log_message.upstream_uri
+        end)
       end)
 
 
@@ -885,15 +879,9 @@ for _, strategy in helpers.each_strategy() do
         -- TEST: ensure that our logging plugin was executed and wrote
         -- something to disk.
 
-        helpers.wait_until(function()
-          return pl_path.exists(FILE_LOG_PATH)
-                 and pl_path.getsize(FILE_LOG_PATH) > 0
-        end, LOG_WAIT_TIMEOUT)
-
-        local log = pl_file.read(FILE_LOG_PATH)
-        local log_message = cjson.decode(pl_stringx.strip(log):match("%b{}"))
-
-        assert.equal(400, log_message.response.status)
+        wait_for_log_line(FILE_LOG_PATH, nil, function(log_message)
+          return 400 == log_message.response.status
+        end)
       end)
 
 
@@ -924,16 +912,11 @@ for _, strategy in helpers.each_strategy() do
         -- TEST: ensure that our logging plugin was executed and wrote
         -- something to disk.
 
-        helpers.wait_until(function()
-          return pl_path.exists(FILE_LOG_PATH)
-                 and pl_path.getsize(FILE_LOG_PATH) > 0
-        end, LOG_WAIT_TIMEOUT)
-
-        local log = pl_file.read(FILE_LOG_PATH)
-        local log_message = cjson.decode(pl_stringx.strip(log):match("%b{}"))
-        assert.equal("POST", log_message.request.method)
-        assert.equal("bar", log_message.request.querystring.foo)
-        assert.equal("", log_message.upstream_uri) -- no URI here since Nginx could not parse request
+        wait_for_log_line(FILE_LOG_PATH, nil, function(log_message)
+          return "POST" == log_message.request.method
+                 and "bar" == log_message.request.querystring.foo
+                 and "" == log_message.upstream_uri -- no URI here since Nginx could not parse request
+        end)
       end)
 
 
@@ -958,16 +941,10 @@ for _, strategy in helpers.each_strategy() do
         -- TEST: ensure that our logging plugin was executed and wrote
         -- something to disk.
 
-        helpers.wait_until(function()
-          return pl_path.exists(FILE_LOG_PATH)
-                 and pl_path.getsize(FILE_LOG_PATH) > 0
-        end, LOG_WAIT_TIMEOUT)
-
-        local log = pl_file.read(FILE_LOG_PATH)
-        local log_message = cjson.decode(pl_stringx.strip(log):match("%b{}"))
-
-        assert.same({}, log_message.request.headers)
-        assert.equal(414, log_message.response.status)
+        wait_for_log_line(FILE_LOG_PATH, nil, function(log_message)
+          return #log_message.request.headers == 0
+                 and 414 == log_message.response.status
+        end)
       end)
 
 
@@ -997,17 +974,12 @@ for _, strategy in helpers.each_strategy() do
         -- TEST: ensure that our logging plugin was executed and wrote
         -- something to disk.
 
-        helpers.wait_until(function()
-          return pl_path.exists(FILE_LOG_PATH)
-                 and pl_path.getsize(FILE_LOG_PATH) > 0
-        end, LOG_WAIT_TIMEOUT)
-
-        local log = pl_file.read(FILE_LOG_PATH)
-        local log_message = cjson.decode(pl_stringx.strip(log):match("%b{}"))
-        assert.equal("POST", log_message.request.method)
-        assert.equal("", log_message.upstream_uri) -- no URI here since Nginx could not parse request
-        assert.is_nil(log_message.request.headers["x-uuid"]) -- none since Nginx could not parse request
-        assert.is_nil(log_message.request.headers.host) -- none as well
+        wait_for_log_line(FILE_LOG_PATH, nil, function(log_message)
+          return "POST" == log_message.request.method
+                 and "" == log_message.upstream_uri -- no URI here since Nginx could not parse request
+                 and nil == log_message.request.headers["x-uuid"] -- none since Nginx could not parse request
+                 and nil == log_message.request.headers.host -- none as well
+        end)
       end)
 
 


### PR DESCRIPTION
outputs

The file-log plugin writes log lines asynchronously, but the current
implementation of test code incorrectly assumes the first line it
encounters from the log file always corresponds to the previous request.
This is not 100% true because log lines for other test cases may not
have been flushed yet. This will cause test failures like:

```
FAILED  spec/02-integration/05-proxy/04-plugins_triggering_spec.lua:440: Plugins triggering [#off] short-circuited requests responses.send stops plugin but runloop continues
spec/02-integration/05-proxy/04-plugins_triggering_spec.lua:471: Expected objects to be equal.
Passed in:
(nil)
Expected:
(string) '1d39b630-dd75-456d-8885-0a42c652cc0d'
```

See: https://github.com/Kong/kong/runs/2691542275 for an example of flaky run caused by this issue.

To properly look for matching test lines, we search the entire log file
(not just the first line) and use the random UUID for the request to
find the correct match.