### PR TITLE
fix(balancer) ensure existing healthchecker is stopped when processing target event

### DIFF
--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -662,6 +662,8 @@ local function on_target_event(operation, target)
     return
   end
 
+  stop_healthchecker(balancer)
+
   local new_balancer, err = create_balancer(upstream, true)
   if not new_balancer then
     return nil, err


### PR DESCRIPTION
### Summary

Ensures that existing healthchecks are stopped when processing CRUD events on targets. 

### Full changelog

* Ensure `stop_healthchecker` is called for existing balancer prior to `create_balancer`. Follows pattern from `do_upstream_event`

**Notes**:
- Haven't added tests for this. Figured I would try copy the existing test from `do_upstream_event` but it doesn't look like this is tested at present? (Was looking at https://github.com/Kong/kong/blob/2.4.1/spec/01-unit/09-balancer_spec.lua so perhaps Iäm in the wrong place?)
- Opened PR against `master`. But it seems like the branching strategy in this repo has changed somewhat since I last submitted a PR. Feel free to let me know if you want this rebased to a (release?) branch.

### Issues resolved

Fix #7406 
Fix #7407
