### PR TITLE
chore(deps) bump prometheus plugin to 1.3.0

### DIFF
--- a/kong-2.4.1-0.rockspec
+++ b/kong-2.4.1-0.rockspec
@@ -43,7 +43,7 @@ dependencies = {
   "kong-plugin-azure-functions ~> 1.0",
   "kong-plugin-zipkin ~> 1.3",
   "kong-plugin-serverless-functions ~> 2.1",
-  "kong-prometheus-plugin ~> 1.2",
+  "kong-prometheus-plugin ~> 1.3",
   "kong-proxy-cache-plugin ~> 1.3",
   "kong-plugin-request-transformer ~> 1.3",
   "kong-plugin-session ~> 2.4",


### PR DESCRIPTION
Changelog from upstream:

- Fix exporter to attach subsystem label to memory stats
  [#118](https://github.com/Kong/kong-plugin-prometheus/pull/118)
- Expose dataplane status on control plane, new metrics `data_plane_last_seen`,
  `data_plane_config_hash` and `data_plane_version_compatible` are added.
  [#98](https://github.com/Kong/kong-plugin-prometheus/pull/98)

