### PR TITLE
(discussion) var usage stats and summary

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -31,6 +31,72 @@ assert(package.loaded["resty.core"], "lua-resty-core must be loaded; make " ..
                                      "sure 'lua_load_resty_core' is not "..
                                      "disabled.")
 
+local ngx_var_orig = ngx.var
+
+
+local function read_file_and_line(traceback)
+  local t = traceback:find("\t", nil, true)
+  traceback = traceback:sub(t + 1)
+  local t = traceback:find("\t", nil, true)
+  traceback = traceback:sub(t + 1)
+  local e = traceback:find(" ", nil, true)
+  traceback = traceback:sub(1, e - 2)
+  local c = traceback:find(":", 1, true)
+  local file = traceback:sub(1, c - 1)
+  local line = tonumber(traceback:sub(c + 1))
+  return file, line
+end
+
+
+local function collect_var_usage(t, k, v, traceback)
+  local file, line = read_file_and_line(traceback)
+  local strip = require "kong.tools.utils".strip
+
+  local i = 0
+  local code
+  for l in io.lines(file) do
+    i = i + 1
+    if i == line then
+      code = strip(l)
+      break
+    end
+  end
+
+  local header = k:find("http_", 1, true) == 1
+  local info = {
+    type = t,
+    phase = ngx.get_phase(),
+    key = k,
+    value = v,
+    file = file,
+    line = line,
+    code = code,
+    header = header,
+    --traceback = traceback
+  }
+
+  local var_usage = ngx.ctx.var_usage
+  if not var_usage then
+    var_usage = {}
+  end
+
+  table.insert(var_usage, info)
+
+  ngx.ctx.var_usage = var_usage
+end
+
+ngx.var = setmetatable({}, {
+  __newindex = function(_, k, v)
+    local traceback = debug.traceback()
+    collect_var_usage("set", k, v, traceback)
+    ngx_var_orig[k] = v
+  end,
+  __index = function(_, k)
+    local traceback = debug.traceback()
+    collect_var_usage("get", k, ngx_var_orig[k], traceback)
+    return ngx_var_orig[k]
+  end
+})
 
 local constants = require "kong.constants"
 do
@@ -1248,73 +1314,73 @@ function Kong.log()
       if ctx.KONG_PREREAD_START and not ctx.KONG_PREREAD_ENDED_AT then
         ctx.KONG_PREREAD_ENDED_AT = ctx.KONG_LOG_START
         ctx.KONG_PREREAD_TIME = ctx.KONG_PREREAD_ENDED_AT -
-                                ctx.KONG_PREREAD_START
+          ctx.KONG_PREREAD_START
       end
 
       if ctx.KONG_BALANCER_START and not ctx.KONG_BALANCER_ENDED_AT then
         ctx.KONG_BALANCER_ENDED_AT = ctx.KONG_LOG_START
         ctx.KONG_BALANCER_TIME = ctx.KONG_BALANCER_ENDED_AT -
-                                 ctx.KONG_BALANCER_START
+          ctx.KONG_BALANCER_START
       end
 
       if ctx.KONG_PROXIED then
         if not ctx.KONG_PROXY_LATENCY then
           ctx.KONG_PROXY_LATENCY = ctx.KONG_LOG_START -
-                                   ctx.KONG_PROCESSING_START
+            ctx.KONG_PROCESSING_START
         end
 
       elseif not ctx.KONG_RESPONSE_LATENCY then
         ctx.KONG_RESPONSE_LATENCY = ctx.KONG_LOG_START -
-                                    ctx.KONG_PROCESSING_START
+          ctx.KONG_PROCESSING_START
       end
 
     else
       if ctx.KONG_REWRITE_START and not ctx.KONG_REWRITE_ENDED_AT then
         ctx.KONG_REWRITE_ENDED_AT = ctx.KONG_ACCESS_START or
-                                    ctx.KONG_BALANCER_START or
-                                    ctx.KONG_RESPONSE_START or
-                                    ctx.KONG_HEADER_FILTER_START or
-                                    ctx.BODY_FILTER_START or
-                                    ctx.KONG_LOG_START
+          ctx.KONG_BALANCER_START or
+          ctx.KONG_RESPONSE_START or
+          ctx.KONG_HEADER_FILTER_START or
+          ctx.BODY_FILTER_START or
+          ctx.KONG_LOG_START
         ctx.KONG_REWRITE_TIME = ctx.KONG_REWRITE_ENDED_AT -
-                                ctx.KONG_REWRITE_START
+          ctx.KONG_REWRITE_START
       end
 
       if ctx.KONG_ACCESS_START and not ctx.KONG_ACCESS_ENDED_AT then
         ctx.KONG_ACCESS_ENDED_AT = ctx.KONG_BALANCER_START or
-                                   ctx.KONG_RESPONSE_START or
-                                   ctx.KONG_HEADER_FILTER_START or
-                                   ctx.BODY_FILTER_START or
-                                   ctx.KONG_LOG_START
+          ctx.KONG_RESPONSE_START or
+          ctx.KONG_HEADER_FILTER_START or
+          ctx.BODY_FILTER_START or
+          ctx.KONG_LOG_START
         ctx.KONG_ACCESS_TIME = ctx.KONG_ACCESS_ENDED_AT -
-                               ctx.KONG_ACCESS_START
+          ctx.KONG_ACCESS_START
       end
 
       if ctx.KONG_BALANCER_START and not ctx.KONG_BALANCER_ENDED_AT then
         ctx.KONG_BALANCER_ENDED_AT = ctx.KONG_RESPONSE_START or
-                                     ctx.KONG_HEADER_FILTER_START or
-                                     ctx.BODY_FILTER_START or
-                                     ctx.KONG_LOG_START
+          ctx.KONG_HEADER_FILTER_START or
+          ctx.BODY_FILTER_START or
+          ctx.KONG_LOG_START
         ctx.KONG_BALANCER_TIME = ctx.KONG_BALANCER_ENDED_AT -
-                                 ctx.KONG_BALANCER_START
+          ctx.KONG_BALANCER_START
       end
 
       if ctx.KONG_HEADER_FILTER_START and not ctx.KONG_HEADER_FILTER_ENDED_AT then
         ctx.KONG_HEADER_FILTER_ENDED_AT = ctx.BODY_FILTER_START or
-                                          ctx.KONG_LOG_START
+          ctx.KONG_LOG_START
         ctx.KONG_HEADER_FILTER_TIME = ctx.KONG_HEADER_FILTER_ENDED_AT -
-                                      ctx.KONG_HEADER_FILTER_START
+          ctx.KONG_HEADER_FILTER_START
       end
 
       if ctx.KONG_BODY_FILTER_START and not ctx.KONG_BODY_FILTER_ENDED_AT then
         ctx.KONG_BODY_FILTER_ENDED_AT = ctx.KONG_LOG_START
         ctx.KONG_BODY_FILTER_TIME = ctx.KONG_BODY_FILTER_ENDED_AT -
-                                    ctx.KONG_BODY_FILTER_START
+          ctx.KONG_BODY_FILTER_START
       end
 
       if ctx.KONG_PROXIED and not ctx.KONG_WAITING_TIME then
         ctx.KONG_WAITING_TIME = ctx.KONG_LOG_START -
-                                (ctx.KONG_BALANCER_ENDED_AT or ctx.KONG_ACCESS_ENDED_AT)
+          (ctx.KONG_BALANCER_ENDED_AT or ctx.KONG_ACCESS_ENDED_AT)
       end
     end
   end
@@ -1326,6 +1392,59 @@ function Kong.log()
   execute_plugins_iterator(plugins_iterator, "log", ctx)
   runloop.log.after(ctx)
 
+  local usage = ngx.ctx.var_usage
+  local cjson = require "cjson.safe"
+
+  local file = io.open("var_usage_data.json", "w+")
+  file:write(cjson.encode(usage))
+  file:close()
+
+  local count = #usage
+
+  local summary = {
+    counts = {
+      headers = 0,
+      others = 0,
+      sets = 0,
+      gets = 0,
+      total = count,
+    },
+    headers = {
+    },
+    others = {
+    },
+    phases = {
+    },
+    vars = {
+    },
+    files = {
+    }
+  }
+
+  for i = 1, count do
+    local u = usage[i]
+    if u.header then
+      summary.counts.headers = summary.counts.headers + 1
+      summary.headers[u.key] = (summary.headers[u.key] or 0) + 1
+    else
+      summary.counts.others = summary.counts.others + 1
+      summary.others[u.key] = (summary.others[u.key] or 0) + 1
+    end
+
+    if u.type == "get" then
+      summary.counts.gets = (summary.counts.gets or 0) + 1
+    else
+      summary.counts.sets = (summary.counts.sets or 0) + 1
+    end
+
+    summary.phases[u.phase] = (summary.phases[u.phase] or 0) + 1
+    summary.vars[u.key] = (summary.vars[u.key] or 0) + 1
+    summary.files[u.file] = (summary.files[u.file] or 0) + 1
+  end
+
+  local file = io.open("var_usage_summary.json", "w+")
+  file:write(cjson.encode(summary))
+  file:close()
 
   -- this is not used for now, but perhaps we need it later?
   --ctx.KONG_LOG_ENDED_AT = get_now_ms()


### PR DESCRIPTION
### ngx.var usage

This PR writes two files, the summary `var_usage_summary.json` and `var_usage_data.json` then executing a proxy request to gather some `ngx.var` access statistics that currently show up on flame graphs.

##### Summary

```json
{
  "vars": {
    "ssl_server_name": 1,
    "http_connection": 1,
    "http_kong_debug": 1,
    "server_port": 1,
    "http_proxy_connection": 1,
    "kong_proxy_mode": 2,
    "upstream_scheme": 5,
    "http_proxy_authorization": 2,
    "upstream_http_connection": 1,
    "upstream_http_upgrade": 1,
    "realip_remote_addr": 1,
    "upstream_http_trailer": 1,
    "https": 1,
    "content_type": 1,
    "request_uri": 3,
    "ctx_ref": 2,
    "upstream_uri": 2,
    "http_upgrade": 1,
    "upstream_connection": 1,
    "http_x_forwarded_for": 1,
    "upstream_x_forwarded_for": 1,
    "remote_addr": 1,
    "upstream_x_forwarded_proto": 1,
    "upstream_x_forwarded_host": 1,
    "upstream_x_forwarded_port": 1,
    "upstream_x_forwarded_path": 1,
    "upstream_x_forwarded_prefix": 1,
    "scheme": 2,
    "upstream_host": 5,
    "upstream_te": 1,
    "upstream_http_proxy_authenticate": 1,
    "http_proxy": 1,
    "is_args": 1,
    "host": 1,
    "http_te": 2,
    "http_host": 1
  },
  "headers": {
    "http_connection": 1,
    "http_kong_debug": 1,
    "http_proxy": 1,
    "http_proxy_connection": 1,
    "http_upgrade": 1,
    "http_te": 2,
    "http_proxy_authorization": 2,
    "http_x_forwarded_for": 1,
    "http_host": 1
  },
  "counts": {
    "total": 52,
    "headers": 11,
    "others": 41,
    "sets": 13,
    "gets": 39
  },
  "others": {
    "ssl_server_name": 1,
    "ctx_ref": 2,
    "upstream_te": 1,
    "server_port": 1,
    "kong_proxy_mode": 2,
    "upstream_scheme": 5,
    "upstream_http_connection": 1,
    "upstream_connection": 1,
    "realip_remote_addr": 1,
    "upstream_http_trailer": 1,
    "upstream_x_forwarded_for": 1,
    "remote_addr": 1,
    "https": 1,
    "upstream_x_forwarded_host": 1,
    "upstream_x_forwarded_port": 1,
    "upstream_x_forwarded_path": 1,
    "upstream_x_forwarded_prefix": 1,
    "scheme": 2,
    "upstream_host": 5,
    "content_type": 1,
    "upstream_http_proxy_authenticate": 1,
    "request_uri": 3,
    "upstream_http_upgrade": 1,
    "is_args": 1,
    "upstream_x_forwarded_proto": 1,
    "upstream_uri": 2,
    "host": 1
  },
  "phases": {
    "header_filter": 5,
    "rewrite": 7,
    "access": 40
  },
  "files": {
    "./kong/resty/ctx.lua": 2,
    "./kong/init.lua": 2,
    "./kong/router.lua": 5,
    "./kong/runloop/handler.lua": 40,
    "./kong/runloop/balancer.lua": 3
  }
}
```

##### Data

```json
[
  {
    "header": false,
    "phase": "rewrite",
    "value": "http",
    "code": "local proxy_mode = var.kong_proxy_mode",
    "line": 781,
    "type": "get",
    "file": "./kong/init.lua",
    "key": "kong_proxy_mode"
  },
  {
    "header": false,
    "phase": "rewrite",
    "value": "",
    "code": "local ctx_ref = ngx.var.ctx_ref",
    "line": 53,
    "type": "get",
    "file": "./kong/resty/ctx.lua",
    "key": "ctx_ref"
  },
  {
    "header": false,
    "phase": "rewrite",
    "value": 2,
    "code": "ngx.var.ctx_ref = ctx_ref",
    "line": 68,
    "type": "set",
    "file": "./kong/resty/ctx.lua",
    "key": "ctx_ref"
  },
  {
    "header": false,
    "phase": "rewrite",
    "value": "on",
    "code": "local is_https = var.https == \"on\"",
    "line": 805,
    "type": "get",
    "file": "./kong/init.lua",
    "key": "https"
  },
  {
    "header": false,
    "phase": "rewrite",
    "value": "8443",
    "code": "local server_port = var.server_port",
    "line": 1114,
    "type": "get",
    "file": "./kong/runloop/handler.lua",
    "key": "server_port"
  },
  {
    "header": true,
    "phase": "rewrite",
    "code": "ctx.http_proxy_authorization = var.http_proxy_authorization",
    "line": 1119,
    "type": "get",
    "file": "./kong/runloop/handler.lua",
    "key": "http_proxy_authorization"
  },
  {
    "header": true,
    "phase": "rewrite",
    "code": "ctx.http_te                  = var.http_te",
    "line": 1120,
    "type": "get",
    "file": "./kong/runloop/handler.lua",
    "key": "http_te"
  },
  {
    "header": false,
    "phase": "access",
    "value": "/",
    "code": "local req_uri = var.request_uri",
    "line": 1822,
    "type": "get",
    "file": "./kong/router.lua",
    "key": "request_uri"
  },
  {
    "header": true,
    "phase": "access",
    "value": "kong.test",
    "code": "local req_host = var.http_host or \"\"",
    "line": 1823,
    "type": "get",
    "file": "./kong/router.lua",
    "key": "http_host"
  },
  {
    "header": false,
    "phase": "access",
    "value": "https",
    "code": "local req_scheme = var.scheme",
    "line": 1824,
    "type": "get",
    "file": "./kong/router.lua",
    "key": "scheme"
  },
  {
    "header": false,
    "phase": "access",
    "value": "localhost",
    "code": "local sni = var.ssl_server_name",
    "line": 1825,
    "type": "get",
    "file": "./kong/router.lua",
    "key": "ssl_server_name"
  },
  {
    "header": true,
    "phase": "access",
    "code": "if var.http_kong_debug then",
    "line": 1859,
    "type": "get",
    "file": "./kong/router.lua",
    "key": "http_kong_debug"
  },
  {
    "header": false,
    "phase": "access",
    "value": "https",
    "code": "local scheme         = var.scheme",
    "line": 1144,
    "type": "get",
    "file": "./kong/runloop/handler.lua",
    "key": "scheme"
  },
  {
    "header": false,
    "phase": "access",
    "value": "kong.test",
    "code": "local host           = var.host",
    "line": 1145,
    "type": "get",
    "file": "./kong/runloop/handler.lua",
    "key": "host"
  },
  {
    "header": false,
    "phase": "access",
    "code": "local content_type   = var.content_type",
    "line": 1148,
    "type": "get",
    "file": "./kong/runloop/handler.lua",
    "key": "content_type"
  },
  {
    "header": false,
    "phase": "access",
    "value": "127.0.0.1",
    "code": "local realip_remote_addr = var.realip_remote_addr",
    "line": 1154,
    "type": "get",
    "file": "./kong/runloop/handler.lua",
    "key": "realip_remote_addr"
  },
  {
    "header": false,
    "phase": "access",
    "value": "/",
    "code": "forwarded_path = var.request_uri",
    "line": 1185,
    "type": "get",
    "file": "./kong/runloop/handler.lua",
    "key": "request_uri"
  },
  {
    "header": false,
    "phase": "access",
    "value": "http",
    "code": "var.upstream_scheme = match_t.upstream_scheme -- COMPAT: pdk",
    "line": 1258,
    "type": "set",
    "file": "./kong/runloop/handler.lua",
    "key": "upstream_scheme"
  },
  {
    "header": false,
    "phase": "access",
    "value": "/anything",
    "code": "var.upstream_uri    = escape(match_t.upstream_uri)",
    "line": 1259,
    "type": "set",
    "file": "./kong/runloop/handler.lua",
    "key": "upstream_uri"
  },
  {
    "header": false,
    "phase": "access",
    "code": "var.upstream_host   = match_t.upstream_host",
    "line": 1260,
    "type": "set",
    "file": "./kong/runloop/handler.lua",
    "key": "upstream_host"
  },
  {
    "header": true,
    "phase": "access",
    "code": "local upgrade = var.http_upgrade",
    "line": 1263,
    "type": "get",
    "file": "./kong/runloop/handler.lua",
    "key": "http_upgrade"
  },
  {
    "header": false,
    "phase": "access",
    "value": "keep-alive",
    "code": "var.upstream_connection = \"keep-alive\"",
    "line": 1269,
    "type": "set",
    "file": "./kong/runloop/handler.lua",
    "key": "upstream_connection"
  },
  {
    "header": true,
    "phase": "access",
    "code": "local http_x_forwarded_for = var.http_x_forwarded_for",
    "line": 1273,
    "type": "get",
    "file": "./kong/runloop/handler.lua",
    "key": "http_x_forwarded_for"
  },
  {
    "header": false,
    "phase": "access",
    "value": "127.0.0.1",
    "code": "var.upstream_x_forwarded_for = var.remote_addr",
    "line": 1279,
    "type": "get",
    "file": "./kong/runloop/handler.lua",
    "key": "remote_addr"
  },
  {
    "header": false,
    "phase": "access",
    "value": "127.0.0.1",
    "code": "var.upstream_x_forwarded_for = var.remote_addr",
    "line": 1279,
    "type": "set",
    "file": "./kong/runloop/handler.lua",
    "key": "upstream_x_forwarded_for"
  },
  {
    "header": false,
    "phase": "access",
    "value": "https",
    "code": "var.upstream_x_forwarded_proto  = forwarded_proto",
    "line": 1282,
    "type": "set",
    "file": "./kong/runloop/handler.lua",
    "key": "upstream_x_forwarded_proto"
  },
  {
    "header": false,
    "phase": "access",
    "value": "kong.test",
    "code": "var.upstream_x_forwarded_host   = forwarded_host",
    "line": 1283,
    "type": "set",
    "file": "./kong/runloop/handler.lua",
    "key": "upstream_x_forwarded_host"
  },
  {
    "header": false,
    "phase": "access",
    "value": 8443,
    "code": "var.upstream_x_forwarded_port   = forwarded_port",
    "line": 1284,
    "type": "set",
    "file": "./kong/runloop/handler.lua",
    "key": "upstream_x_forwarded_port"
  },
  {
    "header": false,
    "phase": "access",
    "value": "/",
    "code": "var.upstream_x_forwarded_path   = forwarded_path",
    "line": 1285,
    "type": "set",
    "file": "./kong/runloop/handler.lua",
    "key": "upstream_x_forwarded_path"
  },
  {
    "header": false,
    "phase": "access",
    "code": "var.upstream_x_forwarded_prefix = forwarded_prefix",
    "line": 1286,
    "type": "set",
    "file": "./kong/runloop/handler.lua",
    "key": "upstream_x_forwarded_prefix"
  },
  {
    "header": false,
    "phase": "access",
    "value": "http",
    "code": "if service and var.kong_proxy_mode == \"http\" then",
    "line": 1291,
    "type": "get",
    "file": "./kong/runloop/handler.lua",
    "key": "kong_proxy_mode"
  },
  {
    "header": false,
    "phase": "access",
    "value": "/anything",
    "code": "local upstream_uri = var.upstream_uri",
    "line": 1319,
    "type": "get",
    "file": "./kong/runloop/handler.lua",
    "key": "upstream_uri"
  },
  {
    "header": false,
    "phase": "access",
    "value": "",
    "code": "if var.is_args == \"?\" or sub(var.request_uri, -1) == \"?\" then",
    "line": 1321,
    "type": "get",
    "file": "./kong/runloop/handler.lua",
    "key": "is_args"
  },
  {
    "header": false,
    "phase": "access",
    "value": "/",
    "code": "if var.is_args == \"?\" or sub(var.request_uri, -1) == \"?\" then",
    "line": 1321,
    "type": "get",
    "file": "./kong/runloop/handler.lua",
    "key": "request_uri"
  },
  {
    "header": false,
    "phase": "access",
    "value": "http",
    "code": "balancer_data.scheme = var.upstream_scheme -- COMPAT: pdk",
    "line": 1327,
    "type": "get",
    "file": "./kong/runloop/handler.lua",
    "key": "upstream_scheme"
  },
  {
    "header": false,
    "phase": "access",
    "code": "if var.upstream_host ~= nil and var.upstream_host ~= \"\" then",
    "line": 1334,
    "type": "get",
    "file": "./kong/runloop/handler.lua",
    "key": "upstream_host"
  },
  {
    "header": false,
    "phase": "access",
    "value": "http",
    "code": "var.upstream_scheme = balancer_data.scheme",
    "line": 1344,
    "type": "set",
    "file": "./kong/runloop/handler.lua",
    "key": "upstream_scheme"
  },
  {
    "header": false,
    "phase": "access",
    "code": "local upstream_host = var.upstream_host",
    "line": 1198,
    "type": "get",
    "file": "./kong/runloop/balancer.lua",
    "key": "upstream_host"
  },
  {
    "header": false,
    "phase": "access",
    "value": "http",
    "code": "local upstream_scheme = var.upstream_scheme",
    "line": 1204,
    "type": "get",
    "file": "./kong/runloop/balancer.lua",
    "key": "upstream_scheme"
  },
  {
    "header": false,
    "phase": "access",
    "value": "httpbin.org",
    "code": "var.upstream_host = upstream_host",
    "line": 1214,
    "type": "set",
    "file": "./kong/runloop/balancer.lua",
    "key": "upstream_host"
  },
  {
    "header": false,
    "phase": "access",
    "value": "httpbin.org",
    "code": "local upstream_host = var.upstream_host",
    "line": 1355,
    "type": "get",
    "file": "./kong/runloop/handler.lua",
    "key": "upstream_host"
  },
  {
    "header": false,
    "phase": "access",
    "value": "http",
    "code": "local upstream_scheme = var.upstream_scheme",
    "line": 1356,
    "type": "get",
    "file": "./kong/runloop/handler.lua",
    "key": "upstream_scheme"
  },
  {
    "header": true,
    "phase": "access",
    "value": "keep-alive",
    "code": "for _, header_name in csv(var.http_connection) do",
    "line": 1366,
    "type": "get",
    "file": "./kong/runloop/handler.lua",
    "key": "http_connection"
  },
  {
    "header": true,
    "phase": "access",
    "code": "for _, header_name in csv(var.http_te) do",
    "line": 1381,
    "type": "get",
    "file": "./kong/runloop/handler.lua",
    "key": "http_te"
  },
  {
    "header": true,
    "phase": "access",
    "code": "if var.http_proxy then",
    "line": 1388,
    "type": "get",
    "file": "./kong/runloop/handler.lua",
    "key": "http_proxy"
  },
  {
    "header": true,
    "phase": "access",
    "code": "if var.http_proxy_connection then",
    "line": 1392,
    "type": "get",
    "file": "./kong/runloop/handler.lua",
    "key": "http_proxy_connection"
  },
  {
    "header": true,
    "phase": "access",
    "code": "local proxy_authorization = var.http_proxy_authorization",
    "line": 1398,
    "type": "get",
    "file": "./kong/runloop/handler.lua",
    "key": "http_proxy_authorization"
  },
  {
    "header": false,
    "phase": "header_filter",
    "value": "keep-alive",
    "code": "for _, header_name in csv(var.upstream_http_connection) do",
    "line": 1416,
    "type": "get",
    "file": "./kong/runloop/handler.lua",
    "key": "upstream_http_connection"
  },
  {
    "header": false,
    "phase": "header_filter",
    "code": "local upgrade = var.upstream_http_upgrade",
    "line": 1422,
    "type": "get",
    "file": "./kong/runloop/handler.lua",
    "key": "upstream_http_upgrade"
  },
  {
    "header": false,
    "phase": "header_filter",
    "code": "if var.upstream_http_proxy_authenticate then",
    "line": 1427,
    "type": "get",
    "file": "./kong/runloop/handler.lua",
    "key": "upstream_http_proxy_authenticate"
  },
  {
    "header": false,
    "phase": "header_filter",
    "value": "",
    "code": "if var.upstream_te == \"\" and var.upstream_http_trailer then",
    "line": 1432,
    "type": "get",
    "file": "./kong/runloop/handler.lua",
    "key": "upstream_te"
  },
  {
    "header": false,
    "phase": "header_filter",
    "code": "if var.upstream_te == \"\" and var.upstream_http_trailer then",
    "line": 1432,
    "type": "get",
    "file": "./kong/runloop/handler.lua",
    "key": "upstream_http_trailer"
  }
]
```



[summary.txt](https://github.com/Kong/kong/files/6607680/summary.txt)
[data.txt](https://github.com/Kong/kong/files/6607683/data.txt)
