### PR TITLE
fix(schema) add default value for LDAP port

### DIFF
--- a/kong/plugins/ldap-auth/schema.lua
+++ b/kong/plugins/ldap-auth/schema.lua
@@ -12,7 +12,7 @@ return {
         type = "record",
         fields = {
           { ldap_host = typedefs.host({ required = true }), },
-          { ldap_port = typedefs.port({ required = true }), },
+          { ldap_port = typedefs.port({ required = true, default = 389 }), },
           { ldaps = { type = "boolean", required = true, default = false } },
           { start_tls = { type = "boolean", required = true, default = false }, },
           { verify_ldap_host = { type = "boolean", required = true, default = false }, },

--- a/spec/03-plugins/20-ldap-auth/02-schema_spec.lua
+++ b/spec/03-plugins/20-ldap-auth/02-schema_spec.lua
@@ -9,6 +9,20 @@ describe("Plugin: ldap-auth (schema)", function()
       assert.equals("'ldaps' and 'start_tls' cannot be enabled simultaneously", err.config["@entity"][1])
     end)
   end)
+
+  describe("defaults", function()
+    it("default port 389 assigned", function()
+      local ok, err = v({ldap_host = "example.com", base_dn="dc=example.com,dc=com", attribute="cn"}, schema_def)
+      assert.falsy(err)
+      assert.equals(389, ok.config["ldap_port"])
+    end)
+
+    it("default port override", function()
+      local ok, err = v({ldap_host = "example.com", ldap_port = 12345, base_dn="dc=example.com,dc=com", attribute="cn"}, schema_def)
+      assert.falsy(err)
+      assert.equals(12345, ok.config["ldap_port"])
+    end)
+  end)
 end)
 
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

LDAP Authentication [documentation](https://docs.konghq.com/hub/kong-inc/ldap-auth/#parameters) indicates a default value for the LDAP port as `389`. This corrects the default value for the `config.ldap_port` and aligns default values with those listed in the plugin documentation.

### Full changelog

* fix(schema) add default value for LDAP port


