### PR TITLE
perf(postgres): meta_schema is a read-only operation

### DIFF
--- a/kong/db/strategies/postgres/connector.lua
+++ b/kong/db/strategies/postgres/connector.lua
@@ -717,7 +717,7 @@ function _mt:schema_migrations()
     "SELECT *\n",
     "  FROM schema_meta\n",
     " WHERE key = ",  self:escape_literal("schema_meta"), ";"
-  }))
+  }), "read")
 
   if not rows then
     return nil, err


### PR DESCRIPTION
### Summary

All operations that qualify as a non-critical "read" operation are correctly hitting the postgres read-only replica. With the exception of the call to the `schema_meta` table.

### Full changelog

* Add the `read` operation keyword to route the query to a potential read-only replica
