### PR TITLE
docs(admin-api) Update protocols and name definitions

### DIFF
--- a/autodoc/admin-api/data/admin-api.lua
+++ b/autodoc/admin-api/data/admin-api.lua
@@ -810,7 +810,7 @@ return {
         },
         protocols = {
           description = [[
-            An array of the protocols this Route should allow. To allow only one protocol, send a string value. See the Route Object section for a list of accepted protocols. When set to only `"https"`,
+            An array of the protocols this Route should allow. See the [Route Object](#route-object) section for a list of accepted protocols. When set to only `"https"`,
             HTTP requests are answered with an upgrade error. When set to only `"http"`, HTTPS requests are answered with an error. 
           ]],
           examples = {

--- a/autodoc/admin-api/data/admin-api.lua
+++ b/autodoc/admin-api/data/admin-api.lua
@@ -797,7 +797,7 @@ return {
         created_at = { skip = true },
         updated_at = { skip = true },
         name = {
-          description = [[The name of the Route.]]
+          description = [[The name of the Route. Name values must be unique.]]
         },
         regex_priority = {
           description = [[
@@ -810,8 +810,8 @@ return {
         },
         protocols = {
           description = [[
-            A list of the protocols this Route should allow. When set to `["https"]`,
-            HTTP requests are answered with a request to upgrade to HTTPS.
+            An array of the protocols this Route should allow. To allow only one protocol, send a string value. See the Route Object section for a list of accepted protocols. When set to only `"https"`,
+            HTTP requests are answered with an upgrade error. When set to only `"http"`, HTTPS requests are answered with an error. 
           ]],
           examples = {
             {"http", "https"},


### PR DESCRIPTION
### Summary

Update protocols and name definitions

### Full changelog

Update protocols definition to clarify the following use cases:
* only the `HTTPS` protocol is allowed, and user sends `HTTP` request
* only the `HTTP` protocol is allowed, and user sends `HTTPS` request

Clarify that single protocol allowed should be sent as a string and not an array. 

Note that all accepted protocols are listed in the Route Object section. 

Specify that all name values must be unique. 

### Issues resolved

Fix DOCU-707
