### PR TITLE
fix(hybrid) ignore fileds that values are null

### DIFF
--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1085,6 +1085,11 @@ validate_fields = function(self, input)
       field, err = resolve_field(self, k, field, subschema)
       if field then
         _, errors[k] = self:validate_field(field, v)
+      elseif err == validation_errors.UNKNOWN and v == null and
+            kong and kong.configuration and
+            kong.configuration.role == "data_plane" then -- luacheck: ignore
+        -- extra fields with value of null in the input config are ignored
+        -- otherwise record the error
       else
         errors[k] = err
       end

--- a/spec/01-unit/01-db/01-schema/01-schema_spec.lua
+++ b/spec/01-unit/01-db/01-schema/01-schema_spec.lua
@@ -914,7 +914,28 @@ describe("schema", function()
           { f = { type = "number", required = true } }
         }
       })
-      assert.falsy(Test:validate({ k = "wat" }))
+      assert.falsy(Test:validate({ f = 1, k = "wat" }))
+    end)
+
+    it("validates on unknown fields with value of null in data plane", function()
+      local Test = Schema.new({
+        fields = {
+          { f = { type = "number", required = true } }
+        }
+      })
+      assert.falsy(Test:validate({ f = 1, k = "wat" }))
+      assert.falsy(Test:validate({ f = 1, k = ngx.null }))
+
+      _G.kong = {
+        configuration = {
+          role = "data_plane",
+        },
+      }
+
+      local ok = Test:validate({ f = 1, k = ngx.null })
+
+      _G.kong = nil
+      assert.truthy(ok)
     end)
 
     local function run_custom_check_producing_error(error)


### PR DESCRIPTION
This PR was made for the bringing forward compatibilty in DataPlane in hybrid mode.
When a new field is added in ControlPlane but the value is null (usually means it's unset), DP will ignore such
field from schema validation.

Only DataPlane will receive this behaviour. Extra fields from admin API and declarative config are still returning
errors.