### PR TITLE
tests(helpers) add forced_port to proxy_client

### DIFF
--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -805,6 +805,7 @@ end
 --- returns a pre-configured `http_client` for the Kong proxy port.
 -- @function proxy_client
 -- @param timeout (optional, number) the timeout to use
+-- @param forced_port (optional, number) if provided will override the port in
 local function proxy_client(timeout, forced_port)
   local proxy_ip = get_proxy_ip(false)
   local proxy_port = get_proxy_port(false)

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -806,6 +806,7 @@ end
 -- @function proxy_client
 -- @param timeout (optional, number) the timeout to use
 -- @param forced_port (optional, number) if provided will override the port in
+-- the Kong configuration with this port
 local function proxy_client(timeout, forced_port)
   local proxy_ip = get_proxy_ip(false)
   local proxy_port = get_proxy_port(false)

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -805,11 +805,11 @@ end
 --- returns a pre-configured `http_client` for the Kong proxy port.
 -- @function proxy_client
 -- @param timeout (optional, number) the timeout to use
-local function proxy_client(timeout)
+local function proxy_client(timeout, forced_port)
   local proxy_ip = get_proxy_ip(false)
   local proxy_port = get_proxy_port(false)
   assert(proxy_ip, "No http-proxy found in the configuration")
-  return http_client(proxy_ip, proxy_port, timeout or 60000)
+  return http_client(proxy_ip, forced_port or proxy_port, timeout or 60000)
 end
 
 


### PR DESCRIPTION
Same approach used by the admin_client helper:
https://github.com/Kong/kong/blob/2.4.1/spec/helpers.lua#L835-L845