### PR TITLE
chore(plugins) import grpc gateway

### DIFF
--- a/kong-2.4.1-0.rockspec
+++ b/kong-2.4.1-0.rockspec
@@ -50,7 +50,6 @@ dependencies = {
   "kong-plugin-aws-lambda ~> 3.5",
   "kong-plugin-acme ~> 0.2",
   "kong-plugin-grpc-web ~> 0.2",
-  "kong-plugin-grpc-gateway ~> 0.1",
 }
 build = {
   type = "builtin",
@@ -384,5 +383,9 @@ build = {
 
     ["kong.plugins.request-termination.handler"] = "kong/plugins/request-termination/handler.lua",
     ["kong.plugins.request-termination.schema"] = "kong/plugins/request-termination/schema.lua",
+
+    ["kong.plugins.grpc-gateway.deco"] = "kong/plugins/grpc-gateway/deco.lua",
+    ["kong.plugins.grpc-gateway.handler"] = "kong/plugins/grpc-gateway/handler.lua",
+    ["kong.plugins.grpc-gateway.schema"] = "kong/plugins/grpc-gateway/schema.lua",
   }
 }

--- a/kong/plugins/grpc-gateway/CHANGELOG.md
+++ b/kong/plugins/grpc-gateway/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Table of Contents
+
+- [0.1.3](#013---20210603)
+- [0.1.2](#012---20201105)
+- [0.1.1](#011---20200526)
+- [0.1.0](#010---20200521)
+
+##  [0.1.3] - 2021/06/03
+
+- Fix typo from gatewat to gateway (#16)
+- Correctly clear URI args in rewrite (#23)
+- Map grpc-status to HTTP status code (#25)
+
+##  [0.1.2] - 2020/11/05
+
+- Allows `include` directives in protoc files by adding the
+main protoc file's directory as base for non-absolute paths
+- Clear up output buffer when getting partial response (#12)
+
+##  [0.1.1] - 2020/05/26
+
+- Set priority to 998 to avoid clash with other plugins.
+- Pin lua-protobuf to 0.3
+
+##  [0.1.0] - 2020/05/21
+
+- Initial release of gRPC gateway plugin for Kong.
+
+[0.1.3]: https://github.com/Kong/kong-plugin-grpc-gateway/compare/0.1.2...0.1.3
+[0.1.2]: https://github.com/Kong/kong-plugin-grpc-gateway/compare/0.1.1...0.1.2
+[0.1.1]: https://github.com/Kong/kong-plugin-grpc-gateway/compare/0.1.0...0.1.1
+[0.1.0]

--- a/kong/plugins/grpc-gateway/README.md
+++ b/kong/plugins/grpc-gateway/README.md
@@ -1,0 +1,121 @@
+# Kong gRPC-gateway plugin
+
+A [Kong] plugin to allow access to a gRPC service via HTTP REST requests and translate requests and
+responses in a JSON format. Similar to
+[gRPC-gateway](https://github.com/grpc-ecosystem/grpc-gateway).
+
+## Description
+
+This plugin translates requests and responses between gRPC and HTTP REST.
+
+## Usage
+
+This plugin is intended to be used in a Kong route between a gRPC service and an HTTP endpoint.
+
+Sample configuration via declarative (YAML):
+
+```yaml
+_format_version: "1.1"
+services:
+- protocol: grpc
+  host: localhost
+  port: 9000
+  routes:
+  - protocols:
+    - http
+    paths:
+    - /
+    plugins:
+    - name: grpc-gateway
+      config:
+        proto: path/to/hello.proto
+```
+
+Same thing via the administation API:
+
+```bash
+$ # add the gRPC service
+$ curl -XPOST localhost:8001/services \
+  --data name=grpc \
+  --data protocol=grpc \
+  --data host=localhost \
+  --data port=9000
+
+$ # add an http route
+$ curl -XPOST localhost:8001/services/grpc/routes \
+  --data protocols=http \
+  --data name=web-service \
+  --data paths[]=/
+
+$ # add the plugin to the route
+$ curl -XPOST localhost:8001/routes/web-service/plugins \
+  --data name=grpc-gateway
+```
+
+The proto file must contain the
+[HTTP REST to gRPC mapping rule](https://github.com/googleapis/googleapis/blob/fc37c47e70b83c1cc5cc1616c9a307c4303fe789/google/api/http.proto).
+
+In the example we use the following mapping (note the `option (google.api.http) = {}` section):
+
+```protobuf
+syntax = "proto2";
+
+package hello;
+
+service HelloService {
+  rpc SayHello(HelloRequest) returns (HelloResponse) {
+    option (google.api.http) = {
+      get: "/v1/messages/{greeting}"
+      additional_bindings {
+        get: "/v1/messages/legacy/{greeting=**}"
+      }
+      post: "/v1/messages/"
+      body: "*"
+    }
+  }
+}
+
+
+// The request message containing the user's name.
+message HelloRequest {
+  string greeting = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+  string message = 1;
+}
+```
+
+In this example, we can send following requests to Kong that translates to corresponding gRPC requests:
+
+```shell
+# grpc-go/examples/features/reflection/server $ go run main.go &
+
+curl -XGET localhost:8000/v1/messages/Kong2.0
+{"message":"Hello Kong2.0"}
+
+curl -XGET localhost:8000/v1/messages/legacy/Kong2.0
+{"message":"Hello Kong2.0"}
+
+curl -XGET localhost:8000/v1/messages/legacy/Kong2.0/more/paths
+{"message":"Hello Kong2.0\/more\/paths"}
+
+curl -XPOST localhost:8000/v1/messages/Kong2.0 -d '{"greeting":"kong2.0"}'
+{"message":"Hello kong2.0"}
+```
+
+All syntax defined in [Path template syntax](https://github.com/googleapis/googleapis/blob/fc37c47e70b83c1cc5cc1616c9a307c4303fe789/google/api/http.proto#L225)
+is supported.
+
+Currently only unary requests are supported, streaming requests are not supported.
+
+## Dependencies
+
+The gRPC-gateway plugin depends on [lua-protobuf], [lua-cjson] and [lua-pack]
+
+[Kong]: https://konghq.com
+[lua-protobuf]: https://github.com/starwing/lua-protobuf
+[lua-cjson]: https://github.com/openresty/lua-cjson
+[lua-pack]: https://github.com/Kong/lua-pack
+

--- a/kong/plugins/grpc-gateway/deco.lua
+++ b/kong/plugins/grpc-gateway/deco.lua
@@ -1,0 +1,282 @@
+-- Copyright (c) Kong Inc. 2020
+
+package.loaded.lua_pack = nil   -- BUG: why?
+require "lua_pack"
+local cjson = require "cjson"
+local protoc = require "protoc"
+local pb = require "pb"
+local pl_path = require "pl.path"
+
+local setmetatable = setmetatable
+
+local bpack = string.pack         -- luacheck: ignore string
+local bunpack = string.unpack     -- luacheck: ignore string
+
+local ngx = ngx
+local re_gsub = ngx.re.gsub
+local re_match = ngx.re.match
+
+local encode_json = cjson.encode
+
+local deco = {}
+deco.__index = deco
+
+
+local function safe_access(t, ...)
+  for _, k in ipairs({...}) do
+    if t[k] then
+      t = t[k]
+    else
+      return
+    end
+  end
+  return t
+end
+
+local valid_method = {
+  get = true,
+  post = true,
+  put = true,
+  patch = true,
+  delete = true,
+}
+
+--[[
+  // ### Path template syntax
+  //
+  //     Template = "/" Segments [ Verb ] ;
+  //     Segments = Segment { "/" Segment } ;
+  //     Segment  = "*" | "**" | LITERAL | Variable ;
+  //     Variable = "{" FieldPath [ "=" Segments ] "}" ;
+  //     FieldPath = IDENT { "." IDENT } ;
+  //     Verb     = ":" LITERAL ;
+]]
+-- assume LITERAL = [-_.~0-9a-zA-Z], needs more
+local options_path_regex = [=[{([-_.~0-9a-zA-Z]+)=?((?:(?:\*|\*\*|[-_.~0-9a-zA-Z])/?)+)?}]=]
+
+local function parse_options_path(path)
+  local match_groups = {}
+  local match_group_idx = 1
+  local path_regex, _, err = re_gsub("^" .. path .. "$", options_path_regex, function(m)
+    local var = m[1]
+    local paths = m[2]
+    -- store lookup table to matched groups to variable name
+    match_groups[match_group_idx] = var
+    match_group_idx = match_group_idx + 1
+    if not paths or paths == "*" then
+      return "([^/]+)"
+    else
+      return ("(%s)"):format(
+        paths:gsub("%*%*", ".+"):gsub("%*", "[^/]+")
+      )
+    end
+  end, "jo")
+  if err then
+    return nil, nil, err
+  end
+
+  return path_regex, match_groups
+end
+
+-- parse, compile and load .proto file
+-- returns a table mapping valid request URLs to input/output types
+local _proto_info = {}
+local function get_proto_info(fname)
+  local info = _proto_info[fname]
+  if info then
+    return info
+  end
+
+  local dir, name = pl_path.splitpath(pl_path.abspath(fname))
+  local p = protoc.new()
+  p.include_imports = true
+  p:addpath(dir)
+  local parsed = p:parsefile(name)
+
+  info = {}
+
+  for _, srvc in ipairs(parsed.service) do
+    for _, mthd in ipairs(srvc.method) do
+      local options_bindings =  {
+        safe_access(mthd, "options", "options", "google.api.http"),
+        safe_access(mthd, "options", "options", "google.api.http", "additional_bindings")
+      }
+      for _, options in ipairs(options_bindings) do
+        for http_method, http_path in pairs(options) do
+          http_method = http_method:lower()
+          if valid_method[http_method] then
+            local preg, grp, err = parse_options_path(http_path)
+            if err then
+              ngx.log(ngx.ERR, "error ", err, "parsing options path ", http_path)
+            else
+              if not info[http_method] then
+                info[http_method] = {}
+              end
+              table.insert(info[http_method], {
+                regex = preg,
+                varnames = grp,
+                rewrite_path = ("/%s.%s/%s"):format(parsed.package, srvc.name, mthd.name),
+                input_type = mthd.input_type,
+                output_type = mthd.output_type,
+                body_variable = options.body,
+              })
+            end
+          end
+        end
+      end
+    end
+  end
+
+  _proto_info[fname] = info
+
+  p:loadfile(name)
+  return info
+end
+
+-- return input and output names of the method specified by the url path
+-- TODO: memoize
+local function rpc_transcode(method, path, protofile)
+  if not protofile then
+    return nil
+  end
+
+  local info = get_proto_info(protofile)
+  info = info[method]
+  if not info then
+    return nil, ("Unknown method %q"):format(method)
+  end
+  for _, endpoint in ipairs(info) do
+    local m, err = re_match(path, endpoint.regex, "jo")
+    if err then
+      return nil, ("Cannot match path %q"):format(err)
+    end
+    if m then
+      local vars = {}
+      for i, name in ipairs(endpoint.varnames) do
+        vars[name] = m[i]
+      end
+      return endpoint, vars
+    end
+  end
+  return nil, ("Unknown path %q"):format(path)
+end
+
+
+function deco.new(method, path, protofile)
+  if not protofile then
+    return nil, "transcoding requests require a .proto file defining the service"
+  end
+
+  local endpoint, vars = rpc_transcode(method, path, protofile)
+
+  if not endpoint then
+    return nil, "failed to transcode .proto file " .. vars
+  end
+
+  return setmetatable({
+    template_payload = vars,
+    endpoint = endpoint,
+    rewrite_path = endpoint.rewrite_path,
+  }, deco)
+end
+
+
+local function frame(ftype, msg)
+  return bpack("C>I", ftype, #msg) .. msg
+end
+
+local function unframe(body)
+  if not body or #body <= 5 then
+    return nil, body
+  end
+
+  local pos, ftype, sz = bunpack(body, "C>I")       -- luacheck: ignore ftype
+  local frame_end = pos + sz - 1
+  if frame_end > #body then
+    return nil, body
+  end
+
+  return body:sub(pos, frame_end), body:sub(frame_end + 1)
+end
+
+
+function deco:upstream(body)
+  --[[
+    // Note that when using `*` in the body mapping, it is not possible to
+    // have HTTP parameters, as all fields not bound by the path end in
+    // the body. This makes this option more rarely used in practice when
+    // defining REST APIs. The common usage of `*` is in custom methods
+    // which don't use the URL at all for transferring data.
+  ]]
+  -- TODO: do we allow http parameter when body is not *?
+  local payload = self.template_payload
+  local body_variable = self.endpoint.body_variable
+  if body_variable then
+    if body and #body > 0 then
+      local body_decoded = cjson.decode(body)
+      if body_variable ~= "*" then
+        --[[
+          // For HTTP methods that allow a request body, the `body` field
+          // specifies the mapping. Consider a REST update method on the
+          // message resource collection:
+        ]]
+        payload[body_variable] = body_decoded
+      elseif type(body_decoded) == "table" then
+        --[[
+          // The special name `*` can be used in the body mapping to define that
+          // every field not bound by the path template should be mapped to the
+          // request body.  This enables the following alternative definition of
+          // the update method:
+        ]]
+        for k, v in pairs(body_decoded) do
+          payload[k] = v
+        end
+      else
+        return nil, "body must be a table"
+      end
+    end
+  else
+    --[[
+      // Any fields in the request message which are not bound by the path template
+      // automatically become HTTP query parameters if there is no HTTP request body.
+    ]]--
+    -- TODO primitive type checking
+    local args, err = ngx.req.get_uri_args()
+    if not err then
+      for k, v in pairs(args) do
+        payload[k] = v
+      end
+    end
+  end
+  body = frame(0x0, pb.encode(self.endpoint.input_type, payload))
+
+  return body
+end
+
+
+function deco:downstream(chunk)
+  local body = (self.downstream_body or "") .. chunk
+
+  local out, n = {}, 1
+  local msg, body = unframe(body)
+
+  while msg do
+    msg = encode_json(pb.decode(self.endpoint.output_type, msg))
+
+    out[n] = msg
+    n = n + 1
+    msg, body = unframe(body)
+  end
+
+  self.downstream_body = body
+  chunk = table.concat(out)
+
+  return chunk
+end
+
+function deco:get_raw_downstream_body()
+  return self.downstream_body
+end
+
+
+return deco

--- a/kong/plugins/grpc-gateway/handler.lua
+++ b/kong/plugins/grpc-gateway/handler.lua
@@ -1,0 +1,134 @@
+-- Copyright (c) Kong Inc. 2020
+
+local deco = require "kong.plugins.grpc-gateway.deco"
+
+local ngx = ngx
+local kong = kong
+
+
+local ngx_arg = ngx.arg
+
+local kong_request_get_path = kong.request.get_path
+local kong_request_get_method = kong.request.get_method
+local kong_request_get_raw_body = kong.request.get_raw_body
+local kong_response_exit = kong.response.exit
+local kong_response_set_header = kong.response.set_header
+local kong_service_request_set_header = kong.service.request.set_header
+local kong_service_request_set_method = kong.service.request.set_method
+local kong_service_request_set_raw_body = kong.service.request.set_raw_body
+
+
+local grpc_gateway = {
+  PRIORITY = 998,
+  VERSION = '0.1.3',
+}
+
+--require "lua_pack"
+
+
+local CORS_HEADERS = {
+  ["Content-Type"] = "application/json",
+  ["Access-Control-Allow-Origin"] = "*",
+  ["Access-Control-Allow-Methods"] = "GET,POST,PATCH,DELETE",
+  ["Access-Control-Allow-Headers"] = "content-type", -- TODO: more headers?
+}
+
+function grpc_gateway:access(conf)
+  kong_response_set_header("Access-Control-Allow-Origin", "*")
+
+  if kong_request_get_method() == "OPTIONS" then
+    return kong_response_exit(200, "OK", CORS_HEADERS)
+  end
+
+
+  local dec, err = deco.new(kong_request_get_method():lower(),
+                            kong_request_get_path(), conf.proto)
+
+  if not dec then
+    kong.log.err(err)
+    return kong_response_exit(400, err)
+  end
+
+  kong.ctx.plugin.dec = dec
+
+  kong_service_request_set_header("Content-Type", "application/grpc")
+  kong_service_request_set_header("TE", "trailers")
+  local body, err = dec:upstream(kong_request_get_raw_body())
+  if err then
+    kong.log.err(err)
+    return kong_response_exit(400, err)
+  end
+  kong_service_request_set_raw_body(body)
+
+  ngx.req.set_uri(dec.rewrite_path)
+  -- clear any query args
+  ngx.req.set_uri_args("")
+  kong_service_request_set_method("POST")
+end
+
+
+-- https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto
+local grpc_status_map = {
+   [0] = 200, -- OK
+   [1] = 499, -- CANCELLED
+   [2] = 500, -- UNKNOWN
+   [3] = 400, -- INVALID_ARGUMENT
+   [4] = 504, -- DEADLINE_EXCEEDED
+   [5] = 404, -- NOT_FOUND
+   [6] = 409, -- ALREADY_EXISTS
+   [7] = 403, -- PERMISSION_DENIED
+  [16] = 401, -- UNAUTHENTICATED
+   [8] = 429, -- RESOURCE_EXHAUSTED
+   [9] = 400, -- FAILED_PRECONDITION
+  [10] = 409, -- ABORTED
+  [11] = 400, -- OUT_OF_RANGE
+  [12] = 500, -- UNIMPLEMENTED
+  [13] = 500, -- INTERNAL
+  [14] = 503, -- UNAVAILABLE
+  [15] = 500, -- DATA_LOSS
+}
+
+
+function grpc_gateway:header_filter(conf)
+  if kong_request_get_method() == "OPTIONS" then
+    return
+  end
+
+  local dec = kong.ctx.plugin.dec
+  if dec then
+    kong_response_set_header("Content-Type", "application/json")
+  end
+
+  local grpc_status = tonumber(ngx.header['grpc-status'])
+  if grpc_status then
+    local http_status = grpc_status_map[grpc_status]
+    if not http_status then
+      kong.log.warn("Unable to map grpc-status ", ngx.header['grpc-status'], " to HTTP status code")
+      http_status = 500
+    end
+    ngx.status = http_status
+  end
+end
+
+
+function grpc_gateway:body_filter(conf)
+  local dec = kong.ctx.plugin.dec
+  if not dec then
+    return
+  end
+
+  local ret = dec:downstream(ngx_arg[1])
+  if not ret or #ret == 0 then
+    if ngx_arg[2] then
+      -- it's eof and we still cannot decode, fall through
+      ret = deco:get_raw_downstream_body()
+    else
+      -- clear output if we cannot decode, it could be body is not complete yet
+      ret = nil
+    end
+  end
+  ngx_arg[1] = ret
+end
+
+
+return grpc_gateway

--- a/kong/plugins/grpc-gateway/kong-plugin-grpc-gateway-0.1.3-1.rockspec
+++ b/kong/plugins/grpc-gateway/kong-plugin-grpc-gateway-0.1.3-1.rockspec
@@ -1,0 +1,32 @@
+package = "kong-plugin-grpc-gateway"
+
+version = "0.1.3-1"
+
+supported_platforms = {"linux", "macosx"}
+
+source = {
+  url = "git+https://git@github.com/Kong/kong-plugin-grpc-gateway.git",
+  tag = "0.1.3",
+}
+
+description = {
+  summary = "grpc-gateway gateway for Kong.",
+  detailed = "A Kong plugin to allow access to a gRPC service via REST.",
+  homepage = "https://github.com/Kong/kong-plugin-grpc-gateway",
+  license = "MIT",
+}
+
+dependencies = {
+  "lua >= 5.1",
+  "lua-protobuf ~> 0.3",
+  "lua_pack == 1.0.5",
+}
+
+build = {
+  type = "builtin",
+  modules = {
+    ["kong.plugins.grpc-gateway.deco"] = "kong/plugins/grpc-gateway/deco.lua",
+    ["kong.plugins.grpc-gateway.handler"] = "kong/plugins/grpc-gateway/handler.lua",
+    ["kong.plugins.grpc-gateway.schema"] = "kong/plugins/grpc-gateway/schema.lua",
+  }
+}

--- a/kong/plugins/grpc-gateway/schema.lua
+++ b/kong/plugins/grpc-gateway/schema.lua
@@ -1,0 +1,17 @@
+return {
+  name = "grpc-gateway",
+  fields = {
+    { config = {
+      type = "record",
+      fields = {
+        {
+          proto = {
+            type = "string",
+            required = false,
+            default = nil,
+          },
+        },
+      },
+    }, },
+  },
+}

--- a/spec/03-plugins/28-grpc-gateway/01-proxy_spec.lua
+++ b/spec/03-plugins/28-grpc-gateway/01-proxy_spec.lua
@@ -1,0 +1,107 @@
+local cjson = require "cjson"
+local helpers = require "spec.helpers"
+
+for _, strategy in helpers.each_strategy() do
+
+  describe("gRPC-Gateway [#" .. strategy .. "]", function()
+    local proxy_client
+
+
+    lazy_setup(function()
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+      }, {
+        "grpc-gateway",
+      })
+
+      -- the sample server we used is from
+      -- https://github.com/grpc/grpc-go/tree/master/examples/features/reflection
+      -- which listens 50051 by default
+      local service1 = assert(bp.services:insert {
+        name = "grpc",
+        protocol = "grpc",
+        host = "grpcbin",
+        port = 9000,
+      })
+
+      local route1 = assert(bp.routes:insert {
+        protocols = { "http", "https" },
+        paths = { "/" },
+        service = service1,
+      })
+
+      assert(bp.plugins:insert {
+        route = route1,
+        name = "grpc-gateway",
+        config = {
+          proto = "/kong-plugin/spec/fixtures/grpc/helloworld.proto",
+        },
+      })
+
+      assert(helpers.start_kong {
+        database = strategy,
+        plugins = "bundled,grpc-gateway",
+      })
+    end)
+
+    before_each(function()
+      proxy_client = helpers.proxy_client(1000)
+    end)
+
+    lazy_teardown(function()
+      helpers.stop_kong()
+    end)
+
+    test("main entrypoint", function()
+      local res, err = proxy_client:get("/v1/messages/john_doe")
+
+      assert.equal(200, res.status)
+      assert.is_nil(err)
+
+      local body = res:read_body()
+      local data = cjson.decode(body)
+
+      assert.same({reply = "hello john_doe"}, data)
+    end)
+
+    test("additional binding", function()
+      local res, err = proxy_client:get("/v1/messages/legacy/john_doe")
+
+      assert.equal(200, res.status)
+      assert.is_nil(err)
+
+      local data = cjson.decode((res:read_body()))
+
+      assert.same({reply = "hello john_doe"}, data)
+    end)
+
+    test("removes unbound query args", function()
+      local res, err = proxy_client:get("/v1/messages/john_doe?arg1=1&arg2=2")
+
+      assert.equal(200, res.status)
+      assert.is_nil(err)
+
+      local body = res:read_body()
+      local data = cjson.decode(body)
+
+      assert.same({reply = "hello john_doe"}, data)
+    end)
+
+    test("unknown path", function()
+      local res, _ = proxy_client:get("/v1/messages/john_doe/bai")
+      assert.equal(400, res.status)
+      assert.equal("Bad Request", res.reason)
+    end)
+
+    test("transforms grpc-status to HTTP status code", function()
+      local res, _ = proxy_client:get("/v1/unknown/john_doe")
+      -- per ttps://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto
+      -- grpc-status: 12: UNIMPLEMENTED are mapped to http code 500
+      assert.equal(500, res.status)
+      assert.equal('12', res.headers['grpc-status'])
+    end)
+
+  end)
+end

--- a/spec/03-plugins/28-grpc-gateway/01-proxy_spec.lua
+++ b/spec/03-plugins/28-grpc-gateway/01-proxy_spec.lua
@@ -22,8 +22,8 @@ for _, strategy in helpers.each_strategy() do
       local service1 = assert(bp.services:insert {
         name = "grpc",
         protocol = "grpc",
-        host = "grpcbin",
-        port = 9000,
+        host = "127.0.0.1",
+        port = 15002,
       })
 
       local route1 = assert(bp.routes:insert {
@@ -36,7 +36,7 @@ for _, strategy in helpers.each_strategy() do
         route = route1,
         name = "grpc-gateway",
         config = {
-          proto = "/kong-plugin/spec/fixtures/grpc/helloworld.proto",
+          proto = "./spec/fixtures/grpc/helloworld.proto",
         },
       })
 

--- a/spec/fixtures/grpc/helloworld.proto
+++ b/spec/fixtures/grpc/helloworld.proto
@@ -1,0 +1,35 @@
+syntax = "proto3";
+
+package hello;
+
+service HelloService {
+  rpc SayHello(HelloRequest) returns (HelloResponse) {
+    option (google.api.http) = {
+      // https://github.com/googleapis/googleapis/blob/master/google/api/http.proto
+      // HTTP | gRPC
+      // -----|-----
+      // `GET /v1/messages/123456`  | `HelloRequest(greeting: "123456")`
+      get: "/v1/messages/{greeting}"
+      additional_bindings {
+        get: "/v1/messages/legacy/{greeting=**}"
+      }
+      post: "/v1/messages/"
+      body: "*"
+    }
+  };
+
+  // define a gRPC method that's not implemented in grpcbin
+  rpc UnknownMethod(HelloRequest) returns (HelloResponse) {
+    option (google.api.http) = {
+      get: "/v1/unknown/{greeting}"
+    }
+  };
+}
+
+message HelloRequest {
+  required string greeting = 1;
+}
+
+message HelloResponse {
+  required string reply = 1;
+}


### PR DESCRIPTION
As a result of an effort to improve external plugins maintainership, we are importing currently-bundled plugins into Kong's main tree. The grpc-gateway plugin used to live in [1].

Additionally to importing plugin contents, this PR also preserves the Git history. History was amended to correct commit scopes - including `grpc-gateway` in commit messages scope.

*Note*: this also fixes the current failure observed in `master` tests.

[1] https://github.com/Kong/kong-plugin-grpc-gateway