### PR TITLE
docs(autodoc) collapse declarative_admin_api.md into admin_api.md

### DIFF
--- a/autodoc/admin-api/data/admin-api.lua
+++ b/autodoc/admin-api/data/admin-api.lua
@@ -43,15 +43,7 @@ return {
   intro = {
     {
       text = [[
-        <div class="alert alert-info.blue" role="alert">
-          This page refers to the Admin API for running Kong configured with a
-          database (Postgres or Cassandra). For using the Admin API for Kong
-          in DB-less mode, please refer to the
-          <a href="/gateway-oss/{{page.kong_version}}/db-less-admin-api">Admin API for DB-less Mode</a>
-          page.
-        </div>
-
-        Kong comes with an **internal** RESTful Admin API for administration purposes.
+       {{site.base_gateway}} comes with an **internal** RESTful Admin API for administration purposes.
         Requests to the Admin API can be sent to any node in the cluster, and Kong will
         keep the configuration consistent across all nodes.
 
@@ -243,7 +235,6 @@ return {
     [healthchecks]: /{{page.kong_version}}/health-checks-circuit-breakers
     [secure-admin-api]: /{{page.kong_version}}/secure-admin-api
     [proxy-reference]: /{{page.kong_version}}/proxy
-    [db-less-admin-api]: /{{page.kong_version}}/db-less-admin-api
   ]],
 
   general = {
@@ -2127,176 +2118,23 @@ return {
   },
 
 --------------------------------------------------------------------------------
--- Overrides for DB-less mode
+-- DB-less mode
 --------------------------------------------------------------------------------
 
-  dbless = {
-
-    intro = {
-      {
-        text = [[
-          <div class="alert alert-info.blue" role="alert">
-            This page refers to the Admin API for running Kong configured without a
-            database, managing in-memory entities via declarative config.
-            For using the Admin API for Kong with a database, please refer to the
-            <a href="/{{page.kong_version}}/admin-api">Admin API for Database Mode</a> page.
-          </div>
-
-          Kong comes with an **internal** RESTful Admin API for administration purposes.
-          In [DB-less mode][db-less], this Admin API can be used to load a new declarative
-          configuration, and for inspecting the current configuration. In DB-less mode,
-          the Admin API for each Kong node functions independently, reflecting the memory state
-          of that particular Kong node. This is the case because there is no database
-          coordination between Kong nodes.
-
-          - `8001` is the default port on which the Admin API listens.
-          - `8444` is the default port for HTTPS traffic to the Admin API.
-
-          This API provides full control over Kong, so care should be taken when setting
-          up Kong environments to avoid undue public exposure of this API.
-          See [this document][secure-admin-api] for a discussion
-          of methods to secure the Admin API.
-        ]],
-      },
-      {
-        title = [[Supported Content Types]],
-        text = [[
-          The Admin API accepts 3 content types on every endpoint:
-
-          - **application/json**
-
-          Handy for complex bodies (ex: complex plugin configuration), in that case simply send
-          a JSON representation of the data you want to send. Example:
-
-          ```json
-          {
-              "config": {
-                  "limit": 10,
-                  "period": "seconds"
-              }
-          }
-          ```
-
-
-          - **application/x-www-form-urlencoded**
-
-          Simple enough for basic request bodies, you will probably use it most of the time.
-          Note that when sending nested values, Kong expects nested objects to be referenced
-          with dotted keys. Example:
-
-          ```
-          config.limit=10&config.period=seconds
-          ```
-
-
-          - **multipart/form-data**
-
-          Similar to URL-encoded, this content type uses dotted keys to reference nested objects.
-          Here is an example of sending a Lua file to the pre-function Kong plugin:
-
-          ```
-          curl -i -X POST http://localhost:8001/services/plugin-testing/plugins \
-               -F "name=pre-function" \
-               -F "config.functions=@custom-auth.lua"
-          ```
-        ]],
-      },
+  dbless_entities_methods = {
+    -- in DB-less mode, only document GET endpoints for entities
+    ["GET"] = true,
+    ["POST"] = false,
+    ["PATCH"] = false,
+    ["PUT"] = false,
+    ["DELETE"] = false,
+    -- exceptions for the healthcheck endpoints:
+    ["/upstreams/:upstreams/targets/:targets/healthy"] = {
+      ["POST"] = true,
     },
-
-    footer = [[
-      [active]: /gateway-oss/{{page.kong_version}}/health-checks-circuit-breakers/#active-health-checks
-      [healthchecks]: /gateway-oss/{{page.kong_version}}/health-checks-circuit-breakers
-      [secure-admin-api]: /gateway-oss/{{page.kong_version}}/secure-admin-api
-      [proxy-reference]: /gateway-oss/{{page.kong_version}}/proxy
-    ]],
-
-    general = {
-      config = {
-        skip = false,
-        title = [[Declarative Configuration]],
-        description = [[
-          Loading the declarative configuration of entities into Kong
-          can be done in two ways: at start-up, through the `declarative_config`
-          property, or at run-time, through the Admin API using the `/config`
-          endpoint.
-
-          To get started using declarative configuration, you need a file
-          (in YAML or JSON format) containing entity definitions. You can
-          generate a sample declarative configuration with the command:
-
-          ```
-          kong config init
-          ```
-
-          It generates a file named `kong.yml` in the current directory,
-          containing the appropriate structure and examples.
-        ]],
-        ["/config"] = {
-          POST = {
-            title = [[Reload declarative configuration]],
-            endpoint = [[
-              <div class="endpoint post indent">/config</div>
-
-              {:.indent}
-              Attributes | Description
-              ---:| ---
-              `config`<br>**required** | The config data (in YAML or JSON format) to be loaded.
-            ]],
-
-            request_query = [[
-              Attributes | Description
-              ---:| ---
-              `check_hash`<br>*optional* | If set to 1, Kong will compare the hash of the input config data against that of the previous one. If the configuration is identical, it will not reload it and will return HTTP 304.
-            ]],
-
-            description = [[
-              This endpoint allows resetting a DB-less Kong with a new
-              declarative configuration data file. All previous contents
-              are erased from memory, and the entities specified in the
-              given file take their place.
-
-              To learn more about the file format, please read the
-              [declarative configuration][db-less] documentation.
-            ]],
-            response = [[
-              ```
-              HTTP 200 OK
-              ```
-
-              ``` json
-              {
-                  { "services": [],
-                    "routes": []
-                  }
-              }
-              ```
-
-              The response contains a list of all the entities that were parsed from the
-              input file.
-            ]]
-          }
-        },
-      },
+    ["/upstreams/:upstreams/targets/:targets/unhealthy"] = {
+      ["POST"] = true,
     },
-
-    entities = {
-      methods = {
-        -- in DB-less mode, only document GET endpoints for entities
-        ["GET"] = true,
-        ["POST"] = false,
-        ["PATCH"] = false,
-        ["PUT"] = false,
-        ["DELETE"] = false,
-        -- exceptions for the healthcheck endpoints:
-        ["/upstreams/:upstreams/targets/:targets/healthy"] = {
-          ["POST"] = true,
-        },
-        ["/upstreams/:upstreams/targets/:targets/unhealthy"] = {
-          ["POST"] = true,
-        },
-      },
-    }
-
   },
 
 --------------------------------------------------------------------------------
@@ -2307,12 +2145,8 @@ return {
     header = [[
       - title: Admin API
         url: /admin-api/
+        icon: /assets/images/icons/documentation/icn-admin-api-color.svg
         items:
-          - text: DB-less
-            url: /db-less-admin-api
-
-          - text: Declarative Configuration
-            url: /db-less-admin-api/#declarative-configuration
       ]],
   }
 

--- a/autodoc/admin-api/data/admin-api.lua
+++ b/autodoc/admin-api/data/admin-api.lua
@@ -63,8 +63,95 @@ return {
         exposure of this API. See [this document][secure-admin-api] for a discussion
         of methods to secure the Admin API.
       ]]
-    }, {
-      title = [[Supported Content Types]],
+    },
+
+    { title = [[DB-less mode]],
+      text = [[
+
+        In [DB-less mode](../db-less-and-declarative-config), the Admin API can be used to load a new declarative
+        configuration, and for inspecting the current configuration. In DB-less mode,
+        the Admin API for each Kong node functions independently, reflecting the memory state
+        of that particular Kong node. This is the case because there is no database
+        coordination between Kong nodes.
+
+        In DB-less mode, you configure {{site.base_gateway}} declaratively.
+        Therefore, the Admin API is mostly read-only. The only tasks it can perform are all
+        related to handling the declarative config, including:
+
+        * [Validating configurations against schemas](#validate-a-configuration-against-a-schema)
+        * [Validating plugin configurations against schemas](#validate-a-plugin-configuration-against-the-schema)
+        * [Reloading the declarative configuration](#reload-declarative-configuration)
+        * [Setting a target's health status in the load balancer](#set-target-as-healthy)
+
+      ]],
+    },
+
+    { title = [[Declarative configuration]],
+      text = [[
+
+        Loading the declarative configuration of entities into {{site.base_gateway}}
+        can be done in two ways: at start-up, through the `declarative_config`
+        property, or at run-time, through the Admin API using the `/config`
+        endpoint.
+
+        To get started using declarative configuration, you need a file
+        (in YAML or JSON format) containing entity definitions. You can
+        generate a sample declarative configuration with the command:
+
+        ```
+        kong config init
+        ```
+
+        It generates a file named `kong.yml` in the current directory,
+        containing the appropriate structure and examples.
+
+
+        ### Reload Declarative Configuration
+
+        This endpoint allows resetting a DB-less Kong with a new
+        declarative configuration data file. All previous contents
+        are erased from memory, and the entities specified in the
+        given file take their place.
+
+        To learn more about the file format, see the
+        [declarative configuration](../db-less-and-declarative-config) documentation.
+
+
+        <div class="endpoint post indent">/config</div>
+
+        {:.indent}
+        Attributes | Description
+        ---:| ---
+        `config`<br>**required** | The config data (in YAML or JSON format) to be loaded.
+
+
+        #### Request Querystring Parameters
+
+        Attributes | Description
+        ---:| ---
+        `check_hash`<br>*optional* | If set to 1, Kong will compare the hash of the input config data against that of the previous one. If the configuration is identical, it will not reload it and will return HTTP 304.
+
+
+        #### Response
+
+        ```
+        HTTP 200 OK
+        ```
+
+        ``` json
+        {
+            { "services": [],
+              "routes": []
+            }
+        }
+        ```
+
+        The response contains a list of all the entities that were parsed from the
+        input file.
+      ]],
+    },
+
+    { title = [[Supported Content Types]],
       text = [[
         The Admin API accepts 3 content types on every endpoint:
 

--- a/autodoc/admin-api/generate.lua
+++ b/autodoc/admin-api/generate.lua
@@ -4,7 +4,6 @@ setmetatable(_G, nil)
 
 local lfs = require("lfs")
 local cjson = require("cjson")
-local pl_tablex = require("pl.tablex")
 local general = require("autodoc.admin-api.general")
 
 local method_array = {
@@ -84,26 +83,6 @@ if not pok then
 end
 
 local admin_api_data = require("autodoc.admin-api.data.admin-api")
-
-local function deep_merge(t1, t2)
-  local copy = {}
-  for k, v in pairs(t1) do
-    copy[k] = v
-  end
-  for k, v in pairs(t2) do
-    if type(v) == "table" and type(t1[k]) == "table" then
-      copy[k] = deep_merge(t1[k], v)
-    else
-      copy[k] = v
-    end
-  end
-  return copy
-end
-
-local dbless_data = pl_tablex.deepcopy(admin_api_data)
-local dbless_overrides = dbless_data.dbless
-dbless_data.dbless = nil
-dbless_data = deep_merge(dbless_data, dbless_overrides)
 
 local Endpoints = require("kong.api.endpoints")
 
@@ -518,22 +497,49 @@ local function section(outfd, title, content)
   outfd:write("\n")
 end
 
-local function write_endpoint(outfd, endpoint, ep_data, methods)
+local function each_line(str)
+ if str:sub(-1)~="\n" then
+   str = str .. "\n"
+ end
+ return str:gmatch("(.-)\n")
+end
+
+local function blockquote(content)
+  local buffer = {}
+  for line in each_line(content) do
+    buffer[#buffer + 1] = "> " .. line
+  end
+  return table.concat(buffer)
+end
+
+local function warning_message(outfd, content)
+  outfd:write("\n\n{:.note}\n")
+  outfd:write(blockquote(content))
+  outfd:write("\n\n")
+end
+
+local function write_endpoint(outfd, endpoint, ep_data, dbless_methods)
   assert_data(ep_data, "data for endpoint " .. endpoint)
   if ep_data.done or ep_data.skip then
     return
   end
 
   -- check for endpoint-specific overrides (useful for db-less)
-  methods = methods and methods[endpoint] or methods
-
   for i, method in ipairs(method_array) do
-    if methods == nil or methods[method] == true then
-
     local meth_data = ep_data[method]
     if meth_data then
       assert_data(meth_data.title, "info for " .. method .. " " .. endpoint)
       write_title(outfd, 3, meth_data.title)
+      if dbless_methods
+        and not dbless_methods[method]
+        and (not dbless_methods[endpoint]
+             or not dbless_methods[endpoint][method])
+      then
+        warning_message(outfd, "**Note**: Not available in DB-less mode.")
+      else
+        outfd:write('\n{:.badge .dbless}\n\n')
+      end
+
       section(outfd, nil, meth_data.description)
       local fk_endpoints = meth_data.fk_endpoints or {}
       section(outfd, nil, meth_data.endpoint)
@@ -546,16 +552,14 @@ local function write_endpoint(outfd, endpoint, ep_data, methods)
       section(outfd, "Response", meth_data.response)
       outfd:write("---\n\n")
     end
-
-    end
   end
   ep_data.done = true
 end
 
-local function write_endpoints(outfd, info, all_endpoints, methods)
+local function write_endpoints(outfd, info, all_endpoints, dbless_methods)
   for endpoint, ep_data in sortedpairs(info.data) do
     if endpoint:match("^/") then
-      write_endpoint(outfd, endpoint, ep_data, methods)
+      write_endpoint(outfd, endpoint, ep_data, dbless_methods)
       all_endpoints[endpoint] = ep_data
     end
   end
@@ -585,7 +589,7 @@ local function write_general_section(outfd, filename, all_endpoints, name, data_
     mod = assert(loadfile(KONG_PATH .. "/" .. filename))()
   }
 
-  write_endpoints(outfd, info, all_endpoints, data_general.methods)
+  write_endpoints(outfd, info, all_endpoints)
 
   return info
 end
@@ -936,9 +940,8 @@ local function write_admin_api(filename, data, title)
     outfd:write("\n")
     write_title(outfd, 2, ipart.title)
     outfd:write(unindent(ipart.text))
+    outfd:write("\n---\n\n")
   end
-
-  outfd:write("\n---\n\n")
 
   local all_endpoints = {}
 
@@ -966,7 +969,7 @@ local function write_admin_api(filename, data, title)
   for _, entity_info in ipairs(entity_infos) do
     write_title(outfd, 2, entity_info.title)
     outfd:write(entity_info.intro)
-    write_endpoints(outfd, entity_info, all_endpoints, data.entities.methods)
+    write_endpoints(outfd, entity_info, all_endpoints, data.dbless_entities_methods)
   end
 
   -- Check that all endpoints were traversed
@@ -990,7 +993,6 @@ local function write_admin_api_nav(filename, data)
 
   local outfd = assert(io.open(outpath, "w+"))
 
-  outfd:write("# Generated via autodoc/admin-api/generate.lua\n")
   outfd:write(unindent(data.nav.header))
 
   local max_level = 3
@@ -1030,16 +1032,6 @@ local function main()
     "docs_nav.yml.admin-api.in",
     admin_api_data
   )
-
-  write_admin_api(
-    "db-less-admin-api.md",
-    dbless_data,
-    "Admin API for DB-less Mode",
-    {
-      "GET",
-    }
-  )
-
 end
 
 main()

--- a/autodoc/admin-api/generate.lua
+++ b/autodoc/admin-api/generate.lua
@@ -476,7 +476,7 @@ end
 
 local titles = {}
 
-local function write_title(outfd, level, title)
+local function write_title(outfd, level, title, label)
   if not title then
     return
   end
@@ -485,7 +485,12 @@ local function write_title(outfd, level, title)
     level = level,
     title = title,
   })
-  outfd:write((("#"):rep(level) .. " " .. title .. "\n\n"))
+  if label then
+    label = "\n" .. label
+  else
+    label = ""
+  end
+  outfd:write((("#"):rep(level) .. " " .. title .. label .. "\n\n"))
 end
 
 local function section(outfd, title, content)
@@ -529,15 +534,15 @@ local function write_endpoint(outfd, endpoint, ep_data, dbless_methods)
     local meth_data = ep_data[method]
     if meth_data then
       assert_data(meth_data.title, "info for " .. method .. " " .. endpoint)
-      write_title(outfd, 3, meth_data.title)
       if dbless_methods
         and not dbless_methods[method]
         and (not dbless_methods[endpoint]
              or not dbless_methods[endpoint][method])
       then
+        write_title(outfd, 3, meth_data.title)
         warning_message(outfd, "**Note**: Not available in DB-less mode.")
       else
-        outfd:write('\n{:.badge .dbless}\n\n')
+        write_title(outfd, 3, meth_data.title, "{:.badge .dbless}")
       end
 
       section(outfd, nil, meth_data.description)

--- a/scripts/autodoc
+++ b/scripts/autodoc
@@ -149,8 +149,6 @@ then
 fi
 
 copy autodoc/output/admin-api/admin-api.md "$DOCS_APP/admin-api.md"
-copy autodoc/output/admin-api/db-less-admin-api.md "$DOCS_APP/db-less-admin-api.md"
-copy autodoc/output/nav/docs_nav.yml.admin-api.in "$DOCS_REPO/autodoc-nav/docs_nav_$DOCS_VERSION.yml.head.in"
 
 copy autodoc/output/configuration.md "$DOCS_APP/configuration.md"
 copy autodoc/output/cli.md "$DOCS_APP/cli.md"

--- a/scripts/autodoc
+++ b/scripts/autodoc
@@ -31,14 +31,18 @@ function count_indents_on_line() {
     fi
 }
 
-function insert_pdk_nav_file_into_docs_nav_file() {
-    local pdk_nav_file=$1
+function insert_yaml_file_into_nav_file() {
+    local new_nav_partial_file=$1
     local docs_nav_file=$2
+    local first_line_text=$3
+
+    echo "Patching $docs_nav_file with $new_nav_partial_file ..."
 
     # find first_line and last line of the current pdk index in docs_nav_file
-    # first line contains "Plugin Development Kit"
+
+    # first line contains the content of first_line_text
     local first_line
-    first_line=$(sed -n "/text: Plugin Development Kit/=" "$docs_nav_file")
+    first_line=$(sed -n "$first_line_text" "$docs_nav_file")
 
     # find last_line by looking at the indentation of all subsequent lines, looking at the indentation
     # last line is the last one with more indentation that first_line
@@ -62,8 +66,9 @@ function insert_pdk_nav_file_into_docs_nav_file() {
     # delete existing pdk index, insert new pdk nav file instead
     # Passing an option to -i is required on macOS, but not required on Linux
     # Commenting out to make the GitHub Actions build work
-    #sed -i '' -e "${first_line},${last_line}d" -e "${insert_line}r${pdk_nav_file}" "$docs_nav_file"
-    sed -i -e "${first_line},${last_line}d" -e "${insert_line}r${pdk_nav_file}" "$docs_nav_file"
+    #sed -i '' -e "${first_line},${last_line}d" -e "${insert_line}r${new_nav_partial_file}" "$docs_nav_file"
+    # Recommended to `brew install gnu-sed && brew info gnu-sed` to override default sed on Mac
+    sed -i -e "${first_line},${last_line}d" -e "${insert_line}r${new_nav_partial_file}" "$docs_nav_file"
 }
 
 
@@ -163,5 +168,10 @@ for module in autodoc/output/pdk/*; do
   copy "$module" "$DOCS_APP/pdk/"
 done
 
-echo "Patching $DOCS_NAV with autodoc/output/pdk_nav.yml ..."
-insert_pdk_nav_file_into_docs_nav_file ./autodoc/output/_pdk_nav.yml "$DOCS_NAV"
+insert_yaml_file_into_nav_file ./autodoc/output/nav/docs_nav.yml.admin-api.in \
+                               "$DOCS_NAV" \
+                               "/title: Admin API/="
+
+insert_yaml_file_into_nav_file ./autodoc/output/_pdk_nav.yml \
+                               "$DOCS_NAV" \
+                               "/text: Plugin Development Kit/="


### PR DESCRIPTION
Before this PR, autodoc generated two separate (but similar) files for the admin api:
* `admin-api.md` for the "db" Admin API
* `db-less-admin-api.md` for db-less

After this PR,
* only `admin-api.md` will remain
* It will have two new top sections describing db-less & declarative config
* methods that are not compatible with db-less will be marked as such with a warn blue box

---

**Note for reviewers**: I have moved this back to "please review" despite @javierguerragiraldez 's approval because feedback from the docs team resulted in two new changes which were added after his review:

* We now mark both db and db-less methods with badges, with a custom syntax
* We patched the PDK navigation in one way and the Admin API navigation in a totally different way. This second way required an extra lua file to be run in the docs repo. I have simplified the steps and now both files are patched into the nav file with the method for used for the PDK.
* We modified `write_title` to include an optional badge

If you are short on time when reviewing this, you may just concentrate on those changes.