### PR TITLE
fix(tests) add server header on mock upstream responses

### DIFF
--- a/spec/02-integration/10-go_plugins/01-reports_spec.lua
+++ b/spec/02-integration/10-go_plugins/01-reports_spec.lua
@@ -130,7 +130,7 @@ for _, strategy in helpers.each_strategy() do
         headers = { host  = "http-service.test" }
       })
       assert.res_status(200, res)
-      assert.equal("got from server 'openresty'", res.headers['x-hello-from-go-at-response'])
+      assert.equal("got from server 'mock-upstream/1.0.0'", res.headers['x-hello-from-go-at-response'])
 
     end)
 

--- a/spec/fixtures/mock_upstream.lua
+++ b/spec/fixtures/mock_upstream.lua
@@ -66,6 +66,7 @@ local function send_text_response(text, content_type, headers)
   text = ngx.req.get_method() == "HEAD" and "" or tostring(text)
 
   ngx.header["X-Powered-By"]   = "mock_upstream"
+  ngx.header["Server"]         = "mock-upstream/1.0.0"
   ngx.header["Content-Length"] = #text + 1
   ngx.header["Content-Type"]   = content_type
 


### PR DESCRIPTION
### Summary

Needed with: https://github.com/Kong/kong-build-tools/pull/401

The testing branch is here (currently is has issues with grpc-plugin tests):
https://github.com/Kong/kong/pull/7465