### PR TITLE
fix(syslog) ensure new facility field is compatible with older versions in hybrid mode

### DIFF
--- a/kong/plugins/syslog/handler.lua
+++ b/kong/plugins/syslog/handler.lua
@@ -71,14 +71,16 @@ local function log(premature, conf, message)
     return
   end
 
+  local facility = conf.facility or "user"
+
   if message.response.status >= 500 then
-    send_to_syslog(conf.log_level, conf.server_errors_severity, message, conf.facility)
+    send_to_syslog(conf.log_level, conf.server_errors_severity, message, facility)
 
   elseif message.response.status >= 400 then
-    send_to_syslog(conf.log_level, conf.client_errors_severity, message, conf.facility)
+    send_to_syslog(conf.log_level, conf.client_errors_severity, message, facility)
 
   else
-    send_to_syslog(conf.log_level, conf.successful_severity, message, conf.facility)
+    send_to_syslog(conf.log_level, conf.successful_severity, message, facility)
   end
 end
 

--- a/kong/plugins/syslog/handler.lua
+++ b/kong/plugins/syslog/handler.lua
@@ -71,6 +71,8 @@ local function log(premature, conf, message)
     return
   end
 
+  -- TODO: revert this commit and use schema to populate default value
+  -- in 2.7 or 3.0 whichever comes eearlier.
   local facility = conf.facility or "user"
 
   if message.response.status >= 500 then

--- a/kong/plugins/syslog/schema.lua
+++ b/kong/plugins/syslog/schema.lua
@@ -10,8 +10,6 @@ local severity = {
 
 local facility = {
   type = "string",
-  default = "user",
-  required = true,
   one_of = { "auth", "authpriv", "cron", "daemon",
              "ftp", "kern", "lpr", "mail",
              "news", "syslog", "user", "uucp",


### PR DESCRIPTION

The default value is now populated at runtime for compatibiliy.
This commit can be reverted in 2.7 (2 version started from 2.5) or 3.0 whichever comes eariler.