### PR TITLE
[DOCU-1562] add note about host as case sensitive

### DIFF
--- a/autodoc/admin-api/data/admin-api.lua
+++ b/autodoc/admin-api/data/admin-api.lua
@@ -829,7 +829,7 @@ return {
         hosts = {
           kind = "semi-optional",
           description = [[
-            A list of domain names that match this Route.
+            A list of domain names that match this Route. Note that the hosts value is case sensitive.
           ]],
           examples = { {"example.com", "foo.test"}, nil },
           skip_in_example = true, -- hack so we get HTTP fields in the first example and Stream fields in the second

--- a/autodoc/admin-api/data/admin-api.lua
+++ b/autodoc/admin-api/data/admin-api.lua
@@ -652,7 +652,7 @@ return {
           ]]
         },
         host = {
-          description = [[The host of the upstream server.]],
+          description = [[The host of the upstream server. Note that the host value is case sensitive.]],
           example = "example.com",
         },
         port = {


### PR DESCRIPTION
### Summary

This PR addresses issue [586](https://github.com/Kong/docs.konghq.com/issues/586).

### Full changelog

* add note that `host` is case sensitive

Edit: add note that `hosts` is also case sensitive

### Issues resolved

Fix DOCU-1562
