### PR TITLE
feat(clustering) lax version checks

### DIFF
--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -12,12 +12,12 @@ local utils = require("kong.tools.utils")
 local constants = require("kong.constants")
 local openssl_x509 = require("resty.openssl.x509")
 local string = string
-local assert = assert
 local setmetatable = setmetatable
 local type = type
-local math = math
 local pcall = pcall
 local pairs = pairs
+local ipairs = ipairs
+local tonumber = tonumber
 local tostring = tostring
 local ngx = ngx
 local ngx_log = ngx.log
@@ -31,15 +31,18 @@ local ngx_now = ngx.now
 local ngx_var = ngx.var
 local table_insert = table.insert
 local table_remove = table.remove
+local table_concat = table.concat
 local deflate_gzip = utils.deflate_gzip
 
 
 local KONG_VERSION = kong.version
-local ngx_ERR = ngx.ERR
 local ngx_DEBUG = ngx.DEBUG
-local ngx_WARN = ngx.WARN
+local ngx_INFO = ngx.INFO
 local ngx_NOTICE = ngx.NOTICE
+local ngx_WARN = ngx.WARN
+local ngx_ERR = ngx.ERR
 local ngx_OK = ngx.OK
+local ngx_CLOSE = ngx.HTTP_CLOSE
 local MAX_PAYLOAD = constants.CLUSTERING_MAX_PAYLOAD
 local WS_OPTS = {
   timeout = constants.CLUSTERING_TIMEOUT,
@@ -49,6 +52,51 @@ local PING_INTERVAL = constants.CLUSTERING_PING_INTERVAL
 local PING_WAIT = PING_INTERVAL * 1.5
 local OCSP_TIMEOUT = constants.CLUSTERING_OCSP_TIMEOUT
 local CLUSTERING_SYNC_STATUS = constants.CLUSTERING_SYNC_STATUS
+local MAJOR_MINOR_PATTERN = "^(%d+)%.(%d+)%.%d+"
+
+
+local function log(level, ...)
+  ngx_log(level, "[clustering] ", ...)
+end
+
+
+local function extract_major_minor(version)
+  if type(version) ~= "string" then
+    return nil, nil
+  end
+
+  local major, minor = version:match(MAJOR_MINOR_PATTERN)
+  if not major then
+    return nil, nil
+  end
+
+  major = tonumber(major, 10)
+  minor = tonumber(minor, 10)
+
+  return major, minor
+end
+
+
+local function plugins_list_to_map(plugins_list)
+  local versions = {}
+  for _, plugin in ipairs(plugins_list) do
+    local name = plugin.name
+    local version = plugin.version
+    local major, minor = extract_major_minor(plugin.version)
+
+    if major and minor then
+      versions[name] = {
+        major   = major,
+        minor   = minor,
+        version = version,
+      }
+
+    else
+      versions[name] = {}
+    end
+  end
+  return versions
+end
 
 
 local function is_timeout(err)
@@ -75,6 +123,13 @@ function _M:export_deflated_reconfigure_payload()
     return nil, err
   end
 
+  self.plugins_configured = {}
+  if config_table.plugins then
+    for _, plugin in pairs(config_table.plugins) do
+      self.plugins_configured[plugin.name] = true
+    end
+  end
+
   local payload, err = cjson_encode({
     type = "reconfigure",
     timestamp = ngx_now(),
@@ -98,7 +153,7 @@ end
 function _M:push_config()
   local payload, err = self:export_deflated_reconfigure_payload()
   if not payload then
-    ngx_log(ngx_ERR, "unable to export config from database: " .. err)
+    log(ngx_ERR, "unable to export config from database: " .. err)
     return
   end
 
@@ -109,28 +164,34 @@ function _M:push_config()
     n = n + 1
   end
 
-  ngx_log(ngx_DEBUG, "config pushed to ", n, " clients")
+  log(ngx_DEBUG, "config pushed to ", n, " clients")
 end
+
 
 function _M:validate_shared_cert()
   local cert = ngx_var.ssl_client_raw_cert
 
   if not cert then
-    ngx_log(ngx_ERR, "Data Plane failed to present client certificate " ..
-                     "during handshake")
-    return ngx_exit(444)
+    return nil, "data plane failed to present client certificate during handshake"
   end
 
-  cert = assert(openssl_x509.new(cert, "PEM"))
-  local digest = assert(cert:digest("sha256"))
+  local err
+  cert, err = openssl_x509.new(cert, "PEM")
+  if not cert then
+    return nil, "unable to load data plane client certificate during handshake: " .. err
+  end
+
+  local digest, err = cert:digest("sha256")
+  if not digest then
+    return nil, "unable to retrieve data plane client certificate digest during handshake: " .. err
+  end
 
   if digest ~= self.cert_digest then
-    ngx_log(ngx_ERR, "Data Plane presented incorrect client certificate " ..
-                     "during handshake, expected digest: " ..
-                     self.cert_digest ..
-                     " got: " .. digest)
-    return ngx_exit(444)
+    return nil, "data plane presented incorrect client certificate during handshake (expected: " ..
+                self.cert_digest .. ", got: " .. digest .. ")"
   end
+
+  return true
 end
 
 
@@ -196,127 +257,248 @@ do
 end
 
 
-local MAJOR_MINOR_PATTERN = "^(%d+)%.(%d+)%.%d+"
+function _M:check_version_compatibility(dp_version, dp_plugin_map, log_suffix)
+  local major_cp, minor_cp = extract_major_minor(KONG_VERSION)
+  local major_dp, minor_dp = extract_major_minor(dp_version)
 
-function _M:should_send_config_update(node_version, node_plugins)
-  if not node_version or not node_plugins then
-    return false, "your DP did not provide version information to the CP, " ..
-                  "Kong CP after 2.3 requires such information in order to " ..
-                  "ensure generated config is compatible with DPs. " ..
-                  "Sync is suspended for this DP and will resume " ..
-                  "automatically once this DP also upgrades to 2.3 or later"
+  if not major_cp then
+    return nil, "data plane version " .. dp_version .. " is incompatible with control plane version",
+                CLUSTERING_SYNC_STATUS.KONG_VERSION_INCOMPATIBLE
   end
 
-  local major_cp, minor_cp = KONG_VERSION:match(MAJOR_MINOR_PATTERN)
-  local major_node, minor_node = node_version:match(MAJOR_MINOR_PATTERN)
-  minor_cp = tonumber(minor_cp)
-  minor_node = tonumber(minor_node)
-
-  if major_cp ~= major_node or minor_cp - 2 > minor_node or minor_cp < minor_node then
-    return false, "version incompatible, CP version: " .. KONG_VERSION ..
-                  " DP version: " .. node_version ..
-                  " DP versions acceptable are " ..
-                  major_cp .. "." .. math.max(0, minor_cp - 2) .. " to " ..
-                  major_cp .. "." .. minor_cp .. "(edges included)",
-                  CLUSTERING_SYNC_STATUS.KONG_VERSION_INCOMPATIBLE
+  if not major_dp then
+    return nil, "data plane version is incompatible with control plane version " ..
+                KONG_VERSION .. " (" .. major_cp .. ".x.y are accepted)",
+                CLUSTERING_SYNC_STATUS.KONG_VERSION_INCOMPATIBLE
   end
 
-  -- allow DP to have a superset of CP's plugins
-  local p, np
-  local i, j = #self.plugins_list, #node_plugins
-
-  if j < i then
-    return false, "CP and DP does not have same set of plugins installed",
-                  CLUSTERING_SYNC_STATUS.PLUGIN_SET_INCOMPATIBLE
+  if major_cp ~= major_dp then
+    return nil, "data plane version " .. dp_version ..
+                " is incompatible with control plane version " ..
+                KONG_VERSION .. " (" .. major_cp .. ".x.y are accepted)",
+                CLUSTERING_SYNC_STATUS.KONG_VERSION_INCOMPATIBLE
   end
 
-  while i > 0 and j > 0 do
-    p = self.plugins_list[i]
-    np = node_plugins[j]
+  if minor_cp ~= minor_dp then
+    local msg = "data plane minor version " .. dp_version ..
+                " is different to control plane minor version " ..
+                KONG_VERSION
 
-    if p.name ~= np.name then
-      goto continue
-    end
+    log(ngx_INFO, msg, log_suffix)
+  end
 
-    -- ignore plugins without a version (route-by-header is deprecated)
-    if p.version and np.version then
-      -- major/minor check that ignores anything after the second digit
-      local major_minor_p = p.version:match("^(%d+%.%d+)") or "not_a_version"
-      local major_minor_np = np.version:match("^(%d+%.%d+)") or "still_not_a_version"
+  for _, plugin in ipairs(self.plugins_list) do
+    local name = plugin.name
+    local cp_plugin = self.plugins_map[name]
+    local dp_plugin = dp_plugin_map[name]
 
-      if major_minor_p ~= major_minor_np then
-        return false, "plugin \"" .. p.name .. "\" version incompatible, " ..
-                      "CP version: " .. tostring(p.version) ..
-                      " DP version: " .. tostring(np.version) ..
-                      " DP plugin version acceptable is "..
-                      major_minor_p .. ".x",
-                      CLUSTERING_SYNC_STATUS.PLUGIN_VERSION_INCOMPATIBLE
+    if not dp_plugin then
+      if cp_plugin.version then
+        log(ngx_WARN, name, " plugin ", cp_plugin.version, " is missing from data plane", log_suffix)
+      else
+        log(ngx_WARN, name, " plugin is missing from data plane", log_suffix)
+      end
+
+    else
+      if cp_plugin.version and dp_plugin.version then
+        local msg = "data plane " .. name .. " plugin version " .. dp_plugin.version ..
+                    " is different to control plane plugin version " .. cp_plugin.version
+
+        if cp_plugin.major ~= dp_plugin.major then
+          log(ngx_WARN, msg, cp_plugin.version, log_suffix)
+
+        elseif cp_plugin.minor ~= dp_plugin.minor then
+          log(ngx_INFO, msg, log_suffix)
+        end
+
+      elseif dp_plugin.version then
+        log(ngx_NOTICE, "data plane ", name, " plugin version ", dp_plugin.version,
+                        " has unspecified version on control plane", log_suffix)
+
+      elseif cp_plugin.version then
+        log(ngx_NOTICE, "data plane ", name, " plugin version is unspecified, ",
+                        "and is different to control plane plugin version ",
+                        cp_plugin.version, log_suffix)
       end
     end
-
-    i = i - 1
-    ::continue::
-    j = j - 1
   end
 
-  if i > 0 then
-    return false, "CP and DP does not have same set of plugins installed",
-                  CLUSTERING_SYNC_STATUS.PLUGIN_SET_INCOMPATIBLE
-  end
-
-  return true
+  return true, nil, CLUSTERING_SYNC_STATUS.NORMAL
 end
 
 
-function _M:handle_cp_websocket()
-  -- use mutual TLS authentication
-  if self.conf.cluster_mtls == "shared" then
-    self:validate_shared_cert()
+function _M:check_configuration_compatibility(dp_plugin_map)
+  for _, plugin in ipairs(self.plugins_list) do
+    if self.plugins_configured[plugin.name] then
+      local name = plugin.name
+      local cp_plugin = self.plugins_map[name]
+      local dp_plugin = dp_plugin_map[name]
 
-  elseif self.conf.cluster_ocsp ~= "off" then
-    local res, err = check_for_revocation_status()
-    if res == false then
-      ngx_log(ngx_ERR, "DP client certificate was revoked: ", err)
-      return ngx_exit(444)
+      if not dp_plugin then
+        if cp_plugin.version then
+          return nil, "configured " .. name .. " plugin " .. cp_plugin.version ..
+                      " is missing from data plane", CLUSTERING_SYNC_STATUS.PLUGIN_SET_INCOMPATIBLE
+        end
 
-    elseif not res then
-      ngx_log(ngx_WARN, "DP client certificate revocation check failed: ", err)
-      if self.conf.cluster_ocsp == "on" then
-        return ngx_exit(444)
+        return nil, "configured " .. name .. " plugin is missing from data plane",
+               CLUSTERING_SYNC_STATUS.PLUGIN_SET_INCOMPATIBLE
+      end
+
+      if cp_plugin.version and dp_plugin.version and cp_plugin.major ~= dp_plugin.major then
+        local msg = "configured data plane " .. name .. " plugin version " .. dp_plugin.version ..
+                    " is different to control plane plugin version " .. cp_plugin.version
+        return nil, msg, CLUSTERING_SYNC_STATUS.PLUGIN_VERSION_INCOMPATIBLE
       end
     end
   end
 
-  local node_id = ngx_var.arg_node_id
-  if not node_id then
+  -- TODO: DAOs are not checked in any way at the moment. For example if plugin introduces a new DAO in
+  --       minor release and it has entities, that will most likely fail on data plane side, but is not
+  --       checked here.
+
+  return true, nil, CLUSTERING_SYNC_STATUS.NORMAL
+end
+
+function _M:handle_cp_websocket()
+  local dp_id = ngx_var.arg_node_id
+  local dp_hostname = ngx_var.arg_node_hostname
+  local dp_ip = ngx_var.remote_addr
+  local dp_version = ngx_var.arg_node_version
+
+  local log_suffix = {}
+  if type(dp_id) == "string" then
+    table_insert(log_suffix, "id: " .. dp_id)
+  end
+
+  if type(dp_hostname) == "string" then
+    table_insert(log_suffix, "host: " .. dp_hostname)
+  end
+
+  if type(dp_ip) == "string" then
+    table_insert(log_suffix, "ip: " .. dp_ip)
+  end
+
+  if type(dp_version) == "string" then
+    table_insert(log_suffix, "version: " .. dp_version)
+  end
+
+  if #log_suffix > 0 then
+    log_suffix = " [" .. table_concat(log_suffix, ", ") .. "]"
+  else
+    log_suffix = ""
+  end
+
+  local ok, err
+
+  -- use mutual TLS authentication
+  if self.conf.cluster_mtls == "shared" then
+    ok, err = self:validate_shared_cert()
+
+  elseif self.conf.cluster_ocsp ~= "off" then
+    ok, err = check_for_revocation_status()
+    if ok == false then
+      err = "data plane client certificate was revoked: " ..  err
+
+    elseif not ok then
+      if self.conf.cluster_ocsp == "on" then
+        err = "data plane client certificate revocation check failed: " .. err
+
+      else
+        log(ngx_WARN, "data plane client certificate revocation check failed: ", err, log_suffix)
+        err = nil
+      end
+    end
+  end
+
+  if err then
+    log(ngx_ERR, err, log_suffix)
+    return ngx_exit(ngx_CLOSE)
+  end
+
+  if not dp_id then
+    log(ngx_WARN, "data plane didn't pass the id", log_suffix)
     ngx_exit(400)
   end
 
-  local node_hostname = ngx_var.arg_node_hostname
-  local node_ip = ngx_var.remote_addr
-  local node_version = ngx_var.arg_node_version
-  local node_plugins
+  if not dp_version then
+    log(ngx_WARN, "data plane didn't pass the version", log_suffix)
+    ngx_exit(400)
+  end
 
   local wb, err = ws_server:new(WS_OPTS)
   if not wb then
-    ngx_log(ngx_ERR, "failed to perform server side WebSocket handshake: ", err)
-    return ngx_exit(444)
+    log(ngx_ERR, "failed to perform server side websocket handshake: ", err, log_suffix)
+    return ngx_exit(ngx_CLOSE)
   end
 
   -- connection established
-  -- receive basic_info
+  -- receive basic info
   local data, typ
   data, typ, err = wb:recv_frame()
   if err then
-    ngx_log(ngx_ERR, "failed to receive WebSocket basic_info frame: ", err)
-    wb:close()
-    return ngx_exit(444)
+    err = "failed to receive websocket basic info frame: " .. err
 
   elseif typ == "binary" then
-    data = cjson_decode(data)
-    assert(data.type =="basic_info")
-    node_plugins = assert(data.plugins)
+    if not data then
+      err = "failed to receive websocket basic info data"
+
+    else
+      data, err = cjson_decode(data)
+      if type(data) ~= "table" then
+        if err then
+          err = "failed to decode websocket basic info data: " .. err
+        else
+          err = "failed to decode websocket basic info data"
+        end
+
+      else
+        if data.type ~= "basic_info" then
+          err =  "invalid basic info data type: " .. (data.type  or "unknown")
+
+        else
+          if type(data.plugins) ~= "table" then
+            err =  "missing plugins in basic info data"
+          end
+        end
+      end
+    end
   end
+
+  if err then
+    log(ngx_ERR, err, log_suffix)
+    wb:send_close()
+    return ngx_exit(ngx_CLOSE)
+  end
+
+  local dp_plugins_map = plugins_list_to_map(data.plugins)
+  local config_hash = "00000000000000000000000000000000" -- initial hash
+  local last_seen = ngx_time()
+  local sync_status = CLUSTERING_SYNC_STATUS.UNKNOWN
+  local purge_delay = self.conf.cluster_data_plane_purge_delay
+  local update_sync_status = function()
+    last_seen = ngx_time()
+    ok, err = kong.db.clustering_data_planes:upsert({ id = dp_id, }, {
+      last_seen = last_seen,
+      config_hash = config_hash ~= "" and config_hash or nil,
+      hostname = dp_hostname,
+      ip = dp_ip,
+      version = dp_version,
+      sync_status = sync_status, -- TODO: import may have been failed though
+    }, { ttl = purge_delay })
+    if not ok then
+      log(ngx_ERR, "unable to update clustering data plane status: ", err, log_suffix)
+    end
+  end
+
+  ok, err, sync_status = self:check_version_compatibility(dp_version, dp_plugins_map, log_suffix)
+  if not ok then
+    update_sync_status()
+    log(ngx_ERR, err, log_suffix)
+    wb:send_close()
+    return ngx_exit(ngx_CLOSE)
+  end
+
+  ngx.log(ngx.DEBUG, "data plane connected", log_suffix)
 
   local queue
   do
@@ -333,44 +515,33 @@ function _M:handle_cp_websocket()
 
   self.clients[wb] = queue
 
-  local res, sync_status
-  res, err, sync_status = self:should_send_config_update(node_version, node_plugins)
-  if res then
-    sync_status = CLUSTERING_SYNC_STATUS.NORMAL
-    if not self.deflated_reconfigure_payload then
-      assert(self:export_deflated_reconfigure_payload())
-    end
+  if not self.deflated_reconfigure_payload then
+    ok, err = self:export_deflated_reconfigure_payload()
+  end
 
-    if self.deflated_reconfigure_payload then
-      table_insert(queue, self.deflated_reconfigure_payload)
-      queue.post()
-
-    else
-      ngx_log(ngx_ERR, "unable to export config from database: ".. err)
-    end
+  if self.deflated_reconfigure_payload then
+    table_insert(queue, self.deflated_reconfigure_payload)
+    queue.post()
 
   else
-    ngx_log(ngx_WARN, "unable to send updated configuration to " ..
-                      "DP node with hostname: " .. node_hostname ..
-                      " ip: " .. node_ip ..
-                      " reason: " .. err)
+    log(ngx_ERR, "unable to send initial configuration to data plane: ", err, log_suffix)
   end
-  -- how CP connection management works:
+
+  -- how control plane connection management works:
   -- two threads are spawned, when any of these threads exits,
   -- it means a fatal error has occurred on the connection,
   -- and the other thread is also killed
   --
-  -- * read_thread: it is the only thread that receives WS frames from the DP
-  --                and records the current DP status in the database,
-  --                and is also responsible for handling timeout detection
-  -- * write_thread: it is the only thread that sends WS frames to the DP by
-  --                 grabbing any messages currently in the send queue and
-  --                 send them to the DP in a FIFO order. Notice that the
+  -- * read_thread: it is the only thread that receives websocket frames from the
+  --                data plane and records the current data plane status in the
+  --                database, and is also responsible for handling timeout detection
+  -- * write_thread: it is the only thread that sends websocket frames to the data plane
+  --                 by grabbing any messages currently in the send queue and
+  --                 send them to the data plane in a FIFO order. Notice that the
   --                 PONG frames are also sent by this thread after they are
   --                 queued by the read_thread
 
   local read_thread = ngx.thread.spawn(function()
-    local last_seen = ngx_time()
     while not exiting() do
       local data, typ, err = wb:recv_frame()
 
@@ -400,27 +571,16 @@ function _M:handle_cp_websocket()
 
         -- dps only send pings
         if typ ~= "ping" then
-          return nil, "invalid websocket frame received from a data plane: " .. typ
+          return nil, "invalid websocket frame received from data plane: " .. typ
         end
+
+        config_hash = data
 
         -- queue PONG to avoid races
         table_insert(queue, "PONG")
         queue.post()
 
-        last_seen = ngx_time()
-
-        local ok
-        ok, err = kong.db.clustering_data_planes:upsert({ id = node_id, }, {
-          last_seen = last_seen,
-          config_hash = data ~= "" and data or nil,
-          hostname = node_hostname,
-          ip = node_ip,
-          version = node_version,
-          sync_status = sync_status,
-        }, { ttl = self.conf.cluster_data_plane_purge_delay, })
-        if not ok then
-          ngx_log(ngx_ERR, "unable to update clustering data plane status: ", err)
-        end
+        update_sync_status()
       end
     end
   end)
@@ -444,33 +604,34 @@ function _M:handle_cp_websocket()
               return nil, "failed to send PONG back to data plane: " .. err
             end
 
-            ngx_log(ngx_NOTICE, "failed to send PONG back to data plane: ", err)
+            log(ngx_NOTICE, "failed to send PONG back to data plane: ", err, log_suffix)
 
           else
-            ngx_log(ngx_DEBUG, "sent PONG packet to data plane")
+            log(ngx_DEBUG, "sent PONG packet to data plane", log_suffix)
           end
 
         else
-          ok, err = self:should_send_config_update(node_version, node_plugins)
+          local previous_sync_status = sync_status
+          ok, err, sync_status = self:check_configuration_compatibility(dp_plugins_map)
           if ok then
             -- config update
             local _, err = wb:send_binary(payload)
             if err then
               if not is_timeout(err) then
-                return nil, "unable to send updated configuration to node: " .. err
+                return nil, "unable to send updated configuration to data plane: " .. err
               end
 
-              ngx_log(ngx_NOTICE, "unable to send updated configuration to node: ", err)
+              log(ngx_NOTICE, "unable to send updated configuration to data plane: ", err, log_suffix)
 
             else
-              ngx_log(ngx_DEBUG, "sent config update to node")
+              log(ngx_DEBUG, "sent config update to data plane", log_suffix)
             end
 
           else
-            ngx_log(ngx_WARN, "unable to send updated configuration to " ..
-                              "DP node with hostname: " .. node_hostname ..
-                              " ip: " .. node_ip ..
-                              " reason: " .. err)
+            log(ngx_WARN, "unable to send updated configuration to data plane: ", err, log_suffix)
+            if sync_status ~= previous_sync_status then
+              update_sync_status()
+            end
           end
         end
 
@@ -480,20 +641,25 @@ function _M:handle_cp_websocket()
     end
   end)
 
-  local ok, err, perr = ngx.thread.wait(write_thread, read_thread)
+  local perr
+  ok, err, perr = ngx.thread.wait(write_thread, read_thread)
 
   ngx.thread.kill(write_thread)
   ngx.thread.kill(read_thread)
 
   wb:send_close()
 
+  --TODO: should we update disconnect data plane status?
+  --sync_status = CLUSTERING_SYNC_STATUS.UNKNOWN
+  --update_sync_status()
+
   if not ok then
-    ngx_log(ngx_ERR, err)
+    log(ngx_ERR, err, log_suffix)
     return ngx_exit(ngx_ERR)
   end
 
   if perr then
-    ngx_log(ngx_ERR, perr)
+    log(ngx_ERR, perr, log_suffix)
     return ngx_exit(ngx_ERR)
   end
 
@@ -508,7 +674,7 @@ local function push_config_loop(premature, self, push_config_semaphore, delay)
 
   local _, err = self:export_deflated_reconfigure_payload()
   if err then
-    ngx_log(ngx_ERR, "unable to export initial config from database: " .. err)
+    log(ngx_ERR, "unable to export initial config from database: " .. err)
   end
 
   while not exiting() do
@@ -536,11 +702,11 @@ local function push_config_loop(premature, self, push_config_semaphore, delay)
         end
 
       else
-        ngx_log(ngx_ERR, "export and pushing config failed: ", err)
+        log(ngx_ERR, "export and pushing config failed: ", err)
       end
 
     elseif err ~= "timeout" then
-      ngx_log(ngx_ERR, "semaphore wait error: ", err)
+      log(ngx_ERR, "semaphore wait error: ", err)
     end
   end
 end
@@ -549,19 +715,30 @@ end
 function _M:init_worker()
   -- ROLE = "control_plane"
 
+  self.plugins_map = plugins_list_to_map(self.plugins_list)
+
+  self.deflated_reconfigure_payload = nil
+  self.plugins_configured = {}
+  self.plugin_versions = {}
+
+  for i = 1, #self.plugins_list do
+    local plugin = self.plugins_list[i]
+    self.plugin_versions[plugin.name] = plugin.version
+  end
+
   local push_config_semaphore = semaphore.new()
 
   -- Sends "clustering", "push_config" to all workers in the same node, including self
   local function post_push_config_event()
     local res, err = kong.worker_events.post("clustering", "push_config")
     if not res then
-      ngx_log(ngx_ERR, "unable to broadcast event: ", err)
+      log(ngx_ERR, "unable to broadcast event: ", err)
     end
   end
 
   -- Handles "clustering:push_config" cluster event
   local function handle_clustering_push_config_event(data)
-    ngx_log(ngx_DEBUG, "received clustering:push_config event for ", data)
+    log(ngx_DEBUG, "received clustering:push_config event for ", data)
     post_push_config_event()
   end
 
@@ -589,13 +766,13 @@ function _M:init_worker()
   -- The "dao:crud" event is triggered using post_local, which eventually generates an
   -- ""clustering:push_config" cluster event. It is assumed that the workers in the
   -- same node where the dao:crud event originated will "know" about the update mostly via
-  -- changes in the cache shared dict. Since DPs don't use the cache, nodes in the same
+  -- changes in the cache shared dict. Since data planes don't use the cache, nodes in the same
   -- kong node where the event originated will need to be notified so they push config to
-  -- their DPs
+  -- their data planes
   kong.worker_events.register(handle_dao_crud_event, "dao:crud")
 
   -- When "clustering", "push_config" worker event is received by a worker,
-  -- it loads and pushes the config to its the connected DPs
+  -- it loads and pushes the config to its the connected data planes
   kong.worker_events.register(function(_)
     if push_config_semaphore:count() <= 0 then
       -- the following line always executes immediately after the `if` check

--- a/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
@@ -13,6 +13,9 @@ local PATCH = _VERSION_TABLE.patch
 local CLUSTERING_SYNC_STATUS = require("kong.constants").CLUSTERING_SYNC_STATUS
 
 
+local KEY_AUTH_PLUGIN
+
+
 for _, strategy in helpers.each_strategy() do
   describe("CP/DP sync works with #" .. strategy .. " backend", function()
 
@@ -20,10 +23,11 @@ for _, strategy in helpers.each_strategy() do
       helpers.get_db_utils(strategy, {
         "routes",
         "services",
-        "clustering_data_planes",
+        "plugins",
         "upstreams",
         "targets",
         "certificates",
+        "clustering_data_planes",
       }) -- runs migrations
 
       assert(helpers.start_kong({
@@ -45,6 +49,13 @@ for _, strategy in helpers.each_strategy() do
         cluster_control_plane = "127.0.0.1:9005",
         proxy_listen = "0.0.0.0:9002",
       }))
+
+      for _, plugin in ipairs(helpers.get_plugins_list()) do
+        if plugin.name == "key-auth" then
+          KEY_AUTH_PLUGIN = plugin
+          break
+        end
+      end
     end)
 
     lazy_teardown(function()
@@ -73,7 +84,7 @@ for _, strategy in helpers.each_strategy() do
               return true
             end
           end
-        end, 5)
+        end, 10)
       end)
 
       it("shows DP status (#deprecated)", function()
@@ -224,6 +235,10 @@ for _, strategy in helpers.each_strategy() do
         helpers.get_db_utils(strategy, {
           "routes",
           "services",
+          "plugins",
+          "upstreams",
+          "targets",
+          "certificates",
           "clustering_data_planes",
         }) -- runs migrations
 
@@ -237,23 +252,72 @@ for _, strategy in helpers.each_strategy() do
           nginx_conf = "spec/fixtures/custom_nginx.template",
           cluster_version_check = "major_minor",
         }))
+
+        local admin_client = helpers.admin_client()
+        -- configure a few plugins
+        local res = assert(admin_client:post("/plugins", {
+          headers = {
+            ["Content-Type"] = "application/json"
+          },
+          body = {
+            name  = "key-auth"
+          }
+        }))
+        assert.res_status(201, res)
       end)
 
       lazy_teardown(function()
         helpers.stop_kong()
       end)
 
+      local plugins_map = {}
+      -- generate a map of current plugins
+      local plugin_list = pl_tablex.deepcopy(helpers.get_plugins_list())
+      for _, plugin in pairs(plugin_list) do
+        plugins_map[plugin.name] = plugin.version
+      end
+
       -- STARTS allowed cases
       local allowed_cases = {
         ["CP and DP version and plugins matches"] = {},
-        ["CP and DP patch version mismatches"] = {
-          dp_version = string.format("%d.%d.%d", MAJOR, MINOR, 4),
+        ["CP configured plugins list matches DP enabled plugins list"] = {
+          dp_version = string.format("%d.%d.%d", MAJOR, MINOR, PATCH),
+          plugins_list = {
+            {  name = "key-auth", version = plugins_map["key-auth"] }
+          }
+        },
+        ["CP configured plugins list matches DP enabled plugins version"] = {
+          dp_version = string.format("%d.%d.%d", MAJOR, MINOR, PATCH),
+          plugins_list = {
+            {  name = "key-auth", version = plugins_map["key-auth"] }
+          }
+        },
+        ["CP configured plugins list matches DP enabled plugins major version (newer dp plugin)"] = {
+          dp_version = string.format("%d.%d.%d", MAJOR, MINOR, PATCH),
+          plugins_list = {
+            {  name = "key-auth", version = tonumber(plugins_map["key-auth"]:match("(%d+)")) .. ".1000.1000" }
+          }
+        },
+        ["CP configured plugins list matches DP enabled plugins major version (older dp plugin)"] = {
+          dp_version = string.format("%d.%d.%d", MAJOR, MINOR, PATCH),
+          plugins_list = {
+            {  name = "key-auth", version = tonumber(plugins_map["key-auth"]:match("(%d+)")) .. ".0.0" }
+          }
+        },
+        ["CP and DP minor version mismatches (newer dp)"] = {
+          dp_version = string.format("%d.%d.%d", MAJOR, 1000, PATCH),
+        },
+        ["CP and DP minor version mismatches (older dp)"] = {
+          dp_version = string.format("%d.%d.%d", MAJOR, 0, PATCH),
+        },
+        ["CP and DP patch version mismatches (newer dp)"] = {
+          dp_version = string.format("%d.%d.%d", MAJOR, MINOR, 1000),
+        },
+        ["CP and DP patch version mismatches (older dp)"] = {
+          dp_version = string.format("%d.%d.%d", MAJOR, MINOR, 0),
         },
         ["CP and DP suffix mismatches"] = {
           dp_version = tostring(_VERSION_TABLE) .. "-enterprise-version",
-        },
-        ["0 <= CP.minor - DP.minor <= 2"] = {
-          dp_version = tostring(_VERSION_TABLE) ,
         },
       }
 
@@ -264,23 +328,48 @@ for _, strategy in helpers.each_strategy() do
         plugins_list = pl1
       }
 
+
+      allowed_cases["DP plugin set is a subset of CP"] = {
+        plugins_list = { KEY_AUTH_PLUGIN }
+      }
+
       local pl2 = pl_tablex.deepcopy(helpers.get_plugins_list())
-      for i, p in ipairs(pl2) do
+      for i, _ in ipairs(pl2) do
         local v = pl2[i].version
+        local minor = v and v:match("%d+%.(%d+)%.%d+")
+        -- find a plugin that has minor version mismatch
+        -- we hardcode `dummy` plugin to be 9.9.9 so there must be at least one
+        if minor and tonumber(minor) and tonumber(minor) > 2 then
+          pl2[i].version = string.format("%d.%d.%d",
+                                         tonumber(v:match("(%d+)")),
+                                         tonumber(minor - 2),
+                                         tonumber(v:match("%d+%.%d+%.(%d+)"))
+
+          )
+          break
+        end
+      end
+      allowed_cases["CP and DP plugin version matches to major"] = {
+        plugins_list = pl2
+      }
+
+      local pl3 = pl_tablex.deepcopy(helpers.get_plugins_list())
+      for i, _ in ipairs(pl3) do
+        local v = pl3[i].version
         local patch = v and v:match("%d+%.%d+%.(%d+)")
         -- find a plugin that has patch version mismatch
         -- we hardcode `dummy` plugin to be 9.9.9 so there must be at least one
         if patch and tonumber(patch) and tonumber(patch) > 2 then
-          pl2[i].version = string.format("%d.%d.%d",
-            tonumber(v:match("(%d+)")),
-            tonumber(v:match("%d+%.(%d+)")),
-            tonumber(patch - 2)
+          pl3[i].version = string.format("%d.%d.%d",
+                                         tonumber(v:match("(%d+)")),
+                                         tonumber(v:match("%d+%.(%d+)")),
+                                         tonumber(patch - 2)
           )
           break
         end
       end
       allowed_cases["CP and DP plugin version matches to major.minor"] = {
-        plugins_list = pl2
+        plugins_list = pl3
       }
 
       for desc, harness in pairs(allowed_cases) do
@@ -325,81 +414,32 @@ for _, strategy in helpers.each_strategy() do
 
       -- STARTS blocked cases
       local blocked_cases = {
+        ["CP configured plugin list mismatches DP enabled plugins list"] = {
+          dp_version = string.format("%d.%d.%d", MAJOR, MINOR, PATCH),
+          expected = CLUSTERING_SYNC_STATUS.PLUGIN_SET_INCOMPATIBLE,
+          plugins_list = {
+            {  name="banana-plugin", version="1.0.0" }
+          }
+        },
+        ["CP configured plugin list mismatches DP enabled plugins list version"] = {
+          dp_version = string.format("%d.%d.%d", MAJOR, MINOR, PATCH),
+          expected = CLUSTERING_SYNC_STATUS.PLUGIN_VERSION_INCOMPATIBLE,
+          plugins_list = {
+            {  name="key-auth", version="1.0.0" }
+          }
+        },
         ["CP and DP major version mismatches"] = {
           dp_version = "1.0.0",
           expected = CLUSTERING_SYNC_STATUS.KONG_VERSION_INCOMPATIBLE,
+          ignore_error = true
         },
-        ["CP.minor - DP.minor > 2"] = {
-          dp_version = string.format("%d.%d.%d", MAJOR, MINOR-3, PATCH),
-          expected = CLUSTERING_SYNC_STATUS.KONG_VERSION_INCOMPATIBLE,
-        },
-        ["CP.minor - DP.minor < 0"] = {
-          dp_version = string.format("%d.%d.%d", MAJOR, MINOR+1, PATCH),
-          expected = CLUSTERING_SYNC_STATUS.KONG_VERSION_INCOMPATIBLE,
-        },
-      }
-
-      local pl1 = pl_tablex.deepcopy(helpers.get_plugins_list())
-      for i, p in ipairs(pl1) do
-        local v = pl1[i].version
-        local minor = v and v:match("%d+%.(%d+)")
-        -- find a plugin that has minor larger than 1 :joy:
-        -- we hardcode `dummy` plugin to be 9.9.9 so there must be at least one
-        if minor and tonumber(minor) and tonumber(minor) > 1 then
-          pl1[i].version = string.format("%d.%d.%d",
-            tonumber(v:match("(%d+)")),
-            tonumber(v:match("%d+%.(%d+)")) - 1,
-            tonumber(v:match("%d+%.%d+%.(%d+)"))
-          )
-          break
-        end
-      end
-      blocked_cases["CP and DP plugin minor version mismatch"] = {
-        plugins_list = pl1,
-        expected = CLUSTERING_SYNC_STATUS.PLUGIN_VERSION_INCOMPATIBLE,
-      }
-
-      local pl2 = pl_tablex.deepcopy(helpers.get_plugins_list())
-      for i, p in ipairs(pl2) do
-        local v = pl2[i].version
-        local major = v and v:match("(%d+)")
-        -- find a plugin that has major larger than 1 :joy:
-        -- we hardcode `dummy` plugin to be 9.9.9 so there must be at least one
-        if major and tonumber(major) and tonumber(major) > 1 then
-          pl2[i].version = string.format("%d.%d.%d",
-            tonumber(major - 1),
-            tonumber(v:match("%d+%.(%d+)")),
-            tonumber(v:match("%d+%.%d+%.(%d+)"))
-          )
-          break
-        end
-      end
-      blocked_cases["CP and DP plugin major version mismatch"] = {
-        plugins_list = pl2,
-        expected = CLUSTERING_SYNC_STATUS.PLUGIN_VERSION_INCOMPATIBLE,
-      }
-
-      local pl3 = pl_tablex.deepcopy(helpers.get_plugins_list())
-      table.remove(pl3, #pl3/2)
-      blocked_cases["DP plugin set is subset of CP"] = {
-        plugins_list = pl3,
-        expected = CLUSTERING_SYNC_STATUS.PLUGIN_SET_INCOMPATIBLE,
-      }
-
-      local pl4 = pl_tablex.deepcopy(helpers.get_plugins_list())
-      table.remove(pl4, 2)
-      table.insert(pl4, 4, { name = "banana", version = "1.1.1" })
-      table.insert(pl4, { name = "pineapple", version = "1.1.1" })
-      blocked_cases["CP and DP plugin set mismatch"] = {
-        plugins_list = pl4,
-        expected = CLUSTERING_SYNC_STATUS.PLUGIN_SET_INCOMPATIBLE,
       }
 
       for desc, harness in pairs(blocked_cases) do
         it(desc ..", sync is blocked", function()
           local uuid = utils.uuid()
 
-          local res = assert(helpers.clustering_client({
+          local res, err = helpers.clustering_client({
             host = "127.0.0.1",
             port = 9005,
             cert = "spec/fixtures/kong_clustering.crt",
@@ -407,9 +447,16 @@ for _, strategy in helpers.each_strategy() do
             node_id = uuid,
             node_version = harness.dp_version,
             node_plugins_list = harness.plugins_list,
-          }))
+          })
 
-          assert.equals("PONG", res)
+          if not res then
+            if not harness.ignore_error then
+              error(err)
+            end
+
+          else
+            assert.equals("PONG", res)
+          end
 
           -- needs wait_until for c* convergence
           helpers.wait_until(function()
@@ -441,6 +488,11 @@ for _, strategy in helpers.each_strategy() do
       helpers.get_db_utils(strategy, {
         "routes",
         "services",
+        "plugins",
+        "upstreams",
+        "targets",
+        "certificates",
+        "clustering_data_planes",
       }) -- runs migrations
 
       assert(helpers.start_kong({

--- a/spec/02-integration/09-hybrid_mode/05-ocsp_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/05-ocsp_spec.lua
@@ -199,10 +199,10 @@ for _, strategy in helpers.each_strategy() do
         helpers.stop_kong()
       end)
       describe("status API", function()
-        it("shows DP status", function()
+        it("does not show DP status", function()
           helpers.wait_until(function()
             local logs = pl_file.read(TEST_CONF.prefix .. "/" .. TEST_CONF.proxy_error_log)
-            if logs:find('DP client certificate revocation check failed: OCSP responder returns bad HTTP status code: 500', nil, true) then
+            if logs:find('data plane client certificate revocation check failed: OCSP responder returns bad HTTP status code: 500', nil, true) then
               local admin_client = helpers.admin_client()
               finally(function()
                 admin_client:close()
@@ -421,7 +421,7 @@ for _, strategy in helpers.each_strategy() do
             for _, v in pairs(json.data) do
               if v.ip == "127.0.0.1" then
                 local logs = pl_file.read(TEST_CONF.prefix .. "/" .. TEST_CONF.proxy_error_log)
-                if logs:find('DP client certificate revocation check failed: OCSP responder returns bad HTTP status code: 500', nil, true) then
+                if logs:find('data plane client certificate revocation check failed: OCSP responder returns bad HTTP status code: 500', nil, true) then
                   return true
                 end
               end


### PR DESCRIPTION
### Summary

Incompatibility checks on control plane were loosened. Previously data plane was considered incompatible when:

1. data plane kong major version is different to control plane major version
2. data plane minor version is greater than control plane minor version
3. data plane minor version is behind more than two minor versions of control plane
4. data plane missed plugin that control plane had (whether it was configured or not)
5. data plane has different major.minor version of the plugin that control plane had
   (whether it was configured or not)

This commit changes that. With this commit the data plane is considered incompatible when:

1. data plane kong major version is different to control plane major version
2. data plane misses _configured_ plugin
3. data plane plugin major version is different to _configured_ plugin major version on control plane

This also makes the logging on these configuration issues on control plane more uniform and contains
information about the data plane which caused the incompatibility.

It still misses features such as data plane reporting import errors back to control plane or dao checks,
but let's leave that to other future pr.