### PR TITLE
docs/openapi spec sorted yaml

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -100,6 +100,11 @@ jobs:
           eval `luarocks path`
           scripts/autodoc
 
+    - name: Check Admin API definition generation
+      run: |
+          eval `luarocks path`
+          scripts/gen-admin-api-def.sh
+
     - name: Lint Lua code
       run: |
           eval `luarocks path`

--- a/autodoc/admin-api/lyaml-sorted-dump.lua
+++ b/autodoc/admin-api/lyaml-sorted-dump.lua
@@ -1,0 +1,252 @@
+local explicit = require 'lyaml.explicit'
+local functional = require 'lyaml.functional'
+local implicit = require 'lyaml.implicit'
+local yaml = require 'yaml'
+
+local anyof = functional.anyof
+local find = string.find
+local id = functional.id
+local isnull = functional.isnull
+
+
+local TAG_PREFIX = 'tag:yaml.org,2002:'
+
+
+local function tag(name)
+   return TAG_PREFIX .. name
+end
+
+
+local default = {
+   -- Tag table to lookup explicit scalar conversions.
+   explicit_scalar = {
+      [tag 'bool'] = explicit.bool,
+      [tag 'float'] = explicit.float,
+      [tag 'int'] = explicit.int,
+      [tag 'null'] = explicit.null,
+      [tag 'str'] = explicit.str,
+   },
+   -- Order is important, so we put most likely and fastest nearer
+   -- the top to reduce average number of comparisons and funcalls.
+   implicit_scalar = anyof {
+      implicit.null,
+      implicit.octal,	-- subset of decimal, must come earlier
+      implicit.decimal,
+      implicit.float,
+      implicit.bool,
+      implicit.inf,
+      implicit.nan,
+      implicit.hexadecimal,
+      implicit.binary,
+      implicit.sexagesimal,
+      implicit.sexfloat,
+      id,
+   },
+}
+
+
+
+-- Metatable for Dumper objects.
+local dumper_mt = {
+   __index = {
+      -- Emit EVENT to the LibYAML emitter.
+      emit = function(self, event)
+         return self.emitter.emit(event)
+      end,
+
+      -- Look up an anchor for a repeated document element.
+      get_anchor = function(self, value)
+         local r = self.anchors[value]
+         if r then
+            self.aliased[value], self.anchors[value] = self.anchors[value], nil
+         end
+         return r
+      end,
+
+      -- Look up an already anchored repeated document element.
+      get_alias = function(self, value)
+         return self.aliased[value]
+      end,
+
+      -- Dump ALIAS into the event stream.
+      dump_alias = function(self, alias)
+         return self:emit {
+            type = 'ALIAS',
+            anchor = alias,
+         }
+      end,
+
+      -- Dump MAP into the event stream.
+      dump_mapping = function(self, map)
+         local alias = self:get_alias(map)
+         if alias then
+            return self:dump_alias(alias)
+         end
+
+         self:emit {
+            type = 'MAPPING_START',
+            style = 'BLOCK',
+         }
+
+         local keys = {}
+         for k in pairs(map) do
+            keys[#keys + 1] = k
+         end
+         table.sort(keys)
+
+         for i = 1,#keys do
+            local k = keys[i]
+            self:dump_node(k)
+            self:dump_node(map[k])
+         end
+         return self:emit {type='MAPPING_END'}
+      end,
+
+      -- Dump SEQUENCE into the event stream.
+      dump_sequence = function(self, sequence)
+         local alias = self:get_alias(sequence)
+         if alias then
+            return self:dump_alias(alias)
+         end
+
+         self:emit {
+            type   = 'SEQUENCE_START',
+            anchor = self:get_anchor(sequence),
+            style  = 'BLOCK',
+         }
+         for _, v in ipairs(sequence) do
+            self:dump_node(v)
+         end
+         return self:emit {type='SEQUENCE_END'}
+      end,
+
+      -- Dump a null into the event stream.
+      dump_null = function(self)
+         return self:emit {
+            type = 'SCALAR',
+            value = '~',
+            plain_implicit = true,
+            quoted_implicit = true,
+            style = 'PLAIN',
+         }
+      end,
+
+      -- Dump VALUE into the event stream.
+      dump_scalar = function(self, value)
+         local alias = self:get_alias(value)
+         if alias then
+            return self:dump_alias(alias)
+         end
+
+         local anchor = self:get_anchor(value)
+         local itsa = type(value)
+         local style = 'PLAIN'
+         if itsa == 'string' and self.implicit_scalar(value) ~= value then
+            -- take care to round-trip strings that look like scalars
+            style = 'SINGLE_QUOTED'
+         elseif value == math.huge then
+            value = '.inf'
+         elseif value == -math.huge then
+            value = '-.inf'
+         elseif value ~= value then
+            value = '.nan'
+         elseif itsa == 'number' or itsa == 'boolean' then
+            value = tostring(value)
+         elseif itsa == 'string' and find(value, '\n') then
+            style = 'LITERAL'
+         end
+         return self:emit {
+            type = 'SCALAR',
+            anchor = anchor,
+            value = value,
+            plain_implicit = true,
+            quoted_implicit = true,
+            style = style,
+         }
+      end,
+
+      -- Decompose NODE into a stream of events.
+      dump_node = function(self, node)
+         local itsa = type(node)
+         if isnull(node) then
+            return self:dump_null()
+         elseif itsa == 'string' or itsa == 'boolean' or itsa == 'number' then
+            return self:dump_scalar(node)
+         elseif itsa == 'table' then
+            -- Something is only a sequence if its keys start at 1
+            -- and are consecutive integers without any jumps.
+            local prior_key = 0
+            local is_pure_sequence = true
+            local i, _ = next(node, nil)
+            while i and is_pure_sequence do
+              if type(i) ~= "number" or (prior_key + 1 ~= i) then
+                is_pure_sequence = false -- breaks the loop
+              else
+                prior_key = i
+                i, _ = next(node, prior_key)
+              end
+            end
+            if is_pure_sequence then
+               -- Only sequentially numbered integer keys starting from 1.
+               return self:dump_sequence(node)
+            else
+               -- Table contains non sequential integer keys or mixed keys.
+               return self:dump_mapping(node)
+            end
+         else -- unsupported Lua type
+            error("cannot dump object of type '" .. itsa .. "'", 2)
+         end
+      end,
+
+      -- Dump DOCUMENT into the event stream.
+      dump_document = function(self, document)
+         self:emit {type='DOCUMENT_START'}
+         self:dump_node(document)
+         return self:emit {type='DOCUMENT_END'}
+      end,
+   },
+}
+
+
+local function Dumper(opts)
+   local anchors = {}
+   for k, v in pairs(opts.anchors) do
+      anchors[v] = k
+   end
+   local object = {
+      aliased = {},
+      anchors = anchors,
+      emitter = yaml.emitter(),
+      implicit_scalar = opts.implicit_scalar,
+   }
+   return setmetatable(object, dumper_mt)
+end
+
+
+--- Dump a list of Lua tables to an equivalent YAML stream.
+-- @tparam table documents a sequence of Lua tables.
+-- @tparam[opt] dumper_opts opts initialisation options
+-- @treturn string equivalest YAML stream
+local function lyaml_sorted_dump(documents, opts)
+   opts = opts or {}
+
+   -- backwards compatibility
+   if opts.anchors == nil and opts.implicit_scalar == nil then
+      opts = {anchors=opts}
+   end
+
+   local dumper = Dumper {
+      anchors = opts.anchors or {},
+      implicit_scalar = opts.implicit_scalar or default.implicit_scalar,
+   }
+
+   dumper:emit {type='STREAM_START', encoding='UTF8'}
+   for _, document in ipairs(documents) do
+      dumper:dump_document(document)
+   end
+   local _, stream = dumper:emit {type='STREAM_END'}
+   return stream
+end
+
+
+return lyaml_sorted_dump

--- a/autodoc/admin-api/openapi-gen.lua
+++ b/autodoc/admin-api/openapi-gen.lua
@@ -1,0 +1,440 @@
+local admin_api_data = require "autodoc.admin-api.data.admin-api"
+local kong_meta = require "kong.meta"
+local lfs = require "lfs"
+local lyaml = require "lyaml"
+local typedefs = require "kong.db.schema.typedefs"
+
+local OPENAPI_VERSION = "3.1.0"
+local KONG_CONTACT_NAME = "Kong"
+local KONG_CONTACT_URL = "https://github.com/Kong/kong"
+local LICENSE_NAME = "Apache 2.0"
+local LICENSE_URL = "https://github.com/Kong/kong/blob/master/LICENSE"
+
+local METHOD_NA_DBLESS = "This method is not available when using DB-less mode."
+local METHOD_ONLY_DBLESS = "This method is only available when using DB-less mode."
+
+local HTTP_METHODS = {
+  ["GET"] = true,
+  ["HEAD"] = true,
+  ["POST"] = true,
+  ["PUT"] = true,
+  ["DELETE"] = true,
+  ["CONNECT"] = true,
+  ["OPTIONS"] = true,
+  ["TRACE"] = true,
+  ["PATCH"] = true,
+}
+
+local entities_path = "kong/db/schema/entities"
+local routes_path = "kong/api/routes"
+
+-- workaround to load module files
+_KONG = require("kong.meta")          -- luacheck: ignore
+kong = require("kong.global").new()   -- luacheck: ignore
+kong.configuration = {                -- luacheck: ignore
+  loaded_plugins = {},
+}
+kong.db = require("kong.db").new({    -- luacheck: ignore
+  database = "postgres",
+})
+kong.configuration = { -- luacheck: ignore
+  loaded_plugins = {}
+}
+
+
+
+local property_format = {
+  ["auto_timestamp_ms"] = "float",
+  ["auto_timestamp_s"] = "int32",
+  ["host"] = "hostname",
+  ["ip"] = "ip",
+  ["port"] = "int32",
+  ["uuid"] = "uuid",
+}
+
+local property_type = {
+  ["array"] = "array",
+  ["boolean"] = "boolean",
+  ["foreign"] = nil,
+  ["integer"] = "integer",
+  ["map"] = "array",
+  ["number"] = "number",
+  ["record"] = "array",
+  ["set"] = "array",
+  ["string"] = "string",
+  ["auto_timestamp_ms"] = "number",
+  ["auto_timestamp_s"] = "integer",
+  ["destinations"] = "array",
+  ["header_name"] = "string",
+  ["host"] = "string",
+  ["host_with_optional_port"] = "string",
+  ["hosts"] = "array",
+  ["ip"] = "string",
+  ["methods"] = "array",
+  ["path"] = "string",
+  ["paths"] = "array",
+  ["port"] = "integer",
+  ["protocols"] = "array",
+  ["semantic_version"] = "string",
+  ["sources"] = "array",
+  ["tag"] = "string",
+  ["tags"] = "array",
+  ["utf8_name"] = "string",
+  ["uuid"] = "string",
+}
+
+local property_enum = {
+  ["protocols"] = {
+    "http",
+    "https",
+    "tcp",
+    "tls",
+    "udp",
+    "grpc",
+    "grpcs"
+  },
+}
+
+local property_minimum = {
+  ["port"] = 0,
+}
+
+local property_maximum = {
+  ["port"] = 65535,
+}
+
+
+local function sanitize_text(text)
+  if text == nil then
+    return text
+  end
+
+  if type(text) ~= "string" then
+    error("invalid type received: " .. type(text) ..
+          ". sanitize_text() sanitizes text", 2)
+  end
+
+  -- remove all <div></div> from text
+  text = text:gsub("<div.->(.-)</div>","")
+
+  return text
+end
+
+
+local function get_openapi()
+  local openapi = OPENAPI_VERSION
+
+  return openapi
+end
+
+
+local function get_info()
+  local info = {
+    ["title"] = "Kong Admin API",
+    ["summary"] = "Kong RESTful Admin API for administration purposes.",
+    ["description"] = sanitize_text(admin_api_data["intro"][1]["text"]),
+    ["version"] = kong_meta._VERSION,
+    ["contact"] = {
+      ["name"] = KONG_CONTACT_NAME,
+      ["url"] = KONG_CONTACT_URL,
+      --["email"] = "",
+    },
+    ["license"] = {
+      ["name"] = LICENSE_NAME,
+      ["url"] = LICENSE_URL,
+    },
+  }
+
+  return info
+end
+
+
+local function get_servers()
+  local servers = {
+    {
+      ["url"] = "http://localhost:8001",
+      ["description"] = "8001 is the default port on which the Admin API listens.",
+    },
+    {
+      ["url"] = "https://localhost:8444",
+      ["description"] = "8444 is the default port for HTTPS traffic to the Admin API.",
+    },
+  }
+
+  return servers
+end
+
+
+local function get_package_from_path(path)
+  if type(path) ~= "string" then
+    error("path must be a string, but it is " .. type(path), 2)
+  end
+
+  local package = path:gsub("(.lua)","")
+  package = package:gsub("/",".")
+
+  return package
+end
+
+
+local function get_property_reference(reference)
+  local reference_path
+
+  if reference ~= nil and type(reference) == "string" then
+    reference_path = "#/components/schemas/" .. reference
+  end
+
+  return reference_path
+end
+
+
+local function get_full_type(properties)
+  local actual_type
+
+  if properties.type == nil or properties.type == "foreign" then
+    return nil
+  end
+
+  for type_name, type_content in pairs(typedefs) do
+    if properties == type_content then
+      actual_type = type_name
+      break
+    end
+  end
+
+  if actual_type == nil and properties.type then
+    actual_type = properties.type
+  end
+
+  return actual_type
+end
+
+
+local function get_field_details(field_properties)
+  local details = {}
+
+  local actual_type = get_full_type(field_properties)
+  if actual_type then
+    details.type = property_type[actual_type]
+    details.format = property_format[actual_type]
+    details.enum = property_enum[actual_type]
+    details.minimum = property_minimum[actual_type]
+    details.maximum = property_maximum[actual_type]
+  end
+
+  details["$ref"] = get_property_reference(field_properties.reference)
+  if field_properties.default == ngx.null then
+    details.nullable = true
+    details.default = lyaml.null
+  else
+    details.default = field_properties.default
+  end
+
+  return details
+end
+
+
+local function get_properties_from_entity_fields(fields)
+  local properties = {}
+  local required = {}
+
+  for _, field in ipairs(fields) do
+    for field_name, field_props in pairs(field) do
+      properties[field_name] = get_field_details(field_props)
+      if field_props.required then
+        table.insert(required, field_name)
+      end
+    end
+  end
+
+  return properties, required
+end
+
+
+local function get_schemas()
+  local schemas = {}
+
+  for file in lfs.dir(entities_path) do
+    if file ~= "." and file ~= ".." then
+      local entity_path = entities_path .. "/" .. file
+      local entity_package = get_package_from_path(entity_path)
+      local entity = require(entity_package)
+      if entity then
+        if entity.name then -- TODO: treat special case "routes_subschemas"
+          local entity_content = {}
+          entity_content.type = "object"
+          entity_content.properties, entity_content.required = get_properties_from_entity_fields(entity.fields)
+          schemas[entity.name] = entity_content
+        end
+      end
+    end
+  end
+
+  return schemas
+end
+
+
+local function get_components()
+  local components = {}
+  components.schemas = get_schemas()
+
+  return components
+end
+
+
+local function get_all_routes()
+  local routes = {}
+
+  for file in lfs.dir(routes_path) do
+    if file ~= "." and file ~= ".." then
+      local route_path = routes_path .. "/" .. file
+      local route_package = get_package_from_path(route_path)
+      local route = require(route_package)
+      table.insert(routes, route)
+    end
+  end
+
+  return routes
+end
+
+
+local function is_http_method(name)
+  return HTTP_METHODS[name] == true
+end
+
+
+local function translate_path(entry)
+  if entry:len() < 2 then
+    return entry
+  end
+
+  local translated = ""
+
+  for segment in string.gmatch(entry, "([^/]+)") do
+    if segment:byte(1) == string.byte(":") then
+      segment = "{" .. segment:sub(2, segment:len()) .. "}"
+    end
+    translated = translated .. "/" .. segment
+  end
+
+  return translated
+end
+
+
+local function fill_paths(paths)
+  local entities = admin_api_data.entities
+  local general_routes = admin_api_data.general
+  local path_content = {}
+
+  -- extract path details from entities
+  for name, entity in pairs(entities) do
+    for entry, content in pairs(entity) do
+      if type(entry) == "string" and entry:sub(1,1) == "/" then
+        path_content[entry] = content
+      end
+    end
+  end
+
+  -- extract path details from general entries
+  for x, content in pairs(general_routes) do
+    if type(content) == "table" then
+      for entry, entry_content in pairs(content) do
+        if type(entry) == "string" and entry:sub(1,1) == "/" then
+          path_content[entry] = entry_content
+        end
+      end
+    end
+  end
+
+  -- fill received paths
+  for path, methods in pairs(paths) do
+    for method, content in pairs(methods) do
+      if path == "/config" then
+        content.summary = METHOD_ONLY_DBLESS
+      elseif method ~= "get" then
+        content.summary = METHOD_NA_DBLESS
+      end
+
+      if path_content[path] and path_content[path][method:upper()] and path_content[path][method:upper()].title then
+        if content.summary and content.summary:len() > 1 then
+          content.summary = content.summary .. " "
+        else
+          content.summary = ""
+        end
+
+        content.summary = content.summary .. path_content[path][method:upper()].title
+      end
+    end
+
+    -- translate :entity to {entity} in paths
+    local actual_path = translate_path(path)
+    if actual_path ~= path then
+      paths[actual_path] = paths[path]
+      paths[path] = nil
+    end
+  end
+
+end
+
+
+local function get_paths()
+  local paths = {}
+  local routes = get_all_routes()
+
+  for _, route in ipairs(routes) do
+    for entry, functions in pairs(route) do
+      if type(entry) == "string" and entry:sub(1,1) == "/" then
+        paths[entry] = {}
+        for function_name, _ in pairs(functions) do
+          if is_http_method(function_name) then
+            paths[entry][function_name:lower()] = {}
+          end
+        end
+      end
+    end
+  end
+
+  fill_paths(paths)
+
+  return paths
+end
+
+
+local function write_file(filename, content)
+  local pok, yaml, err = pcall(lyaml.dump, { content })
+  if not pok then
+    error("lyaml failed: " .. yaml, 2)
+  end
+  if not yaml then
+    print("creating yaml failed: " .. err, 2)
+  end
+
+  -- drop the multi-document "---\n" header and "\n..." trailer
+  local content = yaml:sub(5, -5)
+  if content then
+    local file, errmsg = io.open(filename, "w")
+    if errmsg then
+      error("could not open " .. filename .. " for writing: " .. errmsg, 2)
+    end
+    file:write(content)
+    file:close()
+  end
+
+end
+
+
+local function main(filepath)
+
+  local openapi_spec_content = {}
+
+  openapi_spec_content.openapi = get_openapi()
+  openapi_spec_content.info = get_info()
+  openapi_spec_content.servers = get_servers()
+  openapi_spec_content.components = get_components()
+  openapi_spec_content.paths = get_paths()
+
+  write_file(filepath, openapi_spec_content)
+end
+
+
+main(arg[1])

--- a/autodoc/admin-api/openapi-gen.lua
+++ b/autodoc/admin-api/openapi-gen.lua
@@ -350,19 +350,13 @@ local function fill_paths(paths)
   for path, methods in pairs(paths) do
     for method, content in pairs(methods) do
       if path == "/config" then
-        content.summary = METHOD_ONLY_DBLESS
+        content.description = METHOD_ONLY_DBLESS
       elseif method ~= "get" then
-        content.summary = METHOD_NA_DBLESS
+        content.description = METHOD_NA_DBLESS
       end
 
-      if path_content[path] and path_content[path][method:upper()] and path_content[path][method:upper()].title then
-        if content.summary and content.summary:len() > 1 then
-          content.summary = content.summary .. " "
-        else
-          content.summary = ""
-        end
-
-        content.summary = content.summary .. path_content[path][method:upper()].title
+      if path_content[path] and path_content[path][method:upper()] then
+        content.summary = path_content[path][method:upper()].title
       end
     end
 

--- a/autodoc/admin-api/openapi-gen.lua
+++ b/autodoc/admin-api/openapi-gen.lua
@@ -1,8 +1,14 @@
+#!/usr/bin/env resty
+
+setmetatable(_G, nil)
+
+
 local admin_api_data = require "autodoc.admin-api.data.admin-api"
 local kong_meta = require "kong.meta"
 local lfs = require "lfs"
 local lyaml = require "lyaml"
 local typedefs = require "kong.db.schema.typedefs"
+local lsd = require "autodoc.admin-api.lyaml-sorted-dump"
 
 local OPENAPI_VERSION = "3.1.0"
 local KONG_CONTACT_NAME = "Kong"
@@ -395,7 +401,7 @@ end
 
 
 local function write_file(filename, content)
-  local pok, yaml, err = pcall(lyaml.dump, { content })
+  local pok, yaml, err = pcall(lsd, { content })
   if not pok then
     error("lyaml failed: " .. yaml, 2)
   end
@@ -431,4 +437,4 @@ local function main(filepath)
 end
 
 
-main(arg[1])
+main(arg[1] or "kong-admin-api.yml")

--- a/kong-admin-api.yml
+++ b/kong-admin-api.yml
@@ -2,9 +2,75 @@ servers:
 - description: 8001 is the default port on which the Admin API listens.
   url: http://localhost:8001
 - description: 8444 is the default port for HTTPS traffic to the Admin API.
-  url: http://localhost:8444
+  url: https://localhost:8444
+openapi: 3.1.0
 components:
   schemas:
+    parameters:
+      required:
+      - key
+      - value
+      type: object
+      properties:
+        value:
+          type: string
+        key:
+          type: string
+        created_at:
+          format: int32
+          type: integer
+    services:
+      required:
+      - protocol
+      - host
+      - port
+      type: object
+      properties:
+        tls_verify:
+          type: boolean
+        tls_verify_depth:
+          default: ~
+          type: integer
+          nullable: true
+        created_at:
+          format: int32
+          type: integer
+        updated_at:
+          format: int32
+          type: integer
+        name:
+          type: string
+        tags:
+          type: array
+        ca_certificates:
+          type: array
+        retries:
+          type: integer
+          default: 5
+        host:
+          type: string
+        id:
+          format: uuid
+          type: string
+        port:
+          type: integer
+          default: 80
+        path:
+          type: string
+        protocol:
+          type: string
+          default: http
+        read_timeout:
+          type: integer
+          default: 60000
+        connect_timeout:
+          type: integer
+          default: 60000
+        client_certificate:
+          $ref: '#/components/schemas/certificates'
+        write_timeout:
+          type: integer
+          default: 60000
     routes:
       required:
       - protocols
@@ -15,67 +81,65 @@ components:
       - response_buffering
       type: object
       properties:
-        headers:
+        destinations:
           type: array
+        hosts:
+          type: array
+        methods:
+          type: array
+        paths:
+          type: array
+        protocols:
+          type: array
+          default:
+          - http
+          - https
+        created_at:
+          format: int32
+          type: integer
+        strip_path:
+          type: boolean
+          default: true
         name:
           type: string
+        path_handling:
+          type: string
+          default: v0
+        preserve_host:
+          type: boolean
+          default: false
+        request_buffering:
+          type: boolean
+          default: true
+        response_buffering:
+          type: boolean
+          default: true
+        regex_priority:
+          type: integer
+          default: 0
+        service:
+          $ref: '#/components/schemas/services'
+        https_redirect_status_code:
+          type: integer
+          default: 426
         id:
           format: uuid
           type: string
         tags:
           type: array
-        strip_path:
-          default: true
-          type: boolean
-        destinations:
+        sources:
           type: array
-        path_handling:
-          default: v0
-          type: string
-        hosts:
+        snis:
           type: array
-        methods:
+        headers:
           type: array
-        request_buffering:
-          default: true
-          type: boolean
         updated_at:
           format: int32
           type: integer
-        response_buffering:
-          default: true
-          type: boolean
-        sources:
-          type: array
-        service:
-          $ref: '#/components/schemas/services'
-        snis:
-          type: array
-        https_redirect_status_code:
-          default: 426
-          type: integer
-        created_at:
-          format: int32
-          type: integer
-        preserve_host:
-          default: false
-          type: boolean
-        protocols:
-          default:
-          - http
-          - https
-          type: array
-        regex_priority:
-          default: 0
-          type: integer
-        paths:
-          type: array
     consumers:
       required: []
       type: object
       properties:
-        custom_id:
-          type: string
         id:
           format: uuid
           type: string
@@ -86,6 +150,8 @@ components:
           type: string
         tags:
           type: array
+        custom_id:
+          type: string
     plugins:
       required:
       - name
@@ -93,18 +159,33 @@ components:
       - enabled
       type: object
       properties:
-        name:
+        service:
+          $ref: '#/components/schemas/services'
+          default: ~
+          nullable: true
+        enabled:
+          type: boolean
+          default: true
+        id:
+          format: uuid
           type: string
         created_at:
           format: int32
           type: integer
+        tags:
+          type: array
+        name:
+          type: string
+        route:
+          $ref: '#/components/schemas/routes'
+          default: ~
+          nullable: true
         protocols:
           default:
           - grpc
           - grpcs
           - http
           - https
-          type: array
           enum:
           - http
           - https
@@ -113,47 +194,32 @@ components:
           - udp
           - grpc
           - grpcs
-        service:
-          default: ~
-          nullable: true
-          $ref: '#/components/schemas/services'
-        enabled:
-          default: true
-          type: boolean
-        id:
-          format: uuid
-          type: string
-        route:
-          default: ~
-          nullable: true
-          $ref: '#/components/schemas/routes'
-        tags:
           type: array
-        consumer:
-          default: ~
-          nullable: true
-          $ref: '#/components/schemas/consumers'
         config:
           type: array
+        consumer:
+          $ref: '#/components/schemas/consumers'
+          default: ~
+          nullable: true
     certificates:
       required:
       - cert
       - key
       type: object
       properties:
-        cert_alt:
-          type: string
         id:
           format: uuid
-          type: string
-        cert:
           type: string
         created_at:
           format: int32
           type: integer
+        key_alt:
+          type: string
+        cert:
+          type: string
         tags:
           type: array
-        key_alt:
+        cert_alt:
           type: string
         key:
           type: string
@@ -165,17 +231,17 @@ components:
         id:
           format: uuid
           type: string
-        comment:
-          type: string
         created_at:
           format: int32
           type: integer
-        meta:
-          type: array
-        config:
-          type: array
+        comment:
+          type: string
         name:
           type: string
+        config:
+          type: array
+        meta:
+          type: array
     snis:
       required:
       - name
@@ -185,36 +251,67 @@ components:
         id:
           format: uuid
           type: string
-        name:
-          type: string
         created_at:
           format: int32
           type: integer
-        certificate:
-          $ref: '#/components/schemas/certificates'
+        name:
+          type: string
         tags:
           type: array
+        certificate:
+          $ref: '#/components/schemas/certificates'
     upstreams:
       required:
       - name
       type: object
       properties:
-        algorithm:
-          default: round-robin
+        hash_fallback:
           type: string
+          default: none
+        hash_on_header:
+          type: string
+        client_certificate:
+          $ref: '#/components/schemas/certificates'
+        hash_fallback_header:
+          type: string
+        host_header:
+          type: string
+        hash_on_cookie:
+          type: string
+        tags:
+          type: array
+        id:
+          format: uuid
+          type: string
+        created_at:
+          format: int32
+          type: integer
+        slots:
+          type: integer
+          default: 10000
+        name:
+          type: string
+        algorithm:
+          type: string
+          default: round-robin
         healthchecks:
+          type: array
           default:
             active:
-              type: http
               timeout: 1
+              concurrency: 10
+              type: http
+              https_verify_certificate: true
               healthy:
+                interval: 0
+                successes: 0
                 http_statuses:
                 - 200
                 - 302
-                interval: 0
-                successes: 0
               unhealthy:
+                timeouts: 0
                 interval: 0
+                http_failures: 0
                 http_statuses:
                 - 429
                 - 404
@@ -225,21 +322,8 @@ components:
                 - 504
                 - 505
                 tcp_failures: 0
-                timeouts: 0
-                http_failures: 0
-              https_verify_certificate: true
-              concurrency: 10
               http_path: /
             passive:
-              unhealthy:
-                http_statuses:
-                - 429
-                - 500
-                - 503
-                tcp_failures: 0
-                timeouts: 0
-                http_failures: 0
-              type: http
               healthy:
                 successes: 0
                 http_statuses:
@@ -262,39 +346,21 @@ components:
                 - 306
                 - 307
                 - 308
-          type: array
-        name:
-          type: string
-        created_at:
-          format: int32
-          type: integer
-        hash_fallback:
-          default: none
-          type: string
-        client_certificate:
-          $ref: '#/components/schemas/certificates'
-        hash_on_header:
-          type: string
-        host_header:
-          type: string
-        hash_fallback_header:
-          type: string
-        id:
-          format: uuid
-          type: string
-        hash_on_cookie:
-          type: string
-        tags:
-          type: array
-        hash_on_cookie_path:
-          default: /
-          type: string
+              type: http
+              unhealthy:
+                timeouts: 0
+                http_failures: 0
+                http_statuses:
+                - 429
+                - 500
+                - 503
+                tcp_failures: 0
         hash_on:
-          default: none
           type: string
-        slots:
-          default: 10000
-          type: integer
+          default: none
+        hash_on_cookie_path:
+          type: string
+          default: /
     targets:
       required:
       - upstream
@@ -304,68 +370,18 @@ components:
         id:
           format: uuid
           type: string
-        upstream:
-          $ref: '#/components/schemas/upstreams'
         created_at:
           format: float
           type: number
         tags:
           type: array
+        upstream:
+          $ref: '#/components/schemas/upstreams'
         target:
           type: string
         weight:
+          type: integer
           default: 100
-          type: integer
-    clustering_data_planes:
-      required:
-      - id
-      - ip
-      - hostname
-      - sync_status
-      type: object
-      properties:
-        sync_status:
-          default: unknown
-          type: string
-        id:
-          type: string
-        version:
-          type: string
-        last_seen:
-          format: int32
-          type: integer
-        config_hash:
-          type: string
-        ip:
-          type: string
-        hostname:
-          type: string
-    tags:
-      required:
-      - tag
-      - entity_name
-      - entity_id
-      type: object
-      properties:
-        tag:
-          type: string
-        entity_name:
-          type: string
-        entity_id:
-          type: string
-    parameters:
-      required:
-      - key
-      - value
-      type: object
-      properties:
-        created_at:
-          format: int32
-          type: integer
-        key:
-          type: string
-        value:
-          type: string
     ca_certificates:
       required:
       - cert
@@ -374,184 +390,55 @@ components:
         id:
           format: uuid
           type: string
-        cert_digest:
-          type: string
         created_at:
           format: int32
           type: integer
-        tags:
-          type: array
         cert:
           type: string
-    services:
-      required:
-      - protocol
-      - host
-      - port
-      type: object
-      properties:
-        path:
+        cert_digest:
           type: string
-        name:
-          type: string
-        host:
-          type: string
-        write_timeout:
-          default: 60000
-          type: integer
-        read_timeout:
-          default: 60000
-          type: integer
-        client_certificate:
-          $ref: '#/components/schemas/certificates'
-        id:
-          format: uuid
-          type: string
-        tls_verify:
-          type: boolean
         tags:
           type: array
-        tls_verify_depth:
-          default: ~
-          nullable: true
-          type: integer
-        created_at:
-          format: int32
-          type: integer
-        updated_at:
-          format: int32
-          type: integer
-        protocol:
-          default: http
+    tags:
+      required:
+      - tag
+      - entity_name
+      - entity_id
+      type: object
+      properties:
+        entity_name:
           type: string
-        ca_certificates:
-          type: array
-        connect_timeout:
-          default: 60000
+        entity_id:
+          type: string
+        tag:
+          type: string
+    clustering_data_planes:
+      required:
+      - id
+      - ip
+      - hostname
+      - sync_status
+      type: object
+      properties:
+        id:
+          type: string
+        last_seen:
+          format: int32
           type: integer
-        port:
-          default: 80
-          type: integer
-        retries:
-          default: 5
-          type: integer
-openapi: 3.1.0
-paths:
-  /targets/{targets}: []
-  /targets/{targets}/upstream: []
-  /:
-    get:
-      summary: Retrieve node information
-  /routes/{routes}/plugins:
-    post:
-      summary: This method is not available when using DB-less mode.
-  /cache/{key}:
-    delete:
-      summary: This method is not available when using DB-less mode.
-    get: []
-  /clustering/data-planes: []
-  /clustering/status: []
-  /schemas/{db_entity_name}/validate:
-    post:
-      summary: This method is not available when using DB-less mode. Validate a configuration
-        against a schema
-  /schemas/{name}:
-    get:
-      summary: Retrieve Entity Schema
-  /routes/{routes}/plugins/{plugins}:
-    patch:
-      summary: This method is not available when using DB-less mode.
-  /services/{services}/plugins/{plugins}:
-    patch:
-      summary: This method is not available when using DB-less mode.
-  /config:
-    post:
-      summary: This method is only available when using DB-less mode.
-    get:
-      summary: This method is only available when using DB-less mode.
-  /schemas/plugins/{name}:
-    get:
-      summary: Retrieve Plugin Schema
-  /upstreams/{upstreams}/targets/{targets}:
-    delete:
-      summary: This method is not available when using DB-less mode. Delete Target
-    patch:
-      summary: This method is not available when using DB-less mode. Update Target
-    get: []
-    put:
-      summary: This method is not available when using DB-less mode.
-  /upstreams/{upstreams}/targets:
-    post:
-      summary: This method is not available when using DB-less mode.
-    get: []
-  /plugins/schema/{name}:
-    get: []
-  /consumers/{consumers}/plugins/{plugins}:
-    patch:
-      summary: This method is not available when using DB-less mode.
-  /upstreams/{upstreams}/targets/{targets}/{address}/unhealthy:
-    post:
-      summary: This method is not available when using DB-less mode.
-  /upstreams/{upstreams}/targets/all:
-    get:
-      summary: List all Targets
-  /consumers/{consumers}/plugins:
-    post:
-      summary: This method is not available when using DB-less mode.
-  /plugins/enabled:
-    get:
-      summary: Retrieve Enabled Plugins
-  /snis/{snis}/certificate: []
-  /upstreams/{upstreams}/targets/{targets}/healthy:
-    post:
-      summary: This method is not available when using DB-less mode.
-  /endpoints:
-    get:
-      summary: List available endpoints
-  /upstreams/{upstreams}/health:
-    get:
-      summary: Show Upstream health for node
-  /certificates/{certificates}:
-    patch:
-      summary: This method is not available when using DB-less mode.
-    get: []
-    put:
-      summary: This method is not available when using DB-less mode.
-  /cache:
-    delete:
-      summary: This method is not available when using DB-less mode.
-  /consumers:
-    get: []
-  /upstreams/{upstreams}/targets/{targets}/unhealthy:
-    post:
-      summary: This method is not available when using DB-less mode.
-  /tags/{tags}:
-    get:
-      summary: ' List entity IDs by tag '
-  /upstreams/{upstreams}/targets/{targets}/{address}/healthy:
-    post:
-      summary: This method is not available when using DB-less mode.
-  /plugins/{plugins}:
-    patch:
-      summary: This method is not available when using DB-less mode.
-  /certificates/{certificates}/snis: []
-  /certificates/{certificates}/snis/{snis}: []
-  /targets: []
-  /schemas/plugins/validate:
-    post:
-      summary: This method is not available when using DB-less mode. Validate a plugin
-        configuration against the schema
-  /services/{services}/plugins:
-    post:
-      summary: This method is not available when using DB-less mode.
-  /plugins:
-    post:
-      summary: This method is not available when using DB-less mode.
-  /status:
-    get:
-      summary: Retrieve node status
+        config_hash:
+          type: string
+        sync_status:
+          type: string
+          default: unknown
+        version:
+          type: string
+        hostname:
+          type: string
+        ip:
+          type: string
 info:
   summary: Kong RESTful Admin API for administration purposes.
+  version: 2.4.1
   description: "        \n\n        Kong comes with an **internal** RESTful Admin
     API for administration purposes.\n        Requests to the Admin API can be sent
     to any node in the cluster, and Kong will\n        keep the configuration consistent
@@ -561,11 +448,130 @@ info:
     over Kong, so\n        care should be taken when setting up Kong environments
     to avoid undue public\n        exposure of this API. See [this document][secure-admin-api]
     for a discussion\n        of methods to secure the Admin API.\n      "
-  version: 2.4.1
-  license:
-    url: https://github.com/Kong/kong/blob/master/LICENSE
-    name: Apache 2.0
-  title: Kong Admin API
   contact:
     url: https://github.com/Kong/kong
     name: Kong
+  title: Kong Admin API
+  license:
+    url: https://github.com/Kong/kong/blob/master/LICENSE
+    name: Apache 2.0
+paths:
+  /clustering/data-planes: []
+  /cache/{key}:
+    delete:
+      description: This method is not available when using DB-less mode.
+    get: []
+  /upstreams/{upstreams}/targets/{targets}/unhealthy:
+    post:
+      description: This method is not available when using DB-less mode.
+      summary: Set target as unhealthy
+  /clustering/status: []
+  /upstreams/{upstreams}/targets/all:
+    get:
+      summary: List all Targets
+  /plugins/enabled:
+    get:
+      summary: Retrieve Enabled Plugins
+  /upstreams/{upstreams}/targets/{targets}/healthy:
+    post:
+      description: This method is not available when using DB-less mode.
+      summary: Set target as healthy
+  /services/{services}/plugins/{plugins}:
+    patch:
+      description: This method is not available when using DB-less mode.
+  /plugins/schema/{name}:
+    get: []
+  /upstreams/{upstreams}/targets/{targets}/{address}/healthy:
+    post:
+      description: This method is not available when using DB-less mode.
+      summary: Set target address as healthy
+  /schemas/plugins/validate:
+    post:
+      description: This method is not available when using DB-less mode.
+      summary: Validate a plugin configuration against the schema
+  /:
+    get:
+      summary: Retrieve node information
+  /schemas/{db_entity_name}/validate:
+    post:
+      description: This method is not available when using DB-less mode.
+      summary: Validate a configuration against a schema
+  /upstreams/{upstreams}/targets/{targets}:
+    put:
+      description: This method is not available when using DB-less mode.
+    patch:
+      description: This method is not available when using DB-less mode.
+      summary: Update Target
+    delete:
+      description: This method is not available when using DB-less mode.
+      summary: Delete Target
+    get: []
+  /status:
+    get:
+      summary: Retrieve node status
+  /certificates/{certificates}:
+    put:
+      description: This method is not available when using DB-less mode.
+    patch:
+      description: This method is not available when using DB-less mode.
+    get: []
+  /upstreams/{upstreams}/health:
+    get:
+      summary: Show Upstream health for node
+  /upstreams/{upstreams}/targets/{targets}/{address}/unhealthy:
+    post:
+      description: This method is not available when using DB-less mode.
+      summary: Set target address as unhealthy
+  /certificates/{certificates}/snis/{snis}: []
+  /upstreams/{upstreams}/targets:
+    post:
+      description: This method is not available when using DB-less mode.
+    get: []
+  /schemas/{name}:
+    get:
+      summary: Retrieve Entity Schema
+  /plugins:
+    post:
+      description: This method is not available when using DB-less mode.
+  /cache:
+    delete:
+      description: This method is not available when using DB-less mode.
+  /certificates/{certificates}/snis: []
+  /targets/{targets}: []
+  /targets/:targets/upstream: []
+  /targets: []
+  /routes/{routes}/plugins:
+    post:
+      description: This method is not available when using DB-less mode.
+  /routes/{routes}/plugins/{plugins}:
+    patch:
+      description: This method is not available when using DB-less mode.
+  /schemas/plugins/{name}:
+    get:
+      summary: Retrieve Plugin Schema
+  /consumers/{consumers}/plugins:
+    post:
+      description: This method is not available when using DB-less mode.
+  /consumers/{consumers}/plugins/{plugins}:
+    patch:
+      description: This method is not available when using DB-less mode.
+  /config:
+    post:
+      description: This method is only available when using DB-less mode.
+    get:
+      description: This method is only available when using DB-less mode.
+  /snis/{snis}/certificate: []
+  /plugins/{plugins}:
+    patch:
+      description: This method is not available when using DB-less mode.
+  /tags/{tags}:
+    get:
+      summary: ' List entity IDs by tag '
+  /consumers:
+    get: []
+  /endpoints:
+    get:
+      summary: List available endpoints
+  /services/{services}/plugins:
+    post:
+      description: This method is not available when using DB-less mode.

--- a/kong-admin-api.yml
+++ b/kong-admin-api.yml
@@ -1,0 +1,571 @@
+servers:
+- description: 8001 is the default port on which the Admin API listens.
+  url: http://localhost:8001
+- description: 8444 is the default port for HTTPS traffic to the Admin API.
+  url: http://localhost:8444
+components:
+  schemas:
+    routes:
+      required:
+      - protocols
+      - https_redirect_status_code
+      - strip_path
+      - preserve_host
+      - request_buffering
+      - response_buffering
+      type: object
+      properties:
+        headers:
+          type: array
+        name:
+          type: string
+        id:
+          format: uuid
+          type: string
+        tags:
+          type: array
+        strip_path:
+          default: true
+          type: boolean
+        destinations:
+          type: array
+        path_handling:
+          default: v0
+          type: string
+        hosts:
+          type: array
+        methods:
+          type: array
+        request_buffering:
+          default: true
+          type: boolean
+        updated_at:
+          format: int32
+          type: integer
+        response_buffering:
+          default: true
+          type: boolean
+        sources:
+          type: array
+        service:
+          $ref: '#/components/schemas/services'
+        snis:
+          type: array
+        https_redirect_status_code:
+          default: 426
+          type: integer
+        created_at:
+          format: int32
+          type: integer
+        preserve_host:
+          default: false
+          type: boolean
+        protocols:
+          default:
+          - http
+          - https
+          type: array
+        regex_priority:
+          default: 0
+          type: integer
+        paths:
+          type: array
+    consumers:
+      required: []
+      type: object
+      properties:
+        custom_id:
+          type: string
+        id:
+          format: uuid
+          type: string
+        created_at:
+          format: int32
+          type: integer
+        username:
+          type: string
+        tags:
+          type: array
+    plugins:
+      required:
+      - name
+      - protocols
+      - enabled
+      type: object
+      properties:
+        name:
+          type: string
+        created_at:
+          format: int32
+          type: integer
+        protocols:
+          default:
+          - grpc
+          - grpcs
+          - http
+          - https
+          type: array
+          enum:
+          - http
+          - https
+          - tcp
+          - tls
+          - udp
+          - grpc
+          - grpcs
+        service:
+          default: ~
+          nullable: true
+          $ref: '#/components/schemas/services'
+        enabled:
+          default: true
+          type: boolean
+        id:
+          format: uuid
+          type: string
+        route:
+          default: ~
+          nullable: true
+          $ref: '#/components/schemas/routes'
+        tags:
+          type: array
+        consumer:
+          default: ~
+          nullable: true
+          $ref: '#/components/schemas/consumers'
+        config:
+          type: array
+    certificates:
+      required:
+      - cert
+      - key
+      type: object
+      properties:
+        cert_alt:
+          type: string
+        id:
+          format: uuid
+          type: string
+        cert:
+          type: string
+        created_at:
+          format: int32
+          type: integer
+        tags:
+          type: array
+        key_alt:
+          type: string
+        key:
+          type: string
+    workspaces:
+      required:
+      - name
+      type: object
+      properties:
+        id:
+          format: uuid
+          type: string
+        comment:
+          type: string
+        created_at:
+          format: int32
+          type: integer
+        meta:
+          type: array
+        config:
+          type: array
+        name:
+          type: string
+    snis:
+      required:
+      - name
+      - certificate
+      type: object
+      properties:
+        id:
+          format: uuid
+          type: string
+        name:
+          type: string
+        created_at:
+          format: int32
+          type: integer
+        certificate:
+          $ref: '#/components/schemas/certificates'
+        tags:
+          type: array
+    upstreams:
+      required:
+      - name
+      type: object
+      properties:
+        algorithm:
+          default: round-robin
+          type: string
+        healthchecks:
+          default:
+            active:
+              type: http
+              timeout: 1
+              healthy:
+                http_statuses:
+                - 200
+                - 302
+                interval: 0
+                successes: 0
+              unhealthy:
+                interval: 0
+                http_statuses:
+                - 429
+                - 404
+                - 500
+                - 501
+                - 502
+                - 503
+                - 504
+                - 505
+                tcp_failures: 0
+                timeouts: 0
+                http_failures: 0
+              https_verify_certificate: true
+              concurrency: 10
+              http_path: /
+            passive:
+              unhealthy:
+                http_statuses:
+                - 429
+                - 500
+                - 503
+                tcp_failures: 0
+                timeouts: 0
+                http_failures: 0
+              type: http
+              healthy:
+                successes: 0
+                http_statuses:
+                - 200
+                - 201
+                - 202
+                - 203
+                - 204
+                - 205
+                - 206
+                - 207
+                - 208
+                - 226
+                - 300
+                - 301
+                - 302
+                - 303
+                - 304
+                - 305
+                - 306
+                - 307
+                - 308
+          type: array
+        name:
+          type: string
+        created_at:
+          format: int32
+          type: integer
+        hash_fallback:
+          default: none
+          type: string
+        client_certificate:
+          $ref: '#/components/schemas/certificates'
+        hash_on_header:
+          type: string
+        host_header:
+          type: string
+        hash_fallback_header:
+          type: string
+        id:
+          format: uuid
+          type: string
+        hash_on_cookie:
+          type: string
+        tags:
+          type: array
+        hash_on_cookie_path:
+          default: /
+          type: string
+        hash_on:
+          default: none
+          type: string
+        slots:
+          default: 10000
+          type: integer
+    targets:
+      required:
+      - upstream
+      - target
+      type: object
+      properties:
+        id:
+          format: uuid
+          type: string
+        upstream:
+          $ref: '#/components/schemas/upstreams'
+        created_at:
+          format: float
+          type: number
+        tags:
+          type: array
+        target:
+          type: string
+        weight:
+          default: 100
+          type: integer
+    clustering_data_planes:
+      required:
+      - id
+      - ip
+      - hostname
+      - sync_status
+      type: object
+      properties:
+        sync_status:
+          default: unknown
+          type: string
+        id:
+          type: string
+        version:
+          type: string
+        last_seen:
+          format: int32
+          type: integer
+        config_hash:
+          type: string
+        ip:
+          type: string
+        hostname:
+          type: string
+    tags:
+      required:
+      - tag
+      - entity_name
+      - entity_id
+      type: object
+      properties:
+        tag:
+          type: string
+        entity_name:
+          type: string
+        entity_id:
+          type: string
+    parameters:
+      required:
+      - key
+      - value
+      type: object
+      properties:
+        created_at:
+          format: int32
+          type: integer
+        key:
+          type: string
+        value:
+          type: string
+    ca_certificates:
+      required:
+      - cert
+      type: object
+      properties:
+        id:
+          format: uuid
+          type: string
+        cert_digest:
+          type: string
+        created_at:
+          format: int32
+          type: integer
+        tags:
+          type: array
+        cert:
+          type: string
+    services:
+      required:
+      - protocol
+      - host
+      - port
+      type: object
+      properties:
+        path:
+          type: string
+        name:
+          type: string
+        host:
+          type: string
+        write_timeout:
+          default: 60000
+          type: integer
+        read_timeout:
+          default: 60000
+          type: integer
+        client_certificate:
+          $ref: '#/components/schemas/certificates'
+        id:
+          format: uuid
+          type: string
+        tls_verify:
+          type: boolean
+        tags:
+          type: array
+        tls_verify_depth:
+          default: ~
+          nullable: true
+          type: integer
+        created_at:
+          format: int32
+          type: integer
+        updated_at:
+          format: int32
+          type: integer
+        protocol:
+          default: http
+          type: string
+        ca_certificates:
+          type: array
+        connect_timeout:
+          default: 60000
+          type: integer
+        port:
+          default: 80
+          type: integer
+        retries:
+          default: 5
+          type: integer
+openapi: 3.1.0
+paths:
+  /targets/{targets}: []
+  /targets/{targets}/upstream: []
+  /:
+    get:
+      summary: Retrieve node information
+  /routes/{routes}/plugins:
+    post:
+      summary: This method is not available when using DB-less mode.
+  /cache/{key}:
+    delete:
+      summary: This method is not available when using DB-less mode.
+    get: []
+  /clustering/data-planes: []
+  /clustering/status: []
+  /schemas/{db_entity_name}/validate:
+    post:
+      summary: This method is not available when using DB-less mode. Validate a configuration
+        against a schema
+  /schemas/{name}:
+    get:
+      summary: Retrieve Entity Schema
+  /routes/{routes}/plugins/{plugins}:
+    patch:
+      summary: This method is not available when using DB-less mode.
+  /services/{services}/plugins/{plugins}:
+    patch:
+      summary: This method is not available when using DB-less mode.
+  /config:
+    post:
+      summary: This method is only available when using DB-less mode.
+    get:
+      summary: This method is only available when using DB-less mode.
+  /schemas/plugins/{name}:
+    get:
+      summary: Retrieve Plugin Schema
+  /upstreams/{upstreams}/targets/{targets}:
+    delete:
+      summary: This method is not available when using DB-less mode. Delete Target
+    patch:
+      summary: This method is not available when using DB-less mode. Update Target
+    get: []
+    put:
+      summary: This method is not available when using DB-less mode.
+  /upstreams/{upstreams}/targets:
+    post:
+      summary: This method is not available when using DB-less mode.
+    get: []
+  /plugins/schema/{name}:
+    get: []
+  /consumers/{consumers}/plugins/{plugins}:
+    patch:
+      summary: This method is not available when using DB-less mode.
+  /upstreams/{upstreams}/targets/{targets}/{address}/unhealthy:
+    post:
+      summary: This method is not available when using DB-less mode.
+  /upstreams/{upstreams}/targets/all:
+    get:
+      summary: List all Targets
+  /consumers/{consumers}/plugins:
+    post:
+      summary: This method is not available when using DB-less mode.
+  /plugins/enabled:
+    get:
+      summary: Retrieve Enabled Plugins
+  /snis/{snis}/certificate: []
+  /upstreams/{upstreams}/targets/{targets}/healthy:
+    post:
+      summary: This method is not available when using DB-less mode.
+  /endpoints:
+    get:
+      summary: List available endpoints
+  /upstreams/{upstreams}/health:
+    get:
+      summary: Show Upstream health for node
+  /certificates/{certificates}:
+    patch:
+      summary: This method is not available when using DB-less mode.
+    get: []
+    put:
+      summary: This method is not available when using DB-less mode.
+  /cache:
+    delete:
+      summary: This method is not available when using DB-less mode.
+  /consumers:
+    get: []
+  /upstreams/{upstreams}/targets/{targets}/unhealthy:
+    post:
+      summary: This method is not available when using DB-less mode.
+  /tags/{tags}:
+    get:
+      summary: ' List entity IDs by tag '
+  /upstreams/{upstreams}/targets/{targets}/{address}/healthy:
+    post:
+      summary: This method is not available when using DB-less mode.
+  /plugins/{plugins}:
+    patch:
+      summary: This method is not available when using DB-less mode.
+  /certificates/{certificates}/snis: []
+  /certificates/{certificates}/snis/{snis}: []
+  /targets: []
+  /schemas/plugins/validate:
+    post:
+      summary: This method is not available when using DB-less mode. Validate a plugin
+        configuration against the schema
+  /services/{services}/plugins:
+    post:
+      summary: This method is not available when using DB-less mode.
+  /plugins:
+    post:
+      summary: This method is not available when using DB-less mode.
+  /status:
+    get:
+      summary: Retrieve node status
+info:
+  summary: Kong RESTful Admin API for administration purposes.
+  description: "        \n\n        Kong comes with an **internal** RESTful Admin
+    API for administration purposes.\n        Requests to the Admin API can be sent
+    to any node in the cluster, and Kong will\n        keep the configuration consistent
+    across all nodes.\n\n        - `8001` is the default port on which the Admin API
+    listens.\n        - `8444` is the default port for HTTPS traffic to the Admin
+    API.\n\n        This API is designed for internal use and provides full control
+    over Kong, so\n        care should be taken when setting up Kong environments
+    to avoid undue public\n        exposure of this API. See [this document][secure-admin-api]
+    for a discussion\n        of methods to secure the Admin API.\n      "
+  version: 2.4.1
+  license:
+    url: https://github.com/Kong/kong/blob/master/LICENSE
+    name: Apache 2.0
+  title: Kong Admin API
+  contact:
+    url: https://github.com/Kong/kong
+    name: Kong

--- a/kong-admin-api.yml
+++ b/kong-admin-api.yml
@@ -1,185 +1,116 @@
-servers:
-- description: 8001 is the default port on which the Admin API listens.
-  url: http://localhost:8001
-- description: 8444 is the default port for HTTPS traffic to the Admin API.
-  url: https://localhost:8444
-openapi: 3.1.0
 components:
   schemas:
+    ca_certificates:
+      properties:
+        cert:
+          type: string
+        cert_digest:
+          type: string
+        created_at:
+          format: int32
+          type: integer
+        id:
+          format: uuid
+          type: string
+        tags:
+          type: array
+      required:
+      - cert
+      type: object
+    certificates:
+      properties:
+        cert:
+          type: string
+        cert_alt:
+          type: string
+        created_at:
+          format: int32
+          type: integer
+        id:
+          format: uuid
+          type: string
+        key:
+          type: string
+        key_alt:
+          type: string
+        tags:
+          type: array
+      required:
+      - cert
+      - key
+      type: object
+    clustering_data_planes:
+      properties:
+        config_hash:
+          type: string
+        hostname:
+          type: string
+        id:
+          type: string
+        ip:
+          type: string
+        last_seen:
+          format: int32
+          type: integer
+        sync_status:
+          default: unknown
+          type: string
+        version:
+          type: string
+      required:
+      - id
+      - ip
+      - hostname
+      - sync_status
+      type: object
+    consumers:
+      properties:
+        created_at:
+          format: int32
+          type: integer
+        custom_id:
+          type: string
+        id:
+          format: uuid
+          type: string
+        tags:
+          type: array
+        username:
+          type: string
+      required: []
+      type: object
     parameters:
+      properties:
+        created_at:
+          format: int32
+          type: integer
+        key:
+          type: string
+        value:
+          type: string
       required:
       - key
       - value
       type: object
-      properties:
-        value:
-          type: string
-        key:
-          type: string
-        created_at:
-          format: int32
-          type: integer
-    services:
-      required:
-      - protocol
-      - host
-      - port
-      type: object
-      properties:
-        tls_verify:
-          type: boolean
-        tls_verify_depth:
-          default: ~
-          type: integer
-          nullable: true
-        created_at:
-          format: int32
-          type: integer
-        updated_at:
-          format: int32
-          type: integer
-        name:
-          type: string
-        tags:
-          type: array
-        ca_certificates:
-          type: array
-        retries:
-          type: integer
-          default: 5
-        host:
-          type: string
-        id:
-          format: uuid
-          type: string
-        port:
-          type: integer
-          default: 80
-        path:
-          type: string
-        protocol:
-          type: string
-          default: http
-        read_timeout:
-          type: integer
-          default: 60000
-        connect_timeout:
-          type: integer
-          default: 60000
-        client_certificate:
-          $ref: '#/components/schemas/certificates'
-        write_timeout:
-          type: integer
-          default: 60000
-    routes:
-      required:
-      - protocols
-      - https_redirect_status_code
-      - strip_path
-      - preserve_host
-      - request_buffering
-      - response_buffering
-      type: object
-      properties:
-        destinations:
-          type: array
-        hosts:
-          type: array
-        methods:
-          type: array
-        paths:
-          type: array
-        protocols:
-          type: array
-          default:
-          - http
-          - https
-        created_at:
-          format: int32
-          type: integer
-        strip_path:
-          type: boolean
-          default: true
-        name:
-          type: string
-        path_handling:
-          type: string
-          default: v0
-        preserve_host:
-          type: boolean
-          default: false
-        request_buffering:
-          type: boolean
-          default: true
-        response_buffering:
-          type: boolean
-          default: true
-        regex_priority:
-          type: integer
-          default: 0
-        service:
-          $ref: '#/components/schemas/services'
-        https_redirect_status_code:
-          type: integer
-          default: 426
-        id:
-          format: uuid
-          type: string
-        tags:
-          type: array
-        sources:
-          type: array
-        snis:
-          type: array
-        headers:
-          type: array
-        updated_at:
-          format: int32
-          type: integer
-    consumers:
-      required: []
-      type: object
-      properties:
-        id:
-          format: uuid
-          type: string
-        created_at:
-          format: int32
-          type: integer
-        username:
-          type: string
-        tags:
-          type: array
-        custom_id:
-          type: string
     plugins:
-      required:
-      - name
-      - protocols
-      - enabled
-      type: object
       properties:
-        service:
-          $ref: '#/components/schemas/services'
+        config:
+          type: array
+        consumer:
+          $ref: '#/components/schemas/consumers'
           default: ~
           nullable: true
-        enabled:
-          type: boolean
-          default: true
-        id:
-          format: uuid
-          type: string
         created_at:
           format: int32
           type: integer
-        tags:
-          type: array
+        enabled:
+          default: true
+          type: boolean
+        id:
+          format: uuid
+          type: string
         name:
           type: string
-        route:
-          $ref: '#/components/schemas/routes'
-          default: ~
-          nullable: true
         protocols:
           default:
           - grpc
@@ -195,122 +126,230 @@ components:
           - grpc
           - grpcs
           type: array
-        config:
-          type: array
-        consumer:
-          $ref: '#/components/schemas/consumers'
+        route:
+          $ref: '#/components/schemas/routes'
           default: ~
           nullable: true
-    certificates:
-      required:
-      - cert
-      - key
-      type: object
-      properties:
-        id:
-          format: uuid
-          type: string
-        created_at:
-          format: int32
-          type: integer
-        key_alt:
-          type: string
-        cert:
-          type: string
+        service:
+          $ref: '#/components/schemas/services'
+          default: ~
+          nullable: true
         tags:
           type: array
-        cert_alt:
-          type: string
-        key:
-          type: string
-    workspaces:
       required:
       - name
+      - protocols
+      - enabled
       type: object
+    routes:
       properties:
-        id:
-          format: uuid
-          type: string
         created_at:
           format: int32
           type: integer
-        comment:
+        destinations:
+          type: array
+        headers:
+          type: array
+        hosts:
+          type: array
+        https_redirect_status_code:
+          default: 426
+          type: integer
+        id:
+          format: uuid
+          type: string
+        methods:
+          type: array
+        name:
+          type: string
+        path_handling:
+          default: v0
+          type: string
+        paths:
+          type: array
+        preserve_host:
+          default: false
+          type: boolean
+        protocols:
+          default:
+          - http
+          - https
+          type: array
+        regex_priority:
+          default: 0
+          type: integer
+        request_buffering:
+          default: true
+          type: boolean
+        response_buffering:
+          default: true
+          type: boolean
+        service:
+          $ref: '#/components/schemas/services'
+        snis:
+          type: array
+        sources:
+          type: array
+        strip_path:
+          default: true
+          type: boolean
+        tags:
+          type: array
+        updated_at:
+          format: int32
+          type: integer
+      required:
+      - protocols
+      - https_redirect_status_code
+      - strip_path
+      - preserve_host
+      - request_buffering
+      - response_buffering
+      type: object
+    services:
+      properties:
+        ca_certificates:
+          type: array
+        client_certificate:
+          $ref: '#/components/schemas/certificates'
+        connect_timeout:
+          default: 60000
+          type: integer
+        created_at:
+          format: int32
+          type: integer
+        host:
+          type: string
+        id:
+          format: uuid
           type: string
         name:
           type: string
-        config:
+        path:
+          type: string
+        port:
+          default: 80
+          type: integer
+        protocol:
+          default: http
+          type: string
+        read_timeout:
+          default: 60000
+          type: integer
+        retries:
+          default: 5
+          type: integer
+        tags:
           type: array
-        meta:
-          type: array
+        tls_verify:
+          type: boolean
+        tls_verify_depth:
+          default: ~
+          nullable: true
+          type: integer
+        updated_at:
+          format: int32
+          type: integer
+        write_timeout:
+          default: 60000
+          type: integer
+      required:
+      - protocol
+      - host
+      - port
+      type: object
     snis:
+      properties:
+        certificate:
+          $ref: '#/components/schemas/certificates'
+        created_at:
+          format: int32
+          type: integer
+        id:
+          format: uuid
+          type: string
+        name:
+          type: string
+        tags:
+          type: array
       required:
       - name
       - certificate
       type: object
+    tags:
       properties:
+        entity_id:
+          type: string
+        entity_name:
+          type: string
+        tag:
+          type: string
+      required:
+      - tag
+      - entity_name
+      - entity_id
+      type: object
+    targets:
+      properties:
+        created_at:
+          format: float
+          type: number
         id:
           format: uuid
           type: string
-        created_at:
-          format: int32
-          type: integer
-        name:
-          type: string
         tags:
           type: array
-        certificate:
-          $ref: '#/components/schemas/certificates'
-    upstreams:
-      required:
-      - name
-      type: object
-      properties:
-        hash_fallback:
+        target:
           type: string
-          default: none
-        hash_on_header:
+        upstream:
+          $ref: '#/components/schemas/upstreams'
+        weight:
+          default: 100
+          type: integer
+      required:
+      - upstream
+      - target
+      type: object
+    upstreams:
+      properties:
+        algorithm:
+          default: round-robin
           type: string
         client_certificate:
           $ref: '#/components/schemas/certificates'
-        hash_fallback_header:
-          type: string
-        host_header:
-          type: string
-        hash_on_cookie:
-          type: string
-        tags:
-          type: array
-        id:
-          format: uuid
-          type: string
         created_at:
           format: int32
           type: integer
-        slots:
-          type: integer
-          default: 10000
-        name:
+        hash_fallback:
+          default: none
           type: string
-        algorithm:
+        hash_fallback_header:
           type: string
-          default: round-robin
+        hash_on:
+          default: none
+          type: string
+        hash_on_cookie:
+          type: string
+        hash_on_cookie_path:
+          default: /
+          type: string
+        hash_on_header:
+          type: string
         healthchecks:
-          type: array
           default:
             active:
-              timeout: 1
               concurrency: 10
-              type: http
-              https_verify_certificate: true
               healthy:
-                interval: 0
-                successes: 0
                 http_statuses:
                 - 200
                 - 302
-              unhealthy:
-                timeouts: 0
                 interval: 0
+                successes: 0
+              http_path: /
+              https_verify_certificate: true
+              timeout: 1
+              type: http
+              unhealthy:
                 http_failures: 0
                 http_statuses:
                 - 429
@@ -321,11 +360,11 @@ components:
                 - 503
                 - 504
                 - 505
+                interval: 0
                 tcp_failures: 0
-              http_path: /
+                timeouts: 0
             passive:
               healthy:
-                successes: 0
                 http_statuses:
                 - 200
                 - 201
@@ -346,99 +385,55 @@ components:
                 - 306
                 - 307
                 - 308
+                successes: 0
               type: http
               unhealthy:
-                timeouts: 0
                 http_failures: 0
                 http_statuses:
                 - 429
                 - 500
                 - 503
                 tcp_failures: 0
-        hash_on:
+                timeouts: 0
+          type: array
+        host_header:
           type: string
-          default: none
-        hash_on_cookie_path:
-          type: string
-          default: /
-    targets:
-      required:
-      - upstream
-      - target
-      type: object
-      properties:
         id:
           format: uuid
           type: string
-        created_at:
-          format: float
-          type: number
+        name:
+          type: string
+        slots:
+          default: 10000
+          type: integer
         tags:
           type: array
-        upstream:
-          $ref: '#/components/schemas/upstreams'
-        target:
-          type: string
-        weight:
-          type: integer
-          default: 100
-    ca_certificates:
       required:
-      - cert
+      - name
       type: object
+    workspaces:
       properties:
+        comment:
+          type: string
+        config:
+          type: array
+        created_at:
+          format: int32
+          type: integer
         id:
           format: uuid
           type: string
-        created_at:
-          format: int32
-          type: integer
-        cert:
-          type: string
-        cert_digest:
-          type: string
-        tags:
+        meta:
           type: array
-    tags:
+        name:
+          type: string
       required:
-      - tag
-      - entity_name
-      - entity_id
+      - name
       type: object
-      properties:
-        entity_name:
-          type: string
-        entity_id:
-          type: string
-        tag:
-          type: string
-    clustering_data_planes:
-      required:
-      - id
-      - ip
-      - hostname
-      - sync_status
-      type: object
-      properties:
-        id:
-          type: string
-        last_seen:
-          format: int32
-          type: integer
-        config_hash:
-          type: string
-        sync_status:
-          type: string
-          default: unknown
-        version:
-          type: string
-        hostname:
-          type: string
-        ip:
-          type: string
 info:
-  summary: Kong RESTful Admin API for administration purposes.
-  version: 2.4.1
+  contact:
+    name: Kong
+    url: https://github.com/Kong/kong
   description: "        \n\n        Kong comes with an **internal** RESTful Admin
     API for administration purposes.\n        Requests to the Admin API can be sent
     to any node in the cluster, and Kong will\n        keep the configuration consistent
@@ -448,130 +443,132 @@ info:
     over Kong, so\n        care should be taken when setting up Kong environments
     to avoid undue public\n        exposure of this API. See [this document][secure-admin-api]
     for a discussion\n        of methods to secure the Admin API.\n      "
-  contact:
-    url: https://github.com/Kong/kong
-    name: Kong
-  title: Kong Admin API
   license:
-    url: https://github.com/Kong/kong/blob/master/LICENSE
     name: Apache 2.0
+    url: https://github.com/Kong/kong/blob/master/LICENSE
+  summary: Kong RESTful Admin API for administration purposes.
+  title: Kong Admin API
+  version: 2.4.1
+openapi: 3.1.0
 paths:
-  /clustering/data-planes: []
+  /:
+    get:
+      summary: Retrieve node information
+  /cache:
+    delete:
+      description: This method is not available when using DB-less mode.
   /cache/{key}:
     delete:
       description: This method is not available when using DB-less mode.
     get: []
-  /upstreams/{upstreams}/targets/{targets}/unhealthy:
-    post:
-      description: This method is not available when using DB-less mode.
-      summary: Set target as unhealthy
-  /clustering/status: []
-  /upstreams/{upstreams}/targets/all:
-    get:
-      summary: List all Targets
-  /plugins/enabled:
-    get:
-      summary: Retrieve Enabled Plugins
-  /upstreams/{upstreams}/targets/{targets}/healthy:
-    post:
-      description: This method is not available when using DB-less mode.
-      summary: Set target as healthy
-  /services/{services}/plugins/{plugins}:
-    patch:
-      description: This method is not available when using DB-less mode.
-  /plugins/schema/{name}:
-    get: []
-  /upstreams/{upstreams}/targets/{targets}/{address}/healthy:
-    post:
-      description: This method is not available when using DB-less mode.
-      summary: Set target address as healthy
-  /schemas/plugins/validate:
-    post:
-      description: This method is not available when using DB-less mode.
-      summary: Validate a plugin configuration against the schema
-  /:
-    get:
-      summary: Retrieve node information
-  /schemas/{db_entity_name}/validate:
-    post:
-      description: This method is not available when using DB-less mode.
-      summary: Validate a configuration against a schema
-  /upstreams/{upstreams}/targets/{targets}:
-    put:
-      description: This method is not available when using DB-less mode.
-    patch:
-      description: This method is not available when using DB-less mode.
-      summary: Update Target
-    delete:
-      description: This method is not available when using DB-less mode.
-      summary: Delete Target
-    get: []
-  /status:
-    get:
-      summary: Retrieve node status
   /certificates/{certificates}:
-    put:
-      description: This method is not available when using DB-less mode.
+    get: []
     patch:
       description: This method is not available when using DB-less mode.
-    get: []
-  /upstreams/{upstreams}/health:
-    get:
-      summary: Show Upstream health for node
-  /upstreams/{upstreams}/targets/{targets}/{address}/unhealthy:
-    post:
-      description: This method is not available when using DB-less mode.
-      summary: Set target address as unhealthy
-  /certificates/{certificates}/snis/{snis}: []
-  /upstreams/{upstreams}/targets:
-    post:
-      description: This method is not available when using DB-less mode.
-    get: []
-  /schemas/{name}:
-    get:
-      summary: Retrieve Entity Schema
-  /plugins:
-    post:
-      description: This method is not available when using DB-less mode.
-  /cache:
-    delete:
+    put:
       description: This method is not available when using DB-less mode.
   /certificates/{certificates}/snis: []
-  /targets/{targets}: []
-  /targets/:targets/upstream: []
-  /targets: []
-  /routes/{routes}/plugins:
-    post:
-      description: This method is not available when using DB-less mode.
-  /routes/{routes}/plugins/{plugins}:
-    patch:
-      description: This method is not available when using DB-less mode.
-  /schemas/plugins/{name}:
+  /certificates/{certificates}/snis/{snis}: []
+  /clustering/data-planes: []
+  /clustering/status: []
+  /config:
     get:
-      summary: Retrieve Plugin Schema
+      description: This method is only available when using DB-less mode.
+    post:
+      description: This method is only available when using DB-less mode.
+  /consumers:
+    get: []
   /consumers/{consumers}/plugins:
     post:
       description: This method is not available when using DB-less mode.
   /consumers/{consumers}/plugins/{plugins}:
     patch:
       description: This method is not available when using DB-less mode.
-  /config:
-    post:
-      description: This method is only available when using DB-less mode.
-    get:
-      description: This method is only available when using DB-less mode.
-  /snis/{snis}/certificate: []
-  /plugins/{plugins}:
-    patch:
-      description: This method is not available when using DB-less mode.
-  /tags/{tags}:
-    get:
-      summary: ' List entity IDs by tag '
-  /consumers:
-    get: []
   /endpoints:
     get:
       summary: List available endpoints
+  /plugins:
+    post:
+      description: This method is not available when using DB-less mode.
+  /plugins/enabled:
+    get:
+      summary: Retrieve Enabled Plugins
+  /plugins/schema/{name}:
+    get: []
+  /plugins/{plugins}:
+    patch:
+      description: This method is not available when using DB-less mode.
+  /routes/{routes}/plugins:
+    post:
+      description: This method is not available when using DB-less mode.
+  /routes/{routes}/plugins/{plugins}:
+    patch:
+      description: This method is not available when using DB-less mode.
+  /schemas/plugins/validate:
+    post:
+      description: This method is not available when using DB-less mode.
+      summary: Validate a plugin configuration against the schema
+  /schemas/plugins/{name}:
+    get:
+      summary: Retrieve Plugin Schema
+  /schemas/{db_entity_name}/validate:
+    post:
+      description: This method is not available when using DB-less mode.
+      summary: Validate a configuration against a schema
+  /schemas/{name}:
+    get:
+      summary: Retrieve Entity Schema
+  /services/:services/plugins/:plugins:
+    patch: []
   /services/{services}/plugins:
     post:
       description: This method is not available when using DB-less mode.
+  /snis/{snis}/certificate: []
+  /status:
+    get:
+      summary: Retrieve node status
+  /tags/{tags}:
+    get:
+      summary: ' List entity IDs by tag '
+  /targets: []
+  /targets/{targets}: []
+  /targets/{targets}/upstream: []
+  /upstreams/:upstreams/targets/:targets/:address/unhealthy:
+    post: []
+  /upstreams/{upstreams}/health:
+    get:
+      summary: Show Upstream health for node
+  /upstreams/{upstreams}/targets:
+    get: []
+    post:
+      description: This method is not available when using DB-less mode.
+  /upstreams/{upstreams}/targets/all:
+    get:
+      summary: List all Targets
+  /upstreams/{upstreams}/targets/{targets}:
+    delete:
+      description: This method is not available when using DB-less mode.
+      summary: Delete Target
+    get: []
+    patch:
+      description: This method is not available when using DB-less mode.
+      summary: Update Target
+    put:
+      description: This method is not available when using DB-less mode.
+  /upstreams/{upstreams}/targets/{targets}/healthy:
+    post:
+      description: This method is not available when using DB-less mode.
+      summary: Set target as healthy
+  /upstreams/{upstreams}/targets/{targets}/unhealthy:
+    post:
+      description: This method is not available when using DB-less mode.
+      summary: Set target as unhealthy
+  /upstreams/{upstreams}/targets/{targets}/{address}/healthy:
+    post:
+      description: This method is not available when using DB-less mode.
+      summary: Set target address as healthy
+servers:
+- description: 8001 is the default port on which the Admin API listens.
+  url: http://localhost:8001
+- description: 8444 is the default port for HTTPS traffic to the Admin API.
+  url: https://localhost:8444

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -8,12 +8,12 @@ function commit_changelog() {
         then
             die "No changes in CHANGELOG.md to commit. Did you write the changelog?"
         fi
-    
+
         git diff CHANGELOG.md
-    
+
         CONFIRM "If everything looks all right, press Enter to commit" \
                   "or Ctrl-C to cancel."
-    
+
         set -e
         git add CHANGELOG.md
         git commit -m "docs(changelog) add $1 changes"
@@ -30,6 +30,19 @@ function update_copyright() {
    git add COPYRIGHT
 
    git commit -m "docs(COPYRIGHT) update copyright for $1"
+   git log -n 1
+}
+
+#-------------------------------------------------------------------------------
+function update_admin_api_def() {
+   if ! "$scripts_folder/gen-admin-api-def.sh"
+   then
+      die "Could not update kong-admin-api.yml file. Check script output for any error messages."
+   fi
+
+   git add kong-admin-api.yml
+
+   git commit -m "docs(kong-admin-api.yml) update Admin API definition for $1"
    git log -n 1
 }
 
@@ -224,25 +237,25 @@ As always, happy Konging! :gorilla:
 EOF
 }
 
-#-------------------------------------------------------------------------------	
-function step() {	
-   box="   "	
-   color="$nocolor"	
-   if [ "$version" != "<x.y.z>" ]	
-   then	
-      if [ -e "/tmp/.step-$1-$version" ]	
-      then	
-         color="$green"	
-         box="[x]"	
-      else	
-         color="$bold"	
-         box="[ ]"	
-      fi	
-   fi	
-   echo -e "$color $box Step $c) $2"	
-   echo "        $0 $version $1 $3"	
-   echo -e "$nocolor"	
-   c="$[c+1]"	
+#-------------------------------------------------------------------------------
+function step() {
+   box="   "
+   color="$nocolor"
+   if [ "$version" != "<x.y.z>" ]
+   then
+      if [ -e "/tmp/.step-$1-$version" ]
+      then
+         color="$green"
+         box="[x]"
+      else
+         color="$bold"
+         box="[ ]"
+      fi
+   fi
+   echo -e "$color $box Step $c) $2"
+   echo "        $0 $version $1 $3"
+   echo -e "$nocolor"
+   c="$[c+1]"
 }
 
 #-------------------------------------------------------------------------------
@@ -255,10 +268,10 @@ function update_docker {
         git clone https://github.com/kong/docker-kong
         cd docker-kong
     fi
-    
+
     git pull
     git checkout -B "release/$1"
-    
+
     set -e
     ./update.sh "$1"
 }

--- a/scripts/gen-admin-api-def.sh
+++ b/scripts/gen-admin-api-def.sh
@@ -1,0 +1,1 @@
+resty ./autodoc/admin-api/openapi-gen.lua kong-admin-api.yml

--- a/scripts/make-patch-release
+++ b/scripts/make-patch-release
@@ -20,22 +20,23 @@ function usage() {
       echo
    fi
    c=1
-   step "create"           "create the branch"
-   step "write_changelog"  "prepare the changelog"
-   step "commit_changelog" "commit the changelog"
-   step "update_copyright" "update copyright file"
-   step "version_bump"     "bump and commit the version number"
-   step "submit"           "push and submit a release PR"
-   step "docs_pr"          "push and submit a docs.konghq.com PR for the release"
-   step "merge"            "merge, tag and sign the release"
-   step "update_docker"    "(ran by CI now) update and submit a PR to Kong's docker-kong repo"
-   step "merge_docker"     "merge, tag and sign Kong's docker-kong PR"
-   step "submit_docker"    "submit a PR to docker-library/official-images"
-   step "homebrew"         "(ran by CI now) bump version and submit a PR to homebrew-kong"
-   step "luarocks"         "upload to LuaRocks" "<api-key>"
-   step "vagrant"          "(ran by CI now) bump version and submit a PR to kong-vagrant"
-   step "pongo"            "(ran by CI now) bump version and submit a PR to kong-pongo"
-   step "announce"         "Get announcement messages for Kong Nation and Slack #general"
+   step "create"               "create the branch"
+   step "write_changelog"      "prepare the changelog"
+   step "commit_changelog"     "commit the changelog"
+   step "update_copyright"     "update copyright file"
+   step "update_admin_api_def" "update Admin API definition"
+   step "version_bump"         "bump and commit the version number"
+   step "submit"               "push and submit a release PR"
+   step "docs_pr"              "push and submit a docs.konghq.com PR for the release"
+   step "merge"                "merge, tag and sign the release"
+   step "update_docker"        "(ran by CI now) update and submit a PR to Kong's docker-kong repo"
+   step "merge_docker"         "merge, tag and sign Kong's docker-kong PR"
+   step "submit_docker"        "submit a PR to docker-library/official-images"
+   step "homebrew"             "(ran by CI now) bump version and submit a PR to homebrew-kong"
+   step "luarocks"             "upload to LuaRocks" "<api-key>"
+   step "vagrant"              "(ran by CI now) bump version and submit a PR to kong-vagrant"
+   step "pongo"                "(ran by CI now) bump version and submit a PR to kong-pongo"
+   step "announce"             "Get announcement messages for Kong Nation and Slack #general"
    exit 0
 }
 
@@ -143,6 +144,14 @@ case "$step" in
       update_copyright "$version"
 
       SUCCESS "The COPYRIGHT file is updated locally." \
+              "You are ready to run the next step:" \
+              "    $0 $version update_admin_api_def"
+      ;;
+   #---------------------------------------------------------------------------
+   update_admin_api_def)
+      update_admin_api_def "$version"
+
+      SUCCESS "The kong-admin-api.yml file is updated locally." \
               "You are ready to run the next step:" \
               "    $0 $version version_bump"
       ;;

--- a/scripts/make-prerelease-release
+++ b/scripts/make-prerelease-release
@@ -21,20 +21,21 @@ function usage() {
       echo
    fi
    c=1
-   step "switch"           "switch or create to the release branch"
-   step "write_changelog"  "prepare the changelog"
-   step "commit_changelog" "commit the changelog"
-   step "update_copyright" "update copyright file"
-   step "version_bump"     "bump and commit the version number"
-   step "submit"           "push and submit a release PR"
-   step "tag"              "tag and sign the release candidate"
+   step "switch"               "switch or create to the release branch"
+   step "write_changelog"      "prepare the changelog"
+   step "commit_changelog"     "commit the changelog"
+   step "update_copyright"     "update copyright file"
+   step "update_admin_api_def" "update Admin API definition"
+   step "version_bump"         "bump and commit the version number"
+   step "submit"               "push and submit a release PR"
+   step "tag"                  "tag and sign the release candidate"
    if [ "$beta" == true ]
    then
-     step "docs_pr"        "push and submit a docs.konghq.com PR for the release"
-     step "update_docker"  "update and submit a PR to Kong's docker-kong repo"
-     step "merge_docker"   "merge, tag and sign Kong's docker-kong PR"
-     step "homebrew"       "bump version and submit a PR to homebrew-kong"
-     step "pongo"          "bump version and submit a PR to kong-pongo"
+     step "docs_pr"            "push and submit a docs.konghq.com PR for the release"
+     step "update_docker"      "update and submit a PR to Kong's docker-kong repo"
+     step "merge_docker"       "merge, tag and sign Kong's docker-kong PR"
+     step "homebrew"           "bump version and submit a PR to homebrew-kong"
+     step "pongo"              "bump version and submit a PR to kong-pongo"
    fi
    exit 0
 }
@@ -134,7 +135,15 @@ case "$step" in
 
       SUCCESS "The COPYRIGHT file is updated locally." \
               "You are ready to run the next step:" \
-              "    $0 -v $version -s version_bump"
+              "    $0 $version update_admin_api_def"
+      ;;
+   #---------------------------------------------------------------------------
+   update_admin_api_def)
+      update_admin_api_def "$version"
+
+      SUCCESS "The kong-admin-api.yml file is updated locally." \
+              "You are ready to run the next step:" \
+              "    $0 $version version_bump"
       ;;
    #---------------------------------------------------------------------------
    version_bump)


### PR DESCRIPTION
This PR = #7413 - the last commit, "force entries order in generated file" + a lyaml low-level dumper that generates sorted yamls instead + some other minor things.

The reason why the dumper is so much code is because lyaml doesn't expose its internal dumper, so the only way to do sorted yaml is copy-pasting the whole thing in order to edit one tiny part of the `dump_mapping` function (to do the key sort before iterating over the table). Related: https://github.com/gvvaughan/lyaml/issues/46

