### PR TITLE
fix(clustering) more reliable way to calculate data plane config hash

### DIFF
--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -126,10 +126,13 @@ function _M:export_deflated_reconfigure_payload()
     end
   end
 
+  local config_hash = self:calculate_config_hash(config_table)
+
   local payload, err = cjson_encode({
     type = "reconfigure",
     timestamp = ngx_now(),
     config_table = config_table,
+    config_hash = config_hash,
   })
   if not payload then
     return nil, err
@@ -140,9 +143,10 @@ function _M:export_deflated_reconfigure_payload()
     return nil, err
   end
 
+  self.current_config_hash = config_hash
   self.deflated_reconfigure_payload = payload
 
-  return payload
+  return payload, nil, config_hash
 end
 
 

--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -9,18 +9,14 @@ local constants = require("kong.constants")
 local utils = require("kong.tools.utils")
 local system_constants = require("lua_system_constants")
 local ffi = require("ffi")
-local tablex = require("pl.tablex")
 local assert = assert
 local setmetatable = setmetatable
 local type = type
 local math = math
 local pcall = pcall
-local concat = table.concat
 local tostring = tostring
 local ngx = ngx
-local md5 = ngx.md5
 local ngx_log = ngx.log
-local ngx_null = ngx.null
 local ngx_sleep = ngx.sleep
 local cjson_decode = cjson.decode
 local cjson_encode = cjson.encode
@@ -54,49 +50,6 @@ local function is_timeout(err)
 end
 
 
-local function sort(t)
-  if t == ngx_null then
-    return "/null/"
-  end
-
-  local typ = type(t)
-  if typ == "table" then
-    local i = 1
-    local o = { "{" }
-    for k, v in tablex.sort(t) do
-      o[i+1] = sort(k)
-      o[i+2] = ":"
-      o[i+3] = sort(v)
-      o[i+4] = ";"
-      i=i+4
-    end
-    if i == 1 then
-      i = i + 1
-    end
-    o[i] = "}"
-
-    return concat(o, nil, 1, i)
-
-  elseif typ == "string" then
-    return '$' .. t .. '$'
-
-  elseif typ == "number" then
-    return '#' .. tostring(t) .. '#'
-
-  elseif typ == "boolean" then
-    return '?' .. tostring(t) .. '?'
-
-  else
-    return '(' .. tostring(t) .. ')'
-  end
-end
-
-
-local function hash(t)
-  return md5(sort(t))
-end
-
-
 function _M.new(parent)
   local self = {
     declarative_config = declarative.new_config(parent.conf),
@@ -110,11 +63,15 @@ function _M.new(parent)
 end
 
 
-function _M:update_config(config_table, update_cache)
+function _M:update_config(config_table, config_hash, update_cache)
   assert(type(config_table) == "table")
 
+  if not config_hash then
+    config_hash = self:calculate_config_hash(config_table)
+  end
+
   local entities, err, _, meta, new_hash =
-              self.declarative_config:parse_table(config_table, hash(config_table))
+              self.declarative_config:parse_table(config_table, config_hash)
   if not entities then
     return nil, "bad config received from control plane " .. err
   end
@@ -177,7 +134,7 @@ function _M:init_worker()
 
           if config then
             local res
-            res, err = self:update_config(config, false)
+            res, err = self:update_config(config)
             if not res then
               ngx_log(ngx_ERR, _log_prefix, "unable to update running config from cache: ", err)
             end
@@ -316,9 +273,10 @@ function _M:communicate(premature)
       local ok, err = config_semaphore:wait(1)
       if ok then
         local config_table = self.next_config
+        local config_hash  = self.next_hash
         if config_table then
           local pok, res
-          pok, res, err = pcall(self.update_config, self, config_table, true)
+          pok, res, err = pcall(self.update_config, self, config_table, config_hash, true)
           if pok then
             if not res then
               ngx_log(ngx_ERR, _log_prefix, "unable to update running config: ", err)
@@ -395,6 +353,7 @@ function _M:communicate(premature)
             end
 
             self.next_config = assert(msg.config_table)
+            self.next_hash = msg.config_hash
 
             if config_semaphore:count() <= 0 then
               -- the following line always executes immediately after the `if` check

--- a/kong/clustering/init.lua
+++ b/kong/clustering/init.lua
@@ -5,9 +5,53 @@ local pl_file = require("pl.file")
 local pl_tablex = require("pl.tablex")
 local ssl = require("ngx.ssl")
 local openssl_x509 = require("resty.openssl.x509")
+local ngx_null = ngx.null
+local ngx_md5 = ngx.md5
+local tostring = tostring
+local assert = assert
+local concat = table.concat
+local sort = table.sort
+local type = type
 
 
 local MT = { __index = _M, }
+
+local function table_to_sorted_string(t)
+  if t == ngx_null then
+    return "/null/"
+  end
+
+  local typ = type(t)
+  if typ == "table" then
+    local i = 1
+    local o = { "{" }
+    for k, v in pl_tablex.sort(t) do
+      o[i+1] = table_to_sorted_string(k)
+      o[i+2] = ":"
+      o[i+3] = table_to_sorted_string(v)
+      o[i+4] = ";"
+      i=i+4
+    end
+    if i == 1 then
+      i = i + 1
+    end
+    o[i] = "}"
+
+    return concat(o, nil, 1, i)
+
+  elseif typ == "string" then
+    return '$' .. t .. '$'
+
+  elseif typ == "number" then
+    return '#' .. tostring(t) .. '#'
+
+  elseif typ == "boolean" then
+    return '?' .. tostring(t) .. '?'
+
+  else
+    return '(' .. tostring(t) .. ')'
+  end
+end
 
 
 function _M.new(conf)
@@ -36,6 +80,11 @@ function _M.new(conf)
 end
 
 
+function _M:calculate_config_hash(config_table)
+  return ngx_md5(table_to_sorted_string(config_table))
+end
+
+
 function _M:handle_cp_websocket()
   return self.child:handle_cp_websocket()
 end
@@ -43,7 +92,7 @@ end
 
 function _M:init_worker()
   self.plugins_list = assert(kong.db.plugins:get_handlers())
-  table.sort(self.plugins_list, function(a, b)
+  sort(self.plugins_list, function(a, b)
     return a.name:lower() < b.name:lower()
   end)
 

--- a/spec/01-unit/19-hybrid/02-clustering_spec.lua
+++ b/spec/01-unit/19-hybrid/02-clustering_spec.lua
@@ -1,0 +1,228 @@
+local clustering = require("kong.clustering")
+
+
+describe("kong.clustering", function()
+  describe(".calculate_config_hash()", function()
+    it("calculating hash for nil errors", function()
+      local pok = pcall(clustering.calculate_config_hash, clustering, nil)
+      assert.falsy(pok)
+    end)
+
+    it("calculates hash for null", function()
+      local value = ngx.null
+
+      for _ = 1, 10 do
+        local hash = clustering.calculate_config_hash(clustering, value)
+        assert.is_string(hash)
+        assert.equal("5bf07a8b7343015026657d1108d8206e", hash)
+      end
+
+      local correct = ngx.md5("/null/")
+      assert.equal("5bf07a8b7343015026657d1108d8206e", correct)
+
+      for _ = 1, 10 do
+        local hash = clustering.calculate_config_hash(clustering, value)
+        assert.is_string(hash)
+        assert.equal(correct, hash)
+      end
+    end)
+
+    it("calculates hash for number", function()
+      local value = 10
+
+      for _ = 1, 10 do
+        local hash = clustering.calculate_config_hash(clustering, value)
+        assert.is_string(hash)
+        assert.equal("326afd95b21a24c277d9d05684cc3de6", hash)
+      end
+
+      local correct = ngx.md5("#10#")
+      assert.equal("326afd95b21a24c277d9d05684cc3de6", correct)
+
+      for _ = 1, 10 do
+        local hash = clustering.calculate_config_hash(clustering, value)
+        assert.is_string(hash)
+        assert.equal(correct, hash)
+      end
+    end)
+
+    it("calculates hash for double", function()
+      local value = 0.9
+
+      for _ = 1, 10 do
+        local hash = clustering.calculate_config_hash(clustering, value)
+        assert.is_string(hash)
+        assert.equal("fccfc6bd485ed004537bbcac3c697048", hash)
+      end
+
+      local correct = ngx.md5("#0.9#")
+      assert.equal("fccfc6bd485ed004537bbcac3c697048", correct)
+
+      for _ = 1, 10 do
+        local hash = clustering.calculate_config_hash(clustering, value)
+        assert.is_string(hash)
+        assert.equal(correct, hash)
+      end
+    end)
+
+    it("calculates hash for empty string", function()
+      local value = ""
+
+      for _ = 1, 10 do
+        local hash = clustering.calculate_config_hash(clustering, value)
+        assert.is_string(hash)
+        assert.equal("58859d93c30e635814dc980ed86e3f84", hash)
+      end
+
+      local correct = ngx.md5("$$")
+      assert.equal("58859d93c30e635814dc980ed86e3f84", correct)
+
+      for _ = 1, 10 do
+        local hash = clustering.calculate_config_hash(clustering, value)
+        assert.is_string(hash)
+        assert.equal(correct, hash)
+      end
+    end)
+
+    it("calculates hash for string", function()
+      local value = "hello"
+
+      for _ = 1, 10 do
+        local hash = clustering.calculate_config_hash(clustering, value)
+        assert.is_string(hash)
+        assert.equal("34d2d743af7d615ff842c839ac762e14", hash)
+      end
+
+      local correct = ngx.md5("$hello$")
+      assert.equal("34d2d743af7d615ff842c839ac762e14", correct)
+
+      for _ = 1, 10 do
+        local hash = clustering.calculate_config_hash(clustering, value)
+        assert.is_string(hash)
+        assert.equal(correct, hash)
+      end
+    end)
+
+    it("calculates hash for boolean false", function()
+      local value = false
+
+      for _ = 1, 10 do
+        local hash = clustering.calculate_config_hash(clustering, value)
+        assert.is_string(hash)
+        assert.equal("7317c9dbe950ab8ffe4a4cff2f596e8a", hash)
+      end
+
+      local correct = ngx.md5("?false?")
+      assert.equal("7317c9dbe950ab8ffe4a4cff2f596e8a", correct)
+
+      for _ = 1, 10 do
+        local hash = clustering.calculate_config_hash(clustering, value)
+        assert.is_string(hash)
+        assert.equal(correct, hash)
+      end
+    end)
+
+    it("calculates hash for boolean true", function()
+      local value = true
+
+      for _ = 1, 10 do
+        local hash = clustering.calculate_config_hash(clustering, value)
+        assert.is_string(hash)
+        assert.equal("437765a4d8772918472d8a25102edf2e", hash)
+      end
+
+      local correct = ngx.md5("?true?")
+      assert.equal("437765a4d8772918472d8a25102edf2e", correct)
+
+      for _ = 1, 10 do
+        local hash = clustering.calculate_config_hash(clustering, value)
+        assert.is_string(hash)
+        assert.equal(correct, hash)
+      end
+    end)
+
+    it("calculating hash for function errors", function()
+      local pok = pcall(clustering.calculate_config_hash, clustering, function() end)
+      assert.falsy(pok)
+    end)
+
+    it("calculating hash for thread errors", function()
+      local pok = pcall(clustering.calculate_config_hash, clustering, coroutine.create(function() end))
+      assert.falsy(pok)
+    end)
+
+    it("calculating hash for userdata errors", function()
+      local pok = pcall(clustering.calculate_config_hash, clustering, io.tmpfile())
+      assert.falsy(pok)
+    end)
+
+    it("calculating hash for cdata errors", function()
+      local pok = pcall(clustering.calculate_config_hash, clustering, require "ffi".new("char[6]", "foobar"))
+      assert.falsy(pok)
+    end)
+
+    it("calculates hash for empty table", function()
+      local value = {}
+
+      for _ = 1, 10 do
+        local hash = clustering.calculate_config_hash(clustering, value)
+        assert.is_string(hash)
+        assert.equal("99914b932bd37a50b983c5e7c90ae93b", hash)
+      end
+
+      local correct = ngx.md5("{}")
+      assert.equal("99914b932bd37a50b983c5e7c90ae93b", correct)
+
+      for _ = 1, 10 do
+        local hash = clustering.calculate_config_hash(clustering, value)
+        assert.is_string(hash)
+        assert.equal(correct, hash)
+      end
+    end)
+
+    it("calculates hash for complex table", function()
+      local value = {
+        "a",
+        -3,
+        3,
+        "b",
+        -2,
+        2,
+        "c",
+        1,
+        -1,
+        0.9,
+        {},
+        { a = "b" },
+        ngx.null,
+        hello      = "a",
+        [-1]       = "b",
+        [0.9]      = "c",
+        [true]     = "d",
+        [false]    = "e",
+        [ngx.null] = "f",
+        [{}]       = "g",
+        a = "hello",
+        b = -1,
+        c = 0.9,
+        d = true,
+        e = false,
+        f = ngx.null,
+        g = {},
+      }
+
+      local correct = ngx.md5(
+        "{#-1#:$b$;#0.9#:$c$;#1#:$a$;#10#:#0.9#;#11#:{};#12#:{$a$:$b$};#13#:/null/;" ..
+        "#2#:#-3#;#3#:#3#;#4#:$b$;#5#:#-2#;#6#:#2#;#7#:$c$;#8#:#1#;#9#:#-1#;$a$:$he" ..
+        "llo$;$b$:#-1#;$c$:#0.9#;$d$:?true?;$e$:?false?;$f$:/null/;$g$:{};$hello$:$" ..
+        "a$;/null/:$f$;?false?:$e$;?true?:$d$;{}:$g$}")
+
+      for _ = 1, 10 do
+        local hash = clustering.calculate_config_hash(clustering, value)
+        assert.is_string(hash)
+        assert.equal(correct, hash)
+      end
+    end)
+
+  end)
+end)


### PR DESCRIPTION
### Summary

Previously data plane hash calculation was flaky and with recent OpenResty changes it become
even flakier. This PR tries to calculate data plane config hash in a more reliable way by
sorting the data and then calculating the hash out of it.