### PR TITLE
fix(clustering) ignore patch version mismatch

### DIFF
--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -354,7 +354,7 @@ function _M:check_configuration_compatibility(dp_plugin_map)
         -- CP plugin needs to match DP plugins with major version
         -- CP must have plugin with equal or newer version than that on DP
         if cp_plugin.major ~= dp_plugin.major or
-          (cp_plugin.major == dp_plugin.major and cp_plugin.minor < dp_plugin.minor) then
+          cp_plugin.minor < dp_plugin.minor then
           local msg = "configured data plane " .. name .. " plugin version " .. dp_plugin.version ..
                       " is different to control plane plugin version " .. cp_plugin.version
           return nil, msg, CLUSTERING_SYNC_STATUS.PLUGIN_VERSION_INCOMPATIBLE

--- a/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
@@ -298,11 +298,20 @@ for _, strategy in helpers.each_strategy() do
             {  name = "key-auth", version = tonumber(plugins_map["key-auth"]:match("(%d+)")) .. ".0.0" }
           }
         },
+        ["CP has configured plugin with older patch version than in DP enabled plugins"] = {
+          dp_version = string.format("%d.%d.%d", MAJOR, MINOR, PATCH),
+          plugins_list = {
+            {  name = "key-auth", version = plugins_map["key-auth"]:match("(%d+.%d+)") .. ".1000" }
+          }
+        },
         ["CP and DP minor version mismatches (older dp)"] = {
           dp_version = string.format("%d.%d.%d", MAJOR, 0, PATCH),
         },
         ["CP and DP patch version mismatches (older dp)"] = {
           dp_version = string.format("%d.%d.%d", MAJOR, MINOR, 0),
+        },
+        ["CP and DP patch version mismatches (newer dp)"] = {
+          dp_version = string.format("%d.%d.%d", MAJOR, MINOR, 1000),
         },
         ["CP and DP suffix mismatches"] = {
           dp_version = tostring(_VERSION_TABLE) .. "-enterprise-version",
@@ -430,24 +439,12 @@ for _, strategy in helpers.each_strategy() do
             {  name = "key-auth", version = tonumber(plugins_map["key-auth"]:match("(%d+)")) .. ".1000.0" }
           }
         },
-        ["CP has configured plugin with older patch version than in DP enabled plugins"] = {
-          dp_version = string.format("%d.%d.%d", MAJOR, MINOR, PATCH),
-          expected = CLUSTERING_SYNC_STATUS.PLUGIN_VERSION_INCOMPATIBLE,
-          plugins_list = {
-            {  name = "key-auth", version = plugins_map["key-auth"]:match("(%d+.%d+)") .. ".1000" }
-          }
-        },
         ["CP and DP major version mismatches"] = {
           dp_version = "1.0.0",
           expected = CLUSTERING_SYNC_STATUS.KONG_VERSION_INCOMPATIBLE,
           -- KONG_VERSION_INCOMPATIBLE is send during first handshake, CP closes
           -- connection immediately if kong version mismatches.
           -- ignore_error is needed to ignore the `closed` error
-          ignore_error = true,
-        },
-        ["CP and DP patch version mismatches (newer dp)"] = {
-          dp_version = string.format("%d.%d.%d", MAJOR, MINOR, 1000),
-          expected = CLUSTERING_SYNC_STATUS.KONG_VERSION_INCOMPATIBLE,
           ignore_error = true,
         },
         ["CP and DP minor version mismatches (newer dp)"] = {


### PR DESCRIPTION
This PR fixes a regression from
9cdd34ed4ee8f6fd8cab560ac09173950076355b,
where patch versions on DP are ignored no matter it's newer or older.

This preserves the same behaviour before
9cdd34ed4ee8f6fd8cab560ac09173950076355b.

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

SUMMARY_GOES_HERE

### Full changelog

* [Implement ...]
* [Add related tests]
* ...

### Issues resolved

Fix #XXX
