### PR TITLE
fix(db) Apache Cassandra 4.0 compatibility

### DIFF
--- a/kong/db/strategies/cassandra/connector.lua
+++ b/kong/db/strategies/cassandra/connector.lua
@@ -1021,6 +1021,7 @@ do
           or string.find(err, "[Uu]ndefined column name")
           or string.find(err, "No column definition found for column")
           or string.find(err, "Undefined name .- in selection clause")
+          or string.find(err, "Column with name .- already exists")
           then
             log.warn("ignored error while running '%s' migration: %s (%s)",
                      name, err, cql:gsub("\n", " "):gsub("%s%s+", " "))


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

ALTER statements for existing columns cause migration/bootstrap errors when initializing Kong. This commit ensures that ALTER statement errors are safely ignored for standard migrations and re-entrant migration operations when using Apache Cassandra 4.0.

GitHub Actions were also updated to test against 4.0-rc1.

### Full changelog

* fix(db) Apache Cassandra 4.0 compatibility
