### PR TITLE
chore(deps) bump resty-worker-events to 2.0.1

### DIFF
--- a/kong-2.4.1-0.rockspec
+++ b/kong-2.4.1-0.rockspec
@@ -31,7 +31,7 @@ dependencies = {
   "lua_pack == 1.0.5",
   "lua-resty-dns-client == 6.0.1",
   "lua-protobuf == 0.3.2",
-  "lua-resty-worker-events == 1.0.0",
+  "lua-resty-worker-events == 2.0.1",
   "lua-resty-healthcheck == 1.4.1",
   "lua-resty-cookie == 0.1.0",
   "lua-resty-mlcache == 2.5.0",

--- a/kong/api/api_helpers.lua
+++ b/kong/api/api_helpers.lua
@@ -269,7 +269,10 @@ local function parse_params(fn)
 
     local res, err = fn(self, ...)
 
-    kong.worker_events.poll()
+    local ok, err2 = kong.worker_events.poll()
+    if not ok then
+      kong.log.notice("polling worker events failed: ", err2)
+    end
 
     if err then
       kong.log.err(err)

--- a/kong/cache/init.lua
+++ b/kong/cache/init.lua
@@ -114,6 +114,11 @@ function _M.new(opts)
             if not ok then
               log(ERR, "failed to post event '", channel_name, "', '",
                        channel, "': ", err)
+            else
+              ok, err = opts.worker_events.poll()
+              if not ok then
+                log(NOTICE, "polling worker events failed: ", err)
+              end
             end
           end
         }

--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -737,9 +737,14 @@ function _M:init_worker()
 
   -- Sends "clustering", "push_config" to all workers in the same node, including self
   local function post_push_config_event()
-    local res, err = kong.worker_events.post("clustering", "push_config")
-    if not res then
+    local ok, err = kong.worker_events.post("clustering", "push_config")
+    if not ok then
       ngx_log(ngx_ERR, _log_prefix, "unable to broadcast event: ", err)
+    else
+      ok, err = kong.worker_events.poll()
+      if not ok then
+        ngx_log(ngx_NOTICE, _log_prefix, "polling worker events failed: ", err)
+      end
     end
   end
 

--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -839,9 +839,9 @@ do
     ok, err, default_ws = declarative.load_into_cache(entities, meta, hash, SHADOW)
     if ok then
       ok, err = kong.worker_events.post("declarative", "flip_config", default_ws)
-      if ok ~= "done" then
+      if not ok then
         ngx.shared.kong:delete(DECLARATIVE_LOCK_KEY)
-        return nil, "failed to flip declarative config cache pages: " .. (err or ok)
+        return nil, "failed to flip declarative config cache pages: " .. (err or "unknown error")
       end
 
     else

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -1381,7 +1381,6 @@ local function serve_content(module, options)
   ctx.KONG_PROCESSING_START = start_time() * 1000
   ctx.KONG_ADMIN_CONTENT_START = ctx.KONG_ADMIN_CONTENT_START or get_now_ms()
 
-
   log_init_worker_errors(ctx)
 
   options = options or {}
@@ -1408,7 +1407,10 @@ end
 
 
 function Kong.admin_content(options)
-  kong.worker_events.poll()
+  local ok, err = kong.worker_events.poll()
+  if not ok then
+    kong.log.notice("polling worker events failed: ", err)
+  end
 
   local ctx = ngx.ctx
   if not ctx.workspace then
@@ -1464,6 +1466,11 @@ end
 
 
 function Kong.status_content()
+  local ok, err = kong.worker_events.poll()
+  if not ok then
+    kong.log.notice("polling worker events failed: ", err)
+  end
+
   return serve_content("kong.status")
 end
 

--- a/kong/pdk/response.lua
+++ b/kong/pdk/response.lua
@@ -774,7 +774,10 @@ local function new(self, major_version)
     --
     function _RESPONSE.exit(status, body, headers)
       if self.worker_events and ngx.get_phase() == "content" then
-        self.worker_events.poll()
+        local ok, err = self.worker_events.poll()
+        if not ok then
+          self.log.notice("polling worker events failed: ", err)
+        end
       end
 
       check_phase(rewrite_access_header)
@@ -960,7 +963,10 @@ local function new(self, major_version)
   -- return kong.response.error(403)
   function _RESPONSE.error(status, message, headers)
     if self.worker_events and ngx.get_phase() == "content" then
-      self.worker_events.poll()
+      local ok, err = self.worker_events.poll()
+      if not ok then
+        self.log.notice("polling worker events failed: ", err)
+      end
     end
 
     check_phase(rewrite_access_header)

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -186,8 +186,12 @@ local function register_balancer_events(core_cache, worker_events, cluster_event
         entity = data.entity,
       })
     if not ok then
-      log(ERR, "failed broadcasting target ",
-        operation, " to workers: ", err)
+      log(ERR, "failed broadcasting target ", operation, " to workers: ", err)
+    else
+      ok, err = worker_events.poll()
+      if not ok then
+        log(NOTICE, "polling worker events failed: ", err)
+      end
     end
     -- => to cluster_events handler
     local key = fmt("%s:%s", operation, target.upstream.id)
@@ -226,6 +230,11 @@ local function register_balancer_events(core_cache, worker_events, cluster_event
       })
     if not ok then
       log(ERR, "failed broadcasting target ", operation, " to workers: ", err)
+    else
+      ok, err = worker_events.poll()
+      if not ok then
+        log(NOTICE, "polling worker events failed: ", err)
+      end
     end
   end)
 
@@ -259,8 +268,12 @@ local function register_balancer_events(core_cache, worker_events, cluster_event
         entity = data.entity,
       })
     if not ok then
-      log(ERR, "failed broadcasting upstream ",
-        operation, " to workers: ", err)
+      log(ERR, "failed broadcasting upstream ", operation, " to workers: ", err)
+    else
+      ok, err = worker_events.poll()
+      if not ok then
+        log(NOTICE, "polling worker events failed: ", err)
+      end
     end
     -- => to cluster_events handler
     local key = fmt("%s:%s:%s", operation, upstream.id, upstream.name)
@@ -297,6 +310,11 @@ local function register_balancer_events(core_cache, worker_events, cluster_event
       })
     if not ok then
       log(ERR, "failed broadcasting upstream ", operation, " to workers: ", err)
+    else
+      ok, err = worker_events.poll()
+      if not ok then
+        log(NOTICE, "polling worker events failed: ", err)
+      end
     end
   end)
 end

--- a/spec/01-unit/09-balancer_spec.lua
+++ b/spec/01-unit/09-balancer_spec.lua
@@ -1,5 +1,7 @@
 local utils = require "kong.tools.utils"
 local mocker = require "spec.fixtures.mocker"
+local we = require "resty.worker.events"
+
 
 local ws_id = utils.uuid()
 
@@ -469,6 +471,7 @@ for _, consistency in ipairs({"strict", "eventual"}) do
         }
         for _, t in ipairs(tests) do
           assert(balancer.post_health(upstream_ph, t.host, nil, t.port, t.health))
+          we.poll()
           local health_info = assert(balancer.get_upstream_health("ph"))
           local response = t.health and "HEALTHY" or "UNHEALTHY"
           assert.same(response,
@@ -506,12 +509,14 @@ for _, consistency in ipairs({"strict", "eventual"}) do
             port = 1111,
             host = {hostname = "localhost"},
           }}, 429)
+        we.poll()
         my_balancer.report_http_status({
           address = {
             ip = "127.0.0.1",
             port = 1111,
             host = {hostname = "localhost"},
           }}, 200)
+        we.poll()
         balancer.unsubscribe_from_healthcheck_events(cb)
         my_balancer.report_http_status({
           address = {

--- a/spec/02-integration/05-proxy/10-balancer/01-healthchecks_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer/01-healthchecks_spec.lua
@@ -8,7 +8,7 @@ local https_server = helpers.https_server
 
 
 for _, strategy in helpers.each_strategy() do
-  local bp
+  local bp, db
 
   local DB_UPDATE_PROPAGATION = strategy == "cassandra" and 0.1 or 0
   local DB_UPDATE_FREQUENCY   = strategy == "cassandra" and 0.1 or 0.1
@@ -23,12 +23,15 @@ for _, strategy in helpers.each_strategy() do
 
   describe("Healthcheck #" .. strategy, function()
     lazy_setup(function()
-      bp = bu.get_db_utils_for_dc_and_admin_api(strategy, {
+      bp, db = bu.get_db_utils_for_dc_and_admin_api(strategy, {
         "routes",
         "services",
         "plugins",
         "upstreams",
         "targets",
+      }, {
+        "worker-events-poll",
+        "fail-once-auth",
       })
 
       local fixtures = {
@@ -73,6 +76,10 @@ for _, strategy in helpers.each_strategy() do
         address = "127.0.0.2",
       }
 
+      db.plugins:insert({
+        name = "worker-events-poll",
+      })
+
       assert(helpers.start_kong({
         database   = strategy,
         dns_resolver = "127.0.0.1",
@@ -81,6 +88,7 @@ for _, strategy in helpers.each_strategy() do
         nginx_conf = "spec/fixtures/custom_nginx.template",
         db_update_frequency = DB_UPDATE_FREQUENCY,
         db_update_propagation = DB_UPDATE_PROPAGATION,
+        plugins = "bundled,fail-once-auth,worker-events-poll"
       }, nil, nil, fixtures))
 
     end)
@@ -361,11 +369,14 @@ for _, strategy in helpers.each_strategy() do
 
 
     lazy_setup(function()
-      bp = bu.get_db_utils_for_dc_and_admin_api(strategy, {
+      bp, db = bu.get_db_utils_for_dc_and_admin_api(strategy, {
         "services",
         "routes",
         "upstreams",
         "targets",
+      }, {
+        "worker-events-poll",
+        "fail-once-auth",
       })
 
       local fixtures = {
@@ -377,6 +388,10 @@ for _, strategy in helpers.each_strategy() do
         address = "127.0.0.1",
       }
 
+      db.plugins:insert({
+        name = "worker-events-poll",
+      })
+
       assert(helpers.start_kong({
         database   = strategy,
         admin_listen = default_admin_listen,
@@ -387,7 +402,7 @@ for _, strategy in helpers.each_strategy() do
         client_ssl_cert_key = "spec/fixtures/kong_spec.key",
         db_update_frequency = 0.1,
         stream_listen = "off",
-        plugins = "bundled,fail-once-auth",
+        plugins = "bundled,fail-once-auth,worker-events-poll",
       }, nil, nil, fixtures))
     end)
 
@@ -469,11 +484,18 @@ for _, strategy in helpers.each_strategy() do
   describe("Ring-balancer #" .. strategy, function()
 
     lazy_setup(function()
-      bp = bu.get_db_utils_for_dc_and_admin_api(strategy, {
+      bp, db = bu.get_db_utils_for_dc_and_admin_api(strategy, {
         "services",
         "routes",
         "upstreams",
         "targets",
+      }, {
+        "fail-once-auth",
+        "worker-events-poll",
+      })
+
+      db.plugins:insert({
+        name = "worker-events-poll",
       })
 
       assert(helpers.start_kong({
@@ -486,7 +508,7 @@ for _, strategy in helpers.each_strategy() do
         stream_listen = "off",
         db_update_frequency = DB_UPDATE_FREQUENCY,
         db_update_propagation = DB_UPDATE_PROPAGATION,
-        plugins = "bundled,fail-once-auth",
+        plugins = "bundled,fail-once-auth,worker-events-poll",
       }))
     end)
 
@@ -512,6 +534,7 @@ for _, strategy in helpers.each_strategy() do
           log_level = "debug",
           db_update_frequency = DB_UPDATE_FREQUENCY,
           db_update_propagation = DB_UPDATE_PROPAGATION,
+          plugins = "bundled,fail-once-auth,worker-events-poll",
         })
       end)
 
@@ -1053,7 +1076,7 @@ for _, strategy in helpers.each_strategy() do
                 lua_ssl_trusted_certificate = "spec/fixtures/kong_spec.crt",
                 db_update_frequency = 0.1,
                 stream_listen = "off",
-                plugins = "bundled,fail-once-auth",
+                plugins = "bundled,fail-once-auth,worker-events-poll",
               }, nil, fixtures)
               bu.end_testcase_setup(strategy, bp)
 
@@ -1481,7 +1504,7 @@ for _, strategy in helpers.each_strategy() do
                   lua_ssl_trusted_certificate = "spec/fixtures/kong_spec.crt",
                   db_update_frequency = 0.1,
                   stream_listen = "off",
-                  plugins = "bundled,fail-once-auth",
+                  plugins = "bundled,fail-once-auth,worker-events-poll",
                 }, nil, fixtures)
                 bu.end_testcase_setup(strategy, bp)
 
@@ -1590,7 +1613,7 @@ for _, strategy in helpers.each_strategy() do
                   lua_ssl_trusted_certificate = "spec/fixtures/kong_spec.crt",
                   db_update_frequency = 0.1,
                   stream_listen = "off",
-                  plugins = "bundled,fail-once-auth",
+                  plugins = "bundled,fail-once-auth,worker-events-poll",
                 }, nil, fixtures)
                 bu.end_testcase_setup(strategy, bp)
 
@@ -1813,7 +1836,7 @@ for _, strategy in helpers.each_strategy() do
                 lua_ssl_trusted_certificate = "spec/fixtures/kong_spec.crt",
                 db_update_frequency = 0.1,
                 stream_listen = "off",
-                plugins = "bundled,fail-once-auth",
+                plugins = "bundled,fail-once-auth,worker-events-poll",
               })
               bu.end_testcase_setup(strategy, bp)
 

--- a/spec/03-plugins/25-oauth2/04-invalidations_spec.lua
+++ b/spec/03-plugins/25-oauth2/04-invalidations_spec.lua
@@ -316,6 +316,15 @@ for _, strategy in helpers.each_strategy() do
         local token = cjson.decode(assert.res_status(200, res))
         assert.is_table(token)
 
+        -- Check that cache is not populated
+        local cache_key = db.oauth2_tokens:cache_key(token.access_token)
+        local res = assert(admin_client:send {
+          method  = "GET",
+          path    = "/cache/" .. cache_key,
+          headers = {}
+        })
+        assert.res_status(404, res)
+
         -- The token should work
         local res = assert(proxy_ssl_client:send {
           method  = "GET",
@@ -327,7 +336,6 @@ for _, strategy in helpers.each_strategy() do
         assert.res_status(200, res)
 
         -- Check that cache is populated
-        local cache_key = db.oauth2_tokens:cache_key(token.access_token)
         local res = assert(admin_client:send {
           method  = "GET",
           path    = "/cache/" .. cache_key,
@@ -376,6 +384,15 @@ for _, strategy in helpers.each_strategy() do
         local token = cjson.decode(assert.res_status(200, res))
         assert.is_table(token)
 
+        -- Check that cache is not populated
+        local cache_key = db.oauth2_tokens:cache_key(token.access_token)
+        local res = assert(admin_client:send {
+          method  = "GET",
+          path    = "/cache/" .. cache_key,
+          headers = {}
+        })
+        assert.res_status(404, res)
+
         -- The token should work
         local res = assert(proxy_ssl_client:send {
           method  = "GET",
@@ -387,8 +404,6 @@ for _, strategy in helpers.each_strategy() do
         assert.res_status(200, res)
 
         -- Check that cache is populated
-        local cache_key = db.oauth2_tokens:cache_key(token.access_token)
-
         local res = assert(admin_client:send {
           method  = "GET",
           path    = "/cache/" .. cache_key,
@@ -454,6 +469,15 @@ for _, strategy in helpers.each_strategy() do
         local token = cjson.decode(assert.res_status(200, res))
         assert.is_table(token)
 
+        -- Check that cache is not populated
+        local cache_key = db.oauth2_tokens:cache_key(token.access_token)
+        local res = assert(admin_client:send {
+          method  = "GET",
+          path    = "/cache/" .. cache_key,
+          headers = {}
+        })
+        assert.res_status(404, res)
+
         -- The token should work
         local res = assert(proxy_ssl_client:send {
           method  = "GET",
@@ -465,8 +489,6 @@ for _, strategy in helpers.each_strategy() do
         assert.res_status(200, res)
 
         -- Check that cache is populated
-        local cache_key = db.oauth2_tokens:cache_key(token.access_token)
-
         local res = assert(admin_client:send {
           method  = "GET",
           path    = "/cache/" .. cache_key,

--- a/spec/fixtures/balancer_utils.lua
+++ b/spec/fixtures/balancer_utils.lua
@@ -479,12 +479,12 @@ local function end_testcase_setup(strategy, bp, consistency)
 end
 
 
-local function get_db_utils_for_dc_and_admin_api(strategy, tables)
-  local bp = assert(helpers.get_db_utils(strategy, tables))
+local function get_db_utils_for_dc_and_admin_api(strategy, tables, plugins)
+  local bp, db = assert(helpers.get_db_utils(strategy, tables, plugins))
   if strategy ~= "off" then
     bp = require("spec.fixtures.admin_api")
   end
-  return bp
+  return bp, db
 end
 
 

--- a/spec/fixtures/custom_plugins/kong/plugins/worker-events-poll/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/worker-events-poll/handler.lua
@@ -1,0 +1,20 @@
+local kong = kong
+local math = math
+
+
+local WorkerEventsPoll = {
+  PRIORITY = math.huge
+}
+
+
+function WorkerEventsPoll:preread()
+  kong.worker_events.poll()
+end
+
+
+function WorkerEventsPoll:rewrite()
+  kong.worker_events.poll()
+end
+
+
+return WorkerEventsPoll

--- a/spec/fixtures/custom_plugins/kong/plugins/worker-events-poll/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/worker-events-poll/schema.lua
@@ -1,0 +1,17 @@
+local typedefs = require "kong.db.schema.typedefs"
+
+return {
+  name = "worker-events-poll",
+  fields = {
+    {
+      protocols = typedefs.protocols { default = { "http", "https", "tcp", "tls", "grpc", "grpcs" } },
+    },
+    {
+      config = {
+        type = "record",
+        fields = {
+        },
+      },
+    },
+  },
+}


### PR DESCRIPTION
### Summary

#### resty.worker.events 2.0.1, 28-June-2021

- fix: possible deadlock in the 'init phase

#### resty.worker.events 2.0.0, 16-September-2020

- BREAKING: the `post` function does not call `poll` anymore, making all events  asynchronous. When an immediate treatment to an event is needed an explicit call to `poll` must be done.
- BREAKING: the `post_local` function does not immediately execute the   event anymore, making all local events asynchronous. When an immediate   treatment to an event is needed an explicit call to `poll` must be done.
- fix: prevent spinning at 100% CPU when during a reload the event-shm is cleared
- fix: improved logging in case of failure to write to shm (add payload size for troubleshooting purposes)
- fix: do not log the payload anymore, since it might expose sensitive data through the logs
- change: updated `shm_retries` default to 999
- change: changed timer loop to a sleep-loop (performance)
- fix: when re-configuring make sure callbacks table is initialized