### PR TITLE
chore(log) remove duplicate CP plugin version output in log

### DIFF
--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -307,7 +307,7 @@ function _M:check_version_compatibility(dp_version, dp_plugin_map, log_suffix)
                     " is different to control plane plugin version " .. cp_plugin.version
 
         if cp_plugin.major ~= dp_plugin.major then
-          ngx_log(ngx_WARN, _log_prefix, msg, cp_plugin.version, log_suffix)
+          ngx_log(ngx_WARN, _log_prefix, msg, log_suffix)
 
         elseif cp_plugin.minor ~= dp_plugin.minor then
           ngx_log(ngx_INFO, _log_prefix, msg, log_suffix)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Duplicated CP plugin version information is being appended to a log message when the CP and DP major versions differ. The CP plugin version is already part of `msg`.

```
18:44:01 [warn] 2997#0: *26 [lua] control_plane.lua:247: check_version_compatibility(): [clustering] data plane acl plugin version 3.0.1 is different to control plane plugin version 3.0.13.0.1 [id: e5ecbe97-b04a-464f-8667-ba82edea4953, host: d9d9a0877271, ip: 127.0.0.1, version: 2.4.1.1-dev-enterprise-edition], client: 127.0.0.1, server: kong_cluster_listener, request: "GET /v1/outlet?node_id=e5ecbe97-b04a-464f-8667-ba82edea4953&node_hostname=d9d9a0877271&node_version=2.4.1.1-dev-enterprise-edition HTTP/1.1", host: "127.0.0.1:9005"
18:44:01 [warn] 2997#0: *26 [lua] control_plane.lua:247: check_version_compatibility(): [clustering] data plane acme plugin version 0.2.14 is different to control plane plugin version 0.2.140.2.14 [id: e5ecbe97-b04a-464f-8667-ba82edea4953, host: d9d9a0877271, ip: 127.0.0.1, version: 2.4.1.1-dev-enterprise-edition], client: 127.0.0.1, server: kong_cluster_listener, request: "GET /v1/outlet?node_id=e5ecbe97-b04a-464f-8667-ba82edea4953&node_hostname=d9d9a0877271&node_version=2.4.1.1-dev-enterprise-edition HTTP/1.1", host: "127.0.0.1:9005"
```

**Note**: The log message above is just for demonstration to show the extra `3.013.01` and `0.2.140.2.14` in the log messages.

### Full changelog

* chore(log) remove extra CP plugin version output in log
