### PR TITLE
fix(clustering) fix race condition causing flakiness on sync status of data plane

### DIFF
--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -572,6 +572,7 @@ function _M:handle_cp_websocket()
 
       else
         if typ == "close" then
+          ngx_log(ngx_DEBUG, _log_prefix, "received close frame from data plane", log_suffix)
           return
         end
 
@@ -583,6 +584,8 @@ function _M:handle_cp_websocket()
         if typ ~= "ping" then
           return nil, "invalid websocket frame received from data plane: " .. typ
         end
+
+        ngx_log(ngx_DEBUG, _log_prefix, "received ping frame from data plane", log_suffix)
 
         config_hash = data
         last_seen = ngx_time()
@@ -611,13 +614,13 @@ function _M:handle_cp_websocket()
           local _, err = wb:send_pong()
           if err then
             if not is_timeout(err) then
-              return nil, "failed to send PONG back to data plane: " .. err
+              return nil, "failed to send pong frame to data plane: " .. err
             end
 
-            ngx_log(ngx_NOTICE, _log_prefix, "failed to send PONG back to data plane: ", err, log_suffix)
+            ngx_log(ngx_NOTICE, _log_prefix, "failed to send pong frame to data plane: ", err, log_suffix)
 
           else
-            ngx_log(ngx_DEBUG, _log_prefix, "sent PONG packet to data plane", log_suffix)
+            ngx_log(ngx_DEBUG, _log_prefix, "sent pong frame to data plane", log_suffix)
           end
 
         else


### PR DESCRIPTION
### Summary

#### fix(clustering) fix race condition causing flakiness on sync status of data plane

There are two cases that may cause updating the sync status on database:

1. PING frame received by control plane from dataplane
2. New config send to dataplane from control plane

As these are ran in two threads and as the postgres upsert statement is asynchronous non-blocking query, the order which we send the queries is not always the order which they appear in postgres.

This PR makes our test suite less flaky on the race condition by grabbing the initial configuration compatibility before starting the read/write threads.

There is also a small change that makes `last-seen` only updated when receiving `PING` frame from data plane. This is more in line of what we had before.

#### chore(clustering) more symmetric logging on control plane and data plane 

Changed data plane log messages to contain information about control plane. This also adds couple of new log statements for symmetry and makes the language more consistent.

### Issues resolved

Fix test flakiness