### PR TITLE
chore(plugins) bump syslog plugin version

### DIFF
--- a/kong/plugins/syslog/handler.lua
+++ b/kong/plugins/syslog/handler.lua
@@ -89,7 +89,7 @@ end
 
 local SysLogHandler = {
   PRIORITY = 4,
-  VERSION = "2.2.0",
+  VERSION = "2.3.0",
 }
 
 


### PR DESCRIPTION
There's a new config entry, if the version is not bumped the docs would be confuse.