### PR TITLE
fix(ci) pin Alpine release to 3.13

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
                 RELEASE_DOCKER_ONLY="true"
                 PACKAGE_TYPE="apk"
                 RESTY_IMAGE_BASE="alpine"
-                RESTY_IMAGE_TAG="latest"
+                RESTY_IMAGE_TAG="3.13"
             }
             steps {
                 sh 'echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin || true'


### PR DESCRIPTION
Release 3.14 (15-6-2021, see https://alpinelinux.org/releases/ ) has issues that break `make` (see https://github.com/alpinelinux/docker-alpine/issues/146 ) and hence cause Pongo image builds to fail.

NOTE: it was set to `latest` which was good to catch issues early (this issue proves the approach worked), so we'll have to revisit upon newer Alpine releases whether we can go back to the `latest` tag.