### PR TITLE
fix(proxy) removal of proxy-authorization header

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1114,10 +1114,9 @@ return {
       local server_port = var.server_port
       ctx.host_port = HOST_PORTS[server_port] or server_port
 
-      -- special handling for proxy-authorization and te headers in case
+      -- special handling for proxy-authorization header in case
       -- the plugin(s) want to specify them (store the original)
       ctx.http_proxy_authorization = var.http_proxy_authorization
-      ctx.http_te                  = var.http_te
     end,
     after = NOOP,
   },
@@ -1350,7 +1349,7 @@ return {
         return ngx.exit(500)
       end
 
-      -- the nginx grpc module does not offer a way to overrride the
+      -- the nginx grpc module does not offer a way to override the
       -- :authority pseudo-header; use our internal API to do so
       local upstream_host = var.upstream_host
       local upstream_scheme = var.upstream_scheme
@@ -1395,9 +1394,8 @@ return {
 
       -- clear the proxy-authorization header only in case the plugin didn't
       -- specify it, assuming that the plugin didn't specify the same value.
-      local proxy_authorization = var.http_proxy_authorization
-      if proxy_authorization and
-         proxy_authorization == var.http_proxy_authorization then
+      if ctx.http_proxy_authorization and
+         ctx.http_proxy_authorization == var.http_proxy_authorization then
         clear_header("Proxy-Authorization")
       end
     end


### PR DESCRIPTION
### Summary

Clear proxy authorization header only when it is part of original request headers.
Removes it also when the plugin specifies it with exactly same value as in original
request headers.