### PR TITLE
Handle HEAD requests in buffered mode.

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -1052,7 +1052,7 @@ do
     }
 
     local res = ngx.location.capture("/kong_buffered_http", options)
-    if res.truncated then
+    if res.truncated and options.method ~= ngx.HTTP_HEAD then
       kong_global.set_phase(kong, PHASES.error)
       ngx.status = 502
       return kong_error_handlers(ctx)

--- a/spec/02-integration/05-proxy/24-buffered_spec.lua
+++ b/spec/02-integration/05-proxy/24-buffered_spec.lua
@@ -155,6 +155,18 @@ for _, strategy in helpers.each_strategy() do
         assert.equal(md5(body), res.headers["MD5"])
       end)
 
+      it("HEAD request work the same, without a body", function()
+        local res = proxy_client:send{ method="HEAD", path="/1/status/231"}
+        local body = assert.res_status(231, res)
+        assert.equal(body, "")
+        assert.equal(md5(body), res.headers["MD5"])
+
+        local res = proxy_ssl_client:send{ method="HEAD", path="/1/status/232" }
+        local body = assert.res_status(232, res)
+        assert.equal(body, "")
+        assert.equal(md5(body), res.headers["MD5"])
+      end)
+
       it("header can be set from upstream response body and body can be modified on header_filter phase", function()
         local res = proxy_client:get("/2/status/233")
         local body = assert.res_status(233, res)
@@ -176,6 +188,18 @@ for _, strategy in helpers.each_strategy() do
 
         local res = proxy_ssl_client:get("/3/status/236")
         local body = assert.res_status(236, res)
+        assert.equal(md5(body), res.headers["MD5"])
+      end)
+
+      it("response phase works in HEAD request", function()
+        local res = proxy_client:send{ method="HEAD", path="/3/status/235" }
+        local body = assert.res_status(235, res)
+        assert.equal(body, "")
+        assert.equal(md5(body), res.headers["MD5"])
+
+        local res = proxy_ssl_client:send{ method="HEAD", path="/3/status/236" }
+        local body = assert.res_status(236, res)
+        assert.equal(body, "")
         assert.equal(md5(body), res.headers["MD5"])
       end)
 


### PR DESCRIPTION
According to docs, `ngx.location.capture` returns `res.truncated ==
true` on error cases, but it seems HEAD requests might cause it too.  In
 those cases don't force an error response.

Fixes #7059