### PR TITLE
fix(test) reduce test flakyness by actually waiting

### DIFF
--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -573,15 +573,14 @@ local function wait_until(f, timeout, step)
   timeout = timeout or 5
   step = step or 0.05
 
-  local tstart = ngx.time()
-  local texp = tstart + timeout
+  local texp = ngx.now() + timeout
   local ok, res, err
 
   repeat
     ok, res, err = pcall(f)
     ngx.sleep(step)
     ngx.update_time()
-  until not ok or res or ngx.time() >= texp
+  until not ok or res or ngx.now() >= texp
 
   if not ok then
     -- report error from `f`, such as assert gone wrong


### PR DESCRIPTION
because it used to use `ngx.time()` which only has second
precision, a time-out specified as 1 second could actually be
only 0.001, if that 1ms would cross the second boundary
