### PR TITLE
plugins/grpc-gateway: fix failing imports, issue #7470

### DIFF
--- a/kong/plugins/grpc-gateway/deco.lua
+++ b/kong/plugins/grpc-gateway/deco.lua
@@ -91,6 +91,7 @@ local function get_proto_info(fname)
   local p = protoc.new()
   p.include_imports = true
   p:addpath(dir)
+  p:loadfile(name)
   local parsed = p:parsefile(name)
 
   info = {}
@@ -129,7 +130,6 @@ local function get_proto_info(fname)
 
   _proto_info[fname] = info
 
-  p:loadfile(name)
   return info
 end
 


### PR DESCRIPTION
### Summary

Files with imports are not loaded properly due to late fileload

### Full changelog

`p:loadfile(name)` from https://github.com/Kong/kong/blob/master/kong/plugins/grpc-gateway/deco.lua#L132 moved before `p:parsefile(name)` at https://github.com/Kong/kong/blob/master/kong/plugins/grpc-gateway/deco.lua#L94

### Issues resolved

fix for issue #7470  - Proto file with import causes error during REST call 
