### PR TITLE
fix(clustering) ensure data plane config thread is terminated gracefully

### DIFF
--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -267,9 +267,10 @@ function _M:communicate(premature)
   --                 and is also responsible for handling timeout detection
 
   local ping_immediately
+  local config_exit
 
   local config_thread = ngx.thread.spawn(function()
-    while not exiting() do
+    while not exiting() and not config_exit do
       local ok, err = config_semaphore:wait(1)
       if ok then
         local config_table = self.next_config
@@ -378,9 +379,19 @@ function _M:communicate(premature)
 
   ngx.thread.kill(read_thread)
   ngx.thread.kill(write_thread)
-  ngx.thread.kill(config_thread)
-
   c:close()
+
+  if not ok then
+    ngx_log(ngx_ERR, _log_prefix, err, log_suffix)
+
+  elseif perr then
+    ngx_log(ngx_ERR, _log_prefix, perr, log_suffix)
+  end
+
+  -- the config thread might be holding a lock if it's in the middle of an
+  -- update, so we need to give it a chance to terminate gracefully
+  config_exit = true
+  ok, err, perr = ngx.thread.wait(config_thread)
 
   if not ok then
     ngx_log(ngx_ERR, _log_prefix, err, log_suffix)


### PR DESCRIPTION
### Summary

Ensure data plane config thread is terminated gracefully, preventing it from getting into a semi-deadlocked state.

It'd be pretty tough to make this testable, so I hope it's okay without any additional tests added. I haven't run the test suite locally so :crossed_fingers: that it passes the automated tests here.


### Issues resolved

Fix #7567
