### PR TITLE
chore(test) helper db-export should honor test config

### DIFF
--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -167,7 +167,7 @@ local function make_yaml_file(content, filename)
     assert(fd:write("\n")) -- ensure last line ends in newline
     assert(fd:close())
   else
-    assert(kong_exec("config db_export "..filename))
+    assert(kong_exec("config db_export --conf "..TEST_CONF_PATH.." "..filename))
   end
   return filename
 end


### PR DESCRIPTION
fixes the issue reported here: https://github.com/Kong/kong-plugin/pull/16#issuecomment-881673138