### PR TITLE
Solved Kong config parse crashing .

### DIFF
--- a/kong/runloop/plugin_servers/process.lua
+++ b/kong/runloop/plugin_servers/process.lua
@@ -51,7 +51,7 @@ end
 
 
 local function get_server_defs()
-  local config = kong.configuration
+  config = kong.configuration
 
   if not _servers then
     _servers = {}


### PR DESCRIPTION
As the config variable was previously of local scope , which limited itself. That caused a crash when there is a go plugin server enabled.Now I hope it is solved.

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

SUMMARY_GOES_HERE

### Full changelog

* [Implement ...]
* [Add related tests]
* ...

### Issues resolved

Fix #XXX
