### PR TITLE
update module's `local kong` var

### DIFF
--- a/kong/runloop/plugin_servers/init.lua
+++ b/kong/runloop/plugin_servers/init.lua
@@ -258,6 +258,7 @@ local plugin_servers = {}
 local loaded_plugins = {}
 
 local function get_plugin(plugin_name)
+  kong = kong or _G.kong    -- some CLI cmds set the global after loading the module.
   if not loaded_plugins[plugin_name] then
     local plugin = get_plugin_info(plugin_name)
     loaded_plugins[plugin_name] = build_phases(plugin)

--- a/kong/runloop/plugin_servers/process.lua
+++ b/kong/runloop/plugin_servers/process.lua
@@ -189,6 +189,7 @@ end
 
 function proc_mgmt.get_plugin_info(plugin_name)
   if not _plugin_infos then
+    kong = kong or _G.kong    -- some CLI cmds set the global after loading the module.
     _plugin_infos = {}
 
     for _, server_def in ipairs(get_server_defs()) do


### PR DESCRIPTION
The external plugins rewrite of #6600 regressed CLI bug first reported
in #6437 and fixed in #6596.

Fix #7583