### PR TITLE
Updates changelog with performance testing framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,7 +229,7 @@ grpc-gateway plugin first:
   used Kong with TCP, they couldn’t use a custom log format. With this fix, `proxy_stream_access_log` and `proxy_stream_error_log`
   have been added to differentiate stream access log from the HTTP subsystem. See
   [`proxy_stream_access_log`](https://docs.konghq.com/gateway-oss/2.5.x/configuration/#proxy_stream_access_log)
-  and [`proxy_stream_error`](https://docs.konghq.com/gateway-oss/2.5.x/configuration/#proxy_stream_error) in the Configuration
+  and [`proxy_stream_error_log`](https://docs.konghq.com/gateway-oss/2.5.x/configuration/#proxy_stream_error_log) in the Configuration
   Property Reference for more information. [#7046](https://github.com/kong/kong/pull/7046)
 
 #### Migrations
@@ -246,7 +246,7 @@ grpc-gateway plugin first:
 - With this update, `kong.response.get_XXX()` functions now work in the log phase on external plugins. Before
   `kong.response.get_XXX()` functions required data from the response object, which was not accessible in the
   post-log timer used to call log handlers in external plugins. Now these functions work by accessing the required
-  data from the set saved at the start of the log phase. See [`kong.response`](https://docs.konghq.com/gateway-oss/{{page.kong_version}}/kong.response)
+  data from the set saved at the start of the log phase. See [`kong.response`](https://docs.konghq.com/gateway-oss/2.5.x/pdk/kong.response)
   in the Plugin Development Kit for more information. [#7048](https://github.com/kong/kong/pull/7048)
 - External plugins handle certain error conditions better while the Kong balancer is being refreshed. Before
   when an `instance_id` of an external plugin changed, and the plugin instance attempted to reset and retry,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,12 @@ grpc-gateway plugin first:
   [Loading The Declarative Configuration File](https://docs.konghq.com/2.5.x/db-less-and-declarative-config/#loading-the-declarative-configuration-file)
   section of the DB-less and Declarative Configuration guide for more information.
   [#7379](https://github.com/kong/kong/pull/7379)
+- This release adds a new Performance Testing Framework used to assess the performance of the Kong Gateway (OSS) itself with bundled
+  or custom plugins, as well as plot frame graphs to debug performance bottlenecks. Built into Kong Gateway’s (OSS)
+  existing integration testing approach, the Framework makes developing performance tests easier. See the
+  [Performance Testing Framework](https://docs.konghq.com/gateway-oss/2.5.x/performance-testing-framework) documentation
+  and [implementation examples](https://github.com/Kong/kong/tree/master/spec/04-perf) for more information.
+  [#7030](https://github.com/Kong/kong/pull/7030)
 
 #### PDK
 


### PR DESCRIPTION
### Summary

The Performance Testing Framework was part of the 2.5 release but absent from the 2.5 changelog.
### Full changelog

* Adds Performance Testing Framework to the 2.5 changelog.

