### PR TITLE
fix(schema) iterate _cache[...].constraints with pairs

### DIFF
--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -2002,7 +2002,7 @@ end
 function Schema:get_constraints()
   if self.name == "workspaces" then
     -- merge explicit and implicit constraints for workspaces
-    for _, e in ipairs(_cache["workspaces"].constraints) do
+    for _, e in pairs(_cache["workspaces"].constraints) do
       local found = false
       for _, w in ipairs(_workspaceable) do
         if w == e then


### PR DESCRIPTION
### Summary

I modified the internal constraints object to be a Hash instead of an
Array. `ipairs` ignores non-numeric keys so in order to iterate it
correctly we need to use `pairs`. I was already doing this for
non-workspace entities but missed doing it for the workspace special
case in `.get_constraints()`.

Original PR: https://github.com/Kong/kong/pull/7560
