### PR TITLE
chore(deps) bump lua-resty-openssl from 0.7.3 to 0.7.4

### DIFF
--- a/kong-2.5.0-0.rockspec
+++ b/kong-2.5.0-0.rockspec
@@ -36,7 +36,7 @@ dependencies = {
   "lua-resty-cookie == 0.1.0",
   "lua-resty-mlcache == 2.5.0",
   "lua-messagepack == 0.5.2",
-  "lua-resty-openssl == 0.7.3",
+  "lua-resty-openssl == 0.7.4",
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6",
   "lua-resty-acme == 0.7.1",


### PR DESCRIPTION
### Summary

- **extension:** fallback to ASN1_STRING_print in extension:text where X509V3_EXT_print is not available [f0268f5](https://github.com/fffonion/lua-resty-acme/commit/f0268f55b124eb4ff65b472899e241af850f9d35)