### PR TITLE
chore(deps) bump lua-resty-acme from ~> 0.6 to == 0.7.1

### DIFF
--- a/kong-2.5.0-0.rockspec
+++ b/kong-2.5.0-0.rockspec
@@ -39,7 +39,7 @@ dependencies = {
   "lua-resty-openssl == 0.7.3",
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6",
-  "lua-resty-acme ~> 0.6",
+  "lua-resty-acme == 0.7.1",
   -- external Kong plugins
   "kong-plugin-azure-functions ~> 1.0",
   "kong-plugin-zipkin ~> 1.4",


### PR DESCRIPTION
### Summary

#### bug fixes
- ***:** popup errors from lower functions [a19e9c8](https://github.com/fffonion/lua-resty-acme/commit/a19e9c8af9179a81815c653d176aa0bfc27e532b)
- **autossl:** pass storage config to acme client ([#43](https://github.com/fffonion/lua-resty-acme/issues/43)) [ef1e541](https://github.com/fffonion/lua-resty-acme/commit/ef1e54112d1bdda187812a0e6c96d8b134fd4d04)

#### features
- **autossl:** add challenge_start_delay [df4ba0b](https://github.com/fffonion/lua-resty-acme/commit/df4ba0b71a1f92b87d7f9f203475bc7115c56b9a)
- **autossl:** check if domain is whitelisted before cert renewal ([#35](https://github.com/fffonion/lua-resty-acme/issues/35)) [942c007](https://github.com/fffonion/lua-resty-acme/commit/942c007711ba1a0f04b8f30f81443a46ae0ed412)
- **client:** add challenge_start_callback [1c9b2d5](https://github.com/fffonion/lua-resty-acme/commit/1c9b2d5a03eb644cc0770ec54e4d711bc03cdd42)
- **client:** allow to read "alternate" link and select preferred chain ([#42](https://github.com/fffonion/lua-resty-acme/issues/42)) [ff17a74](https://github.com/fffonion/lua-resty-acme/commit/ff17a741d36f2058a21621c9191fda8513cb2c73)
- **storage/vault:** add support for kubernetes auth ([#37](https://github.com/fffonion/lua-resty-acme/issues/37)) [93c2121](https://github.com/fffonion/lua-resty-acme/commit/93c212132a5d28b93269675c63a88a4e452001dc)