### PR TITLE
fix(migrations) ensure inserts are performed after schema agreement

### DIFF
--- a/kong/db/migrations/core/013_220_to_230.lua
+++ b/kong/db/migrations/core/013_220_to_230.lua
@@ -50,7 +50,7 @@ return {
     ]], CLUSTER_ID),
   },
   cassandra = {
-    up = string.format([[
+    up = [[
       CREATE TABLE IF NOT EXISTS parameters(
         key            text,
         value          text,
@@ -58,13 +58,22 @@ return {
         PRIMARY KEY    (key)
       );
 
-      INSERT INTO parameters (key, value) VALUES('cluster_id', '%s')
-      IF NOT EXISTS;
-
       ALTER TABLE certificates ADD cert_alt TEXT;
       ALTER TABLE certificates ADD key_alt TEXT;
       ALTER TABLE clustering_data_planes ADD version text;
       ALTER TABLE clustering_data_planes ADD sync_status text;
-    ]], CLUSTER_ID),
+    ]],
+    up_f = function(connector)
+      local coordinator = assert(connector:get_stored_connection())
+      local _, err = coordinator:execute(string.format([[
+        INSERT INTO parameters (key, value) VALUES('cluster_id', '%s')
+        IF NOT EXISTS;
+      ]], CLUSTER_ID))
+
+      if err then
+        return nil, err
+      end
+      return true
+    end,
   }
 }


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Using a multi-node Apache Cassandra 4.0.0 cluster fails bootstrap

```
Error: 
/usr/local/share/lua/5.1/kong/cmd/utils/migrations.lua:48: [Cassandra error] cluster_mutex callback threw an error: /usr/local/share/lua/5.1/kong/cmd/utils/migrations.lua:41: [Cassandra error] failed to run migration '013_220_to_230' up: [Write timeout] Operation timed out - received only 1 responses.
stack traceback:
        [C]: in function 'assert'
        /usr/local/share/lua/5.1/kong/cmd/utils/migrations.lua:41: in function </usr/local/share/lua/5.1/kong/cmd/utils/migrations.lua:40>
        [C]: in function 'xpcall'
        /usr/local/share/lua/5.1/kong/db/init.lua:402: in function </usr/local/share/lua/5.1/kong/db/init.lua:352>
        [C]: in function 'pcall'
        /usr/local/share/lua/5.1/kong/concurrency.lua:45: in function 'cluster_mutex'
        /usr/local/share/lua/5.1/kong/cmd/utils/migrations.lua:40: in function 'bootstrap'
        /usr/local/share/lua/5.1/kong/cmd/migrations.lua:162: in function 'cmd_exec'
        /usr/local/share/lua/5.1/kong/cmd/init.lua:88: in function </usr/local/share/lua/5.1/kong/cmd/init.lua:88>
        [C]: in function 'xpcall'
        /usr/local/share/lua/5.1/kong/cmd/init.lua:88: in function </usr/local/share/lua/5.1/kong/cmd/init.lua:45>
        /usr/local/bin/kong:9: in function 'file_gen'
        init_worker_by_lua:48: in function <init_worker_by_lua:46>
        [C]: in function 'xpcall'
        init_worker_by_lua:55: in function <init_worker_by_lua:53>
stack traceback:
        [C]: in function 'error'
        /usr/local/share/lua/5.1/kong/cmd/utils/migrations.lua:48: in function 'bootstrap'
        /usr/local/share/lua/5.1/kong/cmd/migrations.lua:162: in function 'cmd_exec'
        /usr/local/share/lua/5.1/kong/cmd/init.lua:88: in function </usr/local/share/lua/5.1/kong/cmd/init.lua:88>
        [C]: in function 'xpcall'
        /usr/local/share/lua/5.1/kong/cmd/init.lua:88: in function </usr/local/share/lua/5.1/kong/cmd/init.lua:45>
        /usr/local/bin/kong:9: in function 'file_gen'
        init_worker_by_lua:48: in function <init_worker_by_lua:46>
        [C]: in function 'xpcall'
        init_worker_by_lua:55: in function <init_worker_by_lua:53>
```

When bootstrapping a multi-node Apache Cassandra cluster, the CREATE TABLE response from the coordinator node does guarantee that the schema altering statement will result in schema agreement across the cluster. This update moves the insert statement to occur after the CREATE TABLE statement to ensure schema agreement occurs before executing the insert statement.

### Full changelog

* fix(migrations) ensure inserts are performed after schema agreement

### Reproduction steps

```
#!/usr/bin/env bash

# Start with a fresh environment
ccm remove
gojira nuke -f
set -e

# Create and start a C* cluster
CASS_VERSION=${1:-4.0.0}
CASS_NODES=${2:-3}
CASS_NAME="cass-${CASS_VERSION//\./-}-${CASS_NODES}-nodes"
ccm create -v "$CASS_VERSION" -n "$CASS_NODES" -s "$CASS_NAME"

# Export some Kong Gateway settings for ease of use with Gojira environments
export KONG_DATABASE=cassandra
export KONG_TEST_DATABASE=cassandra
if [[ $2 -eq 1 ]]; then
  export KONG_CASSANDRA_REPL_FACTOR=1
  export KONG_CASSANDRA_WRITE_CONSISTENCY=ONE
  export KONG_CASSANDRA_READ_CONSISTENCY=ONE
else
  export KONG_CASSANDRA_REPL_FACTOR=3
  export KONG_CASSANDRA_WRITE_CONSISTENCY=LOCAL_QUORUM
  export KONG_CASSANDRA_READ_CONSISTENCY=LOCAL_QUORUM
fi
export KONG_DB_UPDATE_PROPAGATION=2

# Bring up the Kong Gateway instance
gojira up \
       --network-mode host \
       --alone \
       -e KONG_CASSANDRA_REPL_FACTOR \
       -e KONG_CASSANDRA_WRITE_CONSISTENCY \
       -e KONG_CASSANDRA_READ_CONSISTENCY \
       -e KONG_DB_UPDATE_PROPAGATION

# Prepare the C* datastore
gojira run \
       --network-mode host \
       --alone \
       -e KONG_CASSANDRA_REPL_FACTOR \
       -e KONG_CASSANDRA_WRITE_CONSISTENCY \
       -e KONG_CASSANDRA_READ_CONSISTENCY \
       -e KONG_DB_UPDATE_PROPAGATION \
       kong migrations bootstrap --vv

# Start the Kong Gateway
gojira run \
       --network-mode host \
       --alone \
       -e KONG_CASSANDRA_REPL_FACTOR \
       -e KONG_CASSANDRA_WRITE_CONSISTENCY \
       -e KONG_CASSANDRA_READ_CONSISTENCY \
       -e KONG_DB_UPDATE_PROPAGATION \
       kong start
```