### PR TITLE
Eliminated the steps to reproduce

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,13 +20,6 @@ https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#where-to-seek-for-help
 - Kong version (`$ kong version`)
 - A concise summary of the bug.
 
-### Steps To Reproduce
-
-1.
-2.
-3.
-4.
-
 ### Additional Details & Logs
 - Kong debug-level startup logs (`$ kong start --vv`)
 - Kong error logs (`<KONG_PREFIX>/logs/error.log`)


### PR DESCRIPTION
Eliminated the steps to reproduce heading followed by the numbering as it was empty.

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

SUMMARY_GOES_HERE

### Full changelog

* [Implement ...]
* [Add related tests]
* ...

### Issues resolved

Fix #XXX
