### PR TITLE
fix(api) ensure target GET endpoint returns targets of weight=0

### DIFF
--- a/kong/api/routes/upstreams.lua
+++ b/kong/api/routes/upstreams.lua
@@ -49,7 +49,7 @@ end
 
 
 local function select_target_cb(self, db, upstream, target)
-  if target and target.weight ~= 0 then
+  if target then
     return kong.response.exit(200, target)
   end
 

--- a/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -749,6 +749,7 @@ describe("Admin API #" .. strategy, function()
     describe("GET", function()
       local target
       local upstream
+      local target_0
 
       before_each(function()
         upstream = bp.upstreams:insert {}
@@ -764,6 +765,12 @@ describe("Admin API #" .. strategy, function()
           weight = 10,
           upstream = { id = upstream.id },
         }
+
+        target_0 = bp.targets:insert {
+          target = "api-3:80",
+          weight = 0,
+          upstream = { id = upstream.id },
+        }
       end)
 
       it("returns target entity", function()
@@ -772,6 +779,14 @@ describe("Admin API #" .. strategy, function()
         local json = assert.response(res).has.jsonbody()
         json.tags = nil
         assert.same(target, json)
+      end)
+
+      it("returns target entity when the target weight is 0", function()
+        local res = client:get("/upstreams/" .. upstream.name .. "/targets/" .. target_0.target)
+        assert.response(res).has.status(200)
+        local json = assert.response(res).has.jsonbody()
+        json.tags = nil
+        assert.same(target_0, json)
       end)
     end)
 


### PR DESCRIPTION
### Summary

This removes the logic that returns a 404 for `GET /upstreams/:upstream/targets/:target` when `target.weight` is 0.

### Full changelog

* fix(api) ensure target GET endpoint returns targets of weight=0

### Issues resolved

Fix #7699

---

I haven't taken the time to set up the local dev environment in order to run the test suite, so for the moment I just eyeballed the test case. If something fails I'll do the fix+squash+push dance.