### PR TITLE
Bump lua-resty-ipmatcher to 0.6.1

### DIFF
--- a/kong-2.5.0-0.rockspec
+++ b/kong-2.5.0-0.rockspec
@@ -38,7 +38,7 @@ dependencies = {
   "lua-messagepack == 0.5.2",
   "lua-resty-openssl == 0.7.4",
   "lua-resty-counter == 0.2.1",
-  "lua-resty-ipmatcher == 0.6",
+  "lua-resty-ipmatcher == 0.6.1",
   "lua-resty-acme == 0.7.1",
   -- external Kong plugins
   "kong-plugin-azure-functions ~> 1.0",


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Fixes IPv6 using same prefix for same mask length: https://github.com/api7/lua-resty-ipmatcher/issues/18

### Full changelog

* Change lua-resty-ipmatcher version from 0.6 to 0.6.1
