### PR TITLE
chore(scripts) implement scripts/changelog-helper.lua

### DIFF
--- a/scripts/changelog-helper.lua
+++ b/scripts/changelog-helper.lua
@@ -1,0 +1,420 @@
+#!/usr/bin/env resty
+setmetatable(_G, nil)
+
+local cjson = require "cjson"
+local http = require "resty.http"
+
+local USAGE = [[
+  Usage:
+
+  scripts/changelog-helper.lua <from_ref> <to_ref> <token>
+
+  Example:
+
+  scripts/changelog-helper.lua 2.4.1 master $GITHUB_TOKEN
+
+  For the Github token, visit https://github.com/settings/tokens . It only needs "public_repo" and "read:org" scopes.
+
+  ** NOTE: Github limits the number of commits to compare to 250. If the diff is bigger, you will get an error, and will have to do the changelog manually **
+]]
+
+
+local KNOWN_KONGERS = { -- include kong alumni here
+  hishamhm = true,
+  p0pr0ck5 = true,
+}
+
+local fmt = string.format
+
+local new_github_api = function(github_token)
+  local get
+  get = function(path)
+    local httpc = assert(http.new())
+    httpc:set_timeout(10000)
+
+    -- The prefix "https://api.github.com" is optional. Add it to the path if not present
+    if not path:match("^https:%/%/api%.github%.com%/.*$") then
+      path = fmt("https://api.github.com%s", path)
+    end
+
+    local res = assert(httpc:request_uri(path, {
+      method = "GET",
+      ssl_verify = false,
+      headers = {
+        ["Authorization"] = fmt("token %s", github_token),
+        -- needed to get prs associated to sha (/repos/kong/kong/commits/%s/pulls):
+        ["Accept"] = "application/vnd.github.groot-preview+json",
+      }
+    }))
+    -- recursively follow redirects
+    if res.status == 302 and res.headers.Location then
+      return get(res.headers.Location)
+    end
+
+    local body = res.body
+    if body and body ~= "" then
+      body = cjson.decode(body)
+    end
+
+    return body, res.status, res.headers
+  end
+
+  return { get = get }
+end
+
+
+local function get_comparison_commits(api, from_ref, to_ref)
+  print("\n\nGetting comparison commits")
+  local compare_res = api.get(fmt("/repos/kong/kong/compare/%s...%s", from_ref, to_ref))
+
+  --[[
+  if #compare_res.commits >= 250 then
+    error("250 commits or more found on compare. Github only shows 250 on its compare query, so the comparison likely is missing data. Aborting in order to not produce incomplete results")
+  end
+  ]]
+
+  return compare_res.commits
+end
+
+
+local function get_prs_from_comparison_commits(api, commits)
+  local prs = {}
+  local non_pr_commits = {}
+  local pr_by_commit_sha = {}
+
+  print("\n\nGetting PRs associated to commits in main comparison")
+  local prs_res, pr
+  for i, commit in ipairs(commits) do
+    pr = pr_by_commit_sha[commit.sha]
+    if not pr then
+      prs_res = api.get(fmt("/repos/kong/kong/commits/%s/pulls", commit.sha))
+      -- FIXME find a more appropiate pr from the list in pr_res. Perhaps using to_ref ?
+      if type(prs_res[1]) == "table" then
+        pr = prs_res[1]
+      else
+        non_pr_commits[#non_pr_commits + 1] = commit
+        io.stdout:write(" !", commit.sha)
+        io.stdout:flush()
+      end
+    end
+
+    if pr then
+      if not prs[pr.number] then
+        prs[pr.number] = pr
+        io.stdout:write(" #", pr.number)
+
+        -- optimization: preload all commits for this PR into pr_by_commit_sha to avoid unnecessary calls to /repos/kong/kong/commits/%s/pulls
+        local pr_commits_res = api.get(fmt("/repos/kong/kong/pulls/%d/commits?per_page=100", pr.number))
+        for _, pr_commit in ipairs(pr_commits_res) do
+          pr_by_commit_sha[pr_commit.sha] = pr
+        end
+      end
+      pr.commits = pr.commits or {}
+      pr.commits[#pr.commits + 1] = commit
+      io.stdout:write(".")
+      io.stdout:flush()
+    end
+  end
+
+  return prs, non_pr_commits
+end
+
+
+local function get_non_konger_authors(api, commits)
+  print("\n\nFinding non-konger authors")
+  local author_logins_hash = {}
+  for i, commit in ipairs(commits) do
+    if type(commit.author) == "table" then -- can be null
+      author_logins_hash[commit.author.login] = true
+    end
+  end
+
+  local non_kongers = {}
+  for login in pairs(author_logins_hash) do
+    io.stdout:write(" ", login, ":")
+    if KNOWN_KONGERS[login] then
+      io.stdout:write("🦍")
+    else
+      local _, status = api.get(fmt("/orgs/kong/memberships/%s", login))
+      if status == 404 then
+        non_kongers[login] = true
+        io.stdout:write("✅")
+      else
+        io.stdout:write("🦍")
+      end
+    end
+    io.stdout:flush()
+  end
+
+  return non_kongers
+end
+
+
+local function extract_type_and_scope_and_title(str)
+  local typ, scope, title = string.match(str, "^([^%(]+)%(([^%)]+)%) (.+)$")
+  return typ, scope, title
+end
+
+
+local function get_first_line(str)
+  return str:match("^([^\n]+)")
+end
+
+-- Transforms the list of PRs into a shorter table that is easier to get a report out of
+local function categorize_prs(prs)
+  print("\n\nCategorizing PRs")
+  local categorized_prs = {}
+  local commits, authors_hash
+  for pr_number,pr in pairs(prs) do
+    commits = {}
+    authors_hash = {}
+    for _,c in ipairs(pr.commits) do
+      if c.author and c.author.login then
+        authors_hash[c.author.login] = true
+      end
+      commits[#commits + 1] = c.commit.message
+    end
+
+    local typ, scope, title = extract_type_and_scope_and_title(pr.title)
+    -- when pr title does not follow the "type(scope) title" format, use the last commit on the PR to extract type & scope
+    if not typ then
+      title = pr.title
+      typ, scope = extract_type_and_scope_and_title(commits[#commits])
+      if not typ then
+        typ, scope = "unknown", "unknown"
+      end
+    end
+
+    local authors = {}
+    for a in pairs(authors_hash) do
+      authors[#authors + 1] = a
+    end
+    table.sort(authors)
+
+    categorized_prs[pr_number] = {
+      number = pr_number,
+      title = title,
+      typ = typ,
+      scope = scope,
+      url = pr.html_url,
+      description = pr.body,
+      commits = commits,
+      authors = authors,
+    }
+  end
+
+  return categorized_prs
+end
+
+-- to_sentence({}) = ""
+-- to_sentence({"a"}) = "a"
+-- to_sentence({"a", "b"}) = "a and b"
+-- to_sentence({"a", "b", "c" }) = "a, b and c"
+local function to_sentence(arr)
+  local buffer = {}
+  local len = #arr
+  for i = 1, len do
+    buffer[i * 2 - 1] = arr[i]
+    if i < len - 1 then
+      buffer[i * 2] = ", "
+    elseif i == len - 1 then
+      buffer[i * 2] = " and "
+    end
+  end
+  return table.concat(buffer)
+end
+
+local function render_pr_li_thank_you(authors, non_kongers_hash)
+  local non_kongers_links = {}
+  for _,login in ipairs(authors) do
+    if non_kongers_hash[login] then
+      non_kongers_links[#non_kongers_links + 1] = fmt("[%s](https://github.com/%s)", login, login)
+    end
+  end
+  if #non_kongers_links == 0 then
+    return "."
+  end
+  return fmt("\n  Thanks %s for the patch!", to_sentence(non_kongers_links))
+end
+
+local function render_pr_li_markdown(pr, non_kongers_hash)
+  return fmt([[
+- %s
+  [#%d](%s)%s
+]], pr.title, pr.number, pr.url, render_pr_li_thank_you(pr.authors, non_kongers_hash))
+end
+
+
+local function print_report(categorized_prs, non_pr_commits, non_kongers_hash, to_ref)
+  local pr_numbers = {}
+  for pr_number in pairs(categorized_prs) do
+    pr_numbers[#pr_numbers + 1] = pr_number
+  end
+  table.sort(pr_numbers)
+
+  print("=================================================")
+
+  local pr
+  -- Dependencies
+  local first_dep = true
+  for _,pr_number in ipairs(pr_numbers) do
+    pr = categorized_prs[pr_number]
+
+    if pr.typ == "chore" and (pr.scope == "deps" or pr.scope == "rockspec") then
+      if first_dep then
+        first_dep = false
+        print("\n\n### Dependencies\n")
+      end
+      pr.reported = true
+      print(render_pr_li_markdown(pr, non_kongers_hash))
+    end
+  end
+
+
+  local categories_markdown = [[
+##### Core
+
+##### CLI
+
+##### Configuration
+
+##### Admin API
+
+##### PDK
+
+##### Plugins
+  ]]
+
+  local feats = {}
+  local fixes = {}
+  local unknown = {}
+  for _,pr_number in ipairs(pr_numbers) do
+    pr = categorized_prs[pr_number]
+    if pr.typ == "feat" then
+      feats[#feats + 1] = pr
+    elseif pr.typ == "fix" then
+      fixes[#fixes + 1] = pr
+    elseif not pr.reported then
+      unknown[#unknown + 1] = pr
+    end
+  end
+
+  local sort_by_scope = function(a,b)
+    if a.scope == b.scope then
+      return a.number < b.number
+    end
+    return a.scope < b.scope
+  end
+  table.sort(feats, sort_by_scope)
+  table.sort(fixes, sort_by_scope)
+  table.sort(unknown, sort_by_scope)
+
+  for i,pr in ipairs(feats) do
+    if i == 1 then
+      print([[
+
+
+### Additions
+
+Note: Categorize the additions below into one of these categories (add categories if needed).
+      Remove this note
+
+]], categories_markdown)
+    end
+    print(render_pr_li_markdown(pr, non_kongers_hash))
+  end
+
+  for i,pr in ipairs(fixes) do
+    if i == 1 then
+      print([[
+
+
+### Fixes
+
+Note: Categorize the fixes below into one of these categories (add categories if needed).
+      Remove this note
+
+]], categories_markdown)
+    end
+    print(render_pr_li_markdown(pr, non_kongers_hash))
+  end
+
+
+  for i,pr in ipairs(unknown) do
+    if i == 1 then
+      print([[
+
+
+### Unknown PRs
+
+The following PRs could not be identified as either fixes or feats. Please move them to their appropiate place or discard them.
+Remove this whole section afterwards.
+
+]])
+    end
+
+    print(fmt([[
+- %s
+  [#%d](%s)%s.
+  Categorization: %s(%s)
+  Commits:]],
+  pr.title, pr.number, pr.url, render_pr_li_thank_you(pr.authors, non_kongers_hash), pr.typ, pr.scope))
+
+    for j, commit in ipairs(pr.commits) do
+      print(fmt([[
+  - %s]], get_first_line(commit)))
+    end
+  end
+
+
+  for i,commit in ipairs(non_pr_commits) do
+    if i == 1 then
+      print(fmt([[
+
+### Non-PR commits
+
+I could not find the PR for the following commits. They are likely direct pushes against %s.
+
+]], to_ref))
+    end
+
+    local msg = commit.commit.message
+    local typ, scope = extract_type_and_scope_and_title(msg)
+    if not typ then
+      typ, scope = "unknown", "unknown"
+    end
+    local author = commit.author and (commit.author.login or commit.author.name) or "unknown"
+
+    print(fmt([[
+- %s
+  [%s](%s)
+  Categorization: %s(%s)
+  Author: %s
+]], get_first_line(msg), commit.sha, commit.html_url, typ, scope, author))
+  end
+
+end
+
+
+
+-----------------------
+
+local from_ref, to_ref, github_token = arg[1], arg[2], arg[3]
+
+if not from_ref or not to_ref or not github_token then
+  print(USAGE)
+  os.exit(0)
+end
+
+local api = new_github_api(github_token)
+
+local commits = get_comparison_commits(api, from_ref, to_ref)
+
+local prs, non_pr_commits = get_prs_from_comparison_commits(api, commits)
+
+local categorized_prs = categorize_prs(prs)
+
+local non_kongers_hash = get_non_konger_authors(api, commits)
+
+print_report(categorized_prs, non_pr_commits, non_kongers_hash, to_ref)
+

--- a/scripts/changelog-helper.lua
+++ b/scripts/changelog-helper.lua
@@ -43,7 +43,7 @@ end
 local function datetime_to_epoch(d)
   local yyyy,MM,dd,hh,mm,ss = string.match(d, "^(%d%d%d%d)-(%d%d)-(%d%d)T(%d%d):(%d%d):(%d%d)Z$")
   if not yyyy then
-    error("Could not parse date: " .. tostring(date))
+    error("Could not parse date: " .. tostring(d))
   end
   yyyy,MM,dd,hh,mm,ss = tonumber(yyyy), tonumber(MM), tonumber(dd), tonumber(hh), tonumber(mm), tonumber(ss)
   return os.time({year = yyyy, month = MM, day = dd, hour = hh, min = mm, sec = ss})
@@ -479,4 +479,3 @@ local categorized_prs = categorize_prs(prs)
 local non_kongers_hash = get_non_konger_authors(api, commits)
 
 print_report(categorized_prs, non_pr_commits, non_kongers_hash, to_ref)
-

--- a/scripts/changelog-helper.lua
+++ b/scripts/changelog-helper.lua
@@ -416,7 +416,7 @@ Remove this whole section afterwards.
 
     print(fmt([[
 - %s
-  [#%d](%s)%s.
+  [#%d](%s)%s
   Categorization: %s(%s)
   Commits:]],
   pr.title, pr.number, pr.url, render_pr_li_thank_you(pr.authors, non_kongers_hash), pr.typ, pr.scope))

--- a/scripts/changelog-helper.lua
+++ b/scripts/changelog-helper.lua
@@ -146,11 +146,11 @@ local function get_prs_from_comparison_commits(api, commits)
 
   print("\n\nGetting PRs associated to commits in main comparison")
   local prs_res, pr
-  for i, commit in ipairs(commits) do
+  for _, commit in ipairs(commits) do
     pr = pr_by_commit_sha[commit.sha]
     if not pr then
       prs_res = api.get(fmt("/repos/kong/kong/commits/%s/pulls", commit.sha))
-      -- FIXME find a more appropiate pr from the list in pr_res. Perhaps using to_ref ?
+      -- FIXME find a more appropriate pr from the list in pr_res. Perhaps using to_ref ?
       if type(prs_res[1]) == "table" then
         pr = prs_res[1]
       else
@@ -185,7 +185,7 @@ end
 local function get_non_konger_authors(api, commits)
   print("\n\nFinding non-konger authors")
   local author_logins_hash = {}
-  for i, commit in ipairs(commits) do
+  for _, commit in ipairs(commits) do
     if type(commit.author) == "table" then -- can be null
       author_logins_hash[commit.author.login] = true
     end
@@ -316,11 +316,10 @@ local function print_report(categorized_prs, non_pr_commits, non_kongers_hash, t
 
   print("=================================================")
 
-  local pr
   -- Dependencies
   local first_dep = true
-  for _,pr_number in ipairs(pr_numbers) do
-    pr = categorized_prs[pr_number]
+  for _, pr_number in ipairs(pr_numbers) do
+    local pr = categorized_prs[pr_number]
 
     if pr.typ == "chore" and (pr.scope == "deps" or pr.scope == "rockspec") then
       if first_dep then
@@ -350,8 +349,8 @@ local function print_report(categorized_prs, non_pr_commits, non_kongers_hash, t
   local feats = {}
   local fixes = {}
   local unknown = {}
-  for _,pr_number in ipairs(pr_numbers) do
-    pr = categorized_prs[pr_number]
+  for _, pr_number in ipairs(pr_numbers) do
+    local pr = categorized_prs[pr_number]
     if pr.typ == "feat" then
       feats[#feats + 1] = pr
     elseif pr.typ == "fix" then
@@ -371,7 +370,7 @@ local function print_report(categorized_prs, non_pr_commits, non_kongers_hash, t
   table.sort(fixes, sort_by_scope)
   table.sort(unknown, sort_by_scope)
 
-  for i,pr in ipairs(feats) do
+  for i, pr in ipairs(feats) do
     if i == 1 then
       print([[
 
@@ -386,7 +385,7 @@ Note: Categorize the additions below into one of these categories (add categorie
     print(render_pr_li_markdown(pr, non_kongers_hash))
   end
 
-  for i,pr in ipairs(fixes) do
+  for i, pr in ipairs(fixes) do
     if i == 1 then
       print([[
 
@@ -402,7 +401,7 @@ Note: Categorize the fixes below into one of these categories (add categories if
   end
 
 
-  for i,pr in ipairs(unknown) do
+  for i, pr in ipairs(unknown) do
     if i == 1 then
       print([[
 
@@ -422,7 +421,7 @@ Remove this whole section afterwards.
   Commits:]],
   pr.title, pr.number, pr.url, render_pr_li_thank_you(pr.authors, non_kongers_hash), pr.typ, pr.scope))
 
-    for j, commit in ipairs(pr.commits) do
+    for _, commit in ipairs(pr.commits) do
       print(fmt([[
   - %s]], get_first_line(commit)))
     end


### PR DESCRIPTION
The following command:

```
./scripts/changelog-helper.lua 2.5.0 master $GITHUB_TOKEN
```

Currently (Aug 31st) generates the following output:
```
Getting comparison commits


Getting PRs associated to commits in main comparison
 #7785. #7765.. #7777. #7767. #7774. #7723. #7632. #7748. #7756. #7725. #7759. #7750. #7757. #7758. #7695. #7742. #6744. #7738. #7736..... #7727. #7731. #7589. #7719..... #7724. #7704. #7703. #7606.. #7380. #7666. !b0fe5611adc1cb34822dae460ed68be5582c9a33... #7454. #7516. #7598. #7661. #7657. #7659. #7658.. #7547...... #7656. #7607. #7568. #7604. #7642.... #7637.. #7545.. #7464. #7617. #7538. #7578.. #7549. #7586. #7560.. !4088d4b4fab04de7eb0891ed84d1d424ac058431 #7605. #7558..... #7502. #7569. #6872...

Categorizing PRs


Finding non-konger authors
 jiachinzhao:✅ liov:✅ Tieske:🦍 jschmid1:🦍 samnela:✅ tyler-ball:🦍 lena-larionova:🦍 PaulFischer-Kong:🦍 gszr:🦍 javierguerragiraldez:🦍 locao:🦍 guanlan:🦍 fffonion:🦍 flrgh:✅ EpicEric:✅ bungle:🦍 mikefero:🦍 hbagdi:🦍 dndx:🦍 subnetmarco:🦍

=================================================


### Dependencies

- fix/luarocks unit test
  [#7606](https://github.com/Kong/kong/pull/7606).

- bump lua-protobuf from 0.3.2 to 0.3.3
  [#7656](https://github.com/Kong/kong/pull/7656).

- bump lua-resty-openssl from 0.7.3 to 0.7.4
  [#7657](https://github.com/Kong/kong/pull/7657).

- bump lua-resty-acme from ~> 0.6 to == 0.7.1
  [#7658](https://github.com/Kong/kong/pull/7658).

- bump grpcurl from 1.8.1 to 1.8.2
  [#7659](https://github.com/Kong/kong/pull/7659).

- bump openresty from 1.19.3.2 to 1.19.9.1
  [#7727](https://github.com/Kong/kong/pull/7727).

- bump Penlight to 1.11.0
  [#7736](https://github.com/Kong/kong/pull/7736).

- bump luasec from 1.0.1 to 1.0.2
  [#7750](https://github.com/Kong/kong/pull/7750).

- bump openssl from 1.1.1k to 1.1.1l
  [#7767](https://github.com/Kong/kong/pull/7767).



### Additions

Note: Categorize the additions below into one of these categories (add categories if needed).
      Remove this note

##### Core

##### CLI

##### Configuration

##### Admin API

##### PDK

##### Plugins

- add support for detecting AWS region from environment variable
  [#7765](https://github.com/Kong/kong/pull/7765).

- encode Timestamp
  [#7538](https://github.com/Kong/kong/pull/7538).

- bring back healthcheck_subscribers
  [#7558](https://github.com/Kong/kong/pull/7558).

- allow os.getenv in the template renderer
  [#6872](https://github.com/Kong/kong/pull/6872).

- add a request-echo option
  [#6744](https://github.com/Kong/kong/pull/6744).



### Fixes

Note: Categorize the fixes below into one of these categories (add categories if needed).
      Remove this note

##### Core

##### CLI

##### Configuration

##### Admin API

##### PDK

##### Plugins

- GET /upstreams/:upstreams/targets/:target returns 404 when target weight is 0
  [#7758](https://github.com/Kong/kong/pull/7758).

- set :authority on balancer retries
  [#7725](https://github.com/Kong/kong/pull/7725).

- stop health check when recreating balancer
  [#7549](https://github.com/Kong/kong/pull/7549).

- ensure data plane config thread is terminated gracefully
  [#7568](https://github.com/Kong/kong/pull/7568)
  Thanks [flrgh](https://github.com/flrgh) for the patch!

- remove extra schema field `use_env`
  [#7632](https://github.com/Kong/kong/pull/7632).

- correctly print foreign references provided inside the
  [#7756](https://github.com/Kong/kong/pull/7756).

- yaml anchors were not properly processed
  [#7748](https://github.com/Kong/kong/pull/7748).

- add missing lua files from new balancer
  [#7605](https://github.com/Kong/kong/pull/7605).

- malformed accept header can cause unexpected HTTP 500
  [#7757](https://github.com/Kong/kong/pull/7757).

- update module's `local kong` var
  [#7589](https://github.com/Kong/kong/pull/7589).

- keep proxy-authentication request header and proxy-authenticate response header
  [#7724](https://github.com/Kong/kong/pull/7724).

- fix sort routes with both regex and prefix routes
  [#7695](https://github.com/Kong/kong/pull/7695)
  Thanks [jiachinzhao](https://github.com/jiachinzhao) for the patch!

- Decrement workspace_entity_counters on cascade deletes
  [#7560](https://github.com/Kong/kong/pull/7560).

- iterate _cache[...].constraints with pairs
  [#7617](https://github.com/Kong/kong/pull/7617).

- force yield (via `sleep(0)`) after semaphore:post()
  [#7704](https://github.com/Kong/kong/pull/7704).

- fix(workspace): do not allow reserved names
  [#7380](https://github.com/Kong/kong/pull/7380).



### Unknown PRs

The following PRs could not be identified as either fixes or feats. Please move them to their appropiate place or discard them.
Remove this whole section afterwards.


- import aws lambda
  [#7464](https://github.com/Kong/kong/pull/7464)..
  Categorization: chore(*)
  Commits:
  - Merge pull request #7464 from Kong/feat/import-aws-lambda
  - Merge branch 'master' into feat/import-aws-lambda
- added template chooser
  [#7502](https://github.com/Kong/kong/pull/7502)..
  Categorization: chore(*)
  Commits:
  - chore(*) added template chooser (#7502)
- import acme
  [#7545](https://github.com/Kong/kong/pull/7545)..
  Categorization: chore(*)
  Commits:
  - Merge pull request #7545 from Kong/chore/import-acme
  - Merge branch 'master' into chore/import-acme
  - Merge branch 'master' into chore/import-acme
- new tests cases and fixes
  [#7547](https://github.com/Kong/kong/pull/7547)..
  Categorization: perf(*)
  Commits:
  - feat(perf) add balancer, plugin iterator tests
- import prometheus
  [#7666](https://github.com/Kong/kong/pull/7666)..
  Categorization: chore(*)
  Commits:
  - Merge pull request #7666 from Kong/chore/import-prometheus
- import session
  [#7731](https://github.com/Kong/kong/pull/7731)..
  Categorization: chore(*)
  Commits:
  - Merge pull request #7731 from Kong/chore/import-session
- import proxy cache
  [#7738](https://github.com/Kong/kong/pull/7738)..
  Categorization: chore(*)
  Commits:
  - Merge pull request #7738 from Kong/chore/import-proxy-cache
  - tests(proxy-cache) adapt proxy-cache tests
  - chore(proxy-cache) add proxy-cache files to rockspec
  - Merge branch 'adapt-proxy-cache-master' into chore/import-proxy-cache
  - chore(proxy-cache) adapt file org to merge into kong
- Update links in autodocs
  [#7759](https://github.com/Kong/kong/pull/7759)..
  Categorization: docs(autodoc)
  Commits:
  - docs(*) update links in autodocs (#7759)
- style: use string.rep instead of a hard-coded string
  [#7661](https://github.com/Kong/kong/pull/7661)..
  Categorization: style(clustering)
  Commits:
  - style(clustering) use string.rep instead of a hard-coded string (#7661)
- bump version from 3.0.1 to 3.1.0
  [#7598](https://github.com/Kong/kong/pull/7598)..
  Categorization: chore(datadog)
  Commits:
  - chore(datadog) bump version from 3.0.1 to 3.1.0 (#7598)
- Tests/fix adminclient timeout
  [#7578](https://github.com/Kong/kong/pull/7578)..
  Categorization: tests(fixtures)
  Commits:
  - tests(fixtures) use dummy timer to ensure Nginx event loop continues after
- deprecate go-pluginserver
  [#7604](https://github.com/Kong/kong/pull/7604)..
  Categorization: tests(go)
  Commits:
  - tests(go) deprecate go-pluginserver (#7604)
- new grpc target
  [#7607](https://github.com/Kong/kong/pull/7607)..
  Categorization: tests(grpc-gateway)
  Commits:
  - tests(grpc-gateway) new grpc target and add Timestamp transformation (#7607)
- remove duplicate CP plugin version output in log
  [#7516](https://github.com/Kong/kong/pull/7516)..
  Categorization: chore(log)
  Commits:
  - chore(log) remove duplicate CP plugin version output in log (#7516)
- import missing commits
  [#7642](https://github.com/Kong/kong/pull/7642)..
  Categorization: chore(plugins/acme)
  Commits:
  - fix(acme) also check if host is in domain list in sanity test
- import new aws lambda features
  [#7637](https://github.com/Kong/kong/pull/7637)..
  Categorization: chore(plugins/aws-lambda)
  Commits:
  - tests(aws-lambda) Update spec/plugins/aws-lambda/99-access_spec.lua
- attempt to fix flakiness
  [#7719](https://github.com/Kong/kong/pull/7719)..
  Categorization: tests(prometheus)
  Commits:
  - tests(prometheus) attempt to fix flakiness
- fix typo（pluginserger->pluginserver）
  [#7785](https://github.com/Kong/kong/pull/7785)
  Thanks [liov](https://github.com/liov) for the patch!.
  Categorization: style(runloop)
  Commits:
  - style(runloop) fix a typo in plugin server process module (#7785)
- fix final release script merge order
  [#7586](https://github.com/Kong/kong/pull/7586)..
  Categorization: chore(scripts)
  Commits:
  - chore(scripts) fix final release script merge order
- helper db-export should honor test config
  [#7569](https://github.com/Kong/kong/pull/7569)..
  Categorization: chore(test)
  Commits:
  - chore(test) helper db-export should honor test config (#7569)
- rename and document test option
  [#7723](https://github.com/Kong/kong/pull/7723)..
  Categorization: chore(test)
  Commits:
  - chore(test) rename and document test option
- perf(postgres): meta_schema is a read-only operation
  [#7454](https://github.com/Kong/kong/pull/7454)..
  Categorization: unknown(unknown)
  Commits:
  - perf(postgres): meta_schema is a read-only operation (#7454)
- Bump lua-resty-ipmatcher to 0.6.1
  [#7703](https://github.com/Kong/kong/pull/7703)
  Thanks [EpicEric](https://github.com/EpicEric) for the patch!.
  Categorization: unknown(unknown)
  Commits:
  - Bump lua-resty-ipmatcher to 0.6.1
- chore(process): issue template forms
  [#7774](https://github.com/Kong/kong/pull/7774)..
  Categorization: unknown(unknown)
  Commits:
  - chore(process): issue template forms
- chore(process): move feature request to discussion
  [#7777](https://github.com/Kong/kong/pull/7777)..
  Categorization: unknown(unknown)
  Commits:
  - chore(process): move feature request to discussion
- escape only when needed
  [#7742](https://github.com/Kong/kong/pull/7742)..
  Categorization: perf(uri)
  Commits:
  - perf(uri) escape only when needed (#7742)

### Non-PR commits

I could not find the PR for the following commits. They are likely direct pushes against master.


- docs(readme): adding link to the ingress controller
  [b0fe5611adc1cb34822dae460ed68be5582c9a33](https://github.com/Kong/kong/commit/b0fe5611adc1cb34822dae460ed68be5582c9a33)
  Categorization: unknown(unknown)
  Author: subnetmarco

- docs(SECURITY.md) Adding a simple security policy
  [4088d4b4fab04de7eb0891ed84d1d424ac058431](https://github.com/Kong/kong/commit/4088d4b4fab04de7eb0891ed84d1d424ac058431)
  Categorization: docs(SECURITY.md)
  Author: guanlan
```