### PR TITLE
chore(test) rename and document test option

### DIFF
--- a/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -30,9 +30,10 @@ describe("Admin API #" .. strategy, function()
 
   lazy_setup(function()
     local fixtures = {
-      dns_mock = helpers.dns_mock.new()
+      dns_mock = helpers.dns_mock.new({
+        mocks_only = true,      -- don't fallback to "real" DNS
+      })
     }
-    fixtures.dns_mock.should_fail = true  -- don't fallback to "real" DNS
     fixtures.dns_mock:A {
       name = "custom_localhost",
       address = "127.0.0.1",

--- a/spec/fixtures/mocks/lua-resty-dns/resty/dns/resolver.lua
+++ b/spec/fixtures/mocks/lua-resty-dns/resty/dns/resolver.lua
@@ -50,7 +50,7 @@ do
   local mock_file
   get_mock_records = function()
     if mock_file then
-      return mock_file.records, mock_file.should_fail
+      return mock_file.records, mock_file.mocks_only
     end
 
     local is_file = require("pl.path").isfile
@@ -76,7 +76,7 @@ do
     f:close()
 
     mock_file = assert(cjson.decode(json_file))
-    return mock_file.records, mock_file.should_fail
+    return mock_file.records, mock_file.mocks_only
   end
 end
 
@@ -84,7 +84,7 @@ end
 -- patch the actual query method
 local old_query = resolver.query
 resolver.query = function(self, name, options, tries)
-  local mock_records, should_fail = get_mock_records()
+  local mock_records, mocks_only = get_mock_records()
   local qtype = (options or {}).qtype or resolver.TYPE_A
 
   local answer = (mock_records[qtype] or {})[name]
@@ -94,7 +94,7 @@ resolver.query = function(self, name, options, tries)
     return answer, nil, tries
   end
 
-  if not should_fail then
+  if not mocks_only then
     -- no mock, so invoke original resolver
     local a, b, c = old_query(self, name, options, tries)
     return a, b, c

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -2058,7 +2058,7 @@ end
 -- @usage
 -- -- Create a new DNS mock and add some DNS records
 -- local fixtures = {
---   dns_mock = helpers.dns_mock.new()
+--   dns_mock = helpers.dns_mock.new { mocks_only = true }
 -- }
 --
 -- fixtures.dns_mock:SRV {
@@ -2088,7 +2088,7 @@ do
   dns_mock.__tostring = function(self)
     -- fill array to prevent json encoding errors
     local out = {
-      should_fail = self.should_fail,
+      mocks_only = self.mocks_only,
       records = {}
     }
     for i = 1, 33 do
@@ -2103,10 +2103,17 @@ do
 
 
   --- Creates a new DNS mock.
+  -- The options table supports the following fields:
+  --
+  -- - `mocks_only`: boolean, if set to `true` then only mock records will be
+  --   returned. If `falsy` it will fall through to an actual DNS lookup.
   -- @function dns_mock.new
+  -- @param options table with mock options
   -- @return dns_mock object
-  function dns_mock.new()
-    return setmetatable({}, dns_mock)
+  -- @usage
+  -- local mock = helpers.dns_mock.new { mocks_only = true }
+  function dns_mock.new(options)
+    return setmetatable(options or {}, dns_mock)
   end
 
 


### PR DESCRIPTION
renames `should_fail` to `mocks_only` and documents it. Also the
way to use the option is now more Luaish by passing an options
table to the constructor.
