### PR TITLE
fix(balancer) set :authority on balancer retries

### DIFF
--- a/kong/pdk/service/request.lua
+++ b/kong/pdk/service/request.lua
@@ -29,6 +29,7 @@ local PHASES = phase_checker.phases
 
 local access_and_rewrite = phase_checker.new(PHASES.rewrite, PHASES.access)
 local preread_and_balancer = phase_checker.new(PHASES.preread, PHASES.balancer)
+local access_rewrite_balancer = phase_checker.new(PHASES.rewrite, PHASES.access, PHASES.balancer)
 
 
 ---
@@ -280,14 +281,14 @@ local function new(self)
   -- will also set the SNI of the request to the Service.
   --
   -- @function kong.service.request.set_header
-  -- @phases `rewrite`, `access`
+  -- @phases `rewrite`, `access`, `balancer`
   -- @tparam string header The header name. Example: "X-Foo"
   -- @tparam string|boolean|number value The header value. Example: "hello world"
   -- @return Nothing; throws an error on invalid inputs.
   -- @usage
   -- kong.service.request.set_header("X-Foo", "value")
   request.set_header = function(header, value)
-    check_phase(access_and_rewrite)
+    check_phase(access_rewrite_balancer)
 
     validate_header(header, value)
 

--- a/kong/runloop/balancer/init.lua
+++ b/kong/runloop/balancer/init.lua
@@ -347,6 +347,15 @@ local function set_host_header(balancer_data)
   end
 
   if upstream_host ~= orig_upstream_host then
+    -- the nginx grpc module does not offer a way to override the
+    -- :authority pseudo-header; use our internal API to do so
+    if upstream_scheme == "grpc" or upstream_scheme == "grpcs" then
+      local ok, err = kong.service.request.set_header(":authority", upstream_host)
+      if not ok then
+        log(ERR, "failed to set :authority header: ", err)
+      end
+    end
+
     var.upstream_host = upstream_host
 
     if phase == "balancer" then


### PR DESCRIPTION
### Summary

Ensure the `:authority` pseudo-header is set on balancer retry upstream requests.

Depends on:
- https://github.com/Kong/kong-build-tools/pull/403
- https://github.com/Kong/lua-kong-nginx-module/pull/18