### PR TITLE
chore(deps) bump Penlight to 1.11.0

### DIFF
--- a/kong-2.5.0-0.rockspec
+++ b/kong-2.5.0-0.rockspec
@@ -15,7 +15,7 @@ dependencies = {
   "inspect == 3.1.1",
   "luasec == 1.0.1",
   "luasocket == 3.0-rc1",
-  "penlight == 1.10.0",
+  "penlight == 1.11.0",
   "lua-resty-http == 0.15",
   "lua-resty-jit-uuid == 0.0.7",
   "lua-ffi-zlib == 0.5",

--- a/spec/02-integration/05-proxy/24-buffered_spec.lua
+++ b/spec/02-integration/05-proxy/24-buffered_spec.lua
@@ -147,11 +147,11 @@ for _, strategy in helpers.each_strategy() do
 
       it("header can be set from upstream response body on header_filter phase", function()
         local res = proxy_client:get("/1/status/231")
-        local body = assert.res_status(231, res)
+        local body = assert.res_status(231, res) .. "\n"
         assert.equal(md5(body), res.headers["MD5"])
 
         local res = proxy_ssl_client:get("/1/status/232")
-        local body = assert.res_status(232, res)
+        local body = assert.res_status(232, res) .. "\n"
         assert.equal(md5(body), res.headers["MD5"])
       end)
 
@@ -183,11 +183,11 @@ for _, strategy in helpers.each_strategy() do
 
       it("header can be set from upstream response body on response phase", function()
         local res = proxy_client:get("/3/status/235")
-        local body = assert.res_status(235, res)
+        local body = assert.res_status(235, res) .. "\n"
         assert.equal(md5(body), res.headers["MD5"])
 
         local res = proxy_ssl_client:get("/3/status/236")
-        local body = assert.res_status(236, res)
+        local body = assert.res_status(236, res) .. "\n"
         assert.equal(md5(body), res.headers["MD5"])
       end)
 


### PR DESCRIPTION
Changes:
- fix: `stringx.strip` behaved badly with string lengths > 200
- fix: `path.currentdir` now takes no arguments and calls `lfs.currentdir` without argument
- feat: `utils.raise_deprecation` now has an option to NOT include a stack-trace

See changelog: https://github.com/lunarmodules/Penlight/blob/master/CHANGELOG.md#1110-2021-08-18
