### PR TITLE
perf(uri) escape only when needed

### DIFF
--- a/kong/tools/uri.lua
+++ b/kong/tools/uri.lua
@@ -9,6 +9,7 @@ local string_byte = string.byte
 local string_format = string.format
 local tonumber = tonumber
 local table_concat = table.concat
+local ngx_re_find = ngx.re.find
 local ngx_re_gsub = ngx.re.gsub
 
 
@@ -33,6 +34,9 @@ local RESERVED_CHARACTERS = {
   [0x5B] = true, -- [
   [0x5D] = true, -- ]
 }
+
+local ESCAPE_PATTERN = "[^!#$&'()*+,/:;=?@[\\]A-Z\\d-_.~%]"
+
 local TMP_OUTPUT = require("table.new")(16, 0)
 local DOT = string_byte(".")
 local SLASH = string_byte("/")
@@ -145,7 +149,11 @@ end
 
 
 function _M.escape(uri)
-  return ngx_re_gsub(uri, "[^!#$&'()*+,/:;=?@[\\]A-Z\\d-_.~%]", escape, "joi")
+  if ngx_re_find(uri, ESCAPE_PATTERN, "joi") then
+    return ngx_re_gsub(uri, ESCAPE_PATTERN, escape, "joi")
+  end
+
+  return uri
 end
 
 


### PR DESCRIPTION
### Summary

Runs ngx.re.gsub only when ngx.re.find finds that there is something to escape.
In many cases there will not be anything to escape.