### PR TITLE
perf(*) reduce unnecessary read on ngx.var and avoid caching outside

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -926,7 +926,7 @@ function Kong.balancer()
       return ngx.exit(errcode)
     end
 
-    ok, err = balancer.set_host_header(balancer_data)
+    ok, err = balancer.set_host_header(balancer_data, var.upstream_scheme, var.upstream_host)
     if not ok then
       ngx_log(ngx_ERR, "failed to set balancer Host header: ", err)
 

--- a/kong/router.lua
+++ b/kong/router.lua
@@ -1822,11 +1822,11 @@ function _M.new(routes)
   self._set_ngx = _set_ngx
 
   if subsystem == "http" then
-    function self.exec()
+    function self.exec(ctx)
       local req_method = get_method()
-      local req_uri = var.request_uri
+      local req_uri = ctx and ctx.request_uri or var.request_uri
       local req_host = var.http_host or ""
-      local req_scheme = var.scheme
+      local req_scheme = ctx and ctx.scheme or var.scheme
       local sni = var.ssl_server_name
 
       local headers

--- a/kong/runloop/balancer/init.lua
+++ b/kong/runloop/balancer/init.lua
@@ -325,38 +325,35 @@ local function post_health(upstream, hostname, ip, port, is_healthy)
 end
 
 
-local function set_host_header(balancer_data)
+local function set_host_header(balancer_data, upstream_scheme, upstream_host)
   if balancer_data.preserve_host then
     return true
   end
 
   -- set the upstream host header if not `preserve_host`
-  local upstream_host = var.upstream_host
-  local orig_upstream_host = upstream_host
+  local new_upstream_host = balancer_data.hostname
   local phase = get_phase()
 
-  upstream_host = balancer_data.hostname
-
-  local upstream_scheme = var.upstream_scheme
-  if  upstream_scheme == "http"  and balancer_data.port ~= 80 or
-      upstream_scheme == "https" and balancer_data.port ~= 443 or
-      upstream_scheme == "grpc"  and balancer_data.port ~= 80 or
-      upstream_scheme == "grpcs" and balancer_data.port ~= 443
+  local port = balancer_data.port
+  if  upstream_scheme == "http"  and port ~= 80 or
+      upstream_scheme == "https" and port ~= 443 or
+      upstream_scheme == "grpc"  and port ~= 80 or
+      upstream_scheme == "grpcs" and port ~= 443
   then
-    upstream_host = upstream_host .. ":" .. balancer_data.port
+    new_upstream_host = new_upstream_host .. ":" .. port
   end
 
-  if upstream_host ~= orig_upstream_host then
+  if new_upstream_host ~= upstream_host then
     -- the nginx grpc module does not offer a way to override the
     -- :authority pseudo-header; use our internal API to do so
     if upstream_scheme == "grpc" or upstream_scheme == "grpcs" then
-      local ok, err = kong.service.request.set_header(":authority", upstream_host)
+      local ok, err = kong.service.request.set_header(":authority", new_upstream_host)
       if not ok then
         log(ERR, "failed to set :authority header: ", err)
       end
     end
 
-    var.upstream_host = upstream_host
+    var.upstream_host = new_upstream_host
 
     if phase == "balancer" then
       return recreate_request()

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1126,9 +1126,12 @@ return {
         return
       end
 
+      ctx.scheme = var.scheme
+      ctx.request_uri = var.request_uri
+
       -- routing request
       local router = get_updated_router()
-      local match_t = router.exec()
+      local match_t = router.exec(ctx)
       if not match_t then
         return kong.response.exit(404, { message = "no Route matched with those values" })
       end
@@ -1136,11 +1139,9 @@ return {
       ctx.workspace = match_t.route and match_t.route.ws_id
 
       local http_version   = ngx.req.http_version()
-      local scheme         = var.scheme
       local host           = var.host
       local port           = tonumber(ctx.host_port, 10)
                           or tonumber(var.server_port, 10)
-      local content_type   = var.content_type
 
       local route          = match_t.route
       local service        = match_t.service
@@ -1164,20 +1165,20 @@ return {
 
       local trusted_ip = kong.ip.is_trusted(realip_remote_addr)
       if trusted_ip then
-        forwarded_proto  = var.http_x_forwarded_proto  or scheme
+        forwarded_proto  = var.http_x_forwarded_proto  or ctx.scheme
         forwarded_host   = var.http_x_forwarded_host   or host
         forwarded_port   = var.http_x_forwarded_port   or port
         forwarded_path   = var.http_x_forwarded_path
         forwarded_prefix = var.http_x_forwarded_prefix
 
       else
-        forwarded_proto  = scheme
+        forwarded_proto  = ctx.scheme
         forwarded_host   = host
         forwarded_port   = port
       end
 
       if not forwarded_path then
-        forwarded_path = var.request_uri
+        forwarded_path = ctx.request_uri
         local p = find(forwarded_path, "?", 2, true)
         if p then
           forwarded_path = sub(forwarded_path, 1, p - 1)
@@ -1206,37 +1207,38 @@ return {
         or redirect_status_code == 307
         or redirect_status_code == 308
         then
-          header["Location"] = "https://" .. forwarded_host .. var.request_uri
+          header["Location"] = "https://" .. forwarded_host .. ctx.request_uri
           return kong.response.exit(redirect_status_code)
         end
       end
 
-      -- mismatch: non-http/2 request matched grpc route
-      if (protocols and (protocols.grpc or protocols.grpcs) and http_version ~= 2 and
-        (content_type and sub(content_type, 1, #"application/grpc") == "application/grpc"))
-      then
-        return kong.response.exit(426, { message = "Please use HTTP2 protocol" }, {
-          ["connection"] = "Upgrade",
-          ["upgrade"]    = "HTTP/2",
-        })
-      end
+      if protocols.grpc or protocols.grpcs then
+        -- perf: branch usually not taken, don't cache var outside
+        local content_type = var.content_type
 
-      -- mismatch: non-grpc request matched grpc route
-      if (protocols and (protocols.grpc or protocols.grpcs) and
-        (not content_type or sub(content_type, 1, #"application/grpc") ~= "application/grpc"))
-      then
-        return kong.response.exit(415, { message = "Non-gRPC request matched gRPC route" })
-      end
+        if content_type and sub(content_type, 1, #"application/grpc") == "application/grpc" then
+          http_version = ngx.req.http_version()
+          if http_version ~= 2 then
+            -- mismatch: non-http/2 request matched grpc route
+            return kong.response.exit(426, { message = "Please use HTTP2 protocol" }, {
+              ["connection"] = "Upgrade",
+              ["upgrade"]    = "HTTP/2",
+            })
+          end
 
-      -- mismatch: grpc request matched grpcs route
-      if (protocols and protocols.grpcs and not protocols.grpc and
-        forwarded_proto ~= "https")
-      then
-        return kong.response.exit(200, nil, {
-          ["content-type"] = "application/grpc",
-          ["grpc-status"] = 1,
-          ["grpc-message"] = "gRPC request matched gRPCs route",
-        })
+        else
+          -- mismatch: non-grpc request matched grpc route
+          return kong.response.exit(415, { message = "Non-gRPC request matched gRPC route" })
+        end
+
+        if not protocols.grpc and forwarded_proto ~= "https" then
+          -- mismatch: grpc request matched grpcs route
+          return kong.response.exit(200, nil, {
+            ["content-type"] = "application/grpc",
+            ["grpc-status"] = 1,
+            ["grpc-message"] = "gRPC request matched gRPCs route",
+          })
+        end
       end
 
       balancer_prepare(ctx, match_t.upstream_scheme,
@@ -1305,28 +1307,29 @@ return {
     end,
     -- Only executed if the `router` module found a route and allows nginx to proxy it.
     after = function(ctx)
-      do
-        -- Nginx's behavior when proxying a request with an empty querystring
-        -- `/foo?` is to keep `$is_args` an empty string, hence effectively
-        -- stripping the empty querystring.
-        -- We overcome this behavior with our own logic, to preserve user
-        -- desired semantics.
-        local upstream_uri = var.upstream_uri
-
-        if var.is_args == "?" or sub(var.request_uri, -1) == "?" then
-          var.upstream_uri = upstream_uri .. "?" .. (var.args or "")
-        end
+      -- Nginx's behavior when proxying a request with an empty querystring
+      -- `/foo?` is to keep `$is_args` an empty string, hence effectively
+      -- stripping the empty querystring.
+      -- We overcome this behavior with our own logic, to preserve user
+      -- desired semantics.
+      -- perf: branch usually not taken, don't cache var outside
+      if sub(ctx.request_uri or var.request_uri, -1) == "?" then
+        var.upstream_uri = var.upstream_uri .. "?"
+      elseif var.is_args == "?" then
+        var.upstream_uri = var.upstream_uri .. "?" .. var.args or ""
       end
 
       local balancer_data = ctx.balancer_data
       balancer_data.scheme = var.upstream_scheme -- COMPAT: pdk
+      local upstream_scheme = balancer_data.scheme
 
       -- The content of var.upstream_host is only set by the router if
       -- preserve_host is true
       --
       -- We can't rely on var.upstream_host for balancer retries inside
       -- `set_host_header` because it would never be empty after the first -- balancer try
-      if var.upstream_host ~= nil and var.upstream_host ~= "" then
+      local upstream_host = var.upstream_host
+      if upstream_host ~= nil and upstream_host ~= "" then
         balancer_data.preserve_host = true
 
         -- the nginx grpc module does not offer a way to override the
@@ -1334,8 +1337,8 @@ return {
         -- this call applies to routes with preserve_host=true; for
         -- preserve_host=false, the header is set in `set_host_header`,
         -- so that it also applies to balancer retries
-        if var.upstream_scheme == "grpc" or var.upstream_scheme == "grpcs" then
-          local ok, err = kong.service.request.set_header(":authority", var.upstream_host)
+        if upstream_scheme == "grpc" or upstream_scheme == "grpcs" then
+          local ok, err = kong.service.request.set_header(":authority", upstream_host)
           if not ok then
             log(ERR, "failed to set :authority header: ", err)
           end
@@ -1348,9 +1351,10 @@ return {
         return kong.response.exit(errcode, body)
       end
 
+      upstream_scheme = balancer_data.scheme
       var.upstream_scheme = balancer_data.scheme
 
-      local ok, err = balancer.set_host_header(balancer_data)
+      local ok, err = balancer.set_host_header(balancer_data, upstream_scheme, upstream_host)
       if not ok then
         ngx.log(ngx.ERR, "failed to set balancer Host header: ", err)
 

--- a/spec/01-unit/16-runloop_handler_spec.lua
+++ b/spec/01-unit/16-runloop_handler_spec.lua
@@ -17,7 +17,9 @@ local function setup_it_block()
       timer = {
         at = function() end,
         every = function() end,
-      }
+      },
+      var = {
+      },
     },
 
     kong = {

--- a/spec/04-perf/01-rps/01-simple_spec.lua
+++ b/spec/04-perf/01-rps/01-simple_spec.lua
@@ -88,7 +88,7 @@ describe("perf test #baseline", function()
       perf.start_load({
         uri = upstream_uri,
         path = "/test",
-        connections = 1000,
+        connections = 100,
         threads = 5,
         duration = LOAD_DURATION,
       })
@@ -157,7 +157,7 @@ for _, version in ipairs(versions) do
       for i=1,3 do
         perf.start_load({
           path = "/s1-r1",
-          connections = 1000,
+          connections = 100,
           threads = 5,
           duration = LOAD_DURATION,
         })
@@ -179,7 +179,7 @@ for _, version in ipairs(versions) do
       local results = {}
       for i=1,3 do
         perf.start_load({
-          connections = 1000,
+          connections = 100,
           threads = 5,
           duration = LOAD_DURATION,
           script = wrk_script,
@@ -270,7 +270,7 @@ for _, version in ipairs(versions) do
       local results = {}
       for i=1,3 do
         perf.start_load({
-          connections = 1000,
+          connections = 100,
           threads = 5,
           duration = LOAD_DURATION,
           script = wrk_script,

--- a/spec/04-perf/01-rps/02-balancer_spec.lua
+++ b/spec/04-perf/01-rps/02-balancer_spec.lua
@@ -142,7 +142,7 @@ for _, version in ipairs(versions) do
       for i=1,3 do
         perf.start_load({
           path = "/no-upstream",
-          connections = 1000,
+          connections = 100,
           threads = 5,
           duration = LOAD_DURATION,
         })
@@ -166,7 +166,7 @@ for _, version in ipairs(versions) do
       for i=1,3 do
         perf.start_load({
           path = "/upstream1target",
-          connections = 1000,
+          connections = 100,
           threads = 5,
           duration = LOAD_DURATION,
         })
@@ -189,7 +189,7 @@ for _, version in ipairs(versions) do
       for i=1,3 do
         perf.start_load({
           path = "/upstream10targets",
-          connections = 1000,
+          connections = 100,
           threads = 5,
           duration = LOAD_DURATION,
         })
@@ -231,7 +231,7 @@ for _, version in ipairs(versions) do
       for i=1,3 do
         perf.start_load({
           path = "/upstream10targets",
-          connections = 1000,
+          connections = 100,
           threads = 5,
           duration = LOAD_DURATION,
         })

--- a/spec/04-perf/01-rps/03-plugin_iterator_spec.lua
+++ b/spec/04-perf/01-rps/03-plugin_iterator_spec.lua
@@ -114,7 +114,7 @@ for _, version in ipairs(versions) do
       for i=1,3 do
         perf.start_load({
           path = "/test",
-          connections = 1000,
+          connections = 100,
           threads = 5,
           duration = LOAD_DURATION,
         })
@@ -156,7 +156,7 @@ for _, version in ipairs(versions) do
       for i=1,3 do
         perf.start_load({
           path = "/test",
-          connections = 1000,
+          connections = 100,
           threads = 5,
           duration = LOAD_DURATION,
         })

--- a/spec/04-perf/02-flamegraph/01-simple_spec.lua
+++ b/spec/04-perf/02-flamegraph/01-simple_spec.lua
@@ -110,7 +110,7 @@ for _, version in ipairs(versions) do
       perf.start_stapxx("lj-lua-stacks.sxx", "-D MAXMAPENTRIES=1000000 --arg time=" .. LOAD_DURATION)
 
       perf.start_load({
-        connections = 1000,
+        connections = 100,
         threads = 5,
         duration = LOAD_DURATION,
         script = wrk_script,

--- a/spec/04-perf/02-flamegraph/03-plugin_iterator_spec.lua
+++ b/spec/04-perf/02-flamegraph/03-plugin_iterator_spec.lua
@@ -104,7 +104,7 @@ for _, version in ipairs(versions) do
 
       perf.start_load({
         path = "/test",
-        connections = 1000,
+        connections = 100,
         threads = 5,
         duration = LOAD_DURATION,
       })
@@ -147,7 +147,7 @@ for _, version in ipairs(versions) do
 
       perf.start_load({
         path = "/test",
-        connections = 1000,
+        connections = 100,
         threads = 5,
         duration = LOAD_DURATION,
       })


### PR DESCRIPTION
of uncommon branches

Other work like reducing var.http_HEADER and upstream var will be done in seperate PR.


Partly from #7426 #7421