### PR TITLE
chore(deps) bump luasec from 1.0.1 to 1.0.2

### DIFF
--- a/kong-2.5.0-0.rockspec
+++ b/kong-2.5.0-0.rockspec
@@ -13,7 +13,7 @@ description = {
 }
 dependencies = {
   "inspect == 3.1.1",
-  "luasec == 1.0.1",
+  "luasec == 1.0.2",
   "luasocket == 3.0-rc1",
   "penlight == 1.11.0",
   "lua-resty-http == 0.15",


### PR DESCRIPTION
### Summary

* Fix handle SSL_send SYSCALL error without errno
* Fix off by one in cert:validat(notafter)
* Fix meth_get_{sinagure => signature}_name function name
* Fix update the Lua state reference on the selected SSL context after SNI
* Fix ignore SSL_OP_BIT(n) macro and update option.c