### PR TITLE
fix(admin) GET /upstreams/:upstreams/targets/:target returns 404 when target weight is 0

### DIFF
--- a/kong/api/routes/upstreams.lua
+++ b/kong/api/routes/upstreams.lua
@@ -49,7 +49,7 @@ end
 
 
 local function select_target_cb(self, db, upstream, target)
-  if target and target.weight ~= 0 then
+  if target then
     return kong.response.exit(200, target)
   end
 
@@ -243,4 +243,3 @@ return {
     end,
   },
 }
-

--- a/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -132,6 +132,12 @@ describe("Admin API #" .. strategy, function()
           assert.is_number(json.created_at)
           assert.is_string(json.id)
           assert.are.equal(0, json.weight)
+
+          -- added for testing #7699
+          local res2 = assert(client:get("/upstreams/" .. upstream.name .. "/targets/zero.weight.test:8080"))
+          assert.response(res2).has.status(200)
+          local json2 = assert.response(res2).has.jsonbody()
+          assert.same(json, json2)
         end
       end)
 


### PR DESCRIPTION
### Summary

@flrgh reported on issue #7699 that our admin api return 404 for GET requests with target endpoint
when the target.weight is 0.

### Issues Resolved

Fix #7699