### PR TITLE
docs(autodoc) Update links in autodocs

### DIFF
--- a/autodoc/admin-api/data/admin-api.lua
+++ b/autodoc/admin-api/data/admin-api.lua
@@ -229,12 +229,12 @@ return {
   },
 
   footer = [[
-    [clustering]: /{{page.kong_version}}/clustering
-    [cli]: /{{page.kong_version}}/cli
-    [active]: /{{page.kong_version}}/health-checks-circuit-breakers/#active-health-checks
-    [healthchecks]: /{{page.kong_version}}/health-checks-circuit-breakers
-    [secure-admin-api]: /{{page.kong_version}}/secure-admin-api
-    [proxy-reference]: /{{page.kong_version}}/proxy
+    [clustering]: /gateway-oss/{{page.kong_version}}/clustering
+    [cli]: /gateway-oss/{{page.kong_version}}/cli
+    [active]: /gateway-oss/{{page.kong_version}}/health-checks-circuit-breakers/#active-health-checks
+    [healthchecks]: /gateway-oss/{{page.kong_version}}/health-checks-circuit-breakers
+    [secure-admin-api]: /gateway-oss/{{page.kong_version}}/secure-admin-api
+    [proxy-reference]: /gateway-oss/{{page.kong_version}}/proxy
   ]],
 
   general = {
@@ -888,9 +888,9 @@ return {
         },
         protocols = {
           description = [[
-            An array of the protocols this Route should allow. See the [Route Object](#route-object) section for a list of accepted protocols. 
-            
-            When set to only `"https"`, HTTP requests are answered with an upgrade error. When set to only `"http"`, HTTPS requests are answered with an error. 
+            An array of the protocols this Route should allow. See the [Route Object](#route-object) section for a list of accepted protocols.
+
+            When set to only `"https"`, HTTP requests are answered with an upgrade error. When set to only `"http"`, HTTPS requests are answered with an error.
           ]],
           examples = {
             {"http", "https"},

--- a/autodoc/cli/data.lua
+++ b/autodoc/cli/data.lua
@@ -40,7 +40,7 @@ data.command_intro = {
 
 data.footer = [[
 
-[configuration-reference]: /{{page.kong_version}}/configuration
+[configuration-reference]: /gateway-oss/{{page.kong_version}}/configuration
 ]]
 
 return data


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Updating links to point to `/gateway-oss/` instead of just `/`. 
This directory changed a few releases ago, so these pages now live here: https://docs.konghq.com/gateway-oss/

### Full changelog

N/A, internal doc changes only.

### Issues resolved

N/A
