### PR TITLE
perf(plugins-iterator) use stateful iterator to avoid table creation

### DIFF
--- a/kong/runloop/plugins_iterator.lua
+++ b/kong/runloop/plugins_iterator.lua
@@ -258,13 +258,16 @@ end
 
 
 local function get_next_no_ctx(loaded, phases)
-  local i = 0
+  local i = 1
   return function()
-    i = i + 1
     local plugin = loaded[i]
     while plugin and (phases == nil or not phases[plugin.name]) do
       i = i + 1
       plugin = loaded[i]
+    end
+
+    if plugin then
+      i = i + 1
     end
 
     return plugin
@@ -272,12 +275,10 @@ local function get_next_no_ctx(loaded, phases)
 end
 
 local function get_next_with_ctx(ctx, loaded, phases, combos, map, configure)
-  local i = 0
+  local i = 1
   return function()
     local cfg
-    i = i + 1
     local plugin = loaded[i]
-
     while plugin do
       local name = plugin.name
       if map[name] then
@@ -306,6 +307,10 @@ local function get_next_with_ctx(ctx, loaded, phases, combos, map, configure)
 
       i = i + 1
       plugin = loaded[i]
+    end
+
+    if plugin then
+      i = i + 1
     end
 
     return plugin, cfg

--- a/spec/04-perf/01-rps/01-simple_spec.lua
+++ b/spec/04-perf/01-rps/01-simple_spec.lua
@@ -88,7 +88,7 @@ describe("perf test #baseline", function()
       perf.start_load({
         uri = upstream_uri,
         path = "/test",
-        connections = 1000,
+        connections = 100,
         threads = 5,
         duration = LOAD_DURATION,
       })
@@ -157,7 +157,7 @@ for _, version in ipairs(versions) do
       for i=1,3 do
         perf.start_load({
           path = "/s1-r1",
-          connections = 1000,
+          connections = 100,
           threads = 5,
           duration = LOAD_DURATION,
         })
@@ -179,7 +179,7 @@ for _, version in ipairs(versions) do
       local results = {}
       for i=1,3 do
         perf.start_load({
-          connections = 1000,
+          connections = 100,
           threads = 5,
           duration = LOAD_DURATION,
           script = wrk_script,
@@ -270,7 +270,7 @@ for _, version in ipairs(versions) do
       local results = {}
       for i=1,3 do
         perf.start_load({
-          connections = 1000,
+          connections = 100,
           threads = 5,
           duration = LOAD_DURATION,
           script = wrk_script,

--- a/spec/04-perf/01-rps/02-balancer_spec.lua
+++ b/spec/04-perf/01-rps/02-balancer_spec.lua
@@ -142,7 +142,7 @@ for _, version in ipairs(versions) do
       for i=1,3 do
         perf.start_load({
           path = "/no-upstream",
-          connections = 1000,
+          connections = 100,
           threads = 5,
           duration = LOAD_DURATION,
         })
@@ -166,7 +166,7 @@ for _, version in ipairs(versions) do
       for i=1,3 do
         perf.start_load({
           path = "/upstream1target",
-          connections = 1000,
+          connections = 100,
           threads = 5,
           duration = LOAD_DURATION,
         })
@@ -189,7 +189,7 @@ for _, version in ipairs(versions) do
       for i=1,3 do
         perf.start_load({
           path = "/upstream10targets",
-          connections = 1000,
+          connections = 100,
           threads = 5,
           duration = LOAD_DURATION,
         })
@@ -231,7 +231,7 @@ for _, version in ipairs(versions) do
       for i=1,3 do
         perf.start_load({
           path = "/upstream10targets",
-          connections = 1000,
+          connections = 100,
           threads = 5,
           duration = LOAD_DURATION,
         })

--- a/spec/04-perf/01-rps/03-plugin_iterator_spec.lua
+++ b/spec/04-perf/01-rps/03-plugin_iterator_spec.lua
@@ -31,8 +31,8 @@ if env_versions then
   versions = split(env_versions, ",")
 end
 
-local LOAD_DURATION = 60
-local NUM_LOADS = 3
+local LOAD_DURATION = 20
+local NUM_LOADS = 1
 
 local function print_and_save(s, path)
   os.execute("mkdir -p output")

--- a/spec/04-perf/02-flamegraph/01-simple_spec.lua
+++ b/spec/04-perf/02-flamegraph/01-simple_spec.lua
@@ -110,7 +110,7 @@ for _, version in ipairs(versions) do
       perf.start_stapxx("lj-lua-stacks.sxx", "-D MAXMAPENTRIES=1000000 --arg time=" .. LOAD_DURATION)
 
       perf.start_load({
-        connections = 1000,
+        connections = 100,
         threads = 5,
         duration = LOAD_DURATION,
         script = wrk_script,

--- a/spec/04-perf/02-flamegraph/03-plugin_iterator_spec.lua
+++ b/spec/04-perf/02-flamegraph/03-plugin_iterator_spec.lua
@@ -104,7 +104,7 @@ for _, version in ipairs(versions) do
 
       perf.start_load({
         path = "/test",
-        connections = 1000,
+        connections = 100,
         threads = 5,
         duration = LOAD_DURATION,
       })
@@ -147,7 +147,7 @@ for _, version in ipairs(versions) do
 
       perf.start_load({
         path = "/test",
-        connections = 1000,
+        connections = 100,
         threads = 5,
         duration = LOAD_DURATION,
       })

--- a/spec/helpers/perf.lua
+++ b/spec/helpers/perf.lua
@@ -55,7 +55,7 @@ local function use_driver(name, opts)
   end
 
   check_driver_sanity(mod)
-  
+
   DRIVER = mod.new(opts)
 end
 
@@ -233,7 +233,7 @@ end
 -- @return string the test report text
 function _M.wait_result(opts)
   if not load_thread then
-    error("load haven't been started or already collected, " .. 
+    error("load haven't been started or already collected, " ..
           "start it using start_load() first", 2)
   end
 
@@ -353,7 +353,7 @@ function _M.generate_flamegraph(filename, title)
   if string.sub(filename, #filename-3, #filename):lower() ~= ".svg" then
     filename = filename .. ".svg"
   end
-  
+
   if not title then
     title = "Flame graph"
   end


### PR DESCRIPTION
### Summary

Just checking if stateful iterator will help any.

> “it is cheaper to create a closure than a table; second, access to upvalues is faster than access to table fields.”

but well, as @javierguerragiraldez argued below that ^ doesn't hold true with LuaJIT.