### PR TITLE
feat(aws-lambda) add support for detecting AWS region from environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,12 @@
 - Schema improvements:
   - New entity validator: `mutually_exclusive`.
 
+#### Plugins
+
+- **aws-lambda**: The plugin will now try to detect the AWS region by using `AWS_REGION` and
+  `AWS_DEFAULT_REGION` environment variables (when not specified with the plugin configuration).
+  [#7765](https://github.com/Kong/kong/pull/7765)
+
 ## [2.5.0]
 
 > Release date: 2021-07-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,13 @@
 - Bumped `openssl` from `1.1.1k` to `1.1.1l`
   [7767](https://github.com/Kong/kong/pull/7767)
 
+### Additions
+
+#### Core
+
+- Schema improvements:
+  - New entity validator: `mutually_exclusive`.
+
 ## [2.5.0]
 
 > Release date: 2021-07-13

--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -206,6 +206,7 @@ local entity_checkers = {
     }
   },
   { mutually_required = { type = "array", elements = { type = "string" } } },
+  { mutually_exclusive = { type = "array", elements = { type = "string" } } },
   { mutually_exclusive_sets = {
       type = "record",
       fields = {

--- a/kong/plugins/aws-lambda/schema.lua
+++ b/kong/plugins/aws-lambda/schema.lua
@@ -40,7 +40,7 @@ return {
         { aws_region = typedefs.host },
         { function_name = {
           type = "string",
-          required = true,
+          required = false,
         } },
         { qualifier = {
           type = "string",
@@ -106,6 +106,6 @@ return {
   entity_checks = {
     { mutually_required = { "config.aws_key", "config.aws_secret" } },
     { mutually_required = { "config.proxy_scheme", "config.proxy_url" } },
-    { only_one_of = { "config.aws_region", "config.host" } },
+    { mutually_exclusive = { "config.aws_region", "config.host" } },
   }
 }

--- a/spec/01-unit/01-db/01-schema/01-schema_spec.lua
+++ b/spec/01-unit/01-db/01-schema/01-schema_spec.lua
@@ -1825,6 +1825,38 @@ describe("schema", function()
       assert.falsy(err)
     end)
 
+    it("test mutually exclusive checks", function()
+      local Test = Schema.new({
+        fields = {
+          { a1 = { type = "string" } },
+          { a2 = { type = "string" } },
+          { a3 = { type = "string" } },
+        },
+        entity_checks = {
+          { mutually_exclusive = { "a2" } },
+          { mutually_exclusive = { "a1", "a3" } },
+        }
+      })
+
+      local ok, err = Test:validate_update({
+        a1 = "foo",
+        a3 = "foo",
+      })
+      assert.is_falsy(ok)
+      assert.match("only one or none of these fields must be set: 'a1', 'a3'", err["@entity"][1])
+
+      ok, err = Test:validate_update({
+        a2 = "foo"
+      })
+      assert.truthy(ok)
+      assert.falsy(err)
+
+      ok, err = Test:validate_update({})
+      assert.truthy(ok)
+      assert.falsy(err)
+    end)
+
+
     it("test mutually required checks specified by transformations", function()
       local Test = Schema.new({
         fields = {

--- a/spec/03-plugins/27-aws-lambda/02-schema_spec.lua
+++ b/spec/03-plugins/27-aws-lambda/02-schema_spec.lua
@@ -100,25 +100,23 @@ describe("Plugin: AWS Lambda (schema)", function()
     assert.truthy(ok)
   end)
 
-  it("errors if none of aws_region and host are passed ", function()
+  it("does not error if none of aws_region and host are passed (tries to autodetect on runtime)", function()
     local ok, err = v({
       function_name = "my-function"
     }, schema_def)
 
-
-    assert.equal("only one of these fields must be non-empty: 'config.aws_region', 'config.host'", err["@entity"][1])
-    assert.falsy(ok)
+    assert.is_nil(err)
+    assert.truthy(ok)
   end)
 
-  it("errors if both of aws_region and host are passed ", function()
+  it("errors if both of aws_region and host are passed", function()
     local ok, err = v({
       host = "my.lambda.host",
       aws_region = "us-east-1",
       function_name = "my-function"
     }, schema_def)
 
-
-    assert.equal("only one of these fields must be non-empty: 'config.aws_region', 'config.host'", err["@entity"][1])
+    assert.equal("only one or none of these fields must be set: 'config.aws_region', 'config.host'", err["@entity"][1])
     assert.falsy(ok)
   end)
 end)


### PR DESCRIPTION
### Summary

Allows auto-detection of region using either `AWS_REGION` or `AWS_DEFAULT_REGION` environment variables.

This PR also has another commit:

#### feat(schema) add mutually_exclusive entity validator 

The `only_one_of` validator marks at least one field required, this new `mutually_exclusive` entity validator allows none to be configured.

### Issues resolved

Partly resolves issue #7697