### PR TITLE
perf(*) use ngx.req.set_header to set upstream_headers

### DIFF
--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -326,7 +326,7 @@ local function new(self)
       end
     end
 
-    return ngx.var.upstream_x_forwarded_prefix
+    return ngx.ctx.upstream_x_forwarded_prefix
   end
 
 

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -133,12 +133,6 @@ server {
         set $upstream_connection         '';
         set $upstream_scheme             '';
         set $upstream_uri                '';
-        set $upstream_x_forwarded_for    '';
-        set $upstream_x_forwarded_proto  '';
-        set $upstream_x_forwarded_host   '';
-        set $upstream_x_forwarded_port   '';
-        set $upstream_x_forwarded_path   '';
-        set $upstream_x_forwarded_prefix '';
         set $kong_proxy_mode             'http';
 
         proxy_http_version      1.1;
@@ -149,13 +143,6 @@ server {
         proxy_set_header      Host               $upstream_host;
         proxy_set_header      Upgrade            $upstream_upgrade;
         proxy_set_header      Connection         $upstream_connection;
-        proxy_set_header      X-Forwarded-For    $upstream_x_forwarded_for;
-        proxy_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
-        proxy_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
-        proxy_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
-        proxy_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
-        proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
-        proxy_set_header      X-Real-IP          $remote_addr;
         proxy_pass_header     Server;
         proxy_pass_header     Date;
         proxy_ssl_name        $upstream_host;
@@ -180,13 +167,6 @@ server {
         proxy_set_header      Host               $upstream_host;
         proxy_set_header      Upgrade            $upstream_upgrade;
         proxy_set_header      Connection         $upstream_connection;
-        proxy_set_header      X-Forwarded-For    $upstream_x_forwarded_for;
-        proxy_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
-        proxy_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
-        proxy_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
-        proxy_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
-        proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
-        proxy_set_header      X-Real-IP          $remote_addr;
         proxy_pass_header     Server;
         proxy_pass_header     Date;
         proxy_ssl_name        $upstream_host;
@@ -211,13 +191,6 @@ server {
         proxy_set_header      Host               $upstream_host;
         proxy_set_header      Upgrade            $upstream_upgrade;
         proxy_set_header      Connection         $upstream_connection;
-        proxy_set_header      X-Forwarded-For    $upstream_x_forwarded_for;
-        proxy_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
-        proxy_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
-        proxy_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
-        proxy_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
-        proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
-        proxy_set_header      X-Real-IP          $remote_addr;
         proxy_pass_header     Server;
         proxy_pass_header     Date;
         proxy_ssl_name        $upstream_host;
@@ -242,13 +215,6 @@ server {
         proxy_set_header      Host               $upstream_host;
         proxy_set_header      Upgrade            $upstream_upgrade;
         proxy_set_header      Connection         $upstream_connection;
-        proxy_set_header      X-Forwarded-For    $upstream_x_forwarded_for;
-        proxy_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
-        proxy_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
-        proxy_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
-        proxy_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
-        proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
-        proxy_set_header      X-Real-IP          $remote_addr;
         proxy_pass_header     Server;
         proxy_pass_header     Date;
         proxy_ssl_name        $upstream_host;
@@ -266,13 +232,6 @@ server {
         set $kong_proxy_mode 'grpc';
 
         grpc_set_header      TE                 $upstream_te;
-        grpc_set_header      X-Forwarded-For    $upstream_x_forwarded_for;
-        grpc_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
-        grpc_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
-        grpc_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
-        grpc_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
-        grpc_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
-        grpc_set_header      X-Real-IP          $remote_addr;
         grpc_pass_header     Server;
         grpc_pass_header     Date;
         grpc_ssl_name        $upstream_host;
@@ -300,13 +259,6 @@ server {
         proxy_set_header      Host               $upstream_host;
         proxy_set_header      Upgrade            $upstream_upgrade;
         proxy_set_header      Connection         $upstream_connection;
-        proxy_set_header      X-Forwarded-For    $upstream_x_forwarded_for;
-        proxy_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
-        proxy_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
-        proxy_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
-        proxy_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
-        proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
-        proxy_set_header      X-Real-IP          $remote_addr;
         proxy_pass_header     Server;
         proxy_pass_header     Date;
         proxy_ssl_name        $upstream_host;

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -153,12 +153,6 @@ http {
             set $upstream_connection         '';
             set $upstream_scheme             '';
             set $upstream_uri                '';
-            set $upstream_x_forwarded_for    '';
-            set $upstream_x_forwarded_proto  '';
-            set $upstream_x_forwarded_host   '';
-            set $upstream_x_forwarded_port   '';
-            set $upstream_x_forwarded_path   '';
-            set $upstream_x_forwarded_prefix '';
             set $kong_proxy_mode             'http';
 
             proxy_http_version      1.1;
@@ -169,13 +163,6 @@ http {
             proxy_set_header      Host               $upstream_host;
             proxy_set_header      Upgrade            $upstream_upgrade;
             proxy_set_header      Connection         $upstream_connection;
-            proxy_set_header      X-Forwarded-For    $upstream_x_forwarded_for;
-            proxy_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
-            proxy_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
-            proxy_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
-            proxy_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
-            proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
-            proxy_set_header      X-Real-IP          $remote_addr;
             proxy_pass_header     Server;
             proxy_pass_header     Date;
             proxy_ssl_name        $upstream_host;
@@ -200,13 +187,6 @@ http {
             proxy_set_header      Host               $upstream_host;
             proxy_set_header      Upgrade            $upstream_upgrade;
             proxy_set_header      Connection         $upstream_connection;
-            proxy_set_header      X-Forwarded-For    $upstream_x_forwarded_for;
-            proxy_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
-            proxy_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
-            proxy_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
-            proxy_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
-            proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
-            proxy_set_header      X-Real-IP          $remote_addr;
             proxy_pass_header     Server;
             proxy_pass_header     Date;
             proxy_ssl_name        $upstream_host;
@@ -231,12 +211,6 @@ http {
             proxy_set_header      Host               $upstream_host;
             proxy_set_header      Upgrade            $upstream_upgrade;
             proxy_set_header      Connection         $upstream_connection;
-            proxy_set_header      X-Forwarded-For    $upstream_x_forwarded_for;
-            proxy_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
-            proxy_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
-            proxy_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
-            proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
-            proxy_set_header      X-Real-IP          $remote_addr;
             proxy_pass_header     Server;
             proxy_pass_header     Date;
             proxy_ssl_name        $upstream_host;
@@ -261,12 +235,6 @@ http {
             proxy_set_header      Host               $upstream_host;
             proxy_set_header      Upgrade            $upstream_upgrade;
             proxy_set_header      Connection         $upstream_connection;
-            proxy_set_header      X-Forwarded-For    $upstream_x_forwarded_for;
-            proxy_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
-            proxy_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
-            proxy_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
-            proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
-            proxy_set_header      X-Real-IP          $remote_addr;
             proxy_pass_header     Server;
             proxy_pass_header     Date;
             proxy_ssl_name        $upstream_host;
@@ -284,13 +252,6 @@ http {
             set $kong_proxy_mode 'grpc';
 
             grpc_set_header      TE                 $upstream_te;
-            grpc_set_header      X-Forwarded-For    $upstream_x_forwarded_for;
-            grpc_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
-            grpc_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
-            grpc_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
-            grpc_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
-            grpc_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
-            grpc_set_header      X-Real-IP          $remote_addr;
             grpc_pass_header     Server;
             grpc_pass_header     Date;
             grpc_ssl_name        $upstream_host;
@@ -318,13 +279,6 @@ http {
             proxy_set_header      Host               $upstream_host;
             proxy_set_header      Upgrade            $upstream_upgrade;
             proxy_set_header      Connection         $upstream_connection;
-            proxy_set_header      X-Forwarded-For    $upstream_x_forwarded_for;
-            proxy_set_header      X-Forwarded-Proto  $upstream_x_forwarded_proto;
-            proxy_set_header      X-Forwarded-Host   $upstream_x_forwarded_host;
-            proxy_set_header      X-Forwarded-Port   $upstream_x_forwarded_port;
-            proxy_set_header      X-Forwarded-Path   $upstream_x_forwarded_path;
-            proxy_set_header      X-Forwarded-Prefix $upstream_x_forwarded_prefix;
-            proxy_set_header      X-Real-IP          $remote_addr;
             proxy_pass_header     Server;
             proxy_pass_header     Date;
             proxy_ssl_name        $upstream_host;


### PR DESCRIPTION
Optimize performance by replacing ngx.var access with ngx.req.set_header to set x-forwarded-* headers. Those
headers are not set until access.after so that plugins that terminates requests in access phase still functions
as before.

Setting other headers through nginx variable are kept as is, some (like TE) are tricky to handle in Lua probably Nginx
has special handling of it, others like Host, Connection and Upgrade are kept since ngx.req.set_header mutates the
request headers directly, and plugins may then not be able to read the original request header.

