### PR TITLE
fix(handler) use request workspace to post balancer events

### DIFF
--- a/kong/runloop/balancer/upstreams.lua
+++ b/kong/runloop/balancer/upstreams.lua
@@ -148,7 +148,7 @@ function upstreams_M.get_upstream_by_name(upstream_name)
 end
 
 function upstreams_M.setUpstream_by_name(upstream)
-  local ws_id = workspaces.get_workspace_id()
+  local ws_id = upstream.ws_id or workspaces.get_workspace_id()
   upstream_by_name[ws_id .. ":" .. upstream.name] = upstream
 end
 
@@ -162,7 +162,7 @@ local upstream_events_queue = {}
 local function do_upstream_event(operation, upstream_data)
   local upstream_id = upstream_data.id
   local upstream_name = upstream_data.name
-  local ws_id = workspaces.get_workspace_id()
+  local ws_id = upstream_data.ws_id or workspaces.get_workspace_id()
   local by_name_key = ws_id .. ":" .. upstream_name
 
   if operation == "create" then
@@ -231,7 +231,7 @@ function upstreams_M.update_balancer_state(premature)
 
   while upstream_events_queue[1] do
     local event  = upstream_events_queue[1]
-    local _, err = do_upstream_event(event.operation, event.upstream_data, event.workspaces)
+    local _, err = do_upstream_event(event.operation, event.upstream_data)
     if err then
       log(CRIT, "failed handling upstream event: ", err)
       return

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -11,6 +11,7 @@ local singletons   = require "kong.singletons"
 local certificate  = require "kong.runloop.certificate"
 local concurrency  = require "kong.concurrency"
 local declarative  = require "kong.db.declarative"
+local workspaces   = require "kong.workspaces"
 local PluginsIterator = require "kong.runloop.plugins_iterator"
 
 
@@ -253,6 +254,12 @@ local function register_balancer_events(core_cache, worker_events, cluster_event
   worker_events.register(function(data)
     local operation = data.operation
     local upstream = data.entity
+    local ws_id = workspaces.get_workspace_id()
+    if not data.entity.ws_id then
+      log(DEBUG, "Event crud ", operation, " for upstream ", upstream.id,
+          " received without ws_id, adding.")
+      data.entity.ws_id = ws_id
+    end
     -- => to worker_events node handler
     local ok, err = worker_events.post("balancer", "upstreams", {
         operation = data.operation,
@@ -263,7 +270,7 @@ local function register_balancer_events(core_cache, worker_events, cluster_event
         operation, " to workers: ", err)
     end
     -- => to cluster_events handler
-    local key = fmt("%s:%s:%s", operation, upstream.id, upstream.name)
+    local key = fmt("%s:%s:%s:%s", operation, data.entity.ws_id, upstream.id, upstream.name)
     local ok, err = cluster_events:broadcast("balancer:upstreams", key)
     if not ok then
       log(ERR, "failed broadcasting upstream ", operation, " to cluster: ", err)
@@ -276,6 +283,12 @@ local function register_balancer_events(core_cache, worker_events, cluster_event
     local operation = data.operation
     local upstream = data.entity
 
+    if not data.entity.ws_id then
+      log(CRIT, "Operation ", operation, " for upstream ", data.entity.id,
+          " received without workspace, discarding.")
+      return
+    end
+
     singletons.core_cache:invalidate_local("balancer:upstreams")
     singletons.core_cache:invalidate_local("balancer:upstreams:" .. upstream.id)
 
@@ -285,10 +298,11 @@ local function register_balancer_events(core_cache, worker_events, cluster_event
 
 
   cluster_events:subscribe("balancer:upstreams", function(data)
-    local operation, id, name = unpack(utils.split(data, ":"))
+    local operation, ws_id, id, name = unpack(utils.split(data, ":"))
     local entity = {
       id = id,
       name = name,
+      ws_id = ws_id,
     }
     -- => to worker_events node handler
     local ok, err = worker_events.post("balancer", "upstreams", {


### PR DESCRIPTION
### Summary

The workspace id received in the request was being dismissed when posting balancer CRUD events. When workers used these posted events they had to fallback to the default workspace.


### Full changelog

* When an upstream event is received from the DAO `handler.lua` now gets the workspace id from the request and adds it to the upstream entity that will be used in the worker and cluster events. Before this change, when an worker or cluster event was treated, the workspace id was lost and the balancer used the default workspace id as a fallback.
* No tests were added as Kong API Gateway does not use custom workspaces.
