### PR TITLE
fix(handler) use request workspace to post balancer events

### DIFF
--- a/kong/runloop/balancer.lua
+++ b/kong/runloop/balancer.lua
@@ -515,7 +515,7 @@ do
     local balancer, err = create_balancer_exclusive(upstream)
 
     creating[upstream.id] = nil
-    local ws_id = workspaces.get_workspace_id()
+    local ws_id = upstream.ws_id or workspaces.get_workspace_id()
     upstream_by_name[ws_id .. ":" .. upstream.name] = upstream
 
     return balancer, err
@@ -676,7 +676,7 @@ end
 local function do_upstream_event(operation, upstream_data)
   local upstream_id = upstream_data.id
   local upstream_name = upstream_data.name
-  local ws_id = workspaces.get_workspace_id()
+  local ws_id = upstream_data.ws_id or workspaces.get_workspace_id()
   local by_name_key = ws_id .. ":" .. upstream_name
 
   if operation == "create" then
@@ -864,7 +864,7 @@ local function update_balancer_state(premature)
 
   while upstream_events_queue[1] do
     local v = upstream_events_queue[1]
-    local _, err = do_upstream_event(v.operation, v.upstream_data, v.workspaces)
+    local _, err = do_upstream_event(v.operation, v.upstream_data)
     if err then
       log(CRIT, "failed handling upstream event: ", err)
       return

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -270,7 +270,7 @@ local function register_balancer_events(core_cache, worker_events, cluster_event
         operation, " to workers: ", err)
     end
     -- => to cluster_events handler
-    local key = fmt("%s:%s:%s:%s", operation, ws_id, upstream.id, upstream.name)
+    local key = fmt("%s:%s:%s:%s", operation, data.entity.ws_id, upstream.id, upstream.name)
     local ok, err = cluster_events:broadcast("balancer:upstreams", key)
     if not ok then
       log(ERR, "failed broadcasting upstream ", operation, " to cluster: ", err)


### PR DESCRIPTION
The workspace id received in the request was being dismissed when
posting balancer CRUD events. When workers used these posted events
they had to fallback to the default workspace.

Note: This is targeting 2.5.x.