### PR TITLE
Add MAX_ONE_OF as entity checker

### DIFF
--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -94,6 +94,7 @@ local validation_errors = {
   CONDITIONAL               = "failed conditional validation given value of field '%s'",
   AT_LEAST_ONE_OF           = "at least one of these fields must be non-empty: %s",
   CONDITIONAL_AT_LEAST_ONE_OF = "at least one of these fields must be non-empty: %s",
+  MAX_ONE_OF                = "maximun one of these fields must be non-empty: %s",
   ONLY_ONE_OF               = "only one of these fields must be non-empty: %s",
   DISTINCT                  = "values of these fields must be distinct: %s",
   MUTUALLY_REQUIRED         = "all or none of these fields must be set: %s",
@@ -639,6 +640,24 @@ Schema.entity_checkers = {
       return nil, list, then_err
     end,
   },
+  max_one_of = {
+    run_with_missing_fields = false,
+    run_with_invalid_fields = true,
+    fn = function(entity, field_names)
+      local found = 0
+      for _, name in ipairs(field_names) do
+        if is_nonempty(get_field(entity, name)) then
+          found = found + 1
+        end
+      end
+
+      if found <= 1 then
+        return true
+      end
+      return nil, quoted_list(field_names)
+    end,
+  },
+
 
   only_one_of = {
     run_with_missing_fields = false,

--- a/spec/01-unit/01-db/01-schema/01-schema_spec.lua
+++ b/spec/01-unit/01-db/01-schema/01-schema_spec.lua
@@ -1749,7 +1749,27 @@ describe("schema", function()
         }
       })
       assert.falsy(Test:validate_update({ a = 12 }))
+      assert.falsy(Test:validate_update({ a = ngx.null, b = ngx.null }))
       assert.truthy(Test:validate_update({ a = 12, b = ngx.null }))
+    end)
+
+    it("test max_one_of", function()
+      local Test = Schema.new({
+        fields = {
+          { a = { type = "number" } },
+          { b = { type = "number" } },
+          { c = { type = "number" } },
+          { d = { type = "number" } },
+        },
+        entity_checks = {
+          { max_one_of = { "a", "b", "c" } },
+        }
+      })
+      assert.falsy(Test:validate_update({ a = 12, b = 42 }))
+      assert.falsy(Test:validate_update({ a = 12, b = ngx.null }))
+      assert.truthy(Test:validate_update({ a = 12, b = ngx.null, c = ngx.null }))
+      assert.truthy(Test:validate_update({ a = ngx.null, b = ngx.null, c = ngx.null }))
+      assert.truthy(Test:validate_update({ a = ngx.null, b = ngx.null, c = ngx.null, d = 12 }))
     end)
 
     it("test conditional checks", function()


### PR DESCRIPTION
### Summary

There is already  `AT_LEAST_ONE_OF` and `ONLY_ONE_OF` schema helper,
in some case we need to have none set or maximum only one.

### Full changelog

* Add a check on `ONLY_ONE_OF` when none of expected value is set this should
be rejected.
* Implements `MAX_ONE_OF` and add tests