### PR TITLE
chore(scripts) add reminder steps

### DIFF
--- a/scripts/make-final-release
+++ b/scripts/make-final-release
@@ -20,6 +20,12 @@ function usage() {
       echo
    fi
    c=1
+   step "all_clear"            "ensure all PRs marked on the release milestone are 100% merged"
+   step "dependencies"         "ensure all kong dependencies are bumped in the rockspec"
+   step "check_perf"           "ensure performance tests were executed"
+   step "check_upgrade_tests"  "ensure upgrade tests were executed"
+   step "check_changelog"      "ensure changelog was written in pre-release and is ready for final"
+   step "check_upgrade"        "ensure upgrade.md was updated in pre-release and is ready for final"
    step "version_bump"         "bump and commit the version number"
    step "submit"               "push and submit a release PR"
    step "merge"                "merge, tag and sign the release"
@@ -90,6 +96,81 @@ fi
 EDITOR="${EDITOR-$VISUAL}"
 
 case "$step" in
+   #---------------------------------------------------------------------------
+   all_clear)
+      if which firefox > /dev/null 2>&1
+      then
+        browser=firefox
+      elif which xdg-open > /dev/null 2>&1
+      then
+        browser=xdg-open
+      elif which open > /dev/null 2>&1
+      then
+          browser=open
+      fi
+
+      echo "Visit the milestones page (https://github.com/Kong/kong/milestone) and ensure PRs are merged. Press 'y' to open it or Ctrl-C to quit"
+      read
+      if [ "$REPLY" = "y" ]
+      then
+        $browser https://github.com/Kong/kong/milestones
+      fi
+
+      CONFIRM "If everything looks all right, press Enter to continue"
+      SUCCESS "All PRs are merged. Proceeding!"
+      ;;
+
+   #---------------------------------------------------------------------------
+   dependencies)
+      echo "Ensure Kong dependencies in the rockspec are bumped to their latest version. Press 'y' to open Kong's rockspec or Ctrl+C to quit"
+      read
+      if [ "$REPLY" = "y" ]
+      then
+        $EDITOR *.rockspec
+      fi
+
+      CONFIRM "If everything looks all right, press Enter to continue"
+      SUCCESS "All dependencies are bumped. Proceeding!"
+      ;;
+
+   #---------------------------------------------------------------------------
+   check_perf)
+      CONFIRM "Ensure Kong performance tests were performed and no showstopper regressions were found. If everything looks all right, press Enter to continue or Ctrl+C to quit"
+      SUCCESS "Proceeding."
+      ;;
+
+   #---------------------------------------------------------------------------
+   check_upgrade_tests)
+      CONFIRM "Ensure Kong upgrade tests were performed and no showstopper regressions were found. If everything looks all right, press Enter to continue or Ctrl+C to quit"
+      SUCCESS "Proceeding."
+      ;;
+
+   #---------------------------------------------------------------------------
+   check_changelog)
+      echo "Ensure changelog was written in pre-release and is ready for the final. Press 'y' to open the CHANGELOG or Ctrl+C to quit"
+      read
+      if [ "$REPLY" = "y" ]
+      then
+        $EDITOR CHANGELOG.md
+      fi
+
+      CONFIRM "If everything looks all right, press Enter to continue"
+      SUCCESS "CHANGELOG is ready. Proceeding!"
+      ;;
+
+   #---------------------------------------------------------------------------
+   check_upgrade)
+      echo "Ensure UPGRADE.md was written in pre-release and is ready for the final. Press 'y' to open UPGRADE.md or Ctrl+C to quit"
+      read
+      if [ "$REPLY" = "y" ]
+      then
+        $EDITOR UPGRADE.md
+      fi
+
+      CONFIRM "If everything looks all right, press Enter to continue"
+      SUCCESS "UPGRADE.md is ready. Proceeding!"
+      ;;
+
    #---------------------------------------------------------------------------
    version_bump)
       sed -i.bak 's/major = [0-9]*/major = '$major'/' kong/meta.lua

--- a/scripts/make-patch-release
+++ b/scripts/make-patch-release
@@ -20,6 +20,8 @@ function usage() {
       echo
    fi
    c=1
+   step "all_clear"            "ensure all PRs marked on the release milestone are 100% merged"
+   step "dependencies"         "ensure all kong dependencies are bumped in the rockspec"
    step "create"               "create the branch"
    step "write_changelog"      "prepare the changelog"
    step "commit_changelog"     "commit the changelog"
@@ -96,6 +98,43 @@ fi
 EDITOR="${EDITOR-$VISUAL}"
 
 case "$step" in
+   #---------------------------------------------------------------------------
+   all_clear)
+      if which firefox > /dev/null 2>&1
+      then
+        browser=firefox
+      elif which xdg-open > /dev/null 2>&1
+      then
+        browser=xdg-open
+      elif which open > /dev/null 2>&1
+      then
+          browser=open
+      fi
+
+      echo "Visit the milestones page (https://github.com/Kong/kong/milestone) and ensure PRs are merged. Press 'y' to open it or Ctrl-C to quit"
+      read
+      if [ "$REPLY" = "y" ]
+      then
+        $browser https://github.com/Kong/kong/milestones
+      fi
+
+      CONFIRM "If everything looks all right, press Enter to continue"
+      SUCCESS "All PRs are merged. Proceeding!"
+      ;;
+
+   #---------------------------------------------------------------------------
+   dependencies)
+      echo "Ensure Kong dependencies in the rockspec are bumped to their latest patch version. Press 'y' to open Kong's rockspec or Ctrl+C to quit"
+      read
+      if [ "$REPLY" = "y" ]
+      then
+        $EDITOR *.rockspec
+      fi
+
+      CONFIRM "If everything looks all right, press Enter to continue"
+      SUCCESS "All dependencies are bumped. Proceeding!"
+      ;;
+
    #---------------------------------------------------------------------------
    create)
       if [ $(git status --untracked-files=no --porcelain | wc -l) != "0" ]


### PR DESCRIPTION
This will allow us to deprecate internal checklists and
only use the script. Implements https://github.com/Kong/core-team/blob/master/adr/2021-07-29-deprecate-release-checklists.md.