### PR TITLE
feat(plugins/prometheus) expose DP cert expiry timestamp

### DIFF
--- a/kong/plugins/prometheus/exporter.lua
+++ b/kong/plugins/prometheus/exporter.lua
@@ -121,6 +121,19 @@ local function init()
     metrics.data_plane_version_compatible = prometheus:gauge("data_plane_version_compatible",
                                               "Version compatible status of the data plane, 0 is incompatible",
                                               {"node_id", "hostname", "ip", "kong_version"})
+  elseif role == "data_plane" then
+    local data_plane_cluster_cert_expiry_timestamp = prometheus:gauge(
+      "data_plane_cluster_cert_expiry_timestamp",
+      "Unix timestamp of Data Plane's cluster_cert expiry time")
+    -- The cluster_cert doesn't change once Kong starts.
+    -- We set this metrics just once to avoid file read in each scrape.
+    local f = assert(io.open(kong.configuration.cluster_cert))
+    local pem = assert(f:read("*a"))
+    f:close()
+    local x509 = require("resty.openssl.x509")
+    local cert = assert(x509.new(pem, "PEM"))
+    local not_after = assert(cert:get_not_after())
+    data_plane_cluster_cert_expiry_timestamp:set(not_after)
   end
 end
 

--- a/spec/03-plugins/26-prometheus/06-hybrid-mode_metrics.lua
+++ b/spec/03-plugins/26-prometheus/06-hybrid-mode_metrics.lua
@@ -1,0 +1,45 @@
+local helpers = require "spec.helpers"
+
+local tcp_status_port = helpers.get_available_port()
+
+describe("Plugin: prometheus (Hybrid Mode)", function()
+  local status_client
+
+  setup(function()
+    assert(helpers.start_kong {
+      nginx_conf = "spec/fixtures/custom_nginx.template",
+      plugins = "bundled",
+      database = "off",
+      role = "data_plane",
+      cluster_cert = "spec/fixtures/ocsp_certs/kong_clustering.crt",
+      cluster_cert_key = "spec/fixtures/ocsp_certs/kong_clustering.key",
+      status_listen = "0.0.0.0:" .. tcp_status_port,
+    })
+  end)
+
+
+  before_each(function()
+    status_client = helpers.http_client("127.0.0.1", tcp_status_port, 20000)
+  end)
+
+  after_each(function()
+    if status_client then
+      status_client:close()
+    end
+  end)
+
+  teardown(function()
+    helpers.stop_kong()
+  end)
+
+  it("exposes data plane's cluster_cert expiry timestamp", function()
+    local res = assert(status_client:send {
+      method  = "GET",
+      path    = "/metrics",
+    })
+    local body = assert.res_status(200, res)
+    assert.matches('data_plane_cluster_cert_expiry_timestamp %d+', body)
+
+    assert.matches('kong_nginx_metric_errors_total 0', body, nil, true)
+  end)
+end)


### PR DESCRIPTION
### Summary

A new metrics `data_plane_cluster_cert_expiry_timestamp` is added to expose the Data Plane's `cluster_cert`
expiry timestamp.

### Full changelog

* expose DP cert expiry timestamp

