### PR TITLE
Feat/proxy cache debug

### DIFF
--- a/kong/plugins/proxy-cache/handler.lua
+++ b/kong/plugins/proxy-cache/handler.lua
@@ -52,6 +52,11 @@ local function overwritable_header(header)
      and not ngx_re_match(n_header, "ratelimit-remaining")
 end
 
+local function set_header(header, value)
+  if ngx.var.http_kong_debug then
+    kong.response.set_header(header, value)
+  end
+end
 
 local function parse_directive_header(h)
   if not h then
@@ -203,8 +208,7 @@ local function signal_cache_req(ctx, cache_key, cache_status)
   ctx.proxy_cache = {
     cache_key = cache_key,
   }
-
-  kong.response.set_header("X-Cache-Status", cache_status or "Miss")
+  set_header("X-Cache-Status", cache_status or "Miss")
 end
 
 
@@ -260,7 +264,7 @@ function ProxyCacheHandler:access(conf)
 
   -- if we know this request isnt cacheable, bail out
   if not cacheable_request(conf, cc) then
-    kong.response.set_header("X-Cache-Status", "Bypass")
+    set_header("X-Cache-Status", "Bypass")
     return
   end
 
@@ -275,7 +279,7 @@ function ProxyCacheHandler:access(conf)
                                               kong.request.get_headers(),
                                               conf)
 
-  kong.response.set_header("X-Cache-Key", cache_key)
+  set_header("X-Cache-Key", cache_key)
 
   -- try to fetch the cached object from the computed cache key
   local strategy = require(STRATEGY_PATH)({
@@ -356,8 +360,15 @@ function ProxyCacheHandler:access(conf)
     end
   end
 
-  res.headers["Age"] = floor(time() - res.timestamp)
-  res.headers["X-Cache-Status"] = "Hit"
+
+  if ngx.var.http_kong_debug then
+    res.headers["Age"] = floor(time() - res.timestamp)
+    res.headers["X-Cache-Status"] = "Hit"
+  else
+    res.headers["Age"] = nil
+    res.headers["X-Cache-Status"] = nil
+    res.headers["X-Cache-Key"] = nil
+  end
 
   return kong.response.exit(res.status, res.body, res.headers)
 end
@@ -381,7 +392,7 @@ function ProxyCacheHandler:header_filter(conf)
     proxy_cache.res_ttl = conf.cache_control and resource_ttl(cc) or conf.cache_ttl
 
   else
-    kong.response.set_header("X-Cache-Status", "Bypass")
+    set_header("X-Cache-Status", "Bypass")
     ctx.proxy_cache = nil
   end
 

--- a/spec/03-plugins/31-proxy-cache/02-access_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/02-access_spec.lua
@@ -277,6 +277,7 @@ do
       local res = assert(client:get("/get", {
         headers = {
           host = "route-1.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -296,6 +297,7 @@ do
       local res = client:get("/get", {
         headers = {
           host = "route-1.com",
+          ["kong-debug"] = 1,
         }
       })
 
@@ -315,6 +317,7 @@ do
       local res = assert(client:get("/get", {
         headers = {
           host = "route-6.com",
+          ["kong-debug"] = 1,
         }
       })
       )
@@ -331,6 +334,7 @@ do
       res = client:get("/get", {
         headers = {
           host = "route-6.com",
+          ["kong-debug"] = 1,
         }
       })
 
@@ -353,6 +357,7 @@ do
       res = assert(client:get("/get", {
         headers = {
           host = "route-6.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -368,6 +373,7 @@ do
       res = assert(client:get("/get", {
         headers = {
           host = "route-6.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -378,6 +384,7 @@ do
       res = assert(client:get("/get", {
         headers = {
           host = "route-9.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -393,6 +400,7 @@ do
       res = assert(client:get("/get", {
         headers = {
           host = "route-9.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -416,6 +424,7 @@ do
       res = assert(client:get("/get", {
         headers = {
           host = "route-9.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -425,6 +434,7 @@ do
       res = assert(client:get("/get", {
         headers = {
           host = "route-9.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -436,6 +446,7 @@ do
       local res = assert(client:get("/cache/2", {
         headers = {
           host = "route-7.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -451,6 +462,7 @@ do
       res = assert(client:get("/cache/2", {
         headers = {
           host = "route-7.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -471,6 +483,7 @@ do
       res = assert(client:get("/cache/2", {
         headers = {
           host = "route-7.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -485,6 +498,7 @@ do
       res = assert(client:get("/cache/2", {
         headers = {
           host = "route-7.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -495,6 +509,7 @@ do
       res = assert(client:get("/cache/0", {
         headers = {
           host = "route-7.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -504,6 +519,7 @@ do
       res = assert(client:get("/cache/0", {
         headers = {
           host = "route-7.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -517,6 +533,7 @@ do
       local res = assert(client:get("/response-headers?Cache-Control=max-age%3D604800", {
         headers = {
           host = "route-7.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -528,6 +545,7 @@ do
       local res = assert(client:get("/response-headers?Cache-Control=s-maxage%3D604800", {
         headers = {
           host = "route-7.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -541,6 +559,7 @@ do
         query = "Expires=" .. httpdate,
         headers = {
           host = "route-7.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -555,6 +574,7 @@ do
           headers = {
             host = "route-7.com",
             ["Cache-Control"] = "min-fresh=30",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -567,6 +587,7 @@ do
           headers = {
             host = "route-7.com",
             ["Cache-Control"] = "max-age=2",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -583,6 +604,7 @@ do
           headers = {
             host = "route-7.com",
             ["Cache-Control"] = "max-age=2",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -605,6 +627,7 @@ do
           headers = {
             host = "route-7.com",
             ["Cache-Control"] = "max-age=2",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -616,6 +639,7 @@ do
         local res = assert(client:get("/cache/2", {
           headers = {
             host = "route-8.com",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -631,6 +655,7 @@ do
         res = assert(client:get("/cache/2", {
           headers = {
             host = "route-8.com",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -652,6 +677,7 @@ do
           headers = {
             host = "route-8.com",
             ["Cache-Control"] = "max-stale=1",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -664,6 +690,7 @@ do
           headers = {
             host = "route-8.com",
             ["Cache-Control"] = "only-if-cached",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -675,6 +702,7 @@ do
       local res = assert(client:get("/stream/3", {
         headers = {
           host = "route-1.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -691,6 +719,7 @@ do
       res = assert(client:get("/stream/3", {
         headers = {
           host = "route-1.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -704,6 +733,7 @@ do
         headers = {
           host = "route-13.com",
           apikey = "bob",
+          ["kong-debug"] = 1,
         }
       }))
       assert.res_status(200, res)
@@ -713,6 +743,7 @@ do
         headers = {
           host = "route-14.com",
           apikey = "bob",
+          ["kong-debug"] = 1,
         }
       }))
       assert.res_status(200, res)
@@ -726,6 +757,7 @@ do
         headers = {
           host = "route-15.com",
           apikey = "bob",
+          ["kong-debug"] = 1,
         }
       }))
       assert.res_status(200, res)
@@ -735,6 +767,7 @@ do
         headers = {
           host = "route-16.com",
           apikey = "bob",
+          ["kong-debug"] = 1,
         }
       }))
       assert.res_status(200, res)
@@ -747,6 +780,7 @@ do
       local res = assert(client:get("/get", {
         headers = {
           host = "route-3.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -760,6 +794,7 @@ do
       res = assert(client:get("/get", {
         headers = {
           host = "route-4.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -774,6 +809,7 @@ do
       local res = assert(client:get("/get", {
         headers = {
           host = "route-2.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -792,6 +828,7 @@ do
       res = assert(client:get("/get", {
         headers = {
           host = "route-2.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -805,6 +842,7 @@ do
       local res = assert(client:get("/get?a=b&b=c", {
         headers = {
           host = "route-1.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -814,6 +852,7 @@ do
       res = assert(client:get("/get?a=c", {
         headers = {
           host = "route-1.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -824,6 +863,7 @@ do
       res = assert(client:get("/get?b=c&a=b", {
         headers = {
           host = "route-1.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -833,6 +873,7 @@ do
       res = assert(client:get("/get?a&b", {
         headers = {
           host = "route-1.com",
+          ["kong-debug"] = 1,
         }
       }))
       assert.res_status(200, res)
@@ -841,6 +882,7 @@ do
       res = assert(client:get("/get?a&b", {
         headers = {
           host = "route-1.com",
+          ["kong-debug"] = 1,
         }
       }))
       assert.res_status(200, res)
@@ -851,6 +893,7 @@ do
       local res = assert(client:get("/get?foo=b&b=c", {
         headers = {
           host = "route-12.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -867,6 +910,7 @@ do
       res = assert(client:get("/get?b=d&foo=b", {
         headers = {
           host = "route-12.com",
+          ["kong-debug"] = 1,
         }
       }))
 
@@ -880,6 +924,7 @@ do
         headers = {
           host = "route-11.com",
           foo = "bar",
+          ["kong-debug"] = 1,
         }
       }))
       assert.res_status(200, res)
@@ -895,6 +940,7 @@ do
         headers = {
           host = "route-11.com",
           foo = "bar",
+          ["kong-debug"] = 1,
         }
       }))
       assert.res_status(200, res)
@@ -904,6 +950,7 @@ do
         headers = {
           host = "route-11.com",
           foo = "baz",
+          ["kong-debug"] = 1,
         }
       }))
       assert.res_status(200, res)
@@ -915,6 +962,7 @@ do
         local res = assert(client:get("/get", {
           headers = {
             host = "route-5.com",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -927,6 +975,7 @@ do
           headers = {
             host = "route-5.com",
             apikey = "bob",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -937,6 +986,7 @@ do
           headers = {
             host = "route-5.com",
             apikey = "bob",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -947,6 +997,7 @@ do
           headers = {
             host = "route-5.com",
             apikey = "alice",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -957,6 +1008,7 @@ do
           headers = {
             host = "route-5.com",
             apikey = "alice",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -972,6 +1024,7 @@ do
           headers = {
             host = "route-1.com",
             ["Content-Type"] = "application/json",
+            ["kong-debug"] = 1,
           },
           {
             foo = "bar",
@@ -988,6 +1041,7 @@ do
         local res = assert(client:get("/status/418", {
           headers = {
             host = "route-1.com",
+            ["kong-debug"] = 1,
           },
         }))
 
@@ -999,6 +1053,7 @@ do
         local res = assert(client:get("/xml", {
           headers = {
             host = "route-1.com",
+            ["kong-debug"] = 1,
           },
         }))
 
@@ -1013,6 +1068,7 @@ do
           headers = {
             host = "route-10.com",
             ["Content-Type"] = "application/json",
+            ["kong-debug"] = 1,
           },
           {
             foo = "bar",
@@ -1032,6 +1088,7 @@ do
           headers = {
             host = "route-10.com",
             ["Content-Type"] = "application/json",
+            ["kong-debug"] = 1,
           },
           {
             foo = "bar",
@@ -1046,6 +1103,7 @@ do
         local res = assert(client:get("/status/417", {
           headers = {
             host = "route-10.com",
+            ["kong-debug"] = 1,
           },
         }))
 
@@ -1055,6 +1113,7 @@ do
         res = assert(client:get("/status/417", {
           headers = {
             host = "route-10.com",
+            ["kong-debug"] = 1,
           },
         }))
 
@@ -1069,6 +1128,7 @@ do
         local res = assert(client:get("/get?show-me=proxy-latency", {
           headers = {
             host = "route-1.com",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -1079,6 +1139,7 @@ do
         res = assert(client:get("/get?show-me=proxy-latency", {
           headers = {
             host = "route-1.com",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -1091,6 +1152,7 @@ do
         local res = assert(client:get("/get?show-me=upstream-latency", {
           headers = {
             host = "route-1.com",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -1107,6 +1169,7 @@ do
         res = assert(client:get("/get?show-me=upstream-latency", {
           headers = {
             host = "route-1.com",
+            ["kong-debug"] = 1,
           }
         }))
 

--- a/spec/03-plugins/31-proxy-cache/02-access_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/02-access_spec.lua
@@ -1,6 +1,14 @@
 local helpers = require "spec.helpers"
 local strategies = require("kong.plugins.proxy-cache.strategies")
 
+local function get(client, host)
+  return assert(client:get("/get", {
+    headers = {
+      host = host,
+      ["kong-debug"] = 1,
+    },
+  }))
+end
 
 --local TIMEOUT = 10 -- default timeout for non-memory strategies
 
@@ -274,12 +282,7 @@ do
     end)
 
     it("caches a simple request", function()
-      local res = assert(client:get("/get", {
-        headers = {
-          host = "route-1.com",
-          ["kong-debug"] = 1,
-        }
-      }))
+      local res = assert(get(client, "route-1.com"))
 
       local body1 = assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
@@ -294,12 +297,7 @@ do
       --  return strategy:fetch(cache_key1) ~= nil
       --end, TIMEOUT)
 
-      local res = client:get("/get", {
-        headers = {
-          host = "route-1.com",
-          ["kong-debug"] = 1,
-        }
-      })
+      local res = assert(get(client, "route-1.com"))
 
       local body2 = assert.res_status(200, res)
       assert.same("Hit", res.headers["X-Cache-Status"])
@@ -312,15 +310,26 @@ do
       -- examine this cache key against another plugin's cache key for the same req
       --cache_key = cache_key1
     end)
+    it("No X-Cache* headers on the reponse without debug header in the query", function()
+      local res =  assert(client:get("/get", {
+        headers = { Host ="route-1.com", },
+      }))
+
+      assert.res_status(200, res)
+      assert.is_nil(res.headers["X-Cache-Status"])
+      res =  assert(client:get("/get", {
+        headers = { Host ="route-1.com", },
+      }))
+      assert.res_status(200, res)
+      assert.is_nil(res.headers["X-Cache-Status"])
+      assert.is_nil(res.headers["X-Cache-Key"])
+      res = assert(get(client, "route-1.com"))
+      assert.same("Hit", res.headers["X-Cache-Status"])
+    end)
+
 
     it("respects cache ttl", function()
-      local res = assert(client:get("/get", {
-        headers = {
-          host = "route-6.com",
-          ["kong-debug"] = 1,
-        }
-      })
-      )
+      local res = assert(get(client, "route-6.com"))
 
       --local cache_key2 = res.headers["X-Cache-Key"]
       assert.res_status(200, res)
@@ -331,12 +340,7 @@ do
       --  return strategy:fetch(cache_key2) ~= nil
       --end, TIMEOUT)
 
-      res = client:get("/get", {
-        headers = {
-          host = "route-6.com",
-          ["kong-debug"] = 1,
-        }
-      })
+      res = assert(get(client, "route-6.com"))
 
       assert.res_status(200, res)
       assert.same("Hit", res.headers["X-Cache-Status"])
@@ -354,12 +358,7 @@ do
       --end, TIMEOUT)
 
       -- and go through the cycle again
-      res = assert(client:get("/get", {
-        headers = {
-          host = "route-6.com",
-          ["kong-debug"] = 1,
-        }
-      }))
+      res = assert(get(client, "route-6.com"))
 
       assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
@@ -370,23 +369,13 @@ do
       --  return strategy:fetch(cache_key) ~= nil
       --end, TIMEOUT)
 
-      res = assert(client:get("/get", {
-        headers = {
-          host = "route-6.com",
-          ["kong-debug"] = 1,
-        }
-      }))
+      res = assert(get(client, "route-6.com"))
 
       assert.res_status(200, res)
       assert.same("Hit", res.headers["X-Cache-Status"])
 
       -- examine the behavior of keeping cache in memory for longer than ttl
-      res = assert(client:get("/get", {
-        headers = {
-          host = "route-9.com",
-          ["kong-debug"] = 1,
-        }
-      }))
+      res = assert(get(client, "route-9.com"))
 
       assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
@@ -397,12 +386,7 @@ do
       --  return strategy:fetch(cache_key) ~= nil
       --end, TIMEOUT)
 
-      res = assert(client:get("/get", {
-        headers = {
-          host = "route-9.com",
-          ["kong-debug"] = 1,
-        }
-      }))
+      res = assert(get(client, "route-9.com"))
 
       assert.res_status(200, res)
       assert.same("Hit", res.headers["X-Cache-Status"])
@@ -421,22 +405,12 @@ do
       --end, TIMEOUT)
 
       -- and go through the cycle again
-      res = assert(client:get("/get", {
-        headers = {
-          host = "route-9.com",
-          ["kong-debug"] = 1,
-        }
-      }))
+      res = assert(get(client, "route-9.com"))
 
       assert.res_status(200, res)
       assert.same("Refresh", res.headers["X-Cache-Status"])
 
-      res = assert(client:get("/get", {
-        headers = {
-          host = "route-9.com",
-          ["kong-debug"] = 1,
-        }
-      }))
+      res = assert(get(client, "route-9.com"))
 
       assert.res_status(200, res)
       assert.same("Hit", res.headers["X-Cache-Status"])
@@ -777,12 +751,7 @@ do
     end)
 
     it("uses an separate cache key between routes-specific and a global plugin", function()
-      local res = assert(client:get("/get", {
-        headers = {
-          host = "route-3.com",
-          ["kong-debug"] = 1,
-        }
-      }))
+      local res = assert(get(client, "route-3.com"))
 
       assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
@@ -791,12 +760,7 @@ do
       assert.matches("^[%w%d]+$", cache_key1)
       assert.equals(32, #cache_key1)
 
-      res = assert(client:get("/get", {
-        headers = {
-          host = "route-4.com",
-          ["kong-debug"] = 1,
-        }
-      }))
+      res = assert(get(client, "route-4.com"))
 
       assert.res_status(200, res)
 
@@ -806,12 +770,7 @@ do
     end)
 
     it("differentiates caches between instances", function()
-      local res = assert(client:get("/get", {
-        headers = {
-          host = "route-2.com",
-          ["kong-debug"] = 1,
-        }
-      }))
+      local res = assert(get(client, "route-2.com"))
 
       assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
@@ -825,12 +784,7 @@ do
       --  return strategy:fetch(cache_key1) ~= nil
       --end, TIMEOUT)
 
-      res = assert(client:get("/get", {
-        headers = {
-          host = "route-2.com",
-          ["kong-debug"] = 1,
-        }
-      }))
+      res = assert(get(client, "route-2.com"))
 
       local cache_key2 = res.headers["X-Cache-Key"]
       assert.res_status(200, res)
@@ -959,12 +913,7 @@ do
 
     describe("handles authenticated routes", function()
       it("by ignoring cache if the request is unauthenticated", function()
-        local res = assert(client:get("/get", {
-          headers = {
-            host = "route-5.com",
-            ["kong-debug"] = 1,
-          }
-        }))
+        local res = assert(get(client, "route-5.com"))
 
         assert.res_status(401, res)
         assert.is_nil(res.headers["X-Cache-Status"])

--- a/spec/03-plugins/31-proxy-cache/02-access_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/02-access_spec.lua
@@ -274,13 +274,11 @@ do
     end)
 
     it("caches a simple request", function()
-      local res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      local res = assert(client:get("/get", {
         headers = {
           host = "route-1.com",
         }
-      })
+      }))
 
       local body1 = assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
@@ -295,13 +293,11 @@ do
       --  return strategy:fetch(cache_key1) ~= nil
       --end, TIMEOUT)
 
-      local res = client:send {
-        method = "GET",
-        path = "/get",
+      local res = client:get("/get", {
         headers = {
           host = "route-1.com",
         }
-      }
+      })
 
       local body2 = assert.res_status(200, res)
       assert.same("Hit", res.headers["X-Cache-Status"])
@@ -316,13 +312,12 @@ do
     end)
 
     it("respects cache ttl", function()
-      local res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      local res = assert(client:get("/get", {
         headers = {
           host = "route-6.com",
         }
       })
+      )
 
       --local cache_key2 = res.headers["X-Cache-Key"]
       assert.res_status(200, res)
@@ -333,13 +328,11 @@ do
       --  return strategy:fetch(cache_key2) ~= nil
       --end, TIMEOUT)
 
-      res = client:send {
-        method = "GET",
-        path = "/get",
+      res = client:get("/get", {
         headers = {
           host = "route-6.com",
         }
-      }
+      })
 
       assert.res_status(200, res)
       assert.same("Hit", res.headers["X-Cache-Status"])
@@ -357,13 +350,11 @@ do
       --end, TIMEOUT)
 
       -- and go through the cycle again
-      res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      res = assert(client:get("/get", {
         headers = {
           host = "route-6.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
@@ -374,25 +365,21 @@ do
       --  return strategy:fetch(cache_key) ~= nil
       --end, TIMEOUT)
 
-      res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      res = assert(client:get("/get", {
         headers = {
           host = "route-6.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Hit", res.headers["X-Cache-Status"])
 
       -- examine the behavior of keeping cache in memory for longer than ttl
-      res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      res = assert(client:get("/get", {
         headers = {
           host = "route-9.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
@@ -403,13 +390,11 @@ do
       --  return strategy:fetch(cache_key) ~= nil
       --end, TIMEOUT)
 
-      res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      res = assert(client:get("/get", {
         headers = {
           host = "route-9.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Hit", res.headers["X-Cache-Status"])
@@ -428,37 +413,31 @@ do
       --end, TIMEOUT)
 
       -- and go through the cycle again
-      res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      res = assert(client:get("/get", {
         headers = {
           host = "route-9.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Refresh", res.headers["X-Cache-Status"])
 
-      res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      res = assert(client:get("/get", {
         headers = {
           host = "route-9.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Hit", res.headers["X-Cache-Status"])
     end)
 
     it("respects cache ttl via cache control", function()
-      local res = assert(client:send {
-        method = "GET",
-        path = "/cache/2",
+      local res = assert(client:get("/cache/2", {
         headers = {
           host = "route-7.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
@@ -469,13 +448,11 @@ do
       --  return strategy:fetch(cache_key) ~= nil
       --end, TIMEOUT)
 
-      res = assert(client:send {
-        method = "GET",
-        path = "/cache/2",
+      res = assert(client:get("/cache/2", {
         headers = {
           host = "route-7.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Hit", res.headers["X-Cache-Status"])
@@ -491,13 +468,11 @@ do
       --end, TIMEOUT)
 
       -- and go through the cycle again
-      res = assert(client:send {
-        method = "GET",
-        path = "/cache/2",
+      res = assert(client:get("/cache/2", {
         headers = {
           host = "route-7.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
@@ -507,36 +482,30 @@ do
       --  return strategy:fetch(cache_key) ~= nil
       --end, TIMEOUT)
 
-      res = assert(client:send {
-        method = "GET",
-        path = "/cache/2",
+      res = assert(client:get("/cache/2", {
         headers = {
           host = "route-7.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Hit", res.headers["X-Cache-Status"])
 
       -- assert that max-age=0 never results in caching
-      res = assert(client:send {
-        method = "GET",
-        path = "/cache/0",
+      res = assert(client:get("/cache/0", {
         headers = {
           host = "route-7.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Bypass", res.headers["X-Cache-Status"])
 
-      res = assert(client:send {
-        method = "GET",
-        path = "/cache/0",
+      res = assert(client:get("/cache/0", {
         headers = {
           host = "route-7.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Bypass", res.headers["X-Cache-Status"])
@@ -545,26 +514,22 @@ do
     it("public not present in Cache-Control, but max-age is", function()
       -- httpbin's /cache endpoint always sets "Cache-Control: public"
       -- necessary to set it manually using /response-headers instead
-      local res = assert(client:send {
-        method = "GET",
-        path = "/response-headers?Cache-Control=max-age%3D604800",
+      local res = assert(client:get("/response-headers?Cache-Control=max-age%3D604800", {
         headers = {
           host = "route-7.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
     end)
 
     it("Cache-Control contains s-maxage only", function()
-      local res = assert(client:send {
-        method = "GET",
-        path = "/response-headers?Cache-Control=s-maxage%3D604800",
+      local res = assert(client:get("/response-headers?Cache-Control=s-maxage%3D604800", {
         headers = {
           host = "route-7.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
@@ -572,14 +537,12 @@ do
 
     it("Expires present, Cache-Control absent", function()
       local httpdate = ngx.escape_uri(os.date("!%a, %d %b %Y %X %Z", os.time()+5000))
-      local res = assert(client:send {
-        method = "GET",
-        path = "/response-headers",
+      local res = assert(client:get("/response-headers", {
         query = "Expires=" .. httpdate,
         headers = {
           host = "route-7.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
@@ -588,28 +551,24 @@ do
     describe("respects cache-control", function()
       it("min-fresh", function()
         -- bypass via unsatisfied min-fresh
-        local res = assert(client:send {
-          method = "GET",
-          path = "/cache/2",
+        local res = assert(client:get("/cache/2", {
           headers = {
             host = "route-7.com",
             ["Cache-Control"] = "min-fresh=30",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Refresh", res.headers["X-Cache-Status"])
       end)
 
       it("max-age", function()
-        local res = assert(client:send {
-          method = "GET",
-          path = "/cache/10",
+        local res = assert(client:get("/cache/10", {
           headers = {
             host = "route-7.com",
             ["Cache-Control"] = "max-age=2",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Miss", res.headers["X-Cache-Status"])
@@ -620,14 +579,12 @@ do
         --  return strategy:fetch(cache_key) ~= nil
         --end, TIMEOUT)
 
-        res = assert(client:send {
-          method = "GET",
-          path = "/cache/10",
+        res = assert(client:get("/cache/10", {
           headers = {
             host = "route-7.com",
             ["Cache-Control"] = "max-age=2",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Hit", res.headers["X-Cache-Status"])
@@ -644,27 +601,23 @@ do
         --  return ngx.time() - obj.timestamp > 2
         --end, TIMEOUT)
 
-        res = assert(client:send {
-          method = "GET",
-          path = "/cache/10",
+        res = assert(client:get("/cache/10", {
           headers = {
             host = "route-7.com",
             ["Cache-Control"] = "max-age=2",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Refresh", res.headers["X-Cache-Status"])
       end)
 
       it("max-stale", function()
-        local res = assert(client:send {
-          method = "GET",
-          path = "/cache/2",
+        local res = assert(client:get("/cache/2", {
           headers = {
             host = "route-8.com",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Miss", res.headers["X-Cache-Status"])
@@ -675,13 +628,11 @@ do
         --  return strategy:fetch(cache_key) ~= nil
         --end, TIMEOUT)
 
-        res = assert(client:send {
-          method = "GET",
-          path = "/cache/2",
+        res = assert(client:get("/cache/2", {
           headers = {
             host = "route-8.com",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Hit", res.headers["X-Cache-Status"])
@@ -697,41 +648,35 @@ do
         --  return ngx.time() - obj.timestamp - obj.ttl > 2
         --end, TIMEOUT)
 
-        res = assert(client:send {
-          method = "GET",
-          path = "/cache/2",
+        res = assert(client:get("/cache/2", {
           headers = {
             host = "route-8.com",
             ["Cache-Control"] = "max-stale=1",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Refresh", res.headers["X-Cache-Status"])
       end)
 
       it("only-if-cached", function()
-        local res = assert(client:send {
-          method = "GET",
-          path   = "/get?not=here",
+        local res = assert(client:get("/get?not=here", {
           headers = {
             host = "route-8.com",
             ["Cache-Control"] = "only-if-cached",
           }
-        })
+        }))
 
         assert.res_status(504, res)
       end)
     end)
 
     it("caches a streaming request", function()
-      local res = assert(client:send {
-        method = "GET",
-        path = "/stream/3",
+      local res = assert(client:get("/stream/3", {
         headers = {
           host = "route-1.com",
         }
-      })
+      }))
 
       local body1 = assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
@@ -743,13 +688,11 @@ do
       --  return strategy:fetch(cache_key) ~= nil
       --end, TIMEOUT)
 
-      res = assert(client:send {
-        method = "GET",
-        path = "/stream/3",
+      res = assert(client:get("/stream/3", {
         headers = {
           host = "route-1.com",
         }
-      })
+      }))
 
       local body2 = assert.res_status(200, res)
       assert.same("Hit", res.headers["X-Cache-Status"])
@@ -757,25 +700,21 @@ do
     end)
 
     it("uses a separate cache key for the same consumer between routes", function()
-      local res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      local res = assert(client:get("/get", {
         headers = {
           host = "route-13.com",
           apikey = "bob",
         }
-      })
+      }))
       assert.res_status(200, res)
       local cache_key1 = res.headers["X-Cache-Key"]
 
-      local res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      local res = assert(client:get("/get", {
         headers = {
           host = "route-14.com",
           apikey = "bob",
         }
-      })
+      }))
       assert.res_status(200, res)
       local cache_key2 = res.headers["X-Cache-Key"]
 
@@ -783,25 +722,21 @@ do
     end)
 
     it("uses a separate cache key for the same consumer between routes/services", function()
-      local res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      local res = assert(client:get("/get", {
         headers = {
           host = "route-15.com",
           apikey = "bob",
         }
-      })
+      }))
       assert.res_status(200, res)
       local cache_key1 = res.headers["X-Cache-Key"]
 
-      local res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      local res = assert(client:get("/get", {
         headers = {
           host = "route-16.com",
           apikey = "bob",
         }
-      })
+      }))
       assert.res_status(200, res)
       local cache_key2 = res.headers["X-Cache-Key"]
 
@@ -809,13 +744,11 @@ do
     end)
 
     it("uses an separate cache key between routes-specific and a global plugin", function()
-      local res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      local res = assert(client:get("/get", {
         headers = {
           host = "route-3.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
@@ -824,13 +757,11 @@ do
       assert.matches("^[%w%d]+$", cache_key1)
       assert.equals(32, #cache_key1)
 
-      res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      res = assert(client:get("/get", {
         headers = {
           host = "route-4.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
 
@@ -840,13 +771,11 @@ do
     end)
 
     it("differentiates caches between instances", function()
-      local res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      local res = assert(client:get("/get", {
         headers = {
           host = "route-2.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
@@ -860,13 +789,11 @@ do
       --  return strategy:fetch(cache_key1) ~= nil
       --end, TIMEOUT)
 
-      res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      res = assert(client:get("/get", {
         headers = {
           host = "route-2.com",
         }
-      })
+      }))
 
       local cache_key2 = res.headers["X-Cache-Key"]
       assert.res_status(200, res)
@@ -875,69 +802,57 @@ do
     end)
 
     it("uses request params as part of the cache key", function()
-      local res = assert(client:send {
-        method = "GET",
-        path = "/get?a=b&b=c",
+      local res = assert(client:get("/get?a=b&b=c", {
         headers = {
           host = "route-1.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
 
-      res = assert(client:send {
-        method = "GET",
-        path = "/get?a=c",
+      res = assert(client:get("/get?a=c", {
         headers = {
           host = "route-1.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
 
       assert.same("Miss", res.headers["X-Cache-Status"])
 
-      res = assert(client:send {
-        method = "GET",
-        path = "/get?b=c&a=b",
+      res = assert(client:get("/get?b=c&a=b", {
         headers = {
           host = "route-1.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Hit", res.headers["X-Cache-Status"])
 
-      res = assert(client:send {
-        method = "GET",
-        path = "/get?a&b",
+      res = assert(client:get("/get?a&b", {
         headers = {
           host = "route-1.com",
         }
-      })
+      }))
       assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
 
-      res = assert(client:send {
-        method = "GET",
-        path = "/get?a&b",
+      res = assert(client:get("/get?a&b", {
         headers = {
           host = "route-1.com",
         }
-      })
+      }))
       assert.res_status(200, res)
       assert.same("Hit", res.headers["X-Cache-Status"])
     end)
 
     it("can focus only in a subset of the query arguments", function()
-      local res = assert(client:send {
-        method = "GET",
-        path = "/get?foo=b&b=c",
+      local res = assert(client:get("/get?foo=b&b=c", {
         headers = {
           host = "route-12.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
@@ -949,13 +864,11 @@ do
       --  return strategy:fetch(cache_key) ~= nil
       --end, TIMEOUT)
 
-      res = assert(client:send {
-        method = "GET",
-        path = "/get?b=d&foo=b",
+      res = assert(client:get("/get?b=d&foo=b", {
         headers = {
           host = "route-12.com",
         }
-      })
+      }))
 
       assert.res_status(200, res)
 
@@ -963,14 +876,12 @@ do
     end)
 
     it("uses headers if instructed to do so", function()
-      local res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      local res = assert(client:get("/get", {
         headers = {
           host = "route-11.com",
           foo = "bar",
         }
-      })
+      }))
       assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
       --local cache_key = res.headers["X-Cache-Key"]
@@ -980,88 +891,74 @@ do
       --  return strategy:fetch(cache_key) ~= nil
       --end, TIMEOUT)
 
-      res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      res = assert(client:get("/get", {
         headers = {
           host = "route-11.com",
           foo = "bar",
         }
-      })
+      }))
       assert.res_status(200, res)
       assert.same("Hit", res.headers["X-Cache-Status"])
 
-      res = assert(client:send {
-        method = "GET",
-        path = "/get",
+      res = assert(client:get("/get", {
         headers = {
           host = "route-11.com",
           foo = "baz",
         }
-      })
+      }))
       assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
     end)
 
     describe("handles authenticated routes", function()
       it("by ignoring cache if the request is unauthenticated", function()
-        local res = assert(client:send {
-          method = "GET",
-          path = "/get",
+        local res = assert(client:get("/get", {
           headers = {
             host = "route-5.com",
           }
-        })
+        }))
 
         assert.res_status(401, res)
         assert.is_nil(res.headers["X-Cache-Status"])
       end)
 
       it("by maintaining a separate cache per consumer", function()
-        local res = assert(client:send {
-          method = "GET",
-          path = "/get",
+        local res = assert(client:get("/get", {
           headers = {
             host = "route-5.com",
             apikey = "bob",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Miss", res.headers["X-Cache-Status"])
 
-        res = assert(client:send {
-          method = "GET",
-          path = "/get",
+        res = assert(client:get("/get", {
           headers = {
             host = "route-5.com",
             apikey = "bob",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Hit", res.headers["X-Cache-Status"])
 
-        local res = assert(client:send {
-          method = "GET",
-          path = "/get",
+        local res = assert(client:get("/get", {
           headers = {
             host = "route-5.com",
             apikey = "alice",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Miss", res.headers["X-Cache-Status"])
 
-        res = assert(client:send {
-          method = "GET",
-          path = "/get",
+        res = assert(client:get("/get", {
           headers = {
             host = "route-5.com",
             apikey = "alice",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Hit", res.headers["X-Cache-Status"])
@@ -1071,9 +968,7 @@ do
 
     describe("bypasses cache for uncacheable requests: ", function()
       it("request method", function()
-        local res = assert(client:send {
-          method = "POST",
-          path = "/post",
+        local res = assert(client:post("/post", {
           headers = {
             host = "route-1.com",
             ["Content-Type"] = "application/json",
@@ -1081,7 +976,7 @@ do
           {
             foo = "bar",
           },
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Bypass", res.headers["X-Cache-Status"])
@@ -1090,26 +985,22 @@ do
 
     describe("bypasses cache for uncacheable responses:", function()
       it("response status", function()
-        local res = assert(client:send {
-          method = "GET",
-          path = "/status/418",
+        local res = assert(client:get("/status/418", {
           headers = {
             host = "route-1.com",
           },
-        })
+        }))
 
         assert.res_status(418, res)
         assert.same("Bypass", res.headers["X-Cache-Status"])
       end)
 
       it("response content type", function()
-        local res = assert(client:send {
-          method = "GET",
-          path = "/xml",
+        local res = assert(client:get("/xml", {
           headers = {
             host = "route-1.com",
           },
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Bypass", res.headers["X-Cache-Status"])
@@ -1118,9 +1009,7 @@ do
 
     describe("caches non-default", function()
       it("request methods", function()
-        local res = assert(client:send {
-          method = "POST",
-          path = "/post",
+        local res = assert(client:post("/post", {
           headers = {
             host = "route-10.com",
             ["Content-Type"] = "application/json",
@@ -1128,7 +1017,7 @@ do
           {
             foo = "bar",
           },
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Miss", res.headers["X-Cache-Status"])
@@ -1139,9 +1028,7 @@ do
         --  return strategy:fetch(cache_key) ~= nil
         --end, TIMEOUT)
 
-        res = assert(client:send {
-          method = "POST",
-          path = "/post",
+        res = assert(client:post("/post", {
           headers = {
             host = "route-10.com",
             ["Content-Type"] = "application/json",
@@ -1149,31 +1036,27 @@ do
           {
             foo = "bar",
           },
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Hit", res.headers["X-Cache-Status"])
       end)
 
       it("response status", function()
-        local res = assert(client:send {
-          method = "GET",
-          path = "/status/417",
+        local res = assert(client:get("/status/417", {
           headers = {
             host = "route-10.com",
           },
-        })
+        }))
 
         assert.res_status(417, res)
         assert.same("Miss", res.headers["X-Cache-Status"])
 
-        res = assert(client:send {
-          method = "GET",
-          path = "/status/417",
+        res = assert(client:get("/status/417", {
           headers = {
             host = "route-10.com",
           },
-        })
+        }))
 
         assert.res_status(417, res)
         assert.same("Hit", res.headers["X-Cache-Status"])
@@ -1183,25 +1066,21 @@ do
 
     describe("displays Kong core headers:", function()
       it("X-Kong-Proxy-Latency", function()
-        local res = assert(client:send {
-          method = "GET",
-          path = "/get?show-me=proxy-latency",
+        local res = assert(client:get("/get?show-me=proxy-latency", {
           headers = {
             host = "route-1.com",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Miss", res.headers["X-Cache-Status"])
         assert.matches("^%d+$", res.headers["X-Kong-Proxy-Latency"])
 
-        res = assert(client:send {
-          method = "GET",
-          path = "/get?show-me=proxy-latency",
+        res = assert(client:get("/get?show-me=proxy-latency", {
           headers = {
             host = "route-1.com",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Hit", res.headers["X-Cache-Status"])
@@ -1209,13 +1088,11 @@ do
       end)
 
       it("X-Kong-Upstream-Latency", function()
-        local res = assert(client:send {
-          method = "GET",
-          path = "/get?show-me=upstream-latency",
+        local res = assert(client:get("/get?show-me=upstream-latency", {
           headers = {
             host = "route-1.com",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Miss", res.headers["X-Cache-Status"])
@@ -1227,13 +1104,11 @@ do
         --  return strategy:fetch(cache_key) ~= nil
         --end, TIMEOUT)
 
-        res = assert(client:send {
-          method = "GET",
-          path = "/get?show-me=upstream-latency",
+        res = assert(client:get("/get?show-me=upstream-latency", {
           headers = {
             host = "route-1.com",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Hit", res.headers["X-Cache-Status"])

--- a/spec/03-plugins/31-proxy-cache/02-access_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/02-access_spec.lua
@@ -593,7 +593,7 @@ do
           path = "/cache/2",
           headers = {
             host = "route-7.com",
-            ["Cache-Control"] = "min-fresh=30"
+            ["Cache-Control"] = "min-fresh=30",
           }
         })
 
@@ -607,7 +607,7 @@ do
           path = "/cache/10",
           headers = {
             host = "route-7.com",
-            ["Cache-Control"] = "max-age=2"
+            ["Cache-Control"] = "max-age=2",
           }
         })
 
@@ -625,7 +625,7 @@ do
           path = "/cache/10",
           headers = {
             host = "route-7.com",
-            ["Cache-Control"] = "max-age=2"
+            ["Cache-Control"] = "max-age=2",
           }
         })
 
@@ -649,7 +649,7 @@ do
           path = "/cache/10",
           headers = {
             host = "route-7.com",
-            ["Cache-Control"] = "max-age=2"
+            ["Cache-Control"] = "max-age=2",
           }
         })
 
@@ -968,7 +968,7 @@ do
         path = "/get",
         headers = {
           host = "route-11.com",
-          foo = "bar"
+          foo = "bar",
         }
       })
       assert.res_status(200, res)
@@ -985,7 +985,7 @@ do
         path = "/get",
         headers = {
           host = "route-11.com",
-          foo = "bar"
+          foo = "bar",
         }
       })
       assert.res_status(200, res)
@@ -996,7 +996,7 @@ do
         path = "/get",
         headers = {
           host = "route-11.com",
-          foo = "baz"
+          foo = "baz",
         }
       })
       assert.res_status(200, res)

--- a/spec/03-plugins/31-proxy-cache/03-api_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/03-api_spec.lua
@@ -206,6 +206,7 @@ describe("Plugin: proxy-cache", function()
         local res = assert(proxy_client:get("/get", {
           headers = {
             host = "route-1.com",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -221,6 +222,7 @@ describe("Plugin: proxy-cache", function()
         res = assert(proxy_client:get("/get", {
           headers = {
             host = "route-1.com",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -236,6 +238,7 @@ describe("Plugin: proxy-cache", function()
         local res = assert(proxy_client:get("/get", {
           headers = {
             host = "route-1.com",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -249,6 +252,7 @@ describe("Plugin: proxy-cache", function()
         local res = assert(proxy_client:get("/get", {
           headers = {
             host = "route-1.com",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -260,6 +264,7 @@ describe("Plugin: proxy-cache", function()
         local res = assert(proxy_client:get("/get", {
           headers = {
             host = "route-1.com",
+            ["kong-debug"] = 1,
           }
         }))
         assert.res_status(200, res)
@@ -269,6 +274,7 @@ describe("Plugin: proxy-cache", function()
         local res = assert(proxy_client:get("/get", {
           headers = {
             host = "route-2.com",
+            ["kong-debug"] = 1,
           }
         }))
 
@@ -284,6 +290,7 @@ describe("Plugin: proxy-cache", function()
         res = assert(proxy_client:get("/get", {
           headers = {
             host = "route-2.com",
+            ["kong-debug"] = 1,
           }
         }))
 

--- a/spec/03-plugins/31-proxy-cache/03-api_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/03-api_spec.lua
@@ -71,9 +71,7 @@ describe("Plugin: proxy-cache", function()
     local body
 
     it("accepts an array of numbers as strings", function()
-      local res = assert(admin_client:send {
-        method = "POST",
-        path = "/plugins",
+      local res = assert(admin_client:post("/plugins", {
         body = {
           name = "proxy-cache",
           config = {
@@ -90,7 +88,7 @@ describe("Plugin: proxy-cache", function()
         headers = {
           ["Content-Type"] = "application/json",
         },
-      })
+      }))
       body = assert.res_status(201, res)
     end)
     it("casts an array of response_code values to number types", function()
@@ -205,13 +203,11 @@ describe("Plugin: proxy-cache", function()
   describe("(API)", function()
     describe("DELETE", function()
       it("delete a cache entry", function()
-        local res = assert(proxy_client:send {
-          method = "GET",
-          path = "/get",
+        local res = assert(proxy_client:get("/get", {
           headers = {
             host = "route-1.com",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Miss", res.headers["X-Cache-Status"])
@@ -222,13 +218,11 @@ describe("Plugin: proxy-cache", function()
         assert.equals(32, #cache_key1)
         cache_key = cache_key1
 
-        res = assert(proxy_client:send {
-          method = "GET",
-          path = "/get",
+        res = assert(proxy_client:get("/get", {
           headers = {
             host = "route-1.com",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Hit", res.headers["X-Cache-Status"])
@@ -236,61 +230,47 @@ describe("Plugin: proxy-cache", function()
         assert.same(cache_key1, cache_key2)
 
         -- delete the key
-        res = assert(admin_client:send {
-          method = "DELETE",
-          path = "/proxy-cache/" .. plugin1.id .. "/caches/" .. cache_key,
-        })
+        res = assert(admin_client:delete("/proxy-cache/" .. plugin1.id .. "/caches/" .. cache_key))
         assert.res_status(204, res)
 
-        local res = assert(proxy_client:send {
-          method = "GET",
-          path = "/get",
+        local res = assert(proxy_client:get("/get", {
           headers = {
             host = "route-1.com",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Miss", res.headers["X-Cache-Status"])
 
         -- delete directly, having to look up all proxy-cache instances
-        res = assert(admin_client:send {
-          method = "DELETE",
-          path = "/proxy-cache/" .. cache_key,
-        })
+        res = assert(admin_client:delete("/proxy-cache/" .. cache_key))
         assert.res_status(204, res)
 
-        local res = assert(proxy_client:send {
-          method = "GET",
-          path = "/get",
+        local res = assert(proxy_client:get("/get", {
           headers = {
             host = "route-1.com",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Miss", res.headers["X-Cache-Status"])
       end)
       it("purge all the cache entries", function()
         -- make a `Hit` request to `route-1`
-        local res = assert(proxy_client:send {
-          method = "GET",
-          path = "/get",
+        local res = assert(proxy_client:get("/get", {
           headers = {
             host = "route-1.com",
           }
-        })
+        }))
         assert.res_status(200, res)
         assert.same("Hit", res.headers["X-Cache-Status"])
 
         -- make a `Miss` request to `route-2`
-        local res = assert(proxy_client:send {
-          method = "GET",
-          path = "/get",
+        local res = assert(proxy_client:get("/get", {
           headers = {
             host = "route-2.com",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Miss", res.headers["X-Cache-Status"])
@@ -301,13 +281,11 @@ describe("Plugin: proxy-cache", function()
         assert.equals(32, #cache_key1)
 
         -- make a `Hit` request to `route-1`
-        res = assert(proxy_client:send {
-          method = "GET",
-          path = "/get",
+        res = assert(proxy_client:get("/get", {
           headers = {
             host = "route-2.com",
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Hit", res.headers["X-Cache-Status"])
@@ -315,109 +293,76 @@ describe("Plugin: proxy-cache", function()
         assert.same(cache_key1, cache_key2)
 
         -- delete all the cache keys
-        res = assert(admin_client:send {
-          method = "DELETE",
-          path = "/proxy-cache",
-        })
+        res = assert(admin_client:delete("/proxy-cache"))
         assert.res_status(204, res)
 
-        local res = assert(proxy_client:send {
-          method = "GET",
-          path = "/get",
+        local res = assert(proxy_client:get("/get", {
           headers = {
             host = "route-1.com",
+            ["kong-debug"] = 1,
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Miss", res.headers["X-Cache-Status"])
 
-        local res = assert(proxy_client:send {
-          method = "GET",
-          path = "/get",
+        local res = assert(proxy_client:get("/get", {
           headers = {
             host = "route-2.com",
+            ["kong-debug"] = 1,
           }
-        })
+        }))
 
         assert.res_status(200, res)
         assert.same("Miss", res.headers["X-Cache-Status"])
       end)
       it("delete a non-existing cache key", function()
         -- delete all the cache keys
-        local res = assert(admin_client:send {
-          method = "DELETE",
-          path = "/proxy-cache",
-        })
+        local res = assert(admin_client:delete("/proxy-cache"))
         assert.res_status(204, res)
 
-        local res = assert(admin_client:send {
-          method = "DELETE",
-          path = "/proxy-cache/" .. plugin1.id .. "/caches/" .. "123",
-        })
+        local res = assert(admin_client:delete("/proxy-cache/" .. plugin1.id .. "/caches/" .. "123"))
         assert.res_status(404, res)
       end)
       it("delete a non-existing plugins's cache key", function()
         -- delete all the cache keys
-        local res = assert(admin_client:send {
-          method = "DELETE",
-          path = "/proxy-cache",
-        })
+        local res = assert(admin_client:delete("/proxy-cache"))
         assert.res_status(204, res)
 
-        local res = assert(admin_client:send {
-          method = "DELETE",
-          path = "/proxy-cache/" .. route1.id .. "/caches/" .. "123",
-        })
+        local res = assert(admin_client:delete("/proxy-cache/" .. route1.id .. "/caches/" .. "123"))
         assert.res_status(404, res)
       end)
     end)
     describe("GET", function()
       it("get a non-existing cache", function()
         -- delete all the cache keys
-        local res = assert(admin_client:send {
-          method = "DELETE",
-          path = "/proxy-cache",
-        })
+        local res = assert(admin_client:delete("/proxy-cache"))
         assert.res_status(204, res)
 
-        local res = assert(admin_client:send {
-          method = "GET",
-          path = "/proxy-cache/" .. plugin1.id .. "/caches/" .. cache_key,
-        })
+        local res = assert(admin_client:get("/proxy-cache/" .. plugin1.id .. "/caches/" .. cache_key))
         assert.res_status(404, res)
 
         -- attempt to list an entry directly via cache key
-        local res = assert(admin_client:send {
-          method = "GET",
-          path = "/proxy-cache/" .. cache_key,
-        })
+        local res = assert(admin_client:get("/proxy-cache/" .. cache_key))
         assert.res_status(404, res)
       end)
       it("get a existing cache", function()
         -- add request to cache
-        local res = assert(proxy_client:send {
-          method = "GET",
-          path = "/get",
+        local res = assert(proxy_client:get("/get", {
           headers = {
             host = "route-1.com",
+            ["kong-debug"] = 1,
           }
-        })
+        }))
         assert.res_status(200, res)
 
-        local res = assert(admin_client:send {
-          method = "GET",
-          path = "/proxy-cache/" .. plugin1.id .. "/caches/" .. cache_key,
-        })
+        local res = assert(admin_client:get("/proxy-cache/" .. plugin1.id .. "/caches/" .. cache_key))
         local body = assert.res_status(200, res)
         local json_body = cjson.decode(body)
         assert.same(cache_key, json_body.headers["X-Cache-Key"])
 
         -- list an entry directly via cache key
-        local res = assert(admin_client:send {
-          method = "GET",
-          path = "/proxy-cache/" ..  cache_key,
-        })
+        local res = assert(admin_client:get("/proxy-cache/" ..  cache_key))
         local body = assert.res_status(200, res)
         local json_body = cjson.decode(body)
         assert.same(cache_key, json_body.headers["X-Cache-Key"])

--- a/spec/03-plugins/31-proxy-cache/04-invalidations_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/04-invalidations_spec.lua
@@ -115,125 +115,101 @@ describe("proxy-cache invalidations via: " .. strategy, function()
 
     setup(function()
       -- prime cache entries on both instances
-      local res_1 = assert(client_1:send {
-        method = "GET",
-        path = "/get",
+      local res_1 = assert(client_1:get("/get", {
         headers = {
           Host = "route-1.com",
         },
-      })
+      }))
 
       assert.res_status(200, res_1)
       assert.same("Miss", res_1.headers["X-Cache-Status"])
       cache_key = res_1.headers["X-Cache-Key"]
 
-      local res_2 = assert(client_2:send {
-        method = "GET",
-        path = "/get",
+      local res_2 = assert(client_2:get("/get", {
         headers = {
           host = "route-1.com",
         },
-      })
+      }))
 
       assert.res_status(200, res_2)
       assert.same("Miss", res_2.headers["X-Cache-Status"])
       assert.same(cache_key, res_2.headers["X-Cache-Key"])
 
-      res_1 = assert(client_1:send {
-        method = "GET",
-        path = "/get",
+      res_1 = assert(client_1:get("/get", {
         headers = {
           host = "route-2.com",
         },
-      })
+      }))
 
       assert.res_status(200, res_1)
       assert.same("Miss", res_1.headers["X-Cache-Status"])
       cache_key2 = res_1.headers["X-Cache-Key"]
       assert.not_same(cache_key, cache_key2)
 
-      res_2 = assert(client_2:send {
-        method = "GET",
-        path = "/get",
+      res_2 = assert(client_2:get("/get", {
         headers = {
           host = "route-2.com",
         },
-      })
+      }))
 
       assert.res_status(200, res_2)
       assert.same("Miss", res_2.headers["X-Cache-Status"])
     end)
 
     it("propagates purges via cluster events mechanism", function()
-      local res_1 = assert(client_1:send {
-        method = "GET",
-        path = "/get",
+      local res_1 = assert(client_1:get("/get", {
         headers = {
           host = "route-1.com",
         },
-      })
+      }))
 
       assert.res_status(200, res_1)
       assert.same("Hit", res_1.headers["X-Cache-Status"])
 
-      local res_2 = assert(client_2:send {
-        method = "GET",
-        path = "/get",
+      local res_2 = assert(client_2:get("/get", {
         headers = {
           host = "route-1.com",
         },
-      })
+      }))
 
       assert.res_status(200, res_2)
       assert.same("Hit", res_2.headers["X-Cache-Status"])
 
       -- now purge the entry
-      local res = assert(admin_client_1:send {
-        method = "DELETE",
-        path = "/proxy-cache/" .. plugin1.id .. "/caches/" .. cache_key,
-      })
+      local res = assert(admin_client_1:delete("/proxy-cache/" .. plugin1.id .. "/caches/" .. cache_key))
 
       assert.res_status(204, res)
 
       helpers.wait_until(function()
         -- assert that the entity was purged from the second instance
-        res = assert(admin_client_2:send {
-          method = "GET",
-          path = "/proxy-cache/" .. plugin1.id .. "/caches/" .. cache_key,
-        })
+        res = assert(admin_client_2:get("/proxy-cache/" .. plugin1.id .. "/caches/" .. cache_key, {
+        }))
         res:read_body()
         return res.status == 404
       end, 10)
 
       -- refresh and purge with our second endpoint
-      res_1 = assert(client_1:send {
-        method = "GET",
-        path = "/get",
+      res_1 = assert(client_1:get("/get", {
         headers = {
           Host = "route-1.com",
         },
-      })
+      }))
 
       assert.res_status(200, res_1)
       assert.same("Miss", res_1.headers["X-Cache-Status"])
 
-      res_2 = assert(client_2:send {
-        method = "GET",
-        path = "/get",
+      res_2 = assert(client_2:get("/get", {
         headers = {
           host = "route-1.com",
         },
-      })
+      }))
 
       assert.res_status(200, res_2)
       assert.same("Miss", res_2.headers["X-Cache-Status"])
       assert.same(cache_key, res_2.headers["X-Cache-Key"])
 
       -- now purge the entry
-      res = assert(admin_client_1:send {
-        method = "DELETE",
-        path = "/proxy-cache/" .. cache_key,
-      })
+      res = assert(admin_client_1:delete("/proxy-cache/" .. cache_key))
 
       assert.res_status(204, res)
 
@@ -242,55 +218,42 @@ describe("proxy-cache invalidations via: " .. strategy, function()
 
       helpers.wait_until(function()
         -- assert that the entity was purged from the second instance
-        res = assert(admin_client_2:send {
-          method = "GET",
-          path = "/proxy-cache/" .. cache_key,
-        })
+        res = assert(admin_client_2:get("/proxy-cache/" .. cache_key, {
+        }))
         res:read_body()
         return res.status == 404
       end, 10)
     end)
 
     it("does not affect cache entries under other plugin instances", function()
-      local res = assert(admin_client_1:send {
-        method = "GET",
-        path = "/proxy-cache/" .. plugin2.id .. "/caches/" .. cache_key2,
-      })
+      local res = assert(admin_client_1:get("/proxy-cache/" .. plugin2.id .. "/caches/" .. cache_key2, {
+      }))
 
       assert.res_status(200, res)
 
-      res = assert(admin_client_2:send {
-        method = "GET",
-        path = "/proxy-cache/" .. plugin2.id .. "/caches/" .. cache_key2,
-      })
+      res = assert(admin_client_2:get("/proxy-cache/" .. plugin2.id .. "/caches/" .. cache_key2, {
+      }))
 
       assert.res_status(200, res)
     end)
 
     it("propagates global purges", function()
       do
-        local res = assert(admin_client_1:send {
-          method = "DELETE",
-          path = "/proxy-cache/",
-        })
-  
+        local res = assert(admin_client_1:delete("/proxy-cache/"))
+
         assert.res_status(204, res)
       end
 
       helpers.wait_until(function()
-        local res = assert(admin_client_1:send {
-          method = "GET",
-          path = "/proxy-cache/" .. plugin2.id .. "/caches/" .. cache_key2,
-        })
+        local res = assert(admin_client_1:get("/proxy-cache/" .. plugin2.id .. "/caches/" .. cache_key2, {
+        }))
         res:read_body()
         return res.status == 404
       end, 10)
 
       helpers.wait_until(function()
-        local res = assert(admin_client_2:send {
-          method = "GET",
-          path = "/proxy-cache/" .. plugin2.id .. "/caches/" .. cache_key2,
-        })
+        local res = assert(admin_client_2:get("/proxy-cache/" .. plugin2.id .. "/caches/" .. cache_key2, {
+        }))
         res:read_body()
         return res.status == 404
       end, 10)

--- a/spec/03-plugins/31-proxy-cache/04-invalidations_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/04-invalidations_spec.lua
@@ -1,8 +1,17 @@
-local helpers      = require "spec.helpers"
+local helpers = require "spec.helpers"
+
 
 
 local POLL_INTERVAL = 0.3
 
+local function get(client, host)
+  return assert(client:get("/get", {
+    headers = {
+      Host = host,
+      ["kong-debug"] = 1,
+    },
+  }))
+end
 
 for _, strategy in helpers.each_strategy() do
 describe("proxy-cache invalidations via: " .. strategy, function()
@@ -115,68 +124,38 @@ describe("proxy-cache invalidations via: " .. strategy, function()
 
     setup(function()
       -- prime cache entries on both instances
-      local res_1 = assert(client_1:get("/get", {
-        headers = {
-          Host = "route-1.com",
-          ["kong-debug"] = 1,
-        },
-      }))
+      local res_1 = get(client_1, "route-1.com")
 
       assert.res_status(200, res_1)
       assert.same("Miss", res_1.headers["X-Cache-Status"])
       cache_key = res_1.headers["X-Cache-Key"]
 
-      local res_2 = assert(client_2:get("/get", {
-        headers = {
-          host = "route-1.com",
-          ["kong-debug"] = 1,
-        },
-      }))
+      local res_2 = get(client_2, "route-1.com")
 
       assert.res_status(200, res_2)
       assert.same("Miss", res_2.headers["X-Cache-Status"])
       assert.same(cache_key, res_2.headers["X-Cache-Key"])
 
-      res_1 = assert(client_1:get("/get", {
-        headers = {
-          host = "route-2.com",
-          ["kong-debug"] = 1,
-        },
-      }))
+      res_1 = get(client_1, "route-2.com")
 
       assert.res_status(200, res_1)
       assert.same("Miss", res_1.headers["X-Cache-Status"])
       cache_key2 = res_1.headers["X-Cache-Key"]
       assert.not_same(cache_key, cache_key2)
 
-      res_2 = assert(client_2:get("/get", {
-        headers = {
-          host = "route-2.com",
-          ["kong-debug"] = 1,
-        },
-      }))
+      local res_2 = get(client_2, "route-2.com")
 
       assert.res_status(200, res_2)
       assert.same("Miss", res_2.headers["X-Cache-Status"])
     end)
 
     it("propagates purges via cluster events mechanism", function()
-      local res_1 = assert(client_1:get("/get", {
-        headers = {
-          host = "route-1.com",
-          ["kong-debug"] = 1,
-        },
-      }))
+      local res_1 = get(client_1, "route-1.com")
 
       assert.res_status(200, res_1)
       assert.same("Hit", res_1.headers["X-Cache-Status"])
 
-      local res_2 = assert(client_2:get("/get", {
-        headers = {
-          host = "route-1.com",
-          ["kong-debug"] = 1,
-        },
-      }))
+      local res_2 = get(client_2, "route-1.com")
 
       assert.res_status(200, res_2)
       assert.same("Hit", res_2.headers["X-Cache-Status"])
@@ -195,22 +174,12 @@ describe("proxy-cache invalidations via: " .. strategy, function()
       end, 10)
 
       -- refresh and purge with our second endpoint
-      res_1 = assert(client_1:get("/get", {
-        headers = {
-          Host = "route-1.com",
-          ["kong-debug"] = 1,
-        },
-      }))
+      res_1 = get(client_1, "route-1.com")
 
       assert.res_status(200, res_1)
       assert.same("Miss", res_1.headers["X-Cache-Status"])
 
-      res_2 = assert(client_2:get("/get", {
-        headers = {
-          host = "route-1.com",
-          ["kong-debug"] = 1,
-        },
-      }))
+      res_2 = get(client_2, "route-1.com")
 
       assert.res_status(200, res_2)
       assert.same("Miss", res_2.headers["X-Cache-Status"])

--- a/spec/03-plugins/31-proxy-cache/04-invalidations_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/04-invalidations_spec.lua
@@ -118,6 +118,7 @@ describe("proxy-cache invalidations via: " .. strategy, function()
       local res_1 = assert(client_1:get("/get", {
         headers = {
           Host = "route-1.com",
+          ["kong-debug"] = 1,
         },
       }))
 
@@ -128,6 +129,7 @@ describe("proxy-cache invalidations via: " .. strategy, function()
       local res_2 = assert(client_2:get("/get", {
         headers = {
           host = "route-1.com",
+          ["kong-debug"] = 1,
         },
       }))
 
@@ -138,6 +140,7 @@ describe("proxy-cache invalidations via: " .. strategy, function()
       res_1 = assert(client_1:get("/get", {
         headers = {
           host = "route-2.com",
+          ["kong-debug"] = 1,
         },
       }))
 
@@ -149,6 +152,7 @@ describe("proxy-cache invalidations via: " .. strategy, function()
       res_2 = assert(client_2:get("/get", {
         headers = {
           host = "route-2.com",
+          ["kong-debug"] = 1,
         },
       }))
 
@@ -160,6 +164,7 @@ describe("proxy-cache invalidations via: " .. strategy, function()
       local res_1 = assert(client_1:get("/get", {
         headers = {
           host = "route-1.com",
+          ["kong-debug"] = 1,
         },
       }))
 
@@ -169,6 +174,7 @@ describe("proxy-cache invalidations via: " .. strategy, function()
       local res_2 = assert(client_2:get("/get", {
         headers = {
           host = "route-1.com",
+          ["kong-debug"] = 1,
         },
       }))
 
@@ -192,6 +198,7 @@ describe("proxy-cache invalidations via: " .. strategy, function()
       res_1 = assert(client_1:get("/get", {
         headers = {
           Host = "route-1.com",
+          ["kong-debug"] = 1,
         },
       }))
 
@@ -201,6 +208,7 @@ describe("proxy-cache invalidations via: " .. strategy, function()
       res_2 = assert(client_2:get("/get", {
         headers = {
           host = "route-1.com",
+          ["kong-debug"] = 1,
         },
       }))
 


### PR DESCRIPTION
### Summary

Remove proxy cache headers from response if the kong debug is not set.
Adding Miss/Hit, Age and cache key to answer shouldn't be the default behavior.

### Full changelog

The following headers:
* X-Cache-Status
* X-Cache-Key
* Age

are now set only if the header kong-debug is set to 1

Refactor test to remove duplicated lines and use get, post and delete helpers instead of send