### PR TITLE
fix(proxy-cache) handle 204/304 responses without Content-Type

### DIFF
--- a/kong/plugins/proxy-cache/handler.lua
+++ b/kong/plugins/proxy-cache/handler.lua
@@ -163,25 +163,29 @@ local function cacheable_response(conf, cc)
   end
 
   do
-    local content_type = ngx.var.sent_http_content_type
+    local status = kong.response.get_status()
+    -- conform to RFC since 204/304 do not have Content-Type header
+    if status ~= 204 and status ~= 304 then
+      local content_type = ngx.var.sent_http_content_type
 
-    -- bail if we cannot examine this content type
-    if not content_type or type(content_type) == "table" or
-       content_type == "" then
+      -- bail if we cannot examine this content type
+      if not content_type or type(content_type) == "table" or
+        content_type == "" then
 
-      return false
-    end
-
-    local content_match = false
-    for i = 1, #conf.content_type do
-      if conf.content_type[i] == content_type then
-        content_match = true
-        break
+        return false
       end
-    end
 
-    if not content_match then
-      return false
+      local content_match = false
+      for i = 1, #conf.content_type do
+        if conf.content_type[i] == content_type then
+          content_match = true
+          break
+        end
+      end
+
+      if not content_match then
+        return false
+      end
     end
   end
 

--- a/spec/03-plugins/31-proxy-cache/02-access_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/02-access_spec.lua
@@ -1201,6 +1201,8 @@ do
 
         assert.res_status(304, res)
         assert.same("Hit", res.headers["X-Cache-Status"])
+        assert.is_nil(res.headers["Content-Type"])
+
       end)
 
       it("response status with 204 empty Content-Type", function()
@@ -1225,6 +1227,7 @@ do
 
         assert.res_status(204, res)
         assert.same("Hit", res.headers["X-Cache-Status"])
+        assert.is_nil(res.headers["Content-Type"])
       end)
     end)
 

--- a/spec/03-plugins/31-proxy-cache/02-access_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/02-access_spec.lua
@@ -210,7 +210,7 @@ do
         config = {
           strategy = policy,
           content_type = { "text/html; charset=utf-8", "application/json" },
-          response_code = { 200, 417 },
+          response_code = { 200, 204, 304, 417 },
           request_method = { "GET", "HEAD", "POST" },
           [policy] = policy_config,
         },
@@ -1179,6 +1179,53 @@ do
         assert.same("Hit", res.headers["X-Cache-Status"])
       end)
 
+     it("response status with 304 empty Content-Type", function()
+        local res = assert(client:send {
+          method = "GET",
+          path = "/status/304",
+          headers = {
+            host = "route-10.com",
+          },
+        })
+
+        assert.res_status(304, res)
+        assert.same("Miss", res.headers["X-Cache-Status"])
+
+        res = assert(client:send {
+          method = "GET",
+          path = "/status/304",
+          headers = {
+            host = "route-10.com",
+          },
+        })
+
+        assert.res_status(304, res)
+        assert.same("Hit", res.headers["X-Cache-Status"])
+      end)
+
+      it("response status with 204 empty Content-Type", function()
+        local res = assert(client:send {
+          method = "GET",
+          path = "/status/204",
+          headers = {
+            host = "route-10.com",
+          },
+        })
+
+        assert.res_status(204, res)
+        assert.same("Miss", res.headers["X-Cache-Status"])
+
+        res = assert(client:send {
+          method = "GET",
+          path = "/status/204",
+          headers = {
+            host = "route-10.com",
+          },
+        })
+
+        assert.res_status(204, res)
+        assert.same("Hit", res.headers["X-Cache-Status"])
+      end)
     end)
 
     describe("displays Kong core headers:", function()

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -691,6 +691,10 @@ http {
                 if not code then
                     return ngx.exit(ngx.HTTP_NOT_FOUND)
                 end
+                if code == 204 or code == 304 then
+                    return ngx.exit(code)
+                end
+
                 ngx.status = code
                 return mu.send_default_json_response({
                   code = code,


### PR DESCRIPTION
### Summary

According to the RFC 7231 & 7232, 204 and 304 should not have content type
header:

* 204 https://datatracker.ietf.org/doc/html/rfc7231#section-6.3.5
* 304 https://datatracker.ietf.org/doc/html/rfc7232#section-4.1

Initial commit from @adrien-f
see https://github.com/Kong/kong-plugin-proxy-cache/pull/34
