### PR TITLE
tests(pdk) make t/Util.pm findable by Perl >= 5.26

### DIFF
--- a/t/01-pdk/00-sanity.t
+++ b/t/01-pdk/00-sanity.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 #repeat_each(2);
 

--- a/t/01-pdk/01-table.t
+++ b/t/01-pdk/01-table.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/02-log/00-phase_checks.t
+++ b/t/01-pdk/02-log/00-phase_checks.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/02-log/01-sanity.t
+++ b/t/01-pdk/02-log/01-sanity.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 log_level('debug');
 

--- a/t/01-pdk/02-log/02-new.t
+++ b/t/01-pdk/02-log/02-new.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/02-log/03-set_format.t
+++ b/t/01-pdk/02-log/03-set_format.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/02-log/04-inspect.t
+++ b/t/01-pdk/02-log/04-inspect.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 plan tests => repeat_each() * (blocks() * 4 + 6);
 

--- a/t/01-pdk/02-log/05-set_serialize_value.t
+++ b/t/01-pdk/02-log/05-set_serialize_value.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 plan tests => 49;
 

--- a/t/01-pdk/02-log/06-deprecation.t
+++ b/t/01-pdk/02-log/06-deprecation.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 plan tests => repeat_each() * (blocks() * 4);
 

--- a/t/01-pdk/03-ip/01-is_trusted.t
+++ b/t/01-pdk/03-ip/01-is_trusted.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/04-request/00-phase_checks.t
+++ b/t/01-pdk/04-request/00-phase_checks.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/04-request/01-get_scheme.t
+++ b/t/01-pdk/04-request/01-get_scheme.t
@@ -2,7 +2,7 @@ use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use File::Spec;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_CERT_DIR} ||= File::Spec->catdir(server_root(), '..', 'certs');
 $ENV{TEST_NGINX_NXSOCK}   ||= html_dir();

--- a/t/01-pdk/04-request/02-get_host.t
+++ b/t/01-pdk/04-request/02-get_host.t
@@ -2,7 +2,7 @@ use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use File::Spec;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_CERT_DIR} ||= File::Spec->catdir(server_root(), '..', 'certs');
 $ENV{TEST_NGINX_NXSOCK}   ||= html_dir();

--- a/t/01-pdk/04-request/03-get_port.t
+++ b/t/01-pdk/04-request/03-get_port.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/04-request/04-get_forwarded_scheme.t
+++ b/t/01-pdk/04-request/04-get_forwarded_scheme.t
@@ -2,7 +2,7 @@ use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use File::Spec;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_CERT_DIR} ||= File::Spec->catdir(server_root(), '..', 'certs');
 $ENV{TEST_NGINX_NXSOCK}   ||= html_dir();

--- a/t/01-pdk/04-request/05-get_forwarded_host.t
+++ b/t/01-pdk/04-request/05-get_forwarded_host.t
@@ -2,7 +2,7 @@ use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use File::Spec;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_CERT_DIR} ||= File::Spec->catdir(server_root(), '..', 'certs');
 $ENV{TEST_NGINX_NXSOCK}   ||= html_dir();

--- a/t/01-pdk/04-request/06-get_forwarded_port.t
+++ b/t/01-pdk/04-request/06-get_forwarded_port.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_CERT_DIR} ||= File::Spec->catdir(server_root(), '..', 'certs');
 $ENV{TEST_NGINX_NXSOCK}   ||= html_dir();

--- a/t/01-pdk/04-request/07-get_http_version.t
+++ b/t/01-pdk/04-request/07-get_http_version.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/04-request/08-get_method.t
+++ b/t/01-pdk/04-request/08-get_method.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/04-request/09-get_path.t
+++ b/t/01-pdk/04-request/09-get_path.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/04-request/10-get_raw_query.t
+++ b/t/01-pdk/04-request/10-get_raw_query.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/04-request/11-get_query_arg.t
+++ b/t/01-pdk/04-request/11-get_query_arg.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/04-request/12-get_query.t
+++ b/t/01-pdk/04-request/12-get_query.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/04-request/13-get_header.t
+++ b/t/01-pdk/04-request/13-get_header.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/04-request/14-get_headers.t
+++ b/t/01-pdk/04-request/14-get_headers.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/04-request/15-get_raw_body.t
+++ b/t/01-pdk/04-request/15-get_raw_body.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/04-request/16-get_body.t
+++ b/t/01-pdk/04-request/16-get_body.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/04-request/17-get_path_with_query.t
+++ b/t/01-pdk/04-request/17-get_path_with_query.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/04-request/18-get_forwarded_path.t
+++ b/t/01-pdk/04-request/18-get_forwarded_path.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_CERT_DIR} ||= File::Spec->catdir(server_root(), '..', 'certs');
 $ENV{TEST_NGINX_NXSOCK}   ||= html_dir();

--- a/t/01-pdk/04-request/19-get_forwarded_prefix.t
+++ b/t/01-pdk/04-request/19-get_forwarded_prefix.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_CERT_DIR} ||= File::Spec->catdir(server_root(), '..', 'certs');
 $ENV{TEST_NGINX_NXSOCK}   ||= html_dir();

--- a/t/01-pdk/05-client/00-phase_checks.t
+++ b/t/01-pdk/05-client/00-phase_checks.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/05-client/01-get_ip.t
+++ b/t/01-pdk/05-client/01-get_ip.t
@@ -2,7 +2,7 @@ use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use Test::Nginx::Socket::Lua::Stream;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/05-client/02-get_forwarded_ip.t
+++ b/t/01-pdk/05-client/02-get_forwarded_ip.t
@@ -2,7 +2,7 @@ use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use Test::Nginx::Socket::Lua::Stream;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/05-client/03-get_port.t
+++ b/t/01-pdk/05-client/03-get_port.t
@@ -2,7 +2,7 @@ use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use Test::Nginx::Socket::Lua::Stream;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/05-client/04-get_forwarded_port.t
+++ b/t/01-pdk/05-client/04-get_forwarded_port.t
@@ -2,7 +2,7 @@ use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use Test::Nginx::Socket::Lua::Stream;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/05-client/05-get_credential.t
+++ b/t/01-pdk/05-client/05-get_credential.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/05-client/06-get_consumer.t
+++ b/t/01-pdk/05-client/06-get_consumer.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/05-client/07-authenticate.t
+++ b/t/01-pdk/05-client/07-authenticate.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/05-client/08-get_protocol.t
+++ b/t/01-pdk/05-client/08-get_protocol.t
@@ -2,7 +2,7 @@ use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use Test::Nginx::Socket::Lua::Stream;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_CERT_DIR} ||= File::Spec->catdir(server_root(), '..', 'certs');
 $ENV{TEST_NGINX_NXSOCK}   ||= html_dir();

--- a/t/01-pdk/05-client/09-load-consumer.t
+++ b/t/01-pdk/05-client/09-load-consumer.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/06-service-request/00-phase_checks.t
+++ b/t/01-pdk/06-service-request/00-phase_checks.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/06-service-request/01-set_scheme.t
+++ b/t/01-pdk/06-service-request/01-set_scheme.t
@@ -2,7 +2,7 @@ use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use File::Spec;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_CERT_DIR} ||= File::Spec->catdir(server_root(), '..', 'certs');
 $ENV{TEST_NGINX_NXSOCK}   ||= html_dir();

--- a/t/01-pdk/06-service-request/04-set_path.t
+++ b/t/01-pdk/06-service-request/04-set_path.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/06-service-request/05-set_raw_query.t
+++ b/t/01-pdk/06-service-request/05-set_raw_query.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/06-service-request/06-set_method.t
+++ b/t/01-pdk/06-service-request/06-set_method.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/06-service-request/07-set_body.t
+++ b/t/01-pdk/06-service-request/07-set_body.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/06-service-request/08-set_query.t
+++ b/t/01-pdk/06-service-request/08-set_query.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/06-service-request/09-set_header.t
+++ b/t/01-pdk/06-service-request/09-set_header.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/06-service-request/10-add_header.t
+++ b/t/01-pdk/06-service-request/10-add_header.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/06-service-request/11-clear_header.t
+++ b/t/01-pdk/06-service-request/11-clear_header.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/06-service-request/12-set_headers.t
+++ b/t/01-pdk/06-service-request/12-set_headers.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/06-service-request/13-set_raw_body.t
+++ b/t/01-pdk/06-service-request/13-set_raw_body.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/07-service-response/00-phase_checks.t
+++ b/t/01-pdk/07-service-response/00-phase_checks.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/07-service-response/01-get_status.t
+++ b/t/01-pdk/07-service-response/01-get_status.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/07-service-response/02-get_headers.t
+++ b/t/01-pdk/07-service-response/02-get_headers.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/07-service-response/03-get_header.t
+++ b/t/01-pdk/07-service-response/03-get_header.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/07-service-response/04-get_raw_body.t
+++ b/t/01-pdk/07-service-response/04-get_raw_body.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/07-service-response/05-get_body.t
+++ b/t/01-pdk/07-service-response/05-get_body.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/08-response/00-phase_checks.t
+++ b/t/01-pdk/08-response/00-phase_checks.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/08-response/01-get_status.t
+++ b/t/01-pdk/08-response/01-get_status.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/08-response/02-get_header.t
+++ b/t/01-pdk/08-response/02-get_header.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/08-response/03-get_headers.t
+++ b/t/01-pdk/08-response/03-get_headers.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/08-response/04-set_status.t
+++ b/t/01-pdk/08-response/04-set_status.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/08-response/05-set_header.t
+++ b/t/01-pdk/08-response/05-set_header.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/08-response/06-add_header.t
+++ b/t/01-pdk/08-response/06-add_header.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/08-response/07-clear_header.t
+++ b/t/01-pdk/08-response/07-clear_header.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/08-response/08-set_headers.t
+++ b/t/01-pdk/08-response/08-set_headers.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/08-response/09-set_raw_body.t
+++ b/t/01-pdk/08-response/09-set_raw_body.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/08-response/10-set_body.t
+++ b/t/01-pdk/08-response/10-set_body.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/08-response/11-exit.t
+++ b/t/01-pdk/08-response/11-exit.t
@@ -2,7 +2,7 @@ use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use Test::Nginx::Socket::Lua::Stream;
-use t::Util;
+do "./t/Util.pm";
 
 plan tests => repeat_each() * (blocks() * 4) + 10;
 

--- a/t/01-pdk/08-response/12-get_source.t
+++ b/t/01-pdk/08-response/12-get_source.t
@@ -1,6 +1,6 @@
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 plan tests => repeat_each() * (blocks() * 3) - 3;
 

--- a/t/01-pdk/08-response/13-error.t
+++ b/t/01-pdk/08-response/13-error.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/09-service/00-phase_checks.t
+++ b/t/01-pdk/09-service/00-phase_checks.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/09-service/01-set-upstream.t
+++ b/t/01-pdk/09-service/01-set-upstream.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/09-service/02-set-target.t
+++ b/t/01-pdk/09-service/02-set-target.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/09-service/03-set-tls-cert-key.t
+++ b/t/01-pdk/09-service/03-set-tls-cert-key.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/10-nginx/00-phase_checks.t
+++ b/t/01-pdk/10-nginx/00-phase_checks.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/10-nginx/01-get_subsystem.t
+++ b/t/01-pdk/10-nginx/01-get_subsystem.t
@@ -2,7 +2,7 @@ use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 use Test::Nginx::Socket::Lua::Stream;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/11-ctx.t
+++ b/t/01-pdk/11-ctx.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 no_long_string();
 

--- a/t/01-pdk/12-node/00-phase_checks.t
+++ b/t/01-pdk/12-node/00-phase_checks.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/12-node/01-get_id.t
+++ b/t/01-pdk/12-node/01-get_id.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/12-node/02-get_memory_stats.t
+++ b/t/01-pdk/12-node/02-get_memory_stats.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 master_on();
 workers(2);

--- a/t/01-pdk/12-node/03-get_hostname.t
+++ b/t/01-pdk/12-node/03-get_hostname.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 plan tests => repeat_each() * (blocks() * 3);
 

--- a/t/01-pdk/13-router/00-phase_checks.t
+++ b/t/01-pdk/13-router/00-phase_checks.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/13-router/01-get_route.t
+++ b/t/01-pdk/13-router/01-get_route.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/13-router/02-get_service.t
+++ b/t/01-pdk/13-router/02-get_service.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_NXSOCK} ||= html_dir();
 

--- a/t/01-pdk/14-client-tls/00-phase_checks.t
+++ b/t/01-pdk/14-client-tls/00-phase_checks.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 $ENV{TEST_NGINX_CERT_DIR} ||= File::Spec->catdir(server_root(), '..', 'certs');
 $ENV{TEST_NGINX_NXSOCK}   ||= html_dir();

--- a/t/02-global/01-init-pdk.t
+++ b/t/02-global/01-init-pdk.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 no_long_string();
 

--- a/t/02-global/02-set-named-ctx.t
+++ b/t/02-global/02-set-named-ctx.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 no_long_string();
 

--- a/t/02-global/03-namespaced_log.t
+++ b/t/02-global/03-namespaced_log.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
-use t::Util;
+do "./t/Util.pm";
 
 no_long_string();
 


### PR DESCRIPTION
In Perl 5.26 the `@INC` variable (used for finding libraries) does not
include the current working folder ('.') any more.

https://metacpan.org/pod/perl5260delta#Removal-of-the-current-directory-(%22.%22)-from-@INC

This is considered a security problem so some Linux distros have
backported this change. Perl 5.26 is the system Perl shipped by MacOS
Big Sur.

The fix consists on using `do` instead of `use`. `do` allows for
explicit filepaths, and the current folder (`.`) can be used directly
there.

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->
