### PR TITLE
chore(scripts) fix date used in changelog helper script

### DIFF
--- a/scripts/changelog-helper.lua
+++ b/scripts/changelog-helper.lua
@@ -130,9 +130,13 @@ local function get_comparison_commits(api, from_ref, to_ref)
 
   local commits = {}
   for commit in api.iterate_paged(fmt("/repos/kong/kong/commits?since=%s", latest_ancestor_iso8601)) do
-    if datetime_to_epoch(commit.commit.author.date) > latest_ancestor_epoch then
+    if datetime_to_epoch(commit.commit.committer.date) > latest_ancestor_epoch then
       commits[#commits + 1] = commit
+      --print("sha: ", commit.sha, ", date: ", commit.commit.committer.date, ", epoch: ", datetime_to_epoch(commit.commit.committer.date))
+    --else
+      --print("REJECTED sha: ", commit.sha, ", date: ", commit.commit.committer.date, ", epoch: ", datetime_to_epoch(commit.commit.committer.date), " > ", latest_ancestor_epoch)
     end
+
   end
 
   return commits


### PR DESCRIPTION
The script was using:

* `commit.commit.author.date`, which was when the commit was **written**

It should have been using this instead:

* `commit.commit.committer.date`, which is the last time the commit was
  modified/merged.

As a result of this change, the script now does not ignore some commits
that were previously discarded (they where originally written before the
appropriate period, but were merged inside the period)
