### PR TITLE
feat(pdk) add kong.response.get_raw_body and kong.response.set_raw_body

### DIFF
--- a/kong/pdk/response.lua
+++ b/kong/pdk/response.lua
@@ -19,12 +19,14 @@ local utils = require "kong.tools.utils"
 
 
 local ngx = ngx
+local arg = ngx.arg
 local fmt = string.format
 local type = type
 local find = string.find
 local lower = string.lower
 local error = error
 local pairs = pairs
+local concat = table.concat
 local coroutine = coroutine
 local normalize_header = checks.normalize_header
 local normalize_multi_header = checks.normalize_multi_header
@@ -517,14 +519,111 @@ local function new(self, major_version)
   end
 
 
-  --function _RESPONSE.set_raw_body(body)
-  --  -- TODO: implement, but how?
-  --end
+  ---
+  -- Returns the full body when the last chunk has been read.
   --
+  -- Calling this function will start to buffer the body in
+  -- an internal request context variable, and set the current
+  -- chunk (`ngx.arg[1]`) to `nil` when the chunk is not the
+  -- last one. Otherwise it returns the full buffered body.
   --
-  --function _RESPONSE.set_body(args, mimetype)
-  --  -- TODO: implement, but how?
-  --end
+  -- @function kong.response.get_raw_body
+  -- @phases `body_filter`
+  -- @treturn string body The full body when the last chunk has been read,
+  --                      otherwise returns `nil`
+  -- @usage
+  -- local body = kong.response.get_raw_body()
+  -- if body then
+  --   body = transform(body)
+  --   kong.response.set_raw_body(body)
+  -- end
+  function _RESPONSE.get_raw_body()
+    check_phase(PHASES.body_filter)
+
+    local body_buffer
+    local chunk = arg[1]
+    local eof = arg[2]
+    if eof then
+      body_buffer = self.ctx.core.body_buffer
+      if not body_buffer then
+        return chunk
+      end
+    end
+
+    if type(chunk) == "string" and chunk ~= "" then
+      if not eof then
+        body_buffer = self.ctx.core.body_buffer
+      end
+
+      if body_buffer then
+        local n = body_buffer.n + 1
+        body_buffer.n = n
+        body_buffer[n] = chunk
+
+      else
+        body_buffer = {
+          chunk,
+          n = 1
+        }
+
+        self.ctx.core.body_buffer = body_buffer
+      end
+    end
+
+    if eof then
+      if body_buffer then
+        body_buffer = concat(body_buffer, "", 1, body_buffer.n)
+      else
+        body_buffer = ""
+      end
+
+      arg[1] = body_buffer
+      return body_buffer
+    end
+
+    arg[1] = nil
+    return nil
+  end
+
+
+  ---
+  -- Sets the body of the response
+  --
+  -- The `body` argument must be a string and will not be processed in any way.
+  -- This function cannot anymore change the `Content-Length` header if one was
+  -- added. So if you decide to use this function, the `Content-Length` header
+  -- should also be cleared, e.g. in `header_filter` phase.
+  --
+  -- @function kong.response.set_raw_body
+  -- @phases `body_filter`
+  -- @tparam string body The raw body
+  -- @return Nothing; throws an error on invalid inputs.
+  -- @usage
+  -- kong.response.set_raw_body("Hello, world!")
+  -- -- or
+  -- local body = kong.response.get_raw_body()
+  -- if body then
+  --   body = transform(body)
+  --   kong.response.set_raw_body(body)
+  -- end
+  function _RESPONSE.set_raw_body(body)
+    check_phase(PHASES.body_filter)
+
+    if type(body) ~= "string" then
+      error("body must be a string", 2)
+    end
+
+    if body == "" then -- Needed by Nginx
+      arg[1] = "\n"
+    else
+      arg[1] = body
+    end
+
+    arg[2] = true
+
+    self.ctx.core.body_buffer = nil
+  end
+
 
   local function is_grpc_request()
     local req_ctype = ngx.var.content_type

--- a/kong/plugins/proxy-cache/handler.lua
+++ b/kong/plugins/proxy-cache/handler.lua
@@ -209,7 +209,7 @@ end
 
 
 local ProxyCacheHandler = {
-  VERSION  = "1.3.1",
+  VERSION  = "1.3.2",
   PRIORITY = 100,
 }
 
@@ -396,12 +396,8 @@ function ProxyCacheHandler:body_filter(conf)
     return
   end
 
-  local chunk = ngx.arg[1]
-  local eof   = ngx.arg[2]
-
-  proxy_cache.res_body = (proxy_cache.res_body or "") .. (chunk or "")
-
-  if eof then
+  local body = kong.response.get_raw_body()
+  if body then
     local strategy = require(STRATEGY_PATH)({
       strategy_name = conf.strategy,
       strategy_opts = conf[conf.strategy],
@@ -410,8 +406,8 @@ function ProxyCacheHandler:body_filter(conf)
     local res = {
       status    = kong.response.get_status(),
       headers   = proxy_cache.res_headers,
-      body      = proxy_cache.res_body,
-      body_len  = #proxy_cache.res_body,
+      body      = body,
+      body_len  = #body,
       timestamp = time(),
       ttl       = proxy_cache.res_ttl,
       version   = CACHE_VERSION,

--- a/t/01-pdk/08-response/00-phase_checks.t
+++ b/t/01-pdk/08-response/00-phase_checks.t
@@ -174,6 +174,30 @@ qq{
                 body_filter   = false,
                 log           = false,
                 admin_api     = true,
+            }, {
+                method        = "get_raw_body",
+                args          = { },
+                init_worker   = false,
+                certificate   = false,
+                rewrite       = false,
+                access        = false,
+                header_filter = false,
+                response      = false,
+                body_filter   = true,
+                log           = false,
+                admin_api     = false,
+            }, {
+                method        = "set_raw_body",
+                args          = { "lorem, ipsum" },
+                init_worker   = false,
+                certificate   = false,
+                rewrite       = false,
+                access        = false,
+                header_filter = false,
+                response      = false,
+                body_filter   = true,
+                log           = false,
+                admin_api     = false,
             }
         }
 

--- a/t/01-pdk/08-response/09-set_raw_body.t
+++ b/t/01-pdk/08-response/09-set_raw_body.t
@@ -3,23 +3,124 @@ use warnings FATAL => 'all';
 use Test::Nginx::Socket::Lua;
 do "./t/Util.pm";
 
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
+
 plan tests => repeat_each() * (blocks() * 3);
 
 run_tests();
 
 __DATA__
 
-=== TEST 1: response.set_raw_body() sets raw body
+=== TEST 1: response.set_raw_body() errors if not a string
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
         content_by_lua_block {
-            -- TODO: implement
+        }
+        header_filter_by_lua_block {
+            ngx.status = 200
+            ngx.header["Content-Length"] = nil
+        }
+        body_filter_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            local pok, err = pcall(pdk.response.set_raw_body, 0)
+            if not pok then
+                pdk.response.set_raw_body(err .. "\n")
+            end
         }
     }
 --- request
 GET /t
 --- response_body
+body must be a string
+--- no_error_log
+[error]
 
+
+
+=== TEST 2: response.set_raw_body() errors if given no arguments
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+        }
+        header_filter_by_lua_block {
+            ngx.status = 200
+            ngx.header["Content-Length"] = nil
+        }
+        body_filter_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            local pok, err = pcall(pdk.response.set_raw_body)
+            if not pok then
+                pdk.response.set_raw_body(err .. "\n")
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+body must be a string
+--- no_error_log
+[error]
+
+
+
+=== TEST 3: response.set_raw_body() accepts an empty string
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            ngx.say("Default Content")
+        }
+        header_filter_by_lua_block {
+            ngx.status = 200
+            ngx.header["Content-Length"] = nil
+        }
+        body_filter_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            local pok, err = pcall(pdk.response.set_raw_body, "")
+            if pok then
+                ngx.arg[1] = "Empty Body:" .. (ngx.arg[1] or "")
+            else
+                ngx.arg[1] = "Error:" .. (err or "") .. "\n"
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+Empty Body:
+--- no_error_log
+[error]
+
+
+
+=== TEST 4: response.set_raw_body() sets raw body
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+        }
+        header_filter_by_lua_block {
+            ngx.status = 200
+            ngx.header["Content-Length"] = nil
+        }
+        body_filter_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            pdk.response.set_raw_body("Hello, World!\n")
+        }
+    }
+--- request
+GET /t
+--- response_body
+Hello, World!
 --- no_error_log
 [error]

--- a/t/01-pdk/08-response/14-get_raw_body.t
+++ b/t/01-pdk/08-response/14-get_raw_body.t
@@ -1,0 +1,75 @@
+use strict;
+use warnings FATAL => 'all';
+use Test::Nginx::Socket::Lua;
+do "./t/Util.pm";
+
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
+
+plan tests => repeat_each() * (blocks() * 3);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: response.get_raw_body() gets raw body
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            ngx.say("Hello, Content by Lua Block")
+        }
+        body_filter_by_lua_block {
+            ngx.ctx.called = (ngx.ctx.called or 0) + 1
+
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            local body = pdk.response.get_raw_body()
+            if body then
+                pdk.response.set_raw_body(body .. "Enhanced by Body Filter\nCalled "
+                                               .. ngx.ctx.called .. " times\n")
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+Hello, Content by Lua Block
+Enhanced by Body Filter
+Called 2 times
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: response.get_raw_body() gets raw body when chunked
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        echo -n 'Hello, ';
+        echo 'Content by Lua Block';
+
+        body_filter_by_lua_block {
+            ngx.ctx.called = (ngx.ctx.called or 0) + 1
+
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            local body = pdk.response.get_raw_body()
+            if body then
+                if body == "Hello, Content by Lua Block\n" then
+                    pdk.response.set_raw_body(body .. "Enhanced by Body Filter\nCalled " .. ngx.ctx.called ..  " times\n")
+                else
+                    pdk.response.set_raw_body("Wrong body")
+                end
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+Hello, Content by Lua Block
+Enhanced by Body Filter
+Called 3 times
+--- no_error_log
+[error]


### PR DESCRIPTION
### Summary

Adds two new PDK functions that currently only work on `body_filter` phase:

1. kong.response.get_raw_body
2. kong.response.set_raw_body

The `body_filter` phase may be called for each chunk. Sometimes plugins need the full body. If all plugins try to buffer the response, it leads to multiple buffers and even buggy situations. Thus, `kong.response.get_raw_body` was added.

The `kong.response.set_raw_body` as a better way to do:

```
ngx.arg[1] = "hello"
ngx.arg[2] = true
```

in `body_filter` phase. It also clears the `buffer` if one was created by' `kong.response.get_raw_body`.

This also updates two core plugins to use those new functions.