### PR TITLE
fix(clustering) add unknown fields for removal with older dataplanes

### DIFF
--- a/kong/clustering/compat/removed_fields.lua
+++ b/kong/clustering/compat/removed_fields.lua
@@ -38,5 +38,18 @@ return {
     syslog = {
       "facility",
     },
+  },
+
+  -- Any dataplane older than 2.6.0
+  [2005999999] = {
+    aws_lambda = {
+      "base64_encode_body",
+    },
+    grpc_web = {
+      "allow_origin_header",
+    },
+    request_termination = {
+      "echo",
+    },
   }
 }

--- a/spec/01-unit/19-hybrid/03-fields-removal_spec.lua
+++ b/spec/01-unit/19-hybrid/03-fields-removal_spec.lua
@@ -48,6 +48,15 @@ describe("kong.clustering.control_plane", function()
         "read_timeout",
         "send_timeout",
       },
+      aws_lambda = {
+        "base64_encode_body",
+      },
+      grpc_web = {
+        "allow_origin_header",
+      },
+      request_termination = {
+        "echo",
+      },
     }, cp._get_removed_fields(2003000000))
 
     assert.same({
@@ -60,7 +69,16 @@ describe("kong.clustering.control_plane", function()
       },
       syslog = {
         "facility",
-      }
+      },
+      aws_lambda = {
+        "base64_encode_body",
+      },
+      grpc_web = {
+        "allow_origin_header",
+      },
+      request_termination = {
+        "echo",
+      },
     }, cp._get_removed_fields(2003003003))
 
     assert.same({
@@ -73,9 +91,18 @@ describe("kong.clustering.control_plane", function()
       },
       syslog = {
         "facility",
-      }
+      },
+      aws_lambda = {
+        "base64_encode_body",
+      },
+      grpc_web = {
+        "allow_origin_header",
+      },
+      request_termination = {
+        "echo",
+      },
     }, cp._get_removed_fields(2003004000))
-  
+
     assert.same({
       redis = {
         "connect_timeout",
@@ -86,14 +113,46 @@ describe("kong.clustering.control_plane", function()
       },
       syslog = {
         "facility",
-      }
+      },
+      aws_lambda = {
+        "base64_encode_body",
+      },
+      grpc_web = {
+        "allow_origin_header",
+      },
+      request_termination = {
+        "echo",
+      },
     }, cp._get_removed_fields(2004001000))
 
-    assert.same(nil, cp._get_removed_fields(2004001002))
-    assert.same(nil, cp._get_removed_fields(2005000000))
+    assert.same({
+      aws_lambda = {
+        "base64_encode_body",
+      },
+      grpc_web = {
+        "allow_origin_header",
+      },
+      request_termination = {
+        "echo",
+      },
+    }, cp._get_removed_fields(2004001002))
+
+    assert.same({
+      aws_lambda = {
+        "base64_encode_body",
+      },
+      grpc_web = {
+        "allow_origin_header",
+      },
+      request_termination = {
+        "echo",
+      },
+    }, cp._get_removed_fields(2005000000))
+
+    assert.same(nil, cp._get_removed_fields(2006000000))
   end)
 
-  it("removing unknonwn fields", function()
+  it("removing unknown fields", function()
     local test_with = function(payload, dp_version)
       local has_update, deflated_payload, err = cp._update_compatible_payload(
         payload, dp_version


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Fix version compatibility with older dataplanes connected newer control plane containing schema changes for `aws-lambda`, `grpc-web`, and `request-termination`

**Note**: `aws-lambda` and `grpc-web` minor (or patch) versions still need to be bumped as their are new features which were incorporated during the importing of the plugins into the repo.

- aws-lambda comparison from previous Kong Gateway (OSS) 2.5.1 release; https://github.com/Kong/kong-plugin-aws-lambda/compare/3.5.4...master
- grpc-web comparison from previous Kong Gateway (OSS) 2.5.1 release; https://github.com/Kong/kong-plugin-grpc-web/compare/v0.2.0...master

### Full changelog

* fix(clustering) add unknown fields for removal with older dataplanes
