### PR TITLE
feat(cors) support for CORS-RFC1918

### DIFF
--- a/kong/plugins/cors/handler.lua
+++ b/kong/plugins/cors/handler.lua
@@ -189,6 +189,23 @@ local function configure_credentials(conf, allow_all, header_filter)
 end
 
 
+local function configure_private_network(conf)
+  local set_header = kong.response.set_header
+
+  if not conf.private_network
+     or conf.private_network == "default"
+  then
+    return
+  end
+
+  if conf.private_network == "enabled" then
+    set_header("Access-Control-Allow-Private-Network", true)
+  else
+    set_header("Access-Control-Allow-Private-Network", false)
+  end
+end
+
+
 function CorsHandler:access(conf)
   if kong.request.get_method() ~= "OPTIONS"
      or not kong.request.get_header("Origin")
@@ -208,6 +225,8 @@ function CorsHandler:access(conf)
 
   local allow_all = configure_origin(conf, false)
   configure_credentials(conf, allow_all, false)
+
+  configure_private_network(conf)
 
   local set_header = kong.response.set_header
 
@@ -243,6 +262,8 @@ function CorsHandler:header_filter(conf)
 
   local allow_all = configure_origin(conf, true)
   configure_credentials(conf, allow_all, true)
+
+  configure_private_network(conf)
 
   if conf.exposed_headers and #conf.exposed_headers > 0 then
     kong.response.set_header("Access-Control-Expose-Headers",

--- a/kong/plugins/cors/schema.lua
+++ b/kong/plugins/cors/schema.lua
@@ -14,6 +14,12 @@ local METHODS = {
   "CONNECT",
 }
 
+local PRIVATE_NETWORKS = {
+  "default",
+  "enabled",
+  "disabled",
+}
+
 
 local function validate_asterisk_or_regex(value)
   if value == "*" or is_regex(value) then
@@ -48,6 +54,11 @@ return {
           }, }, },
           { max_age = { type = "number" }, },
           { credentials = { type = "boolean", required = true, default = false }, },
+          { private_network = {
+              type = "string",
+              default = 'default',
+              one_of = PRIVATE_NETWORKS,
+          }, },
           { preflight_continue = { type = "boolean", required = true, default = false }, },
     }, }, },
   },


### PR DESCRIPTION
The **CORS-RFC1918** is [https://wicg.github.io/private-network-access/](https://wicg.github.io/private-network-access/)


**Default** blocking requests to private networks from insecure public websites starting in Chrome 94.

Chrome blog is [https://developer.chrome.com/blog/private-network-access-update/](https://developer.chrome.com/blog/private-network-access-update/)



### Changes

* add `private_network` option to **cors**
* set `Access-Control-Allow-Private-Network` header to response
