### PR TITLE
tests(balancer) port remaining balancer tests from lua-resty-dns-client.

### DIFF
--- a/kong/runloop/balancer/balancers.lua
+++ b/kong/runloop/balancer/balancers.lua
@@ -1,7 +1,7 @@
 
 
 local upstreams = require "kong.runloop.balancer.upstreams"
-local targets = require "kong.runloop.balancer.targets"
+local targets
 local healthcheckers
 local dns_utils = require "resty.dns.utils"
 
@@ -49,6 +49,7 @@ balancers_M.errors = setmetatable({
 
 
 function balancers_M.init()
+  targets = require "kong.runloop.balancer.targets"
   healthcheckers = require "kong.runloop.balancer.healthcheckers"
 end
 
@@ -303,6 +304,9 @@ function balancer_mt:setAddressStatus(address, available)
   address.target.unavailableWeight = address.target.unavailableWeight + delta
   self.unavailableWeight = self.unavailableWeight + delta
   self:updateStatus()
+  if self.algorithm and self.algorithm.afterHostUpdate then
+    self.algorithm:afterHostUpdate()
+  end
   return true
 end
 
@@ -350,12 +354,6 @@ function balancer_mt:addAddress(target, entry)
   local entry_ip = entry.address or entry.target
   local entry_port = (entry.port ~= 0 and entry.port) or target.port
   local addresses = target.addresses
-  for _, addr in ipairs(addresses) do
-    if addr.ip == entry_ip and addr.port == entry_port then
-      -- already there, should we update something? add weights?
-      return
-    end
-  end
 
   local weight = entry.weight  -- this is nil for anything else than SRV
   if weight == 0 then
@@ -383,6 +381,14 @@ function balancer_mt:addAddress(target, entry)
   self.totalWeight = self.totalWeight + weight
   self:updateStatus()
 
+  if self.callback then
+    self:callback("added", addr, addr.ip, addr.port, addr.target.name, addr.hostHeader)
+  end
+
+  if self.algorithm and self.algorithm.afterHostUpdate then
+    self.algorithm:afterHostUpdate()
+  end
+
   return true
 end
 
@@ -407,6 +413,9 @@ function balancer_mt:changeWeight(target, entry, newWeight)
 
       addr.weight = newWeight
       self:updateStatus()
+      if self.algorithm and self.algorithm.afterHostUpdate then
+        self.algorithm:afterHostUpdate()
+      end
       return addr
     end
   end
@@ -546,6 +555,10 @@ end
 
 
 function balancer_mt:getPeer(...)
+  if not self.healthy then
+    return nil, "Balancer is unhealthy"
+  end
+
   if not self.algorithm or not self.algorithm.afterHostUpdate then
     return
   end

--- a/kong/runloop/balancer/least_connections.lua
+++ b/kong/runloop/balancer/least_connections.lua
@@ -131,7 +131,7 @@ function lc:getPeer(cacheOnly, handle, hashValue)
       break
     end
 
-    if port ~= self.errors.ERR_DNS_UPDATED then
+    if port ~= balancers.errors.ERR_DNS_UPDATED then
       -- an unknown error
       break
     end

--- a/kong/runloop/balancer/targets.lua
+++ b/kong/runloop/balancer/targets.lua
@@ -10,7 +10,7 @@ local singletons = require "kong.singletons"
 
 local dns_client = require "resty.dns.client"
 local upstreams = require "kong.runloop.balancer.upstreams"
-local balancers   -- require at init time to avoid dependency loop
+local balancers = require "kong.runloop.balancer.balancers"
 local dns_utils = require "resty.dns.utils"
 
 local ngx = ngx
@@ -41,10 +41,10 @@ local resolve_timer_callback
 local queryDns
 
 function targets_M.init()
-  require("kong.tools.dns")(kong.configuration)    -- configure DNS client
-  balancers = require "kong.runloop.balancer.balancers"
+  dns_client = require("kong.tools.dns")(kong.configuration)    -- configure DNS client
   ngx.timer.every(1, resolve_timer_callback)
 end
+
 
 local _rtype_to_name
 function targets_M.get_dns_name_from_record_type(rtype)

--- a/spec/01-unit/09-balancer/01-generic_spec.lua
+++ b/spec/01-unit/09-balancer/01-generic_spec.lua
@@ -1,0 +1,1803 @@
+
+local client -- forward declaration
+local dns_utils = require "resty.dns.utils"
+local helpers = require "spec.helpers.dns"
+local dnsSRV = function(...) return helpers.dnsSRV(client, ...) end
+local dnsA = function(...) return helpers.dnsA(client, ...) end
+local dnsExpire = helpers.dnsExpire
+
+local mocker = require "spec.fixtures.mocker"
+local utils = require "kong.tools.utils"
+
+local ws_id = utils.uuid()
+
+
+local unset_register = {}
+local function setup_block()
+  local function mock_cache(cache_table, limit)
+    return {
+      safe_set = function(self, k, v)
+        if limit then
+          local n = 0
+          for _, _ in pairs(cache_table) do
+            n = n + 1
+          end
+          if n >= limit then
+            return nil, "no memory"
+          end
+        end
+        cache_table[k] = v
+        return true
+      end,
+      get = function(self, k, _, fn, arg)
+        if cache_table[k] == nil then
+          cache_table[k] = fn(arg)
+        end
+        return cache_table[k]
+      end,
+    }
+  end
+
+  local cache_table = {}
+  local function register_unsettter(f)
+    table.insert(unset_register, f)
+  end
+
+  mocker.setup(register_unsettter, {
+    kong = {
+      configuration = {
+        --worker_consistency = consistency,
+        worker_state_update_frequency = 0.1,
+      },
+      core_cache = mock_cache(cache_table),
+    },
+    ngx = {
+      ctx = {
+        workspace = ws_id,
+      }
+    }
+  })
+end
+
+local function unsetup_block()
+  for _, f in ipairs(unset_register) do
+    f()
+  end
+end
+
+
+local balancers, targets
+
+local upstream_index = 0
+
+local function new_balancer(algorithm)
+  upstream_index = upstream_index + 1
+  local upname="upstream_" .. upstream_index
+  local hc_defaults = {
+    active = {
+      timeout = 1,
+      concurrency = 10,
+      http_path = "/",
+      healthy = {
+        interval = 0,  -- 0 = probing disabled by default
+        http_statuses = { 200, 302 },
+        successes = 0, -- 0 = disabled by default
+      },
+      unhealthy = {
+        interval = 0, -- 0 = probing disabled by default
+        http_statuses = { 429, 404,
+                          500, 501, 502, 503, 504, 505 },
+        tcp_failures = 0,  -- 0 = disabled by default
+        timeouts = 0,      -- 0 = disabled by default
+        http_failures = 0, -- 0 = disabled by default
+      },
+    },
+    passive = {
+      healthy = {
+        http_statuses = { 200, 201, 202, 203, 204, 205, 206, 207, 208, 226,
+                          300, 301, 302, 303, 304, 305, 306, 307, 308 },
+        successes = 0,
+      },
+      unhealthy = {
+        http_statuses = { 429, 500, 503 },
+        tcp_failures = 0,  -- 0 = circuit-breaker disabled by default
+        timeouts = 0,      -- 0 = circuit-breaker disabled by default
+        http_failures = 0, -- 0 = circuit-breaker disabled by default
+      },
+    },
+  }
+  local my_upstream = { id=upname, name=upname, ws_id=ws_id, slots=10, healthchecks=hc_defaults, algorithm=algorithm }
+  local b = (balancers.create_balancer(my_upstream, true))
+
+  return b
+end
+
+local function add_target(b, name, port, weight)
+
+  -- adding again changes weight
+  for _, prev_target in ipairs(b.targets) do
+    if prev_target.name == name and prev_target.port == port then
+      local entry = {port = port}
+      for _, addr in ipairs(prev_target.addresses) do
+        entry.address = addr.ip
+        b:changeWeight(prev_target, entry, weight)
+      end
+      prev_target.weight = weight
+      return prev_target
+    end
+  end
+
+  -- add new
+  local upname = b.upstream and b.upstream.name or b.upstream_id
+  local target = {
+    upstream = name or upname,
+    balancer = b,
+    name = name,
+    nameType = dns_utils.hostnameType(name),
+    addresses = {},
+    port = port or 8000,
+    weight = weight or 100,
+    totalWeight = 0,
+    unavailableWeight = 0,
+  }
+
+  table.insert(b.targets, target)
+  targets.resolve_targets(b.targets)
+
+  return target
+end
+
+
+for _, algorithm in ipairs{ "consistent-hashing", "least-connections", "round-robin" } do
+
+  describe("[" .. algorithm .. "]", function()
+
+    local snapshot
+
+    setup(function()
+      _G.package.loaded["resty.dns.client"] = nil -- make sure module is reloaded
+      _G.package.loaded["kong.runloop.balancer.targets"] = nil -- make sure module is reloaded
+
+      local singletons = require "kong.singletons"
+      singletons.worker_events = require "resty.worker.events"
+      singletons.db = {}
+
+      client = require "resty.dns.client"
+      targets = require "kong.runloop.balancer.targets"
+      balancers = require "kong.runloop.balancer.balancers"
+      local healthcheckers = require "kong.runloop.balancer.healthcheckers"
+      healthcheckers.init()
+      balancers.init()
+
+      singletons.worker_events.configure({
+        shm = "kong_process_events", -- defined by "lua_shared_dict"
+        timeout = 5,            -- life time of event data in shm
+        interval = 1,           -- poll interval (seconds)
+
+        wait_interval = 0.010,  -- wait before retry fetching event data
+        wait_max = 0.5,         -- max wait time before discarding event
+      })
+
+      local function empty_each()
+        return function() end
+      end
+
+      singletons.db = {
+        targets = {
+          each = empty_each,
+          select_by_upstream_raw = function()
+            return {}
+          end
+        },
+        upstreams = {
+          each = empty_each,
+          select = function() end,
+        },
+      }
+
+      singletons.core_cache = {
+        _cache = {},
+        get = function(self, key, _, loader, arg)
+          local v = self._cache[key]
+          if v == nil then
+            v = loader(arg)
+            self._cache[key] = v
+          end
+          return v
+        end,
+        invalidate_local = function(self, key)
+          self._cache[key] = nil
+        end
+      }
+
+    end)
+
+
+    before_each(function()
+      setup_block()
+      assert(client.init {
+        hosts = {},
+        resolvConf = {
+          "nameserver 8.8.8.8"
+        },
+      })
+      snapshot = assert:snapshot()
+      assert:set_parameter("TableFormatLevel", 10)
+    end)
+
+
+    after_each(function()
+      snapshot:revert()  -- undo any spying/stubbing etc.
+      unsetup_block()
+      collectgarbage()
+      collectgarbage()
+    end)
+
+
+    describe("health:", function()
+
+      local b
+
+      before_each(function()
+        b = new_balancer(algorithm)
+        b.healthThreshold = 50
+      end)
+
+      after_each(function()
+        b = nil
+      end)
+
+      it("empty balancer is unhealthy", function()
+        assert.is_false((b:getStatus().healthy))
+      end)
+
+      it("adding first address marks healthy", function()
+        assert.is_false(b:getStatus().healthy)
+        add_target(b, "127.0.0.1", 8000, 100)
+        assert.is_true(b:getStatus().healthy)
+      end)
+
+      it("dropping below the health threshold marks unhealthy", function()
+        assert.is_false(b:getStatus().healthy)
+        add_target(b, "127.0.0.1", 8000, 100)
+        add_target(b, "127.0.0.2", 8000, 100)
+        add_target(b, "127.0.0.3", 8000, 100)
+        assert.is_true(b:getStatus().healthy)
+        b:setAddressStatus(b:findAddress("127.0.0.2", 8000, "127.0.0.2"), false)
+        assert.is_true(b:getStatus().healthy)
+        b:setAddressStatus(b:findAddress("127.0.0.3", 8000, "127.0.0.3"), false)
+        assert.is_false(b:getStatus().healthy)
+      end)
+
+      it("rising above the health threshold marks healthy", function()
+        assert.is_false(b:getStatus().healthy)
+        add_target(b, "127.0.0.1", 8000, 100)
+        add_target(b, "127.0.0.2", 8000, 100)
+        add_target(b, "127.0.0.3", 8000, 100)
+        b:setAddressStatus(b:findAddress("127.0.0.2", 8000, "127.0.0.2"), false)
+        b:setAddressStatus(b:findAddress("127.0.0.3", 8000, "127.0.0.3"), false)
+        assert.is_false(b:getStatus().healthy)
+        b:setAddressStatus(b:findAddress("127.0.0.2", 8000, "127.0.0.2"), true)
+        assert.is_true(b:getStatus().healthy)
+      end)
+
+    end)
+
+
+
+    describe("weights:", function()
+
+      local b
+
+      before_each(function()
+        b = new_balancer(algorithm)
+        add_target(b, "127.0.0.1", 8000, 100)  -- add 1 initial host
+      end)
+
+      after_each(function()
+        b = nil
+      end)
+
+
+
+      describe("(A)", function()
+
+        it("adding a host",function()
+          dnsA({
+            { name = "arecord.tst", address = "1.2.3.4" },
+            { name = "arecord.tst", address = "5.6.7.8" },
+          })
+
+          assert.same({
+            healthy = true,
+            weight = {
+              total = 100,
+              available = 100,
+              unavailable = 0
+            },
+            hosts = {
+              {
+                host = "127.0.0.1",
+                port = 8000,
+                dns = "A",
+                nodeWeight = 100,
+                weight = {
+                  total = 100,
+                  available = 100,
+                  unavailable = 0
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "127.0.0.1",
+                    port = 8000,
+                    weight = 100
+                  },
+                },
+              },
+            },
+          }, b:getStatus())
+
+          add_target(b, "arecord.tst", 8001, 25)
+          assert.same({
+            healthy = true,
+            weight = {
+              total = 150,
+              available = 150,
+              unavailable = 0
+            },
+            hosts = {
+              {
+                host = "127.0.0.1",
+                port = 8000,
+                dns = "A",
+                nodeWeight = 100,
+                weight = {
+                  total = 100,
+                  available = 100,
+                  unavailable = 0
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "127.0.0.1",
+                    port = 8000,
+                    weight = 100
+                  },
+                },
+              },
+              {
+                host = "arecord.tst",
+                port = 8001,
+                dns = "A",
+                nodeWeight = 25,
+                weight = {
+                  total = 50,
+                  available = 50,
+                  unavailable = 0
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "1.2.3.4",
+                    port = 8001,
+                    weight = 25
+                  },
+                  {
+                    healthy = true,
+                    ip = "5.6.7.8",
+                    port = 8001,
+                    weight = 25
+                  },
+                },
+              },
+            },
+          }, b:getStatus())
+        end)
+
+        it("switching address availability",function()
+          dnsA({
+            { name = "arecord.tst", address = "1.2.3.4" },
+            { name = "arecord.tst", address = "5.6.7.8" },
+          })
+
+          assert.same({
+            healthy = true,
+            weight = {
+              total = 100,
+              available = 100,
+              unavailable = 0
+            },
+            hosts = {
+              {
+                host = "127.0.0.1",
+                port = 8000,
+                dns = "A",
+                nodeWeight = 100,
+                weight = {
+                  total = 100,
+                  available = 100,
+                  unavailable = 0
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "127.0.0.1",
+                    port = 8000,
+                    weight = 100
+                  },
+                },
+              },
+            },
+          }, b:getStatus())
+
+          add_target(b, "arecord.tst", 8001, 25)
+          assert.same({
+            healthy = true,
+            weight = {
+              total = 150,
+              available = 150,
+              unavailable = 0
+            },
+            hosts = {
+              {
+                host = "127.0.0.1",
+                port = 8000,
+                dns = "A",
+                nodeWeight = 100,
+                weight = {
+                  total = 100,
+                  available = 100,
+                  unavailable = 0
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "127.0.0.1",
+                    port = 8000,
+                    weight = 100
+                  },
+                },
+              },
+              {
+                host = "arecord.tst",
+                port = 8001,
+                dns = "A",
+                nodeWeight = 25,
+                weight = {
+                  total = 50,
+                  available = 50,
+                  unavailable = 0
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "1.2.3.4",
+                    port = 8001,
+                    weight = 25
+                  },
+                  {
+                    healthy = true,
+                    ip = "5.6.7.8",
+                    port = 8001,
+                    weight = 25
+                  },
+                },
+              },
+            },
+          }, b:getStatus())
+
+          -- switch to unavailable
+          assert(b:setAddressStatus(b:findAddress("1.2.3.4", 8001, "arecord.tst"), false))
+          add_target(b, "arecord.tst", 8001, 25)
+          assert.same({
+            healthy = true,
+            weight = {
+              total = 150,
+              available = 125,
+              unavailable = 25
+            },
+            hosts = {
+              {
+                host = "127.0.0.1",
+                port = 8000,
+                dns = "A",
+                nodeWeight = 100,
+                weight = {
+                  total = 100,
+                  available = 100,
+                  unavailable = 0
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "127.0.0.1",
+                    port = 8000,
+                    weight = 100
+                  },
+                },
+              },
+              {
+                host = "arecord.tst",
+                port = 8001,
+                dns = "A",
+                nodeWeight = 25,
+                weight = {
+                  total = 50,
+                  available = 25,
+                  unavailable = 25
+                },
+                addresses = {
+                  {
+                    healthy = false,
+                    ip = "1.2.3.4",
+                    port = 8001,
+                    weight = 25
+                  },
+                  {
+                    healthy = true,
+                    ip = "5.6.7.8",
+                    port = 8001,
+                    weight = 25
+                  },
+                },
+              },
+            },
+          }, b:getStatus())
+
+          -- switch to available
+          assert(b:setAddressStatus(b:findAddress("1.2.3.4", 8001, "arecord.tst"), true))
+          assert.same({
+            healthy = true,
+            weight = {
+              total = 150,
+              available = 150,
+              unavailable = 0
+            },
+            hosts = {
+              {
+                host = "127.0.0.1",
+                port = 8000,
+                dns = "A",
+                nodeWeight = 100,
+                weight = {
+                  total = 100,
+                  available = 100,
+                  unavailable = 0
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "127.0.0.1",
+                    port = 8000,
+                    weight = 100
+                  },
+                },
+              },
+              {
+                host = "arecord.tst",
+                port = 8001,
+                dns = "A",
+                nodeWeight = 25,
+                weight = {
+                  total = 50,
+                  available = 50,
+                  unavailable = 0
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "1.2.3.4",
+                    port = 8001,
+                    weight = 25
+                  },
+                  {
+                    healthy = true,
+                    ip = "5.6.7.8",
+                    port = 8001,
+                    weight = 25
+                  },
+                },
+              },
+            },
+          }, b:getStatus())
+        end)
+
+        it("changing weight of an available address",function()
+          dnsA({
+            { name = "arecord.tst", address = "1.2.3.4" },
+            { name = "arecord.tst", address = "5.6.7.8" },
+          })
+
+          add_target(b, "arecord.tst", 8001, 25)
+          assert.same({
+            healthy = true,
+            weight = {
+              total = 150,
+              available = 150,
+              unavailable = 0
+            },
+            hosts = {
+              {
+                host = "127.0.0.1",
+                port = 8000,
+                dns = "A",
+                nodeWeight = 100,
+                weight = {
+                  total = 100,
+                  available = 100,
+                  unavailable = 0
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "127.0.0.1",
+                    port = 8000,
+                    weight = 100
+                  },
+                },
+              },
+              {
+                host = "arecord.tst",
+                port = 8001,
+                dns = "A",
+                nodeWeight = 25,
+                weight = {
+                  total = 50,
+                  available = 50,
+                  unavailable = 0
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "1.2.3.4",
+                    port = 8001,
+                    weight = 25
+                  },
+                  {
+                    healthy = true,
+                    ip = "5.6.7.8",
+                    port = 8001,
+                    weight = 25
+                  },
+                },
+              },
+            },
+          }, b:getStatus())
+
+          add_target(b, "arecord.tst", 8001, 50) -- adding again changes weight
+          assert.same({
+            healthy = true,
+            weight = {
+              total = 200,
+              available = 200,
+              unavailable = 0
+            },
+            hosts = {
+              {
+                host = "127.0.0.1",
+                port = 8000,
+                dns = "A",
+                nodeWeight = 100,
+                weight = {
+                  total = 100,
+                  available = 100,
+                  unavailable = 0
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "127.0.0.1",
+                    port = 8000,
+                    weight = 100
+                  },
+                },
+              },
+              {
+                host = "arecord.tst",
+                port = 8001,
+                dns = "A",
+                nodeWeight = 50,
+                weight = {
+                  total = 100,
+                  available = 100,
+                  unavailable = 0
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "1.2.3.4",
+                    port = 8001,
+                    weight = 50
+                  },
+                  {
+                    healthy = true,
+                    ip = "5.6.7.8",
+                    port = 8001,
+                    weight = 50
+                  },
+                },
+              },
+            },
+          }, b:getStatus())
+        end)
+
+        it("changing weight of an unavailable address",function()
+          dnsA({
+            { name = "arecord.tst", address = "1.2.3.4" },
+            { name = "arecord.tst", address = "5.6.7.8" },
+          })
+
+          add_target(b, "arecord.tst", 8001, 25)
+          assert.same({
+            healthy = true,
+            weight = {
+              total = 150,
+              available = 150,
+              unavailable = 0
+            },
+            hosts = {
+              {
+                host = "127.0.0.1",
+                port = 8000,
+                dns = "A",
+                nodeWeight = 100,
+                weight = {
+                  total = 100,
+                  available = 100,
+                  unavailable = 0
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "127.0.0.1",
+                    port = 8000,
+                    weight = 100
+                  },
+                },
+              },
+              {
+                host = "arecord.tst",
+                port = 8001,
+                dns = "A",
+                nodeWeight = 25,
+                weight = {
+                  total = 50,
+                  available = 50,
+                  unavailable = 0
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "1.2.3.4",
+                    port = 8001,
+                    weight = 25
+                  },
+                  {
+                    healthy = true,
+                    ip = "5.6.7.8",
+                    port = 8001,
+                    weight = 25
+                  },
+                },
+              },
+            },
+          }, b:getStatus())
+
+          -- switch to unavailable
+          assert(b:setAddressStatus(b:findAddress("1.2.3.4", 8001, "arecord.tst"), false))
+          assert.same({
+            healthy = true,
+            weight = {
+              total = 150,
+              available = 125,
+              unavailable = 25
+            },
+            hosts = {
+              {
+                host = "127.0.0.1",
+                port = 8000,
+                dns = "A",
+                nodeWeight = 100,
+                weight = {
+                  total = 100,
+                  available = 100,
+                  unavailable = 0
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "127.0.0.1",
+                    port = 8000,
+                    weight = 100
+                  },
+                },
+              },
+              {
+                host = "arecord.tst",
+                port = 8001,
+                dns = "A",
+                nodeWeight = 25,
+                weight = {
+                  total = 50,
+                  available = 25,
+                  unavailable = 25
+                },
+                addresses = {
+                  {
+                    healthy = false,
+                    ip = "1.2.3.4",
+                    port = 8001,
+                    weight = 25
+                  },
+                  {
+                    healthy = true,
+                    ip = "5.6.7.8",
+                    port = 8001,
+                    weight = 25
+                  },
+                },
+              },
+            },
+          }, b:getStatus())
+
+          add_target(b, "arecord.tst", 8001, 50) -- adding again changes weight
+          assert.same({
+            healthy = true,
+            weight = {
+              total = 200,
+              available = 150,
+              unavailable = 50
+            },
+            hosts = {
+              {
+                host = "127.0.0.1",
+                port = 8000,
+                dns = "A",
+                nodeWeight = 100,
+                weight = {
+                  total = 100,
+                  available = 100,
+                  unavailable = 0
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "127.0.0.1",
+                    port = 8000,
+                    weight = 100
+                  },
+                },
+              },
+              {
+                host = "arecord.tst",
+                port = 8001,
+                dns = "A",
+                nodeWeight = 50,
+                weight = {
+                  total = 100,
+                  available = 50,
+                  unavailable = 50
+                },
+                addresses = {
+                  {
+                    healthy = false,
+                    ip = "1.2.3.4",
+                    port = 8001,
+                    weight = 50
+                  },
+                  {
+                    healthy = true,
+                    ip = "5.6.7.8",
+                    port = 8001,
+                    weight = 50
+                  },
+                },
+              },
+            },
+          }, b:getStatus())
+        end)
+
+      end)
+
+      describe("(SRV)", function()
+
+        it("adding a host",function()
+          dnsSRV({
+            { name = "srvrecord.tst", target = "1.1.1.1", port = 9000, weight = 10 },
+            { name = "srvrecord.tst", target = "2.2.2.2", port = 9001, weight = 10 },
+          })
+
+          add_target(b, "srvrecord.tst", 8001, 25)
+          assert.same({
+            healthy = true,
+            weight = {
+              total = 120,
+              available = 120,
+              unavailable = 0
+            },
+            hosts = {
+              {
+                host = "127.0.0.1",
+                port = 8000,
+                dns = "A",
+                nodeWeight = 100,
+                weight = {
+                  total = 100,
+                  available = 100,
+                  unavailable = 0
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "127.0.0.1",
+                    port = 8000,
+                    weight = 100
+                  },
+                },
+              },
+              {
+                host = "srvrecord.tst",
+                port = 8001,
+                dns = "SRV",
+                nodeWeight = 25,
+                weight = {
+                  total = 20,
+                  available = 20,
+                  unavailable = 0
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "1.1.1.1",
+                    port = 9000,
+                    weight = 10
+                  },
+                  {
+                    healthy = true,
+                    ip = "2.2.2.2",
+                    port = 9001,
+                    weight = 10
+                  },
+                },
+              },
+            },
+          }, b:getStatus())
+        end)
+
+        it("switching address availability",function()
+          dnsSRV({
+            { name = "srvrecord.tst", target = "1.1.1.1", port = 9000, weight = 10 },
+            { name = "srvrecord.tst", target = "2.2.2.2", port = 9001, weight = 10 },
+          })
+
+          add_target(b, "srvrecord.tst", 8001, 25)
+          assert.same({
+            healthy = true,
+            weight = {
+              total = 120,
+              available = 120,
+              unavailable = 0
+            },
+            hosts = {
+              {
+                host = "127.0.0.1",
+                port = 8000,
+                dns = "A",
+                nodeWeight = 100,
+                weight = {
+                  total = 100,
+                  available = 100,
+                  unavailable = 0
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "127.0.0.1",
+                    port = 8000,
+                    weight = 100
+                  },
+                },
+              },
+              {
+                host = "srvrecord.tst",
+                port = 8001,
+                dns = "SRV",
+                nodeWeight = 25,
+                weight = {
+                  total = 20,
+                  available = 20,
+                  unavailable = 0
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "1.1.1.1",
+                    port = 9000,
+                    weight = 10
+                  },
+                  {
+                    healthy = true,
+                    ip = "2.2.2.2",
+                    port = 9001,
+                    weight = 10
+                  },
+                },
+              },
+            },
+          }, b:getStatus())
+
+          -- switch to unavailable
+          assert(b:setAddressStatus(b:findAddress("1.1.1.1", 9000, "srvrecord.tst"), false))
+          assert.same({
+            healthy = true,
+            weight = {
+              total = 120,
+              available = 110,
+              unavailable = 10
+            },
+            hosts = {
+              {
+                host = "127.0.0.1",
+                port = 8000,
+                dns = "A",
+                nodeWeight = 100,
+                weight = {
+                  total = 100,
+                  available = 100,
+                  unavailable = 0
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "127.0.0.1",
+                    port = 8000,
+                    weight = 100
+                  },
+                },
+              },
+              {
+                host = "srvrecord.tst",
+                port = 8001,
+                dns = "SRV",
+                nodeWeight = 25,
+                weight = {
+                  total = 20,
+                  available = 10,
+                  unavailable = 10
+                },
+                addresses = {
+                  {
+                    healthy = false,
+                    ip = "1.1.1.1",
+                    port = 9000,
+                    weight = 10
+                  },
+                  {
+                    healthy = true,
+                    ip = "2.2.2.2",
+                    port = 9001,
+                    weight = 10
+                  },
+                },
+              },
+            },
+          }, b:getStatus())
+
+          -- switch to available
+          assert(b:setAddressStatus(b:findAddress("1.1.1.1", 9000, "srvrecord.tst"), true))
+          assert.same({
+            healthy = true,
+            weight = {
+              total = 120,
+              available = 120,
+              unavailable = 0
+            },
+            hosts = {
+              {
+                host = "127.0.0.1",
+                port = 8000,
+                dns = "A",
+                nodeWeight = 100,
+                weight = {
+                  total = 100,
+                  available = 100,
+                  unavailable = 0
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "127.0.0.1",
+                    port = 8000,
+                    weight = 100
+                  },
+                },
+              },
+              {
+                host = "srvrecord.tst",
+                port = 8001,
+                dns = "SRV",
+                nodeWeight = 25,
+                weight = {
+                  total = 20,
+                  available = 20,
+                  unavailable = 0
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "1.1.1.1",
+                    port = 9000,
+                    weight = 10
+                  },
+                  {
+                    healthy = true,
+                    ip = "2.2.2.2",
+                    port = 9001,
+                    weight = 10
+                  },
+                },
+              },
+            },
+          }, b:getStatus())
+        end)
+
+        it("changing weight of an available address (dns update)",function()
+          local record = dnsSRV({
+            { name = "srvrecord.tst", target = "1.1.1.1", port = 9000, weight = 10 },
+            { name = "srvrecord.tst", target = "2.2.2.2", port = 9001, weight = 10 },
+          })
+
+          add_target(b, "srvrecord.tst", 8001, 10)
+          assert.same({
+            healthy = true,
+            weight = {
+              total = 120,
+              available = 120,
+              unavailable = 0
+            },
+            hosts = {
+              {
+                host = "127.0.0.1",
+                port = 8000,
+                dns = "A",
+                nodeWeight = 100,
+                weight = {
+                  total = 100,
+                  available = 100,
+                  unavailable = 0
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "127.0.0.1",
+                    port = 8000,
+                    weight = 100
+                  },
+                },
+              },
+              {
+                host = "srvrecord.tst",
+                port = 8001,
+                dns = "SRV",
+                nodeWeight = 10,
+                weight = {
+                  total = 20,
+                  available = 20,
+                  unavailable = 0
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "1.1.1.1",
+                    port = 9000,
+                    weight = 10
+                  },
+                  {
+                    healthy = true,
+                    ip = "2.2.2.2",
+                    port = 9001,
+                    weight = 10
+                  },
+                },
+              },
+            },
+          }, b:getStatus())
+
+          dnsExpire(record)
+          dnsSRV({
+            { name = "srvrecord.tst", target = "1.1.1.1", port = 9000, weight = 20 },
+            { name = "srvrecord.tst", target = "2.2.2.2", port = 9001, weight = 20 },
+          })
+          targets.resolve_targets(b.targets)  -- touch all adresses to force dns renewal
+          add_target(b, "srvrecord.tst", 8001, 99) -- add again to update nodeWeight
+
+          assert.same({
+            healthy = true,
+            weight = {
+              total = 140,
+              available = 140,
+              unavailable = 0
+            },
+            hosts = {
+              {
+                host = "127.0.0.1",
+                port = 8000,
+                dns = "A",
+                nodeWeight = 100,
+                weight = {
+                  total = 100,
+                  available = 100,
+                  unavailable = 0
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "127.0.0.1",
+                    port = 8000,
+                    weight = 100
+                  },
+                },
+              },
+              {
+                host = "srvrecord.tst",
+                port = 8001,
+                dns = "SRV",
+                nodeWeight = 99,
+                weight = {
+                  total = 40,
+                  available = 40,
+                  unavailable = 0
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "1.1.1.1",
+                    port = 9000,
+                    weight = 20
+                  },
+                  {
+                    healthy = true,
+                    ip = "2.2.2.2",
+                    port = 9001,
+                    weight = 20
+                  },
+                },
+              },
+            },
+          }, b:getStatus())
+        end)
+
+        it("changing weight of an unavailable address (dns update)",function()
+          local record = dnsSRV({
+            { name = "srvrecord.tst", target = "1.1.1.1", port = 9000, weight = 10 },
+            { name = "srvrecord.tst", target = "2.2.2.2", port = 9001, weight = 10 },
+          })
+
+          add_target(b, "srvrecord.tst", 8001, 25)
+          assert.same({
+            healthy = true,
+            weight = {
+              total = 120,
+              available = 120,
+              unavailable = 0
+            },
+            hosts = {
+              {
+                host = "127.0.0.1",
+                port = 8000,
+                dns = "A",
+                nodeWeight = 100,
+                weight = {
+                  total = 100,
+                  available = 100,
+                  unavailable = 0
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "127.0.0.1",
+                    port = 8000,
+                    weight = 100
+                  },
+                },
+              },
+              {
+                host = "srvrecord.tst",
+                port = 8001,
+                dns = "SRV",
+                nodeWeight = 25,
+                weight = {
+                  total = 20,
+                  available = 20,
+                  unavailable = 0
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "1.1.1.1",
+                    port = 9000,
+                    weight = 10
+                  },
+                  {
+                    healthy = true,
+                    ip = "2.2.2.2",
+                    port = 9001,
+                    weight = 10
+                  },
+                },
+              },
+            },
+          }, b:getStatus())
+
+          -- switch to unavailable
+          assert(b:setAddressStatus(b:findAddress("2.2.2.2", 9001, "srvrecord.tst"), false))
+          assert.same({
+            healthy = true,
+            weight = {
+              total = 120,
+              available = 110,
+              unavailable = 10
+            },
+            hosts = {
+              {
+                host = "127.0.0.1",
+                port = 8000,
+                dns = "A",
+                nodeWeight = 100,
+                weight = {
+                  total = 100,
+                  available = 100,
+                  unavailable = 0
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "127.0.0.1",
+                    port = 8000,
+                    weight = 100
+                  },
+                },
+              },
+              {
+                host = "srvrecord.tst",
+                port = 8001,
+                dns = "SRV",
+                nodeWeight = 25,
+                weight = {
+                  total = 20,
+                  available = 10,
+                  unavailable = 10
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "1.1.1.1",
+                    port = 9000,
+                    weight = 10
+                  },
+                  {
+                    healthy = false,
+                    ip = "2.2.2.2",
+                    port = 9001,
+                    weight = 10
+                  },
+                },
+              },
+            },
+          }, b:getStatus())
+
+          -- update weight, through dns renewal
+          dnsExpire(record)
+          dnsSRV({
+            { name = "srvrecord.tst", target = "1.1.1.1", port = 9000, weight = 20 },
+            { name = "srvrecord.tst", target = "2.2.2.2", port = 9001, weight = 20 },
+          })
+          targets.resolve_targets(b.targets)  -- touch all adresses to force dns renewal
+          add_target(b, "srvrecord.tst", 8001, 99) -- add again to update nodeWeight
+
+          assert.same({
+            healthy = true,
+            weight = {
+              total = 140,
+              available = 120,
+              unavailable = 20
+            },
+            hosts = {
+              {
+                host = "127.0.0.1",
+                port = 8000,
+                dns = "A",
+                nodeWeight = 100,
+                weight = {
+                  total = 100,
+                  available = 100,
+                  unavailable = 0
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "127.0.0.1",
+                    port = 8000,
+                    weight = 100
+                  },
+                },
+              },
+              {
+                host = "srvrecord.tst",
+                port = 8001,
+                dns = "SRV",
+                nodeWeight = 99,
+                weight = {
+                  total = 40,
+                  available = 20,
+                  unavailable = 20
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "1.1.1.1",
+                    port = 9000,
+                    weight = 20
+                  },
+                  {
+                    healthy = false,
+                    ip = "2.2.2.2",
+                    port = 9001,
+                    weight = 20
+                  },
+                },
+              },
+            },
+          }, b:getStatus())
+        end)
+
+      end)
+
+    end)
+
+
+
+    describe("getpeer()", function()
+
+      local b
+
+      before_each(function()
+        b = new_balancer(algorithm)
+        b.healthThreshold = 50
+        b.useSRVname = false
+      end)
+
+      after_each(function()
+        b = nil
+      end)
+
+
+      it("returns expected results/types when using SRV with IP", function()
+        dnsSRV({
+          { name = "konghq.com", target = "1.1.1.1", port = 2, weight = 3 },
+        })
+        add_target(b, "konghq.com", 8000, 50)
+        local ip, port, hostname, handle = b:getPeer(true, nil, "a string")
+        assert.equal("1.1.1.1", ip)
+        assert.equal(2, port)
+        assert.equal("konghq.com", hostname)
+        assert.not_nil(handle)
+      end)
+
+
+      it("returns expected results/types when using SRV with name ('useSRVname=false')", function()
+        dnsA({
+          { name = "getkong.org", address = "1.2.3.4" },
+        })
+        dnsSRV({
+          { name = "konghq.com", target = "getkong.org", port = 2, weight = 3 },
+        })
+        add_target(b, "konghq.com", 8000, 50)
+        local ip, port, hostname, handle = b:getPeer(true, nil, "a string")
+        assert.equal("1.2.3.4", ip)
+        assert.equal(2, port)
+        assert.equal("konghq.com", hostname)
+        assert.not_nil(handle)
+      end)
+
+
+      it("returns expected results/types when using SRV with name ('useSRVname=true')", function()
+        b.useSRVname = true -- override setting specified when creating
+
+        dnsA({
+          { name = "getkong.org", address = "1.2.3.4" },
+        })
+        dnsSRV({
+          { name = "konghq.com", target = "getkong.org", port = 2, weight = 3 },
+        })
+        add_target(b, "konghq.com", 8000, 50)
+        local ip, port, hostname, handle = b:getPeer(true, nil, "a string")
+        assert.equal("1.2.3.4", ip)
+        assert.equal(2, port)
+        assert.equal("getkong.org", hostname)
+        assert.not_nil(handle)
+      end)
+
+
+      it("returns expected results/types when using A", function()
+        dnsA({
+          { name = "getkong.org", address = "1.2.3.4" },
+        })
+        add_target(b, "getkong.org", 8000, 50)
+        local ip, port, hostname, handle = b:getPeer(true, nil, "another string")
+        assert.equal("1.2.3.4", ip)
+        assert.equal(8000, port)
+        assert.equal("getkong.org", hostname)
+        assert.not_nil(handle)
+      end)
+
+
+      it("returns expected results/types when using IPv4", function()
+        add_target(b, "4.3.2.1", 8000, 50)
+        local ip, port, hostname, handle = b:getPeer(true, nil, "a string")
+        assert.equal("4.3.2.1", ip)
+        assert.equal(8000, port)
+        assert.equal(nil, hostname)
+        assert.not_nil(handle)
+      end)
+
+
+      it("returns expected results/types when using IPv6", function()
+        add_target(b, "::1", 8000, 50)
+        local ip, port, hostname, handle = b:getPeer(true, nil, "just a string")
+        assert.equal("[::1]", ip)
+        assert.equal(8000, port)
+        assert.equal(nil, hostname)
+        assert.not_nil(handle)
+      end)
+
+
+      it("fails when there are no addresses added", function()
+        assert.same({
+            nil, "Balancer is unhealthy", nil, nil,
+          }, {
+            b:getPeer(true, nil, "any string")
+          }
+        )
+      end)
+
+
+      it("fails when all addresses are unhealthy", function()
+        add_target(b, "127.0.0.1", 8000, 100)
+        add_target(b, "127.0.0.2", 8000, 100)
+        add_target(b, "127.0.0.3", 8000, 100)
+        b:setAddressStatus(b:findAddress("127.0.0.1", 8000, "127.0.0.1"), false)
+        b:setAddressStatus(b:findAddress("127.0.0.2", 8000, "127.0.0.2"), false)
+        b:setAddressStatus(b:findAddress("127.0.0.3", 8000, "127.0.0.3"), false)
+        assert.same({
+            nil, "Balancer is unhealthy", nil, nil,
+          }, {
+            b:getPeer(true, nil, "a client string")
+          }
+        )
+      end)
+
+
+      it("fails when balancer switches to unhealthy", function()
+        add_target(b, "127.0.0.1", 8000, 100)
+        add_target(b, "127.0.0.2", 8000, 100)
+        add_target(b, "127.0.0.3", 8000, 100)
+        assert.not_nil(b:getPeer(true, nil, "any client string here"))
+
+        b:setAddressStatus(b:findAddress("127.0.0.1", 8000, "127.0.0.1"), false)
+        b:setAddressStatus(b:findAddress("127.0.0.2", 8000, "127.0.0.2"), false)
+        assert.same({
+            nil, "Balancer is unhealthy", nil, nil,
+          }, {
+            b:getPeer(true, nil, "any string here")
+          }
+        )
+      end)
+
+
+      it("recovers when balancer switches to healthy", function()
+        add_target(b, "127.0.0.1", 8000, 100)
+        add_target(b, "127.0.0.2", 8000, 100)
+        add_target(b, "127.0.0.3", 8000, 100)
+        assert.not_nil(b:getPeer(true, nil, "string from the client"))
+
+        b:setAddressStatus(b:findAddress("127.0.0.1", 8000, "127.0.0.1"), false)
+        b:setAddressStatus(b:findAddress("127.0.0.2", 8000, "127.0.0.2"), false)
+        assert.same({
+            nil, "Balancer is unhealthy", nil, nil,
+          }, {
+            b:getPeer(true, nil, "string from the client")
+          }
+        )
+
+        b:setAddressStatus(b:findAddress("127.0.0.2", 8000, "127.0.0.2"), true)
+        assert.not_nil(b:getPeer(true, nil, "a string"))
+      end)
+
+
+      it("recovers when dns entries are replaced by healthy ones", function()
+        local record = dnsA({
+          { name = "getkong.org", address = "1.2.3.4", ttl = 2 },
+        })
+        add_target(b, "getkong.org", 8000, 50)
+        assert.not_nil(b:getPeer(true, nil, "from the client"))
+
+        -- mark it as unhealthy
+        assert(b:setAddressStatus(b:findAddress("1.2.3.4", 8000, "getkong.org", false)))
+        assert.same({
+            nil, "Balancer is unhealthy", nil, nil,
+          }, {
+            b:getPeer(true, nil, "from the client")
+          }
+        )
+
+        -- update DNS with a new backend IP
+        -- balancer should now recover since a new healthy backend is available
+        record.expire = 0
+        dnsA({
+          { name = "getkong.org", address = "5.6.7.8", ttl = 60 },
+        })
+        targets.resolve_targets(b.targets)
+
+        local timeout = ngx.now() + 5   -- we'll try for 5 seconds
+        while true do
+          assert(ngx.now() < timeout, "timeout")
+          local ip = b:getPeer(true, nil, "from the client")
+          if algorithm == "consistent-hashing" then
+            if ip ~= nil then
+              break  -- expected result, success!
+            end
+          else
+            if ip == "5.6.7.8" then
+              break  -- expected result, success!
+            end
+          end
+
+          ngx.sleep(0.1)  -- wait a bit before retrying
+        end
+      end)
+    end)
+
+
+    describe("status:", function()
+
+      local b
+
+      before_each(function()
+        b = new_balancer(algorithm)
+      end)
+
+      after_each(function()
+        b = nil
+      end)
+
+
+      describe("reports DNS source", function()
+
+        it("status report",function()
+          add_target(b, "127.0.0.1", 8000, 100)
+          add_target(b, "0::1", 8080, 50)
+          dnsSRV({
+            { name = "srvrecord.tst", target = "1.1.1.1", port = 9000, weight = 10 },
+            { name = "srvrecord.tst", target = "2.2.2.2", port = 9001, weight = 10 },
+          })
+          add_target(b, "srvrecord.tst", 1234, 9999)
+          dnsA({
+            { name = "getkong.org", address = "5.6.7.8", ttl = 0 },
+          })
+          add_target(b, "getkong.org", 5678, 1000)
+          add_target(b, "notachanceinhell.this.name.exists.konghq.com", 4321, 100)
+
+          local status = b:getStatus()
+          table.sort(status.hosts, function(hostA, hostB) return hostA.host < hostB.host end)
+
+          assert.same({
+            healthy = true,
+            weight = {
+              total = 1170,
+              available = 1170,
+              unavailable = 0
+            },
+            hosts = {
+              {
+                host = "0::1",
+                port = 8080,
+                dns = "AAAA",
+                nodeWeight = 50,
+                weight = {
+                  total = 50,
+                  available = 50,
+                  unavailable = 0
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "[0::1]",
+                    port = 8080,
+                    weight = 50
+                  },
+                },
+              },
+              {
+                host = "127.0.0.1",
+                port = 8000,
+                dns = "A",
+                nodeWeight = 100,
+                weight = {
+                  total = 100,
+                  available = 100,
+                  unavailable = 0
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "127.0.0.1",
+                    port = 8000,
+                    weight = 100
+                  },
+                },
+              },
+              {
+                host = "getkong.org",
+                port = 5678,
+                dns = "ttl=0, virtual SRV",
+                nodeWeight = 1000,
+                weight = {
+                  total = 1000,
+                  available = 1000,
+                  unavailable = 0
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "getkong.org",
+                    port = 5678,
+                    weight = 1000
+                  },
+                },
+              },
+              {
+                host = "notachanceinhell.this.name.exists.konghq.com",
+                port = 4321,
+                dns = "dns server error: 3 name error",
+                nodeWeight = 100,
+                weight = {
+                  total = 0,
+                  available = 0,
+                  unavailable = 0
+                },
+                addresses = {},
+              },
+              {
+                host = "srvrecord.tst",
+                port = 1234,
+                dns = "SRV",
+                nodeWeight = 9999,
+                weight = {
+                  total = 20,
+                  available = 20,
+                  unavailable = 0
+                },
+                addresses = {
+                  {
+                    healthy = true,
+                    ip = "1.1.1.1",
+                    port = 9000,
+                    weight = 10
+                  },
+                  {
+                    healthy = true,
+                    ip = "2.2.2.2",
+                    port = 9001,
+                    weight = 10
+                  },
+                },
+              },
+            },
+          }, status)
+        end)
+      end)
+    end)
+  end)
+end

--- a/spec/01-unit/09-balancer/02-least_connections_spec.lua
+++ b/spec/01-unit/09-balancer/02-least_connections_spec.lua
@@ -1,0 +1,517 @@
+
+local dns_utils = require "resty.dns.utils"
+local mocker = require "spec.fixtures.mocker"
+local utils = require "kong.tools.utils"
+
+local ws_id = utils.uuid()
+
+local client, balancers, targets
+
+local helpers = require "spec.helpers.dns"
+--local gettime = helpers.gettime
+--local sleep = helpers.sleep
+local dnsSRV = function(...) return helpers.dnsSRV(client, ...) end
+local dnsA = function(...) return helpers.dnsA(client, ...) end
+--local dnsAAAA = function(...) return helpers.dnsAAAA(client, ...) end
+--local dnsExpire = helpers.dnsExpire
+local t_insert = table.insert
+
+
+local unset_register = {}
+local function setup_block(consistency)
+  local cache_table = {}
+
+  local function mock_cache()
+    return {
+      safe_set = function(self, k, v)
+        cache_table[k] = v
+        return true
+      end,
+      get = function(self, k, _, fn, arg)
+        if cache_table[k] == nil then
+          cache_table[k] = fn(arg)
+        end
+        return cache_table[k]
+      end,
+    }
+  end
+
+  local function register_unsettter(f)
+    table.insert(unset_register, f)
+  end
+
+  mocker.setup(register_unsettter, {
+    kong = {
+      configuration = {
+        worker_consistency = consistency,
+        worker_state_update_frequency = 0.1,
+      },
+      core_cache = mock_cache(cache_table),
+    },
+    ngx = {
+      ctx = {
+        workspace = ws_id,
+      }
+    }
+  })
+end
+
+local function unsetup_block()
+  for _, f in ipairs(unset_register) do
+    f()
+  end
+end
+
+
+local upstream_index = 0
+local function new_balancer(targets_list)
+  upstream_index = upstream_index + 1
+  local upname="upstream_" .. upstream_index
+  local hc_defaults = {
+    active = {
+      timeout = 1,
+      concurrency = 10,
+      http_path = "/",
+      healthy = {
+        interval = 0,  -- 0 = probing disabled by default
+        http_statuses = { 200, 302 },
+        successes = 0, -- 0 = disabled by default
+      },
+      unhealthy = {
+        interval = 0, -- 0 = probing disabled by default
+        http_statuses = { 429, 404,
+                          500, 501, 502, 503, 504, 505 },
+        tcp_failures = 0,  -- 0 = disabled by default
+        timeouts = 0,      -- 0 = disabled by default
+        http_failures = 0, -- 0 = disabled by default
+      },
+    },
+    passive = {
+      healthy = {
+        http_statuses = { 200, 201, 202, 203, 204, 205, 206, 207, 208, 226,
+                          300, 301, 302, 303, 304, 305, 306, 307, 308 },
+        successes = 0,
+      },
+      unhealthy = {
+        http_statuses = { 429, 500, 503 },
+        tcp_failures = 0,  -- 0 = circuit-breaker disabled by default
+        timeouts = 0,      -- 0 = circuit-breaker disabled by default
+        http_failures = 0, -- 0 = circuit-breaker disabled by default
+      },
+    },
+  }
+  local my_upstream = { id=upname, name=upname, ws_id=ws_id, slots=10, healthchecks=hc_defaults, algorithm="least-connections" }
+  local b = (balancers.create_balancer(my_upstream, true))
+
+  for _, target in ipairs(targets_list) do
+    local name, port, weight = target, nil, nil
+    if type(target) == "table" then
+      name = target.name or target[1]
+      port = target.port or target[2]
+      weight = target.weight or target[3]
+    end
+
+    table.insert(b.targets, {
+      upstream = name or upname,
+      balancer = b,
+      name = name,
+      nameType = dns_utils.hostnameType(name),
+      addresses = {},
+      port = port or 8000,
+      weight = weight or 100,
+      totalWeight = 0,
+      unavailableWeight = 0,
+    })
+  end
+
+  targets.resolve_targets(b.targets)
+  return b
+end
+
+local function validate_lcb(b, debug)
+  local available, unavailable = 0, 0
+  local bheap = b.algorithm.binaryHeap
+  local num_addresses = 0
+  for _, target in ipairs(b.targets) do
+    for _, addr in ipairs(target.addresses) do
+      if bheap:valueByPayload(addr) then
+        -- it's in the heap
+        assert(not addr.disabled, "should be enabled when in the heap")
+        assert(addr.available, "should be available when in the heap")
+        available = available + 1
+        assert(bheap:valueByPayload(addr) == (addr.connectionCount+1)/addr.weight)
+      else
+        assert(not addr.disabled, "should be enabled when not in the heap")
+        assert(not addr.available, "should not be available when not in the heap")
+        unavailable = unavailable + 1
+      end
+      num_addresses = num_addresses + 1
+    end
+  end
+  assert(available + unavailable == num_addresses, "mismatch in counts")
+  return b
+end
+
+
+describe("[least-connections]", function()
+
+  local snapshot
+
+  setup(function()
+    _G.package.loaded["resty.dns.client"] = nil -- make sure module is reloaded
+    _G.package.loaded["kong.runloop.balancer.targets"] = nil -- make sure module is reloaded
+
+    client = require "resty.dns.client"
+    targets = require "kong.runloop.balancer.targets"
+    balancers = require "kong.runloop.balancer.balancers"
+    local healthcheckers = require "kong.runloop.balancer.healthcheckers"
+    healthcheckers.init()
+    balancers.init()
+
+    local singletons = require "kong.singletons"
+    singletons.worker_events = require "resty.worker.events"
+    singletons.worker_events.configure({
+      shm = "kong_process_events", -- defined by "lua_shared_dict"
+      timeout = 5,            -- life time of event data in shm
+      interval = 1,           -- poll interval (seconds)
+
+      wait_interval = 0.010,  -- wait before retry fetching event data
+      wait_max = 0.5,         -- max wait time before discarding event
+    })
+
+    local function empty_each()
+      return function() end
+    end
+
+    singletons.db = {
+      targets = {
+        each = empty_each,
+        select_by_upstream_raw = function()
+          return {}
+        end
+      },
+      upstreams = {
+        each = empty_each,
+        select = function() end,
+      },
+    }
+
+    singletons.core_cache = {
+      _cache = {},
+      get = function(self, key, _, loader, arg)
+        local v = self._cache[key]
+        if v == nil then
+          v = loader(arg)
+          self._cache[key] = v
+        end
+        return v
+      end,
+      invalidate_local = function(self, key)
+        self._cache[key] = nil
+      end
+    }
+  end)
+
+
+  before_each(function()
+    setup_block()
+    assert(client.init {
+      hosts = {},
+      resolvConf = {
+        "nameserver 8.8.8.8"
+      },
+    })
+    snapshot = assert:snapshot()
+  end)
+
+
+  after_each(function()
+    snapshot:revert()  -- undo any spying/stubbing etc.
+    unsetup_block()
+    collectgarbage()
+    collectgarbage()
+  end)
+
+
+
+  describe("new()", function()
+
+    it("inserts provided hosts", function()
+      dnsA({
+        { name = "konghq.com", address = "1.2.3.4" },
+      })
+      dnsA({
+        { name = "github.com", address = "1.2.3.4" },
+      })
+      dnsA({
+        { name = "getkong.org", address = "1.2.3.4" },
+      })
+      local b = validate_lcb(new_balancer({
+        "konghq.com",                                      -- name only, as string
+        { name = "github.com" },                           -- name only, as table
+        { name = "getkong.org", port = 80, weight = 25 },  -- fully specified, as table
+      }))
+      assert.equal("konghq.com", b.targets[1].name)
+      assert.equal("github.com", b.targets[2].name)
+      assert.equal("getkong.org", b.targets[3].name)
+    end)
+  end)
+
+
+  describe("getPeer()", function()
+
+    it("honours weights", function()
+      dnsSRV({
+        { name = "konghq.com", target = "20.20.20.20", port = 80, weight = 20 },
+        { name = "konghq.com", target = "50.50.50.50", port = 80, weight = 50 },
+      })
+      local b = validate_lcb(new_balancer({ "konghq.com" }))
+
+      local counts = {}
+      local handles = {}
+      for i = 1,70 do
+        local ip, _, _, handle = b:getPeer()
+        counts[ip] = (counts[ip] or 0) + 1
+        t_insert(handles, handle)  -- don't let them get GC'ed
+      end
+
+      validate_lcb(b)
+
+      assert.same({
+        ["20.20.20.20"] = 20,
+        ["50.50.50.50"] = 50
+      }, counts)
+    end)
+
+
+    it("first returns top weights, on a 0-connection balancer", function()
+      dnsSRV({
+        { name = "konghq.com", target = "20.20.20.20", port = 80, weight = 20 },
+        { name = "konghq.com", target = "50.50.50.50", port = 80, weight = 50 },
+      })
+      local b = validate_lcb(new_balancer({ "konghq.com" }))
+
+      local handles = {}
+      local ip, _, handle
+
+      -- first try
+      ip, _, _, handle= b:getPeer()
+      t_insert(handles, handle)  -- don't let them get GC'ed
+      validate_lcb(b)
+      assert.equal("50.50.50.50", ip)
+
+      -- second try
+      ip, _, _, handle= b:getPeer()
+      t_insert(handles, handle)  -- don't let them get GC'ed
+      validate_lcb(b)
+      assert.equal("50.50.50.50", ip)
+
+      -- third try
+      ip, _, _, handle= b:getPeer()
+      t_insert(handles, handle)  -- don't let them get GC'ed
+      validate_lcb(b)
+      assert.equal("20.20.20.20", ip)
+    end)
+
+
+    it("doesn't use unavailable addresses", function()
+      dnsSRV({
+        { name = "konghq.com", target = "20.20.20.20", port = 80, weight = 20 },
+        { name = "konghq.com", target = "50.50.50.50", port = 80, weight = 50 },
+      })
+      local b = validate_lcb(new_balancer({ "konghq.com" }))
+
+      -- mark one as unavailable
+      b:setAddressStatus(b:findAddress("50.50.50.50", 80, "konghq.com"), false)
+      local counts = {}
+      local handles = {}
+      for i = 1,70 do
+        local ip, _, _, handle = assert(b:getPeer())
+        counts[ip] = (counts[ip] or 0) + 1
+        t_insert(handles, handle)  -- don't let them get GC'ed
+      end
+
+      validate_lcb(b)
+
+      assert.same({
+        ["20.20.20.20"] = 70,
+        ["50.50.50.50"] = nil,
+      }, counts)
+    end)
+
+
+    it("uses reenabled (available) addresses again", function()
+      dnsSRV({
+        { name = "konghq.com", target = "20.20.20.20", port = 80, weight = 20 },
+        { name = "konghq.com", target = "50.50.50.50", port = 80, weight = 50 },
+      })
+      local b = validate_lcb(new_balancer({ "konghq.com" }))
+
+      -- mark one as unavailable
+      b:setAddressStatus(b:findAddress("20.20.20.20", 80, "konghq.com"), false)
+      local counts = {}
+      local handles = {}
+      for i = 1,70 do
+        local ip, _, _, handle = b:getPeer()
+        counts[ip] = (counts[ip] or 0) + 1
+        t_insert(handles, handle)  -- don't let them get GC'ed
+      end
+
+      validate_lcb(b)
+
+      assert.same({
+        ["20.20.20.20"] = nil,
+        ["50.50.50.50"] = 70,
+      }, counts)
+
+      -- let's do another 70, after resetting
+      b:setAddressStatus(b:findAddress("20.20.20.20", 80, "konghq.com"), true)
+      for i = 1,70 do
+        local ip, _, _, handle = b:getPeer()
+        counts[ip] = (counts[ip] or 0) + 1
+        t_insert(handles, handle)  -- don't let them get GC'ed
+      end
+
+      validate_lcb(b)
+
+      assert.same({
+        ["20.20.20.20"] = 40,
+        ["50.50.50.50"] = 100,
+      }, counts)
+    end)
+
+
+  end)
+
+
+  describe("retrying getPeer()", function()
+
+    it("does not return already failed addresses", function()
+      dnsSRV({
+        { name = "konghq.com", target = "20.20.20.20", port = 80, weight = 20 },
+        { name = "konghq.com", target = "50.50.50.50", port = 80, weight = 50 },
+        { name = "konghq.com", target = "70.70.70.70", port = 80, weight = 70 },
+      })
+      local b = validate_lcb(new_balancer({ "konghq.com" }))
+
+      local tried = {}
+      local ip, _, handle
+      -- first try
+      ip, _, _, handle = b:getPeer()
+      tried[ip] = (tried[ip] or 0) + 1
+      validate_lcb(b)
+
+
+      -- 1st retry
+      ip, _, _, handle = b:getPeer(nil, handle)
+      assert.is_nil(tried[ip])
+      tried[ip] = (tried[ip] or 0) + 1
+      validate_lcb(b)
+
+      -- 2nd retry
+      ip, _, _, _ = b:getPeer(nil, handle)
+      assert.is_nil(tried[ip])
+      tried[ip] = (tried[ip] or 0) + 1
+      validate_lcb(b)
+
+      assert.same({
+        ["20.20.20.20"] = 1,
+        ["50.50.50.50"] = 1,
+        ["70.70.70.70"] = 1,
+      }, tried)
+    end)
+
+
+    it("retries, after all adresses failed, restarts with previously failed ones", function()
+      dnsSRV({
+        { name = "konghq.com", target = "20.20.20.20", port = 80, weight = 20 },
+        { name = "konghq.com", target = "50.50.50.50", port = 80, weight = 50 },
+        { name = "konghq.com", target = "70.70.70.70", port = 80, weight = 70 },
+      })
+      local b = validate_lcb(new_balancer({ "konghq.com" }))
+
+      local tried = {}
+      local ip, _, handle
+
+      for i = 1,6 do
+        ip, _, _, handle = b:getPeer(nil, handle)
+        tried[ip] = (tried[ip] or 0) + 1
+        validate_lcb(b)
+      end
+
+      assert.same({
+        ["20.20.20.20"] = 2,
+        ["50.50.50.50"] = 2,
+        ["70.70.70.70"] = 2,
+      }, tried)
+    end)
+
+
+    it("releases the previous connection", function()
+      dnsSRV({
+        { name = "konghq.com", target = "20.20.20.20", port = 80, weight = 20 },
+        { name = "konghq.com", target = "50.50.50.50", port = 80, weight = 50 },
+      })
+      local b = validate_lcb(new_balancer({ "konghq.com" }))
+
+      local counts = {}
+      local handle -- define outside loop, so it gets reused and released
+      for i = 1,70 do
+        local ip, _
+        ip, _, _, handle = b:getPeer(nil, handle)
+        counts[ip] = (counts[ip] or 0) + 1
+      end
+
+      validate_lcb(b)
+
+      local ccount = 0
+      for _, target in ipairs(b.targets) do
+        for _, addr in ipairs(target.addresses) do
+          ccount = ccount + addr.connectionCount
+        end
+      end
+      assert.equal(1, ccount)
+    end)
+
+  end)
+
+
+  describe("release()", function()
+
+    it("releases a connection", function()
+      dnsSRV({
+        { name = "konghq.com", target = "20.20.20.20", port = 80, weight = 20 },
+      })
+      local b = validate_lcb(new_balancer({ "konghq.com" }))
+
+      local ip, _, _, handle = b:getPeer()
+      assert.equal("20.20.20.20", ip)
+      assert.equal(1, b.targets[1].addresses[1].connectionCount)
+
+      handle:release()
+      assert.equal(0, b.targets[1].addresses[1].connectionCount)
+    end)
+
+
+    it("releases connection of already disabled/removed address", function()
+      dnsSRV({
+        { name = "konghq.com", target = "20.20.20.20", port = 80, weight = 20 },
+      })
+      local b = validate_lcb(new_balancer({ "konghq.com" }))
+
+      local ip, _, _, handle = b:getPeer()
+      assert.equal("20.20.20.20", ip)
+      assert.equal(1, b.targets[1].addresses[1].connectionCount)
+
+      -- remove the host and its addresses
+      table.remove(b.targets)
+      assert.equal(0, #b.targets)
+
+      local addr = handle.address
+      handle:release()
+      assert.equal(0, addr.connectionCount)
+    end)
+
+  end)
+
+end)

--- a/spec/01-unit/09-balancer/03-consistent_hashing_spec.lua
+++ b/spec/01-unit/09-balancer/03-consistent_hashing_spec.lua
@@ -1,0 +1,1118 @@
+
+assert:set_parameter("TableFormatLevel", 5) -- when displaying tables, set a bigger default depth
+
+------------------------
+-- START TEST HELPERS --
+------------------------
+local client
+local targets, balancers
+
+local dns_utils = require "resty.dns.utils"
+local mocker = require "spec.fixtures.mocker"
+local utils = require "kong.tools.utils"
+
+local ws_id = utils.uuid()
+
+local helpers = require "spec.helpers.dns"
+local gettime = helpers.gettime
+local sleep = helpers.sleep
+local dnsSRV = function(...) return helpers.dnsSRV(client, ...) end
+local dnsA = function(...) return helpers.dnsA(client, ...) end
+local dnsAAAA = function(...) return helpers.dnsAAAA(client, ...) end
+
+
+
+local unset_register = {}
+local function setup_block(consistency)
+  local cache_table = {}
+
+  local function mock_cache()
+    return {
+      safe_set = function(self, k, v)
+        cache_table[k] = v
+        return true
+      end,
+      get = function(self, k, _, fn, arg)
+        if cache_table[k] == nil then
+          cache_table[k] = fn(arg)
+        end
+        return cache_table[k]
+      end,
+    }
+  end
+
+  local function register_unsettter(f)
+    table.insert(unset_register, f)
+  end
+
+  mocker.setup(register_unsettter, {
+    kong = {
+      configuration = {
+        worker_consistency = consistency,
+        worker_state_update_frequency = 0.1,
+      },
+      core_cache = mock_cache(cache_table),
+    },
+    ngx = {
+      ctx = {
+        workspace = ws_id,
+      }
+    }
+  })
+end
+
+local function unsetup_block()
+  for _, f in ipairs(unset_register) do
+    f()
+  end
+end
+
+
+local function add_target(b, name, port, weight)
+  -- adding again changes weight
+  for _, prev_target in ipairs(b.targets) do
+    if prev_target.name == name and prev_target.port == port then
+      local entry = {port = port}
+      for _, addr in ipairs(prev_target.addresses) do
+        entry.address = addr.ip
+        b:changeWeight(prev_target, entry, weight)
+      end
+      prev_target.weight = weight
+      return prev_target
+    end
+  end
+
+  if type(name) == "table" then
+    local entry = name
+    name = entry.name or entry[1]
+    port = entry.port or entry[2]
+    weight = entry.weight or entry[3]
+  end
+
+  local target = {
+    upstream = b.upstream_id,
+    balancer = b,
+    name = name,
+    nameType = dns_utils.hostnameType(name),
+    addresses = {},
+    port = port or 80,
+    weight = weight or 100,
+    totalWeight = 0,
+    unavailableWeight = 0,
+  }
+  table.insert(b.targets, target)
+  targets.resolve_targets(b.targets)
+
+  return target
+end
+
+local upstream_index = 0
+local function new_balancer(opts)
+  upstream_index = upstream_index + 1
+  local upname="upstream_" .. upstream_index
+  local hc_defaults = {
+    active = {
+      timeout = 1,
+      concurrency = 10,
+      http_path = "/",
+      healthy = {
+        interval = 0,  -- 0 = probing disabled by default
+        http_statuses = { 200, 302 },
+        successes = 0, -- 0 = disabled by default
+      },
+      unhealthy = {
+        interval = 0, -- 0 = probing disabled by default
+        http_statuses = { 429, 404,
+                          500, 501, 502, 503, 504, 505 },
+        tcp_failures = 0,  -- 0 = disabled by default
+        timeouts = 0,      -- 0 = disabled by default
+        http_failures = 0, -- 0 = disabled by default
+      },
+    },
+    passive = {
+      healthy = {
+        http_statuses = { 200, 201, 202, 203, 204, 205, 206, 207, 208, 226,
+                          300, 301, 302, 303, 304, 305, 306, 307, 308 },
+        successes = 0,
+      },
+      unhealthy = {
+        http_statuses = { 429, 500, 503 },
+        tcp_failures = 0,  -- 0 = circuit-breaker disabled by default
+        timeouts = 0,      -- 0 = circuit-breaker disabled by default
+        http_failures = 0, -- 0 = circuit-breaker disabled by default
+      },
+    },
+  }
+  local my_upstream = { id=upname, name=upname, ws_id=ws_id, slots=10, healthchecks=hc_defaults, algorithm="consistent-hashing" }
+  local b = (balancers.create_balancer(my_upstream, true))
+
+  for k, v in pairs{
+    wheelSize = opts.wheelSize,
+    requeryInterval = opts.requery,
+    ttl0Interval = opts.ttl0,
+  } do
+    b[k] = v
+  end
+  if opts.callback then
+    b:setCallback(opts.callback)
+  end
+
+  for _, target in ipairs(opts.hosts or {}) do
+    add_target(b, target)
+  end
+
+  return b
+end
+
+
+-- creates a hash table with "address:port" keys and as value the number of indices
+local function count_indices(b)
+  local r = {}
+  local continuum = b.algorithm.continuum
+  for _, address in pairs(continuum) do
+    local key = tostring(address.ip)
+    if key:find(":",1,true) then
+      --print("available: ", address.available)
+      key = "["..key.."]:"..address.port
+    else
+      key = key..":"..address.port
+    end
+    r[key] = (r[key] or 0) + 1
+  end
+  return r
+end
+
+-- copies the wheel to a list with ip, port and hostname in the field values.
+-- can be used for before/after comparison
+local copyWheel = function(b)
+  local copy = {}
+  local continuum = b.algorithm.continuum
+  for i, address in pairs(continuum) do
+    copy[i] = i.." - "..address.ip.." @ "..address.port.." ("..address.target.name..")"
+  end
+  return copy
+end
+
+----------------------
+-- END TEST HELPERS --
+----------------------
+
+
+describe("[consistent_hashing]", function()
+
+  local snapshot
+
+  setup(function()
+    _G.package.loaded["resty.dns.client"] = nil -- make sure module is reloaded
+    _G.package.loaded["kong.runloop.balancer.targets"] = nil -- make sure module is reloaded
+
+    client = require "resty.dns.client"
+    targets = require "kong.runloop.balancer.targets"
+    balancers = require "kong.runloop.balancer.balancers"
+    local healthcheckers = require "kong.runloop.balancer.healthcheckers"
+    healthcheckers.init()
+    balancers.init()
+
+    local singletons = require "kong.singletons"
+    singletons.worker_events = require "resty.worker.events"
+    singletons.worker_events.configure({
+      shm = "kong_process_events", -- defined by "lua_shared_dict"
+      timeout = 5,            -- life time of event data in shm
+      interval = 1,           -- poll interval (seconds)
+
+      wait_interval = 0.010,  -- wait before retry fetching event data
+      wait_max = 0.5,         -- max wait time before discarding event
+    })
+
+    local function empty_each()
+      return function() end
+    end
+
+    singletons.db = {
+      targets = {
+        each = empty_each,
+        select_by_upstream_raw = function()
+          return {}
+        end
+      },
+      upstreams = {
+        each = empty_each,
+        select = function() end,
+      },
+    }
+
+    singletons.core_cache = {
+      _cache = {},
+      get = function(self, key, _, loader, arg)
+        local v = self._cache[key]
+        if v == nil then
+          v = loader(arg)
+          self._cache[key] = v
+        end
+        return v
+      end,
+      invalidate_local = function(self, key)
+        self._cache[key] = nil
+      end
+    }
+  end)
+
+  before_each(function()
+    setup_block()
+    assert(client.init {
+      hosts = {},
+      resolvConf = {
+        "nameserver 8.8.8.8"
+      },
+    })
+    snapshot = assert:snapshot()
+  end)
+
+  after_each(function()
+    snapshot:revert()  -- undo any spying/stubbing etc.
+    unsetup_block()
+    collectgarbage()
+    collectgarbage()
+  end)
+
+  describe("getting targets", function()
+    it("gets an IP address and port number; consistent hashing", function()
+      dnsA({
+        { name = "mashape.com", address = "1.2.3.4" },
+      })
+      dnsA({
+        { name = "getkong.org", address = "5.6.7.8" },
+      })
+      local b = new_balancer({
+        hosts = {
+          {name = "mashape.com", port = 123, weight = 10},
+          {name = "getkong.org", port = 321, weight = 5},
+        },
+        dns = client,
+        wheelSize = (1000),
+      })
+      -- run down the wheel, hitting all indices once
+      local res = {}
+      for n = 1, 1500 do
+        local addr, port, host = b:getPeer(false, nil, tostring(n))
+        res[addr..":"..port] = (res[addr..":"..port] or 0) + 1
+        res[host..":"..port] = (res[host..":"..port] or 0) + 1
+      end
+      -- weight distribution may vary up to 10% when using ketama algorithm
+      assert.is_true(res["1.2.3.4:123"] > 900)
+      assert.is_true(res["1.2.3.4:123"] < 1100)
+      assert.is_true(res["5.6.7.8:321"] > 450)
+      assert.is_true(res["5.6.7.8:321"] < 550)
+      -- hit one index 15 times
+      res = {}
+      local hash = tostring(6)  -- just pick one
+      for _ = 1, 15 do
+        local addr, port, host = b:getPeer(false, nil, hash)
+        res[addr..":"..port] = (res[addr..":"..port] or 0) + 1
+        res[host..":"..port] = (res[host..":"..port] or 0) + 1
+      end
+      assert(15 == res["1.2.3.4:123"] or nil == res["1.2.3.4:123"], "mismatch")
+      assert(15 == res["mashape.com:123"] or nil == res["mashape.com:123"], "mismatch")
+      assert(15 == res["5.6.7.8:321"] or nil == res["5.6.7.8:321"], "mismatch")
+      assert(15 == res["getkong.org:321"] or nil == res["getkong.org:321"], "mismatch")
+    end)
+    it("evaluate the change in the continuum", function()
+      local res1 = {}
+      local res2 = {}
+      local res3 = {}
+      local b = new_balancer({
+        hosts = {
+          {name = "10.0.0.1", port = 1, weight = 100},
+          {name = "10.0.0.2", port = 2, weight = 100},
+          {name = "10.0.0.3", port = 3, weight = 100},
+          {name = "10.0.0.4", port = 4, weight = 100},
+          {name = "10.0.0.5", port = 5, weight = 100},
+        },
+        dns = client,
+        wheelSize = 5000,
+      })
+      for n = 1, 10000 do
+        local addr, port = b:getPeer(false, nil, n)
+        res1[n] = { ip = addr, port = port }
+      end
+      add_target(b, "10.0.0.6", 6, 100)
+      for n = 1, 10000 do
+        local addr, port = b:getPeer(false, nil, n)
+        res2[n] = { ip = addr, port = port }
+      end
+
+      local dif = 0
+      for n = 1, 10000 do
+        if res1[n].ip ~= res2[n].ip or res1[n].port ~= res2[n].port then
+          dif = dif + 1
+        end
+      end
+
+      -- increasing the number of addresses from 5 to 6 should change 49% of
+      -- targets if we were using a simple distribution, like an array.
+      -- anyway, we should be below than 20%.
+      assert((dif/100) < 49, "it should be better than a simple distribution")
+      assert((dif/100) < 20, "it is still to much change ")
+
+
+      add_target(b, "10.0.0.7", 7, 100)
+      add_target(b, "10.0.0.8", 8, 100)
+      for n = 1, 10000 do
+        local addr, port = b:getPeer(false, nil, n)
+        res3[n] = { ip = addr, port = port }
+      end
+
+      dif = 0
+      local dif2 = 0
+      for n = 1, 10000 do
+        if res1[n].ip ~= res3[n].ip or res1[n].port ~= res3[n].port then
+          dif = dif + 1
+        end
+        if res2[n].ip ~= res3[n].ip or res2[n].port ~= res3[n].port then
+          dif2 = dif2 + 1
+        end
+      end
+      -- increasing the number of addresses from 5 to 8 should change 83% of
+      -- targets, and from 6 to 8, 76%, if we were using a simple distribution,
+      -- like an array.
+      -- either way, we should be below than 40% and 25%.
+      assert((dif/100) < 83, "it should be better than a simple distribution")
+      assert((dif/100) < 40, "it is still to much change ")
+      assert((dif2/100) < 76, "it should be better than a simple distribution")
+      assert((dif2/100) < 25, "it is still to much change ")
+    end)
+    it("gets an IP address and port number; consistent hashing skips unhealthy addresses", function()
+      dnsA({
+        { name = "mashape.com", address = "1.2.3.4" },
+      })
+      dnsA({
+        { name = "getkong.org", address = "5.6.7.8" },
+      })
+      local b = new_balancer({
+        hosts = {
+          {name = "mashape.com", port = 123, weight = 100},
+          {name = "getkong.org", port = 321, weight = 50},
+        },
+        dns = client,
+        wheelSize = 1000,
+      })
+      -- mark node down
+      assert(b:setAddressStatus(b:findAddress("1.2.3.4", 123, "mashape.com"), false))
+      -- do a few requests
+      local res = {}
+      for n = 1, 160 do
+        local addr, port, host = b:getPeer(false, nil, n)
+        res[addr..":"..port] = (res[addr..":"..port] or 0) + 1
+        res[host..":"..port] = (res[host..":"..port] or 0) + 1
+      end
+      assert.equal(nil, res["1.2.3.4:123"])     -- address got no hits, key never gets initialized
+      assert.equal(nil, res["mashape.com:123"]) -- host got no hits, key never gets initialized
+      assert.equal(160, res["5.6.7.8:321"])
+      assert.equal(160, res["getkong.org:321"])
+    end)
+    it("does not hit the resolver when 'cache_only' is set", function()
+      local record = dnsA({
+        { name = "mashape.com", address = "1.2.3.4" },
+      })
+      local b = new_balancer({
+        hosts = { { name = "mashape.com", port = 80, weight = 5 } },
+        dns = client,
+        wheelSize = 10,
+      })
+      record.expire = gettime() - 1 -- expire current dns cache record
+      dnsA({   -- create a new record
+        { name = "mashape.com", address = "5.6.7.8" },
+      })
+      -- create a spy to check whether dns was queried
+      spy.on(client, "resolve")
+      local hash = "a value to hash"
+      local cache_only = true
+      local ip, port, host = b:getPeer(cache_only, nil, hash)
+      assert.spy(client.resolve).Not.called_with("mashape.com",nil, nil)
+      assert.equal("1.2.3.4", ip)  -- initial un-updated ip address
+      assert.equal(80, port)
+      assert.equal("mashape.com", host)
+    end)
+  end)
+
+  describe("setting status triggers address-callback", function()
+    it("for IP addresses", function()
+      local count_add = 0
+      local count_remove = 0
+      local b
+      b = new_balancer({
+        hosts = {},  -- no hosts, so balancer is empty
+        dns = client,
+        wheelSize = 10,
+        callback = function(balancer, action, address, ip, port, hostname)
+          assert.equal(b, balancer)
+          if action == "added" then
+            count_add = count_add + 1
+          elseif action == "removed" then
+            count_remove = count_remove + 1
+          elseif action == "health" then  --luacheck: ignore
+            -- nothing to do
+          else
+            error("unknown action received: "..tostring(action))
+          end
+          if action ~= "health" then
+            assert.equals("12.34.56.78", ip)
+            assert.equals(123, port)
+            assert.equals("12.34.56.78", hostname)
+          end
+        end
+      })
+      add_target(b, "12.34.56.78", 123, 100)
+      ngx.sleep(0.1)
+      assert.equal(1, count_add)
+      assert.equal(0, count_remove)
+
+      --b:removeHost("12.34.56.78", 123)
+      b.targets[1].addresses[1].disabled = true
+      b:deleteDisabledAddresses(b.targets[1])
+      ngx.sleep(0.1)
+      assert.equal(1, count_add)
+      assert.equal(1, count_remove)
+    end)
+    it("for 1 level dns", function()
+      local count_add = 0
+      local count_remove = 0
+      local b
+      b = new_balancer({
+        hosts = {},  -- no hosts, so balancer is empty
+        dns = client,
+        wheelSize = 10,
+        callback = function(balancer, action, address, ip, port, hostname)
+          assert.equal(b, balancer)
+          if action == "added" then
+            count_add = count_add + 1
+          elseif action == "removed" then
+            count_remove = count_remove + 1
+          elseif action == "health" then  --luacheck: ignore
+            -- nothing to do
+          else
+            error("unknown action received: "..tostring(action))
+          end
+          if action ~= "health" then
+            assert.equals("12.34.56.78", ip)
+            assert.equals(123, port)
+            assert.equals("mashape.com", hostname)
+          end
+        end
+      })
+      dnsA({
+        { name = "mashape.com", address = "12.34.56.78" },
+        { name = "mashape.com", address = "12.34.56.78" },
+      })
+      add_target(b, "mashape.com", 123, 100)
+      ngx.sleep(0.1)
+      assert.equal(2, count_add)
+      assert.equal(0, count_remove)
+
+      b.targets[1].addresses[1].disabled = true
+      b.targets[1].addresses[2].disabled = true
+      b:deleteDisabledAddresses(b.targets[1])
+      ngx.sleep(0.1)
+      assert.equal(2, count_add)
+      assert.equal(2, count_remove)
+    end)
+    it("for 2+ level dns", function()
+      local count_add = 0
+      local count_remove = 0
+      local b
+      b = new_balancer({
+        hosts = {},  -- no hosts, so balancer is empty
+        dns = client,
+        wheelSize = 10,
+        callback = function(balancer, action, address, ip, port, hostname)
+          assert.equal(b, balancer)
+          if action == "added" then
+            count_add = count_add + 1
+          elseif action == "removed" then
+            count_remove = count_remove + 1
+          elseif action == "health" then  --luacheck: ignore
+            -- nothing to do
+          else
+            error("unknown action received: "..tostring(action))
+          end
+          if action ~= "health" then
+            assert(ip == "mashape1.com" or ip == "mashape2.com")
+            assert(port == 8001 or port == 8002)
+            assert.equals("mashape.com", hostname)
+          end
+        end
+      })
+      dnsA({
+        { name = "mashape1.com", address = "12.34.56.1" },
+      })
+      dnsA({
+        { name = "mashape2.com", address = "12.34.56.2" },
+      })
+      dnsSRV({
+        { name = "mashape.com", target = "mashape1.com", port = 8001, weight = 5 },
+        { name = "mashape.com", target = "mashape2.com", port = 8002, weight = 5 },
+      })
+      add_target(b, "mashape.com", 123, 100)
+      ngx.sleep(0.1)
+      assert.equal(2, count_add)
+      assert.equal(0, count_remove)
+
+      --b:removeHost("mashape.com", 123)
+      b.targets[1].addresses[1].disabled = true
+      b.targets[1].addresses[2].disabled = true
+      b:deleteDisabledAddresses(b.targets[1])
+      ngx.sleep(0.1)
+      assert.equal(2, count_add)
+      assert.equal(2, count_remove)
+    end)
+  end)
+
+  describe("wheel manipulation", function()
+    it("wheel updates are atomic", function()
+      -- testcase for issue #49, see:
+      -- https://github.com/Kong/lua-resty-dns-client/issues/49
+      local order_of_events = {}
+      local b
+      b = new_balancer({
+        hosts = {},  -- no hosts, so balancer is empty
+        dns = client,
+        wheelSize = 10,
+        callback = function(balancer, action, ip, port, hostname)
+          table.insert(order_of_events, "callback")
+          -- this callback is called when updating. So yield here and
+          -- verify that the second thread does not interfere with
+          -- the first update, yielded here.
+          ngx.sleep(0.1)
+        end
+      })
+      dnsA({
+        { name = "mashape1.com", address = "12.34.56.78" },
+      })
+      dnsA({
+        { name = "mashape2.com", address = "123.45.67.89" },
+      })
+      local t1 = ngx.thread.spawn(function()
+        table.insert(order_of_events, "thread1 start")
+        add_target(b, "mashape1.com")
+        table.insert(order_of_events, "thread1 end")
+      end)
+      local t2 = ngx.thread.spawn(function()
+        table.insert(order_of_events, "thread2 start")
+        add_target(b, "mashape2.com")
+        table.insert(order_of_events, "thread2 end")
+      end)
+      ngx.thread.wait(t1)
+      ngx.thread.wait(t2)
+      ngx.sleep(0.1)
+      assert.same({
+        [1] = 'thread1 start',
+        [2] = 'thread1 end',
+        [3] = 'thread2 start',
+        [4] = 'thread2 end',
+        [5] = 'callback',
+        [6] = 'callback',
+        [7] = 'callback',
+      }, order_of_events)
+    end)
+    it("equal weights and 'fitting' indices", function()
+      dnsA({
+        { name = "mashape.com", address = "1.2.3.4" },
+        { name = "mashape.com", address = "1.2.3.5" },
+      })
+      local b = new_balancer({
+        hosts = {"mashape.com"},
+        dns = client,
+        wheelSize = 1000,
+      })
+      local expected = {
+        ["1.2.3.4:80"] = 80,
+        ["1.2.3.5:80"] = 80,
+      }
+      assert.are.same(expected, count_indices(b))
+    end)
+    it("DNS record order has no effect", function()
+      dnsA({
+        { name = "mashape.com", address = "1.2.3.1" },
+        { name = "mashape.com", address = "1.2.3.2" },
+        { name = "mashape.com", address = "1.2.3.3" },
+        { name = "mashape.com", address = "1.2.3.4" },
+        { name = "mashape.com", address = "1.2.3.5" },
+        { name = "mashape.com", address = "1.2.3.6" },
+        { name = "mashape.com", address = "1.2.3.7" },
+        { name = "mashape.com", address = "1.2.3.8" },
+        { name = "mashape.com", address = "1.2.3.9" },
+        { name = "mashape.com", address = "1.2.3.10" },
+      })
+      local b = new_balancer({
+        hosts = {"mashape.com"},
+        dns = client,
+        wheelSize = 1000,
+      })
+      local expected = count_indices(b)
+      dnsA({
+        { name = "mashape.com", address = "1.2.3.8" },
+        { name = "mashape.com", address = "1.2.3.3" },
+        { name = "mashape.com", address = "1.2.3.1" },
+        { name = "mashape.com", address = "1.2.3.2" },
+        { name = "mashape.com", address = "1.2.3.4" },
+        { name = "mashape.com", address = "1.2.3.5" },
+        { name = "mashape.com", address = "1.2.3.6" },
+        { name = "mashape.com", address = "1.2.3.9" },
+        { name = "mashape.com", address = "1.2.3.10" },
+        { name = "mashape.com", address = "1.2.3.7" },
+      })
+      b = new_balancer({
+        hosts = {"mashape.com"},
+        dns = client,
+        wheelSize = 1000,
+      })
+
+      assert.are.same(expected, count_indices(b))
+    end)
+    it("changing hostname order has no effect", function()
+      dnsA({
+        { name = "mashape.com", address = "1.2.3.1" },
+      })
+      dnsA({
+        { name = "getkong.org", address = "1.2.3.2" },
+      })
+      local b = new_balancer {
+        hosts = {"mashape.com", "getkong.org"},
+        dns = client,
+        wheelSize = 1000,
+      }
+      local expected = count_indices(b)
+      b = new_balancer({
+        hosts = {"getkong.org", "mashape.com"},  -- changed host order
+        dns = client,
+        wheelSize = 1000,
+      })
+      assert.are.same(expected, count_indices(b))
+    end)
+    it("adding a host", function()
+      dnsA({
+        { name = "mashape.com", address = "1.2.3.4" },
+        { name = "mashape.com", address = "1.2.3.5" },
+      })
+      dnsAAAA({
+        { name = "getkong.org", address = "::1" },
+      })
+      local b = new_balancer({
+        hosts = { { name = "mashape.com", port = 80, weight = 5 } },
+        dns = client,
+        wheelSize = 2000,
+      })
+      add_target(b, "getkong.org", 8080, 10 )
+      local expected = {
+        ["1.2.3.4:80"] = 80,
+        ["1.2.3.5:80"] = 80,
+        ["[::1]:8080"] = 160,
+      }
+      assert.are.same(expected, count_indices(b))
+    end)
+    it("removing the last host", function()
+      dnsA({
+        { name = "mashape.com", address = "1.2.3.4" },
+        { name = "mashape.com", address = "1.2.3.5" },
+      })
+      dnsAAAA({
+        { name = "getkong.org", address = "::1" },
+      })
+      local b = new_balancer({
+        dns = client,
+        wheelSize = 1000,
+      })
+      add_target(b, "mashape.com", 80, 5)
+      add_target(b, "getkong.org", 8080, 10)
+      --b:removeHost("getkong.org", 8080)
+      --b:removeHost("mashape.com", 80)
+    end)
+    it("weight change updates properly", function()
+      dnsA({
+        { name = "mashape.com", address = "1.2.3.4" },
+        { name = "mashape.com", address = "1.2.3.5" },
+      })
+      dnsAAAA({
+        { name = "getkong.org", address = "::1" },
+      })
+      local b = new_balancer({
+        dns = client,
+        wheelSize = 1000,
+      })
+      add_target(b, "mashape.com", 80, 10)
+      add_target(b, "getkong.org", 80, 10)
+      local count = count_indices(b)
+      -- 2 hosts -> 320 points
+      -- resolved to 3 addresses with same weight -> 106 points each
+      assert.same({
+        ["1.2.3.4:80"] = 106,
+        ["1.2.3.5:80"] = 106,
+        ["[::1]:80"]   = 106,
+      }, count)
+
+      add_target(b, "mashape.com", 80, 25)
+      count = count_indices(b)
+      -- 2 hosts -> 320 points
+      -- 1 with 83% of weight resolved to 2 addresses -> 133 points each addr
+      -- 1 with 16% of weight resolved to 1 address -> 53 points
+      assert.same({
+        ["1.2.3.4:80"] = 133,
+        ["1.2.3.5:80"] = 133,
+        ["[::1]:80"]   = 53,
+      }, count)
+    end)
+    it("weight change ttl=0 record, updates properly", function()
+      -- mock the resolve/toip methods
+      local old_resolve = client.resolve
+      local old_toip = client.toip
+      finally(function()
+        client.resolve = old_resolve
+        client.toip = old_toip
+      end)
+      client.resolve = function(name, ...)
+        if name == "mashape.com" then
+          local record = dnsA({
+            { name = "mashape.com", address = "1.2.3.4", ttl = 0 },
+          })
+          return record
+        else
+          return old_resolve(name, ...)
+        end
+      end
+      client.toip = function(name, ...)
+        if name == "mashape.com" then
+          return "1.2.3.4", ...
+        else
+          return old_toip(name, ...)
+        end
+      end
+
+      -- insert 2nd address
+      dnsA({
+        { name = "getkong.org", address = "9.9.9.9", ttl = 60*60 },
+      })
+
+      local b = new_balancer({
+        hosts = {
+          { name = "mashape.com", port = 80, weight = 50 },
+          { name = "getkong.org", port = 123, weight = 50 },
+        },
+        dns = client,
+        wheelSize = 100,
+        ttl0 = 2,
+      })
+
+      local count = count_indices(b)
+      assert.same({
+        ["mashape.com:80"] = 160,
+        ["9.9.9.9:123"] = 160,
+      }, count)
+
+      -- update weights
+      add_target(b, "mashape.com", 80, 150)
+
+      count = count_indices(b)
+      -- total weight: 200
+      -- 2 hosts: 320 points
+      -- 75%: 240, 25%: 80
+      assert.same({
+        ["mashape.com:80"] = 240,
+        ["9.9.9.9:123"] = 80,
+      }, count)
+    end)
+    it("weight change for unresolved record, updates properly", function()
+      local record = dnsA({
+        { name = "really.really.really.does.not.exist.thijsschreijer.nl", address = "1.2.3.4" },
+      })
+      dnsAAAA({
+        { name = "getkong.org", address = "::1" },
+      })
+      local b = new_balancer({
+        dns = client,
+        wheelSize = 1000,
+        requery = 1,
+      })
+      add_target(b, "really.really.really.does.not.exist.thijsschreijer.nl", 80, 10)
+      add_target(b, "getkong.org", 80, 10)
+      local count = count_indices(b)
+      assert.same({
+        ["1.2.3.4:80"] = 160,
+        ["[::1]:80"]   = 160,
+      }, count)
+
+      -- expire the existing record
+      record.expire = 0
+      record.expired = true
+      -- do a lookup to trigger the async lookup
+      client.resolve("really.really.really.does.not.exist.thijsschreijer.nl", {qtype = client.TYPE_A})
+      sleep(1) -- provide time for async lookup to complete
+
+      --b:_hit_all() -- hit them all to force renewal
+      targets.resolve_targets(b.targets)
+
+      count = count_indices(b)
+      assert.same({
+        --["1.2.3.4:80"] = 0,  --> failed to resolve, no more entries
+        ["[::1]:80"]   = 320,
+      }, count)
+
+      -- update the failed record
+      add_target(b, "really.really.really.does.not.exist.thijsschreijer.nl", 80, 20)
+      -- reinsert a cache entry
+      dnsA({
+        { name = "really.really.really.does.not.exist.thijsschreijer.nl", address = "1.2.3.4" },
+      })
+      --sleep(2)  -- wait for timer to re-resolve the record
+      targets.resolve_targets(b.targets)
+
+      count = count_indices(b)
+      -- 66%: 213 points
+      -- 33%: 106 points
+      assert.same({
+        ["1.2.3.4:80"] = 213,
+        ["[::1]:80"]   = 106,
+      }, count)
+    end)
+    it("weight change SRV record, has no effect", function()
+      dnsA({
+        { name = "mashape.com", address = "1.2.3.4" },
+        { name = "mashape.com", address = "1.2.3.5" },
+      })
+      dnsSRV({
+        { name = "gelato.io", target = "1.2.3.6", port = 8001, weight = 5 },
+        { name = "gelato.io", target = "1.2.3.6", port = 8002, weight = 5 },
+      })
+      local b = new_balancer({
+        dns = client,
+        wheelSize = 1000,
+      })
+      add_target(b, "mashape.com", 80, 10)
+      add_target(b, "gelato.io", 80, 10)  --> port + weight will be ignored
+      local count = count_indices(b)
+      local state = copyWheel(b)
+      -- 33%: 106 points
+      -- 16%: 53 points
+      assert.same({
+        ["1.2.3.4:80"]   = 106,
+        ["1.2.3.5:80"]   = 106,
+        ["1.2.3.6:8001"] = 53,
+        ["1.2.3.6:8002"] = 53,
+      }, count)
+
+      add_target(b, "gelato.io", 80, 20)  --> port + weight will be ignored
+      count = count_indices(b)
+      assert.same({
+        ["1.2.3.4:80"]   = 106,
+        ["1.2.3.5:80"]   = 106,
+        ["1.2.3.6:8001"] = 53,
+        ["1.2.3.6:8002"] = 53,
+      }, count)
+      assert.same(state, copyWheel(b))
+    end)
+    it("renewed DNS A record; no changes", function()
+      local record = dnsA({
+        { name = "mashape.com", address = "1.2.3.4" },
+        { name = "mashape.com", address = "1.2.3.5" },
+      })
+      dnsA({
+        { name = "getkong.org", address = "9.9.9.9" },
+      })
+      local b = new_balancer({
+        hosts = {
+          { name = "mashape.com", port = 80, weight = 5 },
+          { name = "getkong.org", port = 123, weight = 10 },
+        },
+        dns = client,
+        wheelSize = 100,
+      })
+      local state = copyWheel(b)
+      record.expire = gettime() -1 -- expire current dns cache record
+      dnsA({   -- create a new record (identical)
+        { name = "mashape.com", address = "1.2.3.4" },
+        { name = "mashape.com", address = "1.2.3.5" },
+      })
+      -- create a spy to check whether dns was queried
+      spy.on(client, "resolve")
+      -- call all, to make sure we hit the expired one
+      -- invoke balancer, to expire record and re-query dns
+      --b:_hit_all()
+      targets.resolve_targets(b.targets)
+      assert.spy(client.resolve).was_called_with("mashape.com",nil, nil)
+      assert.same(state, copyWheel(b))
+    end)
+
+    it("renewed DNS AAAA record; no changes", function()
+      local record = dnsAAAA({
+        { name = "mashape.com", address = "::1" },
+        { name = "mashape.com", address = "::2" },
+      })
+      dnsA({
+        { name = "getkong.org", address = "9.9.9.9" },
+      })
+      local b = new_balancer({
+        hosts = {
+          { name = "mashape.com", port = 80, weight = 5 },
+          { name = "getkong.org", port = 123, weight = 10 },
+        },
+        dns = client,
+        wheelSize = 100,
+      })
+      local state = copyWheel(b)
+      record.expire = gettime() -1 -- expire current dns cache record
+      dnsAAAA({   -- create a new record (identical)
+        { name = "mashape.com", address = "::1" },
+        { name = "mashape.com", address = "::2" },
+      })
+      -- create a spy to check whether dns was queried
+      spy.on(client, "resolve")
+      -- call all, to make sure we hit the expired one
+      -- invoke balancer, to expire record and re-query dns
+      --b:_hit_all()
+      targets.resolve_targets(b.targets)
+      assert.spy(client.resolve).was_called_with("mashape.com",nil, nil)
+      assert.same(state, copyWheel(b))
+    end)
+    it("renewed DNS SRV record; no changes", function()
+      local record = dnsSRV({
+        { name = "gelato.io", target = "1.2.3.6", port = 8001, weight = 5 },
+        { name = "gelato.io", target = "1.2.3.6", port = 8002, weight = 5 },
+        { name = "gelato.io", target = "1.2.3.6", port = 8003, weight = 5 },
+      })
+      dnsA({
+        { name = "getkong.org", address = "9.9.9.9" },
+      })
+      local b = new_balancer({
+        hosts = {
+          { name = "gelato.io" },
+          { name = "getkong.org", port = 123, weight = 10 },
+        },
+        dns = client,
+        wheelSize = 100,
+      })
+      local state = copyWheel(b)
+      record.expire = gettime() -1 -- expire current dns cache record
+      dnsSRV({    -- create a new record (identical)
+        { name = "gelato.io", target = "1.2.3.6", port = 8001, weight = 5 },
+        { name = "gelato.io", target = "1.2.3.6", port = 8002, weight = 5 },
+        { name = "gelato.io", target = "1.2.3.6", port = 8003, weight = 5 },
+      })
+      -- create a spy to check whether dns was queried
+      spy.on(client, "resolve")
+      -- call all, to make sure we hit the expired one
+      -- invoke balancer, to expire record and re-query dns
+      --b:_hit_all()
+      targets.resolve_targets(b.targets)
+      assert.spy(client.resolve).was_called_with("gelato.io",nil, nil)
+      assert.same(state, copyWheel(b))
+    end)
+    it("low weight with zero-indices assigned doesn't fail", function()
+      -- depending on order of insertion it is either 1 or 0 indices
+      -- but it may never error.
+      dnsA({
+        { name = "mashape.com", address = "1.2.3.4" },
+      })
+      dnsA({
+        { name = "getkong.org", address = "9.9.9.9" },
+      })
+      new_balancer({
+        hosts = {
+          { name = "mashape.com", port = 80, weight = 99999 },
+          { name = "getkong.org", port = 123, weight = 1 },
+        },
+        dns = client,
+        wheelSize = 1000,
+      })
+      -- Now the order reversed (weights exchanged)
+      dnsA({
+        { name = "mashape.com", address = "1.2.3.4" },
+      })
+      dnsA({
+        { name = "getkong.org", address = "9.9.9.9" },
+      })
+      new_balancer({
+        hosts = {
+          { name = "mashape.com", port = 80, weight = 1 },
+          { name = "getkong.org", port = 123, weight = 99999 },
+        },
+        dns = client,
+        wheelSize = 1000,
+      })
+    end)
+    it("SRV record with 0 weight doesn't fail resolving", function()
+      -- depending on order of insertion it is either 1 or 0 indices
+      -- but it may never error.
+      dnsSRV({
+        { name = "gelato.io", target = "1.2.3.6", port = 8001, weight = 0 },
+        { name = "gelato.io", target = "1.2.3.6", port = 8002, weight = 0 },
+      })
+      local b = new_balancer({
+        hosts = {
+          -- port and weight will be overridden by the above
+          { name = "gelato.io", port = 80, weight = 99999 },
+        },
+        dns = client,
+        wheelSize = 100,
+      })
+      local ip, port = b:getPeer(false, nil, "test")
+      assert.equal("1.2.3.6", ip)
+      assert(port == 8001 or port == 8002, "port expected 8001 or 8002")
+    end)
+    it("recreate Kong issue #2131", function()
+      -- erasing does not remove the address from the host
+      -- so if the same address is added again, and then deleted again
+      -- then upon erasing it will find the previous erased address object,
+      -- and upon erasing again a nil-referencing issue then occurs
+      local ttl = 1
+      local record
+      local hostname = "dnstest.mashape.com"
+
+      -- mock the resolve/toip methods
+      local old_resolve = client.resolve
+      local old_toip = client.toip
+      finally(function()
+        client.resolve = old_resolve
+        client.toip = old_toip
+      end)
+      client.resolve = function(name, ...)
+        if name == hostname then
+          record = dnsA({
+            { name = hostname, address = "1.2.3.4", ttl = ttl },
+          })
+          return record
+        else
+          return old_resolve(name, ...)
+        end
+      end
+      client.toip = function(name, ...)
+        if name == hostname then
+          return "1.2.3.4", ...
+        else
+          return old_toip(name, ...)
+        end
+      end
+
+      -- create a new balancer
+      local b = new_balancer({
+        hosts = {
+          { name = hostname, port = 80, weight = 50 },
+        },
+        dns = client,
+        wheelSize = 1000,
+        ttl0 = 1,
+      })
+
+      sleep(1.1) -- wait for ttl to expire
+      -- fetch a peer to reinvoke dns and update balancer, with a ttl=0
+      ttl = 0
+      b:getPeer(false, nil, "value")   --> force update internal from A to SRV
+      sleep(1.1) -- wait for ttl0, as provided to balancer, to expire
+      -- restore ttl to non-0, and fetch a peer to update balancer
+      ttl = 1
+      b:getPeer(false, nil, "value")   --> force update internal from SRV to A
+      sleep(1.1) -- wait for ttl to expire
+      -- fetch a peer to reinvoke dns and update balancer, with a ttl=0
+      ttl = 0
+      b:getPeer(false, nil, "value")   --> force update internal from A to SRV
+    end)
+  end)
+end)

--- a/spec/01-unit/09-balancer/04-round_robin_spec.lua
+++ b/spec/01-unit/09-balancer/04-round_robin_spec.lua
@@ -1,0 +1,1575 @@
+
+assert:set_parameter("TableFormatLevel", 5) -- when displaying tables, set a bigger default depth
+
+------------------------
+-- START TEST HELPERS --
+------------------------
+local client
+local targets, balancers
+
+local dns_utils = require "resty.dns.utils"
+local mocker = require "spec.fixtures.mocker"
+local utils = require "kong.tools.utils"
+
+local ws_id = utils.uuid()
+
+local helpers = require "spec.helpers.dns"
+local gettime = helpers.gettime
+local sleep = helpers.sleep
+local dnsSRV = function(...) return helpers.dnsSRV(client, ...) end
+local dnsA = function(...) return helpers.dnsA(client, ...) end
+local dnsAAAA = function(...) return helpers.dnsAAAA(client, ...) end
+
+
+local unset_register = {}
+local function setup_block(consistency)
+  local cache_table = {}
+
+  local function mock_cache()
+    return {
+      safe_set = function(self, k, v)
+        cache_table[k] = v
+        return true
+      end,
+      get = function(self, k, _, fn, arg)
+        if cache_table[k] == nil then
+          cache_table[k] = fn(arg)
+        end
+        return cache_table[k]
+      end,
+    }
+  end
+
+  local function register_unsettter(f)
+    table.insert(unset_register, f)
+  end
+
+  mocker.setup(register_unsettter, {
+    kong = {
+      configuration = {
+        worker_consistency = consistency,
+        worker_state_update_frequency = 0.1,
+      },
+      core_cache = mock_cache(cache_table),
+    },
+    ngx = {
+      ctx = {
+        workspace = ws_id,
+      }
+    }
+  })
+end
+
+local function unsetup_block()
+  for _, f in ipairs(unset_register) do
+    f()
+  end
+end
+
+
+
+local function insert_target(b, name, port, weight)
+  -- adding again changes weight
+  for _, prev_target in ipairs(b.targets) do
+    if prev_target.name == name and prev_target.port == port then
+      local entry = {port = port}
+      for _, addr in ipairs(prev_target.addresses) do
+        entry.address = addr.ip
+        b:changeWeight(prev_target, entry, weight)
+      end
+      prev_target.weight = weight
+      return prev_target
+    end
+  end
+
+  if type(name) == "table" then
+    local entry = name
+    name = entry.name or entry[1]
+    port = entry.port or entry[2]
+    weight = entry.weight or entry[3]
+  end
+
+  local target = {
+    upstream = b.upstream_id,
+    balancer = b,
+    name = name,
+    nameType = dns_utils.hostnameType(name),
+    addresses = {},
+    port = port or 80,
+    weight = weight or 100,
+    totalWeight = 0,
+    unavailableWeight = 0,
+  }
+  table.insert(b.targets, target)
+
+  return target
+end
+
+local function add_target(b, ...)
+  local target = insert_target(b, ...)
+  targets.resolve_targets(b.targets)
+  return target
+end
+
+
+local upstream_index = 0
+local function new_balancer(opts)
+  upstream_index = upstream_index + 1
+  local upname="upstream_" .. upstream_index
+  local hc_defaults = {
+    active = {
+      timeout = 1,
+      concurrency = 10,
+      http_path = "/",
+      healthy = {
+        interval = 0,  -- 0 = probing disabled by default
+        http_statuses = { 200, 302 },
+        successes = 0, -- 0 = disabled by default
+      },
+      unhealthy = {
+        interval = 0, -- 0 = probing disabled by default
+        http_statuses = { 429, 404,
+                          500, 501, 502, 503, 504, 505 },
+        tcp_failures = 0,  -- 0 = disabled by default
+        timeouts = 0,      -- 0 = disabled by default
+        http_failures = 0, -- 0 = disabled by default
+      },
+    },
+    passive = {
+      healthy = {
+        http_statuses = { 200, 201, 202, 203, 204, 205, 206, 207, 208, 226,
+                          300, 301, 302, 303, 304, 305, 306, 307, 308 },
+        successes = 0,
+      },
+      unhealthy = {
+        http_statuses = { 429, 500, 503 },
+        tcp_failures = 0,  -- 0 = circuit-breaker disabled by default
+        timeouts = 0,      -- 0 = circuit-breaker disabled by default
+        http_failures = 0, -- 0 = circuit-breaker disabled by default
+      },
+    },
+  }
+  local my_upstream = { id=upname, name=upname, ws_id=ws_id, slots=10, healthchecks=hc_defaults, algorithm="round-robin" }
+  local b = (balancers.create_balancer(my_upstream, true))
+
+  for k, v in pairs{
+    wheelSize = opts.wheelSize,
+    requeryInterval = opts.requery,
+    ttl0Interval = opts.ttl0,
+  } do
+    b[k] = v
+  end
+
+  if opts.callback then
+    b:setCallback(opts.callback)
+  end
+
+  for _, target in ipairs(opts.hosts or {}) do
+    insert_target(b, target)
+  end
+  targets.resolve_targets(b.targets)
+
+  return b
+end
+
+
+
+-- checks the integrity of a list, returns the length of list + number of non-array keys
+local check_list = function(t)
+  local size = 0
+  local keys = 0
+  for i, _ in pairs(t) do
+    if (type(i) == "number") then
+      if (i > size) then size = i end
+    else
+      keys = keys + 1
+    end
+  end
+  for i = 1, size do
+    assert(t[i], "invalid sequence, index "..tostring(i).." is missing")
+  end
+  return size, keys
+end
+
+-- checks the integrity of the balancer, hosts, addresses, and indices. returns the balancer.
+local check_balancer = function(b)
+  assert.is.table(b)
+  assert.is.table(b.algorithm)
+  check_list(b.targets)
+  assert.are.equal(b.algorithm.wheelSize, check_list(b.algorithm.wheel))
+  return b
+end
+
+-- creates a hash table with "address:port" keys and as value the number of indices
+local function count_indices(b)
+  local r = {}
+  for _, address in ipairs(b.algorithm.wheel) do
+    local key = tostring(address.ip)
+    if key:find(":",1,true) then
+      key = "["..key.."]:"..address.port
+    else
+      key = key..":"..address.port
+    end
+    r[key] = (r[key] or 0) + 1
+  end
+  return r
+end
+
+-- copies the wheel to a list with ip, port and hostname in the field values.
+-- can be used for before/after comparison
+local copyWheel = function(b)
+  local copy = {}
+  for i, address in ipairs(b.algorithm.wheel) do
+    copy[i] = i.." - "..address.ip.." @ "..address.port.." ("..address.target.name..")"
+  end
+  return copy
+end
+
+local updateWheelState = function(state, patt, repl)
+  for i, entry in ipairs(state) do
+    state[i] = entry:gsub(patt, repl, 1)
+  end
+  return state
+end
+----------------------
+-- END TEST HELPERS --
+----------------------
+
+
+describe("[round robin balancer]", function()
+
+  local snapshot
+
+  setup(function()
+    _G.package.loaded["resty.dns.client"] = nil -- make sure module is reloaded
+    _G.package.loaded["kong.runloop.balancer.targets"] = nil -- make sure module is reloaded
+
+    client = require "resty.dns.client"
+    targets = require "kong.runloop.balancer.targets"
+    balancers = require "kong.runloop.balancer.balancers"
+    local healthcheckers = require "kong.runloop.balancer.healthcheckers"
+    healthcheckers.init()
+    balancers.init()
+
+    local singletons = require "kong.singletons"
+    singletons.worker_events = require "resty.worker.events"
+    singletons.worker_events.configure({
+      shm = "kong_process_events", -- defined by "lua_shared_dict"
+      timeout = 5,            -- life time of event data in shm
+      interval = 1,           -- poll interval (seconds)
+
+      wait_interval = 0.010,  -- wait before retry fetching event data
+      wait_max = 0.5,         -- max wait time before discarding event
+    })
+
+    local function empty_each()
+      return function() end
+    end
+
+    singletons.db = {
+      targets = {
+        each = empty_each,
+        select_by_upstream_raw = function()
+          return {}
+        end
+      },
+      upstreams = {
+        each = empty_each,
+        select = function() end,
+      },
+    }
+
+    singletons.core_cache = {
+      _cache = {},
+      get = function(self, key, _, loader, arg)
+        local v = self._cache[key]
+        if v == nil then
+          v = loader(arg)
+          self._cache[key] = v
+        end
+        return v
+      end,
+      invalidate_local = function(self, key)
+        self._cache[key] = nil
+      end
+    }
+
+  end)
+
+  before_each(function()
+    setup_block()
+    assert(client.init {
+      hosts = {},
+      resolvConf = {
+        "nameserver 8.8.8.8"
+      },
+    })
+    snapshot = assert:snapshot()
+  end)
+
+  after_each(function()
+    unsetup_block()
+    snapshot:revert()  -- undo any spying/stubbing etc.
+    collectgarbage()
+    collectgarbage()
+  end)
+
+  describe("unit tests", function()
+    it("addressIter", function()
+      dnsA({
+        { name = "mashape.test", address = "1.2.3.4" },
+        { name = "mashape.test", address = "1.2.3.5" },
+      })
+      dnsAAAA({
+        { name = "getkong.test", address = "::1" },
+      })
+      dnsSRV({
+        { name = "gelato.test", target = "1.2.3.6", port = 8001 },
+        { name = "gelato.test", target = "1.2.3.6", port = 8002 },
+        { name = "gelato.test", target = "1.2.3.6", port = 8003 },
+      })
+      local b = new_balancer{
+        hosts = {"mashape.test", "getkong.test", "gelato.test" },
+        dns = client,
+        wheelSize = 10,
+      }
+      local count = 0
+      --for _,_,_ in b:addressIter() do count = count + 1 end
+      b:eachAddress(function() count = count + 1  end)
+      assert.equals(6, count)
+    end)
+
+    describe("create", function()
+      it("succeeds with proper options", function()
+        dnsA({
+          { name = "mashape.test", address = "1.2.3.4" },
+          { name = "mashape.test", address = "1.2.3.5" },
+        })
+        check_balancer(new_balancer{
+          hosts = {"mashape.test"},
+          dns = client,
+          requery = 2,
+          ttl0 = 5,
+          callback = function() end,
+        })
+      end)
+      it("succeeds without 'hosts' option", function()
+        local b = check_balancer(new_balancer{
+          dns = client,
+        })
+        assert.are.equal(0, #b.algorithm.wheel)
+
+        b = check_balancer(new_balancer{
+          dns = client,
+          hosts = {},  -- empty hosts table hould work too
+        })
+        assert.are.equal(0, #b.algorithm.wheel)
+      end)
+      it("succeeds with multiple hosts", function()
+        dnsA({
+          { name = "mashape.test", address = "1.2.3.4" },
+        })
+        dnsAAAA({
+          { name = "getkong.test", address = "::1" },
+        })
+        dnsSRV({
+          { name = "gelato.test", target = "1.2.3.4", port = 8001 },
+        })
+        local b = new_balancer{
+          hosts = {"mashape.test", "getkong.test", "gelato.test" },
+          dns = client,
+          wheelSize = 10,
+        }
+        check_balancer(b)
+      end)
+    end)
+
+    describe("adding hosts", function()
+      it("accepts a hostname that does not resolve", function()
+        -- weight should be 0, with no addresses
+        local b = check_balancer(new_balancer {
+          dns = client,
+          wheelSize = 15,
+        })
+        assert(add_target(b, "really.really.really.does.not.exist.thijsschreijer.nl", 80, 10))
+        check_balancer(b)
+        assert.equals(0, b.totalWeight) -- has one failed host, so weight must be 0
+        dnsA({
+          { name = "mashape.test", address = "1.2.3.4" },
+        })
+        add_target(b, "mashape.test", 80, 10)
+        check_balancer(b)
+        assert.equals(10, b.totalWeight) -- has one succesful host, so weight must equal that one
+      end)
+      it("accepts a hostname when dns server is unavailable #slow", function()
+        -- This test might show some error output similar to the lines below. This is expected and ok.
+        -- 2016/11/07 16:48:33 [error] 81932#0: *2 recv() failed (61: Connection refused), context: ngx.timer
+
+        -- reconfigure the dns client to make sure query fails
+        assert(client.init {
+          hosts = {},
+          resolvConf = {
+            "nameserver 127.0.0.1:22000" -- make sure dns query fails
+          },
+        })
+        -- create balancer
+        local b = check_balancer(new_balancer {
+         requery = 0.1,
+         hosts = {
+            { name = "mashape.test", port = 80, weight = 10 },
+          },
+          dns = client,
+        })
+        assert.equal(0, b.totalWeight)
+      end)
+      it("updates the weight when 'hostname:port' combo already exists", function()
+        -- returns nil + error
+        local b = check_balancer(new_balancer {
+          dns = client,
+          wheelSize = 15,
+        })
+        dnsA({
+          { name = "mashape.test", address = "1.2.3.4" },
+        })
+        add_target(b, "mashape.test", 80, 10)
+        check_balancer(b)
+        assert.equal(10, b.totalWeight)
+
+        add_target(b, "mashape.test", 81, 20)  -- different port
+        check_balancer(b)
+        assert.equal(30, b.totalWeight)
+
+        add_target(b, "mashape.test", 80, 5)  -- reduce weight by 5
+        check_balancer(b)
+        assert.equal(25, b.totalWeight)
+      end)
+    end)
+
+    describe("setting status", function()
+      it("valid target is accepted", function()
+        local b = check_balancer(new_balancer { dns = client })
+        dnsA({
+          { name = "kong.inc", address = "4.3.2.1" },
+        })
+        add_target(b, "1.2.3.4", 80, 10)
+        add_target(b, "kong.inc", 80, 10)
+        --local ok, err = b:setAddressStatus(false, "1.2.3.4", 80, "1.2.3.4")
+        local ok, err = b:setAddressStatus(b:findAddress("1.2.3.4", 80, "1.2.3.4"), false)
+        assert.is_true(ok)
+        assert.is_nil(err)
+        ok, err = b:setAddressStatus(b:findAddress("4.3.2.1", 80, "kong.inc"), false)
+        assert.is_true(ok)
+        assert.is_nil(err)
+      end)
+      it("valid address accepted", function()
+        local b = check_balancer(new_balancer { dns = client })
+        dnsA({
+          { name = "kong.inc", address = "4.3.2.1" },
+        })
+        add_target(b, "kong.inc", 80, 10)
+        local _, _, _, handle = b:getPeer()
+        local ok, err = b:setAddressStatus(handle.address, false)
+        assert.is_true(ok)
+        assert.is_nil(err)
+      end)
+      it("invalid target returns an error", function()
+        local b = check_balancer(new_balancer { dns = client })
+        dnsA({
+          { name = "kong.inc", address = "4.3.2.1" },
+        })
+        add_target(b, "1.2.3.4", 80, 10)
+        add_target(b, "kong.inc", 80, 10)
+
+        --local ok, err = b:setAddressStatus(false, "1.1.1.1", 80)
+        local ok, err = b:setAddressStatus(b:findAddress("1.1.1.1", 80), false)
+        assert.is_nil(ok)
+        --assert.equals("no peer found by name '1.1.1.1' and address 1.1.1.1:80", err)
+        assert.is_string(err)
+        ok, err = b:setAddressStatus(b:findAddress("1.1.1.1", 80, "kong.inc"), false)
+        assert.is_nil(ok)
+        --assert.equals("no peer found by name 'kong.inc' and address 1.1.1.1:80", err)
+        assert.is_string(err)
+      end)
+      it("SRV target with A record targets can be changed with a handle", function()
+        local b = check_balancer(new_balancer { dns = client })
+        dnsA({
+          { name = "mashape1.test", address = "12.34.56.1" },
+        })
+        dnsA({
+          { name = "mashape2.test", address = "12.34.56.2" },
+        })
+        dnsSRV({
+          { name = "mashape.test", target = "mashape1.test", port = 8001, weight = 5 },
+          { name = "mashape.test", target = "mashape2.test", port = 8002, weight = 5 },
+        })
+        add_target(b, "mashape.test", 80, 10)
+
+        local _, _, _, handle = b:getPeer()
+        local ok, err = b:setAddressStatus(handle.address, false)
+        assert.is_true(ok)
+        assert.is_nil(err)
+
+        _, _, _, handle = b:getPeer()
+        ok, err = b:setAddressStatus(handle.address, false)
+        assert.is_true(ok)
+        assert.is_nil(err)
+
+        local ip, port = b:getPeer()
+        assert.is_nil(ip)
+        assert.matches("Balancer is unhealthy", port)
+
+      end)
+      it("SRV target with A record targets can be changed with an address", function()
+        local b = check_balancer(new_balancer { dns = client })
+        dnsA({
+          { name = "mashape1.test", address = "12.34.56.1" },
+        })
+        dnsA({
+          { name = "mashape2.test", address = "12.34.56.2" },
+        })
+        dnsSRV({
+          { name = "mashape.test", target = "mashape1.test", port = 8001, weight = 5 },
+          { name = "mashape.test", target = "mashape2.test", port = 8002, weight = 5 },
+        })
+        add_target(b, "mashape.test", 80, 10)
+
+        local _, _, _, handle = b:getPeer()
+        local ok, err = b:setAddressStatus(handle.address, false)
+        assert.is_true(ok)
+        assert.is_nil(err)
+
+        _, _, _, handle = b:getPeer()
+        ok, err = b:setAddressStatus(handle.address, false)
+        assert.is_true(ok)
+        assert.is_nil(err)
+
+        local ip, port = b:getPeer()
+        assert.is_nil(ip)
+        assert.matches("Balancer is unhealthy", port)
+
+      end)
+      it("SRV target with port=0 returns the default port", function()
+        local b = check_balancer(new_balancer { dns = client })
+        dnsA({
+          { name = "mashape1.test", address = "12.34.56.78" },
+        })
+        dnsSRV({
+          { name = "mashape.test", target = "mashape1.test", port = 0, weight = 5 },
+        })
+        add_target(b, "mashape.test", 80, 10)
+        local ip, port = b:getPeer()
+        assert.equals("12.34.56.78", ip)
+        assert.equals(80, port)
+      end)
+    end)
+
+  end)
+
+  describe("getting targets", function()
+    it("gets an IP address, port and hostname for named SRV entries", function()
+      -- this case is special because it does a last-minute `toip` call and hence
+      -- uses a different code branch
+      -- See issue #17
+      dnsA({
+        { name = "mashape.test", address = "1.2.3.4" },
+      })
+      dnsSRV({
+        { name = "gelato.test", target = "mashape.test", port = 8001 },
+      })
+      local b = check_balancer(new_balancer {
+        hosts = {
+          {name = "gelato.test", port = 123, weight = 100},
+        },
+        dns = client,
+      })
+      local addr, port, host = b:getPeer()
+      assert.equal("1.2.3.4", addr)
+      assert.equal(8001, port)
+      assert.equal("gelato.test", host)
+    end)
+    it("gets an IP address and port number; round-robin", function()
+      dnsA({
+        { name = "mashape.test", address = "1.2.3.4" },
+      })
+      dnsA({
+        { name = "getkong.test", address = "5.6.7.8" },
+      })
+      local b = check_balancer(new_balancer {
+        hosts = {
+          {name = "mashape.test", port = 123, weight = 100},
+          {name = "getkong.test", port = 321, weight = 50},
+        },
+        dns = client,
+      })
+      -- run down the wheel twice
+      local res = {}
+      for _ = 1, 15*2 do
+        local addr, port, host = b:getPeer()
+        res[addr..":"..port] = (res[addr..":"..port] or 0) + 1
+        res[host..":"..port] = (res[host..":"..port] or 0) + 1
+      end
+      assert.equal(20, res["1.2.3.4:123"])
+      assert.equal(20, res["mashape.test:123"])
+      assert.equal(10, res["5.6.7.8:321"])
+      assert.equal(10, res["getkong.test:321"])
+    end)
+    it("gets an IP address and port number; round-robin skips unhealthy addresses", function()
+      dnsA({
+        { name = "mashape.test", address = "1.2.3.4" },
+      })
+      dnsA({
+        { name = "getkong.test", address = "5.6.7.8" },
+      })
+      local b = check_balancer(new_balancer {
+        hosts = {
+          {name = "mashape.test", port = 123, weight = 100},
+          {name = "getkong.test", port = 321, weight = 50},
+        },
+        dns = client,
+        wheelSize = 15,
+      })
+      -- mark node down
+      assert(b:setAddressStatus(b:findAddress("1.2.3.4", 123, "mashape.test"), false))
+      -- run down the wheel twice
+      local res = {}
+      for _ = 1, 15*2 do
+        local addr, port, host = b:getPeer()
+        res[addr..":"..port] = (res[addr..":"..port] or 0) + 1
+        res[host..":"..port] = (res[host..":"..port] or 0) + 1
+      end
+      assert.equal(nil, res["1.2.3.4:123"])     -- address got no hits, key never gets initialized
+      assert.equal(nil, res["mashape.test:123"]) -- host got no hits, key never gets initialized
+      assert.equal(30, res["5.6.7.8:321"])
+      assert.equal(30, res["getkong.test:321"])
+    end)
+    it("does not hit the resolver when 'cache_only' is set", function()
+      local record = dnsA({
+        { name = "mashape.test", address = "1.2.3.4" },
+      })
+      local b = check_balancer(new_balancer {
+        hosts = { { name = "mashape.test", port = 80, weight = 5 } },
+        dns = client,
+        wheelSize = 10,
+      })
+      record.expire = gettime() - 1 -- expire current dns cache record
+      dnsA({   -- create a new record
+        { name = "mashape.test", address = "5.6.7.8" },
+      })
+      -- create a spy to check whether dns was queried
+      spy.on(client, "resolve")
+      local hash = nil
+      local cache_only = true
+      local ip, port, host = b:getPeer(cache_only, nil, hash)
+      assert.spy(client.resolve).Not.called_with("mashape.test",nil, nil)
+      assert.equal("1.2.3.4", ip)  -- initial un-updated ip address
+      assert.equal(80, port)
+      assert.equal("mashape.test", host)
+    end)
+  end)
+
+  describe("setting status triggers address-callback", function()
+    it("for IP addresses", function()
+      local count_add = 0
+      local count_remove = 0
+      local b
+      b = check_balancer(new_balancer {
+        hosts = {},  -- no hosts, so balancer is empty
+        dns = client,
+        wheelSize = 10,
+        callback = function(balancer, action, address, ip, port, hostname)
+          assert.equal(b, balancer)
+          if action == "added" then
+            count_add = count_add + 1
+          elseif action == "removed" then
+            count_remove = count_remove + 1
+          elseif action == "health" then  --luacheck: ignore
+            -- nothing to do
+          else
+            error("unknown action received: "..tostring(action))
+          end
+          if action ~= "health" then
+            assert.equals("12.34.56.78", ip)
+            assert.equals(123, port)
+            assert.equals("12.34.56.78", hostname)
+          end
+        end
+      })
+      add_target(b, "12.34.56.78", 123, 100)
+      ngx.sleep(0.1)
+      assert.equal(1, count_add)
+      assert.equal(0, count_remove)
+
+      --b:removeHost("12.34.56.78", 123)
+      b.targets[1].addresses[1].disabled = true
+      b:deleteDisabledAddresses(b.targets[1])
+      ngx.sleep(0.1)
+      assert.equal(1, count_add)
+      assert.equal(1, count_remove)
+    end)
+    it("for 1 level dns", function()
+      local count_add = 0
+      local count_remove = 0
+      local b
+      b = check_balancer(new_balancer {
+        hosts = {},  -- no hosts, so balancer is empty
+        dns = client,
+        wheelSize = 10,
+        callback = function(balancer, action, address, ip, port, hostname)
+          assert.equal(b, balancer)
+          if action == "added" then
+            count_add = count_add + 1
+          elseif action == "removed" then
+            count_remove = count_remove + 1
+          elseif action == "health" then  --luacheck: ignore
+            -- nothing to do
+          else
+            error("unknown action received: "..tostring(action))
+          end
+          if action ~= "health" then
+            assert.equals("12.34.56.78", ip)
+            assert.equals(123, port)
+            assert.equals("mashape.test", hostname)
+          end
+        end
+      })
+      dnsA({
+        { name = "mashape.test", address = "12.34.56.78" },
+        { name = "mashape.test", address = "12.34.56.78" },
+      })
+      add_target(b, "mashape.test", 123, 100)
+      ngx.sleep(0.1)
+      assert.equal(2, count_add)
+      assert.equal(0, count_remove)
+
+      b.targets[1].addresses[1].disabled = true
+      b.targets[1].addresses[2].disabled = true
+      b:deleteDisabledAddresses(b.targets[1])
+      ngx.sleep(0.1)
+      assert.equal(2, count_add)
+      assert.equal(2, count_remove)
+    end)
+    it("for 2+ level dns", function()
+      local count_add = 0
+      local count_remove = 0
+      local b
+      b = check_balancer(new_balancer {
+        hosts = {},  -- no hosts, so balancer is empty
+        dns = client,
+        wheelSize = 10,
+        callback = function(balancer, action, address, ip, port, hostname)
+          assert.equal(b, balancer)
+          if action == "added" then
+            count_add = count_add + 1
+          elseif action == "removed" then
+            count_remove = count_remove + 1
+          elseif action == "health" then  --luacheck: ignore
+            -- nothing to do
+          else
+            error("unknown action received: "..tostring(action))
+          end
+          if action ~= "health" then
+            assert(ip == "mashape1.test" or ip == "mashape2.test")
+            assert(port == 8001 or port == 8002)
+            assert.equals("mashape.test", hostname)
+          end
+        end
+      })
+      dnsA({
+        { name = "mashape1.test", address = "12.34.56.1" },
+      })
+      dnsA({
+        { name = "mashape2.test", address = "12.34.56.2" },
+      })
+      dnsSRV({
+        { name = "mashape.test", target = "mashape1.test", port = 8001, weight = 5 },
+        { name = "mashape.test", target = "mashape2.test", port = 8002, weight = 5 },
+      })
+      add_target(b, "mashape.test", 123, 100)
+      ngx.sleep(0.1)
+      assert.equal(2, count_add)
+      assert.equal(0, count_remove)
+
+      --b:removeHost("mashape.test", 123)
+      b.targets[1].addresses[1].disabled = true
+      b.targets[1].addresses[2].disabled = true
+      b:deleteDisabledAddresses(b.targets[1])
+      ngx.sleep(0.1)
+      assert.equal(2, count_add)
+      assert.equal(2, count_remove)
+    end)
+  end)
+
+  describe("wheel manipulation", function()
+    it("wheel updates are atomic", function()
+      -- testcase for issue #49, see:
+      -- https://github.test/Kong/lua-resty-dns-client/issues/49
+      local order_of_events = {}
+      local b
+      b = check_balancer(new_balancer {
+        hosts = {},  -- no hosts, so balancer is empty
+        dns = client,
+        wheelSize = 10,
+        callback = function(balancer, action, ip, port, hostname)
+          table.insert(order_of_events, "callback")
+          -- this callback is called when updating. So yield here and
+          -- verify that the second thread does not interfere with
+          -- the first update, yielded here.
+          ngx.sleep(0.1)
+        end
+      })
+      dnsA({
+        { name = "mashape1.test", address = "12.34.56.78" },
+      })
+      dnsA({
+        { name = "mashape2.test", address = "123.45.67.89" },
+      })
+      local t1 = ngx.thread.spawn(function()
+        table.insert(order_of_events, "thread1 start")
+        add_target(b, "mashape1.test")
+        table.insert(order_of_events, "thread1 end")
+      end)
+      local t2 = ngx.thread.spawn(function()
+        table.insert(order_of_events, "thread2 start")
+        add_target(b, "mashape2.test")
+        table.insert(order_of_events, "thread2 end")
+      end)
+      ngx.thread.wait(t1)
+      ngx.thread.wait(t2)
+      ngx.sleep(0.1)
+      assert.same({
+        [1] = 'thread1 start',
+        [2] = 'thread1 end',
+        [3] = 'thread2 start',
+        [4] = 'thread2 end',
+        [5] = 'callback',
+        [6] = 'callback',
+        [7] = 'callback',
+      }, order_of_events)
+    end)
+    it("equal weights and 'fitting' indices", function()
+      dnsA({
+        { name = "mashape.test", address = "1.2.3.4" },
+        { name = "mashape.test", address = "1.2.3.5" },
+      })
+      local b = check_balancer(new_balancer {
+        hosts = {"mashape.test"},
+        dns = client,
+      })
+      local expected = {
+        ["1.2.3.4:80"] = 1,
+        ["1.2.3.5:80"] = 1,
+      }
+      assert.are.same(expected, count_indices(b))
+    end)
+    it("DNS record order has no effect", function()
+      dnsA({
+        { name = "mashape.test", address = "1.2.3.1" },
+        { name = "mashape.test", address = "1.2.3.2" },
+        { name = "mashape.test", address = "1.2.3.3" },
+        { name = "mashape.test", address = "1.2.3.4" },
+        { name = "mashape.test", address = "1.2.3.5" },
+        { name = "mashape.test", address = "1.2.3.6" },
+        { name = "mashape.test", address = "1.2.3.7" },
+        { name = "mashape.test", address = "1.2.3.8" },
+        { name = "mashape.test", address = "1.2.3.9" },
+        { name = "mashape.test", address = "1.2.3.10" },
+      })
+      local b = check_balancer(new_balancer {
+        hosts = {"mashape.test"},
+        dns = client,
+        wheelSize = 19,
+      })
+      local expected = count_indices(b)
+      dnsA({
+        { name = "mashape.test", address = "1.2.3.8" },
+        { name = "mashape.test", address = "1.2.3.3" },
+        { name = "mashape.test", address = "1.2.3.1" },
+        { name = "mashape.test", address = "1.2.3.2" },
+        { name = "mashape.test", address = "1.2.3.4" },
+        { name = "mashape.test", address = "1.2.3.5" },
+        { name = "mashape.test", address = "1.2.3.6" },
+        { name = "mashape.test", address = "1.2.3.9" },
+        { name = "mashape.test", address = "1.2.3.10" },
+        { name = "mashape.test", address = "1.2.3.7" },
+      })
+      b = check_balancer(new_balancer {
+        hosts = {"mashape.test"},
+        dns = client,
+        wheelSize = 19,
+      })
+
+      assert.are.same(expected, count_indices(b))
+    end)
+    it("changing hostname order has no effect", function()
+      dnsA({
+        { name = "mashape.test", address = "1.2.3.1" },
+      })
+      dnsA({
+        { name = "getkong.test", address = "1.2.3.2" },
+      })
+      local b = new_balancer {
+        hosts = {"mashape.test", "getkong.test"},
+        dns = client,
+        wheelSize = 3,
+      }
+      local expected = count_indices(b)
+      b = check_balancer(new_balancer {
+        hosts = {"getkong.test", "mashape.test"},  -- changed host order
+        dns = client,
+        wheelSize = 3,
+      })
+      assert.are.same(expected, count_indices(b))
+    end)
+    it("adding a host (fitting indices)", function()
+      dnsA({
+        { name = "mashape.test", address = "1.2.3.4" },
+        { name = "mashape.test", address = "1.2.3.5" },
+      })
+      dnsAAAA({
+        { name = "getkong.test", address = "::1" },
+      })
+      local b = check_balancer(new_balancer {
+        hosts = { { name = "mashape.test", port = 80, weight = 5 } },
+        dns = client,
+      })
+      add_target(b, "getkong.test", 8080, 10 )
+      check_balancer(b)
+      local expected = {
+        ["1.2.3.4:80"] = 1,
+        ["1.2.3.5:80"] = 1,
+        ["[::1]:8080"] = 2,
+      }
+      assert.are.same(expected, count_indices(b))
+    end)
+    it("removing the last host", function()
+      dnsA({
+        { name = "mashape.test", address = "1.2.3.4" },
+        { name = "mashape.test", address = "1.2.3.5" },
+      })
+      dnsAAAA({
+        { name = "getkong.test", address = "::1" },
+      })
+      local b = check_balancer(new_balancer {
+        dns = client,
+        wheelSize = 20,
+      })
+      add_target(b, "mashape.test", 80, 5)
+      add_target(b, "getkong.test", 8080, 10)
+      --b:removeHost("getkong.test", 8080)
+      --b:removeHost("mashape.test", 80)
+    end)
+    it("weight change updates properly", function()
+      dnsA({
+        { name = "mashape.test", address = "1.2.3.4" },
+        { name = "mashape.test", address = "1.2.3.5" },
+      })
+      dnsAAAA({
+        { name = "getkong.test", address = "::1" },
+      })
+      local b = check_balancer(new_balancer {
+        dns = client,
+        wheelSize = 60,
+      })
+      add_target(b, "mashape.test", 80, 10)
+      add_target(b, "getkong.test", 80, 10)
+      local count = count_indices(b)
+      assert.same({
+        ["1.2.3.4:80"] = 1,
+        ["1.2.3.5:80"] = 1,
+        ["[::1]:80"]   = 1,
+      }, count)
+
+      add_target(b, "mashape.test", 80, 25)
+      count = count_indices(b)
+      assert.same({
+        ["1.2.3.4:80"] = 5,
+        ["1.2.3.5:80"] = 5,
+        ["[::1]:80"]   = 2,
+      }, count)
+    end)
+    it("weight change ttl=0 record, updates properly", function()
+      -- mock the resolve/toip methods
+      local old_resolve = client.resolve
+      local old_toip = client.toip
+      finally(function()
+        client.resolve = old_resolve
+        client.toip = old_toip
+      end)
+      client.resolve = function(name, ...)
+        if name == "mashape.test" then
+          local record = dnsA({
+            { name = "mashape.test", address = "1.2.3.4", ttl = 0 },
+          })
+          return record
+        else
+          return old_resolve(name, ...)
+        end
+      end
+      client.toip = function(name, ...)
+        if name == "mashape.test" then
+          return "1.2.3.4", ...
+        else
+          return old_toip(name, ...)
+        end
+      end
+
+      -- insert 2nd address
+      dnsA({
+        { name = "getkong.test", address = "9.9.9.9", ttl = 60*60 },
+      })
+
+      local b = check_balancer(new_balancer {
+        hosts = {
+          { name = "mashape.test", port = 80, weight = 50 },
+          { name = "getkong.test", port = 123, weight = 50 },
+        },
+        dns = client,
+        wheelSize = 100,
+        ttl0 = 2,
+      })
+
+      local count = count_indices(b)
+      assert.same({
+        ["mashape.test:80"] = 1,
+        ["9.9.9.9:123"] = 1,
+      }, count)
+
+      -- update weights
+      add_target(b, "mashape.test", 80, 150)
+
+      count = count_indices(b)
+      assert.same({
+        ["mashape.test:80"] = 3,
+        ["9.9.9.9:123"] = 1,
+      }, count)
+    end)
+    it("weight change for unresolved record, updates properly", function()
+      local record = dnsA({
+        { name = "really.really.really.does.not.exist.thijsschreijer.nl", address = "1.2.3.4" },
+      })
+      dnsAAAA({
+        { name = "getkong.test", address = "::1" },
+      })
+      local b = check_balancer(new_balancer {
+        dns = client,
+        wheelSize = 60,
+        requery = 0.1,
+      })
+      add_target(b, "really.really.really.does.not.exist.thijsschreijer.nl", 80, 10)
+      add_target(b, "getkong.test", 80, 10)
+      local count = count_indices(b)
+      assert.same({
+        ["1.2.3.4:80"] = 1,
+        ["[::1]:80"]   = 1,
+      }, count)
+
+      -- expire the existing record
+      record.expire = 0
+      record.expired = true
+      -- do a lookup to trigger the async lookup
+      client.resolve("really.really.really.does.not.exist.thijsschreijer.nl", {qtype = client.TYPE_A})
+      sleep(0.5) -- provide time for async lookup to complete
+
+      for _ = 1, b.wheelSize do b:getPeer() end -- hit them all to force renewal
+
+      count = count_indices(b)
+      assert.same({
+        --["1.2.3.4:80"] = 0,  --> failed to resolve, no more entries
+        ["[::1]:80"]   = 1,
+      }, count)
+
+      -- update the failed record
+      add_target(b, "really.really.really.does.not.exist.thijsschreijer.nl", 80, 20)
+      -- reinsert a cache entry
+      dnsA({
+        { name = "really.really.really.does.not.exist.thijsschreijer.nl", address = "1.2.3.4" },
+      })
+      sleep(2)  -- wait for timer to re-resolve the record
+      targets.resolve_targets(b.targets)
+
+      count = count_indices(b)
+      assert.same({
+        ["1.2.3.4:80"] = 2,
+        ["[::1]:80"]   = 1,
+      }, count)
+    end)
+    it("weight change SRV record, has no effect", function()
+      dnsA({
+        { name = "mashape.test", address = "1.2.3.4" },
+        { name = "mashape.test", address = "1.2.3.5" },
+      })
+      dnsSRV({
+        { name = "gelato.test", target = "1.2.3.6", port = 8001, weight = 5 },
+        { name = "gelato.test", target = "1.2.3.6", port = 8002, weight = 5 },
+      })
+      local b = check_balancer(new_balancer {
+        dns = client,
+        wheelSize = 120,
+      })
+      add_target(b, "mashape.test", 80, 10)
+      add_target(b, "gelato.test", 80, 10)  --> port + weight will be ignored
+      local count = count_indices(b)
+      local state = copyWheel(b)
+      assert.same({
+        ["1.2.3.4:80"]   = 2,
+        ["1.2.3.5:80"]   = 2,
+        ["1.2.3.6:8001"] = 1,
+        ["1.2.3.6:8002"] = 1,
+      }, count)
+
+      add_target(b, "gelato.test", 80, 20)  --> port + weight will be ignored
+      count = count_indices(b)
+      assert.same({
+        ["1.2.3.4:80"]   = 2,
+        ["1.2.3.5:80"]   = 2,
+        ["1.2.3.6:8001"] = 1,
+        ["1.2.3.6:8002"] = 1,
+      }, count)
+      assert.same(state, copyWheel(b))
+    end)
+    it("renewed DNS A record; no changes", function()
+      local record = dnsA({
+        { name = "mashape.test", address = "1.2.3.4" },
+        { name = "mashape.test", address = "1.2.3.5" },
+      })
+      dnsA({
+        { name = "getkong.test", address = "9.9.9.9" },
+      })
+      local b = check_balancer(new_balancer {
+        hosts = {
+          { name = "mashape.test", port = 80, weight = 5 },
+          { name = "getkong.test", port = 123, weight = 10 },
+        },
+        dns = client,
+        wheelSize = 100,
+      })
+      local state = copyWheel(b)
+      record.expire = gettime() -1 -- expire current dns cache record
+      dnsA({   -- create a new record (identical)
+        { name = "mashape.test", address = "1.2.3.4" },
+        { name = "mashape.test", address = "1.2.3.5" },
+      })
+      -- create a spy to check whether dns was queried
+      spy.on(client, "resolve")
+      for _ = 1, b.wheelSize do -- call all, to make sure we hit the expired one
+        b:getPeer()  -- invoke balancer, to expire record and re-query dns
+      end
+      assert.spy(client.resolve).was_called_with("mashape.test",nil, nil)
+      assert.same(state, copyWheel(b))
+    end)
+
+    it("renewed DNS AAAA record; no changes", function()
+      local record = dnsAAAA({
+        { name = "mashape.test", address = "::1" },
+        { name = "mashape.test", address = "::2" },
+      })
+      dnsA({
+        { name = "getkong.test", address = "9.9.9.9" },
+      })
+      local b = check_balancer(new_balancer {
+        hosts = {
+          { name = "mashape.test", port = 80, weight = 5 },
+          { name = "getkong.test", port = 123, weight = 10 },
+        },
+        dns = client,
+        wheelSize = 100,
+      })
+      local state = copyWheel(b)
+      record.expire = gettime() -1 -- expire current dns cache record
+      dnsAAAA({   -- create a new record (identical)
+        { name = "mashape.test", address = "::1" },
+        { name = "mashape.test", address = "::2" },
+      })
+      -- create a spy to check whether dns was queried
+      spy.on(client, "resolve")
+      for _ = 1, b.wheelSize do -- call all, to make sure we hit the expired one
+        b:getPeer()  -- invoke balancer, to expire record and re-query dns
+      end
+      assert.spy(client.resolve).was_called_with("mashape.test",nil, nil)
+      assert.same(state, copyWheel(b))
+    end)
+    it("renewed DNS SRV record; no changes", function()
+      local record = dnsSRV({
+        { name = "gelato.test", target = "1.2.3.6", port = 8001, weight = 5 },
+        { name = "gelato.test", target = "1.2.3.6", port = 8002, weight = 5 },
+        { name = "gelato.test", target = "1.2.3.6", port = 8003, weight = 5 },
+      })
+      dnsA({
+        { name = "getkong.test", address = "9.9.9.9" },
+      })
+      local b = check_balancer(new_balancer {
+        hosts = {
+          { name = "gelato.test" },
+          { name = "getkong.test", port = 123, weight = 10 },
+        },
+        dns = client,
+        wheelSize = 100,
+      })
+      local state = copyWheel(b)
+      record.expire = gettime() -1 -- expire current dns cache record
+      dnsSRV({    -- create a new record (identical)
+        { name = "gelato.test", target = "1.2.3.6", port = 8001, weight = 5 },
+        { name = "gelato.test", target = "1.2.3.6", port = 8002, weight = 5 },
+        { name = "gelato.test", target = "1.2.3.6", port = 8003, weight = 5 },
+      })
+      -- create a spy to check whether dns was queried
+      spy.on(client, "resolve")
+      for _ = 1, b.wheelSize do -- call all, to make sure we hit the expired one
+        b:getPeer()  -- invoke balancer, to expire record and re-query dns
+      end
+      assert.spy(client.resolve).was_called_with("gelato.test",nil, nil)
+      assert.same(state, copyWheel(b))
+    end)
+    it("renewed DNS A record; address changes", function()
+      local record = dnsA({
+        { name = "mashape.test", address = "1.2.3.4" },
+        { name = "mashape.test", address = "1.2.3.5" },
+      })
+      dnsA({
+        { name = "getkong.test", address = "9.9.9.9" },
+        { name = "getkong.test", address = "8.8.8.8" },
+      })
+      local b = check_balancer(new_balancer {
+        hosts = {
+          { name = "mashape.test", port = 80, weight = 10 },
+          { name = "getkong.test", port = 123, weight = 10 },
+        },
+        dns = client,
+        wheelSize = 100,
+      })
+      local state = copyWheel(b)
+      record.expire = gettime() -1 -- expire current dns cache record
+      dnsA({                       -- insert an updated record
+        { name = "mashape.test", address = "1.2.3.4" },
+        { name = "mashape.test", address = "1.2.3.6" },  -- target updated
+      })
+      -- run entire wheel to make sure the expired one is requested, and updated
+      for _ = 1, b.wheelSize do b:getPeer() end
+      -- all old 'mashape.test @ 1.2.3.5' should now be 'mashape.test @ 1.2.3.6'
+      -- and more important; all others should not have moved indices/positions!
+      updateWheelState(state, " %- 1%.2%.3%.5 @ ", " - 1.2.3.6 @ ")
+      -- FIXME: this test depends on wheel sorting, which is not good
+      --assert.same(state, copyWheel(b))
+    end)
+    it("renewed DNS A record; failed #slow", function()
+      -- This test might show some error output similar to the lines below. This is expected and ok.
+      -- 2016/11/07 16:48:33 [error] 81932#0: *2 recv() failed (61: Connection refused), context: ngx.timer
+
+      local record = dnsA({
+        { name = "mashape.test", address = "1.2.3.4" },
+      })
+      dnsA({
+        { name = "getkong.test", address = "9.9.9.9" },
+      })
+      local b = check_balancer(new_balancer {
+        hosts = {
+          { name = "mashape.test", port = 80, weight = 10 },
+          { name = "getkong.test", port = 123, weight = 10 },
+        },
+        dns = client,
+        wheelSize = 20,
+        requery = 0.1,   -- shorten default requery time for the test
+      })
+      copyWheel(b)
+      copyWheel(b)
+      -- reconfigure the dns client to make sure next query fails
+      assert(client.init {
+        hosts = {},
+        resolvConf = {
+          "nameserver 127.0.0.1:22000" -- make sure dns query fails
+        },
+      })
+      record.expire = gettime() -1 -- expire current dns cache record
+      -- run entire wheel to make sure the expired one is requested, so it can fail
+      for _ = 1, b.wheelSize do b:getPeer() end
+      -- the only indice is now getkong.test
+      assert.same({"1 - 9.9.9.9 @ 123 (getkong.test)" }, copyWheel(b))
+
+      -- reconfigure the dns client to make sure next query works again
+      assert(client.init {
+        hosts = {},
+        resolvConf = {
+          "nameserver 8.8.8.8"
+        },
+      })
+      dnsA({
+        { name = "mashape.test", address = "1.2.3.4" },
+      })
+      sleep(b.requeryInterval + 2) --requery timer runs, so should be fixed after this
+
+      -- wheel should be back in original state
+      -- FIXME: this test depends on wheel sorting, which is not good
+      --assert.same(state1, copyWheel(b))
+    end)
+    it("renewed DNS A record; last host fails DNS resolution #slow", function()
+      -- This test might show some error output similar to the lines below. This is expected and ok.
+      -- 2017/11/06 15:52:49 [warn] 5123#0: *2 [lua] balancer.lua:320: queryDns(): [ringbalancer] querying dns for really.really.really.does.not.exist.thijsschreijer.nl failed: dns server error: 3 name error, context: ngx.timer
+
+      local test_name = "really.really.really.does.not.exist.thijsschreijer.nl"
+      local ttl = 0.1
+      local staleTtl = 0   -- stale ttl = 0, force lookup upon expiring
+      local record = dnsA({
+        { name = test_name, address = "1.2.3.4", ttl = ttl },
+      }, staleTtl)
+      local b = check_balancer(new_balancer {
+        hosts = {
+          { name = test_name, port = 80, weight = 10 },
+        },
+        dns = client,
+      })
+      for _ = 1, b.wheelSize do
+        local ip = b:getPeer()
+        assert.equal(record[1].address, ip)
+      end
+      -- wait for ttl to expire
+      sleep(ttl + 0.1)
+      targets.resolve_targets(b.targets)
+      -- run entire wheel to make sure the expired one is requested, so it can fail
+      for _ = 1, b.wheelSize do
+        local ip, port = b:getPeer()
+        assert.is_nil(ip)
+        assert.equal(port, "Balancer is unhealthy")
+      end
+    end)
+    it("renewed DNS A record; unhealthy entries remain unhealthy after renewal", function()
+      local record = dnsA({
+        { name = "mashape.test", address = "1.2.3.4" },
+        { name = "mashape.test", address = "1.2.3.5" },
+      })
+      dnsA({
+        { name = "getkong.test", address = "9.9.9.9" },
+      })
+      local b = check_balancer(new_balancer {
+        hosts = {
+          { name = "mashape.test", port = 80, weight = 5 },
+          { name = "getkong.test", port = 123, weight = 10 },
+        },
+        dns = client,
+        wheelSize = 20,
+      })
+
+      -- mark node down
+      assert(b:setAddressStatus(b:findAddress("1.2.3.4", 80, "mashape.test"), false))
+
+      -- run the wheel
+      local res = {}
+      for _ = 1, 15 do
+        local addr, port, host = b:getPeer()
+        res[addr..":"..port] = (res[addr..":"..port] or 0) + 1
+        res[host..":"..port] = (res[host..":"..port] or 0) + 1
+      end
+
+      assert.equal(nil, res["1.2.3.4:80"])    -- unhealthy node gets no hits, key never gets initialized
+      assert.equal(5, res["1.2.3.5:80"])
+      assert.equal(5, res["mashape.test:80"])
+      assert.equal(10, res["9.9.9.9:123"])
+      assert.equal(10, res["getkong.test:123"])
+
+      local state = copyWheel(b)
+
+      record.expire = gettime() -1 -- expire current dns cache record
+      dnsA({   -- create a new record (identical)
+        { name = "mashape.test", address = "1.2.3.4" },
+        { name = "mashape.test", address = "1.2.3.5" },
+      })
+      -- create a spy to check whether dns was queried
+      spy.on(client, "resolve")
+      for _ = 1, b.wheelSize do -- call all, to make sure we hit the expired one
+        b:getPeer()  -- invoke balancer, to expire record and re-query dns
+      end
+      assert.spy(client.resolve).was_called_with("mashape.test",nil, nil)
+      assert.same(state, copyWheel(b))
+
+      -- run the wheel again
+      local res2 = {}
+      for _ = 1, 15 do
+        local addr, port, host = b:getPeer()
+        res2[addr..":"..port] = (res2[addr..":"..port] or 0) + 1
+        res2[host..":"..port] = (res2[host..":"..port] or 0) + 1
+      end
+
+      -- results are identical: unhealthy node remains unhealthy
+      assert.same(res, res2)
+
+    end)
+    it("low weight with zero-indices assigned doesn't fail", function()
+      -- depending on order of insertion it is either 1 or 0 indices
+      -- but it may never error.
+      dnsA({
+        { name = "mashape.test", address = "1.2.3.4" },
+      })
+      dnsA({
+        { name = "getkong.test", address = "9.9.9.9" },
+      })
+      check_balancer(new_balancer {
+        hosts = {
+          { name = "mashape.test", port = 80, weight = 99999 },
+          { name = "getkong.test", port = 123, weight = 1 },
+        },
+        dns = client,
+        wheelSize = 100,
+      })
+      -- Now the order reversed (weights exchanged)
+      dnsA({
+        { name = "mashape.test", address = "1.2.3.4" },
+      })
+      dnsA({
+        { name = "getkong.test", address = "9.9.9.9" },
+      })
+      check_balancer(new_balancer {
+        hosts = {
+          { name = "mashape.test", port = 80, weight = 1 },
+          { name = "getkong.test", port = 123, weight = 99999 },
+        },
+        dns = client,
+        wheelSize = 100,
+      })
+    end)
+    it("SRV record with 0 weight doesn't fail resolving", function()
+      -- depending on order of insertion it is either 1 or 0 indices
+      -- but it may never error.
+      dnsSRV({
+        { name = "gelato.test", target = "1.2.3.6", port = 8001, weight = 0 },
+        { name = "gelato.test", target = "1.2.3.6", port = 8002, weight = 0 },
+      })
+      local b = check_balancer(new_balancer {
+        hosts = {
+          -- port and weight will be overridden by the above
+          { name = "gelato.test", port = 80, weight = 99999 },
+        },
+        dns = client,
+        wheelSize = 100,
+      })
+      local ip, port = b:getPeer()
+      assert.equal("1.2.3.6", ip)
+      assert(port == 8001 or port == 8002, "port expected 8001 or 8002")
+    end)
+    it("ttl of 0 inserts only a single unresolved address", function()
+      local ttl = 0
+      local resolve_count = 0
+      local toip_count = 0
+
+      -- mock the resolve/toip methods
+      local old_resolve = client.resolve
+      local old_toip = client.toip
+      finally(function()
+        client.resolve = old_resolve
+        client.toip = old_toip
+      end)
+      client.resolve = function(name, ...)
+        if name == "mashape.test" then
+          local record = dnsA({
+            { name = "mashape.test", address = "1.2.3.4", ttl = ttl },
+          })
+          resolve_count = resolve_count + 1
+          return record
+        else
+          return old_resolve(name, ...)
+        end
+      end
+      client.toip = function(name, ...)
+        if name == "mashape.test" then
+          toip_count = toip_count + 1
+          return "1.2.3.4", ...
+        else
+          return old_toip(name, ...)
+        end
+      end
+
+      -- insert 2nd address
+      dnsA({
+        { name = "getkong.test", address = "9.9.9.9", ttl = 60*60 },
+      })
+
+      local b = check_balancer(new_balancer {
+        hosts = {
+          { name = "mashape.test", port = 80, weight = 50 },
+          { name = "getkong.test", port = 123, weight = 50 },
+        },
+        dns = client,
+        wheelSize = 100,
+        ttl0 = 2,
+      })
+      -- get current state
+      local state = copyWheel(b)
+      -- run it down, count the dns queries done
+      for _ = 1, b.wheelSize do b:getPeer() end
+      assert.equal(b.wheelSize/2, toip_count)  -- one resolver hit for each index
+      assert.equal(1, resolve_count) -- hit once, when adding the host to the balancer
+
+      ttl = 60 -- set our records ttl to 60 now, so we only get one extra hit now
+      toip_count = 0  --reset counters
+      resolve_count = 0
+      -- wait for expiring the 0-ttl setting
+      sleep(b.ttl0Interval + 1)  -- 0 ttl will be requeried, to check for changed ttl
+
+      -- run it down, count the dns queries done
+      for _ = 1, b.wheelSize do b:getPeer() end
+      --assert.equal(0, toip_count)   -- TODO:  must it be 0?
+      assert.equal(1, resolve_count) -- hit once, when updating the 0-ttl entry
+
+      -- finally check whether indices didn't move around
+      updateWheelState(state, " %- mashape%.test @ ", " - 1.2.3.4 @ ")
+      copyWheel(b)
+      -- FIXME: this test depends on wheel sorting, which is not good
+      --assert.same(state, copyWheel(b))
+    end)
+    it("recreate Kong issue #2131", function()
+      -- erasing does not remove the address from the host
+      -- so if the same address is added again, and then deleted again
+      -- then upon erasing it will find the previous erased address object,
+      -- and upon erasing again a nil-referencing issue then occurs
+      local ttl = 1
+      local record
+      local hostname = "dnstest.mashape.test"
+
+      -- mock the resolve/toip methods
+      local old_resolve = client.resolve
+      local old_toip = client.toip
+      finally(function()
+        client.resolve = old_resolve
+        client.toip = old_toip
+      end)
+      client.resolve = function(name, ...)
+        if name == hostname then
+          record = dnsA({
+            { name = hostname, address = "1.2.3.4", ttl = ttl },
+          })
+          return record
+        else
+          return old_resolve(name, ...)
+        end
+      end
+      client.toip = function(name, ...)
+        if name == hostname then
+          return "1.2.3.4", ...
+        else
+          return old_toip(name, ...)
+        end
+      end
+
+      -- create a new balancer
+      local b = check_balancer(new_balancer {
+        hosts = {
+          { name = hostname, port = 80, weight = 50 },
+        },
+        dns = client,
+        wheelSize = 10,
+        ttl0 = 1,
+      })
+
+      sleep(1.1) -- wait for ttl to expire
+      -- fetch a peer to reinvoke dns and update balancer, with a ttl=0
+      ttl = 0
+      b:getPeer()   --> force update internal from A to SRV
+      sleep(1.1) -- wait for ttl0, as provided to balancer, to expire
+      -- restore ttl to non-0, and fetch a peer to update balancer
+      ttl = 1
+      b:getPeer()   --> force update internal from SRV to A
+      sleep(1.1) -- wait for ttl to expire
+      -- fetch a peer to reinvoke dns and update balancer, with a ttl=0
+      ttl = 0
+      b:getPeer()   --> force update internal from A to SRV
+    end)
+  end)
+end)

--- a/spec/helpers/dns.lua
+++ b/spec/helpers/dns.lua
@@ -1,0 +1,138 @@
+-- test helper methods
+
+local _M = {}
+
+
+if ngx then
+  _M.gettime = ngx.now
+  _M.sleep = ngx.sleep
+else
+  local socket = require("socket")
+  _M.gettime = socket.gettime
+  _M.sleep = socket.sleep
+end
+local gettime = _M.gettime
+
+
+-- iterator over different balancer types
+-- @return algorithm_name, balancer_module
+function _M.balancer_types()
+  local b_types = {
+    -- algorithm             name
+    { "consistent-hashing", "consistent_hashing" },
+    { "round-robin",        "round_robin" },
+    { "least-connections",  "least_connections" },
+  }
+  local i = 0
+  return function()
+           i = i + 1
+           if b_types[i] then
+             return b_types[i][1], require("resty.dns.balancer." .. b_types[i][2])
+           end
+         end
+end
+
+
+-- expires a record now
+function _M.dnsExpire(record)
+  record.expire = gettime() - 1
+end
+
+
+-- creates an SRV record in the cache
+function _M.dnsSRV(client, records, staleTtl)
+  local dnscache = client.getcache()
+  -- if single table, then insert into a new list
+  if not records[1] then records = { records } end
+
+  for _, record in ipairs(records) do
+    record.type = client.TYPE_SRV
+
+    -- check required input
+    assert(record.target, "target field is required for SRV record")
+    assert(record.name, "name field is required for SRV record")
+    assert(record.port, "port field is required for SRV record")
+    record.name = record.name:lower()
+
+    -- optionals, insert defaults
+    record.weight = record.weight or 10
+    record.ttl = record.ttl or 600
+    record.priority = record.priority or 20
+    record.class = record.class or 1
+  end
+  -- set timeouts
+  records.touch = gettime()
+  records.expire = gettime() + records[1].ttl
+
+  -- create key, and insert it
+  local key = records[1].type..":"..records[1].name
+  dnscache:set(key, records, records[1].ttl + (staleTtl or 4))
+  -- insert last-succesful lookup type
+  dnscache:set(records[1].name, records[1].type)
+  return records
+end
+
+
+-- creates an A record in the cache
+function _M.dnsA(client, records, staleTtl)
+  local dnscache = client.getcache()
+  -- if single table, then insert into a new list
+  if not records[1] then records = { records } end
+
+  for _, record in ipairs(records) do
+    record.type = client.TYPE_A
+
+    -- check required input
+    assert(record.address, "address field is required for A record")
+    assert(record.name, "name field is required for A record")
+    record.name = record.name:lower()
+
+    -- optionals, insert defaults
+    record.ttl = record.ttl or 600
+    record.class = record.class or 1
+  end
+  -- set timeouts
+  records.touch = gettime()
+  records.expire = gettime() + records[1].ttl
+
+  -- create key, and insert it
+  local key = records[1].type..":"..records[1].name
+  dnscache:set(key, records, records[1].ttl + (staleTtl or 4))
+  -- insert last-succesful lookup type
+  dnscache:set(records[1].name, records[1].type)
+  return records
+end
+
+
+-- creates an AAAA record in the cache
+function _M.dnsAAAA(client, records, staleTtl)
+  local dnscache = client.getcache()
+  -- if single table, then insert into a new list
+  if not records[1] then records = { records } end
+
+  for _, record in ipairs(records) do
+    record.type = client.TYPE_AAAA
+
+    -- check required input
+    assert(record.address, "address field is required for AAAA record")
+    assert(record.name, "name field is required for AAAA record")
+    record.name = record.name:lower()
+
+    -- optionals, insert defaults
+    record.ttl = record.ttl or 600
+    record.class = record.class or 1
+  end
+  -- set timeouts
+  records.touch = gettime()
+  records.expire = gettime() + records[1].ttl
+
+  -- create key, and insert it
+  local key = records[1].type..":"..records[1].name
+  dnscache:set(key, records, records[1].ttl + (staleTtl or 4))
+  -- insert last-succesful lookup type
+  dnscache:set(records[1].name, records[1].type)
+  return records
+end
+
+
+return _M


### PR DESCRIPTION
Main differences come from the fact that the new balancer is not a general-purpose library, and doesn't present a large and defensive API to manage its internal structures. Instead, it now depends on the working of Kong's data entities.

Kinds of tests we're no longer interested in and has been removed:
* Accept/reject a wide variety of call styles to create balancer and add targets to it:  these are helper functions to emulate database operations, no need to make them robust and generally useful.
* Garbage collecting a handle releases it: handles are simple Lua tables, they are expected to be properly released and not just dropped. Integration tests ensure that.
* Accept a handle instead of an address: feature removed.
* Detailed errors for 'address not found' on many methods: most of these methods now take a concrete address reference, the error is generated by Kong code before calling these functions.
* Garbage collecting a balancer removes associated timers: balancers (and other things) are tied to the config database. They're expected to be properly released.
* `b:removeHost()`: targets can't be removed from a balancer, the balancer is rebuilt by the database event.

The deduplication step previously preserved was more for the library API than for internal working. The DNS update function now skips deduplication and actually allows duplicates.

This commit also contains the following fixes in order for the tests to
pass:
* Fixed wordings on error messages to be expected by tests
* Fixed an issue that some events weren't rebuilding the balancer's algorithms as they should
* Make sure registered balancer callbacks are always triggered
* The round-robin algorithm kept a copy of the targets list, but didn't update it properly (now it instead uses the balancer's list)

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

SUMMARY_GOES_HERE

### Full changelog

* [Implement ...]
* [Add related tests]
* ...

### Issues resolved

Fix #XXX
