### PR TITLE
chore(grpc-gateway) bump the plugin version

### DIFF
--- a/kong/plugins/grpc-gateway/CHANGELOG.md
+++ b/kong/plugins/grpc-gateway/CHANGELOG.md
@@ -5,6 +5,11 @@
 - [0.1.1](#011---20200526)
 - [0.1.0](#010---20200521)
 
+##  [0.2.0] - 2021-09-28
+
+- Transcode `.google.protobuf.Timestamp` fields to and from datetime strings (#7538)
+- Support structured URL arguments (#7564)
+
 ##  [0.1.3] - 2021/06/03
 
 - Fix typo from gatewat to gateway (#16)

--- a/kong/plugins/grpc-gateway/handler.lua
+++ b/kong/plugins/grpc-gateway/handler.lua
@@ -20,7 +20,7 @@ local kong_service_request_set_raw_body = kong.service.request.set_raw_body
 
 local grpc_gateway = {
   PRIORITY = 998,
-  VERSION = '0.1.3',
+  VERSION = '0.2.0',
 }
 
 --require "lua_pack"


### PR DESCRIPTION
This is a cherry-pick from the 2.6.x branch into master.
