### PR TITLE
chore(deps) bump resty.acme from 0.7.1 to 0.7.2

### DIFF
--- a/kong-2.6.0-0.rockspec
+++ b/kong-2.6.0-0.rockspec
@@ -39,7 +39,7 @@ dependencies = {
   "lua-resty-openssl == 0.7.4",
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6.1",
-  "lua-resty-acme == 0.7.1",
+  "lua-resty-acme == 0.7.2",
   "lua-resty-session == 3.8",
   -- external Kong plugins
   "kong-plugin-azure-functions ~> 1.0",


### PR DESCRIPTION
### Summary

#### bug fixes
- ***:** use a standarlized log interface [0ff01bd](https://github.com/fffonion/lua-resty-acme/commit/0ff01bd2ab39ff3973106946644223d1740a31b8)
- **autossl:** release update_lock after cert is created to allow multiple type of certs for same domain to be created within short time [e315070](https://github.com/fffonion/lua-resty-acme/commit/e315070834a6c5b516110d61bb12bb9052f896a8)
- **autossl:** increase cert lock time ([#47](https://github.com/fffonion/lua-resty-acme/issues/47)) [efb0602](https://github.com/fffonion/lua-resty-acme/commit/efb0602ab286f93f25d6f98d9ec26521970f743b)
- **tls-alpn-01:** set version 3 in certificate generated ([#49](https://github.com/fffonion/lua-resty-acme/issues/49)) [887cad8](https://github.com/fffonion/lua-resty-acme/commit/887cad8b2ee02748c863f85e8f8afdec3ca897bf)