### PR TITLE
fix(plugins) sort plugins hash DAO topologically

### DIFF
--- a/kong/db/schema/topological_sort.lua
+++ b/kong/db/schema/topological_sort.lua
@@ -39,7 +39,7 @@ end
 -- @usage
 -- local res = topological_sort({ services, routes, plugins, consumers })
 -- assert.same({ consumers, services, routes, plugins }, res)
-local declarative_topological_sort = function(schemas)
+local schema_topological_sort = function(schemas)
   local s
   local schemas_by_name = {}
   local copy = {}
@@ -77,4 +77,4 @@ local declarative_topological_sort = function(schemas)
   return utils_toposort(schemas, get_schema_neighbors)
 end
 
-return declarative_topological_sort
+return schema_topological_sort

--- a/spec/fixtures/custom_plugins/kong/plugins/foreign-entity/daos.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/foreign-entity/daos.lua
@@ -2,7 +2,7 @@ local typedefs = require "kong.db.schema.typedefs"
 
 
 return {
-  {
+  foreign_entities = {
     name = "foreign_entities",
     primary_key = { "id" },
     endpoint_key = "name",
@@ -13,7 +13,7 @@ return {
       { same = typedefs.uuid },
     },
   },
-  {
+  foreign_references = {
     name = "foreign_references",
     primary_key = { "id" },
     endpoint_key = "name",


### PR DESCRIPTION
This fixes an intermittent issue which makes kong not start.

The error manifested itself when a plugin has these three characteristics:

* At least two custom entities
* With at least one foreign relationship between them
* The schemas in the plugin's `daos.lua` are expressed as a hash-table
instead of as an array.

In other words we have a situation like this:
```
-- my_plugin/daos.lua
{ my_entities = {
    name = "my_entities",
    fields = {
      { id = typedefs.uuid },
    },
  }
  my_other_entities = {
    name = "my_other_entities",
    fields = {
      { id = typedefs.uuid },
      { ref = { type = "foreign", reference = "my_entities", on_delete = "cascade" } },
    },
  }
}
```

The hash-like table would be iterated over with `pairs` by the
plugin_loader, so in some cases `my_other_entities` would be loaded
before `my_entities`, provoking an error while loading
`my_other_entities.ref`.

Note that this problem can be sidestepped by using an array instead of a hash on
daos.lua. So instead of:
```
-- my_plugin/daos.lua
{ my_entities = {
    name = "my_entities", ...
  },
  my_other_entities =
    name = "my_other_entities", ...
  }
}
```
We could use this:
```
-- my_plugin/daos.lua
{ {
    name = "my_entities", ...
  },
  {
    name = "my_other_entities", ...
  }
}
```

And that would avoid the issue since when the plugin loader finds an array-like
table like that, it will always load the entities in the same order as they are
introduced on the table.

The test for this fix consists on using a hash-like table on the
`foreign-entity` custom plugin. If the fix is incorrect Kong should
ramdomly fail to start when that plugin is used in
`spec/02-integration/04-admin_api/17-foreign-entity_spec.lua`.