### PR TITLE
fix(balancer) reset local caches on init

### DIFF
--- a/kong/runloop/balancer/upstreams.lua
+++ b/kong/runloop/balancer/upstreams.lua
@@ -31,6 +31,7 @@ local upstream_by_name = {}
 function upstreams_M.init()
   balancers = require "kong.runloop.balancer.balancers"
   healthcheckers = require "kong.runloop.balancer.healthcheckers"
+  upstream_by_name = {}
 end
 
 

--- a/spec/01-unit/09-balancer_spec.lua
+++ b/spec/01-unit/09-balancer_spec.lua
@@ -46,9 +46,85 @@ local function setup_it_block(consistency)
   })
 end
 
+local function setup_singletons(fixtures)
+  local singletons = require "kong.singletons"
+  singletons.worker_events = require "resty.worker.events"
+  singletons.db = {}
+
+  singletons.worker_events.configure({
+    shm = "kong_process_events", -- defined by "lua_shared_dict"
+    timeout = 5,            -- life time of event data in shm
+    interval = 1,           -- poll interval (seconds)
+
+    wait_interval = 0.010,  -- wait before retry fetching event data
+    wait_max = 0.5,         -- max wait time before discarding event
+  })
+
+  local function each(fixture)
+    return function()
+      local i = 0
+      return function(self)
+        i = i + 1
+        return fixture[i]
+      end
+    end
+  end
+
+  local function select(fixture)
+    return function(self, pk)
+      for item in self:each() do
+        if item.id == pk.id then
+          return item
+        end
+      end
+    end
+  end
+
+  singletons.db = {
+    targets = {
+      each = each(fixtures.targets),
+      select_by_upstream_raw = function(self, upstream_pk)
+        local upstream_id = upstream_pk.id
+        local res, len = {}, 0
+        for tgt in self:each() do
+          if tgt.upstream.id == upstream_id then
+            tgt.order = string.format("%d:%s", tgt.created_at * 1000, tgt.id)
+            len = len + 1
+            res[len] = tgt
+          end
+        end
+
+        table.sort(res, function(a, b) return a.order < b.order end)
+        return res
+      end
+    },
+    upstreams = {
+      each = each(fixtures.upstreams),
+      select = select(fixtures.upstreams),
+    },
+  }
+
+  singletons.core_cache = {
+    _cache = {},
+    get = function(self, key, _, loader, arg)
+      local v = self._cache[key]
+      if v == nil then
+        v = loader(arg)
+        self._cache[key] = v
+      end
+      return v
+    end,
+    invalidate_local = function(self, key)
+      self._cache[key] = nil
+    end
+  }
+
+  return singletons
+end
+
 for _, consistency in ipairs({"strict", "eventual"}) do
   describe("Balancer (worker_consistency = " .. consistency .. ")", function()
-    local singletons, balancer
+    local balancer
     local targets, upstreams, balancers, healthcheckers
     local UPSTREAMS_FIXTURES
     local TARGETS_FIXTURES
@@ -64,22 +140,10 @@ for _, consistency in ipairs({"strict", "eventual"}) do
       stub(ngx, "log")
 
       balancer = require "kong.runloop.balancer"
-      singletons = require "kong.singletons"
-      singletons.worker_events = require "resty.worker.events"
-      singletons.db = {}
       targets = require "kong.runloop.balancer.targets"
       upstreams = require "kong.runloop.balancer.upstreams"
       balancers = require "kong.runloop.balancer.balancers"
       healthcheckers = require "kong.runloop.balancer.healthcheckers"
-
-      singletons.worker_events.configure({
-        shm = "kong_process_events", -- defined by "lua_shared_dict"
-        timeout = 5,            -- life time of event data in shm
-        interval = 1,           -- poll interval (seconds)
-
-        wait_interval = 0.010,  -- wait before retry fetching event data
-        wait_max = 0.5,         -- max wait time before discarding event
-      })
 
       local hc_defaults = {
         active = {
@@ -273,64 +337,10 @@ for _, consistency in ipairs({"strict", "eventual"}) do
         },
       }
 
-      local function each(fixture)
-        return function()
-          local i = 0
-          return function(self)
-            i = i + 1
-            return fixture[i]
-          end
-        end
-      end
-
-      local function select(fixture)
-        return function(self, pk)
-          for item in self:each() do
-            if item.id == pk.id then
-              return item
-            end
-          end
-        end
-      end
-
-      singletons.db = {
-        targets = {
-          each = each(TARGETS_FIXTURES),
-          select_by_upstream_raw = function(self, upstream_pk)
-            local upstream_id = upstream_pk.id
-            local res, len = {}, 0
-            for tgt in self:each() do
-              if tgt.upstream.id == upstream_id then
-                tgt.order = string.format("%d:%s", tgt.created_at * 1000, tgt.id)
-                len = len + 1
-                res[len] = tgt
-              end
-            end
-
-            table.sort(res, function(a, b) return a.order < b.order end)
-            return res
-          end
-        },
-        upstreams = {
-          each = each(UPSTREAMS_FIXTURES),
-          select = select(UPSTREAMS_FIXTURES),
-        },
-      }
-
-      singletons.core_cache = {
-        _cache = {},
-        get = function(self, key, _, loader, arg)
-          local v = self._cache[key]
-          if v == nil then
-            v = loader(arg)
-            self._cache[key] = v
-          end
-          return v
-        end,
-        invalidate_local = function(self, key)
-          self._cache[key] = nil
-        end
-      }
+      setup_singletons({
+        targets = TARGETS_FIXTURES,
+        upstreams = UPSTREAMS_FIXTURES,
+      })
 
       balancers.init()
       healthcheckers.init()
@@ -428,6 +438,10 @@ for _, consistency in ipairs({"strict", "eventual"}) do
 
     describe("get_upstream_by_name()", function()
       it("retrieves a complete upstream based on its name", function()
+        setup_singletons({
+          targets = TARGETS_FIXTURES,
+          upstreams = UPSTREAMS_FIXTURES,
+        })
         setup_it_block(consistency)
         for _, fixture in ipairs(UPSTREAMS_FIXTURES) do
           local upstream = balancer.get_upstream_by_name(fixture.name)


### PR DESCRIPTION
Balancer modules have an `init()` method that also gets called on
configuration reload.  This is an opportunity to clear any local cache
that should reflect the database.


Fix #7859
