### PR TITLE
Docs/fix typo

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -26,7 +26,7 @@ Examples of unacceptable behavior by participants include:
 advances
 * Trolling, insulting/derogatory comments, and personal or political attacks
 * Public or private harassment
-* Publishing others' private information, such as a physical or electronic
+* Publishing other's private information, such as a physical or electronic
   address, without explicit permission
 * Other conduct which could reasonably be considered inappropriate in a
   professional setting

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Contributing to Kong :monkey_face:
 
 Hello, and welcome! Whether you are looking for help, trying to report a bug,
-thinking about getting involved in the project or about to submit a patch, this
-document is for you! Its intent is to be both an entry point for newcomers to
+thinking about getting involved in the project, or about to submit a patch, this
+document is for you! It intends to be both an entry point for newcomers to
 the community (with various technical backgrounds), and a guide/reference for
 contributors and maintainers.
 
@@ -51,7 +51,7 @@ https://konghq.com/kong-enterprise-edition/ or contact us at
 There are several channels where you can get answers from the community
 or the maintainers of this project:
 
-- Our public forum, [Kong Nation](https://discuss.konghq.com), is great for
+- Our public forum, [Kong Nation](https://discuss.konghq.com) is great for
   asking questions, giving advice, and staying up-to-date with the latest
   announcements. Kong Nation is frequented by Kong maintainers.
 - Two chat channels are used by the community, but are rarely visited by Kong
@@ -160,7 +160,7 @@ first!
 
 When contributing, please follow the guidelines provided in this document. They
 will cover topics such as the different Git branches we use, the commit message
-format to use or the appropriate code style.
+format to use, or the appropriate code style.
 
 Once you have read them, and you are ready to submit your Pull Request, be sure
 to verify a few things:
@@ -174,7 +174,7 @@ to verify a few things:
   development documentation for additional details)
 - The tests are passing: run `make test`, `make test-all`, or whichever is
   appropriate for your change
-- Do not update CHANGELOG.md yourself. Your change will be included there in
+- Do not update CHANGELOG.md yourself. Your change will be included therein
   due time if it is accepted, no worries!
 
 If the above guidelines are respected, your Pull Request has all its chances
@@ -513,7 +513,7 @@ contributors should find themselves at ease when contributing to Kong.
 When you are unsure about the style to adopt, please browse other parts of the
 codebase to find a similar case, and stay consistent with it.
 
-You might also notice places in the code base where the described style is not
+You might also notice places in the codebase where the described style is not
 respected. This is due to legacy code. **Contributions to update the code to
 the recommended style are welcome!**
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

`Other's` was spelled `others'` on this [line](https://github.com/Kong/kong/blob/c72b784595c99b49fbd07927521ead9d07f866cf/CODE_OF_CONDUCT.md#L29). This has been fixed.

Fixes #7936 
