### PR TITLE
chore(deps) remove dependency to resty.cookie

### DIFF
--- a/kong-2.6.0-0.rockspec
+++ b/kong-2.6.0-0.rockspec
@@ -36,7 +36,6 @@ dependencies = {
   "lua-protobuf == 0.3.3",
   "lua-resty-worker-events == 1.0.0",
   "lua-resty-healthcheck == 1.4.2",
-  "lua-resty-cookie == 0.1.0",
   "lua-resty-mlcache == 2.5.0",
   "lua-messagepack == 0.5.2",
   "lua-resty-openssl == 0.7.5",

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1,6 +1,5 @@
 -- Kong runloop
 
-local ck           = require "resty.cookie"
 local meta         = require "kong.meta"
 local utils        = require "kong.tools.utils"
 local Router       = require "kong.router"
@@ -1464,17 +1463,8 @@ return {
       end
 
       local hash_cookie = ctx.balancer_data.hash_cookie
-      if not hash_cookie then
-        return
-      end
-
-      local cookie = ck:new()
-      local ok, err = cookie:set(hash_cookie)
-
-      if not ok then
-        log(WARN, "failed to set the cookie for hash-based load balancing: ", err,
-                  " (key=", hash_cookie.key,
-                  ", path=", hash_cookie.path, ")")
+      if hash_cookie then
+        balancer.set_cookie(hash_cookie)
       end
     end,
     after = function(ctx)


### PR DESCRIPTION
### Summary

The `resty.cookie` library is not maintained, and setting the cookie is not that difficult to warrant a dependency to it. It was only used in one occasion in our code base.