### PR TITLE
chore(deps) remove dependency to resty.timer

### DIFF
--- a/kong-2.6.0-0.rockspec
+++ b/kong-2.6.0-0.rockspec
@@ -30,7 +30,6 @@ dependencies = {
   "luasyslog == 2.0.1",
   "lua_pack == 1.0.5",
   "lrandom",
-  "lua-resty-timer ~> 1",
   "binaryheap >= 0.4",
   "luaxxhash >= 1.0",
   "lua-protobuf == 0.3.3",


### PR DESCRIPTION
### Summary

This is a dependency on `resty.healtchecks`, and not a direct dependency of Kong.