### PR TITLE
chore/deprecate hash plugin daos

### DIFF
--- a/kong-2.6.0-0.rockspec
+++ b/kong-2.6.0-0.rockspec
@@ -316,7 +316,6 @@ build = {
     ["kong.plugins.response-ratelimiting.header_filter"] = "kong/plugins/response-ratelimiting/header_filter.lua",
     ["kong.plugins.response-ratelimiting.log"] = "kong/plugins/response-ratelimiting/log.lua",
     ["kong.plugins.response-ratelimiting.schema"] = "kong/plugins/response-ratelimiting/schema.lua",
-    ["kong.plugins.response-ratelimiting.daos"] = "kong/plugins/response-ratelimiting/daos.lua",
     ["kong.plugins.response-ratelimiting.policies"] = "kong/plugins/response-ratelimiting/policies/init.lua",
     ["kong.plugins.response-ratelimiting.policies.cluster"] = "kong/plugins/response-ratelimiting/policies/cluster.lua",
 

--- a/kong/db/schema/plugin_loader.lua
+++ b/kong/db/schema/plugin_loader.lua
@@ -297,6 +297,11 @@ function plugin_loader.load_entities(plugin, errors, loader_fn)
     -- daos_schemas is a non-empty hash (old syntax). Sort it topologically in order to avoid errors when loading
     -- relationships before loading entities within the same plugin
     daos_schemas = sort_daos_schemas_topologically(daos_schemas)
+
+    kong.log.deprecation("The plugin ", plugin,
+     " is using a hash-like syntax on its `daos.lua` file. ",
+     "Please replace the hash table with a sequential array of schemas.",
+     { after = "2.6.0", removal = "3.0.0" })
   end
 
   local res = {}

--- a/kong/plugins/acl/daos.lua
+++ b/kong/plugins/acl/daos.lua
@@ -1,7 +1,7 @@
 local typedefs = require "kong.db.schema.typedefs"
 
 return {
-  acls = {
+  {
     dao = "kong.plugins.acl.acls",
     name = "acls",
     primary_key = { "id" },

--- a/kong/plugins/acme/daos.lua
+++ b/kong/plugins/acme/daos.lua
@@ -1,7 +1,7 @@
 local typedefs = require "kong.db.schema.typedefs"
 
 return {
-  acme_storage = {
+  {
     ttl = true,
     primary_key = { "id" },
     cache_key = { "key" },

--- a/kong/plugins/basic-auth/daos.lua
+++ b/kong/plugins/basic-auth/daos.lua
@@ -3,7 +3,7 @@ local crypto = require "kong.plugins.basic-auth.crypto"
 
 
 return {
-  basicauth_credentials = {
+  {
     name = "basicauth_credentials",
     primary_key = { "id" },
     cache_key = { "username" },

--- a/kong/plugins/hmac-auth/daos.lua
+++ b/kong/plugins/hmac-auth/daos.lua
@@ -2,7 +2,7 @@ local typedefs = require "kong.db.schema.typedefs"
 
 
 return {
-  hmacauth_credentials = {
+  {
     primary_key = { "id" },
     name = "hmacauth_credentials",
     endpoint_key = "username",

--- a/kong/plugins/jwt/daos.lua
+++ b/kong/plugins/jwt/daos.lua
@@ -11,7 +11,7 @@ local function validate_ssl_key(key)
 end
 
 return {
-  jwt_secrets = {
+  {
     name = "jwt_secrets",
     primary_key = { "id" },
     cache_key = { "key" },

--- a/kong/plugins/key-auth/daos.lua
+++ b/kong/plugins/key-auth/daos.lua
@@ -1,7 +1,7 @@
 local typedefs = require "kong.db.schema.typedefs"
 
 return {
-  keyauth_credentials = {
+  {
     ttl = true,
     primary_key = { "id" },
     name = "keyauth_credentials",

--- a/kong/plugins/response-ratelimiting/daos.lua
+++ b/kong/plugins/response-ratelimiting/daos.lua
@@ -1,3 +1,0 @@
-return {
-  tables = { "response_ratelimiting_metrics" }
-}

--- a/kong/plugins/session/daos.lua
+++ b/kong/plugins/session/daos.lua
@@ -1,7 +1,7 @@
 local typedefs = require "kong.db.schema.typedefs"
 
 return {
-  sessions = {
+  {
     primary_key = { "id" },
     endpoint_key = "session_id",
     name = "sessions",


### PR DESCRIPTION
Plugin DAOs should be arrays instead of hashes.

Hashes have an obvious drawback in that the order in which they are parsed isn't guaranteed - so if an entity has a foreign reference to a different entity on the same plugin DAO, kong can stop failing.

This was fixed on #7911 , but the hash syntax is still deprecated. That fix is reserved for old plugins, and will generate a deprecation warning on the logs.

Depends on #7911 