### PR TITLE
fix(dns) Ensure the resolve timers are started only once

### DIFF
--- a/kong/runloop/balancer/targets.lua
+++ b/kong/runloop/balancer/targets.lua
@@ -22,7 +22,7 @@ local string_match  = string.match
 local ipairs = ipairs
 local tonumber = tonumber
 local table_sort = table.sort
---local assert = assert
+local assert = assert
 
 local ERR = ngx.ERR
 local WARN = ngx.WARN
@@ -38,11 +38,15 @@ local targets_M = {}
 
 -- forward local declarations
 local resolve_timer_callback
+local resolve_timer_running
 local queryDns
 
 function targets_M.init()
   dns_client = require("kong.tools.dns")(kong.configuration)    -- configure DNS client
-  ngx.timer.every(1, resolve_timer_callback)
+
+  if not resolve_timer_running then
+    resolve_timer_running = assert(ngx.timer.every(1, resolve_timer_callback))
+  end
 end
 
 

--- a/spec/01-unit/09-balancer/01-generic_spec.lua
+++ b/spec/01-unit/09-balancer/01-generic_spec.lua
@@ -1654,7 +1654,7 @@ for _, algorithm in ipairs{ "consistent-hashing", "least-connections", "round-ro
             end
           end
 
-          ngx.sleep(0.1)  -- wait a bit before retrying
+          ngx.sleep(0)  -- wait a bit before retrying
         end
       end)
     end)

--- a/spec/01-unit/09-balancer/03-consistent_hashing_spec.lua
+++ b/spec/01-unit/09-balancer/03-consistent_hashing_spec.lua
@@ -470,7 +470,7 @@ describe("[consistent_hashing]", function()
       --b:removeHost("12.34.56.78", 123)
       b.targets[1].addresses[1].disabled = true
       b:deleteDisabledAddresses(b.targets[1])
-      ngx.sleep(0.1)
+      ngx.sleep(0)
       assert.equal(1, count_add)
       assert.equal(1, count_remove)
     end)
@@ -505,14 +505,14 @@ describe("[consistent_hashing]", function()
         { name = "mashape.com", address = "12.34.56.78" },
       })
       add_target(b, "mashape.com", 123, 100)
-      ngx.sleep(0.1)
+      ngx.sleep(0)
       assert.equal(2, count_add)
       assert.equal(0, count_remove)
 
       b.targets[1].addresses[1].disabled = true
       b.targets[1].addresses[2].disabled = true
       b:deleteDisabledAddresses(b.targets[1])
-      ngx.sleep(0.1)
+      ngx.sleep(0)
       assert.equal(2, count_add)
       assert.equal(2, count_remove)
     end)
@@ -553,7 +553,7 @@ describe("[consistent_hashing]", function()
         { name = "mashape.com", target = "mashape2.com", port = 8002, weight = 5 },
       })
       add_target(b, "mashape.com", 123, 100)
-      ngx.sleep(0.1)
+      ngx.sleep(0)
       assert.equal(2, count_add)
       assert.equal(0, count_remove)
 
@@ -561,7 +561,7 @@ describe("[consistent_hashing]", function()
       b.targets[1].addresses[1].disabled = true
       b.targets[1].addresses[2].disabled = true
       b:deleteDisabledAddresses(b.targets[1])
-      ngx.sleep(0.1)
+      ngx.sleep(0)
       assert.equal(2, count_add)
       assert.equal(2, count_remove)
     end)
@@ -582,7 +582,7 @@ describe("[consistent_hashing]", function()
           -- this callback is called when updating. So yield here and
           -- verify that the second thread does not interfere with
           -- the first update, yielded here.
-          ngx.sleep(0.1)
+          ngx.sleep(0)
         end
       })
       dnsA({
@@ -603,7 +603,7 @@ describe("[consistent_hashing]", function()
       end)
       ngx.thread.wait(t1)
       ngx.thread.wait(t2)
-      ngx.sleep(0.1)
+      ngx.sleep(0)
       assert.same({
         [1] = 'thread1 start',
         [2] = 'thread1 end',

--- a/spec/01-unit/09-balancer/04-round_robin_spec.lua
+++ b/spec/01-unit/09-balancer/04-round_robin_spec.lua
@@ -695,14 +695,14 @@ describe("[round robin balancer]", function()
         end
       })
       add_target(b, "12.34.56.78", 123, 100)
-      ngx.sleep(0.1)
+      ngx.sleep(0)
       assert.equal(1, count_add)
       assert.equal(0, count_remove)
 
       --b:removeHost("12.34.56.78", 123)
       b.targets[1].addresses[1].disabled = true
       b:deleteDisabledAddresses(b.targets[1])
-      ngx.sleep(0.1)
+      ngx.sleep(0)
       assert.equal(1, count_add)
       assert.equal(1, count_remove)
     end)
@@ -737,14 +737,14 @@ describe("[round robin balancer]", function()
         { name = "mashape.test", address = "12.34.56.78" },
       })
       add_target(b, "mashape.test", 123, 100)
-      ngx.sleep(0.1)
+      ngx.sleep(0)
       assert.equal(2, count_add)
       assert.equal(0, count_remove)
 
       b.targets[1].addresses[1].disabled = true
       b.targets[1].addresses[2].disabled = true
       b:deleteDisabledAddresses(b.targets[1])
-      ngx.sleep(0.1)
+      ngx.sleep(0)
       assert.equal(2, count_add)
       assert.equal(2, count_remove)
     end)
@@ -785,7 +785,7 @@ describe("[round robin balancer]", function()
         { name = "mashape.test", target = "mashape2.test", port = 8002, weight = 5 },
       })
       add_target(b, "mashape.test", 123, 100)
-      ngx.sleep(0.1)
+      ngx.sleep(0)
       assert.equal(2, count_add)
       assert.equal(0, count_remove)
 
@@ -793,7 +793,7 @@ describe("[round robin balancer]", function()
       b.targets[1].addresses[1].disabled = true
       b.targets[1].addresses[2].disabled = true
       b:deleteDisabledAddresses(b.targets[1])
-      ngx.sleep(0.1)
+      ngx.sleep(0)
       assert.equal(2, count_add)
       assert.equal(2, count_remove)
     end)
@@ -814,7 +814,7 @@ describe("[round robin balancer]", function()
           -- this callback is called when updating. So yield here and
           -- verify that the second thread does not interfere with
           -- the first update, yielded here.
-          ngx.sleep(0.1)
+          ngx.sleep(0)
         end
       })
       dnsA({
@@ -835,7 +835,7 @@ describe("[round robin balancer]", function()
       end)
       ngx.thread.wait(t1)
       ngx.thread.wait(t2)
-      ngx.sleep(0.1)
+      ngx.sleep(0)
       assert.same({
         [1] = 'thread1 start',
         [2] = 'thread1 end',


### PR DESCRIPTION
The xxx.init() functions are called not only at startup, but also at
config reload.

Fix #7928 