### PR TITLE
fix(clustering) add trigger to removed fields for request-termination

### DIFF
--- a/kong/clustering/compat/removed_fields.lua
+++ b/kong/clustering/compat/removed_fields.lua
@@ -50,6 +50,7 @@ return {
     },
     request_termination = {
       "echo",
+      "trigger",
     },
   }
 }

--- a/spec/01-unit/19-hybrid/03-fields-removal_spec.lua
+++ b/spec/01-unit/19-hybrid/03-fields-removal_spec.lua
@@ -56,6 +56,7 @@ describe("kong.clustering.control_plane", function()
       },
       request_termination = {
         "echo",
+        "trigger",
       },
     }, cp._get_removed_fields(2003000000))
 
@@ -78,6 +79,7 @@ describe("kong.clustering.control_plane", function()
       },
       request_termination = {
         "echo",
+        "trigger",
       },
     }, cp._get_removed_fields(2003003003))
 
@@ -100,6 +102,7 @@ describe("kong.clustering.control_plane", function()
       },
       request_termination = {
         "echo",
+        "trigger",
       },
     }, cp._get_removed_fields(2003004000))
 
@@ -122,6 +125,7 @@ describe("kong.clustering.control_plane", function()
       },
       request_termination = {
         "echo",
+        "trigger",
       },
     }, cp._get_removed_fields(2004001000))
 
@@ -134,6 +138,7 @@ describe("kong.clustering.control_plane", function()
       },
       request_termination = {
         "echo",
+        "trigger",
       },
     }, cp._get_removed_fields(2004001002))
 
@@ -146,6 +151,7 @@ describe("kong.clustering.control_plane", function()
       },
       request_termination = {
         "echo",
+        "trigger",
       },
     }, cp._get_removed_fields(2005000000))
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

The echo option added to the request-termination plugin added two new fields; `echo` and `trigger`. To ensure backwards compatibility with older dataplanes both fields must be removed. This commit adds the `trigger` field to the removal list.


### Full changelog

* fix(clustering) add trigger to removed fields for request-termination

### Issues resolved

Fixes version compatibility with older dataplanes (hybrid mode); `trigger` was missing from the removal fields list.
