### PR TITLE
fix(pdk): use x-forwarded-for to get client forwarded ip

### DIFF
--- a/kong/pdk/client.lua
+++ b/kong/pdk/client.lua
@@ -81,7 +81,15 @@ local function new(self)
   function _CLIENT.get_forwarded_ip()
     check_not_phase(PHASES.init_worker)
 
-    return ngx.var.remote_addr
+    local client_ip
+    if ngx.var.upstream_x_forwarded_for ~= nil then
+      -- take the first ip in x-forwarded-for list (client real ip)
+      client_ip = utils.split(ngx.var.upstream_x_forwarded_for, ",")[1]
+      -- remove port from ip (if it's present)
+      client_ip = utils.strip(utils.split(client_ip, ":")[1])
+    end
+
+    return client_ip or ngx.var.remote_addr
   end
 
 


### PR DESCRIPTION
### Summary

The ngx.var.remote_addr not take into account possible load balancers in front of nginx so the ip obtained is not
the real ip of the client that make the request, instead it's the ip of the last load balancer.
We deployed Kong behind of Azure load balancer and we get the ip of that load balancer using this method; we notice that after using the ip-rate-limitting kong plugin as the rate is triggering with different ips and it shouldn't.

Instead if we use x-forwareded-for first part, we will obtain the real ip of the client making the request and also the rate limitting plugin works well.


### Full changelog

* fix(pdk): use x-forwarded-for to get client forwarded ip


