### PR TITLE
fix: remove link with 404 error

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,9 +144,7 @@ of the Plugin Development Guide.
 
 To give visibility to your plugin, we advise that you:
 
-1. [Add your
-   plugin](https://github.com/Kong/docs.konghq.com/blob/master/CONTRIBUTING.md#contributing-to-kong-documentation-and-the-kong-hub)
-   to the [Kong Hub](https://docs.konghq.com/hub/)
+1. Add your plugin to the [Kong Hub](https://docs.konghq.com/hub/)
 2. Create a post in the [Announcements category of Kong
    Nation](https://discuss.konghq.com/c/announcements)
 


### PR DESCRIPTION
The link was redirecting to a github page with "error 404", I searched for an "add your plugin" section and couldn't find anything to replace with the other link, so I just removed it