### PR TITLE
refactor(grpc plugins) extract common grpc code

### DIFF
--- a/kong-2.6.0-0.rockspec
+++ b/kong-2.6.0-0.rockspec
@@ -131,6 +131,7 @@ build = {
     ["kong.status"] = "kong/status/init.lua",
 
     ["kong.tools.dns"] = "kong/tools/dns.lua",
+    ["kong.tools.grpc"] = "kong/tools/grpc.lua",
     ["kong.tools.utils"] = "kong/tools/utils.lua",
     ["kong.tools.timestamp"] = "kong/tools/timestamp.lua",
     ["kong.tools.stream_api"] = "kong/tools/stream_api.lua",

--- a/kong/plugins/grpc-web/deco.lua
+++ b/kong/plugins/grpc-web/deco.lua
@@ -1,15 +1,12 @@
 -- Copyright (c) Kong Inc. 2020
 
-require"lua_pack"
 local cjson = require "cjson"
-local protoc = require "protoc"
 local pb = require "pb"
-local pl_path = require "pl.path"
+local grpc_tools = require "kong.tools.grpc"
+local grpc_frame = grpc_tools.frame
+local grpc_unframe = grpc_tools.unframe
 
 local setmetatable = setmetatable
-
-local bpack=string.pack         -- luacheck: ignore string
-local bunpack=string.unpack     -- luacheck: ignore string
 
 local ngx = ngx
 local decode_base64 = ngx.decode_base64
@@ -62,26 +59,15 @@ local function get_proto_info(fname)
     return info
   end
 
-  local dir, name = pl_path.splitpath(pl_path.abspath(fname))
-  local p = protoc.new()
-  p.include_imports = true
-  p:addpath(dir)
-  local parsed = p:parsefile(name)
-
   info = {}
-
-  for _, srvc in ipairs(parsed.service) do
-    for _, mthd in ipairs(srvc.method) do
-      info[("/%s.%s/%s"):format(parsed.package, srvc.name, mthd.name)] = {
-        mthd.input_type,
-        mthd.output_type,
-      }
-    end
-  end
+  grpc_tools.each_method(fname, function(parsed, srvc, mthd)
+    info[("/%s.%s/%s"):format(parsed.package, srvc.name, mthd.name)] = {
+      mthd.input_type,
+      mthd.output_type,
+    }
+  end)
 
   _proto_info[fname] = info
-
-  p:loadfile(name)
   return info
 end
 
@@ -130,25 +116,6 @@ function deco.new(mimetype, path, protofile)
 end
 
 
-local function frame(ftype, msg)
-  return bpack("C>I", ftype, #msg) .. msg
-end
-
-local function unframe(body)
-  if not body or #body <= 5 then
-    return nil, body
-  end
-
-  local pos, ftype, sz = bunpack(body, "C>I")       -- luacheck: ignore ftype
-  local frame_end = pos + sz - 1
-  if frame_end > #body then
-    return nil, body
-  end
-
-  return body:sub(pos, frame_end), body:sub(frame_end + 1)
-end
-
-
 function deco:upstream(body)
   if self.text_encoding == "base64" then
     body = decode_base64(body)
@@ -157,10 +124,10 @@ function deco:upstream(body)
   if self.msg_encoding == "json" then
     local msg = body
     if self.framing == "grpc" then
-      msg = unframe(body)
+      msg = grpc_unframe(body)
     end
 
-    body = frame(0x0, pb.encode(self.input_type, decode_json(msg)))
+    body = grpc_frame(0x0, pb.encode(self.input_type, decode_json(msg)))
   end
 
   return body
@@ -172,17 +139,17 @@ function deco:downstream(chunk)
     local body = (self.downstream_body or "") .. chunk
 
     local out, n = {}, 1
-    local msg, body = unframe(body)
+    local msg, body = grpc_unframe(body)
 
     while msg do
       msg = encode_json(pb.decode(self.output_type, msg))
       if self.framing == "grpc" then
-        msg = frame(0x0, msg)
+        msg = grpc_frame(0x0, msg)
       end
 
       out[n] = msg
       n = n + 1
-      msg, body = unframe(body)
+      msg, body = grpc_unframe(body)
     end
 
     self.downstream_body = body
@@ -198,7 +165,7 @@ end
 
 
 function deco:frame(ftype, msg)
-  local f = frame(ftype, msg)
+  local f = grpc_frame(ftype, msg)
 
   if self.text_encoding == "base64" then
     f = ngx.encode_base64(f)

--- a/kong/tools/grpc.lua
+++ b/kong/tools/grpc.lua
@@ -1,0 +1,109 @@
+package.loaded.lua_pack = nil   -- BUG: why?
+require "lua_pack"
+local protoc = require "protoc"
+local pb = require "pb"
+local pl_path = require "pl.path"
+local date = require "date"
+
+local bpack=string.pack         -- luacheck: ignore string
+local bunpack=string.unpack     -- luacheck: ignore string
+
+
+local grpc = {}
+
+
+local function safe_set_type_hook(type, dec, enc)
+  if not pcall(pb.hook, type) then
+    ngx.log(ngx.NOTICE, "no type '" .. type .. "' defined")
+    return
+  end
+
+  if not pb.hook(type) then
+    pb.hook(type, dec)
+  end
+
+  if not pb.encode_hook(type) then
+    pb.encode_hook(type, enc)
+  end
+end
+
+local function set_hooks()
+  pb.option("enable_hooks")
+  local epoch = date.epoch()
+
+  safe_set_type_hook(
+    ".google.protobuf.Timestamp",
+    function (t)
+      if type(t) ~= "table" then
+        error(string.format("expected table, got (%s)%q", type(t), tostring(t)))
+      end
+
+      return date(t.seconds):fmt("${iso}")
+    end,
+    function (t)
+      if type(t) ~= "string" then
+        error (string.format("expected time string, got (%s)%q", type(t), tostring(t)))
+      end
+
+      local ds = date(t) - epoch
+      return {
+        seconds = ds:spanseconds(),
+        nanos = ds:getticks() * 1000,
+      }
+    end)
+end
+
+--- loads a .proto file optionally applies a function on each defined method.
+function grpc.each_method(fname, f)
+
+  local dir, name = pl_path.splitpath(pl_path.abspath(fname))
+  local p = protoc.new()
+  p:addpath("/usr/include")
+  p:addpath("/usr/local/opt/protobuf/include/")
+  p:addpath("/usr/local/kong/lib/")
+  p:addpath("kong")
+
+  p.include_imports = true
+  p:addpath(dir)
+  p:loadfile(name)
+  set_hooks()
+  local parsed = p:parsefile(name)
+
+  if f then
+    for _, srvc in ipairs(parsed.service) do
+      for _, mthd in ipairs(srvc.method) do
+        f(parsed, srvc, mthd)
+      end
+    end
+  end
+
+  return parsed
+end
+
+
+--- wraps a binary payload into a grpc stream frame.
+function grpc.frame(ftype, msg)
+  return bpack("C>I", ftype, #msg) .. msg
+end
+
+--- unwraps one frame from a grpc stream.
+--- If success, returns `content, rest`.
+--- If heading frame isn't complete, returns `nil, body`,
+--- try again with more data.
+function grpc.unframe(body)
+  if not body or #body <= 5 then
+    return nil, body
+  end
+
+  local pos, ftype, sz = bunpack(body, "C>I")       -- luacheck: ignore ftype
+  local frame_end = pos + sz - 1
+  if frame_end > #body then
+    return nil, body
+  end
+
+  return body:sub(pos, frame_end), body:sub(frame_end + 1)
+end
+
+
+
+return grpc


### PR DESCRIPTION
common functions for:

- loading a `.proto` file
  - from common subdirectories
  - installs "well-known types" transcoding (only Timestamp for now)
  - applies a function to analize each defined RPC method.
- (un)framing protobuf messages in a data stream.
