### PR TITLE
chore(deps) bump pgmoon from 1.12.0 to 1.13.0

### DIFF
--- a/kong-2.6.0-0.rockspec
+++ b/kong-2.6.0-0.rockspec
@@ -23,7 +23,7 @@ dependencies = {
   "version == 1.0.1",
   "kong-lapis == 1.8.3.1",
   "lua-cassandra == 1.5.1",
-  "pgmoon == 1.12.0",
+  "pgmoon == 1.13.0",
   "luatz == 0.4",
   "lua_system_constants == 0.1.4",
   "lyaml == 6.2.7",


### PR DESCRIPTION
### Summary

- Add support for scram_sha_256_auth by @murillopaula
- feat(socket) change LuaSec ssl_protocol default options by @jeremymv2
- Make application_name pg client init param configurable by @mecampbellsoup
- feature: added 'backlog' and 'pool_size' options while using ngx.socket. by @xiaocang 