### PR TITLE
chore(clustering) remove client queue when closing websocket

### DIFF
--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -784,6 +784,8 @@ function _M:handle_cp_websocket()
 
   local ok, err, perr = ngx.thread.wait(write_thread, read_thread)
 
+  self.clients[wb] = nil
+
   ngx.thread.kill(write_thread)
   ngx.thread.kill(read_thread)
 


### PR DESCRIPTION
### Summary

Explicitly removes the websocket queue from `self.clients` when client connection is dropped.