### PR TITLE
fix(ldap) fix parsing of basic auth header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,10 @@ In this release we continued our work on better performance:
   `redis_ssl` (can be set to `true` or `false`), `ssl_verify`, and `ssl_server_name`.
   [#6737](https://github.com/Kong/kong/pull/6737)
   Thanks [gabeio](https://github.com/gabeio) for the patch!
+- **LDAP**: basic authentication header was not parsed correctly when
+  the password contained colon (`:`).
+  [#7977](https://github.com/Kong/kong/pull/7977)
+  Thanks [beldahanit](https://github.com/beldahanit) for reporting the issue!
 
 [Back to TOC](#table-of-contents)
 

--- a/kong/plugins/ldap-auth/access.lua
+++ b/kong/plugins/ldap-auth/access.lua
@@ -33,7 +33,7 @@ local function retrieve_credentials(authorization_header_value, conf)
     if s == 1 then
       local cred = sub(authorization_header_value, e + 1)
       local decoded_cred = decode_base64(cred)
-      username, password = match(decoded_cred, "(.+):(.+)")
+      username, password = match(decoded_cred, "(.-):(.+)")
     end
   end
 


### PR DESCRIPTION
### Summary

@beldahanit reported on issue #7968 that our ldap plugin parses Basic auth header incorrectly when the password contains `:`.

He is right that:
```
> return  string.match("user:pass:word", "(.+):(.+)")
user:pass	word
```

This is wrong. The specs say that username cannot contain `:`. This commit fixes that.

### Issues Resolved

Fix #7968