### PR TITLE
perf(proxy) reduce unneccessary ngx.var usage on hot path

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1102,7 +1102,8 @@ return {
   },
   preread = {
     before = function(ctx)
-      ctx.host_port = HOST_PORTS[var.server_port] or var.server_port
+      local server_port = var.server_port
+      ctx.host_port = HOST_PORTS[server_port] or server_port
 
       local router = get_updated_router()
 
@@ -1276,7 +1277,9 @@ return {
       -- `host` is the original header to be preserved if set.
       var.upstream_scheme = match_t.upstream_scheme -- COMPAT: pdk
       var.upstream_uri    = escape(match_t.upstream_uri)
-      var.upstream_host   = match_t.upstream_host
+      if match_t.upstream_host then
+        var.upstream_host = match_t.upstream_host
+      end
 
       -- Keep-Alive and WebSocket Protocol Upgrade Headers
       local upgrade = var.http_upgrade
@@ -1341,9 +1344,10 @@ return {
         var.upstream_uri = var.upstream_uri .. "?" .. var.args or ""
       end
 
+      local upstream_scheme = var.upstream_scheme
+
       local balancer_data = ctx.balancer_data
-      balancer_data.scheme = var.upstream_scheme -- COMPAT: pdk
-      local upstream_scheme = balancer_data.scheme
+      balancer_data.scheme = upstream_scheme -- COMPAT: pdk
 
       -- The content of var.upstream_host is only set by the router if
       -- preserve_host is true
@@ -1372,9 +1376,6 @@ return {
         local body = utils.get_default_exit_body(errcode, err)
         return kong.response.exit(errcode, body)
       end
-
-      upstream_scheme = balancer_data.scheme
-      var.upstream_scheme = balancer_data.scheme
 
       local ok, err = balancer.set_host_header(balancer_data, upstream_scheme, upstream_host)
       if not ok then


### PR DESCRIPTION
### Summary

I found a couple of more places where we can reduce variable usage on our hot path. This commit reduces unnecessary setting of `ngx.var.upstream_schema` and `ngx.var.upstream_host`, and also removes one unnecessary read on `preread`.