### PR TITLE
chore(amazonlinux): amazon linux 1 was deprecated long ago

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,7 +72,6 @@ pipeline {
                     steps {
                         sh 'echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin || true'
                         sh 'make setup-kong-build-tools'
-                        sh 'PACKAGE_TYPE=rpm RESTY_IMAGE_BASE=amazonlinux RESTY_IMAGE_TAG=1 make release'
                         sh 'PACKAGE_TYPE=rpm RESTY_IMAGE_BASE=amazonlinux RESTY_IMAGE_TAG=2 make release'
                     }
                 }


### PR DESCRIPTION
https://aws.amazon.com/blogs/aws/update-on-amazon-linux-ami-end-of-life/

related: https://github.com/Kong/kong-build-tools/pull/413