### PR TITLE
chore(deps) bump lua_pack to 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,11 @@ In this release we continued our work on better performance:
 - Configuration reload no longer causes a new DNS-resolving timer to be started.
   [#7943](https://github.com/Kong/kong/pull/7943)
 
+### Dependencies
+
+- Bumped `lua-pack` from 1.0.5 to 2.0.0
+  [#8004](https://github.com/Kong/kong/pull/8004)
+
 [Back to TOC](#table-of-contents)
 
 

--- a/kong-2.6.0-0.rockspec
+++ b/kong-2.6.0-0.rockspec
@@ -28,7 +28,7 @@ dependencies = {
   "lua_system_constants == 0.1.4",
   "lyaml == 6.2.7",
   "luasyslog == 2.0.1",
-  "lua_pack == 1.0.5",
+  "lua_pack == 2.0.0",
   "binaryheap >= 0.4",
   "luaxxhash >= 1.0",
   "lua-protobuf == 0.3.3",

--- a/kong/plugins/grpc-gateway/handler.lua
+++ b/kong/plugins/grpc-gateway/handler.lua
@@ -23,8 +23,6 @@ local grpc_gateway = {
   VERSION = '0.2.0',
 }
 
---require "lua_pack"
-
 
 local CORS_HEADERS = {
   ["Content-Type"] = "application/json",

--- a/kong/plugins/ldap-auth/asn1.lua
+++ b/kong/plugins/ldap-auth/asn1.lua
@@ -1,15 +1,6 @@
-local bpack, bunpack
-do
-  local string_pack = string.pack
-  local string_unpack = string.unpack
-  require "lua_pack"
-  bpack = string.pack
-  bunpack = string.unpack
-  -- luacheck: globals string.unpack
-  string.unpack = string_unpack
-  -- luacheck: globals string.pack
-  string.pack = string_pack
-end
+local lpack = require "lua_pack"
+local bpack = lpack.pack
+local bunpack = lpack.unpack
 
 
 local setmetatable = setmetatable
@@ -25,7 +16,7 @@ local char = string.char
 local bit = bit
 
 
-local _M = { bpack = bpack, bunpack = bunpack }
+local _M = {}
 
 
 _M.BERCLASS = {

--- a/kong/plugins/ldap-auth/ldap.lua
+++ b/kong/plugins/ldap-auth/ldap.lua
@@ -1,7 +1,5 @@
 local asn1 = require "kong.plugins.ldap-auth.asn1"
-
-
-local bunpack = asn1.bunpack
+local bunpack = require "lua_pack".unpack
 local fmt = string.format
 
 

--- a/kong/runloop/plugin_servers/pb_rpc.lua
+++ b/kong/runloop/plugin_servers/pb_rpc.lua
@@ -2,7 +2,7 @@ local kong_global = require "kong.global"
 local cjson = require "cjson.safe"
 local protoc = require "protoc"
 local pb = require "pb"
-require "lua_pack"
+local lpack = require "lua_pack"
 
 local ngx = ngx
 local kong = kong
@@ -10,8 +10,8 @@ local kong = kong
 
 local cjson_encode = cjson.encode
 local t_unpack = table.unpack       -- luacheck: ignore table
-local st_pack = string.pack         -- luacheck: ignore string
-local st_unpack = string.unpack     -- luacheck: ignore string
+local st_pack = lpack.pack
+local st_unpack = lpack.unpack
 
 local Rpc = {}
 Rpc.__index = Rpc

--- a/kong/tools/grpc.lua
+++ b/kong/tools/grpc.lua
@@ -1,12 +1,11 @@
-package.loaded.lua_pack = nil   -- BUG: why?
-require "lua_pack"
+local lpack = require "lua_pack"
 local protoc = require "protoc"
 local pb = require "pb"
 local pl_path = require "pl.path"
 local date = require "date"
 
-local bpack=string.pack         -- luacheck: ignore string
-local bunpack=string.unpack     -- luacheck: ignore string
+local bpack = lpack.pack
+local bunpack = lpack.unpack
 
 
 local grpc = {}

--- a/kong/tools/stream_api.lua
+++ b/kong/tools/stream_api.lua
@@ -3,12 +3,12 @@
 -- may changed or be removed in the future Kong releases once a better mechanism
 -- for inter subsystem communication in OpenResty became available.
 
-require "lua_pack"
+local lpack = require "lua_pack"
 
 
 local kong       = kong
-local st_pack    = string.pack      -- luacheck: ignore string
-local st_unpack  = string.unpack    -- luacheck: ignore string
+local st_pack    = lpack.pack
+local st_unpack  = lpack.unpack
 local st_format  = string.format
 local table_concat = table.concat
 local assert     = assert


### PR DESCRIPTION
No longer pollutes the `string` library, it's just a "normal" module.