### PR TITLE
perf(plugin-iterator) return zero iterator when no global plugins specified

### DIFF
--- a/kong/runloop/plugins_iterator.lua
+++ b/kong/runloop/plugins_iterator.lua
@@ -416,11 +416,8 @@ local function new_ws_data()
     }
   end
 
-  local plugins = {}
-  plugins[0] = 0
-
   return {
-    plugins = plugins,
+    plugins = { [0] = 0 },
     globals = 0,
     combos = {},
     phases = phases,

--- a/kong/runloop/plugins_iterator.lua
+++ b/kong/runloop/plugins_iterator.lua
@@ -358,7 +358,9 @@ local function iterate(self, phase, ctx)
   ctx.plugins = kong.table.new(plugins[0] * 2, 1)
   ctx.plugins[0] = 0
 
-  if plugins[0] == 0 then
+  if (plugins[0] == 0)
+  or (ws.globals == 0 and (phase == "certificate" or phase == "rewrite"))
+  then
     return zero_iter
   end
 
@@ -419,6 +421,7 @@ local function new_ws_data()
 
   return {
     plugins = plugins,
+    globals = 0,
     combos = {},
     phases = phases,
   }
@@ -476,6 +479,10 @@ function PluginsIterator.new(version)
       local combo_key = (plugin.route    and 1 or 0)
                       + (plugin.service  and 2 or 0)
                       + (plugin.consumer and 4 or 0)
+
+      if combo_key == 0 then
+        data.globals = data.globals + 1
+      end
 
       if kong.db.strategy == "off" then
         if plugin.enabled then


### PR DESCRIPTION
### Summary

We don't need to iterate over the plugins on `certificate` or `rewrite` phases if there are no global plugins configured.

(the perf test is broken, until it is fixed or 2.7 is released, but I don't think we should wait for it)