### PR TITLE
docs(admin API) Update path handling table

### DIFF
--- a/autodoc/admin-api/data/admin-api.lua
+++ b/autodoc/admin-api/data/admin-api.lua
@@ -892,18 +892,26 @@ return {
         Both versions of the algorithm detect "double slashes" when combining paths, replacing them by single
         slashes.
 
-        In the following table, `s` is the Service and `r` is the Route.
+        The following table shows the possible combinations of path handling version, strip path, and request:
 
-        | `s.path` | `r.path` | `r.strip_path` | `r.path_handling` | request path | proxied path  |
-        |----------|----------|----------------|-------------------|--------------|---------------|
-        | `/s`     | `/fv0`   | `false`        | `v0`              | `/fv0req`    | `/s/fv0req`   |
-        | `/s`     | `/fv1`   | `false`        | `v1`              | `/fv1req`    | `/sfv1req`    |
-        | `/s`     | `/tv0`   | `true`         | `v0`              | `/tv0req`    | `/s/req`      |
-        | `/s`     | `/tv1`   | `true`         | `v1`              | `/tv1req`    | `/sreq`       |
-        | `/s`     | `/fv0/`  | `false`        | `v0`              | `/fv0/req`   | `/s/fv0/req`  |
-        | `/s`     | `/fv1/`  | `false`        | `v1`              | `/fv1/req`   | `/sfv1/req`   |
-        | `/s`     | `/tv0/`  | `true`         | `v0`              | `/tv0/req`   | `/s/req`      |
-        | `/s`     | `/tv1/`  | `true`         | `v1`              | `/tv1/req`   | `/sreq`       |
+        | `service.path` | `route.path` | `request` |`route.strip_path` | `route.path_handling` | request path | upstream path |
+        |----------------|--------------|-----------|-------------------|-----------------------|--------------|---------------|
+        | `/s`           | `/fv0`       | `req`     | `false`           | `v0`                  |  `/fv0/req`  | `/s/fv0/req`  |
+        | `/s`           | `/fv0`       | `blank`   | `false`           | `v0`                  |  `/fv0`      | `/s/fv0`      |
+        | `/s`           | `/fv1`       | `req`     | `false`           | `v1`                  |  `/fv1/req`  | `/sfv1/req`   |
+        | `/s`           | `/fv1`       | `blank`   | `false`           | `v1`                  |  `/fv1`      | `/sfv1`       |
+        | `/s`           | `/tv0`       | `req`     | `true`            | `v0`                  |  `/tv0/req`  | `/s/req`      |
+        | `/s`           | `/tv0`       | `blank`   | `true`            | `v0`                  |  `/tv0`      | `/s`          |
+        | `/s`           | `/tv1`       | `req`     | `true`            | `v1`                  |  `/tv1/req`  | `/s/req`      |
+        | `/s`           | `/tv1`       | `blank`   | `true`            | `v1`                  |  `/tv1`      | `/s`          |
+        | `/s`           | `/fv0/`      | `req`     | `false`           | `v0`                  |  `/fv0/req`  | `/s/fv0/req`  |
+        | `/s`           | `/fv0/`      | `blank`   | `false`           | `v0`                  |  `/fv0/`     | `/s/fv01/`    |
+        | `/s`           | `/fv1/`      | `req`     | `false`           | `v1`                  |  `/fv1/req`  | `/sfv1/req`   |
+        | `/s`           | `/fv1/`      | `blank`   | `false`           | `v1`                  |  `/fv1/`     | `/sfv1/`      |
+        | `/s`           | `/tv0/`      | `req`     | `true`            | `v0`                  |  `/tv0/req`  | `/s/req`      |
+        | `/s`           | `/tv0/`      | `blank`   | `true`            | `v0`                  |  `/tv0/`     | `/s/`         |
+        | `/s`           | `/tv1/`      | `req`     | `true`            | `v1`                  |  `/tv1/req`  | `/sreq`       |
+        | `/s`           | `/tv1/`      | `blank`   | `true`            | `v1`                  |  `/tv1/`     | `/s`          |
 
       ]],
       fields = {


### PR DESCRIPTION
### Summary

Updating the route path handling algorithms table in the Admin API doc based on feedback from a field engineer working with customers. The updated table has a more complete matrix and fixes some broken markdown.

Parallel to docs repo PR: https://github.com/Kong/docs.konghq.com/pull/3353

### Full changelog

N/A

### Issues resolved

From original PR submitter: Was walking through the logic with a client and found it slightly confusing, and also noticed the table broken in the official docs. Tested this using a kong instance and setting up a service and route and calling the proxy api to test each combination in the table. Have also shared this with the client (new table) and they are happier that it makes more sense and values match what they have seen too.
