### PR TITLE
chore(*) import azure functions

### DIFF
--- a/kong-2.6.0-0.rockspec
+++ b/kong-2.6.0-0.rockspec
@@ -42,7 +42,6 @@ dependencies = {
   "lua-resty-acme == 0.7.2",
   "lua-resty-session == 3.8",
   -- external Kong plugins
-  "kong-plugin-azure-functions ~> 1.0",
   "kong-plugin-zipkin ~> 1.4",
   "kong-plugin-request-transformer ~> 1.3",
 }
@@ -458,5 +457,8 @@ build = {
 
     ["kong.plugins.post-function.handler"] = "kong/plugins/post-function/handler.lua",
     ["kong.plugins.post-function.schema"] = "kong/plugins/post-function/schema.lua",
+
+    ["kong.plugins.azure-functions.handler"] = "kong/plugins/azure-functions/handler.lua",
+    ["kong.plugins.azure-functions.schema"]  = "kong/plugins/azure-functions/schema.lua",
   }
 }

--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -33,8 +33,8 @@ local plugins = {
   "grpc-web",
   "pre-function",
   "post-function",
-  -- external plugins
   "azure-functions",
+  -- external plugins
   "zipkin",
 }
 

--- a/kong/plugins/azure-functions/handler.lua
+++ b/kong/plugins/azure-functions/handler.lua
@@ -1,0 +1,118 @@
+local constants     = require "kong.constants"
+local meta          = require "kong.meta"
+local http          = require "resty.http"
+
+
+local kong          = kong
+local fmt           = string.format
+local var           = ngx.var
+local pairs         = pairs
+local server_header = meta._SERVER_TOKENS
+local conf_cache    = setmetatable({}, { __mode = "k" })
+
+
+local function send(status, content, headers)
+  if kong.configuration.enabled_headers[constants.HEADERS.VIA] then
+    headers = kong.table.merge(headers) -- create a copy of headers
+    headers[constants.HEADERS.VIA] = server_header
+  end
+
+  return kong.response.exit(status, content, headers)
+end
+
+
+local azure = {
+  PRIORITY = 749,
+  VERSION  = "1.0.1",
+}
+
+
+function azure:access(config)
+  -- prepare and store updated config in cache
+  local conf = conf_cache[config]
+  if not conf then
+    conf = {}
+    for k,v in pairs(config) do
+      conf[k] = v
+    end
+    conf.host = config.appname .. "." .. config.hostdomain
+    conf.port = config.https and 443 or 80
+    local f = (config.functionname or ""):match("^/*(.-)/*$")  -- drop pre/postfix slashes
+    local p = (config.routeprefix or ""):match("^/*(.-)/*$")  -- drop pre/postfix slashes
+    if p ~= "" then
+      p = "/" .. p
+    end
+    conf.path = p .. "/" .. f
+
+    conf_cache[config] = conf
+  end
+  config = conf
+
+  local request_method = kong.request.get_method()
+  local request_body = kong.request.get_raw_body()
+  local request_headers = kong.request.get_headers()
+  local request_args = kong.request.get_query()
+
+  local upstream_uri = var.upstream_uri
+  local path = conf.path
+  local end1 = path:sub(-1, -1)
+  local start2 = upstream_uri:sub(1, 1)
+  if end1 == "/" then
+    if start2 == "/" then
+      path = path .. upstream_uri:sub(2,-1)
+    else
+      path = path .. upstream_uri
+    end
+  else
+    if start2 == "/" then
+      path = path .. upstream_uri
+    else
+      if upstream_uri ~= "" then
+        path = path .. "/" .. upstream_uri
+      end
+    end
+  end
+
+  request_headers["host"] = nil  -- NOTE: OR return lowercase!
+  request_headers["x-functions-key"] = config.apikey
+  request_headers["x-functions-clientid"] = config.clientid
+
+
+  local scheme = config.https and "https" or "http"
+  local uri = conf.port and fmt("%s://%s:%d", scheme, conf.host, conf.port)
+                         or fmt("%s://%s", scheme, conf.host)
+
+  local client = http.new()
+  client:set_timeout(config.timeout)
+  local res, err = client:request_uri(uri, {
+    method = request_method,
+    path = path,
+    body = request_body,
+    query = request_args,
+    headers = request_headers,
+    ssl_verify = config.https_verify,
+    keepalive_timeout = conf.keepalive,
+  })
+
+  if not res then
+    kong.log.err(err)
+    return kong.response.exit(500, { message = "An unexpected error occurred" })
+  end
+
+  local response_headers = res.headers
+  local response_status = res.status
+  local response_content = res.body
+
+  if var.http2 then
+    response_headers["Connection"] = nil
+    response_headers["Keep-Alive"] = nil
+    response_headers["Proxy-Connection"] = nil
+    response_headers["Upgrade"] = nil
+    response_headers["Transfer-Encoding"] = nil
+  end
+
+  return send(response_status, response_content, response_headers)
+end
+
+
+return azure

--- a/kong/plugins/azure-functions/kong-plugin-azure-functions-1.0.1-1.rockspec
+++ b/kong/plugins/azure-functions/kong-plugin-azure-functions-1.0.1-1.rockspec
@@ -1,0 +1,21 @@
+package = "kong-plugin-azure-functions"
+version = "1.0.1-1"
+source = {
+  url = "git://github.com/kong/kong-plugin-azure-functions",
+  tag = "1.0.1"
+}
+description = {
+  summary = "This plugin allows Kong to invoke Azure functions.",
+  license = "Apache 2.0"
+}
+dependencies = {
+  "lua >= 5.1",
+  --"kong >= 0.15.0",
+}
+build = {
+  type = "builtin",
+  modules = {
+    ["kong.plugins.azure-functions.handler"] = "kong/plugins/azure-functions/handler.lua",
+    ["kong.plugins.azure-functions.schema"]  = "kong/plugins/azure-functions/schema.lua",
+  }
+}

--- a/kong/plugins/azure-functions/schema.lua
+++ b/kong/plugins/azure-functions/schema.lua
@@ -1,0 +1,23 @@
+return {
+  name = "azure-functions",
+  fields = {
+    { config = {
+        type = "record",
+        fields = {
+          -- connection basics
+          { timeout       = { type = "number",  default  = 600000}, },
+          { keepalive     = { type = "number",  default  = 60000 }, },
+          { https         = { type = "boolean", default  = true  }, },
+          { https_verify  = { type = "boolean", default  = false }, },
+          -- authorization
+          { apikey        = { type = "string"                    }, },
+          { clientid      = { type = "string"                    }, },
+          -- target/location
+          { appname       = { type = "string",  required = true  }, },
+          { hostdomain    = { type = "string",  required = true, default = "azurewebsites.net" }, },
+          { routeprefix   = { type = "string",  default = "api"  }, },
+          { functionname  = { type = "string",  required = true  }, },
+        },
+    }, },
+  },
+}

--- a/spec/03-plugins/35-azure-functions/01-access_spec.lua
+++ b/spec/03-plugins/35-azure-functions/01-access_spec.lua
@@ -1,0 +1,180 @@
+local helpers = require "spec.helpers"
+local meta = require "kong.meta"
+
+
+local server_tokens = meta._SERVER_TOKENS
+
+
+for _, strategy in helpers.each_strategy() do
+  describe("Plugin: Azure Functions (access) [#" .. strategy .. "]", function()
+    local proxy_client
+
+    setup(function()
+      local bp = helpers.get_db_utils(strategy)
+
+      local route2 = bp.routes:insert {
+        hosts      = { "azure2.com" },
+        protocols  = { "http", "https" },
+        service    = bp.services:insert({
+          protocol = "http",
+          host     = "to.be.overridden",
+          port     = 80,
+        })
+      }
+
+      -- this plugin definition results in an upstream url to
+      -- http://httpbin.org/anything
+      -- which will echo the request for inspection
+      bp.plugins:insert {
+        name     = "azure-functions",
+        route    = { id = route2.id },
+        config   = {
+          https           = true,
+          appname         = "httpbin",
+          hostdomain      = "org",
+          routeprefix     = "anything",
+          functionname    = "test-func-name",
+          apikey          = "anything_but_an_API_key",
+          clientid        = "and_no_clientid",
+        },
+      }
+
+      assert(helpers.start_kong{
+        database = strategy,
+        plugins  = "azure-functions",
+      })
+
+    end) -- setup
+
+    before_each(function()
+      proxy_client = helpers.proxy_client()
+    end)
+
+    after_each(function ()
+      proxy_client:close()
+    end)
+
+    teardown(function()
+      helpers.stop_kong()
+    end)
+
+
+    it("passes request query parameters", function()
+      local res = assert(proxy_client:send {
+        method  = "GET",
+        path    = "/",
+        query   = { hello = "world" },
+        headers = {
+          ["Host"] = "azure2.com"
+        }
+      })
+
+      assert.response(res).has.status(200)
+      local json = assert.response(res).has.jsonbody()
+      assert.same({ hello ="world" }, json.args)
+    end)
+
+    it("passes request body", function()
+      local body = "I'll be back"
+      local res = assert(proxy_client:send {
+        method  = "GET",
+        path    = "/",
+        body    = body,
+        query   = { hello = "world" },
+        headers = {
+          ["Host"] = "azure2.com"
+        }
+      })
+
+      assert.response(res).has.status(200)
+      local json = assert.response(res).has.jsonbody()
+      assert.same(body, json.data)
+    end)
+
+    it("passes the path parameters", function()
+      local res = assert(proxy_client:send {
+        method  = "GET",
+        path    = "/and/then/some",
+        headers = {
+          ["Host"] = "azure2.com"
+        }
+      })
+
+      assert.response(res).has.status(200)
+      local json = assert.response(res).has.jsonbody()
+      assert.matches("httpbin.org/anything/test%-func%-name/and/then/some", json.url)
+    end)
+
+    it("passes the method", function()
+      local res = assert(proxy_client:send {
+        method  = "POST",
+        path    = "/",
+        headers = {
+          ["Host"] = "azure2.com"
+        }
+      })
+
+      assert.response(res).has.status(200)
+      local json = assert.response(res).has.jsonbody()
+      assert.same("POST", json.method)
+    end)
+
+    it("passes the headers", function()
+      local res = assert(proxy_client:send {
+        method  = "GET",
+        path    = "/and/then/some",
+        headers = {
+          ["Host"] = "azure2.com",
+          ["Just-A-Header"] = "just a value",
+        }
+      })
+
+      assert.response(res).has.status(200)
+      local json = assert.response(res).has.jsonbody()
+      assert.same("just a value", json.headers["Just-A-Header"])
+    end)
+
+    it("injects the apikey and clientid", function()
+      local res = assert(proxy_client:send {
+        method  = "POST",
+        path    = "/",
+        headers = {
+          ["Host"] = "azure2.com"
+        }
+      })
+
+      assert.response(res).has.status(200)
+      local json = assert.response(res).has.jsonbody()
+      --assert.same({}, json.headers)
+      assert.same("anything_but_an_API_key", json.headers["X-Functions-Key"])
+      assert.same("and_no_clientid", json.headers["X-Functions-Clientid"])
+    end)
+
+    it("returns server tokens with Via header", function()
+      local res = assert(proxy_client:send {
+        method  = "GET",
+        path    = "/",
+        query   = { hello = "world" },
+        headers = {
+          ["Host"] = "azure2.com"
+        }
+      })
+
+      assert.equal(server_tokens, res.headers["Via"])
+    end)
+
+    it("returns Content-Length header", function()
+      local res = assert(proxy_client:send {
+        method  = "GET",
+        path    = "/",
+        query   = { hello = "world" },
+        headers = {
+          ["Host"] = "azure2.com"
+        }
+      })
+
+      assert(tonumber(res.headers["Content-Length"]) > 100)
+    end)
+
+  end) -- describe
+end


### PR DESCRIPTION
As a result of an effort to improve external plugins maintainership, we are importing currently-bundled plugins into Kong's main tree. The azure-functions plugin used to live in [1].

Additionally to importing plugin contents, this PR also preserves the Git history. History was amended to correct commit scopes - including azure-functions in commit messages scope.

[1] https://github.com/Kong/kong-plugin-azure-functions