### PR TITLE
feat(rate-limiting) add redis username support

### DIFF
--- a/kong/plugins/rate-limiting/policies/init.lua
+++ b/kong/plugins/rate-limiting/policies/init.lua
@@ -79,7 +79,13 @@ local function get_redis_connection(conf)
 
   if times == 0 then
     if is_present(conf.redis_password) then
-      local ok, err = red:auth(conf.redis_password)
+      local ok, err
+      if is_present(conf.redis_username) then
+        ok, err = red:auth(conf.redis_username, conf.redis_password)
+      else
+        ok, err = red:auth(conf.redis_password)
+      end
+
       if not ok then
         kong.log.err("failed to auth Redis: ", err)
         return nil, err

--- a/kong/plugins/rate-limiting/schema.lua
+++ b/kong/plugins/rate-limiting/schema.lua
@@ -84,6 +84,7 @@ return {
           { redis_host = typedefs.host },
           { redis_port = typedefs.port({ default = 6379 }), },
           { redis_password = { type = "string", len_min = 0 }, },
+          { redis_username = { type = "string" }, },
           { redis_ssl = { type = "boolean", required = true, default = false, }, },
           { redis_ssl_verify = { type = "boolean", required = true, default = false }, },
           { redis_server_name = typedefs.sni },


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Adds support for configuring a username for the redis connection.

### Full changelog

- Adds the optional property `redis_username` used for connecting to redis. This allows to make use of redis ACL features supported with Redis 6.0

### Issues resolved


