### PR TITLE
feat(rate-limiting) add redis username support

### DIFF
--- a/kong/plugins/rate-limiting/policies/init.lua
+++ b/kong/plugins/rate-limiting/policies/init.lua
@@ -79,7 +79,13 @@ local function get_redis_connection(conf)
 
   if times == 0 then
     if is_present(conf.redis_password) then
-      local ok, err = red:auth(conf.redis_password)
+      local ok, err
+      if is_present(conf.redis_username) then
+        ok, err = red:auth(conf.redis_username, conf.redis_password)
+      else
+        ok, err = red:auth(conf.redis_password)
+      end
+
       if not ok then
         kong.log.err("failed to auth Redis: ", err)
         return nil, err

--- a/kong/plugins/rate-limiting/schema.lua
+++ b/kong/plugins/rate-limiting/schema.lua
@@ -84,6 +84,7 @@ return {
           { redis_host = typedefs.host },
           { redis_port = typedefs.port({ default = 6379 }), },
           { redis_password = { type = "string", len_min = 0 }, },
+          { redis_username = { type = "string" }, },
           { redis_ssl = { type = "boolean", required = true, default = false, }, },
           { redis_ssl_verify = { type = "boolean", required = true, default = false }, },
           { redis_server_name = typedefs.sni },

--- a/spec/03-plugins/23-rate-limiting/05-integration_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/05-integration_spec.lua
@@ -119,6 +119,7 @@ describe("Plugin: rate-limiting (integration)", function()
           redis_port     = REDIS_PORT,
           redis_username = REDIS_USER_VALID,
           redis_password = REDIS_PASSWORD,
+          redis_database = 3, -- ensure to not get a pooled authenticated connection by using a different db
           fault_tolerant = false,
         }
       })
@@ -136,6 +137,7 @@ describe("Plugin: rate-limiting (integration)", function()
           redis_port     = REDIS_PORT,
           redis_username = REDIS_USER_INVALID,
           redis_password = REDIS_PASSWORD,
+          redis_database = 4, -- ensure to not get a pooled authenticated connection by using a different db                  
           fault_tolerant = false,
         }
       })

--- a/spec/03-plugins/23-rate-limiting/05-integration_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/05-integration_spec.lua
@@ -8,6 +8,11 @@ local REDIS_DB_1 = 1
 local REDIS_DB_2 = 2
 
 
+local REDIS_USER_VALID = "ratelimit-user"
+local REDIS_USER_INVALID = "some-user"
+local REDIS_PASSWORD = "secret"
+
+
 local SLEEP_TIME = 1
 
 
@@ -20,6 +25,23 @@ local function flush_redis(db)
   red:close()
 end
 
+local function add_redis_user()
+  local red = redis:new()
+  red:set_timeout(2000)
+  assert(red:connect(REDIS_HOST, REDIS_PORT))
+  assert(red:acl("setuser", REDIS_USER_VALID, "on", "allkeys", "+incrby", "+select", "+info", "+expire", "+get", ">" .. REDIS_PASSWORD))
+  assert(red:acl("setuser", REDIS_USER_INVALID, "on", "allkeys", "+get", ">" .. REDIS_PASSWORD))
+  red:close()
+end
+
+local function remove_redis_user()
+  local red = redis:new()
+  red:set_timeout(2000)
+  assert(red:connect(REDIS_HOST, REDIS_PORT))
+  assert(red:acl("deluser", REDIS_USER_VALID))
+  assert(red:acl("deluser", REDIS_USER_INVALID))
+  red:close()
+end
 
 describe("Plugin: rate-limiting (integration)", function()
   local client
@@ -50,6 +72,7 @@ describe("Plugin: rate-limiting (integration)", function()
     lazy_setup(function()
       flush_redis(REDIS_DB_1)
       flush_redis(REDIS_DB_2)
+      add_redis_user()
 
       local route1 = assert(bp.routes:insert {
         hosts        = { "redistest1.com" },
@@ -82,10 +105,50 @@ describe("Plugin: rate-limiting (integration)", function()
           fault_tolerant = false,
         }
       })
+
+      local route3 = assert(bp.routes:insert {
+        hosts        = { "redistest3.com" },
+      })
+      assert(bp.plugins:insert {
+        name = "rate-limiting",
+        route = { id = route3.id },
+        config = {
+          minute         = 1,
+          policy         = "redis",
+          redis_host     = REDIS_HOST,
+          redis_port     = REDIS_PORT,
+          redis_username = REDIS_USER_VALID,
+          redis_password = REDIS_PASSWORD,
+          fault_tolerant = false,
+        }
+      })
+
+      local route4 = assert(bp.routes:insert {
+        hosts        = { "redistest4.com" },
+      })
+      assert(bp.plugins:insert {
+        name = "rate-limiting",
+        route = { id = route4.id },
+        config = {
+          minute         = 1,
+          policy         = "redis",
+          redis_host     = REDIS_HOST,
+          redis_port     = REDIS_PORT,
+          redis_username = REDIS_USER_INVALID,
+          redis_password = REDIS_PASSWORD,
+          fault_tolerant = false,
+        }
+      })
+
+
       assert(helpers.start_kong({
         nginx_conf = "spec/fixtures/custom_nginx.template",
       }))
       client = helpers.proxy_client()
+    end)
+
+    lazy_teardown(function()
+      remove_redis_user()
     end)
 
     it("connection pool respects database setting", function()
@@ -160,5 +223,28 @@ describe("Plugin: rate-limiting (integration)", function()
       assert.equal(1, tonumber(size_1))
       assert.equal(1, tonumber(size_2))
     end)
+
+    it("authenticates and executes with a valid redis user having proper ACLs", function()
+      local res = assert(client:send {
+        method = "GET",
+        path = "/status/200",
+        headers = {
+          ["Host"] = "redistest3.com"
+        }
+      })
+      assert.res_status(200, res)
+    end)
+
+    it("fails to rate-limit for a redis user with missing ACLs", function()
+      local res = assert(client:send {
+        method = "GET",
+        path = "/status/200",
+        headers = {
+          ["Host"] = "redistest4.com"
+        }
+      })
+      assert.res_status(500, res)
+    end)
+
   end)
 end)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Adds support for configuring an username for the redis connection.

### Full changelog

- Adds the optional property redis_username used for connecting to redis. This allows to make use of redis ACL features supported with Redis 6.0

### Issues resolved

