### PR TITLE
tests(dns-client) do not search local domain when resolving

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -123,14 +123,7 @@ jobs:
     strategy:
       matrix:
         suite: [integration, plugins]
-        split: [all, first (01-04), second (>= 05)]
-        exclude:
-          - suite: plugins
-            split: first (01-04)
-          - suite: plugins
-            split: second (>= 05)
-          - suite: integration
-            split: all
+        split: [first (01-04), second (>= 05)]
 
     env:
       KONG_TEST_PG_DATABASE: kong
@@ -256,14 +249,7 @@ jobs:
       matrix:
         suite: [integration, plugins]
         cassandra_version: [3]
-        split: [all, first (01-04), second (>= 05)]
-        exclude:
-          - suite: plugins
-            split: first (01-04)
-          - suite: plugins
-            split: second (>= 05)
-          - suite: integration
-            split: all
+        split: [first (01-04), second (>= 05)]
 
     env:
       KONG_TEST_DATABASE: cassandra

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -1969,6 +1969,12 @@ describe("Router", function()
           router = assert(Router.new(benchmark_use_cases))
         end)
 
+        lazy_teardown(function()
+          -- this avoids memory leakage
+          router = nil
+          benchmark_use_cases = nil
+        end)
+
         it("takes < 1ms", function()
           local match_t = router.select("GET", "/", target_domain)
           assert.truthy(match_t)
@@ -2013,6 +2019,12 @@ describe("Router", function()
           router = assert(Router.new(benchmark_use_cases))
         end)
 
+        lazy_teardown(function()
+          -- this avoids memory leakage
+          router = nil
+          benchmark_use_cases = nil
+        end)
+
         it("takes < 1ms", function()
           local match_t = router.select("POST", target_uri, target_domain)
           assert.truthy(match_t)
@@ -2042,6 +2054,12 @@ describe("Router", function()
 
             target_location =  "somewhere-" .. n
             router = assert(Router.new(benchmark_use_cases))
+          end)
+
+          lazy_teardown(function()
+            -- this avoids memory leakage
+            router = nil
+            benchmark_use_cases = nil
           end)
 
           it("takes < 1ms", function()
@@ -2077,6 +2095,12 @@ describe("Router", function()
             target_key = "key-" .. n
             target_val =  "somewhere"
             router = assert(Router.new(benchmark_use_cases))
+          end)
+
+          lazy_teardown(function()
+            -- this avoids memory leakage
+            router = nil
+            benchmark_use_cases = nil
           end)
 
           it("takes < 1ms", function()
@@ -2124,6 +2148,12 @@ describe("Router", function()
           target_uri = "/my-real-route"
           target_domain = "domain.org"
           router = assert(Router.new(benchmark_use_cases))
+        end)
+
+        lazy_teardown(function()
+          -- this avoids memory leakage
+          router = nil
+          benchmark_use_cases = nil
         end)
 
         it("takes < 1ms", function()
@@ -2175,6 +2205,12 @@ describe("Router", function()
           target_domain = "domain-" .. n .. ".org"
           target_location = "somewhere-" .. n
           router = assert(Router.new(benchmark_use_cases))
+        end)
+
+        lazy_teardown(function()
+          -- this avoids memory leakage
+          router = nil
+          benchmark_use_cases = nil
         end)
 
         it("takes < 1ms", function()
@@ -3535,7 +3571,7 @@ end)
 
 describe("[both regex and prefix with regex_priority]", function()
   local use_case = {
-    -- regex  
+    -- regex
     {
       service = service,
       route   = {

--- a/spec/01-unit/21-dns-client/01-utils_spec.lua
+++ b/spec/01-unit/21-dns-client/01-utils_spec.lua
@@ -303,13 +303,13 @@ options ndots:2
       assert.Not.equal(val1, val2) -- no ttl specified, so distinct tables
       assert.Not.equal(val1r, val2r) -- no ttl specified, so distinct tables
 
-      val1r, val1 = dnsutils.getHosts(1)
+      val1r, val1 = dnsutils.getHosts(0.1)
       val2r, val2 = dnsutils.getHosts()
       assert.are.equal(val1, val2)   -- ttl specified, so same tables
       assert.are.equal(val1r, val2r) -- ttl specified, so same tables
 
       -- wait for cache to expire
-      sleep(2)
+      sleep(0.2)
 
       val2r, val2 = dnsutils.getHosts()
       assert.Not.equal(val1, val2) -- ttl timed out, so distinct tables
@@ -321,12 +321,12 @@ options ndots:2
       local val2 = dnsutils.getResolv()
       assert.Not.equal(val1, val2) -- no ttl specified, so distinct tables
 
-      val1 = dnsutils.getResolv(1)
+      val1 = dnsutils.getResolv(0.1)
       val2 = dnsutils.getResolv()
       assert.are.equal(val1, val2)   -- ttl specified, so same tables
 
       -- wait for cache to expire
-      sleep(2)
+      sleep(0.2)
 
       val2 = dnsutils.getResolv()
       assert.Not.equal(val1, val2)   -- ttl timed out, so distinct tables

--- a/spec/01-unit/21-dns-client/02-client_spec.lua
+++ b/spec/01-unit/21-dns-client/02-client_spec.lua
@@ -653,7 +653,7 @@ describe("[DNS client]", function()
   end)
 
   it("fetching A record redirected through 2 CNAME records (un-typed)", function()
-    assert(client.init())
+    assert(client.init({ search = {}, }))
     local lrucache = client.getcache()
 
     --[[
@@ -720,7 +720,7 @@ describe("[DNS client]", function()
   end)
 
   it("fetching multiple SRV records through CNAME (un-typed)", function()
-    assert(client.init())
+    assert(client.init({ search = {}, }))
     local lrucache = client.getcache()
 
     local host = "cname2srv.thijsschreijer.nl"
@@ -1058,7 +1058,7 @@ describe("[DNS client]", function()
 
   describe("toip() function", function()
     it("A/AAAA-record, round-robin",function()
-      assert(client.init())
+      assert(client.init({ search = {}, }))
       local host = "atest.thijsschreijer.nl"
       local answers = assert(client.resolve(host))
       answers.last_index = nil -- make sure to clean
@@ -1079,7 +1079,7 @@ describe("[DNS client]", function()
       end
     end)
     it("SRV-record, round-robin on lowest prio",function()
-      assert(client.init())
+      assert(client.init({ search = {}, }))
       local host = "srvtest.thijsschreijer.nl"
 
       local results = {}
@@ -1176,7 +1176,7 @@ describe("[DNS client]", function()
       assert.equal(2, track["1.2.3.4"])
     end)
     it("port passing",function()
-      assert(client.init())
+      assert(client.init({ search = {}, }))
       local ip, port, host
       host = "atest.thijsschreijer.nl"
       ip,port = client.toip(host)
@@ -1198,7 +1198,7 @@ describe("[DNS client]", function()
       assert.is_not.equal(0, port)
     end)
     it("port passing if SRV port=0",function()
-      assert(client.init())
+      assert(client.init({ search = {}, }))
       local ip, port, host
 
       host = "srvport0.thijsschreijer.nl"
@@ -1577,7 +1577,7 @@ describe("[DNS client]", function()
     it("timeout while waiting", function()
       -- basically the local function _synchronized_query
       assert(client.init({
-        timeout = 2000,
+        timeout = 500,
         retrans = 1,
         resolvConf = {
           -- resolv.conf without `search` and `domain` options
@@ -1600,7 +1600,7 @@ describe("[DNS client]", function()
           touch = 0,
           expire = gettime() + 10,
         }
-        sleep(2) -- wait before we return the results
+        sleep(0.5) -- wait before we return the results
         return entry
       end
 

--- a/spec/02-integration/05-proxy/19-grpc_proxy_spec.lua
+++ b/spec/02-integration/05-proxy/19-grpc_proxy_spec.lua
@@ -1,6 +1,5 @@
 local helpers = require "spec.helpers"
 local cjson = require "cjson"
-local pl_file = require "pl.file"
 local pl_path = require "pl.path"
 
 local FILE_LOG_PATH = os.tmpname()
@@ -256,10 +255,16 @@ for _, strategy in helpers.each_strategy() do
             ["-v"] = true,
           }
         })
-        file_log_json = cjson.decode((assert(pl_file.read(FILE_LOG_PATH))))
+        local f = io.open(FILE_LOG_PATH, 'r')
+        if not f then
+          return false
+        end
+
+        file_log_json = cjson.decode((assert(f:read("*a"))))
+        f:close()
         return pl_path.exists(FILE_LOG_PATH) and pl_path.getsize(FILE_LOG_PATH) > 0
               and #file_log_json.tries >= 2
-      end, 15)
+      end, 5)
 
       assert.matches("received%-host: 127.0.0.1:8765", resp)
     end)


### PR DESCRIPTION
This causes massive slowdown when `resolv.conf` contains `search`
directive as the client may need timeout 10 times searching local domain
before trying the correct domain name:

```
10:26:40.740170 IP (tos 0x0, ttl 64, id 1379, offset 0, flags [DF], proto UDP (17), length 79)
    192.168.40.133.37051 > 192.168.40.2.domain: [bad udp cksum 0xd224 -> 0x0e86!] 27482+ SRV? www.thijsschreijer.nl.localdomain. (51)
10:26:42.742989 IP (tos 0x0, ttl 64, id 2060, offset 0, flags [DF], proto UDP (17), length 79)
    192.168.40.133.37051 > 192.168.40.2.domain: [bad udp cksum 0xd224 -> 0x0e86!] 27482+ SRV? www.thijsschreijer.nl.localdomain. (51)
10:26:44.746401 IP (tos 0x0, ttl 64, id 3213, offset 0, flags [DF], proto UDP (17), length 79)
    192.168.40.133.37051 > 192.168.40.2.domain: [bad udp cksum 0xd224 -> 0x0e86!] 27482+ SRV? www.thijsschreijer.nl.localdomain. (51)
10:26:46.749775 IP (tos 0x0, ttl 64, id 4016, offset 0, flags [DF], proto UDP (17), length 79)
    192.168.40.133.37051 > 192.168.40.2.domain: [bad udp cksum 0xd224 -> 0x0e86!] 27482+ SRV? www.thijsschreijer.nl.localdomain. (51)
10:26:48.752219 IP (tos 0x0, ttl 64, id 5258, offset 0, flags [DF], proto UDP (17), length 79)
    192.168.40.133.37051 > 192.168.40.2.domain: [bad udp cksum 0xd224 -> 0x0e86!] 27482+ SRV? www.thijsschreijer.nl.localdomain. (51)
10:26:50.741864 IP (tos 0x0, ttl 64, id 6948, offset 0, flags [DF], proto UDP (17), length 79)
    192.168.40.133.53208 > 192.168.40.2.domain: [bad udp cksum 0xd224 -> 0x0102!] 14785+ SRV? www.thijsschreijer.nl.localdomain. (51)
10:26:52.744810 IP (tos 0x0, ttl 64, id 8251, offset 0, flags [DF], proto UDP (17), length 79)
    192.168.40.133.53208 > 192.168.40.2.domain: [bad udp cksum 0xd224 -> 0x0102!] 14785+ SRV? www.thijsschreijer.nl.localdomain. (51)
10:26:54.747184 IP (tos 0x0, ttl 64, id 8387, offset 0, flags [DF], proto UDP (17), length 79)
    192.168.40.133.53208 > 192.168.40.2.domain: [bad udp cksum 0xd224 -> 0x0102!] 14785+ SRV? www.thijsschreijer.nl.localdomain. (51)
10:27:17.179007 IP (tos 0x0, ttl 64, id 18388, offset 0, flags [DF], proto UDP (17), length 71)
    192.168.40.133.37227 > 192.168.40.2.domain: [bad udp cksum 0xd21c -> 0xe995!] 52049+ TXT? txttest.thijsschreijer.nl. (43)
10:27:17.182493 IP (tos 0x0, ttl 128, id 2303, offset 0, flags [none], proto UDP (17), length 104)
    192.168.40.2.domain > 192.168.40.133.37227: [udp sum ok] 52049 q: TXT? txttest.thijsschreijer.nl. 1/0/0 txttest.thijsschreijer.nl. TXT "just a piece of text" (76)
```