### PR TITLE
fix(client) allow semaphore wait in some ssl_* phases

### DIFF
--- a/kong/resty/dns/client.lua
+++ b/kong/resty/dns/client.lua
@@ -832,6 +832,8 @@ local function syncQuery(qname, r_opts, try_list, count)
     access = true,
     content = true,
     timer = true,
+    ssl_cert = true,
+    ssl_session_fetch = true,
   }
 
   local ngx_phase = get_phase()


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

`ssl_cert` and `ssl_session_fetch` can both yield, but were missing from the supported list. Without this, a client running in one of these phases may fail to resolve unexpectedly.

### Full changelog

* Fix:  allow semaphore wait in some ssl\_\* phases. [PR 137](https://github.com/Kong/lua-resty-dns-client/pull/137)

**Note**: This is a [cherry-pick from lua-resty-dns-client](https://github.com/Kong/lua-resty-dns-client/commit/e723618cd268b42ff51d36a5b3a1bec6e1b431f3) that was missed during the [initial import](https://github.com/Kong/kong/commit/9a1a32e11d88d91fcc6da58d9d7410de569cb223).
