### PR TITLE
feat(router) add decode_uri_captures parameter

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -787,6 +787,22 @@
                                         # connection may be kept open
                                         # indefinitely.
 
+#normalize_req_uri = on                 # Whether to normalize the request URI.
+                                        # If enabled, the request URI will be normalized.
+                                        #
+                                        # Examples of `normalize_req_uri = on`
+                                        # behavior:
+                                        #
+                                        # Assuming the request uri is `/test/some%20resource%20document`,
+                                        # it will be normalized as `/test/some resource document`.
+                                        #
+                                        # Valid values to this setting are:
+                                        #
+                                        # - `on`: Request URI normalization is enabled.
+                                        # - `off`: Request URI normalization is disabled.
+                                        #
+                                        # By default this value is set to `on`.
+
 #------------------------------------------------------------------------------
 # NGINX injected directives
 #------------------------------------------------------------------------------

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -787,21 +787,30 @@
                                         # connection may be kept open
                                         # indefinitely.
 
-#normalize_req_uri = on                 # Whether to normalize the request URI.
-                                        # If enabled, the request URI will be normalized.
+#normalize_uri_captures = on            # Whether to normalize the captured request URI after route matching.
+                                        # If enabled, the captured URI will be normalized.
                                         #
-                                        # Examples of `normalize_req_uri = on`
-                                        # behavior:
+                                        # Examples of `normalize_uri_captures = on`
                                         #
-                                        # Assuming the request uri is `/test/some%20resource%20document`,
-                                        # it will be normalized as `/test/some resource document`.
+                                        # - Assuming that the route path is `/plain/(a%2Eb%20c)/(.*)` and the request URI is `/plain/a%2Eb%20c/a%2Eb%20c`,
+                                        # the captured request URI is normalized as `/plain/a.b c/a.b c`.
+                                        # - Assuming that the route path is `/plain/(a.b c)/(.*)` and the request URI is `/plain/a%2Eb%20c/a%2Eb%20c`,
+                                        # the captured request URI is normalized as `/plain/a.b c/a.b c`.
+                                        #
+                                        # Examples of `normalize_uri_captures = off`
+                                        #
+                                        # - Assuming that the route path is `/plain/(a%2Eb%20c)/(.*)` and the request URI is `/plain/a%2Eb%20c/a%2Eb%20c`,
+                                        # the captured request URI is `/plain/a%2Eb%20c/a%2Eb%20c` without URI normalization.
+                                        # - Assuming that the route path is `/plain/(a.b c)/(.*)` and the request URI is `/plain/a%2Eb%20c/a%2Eb%20c`,
+                                        # the request URI can not match the route path without URI normalization.
+                                        # As a result, the captured request URI is normalized as `/plain/a.b c/a.b c`.
                                         #
                                         # Valid values to this setting are:
                                         #
-                                        # - `on`: Request URI normalization is enabled.
-                                        # - `off`: Request URI normalization is disabled.
+                                        # - `on`: Captured request URI normalization is enabled.
+                                        # - `off`: Captured request URI normalization is disabled.
                                         #
-                                        # By default this value is set to `on`.
+                                        # By default this value is set as `on`.
 
 #------------------------------------------------------------------------------
 # NGINX injected directives

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -787,28 +787,28 @@
                                         # connection may be kept open
                                         # indefinitely.
 
-#normalize_uri_captures = on            # Whether to normalize the captured request URI after route matching.
-                                        # If enabled, the captured URI will be normalized.
+#decode_uri_captures = on               # Whether to decode the captured request URI after route matching.
+                                        # If enabled, the captured URI will be decoded.
                                         #
-                                        # Examples of `normalize_uri_captures = on`
-                                        #
-                                        # - Assuming that the route path is `/plain/(a%2Eb%20c)/(.*)` and the request URI is `/plain/a%2Eb%20c/a%2Eb%20c`,
-                                        # the captured request URI is normalized as `/plain/a.b c/a.b c`.
-                                        # - Assuming that the route path is `/plain/(a.b c)/(.*)` and the request URI is `/plain/a%2Eb%20c/a%2Eb%20c`,
-                                        # the captured request URI is normalized as `/plain/a.b c/a.b c`.
-                                        #
-                                        # Examples of `normalize_uri_captures = off`
+                                        # Examples of `decode_uri_captures = on`
                                         #
                                         # - Assuming that the route path is `/plain/(a%2Eb%20c)/(.*)` and the request URI is `/plain/a%2Eb%20c/a%2Eb%20c`,
-                                        # the captured request URI is `/plain/a%2Eb%20c/a%2Eb%20c` without URI normalization.
+                                        # the captured request URI is decoded as `/plain/a.b c/a.b c`.
                                         # - Assuming that the route path is `/plain/(a.b c)/(.*)` and the request URI is `/plain/a%2Eb%20c/a%2Eb%20c`,
-                                        # the request URI can not match the route path without URI normalization.
-                                        # As a result, the captured request URI is normalized as `/plain/a.b c/a.b c`.
+                                        # the captured request URI is decoded as `/plain/a.b c/a.b c`.
+                                        #
+                                        # Examples of `decode_uri_captures = off`
+                                        #
+                                        # - Assuming that the route path is `/plain/(a%2Eb%20c)/(.*)` and the request URI is `/plain/a%2Eb%20c/a%2Eb%20c`,
+                                        # the captured request URI is `/plain/a%2Eb%20c/a%2Eb%20c` without URI decoding.
+                                        # - Assuming that the route path is `/plain/(a.b c)/(.*)` and the request URI is `/plain/a%2Eb%20c/a%2Eb%20c`,
+                                        # the request URI can not match the route path without URI decoding.
+                                        # As a result, the captured request URI is decoded as `/plain/a.b c/a.b c`.
                                         #
                                         # Valid values to this setting are:
                                         #
-                                        # - `on`: Captured request URI normalization is enabled.
-                                        # - `off`: Captured request URI normalization is disabled.
+                                        # - `on`: Captured request URI decoding is enabled.
+                                        # - `off`: Captured request URI decoding is disabled.
                                         #
                                         # By default this value is set as `on`.
 

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -324,7 +324,7 @@ local CONF_INFERENCES = {
   db_cache_neg_ttl = {  typ = "number"  },
   db_resurrect_ttl = {  typ = "number"  },
   db_cache_warmup_entities = { typ = "array" },
-  normalize_req_uri = { enum = { "on", "off"} },
+  normalize_uri_captures = { typ = "boolean" },
   nginx_user = {
     typ = "string",
     alias = {

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -324,6 +324,7 @@ local CONF_INFERENCES = {
   db_cache_neg_ttl = {  typ = "number"  },
   db_resurrect_ttl = {  typ = "number"  },
   db_cache_warmup_entities = { typ = "array" },
+  normalize_req_uri = { enum = { "on", "off"} },
   nginx_user = {
     typ = "string",
     alias = {

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -324,7 +324,7 @@ local CONF_INFERENCES = {
   db_cache_neg_ttl = {  typ = "number"  },
   db_resurrect_ttl = {  typ = "number"  },
   db_cache_warmup_entities = { typ = "array" },
-  normalize_uri_captures = { typ = "boolean" },
+  decode_uri_captures = { typ = "boolean" },
   nginx_user = {
     typ = "string",
     alias = {

--- a/kong/router.lua
+++ b/kong/router.lua
@@ -1020,7 +1020,7 @@ do
                 ctx.matches.uri_captures = m
 
                 -- for the case unnormalized_req_uri is not equal to req_uri
-                -- try to get unnormalized uri_captures
+                -- try to get uri_captures without decoding
                 if (ctx.unnormalized_req_uri ~= ctx.req_uri) then
                   local unnormalized_m, err = re_match(ctx.unnormalized_req_uri, uri_t.unnormalized_strip_regex, "ajo")
                   if err then
@@ -1076,7 +1076,7 @@ do
               ctx.matches.uri_captures = m
 
               -- for the case unnormalized_req_uri is not equal to req_uri
-              -- try to get unnormalized uri_captures
+              -- try to get uri_captures without decoding
               if (ctx.unnormalized_req_uri ~= ctx.req_uri) then
                 local unnormalized_m, err = re_match(ctx.unnormalized_req_uri, uri_t.unnormalized_strip_regex, "ajo")
                 if err then
@@ -1852,7 +1852,7 @@ function _M.new(routes)
 
   self.select = find_route
   self._set_ngx = _set_ngx
-  self.normalize_uri_captures = routes.normalize_uri_captures
+  self.decode_uri_captures = routes.decode_uri_captures
 
   if subsystem == "http" then
     function self.exec(ctx)
@@ -1884,8 +1884,8 @@ function _M.new(routes)
         
         unnormalized_req_uri = req_uri
         req_uri = normalize(req_uri, true)
-        if self.normalize_uri_captures ~= false then
-          -- for the case unnormalized_req_uri is equal to req_uri, uri_captures will be normalized
+        if self.decode_uri_captures ~= false then
+          -- for the case unnormalized_req_uri is equal to req_uri, uri_captures will be decoded
           unnormalized_req_uri = req_uri
         end
       end

--- a/kong/router.lua
+++ b/kong/router.lua
@@ -1849,7 +1849,7 @@ function _M.new(routes)
           req_uri = sub(req_uri, 1, idx - 1)
         end
         
-        if self.normalize_req_uri == "on" then
+        if self.normalize_req_uri ~= "off" then
             req_uri = normalize(req_uri, true)
         end
       end

--- a/kong/router.lua
+++ b/kong/router.lua
@@ -1820,6 +1820,7 @@ function _M.new(routes)
 
   self.select = find_route
   self._set_ngx = _set_ngx
+  self.normalize_req_uri = routes.normalize_req_uri
 
   if subsystem == "http" then
     function self.exec(ctx)
@@ -1848,8 +1849,7 @@ function _M.new(routes)
           req_uri = sub(req_uri, 1, idx - 1)
         end
         
-        local normalize_req_uri = kong.configuration.normalize_req_uri
-        if normalize_req_uri == "on" then
+        if self.normalize_req_uri == "on" then
             req_uri = normalize(req_uri, true)
         end
       end

--- a/kong/router.lua
+++ b/kong/router.lua
@@ -1847,8 +1847,11 @@ function _M.new(routes)
         if idx then
           req_uri = sub(req_uri, 1, idx - 1)
         end
-
-        req_uri = normalize(req_uri, true)
+        
+        local normalize_req_uri = kong.configuration.normalize_req_uri
+        if normalize_req_uri == "on" then
+            req_uri = normalize(req_uri, true)
+        end
       end
 
       local match_t = find_route(req_method, req_uri, req_host, req_scheme,

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -688,7 +688,7 @@ do
   build_router = function(version)
     local db = kong.db
     local routes, i = {}, 0
-    routes.normalize_uri_captures = kong.configuration.normalize_uri_captures
+    routes.decode_uri_captures = kong.configuration.decode_uri_captures
 
     local err
     -- The router is initially created on init phase, where kong.core_cache is

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -688,7 +688,7 @@ do
   build_router = function(version)
     local db = kong.db
     local routes, i = {}, 0
-    routes.normalize_req_uri = kong.configuration.normalize_req_uri
+    routes.normalize_uri_captures = kong.configuration.normalize_uri_captures
 
     local err
     -- The router is initially created on init phase, where kong.core_cache is

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -688,6 +688,7 @@ do
   build_router = function(version)
     local db = kong.db
     local routes, i = {}, 0
+    routes.normalize_req_uri = kong.configuration.normalize_req_uri
 
     local err
     -- The router is initially created on init phase, where kong.core_cache is

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -55,7 +55,7 @@ upstream_keepalive = NONE
 upstream_keepalive_pool_size = 60
 upstream_keepalive_max_requests = 100
 upstream_keepalive_idle_timeout = 60
-normalize_req_uri = on
+normalize_uri_captures = on
 
 nginx_user = kong kong
 nginx_worker_processes = auto

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -55,6 +55,7 @@ upstream_keepalive = NONE
 upstream_keepalive_pool_size = 60
 upstream_keepalive_max_requests = 100
 upstream_keepalive_idle_timeout = 60
+normalize_req_uri = on
 
 nginx_user = kong kong
 nginx_worker_processes = auto

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -55,7 +55,7 @@ upstream_keepalive = NONE
 upstream_keepalive_pool_size = 60
 upstream_keepalive_max_requests = 100
 upstream_keepalive_idle_timeout = 60
-normalize_uri_captures = on
+decode_uri_captures = on
 
 nginx_user = kong kong
 nginx_worker_processes = auto

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -3176,7 +3176,7 @@ describe("Router", function()
       end
     end)
 
-    describe("#normalize uri captures", function()
+    describe("#decode uri captures", function()
       local use_case_routes = {
         {
           service = service,
@@ -3192,12 +3192,12 @@ describe("Router", function()
       local req_uri_2 = "/plain/a%2Eb%20c/a%2Eb%20c"
 
       local combination = {
-        -- normalize_uri_captures is false
+        -- decode_uri_captures is false
         {flag = false, path = regex_path_1, req_uri = req_uri_1, uri_captures = {"/plain/a.b c/a.b c", "a.b c", "a.b c"} },
         {flag = false, path = regex_path_1, req_uri = req_uri_2, uri_captures = {"/plain/a.b c/a.b c", "a.b c", "a.b c"} },
         {flag = false, path = regex_path_2, req_uri = req_uri_1, uri_captures = {"/plain/a.b c/a.b c", "a.b c", "a.b c"} },
         {flag = false, path = regex_path_2, req_uri = req_uri_2, uri_captures = {"/plain/a%2Eb%20c/a%2Eb%20c", "a%2Eb%20c", "a%2Eb%20c"} },
-        -- normalize_uri_captures is true
+        -- decode_uri_captures is true
         {flag = true, path = regex_path_1, req_uri = req_uri_1, uri_captures = {"/plain/a.b c/a.b c", "a.b c", "a.b c"} },
         {flag = true, path = regex_path_1, req_uri = req_uri_2, uri_captures = {"/plain/a.b c/a.b c", "a.b c", "a.b c"} },
         {flag = true, path = regex_path_2, req_uri = req_uri_1, uri_captures = {"/plain/a.b c/a.b c", "a.b c", "a.b c"} },
@@ -3205,9 +3205,9 @@ describe("Router", function()
       }
 
       for _, c in pairs(combination) do
-        it("normalize_uri_captures: " .. tostring(c.flag) .. ", route path: " .. c.path .. ", req: " .. c.req_uri, function()
+        it("decode_uri_captures: " .. tostring(c.flag) .. ", route path: " .. c.path .. ", req: " .. c.req_uri, function()
           use_case_routes[1].route.paths[1] = c.path
-          use_case_routes.normalize_uri_captures = c.flag
+          use_case_routes.decode_uri_captures = c.flag
           local router = assert(Router.new(use_case_routes))
           local _ngx = mock_ngx("GET", c.req_uri, { host = "domain.org" })
           router._set_ngx(_ngx)


### PR DESCRIPTION
Add a new parameter `decode_uri_captures` to decide whether to normalize the captured request URI after route matching.

New feature for #7913

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Add a new parameter `decode_uri_captures` to decide whether to normalize the captured request URI after route matching.

Only allow setting `on` or `off`:
- `on`: Captured request URI decoding is enabled.
- `off`: Captured request URI decoding is disabled.

By default, this value is set as `on`.

Examples of `decode_uri_captures = on` behavior:

- Assuming that the route path is `/plain/(a%2Eb%20c)/(.*)` and the request URI is `/plain/a%2Eb%20c/a%2Eb%20c`, the captured request URI is decoded as `/plain/a.b c/a.b c`.
- Assuming that the route path is `/plain/(a.b c)/(.*)` and the request URI is `/plain/a%2Eb%20c/a%2Eb%20c`, the captured request URI is decoded as `/plain/a.b c/a.b c`.

Examples of `decode_uri_captures = off`
- Assuming that the route path is `/plain/(a%2Eb%20c)/(.*)` and the request URI is `/plain/a%2Eb%20c/a%2Eb%20c`, the captured request URI is `/plain/a%2Eb%20c/a%2Eb%20c` without URI decoding.
- Assuming that the route path is `/plain/(a.b c)/(.*)` and the request URI is `/plain/a%2Eb%20c/a%2Eb%20c`, the request URI can not match the route path without URI decoding. As a result, the captured request URI is decoded as `/plain/a.b c/a.b c`.


### Full changelog

* Add a parameter `decode_uri_captures` to only decide whether to decode captured request URI or not (Do not have affect for route matching and upstream request)
* Use a self parameter(decode_uri_captures) of kong.router to load the new parameter.
* Add unit tests

### Issues resolved

Fix #7913
