### PR TITLE
docs(autodoc) change upgrade autodoc front matter

### DIFF
--- a/autodoc/upgrading/generate.lua
+++ b/autodoc/upgrading/generate.lua
@@ -9,7 +9,8 @@ local lfs = require("lfs")
 local header = [[
 ---
 # Generated via autodoc/upgrading/generate.lua in the kong/kong repo
-title: Upgrade guide
+title: Upgrade Kong Gateway OSS
+badge: oss
 ---
 
 This document guides you through the process of upgrading {{site.ce_product_name}} to the **latest version**.


### PR DESCRIPTION
* Update title in front matter
* Add OSS badge to front matter

We are single-sourcing the Gateway docs and have two upgrade guides, one for OSS and one for Enterprise. We need to differentiate them better, so this meta data will do that. 
