### PR TITLE
fix(aws-lambda-plugin) require AWS region, allow custom lambda hosts

### DIFF
--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -185,8 +185,8 @@ function AWSLambdaHandler:access(conf)
   local region = conf.aws_region or AWS_REGION
   local host = conf.host
 
-  if not region and not host then
-    return error("no region or host specified")
+  if not region then
+    return error("no region specified")
   end
 
   if not host then

--- a/kong/plugins/aws-lambda/schema.lua
+++ b/kong/plugins/aws-lambda/schema.lua
@@ -106,6 +106,5 @@ return {
   entity_checks = {
     { mutually_required = { "config.aws_key", "config.aws_secret" } },
     { mutually_required = { "config.proxy_scheme", "config.proxy_url" } },
-    { mutually_exclusive = { "config.aws_region", "config.host" } },
   }
 }

--- a/kong/plugins/aws-lambda/v4.lua
+++ b/kong/plugins/aws-lambda/v4.lua
@@ -87,10 +87,6 @@ local function prepare_awsv4_request(tbl)
   local path = tbl.path
   local host = tbl.host
 
-  if region then
-    host = service .. "." .. region .. "." .. domain
-  end
-
   if path and not canonicalURI then
     canonicalURI = canonicalise_path(path)
   elseif canonicalURI == nil or canonicalURI == "" then
@@ -154,67 +150,64 @@ local function prepare_awsv4_request(tbl)
     headers[k] = v
   end
 
-  -- if this is an AWS request, sign it
-  if region then
-    -- Task 1: Create a Canonical Request For Signature Version 4
-    -- http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
-    local canonical_headers, signed_headers do
-      -- We structure this code in a way so that we only have to sort once.
-      canonical_headers, signed_headers = {}, {}
-      local i = 0
-      for name, value in pairs(headers) do
-        if value then -- ignore headers with 'false', they are used to override defaults
-          i = i + 1
-          local name_lower = name:lower()
-          signed_headers[i] = name_lower
-          if canonical_headers[name_lower] ~= nil then
-            return nil, "header collision"
-          end
-          canonical_headers[name_lower] = pl_string.strip(value)
+  -- Task 1: Create a Canonical Request For Signature Version 4
+  -- http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
+  local canonical_headers, signed_headers do
+    -- We structure this code in a way so that we only have to sort once.
+    canonical_headers, signed_headers = {}, {}
+    local i = 0
+    for name, value in pairs(headers) do
+      if value then -- ignore headers with 'false', they are used to override defaults
+        i = i + 1
+        local name_lower = name:lower()
+        signed_headers[i] = name_lower
+        if canonical_headers[name_lower] ~= nil then
+          return nil, "header collision"
         end
+        canonical_headers[name_lower] = pl_string.strip(value)
       end
-      table.sort(signed_headers)
-      for j=1, i do
-        local name = signed_headers[j]
-        local value = canonical_headers[name]
-        canonical_headers[j] = name .. ":" .. value .. "\n"
-      end
-      signed_headers = table.concat(signed_headers, ";", 1, i)
-      canonical_headers = table.concat(canonical_headers, nil, 1, i)
     end
-    local canonical_request =
-      request_method .. '\n' ..
-      canonicalURI .. '\n' ..
-      (canonical_querystring or "") .. '\n' ..
-      canonical_headers .. '\n' ..
-      signed_headers .. '\n' ..
-      hex_encode(hash(req_payload or ""))
+    table.sort(signed_headers)
+    for j=1, i do
+      local name = signed_headers[j]
+      local value = canonical_headers[name]
+      canonical_headers[j] = name .. ":" .. value .. "\n"
+    end
+    signed_headers = table.concat(signed_headers, ";", 1, i)
+    canonical_headers = table.concat(canonical_headers, nil, 1, i)
+  end
+  local canonical_request =
+    request_method .. '\n' ..
+    canonicalURI .. '\n' ..
+    (canonical_querystring or "") .. '\n' ..
+    canonical_headers .. '\n' ..
+    signed_headers .. '\n' ..
+    hex_encode(hash(req_payload or ""))
 
-    local hashed_canonical_request = hex_encode(hash(canonical_request))
-    -- Task 2: Create a String to Sign for Signature Version 4
-    -- http://docs.aws.amazon.com/general/latest/gr/sigv4-create-string-to-sign.html
-    local credential_scope = date .. "/" .. region .. "/" .. service .. "/aws4_request"
-    local string_to_sign =
-      ALGORITHM .. '\n' ..
-      req_date .. '\n' ..
-      credential_scope .. '\n' ..
-      hashed_canonical_request
+  local hashed_canonical_request = hex_encode(hash(canonical_request))
+  -- Task 2: Create a String to Sign for Signature Version 4
+  -- http://docs.aws.amazon.com/general/latest/gr/sigv4-create-string-to-sign.html
+  local credential_scope = date .. "/" .. region .. "/" .. service .. "/aws4_request"
+  local string_to_sign =
+    ALGORITHM .. '\n' ..
+    req_date .. '\n' ..
+    credential_scope .. '\n' ..
+    hashed_canonical_request
 
-    -- Task 3: Calculate the AWS Signature Version 4
-    -- http://docs.aws.amazon.com/general/latest/gr/sigv4-calculate-signature.html
-    if signing_key == nil then
-      signing_key = derive_signing_key(secret_key, date, region, service)
-    end
-    local signature = hex_encode(hmac(signing_key, string_to_sign))
-    -- Task 4: Add the Signing Information to the Request
-    -- http://docs.aws.amazon.com/general/latest/gr/sigv4-add-signature-to-request.html
-    local authorization = ALGORITHM
-      .. " Credential=" .. access_key .. "/" .. credential_scope
-      .. ", SignedHeaders=" .. signed_headers
-      .. ", Signature=" .. signature
-    if add_auth_header then
-      headers.Authorization = authorization
-    end
+  -- Task 3: Calculate the AWS Signature Version 4
+  -- http://docs.aws.amazon.com/general/latest/gr/sigv4-calculate-signature.html
+  if signing_key == nil then
+    signing_key = derive_signing_key(secret_key, date, region, service)
+  end
+  local signature = hex_encode(hmac(signing_key, string_to_sign))
+  -- Task 4: Add the Signing Information to the Request
+  -- http://docs.aws.amazon.com/general/latest/gr/sigv4-add-signature-to-request.html
+  local authorization = ALGORITHM
+    .. " Credential=" .. access_key .. "/" .. credential_scope
+    .. ", SignedHeaders=" .. signed_headers
+    .. ", Signature=" .. signature
+  if add_auth_header then
+    headers.Authorization = authorization
   end
 
   local target = path or canonicalURI

--- a/spec/03-plugins/27-aws-lambda/02-schema_spec.lua
+++ b/spec/03-plugins/27-aws-lambda/02-schema_spec.lua
@@ -109,14 +109,14 @@ describe("Plugin: AWS Lambda (schema)", function()
     assert.truthy(ok)
   end)
 
-  it("errors if both of aws_region and host are passed", function()
+  it("allow both of aws_region and host to be passed", function()
     local ok, err = v({
       host = "my.lambda.host",
       aws_region = "us-east-1",
       function_name = "my-function"
     }, schema_def)
 
-    assert.equal("only one or none of these fields must be set: 'config.aws_region', 'config.host'", err["@entity"][1])
-    assert.falsy(ok)
+    assert.is_nil(err)
+    assert.truthy(ok)
   end)
 end)

--- a/spec/03-plugins/27-aws-lambda/99-access_spec.lua
+++ b/spec/03-plugins/27-aws-lambda/99-access_spec.lua
@@ -118,13 +118,19 @@ for _, strategy in helpers.each_strategy() do
       }
 
       local route18 = bp.routes:insert {
-        hosts       = { "lambda18.test" },
+        hosts       = { "lambda18.com" },
         protocols   = { "http", "https" },
         service     = null,
       }
 
       local route19 = bp.routes:insert {
-        hosts       = { "lambda19.test" },
+        hosts       = { "lambda19.com" },
+        protocols   = { "http", "https" },
+        service     = null,
+      }
+
+      local route20 = bp.routes:insert {
+        hosts       = { "lambda20.com" },
         protocols   = { "http", "https" },
         service     = null,
       }
@@ -372,7 +378,7 @@ for _, strategy in helpers.each_strategy() do
           aws_key              = "mock-key",
           aws_secret           = "mock-secret",
           function_name        = "functionWithMultiValueHeadersResponse",
-          host                 = "lambda18.test",
+          host                 = "custom.lambda.endpoint",
           is_proxy_integration = true,
         }
       }
@@ -389,18 +395,24 @@ for _, strategy in helpers.each_strategy() do
         }
       }
 
+      bp.plugins:insert {
+        name     = "aws-lambda",
+        route    = { id = route20.id },
+        config                 = {
+          port                 = 10001,
+          aws_key              = "mock-key",
+          aws_secret           = "mock-secret",
+          aws_region           = "us-east-1",
+          function_name        = "kongLambdaTest",
+          host                 = "custom.lambda.endpoint",
+        }
+      }
+
       fixtures.dns_mock:A({
-        name = "lambda18.test",
-        address = helpers.mock_upstream_host,
+        name = "custom.lambda.endpoint",
+        address = "127.0.0.1",
       })
 
-      helpers.setenv("AWS_REGION", "us-east-1")
-
-      assert(helpers.start_kong({
-        database   = strategy,
-        plugins = "aws-lambda",
-        nginx_conf = "spec/fixtures/custom_nginx.template",
-      }, nil, nil, fixtures))
     end)
 
     before_each(function()
@@ -413,535 +425,26 @@ for _, strategy in helpers.each_strategy() do
       admin_client:close()
     end)
 
-    lazy_teardown(function()
-      helpers.stop_kong()
-      helpers.unsetenv("AWS_REGION", "us-east-1")
-    end)
+    describe("AWS_REGION environment is not set", function()
 
-    it("invokes a Lambda function with GET", function()
-      local res = assert(proxy_client:send {
-        method  = "GET",
-        path    = "/get?key1=some_value1&key2=some_value2&key3=some_value3",
-        headers = {
-          ["Host"] = "lambda.com"
-        }
-      })
-      assert.res_status(200, res)
-      local body = assert.response(res).has.jsonbody()
-      assert.is_string(res.headers["x-amzn-RequestId"])
-      assert.equal("some_value1", body.key1)
-      assert.is_nil(res.headers["X-Amz-Function-Error"])
-    end)
-
-    it("invokes a Lambda function with GET, ignores route's service", function()
-      local res = assert(proxy_client:send {
-        method  = "GET",
-        path    = "/get?key1=some_value1&key2=some_value2&key3=some_value3",
-        headers = {
-          ["Host"] = "lambda_ignore_service.com"
-        }
-      })
-      assert.res_status(200, res)
-      local body = assert.response(res).has.jsonbody()
-      assert.is_string(res.headers["x-amzn-RequestId"])
-      assert.equal("some_value1", body.key1)
-      assert.is_nil(res.headers["X-Amz-Function-Error"])
-    end)
-
-    it("invokes a Lambda function with POST params", function()
-      local res = assert(proxy_client:send {
-        method  = "POST",
-        path    = "/post",
-        headers = {
-          ["Host"]         = "lambda.com",
-          ["Content-Type"] = "application/x-www-form-urlencoded"
-        },
-        body = {
-          key1 = "some_value_post1",
-          key2 = "some_value_post2",
-          key3 = "some_value_post3"
-        }
-      })
-      assert.res_status(200, res)
-      local body = assert.response(res).has.jsonbody()
-      assert.is_string(res.headers["x-amzn-RequestId"])
-      assert.equal("some_value_post1", body.key1)
-    end)
-    it("invokes a Lambda function with POST json body", function()
-      local res = assert(proxy_client:send {
-        method  = "POST",
-        path    = "/post",
-        headers = {
-          ["Host"]         = "lambda.com",
-          ["Content-Type"] = "application/json"
-        },
-        body = {
-          key1 = "some_value_json1",
-          key2 = "some_value_json2",
-          key3 = "some_value_json3"
-        }
-      })
-      assert.res_status(200, res)
-      local body = assert.response(res).has.jsonbody()
-      assert.is_string(res.headers["x-amzn-RequestId"])
-      assert.equal("some_value_json1", body.key1)
-    end)
-    it("passes empty json arrays unmodified", function()
-      local res = assert(proxy_client:send {
-        method  = "POST",
-        path    = "/post",
-        headers = {
-          ["Host"]         = "lambda.com",
-          ["Content-Type"] = "application/json"
-        },
-        body = '[{}, []]'
-      })
-      assert.res_status(200, res)
-      assert.equal('[{},[]]', string.gsub(res:read_body(), "\n",""))
-    end)
-    it("invokes a Lambda function with POST and both querystring and body params", function()
-      local res = assert(proxy_client:send {
-        method  = "POST",
-        path    = "/post?key1=from_querystring",
-        headers = {
-          ["Host"]         = "lambda.com",
-          ["Content-Type"] = "application/x-www-form-urlencoded"
-        },
-        body = {
-          key2 = "some_value_post2",
-          key3 = "some_value_post3"
-        }
-      })
-      assert.res_status(200, res)
-      local body = assert.response(res).has.jsonbody()
-      assert.is_string(res.headers["x-amzn-RequestId"])
-      assert.equal("from_querystring", body.key1)
-    end)
-    it("invokes a Lambda function with POST and xml payload, custom header and query parameter", function()
-      local res = assert(proxy_client:send {
-        method  = "POST",
-        path    = "/post?key1=from_querystring",
-        headers = {
-          ["Host"]          = "lambda9.com",
-          ["Content-Type"]  = "application/xml",
-          ["custom-header"] = "someheader"
-        },
-        body = "<xml/>"
-      })
-      assert.res_status(200, res)
-      local body = assert.response(res).has.jsonbody()
-      assert.is_string(res.headers["x-amzn-RequestId"])
-
-      -- request_method
-      assert.equal("POST", body.request_method)
-
-      -- request_uri
-      assert.equal("/post?key1=from_querystring", body.request_uri)
-      assert.is_table(body.request_uri_args)
-
-      -- request_headers
-      assert.equal("someheader", body.request_headers["custom-header"])
-      assert.equal("lambda9.com", body.request_headers.host)
-
-      -- request_body
-      assert.equal("<xml/>", body.request_body)
-      assert.is_table(body.request_body_args)
-    end)
-    it("invokes a Lambda function with POST and json payload, custom header and query parameter", function()
-      local res = assert(proxy_client:send {
-        method  = "POST",
-        path    = "/post?key1=from_querystring",
-        headers = {
-          ["Host"]          = "lambda10.com",
-          ["Content-Type"]  = "application/json",
-          ["custom-header"] = "someheader"
-        },
-        body = { key2 = "some_value" }
-      })
-      assert.res_status(200, res)
-      local body = assert.response(res).has.jsonbody()
-      assert.is_string(res.headers["x-amzn-RequestId"])
-
-      -- request_method
-      assert.equal("POST", body.request_method)
-
-      -- no request_uri
-      assert.is_nil(body.request_uri)
-      assert.is_nil(body.request_uri_args)
-
-      -- request_headers
-      assert.equal("lambda10.com", body.request_headers.host)
-      assert.equal("someheader", body.request_headers["custom-header"])
-
-      -- request_body
-      assert.equal("some_value", body.request_body_args.key2)
-      assert.is_table(body.request_body_args)
-    end)
-    it("invokes a Lambda function with POST and txt payload, custom header and query parameter", function()
-      local res = assert(proxy_client:send {
-        method  = "POST",
-        path    = "/post?key1=from_querystring",
-        headers = {
-          ["Host"]          = "lambda9.com",
-          ["Content-Type"]  = "text/plain",
-          ["custom-header"] = "someheader"
-        },
-        body = "some text"
-      })
-      assert.res_status(200, res)
-      local body = assert.response(res).has.jsonbody()
-      assert.is_string(res.headers["x-amzn-RequestId"])
-
-      -- request_method
-      assert.equal("POST", body.request_method)
-
-      -- request_uri
-      assert.equal("/post?key1=from_querystring", body.request_uri)
-      assert.is_table(body.request_uri_args)
-
-      -- request_headers
-      assert.equal("someheader", body.request_headers["custom-header"])
-      assert.equal("lambda9.com", body.request_headers.host)
-
-      -- request_body
-      assert.equal("some text", body.request_body)
-      assert.is_nil(body.request_body_base64)
-      assert.is_table(body.request_body_args)
-    end)
-    it("invokes a Lambda function with POST and binary payload and custom header", function()
-      local res = assert(proxy_client:send {
-        method  = "POST",
-        path    = "/post?key1=from_querystring",
-        headers = {
-          ["Host"]          = "lambda9.com",
-          ["Content-Type"]  = "application/octet-stream",
-          ["custom-header"] = "someheader"
-        },
-        body = "01234"
-      })
-      assert.res_status(200, res)
-      local body = assert.response(res).has.jsonbody()
-      assert.is_string(res.headers["x-amzn-RequestId"])
-
-      -- request_method
-      assert.equal("POST", body.request_method)
-
-      -- request_uri
-      assert.equal("/post?key1=from_querystring", body.request_uri)
-      assert.is_table(body.request_uri_args)
-
-      -- request_headers
-      assert.equal("lambda9.com", body.request_headers.host)
-      assert.equal("someheader", body.request_headers["custom-header"])
-
-      -- request_body
-      assert.equal(ngx.encode_base64('01234'), body.request_body)
-      assert.is_true(body.request_body_base64)
-      assert.is_table(body.request_body_args)
-    end)
-    it("invokes a Lambda function with POST params and Event invocation_type", function()
-      local res = assert(proxy_client:send {
-        method  = "POST",
-        path    = "/post",
-        headers = {
-          ["Host"]         = "lambda2.com",
-          ["Content-Type"] = "application/x-www-form-urlencoded"
-        },
-        body = {
-          key1 = "some_value_post1",
-          key2 = "some_value_post2",
-          key3 = "some_value_post3"
-        }
-      })
-      assert.res_status(202, res)
-      assert.is_string(res.headers["x-amzn-RequestId"])
-    end)
-    it("invokes a Lambda function with POST params and DryRun invocation_type", function()
-      local res = assert(proxy_client:send {
-        method  = "POST",
-        path    = "/post",
-        headers = {
-          ["Host"]         = "lambda3.com",
-          ["Content-Type"] = "application/x-www-form-urlencoded"
-        },
-        body = {
-          key1 = "some_value_post1",
-          key2 = "some_value_post2",
-          key3 = "some_value_post3"
-        }
-      })
-      assert.res_status(204, res)
-      assert.is_string(res.headers["x-amzn-RequestId"])
-    end)
-    it("errors on connection timeout", function()
-      local res = assert(proxy_client:send {
-        method  = "GET",
-        path    = "/get?key1=some_value1&key2=some_value2&key3=some_value3",
-        headers = {
-          ["Host"] = "lambda4.com",
-        }
-      })
-      assert.res_status(500, res)
-    end)
-
-    it("invokes a Lambda function with an unhandled function error (and no unhandled_status set)", function()
-      local res = assert(proxy_client:send {
-        method  = "GET",
-        path    = "/get?key1=some_value1&key2=some_value2&key3=some_value3",
-        headers = {
-          ["Host"] = "lambda5.com"
-        }
-      })
-      assert.res_status(200, res)
-      assert.equal("Unhandled", res.headers["X-Amz-Function-Error"])
-    end)
-    it("invokes a Lambda function with an unhandled function error with Event invocation type", function()
-      local res = assert(proxy_client:send {
-        method  = "GET",
-        path    = "/get?key1=some_value1&key2=some_value2&key3=some_value3",
-        headers = {
-          ["Host"] = "lambda6.com"
-        }
-      })
-      assert.res_status(202, res)
-      assert.equal("Unhandled", res.headers["X-Amz-Function-Error"])
-    end)
-    it("invokes a Lambda function with an unhandled function error with DryRun invocation type", function()
-      local res = assert(proxy_client:send {
-        method  = "GET",
-        path    = "/get?key1=some_value1&key2=some_value2&key3=some_value3",
-        headers = {
-          ["Host"] = "lambda7.com"
-        }
-      })
-      assert.res_status(204, res)
-      assert.equal("Unhandled", res.headers["X-Amz-Function-Error"])
-    end)
-    it("invokes a Lambda function with an unhandled function error", function()
-      local res = assert(proxy_client:send {
-        method  = "GET",
-        path    = "/get?key1=some_value1&key2=some_value2&key3=some_value3",
-        headers = {
-          ["Host"] = "lambda8.com"
-        }
-      })
-      assert.res_status(412, res)
-      assert.equal("Unhandled", res.headers["X-Amz-Function-Error"])
-    end)
-
-    it("returns server tokens with Via header", function()
-      local res = assert(proxy_client:send {
-        method  = "GET",
-        path    = "/get?key1=some_value1&key2=some_value2&key3=some_value3",
-        headers = {
-          ["Host"] = "lambda.com"
-        }
-      })
-
-      if server_tokens then
-        assert.equal(server_tokens, res.headers["Via"])
-      end
-    end)
-
-    it("returns Content-Length header", function()
-      local res = assert(proxy_client:send {
-        method  = "GET",
-        path    = "/get?key1=some_value1&key2=some_value2&key3=some_value3",
-        headers = {
-          ["Host"] = "lambda.com"
-        }
-      })
-
-      assert.equal(65, tonumber(res.headers["Content-Length"]))
-    end)
-
-    it("errors on bad region name (DNS resolution)", function()
-      local res = assert(proxy_client:send {
-        method  = "GET",
-        path    = "/get?key1=some_value1",
-        headers = {
-          ["Host"] = "lambda15.com"
-        }
-      })
-      assert.res_status(500, res)
-
-      helpers.wait_until(function()
-        local logs = pl_file.read(TEST_CONF.prefix .. "/" .. TEST_CONF.proxy_error_log)
-        local _, count = logs:gsub([[%[aws%-lambda%].+lambda%.ab%-cdef%-1%.amazonaws%.com.+name error"]], "")
-        return count >= 1
-      end, 10)
-    end)
-
-    describe("config.is_proxy_integration = true", function()
-
-
--- here's where we miss the changes to the custom nginx template, to be able to
--- run the tests against older versions (0.13.x) of Kong. Add those manually
--- and the tests pass.
--- see: https://github.com/Kong/kong/commit/c6f9e4558b5a654e78ca96b2ba4309e527053403#diff-9d13d8efc852de84b07e71bf419a2c4d
-
-      it("sets proper status code on custom response from Lambda", function()
-        local res = assert(proxy_client:send {
-          method  = "POST",
-          path    = "/post",
-          headers = {
-            ["Host"]         = "lambda11.com",
-            ["Content-Type"] = "application/json"
-          },
-          body = {
-            statusCode = 201,
-          }
-        })
-        local body = assert.res_status(201, res)
-        assert.equal(0, tonumber(res.headers["Content-Length"]))
-        assert.equal(nil, res.headers["X-Custom-Header"])
-        assert.equal("", body)
+      lazy_setup(function()
+        assert(helpers.start_kong({
+          database   = strategy,
+          plugins = "aws-lambda",
+          nginx_conf = "spec/fixtures/custom_nginx.template",
+        }, nil, nil, fixtures))  
       end)
 
-      it("sets proper status code/headers/body on custom response from Lambda", function()
-        -- the lambda function must return a string
-        -- for the custom response "body" property
-        local body = cjson.encode({
-          key1 = "some_value_post1",
-          key2 = "some_value_post2",
-          key3 = "some_value_post3",
-        })
-
-        local res = assert(proxy_client:send {
-          method  = "POST",
-          path    = "/post",
-          headers = {
-            ["Host"]         = "lambda11.com",
-            ["Content-Type"] = "application/json",
-          },
-          body = {
-            statusCode = 201,
-            body = body,
-            headers = {
-              ["X-Custom-Header"] = "Hello world!"
-            }
-          }
-        })
-
-        local res_body = assert.res_status(201, res)
-        assert.equal(79, tonumber(res.headers["Content-Length"]))
-        assert.equal("Hello world!", res.headers["X-Custom-Header"])
-        assert.equal(body, res_body)
+      lazy_teardown(function()
+        helpers.stop_kong()
       end)
-
-      it("override duplicated headers with value from the custom response from Lambda", function()
-        -- the default "x-amzn-RequestId" returned is "foo"
-        -- let's check it is overriden with a custom value
-        local headers = {
-          ["x-amzn-RequestId"] = "bar",
-        }
-
-        local res = assert(proxy_client:send {
-          method  = "POST",
-          path    = "/post",
-          headers = {
-            ["Host"]         = "lambda11.com",
-            ["Content-Type"] = "application/json",
-          },
-          body = {
-            statusCode = 201,
-            headers = headers,
-          }
-        })
-
-        assert.res_status(201, res)
-        assert.equal("bar", res.headers["x-amzn-RequestId"])
-      end)
-
-      it("returns HTTP 502 when 'status' property of custom response is not a number", function()
-        local res = assert(proxy_client:send {
-          method  = "POST",
-          path    = "/post",
-          headers = {
-            ["Host"]         = "lambda11.com",
-            ["Content-Type"] = "application/json",
-          },
-          body = {
-            statusCode = "hello",
-          }
-        })
-
-        assert.res_status(502, res)
-        local b = assert.response(res).has.jsonbody()
-        assert.equal("Bad Gateway", b.message)
-      end)
-
-      it("returns HTTP 502 when 'headers' property of custom response is not a table", function()
-        local res = assert(proxy_client:send {
-          method  = "POST",
-          path    = "/post",
-          headers = {
-            ["Host"]         = "lambda11.com",
-            ["Content-Type"] = "application/json",
-          },
-          body = {
-            headers = "hello",
-          }
-        })
-
-        assert.res_status(502, res)
-        local b = assert.response(res).has.jsonbody()
-        assert.equal("Bad Gateway", b.message)
-      end)
-
-      it("returns HTTP 502 when 'body' property of custom response is not a string", function()
-        local res = assert(proxy_client:send {
-          method  = "POST",
-          path    = "/post",
-          headers = {
-            ["Host"]         = "lambda11.com",
-            ["Content-Type"] = "application/json",
-          },
-          body = {
-            statusCode = 201,
-            body = 1234,
-          }
-        })
-
-        assert.res_status(502, res)
-        local b = assert.response(res).has.jsonbody()
-        assert.equal("Bad Gateway", b.message)
-      end)
-
-      it("returns HTTP 502 with when response from lambda is not valid JSON", function()
-        local res = assert(proxy_client:send {
-          method  = "POST",
-          path    = "/post",
-          headers = {
-            ["Host"] = "lambda12.com",
-          }
-        })
-
-        assert.res_status(502, res)
-        local b = assert.response(res).has.jsonbody()
-        assert.equal("Bad Gateway", b.message)
-      end)
-
-      it("returns HTTP 502 on empty response from Lambda", function()
-        local res = assert(proxy_client:send {
-          method  = "POST",
-          path    = "/post",
-          headers = {
-            ["Host"] = "lambda13.com",
-          }
-        })
-
-        assert.res_status(502, res)
-        local b = assert.response(res).has.jsonbody()
-        assert.equal("Bad Gateway", b.message)
-      end)
-
-      it("invokes a Lambda function with GET using serviceless route", function()
+  
+      it("invokes a Lambda function with GET", function()
         local res = assert(proxy_client:send {
           method  = "GET",
           path    = "/get?key1=some_value1&key2=some_value2&key3=some_value3",
           headers = {
-            ["Host"] = "lambda14.com"
+            ["Host"] = "lambda.com"
           }
         })
         assert.res_status(200, res)
@@ -951,42 +454,620 @@ for _, strategy in helpers.each_strategy() do
         assert.is_nil(res.headers["X-Amz-Function-Error"])
       end)
 
-      it("returns decoded base64 response from a Lambda function", function()
+      it("invokes a Lambda function with GET, ignores route's service", function()
         local res = assert(proxy_client:send {
           method  = "GET",
           path    = "/get?key1=some_value1&key2=some_value2&key3=some_value3",
           headers = {
-            ["Host"] = "lambda16.com"
+            ["Host"] = "lambda_ignore_service.com"
           }
         })
         assert.res_status(200, res)
-        assert.equal("test", res:read_body())
+        local body = assert.response(res).has.jsonbody()
+        assert.is_string(res.headers["x-amzn-RequestId"])
+        assert.equal("some_value1", body.key1)
+        assert.is_nil(res.headers["X-Amz-Function-Error"])
       end)
 
-      it("returns multivalueheaders response from a Lambda function", function()
+      it("invokes a Lambda function with POST params", function()
+        local res = assert(proxy_client:send {
+          method  = "POST",
+          path    = "/post",
+          headers = {
+            ["Host"]         = "lambda.com",
+            ["Content-Type"] = "application/x-www-form-urlencoded"
+          },
+          body = {
+            key1 = "some_value_post1",
+            key2 = "some_value_post2",
+            key3 = "some_value_post3"
+          }
+        })
+        assert.res_status(200, res)
+        local body = assert.response(res).has.jsonbody()
+        assert.is_string(res.headers["x-amzn-RequestId"])
+        assert.equal("some_value_post1", body.key1)
+      end)
+
+      it("invokes a Lambda function with POST json body", function()
+        local res = assert(proxy_client:send {
+          method  = "POST",
+          path    = "/post",
+          headers = {
+            ["Host"]         = "lambda.com",
+            ["Content-Type"] = "application/json"
+          },
+          body = {
+            key1 = "some_value_json1",
+            key2 = "some_value_json2",
+            key3 = "some_value_json3"
+          }
+        })
+        assert.res_status(200, res)
+        local body = assert.response(res).has.jsonbody()
+        assert.is_string(res.headers["x-amzn-RequestId"])
+        assert.equal("some_value_json1", body.key1)
+      end)
+
+      it("passes empty json arrays unmodified", function()
+        local res = assert(proxy_client:send {
+          method  = "POST",
+          path    = "/post",
+          headers = {
+            ["Host"]         = "lambda.com",
+            ["Content-Type"] = "application/json"
+          },
+          body = '[{}, []]'
+        })
+        assert.res_status(200, res)
+        assert.equal('[{},[]]', string.gsub(res:read_body(), "\n",""))
+      end)
+
+      it("invokes a Lambda function with POST and both querystring and body params", function()
+        local res = assert(proxy_client:send {
+          method  = "POST",
+          path    = "/post?key1=from_querystring",
+          headers = {
+            ["Host"]         = "lambda.com",
+            ["Content-Type"] = "application/x-www-form-urlencoded"
+          },
+          body = {
+            key2 = "some_value_post2",
+            key3 = "some_value_post3"
+          }
+        })
+        assert.res_status(200, res)
+        local body = assert.response(res).has.jsonbody()
+        assert.is_string(res.headers["x-amzn-RequestId"])
+        assert.equal("from_querystring", body.key1)
+      end)
+
+      it("invokes a Lambda function with POST and xml payload, custom header and query parameter", function()
+        local res = assert(proxy_client:send {
+          method  = "POST",
+          path    = "/post?key1=from_querystring",
+          headers = {
+            ["Host"]          = "lambda9.com",
+            ["Content-Type"]  = "application/xml",
+            ["custom-header"] = "someheader"
+          },
+          body = "<xml/>"
+        })
+        assert.res_status(200, res)
+        local body = assert.response(res).has.jsonbody()
+        assert.is_string(res.headers["x-amzn-RequestId"])
+
+        -- request_method
+        assert.equal("POST", body.request_method)
+
+        -- request_uri
+        assert.equal("/post?key1=from_querystring", body.request_uri)
+        assert.is_table(body.request_uri_args)
+
+        -- request_headers
+        assert.equal("someheader", body.request_headers["custom-header"])
+        assert.equal("lambda9.com", body.request_headers.host)
+
+        -- request_body
+        assert.equal("<xml/>", body.request_body)
+        assert.is_table(body.request_body_args)
+      end)
+
+      it("invokes a Lambda function with POST and json payload, custom header and query parameter", function()
+        local res = assert(proxy_client:send {
+          method  = "POST",
+          path    = "/post?key1=from_querystring",
+          headers = {
+            ["Host"]          = "lambda10.com",
+            ["Content-Type"]  = "application/json",
+            ["custom-header"] = "someheader"
+          },
+          body = { key2 = "some_value" }
+        })
+        assert.res_status(200, res)
+        local body = assert.response(res).has.jsonbody()
+        assert.is_string(res.headers["x-amzn-RequestId"])
+
+        -- request_method
+        assert.equal("POST", body.request_method)
+
+        -- no request_uri
+        assert.is_nil(body.request_uri)
+        assert.is_nil(body.request_uri_args)
+
+        -- request_headers
+        assert.equal("lambda10.com", body.request_headers.host)
+        assert.equal("someheader", body.request_headers["custom-header"])
+
+        -- request_body
+        assert.equal("some_value", body.request_body_args.key2)
+        assert.is_table(body.request_body_args)
+      end)
+
+      it("invokes a Lambda function with POST and txt payload, custom header and query parameter", function()
+        local res = assert(proxy_client:send {
+          method  = "POST",
+          path    = "/post?key1=from_querystring",
+          headers = {
+            ["Host"]          = "lambda9.com",
+            ["Content-Type"]  = "text/plain",
+            ["custom-header"] = "someheader"
+          },
+          body = "some text"
+        })
+        assert.res_status(200, res)
+        local body = assert.response(res).has.jsonbody()
+        assert.is_string(res.headers["x-amzn-RequestId"])
+
+        -- request_method
+        assert.equal("POST", body.request_method)
+
+        -- request_uri
+        assert.equal("/post?key1=from_querystring", body.request_uri)
+        assert.is_table(body.request_uri_args)
+
+        -- request_headers
+        assert.equal("someheader", body.request_headers["custom-header"])
+        assert.equal("lambda9.com", body.request_headers.host)
+
+        -- request_body
+        assert.equal("some text", body.request_body)
+        assert.is_nil(body.request_body_base64)
+        assert.is_table(body.request_body_args)
+      end)
+
+      it("invokes a Lambda function with POST and binary payload and custom header", function()
+        local res = assert(proxy_client:send {
+          method  = "POST",
+          path    = "/post?key1=from_querystring",
+          headers = {
+            ["Host"]          = "lambda9.com",
+            ["Content-Type"]  = "application/octet-stream",
+            ["custom-header"] = "someheader"
+          },
+          body = "01234"
+        })
+        assert.res_status(200, res)
+        local body = assert.response(res).has.jsonbody()
+        assert.is_string(res.headers["x-amzn-RequestId"])
+
+        -- request_method
+        assert.equal("POST", body.request_method)
+
+        -- request_uri
+        assert.equal("/post?key1=from_querystring", body.request_uri)
+        assert.is_table(body.request_uri_args)
+
+        -- request_headers
+        assert.equal("lambda9.com", body.request_headers.host)
+        assert.equal("someheader", body.request_headers["custom-header"])
+
+        -- request_body
+        assert.equal(ngx.encode_base64('01234'), body.request_body)
+        assert.is_true(body.request_body_base64)
+        assert.is_table(body.request_body_args)
+      end)
+
+      it("invokes a Lambda function with POST params and Event invocation_type", function()
+        local res = assert(proxy_client:send {
+          method  = "POST",
+          path    = "/post",
+          headers = {
+            ["Host"]         = "lambda2.com",
+            ["Content-Type"] = "application/x-www-form-urlencoded"
+          },
+          body = {
+            key1 = "some_value_post1",
+            key2 = "some_value_post2",
+            key3 = "some_value_post3"
+          }
+        })
+        assert.res_status(202, res)
+        assert.is_string(res.headers["x-amzn-RequestId"])
+      end)
+
+      it("invokes a Lambda function with POST params and DryRun invocation_type", function()
+        local res = assert(proxy_client:send {
+          method  = "POST",
+          path    = "/post",
+          headers = {
+            ["Host"]         = "lambda3.com",
+            ["Content-Type"] = "application/x-www-form-urlencoded"
+          },
+          body = {
+            key1 = "some_value_post1",
+            key2 = "some_value_post2",
+            key3 = "some_value_post3"
+          }
+        })
+        assert.res_status(204, res)
+        assert.is_string(res.headers["x-amzn-RequestId"])
+      end)
+
+      it("errors on connection timeout", function()
         local res = assert(proxy_client:send {
           method  = "GET",
           path    = "/get?key1=some_value1&key2=some_value2&key3=some_value3",
           headers = {
-            ["Host"] = "lambda17.com"
+            ["Host"] = "lambda4.com",
+          }
+        })
+        assert.res_status(500, res)
+      end)
+
+      it("invokes a Lambda function with an unhandled function error (and no unhandled_status set)", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/get?key1=some_value1&key2=some_value2&key3=some_value3",
+          headers = {
+            ["Host"] = "lambda5.com"
           }
         })
         assert.res_status(200, res)
-        assert.is_string(res.headers.age)
-        assert.is_array(res.headers["Access-Control-Allow-Origin"])
+        assert.equal("Unhandled", res.headers["X-Amz-Function-Error"])
       end)
 
-      it("use host value when no region is set", function()
+      it("invokes a Lambda function with an unhandled function error with Event invocation type", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/get?key1=some_value1&key2=some_value2&key3=some_value3",
+          headers = {
+            ["Host"] = "lambda6.com"
+          }
+        })
+        assert.res_status(202, res)
+        assert.equal("Unhandled", res.headers["X-Amz-Function-Error"])
+      end)
+
+      it("invokes a Lambda function with an unhandled function error with DryRun invocation type", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/get?key1=some_value1&key2=some_value2&key3=some_value3",
+          headers = {
+            ["Host"] = "lambda7.com"
+          }
+        })
+        assert.res_status(204, res)
+        assert.equal("Unhandled", res.headers["X-Amz-Function-Error"])
+      end)
+
+      it("invokes a Lambda function with an unhandled function error", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/get?key1=some_value1&key2=some_value2&key3=some_value3",
+          headers = {
+            ["Host"] = "lambda8.com"
+          }
+        })
+        assert.res_status(412, res)
+        assert.equal("Unhandled", res.headers["X-Amz-Function-Error"])
+      end)
+
+      it("returns server tokens with Via header", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/get?key1=some_value1&key2=some_value2&key3=some_value3",
+          headers = {
+            ["Host"] = "lambda.com"
+          }
+        })
+
+        if server_tokens then
+          assert.equal(server_tokens, res.headers["Via"])
+        end
+      end)
+
+      it("returns Content-Length header", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/get?key1=some_value1&key2=some_value2&key3=some_value3",
+          headers = {
+            ["Host"] = "lambda.com"
+          }
+        })
+
+        assert.equal(65, tonumber(res.headers["Content-Length"]))
+      end)
+
+      it("errors on bad region name (DNS resolution)", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/get?key1=some_value1",
+          headers = {
+            ["Host"] = "lambda15.com"
+          }
+        })
+        assert.res_status(500, res)
+
+        helpers.wait_until(function()
+          local logs = pl_file.read(TEST_CONF.prefix .. "/" .. TEST_CONF.proxy_error_log)
+          local _, count = logs:gsub([[%[aws%-lambda%].+lambda%.ab%-cdef%-1%.amazonaws%.com.+name error"]], "")
+          return count >= 1
+        end, 10)
+      end)
+
+      describe("config.is_proxy_integration = true", function()
+
+
+  -- here's where we miss the changes to the custom nginx template, to be able to
+  -- run the tests against older versions (0.13.x) of Kong. Add those manually
+  -- and the tests pass.
+  -- see: https://github.com/Kong/kong/commit/c6f9e4558b5a654e78ca96b2ba4309e527053403#diff-9d13d8efc852de84b07e71bf419a2c4d
+
+        it("sets proper status code on custom response from Lambda", function()
+          local res = assert(proxy_client:send {
+            method  = "POST",
+            path    = "/post",
+            headers = {
+              ["Host"]         = "lambda11.com",
+              ["Content-Type"] = "application/json"
+            },
+            body = {
+              statusCode = 201,
+            }
+          })
+          local body = assert.res_status(201, res)
+          assert.equal(0, tonumber(res.headers["Content-Length"]))
+          assert.equal(nil, res.headers["X-Custom-Header"])
+          assert.equal("", body)
+        end)
+
+        it("sets proper status code/headers/body on custom response from Lambda", function()
+          -- the lambda function must return a string
+          -- for the custom response "body" property
+          local body = cjson.encode({
+            key1 = "some_value_post1",
+            key2 = "some_value_post2",
+            key3 = "some_value_post3",
+          })
+
+          local res = assert(proxy_client:send {
+            method  = "POST",
+            path    = "/post",
+            headers = {
+              ["Host"]         = "lambda11.com",
+              ["Content-Type"] = "application/json",
+            },
+            body = {
+              statusCode = 201,
+              body = body,
+              headers = {
+                ["X-Custom-Header"] = "Hello world!"
+              }
+            }
+          })
+
+          local res_body = assert.res_status(201, res)
+          assert.equal(79, tonumber(res.headers["Content-Length"]))
+          assert.equal("Hello world!", res.headers["X-Custom-Header"])
+          assert.equal(body, res_body)
+        end)
+
+        it("override duplicated headers with value from the custom response from Lambda", function()
+          -- the default "x-amzn-RequestId" returned is "foo"
+          -- let's check it is overriden with a custom value
+          local headers = {
+            ["x-amzn-RequestId"] = "bar",
+          }
+
+          local res = assert(proxy_client:send {
+            method  = "POST",
+            path    = "/post",
+            headers = {
+              ["Host"]         = "lambda11.com",
+              ["Content-Type"] = "application/json",
+            },
+            body = {
+              statusCode = 201,
+              headers = headers,
+            }
+          })
+
+          assert.res_status(201, res)
+          assert.equal("bar", res.headers["x-amzn-RequestId"])
+        end)
+
+        it("returns HTTP 502 when 'status' property of custom response is not a number", function()
+          local res = assert(proxy_client:send {
+            method  = "POST",
+            path    = "/post",
+            headers = {
+              ["Host"]         = "lambda11.com",
+              ["Content-Type"] = "application/json",
+            },
+            body = {
+              statusCode = "hello",
+            }
+          })
+
+          assert.res_status(502, res)
+          local b = assert.response(res).has.jsonbody()
+          assert.equal("Bad Gateway", b.message)
+        end)
+
+        it("returns HTTP 502 when 'headers' property of custom response is not a table", function()
+          local res = assert(proxy_client:send {
+            method  = "POST",
+            path    = "/post",
+            headers = {
+              ["Host"]         = "lambda11.com",
+              ["Content-Type"] = "application/json",
+            },
+            body = {
+              headers = "hello",
+            }
+          })
+
+          assert.res_status(502, res)
+          local b = assert.response(res).has.jsonbody()
+          assert.equal("Bad Gateway", b.message)
+        end)
+
+        it("returns HTTP 502 when 'body' property of custom response is not a string", function()
+          local res = assert(proxy_client:send {
+            method  = "POST",
+            path    = "/post",
+            headers = {
+              ["Host"]         = "lambda11.com",
+              ["Content-Type"] = "application/json",
+            },
+            body = {
+              statusCode = 201,
+              body = 1234,
+            }
+          })
+
+          assert.res_status(502, res)
+          local b = assert.response(res).has.jsonbody()
+          assert.equal("Bad Gateway", b.message)
+        end)
+
+        it("returns HTTP 502 with when response from lambda is not valid JSON", function()
+          local res = assert(proxy_client:send {
+            method  = "POST",
+            path    = "/post",
+            headers = {
+              ["Host"] = "lambda12.com",
+            }
+          })
+
+          assert.res_status(502, res)
+          local b = assert.response(res).has.jsonbody()
+          assert.equal("Bad Gateway", b.message)
+        end)
+
+        it("returns HTTP 502 on empty response from Lambda", function()
+          local res = assert(proxy_client:send {
+            method  = "POST",
+            path    = "/post",
+            headers = {
+              ["Host"] = "lambda13.com",
+            }
+          })
+
+          assert.res_status(502, res)
+          local b = assert.response(res).has.jsonbody()
+          assert.equal("Bad Gateway", b.message)
+        end)
+
+        it("invokes a Lambda function with GET using serviceless route", function()
+          local res = assert(proxy_client:send {
+            method  = "GET",
+            path    = "/get?key1=some_value1&key2=some_value2&key3=some_value3",
+            headers = {
+              ["Host"] = "lambda14.com"
+            }
+          })
+          assert.res_status(200, res)
+          local body = assert.response(res).has.jsonbody()
+          assert.is_string(res.headers["x-amzn-RequestId"])
+          assert.equal("some_value1", body.key1)
+          assert.is_nil(res.headers["X-Amz-Function-Error"])
+        end)
+
+        it("returns decoded base64 response from a Lambda function", function()
+          local res = assert(proxy_client:send {
+            method  = "GET",
+            path    = "/get?key1=some_value1&key2=some_value2&key3=some_value3",
+            headers = {
+              ["Host"] = "lambda16.com"
+            }
+          })
+          assert.res_status(200, res)
+          assert.equal("test", res:read_body())
+        end)
+
+        it("returns multivalueheaders response from a Lambda function", function()
+          local res = assert(proxy_client:send {
+            method  = "GET",
+            path    = "/get?key1=some_value1&key2=some_value2&key3=some_value3",
+            headers = {
+              ["Host"] = "lambda17.com"
+            }
+          })
+          assert.res_status(200, res)
+          assert.is_string(res.headers.age)
+          assert.is_array(res.headers["Access-Control-Allow-Origin"])
+        end)
+      end)
+
+      it("fails when no region is set and no host is provided", function()
         local res = assert(proxy_client:send({
           method  = "GET",
           path    = "/get?key1=some_value1",
           headers = {
-            ["Host"] = "lambda18.test"
+            ["Host"] = "lambda18.com"
           }
         }))
+        assert.res_status(500, res)
+      end)
+
+      it("succeeds when region is set in config and not set in environment", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/get?key1=some_value1&key2=some_value2&key3=some_value3",
+          headers = {
+            ["Host"] = "lambda.com"
+          }
+        })
         assert.res_status(200, res)
-        assert.is_string(res.headers.age)
-        assert.is_array(res.headers["Access-Control-Allow-Origin"])
+        local body = assert.response(res).has.jsonbody()
+        assert.is_string(res.headers["x-amzn-RequestId"])
+        assert.equal("some_value1", body.key1)
+        assert.is_nil(res.headers["X-Amz-Function-Error"])
+      end)
+
+      it("succeeds when region and host are set in config", function()
+        local res = assert(proxy_client:send({
+          method  = "GET",
+          path    = "/get?key1=some_value1&key2=some_value2&key3=some_value3",
+          headers = {
+            ["Host"] = "lambda20.com",
+          }
+        }))
+
+        local body = assert.response(res).has.jsonbody()
+        assert.is_string(res.headers["x-amzn-RequestId"])
+        assert.equal("some_value1", body.key1)
+        assert.is_nil(res.headers["X-Amz-Function-Error"])
+      end)
+
+    end)
+
+    describe("AWS_REGION environment is set", function()
+
+      lazy_setup(function()
+        helpers.setenv("AWS_REGION", "us-east-1")
+        assert(helpers.start_kong({
+          database   = strategy,
+          plugins = "aws-lambda",
+          nginx_conf = "spec/fixtures/custom_nginx.template",
+        }, nil, nil, fixtures))  
+      end)
+
+      lazy_teardown(function()
+        helpers.stop_kong()
+        helpers.unsetenv("AWS_REGION", "us-east-1")
       end)
 
       it("use ENV value when no region nor host is set", function()
@@ -994,13 +1075,14 @@ for _, strategy in helpers.each_strategy() do
           method  = "GET",
           path    = "/get?key1=some_value1",
           headers = {
-            ["Host"] = "lambda19.test"
+            ["Host"] = "lambda19.com"
           }
         }))
         assert.res_status(200, res)
         assert.is_string(res.headers.age)
         assert.is_array(res.headers["Access-Control-Allow-Origin"])
       end)
+
     end)
   end)
 end


### PR DESCRIPTION
### Summary

As per FTI-2928, customer uses Kong in front of AWS lambda in the isolated gov AWS region. Such regions use custom service endpoints, therefore customer uses `host` configuration to override it. Since config schema does not allow both host and region be supplied simultaneously, it is impossible to correctly sign the request using AWS SigV4 algorithm. The correct implementation of such plugin should allow both `aws_region` and `host` be supplied, as `aws_region` is a mandatory field for SigV4 signature algo.

### Full changelog

* Allow both host and aws_region in config
* Require AWS region to always be configured
* Always apply SigV4 signature
* Fixed tests to test environment variable configuration correctly

### Issues resolved

Fix FTI-2928
