### PR TITLE
perf(dao/schema) no ipairs, max page size, skip deep clone, localize vars

### DIFF
--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -9,8 +9,8 @@ local workspaces = require "kong.workspaces"
 local setmetatable = setmetatable
 local tostring     = tostring
 local require      = require
-local ipairs       = ipairs
 local concat       = table.concat
+local insert       = table.insert
 local error        = error
 local pairs        = pairs
 local floor        = math.floor
@@ -634,7 +634,8 @@ local function find_cascade_delete_entities(self, entity, show_ws_id)
   local constraints = self.schema:get_constraints()
   local entries = {}
   local pk = self.schema:extract_pk_values(entity)
-  for _, constraint in ipairs(constraints) do
+  for i = 1, #constraints do
+    local constraint = constraints[i]
     if constraint.on_delete == "cascade" then
       local dao = self.db.daos[constraint.schema.name]
       local method = "each_for_" .. constraint.field_name
@@ -643,8 +644,8 @@ local function find_cascade_delete_entities(self, entity, show_ws_id)
           log(ERR, "[db] failed to traverse entities for cascade-delete: ", err)
           break
         end
-        
-        table.insert(entries, { dao = dao, entity = row })
+
+        insert(entries, { dao = dao, entity = row })
       end
     end
   end
@@ -654,8 +655,8 @@ end
 
 
 local function propagate_cascade_delete_events(entries, options)
-  for _, entry in ipairs(entries) do
-    entry.dao:post_crud_event("delete", entry.entity, nil, options)
+  for i = 1, #entries do
+    entries[i].dao:post_crud_event("delete", entries[i].entity, nil, options)
   end
 end
 
@@ -1487,7 +1488,8 @@ function DAO:cache_key(key, arg2, arg3, arg4, arg5, ws_id)
   local source = self.schema.cache_key or self.schema.primary_key
 
   local i = 2
-  for _, name in ipairs(source) do
+  for j = 1, #source do
+    local name = source[j]
     local field = self.schema.fields[name]
     local value = key[name]
     if value == null or value == nil then

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -5,14 +5,15 @@ local cjson        = require "cjson"
 
 
 local setmetatable = setmetatable
+local getmetatable = getmetatable
 local re_match     = ngx.re.match
 local re_find      = ngx.re.find
+local tostring     = tostring
 local concat       = table.concat
 local insert       = table.insert
 local format       = string.format
 local unpack       = unpack
 local assert       = assert
-local ipairs       = ipairs
 local pairs        = pairs
 local pcall        = pcall
 local floor        = math.floor
@@ -163,7 +164,8 @@ end
 -- @return The string of quoted words and/or arrays.
 local function quoted_list(words)
   local msg = {}
-  for _, word in ipairs(words) do
+  for i = 1, #words do
+    local word = words[i]
     if type(word) == "table" then
       insert(msg, ("(%s)"):format(quoted_list(word)))
     else
@@ -273,8 +275,9 @@ Schema.validators = {
   end,
 
   match_any = function(value, arg)
-    for _, pattern in ipairs(arg.patterns) do
-      local m = value:match(pattern)
+    local patterns = arg.patterns
+    for i = 1, #patterns do
+      local m = value:match(patterns[i])
       if m then
         return true
       end
@@ -291,8 +294,8 @@ Schema.validators = {
   end,
 
   one_of = function(value, options)
-    for _, option in ipairs(options) do
-      if value == option then
+    for i = 1, #options do
+      if value == options[i] then
         return true
       end
     end
@@ -300,8 +303,8 @@ Schema.validators = {
   end,
 
   not_one_of = function(value, options)
-    for _, option in ipairs(options) do
-      if value == option then
+    for i = 1, #options do
+      if value == options[i] then
         return nil, validation_errors.NOT_ONE_OF:format(concat(options, ", "))
       end
     end
@@ -320,8 +323,8 @@ Schema.validators = {
   end,
 
   contains = function(array, wanted)
-    for _, item in ipairs(array) do
-      if item == wanted then
+    for i = 1, #array do
+      if array[i] == wanted then
         return true
       end
     end
@@ -331,15 +334,17 @@ Schema.validators = {
 
   mutually_exclusive_subsets = function(value, subsets)
     local subset_union = {} -- union of all subsets; key is an element, value is the
-    for _, subset in ipairs(subsets) do -- the subset the element is part of
-      for _, el in ipairs(subset) do
-        subset_union[el] = subset
+    for i = 1, #subsets do -- the subset the element is part of
+      local subset = subsets[i]
+      for j = 1, #subset do
+        subset_union[subset[j]] = subset
       end
     end
 
     local member_of = {}
 
-    for _, val in ipairs(value) do -- for each value, add the set it's part of
+    for i = 1, #value do -- for each value, add the set it's part of
+      local val = value[i]
       if subset_union[val] and not member_of[subset_union[val]] then -- to member_of, iff it hasn't already
         member_of[subset_union[val]] = true
         member_of[#member_of+1] = subset_union[val]
@@ -495,7 +500,8 @@ end
 local function mutually_required(entity, field_names)
   local nonempty = {}
 
-  for _, name in ipairs(field_names) do
+  for i = 1, #field_names do
+    local name = field_names[i]
     if is_nonempty(get_field(entity, name)) then
       insert(nonempty, name)
     end
@@ -512,7 +518,8 @@ end
 local function mutually_exclusive(entity, field_names)
   local nonempty = {}
 
-  for _, name in ipairs(field_names) do
+  for i = 1, #field_names do
+    local name = field_names[i]
     if is_nonempty(get_field(entity, name)) then
       insert(nonempty, name)
     end
@@ -566,7 +573,8 @@ Schema.entity_checkers = {
     run_with_missing_fields = true,
     run_with_invalid_fields = true,
     fn = function(entity, field_names)
-      for _, name in ipairs(field_names) do
+      for i = 1, #field_names do
+        local name = field_names[i]
         if is_nonempty(get_field(entity, name)) then
           return true
         end
@@ -609,8 +617,9 @@ Schema.entity_checkers = {
           return true
         end
 
-        for _, name in ipairs(arg.else_then_at_least_one_of) do
-          if is_nonempty(get_field(entity, name)) then
+        local names = arg.else_then_at_least_one_of
+        for i = 1, #names do
+          if is_nonempty(get_field(entity, names[i])) then
             return true
           end
         end
@@ -625,8 +634,9 @@ Schema.entity_checkers = {
       end
 
       -- run 'if'
-      for _, name in ipairs(arg.then_at_least_one_of) do
-        if is_nonempty(get_field(entity, name)) then
+      local names = arg.then_at_least_one_of
+      for i = 1, #names do
+        if is_nonempty(get_field(entity, names[i])) then
           return true
         end
       end
@@ -647,8 +657,8 @@ Schema.entity_checkers = {
     fn = function(entity, field_names)
       local found = false
       local ok = false
-      for _, name in ipairs(field_names) do
-        if is_nonempty(get_field(entity, name)) then
+      for i = 1, #field_names do
+        if is_nonempty(get_field(entity, field_names[i])) then
           if not found then
             found = true
             ok = true
@@ -670,8 +680,8 @@ Schema.entity_checkers = {
     run_with_invalid_fields = true,
     fn = function(entity, field_names)
       local seen = {}
-      for _, name in ipairs(field_names) do
-        local value = get_field(entity, name)
+      for i = 1, #field_names do
+        local value = get_field(entity, field_names[i])
         if is_nonempty(value) then
           if seen[value] then
             return nil, quoted_list(field_names)
@@ -767,13 +777,15 @@ Schema.entity_checkers = {
       local nonempty1 = {}
       local nonempty2 = {}
 
-      for _, name in ipairs(args.set1) do
+      for i = 1, #args.set1 do
+        local name = args.set1[i]
         if is_nonempty(get_field(entity, name)) then
           insert(nonempty1, name)
         end
       end
 
-      for _, name in ipairs(args.set2) do
+      for i = 1, #args.set2 do
+        local name = args.set2[i]
         if is_nonempty(get_field(entity, name)) then
           insert(nonempty2, name)
         end
@@ -807,8 +819,8 @@ local function validate_elements(self, field, value)
   field.elements.required = true
   local errs = {}
   local all_ok = true
-  for i, v in ipairs(value) do
-    local ok, err = self:validate_field(field.elements, v)
+  for i = 1, #value do
+    local ok, err = self:validate_field(field.elements, value[i])
     if not ok then
       errs[i] = err
       all_ok = false
@@ -840,7 +852,6 @@ local validate_fields
 -- @return true if the field validates correctly;
 -- nil and an error message on failure.
 function Schema:validate_field(field, value)
-
   if value == null then
     if field.ne == null then
       return nil, field.err or validation_errors.NE:format("null")
@@ -962,7 +973,9 @@ function Schema:validate_field(field, value)
     return nil, validation_errors.SCHEMA_TYPE:format(field.type)
   end
 
-  for _, k in ipairs(Schema.validators_order) do
+  local validators = Schema.validators_order
+  for i = 1, #validators do
+    local k = validators[i]
     if field[k] ~= nil then
       local ok, err = self.validators[k](value, field[k], field)
       if not ok then
@@ -1051,8 +1064,8 @@ local function get_subschema(self, input)
     end
 
     if type(input_key) == "table" then  -- if subschema key is a set, return
-      for _, v in ipairs(input_key) do  -- subschema for first key
-        local subschema = self.subschemas[v]
+      for i = 1, #input_key do  -- subschema for first key
+        local subschema = self.subschemas[input_key[i]]
         if subschema then
           return subschema
         end
@@ -1153,7 +1166,8 @@ local function run_entity_check(self, name, input, arg, full_check, errors)
 
   local required_fields = {}
   if checker.field_sources then
-    for _, source in ipairs(checker.field_sources) do
+    for i = 1, #checker.field_sources do
+      local source = checker.field_sources[i]
       local v = arg[source]
       if type(v) == "string" then
         insert(fields_to_check, v)
@@ -1161,7 +1175,8 @@ local function run_entity_check(self, name, input, arg, full_check, errors)
           required_fields[v] = true
         end
       elseif type(v) == "table" then
-        for _, fname in ipairs(v) do
+        for j = 1, #v do
+          local fname = v[j]
           insert(fields_to_check, fname)
           if checker.required_fields[source] then
             required_fields[fname] = true
@@ -1171,15 +1186,16 @@ local function run_entity_check(self, name, input, arg, full_check, errors)
     end
   else
     fields_to_check = arg
-    for _, fname in ipairs(arg) do
-      required_fields[fname] = true
+    for i = 1, #arg do
+      required_fields[arg[i]] = true
     end
   end
 
   local missing
   local all_nil = true
   local all_ok = true
-  for _, fname in ipairs(fields_to_check) do
+  for i = 1, #fields_to_check do
+    local fname = fields_to_check[i]
     local value = get_field(input, fname)
     if value == nil then
       if (not checker.run_with_missing_fields) and
@@ -1209,8 +1225,8 @@ local function run_entity_check(self, name, input, arg, full_check, errors)
 
   -- Don't run check if a required field is missing
   if missing then
-    for _, fname in ipairs(missing) do
-      set_field(errors, fname, validation_errors.REQUIRED_FOR_ENTITY_CHECK)
+    for i = 1, #missing do
+      set_field(errors, missing[i], validation_errors.REQUIRED_FOR_ENTITY_CHECK)
     end
     return
   end
@@ -1287,7 +1303,8 @@ do
     if not checks then
       return
     end
-    for _, check in ipairs(checks) do
+    for i = 1, #checks do
+      local check = checks[i]
       local check_name = next(check)
       local arg = check[check_name]
       if arg and arg ~= null then
@@ -1336,12 +1353,15 @@ end
 
 
 local function run_transformation_checks(schema_or_subschema, input, original_input, rbw_entity, errors)
-  if schema_or_subschema.transformations then
-    for _, transformation in ipairs(schema_or_subschema.transformations) do
+  local transformations = schema_or_subschema.transformations
+  if transformations then
+    for i = 1, #transformations do
+      local transformation = transformations[i]
       local args = {}
       local argc = 0
       local none_set = true
-      for _, input_field_name in ipairs(transformation.input) do
+      for j = 1, #transformation.input do
+        local input_field_name = transformation.input[j]
         if is_nonempty(get_field(original_input or input, input_field_name)) then
           none_set = false
         end
@@ -1352,7 +1372,8 @@ local function run_transformation_checks(schema_or_subschema, input, original_in
 
       local needs_changed = false
       if transformation.needs then
-        for _, input_field_name in ipairs(transformation.needs) do
+        for j = 1, #transformation.needs do
+          local input_field_name = transformation.needs[j]
           if rbw_entity and not needs_changed then
             local value = get_field(original_input or input, input_field_name)
             local rbw_value = get_field(rbw_entity, input_field_name)
@@ -1398,7 +1419,9 @@ function Schema:validate_primary_key(pk, ignore_others)
   local pk_set = {}
   local errors = {}
 
-  for _, k in ipairs(self.primary_key) do
+  local primary_key = self.primary_key
+  for i = 1, #primary_key do
+    local k = primary_key[i]
     pk_set[k] = true
     local field = self.fields[k]
     local v = pk[k]
@@ -1538,8 +1561,8 @@ local function adjust_field_for_context(field, value, context, nulls, opts)
     end
 
     if subfield then
-      for i, e in ipairs(value) do
-        value[i] = adjust_field_for_context(subfield, e, context, nulls, opts)
+      for i = 1, #value do
+        value[i] = adjust_field_for_context(subfield, value[i], context, nulls, opts)
       end
     end
   end
@@ -1570,10 +1593,11 @@ function Schema:process_auto_fields(data, context, nulls, opts)
 
   data = tablex.deepcopy(data)
 
-  if self.shorthand_fields then
+  local shorthand_fields = self.shorthand_fields
+  if shorthand_fields then
     local errs = {}
-    for _, shorthand in ipairs(self.shorthand_fields) do
-      local sname, sdata = next(shorthand)
+    for i = 1, #shorthand_fields do
+      local sname, sdata = next(shorthand_fields[i])
       local value = data[sname]
       if value ~= nil then
         local _, err = self:validate_field(sdata, value)
@@ -1596,9 +1620,10 @@ function Schema:process_auto_fields(data, context, nulls, opts)
   end
 
   -- deprecated
-  if self.shorthands then
-    for _, shorthand in ipairs(self.shorthands) do
-      local sname, sfunc = next(shorthand)
+  local shorthands = self.shorthands
+  if shorthands then
+    for i = 1, #shorthands do
+      local sname, sfunc = next(shorthands[i])
       local value = data[sname]
       if value ~= nil then
         data[sname] = nil
@@ -1968,8 +1993,8 @@ function Schema:errors_to_string(errors)
     end
   end
 
-  for _, err in ipairs(errors) do
-    insert(msgs, err)
+  for i = 1, #errors do
+    insert(msgs, errors[i])
   end
 
   -- Field-specific errors
@@ -2047,14 +2072,14 @@ function Schema:get_constraints()
     -- merge explicit and implicit constraints for workspaces
     for _, e in pairs(_cache["workspaces"].constraints) do
       local found = false
-      for _, w in ipairs(_workspaceable) do
-        if w == e then
+      for i = 1, #_workspaceable do
+        if _workspaceable[i] == e then
           found = true
           break
         end
       end
       if not found then
-        table.insert(_workspaceable, e)
+        insert(_workspaceable, e)
       end
     end
     return _workspaceable
@@ -2062,7 +2087,7 @@ function Schema:get_constraints()
 
   local constraints = {}
   for _, c in pairs(_cache[self.name].constraints) do
-    table.insert(constraints, c)
+    insert(constraints, c)
   end
   return constraints
 end
@@ -2086,7 +2111,8 @@ end
 local function get_transform_args(input, original_input, output, transformation)
   local args = {}
   local argc = 0
-  for _, input_field_name in ipairs(transformation.input) do
+  for i = 1, #transformation.input do
+    local input_field_name = transformation.input[i]
     local value = get_field(output or original_input or input, input_field_name)
     if is_nonempty(value) then
       argc = argc + 1
@@ -2102,7 +2128,8 @@ local function get_transform_args(input, original_input, output, transformation)
   end
 
   if transformation.needs then
-    for _, need in ipairs(transformation.needs) do
+    for i = 1, #transformation.needs do
+      local need = transformation.needs[i]
       local value = get_field(output or input, need)
       if is_nonempty(value) then
         argc = argc + 1
@@ -2119,7 +2146,8 @@ end
 
 local function run_transformations(self, transformations, input, original_input, context)
   local output
-  for _, transformation in ipairs(transformations) do
+  for i = 1, #transformations do
+    local transformation = transformations[i]
     local transform
     if context == "select" then
       transform = transformation.on_read
@@ -2191,10 +2219,11 @@ function Schema.new(definition, is_subschema)
   local self = copy(definition)
   setmetatable(self, Schema)
 
-  if self.cache_key then
+  local cache_key = self.cache_key
+  if cache_key then
     self.cache_key_set = {}
-    for _, name in ipairs(self.cache_key) do
-      self.cache_key_set[name] = true
+    for i = 1, #cache_key do
+      self.cache_key_set[cache_key[i]] = true
     end
   end
 
@@ -2230,7 +2259,7 @@ function Schema.new(definition, is_subschema)
   if self.workspaceable and self.name then
     if not _workspaceable[self.name] then
       _workspaceable[self.name] = true
-      table.insert(_workspaceable, { schema = self })
+      insert(_workspaceable, { schema = self })
     end
   end
 
@@ -2263,8 +2292,8 @@ function Schema.new_subschema(self, key, definition)
   end
 
   local parent_by_name = {}
-  for _, f in ipairs(self.fields) do
-    local fname, fdata = next(f)
+  for i = 1, #self.fields do
+    local fname, fdata = next(self.fields[i])
     parent_by_name[fname] = fdata
   end
 

--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -1,9 +1,19 @@
 --- A schema for validating schemas
 -- @module kong.db.schema.metaschema
 
-local Schema = require("kong.db.schema")
+local Schema = require "kong.db.schema"
 
-local tablex = require("pl.tablex")
+
+local setmetatable = setmetatable
+local assert = assert
+local insert = table.insert
+local pairs = pairs
+local find = string.find
+local type = type
+local next = next
+local keys = require("pl.tablex").keys
+local sub = string.sub
+local fmt = string.format
 
 
 local match_list = {
@@ -56,9 +66,10 @@ local validators = {
   { mutually_exclusive_subsets = { type = "array", elements = { type = "array", elements = { type = "string" } } } },
 }
 
+
 -- Other field attributes, that do not correspond to validators
 local field_schema = {
-  { type = { type = "string", one_of = tablex.keys(Schema.valid_types), required = true }, },
+  { type = { type = "string", one_of = keys(Schema.valid_types), required = true }, },
   { required = { type = "boolean" }, },
   { reference = { type = "string" }, },
   { auto = { type = "boolean" }, },
@@ -74,15 +85,19 @@ local field_schema = {
   { encrypted = { type = "boolean" }, },
 }
 
-for _, field in ipairs(validators) do
-  table.insert(field_schema, field)
+
+for i = 1, #validators do
+  insert(field_schema, validators[i])
 end
 
+
 -- Most of the above are optional
-for _, field in ipairs(field_schema) do
+for i = 1, #field_schema do
+  local field = field_schema[i]
   local data = field[next(field)]
   data.nilable = not data.required
 end
+
 
 local field_entity_checks = {
   -- if 'unique_across_ws' is set, then 'unique' must be set too
@@ -93,6 +108,7 @@ local field_entity_checks = {
     }
   },
 }
+
 
 local fields_array = {
   type = "array",
@@ -154,11 +170,13 @@ local transformations_array = {
   },
 }
 
+
 -- Recursive field attributes
-table.insert(field_schema, { elements = { type = "record", fields = field_schema } })
-table.insert(field_schema, { keys     = { type = "record", fields = field_schema } })
-table.insert(field_schema, { values   = { type = "record", fields = field_schema } })
-table.insert(field_schema, { fields   = fields_array })
+insert(field_schema, { elements = { type = "record", fields = field_schema } })
+insert(field_schema, { keys     = { type = "record", fields = field_schema } })
+insert(field_schema, { values   = { type = "record", fields = field_schema } })
+insert(field_schema, { fields   = fields_array })
+
 
 local conditional_validators = {
   { required = { type = "boolean" } },
@@ -166,9 +184,10 @@ local conditional_validators = {
   { keys     = { type = "record", fields = field_schema } },
   { values   = { type = "record", fields = field_schema } },
 }
-for _, field in ipairs(validators) do
-  table.insert(conditional_validators, field)
+for i = 1, #validators do
+  insert(conditional_validators, validators[i])
 end
+
 
 local entity_checkers = {
   { at_least_one_of = { type = "array", elements = { type = "string" } } },
@@ -218,13 +237,17 @@ local entity_checkers = {
   },
 }
 
+
 local entity_check_names = {}
 
-for _, field in ipairs(entity_checkers) do
+
+for i = 1, #entity_checkers do
+  local field = entity_checkers[i]
   local name = next(field)
   --field[name].nilable = true
-  table.insert(entity_check_names, name)
+  insert(entity_check_names, name)
 end
+
 
 local entity_checks_schema = {
   type = "array",
@@ -232,11 +255,12 @@ local entity_checks_schema = {
     type = "record",
     fields = entity_checkers,
     entity_checks = {
-      { only_one_of = tablex.keys(Schema.entity_checkers) }
+      { only_one_of = keys(Schema.entity_checkers) }
     }
   },
   nilable = true,
 }
+
 
 local shorthands_array = {
   type = "array",
@@ -250,6 +274,7 @@ local shorthands_array = {
   nilable = true,
 }
 
+
 local shorthand_fields_array = {
   type = "array",
   elements = {
@@ -262,9 +287,11 @@ local shorthand_fields_array = {
   nilable = true,
 }
 
-table.insert(field_schema, { entity_checks = entity_checks_schema })
-table.insert(field_schema, { shorthands = shorthands_array })
-table.insert(field_schema, { shorthand_fields = shorthand_fields_array })
+
+insert(field_schema, { entity_checks = entity_checks_schema })
+insert(field_schema, { shorthands = shorthands_array })
+insert(field_schema, { shorthand_fields = shorthand_fields_array })
+
 
 local meta_errors = {
   ATTRIBUTE = "field of type '%s' cannot have attribute '%s'",
@@ -358,16 +385,22 @@ local nested_attributes = {
   ["values" ] = true,
 }
 
+
 local check_field
+
 
 local function has_schema_field(schema, name)
   if schema == nil then
     return false
   end
 
-  local dot = string.find(name, ".", 1, true)
+  local fields = schema.fields
+  local fields_count = #fields
+
+  local dot = find(name, ".", 1, true)
   if not dot then
-    for _, field in ipairs(schema.fields) do
+    for i = 1, fields_count do
+      local field = fields[i]
       local k = next(field)
       if k == name then
         return true
@@ -377,8 +410,9 @@ local function has_schema_field(schema, name)
     return false
   end
 
-  local hd, tl = string.sub(name, 1, dot - 1), string.sub(name, dot + 1)
-  for _, field in ipairs(schema.fields) do
+  local hd, tl = sub(name, 1, dot - 1), sub(name, dot + 1)
+  for i = 1, fields_count do
+    local field = fields[i]
     local k = next(field)
     if k == hd then
       if field[hd] and field[hd].type == "foreign" then
@@ -396,31 +430,36 @@ local function has_schema_field(schema, name)
 end
 
 local check_fields = function(schema, errors)
-  if schema.transformations then
-    for i, transformation in ipairs(schema.transformations) do
-      for j, input in ipairs(transformation.input) do
+  local transformations = schema.transformations
+  if transformations then
+    for i = 1, #transformations do
+      local transformation = transformations[i]
+      for j = 1, #transformation.input do
+        local input = transformation.input[j]
         if not has_schema_field(schema, input) then
           errors.transformations = errors.transformations or {}
           errors.transformations.input = errors.transformations.input or {}
           errors.transformations.input[i] = errors.transformations.input[i] or {}
-          errors.transformations.input[i][j] = string.format("invalid field name: %s", input)
+          errors.transformations.input[i][j] = fmt("invalid field name: %s", input)
         end
       end
 
       if transformation.needs then
-        for j, need in ipairs(transformation.needs) do
+        for j = 1, #transformation.needs do
+          local need = transformation.needs[j]
           if not has_schema_field(schema, need) then
             errors.transformations = errors.transformations or {}
             errors.transformations.needs = errors.transformations.needs or {}
             errors.transformations.needs[i] = errors.transformations.needs[i] or {}
-            errors.transformations.needs[i][j] = string.format("invalid field name: %s", need)
+            errors.transformations.needs[i][j] = fmt("invalid field name: %s", need)
           end
         end
       end
     end
   end
 
-  for _, item in ipairs(schema.fields) do
+  for i = 1, #schema.fields do
+    local item = schema.fields[i]
     if type(item) ~= "table" then
       errors["fields"] = meta_errors.FIELDS_ARRAY
       break
@@ -443,6 +482,7 @@ local check_fields = function(schema, errors)
   return true
 end
 
+
 check_field = function(k, field, errors)
   if not field.type then
     errors[k] = meta_errors.TYPE
@@ -453,7 +493,8 @@ check_field = function(k, field, errors)
     if field.abstract and field.type == "record" then
       req_attrs = {}
     end
-    for _, required in ipairs(req_attrs) do
+    for i = 1, #req_attrs do
+      local required = req_attrs[i]
       if not field[required] then
         errors[k] = meta_errors.REQUIRED:format(field.type, required)
       end
@@ -496,16 +537,16 @@ local function make_shorthand_field_schema()
   }
 
   local shorthand_field_types = {}
-  for k, _ in pairs(Schema.valid_types) do
+  for k in pairs(Schema.valid_types) do
     if not invalid_as_shorthand[k] then
-      table.insert(shorthand_field_types, k)
+      insert(shorthand_field_types, k)
     end
   end
 
   assert(next(shorthand_field_schema[1]) == "type")
   shorthand_field_schema[1] = { type = { type = "string", one_of = shorthand_field_types, required = true }, }
 
-  table.insert(shorthand_field_schema, { func = { type = "function", required = true } })
+  insert(shorthand_field_schema, { func = { type = "function", required = true } })
   return shorthand_field_schema
 end
 
@@ -518,9 +559,7 @@ shorthand_fields_array.elements.values = {
 
 
 local MetaSchema = Schema.new({
-
   name = "metaschema",
-
   fields = {
     {
       name = {
@@ -641,16 +680,17 @@ local MetaSchema = Schema.new({
 
   check = function(schema)
     local errors = {}
+    local fields = schema.fields
 
-    if not schema.fields then
+    if not fields then
       errors["fields"] = meta_errors.TABLE:format("fields")
       return nil, errors
     end
 
     if schema.endpoint_key then
       local found = false
-      for _, item in ipairs(schema.fields) do
-        local k = next(item)
+      for i = 1, #fields do
+        local k = next(fields[i])
         if schema.endpoint_key == k then
           found = true
           break
@@ -661,13 +701,15 @@ local MetaSchema = Schema.new({
       end
     end
 
-    if schema.cache_key then
+    local cache_key = schema.cache_key
+    if cache_key then
       local found
-      for _, e in ipairs(schema.cache_key) do
+      for i = 1, #cache_key do
         found = nil
-        for _, item in ipairs(schema.fields) do
+        for j = 1, #fields do
+          local item = fields[j]
           local k = next(item)
-          if e == k then
+          if cache_key[i] == k then
             found = item[k]
             break
           end
@@ -677,7 +719,8 @@ local MetaSchema = Schema.new({
           break
         end
       end
-      if #schema.cache_key == 1 then
+
+      if #cache_key == 1 then
         if found and not found.unique then
           errors["cache_key"] = meta_errors.CACHE_KEY_UNIQUE
         end
@@ -686,7 +729,8 @@ local MetaSchema = Schema.new({
 
     if schema.subschema_key then
       local found = false
-      for _, item in ipairs(schema.fields) do
+      for i = 1, #fields do
+        local item = fields[i]
         local k = next(item)
         local field = item[k]
         if schema.subschema_key == k then
@@ -703,8 +747,8 @@ local MetaSchema = Schema.new({
     end
 
     if schema.ttl then
-      for _, item in ipairs(schema.fields) do
-        local k = next(item)
+      for i = 1, #fields do
+        local k = next(fields[i])
         if k == "ttl" then
           errors["ttl"] = meta_errors.TTL_RESERVED
           break
@@ -712,9 +756,55 @@ local MetaSchema = Schema.new({
       end
     end
 
+    local transformations = schema.transformations
+    if transformations then
+      for i = 1, #transformations do
+        local input = transformations[i].input
+        for j = 1, #input do
+          if not has_schema_field(schema, input[j]) then
+            if not errors.transformations then
+              errors.transformations = {}
+            end
+
+            if not errors.transformations.input then
+              errors.transformations.input = {}
+            end
+
+
+            if not errors.transformations.input[i] then
+              errors.transformations.input[i] = {}
+            end
+
+            errors.transformations.input[i][j] = fmt("invalid field name: %s", input)
+          end
+        end
+
+        local needs = transformations[i].needs
+        if needs then
+          for j = 1, #needs do
+            if not has_schema_field(schema, needs[j]) then
+              if not errors.transformations then
+                errors.transformations = {}
+              end
+
+              if not errors.transformations.needs then
+                errors.transformations.needs = {}
+              end
+
+
+              if not errors.transformations.needs[i] then
+                errors.transformations.needs[i] = {}
+              end
+
+              errors.transformations.needs[i][j] = fmt("invalid field name: %s", needs[j])
+            end
+          end
+        end
+      end
+    end
+
     return check_fields(schema, errors)
   end,
-
 })
 
 
@@ -729,8 +819,8 @@ MetaSchema.valid_types = setmetatable({
 -- @return a set of validator names.
 function MetaSchema.get_supported_validator_set()
   local set = {}
-  for _, item in ipairs(validators) do
-    local name = next(item)
+  for i = 1, #validators do
+    local name = next(validators[i])
     set[name] = true
   end
   return set
@@ -738,9 +828,7 @@ end
 
 
 MetaSchema.MetaSubSchema = Schema.new({
-
   name = "metasubschema",
-
   fields = {
     {
       name = {
@@ -770,7 +858,6 @@ MetaSchema.MetaSubSchema = Schema.new({
       },
     },
   },
-
   check = function(schema)
     local errors = {}
 
@@ -781,7 +868,7 @@ MetaSchema.MetaSubSchema = Schema.new({
 
     return check_fields(schema, errors)
   end,
-
 })
+
 
 return MetaSchema

--- a/kong/db/schema/topological_sort.lua
+++ b/kong/db/schema/topological_sort.lua
@@ -1,13 +1,18 @@
 local constants = require "kong.constants"
 local utils = require "kong.tools.utils"
 
+
 local utils_toposort = utils.topological_sort
+local sort = table.sort
+
+
+local CORE_ENTITIES = constants.CORE_ENTITIES
 
 
 local sort_core_first do
   local CORE_SCORE = {}
-  for _, v in ipairs(constants.CORE_ENTITIES) do
-    CORE_SCORE[v] = 1
+  for i = 1, #CORE_ENTITIES do
+    CORE_SCORE[CORE_ENTITIES[i]] = 1
   end
   CORE_SCORE["workspaces"] = 2
 
@@ -51,7 +56,7 @@ local schema_topological_sort = function(schemas)
   end
   schemas = copy
 
-  table.sort(schemas, sort_core_first)
+  sort(schemas, sort_core_first)
 
   -- given a schema, return all the schemas to which it has references
   -- (and are in the list of the `schemas` provided)
@@ -76,5 +81,6 @@ local schema_topological_sort = function(schemas)
 
   return utils_toposort(schemas, get_schema_neighbors)
 end
+
 
 return schema_topological_sort

--- a/kong/runloop/balancer/upstreams.lua
+++ b/kong/runloop/balancer/upstreams.lua
@@ -83,7 +83,13 @@ local function load_upstreams_dict_into_memory()
   local found = nil
 
   -- build a dictionary, indexed by the upstream name
-  for up, err in singletons.db.upstreams:each(nil, GLOBAL_QUERY_OPTS) do
+  local upstreams = singletons.db.upstreams
+
+  local page_size
+  if upstreams.pagination then
+    page_size = upstreams.pagination.max_page_size
+  end
+  for up, err in upstreams:each(page_size, GLOBAL_QUERY_OPTS) do
     if err then
       log(CRIT, "could not obtain list of upstreams: ", err)
       return nil

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -642,8 +642,13 @@ do
 
   local function build_services_init_cache(db)
     local services_init_cache = {}
+    local services = db.services
+    local page_size
+    if services.pagination then
+      page_size = services.pagination.max_page_size
+    end
 
-    for service, err in db.services:each(nil, GLOBAL_QUERY_OPTS) do
+    for service, err in services:each(page_size, GLOBAL_QUERY_OPTS) do
       if err then
         return nil, err
       end


### PR DESCRIPTION
### Summary

This set of performance improvements contains mainly schema and dao related enhancements:
- uses max page size when iterating over tables on initialization, rebuilds and warmups
- localize variable access in dao/schema modules
- optimizes very hot process auto fields function
- replaces ipairs with for i, #array loops

See the individual commits.

In my tests these patches together with #8010 will improve dbless reloads. E.g. router rebuild used to take something like 7 seconds per worker with my 50 MB YAML-test configuration. With these two PRs I get that to around 3-4 seconds.