### PR TITLE
docs(c*): add cassandra deprecation message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@
 ### Dependencies
 
 - Bumped `go-pdk` used in tests from v0.6.0 to v0.7.1 [#7964](https://github.com/Kong/kong/pull/7964)
+- Cassandra support is deprecated with 2.7 and will be fully removed with 4.0.
+  https://konghq.com/blog/cassandra-support-deprecated
 
 ### Additions
 

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -774,6 +774,7 @@ local function check_and_infer(conf, opts)
   end
 
   if conf.database == "cassandra" then
+    log.deprecation("Support for Cassandra is deprecated. Please refer to https://konghq.com/blog/cassandra-support-deprecated", {after = "2.7", removal = "4.0"})
     if string.find(conf.cassandra_lb_policy, "DCAware", nil, true)
        and not conf.cassandra_local_datacenter
     then


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jaiks@posteo.de>

### Summary

Cassandra deprecation message when starting/restarting/reloading kong.

This appears on screen as well as in the logs.

### Full changelog

- Cassandra support is deprecated with 2.7 and will be fully removed with 4.0.

TODO:

- [x] replace \<insert blog post for more information\> with actual link.