### PR TITLE
feat(conf) add dns_cache_size configuration parameter support

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1294,7 +1294,10 @@
 #dns_cache_size = 10000          # Defines the maximum allowed number of
                                  # DNS records stored in memory cache.
                                  # Least recently used DNS records are discarded 
-                                 # from cache if it is full.
+                                 # from cache if it is full. Both errors and 
+                                 # data are cached, therefore a single name query 
+                                 # can easily take up 10-15 slots. Especially 
+                                 # with k8s, with the default ndots=5 setting.
 
 #dns_not_found_ttl = 30          # TTL in seconds for empty DNS responses and
                                  # "(3) name error" responses.

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1296,8 +1296,7 @@
                                  # Least recently used DNS records are discarded 
                                  # from cache if it is full. Both errors and 
                                  # data are cached, therefore a single name query 
-                                 # can easily take up 10-15 slots. Especially 
-                                 # with k8s, with the default ndots=5 setting.
+                                 # can easily take up 10-15 slots.
 
 #dns_not_found_ttl = 30          # TTL in seconds for empty DNS responses and
                                  # "(3) name error" responses.

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1291,6 +1291,11 @@
                                  # completes, or the `dns_stale_ttl` number of
                                  # seconds have passed.
 
+#dns_cache_size = 10000          # Defines the maximum allowed number of
+                                 # DNS records stored in memory cache.
+                                 # Least recently used DNS records are discarded 
+                                 # from cache if it is full.
+
 #dns_not_found_ttl = 30          # TTL in seconds for empty DNS responses and
                                  # "(3) name error" responses.
 

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -517,6 +517,7 @@ local CONF_INFERENCES = {
   dns_order = { typ = "array" },
   dns_valid_ttl = { typ = "number" },
   dns_stale_ttl = { typ = "number" },
+  dns_cache_size = { typ = "number" },
   dns_not_found_ttl = { typ = "number" },
   dns_error_ttl = { typ = "number" },
   dns_no_sync = { typ = "boolean" },

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -155,6 +155,7 @@ dns_hostsfile = /etc/hosts
 dns_order = LAST,SRV,A,CNAME
 dns_valid_ttl = NONE
 dns_stale_ttl = 4
+dns_cache_size = 10000
 dns_not_found_ttl = 30
 dns_error_ttl = 1
 dns_no_sync = off

--- a/kong/tools/dns.lua
+++ b/kong/tools/dns.lua
@@ -31,6 +31,7 @@ local setup_client = function(conf)
     badTtl = conf.dns_error_ttl,       -- ttl in seconds for dns error responses (except 3 - name error)
     emptyTtl = conf.dns_not_found_ttl, -- ttl in seconds for empty and "(3) name error" dns responses
     staleTtl = conf.dns_stale_ttl,     -- ttl in seconds for records once they become stale
+    cacheSize = conf.dns_cache_size,   -- maximum number of records cached in memory
     order = conf.dns_order,            -- order of trying record types
     noSynchronisation = conf.dns_no_sync,
   }


### PR DESCRIPTION
### Summary

Add dns_cache_size configuration parameter to support maximum number of records for in-memory DNS client cache

### Full changelog

* Add configuration parameter draft
