### PR TITLE
feat(conf) add a new cipehrsuites `fips` that includes only FIPS

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -536,11 +536,12 @@
 
 #ssl_cipher_suite = intermediate # Defines the TLS ciphers served by Nginx.
                                  # Accepted values are `modern`,
-                                 # `intermediate`, `old`, or `custom`.
+                                 # `intermediate`, `old`, `fips` or `custom`.
                                  #
                                  # See https://wiki.mozilla.org/Security/Server_Side_TLS
                                  # for detailed descriptions of each cipher
-                                 # suite.
+                                 # suite. `fips` cipher suites are as decribed in
+                                 # https://wiki.openssl.org/index.php/FIPS_mode_and_TLS.
 
 #ssl_ciphers =                   # Defines a custom list of TLS ciphers to be
                                  # served by Nginx. This list must conform to

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -74,6 +74,18 @@ local cipher_suites = {
                          .. "AES256-SHA:"
                          .. "DES-CBC3-SHA",
     prefer_server_ciphers = "on",
+  },
+                     fips = { -- https://wiki.openssl.org/index.php/FIPS_mode_and_TLS
+                          -- TLSv1.0 and TLSv1.1 is not completely not FIPS compliant,
+                          -- but must be used under certain condititions like key sizes,
+                          -- signatures in the full chain that Kong can't control.
+                          -- In that case, we disables TLSv1.0 and TLSv1.1 and user
+                          -- can optionally turn them on if they are aware of the caveats.
+                          -- No FIPS compliant predefined DH group available prior to
+                          -- OpenSSL 3.0.
+                protocols = "TLSv1.2",
+                  ciphers = "TLSv1.2+FIPS:kRSA+FIPS:!eNULL:!aNULL",
+    prefer_server_ciphers = "on",
   }
 }
 


### PR DESCRIPTION
compliant ciphers

Turning this option on doesn't make Kong FIPS complaint, it needs Kong
to be linked with a FIPS complaint OpenSSL.

