### PR TITLE
refactor(utils) use Lua 5.1 compatible xpcall

### DIFF
--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -695,7 +695,9 @@ end
 -- @return success A boolean indicating wether the module was found.
 -- @return module The retrieved module, or the error in case of a failure
 function _M.load_module_if_exists(module_name)
-  local status, res = xpcall(require, debug.traceback, module_name)
+  local status, res = xpcall(function()
+    return require(module_name)
+  end, debug.traceback)
   if status then
     return true, res
   -- Here we match any character because if a module has a dash '-' in its name, we would need to escape it.


### PR DESCRIPTION
### Summary

Use Lua 5.1 compatible `xpcall` invocation. 
This helps run a subset of Kong's functionality within a Lua 5.1-only compatible VM.

### Issues resolved

None