### PR TITLE
fix: Remove the default host and port from datadog plugin schema

### DIFF
--- a/kong/plugins/datadog/schema.lua
+++ b/kong/plugins/datadog/schema.lua
@@ -74,8 +74,8 @@ return {
         type = "record",
         default = { metrics = DEFAULT_METRICS },
         fields = {
-          { host = typedefs.host, },
-          { port = typedefs.port, },
+          { host = typedefs.host({ default = "localhost" }), },
+          { port = typedefs.port({ default = 8125 }), },
           { prefix = { type = "string", default = "kong" }, },
           { service_name_tag = { type = "string", default = "name" }, },
           { status_tag = { type = "string", default = "status" }, },

--- a/kong/plugins/datadog/schema.lua
+++ b/kong/plugins/datadog/schema.lua
@@ -74,8 +74,8 @@ return {
         type = "record",
         default = { metrics = DEFAULT_METRICS },
         fields = {
-          { host = typedefs.host({ default = "localhost" }), },
-          { port = typedefs.port({ default = 8125 }), },
+          { host = typedefs.host, },
+          { port = typedefs.port, },
           { prefix = { type = "string", default = "kong" }, },
           { service_name_tag = { type = "string", default = "name" }, },
           { status_tag = { type = "string", default = "status" }, },

--- a/kong/plugins/datadog/statsd_logger.lua
+++ b/kong/plugins/datadog/statsd_logger.lua
@@ -25,8 +25,8 @@ local env_datadog_agent_port = tonumber(os.getenv 'KONG_DATADOG_AGENT_PORT' or "
 
 function statsd_mt:new(conf)
   local sock   = udp()
-  local host = conf.host or env_datadog_agent_host
-  local port = conf.port or env_datadog_agent_port
+  local host = env_datadog_agent_host or conf.host
+  local port = env_datadog_agent_port or conf.port
 
   local _, err = sock:setpeername(host, port)
   if err then


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Removes the default values from the host configuration, to allow using the environment variables when no host is specified

### Full changelog

* Updates the datadog schema
