### PR TITLE
chore(plugins-ee) enable encryption of some fields if keyring enabled (EE feature)

### DIFF
--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -71,6 +71,7 @@ local field_schema = {
   { legacy = { type = "boolean" }, },
   { immutable = { type = "boolean" }, },
   { err = { type = "string" } },
+  { encrypted = { type = "boolean" }, },
 }
 
 for _, field in ipairs(validators) do

--- a/kong/plugins/acme/schema.lua
+++ b/kong/plugins/acme/schema.lua
@@ -64,6 +64,7 @@ local schema = {
           -- very loose validation for basic sanity test
           match = "%w*%p*@+%w*%.?%w*",
           required = true,
+          encrypted = true, -- Kong Enterprise-exclusive feature, does nothing in Kong CE
         }, },
         { api_uri = typedefs.url({ default = "https://acme-v02.api.letsencrypt.org/directory" }),
         },
@@ -73,9 +74,11 @@ local schema = {
         }, },
         { eab_kid = {
           type = "string",
+          encrypted = true, -- Kong Enterprise-exclusive feature, does nothing in Kong CE
         }, },
         { eab_hmac_key = {
           type = "string",
+          encrypted = true, -- Kong Enterprise-exclusive feature, does nothing in Kong CE
         }, },
         -- Kong doesn't support multiple certificate chains yet
         { cert_type = {

--- a/kong/plugins/aws-lambda/schema.lua
+++ b/kong/plugins/aws-lambda/schema.lua
@@ -1,17 +1,5 @@
 local typedefs = require "kong.db.schema.typedefs"
 
-local function keyring_enabled()
-  local ok, enabled = pcall(function()
-    return kong.configuration.keyring_enabled
-  end)
-
-  return ok and enabled or nil
-end
-
--- symmetrically encrypt IAM access keys, if configured. this is available
--- in Kong Enterprise: https://docs.konghq.com/enterprise/1.3-x/db-encryption/
-local ENCRYPTED = keyring_enabled()
-
 return {
   name = "aws-lambda",
   fields = {
@@ -31,11 +19,11 @@ return {
         } },
         { aws_key = {
           type = "string",
-          encrypted = ENCRYPTED,
+          encrypted = true, -- Kong Enterprise-exclusive feature, does nothing in Kong CE
         } },
         { aws_secret = {
           type = "string",
-          encrypted = ENCRYPTED,
+          encrypted = true, -- Kong Enterprise-exclusive feature, does nothing in Kong CE
         } },
         { aws_region = typedefs.host },
         { function_name = {

--- a/kong/plugins/azure-functions/schema.lua
+++ b/kong/plugins/azure-functions/schema.lua
@@ -10,8 +10,8 @@ return {
           { https         = { type = "boolean", default  = true  }, },
           { https_verify  = { type = "boolean", default  = false }, },
           -- authorization
-          { apikey        = { type = "string"                    }, },
-          { clientid      = { type = "string"                    }, },
+          { apikey        = { type = "string", encrypted = true }, }, -- encrypted = true is a Kong Enterprise Exclusive feature. It does nothing in Kong CE
+          { clientid      = { type = "string", encrypted = true }, }, -- encrypted = true is a Kong Enterprise Exclusive feature. It does nothing in Kong CE
           -- target/location
           { appname       = { type = "string",  required = true  }, },
           { hostdomain    = { type = "string",  required = true, default = "azurewebsites.net" }, },

--- a/kong/plugins/basic-auth/daos.lua
+++ b/kong/plugins/basic-auth/daos.lua
@@ -1,7 +1,6 @@
 local typedefs = require "kong.db.schema.typedefs"
 local crypto = require "kong.plugins.basic-auth.crypto"
 
-
 return {
   {
     name = "basicauth_credentials",
@@ -16,7 +15,7 @@ return {
       { created_at = typedefs.auto_timestamp_s },
       { consumer = { type = "foreign", reference = "consumers", required = true, on_delete = "cascade" }, },
       { username = { type = "string", required = true, unique = true }, },
-      { password = { type = "string", required = true }, },
+      { password = { type = "string", required = true, encrypted = true }, }, -- encrypted = true is a Kong Enterprise Exclusive feature, it does nothing in Kong CE
       { tags     = typedefs.tags },
     },
     transformations = {

--- a/kong/plugins/http-log/schema.lua
+++ b/kong/plugins/http-log/schema.lua
@@ -9,7 +9,7 @@ return {
         type = "record",
         fields = {
           -- NOTE: any field added here must be also included in the handler's get_queue_id method
-          { http_endpoint = typedefs.url({ required = true }) },
+          { http_endpoint = typedefs.url({ required = true, encrypted = true }) }, -- encrypted = true is a Kong-Enterprise exclusive feature, does nothing in Kong CE
           { method = { type = "string", default = "POST", one_of = { "POST", "PUT", "PATCH" }, }, },
           { content_type = { type = "string", default = "application/json", one_of = { "application/json" }, }, },
           { timeout = { type = "number", default = 10000 }, },

--- a/kong/plugins/loggly/schema.lua
+++ b/kong/plugins/loggly/schema.lua
@@ -15,7 +15,7 @@ return {
         fields = {
           { host = typedefs.host({ default = "logs-01.loggly.com" }), },
           { port = typedefs.port({ default = 514 }), },
-          { key = { type = "string", required = true }, },
+          { key = { type = "string", required = true, encrypted = true }, }, -- encrypted = true is a Kong Enterprise Exclusive feature, it does nothing in Kong CE
           { tags = {
               type = "set",
               default = { "kong" },

--- a/kong/plugins/oauth2/daos.lua
+++ b/kong/plugins/oauth2/daos.lua
@@ -32,7 +32,7 @@ local oauth2_credentials = {
     { consumer = { type = "foreign", reference = "consumers", required = true, on_delete = "cascade", }, },
     { name = { type = "string", required = true }, },
     { client_id = { type = "string", required = false, unique = true, auto = true }, },
-    { client_secret = { type = "string", required = false, auto = true }, },
+    { client_secret = { type = "string", required = false, auto = true, encrypted = true }, }, -- encrypted = true is a Kong Enterprise Exclusive feature. It does nothing in Kong CE
     { hash_secret = { type = "boolean", required = true, default = false }, },
     { redirect_uris = {
       type = "array",

--- a/kong/plugins/oauth2/schema.lua
+++ b/kong/plugins/oauth2/schema.lua
@@ -22,7 +22,7 @@ return {
         fields = {
           { scopes = { type = "array", elements = { type = "string" }, }, },
           { mandatory_scope = { type = "boolean", default = false, required = true }, },
-          { provision_key = { type = "string", unique = true, auto = true, required = true }, },
+          { provision_key = { type = "string", unique = true, auto = true, required = true, encrypted = true }, }, -- encrypted = true is a Kong Enterprise Exclusive feature. It does nothing in Kong CE
           { token_expiration = { type = "number", default = 7200, required = true }, },
           { enable_authorization_code = { type = "boolean", default = false, required = true }, },
           { enable_implicit_grant = { type = "boolean", default = false, required = true }, },

--- a/kong/plugins/session/schema.lua
+++ b/kong/plugins/session/schema.lua
@@ -2,7 +2,6 @@ local typedefs = require "kong.db.schema.typedefs"
 local Schema = require "kong.db.schema"
 local utils = require "kong.tools.utils"
 
-
 local char = string.char
 local rand = math.random
 local encode_base64 = ngx.encode_base64
@@ -42,6 +41,7 @@ return {
               type = "string",
               required = false,
               default = random_string(),
+              encrypted = true, -- Kong Enterprise Exclusive. This does nothing in Kong CE
             },
           },
           { cookie_name = { type = "string", default = "session" } },


### PR DESCRIPTION
This PR marks several key fields as encrypted in several plugins.

Field encryption at rest is a Kong-EE-exclusive feature, this is here for easy upwards merges.
