### PR TITLE
feat(pdk) add kong.request.get_normalized_path

### DIFF
--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -8,6 +8,7 @@
 local cjson = require "cjson.safe".new()
 local multipart = require "multipart"
 local phase_checker = require "kong.pdk.private.phases"
+local normalize = require("kong.tools.uri").normalize
 
 
 local ngx = ngx
@@ -383,6 +384,34 @@ local function new(self)
     local uri = ngx.var.request_uri or ""
     local s = find(uri, "?", 2, true)
     return s and sub(uri, 1, s - 1) or uri
+  end
+
+  ---
+  -- Returns the normalized path component of the request's URL. The return
+  -- value is the same as `kong.request.get_path()` but normalized according
+  -- to RFC 3986 section 6:
+  --
+  -- * Percent-encoded values of unreserved characters are decoded (`%20`
+  --   becomes ` `).
+  -- * Percent-encoded values of reserved characters have their hexidecimal
+  --   value uppercased (`%2f` becomes `%2F`).
+  -- * Relative path elements (`/.` and `/..`) are dereferenced.
+  -- * Duplicate slashes are consolidated (`//` becomes `/`).
+  --
+  -- Merging of duplicate slashes can be disabled by passing in `false` for the
+  -- `merge_slashes` parameter.
+  --
+  -- @function kong.request.get_normalized_path
+  -- @phases rewrite, access, header_filter, response, body_filter, log, admin_api
+  -- @tparam[opt=true] boolean merge_slashes consolidate duplicate slashes in the path
+  -- @treturn string the path
+  -- @usage
+  -- -- Given a request to https://example.com/t/Abc%20123%C3%B8%2f/parent/..//test/./
+  --
+  -- kong.request.get_normalized_path()       -- "/t/Abc 123ø%2F/test/"
+  -- kong.request.get_normalized_path(false)  -- "/t/Abc 123ø%2F//test/"
+  function _REQUEST.get_normalized_path(merge_slashes)
+    return normalize(_REQUEST.get_path(), merge_slashes ~= false)
   end
 
 

--- a/t/01-pdk/04-request/00-phase_checks.t
+++ b/t/01-pdk/04-request/00-phase_checks.t
@@ -163,6 +163,18 @@ qq{
                 log           = true,
                 admin_api     = true,
             }, {
+                method        = "get_normalized_path",
+                args          = {},
+                init_worker   = false,
+                certificate   = "pending",
+                rewrite       = true,
+                access        = true,
+                header_filter = true,
+                response      = true,
+                body_filter   = true,
+                log           = true,
+                admin_api     = true,
+            }, {
                 method        = "get_path_with_query",
                 args          = {},
                 init_worker   = false,

--- a/t/01-pdk/04-request/20-get_normalized_path.t
+++ b/t/01-pdk/04-request/20-get_normalized_path.t
@@ -1,0 +1,110 @@
+use strict;
+use warnings FATAL => 'all';
+use Test::Nginx::Socket::Lua;
+do "./t/Util.pm";
+
+plan tests => repeat_each() * (blocks() * 3);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: request.get_normalized_path() returns path component of uri
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            ngx.say("normalized path: ", pdk.request.get_normalized_path())
+        }
+    }
+--- request
+GET /t
+--- response_body
+normalized path: /t
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: request.get_normalized_path() returns at least slash
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = / {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            ngx.say("normalized path: ", pdk.request.get_normalized_path())
+        }
+    }
+--- request
+GET http://kong
+--- response_body
+normalized path: /
+--- no_error_log
+[error]
+
+
+
+=== TEST 3: request.get_normalized_path() is normalized
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location /t/ {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            ngx.say("normalized path: ", pdk.request.get_normalized_path())
+        }
+    }
+--- request
+GET /t/Abc%20123%C3%B8/parent/../test/.
+--- response_body
+normalized path: /t/Abc 123ø/test/
+--- no_error_log
+[error]
+
+
+
+=== TEST 4: request.get_normalized_path() strips query string
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location /t/ {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            ngx.say("normalized path: ", pdk.request.get_normalized_path())
+        }
+    }
+--- request
+GET /t/demo?param=value
+--- response_body
+normalized path: /t/demo
+--- no_error_log
+[error]
+
+
+
+=== TEST 5: request.get_normalized_path() optionally ignores duplicate slashes
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location /t/ {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            ngx.say("merged: ", pdk.request.get_normalized_path())
+            ngx.say("un-merged: ", pdk.request.get_normalized_path(false))
+        }
+    }
+--- request
+GET /t/Abc%20123%C3%B8%2f/parent/..//test/./
+--- response_body
+merged: /t/Abc 123ø%2F/test/
+un-merged: /t/Abc 123ø%2F//test/
+--- no_error_log
+[error]


### PR DESCRIPTION
This adds a PDK method for retrieving the normalized path component of the current downstream http request.

Most of the test cases were copy-pasted from `kong.request.get_path`, with a couple added to validate the correct behavior.

----
Internal tracking
[FT-2116]

[FT-2116]: https://konghq.atlassian.net/browse/FT-2116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ