### PR TITLE
perf(dbless) improve proxy long tail latency for DB-less reload [CT-321]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,8 @@ In this release we continued our work on better performance:
   [#7979](https://github.com/Kong/kong/pull/7979)
 - Simplified the Kong core context read and writes for better performance
   [#7919](https://github.com/Kong/kong/pull/7919)
+- Reduced proxy long tail latency while reloading DB-less config
+  [#8133](https://github.com/Kong/kong/pull/8133)
 
 ### Plugins
 

--- a/kong/router.lua
+++ b/kong/router.lua
@@ -31,6 +31,7 @@ local type          = type
 local max           = math.max
 local band          = bit.band
 local bor           = bit.bor
+local yield         = require("kong.tools.utils").yield
 
 -- limits regex degenerate times to the low miliseconds
 local REGEX_PREFIX  = "(*LIMIT_MATCH=10000)"
@@ -1344,6 +1345,7 @@ function _M.new(routes)
     local marshalled_routes = {}
 
     for i = 1, #routes do
+      yield(true)
 
       local route = utils.deep_copy(routes[i], false)
       local paths = utils.deep_copy(route.route.paths, false)
@@ -1386,6 +1388,8 @@ function _M.new(routes)
     sort(marshalled_routes, sort_routes)
 
     for i = 1, #marshalled_routes do
+      yield(true)
+
       local route_t = marshalled_routes[i]
 
       categorize_route_t(route_t, route_t.match_rules, categories)
@@ -1418,12 +1422,16 @@ function _M.new(routes)
     categories_lookup[c.category_bit] = i
   end
 
+  yield()
+
   -- the number of categories to iterate on for this instance of the router
   local categories_len = #categories_weight_sorted
 
   sort(prefix_uris, sort_uris)
 
   for _, category in pairs(categories) do
+    yield()
+
     for _, routes in pairs(category.routes_by_sources) do
       sort(routes, sort_sources)
     end

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -35,6 +35,8 @@ local gsub          = string.gsub
 local split         = pl_stringx.split
 local re_find       = ngx.re.find
 local re_match      = ngx.re.match
+local get_phase     = ngx.get_phase
+local ngx_sleep     = ngx.sleep
 local inflate_gzip  = zlib.inflateGzip
 local deflate_gzip  = zlib.deflateGzip
 local stringio_open = pl_stringio.open
@@ -60,6 +62,7 @@ char *strerror(int errnum);
 ]]
 
 local _M = {}
+local YIELD_ITERATIONS = 500
 
 --- splits a string.
 -- just a placeholder to the penlight `pl.stringx.split` function
@@ -1422,5 +1425,26 @@ local topological_sort do
   end
 end
 _M.topological_sort = topological_sort
+
+
+do
+  local counter = 0
+  function _M.yield(in_loop)
+    if get_phase() ~= "init" then
+      if in_loop then
+        counter = counter + 1
+        if counter % YIELD_ITERATIONS == 0 then
+          counter = 0
+          ngx_sleep(0)
+        end
+
+        return
+      end
+
+      ngx_sleep(0)
+    end
+  end
+end
+
 
 return _M

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -1429,20 +1429,19 @@ _M.topological_sort = topological_sort
 
 do
   local counter = 0
-  function _M.yield(in_loop)
-    if get_phase() ~= "init" then
-      if in_loop then
-        counter = counter + 1
-        if counter % YIELD_ITERATIONS == 0 then
-          counter = 0
-          ngx_sleep(0)
-        end
-
+  function _M.yield(in_loop, phase)
+    phase = phase or get_phase()
+    if phase == "init" or phase == "init_worker"  then
+      return
+    end
+    if in_loop then
+      counter = counter + 1
+      if counter % YIELD_ITERATIONS ~= 0 then
         return
       end
-
-      ngx_sleep(0)
+      counter = 0
     end
+    ngx_sleep(0)
   end
 end
 


### PR DESCRIPTION
Previously, when a large DB-less config is processed by Kong, Kong will
be CPU bound when parsing/validating the config and rebuilding the router.
This could cause undesirable proxy latency behavior during reloads.

This PR introduces periodic yielding points so that reload tasks no
longer hogs the CPU until reload completely finishes. Request processing
will be able to continue even while DB-less reload and router rebuild is
happening.

CT-321