### PR TITLE
chore(deps) bump resty.openssl to from 0.8.1 to 0.8.2

### DIFF
--- a/kong-2.6.0-0.rockspec
+++ b/kong-2.6.0-0.rockspec
@@ -36,7 +36,7 @@ dependencies = {
   "lua-resty-healthcheck == 1.4.2",
   "lua-resty-mlcache == 2.5.0",
   "lua-messagepack == 0.5.2",
-  "lua-resty-openssl == 0.8.1",
+  "lua-resty-openssl == 0.8.2",
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6.1",
   "lua-resty-acme == 0.7.2",


### PR DESCRIPTION
### Summary

- **jwk:** fix typo of secp521r1 [81d2a64](https://github.com/fffonion/lua-resty-openssl/commit/81d2a646bde7a66ab87e127eace0d40aa714be58)
