### PR TITLE
fix(declarative) change default back to false skip_ws

### DIFF
--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -478,7 +478,7 @@ function declarative.export_from_db(fd, skip_ws, skip_disabled_entities)
   -- not sure if this really useful for skip_ws,
   -- but I want to allow skip_disabled_entities and would rather have consistant interface
   if skip_ws == nil then
-    skip_ws = true
+    skip_ws = false
   end
 
   if skip_disabled_entities == nil then 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

declarative.export_from_db skip_ws was inadvertently changed to true in https://github.com/Kong/kong/pull/8113
 

### Full changelog

declarative.export_from_db skip_ws default set back to false

### Issues resolved

Tests break in ee without this.

Fix #XXX
