### PR TITLE
fix(router) properly escape uri captures

### DIFF
--- a/kong/router.lua
+++ b/kong/router.lua
@@ -7,6 +7,7 @@ local bit           = require "bit"
 
 local hostname_type = utils.hostname_type
 local normalize     = require("kong.tools.uri").normalize
+local escape        = require("kong.tools.uri").escape
 local subsystem     = ngx.config.subsystem
 local get_method    = ngx.req.get_method
 local get_headers   = ngx.req.get_headers
@@ -749,7 +750,7 @@ local function sort_routes(r1, r2)
     end
   end
 
-  -- only regex path use regex_priority 
+  -- only regex path use regex_priority
   if band(r1.submatch_weight,MATCH_SUBRULES.HAS_REGEX_URI) ~= 0 then
     do
       local rp1 = r1.route.regex_priority or 0
@@ -1015,6 +1016,10 @@ do
               ctx.matches.uri_postfix = uri_postfix
 
               if uri_t.has_captures then
+                for k, v in pairs(m) do
+                  m[k] = escape(v)
+                end
+
                 ctx.matches.uri_captures = m
               end
 


### PR DESCRIPTION
### Summary

When we added normalization `kong.tools.uri.normalize`, that function does percent-decoding on everything, except for the reserved characters.

That means that we basically percent-decode more than just the ranges of ALPHA (%41–%5A and %61–%7A), DIGIT (%30–%39), hyphen (%2D), period (%2E), underscore (%5F), or tilde (%7E).

Which is fine for matching (as we run both inputs through it). Though calling it `normalize` is wrong, but that is another issue.

Because of doing excessive percent-decoding, we endup things leaking from there. One of the leakeage is uri captures that now contain the captures based on our raw normalization.

This commit adds escaping to uri captures, and should fix the leak.

Alternative to this is to not percent-decode the chars outside the ones specified above.

### Issues resolved

Fix #7913, FTI-2904

### Alternative and Better Implementation

See #8140