### PR TITLE
fix(balancer) avoid using nil hash-value

### DIFF
--- a/kong/runloop/balancer/init.lua
+++ b/kong/runloop/balancer/init.lua
@@ -212,7 +212,7 @@ local function execute(balancer_data, ctx)
       -- only add it if it doesn't exist, in case a plugin inserted one
       hash_value = balancer_data.hash_value
       if not hash_value then
-        hash_value = get_value_to_hash(upstream, ctx)
+        hash_value = get_value_to_hash(upstream, ctx) or ""
         balancer_data.hash_value = hash_value
       end
 

--- a/spec/02-integration/05-proxy/10-balancer/03-consistent-hashing_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer/03-consistent-hashing_spec.lua
@@ -69,6 +69,43 @@ for _, strategy in helpers.each_strategy() do
           assert(count1.total + count2.total == requests)
         end)
 
+        it("hashing on missing header", function()
+          local requests = bu.SLOTS * 2 -- go round the balancer twice
+
+          bu.begin_testcase_setup(strategy, bp)
+          local upstream_name, upstream_id = bu.add_upstream(bp, {
+            hash_on = "header",
+            hash_on_header = "hashme",
+          })
+          local port1 = bu.add_target(bp, upstream_id, localhost)
+          local port2 = bu.add_target(bp, upstream_id, localhost)
+          local api_host = bu.add_api(bp, upstream_name)
+          bu.end_testcase_setup(strategy, bp)
+
+          -- setup target servers
+          local server1 = https_server.new(port1, localhost)
+          local server2 = https_server.new(port2, localhost)
+          server1:start()
+          server2:start()
+
+          -- Go hit them with our test requests
+          local oks = bu.client_requests(requests, {
+            ["Host"] = api_host,
+            ["nothashme"] = "just a value",
+          })
+          assert.are.equal(requests, oks)
+
+          -- collect server results; hitcount
+          -- one should get all the hits, the other 0
+          local count1 = server1:shutdown()
+          local count2 = server2:shutdown()
+
+          -- verify
+          assert(count1.total == 0 or count1.total == requests, "counts should either get 0 or ALL hits")
+          assert(count2.total == 0 or count2.total == requests, "counts should either get 0 or ALL hits")
+          assert(count1.total + count2.total == requests)
+        end)
+
         describe("hashing on cookie", function()
           it("does not reply with Set-Cookie if cookie is already set", function()
             bu.begin_testcase_setup(strategy, bp)


### PR DESCRIPTION
When the field set to be used for hashing is not found, the balancer will use an empty string to avoid that the selected balancing algorithm tries to hash a nil value.

This PR rebases the fix targeted to 2.7 (#8141) to `release/2.6.x` branch.