### PR TITLE
tests(least-connections) increase test precision

### DIFF
--- a/spec/02-integration/05-proxy/10-balancer/02-least-connections_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer/02-least-connections_spec.lua
@@ -64,7 +64,7 @@ for _, strategy in helpers.each_strategy() do
     it("balances by least-connections", function()
       server1:start()
       server2:start()
-      local thread_max = 50 -- maximum number of threads to use
+      local thread_max = 100 -- maximum number of threads to use
       local done = false
       local threads = {}
 
@@ -91,7 +91,7 @@ for _, strategy in helpers.each_strategy() do
       -- wait while we're executing
       local finish_at = ngx.now() + 1.5
       repeat
-        ngx.sleep(0.1)
+        ngx.sleep(0.01)
       until ngx.now() >= finish_at
 
       -- finish up


### PR DESCRIPTION
With 50 threads testing the least-connections algorithm this test was flaky, sometimes the number of parallel requests were not enough.
