### PR TITLE
[DOCU-2074] Add enabled param to Admin API

### DIFF
--- a/autodoc/admin-api/data/admin-api.lua
+++ b/autodoc/admin-api/data/admin-api.lua
@@ -819,6 +819,12 @@ return {
             If set to `null`, then the Nginx default is respected.
           ]],
         },
+        enabled = {
+          description = [[
+            Whether the Service is active. If set to `false`, the proxy behavior 
+            will be as if any routes attached to it do not exist (404). Default: `true`. 
+          ]],
+        },
         ca_certificates = {
           description = [[
             Array of `CA Certificate` object UUIDs that are used to build the trust store


### PR DESCRIPTION
Add the `enabled` boolean param to Admin API.

Closes [DOCU-2074](https://konghq.atlassian.net/browse/DOCU-2074) and [TDX-1675](https://konghq.atlassian.net/browse/TDX-1675)