### PR TITLE
autodocs(upgrade) Update filename for upgrade guide on docs site

### DIFF
--- a/scripts/autodoc
+++ b/scripts/autodoc
@@ -155,8 +155,8 @@ fi
 copy autodoc/output/admin-api/admin-api.md "$DOCS_APP/admin-api.md"
 copy autodoc/output/cli.md "$DOCS_APP/reference/cli.md"
 
-rm -rf "$DOCS_APP/install-and-run/upgrading.md"
-copy autodoc/output/upgrading.md "$DOCS_APP/install-and-run/upgrading.md"
+rm -rf "$DOCS_APP/install-and-run/upgrade-oss.md"
+copy autodoc/output/upgrading.md "$DOCS_APP/install-and-run/upgrade-oss.md"
 
 rm -rf "$DOCS_APP/pdk/"
 mkdir -p "$DOCS_APP/pdk"


### PR DESCRIPTION
### Summary

Updating the output filename for the generated upgrade guide.

The filename had to be changed since we need two separate pages for Enterprise and open-source gateway upgrades. This is the new page location: https://docs.konghq.com/gateway/2.6.x/install-and-run/upgrade-oss/

### Full changelog

N/A

### Issues resolved

Guide was being generated into the wrong file.
