### PR TITLE
Fix dns client semaphose phases

### DIFF
--- a/kong/resty/dns/client.lua
+++ b/kong/resty/dns/client.lua
@@ -832,6 +832,8 @@ local function syncQuery(qname, r_opts, try_list, count)
     access = true,
     content = true,
     timer = true,
+    ssl_cert = true,
+    ssl_session_fetch = true,
   }
 
   local ngx_phase = get_phase()


### PR DESCRIPTION
`ssl_cert` and `ssl_session_fetch` can both yield, but were missing from
the supported list. Without this, a client running in one of these
phases may fail to resolve unexpectedly.

https://github.com/Kong/lua-resty-dns-client/commit/e723618cd268b42ff51d36a5b3a1bec6e1b431f3

This fix connection issues with the kong ee mtls-auth plugin.