### PR TITLE
feature: add perf flame graph opts for local/terraform

### DIFF
--- a/spec/helpers/perf.lua
+++ b/spec/helpers/perf.lua
@@ -111,7 +111,7 @@ local _M = {
 --- Start the upstream (nginx) with given conf
 -- @function start_upstream
 -- @param conf string the Nginx nginx snippet under server{} context
--- @return upstream_uri as string or table if port_count is more than 1
+-- @return upstream_uri as string
 function _M.start_upstream(conf)
   return invoke_driver("start_upstreams", conf, 1)[1]
 end

--- a/spec/helpers/perf.lua
+++ b/spec/helpers/perf.lua
@@ -345,15 +345,17 @@ end
 
 --- Generate the flamegraph and return SVG
 -- @function generate_flamegraph
+-- @param title the title for flamegraph
+-- @param opts the command line options string(not table) for flamegraph.pl
 -- @return Nothing. Throws an error if any.
-function _M.generate_flamegraph(filename, title)
+function _M.generate_flamegraph(filename, title, opts)
   if not filename then
     error("filename must be specified for generate_flamegraph")
   end
   if string.sub(filename, #filename-3, #filename):lower() ~= ".svg" then
     filename = filename .. ".svg"
   end
-  
+
   if not title then
     title = "Flame graph"
   end
@@ -364,7 +366,7 @@ function _M.generate_flamegraph(filename, title)
     title = title .. " (based on " .. git.get_kong_version() .. ")"
   end
 
-  local out = invoke_driver("generate_flamegraph", title)
+  local out = invoke_driver("generate_flamegraph", title, opts)
 
   local f, err = io.open(filename, "w")
   if not f then

--- a/spec/helpers/perf/drivers/local.lua
+++ b/spec/helpers/perf/drivers/local.lua
@@ -228,7 +228,7 @@ function _M:get_wait_stapxx_cmd(timeout)
   return "lsmod | grep stap_"
 end
 
-function _M:generate_flamegraph(title)
+function _M:generate_flamegraph(title, opts)
   local path = self.systemtap_dest_path
   self.systemtap_dest_path = nil
 
@@ -241,7 +241,7 @@ function _M:generate_flamegraph(title)
   local cmds = {
     "/tmp/perf-ost/fix-lua-bt " .. path .. ".bt > " .. path .. ".fbt",
     "/tmp/perf-fg/stackcollapse-stap.pl " .. path .. ".fbt > " .. path .. ".cbt",
-    "/tmp/perf-fg/flamegraph.pl --title='" .. title .. "' " .. path .. ".cbt > " .. path .. ".svg",
+    "/tmp/perf-fg/flamegraph.pl --title='" .. title .. "' " .. (opts or "") .. " " .. path .. ".cbt > " .. path .. ".svg",
     "cat " .. path .. ".svg",
   }
   local out, err

--- a/spec/helpers/perf/drivers/terraform.lua
+++ b/spec/helpers/perf/drivers/terraform.lua
@@ -415,7 +415,7 @@ function _M:get_wait_stapxx_cmd(timeout)
   return ssh_execute_wrap(self, self.kong_ip, "lsmod | grep stap_")
 end
 
-function _M:generate_flamegraph(title)
+function _M:generate_flamegraph(title, opts)
   local path = self.systemtap_dest_path
   self.systemtap_dest_path = nil
 
@@ -427,7 +427,7 @@ function _M:generate_flamegraph(title)
   local ok, err = execute_batch(self, self.kong_ip, {
     "/tmp/perf-ost/fix-lua-bt " .. path .. ".bt > " .. path .. ".fbt",
     "/tmp/perf-fg/stackcollapse-stap.pl " .. path .. ".fbt > " .. path .. ".cbt",
-    "/tmp/perf-fg/flamegraph.pl --title='" .. title .. "' " .. path .. ".cbt > " .. path .. ".svg",
+    "/tmp/perf-fg/flamegraph.pl --title='" .. title .. "' " .. (opts or "") .. " " .. path .. ".cbt > " .. path .. ".svg",
   })
   if not ok then
     return false, err

--- a/spec/helpers/perf/utils.lua
+++ b/spec/helpers/perf/utils.lua
@@ -46,7 +46,7 @@ local function execute(cmd, opts)
     local l, err = proc:stdout_read_line()
     if l then
       if log_output then
-        opts.logger(l)
+        log_output(l)
       else
         table.insert(ret, l)
       end

--- a/spec/helpers/perf/utils.lua
+++ b/spec/helpers/perf/utils.lua
@@ -12,7 +12,7 @@ end
 --- Spawns a child process and get its exit code and outputs
 -- @param opts.stdin string the stdin buffer
 -- @param opts.logger function(lvl, _, line) stdout+stderr writer; if not defined, whole
--- stdoud and stderr is returned
+-- stdout and stderr is returned
 -- @param opts.stop_signal function return true to abort execution
 -- @return stdout+stderr, err if opts.logger not set; bool+err if opts.logger set
 local function execute(cmd, opts)


### PR DESCRIPTION

### Summary

Add options for generate flame graph in perf.lua,
So we can use options like '--inverted --color aqua'.

It also has some code clean and typofix.

### Full changelog

* add param opts in  generate_flamegraph()
* change flamegraph cmd string in generate_flamegraph()
* some code clean
* minor typofix

