### PR TITLE
optimize(pdk) use string.byte to avoid lj_str_new overhead

### DIFF
--- a/kong/pdk/service/request.lua
+++ b/kong/pdk/service/request.lua
@@ -15,6 +15,7 @@ local table_concat = table.concat
 local type = type
 local string_find = string.find
 local string_sub = string.sub
+local string_byte = string.byte
 local string_lower = string.lower
 local normalize_header = checks.normalize_header
 local normalize_multi_header = checks.normalize_multi_header
@@ -141,7 +142,8 @@ local function new(self)
       error("path must be a string", 2)
     end
 
-    if string_sub(path, 1, 1) ~= "/" then
+    -- 47 = 0x2f = '/'
+    if string_byte(path) ~= 47 then
       error("path must start with /", 2)
     end
 

--- a/kong/pdk/service/request.lua
+++ b/kong/pdk/service/request.lua
@@ -77,6 +77,7 @@ local function new(self)
   local CONTENT_TYPE_JSON      = "application/json"
   local CONTENT_TYPE_FORM_DATA = "multipart/form-data"
 
+  local SLASH                  = string_byte("/")
 
   ---
   -- Enables buffered proxying that allows plugins to access service body and
@@ -142,8 +143,7 @@ local function new(self)
       error("path must be a string", 2)
     end
 
-    -- 47 = 0x2f = '/'
-    if string_byte(path) ~= 47 then
+    if string_byte(path) ~= SLASH then
       error("path must start with /", 2)
     end
 

--- a/spec/helpers/perf/utils.lua
+++ b/spec/helpers/perf/utils.lua
@@ -12,7 +12,7 @@ end
 --- Spawns a child process and get its exit code and outputs
 -- @param opts.stdin string the stdin buffer
 -- @param opts.logger function(lvl, _, line) stdout+stderr writer; if not defined, whole
--- stdoud and stderr is returned
+-- stdout and stderr is returned
 -- @param opts.stop_signal function return true to abort execution
 -- @return stdout+stderr, err if opts.logger not set; bool+err if opts.logger set
 local function execute(cmd, opts)


### PR DESCRIPTION


### Summary

Optimize pdk request.lua with string.byte,
It will avoid  lj_str_new temp string overhead

### Full changelog

* add local string_byte = string.byte
* change request.set_path, replace string.sub to string.byte


