### PR TITLE
chore(rate-limiting) bump plugin version

### DIFF
--- a/kong/clustering/compat/removed_fields.lua
+++ b/kong/clustering/compat/removed_fields.lua
@@ -52,5 +52,14 @@ return {
       "echo",
       "trigger",
     },
-  }
+  },
+
+  -- Any dataplane older than 2.7.0
+  [2006999999] = {
+    rate_limiting = {
+      "redis_ssl",
+      "redis_ssl_verify",
+      "redis_server_name",
+    },
+  },
 }

--- a/kong/plugins/rate-limiting/handler.lua
+++ b/kong/plugins/rate-limiting/handler.lua
@@ -47,7 +47,7 @@ local RateLimitingHandler = {}
 
 
 RateLimitingHandler.PRIORITY = 901
-RateLimitingHandler.VERSION = "2.2.2"
+RateLimitingHandler.VERSION = "2.3.0"
 
 
 local function get_identifier(conf)

--- a/spec/01-unit/19-hybrid/03-fields-removal_spec.lua
+++ b/spec/01-unit/19-hybrid/03-fields-removal_spec.lua
@@ -58,6 +58,11 @@ describe("kong.clustering.control_plane", function()
         "echo",
         "trigger",
       },
+      rate_limiting = {
+        "redis_ssl",
+        "redis_ssl_verify",
+        "redis_server_name",
+      },
     }, cp._get_removed_fields(2003000000))
 
     assert.same({
@@ -80,6 +85,11 @@ describe("kong.clustering.control_plane", function()
       request_termination = {
         "echo",
         "trigger",
+      },
+      rate_limiting = {
+        "redis_ssl",
+        "redis_ssl_verify",
+        "redis_server_name",
       },
     }, cp._get_removed_fields(2003003003))
 
@@ -104,6 +114,11 @@ describe("kong.clustering.control_plane", function()
         "echo",
         "trigger",
       },
+      rate_limiting = {
+        "redis_ssl",
+        "redis_ssl_verify",
+        "redis_server_name",
+      },
     }, cp._get_removed_fields(2003004000))
 
     assert.same({
@@ -127,6 +142,11 @@ describe("kong.clustering.control_plane", function()
         "echo",
         "trigger",
       },
+      rate_limiting = {
+        "redis_ssl",
+        "redis_ssl_verify",
+        "redis_server_name",
+      },
     }, cp._get_removed_fields(2004001000))
 
     assert.same({
@@ -139,6 +159,11 @@ describe("kong.clustering.control_plane", function()
       request_termination = {
         "echo",
         "trigger",
+      },
+      rate_limiting = {
+        "redis_ssl",
+        "redis_ssl_verify",
+        "redis_server_name",
       },
     }, cp._get_removed_fields(2004001002))
 
@@ -153,9 +178,22 @@ describe("kong.clustering.control_plane", function()
         "echo",
         "trigger",
       },
+      rate_limiting = {
+        "redis_ssl",
+        "redis_ssl_verify",
+        "redis_server_name",
+      },
     }, cp._get_removed_fields(2005000000))
 
-    assert.same(nil, cp._get_removed_fields(2006000000))
+    assert.same({
+      rate_limiting = {
+        "redis_ssl",
+        "redis_ssl_verify",
+        "redis_server_name",
+      },
+    }, cp._get_removed_fields(2006000000))
+
+    assert.same(nil, cp._get_removed_fields(2007000000))
   end)
 
   it("removing unknown fields", function()


### PR DESCRIPTION
Add new rate-limiting fields to the list of excluded fields for older DPs compatibility.