### PR TITLE
perf(pdk) another string.byte to avoid lj_str_new overhead

### DIFF
--- a/kong/pdk/service/request.lua
+++ b/kong/pdk/service/request.lua
@@ -464,6 +464,8 @@ local function new(self)
 
 
   do
+    local QUOTE = string_byte('"')
+
     local set_body_handlers = {
 
       [CONTENT_TYPE_POST] = function(args, mime)
@@ -496,7 +498,7 @@ local function new(self)
         local at = string_find(mime, "boundary=", 1, true)
         if at then
           at = at + 9
-          if string_sub(mime, at, at) == '"' then
+          if string_byte(mime, at) == QUOTE then
             local till = string_find(mime, '"', at + 1, true)
             boundary = string_sub(mime, at + 1, till - 1)
           else


### PR DESCRIPTION
Summary
Optimize pdk request.lua with string.byte,
It will avoid lj_str_new temp string overhead
Same as PR #8168

Full changelog
change set_body_handlers[CONTENT_TYPE_FORM_DATA], replace string.sub to string.byte