### PR TITLE
Support TLS SNI custom dynamic configuration

### DIFF
--- a/kong/templates/nginx_kong_stream.lua
+++ b/kong/templates/nginx_kong_stream.lua
@@ -122,11 +122,9 @@ server {
     }
 > end
 
-    set $tls_sni_name 'kong_upstream';
     preread_by_lua_block {
         Kong.preread()
     }
-    proxy_ssl_name $tls_sni_name;
 
     proxy_ssl on;
     proxy_ssl_server_name on;

--- a/kong/templates/nginx_kong_stream.lua
+++ b/kong/templates/nginx_kong_stream.lua
@@ -121,10 +121,12 @@ server {
         Kong.ssl_certificate()
     }
 > end
-
+    
+    set $tls_sni_name 'kong_upstream';
     preread_by_lua_block {
         Kong.preread()
     }
+    proxy_ssl_name $tls_sni_name;
 
     proxy_ssl on;
     proxy_ssl_server_name on;

--- a/kong/templates/nginx_kong_stream.lua
+++ b/kong/templates/nginx_kong_stream.lua
@@ -122,9 +122,11 @@ server {
     }
 > end
 
+    set $tls_sni_name 'kong_upstream';
     preread_by_lua_block {
         Kong.preread()
     }
+    proxy_ssl_name $tls_sni_name;
 
     proxy_ssl on;
     proxy_ssl_server_name on;


### PR DESCRIPTION
### Summary

In version 2.6 0, unable to transparently transmit SNI when proxy TLS service

In this modification, you can customize the transparent dynamic TLS SNI name. If you need to customize it, you can configure it in the plug-in. The default name is the same as the original one,using kong_ upstream
