### PR TITLE
fix(ffi) make corrections on ffi declarations for macOS+M1

### DIFF
--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -158,10 +158,13 @@ function _M:init_worker()
 
     else
       -- CONFIG_CACHE does not exist, pre create one with 0600 permission
-      local fd = ffi.C.open(CONFIG_CACHE, bit.bor(system_constants.O_RDONLY(),
-                                                  system_constants.O_CREAT()),
-                                          bit.bor(system_constants.S_IRUSR(),
-                                                  system_constants.S_IWUSR()))
+      local flags = bit.bor(system_constants.O_RDONLY(),
+                            system_constants.O_CREAT())
+
+      local mode = ffi.new("int", bit.bor(system_constants.S_IRUSR(),
+                                          system_constants.S_IWUSR()))
+
+      local fd = ffi.C.open(CONFIG_CACHE, flags, mode)
       if fd == -1 then
         ngx_log(ngx_ERR, _log_prefix, "unable to pre-create cached config file: ",
                 ffi.string(ffi.C.strerror(ffi.errno())))

--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -35,10 +35,13 @@ local os = os
 
 
 local function pre_create_private_file(file)
-  local fd = ffi.C.open(file, bit.bor(system_constants.O_RDONLY(),
-                                      system_constants.O_CREAT()),
-                              bit.bor(system_constants.S_IRUSR(),
+  local flags = bit.bor(system_constants.O_RDONLY(),
+                        system_constants.O_CREAT())
+
+  local mode = ffi.new("int", bit.bor(system_constants.S_IRUSR(),
                                       system_constants.S_IWUSR()))
+
+  local fd = ffi.C.open(file, flags, mode)
   if fd == -1 then
     log.warn("unable to pre-create '", file ,"' file: ",
              ffi.string(ffi.C.strerror(ffi.errno())))
@@ -283,7 +286,7 @@ local function write_env_file(path, data)
   local c = require "lua_system_constants"
 
   local flags = bit.bor(c.O_CREAT(), c.O_WRONLY())
-  local mode  = bit.bor(c.S_IRUSR(), c.S_IWUSR(), c.S_IRGRP())
+  local mode = ffi.new("int", bit.bor(c.S_IRUSR(), c.S_IWUSR(), c.S_IRGRP()))
 
   local fd = ffi.C.open(path, flags, mode)
   if fd < 0 then

--- a/kong/plugins/file-log/handler.lua
+++ b/kong/plugins/file-log/handler.lua
@@ -1,4 +1,7 @@
 -- Copyright (C) Kong Inc.
+require "kong.tools.utils" -- ffi.cdefs
+
+
 local ffi = require "ffi"
 local cjson = require "cjson"
 local system_constants = require "lua_system_constants"
@@ -18,7 +21,7 @@ local S_IROTH = system_constants.S_IROTH()
 
 
 local oflags = bit.bor(O_WRONLY, O_CREAT, O_APPEND)
-local mode = bit.bor(S_IRUSR, S_IWUSR, S_IRGRP, S_IROTH)
+local mode = ffi.new("int", bit.bor(S_IRUSR, S_IWUSR, S_IRGRP, S_IROTH))
 
 
 local sandbox_opts = { env = { kong = kong, ngx = ngx } }
@@ -27,15 +30,10 @@ local sandbox_opts = { env = { kong = kong, ngx = ngx } }
 local C = ffi.C
 
 
-ffi.cdef [[
-int write(int fd, const void * ptr, int numbytes);
-]]
-
-
 -- fd tracking utility functions
 local file_descriptors = {}
 
--- Log to a file. 
+-- Log to a file.
 -- @param `conf`     Configuration table, holds http endpoint details
 -- @param `message`  Message to be logged
 local function log(conf, message)

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -54,7 +54,7 @@ void ERR_free_strings(void);
 
 const char *ERR_reason_error_string(unsigned long e);
 
-int open(const char * filename, int flags, int mode);
+int open(const char * filename, int flags, ...);
 size_t read(int fd, void *buf, size_t count);
 int write(int fd, const void *ptr, int numbytes);
 int close(int fd);


### PR DESCRIPTION
### Summary

Changes `ffi.cdef` for:
```
int open(const char * filename, int flags, int mode);
```
to correct one:
```
int open(const char * filename, int flags, ...);
```

The previous (wrong) declaration causes issues with macOS with M1.

There will be other related PRs on other repositories for better M1 support for Kong.

See also:
https://github.com/Kong/kong-build-tools/pull/427
https://github.com/Kong/lua-kong-nginx-module/pull/21