### PR TITLE
chore(certificate) remove a temporary arm64 workaround

### DIFF
--- a/kong/runloop/certificate.lua
+++ b/kong/runloop/certificate.lua
@@ -6,11 +6,6 @@ local new_tab = require "table.new"
 local openssl_x509_store = require "resty.openssl.x509.store"
 local openssl_x509 = require "resty.openssl.x509"
 
-if jit.arch == 'arm64' then
-  jit.off(mlcache.get_bulk)        -- "temporary" workaround for issue #5748 on ARM
-end
-
-
 
 local ngx_log     = ngx.log
 local ERR         = ngx.ERR


### PR DESCRIPTION
### Summary

This was originally fixed because of:
https://github.com/Kong/kong/issues/5748

It is fixed as seen here:
https://github.com/LuaJIT/LuaJIT/issues/579#issuecomment-623803502