### PR TITLE
fix(pdk) get_phases_names wrong lshift

### DIFF
--- a/kong/pdk/private/phases.lua
+++ b/kong/pdk/private/phases.lua
@@ -33,13 +33,12 @@ do
     t[k] = v
   end
 
-  local n = 0
   for k, v in pairs(t) do
-    n = n + 1
     PHASES[v] = k
   end
 
-  PHASES.n = n
+  -- max lshift limit, 2^30 = 0x40000000
+  PHASES.n = 30
 end
 
 


### PR DESCRIPTION

### Summary

PHASES.n means lshift times, but now it equals to 13, it is 0x2000，
but the max phases admin_api is 0x10000000,
so the function get_phases_names can not get the right name.

I change the PHASES.n to 30, then we can support the all phases bits.

### Full changelog

* change PHASES.n to 30, means 2^30 = 0x40000000


