### PR TITLE
chore(entities) adjust tags schema

### DIFF
--- a/kong/db/schema/entities/tags.lua
+++ b/kong/db/schema/entities/tags.lua
@@ -9,11 +9,7 @@ return {
 
   fields = {
     { tag          = typedefs.tag, },
-    { entity_name  = { type = "string", required = true, unique = false }, },
-    { entity_id    = { type = "string",
-                        elements = typedefs.uuid,
-                        unique = true,
-                        required = true }, },
-    }
-
+    { entity_name  = { type = "string", required = true }, },
+    { entity_id    = typedefs.uuid { required = true }, },
+  }
 }


### PR DESCRIPTION
### Summary

Yes, `tags` schema is kinda abstract, but it was a bit confusing for me to see a field with `type=string` and then having `elements` too. This commit just changes the schema to a bit less confusing.