### PR TITLE
chore(revert) re-add Redis username support

### DIFF
--- a/kong/plugins/rate-limiting/policies/init.lua
+++ b/kong/plugins/rate-limiting/policies/init.lua
@@ -79,7 +79,13 @@ local function get_redis_connection(conf)
 
   if times == 0 then
     if is_present(conf.redis_password) then
-      local ok, err = red:auth(conf.redis_password)
+      local ok, err
+      if is_present(conf.redis_username) then
+        ok, err = red:auth(conf.redis_username, conf.redis_password)
+      else
+        ok, err = red:auth(conf.redis_password)
+      end
+
       if not ok then
         kong.log.err("failed to auth Redis: ", err)
         return nil, err

--- a/kong/plugins/rate-limiting/policies/init.lua
+++ b/kong/plugins/rate-limiting/policies/init.lua
@@ -180,21 +180,35 @@ return {
         return nil, err
       end
 
+      local keys = {}
+      local expiration = {}
+      local idx = 0
       local periods = timestamp.get_timestamps(current_timestamp)
-      red:init_pipeline()
       for period, period_date in pairs(periods) do
         if limits[period] then
           local cache_key = get_local_key(conf, identifier, period, period_date)
+          local exists, err = red:exists(cache_key)
+          if err then
+            kong.log.err("failed to query Redis: ", err)
+            return nil, err
+          end
 
-          red:eval([[
-            local key, value, expiration = KEYS[1], tonumber(ARGV[1]), ARGV[2]
+          idx = idx + 1
+          keys[idx] = cache_key
+          if not exists or exists == 0 then
+            expiration[idx] = EXPIRATION[period]
+          end
 
-            if redis.call("incrby", key, value) == value then
-              redis.call("expire", key, expiration)
+          red:init_pipeline()
+          for i = 1, idx do
+            red:incrby(keys[i], value)
+            if expiration[i] then
+              red:expire(keys[i], expiration[i])
             end
-          ]], 1, cache_key, value, EXPIRATION[period])
+          end
         end
       end
+
       local _, err = red:commit_pipeline()
       if err then
         kong.log.err("failed to commit increment pipeline in Redis: ", err)

--- a/kong/plugins/rate-limiting/schema.lua
+++ b/kong/plugins/rate-limiting/schema.lua
@@ -84,6 +84,7 @@ return {
           { redis_host = typedefs.host },
           { redis_port = typedefs.port({ default = 6379 }), },
           { redis_password = { type = "string", len_min = 0 }, },
+          { redis_username = { type = "string" }, },
           { redis_ssl = { type = "boolean", required = true, default = false, }, },
           { redis_ssl_verify = { type = "boolean", required = true, default = false }, },
           { redis_server_name = typedefs.sni },

--- a/spec/03-plugins/23-rate-limiting/05-integration_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/05-integration_spec.lua
@@ -1,51 +1,49 @@
 local helpers = require "spec.helpers"
 local redis = require "resty.redis"
+local version = require "version"
 
 
 local REDIS_HOST = helpers.redis_host
 local REDIS_PORT = 6379
 local REDIS_DB_1 = 1
 local REDIS_DB_2 = 2
-
+local REDIS_DB_3 = 3
+local REDIS_DB_4 = 4
 
 local REDIS_USER_VALID = "ratelimit-user"
 local REDIS_USER_INVALID = "some-user"
 local REDIS_PASSWORD = "secret"
 
-
 local SLEEP_TIME = 1
 
-
-local function flush_redis(db)
+local function redis_connect()
   local red = redis:new()
   red:set_timeout(2000)
   assert(red:connect(REDIS_HOST, REDIS_PORT))
+  local red_version = string.match(red:info(), 'redis_version:([%g]+)\r\n')
+  return red, assert(version(red_version))
+end
+
+local function flush_redis(red, db)
   assert(red:select(db))
   red:flushall()
-  red:close()
 end
 
-local function add_redis_user()
-  local red = redis:new()
-  red:set_timeout(2000)
-  assert(red:connect(REDIS_HOST, REDIS_PORT))
-  assert(red:acl("setuser", REDIS_USER_VALID, "on", "allkeys", "+incrby", "+select", "+info", "+expire", "+get", ">" .. REDIS_PASSWORD))
+local function add_redis_user(red)
+  assert(red:acl("setuser", REDIS_USER_VALID, "on", "allkeys", "+incrby", "+select", "+info", "+expire", "+get", "+exists", ">" .. REDIS_PASSWORD))
   assert(red:acl("setuser", REDIS_USER_INVALID, "on", "allkeys", "+get", ">" .. REDIS_PASSWORD))
-  red:close()
 end
 
-local function remove_redis_user()
-  local red = redis:new()
-  red:set_timeout(2000)
-  assert(red:connect(REDIS_HOST, REDIS_PORT))
+local function remove_redis_user(red)
   assert(red:acl("deluser", REDIS_USER_VALID))
   assert(red:acl("deluser", REDIS_USER_INVALID))
-  red:close()
 end
 
 describe("Plugin: rate-limiting (integration)", function()
   local client
   local bp
+  local red
+  local red_version
 
   lazy_setup(function()
     bp = helpers.get_db_utils(nil, {
@@ -55,11 +53,15 @@ describe("Plugin: rate-limiting (integration)", function()
     }, {
       "rate-limiting"
     })
+    red, red_version = redis_connect()
   end)
 
   lazy_teardown(function()
     if client then
       client:close()
+    end
+    if red then
+      red:close()
     end
 
     helpers.stop_kong()
@@ -70,9 +72,12 @@ describe("Plugin: rate-limiting (integration)", function()
     -- https://github.com/Kong/kong/issues/3292
 
     lazy_setup(function()
-      flush_redis(REDIS_DB_1)
-      flush_redis(REDIS_DB_2)
-      add_redis_user()
+      flush_redis(red, REDIS_DB_1)
+      flush_redis(red, REDIS_DB_2)
+      flush_redis(red, REDIS_DB_3)
+      if red_version >= version("6.0.0") then
+        add_redis_user(red)
+      end
 
       local route1 = assert(bp.routes:insert {
         hosts        = { "redistest1.com" },
@@ -106,41 +111,43 @@ describe("Plugin: rate-limiting (integration)", function()
         }
       })
 
-      local route3 = assert(bp.routes:insert {
-        hosts        = { "redistest3.com" },
-      })
-      assert(bp.plugins:insert {
-        name = "rate-limiting",
-        route = { id = route3.id },
-        config = {
-          minute         = 1,
-          policy         = "redis",
-          redis_host     = REDIS_HOST,
-          redis_port     = REDIS_PORT,
-          redis_username = REDIS_USER_VALID,
-          redis_password = REDIS_PASSWORD,
-          redis_database = 3, -- ensure to not get a pooled authenticated connection by using a different db
-          fault_tolerant = false,
-        }
-      })
+      if red_version >= version("6.0.0") then
+        local route3 = assert(bp.routes:insert {
+          hosts        = { "redistest3.com" },
+        })
+        assert(bp.plugins:insert {
+          name = "rate-limiting",
+          route = { id = route3.id },
+          config = {
+            minute         = 2, -- Handle multiple tests
+            policy         = "redis",
+            redis_host     = REDIS_HOST,
+            redis_port     = REDIS_PORT,
+            redis_username = REDIS_USER_VALID,
+            redis_password = REDIS_PASSWORD,
+            redis_database = REDIS_DB_3, -- ensure to not get a pooled authenticated connection by using a different db
+            fault_tolerant = false,
+          }
+        })
 
-      local route4 = assert(bp.routes:insert {
-        hosts        = { "redistest4.com" },
-      })
-      assert(bp.plugins:insert {
-        name = "rate-limiting",
-        route = { id = route4.id },
-        config = {
-          minute         = 1,
-          policy         = "redis",
-          redis_host     = REDIS_HOST,
-          redis_port     = REDIS_PORT,
-          redis_username = REDIS_USER_INVALID,
-          redis_password = REDIS_PASSWORD,
-          redis_database = 4, -- ensure to not get a pooled authenticated connection by using a different db                  
-          fault_tolerant = false,
-        }
-      })
+        local route4 = assert(bp.routes:insert {
+          hosts        = { "redistest4.com" },
+        })
+        assert(bp.plugins:insert {
+          name = "rate-limiting",
+          route = { id = route4.id },
+          config = {
+            minute         = 1,
+            policy         = "redis",
+            redis_host     = REDIS_HOST,
+            redis_port     = REDIS_PORT,
+            redis_username = REDIS_USER_INVALID,
+            redis_password = REDIS_PASSWORD,
+            redis_database = REDIS_DB_4, -- ensure to not get a pooled authenticated connection by using a different db
+            fault_tolerant = false,
+          }
+        })
+      end
 
 
       assert(helpers.start_kong({
@@ -150,21 +157,12 @@ describe("Plugin: rate-limiting (integration)", function()
     end)
 
     lazy_teardown(function()
-      remove_redis_user()
+      if red_version >= version("6.0.0") then
+        remove_redis_user(red)
+      end
     end)
 
     it("connection pool respects database setting", function()
-      local red = redis:new()
-      red:set_timeout(2000)
-
-      finally(function()
-        if red then
-          red:close()
-        end
-      end)
-
-      assert(red:connect(REDIS_HOST, REDIS_PORT))
-
       assert(red:select(REDIS_DB_1))
       local size_1 = assert(red:dbsize())
 
@@ -173,6 +171,11 @@ describe("Plugin: rate-limiting (integration)", function()
 
       assert.equal(0, tonumber(size_1))
       assert.equal(0, tonumber(size_2))
+      if red_version >= version("6.0.0") then
+        assert(red:select(REDIS_DB_3))
+        local size_3 = assert(red:dbsize())
+        assert.equal(0, tonumber(size_3))
+      end
 
       local res = assert(client:send {
         method = "GET",
@@ -193,10 +196,15 @@ describe("Plugin: rate-limiting (integration)", function()
       assert(red:select(REDIS_DB_2))
       size_2 = assert(red:dbsize())
 
-      -- TEST: DB 1 should now have one hit, DB 2 none
+      -- TEST: DB 1 should now have one hit, DB 2 and 3 none
 
       assert.equal(1, tonumber(size_1))
       assert.equal(0, tonumber(size_2))
+      if red_version >= version("6.0.0") then
+        assert(red:select(REDIS_DB_3))
+        local size_3 = assert(red:dbsize())
+        assert.equal(0, tonumber(size_3))
+      end
 
       -- rate-limiting plugin will reuses the redis connection
       local res = assert(client:send {
@@ -218,34 +226,80 @@ describe("Plugin: rate-limiting (integration)", function()
       assert(red:select(REDIS_DB_2))
       size_2 = assert(red:dbsize())
 
-      -- TEST: Both DBs should now have one hit, because the
-      -- plugin correctly chose to select the database it is
-      -- configured to hit
+      -- TEST: DB 1 and 2 should now have one hit, DB 3 none
 
       assert.equal(1, tonumber(size_1))
       assert.equal(1, tonumber(size_2))
+      if red_version >= version("6.0.0") then
+        assert(red:select(REDIS_DB_3))
+        local size_3 = assert(red:dbsize())
+        assert.equal(0, tonumber(size_3))
+      end
+
+      if red_version >= version("6.0.0") then
+        -- rate-limiting plugin will reuses the redis connection
+        local res = assert(client:send {
+          method = "GET",
+          path = "/status/200",
+          headers = {
+            ["Host"] = "redistest3.com"
+          }
+        })
+        assert.res_status(200, res)
+
+        -- Wait for async timer to increment the limit
+
+        ngx.sleep(SLEEP_TIME)
+
+        assert(red:select(REDIS_DB_1))
+        size_1 = assert(red:dbsize())
+
+        assert(red:select(REDIS_DB_2))
+        size_2 = assert(red:dbsize())
+
+        assert(red:select(REDIS_DB_3))
+        local size_3 = assert(red:dbsize())
+
+        -- TEST: All DBs should now have one hit, because the
+        -- plugin correctly chose to select the database it is
+        -- configured to hit
+
+        assert.is_true(tonumber(size_1) > 0)
+        assert.is_true(tonumber(size_2) > 0)
+        assert.is_true(tonumber(size_3) > 0)
+      end
     end)
 
     it("authenticates and executes with a valid redis user having proper ACLs", function()
-      local res = assert(client:send {
-        method = "GET",
-        path = "/status/200",
-        headers = {
-          ["Host"] = "redistest3.com"
-        }
-      })
-      assert.res_status(200, res)
+      if red_version >= version("6.0.0") then
+        local res = assert(client:send {
+          method = "GET",
+          path = "/status/200",
+          headers = {
+            ["Host"] = "redistest3.com"
+          }
+        })
+        assert.res_status(200, res)
+      else
+        ngx.log(ngx.WARN, "Redis v" .. tostring(red_version) .. " does not support ACL functions " ..
+          "'authenticates and executes with a valid redis user having proper ACLs' will be skipped")
+      end
     end)
 
     it("fails to rate-limit for a redis user with missing ACLs", function()
-      local res = assert(client:send {
-        method = "GET",
-        path = "/status/200",
-        headers = {
-          ["Host"] = "redistest4.com"
-        }
-      })
-      assert.res_status(500, res)
+      if red_version >= version("6.0.0") then
+        local res = assert(client:send {
+          method = "GET",
+          path = "/status/200",
+          headers = {
+            ["Host"] = "redistest4.com"
+          }
+        })
+        assert.res_status(500, res)
+      else
+        ngx.log(ngx.WARN, "Redis v" .. tostring(red_version) .. " does not support ACL functions " ..
+          "'fails to rate-limit for a redis user with missing ACLs' will be skipped")
+      end
     end)
 
   end)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Re-adding `username` support for Redis connections; @27ascii contribution.

On top of reverting the removal of the `username` support, this PR fixes an issue with Redis increment eval query, adds Redis server version checking for the ACL tests added and adds a minimum supported Redis version; logs error if below minimum.

see https://github.com/Kong/kong/pull/8032 for original PR by @27ascii. 

### Full changelog

* Adds the optional property redis_username used for connecting to redis. This allows to make use of redis ACL features supported with Redis 6.0
* fix(plugin) correct Redis increment eval for ACL queries
