### PR TITLE
feat(plugin) add ACL configuration for response ratelimiting [FT-2189]

### DIFF
--- a/kong/plugins/response-ratelimiting/policies/init.lua
+++ b/kong/plugins/response-ratelimiting/policies/init.lua
@@ -21,7 +21,6 @@ local EXPIRATIONS = {
   year = 31536000,
 }
 
-
 local function is_present(str)
   return str and str ~= "" and str ~= null
 end
@@ -52,6 +51,56 @@ end
 
 
 local sock_opts = {}
+local function get_redis_connection(conf)
+  local red = redis:new()
+  red:set_timeout(conf.redis_timeout)
+
+  -- use a special pool name only if redis_database is set to non-zero
+  -- otherwise use the default pool name host:port
+  sock_opts.pool = conf.redis_database and
+                   conf.redis_host .. ":" .. conf.redis_port ..
+                   ":" .. conf.redis_database
+  local ok, err = red:connect(conf.redis_host, conf.redis_port,
+                              sock_opts)
+  if not ok then
+    kong.log.err("failed to connect to Redis: ", err)
+    return nil, err
+  end
+
+  local times, err = red:get_reused_times()
+  if err then
+    kong.log.err("failed to get connect reused times: ", err)
+    return nil, err
+  end
+
+  if times == 0 then
+    if is_present(conf.redis_password) then
+      local ok, err
+      if is_present(conf.redis_username) then
+        ok, err = red:auth(conf.redis_username, conf.redis_password)
+      else
+        ok, err = red:auth(conf.redis_password)
+      end
+      if not ok then
+        kong.log.err("failed to auth Redis: ", err)
+        return nil, err
+      end
+    end
+
+    if conf.redis_database ~= 0 then
+      -- Only call select first time, since we know the connection is shared
+      -- between instances that use the same redis database
+
+      local ok, err = red:select(conf.redis_database)
+      if not ok then
+        kong.log.err("failed to change Redis database: ", err)
+        return nil, err
+      end
+    end
+  end
+
+  return red
+end
 
 
 return {
@@ -122,51 +171,9 @@ return {
   },
   ["redis"] = {
     increment = function(conf, identifier, name, current_timestamp, value)
-      local red = redis:new()
-      red:set_timeout(conf.redis_timeout)
-
-      -- use a special pool name only if redis_database is set to non-zero
-      -- otherwise use the default pool name host:port
-      sock_opts.pool = conf.redis_database and
-                       conf.redis_host .. ":" .. conf.redis_port ..
-                       ":" .. conf.redis_database
-      local ok, err = red:connect(conf.redis_host, conf.redis_port,
-                                  sock_opts)
-      if not ok then
-        kong.log.err("failed to connect to Redis: ", err)
+      local red, err = get_redis_connection(conf)
+      if not red then
         return nil, err
-      end
-
-      local times, err = red:get_reused_times()
-      if err then
-        kong.log.err("failed to get connect reused times: ", err)
-        return nil, err
-      end
-
-      if times == 0 then
-        if is_present(conf.redis_password) then
-          local ok, err
-          if is_present(conf.redis_username) then
-            ok, err = red:auth(conf.redis_username, conf.redis_password)
-          else
-            ok, err = red:auth(conf.redis_password)
-          end
-          if not ok then
-            kong.log.err("failed to auth Redis: ", err)
-            return nil, err
-          end
-        end
-
-        if conf.redis_database ~= 0 then
-          -- Only call select first time, since we know the connection is shared
-          -- between instances that use the same redis database
-
-          local ok, err = red:select(conf.redis_database)
-          if not ok then
-            kong.log.err("failed to change Redis database: ", err)
-            return nil, err
-          end
-        end
       end
 
       local keys = {}
@@ -211,50 +218,9 @@ return {
       return true
     end,
     usage = function(conf, identifier, name, period, current_timestamp)
-      local red = redis:new()
-      red:set_timeout(conf.redis_timeout)
-      -- use a special pool name only if redis_database is set to non-zero
-      -- otherwise use the default pool name host:port
-      sock_opts.pool = conf.redis_database and
-                       conf.redis_host .. ":" .. conf.redis_port ..
-                       ":" .. conf.redis_database
-      local ok, err = red:connect(conf.redis_host, conf.redis_port,
-                                  sock_opts)
-      if not ok then
-        kong.log.err("failed to connect to Redis: ", err)
+      local red, err = get_redis_connection(conf)
+      if not red then
         return nil, err
-      end
-
-      local times, err = red:get_reused_times()
-      if err then
-        kong.log.err("failed to get connect reused times: ", err)
-        return nil, err
-      end
-
-      if times == 0 then
-        if is_present(conf.redis_password) then
-          local ok, err
-          if is_present(conf.redis_username) then
-            ok, err = red:auth(conf.redis_username, conf.redis_password)
-          else
-            ok, err = red:auth(conf.redis_password)
-          end
-          if not ok then
-            kong.log.err("failed to auth Redis: ", err)
-            return nil, err
-          end
-        end
-
-        if conf.redis_database ~= 0 then
-          -- Only call select first time, since we know the connection is shared
-          -- between instances that use the same redis database
-
-          local ok, err = red:select(conf.redis_database)
-          if not ok then
-            kong.log.err("failed to change Redis database: ", err)
-            return nil, err
-          end
-        end
       end
 
       reports.retrieve_redis_version(red)

--- a/kong/plugins/response-ratelimiting/policies/init.lua
+++ b/kong/plugins/response-ratelimiting/policies/init.lua
@@ -145,7 +145,12 @@ return {
 
       if times == 0 then
         if is_present(conf.redis_password) then
-          local ok, err = red:auth(conf.redis_password)
+          local ok, err
+          if is_present(conf.redis_username) then
+            ok, err = red:auth(conf.redis_username, conf.redis_password)
+          else
+            ok, err = red:auth(conf.redis_password)
+          end
           if not ok then
             kong.log.err("failed to auth Redis: ", err)
             return nil, err
@@ -228,7 +233,12 @@ return {
 
       if times == 0 then
         if is_present(conf.redis_password) then
-          local ok, err = red:auth(conf.redis_password)
+          local ok, err
+          if is_present(conf.redis_username) then
+            ok, err = red:auth(conf.redis_username, conf.redis_password)
+          else
+            ok, err = red:auth(conf.redis_password)
+          end
           if not ok then
             kong.log.err("failed to auth Redis: ", err)
             return nil, err

--- a/kong/plugins/response-ratelimiting/schema.lua
+++ b/kong/plugins/response-ratelimiting/schema.lua
@@ -74,6 +74,7 @@ return {
           { redis_host = typedefs.host },
           { redis_port = typedefs.port({ default = 6379 }), },
           { redis_password = { type = "string", len_min = 0 }, },
+          { redis_username = { type = "string" }, },
           { redis_timeout = { type = "number", default = 2000 }, },
           { redis_database = { type = "number", default = 0 }, },
           { block_on_first_violation = { type = "boolean", required = true, default = false }, },

--- a/spec/03-plugins/24-response-rate-limiting/05-integration_spec.lua
+++ b/spec/03-plugins/24-response-rate-limiting/05-integration_spec.lua
@@ -1,29 +1,50 @@
 local helpers = require "spec.helpers"
 local redis = require "resty.redis"
+local version = require "version"
+local tostring = tostring
 
 
 local REDIS_HOST = helpers.redis_host
 local REDIS_PORT = 6379
 local REDIS_DB_1 = 1
 local REDIS_DB_2 = 2
+local REDIS_DB_3 = 3
+local REDIS_DB_4 = 4
 
+local REDIS_USER_VALID = "response-ratelimit-user"
+local REDIS_USER_INVALID = "some-user"
+local REDIS_PASSWORD = "secret"
 
 local SLEEP_TIME = 1
 
-
-local function flush_redis(db)
+local function redis_connect()
   local red = redis:new()
   red:set_timeout(2000)
   assert(red:connect(REDIS_HOST, REDIS_PORT))
-  assert(red:select(db))
-  red:flushall()
-  red:close()
+  local red_version = string.match(red:info(), 'redis_version:([%g]+)\r\n')
+  return red, assert(version(red_version))
 end
 
+local function flush_redis(red, db)
+  assert(red:select(db))
+  red:flushall()
+end
+
+local function add_redis_user(red)
+  assert(red:acl("setuser", REDIS_USER_VALID, "on", "allkeys", "+incrby", "+select", "+info", "+expire", "+get", "+exists", ">" .. REDIS_PASSWORD))
+  assert(red:acl("setuser", REDIS_USER_INVALID, "on", "allkeys", "+get", ">" .. REDIS_PASSWORD))
+end
+
+local function remove_redis_user(red)
+  assert(red:acl("deluser", REDIS_USER_VALID))
+  assert(red:acl("deluser", REDIS_USER_INVALID))
+end
 
 describe("Plugin: rate-limiting (integration)", function()
   local client
   local bp
+  local red
+  local red_version
 
   lazy_setup(function()
     -- only to run migrations
@@ -34,11 +55,16 @@ describe("Plugin: rate-limiting (integration)", function()
     }, {
       "response-ratelimiting",
     })
+    red, red_version = redis_connect()
+
   end)
 
   lazy_teardown(function()
     if client then
       client:close()
+    end
+    if red then
+      red:close()
     end
 
     helpers.stop_kong()
@@ -49,8 +75,12 @@ describe("Plugin: rate-limiting (integration)", function()
     -- https://github.com/Kong/kong/issues/3292
 
     lazy_setup(function()
-      flush_redis(REDIS_DB_1)
-      flush_redis(REDIS_DB_2)
+      flush_redis(red, REDIS_DB_1)
+      flush_redis(red, REDIS_DB_2)
+      flush_redis(red, REDIS_DB_3)
+      if red_version >= version("6.0.0") then
+        add_redis_user(red)
+      end
 
       local route1 = assert(bp.routes:insert {
         hosts        = { "redistest1.com" },
@@ -83,24 +113,58 @@ describe("Plugin: rate-limiting (integration)", function()
           limits         = { video = { minute = 6 } },
         },
       })
+
+      if red_version >= version("6.0.0") then
+        local route3 = assert(bp.routes:insert {
+          hosts        = { "redistest3.com" },
+        })
+        assert(bp.plugins:insert {
+          name   = "response-ratelimiting",
+          route = { id = route3.id },
+          config = {
+            policy         = "redis",
+            redis_host     = REDIS_HOST,
+            redis_port     = REDIS_PORT,
+            redis_username = REDIS_USER_VALID,
+            redis_password = REDIS_PASSWORD,
+            redis_database = REDIS_DB_3,
+            fault_tolerant = false,
+            limits         = { video = { minute = 6 } },
+          },
+        })
+
+        local route4 = assert(bp.routes:insert {
+          hosts        = { "redistest4.com" },
+        })
+        assert(bp.plugins:insert {
+          name   = "response-ratelimiting",
+          route = { id = route4.id },
+          config = {
+            policy         = "redis",
+            redis_host     = REDIS_HOST,
+            redis_port     = REDIS_PORT,
+            redis_username = REDIS_USER_INVALID,
+            redis_password = REDIS_PASSWORD,
+            redis_database = REDIS_DB_4,
+            fault_tolerant = false,
+            limits         = { video = { minute = 6 } },
+          },
+        })
+      end
+
       assert(helpers.start_kong({
         nginx_conf = "spec/fixtures/custom_nginx.template",
       }))
       client = helpers.proxy_client()
     end)
 
+    lazy_teardown(function()
+      if red_version >= version("6.0.0") then
+        remove_redis_user(red)
+      end
+    end)
+
     it("connection pool respects database setting", function()
-      local red = redis:new()
-      red:set_timeout(2000)
-
-      finally(function()
-        if red then
-          red:close()
-        end
-      end)
-
-      assert(red:connect(REDIS_HOST, REDIS_PORT))
-
       assert(red:select(REDIS_DB_1))
       local size_1 = assert(red:dbsize())
 
@@ -109,6 +173,11 @@ describe("Plugin: rate-limiting (integration)", function()
 
       assert.equal(0, tonumber(size_1))
       assert.equal(0, tonumber(size_2))
+      if red_version >= version("6.0.0") then
+        assert(red:select(REDIS_DB_3))
+        local size_3 = assert(red:dbsize())
+        assert.equal(0, tonumber(size_3))
+      end
 
       local res = assert(client:send {
         method = "GET",
@@ -126,15 +195,20 @@ describe("Plugin: rate-limiting (integration)", function()
       ngx.sleep(SLEEP_TIME)
 
       assert(red:select(REDIS_DB_1))
-      local size_1 = assert(red:dbsize())
+      size_1 = assert(red:dbsize())
 
       assert(red:select(REDIS_DB_2))
-      local size_2 = assert(red:dbsize())
+      size_2 = assert(red:dbsize())
 
-      -- TEST: DB 1 should now have one hit, DB 2 none
+      -- TEST: DB 1 should now have one hit, DB 2 and 3 none
 
       assert.is_true(tonumber(size_1) > 0)
       assert.equal(0, tonumber(size_2))
+      if red_version >= version("6.0.0") then
+        assert(red:select(REDIS_DB_3))
+        local size_3 = assert(red:dbsize())
+        assert.equal(0, tonumber(size_3))
+      end
 
       -- response-ratelimiting plugin reuses the redis connection
       local res = assert(client:send {
@@ -153,17 +227,87 @@ describe("Plugin: rate-limiting (integration)", function()
       ngx.sleep(SLEEP_TIME)
 
       assert(red:select(REDIS_DB_1))
-      local size_1 = assert(red:dbsize())
+      size_1 = assert(red:dbsize())
 
       assert(red:select(REDIS_DB_2))
-      local size_2 = assert(red:dbsize())
+      size_2 = assert(red:dbsize())
 
-      -- TEST: Both DBs should now have one hit, because the
-      -- plugin correctly chose to select the database it is
-      -- configured to hit
+      -- TEST: DB 1 and 2 should now have one hit, DB 3 none
 
       assert.is_true(tonumber(size_1) > 0)
       assert.is_true(tonumber(size_2) > 0)
+      if red_version >= version("6.0.0") then
+        assert(red:select(REDIS_DB_3))
+        local size_3 = assert(red:dbsize())
+        assert.equal(0, tonumber(size_3))
+      end
+
+      -- response-ratelimiting plugin reuses the redis connection
+      if red_version >= version("6.0.0") then
+        local res = assert(client:send {
+          method = "GET",
+          path = "/response-headers?x-kong-limit=video=1",
+          headers = {
+            ["Host"] = "redistest3.com"
+          }
+        })
+        assert.res_status(200, res)
+        assert.equal(6, tonumber(res.headers["x-ratelimit-limit-video-minute"]))
+        assert.equal(5, tonumber(res.headers["x-ratelimit-remaining-video-minute"]))
+
+        -- Wait for async timer to increment the limit
+
+        ngx.sleep(SLEEP_TIME)
+
+        assert(red:select(REDIS_DB_1))
+        size_1 = assert(red:dbsize())
+
+        assert(red:select(REDIS_DB_2))
+        size_2 = assert(red:dbsize())
+
+        assert(red:select(REDIS_DB_3))
+        local size_3 = assert(red:dbsize())
+
+        -- TEST: All DBs should now have one hit, because the
+        -- plugin correctly chose to select the database it is
+        -- configured to hit
+
+        assert.is_true(tonumber(size_1) > 0)
+        assert.is_true(tonumber(size_2) > 0)
+        assert.is_true(tonumber(size_3) > 0)
+      end
+    end)
+
+    it("authenticates and executes with a valid redis user having proper ACLs", function()
+      if red_version >= version("6.0.0") then
+        local res = assert(client:send {
+          method = "GET",
+          path = "/status/200",
+          headers = {
+            ["Host"] = "redistest3.com"
+          }
+        })
+        assert.res_status(200, res)
+      else
+        ngx.log(ngx.WARN, "Redis v" .. tostring(red_version) .. " does not support ACL functions " ..
+          "'authenticates and executes with a valid redis user having proper ACLs' will be skipped")
+      end
+    end)
+
+    it("fails to rate-limit for a redis user with missing ACLs", function()
+      if red_version >= version("6.0.0") then
+        local res = assert(client:send {
+          method = "GET",
+          path = "/status/200",
+          headers = {
+            ["Host"] = "redistest4.com"
+          }
+        })
+        assert.res_status(500, res)
+      else
+        ngx.log(ngx.WARN, "Redis v" .. tostring(red_version) .. " does not support ACL functions " ..
+          "'fails to response rate-limit for a redis user with missing ACLs' will be skipped")
+      end
     end)
   end)
 end)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

This PR adds ACL configurations by adding `redis_username` configuration to the response ratelimiting plugin. This syncs with the feature added for the ratelimiting plugin by @27ascii; see https://github.com/Kong/kong/pull/8213 for re-addition into `master` branch.

This PR also refactors the Redis connection logic to be shared via a function (removes copy-pasta).

### Full changelog

* Adds the optional property redis_username used for connecting to redis. This allows to make use of redis ACL features supported with Redis 6.0

### Issues resolved

https://konghq.atlassian.net/browse/FT-2189
