### PR TITLE
fix(make-dev) bail out if rock installation fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ dependencies: bin/grpcurl
 	    echo $$rock already installed, skipping ; \
 	  else \
 	    echo $$rock not found, installing via luarocks... ; \
-	    luarocks install $$rock OPENSSL_DIR=$(OPENSSL_DIR) CRYPTO_DIR=$(OPENSSL_DIR); \
+	    luarocks install $$rock OPENSSL_DIR=$(OPENSSL_DIR) CRYPTO_DIR=$(OPENSSL_DIR) || exit 1; \
 	  fi \
 	done;
 


### PR DESCRIPTION
This fixes the deeper underlying problem related to https://github.com/Kong/kong-pongo/pull/241 .

In those cases the `make dev` overall failed because LuaRocks failed, but it was not signaled. Hence docker assumes the image to be valid and even caches the results of the docker commands. Despite them being faulty.
