### PR TITLE
chore(deps) bump resty.openssl from 0.8.2 to 0.8.4

### DIFF
--- a/kong-2.7.0-0.rockspec
+++ b/kong-2.7.0-0.rockspec
@@ -36,7 +36,7 @@ dependencies = {
   "lua-resty-healthcheck == 1.4.2",
   "lua-resty-mlcache == 2.5.0",
   "lua-messagepack == 0.5.2",
-  "lua-resty-openssl == 0.8.2",
+  "lua-resty-openssl == 0.8.4",
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6.1",
   "lua-resty-acme == 0.7.2",


### PR DESCRIPTION
Changelog:
<a name="0.8.4"></a>
## [0.8.4] - 2021-12-20
### bug fixes
- **x509.\*:** use SHA256 as default sign digest in BoringSSL [355681a](https://github.com/fffonion/lua-resty-openssl/commit/355681a33d88d85de0faae3e8eb6685e0e3b9f34)

### features
- **pkey:** add pkey:get_default_digest_type [0572e57](https://github.com/fffonion/lua-resty-openssl/commit/0572e57e0ab418f2dd749dbc5042b0c680e346a7)


<a name="0.8.3"></a>
## [0.8.3] - 2021-12-16
### bug fixes
- **hmac:** include evp.md headers [125ea05](https://github.com/fffonion/lua-resty-openssl/commit/125ea059da6b1effef7a187c434ebd6022dc3b82)