### PR TITLE
Fix C* connector record migration consistency level

### DIFF
--- a/kong/db/strategies/cassandra/connector.lua
+++ b/kong/db/strategies/cassandra/connector.lua
@@ -1052,6 +1052,7 @@ do
 
     local cql
     local args
+    local opts = { consistency = self.opts.write_consistency }
 
     if state == "executed" then
       cql = [[UPDATE schema_meta
@@ -1088,7 +1089,7 @@ do
     table.insert(args, SCHEMA_META_KEY)
     table.insert(args, subsystem)
 
-    local res, err = conn:execute(cql, args)
+    local res, err = conn:execute(cql, args, opts)
     if not res then
       return nil, err
     end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

The Cassandra connector should use the write consistency setting
(`cassandra_write_consistency`) from the Kong configuration file for
recording the migration status.

### Full changelog

* Fixed defect in Cassandra connector where it didn't use the configuration file consistency.
