### PR TITLE
fix(rate-limiting) removes race condition(redis) for better accuracy

### DIFF
--- a/kong/plugins/rate-limiting/handler.lua
+++ b/kong/plugins/rate-limiting/handler.lua
@@ -1,6 +1,7 @@
 -- Copyright (C) Kong Inc.
 local timestamp = require "kong.tools.timestamp"
 local policies = require "kong.plugins.rate-limiting.policies"
+local kong_meta = require "kong.meta"
 
 
 local kong = kong
@@ -46,8 +47,8 @@ local X_RATELIMIT_REMAINING = {
 local RateLimitingHandler = {}
 
 
-RateLimitingHandler.PRIORITY = 901
-RateLimitingHandler.VERSION = "2.4.0"
+RateLimitingHandler.VERSION = kong_meta.version
+RateLimitingHandler.PRIORITY = 910
 
 
 local function get_identifier(conf)
@@ -191,7 +192,7 @@ function RateLimitingHandler:access(conf)
       if stop then
         headers = headers or {}
         headers[RETRY_AFTER] = reset
-        return kong.response.error(429, "API rate limit exceeded", headers)
+        return kong.response.error(conf.error_code, conf.error_message, headers)
       end
 
       if headers then
@@ -236,7 +237,7 @@ function RateLimitingHandler:access(conf)
       if stop then
         headers = headers or {}
         headers[RETRY_AFTER] = reset
-        return kong.response.error(429, "API rate limit exceeded", headers)
+        return kong.response.error(conf.error_code, conf.error_message, headers)
       end
 
       if headers then

--- a/kong/plugins/rate-limiting/schema.lua
+++ b/kong/plugins/rate-limiting/schema.lua
@@ -22,6 +22,14 @@ local function validate_periods_order(config)
   return true
 end
 
+local function validate_periods_order_by_window_type(config)
+  if config.window_type == "fixed" then
+    return validate_periods_order(config)
+  elseif config.window_type == "sliding" then
+    return true
+  end
+end
+
 
 local function is_dbless()
   local _, database, role = pcall(function()
@@ -72,6 +80,13 @@ return {
           { day = { type = "number", gt = 0 }, },
           { month = { type = "number", gt = 0 }, },
           { year = { type = "number", gt = 0 }, },
+          { window_size = { type = "number", gt = 0 }, },
+          { limit = { type = "number", gt = 0 }, },
+          { window_type = {
+            type = "string",
+            default = "fixed",
+            one_of = { "fixed", "sliding" },
+          }, },
           { limit_by = {
               type = "string",
               default = "consumer",
@@ -92,12 +107,28 @@ return {
           { redis_database = { type = "integer", default = 0 }, },
           { hide_client_headers = { type = "boolean", required = true, default = false }, },
         },
-        custom_validator = validate_periods_order,
+        custom_validator = validate_periods_order_by_window_type,
       },
     },
   },
   entity_checks = {
-    { at_least_one_of = { "config.second", "config.minute", "config.hour", "config.day", "config.month", "config.year" } },
+    { conditional_at_least_one_of = { if_field = "config.window_type",
+                                      if_match = { eq = "fixed" },
+                                      then_at_least_one_of = { "config.second", "config.minute", "config.hour", "config.day", "config.month", "config.year" },
+                                      then_err = "at least one of these fields must be non-empty: %s",
+                                    }},
+    { custom_entity_check = {
+      field_sources = { "config" },
+      fn = function(entity)
+        local config = entity.config
+        if config.window_type == "sliding" then
+          if config.policy ~= "redis" then
+            return nil, "On redis policy is supported when window_type == 'sliding'"
+          end
+        end
+        return true
+      end,
+    } },
     { conditional = {
       if_field = "config.policy", if_match = { eq = "redis" },
       then_field = "config.redis_host", then_match = { required = true },
@@ -117,6 +148,14 @@ return {
     { conditional = {
       if_field = "config.policy", if_match = { eq = "redis" },
       then_field = "config.redis_timeout", then_match = { required = true },
+    } },
+    { conditional = {
+      if_field = "config.window_type", if_match = { eq = "sliding" },
+      then_field = "config.limit", then_match = { required = true },
+    } },
+    { conditional = {
+      if_field = "config.window_type", if_match = { eq = "sliding" },
+      then_field = "config.window_size", then_match = { required = true },
     } },
   },
 }

--- a/spec/03-plugins/23-rate-limiting/01-schema_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/01-schema_spec.lua
@@ -3,35 +3,38 @@ local v = require("spec.helpers").validate_plugin_config_schema
 
 
 describe("Plugin: rate-limiting (schema)", function()
-  it("proper config validates", function()
-    local config = { second = 10 }
-    local ok, _, err = v(config, schema_def)
-    assert.truthy(ok)
-    assert.is_nil(err)
+  describe("should work when", function()
+    it("proper config validates", function()
+      local config = { second = 10 }
+      local ok, _, err = v(config, schema_def)
+      assert.truthy(ok)
+      assert.is_nil(err)
+    end)
+
+    it("proper config validates (bis)", function()
+      local config = { second = 10, minute = 20, hour = 30, day = 40, month = 50, year = 60 }
+      local ok, _, err = v(config, schema_def)
+      assert.truthy(ok)
+      assert.is_nil(err)
+    end)
+
+    it("proper config validates (header)", function()
+      local config = { second = 10, limit_by = "header", header_name = "X-App-Version" }
+      local ok, _, err = v(config, schema_def)
+      assert.truthy(ok)
+      assert.is_nil(err)
+    end)
+
+    it("proper config validates (path)", function()
+      local config = { second = 10, limit_by = "path", path = "/request" }
+      local ok, _, err = v(config, schema_def)
+      assert.truthy(ok)
+      assert.is_nil(err)
+    end)
+
   end)
 
-  it("proper config validates (bis)", function()
-    local config = { second = 10, minute = 20, hour = 30, day = 40, month = 50, year = 60 }
-    local ok, _, err = v(config, schema_def)
-    assert.truthy(ok)
-    assert.is_nil(err)
-  end)
-
-  it("proper config validates (header)", function()
-    local config = { second = 10, limit_by = "header", header_name = "X-App-Version" }
-    local ok, _, err = v(config, schema_def)
-    assert.truthy(ok)
-    assert.is_nil(err)
-  end)
-
-  it("proper config validates (path)", function()
-    local config = { second = 10, limit_by = "path", path = "/request" }
-    local ok, _, err = v(config, schema_def)
-    assert.truthy(ok)
-    assert.is_nil(err)
-  end)
-
-  describe("errors", function()
+  describe("should fail when", function()
     it("limits: smaller unit is less than bigger unit", function()
       local config = { second = 20, hour = 10 }
       local ok, err = v(config, schema_def)
@@ -66,6 +69,104 @@ describe("Plugin: rate-limiting (schema)", function()
       local ok, err = v(config, schema_def)
       assert.falsy(ok)
       assert.equal("required field missing", err.config.path)
+    end)
+
+    it("window_type is invalid", function()
+      local config = { window_type = "none" }
+      local ok, err = v(config, schema_def)
+      assert.falsy(ok)
+      assert.equal("expected one of: fixed, sliding", err.config.window_type)
+    end)
+
+  end)
+end)
+
+describe("Plugin: rate-limiting (schema) - window_type == 'sliding'", function()
+  describe("should fail when", function()
+    it("is window_type=sliding and policy is not redis", function()
+      local config = { window_type = "sliding", window_size = 60 , limit = 10, policy="local" }
+      local ok, err = v(config, schema_def)
+      assert.falsy(ok)
+      assert.same({"On redis policy is supported when window_type == 'sliding'" },
+      err["@entity"])
+    end)
+
+    it("limit is missing", function()
+      local config = { window_type = "sliding", window_size = 60}
+      local ok, err = v(config, schema_def)
+      assert.falsy(ok)
+      assert.equals("required field missing",err.config.limit)
+    end)
+
+    it("window_size is missing", function()
+      local config = { window_type = "sliding", limit = 10}
+      local ok, err = v(config, schema_def)
+      assert.falsy(ok)
+      assert.equals("required field missing",err.config.window_size)
+
+    end)
+
+    it("window_size and limit are missing", function()
+      local config = { window_type = "sliding" }
+      local ok, err = v(config, schema_def)
+      local result = {}
+      result['limit'] = 'required field missing'
+      result['window_size'] = 'required field missing'
+
+      assert.falsy(ok)
+      assert.same(result, err.config)
+    end)
+
+    it("window_size is less then 0", function()
+      local config = { window_type = "sliding", window_size = 0 , limit = 10}
+      local ok, err = v(config, schema_def)
+      assert.falsy(ok)
+      assert.equals("value must be greater than 0", err.config.window_size)
+    end)
+
+    it("limit is less then 0", function()
+      local config = { window_type = "sliding", window_size = 60 , limit = -5}
+      local ok, err = v(config, schema_def)
+      assert.falsy(ok)
+      assert.equals("value must be greater than 0", err.config.limit)
+    end)
+
+
+    it("is limited by header but the header_name field is missing", function()
+      local config = { window_type = "sliding", window_size = 60 , limit = 10, limit_by = "header", header_name = nil }
+      local ok, err = v(config, schema_def)
+      assert.falsy(ok)
+      assert.equal("required field missing", err.config.header_name)
+    end)
+
+    it("is limited by path but the path field is missing", function()
+      local config = { window_type = "sliding", window_size = 60 , limit = 10, limit_by = "path", path =  nil }
+      local ok, err = v(config, schema_def)
+      assert.falsy(ok)
+      assert.equal("required field missing", err.config.path)
+    end)
+  end)
+
+  describe("should work when", function()
+    it("proper config validates window_type == sliding", function()
+      local config = { window_type = "sliding", window_size = 60 , limit = 10, policy = "redis", redis_host = 'localhost' }
+      local ok, _, err = v(config, schema_def)
+      assert.truthy(ok)
+      assert.is_nil(err)
+    end)
+
+    it("proper config validates (header)", function()
+      local config = { window_type = "sliding", window_size = 60 , limit = 10, policy = "redis", redis_host = 'localhost', limit_by = "header", header_name = "X-App-Version" }
+      local ok, _, err = v(config, schema_def)
+      assert.truthy(ok)
+      assert.is_nil(err)
+    end)
+
+    it("proper config validates (path)", function()
+      local config = { window_type = "sliding", window_size = 60 , limit = 10, policy = "redis", redis_host = 'localhost', limit_by = "path", path = "/request" }
+      local ok, _, err = v(config, schema_def)
+      assert.truthy(ok)
+      assert.is_nil(err)
     end)
   end)
 end)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

fix rate-limiting accuracy reported on issue: https://github.com/Kong/kong/issues/5311

There is a low impact change to the current code and this implementation has better accuracy on redis policy

### Full changelog

* [it removes the race condition problem getting keys on redis. it uses the return of the increment command as the usage counter ensuring atomicity, different from the current one, which allows multiple requests to get the same value of the redis key while the counter increment is done asynchronously]

* [it uses sliding window algorithm which is the most suitable for better accuracy]

* [it works only with redis polity because redis is capable of guaranteeing atomicity and performance, which other polices could not guarantee]

* [it maintains the current functioning and configuration of the plugin. the fixed window setting is the default to not impact routes already configured]

* [it has an even better performance than the current plugin using the redis policy and fixed window, as it does only 1 operation per request in redis (eval) instead of the two operations per request that the current one (get and eval)]

### Issues resolved

Fix #5311
KAG-981