### PR TITLE
perf(runloop) use string.byte in access.after to check is_args

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -58,6 +58,7 @@ local COMMA = byte(",")
 local SPACE = byte(" ")
 local ARRAY_MT = require("cjson.safe").array_mt
 
+local QUESTION_MARK = byte("?")
 
 local HOST_PORTS = {}
 
@@ -1398,7 +1399,7 @@ return {
       -- We overcome this behavior with our own logic, to preserve user
       -- desired semantics.
       -- perf: branch usually not taken, don't cache var outside
-      if sub(ctx.request_uri or var.request_uri, -1) == "?" then
+      if byte(ctx.request_uri or var.request_uri, -1) == QUESTION_MARK then
         var.upstream_uri = var.upstream_uri .. "?"
       elseif var.is_args == "?" then
         var.upstream_uri = var.upstream_uri .. "?" .. var.args or ""

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -56,9 +56,9 @@ local WARN  = ngx.WARN
 local DEBUG = ngx.DEBUG
 local COMMA = byte(",")
 local SPACE = byte(" ")
+local QUESTION_MARK = byte("?")
 local ARRAY_MT = require("cjson.safe").array_mt
 
-local QUESTION_MARK = byte("?")
 
 local HOST_PORTS = {}
 


### PR DESCRIPTION

### Summary

As before's PR, it is a minor improvement about string.byte.
But I think it is in a hot code path, may  reduce many lj_str_new overhead.

### Full changelog

* use string.byte to check the last char of uri



