### PR TITLE
chore(perf) rename packet to metal and bump terraform version

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -8,7 +8,7 @@ on:
   - cron:  '0 7 * * *'
 
 env:
-  terraform_version: '0.15.3'
+  terraform_version: '1.1.2'
 
 jobs:
   perf:
@@ -98,8 +98,8 @@ jobs:
     - name: Run Tests
       env:
         PERF_TEST_VERSIONS: git:${{ github.sha }},git:master
-        PERF_TEST_PACKET_PROJECT_ID: ${{ secrets.PERF_TEST_PACKET_PROJECT_ID }}
-        PERF_TEST_PACKET_AUTH_TOKEN: ${{ secrets.PERF_TEST_PACKET_AUTH_TOKEN }}
+        PERF_TEST_METAL_PROJECT_ID: ${{ secrets.PERF_TEST_PACKET_PROJECT_ID }}
+        PERF_TEST_METAL_AUTH_TOKEN: ${{ secrets.PERF_TEST_PACKET_AUTH_TOKEN }}
         PERF_TEST_DRIVER: terraform
       timeout-minutes: 60
       run: |
@@ -117,8 +117,8 @@ jobs:
       if: always()
       env:
         PERF_TEST_VERSIONS: git:${{ github.sha }},git:master
-        PERF_TEST_PACKET_PROJECT_ID: ${{ secrets.PERF_TEST_PACKET_PROJECT_ID }}
-        PERF_TEST_PACKET_AUTH_TOKEN: ${{ secrets.PERF_TEST_PACKET_AUTH_TOKEN }}
+        PERF_TEST_METAL_PROJECT_ID: ${{ secrets.PERF_TEST_PACKET_PROJECT_ID }}
+        PERF_TEST_METAL_AUTH_TOKEN: ${{ secrets.PERF_TEST_PACKET_AUTH_TOKEN }}
         PERF_TEST_DRIVER: terraform
         PERF_TEST_TEARDOWN_ALL: "true"
       run: |

--- a/spec/04-perf/01-rps/01-simple_spec.lua
+++ b/spec/04-perf/01-rps/01-simple_spec.lua
@@ -12,12 +12,12 @@ if driver == "terraform" then
     provider = "equinix-metal",
     tfvars = {
       -- Kong Benchmarking
-      packet_project_id = os.getenv("PERF_TEST_PACKET_PROJECT_ID"),
+      metal_project_id = os.getenv("PERF_TEST_METAL_PROJECT_ID"),
       -- TODO: use an org token
-      packet_auth_token = os.getenv("PERF_TEST_PACKET_AUTH_TOKEN"),
-      -- packet_plan = "baremetal_1",
-      -- packet_region = "sjc1",
-      -- packet_os = "ubuntu_20_04",
+      metal_auth_token = os.getenv("PERF_TEST_METAL_AUTH_TOKEN"),
+      -- metal_plan = "baremetal_1",
+      -- metal_region = "sjc1",
+      -- metal_os = "ubuntu_20_04",
     }
   })
 else

--- a/spec/04-perf/01-rps/02-balancer_spec.lua
+++ b/spec/04-perf/01-rps/02-balancer_spec.lua
@@ -12,12 +12,12 @@ if driver == "terraform" then
     provider = "equinix-metal",
     tfvars = {
       -- Kong Benchmarking
-      packet_project_id = os.getenv("PERF_TEST_PACKET_PROJECT_ID"),
+      metal_project_id = os.getenv("PERF_TEST_METAL_PROJECT_ID"),
       -- TODO: use an org token
-      packet_auth_token = os.getenv("PERF_TEST_PACKET_AUTH_TOKEN"),
-      -- packet_plan = "baremetal_1",
-      -- packet_region = "sjc1",
-      -- packet_os = "ubuntu_20_04",
+      metal_auth_token = os.getenv("PERF_TEST_METAL_AUTH_TOKEN"),
+      -- metal_plan = "baremetal_1",
+      -- metal_region = "sjc1",
+      -- metal_os = "ubuntu_20_04",
     }
   })
 else

--- a/spec/04-perf/01-rps/03-plugin_iterator_spec.lua
+++ b/spec/04-perf/01-rps/03-plugin_iterator_spec.lua
@@ -12,12 +12,12 @@ if driver == "terraform" then
     provider = "equinix-metal",
     tfvars = {
       -- Kong Benchmarking
-      packet_project_id = os.getenv("PERF_TEST_PACKET_PROJECT_ID"),
+      metal_project_id = os.getenv("PERF_TEST_METAL_PROJECT_ID"),
       -- TODO: use an org token
-      packet_auth_token = os.getenv("PERF_TEST_PACKET_AUTH_TOKEN"),
-      -- packet_plan = "baremetal_1",
-      -- packet_region = "sjc1",
-      -- packet_os = "ubuntu_20_04",
+      metal_auth_token = os.getenv("PERF_TEST_METAL_AUTH_TOKEN"),
+      -- metal_plan = "baremetal_1",
+      -- metal_region = "sjc1",
+      -- metal_os = "ubuntu_20_04",
     }
   })
 else

--- a/spec/04-perf/02-flamegraph/01-simple_spec.lua
+++ b/spec/04-perf/02-flamegraph/01-simple_spec.lua
@@ -12,12 +12,12 @@ if driver == "terraform" then
     provider = "equinix-metal",
     tfvars = {
       -- Kong Benchmarking
-      packet_project_id = os.getenv("PERF_TEST_PACKET_PROJECT_ID"),
+      metal_project_id = os.getenv("PERF_TEST_METAL_PROJECT_ID"),
       -- TODO: use an org token
-      packet_auth_token = os.getenv("PERF_TEST_PACKET_AUTH_TOKEN"),
-      -- packet_plan = "baremetal_1",
-      -- packet_region = "sjc1",
-      -- packet_os = "ubuntu_20_04",
+      metal_auth_token = os.getenv("PERF_TEST_METAL_AUTH_TOKEN"),
+      -- metal_plan = "baremetal_1",
+      -- metal_region = "sjc1",
+      -- metal_os = "ubuntu_20_04",
     }
   })
 else

--- a/spec/04-perf/02-flamegraph/03-plugin_iterator_spec.lua
+++ b/spec/04-perf/02-flamegraph/03-plugin_iterator_spec.lua
@@ -12,12 +12,12 @@ if driver == "terraform" then
     provider = "equinix-metal",
     tfvars = {
       -- Kong Benchmarking
-      packet_project_id = os.getenv("PERF_TEST_PACKET_PROJECT_ID"),
+      metal_project_id = os.getenv("PERF_TEST_METAL_PROJECT_ID"),
       -- TODO: use an org token
-      packet_auth_token = os.getenv("PERF_TEST_PACKET_AUTH_TOKEN"),
-      -- packet_plan = "baremetal_1",
-      -- packet_region = "sjc1",
-      -- packet_os = "ubuntu_20_04",
+      metal_auth_token = os.getenv("PERF_TEST_METAL_AUTH_TOKEN"),
+      -- metal_plan = "baremetal_1",
+      -- metal_region = "sjc1",
+      -- metal_os = "ubuntu_20_04",
     }
   })
 else

--- a/spec/04-perf/99-teardown/01-teardown_spec.lua
+++ b/spec/04-perf/99-teardown/01-teardown_spec.lua
@@ -12,12 +12,12 @@ if driver == "terraform" then
     provider = "equinix-metal",
     tfvars = {
       -- Kong Benchmarking
-      packet_project_id = os.getenv("PERF_TEST_PACKET_PROJECT_ID"),
+      metal_project_id = os.getenv("PERF_TEST_METAL_PROJECT_ID"),
       -- TODO: use an org token
-      packet_auth_token = os.getenv("PERF_TEST_PACKET_AUTH_TOKEN"),
-      -- packet_plan = "baremetal_1",
-      -- packet_region = "sjc1",
-      -- packet_os = "ubuntu_20_04",
+      metal_auth_token = os.getenv("PERF_TEST_METAL_AUTH_TOKEN"),
+      -- metal_plan = "baremetal_1",
+      -- metal_region = "sjc1",
+      -- metal_os = "ubuntu_20_04",
     }
   })
 else

--- a/spec/fixtures/perf/terraform/equinix-metal/main.tf
+++ b/spec/fixtures/perf/terraform/equinix-metal/main.tf
@@ -8,8 +8,8 @@ terraform {
     null = {
       version = "~> 2.1"
     }
-    packet = {
-      source = "packethost/packet"
+    metal = {
+      source = "equinix/metal"
       version = "~> 3.2"
     }
     tls = {
@@ -21,6 +21,6 @@ terraform {
   }
 }
 
-provider "packet" {
-  auth_token = var.packet_auth_token
+provider "metal" {
+  auth_token = var.metal_auth_token
 }

--- a/spec/fixtures/perf/terraform/equinix-metal/metal.tf
+++ b/spec/fixtures/perf/terraform/equinix-metal/metal.tf
@@ -1,30 +1,30 @@
-resource "packet_ssh_key" "key" {
+resource "metal_ssh_key" "key" {
   name       = "key1"
   public_key = tls_private_key.key.public_key_openssh
 }
 
-resource "packet_device" "kong" {
+resource "metal_device" "kong" {
   hostname         = "kong-test-${random_string.ident.result}"
-  plan             = var.packet_plan
-  facilities       = [var.packet_region]
-  operating_system = var.packet_os
+  plan             = var.metal_plan
+  facilities       = [var.metal_region]
+  operating_system = var.metal_os
   billing_cycle    = "hourly"
-  project_id       = var.packet_project_id
+  project_id       = var.metal_project_id
   depends_on = [
-    packet_ssh_key.key,
+    metal_ssh_key.key,
     null_resource.key_chown,
   ]
 }
 
-resource "packet_device" "worker" {
+resource "metal_device" "worker" {
   hostname         = "worker-${random_string.ident.result}"
-  plan             = var.packet_plan
-  facilities       = [var.packet_region]
-  operating_system = var.packet_os
+  plan             = var.metal_plan
+  facilities       = [var.metal_region]
+  operating_system = var.metal_os
   billing_cycle    = "hourly"
-  project_id       = var.packet_project_id
+  project_id       = var.metal_project_id
   depends_on = [
-    packet_ssh_key.key,
+    metal_ssh_key.key,
     null_resource.key_chown,
   ]
 

--- a/spec/fixtures/perf/terraform/equinix-metal/output.tf
+++ b/spec/fixtures/perf/terraform/equinix-metal/output.tf
@@ -1,16 +1,16 @@
 output "kong-ip" {
-  value = packet_device.kong.access_public_ipv4
+  value = metal_device.kong.access_public_ipv4
 }
 
 output "kong-internal-ip" {
-  value = packet_device.kong.access_private_ipv4
+  value = metal_device.kong.access_private_ipv4
 }
 
 output "worker-ip" {
-  value = packet_device.worker.access_public_ipv4
+  value = metal_device.worker.access_public_ipv4
 }
 
 output "worker-internal-ip" {
-  value = packet_device.worker.access_private_ipv4
+  value = metal_device.worker.access_private_ipv4
 }
 

--- a/spec/fixtures/perf/terraform/equinix-metal/variables.tf
+++ b/spec/fixtures/perf/terraform/equinix-metal/variables.tf
@@ -1,28 +1,28 @@
-variable "packet_auth_token" {
+variable "metal_auth_token" {
   type        = string
-  description = "The pre-existing Packet auth token"
+  description = "The pre-existing Metal auth token"
 }
 
-variable "packet_project_id" {
+variable "metal_project_id" {
   type        = string
-  description = "The pre-existing Packet project ID under which to create the devices"
+  description = "The pre-existing Metal project ID under which to create the devices"
 }
 
-variable "packet_plan" {
+variable "metal_plan" {
   type        = string
-  description = "The Packet device plan on which to create the kong and worker devices"
+  description = "The Metal device plan on which to create the kong and worker devices"
   default     = "baremetal_1"
 }
 
-variable "packet_region" {
+variable "metal_region" {
   type        = string
-  description = "The Packet region in which to create the devices"
+  description = "The Metal region in which to create the devices"
   default     = "sjc1"
 }
 
-variable "packet_os" {
+variable "metal_os" {
   type        = string
-  description = "The OS to install on the Packet devices"
+  description = "The OS to install on the Metal devices"
   default     = "ubuntu_20_04"
 }
 


### PR DESCRIPTION
As the rebranding of packet, its terraform provider also moved to different name:
```
19:21:51.730  [debug] [terraform] => The remote registry returned warnings for
19:21:51.730  [debug] [terraform] => registry.terraform.io/packethost/packet:
19:21:51.730  [debug] [terraform] => - For users on Terraform 0.13 or greater, this provider has moved to
19:21:51.731  [debug] [terraform] => equinix/metal. Please update your source in required_providers.
```
This PR cleans up the places where old names are used and point to the new provider.