### PR TITLE
fix(targets) reschedule resolve timer after resolving

### DIFF
--- a/kong/runloop/balancer/targets.lua
+++ b/kong/runloop/balancer/targets.lua
@@ -24,9 +24,10 @@ local tonumber = tonumber
 local table_sort = table.sort
 local assert = assert
 
+local CRIT = ngx.CRIT
+local DEBUG = ngx.DEBUG
 local ERR = ngx.ERR
 local WARN = ngx.WARN
-local DEBUG = ngx.DEBUG
 
 local SRV_0_WEIGHT = 1      -- SRV record with weight 0 should be hit minimally, hence we replace by 1
 local EMPTY = setmetatable({},
@@ -45,7 +46,7 @@ function targets_M.init()
   dns_client = require("kong.tools.dns")(kong.configuration)    -- configure DNS client
 
   if not resolve_timer_running then
-    resolve_timer_running = assert(ngx.timer.every(1, resolve_timer_callback))
+    resolve_timer_running = assert(ngx.timer.at(1, resolve_timer_callback))
   end
 end
 
@@ -240,6 +241,13 @@ function resolve_timer_callback()
       queryDns(target, false) -- timer-context; cacheOnly always false
     end
   end
+
+  local err
+  resolve_timer_running, err = ngx.timer.at(1, resolve_timer_callback)
+  if not resolve_timer_running then
+    log(CRIT, "could not reschedule DNS resolver timer: ", err)
+  end
+
 end
 
 


### PR DESCRIPTION
As `ngx.timer.every` was used, if resolving an address took longer than 1 sec, another resolving callback would be called, instead of waiting until the first one finish. With this change, a new timer will be scheduled only after the previous one has executed.