### PR TITLE
fix(router) may be a bug in has_wildcard_host_port check

### DIFF
--- a/kong/router.lua
+++ b/kong/router.lua
@@ -376,7 +376,7 @@ local function marshall_route(r)
 
     local has_host_wildcard
     local has_host_plain
-    local has_port, has_wildcard_host_port
+    local has_wildcard_host_port
 
     for _, host in ipairs(hosts) do
       if type(host) ~= "string" then
@@ -390,7 +390,7 @@ local function marshall_route(r)
         local wildcard_host_regex = host:gsub("%.", "\\.")
                                         :gsub("%*", ".+") .. "$"
 
-        _, _, has_port = split_port(host)
+        local _, _, has_port = split_port(host)
         if not has_port then
           wildcard_host_regex = wildcard_host_regex:gsub("%$$", [[(?::\d+)?$]])
         end

--- a/kong/router.lua
+++ b/kong/router.lua
@@ -376,7 +376,7 @@ local function marshall_route(r)
 
     local has_host_wildcard
     local has_host_plain
-    local has_port
+    local has_port, has_wildcard_host_port
 
     for _, host in ipairs(hosts) do
       if type(host) ~= "string" then
@@ -393,6 +393,10 @@ local function marshall_route(r)
         _, _, has_port = split_port(host)
         if not has_port then
           wildcard_host_regex = wildcard_host_regex:gsub("%$$", [[(?::\d+)?$]])
+        end
+
+        if has_wildcard_host_port == nil and has_port then
+          has_wildcard_host_port = true
         end
 
         insert(route_t.hosts, {
@@ -423,7 +427,7 @@ local function marshall_route(r)
                                     MATCH_SUBRULES.PLAIN_HOSTS_ONLY)
     end
 
-    if has_port then
+    if has_wildcard_host_port then
       route_t.submatch_weight = bor(route_t.submatch_weight,
                                     MATCH_SUBRULES.HAS_WILDCARD_HOST_PORT)
     end

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -1194,6 +1194,33 @@ describe("Router", function()
         assert.same(nil, match_t.matches.uri_captures)
       end)
 
+      it("submatch_weight [wildcard host port] > [wildcard host] ", function()
+        local use_case = {
+          {
+            service = service,
+            route = {
+              hosts = { "route.*" },
+            },
+          },
+          {
+            service = service,
+            route = {
+              hosts = { "route.*:80", "route.com.*" },
+            },
+          },
+        }
+
+        local router = assert(Router.new(use_case))
+
+        local match_t = router.select("GET", "/", "route.org:80")
+        assert.truthy(match_t)
+        assert.same(use_case[2].route, match_t.route)
+        assert.same("route.*:80", match_t.matches.host)
+        assert.same(nil, match_t.matches.method)
+        assert.same(nil, match_t.matches.uri)
+        assert.same(nil, match_t.matches.uri_captures)
+      end)
+
       it("matches a [wildcard host + port] even if a [wildcard host] matched", function()
         local use_case = {
           {


### PR DESCRIPTION


### Summary

When I view the code in router.lua, 
I find the logic of MATCH_SUBRULES.HAS_WILDCARD_HOST_PORT may be a mistake.
if we have many hosts, the value of has_port may disappear in the next loop.

Please check the logic flow to confirm I am right or wrong.

### Full changelog

* add a new var has_wildcard_host_port
* use has_wildcard_host_port to determine subrules.


