### PR TITLE
perf(router) use ngx.ssl.server_name() instead of var.ssl_server_name

### DIFF
--- a/kong/router.lua
+++ b/kong/router.lua
@@ -1829,13 +1829,15 @@ function _M.new(routes)
   self.select = find_route
   self._set_ngx = _set_ngx
 
+  local server_name = require("ngx.ssl").server_name
+
   if subsystem == "http" then
     function self.exec(ctx)
       local req_method = get_method()
       local req_uri = ctx and ctx.request_uri or var.request_uri
       local req_host = var.http_host or ""
       local req_scheme = ctx and ctx.scheme or var.scheme
-      local sni = var.ssl_server_name
+      local sni, _ = server_name()
 
       local headers
       local err
@@ -1895,8 +1897,6 @@ function _M.new(routes)
     end
 
   else -- stream
-    local server_name = require("ngx.ssl").server_name
-
     function self.exec(ctx)
       local src_ip = var.remote_addr
       local src_port = tonumber(var.remote_port, 10)

--- a/kong/router.lua
+++ b/kong/router.lua
@@ -32,6 +32,7 @@ local max           = math.max
 local band          = bit.band
 local bor           = bit.bor
 local yield         = require("kong.tools.utils").yield
+local server_name   = require("ngx.ssl").server_name
 
 -- limits regex degenerate times to the low miliseconds
 local REGEX_PREFIX  = "(*LIMIT_MATCH=10000)"
@@ -1828,8 +1829,6 @@ function _M.new(routes)
 
   self.select = find_route
   self._set_ngx = _set_ngx
-
-  local server_name = require("ngx.ssl").server_name
 
   if subsystem == "http" then
     function self.exec(ctx)


### PR DESCRIPTION

### Summary

Openresty has a more efficient ffi function ngx.ssl.server_name() ,
it has the same result as var.ssl_server_name,
so I think we can use it both in stream and http subsystem.

### Full changelog

* use ngx.ssl.server_name() to get the value of  var.ssl_server_name

