### PR TITLE
chore(init): print err when loading config file err

### DIFF
--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -1348,7 +1348,10 @@ local function load(path, custom_conf, opts)
   else
     log.verbose("reading config file at %s", path)
 
-    from_file_conf = load_config_file(path)
+    from_file_conf, err = load_config_file(path)
+    if not from_file_conf then
+      return nil, "could not load config file: " .. err
+    end
   end
 
   -----------------------


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Print error message when failed to load config file.
Output err msg can be useful when debugging problems related to file config.

### Full changelog

* Print error message when failed to load config file

### Issues related

ref: https://github.com/Kong/kong/issues/8230
