### PR TITLE
fix(admin-api) correctly return next field for

### DIFF
--- a/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -536,12 +536,22 @@ describe("Admin API #" .. strategy, function()
       it("offset is a string", function()
         local res = assert(client:send {
           method = "GET",
-          path = "/upstreams/" .. upstream.name .. "/targets",
+          path = "/upstreams/" .. upstream.name .. "/targets/all",
           query = {size = 3},
         })
         assert.response(res).has.status(200)
         local json = assert.response(res).has.jsonbody()
         assert.is_string(json.offset)
+      end)
+      it("next url ends with /targets/all", function()
+        local res = assert(client:send {
+          method = "GET",
+          path = "/upstreams/" .. upstream.name .. "/targets/all",
+          query = {size = 3},
+        })
+        assert.response(res).has.status(200)
+        local json = assert.response(res).has.jsonbody()
+        assert.equals("/upstreams/" .. upstream.name .. "/targets/all?offset=" .. ngx.escape_uri(json.offset), json.next)
       end)
       it("paginates a set", function()
         local pages = {}


### PR DESCRIPTION
/upstreams/<upstream>/targets/all endpoint

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

/upstreams/<upstream>/targets/all endpoint returns an incorrect `next` field where the url is
`/upstreams/<upstream>/targets` but `offset` is the one used in `/all` endpoint. When user use the
returned URL, Kong throws an error since the `offset` format is different in `/upstreams/<upstream>/targets`
versus `/upstreams/<upstream>/targets/all`.
This PR duplicates the `endpoints.get_collection_endpoint` function to generate a correct `next` field in response.

### Full changelog

* fix(admin-api) correctly return next field for /upstreams/<upstream>/targets/all endpoint

### Issues resolved

Fix #8243
