### PR TITLE
perf(runloop) optimize the call of ngx.time in log phase

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -116,15 +116,16 @@ end
 local update_lua_mem
 do
   local pid = ngx.worker.pid
+  local ngx_time = ngx.time
   local kong_shm = ngx.shared.kong
 
   local LUA_MEM_SAMPLE_RATE = 10 -- seconds
-  local last = ngx.time()
+  local last = ngx_time()
 
   local collectgarbage = collectgarbage
 
   update_lua_mem = function(force)
-    local time = ngx.time()
+    local time = ngx_time()
 
     if force or time - last >= LUA_MEM_SAMPLE_RATE then
       local count = collectgarbage("count")
@@ -134,7 +135,7 @@ do
         log(ERR, "could not record Lua VM allocated memory: ", err)
       end
 
-      last = ngx.time()
+      last = time
     end
   end
 end


### PR DESCRIPTION


### Summary

SUMMARY_GOES_HERE

localize ngx.time for better performance

* localize ngx.time in update_lua_mem


