### PR TITLE
feat(api) add a config readiness endpoint

### DIFF
--- a/kong-2.8.0-0.rockspec
+++ b/kong-2.8.0-0.rockspec
@@ -126,6 +126,7 @@ build = {
     ["kong.api.routes.clustering"] = "kong/api/routes/clustering.lua",
 
     ["kong.status"] = "kong/status/init.lua",
+    ["kong.status.routes.config"] = "kong/status/routes/config.lua",
 
     ["kong.tools.dns"] = "kong/tools/dns.lua",
     ["kong.tools.grpc"] = "kong/tools/grpc.lua",

--- a/kong/api/routes/health.lua
+++ b/kong/api/routes/health.lua
@@ -17,6 +17,20 @@ local data_plane_role = kong.configuration.role == "data_plane"
 
 
 return {
+  ["/config/ready"] = {
+    GET = function(self, dao, helpers)
+      if kong.db.strategy ~= "off" then
+        return kong.response.exit(200)
+      end
+    -- unintuitively, "true" is unitialized. we do always initialize the shdict key
+    -- after a config loads, this returns the hash string
+    if declarative.get_current_hash() == true then
+      return kong.response.exit(503)
+    end
+
+    return kong.response.exit(200)
+    end
+  },
   ["/status"] = {
     GET = function(self, dao, helpers)
       local query = self.req.params_get

--- a/kong/api/routes/health.lua
+++ b/kong/api/routes/health.lua
@@ -17,20 +17,6 @@ local data_plane_role = kong.configuration.role == "data_plane"
 
 
 return {
-  ["/config/ready"] = {
-    GET = function(self, dao, helpers)
-      if kong.db.strategy ~= "off" then
-        return kong.response.exit(200)
-      end
-    -- unintuitively, "true" is unitialized. we do always initialize the shdict key
-    -- after a config loads, this returns the hash string
-    if not declarative.has_config() then
-      return kong.response.exit(503)
-    end
-
-    return kong.response.exit(200)
-    end
-  },
   ["/status"] = {
     GET = function(self, dao, helpers)
       local query = self.req.params_get

--- a/kong/api/routes/health.lua
+++ b/kong/api/routes/health.lua
@@ -24,7 +24,7 @@ return {
       end
     -- unintuitively, "true" is unitialized. we do always initialize the shdict key
     -- after a config loads, this returns the hash string
-    if declarative.get_current_hash() == true then
+    if not declarative.has_config() then
       return kong.response.exit(503)
     end
 

--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -188,6 +188,7 @@ local constants = {
   DECLARATIVE_LOAD_KEY = "declarative_config:loaded",
   DECLARATIVE_HASH_KEY = "declarative_config:hash",
   DECLARATIVE_EMPTY_CONFIG_HASH = string.rep("0", 32),
+  DECLARATIVE_CONFIG_READY_KEY = "declarative_config:ready",
 
   CLUSTER_ID_PARAM_KEY = "cluster_id",
 

--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -38,11 +38,8 @@ local PREFIX = ngx.config.prefix()
 local SUBSYS = ngx.config.subsystem
 local WORKER_COUNT = ngx.worker.count()
 local DECLARATIVE_HASH_KEY = constants.DECLARATIVE_HASH_KEY
-<<<<<<< HEAD
 local DECLARATIVE_EMPTY_CONFIG_HASH = constants.DECLARATIVE_EMPTY_CONFIG_HASH
-=======
-local DECLARATIVE_HASH_EMPTY_VALUE = constants.DECLARATIVE_HASH_EMPTY_VALUE
->>>>>>> 9ee265aa7 (feat(db) use a library variable for default hash)
+local DECLARATIVE_CONFIG_READY_KEY = constants.DECLARATIVE_CONFIG_READY_KEY
 
 
 local DECLARATIVE_LOCK_KEY = "declarative:lock"
@@ -577,7 +574,9 @@ end
 
 
 function declarative.has_config()
-  return declarative.get_current_hash() ~= DECLARATIVE_HASH_EMPTY_VALUE
+  if declarative.get_current_hash() ~= DECLARATIVE_HASH_EMPTY_VALUE then
+    return ngx.shared.kong:get(DECLARATIVE_CONFIG_READY_KEY)
+  end
 end
 
 

--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -572,6 +572,15 @@ function declarative.get_current_hash()
 end
 
 
+function declarative.has_config()
+  -- true is the unset value of the config hash
+  -- declarative.load_into_cache() sets DECLARATIVE_HASH_KEY's value to
+  -- "hash or true", and hash is only not set when loading the default (empty)
+  -- config
+  return declarative.get_current_hash() ~= true
+end
+
+
 local function find_default_ws(entities)
   for _, v in pairs(entities.workspaces or {}) do
     if v.name == "default" then

--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -38,7 +38,11 @@ local PREFIX = ngx.config.prefix()
 local SUBSYS = ngx.config.subsystem
 local WORKER_COUNT = ngx.worker.count()
 local DECLARATIVE_HASH_KEY = constants.DECLARATIVE_HASH_KEY
+<<<<<<< HEAD
 local DECLARATIVE_EMPTY_CONFIG_HASH = constants.DECLARATIVE_EMPTY_CONFIG_HASH
+=======
+local DECLARATIVE_HASH_EMPTY_VALUE = constants.DECLARATIVE_HASH_EMPTY_VALUE
+>>>>>>> 9ee265aa7 (feat(db) use a library variable for default hash)
 
 
 local DECLARATIVE_LOCK_KEY = "declarative:lock"
@@ -573,11 +577,7 @@ end
 
 
 function declarative.has_config()
-  -- true is the unset value of the config hash
-  -- declarative.load_into_cache() sets DECLARATIVE_HASH_KEY's value to
-  -- "hash or true", and hash is only not set when loading the default (empty)
-  -- config
-  return declarative.get_current_hash() ~= true
+  return declarative.get_current_hash() ~= DECLARATIVE_HASH_EMPTY_VALUE
 end
 
 

--- a/kong/globalpatches.lua
+++ b/kong/globalpatches.lua
@@ -332,6 +332,11 @@ return function(options)
           if not ok then
             ngx.log(ngx.WARN, "could not store process id in kong shm: ", err)
           end
+          local constants = require "kong.constants"
+          local ok, err = ngx.shared.kong:safe_set(constants.DECLARATIVE_CONFIG_READY_KEY .. pid, false)
+          if not ok then
+              ngx.log(ngx.WARN, "failed to initialize config ready for ", pid, " in SHM: ", err)
+          end
 
           seeded[pid] = true
         end

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -549,10 +549,7 @@ function Kong.init()
   end
 
   if config.database == "off" then
-    local ok, err = ngx.shared.kong:safe_set(constants.DECLARATIVE_CONFIG_READY_KEY, false)
-    if not ok then
-        ngx_log(ngx_ERR, "failed to initialize config ready in SHM: ", err)
-    end
+    local err
     declarative_entities, err, declarative_meta, declarative_hash = parse_declarative_config(kong.configuration)
     if not declarative_entities then
       error(err)

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -549,7 +549,10 @@ function Kong.init()
   end
 
   if config.database == "off" then
-    local err
+    local ok, err = ngx.shared.kong:safe_set(constants.DECLARATIVE_CONFIG_READY_KEY, false)
+    if not ok then
+        ngx_log(ngx_ERR, "failed to initialize config ready in SHM: ", err)
+    end
     declarative_entities, err, declarative_meta, declarative_hash = parse_declarative_config(kong.configuration)
     if not declarative_entities then
       error(err)

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -67,6 +67,7 @@ local HOST_PORTS = {}
 
 local SUBSYSTEMS = constants.PROTOCOLS_WITH_SUBSYSTEM
 local CLEAR_HEALTH_STATUS_DELAY = constants.CLEAR_HEALTH_STATUS_DELAY
+local DECLARATIVE_CONFIG_READY_KEY = constants.DECLARATIVE_CONFIG_READY_KEY
 local TTL_ZERO = { ttl = 0 }
 
 
@@ -387,6 +388,11 @@ local function register_events()
 
       if not ok then
         log(ERR, "config flip failed: ", err)
+      end
+
+      local ok, err = ngx.shared.kong:safe_set(DECLARATIVE_CONFIG_READY_KEY, true)
+      if not ok then
+        log(ERR, "failed to set config ready in SHM: ", err)
       end
     end, "declarative", "flip_config")
 

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -390,9 +390,15 @@ local function register_events()
         log(ERR, "config flip failed: ", err)
       end
 
-      local ok, err = ngx.shared.kong:safe_set(DECLARATIVE_CONFIG_READY_KEY, true)
-      if not ok then
-        log(ERR, "failed to set config ready in SHM: ", err)
+      local ready, err = ngx.shared.kong:get(DECLARATIVE_CONFIG_READY_KEY .. ngx.worker.pid())
+      if err then
+        log(ERR, "failed to get config status from SHM: ", err)
+      end
+      if not ready then
+        local ok, err = ngx.shared.kong:safe_set(DECLARATIVE_CONFIG_READY_KEY .. ngx.worker.pid(), true)
+        if not ok then
+          log(ERR, "failed to set config status in SHM: ", err)
+        end
       end
     end, "declarative", "flip_config")
 

--- a/kong/status/init.lua
+++ b/kong/status/init.lua
@@ -27,6 +27,7 @@ ngx.log(ngx.DEBUG, "Loading Status API endpoints")
 
 -- Load core health route
 api_helpers.attach_routes(app, require "kong.api.routes.health")
+api_helpers.attach_routes(app, require "kong.status.routes.config")
 
 
 if kong.configuration.database == "off" then

--- a/kong/status/routes/config.lua
+++ b/kong/status/routes/config.lua
@@ -1,0 +1,20 @@
+local declarative = require("kong.db.declarative")
+
+local kong = kong
+
+return {
+  ["/status/config"] = {
+    GET = function(self, dao, helpers)
+      if kong.db.strategy ~= "off" then
+        return kong.response.exit(200)
+      end
+    -- unintuitively, "true" is unitialized. we do always initialize the shdict key
+    -- after a config loads, this returns the hash string
+    if not declarative.has_config() then
+      return kong.response.exit(503)
+    end
+
+    return kong.response.exit(200)
+    end
+  },
+}

--- a/kong/status/routes/config.lua
+++ b/kong/status/routes/config.lua
@@ -8,13 +8,12 @@ return {
       if kong.db.strategy ~= "off" then
         return kong.response.exit(200)
       end
-    -- unintuitively, "true" is unitialized. we do always initialize the shdict key
-    -- after a config loads, this returns the hash string
-    if not declarative.has_config() then
-      return kong.response.exit(503)
+    local ready, hash = declarative.has_config()
+    if not ready then
+      return kong.response.exit(503, hash)
     end
 
-    return kong.response.exit(200)
+    return kong.response.exit(200, hash)
     end
   },
 }

--- a/spec/02-integration/04-admin_api/02-kong_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/02-kong_routes_spec.lua
@@ -246,7 +246,7 @@ describe("Admin API - Kong routes with strategy #" .. strategy, function()
         assert(shm_client:send {
           method = "PUT",
           path = "/shm?key=" .. constants.DECLARATIVE_HASH_KEY,
-          body = "true"
+          body = tostring(constants.DECLARATIVE_HASH_EMPTY_VALUE)
         })
 
         local res = assert(client:send {


### PR DESCRIPTION
### Summary

Adds a config readiness endpoint. This is designed to [allow the Ingress controller to detect when Kong has restarted](https://github.com/Kong/kubernetes-ingress-controller/issues/2107) and needs to receive configuration again. It should also be useful for load balancers that want to avoid sending requests through an instance before it is ready to process them.

### Full changelog

* Add a config readiness endpoint and include it on the status listen. When db="off", it returns a 200 if Kong has loaded or received a configuration and applied it, or 503 if not.
* Compute hashes when loading configuration from the environment, to distinguish between user-supplied configuration and the default blank configuration.
* Set the database mode to the strategy for Kong endpoint tests. It's unclear if this was the earlier intent, since the previous strategy effectively did nothing as best I can tell. Doing so is necessary for the new endpoint tests to function.
* Use the config hash when updating the stream configuration. Unclear if this is necessary, since we presumably can't check its SHM value until the stream and HTTP SHMs are unified (the admin API only looks at the HTTP subsystem SHM). We send it though, so may as well :shrug: 