### PR TITLE
fix(*) catch file read failures

### DIFF
--- a/kong/clustering/init.lua
+++ b/kong/clustering/init.lua
@@ -75,15 +75,13 @@ function _M.new(conf)
 
   setmetatable(self, MT)
 
-  -- note: pl_file.read throws error on failure so
-  -- no need for error checking
-  local cert = pl_file.read(conf.cluster_cert)
+  local cert = assert(pl_file.read(conf.cluster_cert))
   self.cert = assert(ssl.parse_pem_cert(cert))
 
   cert = openssl_x509.new(cert, "PEM")
   self.cert_digest = cert:digest("sha256")
 
-  local key = pl_file.read(conf.cluster_cert_key)
+  local key = assert(pl_file.read(conf.cluster_cert_key))
   self.cert_key = assert(ssl.parse_pem_priv_key(key))
 
   self.child = require("kong.clustering." .. conf.role).new(self)

--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -186,7 +186,7 @@ local function gen_trusted_certs_combined_file(combined_filepath, paths)
   local fd = assert(io.open(combined_filepath, "w"))
 
   for _, path in ipairs(paths) do
-    fd:write(pl_file.read(path))
+    fd:write(assert(pl_file.read(path)))
     fd:write("\n")
   end
 
@@ -430,7 +430,12 @@ local function prepare_prefix(kong_config, nginx_custom_template_path, skip_writ
     if not pl_path.exists(nginx_custom_template_path) then
       return nil, "no such file: " .. nginx_custom_template_path
     end
-    nginx_template = pl_file.read(nginx_custom_template_path)
+    local read_err
+    nginx_template, read_err = pl_file.read(nginx_custom_template_path)
+    if not nginx_template then
+      read_err = tostring(read_err or "unknown error")
+      return nil, "failed reading custom nginx template file: " .. read_err
+    end
   end
 
   if kong_config.proxy_ssl_enabled or

--- a/spec/01-unit/04-prefix_handler_spec.lua
+++ b/spec/01-unit/04-prefix_handler_spec.lua
@@ -935,6 +935,15 @@ describe("NGINX conf compiler", function()
     describe("custom template", function()
       local templ_fixture = "spec/fixtures/custom_nginx.template"
 
+      lazy_setup(function()
+        pcall(helpers.dir.rmtree, "/tmp/not-a-file")
+        assert(helpers.dir.makepath("/tmp/not-a-file"))
+      end)
+
+      lazy_teardown(function()
+        pcall(helpers.dir.rmtree, "/tmp/not-a-file")
+      end)
+
       it("accepts a custom NGINX conf template", function()
         assert(prefix_handler.prepare_prefix(tmp_config, templ_fixture))
         assert.truthy(exists(tmp_config.nginx_conf))
@@ -948,6 +957,11 @@ describe("NGINX conf compiler", function()
         local ok, err = prefix_handler.prepare_prefix(tmp_config, "spec/fixtures/inexistent.template")
         assert.is_nil(ok)
         assert.equal("no such file: spec/fixtures/inexistent.template", err)
+      end)
+      it("errors on file read failures", function()
+        local ok, err = prefix_handler.prepare_prefix(tmp_config, "/tmp/not-a-file")
+        assert.is_nil(ok)
+        assert.matches("failed reading custom nginx template file: /tmp/not-a-file", err, nil, true)
       end)
       it("reports Penlight templating errors", function()
         local u = helpers.unindent


### PR DESCRIPTION
There were some spots in `kong.clustering` that assumed `pl_file.read()` would throw an error on failure, causing it to throw cryptic errors when we can't read a file:

```
[error] 2050#0: init_by_lua error: /usr/local/openresty/lualib/ngx/ssl.lua:378: attempt to get length of local 'pem' (a nil value)
stack traceback:
        /usr/local/openresty/lualib/ngx/ssl.lua:378: in function 'parse_pem_priv_key'
        /usr/local/share/lua/5.1/kong/clustering/init.lua:130: in function 'new'
        /usr/local/share/lua/5.1/kong/init.lua:613: in function 'init'
        init_by_lua:3: in main chunk
nginx: [error] init_by_lua error: /usr/local/openresty/lualib/ngx/ssl.lua:378: attempt to get length of local 'pem' (a nil value)
```

I have wrapped these in `assert()` so that Kong will throw a more meaningful error in this case.

I also found a couple more cases of this in `cmd.utils.prefix_handler` (one of which results in Kong loading the default NGINX template instead of the user's specified custom template). I fixed these and added a test case.

Adding meaningful test coverage for `kong.clustering.new()` is a little more involved due to it needing to invoke a whole bunch of dependencies when `require`-ing the `kong.clustering.*` child modules (therefore necessitating lots of boilerplate setup code _or_ hack-y `package.loaded` munging). I think things are okay as-is, but if more test coverage is needed I'm happy to add it.