### PR TITLE
style(runloop) remove local ngx.null reference

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -31,7 +31,6 @@ local var          = ngx.var
 local log          = ngx.log
 local exit         = ngx.exit
 local exec         = ngx.exec
-local null         = ngx.null
 local header       = ngx.header
 local timer_at     = ngx.timer.at
 local timer_every  = ngx.timer.every
@@ -69,7 +68,7 @@ local TTL_ZERO = { ttl = 0 }
 local ROUTER_SYNC_OPTS
 local PLUGINS_ITERATOR_SYNC_OPTS
 local FLIP_CONFIG_OPTS
-local GLOBAL_QUERY_OPTS = { workspace = null, show_ws_id = true }
+local GLOBAL_QUERY_OPTS = { workspace = ngx.null, show_ws_id = true }
 
 
 local get_plugins_iterator, get_updated_plugins_iterator


### PR DESCRIPTION


### Summary

It looks like there is no other reference of ngx.null,
so the localization of ngx.null is useless,
just like we did to ngx.config.prefix.

Please do a double check for handler.lua.

### Full changelog

* remove localization of ngx.null
* use ngx.null in GLOBAL_QUERY_OPTS


