### PR TITLE
fix(conf) check transfer-encoding header presence before adding content-length header

### DIFF
--- a/kong/pdk/response.lua
+++ b/kong/pdk/response.lua
@@ -651,7 +651,9 @@ local function new(self, major_version)
           then
             has_content_type = true
           elseif lower_name == "content-length"
-              or lower_name == "content_length" then
+              or lower_name == "content_length"
+              or lower_name == "transfer-encoding"
+              or lower_name == "transfer_encoding" then
             has_content_length = true
           end
         end

--- a/kong/pdk/response.lua
+++ b/kong/pdk/response.lua
@@ -640,22 +640,21 @@ local function new(self, major_version)
     ngx.status = status
 
     local has_content_type
-    local has_content_length_or_chunked
+    local has_content_length
     if headers ~= nil then
       for name, value in pairs(headers) do
         ngx.header[name] = normalize_multi_header(value)
-        if not has_content_type or not has_content_length_or_chunked then
+        if not has_content_type or not has_content_length then
           local lower_name = lower(name)
           if lower_name == "content-type"
-            or lower_name == "content_type"
+          or lower_name == "content_type"
           then
             has_content_type = true
           elseif lower_name == "content-length"
-            or lower_name == "content_length"
-            or ((lower_name == "transfer-encoding" or
-                  lower_name == "transfer_encoding") and
-                  value == 'chunked')  then
-            has_content_length_or_chunked = true
+              or lower_name == "content_length"
+              or lower_name == "transfer-encoding"
+              or lower_name == "transfer_encoding" then
+            has_content_length = true
           end
         end
       end
@@ -723,7 +722,7 @@ local function new(self, major_version)
         ngx.header[CONTENT_TYPE_NAME] = CONTENT_TYPE_JSON
       end
 
-      if not has_content_length_or_chunked then
+      if not has_content_length then
         ngx.header[CONTENT_LENGTH_NAME] = #json
       end
 
@@ -747,7 +746,7 @@ local function new(self, major_version)
         end
 
       else
-        if not has_content_length_or_chunked then
+        if not has_content_length then
           ngx.header[CONTENT_LENGTH_NAME] = #body
         end
 
@@ -764,7 +763,7 @@ local function new(self, major_version)
       end
 
     else
-      if not has_content_length_or_chunked then
+      if not has_content_length then
         ngx.header[CONTENT_LENGTH_NAME] = 0
       end
 

--- a/t/01-pdk/08-response/11-exit.t
+++ b/t/01-pdk/08-response/11-exit.t
@@ -1125,3 +1125,29 @@ unable to proxy stream connection, status: 400, err: error message
 [error]
 --- error_log
 finalize stream session: 200
+
+
+
+=== TEST 44: response.exit() does not set content-length header when transfer-encoding header is present
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        default_type 'text/test';
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            pdk.response.exit(200, "", {
+                ["Transfer-Encoding"] = "chunked" 
+            })
+        }
+    }
+--- request
+GET /t
+--- error_code: 200
+--- response_headers_like
+Transfer-Encoding: chunked
+--- response_body chop
+
+--- no_error_log
+[error]


### PR DESCRIPTION
### **Summary**
When calling kong.response.exit(), the function automatically sets the Content-Length header on the response even if the Transfer-Encoding header is present. This is in violation of RFC 7230 3.3.2:

> A sender MUST NOT send a Content-Length header field in any message
> that contains a Transfer-Encoding header field.
> 

### Full changelog

* If the transfer-encoding header is present in the response then assign the variable `has_content_length = true` in the function `send(status, body, headers)`.
* Add an extra test case on the function's specs.


### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
[Fix #8083](https://github.com/Kong/kong/issues/8083)
