### PR TITLE
fix(makefile) grpcurl compatible with aarch64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,12 @@ OPENSSL_DIR ?= /usr
 GRPCURL_OS ?= $(OS)
 endif
 
+ifeq ($(MACHINE), aarch64)
+GRPCURL_MACHINE ?= arm64
+else
+GRPCURL_MACHINE ?= $(MACHINE)
+endif
+
 .PHONY: install dependencies dev remove grpcurl \
 	setup-ci setup-kong-build-tools \
 	lint test test-integration test-plugins test-all \

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ dependencies: bin/grpcurl
 
 bin/grpcurl:
 	@curl -s -S -L \
-		https://github.com/fullstorydev/grpcurl/releases/download/v$(GRPCURL_VERSION)/grpcurl_$(GRPCURL_VERSION)_$(GRPCURL_OS)_$(MACHINE).tar.gz | tar xz -C bin;
+		https://github.com/fullstorydev/grpcurl/releases/download/v$(GRPCURL_VERSION)/grpcurl_$(GRPCURL_VERSION)_$(GRPCURL_OS)_$(GRPCURL_MACHINE).tar.gz | tar xz -C bin;
 	@rm bin/LICENSE
 
 dev: remove install dependencies


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

Download grpcurl arm64 version when the machine is aarch64.

Failed to exec `make bin/grpcul` on Mac M1 Docker container (ubuntu image, `uname -m`: aarch64).
See: https://stackoverflow.com/questions/31851611/differences-between-arm64-and-aarch64
AArch64 and ARM64 refer to the same thing.

### Full changelog

* Download grpcurl arm64 version when the machine is aarch64.
