### PR TITLE
fix(router) remove last dot in FQDNs

### DIFF
--- a/kong/router.lua
+++ b/kong/router.lua
@@ -38,6 +38,7 @@ local server_name   = require("ngx.ssl").server_name
 local REGEX_PREFIX  = "(*LIMIT_MATCH=10000)"
 local SLASH         = byte("/")
 
+local DEBUG         = ngx.DEBUG
 local ERR           = ngx.ERR
 local WARN          = ngx.WARN
 
@@ -621,6 +622,11 @@ local function marshall_route(r)
       for _, sni in ipairs(snis) do
         if type(sni) ~= "string" then
           return nil, "sni elements must be strings"
+        end
+        
+        if sni:len() > 1 and sni:sub(-1) == "." then
+          log(DEBUG, "last dot in FQDNs must not be used for routing, removing in ", sni)
+          sni = sni:sub(1, -2)
         end
 
         route_t.match_rules = bor(route_t.match_rules, MATCH_RULES.SNI)


### PR DESCRIPTION
### Summary

When a route has an SNI attribute containing an FQDN ending in a dot, the trailing dot was being used to match routes. But according to [RFC-3546](https://datatracker.ietf.org/doc/html/rfc3546#section-3.1), this trailing dot is not part of the hostname, thus must not be used for matching.

This change updates the route marshaling function to not include the trailing dot in this case.

### Full changelog

* Remove trailing dot from SNIs in route marshaling function.
* Added test for specific case.

### Issue reference

Fix #7550
CT-236
