### PR TITLE
fix(tests) add pl_path.mkdir(nginx_prefix)

### DIFF
--- a/spec/helpers/perf/drivers/local.lua
+++ b/spec/helpers/perf/drivers/local.lua
@@ -81,6 +81,8 @@ function _M:start_upstreams(conf, port_count)
 
   local nginx_conf_path = "/tmp/perf-test-nginx.conf"
   local nginx_prefix = "/tmp/perf-test-nginx"
+
+  pl_path.mkdir(nginx_prefix)
   pl_path.mkdir(nginx_prefix .. "/logs")
 
   local f = io.open(nginx_conf_path, "w")

--- a/spec/helpers/perf/drivers/local.lua
+++ b/spec/helpers/perf/drivers/local.lua
@@ -66,7 +66,7 @@ function _M:teardown()
 
   perf.git_restore()
 
-  perf.execute("rm -v " .. WRK_SCRIPT_PREFIX .. "*.lua",
+  perf.execute("rm -vf " .. WRK_SCRIPT_PREFIX .. "*.lua",
               { logger = self.log.log_exec })
 
   return self:stop_kong()


### PR DESCRIPTION


### Summary

In perf local dirver, if there is no dir '/tmp/perf-test-nginx',
the 'mkdir /tmp/perf-test-nginx/logs' will failed,
then the perf test will failed.

pl.path.mkdir can not create dir recursively, 
so we have to create it by our self.

### Full changelog

* add pl_path.mkdir(nginx_prefix)

