### PR TITLE
tests(perf) add env to adjust perf test load duration

### DIFF
--- a/spec/04-perf/01-rps/01-simple_spec.lua
+++ b/spec/04-perf/01-rps/01-simple_spec.lua
@@ -31,7 +31,7 @@ if env_versions then
   versions = split(env_versions, ",")
 end
 
-local LOAD_DURATION = 30
+local LOAD_DURATION = os.getenv("PERF_TEST_LOAD_DURATION") or 30
 
 local SERVICE_COUNT = 10
 local ROUTE_PER_SERVICE = 10

--- a/spec/04-perf/01-rps/02-balancer_spec.lua
+++ b/spec/04-perf/01-rps/02-balancer_spec.lua
@@ -31,7 +31,7 @@ if env_versions then
   versions = split(env_versions, ",")
 end
 
-local LOAD_DURATION = 30
+local LOAD_DURATION = os.getenv("PERF_TEST_LOAD_DURATION") or 30
 
 local function print_and_save(s, path)
   os.execute("mkdir -p output")

--- a/spec/04-perf/01-rps/03-plugin_iterator_spec.lua
+++ b/spec/04-perf/01-rps/03-plugin_iterator_spec.lua
@@ -31,7 +31,7 @@ if env_versions then
   versions = split(env_versions, ",")
 end
 
-local LOAD_DURATION = 30
+local LOAD_DURATION = os.getenv("PERF_TEST_LOAD_DURATION") or 30
 
 local function print_and_save(s, path)
   os.execute("mkdir -p output")


### PR DESCRIPTION


### Summary

Sometime we want to shorter or longer time for perf test,
the original load duration is fixed to 30s in code,
now we can use env to adjust this value

### Full changelog

* check env PERF_TEST_LOAD_DURATION in perf test


