### PR TITLE
tests(flamegraph) fix generate flamegraph in local driver

### DIFF
--- a/spec/helpers/perf/drivers/local.lua
+++ b/spec/helpers/perf/drivers/local.lua
@@ -242,18 +242,16 @@ function _M:generate_flamegraph(title, opts)
     "/tmp/perf-ost/fix-lua-bt " .. path .. ".bt > " .. path .. ".fbt",
     "/tmp/perf-fg/stackcollapse-stap.pl " .. path .. ".fbt > " .. path .. ".cbt",
     "/tmp/perf-fg/flamegraph.pl --title='" .. title .. "' " .. (opts or "") .. " " .. path .. ".cbt > " .. path .. ".svg",
-    "cat " .. path .. ".svg",
   }
   local out, err
   for _, cmd in ipairs(cmds) do
-    local is_cat_cmd = string.find(cmd, "cat ", 1, true)
-    local opts = is_cat_cmd and {} or { logger = self.log.log_exec }
-
-    out, err = perf.execute(cmd, opts)
+    out, err = perf.execute(cmd, { logger = self.log.log_exec })
     if err then
       return nil, cmd .. " failed: " .. err
     end
   end
+
+  local out, _ = perf.execute("cat " .. path .. ".svg")
 
   perf.execute("rm " .. path .. ".*")
 

--- a/spec/helpers/perf/drivers/local.lua
+++ b/spec/helpers/perf/drivers/local.lua
@@ -246,7 +246,9 @@ function _M:generate_flamegraph(title, opts)
   }
   local out, err
   for _, cmd in ipairs(cmds) do
-    out, err = perf.execute(cmd, { logger = self.log.log_exec })
+    local is_cat_cmd = string.find(cmd, "cat ", 1, true)
+
+    out, err = perf.execute(cmd, { logger = is_cat_cmd and nil or self.log.log_exec })
     if err then
       return nil, cmd .. " failed: " .. err
     end

--- a/spec/helpers/perf/drivers/local.lua
+++ b/spec/helpers/perf/drivers/local.lua
@@ -243,9 +243,9 @@ function _M:generate_flamegraph(title, opts)
     "/tmp/perf-fg/stackcollapse-stap.pl " .. path .. ".fbt > " .. path .. ".cbt",
     "/tmp/perf-fg/flamegraph.pl --title='" .. title .. "' " .. (opts or "") .. " " .. path .. ".cbt > " .. path .. ".svg",
   }
-  local out, err
+  local err
   for _, cmd in ipairs(cmds) do
-    out, err = perf.execute(cmd, { logger = self.log.log_exec })
+    _, err = perf.execute(cmd, { logger = self.log.log_exec })
     if err then
       return nil, cmd .. " failed: " .. err
     end

--- a/spec/helpers/perf/drivers/local.lua
+++ b/spec/helpers/perf/drivers/local.lua
@@ -247,8 +247,9 @@ function _M:generate_flamegraph(title, opts)
   local out, err
   for _, cmd in ipairs(cmds) do
     local is_cat_cmd = string.find(cmd, "cat ", 1, true)
+    local opts = is_cat_cmd and {} or { logger = self.log.log_exec }
 
-    out, err = perf.execute(cmd, { logger = is_cat_cmd and nil or self.log.log_exec })
+    out, err = perf.execute(cmd, opts)
     if err then
       return nil, cmd .. " failed: " .. err
     end


### PR DESCRIPTION

### Summary

When generate flame graph in local drive,
The `cat` cmd will dump the svg into logger but not stdout,
so we should check the cmd, if it is cat then use an empty opts.

### Full changelog

* add a flag is_cat_cmd
* check flag to determine opts
