### PR TITLE
deps(penlight) Bump to 1.12

### DIFF
--- a/kong-2.7.0-0.rockspec
+++ b/kong-2.7.0-0.rockspec
@@ -15,7 +15,7 @@ dependencies = {
   "inspect == 3.1.2",
   "luasec == 1.0.2",
   "luasocket == 3.0-rc1",
-  "penlight == 1.11.0",
+  "penlight == 1.12.0",
   "lua-resty-http == 0.16.1",
   "lua-resty-jit-uuid == 0.0.7",
   "lua-ffi-zlib == 0.5",


### PR DESCRIPTION
Changelog: https://github.com/lunarmodules/Penlight/blob/master/CHANGELOG.md#1120-2022-jan-10

## 1.12.0 (2022-Jan-10)
 - deprecate: module `pl.text` the contents have moved to `pl.stringx` (removal later) [#407](https://github.com/lunarmodules/Penlight/pull/407)
 - deprecate: module `pl.xml`, please switch to a more specialized library (removal later) [#409](https://github.com/lunarmodules/Penlight/pull/409)
 - feat: `utils.npairs` added. An iterator with a range that honours the `n` field [#387](https://github.com/lunarmodules/Penlight/pull/387)
 - fix: `xml.maptags` would hang if it encountered text-nodes [#396](https://github.com/lunarmodules/Penlight/pull/396)
 - fix: `text.dedent` didn't handle declining indents nor empty lines [#402](https://github.com/lunarmodules/Penlight/pull/402)
 - fix: `dir.getfiles`, `dir.getdirectories`, and `dir.getallfiles` now have the directory optional, as was already documented [#405](https://github.com/lunarmodules/Penlight/pull/405)
 - feat: `array2d.default_range` now also takes a spreadsheet range, which means also other functions now take a range. [#404](https://github.com/lunarmodules/Penlight/pull/404)
 - fix: `lapp` enums allow [patterns magic characters](https://www.lua.org/pil/20.2.html) [#393](https://github.com/lunarmodules/Penlight/pull/393)
 - fix: `text.wrap` and `text.fill` numerous fixes for handling whitespace, accented characters, honouring width, etc. [#400](https://github.com/lunarmodules/Penlight/pull/400)
 - feat: `text.wrap` and `text.fill` have a new parameter to forcefully break words longer than the width given. [#400](https://github.com/lunarmodules/Penlight/pull/400)
 - fix: `stringx.expandtabs` could error out on Lua 5.3+ [#406](https://github.com/lunarmodules/Penlight/pull/406)
 - fix: `pl` the module would not properly forward the `newindex` metamethod on the global table. [#395](https://github.com/lunarmodules/Penlight/pull/395)
 - feat: `utils.enum` added to create enums and prevent magic strings [#408](https://github.com/lunarmodules/Penlight/pull/408)
 - change: `xml.new` added some sanity checks on input [#397](https://github.com/lunarmodules/Penlight/pull/397)
 - added: `xml.xml_escape` and `xml.xml_unescape` functions (previously private) [#397](https://github.com/lunarmodules/Penlight/pull/397)
 - feat: `xml.tostring` now also takes numeric indents (previously only strings) [#397](https://github.com/lunarmodules/Penlight/pull/397)
 - fix: `xml.walk` now detects recursion (errors out) [#397](https://github.com/lunarmodules/Penlight/pull/397)
 - fix: `xml.clone` now detects recursion (errors out) [#397](https://github.com/lunarmodules/Penlight/pull/397)
 - fix: `xml.compare` now detects recursion (errors out) [#397](https://github.com/lunarmodules/Penlight/pull/397)
 - fix: `xml.compare` text compares now work [#397](https://github.com/lunarmodules/Penlight/pull/397)
 - fix: `xml.compare` attribute order compares now only compare if both inputs provide an order [#397](https://github.com/lunarmodules/Penlight/pull/397)
 - fix: `xml.compare` child comparisons failing now report proper error [#397](https://github.com/lunarmodules/Penlight/pull/397)
