### PR TITLE
fix(extplugin) add type unwrap functions

### DIFF
--- a/kong/runloop/plugin_servers/pb_rpc.lua
+++ b/kong/runloop/plugin_servers/pb_rpc.lua
@@ -82,6 +82,12 @@ do
     [".kong_plugin_protocol.ExitArgs"] = function (d)
       return d.status, d.body, structpb_struct(d.headers)
     end,
+    [".kong_plugin_protocol.ConsumerSpec"] = function (d)
+      return d.id, d.by_username
+    end,
+    [".kong_plugin_protocol.AuthenticateArgs"] = function (d)
+      return d.consumer, d.credential
+    end,
   }
 end
 


### PR DESCRIPTION
### Summary

ConsumerSpec and AuthenticateArgs type defined in proto need unwrapping, otherwise
`client.load_consumer()` and `client.authentication()` will not work with external plugin via pb-rpc protocol.

### Full changelog

* Add type unwrap functions for ConsumerSpec and AuthenticateArgs

### Issue reference

Fix #8279
