### PR TITLE
 Fix broken links to DB-less and Declarative config on Admin API

### DIFF
--- a/autodoc/admin-api/data/admin-api.lua
+++ b/autodoc/admin-api/data/admin-api.lua
@@ -60,7 +60,7 @@ return {
     { title = [[DB-less mode]],
       text = [[
 
-        In [DB-less mode](../db-less-and-declarative-config), the Admin API can be used to load a new declarative
+        In [DB-less mode](../reference/db-less-and-declarative-config), the Admin API can be used to load a new declarative
         configuration, and for inspecting the current configuration. In DB-less mode,
         the Admin API for each Kong node functions independently, reflecting the memory state
         of that particular Kong node. This is the case because there is no database
@@ -106,7 +106,7 @@ return {
         given file take their place.
 
         To learn more about the file format, see the
-        [declarative configuration](../db-less-and-declarative-config) documentation.
+        [declarative configuration](../reference/db-less-and-declarative-config) documentation.
 
 
         <div class="endpoint post indent">/config</div>


### PR DESCRIPTION
### Summary

Broken links in the docs.

### Full changelog

* Fix links in `autodocs/admin-api`

### Issue reference

Related to https://github.com/Kong/docs.konghq.com/pull/3549
