### PR TITLE
chore(deps) bump resty.session from 3.8 to 3.10

### DIFF
--- a/kong-2.7.0-0.rockspec
+++ b/kong-2.7.0-0.rockspec
@@ -40,7 +40,7 @@ dependencies = {
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6.1",
   "lua-resty-acme == 0.7.2",
-  "lua-resty-session == 3.8",
+  "lua-resty-session == 3.10",
 }
 build = {
   type = "builtin",


### PR DESCRIPTION
### Summary

### Fixed
- Fix 138 issue of chunked cookies are not expired when session shrinks,   thanks @alexdowad.
- Fix 134 where regenerate strategy destroyed previous session when calling   `session:regenerate`, it should just `ttl` the old session, thanks @hoebelix
- 3.9 introduced an issue where calling session:regenerate with flush=true, didn't really flush if the session strategy was `regenerate`.


### Added
- AES GCM mode support was added to AES cipher.   This is recommended, but for backward compatibility it was not set as default.  It will be changed in 4.0 release.
- Redis ACL authentication is now available.
  - Add `session_redis_username`
  - Add `session_redis_password`
  - Deprecate `session_redis_auth`; use `session_redis_password`

### Changed
- Optimize Redis and Memcache storage adapters to not connect to database when not needed.