### PR TITLE
tests(dns) fix dns resolve in 14-dns_spec.lua

### DIFF
--- a/spec/01-unit/14-dns_spec.lua
+++ b/spec/01-unit/14-dns_spec.lua
@@ -5,8 +5,9 @@ local utils = require "kong.tools.utils"
 local ws_id = utils.uuid()
 
 local function setup_it_block()
-  local cache_table = {}
   local client = require "kong.resty.dns.client"
+
+  local cache_table = {}
 
   local function mock_cache(cache_table, limit)
     return {


### PR DESCRIPTION

### Summary

There is a implicit call of dns.client.init in 
setup_it_block() => balancer.init() =>  targets.init(),
so the dns.client.init in before_each will be overwrited and can not work.

To solve this, we should move dns.client.init into setup_it_block(),
then dns.client can use proprer init configration.

### Full changelog

* move dns.client.init into setup_it_block()

