### PR TITLE
chore(*) add Github Action labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -22,7 +22,8 @@ core/db:
 
 core/docs:
 - kong/autodoc/**/*
-- *.md
+- ./**/*.md
+- ./*.md
 
 core/language/go:
 - kong/runloop/plugin_servers/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -53,114 +53,114 @@ chore:
 - .devcontainer/**/*
 
 plugins/acl:
-- kong/plugins/acl
+- kong/plugins/acl/**/*
 
 plugins/acme:
-- kong/plugins/acme
+- kong/plugins/acme/**/*
 
 plugins/aws-lambda:
-- kong/plugins/aws-lambda
+- kong/plugins/aws-lambda/**/*
 
 plugins/azure-functions:
-- kong/plugins/azure-functions
+- kong/plugins/azure-functions/**/*
 
 plugins/basic-auth:
-- kong/plugins/basic-auth
+- kong/plugins/basic-auth/**/*
 
 plugins/bot-detection:
-- kong/plugins/bot-detection
+- kong/plugins/bot-detection/**/*
 
 plugins/correlation-id:
-- kong/plugins/correlation-id
+- kong/plugins/correlation-id/**/*
 
 plugins/cors:
-- kong/plugins/cors
+- kong/plugins/cors/**/*
 
 plugins/datadog:
-- kong/plugins/datadog
+- kong/plugins/datadog/**/*
 
 plugins/file-log:
-- kong/plugins/file-log
+- kong/plugins/file-log/**/*
 
 plugins/grpc-gateway:
-- kong/plugins/grpc-gateway
+- kong/plugins/grpc-gateway/**/*
 
 plugins/grpc-web:
-- kong/plugins/grpc-web
+- kong/plugins/grpc-web/**/*
 
 plugins/hmac-auth:
-- kong/plugins/hmac-auth
+- kong/plugins/hmac-auth/**/*
 
 plugins/http-log:
-- kong/plugins/http-log
+- kong/plugins/http-log/**/*
 
 plugins/ip-restriction:
-- kong/plugins/ip-restriction
+- kong/plugins/ip-restriction/**/*
 
 plugins/jwt:
-- kong/plugins/jwt
+- kong/plugins/jwt/**/*
 
 plugins/key-auth:
-- kong/plugins/key-auth
+- kong/plugins/key-auth/**/*
 
 plugins/ldap-auth:
-- kong/plugins/ldap-auth
+- kong/plugins/ldap-auth/**/*
 
 plugins/log-serializers:
-- kong/plugins/log-serializers
+- kong/plugins/log-serializers/**/*
 
 plugins/loggly:
-- kong/plugins/loggly
+- kong/plugins/loggly/**/*
 
 plugins/oauth2:
-- kong/plugins/oauth2
+- kong/plugins/oauth2/**/*
 
 plugins/post-function:
-- kong/plugins/post-function
+- kong/plugins/post-function/**/*
 
 plugins/pre-function:
-- kong/plugins/pre-function
+- kong/plugins/pre-function/**/*
 
 plugins/prometheus:
-- kong/plugins/prometheus
+- kong/plugins/prometheus/**/*
 
 plugins/proxy-cache:
-- kong/plugins/proxy-cache
+- kong/plugins/proxy-cache/**/*
 
 plugins/rate-limiting:
-- kong/plugins/rate-limiting
+- kong/plugins/rate-limiting/**/*
 
 plugins/request-size-limiting:
-- kong/plugins/request-size-limiting
+- kong/plugins/request-size-limiting/**/*
 
 plugins/request-termination:
-- kong/plugins/request-termination
+- kong/plugins/request-termination/**/*
 
 plugins/request-transformer:
-- kong/plugins/request-transformer
+- kong/plugins/request-transformer/**/*
 
 plugins/response-ratelimiting:
-- kong/plugins/response-ratelimiting
+- kong/plugins/response-ratelimiting/**/*
 
 plugins/response-transformer:
-- kong/plugins/response-transformer
+- kong/plugins/response-transformer/**/*
 
 plugins/session:
-- kong/plugins/session
+- kong/plugins/session/**/*
 
 plugins/statsd:
-- kong/plugins/statsd
+- kong/plugins/statsd/**/*
 
 plugins/syslog:
-- kong/plugins/syslog
+- kong/plugins/syslog/**/*
 
 plugins/tcp-log:
-- kong/plugins/tcp-log
+- kong/plugins/tcp-log/**/*
 
 plugins/udp-log:
-- kong/plugins/udp-log
+- kong/plugins/udp-log/**/*
 
 plugins/zipkin:
-- kong/plugins/zipkin
+- kong/plugins/zipkin/**/*
 
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,166 @@
+core/admin-api:
+- kong/api/**/*
+
+core/balancer:
+- kong/runloop/balancer/*
+
+core/cli:
+- kong/cmd/**/*
+
+core/clustering:
+- kong/clustering/**/*
+- kong/cluster_events/**/*
+
+core/configuration:
+- kong/conf_loader/*
+
+core/db/migrations:
+- kong/db/migrations/**/*
+
+core/db:
+- kong/db/**/*
+
+core/docs:
+- kong/autodoc/**/*
+- *.md
+
+core/language/go:
+- kong/runloop/plugin_servers/*
+
+core/language/js:
+- kong/runloop/plugin_servers/*
+
+core/language/python:
+- kong/runloop/plugin_servers/*
+
+core/logs:
+- kong/pdk/log.lua
+
+core/pdk:
+- kong/pdk/**/*
+
+core/proxy:
+- kong/runloop/**/*
+
+core/router:
+- kong/router.lua
+
+core/templates:
+- kong/templates/*
+
+chore:
+- .github/**/*
+- .devcontainer/**/*
+
+plugins/acl:
+- kong/plugins/acl
+
+plugins/acme:
+- kong/plugins/acme
+
+plugins/aws-lambda:
+- kong/plugins/aws-lambda
+
+plugins/azure-functions:
+- kong/plugins/azure-functions
+
+plugins/basic-auth:
+- kong/plugins/basic-auth
+
+plugins/bot-detection:
+- kong/plugins/bot-detection
+
+plugins/correlation-id:
+- kong/plugins/correlation-id
+
+plugins/cors:
+- kong/plugins/cors
+
+plugins/datadog:
+- kong/plugins/datadog
+
+plugins/file-log:
+- kong/plugins/file-log
+
+plugins/grpc-gateway:
+- kong/plugins/grpc-gateway
+
+plugins/grpc-web:
+- kong/plugins/grpc-web
+
+plugins/hmac-auth:
+- kong/plugins/hmac-auth
+
+plugins/http-log:
+- kong/plugins/http-log
+
+plugins/ip-restriction:
+- kong/plugins/ip-restriction
+
+plugins/jwt:
+- kong/plugins/jwt
+
+plugins/key-auth:
+- kong/plugins/key-auth
+
+plugins/ldap-auth:
+- kong/plugins/ldap-auth
+
+plugins/log-serializers:
+- kong/plugins/log-serializers
+
+plugins/loggly:
+- kong/plugins/loggly
+
+plugins/oauth2:
+- kong/plugins/oauth2
+
+plugins/post-function:
+- kong/plugins/post-function
+
+plugins/pre-function:
+- kong/plugins/pre-function
+
+plugins/prometheus:
+- kong/plugins/prometheus
+
+plugins/proxy-cache:
+- kong/plugins/proxy-cache
+
+plugins/rate-limiting:
+- kong/plugins/rate-limiting
+
+plugins/request-size-limiting:
+- kong/plugins/request-size-limiting
+
+plugins/request-termination:
+- kong/plugins/request-termination
+
+plugins/request-transformer:
+- kong/plugins/request-transformer
+
+plugins/response-ratelimiting:
+- kong/plugins/response-ratelimiting
+
+plugins/response-transformer:
+- kong/plugins/response-transformer
+
+plugins/session:
+- kong/plugins/session
+
+plugins/statsd:
+- kong/plugins/statsd
+
+plugins/syslog:
+- kong/plugins/syslog
+
+plugins/tcp-log:
+- kong/plugins/tcp-log
+
+plugins/udp-log:
+- kong/plugins/udp-log
+
+plugins/zipkin:
+- kong/plugins/zipkin
+
+

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,22 @@
+# This workflow will triage pull requests and apply a label based on the
+# paths that are modified in the pull request.
+#
+# To use this workflow, you will need to set up a .github/labeler.yml
+# file with configuration.  For more information, see:
+# https://github.com/actions/labeler
+
+name: Labeler
+on: [pull_request]
+
+jobs:
+  label:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

[actions/labeler](https://github.com/actions/labeler) is an action for automatically labeling pull requests.

#### Usages

See https://github.com/actions/labeler#usage

Edit `.github/labeler.yml` file to add/delete labels or paths.
```yaml
# Add 'repo' label to any root file changes
repo:
- '*'

# Add '@domain/core' label to any change within the 'core' package
@domain/core:
- package/core/*
- package/core/**/*

# Add 'test' label to any change to *.spec.js files within the source dir
test:
- src/**/*.spec.js

# Add 'source' label to any change to src files within the source dir EXCEPT for the docs sub-folder
source:
- any: ['src/**/*', '!src/docs/*']

# Add 'frontend` label to any change to *.js files as long as the `main.js` hasn't changed
frontend:
- any: ['src/**/*.js']
  all: ['!src/main.js']
```