### PR TITLE
fix(dns) check options.search array for dot domain

### DIFF
--- a/kong/resty/dns/client.lua
+++ b/kong/resty/dns/client.lua
@@ -620,9 +620,9 @@ _M.init = function(options)
   log(DEBUG, PREFIX, "search = ", table_concat(options.search,", "))
 
   -- check if there is special domain like "."
-  for i = 1, #options.search do
+  for i = #options.search, 1, -1 do
     if options.search[i] == "." then
-      options.search[i] = ""
+      table_remove(options.search, i)
     end
   end
 

--- a/kong/resty/dns/client.lua
+++ b/kong/resty/dns/client.lua
@@ -619,6 +619,13 @@ _M.init = function(options)
   options.search = options.search or resolv.search or { resolv.domain }
   log(DEBUG, PREFIX, "search = ", table_concat(options.search,", "))
 
+  -- check if there is special domain like "."
+  for i = 1, #options.search do
+    if options.search[i] == "." then
+      options.search[i] = ""
+    end
+  end
+
 
   -- other options
 

--- a/spec/01-unit/21-dns-client/02-client_spec.lua
+++ b/spec/01-unit/21-dns-client/02-client_spec.lua
@@ -207,6 +207,26 @@ describe("[DNS client]", function()
           }, list)
       end)
 
+      it("works with a 'search .' option", function()
+        assert(client.init({
+            resolvConf = {
+              "nameserver 8.8.8.8",
+              "search .",
+              "options ndots:1",
+            }
+          }))
+        local list = {}
+        for qname, qtype in client._search_iter("host", nil) do
+          table.insert(list, tostring(qname)..":"..tostring(qtype))
+        end
+        assert.same({
+            'host:33',
+            'host:1',
+            'host:28',
+            'host:5',
+          }, list)
+      end)
+
       it("works with a 'domain' option", function()
         assert(client.init({
             resolvConf = {
@@ -271,6 +291,26 @@ describe("[DNS client]", function()
             resolvConf = {
               "nameserver 8.8.8.8",
               "search one.com two.com",
+              "options ndots:1",
+            }
+          }))
+        local list = {}
+        for qname, qtype in client._search_iter("host.", nil) do
+          table.insert(list, tostring(qname)..":"..tostring(qtype))
+        end
+        assert.same({
+            'host.:33',
+            'host.:1',
+            'host.:28',
+            'host.:5',
+          }, list)
+      end)
+
+      it("works with a 'search .' option", function()
+        assert(client.init({
+            resolvConf = {
+              "nameserver 8.8.8.8",
+              "search .",
               "options ndots:1",
             }
           }))


### PR DESCRIPTION

### Summary

if `/etc/resolv.conf` has some special value, like `search .`
then in function `search_iter()`, we will get wrong domain `qname..` ,
It is not a valid dns and will cause error.

So we should check the `search` table,
if there is only one char '.', we replace it with '',
then we can get the right dns name 'qname.'

### Full changelog

* check options.search, replace single '.' to ''

