### PR TITLE
docs(changelog) add 2.8 changelog section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,12 @@
 - [0.10.0](#0100---20170307)
 - [0.9.9 and prior](#099---20170202)
 
+## 2.8.0 (UNRELEASED)
+
+### Dependencies
+
+### Additions
+
 ## [2.7.0]
 
 ### Dependencies


### PR DESCRIPTION
A place where new PR for 2.8 can target their Changelog entry to.