### PR TITLE
fix(datadog) default value for metrics specified twice

### DIFF
--- a/kong/plugins/datadog/schema.lua
+++ b/kong/plugins/datadog/schema.lua
@@ -72,7 +72,6 @@ return {
     { protocols = typedefs.protocols },
     { config = {
         type = "record",
-        default = { metrics = DEFAULT_METRICS },
         fields = {
           { host = typedefs.host({ default = "localhost" }), },
           { port = typedefs.port({ default = 8125 }), },


### PR DESCRIPTION
### Summary

I found out that datadog schema specifies default for metrics in two levels. Once in config field level and second in metrics level. The config field level causes validation errors in schema loading but those errors are ignored by our loader for some reason. Still I think this is a bug and the default should not be there twice.