### PR TITLE
docs(autodoc) Update links and output files for Admin API and CLI docs

### DIFF
--- a/autodoc/admin-api/data/admin-api.lua
+++ b/autodoc/admin-api/data/admin-api.lua
@@ -229,12 +229,12 @@ return {
   },
 
   footer = [[
-    [clustering]: /gateway-oss/{{page.kong_version}}/clustering
-    [cli]: /gateway-oss/{{page.kong_version}}/cli
-    [active]: /gateway-oss/{{page.kong_version}}/health-checks-circuit-breakers/#active-health-checks
-    [healthchecks]: /gateway-oss/{{page.kong_version}}/health-checks-circuit-breakers
-    [secure-admin-api]: /gateway-oss/{{page.kong_version}}/secure-admin-api
-    [proxy-reference]: /gateway-oss/{{page.kong_version}}/proxy
+    [clustering]: /gateway/{{page.kong_version}}/reference/clustering
+    [cli]: /gateway/{{page.kong_version}}/reference/cli
+    [active]: /gateway/{{page.kong_version}}/reference/health-checks-circuit-breakers/#active-health-checks
+    [healthchecks]: /gateway/{{page.kong_version}}/reference/health-checks-circuit-breakers
+    [secure-admin-api]: /gateway/{{page.kong_version}}/admin-api/secure-admin-api
+    [proxy-reference]: /gateway/{{page.kong_version}}/reference/proxy
   ]],
 
   general = {
@@ -821,8 +821,8 @@ return {
         },
         enabled = {
           description = [[
-            Whether the Service is active. If set to `false`, the proxy behavior 
-            will be as if any routes attached to it do not exist (404). Default: `true`. 
+            Whether the Service is active. If set to `false`, the proxy behavior
+            will be as if any routes attached to it do not exist (404). Default: `true`.
           ]],
         },
         ca_certificates = {
@@ -929,7 +929,7 @@ return {
         updated_at = { skip = true },
         name = {
           description = [[The name of the Route. Route names must be unique, and they are
-          case sensitive. For example, there can be two different Routes named "test" and 
+          case sensitive. For example, there can be two different Routes named "test" and
           "Test".]]
         },
         regex_priority = {

--- a/autodoc/cli/data.lua
+++ b/autodoc/cli/data.lua
@@ -10,8 +10,6 @@ data.header = [[
 title: CLI Reference
 ---
 
-## Introduction
-
 The provided CLI (*Command Line Interface*) allows you to start, stop, and
 manage your Kong instances. The CLI manages your local node (as in, on the
 current machine).
@@ -26,8 +24,6 @@ All commands take a set of special, optional flags as arguments:
 * `--v`: enable verbose mode
 * `--vv`: enable debug mode (noisy)
 
-[Back to top](#introduction)
-
 ## Available commands
 
 ]]
@@ -40,7 +36,7 @@ data.command_intro = {
 
 data.footer = [[
 
-[configuration-reference]: /gateway-oss/{{page.kong_version}}/configuration
+[configuration-reference]: /gateway/{{page.kong_version}}/reference/configuration/
 ]]
 
 return data

--- a/autodoc/cli/generate.lua
+++ b/autodoc/cli/generate.lua
@@ -47,8 +47,6 @@ for _, cmd in ipairs(cmds) do
   pd:close()
   write("```")
   write("")
-  write("[Back to top](#introduction)")
-  write("")
   write("---")
   write("")
 end

--- a/scripts/autodoc
+++ b/scripts/autodoc
@@ -152,7 +152,7 @@ then
     exit 4
 fi
 
-copy autodoc/output/admin-api/admin-api.md "$DOCS_APP/admin-api.md"
+copy autodoc/output/admin-api/admin-api.md "$DOCS_APP/admin-api/index.md"
 copy autodoc/output/cli.md "$DOCS_APP/reference/cli.md"
 
 rm -rf "$DOCS_APP/install-and-run/upgrade-oss.md"


### PR DESCRIPTION
### Summary

For the Admin API doc:
* Set the correct output file for the Admin API doc in the docs.konghq.com repo. The file path is [`admin-api/index.md`](https://github.com/Kong/docs.konghq.com/blob/main/app/gateway/2.7.x/admin-api/index.md), not `admin-api.md`
* Update links to new structure, as the `gateway-oss` URL is now just `gateway`

For the CLI doc:
* Removing `Back to Top` links from the `generate.lua` file for the CLI doc. As with the PDK, they're redundant: 
  * The docs site has a scroll to top button built in, and a right-side nav to scroll to any header on the page.
* Removing leading `Introduction` header, as this is also redundant
* Update link to new structure, as the `gateway-oss` URL is now just `gateway`

Tested by generating the docs via the script, everything displayed as intended.

### Full changelog

N/A, I think.

### Issue reference

N/A
