### PR TITLE
chore(ci) run the labeler on pull_request_target

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -6,7 +6,7 @@
 # https://github.com/actions/labeler
 
 name: Labeler
-on: [pull_request]
+on: [pull_request_target]
 
 jobs:
   label:

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -6,7 +6,7 @@
 # https://github.com/actions/labeler
 
 name: Labeler
-on: [pull_request_target]
+on: [pull_request, pull_request_target]
 
 jobs:
   label:


### PR DESCRIPTION
The labeler github action is currently failing on PRs [like this one](https://github.com/Kong/kong/pull/8287) that originate from a fork rather than an internal branch:

> Error: HttpError: Resource not accessible by integration
> Error: Resource not accessible by integration

[link](https://github.com/Kong/kong/runs/4903066028)

I believe it's related to [this super long issue](https://github.com/actions/labeler/issues/12)

The generally-accepted solution seems to be using `pull_request_target` as the event trigger instead of `pull_request`, and the github actions [event trigger docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) also seem to imply that it's the proper event trigger for this use case:

> This event runs in the context of the base of the pull request, rather than in the context of the merge commit, as the pull_request event does. This prevents execution of unsafe code from the head of the pull request that could alter your repository or steal any secrets you use in your workflow. **This event allows your workflow to do things like label or comment on pull requests from forks.** Avoid using this event if you need to build or run code from the pull request.

I know almost nothing about github actions, so this definitely needs a +1 from someone who does.

