### PR TITLE
Add review:autodoc to generated docs PR

### DIFF
--- a/.github/workflows/autodocs.yml
+++ b/.github/workflows/autodocs.yml
@@ -135,4 +135,4 @@ jobs:
         run: |
           cd docs.konghq.com
           echo "${{ secrets.PAT }}" | gh auth login --with-token
-          gh pr create --base "${{ github.event.inputs.target_branch }}" --fill
+          gh pr create --base "${{ github.event.inputs.target_branch }}" --fill --label "review:autodoc"


### PR DESCRIPTION
### Summary

The docs repo has a new CI check to help categorise PRs. This PR automatically adds the `review:autodocs` label to any PR raised in the docs repo

### Full changelog

* Use the `review:autodocs` label on generated PRs