### PR TITLE
chore(cache) optimize cache init new

### DIFF
--- a/kong/cache/init.lua
+++ b/kong/cache/init.lua
@@ -49,8 +49,6 @@ function _M.new(opts)
 
   -- opts validation
 
-  opts = opts or {}
-
   if not opts.cluster_events then
     error("opts.cluster_events is required", 2)
   end

--- a/kong/cache/init.lua
+++ b/kong/cache/init.lua
@@ -39,6 +39,10 @@ local mt = { __index = _M }
 
 
 function _M.new(opts)
+  opts = opts or {}
+
+  -- opts validation
+
   if type(opts.shm_name) ~= "string" then
     error("opts.shm_name must be a string", 2)
   end
@@ -46,8 +50,6 @@ function _M.new(opts)
   if _init[opts.shm_name] then
     error("kong.cache (" .. opts.shm_name .. ") was already created", 2)
   end
-
-  -- opts validation
 
   if not opts.cluster_events then
     error("opts.cluster_events is required", 2)


### PR DESCRIPTION


### Summary

Check whether `opts` is table is a good idea,
but it seems to be a little late after checking `opts.shm_name`,
So I moved the code to the begin of the function.

### Full changelog

* check opts in the begin of function.



