### PR TITLE
chore(ci) run the labeler only on pull_request_target

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -6,7 +6,7 @@
 # https://github.com/actions/labeler
 
 name: Labeler
-on: [pull_request, pull_request_target]
+on: [pull_request_target]
 
 jobs:
   label:


### PR DESCRIPTION
See #8322 for more details.

Adding `pull_request_target` was not enough to fix the permission issue. This PR is a workaround, probably the ideal solution is the suggested in [this comment](https://github.com/actions/labeler/issues/12#issuecomment-1019246202).