### PR TITLE
chore(templates) remove unnecessary var index

### DIFF
--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -59,7 +59,6 @@ init_worker_by_lua_block {
 lua_kong_load_var_index $args;
 lua_kong_load_var_index $bytes_sent;
 lua_kong_load_var_index $content_type;
-lua_kong_load_var_index $ctx_ref;
 lua_kong_load_var_index $host;
 lua_kong_load_var_index $http_authorization;
 lua_kong_load_var_index $http_connection;
@@ -78,7 +77,6 @@ lua_kong_load_var_index $http_x_forwarded_proto;
 lua_kong_load_var_index $https;
 lua_kong_load_var_index $http2;
 lua_kong_load_var_index $is_args;
-lua_kong_load_var_index $kong_proxy_mode;
 lua_kong_load_var_index $realip_remote_addr;
 lua_kong_load_var_index $realip_remote_port;
 lua_kong_load_var_index $remote_addr;
@@ -96,22 +94,10 @@ lua_kong_load_var_index $ssl_client_raw_cert;
 lua_kong_load_var_index $ssl_client_verify;
 lua_kong_load_var_index $ssl_protocol;
 lua_kong_load_var_index $ssl_server_name;
-lua_kong_load_var_index $upstream_connection;
-lua_kong_load_var_index $upstream_host;
 lua_kong_load_var_index $upstream_http_connection;
 lua_kong_load_var_index $upstream_http_trailer;
 lua_kong_load_var_index $upstream_http_upgrade;
-lua_kong_load_var_index $upstream_scheme;
 lua_kong_load_var_index $upstream_status;
-lua_kong_load_var_index $upstream_te;
-lua_kong_load_var_index $upstream_uri;
-lua_kong_load_var_index $upstream_upgrade;
-lua_kong_load_var_index $upstream_x_forwarded_for;
-lua_kong_load_var_index $upstream_x_forwarded_host;
-lua_kong_load_var_index $upstream_x_forwarded_path;
-lua_kong_load_var_index $upstream_x_forwarded_port;
-lua_kong_load_var_index $upstream_x_forwarded_prefix;
-lua_kong_load_var_index $upstream_x_forwarded_proto;
 
 upstream kong_upstream {
     server 0.0.0.1;

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -100,7 +100,6 @@ http {
     lua_kong_load_var_index $https;
     lua_kong_load_var_index $http2;
     lua_kong_load_var_index $is_args;
-    lua_kong_load_var_index $kong_proxy_mode;
     lua_kong_load_var_index $realip_remote_addr;
     lua_kong_load_var_index $realip_remote_port;
     lua_kong_load_var_index $remote_addr;
@@ -118,22 +117,10 @@ http {
     lua_kong_load_var_index $ssl_client_verify;
     lua_kong_load_var_index $ssl_protocol;
     lua_kong_load_var_index $ssl_server_name;
-    lua_kong_load_var_index $upstream_connection;
-    lua_kong_load_var_index $upstream_host;
     lua_kong_load_var_index $upstream_http_connection;
     lua_kong_load_var_index $upstream_http_trailer;
     lua_kong_load_var_index $upstream_http_upgrade;
-    lua_kong_load_var_index $upstream_scheme;
     lua_kong_load_var_index $upstream_status;
-    lua_kong_load_var_index $upstream_te;
-    lua_kong_load_var_index $upstream_uri;
-    lua_kong_load_var_index $upstream_upgrade;
-    lua_kong_load_var_index $upstream_x_forwarded_for;
-    lua_kong_load_var_index $upstream_x_forwarded_host;
-    lua_kong_load_var_index $upstream_x_forwarded_path;
-    lua_kong_load_var_index $upstream_x_forwarded_port;
-    lua_kong_load_var_index $upstream_x_forwarded_prefix;
-    lua_kong_load_var_index $upstream_x_forwarded_proto;
 
     upstream kong_upstream {
         server 0.0.0.1;


### PR DESCRIPTION


### Summary

As lua-kong-nginx-module says(https://github.com/Kong/lua-kong-nginx-module#lua_kong_load_var_index): 

Note that variables defined by set directive are always indexed by default and does not need to be defined here again.

We need not to add `var_index` for these var defined by `set`.

### Full changelog

* remove unnecessary var index(ctx_ref/kong_proxy_mode/...)

