### PR TITLE
fix(zipkin): jaeger header validation

### DIFF
--- a/kong/plugins/zipkin/tracing_headers.lua
+++ b/kong/plugins/zipkin/tracing_headers.lua
@@ -265,13 +265,13 @@ local function parse_jaeger_trace_context_headers(jaeger_header)
 
   -- values are not parsable hexidecimal and therefore invalid.
   if trace_id == nil or span_id == nil or parent_id == nil or trace_flags == nil then
-    warn(fmt("invalid jaeger uber-trace-id header; ignoring. Trace ID : %s, Span ID: %s, Parent ID: %s, Trace Flags: %s", trace_id, span_id, parent_id, trace_flags))
+    warn("invalid jaeger uber-trace-id header; ignoring.")
     return nil, nil, nil, nil
   end
 
   -- valid trace_id is required.
   if #trace_id > 32 or tonumber(trace_id, 16) == 0 then
-    warn(fmt("invalid jaeger trace ID: %s ; ignoring. ", trace_id))
+    warn("invalid jaeger trace ID; ignoring.")
     return nil, nil, nil, nil
   end
 
@@ -283,12 +283,12 @@ local function parse_jaeger_trace_context_headers(jaeger_header)
   -- validating parent_id. If it is invalid just logging, as it can be ignored
   -- https://www.jaegertracing.io/docs/1.29/client-libraries/#tracespan-identity
   if #parent_id ~= 16 and tonumber(parent_id, 16) ~= 0 then
-    warn(fmt("invalid jaeger parent ID: %s ; ignoring. ", parent_id))
+    warn("invalid jaeger parent ID; ignoring.")
   end
 
   -- valid span_id is required.
   if #span_id > 16 or tonumber(span_id, 16) == 0 then
-    warn(fmt("invalid jaeger span ID: %s; ignoring.", span_id))
+    warn("invalid jaeger span ID; ignoring.")
     return nil, nil, nil, nil
   end
 
@@ -299,7 +299,7 @@ local function parse_jaeger_trace_context_headers(jaeger_header)
 
   -- valid flags are required
   if #trace_flags ~= 1 and #trace_flags ~= 2 then
-    warn(fmt("invalid jaeger flags: %s; ignoring.", trace_flags))
+    warn("invalid jaeger flags; ignoring.")
     return nil, nil, nil, nil
   end
 

--- a/kong/plugins/zipkin/tracing_headers.lua
+++ b/kong/plugins/zipkin/tracing_headers.lua
@@ -272,15 +272,15 @@ local function parse_jaeger_trace_context_headers(jaeger_header)
   end
 
   -- valid span_id is required.
-  if #span_id ~= 16 or tonumber(parent_id, 16) == 0 then
+  if #span_id ~= 16 or tonumber(span_id, 16) == 0 then
     warn("invalid jaeger span ID; ignoring.")
     return nil, nil, nil, nil
   end
 
-  -- valid parent_id is required.
-  if #parent_id ~= 16 then
-    warn("invalid jaeger parent ID; ignoring.")
-    return nil, nil, nil, nil
+  -- validating parent_id. If it is invalid just logging, as it can be ignored
+  -- https://www.jaegertracing.io/docs/1.29/client-libraries/#tracespan-identity
+  if #parent_id ~= 16 and tonumber(parent_id, 16) ~= 0 then
+    warn(fmt("invalid jaeger parent ID; ignoring."))
   end
 
   -- valid flags are required

--- a/spec/03-plugins/34-zipkin/tracing_headers_spec.lua
+++ b/spec/03-plugins/34-zipkin/tracing_headers_spec.lua
@@ -374,6 +374,13 @@ describe("tracing_headers.parse", function()
       assert.spy(warn).not_called()
     end)
 
+    it("valid uber-trace-id with parent_id 0", function()
+      local ubertraceid = fmt("%s:%s:%s:%s", trace_id, span_id, "0", "1")
+      local t = { parse({ ["uber-trace-id"] = ubertraceid }) }
+      assert.same({ "jaeger", trace_id, span_id, to_hex("0"), true }, to_hex_ids(t))
+      assert.spy(warn).not_called()
+    end)
+
     describe("errors", function()
       it("rejects invalid header", function()
         local ubertraceid = fmt("vv:%s:%s:%s", span_id, parent_id, "0")
@@ -418,12 +425,12 @@ describe("tracing_headers.parse", function()
       it("rejects invalid parent IDs", function()
         local ubertraceid = fmt("%s:%s:%s:%s", trace_id, span_id, too_short_id, "1")
         local t = { parse({ ["uber-trace-id"] = ubertraceid }) }
-        assert.same({ "jaeger" }, t)
+        assert.same({ "jaeger", trace_id, span_id, too_short_id, true }, to_hex_ids(t))
         assert.spy(warn).was_called_with("invalid jaeger parent ID; ignoring.")
 
         ubertraceid = fmt("%s:%s:%s:%s", trace_id, span_id, too_long_id, "1")
         t = { parse({ ["uber-trace-id"] = ubertraceid }) }
-        assert.same({ "jaeger" }, t)
+        assert.same({ "jaeger", trace_id, span_id, too_long_id, true }, to_hex_ids(t))
         assert.spy(warn).was_called_with("invalid jaeger parent ID; ignoring.")
       end)
 

--- a/spec/03-plugins/34-zipkin/tracing_headers_spec.lua
+++ b/spec/03-plugins/34-zipkin/tracing_headers_spec.lua
@@ -14,6 +14,10 @@ local function to_hex_ids(arr)
            arr[5] }
 end
 
+local function left_pad_zero(str, count)
+  return ('0'):rep(count-#str) .. str
+end
+
 local parse = tracing_headers.parse
 local set = tracing_headers.set
 local from_hex = tracing_headers.from_hex
@@ -349,14 +353,14 @@ describe("tracing_headers.parse", function()
     it("valid uber-trace-id with sampling", function()
       local ubertraceid = fmt("%s:%s:%s:%s", trace_id, span_id, parent_id, "1")
       local t = { parse({ ["uber-trace-id"] = ubertraceid }) }
-      assert.same({ "jaeger", trace_id, span_id, parent_id, true }, to_hex_ids(t))
+      assert.same({ "jaeger", left_pad_zero(trace_id, 32), span_id, parent_id, true }, to_hex_ids(t))
       assert.spy(warn).not_called()
     end)
 
     it("valid uber-trace-id without sampling", function()
       local ubertraceid = fmt("%s:%s:%s:%s", trace_id, span_id, parent_id, "0")
       local t = { parse({ ["uber-trace-id"] = ubertraceid }) }
-      assert.same({ "jaeger", trace_id, span_id, parent_id, false }, to_hex_ids(t))
+      assert.same({ "jaeger", left_pad_zero(trace_id, 32), span_id, parent_id, false }, to_hex_ids(t))
       assert.spy(warn).not_called()
     end)
 
@@ -377,7 +381,7 @@ describe("tracing_headers.parse", function()
     it("valid uber-trace-id with parent_id 0", function()
       local ubertraceid = fmt("%s:%s:%s:%s", trace_id, span_id, "0", "1")
       local t = { parse({ ["uber-trace-id"] = ubertraceid }) }
-      assert.same({ "jaeger", trace_id, span_id, to_hex("0"), true }, to_hex_ids(t))
+      assert.same({ "jaeger", left_pad_zero(trace_id, 32), span_id, to_hex("0"), true }, to_hex_ids(t))
       assert.spy(warn).not_called()
     end)
 
@@ -405,11 +409,6 @@ describe("tracing_headers.parse", function()
       end)
 
       it("rejects invalid trace IDs", function()
-        local ubertraceid = fmt("%s:%s:%s:%s", too_short_id, span_id, parent_id, "1")
-        local t = { parse({ ["uber-trace-id"] = ubertraceid }) }
-        assert.same({ "jaeger" }, t)
-        assert.spy(warn).was_called_with("invalid jaeger trace ID; ignoring.")
-
         ubertraceid = fmt("%s:%s:%s:%s", too_long_id, span_id, parent_id, "1")
         t = { parse({ ["uber-trace-id"] = ubertraceid }) }
         assert.same({ "jaeger" }, t)
@@ -423,23 +422,20 @@ describe("tracing_headers.parse", function()
       end)
 
       it("rejects invalid parent IDs", function()
+        -- Ignores invalid parent id and logs
         local ubertraceid = fmt("%s:%s:%s:%s", trace_id, span_id, too_short_id, "1")
         local t = { parse({ ["uber-trace-id"] = ubertraceid }) }
-        assert.same({ "jaeger", trace_id, span_id, too_short_id, true }, to_hex_ids(t))
+        assert.same({ "jaeger", left_pad_zero(trace_id, 32), span_id, too_short_id, true }, to_hex_ids(t))
         assert.spy(warn).was_called_with("invalid jaeger parent ID; ignoring.")
 
+        -- Ignores invalid parent id and logs
         ubertraceid = fmt("%s:%s:%s:%s", trace_id, span_id, too_long_id, "1")
         t = { parse({ ["uber-trace-id"] = ubertraceid }) }
-        assert.same({ "jaeger", trace_id, span_id, too_long_id, true }, to_hex_ids(t))
+        assert.same({ "jaeger", left_pad_zero(trace_id, 32), span_id, too_long_id, true }, to_hex_ids(t))
         assert.spy(warn).was_called_with("invalid jaeger parent ID; ignoring.")
       end)
 
       it("rejects invalid span IDs", function()
-        local ubertraceid = fmt("%s:%s:%s:%s", trace_id, too_short_id, parent_id, "1")
-        local t = { parse({ ["uber-trace-id"] = ubertraceid }) }
-        assert.same({ "jaeger" }, t)
-        assert.spy(warn).was_called_with("invalid jaeger span ID; ignoring.")
-
         ubertraceid = fmt("%s:%s:%s:%s", trace_id, too_long_id, parent_id, "1")
         t = { parse({ ["uber-trace-id"] = ubertraceid }) }
         assert.same({ "jaeger" }, t)
@@ -457,6 +453,18 @@ describe("tracing_headers.parse", function()
         local t = { parse({ ["uber-trace-id"] = ubertraceid }) }
         assert.same({ "jaeger" }, t)
         assert.spy(warn).was_called_with("invalid jaeger flags; ignoring.")
+      end)
+
+      it("0-pad shorter span IDs", function()
+        local ubertraceid = fmt("%s:%s:%s:%s", trace_id, too_short_id, parent_id, "1")
+        local t = { parse({ ["uber-trace-id"] = ubertraceid }) }
+        assert.same({ "jaeger", left_pad_zero(trace_id, 32), left_pad_zero(too_short_id, 16), parent_id, true }, to_hex_ids(t))
+      end)
+
+      it("0-pad shorter trace IDs", function()
+        local ubertraceid = fmt("%s:%s:%s:%s", too_short_id, span_id, parent_id, "1")
+        local t = { parse({ ["uber-trace-id"] = ubertraceid }) }
+        assert.same({ "jaeger", left_pad_zero(too_short_id, 32), span_id, parent_id, true }, to_hex_ids(t))
       end)
     end)
   end)

--- a/spec/03-plugins/34-zipkin/tracing_headers_spec.lua
+++ b/spec/03-plugins/34-zipkin/tracing_headers_spec.lua
@@ -409,8 +409,8 @@ describe("tracing_headers.parse", function()
       end)
 
       it("rejects invalid trace IDs", function()
-        ubertraceid = fmt("%s:%s:%s:%s", too_long_id, span_id, parent_id, "1")
-        t = { parse({ ["uber-trace-id"] = ubertraceid }) }
+        local ubertraceid = fmt("%s:%s:%s:%s", too_long_id, span_id, parent_id, "1")
+        local t = { parse({ ["uber-trace-id"] = ubertraceid }) }
         assert.same({ "jaeger" }, t)
         assert.spy(warn).was_called_with("invalid jaeger trace ID; ignoring.")
 
@@ -425,7 +425,8 @@ describe("tracing_headers.parse", function()
         -- Ignores invalid parent id and logs
         local ubertraceid = fmt("%s:%s:%s:%s", trace_id, span_id, too_short_id, "1")
         local t = { parse({ ["uber-trace-id"] = ubertraceid }) }
-        assert.same({ "jaeger", left_pad_zero(trace_id, 32), span_id, too_short_id, true }, to_hex_ids(t))
+        -- Note: to_hex(from_hex()) for too_short_id as the binary conversion from hex is resulting in a different number
+        assert.same({ "jaeger", left_pad_zero(trace_id, 32), span_id, to_hex(from_hex(too_short_id)), true }, to_hex_ids(t))
         assert.spy(warn).was_called_with("invalid jaeger parent ID; ignoring.")
 
         -- Ignores invalid parent id and logs
@@ -436,8 +437,8 @@ describe("tracing_headers.parse", function()
       end)
 
       it("rejects invalid span IDs", function()
-        ubertraceid = fmt("%s:%s:%s:%s", trace_id, too_long_id, parent_id, "1")
-        t = { parse({ ["uber-trace-id"] = ubertraceid }) }
+        local ubertraceid = fmt("%s:%s:%s:%s", trace_id, too_long_id, parent_id, "1")
+        local t = { parse({ ["uber-trace-id"] = ubertraceid }) }
         assert.same({ "jaeger" }, t)
         assert.spy(warn).was_called_with("invalid jaeger span ID; ignoring.")
 

--- a/spec/03-plugins/34-zipkin/zipkin_no_endpoint_spec.lua
+++ b/spec/03-plugins/34-zipkin/zipkin_no_endpoint_spec.lua
@@ -141,7 +141,8 @@ describe("http integration tests with zipkin server (no http_endpoint) [#"
     })
     local body = assert.response(r).has.status(200)
     local json = cjson.decode(body)
-    assert.matches(trace_id .. ":%x+:" .. span_id .. ":01", json.headers["uber-trace-id"])
+    -- Trace ID is left padded with 0 for assert
+    assert.matches( ('0'):rep(32-#trace_id) .. trace_id .. ":%x+:" .. span_id .. ":01", json.headers["uber-trace-id"])
   end)
 
   it("propagates ot headers", function()

--- a/spec/03-plugins/34-zipkin/zipkin_spec.lua
+++ b/spec/03-plugins/34-zipkin/zipkin_spec.lua
@@ -871,7 +871,7 @@ describe("http integration tests with zipkin server [#"
       })
       local body = assert.response(r).has.status(200)
       local json = cjson.decode(body)
-      assert.matches(trace_id .. ":%x+:" .. span_id .. ":01", json.headers["uber-trace-id"])
+      assert.matches(('0'):rep(32-#trace_id) .. trace_id .. ":%x+:" .. span_id .. ":01", json.headers["uber-trace-id"])
 
       local balancer_span, proxy_span, request_span =
       wait_for_spans(zipkin_client, 3, nil, trace_id)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

With the latest [spec](https://www.jaegertracing.io/docs/1.29/client-libraries/#tracespan-identity) of `uber-trace-id`, parent_id is not mandatory. Because of this zipkin plugin validation is failing if the parent_id is sent as `0` and it is recreating the header with new `trace_id`. This results in not propagating the downstream context to upstream services.