### PR TITLE
chore(scripts) update make_patch_release to new branching model

### DIFF
--- a/scripts/make-patch-release
+++ b/scripts/make-patch-release
@@ -14,7 +14,6 @@ function usage() {
       echo "        $0 $version $1 $3"
       echo
    fi
-   c=1
    step "check_milestone"      "ensure all PRs marked on the release milestone are 100% merged"
    step "check_dependencies"   "ensure all kong dependencies are bumped in the rockspec"
    step "create"               "create the branch"
@@ -82,7 +81,7 @@ case "$step" in
 
    #---------------------------------------------------------------------------
    create)
-      if [ $(git status --untracked-files=no --porcelain | wc -l) != "0" ]
+      if [ "$(git status --untracked-files=no --porcelain | wc -l)" != "0" ]
       then
          die "Local tree is not clean, please commit or stash before running this."
       fi
@@ -107,14 +106,14 @@ case "$step" in
    version_bump)
       if ! grep -q "patch = $patch" kong/meta.lua
       then
-         sed -i.bak 's/patch = [0-9]*/patch = '$patch'/' kong/meta.lua
+         sed -i.bak 's/patch = [0-9]*/patch = '"$patch"'/' kong/meta.lua
          git add kong/meta.lua
       fi
       if ! [ -f "$rockspec" ]
       then
          git mv kong-*-0.rockspec "$rockspec"
-         sed -i.bak 's/^version = ".*"/version = "'$version'-0"/' "$rockspec"
-         sed -i.bak 's/^  tag = ".*"/  tag = "'$version'"/' "$rockspec"
+         sed -i.bak 's/^version = ".*"/version = "'"$version"'-0"/' "$rockspec"
+         sed -i.bak 's/^  tag = ".*"/  tag = "'"$version"'"/' "$rockspec"
       fi
 
       git status
@@ -123,7 +122,7 @@ case "$step" in
       CONFIRM "If everything looks all right, press Enter to make the release commit" \
               "or Ctrl-C to cancel."
 
-      git add $rockspec
+      git add "$rockspec"
 
       git commit -m "release: $version"
       git log -n 1
@@ -153,8 +152,8 @@ case "$step" in
 
       make_github_release_file
 
-      hub release create -F release-$version.txt "$version"
-      rm -f release-$version.txt
+      hub release create -F "release-$version.txt" "$version"
+      rm -f "release-$version.txt"
 
       SUCCESS "Make sure the packages are built and available on download.konghq.com" \
               "before continuing to the following steps." \
@@ -176,7 +175,7 @@ case "$step" in
    approve_docker) approve_docker ;;
    merge_docker) merge_docker "$branch" "$version" ;;
    submit_docker) submit_docker "$version";;
-   merge_homebrew)merge_homebrew ;;
+   merge_homebrew) merge_homebrew ;;
    merge_pongo) merge_pongo ;;
    merge_vagrant) merge_vagrant ;;
    upload_luarock) upload_luarock "$rockspec" "$3" ;;

--- a/scripts/make-patch-release
+++ b/scripts/make-patch-release
@@ -138,13 +138,13 @@ case "$step" in
 
    #---------------------------------------------------------------------------
    merge)
-      CONFIRM "Press Enter to merge the PR into master and push the tag and Github release" \
+      CONFIRM "Press Enter to merge the PR into $base and push the tag and Github release" \
               "or Ctrl-C to cancel."
 
       set -e
       git checkout "$branch"
       git pull
-      git checkout master
+      git checkout "$base"
       git pull
       git merge "$branch"
       git push


### PR DESCRIPTION
`scripts/make_patch_release` wanted to use the old `master/next` model, in which all changes were merged back to `master`.

In our new branching model, patch releases (`2.7.1` branch off from minor branches (`release/2.7.x`). That's what "$base" points to.

This PR also includes some minor changes to the script to appease shellcheck, on a separate commit

- chore(scripts) update make_patch_release to new branching model
- chore(scripts) make shellcheck happy about make-patch-release
