### PR TITLE
chore(deps) bump lua-resty-openssl to 0.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@
   [#8191](https://github.com/Kong/kong/pull/8191)
 - Bumped resty.session from 3.8 to 3.10
   [#8294](https://github.com/Kong/kong/pull/8294)
+- Bump lua-resty-openssl to 0.8.5
+  [#8368](https://github.com/Kong/kong/pull/8368)
 
 ### Additions
 

--- a/kong-2.7.0-0.rockspec
+++ b/kong-2.7.0-0.rockspec
@@ -36,7 +36,7 @@ dependencies = {
   "lua-resty-healthcheck == 1.4.2",
   "lua-resty-mlcache == 2.5.0",
   "lua-messagepack == 0.5.2",
-  "lua-resty-openssl == 0.8.4",
+  "lua-resty-openssl == 0.8.5",
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6.1",
   "lua-resty-acme == 0.7.2",


### PR DESCRIPTION
## Summary

Bump lua-resty-openssl to 0.8.5.

https://github.com/fffonion/lua-resty-openssl/blob/master/CHANGELOG.md