### PR TITLE
chore(prometheus) increment plugin version

### DIFF
--- a/kong/plugins/prometheus/handler.lua
+++ b/kong/plugins/prometheus/handler.lua
@@ -7,7 +7,7 @@ prometheus.init()
 
 local PrometheusHandler = {
   PRIORITY = 13,
-  VERSION  = "1.4.0",
+  VERSION  = "1.5.0",
 }
 
 function PrometheusHandler.init_worker()

--- a/kong/plugins/prometheus/kong-prometheus-plugin-1.5.0-1.rockspec
+++ b/kong/plugins/prometheus/kong-prometheus-plugin-1.5.0-1.rockspec
@@ -1,9 +1,9 @@
 package = "kong-prometheus-plugin"
-version = "1.3.0-1"
+version = "1.5.0-1"
 
 source = {
   url = "git://github.com/Kong/kong-plugin-prometheus",
-  tag = "1.3.0"
+  tag = "1.5.0"
 }
 
 supported_platforms = {"linux", "macosx"}


### PR DESCRIPTION
We have some changes going into the [EE plugin](https://github.com/Kong/kong-ee/pull/2835) that necessitate a minor version bump. This is essentially just a noop version increment in order to keep the plugin version in-step with EE. It's kind of unfortunate and awkward, but it's (IMO) better than having two different versions to reconcile later on.