### PR TITLE
feat(prometheus) add nginx timer metrics

### DIFF
--- a/kong/plugins/prometheus/exporter.lua
+++ b/kong/plugins/prometheus/exporter.lua
@@ -48,6 +48,9 @@ local function init()
       "Number of Stream connections",
       {"state"})
   end
+  metrics.timers = prometheus:gauge("nginx_current_timers",
+                                    "Number of nginx timers",
+                                    {"state"})
   metrics.db_reachable = prometheus:gauge("datastore_reachable",
                                           "Datastore reachable from Kong, " ..
                                           "0 is unreachable")
@@ -101,7 +104,6 @@ local function init()
   metrics.consumer_status = prometheus:counter("http_consumer_status",
                                           "HTTP status codes for customer per service/route in Kong",
                                           {"service", "route", "code", "consumer"})
-
 
   -- Hybrid mode status
   if role == "control_plane" then
@@ -313,6 +315,9 @@ local function metric_data()
   metrics.connections:set(ngx.var.connections_reading or 0, { "reading" })
   metrics.connections:set(ngx.var.connections_writing or 0, { "writing" })
   metrics.connections:set(ngx.var.connections_waiting or 0, { "waiting" })
+
+  metrics.timers:set(ngx.timer.running_count(), {"running"})
+  metrics.timers:set(ngx.timer.pending_count(), {"pending"})
 
   -- db reachable?
   local ok, err = kong.db.connector:connect()

--- a/kong/plugins/prometheus/exporter.lua
+++ b/kong/plugins/prometheus/exporter.lua
@@ -48,7 +48,7 @@ local function init()
       "Number of Stream connections",
       {"state"})
   end
-  metrics.timers = prometheus:gauge("nginx_current_timers",
+  metrics.timers = prometheus:gauge("nginx_timers",
                                     "Number of nginx timers",
                                     {"state"})
   metrics.db_reachable = prometheus:gauge("datastore_reachable",

--- a/kong/plugins/prometheus/exporter.lua
+++ b/kong/plugins/prometheus/exporter.lua
@@ -4,6 +4,8 @@ local find = string.find
 local lower = string.lower
 local concat = table.concat
 local select = select
+local ngx_timer_pending_count = ngx.timer.pending_count
+local ngx_timer_running_count = ngx.timer.running_count
 local balancer = require("kong.runloop.balancer")
 local get_all_upstreams = balancer.get_all_upstreams
 if not balancer.get_all_upstreams then -- API changed since after Kong 2.5
@@ -316,8 +318,8 @@ local function metric_data()
   metrics.connections:set(ngx.var.connections_writing or 0, { "writing" })
   metrics.connections:set(ngx.var.connections_waiting or 0, { "waiting" })
 
-  metrics.timers:set(ngx.timer.running_count(), {"running"})
-  metrics.timers:set(ngx.timer.pending_count(), {"pending"})
+  metrics.timers:set(ngx_timer_running_count(), {"running"})
+  metrics.timers:set(ngx_timer_pending_count(), {"pending"})
 
   -- db reachable?
   local ok, err = kong.db.connector:connect()

--- a/spec/03-plugins/26-prometheus/04-status_api_spec.lua
+++ b/spec/03-plugins/26-prometheus/04-status_api_spec.lua
@@ -292,8 +292,8 @@ describe("Plugin: prometheus (access via status API)", function()
       path    = "/metrics",
     })
     local body = assert.res_status(200, res)
-    assert.matches('kong_nginx_current_timers{state="running"} %d+', body, nil, true)
-    assert.matches('kong_nginx_current_timers{state="pending"} %d+', body, nil, true)
+    assert.matches('kong_nginx_timers{state="running"} %d+', body, nil, true)
+    assert.matches('kong_nginx_timers{state="pending"} %d+', body, nil, true)
   end)
 
   it("exposes upstream's target health metrics - healthchecks-off", function()

--- a/spec/03-plugins/26-prometheus/04-status_api_spec.lua
+++ b/spec/03-plugins/26-prometheus/04-status_api_spec.lua
@@ -292,8 +292,8 @@ describe("Plugin: prometheus (access via status API)", function()
       path    = "/metrics",
     })
     local body = assert.res_status(200, res)
-    assert.matches('kong_nginx_timers{state="running"} %d+', body, nil, true)
-    assert.matches('kong_nginx_timers{state="pending"} %d+', body, nil, true)
+    assert.matches('kong_nginx_timers{state="running"} %d+', body)
+    assert.matches('kong_nginx_timers{state="pending"} %d+', body)
   end)
 
   it("exposes upstream's target health metrics - healthchecks-off", function()

--- a/spec/03-plugins/26-prometheus/04-status_api_spec.lua
+++ b/spec/03-plugins/26-prometheus/04-status_api_spec.lua
@@ -286,6 +286,16 @@ describe("Plugin: prometheus (access via status API)", function()
     assert.matches('kong_datastore_reachable 1', body, nil, true)
   end)
 
+  it("exposes nginx timer metrics", function()
+    local res = assert(status_client:send {
+      method  = "GET",
+      path    = "/metrics",
+    })
+    local body = assert.res_status(200, res)
+    assert.matches('kong_nginx_current_timers{state="running"} %d+', body, nil, true)
+    assert.matches('kong_nginx_current_timers{state="pending"} %d+', body, nil, true)
+  end)
+
   it("exposes upstream's target health metrics - healthchecks-off", function()
     local body
     helpers.wait_until(function()


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

This adds gauges to track ngx.timer.running_count() and ngx.timer.pending_count() as requested by @rishabh-gupta2.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #7670
