### PR TITLE
fix(go-pdk) request.GetRawBody when buffered

### DIFF
--- a/kong/pluginsocket.proto
+++ b/kong/pluginsocket.proto
@@ -113,6 +113,14 @@ message CertificateKey {
     string id = 1;
 }
 
+message RawBodyResult {
+    oneof kind {
+        bytes content = 1;
+        string body_filepath = 2;
+        string error = 3;
+    }
+}
+
 message Route {
     string id = 1;
     int64 created_at = 2;
@@ -292,7 +300,7 @@ service Kong {
     rpc Request_GetQuery(Int) returns (google.protobuf.Struct);
     rpc Request_GetHeader(String) returns (String);
     rpc Request_GetHeaders(Int) returns (google.protobuf.Struct);
-    rpc Request_GetRawBody(google.protobuf.Empty) returns (String);
+    rpc Request_GetRawBody(google.protobuf.Empty) returns (RawBodyResult);
 
     rpc Response_GetStatus(google.protobuf.Empty) returns (Int);
     rpc Response_GetHeader(String) returns (String);

--- a/kong/runloop/plugin_servers/pb_rpc.lua
+++ b/kong/runloop/plugin_servers/pb_rpc.lua
@@ -151,6 +151,18 @@ do
     [".kong_plugin_protocol.Number"] = wrap_val,
     [".kong_plugin_protocol.Int"] = wrap_val,
     [".kong_plugin_protocol.String"] = wrap_val,
+    [".kong_plugin_protocol.RawBodyResult"] = function(v, err)
+      if type(v) == "string" then
+        return {  content = v }
+      end
+
+      local path = ngx.req.get_body_file()
+      if path then
+        return { body_filepath = path }
+      end
+
+      return { error = err or "Can't read request body" }
+    end,
     --[".kong_plugin_protocol.MemoryStats"] = - function(v)
     --  return {
     --    lua_shared_dicts = {


### PR DESCRIPTION
the response can be: content (as bytes), filepath of buffered data, or
error string.

Fix: Kong/go-pdk#85
Requires: Kong/go-pdk#91
