### PR TITLE
fix(cors) don't send vary header with * origin

### DIFF
--- a/kong/plugins/cors/handler.lua
+++ b/kong/plugins/cors/handler.lua
@@ -64,22 +64,16 @@ local function configure_origin(conf, header_filter)
   local n_origins = conf.origins ~= nil and #conf.origins or 0
   local set_header = kong.response.set_header
 
-  -- always set Vary header (it can be used for calculating cache key)
-  -- https://github.com/rs/cors/issues/10
-  add_vary_header(header_filter)
-
-  if n_origins == 0 then
+  if n_origins == 0 or (n_origins == 1 and conf.origins[1] == "*") then
     set_header("Access-Control-Allow-Origin", "*")
     return true
   end
 
+  -- always set Vary header (it can be used for calculating cache key)
+  -- https://github.com/rs/cors/issues/10
+  add_vary_header(header_filter)
+
   if n_origins == 1 then
-    if conf.origins[1] == "*" then
-      set_header("Access-Control-Allow-Origin", "*")
-      return true
-    end
-
-
     -- if this doesnt look like a regex, set the ACAO header directly
     -- otherwise, we'll fall through to an iterative search and
     -- set the ACAO header based on the client Origin
@@ -183,6 +177,7 @@ local function configure_credentials(conf, allow_all, header_filter)
   -- be 'true' if ACAO is '*'.
   local req_origin = kong.request.get_header("origin")
   if req_origin then
+    add_vary_header(header_filter)
     set_header("Access-Control-Allow-Origin", req_origin)
     set_header("Access-Control-Allow-Credentials", true)
   end

--- a/spec/03-plugins/13-cors/01-access_spec.lua
+++ b/spec/03-plugins/13-cors/01-access_spec.lua
@@ -570,7 +570,7 @@ for _, strategy in helpers.each_strategy() do
         assert.is_nil(res.headers["Access-Control-Expose-Headers"])
         assert.is_nil(res.headers["Access-Control-Allow-Credentials"])
         assert.is_nil(res.headers["Access-Control-Max-Age"])
-        assert.equal("Origin", res.headers["Vary"])
+        assert.is_nul(res.headers["Vary"])
       end)
 
       it("gives * wildcard when config.origins is empty", function()
@@ -596,7 +596,7 @@ for _, strategy in helpers.each_strategy() do
         assert.is_nil(res.headers["Access-Control-Expose-Headers"])
         assert.is_nil(res.headers["Access-Control-Allow-Credentials"])
         assert.is_nil(res.headers["Access-Control-Max-Age"])
-        assert.equal("Origin", res.headers["Vary"])
+        assert.is_nil(res.headers["Vary"])
       end)
 
       it("gives appropriate defaults when origin is explicitly set to *", function()
@@ -722,7 +722,7 @@ for _, strategy in helpers.each_strategy() do
         assert.is_nil(res.headers["Access-Control-Expose-Headers"])
         assert.is_nil(res.headers["Access-Control-Allow-Credentials"])
         assert.is_nil(res.headers["Access-Control-Max-Age"])
-        assert.equal("Origin", res.headers["Vary"])
+        assert.is_nil(res.headers["Vary"])
       end)
 
       it("proxies a non-preflight OPTIONS request", function()
@@ -742,7 +742,7 @@ for _, strategy in helpers.each_strategy() do
         assert.is_nil(res.headers["Access-Control-Expose-Headers"])
         assert.is_nil(res.headers["Access-Control-Allow-Credentials"])
         assert.is_nil(res.headers["Access-Control-Max-Age"])
-        assert.equal("Origin", res.headers["Vary"])
+        assert.is_nil(res.headers["Vary"])
       end)
 
       it("accepts config options", function()
@@ -811,7 +811,7 @@ for _, strategy in helpers.each_strategy() do
         assert.is_nil(res.headers["Access-Control-Expose-Headers"])
         assert.is_nil(res.headers["Access-Control-Allow-Credentials"])
         assert.is_nil(res.headers["Access-Control-Max-Age"])
-        assert.equal("Origin", res.headers["Vary"])
+        assert.is_nil(res.headers["Vary"])
       end)
 
       it("works with 40x responses returned by another plugin", function()
@@ -828,7 +828,7 @@ for _, strategy in helpers.each_strategy() do
         assert.is_nil(res.headers["Access-Control-Expose-Headers"])
         assert.is_nil(res.headers["Access-Control-Allow-Credentials"])
         assert.is_nil(res.headers["Access-Control-Max-Age"])
-        assert.equal("Origin", res.headers["Vary"])
+        assert.is_nil(res.headers["Vary"])
       end)
 
       it("sets CORS orgin based on origin host", function()
@@ -1015,7 +1015,7 @@ for _, strategy in helpers.each_strategy() do
         assert.res_status(200, res)
         assert.equals("*", res.headers["Access-Control-Allow-Origin"])
         assert.is_nil(res.headers["Access-Control-Allow-Credentials"])
-        assert.equal("Origin", res.headers["Vary"])
+        assert.is_nil(res.headers["Vary"])
       end)
 
       it("removes upstream ACAO header when no match is found", function()

--- a/spec/03-plugins/13-cors/01-access_spec.lua
+++ b/spec/03-plugins/13-cors/01-access_spec.lua
@@ -570,7 +570,7 @@ for _, strategy in helpers.each_strategy() do
         assert.is_nil(res.headers["Access-Control-Expose-Headers"])
         assert.is_nil(res.headers["Access-Control-Allow-Credentials"])
         assert.is_nil(res.headers["Access-Control-Max-Age"])
-        assert.is_nul(res.headers["Vary"])
+        assert.is_nil(res.headers["Vary"])
       end)
 
       it("gives * wildcard when config.origins is empty", function()


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

The CORS plugin currently always sets a `Vary: Origin` header on
responses.
`Vary: Origin` should not be sent together with `Access-Control-Allow-Origin: *` since the response won't vary by the `Origin` request header.

Unnecessarily sending the `Vary: Origin` header can cause issues with intermediate caches and cause them to either create identical cache copies for each origin or cause them to outright refuse caching the result.

This fixes behavior by no longer sending a `Vary: Origin` header when
`Access-Control-Allow-Origin: *` and credentials is disabled.

### Full changelog

* don't send vary: origin header when access-control-allow-origin header is *
* update tests to match behavior of not sending vary: origin header when access-control-allow-origin header is *
