### PR TITLE
tests(dbless) use mock upstream

### DIFF
--- a/spec/02-integration/11-dbless/01-respawn_spec.lua
+++ b/spec/02-integration/11-dbless/01-respawn_spec.lua
@@ -8,6 +8,7 @@ describe("worker respawn", function()
   lazy_setup(function()
     assert(helpers.start_kong({
       database   = "off",
+      nginx_conf = "spec/fixtures/custom_nginx.template",
     }))
   end)
 
@@ -144,11 +145,14 @@ describe("worker respawn", function()
       method = "POST",
       path = "/config",
       body = {
-        config = [[
+        config = string.format([[
         _format_version: "1.1"
         services:
         - name: my-service
-          url: https://example.com
+          host: %s
+          port: %s
+          path: /
+          protocol: http
           plugins:
           - name: key-auth
           routes:
@@ -160,7 +164,7 @@ describe("worker respawn", function()
         - username: my-user
           keyauth_credentials:
           - key: my-key
-        ]],
+        ]], helpers.mock_upstream_host, helpers.mock_upstream_port),
       },
       headers = {
         ["Content-Type"] = "application/json"


### PR DESCRIPTION
This test case was flaky because it relied on proxying a real request out to `example.com`. Using the mock upstream instead will make the test more reliable.