### PR TITLE
feat(conf) allow user-specified OpenResty install path

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1545,7 +1545,7 @@
                                      # available, may create opportunities to
                                      # escape the sandbox.
 
-#openresty_prefix =               # Path to the OpenResty installation that Kong
+#openresty_path =                 # Path to the OpenResty installation that Kong
                                   # will use. When this is empty (the default),
                                   # Kong determines the OpenResty installation
                                   # by searching for a system-installed OpenResty

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1544,3 +1544,14 @@
                                      # **Warning**: Certain variables, when made
                                      # available, may create opportunities to
                                      # escape the sandbox.
+
+#openresty_prefix =               # Path to the OpenResty installation that Kong
+                                  # will use. When this is empty (the default),
+                                  # Kong determines the OpenResty installation
+                                  # by searching for a system-installed OpenResty
+                                  # and falling back to searching $PATH for the
+                                  # nginx binary.
+                                  #
+                                  # Setting this attribute disables the search
+                                  # behavior and explicitly instructs Kong which
+                                  # OpenResty installation to use.

--- a/kong/cmd/utils/nginx_signals.lua
+++ b/kong/cmd/utils/nginx_signals.lua
@@ -8,11 +8,22 @@ local pl_stringx = require "pl.stringx"
 local fmt = string.format
 
 local nginx_bin_name = "nginx"
-local nginx_search_paths = {
-  "/usr/local/openresty/nginx/sbin",
-  "/opt/openresty/nginx/sbin",
-  ""
-}
+local nginx_search_paths
+do
+  local resty_prefix = os.getenv("KONG_OPENRESTY_PREFIX")
+  if resty_prefix then
+    log.debug("using custom OpenResty prefix: %s", resty_prefix)
+    nginx_search_paths = {
+      pl_path.join(resty_prefix, "nginx", "sbin")
+    }
+  else
+    nginx_search_paths = {
+      "/usr/local/openresty/nginx/sbin",
+      "/opt/openresty/nginx/sbin",
+      ""
+    }
+  end
+end
 local nginx_version_pattern = "^nginx.-openresty.-([%d%.]+)"
 local nginx_compatible = version.set(unpack(meta._DEPENDENCIES.nginx))
 

--- a/kong/cmd/utils/nginx_signals.lua
+++ b/kong/cmd/utils/nginx_signals.lua
@@ -55,10 +55,10 @@ function _M.find_nginx_bin(kong_conf)
   log.debug("searching for OpenResty 'nginx' executable")
 
   local search_paths = nginx_search_paths
-  if kong_conf and kong_conf.openresty_prefix then
-    log.debug("using custom OpenResty prefix: %s", kong_conf.openresty_prefix)
+  if kong_conf and kong_conf.openresty_path then
+    log.debug("using custom OpenResty path: %s", kong_conf.openresty_path)
     search_paths = {
-      pl_path.join(kong_conf.openresty_prefix, "nginx", "sbin"),
+      pl_path.join(kong_conf.openresty_path, "nginx", "sbin"),
     }
   end
 

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -179,5 +179,5 @@ untrusted_lua = sandbox
 untrusted_lua_sandbox_requires =
 untrusted_lua_sandbox_environment =
 
-openresty_prefix =
+openresty_path =
 ]]

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -178,4 +178,6 @@ pluginserver_names = NONE
 untrusted_lua = sandbox
 untrusted_lua_sandbox_requires =
 untrusted_lua_sandbox_environment =
+
+openresty_prefix =
 ]]

--- a/spec/02-integration/02-cmd/15-utils_spec.lua
+++ b/spec/02-integration/02-cmd/15-utils_spec.lua
@@ -1,0 +1,72 @@
+describe("kong cli utils", function()
+
+  describe("nginx_signals", function()
+    local signals = require "kong.cmd.utils.nginx_signals"
+    local pl_path = require "pl.path"
+    local pl_file = require "pl.file"
+    local pl_dir = require "pl.dir"
+
+    describe("find_nginx_bin()", function()
+      local tmpdir
+      before_each(function()
+        tmpdir = pl_path.tmpname()
+        assert(os.remove(tmpdir))
+      end)
+
+      after_each(function()
+        pcall(pl_dir.rmtree, tmpdir)
+      end)
+
+      local function fake_nginx_binary(version)
+        local bin_dir = pl_path.join(tmpdir, "nginx/sbin")
+        pl_dir.makepath(bin_dir)
+
+        local nginx = pl_path.join(bin_dir, "nginx")
+        pl_file.write(nginx, string.format(
+          [[#!/bin/sh
+echo 'nginx version: openresty/%s' >&2]], version
+        ))
+
+        assert(os.execute("chmod +x " .. nginx))
+
+        return nginx
+      end
+
+
+      it("works with empty/unset input", function()
+        local bin, err = signals.find_nginx_bin()
+        assert.is_nil(err)
+        assert.matches("sbin/nginx", bin)
+        assert.truthy(pl_path.exists(bin))
+      end)
+
+      it("works when openresty_prefix is unset", function()
+        local bin, err = signals.find_nginx_bin({})
+        assert.is_nil(err)
+        assert.matches("sbin/nginx", bin)
+        assert.truthy(pl_path.exists(bin))
+      end)
+
+      it("prefers `openresty_prefix` when supplied", function()
+        local meta = require "kong.meta"
+        local version = meta._DEPENDENCIES.nginx[1]
+
+        local nginx = fake_nginx_binary(version)
+
+        local bin, err = signals.find_nginx_bin({ openresty_prefix = tmpdir })
+
+        assert.is_nil(err)
+        assert.equals(nginx, bin)
+      end)
+
+      it("returns nil+error if a compatible nginx bin is not found in `openresty_prefix`", function()
+        fake_nginx_binary("1.0.1")
+        local bin, err = signals.find_nginx_bin({ openresty_prefix = tmpdir })
+        assert.is_nil(bin)
+        assert.not_nil(err)
+        assert.matches("could not find OpenResty", err)
+      end)
+
+    end)
+  end)
+end)

--- a/spec/02-integration/02-cmd/15-utils_spec.lua
+++ b/spec/02-integration/02-cmd/15-utils_spec.lua
@@ -40,28 +40,28 @@ echo 'nginx version: openresty/%s' >&2]], version
         assert.truthy(pl_path.exists(bin))
       end)
 
-      it("works when openresty_prefix is unset", function()
+      it("works when openresty_path is unset", function()
         local bin, err = signals.find_nginx_bin({})
         assert.is_nil(err)
         assert.matches("sbin/nginx", bin)
         assert.truthy(pl_path.exists(bin))
       end)
 
-      it("prefers `openresty_prefix` when supplied", function()
+      it("prefers `openresty_path` when supplied", function()
         local meta = require "kong.meta"
         local version = meta._DEPENDENCIES.nginx[1]
 
         local nginx = fake_nginx_binary(version)
 
-        local bin, err = signals.find_nginx_bin({ openresty_prefix = tmpdir })
+        local bin, err = signals.find_nginx_bin({ openresty_path = tmpdir })
 
         assert.is_nil(err)
         assert.equals(nginx, bin)
       end)
 
-      it("returns nil+error if a compatible nginx bin is not found in `openresty_prefix`", function()
+      it("returns nil+error if a compatible nginx bin is not found in `openresty_path`", function()
         fake_nginx_binary("1.0.1")
-        local bin, err = signals.find_nginx_bin({ openresty_prefix = tmpdir })
+        local bin, err = signals.find_nginx_bin({ openresty_path = tmpdir })
         assert.is_nil(bin)
         assert.not_nil(err)
         assert.matches("could not find OpenResty", err)

--- a/spec/02-integration/02-cmd/15-utils_spec.lua
+++ b/spec/02-integration/02-cmd/15-utils_spec.lua
@@ -1,10 +1,11 @@
+local signals = require "kong.cmd.utils.nginx_signals"
+local pl_path = require "pl.path"
+local pl_file = require "pl.file"
+local pl_dir = require "pl.dir"
+
 describe("kong cli utils", function()
 
   describe("nginx_signals", function()
-    local signals = require "kong.cmd.utils.nginx_signals"
-    local pl_path = require "pl.path"
-    local pl_file = require "pl.file"
-    local pl_dir = require "pl.dir"
 
     describe("find_nginx_bin()", function()
       local tmpdir
@@ -68,5 +69,7 @@ echo 'nginx version: openresty/%s' >&2]], version
       end)
 
     end)
+
   end)
+
 end)


### PR DESCRIPTION
### Summary

I maintain several different installations of OpenResty (both vanilla and Kong-flavored) on my machine for dev/testing of different projects.

The first time I went to run the Kong test suite locally, I spent a half hour or so scratching my head and cursing the sky over this error:

```
nginx: [emerg] unknown directive "lua_kong_load_var_index" in /home/flrgh/git/kong/kong/servroot/nginx.conf:69
nginx: configuration file /home/flrgh/git/kong/kong/servroot/nginx.conf test failed
```

_But I prepended the correct NGINX bin dir to my PATH already--why doesn't it work?!_

As I would soon discover, Kong searches some common OpenResty system/default paths _before_ consulting PATH, making it impossible to use a non-standard OpenResty installation for running the Kong cli, busted, etc. if system OpenResty is already installed.

The commit message has some more details, but in short, with this change, operators can use a custom OpenResty install with Kong by setting ~`openresty_prefix`~ `openresty_path`.

###  Why not just update things so that we search PATH first?

This would be a nice improvement, and in my opinion would nicely correct things as to not violate the principle of least surprise. However, that would be a breaking change with potential far-reaching, headache-inducing impact as operators, package maintainers, and CI pipeline owners now suffer through the same debug session that I went through.

### Why ~openresty_prefix~ openresty_path and not nginx_bin?

Kong is tightly-coupled to OpenResty than vanilla NGINX, so it "feels" more cohesive this way, to me at least. _Also_ this leaves the door open to expand our usage of this variable. For instance, I think it would be nice if it had a cascading effect on the default values of lua `package.path`/`package.cpath`.

### Why use ~openresty_prefix~ openresty_path exclusively instead of inserting it at the head of the search list?

Because the operator told us explicitly which path to use, and if it doesn't exist, we should fail fast rather than potentially falling back to another version of OpenResty that happens to exist on the same filesystem.

---

For discussion:

~Is it okay for this to slide in as an undocumented, not-exactly-public-but-not-completely-private/internal feature, or do we need to make it a fully-documented first-class citizen of the conf_loader? IMO the latter would be nice, but I stopped short of that because I think it would need to be more fleshed-out first--potentially incorporating some of the other behaviors I mentioned (re: lua `package.path`).~ I'm adding it to the Kong config.