### PR TITLE
[DOCU-2140] Update Admin API Target Object 

### DIFF
--- a/autodoc/admin-api/data/admin-api.lua
+++ b/autodoc/admin-api/data/admin-api.lua
@@ -1606,8 +1606,7 @@ return {
         service. Every upstream can have many targets, and the targets can be
         dynamically added, modified, or deleted. Changes take effect on the fly.
 
-        Because the upstream maintains a history of target changes, the targets cannot
-        be deleted or modified. To disable a target, post a new one with `weight=0`;
+        To disable a target, post a new one with `weight=0`;
         alternatively, use the `DELETE` convenience method to accomplish the same.
 
         The current target object definition is the one with the latest `created_at`.

--- a/autodoc/admin-api/generate.lua
+++ b/autodoc/admin-api/generate.lua
@@ -542,7 +542,7 @@ local function write_endpoint(outfd, endpoint, ep_data, dbless_methods)
              or not dbless_methods[endpoint][method])
       then
         write_title(outfd, 3, meth_data.title)
-        warning_message(outfd, "**Note**: Not available in DB-less mode.")
+        warning_message(outfd, "**Note**: This API is not available in DB-less mode.")
       else
         write_title(outfd, 3, meth_data.title, "{:.badge .dbless}")
       end


### PR DESCRIPTION
Remove wording in Admin API docs Target Object that says targets cannot be modified or deleted.

Corresponds to: https://github.com/Kong/docs.konghq.com/pull/3663

Addresses: [DOCU-2140](https://konghq.atlassian.net/browse/DOCU-2140)
