### PR TITLE
fix(plugin_server) skip preloading headers in stream subsystem

### DIFF
--- a/kong/runloop/plugin_servers/init.lua
+++ b/kong/runloop/plugin_servers/init.lua
@@ -9,6 +9,7 @@ local ngx_var = ngx.var
 local coroutine_running = coroutine.running
 local get_plugin_info = proc_mgmt.get_plugin_info
 local ngx_timer_at = ngx.timer.at
+local subsystem = ngx.config.subsystem
 
 --- keep request data a bit longer, into the log timer
 local save_for_later = {}
@@ -244,8 +245,8 @@ local function build_phases(plugin)
           serialize_data = kong.log.serialize(),
           ngx_ctx = ngx.ctx,
           ctx_shared = kong.ctx.shared,
-          request_headers = ngx.req.get_headers(100),
-          response_headers = ngx.resp.get_headers(100),
+          request_headers = subsystem == "http" and ngx.req.get_headers(100) or nil,
+          response_headers = subsystem == "http" and ngx.resp.get_headers(100) or nil,
           response_status = ngx.status,
         }
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Skip preloading headers in stream subsystem.
Note this PR doesn't try to guard from user actively call `kong.request.get_header{,s}`,
which will result into an error, but rather let the log phase proceed in stream subsystem

### Full changelog

* skip preloading headers in stream subsystem

### Issue reference
