### PR TITLE
fix(oauth2) clear authenticated oauth2 headers with multi-auth

### DIFF
--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -1083,8 +1083,12 @@ function _M.execute(conf)
   if conf.anonymous and kong.client.get_credential() then
     -- we're already authenticated, and we're configured for using anonymous,
     -- hence we're in a logical OR between auth methods and we're already done.
+    local clear_header = kong.service.request.clear_header
+    clear_header("X-Authenticated-Scope")
+    clear_header("X-Authenticated-UserId")
     return
   end
+
 
   local ok, err = do_authentication(conf)
   if not ok then

--- a/spec/03-plugins/25-oauth2/03-access_spec.lua
+++ b/spec/03-plugins/25-oauth2/03-access_spec.lua
@@ -3,6 +3,8 @@ local helpers = require "spec.helpers"
 local utils   = require "kong.tools.utils"
 local admin_api = require "spec.fixtures.admin_api"
 local sha256 = require "resty.sha256"
+local jwt_encoder = require "kong.plugins.jwt.jwt_parser"
+
 
 local math_random = math.random
 local string_char = string.char
@@ -11,6 +13,14 @@ local string_rep = string.rep
 
 
 local ngx_encode_base64 = ngx.encode_base64
+
+
+local PAYLOAD = {
+  iss = nil,
+  nbf = os.time(),
+  iat = os.time(),
+  exp = os.time() + 3600
+}
 
 
 local kong = {
@@ -141,6 +151,7 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
       "consumers",
       "plugins",
       "keyauth_credentials",
+      "jwt_secrets",
       "oauth2_credentials",
       "oauth2_authorization_codes",
       "oauth2_tokens",
@@ -3624,6 +3635,7 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
     local user2
     local anonymous
     local keyauth
+    local jwt_secret
 
     lazy_setup(function()
       local service1 = admin_api.services:insert({
@@ -3668,8 +3680,22 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
         service    = service2
       }))
 
+      local route3 = assert(admin_api.routes:insert({
+        hosts      = { "logical-or-jwt.com" },
+        protocols  = { "http", "https" },
+        service    = service2
+      }))
+
       admin_api.oauth2_plugins:insert({
         route = { id = route2.id },
+        config   = {
+          scopes    = { "email", "profile", "user.email" },
+          anonymous = anonymous.id,
+        },
+      })
+
+      admin_api.oauth2_plugins:insert({
+        route = { id = route3.id },
         config   = {
           scopes    = { "email", "profile", "user.email" },
           anonymous = anonymous.id,
@@ -3684,9 +3710,21 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
         },
       }
 
+      admin_api.plugins:insert {
+        name     = "jwt",
+        route = { id = route3.id },
+        config   = {
+          anonymous = anonymous.id,
+        },
+      }
+
       keyauth = admin_api.keyauth_credentials:insert({
         key      = "Mouse",
         consumer = { id = user1.id },
+      })
+
+      jwt_secret = admin_api.jwt_secrets:insert({
+        consumer = { id = user1.id }
       })
 
       admin_api.oauth2_credentials:insert {
@@ -3798,15 +3836,18 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
         assert.request(res).has.no.header("x-credential-username")
       end)
 
-      it("passes with only the first credential provided", function()
+      it("passes with only the first credential provided (higher priority)", function()
         local res = assert(proxy_client:send {
           method  = "GET",
           path = "/request",
           headers = {
             ["Host"] = "logical-or.com",
             ["apikey"] = "Mouse",
+            ["X-Authenticated-Scope"] = "all-access",
+            ["X-Authenticated-UserId"] = "admin",
           }
         })
+
         assert.response(res).has.status(200)
         assert.request(res).has.no.header("x-anonymous-consumer")
         local id = assert.request(res).has.header("x-consumer-id")
@@ -3815,6 +3856,35 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
         local client_id = assert.request(res).has.header("x-credential-identifier")
         assert.equal(keyauth.id, client_id)
         assert.request(res).has.no.header("x-credential-username")
+        assert.request(res).has.no.header("x-authenticated-scope")
+        assert.request(res).has.no.header("x-authenticated-userid")
+      end)
+
+      it("passes with only the first credential provided (lower priority)", function()
+        PAYLOAD.iss = jwt_secret.key
+        local jwt = jwt_encoder.encode(PAYLOAD, jwt_secret.secret)
+        local authorization = "Bearer " .. jwt
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path = "/request",
+          headers = {
+            ["Host"] = "logical-or-jwt.com",
+            ["Authorization"] = authorization,
+            ["X-Authenticated-Scope"] = "all-access",
+            ["X-Authenticated-UserId"] = "admin",
+          }
+        })
+
+        assert.response(res).has.status(200)
+        assert.request(res).has.no.header("x-anonymous-consumer")
+        local id = assert.request(res).has.header("x-consumer-id")
+        assert.not_equal(id, anonymous.id)
+        assert.equal(user1.id, id)
+        local client_id = assert.request(res).has.header("x-credential-identifier")
+        assert.equal(jwt_secret.key, client_id)
+        assert.request(res).has.no.header("x-credential-username")
+        assert.request(res).has.no.header("x-authenticated-scope")
+        assert.request(res).has.no.header("x-authenticated-userid")
       end)
 
       it("passes with only the second credential provided", function()


### PR DESCRIPTION
### Summary

It was reported that when Kong OAuth 2.0 plugin is configured together with some other authentication plugin with `conf.anonymous` (logical OR), the OAuth 2.0 plugin does not clear `X-Authenticated-UserId` and `X-Authenticated-Scope` headers that it normally only sets on successful authentication (aka when plugin runs).

This can lead to potential issue on upstream if upstream rely on these headers and trust that they came from OAuth 2.0 plugin. This change makes OAuth 2.0 plugin to clear such headers in logical OR scenario.

It is to be noted that Kong itself worked as expected, it is just about the expectations that upstream service may have made. It is probably harmless to remove these headers when OAuth 2.0 plugin is configured in logical OR.