### PR TITLE
fix(db) when auto-dereferencing fails set value to nil

### DIFF
--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1665,6 +1665,7 @@ function Schema:process_auto_fields(data, context, nulls, opts)
   -- and and admin api requests, admin api request could be
   -- detected with ngx.ctx.KONG_PHASE, but to limit context
   -- access we use nulls that admin api sets to true.
+  local kong = kong
   local resolve_references
   if is_select and not nulls then
     if kong and kong.configuration then
@@ -1733,10 +1734,12 @@ function Schema:process_auto_fields(data, context, nulls, opts)
               value = deref
             else
               if err then
-                kong.log.warn("unable to resolve reference ", value, "(", err, ")")
+                kong.log.warn("unable to resolve reference ", value, " (", err, ")")
               else
                 kong.log.warn("unable to resolve reference ", value)
               end
+
+              value = nil
             end
           end
 
@@ -1752,10 +1755,12 @@ function Schema:process_auto_fields(data, context, nulls, opts)
                     value = deref
                   else
                     if err then
-                      kong.log.warn("unable to resolve reference ", value, "(", err, ")")
+                      kong.log.warn("unable to resolve reference ", value, " (", err, ")")
                     else
                       kong.log.warn("unable to resolve reference ", value)
                     end
+
+                    value[i] = nil
                   end
                 end
               end

--- a/spec/02-integration/13-vaults/01-vault_spec.lua
+++ b/spec/02-integration/13-vaults/01-vault_spec.lua
@@ -6,9 +6,14 @@ local cjson = require "cjson"
 for _, strategy in helpers.each_strategy() do
   describe("/certificates with DB: #" .. strategy, function()
     local client
+    local db
 
     lazy_setup(function()
-      helpers.get_db_utils(strategy, {
+      helpers.setenv("CERT", ssl_fixtures.cert)
+      helpers.setenv("KEY", ssl_fixtures.key)
+
+      local _
+      _, db = helpers.get_db_utils(strategy, {
         "certificates",
         "vaults_beta",
       })
@@ -38,27 +43,44 @@ for _, strategy in helpers.each_strategy() do
 
     lazy_teardown(function()
       helpers.stop_kong()
+      helpers.unsetenv("CERT")
+      helpers.unsetenv("KEY")
     end)
 
     it("create certificates with cert and key as secret", function()
-      finally(function()
-        helpers.unsetenv("CERT")
-        helpers.unsetenv("KEY")
-      end)
-      helpers.setenv("CERT", ssl_fixtures.cert)
-      helpers.setenv("KEY", ssl_fixtures.key)
       local res, err  = client:post("/certificates", {
-        body    = {
-          cert  = "{vault://test-vault/cert}",
-          key   = "{vault://test-vault/key}",
-        },
         headers = { ["Content-Type"] = "application/json" },
+        body = {
+          cert     = "{vault://test-vault/cert}",
+          key      = "{vault://test-vault/key}",
+          cert_alt = "{vault://unknown/cert}",
+          key_alt  = "{vault://unknown/missing-key}",
+        },
       })
       assert.is_nil(err)
       local body = assert.res_status(201, res)
       local certificate = cjson.decode(body)
-      assert.not_nil(certificate.key)
-      assert.not_nil(certificate.cert)
+      assert.equal("{vault://test-vault/cert}", certificate.cert)
+      assert.equal("{vault://test-vault/key}", certificate.key)
+      assert.equal("{vault://unknown/cert}", certificate.cert_alt)
+      assert.equal("{vault://unknown/missing-key}", certificate.key_alt)
+
+      certificate, err = db.certificates:select({ id = certificate.id })
+      assert.is_nil(err)
+      assert.equal(ssl_fixtures.cert, certificate.cert)
+      assert.equal(ssl_fixtures.key, certificate.key)
+      assert.is_nil(certificate.cert_alt)
+      assert.is_nil(certificate.key_alt)
+
+      -- TODO: this is unexpected but schema.process_auto_fields uses currently
+      -- the `nulls` parameter to detect if the call comes from Admin API
+      -- for performance reasons
+      certificate, err = db.certificates:select({ id = certificate.id }, { nulls = true })
+      assert.is_nil(err)
+      assert.equal("{vault://test-vault/cert}", certificate.cert)
+      assert.equal("{vault://test-vault/key}", certificate.key)
+      assert.equal("{vault://unknown/cert}", certificate.cert_alt)
+      assert.equal("{vault://unknown/missing-key}", certificate.key_alt)
     end)
   end)
 end

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -183,16 +183,19 @@ _G.kong = kong_global.new()
 kong_global.init_pdk(_G.kong, conf, nil) -- nil: latest PDK
 ngx.ctx.KONG_PHASE = kong_global.phases.access
 _G.kong.core_cache = {
-  get = function(self, key)
+  get = function(self, key, opts, func, ...)
     if key == constants.CLUSTER_ID_PARAM_KEY then
       return "123e4567-e89b-12d3-a456-426655440000"
     end
+
+    return func(...)
   end
 }
 
 local db = assert(DB.new(conf))
 assert(db:init_connector())
 db.plugins:load_plugin_schemas(conf.loaded_plugins)
+db.vaults_beta:load_vault_schemas(conf.loaded_vaults)
 local blueprints = assert(Blueprints.new(db))
 local dcbp
 local config_yml
@@ -399,6 +402,7 @@ local function get_db_utils(strategy, tables, plugins)
 
   db:truncate("plugins")
   assert(db.plugins:load_plugin_schemas(conf.loaded_plugins))
+  assert(db.vaults_beta:load_vault_schemas(conf.loaded_vaults))
 
   -- cleanup the tags table, since it will be hacky and
   -- not necessary to implement "truncate trigger" in Cassandra

--- a/spec/kong_tests.conf
+++ b/spec/kong_tests.conf
@@ -39,3 +39,4 @@ go_plugins_dir = off
 
 untrusted_lua = sandbox
 
+vaults = bundled


### PR DESCRIPTION
### Summary

When auto-dereferencing secrets fail, we have two options:

1. keep the value (which means the value is actually a reference such as: `{vault://env/cert-1/key}`
2. set value to `nil`

In both cases the error is also logged.

Original implementation followed 1. but this commit changes it to 2.

Reason being that reference strings can leak to secrets, which they are not meant to.

For example session plugin has secret. If you set secret to `{vault://env/session-secret}` and the dereferencing fails, the secret becomes `{vault://env/session-secret}`. This can lead to potential leak of secret on a system that does not resolve secrets correctly. Or at least it is not good idea that references can become secrets. This commit changes it so that on failure (we log the warning) and also set the value to `nil`.

There is also added test that checks that this is functioning correctly.