### PR TITLE
fix(declarative) initialize hash for empty config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,13 @@
   Thanks, [@andrewgknew](https://github.com/andrewgknew)!
   [#8337](https://github.com/Kong/kong/pull/8337)
 
+#### Admin API
+
+- The current declarative configuration hash is now returned by the `status`
+  endpoint when Kong node is running in dbless or data-plane mode.
+  [#8214](https://github.com/Kong/kong/pull/8214)
+  [#8425](https://github.com/Kong/kong/pull/8425)
+
 ### Fixes
 
 #### Core

--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -54,6 +54,7 @@ local PING_INTERVAL = constants.CLUSTERING_PING_INTERVAL
 local PING_WAIT = PING_INTERVAL * 1.5
 local OCSP_TIMEOUT = constants.CLUSTERING_OCSP_TIMEOUT
 local CLUSTERING_SYNC_STATUS = constants.CLUSTERING_SYNC_STATUS
+local DECLARATIVE_EMPTY_CONFIG_HASH = constants.DECLARATIVE_EMPTY_CONFIG_HASH
 local PONG_TYPE = "PONG"
 local RECONFIGURE_TYPE = "RECONFIGURE"
 local MAJOR_MINOR_PATTERN = "^(%d+)%.(%d+)%.%d+"
@@ -598,7 +599,7 @@ function _M:handle_cp_websocket()
   end
 
   local dp_plugins_map = plugins_list_to_map(data.plugins)
-  local config_hash = string.rep("0", 32) -- initial hash
+  local config_hash = DECLARATIVE_EMPTY_CONFIG_HASH -- initial hash
   local last_seen = ngx_time()
   local sync_status = CLUSTERING_SYNC_STATUS.UNKNOWN
   local purge_delay = self.conf.cluster_data_plane_purge_delay

--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -43,6 +43,7 @@ local WS_OPTS = {
 local PING_INTERVAL = constants.CLUSTERING_PING_INTERVAL
 local PING_WAIT = PING_INTERVAL * 1.5
 local _log_prefix = "[clustering] "
+local DECLARATIVE_EMPTY_CONFIG_HASH = constants.DECLARATIVE_EMPTY_CONFIG_HASH
 
 
 local function is_timeout(err)
@@ -187,7 +188,7 @@ local function send_ping(c, log_suffix)
   local hash = declarative.get_current_hash()
 
   if hash == true then
-    hash = string.rep("0", 32)
+    hash = DECLARATIVE_EMPTY_CONFIG_HASH
   end
 
   local _, err = c:send_ping(hash)

--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -187,6 +187,7 @@ local constants = {
   DECLARATIVE_PAGE_KEY = "declarative:page",
   DECLARATIVE_LOAD_KEY = "declarative_config:loaded",
   DECLARATIVE_HASH_KEY = "declarative_config:hash",
+  DECLARATIVE_EMPTY_CONFIG_HASH = string.rep("0", 32),
 
   CLUSTER_ID_PARAM_KEY = "cluster_id",
 

--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -38,13 +38,12 @@ local PREFIX = ngx.config.prefix()
 local SUBSYS = ngx.config.subsystem
 local WORKER_COUNT = ngx.worker.count()
 local DECLARATIVE_HASH_KEY = constants.DECLARATIVE_HASH_KEY
+local DECLARATIVE_EMPTY_CONFIG_HASH = constants.DECLARATIVE_EMPTY_CONFIG_HASH
 
 
 local DECLARATIVE_LOCK_KEY = "declarative:lock"
 local DECLARATIVE_LOCK_TTL = 60
 local GLOBAL_QUERY_OPTS = { nulls = true, workspace = null }
-
-local EMPTY_CONFIGURATION_HASH = string.rep("0", 32)
 
 
 local declarative = {}
@@ -608,6 +607,10 @@ function declarative.load_into_cache(entities, meta, hash, shadow)
 
   assert(type(fallback_workspace) == "string")
 
+  if not hash or hash == "" then
+    hash = DECLARATIVE_EMPTY_CONFIG_HASH
+  end
+
   -- Keys: tag name, like "admin"
   -- Values: array of encoded tags, similar to the `tags` variable,
   -- but filtered for a given tag
@@ -845,11 +848,6 @@ function declarative.load_into_cache(entities, meta, hash, shadow)
   local ok, err = core_cache:safe_set("tags||@list", tags, shadow)
   if not ok then
     return nil, err
-  end
-
-  -- mask any default hash to indicate no hash is available.
-  if hash == EMPTY_CONFIGURATION_HASH or hash == "" then
-    hash = null
   end
 
   -- set the value of the configuration hash. The value can be nil, which

--- a/spec/02-integration/04-admin_api/02-kong_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/02-kong_routes_spec.lua
@@ -207,7 +207,11 @@ describe("Admin API - Kong routes with strategy #" .. strategy, function()
       assert.is_number(json.server.connections_writing)
       assert.is_number(json.server.connections_waiting)
       assert.is_number(json.server.total_requests)
-      assert.is_nil(json.server.configuration_hash) -- not present in DB mode, or in DBLESS mode until configuration is applied
+      if strategy == "off" then
+        assert.is_equal(string.rep("0", 32), json.configuration_hash) -- all 0 in DBLESS mode until configuration is applied
+      else
+        assert.is_nil(json.configuration_hash) -- not present in DB mode
+      end
     end)
 
     it("returns status info including a configuration_hash in DBLESS mode if an initial configuration has been provided #off", function()

--- a/spec/02-integration/08-status_api/01-core_routes_spec.lua
+++ b/spec/02-integration/08-status_api/01-core_routes_spec.lua
@@ -21,7 +21,7 @@ describe("Status API - with strategy #" .. strategy, function()
   end)
 
   describe("core", function()
-    it("/status returns status info without configuration_hash", function()
+    it("/status returns status info with blank configuration_hash (declarative config) or without it (db mode)", function()
       local res = assert(client:send {
         method = "GET",
         path = "/status"
@@ -40,7 +40,11 @@ describe("Status API - with strategy #" .. strategy, function()
       assert.is_number(json.server.connections_writing)
       assert.is_number(json.server.connections_waiting)
       assert.is_number(json.server.total_requests)
-      assert.is_nil(json.server.configuration_hash) -- no hash in DB mode, or in DBLESS mode until configuration has been applied
+      if strategy == "off" then
+        assert.is_equal(string.rep("0", 32), json.configuration_hash) -- all 0 in DBLESS mode until configuration is applied
+      else
+        assert.is_nil(json.configuration_hash) -- not present in DB mode
+      end
     end)
 
     it("/status starts providing a config_hash once an initial configuration has been pushed in dbless mode #off", function()
@@ -77,8 +81,8 @@ describe("Status API - with strategy #" .. strategy, function()
       assert.is_number(json.server.connections_writing)
       assert.is_number(json.server.connections_waiting)
       assert.is_number(json.server.total_requests)
-      assert.is_string(json.server.configuration_hash)
-      assert.equal(32, #json.server.configuration_hash)
+      assert.is_string(json.configuration_hash)
+      assert.equal(32, #json.configuration_hash)
     end)
 
   end)


### PR DESCRIPTION
### Summary

This change adds back the `configuration_hash` entry to the `/status` endpoint when using dbless mode/node is a dataplane and no configuration has been loaded.

See #8214 for reference.

### Full changelog

* `configuration_hash` returns `"00000000000000000000000000000000"` when no configuration has been loaded.
* Tests updated.

FT-2358