### PR TITLE
fix(pdk) fill default values with vault config required fields

### DIFF
--- a/kong/pdk/vault.lua
+++ b/kong/pdk/vault.lua
@@ -160,12 +160,14 @@ local function process_secret(reference, opts)
     local fields = field.fields
     local env_name = gsub(name, "-", "_")
     for i = 1, #fields do
-      local k = next(fields[i])
+      local k, f = next(fields[i])
       if config[k] == nil then
         local n = lower(fmt("vault_%s_%s", env_name, k))
         local v = configuration[n]
         if v ~= nil then
           config[k] = v
+        elseif f.required and f.default ~= nil then
+          config[k] = f.default
         end
       end
     end


### PR DESCRIPTION
### Summary

This fixes the vault to fill default values for configuration based on a config field schema in case the field is required and has a default value, when there is no configuration for the field already.