### PR TITLE
docs(admin-api) field configuration_hash in /status

### DIFF
--- a/autodoc/admin-api/data/admin-api.lua
+++ b/autodoc/admin-api/data/admin-api.lua
@@ -530,7 +530,8 @@ return {
                     "connections_reading": 0,
                     "connections_writing": 1,
                     "connections_waiting": 0
-                }
+                },
+                "configuration_hash": "779742c3d7afee2e38f977044d2ed96b"
             }
             ```
 
@@ -581,6 +582,9 @@ return {
                 * `reachable`: A boolean value reflecting the state of the
                   database connection. Please note that this flag **does not**
                   reflect the health of the database itself.
+            * `configuration_hash`: The hash of the current configuration. This
+              field is only returned when the Kong node is running in DB-less
+              or data-plane mode.
           ]],
         },
       }


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Added description for the field `configuration_hash` in the `/status` endpoint.

### Issue reference

#8214 
#8425