### PR TITLE
chore(deprecation) add deprecation warning

### DIFF
--- a/kong/runloop/plugin_servers/process.lua
+++ b/kong/runloop/plugin_servers/process.lua
@@ -70,7 +70,8 @@ local function get_server_defs()
       end
 
     elseif config.go_plugins_dir ~= "off" then
-      kong.log.info("old go_pluginserver style")
+      kong.log.deprecation("Properties go_pluginserver_exe and go_plugins_dir are deprecated. Please refer to https://docs.konghq.com/gateway/latest/reference/external-plugins/", {after = "2.8", removal = "3.0"})
+
       _servers[1] = {
         name = "go-pluginserver",
         socket = config.prefix .. "/go_pluginserver.sock",


### PR DESCRIPTION
The properties `go_pluginserver_exe` and `go_pluginserver` are
deprecated in favor of new multi-pluginservers implementation.
Compatibility code will remain in place until 3.0, when it will be
removed.

