### PR TITLE
Bump plugin versions of rate-limiting and response-ratelimiting (2.8.x)

### DIFF
--- a/kong/plugins/rate-limiting/handler.lua
+++ b/kong/plugins/rate-limiting/handler.lua
@@ -47,7 +47,7 @@ local RateLimitingHandler = {}
 
 
 RateLimitingHandler.PRIORITY = 901
-RateLimitingHandler.VERSION = "2.3.0"
+RateLimitingHandler.VERSION = "2.4.0"
 
 
 local function get_identifier(conf)

--- a/kong/plugins/response-ratelimiting/handler.lua
+++ b/kong/plugins/response-ratelimiting/handler.lua
@@ -27,7 +27,7 @@ end
 
 
 ResponseRateLimitingHandler.PRIORITY = 900
-ResponseRateLimitingHandler.VERSION = "2.0.1"
+ResponseRateLimitingHandler.VERSION = "2.1.0"
 
 
 return ResponseRateLimitingHandler


### PR DESCRIPTION
Bumping for the new redis_username field.