### PR TITLE
chore(release 2.8.x) cherry pick changes for 2.8.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,12 @@
 
 ## [2.8.0] (UNRELEASED)
 
+### Deprecations
+
+- The external [go-pluginserver](https://github.com/Kong/go-pluginserver) project
+is considered deprecated in favor of the embedded server approach described in
+the [docs](https://docs.konghq.com/gateway/2.7.x/reference/external-plugins/).
+
 ### Dependencies
 
 - OpenSSL bumped to 1.1.1m

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,13 @@ the [docs](https://docs.konghq.com/gateway/2.7.x/reference/external-plugins/).
   Thanks, [@andrewgknew](https://github.com/andrewgknew)!
   [#8337](https://github.com/Kong/kong/pull/8337)
 
+#### Admin API
+
+- The current declarative configuration hash is now returned by the `status`
+  endpoint when Kong node is running in dbless or data-plane mode.
+  [#8214](https://github.com/Kong/kong/pull/8214)
+  [#8425](https://github.com/Kong/kong/pull/8425)
+
 ### Fixes
 
 #### Core

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,8 +170,12 @@ the [docs](https://docs.konghq.com/gateway/2.7.x/reference/external-plugins/).
   Thanks, [@raptium](https://github.com/raptium)!
   [#8280](https://github.com/Kong/kong/pull/8280)
 - **AWS-Lambda**: Fixed incorrect behavior when configured to use an http proxy
-    and deprecated the `proxy_scheme` config attribute for removal in 3.0
-    [#8406](https://github.com/Kong/kong/pull/8406)
+  and deprecated the `proxy_scheme` config attribute for removal in 3.0
+  [#8406](https://github.com/Kong/kong/pull/8406)
+- **CORS**: The CORS plugin does not send the `Vary: Origin` header any more when
+  the header `Access-Control-Allow-Origin` is set to `*`.
+  Thanks, [@jkla-dr](https://github.com/jkla-dr)!
+  [#8401](https://github.com/Kong/kong/pull/8401)
 
 
 ## [2.7.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,8 +76,10 @@ the [docs](https://docs.konghq.com/gateway/2.7.x/reference/external-plugins/).
   [#8191](https://github.com/Kong/kong/pull/8191)
 - Bumped resty.session from 3.8 to 3.10
   [#8294](https://github.com/Kong/kong/pull/8294)
-- Bump lua-resty-openssl to 0.8.5
+- Bumped lua-resty-openssl to 0.8.5
   [#8368](https://github.com/Kong/kong/pull/8368)
+- Bumped pgmoon from 1.13.0 to 1.14.0
+  [#8429](https://github.com/Kong/kong/pull/8429)
 
 ### Additions
 
@@ -89,16 +91,26 @@ the [docs](https://docs.konghq.com/gateway/2.7.x/reference/external-plugins/).
 - Routes now support matching headers with regular expressions
   Thanks, [@vanhtuan0409](https://github.com/vanhtuan0409)!
   [#6079](https://github.com/Kong/kong/pull/6079)
-- Targets keep their health status when upstreams are updated.
-  [#8394](https://github.com/Kong/kong/pull/8394)
+
+#### Beta
+
+- Secrets Management and Vault support as been introduced as a Beta feature.
+  This means it is intended for testing in staging environments. It not intended
+  for use in Production environments.
+  You can read more about Secrets Management in
+  [our docs page](https://docs.konghq.com/gateway/latest/plan-and-deploy/security/secrets-management/backends-overview).
+  [#8403](https://github.com/Kong/kong/pull/8403)
 
 #### Performance
 
 - Improved the calculation of declarative configuration hash for big configurations
   The new method is faster and uses less memory
   [#8204](https://github.com/Kong/kong/pull/8204)
-- Several improvements in the Router decreased routing time and rebuild time. This should be
-  particularly noticeable when rebuilding on db-less environments
+- Multiple improvements in the Router. Amongst others:
+  - The router builds twice as faster
+  - Failures are cached and discarded faster (negative caching)
+  - Routes with header matching are cached
+  These changes should be particularly noticeable when rebuilding on db-less environments
   [#8087](https://github.com/Kong/kong/pull/8087)
   [#8010](https://github.com/Kong/kong/pull/8010)
 
@@ -106,11 +118,14 @@ the [docs](https://docs.konghq.com/gateway/2.7.x/reference/external-plugins/).
 
 - **Response-ratelimiting**: Redis ACL support,
   and genenarized Redis connection support for usernames.
-  Thanks, [@27ascii](https://github.com/27ascii) for the origina contribution!
+  Thanks, [@27ascii](https://github.com/27ascii) for the original contribution!
   [#8213](https://github.com/Kong/kong/pull/8213)
 - **ACME**: Add rsa_key_size config option
   Thanks, [lodrantl](https://github.com/lodrantl)!
   [#8114](https://github.com/Kong/kong/pull/8114)
+- **Prometheus**: Added gauges to track `ngx.timer.running_count()` and
+  `ngx.timer.pending_count()`
+  [#8387](https://github.com/Kong/kong/pull/8387)
 
 #### Clustering
 
@@ -145,6 +160,14 @@ the [docs](https://docs.konghq.com/gateway/2.7.x/reference/external-plugins/).
   Thanks, [@mpenick](https://github.com/mpenick)!
   [#8226](https://github.com/Kong/kong/pull/8226)
 
+#### Balancer
+
+- Targets keep their health status when upstreams are updated.
+  [#8394](https://github.com/Kong/kong/pull/8394)
+- One debug message which was erroneously using the `error` log level
+  has been downgraded to the appropiate `debug` log level.
+  [#8410](https://github.com/Kong/kong/pull/8410)
+
 #### Clustering
 
 - Replaced cryptic error message with more useful one when
@@ -160,6 +183,10 @@ the [docs](https://docs.konghq.com/gateway/2.7.x/reference/external-plugins/).
 
 - Phase names are correctly selected when performing phase checks
   [#8208](https://github.com/Kong/kong/pull/8208)
+- Fixed a bug in the go-PDK where if `kong.request.getrawbody` was
+  big enough to be buffered into a temporary file, it would return an
+  an empty string.
+  [#8390](https://github.com/Kong/kong/pull/8390)
 
 #### Plugins
 
@@ -169,13 +196,24 @@ the [docs](https://docs.konghq.com/gateway/2.7.x/reference/external-plugins/).
 - **External Plugins**: Unwrap `ConsumerSpec` and `AuthenticateArgs`.
   Thanks, [@raptium](https://github.com/raptium)!
   [#8280](https://github.com/Kong/kong/pull/8280)
-- **AWS-Lambda**: Fixed incorrect behavior when configured to use an http proxy
-  and deprecated the `proxy_scheme` config attribute for removal in 3.0
-  [#8406](https://github.com/Kong/kong/pull/8406)
+- **External Plugins**: Fixed a problem in the stream subsystem would attempt to load
+  HTTP headers.
+  [#8414](https://github.com/Kong/kong/pull/8414)
 - **CORS**: The CORS plugin does not send the `Vary: Origin` header any more when
   the header `Access-Control-Allow-Origin` is set to `*`.
   Thanks, [@jkla-dr](https://github.com/jkla-dr)!
   [#8401](https://github.com/Kong/kong/pull/8401)
+- **AWS-Lambda**: Fixed incorrect behavior when configured to use an http proxy
+  and deprecated the `proxy_scheme` config attribute for removal in 3.0
+  [#8406](https://github.com/Kong/kong/pull/8406)
+- **oauth2**: The plugin clears the `X-Authenticated-UserId` and
+  `X-Authenticated-Scope` headers when it configured in logical OR and
+  is used in conjunction with another authentication plugin.
+  [#8422](https://github.com/Kong/kong/pull/8422)
+- **Datadog**: The plugin schema now lists the default values
+  for configuration options in a single place instead of in two
+  separate places.
+  [#8315](https://github.com/Kong/kong/pull/8315)
 
 
 ## [2.7.1]

--- a/autodoc/admin-api/data/admin-api.lua
+++ b/autodoc/admin-api/data/admin-api.lua
@@ -1606,8 +1606,7 @@ return {
         service. Every upstream can have many targets, and the targets can be
         dynamically added, modified, or deleted. Changes take effect on the fly.
 
-        Because the upstream maintains a history of target changes, the targets cannot
-        be deleted or modified. To disable a target, post a new one with `weight=0`;
+        To disable a target, post a new one with `weight=0`;
         alternatively, use the `DELETE` convenience method to accomplish the same.
 
         The current target object definition is the one with the latest `created_at`.

--- a/autodoc/admin-api/data/admin-api.lua
+++ b/autodoc/admin-api/data/admin-api.lua
@@ -31,6 +31,7 @@ return {
       "snis",
       "upstreams",
       "targets",
+      "vaults_beta",
     },
     nodoc_entities = {
     },
@@ -1884,7 +1885,66 @@ return {
           },
         },
       },
-    }
+    },
+
+    vaults_beta = {
+      title = "Vaults Beta Entity",
+      entity_title = "Vault",
+      entity_title_plural = "Vaults",
+      description = [[
+        Vault entities are used to configure different Vault connectors. Examples of
+        Vaults are Environment Variables, Hashicorp Vault and AWS Secrets Manager.
+
+        Configuring a Vault allows referencing the secrets with other entities. For
+        example a certificate entity can store a reference to a certificate and key,
+        stored in a vault, instead of storing the certificate and key within the
+        entity. This allows a proper separation of secrets and configuration and
+        prevents secret sprawl.
+      ]],
+
+      fields = {
+        id = { skip = true },
+        created_at = { skip = true },
+        updated_at = { skip = true },
+        name = {
+          description = [[
+            The name of the Vault that's going to be added. Currently, the Vault implementation
+            must be installed in every Kong instance.
+          ]],
+          example = "env",
+        },
+        prefix = {
+          description = [[
+            The unique prefix (or identifier) for this Vault configuration. The prefix
+            is used to load the right Vault configuration and implementation when referencing
+            secrets with the other entities.
+          ]],
+          example = "env",
+        },
+        description = {
+          description = [[
+            The description of the Vault entity.
+          ]],
+          example = "This vault is used to retrieve redis database access credentials",
+        },
+        config = {
+          description = [[
+            The configuration properties for the Vault which can be found on
+            the vaults' documentation page.
+          ]],
+          example = { prefix = "SSL_" },
+        },
+        tags = {
+          description = [[
+            An optional set of strings associated with the Vault for grouping and filtering.
+          ]],
+          examples = {
+            { "database-credentials", "data-plane" },
+            { "certificates", "critical" },
+          },
+        },
+      },
+    },
   },
 
 --------------------------------------------------------------------------------

--- a/autodoc/admin-api/generate.lua
+++ b/autodoc/admin-api/generate.lua
@@ -542,7 +542,7 @@ local function write_endpoint(outfd, endpoint, ep_data, dbless_methods)
              or not dbless_methods[endpoint][method])
       then
         write_title(outfd, 3, meth_data.title)
-        warning_message(outfd, "**Note**: Not available in DB-less mode.")
+        warning_message(outfd, "**Note**: This API is not available in DB-less mode.")
       else
         write_title(outfd, 3, meth_data.title, "{:.badge .dbless}")
       end

--- a/autodoc/admin-api/generate.lua
+++ b/autodoc/admin-api/generate.lua
@@ -93,12 +93,14 @@ _KONG = require("kong.meta")          -- luacheck: ignore
 kong = require("kong.global").new()   -- luacheck: ignore
 kong.configuration = {                -- luacheck: ignore
   loaded_plugins = {},
+  loaded_vaults = {},
 }
 kong.db = require("kong.db").new({    -- luacheck: ignore
   database = "postgres",
 })
 kong.configuration = { -- luacheck: ignore
-  loaded_plugins = {}
+  loaded_plugins = {},
+  loaded_vaults = {},
 }
 
 --------------------------------------------------------------------------------
@@ -196,6 +198,9 @@ do
     "0c61e164-6171-4837-8836-8f5298726d53",
     "5027BBC1-508C-41F8-87F2-AB1801E9D5C3",
     "68FDB05B-7B08-47E9-9727-AF7F897CFF1A",
+    "B2A30E8F-C542-49CF-8015-FB674987D1A5",
+    "518BBE43-2454-4559-99B0-8E7D1CD3E8C8",
+    "7C4747E9-E831-4ED8-9377-83A6F8A37603",
   }
 
   local ctr = 0

--- a/autodoc/admin-api/openapi-gen.lua
+++ b/autodoc/admin-api/openapi-gen.lua
@@ -33,12 +33,14 @@ _KONG = require("kong.meta")          -- luacheck: ignore
 kong = require("kong.global").new()   -- luacheck: ignore
 kong.configuration = {                -- luacheck: ignore
   loaded_plugins = {},
+  loaded_vaults = {},
 }
 kong.db = require("kong.db").new({    -- luacheck: ignore
   database = "postgres",
 })
 kong.configuration = { -- luacheck: ignore
-  loaded_plugins = {}
+  loaded_plugins = {},
+  loaded_vaults = {},
 }
 
 

--- a/kong-2.7.0-0.rockspec
+++ b/kong-2.7.0-0.rockspec
@@ -23,7 +23,7 @@ dependencies = {
   "version == 1.0.1",
   "kong-lapis == 1.8.3.1",
   "lua-cassandra == 1.5.1",
-  "pgmoon == 1.13.0",
+  "pgmoon == 1.14.0",
   "luatz == 0.4",
   "lua_system_constants == 0.1.4",
   "lyaml == 6.2.7",

--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -54,6 +54,7 @@ local PING_INTERVAL = constants.CLUSTERING_PING_INTERVAL
 local PING_WAIT = PING_INTERVAL * 1.5
 local OCSP_TIMEOUT = constants.CLUSTERING_OCSP_TIMEOUT
 local CLUSTERING_SYNC_STATUS = constants.CLUSTERING_SYNC_STATUS
+local DECLARATIVE_EMPTY_CONFIG_HASH = constants.DECLARATIVE_EMPTY_CONFIG_HASH
 local PONG_TYPE = "PONG"
 local RECONFIGURE_TYPE = "RECONFIGURE"
 local MAJOR_MINOR_PATTERN = "^(%d+)%.(%d+)%.%d+"
@@ -598,7 +599,7 @@ function _M:handle_cp_websocket()
   end
 
   local dp_plugins_map = plugins_list_to_map(data.plugins)
-  local config_hash = string.rep("0", 32) -- initial hash
+  local config_hash = DECLARATIVE_EMPTY_CONFIG_HASH -- initial hash
   local last_seen = ngx_time()
   local sync_status = CLUSTERING_SYNC_STATUS.UNKNOWN
   local purge_delay = self.conf.cluster_data_plane_purge_delay

--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -43,6 +43,7 @@ local WS_OPTS = {
 local PING_INTERVAL = constants.CLUSTERING_PING_INTERVAL
 local PING_WAIT = PING_INTERVAL * 1.5
 local _log_prefix = "[clustering] "
+local DECLARATIVE_EMPTY_CONFIG_HASH = constants.DECLARATIVE_EMPTY_CONFIG_HASH
 
 
 local function is_timeout(err)
@@ -187,7 +188,7 @@ local function send_ping(c, log_suffix)
   local hash = declarative.get_current_hash()
 
   if hash == true then
-    hash = string.rep("0", 32)
+    hash = DECLARATIVE_EMPTY_CONFIG_HASH
   end
 
   local _, err = c:send_ping(hash)

--- a/kong/cmd/vault.lua
+++ b/kong/cmd/vault.lua
@@ -38,8 +38,6 @@ local function init_db(args)
   assert(db.vaults_beta:load_vault_schemas(conf.loaded_vaults))
 
   _G.kong.db = db
-
-  return db
 end
 
 
@@ -51,7 +49,7 @@ local function get(args)
       return error("the 'get' command needs a <reference> argument \nkong vault get <reference>")
     end
 
-    local db = init_db(args)
+    init_db(args)
 
     if not vault.is_reference(reference) then
       -- assuming short form: <name>/<resource>[/<key>]
@@ -63,21 +61,7 @@ local function get(args)
       return error(err)
     end
 
-    local name = opts.name
-    local res
-
-    local vaults = db.vaults_beta
-    if vaults.strategies[name] then
-      res, err = vault.get(reference)
-
-    elseif vaults:select_by_prefix(name) then
-      ngx.IS_CLI = false
-      res, err = vault.get(reference)
-      ngx.IS_CLI = true
-    else
-      error(fmt("vault '%s' was not found", name, name, args[1]))
-    end
-
+    local res, err = vault.get(reference)
     if err then
       return error(err)
     end

--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -187,6 +187,7 @@ local constants = {
   DECLARATIVE_PAGE_KEY = "declarative:page",
   DECLARATIVE_LOAD_KEY = "declarative_config:loaded",
   DECLARATIVE_HASH_KEY = "declarative_config:hash",
+  DECLARATIVE_EMPTY_CONFIG_HASH = string.rep("0", 32),
 
   CLUSTER_ID_PARAM_KEY = "cluster_id",
 

--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -38,13 +38,12 @@ local PREFIX = ngx.config.prefix()
 local SUBSYS = ngx.config.subsystem
 local WORKER_COUNT = ngx.worker.count()
 local DECLARATIVE_HASH_KEY = constants.DECLARATIVE_HASH_KEY
+local DECLARATIVE_EMPTY_CONFIG_HASH = constants.DECLARATIVE_EMPTY_CONFIG_HASH
 
 
 local DECLARATIVE_LOCK_KEY = "declarative:lock"
 local DECLARATIVE_LOCK_TTL = 60
 local GLOBAL_QUERY_OPTS = { nulls = true, workspace = null }
-
-local EMPTY_CONFIGURATION_HASH = string.rep("0", 32)
 
 
 local declarative = {}
@@ -608,6 +607,10 @@ function declarative.load_into_cache(entities, meta, hash, shadow)
 
   assert(type(fallback_workspace) == "string")
 
+  if not hash or hash == "" then
+    hash = DECLARATIVE_EMPTY_CONFIG_HASH
+  end
+
   -- Keys: tag name, like "admin"
   -- Values: array of encoded tags, similar to the `tags` variable,
   -- but filtered for a given tag
@@ -845,11 +848,6 @@ function declarative.load_into_cache(entities, meta, hash, shadow)
   local ok, err = core_cache:safe_set("tags||@list", tags, shadow)
   if not ok then
     return nil, err
-  end
-
-  -- mask any default hash to indicate no hash is available.
-  if hash == EMPTY_CONFIGURATION_HASH or hash == "" then
-    hash = null
   end
 
   -- set the value of the configuration hash. The value can be nil, which

--- a/kong/db/schema/entities/vaults_beta.lua
+++ b/kong/db/schema/entities/vaults_beta.lua
@@ -1,6 +1,43 @@
 local typedefs = require "kong.db.schema.typedefs"
 
 
+local VAULTS do
+  local i = 0
+  local pairs = pairs
+  local names = {}
+  local constants = require "kong.constants"
+  local bundled = constants and constants.BUNDLED_VAULTS
+  if bundled then
+    for name in pairs(bundled) do
+      if not names[name] then
+        names[name] = true
+        i = i + 1
+        if i == 1 then
+          VAULTS = { name }
+        else
+          VAULTS[i] = name
+        end
+      end
+    end
+  end
+
+  local loaded_vaults = kong and kong.configuration and kong.configuration.loaded_vaults
+  if loaded_vaults then
+    for name in pairs(loaded_vaults) do
+      if not names[name] then
+        names[name] = true
+        i = i + 1
+        if i == 1 then
+          VAULTS = { name }
+        else
+          VAULTS[i] = name
+        end
+      end
+    end
+  end
+end
+
+
 return {
   name = "vaults_beta",
   primary_key = { "id" },
@@ -16,7 +53,7 @@ return {
     -- note: prefix must be valid in a host part of vault reference uri:
     -- {vault://<vault-prefix>/<secret-id>[/<secret-key]}
     { prefix = { type = "string", required = true, unique = true, unique_across_ws = true,
-                 match = [[^[a-z][a-z%d-]-[a-z%d]+$]] }},
+                 match = [[^[a-z][a-z%d-]-[a-z%d]+$]], not_one_of = VAULTS }},
     { name = { type = "string", required = true }},
     { description = { type = "string" }},
     { config = { type = "record", abstract = true }},

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1665,6 +1665,7 @@ function Schema:process_auto_fields(data, context, nulls, opts)
   -- and and admin api requests, admin api request could be
   -- detected with ngx.ctx.KONG_PHASE, but to limit context
   -- access we use nulls that admin api sets to true.
+  local kong = kong
   local resolve_references
   if is_select and not nulls then
     if kong and kong.configuration then
@@ -1733,10 +1734,12 @@ function Schema:process_auto_fields(data, context, nulls, opts)
               value = deref
             else
               if err then
-                kong.log.warn("unable to resolve reference ", value, "(", err, ")")
+                kong.log.warn("unable to resolve reference ", value, " (", err, ")")
               else
                 kong.log.warn("unable to resolve reference ", value)
               end
+
+              value = nil
             end
           end
 
@@ -1752,10 +1755,12 @@ function Schema:process_auto_fields(data, context, nulls, opts)
                     value = deref
                   else
                     if err then
-                      kong.log.warn("unable to resolve reference ", value, "(", err, ")")
+                      kong.log.warn("unable to resolve reference ", value, " (", err, ")")
                     else
                       kong.log.warn("unable to resolve reference ", value)
                     end
+
+                    value[i] = nil
                   end
                 end
               end

--- a/kong/pdk/vault.lua
+++ b/kong/pdk/vault.lua
@@ -20,6 +20,7 @@ local ngx = ngx
 local fmt = string.format
 local sub = string.sub
 local byte = string.byte
+local gsub = string.gsub
 local type = type
 local next = next
 local pcall = pcall
@@ -157,10 +158,11 @@ local function process_secret(reference, opts)
   if kong and kong.configuration then
     local configuration = kong.configuration
     local fields = field.fields
+    local env_name = gsub(name, "-", "_")
     for i = 1, #fields do
       local k = next(fields[i])
       if config[k] == nil then
-        local n = lower(fmt("vault_%s_%s", name, k))
+        local n = lower(fmt("vault_%s_%s", env_name, k))
         local v = configuration[n]
         if v ~= nil then
           config[k] = v

--- a/kong/pdk/vault.lua
+++ b/kong/pdk/vault.lua
@@ -160,12 +160,14 @@ local function process_secret(reference, opts)
     local fields = field.fields
     local env_name = gsub(name, "-", "_")
     for i = 1, #fields do
-      local k = next(fields[i])
+      local k, f = next(fields[i])
       if config[k] == nil then
         local n = lower(fmt("vault_%s_%s", env_name, k))
         local v = configuration[n]
         if v ~= nil then
           config[k] = v
+        elseif f.required and f.default ~= nil then
+          config[k] = f.default
         end
       end
     end

--- a/kong/plugins/acme/handler.lua
+++ b/kong/plugins/acme/handler.lua
@@ -13,7 +13,7 @@ local ACMEHandler = {}
 -- otherwise acme-challenges endpoints may be blocked by auth plugins
 -- causing validation failures
 ACMEHandler.PRIORITY = 1007
-ACMEHandler.VERSION = "0.3.0"
+ACMEHandler.VERSION = "0.4.0"
 
 local function build_domain_matcher(domains)
   local domains_plain = {}

--- a/kong/plugins/cors/handler.lua
+++ b/kong/plugins/cors/handler.lua
@@ -64,22 +64,16 @@ local function configure_origin(conf, header_filter)
   local n_origins = conf.origins ~= nil and #conf.origins or 0
   local set_header = kong.response.set_header
 
-  -- always set Vary header (it can be used for calculating cache key)
-  -- https://github.com/rs/cors/issues/10
-  add_vary_header(header_filter)
-
-  if n_origins == 0 then
+  if n_origins == 0 or (n_origins == 1 and conf.origins[1] == "*") then
     set_header("Access-Control-Allow-Origin", "*")
     return true
   end
 
+  -- always set Vary header (it can be used for calculating cache key)
+  -- https://github.com/rs/cors/issues/10
+  add_vary_header(header_filter)
+
   if n_origins == 1 then
-    if conf.origins[1] == "*" then
-      set_header("Access-Control-Allow-Origin", "*")
-      return true
-    end
-
-
     -- if this doesnt look like a regex, set the ACAO header directly
     -- otherwise, we'll fall through to an iterative search and
     -- set the ACAO header based on the client Origin
@@ -183,6 +177,7 @@ local function configure_credentials(conf, allow_all, header_filter)
   -- be 'true' if ACAO is '*'.
   local req_origin = kong.request.get_header("origin")
   if req_origin then
+    add_vary_header(header_filter)
     set_header("Access-Control-Allow-Origin", req_origin)
     set_header("Access-Control-Allow-Credentials", true)
   end

--- a/kong/plugins/cors/handler.lua
+++ b/kong/plugins/cors/handler.lua
@@ -17,7 +17,7 @@ local CorsHandler = {}
 
 
 CorsHandler.PRIORITY = 2000
-CorsHandler.VERSION = "2.0.0"
+CorsHandler.VERSION = "2.1.1"
 
 
 -- per-plugin cache of normalized origins for runtime comparison

--- a/kong/plugins/datadog/handler.lua
+++ b/kong/plugins/datadog/handler.lua
@@ -95,7 +95,7 @@ end
 
 local DatadogHandler = {
   PRIORITY = 10,
-  VERSION = "3.1.0",
+  VERSION = "3.1.1",
 }
 
 

--- a/kong/plugins/datadog/schema.lua
+++ b/kong/plugins/datadog/schema.lua
@@ -72,7 +72,6 @@ return {
     { protocols = typedefs.protocols },
     { config = {
         type = "record",
-        default = { metrics = DEFAULT_METRICS },
         fields = {
           { host = typedefs.host({ default = "localhost" }), },
           { port = typedefs.port({ default = 8125 }), },

--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -1083,8 +1083,12 @@ function _M.execute(conf)
   if conf.anonymous and kong.client.get_credential() then
     -- we're already authenticated, and we're configured for using anonymous,
     -- hence we're in a logical OR between auth methods and we're already done.
+    local clear_header = kong.service.request.clear_header
+    clear_header("X-Authenticated-Scope")
+    clear_header("X-Authenticated-UserId")
     return
   end
+
 
   local ok, err = do_authentication(conf)
   if not ok then

--- a/kong/plugins/oauth2/handler.lua
+++ b/kong/plugins/oauth2/handler.lua
@@ -3,7 +3,7 @@ local access = require "kong.plugins.oauth2.access"
 
 local OAuthHandler = {
   PRIORITY = 1004,
-  VERSION = "2.1.1",
+  VERSION = "2.1.2",
 }
 
 

--- a/kong/plugins/prometheus/exporter.lua
+++ b/kong/plugins/prometheus/exporter.lua
@@ -4,6 +4,8 @@ local find = string.find
 local lower = string.lower
 local concat = table.concat
 local select = select
+local ngx_timer_pending_count = ngx.timer.pending_count
+local ngx_timer_running_count = ngx.timer.running_count
 local balancer = require("kong.runloop.balancer")
 local get_all_upstreams = balancer.get_all_upstreams
 if not balancer.get_all_upstreams then -- API changed since after Kong 2.5
@@ -48,6 +50,9 @@ local function init()
       "Number of Stream connections",
       {"state"})
   end
+  metrics.timers = prometheus:gauge("nginx_timers",
+                                    "Number of nginx timers",
+                                    {"state"})
   metrics.db_reachable = prometheus:gauge("datastore_reachable",
                                           "Datastore reachable from Kong, " ..
                                           "0 is unreachable")
@@ -101,7 +106,6 @@ local function init()
   metrics.consumer_status = prometheus:counter("http_consumer_status",
                                           "HTTP status codes for customer per service/route in Kong",
                                           {"service", "route", "code", "consumer"})
-
 
   -- Hybrid mode status
   if role == "control_plane" then
@@ -313,6 +317,9 @@ local function metric_data()
   metrics.connections:set(ngx.var.connections_reading or 0, { "reading" })
   metrics.connections:set(ngx.var.connections_writing or 0, { "writing" })
   metrics.connections:set(ngx.var.connections_waiting or 0, { "waiting" })
+
+  metrics.timers:set(ngx_timer_running_count(), {"running"})
+  metrics.timers:set(ngx_timer_pending_count(), {"pending"})
 
   -- db reachable?
   local ok, err = kong.db.connector:connect()

--- a/kong/plugins/prometheus/handler.lua
+++ b/kong/plugins/prometheus/handler.lua
@@ -7,7 +7,7 @@ prometheus.init()
 
 local PrometheusHandler = {
   PRIORITY = 13,
-  VERSION  = "1.5.0",
+  VERSION  = "1.6.0",
 }
 
 function PrometheusHandler.init_worker()

--- a/kong/pluginsocket.proto
+++ b/kong/pluginsocket.proto
@@ -113,6 +113,14 @@ message CertificateKey {
     string id = 1;
 }
 
+message RawBodyResult {
+    oneof kind {
+        bytes content = 1;
+        string body_filepath = 2;
+        string error = 3;
+    }
+}
+
 message Route {
     string id = 1;
     int64 created_at = 2;
@@ -292,7 +300,7 @@ service Kong {
     rpc Request_GetQuery(Int) returns (google.protobuf.Struct);
     rpc Request_GetHeader(String) returns (String);
     rpc Request_GetHeaders(Int) returns (google.protobuf.Struct);
-    rpc Request_GetRawBody(google.protobuf.Empty) returns (String);
+    rpc Request_GetRawBody(google.protobuf.Empty) returns (RawBodyResult);
 
     rpc Response_GetStatus(google.protobuf.Empty) returns (Int);
     rpc Response_GetHeader(String) returns (String);

--- a/kong/runloop/plugin_servers/pb_rpc.lua
+++ b/kong/runloop/plugin_servers/pb_rpc.lua
@@ -151,6 +151,18 @@ do
     [".kong_plugin_protocol.Number"] = wrap_val,
     [".kong_plugin_protocol.Int"] = wrap_val,
     [".kong_plugin_protocol.String"] = wrap_val,
+    [".kong_plugin_protocol.RawBodyResult"] = function(v, err)
+      if type(v) == "string" then
+        return {  content = v }
+      end
+
+      local path = ngx.req.get_body_file()
+      if path then
+        return { body_filepath = path }
+      end
+
+      return { error = err or "Can't read request body" }
+    end,
     --[".kong_plugin_protocol.MemoryStats"] = - function(v)
     --  return {
     --    lua_shared_dicts = {

--- a/kong/runloop/plugin_servers/process.lua
+++ b/kong/runloop/plugin_servers/process.lua
@@ -70,7 +70,8 @@ local function get_server_defs()
       end
 
     elseif config.go_plugins_dir ~= "off" then
-      kong.log.info("old go_pluginserver style")
+      kong.log.deprecation("Properties go_pluginserver_exe and go_plugins_dir are deprecated. Please refer to https://docs.konghq.com/gateway/latest/reference/external-plugins/", {after = "2.8", removal = "3.0"})
+
       _servers[1] = {
         name = "go-pluginserver",
         socket = config.prefix .. "/go_pluginserver.sock",

--- a/kong/vaults/env/init.lua
+++ b/kong/vaults/env/init.lua
@@ -1,4 +1,5 @@
 local type = type
+local gsub = string.gsub
 local upper = string.upper
 local kong = kong
 
@@ -35,15 +36,20 @@ end
 
 local function get(conf, resource, version)
   local prefix = conf.prefix
+
+  resource = gsub(resource, "-", "_")
+
   if type(prefix) == "string" then
     resource = prefix .. resource
   end
+
+  resource = upper(resource)
 
   if version == 2 then
     resource = resource .. "_PREVIOUS"
   end
 
-  return ENV[upper(resource)]
+  return ENV[resource]
 end
 
 

--- a/spec/02-integration/02-cmd/14-vault_spec.lua
+++ b/spec/02-integration/02-cmd/14-vault_spec.lua
@@ -30,7 +30,7 @@ describe("kong vault", function()
 
   it("vault get with non-existing vault", function()
     local ok, stderr, stdout = helpers.kong_exec("vault get none/foo")
-    assert.matches("Error: vault 'none' was not found", stderr, nil, true)
+    assert.matches("Error: vault not found (none) [{vault://none/foo}]", stderr, nil, true)
     assert.is_nil(stdout)
     assert.is_false(ok)
   end)

--- a/spec/02-integration/03-db/01-db_spec.lua
+++ b/spec/02-integration/03-db/01-db_spec.lua
@@ -285,11 +285,13 @@ for _, strategy in helpers.each_strategy() do
 
       if strategy == "postgres" then
         assert.equal("nginx", db.connector:get_stored_connection().sock_type)
-      --elseif strategy == "cassandra" then
-      --TODO: cassandra forces luasocket on timer
+        assert.is_false(db.connector:get_stored_connection().config.ssl)
+
+      elseif strategy == "cassandra" then
+        --TODO: cassandra forces luasocket on timer
+        assert.is_false(db.connector:get_stored_connection().ssl)
       end
 
-      assert.is_false(db.connector:get_stored_connection().ssl)
 
       db:close()
     end)
@@ -308,13 +310,13 @@ for _, strategy in helpers.each_strategy() do
       assert.is_table(conn)
 
       if strategy == "postgres" then
-        assert.equal("luasocket",
-                     db.connector:get_stored_connection().sock_type)
-      --elseif strategy == "cassandra" then
-      --TODO: cassandra forces luasocket on timer
-      end
+        assert.equal("luasocket", db.connector:get_stored_connection().sock_type)
+        assert.is_false(db.connector:get_stored_connection().config.ssl)
 
-      assert.is_false(db.connector:get_stored_connection().ssl)
+      elseif strategy == "cassandra" then
+        --TODO: cassandra forces luasocket on timer
+        assert.is_false(db.connector:get_stored_connection().ssl)
+      end
 
       db:close()
     end)
@@ -339,11 +341,12 @@ for _, strategy in helpers.each_strategy() do
 
       if strategy == "postgres" then
         assert.equal("nginx", db.connector:get_stored_connection().sock_type)
-      --elseif strategy == "cassandra" then
-      --TODO: cassandra forces luasocket on timer
-      end
+        assert.is_true(db.connector:get_stored_connection().config.ssl)
 
-      assert.is_true(db.connector:get_stored_connection().ssl)
+      elseif strategy == "cassandra" then
+        --TODO: cassandra forces luasocket on timer
+        assert.is_true(db.connector:get_stored_connection().ssl)
+      end
 
       db:close()
     end)
@@ -367,13 +370,13 @@ for _, strategy in helpers.each_strategy() do
       assert.is_table(conn)
 
       if strategy == "postgres" then
-        assert.equal("luasocket",
-                     db.connector:get_stored_connection().sock_type)
-      --elseif strategy == "cassandra" then
-      --TODO: cassandra forces luasocket on timer
-      end
+        assert.equal("luasocket", db.connector:get_stored_connection().sock_type)
+        assert.is_true(db.connector:get_stored_connection().config.ssl)
 
-      assert.is_true(db.connector:get_stored_connection().ssl)
+      elseif strategy == "cassandra" then
+        --TODO: cassandra forces luasocket on timer
+        assert.is_true(db.connector:get_stored_connection().ssl)
+      end
 
       db:close()
     end)
@@ -398,7 +401,12 @@ for _, strategy in helpers.each_strategy() do
       assert.is_nil(db.connector:get_stored_connection()) -- empty defaults to "write"
 
       assert.equal("nginx", db.connector:get_stored_connection("read").sock_type)
-      assert.is_false(db.connector:get_stored_connection("read").ssl)
+
+      if strategy == "postgres" then
+        assert.is_false(db.connector:get_stored_connection("read").config.ssl)
+      elseif strategy == "cassandra" then
+        assert.is_false(db.connector:get_stored_connection("read").ssl)
+      end
 
       db:close()
     end)
@@ -423,10 +431,20 @@ for _, strategy in helpers.each_strategy() do
       assert.is_nil(db.connector:get_stored_connection("read"))
 
       assert.equal("luasocket", db.connector:get_stored_connection("write").sock_type)
-      assert.is_false(db.connector:get_stored_connection("write").ssl)
+
+      if strategy == "portgres" then
+        assert.is_false(db.connector:get_stored_connection("write").config.ssl)
+      elseif strategy == "cassandra" then
+        assert.is_false(db.connector:get_stored_connection("write").ssl)
+      end
 
       assert.equal("luasocket", db.connector:get_stored_connection().sock_type)
-      assert.is_false(db.connector:get_stored_connection().ssl)
+
+      if strategy == "portgres" then
+        assert.is_false(db.connector:get_stored_connection("write").config.ssl)
+      elseif strategy == "cassandra" then
+        assert.is_false(db.connector:get_stored_connection("write").ssl)
+      end
 
       db:close()
     end)
@@ -451,13 +469,16 @@ for _, strategy in helpers.each_strategy() do
       assert.is_nil(err)
       assert.is_table(conn)
 
+
       if strategy == "postgres" then
         assert.equal("nginx", db.connector:get_stored_connection().sock_type)
-      --elseif strategy == "cassandra" then
-      --TODO: cassandra forces luasocket on timer
+        assert.is_false(db.connector:get_stored_connection().config.ssl)
+
+      elseif strategy == "cassandra" then
+        --TODO: cassandra forces luasocket on timer
+        assert.is_false(db.connector:get_stored_connection().ssl)
       end
 
-      assert.is_false(db.connector:get_stored_connection().ssl)
       assert.is_true(db:setkeepalive())
 
       db:close()
@@ -477,13 +498,15 @@ for _, strategy in helpers.each_strategy() do
       assert.is_table(conn)
 
       if strategy == "postgres" then
-        assert.equal("luasocket",
-                     db.connector:get_stored_connection().sock_type)
-      --elseif strategy == "cassandra" then
-      --TODO: cassandra forces luasocket on timer
+        assert.equal("luasocket", db.connector:get_stored_connection().sock_type)
+        assert.is_false(db.connector:get_stored_connection().config.ssl)
+
+      elseif strategy == "cassandra" then
+        --TODO: cassandra forces luasocket on timer
+        assert.is_false(db.connector:get_stored_connection().ssl)
       end
 
-      assert.is_false(db.connector:get_stored_connection().ssl)
+
       assert.is_true(db:setkeepalive())
 
       db:close()
@@ -509,11 +532,13 @@ for _, strategy in helpers.each_strategy() do
 
       if strategy == "postgres" then
         assert.equal("nginx", db.connector:get_stored_connection().sock_type)
-      --elseif strategy == "cassandra" then
-      --TODO: cassandra forces luasocket on timer
+        assert.is_true(db.connector:get_stored_connection().config.ssl)
+
+      elseif strategy == "cassandra" then
+        --TODO: cassandra forces luasocket on timer
+        assert.is_true(db.connector:get_stored_connection().ssl)
       end
 
-      assert.is_true(db.connector:get_stored_connection().ssl)
       assert.is_true(db:setkeepalive())
 
       db:close()
@@ -538,13 +563,15 @@ for _, strategy in helpers.each_strategy() do
       assert.is_table(conn)
 
       if strategy == "postgres" then
-        assert.equal("luasocket",
-                     db.connector:get_stored_connection().sock_type)
-      --elseif strategy == "cassandra" then
-      --TODO: cassandra forces luasocket on timer
+        assert.equal("luasocket", db.connector:get_stored_connection().sock_type)
+        assert.is_true(db.connector:get_stored_connection().config.ssl)
+
+      elseif strategy == "cassandra" then
+        --TODO: cassandra forces luasocket on timer
+        assert.is_true(db.connector:get_stored_connection().ssl)
       end
 
-      assert.is_true(db.connector:get_stored_connection().ssl)
+
       assert.is_true(db:setkeepalive())
 
       db:close()
@@ -599,8 +626,14 @@ for _, strategy in helpers.each_strategy() do
       assert.equal("nginx", db.connector:get_stored_connection("read").sock_type)
       assert.equal("nginx", db.connector:get_stored_connection("write").sock_type)
 
-      assert.is_false(db.connector:get_stored_connection("read").ssl)
-      assert.is_false(db.connector:get_stored_connection("write").ssl)
+      if strategy == "postgres" then
+        assert.is_false(db.connector:get_stored_connection("read").config.ssl)
+        assert.is_false(db.connector:get_stored_connection("write").config.ssl)
+
+      elseif strategy == "cassandra" then
+        assert.is_false(db.connector:get_stored_connection("read").ssl)
+        assert.is_false(db.connector:get_stored_connection("write").ssl)
+      end
 
       assert.is_true(db:setkeepalive())
 
@@ -634,7 +667,11 @@ for _, strategy in helpers.each_strategy() do
       assert.equal("luasocket", db.connector:get_stored_connection("write").sock_type)
       assert.is_nil(db.connector:get_stored_connection("read"))
 
-      assert.is_false(db.connector:get_stored_connection("write").ssl)
+      if strategy == "postgres" then
+        assert.is_false(db.connector:get_stored_connection("write").config.ssl)
+      elseif strategy == "cassandra" then
+        assert.is_false(db.connector:get_stored_connection("write").ssl)
+      end
 
       assert.is_true(db:setkeepalive())
 
@@ -666,11 +703,14 @@ for _, strategy in helpers.each_strategy() do
 
       if strategy == "postgres" then
         assert.equal("nginx", db.connector:get_stored_connection().sock_type)
-      --elseif strategy == "cassandra" then
-      --TODO: cassandra forces luasocket on timer
+        assert.is_false(db.connector:get_stored_connection().config.ssl)
+
+      elseif strategy == "cassandra" then
+        --TODO: cassandra forces luasocket on timer
+        assert.is_false(db.connector:get_stored_connection().ssl)
       end
 
-      assert.is_false(db.connector:get_stored_connection().ssl)
+
       assert.is_true(db:close())
     end)
 
@@ -689,11 +729,14 @@ for _, strategy in helpers.each_strategy() do
 
       if strategy == "postgres" then
         assert.equal("luasocket", db.connector:get_stored_connection().sock_type)
-      --elseif strategy == "cassandra" then
-      --TODO: cassandra forces luasocket on timer
+        assert.is_false(db.connector:get_stored_connection().config.ssl)
+
+      elseif strategy == "cassandra" then
+        --TODO: cassandra forces luasocket on timer
+        assert.is_false(db.connector:get_stored_connection().ssl)
       end
 
-      assert.is_false(db.connector:get_stored_connection().ssl)
+
       assert.is_true(db:close())
     end)
 
@@ -717,11 +760,13 @@ for _, strategy in helpers.each_strategy() do
 
       if strategy == "postgres" then
         assert.equal("nginx", db.connector:get_stored_connection().sock_type)
-      --elseif strategy == "cassandra" then
-      --TODO: cassandra forces luasocket on timer
+        assert.is_true(db.connector:get_stored_connection().config.ssl)
+
+      elseif strategy == "cassandra" then
+        --TODO: cassandra forces luasocket on timer
+        assert.is_true(db.connector:get_stored_connection().ssl)
       end
 
-      assert.is_true(db.connector:get_stored_connection().ssl)
       assert.is_true(db:close())
     end)
 
@@ -744,13 +789,14 @@ for _, strategy in helpers.each_strategy() do
       assert.is_table(conn)
 
       if strategy == "postgres" then
-        assert.equal("luasocket",
-                     db.connector:get_stored_connection().sock_type)
-      --elseif strategy == "cassandra" then
-      --TODO: cassandra forces luasocket on timer
+        assert.equal("luasocket", db.connector:get_stored_connection().sock_type)
+        assert.is_true(db.connector:get_stored_connection().config.ssl)
+
+      elseif strategy == "cassandra" then
+        --TODO: cassandra forces luasocket on timer
+        assert.is_true(db.connector:get_stored_connection().ssl)
       end
 
-      assert.is_true(db.connector:get_stored_connection().ssl)
       assert.is_true(db:close())
     end)
 
@@ -803,8 +849,14 @@ for _, strategy in helpers.each_strategy() do
       assert.equal("nginx", db.connector:get_stored_connection("read").sock_type)
       assert.equal("nginx", db.connector:get_stored_connection("write").sock_type)
 
-      assert.is_false(db.connector:get_stored_connection("read").ssl)
-      assert.is_false(db.connector:get_stored_connection("write").ssl)
+      if strategy == "postgres" then
+        assert.is_false(db.connector:get_stored_connection("read").config.ssl)
+        assert.is_false(db.connector:get_stored_connection("write").config.ssl)
+
+      elseif strategy == "cassandra" then
+        assert.is_false(db.connector:get_stored_connection("read").ssl)
+        assert.is_false(db.connector:get_stored_connection("write").ssl)
+      end
 
       assert.is_true(db:close())
 
@@ -837,7 +889,11 @@ for _, strategy in helpers.each_strategy() do
       assert.equal("luasocket", db.connector:get_stored_connection("write").sock_type)
       assert.is_nil(db.connector:get_stored_connection("read"))
 
-      assert.is_false(db.connector:get_stored_connection("write").ssl)
+      if strategy == "postgres" then
+        assert.is_false(db.connector:get_stored_connection("write").config.ssl)
+      elseif strategy == "cassandra" then
+        assert.is_false(db.connector:get_stored_connection("write").ssl)
+      end
 
       assert.is_true(db:close())
 

--- a/spec/02-integration/04-admin_api/02-kong_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/02-kong_routes_spec.lua
@@ -207,7 +207,11 @@ describe("Admin API - Kong routes with strategy #" .. strategy, function()
       assert.is_number(json.server.connections_writing)
       assert.is_number(json.server.connections_waiting)
       assert.is_number(json.server.total_requests)
-      assert.is_nil(json.server.configuration_hash) -- not present in DB mode, or in DBLESS mode until configuration is applied
+      if strategy == "off" then
+        assert.is_equal(string.rep("0", 32), json.configuration_hash) -- all 0 in DBLESS mode until configuration is applied
+      else
+        assert.is_nil(json.configuration_hash) -- not present in DB mode
+      end
     end)
 
     it("returns status info including a configuration_hash in DBLESS mode if an initial configuration has been provided #off", function()

--- a/spec/02-integration/04-admin_api/19-vaults_spec.lua
+++ b/spec/02-integration/04-admin_api/19-vaults_spec.lua
@@ -1,0 +1,289 @@
+local helpers = require "spec.helpers"
+local utils = require "kong.tools.utils"
+local cjson = require "cjson"
+
+
+local HEADERS = { ["Content-Type"] = "application/json" }
+
+
+for _, strategy in helpers.each_strategy() do
+  describe("Admin API #" .. strategy, function()
+    local client
+    lazy_setup(function()
+      helpers.get_db_utils(strategy, {
+        "vaults",
+      })
+
+      assert(helpers.start_kong({
+        database = strategy,
+        vaults = "bundled",
+      }))
+    end)
+
+    lazy_teardown(function()
+      helpers.stop_kong(nil, true)
+    end)
+
+    before_each(function()
+      client = helpers.admin_client()
+    end)
+
+    after_each(function()
+      if client then
+        client:close()
+      end
+    end)
+
+    describe("/vaults-beta", function()
+      local vaults = {}
+
+      lazy_setup(function()
+        for i = 1, 3 do
+          local res = helpers.admin_client():put("/vaults-beta/env-" .. i, {
+            headers = HEADERS,
+            body = {
+              name = "env",
+            },
+          })
+
+          local body = assert.res_status(200, res)
+          local json = cjson.decode(body)
+          vaults[i] = json
+        end
+      end)
+
+      describe("GET", function()
+        it("retrieves all vaults configured", function()
+          local res = client:get("/vaults-beta")
+          local body = assert.res_status(200, res)
+          local json = cjson.decode(body)
+          assert.equal(3, #json.data)
+        end)
+      end)
+
+      it("returns 405 on invalid method", function()
+        local methods = { "delete", "patch" }
+        for i = 1, #methods do
+          local res = client[methods[i]](client, "/vaults-beta", {
+            headers = HEADERS,
+            body = {}, -- tmp: body to allow POST/PUT to work
+          })
+          local body = assert.response(res).has.status(405)
+          local json = cjson.decode(body)
+          assert.same({ message = "Method not allowed" }, json)
+        end
+      end)
+
+      describe("/vaults-beta/{vault}", function()
+        describe("GET", function()
+          it("retrieves a vault by id", function()
+            local res = client:get("/vaults-beta/" .. vaults[1].id)
+            local body = assert.res_status(200, res)
+            local json = cjson.decode(body)
+            assert.same(vaults[1], json)
+          end)
+
+          -- TODO: `unique_across_ws=true` doesn't seem to work with Cassandra
+          if strategy ~= "cassandra" then
+            it("retrieves a vault by prefix", function()
+              local res = client:get("/vaults-beta/" .. vaults[1].prefix)
+              local body = assert.res_status(200, res)
+              local json = cjson.decode(body)
+              assert.same(vaults[1], json)
+            end)
+          end
+
+          it("returns 404 if not found by id", function()
+            local res = client:get("/vaults-beta/f4aecadc-05c7-11e6-8d41-1f3b3d5fa15c")
+            assert.res_status(404, res)
+          end)
+
+          it("returns 404 if not found by prefix", function()
+            local res = client:get("/vaults-beta/not-found")
+            assert.res_status(404, res)
+          end)
+        end)
+
+        describe("PUT", function()
+          it("can create a vault by id", function()
+            local res = client:put("/vaults-beta/" .. utils.uuid(), {
+              headers = HEADERS,
+              body = {
+                name = "env",
+                prefix = "put-env-id"
+              },
+            })
+            assert.res_status(200, res)
+          end)
+
+          it("can create a vault by prefix", function()
+            local res = client:put("/vaults-beta/put-env-prefix", {
+              headers = HEADERS,
+              body = {
+                name = "env",
+              },
+            })
+            assert.res_status(200, res)
+          end)
+
+          describe("errors", function()
+            it("handles invalid input by id", function()
+              local res = client:put("/vaults-beta/" .. utils.uuid(), {
+                headers = HEADERS,
+                body = {
+                  name = "env",
+                  prefix = "env",
+                },
+              })
+              local body = assert.res_status(400, res)
+              local json = cjson.decode(body)
+              assert.same({
+                name = "schema violation",
+                code = 2,
+                message = "schema violation (prefix: must not be one of: env)",
+                fields = {
+                  prefix = "must not be one of: env",
+                },
+              }, json)
+            end)
+
+            -- TODO: `unique_across_ws=true` doesn't seem to work with Cassandra
+            if strategy ~= "cassandra" then
+              it("handles invalid input by prefix", function()
+                local res = client:put("/vaults-beta/env", {
+                  headers = HEADERS,
+                  body = {
+                    name = "env",
+                  },
+                })
+                local body = assert.res_status(400, res)
+                local json = cjson.decode(body)
+                assert.same({
+                  name = "invalid unique prefix",
+                  code = 10,
+                  message = "must not be one of: env",
+                }, json)
+              end)
+            end
+          end)
+        end)
+
+        describe("PATCH", function()
+          it("updates a vault by id", function()
+            local res = client:patch("/vaults-beta/" .. vaults[1].id, {
+              headers = HEADERS,
+              body = {
+                config = {
+                  prefix = "SSL_",
+                }
+              },
+            })
+            local body = assert.res_status(200, res)
+            local json = cjson.decode(body)
+            assert.equal("SSL_", json.config.prefix)
+
+            vaults[1] = json
+          end)
+
+          -- TODO: `unique_across_ws=true` doesn't seem to work with Cassandra
+          if strategy ~= "cassandra" then
+            it("updates a vault by prefix", function()
+              local res = client:patch("/vaults-beta/env-1", {
+                headers = HEADERS,
+                body = {
+                  config = {
+                    prefix = "CERT_",
+                  }
+                },
+              })
+              local body = assert.res_status(200, res)
+              local json = cjson.decode(body)
+              assert.equal("CERT_", json.config.prefix)
+
+              vaults[1] = json
+            end)
+          end
+
+          describe("errors", function()
+            it("handles invalid input by id", function()
+              local res = client:patch("/vaults-beta/" .. vaults[1].id, {
+                headers = HEADERS,
+                body = { prefix = "env" },
+              })
+              local body = assert.res_status(400, res)
+              local json = cjson.decode(body)
+              assert.same({
+                name = "schema violation",
+                code = 2,
+                message = "schema violation (prefix: must not be one of: env)",
+                fields = {
+                  prefix = "must not be one of: env",
+                },
+              }, json)
+            end)
+
+            -- TODO: `unique_across_ws=true` doesn't seem to work with Cassandra
+            if strategy ~= "cassandra" then
+              it("handles invalid input by prefix", function()
+                local res = client:patch("/vaults-beta/env-1", {
+                  headers = HEADERS,
+                  body = { prefix = "env" },
+                })
+                local body = assert.res_status(400, res)
+                local json = cjson.decode(body)
+                assert.same({
+                  name = "schema violation",
+                  code = 2,
+                  message = "schema violation (prefix: must not be one of: env)",
+                  fields = {
+                    prefix = "must not be one of: env",
+                  },
+                }, json)
+              end)
+            end
+
+            it("returns 404 if not found", function()
+              local res = client:patch("/vaults-beta/f4aecadc-05c7-11e6-8d41-1f3b3d5fa15c", {
+                headers = HEADERS,
+                body = { prefix = "env" },
+              })
+              assert.res_status(404, res)
+            end)
+          end)
+        end)
+
+        describe("DELETE", function()
+          it("deletes by id", function()
+            local res = client:get("/vaults-beta/" .. vaults[3].id)
+            assert.res_status(200, res)
+
+            res = client:delete("/vaults-beta/" .. vaults[3].id)
+            assert.res_status(204, res)
+
+            res = client:get("/vaults-beta/" .. vaults[3].id)
+            assert.res_status(404, res)
+          end)
+
+          -- TODO: `unique_across_ws=true` doesn't seem to work with Cassandra
+          if strategy ~= "cassandra" then
+            it("deletes by prefix", function()
+              local res = client:get("/vaults-beta/env-2")
+              assert.res_status(200, res)
+
+              res = client:delete("/vaults-beta/env-2")
+              assert.res_status(204, res)
+
+              res = client:get("/vaults-beta/env-2")
+              assert.res_status(404, res)
+            end)
+          end
+
+          it("returns 204 if not found", function()
+            local res = client:delete("/vaults-beta/f4aecadc-05c7-11e6-8d41-1f3b3d5fa15c")
+            assert.res_status(204, res)
+          end)
+        end)
+      end)
+    end)
+  end)
+end

--- a/spec/02-integration/08-status_api/01-core_routes_spec.lua
+++ b/spec/02-integration/08-status_api/01-core_routes_spec.lua
@@ -21,7 +21,7 @@ describe("Status API - with strategy #" .. strategy, function()
   end)
 
   describe("core", function()
-    it("/status returns status info without configuration_hash", function()
+    it("/status returns status info with blank configuration_hash (declarative config) or without it (db mode)", function()
       local res = assert(client:send {
         method = "GET",
         path = "/status"
@@ -40,7 +40,11 @@ describe("Status API - with strategy #" .. strategy, function()
       assert.is_number(json.server.connections_writing)
       assert.is_number(json.server.connections_waiting)
       assert.is_number(json.server.total_requests)
-      assert.is_nil(json.server.configuration_hash) -- no hash in DB mode, or in DBLESS mode until configuration has been applied
+      if strategy == "off" then
+        assert.is_equal(string.rep("0", 32), json.configuration_hash) -- all 0 in DBLESS mode until configuration is applied
+      else
+        assert.is_nil(json.configuration_hash) -- not present in DB mode
+      end
     end)
 
     it("/status starts providing a config_hash once an initial configuration has been pushed in dbless mode #off", function()
@@ -77,8 +81,8 @@ describe("Status API - with strategy #" .. strategy, function()
       assert.is_number(json.server.connections_writing)
       assert.is_number(json.server.connections_waiting)
       assert.is_number(json.server.total_requests)
-      assert.is_string(json.server.configuration_hash)
-      assert.equal(32, #json.server.configuration_hash)
+      assert.is_string(json.configuration_hash)
+      assert.equal(32, #json.configuration_hash)
     end)
 
   end)

--- a/spec/02-integration/13-vaults/01-vault_spec.lua
+++ b/spec/02-integration/13-vaults/01-vault_spec.lua
@@ -6,9 +6,14 @@ local cjson = require "cjson"
 for _, strategy in helpers.each_strategy() do
   describe("/certificates with DB: #" .. strategy, function()
     local client
+    local db
 
     lazy_setup(function()
-      helpers.get_db_utils(strategy, {
+      helpers.setenv("CERT", ssl_fixtures.cert)
+      helpers.setenv("KEY", ssl_fixtures.key)
+
+      local _
+      _, db = helpers.get_db_utils(strategy, {
         "certificates",
         "vaults_beta",
       })
@@ -38,27 +43,44 @@ for _, strategy in helpers.each_strategy() do
 
     lazy_teardown(function()
       helpers.stop_kong()
+      helpers.unsetenv("CERT")
+      helpers.unsetenv("KEY")
     end)
 
     it("create certificates with cert and key as secret", function()
-      finally(function()
-        helpers.unsetenv("CERT")
-        helpers.unsetenv("KEY")
-      end)
-      helpers.setenv("CERT", ssl_fixtures.cert)
-      helpers.setenv("KEY", ssl_fixtures.key)
       local res, err  = client:post("/certificates", {
-        body    = {
-          cert  = "{vault://test-vault/cert}",
-          key   = "{vault://test-vault/key}",
-        },
         headers = { ["Content-Type"] = "application/json" },
+        body = {
+          cert     = "{vault://test-vault/cert}",
+          key      = "{vault://test-vault/key}",
+          cert_alt = "{vault://unknown/cert}",
+          key_alt  = "{vault://unknown/missing-key}",
+        },
       })
       assert.is_nil(err)
       local body = assert.res_status(201, res)
       local certificate = cjson.decode(body)
-      assert.not_nil(certificate.key)
-      assert.not_nil(certificate.cert)
+      assert.equal("{vault://test-vault/cert}", certificate.cert)
+      assert.equal("{vault://test-vault/key}", certificate.key)
+      assert.equal("{vault://unknown/cert}", certificate.cert_alt)
+      assert.equal("{vault://unknown/missing-key}", certificate.key_alt)
+
+      certificate, err = db.certificates:select({ id = certificate.id })
+      assert.is_nil(err)
+      assert.equal(ssl_fixtures.cert, certificate.cert)
+      assert.equal(ssl_fixtures.key, certificate.key)
+      assert.is_nil(certificate.cert_alt)
+      assert.is_nil(certificate.key_alt)
+
+      -- TODO: this is unexpected but schema.process_auto_fields uses currently
+      -- the `nulls` parameter to detect if the call comes from Admin API
+      -- for performance reasons
+      certificate, err = db.certificates:select({ id = certificate.id }, { nulls = true })
+      assert.is_nil(err)
+      assert.equal("{vault://test-vault/cert}", certificate.cert)
+      assert.equal("{vault://test-vault/key}", certificate.key)
+      assert.equal("{vault://unknown/cert}", certificate.cert_alt)
+      assert.equal("{vault://unknown/missing-key}", certificate.key_alt)
     end)
   end)
 end

--- a/spec/03-plugins/13-cors/01-access_spec.lua
+++ b/spec/03-plugins/13-cors/01-access_spec.lua
@@ -570,7 +570,7 @@ for _, strategy in helpers.each_strategy() do
         assert.is_nil(res.headers["Access-Control-Expose-Headers"])
         assert.is_nil(res.headers["Access-Control-Allow-Credentials"])
         assert.is_nil(res.headers["Access-Control-Max-Age"])
-        assert.equal("Origin", res.headers["Vary"])
+        assert.is_nil(res.headers["Vary"])
       end)
 
       it("gives * wildcard when config.origins is empty", function()
@@ -596,7 +596,7 @@ for _, strategy in helpers.each_strategy() do
         assert.is_nil(res.headers["Access-Control-Expose-Headers"])
         assert.is_nil(res.headers["Access-Control-Allow-Credentials"])
         assert.is_nil(res.headers["Access-Control-Max-Age"])
-        assert.equal("Origin", res.headers["Vary"])
+        assert.is_nil(res.headers["Vary"])
       end)
 
       it("gives appropriate defaults when origin is explicitly set to *", function()
@@ -722,7 +722,7 @@ for _, strategy in helpers.each_strategy() do
         assert.is_nil(res.headers["Access-Control-Expose-Headers"])
         assert.is_nil(res.headers["Access-Control-Allow-Credentials"])
         assert.is_nil(res.headers["Access-Control-Max-Age"])
-        assert.equal("Origin", res.headers["Vary"])
+        assert.is_nil(res.headers["Vary"])
       end)
 
       it("proxies a non-preflight OPTIONS request", function()
@@ -742,7 +742,7 @@ for _, strategy in helpers.each_strategy() do
         assert.is_nil(res.headers["Access-Control-Expose-Headers"])
         assert.is_nil(res.headers["Access-Control-Allow-Credentials"])
         assert.is_nil(res.headers["Access-Control-Max-Age"])
-        assert.equal("Origin", res.headers["Vary"])
+        assert.is_nil(res.headers["Vary"])
       end)
 
       it("accepts config options", function()
@@ -811,7 +811,7 @@ for _, strategy in helpers.each_strategy() do
         assert.is_nil(res.headers["Access-Control-Expose-Headers"])
         assert.is_nil(res.headers["Access-Control-Allow-Credentials"])
         assert.is_nil(res.headers["Access-Control-Max-Age"])
-        assert.equal("Origin", res.headers["Vary"])
+        assert.is_nil(res.headers["Vary"])
       end)
 
       it("works with 40x responses returned by another plugin", function()
@@ -828,7 +828,7 @@ for _, strategy in helpers.each_strategy() do
         assert.is_nil(res.headers["Access-Control-Expose-Headers"])
         assert.is_nil(res.headers["Access-Control-Allow-Credentials"])
         assert.is_nil(res.headers["Access-Control-Max-Age"])
-        assert.equal("Origin", res.headers["Vary"])
+        assert.is_nil(res.headers["Vary"])
       end)
 
       it("sets CORS orgin based on origin host", function()
@@ -1015,7 +1015,7 @@ for _, strategy in helpers.each_strategy() do
         assert.res_status(200, res)
         assert.equals("*", res.headers["Access-Control-Allow-Origin"])
         assert.is_nil(res.headers["Access-Control-Allow-Credentials"])
-        assert.equal("Origin", res.headers["Vary"])
+        assert.is_nil(res.headers["Vary"])
       end)
 
       it("removes upstream ACAO header when no match is found", function()

--- a/spec/03-plugins/25-oauth2/03-access_spec.lua
+++ b/spec/03-plugins/25-oauth2/03-access_spec.lua
@@ -3,6 +3,8 @@ local helpers = require "spec.helpers"
 local utils   = require "kong.tools.utils"
 local admin_api = require "spec.fixtures.admin_api"
 local sha256 = require "resty.sha256"
+local jwt_encoder = require "kong.plugins.jwt.jwt_parser"
+
 
 local math_random = math.random
 local string_char = string.char
@@ -11,6 +13,14 @@ local string_rep = string.rep
 
 
 local ngx_encode_base64 = ngx.encode_base64
+
+
+local PAYLOAD = {
+  iss = nil,
+  nbf = os.time(),
+  iat = os.time(),
+  exp = os.time() + 3600
+}
 
 
 local kong = {
@@ -141,6 +151,7 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
       "consumers",
       "plugins",
       "keyauth_credentials",
+      "jwt_secrets",
       "oauth2_credentials",
       "oauth2_authorization_codes",
       "oauth2_tokens",
@@ -3624,6 +3635,7 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
     local user2
     local anonymous
     local keyauth
+    local jwt_secret
 
     lazy_setup(function()
       local service1 = admin_api.services:insert({
@@ -3668,8 +3680,22 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
         service    = service2
       }))
 
+      local route3 = assert(admin_api.routes:insert({
+        hosts      = { "logical-or-jwt.com" },
+        protocols  = { "http", "https" },
+        service    = service2
+      }))
+
       admin_api.oauth2_plugins:insert({
         route = { id = route2.id },
+        config   = {
+          scopes    = { "email", "profile", "user.email" },
+          anonymous = anonymous.id,
+        },
+      })
+
+      admin_api.oauth2_plugins:insert({
+        route = { id = route3.id },
         config   = {
           scopes    = { "email", "profile", "user.email" },
           anonymous = anonymous.id,
@@ -3684,9 +3710,21 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
         },
       }
 
+      admin_api.plugins:insert {
+        name     = "jwt",
+        route = { id = route3.id },
+        config   = {
+          anonymous = anonymous.id,
+        },
+      }
+
       keyauth = admin_api.keyauth_credentials:insert({
         key      = "Mouse",
         consumer = { id = user1.id },
+      })
+
+      jwt_secret = admin_api.jwt_secrets:insert({
+        consumer = { id = user1.id }
       })
 
       admin_api.oauth2_credentials:insert {
@@ -3798,15 +3836,18 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
         assert.request(res).has.no.header("x-credential-username")
       end)
 
-      it("passes with only the first credential provided", function()
+      it("passes with only the first credential provided (higher priority)", function()
         local res = assert(proxy_client:send {
           method  = "GET",
           path = "/request",
           headers = {
             ["Host"] = "logical-or.com",
             ["apikey"] = "Mouse",
+            ["X-Authenticated-Scope"] = "all-access",
+            ["X-Authenticated-UserId"] = "admin",
           }
         })
+
         assert.response(res).has.status(200)
         assert.request(res).has.no.header("x-anonymous-consumer")
         local id = assert.request(res).has.header("x-consumer-id")
@@ -3815,6 +3856,35 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
         local client_id = assert.request(res).has.header("x-credential-identifier")
         assert.equal(keyauth.id, client_id)
         assert.request(res).has.no.header("x-credential-username")
+        assert.request(res).has.no.header("x-authenticated-scope")
+        assert.request(res).has.no.header("x-authenticated-userid")
+      end)
+
+      it("passes with only the first credential provided (lower priority)", function()
+        PAYLOAD.iss = jwt_secret.key
+        local jwt = jwt_encoder.encode(PAYLOAD, jwt_secret.secret)
+        local authorization = "Bearer " .. jwt
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path = "/request",
+          headers = {
+            ["Host"] = "logical-or-jwt.com",
+            ["Authorization"] = authorization,
+            ["X-Authenticated-Scope"] = "all-access",
+            ["X-Authenticated-UserId"] = "admin",
+          }
+        })
+
+        assert.response(res).has.status(200)
+        assert.request(res).has.no.header("x-anonymous-consumer")
+        local id = assert.request(res).has.header("x-consumer-id")
+        assert.not_equal(id, anonymous.id)
+        assert.equal(user1.id, id)
+        local client_id = assert.request(res).has.header("x-credential-identifier")
+        assert.equal(jwt_secret.key, client_id)
+        assert.request(res).has.no.header("x-credential-username")
+        assert.request(res).has.no.header("x-authenticated-scope")
+        assert.request(res).has.no.header("x-authenticated-userid")
       end)
 
       it("passes with only the second credential provided", function()

--- a/spec/03-plugins/26-prometheus/04-status_api_spec.lua
+++ b/spec/03-plugins/26-prometheus/04-status_api_spec.lua
@@ -286,6 +286,16 @@ describe("Plugin: prometheus (access via status API)", function()
     assert.matches('kong_datastore_reachable 1', body, nil, true)
   end)
 
+  it("exposes nginx timer metrics", function()
+    local res = assert(status_client:send {
+      method  = "GET",
+      path    = "/metrics",
+    })
+    local body = assert.res_status(200, res)
+    assert.matches('kong_nginx_timers{state="running"} %d+', body)
+    assert.matches('kong_nginx_timers{state="pending"} %d+', body)
+  end)
+
   it("exposes upstream's target health metrics - healthchecks-off", function()
     local body
     helpers.wait_until(function()

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -183,16 +183,19 @@ _G.kong = kong_global.new()
 kong_global.init_pdk(_G.kong, conf, nil) -- nil: latest PDK
 ngx.ctx.KONG_PHASE = kong_global.phases.access
 _G.kong.core_cache = {
-  get = function(self, key)
+  get = function(self, key, opts, func, ...)
     if key == constants.CLUSTER_ID_PARAM_KEY then
       return "123e4567-e89b-12d3-a456-426655440000"
     end
+
+    return func(...)
   end
 }
 
 local db = assert(DB.new(conf))
 assert(db:init_connector())
 db.plugins:load_plugin_schemas(conf.loaded_plugins)
+db.vaults_beta:load_vault_schemas(conf.loaded_vaults)
 local blueprints = assert(Blueprints.new(db))
 local dcbp
 local config_yml
@@ -399,6 +402,7 @@ local function get_db_utils(strategy, tables, plugins)
 
   db:truncate("plugins")
   assert(db.plugins:load_plugin_schemas(conf.loaded_plugins))
+  assert(db.vaults_beta:load_vault_schemas(conf.loaded_vaults))
 
   -- cleanup the tags table, since it will be hacky and
   -- not necessary to implement "truncate trigger" in Cassandra

--- a/spec/kong_tests.conf
+++ b/spec/kong_tests.conf
@@ -39,3 +39,4 @@ go_plugins_dir = off
 
 untrusted_lua = sandbox
 
+vaults = bundled


### PR DESCRIPTION
This pull request contains all the fixes and documentation updates that occurred since the 2.8.x feature freeze.

Fixes (Should appear in the changelog):
- fix(aws-lambda) proxy correctly with lua-resty-http (#8406)
- fix(go-pdk) request.GetRawBody when buffered (#8390)
- fix(db) when auto-dereferencing fails set value to nil
- chore(deps) bump pgmoon from 1.13.0 to 1.14.0 (#8429) # Fixes boot up error with default PostgreSQL 14
- fix(declarative) initialize hash for empty config (#8425)
- fix(cors) don't send vary header with * origin (#8401)
- fix(oauth2) clear authenticated oauth2 headers with multi-auth
- fix(datadog) default value for metrics specified twice (#8315)

Hotfixes (fixes for new features like the Vaults Beta, which should not appear in the changelog):
- fix(pdk) missing vault was not handled correctly and could lead to runtime error
- fix(pdk) change detection of process/config secrets
- fix(pdk) vault process configs loading with strategy that has "-" in its name
- fix(pdk) env vault to replace "-" in resource with "_"
- fix(pdk) fill default values with vault config required fields (#8427)

Docs:
- Update to final changelog
- docs(changelog) add missing fix in the changelog. Related #8401
- docs(admin) add docs for vault_beta entity (#8441)
- chore(rate-limiting) bump plugin version
- chore(response-ratelimiting) bump plugin version
- docs(changelog) add deprecation of go-pluginserver
- docs(autodoc) Update Admin API note (#8405)
- docs(autodoc) Update Admin API Target Object  (#8413)
- chore(deprecation) add deprecation warning
- chore(plugins) bump some plugin versions due to changes

Exceptions to feature freeze:
- feat(prometheus) add nginx timer metrics (#8387)
