### PR TITLE
chore(plugins) bump some plugin versions due to changes

### DIFF
--- a/kong/plugins/acme/handler.lua
+++ b/kong/plugins/acme/handler.lua
@@ -13,7 +13,7 @@ local ACMEHandler = {}
 -- otherwise acme-challenges endpoints may be blocked by auth plugins
 -- causing validation failures
 ACMEHandler.PRIORITY = 1007
-ACMEHandler.VERSION = "0.3.0"
+ACMEHandler.VERSION = "0.4.0"
 
 local function build_domain_matcher(domains)
   local domains_plain = {}

--- a/kong/plugins/cors/handler.lua
+++ b/kong/plugins/cors/handler.lua
@@ -17,7 +17,7 @@ local CorsHandler = {}
 
 
 CorsHandler.PRIORITY = 2000
-CorsHandler.VERSION = "2.0.0"
+CorsHandler.VERSION = "2.1.1"
 
 
 -- per-plugin cache of normalized origins for runtime comparison

--- a/kong/plugins/datadog/handler.lua
+++ b/kong/plugins/datadog/handler.lua
@@ -95,7 +95,7 @@ end
 
 local DatadogHandler = {
   PRIORITY = 10,
-  VERSION = "3.1.0",
+  VERSION = "3.1.1",
 }
 
 

--- a/kong/plugins/oauth2/handler.lua
+++ b/kong/plugins/oauth2/handler.lua
@@ -3,7 +3,7 @@ local access = require "kong.plugins.oauth2.access"
 
 local OAuthHandler = {
   PRIORITY = 1004,
-  VERSION = "2.1.1",
+  VERSION = "2.1.2",
 }
 
 

--- a/kong/plugins/prometheus/handler.lua
+++ b/kong/plugins/prometheus/handler.lua
@@ -7,7 +7,7 @@ prometheus.init()
 
 local PrometheusHandler = {
   PRIORITY = 13,
-  VERSION  = "1.5.0",
+  VERSION  = "1.6.0",
 }
 
 function PrometheusHandler.init_worker()


### PR DESCRIPTION
Several plugins should be bumped because we made changes to them.

On Kong 3.0.0 we will change this so the bundled plugin versions
coincide with Kong version

Bumped because of new features:
* ACME #8114
* Prometheus #8387

Bumped because of new fixes:
* CORS #8401
* oauth2 #8422
* Datadog #8315
