### PR TITLE
chore(router) remove [0] in methods_t/snis_t

### DIFF
--- a/kong/router.lua
+++ b/kong/router.lua
@@ -375,10 +375,10 @@ local function marshall_route(r)
   local hosts_t         = { [0] = 0 }
   local headers_t       = { [0] = 0 }
   local uris_t          = { [0] = 0 }
-  local methods_t       = { [0] = 0 }
+  local methods_t       = {}
   local sources_t       = { [0] = 0 }
   local destinations_t  = { [0] = 0 }
-  local snis_t          = { [0] = 0 }
+  local snis_t          = {}
 
 
   -- hosts


### PR DESCRIPTION


### Summary

It seems that methods_t / snis_t does not use function append(),
so the [0] is useless.

### Full changelog

* remove [0] in methods_t/snis_t


