### PR TITLE
style(templates) use var_index default

### DIFF
--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -56,48 +56,7 @@ init_worker_by_lua_block {
 
 > if (role == "traditional" or role == "data_plane") and #proxy_listeners > 0 then
 # Load variable indexes
-lua_kong_load_var_index $args;
-lua_kong_load_var_index $bytes_sent;
-lua_kong_load_var_index $content_type;
-lua_kong_load_var_index $host;
-lua_kong_load_var_index $http_authorization;
-lua_kong_load_var_index $http_connection;
-lua_kong_load_var_index $http_host;
-lua_kong_load_var_index $http_kong_debug;
-lua_kong_load_var_index $http_proxy;
-lua_kong_load_var_index $http_proxy_connection;
-lua_kong_load_var_index $http_te;
-lua_kong_load_var_index $http_upgrade;
-lua_kong_load_var_index $http_x_forwarded_for;
-lua_kong_load_var_index $http_x_forwarded_host;
-lua_kong_load_var_index $http_x_forwarded_path;
-lua_kong_load_var_index $http_x_forwarded_port;
-lua_kong_load_var_index $http_x_forwarded_prefix;
-lua_kong_load_var_index $http_x_forwarded_proto;
-lua_kong_load_var_index $https;
-lua_kong_load_var_index $http2;
-lua_kong_load_var_index $is_args;
-lua_kong_load_var_index $realip_remote_addr;
-lua_kong_load_var_index $realip_remote_port;
-lua_kong_load_var_index $remote_addr;
-lua_kong_load_var_index $remote_port;
-lua_kong_load_var_index $request;
-lua_kong_load_var_index $request_length;
-lua_kong_load_var_index $request_method;
-lua_kong_load_var_index $request_time;
-lua_kong_load_var_index $request_uri;
-lua_kong_load_var_index $scheme;
-lua_kong_load_var_index $server_addr;
-lua_kong_load_var_index $server_port;
-lua_kong_load_var_index $ssl_cipher;
-lua_kong_load_var_index $ssl_client_raw_cert;
-lua_kong_load_var_index $ssl_client_verify;
-lua_kong_load_var_index $ssl_protocol;
-lua_kong_load_var_index $ssl_server_name;
-lua_kong_load_var_index $upstream_http_connection;
-lua_kong_load_var_index $upstream_http_trailer;
-lua_kong_load_var_index $upstream_http_upgrade;
-lua_kong_load_var_index $upstream_status;
+lua_kong_load_var_index default;
 
 upstream kong_upstream {
     server 0.0.0.1;

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -78,48 +78,7 @@ http {
 
 > if (role == "traditional" or role == "data_plane") and #proxy_listeners > 0 then
     # Load variable indexes
-    lua_kong_load_var_index $args;
-    lua_kong_load_var_index $bytes_sent;
-    lua_kong_load_var_index $content_type;
-    lua_kong_load_var_index $host;
-    lua_kong_load_var_index $http_authorization;
-    lua_kong_load_var_index $http_connection;
-    lua_kong_load_var_index $http_host;
-    lua_kong_load_var_index $http_kong_debug;
-    lua_kong_load_var_index $http_proxy;
-    lua_kong_load_var_index $http_proxy_connection;
-    lua_kong_load_var_index $http_te;
-    lua_kong_load_var_index $http_upgrade;
-    lua_kong_load_var_index $http_x_forwarded_for;
-    lua_kong_load_var_index $http_x_forwarded_host;
-    lua_kong_load_var_index $http_x_forwarded_path;
-    lua_kong_load_var_index $http_x_forwarded_port;
-    lua_kong_load_var_index $http_x_forwarded_prefix;
-    lua_kong_load_var_index $http_x_forwarded_proto;
-    lua_kong_load_var_index $https;
-    lua_kong_load_var_index $http2;
-    lua_kong_load_var_index $is_args;
-    lua_kong_load_var_index $realip_remote_addr;
-    lua_kong_load_var_index $realip_remote_port;
-    lua_kong_load_var_index $remote_addr;
-    lua_kong_load_var_index $remote_port;
-    lua_kong_load_var_index $request;
-    lua_kong_load_var_index $request_length;
-    lua_kong_load_var_index $request_method;
-    lua_kong_load_var_index $request_time;
-    lua_kong_load_var_index $request_uri;
-    lua_kong_load_var_index $scheme;
-    lua_kong_load_var_index $server_addr;
-    lua_kong_load_var_index $server_port;
-    lua_kong_load_var_index $ssl_cipher;
-    lua_kong_load_var_index $ssl_client_raw_cert;
-    lua_kong_load_var_index $ssl_client_verify;
-    lua_kong_load_var_index $ssl_protocol;
-    lua_kong_load_var_index $ssl_server_name;
-    lua_kong_load_var_index $upstream_http_connection;
-    lua_kong_load_var_index $upstream_http_trailer;
-    lua_kong_load_var_index $upstream_http_upgrade;
-    lua_kong_load_var_index $upstream_status;
+    lua_kong_load_var_index default;
 
     upstream kong_upstream {
         server 0.0.0.1;


### PR DESCRIPTION


### Summary

In `lua-kong-module` we add a new param `default` for directive `lua_kong_load_var_index`,
It will add many commonly used var index by default.

With this param, the nginx template can be simplified greatly.

Please see:
https://github.com/Kong/lua-kong-nginx-module/pull/34
https://github.com/Kong/lua-kong-nginx-module/pull/35

### Full changelog

* use `lua_kong_load_var_index default`
* remove other `lua_kong_load_var_index`

