### PR TITLE
fix(schema-validator) does not convert the `null` in the declarative configuration to `nil`

### DIFF
--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -26,7 +26,6 @@ local update_time  = ngx.update_time
 local ngx_time     = ngx.time
 local ngx_now      = ngx.now
 local find         = string.find
-local null         = ngx.null
 local max          = math.max
 local sub          = string.sub
 
@@ -1578,8 +1577,15 @@ local function adjust_field_for_context(field, value, context, nulls, opts)
     end
 
     if subfield then
-      for i = 1, #value do
-        value[i] = adjust_field_for_context(subfield, value[i], context, nulls, opts)
+      if field.type ~= "map" then
+        for i = 1, #value do
+          value[i] = adjust_field_for_context(subfield, value[i], context, nulls, opts)
+        end
+
+      else
+        for k, _ in pairs(value) do
+          value[k] = adjust_field_for_context(subfield, value[k], context, nulls, opts)
+        end
       end
     end
   end

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -26,6 +26,7 @@ local update_time  = ngx.update_time
 local ngx_time     = ngx.time
 local ngx_now      = ngx.now
 local find         = string.find
+local null         = ngx.null
 local max          = math.max
 local sub          = string.sub
 

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1584,8 +1584,8 @@ local function adjust_field_for_context(field, value, context, nulls, opts)
         end
 
       else
-        for k, _ in pairs(value) do
-          value[k] = adjust_field_for_context(subfield, value[k], context, nulls, opts)
+        for k, v in pairs(value) do
+          value[k] = adjust_field_for_context(subfield, v, context, nulls, opts)
         end
       end
     end

--- a/kong/plugins/response-ratelimiting/access.lua
+++ b/kong/plugins/response-ratelimiting/access.lua
@@ -9,9 +9,6 @@ local error = error
 local tostring = tostring
 
 
-local null = ngx.null
-
-
 local EMPTY = {}
 local HTTP_TOO_MANY_REQUESTS = 429
 local RATELIMIT_REMAINING = "X-RateLimit-Remaining"

--- a/kong/plugins/response-ratelimiting/access.lua
+++ b/kong/plugins/response-ratelimiting/access.lua
@@ -39,23 +39,21 @@ local function get_usage(conf, identifier, limits, current_timestamp)
 
   for k, v in pairs(limits) do -- Iterate over limit names
     for lk, lv in pairs(v) do -- Iterare over periods
-      if lv ~= null then
-        local current_usage, err = policies[conf.policy].usage(conf, identifier, k, lk, current_timestamp)
-        if err then
-          return nil, err
-        end
-  
-        if not usage[k] then
-          usage[k] = {}
-        end
-  
-        if not usage[k][lk] then
-          usage[k][lk] = {}
-        end
-
-        usage[k][lk].limit = lv
-        usage[k][lk].remaining = lv - current_usage
+      local current_usage, err = policies[conf.policy].usage(conf, identifier, k, lk, current_timestamp)
+      if err then
+        return nil, err
       end
+
+      if not usage[k] then
+        usage[k] = {}
+      end
+
+      if not usage[k][lk] then
+        usage[k][lk] = {}
+      end
+
+      usage[k][lk].limit = lv
+      usage[k][lk].remaining = lv - current_usage
     end
   end
 

--- a/kong/plugins/response-ratelimiting/access.lua
+++ b/kong/plugins/response-ratelimiting/access.lua
@@ -9,6 +9,9 @@ local error = error
 local tostring = tostring
 
 
+local null = ngx.null
+
+
 local EMPTY = {}
 local HTTP_TOO_MANY_REQUESTS = 429
 local RATELIMIT_REMAINING = "X-RateLimit-Remaining"
@@ -36,7 +39,7 @@ local function get_usage(conf, identifier, limits, current_timestamp)
 
   for k, v in pairs(limits) do -- Iterate over limit names
     for lk, lv in pairs(v) do -- Iterare over periods
-      if lv ~= ngx.null then
+      if lv ~= null then
         local current_usage, err = policies[conf.policy].usage(conf, identifier, k, lk, current_timestamp)
         if err then
           return nil, err

--- a/kong/plugins/response-ratelimiting/access.lua
+++ b/kong/plugins/response-ratelimiting/access.lua
@@ -36,21 +36,23 @@ local function get_usage(conf, identifier, limits, current_timestamp)
 
   for k, v in pairs(limits) do -- Iterate over limit names
     for lk, lv in pairs(v) do -- Iterare over periods
-      local current_usage, err = policies[conf.policy].usage(conf, identifier, k, lk, current_timestamp)
-      if err then
-        return nil, err
-      end
+      if lv ~= ngx.null then
+        local current_usage, err = policies[conf.policy].usage(conf, identifier, k, lk, current_timestamp)
+        if err then
+          return nil, err
+        end
+  
+        if not usage[k] then
+          usage[k] = {}
+        end
+  
+        if not usage[k][lk] then
+          usage[k][lk] = {}
+        end
 
-      if not usage[k] then
-        usage[k] = {}
+        usage[k][lk].limit = lv
+        usage[k][lk].remaining = lv - current_usage
       end
-
-      if not usage[k][lk] then
-        usage[k][lk] = {}
-      end
-
-      usage[k][lk].limit = lv
-      usage[k][lk].remaining = lv - current_usage
     end
   end
 

--- a/spec/03-plugins/24-response-rate-limiting/01-schema_spec.lua
+++ b/spec/03-plugins/24-response-rate-limiting/01-schema_spec.lua
@@ -1,5 +1,6 @@
 local schema_def = require "kong.plugins.response-ratelimiting.schema"
 local v = require("spec.helpers").validate_plugin_config_schema
+local null = ngx.null
 
 
 describe("Plugin: response-rate-limiting (schema)", function()
@@ -31,6 +32,12 @@ describe("Plugin: response-rate-limiting (schema)", function()
       local ok, err = v(config, schema_def)
       assert.falsy(ok)
       assert.equal("unknown field", err.config.limits.seco)
+    end)
+    it("limits: \'null\' value", function()
+      -- https://github.com/Kong/kong/issues/8314
+      local config = {limits = {video = {second = null, minute = 1}}}
+      local ok, err = v(config, schema_def)
+      assert.truthy(ok)
     end)
     it("limits: smaller unit is less than bigger unit", function()
       local config = {limits = {video = {second = 2, minute = 1}}}

--- a/spec/03-plugins/24-response-rate-limiting/01-schema_spec.lua
+++ b/spec/03-plugins/24-response-rate-limiting/01-schema_spec.lua
@@ -33,7 +33,7 @@ describe("Plugin: response-rate-limiting (schema)", function()
       assert.falsy(ok)
       assert.equal("unknown field", err.config.limits.seco)
     end)
-    it("limits: \'null\' value", function()
+    it("limits: \'null\' value does not cause 500, issue #8314", function()
       -- https://github.com/Kong/kong/issues/8314
       local config = {limits = {video = {second = null, minute = 1}}}
       local ok, err = v(config, schema_def)

--- a/spec/03-plugins/24-response-rate-limiting/01-schema_spec.lua
+++ b/spec/03-plugins/24-response-rate-limiting/01-schema_spec.lua
@@ -34,7 +34,6 @@ describe("Plugin: response-rate-limiting (schema)", function()
       assert.equal("unknown field", err.config.limits.seco)
     end)
     it("limits: \'null\' value does not cause 500, issue #8314", function()
-      -- https://github.com/Kong/kong/issues/8314
       local config = {limits = {video = {second = null, minute = 1}}}
       local ok, err = v(config, schema_def)
       assert.truthy(ok)

--- a/spec/03-plugins/24-response-rate-limiting/01-schema_spec.lua
+++ b/spec/03-plugins/24-response-rate-limiting/01-schema_spec.lua
@@ -38,6 +38,7 @@ describe("Plugin: response-rate-limiting (schema)", function()
       local config = {limits = {video = {second = null, minute = 1}}}
       local ok, err = v(config, schema_def)
       assert.truthy(ok)
+      assert.falsy(err)
     end)
     it("limits: smaller unit is less than bigger unit", function()
       local config = {limits = {video = {second = 2, minute = 1}}}


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

If `config.limits.{limit_name}.*` is `null`, this plugin will raise a HTTP 500 error.

<!--- Why is this change required? What problem does it solve? -->

### Full changelog

* If `config.limits.{limit_name}.*` is `null`,  skip it.
* Add a related test in `spec/03-plugins/24-response-rate-limiting/01-schema_spec.lua`.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #8314
