### PR TITLE
feat(*) add support for exit_worker_by_lua

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,12 @@
 
 ## Unreleased
 
+### Additions
+
+#### Core
+
+- Plugins can now implement `exit_worker` handler.
+
 ### Dependencies
 
 - Bumped pgmoon from 1.13.0 to 1.14.0

--- a/kong/pdk/private/phases.lua
+++ b/kong/pdk/private/phases.lua
@@ -9,6 +9,7 @@ local ngx_get_phase = ngx.get_phase
 local PHASES = {
   --init            = 0x00000001,
   init_worker       = 0x00000001,
+  exit_worker       = 0x00100000,
   certificate       = 0x00000002,
   --set             = 0x00000004,
   rewrite           = 0x00000010,
@@ -23,7 +24,6 @@ local PHASES = {
   preread           = 0x00004000,
   error             = 0x01000000,
   admin_api         = 0x10000000,
-  cluster_listener  = 0x00000100,
 }
 
 

--- a/kong/plugins/base_plugin.lua
+++ b/kong/plugins/base_plugin.lua
@@ -37,6 +37,11 @@ if subsystem == "http" then
   function BasePlugin:body_filter()
     ngx_log(DEBUG, "executing plugin \"", self._name, "\": body_filter")
   end
+
+  function BasePlugin:exit_worker()
+    ngx_log(DEBUG, "executing plugin \"", self._name, "\": exit_worker")
+  end
+
 elseif subsystem == "stream" then
   function BasePlugin:preread()
     ngx_log(DEBUG, "executing plugin \"", self._name, "\": preread")

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1605,5 +1605,9 @@ return {
         end
       end
     end
-  }
+  },
+  exit_worker = {
+    before = NOOP,
+    after = NOOP,
+  },
 }

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -54,6 +54,10 @@ init_worker_by_lua_block {
     Kong.init_worker()
 }
 
+exit_worker_by_lua_block {
+    Kong.exit_worker()
+}
+
 > if (role == "traditional" or role == "data_plane") and #proxy_listeners > 0 then
 # Load variable indexes
 lua_kong_load_var_index default;

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -76,6 +76,10 @@ http {
         Kong.init_worker()
     }
 
+    exit_worker_by_lua_block {
+        Kong.exit_worker()
+    }
+
 > if (role == "traditional" or role == "data_plane") and #proxy_listeners > 0 then
     # Load variable indexes
     lua_kong_load_var_index default;

--- a/spec/fixtures/custom_plugins/kong/plugins/logger-last/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/logger-last/handler.lua
@@ -20,6 +20,7 @@ LoggerLastHandler.access        = LoggerHandler.access
 LoggerLastHandler.header_filter = LoggerHandler.header_filter
 LoggerLastHandler.body_filter   = LoggerHandler.body_filter
 LoggerLastHandler.log           = LoggerHandler.log
+LoggerLastHandler.exit_worker   = LoggerHandler.exit_worker
 
 
 return LoggerLastHandler

--- a/spec/fixtures/custom_plugins/kong/plugins/logger/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/logger/handler.lua
@@ -68,4 +68,11 @@ function LoggerHandler:log(conf)
 end
 
 
+function LoggerHandler:exit_worker(conf)
+  LoggerHandler.super.exit_worker(self)
+
+  kong.log("exit_worker phase")
+end
+
+
 return LoggerHandler


### PR DESCRIPTION
### Summary

Adds support for an OpenResty phase `exit_worker` in Kong core, and enables that phase for plugins too.