### PR TITLE
fix(balancer) stop DNS renewal on target event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,8 +74,13 @@
 
 #### Core
 
-- Fixed problem when the consistent hash header is not found, the balancer tries to hash a nil value.
-  [#8142](https://github.com/Kong/kong/pull/8142)
+- Target entities using hostnames were resolved when they were not needed. Now
+  when a target is removed or updated, the DNS record associated with it is
+  removed from the list of hostnames to be resolved.
+  [#8497](https://github.com/Kong/kong/pull/8497)
+- Fixed an issue where using the consistent-hashing load-balancing algorithm
+  and the header set in the `hash_on_header` property was not found in the
+  request, proxying would fail. [#8142](https://github.com/Kong/kong/pull/8142)
 
 #### Plugins
 


### PR DESCRIPTION
### Summary

If the target event received is not creating a new target, the DNS record renewal for said record must be stopped. If it's not, Kong will keep resolving every removed/updated target it ever known.

### Full changelog

* When a target event different from `"create"` is received, remove the hostname from the heap containing the hostnames that must be resolved.
* As the heap is not exposed outside of `targets.lua`, no tests were added.

FTI-2927