### PR TITLE
[DOCU-348] Admin API: rm DEL service for route

### DIFF
--- a/autodoc/admin-api/data/admin-api.lua
+++ b/autodoc/admin-api/data/admin-api.lua
@@ -1231,6 +1231,11 @@ return {
       -- While these endpoints actually support DELETE (deleting the entity and
       -- cascade-deleting the plugin), we do not document them, as this operation
       -- is somewhat odd.
+      ["/routes/:routes/service"] = {
+        DELETE = {
+             endpoint = false,
+        }
+      },
       ["/plugins/:plugins/route"] = {
         DELETE = {
           endpoint = false,


### PR DESCRIPTION
### Summary

Remove Admin API **Delete Service Associated to a Specific Route** endpoint.

Accompanying PR for https://github.com/Kong/docs.konghq.com/pull/3740

