### PR TITLE
fix(admin) 500 response when post /config API busy

### DIFF
--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -30,7 +30,7 @@ local pairs = pairs
 local ngx_socket_tcp = ngx.socket.tcp
 local yield = require("kong.tools.utils").yield
 local marshall = require("kong.db.declarative.marshaller").marshall
-loacl min = math.min
+local min = math.min
 
 
 local REMOVE_FIRST_LINE_PATTERN = "^[^\n]+\n(.+)$"

--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -870,7 +870,7 @@ do
     if exiting() then
       return nil, "exiting"
     end
-    
+
     local worker_events = kong.worker_events
 
     local ok, err, default_ws = declarative.load_into_cache(entities, meta, hash)

--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -912,6 +912,7 @@ do
     if exiting() then
       return nil, "exiting"
     end
+
     return true
   end
 

--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -30,6 +30,7 @@ local pairs = pairs
 local ngx_socket_tcp = ngx.socket.tcp
 local yield = require("kong.tools.utils").yield
 local marshall = require("kong.db.declarative.marshaller").marshall
+loacl min = math.min
 
 
 local REMOVE_FIRST_LINE_PATTERN = "^[^\n]+\n(.+)$"
@@ -931,7 +932,7 @@ do
     local ok, err = kong_shm:add(DECLARATIVE_LOCK_KEY, 0, DECLARATIVE_LOCK_TTL)
     if not ok then
       if err == "exists" then
-        local ttl = math.min(ngx.shared.kong:ttl(DECLARATIVE_LOCK_KEY), DECLARATIVE_RETRY_TTL_MAX)
+        local ttl = min(kong_shm:ttl(DECLARATIVE_LOCK_KEY), DECLARATIVE_RETRY_TTL_MAX)
         return nil, "busy", ttl
       end
 


### PR DESCRIPTION
### Summary

fix(admin) 500 response when post /config API busy

When admin API /config is busy loading new config and another upload requested, server response with 500, and message like: failed to broadcast reconfigure event: recursive.

This is caused by `worker_event`'s implementation of detection of recursive. We solve this by rejecting upload requests when busy(429 instead of 500)

Fix FT-2472


