### PR TITLE
Chore(labeler) does not add some labels correctly

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -21,7 +21,8 @@ core/db:
 - any: ['kong/db/**/*', '!kong/db/migrations/**/*']
 
 core/docs:
-- any: ['./*.md', './**/*.md', 'kong/autodoc/**/*']
+- '**/*.md'
+- 'kong/autodoc/**/*'
 
 core/language/go:
 - kong/runloop/plugin_servers/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -21,10 +21,7 @@ core/db:
 - any: ['kong/db/**/*', '!kong/db/migrations/**/*']
 
 core/docs:
-  any:
-  - kong/autodoc/**/*
-  - ./**/*.md
-  - ./*.md
+- any: ['./*.md', './**/*.md', 'kong/autodoc/**/*']
 
 core/language/go:
 - kong/runloop/plugin_servers/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -21,9 +21,10 @@ core/db:
 - any: ['kong/db/**/*', '!kong/db/migrations/**/*']
 
 core/docs:
-- kong/autodoc/**/*
-- ./**/*.md
-- ./*.md
+  any:
+  - kong/autodoc/**/*
+  - ./**/*.md
+  - ./*.md
 
 core/language/go:
 - kong/runloop/plugin_servers/*

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -18,10 +18,6 @@ For a quick start with custom plugin development, check out [Pongo](https://gith
 and the [plugin template](https://github.com/Kong/kong-plugin) explained in detail below.
 
 
-
-
-
-
 ## Distributions
 
 Kong comes in many shapes. While this repository contains its core's source

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -18,6 +18,10 @@ For a quick start with custom plugin development, check out [Pongo](https://gith
 and the [plugin template](https://github.com/Kong/kong-plugin) explained in detail below.
 
 
+
+
+
+
 ## Distributions
 
 Kong comes in many shapes. While this repository contains its core's source


### PR DESCRIPTION
The labeler does not add some labels correctly, such as I create a PR to change the `DEVELOPER.md`, the labeler should add the label named 'corex/docs', but it is not now.

Example: #8518