### PR TITLE
feat(hmac-auth) add support for RSA signatures

### DIFF
--- a/kong/plugins/hmac-auth/access.lua
+++ b/kong/plugins/hmac-auth/access.lua
@@ -1,6 +1,7 @@
 local constants = require "kong.constants"
 local sha256 = require "resty.sha256"
 local openssl_hmac = require "resty.openssl.hmac"
+local openssl_pkey = require "resty.openssl.pkey"
 local utils = require "kong.tools.utils"
 
 
@@ -31,18 +32,45 @@ local SIGNATURE_NOT_VALID = "HMAC signature cannot be verified"
 local SIGNATURE_NOT_SAME = "HMAC signature does not match"
 
 
+local function verify_rsa(public_key, signature, signing_string, md_alg)
+  local pub, err = openssl_pkey.new(public_key)
+  if not pub then
+    kong.log.err("failed to create public key : ", err)
+    return false
+  end
+
+  local verified, err = pub:verify(signature, signing_string, md_alg)
+  if not err then
+    return verified
+  else
+    kong.log.err("failed to verify signature : ", err)
+    return false
+  end
+end
+
+
+local rsa = {
+  ["rsa-sha256"] = function(public_key, signature, signing_string)
+    return verify_rsa(public_key, signature, signing_string, "sha256")
+  end,
+  ["rsa-sha512"] = function(public_key, signature, signing_string)
+    return verify_rsa(public_key, signature, signing_string, "sha512")
+  end,
+}
+
+
 local hmac = {
-  ["hmac-sha1"] = function(secret, data)
-    return hmac_sha1(secret, data)
+  ["hmac-sha1"] = function(secret, signature, signing_string)
+    return signature == hmac_sha1(secret, signing_string)
   end,
-  ["hmac-sha256"] = function(secret, data)
-    return openssl_hmac.new(secret, "sha256"):final(data)
+  ["hmac-sha256"] = function(secret, signature, signing_string)
+    return signature == openssl_hmac.new(secret, "sha256"):final(signing_string)
   end,
-  ["hmac-sha384"] = function(secret, data)
-    return openssl_hmac.new(secret, "sha384"):final(data)
+  ["hmac-sha384"] = function(secret, signature, signing_string)
+    return signature == openssl_hmac.new(secret, "sha384"):final(signing_string)
   end,
-  ["hmac-sha512"] = function(secret, data)
-    return openssl_hmac.new(secret, "sha512"):final(data)
+  ["hmac-sha512"] = function(secret, signature, signing_string)
+    return signature == openssl_hmac.new(secret, "sha512"):final(signing_string)
   end,
 }
 
@@ -97,7 +125,7 @@ local function retrieve_hmac_fields(authorization_header)
   -- parse the header to retrieve hamc parameters
   if authorization_header then
     local iterator, iter_err = re_gmatch(authorization_header,
-                                         "\\s*[Hh]mac\\s*username=\"(.+)\"," ..
+                                         "(\\s*[Hh]mac)?\\s*username=\"(.+)\"," ..
                                          "\\s*algorithm=\"(.+)\",\\s*header" ..
                                          "s=\"(.+)\",\\s*signature=\"(.+)\"",
                                          "jo")
@@ -113,10 +141,10 @@ local function retrieve_hmac_fields(authorization_header)
     end
 
     if m and #m >= 4 then
-      hmac_params.username = m[1]
-      hmac_params.algorithm = m[2]
-      hmac_params.hmac_headers = utils.split(m[3], " ")
-      hmac_params.signature = m[4]
+      hmac_params.username = m[2]
+      hmac_params.algorithm = m[3]
+      hmac_params.hmac_headers = utils.split(m[4], " ")
+      hmac_params.signature = m[5]
     end
   end
 
@@ -126,7 +154,7 @@ end
 
 -- plugin assumes the request parameters being used for creating
 -- signature by client are not changed by core or any other plugin
-local function create_hash(request_uri, hmac_params)
+local function generate_signing_string(request_uri, hmac_params)
   local signing_string = ""
   local hmac_headers = hmac_params.hmac_headers
 
@@ -161,14 +189,18 @@ local function create_hash(request_uri, hmac_params)
     end
   end
 
-  return hmac[hmac_params.algorithm](hmac_params.secret, signing_string)
+  return signing_string
 end
 
 
 local function validate_signature(hmac_params)
-  local signature_1 = create_hash(kong_request.get_path_with_query(), hmac_params)
-  local signature_2 = decode_base64(hmac_params.signature)
-  return signature_1 == signature_2
+  local signature = decode_base64(hmac_params.signature)
+  local signing_string = generate_signing_string(kong_request.get_path_with_query(), hmac_params)
+  if hmac_params.algorithm:sub(1, 4) == "rsa-" then
+    return rsa[hmac_params.algorithm](hmac_params.public_key, signature, signing_string)
+  else
+    return hmac[hmac_params.algorithm](hmac_params.secret, signature, signing_string)
+  end
 end
 
 
@@ -326,6 +358,7 @@ local function do_authentication(conf)
   end
 
   hmac_params.secret = credential.secret
+  hmac_params.public_key = credential.public_key
 
   if not validate_signature(hmac_params) then
     return false, { status = 401, message = SIGNATURE_NOT_SAME }

--- a/kong/plugins/hmac-auth/daos.lua
+++ b/kong/plugins/hmac-auth/daos.lua
@@ -17,6 +17,7 @@ return {
       { consumer = { type = "foreign", reference = "consumers", required = true, on_delete = "cascade", }, },
       { username = { type = "string", required = true, unique = true }, },
       { secret = { type = "string", auto = true }, },
+      { public_key = { type = "string" }, },
       { tags   = typedefs.tags },
     },
   },

--- a/kong/plugins/hmac-auth/migrations/004_add_public_key.lua
+++ b/kong/plugins/hmac-auth/migrations/004_add_public_key.lua
@@ -1,0 +1,18 @@
+return {
+  postgres = {
+    up = [[
+      DO $$
+      BEGIN
+        ALTER TABLE IF EXISTS ONLY hmacauth_credentials ADD public_key TEXT;
+      EXCEPTION WHEN DUPLICATE_COLUMN THEN
+        -- Do nothing, accept existing state
+      END$$;
+
+    ]],
+  },
+  cassandra = {
+    up = [[
+      ALTER TABLE hmacauth_credentials ADD public_key text;
+    ]],
+  }
+}

--- a/kong/plugins/hmac-auth/migrations/init.lua
+++ b/kong/plugins/hmac-auth/migrations/init.lua
@@ -2,4 +2,5 @@ return {
   "000_base_hmac_auth",
   "002_130_to_140",
   "003_200_to_210",
+  "004_add_public_key",
 }

--- a/kong/plugins/hmac-auth/schema.lua
+++ b/kong/plugins/hmac-auth/schema.lua
@@ -6,6 +6,8 @@ local ALGORITHMS = {
   "hmac-sha256",
   "hmac-sha384",
   "hmac-sha512",
+  "rsa-sha256",
+  "rsa-sha512",
 }
 
 

--- a/spec/03-plugins/19-hmac-auth/01-schema_spec.lua
+++ b/spec/03-plugins/19-hmac-auth/01-schema_spec.lua
@@ -20,7 +20,7 @@ describe("Plugin: hmac-auth (schema)", function()
   it("errors with wrong algorithm", function()
     local ok, err = v({ algorithms = { "sha1024" } }, schema_def)
     assert.is_falsy(ok)
-    assert.equal("expected one of: hmac-sha1, hmac-sha256, hmac-sha384, hmac-sha512",
+    assert.equal("expected one of: hmac-sha1, hmac-sha256, hmac-sha384, hmac-sha512, rsa-sha256, rsa-sha512",
                  err.config.algorithms[1])
   end)
 end)

--- a/spec/03-plugins/19-hmac-auth/03-access_spec.lua
+++ b/spec/03-plugins/19-hmac-auth/03-access_spec.lua
@@ -1,5 +1,6 @@
 local cjson = require "cjson"
 local openssl_hmac = require "resty.openssl.hmac"
+local openssl_pkey = require "resty.openssl.pkey"
 local helpers = require "spec.helpers"
 local utils = require "kong.tools.utils"
 local resty_sha256 = require "resty.sha256"
@@ -20,6 +21,7 @@ for _, strategy in helpers.each_strategy() do
     local proxy_client
     local consumer
     local credential
+    local rsa_key_pair
 
     lazy_setup(function()
       local bp = helpers.get_db_utils(strategy, {
@@ -68,6 +70,19 @@ for _, strategy in helpers.each_strategy() do
         username = "bob",
         secret   = "secret",
         consumer = { id = consumer.id },
+      }
+
+      rsa_key_pair = openssl_pkey.new()
+
+      local consumer2 = bp.consumers:insert {
+        username  = "alice",
+        custom_id = "123456"
+      }
+
+      bp.hmacauth_credentials:insert {
+        username   = "alice",
+        public_key = rsa_key_pair:to_PEM("public"),
+        consumer   = { id = consumer2.id },
       }
 
       local anonymous_user = bp.consumers:insert {
@@ -152,6 +167,19 @@ for _, strategy in helpers.each_strategy() do
         config   = {
           anonymous  = anonymous_user.username,
           clock_skew = 3000
+        }
+      }
+
+      local route8 = bp.routes:insert {
+        hosts = { "hmacauth8.com" },
+      }
+
+      bp.plugins:insert {
+        name     = "hmac-auth",
+        route = { id = route8.id },
+        config   = {
+          enforce_headers = {"date"},
+          algorithms      = {"rsa-sha256", "rsa-sha512"},
         }
       }
 
@@ -1689,6 +1717,66 @@ for _, strategy in helpers.each_strategy() do
             date                    = date,
             ["proxy-authorization"] = hmacAuth,
             ["content-md5"]         = "md5",
+          },
+        })
+        assert.res_status(200, res)
+      end)
+
+      it("should not pass with GET with rsa-sha256 when signing with wrong key", function()
+        local date = os.date("!%a, %d %b %Y %H:%M:%S GMT")
+        local signature = openssl_pkey.new():sign("date: " .. date .. "\nGET /request HTTP/1.1", "sha256")
+        local encodedSignature = ngx.encode_base64(signature)
+        local hmacAuth = [[username="alice",  algorithm="rsa-sha256", ]]
+          .. [[headers="date request-line", signature="]]
+          .. encodedSignature .. [["]]
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/request",
+          body    = {},
+          headers = {
+            ["HOST"]                = "hmacauth8.com",
+            date                    = date,
+            ["proxy-authorization"] = hmacAuth,
+          },
+        })
+        assert.res_status(401, res)
+      end)
+
+      it("should pass with GET with rsa-sha256", function()
+        local date = os.date("!%a, %d %b %Y %H:%M:%S GMT")
+        local signature = rsa_key_pair:sign("date: " .. date .. "\nGET /request HTTP/1.1", "sha256")
+        local encodedSignature = ngx.encode_base64(signature)
+        local hmacAuth = [[username="alice",  algorithm="rsa-sha256", ]]
+                .. [[headers="date request-line", signature="]]
+                .. encodedSignature .. [["]]
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/request",
+          body    = {},
+          headers = {
+            ["HOST"]                = "hmacauth8.com",
+            date                    = date,
+            ["proxy-authorization"] = hmacAuth,
+          },
+        })
+        assert.res_status(200, res)
+      end)
+
+      it("should pass with GET with rsa-sha512", function()
+        local date = os.date("!%a, %d %b %Y %H:%M:%S GMT")
+        local signature = rsa_key_pair:sign("date: " .. date .. "\nGET /request HTTP/1.1", "sha512")
+        local encodedSignature = ngx.encode_base64(signature)
+        local hmacAuth = [[username="alice",  algorithm="rsa-sha512", ]]
+                .. [[headers="date request-line", signature="]]
+                .. encodedSignature .. [["]]
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/request",
+          body    = {},
+          headers = {
+            ["HOST"]                = "hmacauth8.com",
+            date                    = date,
+            ["proxy-authorization"] = hmacAuth,
           },
         })
         assert.res_status(200, res)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

The hmac-auth plugin allow authentication with HMAC signatures based on the [draft-cavage-http-signatures](https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12) draft.
This commit aims to add support for RSA signatures as described in the draft, providing a stronger layer
of security via asymmetric encryption.

### Full changelog

* Add possible values to `algorithms` (`rsa-sha256` and `rsa-sha512`)
* Add a new field to this plugin's credential (`public_key`)
* Add tests showing failed and succeeded authentications using `rsa` algorithms

### How to test

First, create a RSA key pair : 
```
openssl genrsa -out private_key.pem
openssl rsa -in private_key.pem -pubout -out public_key.pem
```

Then, enable the plugin, create a consumer and a corresponding credential with the public key :
```
curl -X POST http://localhost:8001/plugins \
    --form "name=hmac-auth"  \
    --form "config.algorithms=rsa-sha256" \
    --form "config.algorithms=rsa-sha512"

curl -X POST http://localhost:8001/consumers \
    --form "username=alice"

curl -X POST http://localhost:8001/consumers/alice/hmac-auth \
    --form "username=alice" \
    --form "public_key=@public_key.pem"
```

Finally, make a signed request :
```
export DATE="date: $(echo -n $(TZ=GMT date '+%a, %d %b %Y %T %Z'))"
export SIGNATURE=$(printf %s "${DATE}" | openssl dgst -binary -sha512 -sign private_key.pem | openssl base64 -A)
export AUTHORIZATION='authorization: username="alice", algorithm="rsa-sha512", headers="date", signature="'${SIGNATURE}'"'

curl -X GET http://localhost:8000 \
    --header "${DATE}" \
    --header "${AUTHORIZATION}"
```

### Possible improvements

Here are some improvements that we might want to implement after this one :
* Check public key validity during credential creation/update
* Rebrand the plugin to `HTTP Signature`
* Use `Signature` header to provide the signature (or let it be configurable)
* Implement `keyId` from the draft
