### PR TITLE
feat(hmac-auth) enforce unique consumer

### DIFF
--- a/kong/plugins/hmac-auth/schema.lua
+++ b/kong/plugins/hmac-auth/schema.lua
@@ -20,6 +20,7 @@ return {
           { hide_credentials = { type = "boolean", required = true, default = false }, },
           { clock_skew = { type = "number", default = 300, gt = 0 }, },
           { anonymous = { type = "string" }, },
+          { enforce_unique_consumer = { type = "boolean", required = true, default = false }, },
           { validate_request_body = { type = "boolean", required = true, default = false }, },
           { enforce_headers = {
               type = "array",


### PR DESCRIPTION
### Summary

There is currently no check regarding the consumer if multiple authentications plugins are used with the `AND` method. This PR aims to implement this check.
It currently is only implemented on `hmac-auth` plugin as an example.

### Full changelog

* Add `enforce_unique_consumer` flag to plugin configuration
* Check consumer uniqueness when the flag is set
* Add tests showing succeeded and failed authentications using the flag 

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #8541