### PR TITLE
fix(plugins) ensure go plugins on protobuf restart instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,9 @@
   [#8567](https://github.com/Kong/kong/pull/8567)
 - External plugins now handle returned JSON with null member correctly.
   [#8610](https://github.com/Kong/kong/pull/8610)
+- Fix issue where the Go plugin server instance would not be updated after
+a restart (e.g., upon a plugin server crash).
+  [#8547](https://github.com/Kong/kong/pull/8547)
 
 #### Plugins
 

--- a/kong/runloop/plugin_servers/pb_rpc.lua
+++ b/kong/runloop/plugin_servers/pb_rpc.lua
@@ -393,10 +393,11 @@ function Rpc:handle_event(plugin_name, conf, phase)
     instance_id = instance_id,
     event_name = phase,
   }, true)
-  if not res then
+  if not res or res == "" then
     kong.log.err(err)
+    if    string.match(err:lower(), "no plugin instance")
+       or string.match(err:lower(), "closed")  then
 
-    if string.match(err:lower(), "no plugin instance") then
       self.reset_instance(plugin_name, conf)
       return self:handle_event(plugin_name, conf, phase)
     end


### PR DESCRIPTION
Fix issue where the Go plugin instance would not get updated after
a plugin server restart.

Fixes #8293
