### PR TITLE
fix(db) make dao:cache_key to fallback to primary_key if nothing from cache_key was found

### DIFF
--- a/spec/01-unit/01-db/04-dao_spec.lua
+++ b/spec/01-unit/01-db/04-dao_spec.lua
@@ -459,7 +459,7 @@ describe("DAO", function()
   describe("delete", function()
 
     lazy_setup(function()
- 
+
       local kong_global = require "kong.global"
       _G.kong = kong_global.new()
 
@@ -496,7 +496,7 @@ describe("DAO", function()
         end
       }
       local parent_dao = DAO.new(mock_db, parent_schema, parent_strategy, errors)
-      
+
       local _, err = parent_dao:delete({ a = 42 })
       assert.falsy(err)
     end)
@@ -522,5 +522,15 @@ describe("DAO", function()
       local cache_key = dao:cache_key(data)
       assert.equals("Foo:foo:::::", cache_key)
     end)
+
+    it("fallbacks to primary_key if nothing in cache_key is found", function()
+      local schema = assert(Schema.new(optional_cache_key_fields_schema))
+      local dao = DAO.new(mock_db, schema, {}, errors)
+
+      local data = { a = 42 }
+      local cache_key = dao:cache_key(data)
+      assert.equals("Foo:42:::::", cache_key)
+    end)
+
   end)
 end)


### PR DESCRIPTION
### Summary

This makes the `cache_key` function more robust. For example this code may be quite common:

```lua
local route = kong.db.routes:select_by_name("my-route")
-- {
--   id = ...,
--   name = "my-route",
--   ...
--   service = {
--     id = ...
--   }
-- }

local cache_key = kong.db.services:cache_key(route.service)
```

Now if `service` schema has `cache_key = { "name" }` (it does not, but just as an example) you can see that the `local cache_key` will then be same for all the `services` (no matter if they are pointing to different service by id), as the `route.service` is not expanded by default, and it only contains the primary key, in this case `id`.

The change in this commit is that it will now actually fallback to `primary_key = { "id" }` in case it cannot find anything by the `cache_key`. As it can be seen in code above, it is quite easy to make this mistake, and not see the mistake. User could fix their code by calling:

```lua
local cache_key = kong.db.services:cache_key(route.service.id)
```

instead of:

```lua
local cache_key = kong.db.services:cache_key(route.service)
```

But as this can potentially be dangerous if forgotten, I think it is worth to fallback to `primary_key` by default on such case.