### PR TITLE
fix(hmac-auth) remove deprecated signatures

### DIFF
--- a/kong/plugins/hmac-auth/access.lua
+++ b/kong/plugins/hmac-auth/access.lua
@@ -168,13 +168,7 @@ end
 local function validate_signature(hmac_params)
   local signature_1 = create_hash(kong_request.get_path_with_query(), hmac_params)
   local signature_2 = decode_base64(hmac_params.signature)
-  if signature_1 == signature_2 then
-    return true
-  end
-
-  -- DEPRECATED BY: https://github.com/Kong/kong/pull/3339
-  local signature_1_deprecated = create_hash(ngx.var.uri, hmac_params)
-  return signature_1_deprecated == signature_2
+  return signature_1 == signature_2
 end
 
 

--- a/spec/03-plugins/19-hmac-auth/03-access_spec.lua
+++ b/spec/03-plugins/19-hmac-auth/03-access_spec.lua
@@ -1335,11 +1335,8 @@ for _, strategy in helpers.each_strategy() do
         assert.res_status(200, res)
       end)
 
-      it("should pass with GET with request-line having query param but signed without query param", function()
-        -- hmac-auth needs to validate signatures created both with and without
-        -- query params for a supported deprecation period.
-        --
-        -- Regression for https://github.com/Kong/kong/issues/3672
+      it("should fail with GET with request-line having query param but signed without query param", function()
+        -- hmac-auth signature must include the same query param in request-line: https://github.com/Kong/kong/pull/3339
         local date = os.date("!%a, %d %b %Y %H:%M:%S GMT")
         local encodedSignature = ngx.encode_base64(
           hmac_sha1_binary("secret", "date: "
@@ -1358,7 +1355,7 @@ for _, strategy in helpers.each_strategy() do
             ["content-md5"]         = "md5",
           },
         })
-        assert.res_status(200, res)
+        assert.res_status(401, res)
 
         encodedSignature = ngx.encode_base64(
           hmac_sha1_binary("secret", "date: "
@@ -1377,7 +1374,7 @@ for _, strategy in helpers.each_strategy() do
             ["content-md5"]         = "md5",
           },
         })
-        assert.res_status(200, res)
+        assert.res_status(401, res)
       end)
 
       it("should pass with GET with request-line having query param", function()


### PR DESCRIPTION
### Changelog

Remove deprecated signatures from hmac-auth plugin

FT-2557
