### PR TITLE
fix(serverless) remove `config.functions` from schema

### DIFF
--- a/kong/plugins/pre-function/_handler.lua
+++ b/kong/plugins/pre-function/_handler.lua
@@ -65,8 +65,7 @@ local config_cache do
 
 
   local phases = { "certificate", "rewrite", "access",
-                   "header_filter", "body_filter", "log",
-                   "functions" } -- <-- this one being legacy
+                   "header_filter", "body_filter", "log" }
 
 
   config_cache = setmetatable({}, {
@@ -76,17 +75,6 @@ local config_cache do
       local runtime_funcs = {}
       for _, phase in ipairs(phases) do
         local func = compile_phase_array(config[phase])
-
-        if phase == "functions" then
-          if func == no_op then
-            func = nil -- do not set a "functions" key, since we won't run it anyway
-          else
-            -- functions, which is legacy is specified, so inject as "access". The
-            -- schema already prevents "access" and "functions" to co-exist, so
-            -- this should be safe.
-            phase = "access"
-          end
-        end
 
         runtime_funcs[phase] = func
       end

--- a/kong/plugins/pre-function/_schema.lua
+++ b/kong/plugins/pre-function/_schema.lua
@@ -49,7 +49,6 @@ return function(plugin_name)
     },
     entity_checks = {
       { at_least_one_of = {
-        "config.functions",
         "config.certificate",
         "config.rewrite",
         "config.access",

--- a/kong/plugins/pre-function/_schema.lua
+++ b/kong/plugins/pre-function/_schema.lua
@@ -6,8 +6,6 @@ return function(plugin_name)
 
   local loadstring = loadstring
 
-  local functions_deprecated = "[%s] 'config.functions' will be deprecated in favour of 'config.access'"
-
 
   local function validate_function(fun)
     local _, err = loadstring(fun)
@@ -38,16 +36,6 @@ return function(plugin_name)
         config = {
           type = "record",
           fields = {
-            -- old interface. functions are always on access phase
-            { functions = phase_functions {
-              custom_validator = function(v)
-                if #v > 0 then
-                  kong.log.warn(functions_deprecated:format(plugin_name))
-                end
-
-                return true
-              end,
-            } },
             -- new interface
             { certificate = phase_functions },
             { rewrite = phase_functions },
@@ -60,10 +48,6 @@ return function(plugin_name)
       },
     },
     entity_checks = {
-      { mutually_exclusive_sets = {
-        set1 = { "config.functions" },
-        set2 = { "config.access" },
-      } },
       { at_least_one_of = {
         "config.functions",
         "config.certificate",

--- a/spec/03-plugins/33-serverless-functions/01-schema_spec.lua
+++ b/spec/03-plugins/33-serverless-functions/01-schema_spec.lua
@@ -9,21 +9,13 @@ local mock_fn_invalid_return = 'return "hello-world"'
 
 for _, plugin_name in ipairs({ "pre-function", "post-function" }) do
 
-  for _, method in ipairs({ "functions", "phase=functions"}) do
+  for _, method in ipairs({ "phase=functions" }) do
     local function get_conf(functions)
-      if method == "functions" then
-        return { functions = functions }
-      elseif method == "phase=functions" then
-        return { access = functions }
-      end
+      return { access = functions }
     end
 
     local function get_functions_from_error(err)
-      if method == "functions" then
-        return err.config.functions
-      elseif method == "phase=functions" then
-        return err.config.access
-      end
+      return err.config.access
     end
 
 

--- a/spec/03-plugins/33-serverless-functions/02-access_spec.lua
+++ b/spec/03-plugins/33-serverless-functions/02-access_spec.lua
@@ -69,13 +69,9 @@ end)
 
 for _, plugin_name in ipairs({ "pre-function", "post-function" }) do
 
-  for _, method in ipairs({ "functions", "phase=functions"}) do
+  for _, method in ipairs({ "phase=functions" }) do
     local function get_conf(functions)
-      if method == "functions" then
-        return { functions = functions }
-      elseif method == "phase=functions" then
-        return { access = functions }
-      end
+      return { access = functions }
     end
 
     describe("Plugin: " .. plugin_name .. string.format(" (by %s)", method) .. " access", function()

--- a/spec/03-plugins/33-serverless-functions/03-dbless_spec.lua
+++ b/spec/03-plugins/33-serverless-functions/03-dbless_spec.lua
@@ -46,7 +46,7 @@ for _, plugin_name in ipairs({ "pre-function", "post-function" }) do
               plugins:
               - name: "pre-function"
                 config:
-                  functions:
+                  access:
                   - | 
                       kong.log.err("foo")
                       kong.response.exit(418)

--- a/spec/03-plugins/36-request-transformer/02-access_spec.lua
+++ b/spec/03-plugins/36-request-transformer/02-access_spec.lua
@@ -371,7 +371,7 @@ describe("Plugin: request-transformer(access) [#" .. strategy .. "]", function()
         route = { id = route21.id },
         name = "pre-function",
         config = {
-          functions = {
+          access = {
             [[
               kong.ctx.shared.my_version = "1.2.3"
             ]]


### PR DESCRIPTION
### Changelog

remove `config.functions` from serverless plugin schema

migrations for replace `conifig.functions` with `config.access` might needed.

FT-2557