### PR TITLE
fix(runloop) reschedule rebuild timers after running them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,9 +77,12 @@
 
 #### Core
 
-- The schema validator now correctly 
-converts `null` from declarative configurations to `nil`
-[#8483](https://github.com/Kong/kong/pull/8483).
+- The schema validator now correctly converts `null` from declarative
+  configurations to `nil`. [#8483](https://github.com/Kong/kong/pull/8483)
+- Only reschedule router and plugin iterator timers after finishing previous
+  execution, avoiding unnecessary concurrent executions.
+  [#8567](https://github.com/Kong/kong/pull/8567)
+
 
 ## [2.8.0]
 

--- a/kong/runloop/plugins_iterator.lua
+++ b/kong/runloop/plugins_iterator.lua
@@ -466,7 +466,10 @@ function PluginsIterator.new(version)
       end
 
       if new_version ~= version then
-        return nil, "plugins iterator was changed while rebuilding it"
+        -- the plugins iterator rebuild is being done by a different process at
+        -- the same time, stop here and let the other one go for it
+        kong.log.info("plugins iterator was changed while rebuilding it")
+        return
       end
     end
 


### PR DESCRIPTION
### Summary

Router and plugin iterator rebuild timers were scheduled using `ngx.timer.every`. If the rebuild processes took longer than `worker_state_update_frequency` to execute, they would start again while the previous one was still running.

### Full changelog

* Change `ngx.timer.every` calls to `ngx.timer.at`.
* Previously returned error `"plugins iterator was changed while rebuilding it"` is now logged as an info message.
* No tests were added, the behavior is the same as before.

### Issue reference

There were multiple reports of `"plugins iterator was changed while rebuilding it"` logged as error.

Fix #8525 

FTI-3239