### PR TITLE
add additional http status metrics to distinguish b/w Kong and upstream

### DIFF
--- a/kong/plugins/prometheus/handler.lua
+++ b/kong/plugins/prometheus/handler.lua
@@ -23,7 +23,7 @@ function PrometheusHandler.log(self, conf)
     serialized.consumer = message.consumer.username
   end
 
-  prometheus.log(message, serialized)
+  prometheus.log(message, serialized, conf.kong_http_status_with_target)
 end
 
 

--- a/kong/plugins/prometheus/schema.lua
+++ b/kong/plugins/prometheus/schema.lua
@@ -14,6 +14,7 @@ return {
         type = "record",
         fields = {
           { per_consumer = { type = "boolean", default = false }, },
+          { kong_http_status_with_target = { type = "boolean", default = false }, },
         },
         custom_validator = validate_shared_dict,
     }, },


### PR DESCRIPTION
make target_label http metrics driven from config

update config variable name to kong_http_status_with_target

update default value of kong_http_status_with_target

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Full changelog

* [Implement ...]
* [Add related tests]
* ...

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
