### PR TITLE
fix(env) localize environ pointer and early return on nil

### DIFF
--- a/kong/cmd/utils/env.lua
+++ b/kong/cmd/utils/env.lua
@@ -12,14 +12,12 @@ ffi.cdef [[
 ]]
 
 
-local environ = ffi.C.environ
-
-
 local function read_all()
   log.debug("reading environment variables")
 
   local env = {}
 
+  local environ = ffi.C.environ
   if not environ then
     log.warn("could not access **environ")
     return env

--- a/kong/vaults/env/init.lua
+++ b/kong/vaults/env/init.lua
@@ -15,6 +15,7 @@ local function init()
   local e = ffi.C.environ
   if not e then
     kong.log.warn("could not access environment variables")
+    return
   end
 
   local find = string.find


### PR DESCRIPTION
ffi.C.environ's address can change during realloc, this patch
avoid globalize it to prevent pointing to wrong memory address

cc @aboudreault 