### PR TITLE
fix(core) use admin_error_log for cluster listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,11 @@ converts `null` from declarative configurations to `nil`
 - **hmac-auth**: Removed deprecated signature format using `ngx.var.uri`
 [#8558](https://github.com/Kong/kong/pull/8558)
 
+#### Clustering
+
+- The cluster listener now uses the value of `admin_error_log` for its log file
+  instead of `proxy_error_log` [8583](https://github.com/Kong/kong/pull/8583)
+
 ## [2.8.0]
 
 ### Deprecations

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -431,6 +431,7 @@ server {
 > end
 
     access_log ${{ADMIN_ACCESS_LOG}};
+    error_log  ${{ADMIN_ERROR_LOG}} ${{LOG_LEVEL}};
 
 > if cluster_mtls == "shared" then
     ssl_verify_client   optional_no_ca;

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -451,6 +451,7 @@ http {
 > end
 
         access_log ${{ADMIN_ACCESS_LOG}};
+        error_log  ${{ADMIN_ERROR_LOG}} ${{LOG_LEVEL}};
 
         ssl_verify_client   optional_no_ca;
         ssl_certificate     ${{CLUSTER_CERT}};


### PR DESCRIPTION
This `server {}` block previously had no `error_log` directive, so it was inheriting the `proxy_error_log` settings from the `http {}` scope. Logging to the same place as `admin_error_log` is more sensible. We might want to consider introducing a new `cluster_error_log` config option at some point to give users more flexibility (using `admin_error_log` as a fallback), but to me this seems fine for now.