### PR TITLE
fix(luarocks): luarocks install requires luasec to be installed

### DIFF
--- a/kong-2.8.0-0.rockspec
+++ b/kong-2.8.0-0.rockspec
@@ -13,6 +13,7 @@ description = {
 }
 dependencies = {
   "inspect == 3.1.2",
+  "luasec == 1.0.2",
   "luasocket == 3.0-rc1",
   "penlight == 1.12.0",
   "lua-resty-http == 0.16.1",


### PR DESCRIPTION
per the kong-build-tools e2e tests `luarocks install` requires luasec