### PR TITLE
chore(deps) bump inspect from 3.1.2 to 3.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@
   [#8544](https://github.com/Kong/kong/pull/8544)
 - Bumped resty.openssl from 0.8.5 to 0.8.7
   [#8592](https://github.com/Kong/kong/pull/8592)
+- Bumped inspect from 3.1.2 to 3.1.3
+  [#8589](https://github.com/Kong/kong/pull/8589)
 
 ### Fixes
 

--- a/kong-2.8.0-0.rockspec
+++ b/kong-2.8.0-0.rockspec
@@ -12,7 +12,7 @@ description = {
   license = "Apache 2.0"
 }
 dependencies = {
-  "inspect == 3.1.2",
+  "inspect == 3.1.3",
   "luasec == 1.0.2",
   "luasocket == 3.0-rc1",
   "penlight == 1.12.0",


### PR DESCRIPTION
### Summary

* A minimal performance test was introduced. Several refactors were introduced, which seem to make inspect.lua faster now.
* inspect.lua was rewritten using Teal