### PR TITLE
chore(deps) bump luasocket from 3.0-rc1 to 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,12 +90,14 @@
   [#8592](https://github.com/Kong/kong/pull/8592)
 - Bumped inspect from 3.1.2 to 3.1.3
   [#8589](https://github.com/Kong/kong/pull/8589)
+- Bumped LuaSocket from 3.0-rc1 to 3.0.0
+  [#8590](https://github.com/Kong/kong/pull/8590)
 
 ### Additions
 
 #### Plugins
 
-- **Zipkin**: add support for including HTTP path in span name 
+- **Zipkin**: add support for including HTTP path in span name
   through configuration property `http_span_name`.
   [#8150](https://github.com/Kong/kong/pull/8150)
 

--- a/kong-2.8.0-0.rockspec
+++ b/kong-2.8.0-0.rockspec
@@ -14,7 +14,7 @@ description = {
 dependencies = {
   "inspect == 3.1.3",
   "luasec == 1.0.2",
-  "luasocket == 3.0-rc1",
+  "luasocket == 3.0.0",
   "penlight == 1.12.0",
   "lua-resty-http == 0.16.1",
   "lua-resty-jit-uuid == 0.0.7",

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -1174,7 +1174,8 @@ local function http_server(port, ...)
     function(port)
       local socket = require "socket"
       local server = assert(socket.tcp())
-      assert(server:setoption('reuseaddr', true))
+      --TODO: Commented out, see https://github.com/lunarmodules/luasocket/issues/371
+      --assert(server:setoption('reuseaddr', true))
       assert(server:bind("*", port))
       assert(server:listen())
       local client = assert(server:accept())
@@ -1231,7 +1232,8 @@ local function udp_server(port, n, timeout)
       local socket = require "socket"
       local server = assert(socket.udp())
       server:settimeout(timeout or 360)
-      server:setoption("reuseaddr", true)
+      --TODO: Commented out, see https://github.com/lunarmodules/luasocket/issues/371
+      --assert(server:setoption('reuseaddr', true))
       server:setsockname("127.0.0.1", port)
       local err
       local data = {}


### PR DESCRIPTION
### Summary

The last time LuaSocket had a stable release tag was 14 years ago when 2.0.2 was tagged.
A v3 release candidate was tagged 9 years ago.
Since then it has been downloaded over 3 million times.
Additionally the Git repository regularly gets several hundred clones a day.
But 9 years is a long time and even the release candidate has grown a bit long in the tooth.
Many Linux distros have packaged the current Git HEAD or some specific tested point as dated or otherwise labeled releases.
256 commits later and having been migrated to the @lunarmodules org namespace on GitHub, please welcome v3.

This release is a "safe-harbor" tag that represents a minimal amount of changes to get a release tagged.
Beyond some CI tooling, very little code has changed since migration to @lunarmodules ([5b18e47..e47d98f](https://github.com/lunarmodules/luasocket/compare/5b18e47..e47d98f?w=1)):

* Lua 5.4.3+ support – @pkulchenko, @Zash
* Cleanup minor issues to get a code linter to pass – @Tieske, @jyoui, @alerque
* Update Visual Studio build rules for Lua 5.1 – @ewestbrook
* Set http transfer-encoding even without content-length – @tokenrove

Prior to migration to @lunarmodules ([v3.0-rc1..5b18e47](https://github.com/lunarmodules/luasocket/compare/v3.0-rc1..5b18e47?w=1)) many things happened of which the author of this changelog is not fully apprised.
Your best bet if it affects your project somehow is to read the commit log & diffs yourself.
