### PR TITLE
chore(deps) bump lua-protobuf from 0.3.3 to 0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,12 +90,14 @@
   [#8592](https://github.com/Kong/kong/pull/8592)
 - Bumped inspect from 3.1.2 to 3.1.3
   [#8589](https://github.com/Kong/kong/pull/8589)
+- Bumped lua-protobuf from 0.3.3 to 0.3.4
+  [#8591](https://github.com/Kong/kong/pull/8591)
 
 ### Additions
 
 #### Plugins
 
-- **Zipkin**: add support for including HTTP path in span name 
+- **Zipkin**: add support for including HTTP path in span name
   through configuration property `http_span_name`.
   [#8150](https://github.com/Kong/kong/pull/8150)
 

--- a/kong-2.8.0-0.rockspec
+++ b/kong-2.8.0-0.rockspec
@@ -31,7 +31,7 @@ dependencies = {
   "lua_pack == 2.0.0",
   "binaryheap >= 0.4",
   "luaxxhash >= 1.0",
-  "lua-protobuf == 0.3.3",
+  "lua-protobuf == 0.3.4",
   "lua-resty-worker-events == 1.0.0",
   "lua-resty-healthcheck == 1.5.0",
   "lua-resty-mlcache == 2.5.0",


### PR DESCRIPTION
### Summary

- fix memory leak in pb.load
- fix bugs in "protoc.lua"
- fix memory usage in messages contains oneof
- code improved