### PR TITLE
chore(deps) bump resty.openssl from 0.8.6 to 0.8.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,8 +70,8 @@
   [#8429](https://github.com/Kong/kong/pull/8429)
 - OpenSSL bumped to 1.1.1n
   [#8544](https://github.com/Kong/kong/pull/8544)
-- Bumped resty.openssl from 0.8.5 to 0.8.6
-  [#8545](https://github.com/Kong/kong/pull/8545)
+- Bumped resty.openssl from 0.8.5 to 0.8.7
+  [#8592](https://github.com/Kong/kong/pull/8592)
 
 ### Fixes
 

--- a/kong-2.8.0-0.rockspec
+++ b/kong-2.8.0-0.rockspec
@@ -36,7 +36,7 @@ dependencies = {
   "lua-resty-healthcheck == 1.5.0",
   "lua-resty-mlcache == 2.5.0",
   "lua-messagepack == 0.5.2",
-  "lua-resty-openssl == 0.8.6",
+  "lua-resty-openssl == 0.8.7",
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6.1",
   "lua-resty-acme == 0.7.2",


### PR DESCRIPTION
### Summary

#### Features

- **x509.crl:** add functions to find and inspect revoked list in CRL [37c1661](https://github.com/fffonion/lua-resty-openssl/commit/37c1661fbebebad3b804f602f631e4ba65b80e07)