### PR TITLE
fix(api) targets upserts using PUT HTTP method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,7 +107,7 @@
 
 #### Admin API
 
-- Insert and update operations on target entities are done using the PUT HTTP
+- Insert and update operations on target entities require using the `PUT` HTTP
   method now. [#8596](https://github.com/Kong/kong/pull/8596)
 
 ### Additions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,6 @@
   execution, avoiding unnecessary concurrent executions.
   [#8567](https://github.com/Kong/kong/pull/8567)
 
-
 #### Plugins
 
 - **ACME**: `auth_method` default value is set to `token`
@@ -105,6 +104,11 @@
 
 - The cluster listener now uses the value of `admin_error_log` for its log file
   instead of `proxy_error_log` [8583](https://github.com/Kong/kong/pull/8583)
+
+#### Admin API
+
+- Insert and update operations on target entities are done using the PUT HTTP
+  method now. [#8596](https://github.com/Kong/kong/pull/8596)
 
 ## [2.8.0]
 

--- a/kong/api/routes/upstreams.lua
+++ b/kong/api/routes/upstreams.lua
@@ -10,7 +10,7 @@ local tostring = tostring
 local fmt = string.format
 
 
-local function post_health(self, db, is_healthy)
+local function set_target_health(self, db, is_healthy)
   local upstream, _, err_t = endpoints.select_entity(self, db, db.upstreams.schema)
   if err_t then
     return endpoints.handle_error(err_t)
@@ -180,9 +180,7 @@ return {
                                             kong.db.upstreams.schema,
                                             "upstream",
                                             "page_for_upstream"),
-    POST = function(self, db)
-      -- updating a target using POST is a compatibility with existent API and
-      -- should be deprecated in next major version
+    PUT = function(self, db)
       local entity, _, err_t = update_existent_target(self, db)
       if err_t then
         return endpoints.handle_error(err_t)
@@ -194,7 +192,10 @@ return {
       local create = endpoints.post_collection_endpoint(kong.db.targets.schema,
                         kong.db.upstreams.schema, "upstream")
       return create(self, db)
-    end
+    end,
+    POST = function(self, db)
+      return kong.response.exit(405)
+    end,
   },
 
   ["/upstreams/:upstreams/targets/all"] = {
@@ -232,26 +233,26 @@ return {
   },
 
   ["/upstreams/:upstreams/targets/:targets/healthy"] = {
-    POST = function(self, db)
-      return post_health(self, db, true)
+    PUT = function(self, db)
+      return set_target_health(self, db, true)
     end,
   },
 
   ["/upstreams/:upstreams/targets/:targets/unhealthy"] = {
-    POST = function(self, db)
-      return post_health(self, db, false)
+    PUT = function(self, db)
+      return set_target_health(self, db, false)
     end,
   },
 
   ["/upstreams/:upstreams/targets/:targets/:address/healthy"] = {
-    POST = function(self, db)
-      return post_health(self, db, true)
+    PUT = function(self, db)
+      return set_target_health(self, db, true)
     end,
   },
 
   ["/upstreams/:upstreams/targets/:targets/:address/unhealthy"] = {
-    POST = function(self, db)
-      return post_health(self, db, false)
+    PUT = function(self, db)
+      return set_target_health(self, db, false)
     end,
   },
 

--- a/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
@@ -723,7 +723,7 @@ describe("Admin API: #" .. strategy, function()
 
         -- create the target
         local res = assert(client:send {
-          method = "POST",
+          method = "PUT",
           path = "/upstreams/my-upstream/targets",
           body = {
             target = "127.0.0.1:8000",
@@ -791,7 +791,7 @@ describe("Admin API: #" .. strategy, function()
 
         -- create the target
         local res = assert(client:send {
-          method = "POST",
+          method = "PUT",
           path = "/upstreams/my-upstream/targets",
           body = {
             target = "127.0.0.1:8000",

--- a/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -74,12 +74,12 @@ describe("Admin API #" .. strategy, function()
   end)
 
   describe("/upstreams/{upstream}/targets/", function()
-    describe("POST", function()
+    describe("PUT", function()
       it_content_types("creates a target with defaults", function(content_type)
         return function()
           local upstream = bp.upstreams:insert { slots = 10 }
           local res = assert(client:send {
-            method = "POST",
+            method = "PUT",
             path = "/upstreams/" .. upstream.name .. "/targets/",
             body = {
               target = "mashape.com",
@@ -98,7 +98,7 @@ describe("Admin API #" .. strategy, function()
         return function()
           local upstream = bp.upstreams:insert { slots = 10 }
           local res = assert(client:send {
-            method = "POST",
+            method = "PUT",
             path = "/upstreams/" .. upstream.name .. "/targets/",
             body = {
               target = "mashape.com:123",
@@ -119,7 +119,7 @@ describe("Admin API #" .. strategy, function()
         return function()
           local upstream = bp.upstreams:insert { slots = 10 }
           local res = assert(client:send {
-            method = "POST",
+            method = "PUT",
             path = "/upstreams/" .. upstream.name .. "/targets/",
             body = {
               target = "zero.weight.test:8080",
@@ -146,7 +146,7 @@ describe("Admin API #" .. strategy, function()
         return function()
           local upstream = bp.upstreams:insert { slots = 10 }
           local res = assert(client:send {
-            method = "POST",
+            method = "PUT",
             path = "/upstreams/" .. upstream.name .. "/targets/",
             body = {
               target = "single-target.test:8080",
@@ -163,7 +163,7 @@ describe("Admin API #" .. strategy, function()
           assert.are.equal(1, json.weight)
 
           local res = assert(client:send {
-            method = "POST",
+            method = "PUT",
             path = "/upstreams/" .. upstream.name .. "/targets/",
             body = {
               target = "single-target.test:8080",
@@ -183,7 +183,7 @@ describe("Admin API #" .. strategy, function()
         it("handles malformed JSON body", function()
           local upstream = bp.upstreams:insert { slots = 10 }
           local res = assert(client:request {
-            method = "POST",
+            method = "PUT",
             path = "/upstreams/" .. upstream.name .. "/targets/",
             body = '{"hello": "world"',
             headers = {["Content-Type"] = "application/json"}
@@ -197,7 +197,7 @@ describe("Admin API #" .. strategy, function()
             local upstream = bp.upstreams:insert { slots = 10 }
             -- Missing parameter
             local res = assert(client:send {
-              method = "POST",
+              method = "PUT",
               path = "/upstreams/" .. upstream.name .. "/targets/",
               body = {
                 weight = weight_min,
@@ -211,7 +211,7 @@ describe("Admin API #" .. strategy, function()
 
             -- Invalid target parameter
             res = assert(client:send {
-              method = "POST",
+              method = "PUT",
               path = "/upstreams/" .. upstream.name .. "/targets/",
               body = {
                 target = "some invalid host name",
@@ -225,7 +225,7 @@ describe("Admin API #" .. strategy, function()
 
             -- Invalid weight parameter
             res = assert(client:send {
-              method = "POST",
+              method = "PUT",
               path = "/upstreams/" .. upstream.name .. "/targets/",
               body = {
                 target = "mashape.com",
@@ -240,7 +240,7 @@ describe("Admin API #" .. strategy, function()
           end
         end)
 
-        for _, method in ipairs({"PUT", "PATCH", "DELETE"}) do
+        for _, method in ipairs({"POST", "PATCH", "DELETE"}) do
           it_content_types("returns 405 on " .. method, function(content_type)
             return function()
               local upstream = bp.upstreams:insert { slots = 10 }
@@ -337,7 +337,7 @@ describe("Admin API #" .. strategy, function()
 
         for i = 1, #weights do
           local status, body = client_send({
-            method = "POST",
+            method = "PUT",
             path = "/upstreams/" .. upstream.name .. "/targets",
             headers = {
               ["Content-Type"] = "application/json",
@@ -668,7 +668,7 @@ describe("Admin API #" .. strategy, function()
           local json = assert(cjson.decode(body))
 
           status, body = assert(client_send({
-            method = "POST",
+            method = "PUT",
             path = "/upstreams/" .. upstream.id .. "/targets",
             headers = {["Content-Type"] = "application/json"},
             body = {
@@ -691,7 +691,7 @@ describe("Admin API #" .. strategy, function()
                 local expected = (i >= 3 and j >= 4) and 204 or 404
                 local path = "/upstreams/" .. u .. "/targets/" .. t .. "/" .. e
                 local status = assert(client_send {
-                  method = "POST",
+                  method = "PUT",
                   path = "/upstreams/" .. u .. "/targets/" .. t .. "/" .. e
                 })
                 assert.same(expected, status, "bad status for path " .. path)
@@ -703,7 +703,7 @@ describe("Admin API #" .. strategy, function()
         it("flips the target status from UNHEALTHY to HEALTHY", function()
           local status, body, json
           status, body = assert(client_send {
-            method = "POST",
+            method = "PUT",
             path = target_path .. "/unhealthy"
           })
           assert.same(204, status, body)
@@ -716,7 +716,7 @@ describe("Admin API #" .. strategy, function()
           assert.same(target.target, json.data[1].target)
           assert.same("UNHEALTHY", json.data[1].health)
           status = assert(client_send {
-            method = "POST",
+            method = "PUT",
             path = target_path .. "/healthy"
           })
           assert.same(204, status)
@@ -733,7 +733,7 @@ describe("Admin API #" .. strategy, function()
         it("flips the target status from HEALTHY to UNHEALTHY", function()
           local status, body, json
           status = assert(client_send {
-            method = "POST",
+            method = "PUT",
             path = target_path .. "/healthy"
           })
           assert.same(204, status)
@@ -746,7 +746,7 @@ describe("Admin API #" .. strategy, function()
           assert.same(target.target, json.data[1].target)
           assert.same("HEALTHY", json.data[1].health)
           status = assert(client_send {
-            method = "POST",
+            method = "PUT",
             path = target_path .. "/unhealthy"
           })
           assert.same(204, status)

--- a/spec/02-integration/04-admin_api/15-off_spec.lua
+++ b/spec/02-integration/04-admin_api/15-off_spec.lua
@@ -799,7 +799,7 @@ describe("Admin API #off", function()
       assert.response(res).has.status(201)
 
       local res = assert(client:send {
-        method = "POST",
+        method = "PUT",
         path = "/upstreams/foo/targets/c830b59e-59cc-5392-adfd-b414d13adfc4/10.20.30.40/unhealthy",
       })
 

--- a/spec/02-integration/05-proxy/10-balancer/01-healthchecks_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer/01-healthchecks_spec.lua
@@ -167,7 +167,7 @@ for _, strategy in helpers.each_strategy() do
       assert.equals("UNHEALTHY", health.data[1].data.addresses[1].health)
       assert.equals("UNHEALTHY", health.data[1].data.addresses[2].health)
 
-      local status = bu.post_target_address_health(upstream_id, "multiple-ips.test:80", "127.0.0.2:80", "healthy")
+      local status = bu.put_target_address_health(upstream_id, "multiple-ips.test:80", "127.0.0.2:80", "healthy")
       assert.same(204, status)
 
       health = bu.get_upstream_health(upstream_name)
@@ -180,7 +180,7 @@ for _, strategy in helpers.each_strategy() do
       assert.equals("UNHEALTHY", health.data[1].data.addresses[1].health)
       assert.equals("HEALTHY", health.data[1].data.addresses[2].health)
 
-      local status = bu.post_target_address_health(upstream_id, "multiple-ips.test:80", "127.0.0.2:80", "unhealthy")
+      local status = bu.put_target_address_health(upstream_id, "multiple-ips.test:80", "127.0.0.2:80", "unhealthy")
       assert.same(204, status)
 
       health = bu.get_upstream_health(upstream_name)
@@ -233,7 +233,7 @@ for _, strategy in helpers.each_strategy() do
       assert.equals("UNHEALTHY", health.data[1].data.addresses[1].health)
       assert.equals("UNHEALTHY", health.data[1].data.addresses[2].health)
 
-      local status = bu.post_target_address_health(upstream_id, "multiple-ips.test:80", "127.0.0.2:80", "healthy")
+      local status = bu.put_target_address_health(upstream_id, "multiple-ips.test:80", "127.0.0.2:80", "healthy")
       assert.same(204, status)
 
       health = bu.get_upstream_health(upstream_name)
@@ -246,7 +246,7 @@ for _, strategy in helpers.each_strategy() do
       assert.equals("UNHEALTHY", health.data[1].data.addresses[1].health)
       assert.equals("HEALTHY", health.data[1].data.addresses[2].health)
 
-      local status = bu.post_target_address_health(upstream_id, "multiple-ips.test:80", "127.0.0.2:80", "unhealthy")
+      local status = bu.put_target_address_health(upstream_id, "multiple-ips.test:80", "127.0.0.2:80", "unhealthy")
       assert.same(204, status)
 
       health = bu.get_upstream_health(upstream_name)
@@ -298,7 +298,7 @@ for _, strategy in helpers.each_strategy() do
       assert.equals("UNHEALTHY", health.data[1].health)
       assert.equals("UNHEALTHY", health.data[1].data.addresses[1].health)
 
-      local status = bu.post_target_address_health(upstream_id, "srv-changes-port.test:80", "a-changes-port.test:90", "healthy")
+      local status = bu.put_target_address_health(upstream_id, "srv-changes-port.test:80", "a-changes-port.test:90", "healthy")
       assert.same(204, status)
 
       health = bu.get_upstream_health(upstream_name)
@@ -381,7 +381,7 @@ for _, strategy in helpers.each_strategy() do
       assert.equals("UNHEALTHY", health.data[1].data.addresses[1].health)
       assert.equals("UNHEALTHY", health.data[1].data.addresses[2].health)
 
-      local status = bu.post_target_address_health(upstream_id, "multiple-ips.test:80", "127.0.0.2:80", "healthy")
+      local status = bu.put_target_address_health(upstream_id, "multiple-ips.test:80", "127.0.0.2:80", "healthy")
       assert.same(204, status)
 
       health = bu.get_upstream_health(upstream_name)
@@ -394,7 +394,7 @@ for _, strategy in helpers.each_strategy() do
       assert.equals("UNHEALTHY", health.data[1].data.addresses[1].health)
       assert.equals("HEALTHY", health.data[1].data.addresses[2].health)
 
-      local status = bu.post_target_address_health(upstream_id, "multiple-ips.test:80", "127.0.0.2:80", "unhealthy")
+      local status = bu.put_target_address_health(upstream_id, "multiple-ips.test:80", "127.0.0.2:80", "unhealthy")
       assert.same(204, status)
 
       health = bu.get_upstream_health(upstream_name)
@@ -697,11 +697,11 @@ for _, strategy in helpers.each_strategy() do
 
             if mode == "ipv6" then
               -- TODO /upstreams does not understand shortened IPv6 addresses
-              bu.post_target_endpoint(upstream_id, "[0000:0000:0000:0000:0000:0000:0000:0001]", port, "unhealthy")
+              bu.put_target_endpoint(upstream_id, "[0000:0000:0000:0000:0000:0000:0000:0001]", port, "unhealthy")
               bu.poll_wait_health(upstream_id, "[0000:0000:0000:0000:0000:0000:0000:0001]", port, "UNHEALTHY", admin_port_1)
               bu.poll_wait_health(upstream_id, "[0000:0000:0000:0000:0000:0000:0000:0001]", port, "UNHEALTHY", admin_port_2)
             else
-              bu.post_target_endpoint(upstream_id, localhost, port, "unhealthy")
+              bu.put_target_endpoint(upstream_id, localhost, port, "unhealthy")
               bu.poll_wait_health(upstream_id, localhost, port, "UNHEALTHY", admin_port_1)
               bu.poll_wait_health(upstream_id, localhost, port, "UNHEALTHY", admin_port_2)
             end
@@ -1181,10 +1181,10 @@ for _, strategy in helpers.each_strategy() do
                 bu.end_testcase_setup(strategy, bp)
 
                 -- 100% healthy
-                bu.post_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.1:80", "healthy")
-                bu.post_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.2:80", "healthy")
-                bu.post_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.3:80", "healthy")
-                bu.post_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.4:80", "healthy")
+                bu.put_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.1:80", "healthy")
+                bu.put_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.2:80", "healthy")
+                bu.put_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.3:80", "healthy")
+                bu.put_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.4:80", "healthy")
 
                 local health = bu.get_balancer_health(upstream_name)
                 assert.is.table(health)
@@ -1203,7 +1203,7 @@ for _, strategy in helpers.each_strategy() do
                 end
 
                 -- 75% healthy
-                bu.post_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.1:80", "unhealthy")
+                bu.put_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.1:80", "unhealthy")
                 health = bu.get_balancer_health(upstream_name)
 
                 assert.same({
@@ -1219,7 +1219,7 @@ for _, strategy in helpers.each_strategy() do
                 end
 
                 -- 50% healthy
-                bu.post_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.2:80", "unhealthy")
+                bu.put_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.2:80", "unhealthy")
                 health = bu.get_balancer_health(upstream_name)
 
                 assert.same({
@@ -1235,7 +1235,7 @@ for _, strategy in helpers.each_strategy() do
                 end
 
                 -- 25% healthy
-                bu.post_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.3:80", "unhealthy")
+                bu.put_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.3:80", "unhealthy")
                 health = bu.get_balancer_health(upstream_name)
 
                 assert.same({
@@ -1251,7 +1251,7 @@ for _, strategy in helpers.each_strategy() do
                 end
 
                 -- 0% healthy
-                bu.post_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.4:80", "unhealthy")
+                bu.put_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.4:80", "unhealthy")
                 health = bu.get_balancer_health(upstream_name)
 
                 assert.same({
@@ -1996,10 +1996,10 @@ for _, strategy in helpers.each_strategy() do
                 -- manually bring it back using the endpoint
                 if mode == "ipv6" then
                   -- TODO /upstreams does not understand shortened IPv6 addresses
-                  bu.post_target_endpoint(upstream_id, "[0000:0000:0000:0000:0000:0000:0000:0001]", port2, "healthy")
+                  bu.put_target_endpoint(upstream_id, "[0000:0000:0000:0000:0000:0000:0000:0001]", port2, "healthy")
                   bu.poll_wait_health(upstream_id, "[0000:0000:0000:0000:0000:0000:0000:0001]", port2, "HEALTHY")
                 else
-                  bu.post_target_endpoint(upstream_id, localhost, port2, "healthy")
+                  bu.put_target_endpoint(upstream_id, localhost, port2, "healthy")
                   bu.poll_wait_health(upstream_id, localhost, port2, "HEALTHY")
                 end
 
@@ -2058,10 +2058,10 @@ for _, strategy in helpers.each_strategy() do
               -- manually bring it down using the endpoint
               if mode == "ipv6" then
                 -- TODO /upstreams does not understand shortened IPv6 addresses
-                bu.post_target_endpoint(upstream_id, "[0000:0000:0000:0000:0000:0000:0000:0001]", port2, "unhealthy")
+                bu.put_target_endpoint(upstream_id, "[0000:0000:0000:0000:0000:0000:0000:0001]", port2, "unhealthy")
                 bu.poll_wait_health(upstream_id, "[0000:0000:0000:0000:0000:0000:0000:0001]", port2, "UNHEALTHY")
               else
-                bu.post_target_endpoint(upstream_id, localhost, port2, "unhealthy")
+                bu.put_target_endpoint(upstream_id, localhost, port2, "unhealthy")
                 bu.poll_wait_health(upstream_id, localhost, port2, "UNHEALTHY")
               end
 
@@ -2075,10 +2075,10 @@ for _, strategy in helpers.each_strategy() do
               -- manually bring it back using the endpoint
               if mode == "ipv6" then
                 -- TODO /upstreams does not understand shortened IPv6 addresses
-                bu.post_target_endpoint(upstream_id, "[0000:0000:0000:0000:0000:0000:0000:0001]", port2, "healthy")
+                bu.put_target_endpoint(upstream_id, "[0000:0000:0000:0000:0000:0000:0000:0001]", port2, "healthy")
                 bu.poll_wait_health(upstream_id, "[0000:0000:0000:0000:0000:0000:0000:0001]", port2, "HEALTHY")
               else
-                bu.post_target_endpoint(upstream_id, localhost, port2, "healthy")
+                bu.put_target_endpoint(upstream_id, localhost, port2, "healthy")
                 bu.poll_wait_health(upstream_id, localhost, port2, "HEALTHY")
               end
 

--- a/spec/02-integration/05-proxy/10-balancer/02-least-connections_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer/02-least-connections_spec.lua
@@ -113,7 +113,7 @@ for _, strategy in helpers.each_strategy() do
 
         -- create a new target
         local res = assert(api_client:send({
-          method = "POST",
+          method = "PUT",
           path = "/upstreams/" .. upstream1_id .. "/targets",
           headers = {
             ["Content-Type"] = "application/json",
@@ -218,7 +218,7 @@ for _, strategy in helpers.each_strategy() do
 
         -- create a new target
         local res = assert(api_client:send({
-          method = "POST",
+          method = "PUT",
           path = "/upstreams/" .. an_upstream.id .. "/targets",
           headers = {
             ["Content-Type"] = "application/json",

--- a/spec/fixtures/admin_api.lua
+++ b/spec/fixtures/admin_api.lua
@@ -65,7 +65,7 @@ admin_api_as_db["basicauth_credentials"] = {
 
 admin_api_as_db["targets"] = {
   insert = function(_, tbl)
-    return api_send("POST", "/upstreams/" .. tbl.upstream.id .. "/targets", tbl)
+    return api_send("PUT", "/upstreams/" .. tbl.upstream.id .. "/targets", tbl)
   end,
   remove = function(_, tbl)
     return api_send("DELETE", "/upstreams/" .. tbl.upstream.id .. "/targets/" .. tbl.id)

--- a/spec/fixtures/balancer_utils.lua
+++ b/spec/fixtures/balancer_utils.lua
@@ -80,7 +80,7 @@ local function direct_request(host, port, path, protocol, host_header)
 end
 
 
-local function post_target_endpoint(upstream_id, host, port, endpoint)
+local function put_target_endpoint(upstream_id, host, port, endpoint)
   if host == "[::1]" then
     host = "[0000:0000:0000:0000:0000:0000:0000:0001]"
   end
@@ -90,7 +90,7 @@ local function post_target_endpoint(upstream_id, host, port, endpoint)
                              .. "/" .. endpoint
   local api_client = helpers.admin_client()
   local res, err = assert(api_client:send {
-    method = "POST",
+    method = "PUT",
     path = prefix .. path,
     headers = {
       ["Content-Type"] = "application/json",
@@ -159,7 +159,7 @@ local patch_upstream
 local get_upstream
 local get_upstream_health
 local get_balancer_health
-local post_target_address_health
+local put_target_address_health
 local get_router_version
 local add_target
 local update_target
@@ -241,9 +241,9 @@ do
     end
   end
 
-  post_target_address_health = function(upstream_id, target_id, address, mode, forced_port)
+  put_target_address_health = function(upstream_id, target_id, address, mode, forced_port)
     local path = "/upstreams/" .. upstream_id .. "/targets/" .. target_id .. "/" .. address .. "/" .. mode
-    return api_send("POST", path, {}, forced_port)
+    return api_send("PUT", path, {}, forced_port)
   end
 
   get_router_version = function(forced_port)
@@ -567,8 +567,8 @@ balancer_utils.patch_api = patch_api
 balancer_utils.patch_upstream = patch_upstream
 balancer_utils.poll_wait_address_health = poll_wait_address_health
 balancer_utils.poll_wait_health = poll_wait_health
-balancer_utils.post_target_address_health = post_target_address_health
-balancer_utils.post_target_endpoint = post_target_endpoint
+balancer_utils.put_target_address_health = put_target_address_health
+balancer_utils.put_target_endpoint = put_target_endpoint
 balancer_utils.SLOTS = SLOTS
 balancer_utils.tcp_client_requests = tcp_client_requests
 balancer_utils.wait_for_router_update = wait_for_router_update


### PR DESCRIPTION
### Summary

Kong has used the [POST](https://www.ietf.org/rfc/rfc2616.html#section-9.5) method to insert and update targets since always, but [RFC-2616](https://www.ietf.org/rfc/rfc2616.html) defines that the [PUT](https://www.ietf.org/rfc/rfc2616.html#section-9.6) method is the one appropriate one for this action.

This is a breaking change planned for the next major version.

### Full changelog

* Changed method in Admin API.
* Updated tests and test helper functions.

FT-2544