### PR TITLE
fix(core) ctx dropped in log phase

### DIFF
--- a/kong/runloop/plugin_servers/init.lua
+++ b/kong/runloop/plugin_servers/init.lua
@@ -35,27 +35,19 @@ local exposed_api = {
   ["kong.nginx.get_tls1_version_str"] = ngx_ssl.get_tls1_version_str,
 
   ["kong.nginx.get_ctx"] = function(k)
-    local saved = save_for_later[coroutine_running()]
-    local ngx_ctx = saved and saved.ngx_ctx or ngx.ctx
-    return ngx_ctx[k]
+    return ngx.ctx
   end,
 
   ["kong.nginx.set_ctx"] = function(k, v)
-    local saved = save_for_later[coroutine_running()]
-    local ngx_ctx = saved and saved.ngx_ctx or ngx.ctx
-    ngx_ctx[k] = v
+    ngx.ctx[k] = v
   end,
 
   ["kong.ctx.shared.get"] = function(k)
-    local saved = save_for_later[coroutine_running()]
-    local ctx_shared = saved and saved.ctx_shared or kong.ctx.shared
-    return ctx_shared[k]
+    return kong.ctx.shared[k]
   end,
 
   ["kong.ctx.shared.set"] = function(k, v)
-    local saved = save_for_later[coroutine_running()]
-    local ctx_shared = saved and saved.ctx_shared or kong.ctx.shared
-    ctx_shared[k] = v
+    kong.ctx.shared[k] = v
   end,
 
   ["kong.request.get_headers"] = function(max)
@@ -99,11 +91,6 @@ local exposed_api = {
     end
 
     return header_value
-  end,
-
-  ["kong.response.get_source"] = function()
-    local saved = save_for_later[coroutine_running()]
-    return kong.response.get_source(saved and saved.ngx_ctx or nil)
   end,
 
   ["kong.nginx.req_start_time"] = ngx.req.start_time,

--- a/kong/runloop/plugin_servers/mp_rpc.lua
+++ b/kong/runloop/plugin_servers/mp_rpc.lua
@@ -122,6 +122,8 @@ local function call_pdk_method(cmd, args)
 
   local saved = Rpc.save_for_later[coroutine.running()]
   if saved and saved.plugin_name then
+    ngx.ctx = saved.ngx_ctx
+    kong.ctx.shared = saved.ctx_shared
     kong_global.set_namespaced_log(kong, saved.plugin_name)
   end
 


### PR DESCRIPTION
log phase does recover ngx.ctx for some of functions(with wrapper function), however for those functon not wrapped, they will see an empty ngx.ctx, and cause unreadable error message for check_phase

Fix #8598
