### PR TITLE
fix(core) ctx dropped in log phase

### DIFF
--- a/kong/runloop/plugin_servers/mp_rpc.lua
+++ b/kong/runloop/plugin_servers/mp_rpc.lua
@@ -122,6 +122,7 @@ local function call_pdk_method(cmd, args)
 
   local saved = Rpc.save_for_later[coroutine.running()]
   if saved and saved.plugin_name then
+    ngx.ctx.KONG_PHASE = saved.ngx_ctx.KONG_PHASE
     kong_global.set_namespaced_log(kong, saved.plugin_name)
   end
 


### PR DESCRIPTION
Log phase does recover ngx.ctx for some of functions(with wrapper function), however for those functions not wrapped, they will see an empty ngx.ctx, and cause an unreadable error message for `check_phase`.
This is an ad hoc fix for `check_phase`.

Fix #8598
