### PR TITLE
chore(proxy-cache) do not copy response data to request's ctx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,13 @@
   scripts that depend on it being `POST`, these scripts will need to be updated
   when updating to Kong 3.0.
 
+#### Plugins
+
+- The proxy-cache plugin does not share the response data in
+  `ngx.ctx.proxy_cache_hit` anymore. Logging plugins that need the response data
+  must read it from `kong.ctx.shared.proxy_cache_hit` from Kong 3.0 on.
+  [#8607](https://github.com/Kong/kong/pull/8607)
+
 ### Dependencies
 
 - Bumped pgmoon from 1.13.0 to 1.14.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@
 
 #### Plugins
 
-- The proxy-cache plugin does not share the response data in
+- The proxy-cache plugin does not store the response data in
   `ngx.ctx.proxy_cache_hit` anymore. Logging plugins that need the response data
   must read it from `kong.ctx.shared.proxy_cache_hit` from Kong 3.0 on.
   [#8607](https://github.com/Kong/kong/pull/8607)

--- a/kong/plugins/proxy-cache/handler.lua
+++ b/kong/plugins/proxy-cache/handler.lua
@@ -347,7 +347,6 @@ function ProxyCacheHandler:access(conf)
   kong.ctx.shared.proxy_cache_hit = response_data
 
   local nctx = ngx.ctx
-  nctx.proxy_cache_hit = response_data -- TODO: deprecated
   nctx.KONG_PROXIED = true
 
   for k in pairs(res.headers) do


### PR DESCRIPTION
### Summary

`proxy_cache_hit` contains the response data to be shared with the logging plugins. Originally it was added to the generic Nginx request's ctx, then later it was changed to use Kong's ctx but the previous one was kept as a backward compatibility. For the next major version this compatibility will be removed.

### Full changelog

* Removed `proxy_cache_hit` backward compatibility.



FT-2559