### PR TITLE
chore(rockspec) bump lua-resty-healthcheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,10 @@
     and deprecated the `proxy_scheme` config attribute for removal in 3.0
     [#8406](https://github.com/Kong/kong/pull/8406)
 
+### Dependencies
+
+- Bumped `lua-resty-healthcheck` from 1.4.2 to 1.5.1
+  [#8615](https://github.com/Kong/kong/pull/8615)
 
 ## [2.7.1]
 

--- a/kong-2.7.1-0.rockspec
+++ b/kong-2.7.1-0.rockspec
@@ -33,7 +33,7 @@ dependencies = {
   "luaxxhash >= 1.0",
   "lua-protobuf == 0.3.3",
   "lua-resty-worker-events == 1.0.0",
-  "lua-resty-healthcheck == 1.4.2",
+  "lua-resty-healthcheck == 1.5.1",
   "lua-resty-mlcache == 2.5.0",
   "lua-messagepack == 0.5.2",
   "lua-resty-openssl == 0.8.2",


### PR DESCRIPTION
### Summary

Bump needed to fix an issue in lua-resty-healthcheck that could break active health checks when changing targets.

### Issue reference

Fix #7652 
