### PR TITLE
fix(aws-lambda) construct request path from upstream_uri

### DIFF
--- a/kong/plugins/aws-lambda/aws-serializer.lua
+++ b/kong/plugins/aws-lambda/aws-serializer.lua
@@ -78,7 +78,7 @@ return function(ctx, config)
   end
 
   -- prepare path
-  local path = var.request_uri:match("^([^%?]+)")  -- strip any query args
+  local path = var.upstream_uri:match("^([^%?]+)")  -- strip any query args
 
   local request = {
     resource                        = ctx.router_matches.uri,


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

The request event path should respect the upstream URI in order to match what other plugins may define when this is changed from other plugins e.g. request-transformer. These updates respect the upstream URI configuration to properly build the path.

### Full changelog

* replace path from request_uri to upstream_uri

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #8608