### PR TITLE
tests(*) make the `host` and `port` of `grpcbin` configurable

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -134,6 +134,8 @@ jobs:
       KONG_TEST_PG_DATABASE: kong
       KONG_TEST_PG_USER: kong
       KONG_TEST_DATABASE: postgres
+      KONG_SPEC_TEST_GRPCBIN_PORT: "15002"
+      KONG_SPEC_TEST_GRPCBIN_SSL_PORT: "15003"
       TEST_SUITE: ${{ matrix.suite }}
       TEST_SPLIT: ${{ matrix.split }}
 
@@ -214,6 +216,8 @@ jobs:
       KONG_TEST_PG_DATABASE: kong
       KONG_TEST_PG_USER: kong
       KONG_TEST_DATABASE: 'off'
+      KONG_SPEC_TEST_GRPCBIN_PORT: "15002"
+      KONG_SPEC_TEST_GRPCBIN_SSL_PORT: "15003"
       TEST_SUITE: dbless
 
     services:
@@ -267,6 +271,8 @@ jobs:
 
     env:
       KONG_TEST_DATABASE: cassandra
+      KONG_SPEC_TEST_GRPCBIN_PORT: "15002"
+      KONG_SPEC_TEST_GRPCBIN_SSL_PORT: "15003"
       TEST_SUITE: ${{ matrix.suite }}
       TEST_SPLIT: ${{ matrix.split }}
 

--- a/spec/02-integration/05-proxy/02-router_spec.lua
+++ b/spec/02-integration/05-proxy/02-router_spec.lua
@@ -470,7 +470,7 @@ for _, strategy in helpers.each_strategy() do
     describe("use cases #grpc", function()
       local routes
       local service = {
-        url = "grpc://localhost:15002"
+        url = helpers.grpcbin_url,
       }
 
       local proxy_client_grpc
@@ -1742,7 +1742,7 @@ for _, strategy in helpers.each_strategy() do
             snis = { "grpcs_1.test" },
             service = {
               name = "grpcs_1",
-              url = "grpcs://localhost:15003",
+              url = helpers.grpcbin_ssl_url,
             },
           },
           {
@@ -1750,7 +1750,7 @@ for _, strategy in helpers.each_strategy() do
             snis = { "grpcs_2.test" },
             service = {
               name = "grpcs_2",
-              url = "grpcs://localhost:15003",
+              url = helpers.grpcbin_ssl_url,
             },
           },
         })

--- a/spec/02-integration/05-proxy/19-grpc_proxy_spec.lua
+++ b/spec/02-integration/05-proxy/19-grpc_proxy_spec.lua
@@ -22,12 +22,12 @@ for _, strategy in helpers.each_strategy() do
 
       local service1 = assert(bp.services:insert {
         name = "grpc",
-        url = "grpc://localhost:15002",
+        url = helpers.grpcbin_url,
       })
 
       local service2 = assert(bp.services:insert {
         name = "grpcs",
-        url = "grpcs://localhost:15003",
+        url = helpers.grpcbin_ssl_url,
       })
 
       local mock_grpc_service = assert(bp.services:insert {

--- a/spec/02-integration/05-proxy/21-grpc_plugins_triggering_spec.lua
+++ b/spec/02-integration/05-proxy/21-grpc_plugins_triggering_spec.lua
@@ -112,12 +112,12 @@ for _, strategy in helpers.each_strategy() do
 
       local service1 = assert(bp.services:insert {
         name = "grpc",
-        url = "grpc://localhost:15002",
+        url = helpers.grpcbin_url,
       })
 
       local service2 = assert(bp.services:insert {
         name = "grpcs",
-        url = "grpcs://localhost:15003",
+        url = helpers.grpcbin_ssl_url,
       })
 
       assert(bp.routes:insert {

--- a/spec/02-integration/05-proxy/22-reports_spec.lua
+++ b/spec/02-integration/05-proxy/22-reports_spec.lua
@@ -83,7 +83,7 @@ for _, strategy in helpers.each_strategy() do
 
       local grpc_srv = bp.services:insert({
         name = "grpc",
-        url = "grpc://localhost:15002",
+        url = helpers.grpcbin_url,
       })
 
       bp.routes:insert({
@@ -94,7 +94,7 @@ for _, strategy in helpers.each_strategy() do
 
       local grpcs_srv = bp.services:insert({
         name = "grpcs",
-        url = "grpcs://localhost:15003",
+        url = helpers.grpcbin_ssl_url,
       })
 
       bp.routes:insert({

--- a/spec/03-plugins/01-tcp-log/01-tcp-log_spec.lua
+++ b/spec/03-plugins/01-tcp-log/01-tcp-log_spec.lua
@@ -60,7 +60,7 @@ for _, strategy in helpers.each_strategy() do
 
       local grpc_service = assert(bp.services:insert {
         name = "grpc-service",
-        url = "grpc://localhost:15002",
+        url = helpers.grpcbin_url,
       })
 
       local route3 = assert(bp.routes:insert {
@@ -80,7 +80,7 @@ for _, strategy in helpers.each_strategy() do
 
       local grpcs_service = assert(bp.services:insert {
         name = "grpcs-service",
-        url = "grpcs://localhost:15003",
+        url = helpers.grpcbin_ssl_url,
       })
 
       local route4 = assert(bp.routes:insert {

--- a/spec/03-plugins/02-udp-log/01-udp-log_spec.lua
+++ b/spec/03-plugins/02-udp-log/01-udp-log_spec.lua
@@ -49,7 +49,7 @@ for _, strategy in helpers.each_strategy() do
 
       local grpc_service = assert(bp.services:insert {
         name = "grpc-service",
-        url = "grpc://localhost:15002",
+        url = helpers.grpcbin_url,
       })
 
       local route2 = assert(bp.routes:insert {
@@ -69,7 +69,7 @@ for _, strategy in helpers.each_strategy() do
 
       local grpcs_service = assert(bp.services:insert {
         name = "grpcs-service",
-        url = "grpcs://localhost:15003",
+        url = helpers.grpcbin_ssl_url,
       })
 
       local route3 = assert(bp.routes:insert {

--- a/spec/03-plugins/03-http-log/01-log_spec.lua
+++ b/spec/03-plugins/03-http-log/01-log_spec.lua
@@ -144,7 +144,7 @@ for _, strategy in helpers.each_strategy() do
 
       local grpc_service = assert(bp.services:insert {
         name = "grpc-service",
-        url = "grpc://localhost:15002",
+        url = helpers.grpcbin_url,
       })
 
       local route7 = assert(bp.routes:insert {
@@ -167,7 +167,7 @@ for _, strategy in helpers.each_strategy() do
 
       local grpcs_service = assert(bp.services:insert {
         name = "grpcs-service",
-        url = "grpcs://localhost:15003",
+        url = helpers.grpcbin_ssl_url,
       })
 
       local route8 = assert(bp.routes:insert {

--- a/spec/03-plugins/04-file-log/01-log_spec.lua
+++ b/spec/03-plugins/04-file-log/01-log_spec.lua
@@ -36,7 +36,7 @@ for _, strategy in helpers.each_strategy() do
 
       local grpc_service = assert(bp.services:insert {
         name = "grpc-service",
-        url = "grpc://localhost:15002",
+        url = helpers.grpcbin_url,
       })
 
       local route2 = assert(bp.routes:insert {
@@ -56,7 +56,7 @@ for _, strategy in helpers.each_strategy() do
 
       local grpcs_service = assert(bp.services:insert {
         name = "grpcs-service",
-        url = "grpcs://localhost:15003",
+        url = helpers.grpcbin_ssl_url,
       })
 
       local route3 = assert(bp.routes:insert {

--- a/spec/03-plugins/05-syslog/01-log_spec.lua
+++ b/spec/03-plugins/05-syslog/01-log_spec.lua
@@ -84,7 +84,7 @@ for _, strategy in helpers.each_strategy() do
       -- grpc [[
       local grpc_service = bp.services:insert {
         name = "grpc-service",
-        url = "grpc://localhost:15002",
+        url = helpers.grpcbin_url,
       }
 
       local grpc_route1 = bp.routes:insert {

--- a/spec/03-plugins/06-statsd/01-log_spec.lua
+++ b/spec/03-plugins/06-statsd/01-log_spec.lua
@@ -240,7 +240,7 @@ for _, strategy in helpers.each_strategy() do
       local grpc_routes = {}
       for i = 1, 2 do
         local service = bp.services:insert {
-          url = "grpc://localhost:15002",
+          url = helpers.grpcbin_url,
           name     = fmt("grpc_statsd%s", i)
         }
         grpc_routes[i] = bp.routes:insert {

--- a/spec/03-plugins/07-loggly/01-log_spec.lua
+++ b/spec/03-plugins/07-loggly/01-log_spec.lua
@@ -102,7 +102,7 @@ for _, strategy in helpers.each_strategy() do
       -- grpc [[
       local grpc_service = bp.services:insert {
         name = "grpc-service",
-        url = "grpc://localhost:15002",
+        url = helpers.grpcbin_url,
       }
 
       local grpc_route1 = bp.routes:insert {

--- a/spec/03-plugins/08-datadog/01-log_spec.lua
+++ b/spec/03-plugins/08-datadog/01-log_spec.lua
@@ -55,7 +55,7 @@ for _, strategy in helpers.each_strategy() do
         paths = { "/hello.HelloService/" },
         service = assert(bp.services:insert {
           name = "grpc",
-          url = "grpc://localhost:15002",
+          url = helpers.grpcbin_url,
         }),
       })
 

--- a/spec/03-plugins/09-key-auth/02-access_spec.lua
+++ b/spec/03-plugins/09-key-auth/02-access_spec.lua
@@ -78,7 +78,7 @@ for _, strategy in helpers.each_strategy() do
         paths = { "/hello.HelloService/" },
         service = assert(bp.services:insert {
           name = "grpc",
-          url = "grpc://localhost:15002",
+          url = helpers.grpcbin_url,
         }),
       })
 

--- a/spec/03-plugins/10-basic-auth/03-access_spec.lua
+++ b/spec/03-plugins/10-basic-auth/03-access_spec.lua
@@ -50,7 +50,7 @@ for _, strategy in helpers.each_strategy() do
         paths = { "/hello.HelloService/" },
         service = assert(bp.services:insert {
           name = "grpc",
-          url = "grpc://localhost:15002",
+          url = helpers.grpcbin_url,
         }),
       })
 

--- a/spec/03-plugins/11-correlation-id/01-access_spec.lua
+++ b/spec/03-plugins/11-correlation-id/01-access_spec.lua
@@ -53,7 +53,7 @@ for _, strategy in helpers.each_strategy() do
         paths = { "/hello.HelloService/" },
         service = assert(bp.services:insert {
           name = "grpc",
-          url = "grpc://localhost:15002",
+          url = helpers.grpcbin_url,
         }),
       })
 

--- a/spec/03-plugins/14-request-termination/02-access_spec.lua
+++ b/spec/03-plugins/14-request-termination/02-access_spec.lua
@@ -146,7 +146,7 @@ for _, strategy in helpers.each_strategy() do
         paths = { "/hello.HelloService/" },
         service = assert(bp.services:insert {
           name = "grpc",
-          url = "grpc://localhost:15002",
+          url = helpers.grpcbin_url,
         }),
       })
 

--- a/spec/03-plugins/16-jwt/03-access_spec.lua
+++ b/spec/03-plugins/16-jwt/03-access_spec.lua
@@ -51,7 +51,7 @@ for _, strategy in helpers.each_strategy() do
         paths = { "/hello.HelloService/" },
         service = assert(bp.services:insert {
           name = "grpc",
-          url = "grpc://localhost:15002",
+          url = helpers.grpcbin_url,
         }),
       })
 

--- a/spec/03-plugins/17-ip-restriction/02-access_spec.lua
+++ b/spec/03-plugins/17-ip-restriction/02-access_spec.lua
@@ -67,7 +67,7 @@ for _, strategy in helpers.each_strategy() do
 
       local grpc_service = bp.services:insert {
           name = "grpc1",
-          url = "grpc://localhost:15002",
+          url = helpers.grpcbin_url,
       }
 
       local route_grpc_deny = assert(bp.routes:insert {

--- a/spec/03-plugins/19-hmac-auth/03-access_spec.lua
+++ b/spec/03-plugins/19-hmac-auth/03-access_spec.lua
@@ -39,7 +39,7 @@ for _, strategy in helpers.each_strategy() do
         paths = { "/hello.HelloService/" },
         service = assert(bp.services:insert {
           name = "grpc",
-          url = "grpc://localhost:15002",
+          url = helpers.grpcbin_url,
         }),
       })
 

--- a/spec/03-plugins/20-ldap-auth/01-access_spec.lua
+++ b/spec/03-plugins/20-ldap-auth/01-access_spec.lua
@@ -80,7 +80,7 @@ for _, ldap_strategy in pairs(ldap_strategies) do
             paths = { "/hello.HelloService/" },
             service = assert(bp.services:insert {
               name = "grpc",
-              url = "grpc://localhost:15002",
+              url = helpers.grpcbin_url,
             }),
           })
 

--- a/spec/03-plugins/21-bot-detection/01-access_spec.lua
+++ b/spec/03-plugins/21-bot-detection/01-access_spec.lua
@@ -30,7 +30,7 @@ for _, strategy in helpers.each_strategy() do
 
       local grpc_service = bp.services:insert {
           name = "grpc1",
-          url = "grpc://localhost:15002",
+          url = helpers.grpcbin_url,
       }
 
       local route_grpc1 = assert(bp.routes:insert {

--- a/spec/03-plugins/23-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/04-access_spec.lua
@@ -81,7 +81,7 @@ end
 
 
 local redis_confs = {
-  no_ssl = { 
+  no_ssl = {
     redis_port = REDIS_PORT,
   },
   ssl_verify = {
@@ -109,40 +109,40 @@ for _, strategy in helpers.each_strategy() do
         describe(fmt("Plugin: rate-limiting (access) with policy: #%s #%s [#%s]", redis_conf_name, policy, strategy), function()
           local bp
           local db
-    
+
           lazy_setup(function()
             helpers.kill_all()
             flush_redis()
-    
+
             bp, db = helpers.get_db_utils(strategy)
-    
+
             local consumer1 = bp.consumers:insert {
               custom_id = "provider_123",
             }
-    
+
             bp.keyauth_credentials:insert {
               key      = "apikey122",
               consumer = { id = consumer1.id },
             }
-    
+
             local consumer2 = bp.consumers:insert {
               custom_id = "provider_124",
             }
-    
+
             bp.keyauth_credentials:insert {
               key      = "apikey123",
               consumer = { id = consumer2.id },
             }
-    
+
             bp.keyauth_credentials:insert {
               key      = "apikey333",
               consumer = { id = consumer2.id },
             }
-    
+
             local route1 = bp.routes:insert {
               hosts = { "test1.com" },
             }
-    
+
             bp.rate_limiting_plugins:insert({
               route   = { id = route1.id },
               config  = {
@@ -158,16 +158,16 @@ for _, strategy in helpers.each_strategy() do
                 redis_database    = REDIS_DATABASE,
               }
             })
-    
+
             local route_grpc_1 = assert(bp.routes:insert {
               protocols = { "grpc" },
               paths = { "/hello.HelloService/" },
               service = assert(bp.services:insert {
                 name = "grpc",
-                url = "grpc://localhost:15002",
+                url = helpers.grpcbin_url,
               }),
             })
-    
+
             bp.rate_limiting_plugins:insert({
               route   = { id = route_grpc_1.id },
               config  = {
@@ -183,11 +183,11 @@ for _, strategy in helpers.each_strategy() do
                 redis_database    = REDIS_DATABASE,
               }
             })
-    
+
             local route2 = bp.routes:insert {
               hosts      = { "test2.com" },
             }
-    
+
             bp.rate_limiting_plugins:insert({
               route   = { id = route2.id },
               config  = {
@@ -204,16 +204,16 @@ for _, strategy in helpers.each_strategy() do
                 redis_database    = REDIS_DATABASE,
               }
             })
-    
+
             local route3 = bp.routes:insert {
               hosts = { "test3.com" },
             }
-    
+
             bp.plugins:insert {
               name     = "key-auth",
               route = { id = route3.id },
             }
-    
+
             bp.rate_limiting_plugins:insert({
               route   = { id = route3.id },
               config  = {
@@ -230,7 +230,7 @@ for _, strategy in helpers.each_strategy() do
                 redis_database    = REDIS_DATABASE,
               }
             })
-    
+
             bp.rate_limiting_plugins:insert({
               route     = { id = route3.id },
               consumer  = { id = consumer1.id },
@@ -247,16 +247,16 @@ for _, strategy in helpers.each_strategy() do
                 redis_database    = REDIS_DATABASE
               }
             })
-    
+
             local route4 = bp.routes:insert {
               hosts = { "test4.com" },
             }
-    
+
             bp.plugins:insert {
               name     = "key-auth",
               route = { id = route4.id },
             }
-    
+
             bp.rate_limiting_plugins:insert({
               route     = { id = route4.id },
               consumer  = { id = consumer1.id },
@@ -273,11 +273,11 @@ for _, strategy in helpers.each_strategy() do
                 redis_database    = REDIS_DATABASE,
               },
             })
-    
+
             local route5 = bp.routes:insert {
               hosts = { "test5.com" },
             }
-    
+
             bp.rate_limiting_plugins:insert({
               route   = { id = route5.id },
               config  = {
@@ -294,7 +294,7 @@ for _, strategy in helpers.each_strategy() do
                 redis_database      = REDIS_DATABASE,
               },
             })
-    
+
             local service = bp.services:insert()
             bp.routes:insert {
               hosts = { "test-service1.com" },
@@ -304,7 +304,7 @@ for _, strategy in helpers.each_strategy() do
               hosts = { "test-service2.com" },
               service = service,
             }
-    
+
             bp.rate_limiting_plugins:insert({
               service = { id = service.id },
               config  = {
@@ -320,13 +320,13 @@ for _, strategy in helpers.each_strategy() do
                 redis_database    = REDIS_DATABASE,
               }
             })
-    
+
             local service = bp.services:insert()
             bp.routes:insert {
               hosts = { "test-path.com" },
               service = service,
             }
-    
+
             bp.rate_limiting_plugins:insert({
               service = { id = service.id },
               config = {
@@ -344,26 +344,26 @@ for _, strategy in helpers.each_strategy() do
                 redis_database    = REDIS_DATABASE,
               }
             })
-    
+
             assert(helpers.start_kong({
               database   = strategy,
               nginx_conf = "spec/fixtures/custom_nginx.template",
               lua_ssl_trusted_certificate = "spec/fixtures/redis/ca.crt",
             }))
           end)
-    
+
           lazy_teardown(function()
             helpers.stop_kong()
             assert(db:truncate())
           end)
-    
+
           describe("Without authentication (IP address)", function()
             it_with_retry("blocks if exceeding limit", function()
               for i = 1, 6 do
                 local res = GET("/status/200", {
                   headers = { Host = "test1.com" },
                 }, 200)
-    
+
                 assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
                 assert.are.same(6 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
                 assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
@@ -371,31 +371,31 @@ for _, strategy in helpers.each_strategy() do
                 local reset = tonumber(res.headers["ratelimit-reset"])
                 assert.equal(true, reset <= 60 and reset >= 0)
               end
-    
+
               -- Additonal request, while limit is 6/minute
               local res, body = GET("/status/200", {
                 headers = { Host = "test1.com" },
               }, 429)
-    
+
               assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
               assert.are.same(0, tonumber(res.headers["ratelimit-remaining"]))
-    
+
               local retry = tonumber(res.headers["retry-after"])
               assert.equal(true, retry <= 60 and retry > 0)
-    
+
               local reset = tonumber(res.headers["ratelimit-reset"])
               assert.equal(true, reset <= 60 and reset > 0)
-    
+
               local json = cjson.decode(body)
               assert.same({ message = "API rate limit exceeded" }, json)
             end)
-    
+
             it_with_retry("blocks if exceeding limit, only if done via same path", function()
               for i = 1, 3 do
                 local res = GET("/status/200", {
                   headers = { Host = "test-path.com" },
                 }, 200)
-    
+
                 assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
                 assert.are.same(6 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
                 assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
@@ -403,13 +403,13 @@ for _, strategy in helpers.each_strategy() do
                 local reset = tonumber(res.headers["ratelimit-reset"])
                 assert.equal(true, reset <= 60 and reset > 0)
               end
-    
+
               -- Try a different path on the same host. This should reset the timers
               for i = 1, 3 do
                 local res = GET("/status/201", {
                   headers = { Host = "test-path.com" },
                 }, 201)
-    
+
                 assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
                 assert.are.same(6 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
                 assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
@@ -417,13 +417,13 @@ for _, strategy in helpers.each_strategy() do
                 local reset = tonumber(res.headers["ratelimit-reset"])
                 assert.equal(true, reset <= 60 and reset > 0)
               end
-    
+
               -- Continue doing requests on the path which "blocks"
               for i = 4, 6 do
                 local res = GET("/status/200", {
                   headers = { Host = "test-path.com" },
                 }, 200)
-    
+
                 assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
                 assert.are.same(6 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
                 assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
@@ -431,31 +431,31 @@ for _, strategy in helpers.each_strategy() do
                 local reset = tonumber(res.headers["ratelimit-reset"])
                 assert.equal(true, reset <= 60 and reset > 0)
               end
-    
+
               -- Additonal request, while limit is 6/minute
               local res, body = GET("/status/200", {
                 headers = { Host = "test-path.com" },
               }, 429)
-    
+
               assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
               assert.are.same(0, tonumber(res.headers["ratelimit-remaining"]))
-    
+
               local retry = tonumber(res.headers["retry-after"])
               assert.equal(true, retry <= 60 and retry > 0)
-    
+
               local reset = tonumber(res.headers["ratelimit-reset"])
               assert.equal(true, reset <= 60 and reset > 0)
-    
+
               local json = cjson.decode(body)
               assert.same({ message = "API rate limit exceeded" }, json)
             end)
-    
+
             it_with_retry("counts against the same service register from different routes", function()
               for i = 1, 3 do
                 local res = GET("/status/200", {
                   headers = { Host = "test-service1.com" },
                 }, 200)
-    
+
                 assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
                 assert.are.same(6 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
                 assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
@@ -463,12 +463,12 @@ for _, strategy in helpers.each_strategy() do
                 local reset = tonumber(res.headers["ratelimit-reset"])
                 assert.equal(true, reset <= 60 and reset > 0)
               end
-    
+
               for i = 4, 6 do
                 local res = GET("/status/200", {
                   headers = { Host = "test-service2.com" },
                 }, 200)
-    
+
                 assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
                 assert.are.same(6 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
                 assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
@@ -476,36 +476,36 @@ for _, strategy in helpers.each_strategy() do
                 local reset = tonumber(res.headers["ratelimit-reset"])
                 assert.equal(true, reset <= 60 and reset > 0)
               end
-    
+
               -- Additonal request, while limit is 6/minute
               local res, body = GET("/status/200", {
                 headers = { Host = "test-service1.com" },
               }, 429)
-    
+
               assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
               assert.are.same(0, tonumber(res.headers["ratelimit-remaining"]))
-    
+
               local retry = tonumber(res.headers["retry-after"])
               assert.equal(true, retry <= 60 and retry > 0)
-    
+
               local reset = tonumber(res.headers["ratelimit-reset"])
               assert.equal(true, reset <= 60 and reset > 0)
-    
+
               local json = cjson.decode(body)
               assert.same({ message = "API rate limit exceeded" }, json)
             end)
-    
+
             it_with_retry("handles multiple limits #flaky", function()
               local limits = {
                 minute = 3,
                 hour   = 5
               }
-    
+
               for i = 1, 3 do
                 local res = GET("/status/200", {
                   headers = { Host = "test2.com" },
                 }, 200)
-    
+
                 assert.are.same(limits.minute, tonumber(res.headers["x-ratelimit-limit-minute"]))
                 assert.are.same(limits.minute - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
                 assert.are.same(limits.hour, tonumber(res.headers["x-ratelimit-limit-hour"]))
@@ -515,23 +515,23 @@ for _, strategy in helpers.each_strategy() do
                 local reset = tonumber(res.headers["ratelimit-reset"])
                 assert.equal(true, reset <= 60 and reset > 0)
               end
-    
+
               local res, body = GET("/status/200", {
                 path    = "/status/200",
                 headers = { Host = "test2.com" },
               }, 429)
-    
+
               assert.are.same(limits.minute, tonumber(res.headers["ratelimit-limit"]))
               assert.are.same(0, tonumber(res.headers["ratelimit-remaining"]))
               assert.equal(2, tonumber(res.headers["x-ratelimit-remaining-hour"]))
               assert.equal(0, tonumber(res.headers["x-ratelimit-remaining-minute"]))
-    
+
               local retry = tonumber(res.headers["retry-after"])
               assert.equal(true, retry <= 60 and retry > 0)
-    
+
               local reset = tonumber(res.headers["ratelimit-reset"])
               assert.equal(true, reset <= 60 and reset > 0)
-    
+
               local json = cjson.decode(body)
               assert.same({ message = "API rate limit exceeded" }, json)
             end)
@@ -546,17 +546,17 @@ for _, strategy in helpers.each_strategy() do
                   },
                 }
                 assert.truthy(ok)
-    
+
                 assert.matches("x%-ratelimit%-limit%-minute: 6", res)
                 assert.matches("x%-ratelimit%-remaining%-minute: " .. (6 - i), res)
                 assert.matches("ratelimit%-limit: 6", res)
                 assert.matches("ratelimit%-remaining: " .. (6 - i), res)
-    
+
                 local reset = tonumber(string.match(res, "ratelimit%-reset: (%d+)"))
                 assert.equal(true, reset <= 60 and reset >= 0)
-    
+
               end
-    
+
               -- Additonal request, while limit is 6/minute
               local ok, res = helpers.proxy_client_grpc(){
                 service = "hello.HelloService.SayHello",
@@ -566,14 +566,14 @@ for _, strategy in helpers.each_strategy() do
               }
               assert.falsy(ok)
               assert.matches("Code: ResourceExhausted", res)
-    
+
               assert.matches("ratelimit%-limit: 6", res)
               assert.matches("ratelimit%-remaining: 0", res)
-    
+
               local retry = tonumber(string.match(res, "retry%-after: (%d+)"))
               assert.equal(true, retry <= 60 and retry > 0)
-    
-    
+
+
               local reset = tonumber(string.match(res, "ratelimit%-reset: (%d+)"))
               assert.equal(true, reset <= 60 and reset > 0)
             end)
@@ -585,7 +585,7 @@ for _, strategy in helpers.each_strategy() do
                   local res = GET("/status/200?apikey=apikey123", {
                     headers = { Host = "test3.com" },
                   }, 200)
-    
+
                   assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
                   assert.are.same(6 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
                   assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
@@ -593,24 +593,24 @@ for _, strategy in helpers.each_strategy() do
                   local reset = tonumber(res.headers["ratelimit-reset"])
                   assert.equal(true, reset <= 60 and reset > 0)
                 end
-    
+
                 -- Third query, while limit is 2/minute
                 local res, body = GET("/status/200?apikey=apikey123", {
                   headers = { Host = "test3.com" },
                 }, 429)
-    
+
                 assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
                 assert.are.same(0, tonumber(res.headers["ratelimit-remaining"]))
-    
+
                 local retry = tonumber(res.headers["retry-after"])
                 assert.equal(true, retry <= 60 and retry > 0)
-    
+
                 local reset = tonumber(res.headers["ratelimit-reset"])
                 assert.equal(true, reset <= 60 and reset > 0)
-    
+
                 local json = cjson.decode(body)
                 assert.same({ message = "API rate limit exceeded" }, json)
-    
+
                 -- Using a different key of the same consumer works
                 GET("/status/200?apikey=apikey333", {
                   headers = { Host = "test3.com" },
@@ -623,7 +623,7 @@ for _, strategy in helpers.each_strategy() do
                   local res = GET("/status/200?apikey=apikey122", {
                     headers = { Host = "test3.com" },
                   }, 200)
-    
+
                   assert.are.same(8, tonumber(res.headers["x-ratelimit-limit-minute"]))
                   assert.are.same(8 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
                   assert.are.same(8, tonumber(res.headers["ratelimit-limit"]))
@@ -631,30 +631,30 @@ for _, strategy in helpers.each_strategy() do
                   local reset = tonumber(res.headers["ratelimit-reset"])
                   assert.equal(true, reset <= 60 and reset > 0)
                 end
-    
+
                 local res, body = GET("/status/200?apikey=apikey122", {
                   headers = { Host = "test3.com" },
                 }, 429)
-    
+
                 assert.are.same(8, tonumber(res.headers["ratelimit-limit"]))
                 assert.are.same(0, tonumber(res.headers["ratelimit-remaining"]))
-    
+
                 local retry = tonumber(res.headers["retry-after"])
                 assert.equal(true, retry <= 60 and retry > 0)
-    
+
                 local reset = tonumber(res.headers["ratelimit-reset"])
                 assert.equal(true, reset <= 60 and reset > 0)
-    
+
                 local json = cjson.decode(body)
                 assert.same({ message = "API rate limit exceeded" }, json)
               end)
-    
+
               it_with_retry("blocks if the only rate-limiting plugin existing is per consumer and not per API", function()
                 for i = 1, 6 do
                   local res = GET("/status/200?apikey=apikey122", {
                     headers = { Host = "test4.com" },
                   }, 200)
-    
+
                   assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
                   assert.are.same(6 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
                   assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
@@ -662,32 +662,32 @@ for _, strategy in helpers.each_strategy() do
                   local reset = tonumber(res.headers["ratelimit-reset"])
                   assert.equal(true, reset <= 60 and reset > 0)
                 end
-    
+
                 local res, body = GET("/status/200?apikey=apikey122", {
                   headers = { Host = "test4.com" },
                 }, 429)
-    
+
                 assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
                 assert.are.same(0, tonumber(res.headers["ratelimit-remaining"]))
-    
+
                 local retry = tonumber(res.headers["retry-after"])
                 assert.equal(true, retry <= 60 and retry > 0)
-    
+
                 local reset = tonumber(res.headers["ratelimit-reset"])
                 assert.equal(true, reset <= 60 and reset > 0)
-    
+
                 local json = cjson.decode(body)
                 assert.same({ message = "API rate limit exceeded" }, json)
               end)
             end)
           end)
-    
+
           describe("Config with hide_client_headers", function()
             it_with_retry("does not send rate-limit headers when hide_client_headers==true", function()
               local res = GET("/status/200", {
                 headers = { Host = "test5.com" },
               }, 200)
-    
+
               assert.is_nil(res.headers["x-ratelimit-limit-minute"])
               assert.is_nil(res.headers["x-ratelimit-remaining-minute"])
               assert.is_nil(res.headers["ratelimit-limit"])
@@ -696,166 +696,166 @@ for _, strategy in helpers.each_strategy() do
               assert.is_nil(res.headers["retry-after"])
             end)
           end)
-    
+
           if policy == "cluster" then
             describe("#flaky Fault tolerancy", function()
-    
+
               before_each(function()
                 helpers.kill_all()
-    
+
                 assert(db:truncate())
-    
+
                 local route1 = bp.routes:insert {
                   hosts = { "failtest1.com" },
                 }
-    
+
                 bp.rate_limiting_plugins:insert {
                   route = { id = route1.id },
                   config   = { minute = 6, fault_tolerant = false }
                 }
-    
+
                 local route2 = bp.routes:insert {
                   hosts = { "failtest2.com" },
                 }
-    
+
                 bp.rate_limiting_plugins:insert {
                   name     = "rate-limiting",
                   route = { id = route2.id },
                   config   = { minute = 6, fault_tolerant = true },
                 }
-    
+
                 assert(helpers.start_kong({
                   database   = strategy,
                   nginx_conf = "spec/fixtures/custom_nginx.template",
                   lua_ssl_trusted_certificate = "spec/fixtures/redis/ca.crt",
                 }))
               end)
-    
+
               lazy_teardown(function()
                 helpers.kill_all()
                 assert(db:truncate())
               end)
-    
+
               it_with_retry("does not work if an error occurs", function()
                 local res = GET("/status/200", {
                   headers = { Host = "failtest1.com" },
                 }, 200)
-    
+
                 assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
                 assert.are.same(5, tonumber(res.headers["x-ratelimit-remaining-minute"]))
                 assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
                 assert.are.same(5, tonumber(res.headers["ratelimit-remaining"]))
                 local reset = tonumber(res.headers["ratelimit-reset"])
                 assert.equal(true, reset <= 60 and reset > 0)
-    
+
                 -- Simulate an error on the database
                 assert(db.connector:query("DROP TABLE ratelimiting_metrics"))
-    
+
                 -- Make another request
                 local _, body = GET("/status/200", {
                   headers = { Host = "failtest1.com" },
                 }, 500)
-    
+
                 local json = cjson.decode(body)
                 assert.same({ message = "An unexpected error occurred" }, json)
-    
+
                 db:reset()
                 bp, db = helpers.get_db_utils(strategy)
               end)
-    
+
               it_with_retry("keeps working if an error occurs", function()
                 local res = GET("/status/200", {
                   headers = { Host = "failtest2.com" },
                 }, 200)
-    
+
                 assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
                 assert.are.same(5, tonumber(res.headers["x-ratelimit-remaining-minute"]))
                 assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
                 assert.are.same(5, tonumber(res.headers["ratelimit-remaining"]))
                 local reset = tonumber(res.headers["ratelimit-reset"])
                 assert.equal(true, reset <= 60 and reset > 0)
-    
+
                 -- Simulate an error on the database
                 assert(db.connector:query("DROP TABLE ratelimiting_metrics"))
-    
+
                 -- Make another request
                 local res = GET("/status/200", {
                   headers = { Host = "failtest2.com" },
                 }, 200)
-    
+
                 assert.falsy(res.headers["x-ratelimit-limit-minute"])
                 assert.falsy(res.headers["x-ratelimit-remaining-minute"])
                 assert.falsy(res.headers["ratelimit-limit"])
                 assert.falsy(res.headers["ratelimit-remaining"])
                 assert.falsy(res.headers["ratelimit-reset"])
-    
+
                 db:reset()
                 bp, db = helpers.get_db_utils(strategy)
               end)
             end)
-    
+
           elseif policy == "redis" then
             describe("#flaky Fault tolerancy", function()
-    
+
               before_each(function()
                 helpers.kill_all()
-    
+
                 assert(db:truncate())
-    
+
                 local service1 = bp.services:insert()
-    
+
                 local route1 = bp.routes:insert {
                   hosts      = { "failtest3.com" },
                   protocols  = { "http", "https" },
                   service    = service1
                 }
-    
+
                 bp.rate_limiting_plugins:insert {
                   route = { id = route1.id },
                   config  = { minute = 6, policy = policy, redis_host = "5.5.5.5", fault_tolerant = false },
                 }
-    
+
                 local service2 = bp.services:insert()
-    
+
                 local route2 = bp.routes:insert {
                   hosts      = { "failtest4.com" },
                   protocols  = { "http", "https" },
                   service    = service2
                 }
-    
+
                 bp.rate_limiting_plugins:insert {
                   name   = "rate-limiting",
                   route = { id = route2.id },
                   config = { minute = 6, policy = policy, redis_host = "5.5.5.5", fault_tolerant = true },
                 }
-    
+
                 assert(helpers.start_kong({
                   database   = strategy,
                   nginx_conf = "spec/fixtures/custom_nginx.template",
                   lua_ssl_trusted_certificate = "spec/fixtures/redis/ca.crt",
                 }))
               end)
-    
+
               lazy_teardown(function()
                 helpers.kill_all()
                 assert(db:truncate())
               end)
-    
+
               it_with_retry("does not work if an error occurs", function()
                 -- Make another request
                 local _, body = GET("/status/200", {
                   headers = { Host = "failtest3.com" },
                 }, 500)
-    
+
                 local json = cjson.decode(body)
                 assert.same({ message = "An unexpected error occurred" }, json)
               end)
-    
+
               it_with_retry("keeps working if an error occurs", function()
                 local res = GET("/status/200", {
                   headers = { Host = "failtest4.com" },
                 }, 200)
-    
+
                 assert.falsy(res.headers["x-ratelimit-limit-minute"])
                 assert.falsy(res.headers["x-ratelimit-remaining-minute"])
                 assert.falsy(res.headers["ratelimit-limit"])
@@ -864,19 +864,19 @@ for _, strategy in helpers.each_strategy() do
               end)
             end)
           end
-    
+
           describe("Expirations", function()
             local route
-    
+
             lazy_setup(function()
               helpers.stop_kong()
-    
+
               local bp = helpers.get_db_utils(strategy)
-    
+
               route = bp.routes:insert {
                 hosts = { "expire1.com" },
               }
-    
+
               bp.rate_limiting_plugins:insert {
                 route     = { id = route.id },
                 config    = {
@@ -892,65 +892,65 @@ for _, strategy in helpers.each_strategy() do
                   redis_database    = REDIS_DATABASE,
                 },
               }
-    
+
               assert(helpers.start_kong({
                 database   = strategy,
                 nginx_conf = "spec/fixtures/custom_nginx.template",
                 lua_ssl_trusted_certificate = "spec/fixtures/redis/ca.crt",
               }))
             end)
-    
+
             it_with_retry("#flaky expires a counter", function()
               local t = 61 - (ngx.now() % 60)
-    
+
               local res = GET("/status/200", {
                 headers = { Host = "expire1.com" },
               }, 200)
-    
+
               assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
               assert.are.same(5, tonumber(res.headers["x-ratelimit-remaining-minute"]))
               assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
               assert.are.same(5, tonumber(res.headers["ratelimit-remaining"]))
               local reset = tonumber(res.headers["ratelimit-reset"])
               assert.equal(true, reset <= 60 and reset > 0)
-    
+
               ngx.sleep(t) -- Wait for minute to expire
-    
+
               local res = GET("/status/200", {
                 headers = { Host = "expire1.com" }
               }, 200)
-    
+
               assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
               assert.are.same(5, tonumber(res.headers["x-ratelimit-remaining-minute"]))
               assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
               assert.are.same(5, tonumber(res.headers["ratelimit-remaining"]))
               local reset = tonumber(res.headers["ratelimit-reset"])
               assert.equal(true, reset <= 60 and reset > 0)
-    
+
             end)
           end)
         end)
-    
+
         describe(fmt("Plugin: rate-limiting (access - global for single consumer) with policy: #%s #%s [#%s]", redis_conf_name, policy, strategy), function()
           local bp
           local db
-    
+
           lazy_setup(function()
             helpers.kill_all()
             flush_redis()
             bp, db = helpers.get_db_utils(strategy)
-    
+
             local consumer = bp.consumers:insert {
               custom_id = "provider_125",
             }
-    
+
             bp.key_auth_plugins:insert()
-    
+
             bp.keyauth_credentials:insert {
               key      = "apikey125",
               consumer = { id = consumer.id },
             }
-    
+
             -- just consumer, no no route or service
             bp.rate_limiting_plugins:insert({
               consumer  = { id = consumer.id },
@@ -968,29 +968,29 @@ for _, strategy in helpers.each_strategy() do
                 redis_database    = REDIS_DATABASE,
               }
             })
-    
+
             for i = 1, 6 do
               bp.routes:insert({ hosts = { fmt("test%d.com", i) } })
             end
-    
+
             assert(helpers.start_kong({
               database   = strategy,
               nginx_conf = "spec/fixtures/custom_nginx.template",
               lua_ssl_trusted_certificate = "spec/fixtures/redis/ca.crt",
             }))
           end)
-    
+
           lazy_teardown(function()
             helpers.kill_all()
             assert(db:truncate())
           end)
-    
+
           it_with_retry("blocks when the consumer exceeds their quota, no matter what service/route used", function()
             for i = 1, 6 do
               local res = GET("/status/200?apikey=apikey125", {
                 headers = { Host = fmt("test%d.com", i) },
               }, 200)
-    
+
               assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
               assert.are.same(6 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
               assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
@@ -998,35 +998,35 @@ for _, strategy in helpers.each_strategy() do
               local reset = tonumber(res.headers["ratelimit-reset"])
               assert.equal(true, reset <= 60 and reset > 0)
             end
-    
+
             -- Additonal request, while limit is 6/minute
             local res, body = GET("/status/200?apikey=apikey125", {
               headers = { Host = "test1.com" },
             }, 429)
-    
+
             assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
             assert.are.same(0, tonumber(res.headers["ratelimit-remaining"]))
-    
+
             local retry = tonumber(res.headers["retry-after"])
             assert.equal(true, retry <= 60 and retry > 0)
-    
+
             local reset = tonumber(res.headers["ratelimit-reset"])
             assert.equal(true, reset <= 60 and reset > 0)
-    
+
             local json = cjson.decode(body)
             assert.same({ message = "API rate limit exceeded" }, json)
           end)
         end)
-    
+
         describe(fmt("Plugin: rate-limiting (access - global for service) with policy: #%s #%s [#%s]", redis_conf_name, policy, strategy), function()
           local bp
           local db
-    
+
           lazy_setup(function()
             helpers.kill_all()
             flush_redis()
             bp, db = helpers.get_db_utils(strategy)
-    
+
             -- global plugin (not attached to route, service or consumer)
             bp.rate_limiting_plugins:insert({
               config = {
@@ -1043,34 +1043,34 @@ for _, strategy in helpers.each_strategy() do
                 redis_database    = REDIS_DATABASE,
               }
             })
-    
+
             local service = bp.services:insert()
-    
+
             for i = 1, 6 do
               bp.routes:insert({
                 hosts = { fmt("test%d.com", i) },
                 service = service,
               })
             end
-    
+
             assert(helpers.start_kong({
               database   = strategy,
               nginx_conf = "spec/fixtures/custom_nginx.template",
               lua_ssl_trusted_certificate = "spec/fixtures/redis/ca.crt",
             }))
           end)
-    
+
           lazy_teardown(function()
             helpers.kill_all()
             assert(db:truncate())
           end)
-    
+
           it_with_retry("blocks if exceeding limit", function()
             for i = 1, 6 do
               local res = GET("/status/200", {
                 headers = { Host = fmt("test%d.com", i) },
               }, 200)
-    
+
               assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
               assert.are.same(6 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
               assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
@@ -1078,35 +1078,35 @@ for _, strategy in helpers.each_strategy() do
               local reset = tonumber(res.headers["ratelimit-reset"])
               assert.equal(true, reset <= 60 and reset > 0)
             end
-    
+
             -- Additonal request, while limit is 6/minute
             local res, body = GET("/status/200", {
               headers = { Host = "test1.com" },
             }, 429)
-    
+
             assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
             assert.are.same(0, tonumber(res.headers["ratelimit-remaining"]))
-    
+
             local retry = tonumber(res.headers["retry-after"])
             assert.equal(true, retry <= 60 and retry > 0)
-    
+
             local reset = tonumber(res.headers["ratelimit-reset"])
             assert.equal(true, reset <= 60 and reset > 0)
-    
+
             local json = cjson.decode(body)
             assert.same({ message = "API rate limit exceeded" }, json)
           end)
         end)
-    
+
         describe(fmt("Plugin: rate-limiting (access - per service) with policy: #%s #%s [#%s]", redis_conf_name, policy, strategy), function()
           local bp
           local db
-    
+
           lazy_setup(function()
             helpers.kill_all()
             flush_redis()
             bp, db = helpers.get_db_utils(strategy)
-    
+
             -- global plugin (not attached to route, service or consumer)
             bp.rate_limiting_plugins:insert({
               config = {
@@ -1123,35 +1123,35 @@ for _, strategy in helpers.each_strategy() do
                 redis_database    = REDIS_DATABASE,
               }
             })
-    
+
             local service1 = bp.services:insert()
             bp.routes:insert {
               hosts = { "test1.com" },
               service = service1,
             }
-    
+
             local service2 = bp.services:insert()
             bp.routes:insert {
               hosts = { "test2.com" },
               service = service2,
             }
-    
+
             assert(helpers.start_kong({
               database   = strategy,
               nginx_conf = "spec/fixtures/custom_nginx.template",
               lua_ssl_trusted_certificate = "spec/fixtures/redis/ca.crt",
             }))
           end)
-    
+
           lazy_teardown(function()
             helpers.kill_all()
             assert(db:truncate())
           end)
-    
+
           it_with_retry("blocks if exceeding limit", function()
             for i = 1, 6 do
               local res = GET("/status/200", { headers = { Host = "test1.com" } }, 200)
-    
+
               assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
               assert.are.same(6 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
               assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
@@ -1159,10 +1159,10 @@ for _, strategy in helpers.each_strategy() do
               local reset = tonumber(res.headers["ratelimit-reset"])
               assert.equal(true, reset <= 60 and reset > 0)
             end
-    
+
             for i = 1, 6 do
               local res = GET("/status/200", { headers = { Host = "test2.com" } }, 200)
-    
+
               assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
               assert.are.same(6 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
               assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
@@ -1170,35 +1170,35 @@ for _, strategy in helpers.each_strategy() do
               local reset = tonumber(res.headers["ratelimit-reset"])
               assert.equal(true, reset <= 60 and reset > 0)
             end
-    
+
             -- Additonal request, while limit is 6/minute
             for _, host in ipairs{ "test1.com", "test2.com" } do
               local res, body = GET("/status/200", { headers = { Host = host } }, 429)
-    
+
               assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
               assert.are.same(0, tonumber(res.headers["ratelimit-remaining"]))
-    
+
               local retry = tonumber(res.headers["retry-after"])
               assert.equal(true, retry <= 60 and retry > 0)
-    
+
               local reset = tonumber(res.headers["ratelimit-reset"])
               assert.equal(true, reset <= 60 and reset > 0)
-    
+
               local json = cjson.decode(body)
               assert.same({ message = "API rate limit exceeded" }, json)
             end
           end)
         end)
-    
+
         describe(fmt("Plugin: rate-limiting (access - global) with policy: #%s #%s [#%s]", redis_conf_name, policy, strategy), function()
           local bp
           local db
-    
+
           lazy_setup(function()
             helpers.kill_all()
             flush_redis()
             bp, db = helpers.get_db_utils(strategy)
-    
+
             -- global plugin (not attached to route, service or consumer)
             bp.rate_limiting_plugins:insert({
               config = {
@@ -1214,29 +1214,29 @@ for _, strategy in helpers.each_strategy() do
                 redis_database    = REDIS_DATABASE,
               }
             })
-    
+
             for i = 1, 6 do
               bp.routes:insert({ hosts = { fmt("test%d.com", i) } })
             end
-    
+
             assert(helpers.start_kong({
               database   = strategy,
               nginx_conf = "spec/fixtures/custom_nginx.template",
               lua_ssl_trusted_certificate = "spec/fixtures/redis/ca.crt",
             }))
           end)
-    
+
           lazy_teardown(function()
             helpers.kill_all()
             assert(db:truncate())
           end)
-    
+
           it_with_retry("blocks if exceeding limit", function()
             for i = 1, 6 do
               local res = GET("/status/200", {
                 headers = { Host = fmt("test%d.com", i) },
               }, 200)
-    
+
               assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
               assert.are.same(6 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
               assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
@@ -1244,35 +1244,35 @@ for _, strategy in helpers.each_strategy() do
               local reset = tonumber(res.headers["ratelimit-reset"])
               assert.equal(true, reset <= 60 and reset > 0)
             end
-    
+
             -- Additonal request, while limit is 6/minute
             local res, body = GET("/status/200", {
               headers = { Host = "test1.com" },
             }, 429)
-    
+
             assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
             assert.are.same(0, tonumber(res.headers["ratelimit-remaining"]))
-    
+
             local retry = tonumber(res.headers["retry-after"])
             assert.equal(true, retry <= 60 and retry > 0)
-    
+
             local reset = tonumber(res.headers["ratelimit-reset"])
             assert.equal(true, reset <= 60 and reset > 0)
-    
+
             local json = cjson.decode(body)
             assert.same({ message = "API rate limit exceeded" }, json)
           end)
         end)
-    
+
         describe(fmt("Plugin: rate-limiting (access - global) with policy: #%s #%s [#%s] by path", redis_conf_name, policy, strategy), function()
           local bp
           local db
-    
+
           lazy_setup(function()
             helpers.kill_all()
             flush_redis()
             bp, db = helpers.get_db_utils(strategy)
-    
+
             -- global plugin (not attached to route, service or consumer)
             bp.rate_limiting_plugins:insert({
               config = {
@@ -1288,35 +1288,35 @@ for _, strategy in helpers.each_strategy() do
                 redis_database    = REDIS_DATABASE,
               }
             })
-    
+
             -- hosts with services
             for i = 1, 3 do
               bp.routes:insert({ service = bp.services:insert(), hosts = { fmt("test%d.com", i) } })
             end
-    
+
             -- serviceless routes
             for i = 4, 6 do
               bp.routes:insert({ hosts = { fmt("test%d.com", i) } })
             end
-    
+
             assert(helpers.start_kong({
               database   = strategy,
               nginx_conf = "spec/fixtures/custom_nginx.template",
               lua_ssl_trusted_certificate = "spec/fixtures/redis/ca.crt",
             }))
           end)
-    
+
           lazy_teardown(function()
             helpers.kill_all()
             assert(db:truncate())
           end)
-    
+
           it_with_retry("maintains the counters for a path through different services and routes", function()
             for i = 1, 6 do
               local res = GET("/status/200", {
                 headers = { Host = fmt("test%d.com", i) },
               }, 200)
-    
+
               assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
               assert.are.same(6 - i, tonumber(res.headers["x-ratelimit-remaining-minute"]))
               assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
@@ -1324,21 +1324,21 @@ for _, strategy in helpers.each_strategy() do
               local reset = tonumber(res.headers["ratelimit-reset"])
               assert.equal(true, reset <= 60 and reset > 0)
             end
-    
+
             -- Additonal request, while limit is 6/minute
             local res, body = GET("/status/200", {
               headers = { Host = "test1.com" },
             }, 429)
-    
+
             assert.are.same(6, tonumber(res.headers["ratelimit-limit"]))
             assert.are.same(0, tonumber(res.headers["ratelimit-remaining"]))
-    
+
             local retry = tonumber(res.headers["retry-after"])
             assert.equal(true, retry <= 60 and retry > 0)
-    
+
             local reset = tonumber(res.headers["ratelimit-reset"])
             assert.equal(true, reset <= 60 and reset > 0)
-    
+
             local json = cjson.decode(body)
             assert.same({ message = "API rate limit exceeded" }, json)
           end)

--- a/spec/03-plugins/24-response-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/24-response-rate-limiting/04-access_spec.lua
@@ -300,7 +300,7 @@ describe(fmt("#flaky Plugin: response-ratelimiting (access) with policy: #%s [#%
 
     local grpc_service = assert(bp.services:insert {
       name = "grpc",
-      url = "grpc://localhost:15002",
+      url = helpers.grpcbin_url,
     })
 
     assert(bp.routes:insert {

--- a/spec/03-plugins/25-oauth2/03-access_spec.lua
+++ b/spec/03-plugins/25-oauth2/03-access_spec.lua
@@ -373,7 +373,7 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
 
       local service_grpc = assert(admin_api.services:insert {
           name = "grpc",
-          url = "grpc://localhost:15002",
+          url = helpers.grpcbin_url,
         })
 
       local route_grpc = assert(admin_api.routes:insert {

--- a/spec/03-plugins/26-prometheus/02-access_spec.lua
+++ b/spec/03-plugins/26-prometheus/02-access_spec.lua
@@ -29,7 +29,7 @@ describe("Plugin: prometheus (access)", function()
 
     local grpc_service = bp.services:insert {
       name = "mock-grpc-service",
-      url = "grpc://localhost:15002",
+      url = helpers.grpcbin_url,
     }
 
     bp.routes:insert {
@@ -41,7 +41,7 @@ describe("Plugin: prometheus (access)", function()
 
     local grpcs_service = bp.services:insert {
       name = "mock-grpcs-service",
-      url = "grpcs://localhost:15003",
+      url = helpers.grpcbin_ssl_url,
     }
 
     bp.routes:insert {

--- a/spec/03-plugins/26-prometheus/04-status_api_spec.lua
+++ b/spec/03-plugins/26-prometheus/04-status_api_spec.lua
@@ -97,7 +97,7 @@ describe("Plugin: prometheus (access via status API)", function()
 
     local grpc_service = bp.services:insert {
       name = "mock-grpc-service",
-      url = "grpc://localhost:15002",
+      url = helpers.grpcbin_url,
     }
 
     bp.routes:insert {
@@ -109,7 +109,7 @@ describe("Plugin: prometheus (access via status API)", function()
 
     local grpcs_service = bp.services:insert {
       name = "mock-grpcs-service",
-      url = "grpcs://localhost:15003",
+      url = helpers.grpcbin_ssl_url,
     }
 
     bp.routes:insert {

--- a/spec/03-plugins/32-grpc-web/01-proxy_spec.lua
+++ b/spec/03-plugins/32-grpc-web/01-proxy_spec.lua
@@ -1,9 +1,6 @@
 local cjson = require "cjson"
 local helpers = require "spec.helpers"
 
-local GRPCBIN_HOST = "127.0.0.1"
-local GRPCBIN_PORT = 15002
-
 -- returns nth byte (0: LSB, 3: MSB if 32-bit)
 local function nbyt(x, n)
   return bit.band(bit.rshift(x, 8*n), 0xff)
@@ -37,7 +34,7 @@ for _, strategy in helpers.each_strategy() do
 
       local service1 = assert(bp.services:insert {
         name = "grpc",
-        url = ("grpc://%s:%d"):format(GRPCBIN_HOST, GRPCBIN_PORT),
+        url = helpers.grpcbin_url,
       })
 
       local route1 = assert(bp.routes:insert {

--- a/spec/03-plugins/34-zipkin/zipkin_spec.lua
+++ b/spec/03-plugins/34-zipkin/zipkin_spec.lua
@@ -7,8 +7,6 @@ local fmt = string.format
 
 local ZIPKIN_HOST = helpers.zipkin_host
 local ZIPKIN_PORT = helpers.zipkin_port
-local GRPCBIN_HOST = "127.0.0.1"
-local GRPCBIN_PORT = 15002
 
 -- Transform zipkin annotations into a hash of timestamps. It assumes no repeated values
 -- input: { { value = x, timestamp = y }, { value = x2, timestamp = y2 } }
@@ -392,7 +390,7 @@ describe("http integration tests with zipkin server [#"
     -- grpc upstream
     grpc_service = bp.services:insert {
       name = string.lower("grpc-" .. utils.random_string()),
-      url = fmt("grpc://%s:%d", GRPCBIN_HOST, GRPCBIN_PORT),
+      url = helpers.grpcbin_url,
     }
 
     grpc_route = bp.routes:insert {
@@ -554,13 +552,13 @@ describe("http integration tests with zipkin server [#"
     -- specific assertions for proxy_span
     assert.same(proxy_span.tags["kong.route"], grpc_route.id)
     assert.same(proxy_span.tags["kong.route_name"], grpc_route.name)
-    assert.same(proxy_span.tags["peer.hostname"], GRPCBIN_HOST)
+    assert.same(proxy_span.tags["peer.hostname"], helpers.grpcbin_host)
 
     -- random ip assigned by Docker to the grpcbin container
     local grpcbin_ip = proxy_span.remoteEndpoint.ipv4
     assert.same({
       ipv4 = grpcbin_ip,
-      port = GRPCBIN_PORT,
+      port = helpers.grpcbin_port,
       serviceName = grpc_service.name,
     },
     proxy_span.remoteEndpoint)
@@ -576,7 +574,7 @@ describe("http integration tests with zipkin server [#"
 
     assert.same({
       ipv4 = grpcbin_ip,
-      port = GRPCBIN_PORT,
+      port = helpers.grpcbin_port,
       serviceName = grpc_service.name,
     },
     balancer_span.remoteEndpoint)

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -20,6 +20,9 @@ local MOCK_UPSTREAM_PORT = 15555
 local MOCK_UPSTREAM_SSL_PORT = 15556
 local MOCK_UPSTREAM_STREAM_PORT = 15557
 local MOCK_UPSTREAM_STREAM_SSL_PORT = 15558
+local GRPCBIN_HOST = os.getenv("KONG_SPEC_TEST_GRPCBIN_HOST") or "localhost"
+local GRPCBIN_PORT = tonumber(os.getenv("KONG_SPEC_TEST_GRPCBIN_PORT")) or 9000
+local GRPCBIN_SSL_PORT = tonumber(os.getenv("KONG_SPEC_TEST_GRPCBIN_SSL_PORT")) or 9001
 local MOCK_GRPC_UPSTREAM_PROTO_PATH = "./spec/fixtures/grpc/hello.proto"
 local ZIPKIN_HOST = os.getenv("KONG_SPEC_TEST_ZIPKIN_HOST") or "localhost"
 local ZIPKIN_PORT = tonumber(os.getenv("KONG_SPEC_TEST_ZIPKIN_PORT")) or 9411
@@ -2818,6 +2821,11 @@ end
 -- @field mock_upstream_stream_port
 -- @field mock_upstream_stream_ssl_port
 -- @field mock_grpc_upstream_proto_path
+-- @field grpcbin_host The host for grpcbin service, it can be set by env KONG_SPEC_TEST_GRPCBIN_HOST.
+-- @field grpcbin_port The port (SSL disabled) for grpcbin service, it can be set by env KONG_SPEC_TEST_GRPCBIN_PORT.
+-- @field grpcbin_ssl_port The port (SSL enabled) for grpcbin service it can be set by env KONG_SPEC_TEST_GRPCBIN_SSL_PORT.
+-- @field grpcbin_url The URL (SSL disabled) for grpcbin service
+-- @field grpcbin_ssl_url The URL (SSL enabled) for grpcbin service
 -- @field redis_host The host for Redis, it can be set by env KONG_SPEC_TEST_REDIS_HOST.
 -- @field redis_port The port (SSL disabled) for Redis, it can be set by env KONG_SPEC_TEST_REDIS_PORT.
 -- @field redis_ssl_port The port (SSL enabled) for Redis, it can be set by env KONG_SPEC_TEST_REDIS_SSL_PORT.
@@ -2868,10 +2876,16 @@ end
   zipkin_host = ZIPKIN_HOST,
   zipkin_port = ZIPKIN_PORT,
 
-  redis_host      = REDIS_HOST,
-  redis_port      = REDIS_PORT,
-  redis_ssl_port  = REDIS_SSL_PORT,
-  redis_ssl_sni   = REDIS_SSL_SNI,
+  grpcbin_host     = GRPCBIN_HOST,
+  grpcbin_port     = GRPCBIN_PORT,
+  grpcbin_ssl_port = GRPCBIN_SSL_PORT,
+  grpcbin_url      = string.format("grpc://%s:%d", GRPCBIN_HOST, GRPCBIN_PORT),
+  grpcbin_ssl_url  = string.format("grpcs://%s:%d", GRPCBIN_HOST, GRPCBIN_SSL_PORT),
+
+  redis_host     = REDIS_HOST,
+  redis_port     = REDIS_PORT,
+  redis_ssl_port = REDIS_SSL_PORT,
+  redis_ssl_sni  = REDIS_SSL_SNI,
 
   blackhole_host = BLACKHOLE_HOST,
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Now, the `host` and `port` of the `grpcbin` used for testing are fixed in the code and not easy to change. These parameters should be allowed to be changed via environment variables.

This PR introduces three environment variables to improve it:

* `KONG_SPEC_TEST_GRPCBIN_HOST`
* `KONG_SPEC_TEST_GRPCBIN_PORT`
* `KONG_SPEC_TEST_GRPCBIN_SSL_PORT`
