### PR TITLE
fix(http-log) url query parameter missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,8 @@
 [#8558](https://github.com/Kong/kong/pull/8558)
 - Remove deprecated `blacklist`/`whitelist` config fields from bot-detection, ip-restriction and ACL plugins.
 [#8560](https://github.com/Kong/kong/pull/8560)
+- **http-log**: Record the query parameter.
+[#8627](https://github.com/Kong/kong/pull/8627)
 
 #### Clustering
 

--- a/kong/plugins/http-log/handler.lua
+++ b/kong/plugins/http-log/handler.lua
@@ -93,6 +93,10 @@ local function send_payload(self, conf, payload)
   params_cache.keepalive_timeout = keepalive
 
   local url = fmt("%s://%s:%d%s", parsed_url.scheme, parsed_url.host, parsed_url.port, parsed_url.path)
+  
+  if parsed_url.query then
+    url = url .. "? ".. parsed_url.query
+  end
 
   -- note: `httpc:request` makes a deep copy of `params_cache`, so it will be
   -- fine to reuse the table here

--- a/spec/03-plugins/03-http-log/01-log_spec.lua
+++ b/spec/03-plugins/03-http-log/01-log_spec.lua
@@ -240,7 +240,7 @@ for _, strategy in helpers.each_strategy() do
     it("logs to HTTP", function()
       local res = assert(proxy_client:send({
         method = "GET",
-        path = "/status/200",
+        path = "/status/200?test0=test0&test1=test1",
         headers = {
           ["Host"] = "http_logging.test"
         }
@@ -262,6 +262,10 @@ for _, strategy in helpers.each_strategy() do
 
         if #body.entries == 1 then
           assert.same("127.0.0.1", body.entries[1].client_ip)
+          assert.same({
+            test0 = "test0",
+            test1 = "test1",
+          }, body.entries[1].request.querystring)
           return true
         end
       end, 10)


### PR DESCRIPTION
This commit https://github.com/Kong/kong/commit/2a608480d3f193b87a784666d99efbadb15be1aa is used to fix http log url query parameter missing issue.