### PR TITLE
fix(runloop) reschedule rebuild timers after running them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,12 @@
 
 ### Fixes
 
+#### Core
+
+- Only reschedule router and plugin iterator timers after finishing previous
+  execution, avoiding unnecessary concurrent executions.
+  [#8633](https://github.com/Kong/kong/pull/8633)
+
 #### Plugins
 
 - **AWS-Lambda**: Fixed incorrect behavior when configured to use an http proxy

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -34,7 +34,6 @@ local exec         = ngx.exec
 local null         = ngx.null
 local header       = ngx.header
 local timer_at     = ngx.timer.at
-local timer_every  = ngx.timer.every
 local subsystem    = ngx.config.subsystem
 local clear_header = ngx.req.clear_header
 local http_version = ngx.req.http_version
@@ -1098,7 +1097,7 @@ return {
           on_timeout = "return_true",
         }
 
-        timer_every(worker_state_update_frequency, function(premature)
+        local function rebuild_router_timer(premature)
           if premature then
             return
           end
@@ -1111,7 +1110,17 @@ return {
           if not ok then
             log(ERR, "could not rebuild router via timer: ", err)
           end
-        end)
+
+          local _, err = timer_at(worker_state_update_frequency, rebuild_router_timer)
+          if err then
+            log(ERR, "could not schedule timer to rebuild router: ", err)
+          end
+        end
+
+        local _, err = timer_at(worker_state_update_frequency, rebuild_router_timer)
+        if err then
+          log(ERR, "could not schedule timer to rebuild router: ", err)
+        end
 
         local plugins_iterator_async_opts = {
           name = "plugins_iterator",
@@ -1119,16 +1128,27 @@ return {
           on_timeout = "return_true",
         }
 
-        timer_every(worker_state_update_frequency, function(premature)
+        local function rebuild_plugins_iterator_timer(premature)
           if premature then
             return
           end
 
-          local ok, err = rebuild_plugins_iterator(plugins_iterator_async_opts)
-          if not ok then
+          local _, err = rebuild_plugins_iterator(plugins_iterator_async_opts)
+          if err then
             log(ERR, "could not rebuild plugins iterator via timer: ", err)
           end
-        end)
+
+          local _, err = timer_at(worker_state_update_frequency, rebuild_plugins_iterator_timer)
+          if err then
+            log(ERR, "could not schedule timer to rebuild plugins iterator: ", err)
+          end
+        end
+
+        local _, err = timer_at(worker_state_update_frequency, rebuild_plugins_iterator_timer)
+        if err then
+          log(ERR, "could not schedule timer to rebuild plugins iterator: ", err)
+        end
+
       end
     end,
     after = NOOP,

--- a/kong/runloop/plugins_iterator.lua
+++ b/kong/runloop/plugins_iterator.lua
@@ -466,7 +466,10 @@ function PluginsIterator.new(version)
       end
 
       if new_version ~= version then
-        return nil, "plugins iterator was changed while rebuilding it"
+        -- the plugins iterator rebuild is being done by a different process at
+        -- the same time, stop here and let the other one go for it
+        kong.log.info("plugins iterator was changed while rebuilding it")
+        return
       end
     end
 


### PR DESCRIPTION
### Summary

This is a backport of #8567 that is merged into `master`.

Router and plugin iterator rebuild timers were scheduled using ngx.timer.every. If the rebuild processes took longer than worker_state_update_frequency to execute, they would start again while the previous one was still running.

### Full changelog

Change ngx.timer.every calls to ngx.timer.at.
Previously returned error "plugins iterator was changed while rebuilding it" is now logged as an info message.
No tests were added, the behavior is the same as before.

### Issue reference

There were multiple reports of "plugins iterator was changed while rebuilding it" logged as error.

Fix https://github.com/Kong/kong/issues/8525

FTI-3239