### PR TITLE
fix(runloop) reschedule rebuild timers after running them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,12 @@
 
 ### Fixes
 
+#### Core
+
+- Only reschedule router and plugin iterator timers after finishing previous
+  execution, avoiding unnecessary concurrent executions.
+  [#8634](https://github.com/Kong/kong/pull/8634)
+
 ## [2.8.0]
 
 ### Deprecations

--- a/kong/runloop/plugins_iterator.lua
+++ b/kong/runloop/plugins_iterator.lua
@@ -466,7 +466,10 @@ function PluginsIterator.new(version)
       end
 
       if new_version ~= version then
-        return nil, "plugins iterator was changed while rebuilding it"
+        -- the plugins iterator rebuild is being done by a different process at
+        -- the same time, stop here and let the other one go for it
+        kong.log.info("plugins iterator was changed while rebuilding it")
+        return
       end
     end
 


### PR DESCRIPTION
### Summary

This is a backport of #8567 that is merged into `master`.

Router and plugin iterator rebuild timers were scheduled using ngx.timer.every. If the rebuild processes took longer than worker_state_update_frequency to execute, they would start again while the previous one was still running.

### Full changelog

Change ngx.timer.every calls to ngx.timer.at.
Previously returned error "plugins iterator was changed while rebuilding it" is now logged as an info message.
No tests were added, the behavior is the same as before.

### Issue reference

There were multiple reports of "plugins iterator was changed while rebuilding it" logged as error.

Fix https://github.com/Kong/kong/issues/8525

FTI-3239