### PR TITLE
perf(clustering) conditional rebuilding of router, plugins iterator and balancer on dp (2.8)

### DIFF
--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -74,20 +74,27 @@ function _M:decode_config(config)
 end
 
 
-function _M:update_config(config_table, config_hash, update_cache)
+function _M:update_config(config_table, config_hash, update_cache, hashes)
   assert(type(config_table) == "table")
 
   if not config_hash then
-    config_hash = self:calculate_config_hash(config_table)
+    config_hash, hashes = self:calculate_config_hash(config_table)
+  end
+
+  local current_hash = declarative.get_current_hash()
+  if current_hash == config_hash then
+    ngx_log(ngx_DEBUG, _log_prefix, "same config received from control plane, ",
+                                    "no need to reload")
+    return true
   end
 
   local entities, err, _, meta, new_hash =
-              self.declarative_config:parse_table(config_table, config_hash)
+    self.declarative_config:parse_table(config_table, config_hash)
   if not entities then
     return nil, "bad config received from control plane " .. err
   end
 
-  if declarative.get_current_hash() == new_hash then
+  if current_hash == new_hash then
     ngx_log(ngx_DEBUG, _log_prefix, "same config received from control plane, ",
                                     "no need to reload")
     return true
@@ -95,8 +102,9 @@ function _M:update_config(config_table, config_hash, update_cache)
 
   -- NOTE: no worker mutex needed as this code can only be
   -- executed by worker 0
+
   local res, err =
-    declarative.load_into_cache_with_events(entities, meta, new_hash)
+    declarative.load_into_cache_with_events(entities, meta, new_hash, hashes)
   if not res then
     return nil, err
   end
@@ -289,10 +297,12 @@ function _M:communicate(premature)
       local ok, err = config_semaphore:wait(1)
       if ok then
         local config_table = self.next_config
-        local config_hash  = self.next_hash
         if config_table then
+          local config_hash  = self.next_hash
+          local hashes = self.next_hashes
+
           local pok, res
-          pok, res, err = pcall(self.update_config, self, config_table, config_hash, true)
+          pok, res, err = pcall(self.update_config, self, config_table, config_hash, true, hashes)
           if pok then
             if not res then
               ngx_log(ngx_ERR, _log_prefix, "unable to update running config: ", err)
@@ -370,6 +380,7 @@ function _M:communicate(premature)
 
             self.next_config = assert(msg.config_table)
             self.next_hash = msg.config_hash
+            self.next_hashes = msg.hashes
 
             if config_semaphore:count() <= 0 then
               -- the following line always executes immediately after the `if` check

--- a/spec/01-unit/19-hybrid/02-clustering_spec.lua
+++ b/spec/01-unit/19-hybrid/02-clustering_spec.lua
@@ -167,16 +167,13 @@ describe("kong.clustering", function()
       for _ = 1, 10 do
         local hash = clustering.calculate_config_hash(clustering, value)
         assert.is_string(hash)
-        assert.equal("99914b932bd37a50b983c5e7c90ae93b", hash)
+        assert.equal("aaf38faf0b5851d711027bb4d812d50d", hash)
       end
-
-      local correct = ngx.md5("{}")
-      assert.equal("99914b932bd37a50b983c5e7c90ae93b", correct)
 
       for _ = 1, 10 do
         local hash = clustering.calculate_config_hash(clustering, value)
         assert.is_string(hash)
-        assert.equal(correct, hash)
+        assert.equal("aaf38faf0b5851d711027bb4d812d50d", hash)
       end
     end)
 
@@ -207,7 +204,7 @@ describe("kong.clustering", function()
       for _ = 1, 10 do
         local hash = clustering.calculate_config_hash(clustering, value)
         assert.is_string(hash)
-        assert.equal("e287bdd83a30b3c83c498e6e524f619b", hash)
+        assert.equal("cb83c48d5b2932d1bc9d13672b433365", hash)
         assert.equal(h, hash)
       end
     end)


### PR DESCRIPTION
backport of #8519 

### Summary

Implements conditional rebuilding of `router`, `plugins iterator` and `balancer` on
data planes. This means that DPs will not rebuild router if there were no changes in
routes or services. Similarly, the plugins iterator will not be rebuild if there were
no changes to plugins, and finally balancer in not reinitialized if there are no
changes to upstreams or targets.
