### PR TITLE
feat(stream_api): use TCP instead of UDP

### DIFF
--- a/kong/templates/nginx_kong_stream.lua
+++ b/kong/templates/nginx_kong_stream.lua
@@ -211,7 +211,7 @@ server {
 > end -- database == "off"
 
 server {        # ignore (and close }, to ignore content)
-    listen unix:${{PREFIX}}/stream_rpc.sock udp;
+    listen unix:${{PREFIX}}/stream_rpc.sock;
     error_log  ${{ADMIN_ERROR_LOG}} ${{LOG_LEVEL}};
     content_by_lua_block {
         Kong.stream_api()

--- a/kong/tools/stream_api.lua
+++ b/kong/tools/stream_api.lua
@@ -5,20 +5,234 @@
 
 local lpack = require "lua_pack"
 
+local kong = kong
+local st_pack = lpack.pack
+local st_unpack = lpack.unpack
+local concat = table.concat
+local assert = assert
+local type = type
+local tostring = tostring
+local tcp = ngx.socket.tcp
+local req_socket = ngx.req.socket
+local exit = ngx.exit
+local log = ngx.log
+local ERR = ngx.ERR
+local DEBUG = ngx.DEBUG
+local WARN = ngx.WARN
+local exiting = ngx.worker.exiting
 
-local kong       = kong
-local st_pack    = lpack.pack
-local st_unpack  = lpack.unpack
-local st_format  = string.format
-local table_concat = table.concat
-local assert     = assert
+local CLOSE = 444
+local OK = 0
 
-local MAX_DATA_LEN = 8000
-local PREFIX = ngx.config.prefix()
+
+local PACK_F = "=CI"
+
+-- unsigned char length
+local MAX_KEY_LEN = 2^8 - 1
+
+-- since the length is represented by an unsigned int we could theoretically
+-- go up to 2^32, but that seems way beyond the amount of data that we should
+-- expect to see exchanged over this interface
+local MAX_DATA_LEN = 2^22 - 1
+
+local HEADER_LEN = #st_pack(PACK_F, MAX_KEY_LEN, MAX_DATA_LEN)
+
+local SOCKET_PATH = "unix:" .. ngx.config.prefix() .. "/stream_rpc.sock"
 
 local stream_api = {}
 
 local _handlers  = {}
+
+
+-- # RPC format
+--
+-- RPC messages have a header and a body that are slightly different between
+-- request and response.
+--
+-- ## requests
+--
+-- Requests have two components:
+--  * key (string)
+--  * payload (string)
+--
+-- The request header is made up of:
+--
+-- |   key len     | payload len  |
+-- +---------------+--------------+
+-- | unsigned char | unsigned int |
+--
+-- The header is followed by the request body, which is simply the request key
+-- followed by the request payload (no separator).
+--
+-- ## responses
+--
+-- Responses have two components:
+--   * status (integer)
+--   * payload (string)
+--
+-- Responses have the same header length as requests, but with different
+-- meanings implied by each field:
+--
+-- |   status      | body/payload len  |
+-- +---------------+-------------------+
+-- | unsigned char |   unsigned int    |
+--
+-- The response header is followed by the response body, which is equal to the
+-- body/payload size in the header.
+
+
+--- Compose and send a stream API message.
+--
+-- Returns truth-y on success or `nil`, and an error string on failure.
+--
+-- @tparam  tcpsock       sock
+-- @tparam  string|number key_or_status
+-- @tparam  string        data
+-- @treturn boolean       ok
+-- @treturn string|nil    error
+local function send(sock, key_or_status, data)
+  local key
+  local key_len
+
+  local typ = type(key_or_status)
+
+  if typ == "number" then
+    -- we're sending a response, so the (numerical) status is simply encoded as
+    -- part of the header
+    key = ""
+    key_len = key_or_status
+
+  elseif typ == "string" then
+    -- we're sending a request, so the key length is included in the header,
+    -- while the key itself is part of the body
+    key = key_or_status
+    key_len = #key_or_status
+
+    if key_len == 0 then
+      return nil, "empty key"
+    end
+
+  else
+    return nil, "invalid type for key/status: " .. typ
+  end
+
+  if key_len > MAX_KEY_LEN then
+    return nil, "max key/status size exceeded"
+  end
+
+  local data_len = #data
+  if data_len > MAX_DATA_LEN then
+    return nil, "max data size exceeded"
+  end
+
+  local header = st_pack(PACK_F, key_len, data_len)
+  local msg = header .. key .. data
+
+  return sock:send(msg)
+end
+
+
+--- Send a stream API response.
+--
+-- The connection is closed if send() fails or when returning a non-zero
+-- status code.
+--
+-- @tparam tcpsock sock
+-- @tparam integer status
+-- @tparam string  msg
+local function send_response(sock, status, msg)
+  local sent, err = send(sock, status, msg)
+  if not sent then
+    log(ERR, "failed sending response: ", err)
+    return exit(CLOSE)
+  end
+
+  if status ~= 0 then
+    log(WARN, "closing connection due to non-zero status code")
+    return exit(CLOSE)
+  end
+
+  return true
+end
+
+
+--- Read the request/response header.
+--
+-- @tparam tcpsock sock
+--
+-- @treturn number|nil key_len
+-- @treturn string|nil data_len
+-- @treturn nil|string error
+local function recv_header(sock)
+  local header, err = sock:receive(HEADER_LEN)
+  if not header then
+    return nil, nil, err
+  end
+
+  local pos, key_len, data_len = st_unpack(header, PACK_F)
+
+  -- this probably shouldn't happen
+  if not (pos == (HEADER_LEN + 1) and key_len and data_len) then
+    return nil, nil, "invalid header/data received"
+  end
+
+  return key_len, data_len
+end
+
+--- Receive a stream API request from a downstream client.
+--
+-- @tparam tcpsock sock
+--
+-- @treturn string|nil handler request handler name (`nil` in case of failure)
+-- @treturn string|nil body    request payload (`nil` in case of failure)
+-- @treturn nil|string error   an error string
+local function recv_request(sock)
+  local key_len, data_len, err = recv_header(sock)
+  if not key_len then
+    return nil, nil, err
+  end
+
+  -- requests have the key size packed in the header with the actual key
+  -- at the head of the remaining data
+  local body_len = key_len + data_len
+
+  local body
+  body, err = sock:receive(body_len)
+  if not body then
+    -- need the caller to be able to differentiate between a timeout
+    -- while reading the header (normal) vs a timeout while reading the
+    -- request payload (not normal)
+    err = err == "timeout"
+          and "timeout while reading request body"
+          or err
+    return nil, nil, err
+  end
+
+  return body:sub(1, key_len), body:sub(key_len + 1)
+end
+
+
+--- Receive a stream API response from the server.
+--
+-- @tparam tcpsock sock
+--
+-- @treturn number|nil ok     response status code (`nil` in case of socket error)
+-- @treturn string|nil body   response payload (`nil` in case of socket error)
+-- @treturn nil|string error  an error string, returned for protocol or socket I/O failures
+local function recv_response(sock)
+  local status, body_len, err = recv_header(sock)
+  if not status then
+    return nil, nil, err
+  end
+
+  local body
+  body, err = sock:receive(body_len)
+  if not body then
+    return nil, nil, err
+  end
+
+  return status, body
+end
 
 
 function stream_api.load_handlers()
@@ -27,92 +241,119 @@ function stream_api.load_handlers()
   for plugin_name in pairs(kong.configuration.loaded_plugins) do
     local loaded, custom_endpoints = utils.load_module_if_exists("kong.plugins." .. plugin_name .. ".api")
     if loaded and custom_endpoints._stream then
-      kong.log.debug("Register stream api for plugin: ", plugin_name)
+      log(DEBUG, "Register stream api for plugin: ", plugin_name)
       _handlers[plugin_name] = custom_endpoints._stream
       custom_endpoints._stream = nil
     end
   end
 end
 
+
+--- Send a stream API request.
+--
+-- @tparam  string       key          API handler key/name
+-- @tparam  string       data         request payload
+-- @tparam  string|nil   socket_path  optional path to an alternate unix socket
+--
+-- @treturn string|nil   response
+-- @treturn nil|string   error
 function stream_api.request(key, data, socket_path)
   if type(key) ~= "string" or type(data) ~= "string" then
-    error("key and data must be strings")
-    return
+    return nil, "key and data must be strings"
   end
 
-  if #data > MAX_DATA_LEN then
-    error("too much data")
-  end
+  local sock = assert(tcp())
 
-  local socket = assert(ngx.socket.udp())
-  local ok, err = socket:setpeername(socket_path or "unix:" .. PREFIX .. "/stream_rpc.sock")
+  -- connect/send should always be fast here unless NGINX is really struggling,
+  -- but read might be slow depending on how long our handler takes to execute
+  sock:settimeouts(1000, 1000, 10000)
+
+  socket_path = socket_path or SOCKET_PATH
+
+  local ok, err = sock:connect(socket_path)
   if not ok then
     return nil, "opening internal RPC socket: " .. tostring(err)
   end
 
-  ok, err = socket:send(st_pack("=PP", key, data))
+  ok, err = send(sock, key, data)
   if not ok then
-    socket:close()
     return nil, "sending stream-api request: " .. tostring(err)
   end
 
-  data, err = socket:receive()
-  if not data then
-    socket:close()
+  local status, res
+  status, res, err = recv_response(sock)
+  if not status then
     return nil, "retrieving stream-api response: " .. tostring(err)
   end
 
-  local _, status, payload = st_unpack(data, "=SP")
   if status ~= 0 then
-    socket:close()
-    return nil, "stream-api errmsg: " .. payload
+    return nil, "stream-api err: " .. tostring(res or "unknown")
   end
 
-  socket:close()
-  return payload
+  ok, err = sock:setkeepalive()
+  if not ok then
+    log(WARN, "failed setting keepalive for request sock: ", err)
+  end
+
+  return res
 end
 
 
 function stream_api.handle()
-  local socket = ngx.req.socket()
-  local data, err = socket:receive()
-  if not data then
-    kong.log.error(err)
-    return
+  local sock = assert(req_socket())
+
+  -- keepalive is assumed here
+  while not exiting() do
+    local key, data, err = recv_request(sock)
+
+    if not key then
+      if err == "timeout" then
+        return exit(OK)
+      end
+
+      log(ERR, "failed receiving request: ", tostring(err))
+      return exit(CLOSE)
+    end
+
+    local f = _handlers[key]
+    if not f then
+      return send_response(sock, 1, "no handler")
+    end
+
+    local ok, res
+    ok, res, err = pcall(f, data)
+    if not ok then
+      return send_response(sock, 2, "handler exception: " .. tostring(res))
+
+    elseif not res then
+      return send_response(sock, 2, "handler error: " .. tostring(err))
+    end
+
+    if type(res) == "table" then
+      res = concat(res)
+    end
+
+    if type(res) ~= "string" then
+      log(ERR, "stream_api handler ", key, " response is not a string")
+
+      return send_response(sock, 3, "invalid handler response type")
+    end
+
+    if #res > MAX_DATA_LEN then
+      log(ERR, "stream_api handler ", key,
+                   " response size is > ", MAX_DATA_LEN, " (", #res, ")")
+
+      return send_response(sock, 4, "invalid handler response size")
+    end
+
+    if not send_response(sock, 0, res) then
+      return
+    end
   end
 
-  local _, key, payload = st_unpack(data, "=PP")
-
-  local f = _handlers[key]
-  if not f then
-    assert(socket:send(st_pack("=SP", 1, "no handler")))
-    return
-  end
-
-  local res
-  res, err = f(payload)
-  if not res then
-    kong.log.error(st_format("stream_api handler %q returned error: %q", key, err))
-    assert(socket:send(st_pack("=SP", 2, tostring(err))))
-    return
-  end
-
-  if type(res) == "table" then
-    res = table_concat(res)
-  end
-
-  if type(res) ~= "string" then
-    error(st_format("stream_api handler %q response is not a string", key))
-  end
-
-  if #res > MAX_DATA_LEN then
-    error(st_format(
-      "stream_api handler %q response is %d bytes.  Only %d bytes is supported",
-      key, #res, MAX_DATA_LEN))
-  end
-
-  assert(socket:send(st_pack("=SP", 0, res)))
+  return exit(OK)
 end
 
+stream_api.MAX_PAYLOAD_SIZE = MAX_DATA_LEN
 
 return stream_api

--- a/spec/02-integration/12-stream_api/01-stream_api_endpoint_spec.lua
+++ b/spec/02-integration/12-stream_api/01-stream_api_endpoint_spec.lua
@@ -1,5 +1,6 @@
 local helpers = require "spec.helpers"
 local stream_api = require "kong.tools.stream_api"
+local encode = require("cjson").encode
 
 describe("Stream module API endpoint", function()
 
@@ -23,14 +24,96 @@ describe("Stream module API endpoint", function()
     it("error response for unknown path", function()
       local res, err = stream_api.request("not-this", "nope", socket_path)
       assert.is.falsy(res)
-      assert.equal("stream-api errmsg: no handler", err)
+      assert.equal("stream-api err: no handler", err)
     end)
 
-    it("calls an echo handler", function ()
-      local res, err = stream_api.request("stream-api-echo", "ping!", socket_path)
-      assert.equal("back: ping!", res)
+    it("calls an echo handler", function()
+      local msg = encode { payload = "ping!" }
+      local res, err = stream_api.request("stream-api-echo", msg, socket_path)
       assert.is_nil(err)
+      assert.equal("ping!", res)
     end)
 
+    it("allows handlers to return tables and concatenates them", function()
+      local msg = encode { payload = { "a", "b", "c" } }
+      local res, err = stream_api.request("stream-api-echo", msg, socket_path)
+      assert.is_nil(err)
+      assert.equal("abc", res)
+    end)
+
+    it("can send/receive reasonably large payloads", function ()
+      local payload = string.rep("a", 1024 * 1024 * 2)
+      local msg = encode { payload = payload }
+      local res, err = stream_api.request("stream-api-echo", msg, socket_path)
+      assert.is_nil(err)
+      assert.equals(payload, res)
+
+      msg = encode { action = "rep", rep = stream_api.MAX_PAYLOAD_SIZE }
+      res, err = stream_api.request("stream-api-echo", msg, socket_path)
+      assert.is_nil(err)
+      assert.equals(string.rep("1", stream_api.MAX_PAYLOAD_SIZE), res)
+    end)
+  end)
+
+  describe("validation", function()
+    it("limits payload sizes", function()
+      local payload = string.rep("a", stream_api.MAX_PAYLOAD_SIZE + 1)
+      local res, err = stream_api.request("stream-api-echo", payload, socket_path)
+      assert.is_nil(res)
+      assert.not_nil(err)
+      assert.matches("max data size exceeded", err)
+    end)
+
+    it("limits request key sizes", function()
+      local key = string.rep("k", 2^8)
+      local res, err = stream_api.request(key, "test", socket_path)
+      assert.is_nil(res)
+      assert.not_nil(err)
+      assert.matches("max key/status size exceeded", err)
+    end)
+
+    it("only allows strings for request keys/data", function()
+      for _, typ in ipairs({ true, {}, 123, ngx.null }) do
+        local ok, err = stream_api.request("test", typ, socket_path)
+        assert.is_nil(ok)
+        assert.matches("key and data must be strings", err)
+
+        ok, err = stream_api.request(typ, "test", socket_path)
+        assert.is_nil(ok)
+        assert.matches("key and data must be strings", err)
+      end
+    end)
+  end)
+
+  describe("response error-handling", function()
+    it("returns nil, string when the handler returns an error", function()
+      local msg = encode { payload = nil, err = "test" }
+      local res, err = stream_api.request("stream-api-echo", msg, socket_path)
+      assert.is_nil(res)
+      assert.matches("handler error: test", err)
+    end)
+
+    it("returns nil, string when the handler throws an exception", function()
+      local msg = encode { action = "throw", err = "error!" }
+      local res, err = stream_api.request("stream-api-echo", msg, socket_path)
+      assert.is_nil(res)
+      assert.matches("error!", err)
+    end)
+
+    it("returns nil, string when the handler returns too much data", function()
+      local msg = encode { action = "rep", rep = stream_api.MAX_PAYLOAD_SIZE + 1 }
+      local res, err = stream_api.request("stream-api-echo", msg, socket_path)
+      assert.is_nil(res)
+      assert.matches("handler response size", err)
+    end)
+
+    it("returns nil, string when the handler returns a non-string or non-table", function()
+      for _, typ in ipairs({ true, 123, ngx.null }) do
+        local msg = encode { payload = typ }
+        local ok, err = stream_api.request("stream-api-echo", msg, socket_path)
+        assert.is_nil(ok)
+        assert.matches("invalid handler response type", err)
+      end
+    end)
   end)
 end)

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -955,7 +955,7 @@ server {
     include '*.stream_mock';
 
     server {        # ignore (and close }, to ignore content)
-        listen unix:${{PREFIX}}/stream_rpc.sock udp;
+        listen unix:${{PREFIX}}/stream_rpc.sock;
         error_log  ${{ADMIN_ERROR_LOG}} ${{LOG_LEVEL}};
         content_by_lua_block {
             Kong.stream_api()

--- a/spec/fixtures/custom_plugins/kong/plugins/stream-api-echo/api.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/stream-api-echo/api.lua
@@ -1,7 +1,19 @@
+local cjson_decode = require("cjson").decode
 
 
 return {
   _stream = function(data)
-    return "back: " .. data
+    local json = cjson_decode(data)
+    local action = json.action or "echo"
+
+    if action == "echo" then
+      return json.payload, json.err
+
+    elseif action == "rep" then
+      return string.rep("1", json.rep or 0)
+
+    elseif action == "throw" then
+      error(json.err or "error!")
+    end
   end,
 }


### PR DESCRIPTION
This re-implements the stream API with TCP instead of UDP in order to allow for larger response payloads without having to handle chunking/fragmenting things ourselves.

Performance-wise, keep-alive is used to cut down on per-request connection overhead, and the message payload is sent raw instead of being packed/unpacked on either side. I've done some unscientific testing locally with a single-threaded client and an API that simply echoes back the input payload. With a payload size of 8000 (the max of the current implementation) I am getting ~7-8k rps with the current implementation and ~8-9k rps with this new implementation. Things will obviously degrade from there with larger payload sizes, though I don't think I've raised the limit so high as to necessitate further optimizations (let me know if this is an incorrect assumption though).

Error-handling has also been reworked quite a bit, with many code paths that were previously throwing an exception (`error()`) replaced with logging and/or returning the error to the caller.

Fixes #7377