### PR TITLE
chore(build) Don't build debian jessie since this is failing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -155,7 +155,7 @@ pipeline {
                     steps {
                         sh 'echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin || true'
                         sh 'make setup-kong-build-tools'
-                        sh 'RESTY_IMAGE_TAG=jessie make release'
+                        // sh 'RESTY_IMAGE_TAG=jessie make release'
                         sh 'RESTY_IMAGE_TAG=stretch make release'
                     }
                 }


### PR DESCRIPTION
### Summary

2.7 is also not building it.


