### PR TITLE
tests(fixtures) use functions from pl_stringx

### DIFF
--- a/spec/fixtures/https_server.lua
+++ b/spec/fixtures/https_server.lua
@@ -9,7 +9,7 @@ local pl_dir = require "pl.dir"
 local pl_file = require "pl.file"
 local pl_template = require "pl.template"
 local pl_path = require "pl.path"
-local pl_text = require "pl.text"
+local pl_stringx = require "pl.stringx"
 local uuid = require "resty.jit-uuid"
 
 
@@ -56,7 +56,7 @@ local function create_conf(params)
     return nil, err
   end
 
-  local compiled_tpl = pl_text.Template(tpl:render(params, { ipairs = ipairs }))
+  local compiled_tpl = pl_stringx.Template(tpl:render(params, { ipairs = ipairs }))
   local conf_filename = params.base_path .. "/nginx.conf"
   local conf, err = io.open (conf_filename, "w")
   if err then


### PR DESCRIPTION
### Summary

Penlight functions that were in the `pl_text` module in previous releases are now in `pl_stringx`. This uses the correct module and avoids the display of warning messages.