### PR TITLE
hotfix(conf) make lua_ssl_trusted_certificate fail softly on launch

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1395,9 +1395,6 @@
                                         # - /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem (CentOS/RHEL 7)
                                         # - /etc/ssl/cert.pem (OpenBSD, Alpine)
                                         #
-                                        # If no file is found on any of these paths, an error will
-                                        # be raised.
-                                        #
                                         # `system` can be used by itself or in conjunction with other
                                         # CA filepaths.
                                         #

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -903,25 +903,28 @@ local function check_and_infer(conf, opts)
   if conf.lua_ssl_trusted_certificate then
     local new_paths = {}
 
-    for i, path in ipairs(conf.lua_ssl_trusted_certificate) do
+    for _, path in ipairs(conf.lua_ssl_trusted_certificate) do
       if path == "system" then
         local system_path, err = utils.get_system_trusted_certs_filepath()
         if system_path then
           path = system_path
 
         else
-          errors[#errors + 1] =
-            "lua_ssl_trusted_certificate: unable to locate system bundle - " ..
-            err
+
+          log.info("lua_ssl_trusted_certificate: unable to locate system bundle: " ..
+                     err ..
+                     ". Please set lua_ssl_trusted_certificate to a path with certificates" ..
+                     " in order to remove this message")
         end
       end
 
-      if not pl_path.exists(path) then
-        errors[#errors + 1] = "lua_ssl_trusted_certificate: no such file at " ..
-                               path
+      if path ~= "system" then
+        if not pl_path.exists(path) then
+          errors[#errors + 1] = "lua_ssl_trusted_certificate: no such file at " ..
+                                 path
+        end
+        new_paths[#new_paths + 1] = path
       end
-
-      new_paths[i] = path
     end
 
     conf.lua_ssl_trusted_certificate = new_paths

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -842,6 +842,27 @@ describe("Configuration loader", function()
             pl_path.abspath(system_path),
           }, conf.lua_ssl_trusted_certificate)
           assert.matches(".ca_combined", conf.lua_ssl_trusted_certificate_combined)
+
+          -- test default
+          local conf, _, errors = conf_loader(nil, {})
+          assert.is_nil(errors)
+          assert.same({
+            pl_path.abspath(system_path),
+          }, conf.lua_ssl_trusted_certificate)
+          assert.matches(".ca_combined", conf.lua_ssl_trusted_certificate_combined)
+        end)
+        it("does not throw errors if the host doesn't have system certificates", function()
+          local old_exists = pl_path.exists
+          finally(function()
+            pl_path.exists = old_exists
+          end)
+          pl_path.exists = function(path)
+            return false
+          end
+          local _, _, errors = conf_loader(nil, {
+            lua_ssl_trusted_certificate = "system",
+          })
+          assert.is_nil(errors)
         end)
         it("autoload cluster_cert or cluster_ca_cert for data plane in lua_ssl_trusted_certificate", function()
           local conf, _, errors = conf_loader(nil, {


### PR DESCRIPTION
When `system` was opt-in, it made sense to "fail noisily" if the current
system didn't have certs in any of the usual places and the user had
opted in to system.

Now that we look for them by default, the noisy behavior is incorrect,
because it makes kong unable to start in places with no system certs.
Instead, the abstence of default certificates gets *noted* in the logs,
but Kong can continue without them.

Related with #8602
