### PR TITLE
feat(schema) restrict host and port to avoid malicious configurations 

### DIFF
--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -665,8 +665,8 @@ local CONF_INFERENCES = {
   lmdb_environment_path = { typ = "string" },
   lmdb_map_size = { typ = "string" },
 
-  proxy_restricted_hosts = { typ = "array" },
-  proxy_restricted_ports = { typ = "array" },
+  proxy_denied_hosts = { typ = "array" },
+  proxy_denied_ports = { typ = "array" },
 }
 
 
@@ -1141,20 +1141,20 @@ local function check_and_infer(conf, opts)
     errors[#errors + 1] = "upstream_keepalive_idle_timeout must be 0 or greater"
   end
 
-  if conf.proxy_restricted_hosts then
-    for _, restricted_host in ipairs(conf.proxy_restricted_hosts) do
+  if conf.proxy_denied_hosts then
+    for _, restricted_host in ipairs(conf.proxy_denied_hosts) do
       if not utils.check_hostname(restricted_host) then
-        errors[#errors + 1] = "proxy_restricted_hosts contains invalid hostname: " ..
+        errors[#errors + 1] = "proxy_denied_hosts contains invalid hostname: " ..
                               restricted_host
       end
     end
   end
 
-  if conf.proxy_restricted_ports then
-    for _, restricted_port_str in ipairs(conf.proxy_restricted_ports) do
+  if conf.proxy_denied_ports then
+    for _, restricted_port_str in ipairs(conf.proxy_denied_ports) do
       local restricted_port = tonumber(restricted_port_str)
       if restricted_port < MIN_PORT or restricted_port > MAX_PORT then
-        errors[#errors + 1] = "proxy_restricted_ports contains invalid port: " ..
+        errors[#errors + 1] = "proxy_denied_ports contains invalid port: " ..
                               restricted_port
       end
     end

--- a/kong/db/schema/entities/services.lua
+++ b/kong/db/schema/entities/services.lua
@@ -14,8 +14,8 @@ local nonzero_timeout = Schema.define {
 }
 
 
-local default_protocol = "http"
-local default_port = 80
+local DEFAULT_PROTOCOL = "http"
+local DEFAULT_PORT = 80
 
 
 return {
@@ -31,9 +31,9 @@ return {
     { name               = typedefs.utf8_name },
     { retries            = { type = "integer", default = 5, between = { 0, 32767 } }, },
     -- { tags             = { type = "array", array = { type = "string" } }, },
-    { protocol           = typedefs.protocol { required = true, default = default_protocol } },
-    { host               = typedefs.host { required = true } },
-    { port               = typedefs.port { required = true, default = default_port }, },
+    { protocol           = typedefs.protocol { required = true, default = DEFAULT_PROTOCOL } },
+    { host               = typedefs.proxy_host { required = true } },
+    { port               = typedefs.proxy_port { required = true, default = DEFAULT_PORT }, },
     { path               = typedefs.path },
     { connect_timeout    = nonzero_timeout { default = 60000 }, },
     { write_timeout      = nonzero_timeout { default = 60000 }, },
@@ -88,7 +88,7 @@ return {
           prot = "https"
         end
 
-        local protocol = parsed_url.scheme or prot or default_protocol
+        local protocol = parsed_url.scheme or prot or DEFAULT_PROTOCOL
 
         return {
           protocol = protocol,
@@ -97,7 +97,7 @@ return {
                  parsed_url.port or
                  (protocol == "http"  and 80)  or
                  (protocol == "https" and 443) or
-                 default_port,
+                 DEFAULT_PORT,
           path = parsed_url.path or null,
         }
       end

--- a/kong/db/schema/entities/targets.lua
+++ b/kong/db/schema/entities/targets.lua
@@ -1,19 +1,4 @@
 local typedefs = require "kong.db.schema.typedefs"
-local utils = require "kong.tools.utils"
-
-
-local function validate_target(target)
-  local p = utils.normalize_ip(target)
-  if not p then
-    local ok = utils.validate_utf8(target)
-    if not ok then
-      return nil, "Invalid target; not a valid hostname or ip address"
-    end
-
-    return nil, "Invalid target ('" .. target .. "'); not a valid hostname or ip address"
-  end
-  return true
-end
 
 
 return {
@@ -26,7 +11,7 @@ return {
     { id = typedefs.uuid },
     { created_at = typedefs.auto_timestamp_ms },
     { upstream   = { type = "foreign", reference = "upstreams", required = true, on_delete = "cascade" }, },
-    { target     = { type = "string", required = true, custom_validator = validate_target, }, },
+    { target     = typedefs.proxy_target { required = true }, },
     { weight     = { type = "integer", default = 100, between = { 0, 65535 }, }, },
     { tags       = typedefs.tags },
   },

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -180,4 +180,7 @@ untrusted_lua_sandbox_requires =
 untrusted_lua_sandbox_environment =
 
 openresty_path =
+
+proxy_restricted_hosts = 169.254.169.254
+proxy_restricted_ports = 22, 2375, 3389
 ]]

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -181,6 +181,6 @@ untrusted_lua_sandbox_environment =
 
 openresty_path =
 
-proxy_restricted_hosts = 169.254.169.254
-proxy_restricted_ports = 22, 2375, 3389
+proxy_denied_hosts = 169.254.169.254
+proxy_denied_ports = 22, 2375, 3389
 ]]

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -1411,6 +1411,31 @@ describe("Configuration loader", function()
     end)
   end)
 
+  describe("proxy_restricted_* properties", function()
+    it("are accepted", function()
+      local conf = assert(conf_loader(nil, {
+        proxy_denied_hosts = "localhost, 127.0.0.1",
+        proxy_denied_ports = "22, 1000",
+      }))
+      assert.same({"localhost", "127.0.0.1"}, conf.proxy_denied_hosts)
+      assert.same({"22", "1000"}, conf.proxy_denied_ports)
+    end)
+
+    it("reject invalid values", function()
+      local conf, err = conf_loader(nil, {
+        proxy_denied_hosts = "-.ohno",
+      })
+      assert.is_nil(conf)
+      assert.equal("proxy_denied_hosts contains invalid hostname: -.ohno", err)
+
+      conf, err = conf_loader(nil, {
+        proxy_denied_ports = "22, 65536",
+      })
+      assert.is_nil(conf)
+      assert.equal("proxy_denied_ports contains invalid port: 65536", err)
+    end)
+  end)
+
   describe("errors", function()
     it("returns inexistent file", function()
       local conf, err = conf_loader "inexistent"

--- a/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -237,6 +237,34 @@ describe("Admin API #" .. strategy, function()
             local json = cjson.decode(body)
             assert.equal("schema violation", json.name)
             assert.same({ weight = "value should be between 0 and " .. weight_max }, json.fields)
+
+            -- Invalid port
+            res = assert(client:send {
+              method = "PUT",
+              path = "/upstreams/" .. upstream.name .. "/targets/",
+              body = {
+                target = "konghq.com:22",
+              },
+              headers = {["Content-Type"] = content_type}
+            })
+            body = assert.response(res).has.status(400)
+            local json = cjson.decode(body)
+            assert.equal("schema violation", json.name)
+            assert.same({ target = "proxying to port 22 is disabled" }, json.fields)
+
+            -- Invalid address
+            res = assert(client:send {
+              method = "PUT",
+              path = "/upstreams/" .. upstream.name .. "/targets/",
+              body = {
+                target = "169.254.169.254",
+              },
+              headers = {["Content-Type"] = content_type}
+            })
+            body = assert.response(res).has.status(400)
+            local json = cjson.decode(body)
+            assert.equal("schema violation", json.name)
+            assert.same({ target = "proxying to host 169.254.169.254 is disabled" }, json.fields)
           end
         end)
 

--- a/spec/02-integration/04-admin_api/10-services_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/10-services_routes_spec.lua
@@ -148,6 +148,27 @@ for _, strategy in helpers.each_strategy() do
             assert.res_status(400, res)
           end
         end)
+
+        it_content_types("client error with restricted url", function(content_type)
+          return function()
+            local res = client:post("/services", {
+              body = {
+                url = "http://169.254.169.254:80",
+              },
+              headers = { ["Content-Type"] = content_type },
+            })
+            assert.res_status(400, res)
+
+            res = client:post("/services", {
+              body = {
+                url = "http://example.hostname.test:2375",
+              },
+              headers = { ["Content-Type"] = content_type },
+            })
+            assert.res_status(400, res)
+          end
+        end)
+
       end)
 
       describe("GET", function()


### PR DESCRIPTION
### Summary

It's pretty rare that someone actually needs to set up an API gateway to proxy to some hosts and ports, yet these can be used by attackers to attack internal networks. This change adds a list of hosts and ports that can't be ever used, unless Kong is explicit told so.

### Full changelog

* Added new config properties `proxy_restricted_hosts` and  `proxy_restricted_ports`.
* Validate targets and services entities schema using new config properties.
* Added tests related to configuring new properties and related to creating targets and services.

FT-2125