### PR TITLE
chore(scripts) add missing update_docker function in release/2.8.x

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -604,6 +604,26 @@ function merge_docker() {
           "    $0 $version submit_docker"
 }
 
+
+#-------------------------------------------------------------------------------
+function update_docker {
+    if [ -d ../docker-kong ]
+    then
+        cd ../docker-kong
+    else
+        cd ..
+        git clone https://github.com/kong/docker-kong
+        cd docker-kong
+    fi
+
+    git pull
+    git checkout -B "release/$1"
+
+    set -e
+    ./update.sh "$1"
+}
+
+
 #-------------------------------------------------------------------------------
 function submit_docker() {
   version=$1


### PR DESCRIPTION
This function was removed by mistake on a script refactor (#8078).

It was cherry-picked back into the master branch (#8495) but not to the
release/2.8.x branch. It is not needed for kong to work, but it might be
needed in order to do the post-release steps of a hypothetical 2.8.2
release.
