### PR TITLE
fix(cp) do a pcall for all calls to export_deflated_reconfigure_payload

### DIFF
--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -481,7 +481,10 @@ function _M:handle_cp_websocket()
   self.clients[wb] = queue
 
   if not self.deflated_reconfigure_payload then
-    _, err = self:export_deflated_reconfigure_payload()
+    local ok, _, err = pcall(self.export_deflated_reconfigure_payload, self)
+    if not ok then
+      ngx_log(ngx_ERR, _log_prefix, "unable to export initial config from database: ", err, log_suffix)
+    end
   end
 
   if self.deflated_reconfigure_payload then
@@ -654,8 +657,8 @@ local function push_config_loop(premature, self, push_config_semaphore, delay)
     return
   end
 
-  local _, err = self:export_deflated_reconfigure_payload()
-  if err then
+  local ok, err = pcall(self.export_deflated_reconfigure_payload, self)
+  if not ok then
     ngx_log(ngx_ERR, _log_prefix, "unable to export initial config from database: ", err)
   end
 

--- a/kong/clustering/wrpc_control_plane.lua
+++ b/kong/clustering/wrpc_control_plane.lua
@@ -171,8 +171,8 @@ end
 
 function _M:push_config_one_client(client)
   if not self.config_call_rpc or not self.config_call_args then
-    local payload, err = self:export_deflated_reconfigure_payload()
-    if not payload then
+    local ok, err = pcall(self.export_deflated_reconfigure_payload, self)
+    if not ok then
       ngx_log(ngx_ERR, _log_prefix, "unable to export config from database: ", err)
       return
     end
@@ -558,8 +558,8 @@ local function push_config_loop(premature, self, push_config_semaphore, delay)
   end
 
   do
-    local _, err = self:export_deflated_reconfigure_payload()
-    if err then
+    local ok, err = pcall(self.export_deflated_reconfigure_payload, self)
+    if not ok then
       ngx_log(ngx_ERR, _log_prefix, "unable to export initial config from database: ", err)
     end
   end

--- a/kong/clustering/wrpc_control_plane.lua
+++ b/kong/clustering/wrpc_control_plane.lua
@@ -50,6 +50,13 @@ local _log_prefix = "[wrpc-clustering] "
 
 local wrpc_config_service
 
+
+local function handle_export_deflated_reconfigure_payload(self)
+  local ok, p_err, err = pcall(self.export_deflated_reconfigure_payload, self)
+  return ok, p_err or err
+end
+
+
 local function get_config_service(self)
   if not wrpc_config_service then
     wrpc_config_service = wrpc.new_service()
@@ -171,7 +178,7 @@ end
 
 function _M:push_config_one_client(client)
   if not self.config_call_rpc or not self.config_call_args then
-    local ok, err = pcall(self.export_deflated_reconfigure_payload, self)
+    local ok, err = handle_export_deflated_reconfigure_payload(self)
     if not ok then
       ngx_log(ngx_ERR, _log_prefix, "unable to export config from database: ", err)
       return
@@ -558,7 +565,7 @@ local function push_config_loop(premature, self, push_config_semaphore, delay)
   end
 
   do
-    local ok, err = pcall(self.export_deflated_reconfigure_payload, self)
+    local ok, err = handle_export_deflated_reconfigure_payload(self)
     if not ok then
       ngx_log(ngx_ERR, _log_prefix, "unable to export initial config from database: ", err)
     end


### PR DESCRIPTION
We are already wrapping some calls to
`export_deflated_reconfigure_payload()` inside a pcall in the
`control_plane.lua` file. This change is doing a pcall in all the
remaining calls to `export_deflated_reconfigure_payload()` in this file
to avoid the CP crash whenever we find errors during initialization of
modules for example.