### PR TITLE
chore(rockspec) replace git protocol by https

### DIFF
--- a/kong-2.8.1-0.rockspec
+++ b/kong-2.8.1-0.rockspec
@@ -3,7 +3,7 @@ version = "2.8.1-0"
 rockspec_format = "3.0"
 supported_platforms = {"linux", "macosx"}
 source = {
-  url = "git://github.com/Kong/kong",
+  url = "https://github.com/Kong/kong.git",
   tag = "2.8.1"
 }
 description = {


### PR DESCRIPTION
Luarocks upload was failing when trying to download the rock from
Github, which was failing with "The unauthenticated git protocol
on port 9418 is no longer supported". More information here:

https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git

We're replacing git with https, which is one of the fixes recommended on
that guide.
