### PR TITLE
chore(release) 2.8.1 post-release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+- [2.8.1](#281)
 - [2.8.0](#280)
 - [2.7.1](#271)
 - [2.7.0](#270)
@@ -171,8 +172,8 @@
   - `oauth2` changed from 1004 to 1400
   - `rate-limiting` changed from 901 to 910
 - **JWT**: The authenticated JWT is no longer put into the nginx
-  context (ngx.ctx.authenticated_jwt_token).  Custom plugins which depend on that 
-  value being set under that name must be updated to use Kong's shared context 
+  context (ngx.ctx.authenticated_jwt_token).  Custom plugins which depend on that
+  value being set under that name must be updated to use Kong's shared context
   instead (kong.ctx.shared.authenticated_jwt_token) before upgrading to 3.0
 
 ### Deprecations
@@ -344,6 +345,37 @@ a restart (e.g., upon a plugin server crash).
 
 - The cluster listener now uses the value of `admin_error_log` for its log file
   instead of `proxy_error_log` [8583](https://github.com/Kong/kong/pull/8583)
+
+
+### Additions
+
+#### Performance
+- Do not register unnecessary event handlers on Hybrid mode Control Plane
+nodes [#8452](https://github.com/Kong/kong/pull/8452).
+
+
+## [2.8.1]
+
+### Dependencies
+
+- Bumped lua-resty-healthcheck from 1.5.0 to 1.5.1
+  [#8584](https://github.com/Kong/kong/pull/8584)
+- Bumped `OpenSSL` from 1.1.1l to 1.1.1n
+  [#8635](https://github.com/Kong/kong/pull/8635)
+
+### Fixes
+
+#### Core
+
+- Only reschedule router and plugin iterator timers after finishing previous
+  execution, avoiding unnecessary concurrent executions.
+  [#8634](https://github.com/Kong/kong/pull/8634)
+- Implements conditional rebuilding of router, plugins iterator and balancer on
+  data planes. This means that DPs will not rebuild router if there were no
+  changes in routes or services. Similarly, the plugins iterator will not be
+  rebuilt if there were no changes to plugins, and, finally, the balancer will not be
+  reinitialized if there are no changes to upstreams or targets.
+  [#8639](https://github.com/Kong/kong/pull/8639)
 
 
 ## [2.8.0]
@@ -7148,6 +7180,7 @@ First version running with Cassandra.
 
 [Back to TOC](#table-of-contents)
 
+[2.8.1]: https://github.com/Kong/kong/compare/2.8.0...2.8.1
 [2.8.0]: https://github.com/Kong/kong/compare/2.7.0...2.8.0
 [2.7.1]: https://github.com/Kong/kong/compare/2.7.0...2.7.1
 [2.7.0]: https://github.com/Kong/kong/compare/2.6.0...2.7.0

--- a/kong-2.8.1-0.rockspec
+++ b/kong-2.8.1-0.rockspec
@@ -3,7 +3,7 @@ version = "2.8.1-0"
 rockspec_format = "3.0"
 supported_platforms = {"linux", "macosx"}
 source = {
-  url = "git://github.com/Kong/kong",
+  url = "https://github.com/Kong/kong.git",
   tag = "2.8.1"
 }
 description = {

--- a/kong-2.8.1-0.rockspec
+++ b/kong-2.8.1-0.rockspec
@@ -1,10 +1,10 @@
 package = "kong"
-version = "2.8.0-0"
+version = "2.8.1-0"
 rockspec_format = "3.0"
 supported_platforms = {"linux", "macosx"}
 source = {
   url = "git://github.com/Kong/kong",
-  tag = "2.8.0"
+  tag = "2.8.1"
 }
 description = {
   summary = "Kong is a scalable and customizable API Management Layer built on top of Nginx.",

--- a/kong/meta.lua
+++ b/kong/meta.lua
@@ -1,7 +1,7 @@
 local version = setmetatable({
   major = 2,
   minor = 8,
-  patch = 0,
+  patch = 1,
   --suffix = "rc.1"
 }, {
   -- our Makefile during certain releases adjusts this line. Any changes to


### PR DESCRIPTION
Steps required after the release of 2.8.1:

- Bumping Rockspec and Meta versions
- Changing rockspec protocol from git to http (see sister PR #8672 which modifies the `release/2.8.x` rockspec)
- Manual update of the changelog to include 2.8.1 changes.