### PR TITLE
ci(*) use kong/grpcbin instead of moul/grpcbin for arm64 support

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -144,7 +144,7 @@ jobs:
         options: --health-cmd pg_isready --health-interval 5s --health-timeout 5s --health-retries 8
 
       grpcbin:
-        image: moul/grpcbin
+        image: kong/grpcbin
         ports:
           - 15002:9000
           - 15003:9001


### PR DESCRIPTION
Let's use our kong/grpcbin image in CI until we get an official PR merged on the moul/grpcbin repo.

https://hub.docker.com/r/kong/grpcbin/tags