### PR TITLE
fix(api) support HTTP/2 status and metrics requests

### DIFF
--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -363,12 +363,6 @@ server {
         }
     }
 
-    location /nginx_status {
-        internal;
-        access_log off;
-        stub_status;
-    }
-
     location /robots.txt {
         return 200 'User-agent: *\nDisallow: /';
     }
@@ -408,17 +402,23 @@ server {
         }
     }
 
-    location /nginx_status {
-        internal;
-        access_log off;
-        stub_status;
-    }
-
     location /robots.txt {
         return 200 'User-agent: *\nDisallow: /';
     }
 }
 > end
+
+> if #status_listeners > 0 or (#admin_listeners > 0 and (role == "control_plane" or role == "traditional")) then
+server {
+    server_name nginx_status;
+    listen unix:${{PREFIX}}/nginx_status.sock;
+    error_log  ${{ADMIN_ERROR_LOG}} ${{LOG_LEVEL}};
+    location /nginx_status {
+        access_log off;
+        stub_status;
+    }
+}
+> end -- #status_listeners > 0 or (#admin_listeners > 0 and (role == "control_plane" or role == "traditional"))
 
 > if role == "control_plane" then
 server {

--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -1,4 +1,5 @@
 local helpers = require "spec.helpers"
+local pl_path = require "pl.path"
 
 
 for _, strategy in helpers.each_strategy() do
@@ -10,6 +11,14 @@ describe("kong start/stop #" .. strategy, function()
       "services",
     }) -- runs migrations
     helpers.prepare_prefix()
+  end)
+  before_each(function()
+    helpers.wait_until(function()
+      if pl_path.exists(helpers.test_conf.prefix .. "/nginx_status.sock") then
+        return false
+      end
+      return true
+    end, 10)
   end)
   after_each(function()
     helpers.kill_all()

--- a/spec/02-integration/04-admin_api/01-admin_api_spec.lua
+++ b/spec/02-integration/04-admin_api/01-admin_api_spec.lua
@@ -55,7 +55,7 @@ describe("Admin API listeners", function()
       admin_listen = "127.0.0.1:9001, 127.0.0.1:9002",
     }))
 
-    assert.equals(2, count_server_blocks(helpers.test_conf.nginx_kong_conf))
+    assert.equals(3, count_server_blocks(helpers.test_conf.nginx_kong_conf))
     assert.same({
       ["127.0.0.1:9001"] = 1,
       ["127.0.0.1:9002"] = 2,

--- a/spec/02-integration/05-proxy/01-proxy_spec.lua
+++ b/spec/02-integration/05-proxy/01-proxy_spec.lua
@@ -43,7 +43,7 @@ describe("Proxy interface listeners", function()
       proxy_listen = "off",
       admin_listen = "0.0.0.0:9001",
     }))
-    assert.equals(1, count_server_blocks(helpers.test_conf.nginx_kong_conf))
+    assert.equals(2, count_server_blocks(helpers.test_conf.nginx_kong_conf))
     assert.is_nil(get_listeners(helpers.test_conf.nginx_kong_conf).kong)
   end)
 
@@ -53,7 +53,7 @@ describe("Proxy interface listeners", function()
       admin_listen = "0.0.0.0:9000",
     }))
 
-    assert.equals(2, count_server_blocks(helpers.test_conf.nginx_kong_conf))
+    assert.equals(3, count_server_blocks(helpers.test_conf.nginx_kong_conf))
     assert.same({
       ["127.0.0.1:9001"] = 1,
       ["127.0.0.1:9002"] = 2,

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -385,12 +385,6 @@ http {
             }
         }
 
-        location /nginx_status {
-            internal;
-            access_log off;
-            stub_status;
-        }
-
         location /robots.txt {
             return 200 'User-agent: *\nDisallow: /';
         }
@@ -430,17 +424,22 @@ http {
             }
         }
 
-        location /nginx_status {
-            internal;
-            access_log off;
-            stub_status;
-        }
-
         location /robots.txt {
             return 200 'User-agent: *\nDisallow: /';
         }
     }
 > end
+
+> if #status_listeners > 0 or (#admin_listeners > 0 and (role == "control_plane" or role == "traditional")) then
+server {
+    listen unix:${{PREFIX}}/nginx_status.sock;
+    error_log  ${{ADMIN_ERROR_LOG}} ${{LOG_LEVEL}};
+    location /nginx_status {
+        access_log off;
+        stub_status;
+    }
+}
+> end -- #status_listeners > 0 or (#admin_listeners > 0 and (role == "control_plane" or role == "traditional"))
 
 > if role == "control_plane" then
     server {


### PR DESCRIPTION
### Summary

Rework the status and metrics endpoint implementations to make them not break on HTTP/2.

### Full changelog

* Add a new Unix socket listen that runs NGINX's stub_status on requests for /nginx_status at $PREFIX/nginx_status.sock.
* Use lua-resty-http to access the new status socket listen in the status endpoint instead of using ngx.location.capture (which breaks if invoked during an HTTP/2 request) on the existing internal locations.
* Ditto for Prometheus /metrics.

### Issue reference

Discovered that https://github.com/Kong/kubernetes-ingress-controller/pull/2343 did not work with HTTPS during post-release testing. We'd prefer to change the Kong end rather than disable HTTP/2 across the board on the controller end.

Implements @dndx's suggestion from https://github.com/Kong/kong/pull/8528

### Draft problems

Edit: https://github.com/Kong/kong/pull/8687/commits/671e15ebc289e53781197662d3419a5fea4bdb4e works around this: https://github.com/Kong/kong/pull/8687#issuecomment-1101803889

This exposes a [possible issue in spec/02-integration/02-cmd/02-start_stop_spec.lua](https://github.com/rainest/kong/runs/6030515315?check_suite_focus=true#step:9:173):

```
cat: /home/runner/work/kong/kong/servroot/pids/nginx.pid: No such file or directory
1146.04   OK 635: kong start/stop #postgres deprecated properties prints a warning to stderr client_max_body_size
        __________
        FAILED  spec/02-integration/02-cmd/02-start_stop_spec.lua:641: kong start/stop #postgres deprecated properties prints a warning to stderr client_body_buffer_size
spec/02-integration/02-cmd/02-start_stop_spec.lua:608: 2022/04/14 20:33:48 [warn] the 'client_body_buffer_size' configuration property is deprecated, use 'nginx_http_client_body_buffer_size' instead
Error: ./kong/cmd/start.lua:64: nginx: [emerg] bind() to unix:/home/runner/work/kong/kong/servroot/nginx_status.sock failed (98: Address already in use)
nginx: [emerg] bind() to unix:/home/runner/work/kong/kong/servroot/nginx_status.sock failed (98: Address already in use)
```
This change adds a unix socket that is almost always (either admin or status listen enabled) present. I think I'm hitting something in those tests that has multiple overlapping Kong instances. The `cat` error just before the conflict suggests we were trying to check if an instance was still up and/or kill it but failed due to a missing pidfile, but I'm not familiar enough with the tests to say for sure. I can't reproduce it when testing locally--I get no PID conflicts, just complaints about Cassandra and Postgres availability in 3 out of 39 tests. The issue flakes/does not occur consistently.

Manual testing (do we have HTTP/2 test client stuff yet?): [example.txt](https://github.com/Kong/kong/files/8492387/example.txt)