### PR TITLE
feat(pdk) add kong.request.get_start_time()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,6 +222,10 @@
   running Kong (instead of using the system-installed OpenResty)
   [#8412](https://github.com/Kong/kong/pull/8412)
 
+#### PDK
+- Added new PDK function: `kong.request.get_start_time()`
+  [#8688](https://github.com/Kong/kong/pull/8688)
+
 ### Fixes
 
 #### Core

--- a/kong/pdk/log.lua
+++ b/kong/pdk/log.lua
@@ -747,7 +747,6 @@ do
 
       local ctx = ongx.ctx
       local var = ongx.var
-      local req = ongx.req
 
       local authenticated_entity
       if ctx.authenticated_credential ~= nil then
@@ -809,7 +808,7 @@ do
         service = ctx.service,
         consumer = ctx.authenticated_consumer,
         client_ip = var.remote_addr,
-        started_at = ctx.KONG_PROCESSING_START or (req.start_time() * 1000)
+        started_at = okong.request.get_start_time(),
       })
     end
 
@@ -818,10 +817,10 @@ do
       check_phase(PHASES_LOG)
 
       local ongx = (options or {}).ngx or ngx
+      local okong = (options or {}).kong or kong
 
       local ctx = ongx.ctx
       local var = ongx.var
-      local req = ongx.req
 
       local authenticated_entity
       if ctx.authenticated_credential ~= nil then
@@ -865,7 +864,7 @@ do
         service = ctx.service,
         consumer = ctx.authenticated_consumer,
         client_ip = var.remote_addr,
-        started_at = ctx.KONG_PROCESSING_START or (req.start_time() * 1000)
+        started_at = okong.request.get_start_time(),
       })
     end
   end

--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -826,6 +826,21 @@ local function new(self)
     end
   end
 
+  ---
+  -- Returns the request start time, in Unix epoch milliseconds.
+  --
+  -- @function kong.request.get_start_time
+  -- @phases rewrite, access, header_filter, response, body_filter, log, admin_api
+  -- @treturn number The timestamp
+  -- @usage
+  -- kong.request.get_start_time() -- 1649960273000
+  function _REQUEST.get_start_time()
+    check_phase(PHASES.request)
+
+    return ngx.ctx.KONG_PROCESSING_START or (ngx.req.start_time() * 1000)
+  end
+
+
   return _REQUEST
 end
 

--- a/t/01-pdk/02-log/00-phase_checks.t
+++ b/t/01-pdk/02-log/00-phase_checks.t
@@ -62,6 +62,7 @@ qq{
                           get_query = function() return "query" end,
                           get_method = function() return "GET" end,
                           get_headers = function() return {} end,
+                          get_start_time = function() return 1 end,
                         },
                      }
                   }

--- a/t/01-pdk/04-request/00-phase_checks.t
+++ b/t/01-pdk/04-request/00-phase_checks.t
@@ -306,6 +306,18 @@ qq{
                 body_filter   = false,
                 log           = false,
                 admin_api     = true,
+            }, {
+                method        = "get_start_time",
+                args          = {},
+                init_worker   = "forced false",
+                certificate   = "pending",
+                rewrite       = true,
+                access        = true,
+                header_filter = true,
+                response      = true,
+                body_filter   = true,
+                log           = true,
+                admin_api     = true,
             },
         }
 

--- a/t/01-pdk/04-request/20-get_start_time.t
+++ b/t/01-pdk/04-request/20-get_start_time.t
@@ -1,0 +1,87 @@
+use strict;
+use warnings FATAL => 'all';
+use Test::Nginx::Socket::Lua;
+use Test::Nginx::Socket::Lua::Stream;
+do "./t/Util.pm";
+
+plan tests => repeat_each() * (blocks() * 3);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: request.get_start_time() uses ngx.ctx.KONG_PROCESSING_START when available
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location /t {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            ngx.ctx.KONG_PROCESSING_START = 10001
+            local start_time = pdk.request.get_start_time()
+
+            ngx.say("start_time: ", start_time)
+            ngx.say("type: ", type(start_time))
+        }
+    }
+--- request
+GET /t/request-path
+--- response_body
+start_time: 10001
+type: number
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: request.get_start_time() falls back to ngx.req.start_time() as needed
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location /t {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            ngx.ctx.KONG_PROCESSING_START = nil
+            local ngx_start = ngx.req.start_time() * 1000
+            local pdk_start = pdk.request.get_start_time()
+
+            if pdk_start ~= ngx_start then
+                ngx.status = 500
+                ngx.say("bad result from request.get_start_time(): ", pdk_start)
+                return ngx.exit(500)
+            end
+
+            ngx.say("start_time: ", pdk_start)
+            ngx.say("type: ", type(pdk_start))
+        }
+    }
+--- request
+GET /t/request-path
+--- response_body_like
+^start_time: \d+
+type: number
+--- no_error_log
+[error]
+
+
+
+=== TEST 3: request.get_start_time() works in the stream subsystem
+--- stream_server_config
+    content_by_lua_block {
+        local PDK = require "kong.pdk"
+        local pdk = PDK.new()
+
+        local start_time = pdk.request.get_start_time()
+        ngx.say("ngx.req: ", start_time, " ", type(start_time))
+
+        ngx.ctx.KONG_PROCESSING_START = 1000
+        start_time = pdk.request.get_start_time()
+        ngx.say("ngx.ctx: ", start_time, " ", type(start_time))
+    }
+--- stream_response_like chomp
+ngx.req: \d+ number
+ngx.ctx: 1000 number
+--- no_error_log
+[error]


### PR DESCRIPTION
### Summary

This adds `kong.request.get_start_time` as a PDK function. Before this change the business logic for computing this value was contained in `kong.log.serialize()`, so the only stable-ish API for fetching start time was `kong.log.serialize().started_at` (kind of wasteful/inelegant). Therefore this seems like a worthwhile inclusion to the PDK.

### Full changelog

* Add `kong.request.get_start_time` PDK function.
* Update `kong.log.serialize` to use `kong.request.get_start_time`