### PR TITLE
fix(admin) support HTTP/2 when requesting /status

### DIFF
--- a/kong/api/routes/health.lua
+++ b/kong/api/routes/health.lua
@@ -1,8 +1,9 @@
 local ffi = require("ffi")
-local C = ffi.C
 local utils = require "kong.tools.utils"
 local declarative = require "kong.db.declarative"
 
+local C = ffi.C
+local var = ngx.var
 local tonumber = tonumber
 local kong = kong
 local knode  = (kong and kong.node) and kong.node or
@@ -12,6 +13,23 @@ local knode  = (kong and kong.node) and kong.node or
 local dbless = kong.configuration.database == "off"
 local data_plane_role = kong.configuration.role == "data_plane"
 
+if ffi.arch == "x64" or ffi.arch == "arm64" then
+  ffi.cdef[[
+  uint64_t *ngx_stat_requests;
+  uint64_t *ngx_stat_accepted;
+  uint64_t *ngx_stat_handled;
+  ]]
+
+elseif ffi.arch == "x86" or ffi.arch == "arm" then
+  ffi.cdef[[
+  uint32_t *ngx_stat_requests;
+  uint32_t *ngx_stat_accepted;
+  uint32_t *ngx_stat_handled;
+  ]]
+
+else
+  kong.log.err("Unsupported arch: " .. ffi.arch)
+end
 
 return {
   ["/status"] = {
@@ -38,36 +56,6 @@ return {
       end
 
       -- nginx stats
-
-      if ffi.arch == "x64" or ffi.arch == "arm64" then
-        ffi.cdef[[
-        uint64_t *ngx_stat_requests;
-        uint64_t *ngx_stat_accepted;
-        uint64_t *ngx_stat_handled;
-        uint64_t *ngx_stat_active;
-        uint64_t *ngx_stat_reading;
-        uint64_t *ngx_stat_writing;
-        uint64_t *ngx_stat_waiting;
-        ]]
-      elseif ffi.arch == "x86" or ffi.arch == "arm" then
-        ffi.cdef[[
-        uint32_t *ngx_stat_requests;
-        uint32_t *ngx_stat_accepted;
-        uint32_t *ngx_stat_handled;
-        uint32_t *ngx_stat_active;
-        uint32_t *ngx_stat_reading;
-        uint32_t *ngx_stat_writing;
-        uint32_t *ngx_stat_waiting;
-        ]]
-      else
-        kong.log.err("Unsupported arch: " .. ffi.arch)
-      end
-
-      local accepted = C.ngx_stat_accepted[0]
-      local handled = C.ngx_stat_handled[0]
-      local total = C.ngx_stat_requests[0]
-
-      local var = ngx.var
       local status_response = {
         memory = knode.get_memory_stats(unit, scale),
         server = {
@@ -75,9 +63,9 @@ return {
           connections_reading = tonumber(var.connections_reading),
           connections_writing = tonumber(var.connections_writing),
           connections_waiting = tonumber(var.connections_waiting),
-          connections_accepted = tonumber(accepted),
-          connections_handled = tonumber(handled),
-          total_requests = tonumber(total)
+          connections_accepted = tonumber(C.ngx_stat_accepted[0]),
+          connections_handled = tonumber(C.ngx_stat_handled[0]),
+          total_requests = tonumber(C.ngx_stat_requests[0])
         },
         database = {
           reachable = true,

--- a/kong/api/routes/health.lua
+++ b/kong/api/routes/health.lua
@@ -3,17 +3,12 @@ local C = ffi.C
 local utils = require "kong.tools.utils"
 local declarative = require "kong.db.declarative"
 
-local find = string.find
-local select = select
 local tonumber = tonumber
 local kong = kong
 local knode  = (kong and kong.node) and kong.node or
                require "kong.pdk.node".new()
 
 
-local select = select
-local tonumber = tonumber
-local kong = kong
 local dbless = kong.configuration.database == "off"
 local data_plane_role = kong.configuration.role == "data_plane"
 

--- a/kong/pdk/nginx.lua
+++ b/kong/pdk/nginx.lua
@@ -53,7 +53,7 @@ local function new(self)
   ---
   -- Returns various connection and request metrics exposed by
   -- Nginx, similar to those reported by the
-  -- [ngx_http_stub_status_module](https://nginx.org/en/docs/http/ngx_http_stub_status_module.html#data)
+  -- [ngx_http_stub_status_module](https://nginx.org/en/docs/http/ngx_http_stub_status_module.html#data).
   --
   -- The following fields are included in the returned table:
   -- * `connections_active` - the current number of active client connections including `connections_waiting`.
@@ -61,7 +61,8 @@ local function new(self)
   -- * `connections_writing` - the current number of connections where nginx is writing the response back to the client.
   -- * `connections_waiting` - the current number of idle client connections waiting for a request.
   -- * `connections_accepted` - the total number of accepted client connections.
-  -- * `connections_handled` - the total number of handled connections. Same as `connections_accepted` unless resources limited (e.g. `worker_connections`)
+  -- * `connections_handled` - the total number of handled connections. Same as `connections_accepted` unless some resource limits have been reached
+  --   (for example, the [`worker_connections`](https://nginx.org/en/docs/ngx_core_module.html#worker_connections) limit).
   -- * `total_requests` - the total number of client requests.
   --
   -- @function kong.nginx.get_statistics

--- a/kong/pdk/nginx.lua
+++ b/kong/pdk/nginx.lua
@@ -52,7 +52,8 @@ local function new(self)
 
   ---
   -- Returns various connection and request metrics exposed by
-  -- Nginx ngx_http_stub_status_module
+  -- Nginx, similar to those reported by the
+  -- [ngx_http_stub_status_module](https://nginx.org/en/docs/http/ngx_http_stub_status_module.html#data)
   --
   -- The following fields are included in the returned table:
   -- * `connections_active` - the current number of active client connections including `connections_waiting`.

--- a/kong/pdk/nginx.lua
+++ b/kong/pdk/nginx.lua
@@ -10,11 +10,14 @@ local ffi = require "ffi"
 local C    = ffi.C
 local arch = ffi.arch
 local ngx  = ngx
-local var  = ngx.var
 local tonumber = tonumber
 
 if arch == "x64" or arch == "arm64" then
   ffi.cdef[[
+    uint64_t *ngx_stat_active;
+    uint64_t *ngx_stat_reading;
+    uint64_t *ngx_stat_writing;
+    uint64_t *ngx_stat_waiting;
     uint64_t *ngx_stat_requests;
     uint64_t *ngx_stat_accepted;
     uint64_t *ngx_stat_handled;
@@ -22,6 +25,10 @@ if arch == "x64" or arch == "arm64" then
 
 elseif arch == "x86" or arch == "arm" then
   ffi.cdef[[
+    uint32_t *ngx_stat_active;
+    uint32_t *ngx_stat_reading;
+    uint32_t *ngx_stat_writing;
+    uint32_t *ngx_stat_waiting;
     uint32_t *ngx_stat_requests;
     uint32_t *ngx_stat_accepted;
     uint32_t *ngx_stat_handled;
@@ -71,10 +78,10 @@ local function new(self)
   -- local nginx_statistics = kong.nginx.get_statistics()
   function _NGINX.get_statistics()
     return {
-      connections_active = tonumber(var.connections_active),
-      connections_reading = tonumber(var.connections_reading),
-      connections_writing = tonumber(var.connections_writing),
-      connections_waiting = tonumber(var.connections_waiting),
+      connections_active = tonumber(C.ngx_stat_active[0]),
+      connections_reading = tonumber(C.ngx_stat_reading[0]),
+      connections_writing = tonumber(C.ngx_stat_writing[0]),
+      connections_waiting = tonumber(C.ngx_stat_waiting[0]),
       connections_accepted = tonumber(C.ngx_stat_accepted[0]),
       connections_handled = tonumber(C.ngx_stat_handled[0]),
       total_requests = tonumber(C.ngx_stat_requests[0])

--- a/kong/pdk/nginx.lua
+++ b/kong/pdk/nginx.lua
@@ -4,8 +4,30 @@
 -- details and meta information.
 -- @module kong.nginx
 
+local ffi = require "ffi"
 
+
+local C   = ffi.C
 local ngx = ngx
+local var = ngx.var
+
+if ffi.arch == "x64" or ffi.arch == "arm64" then
+  ffi.cdef[[
+    uint64_t *ngx_stat_requests;
+    uint64_t *ngx_stat_accepted;
+    uint64_t *ngx_stat_handled;
+  ]]
+
+elseif ffi.arch == "x86" or ffi.arch == "arm" then
+  ffi.cdef[[
+    uint32_t *ngx_stat_requests;
+    uint32_t *ngx_stat_accepted;
+    uint32_t *ngx_stat_handled;
+  ]]
+
+else
+  kong.log.err("Unsupported arch: " .. ffi.arch)
+end
 
 
 local function new(self)
@@ -23,6 +45,25 @@ local function new(self)
   -- kong.nginx.get_subsystem() -- "http"
   function _NGINX.get_subsystem()
     return ngx.config.subsystem
+  end
+
+
+  ---
+  -- @function kong.nginx.get_statistics
+  --
+  -- @treturn table Nginx connections and requests statistics
+  -- @usage
+  -- local nginx_statistics = kong.nginx.get_statistics()
+  function _NGINX.get_statistics()
+    return {
+      connections_active = tonumber(var.connections_active),
+      connections_reading = tonumber(var.connections_reading),
+      connections_writing = tonumber(var.connections_writing),
+      connections_waiting = tonumber(var.connections_waiting),
+      connections_accepted = tonumber(C.ngx_stat_accepted[0]),
+      connections_handled = tonumber(C.ngx_stat_handled[0]),
+      total_requests = tonumber(C.ngx_stat_requests[0])
+    }
   end
 
 

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -363,12 +363,6 @@ server {
         }
     }
 
-    location /nginx_status {
-        internal;
-        access_log off;
-        stub_status;
-    }
-
     location /robots.txt {
         return 200 'User-agent: *\nDisallow: /';
     }
@@ -406,12 +400,6 @@ server {
         header_filter_by_lua_block {
             Kong.status_header_filter()
         }
-    }
-
-    location /nginx_status {
-        internal;
-        access_log off;
-        stub_status;
     }
 
     location /robots.txt {

--- a/spec/03-plugins/26-prometheus/05-metrics_spec.lua
+++ b/spec/03-plugins/26-prometheus/05-metrics_spec.lua
@@ -1,143 +1,155 @@
-local helpers = require "spec.helpers"    -- hard dependency
+local helpers = require "spec.helpers" -- hard dependency
 
 
 local ngx = ngx
 
-
 local fixtures = {
-    dns_mock = helpers.dns_mock.new({ mocks_only = true, }),
-    http_mock = {},
-    stream_mock = {},
+  dns_mock = helpers.dns_mock.new({
+    mocks_only = true
+  }),
+  http_mock = {},
+  stream_mock = {}
 }
-fixtures.dns_mock:A {
-    name = "mock.example.com",
-    address = "127.0.0.1",
+
+fixtures.dns_mock:A{
+  name = "mock.example.com",
+  address = "127.0.0.1"
 }
-fixtures.dns_mock:A {
-    name = "status.example.com",
-    address = "127.0.0.1",
+
+fixtures.dns_mock:A{
+  name = "status.example.com",
+  address = "127.0.0.1"
 }
 
 local status_api_port = helpers.get_available_port()
 
 
 for _, strategy in helpers.each_strategy() do
-    describe("Plugin: prometheus (metrics)", function()
-        local bp
-        local admin_ssl_client    -- admin_ssl_client (lua-resty-http) does not support h2
-        local proxy_ssl_client    -- proxy_ssl_client (lua-resty-http) does not support h2
-    
-        setup(function()
-            bp = helpers.get_db_utils(strategy,{
-                "services",
-                "routes",
-                "plugins",
-            })
-    
-            local mock_ssl_service = bp.services:insert {
-                name = "mock-ssl-service",
-                host = helpers.mock_upstream_ssl_host,
-                port = helpers.mock_upstream_ssl_port,
-                protocol = helpers.mock_upstream_ssl_protocol,
-            }
-            bp.routes:insert {
-                name = "mock-ssl-route",
-                protocols = { "https" },
-                hosts = { "mock.example.com" },
-                paths = { "/" },
-                service = { id = mock_ssl_service.id, },
-            }
+  describe("Plugin: prometheus (metrics)", function()
+    local bp
+    local admin_ssl_client -- admin_ssl_client (lua-resty-http) does not support h2
+    local proxy_ssl_client -- proxy_ssl_client (lua-resty-http) does not support h2
 
-            local status_api_ssl_service = bp.services:insert {
-                name = "status-api-ssl-service",
-                url = "https://127.0.0.1:" .. status_api_port .. "/metrics",
-            }
-            bp.routes:insert {
-                name = "status-api-ssl-route",
-                protocols = { "https", },
-                hosts = { "status.example.com", },
-                paths = { "/metrics", },
-                service = { id = status_api_ssl_service.id, },
-            }
-    
-            bp.plugins:insert{
-                name = "prometheus",    -- globally enabled
-            }
-    
-            assert(helpers.start_kong({
-                nginx_conf = "spec/fixtures/custom_nginx.template",
-                plugins = "bundled,prometheus",
-                status_listen = '127.0.0.1:' .. status_api_port .. ' ssl',    -- status api does not support h2
-                status_access_log = "logs/status_access.log",
-                status_error_log = "logs/status_error.log",
-            }, nil, nil, fixtures))
+    setup(function()
+      bp = helpers.get_db_utils(strategy, {"services", "routes", "plugins"})
 
-        end)
-    
-        teardown(function()
-            if admin_ssl_client then admin_ssl_client:close() end
-            if proxy_ssl_client then proxy_ssl_client:close() end
+      local mock_ssl_service = bp.services:insert{
+        name = "mock-ssl-service",
+        host = helpers.mock_upstream_ssl_host,
+        port = helpers.mock_upstream_ssl_port,
+        protocol = helpers.mock_upstream_ssl_protocol
+      }
+      bp.routes:insert{
+        name = "mock-ssl-route",
+        protocols = {"https"},
+        hosts = {"mock.example.com"},
+        paths = {"/"},
+        service = {
+            id = mock_ssl_service.id
+        }
+      }
 
-            helpers.stop_kong()
-        end)
-    
-        before_each(function()
-            admin_ssl_client = helpers.admin_client()
-            proxy_ssl_client = helpers.proxy_ssl_client()
-        end)
-      
-        after_each(function()
-            if admin_ssl_client then admin_ssl_client:close() end
-            if proxy_ssl_client then proxy_ssl_client:close() end
-        end)
+      local status_api_ssl_service = bp.services:insert{
+        name = "status-api-ssl-service",
+        url = "https://127.0.0.1:" .. status_api_port .. "/metrics"
+      }
+      bp.routes:insert{
+        name = "status-api-ssl-route",
+        protocols = {"https"},
+        hosts = {"status.example.com"},
+        paths = {"/metrics"},
+        service = {
+          id = status_api_ssl_service.id
+        }
+      }
 
-        it("expose Nginx connection metrics by admin API #a1.1", function()
-            local res = assert(admin_ssl_client:send {
-                method = "GET",
-                path   = "/metrics",
-            })
-            local body = assert.res_status(200, res)
-    
-            assert.matches('kong_nginx_metric_errors_total 0', body, nil, true)
-            assert.matches('kong_nginx_' .. ngx.config.subsystem .. '_current_connections{state="%w+"} %d+', body)
-        end)
+      bp.plugins:insert{
+        name = "prometheus" -- globally enabled
+      }
 
-        it("increments the count of proxied requests #p1.1", function()
-            local res = assert(proxy_ssl_client:send {
-                method = "GET",
-                path   = "/status/400",
-                headers = {
-                    ["Host"] = "mock.example.com",
-                },
-            })
-            assert.res_status(400, res)
-
-            helpers.wait_until(function()
-                local res = assert(admin_ssl_client:send{
-                    method = "GET",
-                    path = "/metrics",
-                })
-                local body = assert.res_status(200, res)
-
-                assert.matches('kong_nginx_metric_errors_total 0', body, nil, true)
-
-                return body:find('kong_http_status{service="mock-ssl-service",route="mock-ssl-route",code="400"} 1', nil, true)
-            end)
-        end)
-
-        it("expose Nginx connection metrics by status API #s1.1", function()
-            local res = assert(proxy_ssl_client:send {
-                method = "GET",
-                path   = "/metrics",
-                headers = {
-                    ["Host"] = "status.example.com",
-                },
-            })
-            local body = assert.res_status(200, res)
-
-            assert.matches('kong_nginx_metric_errors_total 0', body, nil, true)
-            assert.matches('kong_nginx_' .. ngx.config.subsystem .. '_current_connections{state="%w+"} %d+', body)
-        end)
+      assert(helpers.start_kong({
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+        plugins = "bundled,prometheus",
+        status_listen = '127.0.0.1:' .. status_api_port .. ' ssl', -- status api does not support h2
+        status_access_log = "logs/status_access.log",
+        status_error_log = "logs/status_error.log"
+      }, nil, nil, fixtures))
 
     end)
+
+    teardown(function()
+      if admin_ssl_client then
+        admin_ssl_client:close()
+      end
+      if proxy_ssl_client then
+        proxy_ssl_client:close()
+      end
+
+      helpers.stop_kong()
+    end)
+
+    before_each(function()
+      admin_ssl_client = helpers.admin_client()
+      proxy_ssl_client = helpers.proxy_ssl_client()
+    end)
+
+    after_each(function()
+      if admin_ssl_client then
+        admin_ssl_client:close()
+      end
+      if proxy_ssl_client then
+        proxy_ssl_client:close()
+      end
+    end)
+
+    it("expose Nginx connection metrics by admin API #a1.1", function()
+      local res = assert(admin_ssl_client:send{
+        method = "GET",
+        path = "/metrics"
+      })
+      local body = assert.res_status(200, res)
+
+      assert.matches('kong_nginx_metric_errors_total 0', body, nil, true)
+      assert.matches('kong_nginx_' .. ngx.config.subsystem .. '_current_connections{state="%w+"} %d+', body)
+    end)
+
+    it("increments the count of proxied requests #p1.1", function()
+      local res = assert(proxy_ssl_client:send{
+        method = "GET",
+        path = "/status/400",
+        headers = {
+          ["Host"] = "mock.example.com"
+        }
+      })
+      assert.res_status(400, res)
+
+      helpers.wait_until(function()
+        local res = assert(admin_ssl_client:send{
+          method = "GET",
+          path = "/metrics"
+        })
+        local body = assert.res_status(200, res)
+
+        assert.matches('kong_nginx_metric_errors_total 0', body, nil, true)
+
+        return body:find('kong_http_status{service="mock-ssl-service",route="mock-ssl-route",code="400"} 1',
+          nil, true)
+      end)
+    end)
+
+    it("expose Nginx connection metrics by status API #s1.1", function()
+      local res = assert(proxy_ssl_client:send{
+        method = "GET",
+        path = "/metrics",
+        headers = {
+          ["Host"] = "status.example.com"
+        }
+      })
+      local body = assert.res_status(200, res)
+
+      assert.matches('kong_nginx_metric_errors_total 0', body, nil, true)
+      assert.matches('kong_nginx_' .. ngx.config.subsystem .. '_current_connections{state="%w+"} %d+', body)
+    end)
+
+  end)
 end

--- a/spec/03-plugins/26-prometheus/05-metrics_spec.lua
+++ b/spec/03-plugins/26-prometheus/05-metrics_spec.lua
@@ -1,0 +1,39 @@
+local helpers = require "spec.helpers"
+
+describe("Plugin: prometheus (metrics)", function()
+    local admin_client
+
+    setup(function()
+        bp = helpers.get_db_utils()
+
+        bp.plugins:insert{
+            name = "prometheus",
+        }
+
+        assert(helpers.start_kong({
+            nginx_conf = "spec/fixtures/custom_nginx.template",
+            plugins = "bundled,prometheus",
+        }))
+
+        admin_client = helpers.admin_client()
+    end)
+
+    teardown(function()
+        if admin_client then
+            admin_client:close()
+        end
+
+        helpers.stop_kong()
+    end)
+
+    it("expose Nginx connection metrics", function()
+        local res = assert(admin_client:send {
+            method = "GET",
+            path   = "/metrics",
+        })
+        local body = assert.res_status(200, res)
+
+        assert.matches('kong_nginx_metric_errors_total 0', body, nil, true)
+        assert.matches('kong_nginx_http_current_connections{state="%w+"} %d+', body)
+    end)
+end)

--- a/spec/03-plugins/26-prometheus/05-metrics_spec.lua
+++ b/spec/03-plugins/26-prometheus/05-metrics_spec.lua
@@ -1,39 +1,143 @@
-local helpers = require "spec.helpers"
+local helpers = require "spec.helpers"    -- hard dependency
 
-describe("Plugin: prometheus (metrics)", function()
-    local admin_client
 
-    setup(function()
-        bp = helpers.get_db_utils()
+local ngx = ngx
 
-        bp.plugins:insert{
-            name = "prometheus",
-        }
 
-        assert(helpers.start_kong({
-            nginx_conf = "spec/fixtures/custom_nginx.template",
-            plugins = "bundled,prometheus",
-        }))
+local fixtures = {
+    dns_mock = helpers.dns_mock.new({ mocks_only = true, }),
+    http_mock = {},
+    stream_mock = {},
+}
+fixtures.dns_mock:A {
+    name = "mock.example.com",
+    address = "127.0.0.1",
+}
+fixtures.dns_mock:A {
+    name = "status.example.com",
+    address = "127.0.0.1",
+}
 
-        admin_client = helpers.admin_client()
+local status_api_port = helpers.get_available_port()
+
+
+for _, strategy in helpers.each_strategy() do
+    describe("Plugin: prometheus (metrics)", function()
+        local bp
+        local admin_ssl_client    -- admin_ssl_client (lua-resty-http) does not support h2
+        local proxy_ssl_client    -- proxy_ssl_client (lua-resty-http) does not support h2
+    
+        setup(function()
+            bp = helpers.get_db_utils(strategy,{
+                "services",
+                "routes",
+                "plugins",
+            })
+    
+            local mock_ssl_service = bp.services:insert {
+                name = "mock-ssl-service",
+                host = helpers.mock_upstream_ssl_host,
+                port = helpers.mock_upstream_ssl_port,
+                protocol = helpers.mock_upstream_ssl_protocol,
+            }
+            bp.routes:insert {
+                name = "mock-ssl-route",
+                protocols = { "https" },
+                hosts = { "mock.example.com" },
+                paths = { "/" },
+                service = { id = mock_ssl_service.id, },
+            }
+
+            local status_api_ssl_service = bp.services:insert {
+                name = "status-api-ssl-service",
+                url = "https://127.0.0.1:" .. status_api_port .. "/metrics",
+            }
+            bp.routes:insert {
+                name = "status-api-ssl-route",
+                protocols = { "https", },
+                hosts = { "status.example.com", },
+                paths = { "/metrics", },
+                service = { id = status_api_ssl_service.id, },
+            }
+    
+            bp.plugins:insert{
+                name = "prometheus",    -- globally enabled
+            }
+    
+            assert(helpers.start_kong({
+                nginx_conf = "spec/fixtures/custom_nginx.template",
+                plugins = "bundled,prometheus",
+                status_listen = '127.0.0.1:' .. status_api_port .. ' ssl',    -- status api does not support h2
+                status_access_log = "logs/status_access.log",
+                status_error_log = "logs/status_error.log",
+            }, nil, nil, fixtures))
+
+        end)
+    
+        teardown(function()
+            if admin_ssl_client then admin_ssl_client:close() end
+            if proxy_ssl_client then proxy_ssl_client:close() end
+
+            helpers.stop_kong()
+        end)
+    
+        before_each(function()
+            admin_ssl_client = helpers.admin_client()
+            proxy_ssl_client = helpers.proxy_ssl_client()
+        end)
+      
+        after_each(function()
+            if admin_ssl_client then admin_ssl_client:close() end
+            if proxy_ssl_client then proxy_ssl_client:close() end
+        end)
+
+        it("expose Nginx connection metrics by admin API #a1.1", function()
+            local res = assert(admin_ssl_client:send {
+                method = "GET",
+                path   = "/metrics",
+            })
+            local body = assert.res_status(200, res)
+    
+            assert.matches('kong_nginx_metric_errors_total 0', body, nil, true)
+            assert.matches('kong_nginx_' .. ngx.config.subsystem .. '_current_connections{state="%w+"} %d+', body)
+        end)
+
+        it("increments the count of proxied requests #p1.1", function()
+            local res = assert(proxy_ssl_client:send {
+                method = "GET",
+                path   = "/status/400",
+                headers = {
+                    ["Host"] = "mock.example.com",
+                },
+            })
+            assert.res_status(400, res)
+
+            helpers.wait_until(function()
+                local res = assert(admin_ssl_client:send{
+                    method = "GET",
+                    path = "/metrics",
+                })
+                local body = assert.res_status(200, res)
+
+                assert.matches('kong_nginx_metric_errors_total 0', body, nil, true)
+
+                return body:find('kong_http_status{service="mock-ssl-service",route="mock-ssl-route",code="400"} 1', nil, true)
+            end)
+        end)
+
+        it("expose Nginx connection metrics by status API #s1.1", function()
+            local res = assert(proxy_ssl_client:send {
+                method = "GET",
+                path   = "/metrics",
+                headers = {
+                    ["Host"] = "status.example.com",
+                },
+            })
+            local body = assert.res_status(200, res)
+
+            assert.matches('kong_nginx_metric_errors_total 0', body, nil, true)
+            assert.matches('kong_nginx_' .. ngx.config.subsystem .. '_current_connections{state="%w+"} %d+', body)
+        end)
+
     end)
-
-    teardown(function()
-        if admin_client then
-            admin_client:close()
-        end
-
-        helpers.stop_kong()
-    end)
-
-    it("expose Nginx connection metrics", function()
-        local res = assert(admin_client:send {
-            method = "GET",
-            path   = "/metrics",
-        })
-        local body = assert.res_status(200, res)
-
-        assert.matches('kong_nginx_metric_errors_total 0', body, nil, true)
-        assert.matches('kong_nginx_http_current_connections{state="%w+"} %d+', body)
-    end)
-end)
+end

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -385,12 +385,6 @@ http {
             }
         }
 
-        location /nginx_status {
-            internal;
-            access_log off;
-            stub_status;
-        }
-
         location /robots.txt {
             return 200 'User-agent: *\nDisallow: /';
         }
@@ -428,12 +422,6 @@ http {
             header_filter_by_lua_block {
                 Kong.status_header_filter()
             }
-        }
-
-        location /nginx_status {
-            internal;
-            access_log off;
-            stub_status;
         }
 
         location /robots.txt {

--- a/spec/fixtures/prometheus/metrics.conf
+++ b/spec/fixtures/prometheus/metrics.conf
@@ -10,9 +10,4 @@ server {
        }
    }
 
-   location /nginx_status {
-       internal;
-       access_log off;
-       stub_status;
-   }
 }

--- a/t/01-pdk/10-nginx/00-phase_checks.t
+++ b/t/01-pdk/10-nginx/00-phase_checks.t
@@ -52,6 +52,19 @@ qq{
                 log           = true,
                 admin_api     = true,
             },
+            {
+                method        = "get_statistics",
+                args          = nil,
+                init_worker   = true,
+                certificate   = "pending",
+                rewrite       = true,
+                access        = true,
+                header_filter = true,
+                body_filter   = true,
+                response      = true,
+                log           = true,
+                admin_api     = true,
+            },
         }
 
         phase_check_functions(phases.init_worker)

--- a/t/01-pdk/10-nginx/02-get_statistics.t
+++ b/t/01-pdk/10-nginx/02-get_statistics.t
@@ -1,0 +1,57 @@
+=begin
+1. Check test counts of plan
+2. Refer to https://openresty.gitbooks.io/programming-openresty/content/testing/
+=end
+=cut
+
+use strict;
+use warnings FATAL => 'all';
+use Test::Nginx::Socket::Lua;
+use Test::Nginx::Socket::Lua::Stream;
+do "./t/Util.pm";
+
+$ENV{TEST_NGINX_NXSOCK} ||= html_dir();
+
+plan tests => repeat_each() * (blocks() * 3);
+
+no_long_string();
+run_tests();
+
+
+__DATA__
+
+
+=== TEST 1: nginx.get_statistics()
+returns Nginx connections and requests states
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            local nginx_statistics = pdk.nginx.get_statistics()
+            local ngx = ngx
+            ngx.say("Nginx statistics:")
+            ngx.say("connections_active: ", nginx_statistics["connections_active"])
+            ngx.say("connections_reading: ", nginx_statistics["connections_reading"])
+            ngx.say("connections_writing: ", nginx_statistics["connections_writing"])
+            ngx.say("connections_waiting: ", nginx_statistics["connections_waiting"])
+            ngx.say("connections_accepted: ", nginx_statistics["connections_accepted"])
+            ngx.say("connections_handled: ", nginx_statistics["connections_handled"])
+            ngx.print("total_requests: ", nginx_statistics["total_requests"])
+        }
+    }
+--- request
+GET /t
+--- error_code: 200
+--- response_body_like eval
+qr/Nginx statistics:
+connections_active: \d+
+connections_reading: \d+
+connections_writing: \d+
+connections_waiting: \d+
+connections_accepted: \d+
+connections_handled: \d+/
+--- no_error_log
+[error]


### PR DESCRIPTION
:8444/status does not support HTTP/2 due to
"ngx.location.capture". Now use LuaJIT ffi to retrieve Nginx status
data.

The "/nginx_status" location block is left in nginx-kong.conf as other
components may depend on it.