### PR TITLE
chore(ci) changelog label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -20,8 +20,11 @@ core/db/migrations:
 core/db:
 - any: ['kong/db/**/*', '!kong/db/migrations/**/*']
 
+changelog:
+- CHANGELOG.md
+
 core/docs:
-- '**/*.md'
+- any: ['**/*.md', '!CHANGELOG.md']
 - 'kong/autodoc/**/*'
 
 core/language/go:


### PR DESCRIPTION
Any PR includes a changelog will add a “core/docs” label which is unnecessary, this PR added an extra label 'changelog' to detect changelog file changes.