### PR TITLE
fix(pdk) ignore user set Tranfer-Encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,13 @@
 
 ## Unreleased
 
+### Fixes
+
+#### PDK
+
+- `pdk.response.set_header()`, `pdk.response.set_headers()`, `pdk.response.exit()` now ignore and emit warnings for manually set `Transfer-Encoding` headers.
+  [#8698](https://github.com/Kong/kong/pull/8698)
+
 ### Breaking Changes
 
 #### Admin API
@@ -79,8 +86,6 @@
 
 - The PDK is no longer versioned
   [#8585](https://github.com/Kong/kong/pull/8585)
-- `pdk.response.set_header()`, `pdk.response.set_headers()`, `pdk.response.exit()` now ignore and emit warnings for mannually set `Transfer-Encoding` headers.
-  [#8698](https://github.com/Kong/kong/pull/8698)
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 
 - The PDK is no longer versioned
   [#8585](https://github.com/Kong/kong/pull/8585)
+- `pdk.response.set_header()`, `pdk.response.set_headers()`, `pdk.response.exit()` now ignore and emit warnings for mannually set `Transfer-Encoding` headers.
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@
 - The PDK is no longer versioned
   [#8585](https://github.com/Kong/kong/pull/8585)
 - `pdk.response.set_header()`, `pdk.response.set_headers()`, `pdk.response.exit()` now ignore and emit warnings for mannually set `Transfer-Encoding` headers.
+  [#8698](https://github.com/Kong/kong/pull/8698)
 
 ### Deprecations
 

--- a/kong/pdk/response.lua
+++ b/kong/pdk/response.lua
@@ -408,6 +408,11 @@ local function new(self, major_version)
     end
 
     validate_header(name, value)
+    local lower_name = lower(name)
+    if lower_name == "transfer-encoding" or lower_name == "transfer_encoding" then
+      self.log.warn("mannually setting Transfer-Encoding. Ignored.")
+      return
+    end
 
     ngx.header[name] = normalize_header(value)
   end
@@ -514,7 +519,12 @@ local function new(self, major_version)
     validate_headers(headers)
 
     for name, value in pairs(headers) do
-      ngx.header[name] = normalize_multi_header(value)
+      local lower_name = lower(name)
+      if lower_name == "transfer-encoding" or lower_name == "transfer_encoding" then
+        self.log.warn("mannually setting Transfer-Encoding. Ignored.")
+      else
+        ngx.header[name] = normalize_multi_header(value)
+      end
     end
   end
 
@@ -645,8 +655,13 @@ local function new(self, major_version)
     if headers ~= nil then
       for name, value in pairs(headers) do
         ngx.header[name] = normalize_multi_header(value)
+        local lower_name = lower(name)
+        if lower_name == "transfer-encoding" or lower_name == "transfer_encoding" then
+          self.log.warn("mannually setting Transfer-Encoding. Ignored.")
+        else
+          ngx.header[name] = normalize_multi_header(value)
+        end
         if not has_content_type or not has_content_length then
-          local lower_name = lower(name)
           if lower_name == "content-type"
           or lower_name == "content_type"
           then

--- a/kong/pdk/response.lua
+++ b/kong/pdk/response.lua
@@ -392,6 +392,7 @@ local function new(self, major_version)
   --
   -- Be aware that changing this setting might break any plugins that
   -- rely on the automatic underscore conversion.
+  -- You cannot set Transfer-Encoding header with this function. It will be ignored.
   --
   -- @function kong.response.set_header
   -- @phases rewrite, access, header_filter, response, admin_api
@@ -410,7 +411,7 @@ local function new(self, major_version)
     validate_header(name, value)
     local lower_name = lower(name)
     if lower_name == "transfer-encoding" or lower_name == "transfer_encoding" then
-      self.log.warn("mannually setting Transfer-Encoding. Ignored.")
+      self.log.warn("manually setting Transfer-Encoding. Ignored.")
       return
     end
 
@@ -492,6 +493,8 @@ local function new(self, major_version)
   -- This function overrides any existing header bearing the same name as those
   -- specified in the `headers` argument. Other headers remain unchanged.
   --
+  -- You cannot set Transfer-Encoding header with this function. It will be ignored.
+  --
   -- @function kong.response.set_headers
   -- @phases rewrite, access, header_filter, response, admin_api
   -- @tparam table headers
@@ -521,7 +524,7 @@ local function new(self, major_version)
     for name, value in pairs(headers) do
       local lower_name = lower(name)
       if lower_name == "transfer-encoding" or lower_name == "transfer_encoding" then
-        self.log.warn("mannually setting Transfer-Encoding. Ignored.")
+        self.log.warn("manually setting Transfer-Encoding. Ignored.")
       else
         ngx.header[name] = normalize_multi_header(value)
       end
@@ -657,7 +660,7 @@ local function new(self, major_version)
         ngx.header[name] = normalize_multi_header(value)
         local lower_name = lower(name)
         if lower_name == "transfer-encoding" or lower_name == "transfer_encoding" then
-          self.log.warn("mannually setting Transfer-Encoding. Ignored.")
+          self.log.warn("manually setting Transfer-Encoding. Ignored.")
         else
           ngx.header[name] = normalize_multi_header(value)
         end

--- a/t/01-pdk/08-response/05-set_header.t
+++ b/t/01-pdk/08-response/05-set_header.t
@@ -248,3 +248,32 @@ type: string
 X-Foo: {}
 --- no_error_log
 [error]
+
+
+
+=== TEST 8: response.set_header() does not set transfer-encoding
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        header_filter_by_lua_block {
+            ngx.header.content_length = nil
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            pdk.response.set_header("Transfer-Encoding", "gzip")
+            ngx.status = 200
+        }
+
+        body_filter_by_lua_block {
+            local new_headers = ngx.resp.get_headers()
+
+            ngx.arg[1] = "Transfer-Encoding: " ..  new_headers["Transfer-Encoding"]
+            ngx.arg[2] = true
+        }
+    }
+--- request
+GET /t
+--- response_body chop
+Transfer-Encoding: chunked
+--- error_log
+mannually setting Transfer-Encoding. Ignored.

--- a/t/01-pdk/08-response/05-set_header.t
+++ b/t/01-pdk/08-response/05-set_header.t
@@ -276,4 +276,4 @@ GET /t
 --- response_body chop
 Transfer-Encoding: chunked
 --- error_log
-mannually setting Transfer-Encoding. Ignored.
+manually setting Transfer-Encoding. Ignored.

--- a/t/01-pdk/08-response/08-set_headers.t
+++ b/t/01-pdk/08-response/08-set_headers.t
@@ -642,7 +642,7 @@ X-Foo: {zzz}
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
 
-            local ok, err pdk.response.set_headers({})
+            local ok, err = pdk.response.set_headers({})
             if not ok then
                 ngx.ctx.err = err
             end
@@ -698,3 +698,37 @@ Content-Type: text/plain
 ok
 --- no_error_log
 [error]
+
+
+
+=== TEST 18: response.set_header() does not set transfer-encoding
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        header_filter_by_lua_block {
+            ngx.header.content_length = nil
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            pdk.response.set_headers {
+                ["Transfer-Encoding"] = "gzip",
+                ["X-test"] = "test",
+            }
+            ngx.status = 200
+        }
+
+        body_filter_by_lua_block {
+            local new_headers = ngx.resp.get_headers()
+
+            ngx.arg[1] = "Transfer-Encoding: " ..  new_headers["Transfer-Encoding"] .. "\n"
+                .. "X-test: " ..  new_headers["X-test"]
+            ngx.arg[2] = true
+        }
+    }
+--- request
+GET /t
+--- response_body chop
+Transfer-Encoding: chunked
+X-test: test
+--- error_log
+mannually setting Transfer-Encoding. Ignored.

--- a/t/01-pdk/08-response/08-set_headers.t
+++ b/t/01-pdk/08-response/08-set_headers.t
@@ -731,4 +731,4 @@ GET /t
 Transfer-Encoding: chunked
 X-test: test
 --- error_log
-mannually setting Transfer-Encoding. Ignored.
+manually setting Transfer-Encoding. Ignored.

--- a/t/01-pdk/08-response/11-exit.t
+++ b/t/01-pdk/08-response/11-exit.t
@@ -4,7 +4,7 @@ use Test::Nginx::Socket::Lua;
 use Test::Nginx::Socket::Lua::Stream;
 do "./t/Util.pm";
 
-plan tests => repeat_each() * (blocks() * 4) + 10;
+plan tests => repeat_each() * (blocks() * 4) + 11;
 
 run_tests();
 

--- a/t/01-pdk/08-response/11-exit.t
+++ b/t/01-pdk/08-response/11-exit.t
@@ -1132,15 +1132,15 @@ finalize stream session: 200
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
-        header_filter_by_lua_block {
+        access_by_lua_block {
             ngx.header.content_length = nil
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
 
-            pdk.response.exit(200, "test", {
+            pdk.response.exit(200, "test\n", {
                 ["Transfer-Encoding"] = "gzip",
                 ["X-test"] = "test",
-            }
+            })
         }
     }
 --- request
@@ -1148,7 +1148,9 @@ GET /t
 --- response_body
 test
 --- response_headers
-Content-Length: 4
+Content-Length: 5
 X-test: test
 --- error_log
 mannually setting Transfer-Encoding. Ignored.
+
+

--- a/t/01-pdk/08-response/11-exit.t
+++ b/t/01-pdk/08-response/11-exit.t
@@ -1151,6 +1151,6 @@ test
 Content-Length: 5
 X-test: test
 --- error_log
-mannually setting Transfer-Encoding. Ignored.
+manually setting Transfer-Encoding. Ignored.
 
 

--- a/t/01-pdk/08-response/11-exit.t
+++ b/t/01-pdk/08-response/11-exit.t
@@ -1125,3 +1125,30 @@ unable to proxy stream connection, status: 400, err: error message
 [error]
 --- error_log
 finalize stream session: 200
+
+
+
+=== TEST 18: response.exit() does not set transfer-encoding from headers
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        header_filter_by_lua_block {
+            ngx.header.content_length = nil
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            pdk.response.exit(200, "test", {
+                ["Transfer-Encoding"] = "gzip",
+                ["X-test"] = "test",
+            }
+        }
+    }
+--- request
+GET /t
+--- response_body
+test
+--- response_headers
+Content-Length: 4
+X-test: test
+--- error_log
+mannually setting Transfer-Encoding. Ignored.


### PR DESCRIPTION
Users should not set the Tranfer-Encoding header and it is also not supported by OpenResty.

Fix #8083

Fix CT-312
