### PR TITLE
feat(balancer) add path, uri_capture, and query as hash sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,8 @@
   Build-in instrumentation types and sampling rate are configuable through
   `opentelemetry_tracing` and `opentelemetry_tracing_sampling_rate` options.
  [#8724](https://github.com/Kong/kong/pull/8724)
+- Added `path`, `uri_capture`, and `query_arg` options to upstream `hash_on`
+  for load balancing. [#8701](https://github.com/Kong/kong/pull/8701)
 
 #### Plugins
 

--- a/kong/db/migrations/core/016_280_to_300.lua
+++ b/kong/db/migrations/core/016_280_to_300.lua
@@ -253,6 +253,42 @@ return {
           -- Do nothing, accept existing state
         END;
       $$;
+
+      -- add new hash_on_query_arg field to upstreams
+      DO $$
+        BEGIN
+          ALTER TABLE IF EXISTS ONLY "upstreams" ADD "hash_on_query_arg" TEXT;
+        EXCEPTION WHEN DUPLICATE_COLUMN THEN
+          -- Do nothing, accept existing state
+        END;
+      $$;
+
+      -- add new hash_fallback_query_arg field to upstreams
+      DO $$
+        BEGIN
+          ALTER TABLE IF EXISTS ONLY "upstreams" ADD "hash_fallback_query_arg" TEXT;
+        EXCEPTION WHEN DUPLICATE_COLUMN THEN
+          -- Do nothing, accept existing state
+        END;
+      $$;
+
+      -- add new hash_on_uri_capture field to upstreams
+      DO $$
+        BEGIN
+          ALTER TABLE IF EXISTS ONLY "upstreams" ADD "hash_on_uri_capture" TEXT;
+        EXCEPTION WHEN DUPLICATE_COLUMN THEN
+          -- Do nothing, accept existing state
+        END;
+      $$;
+
+      -- add new hash_fallback_uri_capture field to upstreams
+      DO $$
+        BEGIN
+          ALTER TABLE IF EXISTS ONLY "upstreams" ADD "hash_fallback_uri_capture" TEXT;
+        EXCEPTION WHEN DUPLICATE_COLUMN THEN
+          -- Do nothing, accept existing state
+        END;
+      $$;
     ]],
     teardown = function(connector)
       local _, err = connector:query([[
@@ -289,6 +325,18 @@ return {
 
       ALTER TABLE targets ADD cache_key text;
       CREATE INDEX IF NOT EXISTS targets_cache_key_idx ON targets(cache_key);
+
+      -- add new hash_on_query_arg field to upstreams
+      ALTER TABLE upstreams ADD hash_on_query_arg text;
+
+      -- add new hash_fallback_query_arg field to upstreams
+      ALTER TABLE upstreams ADD hash_fallback_query_arg text;
+
+      -- add new hash_on_uri_capture field to upstreams
+      ALTER TABLE upstreams ADD hash_on_uri_capture text;
+
+      -- add new hash_fallback_uri_capture field to upstreams
+      ALTER TABLE upstreams ADD hash_fallback_uri_capture text;
     ]],
     teardown = function(connector)
       local coordinator = assert(connector:get_stored_connection())

--- a/spec/01-unit/01-db/01-schema/09-upstreams_spec.lua
+++ b/spec/01-unit/01-db/01-schema/09-upstreams_spec.lua
@@ -142,7 +142,89 @@ describe("load upstreams", function()
     ok, errs = validate({ hash_on = "ip", hash_fallback = "ip" })
     assert.falsy(ok)
     assert.truthy(errs.hash_fallback)
+    ok, errs = validate({ hash_on = "path", hash_fallback = "path" })
+    assert.falsy(ok)
+    assert.truthy(errs.hash_fallback)
   end)
+
+  it("hash_on = 'query_arg' makes hash_on_query_arg required", function()
+    local ok, errs = validate({ hash_on = "query_arg" })
+    assert.falsy(ok)
+    assert.truthy(errs.hash_on_query_arg)
+  end)
+
+  it("hash_fallback = 'query_arg' makes hash_fallback_query_arg required", function()
+    local ok, errs = validate({ hash_on = "ip", hash_fallback = "query_arg" })
+    assert.falsy(ok)
+    assert.truthy(errs.hash_fallback_query_arg)
+  end)
+
+  it("hash_on and hash_fallback must be different query args", function()
+    local ok, errs = validate({ hash_on = "query_arg", hash_on_query_arg = "same",
+                                hash_fallback = "query_arg", hash_fallback_query_arg = "same" })
+    assert.falsy(ok)
+    assert.not_nil(errs["@entity"])
+    assert.same(
+      {
+        "values of these fields must be distinct: 'hash_on_query_arg', 'hash_fallback_query_arg'"
+      },
+      errs["@entity"]
+    )
+  end)
+
+  it("hash_on_query_arg and hash_fallback_query_arg must not be empty strings", function()
+    local ok, errs = validate({
+      name = "test",
+      hash_on = "query_arg",
+      hash_on_query_arg = "",
+    })
+    assert.is_nil(ok)
+    assert.not_nil(errs.hash_on_query_arg)
+
+    ok, errs = validate({
+      name = "test",
+      hash_on = "query_arg",
+      hash_on_query_arg = "ok",
+      hash_fallback = "query_arg",
+      hash_fallback_query_arg = "",
+    })
+    assert.is_nil(ok)
+    assert.not_nil(errs.hash_fallback_query_arg)
+  end)
+
+  it("hash_on and hash_fallback must be different uri captures", function()
+    local ok, errs = validate({ hash_on = "uri_capture", hash_on_uri_capture = "same",
+                                hash_fallback = "uri_capture", hash_fallback_uri_capture = "same" })
+    assert.falsy(ok)
+    assert.not_nil(errs["@entity"])
+    assert.same(
+      {
+        "values of these fields must be distinct: 'hash_on_uri_capture', 'hash_fallback_uri_capture'"
+      },
+      errs["@entity"]
+    )
+  end)
+
+  it("hash_on_uri_capture and hash_fallback_uri_capture must not be empty strings", function()
+    local ok, errs = validate({
+      name = "test",
+      hash_on = "uri_capture",
+      hash_on_uri_capture = "",
+    })
+    assert.is_nil(ok)
+    assert.not_nil(errs.hash_on_uri_capture)
+
+    ok, errs = validate({
+      name = "test",
+      hash_on = "uri_capture",
+      hash_on_uri_capture = "ok",
+      hash_fallback = "uri_capture",
+      hash_fallback_uri_capture = "",
+    })
+    assert.is_nil(ok)
+    assert.not_nil(errs.hash_fallback_uri_capture)
+  end)
+
 
   it("produces defaults", function()
     local u = {

--- a/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
+++ b/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
@@ -1770,6 +1770,10 @@ describe("declarative config: flatten", function()
                 hash_on_cookie = null,
                 hash_on_cookie_path = "/",
                 hash_on_header = null,
+                hash_on_query_arg = null,
+                hash_fallback_query_arg = null,
+                hash_on_uri_capture = null,
+                hash_fallback_uri_capture = null,
                 healthchecks = {
                   active = {
                     concurrency = 10,
@@ -1822,6 +1826,10 @@ describe("declarative config: flatten", function()
                 hash_on_cookie = null,
                 hash_on_cookie_path = "/",
                 hash_on_header = null,
+                hash_on_query_arg = null,
+                hash_fallback_query_arg = null,
+                hash_on_uri_capture = null,
+                hash_fallback_uri_capture = null,
                 healthchecks = {
                   active = {
                     concurrency = 10,

--- a/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
@@ -242,7 +242,7 @@ describe("Admin API: #" .. strategy, function()
             body = assert.res_status(400, res)
             local json = cjson.decode(body)
             assert.equals("schema violation", json.name)
-            assert.same({ hash_on = "expected one of: none, consumer, ip, header, cookie" }, json.fields)
+            assert.same({ hash_on = "expected one of: none, consumer, ip, header, cookie, path, query_arg, uri_capture" }, json.fields)
 
             -- Invalid hash_fallback entries
             res = assert(client:send {
@@ -260,7 +260,7 @@ describe("Admin API: #" .. strategy, function()
             assert.equals("schema violation", json.name)
             assert.same({
               ["@entity"] = { [[failed conditional validation given value of field 'hash_on']] },
-              hash_fallback = "expected one of: none, ip, header, cookie",
+              hash_fallback = "expected one of: none, ip, header, cookie, path, query_arg, uri_capture",
             }, json.fields)
 
             -- same hash entries
@@ -278,7 +278,7 @@ describe("Admin API: #" .. strategy, function()
             local json = cjson.decode(body)
             assert.same({
               ["@entity"] = { [[failed conditional validation given value of field 'hash_on']] },
-              hash_fallback = "expected one of: none, ip, header, cookie",
+              hash_fallback = "expected one of: none, ip, header, cookie, path, query_arg, uri_capture",
             }, json.fields)
 
             -- Invalid header

--- a/spec/02-integration/05-proxy/10-balancer/03-consistent-hashing_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer/03-consistent-hashing_spec.lua
@@ -23,6 +23,7 @@ for _, strategy in helpers.each_strategy() do
           assert(helpers.start_kong({
             database   = strategy,
             nginx_conf = "spec/fixtures/custom_nginx.template",
+            plugins    = "post-function",
             db_update_frequency = 0.1,
           }, nil, nil, nil))
 
@@ -195,6 +196,208 @@ for _, strategy in helpers.each_strategy() do
 
         end)
 
+        local function test_with_uri(uri, expect, upstream)
+          local requests = bu.SLOTS * 2 -- go round the balancer twice
+
+          bu.begin_testcase_setup(strategy, bp)
+          local upstream_name, upstream_id = bu.add_upstream(bp, upstream)
+
+          local port1 = bu.add_target(bp, upstream_id, localhost)
+          local port2 = bu.add_target(bp, upstream_id, localhost)
+          local api_host = bu.add_api(bp, upstream_name)
+
+          -- setup target servers
+          local server1 = https_server.new(port1, localhost)
+          local server2 = https_server.new(port2, localhost)
+          server1:start()
+          server2:start()
+
+          bu.end_testcase_setup(strategy, bp)
+
+          local client = helpers.proxy_client()
+          local res = assert(client:request({
+            method = "GET",
+            path = uri,
+            headers = { host = api_host },
+          }))
+
+          -- Go hit them with our test requests
+          local oks = bu.client_requests(requests, api_host, nil, nil, nil, uri)
+
+          -- collect server results; hitcount
+          -- one should get all the hits, the other 0
+          local count1 = server1:shutdown()
+          local count2 = server2:shutdown()
+
+          -- verify
+          assert.res_status(200, res)
+
+          local hash = assert.response(res).has_header("x-balancer-hash-value")
+          assert.equal(expect, hash)
+
+          local req_uri = assert.response(res).has_header("x-uri")
+          assert.equal(uri, req_uri) -- sanity
+
+          assert.equal(requests, oks)
+
+          -- account for our hash_value test request
+          requests = requests + 1
+
+          assert(count1.total == 0 or count1.total == requests, "counts should either get 0 or ALL hits")
+          assert(count2.total == 0 or count2.total == requests, "counts should either get 0 or ALL hits")
+          assert(count1.total + count2.total == requests)
+        end
+
+        describe("hashing on #path", function()
+          it("simple case", function()
+            test_with_uri("/my-path", "/my-path", {
+              hash_on = "path",
+            })
+          end)
+
+          it("only uses the path component", function()
+            test_with_uri("/my-path?a=1&b=2", "/my-path", {
+              hash_on = "path",
+            })
+          end)
+
+          it("uses the normalized path", function()
+            test_with_uri("/root/../%2e/root///././%2F.subdir/../.subdir/./%28%29",
+                          "/root/.subdir/()",
+                          { hash_on = "path" })
+          end)
+
+          it("as a fallback", function()
+            test_with_uri("/my-path?a=1&b=2", "/my-path", {
+              hash_on = "header",
+              hash_on_header = "my-nonexistent-header",
+              hash_fallback = "path",
+            })
+          end)
+        end)
+
+        describe("hashing on #uri_capture", function()
+          it("simple case", function()
+            test_with_uri("/foo/123", "foo", {
+              hash_on = "uri_capture",
+              hash_on_uri_capture = "namespace",
+            })
+
+            test_with_uri("/foo/123", "123", {
+              hash_on = "uri_capture",
+              hash_on_uri_capture = "id",
+            })
+          end)
+
+          it("missing", function()
+            test_with_uri("/", "NONE", {
+              hash_on = "uri_capture",
+              hash_on_uri_capture = "namespace",
+            })
+          end)
+
+          it("missing w/ fallback", function()
+            test_with_uri("/?test=1", "1", {
+              hash_on = "uri_capture",
+              hash_on_uri_capture = "namespace",
+              hash_fallback = "query_arg",
+              hash_fallback_query_arg = "test",
+            })
+          end)
+
+          it("as a fallback", function()
+            test_with_uri("/my-namespace/123?a=1&b=2", "my-namespace", {
+              hash_on = "query_arg",
+              hash_on_query_arg = "hashme",
+              hash_fallback = "uri_capture",
+              hash_fallback_uri_capture = "namespace",
+            })
+          end)
+        end)
+
+        describe("hashing on a #query string arg", function()
+          it("when the arg is present in the request", function()
+            test_with_uri("/?hashme=123", "123", {
+              hash_on = "query_arg",
+              hash_on_query_arg = "hashme",
+            })
+          end)
+
+          it("when the arg is not present in request", function()
+            test_with_uri("/", "NONE", {
+              hash_on = "query_arg",
+              hash_on_query_arg = "hashme",
+            })
+          end)
+
+          it("when the arg has no value (boolean)", function()
+            test_with_uri("/?hashme", "true", {
+              hash_on = "query_arg",
+              hash_on_query_arg = "hashme",
+            })
+          end)
+
+          it("when the arg has an empty value", function()
+            test_with_uri("/?foo=", "NONE", {
+              hash_on = "query_arg",
+              hash_on_query_arg = "foo",
+            })
+          end)
+
+          it("as a fallback", function()
+            test_with_uri("/?fallback=123", "123", {
+              hash_on = "query_arg",
+              hash_on_query_arg = "absent",
+              hash_fallback = "query_arg",
+              hash_fallback_query_arg = "fallback",
+            })
+          end)
+
+          it("multiple args are sorted and concatenated", function()
+            test_with_uri("/?foo=b&foo=a&foo=c", "a,b,c", {
+              hash_on = "query_arg",
+              hash_on_query_arg = "foo",
+            })
+          end)
+
+          it("multiple args of mixed type are handled", function()
+            -- interesting that `foo=` evaluates to an empty string here
+            -- whereas it evaluates to `nil` in the test case with only a
+            -- single arg
+            test_with_uri("/?foo=s&foo&foo=1&foo=", ",1,s,true", {
+              hash_on = "query_arg",
+              hash_on_query_arg = "foo",
+            })
+          end)
+
+          it("multiple boolean args are converted to strings", function()
+            test_with_uri("/?foo&foo&", "true,true", {
+              hash_on = "query_arg",
+              hash_on_query_arg = "foo",
+            })
+          end)
+
+          describe("escaped arg names", function()
+            local values = {
+              "{}", "\r\n", ".", "-----", "-1", "()", "&",
+              "=", "//", "[]", "$", "@", "++", ";", "'", '"',
+              "*", ",", "#", " ", "%", "???",
+            }
+
+            for i, arg in ipairs(values) do
+              it(string.format("(%q)", arg), function()
+                local escaped = ngx.escape_uri(arg)
+                local val = tostring(i)
+                local uri = string.format("/?%s=%s", escaped, val)
+
+                test_with_uri(uri, val, {
+                  hash_on = "query_arg",
+                  hash_on_query_arg = arg,
+                })
+              end)
+            end
+          end)
+        end)
       end)
     end)
   end


### PR DESCRIPTION
This adds `path`, `uri_capture`, and `query_arg` as hash sources for upstreams.

There are some code simplicity vs performance vs absolute correctness tradeoffs to consider here:

* `path` sources its value from `$uri`, which is normalized according to NGINX rules and _not_ `kong.tools.uri.normalize($request_uri)`. The balancer hash is not directly exposed via any public API and is much less sensitive to compatibility issues than other areas of the codebase (i.e. `kong.router`), so I think it's okay to not be 100% consistent here.
* `query_arg` uses `ngx.req.get_uri_args`, which is semi-expensive as it creates a new table (similar to `hash_on_header` now). A feature of an upcoming OpenResty release allows optimizing away the table creation ([link](https://github.com/openresty/lua-resty-core/pull/288)), which I've accounted for. The benefit of doing this over using `ngx.var.arg_{{name}}` is that NGINX handles decoding for us, _and_ that it works for multi-value query string args.