### PR TITLE
fix(balancer) do not reschedule resolve timer when reloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,8 @@
 - Fix issue where the Go plugin server instance would not be updated after
 a restart (e.g., upon a plugin server crash).
   [#8547](https://github.com/Kong/kong/pull/8547)
+- Fixed an issue on trying to reschedule the DNS resolving timer when Kong was
+  being reloaded. [#8702](https://github.com/Kong/kong/pull/8702)
 
 #### Plugins
 

--- a/kong/runloop/balancer/targets.lua
+++ b/kong/runloop/balancer/targets.lua
@@ -229,7 +229,11 @@ end
 
 
 -- Timer invoked to update DNS records
-function resolve_timer_callback()
+function resolve_timer_callback(premature)
+  if premature then
+    return
+  end
+
   local now = ngx_now()
 
   while (renewal_heap:peekValue() or math.huge) < now do


### PR DESCRIPTION
### Summary

Due to a missing check on DNS resolve timer callback, messages like this were logged when issuing a `kong reload` command:

```
2022/04/19 20:44:45 [crit] 80722#0: *17 [lua] targets.lua:248: could not reschedule DNS resolver timer: process exiting, context: ngx.timer
```

### Full changelog

* Added check for [`premature`](https://github.com/openresty/lua-nginx-module#ngxtimerat) schedules and ignored those calls instead of trying to schedule and throwing an error.
