### PR TITLE
fix(conf) vault inferring and no request found

### DIFF
--- a/kong-2.8.0-0.rockspec
+++ b/kong-2.8.0-0.rockspec
@@ -113,6 +113,7 @@ build = {
     ["kong.cmd.utils.tty"] = "kong/cmd/utils/tty.lua",
     ["kong.cmd.utils.nginx_signals"] = "kong/cmd/utils/nginx_signals.lua",
     ["kong.cmd.utils.prefix_handler"] = "kong/cmd/utils/prefix_handler.lua",
+    ["kong.cmd.utils.process_secrets"] = "kong/cmd/utils/process_secrets.lua",
 
     ["kong.api"] = "kong/api/init.lua",
     ["kong.api.api_helpers"] = "kong/api/api_helpers.lua",

--- a/kong/cmd/reload.lua
+++ b/kong/cmd/reload.lua
@@ -33,7 +33,7 @@ local function execute(args)
     conf.declarative_config = nil
   end
 
-  assert(prefix_handler.prepare_prefix(conf, args.nginx_conf))
+  assert(prefix_handler.prepare_prefix(conf, args.nginx_conf, nil, true))
   assert(nginx_signals.reload(conf))
 
   log("Kong reloaded")

--- a/kong/cmd/reload.lua
+++ b/kong/cmd/reload.lua
@@ -1,9 +1,12 @@
 local prefix_handler = require "kong.cmd.utils.prefix_handler"
 local nginx_signals = require "kong.cmd.utils.nginx_signals"
 local conf_loader = require "kong.conf_loader"
+local kong_global = require "kong.global"
 local pl_path = require "pl.path"
 local pl_file = require "pl.file"
 local log = require "kong.cmd.utils.log"
+local DB = require "kong.db"
+
 
 local function execute(args)
   log.disable()
@@ -34,10 +37,18 @@ local function execute(args)
   end
 
   assert(prefix_handler.prepare_prefix(conf, args.nginx_conf, nil, true))
+
+  _G.kong = kong_global.new()
+  kong_global.init_pdk(_G.kong, conf)
+
+  local db = assert(DB.new(conf))
+  assert(db:init_connector())
+
   assert(nginx_signals.reload(conf))
 
   log("Kong reloaded")
 end
+
 
 local lapp = [[
 Usage: kong reload [OPTIONS]
@@ -55,6 +66,7 @@ Options:
  -p,--prefix      (optional string) prefix Kong is running at
  --nginx-conf     (optional string) custom Nginx configuration template
 ]]
+
 
 return {
   lapp = lapp,

--- a/kong/cmd/utils/nginx_signals.lua
+++ b/kong/cmd/utils/nginx_signals.lua
@@ -1,3 +1,4 @@
+local ffi = require "ffi"
 local log = require "kong.cmd.utils.log"
 local kill = require "kong.cmd.utils.kill"
 local meta = require "kong.meta"
@@ -5,7 +6,23 @@ local pl_path = require "pl.path"
 local version = require "version"
 local pl_utils = require "pl.utils"
 local pl_stringx = require "pl.stringx"
+local process_secrets = require "kong.cmd.utils.process_secrets"
+
+
 local fmt = string.format
+local ipairs = ipairs
+local unpack = unpack
+local tostring = tostring
+
+
+local C = ffi.C
+
+
+ffi.cdef([[
+  int setenv(const char *name, const char *value, int overwrite);
+  int unsetenv(const char *name);
+]])
+
 
 local nginx_bin_name = "nginx"
 local nginx_search_paths = {
@@ -14,8 +31,10 @@ local nginx_search_paths = {
   ""
 }
 
+
 local nginx_version_pattern = "^nginx.-openresty.-([%d%.]+)"
 local nginx_compatible = version.set(unpack(meta._DEPENDENCIES.nginx))
+
 
 local function is_openresty(bin_path)
   local cmd = fmt("%s -v", bin_path)
@@ -34,9 +53,10 @@ local function is_openresty(bin_path)
   log.debug("OpenResty 'nginx' executable not found at %s", bin_path)
 end
 
+
 local function send_signal(kong_conf, signal)
   if not kill.is_running(kong_conf.nginx_pid) then
-    return nil, "nginx not running in prefix: " .. kong_conf.prefix
+    return nil, fmt("nginx not running in prefix: %s", kong_conf.prefix)
   end
 
   log.verbose("sending %s signal to nginx running at %s", signal, kong_conf.nginx_pid)
@@ -49,7 +69,32 @@ local function send_signal(kong_conf, signal)
   return true
 end
 
+
+local function set_process_secrets_env(kong_conf)
+  local secrets = process_secrets.extract(kong_conf)
+  if not secrets then
+    return false
+  end
+
+  local err
+  secrets, err = process_secrets.serialize(secrets, kong_conf.kong_env)
+  if not secrets then
+    return nil, err
+  end
+
+  return C.setenv("KONG_PROCESS_SECRETS", secrets, 1) == 0
+end
+
+
+local function unset_process_secrets_env(has_process_secrets)
+  if has_process_secrets then
+    C.unsetenv("KONG_PROCESS_SECRETS")
+  end
+end
+
+
 local _M = {}
+
 
 function _M.find_nginx_bin(kong_conf)
   log.debug("searching for OpenResty 'nginx' executable")
@@ -84,12 +129,13 @@ function _M.find_nginx_bin(kong_conf)
   end
 
   if not found then
-    return nil, ("could not find OpenResty 'nginx' executable. Kong requires" ..
-                 " version %s"):format(tostring(nginx_compatible))
+    return nil, fmt("could not find OpenResty 'nginx' executable. Kong requires version %s",
+                    tostring(nginx_compatible))
   end
 
   return found
 end
+
 
 function _M.start(kong_conf)
   local nginx_bin, err = _M.find_nginx_bin(kong_conf)
@@ -101,6 +147,11 @@ function _M.start(kong_conf)
     return nil, "nginx is already running in " .. kong_conf.prefix
   end
 
+  local has_process_secrets, err = set_process_secrets_env(kong_conf)
+  if err then
+    return nil, err
+  end
+
   local cmd = fmt("%s -p %s -c %s", nginx_bin, kong_conf.prefix, "nginx.conf")
 
   log.debug("starting nginx: %s", cmd)
@@ -110,6 +161,7 @@ function _M.start(kong_conf)
     -- "executeex" method
     local ok, _, _, stderr = pl_utils.executeex(cmd)
     if not ok then
+      unset_process_secrets_env(has_process_secrets)
       return nil, stderr
     end
 
@@ -121,12 +173,15 @@ function _M.start(kong_conf)
     -- redirection instead.
     local ok, retcode = pl_utils.execute(cmd)
     if not ok then
-      return nil, ("failed to start nginx (exit code: %s)"):format(retcode)
+      unset_process_secrets_env(has_process_secrets)
+      return nil, fmt("failed to start nginx (exit code: %s)", retcode)
     end
   end
 
+  unset_process_secrets_env(has_process_secrets)
   return true
 end
+
 
 function _M.check_conf(kong_conf)
   local nginx_bin, err = _M.find_nginx_bin(kong_conf)
@@ -141,24 +196,27 @@ function _M.check_conf(kong_conf)
 
   local ok, retcode, _, stderr = pl_utils.executeex(cmd)
   if not ok then
-    return nil, ("nginx configuration is invalid " ..
-                 "(exit code %d):\n%s"):format(retcode, stderr)
+    return nil, fmt("nginx configuration is invalid (exit code %d):\n%s",
+                    retcode, stderr)
   end
 
   return true
 end
 
+
 function _M.stop(kong_conf)
   return send_signal(kong_conf, "TERM")
 end
+
 
 function _M.quit(kong_conf)
   return send_signal(kong_conf, "QUIT")
 end
 
+
 function _M.reload(kong_conf)
   if not kill.is_running(kong_conf.nginx_pid) then
-    return nil, "nginx not running in prefix: " .. kong_conf.prefix
+    return nil, fmt("nginx not running in prefix: %s", kong_conf.prefix)
   end
 
   local nginx_bin, err = _M.find_nginx_bin(kong_conf)
@@ -178,5 +236,6 @@ function _M.reload(kong_conf)
 
   return true
 end
+
 
 return _M

--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -2,6 +2,7 @@ local default_nginx_template = require "kong.templates.nginx"
 local kong_nginx_template = require "kong.templates.nginx_kong"
 local kong_nginx_stream_template = require "kong.templates.nginx_kong_stream"
 local system_constants = require "lua_system_constants"
+local process_secrets = require "kong.cmd.utils.process_secrets"
 local openssl_bignum = require "resty.openssl.bn"
 local openssl_rand = require "resty.openssl.rand"
 local openssl_pkey = require "resty.openssl.pkey"
@@ -21,6 +22,7 @@ local bit = require "bit"
 local nginx_signals = require "kong.cmd.utils.nginx_signals"
 
 
+local getmetatable = getmetatable
 local tonumber = tonumber
 local tostring = tostring
 local assert = assert
@@ -283,10 +285,11 @@ end
 local function write_env_file(path, data)
   os.remove(path)
 
-  local c = require "lua_system_constants"
-
-  local flags = bit.bor(c.O_CREAT(), c.O_WRONLY())
-  local mode = ffi.new("int", bit.bor(c.S_IRUSR(), c.S_IWUSR(), c.S_IRGRP()))
+  local flags = bit.bor(system_constants.O_CREAT(),
+                        system_constants.O_WRONLY())
+  local mode = ffi.new("int", bit.bor(system_constants.S_IRUSR(),
+                                      system_constants.S_IWUSR(),
+                                      system_constants.S_IRGRP()))
 
   local fd = ffi.C.open(path, flags, mode)
   if fd < 0 then
@@ -318,6 +321,45 @@ local function write_env_file(path, data)
   return true
 end
 
+local function write_process_secrets_file(path, data)
+  os.remove(path)
+
+  local flags = bit.bor(system_constants.O_RDONLY(),
+                        system_constants.O_CREAT())
+
+  local mode = ffi.new("int", bit.bor(system_constants.S_IRUSR(),
+                                      system_constants.S_IWUSR()))
+
+  local fd = ffi.C.open(path, flags, mode)
+  if fd < 0 then
+    local errno = ffi.errno()
+    return nil, "unable to open process secrets path " .. path .. " (" ..
+                ffi.string(ffi.C.strerror(errno)) .. ")"
+  end
+
+  local ok = ffi.C.close(fd)
+  if ok ~= 0 then
+    local errno = ffi.errno()
+    return nil, "failed to close fd (" ..
+                ffi.string(ffi.C.strerror(errno)) .. ")"
+  end
+
+  local file, err = io.open(path, "w+b")
+  if not file then
+    return nil, "unable to open process secrets path " .. path .. " (" .. err .. ")"
+  end
+
+  local ok, err = file:write(data)
+
+  file:close()
+
+  if not ok then
+    return nil, "unable to write process secrets path " .. path .. " (" .. err .. ")"
+  end
+
+  return true
+end
+
 local function compile_kong_conf(kong_config)
   return compile_conf(kong_config, kong_nginx_template)
 end
@@ -331,7 +373,7 @@ local function compile_nginx_conf(kong_config, template)
   return compile_conf(kong_config, template)
 end
 
-local function prepare_prefix(kong_config, nginx_custom_template_path, skip_write)
+local function prepare_prefix(kong_config, nginx_custom_template_path, skip_write, write_process_secrets)
   log.verbose("preparing nginx prefix directory at %s", kong_config.prefix)
 
   if not pl_path.exists(kong_config.prefix) then
@@ -486,9 +528,15 @@ local function prepare_prefix(kong_config, nginx_custom_template_path, skip_writ
   }
 
   local refs = kong_config["$refs"]
+  local has_refs = refs and type(refs) == "table"
+
+  local secrets
+  if write_process_secrets and has_refs then
+    secrets = process_secrets.extract(kong_config)
+  end
 
   for k, v in pairs(kong_config) do
-    if refs and refs[k] then
+    if has_refs and refs[k] then
       v = refs[k]
     end
 
@@ -505,10 +553,22 @@ local function prepare_prefix(kong_config, nginx_custom_template_path, skip_writ
     end
   end
 
-  local ok, err = write_env_file(kong_config.kong_env,
-                                 table.concat(buf, "\n") .. "\n")
+  local env = table.concat(buf, "\n") .. "\n"
+  local ok, err = write_env_file(kong_config.kong_env, env)
   if not ok then
     return nil, err
+  end
+
+  if secrets then
+    secrets, err = process_secrets.serialize(secrets, kong_config.kong_env)
+    if not secrets then
+      return nil, err
+    end
+
+    ok, err = write_process_secrets_file(kong_config.kong_process_secrets, secrets)
+    if not ok then
+      return nil, err
+    end
   end
 
   return true

--- a/kong/cmd/utils/process_secrets.lua
+++ b/kong/cmd/utils/process_secrets.lua
@@ -1,0 +1,195 @@
+local b64 = require "ngx.base64"
+local cjson = require "cjson.safe"
+local file = require "pl.file"
+local path = require "pl.path"
+local cipher = require "resty.openssl.cipher"
+local digest = require "resty.openssl.digest"
+local rand = require "resty.openssl.rand"
+
+
+local fmt = string.format
+local sub = string.sub
+local type = type
+local pairs = pairs
+
+
+local CIPHER_ALG = "aes-256-gcm"
+local DIGEST_ALG = "sha256"
+local IV_SIZE = 12
+local TAG_SIZE = 16
+local AAD = fmt("%s|%s", CIPHER_ALG, DIGEST_ALG)
+
+
+local function read_key_data(key_data_path)
+  if not path.exists(key_data_path) then
+    return nil, fmt("failed to read key data (%s): file not found", key_data_path)
+  end
+
+  local key_data, err = file.read(key_data_path, true)
+  if not key_data then
+    return nil, fmt("failed to read key data file: %s", err)
+  end
+
+  return key_data
+end
+
+
+local function hash_key_data(key_data)
+  local hash, err = digest.new(DIGEST_ALG)
+  if not hash then
+    return nil, fmt("unable to initialize digest (%s)", err)
+  end
+
+  local ok
+  ok, err = hash:update(key_data)
+  if not ok then
+    return nil, fmt("unable to update digest (%s)", err)
+  end
+
+  local key
+  key, err = hash:final()
+  if not key then
+    return nil, fmt("unable to create digest (%s)", err)
+  end
+
+  return key
+end
+
+
+local function extract(conf)
+  local refs = conf["$refs"]
+  if not refs or type(refs) ~= "table" then
+    return
+  end
+
+  local secrets = {}
+  for k in pairs(refs) do
+    secrets[k] = conf[k]
+  end
+
+  return secrets
+end
+
+
+local function encrypt(plaintext, key_data)
+  local key, err = hash_key_data(key_data)
+  if not key then
+    return nil, err
+  end
+
+  local iv
+  iv, err = rand.bytes(IV_SIZE)
+  if not iv then
+    return nil, fmt("unable to generate initialization vector (%s)", err)
+  end
+
+  local cip, err = cipher.new(CIPHER_ALG)
+  if not cip then
+    return nil, fmt("unable to initialize cipher (%s)", err)
+  end
+
+  local ciphertext
+  ciphertext, err = cip:encrypt(key, iv, plaintext, false, AAD)
+  if not ciphertext then
+    return nil, fmt("unable to encrypt (%s)", err)
+  end
+
+  local tag
+  tag, err = cip:get_aead_tag(TAG_SIZE)
+  if not tag then
+    return nil, fmt("unable to get authentication tag (%s)", err)
+  end
+
+  return iv .. tag .. ciphertext
+end
+
+
+local function decrypt(ciphertext, key_data)
+  local key, err = hash_key_data(key_data)
+  if not key then
+    return nil, err
+  end
+
+  local iv = sub(ciphertext, 1, IV_SIZE)
+  local tag = sub(ciphertext, IV_SIZE + 1, IV_SIZE + TAG_SIZE)
+
+  ciphertext = sub(ciphertext, IV_SIZE + TAG_SIZE + 1)
+
+  local cip, err = cipher.new(CIPHER_ALG)
+  if not cip then
+    return nil, fmt("unable to initialize cipher (%s)", err)
+  end
+
+  local plaintext
+  plaintext, err = cip:decrypt(key, iv, ciphertext, false, AAD, tag)
+  if not plaintext then
+    return nil, fmt("unable to decrypt (%s)", err)
+  end
+
+  return plaintext
+end
+
+
+local function serialize(input, key_data_path)
+  local output, err = cjson.encode(input)
+  if not output then
+    return nil, fmt("failed to json encode process secrets: %s", err)
+  end
+
+  if key_data_path then
+    local key_data
+    key_data, err = read_key_data(key_data_path)
+    if not key_data then
+      return nil, err
+    end
+
+    output, err = encrypt(output, key_data)
+    if not output then
+      return nil, fmt("failed to encrypt process secrets: %s", err)
+    end
+  end
+
+  output, err = b64.encode_base64url(output)
+  if not output then
+    return nil, fmt("failed to base64 encode process secrets: %s", err)
+  end
+
+  return output
+end
+
+
+local function deserialize(input, key_data_path)
+  local output, err = b64.decode_base64url(input)
+  if not output then
+    return nil, fmt("failed to base64 decode process secrets: %s", err)
+  end
+
+  if key_data_path then
+    local key_data
+    key_data, err = read_key_data(key_data_path)
+    if not key_data then
+      return nil, err
+    end
+
+    output, err = decrypt(output, key_data)
+    if not output then
+      return nil, fmt("failed to decrypt process secrets: %s", err)
+    end
+  end
+
+  output, err = cjson.decode(output)
+  if not output then
+    return nil, fmt("failed to json decode process secrets: %s", err)
+  end
+
+  return output
+end
+
+
+return {
+  extract = extract,
+  encrypt = encrypt,
+  decrypt = decrypt,
+  serialize = serialize,
+  deserialize = deserialize,
+}

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -1539,13 +1539,14 @@ local function load(path, custom_conf, opts)
     local vault_conf = { loaded_vaults = loaded_vaults }
     for k, v in pairs(conf) do
       if sub(k, 1, 6) == "vault_" then
-        vault_conf[k] = v
+        vault_conf[k] = infer_value(v, "string", opts)
       end
     end
 
     local vault = require("kong.pdk.vault").new({ configuration = vault_conf })
 
     for k, v in pairs(conf) do
+      v = infer_value(v, "string", opts)
       if vault.is_reference(v) then
         if refs then
           refs[k] = v

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -1915,6 +1915,16 @@ return setmetatable({
   remove_sensitive = function(conf)
     local purged_conf = tablex.deepcopy(conf)
 
+    local refs = purged_conf["$refs"]
+    if type(refs) == "table" then
+      for k, v in pairs(refs) do
+        if not CONF_SENSITIVE[k] then
+          purged_conf[k] = v
+        end
+      end
+      purged_conf["$refs"] = nil
+    end
+
     for k in pairs(CONF_SENSITIVE) do
       if purged_conf[k] then
         purged_conf[k] = CONF_SENSITIVE_PLACEHOLDER

--- a/kong/db/schema/entities/vaults_beta.lua
+++ b/kong/db/schema/entities/vaults_beta.lua
@@ -6,20 +6,6 @@ local VAULTS do
   local pairs = pairs
   local names = {}
   local constants = require "kong.constants"
-  local bundled = constants and constants.BUNDLED_VAULTS
-  if bundled then
-    for name in pairs(bundled) do
-      if not names[name] then
-        names[name] = true
-        i = i + 1
-        if i == 1 then
-          VAULTS = { name }
-        else
-          VAULTS[i] = name
-        end
-      end
-    end
-  end
 
   local loaded_vaults = kong and kong.configuration and kong.configuration.loaded_vaults
   if loaded_vaults then
@@ -31,6 +17,22 @@ local VAULTS do
           VAULTS = { name }
         else
           VAULTS[i] = name
+        end
+      end
+    end
+
+  else
+    local bundled = constants and constants.BUNDLED_VAULTS
+    if bundled then
+      for name in pairs(bundled) do
+        if not names[name] then
+          names[name] = true
+          i = i + 1
+          if i == 1 then
+            VAULTS = { name }
+          else
+            VAULTS[i] = name
+          end
         end
       end
     end

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -1728,7 +1728,8 @@ describe("Configuration loader", function()
       helpers.setenv("PG_DATABASE", "resolved-kong-database")
 
       local conf = assert(conf_loader(nil, {
-        pg_database = "{vault://env/pg-database}"
+        pg_database = "{vault://env/pg-database}",
+        vaults = "env",
       }))
 
       assert.equal("resolved-kong-database", conf.pg_database)
@@ -1742,7 +1743,8 @@ describe("Configuration loader", function()
       helpers.setenv("PG_PORT", "5000")
 
       local conf = assert(conf_loader(nil, {
-        pg_port = "{vault://env/pg-port#0}"
+        pg_port = "{vault://env/pg-port#0}",
+        vaults = "env",
       }))
 
       assert.equal(5000, conf.pg_port)

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -1742,11 +1742,11 @@ describe("Configuration loader", function()
       helpers.setenv("PG_PORT", "5000")
 
       local conf = assert(conf_loader(nil, {
-        pg_port = "{vault://env/pg-port}"
+        pg_port = "{vault://env/pg-port#0}"
       }))
 
       assert.equal(5000, conf.pg_port)
-      assert.equal("{vault://env/pg-port}", conf["$refs"].pg_port)
+      assert.equal("{vault://env/pg-port#0}", conf["$refs"].pg_port)
     end)
   end)
 end)

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -1461,6 +1461,36 @@ describe("Configuration loader", function()
       assert.not_equal("hide_me", purged_conf.pg_password)
       assert.not_equal("hide_me", purged_conf.cassandra_password)
     end)
+
+    it("replaces sensitive vault resolved settings", function()
+      finally(function()
+        helpers.unsetenv("PG_PASSWORD")
+        helpers.unsetenv("PG_DATABASE")
+        helpers.unsetenv("CASSANDRA_PASSWORD")
+        helpers.unsetenv("CASSANDRA_KEYSPACE")
+      end)
+
+      helpers.setenv("PG_PASSWORD", "pg-password")
+      helpers.setenv("PG_DATABASE", "pg-database")
+      helpers.setenv("CASSANDRA_PASSWORD", "cassandra-password")
+      helpers.setenv("CASSANDRA_KEYSPACE", "cassandra-keyspace")
+
+      local conf = assert(conf_loader(nil, {
+        pg_password = "{vault://env/pg-password}",
+        pg_database = "{vault://env/pg-database}",
+        cassandra_password = "{vault://env/cassandra-password}",
+        cassandra_keyspace = "{vault://env/cassandra-keyspace}",
+        vaults = "env",
+      }))
+
+      local purged_conf = conf_loader.remove_sensitive(conf)
+      assert.equal("******", purged_conf.pg_password)
+      assert.equal("{vault://env/pg-database}", purged_conf.pg_database)
+      assert.equal("******", purged_conf.cassandra_password)
+      assert.equal("{vault://env/cassandra-keyspace}", purged_conf.cassandra_keyspace)
+      assert.is_nil(purged_conf["$refs"])
+    end)
+
     it("does not insert placeholder if no value", function()
       local conf = assert(conf_loader())
       local purged_conf = conf_loader.remove_sensitive(conf)

--- a/spec/01-unit/04-prefix_handler_spec.lua
+++ b/spec/01-unit/04-prefix_handler_spec.lua
@@ -855,6 +855,7 @@ describe("NGINX conf compiler", function()
         local conf = assert(conf_loader(nil, {
           prefix = tmp_config.prefix,
           pg_database = "{vault://env/pg-database}",
+          vaults = "env",
         }))
 
         assert.equal("resolved-kong-database", conf.pg_database)

--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -24,7 +24,8 @@ describe("kong start/stop #" .. strategy, function()
       database = strategy,
       nginx_proxy_real_ip_header = "{vault://env/ipheader}",
       pg_database = helpers.test_conf.pg_database,
-      cassandra_keyspace = helpers.test_conf.cassandra_keyspace
+      cassandra_keyspace = helpers.test_conf.cassandra_keyspace,
+      vaults = "env",
     })
 
     assert.matches("Error: failed to dereference '{vault://env/ipheader}': unable to load value (ipheader) from vault (env): not found [{vault://env/ipheader}] for config option 'nginx_proxy_real_ip_header'", stderr, nil, true)
@@ -40,9 +41,9 @@ describe("kong start/stop #" .. strategy, function()
       database = helpers.test_conf.database,
       pg_password = "{vault://non-existent/pg_password}",
       pg_database = helpers.test_conf.pg_database,
-      cassandra_keyspace = helpers.test_conf.cassandra_keyspace
+      cassandra_keyspace = helpers.test_conf.cassandra_keyspace,
     })
-    assert.matches("failed to dereference '{vault://non-existent/pg_password}': could not find vault (non-existent)", stderr, nil, true)
+    assert.matches("failed to dereference '{vault://non-existent/pg_password}': vault not found (non-existent)", stderr, nil, true)
     assert.is_nil(stdout)
     assert.is_false(ok)
 
@@ -56,7 +57,8 @@ describe("kong start/stop #" .. strategy, function()
       database = helpers.test_conf.database,
       pg_password = "{vault://env/pg_password}",
       pg_database = helpers.test_conf.pg_database,
-      cassandra_keyspace = helpers.test_conf.cassandra_keyspace
+      cassandra_keyspace = helpers.test_conf.cassandra_keyspace,
+      vaults = "env",
     }))
     assert.not_matches("failed to dereference {vault://env/pg_password}", stderr, nil, true)
     assert.matches("Kong started", stdout, nil, true)

--- a/spec/02-integration/02-cmd/03-reload_spec.lua
+++ b/spec/02-integration/02-cmd/03-reload_spec.lua
@@ -622,6 +622,22 @@ describe("kong reload #" .. strategy, function()
       assert.False(ok)
       assert.matches("Error: nginx not running in prefix: " .. helpers.test_conf.prefix, err, nil, true)
     end)
+
+    if strategy ~= "off" then
+      it("complains when database connection is invalid", function()
+        assert(helpers.start_kong({
+          proxy_listen = "0.0.0.0:9002"
+        }, nil, true))
+
+        local ok = helpers.kong_exec("reload --conf " .. helpers.test_conf_path, {
+          database = strategy,
+          pg_port = 1234,
+          cassandra_port = 1234,
+        })
+
+        assert.False(ok)
+      end)
+    end
   end)
 end)
 

--- a/spec/02-integration/13-vaults/01-vault_spec.lua
+++ b/spec/02-integration/13-vaults/01-vault_spec.lua
@@ -16,11 +16,17 @@ for _, strategy in helpers.each_strategy() do
       _, db = helpers.get_db_utils(strategy, {
         "certificates",
         "vaults_beta",
+      },
+      nil, {
+        "env",
+        "mock",
       })
 
       assert(helpers.start_kong {
         database = strategy,
-        vaults = "env",
+        prefix = helpers.test_conf.prefix,
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+        vaults = "env,mock",
       })
 
       client = assert(helpers.admin_client(10000))
@@ -33,6 +39,19 @@ for _, strategy in helpers.each_strategy() do
       })
 
       assert.res_status(200, res)
+
+      local res = client:put("/vaults-beta/mock-vault", {
+        headers = { ["Content-Type"] = "application/json" },
+        body = {
+          name = "mock",
+        },
+      })
+
+      assert.res_status(200, res)
+    end)
+
+    before_each(function()
+      client = assert(helpers.admin_client(10000))
     end)
 
     after_each(function()
@@ -95,6 +114,59 @@ for _, strategy in helpers.each_strategy() do
       certificate = cjson.decode(body)
       assert.is_equal("{vault://test-vault/cert}", certificate.cert)
       assert.is_equal("{vault://test-vault/key}", certificate.key)
+      assert.is_equal("{vault://unknown/cert}", certificate.cert_alt)
+      assert.is_equal("{vault://unknown/missing-key}", certificate.key_alt)
+      assert.is_nil(certificate["$refs"])
+    end)
+
+    it("create certificates with cert and key as secret using mock vault", function()
+      local res, err = client:post("/certificates", {
+        headers = { ["Content-Type"] = "application/json" },
+        body = {
+          cert     = "{vault://mock-vault/cert}",
+          key      = "{vault://mock-vault/key}",
+          cert_alt = "{vault://unknown/cert}",
+          key_alt  = "{vault://unknown/missing-key}",
+        },
+      })
+      assert.is_nil(err)
+      local body = assert.res_status(201, res)
+      local certificate = cjson.decode(body)
+      assert.equal("{vault://mock-vault/cert}", certificate.cert)
+      assert.equal("{vault://mock-vault/key}", certificate.key)
+      assert.equal("{vault://unknown/cert}", certificate.cert_alt)
+      assert.equal("{vault://unknown/missing-key}", certificate.key_alt)
+      assert.is_nil(certificate["$refs"])
+
+      certificate, err = db.certificates:select({ id = certificate.id })
+      assert.is_nil(err)
+      assert.equal(ssl_fixtures.cert, certificate.cert)
+      assert.equal(ssl_fixtures.key, certificate.key)
+      assert.equal("{vault://mock-vault/cert}", certificate["$refs"].cert)
+      assert.equal("{vault://mock-vault/key}", certificate["$refs"].key)
+      assert.equal("{vault://unknown/cert}", certificate["$refs"].cert_alt)
+      assert.equal("{vault://unknown/missing-key}", certificate["$refs"].key_alt)
+      assert.is_nil(certificate.cert_alt)
+      assert.is_nil(certificate.key_alt)
+
+      -- TODO: this is unexpected but schema.process_auto_fields uses currently
+      -- the `nulls` parameter to detect if the call comes from Admin API
+      -- for performance reasons
+      certificate, err = db.certificates:select({ id = certificate.id }, { nulls = true })
+      assert.is_nil(err)
+      assert.equal("{vault://mock-vault/cert}", certificate.cert)
+      assert.equal("{vault://mock-vault/key}", certificate.key)
+      assert.equal("{vault://unknown/cert}", certificate.cert_alt)
+      assert.equal("{vault://unknown/missing-key}", certificate.key_alt)
+      assert.is_nil(certificate["$refs"])
+
+      -- verify that certificate attributes are of type reference when querying
+      res, err = client:get("/certificates/"..certificate.id)
+      assert.is_nil(err)
+      body = assert.res_status(200, res)
+      certificate = cjson.decode(body)
+      assert.is_equal("{vault://mock-vault/cert}", certificate.cert)
+      assert.is_equal("{vault://mock-vault/key}", certificate.key)
       assert.is_equal("{vault://unknown/cert}", certificate.cert_alt)
       assert.is_equal("{vault://unknown/missing-key}", certificate.key_alt)
       assert.is_nil(certificate["$refs"])

--- a/spec/02-integration/13-vaults/03-mock_spec.lua
+++ b/spec/02-integration/13-vaults/03-mock_spec.lua
@@ -1,0 +1,138 @@
+local helpers = require "spec.helpers"
+local cjson = require "cjson"
+local meta = require "kong.meta"
+
+
+local exists = helpers.path.exists
+local join = helpers.path.join
+
+
+local function get_kong_workers()
+  local workers
+  helpers.wait_until(function()
+    local pok, admin_client = pcall(helpers.admin_client)
+    if not pok then
+      return false
+    end
+    local res = admin_client:send {
+      method = "GET",
+      path = "/",
+    }
+    if not res or res.status ~= 200 then
+      return false
+    end
+    local body = assert.res_status(200, res)
+    local json = cjson.decode(body)
+
+    admin_client:close()
+    workers = json.pids.workers
+    return true
+  end, 10)
+  return workers
+end
+
+
+local function wait_until_no_common_workers(workers, expected_total, strategy)
+  if strategy == "cassandra" then
+    ngx.sleep(0.5)
+  end
+  helpers.wait_until(function()
+    local pok, admin_client = pcall(helpers.admin_client)
+    if not pok then
+      return false
+    end
+    local res = assert(admin_client:send {
+      method = "GET",
+      path = "/",
+    })
+    assert.res_status(200, res)
+    local json = cjson.decode(assert.res_status(200, res))
+    admin_client:close()
+
+    local new_workers = json.pids.workers
+    local total = 0
+    local common = 0
+    if new_workers then
+      for _, v in ipairs(new_workers) do
+        total = total + 1
+        for _, v_old in ipairs(workers) do
+          if v == v_old then
+            common = common + 1
+            break
+          end
+        end
+      end
+    end
+    return common == 0 and total == (expected_total or total)
+  end)
+end
+
+
+for _, strategy in helpers.each_strategy() do
+  describe("Mock Vault #" .. strategy, function()
+    local client
+    lazy_setup(function()
+      helpers.setenv("ADMIN_LISTEN", "127.0.0.1:9001")
+      helpers.setenv("KONG_LUA_PATH_OVERRIDE", "./spec/fixtures/custom_vaults/?.lua;./spec/fixtures/custom_vaults/?/init.lua;;")
+      helpers.get_db_utils(strategy, {
+        "vaults_beta",
+      },
+      nil, {
+        "env",
+        "mock"
+      })
+
+      assert(helpers.start_kong {
+        database = strategy,
+        prefix = helpers.test_conf.prefix,
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+        admin_listen = "{vault://mock/admin-listen}",
+        vaults = "env, mock",
+      })
+    end)
+
+    lazy_teardown(function()
+      helpers.stop_kong()
+      helpers.unsetenv("KONG_LUA_PATH_OVERRIDE")
+      helpers.unsetenv("ADMIN_LISTEN")
+    end)
+
+    after_each(function()
+      if client then
+        client:close()
+      end
+    end)
+
+    describe("Kong Start", function()
+      before_each(function()
+        client = assert(helpers.admin_client(10000))
+      end)
+
+      it("can use co-sockets and resolved referenced are passed to Kong server", function()
+        local res = client:get("/")
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.equal(meta._VERSION, json.version)
+        assert.falsy(exists(join(helpers.test_conf.prefix, ".kong_process_secrets")))
+      end)
+    end)
+
+    describe("Kong Reload", function()
+      it("can use co-sockets and resolved referenced are passed to Kong server", function()
+        local workers = get_kong_workers()
+
+        assert(helpers.kong_exec("reload --conf " .. helpers.test_conf_path ..
+                                 " --nginx-conf spec/fixtures/custom_nginx.template"))
+
+        wait_until_no_common_workers(workers, 1)
+
+        assert.falsy(exists(join(helpers.test_conf.prefix, ".kong_process_secrets")))
+
+        local res = client:get("/")
+        local body = assert.res_status(200, res)
+        local json = cjson.decode(body)
+        assert.equal(meta._VERSION, json.version)
+      end)
+    end)
+  end)
+end

--- a/spec/fixtures/custom_vaults/kong/vaults/mock/init.lua
+++ b/spec/fixtures/custom_vaults/kong/vaults/mock/init.lua
@@ -1,0 +1,37 @@
+local env = require "kong.vaults.env"
+local http = require "resty.http"
+
+
+local assert = assert
+local getenv = os.getenv
+
+
+local function init()
+  env.init()
+  assert(getenv("KONG_PROCESS_SECRETS") == nil, "KONG_PROCESS_SECRETS environment variable found")
+  assert(env.get({}, "KONG_PROCESS_SECRETS") == nil, "KONG_PROCESS_SECRETS environment variable found")
+end
+
+
+local function get(conf, resource, version)
+  local client, err = http.new()
+  if not client then
+    return nil, err
+  end
+
+  client:set_timeouts(20000, 20000, 20000)
+  assert(client:request_uri("http://mockbin.org/headers", {
+    headers = {
+      Accept = "application/json",
+    },
+  }))
+
+  return env.get(conf, resource, version)
+end
+
+
+return {
+  VERSION = "1.0.0",
+  init = init,
+  get = get,
+}

--- a/spec/fixtures/custom_vaults/kong/vaults/mock/schema.lua
+++ b/spec/fixtures/custom_vaults/kong/vaults/mock/schema.lua
@@ -1,0 +1,12 @@
+return {
+  name = "mock",
+  fields = {
+    {
+      config = {
+        type = "record",
+        fields = {
+        },
+      },
+    },
+  },
+}

--- a/spec/fixtures/custom_vaults/kong/vaults/mock/schema.lua
+++ b/spec/fixtures/custom_vaults/kong/vaults/mock/schema.lua
@@ -5,6 +5,7 @@ return {
       config = {
         type = "record",
         fields = {
+          { prefix = { type = "string", match = [[^[%a_][%a%d_]*$]] } },
         },
       },
     },

--- a/spec/kong_tests.conf
+++ b/spec/kong_tests.conf
@@ -29,11 +29,11 @@ nginx_main_worker_rlimit_nofile = NONE
 nginx_events_worker_connections = NONE
 nginx_events_multi_accept = off
 
-plugins=bundled,dummy,cache,rewriter,error-handler-log,error-generator,error-generator-last,short-circuit
+plugins = bundled,dummy,cache,rewriter,error-handler-log,error-generator,error-generator-last,short-circuit
 
 prefix = servroot
 log_level = debug
-lua_package_path=./spec/fixtures/custom_plugins/?.lua
+lua_package_path = ./spec/fixtures/custom_plugins/?.lua;./spec/fixtures/custom_vaults/?.lua;./spec/fixtures/custom_vaults/?/init.lua
 
 
 untrusted_lua = sandbox


### PR DESCRIPTION
### Summary

This PR comes with a few more fixes to Vault on how it handles process secrets.

#### fix(conf) infer vault references

Kong escapes e.g. `"#"` with `"\#"`, and these need to be removed before passing them to vault functions as otherwise reference like:

```
{vault://env/pg-passwordhttps://github.com/Kong/kong/issues/1}
```

Doesn't work as it gets past as:

```
{vault://env/pg-password\#1}
```

This fixes that.

#### fix(conf) ngx.socket.tcp not available on init

Kong's initialization parses Kong configuration twice:

1. first the config is parsed in timer context by kong start (cli)
2. then the config is parsed again in init context when kong server is started

Many Vault implementations will require the availability of `ngx.socket.tcp` to be able to fetch secrets. Unfortunately the `ngx.socket.tcp` is not available on init or init worker phases, but it works on timer context.

Alternative approach would be to fetch secrets using `LuaSocket` on init phase, but that would mean that each secret is fetched twice (added latency + possible costs of accessing Vaults). Also, it is impossible to make `LuaSocket` and `ngx.socket.tcp` fully compatible, but there is one project that at least tried it: https://github.com/thibaultcha/lua-resty-socket

This commit takes yet another approach:
1. it fetches secret on CLI
2. it passes secrets to server via temporary environment variable
3. except on `kong reload` it passes it to server via temporary file `.kong_process_secrets`

The error on current master branch looks like this:
```
Error: ./kong/cmd/start.lua:64: nginx: [error] init_by_lua error: ./kong/globalpatches.lua:396: no request found
```
#### fix(conf) allow only the enabled vaults

There was some logic that allowed the default bundled vaults even in case they were not enabled. This commit fixes that.

#### fix(conf) remove sensitive turns resolved configuration values back to references

When Vault references are used in `kong.conf` settings, these may be displayed in plain in Kong Admin API, e.g. in `http :8001` (except the `pg_password, `cassandra_password`, and `pg_ro_password` which were masked properly). This commit turns configuration values back to references as part of removing sensitive values (`conf_loader.remove_sensitive`).

#### fix(cmd) check db connection on reload

Database connection may be changed on `kong reload`, so it is good that we check that before we signal to actual Kong server process to `reload`.