### PR TITLE
Remove config cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,7 @@
 
 - Change the default of `lua_ssl_trusted_certificate` to `system`
   [#8602](https://github.com/Kong/kong/pull/8602) to automatically load trusted CA list from system CA store.
+- `data_plane_config_cache_mode` and `data_plane_config_cache_path` were removed [#8704](https://github.com/Kong/kong/pull/8704).
 
 ### Dependencies
 

--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -6,7 +6,6 @@ local ws_client = require("resty.websocket.client")
 local cjson = require("cjson.safe")
 local declarative = require("kong.db.declarative")
 local constants = require("kong.constants")
-local clustering_utils = require("kong.clustering.utils")
 local assert = assert
 local setmetatable = setmetatable
 local math = math
@@ -63,8 +62,6 @@ function _M:init_worker()
   -- ROLE = "data_plane"
 
   if ngx.worker.id() == 0 then
-    clustering_utils.load_config_cache(self)
-
     assert(ngx.timer.at(0, function(premature)
       self:communicate(premature)
     end))

--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -183,7 +183,7 @@ function _M:communicate(premature)
           local hashes = self.next_hashes
 
           local pok, res
-          pok, res, err = pcall(self.update_config, self, config_table, config_hash, true, hashes)
+          pok, res, err = pcall(self.update_config, self, config_table, config_hash, hashes)
           if pok then
             if not res then
               ngx_log(ngx_ERR, _log_prefix, "unable to update running config: ", err)

--- a/kong/clustering/init.lua
+++ b/kong/clustering/init.lua
@@ -2,7 +2,6 @@ local _M = {}
 
 local constants = require("kong.constants")
 local declarative = require("kong.db.declarative")
-local clustering_utils = require("kong.clustering.utils")
 local version_negotiation = require("kong.clustering.version_negotiation")
 local pl_file = require("pl.file")
 local pl_tablex = require("pl.tablex")
@@ -217,7 +216,7 @@ function _M:request_version_negotiation()
 end
 
 
-function _M:update_config(config_table, config_hash, update_cache, hashes)
+function _M:update_config(config_table, config_hash, hashes)
   assert(type(config_table) == "table")
 
   if not config_hash then
@@ -254,11 +253,6 @@ function _M:update_config(config_table, config_hash, update_cache, hashes)
   res, err = declarative.load_into_cache_with_events(entities, meta, new_hash, hashes)
   if not res then
     return nil, err
-  end
-
-  if update_cache then
-    -- local persistence only after load finishes without error
-    clustering_utils.save_config_cache(self, config_table)
   end
 
   return true

--- a/kong/clustering/init.lua
+++ b/kong/clustering/init.lua
@@ -315,7 +315,6 @@ function _M:init_worker()
       end
 
       if self.child then
-        clustering_utils.load_config_cache(self.child)
         self.child:communicate()
       end
     end))

--- a/kong/clustering/utils.lua
+++ b/kong/clustering/utils.lua
@@ -5,36 +5,20 @@ local openssl_x509 = require("resty.openssl.x509")
 local ssl = require("ngx.ssl")
 local ocsp = require("ngx.ocsp")
 local http = require("resty.http")
-local system_constants = require("lua_system_constants")
-local bit = require("bit")
-local ffi = require("ffi")
 
 local type = type
 local tonumber = tonumber
 
-local C = ffi.C
-local bor = bit.bor
-
-local io_open = io.open
 local ngx_var = ngx.var
-local cjson_decode = require "cjson.safe".decode
-local cjson_encode = require "cjson.safe".encode
-
-local inflate_gzip = require("kong.tools.utils").inflate_gzip
-local deflate_gzip = require("kong.tools.utils").deflate_gzip
 
 local ngx_log = ngx.log
-local ngx_ERR = ngx.ERR
 local ngx_INFO = ngx.INFO
 local ngx_WARN = ngx.WARN
 local _log_prefix = "[clustering] "
 
-local CONFIG_CACHE = ngx.config.prefix() .. "/config.cache.json.gz"
-
 local MAJOR_MINOR_PATTERN = "^(%d+)%.(%d+)%.%d+"
 local CLUSTERING_SYNC_STATUS = constants.CLUSTERING_SYNC_STATUS
 local OCSP_TIMEOUT = constants.CLUSTERING_OCSP_TIMEOUT
-
 
 
 local clustering_utils = {}
@@ -214,75 +198,6 @@ function clustering_utils.validate_connection_certs(conf, cert_digest)
   end
 
   return true
-end
-
-function clustering_utils.load_config_cache(self)
-  local f = io_open(CONFIG_CACHE, "r")
-  if f then
-    local config, err = f:read("*a")
-    if not config then
-      ngx_log(ngx_ERR, _log_prefix, "unable to read cached config file: ", err)
-    end
-
-    f:close()
-
-    if config and #config > 0 then
-      ngx_log(ngx_INFO, _log_prefix, "found cached config, loading...")
-      config, err = inflate_gzip(config)
-      if config then
-        config, err = cjson_decode(config)
-        if config then
-          local res
-          res, err = self:update_config(config)
-          if not res then
-            ngx_log(ngx_ERR, _log_prefix, "unable to update running config from cache: ", err)
-          end
-
-        else
-          ngx_log(ngx_ERR, _log_prefix, "unable to json decode cached config: ", err, ", ignoring")
-        end
-
-      else
-        ngx_log(ngx_ERR, _log_prefix, "unable to decode cached config: ", err, ", ignoring")
-      end
-    end
-
-  else
-    -- CONFIG_CACHE does not exist, pre create one with 0600 permission
-    local flags = bor(system_constants.O_RDONLY(),
-      system_constants.O_CREAT())
-
-    local mode = ffi.new("int", bor(system_constants.S_IRUSR(),
-      system_constants.S_IWUSR()))
-
-    local fd = C.open(CONFIG_CACHE, flags, mode)
-    if fd == -1 then
-      ngx_log(ngx_ERR, _log_prefix, "unable to pre-create cached config file: ",
-        ffi.string(C.strerror(ffi.errno())))
-
-    else
-      C.close(fd)
-    end
-  end
-end
-
-
-function clustering_utils.save_config_cache(self, config_table)
-  local f, err = io_open(CONFIG_CACHE, "w")
-  if not f then
-    ngx_log(ngx_ERR, _log_prefix, "unable to open config cache file: ", err)
-
-  else
-    local config = assert(cjson_encode(config_table))
-    config = assert(deflate_gzip(config))
-    local res
-    res, err = f:write(config)
-    if not res then
-      ngx_log(ngx_ERR, _log_prefix, "unable to write config cache file: ", err)
-    end
-
-    f:close()
-  end
 end
 
 return clustering_utils

--- a/kong/clustering/wrpc_data_plane.lua
+++ b/kong/clustering/wrpc_data_plane.lua
@@ -5,7 +5,6 @@ local declarative = require("kong.db.declarative")
 local protobuf = require("kong.tools.protobuf")
 local wrpc = require("kong.tools.wrpc")
 local constants = require("kong.constants")
-local clustering_utils = require("kong.clustering.utils")
 local assert = assert
 local setmetatable = setmetatable
 local type = type
@@ -46,8 +45,6 @@ function _M:init_worker()
   -- ROLE = "data_plane"
 
   if ngx.worker.id() == 0 then
-    clustering_utils.load_config_cache(self)
-
     assert(ngx.timer.at(0, function(premature)
       self:communicate(premature)
     end))

--- a/kong/clustering/wrpc_data_plane.lua
+++ b/kong/clustering/wrpc_data_plane.lua
@@ -187,7 +187,7 @@ function _M:communicate(premature)
           ngx_log(ngx_INFO, _log_prefix, "received config #", config_version, log_suffix)
 
           local pok, res
-          pok, res, err = xpcall(self.update_config, debug.traceback, self, config_table, config_hash, true, hashes)
+          pok, res, err = xpcall(self.update_config, debug.traceback, self, config_table, config_hash, hashes)
           if pok then
             last_config_version = config_version
             if not res then

--- a/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
@@ -218,14 +218,6 @@ for _, strategy in helpers.each_strategy() do
           end, 5)
         end)
 
-        it("local cached config file has correct permission", function()
-          local handle = io.popen("ls -l servroot2/config.cache.json.gz")
-          local result = handle:read("*a")
-          handle:close()
-
-          assert.matches("-rw-------", result, nil, true)
-        end)
-
         it('does not sync services where enabled == false', function()
           local admin_client = helpers.admin_client(10000)
           finally(function()

--- a/spec/02-integration/11-dbless/03-config_persistence.lua
+++ b/spec/02-integration/11-dbless/03-config_persistence.lua
@@ -85,7 +85,6 @@ describe("dbless persistence with a declarative config #off", function()
         database   = "off",
         declarative_config = yaml_file,
     }))
-
     admin_client = assert(helpers.admin_client())
     proxy_client = assert(helpers.proxy_client())
 
@@ -118,7 +117,6 @@ describe("dbless persistence with a declarative config #off", function()
     end
     helpers.stop_kong(nil, true)
   end)
-
   lazy_teardown(function()
     os.remove(yaml_file)
   end)
@@ -141,7 +139,6 @@ describe("dbless persistence with a declarative config #off", function()
       database   = "off",
       declarative_config = yaml_file,
     }))
-
     local res
     helpers.wait_until(function()
       proxy_client = assert(helpers.proxy_client())


### PR DESCRIPTION
The data plane configuration is now persisted on disk with the LMDB database. At startup,
the node automatically reload the latest version of the configuration. The config cache mechanism is not useful
anymore.

Do not merge, depends on: https://github.com/Kong/kong/pull/8670