### PR TITLE
test(packaging): do a quick validation that Kong can viably be packaged

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,24 @@ pipeline {
         DEBUG = 0
     }
     stages {
+        stage('Test The Package') {
+            agent {
+                node {
+                    label 'bionic'
+                }
+            }
+            when { changeRequest target: 'master' }
+            environment {
+                KONG_BUILD_TOOLS_LOCATION = "${env.WORKSPACE}/../kong-build-tools"
+                KONG_SOURCE_LOCATION = "${env.WORKSPACE}"
+            }
+            steps {
+                sh 'echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin || true'
+                sh 'make setup-kong-build-tools'
+                sh 'cd /home/ubuntu/workspace/kong_test_packaging/../kong-build-tools && make package-kong test'
+            }
+            
+        }
         stage('Release Per Commit') {
             when {
                 beforeAgent true


### PR DESCRIPTION
Some recent PR's have broken our ability to package / run Kong.

This PR uses our packaging / release tooling to do a single test run.