### PR TITLE
perf(pdk) faster req.get_header implementation

### DIFF
--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -44,12 +44,12 @@ do -- add patch for faster ngx.req.get_header
 
   -- clear the cache if header changed
   local origin_set_header = ngx.req.set_header
-  function ngx.req.set_header(header_name, header_value)
+  function ngx.req.set_header(header_name, header_value) -- luacheck: ignore
     req_get_headers_cache[ngx.ctx] = nil
     return origin_set_header(header_name, header_value)
   end
 
-  function ngx.req.get_header(name)
+  function ngx.req.get_header(name) -- luacheck: ignore
     return req_get_headers_cached()[name]
   end
 end

--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -31,7 +31,7 @@ cjson.decode_array_with_array_mt(true)
 do -- add patch for faster ngx.req.get_header
   local req_get_headers = ngx.req.get_headers
   -- use ngx.ctx as weak cache key
-  local req_get_headers_cache = setmetatable({}, {__mode="k"})
+  local req_get_headers_cache = setmetatable({}, {__mode = "k",})
   local function req_get_headers_cached()
     local ctx = ngx.ctx
     local cache = req_get_headers_cache[ctx]
@@ -55,6 +55,7 @@ do -- add patch for faster ngx.req.get_header
 end
 
 
+local ngx_req_get_header = ngx.req.get_header
 local function new(self)
   local _REQUEST = {}
 
@@ -595,7 +596,7 @@ local function new(self)
       error("header name must be a string", 2)
     end
 
-    local header_value = ngx.req.get_header(name)
+    local header_value = ngx_req_get_header(name)
     if type(header_value) == "table" then
       return header_value[1]
     end

--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -55,7 +55,7 @@ do -- add patch for faster ngx.req.get_header
 end
 
 
-local ngx_req_get_header = ngx.req.get_header
+local ngx_req_get_header = ngx.req.get_header -- luacheck: ignore
 local function new(self)
   local _REQUEST = {}
 


### PR DESCRIPTION
Support this by a patch to `ngx.req` and caching the get_headers() result.

I thought the fix can be put to `globalpatches.lua` but I don't know why it doesn't work. Please suggest a better place to put the patch.

Also, a better solution would be a real implementation of `ngx.req.get_header`.

DO NOT BE EAGER TO MERGE THIS PR!

Fix FT-2780
