### PR TITLE
feat(plugin) Adjust Prometheus to be the reference Impl for metrics

### DIFF
--- a/kong/plugins/prometheus/exporter.lua
+++ b/kong/plugins/prometheus/exporter.lua
@@ -16,12 +16,13 @@ local stream_available, stream_api = pcall(require, "kong.tools.stream_api")
 
 local role = kong.configuration.role
 
-local DEFAULT_BUCKETS = { 1, 2, 5, 7, 10, 15, 20, 25, 30, 40, 50, 60, 70,
-                          80, 90, 100, 200, 300, 400, 500, 1000,
-                          2000, 5000, 10000, 30000, 60000 }
+local KONG_LATENCY_BUCKETS = { 1, 2, 5, 7, 10, 15, 20, 30, 50, 75, 100, 200, 500, 750, 1000}
+local UPSTREAM_LATENCY_BUCKETS = {25, 50, 80, 100, 250, 400, 700, 1000, 2000, 5000, 10000, 30000, 60000 }
+
 local metrics = {}
 -- prometheus.lua instance
 local prometheus
+local node_id = kong.node.get_id()
 
 -- use the same counter library shipped with Kong
 package.loaded['prometheus_resty_counter'] = require("resty.counter")
@@ -39,21 +40,20 @@ local function init()
   prometheus = require("kong.plugins.prometheus.prometheus").init(shm, "kong_")
 
   -- global metrics
-  if kong_subsystem == "http" then
-    metrics.connections = prometheus:gauge("nginx_http_current_connections",
-      "Number of HTTP connections",
-      {"state"})
-  else
-    metrics.connections = prometheus:gauge("nginx_stream_current_connections",
-      "Number of Stream connections",
-      {"state"})
-  end
+  metrics.connections = prometheus:gauge("nginx_connections_total",
+    "Number of connections by subsystem",
+    {"node_id", "subsystem", "state"})
+  metrics.nginx_requests_total = prometheus:gauge("nginx_requests_total",
+      "Number of requests total", {"node_id", "subsystem"})
   metrics.timers = prometheus:gauge("nginx_timers",
                                     "Number of nginx timers",
                                     {"state"})
   metrics.db_reachable = prometheus:gauge("datastore_reachable",
                                           "Datastore reachable from Kong, " ..
                                           "0 is unreachable")
+  metrics.node_info = prometheus:gauge("node_info",
+                                       "Kong Node metadata information",
+                                       {"node_id", "version"})
   -- only export upstream health metrics in traditional mode and data plane
   if role ~= "control_plane" then
     metrics.upstream_target_health = prometheus:gauge("upstream_target_health",
@@ -66,44 +66,60 @@ local function init()
   local memory_stats = {}
   memory_stats.worker_vms = prometheus:gauge("memory_workers_lua_vms_bytes",
                                              "Allocated bytes in worker Lua VM",
-                                             {"pid", "kong_subsystem"})
+                                             {"node_id", "pid", "kong_subsystem"})
   memory_stats.shms = prometheus:gauge("memory_lua_shared_dict_bytes",
                                        "Allocated slabs in bytes in a shared_dict",
-                                       {"shared_dict", "kong_subsystem"})
+                                       {"node_id", "shared_dict", "kong_subsystem"})
   memory_stats.shm_capacity = prometheus:gauge("memory_lua_shared_dict_total_bytes",
                                                "Total capacity in bytes of a shared_dict",
-                                               {"shared_dict", "kong_subsystem"})
+                                               {"node_id", "shared_dict", "kong_subsystem"})
 
   local res = kong.node.get_memory_stats()
   for shm_name, value in pairs(res.lua_shared_dicts) do
-    memory_stats.shm_capacity:set(value.capacity, { shm_name, kong_subsystem })
+    memory_stats.shm_capacity:set(value.capacity, { node_id, shm_name, kong_subsystem })
   end
 
   metrics.memory_stats = memory_stats
 
   -- per service/route
   if kong_subsystem == "http" then
-    metrics.status = prometheus:counter("http_status",
-                                        "HTTP status codes per service/route in Kong",
-                                        {"service", "route", "code"})
+    metrics.status = prometheus:counter("http_requests_total",
+                                        "HTTP status codes per consumer/service/route in Kong",
+                                        {"service", "route", "code", "source", "consumer"})
   else
     metrics.status = prometheus:counter("stream_status",
-                                        "Stream status codes per service/route in Kong",
-                                        {"service", "route", "code"})
+                                        "Stream status codes per consumer/service/route in Kong",
+                                        {"service", "route", "code", "source"})
   end
-  metrics.latency = prometheus:histogram("latency",
-                                         "Latency added by Kong, total " ..
-                                         "request time and upstream latency " ..
-                                         "for each service/route in Kong",
-                                         {"service", "route", "type"},
-                                         DEFAULT_BUCKETS) -- TODO make this configurable
-  metrics.bandwidth = prometheus:counter("bandwidth",
-                                         "Total bandwidth in bytes " ..
-                                         "consumed per service/route in Kong",
-                                         {"service", "route", "type"})
-  metrics.consumer_status = prometheus:counter("http_consumer_status",
-                                          "HTTP status codes for customer per service/route in Kong",
-                                          {"service", "route", "code", "consumer"})
+  metrics.kong_latency = prometheus:histogram("kong_latency_ms",
+                                              "Latency added by Kong and enabled plugins " ..
+                                              "for each service/route in Kong",
+                                              {"service", "route"},
+                                              KONG_LATENCY_BUCKETS)
+  metrics.upstream_latency = prometheus:histogram("upstream_latency_ms",
+                                                  "Latency added by upstream response " ..
+                                                  "for each service/route in Kong",
+                                                  {"service", "route"},
+                                                  UPSTREAM_LATENCY_BUCKETS)
+
+
+  if kong_subsystem == "http" then
+    metrics.total_latency = prometheus:histogram("request_latency_ms",
+                                                 "Total latency incurred during requests " ..
+                                                 "for each service/route in Kong",
+                                                 {"service", "route"},
+                                                 UPSTREAM_LATENCY_BUCKETS)
+  else
+    metrics.total_latency = prometheus:histogram("tcp_session_duration_ms",
+                                                 "latency incurred in stream tcp session " ..
+                                                 "for each service/route in Kong",
+                                                 {"service", "route"},
+                                                 UPSTREAM_LATENCY_BUCKETS)
+  end
+  metrics.bandwidth = prometheus:counter("bandwidth_bytes",
+                                         "Total bandwidth (ingress/egress) " ..
+                                         "throughput in bytes",
+                                         {"service", "route", "direction", "consumer"})
 
   -- Hybrid mode status
   if role == "control_plane" then
@@ -146,8 +162,9 @@ end
 
 -- Since in the prometheus library we create a new table for each diverged label
 -- so putting the "more dynamic" label at the end will save us some memory
-local labels_table = {0, 0, 0}
-local labels_table4 = {0, 0, 0, 0}
+local labels_table = {0, 0, 0, 0}
+local labels_table_status = {0, 0, 0, 0, 0}
+local latency_labels_table = {0, 0}
 local upstream_target_addr_health_table = {
   { value = 0, labels = { 0, 0, 0, "healthchecks_off", ngx.config.subsystem } },
   { value = 0, labels = { 0, 0, 0, "healthy", ngx.config.subsystem } },
@@ -190,10 +207,26 @@ if kong_subsystem == "http" then
       route_name = message.route.name or message.route.id
     end
 
+    local consumer = ""
+    if message and serialized.consumer ~= nil then
+      consumer = serialized.consumer
+    end
+
     labels_table[1] = service_name
     labels_table[2] = route_name
     labels_table[3] = message.response.status
-    metrics.status:inc(1, labels_table)
+    labels_table[4] = consumer
+
+    labels_table_status[1] = service_name
+    labels_table_status[2] = route_name
+    labels_table_status[3] = message.response.status
+    labels_table_status[4] = kong.response.get_source()
+    labels_table_status[5] = consumer
+
+    latency_labels_table[1] = service_name
+    latency_labels_table[2] = route_name
+
+    metrics.status:inc(1, labels_table_status)
 
     local request_size = tonumber(message.request.size)
     if request_size and request_size > 0 then
@@ -209,33 +242,22 @@ if kong_subsystem == "http" then
 
     local request_latency = message.latencies.request
     if request_latency and request_latency >= 0 then
-      labels_table[3] = "request"
-      metrics.latency:observe(request_latency, labels_table)
+      metrics.total_latency:observe(request_latency, latency_labels_table)
     end
 
     local upstream_latency = message.latencies.proxy
     if upstream_latency ~= nil and upstream_latency >= 0 then
-      labels_table[3] = "upstream"
-      metrics.latency:observe(upstream_latency, labels_table)
+      metrics.upstream_latency:observe(upstream_latency, latency_labels_table)
     end
 
     local kong_proxy_latency = message.latencies.kong
     if kong_proxy_latency ~= nil and kong_proxy_latency >= 0 then
-      labels_table[3] = "kong"
-      metrics.latency:observe(kong_proxy_latency, labels_table)
+      metrics.kong_latency:observe(kong_proxy_latency, latency_labels_table)
     end
 
-    if serialized.consumer ~= nil then
-      labels_table4[1] = labels_table[1]
-      labels_table4[2] = labels_table[2]
-      labels_table4[3] = message.response.status
-      labels_table4[4] = serialized.consumer
-      metrics.consumer_status:inc(1, labels_table4)
-    end
   end
-
 else
-  function log(message)
+  function log(message, serialized)
     if not metrics then
       kong.log.err("prometheus: can not log metrics because of an initialization "
               .. "error, please make sure that you've declared "
@@ -259,6 +281,11 @@ else
     labels_table[1] = service_name
     labels_table[2] = route_name
     labels_table[3] = message.session.status
+    labels_table[4] = kong.response.get_source()
+
+    latency_labels_table[1] = service_name
+    latency_labels_table[2] = route_name
+
     metrics.status:inc(1, labels_table)
 
     local ingress_size = tonumber(message.session.received)
@@ -275,14 +302,12 @@ else
 
     local session_latency = message.latencies.session
     if session_latency and session_latency >= 0 then
-      labels_table[3] = "request"
-      metrics.latency:observe(session_latency, labels_table)
+      metrics.total_latency:observe(session_latency, latency_labels_table)
     end
 
     local kong_proxy_latency = message.latencies.kong
     if kong_proxy_latency ~= nil and kong_proxy_latency >= 0 then
-      labels_table[3] = "kong"
-      metrics.latency:observe(kong_proxy_latency, labels_table)
+      metrics.kong_latency:observe(kong_proxy_latency, latency_labels_table)
     end
   end
 end
@@ -296,13 +321,17 @@ local function metric_data()
   end
 
   local nginx_statistics = kong.nginx.get_statistics()
-  metrics.connections:set(nginx_statistics['connections_accepted'], { "accepted" })
-  metrics.connections:set(nginx_statistics['connections_handled'], { "handled" })
-  metrics.connections:set(nginx_statistics['total_requests'], { "total" })
-  metrics.connections:set(nginx_statistics['connections_active'], { "active" })
-  metrics.connections:set(nginx_statistics['connections_reading'], { "reading" })
-  metrics.connections:set(nginx_statistics['connections_writing'], { "writing" })
-  metrics.connections:set(nginx_statistics['connections_waiting'], { "waiting" })
+  metrics.connections:set(nginx_statistics['connections_accepted'], { node_id, kong_subsystem, "accepted" })
+  metrics.connections:set(nginx_statistics['connections_handled'], { node_id, kong_subsystem, "handled" })
+  metrics.connections:set(nginx_statistics['total_requests'], { node_id, kong_subsystem, "total" })
+  metrics.connections:set(nginx_statistics['connections_active'], { node_id, kong_subsystem, "active" })
+  metrics.connections:set(nginx_statistics['connections_reading'], { node_id, kong_subsystem, "reading" })
+  metrics.connections:set(nginx_statistics['connections_writing'], { node_id, kong_subsystem, "writing" })
+  metrics.connections:set(nginx_statistics['connections_waiting'], { node_id, kong_subsystem,"waiting" })
+  metrics.connections:set(nginx_statistics['connections_accepted'], { node_id, kong_subsystem, "accepted" })
+  metrics.connections:set(nginx_statistics['connections_handled'], { node_id, kong_subsystem, "handled" })
+
+  metrics.nginx_requests_total:set(nginx_statistics['total_requests'], { node_id, kong_subsystem })
 
   metrics.timers:set(ngx_timer_running_count(), {"running"})
   metrics.timers:set(ngx_timer_pending_count(), {"pending"})
@@ -357,11 +386,11 @@ local function metric_data()
   -- memory stats
   local res = kong.node.get_memory_stats()
   for shm_name, value in pairs(res.lua_shared_dicts) do
-    metrics.memory_stats.shms:set(value.allocated_slabs, { shm_name, kong_subsystem })
+    metrics.memory_stats.shms:set(value.allocated_slabs, { node_id, shm_name, kong_subsystem })
   end
   for i = 1, #res.workers_lua_vms do
     metrics.memory_stats.worker_vms:set(res.workers_lua_vms[i].http_allocated_gc,
-                                        { res.workers_lua_vms[i].pid, kong_subsystem })
+                                        { node_id, res.workers_lua_vms[i].pid, kong_subsystem })
   end
 
   -- Hybrid mode status

--- a/kong/plugins/prometheus/exporter.lua
+++ b/kong/plugins/prometheus/exporter.lua
@@ -111,7 +111,7 @@ local function init()
                                                  UPSTREAM_LATENCY_BUCKETS)
   else
     metrics.total_latency = prometheus:histogram("session_duration_ms",
-                                                 "latency incurred in stream tcp session " ..
+                                                 "latency incurred in stream session " ..
                                                  "for each service/route in Kong",
                                                  {"service", "route"},
                                                  UPSTREAM_LATENCY_BUCKETS)

--- a/kong/plugins/prometheus/exporter.lua
+++ b/kong/plugins/prometheus/exporter.lua
@@ -287,7 +287,12 @@ else
     labels_table[1] = service_name
     labels_table[2] = route_name
     labels_table[3] = message.session.status
-    labels_table[4] = kong.response.get_source()
+
+    if kong.response.get_source() == "service" then
+      labels_table[4] = "service"
+    else
+      labels_table[4] = "kong"
+    end
 
     latency_labels_table[1] = service_name
     latency_labels_table[2] = route_name

--- a/kong/plugins/prometheus/exporter.lua
+++ b/kong/plugins/prometheus/exporter.lua
@@ -110,7 +110,7 @@ local function init()
                                                  {"service", "route"},
                                                  UPSTREAM_LATENCY_BUCKETS)
   else
-    metrics.total_latency = prometheus:histogram("tcp_session_duration_ms",
+    metrics.total_latency = prometheus:histogram("session_duration_ms",
                                                  "latency incurred in stream tcp session " ..
                                                  "for each service/route in Kong",
                                                  {"service", "route"},
@@ -220,7 +220,13 @@ if kong_subsystem == "http" then
     labels_table_status[1] = service_name
     labels_table_status[2] = route_name
     labels_table_status[3] = message.response.status
-    labels_table_status[4] = kong.response.get_source()
+
+    if kong.response.get_source() == "service" then
+      labels_table_status[4] = "service"
+    else
+      labels_table_status[4] = "kong"
+    end
+
     labels_table_status[5] = consumer
 
     latency_labels_table[1] = service_name

--- a/kong/plugins/prometheus/handler.lua
+++ b/kong/plugins/prometheus/handler.lua
@@ -7,7 +7,7 @@ prometheus.init()
 
 local PrometheusHandler = {
   PRIORITY = 13,
-  VERSION  = "1.6.0",
+  VERSION  = "3.0.0",
 }
 
 function PrometheusHandler.init_worker()

--- a/spec/03-plugins/26-prometheus/02-access_spec.lua
+++ b/spec/03-plugins/26-prometheus/02-access_spec.lua
@@ -200,7 +200,7 @@ describe("Plugin: prometheus (access)", function()
       local body = assert.res_status(200, res)
       assert.matches('kong_nginx_metric_errors_total 0', body, nil, true)
       assert.matches('kong_stream_status{service="tcp-service",route="tcp-route",code="200",source="service"} 1', body, nil, true)
-      assert.matches('kong_tcp_session_duration_ms_bucket{service="tcp%-service",route="tcp%-route",le="%+Inf"} %d+', body)
+      assert.matches('kong_session_duration_ms_bucket{service="tcp%-service",route="tcp%-route",le="%+Inf"} %d+', body)
 
       return body:find('kong_stream_status{service="tcp-service",route="tcp-route",code="200",source="service"} 1', nil, true)
     end)

--- a/spec/03-plugins/26-prometheus/02-access_spec.lua
+++ b/spec/03-plugins/26-prometheus/02-access_spec.lua
@@ -2,6 +2,7 @@ local helpers = require "spec.helpers"
 
 local tcp_service_port = helpers.get_available_port()
 local tcp_proxy_port = helpers.get_available_port()
+local UUID_PATTERN = "%x%x%x%x%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%x%x%x%x%x%x%x%x"
 
 describe("Plugin: prometheus (access)", function()
   local proxy_client
@@ -108,7 +109,7 @@ describe("Plugin: prometheus (access)", function()
       local body = assert.res_status(200, res)
       assert.matches('kong_nginx_metric_errors_total 0', body, nil, true)
 
-      return body:find('kong_http_status{service="mock-service",route="http-route",code="200"} 1', nil, true)
+      return body:find('http_requests_total{service="mock-service",route="http-route",code="200",source="service",consumer=""} 1', nil, true)
     end)
 
     res = assert(proxy_client:send {
@@ -128,7 +129,7 @@ describe("Plugin: prometheus (access)", function()
       local body = assert.res_status(200, res)
       assert.matches('kong_nginx_metric_errors_total 0', body, nil, true)
 
-      return body:find('kong_http_status{service="mock-service",route="http-route",code="400"} 1', nil, true)
+      return body:find('http_requests_total{service="mock-service",route="http-route",code="400",source="service",consumer=""} 1', nil, true)
     end)
   end)
 
@@ -153,7 +154,7 @@ describe("Plugin: prometheus (access)", function()
       local body = assert.res_status(200, res)
       assert.matches('kong_nginx_metric_errors_total 0', body, nil, true)
 
-      return body:find('kong_http_status{service="mock-grpc-service",route="grpc-route",code="200"} 1', nil, true)
+      return body:find('http_requests_total{service="mock-grpc-service",route="grpc-route",code="200",source="service",consumer=""} 1', nil, true)
     end)
 
     ok, resp = proxy_client_grpcs({
@@ -176,7 +177,7 @@ describe("Plugin: prometheus (access)", function()
       local body = assert.res_status(200, res)
       assert.matches('kong_nginx_metric_errors_total 0', body, nil, true)
 
-      return body:find('kong_http_status{service="mock-grpcs-service",route="grpcs-route",code="200"} 1', nil, true)
+      return body:find('http_requests_total{service="mock-grpcs-service",route="grpcs-route",code="200",source="service",consumer=""} 1', nil, true)
     end)
   end)
 
@@ -198,8 +199,10 @@ describe("Plugin: prometheus (access)", function()
       })
       local body = assert.res_status(200, res)
       assert.matches('kong_nginx_metric_errors_total 0', body, nil, true)
+      assert.matches('kong_stream_status{service="tcp-service",route="tcp-route",code="200",source="service"} 1', body, nil, true)
+      assert.matches('kong_tcp_session_duration_ms_bucket{service="tcp%-service",route="tcp%-route",le="%+Inf"} %d+', body)
 
-      return body:find('kong_stream_status{service="tcp-service",route="tcp-route",code="200"} 1', nil, true)
+      return body:find('kong_stream_status{service="tcp-service",route="tcp-route",code="200",source="service"} 1', nil, true)
     end)
 
     thread:join()
@@ -266,8 +269,8 @@ describe("Plugin: prometheus (access)", function()
       path    = "/metrics",
     })
     local body = assert.res_status(200, res)
-    assert.matches('kong_memory_workers_lua_vms_bytes{pid="%d+",kong_subsystem="http"} %d+', body)
-    assert.matches('kong_memory_workers_lua_vms_bytes{pid="%d+",kong_subsystem="stream"} %d+', body)
+    assert.matches('kong_memory_workers_lua_vms_bytes{node_id="' .. UUID_PATTERN .. '",pid="%d+",kong_subsystem="http"} %d+', body)
+    assert.matches('kong_memory_workers_lua_vms_bytes{node_id="' .. UUID_PATTERN .. '",pid="%d+",kong_subsystem="stream"} %d+', body)
 
     assert.matches('kong_nginx_metric_errors_total 0', body, nil, true)
   end)
@@ -279,7 +282,7 @@ describe("Plugin: prometheus (access)", function()
     })
     local body = assert.res_status(200, res)
     assert.matches('kong_memory_lua_shared_dict_total_bytes' ..
-                   '{shared_dict="prometheus_metrics",kong_subsystem="http"} %d+', body)
+                   '{node_id="' .. UUID_PATTERN .. '",shared_dict="prometheus_metrics",kong_subsystem="http"} %d+', body)
     -- TODO: uncomment below once the ngx.shared iterrator in stream is fixed
     -- if stream_available then
     --   assert.matches('kong_memory_lua_shared_dict_total_bytes' ..
@@ -333,8 +336,8 @@ describe("Plugin: prometheus (access) no stream listeners", function()
       path    = "/metrics",
     })
     local body = assert.res_status(200, res)
-    assert.matches('kong_memory_workers_lua_vms_bytes{pid="%d+",kong_subsystem="http"}', body)
-    assert.not_matches('kong_memory_workers_lua_vms_bytes{pid="%d+",kong_subsystem="stream"}', body)
+    assert.matches('kong_memory_workers_lua_vms_bytes{node_id="' .. UUID_PATTERN .. '",pid="%d+",kong_subsystem="http"}', body)
+    assert.not_matches('kong_memory_workers_lua_vms_bytes{node_id="' .. UUID_PATTERN .. '",pid="%d+",kong_subsystem="stream"}', body)
 
     assert.matches('kong_nginx_metric_errors_total 0', body, nil, true)
   end)
@@ -346,10 +349,10 @@ describe("Plugin: prometheus (access) no stream listeners", function()
     })
     local body = assert.res_status(200, res)
     assert.matches('kong_memory_lua_shared_dict_total_bytes' ..
-                   '{shared_dict="prometheus_metrics",kong_subsystem="http"} %d+', body)
+                   '{node_id="' .. UUID_PATTERN .. '",shared_dict="prometheus_metrics",kong_subsystem="http"} %d+', body)
 
     assert.not_matches('kong_memory_lua_shared_dict_bytes' ..
-                   '{shared_dict="stream_prometheus_metric",kong_subsystem="stream"} %d+', body)
+                   '{node_id="' .. UUID_PATTERN .. '",shared_dict="stream_prometheus_metric",kong_subsystem="stream"} %d+', body)
     assert.matches('kong_nginx_metric_errors_total 0', body, nil, true)
   end)
 end)
@@ -436,7 +439,7 @@ describe("Plugin: prometheus (access) per-consumer metrics", function()
       local body = assert.res_status(200, res)
       assert.matches('kong_nginx_metric_errors_total 0', body, nil, true)
 
-      return body:find('kong_http_consumer_status{service="mock-service",route="http-route",code="200",consumer="alice"} 1', nil, true)
+      return body:find('http_requests_total{service="mock-service",route="http-route",code="200",source="service",consumer="alice"} 1', nil, true)
     end)
 
     res = assert(proxy_client:send {
@@ -457,7 +460,7 @@ describe("Plugin: prometheus (access) per-consumer metrics", function()
       local body = assert.res_status(200, res)
       assert.matches('kong_nginx_metric_errors_total 0', body, nil, true)
 
-      return body:find('kong_http_consumer_status{service="mock-service",route="http-route",code="400",consumer="alice"} 1', nil, true)
+      return body:find('http_requests_total{service="mock-service",route="http-route",code="400",source="service",consumer="alice"} 1', nil, true)
     end)
   end)
 
@@ -478,11 +481,10 @@ describe("Plugin: prometheus (access) per-consumer metrics", function()
         path    = "/metrics",
       })
       body = assert.res_status(200, res)
-      return body:find('kong_http_status{service="mock-service",route="http-route",code="200"} 1', nil, true)
+      return body:find('http_requests_total{service="mock-service",route="http-route",code="200",source="service",consumer="alice"} 1', nil, true)
     end)
 
-    assert.not_match('kong_http_consumer_status{service="mock-service",route="http-route",code="401",consumer="alice"} 1', body, nil, true)
-    assert.matches('kong_http_status{service="mock-service",route="http-route",code="401"} 1', body, nil, true)
+    assert.matches('http_requests_total{service="mock-service",route="http-route",code="401",source="exit",consumer=""} 1', body, nil, true)
 
     assert.matches('kong_nginx_metric_errors_total 0', body, nil, true)
   end)

--- a/spec/03-plugins/26-prometheus/02-access_spec.lua
+++ b/spec/03-plugins/26-prometheus/02-access_spec.lua
@@ -484,7 +484,7 @@ describe("Plugin: prometheus (access) per-consumer metrics", function()
       return body:find('http_requests_total{service="mock-service",route="http-route",code="200",source="service",consumer="alice"} 1', nil, true)
     end)
 
-    assert.matches('http_requests_total{service="mock-service",route="http-route",code="401",source="exit",consumer=""} 1', body, nil, true)
+    assert.matches('http_requests_total{service="mock-service",route="http-route",code="401",source="kong",consumer=""} 1', body, nil, true)
 
     assert.matches('kong_nginx_metric_errors_total 0', body, nil, true)
   end)

--- a/spec/03-plugins/26-prometheus/03-custom-serve_spec.lua
+++ b/spec/03-plugins/26-prometheus/03-custom-serve_spec.lua
@@ -57,7 +57,7 @@ describe("Plugin: prometheus (custom server)",function()
         path    = "/metrics",
       })
       local body = assert.res_status(200, res)
-      assert.matches('kong_http_status{service="mock-service",route="http-route",code="200"} 1', body, nil, true)
+      assert.matches('http_requests_total{service="mock-service",route="http-route",code="200",source="service",consumer=""} 1', body, nil, true)
     end)
     it("custom port returns 404 for anything other than /metrics", function()
       local client = helpers.http_client("127.0.0.1", 9542)

--- a/spec/03-plugins/26-prometheus/05-metrics_spec.lua
+++ b/spec/03-plugins/26-prometheus/05-metrics_spec.lua
@@ -22,6 +22,7 @@ fixtures.dns_mock:A{
 }
 
 local status_api_port = helpers.get_available_port()
+local UUID_PATTERN = "%x%x%x%x%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%x%x%x%x%x%x%x%x"
 
 
 for _, strategy in helpers.each_strategy() do
@@ -110,7 +111,7 @@ for _, strategy in helpers.each_strategy() do
       local body = assert.res_status(200, res)
 
       assert.matches('kong_nginx_metric_errors_total 0', body, nil, true)
-      assert.matches('kong_nginx_' .. ngx.config.subsystem .. '_current_connections{state="%w+"} %d+', body)
+      assert.matches('kong_nginx_connections_total{node_id="' .. UUID_PATTERN .. '",subsystem="' .. ngx.config.subsystem .. '",state="%w+"} %d+', body)
     end)
 
     it("increments the count of proxied requests #p1.1", function()
@@ -132,7 +133,7 @@ for _, strategy in helpers.each_strategy() do
 
         assert.matches('kong_nginx_metric_errors_total 0', body, nil, true)
 
-        return body:find('kong_http_status{service="mock-ssl-service",route="mock-ssl-route",code="400"} 1',
+        return body:find('http_requests_total{service="mock-ssl-service",route="mock-ssl-route",code="400",source="service",consumer=""} 1',
           nil, true)
       end)
     end)
@@ -148,7 +149,7 @@ for _, strategy in helpers.each_strategy() do
       local body = assert.res_status(200, res)
 
       assert.matches('kong_nginx_metric_errors_total 0', body, nil, true)
-      assert.matches('kong_nginx_' .. ngx.config.subsystem .. '_current_connections{state="%w+"} %d+', body)
+      assert.matches('kong_nginx_connections_total{node_id="' .. UUID_PATTERN .. '",subsystem="' .. ngx.config.subsystem .. '",state="%w+"} %d+', body)
     end)
 
   end)


### PR DESCRIPTION
Rework and Upgrade Prometheus Plugins Metrics and Labels.

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary
These Prometheus plugin will be the first class citizen for metrics collection in Kong 3.0 and beyond. This patch attempts to lay foundation for a good set of base metrics+labels, that can also be expanded upon in later releases

### Full changelog
* Latency has been split into 4 different metrics: `kong_latency_ms`, `upstream_latency_ms` and `request_latency_ms` (http) /`tcp_session_duration_ms` (stream). Buckets details below.
* Separate out Kong Latency Bucket values and Upstream Latency Bucket values. 
  * Kong Latency and Upstream Latency can operate at orders of magnitudes different. Separate out these buckets to reduce memory overhead.
* `consumer_status` removed.
* `request_count` and `consumer_status` have been merged into just `http_requests_total`. If the `per_consumer` config is set false, the `consumer` label will be empty.  If the `per_consumer` config is true, it will be filled. 
* `http_requests_total` has a new label `source`. set to either `exit`, `error` or `service`. https://docs.konghq.com/gateway/latest/pdk/kong.response/#kongresponseget_source
* New Metric: `node_info`. Single gauge set to 1 that outputs the node's id and kong version.
* All Memory metrics have a new label `node_id`
* `nginx_http_current_connections` merged with `nginx_stream_current_connection` to `nginx_current_connections`
* Plugin Version Bumped to 3.0