### PR TITLE
perf(pdk) faster request.get_header

### DIFF
--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -12,6 +12,7 @@ local phase_checker = require "kong.pdk.private.phases"
 
 
 local ngx = ngx
+local var = ngx.var
 local sub = string.sub
 local find = string.find
 local lower = string.lower
@@ -568,10 +569,7 @@ local function new(self)
       error("header name must be a string", 2)
     end
 
-    local header_value = ngx.var["http_" .. lower(name:gsub("-", "_"))]
-    if type(header_value) == "table" then
-      return header_value[1]
-    end
+    local header_value = var["http_" .. lower(name:gsub("-", "_"))]
 
     return header_value
   end

--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -52,6 +52,8 @@ local header_preprocess do
       local c = name:byte(idx)
       if c == hyphens then
         buffer[idx] = underscores
+      else
+        buffer[idx] = c
       end
     end
     return char(unpack(buffer))

--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -21,7 +21,6 @@ local error = error
 local tonumber = tonumber
 local check_phase = phase_checker.check
 local check_not_phase = phase_checker.check_not
-local re_gsub = ngx.re.gsub
 
 
 local PHASES = phase_checker.phases
@@ -570,7 +569,8 @@ local function new(self)
       error("header name must be a string", 2)
     end
 
-    local header_value = var["http_" .. re_gsub(name, "-", "_", "jo")]
+    -- Do not localize ngx.re.gsub! It will crash because ngx.re is monkey patched.
+    local header_value = var["http_" .. ngx.re.gsub(name, "-", "_", "jo")]
 
     return header_value
   end

--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -30,11 +30,6 @@ cjson.decode_array_with_array_mt(true)
 
 local header_preprocess do
   local char = string.char
-  local ffi = require "ffi"
-  local C = ffi.C
-  ffi.cdef [[
-    int tolower(int c);
-  ]]
   local unpack = unpack
   local clear_tab
   do
@@ -57,8 +52,6 @@ local header_preprocess do
       local c = name:byte(idx)
       if c == hyphens then
         buffer[idx] = underscores
-      else
-        buffer[idx] = C.tolower(c)
       end
     end
     return char(unpack(buffer))

--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -29,6 +29,7 @@ local PHASES = phase_checker.phases
 
 cjson.decode_array_with_array_mt(true)
 
+
 local function new(self)
   local _REQUEST = {}
 

--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -568,7 +568,7 @@ local function new(self)
       error("header name must be a string", 2)
     end
 
-    local header_value = _REQUEST.get_headers()[name]
+    local header_value = ngx.var["http_" .. lower(name:gsub("-", "_"))]
     if type(header_value) == "table" then
       return header_value[1]
     end

--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -21,44 +21,13 @@ local error = error
 local tonumber = tonumber
 local check_phase = phase_checker.check
 local check_not_phase = phase_checker.check_not
+local re_gsub = ngx.re.gsub
 
 
 local PHASES = phase_checker.phases
 
 
 cjson.decode_array_with_array_mt(true)
-
-local header_preprocess do
-  local char = string.char
-  local unpack = unpack
-  local clear_tab
-  do
-    local ok
-    ok, clear_tab = pcall(require, "table.clear")
-    if not ok then
-      clear_tab = function(tab)
-        for k in pairs(tab) do
-          tab[k] = nil
-        end
-      end
-    end
-  end
-  local buffer = {}
-  local hyphens = string.byte("-")
-  local underscores = string.byte("_")
-  header_preprocess = function (name)
-    clear_tab(buffer)
-    for idx = 1, #name do
-      local c = name:byte(idx)
-      if c == hyphens then
-        buffer[idx] = underscores
-      else
-        buffer[idx] = c
-      end
-    end
-    return char(unpack(buffer))
-  end
-end
 
 local function new(self)
   local _REQUEST = {}
@@ -600,7 +569,7 @@ local function new(self)
       error("header name must be a string", 2)
     end
 
-    local header_value = var["http_" .. header_preprocess(name)]
+    local header_value = var["http_" .. re_gsub(name, "-", "_", "jo")]
 
     return header_value
   end

--- a/t/01-pdk/04-request/13-get_header.t
+++ b/t/01-pdk/04-request/13-get_header.t
@@ -104,7 +104,7 @@ X-Foo-Header: ''
 
 
 
-=== TEST 5: request.get_header() have no limit header numbers
+=== TEST 5: request.get_header() have no limit on header numbers
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {

--- a/t/01-pdk/04-request/13-get_header.t
+++ b/t/01-pdk/04-request/13-get_header.t
@@ -104,7 +104,7 @@ X-Foo-Header: ''
 
 
 
-=== TEST 5: request.get_header() returns nil when requested header does not fit in default max_headers
+=== TEST 5: request.get_header() have no limit header numbers
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -133,7 +133,7 @@ X-Foo-Header: ''
 --- request
 GET /t
 --- response_body
-accept header value: nil
+accept header value: text/html
 --- no_error_log
 [error]
 


### PR DESCRIPTION
Applying suggestions from OpenResty contributors. We use `ngx.var.http_*` to get the header.

Notice that the behavior changes. Now `request.get_header` does not have a limit of header number.

Fix FT-2780