### PR TITLE
perf(pdk) faster request.get_header

### DIFF
--- a/t/01-pdk/04-request/13-get_header.t
+++ b/t/01-pdk/04-request/13-get_header.t
@@ -104,7 +104,7 @@ X-Foo-Header: ''
 
 
 
-=== TEST 5: request.get_header() returns nil when requested header does not fit in default max_headers
+=== TEST 5: request.get_header() have no limit on header numbers
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -133,7 +133,7 @@ X-Foo-Header: ''
 --- request
 GET /t
 --- response_body
-accept header value: nil
+accept header value: text/html
 --- no_error_log
 [error]
 


### PR DESCRIPTION
Almost the same as `ngx.var.http_*`(#8716 ), but use ffi to reduce the cost of string concatenation.

Fix FT-2780