### PR TITLE
chore(ci): fix the test packaging

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
             steps {
                 sh 'echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin || true'
                 sh 'make setup-kong-build-tools'
-                sh 'cd /home/ubuntu/workspace/kong_test_packaging/../kong-build-tools && make package-kong test'
+                sh 'cd ../kong-build-tools && make package-kong test'
             }
             
         }


### PR DESCRIPTION
I accidentally committed a hard coded absolute path. I removed / fixed it to be relative 