### PR TITLE
feat: add support for AssumeRoleWithWebIdentity for lambda plugin

### DIFF
--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -20,6 +20,7 @@ end
 
 local fetch_credentials do
   local credential_sources = {
+    require "kong.plugins.aws-lambda.iam-eks-credentials",
     require "kong.plugins.aws-lambda.iam-ecs-credentials",
     -- The EC2 one will always return `configured == true`, so must be the last!
     require "kong.plugins.aws-lambda.iam-ec2-credentials",

--- a/kong/plugins/aws-lambda/iam-eks-credentials.lua
+++ b/kong/plugins/aws-lambda/iam-eks-credentials.lua
@@ -1,0 +1,77 @@
+local kong = kong
+local ENV_TOKEN_FILE = os.getenv 'AWS_WEB_IDENTITY_TOKEN_FILE'
+local ENV_ROLE_ARN = os.getenv 'AWS_ROLE_ARN'
+local DEFAULT_SERVICE_REQUEST_TIMEOUT = 5000
+
+
+local url = require "socket.url"
+local http = require "resty.http"
+local json = require "cjson"
+local ngx_now = ngx.now
+local concat = table.concat
+local tostring = tostring
+
+do
+  if not (ENV_TOKEN_FILE) then
+    -- No variables found, so we're not probably not running on EKS containers
+    kong.log.debug("No Web Identity environment variables found for IAM")
+  end
+end
+
+
+local function fetchCredentials()
+  local client = http.new()
+  client:set_timeout(DEFAULT_SERVICE_REQUEST_TIMEOUT)
+
+  local tokenFile, tokenError = io.open(ENV_TOKEN_FILE)
+
+  if not tokenFile then
+    return nil, "Failed to open identity token file: " .. tostring(tokenError)
+  end
+
+  local response, err = client:request_uri("https://sts.amazonaws.com", {
+    method = "POST",
+    headers = {
+      ["Accept"] = "application/json",
+    },
+    query = {
+      Action = "AssumeRoleWithWebIdentity",
+      RoleArn = ENV_ROLE_ARN,
+      WebIdentityToken = tokenFile:read("*a"),
+      RoleSessionName = "kong",
+      Version = "2011-06-15",
+    },
+  })
+  if not response then
+    return nil, "Failed to request IAM credentials request returned error: " .. tostring(err)
+  end
+
+  if response.status ~= 200 then
+    return nil, "Unable to request IAM credentials request returned status code " ..
+                response.status .. " " .. tostring(response.body)
+  end
+
+  local credentials = json.decode(response.body).AssumeRoleWithWebIdentityResponse.AssumeRoleWithWebIdentityResult.Credentials
+
+  local result = {
+    access_key    = credentials.AccessKeyId,
+    secret_key    = credentials.SecretAccessKey,
+    session_token = credentials.SessionToken,
+    expiration    = tonumber(credentials.Expiration)
+  }
+  return result, nil, result.expiration - ngx_now()
+end
+
+local function fetchCredentialsLogged()
+  -- wrapper to log any errors
+  local creds, err, ttl = fetchCredentials()
+  if creds then
+    return creds, err, ttl
+  end
+  kong.log.err(err)
+end
+
+return {
+  configured = not not ENV_TOKEN_FILE, -- force to boolean
+  fetchCredentials = fetchCredentialsLogged,
+}

--- a/kong/plugins/aws-lambda/kong-plugin-aws-lambda-3.6.3-0.rockspec
+++ b/kong/plugins/aws-lambda/kong-plugin-aws-lambda-3.6.3-0.rockspec
@@ -23,6 +23,7 @@ build = {
     ["kong.plugins.aws-lambda.aws-serializer"]       = "kong/plugins/aws-lambda/aws-serializer.lua",
     ["kong.plugins.aws-lambda.handler"]              = "kong/plugins/aws-lambda/handler.lua",
     ["kong.plugins.aws-lambda.iam-ec2-credentials"]  = "kong/plugins/aws-lambda/iam-ec2-credentials.lua",
+    ["kong.plugins.aws-lambda.iam-eks-credentials"]  = "kong/plugins/aws-lambda/iam-eks-credentials.lua",
     ["kong.plugins.aws-lambda.iam-ecs-credentials"]  = "kong/plugins/aws-lambda/iam-ecs-credentials.lua",
     ["kong.plugins.aws-lambda.schema"]               = "kong/plugins/aws-lambda/schema.lua",
     ["kong.plugins.aws-lambda.v4"]                   = "kong/plugins/aws-lambda/v4.lua",


### PR DESCRIPTION


<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

This PR adds support for using IAM Roles for Service Account credentials within the AWS Lambda plugin. This allows users on EKS to invoke the lambda plugin without static credentials. 