### PR TITLE
Add unit for latency

### DIFF
--- a/kong/plugins/prometheus/exporter.lua
+++ b/kong/plugins/prometheus/exporter.lua
@@ -94,7 +94,7 @@ local function init()
                                         {"service", "route", "code"})
   end
   metrics.latency = prometheus:histogram("latency",
-                                         "Latency added by Kong, total " ..
+                                         "Latency added by Kong in ms, total " ..
                                          "request time and upstream latency " ..
                                          "for each service/route in Kong",
                                          {"service", "route", "type"},


### PR DESCRIPTION
### Summary
Update docs to highlight latency unit

### Reason
When working with the metrics there is no way to find out the latency unit.

### Testing
No testing is needed, please confirm the Latency shows up in milliseconds. 

Seems like Kong is using ngx variables to work with the latency.
```
latency = ctx.KONG_BALANCER_ENDED_AT - ngx.req.start_time() * 1000

function Kong.preread()
  local ctx = ngx.ctx
  if not ctx.KONG_PROCESSING_START then
    ctx.KONG_PROCESSING_START = start_time() * 1000
  end
```

Nginx resources for start_time 
- https://www.nginx.com/resources/wiki/modules/lua/#ngx-req-start-time
- https://github.com/openresty/lua-nginx-module#ngxreqstart_time  
- http://nginx.org/en/docs/http/ngx_http_log_module.html # search for $request_time

```
$request_time
    request processing time in seconds with a milliseconds resolution; time elapsed between the first bytes were read from the client and the log written after the last bytes were sent to the client 
```