### PR TITLE
chore(deps) bump luasec from 1.0.2 to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,8 @@
   [#8680](https://github.com/Kong/kong/pull/8680)
 - Bumped luarocks from 3.8.0 to 3.9.0
   [#8700](https://github.com/Kong/kong/pull/8700)
+- Bumped luasec from 1.0.2 to 1.1.0
+  [#8754](https://github.com/Kong/kong/pull/8754)
 
 ### Additions
 

--- a/kong-2.8.0-0.rockspec
+++ b/kong-2.8.0-0.rockspec
@@ -13,7 +13,7 @@ description = {
 }
 dependencies = {
   "inspect == 3.1.3",
-  "luasec == 1.0.2",
+  "luasec == 1.1.0",
   "luasocket == 3.0-rc1",
   "penlight == 1.12.0",
   "lua-resty-http ~> 0.17",


### PR DESCRIPTION
### Summary

* Fix missing DANE flag
* Remove unused parameter in https.lua
