### PR TITLE
chore(deps) bump luacheck (dev dep) from 0.26.0 to 0.26.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 OS := $(shell uname | awk '{print tolower($$0)}')
 MACHINE := $(shell uname -m)
 
-DEV_ROCKS = "busted 2.0.0" "busted-htest 1.0.0" "luacheck 0.26.0" "lua-llthreads2 0.1.6" "http 0.4" "ldoc 1.4.6"
+DEV_ROCKS = "busted 2.0.0" "busted-htest 1.0.0" "luacheck 0.26.1" "lua-llthreads2 0.1.6" "http 0.4" "ldoc 1.4.6"
 WIN_SCRIPTS = "bin/busted" "bin/kong"
 BUSTED_ARGS ?= -v
 TEST_CMD ?= bin/busted $(BUSTED_ARGS)


### PR DESCRIPTION
### Summary

#### Bug Fixes

- Exempt special builtin \_ENV from 214 warning

#### Features

- In case of no home environment, default to caching in CWD 
- Add multi-thread support to container

#### Miscellaneous Tasks

- Tweak warning message for 214 to be more explicit