### PR TITLE
feat(plugin/file-log) create immutable setting for top level file log paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,19 @@
 
 ### Breaking Changes
 
+#### Configuration
+
+- Add a new configuration `plugin_file_log_path_prefix`
+  to restrict access to the file system for `File-log` plugins.
+  [#8758](https://github.com/Kong/kong/pull/8758)
+
+#### Plugins
+
+- **File-log**: Restrict the prefix of log filename by 
+  environment variable `KONG_PLUGIN_FILE_LOG_PATH_PREFIX`
+  and configureation `plugin_file_log_path_prefix`.
+  [#8758](https://github.com/Kong/kong/pull/8758)
+
 #### Admin API
 
 - Insert and update operations on target entities require using the `PUT` HTTP

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -205,6 +205,10 @@ local DYNAMIC_KEY_NAMESPACES = {
     prefix = "vault_",
     ignore = EMPTY,
   },
+  {
+    prefix = "plugin_file_log_",
+    ignore = EMPTY,
+  },
 }
 
 

--- a/kong/plugins/file-log/schema.lua
+++ b/kong/plugins/file-log/schema.lua
@@ -1,4 +1,22 @@
+local pl_path = require "pl.path"
 local typedefs = require "kong.db.schema.typedefs"
+
+local DEFAULT_PREFIX = pl_path.join(kong.configuration.prefix, "logs/")
+local prefix = kong.configuration.plugin_file_log_path_prefix or DEFAULT_PREFIX
+
+if string.sub(prefix, -1) ~= "/" then
+  prefix = prefix .. "/"
+end
+
+local path_pattern = string.format([[^%s[^*&%%\`]+$]], prefix)
+
+local err_msg = 
+  string.format("not a valid file name, "
+              .. "or the prefix is not [%s], "
+              .. "or contains `..`, "
+              .. "you may need to check the configureation "
+              .. "`plugin_file_log_path_prefix`",
+                 prefix)
 
 
 return {
@@ -10,8 +28,10 @@ return {
         fields = {
           { path = { type = "string",
                      required = true,
-                     match = [[^[^*&%%\`]+$]],
-                     err = "not a valid filename",
+                     match = path_pattern,
+                     -- to avoid the path traversal attack
+                     not_match = [[%.%.]],
+                     err = err_msg,
           }, },
           { reopen = { type = "boolean", required = true, default = false }, },
           { custom_fields_by_lua = typedefs.lua_code },

--- a/kong/plugins/file-log/schema.lua
+++ b/kong/plugins/file-log/schema.lua
@@ -14,7 +14,7 @@ local err_msg =
   string.format("not a valid file name, "
               .. "or the prefix is not [%s], "
               .. "or contains `..`, "
-              .. "you may need to check the configureation "
+              .. "you may need to check the configuration "
               .. "`plugin_file_log_path_prefix`",
                  prefix)
 

--- a/spec/03-plugins/04-file-log/02-schema_spec.lua
+++ b/spec/03-plugins/04-file-log/02-schema_spec.lua
@@ -1,40 +1,78 @@
 local Schema = require("kong.db.schema")
 
-describe("Plugin: file-log (schema)", function()
+local IMMUTABLE_PATH = "/tmp/"
 
+local ERR_MSG_INVLID_FILENAME =
+  string.format("not a valid file name, "
+              .. "or the prefix is not [%s], "
+              .. "or contains `..`, "
+              .. "you may need to check the configureation "
+              .. "`plugin_file_log_path_prefix`",
+                 IMMUTABLE_PATH)
+
+
+insulate("Plugin: file-log (schema)", function()
   local tests = {
     {
       name = "path is required",
       input = {
-        reopen = true
+        reopen = true,
       },
       output = nil,
       error = {
         config = {
-          path = "required field missing"
-        }
-      }
+          path = "required field missing",
+        },
+      },
     },
     ----------------------------------------
     {
       name = "rejects invalid filename",
       input = {
         path = "/ovo*",
-        reopen = true
+        reopen = true,
       },
       output = nil,
       error = {
         config = {
-          path = "not a valid filename"
-        }
-      }
+          path = ERR_MSG_INVLID_FILENAME,
+        },
+      },
+    },
+    ----------------------------------------
+    {
+      name = "avoid path traversal attack",
+      input = {
+        path = "/tmp/../etc/passwd",
+        reopen = true,
+      },
+      output = nil,
+      error = {
+        config = {
+          path = ERR_MSG_INVLID_FILENAME,
+        },
+      },
+    },
+    ----------------------------------------
+    {
+      name = "reject filename without the correct prefix",
+      input = {
+        path = "/error-prefix/log.txt",
+        reopen = true,
+      },
+      output = nil,
+      error = {
+        config = {
+          path = ERR_MSG_INVLID_FILENAME,
+        },
+      },
     },
     ----------------------------------------
     {
       name = "accepts valid filename",
       input = {
         path = "/tmp/log.txt",
-        reopen = true
+        reopen = true,
       },
       output = true,
       error = nil,
@@ -46,7 +84,7 @@ describe("Plugin: file-log (schema)", function()
         path = "/tmp/log.txt",
         custom_fields_by_lua = {
           foo = "return 'bar'",
-        }
+        },
       },
       output = true,
       error = nil,
@@ -58,7 +96,56 @@ describe("Plugin: file-log (schema)", function()
   lazy_setup(function()
     _G.kong = {
       configuration = {
-        untrusted_lua = "sandbox"
+        untrusted_lua = "sandbox",
+        prefix = "/usr/local/kong",
+        plugin_file_log_path_prefix = IMMUTABLE_PATH,
+      }
+    }
+
+    file_log_schema = Schema.new(require("kong.plugins.file-log.schema"))
+  end)
+
+  for _, t in ipairs(tests) do
+    it(t.name, function()
+      local output, err = file_log_schema:validate({
+        protocols = { "http" },
+        config = t.input
+      })
+      assert.same(t.error, err)
+      assert.same(t.output, output)
+    end)
+  end
+end)
+
+
+insulate("Plugin: file-log (schema)", function()
+  local tests = {
+    {
+      name = "reject filename without the default prefix",
+      input = {
+        path = "/error-prefix/log.txt",
+        reopen = true,
+      },
+      output = nil,
+      error = {
+        config = {
+          path = "not a valid file name, "
+              .. "or the prefix is not [/kong/logs/], "
+              .. "or contains `..`, "
+              .. "you may need to check the configureation "
+              .. "`plugin_file_log_path_prefix`",
+        },
+      },
+    },
+  }
+
+  local file_log_schema
+
+  lazy_setup(function()
+    _G.kong = {
+      configuration = {
+        untrusted_lua = "sandbox",
+        prefix = "/kong",
       }
     }
 

--- a/spec/03-plugins/04-file-log/02-schema_spec.lua
+++ b/spec/03-plugins/04-file-log/02-schema_spec.lua
@@ -2,7 +2,7 @@ local Schema = require("kong.db.schema")
 
 local IMMUTABLE_PATH = "/tmp/"
 
-local ERR_MSG_INVLID_FILENAME =
+local ERR_MSG_INVALID_FILENAME =
   string.format("not a valid file name, "
               .. "or the prefix is not [%s], "
               .. "or contains `..`, "
@@ -35,7 +35,7 @@ insulate("Plugin: file-log (schema)", function()
       output = nil,
       error = {
         config = {
-          path = ERR_MSG_INVLID_FILENAME,
+          path = ERR_MSG_INVALID_FILENAME,
         },
       },
     },
@@ -49,7 +49,7 @@ insulate("Plugin: file-log (schema)", function()
       output = nil,
       error = {
         config = {
-          path = ERR_MSG_INVLID_FILENAME,
+          path = ERR_MSG_INVALID_FILENAME,
         },
       },
     },
@@ -63,7 +63,7 @@ insulate("Plugin: file-log (schema)", function()
       output = nil,
       error = {
         config = {
-          path = ERR_MSG_INVLID_FILENAME,
+          path = ERR_MSG_INVALID_FILENAME,
         },
       },
     },

--- a/spec/kong_tests.conf
+++ b/spec/kong_tests.conf
@@ -39,3 +39,8 @@ lua_package_path=./spec/fixtures/custom_plugins/?.lua
 untrusted_lua = sandbox
 
 vaults = bundled
+
+# for spec/02-integration/05-proxy/04-plugins_triggering_spec.lua
+# this test sets the log path of file-log plugin to a random path,
+# so we need to set it to `/` to cover all the paths
+plugin_file_log_path_prefix = /


### PR DESCRIPTION
# We have decided not to include this one on the 3.0 milestone

### Summary

**BREAKING CHANGE**

A plugin should not have arbitrary access to the file system, so we should restrict the access of the `file-log` plugin to the file system.

This PR introduces a new configuration `plugin_file_log_path_prefix`, It restricts the scope of the `file-log` plugin to read and write to the file system. The default value is `{kong_prefix}/logs`.

### Issue reference

Fix FT-2115

### Flaky tests maybe caused by this PR

https://github.com/Kong/kong/runs/6316541320?check_suite_focus=true
