### PR TITLE
feat(plugin/aws-lambda)accept string type statusCode as return when working in proxy integration mode

### DIFF
--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -74,7 +74,6 @@ local function validate_http_status_code(status_code)
     if not status_code then
       return false
     end
-
   end
 
   if status_code >= 100 and status_code <= 599 then

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -70,10 +70,11 @@ local function validate_http_status_code(status_code)
 
   if type(status_code) == "string" then
     status_code = tonumber(status_code)
-  end
 
-  if not status_code then
-    return false
+    if not status_code then
+      return false
+    end
+
   end
 
   if status_code >= 100 and status_code <= 599 then

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -67,7 +67,7 @@ end
 
 local function validate_http_status_code(status_code)
   if not status_code then
-    return false, "statusCode not found"
+    return false
   end
   local status_code_str = tostring(status_code)
   local m, err = re_match(status_code_str, VALID_HTTP_STATUS_CODE_REG, 'jo')

--- a/spec/03-plugins/27-aws-lambda/99-access_spec.lua
+++ b/spec/03-plugins/27-aws-lambda/99-access_spec.lua
@@ -805,7 +805,7 @@ for _, strategy in helpers.each_strategy() do
 -- and the tests pass.
 -- see: https://github.com/Kong/kong/commit/c6f9e4558b5a654e78ca96b2ba4309e527053403#diff-9d13d8efc852de84b07e71bf419a2c4d
 
-      it("sets proper status code on custom response from Lambda", function()
+      it("sets proper status code(number type) on custom response from Lambda", function()
         local res = assert(proxy_client:send {
           method  = "POST",
           path    = "/post",
@@ -815,6 +815,24 @@ for _, strategy in helpers.each_strategy() do
           },
           body = {
             statusCode = 201,
+          }
+        })
+        local body = assert.res_status(201, res)
+        assert.equal(0, tonumber(res.headers["Content-Length"]))
+        assert.equal(nil, res.headers["X-Custom-Header"])
+        assert.equal("", body)
+      end)
+
+      it("sets proper status code(string type) on custom response from Lambda", function()
+        local res = assert(proxy_client:send {
+          method  = "POST",
+          path    = "/post",
+          headers = {
+            ["Host"]         = "lambda11.com",
+            ["Content-Type"] = "application/json"
+          },
+          body = {
+            statusCode = "201",
           }
         })
         local body = assert.res_status(201, res)
@@ -878,7 +896,7 @@ for _, strategy in helpers.each_strategy() do
         assert.equal("bar", res.headers["x-amzn-RequestId"])
       end)
 
-      it("returns HTTP 502 when 'status' property of custom response is not a number", function()
+      it("returns HTTP 502 when 'status' property of custom response contains non-numeric character", function()
         local res = assert(proxy_client:send {
           method  = "POST",
           path    = "/post",
@@ -888,6 +906,42 @@ for _, strategy in helpers.each_strategy() do
           },
           body = {
             statusCode = "hello",
+          }
+        })
+
+        assert.res_status(502, res)
+        local b = assert.response(res).has.jsonbody()
+        assert.equal("Bad Gateway", b.message)
+      end)
+
+      it("returns HTTP 502 when 'status' property of custom response is not a valid HTTP status code", function()
+        local res = assert(proxy_client:send {
+          method  = "POST",
+          path    = "/post",
+          headers = {
+            ["Host"]         = "lambda11.com",
+            ["Content-Type"] = "application/json",
+          },
+          body = {
+            statusCode = "99",
+          }
+        })
+
+        assert.res_status(502, res)
+        local b = assert.response(res).has.jsonbody()
+        assert.equal("Bad Gateway", b.message)
+      end)
+
+      it("returns HTTP 502 when 'status' property of custom response is not a valid HTTP status code", function()
+        local res = assert(proxy_client:send {
+          method  = "POST",
+          path    = "/post",
+          headers = {
+            ["Host"]         = "lambda11.com",
+            ["Content-Type"] = "application/json",
+          },
+          body = {
+            statusCode = "600",
           }
         })
 

--- a/spec/03-plugins/27-aws-lambda/99-access_spec.lua
+++ b/spec/03-plugins/27-aws-lambda/99-access_spec.lua
@@ -805,7 +805,7 @@ for _, strategy in helpers.each_strategy() do
 -- and the tests pass.
 -- see: https://github.com/Kong/kong/commit/c6f9e4558b5a654e78ca96b2ba4309e527053403#diff-9d13d8efc852de84b07e71bf419a2c4d
 
-      it("sets proper status code(number type) on custom response from Lambda", function()
+      it("sets proper status code (type = number) on custom response from Lambda", function()
         local res = assert(proxy_client:send {
           method  = "POST",
           path    = "/post",
@@ -823,7 +823,7 @@ for _, strategy in helpers.each_strategy() do
         assert.equal("", body)
       end)
 
-      it("sets proper status code(string type) on custom response from Lambda", function()
+      it("sets proper status code (type = string) on custom response from Lambda", function()
         local res = assert(proxy_client:send {
           method  = "POST",
           path    = "/post",


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
Hi, I would like to add some compatibility to Kong's `aws-lambda` plugin so that it can receive string type status code when working in the proxy integration mode.

When AWS Lambda function is working as a proxy integration, the `statusCode` returned by lambda function will become the HTTP status code returned by API gateway.

Currently, we only accept number type `statusCode`,
https://github.com/Kong/kong/blob/23f50ea1cd3e6985713ea29c81bc4d50f86f2d6e/kong/plugins/aws-lambda/handler.lua#L75

After some tests I found that AWS API gateway works fine if the type of `statusCode` is either number or string. And if the `statusCode` is an invalid HTTP status code, such as `600`(smaller than 100 or larger than 599) or `200a`(containing non-numeric characters), it will throw an "internal server error".

It would be good for us to be compatible with a string type status code, according to FTI-4014.


### Full changelog

* Add a feature that make aws-lambda handler be compatible with string type `statusCode` 
* Add validation function to check if the `statusCode` is legal

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix FTI-4014
