### PR TITLE
chore(zipkin) Add zipkin prefix to timer logs

### DIFF
--- a/kong/plugins/zipkin/handler.lua
+++ b/kong/plugins/zipkin/handler.lua
@@ -96,7 +96,7 @@ local function timer_log(premature, reporter)
 
   local ok, err = reporter:flush()
   if not ok then
-    kong.log.err("reporter flush ", err)
+    kong.log.err("zipkin reporter flush ", err)
     return
   end
 end

--- a/spec/03-plugins/34-zipkin/zipkin_spec.lua
+++ b/spec/03-plugins/34-zipkin/zipkin_spec.lua
@@ -388,7 +388,7 @@ for _, strategy in helpers.each_strategy() do
       -- wait for zero-delay timer
       helpers.wait_timers_end(wait_timers_ctx, 0.5)
 
-      assert.logfile().has.line("reporter flush failed to request: timeout", false, 2)
+      assert.logfile().has.line("zipkin reporter flush failed to request: timeout", false, 2)
     end)
 
     it("times out if upstream zipkin server takes too long to respond", function()
@@ -406,7 +406,7 @@ for _, strategy in helpers.each_strategy() do
       -- wait for zero-delay timer
       helpers.wait_timers_end(wait_timers_ctx, 0.5)
 
-      assert.logfile().has.line("reporter flush failed to request: timeout", false, 2)
+      assert.logfile().has.line("zipkin reporter flush failed to request: timeout", false, 2)
     end)
 
     it("connection refused if upstream zipkin server is not listening", function()
@@ -424,7 +424,7 @@ for _, strategy in helpers.each_strategy() do
       -- wait for zero-delay timer
       helpers.wait_timers_end(wait_timers_ctx, 0.5)
 
-      assert.logfile().has.line("reporter flush failed to request: connection refused", false, 2)
+      assert.logfile().has.line("zipkin reporter flush failed to request: connection refused", false, 2)
     end)
   end)
 end


### PR DESCRIPTION
### Summary

These run on a timer so they don't get the namespace automatically
appended to the log line which makes it hard to determine which plugin
they come from:

    [error] 1099#0: *436751 [kong] handler.lua:102 reporter flush failed to request: operation timed out, context: ngx.timer, client: 172.17.0.1, server: 0.0.0.0:8443

I've tried looking for a way to solve this generically that would
benefit other plugins like `rate-limiting` but can't see a way to set
the logger or get access to the plugin name when the timer is running.

I've omitted the square brackets from `zipkin` to make it clearer that
it's not coming from the automatic namespace formatting.

<!--- Why is this change required? What problem does it solve? -->

### Full changelog

* feat(zipkin) Add zipkin prefix to timer logs

### Issue reference

N/A

### Other notes

I'm open to suggestions about how this could be solved generically in a way that would benefit all plugins.

This PR depends on the tests from #8735. I can't see a way to change the base branch, so it will need rebasing after that PR is merged.