### PR TITLE
tests(rockspec) add a script to validate rockspec file

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -109,6 +109,11 @@ jobs:
           eval `luarocks path`
           luacheck -q .
 
+    - name: Validate rockspec file
+      run: |
+          eval `luarocks path`
+          scripts/validate-rockspec
+
     - name: Unit tests
       run: |
           eval `luarocks path`
@@ -318,7 +323,7 @@ jobs:
       run: |
           echo "127.0.0.1 grpcs_1.test" | sudo tee -a /etc/hosts
           echo "127.0.0.1 grpcs_2.test" | sudo tee -a /etc/hosts
-    
+
     - name: Enable SSL for Redis
       run: |
           docker cp ${{ github.workspace }} kong_redis:/workspace

--- a/scripts/validate-rockspec
+++ b/scripts/validate-rockspec
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+shopt -s nullglob
+
+fail() {
+    echo "Failure: $@"
+    exit 1
+}
+
+lint() {
+    echo "Linting..."
+
+    luarocks lint "$1"
+}
+
+read_modules() {
+    local spec="$1"
+    resty -e '
+        local fn = loadstring(io.stdin:read("*a"))
+        local rock = {}
+        setfenv(fn, rock)
+        fn()
+
+        for mod, fname in pairs(rock.build.modules) do
+            print(fname .. "|" .. mod)
+        end
+    ' < "$spec"
+}
+
+check_modules() {
+    local spec=$1
+    local -A files=()
+
+    echo "Checking modules..."
+
+    for line in $(read_modules "$spec"); do
+        fname=${line%|*}
+        module=${line#*|}
+        files[$fname]="$module"
+
+        if [[ ! -f $fname ]]; then
+            fail "module ($module) file ($fname) is missing"
+        fi
+    done
+
+    for fname in $(git ls-files 'kong/*.lua'); do
+        mod="${files[$fname]:-}"
+
+        if [[ -z ${mod:-} ]]; then
+            fail "file ($fname) not found in rockspec ($spec)"
+        fi
+    done
+}
+
+
+main() {
+    local files=(kong-*.rockspec)
+    local spec
+
+    if (( ${#files[@]} == 0 )); then
+        fail "no rockspec file found"
+
+    elif (( ${#files[@]} > 1 )); then
+        fail "multiple rockspec files found: ${files[*]}"
+
+    else
+        spec=${files[0]}
+    fi
+
+    echo "Found rockspec file to validate: $spec"
+
+    lint "$spec"
+
+    check_modules "$spec"
+
+    echo "OK!"
+}
+
+
+main "$@"


### PR DESCRIPTION
Not sure if something like this exists already (or how useful it is), but here's a quick n' dirty validation script:

1. Ensures that only one rockspec file exists
2. Runs `luarocks lint` on the rockspec file
3. Validates that all modules in the rockspec file are present on disk
4. Validates that all files in kong have a corresponding entry in the rockspec file

### happy case

```
$ ./scripts/validate-rockspec
Found rockspec file to validate: kong-2.8.0-0.rockspec
Linting...
Checking modules...
OK!
```
### no rockspec file

```
$ ./scripts/validate-rockspec
Failure: No rockspec file found
```

### multiple rockspec files

```
$ ./scripts/validate-rockspec
Failure: Multiple rockspec files found: kong-2.8.0-0.rockspec kong-2.8.0-1.rockspec
```
### luarocks lint failure

```
$ ./scripts/validate-rockspec
Found rockspec file to validate: kong-2.8.0-0.rockspec
Linting...

Error: Failed loading rockspec: /home/michaelm/git/kong/kong/kong-2.8.0-0.rockspec: Unknown field extra (using rockspec format 3.0)
```

### module file in rockspec is missing

```
$ ./scripts/validate-rockspec
Found rockspec file to validate: kong-2.8.0-0.rockspec
Linting...
Checking modules...
Failure: Module kong.not-found file (kong/nope.lua) is missing
```

### file added to git but not the rockspec

```
$ ./scripts/validate-rockspec
Found rockspec file to validate: kong-2.8.0-0.rockspec
Linting...
Checking modules...
Failure: File (kong/hooks.lua) not found in rockspec (kong-2.8.0-0.rockspec)
```
