### PR TITLE
fix(dao) fix incorrect function field reassignment

### DIFF
--- a/kong/db/dao/plugins.lua
+++ b/kong/db/dao/plugins.lua
@@ -336,7 +336,8 @@ function Plugins:select_by_cache_key(key)
 
     -- if migration is complete, disable this translator function and return
     if schema_state:is_migration_executed("core", "009_200_to_210") then
-      Plugins.select_by_cache_key = self.super.select_by_cache_key
+      self.select_by_cache_key = self.super.select_by_cache_key
+      Plugins.select_by_cache_key = nil
       return entity
     end
   end


### PR DESCRIPTION
The Plugins DAO's select_by_cache_key translator function was not disabled even if checked migration had actually been executed before.

### Summary

In order to load a new plugin entity, a worker executes the `Plugins.select_by_cache_key` function (call to `kong.db.plugins:select_by_cache_key(...)`, which delegates the load to `DAO:select_by_cache_key`, and checks whether the _core.009_200_to_210_ migration was executed previously.
If yes, before returning the loaded entity, the `Plugins.select_by_cache_key` function tries to self-replace by the DAO's one, but it doesn't work because the assigned field's object isn't the right one.
As an impact, an important extra latency is added to the plugin's load one, for each request involving such load.

This PR is to fix this behavior, so that extra latency may happen only once per worker.

### Full changelog

* [Fix ever checking core.009_200_to_210 execution on plugin load]

### Issue reference

[Issue #8788](https://github.com/Kong/kong/issues/8788)
