### PR TITLE
perf(schema) no deep copy on select on process auto fields

### DIFF
--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1609,11 +1609,15 @@ end
 -- valid values are: "insert", "update", "upsert", "select"
 -- @param nulls boolean: return nulls as explicit ngx.null values
 -- @return A new table, with the auto fields containing
--- appropriate updated values.
+-- appropriate updated values (except for "select" context
+-- it does it in place by modifying the data directly).
 function Schema:process_auto_fields(data, context, nulls, opts)
   local check_immutable_fields = false
 
-  data = tablex.deepcopy(data)
+  local is_select = context == "select"
+  if not is_select then
+    data = tablex.deepcopy(data)
+  end
 
   local shorthand_fields = self.shorthand_fields
   if shorthand_fields then
@@ -1663,8 +1667,6 @@ function Schema:process_auto_fields(data, context, nulls, opts)
 
   local now_s
   local now_ms
-
-  local is_select = context == "select"
 
   -- We don't want to resolve references on control planes
   -- and and admin api requests, admin api request could be

--- a/kong/db/strategies/off/init.lua
+++ b/kong/db/strategies/off/init.lua
@@ -4,19 +4,28 @@ local lmdb = require("resty.lmdb")
 local marshaller = require("kong.db.declarative.marshaller")
 local yield = require("kong.tools.utils").yield
 
-
 local kong = kong
 local fmt = string.format
 local type = type
 local next = next
+local sort = table.sort
 local pairs = pairs
+local match = string.match
+local assert = assert
 local tostring = tostring
 local tonumber = tonumber
 local encode_base64 = ngx.encode_base64
 local decode_base64 = ngx.decode_base64
-local null          = ngx.null
-local unmarshall    = marshaller.unmarshall
-local lmdb_get      = lmdb.get
+local null = ngx.null
+local unmarshall = marshaller.unmarshall
+local lmdb_get = lmdb.get
+local get_workspace_id = workspaces.get_workspace_id
+
+
+local PROCESS_AUTO_FIELDS_OPTS = {
+  no_defaults = true,
+  show_ws_id = true,
+}
 
 
 local off = {}
@@ -26,8 +35,8 @@ local _mt = {}
 _mt.__index = _mt
 
 
-local function ws(self, options)
-  if not self.schema.workspaceable then
+local function ws(schema, options)
+  if not schema.workspaceable then
     return ""
   end
 
@@ -39,7 +48,8 @@ local function ws(self, options)
       return options.workspace
     end
   end
-  return workspaces.get_workspace_id() or kong.default_workspace
+
+  return get_workspace_id()
 end
 
 
@@ -99,7 +109,7 @@ local function get_entity_ids_tagged(key, tag_names, tags_cond)
     len = len + 1
     arr[len] = entity_id
   end
-  table.sort(arr) -- consistency when paginating results
+  sort(arr) -- consistency when paginating results
 
   return arr
 end
@@ -146,7 +156,8 @@ local function page_for_key(self, key, size, offset, options)
   yield()
 
   local ret = {}
-  local schema_name = self.schema.name
+  local schema = self.schema
+  local schema_name = schema.name
 
   local item
   for i = offset, offset + size - 1 do
@@ -164,7 +175,7 @@ local function page_for_key(self, key, size, offset, options)
     -- For example "admin|services|<a service uuid>"
     -- This loop transforms each individual string into tables.
     if schema_name == "tags" then
-      local tag_name, entity_name, uuid = string.match(item, "^([^|]+)|([^|]+)|(.+)$")
+      local tag_name, entity_name, uuid = match(item, "^([^|]+)|([^|]+)|(.+)$")
       if not tag_name then
         return nil, "Could not parse tag from cache: " .. tostring(item)
       end
@@ -184,12 +195,7 @@ local function page_for_key(self, key, size, offset, options)
       return nil, "stale data detected while paginating"
     end
 
-    item = self.schema:process_auto_fields(item, "select", true, {
-      no_defaults = true,
-      show_ws_id = true,
-    })
-
-    ret[i - offset + 1] = item
+    ret[i - offset + 1] = schema:process_auto_fields(item, "select", true, PROCESS_AUTO_FIELDS_OPTS)
   end
 
   if offset then
@@ -200,33 +206,32 @@ local function page_for_key(self, key, size, offset, options)
 end
 
 
-local function select_by_key(self, key)
+local function select_by_key(schema, key)
   local entity, err = unmarshall(lmdb_get(key))
   if not entity then
     return nil, err
   end
 
-  entity =  self.schema:process_auto_fields(entity, "select", true, {
-    no_defaults = true,
-    show_ws_id = true,
-  })
+  entity = schema:process_auto_fields(entity, "select", true, PROCESS_AUTO_FIELDS_OPTS)
 
   return entity
 end
 
 
 local function page(self, size, offset, options)
-  local ws_id = ws(self, options)
-  local key = self.schema.name .. "|" .. ws_id .. "|@list"
+  local schema = self.schema
+  local ws_id = ws(schema, options)
+  local key = schema.name .. "|" .. ws_id .. "|@list"
   return page_for_key(self, key, size, offset, options)
 end
 
 
 local function select(self, pk, options)
-  local ws_id = ws(self, options)
-  local id = declarative_config.pk_string(self.schema, pk)
-  local key = self.schema.name .. ":" .. id .. ":::::" .. ws_id
-  return select_by_key(self, key)
+  local schema = self.schema
+  local ws_id = ws(schema, options)
+  local id = declarative_config.pk_string(schema, pk)
+  local key = schema.name .. ":" .. id .. ":::::" .. ws_id
+  return select_by_key(schema, key)
 end
 
 
@@ -236,11 +241,12 @@ local function select_by_field(self, field, value, options)
     _, value = next(value)
   end
 
-  local ws_id = ws(self, options)
+  local schema = self.schema
+  local ws_id = ws(schema, options)
 
   local key
   if field ~= "cache_key" then
-    local unique_across_ws = self.schema.fields[field].unique_across_ws
+    local unique_across_ws = schema.fields[field].unique_across_ws
     if unique_across_ws then
       ws_id = ""
     end
@@ -248,15 +254,16 @@ local function select_by_field(self, field, value, options)
     -- only accept global query by field if field is unique across workspaces
     assert(not options or options.workspace ~= null or unique_across_ws)
 
-    key = self.schema.name .. "|" .. ws_id .. "|" .. field .. ":" .. value
+    key = schema.name .. "|" .. ws_id .. "|" .. field .. ":" .. value
 
   else
     -- if select_by_cache_key, use the provided cache_key as key directly
     key = value
   end
 
-  return select_by_key(self, key)
+  return select_by_key(schema, key)
 end
+
 
 do
   local unsupported = function(operation)
@@ -268,7 +275,6 @@ do
   end
 
   local unsupported_by = function(operation)
-
     return function(self, field_name)
       local err = fmt("cannot %s '%s' entities by '%s' when not using a database",
                       operation, self.schema.name, '%s')
@@ -291,6 +297,7 @@ do
   _mt.page_for_key = page_for_key
 end
 
+
 function off.new(connector, schema, errors)
   local self = {
     connector = connector, -- instance of kong.db.strategies.off.connector
@@ -305,14 +312,13 @@ function off.new(connector, schema, errors)
     kong.default_workspace = "00000000-0000-0000-0000-000000000000"
   end
 
-  local name = self.schema.name
+  local name = schema.name
   for fname, fdata in schema:each_field() do
     if fdata.type == "foreign" then
       local entity = fdata.reference
       local method = "page_for_" .. fname
       self[method] = function(_, foreign_key, size, offset, options)
-        local ws_id = ws(self, options)
-
+        local ws_id = ws(schema, options)
         local key = name .. "|" .. ws_id .. "|" .. entity .. "|" .. foreign_key.id .. "|@list"
         return page_for_key(self, key, size, offset, options)
       end

--- a/spec/01-unit/01-db/01-schema/01-schema_spec.lua
+++ b/spec/01-unit/01-db/01-schema/01-schema_spec.lua
@@ -2745,6 +2745,41 @@ describe("schema", function()
   end)
 
   describe("process_auto_fields", function()
+    for _, context in ipairs({ "insert", "update", "upsert"}) do
+      it('returns new table when called with "' .. context .. '" context', function()
+        local Test = Schema.new({
+          fields = {
+            { f = { type = "string", default = "test" } },
+          }
+        })
+
+        local original = {}
+        local data, err = Test:process_auto_fields(original, context)
+        assert.is_nil(err)
+        assert.not_equal(original, data)
+        if context == "update" then
+          assert.is_nil(data.f)
+        else
+          assert.equal("test", data.f)
+        end
+        assert.is_nil(original.f)
+      end)
+    end
+
+    it('modifies table in place when called with "select" context', function()
+      local Test = Schema.new({
+        fields = {
+          { f = { type = "string", default = "test" } },
+        }
+      })
+
+      local original = {}
+      local data, err = Test:process_auto_fields(original, "select")
+      assert.is_nil(err)
+      assert.equal(original, data)
+      assert.equal("test", data.f)
+      assert.equal("test", original.f)
+    end)
 
     it("produces ngx.null for non-required fields", function()
       local Test = Schema.new({


### PR DESCRIPTION
### Summary

It is inefficient to create deep copies of tables when e.g. looping through database rows (and with records in them we recursively deep copy them). In my testing with uploading some 64k routes with dbless (which calls process auto fields twice), this can cut the time looping the data by 1/4th. It also generates much less garbage.

I searched our code bases where we use "select" context, and could not find anything that might break because of this.