### PR TITLE
fix(balancer) set target status using hostname

### DIFF
--- a/kong/runloop/balancer/init.lua
+++ b/kong/runloop/balancer/init.lua
@@ -351,7 +351,7 @@ local function post_health(upstream, hostname, ip, port, is_healthy)
   end
 
   local ok, err
-  if ip then
+  if ip and (utils.hostname_type(ip) ~= "name") then
     ok, err = healthchecker:set_target_status(ip, port, hostname, is_healthy)
   else
     ok, err = healthchecker:set_all_target_statuses_for_hostname(hostname, port, is_healthy)


### PR DESCRIPTION
### Summary

When a target was added using only its hostname, it was not possible to update its health status using only the hostname, i.e. omitting the IP. This change fixes that issue.

This problem was identified while fixing a different issue. The tests don't fail because their current behavior is removing a healthy target and adding it again as unhealthy. The test is already fixed in a different branch (fix/target_creation_method).

### Full changelog

* Check if the ip received is actually an ip before trying to set the health status.
