### PR TITLE
fix(api): use POST to add targets to specific upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,10 +79,12 @@
 
 #### Admin API
 
-- Insert and update operations on target entities require using the `PUT` HTTP
-  method now. [#8596](https://github.com/Kong/kong/pull/8596). If you have
-  scripts that depend on it being `POST`, these scripts will need to be updated
-  when updating to Kong 3.0.
+- `POST` requests on target entities endpoint are no longer able to update
+  existing entities, they are only able to create new ones.
+  [#8596](https://github.com/Kong/kong/pull/8596),
+  [#8798](https://github.com/Kong/kong/pull/8798). If you have scripts that use
+  `POST` requests to modify target entities, you should change them to `PUT`
+  requests to the appropriate endpoints before updating to Kong 3.0.
 - Insert and update operations on duplicated target entities returns 409.
   [#8179](https://github.com/Kong/kong/pull/8179)
 

--- a/kong/api/routes/upstreams.lua
+++ b/kong/api/routes/upstreams.lua
@@ -165,13 +165,10 @@ return {
                                             kong.db.upstreams.schema,
                                             "upstream",
                                             "page_for_upstream"),
-    PUT = function(self, db)
+    POST = function(self, db)
       local create = endpoints.post_collection_endpoint(kong.db.targets.schema,
                         kong.db.upstreams.schema, "upstream")
       return create(self, db)
-    end,
-    POST = function(self, db)
-      return kong.response.exit(405)
     end,
   },
 

--- a/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
@@ -722,14 +722,12 @@ describe("Admin API: #" .. strategy, function()
         client = assert(helpers.admin_client())
 
         -- create the target
-        local res = assert(client:send {
-          method = "PUT",
-          path = "/upstreams/my-upstream/targets",
+        local res = assert(client:post("/upstreams/my-upstream/targets", {
           body = {
             target = "127.0.0.1:8000",
           },
           headers = { ["Content-Type"] = "application/json" }
-        })
+        }))
 
         assert.response(res).has.status(201)
 
@@ -790,14 +788,12 @@ describe("Admin API: #" .. strategy, function()
         client = assert(helpers.admin_client())
 
         -- create the target
-        local res = assert(client:send {
-          method = "PUT",
-          path = "/upstreams/my-upstream/targets",
+        local res = assert(client:post("/upstreams/my-upstream/targets", {
           body = {
             target = "127.0.0.1:8000",
           },
           headers = { ["Content-Type"] = "application/json" }
-        })
+        }))
 
         assert.response(res).has.status(201)
 

--- a/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -74,21 +74,19 @@ describe("Admin API #" .. strategy, function()
   end)
 
   describe("/upstreams/{upstream}/targets/", function()
-    describe("PUT", function()
+    describe("POST", function()
       it_content_types("creates a target with defaults", function(content_type)
         return function()
           local upstream = bp.upstreams:insert { slots = 10 }
-          local res = assert(client:send {
-            method = "PUT",
-            path = "/upstreams/" .. upstream.name .. "/targets/",
+          local res = assert(client:post("/upstreams/" .. upstream.name .. "/targets/", {
             body = {
-              target = "mashape.com",
+              target = "konghq.test",
             },
             headers = {["Content-Type"] = content_type}
-          })
+          }))
           assert.response(res).has.status(201)
           local json = assert.response(res).has.jsonbody()
-          assert.equal("mashape.com:" .. default_port, json.target)
+          assert.equal("konghq.test:" .. default_port, json.target)
           assert.is_number(json.created_at)
           assert.is_string(json.id)
           assert.are.equal(weight_default, json.weight)
@@ -97,18 +95,16 @@ describe("Admin API #" .. strategy, function()
       it_content_types("creates a target without defaults", function(content_type)
         return function()
           local upstream = bp.upstreams:insert { slots = 10 }
-          local res = assert(client:send {
-            method = "PUT",
-            path = "/upstreams/" .. upstream.name .. "/targets/",
+          local res = assert(client:post("/upstreams/" .. upstream.name .. "/targets/", {
             body = {
-              target = "mashape.com:123",
+              target = "konghq.test:123",
               weight = 99,
             },
             headers = {["Content-Type"] = content_type}
-          })
+          }))
           assert.response(res).has.status(201)
           local json = assert.response(res).has.jsonbody()
-          assert.equal("mashape.com:123", json.target)
+          assert.equal("konghq.test:123", json.target)
           assert.is_number(json.created_at)
           assert.is_string(json.id)
           assert.are.equal(99, json.weight)
@@ -118,15 +114,13 @@ describe("Admin API #" .. strategy, function()
       it_content_types("creates a target with weight = 0", function(content_type)
         return function()
           local upstream = bp.upstreams:insert { slots = 10 }
-          local res = assert(client:send {
-            method = "PUT",
-            path = "/upstreams/" .. upstream.name .. "/targets/",
+          local res = assert(client:post("/upstreams/" .. upstream.name .. "/targets/", {
             body = {
               target = "zero.weight.test:8080",
               weight = 0,
             },
             headers = {["Content-Type"] = content_type}
-          })
+          }))
           assert.response(res).has.status(201)
           local json = assert.response(res).has.jsonbody()
           assert.equal("zero.weight.test:8080", json.target)
@@ -142,47 +136,13 @@ describe("Admin API #" .. strategy, function()
         end
       end)
 
-      it_content_types("refuses to create duplicated targets", function(content_type)
-        return function()
-          local upstream = bp.upstreams:insert { slots = 10 }
-          local res = assert(client:send {
-            method = "PUT",
-            path = "/upstreams/" .. upstream.name .. "/targets/",
-            body = {
-              target = "single-target.test:8080",
-              weight = 1,
-            },
-            headers = {["Content-Type"] = content_type}
-          })
-          assert.response(res).has.status(201)
-          local json = assert.response(res).has.jsonbody()
-          assert.equal("single-target.test:8080", json.target)
-          assert.is_number(json.created_at)
-          assert.is_string(json.id)
-          assert.are.equal(1, json.weight)
-
-          local res2 = assert(client:send {
-            method = "PUT",
-            path = "/upstreams/" .. upstream.name .. "/targets/",
-            body = {
-              target = "single-target.test:8080",
-              weight = 100,
-            },
-            headers = {["Content-Type"] = content_type}
-          })
-          assert.response(res2).has.status(409)
-        end
-      end)
-
       describe("errors", function()
         it("handles malformed JSON body", function()
           local upstream = bp.upstreams:insert { slots = 10 }
-          local res = assert(client:request {
-            method = "PUT",
-            path = "/upstreams/" .. upstream.name .. "/targets/",
+          local res = assert(client:post("/upstreams/" .. upstream.name .. "/targets/", {
             body = '{"hello": "world"',
             headers = {["Content-Type"] = "application/json"}
-          })
+          }))
           local body = assert.response(res).has.status(400)
           local json = cjson.decode(body)
           assert.same({ message = "Cannot parse JSON body" }, json)
@@ -191,28 +151,24 @@ describe("Admin API #" .. strategy, function()
           return function()
             local upstream = bp.upstreams:insert { slots = 10 }
             -- Missing parameter
-            local res = assert(client:send {
-              method = "PUT",
-              path = "/upstreams/" .. upstream.name .. "/targets/",
+            local res = assert(client:post("/upstreams/" .. upstream.name .. "/targets/", {
               body = {
                 weight = weight_min,
               },
               headers = {["Content-Type"] = content_type}
-            })
+            }))
             local body = assert.response(res).has.status(400)
             local json = cjson.decode(body)
             assert.equal("schema violation", json.name)
             assert.same({ target = "required field missing" }, json.fields)
 
             -- Invalid target parameter
-            res = assert(client:send {
-              method = "PUT",
-              path = "/upstreams/" .. upstream.name .. "/targets/",
+            res = assert(client:post("/upstreams/" .. upstream.name .. "/targets/", {
               body = {
                 target = "some invalid host name",
               },
               headers = {["Content-Type"] = content_type}
-            })
+            }))
             body = assert.response(res).has.status(400)
             local json = cjson.decode(body)
             assert.equal("schema violation", json.name)
@@ -220,10 +176,10 @@ describe("Admin API #" .. strategy, function()
 
             -- Invalid weight parameter
             res = assert(client:send {
-              method = "PUT",
+              method = "POST",
               path = "/upstreams/" .. upstream.name .. "/targets/",
               body = {
-                target = "mashape.com",
+                target = "konghq.test",
                 weight = weight_max + 1,
               },
               headers = {["Content-Type"] = content_type}
@@ -235,7 +191,7 @@ describe("Admin API #" .. strategy, function()
           end
         end)
 
-        for _, method in ipairs({"POST", "PATCH", "DELETE"}) do
+        for _, method in ipairs({"PUT", "PATCH", "DELETE"}) do
           it_content_types("returns 405 on " .. method, function(content_type)
             return function()
               local upstream = bp.upstreams:insert { slots = 10 }
@@ -243,7 +199,7 @@ describe("Admin API #" .. strategy, function()
                 method = method,
                 path = "/upstreams/" .. upstream.name .. "/targets/",
                 body = {
-                  target = "mashape.com",
+                  target = "konghq.test",
                 },
                 headers = {["Content-Type"] = content_type}
               })
@@ -251,6 +207,34 @@ describe("Admin API #" .. strategy, function()
             end
           end)
         end
+
+        it_content_types("fails to create duplicated targets", function(content_type)
+          return function()
+            local upstream = bp.upstreams:insert { slots = 10 }
+            local res = assert(client:post("/upstreams/" .. upstream.name .. "/targets/", {
+              body = {
+                target = "single-target.test:8080",
+                weight = 1,
+              },
+              headers = {["Content-Type"] = content_type}
+            }))
+            assert.response(res).has.status(201)
+            local json = assert.response(res).has.jsonbody()
+            assert.equal("single-target.test:8080", json.target)
+            assert.is_number(json.created_at)
+            assert.is_string(json.id)
+            assert.are.equal(1, json.weight)
+
+            local res = assert(client:post("/upstreams/" .. upstream.name .. "/targets/", {
+              body = {
+                target = "single-target.test:8080",
+                weight = 100,
+              },
+              headers = {["Content-Type"] = content_type}
+            }))
+            assert.response(res).has.status(409)
+          end
+        end)
       end)
     end)
 
@@ -332,7 +316,7 @@ describe("Admin API #" .. strategy, function()
 
         for i = 1, #weights do
           local status, body = client_send({
-            method = "PUT",
+            method = "POST",
             path = "/upstreams/" .. upstream.name .. "/targets",
             headers = {
               ["Content-Type"] = "application/json",
@@ -663,7 +647,7 @@ describe("Admin API #" .. strategy, function()
           local json = assert(cjson.decode(body))
 
           status, body = assert(client_send({
-            method = "PUT",
+            method = "POST",
             path = "/upstreams/" .. upstream.id .. "/targets",
             headers = {["Content-Type"] = "application/json"},
             body = {

--- a/spec/02-integration/05-proxy/10-balancer/01-healthchecks_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer/01-healthchecks_spec.lua
@@ -697,11 +697,11 @@ for _, strategy in helpers.each_strategy() do
 
             if mode == "ipv6" then
               -- TODO /upstreams does not understand shortened IPv6 addresses
-              bu.put_target_endpoint(upstream_id, "[0000:0000:0000:0000:0000:0000:0000:0001]", port, "unhealthy")
+              bu.post_target_endpoint(upstream_id, "[0000:0000:0000:0000:0000:0000:0000:0001]", port, "unhealthy")
               bu.poll_wait_health(upstream_id, "[0000:0000:0000:0000:0000:0000:0000:0001]", port, "UNHEALTHY", admin_port_1)
               bu.poll_wait_health(upstream_id, "[0000:0000:0000:0000:0000:0000:0000:0001]", port, "UNHEALTHY", admin_port_2)
             else
-              bu.put_target_endpoint(upstream_id, localhost, port, "unhealthy")
+              bu.post_target_endpoint(upstream_id, localhost, port, "unhealthy")
               bu.poll_wait_health(upstream_id, localhost, port, "UNHEALTHY", admin_port_1)
               bu.poll_wait_health(upstream_id, localhost, port, "UNHEALTHY", admin_port_2)
             end
@@ -1996,10 +1996,10 @@ for _, strategy in helpers.each_strategy() do
                 -- manually bring it back using the endpoint
                 if mode == "ipv6" then
                   -- TODO /upstreams does not understand shortened IPv6 addresses
-                  bu.put_target_endpoint(upstream_id, "[0000:0000:0000:0000:0000:0000:0000:0001]", port2, "healthy")
+                  bu.post_target_endpoint(upstream_id, "[0000:0000:0000:0000:0000:0000:0000:0001]", port2, "healthy")
                   bu.poll_wait_health(upstream_id, "[0000:0000:0000:0000:0000:0000:0000:0001]", port2, "HEALTHY")
                 else
-                  bu.put_target_endpoint(upstream_id, localhost, port2, "healthy")
+                  bu.post_target_endpoint(upstream_id, localhost, port2, "healthy")
                   bu.poll_wait_health(upstream_id, localhost, port2, "HEALTHY")
                 end
 
@@ -2040,7 +2040,7 @@ for _, strategy in helpers.each_strategy() do
                 }
               })
               local port1 = bu.add_target(bp, upstream_id, localhost)
-              local port2 = bu.add_target(bp, upstream_id, localhost)
+              local port2, target2 = bu.add_target(bp, upstream_id, localhost)
               local api_host = bu.add_api(bp, upstream_name)
               bu.end_testcase_setup(strategy, bp)
 
@@ -2058,10 +2058,10 @@ for _, strategy in helpers.each_strategy() do
               -- manually bring it down using the endpoint
               if mode == "ipv6" then
                 -- TODO /upstreams does not understand shortened IPv6 addresses
-                bu.put_target_endpoint(upstream_id, "[0000:0000:0000:0000:0000:0000:0000:0001]", port2, "unhealthy")
+                bu.put_target_address_health(upstream_id, target2.id, "[0000:0000:0000:0000:0000:0000:0000:0001]:".. port2, "unhealthy")
                 bu.poll_wait_health(upstream_id, "[0000:0000:0000:0000:0000:0000:0000:0001]", port2, "UNHEALTHY")
               else
-                bu.put_target_endpoint(upstream_id, localhost, port2, "unhealthy")
+                bu.put_target_address_health(upstream_id, target2.id, localhost .. ":" .. port2, "unhealthy")
                 bu.poll_wait_health(upstream_id, localhost, port2, "UNHEALTHY")
               end
 
@@ -2075,10 +2075,10 @@ for _, strategy in helpers.each_strategy() do
               -- manually bring it back using the endpoint
               if mode == "ipv6" then
                 -- TODO /upstreams does not understand shortened IPv6 addresses
-                bu.put_target_endpoint(upstream_id, "[0000:0000:0000:0000:0000:0000:0000:0001]", port2, "healthy")
+                bu.post_target_endpoint(upstream_id, "[0000:0000:0000:0000:0000:0000:0000:0001]", port2, "healthy")
                 bu.poll_wait_health(upstream_id, "[0000:0000:0000:0000:0000:0000:0000:0001]", port2, "HEALTHY")
               else
-                bu.put_target_endpoint(upstream_id, localhost, port2, "healthy")
+                bu.put_target_address_health(upstream_id, target2.id, localhost .. ":" .. port2, "healthy")
                 bu.poll_wait_health(upstream_id, localhost, port2, "HEALTHY")
               end
 

--- a/spec/02-integration/05-proxy/10-balancer/02-least-connections_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer/02-least-connections_spec.lua
@@ -112,9 +112,7 @@ for _, strategy in helpers.each_strategy() do
         local api_client = helpers.admin_client()
 
         -- create a new target
-        local res = assert(api_client:send({
-          method = "PUT",
-          path = "/upstreams/" .. upstream1_id .. "/targets",
+        local res = assert(api_client:post("/upstreams/" .. upstream1_id .. "/targets", {
           headers = {
             ["Content-Type"] = "application/json",
           },
@@ -217,9 +215,7 @@ for _, strategy in helpers.each_strategy() do
         local api_client = helpers.admin_client()
 
         -- create a new target
-        local res = assert(api_client:send({
-          method = "PUT",
-          path = "/upstreams/" .. an_upstream.id .. "/targets",
+        local res = assert(api_client:post("/upstreams/" .. an_upstream.id .. "/targets", {
           headers = {
             ["Content-Type"] = "application/json",
           },

--- a/spec/fixtures/admin_api.lua
+++ b/spec/fixtures/admin_api.lua
@@ -65,7 +65,7 @@ admin_api_as_db["basicauth_credentials"] = {
 
 admin_api_as_db["targets"] = {
   insert = function(_, tbl)
-    return api_send("PUT", "/upstreams/" .. tbl.upstream.id .. "/targets", tbl)
+    return api_send("POST", "/upstreams/" .. tbl.upstream.id .. "/targets", tbl)
   end,
   remove = function(_, tbl)
     return api_send("DELETE", "/upstreams/" .. tbl.upstream.id .. "/targets/" .. tbl.id)

--- a/spec/fixtures/balancer_utils.lua
+++ b/spec/fixtures/balancer_utils.lua
@@ -80,7 +80,7 @@ local function direct_request(host, port, path, protocol, host_header)
 end
 
 
-local function put_target_endpoint(upstream_id, host, port, endpoint)
+local function post_target_endpoint(upstream_id, host, port, endpoint)
   if host == "[::1]" then
     host = "[0000:0000:0000:0000:0000:0000:0000:0001]"
   end
@@ -89,14 +89,12 @@ local function put_target_endpoint(upstream_id, host, port, endpoint)
                              .. utils.format_host(host, port)
                              .. "/" .. endpoint
   local api_client = helpers.admin_client()
-  local res, err = assert(api_client:send {
-    method = "PUT",
-    path = prefix .. path,
+  local res, err = assert(api_client:post(prefix .. path, {
     headers = {
       ["Content-Type"] = "application/json",
     },
     body = {},
-  })
+  }))
   api_client:close()
   return res, err
 end
@@ -568,7 +566,7 @@ balancer_utils.patch_upstream = patch_upstream
 balancer_utils.poll_wait_address_health = poll_wait_address_health
 balancer_utils.poll_wait_health = poll_wait_health
 balancer_utils.put_target_address_health = put_target_address_health
-balancer_utils.put_target_endpoint = put_target_endpoint
+balancer_utils.post_target_endpoint = post_target_endpoint
 balancer_utils.SLOTS = SLOTS
 balancer_utils.tcp_client_requests = tcp_client_requests
 balancer_utils.wait_for_router_update = wait_for_router_update


### PR DESCRIPTION
### Summary

In Kong 2.x series it was possible to update targets using `POST` method. When fixing this behavior, the path `/upstreams/{upstream}/targets` was mistakenly changed to also use `PUT` method, instead of only blocking adding duplicated targets. This PR changes it.

### Full changelog

* Removed support to `PUT` in `/upstreams/{upstream}/targets`
* Refuse to update targets using `POST`.
* Tests updated.
* ~~Cherry-picked #8797, in order to the tests to pass.~~ Needed sister PR already merged.

FT-2874
DECK-64