### PR TITLE
[ENGEN-450] chore(changelog) debian 8 deprecation notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,10 @@
 
 ### Breaking Changes
 
+- Deprecate/stop producing Debian 8 "Jessie" containers and packages (EOLed June 2020)
+  [Kong/kong-build-tools #448](https://github.com/Kong/kong-build-tools/pull/448)
+  [Kong/kong-distributions #766](https://github.com/Kong/kong-distributions/pull/766)
+
 #### Admin API
 
 - Insert and update operations on target entities require using the `PUT` HTTP


### PR DESCRIPTION
### Summary

This reflects the documentation side of the work to deprecate Debian 8 detailed in [ENGEN-450](https://konghq.atlassian.net/browse/ENGEN-450).

The deprecation of Debian 8 (by which I mean we stop making Debian 8-based packages and container) is targetting Kong Gateway(s) 3.0.
So the intent with this PR is that these changelog messages trickle down to kong-ee as well. If that assumption is false and I need to say, open a sister PR there, please let me know.

> - Deprecate/stop producing Debian 8 "Jessie" containers and packages (EOLed June 2020)
  [Kong/kong-build-tools #448](https://github.com/Kong/kong-build-tools/pull/448)
  [Kong/kong-distributions #766](https://github.com/Kong/kong-distributions/pull/766)