### PR TITLE
feat(api) report plugin versions on server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,9 @@
   when updating to Kong 3.0.
 - Insert and update operations on duplicated target entities returns 409.
   [#8179](https://github.com/Kong/kong/pull/8179)
+- The list of reported plugins available on the server now returns the version
+  of the plugin instead of a boolean `true`.
+  [#8810](https://github.com/Kong/kong/pull/8810)
 
 #### PDK
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,8 +81,8 @@
   when updating to Kong 3.0.
 - Insert and update operations on duplicated target entities returns 409.
   [#8179](https://github.com/Kong/kong/pull/8179)
-- The list of reported plugins available on the server now returns the version
-  of the plugin instead of a boolean `true`.
+- The list of reported plugins available on the server now returns a table of
+  metadata per plugin instead of a boolean `true`.
   [#8810](https://github.com/Kong/kong/pull/8810)
 
 #### PDK

--- a/kong/api/routes/kong.lua
+++ b/kong/api/routes/kong.lua
@@ -93,7 +93,9 @@ return {
 
       local available_plugins = {}
       for name in pairs(singletons.configuration.loaded_plugins) do
-        available_plugins[name] = kong.db.plugins.handlers[name].VERSION or true
+        available_plugins[name] = {
+          version = kong.db.plugins.handlers[name].VERSION or true
+        }
       end
 
       return kong.response.exit(200, {

--- a/kong/api/routes/kong.lua
+++ b/kong/api/routes/kong.lua
@@ -91,6 +91,11 @@ return {
         ngx.log(ngx.ERR, "could not get node id: ", err)
       end
 
+      local available_plugins = {}
+      for name in pairs(singletons.configuration.loaded_plugins) do
+        available_plugins[name] = kong.db.plugins.handlers[name].VERSION or true
+      end
+
       return kong.response.exit(200, {
         tagline = tagline,
         version = version,
@@ -98,11 +103,11 @@ return {
         node_id = node_id,
         timers = {
           running = ngx.timer.running_count(),
-          pending = ngx.timer.pending_count()
+          pending = ngx.timer.pending_count(),
         },
         plugins = {
-          available_on_server = singletons.configuration.loaded_plugins,
-          enabled_in_cluster = distinct_plugins
+          available_on_server = available_plugins,
+          enabled_in_cluster = distinct_plugins,
         },
         lua_version = lua_version,
         configuration = conf_loader.remove_sensitive(singletons.configuration),


### PR DESCRIPTION
instead of a list of plugin names with values `true` it will now report the plugin versions:

```json
    "plugins": {
        "available_on_server": {
            "acl": "3.0.1",
            "acme": "0.4.0",
            "aws-lambda": "3.6.3",
            "azure-functions": "1.0.1",
            "basic-auth": "2.2.0",
            "bot-detection": "2.0.0",
            "correlation-id": "2.0.2",
            "cors": "2.1.1",
            "datadog": "3.1.1",
            "file-log": "2.1.0",
            "grpc-gateway": "0.2.0",
            "grpc-web": "0.3.0",
            "hmac-auth": "2.4.0",
            "http-log": "2.1.1",
            "ip-restriction": "2.0.0",
            "jwt": "2.2.0",
            "key-auth": "2.4.0",
            "ldap-auth": "2.2.0",
            "loggly": "2.1.0",
            "oauth2": "2.1.2",
            "post-function": "2.1.0",
            "pre-function": "2.1.0",
            "prometheus": "1.6.0",
            "proxy-cache": "1.3.2",
            "rate-limiting": "2.4.0",
            "request-size-limiting": "2.0.0",
            "request-termination": "2.1.0",
            "request-transformer": "1.3.3",
            "response-ratelimiting": "2.1.0",
            "response-transformer": "2.0.2",
            "session": "2.4.5",
            "statsd": "2.0.1",
            "syslog": "2.2.0",
            "tcp-log": "2.1.0",
            "udp-log": "2.1.0",
            "zipkin": "1.5.0"
        },
        "enabled_in_cluster": []
    },
    "tagline": "Welcome to kong",
    "timers": {
        "pending": 7,
        "running": 0
    },
    "version": "2.8.1"
}
```

Oneliner to get plugin list and versions;
```shell
KONG_DATABASE=off bin/kong start &> /dev/null; http :8001/ | jq .plugins.available_on_server; bin/kong stop > /dev/null
```