### PR TITLE
fix(clustering) missing field in wrpc proto

### DIFF
--- a/kong/include/kong/model/service.proto
+++ b/kong/include/kong/model/service.proto
@@ -25,4 +25,5 @@ message Service {
   int32 tls_verify_depth = 16;
   Certificate client_certificate = 17;
   repeated string ca_certificates = 18;
+  bool enabled = 19;
 }


### PR DESCRIPTION
`service.proto` misses "enabled".
It may relate to wRPC DP/CP flaky tests.
