### PR TITLE
fix(clustering) do not export plugins on a route attached to a disabled service

### DIFF
--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -483,8 +483,9 @@ local function export_from_db(emitter, skip_ws, skip_disabled_entities, expand_f
       -- as well do not export plugins and routes of dsiabled services
       if skip_disabled_entities and name == "services" and not row.enabled then
         disabled_services[row.id] = true
-      elseif skip_disabled_entities and name == "routes" and disabled_services[row.service.id] then
-        disabled_routes[row.id] = true
+      elseif skip_disabled_entities and name == "routes" and row.service and
+        disabled_services[row.service ~= null and row.service.id] then
+          disabled_routes[row.id] = true
       elseif skip_disabled_entities and name == "plugins" and not row.enabled then
         goto skip_emit
 

--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -453,6 +453,7 @@ local function export_from_db(emitter, skip_ws, skip_disabled_entities, expand_f
   })
 
   local disabled_services = {}
+  local disabled_routes = {}
   for i = 1, #sorted_schemas do
     local schema = sorted_schemas[i]
     if schema.db_export == false then
@@ -482,7 +483,8 @@ local function export_from_db(emitter, skip_ws, skip_disabled_entities, expand_f
       -- as well do not export plugins and routes of dsiabled services
       if skip_disabled_entities and name == "services" and not row.enabled then
         disabled_services[row.id] = true
-
+      elseif skip_disabled_entities and name == "routes" and disabled_services[row.service.id] then
+        disabled_routes[row.id] = true
       elseif skip_disabled_entities and name == "plugins" and not row.enabled then
         goto skip_emit
 
@@ -492,7 +494,7 @@ local function export_from_db(emitter, skip_ws, skip_disabled_entities, expand_f
           if type(row[foreign_name]) == "table" then
             local id = row[foreign_name].id
             if id ~= nil then
-              if disabled_services[id] then
+              if disabled_services[id] or disabled_routes[id] then
                 goto skip_emit
               end
               if not expand_foreigns then

--- a/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
@@ -289,7 +289,7 @@ for _, strategy in helpers.each_strategy() do
           proxy_client:close()
         end)
 
-        it('does not sync plugins when service with plugin-enabled route is disabled #aaa', function()
+        it('does not sync plugins when service with plugin-enabled route is disabled', function()
           local admin_client = helpers.admin_client(10000)
           finally(function()
             admin_client:close()

--- a/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
@@ -297,7 +297,7 @@ for _, strategy in helpers.each_strategy() do
 
           -- create service
           local res = assert(admin_client:post("/services", {
-            body = { name = "mockbin-service2", url = "https://127.0.0.1:15556/request", },
+            body = { name = "mockbin-service3", url = "https://127.0.0.1:15556/request", },
             headers = {["Content-Type"] = "application/json"}
           }))
           local body = assert.res_status(201, res)
@@ -305,8 +305,8 @@ for _, strategy in helpers.each_strategy() do
           local service_id = json.id
 
           -- create route
-          res = assert(admin_client:post("/services/mockbin-service2/routes", {
-            body = { paths = { "/soon-to-be-disabled" }, },
+          res = assert(admin_client:post("/services/mockbin-service3/routes", {
+            body = { paths = { "/soon-to-be-disabled-3" }, },
             headers = {["Content-Type"] = "application/json"}
           }))
           local body = assert.res_status(201, res)
@@ -327,7 +327,7 @@ for _, strategy in helpers.each_strategy() do
 
             res = proxy_client:send({
               method  = "GET",
-              path    = "/soon-to-be-disabled",
+              path    = "/soon-to-be-disabled-3",
             })
 
             local status = res and res.status
@@ -348,7 +348,7 @@ for _, strategy in helpers.each_strategy() do
 
             res = assert(proxy_client:send({
               method  = "GET",
-              path    = "/soon-to-be-disabled",
+              path    = "/soon-to-be-disabled-3",
             }))
 
             local status = res and res.status

--- a/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
@@ -289,7 +289,7 @@ for _, strategy in helpers.each_strategy() do
           proxy_client:close()
         end)
 
-        it('does not sync plugins when service with plugin-enabled route is disabled', function()
+        it('does not sync plugins on a route attached to a disabled service', function()
           local admin_client = helpers.admin_client(10000)
           finally(function()
             admin_client:close()

--- a/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
@@ -319,7 +319,7 @@ for _, strategy in helpers.each_strategy() do
             body = { name = "bot-detection" },
             headers = {["Content-Type"] = "application/json"}
           }))
-          local body = assert.res_status(201, res)
+          assert.res_status(201, res)
 
           -- test route
           helpers.wait_until(function()

--- a/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
@@ -332,9 +332,7 @@ for _, strategy in helpers.each_strategy() do
 
             local status = res and res.status
             proxy_client:close()
-            if status == 200 then
-              return true
-            end
+            return status == 200
           end, 10)
 
           -- disable service
@@ -343,20 +341,20 @@ for _, strategy in helpers.each_strategy() do
             headers = {["Content-Type"] = "application/json"}
           }))
           assert.res_status(200, res)
-          -- as this is testing a negative behavior, there is no sure way to wait
-          -- this can probably be optimizted
-          ngx.sleep(2)
-
-          local proxy_client = helpers.http_client("127.0.0.1", 9002)
 
           -- test route again
-          res = assert(proxy_client:send({
-            method  = "GET",
-            path    = "/soon-to-be-disabled",
-          }))
-          assert.res_status(404, res)
+          helpers.wait_until(function()
+            local proxy_client = helpers.http_client("127.0.0.1", 9002)
 
-          proxy_client:close()
+            res = assert(proxy_client:send({
+              method  = "GET",
+              path    = "/soon-to-be-disabled",
+            }))
+
+            local status = res and res.status
+            proxy_client:close()
+            return status == 404
+          end, 10)
         end)
       end)
     end)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

This PR fix for a new DP get zero size config while service with plugin-enabled route is disabled.

The primary reason for this is CP does not totally filtering the exported config so when running in hybrid mode, DPs are sent disabled services and the routes/plugins associated with them. 

FTI-4009 FTI-4040
