### PR TITLE
fix(clustering) localize config_version to avoid race condition from

### DIFF
--- a/kong/clustering/wrpc_data_plane.lua
+++ b/kong/clustering/wrpc_data_plane.lua
@@ -197,14 +197,15 @@ function _M:communicate(premature)
         end
         local config_table = self.next_config
         local config_hash  = self.next_hash
+        local config_version = self.next_config_version
         local hashes = self.next_hashes
-        if config_table and self.next_config_version > last_config_version then
-          ngx_log(ngx_INFO, _log_prefix, "received config #", self.next_config_version, log_suffix)
+        if config_table and config_version > last_config_version then
+          ngx_log(ngx_INFO, _log_prefix, "received config #", config_version, log_suffix)
 
           local pok, res
           pok, res, err = xpcall(self.update_config, debug.traceback, self, config_table, config_hash, true, hashes)
           if pok then
-            last_config_version = self.next_config_version
+            last_config_version = config_version
             if not res then
               ngx_log(ngx_ERR, _log_prefix, "unable to update running config: ", err)
             end


### PR DESCRIPTION
yield

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

`update_config` can yield, so we need to cache fields in `self`, otherwise it might got updated (on L89) before we read it (on L208), and causes L202 become false next time, thus prevent next ConfigSync being executed. This probably become more visiable as we introduce more `yield` from #8800.

### Full changelog

*  localize config_version to avoid race condition from yield
