### PR TITLE
feat(api) add plugin priority to metadata

### DIFF
--- a/kong/api/routes/kong.lua
+++ b/kong/api/routes/kong.lua
@@ -94,7 +94,8 @@ return {
       local available_plugins = {}
       for name in pairs(singletons.configuration.loaded_plugins) do
         available_plugins[name] = {
-          version = kong.db.plugins.handlers[name].VERSION or true
+          version = kong.db.plugins.handlers[name].VERSION,
+          priority = kong.db.plugins.handlers[name].PRIORITY,
         }
       end
 


### PR DESCRIPTION
besides exposing the version, the priority of a plugin is also a property that quite often is unclear to users, so dynamically getting it from the system will help answering those questions.

I didn't include it in the original PR (#8810 ), because of the upcoming dynamic priorities. But after a chat with @jschmid1 it turns out that the hard-coded priorities will remain the default, so still makes sense to expose those as well.

Also; removed the `true` placeholder, which doesn't make sense anymore now that the metadata is an object