### PR TITLE
feat(pdk) normalize kong.request.get_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,10 @@
   [#8815](https://github.com/Kong/kong/pull/8815)
 - The dataplane config cache was removed. The config persistence is now done automatically with LMDB.
   [#8704](https://github.com/Kong/kong/pull/8704)
+- The `kong.request.get_path()` PDK function now performs path normalization
+  on the string that is returned to the caller. The raw, non-normalized version
+  of the request path can be fetched via `kong.request.get_raw_path()`.
+  [8823](https://github.com/Kong/kong/pull/8823)
 
 #### Admin API
 

--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -385,7 +385,6 @@ local function new(self)
   --
   -- @function kong.request.get_path
   -- @phases rewrite, access, header_filter, response, body_filter, log, admin_api
-  -- @tparam[opt=true] boolean merge_slashes consolidate duplicate slashes in the path
   -- @treturn string the path
   -- @usage
   -- -- Given a request to https://example.com/t/Abc%20123%C3%B8%2f/parent/..//test/./

--- a/t/01-pdk/04-request/00-phase_checks.t
+++ b/t/01-pdk/04-request/00-phase_checks.t
@@ -163,6 +163,18 @@ qq{
                 log           = true,
                 admin_api     = true,
             }, {
+                method        = "get_raw_path",
+                args          = {},
+                init_worker   = false,
+                certificate   = "pending",
+                rewrite       = true,
+                access        = true,
+                header_filter = true,
+                response      = true,
+                body_filter   = true,
+                log           = true,
+                admin_api     = true,
+            }, {
                 method        = "get_path_with_query",
                 args          = {},
                 init_worker   = false,

--- a/t/01-pdk/04-request/20-get_raw_path.t
+++ b/t/01-pdk/04-request/20-get_raw_path.t
@@ -9,7 +9,7 @@ run_tests();
 
 __DATA__
 
-=== TEST 1: request.get_path() returns path component of uri
+=== TEST 1: request.get_raw_path() returns path component of uri
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = /t {
@@ -17,19 +17,19 @@ __DATA__
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
 
-            ngx.say("normalized path: ", pdk.request.get_path())
+            ngx.say("path: ", pdk.request.get_raw_path())
         }
     }
 --- request
 GET /t
 --- response_body
-normalized path: /t
+path: /t
 --- no_error_log
 [error]
 
 
 
-=== TEST 2: request.get_path() returns at least slash
+=== TEST 2: request.get_raw_path() returns at least slash
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location = / {
@@ -37,19 +37,19 @@ normalized path: /t
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
 
-            ngx.say("normalized path: ", pdk.request.get_path())
+            ngx.say("path: ", pdk.request.get_raw_path())
         }
     }
 --- request
 GET http://kong
 --- response_body
-normalized path: /
+path: /
 --- no_error_log
 [error]
 
 
 
-=== TEST 3: request.get_path() is normalized
+=== TEST 3: request.get_raw_path() is not normalized
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location /t/ {
@@ -57,19 +57,19 @@ normalized path: /
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
 
-            ngx.say("normalized path: ", pdk.request.get_path())
+            ngx.say("path: ", pdk.request.get_raw_path())
         }
     }
 --- request
-GET /t/Abc%20123%C3%B8/parent/../test/.
+GET /t/Abc%20123%C3%B8/../test/.
 --- response_body
-normalized path: /t/Abc 123ø/test/
+path: /t/Abc%20123%C3%B8/../test/.
 --- no_error_log
 [error]
 
 
 
-=== TEST 4: request.get_path() strips query string
+=== TEST 4: request.get_raw_path() strips query string
 --- http_config eval: $t::Util::HttpConfig
 --- config
     location /t/ {
@@ -77,12 +77,12 @@ normalized path: /t/Abc 123ø/test/
             local PDK = require "kong.pdk"
             local pdk = PDK.new()
 
-            ngx.say("normalized path: ", pdk.request.get_path())
+            ngx.say("path: ", pdk.request.get_raw_path())
         }
     }
 --- request
 GET /t/demo?param=value
 --- response_body
-normalized path: /t/demo
+path: /t/demo
 --- no_error_log
 [error]


### PR DESCRIPTION
This changes the behavior of `kong.request.get_path()` such that it performs path normalization on the value before returning it to the caller. The new PDK function `kong.request.get_raw_path()` performs no normalization and contains a notice about its potential security pitfalls when used unwisely.

**Note:** there has been much discussion on the underlying implementation/methodology of our normalization strategy (see #8140). This pull request does not attempt to resolve that discussion and only focuses on the PDK interface. The assumption here is that the implementation of `kong.tools.uri.normalize` can be updated/finalized at a later date if we wish (though some test cases and LuaDoc annotations may need to be updated depending on what changes are made).
