### PR TITLE
chore(cluster) head request to version negotiation

### DIFF
--- a/kong/clustering/version_negotiation/init.lua
+++ b/kong/clustering/version_negotiation/init.lua
@@ -354,4 +354,40 @@ function _M.get_negotiated_service(name)
   return val.version, val.message
 end
 
+--- detect '/v1/wrpc' endpoint
+--- if there is no '/v1/wrpc', fallback to websocket + json
+function _M.check_wrpc_support(conf, cert, cert_key)
+  local params = {
+    scheme = "https",
+    method = "HEAD",
+
+    ssl_verify = false,
+    ssl_client_cert = cert,
+    ssl_client_priv_key = cert_key,
+  }
+
+  if conf.cluster_mtls == "shared" then
+    params.ssl_server_name = "kong_clustering"
+
+  else
+    -- server_name will be set to the host if it is not explicitly defined here
+    if conf.cluster_server_name ~= "" then
+      params.ssl_server_name = conf.cluster_server_name
+    end
+  end
+
+  local c = http.new()
+  local res, err = c:request_uri(
+    "https://" .. conf.cluster_control_plane .. "/v1/wrpc", params)
+  if not res then
+    return nil, err
+  end
+
+  if res.status == 404 then
+    return "v0"
+  end
+
+  return "v1"   -- wrpc
+end
+
 return _M


### PR DESCRIPTION


### Summary

We do not use `/version-handshake` endpoint, just send a simple `HEAD` request to `/v1/wrpc`,
If it works then we use wrpc, else we fall back to websocket + json.

### Full changelog

* Add a new function `head_request_version` in  `version_negotiation/init.lua`
* Change the behavior of functioin `request_version_negotiation`
* Check the result in `init_worker` 



