### PR TITLE
feat(plugins) opentelemetry plugin

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -165,4 +165,5 @@ plugins/udp-log:
 plugins/zipkin:
 - kong/plugins/zipkin/**/*
 
-
+plugins/opentelemetry:
+- kong/plugins/opentelemetry/**/*

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -136,6 +136,7 @@ jobs:
       KONG_TEST_DATABASE: postgres
       KONG_SPEC_TEST_GRPCBIN_PORT: "15002"
       KONG_SPEC_TEST_GRPCBIN_SSL_PORT: "15003"
+      KONG_SPEC_TEST_OTELCOL_FILE_EXPORTER_PATH: ${{ github.workspace }}/tmp/otel/file_exporter.json
       TEST_SUITE: ${{ matrix.suite }}
       TEST_SPLIT: ${{ matrix.split }}
 
@@ -201,6 +202,20 @@ jobs:
           docker restart kong_redis
           docker logs kong_redis
 
+    - name: Run OpenTelemetry Collector
+      run: |
+          mkdir -p ${{ github.workspace }}/tmp/otel
+          touch ${{ github.workspace }}/tmp/otel/file_exporter.json
+          sudo chmod 777 -R ${{ github.workspace }}/tmp/otel
+          docker run -p 4317:4317 -p 4318:4318 -p 55679:55679 \
+              -v ${{ github.workspace }}/spec/fixtures/opentelemetry/otelcol.yaml:/etc/otel-collector-config.yaml \
+              -v ${{ github.workspace }}/tmp/otel:/etc/otel \
+              --name opentelemetry-collector -d \
+              otel/opentelemetry-collector-contrib:0.52.0 \
+              --config=/etc/otel-collector-config.yaml
+          sleep 2
+          docker logs opentelemetry-collector
+
     - name: Tests
       run: |
           eval `luarocks path`
@@ -218,6 +233,7 @@ jobs:
       KONG_TEST_DATABASE: 'off'
       KONG_SPEC_TEST_GRPCBIN_PORT: "15002"
       KONG_SPEC_TEST_GRPCBIN_SSL_PORT: "15003"
+      KONG_SPEC_TEST_OTELCOL_FILE_EXPORTER_PATH: ${{ github.workspace }}/tmp/otel/file_exporter.json
       TEST_SUITE: dbless
 
     services:
@@ -252,6 +268,20 @@ jobs:
           echo "127.0.0.1 grpcs_1.test" | sudo tee -a /etc/hosts
           echo "127.0.0.1 grpcs_2.test" | sudo tee -a /etc/hosts
 
+    - name: Run OpenTelemetry Collector
+      run: |
+          mkdir -p ${{ github.workspace }}/tmp/otel
+          touch ${{ github.workspace }}/tmp/otel/file_exporter.json
+          sudo chmod 777 -R ${{ github.workspace }}/tmp/otel
+          docker run -p 4317:4317 -p 4318:4318 -p 55679:55679 \
+              -v ${{ github.workspace }}/spec/fixtures/opentelemetry/otelcol.yaml:/etc/otel-collector-config.yaml \
+              -v ${{ github.workspace }}/tmp/otel:/etc/otel \
+              --name opentelemetry-collector -d \
+              otel/opentelemetry-collector-contrib:0.52.0 \
+              --config=/etc/otel-collector-config.yaml
+          sleep 2
+          docker logs opentelemetry-collector
+
     - name: Tests
       run: |
           eval `luarocks path`
@@ -273,6 +303,7 @@ jobs:
       KONG_TEST_DATABASE: cassandra
       KONG_SPEC_TEST_GRPCBIN_PORT: "15002"
       KONG_SPEC_TEST_GRPCBIN_SSL_PORT: "15003"
+      KONG_SPEC_TEST_OTELCOL_FILE_EXPORTER_PATH: ${{ github.workspace }}/tmp/otel/file_exporter.json
       TEST_SUITE: ${{ matrix.suite }}
       TEST_SPLIT: ${{ matrix.split }}
 
@@ -336,6 +367,20 @@ jobs:
           docker cp ${{ github.workspace }}/spec/fixtures/redis/docker-entrypoint.sh kong_redis:/usr/local/bin/docker-entrypoint.sh
           docker restart kong_redis
           docker logs kong_redis
+
+    - name: Run OpenTelemetry Collector
+      run: |
+          mkdir -p ${{ github.workspace }}/tmp/otel
+          touch ${{ github.workspace }}/tmp/otel/file_exporter.json
+          sudo chmod 777 -R ${{ github.workspace }}/tmp/otel
+          docker run -p 4317:4317 -p 4318:4318 -p 55679:55679 \
+              -v ${{ github.workspace }}/spec/fixtures/opentelemetry/otelcol.yaml:/etc/otel-collector-config.yaml \
+              -v ${{ github.workspace }}/tmp/otel:/etc/otel \
+              --name opentelemetry-collector -d \
+              otel/opentelemetry-collector-contrib:0.52.0 \
+              --config=/etc/otel-collector-config.yaml
+          sleep 2
+          docker logs opentelemetry-collector
 
     - name: Tests
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@
   [#8810](https://github.com/Kong/kong/pull/8810)
 
 #### PDK
+
 - `pdk.response.set_header()`, `pdk.response.set_headers()`, `pdk.response.exit()` now ignore and emit warnings for manually set `Transfer-Encoding` headers.
   [#8698](https://github.com/Kong/kong/pull/8698)
 - The PDK is no longer versioned
@@ -205,12 +206,18 @@
   The tracing API is intend to be used with a external exporter plugin.
   Build-in instrumentation types and sampling rate are configuable through
   `opentelemetry_tracing` and `opentelemetry_tracing_sampling_rate` options.
- [#8724](https://github.com/Kong/kong/pull/8724)
+  [#8724](https://github.com/Kong/kong/pull/8724)
 - Added `path`, `uri_capture`, and `query_arg` options to upstream `hash_on`
-  for load balancing. [#8701](https://github.com/Kong/kong/pull/8701)
+  for load balancing.
+  [#8701](https://github.com/Kong/kong/pull/8701)
 
 #### Plugins
 
+- Introduced the new **OpenTelemetry** plugin that export tracing instrumentations
+  to any OTLP/HTTP compatible backend.
+  `opentelemetry_tracing` configuration should be enabled to collect
+  the core tracing spans of Kong.
+  [#8826](https://github.com/Kong/kong/pull/8826)
 - **Zipkin**: add support for including HTTP path in span name
   through configuration property `http_span_name`.
   [#8150](https://github.com/Kong/kong/pull/8150)

--- a/kong-2.8.0-0.rockspec
+++ b/kong-2.8.0-0.rockspec
@@ -482,6 +482,11 @@ build = {
     ["kong.plugins.azure-functions.handler"] = "kong/plugins/azure-functions/handler.lua",
     ["kong.plugins.azure-functions.schema"]  = "kong/plugins/azure-functions/schema.lua",
 
+    ["kong.plugins.opentelemetry.handler"] = "kong/plugins/opentelemetry/handler.lua",
+    ["kong.plugins.opentelemetry.schema"]  = "kong/plugins/opentelemetry/schema.lua",
+    ["kong.plugins.opentelemetry.proto"]  = "kong/plugins/opentelemetry/proto.lua",
+    ["kong.plugins.opentelemetry.otlp"]  = "kong/plugins/opentelemetry/otlp.lua",
+
     ["kong.vaults.env"] = "kong/vaults/env/init.lua",
     ["kong.vaults.env.schema"] = "kong/vaults/env/schema.lua",
 

--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -35,6 +35,7 @@ local plugins = {
   "post-function",
   "azure-functions",
   "zipkin",
+  "opentelemetry",
 }
 
 local plugin_map = {}

--- a/kong/include/opentelemetry/proto/collector/trace/v1/trace_service.proto
+++ b/kong/include/opentelemetry/proto/collector/trace/v1/trace_service.proto
@@ -1,0 +1,45 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package opentelemetry.proto.collector.trace.v1;
+
+import "opentelemetry/proto/trace/v1/trace.proto";
+
+option java_multiple_files = true;
+option java_package = "io.opentelemetry.proto.collector.trace.v1";
+option java_outer_classname = "TraceServiceProto";
+option go_package = "go.opentelemetry.io/proto/otlp/collector/trace/v1";
+
+// Service that can be used to push spans between one Application instrumented with
+// OpenTelemetry and a collector, or between a collector and a central collector (in this
+// case spans are sent/received to/from multiple Applications).
+service TraceService {
+  // For performance reasons, it is recommended to keep this RPC
+  // alive for the entire life of the application.
+  rpc Export(ExportTraceServiceRequest) returns (ExportTraceServiceResponse) {}
+}
+
+message ExportTraceServiceRequest {
+  // An array of ResourceSpans.
+  // For data coming from a single resource this array will typically contain one
+  // element. Intermediary nodes (such as OpenTelemetry Collector) that receive
+  // data from multiple origins typically batch the data before forwarding further and
+  // in that case this array will contain multiple elements.
+  repeated opentelemetry.proto.trace.v1.ResourceSpans resource_spans = 1;
+}
+
+message ExportTraceServiceResponse {
+}

--- a/kong/include/opentelemetry/proto/common/v1/common.proto
+++ b/kong/include/opentelemetry/proto/common/v1/common.proto
@@ -1,0 +1,87 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package opentelemetry.proto.common.v1;
+
+option java_multiple_files = true;
+option java_package = "io.opentelemetry.proto.common.v1";
+option java_outer_classname = "CommonProto";
+option go_package = "go.opentelemetry.io/proto/otlp/common/v1";
+
+// AnyValue is used to represent any type of attribute value. AnyValue may contain a
+// primitive value such as a string or integer or it may contain an arbitrary nested
+// object containing arrays, key-value lists and primitives.
+message AnyValue {
+  // The value is one of the listed fields. It is valid for all values to be unspecified
+  // in which case this AnyValue is considered to be "empty".
+  oneof value {
+    string string_value = 1;
+    bool bool_value = 2;
+    int64 int_value = 3;
+    double double_value = 4;
+    ArrayValue array_value = 5;
+    KeyValueList kvlist_value = 6;
+    bytes bytes_value = 7;
+  }
+}
+
+// ArrayValue is a list of AnyValue messages. We need ArrayValue as a message
+// since oneof in AnyValue does not allow repeated fields.
+message ArrayValue {
+  // Array of values. The array may be empty (contain 0 elements).
+  repeated AnyValue values = 1;
+}
+
+// KeyValueList is a list of KeyValue messages. We need KeyValueList as a message
+// since `oneof` in AnyValue does not allow repeated fields. Everywhere else where we need
+// a list of KeyValue messages (e.g. in Span) we use `repeated KeyValue` directly to
+// avoid unnecessary extra wrapping (which slows down the protocol). The 2 approaches
+// are semantically equivalent.
+message KeyValueList {
+  // A collection of key/value pairs of key-value pairs. The list may be empty (may
+  // contain 0 elements).
+  // The keys MUST be unique (it is not allowed to have more than one
+  // value with the same key).
+  repeated KeyValue values = 1;
+}
+
+// KeyValue is a key-value pair that is used to store Span attributes, Link
+// attributes, etc.
+message KeyValue {
+  string key = 1;
+  AnyValue value = 2;
+}
+
+// InstrumentationLibrary is a message representing the instrumentation library information
+// such as the fully qualified name and version.
+// InstrumentationLibrary is wire-compatible with InstrumentationScope for binary
+// Protobuf format.
+// This message is deprecated and will be removed on June 15, 2022.
+message InstrumentationLibrary {
+  option deprecated = true;
+
+  // An empty instrumentation library name means the name is unknown.
+  string name = 1;
+  string version = 2;
+}
+
+// InstrumentationScope is a message representing the instrumentation scope information
+// such as the fully qualified name and version.
+message InstrumentationScope {
+  // An empty instrumentation scope name means the name is unknown.
+  string name = 1;
+  string version = 2;
+}

--- a/kong/include/opentelemetry/proto/resource/v1/resource.proto
+++ b/kong/include/opentelemetry/proto/resource/v1/resource.proto
@@ -1,0 +1,36 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package opentelemetry.proto.resource.v1;
+
+import "opentelemetry/proto/common/v1/common.proto";
+
+option java_multiple_files = true;
+option java_package = "io.opentelemetry.proto.resource.v1";
+option java_outer_classname = "ResourceProto";
+option go_package = "go.opentelemetry.io/proto/otlp/resource/v1";
+
+// Resource information.
+message Resource {
+  // Set of attributes that describe the resource.
+  // Attribute keys MUST be unique (it is not allowed to have more than one
+  // attribute with the same key).
+  repeated opentelemetry.proto.common.v1.KeyValue attributes = 1;
+
+  // dropped_attributes_count is the number of dropped attributes. If the value is 0, then
+  // no attributes were dropped.
+  uint32 dropped_attributes_count = 2;
+}

--- a/kong/include/opentelemetry/proto/trace/v1/trace.proto
+++ b/kong/include/opentelemetry/proto/trace/v1/trace.proto
@@ -1,0 +1,331 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package opentelemetry.proto.trace.v1;
+
+import "opentelemetry/proto/common/v1/common.proto";
+import "opentelemetry/proto/resource/v1/resource.proto";
+
+option java_multiple_files = true;
+option java_package = "io.opentelemetry.proto.trace.v1";
+option java_outer_classname = "TraceProto";
+option go_package = "go.opentelemetry.io/proto/otlp/trace/v1";
+
+// TracesData represents the traces data that can be stored in a persistent storage,
+// OR can be embedded by other protocols that transfer OTLP traces data but do
+// not implement the OTLP protocol.
+//
+// The main difference between this message and collector protocol is that
+// in this message there will not be any "control" or "metadata" specific to
+// OTLP protocol.
+//
+// When new fields are added into this message, the OTLP request MUST be updated
+// as well.
+message TracesData {
+  // An array of ResourceSpans.
+  // For data coming from a single resource this array will typically contain
+  // one element. Intermediary nodes that receive data from multiple origins
+  // typically batch the data before forwarding further and in that case this
+  // array will contain multiple elements.
+  repeated ResourceSpans resource_spans = 1;
+}
+
+// A collection of ScopeSpans from a Resource.
+message ResourceSpans {
+  // The resource for the spans in this message.
+  // If this field is not set then no resource info is known.
+  opentelemetry.proto.resource.v1.Resource resource = 1;
+
+  // A list of ScopeSpans that originate from a resource.
+  repeated ScopeSpans scope_spans = 2;
+
+  // A list of InstrumentationLibrarySpans that originate from a resource.
+  // This field is deprecated and will be removed after grace period expires on June 15, 2022.
+  //
+  // During the grace period the following rules SHOULD be followed:
+  //
+  // For Binary Protobufs
+  // ====================
+  // Binary Protobuf senders SHOULD NOT set instrumentation_library_spans. Instead
+  // scope_spans SHOULD be set.
+  //
+  // Binary Protobuf receivers SHOULD check if instrumentation_library_spans is set
+  // and scope_spans is not set then the value in instrumentation_library_spans
+  // SHOULD be used instead by converting InstrumentationLibrarySpans into ScopeSpans.
+  // If scope_spans is set then instrumentation_library_spans SHOULD be ignored.
+  //
+  // For JSON
+  // ========
+  // JSON senders that set instrumentation_library_spans field MAY also set
+  // scope_spans to carry the same spans, essentially double-publishing the same data.
+  // Such double-publishing MAY be controlled by a user-settable option.
+  // If double-publishing is not used then the senders SHOULD set scope_spans and
+  // SHOULD NOT set instrumentation_library_spans.
+  //
+  // JSON receivers SHOULD check if instrumentation_library_spans is set and
+  // scope_spans is not set then the value in instrumentation_library_spans
+  // SHOULD be used instead by converting InstrumentationLibrarySpans into ScopeSpans.
+  // If scope_spans is set then instrumentation_library_spans field SHOULD be ignored.
+  repeated InstrumentationLibrarySpans instrumentation_library_spans = 1000 [deprecated = true];
+
+  // This schema_url applies to the data in the "resource" field. It does not apply
+  // to the data in the "scope_spans" field which have their own schema_url field.
+  string schema_url = 3;
+}
+
+// A collection of Spans produced by an InstrumentationScope.
+message ScopeSpans {
+  // The instrumentation scope information for the spans in this message.
+  // Semantically when InstrumentationScope isn't set, it is equivalent with
+  // an empty instrumentation scope name (unknown).
+  opentelemetry.proto.common.v1.InstrumentationScope scope = 1;
+
+  // A list of Spans that originate from an instrumentation scope.
+  repeated Span spans = 2;
+
+  // This schema_url applies to all spans and span events in the "spans" field.
+  string schema_url = 3;
+}
+
+// A collection of Spans produced by an InstrumentationLibrary.
+// InstrumentationLibrarySpans is wire-compatible with ScopeSpans for binary
+// Protobuf format.
+// This message is deprecated and will be removed on June 15, 2022.
+message InstrumentationLibrarySpans {
+  option deprecated = true;
+
+  // The instrumentation library information for the spans in this message.
+  // Semantically when InstrumentationLibrary isn't set, it is equivalent with
+  // an empty instrumentation library name (unknown).
+  opentelemetry.proto.common.v1.InstrumentationLibrary instrumentation_library = 1;
+
+  // A list of Spans that originate from an instrumentation library.
+  repeated Span spans = 2;
+
+  // This schema_url applies to all spans and span events in the "spans" field.
+  string schema_url = 3;
+}
+
+// Span represents a single operation within a trace. Spans can be
+// nested to form a trace tree. Spans may also be linked to other spans
+// from the same or different trace and form graphs. Often, a trace
+// contains a root span that describes the end-to-end latency, and one
+// or more subspans for its sub-operations. A trace can also contain
+// multiple root spans, or none at all. Spans do not need to be
+// contiguous - there may be gaps or overlaps between spans in a trace.
+//
+// The next available field id is 17.
+message Span {
+  // A unique identifier for a trace. All spans from the same trace share
+  // the same `trace_id`. The ID is a 16-byte array. An ID with all zeroes
+  // is considered invalid.
+  //
+  // This field is semantically required. Receiver should generate new
+  // random trace_id if empty or invalid trace_id was received.
+  //
+  // This field is required.
+  bytes trace_id = 1;
+
+  // A unique identifier for a span within a trace, assigned when the span
+  // is created. The ID is an 8-byte array. An ID with all zeroes is considered
+  // invalid.
+  //
+  // This field is semantically required. Receiver should generate new
+  // random span_id if empty or invalid span_id was received.
+  //
+  // This field is required.
+  bytes span_id = 2;
+
+  // trace_state conveys information about request position in multiple distributed tracing graphs.
+  // It is a trace_state in w3c-trace-context format: https://www.w3.org/TR/trace-context/#tracestate-header
+  // See also https://github.com/w3c/distributed-tracing for more details about this field.
+  string trace_state = 3;
+
+  // The `span_id` of this span's parent span. If this is a root span, then this
+  // field must be empty. The ID is an 8-byte array.
+  bytes parent_span_id = 4;
+
+  // A description of the span's operation.
+  //
+  // For example, the name can be a qualified method name or a file name
+  // and a line number where the operation is called. A best practice is to use
+  // the same display name at the same call point in an application.
+  // This makes it easier to correlate spans in different traces.
+  //
+  // This field is semantically required to be set to non-empty string.
+  // Empty value is equivalent to an unknown span name.
+  //
+  // This field is required.
+  string name = 5;
+
+  // SpanKind is the type of span. Can be used to specify additional relationships between spans
+  // in addition to a parent/child relationship.
+  enum SpanKind {
+    // Unspecified. Do NOT use as default.
+    // Implementations MAY assume SpanKind to be INTERNAL when receiving UNSPECIFIED.
+    SPAN_KIND_UNSPECIFIED = 0;
+
+    // Indicates that the span represents an internal operation within an application,
+    // as opposed to an operation happening at the boundaries. Default value.
+    SPAN_KIND_INTERNAL = 1;
+
+    // Indicates that the span covers server-side handling of an RPC or other
+    // remote network request.
+    SPAN_KIND_SERVER = 2;
+
+    // Indicates that the span describes a request to some remote service.
+    SPAN_KIND_CLIENT = 3;
+
+    // Indicates that the span describes a producer sending a message to a broker.
+    // Unlike CLIENT and SERVER, there is often no direct critical path latency relationship
+    // between producer and consumer spans. A PRODUCER span ends when the message was accepted
+    // by the broker while the logical processing of the message might span a much longer time.
+    SPAN_KIND_PRODUCER = 4;
+
+    // Indicates that the span describes consumer receiving a message from a broker.
+    // Like the PRODUCER kind, there is often no direct critical path latency relationship
+    // between producer and consumer spans.
+    SPAN_KIND_CONSUMER = 5;
+  }
+
+  // Distinguishes between spans generated in a particular context. For example,
+  // two spans with the same name may be distinguished using `CLIENT` (caller)
+  // and `SERVER` (callee) to identify queueing latency associated with the span.
+  SpanKind kind = 6;
+
+  // start_time_unix_nano is the start time of the span. On the client side, this is the time
+  // kept by the local machine where the span execution starts. On the server side, this
+  // is the time when the server's application handler starts running.
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
+  //
+  // This field is semantically required and it is expected that end_time >= start_time.
+  fixed64 start_time_unix_nano = 7;
+
+  // end_time_unix_nano is the end time of the span. On the client side, this is the time
+  // kept by the local machine where the span execution ends. On the server side, this
+  // is the time when the server application handler stops running.
+  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
+  //
+  // This field is semantically required and it is expected that end_time >= start_time.
+  fixed64 end_time_unix_nano = 8;
+
+  // attributes is a collection of key/value pairs. Note, global attributes
+  // like server name can be set using the resource API. Examples of attributes:
+  //
+  //     "/http/user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36"
+  //     "/http/server_latency": 300
+  //     "abc.com/myattribute": true
+  //     "abc.com/score": 10.239
+  //
+  // The OpenTelemetry API specification further restricts the allowed value types:
+  // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/common.md#attributes
+  // Attribute keys MUST be unique (it is not allowed to have more than one
+  // attribute with the same key).
+  repeated opentelemetry.proto.common.v1.KeyValue attributes = 9;
+
+  // dropped_attributes_count is the number of attributes that were discarded. Attributes
+  // can be discarded because their keys are too long or because there are too many
+  // attributes. If this value is 0, then no attributes were dropped.
+  uint32 dropped_attributes_count = 10;
+
+  // Event is a time-stamped annotation of the span, consisting of user-supplied
+  // text description and key-value pairs.
+  message Event {
+    // time_unix_nano is the time the event occurred.
+    fixed64 time_unix_nano = 1;
+
+    // name of the event.
+    // This field is semantically required to be set to non-empty string.
+    string name = 2;
+
+    // attributes is a collection of attribute key/value pairs on the event.
+    // Attribute keys MUST be unique (it is not allowed to have more than one
+    // attribute with the same key).
+    repeated opentelemetry.proto.common.v1.KeyValue attributes = 3;
+
+    // dropped_attributes_count is the number of dropped attributes. If the value is 0,
+    // then no attributes were dropped.
+    uint32 dropped_attributes_count = 4;
+  }
+
+  // events is a collection of Event items.
+  repeated Event events = 11;
+
+  // dropped_events_count is the number of dropped events. If the value is 0, then no
+  // events were dropped.
+  uint32 dropped_events_count = 12;
+
+  // A pointer from the current span to another span in the same trace or in a
+  // different trace. For example, this can be used in batching operations,
+  // where a single batch handler processes multiple requests from different
+  // traces or when the handler receives a request from a different project.
+  message Link {
+    // A unique identifier of a trace that this linked span is part of. The ID is a
+    // 16-byte array.
+    bytes trace_id = 1;
+
+    // A unique identifier for the linked span. The ID is an 8-byte array.
+    bytes span_id = 2;
+
+    // The trace_state associated with the link.
+    string trace_state = 3;
+
+    // attributes is a collection of attribute key/value pairs on the link.
+    // Attribute keys MUST be unique (it is not allowed to have more than one
+    // attribute with the same key).
+    repeated opentelemetry.proto.common.v1.KeyValue attributes = 4;
+
+    // dropped_attributes_count is the number of dropped attributes. If the value is 0,
+    // then no attributes were dropped.
+    uint32 dropped_attributes_count = 5;
+  }
+
+  // links is a collection of Links, which are references from this span to a span
+  // in the same or different trace.
+  repeated Link links = 13;
+
+  // dropped_links_count is the number of dropped links after the maximum size was
+  // enforced. If this value is 0, then no links were dropped.
+  uint32 dropped_links_count = 14;
+
+  // An optional final status for this span. Semantically when Status isn't set, it means
+  // span's status code is unset, i.e. assume STATUS_CODE_UNSET (code = 0).
+  Status status = 15;
+}
+
+// The Status type defines a logical error model that is suitable for different
+// programming environments, including REST APIs and RPC APIs.
+message Status {
+  reserved 1;
+
+  // A developer-facing human readable error message.
+  string message = 2;
+
+  // For the semantics of status codes see
+  // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status
+  enum StatusCode {
+    // The default status.
+    STATUS_CODE_UNSET               = 0;
+    // The Span has been validated by an Application developers or Operator to have
+    // completed successfully.
+    STATUS_CODE_OK                  = 1;
+    // The Span contains an error.
+    STATUS_CODE_ERROR               = 2;
+  };
+
+  // The status code.
+  StatusCode code = 3;
+}

--- a/kong/pdk/tracing.lua
+++ b/kong/pdk/tracing.lua
@@ -175,7 +175,7 @@ local function new_span(tracer, name, options)
 
   -- specify span start time manually
   span.start_time_ns = options.start_time_ns or ffi_time_unix_nano()
-  span.kind = options.kind or SPAN_KIND.INTERNAL
+  span.kind = options.span_kind or SPAN_KIND.INTERNAL
   span.attributes = options.attributes
 
   -- indicates whether the span should be reported

--- a/kong/plugins/opentelemetry/handler.lua
+++ b/kong/plugins/opentelemetry/handler.lua
@@ -1,0 +1,199 @@
+local new_tab = require "table.new"
+local http = require "resty.http"
+local clone = require "table.clone"
+local otlp = require "kong.plugins.opentelemetry.otlp"
+local propagation = require "kong.tracing.propagation"
+local tablepool = require "tablepool"
+
+local ngx = ngx
+local kong = kong
+local ngx_log = ngx.log
+local ngx_ERR = ngx.ERR
+local ngx_DEBUG = ngx.DEBUG
+local ngx_now = ngx.now
+local ngx_update_time = ngx.update_time
+local ngx_req = ngx.req
+local ngx_get_headers = ngx_req.get_headers
+local timer_at = ngx.timer.at
+local clear = table.clear
+local propagation_parse = propagation.parse
+local propagation_set = propagation.set
+local tablepool_release = tablepool.release
+local tablepool_fetch = tablepool.fetch
+local null = ngx.null
+local encode_traces = otlp.encode_traces
+local transform_span = otlp.transform_span
+
+local POOL_BATCH_SPANS = "KONG_OTLP_BATCH_SPANS"
+local _log_prefix = "[otel] "
+
+local OpenTelemetryHandler = {
+  VERSION = "0.1.0",
+  PRIORITY = 14,
+}
+
+local default_headers = {
+  ["Content-Type"] = "application/x-protobuf",
+}
+
+-- worker-level spans queue
+local spans_queue = new_tab(5000, 0)
+local headers_cache = setmetatable({}, { __mode = "k" })
+local last_run_cache = setmetatable({}, { __mode = "k" })
+
+local function get_cached_headers(conf_headers)
+  -- cache http headers
+  local headers = default_headers
+  if conf_headers then
+    headers = headers_cache[conf_headers]
+  end
+
+  if not headers then
+    headers = clone(default_headers)
+    if conf_headers and conf_headers ~= null then
+      for k, v in pairs(conf_headers) do
+        headers[k] = v and v[1]
+      end
+    end
+
+    headers_cache[conf_headers] = headers
+  end
+
+  return headers
+end
+
+
+local function http_export_request(conf, pb_data, headers)
+  local httpc = http.new()
+  httpc:set_timeouts(conf.connect_timeout, conf.send_timeout, conf.read_timeout)
+  local res, err = httpc:request_uri(conf.endpoint, {
+    method = "POST",
+    body = pb_data,
+    headers = headers,
+  })
+  if not res then
+    ngx_log(ngx_ERR, _log_prefix, "failed to send request: ", err)
+  end
+
+  if res and res.status ~= 200 then
+    ngx_log(ngx_ERR, _log_prefix, "response error: ", res.status, ", body: ", res.body)
+  end
+end
+
+local function http_export(premature, conf)
+  if premature then
+    return
+  end
+
+  local spans_n = #spans_queue
+  if spans_n == 0 then
+    return
+  end
+
+  local start = ngx_now()
+  local headers = conf.headers and get_cached_headers(conf.headers) or default_headers
+
+  -- batch send spans
+  local spans_buffer = tablepool_fetch(POOL_BATCH_SPANS, conf.batch_span_count, 0)
+
+  for i = 1, spans_n do
+    local len = (spans_buffer.n or 0) + 1
+    spans_buffer[len] = spans_queue[i]
+    spans_buffer.n = len
+
+    if len >= conf.batch_span_count then
+      local pb_data = encode_traces(spans_buffer, conf.resource_attributes)
+      clear(spans_buffer)
+
+      http_export_request(conf, pb_data, headers)
+    end
+  end
+
+  -- remain spans
+  if spans_queue.n and spans_queue.n > 0 then
+    local pb_data = encode_traces(spans_buffer, conf.resource_attributes)
+    http_export_request(conf, pb_data, headers)
+  end
+
+  -- clear the queue
+  clear(spans_queue)
+
+  tablepool_release(POOL_BATCH_SPANS, spans_buffer)
+
+  ngx_update_time()
+  local duration = ngx_now() - start
+  ngx_log(ngx_DEBUG, _log_prefix, "opentelemetry exporter sent " .. spans_n ..
+    " traces to " .. conf.endpoint .. " in " .. duration .. " seconds")
+end
+
+local function process_span(span)
+  if span.should_sample == false
+      or kong.ctx.plugin.should_sample == false
+  then
+    -- ignore
+    return
+  end
+
+  -- overwrite
+  local trace_id = kong.ctx.plugin.trace_id
+  if trace_id then
+    span.trace_id = trace_id
+  end
+
+  local pb_span = transform_span(span)
+
+  local len = spans_queue.n or 0
+  len = len + 1
+
+  spans_queue[len] = pb_span
+  spans_queue.n = len
+end
+
+function OpenTelemetryHandler:rewrite()
+  local headers = ngx_get_headers()
+  local root_span = ngx.ctx.KONG_SPANS and ngx.ctx.KONG_SPANS[1]
+
+  -- make propagation running with tracing instrumetation not enabled
+  if not root_span then
+    local tracer = kong.tracing.new("otel")
+    root_span = tracer.start_span("root")
+
+    -- the span created only for the propagation and will be bypassed to the exporter
+    kong.ctx.plugin.should_sample = false
+  end
+
+  local header_type, trace_id, span_id, _, should_sample, _ = propagation_parse(headers)
+  if should_sample == false then
+    root_span.should_sample = should_sample
+  end
+
+  -- overwrite trace id
+  if trace_id then
+    root_span.trace_id = trace_id
+    kong.ctx.plugin.trace_id = trace_id
+  end
+
+  -- overwrite root span's parent_id
+  if span_id then
+    root_span.parent_id = span_id
+  end
+
+  propagation_set("w3c", header_type, root_span)
+end
+
+function OpenTelemetryHandler:log(conf)
+  ngx_log(ngx_DEBUG, _log_prefix, "total spans in current request: ", ngx.ctx.KONG_SPANS and #ngx.ctx.KONG_SPANS)
+
+  -- transform spans
+  kong.tracing.process_span(process_span)
+
+  local cache_key = conf.__key__
+  local last = last_run_cache[cache_key] or 0
+  local now = ngx_now()
+  if now - last >= conf.batch_flush_delay then
+    last_run_cache[cache_key] = now
+    timer_at(0, http_export, conf)
+  end
+end
+
+return OpenTelemetryHandler

--- a/kong/plugins/opentelemetry/otlp.lua
+++ b/kong/plugins/opentelemetry/otlp.lua
@@ -1,0 +1,169 @@
+require "kong.plugins.opentelemetry.proto"
+local pb = require "pb"
+local new_tab = require "table.new"
+local nkeys = require "table.nkeys"
+local tablepool = require "tablepool"
+local utils = require "kong.tools.utils"
+
+local kong = kong
+local insert = table.insert
+local tablepool_fetch = tablepool.fetch
+local tablepool_release = tablepool.release
+local deep_copy = utils.deep_copy
+local table_merge = utils.table_merge
+
+local POOL_OTLP = "KONG_OTLP"
+local EMPTY_TAB = {}
+
+local PB_STATUS = {}
+for i = 0, 2 do
+  PB_STATUS[i] = { code = i }
+end
+
+local function transform_attributes(attr)
+  if type(attr) ~= "table" then
+    error("invalid attributes", 2)
+  end
+
+  local pb_attributes = new_tab(nkeys(attr), 0)
+  for k, v in pairs(attr) do
+    local typ = type(v)
+    local pb_val
+
+    if typ == "string" then
+      pb_val = { string_value = v }
+
+    elseif typ == "number" then
+      pb_val = { double_value = v }
+
+    elseif typ == "boolean" then
+      pb_val = { bool_value = v }
+
+    else
+      pb_val = EMPTY_TAB -- considered empty
+    end
+
+    insert(pb_attributes, {
+      key = k,
+      value = pb_val,
+    })
+  end
+
+  return pb_attributes
+end
+
+local function transform_events(events)
+  if type(events) ~= "table" then
+    return nil
+  end
+
+  local pb_events = new_tab(#events, 0)
+  for _, evt in ipairs(events) do
+    local pb_evt = {
+      name = evt.name,
+      time_unix_nano = evt.time_ns,
+      -- dropped_attributes_count = 0,
+    }
+
+    if evt.attributes then
+      pb_evt.attributes = transform_attributes(evt.attributes)
+    end
+
+    insert(pb_events, pb_evt)
+  end
+
+  return pb_events
+end
+
+local function transform_span(span)
+  assert(type(span) == "table")
+
+  local pb_span = {
+    trace_id = span.trace_id,
+    span_id = span.span_id,
+    -- trace_state = "",
+    parent_span_id = span.parent_id or "",
+    name = span.name,
+    kind = span.kind or 0,
+    start_time_unix_nano = span.start_time_ns,
+    end_time_unix_nano = span.end_time_ns,
+    attributes = span.attributes and transform_attributes(span.attributes),
+    -- dropped_attributes_count = 0,
+    events = span.events and transform_events(span.events),
+    -- dropped_events_count = 0,
+    -- links = EMPTY_TAB,
+    -- dropped_links_count = 0,
+    status = span.status and PB_STATUS[span.status],
+  }
+
+  return pb_span
+end
+
+local encode_traces
+do
+  local attributes_cache = setmetatable({}, { __mode = "k" })
+  local function default_resource_attributes()
+    return {
+      ["service.name"] = "kong",
+      ["service.instance.id"] = kong and kong.node.get_id(),
+      ["service.version"] = kong and kong.version,
+    }
+  end
+
+  local function render_resource_attributes(attributes)
+    attributes = attributes or EMPTY_TAB
+
+    local resource_attributes = attributes_cache[attributes]
+    if resource_attributes then
+      return resource_attributes
+    end
+
+    local default_attributes = default_resource_attributes()
+    resource_attributes = table_merge(default_attributes, attributes)
+
+    resource_attributes = transform_attributes(resource_attributes)
+    attributes_cache[attributes] = resource_attributes
+
+    return resource_attributes
+  end
+
+  local pb_memo = {
+    resource_spans = {
+      { resource = {
+          attributes = {}
+        },
+        scope_spans = {
+          { scope = {
+              name = "kong-internal",
+              version = "0.1.0",
+            },
+            spans = {}, },
+        }, },
+    },
+  }
+
+  encode_traces = function(spans, resource_attributes)
+    local tab = tablepool_fetch(POOL_OTLP, 0, 2)
+    if not tab.resource_spans then
+      tab.resource_spans = deep_copy(pb_memo.resource_spans)
+    end
+
+    local resource = tab.resource_spans[1].resource
+    resource.attributes = render_resource_attributes(resource_attributes)
+
+    local scoped = tab.resource_spans[1].scope_spans[1]
+    scoped.spans = spans
+    local pb_data = pb.encode("opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest", tab)
+
+    -- remove reference
+    scoped.spans = nil
+    tablepool_release(POOL_OTLP, tab, true) -- no clear
+
+    return pb_data
+  end
+end
+
+return {
+  transform_span = transform_span,
+  encode_traces = encode_traces,
+}

--- a/kong/plugins/opentelemetry/proto.lua
+++ b/kong/plugins/opentelemetry/proto.lua
@@ -1,0 +1,18 @@
+local grpc = require "kong.tools.grpc"
+local pl_path = require "pl.path"
+
+local abspath = pl_path.abspath
+local splitpath = pl_path.splitpath
+
+local proto_fpath = "kong/include/opentelemetry/proto/collector/trace/v1/trace_service.proto"
+
+local function load_proto()
+  local grpc_util = grpc.new()
+  local protoc_instance = grpc_util.protoc_instance
+
+  local dir = splitpath(abspath(proto_fpath))
+  protoc_instance:addpath(dir)
+  protoc_instance:loadfile(proto_fpath)
+end
+
+load_proto()

--- a/kong/plugins/opentelemetry/schema.lua
+++ b/kong/plugins/opentelemetry/schema.lua
@@ -1,0 +1,48 @@
+local typedefs = require "kong.db.schema.typedefs"
+local Schema = require "kong.db.schema"
+
+local function custom_validator(attributes)
+  for _, v in pairs(attributes) do
+    local vtype = type(v)
+    if vtype ~= "string" and
+       vtype ~= "number" and
+       vtype ~= "boolean"
+    then
+      return nil, "invalid type of value: " .. vtype
+    end
+
+    if vtype == "string" and #v == 0 then
+      return nil, "required field missing"
+    end
+  end
+
+  return true
+end
+
+local resource_attributes = Schema.define {
+  type = "map",
+  keys = { type = "string", required = true },
+  -- TODO: support [string, number, boolean]
+  values = { type = "string", required = true },
+  custom_validator = custom_validator,
+}
+
+return {
+  name = "opentelemetry",
+  fields = {
+    { protocols = typedefs.protocols_http }, -- TODO: support stream mode
+    { config = {
+      type = "record",
+      fields = {
+        { endpoint = typedefs.url { required = true } }, -- OTLP/HTTP
+        { headers = typedefs.headers },
+        { resource_attributes = resource_attributes },
+        { batch_span_count = { type = "integer", required = true, default = 200 } },
+        { batch_flush_delay = { type = "integer", required = true, default = 3 } },
+        { connect_timeout = typedefs.timeout { default = 1000 } },
+        { send_timeout = typedefs.timeout { default = 5000 } },
+        { read_timeout = typedefs.timeout { default = 5000 } },
+      },
+    }, },
+  },
+}

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -1447,7 +1447,7 @@ do
     C.clock_gettime(0, nanop)
     local t = nanop[0]
 
-    return tonumber(t.tv_sec) * 100000000 + tonumber(t.tv_nsec)
+    return tonumber(t.tv_sec) * 1e9 + tonumber(t.tv_nsec)
   end
 end
 _M.time_ns = time_ns

--- a/kong/tracing/instrumentation.lua
+++ b/kong/tracing/instrumentation.lua
@@ -67,37 +67,32 @@ function _M.balancer(ctx)
   local span
   local balancer_tries = balancer_data.tries
   local try_count = balancer_data.try_count
-  local upstream_connect_time
+  local upstream_connect_time = split(var.upstream_connect_time, ", ", "jo")
   for i = 1, try_count do
     local try = balancer_tries[i]
     span = tracer.start_span("balancer try #" .. i, {
       kind = 3, -- client
       start_time_ns = try.balancer_start * 1e6,
       attributes = {
-        ["kong.balancer.state"] = try.state,
-        ["http.status_code"] = try.code,
         ["net.peer.ip"] = try.ip,
         ["net.peer.port"] = try.port,
       }
     })
 
-    if i < try_count then
+    if try.state then
+      span:set_attribute("http.status_code", try.code)
       span:set_status(2)
     end
 
     -- last try
-    if i == try_count then
+    if i == try_count and try.state == nil then
       local upstream_finish_time = ctx.KONG_BODY_FILTER_ENDED_AT and ctx.KONG_BODY_FILTER_ENDED_AT * 1e6
       span:finish(upstream_finish_time)
 
     else
-      if not upstream_connect_time then
-        upstream_connect_time = split(var.upstream_connect_time, ",", "jo")
-      end
-
       -- retrying
       if try.balancer_latency ~= nil then
-        local try_upstream_connect_time = (upstream_connect_time[i] or 0) * 1000
+        local try_upstream_connect_time = (tonumber(upstream_connect_time[i]) or 0) * 1000
         span:finish((try.balancer_start + try.balancer_latency + try_upstream_connect_time) * 1e6)
       else
         span:finish()
@@ -149,6 +144,7 @@ function _M.http_client()
     end
 
     local span = tracer.start_span("HTTP " .. method .. " " .. uri, {
+      span_kind = 3,
       attributes = attributes,
     })
 
@@ -190,6 +186,7 @@ function _M.request(ctx)
       or time_ns()
 
   local active_span = tracer.start_span(span_name, {
+    span_kind = 2, -- server
     start_time_ns = start_time,
     attributes = {
       ["http.method"] = method,
@@ -200,6 +197,7 @@ function _M.request(ctx)
       ["net.peer.ip"] = client.get_ip(),
     },
   })
+
   tracer.set_active_span(active_span)
 end
 
@@ -220,6 +218,8 @@ do
     local span = tracer.start_span(name)
     local ip_addr, res_port, try_list = raw_func(host, port)
     if span then
+      span:set_attribute("dns.record.domain", host)
+      span:set_attribute("dns.record.port", port)
       span:set_attribute("dns.record.ip", ip_addr)
       span:finish()
     end
@@ -274,7 +274,7 @@ do
         insert(detail_logs, "\nSpan #" .. i .. " name=" .. span.name)
 
         if span.end_time_ns then
-          insert(detail_logs, " duration=" .. (span.end_time_ns - span.start_time_ns) / 100000 .. "ms")
+          insert(detail_logs, " duration=" .. (span.end_time_ns - span.start_time_ns) / 1e6 .. "ms")
         end
 
         if span.attributes then

--- a/kong/tracing/instrumentation.lua
+++ b/kong/tracing/instrumentation.lua
@@ -72,7 +72,7 @@ function _M.balancer(ctx)
     local try = balancer_tries[i]
     span = tracer.start_span("balancer try #" .. i, {
       kind = 3, -- client
-      start_time_ns = try.balancer_start * 100000,
+      start_time_ns = try.balancer_start * 1e6,
       attributes = {
         ["kong.balancer.state"] = try.state,
         ["http.status_code"] = try.code,
@@ -87,7 +87,7 @@ function _M.balancer(ctx)
 
     -- last try
     if i == try_count then
-      local upstream_finish_time = (ctx.KONG_BODY_FILTER_ENDED_AT or 0) * 100000
+      local upstream_finish_time = ctx.KONG_BODY_FILTER_ENDED_AT and ctx.KONG_BODY_FILTER_ENDED_AT * 1e6
       span:finish(upstream_finish_time)
 
     else
@@ -98,7 +98,7 @@ function _M.balancer(ctx)
       -- retrying
       if try.balancer_latency ~= nil then
         local try_upstream_connect_time = (upstream_connect_time[i] or 0) * 1000
-        span:finish((try.balancer_start + try.balancer_latency + try_upstream_connect_time) * 100000)
+        span:finish((try.balancer_start + try.balancer_latency + try_upstream_connect_time) * 1e6)
       else
         span:finish()
       end
@@ -186,7 +186,7 @@ function _M.request(ctx)
   local req_uri = ctx.request_uri or var.request_uri
 
   local start_time = ngx.ctx.KONG_PROCESSING_START
-      and ngx.ctx.KONG_PROCESSING_START * 100000
+      and ngx.ctx.KONG_PROCESSING_START * 1e6
       or time_ns()
 
   local active_span = tracer.start_span(span_name, {
@@ -259,7 +259,7 @@ function _M.runloop_log_before(ctx)
   -- check root span type to avoid encounter error
   if active_span and type(active_span.finish) == "function" then
     local end_time = ctx.KONG_BODY_FILTER_ENDED_AT
-                  and ctx.KONG_BODY_FILTER_ENDED_AT * 100000
+                  and ctx.KONG_BODY_FILTER_ENDED_AT * 1e6
     active_span:finish(end_time)
   end
 end

--- a/kong/tracing/propagation.lua
+++ b/kong/tracing/propagation.lua
@@ -447,11 +447,10 @@ local function set(conf_header_type, found_header_type, proxy_span, conf_default
   end
 
   if conf_header_type == "b3-single" or found_header_type == "b3-single" then
-    set_header("b3", fmt("%s-%s-%s-%s",
-        to_hex(proxy_span.trace_id),
-        to_hex(proxy_span.span_id),
-        proxy_span.should_sample and "1" or "0",
-      to_hex(proxy_span.parent_id)))
+    set_header("b3", to_hex(proxy_span.trace_id) ..
+        "-" .. to_hex(proxy_span.span_id) ..
+        "-" .. (proxy_span.should_sample and "1" or "0") ..
+        (proxy_span.parent_id and "-" .. to_hex(proxy_span.parent_id) or ""))
   end
 
   if conf_header_type == "w3c" or found_header_type == "w3c" then
@@ -465,7 +464,7 @@ local function set(conf_header_type, found_header_type, proxy_span, conf_default
     set_header("uber-trace-id", fmt("%s:%s:%s:%s",
         to_hex(proxy_span.trace_id),
         to_hex(proxy_span.span_id),
-        to_hex(proxy_span.parent_id),
+        proxy_span.parent_id and to_hex(proxy_span.parent_id) or "0",
       proxy_span.should_sample and "01" or "00"))
   end
 

--- a/spec/01-unit/12-plugins_order_spec.lua
+++ b/spec/01-unit/12-plugins_order_spec.lua
@@ -75,6 +75,7 @@ describe("Plugins", function()
       "aws-lambda",
       "azure-functions",
       "proxy-cache",
+      "opentelemetry",
       "prometheus",
       "http-log",
       "statsd",

--- a/spec/03-plugins/37-opentelemetry/01-otlp_spec.lua
+++ b/spec/03-plugins/37-opentelemetry/01-otlp_spec.lua
@@ -1,0 +1,120 @@
+require "spec.helpers"
+require "kong.plugins.opentelemetry.proto"
+local otlp = require "kong.plugins.opentelemetry.otlp"
+local utils = require "kong.tools.utils"
+local pb = require "pb"
+
+local fmt = string.format
+local rand_bytes = utils.get_rand_bytes
+local time_ns = utils.time_ns
+local insert = table.insert
+local tracer = kong.tracing.new("test")
+
+local function table_compare(expected, passed)
+  if type(expected) ~= type(passed) then
+    return false, fmt("expected: %s, got: %s", type(expected), type(passed))
+  end
+
+  for k, v in pairs(expected) do
+    local v_typ = type(v)
+    if v_typ == "nil"
+      or v_typ == "number"
+      or v_typ == "string"
+      or v_typ == "boolean"
+    then
+      if v ~= passed[k] then
+        return false, fmt("%s field, expected: %s, got: %s", k, v, passed[k])
+      end
+
+    elseif v_typ == "table" and #v > 0 then
+      local ok, err = table_compare(v, passed[k])
+      return ok, fmt("%s field, %s", k, err)
+    end
+  end
+
+  return true
+end
+
+local pb_encode_span = function(data)
+  return pb.encode("opentelemetry.proto.trace.v1.Span", data)
+end
+
+local pb_decode_span = function(data)
+  return pb.decode("opentelemetry.proto.trace.v1.Span", data)
+end
+
+describe("Plugin: opentelemetry (otlp)", function()
+  lazy_setup(function ()
+    -- overwrite for testing
+    pb.option("enum_as_value")
+  end)
+
+  lazy_teardown(function()
+    -- revert it back
+    pb.option("enum_as_name")
+  end)
+
+  after_each(function ()
+    ngx.ctx.KONG_SPANS = nil
+  end)
+
+  it("encode/decode pb", function ()
+    local N = 10000
+
+    local test_spans = {
+      -- default one
+      {
+        name = "full-span",
+        trace_id = rand_bytes(16),
+        span_id = rand_bytes(8),
+        parent_id = rand_bytes(8),
+        start_time_ns = time_ns(),
+        end_time_ns = time_ns() + 1000,
+        should_sample = true,
+        attributes = {
+          foo = "bar",
+          test = true,
+          version = 0.1,
+        },
+        events = {
+          {
+            name = "evt1",
+            time_ns = time_ns(),
+            attributes = {
+              debug = true,
+            }
+          }
+        },
+      },
+    }
+
+    for i = 1, N do
+      local span = tracer.start_span(tostring(i), {
+        span_kind = i % 6,
+        attributes = {
+          str = fmt("tag-%s", i),
+          int = i,
+          bool = (i % 2 == 0 and true) or false,
+          double = i / (N * 1000),
+        },
+      })
+
+      span:set_status(i % 3)
+      span:add_event(tostring(i), span.attributes)
+      span:finish()
+
+      insert(test_spans, table.clone(span))
+      span:release()
+    end
+
+    for _, test_span in ipairs(test_spans) do
+      local pb_span = otlp.transform_span(test_span)
+      local pb_data = pb_encode_span(pb_span)
+      local decoded_span = pb_decode_span(pb_data)
+
+      local ok, err = table_compare(pb_span, decoded_span)
+      assert.is_true(ok, err)
+    end
+  end)
+
+end)

--- a/spec/03-plugins/37-opentelemetry/02-schema_spec.lua
+++ b/spec/03-plugins/37-opentelemetry/02-schema_spec.lua
@@ -1,0 +1,36 @@
+local schema_def = require "kong.plugins.opentelemetry.schema"
+local validate_plugin_config_schema = require "spec.helpers".validate_plugin_config_schema
+
+describe("Plugin: OpenTelemetry (schema)", function()
+  it("rejects invalid attribute keys", function()
+    local ok, err = validate_plugin_config_schema({
+      endpoint = "http://example.dev",
+      resource_attributes = {
+        [123] = "",
+      },
+    }, schema_def)
+
+    assert.is_falsy(ok)
+    assert.same({
+      config = {
+        resource_attributes = "expected a string"
+      }
+    }, err)
+  end)
+
+  it("rejects invalid attribute values", function()
+    local ok, err = validate_plugin_config_schema({
+      endpoint = "http://example.dev",
+      resource_attributes = {
+        foo = "",
+      },
+    }, schema_def)
+
+    assert.is_falsy(ok)
+    assert.same({
+      config = {
+        resource_attributes = "length must be at least 1"
+      }
+    }, err)
+  end)
+end)

--- a/spec/03-plugins/37-opentelemetry/03-propagation_spec.lua
+++ b/spec/03-plugins/37-opentelemetry/03-propagation_spec.lua
@@ -1,0 +1,155 @@
+local helpers = require "spec.helpers"
+local cjson = require "cjson"
+local utils = require "kong.tools.utils"
+local to_hex = require "resty.string".to_hex
+
+local fmt = string.format
+
+
+local function gen_trace_id()
+  return to_hex(utils.get_rand_bytes(16))
+end
+
+
+local function gen_span_id()
+  return to_hex(utils.get_rand_bytes(8))
+end
+
+
+for _, strategy in helpers.each_strategy() do
+describe("propagation tests #" .. strategy, function()
+  local service
+  local proxy_client
+
+  lazy_setup(function()
+    local bp = helpers.get_db_utils(strategy, { "services", "routes", "plugins" })
+
+    -- enable opentelemetry plugin globally pointing to mock server
+    bp.plugins:insert({
+      name = "opentelemetry",
+      config = {
+        -- fake endpoint, request to backend will sliently fail
+        endpoint = "http://localhost:8080/v1/traces",
+      }
+    })
+
+    service = bp.services:insert()
+
+    -- kong (http) mock upstream
+    bp.routes:insert({
+      service = service,
+      hosts = { "http-route" },
+    })
+
+    helpers.start_kong({
+      database = strategy,
+      nginx_conf = "spec/fixtures/custom_nginx.template",
+    })
+
+    proxy_client = helpers.proxy_client()
+  end)
+
+  teardown(function()
+    helpers.stop_kong()
+  end)
+
+  it("propagates tracing headers (b3 request)", function()
+    local trace_id = gen_trace_id()
+    local r = proxy_client:get("/", {
+      headers = {
+        ["x-b3-sampled"] = "1",
+        ["x-b3-traceid"] = trace_id,
+        host  = "http-route",
+      },
+    })
+    local body = assert.response(r).has.status(200)
+    local json = cjson.decode(body)
+    assert.equals(trace_id, json.headers["x-b3-traceid"])
+    assert.matches("00%-" .. trace_id .. "%-%x+-01", json.headers.traceparent)
+  end)
+
+  describe("propagates tracing headers (b3-single request)", function()
+    it("with parent_id", function()
+      local trace_id = gen_trace_id()
+      local span_id = gen_span_id()
+      local parent_id = gen_span_id()
+
+      local r = proxy_client:get("/", {
+        headers = {
+          b3 = fmt("%s-%s-%s-%s", trace_id, span_id, "1", parent_id),
+          host = "http-route",
+        },
+      })
+      local body = assert.response(r).has.status(200)
+      local json = cjson.decode(body)
+      assert.matches(trace_id .. "%-%x+%-1%-%x+", json.headers.b3)
+      assert.matches("00%-" .. trace_id .. "%-%x+-01", json.headers.traceparent)
+    end)
+
+    it("without parent_id", function()
+      local trace_id = gen_trace_id()
+      local span_id = gen_span_id()
+
+      local r = proxy_client:get("/", {
+        headers = {
+          b3 = fmt("%s-%s-1", trace_id, span_id),
+          host = "http-route",
+        },
+      })
+      local body = assert.response(r).has.status(200)
+      local json = cjson.decode(body)
+      assert.matches(trace_id .. "%-%x+%-1", json.headers.b3)
+      assert.matches("00%-" .. trace_id .. "%-%x+-01", json.headers.traceparent)
+    end)
+  end)
+
+  it("propagates w3c tracing headers", function()
+    local trace_id = gen_trace_id() -- w3c only admits 16-byte trace_ids
+    local parent_id = gen_span_id()
+
+    local r = proxy_client:get("/", {
+      headers = {
+        traceparent = fmt("00-%s-%s-01", trace_id, parent_id),
+        host = "http-route"
+      },
+    })
+    local body = assert.response(r).has.status(200)
+    local json = cjson.decode(body)
+    assert.matches("00%-" .. trace_id .. "%-%x+-01", json.headers.traceparent)
+  end)
+
+  it("propagates jaeger tracing headers", function()
+    local trace_id = gen_trace_id()
+    local span_id = gen_span_id()
+    local parent_id = gen_span_id()
+
+    local r = proxy_client:get("/", {
+      headers = {
+        ["uber-trace-id"] = fmt("%s:%s:%s:%s", trace_id, span_id, parent_id, "1"),
+        host = "http-route"
+      },
+    })
+    local body = assert.response(r).has.status(200)
+    local json = cjson.decode(body)
+    -- Trace ID is left padded with 0 for assert
+    assert.matches( ('0'):rep(32-#trace_id) .. trace_id .. ":%x+:" .. span_id .. ":01", json.headers["uber-trace-id"])
+  end)
+
+  it("propagates ot headers", function()
+    local trace_id = gen_trace_id()
+    local span_id = gen_span_id()
+    local r = proxy_client:get("/", {
+      headers = {
+        ["ot-tracer-traceid"] = trace_id,
+        ["ot-tracer-spanid"] = span_id,
+        ["ot-tracer-sampled"] = "1",
+        host = "http-route",
+      },
+    })
+    local body = assert.response(r).has.status(200)
+    local json = cjson.decode(body)
+
+    assert.equals(trace_id, json.headers["ot-tracer-traceid"])
+  end)
+end)
+end

--- a/spec/03-plugins/37-opentelemetry/04-exporter_spec.lua
+++ b/spec/03-plugins/37-opentelemetry/04-exporter_spec.lua
@@ -1,0 +1,166 @@
+require "kong.plugins.opentelemetry.proto"
+local helpers = require "spec.helpers"
+local utils = require "kong.tools.utils"
+local tablex = require "pl.tablex"
+local pb = require "pb"
+
+local table_merge = utils.table_merge
+local HTTP_PORT = 35000
+
+for _, strategy in helpers.each_strategy() do
+  describe("opentelemetry exporter #" .. strategy, function()
+    local proxy_client
+
+    lazy_setup(function ()
+      -- overwrite for testing
+      pb.option("enum_as_value")
+    end)
+
+    lazy_teardown(function()
+      -- revert it back
+      pb.option("enum_as_name")
+    end)
+
+    -- helpers
+    local function setup_instrumentations(types, config)
+      local bp, _ = assert(helpers.get_db_utils(strategy, {
+        "services",
+        "routes",
+        "plugins",
+      }, { "opentelemetry" }))
+
+      local http_srv = assert(bp.services:insert {
+        name = "mock-service",
+        host = helpers.mock_upstream_host,
+        port = helpers.mock_upstream_port,
+      })
+
+      bp.routes:insert({ service = http_srv,
+                         protocols = { "http" },
+                         paths = { "/" }})
+
+      bp.plugins:insert({
+        name = "opentelemetry",
+        config = table_merge({
+          endpoint = "http://127.0.0.1:" .. HTTP_PORT,
+          batch_flush_delay = -1, -- report immediately
+        }, config)
+      })
+
+      assert(helpers.start_kong {
+        database = strategy,
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+        plugins = "opentelemetry",
+        opentelemetry_tracing = types,
+      })
+
+      proxy_client = helpers.proxy_client(1000)
+    end
+
+    describe("valid #http request", function ()
+      lazy_setup(function()
+        setup_instrumentations("all", {
+          headers = {
+            ["X-Access-Token"] = {"token"},
+          },
+        })
+      end)
+
+      lazy_teardown(function()
+        helpers.kill_http_server(HTTP_PORT)
+        helpers.stop_kong()
+      end)
+
+      it("works", function ()
+        local thread = helpers.http_server(HTTP_PORT)
+        local r = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/",
+        })
+        assert.res_status(200, r)
+
+        local ok, headers, body = thread:join()
+        assert.is_true(ok)
+        assert.is_string(body)
+
+        local idx = tablex.find(headers, "Content-Type: application/x-protobuf")
+        assert.not_nil(idx, headers)
+
+        -- custom http headers
+        idx = tablex.find(headers, "X-Access-Token: token")
+        assert.not_nil(idx, headers)
+
+        local decoded = assert(pb.decode("opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest", body))
+        assert.not_nil(decoded)
+
+        -- array is unstable
+        local res_attr = decoded.resource_spans[1].resource.attributes
+        table.sort(res_attr, function(a, b)
+          return a.key < b.key
+        end)
+        -- default resource attributes
+        assert.same("service.instance.id", res_attr[1].key)
+        assert.same("service.name", res_attr[2].key)
+        assert.same({string_value = "kong"}, res_attr[2].value)
+        assert.same("service.version", res_attr[3].key)
+        assert.same({string_value = kong.version}, res_attr[3].value)
+
+        local scope_spans = decoded.resource_spans[1].scope_spans
+        assert.is_true(#scope_spans > 0, scope_spans)
+      end)
+    end)
+
+    describe("overwrite resource attributes #http", function ()
+      lazy_setup(function()
+        setup_instrumentations("all", {
+          resource_attributes = {
+            ["service.name"] = "kong_oss",
+            ["os.version"] = "debian",
+          }
+        })
+      end)
+
+      lazy_teardown(function()
+        helpers.kill_http_server(HTTP_PORT)
+        helpers.stop_kong()
+      end)
+
+      it("works", function ()
+        local thread = helpers.http_server(HTTP_PORT)
+        local r = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/",
+        })
+        assert.res_status(200, r)
+
+        local ok, headers, body = thread:join()
+        assert.is_true(ok)
+        assert.is_string(body)
+
+        local idx = tablex.find(headers, "Content-Type: application/x-protobuf")
+        assert.not_nil(idx, headers)
+
+        local decoded = assert(pb.decode("opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest", body))
+        assert.not_nil(decoded)
+
+        -- array is unstable
+        local res_attr = decoded.resource_spans[1].resource.attributes
+        table.sort(res_attr, function(a, b)
+          return a.key < b.key
+        end)
+        -- resource attributes
+        assert.same("os.version", res_attr[1].key)
+        assert.same({string_value = "debian"}, res_attr[1].value)
+        assert.same("service.instance.id", res_attr[2].key)
+        assert.same("service.name", res_attr[3].key)
+        assert.same({string_value = "kong_oss"}, res_attr[3].value)
+        assert.same("service.version", res_attr[4].key)
+        assert.same({string_value = kong.version}, res_attr[4].value)
+
+        local scope_spans = decoded.resource_spans[1].scope_spans
+        assert.is_true(#scope_spans > 0, scope_spans)
+      end)
+    end)
+
+  end)
+end

--- a/spec/03-plugins/37-opentelemetry/05-otelcol_spec.lua
+++ b/spec/03-plugins/37-opentelemetry/05-otelcol_spec.lua
@@ -1,0 +1,90 @@
+require "kong.plugins.opentelemetry.proto"
+local helpers = require "spec.helpers"
+local utils = require "kong.tools.utils"
+local ngx_re = require "ngx.re"
+local http = require "resty.http"
+
+
+local fmt = string.format
+local table_merge = utils.table_merge
+local split = ngx_re.split
+
+local OTELCOL_HOST = helpers.otelcol_host
+local OTELCOL_HTTP_PORT = helpers.otelcol_http_port
+local OTELCOL_FILE_EXPORTER_PATH = helpers.otelcol_file_exporter_path
+
+for _, strategy in helpers.each_strategy() do
+  local proxy_url
+
+  describe("otelcol #" .. strategy, function()
+    -- helpers
+    local function setup_instrumentations(types, config)
+      local bp, _ = assert(helpers.get_db_utils(strategy, {
+        "services",
+        "routes",
+        "plugins",
+      }, { "opentelemetry" }))
+
+      local http_srv = assert(bp.services:insert {
+        name = "mock-service",
+        host = helpers.mock_upstream_host,
+        port = helpers.mock_upstream_port,
+      })
+
+      bp.routes:insert({ service = http_srv,
+                         protocols = { "http" },
+                         paths = { "/" }})
+
+      bp.plugins:insert({
+        name = "opentelemetry",
+        config = table_merge({
+          endpoint = fmt("http://%s:%s/v1/traces", OTELCOL_HOST, OTELCOL_HTTP_PORT),
+          batch_flush_delay = -1, -- report immediately
+        }, config)
+      })
+
+      assert(helpers.start_kong {
+        database = strategy,
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+        plugins = "opentelemetry",
+        opentelemetry_tracing = types,
+      })
+
+      proxy_url = fmt("http://%s:%s", helpers.get_proxy_ip(), helpers.get_proxy_port())
+    end
+
+    describe("otelcol receives traces #http", function()
+      local LIMIT = 100
+
+      lazy_setup(function()
+        -- clear file
+        os.execute("cat /dev/null > " .. OTELCOL_FILE_EXPORTER_PATH)
+        setup_instrumentations("all")
+      end)
+
+      lazy_teardown(function()
+        helpers.stop_kong()
+      end)
+
+      it("send traces", function()
+        local httpc = http.new()
+        for i = 1, LIMIT do
+          local res, err = httpc:request_uri(proxy_url)
+          assert.is_nil(err)
+          assert.same(200, res.status)
+        end
+      end)
+
+      it("valid traces", function()
+        ngx.sleep(3)
+        local f = assert(io.open(OTELCOL_FILE_EXPORTER_PATH, "rb"))
+        local raw_content = f:read("*all")
+        f:close()
+
+        local parts = split(raw_content, "\n", "jo")
+        assert.is_true(#parts > 0)
+      end)
+    end)
+
+  end)
+end

--- a/spec/fixtures/opentelemetry/otelcol.yaml
+++ b/spec/fixtures/opentelemetry/otelcol.yaml
@@ -1,0 +1,28 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+processors:
+  batch:
+
+exporters:
+  logging:
+    loglevel: debug
+  file:
+    path: /etc/otel/file_exporter.json
+
+extensions:
+  health_check:
+  pprof:
+  zpages:
+    endpoint: "0.0.0.0:55679"
+
+service:
+  extensions: [pprof, zpages, health_check]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logging, file]

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -26,6 +26,10 @@ local GRPCBIN_SSL_PORT = tonumber(os.getenv("KONG_SPEC_TEST_GRPCBIN_SSL_PORT")) 
 local MOCK_GRPC_UPSTREAM_PROTO_PATH = "./spec/fixtures/grpc/hello.proto"
 local ZIPKIN_HOST = os.getenv("KONG_SPEC_TEST_ZIPKIN_HOST") or "localhost"
 local ZIPKIN_PORT = tonumber(os.getenv("KONG_SPEC_TEST_ZIPKIN_PORT")) or 9411
+local OTELCOL_HOST = os.getenv("KONG_SPEC_TEST_OTELCOL_HOST") or "localhost"
+local OTELCOL_HTTP_PORT = tonumber(os.getenv("KONG_SPEC_TEST_OTELCOL_HTTP_PORT")) or 4318
+local OTELCOL_ZPAGES_PORT = tonumber(os.getenv("KONG_SPEC_TEST_OTELCOL_ZPAGES_PORT")) or 55679
+local OTELCOL_FILE_EXPORTER_PATH = os.getenv("KONG_SPEC_TEST_OTELCOL_FILE_EXPORTER_PATH") or "./tmp/otel/file_exporter.json"
 local REDIS_HOST = os.getenv("KONG_SPEC_TEST_REDIS_HOST") or "localhost"
 local REDIS_PORT = tonumber(os.getenv("KONG_SPEC_TEST_REDIS_PORT") or 6379)
 local REDIS_SSL_PORT = tonumber(os.getenv("KONG_SPEC_TEST_REDIS_SSL_PORT") or 6380)
@@ -2934,6 +2938,10 @@ end
 -- @field redis_ssl_sni The server name for Redis, it can be set by env KONG_SPEC_TEST_REDIS_SSL_SNI.
 -- @field zipkin_host The host for Zipkin service, it can be set by env KONG_SPEC_TEST_ZIPKIN_HOST.
 -- @field zipkin_port the port for Zipkin service, it can be set by env KONG_SPEC_TEST_ZIPKIN_PORT.
+-- @field otelcol_host The host for OpenTelemetry Collector service, it can be set by env KONG_SPEC_TEST_OTELCOL_HOST.
+-- @field otelcol_http_port the port for OpenTelemetry Collector service, it can be set by env KONG_SPEC_TEST_OTELCOL_HTTP_PORT.
+-- @field otelcol_zpages_port the port for OpenTelemetry Collector Zpages service, it can be set by env KONG_SPEC_TEST_OTELCOL_ZPAGES_PORT.
+-- @field otelcol_file_exporter_path the path of for OpenTelemetry Collector's file exporter, it can be set by env KONG_SPEC_TEST_OTELCOL_FILE_EXPORTER_PATH.
 
 ----------
 -- Exposed
@@ -2977,6 +2985,11 @@ end
 
   zipkin_host = ZIPKIN_HOST,
   zipkin_port = ZIPKIN_PORT,
+
+  otelcol_host               = OTELCOL_HOST,
+  otelcol_http_port          = OTELCOL_HTTP_PORT,
+  otelcol_zpages_port        = OTELCOL_ZPAGES_PORT,
+  otelcol_file_exporter_path = OTELCOL_FILE_EXPORTER_PATH,
 
   grpcbin_host     = GRPCBIN_HOST,
   grpcbin_port     = GRPCBIN_PORT,


### PR DESCRIPTION
### Summary

Add the OpenTelemetry plugin which pushes the build-in instrumentation to the backend server through the [OTLP/HTTP](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md#otlphttp) protocol with Protobuf content type.

_Note: merge using rebase strategy._

FT-2588