### PR TITLE
chore(deps) bump lua-protobuf from 0.3.3 to 0.3.4

### DIFF
--- a/kong-2.8.0-0.rockspec
+++ b/kong-2.8.0-0.rockspec
@@ -31,7 +31,7 @@ dependencies = {
   "lua_pack == 2.0.0",
   "binaryheap >= 0.4",
   "luaxxhash >= 1.0",
-  "lua-protobuf == 0.3.3",
+  "lua-protobuf == 0.3.4",
   "lua-resty-worker-events == 1.0.0",
   "lua-resty-healthcheck == 1.5.1",
   "lua-resty-mlcache == 2.5.0",


### PR DESCRIPTION
### Changelog

https://github.com/starwing/lua-protobuf/releases/tag/0.3.4

- fix memory leak in pb.load
- fix bugs in "protoc.lua"
- fix memory usage in messages contains oneof
- code improved

Required by https://github.com/Kong/kong/pull/8826