### PR TITLE
fix(dao) check_upsert func return value on invalid options

### DIFF
--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -568,7 +568,7 @@ local function check_upsert(self, key, entity, options, name)
     local ok, errors = validate_options_value(self, options)
     if not ok then
       local err_t = self.errors:invalid_options(errors)
-      return nil, tostring(err_t), err_t
+      return nil, nil, tostring(err_t), err_t
     end
     transform = options.transform
   end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you follow them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Hi, this PR aims to fix the bug that will cause an unexpected 404 error on creating/updating configs with invalid options.

A simple way to reproduce:

1.  Store the example config and sync the config using decK, as you can see the TTL of the consumer key is an invalid value which will not pass the [`validate_options_value` func
](https://github.com/Kong/kong/blob/fcb7275fe30ab7f4f7510cdc3ab6e90a783a868e/kong/db/dao/init.lua#L205)

```
_format_version: "1.1"
consumers:
- keyauth_credentials:
  - key: test
    ttl: 100000001
  username: test@gmail.com
services:
- connect_timeout: 60000
  host: httpbin.org
  name: test1
  path: /anything
  plugins:
  - config:
      anonymous: null
      hide_credentials: false
      key_in_body: false
      key_in_header: true
      key_in_query: true
      key_names:
      - apikey
      run_on_preflight: true
    enabled: true
    name: key-auth
    protocols:
    - grpc
    - grpcs
    - http
    - https
  port: 80
  protocol: http
  read_timeout: 60000
  retries: 5
  routes:
  - https_redirect_status_code: 426
    name: test1
    path_handling: v0
    paths:
    - /auth
    preserve_host: true
    protocols:
    - https
    regex_priority: 100
    request_buffering: true
    response_buffering: true
    strip_path: false
  write_timeout: 60000
```

```
# Syncing using decK
$ deck sync --kong-addr http://localhost:8001 -s kong.yaml
creating consumer test@gmail.com
creating service test1
creating key-auth test for consumer test@gmail.com
Summary:
  Created: 2
  Updated: 0
  Deleted: 0
Error: 1 errors occurred:
        while processing event: {Create} key-auth test for consumer test@gmail.com failed: HTTP status 404 (message: "Not found")
```

As it is shown in the error log, the message is very confusing.

The reason for this weird behaviour is that the `check_upsert` function is returning a wrong list of values, it should be 4 values(starting with 2 nils), but now it returns 3 values
https://github.com/Kong/kong/blob/fcb7275fe30ab7f4f7510cdc3ab6e90a783a868e/kong/db/dao/init.lua#L571

And then it makes `err_t` a nil value
https://github.com/Kong/kong/blob/fcb7275fe30ab7f4f7510cdc3ab6e90a783a868e/kong/db/dao/init.lua#L1201-L1207

Which leads to the wrong 404 logic(because err_t is nil)
https://github.com/Kong/kong/blob/fcb7275fe30ab7f4f7510cdc3ab6e90a783a868e/kong/api/endpoints.lua#L488-L495


After the fix, the error becomes meaningful

```
updating key-auth test for consumer test@gmail.com  {
   "consumer": {
-    "id": "9310d28f-547a-4f25-9ea5-2eda79f1cda8",
+    "id": "92381706-1c6e-405d-91f1-57379722dedf",
-    "username": "Tom"
+    "username": "test@gmail.com"
   },
   "id": "e711b13b-0f2c-4804-b68e-79be8a20c114",
   "key": "test",
-  "ttl": 993849
+  "ttl": 1.00000001e+08
 }

Summary:
  Created: 0
  Updated: 0
  Deleted: 0
Error: 1 errors occurred:
        while processing event: {Update} key-auth test for consumer test@gmail.com failed: HTTP status 400 (message: "invalid option (ttl: must be an integer between 0 and 100000000)")
```

### Full changelog

* fix check upsert func return value on invalid options

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix FTI-4021
