### PR TITLE
Validate plugin PRIORITY and VERSION fields upon loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,9 @@
   [#8698](https://github.com/Kong/kong/pull/8698)
 - The PDK is no longer versioned
   [#8585](https://github.com/Kong/kong/pull/8585)
+- Plugins MUST now have a valid `PRIORITY` (integer) and `VERSION` ("x.y.z" format)
+  field in their `handler.lua` file, otherwise the plugin will fail to load.
+  [#8836](https://github.com/Kong/kong/pull/8836)
 
 #### Plugins
 
@@ -137,6 +140,8 @@
 - **AWS Lambda**: `aws_region` field must be set through either plugin config or environment variables,
   allow both `host` and `aws_region` fields, and always apply SigV4 signature.
   [#8082](https://github.com/Kong/kong/pull/8082)
+- The pre-functions plugin changed priority from `+inf` to `1000000`.
+  [#8836](https://github.com/Kong/kong/pull/8836)
 
 ### Deprecations
 

--- a/kong/api/routes/kong.lua
+++ b/kong/api/routes/kong.lua
@@ -91,15 +91,9 @@ return {
 
       local available_plugins = {}
       for name in pairs(kong.configuration.loaded_plugins) do
-        local pr = kong.db.plugins.handlers[name].PRIORITY
-        if pr ~= nil then
-          if type(pr) ~= "number" or math.abs(pr) == math.huge then
-            pr = tostring(pr)
-          end
-        end
         available_plugins[name] = {
           version = kong.db.plugins.handlers[name].VERSION,
-          priority = pr,
+          priority = kong.db.plugins.handlers[name].PRIORITY,
         }
       end
 

--- a/kong/plugins/pre-function/handler.lua
+++ b/kong/plugins/pre-function/handler.lua
@@ -1,1 +1,1 @@
-return require("kong.plugins.pre-function._handler")(math.huge)
+return require("kong.plugins.pre-function._handler")(1000000)

--- a/spec/02-integration/03-db/03-plugins_spec.lua
+++ b/spec/02-integration/03-db/03-plugins_spec.lua
@@ -193,8 +193,8 @@ for _, strategy in helpers.each_strategy() do
         local ok, err = db.plugins:load_plugin_schemas({
           ["plugin-with-custom-dao"] = true,
         })
-        assert.truthy(ok)
         assert.is_nil(err)
+        assert.truthy(ok)
 
         assert.same("I was implemented for " .. strategy, db.custom_dao:custom_method())
       end)
@@ -206,6 +206,101 @@ for _, strategy in helpers.each_strategy() do
         assert.falsy(ok)
         assert.match("missing plugin is enabled but not installed", err, 1, true)
       end)
+
+      describe("with bad PRIORITY fails; ", function()
+        setup(function()
+          local schema = {}
+          package.loaded["kong.plugins.NaN_priority.schema"] = schema
+          package.loaded["kong.plugins.NaN_priority.handler"] = { PRIORITY = 0/0, VERSION = "1.0" }
+          package.loaded["kong.plugins.huge_negative.schema"] = schema
+          package.loaded["kong.plugins.huge_negative.handler"] = { PRIORITY = -math.huge, VERSION = "1.0" }
+          package.loaded["kong.plugins.string_priority.schema"] = schema
+          package.loaded["kong.plugins.string_priority.handler"] = { PRIORITY = "abc", VERSION = "1.0" }
+        end)
+
+        teardown(function()
+          package.loaded["kong.plugins.NaN_priority.schema"] = nil
+          package.loaded["kong.plugins.NaN_priority.handler"] = nil
+          package.loaded["kong.plugins.huge_negative.schema"] = nil
+          package.loaded["kong.plugins.huge_negative.handler"] = nil
+          package.loaded["kong.plugins.string_priority.schema"] = nil
+          package.loaded["kong.plugins.string_priority.handler"] = nil
+        end)
+
+        it("NaN", function()
+          local ok, err = db.plugins:load_plugin_schemas({
+            ["NaN_priority"] = true,
+          })
+          assert.falsy(ok)
+          assert.match('Plugin "NaN_priority" cannot be loaded because its PRIORITY field is not a valid integer number, got: "nan"', err, 1, true)
+        end)
+
+        it("-math.huge", function()
+          local ok, err = db.plugins:load_plugin_schemas({
+            ["huge_negative"] = true,
+          })
+          assert.falsy(ok)
+          assert.match('Plugin "huge_negative" cannot be loaded because its PRIORITY field is not a valid integer number, got: "-inf"', err, 1, true)
+        end)
+
+        it("string", function()
+          local ok, err = db.plugins:load_plugin_schemas({
+            ["string_priority"] = true,
+          })
+          assert.falsy(ok)
+          assert.match('Plugin "string_priority" cannot be loaded because its PRIORITY field is not a valid integer number, got: "abc"', err, 1, true)
+        end)
+
+      end)
+
+      describe("with bad VERSION fails; ", function()
+        setup(function()
+          local schema = {}
+          package.loaded["kong.plugins.no_version.schema"] = schema
+          package.loaded["kong.plugins.no_version.handler"] = { PRIORITY = 1000, VERSION = nil }
+          package.loaded["kong.plugins.too_many.schema"] = schema
+          package.loaded["kong.plugins.too_many.handler"] = { PRIORITY = 1000, VERSION = "1.0.0.0" }
+          package.loaded["kong.plugins.number.schema"] = schema
+          package.loaded["kong.plugins.number.handler"] = { PRIORITY = 1000, VERSION = 123 }
+        end)
+
+        teardown(function()
+          package.loaded["kong.plugins.no_version.schema"] = nil
+          package.loaded["kong.plugins.no_version.handler"] = nil
+          package.loaded["kong.plugins.too_many.schema"] = nil
+          package.loaded["kong.plugins.too_many.handler"] = nil
+          package.loaded["kong.plugins.number.schema"] = nil
+          package.loaded["kong.plugins.number.handler"] = nil
+        end)
+
+        it("without version", function()
+          local ok, err = db.plugins:load_plugin_schemas({
+            ["no_version"] = true,
+          })
+          assert.falsy(ok)
+          assert.match('Plugin "no_version" cannot be loaded because its VERSION field does not follow the "x.y.z" format, got: "nil"', err, 1, true)
+        end)
+
+        it("too many components", function()
+          local ok, err = db.plugins:load_plugin_schemas({
+            ["too_many"] = true,
+          })
+          assert.falsy(ok)
+          assert.match('Plugin "too_many" cannot be loaded because its VERSION field does not follow the "x.y.z" format, got: "1.0.0.0"', err, 1, true)
+        end)
+
+        it("number", function()
+          local ok, err = db.plugins:load_plugin_schemas({
+            ["number"] = true,
+          })
+          assert.falsy(ok)
+          assert.match('Plugin "number" cannot be loaded because its VERSION field does not follow the "x.y.z" format, got: "123"', err, 1, true)
+        end)
+
+      end)
+
     end)
+
   end) -- kong.db [strategy]
+
 end

--- a/spec/fixtures/custom_plugins/kong/plugins/api-override/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/api-override/handler.lua
@@ -1,1 +1,4 @@
-return {}
+return {
+  PRIORITY = 1000,
+  VERSION = "1.0",
+}

--- a/spec/fixtures/custom_plugins/kong/plugins/ctx-tests-response/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/ctx-tests-response/handler.lua
@@ -191,7 +191,8 @@ end
 
 
 local CtxTests = {
-  PRIORITY = -math.huge
+  PRIORITY = -1000000,
+  VERSION = "1.0",
 }
 
 

--- a/spec/fixtures/custom_plugins/kong/plugins/ctx-tests/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/ctx-tests/handler.lua
@@ -199,7 +199,8 @@ end
 
 
 local CtxTests = {
-  PRIORITY = -math.huge
+  PRIORITY = -1000000,
+  VERSION = "1.0",
 }
 
 

--- a/spec/fixtures/custom_plugins/kong/plugins/enable-buffering-response/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/enable-buffering-response/handler.lua
@@ -3,7 +3,8 @@ local kong = kong
 
 
 local EnableBuffering = {
-  PRIORITY = math.huge
+  PRIORITY = 1000000,
+  VERSION = "1.0",
 }
 
 

--- a/spec/fixtures/custom_plugins/kong/plugins/enable-buffering/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/enable-buffering/handler.lua
@@ -3,7 +3,8 @@ local kong = kong
 
 
 local EnableBuffering = {
-  PRIORITY = math.huge
+  PRIORITY = 1000000,
+  VERSION = "1.0",
 }
 
 

--- a/spec/fixtures/custom_plugins/kong/plugins/error-generator-last/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/error-generator-last/handler.lua
@@ -4,8 +4,8 @@ local error = error
 local ErrorGeneratorLastHandler = {}
 
 
-ErrorGeneratorLastHandler.PRIORITY = -math.huge
-
+ErrorGeneratorLastHandler.PRIORITY = -1000000
+ErrorGeneratorLastHandler.VERSION = "1.0"
 
 function ErrorGeneratorLastHandler:init_worker()
 end

--- a/spec/fixtures/custom_plugins/kong/plugins/error-generator/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/error-generator/handler.lua
@@ -3,7 +3,7 @@ local error = error
 
 local ErrorGeneratorHandler =  {
   VERSION = "0.1-t",
-  PRIORITY = math.huge,
+  PRIORITY = 1000000,
 }
 
 
@@ -58,6 +58,7 @@ function ErrorGeneratorHandler:log(conf)
     error("[error-generator] body_filter")
   end
 end
+
 
 
 return ErrorGeneratorHandler

--- a/spec/fixtures/custom_plugins/kong/plugins/error-handler-log/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/error-handler-log/handler.lua
@@ -6,7 +6,7 @@ local ErrorHandlerLog = {}
 
 
 ErrorHandlerLog.PRIORITY = 1000
-
+ErrorHandlerLog.VERSION = "1.0"
 
 local function register(phase)
   local ws_id = ngx.ctx.workspace or kong.default_workspace

--- a/spec/fixtures/custom_plugins/kong/plugins/foreign-entity/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/foreign-entity/handler.lua
@@ -1,3 +1,4 @@
 return {
-  PRIORITY = 1
+  PRIORITY = 1,
+  VERSION = "1.0",
 }

--- a/spec/fixtures/custom_plugins/kong/plugins/init-worker-lua-error/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/init-worker-lua-error/handler.lua
@@ -2,6 +2,7 @@ local InitWorkerLuaError = {}
 
 
 InitWorkerLuaError.PRIORITY = 1000
+InitWorkerLuaError.VERSION = "1.0"
 
 
 function InitWorkerLuaError:init_worker(conf)

--- a/spec/fixtures/custom_plugins/kong/plugins/invalidations/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/invalidations/handler.lua
@@ -6,7 +6,8 @@ local counts = {}
 
 
 local Invalidations = {
-  PRIORITY = 0
+  PRIORITY = 0,
+  VERSION = "1.0",
 }
 
 

--- a/spec/fixtures/custom_plugins/kong/plugins/reports-api/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/reports-api/handler.lua
@@ -1,5 +1,6 @@
 local ReportsApiHandler = {
-  PRIORITY = 1000
+  PRIORITY = 1000,
+  VERSION = "1.0",
 }
 
 function ReportsApiHandler:preread()

--- a/spec/fixtures/custom_plugins/kong/plugins/short-circuit/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/short-circuit/handler.lua
@@ -11,7 +11,7 @@ local init_worker_called = false
 
 local ShortCircuitHandler =  {
   VERSION = "0.1-t",
-  PRIORITY = math.huge,
+  PRIORITY = 1000000,
 }
 
 
@@ -44,6 +44,5 @@ function ShortCircuitHandler:preread(conf)
   -- TODO: this should really support delayed short-circuiting!
   return exit(conf.status)
 end
-
 
 return ShortCircuitHandler

--- a/spec/fixtures/custom_plugins/kong/plugins/stream-api-echo/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/stream-api-echo/handler.lua
@@ -1,4 +1,5 @@
 
 return {
   PRIORITY = 1000,
+  VERSION = "1.0",
 }

--- a/spec/fixtures/custom_plugins/kong/plugins/tcp-trace-exporter/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/tcp-trace-exporter/handler.lua
@@ -10,6 +10,7 @@ local to_hex = str.to_hex
 
 local _M = {
   PRIORITY = 1001,
+  VERSION = "1.0",
 }
 
 local tracer_name = "tcp-trace-exporter"

--- a/spec/fixtures/custom_plugins/kong/plugins/transformations/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/transformations/handler.lua
@@ -1,3 +1,4 @@
 return {
-  PRIORITY = 1
+  PRIORITY = 1,
+  VERSION = "1.0",
 }

--- a/spec/fixtures/custom_plugins/kong/plugins/unique-foreign/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/unique-foreign/handler.lua
@@ -1,3 +1,4 @@
 return {
-  PRIORITY = 1
+  PRIORITY = 1,
+  VERSION = "1.0",
 }


### PR DESCRIPTION
Adds stricter checks on plugins when loading. Priority must be a valid integer (not `inf` nor `NaN`), and the version must be parseble as `x.y.z`.

This means the `pre-functions` plugin now has a `PRIORITY = 1000000`, which previously was `+inf`.

**review**: best reviewed without whitespace changes