### PR TITLE
perf(clustering) skip push_config if no clients connected

### DIFF
--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -249,6 +249,11 @@ end
 
 
 function _M:push_config()
+  if not next(self.clients) then
+    ngx_log(ngx_DEBUG, _log_prefix, "skip push_config as no data-planes connected")
+    return
+  end
+
   local start = ngx_now()
 
   local payload, err = self:export_deflated_reconfigure_payload()

--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -251,6 +251,9 @@ end
 function _M:push_config()
   if not next(self.clients) then
     ngx_log(ngx_DEBUG, _log_prefix, "skip push_config as no data-planes connected")
+    -- also clearthe payload cache, in case a newly connected client received an
+    -- old cache as its initial config
+    self.deflated_reconfigure_payload = nil
     return
   end
 

--- a/kong/clustering/wrpc_control_plane.lua
+++ b/kong/clustering/wrpc_control_plane.lua
@@ -190,6 +190,11 @@ function _M:push_config_one_client(client)
 end
 
 function _M:push_config()
+  if not next(self.clients) then
+    ngx_log(ngx_DEBUG, _log_prefix, "skip push_config as no data-planes connected")
+    return
+  end
+
   local payload, err = self:export_deflated_reconfigure_payload()
   if not payload then
     ngx_log(ngx_ERR, _log_prefix, "unable to export config from database: ", err)

--- a/kong/clustering/wrpc_control_plane.lua
+++ b/kong/clustering/wrpc_control_plane.lua
@@ -192,6 +192,9 @@ end
 function _M:push_config()
   if not next(self.clients) then
     ngx_log(ngx_DEBUG, _log_prefix, "skip push_config as no data-planes connected")
+    -- also clearthe payload cache, in case a newly connected client received an
+    -- old cache as its initial config
+    self.deflated_reconfigure_payload = nil
     return
   end
 


### PR DESCRIPTION


<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary
json protocol and wRPC protocol starts own timer to push config.
This PR reduces unnecessary overhead when no clients connected to either
of the protocol.

### Full changelog

* perf(clustering) skil push_config if no clients connected

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
