### PR TITLE
chore(deps) bump resty.cassandra from 1.5.1 to 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,8 @@
   [#8754](https://github.com/Kong/kong/pull/8754)
 - Bumped resty.healthcheck from 1.5.0 to 1.5.1
   [#8755](https://github.com/Kong/kong/pull/8755)
+- Bumped resty.cassandra from 1.5.1 to 1.5.2
+  [#8845](https://github.com/Kong/kong/pull/8845)
 
 ### Additions
 

--- a/kong-2.8.0-0.rockspec
+++ b/kong-2.8.0-0.rockspec
@@ -22,7 +22,7 @@ dependencies = {
   "multipart == 0.5.9",
   "version == 1.0.1",
   "kong-lapis == 1.8.3.1",
-  "lua-cassandra == 1.5.1",
+  "lua-cassandra == 1.5.2",
   "pgmoon == 1.14.0",
   "luatz == 0.4",
   "lua_system_constants == 0.1.4",


### PR DESCRIPTION
### Summary

> Released on: 2022/05/20

#### Fixed

- Improve DC-aware LB policies robustness. [#147](https://github.com/thibaultcha/lua-cassandra/pull/147)
- Ensure request-aware + DC-aware LB policy prioritizes local peers over remote ones.
