### PR TITLE
fix(cassandra) print a warn if a cassandra node is down during init

### DIFF
--- a/kong/db/strategies/cassandra/connector.lua
+++ b/kong/db/strategies/cassandra/connector.lua
@@ -244,22 +244,23 @@ function CassandraConnector:init()
   for i = 1, #peers do
     local release_version = peers[i].release_version
     if not release_version then
-      return nil, "no release_version for peer " .. peers[i].host
-    end
+      log.warn("no release_version for peer ", peers[i].host)
 
-    local major_minor, major = extract_major_minor(release_version)
-    major = tonumber(major)
-    if not major_minor or not major then
-      return nil, "failed to extract major version for peer " .. peers[i].host
-                  .. " with version: " .. tostring(peers[i].release_version)
-    end
+    else
+      local major_minor, major = extract_major_minor(release_version)
+      major = tonumber(major)
+      if not major_minor or not major then
+        return nil, "failed to extract major version for peer " .. peers[i].host
+                    .. " with version: " .. tostring(peers[i].release_version)
+      end
 
-    if i == 1 then
-      major_version = major
-      major_minor_version = major_minor
+      if not major_version then
+        major_version = major
+        major_minor_version = major_minor
 
-    elseif major ~= major_version then
-      return nil, "different major versions detected"
+      elseif major ~= major_version then
+        return nil, "different major versions detected"
+      end
     end
   end
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

During `kong start`, if a cassandra node is down, kong refuses to
start as there is not `release_version` available. Here is an example:

```yaml
{
  err = "connection refused",
  host = "127.0.0.2",
  reconn_delay = 1000,
  unhealthy_at = 1652273918689,
  up = false
}
```

### Full changelog

* Skip checking the `release_version` for an unknown node and print a
warning message instead.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[FTI-4018]_
