### PR TITLE
fix(wrpc) `remote_peer`(channel) does not work

### DIFF
--- a/kong/clustering/wrpc_data_plane.lua
+++ b/kong/clustering/wrpc_data_plane.lua
@@ -191,10 +191,6 @@ function _M:communicate(premature)
     while not exiting() and not config_exit do
       local ok, err = config_semaphore:wait(1)
       if ok then
-        if peer.semaphore == config_semaphore then
-          peer.semaphore = nil
-          config_semaphore = nil
-        end
         local config_table = self.next_config
         local config_hash  = self.next_hash
         local config_version = self.next_config_version

--- a/kong/include/wrpc/wrpc.proto
+++ b/kong/include/wrpc/wrpc.proto
@@ -36,6 +36,10 @@ enum ErrorType {
   ERROR_TYPE_UNSPECIFIED = 0;
   // GENERIC signals a general error with the protocol.
   ERROR_TYPE_GENERIC = 1;
+  // Unknown service
+  ERROR_TYPE_INVALID_SERVICE = 2;
+  // Unknown RPC
+  ERROR_TYPE_INVALID_RPC = 3;
 }
 
 // Error represents a protocol error.

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -26,7 +26,6 @@ lua_shared_dict kong_core_db_cache_miss     12m;
 lua_shared_dict kong_db_cache               ${{MEM_CACHE_SIZE}};
 lua_shared_dict kong_db_cache_miss          12m;
 > if role == "data_plane" then
-lua_shared_dict wrpc_channel_dict           5m;
 > end
 > if database == "cassandra" then
 lua_shared_dict kong_cassandra              5m;

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -25,8 +25,6 @@ lua_shared_dict kong_core_db_cache          ${{MEM_CACHE_SIZE}};
 lua_shared_dict kong_core_db_cache_miss     12m;
 lua_shared_dict kong_db_cache               ${{MEM_CACHE_SIZE}};
 lua_shared_dict kong_db_cache_miss          12m;
-> if role == "data_plane" then
-> end
 > if database == "cassandra" then
 lua_shared_dict kong_cassandra              5m;
 > end

--- a/kong/tools/wrpc.lua
+++ b/kong/tools/wrpc.lua
@@ -12,7 +12,6 @@ local table_remove = table.remove
 local exiting = ngx.worker.exiting
 
 local DEFAULT_EXPIRATION_DELAY = 90
-local CHANNEL_CLIENT_PREFIX = "wrpc_client_"
 
 pb.option("no_default_values")
 

--- a/kong/tools/wrpc.lua
+++ b/kong/tools/wrpc.lua
@@ -255,13 +255,17 @@ wrpc_peer.__index = wrpc_peer
 
 local channels = {}
 
+local function is_wsclient(conn)
+  return conn and not conn.close or nil
+end
+
 --- a `peer` object holds a (websocket) connection and a service.
 function wrpc.new_peer(conn, service, opts)
   local ret = setmetatable({
     conn = conn,
     service = service,
     seq = 1,
-    request_queue = Queue.new(),
+    request_queue = is_wsclient(conn) and Queue.new(),
     response_queue = {},
     closing = false,
     _receiving_thread = nil,


### PR DESCRIPTION
Also, fix invalid error messages and clean unused code.

**This PR's target is covered by another PR. Don't merge.**

`remote_peer` is used to access the wRPC connection out of the thread(Nginx timer) that created it. This will be used to implement other services that wRPC supports.

We decide to just use the connection within the same worker and leave the inter-worker problem to the user. So the fix could be much simpler.

This PR is a temporary solution. Eventually, every service including config sync will be using an interface like this and decoupled from the managing of connection.

We will decide how we handle the connection loss or other connection errors:
1. Every time the thread handling wRPC calls encounters an error it reconnects and blocks until  the connection restores, or
2. The clustering module is responsible to reconnect, and clients are aware of the connection loss

And should we just return an error for `call_wait`, or wait for more retries?