### PR TITLE
chore(clustering)  remove wRPC flaky flag

### DIFF
--- a/spec/02-integration/09-hybrid_mode/03-pki_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/03-pki_spec.lua
@@ -86,7 +86,7 @@ for _, cluster_protocol in ipairs{"json", "wrpc"} do
         end)
       end)
 
-      describe("#flaky sync works", function()
+      describe("sync works", function()
         local route_id
 
         it("proxy on DP follows CP config", function()


### PR DESCRIPTION
wRPC should be stable now. Removing the flaky flag from the test.