### PR TITLE
chore(cluster) remove decode/encode_config in data_plane

### DIFF
--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -6,7 +6,6 @@ local ws_client = require("resty.websocket.client")
 local cjson = require("cjson.safe")
 local declarative = require("kong.db.declarative")
 local constants = require("kong.constants")
-local utils = require("kong.tools.utils")
 local clustering_utils = require("kong.clustering.utils")
 local assert = assert
 local setmetatable = setmetatable
@@ -22,6 +21,8 @@ local cjson_encode = cjson.encode
 local kong = kong
 local exiting = ngx.worker.exiting
 local ngx_time = ngx.time
+
+local inflate_gzip = require("kong.tools.utils").inflate_gzip
 
 
 local KONG_VERSION = kong.version

--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -60,16 +60,6 @@ function _M.new(parent)
 end
 
 
-function _M:encode_config(config)
-  return deflate_gzip(config)
-end
-
-
-function _M:decode_config(config)
-  return inflate_gzip(config)
-end
-
-
 function _M:init_worker()
   -- ROLE = "data_plane"
 

--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -22,8 +22,6 @@ local cjson_encode = cjson.encode
 local kong = kong
 local exiting = ngx.worker.exiting
 local ngx_time = ngx.time
-local inflate_gzip = utils.inflate_gzip
-local deflate_gzip = utils.deflate_gzip
 
 
 local KONG_VERSION = kong.version

--- a/kong/clustering/utils.lua
+++ b/kong/clustering/utils.lua
@@ -14,6 +14,9 @@ local ngx_var = ngx.var
 local cjson_decode = require "cjson.safe".decode
 local cjson_encode = require "cjson.safe".encode
 
+local inflate_gzip = require("kong.tools.utils").inflate_gzip
+local deflate_gzip = require("kong.tools.utils").deflate_gzip
+
 local ngx_log = ngx.log
 local ngx_ERR = ngx.ERR
 local ngx_INFO = ngx.INFO
@@ -219,7 +222,7 @@ function clustering_utils.load_config_cache(self)
 
     if config and #config > 0 then
       ngx_log(ngx_INFO, _log_prefix, "found cached config, loading...")
-      config, err = self:decode_config(config)
+      config, err = inflate_gzip(config)
       if config then
         config, err = cjson_decode(config)
         if config then
@@ -265,7 +268,7 @@ function clustering_utils.save_config_cache(self, config_table)
 
   else
     local config = assert(cjson_encode(config_table))
-    config = assert(self:encode_config(config))
+    config = assert(deflate_gzip(config))
     local res
     res, err = f:write(config)
     if not res then

--- a/kong/clustering/wrpc_data_plane.lua
+++ b/kong/clustering/wrpc_data_plane.lua
@@ -17,8 +17,6 @@ local ngx_log = ngx.log
 local ngx_sleep = ngx.sleep
 local kong = kong
 local exiting = ngx.worker.exiting
-local inflate_gzip = utils.inflate_gzip
-local deflate_gzip = utils.deflate_gzip
 
 
 local KONG_VERSION = kong.version

--- a/kong/clustering/wrpc_data_plane.lua
+++ b/kong/clustering/wrpc_data_plane.lua
@@ -5,7 +5,6 @@ local declarative = require("kong.db.declarative")
 local protobuf = require("kong.tools.protobuf")
 local wrpc = require("kong.tools.wrpc")
 local constants = require("kong.constants")
-local utils = require("kong.tools.utils")
 local clustering_utils = require("kong.clustering.utils")
 local assert = assert
 local setmetatable = setmetatable

--- a/kong/clustering/wrpc_data_plane.lua
+++ b/kong/clustering/wrpc_data_plane.lua
@@ -45,16 +45,6 @@ function _M.new(parent)
 end
 
 
-function _M:encode_config(config)
-  return deflate_gzip(config)
-end
-
-
-function _M:decode_config(config)
-  return inflate_gzip(config)
-end
-
-
 function _M:init_worker()
   -- ROLE = "data_plane"
 


### PR DESCRIPTION

### Summary

The functions `encode_config` and `decode_config` are unnecessary and make people confused,
This PR directly uses `deflate_gzip` and `inflate_gzip`, and hides the gzip details in the `utils` module.

### Full changelog

* Remove encode_config` and `decode_config`  in data_plane
* Use `deflate_gzip` and `inflate_gzip` in `utils`



