### PR TITLE
fix(upstreams) mark the update timer as scheduled

### DIFF
--- a/kong/runloop/balancer/upstreams.lua
+++ b/kong/runloop/balancer/upstreams.lua
@@ -272,6 +272,7 @@ function upstreams_M.update_balancer_state()
   if err then
     log(CRIT, "unable to start update proxy state timer: ", err)
   else
+    update_balancer_state_running = true
     log(DEBUG, "update proxy state timer scheduled")
   end
 end

--- a/spec/02-integration/04-admin_api/15-off_spec.lua
+++ b/spec/02-integration/04-admin_api/15-off_spec.lua
@@ -1117,13 +1117,14 @@ end)
 describe("Admin API #off worker_consistency=eventual", function()
 
   local client
+  local WORKER_STATE_UPDATE_FREQ = 0.1
 
   lazy_setup(function()
     assert(helpers.start_kong({
       database = "off",
       lmdb_map_size = LMDB_MAP_SIZE,
       worker_consistency = "eventual",
-      worker_state_update_frequency = 0.1,
+      worker_state_update_frequency = WORKER_STATE_UPDATE_FREQ,
     }))
   end)
 


### PR DESCRIPTION
### Summary

When the balancer state timer is running, it updates the flag that avoids it to be started again on every run. This PR adds the same behavior to scheduling the update timer, instead of waiting for the first run. This change avoids that an upstream that is updated more than once before the eventual consistency timer run for the first time, schedule it again.

This PR completes the fix introduced in #8694. 

### Full changelog

* Set running flag to `true`.
* No tests were added, they were already failing.

