### PR TITLE
refactor(cluster) dpcp config code clean

### DIFF
--- a/kong-2.8.0-0.rockspec
+++ b/kong-2.8.0-0.rockspec
@@ -74,6 +74,7 @@ build = {
     ["kong.clustering.wrpc_control_plane"] = "kong/clustering/wrpc_control_plane.lua",
     ["kong.clustering.utils"] = "kong/clustering/utils.lua",
     ["kong.clustering.compat.removed_fields"] = "kong/clustering/compat/removed_fields.lua",
+    ["kong.clustering.update_config"] = "kong/clustering/update_config.lua",
 
     ["kong.cluster_events"] = "kong/cluster_events/init.lua",
     ["kong.cluster_events.strategies.cassandra"] = "kong/cluster_events/strategies/cassandra.lua",

--- a/kong-2.8.0-0.rockspec
+++ b/kong-2.8.0-0.rockspec
@@ -74,7 +74,7 @@ build = {
     ["kong.clustering.wrpc_control_plane"] = "kong/clustering/wrpc_control_plane.lua",
     ["kong.clustering.utils"] = "kong/clustering/utils.lua",
     ["kong.clustering.compat.removed_fields"] = "kong/clustering/compat/removed_fields.lua",
-    ["kong.clustering.update_config"] = "kong/clustering/update_config.lua",
+    ["kong.clustering.config_helper"] = "kong/clustering/config_helper.lua",
 
     ["kong.cluster_events"] = "kong/cluster_events/init.lua",
     ["kong.cluster_events.strategies.cassandra"] = "kong/cluster_events/strategies/cassandra.lua",

--- a/kong/clustering/config_helper.lua
+++ b/kong/clustering/config_helper.lua
@@ -28,7 +28,7 @@ local _log_prefix = "[clustering] "
 
 
 local _M = {}
-local _MT = { __index = _M, }
+--local _MT = { __index = _M, }
 
 
 local function to_sorted_string(value)
@@ -183,15 +183,7 @@ local function fill_empty_hashes(hashes)
   end
 end
 
-function _M.new(conf)
-  local self = {
-    declarative_config = declarative.new_config(conf),
-  }
-
-  return setmetatable(self, _MT)
-end
-
-function _M:execute(config_table, config_hash, hashes)
+function _M.update(declarative_config, config_table, config_hash, hashes)
   assert(type(config_table) == "table")
 
   if not config_hash then
@@ -210,7 +202,7 @@ function _M:execute(config_table, config_hash, hashes)
   end
 
   local entities, err, _, meta, new_hash =
-  self.declarative_config:parse_table(config_table, config_hash)
+  declarative_config:parse_table(config_table, config_hash)
   if not entities then
     return nil, "bad config received from control plane " .. err
   end

--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -37,9 +37,7 @@ local deflate_gzip = utils.deflate_gzip
 local calculate_config_hash = require("kong.clustering.update_config").calculate_config_hash
 
 local kong_dict = ngx.shared.kong
-local KONG_VERSION = kong.version
 local ngx_DEBUG = ngx.DEBUG
-local ngx_INFO = ngx.INFO
 local ngx_NOTICE = ngx.NOTICE
 local ngx_WARN = ngx.WARN
 local ngx_ERR = ngx.ERR
@@ -253,48 +251,7 @@ end
 
 
 function _M:check_version_compatibility(dp_version, dp_plugin_map, log_suffix)
-  local ok, err, status = clustering_utils.check_kong_version_compatibility(KONG_VERSION, dp_version, log_suffix)
-  if not ok then
-    return ok, err, status
-  end
-
-  for _, plugin in ipairs(self.plugins_list) do
-    local name = plugin.name
-    local cp_plugin = self.plugins_map[name]
-    local dp_plugin = dp_plugin_map[name]
-
-    if not dp_plugin then
-      if cp_plugin.version then
-        ngx_log(ngx_WARN, _log_prefix, name, " plugin ", cp_plugin.version, " is missing from data plane", log_suffix)
-      else
-        ngx_log(ngx_WARN, _log_prefix, name, " plugin is missing from data plane", log_suffix)
-      end
-
-    else
-      if cp_plugin.version and dp_plugin.version then
-        local msg = "data plane " .. name .. " plugin version " .. dp_plugin.version ..
-                    " is different to control plane plugin version " .. cp_plugin.version
-
-        if cp_plugin.major ~= dp_plugin.major then
-          ngx_log(ngx_WARN, _log_prefix, msg, log_suffix)
-
-        elseif cp_plugin.minor ~= dp_plugin.minor then
-          ngx_log(ngx_INFO, _log_prefix, msg, log_suffix)
-        end
-
-      elseif dp_plugin.version then
-        ngx_log(ngx_NOTICE, _log_prefix, "data plane ", name, " plugin version ", dp_plugin.version,
-                        " has unspecified version on control plane", log_suffix)
-
-      elseif cp_plugin.version then
-        ngx_log(ngx_NOTICE, _log_prefix, "data plane ", name, " plugin version is unspecified, ",
-                        "and is different to control plane plugin version ",
-                        cp_plugin.version, log_suffix)
-      end
-    end
-  end
-
-  return true, nil, CLUSTERING_SYNC_STATUS.NORMAL
+  return clustering_utils.check_version_compatibility(self, dp_version, dp_plugin_map, log_suffix)
 end
 
 

--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -1,4 +1,5 @@
 local _M = {}
+local _MT = { __index = _M, }
 
 
 local semaphore = require("ngx.semaphore")
@@ -99,11 +100,7 @@ function _M.new(parent)
     plugins_map = {},
   }
 
-  return setmetatable(self, {
-    __index = function(tab, key)
-      return _M[key] or parent[key]
-    end,
-  })
+  return setmetatable(self, _MT)
 end
 
 

--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -61,31 +61,12 @@ local REMOVED_FIELDS = require("kong.clustering.compat.removed_fields")
 local _log_prefix = "[clustering] "
 
 
+local plugins_list_to_map = clustering_utils.plugins_list_to_map
+
+
 local function handle_export_deflated_reconfigure_payload(self)
   local ok, p_err, err = pcall(self.export_deflated_reconfigure_payload, self)
   return ok, p_err or err
-end
-
-
-local function plugins_list_to_map(plugins_list)
-  local versions = {}
-  for _, plugin in ipairs(plugins_list) do
-    local name = plugin.name
-    local version = plugin.version
-    local major, minor = clustering_utils.extract_major_minor(plugin.version)
-
-    if major and minor then
-      versions[name] = {
-        major   = major,
-        minor   = minor,
-        version = version,
-      }
-
-    else
-      versions[name] = {}
-    end
-  end
-  return versions
 end
 
 

--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -73,13 +73,13 @@ local function is_timeout(err)
 end
 
 
-function _M.new(initer)
+function _M.new(conf, cert_digest)
   local self = {
     clients = setmetatable({}, { __mode = "k", }),
     plugins_map = {},
 
-    conf = initer.conf,
-    cert_digest = initer.cert_digest,
+    conf = conf,
+    cert_digest = cert_digest,
   }
 
   return setmetatable(self, _MT)

--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -98,6 +98,9 @@ function _M.new(parent)
   local self = {
     clients = setmetatable({}, { __mode = "k", }),
     plugins_map = {},
+
+    conf = parent.conf,
+    cert_digest = parent.cert_digest,
   }
 
   return setmetatable(self, _MT)

--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -94,13 +94,13 @@ local function is_timeout(err)
 end
 
 
-function _M.new(parent)
+function _M.new(initer)
   local self = {
     clients = setmetatable({}, { __mode = "k", }),
     plugins_map = {},
 
-    conf = parent.conf,
-    cert_digest = parent.cert_digest,
+    conf = initer.conf,
+    cert_digest = initer.cert_digest,
   }
 
   return setmetatable(self, _MT)

--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -33,6 +33,7 @@ local sub = string.sub
 local gsub = string.gsub
 local deflate_gzip = utils.deflate_gzip
 
+local calculate_config_hash = require("kong.clustering.update_config").calculate_config_hash
 
 local kong_dict = ngx.shared.kong
 local KONG_VERSION = kong.version
@@ -223,7 +224,7 @@ function _M:export_deflated_reconfigure_payload()
   kong_dict:set(shm_key_name, cjson_encode(self.plugins_configured));
   ngx_log(ngx_DEBUG, "plugin configuration map key: " .. shm_key_name .. " configuration: ", kong_dict:get(shm_key_name))
 
-  local config_hash, hashes = self:calculate_config_hash(config_table)
+  local config_hash, hashes = calculate_config_hash(config_table)
 
   local payload = {
     type = "reconfigure",

--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -34,7 +34,7 @@ local sub = string.sub
 local gsub = string.gsub
 local deflate_gzip = utils.deflate_gzip
 
-local calculate_config_hash = require("kong.clustering.update_config").calculate_config_hash
+local calculate_config_hash = require("kong.clustering.config_helper").calculate_config_hash
 
 local kong_dict = ngx.shared.kong
 local ngx_DEBUG = ngx.DEBUG

--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -250,14 +250,9 @@ function _M:push_config()
 end
 
 
-function _M:check_version_compatibility(dp_version, dp_plugin_map, log_suffix)
-  return clustering_utils.check_version_compatibility(self, dp_version, dp_plugin_map, log_suffix)
-end
+_M.check_version_compatibility = clustering_utils.check_version_compatibility
+_M.check_configuration_compatibility = clustering_utils.check_configuration_compatibility
 
-
-function _M:check_configuration_compatibility(dp_plugin_map)
-  return clustering_utils.check_configuration_compatibility(self, dp_plugin_map)
-end
 
 function _M:handle_cp_websocket()
   local dp_id = ngx_var.arg_node_id

--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -256,40 +256,7 @@ end
 
 
 function _M:check_configuration_compatibility(dp_plugin_map)
-  for _, plugin in ipairs(self.plugins_list) do
-    if self.plugins_configured[plugin.name] then
-      local name = plugin.name
-      local cp_plugin = self.plugins_map[name]
-      local dp_plugin = dp_plugin_map[name]
-
-      if not dp_plugin then
-        if cp_plugin.version then
-          return nil, "configured " .. name .. " plugin " .. cp_plugin.version ..
-                      " is missing from data plane", CLUSTERING_SYNC_STATUS.PLUGIN_SET_INCOMPATIBLE
-        end
-
-        return nil, "configured " .. name .. " plugin is missing from data plane",
-               CLUSTERING_SYNC_STATUS.PLUGIN_SET_INCOMPATIBLE
-      end
-
-      if cp_plugin.version and dp_plugin.version then
-        -- CP plugin needs to match DP plugins with major version
-        -- CP must have plugin with equal or newer version than that on DP
-        if cp_plugin.major ~= dp_plugin.major or
-          cp_plugin.minor < dp_plugin.minor then
-          local msg = "configured data plane " .. name .. " plugin version " .. dp_plugin.version ..
-                      " is different to control plane plugin version " .. cp_plugin.version
-          return nil, msg, CLUSTERING_SYNC_STATUS.PLUGIN_VERSION_INCOMPATIBLE
-        end
-      end
-    end
-  end
-
-  -- TODO: DAOs are not checked in any way at the moment. For example if plugin introduces a new DAO in
-  --       minor release and it has entities, that will most likely fail on data plane side, but is not
-  --       checked here.
-
-  return true, nil, CLUSTERING_SYNC_STATUS.NORMAL
+  return clustering_utils.check_configuration_compatibility(self, dp_plugin_map)
 end
 
 function _M:handle_cp_websocket()

--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -48,7 +48,6 @@ end
 
 function _M.new(parent)
   local self = {
-    --declarative_config = declarative.new_config(parent.conf),
     update_config = update_config.new(parent.conf),
   }
 
@@ -185,7 +184,6 @@ function _M:communicate(premature)
           local hashes = self.next_hashes
 
           local pok, res
-          --pok, res, err = pcall(self.update_config, self, config_table, config_hash, hashes)
           pok, res, err = pcall(self.update_config.execute,
                                 self.update_config, config_table, config_hash, hashes)
           if pok then

--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -7,7 +7,7 @@ local ws_client = require("resty.websocket.client")
 local cjson = require("cjson.safe")
 local declarative = require("kong.db.declarative")
 local constants = require("kong.constants")
-local update_config = require("kong.clustering.update_config")
+local config_helper = require("kong.clustering.config_helper")
 local assert = assert
 local setmetatable = setmetatable
 local math = math
@@ -49,7 +49,7 @@ end
 
 function _M.new(conf, cert, cert_key)
   local self = {
-    update_config = update_config.new(conf),
+    declarative_config = declarative.new_config(conf),
     conf = conf,
     cert = cert,
     cert_key = cert_key,
@@ -184,8 +184,8 @@ function _M:communicate(premature)
           local hashes = self.next_hashes
 
           local pok, res
-          pok, res, err = pcall(self.update_config.execute,
-                                self.update_config, config_table, config_hash, hashes)
+          pok, res, err = pcall(config_helper.update,
+                                self.declarative_config, config_table, config_hash, hashes)
           if pok then
             if not res then
               ngx_log(ngx_ERR, _log_prefix, "unable to update running config: ", err)

--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -47,12 +47,12 @@ local function is_timeout(err)
 end
 
 
-function _M.new(initer)
+function _M.new(conf, cert, cert_key)
   local self = {
     update_config = update_config.new(initer.conf),
-    conf = initer.conf,
-    cert = initer.cert,
-    cert_key = initer.cert_key,
+    conf = conf,
+    cert = cert,
+    cert_key = cert_key,
   }
 
   return setmetatable(self, _MT)

--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -1,4 +1,5 @@
 local _M = {}
+local _MT = { __index = _M, }
 
 
 local semaphore = require("ngx.semaphore")
@@ -51,11 +52,7 @@ function _M.new(parent)
     update_config = update_config.new(parent.conf),
   }
 
-  return setmetatable(self, {
-    __index = function(tab, key)
-      return _M[key] or parent[key]
-    end,
-  })
+  return setmetatable(self, _MT)
 end
 
 

--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -47,12 +47,12 @@ local function is_timeout(err)
 end
 
 
-function _M.new(parent)
+function _M.new(initer)
   local self = {
-    update_config = update_config.new(parent.conf),
-    conf = parent.conf,
-    cert = parent.cert,
-    cert_key = parent.cert_key,
+    update_config = update_config.new(initer.conf),
+    conf = initer.conf,
+    cert = initer.cert,
+    cert_key = initer.cert_key,
   }
 
   return setmetatable(self, _MT)

--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -6,6 +6,7 @@ local ws_client = require("resty.websocket.client")
 local cjson = require("cjson.safe")
 local declarative = require("kong.db.declarative")
 local constants = require("kong.constants")
+local update_config = require("kong.clustering.update_config")
 local assert = assert
 local setmetatable = setmetatable
 local math = math
@@ -47,7 +48,8 @@ end
 
 function _M.new(parent)
   local self = {
-    declarative_config = declarative.new_config(parent.conf),
+    --declarative_config = declarative.new_config(parent.conf),
+    update_config = update_config.new(parent.conf),
   }
 
   return setmetatable(self, {
@@ -183,7 +185,9 @@ function _M:communicate(premature)
           local hashes = self.next_hashes
 
           local pok, res
-          pok, res, err = pcall(self.update_config, self, config_table, config_hash, hashes)
+          --pok, res, err = pcall(self.update_config, self, config_table, config_hash, hashes)
+          pok, res, err = pcall(self.update_config.execute,
+                                self.update_config, config_table, config_hash, hashes)
           if pok then
             if not res then
               ngx_log(ngx_ERR, _log_prefix, "unable to update running config: ", err)

--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -49,7 +49,7 @@ end
 
 function _M.new(conf, cert, cert_key)
   local self = {
-    update_config = update_config.new(initer.conf),
+    update_config = update_config.new(conf),
     conf = conf,
     cert = cert,
     cert_key = cert_key,

--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -50,6 +50,9 @@ end
 function _M.new(parent)
   local self = {
     update_config = update_config.new(parent.conf),
+    conf = parent.conf,
+    cert = parent.cert,
+    cert_key = parent.cert_key,
   }
 
   return setmetatable(self, _MT)

--- a/kong/clustering/init.lua
+++ b/kong/clustering/init.lua
@@ -1,8 +1,6 @@
 local _M = {}
 
 local http = require("resty.http")
-local constants = require("kong.constants")
-local declarative = require("kong.db.declarative")
 local version_negotiation = require("kong.clustering.version_negotiation")
 local pl_file = require("pl.file")
 local pl_tablex = require("pl.tablex")

--- a/kong/clustering/init.lua
+++ b/kong/clustering/init.lua
@@ -83,6 +83,9 @@ function _M:init_worker()
   if role == "control_plane" then
     self.json_handler:init_worker()
     self.wrpc_handler:init_worker()
+
+    self.json_handler.plugins_list = self.plugins_list
+    self.wrpc_handler.plugins_list = self.plugins_list
   end
 
   if role == "data_plane" and ngx.worker.id() == 0 then
@@ -107,6 +110,7 @@ function _M:init_worker()
       end
 
       if self.child then
+        self.child.plugins_list = self.plugins_list
         self.child:communicate()
       end
     end))

--- a/kong/clustering/init.lua
+++ b/kong/clustering/init.lua
@@ -70,19 +70,19 @@ function _M:serve_version_handshake()
 end
 
 function _M:init_worker()
-  self.plugins_list = assert(kong.db.plugins:get_handlers())
-  sort(self.plugins_list, function(a, b)
+  local plugins_list = assert(kong.db.plugins:get_handlers())
+  sort(plugins_list, function(a, b)
     return a.name:lower() < b.name:lower()
   end)
 
-  self.plugins_list = pl_tablex.map(function(p)
+  plugins_list = pl_tablex.map(function(p)
     return { name = p.name, version = p.handler.VERSION, }
-  end, self.plugins_list)
+  end, plugins_list)
 
   local role = self.conf.role
   if role == "control_plane" then
-    self.json_handler.plugins_list = self.plugins_list
-    self.wrpc_handler.plugins_list = self.plugins_list
+    self.json_handler.plugins_list = plugins_list
+    self.wrpc_handler.plugins_list = plugins_list
 
     self.json_handler:init_worker()
     self.wrpc_handler:init_worker()
@@ -110,7 +110,7 @@ function _M:init_worker()
       end
 
       if self.child then
-        self.child.plugins_list = self.plugins_list
+        self.child.plugins_list = plugins_list
         self.child:communicate()
       end
     end))

--- a/kong/clustering/init.lua
+++ b/kong/clustering/init.lua
@@ -1,121 +1,21 @@
 local _M = {}
 
-local constants = require("kong.constants")
-local declarative = require("kong.db.declarative")
 local version_negotiation = require("kong.clustering.version_negotiation")
 local pl_file = require("pl.file")
 local pl_tablex = require("pl.tablex")
 local ssl = require("ngx.ssl")
 local openssl_x509 = require("resty.openssl.x509")
-local isempty = require("table.isempty")
-local isarray = require("table.isarray")
-local nkeys = require("table.nkeys")
-local new_tab = require("table.new")
 local ngx_log = ngx.log
-local ngx_null = ngx.null
-local ngx_md5 = ngx.md5
-local ngx_md5_bin = ngx.md5_bin
-local tostring = tostring
 local assert = assert
-local error = error
-local concat = table.concat
-local pairs = pairs
 local sort = table.sort
-local type = type
 
 local ngx_ERR = ngx.ERR
 local ngx_DEBUG = ngx.DEBUG
 
-local DECLARATIVE_EMPTY_CONFIG_HASH = constants.DECLARATIVE_EMPTY_CONFIG_HASH
 local _log_prefix = "[clustering] "
 
 
 local MT = { __index = _M, }
-
-
-local function to_sorted_string(value)
-  if value == ngx_null then
-    return "/null/"
-  end
-
-  local t = type(value)
-  if t == "string" or t == "number" then
-    return value
-
-  elseif t == "boolean" then
-    return tostring(value)
-
-  elseif t == "table" then
-    if isempty(value) then
-      return "{}"
-
-    elseif isarray(value) then
-      local count = #value
-      if count == 1 then
-        return to_sorted_string(value[1])
-
-      elseif count == 2 then
-        return to_sorted_string(value[1]) .. ";" ..
-               to_sorted_string(value[2])
-
-      elseif count == 3 then
-        return to_sorted_string(value[1]) .. ";" ..
-               to_sorted_string(value[2]) .. ";" ..
-               to_sorted_string(value[3])
-
-      elseif count == 4 then
-        return to_sorted_string(value[1]) .. ";" ..
-               to_sorted_string(value[2]) .. ";" ..
-               to_sorted_string(value[3]) .. ";" ..
-               to_sorted_string(value[4])
-
-      elseif count == 5 then
-        return to_sorted_string(value[1]) .. ";" ..
-               to_sorted_string(value[2]) .. ";" ..
-               to_sorted_string(value[3]) .. ";" ..
-               to_sorted_string(value[4]) .. ";" ..
-               to_sorted_string(value[5])
-      end
-
-      local i = 0
-      local o = new_tab(count < 100 and count or 100, 0)
-      for j = 1, count do
-        i = i + 1
-        o[i] = to_sorted_string(value[j])
-
-        if j % 100 == 0 then
-          i = 1
-          o[i] = ngx_md5_bin(concat(o, ";", 1, 100))
-        end
-      end
-
-      return ngx_md5_bin(concat(o, ";", 1, i))
-
-    else
-      local count = nkeys(value)
-      local keys = new_tab(count, 0)
-      local i = 0
-      for k in pairs(value) do
-        i = i + 1
-        keys[i] = k
-      end
-
-      sort(keys)
-
-      local o = new_tab(count, 0)
-      for i = 1, count do
-        o[i] = keys[i] .. ":" .. to_sorted_string(value[keys[i]])
-      end
-
-      value = concat(o, ";", 1, count)
-
-      return #value > 512 and ngx_md5_bin(value) or value
-    end
-
-  else
-    error("invalid type to be sorted (JSON types are supported)")
-  end
-end
 
 
 function _M.new(conf)
@@ -145,65 +45,6 @@ function _M.new(conf)
 end
 
 
-function _M:calculate_config_hash(config_table)
-  if type(config_table) ~= "table" then
-    local config_hash = ngx_md5(to_sorted_string(config_table))
-    return config_hash, { config = config_hash }
-  end
-
-  local routes    = config_table.routes
-  local services  = config_table.services
-  local plugins   = config_table.plugins
-  local upstreams = config_table.upstreams
-  local targets   = config_table.targets
-
-  local routes_hash    = routes    and ngx_md5(to_sorted_string(routes))    or DECLARATIVE_EMPTY_CONFIG_HASH
-  local services_hash  = services  and ngx_md5(to_sorted_string(services))  or DECLARATIVE_EMPTY_CONFIG_HASH
-  local plugins_hash   = plugins   and ngx_md5(to_sorted_string(plugins))   or DECLARATIVE_EMPTY_CONFIG_HASH
-  local upstreams_hash = upstreams and ngx_md5(to_sorted_string(upstreams)) or DECLARATIVE_EMPTY_CONFIG_HASH
-  local targets_hash   = targets   and ngx_md5(to_sorted_string(targets))   or DECLARATIVE_EMPTY_CONFIG_HASH
-
-  config_table.routes    = nil
-  config_table.services  = nil
-  config_table.plugins   = nil
-  config_table.upstreams = nil
-  config_table.targets   = nil
-
-  local config_hash = ngx_md5(to_sorted_string(config_table) .. routes_hash
-                                                             .. services_hash
-                                                             .. plugins_hash
-                                                             .. upstreams_hash
-                                                             .. targets_hash)
-
-  config_table.routes    = routes
-  config_table.services  = services
-  config_table.plugins   = plugins
-  config_table.upstreams = upstreams
-  config_table.targets   = targets
-
-  return config_hash, {
-    config    = config_hash,
-    routes    = routes_hash,
-    services  = services_hash,
-    plugins   = plugins_hash,
-    upstreams = upstreams_hash,
-    targets   = targets_hash,
-  }
-end
-
-local function fill_empty_hashes(hashes)
-  for _, field_name in ipairs{
-    "config",
-    "routes",
-    "services",
-    "plugins",
-    "upstreams",
-    "targets",
-  } do
-    hashes[field_name] = hashes[field_name] or DECLARATIVE_EMPTY_CONFIG_HASH
-  end
-end
-
 function _M:request_version_negotiation()
   local response_data, err = version_negotiation.request_version_handshake(self.conf, self.cert, self.cert_key)
   if not response_data then
@@ -213,49 +54,6 @@ function _M:request_version_negotiation()
     end))
     return
   end
-end
-
-
-function _M:update_config(config_table, config_hash, hashes)
-  assert(type(config_table) == "table")
-
-  if not config_hash then
-    config_hash, hashes = self:calculate_config_hash(config_table)
-  end
-
-  if hashes then
-    fill_empty_hashes(hashes)
-  end
-
-  local current_hash = declarative.get_current_hash()
-  if current_hash == config_hash then
-    ngx_log(ngx_DEBUG, _log_prefix, "same config received from control plane, ",
-      "no need to reload")
-    return true
-  end
-
-  local entities, err, _, meta, new_hash =
-  self.declarative_config:parse_table(config_table, config_hash)
-  if not entities then
-    return nil, "bad config received from control plane " .. err
-  end
-
-  if current_hash == new_hash then
-    ngx_log(ngx_DEBUG, _log_prefix, "same config received from control plane, ",
-      "no need to reload")
-    return true
-  end
-
-  -- NOTE: no worker mutex needed as this code can only be
-  -- executed by worker 0
-
-  local res
-  res, err = declarative.load_into_cache_with_events(entities, meta, new_hash, hashes)
-  if not res then
-    return nil, err
-  end
-
-  return true
 end
 
 

--- a/kong/clustering/init.lua
+++ b/kong/clustering/init.lua
@@ -15,7 +15,7 @@ local ngx_DEBUG = ngx.DEBUG
 local _log_prefix = "[clustering] "
 
 
-local MT = { __index = _M, }
+local _MT = { __index = _M, }
 
 
 function _M.new(conf)
@@ -25,7 +25,7 @@ function _M.new(conf)
     conf = conf,
   }
 
-  setmetatable(self, MT)
+  setmetatable(self, _MT)
 
   local cert = assert(pl_file.read(conf.cluster_cert))
   self.cert = assert(ssl.parse_pem_cert(cert))

--- a/kong/clustering/init.lua
+++ b/kong/clustering/init.lua
@@ -81,11 +81,11 @@ function _M:init_worker()
 
   local role = self.conf.role
   if role == "control_plane" then
-    self.json_handler:init_worker()
-    self.wrpc_handler:init_worker()
-
     self.json_handler.plugins_list = self.plugins_list
     self.wrpc_handler.plugins_list = self.plugins_list
+
+    self.json_handler:init_worker()
+    self.wrpc_handler:init_worker()
   end
 
   if role == "data_plane" and ngx.worker.id() == 0 then

--- a/kong/clustering/init.lua
+++ b/kong/clustering/init.lua
@@ -36,11 +36,6 @@ function _M.new(conf)
   local key = assert(pl_file.read(conf.cluster_cert_key))
   self.cert_key = assert(ssl.parse_pem_priv_key(key))
 
-  if conf.role == "control_plane" then
-    self.json_handler = require("kong.clustering.control_plane").new(self)
-    self.wrpc_handler = require("kong.clustering.wrpc_control_plane").new(self)
-  end
-
   return self
 end
 
@@ -81,6 +76,9 @@ function _M:init_worker()
 
   local role = self.conf.role
   if role == "control_plane" then
+    self.json_handler = require("kong.clustering.control_plane").new(self)
+    self.wrpc_handler = require("kong.clustering.wrpc_control_plane").new(self)
+
     self.json_handler.plugins_list = plugins_list
     self.wrpc_handler.plugins_list = plugins_list
 

--- a/kong/clustering/init.lua
+++ b/kong/clustering/init.lua
@@ -1,6 +1,8 @@
 local _M = {}
 
 local http = require("resty.http")
+local constants = require("kong.constants")
+local declarative = require("kong.db.declarative")
 local version_negotiation = require("kong.clustering.version_negotiation")
 local pl_file = require("pl.file")
 local pl_tablex = require("pl.tablex")

--- a/kong/clustering/init.lua
+++ b/kong/clustering/init.lua
@@ -1,5 +1,6 @@
 local _M = {}
 
+local http = require("resty.http")
 local version_negotiation = require("kong.clustering.version_negotiation")
 local pl_file = require("pl.file")
 local pl_tablex = require("pl.tablex")
@@ -45,15 +46,39 @@ function _M.new(conf)
 end
 
 
-function _M:request_version_negotiation()
-  local response_data, err = version_negotiation.request_version_handshake(self.conf, self.cert, self.cert_key)
-  if not response_data then
-    ngx_log(ngx_ERR, _log_prefix, "error while requesting version negotiation: " .. err)
-    assert(ngx.timer.at(math.random(5, 10), function(premature)
-      self:communicate(premature)
-    end))
-    return
+--- Return the highest supported Hybrid mode protocol version.
+local function check_protocol_support(conf, cert, cert_key)
+  local params = {
+    scheme = "https",
+    method = "HEAD",
+
+    ssl_verify = true,
+    ssl_client_cert = cert,
+    ssl_client_priv_key = cert_key,
+  }
+
+  if conf.cluster_mtls == "shared" then
+    params.ssl_server_name = "kong_clustering"
+
+  else
+    -- server_name will be set to the host if it is not explicitly defined here
+    if conf.cluster_server_name ~= "" then
+      params.ssl_server_name = conf.cluster_server_name
+    end
   end
+
+  local c = http.new()
+  local res, err = c:request_uri(
+    "https://" .. conf.cluster_control_plane .. "/v1/wrpc", params)
+  if not res then
+    return nil, err
+  end
+
+  if res.status == 404 then
+    return "v0"
+  end
+
+  return "v1"   -- wrpc
 end
 
 
@@ -97,11 +122,10 @@ function _M:init_worker()
         return
       end
 
-      self:request_version_negotiation()
+      local config_proto, msg = check_protocol_support(self.conf, self.cert, self.cert_key)
 
-      local config_proto, msg = version_negotiation.get_negotiated_service("config")
       if not config_proto and msg then
-        ngx_log(ngx_ERR, _log_prefix, "error reading negotiated \"config\" service: ", msg)
+        ngx_log(ngx_ERR, _log_prefix, "error check protocol support: ", msg)
       end
 
       ngx_log(ngx_DEBUG, _log_prefix, "config_proto: ", config_proto, " / ", msg)

--- a/kong/clustering/init.lua
+++ b/kong/clustering/init.lua
@@ -80,12 +80,15 @@ function _M:init_worker()
   end, plugins_list)
 
   local role = self.conf.role
+
   if role == "control_plane" then
     self.json_handler.plugins_list = plugins_list
     self.wrpc_handler.plugins_list = plugins_list
 
     self.json_handler:init_worker()
     self.wrpc_handler:init_worker()
+
+    return
   end
 
   if role == "data_plane" and ngx.worker.id() == 0 then

--- a/kong/clustering/update_config.lua
+++ b/kong/clustering/update_config.lua
@@ -39,35 +39,42 @@ local function to_sorted_string(value)
   local t = type(value)
   if t == "string" or t == "number" then
     return value
+  end
 
-  elseif t == "boolean" then
+  if t == "boolean" then
     return tostring(value)
+  end
 
-  elseif t == "table" then
+  if t == "table" then
     if isempty(value) then
       return "{}"
+    end
 
-    elseif isarray(value) then
+    if isarray(value) then
       local count = #value
       if count == 1 then
         return to_sorted_string(value[1])
+      end
 
-      elseif count == 2 then
+      if count == 2 then
         return to_sorted_string(value[1]) .. ";" ..
                to_sorted_string(value[2])
+      end
 
-      elseif count == 3 then
+      if count == 3 then
         return to_sorted_string(value[1]) .. ";" ..
                to_sorted_string(value[2]) .. ";" ..
                to_sorted_string(value[3])
+      end
 
-      elseif count == 4 then
+      if count == 4 then
         return to_sorted_string(value[1]) .. ";" ..
                to_sorted_string(value[2]) .. ";" ..
                to_sorted_string(value[3]) .. ";" ..
                to_sorted_string(value[4])
+      end
 
-      elseif count == 5 then
+      if count == 5 then
         return to_sorted_string(value[1]) .. ";" ..
                to_sorted_string(value[2]) .. ";" ..
                to_sorted_string(value[3]) .. ";" ..
@@ -108,11 +115,11 @@ local function to_sorted_string(value)
       value = concat(o, ";", 1, count)
 
       return #value > 512 and ngx_md5_bin(value) or value
-    end
+    end -- isarray
 
-  else
-    error("invalid type to be sorted (JSON types are supported)")
-  end
+  end   -- table
+
+  error("invalid type to be sorted (JSON types are supported)")
 end
 
 local function calculate_config_hash(config_table)

--- a/kong/clustering/update_config.lua
+++ b/kong/clustering/update_config.lua
@@ -168,15 +168,17 @@ local function calculate_config_hash(config_table)
   }
 end
 
-local function fill_empty_hashes(hashes)
-  for _, field_name in ipairs{
+local hash_fields = {
     "config",
     "routes",
     "services",
     "plugins",
     "upstreams",
     "targets",
-  } do
+  }
+
+local function fill_empty_hashes(hashes)
+  for _, field_name in ipairs(hash_fields) do
     hashes[field_name] = hashes[field_name] or DECLARATIVE_EMPTY_CONFIG_HASH
   end
 end

--- a/kong/clustering/update_config.lua
+++ b/kong/clustering/update_config.lua
@@ -224,7 +224,7 @@ function _M:execute(config_table, config_hash, hashes)
   return true
 end
 
--- for test
+
 _M.calculate_config_hash = calculate_config_hash
 
 

--- a/kong/clustering/update_config.lua
+++ b/kong/clustering/update_config.lua
@@ -1,0 +1,229 @@
+local constants = require("kong.constants")
+local declarative = require("kong.db.declarative")
+
+local tostring = tostring
+local assert = assert
+local type = type
+local error = error
+local pairs = pairs
+local ipairs = ipairs
+local concat = table.concat
+local sort = table.sort
+
+local isempty = require("table.isempty")
+local isarray = require("table.isarray")
+local nkeys = require("table.nkeys")
+local new_tab = require("table.new")
+
+local ngx_log = ngx.log
+local ngx_null = ngx.null
+local ngx_md5 = ngx.md5
+local ngx_md5_bin = ngx.md5_bin
+
+--local ngx_ERR = ngx.ERR
+local ngx_DEBUG = ngx.DEBUG
+
+local DECLARATIVE_EMPTY_CONFIG_HASH = constants.DECLARATIVE_EMPTY_CONFIG_HASH
+local _log_prefix = "[clustering] "
+
+
+local _M = {}
+local _MT = { __index = _M, }
+
+
+local function to_sorted_string(value)
+  if value == ngx_null then
+    return "/null/"
+  end
+
+  local t = type(value)
+  if t == "string" or t == "number" then
+    return value
+
+  elseif t == "boolean" then
+    return tostring(value)
+
+  elseif t == "table" then
+    if isempty(value) then
+      return "{}"
+
+    elseif isarray(value) then
+      local count = #value
+      if count == 1 then
+        return to_sorted_string(value[1])
+
+      elseif count == 2 then
+        return to_sorted_string(value[1]) .. ";" ..
+               to_sorted_string(value[2])
+
+      elseif count == 3 then
+        return to_sorted_string(value[1]) .. ";" ..
+               to_sorted_string(value[2]) .. ";" ..
+               to_sorted_string(value[3])
+
+      elseif count == 4 then
+        return to_sorted_string(value[1]) .. ";" ..
+               to_sorted_string(value[2]) .. ";" ..
+               to_sorted_string(value[3]) .. ";" ..
+               to_sorted_string(value[4])
+
+      elseif count == 5 then
+        return to_sorted_string(value[1]) .. ";" ..
+               to_sorted_string(value[2]) .. ";" ..
+               to_sorted_string(value[3]) .. ";" ..
+               to_sorted_string(value[4]) .. ";" ..
+               to_sorted_string(value[5])
+      end
+
+      local i = 0
+      local o = new_tab(count < 100 and count or 100, 0)
+      for j = 1, count do
+        i = i + 1
+        o[i] = to_sorted_string(value[j])
+
+        if j % 100 == 0 then
+          i = 1
+          o[i] = ngx_md5_bin(concat(o, ";", 1, 100))
+        end
+      end
+
+      return ngx_md5_bin(concat(o, ";", 1, i))
+
+    else
+      local count = nkeys(value)
+      local keys = new_tab(count, 0)
+      local i = 0
+      for k in pairs(value) do
+        i = i + 1
+        keys[i] = k
+      end
+
+      sort(keys)
+
+      local o = new_tab(count, 0)
+      for i = 1, count do
+        o[i] = keys[i] .. ":" .. to_sorted_string(value[keys[i]])
+      end
+
+      value = concat(o, ";", 1, count)
+
+      return #value > 512 and ngx_md5_bin(value) or value
+    end
+
+  else
+    error("invalid type to be sorted (JSON types are supported)")
+  end
+end
+
+local function calculate_config_hash(config_table)
+  if type(config_table) ~= "table" then
+    local config_hash = ngx_md5(to_sorted_string(config_table))
+    return config_hash, { config = config_hash, }
+  end
+
+  local routes    = config_table.routes
+  local services  = config_table.services
+  local plugins   = config_table.plugins
+  local upstreams = config_table.upstreams
+  local targets   = config_table.targets
+
+  local routes_hash    = routes    and ngx_md5(to_sorted_string(routes))    or DECLARATIVE_EMPTY_CONFIG_HASH
+  local services_hash  = services  and ngx_md5(to_sorted_string(services))  or DECLARATIVE_EMPTY_CONFIG_HASH
+  local plugins_hash   = plugins   and ngx_md5(to_sorted_string(plugins))   or DECLARATIVE_EMPTY_CONFIG_HASH
+  local upstreams_hash = upstreams and ngx_md5(to_sorted_string(upstreams)) or DECLARATIVE_EMPTY_CONFIG_HASH
+  local targets_hash   = targets   and ngx_md5(to_sorted_string(targets))   or DECLARATIVE_EMPTY_CONFIG_HASH
+
+  config_table.routes    = nil
+  config_table.services  = nil
+  config_table.plugins   = nil
+  config_table.upstreams = nil
+  config_table.targets   = nil
+
+  local config_hash = ngx_md5(to_sorted_string(config_table) .. routes_hash
+                                                             .. services_hash
+                                                             .. plugins_hash
+                                                             .. upstreams_hash
+                                                             .. targets_hash)
+
+  config_table.routes    = routes
+  config_table.services  = services
+  config_table.plugins   = plugins
+  config_table.upstreams = upstreams
+  config_table.targets   = targets
+
+  return config_hash, {
+    config    = config_hash,
+    routes    = routes_hash,
+    services  = services_hash,
+    plugins   = plugins_hash,
+    upstreams = upstreams_hash,
+    targets   = targets_hash,
+  }
+end
+
+local function fill_empty_hashes(hashes)
+  for _, field_name in ipairs{
+    "config",
+    "routes",
+    "services",
+    "plugins",
+    "upstreams",
+    "targets",
+  } do
+    hashes[field_name] = hashes[field_name] or DECLARATIVE_EMPTY_CONFIG_HASH
+  end
+end
+
+
+function _M.new(conf)
+  local self = {
+    declarative_config = declarative.new_config(conf),
+  }
+
+  return setmetatable(self, _MT)
+end
+
+function _M:execute(config_table, config_hash, hashes)
+  assert(type(config_table) == "table")
+
+  if not config_hash then
+    config_hash, hashes = calculate_config_hash(config_table)
+  end
+
+  if hashes then
+    fill_empty_hashes(hashes)
+  end
+
+  local current_hash = declarative.get_current_hash()
+  if current_hash == config_hash then
+    ngx_log(ngx_DEBUG, _log_prefix, "same config received from control plane, ",
+      "no need to reload")
+    return true
+  end
+
+  local entities, err, _, meta, new_hash =
+  self.declarative_config:parse_table(config_table, config_hash)
+  if not entities then
+    return nil, "bad config received from control plane " .. err
+  end
+
+  if current_hash == new_hash then
+    ngx_log(ngx_DEBUG, _log_prefix, "same config received from control plane, ",
+      "no need to reload")
+    return true
+  end
+
+  -- NOTE: no worker mutex needed as this code can only be
+  -- executed by worker 0
+
+  local res
+  res, err = declarative.load_into_cache_with_events(entities, meta, new_hash, hashes)
+  if not res then
+    return nil, err
+  end
+
+  return true
+end
+
+
+return _M

--- a/kong/clustering/update_config.lua
+++ b/kong/clustering/update_config.lua
@@ -224,5 +224,8 @@ function _M:execute(config_table, config_hash, hashes)
   return true
 end
 
+-- for test
+_M.calculate_config_hash = calculate_config_hash
+
 
 return _M

--- a/kong/clustering/update_config.lua
+++ b/kong/clustering/update_config.lua
@@ -174,7 +174,6 @@ local function fill_empty_hashes(hashes)
   end
 end
 
-
 function _M.new(conf)
   local self = {
     declarative_config = declarative.new_config(conf),

--- a/kong/clustering/utils.lua
+++ b/kong/clustering/utils.lua
@@ -24,10 +24,10 @@ local OCSP_TIMEOUT = constants.CLUSTERING_OCSP_TIMEOUT
 
 local KONG_VERSION = kong.version
 
-local clustering_utils = {}
+local _M = {}
 
 
-function clustering_utils.extract_major_minor(version)
+function _M.extract_major_minor(version)
   if type(version) ~= "string" then
     return nil, nil
   end
@@ -43,9 +43,9 @@ function clustering_utils.extract_major_minor(version)
   return major, minor
 end
 
-function clustering_utils.check_kong_version_compatibility(cp_version, dp_version, log_suffix)
-  local major_cp, minor_cp = clustering_utils.extract_major_minor(cp_version)
-  local major_dp, minor_dp = clustering_utils.extract_major_minor(dp_version)
+function _M.check_kong_version_compatibility(cp_version, dp_version, log_suffix)
+  local major_cp, minor_cp = _M.extract_major_minor(cp_version)
+  local major_dp, minor_dp = _M.extract_major_minor(dp_version)
 
   if not major_cp then
     return nil, "data plane version " .. dp_version .. " is incompatible with control plane version",
@@ -172,7 +172,7 @@ do
 end
 
 
-function clustering_utils.validate_connection_certs(conf, cert_digest)
+function _M.validate_connection_certs(conf, cert_digest)
   local _, err
 
   -- use mutual TLS authentication
@@ -204,12 +204,12 @@ function clustering_utils.validate_connection_certs(conf, cert_digest)
 end
 
 
-function clustering_utils.plugins_list_to_map(plugins_list)
+function _M.plugins_list_to_map(plugins_list)
   local versions = {}
   for _, plugin in ipairs(plugins_list) do
     local name = plugin.name
     local version = plugin.version
-    local major, minor = clustering_utils.extract_major_minor(plugin.version)
+    local major, minor = _M.extract_major_minor(plugin.version)
 
     if major and minor then
       versions[name] = {
@@ -226,8 +226,8 @@ function clustering_utils.plugins_list_to_map(plugins_list)
 end
 
 
-function clustering_utils.check_version_compatibility(obj, dp_version, dp_plugin_map, log_suffix)
-  local ok, err, status = clustering_utils.check_kong_version_compatibility(KONG_VERSION, dp_version, log_suffix)
+function _M.check_version_compatibility(obj, dp_version, dp_plugin_map, log_suffix)
+  local ok, err, status = _M.check_kong_version_compatibility(KONG_VERSION, dp_version, log_suffix)
   if not ok then
     return ok, err, status
   end
@@ -272,7 +272,7 @@ function clustering_utils.check_version_compatibility(obj, dp_version, dp_plugin
 end
 
 
-function clustering_utils.check_configuration_compatibility(obj, dp_plugin_map)
+function _M.check_configuration_compatibility(obj, dp_plugin_map)
   for _, plugin in ipairs(obj.plugins_list) do
     if obj.plugins_configured[plugin.name] then
       local name = plugin.name
@@ -310,4 +310,4 @@ function clustering_utils.check_configuration_compatibility(obj, dp_plugin_map)
 end
 
 
-return clustering_utils
+return _M

--- a/kong/clustering/utils.lua
+++ b/kong/clustering/utils.lua
@@ -13,6 +13,7 @@ local ngx_var = ngx.var
 
 local ngx_log = ngx.log
 local ngx_INFO = ngx.INFO
+local ngx_NOTICE = ngx.NOTICE
 local ngx_WARN = ngx.WARN
 local _log_prefix = "[clustering] "
 
@@ -20,6 +21,7 @@ local MAJOR_MINOR_PATTERN = "^(%d+)%.(%d+)%.%d+"
 local CLUSTERING_SYNC_STATUS = constants.CLUSTERING_SYNC_STATUS
 local OCSP_TIMEOUT = constants.CLUSTERING_OCSP_TIMEOUT
 
+local KONG_VERSION = kong.version
 
 local clustering_utils = {}
 
@@ -220,6 +222,52 @@ function clustering_utils.plugins_list_to_map(plugins_list)
     end
   end
   return versions
+end
+
+
+function clustering_utils.check_version_compatibility(obj, dp_version, dp_plugin_map, log_suffix)
+  local ok, err, status = clustering_utils.check_kong_version_compatibility(KONG_VERSION, dp_version, log_suffix)
+  if not ok then
+    return ok, err, status
+  end
+
+  for _, plugin in ipairs(obj.plugins_list) do
+    local name = plugin.name
+    local cp_plugin = obj.plugins_map[name]
+    local dp_plugin = dp_plugin_map[name]
+
+    if not dp_plugin then
+      if cp_plugin.version then
+        ngx_log(ngx_WARN, _log_prefix, name, " plugin ", cp_plugin.version, " is missing from data plane", log_suffix)
+      else
+        ngx_log(ngx_WARN, _log_prefix, name, " plugin is missing from data plane", log_suffix)
+      end
+
+    else
+      if cp_plugin.version and dp_plugin.version then
+        local msg = "data plane " .. name .. " plugin version " .. dp_plugin.version ..
+                    " is different to control plane plugin version " .. cp_plugin.version
+
+        if cp_plugin.major ~= dp_plugin.major then
+          ngx_log(ngx_WARN, _log_prefix, msg, log_suffix)
+
+        elseif cp_plugin.minor ~= dp_plugin.minor then
+          ngx_log(ngx_INFO, _log_prefix, msg, log_suffix)
+        end
+
+      elseif dp_plugin.version then
+        ngx_log(ngx_NOTICE, _log_prefix, "data plane ", name, " plugin version ", dp_plugin.version,
+                        " has unspecified version on control plane", log_suffix)
+
+      elseif cp_plugin.version then
+        ngx_log(ngx_NOTICE, _log_prefix, "data plane ", name, " plugin version is unspecified, ",
+                        "and is different to control plane plugin version ",
+                        cp_plugin.version, log_suffix)
+      end
+    end
+  end
+
+  return true, nil, CLUSTERING_SYNC_STATUS.NORMAL
 end
 
 

--- a/kong/clustering/utils.lua
+++ b/kong/clustering/utils.lua
@@ -200,4 +200,27 @@ function clustering_utils.validate_connection_certs(conf, cert_digest)
   return true
 end
 
+
+function clustering_utils.plugins_list_to_map(plugins_list)
+  local versions = {}
+  for _, plugin in ipairs(plugins_list) do
+    local name = plugin.name
+    local version = plugin.version
+    local major, minor = clustering_utils.extract_major_minor(plugin.version)
+
+    if major and minor then
+      versions[name] = {
+        major   = major,
+        minor   = minor,
+        version = version,
+      }
+
+    else
+      versions[name] = {}
+    end
+  end
+  return versions
+end
+
+
 return clustering_utils

--- a/kong/clustering/wrpc_control_plane.lua
+++ b/kong/clustering/wrpc_control_plane.lua
@@ -17,7 +17,6 @@ local type = type
 local pcall = pcall
 local pairs = pairs
 local ipairs = ipairs
-local tonumber = tonumber
 local tostring = tostring
 local ngx = ngx
 local ngx_log = ngx.log
@@ -31,6 +30,7 @@ local table_insert = table.insert
 local table_concat = table.concat
 
 local calculate_config_hash = require("kong.clustering.update_config").calculate_config_hash
+local extract_major_minor = require("kong.clustering.utils").extract_major_minor
 
 local kong_dict = ngx.shared.kong
 local KONG_VERSION = kong.version
@@ -47,7 +47,6 @@ local WS_OPTS = {
 }
 local OCSP_TIMEOUT = constants.CLUSTERING_OCSP_TIMEOUT
 local CLUSTERING_SYNC_STATUS = constants.CLUSTERING_SYNC_STATUS
-local MAJOR_MINOR_PATTERN = "^(%d+)%.(%d+)%.%d+"
 local _log_prefix = "[wrpc-clustering] "
 
 local wrpc_config_service
@@ -88,23 +87,6 @@ local function get_config_service(self)
   end
 
   return wrpc_config_service
-end
-
-
-local function extract_major_minor(version)
-  if type(version) ~= "string" then
-    return nil, nil
-  end
-
-  local major, minor = version:match(MAJOR_MINOR_PATTERN)
-  if not major then
-    return nil, nil
-  end
-
-  major = tonumber(major, 10)
-  minor = tonumber(minor, 10)
-
-  return major, minor
 end
 
 

--- a/kong/clustering/wrpc_control_plane.lua
+++ b/kong/clustering/wrpc_control_plane.lua
@@ -170,68 +170,6 @@ function _M:push_config()
 end
 
 
-local check_for_revocation_status
-do
-  local get_full_client_certificate_chain = require("resty.kong.tls").get_full_client_certificate_chain
-  check_for_revocation_status = function()
-    local cert, err = get_full_client_certificate_chain()
-    if not cert then
-      return nil, err
-    end
-
-    local der_cert
-    der_cert, err = ssl.cert_pem_to_der(cert)
-    if not der_cert then
-      return nil, "failed to convert certificate chain from PEM to DER: " .. err
-    end
-
-    local ocsp_url
-    ocsp_url, err = ocsp.get_ocsp_responder_from_der_chain(der_cert)
-    if not ocsp_url then
-      return nil, err or "OCSP responder endpoint can not be determined, " ..
-                         "maybe the client certificate is missing the " ..
-                         "required extensions"
-    end
-
-    local ocsp_req
-    ocsp_req, err = ocsp.create_ocsp_request(der_cert)
-    if not ocsp_req then
-      return nil, "failed to create OCSP request: " .. err
-    end
-
-    local c = http.new()
-    local res
-    res, err = c:request_uri(ocsp_url, {
-      headers = {
-        ["Content-Type"] = "application/ocsp-request"
-      },
-      timeout = OCSP_TIMEOUT,
-      method = "POST",
-      body = ocsp_req,
-    })
-
-    if not res then
-      return nil, "failed sending request to OCSP responder: " .. tostring(err)
-    end
-    if res.status ~= 200 then
-      return nil, "OCSP responder returns bad HTTP status code: " .. res.status
-    end
-
-    local ocsp_resp = res.body
-    if not ocsp_resp or #ocsp_resp == 0 then
-      return nil, "unexpected response from OCSP responder: empty body"
-    end
-
-    res, err = ocsp.validate_ocsp_response(ocsp_resp, der_cert)
-    if not res then
-      return false, "failed to validate OCSP response: " .. err
-    end
-
-    return true
-  end
-end
-
-
 function _M:check_version_compatibility(dp_version, dp_plugin_map, log_suffix)
   local major_cp, minor_cp = extract_major_minor(KONG_VERSION)
   local major_dp, minor_dp = extract_major_minor(dp_version)

--- a/kong/clustering/wrpc_control_plane.lua
+++ b/kong/clustering/wrpc_control_plane.lua
@@ -1,4 +1,5 @@
 local _M = {}
+local _MT = { __index = _M, }
 
 
 local semaphore = require("ngx.semaphore")
@@ -118,11 +119,7 @@ function _M.new(parent)
     plugins_map = {},
   }
 
-  return setmetatable(self, {
-    __index = function(tab, key)
-      return _M[key] or parent[key]
-    end,
-  })
+  return setmetatable(self, _MT)
 end
 
 

--- a/kong/clustering/wrpc_control_plane.lua
+++ b/kong/clustering/wrpc_control_plane.lua
@@ -14,7 +14,6 @@ local setmetatable = setmetatable
 local type = type
 local pcall = pcall
 local pairs = pairs
-local ipairs = ipairs
 local ngx = ngx
 local ngx_log = ngx.log
 local cjson_encode = cjson.encode
@@ -169,40 +168,7 @@ end
 
 
 function _M:check_configuration_compatibility(dp_plugin_map)
-  for _, plugin in ipairs(self.plugins_list) do
-    if self.plugins_configured[plugin.name] then
-      local name = plugin.name
-      local cp_plugin = self.plugins_map[name]
-      local dp_plugin = dp_plugin_map[name]
-
-      if not dp_plugin then
-        if cp_plugin.version then
-          return nil, "configured " .. name .. " plugin " .. cp_plugin.version ..
-                      " is missing from data plane", CLUSTERING_SYNC_STATUS.PLUGIN_SET_INCOMPATIBLE
-        end
-
-        return nil, "configured " .. name .. " plugin is missing from data plane",
-               CLUSTERING_SYNC_STATUS.PLUGIN_SET_INCOMPATIBLE
-      end
-
-      if cp_plugin.version and dp_plugin.version then
-        -- CP plugin needs to match DP plugins with major version
-        -- CP must have plugin with equal or newer version than that on DP
-        if cp_plugin.major ~= dp_plugin.major or
-          cp_plugin.minor < dp_plugin.minor then
-          local msg = "configured data plane " .. name .. " plugin version " .. dp_plugin.version ..
-                      " is different to control plane plugin version " .. cp_plugin.version
-          return nil, msg, CLUSTERING_SYNC_STATUS.PLUGIN_VERSION_INCOMPATIBLE
-        end
-      end
-    end
-  end
-
-  -- TODO: DAOs are not checked in any way at the moment. For example if plugin introduces a new DAO in
-  --       minor release and it has entities, that will most likely fail on data plane side, but is not
-  --       checked here.
-
-  return true, nil, CLUSTERING_SYNC_STATUS.NORMAL
+  return clustering_utils.check_configuration_compatibility(self, dp_plugin_map)
 end
 
 function _M:handle_cp_websocket()

--- a/kong/clustering/wrpc_control_plane.lua
+++ b/kong/clustering/wrpc_control_plane.lua
@@ -84,13 +84,13 @@ local function get_config_service(self)
 end
 
 
-function _M.new(initer)
+function _M.new(conf, cert_digest)
   local self = {
     clients = setmetatable({}, { __mode = "k", }),
     plugins_map = {},
 
-    conf = initer.conf,
-    cert_digest = initer.cert_digest,
+    conf = conf,
+    cert_digest = cert_digest,
   }
 
   return setmetatable(self, _MT)

--- a/kong/clustering/wrpc_control_plane.lua
+++ b/kong/clustering/wrpc_control_plane.lua
@@ -4,9 +4,6 @@ local _MT = { __index = _M, }
 
 local semaphore = require("ngx.semaphore")
 local ws_server = require("resty.websocket.server")
-local ssl = require("ngx.ssl")
-local ocsp = require("ngx.ocsp")
-local http = require("resty.http")
 local cjson = require("cjson.safe")
 local declarative = require("kong.db.declarative")
 local constants = require("kong.constants")
@@ -18,7 +15,6 @@ local type = type
 local pcall = pcall
 local pairs = pairs
 local ipairs = ipairs
-local tostring = tostring
 local ngx = ngx
 local ngx_log = ngx.log
 local cjson_encode = cjson.encode
@@ -47,7 +43,6 @@ local WS_OPTS = {
   timeout = constants.CLUSTERING_TIMEOUT,
   max_payload_len = MAX_PAYLOAD,
 }
-local OCSP_TIMEOUT = constants.CLUSTERING_OCSP_TIMEOUT
 local CLUSTERING_SYNC_STATUS = constants.CLUSTERING_SYNC_STATUS
 local _log_prefix = "[wrpc-clustering] "
 

--- a/kong/clustering/wrpc_control_plane.lua
+++ b/kong/clustering/wrpc_control_plane.lua
@@ -163,6 +163,7 @@ end
 
 
 _M.check_version_compatibility = clustering_utils.check_version_compatibility
+_M.check_configuration_compatibility = clustering_utils.check_configuration_compatibility
 
 
 function _M:handle_cp_websocket()

--- a/kong/clustering/wrpc_control_plane.lua
+++ b/kong/clustering/wrpc_control_plane.lua
@@ -10,6 +10,7 @@ local http = require("resty.http")
 local cjson = require("cjson.safe")
 local declarative = require("kong.db.declarative")
 local constants = require("kong.constants")
+local clustering_utils = require("kong.clustering.utils")
 local wrpc = require("kong.tools.wrpc")
 local string = string
 local setmetatable = setmetatable
@@ -30,8 +31,9 @@ local table_insert = table.insert
 local table_concat = table.concat
 
 local calculate_config_hash = require("kong.clustering.update_config").calculate_config_hash
-local extract_major_minor = require("kong.clustering.utils").extract_major_minor
-local validate_shared_cert = require("kong.clustering.utils").validate_shared_cert
+local extract_major_minor = clustering_utils.extract_major_minor
+local validate_shared_cert = clustering_utils.validate_shared_cert
+local plugins_list_to_map = clustering_utils.plugins_list_to_map
 
 local kong_dict = ngx.shared.kong
 local KONG_VERSION = kong.version
@@ -88,28 +90,6 @@ local function get_config_service(self)
   end
 
   return wrpc_config_service
-end
-
-
-local function plugins_list_to_map(plugins_list)
-  local versions = {}
-  for _, plugin in ipairs(plugins_list) do
-    local name = plugin.name
-    local version = plugin.version
-    local major, minor = extract_major_minor(plugin.version)
-
-    if major and minor then
-      versions[name] = {
-        major   = major,
-        minor   = minor,
-        version = version,
-      }
-
-    else
-      versions[name] = {}
-    end
-  end
-  return versions
 end
 
 

--- a/kong/clustering/wrpc_control_plane.lua
+++ b/kong/clustering/wrpc_control_plane.lua
@@ -10,7 +10,6 @@ local http = require("resty.http")
 local cjson = require("cjson.safe")
 local declarative = require("kong.db.declarative")
 local constants = require("kong.constants")
-local openssl_x509 = require("resty.openssl.x509")
 local wrpc = require("kong.tools.wrpc")
 local string = string
 local setmetatable = setmetatable

--- a/kong/clustering/wrpc_control_plane.lua
+++ b/kong/clustering/wrpc_control_plane.lua
@@ -162,14 +162,8 @@ function _M:push_config()
 end
 
 
-function _M:check_version_compatibility(dp_version, dp_plugin_map, log_suffix)
-  return clustering_utils.check_version_compatibility(self, dp_version, dp_plugin_map, log_suffix)
-end
+_M.check_version_compatibility = clustering_utils.check_version_compatibility
 
-
-function _M:check_configuration_compatibility(dp_plugin_map)
-  return clustering_utils.check_configuration_compatibility(self, dp_plugin_map)
-end
 
 function _M:handle_cp_websocket()
   local dp_id = ngx_var.arg_node_id

--- a/kong/clustering/wrpc_control_plane.lua
+++ b/kong/clustering/wrpc_control_plane.lua
@@ -117,6 +117,9 @@ function _M.new(parent)
   local self = {
     clients = setmetatable({}, { __mode = "k", }),
     plugins_map = {},
+
+    conf = parent.conf,
+    cert_digest = parent.cert_digest,
   }
 
   return setmetatable(self, _MT)

--- a/kong/clustering/wrpc_control_plane.lua
+++ b/kong/clustering/wrpc_control_plane.lua
@@ -113,13 +113,13 @@ local function plugins_list_to_map(plugins_list)
 end
 
 
-function _M.new(parent)
+function _M.new(initer)
   local self = {
     clients = setmetatable({}, { __mode = "k", }),
     plugins_map = {},
 
-    conf = parent.conf,
-    cert_digest = parent.cert_digest,
+    conf = initer.conf,
+    cert_digest = initer.cert_digest,
   }
 
   return setmetatable(self, _MT)

--- a/kong/clustering/wrpc_control_plane.lua
+++ b/kong/clustering/wrpc_control_plane.lua
@@ -30,6 +30,8 @@ local ngx_var = ngx.var
 local table_insert = table.insert
 local table_concat = table.concat
 
+local calculate_config_hash = require("kong.clustering.update_config").calculate_config_hash
+
 local kong_dict = ngx.shared.kong
 local KONG_VERSION = kong.version
 local ngx_DEBUG = ngx.DEBUG
@@ -158,7 +160,7 @@ function _M:export_deflated_reconfigure_payload()
     end
   end
 
-  local config_hash, hashes = self:calculate_config_hash(config_table)
+  local config_hash, hashes = calculate_config_hash(config_table)
   config_version = config_version + 1
 
   -- store serialized plugins map for troubleshooting purposes

--- a/kong/clustering/wrpc_control_plane.lua
+++ b/kong/clustering/wrpc_control_plane.lua
@@ -25,7 +25,7 @@ local ngx_var = ngx.var
 local table_insert = table.insert
 local table_concat = table.concat
 
-local calculate_config_hash = require("kong.clustering.update_config").calculate_config_hash
+local calculate_config_hash = require("kong.clustering.config_helper").calculate_config_hash
 local plugins_list_to_map = clustering_utils.plugins_list_to_map
 
 local kong_dict = ngx.shared.kong

--- a/kong/clustering/wrpc_data_plane.lua
+++ b/kong/clustering/wrpc_data_plane.lua
@@ -33,6 +33,9 @@ local _MT = { __index = _M, }
 function _M.new(parent)
   local self = {
     update_config = update_config.new(parent.conf),
+    conf = parent.conf,
+    cert = parent.cert,
+    cert_key = parent.cert_key,
   }
 
   return setmetatable(self, _MT)

--- a/kong/clustering/wrpc_data_plane.lua
+++ b/kong/clustering/wrpc_data_plane.lua
@@ -28,17 +28,14 @@ local DECLARATIVE_EMPTY_CONFIG_HASH = constants.DECLARATIVE_EMPTY_CONFIG_HASH
 local _M = {
   DPCP_CHANNEL_NAME = "DP-CP_config",
 }
+local _MT = { __index = _M, }
 
 function _M.new(parent)
   local self = {
     update_config = update_config.new(parent.conf),
   }
 
-  return setmetatable(self, {
-    __index = function(_, key)
-      return _M[key] or parent[key]
-    end,
-  })
+  return setmetatable(self, _MT)
 end
 
 

--- a/kong/clustering/wrpc_data_plane.lua
+++ b/kong/clustering/wrpc_data_plane.lua
@@ -31,7 +31,6 @@ local _M = {
 
 function _M.new(parent)
   local self = {
-    --declarative_config = declarative.new_config(parent.conf),
     update_config = update_config.new(parent.conf),
   }
 
@@ -189,7 +188,6 @@ function _M:communicate(premature)
           ngx_log(ngx_INFO, _log_prefix, "received config #", config_version, log_suffix)
 
           local pok, res
-          --pok, res, err = xpcall(self.update_config, debug.traceback, self, config_table, config_hash, hashes)
           pok, res, err = xpcall(self.update_config.execute, debug.traceback,
                                  self.update_config, config_table, config_hash, hashes)
           if pok then

--- a/kong/clustering/wrpc_data_plane.lua
+++ b/kong/clustering/wrpc_data_plane.lua
@@ -30,12 +30,12 @@ local _M = {
 }
 local _MT = { __index = _M, }
 
-function _M.new(initer)
+function _M.new(conf, cert, cert_key)
   local self = {
     update_config = update_config.new(initer.conf),
-    conf = initer.conf,
-    cert = initer.cert,
-    cert_key = initer.cert_key,
+    conf = conf,
+    cert = cert,
+    cert_key = cert_key,
   }
 
   return setmetatable(self, _MT)

--- a/kong/clustering/wrpc_data_plane.lua
+++ b/kong/clustering/wrpc_data_plane.lua
@@ -30,12 +30,12 @@ local _M = {
 }
 local _MT = { __index = _M, }
 
-function _M.new(parent)
+function _M.new(initer)
   local self = {
-    update_config = update_config.new(parent.conf),
-    conf = parent.conf,
-    cert = parent.cert,
-    cert_key = parent.cert_key,
+    update_config = update_config.new(initer.conf),
+    conf = initer.conf,
+    cert = initer.cert,
+    cert_key = initer.cert_key,
   }
 
   return setmetatable(self, _MT)

--- a/kong/clustering/wrpc_data_plane.lua
+++ b/kong/clustering/wrpc_data_plane.lua
@@ -32,7 +32,7 @@ local _MT = { __index = _M, }
 
 function _M.new(conf, cert, cert_key)
   local self = {
-    update_config = update_config.new(initer.conf),
+    update_config = update_config.new(conf),
     conf = conf,
     cert = cert,
     cert_key = cert_key,

--- a/kong/clustering/wrpc_data_plane.lua
+++ b/kong/clustering/wrpc_data_plane.lua
@@ -5,6 +5,7 @@ local declarative = require("kong.db.declarative")
 local protobuf = require("kong.tools.protobuf")
 local wrpc = require("kong.tools.wrpc")
 local constants = require("kong.constants")
+local update_config = require("kong.clustering.update_config")
 local assert = assert
 local setmetatable = setmetatable
 local type = type
@@ -30,7 +31,8 @@ local _M = {
 
 function _M.new(parent)
   local self = {
-    declarative_config = declarative.new_config(parent.conf),
+    --declarative_config = declarative.new_config(parent.conf),
+    update_config = update_config.new(parent.conf),
   }
 
   return setmetatable(self, {
@@ -187,7 +189,9 @@ function _M:communicate(premature)
           ngx_log(ngx_INFO, _log_prefix, "received config #", config_version, log_suffix)
 
           local pok, res
-          pok, res, err = xpcall(self.update_config, debug.traceback, self, config_table, config_hash, hashes)
+          --pok, res, err = xpcall(self.update_config, debug.traceback, self, config_table, config_hash, hashes)
+          pok, res, err = xpcall(self.update_config.execute, debug.traceback,
+                                 self.update_config, config_table, config_hash, hashes)
           if pok then
             last_config_version = config_version
             if not res then

--- a/kong/clustering/wrpc_data_plane.lua
+++ b/kong/clustering/wrpc_data_plane.lua
@@ -5,7 +5,7 @@ local declarative = require("kong.db.declarative")
 local protobuf = require("kong.tools.protobuf")
 local wrpc = require("kong.tools.wrpc")
 local constants = require("kong.constants")
-local update_config = require("kong.clustering.update_config")
+local config_helper = require("kong.clustering.config_helper")
 local assert = assert
 local setmetatable = setmetatable
 local type = type
@@ -32,7 +32,7 @@ local _MT = { __index = _M, }
 
 function _M.new(conf, cert, cert_key)
   local self = {
-    update_config = update_config.new(conf),
+    declarative_config = declarative.new_config(conf),
     conf = conf,
     cert = cert,
     cert_key = cert_key,
@@ -188,8 +188,8 @@ function _M:communicate(premature)
           ngx_log(ngx_INFO, _log_prefix, "received config #", config_version, log_suffix)
 
           local pok, res
-          pok, res, err = xpcall(self.update_config.execute, debug.traceback,
-                                 self.update_config, config_table, config_hash, hashes)
+          pok, res, err = xpcall(config_helper.update, debug.traceback,
+                                 self.declarative_config, config_table, config_hash, hashes)
           if pok then
             last_config_version = config_version
             if not res then

--- a/spec/01-unit/19-hybrid/02-clustering_spec.lua
+++ b/spec/01-unit/19-hybrid/02-clustering_spec.lua
@@ -1,4 +1,4 @@
-local calculate_config_hash = require("kong.clustering.update_config").calculate_config_hash
+local calculate_config_hash = require("kong.clustering.config_helper").calculate_config_hash
 
 
 describe("kong.clustering", function()

--- a/spec/01-unit/19-hybrid/02-clustering_spec.lua
+++ b/spec/01-unit/19-hybrid/02-clustering_spec.lua
@@ -1,10 +1,10 @@
-local clustering = require("kong.clustering")
+local calculate_config_hash = require("kong.clustering.update_config").calculate_config_hash
 
 
 describe("kong.clustering", function()
   describe(".calculate_config_hash()", function()
     it("calculating hash for nil errors", function()
-      local pok = pcall(clustering.calculate_config_hash, clustering, nil)
+      local pok = pcall(calculate_config_hash, nil)
       assert.falsy(pok)
     end)
 
@@ -12,7 +12,7 @@ describe("kong.clustering", function()
       local value = ngx.null
 
       for _ = 1, 10 do
-        local hash = clustering.calculate_config_hash(clustering, value)
+        local hash = calculate_config_hash(value)
         assert.is_string(hash)
         assert.equal("5bf07a8b7343015026657d1108d8206e", hash)
       end
@@ -21,7 +21,7 @@ describe("kong.clustering", function()
       assert.equal("5bf07a8b7343015026657d1108d8206e", correct)
 
       for _ = 1, 10 do
-        local hash = clustering.calculate_config_hash(clustering, value)
+        local hash = calculate_config_hash(value)
         assert.is_string(hash)
         assert.equal(correct, hash)
       end
@@ -31,7 +31,7 @@ describe("kong.clustering", function()
       local value = 10
 
       for _ = 1, 10 do
-        local hash = clustering.calculate_config_hash(clustering, value)
+        local hash = calculate_config_hash(value)
         assert.is_string(hash)
         assert.equal("d3d9446802a44259755d38e6d163e820", hash)
       end
@@ -40,7 +40,7 @@ describe("kong.clustering", function()
       assert.equal("d3d9446802a44259755d38e6d163e820", correct)
 
       for _ = 1, 10 do
-        local hash = clustering.calculate_config_hash(clustering, value)
+        local hash = calculate_config_hash(value)
         assert.is_string(hash)
         assert.equal(correct, hash)
       end
@@ -50,7 +50,7 @@ describe("kong.clustering", function()
       local value = 0.9
 
       for _ = 1, 10 do
-        local hash = clustering.calculate_config_hash(clustering, value)
+        local hash = calculate_config_hash(value)
         assert.is_string(hash)
         assert.equal("a894124cc6d5c5c71afe060d5dde0762", hash)
       end
@@ -59,7 +59,7 @@ describe("kong.clustering", function()
       assert.equal("a894124cc6d5c5c71afe060d5dde0762", correct)
 
       for _ = 1, 10 do
-        local hash = clustering.calculate_config_hash(clustering, value)
+        local hash = calculate_config_hash(value)
         assert.is_string(hash)
         assert.equal(correct, hash)
       end
@@ -69,7 +69,7 @@ describe("kong.clustering", function()
       local value = ""
 
       for _ = 1, 10 do
-        local hash = clustering.calculate_config_hash(clustering, value)
+        local hash = calculate_config_hash(value)
         assert.is_string(hash)
         assert.equal("d41d8cd98f00b204e9800998ecf8427e", hash)
       end
@@ -78,7 +78,7 @@ describe("kong.clustering", function()
       assert.equal("d41d8cd98f00b204e9800998ecf8427e", correct)
 
       for _ = 1, 10 do
-        local hash = clustering.calculate_config_hash(clustering, value)
+        local hash = calculate_config_hash(value)
         assert.is_string(hash)
         assert.equal(correct, hash)
       end
@@ -88,7 +88,7 @@ describe("kong.clustering", function()
       local value = "hello"
 
       for _ = 1, 10 do
-        local hash = clustering.calculate_config_hash(clustering, value)
+        local hash = calculate_config_hash(value)
         assert.is_string(hash)
         assert.equal("5d41402abc4b2a76b9719d911017c592", hash)
       end
@@ -97,7 +97,7 @@ describe("kong.clustering", function()
       assert.equal("5d41402abc4b2a76b9719d911017c592", correct)
 
       for _ = 1, 10 do
-        local hash = clustering.calculate_config_hash(clustering, value)
+        local hash = calculate_config_hash(value)
         assert.is_string(hash)
         assert.equal(correct, hash)
       end
@@ -107,7 +107,7 @@ describe("kong.clustering", function()
       local value = false
 
       for _ = 1, 10 do
-        local hash = clustering.calculate_config_hash(clustering, value)
+        local hash = calculate_config_hash(value)
         assert.is_string(hash)
         assert.equal("68934a3e9455fa72420237eb05902327", hash)
       end
@@ -116,7 +116,7 @@ describe("kong.clustering", function()
       assert.equal("68934a3e9455fa72420237eb05902327", correct)
 
       for _ = 1, 10 do
-        local hash = clustering.calculate_config_hash(clustering, value)
+        local hash = calculate_config_hash(value)
         assert.is_string(hash)
         assert.equal(correct, hash)
       end
@@ -126,7 +126,7 @@ describe("kong.clustering", function()
       local value = true
 
       for _ = 1, 10 do
-        local hash = clustering.calculate_config_hash(clustering, value)
+        local hash = calculate_config_hash(value)
         assert.is_string(hash)
         assert.equal("b326b5062b2f0e69046810717534cb09", hash)
       end
@@ -135,29 +135,29 @@ describe("kong.clustering", function()
       assert.equal("b326b5062b2f0e69046810717534cb09", correct)
 
       for _ = 1, 10 do
-        local hash = clustering.calculate_config_hash(clustering, value)
+        local hash = calculate_config_hash(value)
         assert.is_string(hash)
         assert.equal(correct, hash)
       end
     end)
 
     it("calculating hash for function errors", function()
-      local pok = pcall(clustering.calculate_config_hash, clustering, function() end)
+      local pok = pcall(calculate_config_hash, function() end)
       assert.falsy(pok)
     end)
 
     it("calculating hash for thread errors", function()
-      local pok = pcall(clustering.calculate_config_hash, clustering, coroutine.create(function() end))
+      local pok = pcall(calculate_config_hash, coroutine.create(function() end))
       assert.falsy(pok)
     end)
 
     it("calculating hash for userdata errors", function()
-      local pok = pcall(clustering.calculate_config_hash, clustering, io.tmpfile())
+      local pok = pcall(calculate_config_hash, io.tmpfile())
       assert.falsy(pok)
     end)
 
     it("calculating hash for cdata errors", function()
-      local pok = pcall(clustering.calculate_config_hash, clustering, require "ffi".new("char[6]", "foobar"))
+      local pok = pcall(calculate_config_hash, require "ffi".new("char[6]", "foobar"))
       assert.falsy(pok)
     end)
 
@@ -165,13 +165,13 @@ describe("kong.clustering", function()
       local value = {}
 
       for _ = 1, 10 do
-        local hash = clustering.calculate_config_hash(clustering, value)
+        local hash = calculate_config_hash(value)
         assert.is_string(hash)
         assert.equal("aaf38faf0b5851d711027bb4d812d50d", hash)
       end
 
       for _ = 1, 10 do
-        local hash = clustering.calculate_config_hash(clustering, value)
+        local hash = calculate_config_hash(value)
         assert.is_string(hash)
         assert.equal("aaf38faf0b5851d711027bb4d812d50d", hash)
       end
@@ -199,10 +199,10 @@ describe("kong.clustering", function()
         value.consumers[i] = { username = "user-" .. tostring(i) }
       end
 
-      local h = clustering.calculate_config_hash(clustering, value)
+      local h = calculate_config_hash(value)
 
       for _ = 1, 10 do
-        local hash = clustering.calculate_config_hash(clustering, value)
+        local hash = calculate_config_hash(value)
         assert.is_string(hash)
         assert.equal("cb83c48d5b2932d1bc9d13672b433365", hash)
         assert.equal(h, hash)
@@ -216,7 +216,7 @@ describe("kong.clustering", function()
         local value = {}
 
         for _ = 1, 10 do
-          local hash, hashes = clustering.calculate_config_hash(clustering, value)
+          local hash, hashes = calculate_config_hash(value)
           assert.is_string(hash)
           assert.equal("aaf38faf0b5851d711027bb4d812d50d", hash)
           assert.is_table(hashes)
@@ -239,7 +239,7 @@ describe("kong.clustering", function()
         }
 
         for _ = 1, 10 do
-          local hash, hashes = clustering.calculate_config_hash(clustering, value)
+          local hash, hashes = calculate_config_hash(value)
           assert.is_string(hash)
           assert.equal("768533baebe6e0d46de8d5f8a0c05bf0", hash)
           assert.is_table(hashes)
@@ -259,7 +259,7 @@ describe("kong.clustering", function()
         }
 
         for _ = 1, 10 do
-          local hash, hashes = clustering.calculate_config_hash(clustering, value)
+          local hash, hashes = calculate_config_hash(value)
           assert.is_string(hash)
           assert.equal("6c5fb69169a0fabb24dcfa3a5d7a14b0", hash)
           assert.is_table(hashes)


### PR DESCRIPTION
### Summary

DP/CP's code is too complex and not human readable, it is hard to understand the callback workflows.

This PR separates the logic of `update_config`, moves the code into an isolated file,
and also de-coupled dp/cp modules.

### Full changelog

* separates the logic of `update_config` into `config_helper.lua`
* do not use `self` to mimic oop
* remove duplicated functions `extract_major_minor` and `validate_shared_cert` in wrpc_cp
* add many functions in `utils.lua`
* update config hash test case


