### PR TITLE
refactor(wrpc) Refactor wRPC proto file process

### DIFF
--- a/kong-2.8.0-0.rockspec
+++ b/kong-2.8.0-0.rockspec
@@ -143,7 +143,8 @@ build = {
     ["kong.tools.uri"] = "kong/tools/uri.lua",
     ["kong.tools.kong-lua-sandbox"] = "kong/tools/kong-lua-sandbox.lua",
     ["kong.tools.protobuf"] = "kong/tools/protobuf.lua",
-    ["kong.tools.wrpc"] = "kong/tools/wrpc.lua",
+    ["kong.tools.wrpc"] = "kong/tools/wrpc/init.lua",
+    ["kong.tools.wrpc.proto"] = "kong/tools/wrpc/proto.lua",
     ["kong.tools.channel"] = "kong/tools/channel.lua",
 
     ["kong.runloop.handler"] = "kong/runloop/handler.lua",

--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -220,7 +220,7 @@ function _M:export_deflated_reconfigure_payload()
 
   -- store serialized plugins map for troubleshooting purposes
   local shm_key_name = "clustering:cp_plugins_configured:worker_" .. ngx.worker.id()
-  kong_dict:set(shm_key_name, cjson_encode(self.plugins_configured));
+  kong_dict:set(shm_key_name, cjson_encode(self.plugins_configured))
   ngx_log(ngx_DEBUG, "plugin configuration map key: " .. shm_key_name .. " configuration: ", kong_dict:get(shm_key_name))
 
   local config_hash, hashes = self:calculate_config_hash(config_table)

--- a/kong/clustering/wrpc_control_plane.lua
+++ b/kong/clustering/wrpc_control_plane.lua
@@ -164,7 +164,7 @@ function _M:export_deflated_reconfigure_payload()
 
   -- store serialized plugins map for troubleshooting purposes
   local shm_key_name = "clustering:cp_plugins_configured:worker_" .. ngx.worker.id()
-  kong_dict:set(shm_key_name, cjson_encode(self.plugins_configured));
+  kong_dict:set(shm_key_name, cjson_encode(self.plugins_configured))
 
   local service = get_config_service(self)
   self.config_call_rpc, self.config_call_args = assert(service:encode_args("ConfigService.SyncConfig", {

--- a/kong/clustering/wrpc_control_plane.lua
+++ b/kong/clustering/wrpc_control_plane.lua
@@ -61,7 +61,7 @@ end
 local function get_config_service(self)
   if not wrpc_config_service then
     wrpc_config_service = wrpc_proto.new()
-    wrpc_config_service:import_proto("kong.services.config.v1.config")
+    wrpc_config_service:import("kong.services.config.v1.config")
 
     wrpc_config_service:set_handler("ConfigService.PingCP", function(peer, data)
       local client = self.clients[peer.conn]

--- a/kong/clustering/wrpc_control_plane.lua
+++ b/kong/clustering/wrpc_control_plane.lua
@@ -11,6 +11,7 @@ local declarative = require("kong.db.declarative")
 local constants = require("kong.constants")
 local openssl_x509 = require("resty.openssl.x509")
 local wrpc = require("kong.tools.wrpc")
+local wrpc_proto = require("kong.tools.wrpc.proto")
 local string = string
 local setmetatable = setmetatable
 local type = type
@@ -59,8 +60,8 @@ end
 
 local function get_config_service(self)
   if not wrpc_config_service then
-    wrpc_config_service = wrpc.new_service()
-    wrpc_config_service:add("kong.services.config.v1.config")
+    wrpc_config_service = wrpc_proto.new()
+    wrpc_config_service:import_proto("kong.services.config.v1.config")
 
     wrpc_config_service:set_handler("ConfigService.PingCP", function(peer, data)
       local client = self.clients[peer.conn]

--- a/kong/clustering/wrpc_data_plane.lua
+++ b/kong/clustering/wrpc_data_plane.lua
@@ -57,7 +57,7 @@ local wrpc_config_service
 local function get_config_service()
   if not wrpc_config_service then
     wrpc_config_service = wrpc_proto.new()
-    wrpc_config_service:import_proto("kong.services.config.v1.config")
+    wrpc_config_service:import("kong.services.config.v1.config")
     wrpc_config_service:set_handler("ConfigService.SyncConfig", function(peer, data)
       if peer.config_semaphore then
         if data.config.plugins then

--- a/kong/clustering/wrpc_data_plane.lua
+++ b/kong/clustering/wrpc_data_plane.lua
@@ -5,6 +5,7 @@ local declarative = require("kong.db.declarative")
 local protobuf = require("kong.tools.protobuf")
 local wrpc = require("kong.tools.wrpc")
 local constants = require("kong.constants")
+local wrpc_proto = require("kong.tools.wrpc.proto")
 local assert = assert
 local setmetatable = setmetatable
 local type = type
@@ -55,8 +56,8 @@ end
 local wrpc_config_service
 local function get_config_service()
   if not wrpc_config_service then
-    wrpc_config_service = wrpc.new_service()
-    wrpc_config_service:add("kong.services.config.v1.config")
+    wrpc_config_service = wrpc_proto.new()
+    wrpc_config_service:import_proto("kong.services.config.v1.config")
     wrpc_config_service:set_handler("ConfigService.SyncConfig", function(peer, data)
       if peer.config_semaphore then
         if data.config.plugins then

--- a/kong/plugins/grpc-gateway/deco.lua
+++ b/kong/plugins/grpc-gateway/deco.lua
@@ -87,7 +87,8 @@ local function get_proto_info(fname)
 
   info = {}
 
-  grpc_tools.new():each_method(fname, function(parsed, srvc, mthd)
+  local grpc_tools_instance = grpc_tools.new()
+  grpc_tools_instance:each_method(fname, function(parsed, srvc, mthd)
     local options_bindings =  {
       safe_access(mthd, "options", "options", "google.api.http"),
       safe_access(mthd, "options", "options", "google.api.http", "additional_bindings")

--- a/kong/plugins/grpc-gateway/deco.lua
+++ b/kong/plugins/grpc-gateway/deco.lua
@@ -87,7 +87,7 @@ local function get_proto_info(fname)
 
   info = {}
 
-  grpc_tools.each_method(fname, function(parsed, srvc, mthd)
+  grpc_tools.new():each_method(fname, function(parsed, srvc, mthd)
     local options_bindings =  {
       safe_access(mthd, "options", "options", "google.api.http"),
       safe_access(mthd, "options", "options", "google.api.http", "additional_bindings")

--- a/kong/plugins/grpc-web/deco.lua
+++ b/kong/plugins/grpc-web/deco.lua
@@ -60,7 +60,7 @@ local function get_proto_info(fname)
   end
 
   info = {}
-  grpc_tools.each_method(fname, function(parsed, srvc, mthd)
+  grpc_tools.new():each_method(fname, function(parsed, srvc, mthd)
     info[("/%s.%s/%s"):format(parsed.package, srvc.name, mthd.name)] = {
       mthd.input_type,
       mthd.output_type,

--- a/kong/plugins/grpc-web/deco.lua
+++ b/kong/plugins/grpc-web/deco.lua
@@ -60,7 +60,8 @@ local function get_proto_info(fname)
   end
 
   info = {}
-  grpc_tools.new():each_method(fname, function(parsed, srvc, mthd)
+  local grpc_tools_instance = grpc_tools.new()
+  grpc_tools_instance:each_method(fname, function(parsed, srvc, mthd)
     info[("/%s.%s/%s"):format(parsed.package, srvc.name, mthd.name)] = {
       mthd.input_type,
       mthd.output_type,

--- a/kong/tools/grpc.lua
+++ b/kong/tools/grpc.lua
@@ -21,8 +21,7 @@ local ngx_DEBUG = ngx.DEBUG
 local epoch = date.epoch()
 
 local _M = {}
-_M.__index = _M
-setmetatable(_M, _M)
+local _MT = { __index = _M }
 
 
 local function safe_set_type_hook(typ, dec, enc)
@@ -77,7 +76,7 @@ function _M.new()
 
   return setmetatable({
     protoc_instance = protoc_instance,
-  }, _M)
+  }, _MT)
 end
 
 function _M:addpath(path)

--- a/kong/tools/grpc.lua
+++ b/kong/tools/grpc.lua
@@ -21,7 +21,7 @@ local ngx_DEBUG = ngx.DEBUG
 local epoch = date.epoch()
 
 local _M = {}
-local _MT = { __index = _M }
+local _MT = { __index = _M, }
 
 
 local function safe_set_type_hook(typ, dec, enc)

--- a/kong/tools/wrpc/init.lua
+++ b/kong/tools/wrpc/init.lua
@@ -208,7 +208,7 @@ end
 function wrpc_peer:send_encoded_call(rpc, payloads)
   self:send_payload({
     mtype = "MESSAGE_TYPE_RPC",
-    svc_id = rpc.service_id,
+    svc_id = rpc.svc_id,
     rpc_id = rpc.rpc_id,
     payload_encoding = "ENCODING_PROTO3",
     payloads = payloads,
@@ -269,7 +269,7 @@ end
 --- Could be an incoming method call or the response to a previous one.
 --- @param payload table decoded payload field from incoming `wrpc.WebsocketPayload` message
 function wrpc_peer:handle(payload)
-  local rpc = self.service:get_method(payload.svc_id, payload.rpc_id)
+  local rpc = self.service:get_rpc(payload.svc_id .. '.' .. payload.rpc_id)
   if not rpc then
     self:send_payload({
       mtype = "MESSAGE_TYPE_ERROR",
@@ -277,7 +277,7 @@ function wrpc_peer:handle(payload)
         etype = "ERROR_TYPE_INVALID_SERVICE",
         description = "Invalid service (or rpc)",
       },
-      srvc_id = payload.svc_id,
+      svc_id = payload.svc_id,
       rpc_id = payload.rpc_id,
       ack = payload.seq,
     })
@@ -322,7 +322,7 @@ function wrpc_peer:handle(payload)
             etype = "ERROR_TYPE_UNSPECIFIED",
             description = err,
           },
-          srvc_id = payload.svc_id,
+          svc_id = payload.svc_id,
           rpc_id = payload.rpc_id,
           ack = payload.seq,
         })
@@ -331,7 +331,7 @@ function wrpc_peer:handle(payload)
 
       self:send_payload({
         mtype = "MESSAGE_TYPE_RPC", -- MESSAGE_TYPE_RPC,
-        svc_id = rpc.service_id,
+        svc_id = rpc.svc_id,
         rpc_id = rpc.rpc_id,
         ack = payload.seq,
         payload_encoding = "ENCODING_PROTO3",
@@ -346,7 +346,7 @@ function wrpc_peer:handle(payload)
           etype = "ERROR_TYPE_INVALID_RPC",   -- invalid here, not in the definition
           description = "Unhandled method",
         },
-        srvc_id = payload.svc_id,
+        svc_id = payload.svc_id,
         rpc_id = payload.rpc_id,
         ack = payload.seq,
       })

--- a/kong/tools/wrpc/init.lua
+++ b/kong/tools/wrpc/init.lua
@@ -1,7 +1,6 @@
 local new_tab = require "table.new"
 local pb = require "pb"
 local semaphore = require "ngx.semaphore"
-local grpc = require "kong.tools.grpc"
 local channel = require "kong.tools.channel"
 
 local select = select
@@ -114,141 +113,6 @@ local function merge(a, b)
   return a
 end
 
-local function proto_searchpath(name)
-  return package.searchpath(name, "kong/include/?.proto;/usr/include/?.proto")
-end
-
---- definitions for the transport protocol
-local wrpc_proto
-
-
-local wrpc_service = {}
-wrpc_service.__index = wrpc_service
-
-
---- a `service` object holds a set of methods defined
---- in .proto files
-function wrpc.new_service()
-  if not wrpc_proto then
-    local wrpc_protofname = assert(proto_searchpath("wrpc.wrpc"))
-    wrpc_proto = assert(grpc.each_method(wrpc_protofname))
-  end
-
-  return setmetatable({
-    methods = {},
-  }, wrpc_service)
-end
-
---- Loads the methods from a .proto file.
---- There can be more than one file, and any number of
---- service definitions.
-function wrpc_service:add(service_name)
-  local annotations = {
-    service = {},
-    rpc = {},
-  }
-  local service_fname = assert(proto_searchpath(service_name))
-  local proto_f = assert(io.open(service_fname))
-  local scope_name = ""
-
-  for line in proto_f:lines() do
-    local annotation = line:match("//%s*%+wrpc:%s*(.-)%s*$")
-    if annotation then
-      local nextline = proto_f:read("*l")
-      local keyword, identifier = nextline:match("^%s*(%a+)%s+(%w+)")
-      if keyword and identifier then
-
-        if keyword == "service" then
-          scope_name = identifier;
-
-        elseif keyword == "rpc" then
-          identifier = scope_name .. "." .. identifier
-        end
-
-        local type_annotations = annotations[keyword]
-        if type_annotations then
-          local tag_key, tag_value = annotation:match("^%s*(%S-)=(%S+)%s*$")
-          if tag_key and tag_value then
-            tag_value = tag_value
-            local tags = type_annotations[identifier] or {}
-            type_annotations[identifier] = tags
-            tags[tag_key] = tag_value
-          end
-        end
-      end
-    end
-  end
-  proto_f:close()
-
-  grpc.each_method(service_fname, function(_, srvc, mthd)
-    assert(srvc.name)
-    assert(mthd.name)
-    local rpc_name = srvc.name .. "." .. mthd.name
-
-    local service_id = assert(annotations.service[srvc.name] and annotations.service[srvc.name]["service-id"])
-    local rpc_id = assert(annotations.rpc[rpc_name] and annotations.rpc[rpc_name]["rpc-id"])
-    local rpc = {
-      name = rpc_name,
-      service_id = tonumber(service_id),
-      rpc_id = tonumber(rpc_id),
-      input_type = mthd.input_type,
-      output_type = mthd.output_type,
-    }
-    self.methods[service_id .. ":" .. rpc_id] = rpc
-    self.methods[rpc_name] = rpc
-  end, true)
-end
-
---- returns the method defintion given either:
---- pair of IDs (service, rpc) or
---- rpc name as "<service_name>.<rpc_name>"
-function wrpc_service:get_method(srvc_id, rpc_id)
-  local rpc_name
-  if type(srvc_id) == "string" and rpc_id == nil then
-    rpc_name = srvc_id
-  else
-    rpc_name = tostring(srvc_id) .. ":" .. tostring(rpc_id)
-  end
-
-  return self.methods[rpc_name]
-end
-
---- sets a service handler for the givern rpc method
---- @param rpc_name string Full name of the rpc method
---- @param handler function Function called to handle the rpc method.
---- @param response_handler function Fallback function called to handle responses.
-function wrpc_service:set_handler(rpc_name, handler, response_handler)
-  local rpc = self:get_method(rpc_name)
-  if not rpc then
-    return nil, string.format("unknown method %q", rpc_name)
-  end
-
-  rpc.handler = handler
-  rpc.response_handler = response_handler
-  return rpc
-end
-
-
---- Part of wrpc_peer:call()
---- If calling the same method with the same args several times,
---- (to the same or different peers), this method returns the
---- invariant part, so it can be cached to reduce encoding overhead
-function wrpc_service:encode_args(name, ...)
-  local rpc = self:get_method(name)
-  if not rpc then
-    return nil, string.format("unknown method %q", name)
-  end
-
-  local num_args = select('#', ...)
-  local payloads = new_tab(num_args, 0)
-  for i = 1, num_args do
-    payloads[i] = assert(pb.encode(rpc.input_type, select(i, ...)))
-  end
-
-  return rpc, payloads
-end
-
-
 local wrpc_peer = {
   encode = pb.encode,
   decode = pb.decode,
@@ -260,6 +124,9 @@ local function is_wsclient(conn)
 end
 
 --- a `peer` object holds a (websocket) connection and a service.
+--- @param conn table WebSocket connection to use.
+--- @param service table Proto object that holds Serivces the connection supports.
+--- @param opts table Extra options.
 function wrpc.new_peer(conn, service, opts)
   opts = opts or {}
   return setmetatable(merge({

--- a/kong/tools/wrpc/init.lua
+++ b/kong/tools/wrpc/init.lua
@@ -1,4 +1,3 @@
-local new_tab = require "table.new"
 local pb = require "pb"
 local semaphore = require "ngx.semaphore"
 local channel = require "kong.tools.channel"

--- a/kong/tools/wrpc/proto.lua
+++ b/kong/tools/wrpc/proto.lua
@@ -49,7 +49,7 @@ function _M:parse_annotations(proto_f)
     if keyword == "service" then
       name = identifier
       id_tag_name = "service-id"
-      service = identifier;
+      service = identifier
       ids = svc_ids
 
     elseif keyword == "rpc" then

--- a/kong/tools/wrpc/proto.lua
+++ b/kong/tools/wrpc/proto.lua
@@ -1,0 +1,144 @@
+local pb = require "pb"
+local grpc = require "kong.tools.grpc"
+
+local grpc_new = grpc.new
+local pb_encode = pb.encode
+
+local _M = {}
+_M.__index = _M
+setmetatable(_M, _M)
+
+local wrpc_proto_name = "wrpc.wrpc"
+
+local default_proto_path = { "kong/include/", "/usr/include/" }
+
+local function parse_annotation(annotation)
+    local ret = {}
+    for kv_pair in annotation:gmatch("[^;]+=[^;]+") do
+        local key, value = kv_pair:match("^%s*(%S-)=(%S+)%s*$")
+        ret[key] = value
+    end
+    return ret
+end
+
+-- TODO: better way to do this
+-- +wrpc: key1=val1; key2=val2; ...
+-- service-id and rpc-id to get their id
+function _M:parse_annotations(proto_f)
+    local service_ids = self.service_ids
+    local rpc_ids = self.rpc_ids
+    local annotations = self.annotations
+
+    local service = ""
+    for line in proto_f:lines() do
+        local annotation = line:match("//%s*%+wrpc:%s*(.-)%s*$")
+        if annotation then
+            local nextline = proto_f:read("*l")
+            local keyword, identifier = nextline:match("^%s*(%a+)%s+(%w+)")
+
+            if keyword and identifier then
+                local name, id_tag_name, ids
+                if keyword == "service" then
+                    name = identifier
+                    id_tag_name = "service-id"
+                    service = identifier;
+                    ids = service_ids
+                elseif keyword == "rpc" then
+                    id_tag_name = "rpc-id"
+                    name = service .. '.' .. identifier
+                    ids = rpc_ids
+                else
+                    error("unknown type of protobuf identity")
+                end
+
+                annotations[name] = parse_annotation(annotation)
+                local id = assert(annotations[name][id_tag_name],
+                        keyword .. "with no id assigned")
+                ids[name] =
+                    assert(tonumber(id), keyword .. "'s id should be a number")
+            end
+        end
+    end
+end
+
+function _M.new()
+    local ret = setmetatable({
+        grpc_instance = grpc_new(),
+        service_ids = {},
+        rpc_ids = {},
+        annotations = {},
+        name_to_mthd = {},
+    }, _M)
+
+    ret:addpath(default_proto_path)
+    ret:import_proto(wrpc_proto_name)
+    return ret
+end
+
+function _M:addpath(proto_path)
+    self.grpc_instance:addpath(proto_path)
+end
+
+-- throw when error occurs
+-- pcall if you do not want it throw
+function _M:import_proto(name)
+    local fname = name:gsub('%.', '/') .. '.proto'
+
+    local fh = assert(self.grpc_instance:name_search(fname),
+        "module " .. name .. " cannot be found or cannot be opened")
+    self:parse_annotations(fh)
+    fh:close()
+
+    local service_ids = self.service_ids
+    local rpc_ids = self.rpc_ids
+    -- throwable
+    self.grpc_instance:each_method(fname,
+        function(_, srvc, mthd)
+        self.name_to_mthd[srvc.name .. "." .. mthd.name] = mthd
+        local srvc_id = assert(service_ids[srvc.name], "service " .. srvc.name .. " has no id assigned")
+        local rpc_id = assert(service_ids[mthd.name], "rpc " .. mthd.name .. " has no id assigned")
+        self.name_to_mthd[srvc_id .. "." .. rpc_id] = mthd
+    end
+    )
+end
+
+function _M:get_rpc(srvc, mthd)
+    return self.name_to_mthd[srvc..mthd]
+end
+
+--- sets a service handler for the givern rpc method
+--- @param rpc_name string Full name of the rpc method
+--- @param handler function Function called to handle the rpc method.
+--- @param response_handler function Fallback function called to handle responses.
+function _M:set_handler(rpc_name, handler, response_handler)
+  local rpc = self:get_method(rpc_name)
+  if not rpc then
+    return nil, string.format("unknown method %q", rpc_name)
+  end
+
+  rpc.handler = handler
+  rpc.response_handler = response_handler
+  return rpc
+end
+
+
+--- Part of wrpc_peer:call()
+--- If calling the same method with the same args several times,
+--- (to the same or different peers), this method returns the
+--- invariant part, so it can be cached to reduce encoding overhead
+function _M:encode_args(name, ...)
+  local rpc = self:get_method(name)
+  if not rpc then
+    return nil, string.format("unknown method %q", name)
+  end
+
+  local num_args = select('#', ...)
+  local payloads = table.new(num_args, 0)
+  for i = 1, num_args do
+    payloads[i] = assert(pb_encode(rpc.input_type, select(i, ...)))
+  end
+
+  return rpc, payloads
+end
+
+return _M

--- a/kong/tools/wrpc/proto.lua
+++ b/kong/tools/wrpc/proto.lua
@@ -14,12 +14,13 @@ local wrpc_proto_name = "wrpc.wrpc"
 local default_proto_path = { "kong/include/", "/usr/include/", }
 
 local function parse_annotation(annotation)
-    local parsed = {}
-    for kv_pair in annotation:gmatch("[^;]+=[^;]+") do
-        local key, value = kv_pair:match("^%s*(%S-)=(%S+)%s*$")
-        parsed[key] = value
-    end
-    return parsed
+  local parsed = {}
+  for kv_pair in annotation:gmatch("[^;]+=[^;]+") do
+    local key, value = kv_pair:match("^%s*(%S-)=(%S+)%s*$")
+    parsed[key] = value
+  end
+
+  return parsed
 end
 
 ---@TODO: better way to do this
@@ -27,60 +28,66 @@ end
 -- +wrpc: key1=val1; key2=val2; ...
 -- use key service-id and rpc-id to get IDs for service and rpc
 function _M:parse_annotations(proto_f)
-    local svc_ids = self.svc_ids
-    local rpc_ids = self.rpc_ids
-    local annotations = self.annotations
+  local svc_ids = self.svc_ids
+  local rpc_ids = self.rpc_ids
+  local annotations = self.annotations
 
-    local service = ""
-    for line in proto_f:lines() do
-        local annotation = line:match("//%s*%+wrpc:%s*(.-)%s*$")
-        if annotation then
-            local nextline = proto_f:read("*l")
-            local keyword, identifier = nextline:match("^%s*(%a+)%s+(%w+)")
-
-            if keyword and identifier then
-                local name, id_tag_name, ids
-                if keyword == "service" then
-                    name = identifier
-                    id_tag_name = "service-id"
-                    service = identifier;
-                    ids = svc_ids
-                elseif keyword == "rpc" then
-                    id_tag_name = "rpc-id"
-                    name = service .. '.' .. identifier
-                    ids = rpc_ids
-                else
-                    error("unknown type of protobuf identity")
-                end
-
-                annotations[name] = parse_annotation(annotation)
-                local id = assert(annotations[name][id_tag_name],
-                        keyword .. "with no id assigned")
-                ids[name] =
-                    assert(tonumber(id), keyword .. "'s id should be a number")
-            end
-        end
+  local service = ""
+  for line in proto_f:lines() do
+    local annotation = line:match("//%s*%+wrpc:%s*(.-)%s*$")
+    if not annotation then
+      goto continue
     end
+
+    local nextline = proto_f:read("*l")
+    local keyword, identifier = nextline:match("^%s*(%a+)%s+(%w+)")
+    if not keyword or not identifier then
+      goto continue
+    end
+
+    local name, id_tag_name, ids
+    if keyword == "service" then
+      name = identifier
+      id_tag_name = "service-id"
+      service = identifier;
+      ids = svc_ids
+
+    elseif keyword == "rpc" then
+      id_tag_name = "rpc-id"
+      name = service .. '.' .. identifier
+      ids = rpc_ids
+
+    else
+      error("unknown type of protobuf identity")
+    end
+
+    annotations[name] = parse_annotation(annotation)
+    local id = assert(annotations[name][id_tag_name],
+      keyword .. "with no id assigned")
+    ids[name] = assert(tonumber(id), keyword .. "'s id should be a number")
+  
+    ::continue::
+  end
 end
 
 function _M.new()
-    local proto_instance = setmetatable({
-        grpc_instance = grpc_new(),
-        svc_ids = {},
-        rpc_ids = {},
-        annotations = {},
-        name_to_mthd = {},
-    }, _MT)
+  local proto_instance = setmetatable({
+    grpc_instance = grpc_new(),
+    svc_ids = {},
+    rpc_ids = {},
+    annotations = {},
+    name_to_mthd = {},
+  }, _MT)
 
-    proto_instance:addpath(default_proto_path)
-    proto_instance:import_proto(wrpc_proto_name)
-    return proto_instance
+  proto_instance:addpath(default_proto_path)
+  proto_instance:import(wrpc_proto_name)
+  return proto_instance
 end
 
 -- add searching path for proto files
 ---@param proto_path (string or table) path to search proto files in
 function _M:addpath(proto_path)
-    self.grpc_instance:addpath(proto_path)
+  self.grpc_instance:addpath(proto_path)
 end
 
 -- import wrpc proto
@@ -88,33 +95,35 @@ end
 -- throw when error occurs
 -- pcall if you do not want it throw
 ---@param name(string) name for prototype. a.b.c will be found at a/b/c.proto
-function _M:import_proto(name)
-    local fname = name:gsub('%.', '/') .. '.proto'
+function _M:import(name)
+  local fname = name:gsub('%.', '/') .. '.proto'
 
-    local fh = assert(self.grpc_instance:name_search(fname),
-        "module " .. name .. " cannot be found or cannot be opened")
-    self:parse_annotations(fh)
-    fh:close()
+  local fh = assert(self.grpc_instance:get_proto_file(fname),
+    "module " .. name .. " cannot be found or cannot be opened")
+  self:parse_annotations(fh)
+  fh:close()
 
-    local svc_ids = self.svc_ids
-    local rpc_ids = self.rpc_ids
-    -- throwable
-    self.grpc_instance:each_method(fname,
-        function(_, srvc, mthd)
-        self.name_to_mthd[srvc.name .. "." .. mthd.name] = mthd
-        local svc_id = assert(svc_ids[srvc.name], "service " .. srvc.name .. " has no id assigned")
-        local rpc_id = assert(rpc_ids[srvc.name .. '.' .. mthd.name], "rpc " .. mthd.name .. " has no id assigned")
-        self.name_to_mthd[svc_id .. "." .. rpc_id] = mthd
-        mthd.svc_id = svc_id
-        mthd.rpc_id = rpc_id
+  local svc_ids = self.svc_ids
+  local rpc_ids = self.rpc_ids
+  -- throwable
+  self.grpc_instance:each_method(fname,
+    function(_, srvc, mthd)
+      local svc_id = assert(svc_ids[srvc.name], "service " .. srvc.name .. " has no id assigned")
+      local rpc_id = assert(rpc_ids[srvc.name .. '.' .. mthd.name], "rpc " .. mthd.name .. " has no id assigned")
+
+      mthd.svc_id = svc_id
+      mthd.rpc_id = rpc_id
+
+      self.name_to_mthd[srvc.name .. "." .. mthd.name] = mthd
+      self.name_to_mthd[svc_id .. "." .. rpc_id] = mthd
     end
-    )
+  )
 end
 
 -- get rpc object
 -- both service_name.rpc_name and 1.2(service_id.rpc_id supported
 function _M:get_rpc(rpc_name)
-    return self.name_to_mthd[rpc_name]
+  return self.name_to_mthd[rpc_name]
 end
 
 --- sets a service handler for the givern rpc method
@@ -129,9 +138,9 @@ function _M:set_handler(rpc_name, handler, response_handler)
 
   rpc.handler = handler
   rpc.response_handler = response_handler
+
   return rpc
 end
-
 
 --- Part of wrpc_peer:call()
 --- If calling the same method with the same args several times,

--- a/kong/tools/wrpc/proto.lua
+++ b/kong/tools/wrpc/proto.lua
@@ -96,7 +96,7 @@ function _M:import_proto(name)
         function(_, srvc, mthd)
         self.name_to_mthd[srvc.name .. "." .. mthd.name] = mthd
         local srvc_id = assert(service_ids[srvc.name], "service " .. srvc.name .. " has no id assigned")
-        local rpc_id = assert(service_ids[mthd.name], "rpc " .. mthd.name .. " has no id assigned")
+        local rpc_id = assert(rpc_ids[mthd.name], "rpc " .. mthd.name .. " has no id assigned")
         self.name_to_mthd[srvc_id .. "." .. rpc_id] = mthd
     end
     )

--- a/kong/tools/wrpc/proto.lua
+++ b/kong/tools/wrpc/proto.lua
@@ -21,9 +21,10 @@ local function parse_annotation(annotation)
     return ret
 end
 
--- TODO: better way to do this
+---@TODO: better way to do this
+-- Parse annotations in proto files with format:
 -- +wrpc: key1=val1; key2=val2; ...
--- service-id and rpc-id to get their id
+-- use key service-id and rpc-id to get IDs for service and rpc
 function _M:parse_annotations(proto_f)
     local svc_ids = self.svc_ids
     local rpc_ids = self.rpc_ids
@@ -75,12 +76,17 @@ function _M.new()
     return ret
 end
 
+-- add searching path for proto files
+---@param proto_path (string or table) path to search proto files in
 function _M:addpath(proto_path)
     self.grpc_instance:addpath(proto_path)
 end
 
+-- import wrpc proto
+-- search from default and user specified paths(addpath)
 -- throw when error occurs
 -- pcall if you do not want it throw
+---@param name(string) name for prototype. a.b.c will be found at a/b/c.proto
 function _M:import_proto(name)
     local fname = name:gsub('%.', '/') .. '.proto'
 
@@ -104,6 +110,8 @@ function _M:import_proto(name)
     )
 end
 
+-- get rpc object
+-- both service_name.rpc_name and 1.2(service_id.rpc_id supported
 function _M:get_rpc(rpc_name)
     return self.name_to_mthd[rpc_name]
 end

--- a/kong/tools/wrpc/proto.lua
+++ b/kong/tools/wrpc/proto.lua
@@ -8,7 +8,6 @@ local string_format = string.format
 
 local _M = {}
 local _MT = { __index = _M, }
-_M.__index = _M
 
 local wrpc_proto_name = "wrpc.wrpc"
 

--- a/spec/01-unit/22-grpc-utils_spec.lua
+++ b/spec/01-unit/22-grpc-utils_spec.lua
@@ -3,7 +3,7 @@ local grpc_tools = require "kong.tools.grpc"
 describe("grpc tools", function()
   it("visits service methods", function()
     local methods = {}
-    grpc_tools.each_method("helloworld.proto",
+    grpc_tools.new():each_method("helloworld.proto",
       function(parsed, service, method)
         methods[#methods + 1] = string.format("%s.%s", service.name, method.name)
       end)
@@ -15,7 +15,7 @@ describe("grpc tools", function()
 
   it("visits imported methods", function()
     local methods = {}
-    grpc_tools.each_method("direct_imports.proto",
+    grpc_tools.new():each_method("direct_imports.proto",
       function(parsed, service, method)
         methods[#methods + 1] = string.format("%s.%s", service.name, method.name)
       end, true)
@@ -28,7 +28,7 @@ describe("grpc tools", function()
 
   it("imports recursively", function()
     local methods = {}
-    grpc_tools.each_method("second_level_imports.proto",
+    grpc_tools.new():each_method("second_level_imports.proto",
       function(parsed, service, method)
         methods[#methods + 1] = string.format("%s.%s", service.name, method.name)
       end, true)

--- a/spec/01-unit/22-grpc-utils_spec.lua
+++ b/spec/01-unit/22-grpc-utils_spec.lua
@@ -3,7 +3,8 @@ local grpc_tools = require "kong.tools.grpc"
 describe("grpc tools", function()
   it("visits service methods", function()
     local methods = {}
-    grpc_tools.new():each_method("helloworld.proto",
+    local grpc_tools_instance = grpc_tools.new()
+    grpc_tools_instance:each_method("helloworld.proto",
       function(parsed, service, method)
         methods[#methods + 1] = string.format("%s.%s", service.name, method.name)
       end)
@@ -15,7 +16,8 @@ describe("grpc tools", function()
 
   it("visits imported methods", function()
     local methods = {}
-    grpc_tools.new():each_method("direct_imports.proto",
+    local grpc_tools_instance = grpc_tools.new()
+    grpc_tools_instance:each_method("direct_imports.proto",
       function(parsed, service, method)
         methods[#methods + 1] = string.format("%s.%s", service.name, method.name)
       end, true)
@@ -28,7 +30,8 @@ describe("grpc tools", function()
 
   it("imports recursively", function()
     local methods = {}
-    grpc_tools.new():each_method("second_level_imports.proto",
+    local grpc_tools_instance = grpc_tools.new()
+    grpc_tools_instance:each_method("second_level_imports.proto",
       function(parsed, service, method)
         methods[#methods + 1] = string.format("%s.%s", service.name, method.name)
       end, true)


### PR DESCRIPTION
The origin implementation of proto file searching is hacking with `searchpath`, and that implementation would fail to deal with `include` in a proto file that should be found outside the containing folder of that file.

What this PR does:
1. Extract proto related code into a separate module, and styling;
2. Rewrite implementation of annotation parsing;
3. Rewrite implementation of proto file searching.