### PR TITLE
chore(*) do not maintain fallbacks to luajit table goodies

### DIFF
--- a/kong/cluster_events/strategies/postgres.lua
+++ b/kong/cluster_events/strategies/postgres.lua
@@ -1,4 +1,5 @@
-local utils  = require "kong.tools.utils"
+local utils = require "kong.tools.utils"
+local new_tab = require "table.new"
 
 
 local fmt          = string.format
@@ -8,16 +9,6 @@ local error        = error
 local concat       = table.concat
 local tonumber     = tonumber
 local setmetatable = setmetatable
-
-
-local new_tab
-do
-  local ok
-  ok, new_tab = pcall(require, "table.new")
-  if not ok then
-    new_tab = function(narr, nrec) return {} end
-  end
-end
 
 
 local INSERT_QUERY = [[

--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -4,6 +4,7 @@ local utils = require "kong.tools.utils"
 local defaults = require "kong.db.strategies.connector".defaults
 local hooks = require "kong.hooks"
 local workspaces = require "kong.workspaces"
+local new_tab = require "table.new"
 
 
 local setmetatable = setmetatable
@@ -24,16 +25,6 @@ local run_hook     = hooks.run_hook
 
 
 local ERR          = ngx.ERR
-
-
-local new_tab
-do
-  local ok
-  ok, new_tab = pcall(require, "table.new")
-  if not ok then
-    new_tab = function() return {} end
-  end
-end
 
 
 local _M    = {}

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -2,6 +2,7 @@ local tablex       = require "pl.tablex"
 local pretty       = require "pl.pretty"
 local utils        = require "kong.tools.utils"
 local cjson        = require "cjson"
+local new_tab      = require "table.new"
 local is_reference = require "kong.pdk.vault".new().is_reference
 
 
@@ -39,18 +40,6 @@ Schema.__index     = Schema
 
 local _cache = {}
 local _workspaceable = {}
-
-
-local new_tab
-do
-  local ok
-  ok, new_tab = pcall(require, "table.new")
-  if not ok then
-    new_tab = function(narr, nrec)
-      return {}
-    end
-  end
-end
 
 
 local validation_errors = {

--- a/kong/db/strategies/cassandra/init.lua
+++ b/kong/db/strategies/cassandra/init.lua
@@ -1,6 +1,8 @@
 local iteration = require "kong.db.iteration"
 local cassandra = require "cassandra"
 local cjson = require "cjson"
+local new_tab = require "table.new"
+local clear_tab = require "table.clear"
 
 
 local fmt           = string.format
@@ -18,26 +20,6 @@ local get_phase     = ngx.get_phase
 local setmetatable  = setmetatable
 local encode_base64 = ngx.encode_base64
 local decode_base64 = ngx.decode_base64
-local new_tab
-local clear_tab
-do
-  local ok
-  ok, new_tab = pcall(require, "table.new")
-  if not ok then
-    new_tab = function(narr, nrec)
-      return {}
-    end
-  end
-
-  ok, clear_tab = pcall(require, "table.clear")
-  if not ok then
-    clear_tab = function (tab)
-      for k, _ in pairs(tab) do
-        tab[k] = nil
-      end
-    end
-  end
-end
 
 
 local APPLIED_COLUMN = "[applied]"

--- a/kong/db/strategies/cassandra/tags.lua
+++ b/kong/db/strategies/cassandra/tags.lua
@@ -1,20 +1,9 @@
 local cassandra = require "cassandra"
+local new_tab = require "table.new"
 
 
 local encode_base64 = ngx.encode_base64
 local decode_base64 = ngx.decode_base64
-
-
-local new_tab
-do
-  local ok
-  ok, new_tab = pcall(require, "table.new")
-  if not ok then
-    new_tab = function(narr, nrec)
-      return {}
-    end
-  end
-end
 
 
 local CQL_TAG =  [[

--- a/kong/db/strategies/postgres/init.lua
+++ b/kong/db/strategies/postgres/init.lua
@@ -3,6 +3,8 @@ local json          = require "pgmoon.json"
 local cjson         = require "cjson"
 local cjson_safe    = require "cjson.safe"
 local pl_tablex     = require "pl.tablex"
+local new_tab       = require "table.new"
+local clear_tab     = require "table.clear"
 
 
 local kong          = kong
@@ -37,30 +39,6 @@ local log           = ngx.log
 local NOTICE        = ngx.NOTICE
 local LIMIT         = {}
 local UNIQUE        = {}
-
-
-local new_tab
-local clear_tab
-
-
-do
-  local pcall = pcall
-  local ok
-
-  ok, new_tab = pcall(require, "table.new")
-  if not ok then
-    new_tab = function () return {} end
-  end
-
-  ok, clear_tab = pcall(require, "table.clear")
-  if not ok then
-    clear_tab = function (tab)
-      for k, _ in pairs(tab) do
-        tab[k] = nil
-      end
-    end
-  end
-end
 
 
 local function noop(...)

--- a/kong/pdk/table.lua
+++ b/kong/pdk/table.lua
@@ -3,53 +3,37 @@
 -- @module kong.table
 
 
-local new_tab
-local clear_tab
-do
-  ---
-  -- Returns a table with a pre-allocated number of slots in its array and hash
-  -- parts.
-  --
-  -- @function kong.table.new
-  -- @tparam[opt] number narr Specifies the number of slots to pre-allocate
-  -- in the array part.
-  -- @tparam[opt] number nrec Specifies the number of slots to pre-allocate in
-  -- the hash part.
-  -- @treturn table The newly created table.
-  -- @usage
-  -- local tab = kong.table.new(4, 4)
-  local ok
-  ok, new_tab = pcall(require, "table.new")
-  if not ok then
-    new_tab = function (narr, nrec) return {} end
-  end
+---
+-- Returns a table with a pre-allocated number of slots in its array and hash
+-- parts.
+--
+-- @function kong.table.new
+-- @tparam[opt] number narr Specifies the number of slots to pre-allocate
+-- in the array part.
+-- @tparam[opt] number nrec Specifies the number of slots to pre-allocate in
+-- the hash part.
+-- @treturn table The newly created table.
+-- @usage
+-- local tab = kong.table.new(4, 4)
+local new_tab = require "table.new"
 
-
-  ---
-  -- Clears all array and hash parts entries from a table.
-  --
-  -- @function kong.table.clear
-  -- @tparam table tab The table to be cleared.
-  -- @return Nothing.
-  -- @usage
-  -- local tab = {
-  --   "hello",
-  --   foo = "bar"
-  -- }
-  --
-  -- kong.table.clear(tab)
-  --
-  -- kong.log(tab[1]) -- nil
-  -- kong.log(tab.foo) -- nil
-  ok, clear_tab = pcall(require, "table.clear")
-  if not ok then
-    clear_tab = function (tab)
-      for k, _ in pairs(tab) do
-        tab[k] = nil
-      end
-    end
-  end
-end
+---
+-- Clears all array and hash parts entries from a table.
+--
+-- @function kong.table.clear
+-- @tparam table tab The table to be cleared.
+-- @return Nothing.
+-- @usage
+-- local tab = {
+--   "hello",
+--   foo = "bar"
+-- }
+--
+-- kong.table.clear(tab)
+--
+-- kong.log(tab[1]) -- nil
+-- kong.log(tab.foo) -- nil
+local clear_tab = require "table.clear"
 
 
 --- Merges the contents of two tables together, producing a new one.

--- a/kong/router.lua
+++ b/kong/router.lua
@@ -3,6 +3,7 @@ local ipmatcher     = require "resty.ipmatcher"
 local lrucache      = require "resty.lrucache"
 local isempty       = require "table.isempty"
 local clone         = require "table.clone"
+local clear         = require "table.clear"
 local bit           = require "bit"
 
 
@@ -123,21 +124,10 @@ do
 end
 
 
-local clear_tab
 local log
 do
   log = function(lvl, ...)
     ngx_log(lvl, "[router] ", ...)
-  end
-
-  local ok
-  ok, clear_tab = pcall(require, "table.clear")
-  if not ok then
-    clear_tab = function(tab)
-      for k in pairs(tab) do
-        tab[k] = nil
-      end
-    end
   end
 end
 
@@ -1156,7 +1146,7 @@ do
     -- run cached matcher
     local match_rules = route_t.match_rules
     if type(matchers[match_rules]) == "function" then
-      clear_tab(ctx.matches)
+      clear(ctx.matches)
       return matchers[match_rules](route_t, ctx)
     end
 
@@ -1172,7 +1162,7 @@ do
 
     matchers[route_t.match_rules] = function(route_t, ctx)
       -- clear matches context for this try on this route
-      clear_tab(ctx.matches)
+      clear(ctx.matches)
 
       for i = 1, matchers_set[0] do
         if not matchers_set[i](route_t, ctx) then
@@ -1677,7 +1667,7 @@ function _M.new(routes, cache, cache_neg)
 
     local req_category = 0x00
 
-    clear_tab(hits)
+    clear(hits)
 
     -- router, router, which of these routes is the fairest?
     --

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -507,17 +507,7 @@ do
   local floor = math.floor
   local max = math.max
 
-  local ok, is_array_fast = pcall(require, "table.isarray")
-  if not ok then
-    is_array_fast = function(t)
-      for k in pairs(t) do
-          if type(k) ~= "number" or floor(k) ~= k then
-            return false
-          end
-      end
-      return true
-    end
-  end
+  local is_array_fast = require "table.isarray"
 
   local is_array_strict = function(t)
     local m, c = 0, 0
@@ -614,16 +604,7 @@ end
 
 
 do
-  local ok, clone = pcall(require, "table.clone")
-  if not ok then
-    clone = function(t)
-      local copy = {}
-      for key, value in pairs(t) do
-        copy[key] = value
-      end
-      return copy
-    end
-  end
+  local clone = require "table.clone"
 
   --- Copies a table into a new table.
   -- neither sub tables nor metatables will be copied.

--- a/kong/tools/wrpc.lua
+++ b/kong/tools/wrpc.lua
@@ -1,4 +1,4 @@
-require "table.new"
+local new_tab = require "table.new"
 local pb = require "pb"
 local semaphore = require "ngx.semaphore"
 local grpc = require "kong.tools.grpc"
@@ -240,7 +240,7 @@ function wrpc_service:encode_args(name, ...)
   end
 
   local num_args = select('#', ...)
-  local payloads = table.new(num_args, 0)
+  local payloads = new_tab(num_args, 0)
   for i = 1, num_args do
     payloads[i] = assert(pb.encode(rpc.input_type, select(i, ...)))
   end


### PR DESCRIPTION
### Summary

OpenResty only supports LuaJIT these days and things like `require "table.new"` and friends can be considered to be there. This commit just removes the fallback Lua functions usually associated with them. So basically cleans our code on that.