### PR TITLE
tests(clustering) incorrect pattern and change to print

### DIFF
--- a/spec/02-integration/07-sdk/03-cluster_spec.lua
+++ b/spec/02-integration/07-sdk/03-cluster_spec.lua
@@ -1,6 +1,6 @@
 local helpers = require("spec.helpers")
 
-local uuid_pattern = "^" .. ("%x"):rep(11) .. "%-" .. ("%x"):rep(4) .. "%-"
+local uuid_pattern = "^" .. ("%x"):rep(8) .. "%-" .. ("%x"):rep(4) .. "%-"
                          .. ("%x"):rep(4) .. "%-" .. ("%x"):rep(4) .. "%-"
                          .. ("%x"):rep(12) .. "$"
 local fixtures_dp = {
@@ -14,7 +14,7 @@ fixtures_dp.http_mock.my_server_block = [[
 
       location = "/hello" {
         content_by_lua_block {
-          ngx.say(200, kong.cluster.get_id())
+          ngx.print(kong.cluster.get_id())
         }
       }
   }
@@ -32,7 +32,7 @@ fixtures_cp.http_mock.my_server_block = [[
 
       location = "/hello" {
         content_by_lua_block {
-          ngx.say(200, kong.cluster.get_id())
+          ngx.print(kong.cluster.get_id())
         }
       }
   }


### PR DESCRIPTION
The first part of UUID is not 11 but 8 hex digits. and it's because the incorrect argument of `ngx.say`.