### PR TITLE
chore(oauth2/session) do not db export authorization codes or sessions

### DIFF
--- a/kong/plugins/oauth2/daos.lua
+++ b/kong/plugins/oauth2/daos.lua
@@ -68,6 +68,7 @@ local oauth2_authorization_codes = {
   ttl = true,
   workspaceable = true,
   generate_admin_api = false,
+  db_export = false,
   fields = {
     { id = typedefs.uuid },
     { created_at = typedefs.auto_timestamp_s },

--- a/kong/plugins/session/daos.lua
+++ b/kong/plugins/session/daos.lua
@@ -7,6 +7,7 @@ return {
     name = "sessions",
     cache_key = { "session_id" },
     ttl = true,
+    db_export = false,
     fields = {
       { id = typedefs.uuid },
       { session_id = { type = "string", unique = true, required = true } },


### PR DESCRIPTION
### Summary

##### [chore(oauth2) do not db export authorization codes](https://github.com/Kong/kong/commit/17f0efa67aeaadbc4be4088e936fd8381f8bc6ee)

Authorization codes in general are short-lived, and exporting them is not needed.

##### [chore(session) do not db export sessions](https://github.com/Kong/kong/commit/fb6d6089bc1b899b70a28eae42157aee13cb2b8c)

Sessions are short-lived and not needed for exporting. It can be especially bad with enterprise if this exports sessions used for manager/developer portal to data planes.

These also make little sense on hybrid.