### PR TITLE
chore(cluster) Bump "reconfigure" event log level to info

### DIFF
--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -166,11 +166,11 @@ function _M:communicate(premature)
 
           if msg.type == "reconfigure" then
             if msg.timestamp then
-              ngx_log(ngx_DEBUG, _log_prefix, "received reconfigure frame from control plane with timestamp: ",
+              ngx_log(ngx_INFO, _log_prefix, "received reconfigure frame from control plane with timestamp: ",
                                  msg.timestamp, log_suffix)
 
             else
-              ngx_log(ngx_DEBUG, _log_prefix, "received reconfigure frame from control plane", log_suffix)
+              ngx_log(ngx_INFO, _log_prefix, "received reconfigure frame from control plane", log_suffix)
             end
 
             local config_table = assert(msg.config_table)


### PR DESCRIPTION
The dataplane receiving a configuration update from the controlplane is a significant event and worthy of note. This PR changes the log level from `debug` to `info`.

(It's possible that `notice` would be even more appropriate.)