### PR TITLE
feat(cmd)! remove support for declarative config in Lua format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,12 @@
 - The support for `legacy = true/false` attribute was removed from Kong schemas and
   Kong field schemas.
   [#8958](https://github.com/Kong/kong/pull/8958)
+- It is no longer possible to use a .lua format to import a declarative config from the `kong`
+  command-line tool, only json and yaml are supported. If your update procedure with kong involves
+  executing `kong config db_import config.lua`, please create a `config.json` or `config.yml` and
+  use that before upgrading.
+  [#8898](https://github.com/Kong/kong/pull/8898)
+
 
 #### Admin API
 

--- a/kong/api/routes/config.lua
+++ b/kong/api/routes/config.lua
@@ -10,13 +10,6 @@ local table = table
 local tostring = tostring
 
 
--- Do not accept Lua configurations from the Admin API
--- because it is Turing-complete.
-local accept = {
-  yaml = true,
-  json = true,
-}
-
 local _reports = {
   decl_fmt_version = false,
 }
@@ -89,7 +82,7 @@ return {
           end
         end
         entities, _, err_t, meta, new_hash =
-          dc:parse_string(config, nil, accept, old_hash)
+          dc:parse_string(config, nil, old_hash)
       end
 
       if not entities then

--- a/kong/cmd/config.lua
+++ b/kong/cmd/config.lua
@@ -11,13 +11,6 @@ local kong_yml = require "kong.templates.kong_yml"
 local DEFAULT_FILE = "./kong.yml"
 
 
-local accepted_formats = {
-  yaml = true,
-  json = true,
-  lua = true,
-}
-
-
 local function db_export(filename, conf)
   if pl_file.access_time(filename) then
     error(filename .. " already exists. Will not overwrite it.")
@@ -110,7 +103,7 @@ local function execute(args)
       log.deprecation("db_import of .lua files is deprecated; please convert your file into .yaml or .json")
     end
 
-    local entities, err, _, meta = dc:parse_file(filename, accepted_formats)
+    local entities, err, _, meta = dc:parse_file(filename)
     if not entities then
       error("Failed parsing:\n" .. err)
     end


### PR DESCRIPTION
For a while we accepted .lua declarative configurations via command-line only, but not on the admin API.

BREAKING CHANGE: Dropped support for loading declarative configuration in .lua format using the command-line tool

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Full changelog

* [Implement ...]
* [Add related tests]
* ...

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
