### PR TITLE
fix(ci): autodoc was passing when it should not have been

### DIFF
--- a/scripts/autodoc
+++ b/scripts/autodoc
@@ -82,7 +82,7 @@ rm -rf ./autodoc/output
 
 exit_code=$?
 
-if [ -n "${CI}" ]
+if [[ $exit_code -ne 0 ]]
 then
     exit $exit_code
 fi

--- a/scripts/autodoc
+++ b/scripts/autodoc
@@ -80,6 +80,13 @@ rm -rf ./autodoc/output
 ./autodoc/upgrading/generate.lua && \
 ./autodoc/pdk/generate.lua
 
+exit_code=$?
+
+if [ -n "${CI}" ]
+then
+    exit $exit_code
+fi
+
 if [ -z "$DOCS_REPO" ] || [ -z "$DOCS_VERSION" ]
 then
     echo


### PR DESCRIPTION
### Summary

the autodoc CI test is passing when it should not be ( https://github.com/Kong/kong/runs/6726254426?check_suite_focus=true#step:7:15 ).

This PR makes it fail "correctly" aka if the autodoc fails CI will fail as intended

I'll leave the exercise to other to make the documentation fixes required to pass this PR.