### PR TITLE
tests(fixtures): fortify service creation

### DIFF
--- a/spec/fixtures/balancer_utils.lua
+++ b/spec/fixtures/balancer_utils.lua
@@ -330,6 +330,7 @@ do
     local route_host = gen_sym("host")
     local sproto = opts.service_protocol or opts.route_protocol or "http"
     local rproto = opts.route_protocol or "http"
+    local sport = rproto == "tcp" and 9100 or 80
 
     local rpaths = {
       "/",
@@ -338,12 +339,13 @@ do
 
     bp.services:insert({
       id = service_id,
-      url = sproto .. "://" .. upstream_name .. ":" .. (rproto == "tcp" and 9100 or 80),
+      host = upstream_name,
+      port = sport,
+      protocol = sproto,
       read_timeout = opts.read_timeout,
       write_timeout = opts.write_timeout,
       connect_timeout = opts.connect_timeout,
       retries = opts.retries,
-      protocol = sproto,
     })
     bp.routes:insert({
       id = route_id,


### PR DESCRIPTION
This is an attempt to (maybe) address a mysterious test failure:

https://github.com/Kong/kong/runs/6729326547?check_suite_focus=true

```
./spec/fixtures/balancer_utils.lua:333: Error 400: {"code":2,"message":"schema violation (host: required field missing)","fields":{"host":"required field missing"},"name":"schema violation"}
stack traceback:
	./spec/fixtures/blueprints.lua:21: in function 'insert'
	./spec/fixtures/balancer_utils.lua:333: in function 'add_api'
	...tion/05-proxy/10-balancer/03-consistent-hashing_spec.lua:207: in function 'test_with_uri'
	...tion/05-proxy/10-balancer/03-consistent-hashing_spec.lua:393: in function <...tion/05-proxy/10-balancer/03-consistent-hashing_spec.lua:388>
```

This code uses blueprints to create a service object, via the `url` shorthand. The value of `upstream_name` in this context is auto-generated by the fixture. I suspect that under _some_ weird circumstance, the generated url is not parse-able, leaving `service.host` empty.

This changes the behavior such that we set all the fields explicitly instead of using `service.url`. Hopefully if this condition pops up again, we'll at least get a more meaningful error.