### PR TITLE
fix(session): add `cookie_persistent` to ensure is lifetime is applied

### DIFF
--- a/kong/plugins/session/schema.lua
+++ b/kong/plugins/session/schema.lua
@@ -55,6 +55,7 @@ return {
           { cookie_httponly = { type = "boolean", default = true } },
           { cookie_secure = { type = "boolean", default = true } },
           { cookie_discard = { type = "number", default = 10 } },
+          { cookie_persistent = { type = "boolean", default = false } },
           {
             storage = {
               required = false,

--- a/kong/plugins/session/session.lua
+++ b/kong/plugins/session/session.lua
@@ -15,15 +15,16 @@ local function get_opts(conf)
     secret  = conf.secret,
     storage  = conf.storage,
     cookie  = {
-      lifetime = conf.cookie_lifetime,
-      idletime = conf.cookie_idletime,
-      path     = conf.cookie_path,
-      domain   = conf.cookie_domain,
-      samesite = conf.cookie_samesite,
-      httponly = conf.cookie_httponly,
-      secure   = conf.cookie_secure,
-      renew    = conf.cookie_renew,
-      discard  = conf.cookie_discard,
+      lifetime   = conf.cookie_lifetime,
+      idletime   = conf.cookie_idletime,
+      path       = conf.cookie_path,
+      domain     = conf.cookie_domain,
+      samesite   = conf.cookie_samesite,
+      httponly   = conf.cookie_httponly,
+      secure     = conf.cookie_secure,
+      renew      = conf.cookie_renew,
+      discard    = conf.cookie_discard,
+      persistent = conf.cookie_persistent,
     }
   }
 

--- a/spec/03-plugins/30-session/01-access_spec.lua
+++ b/spec/03-plugins/30-session/01-access_spec.lua
@@ -4,6 +4,7 @@ local helpers = require "spec.helpers"
 local cjson = require "cjson"
 local lower = string.lower
 
+local COOKIE_LIFETIME = 3600
 
 for _, strategy in helpers.each_strategy() do
   describe("Plugin: Session (access) [#" .. strategy .. "]", function()
@@ -36,6 +37,11 @@ for _, strategy in helpers.each_strategy() do
       local route4 = bp.routes:insert {
         paths    = {"/headers"},
         hosts = {"mockbin.org"},
+      }
+
+      local route5 = bp.routes:insert {
+        paths    = {"/test5"},
+        hosts = {"httpbin.org"},
       }
 
       assert(bp.plugins:insert {
@@ -82,6 +88,17 @@ for _, strategy in helpers.each_strategy() do
         }
       }
 
+      assert(bp.plugins:insert {
+        name = "session",
+        route = {
+          id = route5.id,
+        },
+        config = {
+          cookie_lifetime = COOKIE_LIFETIME,
+          cookie_persistent = true,
+        },
+      })
+
       consumer = db.consumers:insert({username = "coop"})
 
       credential = bp.keyauth_credentials:insert {
@@ -126,6 +143,16 @@ for _, strategy in helpers.each_strategy() do
         name = "key-auth",
         route = {
           id = route4.id,
+        },
+        config = {
+          anonymous = anonymous.id
+        }
+      }
+
+      bp.plugins:insert {
+        name = "key-auth",
+        route = {
+          id = route5.id,
         },
         config = {
           anonymous = anonymous.id
@@ -218,6 +245,35 @@ for _, strategy in helpers.each_strategy() do
         res = assert(client:send(request))
         assert.response(res).has.status(200)
         client:close()
+      end)
+
+      it("plugin attaches Set-Cookie with max-age/expiry when cookie_persistent is true", function()
+        client = helpers.proxy_ssl_client()
+        local res = assert(client:send {
+          method = "GET",
+          path = "/test5/status/200",
+          headers = {
+            host = "httpbin.org",
+            apikey = "kong",
+          },
+        })
+        assert.response(res).has.status(200)
+        client:close()
+
+        local cookie = assert.response(res).has.header("Set-Cookie")
+        local cookie_name = utils.split(cookie, "=")[1]
+        assert.equal("session", cookie_name)
+
+        -- e.g. ["Set-Cookie"] =
+        --    "session=m1EL96jlDyQztslA4_6GI20eVuCmsfOtd6Y3lSo4BTY|15434724
+        --    06|U5W4A6VXhvqvBSf4G_v0-Q|DFJMMSR1HbleOSko25kctHZ44oo; Expires=Mon, 06 Jun 2022 08:30:27 GMT;
+        --    Max-Age=3600; Path=/; SameSite=Lax; Secure; HttpOnly"
+        local cookie_parts = utils.split(cookie, "; ")
+        assert.truthy(string.match(cookie_parts[2], "^Expires=(.*)"))
+        assert.equal("Max-Age=" .. COOKIE_LIFETIME, cookie_parts[3])
+        assert.equal("SameSite=Strict", cookie_parts[5])
+        assert.equal("Secure", cookie_parts[6])
+        assert.equal("HttpOnly", cookie_parts[7])
       end)
 
       it("consumer headers are set correctly on request", function()


### PR DESCRIPTION
### Summary

At present, the schema configuration `cookie_lifetime` on the `session` plugin does nothing. As per the docs on [lua-resty-session](https://github.com/bungle/lua-resty-session/#number-sessioncookielifetime)

> session.cookie.lifetime holds the cookie lifetime in seconds in the future. By default this is set to 3,600 seconds. This can be configured with Nginx set $session_cookie_lifetime 3600;. **This does not set cookie's expiration time on session only (by default) cookies, but it is used if the cookies are configured persistent with session.cookie.persistent == true.** See also notes about [ssl_session_timeout](https://github.com/bungle/lua-resty-session/#nginx-configuration-variables).

I.e. to ensure this value is used, `cookie.persistent` must also be set to `true`. Currently this is not possible with the `session` plugin.

### Full changelog

* Add schema option `cookie_persistent` to `session` plugin
* Add test to assert that `Expires` and `Max-Age` are set on session cookie using `cookie_lifetime` when `cookie_persistent = true`

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
No issue has been raised.
