### PR TITLE
feat(aws-lambda) separate aws credential cache in aws-lambda plugin by plugin identifier in config

### DIFF
--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -264,7 +264,7 @@ function AWSLambdaHandler:access(conf)
 
   if not conf.aws_key then
     -- no credentials provided, so try the IAM metadata service
-    local iam_role_cred_cache_key = fmt(IAM_CREDENTIALS_CACHE_KEY_PATTERN, conf.__key__)
+    local iam_role_cred_cache_key = fmt(IAM_CREDENTIALS_CACHE_KEY_PATTERN, conf.aws_assume_role_arn or "default")
     local iam_role_credentials = kong.cache:get(
       iam_role_cred_cache_key,
       nil,

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -11,7 +11,7 @@ local kong = kong
 
 local VIA_HEADER = constants.HEADERS.VIA
 local VIA_HEADER_VALUE = meta._NAME .. "/" .. meta._VERSION
-local IAM_CREDENTIALS_CACHE_KEY = "plugin.aws-lambda.iam_role_temp_creds"
+local IAM_CREDENTIALS_CACHE_KEY_PATTERN = "plugin.aws-lambda.iam_role_temp_creds.%s"
 local AWS_PORT = 443
 local AWS_REGION do
   AWS_REGION = os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION")
@@ -264,8 +264,9 @@ function AWSLambdaHandler:access(conf)
 
   if not conf.aws_key then
     -- no credentials provided, so try the IAM metadata service
+    local iam_role_cred_cache_key = fmt(IAM_CREDENTIALS_CACHE_KEY_PATTERN, conf.__key__)
     local iam_role_credentials = kong.cache:get(
-      IAM_CREDENTIALS_CACHE_KEY,
+      iam_role_cred_cache_key,
       nil,
       fetch_aws_credentials,
       aws_conf


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

This PR is trying to separate AWS credential cache keys which are used by different aws-lambda plugins, by adding a plugin identifier in the mlcache key name.

Users might want to enable multiple aws-lambda plugins, targeting at different IAM roles and different lambda functions. Under this situation credential cache must be separated to avoid mutual overwrite

### Full changelog

* Adding `conf.aws_assume_role_arn` as plugin identifier to the credential cache key name

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
No issue reference for now.