### PR TITLE
chore(deps) bump pgmoon from 1.14.0 to 1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,7 +173,8 @@
 
 - Bumped OpenResty from 1.19.9.1 to [1.21.4.1](https://openresty.org/en/changelog-1021004.html)
   [#8850](https://github.com/Kong/kong/pull/8850)
-- Bumped pgmoon from 1.13.0 to 1.14.0
+- Bumped pgmoon from 1.13.0 to 1.15.0
+  [#8908](https://github.com/Kong/kong/pull/8908)
   [#8429](https://github.com/Kong/kong/pull/8429)
 - OpenSSL bumped to from 1.1.1n to 1.1.1o
   [#8544](https://github.com/Kong/kong/pull/8544)

--- a/kong-2.8.0-0.rockspec
+++ b/kong-2.8.0-0.rockspec
@@ -23,7 +23,7 @@ dependencies = {
   "version == 1.0.1",
   "kong-lapis == 1.8.3.1",
   "lua-cassandra == 1.5.2",
-  "pgmoon == 1.14.0",
+  "pgmoon == 1.15.0",
   "luatz == 0.4",
   "lua_system_constants == 0.1.4",
   "lyaml == 6.2.7",


### PR DESCRIPTION
### Summary

#### Additions

- Add support for Postgres extended query protocol (using text transport)   See https://github.com/leafo/pgmoon#extended-and-simple-query-protocols
- Add support for pgmoon_serialize metamethod on objects to allow objects   to describe how they can be serialized   See https://github.com/leafo/pgmoon#custom-type-serializer
- Implement pgmoon_serialize for the included PostgresArray type
- Add the set_type_deserializer method for easier configuration of deserialization (the undocumented set_type_oid method is deprecated. See https://github.com/leafo/pgmoon#custom-type-deserializer

#### Changes

- The query method can now take additional arguments to cause the query to be sent using the extended query protocol with parameters from the arguments
- Array deserialization is now aware of the NULL value and will return postgres.NULL instead of the string "NULL"
- self.sock is no longer set to nil when calling disconnect or keepalive (you can reconnect again without allocating a new socket
- Calling disconnect will now send a terminate message to the server before closing the socket, following the disconnection protocol previously, on some errors, the socket would be disconnected. This is no longer the case, if message processing fails then the function returns the error result but the socket is left as is so you can continue to attempt operations on it
- escape_literal() can now take pgmoon.NULL as a value and will return NULL
- convert_nulls is now a config option specified in the constructor
- Minor performance optimizations to batch together network operations where possible

#### Misc

- Substantial updates to documentation: detailing new features, usage tips and examples, and other organizational updates
- Add test suite runner for openresty using resty command