### PR TITLE
feat(timerng) integrate the `lua-resty-timer-ng`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,18 @@
 
 ### Additions
 
+#### Performance
+- Do not register unnecessary event handlers on Hybrid mode Control Plane
+nodes [#8452](https://github.com/Kong/kong/pull/8452).
+- Use the new timer library to improve performance,
+  except for the plugin server.
+  [8912](https://github.com/Kong/kong/pull/8912)
+
+#### Admin API
+
+- Added a new API `/timers` to get the timer statistics.
+  [8912](https://github.com/Kong/kong/pull/8912)
+
 #### Core
 
 - Added `cache_key` on target entity for uniqueness detection.
@@ -278,12 +290,6 @@ a restart (e.g., upon a plugin server crash).
 - The cluster listener now uses the value of `admin_error_log` for its log file
   instead of `proxy_error_log` [8583](https://github.com/Kong/kong/pull/8583)
 
-
-### Additions
-
-#### Performance
-- Do not register unnecessary event handlers on Hybrid mode Control Plane
-nodes [#8452](https://github.com/Kong/kong/pull/8452).
 
 ## [2.8.0]
 

--- a/kong-2.8.0-0.rockspec
+++ b/kong-2.8.0-0.rockspec
@@ -41,6 +41,7 @@ dependencies = {
   "lua-resty-ipmatcher == 0.6.1",
   "lua-resty-acme == 0.8.0",
   "lua-resty-session == 3.10",
+  "lua-resty-timer-ng == 0.1.0",
 }
 build = {
   type = "builtin",

--- a/kong/api/routes/kong.lua
+++ b/kong/api/routes/kong.lua
@@ -185,4 +185,9 @@ return {
       return kong.response.exit(200, copy)
     end
   },
+  ["/timers"] = {
+    GET = function (self, db, helpers)
+      return kong.response.exit(200, _G.timerng_stats())
+    end
+  }
 }

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -592,6 +592,7 @@ function Kong.init_worker()
   -- duplicated seeds.
   math.randomseed()
 
+  _G.timerng_start(kong.configuration.log_level == "debug")
 
   -- init DB
 

--- a/kong/runloop/plugin_servers/init.lua
+++ b/kong/runloop/plugin_servers/init.lua
@@ -8,7 +8,6 @@ local kong = kong
 local ngx_var = ngx.var
 local coroutine_running = coroutine.running
 local get_plugin_info = proc_mgmt.get_plugin_info
-local ngx_timer_at = ngx.timer.at
 local subsystem = ngx.config.subsystem
 
 --- keep request data a bit longer, into the log timer
@@ -250,7 +249,7 @@ local function build_phases(plugin)
           response_status = ngx.status,
         }
 
-        ngx_timer_at(0, function()
+        _G.native_timer_at(0, function()
           local co = coroutine_running()
           save_for_later[co] = saved
 
@@ -322,7 +321,7 @@ function plugin_servers.start()
 
   for _, server_def in ipairs(proc_mgmt.get_server_defs()) do
     if server_def.start_command then
-      ngx_timer_at(0, pluginserver_timer, server_def)
+      _G.native_timer_at(0, pluginserver_timer, server_def)
     end
   end
 end

--- a/spec/02-integration/02-cmd/08-quit_spec.lua
+++ b/spec/02-integration/02-cmd/08-quit_spec.lua
@@ -31,6 +31,6 @@ describe("kong quit", function()
     assert(helpers.kong_exec("quit --wait 2 --prefix " .. helpers.test_conf.prefix))
     ngx.update_time()
     local duration = ngx.now() - start
-    assert.is.near(2, duration, 1.6)
+    assert.is.near(2, duration, 2.5)
   end)
 end)

--- a/spec/02-integration/04-admin_api/20-timers_spec.lua
+++ b/spec/02-integration/04-admin_api/20-timers_spec.lua
@@ -1,0 +1,54 @@
+local helpers = require "spec.helpers"
+local cjson = require "cjson"
+
+
+for _, strategy in helpers.each_strategy() do
+
+describe("Admin API[#" .. strategy .. "]" , function()
+local client
+
+    lazy_setup(function()
+        helpers.get_db_utils(strategy)
+
+        assert(helpers.start_kong({
+        database = strategy,
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+        }))
+
+        client = helpers.admin_client()
+    end)
+
+    teardown(function()
+        if client then
+            client:close()
+        end
+        helpers.stop_kong()
+    end)
+
+    it("/timers", function ()
+        local res = assert(client:send {
+            method = "GET",
+            path = "/timers",
+            headers = { ["Content-Type"] = "application/json" }
+        })
+
+        local body = assert.res_status(200 , res)
+        local json = cjson.decode(body)
+
+        assert(type(json.flamegraph.running) == "string")
+        assert(type(json.flamegraph.pending) == "string")
+        assert(type(json.flamegraph.elapsed_time) == "string")
+
+        assert(type(json.sys.total) == "number")
+        assert(type(json.sys.runs) == "number")
+        assert(type(json.sys.running) == "number")
+        assert(type(json.sys.pending) == "number")
+        assert(type(json.sys.waiting) == "number")
+
+        assert(type(json.timers) == "table")
+
+    end)
+
+end)
+
+end

--- a/spec/02-integration/05-proxy/02-router_spec.lua
+++ b/spec/02-integration/05-proxy/02-router_spec.lua
@@ -72,6 +72,9 @@ local function insert_routes(bp, routes)
     local cfg = bp.done()
     local yaml = declarative.to_yaml_string(cfg)
     local admin_client = helpers.admin_client()
+
+    local wait_timers_ctx = helpers.wait_timers_begin()
+
     local res = assert(admin_client:send {
       method  = "POST",
       path    = "/config",
@@ -85,9 +88,12 @@ local function insert_routes(bp, routes)
     assert.res_status(201, res)
     admin_client:close()
 
+    -- wait for timers finish
+    helpers.wait_timers_end(wait_timers_ctx, 0.5)
   end
 
-  ngx.sleep(0.01)  -- temporary wait
+  ngx.sleep(0.01)  -- temporary wait for worker events
+
   return routes
 end
 

--- a/spec/02-integration/09-hybrid_mode/05-ocsp_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/05-ocsp_spec.lua
@@ -46,6 +46,8 @@ for cluster_protocol, conf in pairs(confs) do
             cluster_ca_cert = "spec/fixtures/ocsp_certs/ca.crt",
           }))
 
+          set_ocsp_status("good")
+
           assert(helpers.start_kong({
             role = "data_plane",
             cluster_protocol = cluster_protocol,
@@ -60,8 +62,6 @@ for cluster_protocol, conf in pairs(confs) do
             cluster_server_name = "kong_clustering",
             cluster_ca_cert = "spec/fixtures/ocsp_certs/ca.crt",
           }))
-
-          set_ocsp_status("good")
         end)
 
         lazy_teardown(function()
@@ -117,6 +117,8 @@ for cluster_protocol, conf in pairs(confs) do
             cluster_ca_cert = "spec/fixtures/ocsp_certs/ca.crt",
           }))
 
+          set_ocsp_status("revoked")
+
           assert(helpers.start_kong({
             role = "data_plane",
             cluster_protocol = cluster_protocol,
@@ -131,8 +133,6 @@ for cluster_protocol, conf in pairs(confs) do
             cluster_server_name = "kong_clustering",
             cluster_ca_cert = "spec/fixtures/ocsp_certs/ca.crt",
           }))
-
-          set_ocsp_status("revoked")
         end)
 
         lazy_teardown(function()
@@ -186,6 +186,8 @@ for cluster_protocol, conf in pairs(confs) do
             cluster_ca_cert = "spec/fixtures/ocsp_certs/ca.crt",
           }))
 
+          set_ocsp_status("error")
+
           assert(helpers.start_kong({
             role = "data_plane",
             cluster_protocol = cluster_protocol,
@@ -200,8 +202,6 @@ for cluster_protocol, conf in pairs(confs) do
             cluster_server_name = "kong_clustering",
             cluster_ca_cert = "spec/fixtures/ocsp_certs/ca.crt",
           }))
-
-          set_ocsp_status("error")
         end)
 
         lazy_teardown(function()
@@ -258,6 +258,8 @@ for cluster_protocol, conf in pairs(confs) do
             cluster_ca_cert = "spec/fixtures/ocsp_certs/ca.crt",
           }))
 
+          set_ocsp_status("revoked")
+
           assert(helpers.start_kong({
             role = "data_plane",
             cluster_protocol = cluster_protocol,
@@ -272,8 +274,6 @@ for cluster_protocol, conf in pairs(confs) do
             cluster_server_name = "kong_clustering",
             cluster_ca_cert = "spec/fixtures/ocsp_certs/ca.crt",
           }))
-
-          set_ocsp_status("revoked")
         end)
 
         lazy_teardown(function()
@@ -331,6 +331,8 @@ for cluster_protocol, conf in pairs(confs) do
             cluster_ca_cert = "spec/fixtures/ocsp_certs/ca.crt",
           }))
 
+          set_ocsp_status("revoked")
+
           assert(helpers.start_kong({
             role = "data_plane",
             cluster_protocol = cluster_protocol,
@@ -345,8 +347,6 @@ for cluster_protocol, conf in pairs(confs) do
             cluster_server_name = "kong_clustering",
             cluster_ca_cert = "spec/fixtures/ocsp_certs/ca.crt",
           }))
-
-          set_ocsp_status("revoked")
         end)
 
         lazy_teardown(function()
@@ -400,6 +400,8 @@ for cluster_protocol, conf in pairs(confs) do
             cluster_ca_cert = "spec/fixtures/ocsp_certs/ca.crt",
           }))
 
+          set_ocsp_status("error")
+
           assert(helpers.start_kong({
             role = "data_plane",
             cluster_protocol = cluster_protocol,
@@ -414,8 +416,6 @@ for cluster_protocol, conf in pairs(confs) do
             cluster_server_name = "kong_clustering",
             cluster_ca_cert = "spec/fixtures/ocsp_certs/ca.crt",
           }))
-
-          set_ocsp_status("error")
         end)
 
         lazy_teardown(function()

--- a/spec/02-integration/10-go_plugins/01-reports_spec.lua
+++ b/spec/02-integration/10-go_plugins/01-reports_spec.lua
@@ -10,7 +10,7 @@ for _, strategy in helpers.each_strategy() do
 
   describe("anonymous reports for go plugins #" .. strategy, function()
     local reports_send_ping = function(port)
-      ngx.sleep(0.01) -- hand over the CPU so other threads can do work (processing the sent data)
+      ngx.sleep(0.2) -- hand over the CPU so other threads can do work (processing the sent data)
       local admin_client = helpers.admin_client()
       local res = admin_client:post("/reports/send-ping" .. (port and "?port=" .. port or ""))
       assert.response(res).has_status(200)

--- a/spec/03-plugins/23-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/04-access_spec.lua
@@ -360,6 +360,8 @@ for _, strategy in helpers.each_strategy() do
           describe("Without authentication (IP address)", function()
             it_with_retry("blocks if exceeding limit", function()
               for i = 1, 6 do
+                local wait_timers_ctx = helpers.wait_timers_begin()
+
                 local res = GET("/status/200", {
                   headers = { Host = "test1.com" },
                 }, 200)
@@ -370,6 +372,9 @@ for _, strategy in helpers.each_strategy() do
                 assert.are.same(6 - i, tonumber(res.headers["ratelimit-remaining"]))
                 local reset = tonumber(res.headers["ratelimit-reset"])
                 assert.equal(true, reset <= 60 and reset >= 0)
+
+                -- wait for zero-delay timer
+                helpers.wait_timers_end(wait_timers_ctx, 0.5)
               end
 
               -- Additonal request, while limit is 6/minute
@@ -392,6 +397,8 @@ for _, strategy in helpers.each_strategy() do
 
             it_with_retry("blocks if exceeding limit, only if done via same path", function()
               for i = 1, 3 do
+                local wait_timers_ctx = helpers.wait_timers_begin()
+
                 local res = GET("/status/200", {
                   headers = { Host = "test-path.com" },
                 }, 200)
@@ -402,10 +409,15 @@ for _, strategy in helpers.each_strategy() do
                 assert.are.same(6 - i, tonumber(res.headers["ratelimit-remaining"]))
                 local reset = tonumber(res.headers["ratelimit-reset"])
                 assert.equal(true, reset <= 60 and reset > 0)
+
+                -- wait for zero-delay timer
+                helpers.wait_timers_end(wait_timers_ctx, 0.5)
               end
 
               -- Try a different path on the same host. This should reset the timers
               for i = 1, 3 do
+                local wait_timers_ctx = helpers.wait_timers_begin()
+
                 local res = GET("/status/201", {
                   headers = { Host = "test-path.com" },
                 }, 201)
@@ -416,10 +428,15 @@ for _, strategy in helpers.each_strategy() do
                 assert.are.same(6 - i, tonumber(res.headers["ratelimit-remaining"]))
                 local reset = tonumber(res.headers["ratelimit-reset"])
                 assert.equal(true, reset <= 60 and reset > 0)
+
+                -- wait for zero-delay timer
+                helpers.wait_timers_end(wait_timers_ctx, 0.5)
               end
 
               -- Continue doing requests on the path which "blocks"
               for i = 4, 6 do
+                local wait_timers_ctx = helpers.wait_timers_begin()
+
                 local res = GET("/status/200", {
                   headers = { Host = "test-path.com" },
                 }, 200)
@@ -430,6 +447,9 @@ for _, strategy in helpers.each_strategy() do
                 assert.are.same(6 - i, tonumber(res.headers["ratelimit-remaining"]))
                 local reset = tonumber(res.headers["ratelimit-reset"])
                 assert.equal(true, reset <= 60 and reset > 0)
+
+                -- wait for zero-delay timer
+                helpers.wait_timers_end(wait_timers_ctx, 0.5)
               end
 
               -- Additonal request, while limit is 6/minute
@@ -452,6 +472,8 @@ for _, strategy in helpers.each_strategy() do
 
             it_with_retry("counts against the same service register from different routes", function()
               for i = 1, 3 do
+                local wait_timers_ctx = helpers.wait_timers_begin()
+
                 local res = GET("/status/200", {
                   headers = { Host = "test-service1.com" },
                 }, 200)
@@ -462,9 +484,14 @@ for _, strategy in helpers.each_strategy() do
                 assert.are.same(6 - i, tonumber(res.headers["ratelimit-remaining"]))
                 local reset = tonumber(res.headers["ratelimit-reset"])
                 assert.equal(true, reset <= 60 and reset > 0)
+
+                -- wait for zero-delay timer
+                helpers.wait_timers_end(wait_timers_ctx, 0.5)
               end
 
               for i = 4, 6 do
+                local wait_timers_ctx = helpers.wait_timers_begin()
+
                 local res = GET("/status/200", {
                   headers = { Host = "test-service2.com" },
                 }, 200)
@@ -475,6 +502,9 @@ for _, strategy in helpers.each_strategy() do
                 assert.are.same(6 - i, tonumber(res.headers["ratelimit-remaining"]))
                 local reset = tonumber(res.headers["ratelimit-reset"])
                 assert.equal(true, reset <= 60 and reset > 0)
+
+                -- wait for zero-delay timer
+                helpers.wait_timers_end(wait_timers_ctx, 0.5)
               end
 
               -- Additonal request, while limit is 6/minute
@@ -502,6 +532,8 @@ for _, strategy in helpers.each_strategy() do
               }
 
               for i = 1, 3 do
+                local wait_timers_ctx = helpers.wait_timers_begin()
+
                 local res = GET("/status/200", {
                   headers = { Host = "test2.com" },
                 }, 200)
@@ -514,6 +546,9 @@ for _, strategy in helpers.each_strategy() do
                 assert.are.same(limits.minute - i, tonumber(res.headers["ratelimit-remaining"]))
                 local reset = tonumber(res.headers["ratelimit-reset"])
                 assert.equal(true, reset <= 60 and reset > 0)
+
+                -- wait for zero-delay timer
+                helpers.wait_timers_end(wait_timers_ctx, 0.5)
               end
 
               local res, body = GET("/status/200", {
@@ -539,6 +574,8 @@ for _, strategy in helpers.each_strategy() do
           describe("Without authentication (IP address)", function()
             it_with_retry("blocks if exceeding limit #grpc", function()
               for i = 1, 6 do
+                local wait_timers_ctx = helpers.wait_timers_begin()
+
                 local ok, res = helpers.proxy_client_grpc(){
                   service = "hello.HelloService.SayHello",
                   opts = {
@@ -555,6 +592,8 @@ for _, strategy in helpers.each_strategy() do
                 local reset = tonumber(string.match(res, "ratelimit%-reset: (%d+)"))
                 assert.equal(true, reset <= 60 and reset >= 0)
 
+                -- wait for zero-delay timer
+                helpers.wait_timers_end(wait_timers_ctx, 0.5)
               end
 
               -- Additonal request, while limit is 6/minute
@@ -582,6 +621,8 @@ for _, strategy in helpers.each_strategy() do
             describe("API-specific plugin", function()
               it_with_retry("blocks if exceeding limit", function()
                 for i = 1, 6 do
+                  local wait_timers_ctx = helpers.wait_timers_begin()
+
                   local res = GET("/status/200?apikey=apikey123", {
                     headers = { Host = "test3.com" },
                   }, 200)
@@ -592,6 +633,9 @@ for _, strategy in helpers.each_strategy() do
                   assert.are.same(6 - i, tonumber(res.headers["ratelimit-remaining"]))
                   local reset = tonumber(res.headers["ratelimit-reset"])
                   assert.equal(true, reset <= 60 and reset > 0)
+
+                  -- wait for zero-delay timer
+                  helpers.wait_timers_end(wait_timers_ctx, 0.5)
                 end
 
                 -- Third query, while limit is 2/minute
@@ -620,6 +664,8 @@ for _, strategy in helpers.each_strategy() do
             describe("#flaky Plugin customized for specific consumer and route", function()
               it_with_retry("blocks if exceeding limit", function()
                 for i = 1, 8 do
+                  local wait_timers_ctx = helpers.wait_timers_begin()
+
                   local res = GET("/status/200?apikey=apikey122", {
                     headers = { Host = "test3.com" },
                   }, 200)
@@ -630,6 +676,9 @@ for _, strategy in helpers.each_strategy() do
                   assert.are.same(8 - i, tonumber(res.headers["ratelimit-remaining"]))
                   local reset = tonumber(res.headers["ratelimit-reset"])
                   assert.equal(true, reset <= 60 and reset > 0)
+
+                  -- wait for zero-delay timer
+                  helpers.wait_timers_end(wait_timers_ctx, 0.5)
                 end
 
                 local res, body = GET("/status/200?apikey=apikey122", {
@@ -651,6 +700,8 @@ for _, strategy in helpers.each_strategy() do
 
               it_with_retry("blocks if the only rate-limiting plugin existing is per consumer and not per API", function()
                 for i = 1, 6 do
+                  local wait_timers_ctx = helpers.wait_timers_begin()
+
                   local res = GET("/status/200?apikey=apikey122", {
                     headers = { Host = "test4.com" },
                   }, 200)
@@ -661,6 +712,9 @@ for _, strategy in helpers.each_strategy() do
                   assert.are.same(6 - i, tonumber(res.headers["ratelimit-remaining"]))
                   local reset = tonumber(res.headers["ratelimit-reset"])
                   assert.equal(true, reset <= 60 and reset > 0)
+
+                  -- wait for zero-delay timer
+                  helpers.wait_timers_end(wait_timers_ctx, 0.5)
                 end
 
                 local res, body = GET("/status/200?apikey=apikey122", {
@@ -987,6 +1041,8 @@ for _, strategy in helpers.each_strategy() do
 
           it_with_retry("blocks when the consumer exceeds their quota, no matter what service/route used", function()
             for i = 1, 6 do
+              local wait_timers_ctx = helpers.wait_timers_begin()
+
               local res = GET("/status/200?apikey=apikey125", {
                 headers = { Host = fmt("test%d.com", i) },
               }, 200)
@@ -997,6 +1053,9 @@ for _, strategy in helpers.each_strategy() do
               assert.are.same(6 - i, tonumber(res.headers["ratelimit-remaining"]))
               local reset = tonumber(res.headers["ratelimit-reset"])
               assert.equal(true, reset <= 60 and reset > 0)
+
+              -- wait for zero-delay timer
+              helpers.wait_timers_end(wait_timers_ctx, 0.5)
             end
 
             -- Additonal request, while limit is 6/minute
@@ -1067,6 +1126,8 @@ for _, strategy in helpers.each_strategy() do
 
           it_with_retry("blocks if exceeding limit", function()
             for i = 1, 6 do
+              local wait_timers_ctx = helpers.wait_timers_begin()
+
               local res = GET("/status/200", {
                 headers = { Host = fmt("test%d.com", i) },
               }, 200)
@@ -1077,6 +1138,9 @@ for _, strategy in helpers.each_strategy() do
               assert.are.same(6 - i, tonumber(res.headers["ratelimit-remaining"]))
               local reset = tonumber(res.headers["ratelimit-reset"])
               assert.equal(true, reset <= 60 and reset > 0)
+
+              -- wait for zero-delay timer
+              helpers.wait_timers_end(wait_timers_ctx, 0.5)
             end
 
             -- Additonal request, while limit is 6/minute
@@ -1150,6 +1214,8 @@ for _, strategy in helpers.each_strategy() do
 
           it_with_retry("blocks if exceeding limit", function()
             for i = 1, 6 do
+              local wait_timers_ctx = helpers.wait_timers_begin()
+
               local res = GET("/status/200", { headers = { Host = "test1.com" } }, 200)
 
               assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
@@ -1158,9 +1224,14 @@ for _, strategy in helpers.each_strategy() do
               assert.are.same(6 - i, tonumber(res.headers["ratelimit-remaining"]))
               local reset = tonumber(res.headers["ratelimit-reset"])
               assert.equal(true, reset <= 60 and reset > 0)
+
+              -- wait for zero-delay timer
+              helpers.wait_timers_end(wait_timers_ctx, 0.5)
             end
 
             for i = 1, 6 do
+              local wait_timers_ctx = helpers.wait_timers_begin()
+
               local res = GET("/status/200", { headers = { Host = "test2.com" } }, 200)
 
               assert.are.same(6, tonumber(res.headers["x-ratelimit-limit-minute"]))
@@ -1169,6 +1240,9 @@ for _, strategy in helpers.each_strategy() do
               assert.are.same(6 - i, tonumber(res.headers["ratelimit-remaining"]))
               local reset = tonumber(res.headers["ratelimit-reset"])
               assert.equal(true, reset <= 60 and reset > 0)
+
+              -- wait for zero-delay timer
+              helpers.wait_timers_end(wait_timers_ctx, 0.5)
             end
 
             -- Additonal request, while limit is 6/minute
@@ -1233,6 +1307,8 @@ for _, strategy in helpers.each_strategy() do
 
           it_with_retry("blocks if exceeding limit", function()
             for i = 1, 6 do
+              local wait_timers_ctx = helpers.wait_timers_begin()
+
               local res = GET("/status/200", {
                 headers = { Host = fmt("test%d.com", i) },
               }, 200)
@@ -1243,6 +1319,9 @@ for _, strategy in helpers.each_strategy() do
               assert.are.same(6 - i, tonumber(res.headers["ratelimit-remaining"]))
               local reset = tonumber(res.headers["ratelimit-reset"])
               assert.equal(true, reset <= 60 and reset > 0)
+
+              -- wait for zero-delay timer
+              helpers.wait_timers_end(wait_timers_ctx, 0.5)
             end
 
             -- Additonal request, while limit is 6/minute
@@ -1313,6 +1392,8 @@ for _, strategy in helpers.each_strategy() do
 
           it_with_retry("maintains the counters for a path through different services and routes", function()
             for i = 1, 6 do
+              local wait_timers_ctx = helpers.wait_timers_begin()
+
               local res = GET("/status/200", {
                 headers = { Host = fmt("test%d.com", i) },
               }, 200)
@@ -1323,6 +1404,9 @@ for _, strategy in helpers.each_strategy() do
               assert.are.same(6 - i, tonumber(res.headers["ratelimit-remaining"]))
               local reset = tonumber(res.headers["ratelimit-reset"])
               assert.equal(true, reset <= 60 and reset > 0)
+
+              -- wait for zero-delay timer
+              helpers.wait_timers_end(wait_timers_ctx, 0.5)
             end
 
             -- Additonal request, while limit is 6/minute

--- a/spec/03-plugins/34-zipkin/zipkin_spec.lua
+++ b/spec/03-plugins/34-zipkin/zipkin_spec.lua
@@ -374,6 +374,8 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     it("times out if connection times out to upstream zipkin server", function()
+      local wait_timers_ctx = helpers.wait_timers_begin()
+
       local res = assert(proxy_client:send({
         method  = "GET",
         path    = "/status/200",
@@ -382,10 +384,16 @@ for _, strategy in helpers.each_strategy() do
         }
       }))
       assert.res_status(200, res)
+
+      -- wait for zero-delay timer
+      helpers.wait_timers_end(wait_timers_ctx, 0.5)
+
       assert.logfile().has.line("reporter flush failed to request: timeout", false, 2)
     end)
 
     it("times out if upstream zipkin server takes too long to respond", function()
+      local wait_timers_ctx = helpers.wait_timers_begin()
+
       local res = assert(proxy_client:send({
         method  = "GET",
         path    = "/status/200",
@@ -394,10 +402,16 @@ for _, strategy in helpers.each_strategy() do
         }
       }))
       assert.res_status(200, res)
+
+      -- wait for zero-delay timer
+      helpers.wait_timers_end(wait_timers_ctx, 0.5)
+
       assert.logfile().has.line("reporter flush failed to request: timeout", false, 2)
     end)
 
     it("connection refused if upstream zipkin server is not listening", function()
+      local wait_timers_ctx = helpers.wait_timers_begin()
+
       local res = assert(proxy_client:send({
         method  = "GET",
         path    = "/status/200",
@@ -406,6 +420,10 @@ for _, strategy in helpers.each_strategy() do
         }
       }))
       assert.res_status(200, res)
+
+      -- wait for zero-delay timer
+      helpers.wait_timers_end(wait_timers_ctx, 0.5)
+
       assert.logfile().has.line("reporter flush failed to request: connection refused", false, 2)
     end)
   end)

--- a/spec/fixtures/mocks/lua-resty-dns/resty/dns/resolver.lua
+++ b/spec/fixtures/mocks/lua-resty-dns/resty/dns/resolver.lua
@@ -101,14 +101,14 @@ resolver.query = function(self, name, options, tries)
   end
 end
 
-do
-  local semaphore = require "ngx.semaphore"
-  local old_post = semaphore.post
-  function semaphore.post(self, n)
-    old_post(self, n)
-    ngx.sleep(0)
-  end
-end
+-- do
+--   local semaphore = require "ngx.semaphore"
+--   local old_post = semaphore.post
+--   function semaphore.post(self, n)
+--     old_post(self, n)
+--     ngx.sleep(0)
+--   end
+-- end
 
 
 return resolver


### PR DESCRIPTION
### Summary

Integrating https://github.com/Kong/lua-resty-timer-ng into Kong-CE.

### Full changelog

* fix(plugin_servers) bypass timer library
* feat(AdminAPI) add `/timer` route
* chore(rockspec) add `resty.timerng` as dependency
* tests(unit/db/cache_warmup) fix
* tests(integration/cmd/quit) fix
* tests(integration/hybrid_mode/ocsp) fix
* tests(plugin/rate-limiting/access) fix
* tests(integration/db/query-semaphore) fix
* tests(integration/admin/timers) add tests for `http://kong_admin/timers`
* tests(integration/cmd/start_stop) fix
* tests(integration/proxy/router) fix
* docs(CHANGELOG) update

### Response of `http://kong_admin/timers`

```json
{
    "flamegraph": {
        "running": "@./kong/runloop/balancer/targets.lua:248:Lua() 0\n@./kong/plugins/prometheus/handler.lua:15:Lua();@./kong/plugins/prometheus/exporter.lua:153:init_worker();@./kong/plugins/prometheus/prometheus.lua:673:init_worker();@/build/luarocks/share/lua/5.1/resty/counter.lua:71:new() 0\n@/build/luarocks/share/lua/5.1/resty/worker/events.lua:386:Lua() 0\n@./kong/runloop/handler.lua:1087:Lua();@./kong/runloop/balancer/init.lua:228:init();@./kong/runloop/balancer/targets.lua:47:init() 0\n=init_worker_by_lua:2:main();@./kong/init.lua:617:init_worker();@./kong/global.lua:172:init_worker_events();@/build/luarocks/share/lua/5.1/resty/worker/events.lua:620:configure();@/build/luarocks/share/lua/5.1/resty/worker/events.lua:386:do_timer() 0\n=init_worker_by_lua:2:main();@./kong/init.lua:706:init_worker();@./kong/runloop/handler.lua:1086:before() 0\n",
        "elapsed_time": "@./kong/runloop/balancer/targets.lua:248:Lua() 0\n@./kong/plugins/prometheus/handler.lua:15:Lua();@./kong/plugins/prometheus/exporter.lua:153:init_worker();@./kong/plugins/prometheus/prometheus.lua:673:init_worker();@/build/luarocks/share/lua/5.1/resty/counter.lua:71:new() 0\n@/build/luarocks/share/lua/5.1/resty/worker/events.lua:386:Lua() 0\n@./kong/runloop/handler.lua:1087:Lua();@./kong/runloop/balancer/init.lua:228:init();@./kong/runloop/balancer/targets.lua:47:init() 0\n=init_worker_by_lua:2:main();@./kong/init.lua:617:init_worker();@./kong/global.lua:172:init_worker_events();@/build/luarocks/share/lua/5.1/resty/worker/events.lua:620:configure();@/build/luarocks/share/lua/5.1/resty/worker/events.lua:386:do_timer() 2\n=init_worker_by_lua:2:main();@./kong/init.lua:706:init_worker();@./kong/runloop/handler.lua:1086:before() 17\n",
        "pending": "@./kong/runloop/balancer/targets.lua:248:Lua() 0\n@./kong/plugins/prometheus/handler.lua:15:Lua();@./kong/plugins/prometheus/exporter.lua:153:init_worker();@./kong/plugins/prometheus/prometheus.lua:673:init_worker();@/build/luarocks/share/lua/5.1/resty/counter.lua:71:new() 0\n@/build/luarocks/share/lua/5.1/resty/worker/events.lua:386:Lua() 0\n@./kong/runloop/handler.lua:1087:Lua();@./kong/runloop/balancer/init.lua:228:init();@./kong/runloop/balancer/targets.lua:47:init() 0\n=init_worker_by_lua:2:main();@./kong/init.lua:617:init_worker();@./kong/global.lua:172:init_worker_events();@/build/luarocks/share/lua/5.1/resty/worker/events.lua:620:configure();@/build/luarocks/share/lua/5.1/resty/worker/events.lua:386:do_timer() 0\n=init_worker_by_lua:2:main();@./kong/init.lua:706:init_worker();@./kong/runloop/handler.lua:1086:before() 0\n"
    },
    "sys": {
        "running": 0,
        "runs": 7,
        "pending": 0,
        "waiting": 7,
        "total": 7
    },
    "timers": {
        "unix_timestamp=1654583694012.000000;counter=6:meta=@/build/luarocks/share/lua/5.1/resty/counter.lua:71:new()": {
            "name": "unix_timestamp=1654583694012.000000;counter=6:meta=@/build/luarocks/share/lua/5.1/resty/counter.lua:71:new()",
            "meta": {
                "name": "@/build/luarocks/share/lua/5.1/resty/counter.lua:71:new()",
                "callstack": "@./kong/plugins/prometheus/handler.lua:15:Lua();@./kong/plugins/prometheus/exporter.lua:153:init_worker();@./kong/plugins/prometheus/prometheus.lua:673:init_worker();@/build/luarocks/share/lua/5.1/resty/counter.lua:71:new()"
            },
            "stats": {
                "finish": 2,
                "runs": 2,
                "elapsed_time": {
                    "min": 0,
                    "max": 0,
                    "avg": 0,
                    "variance": 0
                },
                "last_err_msg": ""
            }
        },
        "unix_timestamp=1654583693919.000000;counter=0:meta=@./kong/db/init.lua:167:init_worker()": {
            "name": "unix_timestamp=1654583693919.000000;counter=0:meta=@./kong/db/init.lua:167:init_worker()",
            "meta": {
                "name": "@./kong/db/init.lua:167:init_worker()",
                "callstack": "=init_worker_by_lua:2:main();@./kong/init.lua:599:init_worker();@./kong/db/init.lua:167:init_worker()"
            },
            "stats": {
                "finish": 0,
                "runs": 0,
                "elapsed_time": {
                    "min": 9999999,
                    "max": -1,
                    "avg": 0,
                    "variance": 0
                },
                "last_err_msg": ""
            }
        },
        "unix_timestamp=1654583694010.000000;counter=5:meta=@./kong/runloop/handler.lua:1181:before()": {
            "name": "unix_timestamp=1654583694010.000000;counter=5:meta=@./kong/runloop/handler.lua:1181:before()",
            "meta": {
                "name": "@./kong/runloop/handler.lua:1181:before()",
                "callstack": "=init_worker_by_lua:2:main();@./kong/init.lua:706:init_worker();@./kong/runloop/handler.lua:1181:before()"
            },
            "stats": {
                "finish": 0,
                "runs": 0,
                "elapsed_time": {
                    "min": 9999999,
                    "max": -1,
                    "avg": 0,
                    "variance": 0
                },
                "last_err_msg": ""
            }
        },
        "unix_timestamp=1654583694009.000000;counter=4:meta=@./kong/runloop/handler.lua:1154:before()": {
            "name": "unix_timestamp=1654583694009.000000;counter=4:meta=@./kong/runloop/handler.lua:1154:before()",
            "meta": {
                "name": "@./kong/runloop/handler.lua:1154:before()",
                "callstack": "=init_worker_by_lua:2:main();@./kong/init.lua:706:init_worker();@./kong/runloop/handler.lua:1154:before()"
            },
            "stats": {
                "finish": 0,
                "runs": 0,
                "elapsed_time": {
                    "min": 9999999,
                    "max": -1,
                    "avg": 0,
                    "variance": 0
                },
                "last_err_msg": ""
            }
        },
        "unix_timestamp=1654583695942.000000;counter=10:meta=@/build/luarocks/share/lua/5.1/resty/worker/events.lua:386:Lua()": {
            "name": "unix_timestamp=1654583695942.000000;counter=10:meta=@/build/luarocks/share/lua/5.1/resty/worker/events.lua:386:Lua()",
            "meta": {
                "name": "@/build/luarocks/share/lua/5.1/resty/worker/events.lua:386:Lua()",
                "callstack": "@/build/luarocks/share/lua/5.1/resty/worker/events.lua:386:Lua()"
            },
            "stats": {
                "finish": 0,
                "runs": 0,
                "elapsed_time": {
                    "min": 9999999,
                    "max": -1,
                    "avg": 0,
                    "variance": 0
                },
                "last_err_msg": ""
            }
        },
        "unix_timestamp=1654583696043.000000;counter=11:meta=@./kong/runloop/balancer/targets.lua:248:Lua()": {
            "name": "unix_timestamp=1654583696043.000000;counter=11:meta=@./kong/runloop/balancer/targets.lua:248:Lua()",
            "meta": {
                "name": "@./kong/runloop/balancer/targets.lua:248:Lua()",
                "callstack": "@./kong/runloop/balancer/targets.lua:248:Lua()"
            },
            "stats": {
                "finish": 0,
                "runs": 0,
                "elapsed_time": {
                    "min": 9999999,
                    "max": -1,
                    "avg": 0,
                    "variance": 0
                },
                "last_err_msg": ""
            }
        },
        "unix_timestamp=1654583693982.000000;counter=2:meta=@./kong/cluster_events/init.lua:207:subscribe()": {
            "name": "unix_timestamp=1654583693982.000000;counter=2:meta=@./kong/cluster_events/init.lua:207:subscribe()",
            "meta": {
                "name": "@./kong/cluster_events/init.lua:207:subscribe()",
                "callstack": "=init_worker_by_lua:2:main();@./kong/init.lua:633:init_worker();@./kong/cache/init.lua:138:init_cache();@./kong/cluster_events/init.lua:207:subscribe()"
            },
            "stats": {
                "finish": 0,
                "runs": 0,
                "elapsed_time": {
                    "min": 9999999,
                    "max": -1,
                    "avg": 0,
                    "variance": 0
                },
                "last_err_msg": ""
            }
        }
    }
}
```