### PR TITLE
tests(*) change kong.tools.utils.yield to check IS_CLI on call time

### DIFF
--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -1416,26 +1416,24 @@ local topological_sort do
 end
 _M.topological_sort = topological_sort
 
-
 do
-  if ngx.IS_CLI then
-    function _M.yield() end
-  else
-    local counter = 0
-    function _M.yield(in_loop, phase)
-      phase = phase or get_phase()
-      if phase == "init" or phase == "init_worker" then
+  local counter = 0
+  function _M.yield(in_loop, phase)
+    if ngx.IS_CLI then
+      return
+    end
+    phase = phase or get_phase()
+    if phase == "init" or phase == "init_worker" then
+      return
+    end
+    if in_loop then
+      counter = counter + 1
+      if counter % YIELD_ITERATIONS ~= 0 then
         return
       end
-      if in_loop then
-        counter = counter + 1
-        if counter % YIELD_ITERATIONS ~= 0 then
-          return
-        end
-        counter = 0
-      end
-      ngx_sleep(0)
+      counter = 0
     end
+    ngx_sleep(0)
   end
 end
 


### PR DESCRIPTION
### Summary

It turned out that Kong Enterprise edition requires a tracing framework that requires `kong.tools.utils` before running the `global patches`. This means that things like `ngx.IS_CLI` is not set during `require` time and then the module gets cached. This then makes some of the unit type tests not to pass on enterprise edition CI.

There are several ways to fix this. E.g. not to require `tracing` before running global patches or just doing something like this on test setup that were failing:

```
require("kong.tools.utils").yield = function() end
```

Or setting the `ngx.IS_CLI` even before running global patches...

Here is a solution that just makes detection of `IS_CLI` to happen on yield call-time.