### PR TITLE
fix(language) plugin server graceful shutdown

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -723,12 +723,19 @@ function Kong.init_worker()
 
   runloop.init_worker.after()
 
-  if kong.configuration.role ~= "control_plane" then
+  if kong.configuration.role ~= "control_plane" and ngx.worker.id() == 0 then
     plugin_servers.start()
   end
 
   if kong.clustering then
     kong.clustering:init_worker()
+  end
+end
+
+
+function Kong.exit_worker()
+  if kong.configuration.role ~= "control_plane" and ngx.worker.id() == 0 then
+    plugin_servers.stop()
   end
 end
 

--- a/kong/runloop/plugin_servers/init.lua
+++ b/kong/runloop/plugin_servers/init.lua
@@ -327,4 +327,17 @@ function plugin_servers.start()
   end
 end
 
+function plugin_servers.stop()
+  if ngx.worker.id() ~= 0 then
+    kong.log.notice("only worker #0 can manage")
+    return
+  end
+
+  for _, server_def in ipairs(proc_mgmt.get_server_defs()) do
+    if server_def.proc then
+      server_def.proc:kill(15)
+    end
+  end
+end
+
 return plugin_servers

--- a/kong/runloop/plugin_servers/init.lua
+++ b/kong/runloop/plugin_servers/init.lua
@@ -2,6 +2,7 @@
 local proc_mgmt = require "kong.runloop.plugin_servers.process"
 local cjson = require "cjson.safe"
 local ngx_ssl = require "ngx.ssl"
+local SIGTERM = 15
 
 local ngx = ngx
 local kong = kong
@@ -335,7 +336,7 @@ function plugin_servers.stop()
 
   for _, server_def in ipairs(proc_mgmt.get_server_defs()) do
     if server_def.proc then
-      server_def.proc:kill(15)
+      server_def.proc:kill(SIGTERM)
     end
   end
 end

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -51,6 +51,10 @@ init_worker_by_lua_block {
     Kong.init_worker()
 }
 
+exit_worker_by_lua_block {
+    Kong.exit_worker()
+}
+
 > if (role == "traditional" or role == "data_plane") and #proxy_listeners > 0 then
 # Load variable indexes
 lua_kong_load_var_index default;


### PR DESCRIPTION
When we exit or reload kong, plugin servers are quitting because they encounter errors in the socket(closing). This behavior is not proper. We close with SIGTERM when possible.

Hopefully, this can be a fix to #8531
