### PR TITLE
tests(balancer) fix the slot number for new balancers

### DIFF
--- a/spec/01-unit/09-balancer/03-consistent_hashing_spec.lua
+++ b/spec/01-unit/09-balancer/03-consistent_hashing_spec.lua
@@ -143,7 +143,7 @@ local function new_balancer(opts)
       },
     },
   }
-  local my_upstream = { id=upname, name=upname, ws_id=ws_id, slots=10, healthchecks=hc_defaults, algorithm="consistent-hashing" }
+  local my_upstream = { id=upname, name=upname, ws_id=ws_id, slots=opts.wheelSize or 10, healthchecks=hc_defaults, algorithm="consistent-hashing" }
   local b = (balancers.create_balancer(my_upstream, true))
 
   for k, v in pairs{

--- a/spec/01-unit/09-balancer/04-round_robin_spec.lua
+++ b/spec/01-unit/09-balancer/04-round_robin_spec.lua
@@ -149,7 +149,7 @@ local function new_balancer(opts)
       },
     },
   }
-  local my_upstream = { id=upname, name=upname, ws_id=ws_id, slots=10, healthchecks=hc_defaults, algorithm="round-robin" }
+  local my_upstream = { id=upname, name=upname, ws_id=ws_id, slots=opts.wheelSize or 10, healthchecks=hc_defaults, algorithm="round-robin" }
   local b = (balancers.create_balancer(my_upstream, true))
 
   for k, v in pairs{


### PR DESCRIPTION
### Summary

Round-robin and consistent-hashing algorithms tests were creating new balancers with fixed number of slots (`10`) instead of using the number set in the test case.

### Full changelog

* Fixed helper function that sets the default values for new test balancers.