### PR TITLE
doc(spec): Fix the variable according to `helpers.redis_host`

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -23,7 +23,7 @@ To prevent the test helpers from cleaning the Kong working directory, the
 variable `KONG_TEST_DONT_CLEAN` can be set.
 This comes in handy when inspecting the logs after the tests complete.
 
-When testing with Redis, the environment variable `KONG_SPEC_REDIS_HOST` can be
+When testing with Redis, the environment variable `KONG_SPEC_TEST_REDIS_HOST` can be
 used to specify where the Redis server can be found. If not specified, it will default
 to `127.0.0.1`. This setting is available to tests via `helpers.redis_host`.
 


### PR DESCRIPTION
### Summary

There is a typo into the spec README, 

### Issue reference

https://github.com/Kong/gojira/issues/51
