### PR TITLE
tests(helpers): add a reopen option to proxy http clients

### DIFF
--- a/spec/03-plugins/26-prometheus/04-status_api_spec.lua
+++ b/spec/03-plugins/26-prometheus/04-status_api_spec.lua
@@ -11,20 +11,13 @@ describe("Plugin: prometheus (access via status API)", function()
   local proxy_client_grpc
   local proxy_client_grpcs
 
-  local function get_metrics(reopened)
+  local function get_metrics()
     if not status_client then
       status_client = helpers.http_client("127.0.0.1", tcp_status_port, 20000)
+      status_client.reopen = true -- retry on a closed connection
     end
 
-    local res, err = status_client:send({
-      method  = "GET",
-      path    = "/metrics",
-    })
-
-    if err and err:find("closed", nil, true) and not reopened then
-      status_client = nil
-      return get_metrics(true)
-    end
+    local res, err = status_client:get("/metrics")
 
     assert.is_nil(err, "failed GET /metrics: " .. tostring(err))
     return assert.res_status(200, res)


### PR DESCRIPTION
This takes the re-open logic I used in #8925 and moves it into the helper http client so it can be reused elsewhere.

While there are a lot of tests in kong that could benefit from this behavior, there's not really a huge benefit to updating existing, non-flaky tests that simply create a new http client for each test case, so for now I haven't changed any test cases aside from the obvious prometheus one.