### PR TITLE
tests(helpers): add file waiter

### DIFF
--- a/spec/02-integration/02-cmd/03-reload_spec.lua
+++ b/spec/02-integration/02-cmd/03-reload_spec.lua
@@ -2,16 +2,7 @@ local helpers = require "spec.helpers"
 local cjson = require "cjson"
 
 
-local function assert_wait_call(fn, ...)
-  local res
-  local args = { ... }
-  helpers.wait_until(function()
-    res = fn(unpack(args))
-    return res ~= nil
-  end, 10)
-  return res
-end
-
+local wait_for_file_contents = helpers.wait_for_file_contents
 
 for _, strategy in helpers.each_strategy() do
 
@@ -30,12 +21,12 @@ describe("kong reload #" .. strategy, function()
   it("send a 'reload' signal to a running Nginx master process", function()
     assert(helpers.start_kong())
 
-    local nginx_pid = assert_wait_call(helpers.file.read, helpers.test_conf.nginx_pid)
+    local nginx_pid = wait_for_file_contents(helpers.test_conf.nginx_pid, 10)
 
     -- kong_exec uses test conf too, so same prefix
     assert(helpers.reload_kong(strategy, "reload --prefix " .. helpers.test_conf.prefix))
 
-    local nginx_pid_after = assert_wait_call(helpers.file.read, helpers.test_conf.nginx_pid)
+    local nginx_pid_after = wait_for_file_contents(helpers.test_conf.nginx_pid, 10)
 
     -- same master PID
     assert.equal(nginx_pid, nginx_pid_after)

--- a/spec/02-integration/02-cmd/06-restart_spec.lua
+++ b/spec/02-integration/02-cmd/06-restart_spec.lua
@@ -1,12 +1,7 @@
 local helpers = require "spec.helpers"
 
 local function wait_for_pid()
-  local pid
-  helpers.wait_until(function()
-    pid = helpers.file.read(helpers.test_conf.nginx_pid)
-    return pid
-  end)
-  return pid
+  return helpers.wait_for_file_contents(helpers.test_conf.nginx_pid)
 end
 
 describe("kong restart", function()

--- a/spec/02-integration/02-cmd/12-hybrid_spec.lua
+++ b/spec/02-integration/02-cmd/12-hybrid_spec.lua
@@ -130,8 +130,8 @@ for _, strategy in helpers.each_strategy() do
           proxy_listen = "0.0.0.0:9002",
         }))
 
-        helpers.wait_for_file("file", "servroot/pids/nginx.pid")
-        helpers.wait_for_file("file", "servroot2/pids/nginx.pid")
+        helpers.wait_for_file_contents("servroot/pids/nginx.pid")
+        helpers.wait_for_file_contents("servroot2/pids/nginx.pid")
       end)
 
       lazy_teardown(function()


### PR DESCRIPTION
The main goal I started out with was to make the test in `spec/02-integration/02-cmd/12-hybrid_spec.lua` less flaky. Waiting until a file exists and is non-empty is a common enough task that I made a helper function for it.

```lua
helpers.wait_for_file_contents(fname, timeout) end
```

I have put this function into use in a few tests.

Along the way I discovered that `helpers.wait_until` was using `ngx.time()` and therefore lacks some precision when being used with timeout of <= 1, so I swapped that out for `ngx.now()`.
