### PR TITLE
fix(dao) invalidate client certificate cache when updating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -269,6 +269,8 @@ a restart (e.g., upon a plugin server crash).
   being reloaded. [#8702](https://github.com/Kong/kong/pull/8702)
 - The private stream API has been rewritten to allow for larger message payloads
   [#8641](https://github.com/Kong/kong/pull/8641)
+- Fixed an issue that the certificate caching would not be refreshed after updating
+  [#8934](https://github.com/Kong/kong/pull/8934)
 
 #### Plugins
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -269,7 +269,7 @@ a restart (e.g., upon a plugin server crash).
   being reloaded. [#8702](https://github.com/Kong/kong/pull/8702)
 - The private stream API has been rewritten to allow for larger message payloads
   [#8641](https://github.com/Kong/kong/pull/8641)
-- Fixed an issue that the certificate caching would not be refreshed after updating
+- Fixed an issue that the client certificate sent to upstream was not updated when calling PATCH Admin API
   [#8934](https://github.com/Kong/kong/pull/8934)
 
 #### Plugins

--- a/kong/runloop/certificate.lua
+++ b/kong/runloop/certificate.lua
@@ -193,9 +193,10 @@ end
 
 
 local function get_certificate(pk, sni_name)
-  return kong.core_cache:get("certificates:" .. pk.id,
-                        get_certificate_opts, fetch_certificate,
-                        pk, sni_name)
+  local cache_key = kong.db.certificates:cache_key(pk)
+  return kong.core_cache:get(cache_key,
+                             get_certificate_opts, fetch_certificate,
+                             pk, sni_name)
 end
 
 

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -527,23 +527,6 @@ local function register_events()
     end
   end, "crud", "snis")
 
-
-  worker_events.register(function(data)
-    log(DEBUG, "[events] SSL cert updated, invalidating cached certificates")
-    local certificate = data.entity
-
-    for sni, err in db.snis:each_for_certificate({ id = certificate.id }, nil, GLOBAL_QUERY_OPTS) do
-      if err then
-        log(ERR, "[events] could not find associated snis for certificate: ",
-          err)
-        break
-      end
-
-      local cache_key = "certificates:" .. sni.certificate.id
-      core_cache:invalidate(cache_key)
-    end
-  end, "crud", "certificates")
-
   register_balancer_events(core_cache, worker_events, cluster_events)
 end
 

--- a/spec/02-integration/05-proxy/18-upstream_tls_spec.lua
+++ b/spec/02-integration/05-proxy/18-upstream_tls_spec.lua
@@ -185,7 +185,7 @@ for _, strategy in helpers.each_strategy() do
           end, 10)
         end)
 
-        it("extra test", function ()
+        it("send updated client certificate", function ()
           local res = assert(proxy_client:send {
             path    = "/mtls",
             headers = {


### PR DESCRIPTION
When updating client certificate, the certificate in core_cache should be invalidation, and the corresponding cache item for the new certificate should be used. Currently this logic doesn't work.

### Summary
The logic for invalidating a certificate in core_cache doesn't work when a update event occurs.

### Full changelog
change the logic how to get cache_key for certificate in core_cache and add a test