### PR TITLE
fix(oauth2): specify correct client type in `code_challenge` error msg

### DIFF
--- a/kong/plugins/oauth2/access.lua
+++ b/kong/plugins/oauth2/access.lua
@@ -345,7 +345,7 @@ local function authorize(conf)
       elseif client and not challenge and requires_pkce(conf, client) then
         response_params = {
           [ERROR] = "invalid_request",
-          error_description = CODE_CHALLENGE .. " is required for " .. CLIENT_TYPE_PUBLIC .. " clients"
+          error_description = CODE_CHALLENGE .. " is required for " .. client.client_type .. " clients"
         }
       elseif not challenge then -- do not save a code method unless we have a challenge
         challenge_method = nil

--- a/spec/03-plugins/25-oauth2/03-access_spec.lua
+++ b/spec/03-plugins/25-oauth2/03-access_spec.lua
@@ -1063,7 +1063,7 @@ describe("Plugin: oauth2 [#" .. strategy .. "]", function()
           })
           local body = assert.res_status(400, res)
           local json = cjson.decode(body)
-          assert.same({ redirect_uri = "http://google.com/kong?error=invalid_request&error_description=code_challenge%20is%20required%20for%20public%20clients&state=hello" }, json)
+          assert.same({ redirect_uri = "http://google.com/kong?error=invalid_request&error_description=code_challenge%20is%20required%20for%20confidential%20clients&state=hello" }, json)
         end)
         it("returns success when code challenge is not included for public client when conf.pkce is none", function()
           local res = assert(proxy_ssl_client:send {


### PR DESCRIPTION
### Summary

<!--- Why is this change required? What problem does it solve? -->

PKCE enforcement can be applied to both `public`  and `confidential` clients as per the implementation of [`requires_pkce`](https://github.com/Kong/kong/blob/2c1d24223b95136ece01892a55bc25c626b2eb14/kong/plugins/oauth2/access.lua#L247-L260). Currently the error returns to calling applications will always specify that `code_challenge is required for **public** clients` (even if the calling client is a `confidential` client). This PR ensures that the error message correctly reflects the client type.

### Full changelog

* Use `client.client_type` when building "code challenge required" error message to ensure that the error message correctly reflects the calling client's type
* Updated existing test for confidential client to reflect the updated error message.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
