### PR TITLE
fix(env) luajit table overflow error when using ffi.cdef

### DIFF
--- a/kong/vaults/env/init.lua
+++ b/kong/vaults/env/init.lua
@@ -1,26 +1,27 @@
+local ffi = require "ffi"
+
 local type = type
 local gsub = string.gsub
 local upper = string.upper
+local find = string.find
+local sub = string.sub
+local str = ffi.string
 local kong = kong
 
 
 local ENV = {}
 
+ffi.cdef [[
+  extern char **environ;
+]]
+
 
 local function init()
-  local ffi = require "ffi"
-
-  ffi.cdef("extern char **environ;")
-
   local e = ffi.C.environ
   if not e then
     kong.log.warn("could not access environment variables")
     return
   end
-
-  local find = string.find
-  local sub = string.sub
-  local str = ffi.string
 
   local i = 0
   while e[i] ~= nil do


### PR DESCRIPTION
### Summary

There is a potential risk that if `init` is invoked a lot, a *table overflow* error will occur. Can be verified very simply by: 

```
$ resty -e 'local ffi = require "ffi" while true do ffi.cdef[[void exit(int status);]] end'
ERROR: table overflow
stack traceback:
        (command line -e):1: in function 'inline_gen'
        init_worker_by_lua:44: in function <init_worker_by_lua:43>
        [C]: in function 'xpcall'
        init_worker_by_lua:52: in function <init_worker_by_lua:50>
```

It's wrong to call `ffi.cdef()` repeatedly for the same things. Always call it on the top-level scope of module files. 

### Full changelog

* fix luajit table overflow error when using `ffi.cdef`