### PR TITLE
fix(plugins): change static priorities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,18 @@
   [#8082](https://github.com/Kong/kong/pull/8082)
 - The pre-functions plugin changed priority from `+inf` to `1000000`.
   [#8836](https://github.com/Kong/kong/pull/8836)
+- A couple of plugins that received new priority values.
+  This is important for those who run custom plugins as it may affect the sequence your plugins are executed.
+  Note that this does not change the order of execution for plugins in a standard kong installation.
+  List of plugins and their old and new priority value:
+  - `acme` changed from 1007 to 1705
+  - `basic-auth` changed from 1001 to 1100
+  - `hmac-auth` changed from 1000 to 1030
+  - `jwt` changed from 1005 to 1450
+  - `key-auth` changed from 1003 to 1250
+  - `ldap-auth` changed from 1002 to 1200
+  - `oauth2` changed from 1004 to 1400
+  - `rate-limiting` changed from 901 to 910
 
 ### Deprecations
 

--- a/kong/plugins/acme/handler.lua
+++ b/kong/plugins/acme/handler.lua
@@ -13,8 +13,8 @@ local ACMEHandler = {}
 -- this has to be higher than auth plugins,
 -- otherwise acme-challenges endpoints may be blocked by auth plugins
 -- causing validation failures
-ACMEHandler.PRIORITY = 1007
 ACMEHandler.VERSION = kong_meta.version
+ACMEHandler.PRIORITY = 1705
 
 local function build_domain_matcher(domains)
   local domains_plain = {}

--- a/kong/plugins/basic-auth/handler.lua
+++ b/kong/plugins/basic-auth/handler.lua
@@ -3,8 +3,8 @@ local access = require "kong.plugins.basic-auth.access"
 local kong_meta = require "kong.meta"
 
 local BasicAuthHandler = {
-  PRIORITY = 1001,
   VERSION = kong_meta.version,
+  PRIORITY = 1100,
 }
 
 

--- a/kong/plugins/hmac-auth/handler.lua
+++ b/kong/plugins/hmac-auth/handler.lua
@@ -4,8 +4,8 @@ local kong_meta = require "kong.meta"
 
 
 local HMACAuthHandler = {
-  PRIORITY = 1000,
   VERSION = kong_meta.version,
+  PRIORITY = 1030,
 }
 
 

--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -13,8 +13,8 @@ local re_gmatch = ngx.re.gmatch
 
 
 local JwtHandler = {
-  PRIORITY = 1005,
   VERSION = kong_meta.version,
+  PRIORITY = 1450,
 }
 
 

--- a/kong/plugins/key-auth/handler.lua
+++ b/kong/plugins/key-auth/handler.lua
@@ -8,8 +8,8 @@ local error = error
 
 
 local KeyAuthHandler = {
-  PRIORITY = 1003,
   VERSION = kong_meta.version,
+  PRIORITY = 1250,
 }
 
 

--- a/kong/plugins/ldap-auth/handler.lua
+++ b/kong/plugins/ldap-auth/handler.lua
@@ -3,8 +3,8 @@ local kong_meta = require "kong.meta"
 
 
 local LdapAuthHandler = {
-  PRIORITY = 1002,
   VERSION = kong_meta.version,
+  PRIORITY = 1200,
 }
 
 

--- a/kong/plugins/oauth2/handler.lua
+++ b/kong/plugins/oauth2/handler.lua
@@ -3,8 +3,8 @@ local kong_meta = require "kong.meta"
 
 
 local OAuthHandler = {
-  PRIORITY = 1004,
   VERSION = kong_meta.version,
+  PRIORITY = 1400,
 }
 
 

--- a/kong/plugins/rate-limiting/handler.lua
+++ b/kong/plugins/rate-limiting/handler.lua
@@ -47,8 +47,8 @@ local X_RATELIMIT_REMAINING = {
 local RateLimitingHandler = {}
 
 
-RateLimitingHandler.PRIORITY = 901
 RateLimitingHandler.VERSION = kong_meta.version
+RateLimitingHandler.PRIORITY = 910
 
 
 local function get_identifier(conf)


### PR DESCRIPTION


### Summary

Some static priorities of Kong's plugins collide or are bunched up. This commit will keep the relative priority in which these plugins are executed but loosens the priority numbers.

### Full changelog

- A couple of plugins that received new priority values.
  This is important for those who run custom plugins as it may affect the sequence your plugins are executed.
  Note that this does not change the order of execution for plugins in a standard kong installation.
  List of plugins and their old and new priority value:
  - `acme` changed from 1007 to 1705
  - `basic-auth` changed from 1001 to 1100
  - `hmac-auth` changed from 1000 to 1030
  - `jwt` changed from 1005 to 1450
  - `key-auth` changed from 1003 to 1250
  - `ldap-auth` changed from 1002 to 1200
  - `oauth2` changed from 1004 to 1400
  - `rate-limiting` changed from 901 to 910

Signed-off-by: Joshua Schmid <jaiks@posteo.de>