### PR TITLE
fix(*) remove coroutine in access phase

### DIFF
--- a/kong/pdk/response.lua
+++ b/kong/pdk/response.lua
@@ -27,7 +27,6 @@ local lower = string.lower
 local error = error
 local pairs = pairs
 local concat = table.concat
-local coroutine = coroutine
 local normalize_header = checks.normalize_header
 local normalize_multi_header = checks.normalize_multi_header
 local validate_header = checks.validate_header
@@ -950,7 +949,7 @@ local function new(self, major_version)
         }
 
         ctx.delayed_response_callback = flush
-        coroutine.yield()
+        return
 
       else
         return send(status, body, headers)


### PR DESCRIPTION
We introduce this in
https://github.com/Kong/kong/commit/744d3b32e47323301bdbe402f9bf1cb2acbf88e8
to persist the behaviour that kong.response.exit can shortcut current
processing. Though this is also documented in PDK document, our code
doesn't seem to rely on it at all.

Opening this to see what will break and open for comments; if merged
this will be a breaking change as this is user-facing, so it can only go
in 3.0 or 4.0.

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Full changelog

* remove coroutine in access phase
* remove coroutine yield in kong.response.exit

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
