### PR TITLE
tests(key-auth) change json.consumer.id to json.id

### DIFF
--- a/spec/03-plugins/09-key-auth/01-api_spec.lua
+++ b/spec/03-plugins/09-key-auth/01-api_spec.lua
@@ -137,7 +137,7 @@ for _, strategy in helpers.each_strategy() do
 
           ngx.sleep(3)
 
-          local id = json.consumer.id
+          local id = json.id
           local res = assert(admin_client:send {
             method  = "GET",
             path    = "/consumers/bob/key-auth/" .. id,


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

The `key-auth` credential `id` is incorrectly set to `consumer.id`.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[FTI-4091]_


[FTI-4091]: https://konghq.atlassian.net/browse/FTI-4091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ