### PR TITLE
fix(dao): plugin priority collision handling

### DIFF
--- a/kong/db/dao/plugins.lua
+++ b/kong/db/dao/plugins.lua
@@ -5,6 +5,7 @@ local plugin_loader = require "kong.db.schema.plugin_loader"
 local reports = require "kong.reports"
 local plugin_servers = require "kong.runloop.plugin_servers"
 local version = require "version"
+local sort_by_handler_priority = utils.sort_by_handler_priority
 
 local Plugins = {}
 
@@ -77,12 +78,6 @@ local function check_protocols_match(self, plugin)
 
   return true
 end
-
-
-local function sort_by_handler_priority(a, b)
-  return (a.handler.PRIORITY or 0) > (b.handler.PRIORITY or 0)
-end
-
 
 function Plugins:insert(entity, options)
   local ok, err, err_t = check_protocols_match(self, entity)

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -1416,6 +1416,22 @@ local topological_sort do
 end
 _M.topological_sort = topological_sort
 
+---
+-- Sort by handler priority and check for collisions. In case of a collision
+-- sorting will be applied based on the plugin's name.
+-- @tparam table plugin table containing `handler` table and a `name` string
+-- @tparam table plugin table containing `handler` table and a `name` string
+-- @treturn boolean outcome of sorting
+function _M.sort_by_handler_priority(a, b)
+  local prio_a = a.handler.PRIORITY or 0
+  local prio_b = b.handler.PRIORITY or 0
+  if prio_a == prio_b and not
+      (prio_a == 0 or prio_b == 0) then
+    return a.name > b.name
+  end
+  return prio_a > prio_b
+end
+
 do
   local counter = 0
   function _M.yield(in_loop, phase)


### PR DESCRIPTION
### Summary

When plugin priorities collide we cannot guarantee a deterministic result from the sorting function. There are a couple of plugins that traditionally have colliding priorities like their EE counterparts. To ensure determinism this commit adds a collision detection that falls back to a plugin name based sorting. Also the function moved to the `kong.tools.utils` module to test it in
isolation.

Signed-off-by: Joshua Schmid <jaiks@posteo.de>


_note that this is a backwards port from ee_