### PR TITLE
chore(db) remove schema legacy attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,9 @@
   [8823](https://github.com/Kong/kong/pull/8823)
 - The Kong singletons module `"kong.singletons"` was removed in favor of the PDK `kong.*`.
   [#8874](https://github.com/Kong/kong/pull/8874)
+- The support for `legacy = true/false` attribute was removed from Kong schemas and
+  Kong field schemas.
+  [#8958](https://github.com/Kong/kong/pull/8958)
 
 #### Admin API
 

--- a/kong/api/endpoints.lua
+++ b/kong/api/endpoints.lua
@@ -817,7 +817,7 @@ local function generate_endpoints(schema, endpoints)
   generate_entity_endpoints(endpoints, schema)
 
   for foreign_field_name, foreign_field in schema:each_field() do
-    if foreign_field.type == "foreign" and not foreign_field.schema.legacy then
+    if foreign_field.type == "foreign" then
       -- e.g. /routes/:routes/service
       generate_entity_endpoints(endpoints, schema, foreign_field.schema, foreign_field_name, true)
 

--- a/kong/api/init.lua
+++ b/kong/api/init.lua
@@ -86,7 +86,7 @@ do
 
   -- DAO Routes
   for _, dao in pairs(kong.db.daos) do
-    if dao.schema.generate_admin_api ~= false and not dao.schema.legacy then
+    if dao.schema.generate_admin_api ~= false then
       routes = Endpoints.new(dao.schema, routes)
     end
   end

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1663,10 +1663,6 @@ function Schema:process_auto_fields(data, context, nulls, opts)
   for key, field in self:each_field(data) do
     local ftype = field.type
     local value = data[key]
-    if field.legacy and field.uuid and value == "" then
-      value = null
-    end
-
     if not is_select and field.auto then
       local is_insert_or_upsert = context == "insert" or context == "upsert"
       if field.uuid then
@@ -1782,10 +1778,7 @@ function Schema:process_auto_fields(data, context, nulls, opts)
   for key in pairs(data) do
     local field = self.fields[key]
     if field then
-      if not field.legacy
-         and field.type == "string"
-         and (field.len_min or 1) > 0
-         and data[key] == ""
+      if field.type == "string" and (field.len_min or 1) > 0 and data[key] == ""
       then
         data[key] = nulls and null or nil
       end

--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -79,7 +79,6 @@ local field_schema = {
   { default = { type = "self" }, },
   { abstract = { type = "boolean" }, },
   { generate_admin_api = { type = "boolean" }, },
-  { legacy = { type = "boolean" }, },
   { immutable = { type = "boolean" }, },
   { err = { type = "string" } },
   { encrypted = { type = "boolean" }, },
@@ -337,9 +336,6 @@ local attribute_types = {
     ["integer"] = true,
   },
   uuid = {
-    ["string"] = true,
-  },
-  legacy = {
     ["string"] = true,
   },
   unique = {
@@ -623,12 +619,6 @@ local MetaSchema = Schema.new({
     {
       admin_api_nested_name = {
         type = "string",
-        nilable = true,
-      },
-    },
-    {
-      legacy = {
-        type = "boolean",
         nilable = true,
       },
     },

--- a/spec/01-unit/01-db/01-schema/01-schema_spec.lua
+++ b/spec/01-unit/01-db/01-schema/01-schema_spec.lua
@@ -2818,13 +2818,11 @@ describe("schema", function()
             arr = { type = "array", elements = { type = "string" } }, }, {
             set = { type = "set", elements = { type = "string" } }, }, {
             map = { type = "map", keys = { type = "string" }, values = { type = "string" } }, }, {
-            est = { type = "string", len_min = 0 }, }, {
-            lst = { type = "string", legacy = true }, }, } } },
+            est = { type = "string", len_min = 0 }, }, }, }, },
           { arr = { type = "array", elements = { type = "string" } }, },
           { set = { type = "set", elements = { type = "string" } }, },
           { map = { type = "map", keys = { type = "string" }, values = { type = "string" } }, },
           { est = { type = "string", len_min = 0 }, },
-          { lst = { type = "string", legacy = true }, },
         }
       })
       local data, err = Test:process_auto_fields({
@@ -2835,13 +2833,11 @@ describe("schema", function()
           set = { "", "a", "" },
           map = { key = "" },
           est = "",
-          lst = "",
         },
         arr = { "", "a", "" },
         set = { "", "a", "" },
         map = { key = "" },
         est = "",
-        lst = "",
       }, "select")
 
       assert.is_nil(err)
@@ -2850,7 +2846,6 @@ describe("schema", function()
       assert.same({"", "a" }, data.set)        -- set,   TODO: should we remove empty strings from sets?
       assert.same({ key = "" }, data.map)      -- map,   TODO: should we remove empty strings from maps?
       assert.equal("", data.est)
-      assert.equal("", data.lst)
 
       -- record
       assert.equal(nil, data.rec.str)          -- string
@@ -2858,7 +2853,6 @@ describe("schema", function()
       assert.same({"", "a" }, data.rec.set)    -- set,   TODO: should we remove empty strings from sets?
       assert.same({ key = "" }, data.rec.map)  -- map,   TODO: should we remove empty strings from maps?
       assert.equal("", data.rec.est)
-      assert.equal("", data.rec.lst)
     end)
 
     it("produces ngx.null (when asked) for empty string fields with selects", function()
@@ -2870,13 +2864,11 @@ describe("schema", function()
             arr = { type = "array", elements = { type = "string" } }, }, {
             set = { type = "set", elements = { type = "string" } }, }, {
             map = { type = "map", keys = { type = "string" }, values = { type = "string" } }, }, {
-            est = { type = "string", len_min = 0 }, }, {
-            lst = { type = "string", legacy = true }, }, } } },
+            est = { type = "string", len_min = 0 }, }, }, }, },
           { arr = { type = "array", elements = { type = "string" } }, },
           { set = { type = "set", elements = { type = "string" } }, },
           { map = { type = "map", keys = { type = "string" }, values = { type = "string" } }, },
           { est = { type = "string", len_min = 0 }, },
-          { lst = { type = "string", legacy = true }, },
         }
       })
       local data, err = Test:process_auto_fields({
@@ -2887,13 +2879,11 @@ describe("schema", function()
           set = { "", "a", "" },
           map = { key = "" },
           est = "",
-          lst = "",
         },
         arr = { "", "a", "" },
         set = { "", "a", "" },
         map = { key = "" },
         est = "",
-        lst = "",
       }, "select", true)
       assert.is_nil(err)
       assert.equal(cjson.null, data.str)       -- string
@@ -2901,7 +2891,6 @@ describe("schema", function()
       assert.same({"", "a" }, data.set)        -- set,   TODO: should we set null empty strings from sets?
       assert.same({ key = "" }, data.map)      -- map,   TODO: should we set null empty strings from maps?
       assert.equal("", data.est)
-      assert.equal("", data.lst)
 
       -- record
       assert.equal(cjson.null, data.rec.str)   -- string
@@ -2909,7 +2898,6 @@ describe("schema", function()
       assert.same({"", "a" }, data.rec.set)    -- set,   TODO: should we set null empty strings from sets?
       assert.same({ key = "" }, data.rec.map)  -- map,   TODO: should we set null empty strings from maps?
       assert.equal("", data.rec.est)
-      assert.equal("", data.rec.lst)
     end)
 
     it("does not produce non-required fields on 'update'", function()

--- a/spec/01-unit/01-db/01-schema/02-metaschema_spec.lua
+++ b/spec/01-unit/01-db/01-schema/02-metaschema_spec.lua
@@ -124,14 +124,14 @@ describe("metaschema", function()
     assert.truthy(MetaSchema:validate(s))
   end)
 
-  it("a schema can be marked as legacy", function()
+  it("a schema cannot be marked as legacy", function()
     local s = {
       name = "hello",
       primary_key = { "foo" },
       legacy = true,
       fields = {
         { foo = { type = "number" } } } }
-    assert.truthy(MetaSchema:validate(s))
+    assert.falsy(MetaSchema:validate(s))
 
     s = {
       name = "hello",

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -336,7 +336,7 @@ local function truncate_tables(db, tables)
   end
 
   for _, t in ipairs(tables) do
-    if db[t] and db[t].schema and not db[t].schema.legacy then
+    if db[t] and db[t].schema then
       db[t]:truncate()
     end
   end


### PR DESCRIPTION
### Summary

Removes `legacy = true` support from `schemas` and from `schema fields`.