### PR TITLE
chore(deps) bump `lua-resty-timer-ng` from 0.1.0 to 0.2.0

### DIFF
--- a/kong-2.8.0-0.rockspec
+++ b/kong-2.8.0-0.rockspec
@@ -41,7 +41,7 @@ dependencies = {
   "lua-resty-ipmatcher == 0.6.1",
   "lua-resty-acme == 0.8.0",
   "lua-resty-session == 3.10",
-  "lua-resty-timer-ng == 0.1.0",
+  "lua-resty-timer-ng == 0.2.0",
 }
 build = {
   type = "builtin",


### PR DESCRIPTION
## Changes of [lua-resty-timer-ng](https://github.com/Kong/lua-resty-timer-ng)

* [feat(stats) add field is_running to `timer:stats().timers.<timer_name>](https://github.com/Kong/lua-resty-timer-ng/commit/af977e31413f6387a30cc25ea327939d6a4c1f48)
* [fix(*) reduce log amount](https://github.com/Kong/lua-resty-timer-ng/commit/7e15ffa3783b9baa0ca77e4573b5e45b0c6a3176)