### PR TITLE
fix(rate-limiting) Restore atomic updates to Redis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,7 @@
   [#9173](https://github.com/Kong/kong/pull/9173)
 - **AWS Lambda**: add `requestContext` field into `awsgateway_compatible` input data
   [#9380](https://github.com/Kong/kong/pull/9380)
+- **rate-limiting**: Restore atomic updates to Redis [#8963](https://github.com/Kong/kong/pull/8963)
 
 
 ## [3.0.0]

--- a/kong/plugins/rate-limiting/policies/init.lua
+++ b/kong/plugins/rate-limiting/policies/init.lua
@@ -184,35 +184,21 @@ return {
         return nil, err
       end
 
-      local keys = {}
-      local expiration = {}
-      local idx = 0
       local periods = timestamp.get_timestamps(current_timestamp)
+      red:init_pipeline()
       for period, period_date in pairs(periods) do
         if limits[period] then
           local cache_key = get_local_key(conf, identifier, period, period_date)
-          local exists, err = red:exists(cache_key)
-          if err then
-            kong.log.err("failed to query Redis: ", err)
-            return nil, err
-          end
 
-          idx = idx + 1
-          keys[idx] = cache_key
-          if not exists or exists == 0 then
-            expiration[idx] = EXPIRATION[period]
-          end
+          red:eval([[
+            local key, value, expiration = KEYS[1], tonumber(ARGV[1]), ARGV[2]
 
-          red:init_pipeline()
-          for i = 1, idx do
-            red:incrby(keys[i], value)
-            if expiration[i] then
-              red:expire(keys[i], expiration[i])
+            if redis.call("incrby", key, value) == value then
+              redis.call("expire", key, expiration)
             end
-          end
+          ]], 1, cache_key, value, EXPIRATION[period])
         end
       end
-
       local _, err = red:commit_pipeline()
       if err then
         kong.log.err("failed to commit increment pipeline in Redis: ", err)

--- a/spec/03-plugins/23-rate-limiting/05-integration_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/05-integration_spec.lua
@@ -32,7 +32,7 @@ local function flush_redis(red, db)
 end
 
 local function add_redis_user(red)
-  assert(red:acl("setuser", REDIS_USER_VALID, "on", "allkeys", "+incrby", "+select", "+info", "+expire", "+get", "+exists", ">" .. REDIS_PASSWORD))
+  assert(red:acl("setuser", REDIS_USER_VALID, "on", "allkeys", "allcommands", ">" .. REDIS_PASSWORD))
   assert(red:acl("setuser", REDIS_USER_INVALID, "on", "allkeys", "+get", ">" .. REDIS_PASSWORD))
 end
 


### PR DESCRIPTION
### Summary

This is a partial revert of https://github.com/Kong/kong/commit/83bbfd76b56279ccdfaa9e45b79f36c0199f9a9c (https://github.com/Kong/kong/pull/8213) which restores atomic updates to Redis as originally added in https://github.com/Kong/kong/commit/6125577eb73eb4a156133fe2ccea22ee6cb75290 (https://github.com/Kong/kong/pull/6150).

It retains the additional integration tests are broken by this change and are fixed by..

Give the `REDIS_USER_VALID` permission to execute all commands rather than a restricted list. This fixes the "respects database setting" test after restoring atomic updates in the preceding commit because it now has permission to execute `EVAL` commands. It was painful to debug because `commit_pipeline` didn't return any errors and just silently failed to increment the key.

It's my interpretation that the atomic updates were only reverted to satisfy these tests.

### Full changelog

* fix(rate-limiting) Restore atomic updates to Redis
* fix(rate-limiting) Fix ACL tests

### Issue reference

Fix #8729
Supersedes #8751 which was having some trouble with the tests