### PR TITLE
fix(plugin) pairs disorder when iterate over timestamp table

### DIFF
--- a/kong/plugins/rate-limiting/policies/cluster.lua
+++ b/kong/plugins/rate-limiting/policies/cluster.lua
@@ -71,7 +71,8 @@ return {
       local buf = { "BEGIN" }
       local len = 1
       local periods = timestamp.get_timestamps(current_timestamp)
-      for period, period_date in pairs(periods) do
+      for _, period in ipairs(timestamp.timestamp_table_fields) do
+        local period_date = periods[period]
         if limits[period] then
           len = len + 1
           buf[len] = fmt([[

--- a/kong/plugins/response-ratelimiting/policies/cluster.lua
+++ b/kong/plugins/response-ratelimiting/policies/cluster.lua
@@ -76,7 +76,8 @@ return {
       local len = 1
       local periods = timestamp.get_timestamps(current_timestamp)
 
-      for period, period_date in pairs(periods) do
+      for _, period in ipairs(timestamp.timestamp_table_fields) do
+        local period_date = periods[period]
         len = len + 1
         buf[len] = fmt([[
           INSERT INTO "response_ratelimiting_metrics" ("identifier", "period", "period_date", "service_id", "route_id", "value")

--- a/kong/tools/timestamp.lua
+++ b/kong/tools/timestamp.lua
@@ -9,6 +9,7 @@ local tz_time = luatz.time
 local tt_from_timestamp = luatz.timetable.new_from_timestamp
 local tt = luatz.timetable.new
 local math_floor = math.floor
+local tablex = require "pl.tablex"
 
 --- Current UTC time
 -- @return UTC time in milliseconds since epoch, but with SECOND precision.
@@ -72,4 +73,5 @@ return {
   get_utc_ms = get_utc_ms,
   get_timetable = get_timetable,
   get_timestamps = get_timestamps,
+  timestamp_table_fields = tablex.readonly({"second", "minute", "hour", "day", "month", "year"})
 }


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
This PR aims to fix a disordered behaviour caused by `pairs` which will eventually cause a Postgres DEADLOCK problem.

Currently, SQL transaction that does an increase on rate limit metrics over all spans of the timestamp table is concatenated over a `pairs` code block. The code will iterate through the timestamp table(which is defined as below):
https://github.com/Kong/kong/blob/a02542d6dfb96073c4ef6ab5f86b350b756ae2fa/kong/tools/timestamp.lua#L45-L68

The `pairs` function **does not guarantee the order of the iteration process**, thus the generated SQL might be **disordered**.
In a classic clustering mode(not the DP/CP mode, just multiple Kong instances sharing one database), the SQL may look like this(logs get truncated but as you can see, the `day` insert SQL is in front of the `second` insert SQL)

```
        Process 3207: BEGIN;
                    INSERT INTO "ratelimiting_metrics" ("identifier", "period", "period_date", "service_id", "route_id", "value", "ttl")
                         VALUES ('6b98d6aa-afb6-44d5-b0fe-8cab6a337fd7', 'day', TO_TIMESTAMP(1655337600) AT TIME ZONE 'UTC', '32877632-9f69-4430-a046-3023dc333045', '00000000-0000-0000-0000-000000000000', 1, CURRENT_TIMESTAMP AT TIME ZONE 'UTC'
+ INTERVAL '86400 second')
                    ON CONFLICT ("identifier", "period", "period_date", "service_id", "route_id") DO UPDATE
                            SET "value" = "ratelimiting_metrics"."value" + EXCLUDED."value"
                  ;
                    INSERT INTO "ratelimiting_metrics" ("identifier", "period", "period_date", "service_id", "route_id", "value", "ttl")
                         VALUES ('6b98d6aa-afb6-44d5-b0fe-8cab6a337fd7', 'second', TO_TIMESTAMP(1655398014) AT TIME ZONE 'UTC', '32877632-9f69-4430-a046-3023dc333045', '00000000-0000-0000-0000-000000000000', 1, CURRENT_TIMESTAMP AT TIME ZONE 'UT
C' + INTERVAL '1 second')
                    ON CONFLICT ("identifie
```

And in another instance's request, it may look like this(the `second` insert SQL is in front of the `day` insert SQL):

```
        Process 3198: BEGIN;
                    INSERT INTO "ratelimiting_metrics" ("identifier", "period", "period_date", "service_id", "route_id", "value", "ttl")
                         VALUES ('6b98d6aa-afb6-44d5-b0fe-8cab6a337fd7', 'second', TO_TIMESTAMP(1655398014) AT TIME ZONE 'UTC', '32877632-9f69-4430-a046-3023dc333045', '00000000-0000-0000-0000-000000000000', 1, CURRENT_TIMESTAMP AT TIME ZONE 'UT
C' + INTERVAL '1 second')
                    ON CONFLICT ("identifier", "period", "period_date", "service_id", "route_id") DO UPDATE
                            SET "value" = "ratelimiting_metrics"."value" + EXCLUDED."value"
                  ;
                    INSERT INTO "ratelimiting_metrics" ("identifier", "period", "period_date", "service_id", "route_id", "value", "ttl")
                         VALUES ('6b98d6aa-afb6-44d5-b0fe-8cab6a337fd7', 'day', TO_TIMESTAMP(1655337600) AT TIME ZONE 'UTC', '32877632-9f69-4430-a046-3023dc333045', '00000000-0000-0000-0000-000000000000', 1, CURRENT_TIMESTAMP AT TIME ZONE 'UTC'
+ INTERVAL '86400 second')
                    ON CONFLICT ("identifie
```

And that caused a **deadlock** problem:

```
ERROR:  deadlock detected
DETAIL:  Process 3207 waits for ShareLock on transaction 99215; blocked by process 3198.
        Process 3198 waits for ShareLock on transaction 99350; blocked by process 3207.
```

You can easily reproduce this error with deploying multiple Kong instance sharing one database and with rate-limiting plugin enabled, and then give them some pressure, the problem will show up soon.

I changed the `pairs` into `ipairs` and iterate over an already prepared timestamp field table, which ensures that we are generating the SQL transaction in the predicted order and avoiding the deadlock problem.

### Full changelog

* Change rate-limiting/response rate-limiting plugins cluster policy behavior, from `pairs` iterating timestamp table to `ipairs` iterate firstly through timestamp field table, and then generate SQL into a predicted order

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix [FTI-4096](https://konghq.atlassian.net/browse/FTI-4096)
