### PR TITLE
perf(handler) do not use cache with dbless when looking up service for route

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -684,13 +684,13 @@ do
     local err
 
     -- kong.core_cache is available, not in init phase
-    if kong.core_cache then
+    if kong.core_cache and db.strategy ~= "off" then
       local cache_key = db.services:cache_key(service_pk.id, nil, nil, nil, nil,
                                               route.ws_id)
       service, err = kong.core_cache:get(cache_key, TTL_ZERO,
                                     load_service_from_db, service_pk)
 
-    else -- init phase, kong.core_cache not available
+    else -- dbless or init phase: kong.core_cache not needed/available
 
       -- A new service/route has been inserted while the initial route
       -- was being created, on init (perhaps by a different Kong node).


### PR DESCRIPTION
### Summary

It does not make sense to use cache with dbless where the data is already in memory, especially because the route rebuild process can use a lookup table.

It also consumes a lot of memory to have service in:
1. lmdb (in memory)
2. shared dictionary (in memory)
3. worker local memory

So this commit removes the unneccessary use of cache here.

Reading shdict also causes locking.