### PR TITLE
fix(balancer) fix upstreams reload every 10s

### DIFF
--- a/kong/runloop/balancer/upstreams.lua
+++ b/kong/runloop/balancer/upstreams.lua
@@ -106,15 +106,13 @@ end
 --_load_upstreams_dict_into_memory = load_upstreams_dict_into_memory
 
 
-local opts = { neg_ttl = 10 }
-
 ------------------------------------------------------------------------------
 -- Implements a simple dictionary with all upstream-ids indexed
 -- by their name.
 -- @return The upstreams dictionary (a map with upstream names as string keys
 -- and upstream entity tables as values), or nil+error
 function upstreams_M.get_all_upstreams()
-  return kong.core_cache:get("balancer:upstreams", opts,
+  return kong.core_cache:get("balancer:upstreams", nil,
                                                   load_upstreams_dict_into_memory)
 end
 

--- a/kong/runloop/balancer/upstreams.lua
+++ b/kong/runloop/balancer/upstreams.lua
@@ -82,6 +82,7 @@ end
 ------------------------------------------------------------------------------
 
 local function load_upstreams_dict_into_memory()
+  log(DEBUG, "loading upstreams dict into memory")
   local upstreams_dict = {}
 
   -- build a dictionary, indexed by the upstream name

--- a/kong/runloop/balancer/upstreams.lua
+++ b/kong/runloop/balancer/upstreams.lua
@@ -95,7 +95,7 @@ local function load_upstreams_dict_into_memory()
   for up, err in upstreams:each(page_size, GLOBAL_QUERY_OPTS) do
     if err then
       log(CRIT, "could not obtain list of upstreams: ", err)
-      return nil
+      return nil, err
     end
 
     upstreams_dict[up.ws_id .. ":" .. up.name] = up.id
@@ -114,13 +114,8 @@ local opts = { neg_ttl = 10 }
 -- @return The upstreams dictionary (a map with upstream names as string keys
 -- and upstream entity tables as values), or nil+error
 function upstreams_M.get_all_upstreams()
-  local upstreams_dict, err = kong.core_cache:get("balancer:upstreams", opts,
+  return kong.core_cache:get("balancer:upstreams", opts,
                                                   load_upstreams_dict_into_memory)
-  if err then
-    return nil, err
-  end
-
-  return upstreams_dict
 end
 
 ------------------------------------------------------------------------------

--- a/kong/runloop/balancer/upstreams.lua
+++ b/kong/runloop/balancer/upstreams.lua
@@ -83,7 +83,6 @@ end
 
 local function load_upstreams_dict_into_memory()
   local upstreams_dict = {}
-  local found = nil
 
   -- build a dictionary, indexed by the upstream name
   local upstreams = kong.db.upstreams
@@ -99,10 +98,9 @@ local function load_upstreams_dict_into_memory()
     end
 
     upstreams_dict[up.ws_id .. ":" .. up.name] = up.id
-    found = true
   end
 
-  return found and upstreams_dict
+  return upstreams_dict
 end
 --_load_upstreams_dict_into_memory = load_upstreams_dict_into_memory
 
@@ -121,7 +119,7 @@ function upstreams_M.get_all_upstreams()
     return nil, err
   end
 
-  return upstreams_dict or {}
+  return upstreams_dict
 end
 
 ------------------------------------------------------------------------------

--- a/kong/runloop/balancer/upstreams.lua
+++ b/kong/runloop/balancer/upstreams.lua
@@ -17,6 +17,7 @@ local log = ngx.log
 local null = ngx.null
 local table_remove = table.remove
 local timer_at = ngx.timer.at
+local isempty = require("table.isempty")
 
 
 local CRIT = ngx.CRIT
@@ -99,6 +100,12 @@ local function load_upstreams_dict_into_memory()
     end
 
     upstreams_dict[up.ws_id .. ":" .. up.name] = up.id
+  end
+
+  -- please refer to https://github.com/Kong/kong/pull/4301 and
+  -- https://github.com/Kong/kong/pull/8974#issuecomment-1317788871
+  if isempty(upstreams_dict) then
+    log(DEBUG, "empty upstreams dict. Could it be an uncatched database error?")
   end
 
   return upstreams_dict

--- a/spec/02-integration/06-invalidations/04-balancer_cache_correctness_spec.lua
+++ b/spec/02-integration/06-invalidations/04-balancer_cache_correctness_spec.lua
@@ -32,8 +32,7 @@ for _, strategy in helpers.each_strategy() do
       assert.logfile().has.line("loading upstreams dict into memory", true, 5)
       -- turncate log
       io.open("./servroot/logs/error.log", "w"):close()
-      ngx.sleep(20)
-      assert.logfile().has.no.line("loading upstreams dict into memory", true)
+      assert.logfile().has.no.line("loading upstreams dict into memory", true, 20)
     end)
   end)
 end

--- a/spec/02-integration/06-invalidations/04-balancer_cache_correctness_spec.lua
+++ b/spec/02-integration/06-invalidations/04-balancer_cache_correctness_spec.lua
@@ -1,6 +1,4 @@
-local cjson   = require "cjson"
 local helpers = require "spec.helpers"
-local utils   = require "kong.tools.utils"
 
 local POLL_INTERVAL = 0.3
 

--- a/spec/02-integration/06-invalidations/04-balancer_cache_correctness_spec.lua
+++ b/spec/02-integration/06-invalidations/04-balancer_cache_correctness_spec.lua
@@ -1,0 +1,41 @@
+local cjson   = require "cjson"
+local helpers = require "spec.helpers"
+local utils   = require "kong.tools.utils"
+
+local POLL_INTERVAL = 0.3
+
+for _, strategy in helpers.each_strategy() do
+  describe("balancer cache [#" .. strategy .. "]", function()
+
+    lazy_setup(function()
+      -- truncate the database so we have zero upstreams
+      helpers.get_db_utils(strategy, { "upstreams", })
+
+      local db_update_propagation = strategy == "cassandra" and 0.1 or 0
+
+      assert(helpers.start_kong {
+        log_level             = "debug",
+        database              = strategy,
+        proxy_listen          = "0.0.0.0:8000, 0.0.0.0:8443 ssl",
+        admin_listen          = "0.0.0.0:8001",
+        db_update_frequency   = POLL_INTERVAL,
+        db_update_propagation = db_update_propagation,
+        nginx_conf            = "spec/fixtures/custom_nginx.template",
+      })
+    end)
+
+    lazy_teardown(function()
+      helpers.stop_kong()
+    end)
+
+
+    -- https://github.com/Kong/kong/issues/8970
+    it("upstreams won't reload at unusual rate", function()
+      assert.logfile().has.line("loading upstreams dict into memory", true, 5)
+      -- turncate log
+      io.open("./servroot/logs/error.log", "w"):close()
+      ngx.sleep(20)
+      assert.logfile().has.no.line("loading upstreams dict into memory", true)
+    end)
+  end)
+end


### PR DESCRIPTION
The upstreams module's load_upstreams_dict_into_memory returned
non-cacheable value when upstreams table is empty, causing empty
table reload in request context after 10s negative TTL's expiration.

### Summary

See https://github.com/Kong/kong/issues/8970#issue-1273886114.

To fix this, empty table may be considered a valid value to cache.

### Full changelog

* [Fix empty upstreams table reload every 10s]

### Issue reference

Fix #8970
