### PR TITLE
fix(dao) cache invalidation on deletion of non-workspaceable daos

### DIFF
--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -870,7 +870,7 @@ local function generate_foreign_key_methods(schema)
           return nil, err, err_t
         end
 
-        local show_ws_id = { show_ws_id = true }
+        local show_ws_id = { show_ws_id = self.schema.workspaceable == true }
         local entity, err, err_t = self["select_by_" .. name](self, unique_value, show_ws_id)
         if err then
           return nil, err, err_t
@@ -1245,7 +1245,7 @@ function DAO:delete(primary_key, options)
     return nil, tostring(err_t), err_t
   end
 
-  local show_ws_id = { show_ws_id = true }
+  local show_ws_id = { show_ws_id = self.schema.workspaceable == true }
   local entity, err, err_t = self:select(primary_key, show_ws_id)
   if err then
     return nil, err, err_t

--- a/spec/fixtures/custom_plugins/kong/plugins/foreign-entity/api.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/foreign-entity/api.lua
@@ -1,0 +1,60 @@
+local kong = kong
+
+local foreign_entities = kong.db.foreign_entities
+local foreign_references = kong.db.foreign_references
+
+local function select_by_name(params)
+  return params.dao:select_by_name(params.name)
+end
+
+local function get_cached(self, dao, cb)
+  local name = self.params[dao.schema.name]
+
+  local cache_key = dao:cache_key(name)
+  local entity, err = kong.cache:get(cache_key, nil, cb, { dao = dao, name = name })
+
+  if err then
+    kong.log.debug(err)
+  end
+
+  if not entity then
+    return kong.response.exit(404)
+  end
+
+  return kong.response.exit(200, entity)
+end
+
+return {
+  ["/foreign_entities_cache_warmup/:foreign_entities"] = {
+    schema = foreign_entities.schema,
+    methods = {
+      GET = function(self, db)
+        return get_cached(self, foreign_entities, select_by_name)
+      end,
+    },
+  },
+  ["/foreign_entities_cache/:foreign_entities"] = {
+    schema = foreign_entities.schema,
+    methods = {
+      GET = function(self, db)
+        return get_cached(self, foreign_entities)
+      end,
+    },
+  },
+  ["/foreign_references_cache_warmup/:foreign_references"] = {
+    schema = foreign_references.schema,
+    methods = {
+      GET = function(self, db)
+        return get_cached(self, foreign_references, select_by_name)
+      end,
+    },
+  },
+  ["/foreign_references_cache/:foreign_references"] = {
+    schema = foreign_references.schema,
+    methods = {
+      GET = function(self, db)
+        return get_cached(self, foreign_references)
+      end,
+    },
+  },
+}

--- a/spec/fixtures/custom_plugins/kong/plugins/foreign-entity/daos.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/foreign-entity/daos.lua
@@ -6,6 +6,7 @@ return {
     name = "foreign_entities",
     primary_key = { "id" },
     endpoint_key = "name",
+    cache_key = { "name" },
     admin_api_name = "foreign-entities",
     fields = {
       { id = typedefs.uuid },
@@ -17,6 +18,7 @@ return {
     name = "foreign_references",
     primary_key = { "id" },
     endpoint_key = "name",
+    cache_key = { "name" },
     admin_api_name = "foreign-references",
     fields = {
       { id = typedefs.uuid },


### PR DESCRIPTION
### Summary

<!--- Why is this change required? What problem does it solve? -->

At present when a DAO is deleted, the cache key generated is always suffixed with the workspace id (see logs below for an example). This means that, for example, any custom plugin entities that are deleted via an admin API endpoint are not being evicted from the cache. This PR attempts to address the issue by ensuring that the `delete` and `delete_by_` DAO methods respect whether or not the entity schema is marked as `workspaceable`

```
2022/06/18 08:30:41 [debug] 8924#0: *25 [lua] events.lua:211: do_event(): worker-events: handling event; source=dao:crud, event=delete, pid=nil, data=table: 0x7f7f6033ae80
2022/06/18 08:30:41 [debug] 8924#0: *25 [lua] init.lua:229: invalidate_local(): [DB cache] invalidating (local): 'foreign_references:foreign-reference:::::aa1c7921-afad-4e48-bb9b-7234e7f37b5e'
2022/06/18 08:30:41 [debug] 8924#0: *25 [lua] events.lua:211: do_event_json(): worker-events: handling event; source=mlcache, event=mlcache:invalidations:kong_db_cache, pid=8924, data=foreign_references:foreign-reference:::::aa1c7921-afad-4e48-bb9b-7234e7f37b5e
2022/06/18 08:30:41 [debug] 8924#0: *25 [lua] init.lua:250: invalidate(): [DB cache] broadcasting (cluster) invalidation for key: 'foreign_references:foreign-reference:::::aa1c7921-afad-4e48-bb9b-7234e7f37b5e'
```

### Full changelog

* Only set `show_ws_id` in delete methods to `true` if entity schema has `workspaceable == true`
* Added tests that ensure that non-workspaceable entities deleted via the admin API are correctly evicted from the cache
  - Note: I struggled to find the correct place to try and test this functionality. So, whilst the tests I have written do prove the point, I won't be surprised if there's a better way/place to do this. Feel free to point me in the right direction :smile: 

### Issue reference

