### PR TITLE
tests(autodoc) return exit code 1 when autodoc generation failed

### DIFF
--- a/scripts/autodoc
+++ b/scripts/autodoc
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 DOCS_REPO=$1
 DOCS_VERSION=$2
 
@@ -75,9 +77,9 @@ function insert_yaml_file_into_nav_file() {
 echo "Generating docs ..."
 
 rm -rf ./autodoc/output
-./autodoc/admin-api/generate.lua && \
-./autodoc/cli/generate.lua && \
-./autodoc/upgrading/generate.lua && \
+./autodoc/admin-api/generate.lua
+./autodoc/cli/generate.lua
+./autodoc/upgrading/generate.lua
 ./autodoc/pdk/generate.lua
 
 if [ -z "$DOCS_REPO" ] || [ -z "$DOCS_VERSION" ]


### PR DESCRIPTION
### Summary

Fix autodoc output, it will throw error code 1 when autodoc generation failed.

related: https://github.com/Kong/kong/pull/8984