### PR TITLE
chore(labler) fix autodoc path

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -25,7 +25,9 @@ changelog:
 
 core/docs:
 - any: ['**/*.md', '!CHANGELOG.md']
-- 'kong/autodoc/**/*'
+
+autodoc:
+- 'autodoc/**/*'
 
 core/language/go:
 - kong/runloop/plugin_servers/*


### PR DESCRIPTION
### Summary

Fix autodoc path, add `autodoc` label