### PR TITLE
chore(plugin) local cache ipairs function

### DIFF
--- a/kong/plugins/rate-limiting/policies/cluster.lua
+++ b/kong/plugins/rate-limiting/policies/cluster.lua
@@ -5,6 +5,7 @@ local cassandra = require "cassandra"
 local kong = kong
 local concat = table.concat
 local pairs = pairs
+local ipairs = ipairs
 local floor = math.floor
 local fmt = string.format
 local tonumber = tonumber


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Make local cache of `ipairs` function in rate-limit module level. Missed this #8968 

### Full changelog

* Make local cache of `ipairs` function in rate-limit module level

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
