### PR TITLE
fix(*) drop luasocket in CLI

### DIFF
--- a/bin/busted
+++ b/bin/busted
@@ -54,5 +54,13 @@ require("kong.globalpatches")({
   rbusted = true
 })
 
+-- some libraries used in test like spec/helpers
+-- calls cosocket in module level, and as LuaJIT's
+-- `require` is implemented in C, this throws
+-- "attempt to yield across C-call boundary" error
+-- the following pure-lua implementation is to bypass
+-- this limitation, without need to modify all tests
+_G.require = require "spec.require".require
+
 -- Busted command-line runner
 require 'busted.runner'({ standalone = false })

--- a/kong-2.8.0-0.rockspec
+++ b/kong-2.8.0-0.rockspec
@@ -113,6 +113,7 @@ build = {
     ["kong.cmd.utils.nginx_signals"] = "kong/cmd/utils/nginx_signals.lua",
     ["kong.cmd.utils.prefix_handler"] = "kong/cmd/utils/prefix_handler.lua",
     ["kong.cmd.utils.process_secrets"] = "kong/cmd/utils/process_secrets.lua",
+    ["kong.cmd.utils.respawn_cli."] = "kong/cmd/utils/respawn_cli.lua",
 
     ["kong.api"] = "kong/api/init.lua",
     ["kong.api.api_helpers"] = "kong/api/api_helpers.lua",

--- a/kong-2.8.0-0.rockspec
+++ b/kong-2.8.0-0.rockspec
@@ -113,7 +113,7 @@ build = {
     ["kong.cmd.utils.nginx_signals"] = "kong/cmd/utils/nginx_signals.lua",
     ["kong.cmd.utils.prefix_handler"] = "kong/cmd/utils/prefix_handler.lua",
     ["kong.cmd.utils.process_secrets"] = "kong/cmd/utils/process_secrets.lua",
-    ["kong.cmd.utils.respawn_cli."] = "kong/cmd/utils/respawn_cli.lua",
+    ["kong.cmd.utils.respawn_cli"] = "kong/cmd/utils/respawn_cli.lua",
 
     ["kong.api"] = "kong/api/init.lua",
     ["kong.api.api_helpers"] = "kong/api/api_helpers.lua",

--- a/kong/cluster_events/init.lua
+++ b/kong/cluster_events/init.lua
@@ -126,7 +126,8 @@ function _M.new(opts)
 
   -- set current time (at)
 
-  local now = strategy:server_time() or ngx_now()
+  ngx_update_time()
+  local now = ngx_now()
   local ok, err = self.shm:safe_set(CURRENT_AT_KEY, now)
   if not ok then
     return nil, "failed to set 'at' in shm: " .. err

--- a/kong/cmd/init.lua
+++ b/kong/cmd/init.lua
@@ -3,6 +3,7 @@ require("kong.globalpatches")({cli = true})
 math.randomseed() -- Generate PRNG seed
 
 local pl_app = require "pl.lapp"
+local pl_tablex = require "pl.tablex"
 local log = require "kong.cmd.utils.log"
 
 local options = [[
@@ -44,6 +45,10 @@ Options:
 %s]], table.concat(cmds_arr, "\n "), options)
 
 return function(args)
+  -- copy the args table, so changes are not made to _G.arg
+  -- make it available in kong/cmd/utils/respawn_cli.lua
+  local args = pl_tablex.deepcopy(args)
+
   local cmd_name = table.remove(args, 1)
   if not cmd_name then
     pl_app(help)

--- a/kong/cmd/init.lua
+++ b/kong/cmd/init.lua
@@ -45,9 +45,8 @@ Options:
 %s]], table.concat(cmds_arr, "\n "), options)
 
 return function(args)
-  -- copy the args table, so changes are not made to _G.arg
-  -- make it available in kong/cmd/utils/respawn_cli.lua
-  local args = pl_tablex.deepcopy(args)
+  -- preserve args table to make it available in kong/cmd/utils/respawn_cli.lua
+  _G.cli_args = pl_tablex.deepcopy(args)
 
   local cmd_name = table.remove(args, 1)
   if not cmd_name then

--- a/kong/cmd/migrations.lua
+++ b/kong/cmd/migrations.lua
@@ -6,6 +6,7 @@ local conf_loader = require "kong.conf_loader"
 local kong_global = require "kong.global"
 local prefix_handler = require "kong.cmd.utils.prefix_handler"
 local migrations_utils = require "kong.cmd.utils.migrations"
+local respwan_cli = require "kong.cmd.utils.respawn_cli"
 
 
 local lapp = [[
@@ -85,6 +86,8 @@ local function execute(args)
   local conf = assert(conf_loader(args.conf, {
     prefix = args.prefix
   }))
+
+  respwan_cli(conf)
 
   package.path = conf.lua_package_path .. ";" .. package.path
 

--- a/kong/cmd/migrations.lua
+++ b/kong/cmd/migrations.lua
@@ -6,7 +6,7 @@ local conf_loader = require "kong.conf_loader"
 local kong_global = require "kong.global"
 local prefix_handler = require "kong.cmd.utils.prefix_handler"
 local migrations_utils = require "kong.cmd.utils.migrations"
-local respwan_cli = require "kong.cmd.utils.respawn_cli"
+local respawn_cli = require "kong.cmd.utils.respawn_cli"
 
 
 local lapp = [[
@@ -87,7 +87,7 @@ local function execute(args)
     prefix = args.prefix
   }))
 
-  respwan_cli(conf)
+  respawn_cli(conf)
 
   package.path = conf.lua_package_path .. ";" .. package.path
 

--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -583,4 +583,5 @@ return {
   compile_nginx_conf = compile_nginx_conf,
   gen_default_ssl_cert = gen_default_ssl_cert,
   write_env_file = write_env_file,
+  gen_trusted_certs_combined_file = gen_trusted_certs_combined_file,
 }

--- a/kong/cmd/utils/respawn_cli.lua
+++ b/kong/cmd/utils/respawn_cli.lua
@@ -1,0 +1,28 @@
+local pl_path = require "pl.path"
+local prefix_handler = require "kong.cmd.utils.prefix_handler"
+
+return function(conf)   
+  if not os.getenv("KONG_CLI_RESPAWNED") then
+    -- initial run, so go update the environment
+    local script = {}
+    -- add cli recursion detection
+    table.insert(script, "export KONG_CLI_RESPAWNED=1")
+
+    local combined = pl_path.join(ngx.config.prefix(), "lua_ssl_trusted_combined.crt")
+    prefix_handler.gen_trusted_certs_combined_file(combined, conf.lua_ssl_trusted_certificate)
+
+    -- rebuild the invoked commandline, while inserting extra resty-flags
+    local cmd = { "exec" }
+    for i = -1, #arg do
+      table.insert(cmd, "'" .. arg[i] .. "'")
+    end
+
+    table.insert(cmd, 3, "--http-conf 'lua_ssl_trusted_certificate " .. combined .. ";'")
+
+    table.insert(script, table.concat(cmd, " "))
+
+    -- recurse cli command, with proper variables (un)set for clean testing
+    local _, _, rc = os.execute(table.concat(script, "; "))
+    os.exit(rc)
+  end
+end

--- a/kong/cmd/utils/respawn_cli.lua
+++ b/kong/cmd/utils/respawn_cli.lua
@@ -13,8 +13,10 @@ return function(conf)
 
     -- rebuild the invoked commandline, while inserting extra resty-flags
     local cmd = { "exec" }
-    for i = -1, #arg do
-      table.insert(cmd, "'" .. arg[i] .. "'")
+    -- cli_args is a global set from kong/cmd/init.lua
+    local cli_args = _G.cli_args
+    for i = -1, #cli_args do
+      table.insert(cmd, "'" .. cli_args[i] .. "'")
     end
 
     table.insert(cmd, 3, "--http-conf 'lua_ssl_trusted_certificate " .. combined .. ";'")

--- a/kong/cmd/vault.lua
+++ b/kong/cmd/vault.lua
@@ -2,6 +2,7 @@ local kong_global = require "kong.global"
 local conf_loader = require "kong.conf_loader"
 local pl_path = require "pl.path"
 local log = require "kong.cmd.utils.log"
+local respwan_cli = require "kong.cmd.utils.respawn_cli"
 
 
 local DB = require "kong.db"
@@ -21,6 +22,8 @@ local function init_db(args)
     prefix = args.prefix
   }))
   log.enable()
+
+  respwan_cli(conf)
 
   if pl_path.exists(conf.kong_env) then
     -- load <PREFIX>/kong.conf containing running node's config

--- a/kong/cmd/vault.lua
+++ b/kong/cmd/vault.lua
@@ -2,7 +2,7 @@ local kong_global = require "kong.global"
 local conf_loader = require "kong.conf_loader"
 local pl_path = require "pl.path"
 local log = require "kong.cmd.utils.log"
-local respwan_cli = require "kong.cmd.utils.respawn_cli"
+local respawn_cli = require "kong.cmd.utils.respawn_cli"
 
 
 local DB = require "kong.db"
@@ -23,7 +23,7 @@ local function init_db(args)
   }))
   log.enable()
 
-  respwan_cli(conf)
+  respawn_cli(conf)
 
   if pl_path.exists(conf.kong_env) then
     -- load <PREFIX>/kong.conf containing running node's config

--- a/kong/db/strategies/cassandra/connector.lua
+++ b/kong/db/strategies/cassandra/connector.lua
@@ -152,12 +152,6 @@ function CassandraConnector.new(kong_config)
   if ngx.IS_CLI then
     local policy = require("resty.cassandra.policies.reconnection.const")
     cluster_options.reconn_policy = policy.new(100)
-
-    -- Force LuaSocket usage in the CLI in order to allow for self-signed
-    -- certificates to be trusted (via opts.cafile) in the resty-cli
-    -- interpreter (no way to set lua_ssl_trusted_certificate).
-    local socket = require "cassandra.socket"
-    socket.force_luasocket("timer", true)
   end
 
   if kong_config.cassandra_username and kong_config.cassandra_password then

--- a/kong/db/strategies/postgres/connector.lua
+++ b/kong/db/strategies/postgres/connector.lua
@@ -193,17 +193,6 @@ local setkeepalive
 
 
 local function connect(config)
-  local phase = get_phase()
-  if phase == "init" or phase == "init_worker" or ngx.IS_CLI then
-    -- Force LuaSocket usage in the CLI in order to allow for self-signed
-    -- certificates to be trusted (via opts.cafile) in the resty-cli
-    -- interpreter (no way to set lua_ssl_trusted_certificate).
-    config.socket_type = "luasocket"
-
-  else
-    config.socket_type = "nginx"
-  end
-
   local connection = pgmoon.new(config)
 
   connection.convert_null = true

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -703,10 +703,12 @@ function Kong.init_worker()
   end
 
   if kong.configuration.role ~= "control_plane" then
-    ok, err = execute_cache_warmup(kong.configuration)
-    if not ok then
-      ngx_log(ngx_ERR, "failed to warm up the DB cache: " .. err)
-    end
+    ngx.timer.at(0, function()
+      local ok, err = execute_cache_warmup(kong.configuration)
+      if not ok then
+        ngx_log(ngx_ERR, "failed to warm up the DB cache: " .. err)
+      end
+    end)
   end
 
   runloop.init_worker.before()

--- a/spec/02-integration/03-db/01-db_spec.lua
+++ b/spec/02-integration/03-db/01-db_spec.lua
@@ -265,12 +265,12 @@ for _, strategy in helpers.each_strategy() do
       assert.is_table(conn)
     end)
 
-    it("returns opened connection when using cosockets", function()
-      -- bin/busted runs with ngx.IS_CLI = true, which forces luasocket to
+    it("returns opened connection when using IS_CLI=false", function()
+      -- bin/busted runs with ngx.IS_CLI = true, which forces IS_CLI=true to
       -- be used in the DB connector (for custom CAs to work)
       -- Disable this behavior for this test, especially considering we
       -- are running within resty-cli, and thus within timer_by_lua (which
-      -- can support cosockets).
+      -- can support IS_CLI=false).
       ngx.IS_CLI = false
 
       local db, err = DB.new(helpers.test_conf, strategy)
@@ -288,7 +288,6 @@ for _, strategy in helpers.each_strategy() do
         assert.is_false(db.connector:get_stored_connection().config.ssl)
 
       elseif strategy == "cassandra" then
-        --TODO: cassandra forces luasocket on timer
         assert.is_false(db.connector:get_stored_connection().ssl)
       end
 
@@ -296,7 +295,7 @@ for _, strategy in helpers.each_strategy() do
       db:close()
     end)
 
-    it("returns opened connection when using luasocket", function()
+    it("returns opened connection when using IS_CLI=true", function()
       ngx.IS_CLI = true
 
       local db, err = DB.new(helpers.test_conf, strategy)
@@ -310,18 +309,17 @@ for _, strategy in helpers.each_strategy() do
       assert.is_table(conn)
 
       if strategy == "postgres" then
-        assert.equal("luasocket", db.connector:get_stored_connection().sock_type)
+        assert.equal("nginx", db.connector:get_stored_connection().sock_type)
         assert.is_false(db.connector:get_stored_connection().config.ssl)
 
       elseif strategy == "cassandra" then
-        --TODO: cassandra forces luasocket on timer
         assert.is_false(db.connector:get_stored_connection().ssl)
       end
 
       db:close()
     end)
 
-    postgres_only("returns opened connection with ssl (cosockets)", function()
+    postgres_only("returns opened connection with ssl (IS_CLI=false)", function()
       ngx.IS_CLI = false
 
       local conf = utils.deep_copy(helpers.test_conf)
@@ -344,14 +342,13 @@ for _, strategy in helpers.each_strategy() do
         assert.is_true(db.connector:get_stored_connection().config.ssl)
 
       elseif strategy == "cassandra" then
-        --TODO: cassandra forces luasocket on timer
         assert.is_true(db.connector:get_stored_connection().ssl)
       end
 
       db:close()
     end)
 
-    postgres_only("returns opened connection with ssl (luasocket)", function()
+    postgres_only("returns opened connection with ssl (IS_CLI=true)", function()
       ngx.IS_CLI = true
 
       local conf = utils.deep_copy(helpers.test_conf)
@@ -370,18 +367,17 @@ for _, strategy in helpers.each_strategy() do
       assert.is_table(conn)
 
       if strategy == "postgres" then
-        assert.equal("luasocket", db.connector:get_stored_connection().sock_type)
+        assert.equal("nginx", db.connector:get_stored_connection().sock_type)
         assert.is_true(db.connector:get_stored_connection().config.ssl)
 
       elseif strategy == "cassandra" then
-        --TODO: cassandra forces luasocket on timer
         assert.is_true(db.connector:get_stored_connection().ssl)
       end
 
       db:close()
     end)
 
-    postgres_only("connects to postgres with readonly account (cosockets)", function()
+    postgres_only("connects to postgres with readonly account (IS_CLI=false)", function()
       ngx.IS_CLI = false
 
       local conf = utils.deep_copy(helpers.test_conf)
@@ -411,7 +407,7 @@ for _, strategy in helpers.each_strategy() do
       db:close()
     end)
 
-    postgres_only("connects to postgres with readonly account (luasocket)", function()
+    postgres_only("connects to postgres with readonly account (IS_CLI=true)", function()
       ngx.IS_CLI = true
 
       local conf = utils.deep_copy(helpers.test_conf)
@@ -430,7 +426,7 @@ for _, strategy in helpers.each_strategy() do
 
       assert.is_nil(db.connector:get_stored_connection("read"))
 
-      assert.equal("luasocket", db.connector:get_stored_connection("write").sock_type)
+      assert.equal("nginx", db.connector:get_stored_connection("write").sock_type)
 
       if strategy == "portgres" then
         assert.is_false(db.connector:get_stored_connection("write").config.ssl)
@@ -438,7 +434,7 @@ for _, strategy in helpers.each_strategy() do
         assert.is_false(db.connector:get_stored_connection("write").ssl)
       end
 
-      assert.equal("luasocket", db.connector:get_stored_connection().sock_type)
+      assert.equal("nginx", db.connector:get_stored_connection().sock_type)
 
       if strategy == "portgres" then
         assert.is_false(db.connector:get_stored_connection("write").config.ssl)
@@ -456,7 +452,7 @@ for _, strategy in helpers.each_strategy() do
       helpers.get_db_utils(strategy, {})
     end)
 
-    it("returns true when there is a stored connection (cosockets)", function()
+    it("returns true when there is a stored connection (IS_CLI=false)", function()
       ngx.IS_CLI = false
 
       local db, err = DB.new(helpers.test_conf, strategy)
@@ -475,7 +471,6 @@ for _, strategy in helpers.each_strategy() do
         assert.is_false(db.connector:get_stored_connection().config.ssl)
 
       elseif strategy == "cassandra" then
-        --TODO: cassandra forces luasocket on timer
         assert.is_false(db.connector:get_stored_connection().ssl)
       end
 
@@ -484,7 +479,7 @@ for _, strategy in helpers.each_strategy() do
       db:close()
     end)
 
-    it("returns true when there is a stored connection (luasocket)", function()
+    it("returns true when there is a stored connection (IS_CLI=true)", function()
       ngx.IS_CLI = true
 
       local db, err = DB.new(helpers.test_conf, strategy)
@@ -498,11 +493,10 @@ for _, strategy in helpers.each_strategy() do
       assert.is_table(conn)
 
       if strategy == "postgres" then
-        assert.equal("luasocket", db.connector:get_stored_connection().sock_type)
+        assert.equal("nginx", db.connector:get_stored_connection().sock_type)
         assert.is_false(db.connector:get_stored_connection().config.ssl)
 
       elseif strategy == "cassandra" then
-        --TODO: cassandra forces luasocket on timer
         assert.is_false(db.connector:get_stored_connection().ssl)
       end
 
@@ -512,7 +506,7 @@ for _, strategy in helpers.each_strategy() do
       db:close()
     end)
 
-    postgres_only("returns true when there is a stored connection with ssl (cosockets)", function()
+    postgres_only("returns true when there is a stored connection with ssl (IS_CLI=false)", function()
       ngx.IS_CLI = false
 
       local conf = utils.deep_copy(helpers.test_conf)
@@ -535,7 +529,6 @@ for _, strategy in helpers.each_strategy() do
         assert.is_true(db.connector:get_stored_connection().config.ssl)
 
       elseif strategy == "cassandra" then
-        --TODO: cassandra forces luasocket on timer
         assert.is_true(db.connector:get_stored_connection().ssl)
       end
 
@@ -544,7 +537,7 @@ for _, strategy in helpers.each_strategy() do
       db:close()
     end)
 
-    postgres_only("returns true when there is a stored connection with ssl (luasocket)", function()
+    postgres_only("returns true when there is a stored connection with ssl (IS_CLI=true)", function()
       ngx.IS_CLI = true
 
       local conf = utils.deep_copy(helpers.test_conf)
@@ -563,11 +556,10 @@ for _, strategy in helpers.each_strategy() do
       assert.is_table(conn)
 
       if strategy == "postgres" then
-        assert.equal("luasocket", db.connector:get_stored_connection().sock_type)
+        assert.equal("nginx", db.connector:get_stored_connection().sock_type)
         assert.is_true(db.connector:get_stored_connection().config.ssl)
 
       elseif strategy == "cassandra" then
-        --TODO: cassandra forces luasocket on timer
         assert.is_true(db.connector:get_stored_connection().ssl)
       end
 
@@ -577,7 +569,7 @@ for _, strategy in helpers.each_strategy() do
       db:close()
     end)
 
-    it("returns true when there is no stored connection (cosockets)", function()
+    it("returns true when there is no stored connection (IS_CLI=false)", function()
       ngx.IS_CLI = false
 
       local db, err = DB.new(helpers.test_conf, strategy)
@@ -590,7 +582,7 @@ for _, strategy in helpers.each_strategy() do
       assert.is_true(db:setkeepalive())
     end)
 
-    it("returns true when there is no stored connection (luasocket)", function()
+    it("returns true when there is no stored connection (IS_CLI=true)", function()
       ngx.IS_CLI = true
 
       local db, err = DB.new(helpers.test_conf, strategy)
@@ -603,7 +595,7 @@ for _, strategy in helpers.each_strategy() do
       assert.is_true(db:setkeepalive())
     end)
 
-    postgres_only("keepalives both read only and write connection (cosockets)", function()
+    postgres_only("keepalives both read only and write connection (IS_CLI=false)", function()
       ngx.IS_CLI = false
 
       local conf = utils.deep_copy(helpers.test_conf)
@@ -643,7 +635,7 @@ for _, strategy in helpers.each_strategy() do
       db:close()
     end)
 
-    postgres_only("connects and keepalives only write connection (luasocket)", function()
+    postgres_only("connects and keepalives only write connection (IS_CLI=true)", function()
       ngx.IS_CLI = true
 
       local conf = utils.deep_copy(helpers.test_conf)
@@ -664,7 +656,7 @@ for _, strategy in helpers.each_strategy() do
       assert.is_nil(err)
       assert.is_table(conn)
 
-      assert.equal("luasocket", db.connector:get_stored_connection("write").sock_type)
+      assert.equal("nginx", db.connector:get_stored_connection("write").sock_type)
       assert.is_nil(db.connector:get_stored_connection("read"))
 
       if strategy == "postgres" then
@@ -688,7 +680,7 @@ for _, strategy in helpers.each_strategy() do
       helpers.get_db_utils(strategy, {})
     end)
 
-    it("returns true when there is a stored connection (cosockets)", function()
+    it("returns true when there is a stored connection (IS_CLI=false)", function()
       ngx.IS_CLI = false
 
       local db, err = DB.new(helpers.test_conf, strategy)
@@ -706,7 +698,6 @@ for _, strategy in helpers.each_strategy() do
         assert.is_false(db.connector:get_stored_connection().config.ssl)
 
       elseif strategy == "cassandra" then
-        --TODO: cassandra forces luasocket on timer
         assert.is_false(db.connector:get_stored_connection().ssl)
       end
 
@@ -714,7 +705,7 @@ for _, strategy in helpers.each_strategy() do
       assert.is_true(db:close())
     end)
 
-    it("returns true when there is a stored connection (luasocket)", function()
+    it("returns true when there is a stored connection (IS_CLI=true)", function()
       ngx.IS_CLI = true
 
       local db, err = DB.new(helpers.test_conf, strategy)
@@ -728,11 +719,10 @@ for _, strategy in helpers.each_strategy() do
       assert.is_table(conn)
 
       if strategy == "postgres" then
-        assert.equal("luasocket", db.connector:get_stored_connection().sock_type)
+        assert.equal("nginx", db.connector:get_stored_connection().sock_type)
         assert.is_false(db.connector:get_stored_connection().config.ssl)
 
       elseif strategy == "cassandra" then
-        --TODO: cassandra forces luasocket on timer
         assert.is_false(db.connector:get_stored_connection().ssl)
       end
 
@@ -740,7 +730,7 @@ for _, strategy in helpers.each_strategy() do
       assert.is_true(db:close())
     end)
 
-    postgres_only("returns true when there is a stored connection with ssl (cosockets)", function()
+    postgres_only("returns true when there is a stored connection with ssl (IS_CLI=false)", function()
       ngx.IS_CLI = false
 
       local conf = utils.deep_copy(helpers.test_conf)
@@ -763,14 +753,13 @@ for _, strategy in helpers.each_strategy() do
         assert.is_true(db.connector:get_stored_connection().config.ssl)
 
       elseif strategy == "cassandra" then
-        --TODO: cassandra forces luasocket on timer
         assert.is_true(db.connector:get_stored_connection().ssl)
       end
 
       assert.is_true(db:close())
     end)
 
-    postgres_only("returns true when there is a stored connection with ssl (luasocket)", function()
+    postgres_only("returns true when there is a stored connection with ssl (IS_CLI=true)", function()
       ngx.IS_CLI = true
 
       local conf = utils.deep_copy(helpers.test_conf)
@@ -789,18 +778,17 @@ for _, strategy in helpers.each_strategy() do
       assert.is_table(conn)
 
       if strategy == "postgres" then
-        assert.equal("luasocket", db.connector:get_stored_connection().sock_type)
+        assert.equal("nginx", db.connector:get_stored_connection().sock_type)
         assert.is_true(db.connector:get_stored_connection().config.ssl)
 
       elseif strategy == "cassandra" then
-        --TODO: cassandra forces luasocket on timer
         assert.is_true(db.connector:get_stored_connection().ssl)
       end
 
       assert.is_true(db:close())
     end)
 
-    it("returns true when there is no stored connection (cosockets)", function()
+    it("returns true when there is no stored connection (IS_CLI=false)", function()
       ngx.IS_CLI = false
 
       local db, err = DB.new(helpers.test_conf, strategy)
@@ -813,7 +801,7 @@ for _, strategy in helpers.each_strategy() do
       assert.is_true(db:close())
     end)
 
-    it("returns true when there is no stored connection (luasocket)", function()
+    it("returns true when there is no stored connection (IS_CLI=true)", function()
       ngx.IS_CLI = true
 
       local db, err = DB.new(helpers.test_conf, strategy)
@@ -826,7 +814,7 @@ for _, strategy in helpers.each_strategy() do
       assert.equal(true, db:close())
     end)
 
-    postgres_only("returns true when both read-only and write connection exists (cosockets)", function()
+    postgres_only("returns true when both read-only and write connection exists (IS_CLI=false)", function()
       ngx.IS_CLI = false
 
       local conf = utils.deep_copy(helpers.test_conf)
@@ -866,7 +854,7 @@ for _, strategy in helpers.each_strategy() do
       db:close()
     end)
 
-    postgres_only("returns true when both read-only and write connection exists (luasocket)", function()
+    postgres_only("returns true when both read-only and write connection exists (IS_CLI=true)", function()
       ngx.IS_CLI = true
 
       local conf = utils.deep_copy(helpers.test_conf)
@@ -886,7 +874,7 @@ for _, strategy in helpers.each_strategy() do
       assert.is_nil(err)
       assert.is_table(conn)
 
-      assert.equal("luasocket", db.connector:get_stored_connection("write").sock_type)
+      assert.equal("nginx", db.connector:get_stored_connection("write").sock_type)
       assert.is_nil(db.connector:get_stored_connection("read"))
 
       if strategy == "postgres" then

--- a/spec/require.lua
+++ b/spec/require.lua
@@ -1,0 +1,93 @@
+-- Bundled from https://github.com/pygy/require.lua
+-- License MIT
+--- usage:
+-- require = require"require".require
+-- :o)
+
+local error, ipairs, newproxy, tostring, type 
+    = error, ipairs, newproxy, tostring, type
+
+local t_concat = table.concat
+
+--- Helpers
+
+
+local function checkstring(s)
+    local t = type(s)
+    if t == "string" then
+        return s
+    elseif t == "number" then
+        return tostring(s)
+    else
+        error("bad argument #1 to 'require' (string expected, got "..t..")", 3)
+    end
+end
+
+--- for Lua 5.1
+
+local package, p_loaded, setmetatable = package, package.loaded, setmetatable
+
+local sentinel do
+    local function errhandler() error("the require() sentinel can't be indexed or updated", 2) end
+    sentinel = newproxy and newproxy() or setmetatable({}, {__index = errhandler, __newindex = errhandler, __metatable = false})
+end
+
+local function require51 (name)
+    name = checkstring(name)
+    if p_loaded[name] == sentinel then
+        error("loop or previous error loading module '"..name.."'", 2)
+    end
+
+    local module = p_loaded[name]
+    if module then return module end
+
+    local msg = {}
+    local loader
+    for _, searcher in ipairs(package.loaders) do
+        loader = searcher(name)
+        if type(loader) == "function" then break end
+        if type(loader) == "string" then
+            -- `loader` is actually an error message
+            msg[#msg + 1] = loader
+        end
+        loader = nil
+    end
+    if loader == nil then
+        error("module '" .. name .. "' not found: "..t_concat(msg), 2)
+    end
+    p_loaded[name] = sentinel
+    local res = loader(name)
+    if res ~= nil then
+        module = res
+    elseif p_loaded[name] == sentinel or not p_loaded[name] then
+        module = true
+    else
+	module = p_loaded[name]
+    end
+
+    p_loaded[name] = module
+    return module
+end
+
+local module = {
+    VERSION = "0.1.8",
+    require51 = require51,
+}
+
+if _VERSION == "Lua 5.1" then module.require = require51 end
+
+--- rerequire :o)
+
+for _, o in ipairs{
+    {"rerequiredefault", require},
+    {"rerequire", module.require},
+    {"rerequire51", require51},
+} do
+    local rereq, req = o[1], o[2]
+    module[rereq] = function(name)
+        p_loaded[name] = nil
+        return req(name)
+    end
+end
+
+return module

--- a/spec/require.lua
+++ b/spec/require.lua
@@ -4,7 +4,7 @@
 -- require = require"require".require
 -- :o)
 
-local error, ipairs, newproxy, tostring, type 
+local error, ipairs, newproxy, tostring, type
     = error, ipairs, newproxy, tostring, type
 
 local t_concat = table.concat


### PR DESCRIPTION
WIP, need to add ssl cafile support in `kong migrations` CLI; maybe that will benefit to `kong vaults` as well.

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Full changelog

* [Implement ...]
* [Add related tests]
* ...

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
