### PR TITLE
chore(docs) update documentation to match what PUT endpoints return FT-2589

### DIFF
--- a/autodoc/admin-api/data/admin-api.lua
+++ b/autodoc/admin-api/data/admin-api.lua
@@ -2302,7 +2302,7 @@ return {
       ]],
       response = [[
         ```
-        HTTP 201 Created or HTTP 200 OK
+        HTTP 200 OK
         ```
 
         See POST and PATCH responses.


### PR DESCRIPTION
### Summary

The documentation for PUT entity endpoints state that HTTP status 200 or 201 could be in the response, but [the code](https://github.com/Kong/kong/blob/f04772b75063075c5d3f756eab06af6f5dc61f73/kong/api/endpoints.lua#L486) always returns 200, regardless of whether the entity was created or updated.
