### PR TITLE
fix(balancer) only check healthy state in algorithm

### DIFF
--- a/kong/runloop/balancer/balancers.lua
+++ b/kong/runloop/balancer/balancers.lua
@@ -560,10 +560,6 @@ end
 
 
 function balancer_mt:getPeer(...)
-  if not self.healthy then
-    return nil, "Balancer is unhealthy"
-  end
-
   if not self.algorithm or not self.algorithm.afterHostUpdate then
     return
   end

--- a/kong/runloop/balancer/init.lua
+++ b/kong/runloop/balancer/init.lua
@@ -357,6 +357,7 @@ local function execute(balancer_data, ctx)
     if not ip and
       (port == "No peers are available" or port == "Balancer is unhealthy")
     then
+      log(ERR, "failure to get a peer from the balancer: " .. port)
       return nil, "failure to get a peer from the ring-balancer", 503
     end
     hostname = hostname or ip

--- a/kong/runloop/balancer/round_robin.lua
+++ b/kong/runloop/balancer/round_robin.lua
@@ -100,7 +100,7 @@ function roundrobin_algorithm:getPeer(cacheOnly, handle, hashValue)
         return ip, port, hostname, handle
 
       elseif port == balancers.errors.ERR_DNS_UPDATED then
-        -- if healty we just need to try again
+        -- if not healty we just need to try again
         if not self.balancer.healthy then
           return nil, balancers.errors.ERR_BALANCER_UNHEALTHY
         end


### PR DESCRIPTION
### Summary

Only check `balancer.healthy` in round_robin/consistent_hashing/least_connections algorithms.

https://github.com/Kong/kong/blob/1c313c6eb2e2304f73862dce76636cd09140a0c0/kong/runloop/balancer/round_robin.lua#L102-L106
https://github.com/Kong/kong/blob/6a8f3e267a2b7bd64d00cef78d55bd55f0088036/kong/runloop/balancer/consistent_hashing.lua#L173-L178
https://github.com/Kong/kong/blob/32018c13accd292bbb46341064c8334b9053c87a/kong/runloop/balancer/least_connections.lua#L76-L81