### PR TITLE
fix(admin) add the worker info to the response of `/timers`

### DIFF
--- a/autodoc/admin-api/data/admin-api.lua
+++ b/autodoc/admin-api/data/admin-api.lua
@@ -491,45 +491,52 @@ return {
             ```
 
             ```json
-            {
-                "flamegraph": {
-                  "running": "@./kong/init.lua:706:init_worker();@./kong/runloop/handler.lua:1086:before() 0\n",
-                  "elapsed_time": "@./kong/init.lua:706:init_worker();@./kong/runloop/handler.lua:1086:before() 17\n",
-                  "pending": "@./kong/init.lua:706:init_worker();@./kong/runloop/handler.lua:1086:before() 0\n"
+            {   "worker": {
+                  "id": 0,
+                  "count": 4,
                 },
-                "sys": {
-                    "running": 0,
-                    "runs": 7,
-                    "pending": 0,
-                    "waiting": 7,
-                    "total": 7
-                },
-                "timers": {
-                    "healthcheck-localhost:8080": {
-                        "name": "healthcheck-localhost:8080",
-                        "meta": {
-                            "name": "@/build/luarocks/share/lua/5.1/resty/counter.lua:71:new()",
-                            "callstack": "@./kong/plugins/prometheus/prometheus.lua:673:init_worker();@/build/luarocks/share/lua/5.1/resty/counter.lua:71:new()"
-                        },
-                        "stats": {
-                            "finish": 2,
-                            "runs": 2,
-                            "elapsed_time": {
-                                "min": 0,
-                                "max": 0,
-                                "avg": 0,
-                                "variance": 0
-                            },
-                            "last_err_msg": ""
-                        }
-                    }
+                "stats": {
+                  "flamegraph": {
+                    "running": "@./kong/init.lua:706:init_worker();@./kong/runloop/handler.lua:1086:before() 0\n",
+                    "elapsed_time": "@./kong/init.lua:706:init_worker();@./kong/runloop/handler.lua:1086:before() 17\n",
+                    "pending": "@./kong/init.lua:706:init_worker();@./kong/runloop/handler.lua:1086:before() 0\n"
+                  },
+                  "sys": {
+                      "running": 0,
+                      "runs": 7,
+                      "pending": 0,
+                      "waiting": 7,
+                      "total": 7
+                  },
+                  "timers": {
+                      "healthcheck-localhost:8080": {
+                          "name": "healthcheck-localhost:8080",
+                          "meta": {
+                              "name": "@/build/luarocks/share/lua/5.1/resty/counter.lua:71:new()",
+                              "callstack": "@./kong/plugins/prometheus/prometheus.lua:673:init_worker();@/build/luarocks/share/lua/5.1/resty/counter.lua:71:new()"
+                          },
+                          "stats": {
+                              "finish": 2,
+                              "runs": 2,
+                              "elapsed_time": {
+                                  "min": 0,
+                                  "max": 0,
+                                  "avg": 0,
+                                  "variance": 0
+                              },
+                              "last_err_msg": ""
+                          }
+                      }
+                  }
                 }
             }
             ```
-
-            * `flamegraph`: String-encoded timer-related flamegraph data.
+            * `worker`:
+              * `id`: The ordinal number of the current Nginx worker processes (starting from number 0).
+              * `count`: The total number of the Nginx worker processes.
+            * `stats.flamegraph`: String-encoded timer-related flamegraph data.
               You can use [brendangregg/FlameGraph](https://github.com/brendangregg/FlameGraph) to generate flamegraph svgs.
-            * `sys`: List the number of different type of timers.
+            * `stats.sys`: List the number of different type of timers.
               * `running`: number of running timers.
               * `pending`: number of pending timers.
               * `waiting`: number of unexpired timers.

--- a/kong/api/routes/kong.lua
+++ b/kong/api/routes/kong.lua
@@ -187,7 +187,17 @@ return {
   },
   ["/timers"] = {
     GET = function (self, db, helpers)
-      return kong.response.exit(200, _G.timerng_stats())
+      local body = {
+        worker = {
+          id = ngx.worker.id(),
+          count = ngx.worker.count(),
+        },
+        stats = kong.timer:stats({
+          verbose = true,
+          flamegraph = true,
+        })
+      }
+      return kong.response.exit(200, body)
     end
   }
 }

--- a/kong/globalpatches.lua
+++ b/kong/globalpatches.lua
@@ -72,43 +72,31 @@ return function(options)
     _G.native_timer_at = ngx.timer.at
     _G.native_timer_every = ngx.timer.every
 
-    local timerng
+    local _timerng
 
     if options.cli or options.rbusted then
-      timerng = require("resty.timerng").new({
+      _timerng = require("resty.timerng").new({
         min_threads = 16,
         max_threads = 32,
       })
 
-      timerng:start()
+      _timerng:start()
+
+      _G.timerng = _timerng
 
     else
-      timerng = require("resty.timerng").new()
-
-      -- TODO rename
-      _G.timerng_start = function (debug)
-        timerng:start()
-        timerng:set_debug(debug)
-      end
-
+      _timerng = require("resty.timerng").new()
+      _G.timerng = _timerng
     end
 
+
     _G.ngx.timer.at = function (delay, callback, ...)
-      return timerng:at(delay, callback, ...)
+      return _timerng:at(delay, callback, ...)
     end
 
     _G.ngx.timer.every = function (interval, callback, ...)
-      return timerng:every(interval, callback, ...)
+      return _timerng:every(interval, callback, ...)
     end
-
-    -- TODO rename
-    _G.timerng_stats = function ()
-      return timerng:stats({
-        verbose = true,
-        flamegraph = true,
-      })
-    end
-
   end
 
 

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -592,7 +592,13 @@ function Kong.init_worker()
   -- duplicated seeds.
   math.randomseed()
 
-  _G.timerng_start(kong.configuration.log_level == "debug")
+
+  -- setup timerng to _G.kong
+  kong.timer = _G.timerng
+  _G.timerng = nil
+
+  kong.timer:set_debug(kong.configuration.log_level == "debug")
+  kong.timer:start()
 
   -- init DB
 

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -16,30 +16,30 @@ local PluginsIterator = require "kong.runloop.plugins_iterator"
 local instrumentation = require "kong.tracing.instrumentation"
 
 
-local kong         = kong
-local type         = type
-local ipairs       = ipairs
-local tostring     = tostring
-local tonumber     = tonumber
-local setmetatable = setmetatable
-local sub          = string.sub
-local byte         = string.byte
-local gsub         = string.gsub
-local find         = string.find
-local lower        = string.lower
-local fmt          = string.format
-local ngx          = ngx
-local var          = ngx.var
-local log          = ngx.log
-local exit         = ngx.exit
-local exec         = ngx.exec
-local header       = ngx.header
-local timer_at     = ngx.timer.at
-local subsystem    = ngx.config.subsystem
-local clear_header = ngx.req.clear_header
-local http_version = ngx.req.http_version
-local unpack       = unpack
-local escape       = require("kong.tools.uri").escape
+local kong              = kong
+local type              = type
+local ipairs            = ipairs
+local tostring          = tostring
+local tonumber          = tonumber
+local setmetatable      = setmetatable
+local sub               = string.sub
+local byte              = string.byte
+local gsub              = string.gsub
+local find              = string.find
+local lower             = string.lower
+local fmt               = string.format
+local ngx               = ngx
+local var               = ngx.var
+local log               = ngx.log
+local exit              = ngx.exit
+local exec              = ngx.exec
+local header            = ngx.header
+local timer_at          = ngx.timer.at
+local subsystem         = ngx.config.subsystem
+local clear_header      = ngx.req.clear_header
+local http_version      = ngx.req.http_version
+local unpack            = unpack
+local escape            = require("kong.tools.uri").escape
 
 
 local is_http_module   = subsystem == "http"
@@ -1125,14 +1125,11 @@ return {
           if not ok then
             log(ERR, "could not rebuild router via timer: ", err)
           end
-
-          local _, err = timer_at(worker_state_update_frequency, rebuild_router_timer)
-          if err then
-            log(ERR, "could not schedule timer to rebuild router: ", err)
-          end
         end
 
-        local _, err = timer_at(worker_state_update_frequency, rebuild_router_timer)
+        local _, err = kong.timer:named_every("router-rebuild",
+                                         worker_state_update_frequency,
+                                         rebuild_router_timer)
         if err then
           log(ERR, "could not schedule timer to rebuild router: ", err)
         end
@@ -1152,14 +1149,11 @@ return {
           if err then
             log(ERR, "could not rebuild plugins iterator via timer: ", err)
           end
-
-          local _, err = timer_at(worker_state_update_frequency, rebuild_plugins_iterator_timer)
-          if err then
-            log(ERR, "could not schedule timer to rebuild plugins iterator: ", err)
-          end
         end
 
-        local _, err = timer_at(worker_state_update_frequency, rebuild_plugins_iterator_timer)
+        local _, err = kong.timer:named_every("plugins-iterator-rebuild",
+                                         worker_state_update_frequency,
+                                         rebuild_plugins_iterator_timer)
         if err then
           log(ERR, "could not schedule timer to rebuild plugins iterator: ", err)
         end

--- a/spec/01-unit/01-db/08-cache_warmup_spec.lua
+++ b/spec/01-unit/01-db/08-cache_warmup_spec.lua
@@ -2,6 +2,7 @@ local cache_warmup = require("kong.cache.warmup")
 local helpers = require("spec.helpers")
 
 
+
 local function mock_entity(db_data, entity_name, cache_key)
   return {
     schema = {
@@ -212,13 +213,13 @@ describe("cache_warmup", function()
 
     cache_warmup._mock_kong(kong)
 
-    local runs_old = _G.timerng_stats().sys.runs
+    local runs_old = _G.timerng:stats().sys.runs
 
     assert.truthy(cache_warmup.execute({"my_entity", "services"}))
 
     -- waiting async DNS cacheing
     helpers.wait_until(function ()
-      local runs = _G.timerng_stats().sys.runs
+      local runs = _G.timerng:stats().sys.runs
       return runs_old < runs
     end)
 
@@ -271,13 +272,13 @@ describe("cache_warmup", function()
 
     cache_warmup._mock_kong(kong)
 
-    local runs_old = _G.timerng_stats().sys.runs
+    local runs_old = _G.timerng:stats().sys.runs
 
     assert.truthy(cache_warmup.execute({"my_entity", "services"}))
 
     -- waiting async DNS cacheing
     helpers.wait_until(function ()
-      local runs = _G.timerng_stats().sys.runs
+      local runs = _G.timerng:stats().sys.runs
       return runs_old < runs
     end)
 

--- a/spec/01-unit/16-runloop_handler_spec.lua
+++ b/spec/01-unit/16-runloop_handler_spec.lua
@@ -23,6 +23,7 @@ local function setup_it_block()
     },
 
     kong = {
+      timer = _G.timerng,
       log = {
         err = function() end,
         warn = function() end,

--- a/spec/02-integration/03-db/09-query-semaphore_spec.lua
+++ b/spec/02-integration/03-db/09-query-semaphore_spec.lua
@@ -41,7 +41,7 @@ describe("#postgres Postgres query locks", function()
     assert.res_status(204 , res)
 
     -- wait for zero-delay timer
-    helpers.wait_timer("slow-query", true, true)
+    helpers.wait_timer("slow-query", true, "any-running")
 
     res = assert(client:send {
       method = "GET",

--- a/spec/02-integration/04-admin_api/20-timers_spec.lua
+++ b/spec/02-integration/04-admin_api/20-timers_spec.lua
@@ -35,17 +35,20 @@ local client
         local body = assert.res_status(200 , res)
         local json = cjson.decode(body)
 
-        assert(type(json.flamegraph.running) == "string")
-        assert(type(json.flamegraph.pending) == "string")
-        assert(type(json.flamegraph.elapsed_time) == "string")
+        assert(type(json.worker.id) == "number")
+        assert(type(json.worker.count) == "number")
 
-        assert(type(json.sys.total) == "number")
-        assert(type(json.sys.runs) == "number")
-        assert(type(json.sys.running) == "number")
-        assert(type(json.sys.pending) == "number")
-        assert(type(json.sys.waiting) == "number")
+        assert(type(json.stats.flamegraph.running) == "string")
+        assert(type(json.stats.flamegraph.pending) == "string")
+        assert(type(json.stats.flamegraph.elapsed_time) == "string")
 
-        assert(type(json.timers) == "table")
+        assert(type(json.stats.sys.total) == "number")
+        assert(type(json.stats.sys.runs) == "number")
+        assert(type(json.stats.sys.running) == "number")
+        assert(type(json.stats.sys.pending) == "number")
+        assert(type(json.stats.sys.waiting) == "number")
+
+        assert(type(json.stats.timers) == "table")
 
     end)
 

--- a/spec/03-plugins/23-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/04-access_spec.lua
@@ -372,7 +372,7 @@ for _, strategy in helpers.each_strategy() do
                 assert.equal(true, reset <= 60 and reset >= 0)
 
                 -- wait for zero-delay timer
-                helpers.wait_timer("rate-limiting", 0.5)
+                helpers.wait_timer("rate-limiting", true, "any-finish")
               end
 
               -- Additonal request, while limit is 6/minute
@@ -407,7 +407,7 @@ for _, strategy in helpers.each_strategy() do
                 assert.equal(true, reset <= 60 and reset > 0)
 
                 -- wait for zero-delay timer
-                helpers.wait_timer("rate-limiting", 0.5)
+                helpers.wait_timer("rate-limiting", true, "any-finish")
               end
 
               -- Try a different path on the same host. This should reset the timers
@@ -424,7 +424,7 @@ for _, strategy in helpers.each_strategy() do
                 assert.equal(true, reset <= 60 and reset > 0)
 
                 -- wait for zero-delay timer
-                helpers.wait_timer("rate-limiting", 0.5)
+                helpers.wait_timer("rate-limiting", true, "any-finish")
               end
 
               -- Continue doing requests on the path which "blocks"
@@ -441,7 +441,7 @@ for _, strategy in helpers.each_strategy() do
                 assert.equal(true, reset <= 60 and reset > 0)
 
                 -- wait for zero-delay timer
-                helpers.wait_timer("rate-limiting", 0.5)
+                helpers.wait_timer("rate-limiting", true, "any-finish")
               end
 
               -- Additonal request, while limit is 6/minute
@@ -476,7 +476,7 @@ for _, strategy in helpers.each_strategy() do
                 assert.equal(true, reset <= 60 and reset > 0)
 
                 -- wait for zero-delay timer
-                helpers.wait_timer("rate-limiting", 0.5)
+                helpers.wait_timer("rate-limiting", true, "any-finish")
               end
 
               for i = 4, 6 do
@@ -492,7 +492,7 @@ for _, strategy in helpers.each_strategy() do
                 assert.equal(true, reset <= 60 and reset > 0)
 
                 -- wait for zero-delay timer
-                helpers.wait_timer("rate-limiting", 0.5)
+                helpers.wait_timer("rate-limiting", true, "any-finish")
               end
 
               -- Additonal request, while limit is 6/minute
@@ -534,7 +534,7 @@ for _, strategy in helpers.each_strategy() do
                 assert.equal(true, reset <= 60 and reset > 0)
 
                 -- wait for zero-delay timer
-                helpers.wait_timer("rate-limiting", 0.5)
+                helpers.wait_timer("rate-limiting", true, "any-finish")
               end
 
               local res, body = GET("/status/200", {
@@ -577,7 +577,7 @@ for _, strategy in helpers.each_strategy() do
                 assert.equal(true, reset <= 60 and reset >= 0)
 
                 -- wait for zero-delay timer
-                helpers.wait_timer("rate-limiting", 0.5)
+                helpers.wait_timer("rate-limiting", true, "any-finish")
               end
 
               -- Additonal request, while limit is 6/minute
@@ -617,7 +617,7 @@ for _, strategy in helpers.each_strategy() do
                   assert.equal(true, reset <= 60 and reset > 0)
 
                   -- wait for zero-delay timer
-                  helpers.wait_timer("rate-limiting", 0.5)
+                  helpers.wait_timer("rate-limiting", true, "any-finish")
                 end
 
                 -- Third query, while limit is 2/minute
@@ -658,7 +658,7 @@ for _, strategy in helpers.each_strategy() do
                   assert.equal(true, reset <= 60 and reset > 0)
 
                   -- wait for zero-delay timer
-                  helpers.wait_timer("rate-limiting", 0.5)
+                  helpers.wait_timer("rate-limiting", true, "any-finish")
                 end
 
                 local res, body = GET("/status/200?apikey=apikey122", {
@@ -692,7 +692,7 @@ for _, strategy in helpers.each_strategy() do
                   assert.equal(true, reset <= 60 and reset > 0)
 
                   -- wait for zero-delay timer
-                  helpers.wait_timer("rate-limiting", 0.5)
+                  helpers.wait_timer("rate-limiting", true, "any-finish")
                 end
 
                 local res, body = GET("/status/200?apikey=apikey122", {
@@ -1031,7 +1031,7 @@ for _, strategy in helpers.each_strategy() do
               assert.equal(true, reset <= 60 and reset > 0)
 
               -- wait for zero-delay timer
-              helpers.wait_timer("rate-limiting", 0.5)
+              helpers.wait_timer("rate-limiting", true, "any-finish")
             end
 
             -- Additonal request, while limit is 6/minute
@@ -1114,7 +1114,7 @@ for _, strategy in helpers.each_strategy() do
               assert.equal(true, reset <= 60 and reset > 0)
 
               -- wait for zero-delay timer
-              helpers.wait_timer("rate-limiting", 0.5)
+              helpers.wait_timer("rate-limiting", true, "any-finish")
             end
 
             -- Additonal request, while limit is 6/minute
@@ -1198,7 +1198,7 @@ for _, strategy in helpers.each_strategy() do
               assert.equal(true, reset <= 60 and reset > 0)
 
               -- wait for zero-delay timer
-              helpers.wait_timer("rate-limiting", 0.5)
+              helpers.wait_timer("rate-limiting", true, "any-finish")
             end
 
             for i = 1, 6 do
@@ -1212,7 +1212,7 @@ for _, strategy in helpers.each_strategy() do
               assert.equal(true, reset <= 60 and reset > 0)
 
               -- wait for zero-delay timer
-              helpers.wait_timer("rate-limiting", 0.5)
+              helpers.wait_timer("rate-limiting", true, "any-finish")
             end
 
             -- Additonal request, while limit is 6/minute
@@ -1289,7 +1289,7 @@ for _, strategy in helpers.each_strategy() do
               assert.equal(true, reset <= 60 and reset > 0)
 
               -- wait for zero-delay timer
-              helpers.wait_timer("rate-limiting", 0.5)
+              helpers.wait_timer("rate-limiting", true, "any-finish")
             end
 
             -- Additonal request, while limit is 6/minute
@@ -1372,7 +1372,7 @@ for _, strategy in helpers.each_strategy() do
               assert.equal(true, reset <= 60 and reset > 0)
 
               -- wait for zero-delay timer
-              helpers.wait_timer("rate-limiting", 0.5)
+              helpers.wait_timer("rate-limiting", true, "any-finish")
             end
 
             -- Additonal request, while limit is 6/minute

--- a/spec/03-plugins/34-zipkin/zipkin_spec.lua
+++ b/spec/03-plugins/34-zipkin/zipkin_spec.lua
@@ -384,7 +384,7 @@ for _, strategy in helpers.each_strategy() do
       assert.res_status(200, res)
 
       -- wait for zero-delay timer
-      helpers.wait_timer("zipkin", 0.5)
+      helpers.wait_timer("zipkin", true, "any-finish")
 
       assert.logfile().has.line("reporter flush failed to request: timeout", false, 2)
     end)
@@ -400,7 +400,7 @@ for _, strategy in helpers.each_strategy() do
       assert.res_status(200, res)
 
       -- wait for zero-delay timer
-      helpers.wait_timer("zipkin", 0.5)
+      helpers.wait_timer("zipkin", true, "any-finish")
 
       assert.logfile().has.line("reporter flush failed to request: timeout", false, 2)
     end)
@@ -416,7 +416,7 @@ for _, strategy in helpers.each_strategy() do
       assert.res_status(200, res)
 
       -- wait for zero-delay timer
-      helpers.wait_timer("zipkin", 0.5)
+      helpers.wait_timer("zipkin", true, "any-finish")
 
       assert.logfile().has.line("reporter flush failed to request: connection refused", false, 2)
     end)

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -1393,16 +1393,23 @@ end
 ---wait for some timer
 ---@param timer_name_pattern string
 ---@param plain boolean
----@param running? boolean optional, wait for timer running or exit (default = false)
+---@param mode string all-finish | all-running | any-finish | any-running | worker-wide-all-finish
 ---@param timeout? number optional, maximum time to wait (default = 2)
 ---@param admin_client_timeout? number optional, to override the default timeout setting
 ---@param forced_admin_port? number optional, to override the default port of admin API
-local function wait_timer(timer_name_pattern, plain, running, timeout, admin_client_timeout, forced_admin_port)
+local function wait_timer(timer_name_pattern, plain,
+                          mode, timeout,
+                          admin_client_timeout, forced_admin_port)
   if not timeout then
     timeout = 2
   end
 
   local _admin_client
+
+  local all_running_each_worker = nil
+  local all_finish_each_worker = nil
+  local any_running_each_worker = nil
+  local any_finish_each_worker = nil
 
   wait_until(function ()
     if _admin_client then
@@ -1413,22 +1420,98 @@ local function wait_timer(timer_name_pattern, plain, running, timeout, admin_cli
     local res = assert(_admin_client:get("/timers"))
     local body = luassert.res_status(200, res)
     local json = assert(cjson.decode(body))
+    local worker_id = json.worker.id
+    local worker_count = json.worker.count
 
-    for timer_name, timer in pairs(json.timers) do
-      if string.find(timer_name, timer_name_pattern, 1, plain) then
-        if not running then
-          return false, "failed to wait " .. timer_name_pattern
+    if not all_running_each_worker then
+      all_running_each_worker = {}
+      all_finish_each_worker = {}
+      any_running_each_worker = {}
+      any_finish_each_worker = {}
 
-        elseif timer.is_running then
-          return true
-
-        else
-          return false, "failed to wait " .. timer_name_pattern .. " running"
-        end
+      for i = 0, worker_count - 1 do
+        all_running_each_worker[i] = false
+        all_finish_each_worker[i] = false
+        any_running_each_worker[i] = false
+        any_finish_each_worker[i] = false
       end
     end
 
-    return true
+    local is_matched = false
+
+    all_finish_each_worker[worker_id] = true
+
+    for timer_name, timer in pairs(json.stats.timers) do
+      if string.find(timer_name, timer_name_pattern, 1, plain) then
+        is_matched = true
+
+        if timer.is_running then
+          all_running_each_worker[worker_id] = true
+          any_running_each_worker[worker_id] = true
+          all_finish_each_worker[worker_id] = false
+          goto continue
+        end
+
+        all_running_each_worker[worker_id] = false
+        any_finish_each_worker[worker_id] = true
+
+        goto continue
+      end
+
+      ::continue::
+    end
+
+    if not is_matched then
+      any_finish_each_worker[worker_id] = true
+      all_finish_each_worker[worker_id] = true
+    end
+
+    local all_running = true
+
+    local all_finish = true
+    local all_finish_worker_wide = true
+
+    local any_running = false
+    local any_finish = false
+
+    for _, v in pairs(all_running_each_worker) do
+      all_running = all_running or v
+    end
+
+    for _, v in pairs(all_finish_each_worker) do
+      all_finish = all_finish or v
+      all_finish_worker_wide = all_finish_worker_wide and v
+    end
+
+    for _, v in pairs(any_running_each_worker) do
+      any_running = any_running or v
+    end
+
+    for _, v in pairs(any_finish_each_worker) do
+      any_finish = any_finish or v
+    end
+
+    if mode == "all-running" then
+      return all_running
+    end
+
+    if mode == "all-finish" then
+      return all_finish
+    end
+
+    if mode == "worker-wide-all-finish" then
+      return all_finish_worker_wide
+    end
+
+    if mode == "any-finish" then
+      return any_finish
+    end
+
+    if mode == "any-running" then
+      return any_running
+    end
+
+    error("unexpected error")
   end, timeout)
 end
 


### PR DESCRIPTION
### Summary

* style(runloop) use every timer instead of at timer to rebuild router and plugin iterator
* feat(AdminAPI) add the worker info to the response of `/timers`
* tests(helpers) extend function `wait_timer`
