### PR TITLE
FT-2558 don't put authenticated_jwt_token into ngx.ctx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,9 @@
   - `ldap-auth` changed from 1002 to 1200
   - `oauth2` changed from 1004 to 1400
   - `rate-limiting` changed from 901 to 910
+- **JWT**: The authenticated JWT is no longer put into the nginx
+  context (ngx.ctx.authenticated_jwt_token).  Plugins should access
+  Kong's shared context (kong.ctx.shared.authenticated_jwt_token).
 
 ### Deprecations
 

--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -112,13 +112,7 @@ local function set_consumer(consumer, credential, token)
     set_header(constants.HEADERS.ANONYMOUS, true)
   end
 
-  if token then
-    kong.ctx.shared.authenticated_jwt_token = token -- TODO: wrap in a PDK function?
-    ngx.ctx.authenticated_jwt_token = token  -- backward compatibility only
-  else
-    kong.ctx.shared.authenticated_jwt_token = nil
-    ngx.ctx.authenticated_jwt_token = nil  -- backward compatibility only
-  end
+  kong.ctx.shared.authenticated_jwt_token = token -- TODO: wrap in a PDK function?
 end
 
 

--- a/spec/03-plugins/16-jwt/03-access_spec.lua
+++ b/spec/03-plugins/16-jwt/03-access_spec.lua
@@ -151,7 +151,8 @@ for _, strategy in helpers.each_strategy() do
       plugins:insert({
         name     = "ctx-checker",
         route = { id = routes[1].id },
-        config   = { ctx_check_field = "authenticated_jwt_token" },
+        config   = { ctx_kind = "kong.ctx.shared",
+                     ctx_check_field = "authenticated_jwt_token" },
       })
 
       plugins:insert({
@@ -163,7 +164,8 @@ for _, strategy in helpers.each_strategy() do
       plugins:insert({
         name     = "ctx-checker",
         route = { id = route_grpc.id },
-        config   = { ctx_check_field = "authenticated_jwt_token" },
+        config   = { ctx_kind = "kong.ctx.shared",
+                     ctx_check_field = "authenticated_jwt_token" },
       })
 
 
@@ -866,7 +868,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     describe("ctx.authenticated_jwt_token", function()
-      it("is added to ngx.ctx when authenticated", function()
+      it("is added to kong.ctx.shared when authenticated", function()
         PAYLOAD.iss = jwt_secret.key
         local jwt = jwt_encoder.encode(PAYLOAD, jwt_secret.secret)
         local authorization = "Bearer " .. jwt


### PR DESCRIPTION
### Summary

The `authenticated_jwt_token` attribute has been set in Kong's shared context since ea45129f70001c424d24a97744c9c02b5644e171, which unified how auth information was carried around in Kong.  The code set `ngx.ctx.authenticated_jwt_token` in addition to maintain backwards compatibility. 
