### PR TITLE
fix(db) skip delete hooks if no rows were affected

### DIFF
--- a/kong/db/dao/init.lua
+++ b/kong/db/dao/init.lua
@@ -908,10 +908,13 @@ local function generate_foreign_key_methods(schema)
           return nil, tostring(err_t), err_t
         end
 
-        local _
-        _, err_t = self.strategy:delete_by_field(name, unique_value, options)
+        local rows_affected
+        rows_affected, err_t = self.strategy:delete_by_field(name, unique_value, options)
         if err_t then
           return nil, tostring(err_t), err_t
+
+        elseif not rows_affected then
+          return nil
         end
 
         entity, err_t = run_hook("dao:delete_by:post",
@@ -1294,10 +1297,13 @@ function DAO:delete(primary_key, options)
     return nil, tostring(err_t), err_t
   end
 
-  local _
-  _, err_t = self.strategy:delete(primary_key, options)
+  local rows_affected
+  rows_affected, err_t = self.strategy:delete(primary_key, options)
   if err_t then
     return nil, tostring(err_t), err_t
+
+  elseif not rows_affected then
+    return nil
   end
 
   entity, err_t = run_hook("dao:delete:post", entity, self.schema.name, options, ws_id, cascade_entries)

--- a/kong/db/strategies/cassandra/init.lua
+++ b/kong/db/strategies/cassandra/init.lua
@@ -1720,7 +1720,7 @@ function _mt:delete_by_field(field_name, field_value, options)
   end
 
   if not row then
-    return true
+    return nil, nil
   end
 
   local pk = self.schema:extract_pk_values(row)

--- a/kong/db/strategies/cassandra/init.lua
+++ b/kong/db/strategies/cassandra/init.lua
@@ -1720,7 +1720,7 @@ function _mt:delete_by_field(field_name, field_value, options)
   end
 
   if not row then
-    return nil, nil
+    return nil
   end
 
   local pk = self.schema:extract_pk_values(row)

--- a/spec/01-unit/01-db/04-dao_spec.lua
+++ b/spec/01-unit/01-db/04-dao_spec.lua
@@ -657,6 +657,7 @@ describe("DAO", function()
       local dao = DAO.new({}, schema, strategy, errors)
 
       dao:delete({ id = 1 })
+      dao:delete({ id = 1 })
 
       assert.spy(post_hook).was_called(1)
     end)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

> This pull request cherry-picks https://github.com/Kong/kong-ee/pull/3622

This PR fixes the issue that DAO delete hooks were triggered when no rows were affected.

The issue currently affects Kong Enterprise and Kong Manager. When concurrent delete requests are initiated on the same entity, the counter in the workspace meta will potentially be decremented multiple times and become a negative number.

FT-3072
