### PR TITLE
perf(*) tests(perf) correctly preserve kong source code when using daily image

### DIFF
--- a/spec/helpers/perf.lua
+++ b/spec/helpers/perf.lua
@@ -23,7 +23,7 @@ local driver_functions = {
   "start_upstreams", "start_kong", "stop_kong", "setup", "teardown",
   "get_start_load_cmd", "get_start_stapxx_cmd", "get_wait_stapxx_cmd",
   "generate_flamegraph", "save_error_log", "get_admin_uri",
-  "save_pgdump", "load_pgdump",
+  "save_pgdump", "load_pgdump", "get_based_version",
 }
 
 local function check_driver_sanity(mod)
@@ -461,7 +461,10 @@ function _M.generate_flamegraph(filename, title, opts)
   -- If current test is git-based, also attach the Kong binary package
   -- version it based on
   if git.is_git_repo() and git.is_git_based() then
-    title = title .. " (based on " .. git.get_kong_version() .. ")"
+    -- use driver to get the version; driver could implement version override
+    -- based on setups (like using the daily image)
+    local v = invoke_driver("get_based_version")
+    title = title .. " (based on " .. v .. ")"
   end
 
   local out = invoke_driver("generate_flamegraph", title, opts)

--- a/spec/helpers/perf/drivers/docker.lua
+++ b/spec/helpers/perf/drivers/docker.lua
@@ -15,6 +15,7 @@ function _M.new(opts)
     psql_ct_id = nil,
     kong_ct_ids = {},
     worker_ct_id = nil,
+    daily_image_desc = nil,
   }, mt)
 end
 
@@ -292,6 +293,7 @@ function _M:start_kong(version, kong_conf, driver_conf)
     driver_conf['ports'] = { 8000 }
   end
 
+  self.daily_image_desc = nil
   if version:startswith("git:") then
     perf.git_checkout(version:sub(#("git:")+1))
     use_git = true
@@ -464,6 +466,10 @@ function _M:load_pgdump(path, dont_patch_service)
           "', port=" .. UPSTREAM_PORT ..
           ", protocol='http';\" | docker exec -i " ..  self.psql_ct_id .. " psql -Ukong kong_tests",
           { logger = self.log.log_exec })
+end
+
+function _M:get_based_version()
+  return self.daily_image_desc or perf.get_kong_version()
 end
 
 return _M

--- a/spec/helpers/perf/drivers/local.lua
+++ b/spec/helpers/perf/drivers/local.lua
@@ -292,4 +292,8 @@ function _M:load_pgdump(path, dont_patch_service)
           { logger = self.log.log_exec })
 end
 
+function _M:get_based_version()
+  return perf.get_kong_version()
+end
+
 return _M


### PR DESCRIPTION
This bug didn't affect previous Github action runs, where we test two git based versions.