### PR TITLE
feat(rate-limiting) support dynamic path filtering

### DIFF
--- a/kong/plugins/rate-limiting/handler.lua
+++ b/kong/plugins/rate-limiting/handler.lua
@@ -70,10 +70,7 @@ local function get_identifier(conf)
     identifier = kong.request.get_header(conf.header_name)
 
   elseif conf.limit_by == "path" then
-    local req_path = kong.request.get_path()
-    if req_path == conf.path then
-      identifier = req_path
-    end
+    identifier = kong.request.get_path()
   end
 
   return identifier or kong.client.get_forwarded_ip()

--- a/kong/plugins/rate-limiting/schema.lua
+++ b/kong/plugins/rate-limiting/schema.lua
@@ -78,7 +78,6 @@ return {
               one_of = { "consumer", "credential", "ip", "service", "header", "path" },
           }, },
           { header_name = typedefs.header_name },
-          { path = typedefs.path },
           { policy = policy },
           { fault_tolerant = { type = "boolean", required = true, default = true }, },
           { redis_host = typedefs.host },
@@ -109,10 +108,6 @@ return {
     { conditional = {
       if_field = "config.limit_by", if_match = { eq = "header" },
       then_field = "config.header_name", then_match = { required = true },
-    } },
-    { conditional = {
-      if_field = "config.limit_by", if_match = { eq = "path" },
-      then_field = "config.path", then_match = { required = true },
     } },
     { conditional = {
       if_field = "config.policy", if_match = { eq = "redis" },

--- a/spec/03-plugins/23-rate-limiting/01-schema_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/01-schema_spec.lua
@@ -24,13 +24,6 @@ describe("Plugin: rate-limiting (schema)", function()
     assert.is_nil(err)
   end)
 
-  it("proper config validates (path)", function()
-    local config = { second = 10, limit_by = "path", path = "/request" }
-    local ok, _, err = v(config, schema_def)
-    assert.truthy(ok)
-    assert.is_nil(err)
-  end)
-
   describe("errors", function()
     it("limits: smaller unit is less than bigger unit", function()
       local config = { second = 20, hour = 10 }
@@ -59,13 +52,6 @@ describe("Plugin: rate-limiting (schema)", function()
       local ok, err = v(config, schema_def)
       assert.falsy(ok)
       assert.equal("required field missing", err.config.header_name)
-    end)
-
-    it("is limited by path but the path field is missing", function()
-      local config = { second = 10, limit_by = "path", path =  nil }
-      local ok, err = v(config, schema_def)
-      assert.falsy(ok)
-      assert.equal("required field missing", err.config.path)
     end)
   end)
 end)

--- a/spec/03-plugins/23-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/04-access_spec.lua
@@ -331,7 +331,6 @@ for _, strategy in helpers.each_strategy() do
               service = { id = service.id },
               config = {
                 limit_by          = "path",
-                path              = "/status/200",
                 policy            = policy,
                 minute            = 6,
                 fault_tolerant    = false,


### PR DESCRIPTION
### Summary

The current implementation of path based rate limiting only allows a single path identifier per route. However, there are situations where rate limiting by path would be helpful on a path that is dynamic, such as including a UUID in the path.

The changes included support this functionality by allowing the rate_limiting identifier to be automatically set to the path of the request. This means you don't need to specify which path to rate limit as it will be done automatically.

The existing test in `04-access_spec.lua`:

https://github.com/Kong/kong/blob/master/spec/03-plugins/23-rate-limiting/04-access_spec.lua#L396

Shows this change working by simply removing the `path` value set in the config, the test continues to function as expected as the path gets automatically pulled in.

### Full changelog

feat(rate-limiting) support dynamic path filtering

### Issue reference

N/A
