### PR TITLE
Update migrations.lua

### DIFF
--- a/kong/cmd/migrations.lua
+++ b/kong/cmd/migrations.lua
@@ -24,7 +24,7 @@ The available commands are:
 
   list                              List executed migrations.
 
-  reset                             Reset the database. The `reset` command will erase all the data in Kong's database and delete all the schemas.
+  reset                             Reset the database. The `reset` command erases all of the data in Kong's database and deletes all of the schemas.
 
 Options:
  -y,--yes                           Assume "yes" to prompts and run

--- a/kong/cmd/migrations.lua
+++ b/kong/cmd/migrations.lua
@@ -24,7 +24,7 @@ The available commands are:
 
   list                              List executed migrations.
 
-  reset                             Reset the database.
+  reset                             Reset the database. This erases Kong data and doesn't reset migration steps.
 
 Options:
  -y,--yes                           Assume "yes" to prompts and run

--- a/kong/cmd/migrations.lua
+++ b/kong/cmd/migrations.lua
@@ -24,7 +24,7 @@ The available commands are:
 
   list                              List executed migrations.
 
-  reset                             Reset the database. This erases Kong data and doesn't reset migration steps.
+  reset                             Reset the database. The `reset` command will erase all the data in Kong's database and delete all the schemas.
 
 Options:
  -y,--yes                           Assume "yes" to prompts and run


### PR DESCRIPTION
Updated `reset` command description.

### Summary

This change was requested in [DOCU-1474](https://konghq.atlassian.net/browse/DOCU-1474) because it was unclear to customers that the `reset` command would erase data instead of reset the migration steps.

### Full changelog

* Edited the description of the `reset` command

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix [DOCU-1474](https://konghq.atlassian.net/browse/DOCU-1474)
