### PR TITLE
docs(changelog) add lua-resty-events in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -255,6 +255,9 @@ nodes [#8452](https://github.com/Kong/kong/pull/8452).
 - Added `path`, `uri_capture`, and `query_arg` options to upstream `hash_on`
   for load balancing.
   [#8701](https://github.com/Kong/kong/pull/8701)
+- Introduce unix domain socket based `lua-resty-events` to
+  replace shared memory based `lua-resty-worker-events`
+  [#8890](https://github.com/Kong/kong/pull/8890)
 
 #### Hybrid Mode
 


### PR DESCRIPTION


### Summary

add `lua-resty-events` in changelog.

### Full changelog

* changelog: Additions.Core


