### PR TITLE
fix(schema) process auto-fields attempt to index local 'refs' (a nil value)

### DIFF
--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1736,13 +1736,22 @@ function Schema:process_auto_fields(data, context, nulls, opts)
           if subfield.type == "string" and subfield.referenceable then
             local count = #value
             if count > 0 then
-              refs[key] = new_tab(count, 0)
               for i = 1, count do
                 if is_reference(value[i]) then
+                  if not refs then
+                    refs = {}
+                  end
+
+                  if not refs[key] then
+                    refs[key] = new_tab(count, 0)
+                  end
+
                   refs[key][i] = value[i]
+
                   local deref, err = kong.vault.get(value[i])
                   if deref then
                     value[i] = deref
+
                   else
                     if err then
                       kong.log.warn("unable to resolve reference ", value[i], " (", err, ")")


### PR DESCRIPTION
### Summary

Fix issue internally reported as FT-3076 where schema process auto-fields function could lead to an attempt to index local 'refs' (a nil value) error.