### PR TITLE
chore(deps) bump resty.openssl from 0.8.8 to 0.8.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,9 +212,10 @@
   [#8544](https://github.com/Kong/kong/pull/8544)
   [#8752](https://github.com/Kong/kong/pull/8752)
   [#8994](https://github.com/Kong/kong/pull/8994)
-- Bumped resty.openssl from 0.8.5 to 0.8.7
+- Bumped resty.openssl from 0.8.8 to 0.8.10
   [#8592](https://github.com/Kong/kong/pull/8592)
   [#8753](https://github.com/Kong/kong/pull/8753)
+  [#9023](https://github.com/Kong/kong/pull/9023)
 - Bumped inspect from 3.1.2 to 3.1.3
   [#8589](https://github.com/Kong/kong/pull/8589)
 - Bumped resty.acme from 0.7.2 to 0.8.0

--- a/kong-2.8.0-0.rockspec
+++ b/kong-2.8.0-0.rockspec
@@ -36,7 +36,7 @@ dependencies = {
   "lua-resty-healthcheck == 1.5.1",
   "lua-resty-mlcache == 2.5.0",
   "lua-messagepack == 0.5.2",
-  "lua-resty-openssl == 0.8.8",
+  "lua-resty-openssl == 0.8.10",
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6.1",
   "lua-resty-acme == 0.8.0",


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

[0.8.10] - 2022-06-28

### Features

Commit https://github.com/fffonion/lua-resty-openssl/commit/d54b5d61bc14813121f4a6bda2e1d7eab215094a

* __x509.init__ add `get_signature_digest_name` to return short name of digest algorithm.
* __x509.csr__ add `get_signature_digest_name` to return short name of digest algorithm.
* __x509.crl__ add `get_signature_digest_name` to return short name of digest algorithm.
* __objects__ add `find_sigid_algs` to transforms signature `nid` to digest `nid`.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
* Fix _[FTI-3334](https://konghq.atlassian.net/browse/FTI-3334)_
