### PR TITLE
feat(core) explict flag for regex route.path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,7 +125,7 @@
   [#8988](https://github.com/Kong/kong/pull/8988)
 - `ngx.ctx.balancer_address` does not exist anymore, please use `ngx.ctx.balancer_data` instead.
   [#9043](https://github.com/Kong/kong/pull/9043)
-- Stop normalizing regex `router.path`. Regex path pattern matches with normalized URI,
+- Stop normalizing regex `route.path`. Regex path pattern matches with normalized URI,
   and we used to replace percent-encoding in regex path pattern to ensure different forms of URI matches.
   That is no longer supported. Except for reserved characters defined in
   [rfc3986](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,8 +131,8 @@
   [rfc3986](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2),
   we should write all other characters without percent-encoding.
   [#9024](https://github.com/Kong/kong/pull/9024)
-- Use `"~*"` as prefix to indicate a `route.path` is a regex pattern. We no longer guess
-  whether a path pattern is a regex, and all path without the `"~*"` prefix is considered plain text.
+- Use `"~"` as prefix to indicate a `route.path` is a regex pattern. We no longer guess
+  whether a path pattern is a regex, and all path without the `"~"` prefix is considered plain text.
   [#9027](https://github.com/Kong/kong/pull/9027)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,7 +125,7 @@
   [#8988](https://github.com/Kong/kong/pull/8988)
 - `ngx.ctx.balancer_address` does not exist anymore, please use `ngx.ctx.balancer_data` instead.
   [#9043](https://github.com/Kong/kong/pull/9043)
-- Stop normalizing regex `route.path`. Regex path pattern matches with normalized URI,
+- Stop normalizing regex `router.path`. Regex path pattern matches with normalized URI,
   and we used to replace percent-encoding in regex path pattern to ensure different forms of URI matches.
   That is no longer supported. Except for reserved characters defined in
   [rfc3986](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,9 @@
   [rfc3986](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2),
   we should write all other characters without percent-encoding.
   [#9024](https://github.com/Kong/kong/pull/9024)
+- Use `"~*"` as prefix to indicate a `router.path` is a regex pattern. We no longer guess
+  whether a path pattern is a regex, and all path without the `"~*"` prefix is considered plain text.
+  [#9027](https://github.com/Kong/kong/pull/9027)
 
 
 #### Admin API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,7 +131,7 @@
   [rfc3986](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2),
   we should write all other characters without percent-encoding.
   [#9024](https://github.com/Kong/kong/pull/9024)
-- Use `"~*"` as prefix to indicate a `router.path` is a regex pattern. We no longer guess
+- Use `"~*"` as prefix to indicate a `route.path` is a regex pattern. We no longer guess
   whether a path pattern is a regex, and all path without the `"~*"` prefix is considered plain text.
   [#9027](https://github.com/Kong/kong/pull/9027)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,7 +133,6 @@
   [#9024](https://github.com/Kong/kong/pull/9024)
 
 
-
 #### Admin API
 
 - `POST` requests on target entities endpoint are no longer able to update

--- a/kong/db/migrations/core/016_280_to_300.lua
+++ b/kong/db/migrations/core/016_280_to_300.lua
@@ -289,7 +289,7 @@ end
 
 local function migrate_regex(reg)
   local normalized = normalize_regex(reg)
-  return "~*" .. normalized
+  return "~" .. normalized
 end
 
 local function c_normalize_regex_path(coordinator)

--- a/kong/db/migrations/core/016_280_to_300.lua
+++ b/kong/db/migrations/core/016_280_to_300.lua
@@ -288,8 +288,8 @@ local function is_not_regex(path)
 end
 
 local function migrate_regex(reg)
-  -- also add regex indicator
-  return normalize_regex(reg)
+  local normalized = normalize_regex(reg)
+  return "~*" .. normalized
 end
 
 local function c_normalize_regex_path(coordinator)

--- a/kong/db/schema/typedefs.lua
+++ b/kong/db/schema/typedefs.lua
@@ -295,7 +295,10 @@ typedefs.port = Schema.define {
 
 typedefs.path = Schema.define {
   type = "string",
-  starts_with = "/",
+  match_any = {
+    patterns = {"^/", "^~*/"},
+    err = "should start with /",
+  },
   match_none = {
     { pattern = "//",
       err = "must not have empty segments"
@@ -449,7 +452,7 @@ local function validate_path_with_regexes(path)
   -- We can't take an ok from validate_path as a success just yet,
   -- because the router is currently more strict than RFC 3986 for
   -- non-regex paths:
-  if ngx.re.find(path, [[^[a-zA-Z0-9\.\-_~/%]*$]]) then
+  if path:sub(1,2) ~= "~*" then
     return true
   end
 
@@ -457,7 +460,7 @@ local function validate_path_with_regexes(path)
   -- router as valid non-regex paths.
   -- the value will be interpreted as a regex by the router; but is it a
   -- valid one? Let's dry-run it with the same options as our router.
-  local _, _, err = ngx.re.find("", path, "aj")
+  local _, _, err = ngx.re.find("", path:sub(3), "aj")
   if err then
     return nil,
            string.format("invalid regex: '%s' (PCRE returned: %s)",

--- a/kong/db/schema/typedefs.lua
+++ b/kong/db/schema/typedefs.lua
@@ -296,7 +296,7 @@ typedefs.port = Schema.define {
 typedefs.path = Schema.define {
   type = "string",
   match_any = {
-    patterns = {"^/", "^~%*/"},
+    patterns = {"^/", "^~/"},
     err = "should start with: /",
   },
   match_none = {
@@ -452,11 +452,11 @@ local function validate_path_with_regexes(path)
   -- We can't take an ok from validate_path as a success just yet,
   -- because the router is currently more strict than RFC 3986 for
   -- non-regex paths:
-  if path:sub(1, 2) ~= "~*" then
+  if path:sub(1, 1) ~= "~" then
     return true
   end
 
-  path = path:sub(3)
+  path = path:sub(2)
 
   -- URI contains characters outside of the list recognized by the
   -- router as valid non-regex paths.

--- a/kong/db/schema/typedefs.lua
+++ b/kong/db/schema/typedefs.lua
@@ -452,7 +452,7 @@ local function validate_path_with_regexes(path)
   -- We can't take an ok from validate_path as a success just yet,
   -- because the router is currently more strict than RFC 3986 for
   -- non-regex paths:
-  if path:sub(1,2) ~= "~*" then
+  if path:sub(1, 2) ~= "~*" then
     return true
   end
 

--- a/kong/db/schema/typedefs.lua
+++ b/kong/db/schema/typedefs.lua
@@ -296,7 +296,7 @@ typedefs.port = Schema.define {
 typedefs.path = Schema.define {
   type = "string",
   match_any = {
-    patterns = {"^/", "^~*/"},
+    patterns = {"^/", "^~%*/"},
     err = "should start with: /",
   },
   match_none = {
@@ -456,11 +456,13 @@ local function validate_path_with_regexes(path)
     return true
   end
 
+  path = path:sub(3)
+
   -- URI contains characters outside of the list recognized by the
   -- router as valid non-regex paths.
   -- the value will be interpreted as a regex by the router; but is it a
   -- valid one? Let's dry-run it with the same options as our router.
-  local _, _, err = ngx.re.find("", path:sub(3), "aj")
+  local _, _, err = ngx.re.find("", path, "aj")
   if err then
     return nil,
            string.format("invalid regex: '%s' (PCRE returned: %s)",

--- a/kong/db/schema/typedefs.lua
+++ b/kong/db/schema/typedefs.lua
@@ -297,7 +297,7 @@ typedefs.path = Schema.define {
   type = "string",
   match_any = {
     patterns = {"^/", "^~*/"},
-    err = "should start with /",
+    err = "should start with: /",
   },
   match_none = {
     { pattern = "//",

--- a/kong/db/schema/typedefs.lua
+++ b/kong/db/schema/typedefs.lua
@@ -449,17 +449,12 @@ local function validate_path_with_regexes(path)
     return ok, err, err_code
   end
 
-  -- We can't take an ok from validate_path as a success just yet,
-  -- because the router is currently more strict than RFC 3986 for
-  -- non-regex paths:
   if path:sub(1, 1) ~= "~" then
     return true
   end
 
   path = path:sub(2)
 
-  -- URI contains characters outside of the list recognized by the
-  -- router as valid non-regex paths.
   -- the value will be interpreted as a regex by the router; but is it a
   -- valid one? Let's dry-run it with the same options as our router.
   local _, _, err = ngx.re.find("", path, "aj")

--- a/kong/db/schema/typedefs.lua
+++ b/kong/db/schema/typedefs.lua
@@ -297,7 +297,7 @@ typedefs.path = Schema.define {
   type = "string",
   match_any = {
     patterns = {"^/", "^~/"},
-    err = "should start with: /",
+    err = "should start with: / (fixed path) or ~/ (regex path)",
   },
   match_none = {
     { pattern = "//",

--- a/kong/router.lua
+++ b/kong/router.lua
@@ -426,9 +426,6 @@ local function marshall_route(r)
       for i = 1, count do
         local path = paths[i]
         local is_regex = path:sub(1,2) == "~*"
-        if is_regex then
-          path = path:sub(3)
-        end
 
         if not is_regex then
           -- plain URI or URI prefix
@@ -444,6 +441,7 @@ local function marshall_route(r)
 
         else
 
+          path = path:sub(3)
           -- regex URI
           local strip_regex  = REGEX_PREFIX .. path .. [[(?<uri_postfix>.*)]]
 

--- a/kong/router.lua
+++ b/kong/router.lua
@@ -425,7 +425,7 @@ local function marshall_route(r)
       match_weight = match_weight + 1
       for i = 1, count do
         local path = paths[i]
-        local is_regex = path:sub(1,2) == "~*"
+        local is_regex = path:sub(1, 2) == "~*"
 
         if not is_regex then
           -- plain URI or URI prefix

--- a/kong/router.lua
+++ b/kong/router.lua
@@ -425,8 +425,12 @@ local function marshall_route(r)
       match_weight = match_weight + 1
       for i = 1, count do
         local path = paths[i]
+        local is_regex = path:sub(1,2) == "~*"
+        if is_regex then
+          path = path:sub(3)
+        end
 
-        if re_find(path, [[[a-zA-Z0-9\.\-_~/%]*$]], "ajo") then
+        if not is_regex then
           -- plain URI or URI prefix
 
           local uri_t = {

--- a/kong/router.lua
+++ b/kong/router.lua
@@ -425,7 +425,7 @@ local function marshall_route(r)
       match_weight = match_weight + 1
       for i = 1, count do
         local path = paths[i]
-        local is_regex = path:sub(1, 2) == "~*"
+        local is_regex = path:sub(1, 1) == "~"
 
         if not is_regex then
           -- plain URI or URI prefix
@@ -441,7 +441,7 @@ local function marshall_route(r)
 
         else
 
-          path = path:sub(3)
+          path = path:sub(2)
           -- regex URI
           local strip_regex  = REGEX_PREFIX .. path .. [[(?<uri_postfix>.*)]]
 

--- a/kong/router.lua
+++ b/kong/router.lua
@@ -425,7 +425,7 @@ local function marshall_route(r)
       match_weight = match_weight + 1
       for i = 1, count do
         local path = paths[i]
-        local is_regex = path:sub(1, 1) == "~"
+        local is_regex = sub(path, 1, 1) == "~"
 
         if not is_regex then
           -- plain URI or URI prefix
@@ -441,7 +441,7 @@ local function marshall_route(r)
 
         else
 
-          path = path:sub(2)
+          path = sub(path, 2)
           -- regex URI
           local strip_regex  = REGEX_PREFIX .. path .. [[(?<uri_postfix>.*)]]
 

--- a/spec/01-unit/01-db/01-schema/05-services_spec.lua
+++ b/spec/01-unit/01-db/01-schema/05-services_spec.lua
@@ -168,7 +168,7 @@ describe("services", function()
 
       local ok, err = Services:validate(service)
       assert.falsy(ok)
-      assert.equal("should start with: /", err.path)
+      assert.equal("should start with: / (fixed path) or ~/ (regex path)", err.path)
     end)
 
     it("must not have empty segments (/foo//bar)", function()

--- a/spec/01-unit/01-db/01-schema/06-routes_spec.lua
+++ b/spec/01-unit/01-db/01-schema/06-routes_spec.lua
@@ -251,7 +251,7 @@ describe("routes schema", function()
       local u = require("spec.helpers").unindent
 
       local invalid_paths = {
-        [[~*/users/(foo/profile]],
+        [[~/users/(foo/profile]],
       }
 
       for i = 1, #invalid_paths do

--- a/spec/01-unit/01-db/01-schema/06-routes_spec.lua
+++ b/spec/01-unit/01-db/01-schema/06-routes_spec.lua
@@ -251,7 +251,7 @@ describe("routes schema", function()
       local u = require("spec.helpers").unindent
 
       local invalid_paths = {
-        [[/users/(foo/profile]],
+        [[~*/users/(foo/profile]],
       }
 
       for i = 1, #invalid_paths do

--- a/spec/01-unit/01-db/01-schema/06-routes_spec.lua
+++ b/spec/01-unit/01-db/01-schema/06-routes_spec.lua
@@ -227,7 +227,7 @@ describe("routes schema", function()
 
       local ok, err = Routes:validate(route)
       assert.falsy(ok)
-      assert.equal("should start with: /", err.paths[1])
+      assert.equal("should start with: / (fixed path) or ~/ (regex path)", err.paths[1])
     end)
 
     it("must not have empty segments (/foo//bar)", function()

--- a/spec/01-unit/01-db/01-schema/09-upstreams_spec.lua
+++ b/spec/01-unit/01-db/01-schema/09-upstreams_spec.lua
@@ -376,7 +376,7 @@ describe("load upstreams", function()
         {{ active = { concurrency = 0 }}, pos_integer },
         {{ active = { concurrency = -10 }}, pos_integer },
         {{ active = { http_path = "" }}, len_min_default },
-        {{ active = { http_path = "ovo" }}, "should start with: /" },
+        {{ active = { http_path = "ovo" }}, "should start with: / (fixed path) or ~/ (regex path)" },
         {{ active = { https_sni = "127.0.0.1", }}, invalid_ip },
         {{ active = { https_sni = "127.0.0.1:8080", }}, invalid_ip },
         {{ active = { https_sni = "/example", }}, invalid_host },

--- a/spec/01-unit/01-db/01-schema/11-declarative_config/01-validate_spec.lua
+++ b/spec/01-unit/01-db/01-schema/11-declarative_config/01-validate_spec.lua
@@ -447,7 +447,7 @@ describe("declarative config: validate", function()
                 ["routes"] = {
                   {
                     ["paths"] = {
-                      "should start with: /"
+                      "should start with: / (fixed path) or ~/ (regex path)"
                     }
                   }
                 }

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -832,7 +832,7 @@ describe("Router", function()
           {
             service = service,
             route   = {
-              paths = { [[/users/\d+/profile]] },
+              paths = { [[~*/users/\d+/profile]] },
             },
           },
         }
@@ -853,19 +853,19 @@ describe("Router", function()
           {
             service = service,
             route   = {
-              paths = { [[/route/persons/\d{3}]] },
+              paths = { [[~*/route/persons/\d{3}]] },
             },
           },
           {
             service = service,
             route   = {
-              paths = { [[/route/persons/\d{3}/following]] },
+              paths = { [[~*/route/persons/\d{3}/following]] },
             },
           },
           {
             service = service,
             route   = {
-              paths = { [[/route/persons/\d{3}/[a-z]+]] },
+              paths = { [[~*/route/persons/\d{3}/[a-z]+]] },
             },
           },
         }
@@ -888,7 +888,7 @@ describe("Router", function()
           {
             service = service,
             route   = {
-              paths = { [[/route/persons/\d+/profile]] },
+              paths = { [[~*/route/persons/\d+/profile]] },
             },
           },
         }
@@ -916,7 +916,7 @@ describe("Router", function()
           {
             service = service,
             route   = {
-              paths = { "/route/(fixture)" },
+              paths = { "~*/route/(fixture)" },
             },
           },
         }
@@ -952,7 +952,7 @@ describe("Router", function()
             service = service,
             route   = {
               hosts = { "route.com" },
-              paths = { "/(path)" },
+              paths = { "~*/(path)" },
             },
           },
         }
@@ -1325,7 +1325,7 @@ describe("Router", function()
             service = service,
             route   = {
               hosts = { "*.example.com" },
-              paths = { [[/users/\d+/profile]] },
+              paths = { [[~*/users/\d+/profile]] },
             },
           },
           {
@@ -1481,7 +1481,7 @@ describe("Router", function()
           service = service,
           route   = {
             paths = {
-              "/reg%65x/\\d+", -- /regex/\d+
+              "~*/reg%65x/\\d+", -- /regex/\d+
             },
           },
         },
@@ -1489,7 +1489,7 @@ describe("Router", function()
           service = service,
           route   = {
             paths = {
-              "/regex-meta/%5Cd\\+%2E", -- /regex-meta/\d\+.
+              "~*/regex-meta/%5Cd\\+%2E", -- /regex-meta/\d\+.
             },
           },
         },
@@ -1497,7 +1497,7 @@ describe("Router", function()
           service = service,
           route   = {
             paths = {
-              "/regex-reserved%2Fabc", -- /regex-reserved/abc
+              "~*/regex-reserved%2Fabc", -- /regex-reserved/abc
             },
           },
         },
@@ -1712,14 +1712,14 @@ describe("Router", function()
             service   = service,
             route     = {
               methods = { "GET" },
-              paths   = { [[/users/\d+/profile]] },
+              paths   = { [[~*/users/\d+/profile]] },
             },
           },
           {
             service   = service,
             route     = {
               methods = { "POST" },
-              paths   = { [[/users/\d*/profile]] },
+              paths   = { [[~*/users/\d*/profile]] },
             },
           },
         }
@@ -2440,7 +2440,7 @@ describe("Router", function()
         {
           service   = service,
           route     = {
-            paths   = { [[/users/\d+/profile]] },
+            paths   = { [[~*/users/\d+/profile]] },
           },
         },
       }
@@ -2500,7 +2500,7 @@ describe("Router", function()
         {
           service = service,
           route   = {
-            paths = { [[/users/(?P<user_id>\d+)/profile/?(?P<scope>[a-z]*)]] },
+            paths = { [[~*/users/(?P<user_id>\d+)/profile/?(?P<scope>[a-z]*)]] },
           },
         },
       }
@@ -2572,7 +2572,7 @@ describe("Router", function()
         {
           service = service,
           route   = {
-            paths = { [[/users/\d+/profile]] },
+            paths = { [[~*/users/\d+/profile]] },
           },
         },
       }
@@ -2823,7 +2823,7 @@ describe("Router", function()
           {
             service      = service,
             route        = {
-              paths      = { [[/users/\d+/profile]] },
+              paths      = { [[~*/users/\d+/profile]] },
               strip_path = true,
             },
           },
@@ -2843,7 +2843,7 @@ describe("Router", function()
           {
             service      = service,
             route        = {
-              paths      = { [[/users/(\d+)/profile]] },
+              paths      = { [[~*/users/(\d+)/profile]] },
               strip_path = true,
             },
           },
@@ -3195,7 +3195,7 @@ describe("Router", function()
         if line.route_path then -- skip test cases which match on host
           for j, test in ipairs(line:expand()) do
             local strip = test.strip_path and "on" or "off"
-            local regex = "/[0]?" .. test.route_path:sub(2, -1)
+            local regex = "~*/[0]?" .. test.route_path:sub(2, -1)
             local description = string.format("(%d-%d) regex, %s with %s, strip = %s, %s. req: %s",
               i, j, test.service_path, regex, strip, test.path_handling, test.request_path)
 

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -2572,7 +2572,7 @@ describe("Router", function()
         {
           service = service,
           route   = {
-            paths = { [[/users/\d+/profile]] },
+            paths = { [[~/users/\d+/profile]] },
           },
         },
       }
@@ -2823,7 +2823,7 @@ describe("Router", function()
           {
             service      = service,
             route        = {
-              paths      = { [[/users/\d+/profile]] },
+              paths      = { [[~/users/\d+/profile]] },
               strip_path = true,
             },
           },
@@ -3195,7 +3195,7 @@ describe("Router", function()
         if line.route_path then -- skip test cases which match on host
           for j, test in ipairs(line:expand()) do
             local strip = test.strip_path and "on" or "off"
-            local regex = "/[0]?" .. test.route_path:sub(2, -1)
+            local regex = "~/[0]?" .. test.route_path:sub(2, -1)
             local description = string.format("(%d-%d) regex, %s with %s, strip = %s, %s. req: %s",
               i, j, test.service_path, regex, strip, test.path_handling, test.request_path)
 

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -832,7 +832,7 @@ describe("Router", function()
           {
             service = service,
             route   = {
-              paths = { [[~*/users/\d+/profile]] },
+              paths = { [[~/users/\d+/profile]] },
             },
           },
         }
@@ -853,19 +853,19 @@ describe("Router", function()
           {
             service = service,
             route   = {
-              paths = { [[~*/route/persons/\d{3}]] },
+              paths = { [[~/route/persons/\d{3}]] },
             },
           },
           {
             service = service,
             route   = {
-              paths = { [[~*/route/persons/\d{3}/following]] },
+              paths = { [[~/route/persons/\d{3}/following]] },
             },
           },
           {
             service = service,
             route   = {
-              paths = { [[~*/route/persons/\d{3}/[a-z]+]] },
+              paths = { [[~/route/persons/\d{3}/[a-z]+]] },
             },
           },
         }
@@ -888,7 +888,7 @@ describe("Router", function()
           {
             service = service,
             route   = {
-              paths = { [[~*/route/persons/\d+/profile]] },
+              paths = { [[~/route/persons/\d+/profile]] },
             },
           },
         }
@@ -916,7 +916,7 @@ describe("Router", function()
           {
             service = service,
             route   = {
-              paths = { "~*/route/(fixture)" },
+              paths = { "~/route/(fixture)" },
             },
           },
         }
@@ -952,7 +952,7 @@ describe("Router", function()
             service = service,
             route   = {
               hosts = { "route.com" },
-              paths = { "~*/(path)" },
+              paths = { "~/(path)" },
             },
           },
         }
@@ -1325,7 +1325,7 @@ describe("Router", function()
             service = service,
             route   = {
               hosts = { "*.example.com" },
-              paths = { [[~*/users/\d+/profile]] },
+              paths = { [[~/users/\d+/profile]] },
             },
           },
           {
@@ -1481,7 +1481,7 @@ describe("Router", function()
           service = service,
           route   = {
             paths = {
-              "~*/reg%65x/\\d+", -- /regex/\d+
+              "~/reg%65x/\\d+", -- /regex/\d+
             },
           },
         },
@@ -1489,7 +1489,7 @@ describe("Router", function()
           service = service,
           route   = {
             paths = {
-              "~*/regex-meta/%5Cd\\+%2E", -- /regex-meta/\d\+.
+              "~/regex-meta/%5Cd\\+%2E", -- /regex-meta/\d\+.
             },
           },
         },
@@ -1497,7 +1497,7 @@ describe("Router", function()
           service = service,
           route   = {
             paths = {
-              "~*/regex-reserved%2Fabc", -- /regex-reserved/abc
+              "~/regex-reserved%2Fabc", -- /regex-reserved/abc
             },
           },
         },
@@ -1712,14 +1712,14 @@ describe("Router", function()
             service   = service,
             route     = {
               methods = { "GET" },
-              paths   = { [[~*/users/\d+/profile]] },
+              paths   = { [[~/users/\d+/profile]] },
             },
           },
           {
             service   = service,
             route     = {
               methods = { "POST" },
-              paths   = { [[~*/users/\d*/profile]] },
+              paths   = { [[~/users/\d*/profile]] },
             },
           },
         }
@@ -2440,7 +2440,7 @@ describe("Router", function()
         {
           service   = service,
           route     = {
-            paths   = { [[~*/users/\d+/profile]] },
+            paths   = { [[~/users/\d+/profile]] },
           },
         },
       }
@@ -2500,7 +2500,7 @@ describe("Router", function()
         {
           service = service,
           route   = {
-            paths = { [[~*/users/(?P<user_id>\d+)/profile/?(?P<scope>[a-z]*)]] },
+            paths = { [[~/users/(?P<user_id>\d+)/profile/?(?P<scope>[a-z]*)]] },
           },
         },
       }
@@ -2572,7 +2572,7 @@ describe("Router", function()
         {
           service = service,
           route   = {
-            paths = { [[~*/users/\d+/profile]] },
+            paths = { [[/users/\d+/profile]] },
           },
         },
       }
@@ -2823,7 +2823,7 @@ describe("Router", function()
           {
             service      = service,
             route        = {
-              paths      = { [[~*/users/\d+/profile]] },
+              paths      = { [[/users/\d+/profile]] },
               strip_path = true,
             },
           },
@@ -2843,7 +2843,7 @@ describe("Router", function()
           {
             service      = service,
             route        = {
-              paths      = { [[~*/users/(\d+)/profile]] },
+              paths      = { [[~/users/(\d+)/profile]] },
               strip_path = true,
             },
           },
@@ -3195,7 +3195,7 @@ describe("Router", function()
         if line.route_path then -- skip test cases which match on host
           for j, test in ipairs(line:expand()) do
             local strip = test.strip_path and "on" or "off"
-            local regex = "~*/[0]?" .. test.route_path:sub(2, -1)
+            local regex = "/[0]?" .. test.route_path:sub(2, -1)
             local description = string.format("(%d-%d) regex, %s with %s, strip = %s, %s. req: %s",
               i, j, test.service_path, regex, strip, test.path_handling, test.request_path)
 

--- a/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
@@ -421,7 +421,7 @@ describe("Admin API: #" .. strategy, function()
             })
             body = assert.res_status(400, res)
             local json = cjson.decode(body)
-            assert.same({ hash_on_cookie_path = "should start with: /" }, json.fields)
+            assert.same({ hash_on_cookie_path = "should start with: / (fixed path) or ~/ (regex path)" }, json.fields)
 
             -- Invalid cookie in hash fallback
             res = assert(client:send {
@@ -455,7 +455,7 @@ describe("Admin API: #" .. strategy, function()
             })
             body = assert.res_status(400, res)
             local json = cjson.decode(body)
-            assert.same({ hash_on_cookie_path = "should start with: /" }, json.fields)
+            assert.same({ hash_on_cookie_path = "should start with: / (fixed path) or ~/ (regex path)" }, json.fields)
 
           end
         end)

--- a/spec/02-integration/04-admin_api/10-services_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/10-services_routes_spec.lua
@@ -843,11 +843,11 @@ for _, strategy in helpers.each_strategy() do
                 message  = unindent([[
                   2 schema violations
                   (host: required field missing;
-                  path: should start with: /)
+                  path: should start with: / (fixed path) or ~/ (regex path))
                 ]], true, true),
                 fields = {
                   host = "required field missing",
-                  path = "should start with: /",
+                  path = "should start with: / (fixed path) or ~/ (regex path)",
                 },
               }, json
             )

--- a/spec/02-integration/05-proxy/02-router_spec.lua
+++ b/spec/02-integration/05-proxy/02-router_spec.lua
@@ -2192,11 +2192,6 @@ for _, strategy in ipairs{"postgres"} do
                 }))
 
                 local data = assert.response(res).has.jsonbody()
-                if not data.vars then
-                  print(require"inspect"(res))
-                  print(test.expected_path)
-                  print("localbin-" .. i .. "-" .. j .. ".com")
-                end
                 assert.truthy(data.vars)
                 assert.equal(test.expected_path, data.vars.request_uri)
               end)

--- a/spec/02-integration/05-proxy/02-router_spec.lua
+++ b/spec/02-integration/05-proxy/02-router_spec.lua
@@ -123,7 +123,7 @@ local function remove_routes(strategy, routes)
 end
 
 for _, b in ipairs({ false, true }) do enable_buffering = b
-for _, strategy in helpers.each_strategy() do
+for _, strategy in ipairs{"postgres"} do
   describe("Router [#" .. strategy .. "] with buffering [" .. (b and "on]" or "off]") , function()
     local proxy_client
     local proxy_ssl_client
@@ -227,7 +227,7 @@ for _, strategy in helpers.each_strategy() do
             },
           },
           {
-            paths      = { [[/users/\d+/profile]] },
+            paths      = { [[~*/users/\d+/profile]] },
             protocols  = { "http" },
             strip_path = true,
             service    = {
@@ -249,7 +249,7 @@ for _, strategy in helpers.each_strategy() do
             },
           },
           {
-            paths      = { [[/enabled-service/\w+]] },
+            paths      = { [[~*/enabled-service/\w+]] },
             protocols  = { "http" },
             strip_path = true,
             service    = {
@@ -736,7 +736,7 @@ for _, strategy in helpers.each_strategy() do
           {
             created_at = 1234567890,
             strip_path = true,
-            paths      = { "/status/(re)" },
+            paths      = { "~*/status/(re)" },
             service    = {
               name     = "regex_1",
               path     = "/status/200",
@@ -745,7 +745,7 @@ for _, strategy in helpers.each_strategy() do
           {
             created_at = 1234567891,
             strip_path = true,
-            paths      = { "/status/(r)" },
+            paths      = { "~*/status/(r)" },
             service    = {
               name     = "regex_2",
               path     = "/status/200",
@@ -802,7 +802,7 @@ for _, strategy in helpers.each_strategy() do
 
           {
             strip_path = true,
-            paths      = { "/status/(?<foo>re)" },
+            paths      = { "~*/status/(?<foo>re)" },
             service    = {
               name     = "regex_1",
               path     = "/status/200",
@@ -811,7 +811,7 @@ for _, strategy in helpers.each_strategy() do
           },
           {
             strip_path = true,
-            paths      = { "/status/(re)" },
+            paths      = { "~*/status/(re)" },
             service    = {
               name     = "regex_2",
               path     = "/status/200",
@@ -824,7 +824,7 @@ for _, strategy in helpers.each_strategy() do
           {
             created_at = 1234567890,
             strip_path = true,
-            paths      = { "/status/(ab)" },
+            paths      = { "~*/status/(ab)" },
             service    = {
               name     = "regex_3",
               path     = "/status/200",
@@ -834,7 +834,7 @@ for _, strategy in helpers.each_strategy() do
           {
             created_at = 1234567891,
             strip_path = true,
-            paths      = { "/status/(ab)c?" },
+            paths      = { "~*/status/(ab)c?" },
             service    = {
               name     = "regex_4",
               path     = "/status/200",
@@ -2146,7 +2146,7 @@ for _, strategy in helpers.each_strategy() do
 
       describe("(regex)", function()
         local function make_a_regex(path)
-          return "/[0]?" .. path:sub(2, -1)
+          return "~*/[0]?" .. path:sub(2, -1)
         end
 
         local routes
@@ -2192,6 +2192,12 @@ for _, strategy in helpers.each_strategy() do
                 }))
 
                 local data = assert.response(res).has.jsonbody()
+                if not data.vars then
+                  print(require"inspect"(res))
+                  print(test.expected_path)
+                  print("localbin-" .. i .. "-" .. j .. ".com")
+                end
+                assert.truthy(data.vars)
                 assert.equal(test.expected_path, data.vars.request_uri)
               end)
             end

--- a/spec/02-integration/05-proxy/02-router_spec.lua
+++ b/spec/02-integration/05-proxy/02-router_spec.lua
@@ -227,7 +227,7 @@ for _, strategy in ipairs{"postgres"} do
             },
           },
           {
-            paths      = { [[~*/users/\d+/profile]] },
+            paths      = { [[~/users/\d+/profile]] },
             protocols  = { "http" },
             strip_path = true,
             service    = {
@@ -249,7 +249,7 @@ for _, strategy in ipairs{"postgres"} do
             },
           },
           {
-            paths      = { [[~*/enabled-service/\w+]] },
+            paths      = { [[~/enabled-service/\w+]] },
             protocols  = { "http" },
             strip_path = true,
             service    = {
@@ -736,7 +736,7 @@ for _, strategy in ipairs{"postgres"} do
           {
             created_at = 1234567890,
             strip_path = true,
-            paths      = { "~*/status/(re)" },
+            paths      = { "~/status/(re)" },
             service    = {
               name     = "regex_1",
               path     = "/status/200",
@@ -745,7 +745,7 @@ for _, strategy in ipairs{"postgres"} do
           {
             created_at = 1234567891,
             strip_path = true,
-            paths      = { "~*/status/(r)" },
+            paths      = { "~/status/(r)" },
             service    = {
               name     = "regex_2",
               path     = "/status/200",
@@ -802,7 +802,7 @@ for _, strategy in ipairs{"postgres"} do
 
           {
             strip_path = true,
-            paths      = { "~*/status/(?<foo>re)" },
+            paths      = { "~/status/(?<foo>re)" },
             service    = {
               name     = "regex_1",
               path     = "/status/200",
@@ -811,7 +811,7 @@ for _, strategy in ipairs{"postgres"} do
           },
           {
             strip_path = true,
-            paths      = { "~*/status/(re)" },
+            paths      = { "~/status/(re)" },
             service    = {
               name     = "regex_2",
               path     = "/status/200",
@@ -824,7 +824,7 @@ for _, strategy in ipairs{"postgres"} do
           {
             created_at = 1234567890,
             strip_path = true,
-            paths      = { "~*/status/(ab)" },
+            paths      = { "~/status/(ab)" },
             service    = {
               name     = "regex_3",
               path     = "/status/200",
@@ -834,7 +834,7 @@ for _, strategy in ipairs{"postgres"} do
           {
             created_at = 1234567891,
             strip_path = true,
-            paths      = { "~*/status/(ab)c?" },
+            paths      = { "~/status/(ab)c?" },
             service    = {
               name     = "regex_4",
               path     = "/status/200",
@@ -2146,7 +2146,7 @@ for _, strategy in ipairs{"postgres"} do
 
       describe("(regex)", function()
         local function make_a_regex(path)
-          return "~*/[0]?" .. path:sub(2, -1)
+          return "~/[0]?" .. path:sub(2, -1)
         end
 
         local routes

--- a/spec/02-integration/05-proxy/02-router_spec.lua
+++ b/spec/02-integration/05-proxy/02-router_spec.lua
@@ -123,7 +123,7 @@ local function remove_routes(strategy, routes)
 end
 
 for _, b in ipairs({ false, true }) do enable_buffering = b
-for _, strategy in ipairs{"postgres"} do
+for _, strategy in helpers.each_strategy() do
   describe("Router [#" .. strategy .. "] with buffering [" .. (b and "on]" or "off]") , function()
     local proxy_client
     local proxy_ssl_client

--- a/spec/03-plugins/36-request-transformer/02-access_spec.lua
+++ b/spec/03-plugins/36-request-transformer/02-access_spec.lua
@@ -53,12 +53,12 @@ describe("Plugin: request-transformer(access) [#" .. strategy .. "]", function()
     })
     local route10 = bp.routes:insert({
       hosts = { "test10.test" },
-      paths = { "/requests/user1/(?P<user1>\\w+)/user2/(?P<user2>\\S+)" },
+      paths = { "~*/requests/user1/(?P<user1>\\w+)/user2/(?P<user2>\\S+)" },
       strip_path = false
     })
     local route11 = bp.routes:insert({
       hosts = { "test11.test" },
-      paths = { "/requests/user1/(?P<user1>\\w+)/user2/(?P<user2>\\S+)" }
+      paths = { "~*/requests/user1/(?P<user1>\\w+)/user2/(?P<user2>\\S+)" }
     })
     local route12 = bp.routes:insert({
       hosts = { "test12.test" },
@@ -67,35 +67,35 @@ describe("Plugin: request-transformer(access) [#" .. strategy .. "]", function()
     })
     local route13 = bp.routes:insert({
       hosts = { "test13.test" },
-      paths = { "/requests/user1/(?P<user1>\\w+)/user2/(?P<user2>\\S+)" }
+      paths = { "~*/requests/user1/(?P<user1>\\w+)/user2/(?P<user2>\\S+)" }
     })
     local route14 = bp.routes:insert({
       hosts = { "test14.test" },
-      paths = { "/user1/(?P<user1>\\w+)/user2/(?P<user2>\\S+)" }
+      paths = { "~*/user1/(?P<user1>\\w+)/user2/(?P<user2>\\S+)" }
     })
     local route15 = bp.routes:insert({
       hosts = { "test15.test" },
-      paths = { "/requests/user1/(?<user1>\\w+)/user2/(?<user2>\\S+)" },
+      paths = { "~*/requests/user1/(?<user1>\\w+)/user2/(?<user2>\\S+)" },
       strip_path = false
     })
     local route16 = bp.routes:insert({
       hosts = { "test16.test" },
-      paths = { "/requests/user1/(?<user1>\\w+)/user2/(?<user2>\\S+)" },
+      paths = { "~*/requests/user1/(?<user1>\\w+)/user2/(?<user2>\\S+)" },
       strip_path = false
     })
     local route17 = bp.routes:insert({
       hosts = { "test17.test" },
-      paths = { "/requests/user1/(?<user1>\\w+)/user2/(?<user2>\\S+)" },
+      paths = { "~*/requests/user1/(?<user1>\\w+)/user2/(?<user2>\\S+)" },
       strip_path = false
     })
     local route18 = bp.routes:insert({
       hosts = { "test18.test" },
-      paths = { "/requests/user1/(?<user1>\\w+)/user2/(?<user2>\\S+)" },
+      paths = { "~*/requests/user1/(?<user1>\\w+)/user2/(?<user2>\\S+)" },
       strip_path = false
     })
     local route19 = bp.routes:insert({
       hosts = { "test19.test" },
-      paths = { "/requests/user1/(?<user1>\\w+)/user2/(?<user2>\\S+)" },
+      paths = { "~*/requests/user1/(?<user1>\\w+)/user2/(?<user2>\\S+)" },
       strip_path = false
     })
     local route20 = bp.routes:insert({

--- a/spec/03-plugins/36-request-transformer/02-access_spec.lua
+++ b/spec/03-plugins/36-request-transformer/02-access_spec.lua
@@ -53,12 +53,12 @@ describe("Plugin: request-transformer(access) [#" .. strategy .. "]", function()
     })
     local route10 = bp.routes:insert({
       hosts = { "test10.test" },
-      paths = { "~*/requests/user1/(?P<user1>\\w+)/user2/(?P<user2>\\S+)" },
+      paths = { "~/requests/user1/(?P<user1>\\w+)/user2/(?P<user2>\\S+)" },
       strip_path = false
     })
     local route11 = bp.routes:insert({
       hosts = { "test11.test" },
-      paths = { "~*/requests/user1/(?P<user1>\\w+)/user2/(?P<user2>\\S+)" }
+      paths = { "~/requests/user1/(?P<user1>\\w+)/user2/(?P<user2>\\S+)" }
     })
     local route12 = bp.routes:insert({
       hosts = { "test12.test" },
@@ -67,35 +67,35 @@ describe("Plugin: request-transformer(access) [#" .. strategy .. "]", function()
     })
     local route13 = bp.routes:insert({
       hosts = { "test13.test" },
-      paths = { "~*/requests/user1/(?P<user1>\\w+)/user2/(?P<user2>\\S+)" }
+      paths = { "~/requests/user1/(?P<user1>\\w+)/user2/(?P<user2>\\S+)" }
     })
     local route14 = bp.routes:insert({
       hosts = { "test14.test" },
-      paths = { "~*/user1/(?P<user1>\\w+)/user2/(?P<user2>\\S+)" }
+      paths = { "~/user1/(?P<user1>\\w+)/user2/(?P<user2>\\S+)" }
     })
     local route15 = bp.routes:insert({
       hosts = { "test15.test" },
-      paths = { "~*/requests/user1/(?<user1>\\w+)/user2/(?<user2>\\S+)" },
+      paths = { "~/requests/user1/(?<user1>\\w+)/user2/(?<user2>\\S+)" },
       strip_path = false
     })
     local route16 = bp.routes:insert({
       hosts = { "test16.test" },
-      paths = { "~*/requests/user1/(?<user1>\\w+)/user2/(?<user2>\\S+)" },
+      paths = { "~/requests/user1/(?<user1>\\w+)/user2/(?<user2>\\S+)" },
       strip_path = false
     })
     local route17 = bp.routes:insert({
       hosts = { "test17.test" },
-      paths = { "~*/requests/user1/(?<user1>\\w+)/user2/(?<user2>\\S+)" },
+      paths = { "~/requests/user1/(?<user1>\\w+)/user2/(?<user2>\\S+)" },
       strip_path = false
     })
     local route18 = bp.routes:insert({
       hosts = { "test18.test" },
-      paths = { "~*/requests/user1/(?<user1>\\w+)/user2/(?<user2>\\S+)" },
+      paths = { "~/requests/user1/(?<user1>\\w+)/user2/(?<user2>\\S+)" },
       strip_path = false
     })
     local route19 = bp.routes:insert({
       hosts = { "test19.test" },
-      paths = { "~*/requests/user1/(?<user1>\\w+)/user2/(?<user2>\\S+)" },
+      paths = { "~/requests/user1/(?<user1>\\w+)/user2/(?<user2>\\S+)" },
       strip_path = false
     })
     local route20 = bp.routes:insert({

--- a/spec/fixtures/balancer_utils.lua
+++ b/spec/fixtures/balancer_utils.lua
@@ -327,7 +327,7 @@ do
 
     local rpaths = {
       "/",
-      "~*/(?<namespace>[^/]+)/(?<id>[0-9]+)/?", -- uri capture hash value
+      "~/(?<namespace>[^/]+)/(?<id>[0-9]+)/?", -- uri capture hash value
     }
 
     bp.services:insert({

--- a/spec/fixtures/balancer_utils.lua
+++ b/spec/fixtures/balancer_utils.lua
@@ -327,7 +327,7 @@ do
 
     local rpaths = {
       "/",
-      "/(?<namespace>[^/]+)/(?<id>[0-9]+)/?", -- uri capture hash value
+      "~*/(?<namespace>[^/]+)/(?<id>[0-9]+)/?", -- uri capture hash value
     }
 
     bp.services:insert({


### PR DESCRIPTION
Another solution for #9022.

fix CT-344

We need to remember to add migration, and also "back migration" for EE.

**PLEASE MERGE AFTER: #9024**