### PR TITLE
fix(globalpatches) fallback to alternative_sleep at init phase

### DIFF
--- a/kong/globalpatches.lua
+++ b/kong/globalpatches.lua
@@ -57,9 +57,12 @@ return function(options)
     end
 
     -- luacheck: globals ngx.sleep
+    local blocking_sleep_phases = {
+      init = true,
+      init_worker = true,
+    }
     ngx.sleep = function(s)
-      local phase = get_phase()
-      if phase == "init" or phase == "init_worker" then
+      if blocking_sleep_phases[get_phase()] then
         ngx.log(ngx.NOTICE, "executing a blocking 'sleep' (", s, " seconds)")
         return alternative_sleep(s)
       end

--- a/kong/globalpatches.lua
+++ b/kong/globalpatches.lua
@@ -58,7 +58,8 @@ return function(options)
 
     -- luacheck: globals ngx.sleep
     ngx.sleep = function(s)
-      if get_phase() == "init_worker" then
+      local phase = get_phase()
+      if phase == "init" or phase == "init_worker" then
         ngx.log(ngx.NOTICE, "executing a blocking 'sleep' (", s, " seconds)")
         return alternative_sleep(s)
       end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
Kong Enterprise invoked `ngx.sleep` in `init` phase in some scenarios(e.g. keyring failed). But the current patch for `ngx.sleep` doesn't support fallback to blocking sleep in `init` phase.

### Full changelog

* fix(globalpatches) fallback to alternative_sleep at init phase

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
NO issue related
