### PR TITLE
chore(balancer) remove deprecated ngx.ctx.balancer_address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,8 @@
 - DAOs in plugins must be listed in an array, so that their loading order is explicit. Loading them in a
   hash-like table is no longer supported.
   [#8988](https://github.com/Kong/kong/pull/8988)
+- `ngx.ctx.balancer_address` does not exist anymore, please use `ngx.ctx.balancer_data` instead.
+  [#9043](https://github.com/Kong/kong/pull/9043)
 
 
 #### Admin API

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -925,7 +925,6 @@ do
     ctx.service          = service
     ctx.route            = route
     ctx.balancer_data    = balancer_data
-    ctx.balancer_address = balancer_data -- for plugin backward compatibility
 
     if is_http_module and service then
       local res, err


### PR DESCRIPTION
### Summary

`ngx.ctx.balancer_address` was removed, please use `ngx.ctx.balancer_data` instead.