### PR TITLE
fix(otel) allow only global scope

### DIFF
--- a/kong/plugins/opentelemetry/schema.lua
+++ b/kong/plugins/opentelemetry/schema.lua
@@ -30,6 +30,10 @@ local resource_attributes = Schema.define {
 return {
   name = "opentelemetry",
   fields = {
+    -- global plugin only
+    { consumer = typedefs.no_consumer },
+    { service = typedefs.no_service },
+    { route = typedefs.no_route },
     { protocols = typedefs.protocols_http }, -- TODO: support stream mode
     { config = {
       type = "record",


### PR DESCRIPTION
### Summary

Make sure opentelemetry plugin is the global scope.

FT-3096