### PR TITLE
fix(aws-lambda) change path from request_uri to upstream_uri

### DIFF
--- a/kong/plugins/aws-lambda/aws-serializer.lua
+++ b/kong/plugins/aws-lambda/aws-serializer.lua
@@ -78,7 +78,7 @@ return function(ctx, config)
   end
 
   -- prepare path
-  local path = var.request_uri:match("^([^%?]+)")  -- strip any query args
+  local path = var.upstream_uri:match("^([^%?]+)")  -- strip any query args
 
   local request = {
     resource                        = ctx.router_matches.uri,

--- a/spec/03-plugins/27-aws-lambda/05-aws-serializer_spec.lua
+++ b/spec/03-plugins/27-aws-lambda/05-aws-serializer_spec.lua
@@ -53,7 +53,7 @@ describe("[AWS Lambda] aws-gateway input", function()
       body = "text",
       var = {
         request_method = "GET",
-        request_uri = "/123/strip/more?boolean=;multi-query=first;single-query=hello%20world;multi-query=second"
+        upstream_uri = "/123/strip/more?boolean=;multi-query=first;single-query=hello%20world;multi-query=second"
       },
       ctx = {
         router_matches = {
@@ -113,7 +113,7 @@ describe("[AWS Lambda] aws-gateway input", function()
       body = "text",
       var = {
         request_method = "GET",
-        request_uri = "/plain/strip/more?boolean=;multi-query=first;single-query=hello%20world;multi-query=second"
+        upstream_uri = "/plain/strip/more?boolean=;multi-query=first;single-query=hello%20world;multi-query=second"
       },
       ctx = {
         router_matches = {
@@ -187,7 +187,7 @@ describe("[AWS Lambda] aws-gateway input", function()
           query = {},
           var = {
             request_method = "GET",
-            request_uri = "/plain/strip/more",
+            upstream_uri = "/plain/strip/more",
             http_content_type = tdata.ct,
           },
           ctx = {


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary
when `aws-lambda` plugin `awsgateway_compatible` configuration set to `true` and  `request-transformer` replace uri configuration enabled, `kong` use request_uri to find serializer path args, this action doesn't respect  `request-transformer` configuration parameters

<!--- Why is this change required? What problem does it solve? -->

### Full changelog
change aws-lambda plugin serializer path arg from request_uri to upstream_uri

### Issue reference
Fix #8608 
<!--- If it fixes an open issue, please link to the issue here. -->

