### PR TITLE
fix(dao) response "HEALTHCHECK_OFF" for targets with weight 0

### DIFF
--- a/kong/db/dao/targets.lua
+++ b/kong/db/dao/targets.lua
@@ -255,21 +255,16 @@ function _TARGETS:page_for_upstream_with_health(upstream_pk, ...)
       if health_info[target.target] ~= nil and
         #health_info[target.target].addresses > 0 then
         target.health = "HEALTHCHECKS_OFF"
-        if target.weight == 0 then
-          for _, address in ipairs(health_info[target.target].addresses) do
-            address.health = "HEALTHCHECKS_OFF"
+        -- If any of the target addresses are healthy, then the target is
+        -- considered healthy.
+        for _, address in ipairs(health_info[target.target].addresses) do
+          if address.health == "HEALTHY" then
+            target.health = "HEALTHY"
+            break
+          elseif address.health == "UNHEALTHY" then
+            target.health = "UNHEALTHY"
           end
-        else
-          -- If any of the target addresses are healthy, then the target is
-          -- considered healthy.
-          for _, address in ipairs(health_info[target.target].addresses) do
-            if address.health == "HEALTHY" then
-              target.health = "HEALTHY"
-              break
-            elseif address.health == "UNHEALTHY" then
-              target.health = "UNHEALTHY"
-            end
-          end
+
         end
       else
         target.health = "DNS_ERROR"

--- a/kong/db/dao/targets.lua
+++ b/kong/db/dao/targets.lua
@@ -255,16 +255,21 @@ function _TARGETS:page_for_upstream_with_health(upstream_pk, ...)
       if health_info[target.target] ~= nil and
         #health_info[target.target].addresses > 0 then
         target.health = "HEALTHCHECKS_OFF"
-        -- If any of the target addresses are healthy, then the target is
-        -- considered healthy.
-        for _, address in ipairs(health_info[target.target].addresses) do
-          if address.health == "HEALTHY" then
-            target.health = "HEALTHY"
-            break
-          elseif address.health == "UNHEALTHY" then
-            target.health = "UNHEALTHY"
+        if target.weight == 0 then
+          for _, address in ipairs(health_info[target.target].addresses) do
+            address.health = "HEALTHCHECKS_OFF"
           end
-
+        else
+          -- If any of the target addresses are healthy, then the target is
+          -- considered healthy.
+          for _, address in ipairs(health_info[target.target].addresses) do
+            if address.health == "HEALTHY" then
+              target.health = "HEALTHY"
+              break
+            elseif address.health == "UNHEALTHY" then
+              target.health = "UNHEALTHY"
+            end
+          end
         end
       else
         target.health = "DNS_ERROR"

--- a/kong/runloop/balancer/healthcheckers.lua
+++ b/kong/runloop/balancer/healthcheckers.lua
@@ -329,7 +329,7 @@ function healthcheckers_M.get_upstream_health(upstream_id)
     local key = target.name .. ":" .. target.port
     health_info[key] = balancer:getTargetStatus(target)
     for _, address in ipairs(health_info[key].addresses) do
-      if using_hc target.weight > 0 then
+      if using_hc and target.weight > 0 then
         address.health = address.healthy and "HEALTHY" or "UNHEALTHY"
       else
         address.health = "HEALTHCHECKS_OFF"

--- a/kong/runloop/balancer/healthcheckers.lua
+++ b/kong/runloop/balancer/healthcheckers.lua
@@ -329,7 +329,7 @@ function healthcheckers_M.get_upstream_health(upstream_id)
     local key = target.name .. ":" .. target.port
     health_info[key] = balancer:getTargetStatus(target)
     for _, address in ipairs(health_info[key].addresses) do
-      if using_hc then
+      if using_hc target.weight > 0 then
         address.health = address.healthy and "HEALTHY" or "UNHEALTHY"
       else
         address.health = "HEALTHCHECKS_OFF"

--- a/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -486,7 +486,7 @@ describe("Admin API #" .. strategy, function()
 
         end)
 
-        it("#new returns HEALTHCHECK_OFF for target with weight 0", function ()
+        it("returns HEALTHCHECK_OFF for target with weight 0", function ()
           local status, _ = client_send({
             method = "POST",
             path = "/upstreams/" .. upstream.name .. "/targets",

--- a/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -487,7 +487,7 @@ describe("Admin API #" .. strategy, function()
         end)
 
         it("#new returns HEALTHCHECK_OFF for target with weight 0", function ()
-          local status, body = client_send({
+          local status, _ = client_send({
             method = "POST",
             path = "/upstreams/" .. upstream.name .. "/targets",
             headers = {

--- a/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -512,7 +512,7 @@ describe("Admin API #" .. strategy, function()
             end
           end
           assert.equal(1, #res.data)
-          check_health_addresses(res.data[1].addresses, "HEALTHCHECKS_OFF")
+          check_health_addresses(res.data[1].data.addresses, "HEALTHCHECKS_OFF")
 
         end)
       end)

--- a/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -506,7 +506,13 @@ describe("Admin API #" .. strategy, function()
           })
           assert.same(200, status)
           local res = assert(cjson.decode(body))
-          assert.same("HEALTHCHECKS_OFF", res.data[1].health)
+          local function check_health_addresses(addresses, health)
+            for i=1, #addresses do
+              assert.same(health, addresses[i].health)
+            end
+          end
+          assert.equal(1, #res.data)
+          check_health_addresses(res.data[1].addresses, "HEALTHCHECKS_OFF")
 
         end)
       end)


### PR DESCRIPTION
### Summary

Target with weight 0 will not be added into the healthcheck list,
and the default Health status of targets is HEALTHY. For such
targets, Admin API call /upstreams/<upstream>/health reports Health
status as HEALTHY while the healthcheck is not performed for them.
The appropriate status is HEALTHCHECK_OFF.
Fix for Admin API call to provide response with "HEALTHCHECK_OFF"
for targets with weight 0.
