### PR TITLE
fix(prometheus) data_plane_version_compatible metric of inexistent data plan had been hold in shared dict

### DIFF
--- a/kong/plugins/prometheus/exporter.lua
+++ b/kong/plugins/prometheus/exporter.lua
@@ -396,6 +396,7 @@ local function metric_data(write_fn)
     -- Cleanup old metrics
     metrics.data_plane_last_seen:reset()
     metrics.data_plane_config_hash:reset()
+    metrics.data_plane_version_compatible:reset()
 
     for data_plane, err in kong.db.clustering_data_planes:each() do
       if err then


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->


### Full changelog

* fix(prometheus) data_plane_version_compatible metric of inexistent data plan had been held in shared dict

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
FTI-4157
