### PR TITLE
feat(rate-limiting) support rate-limiting plugin timezone awareness

### DIFF
--- a/kong/plugins/rate-limiting/handler.lua
+++ b/kong/plugins/rate-limiting/handler.lua
@@ -118,7 +118,13 @@ end
 
 
 function RateLimitingHandler:access(conf)
-  local current_timestamp = time() * 1000
+  local local_timezone = conf.local_timezone
+  local current_timestamp
+  if local_timezone then
+    current_timestamp = timestamp.get_tz_time()
+  else
+    current_timestamp = time() * 1000
+  end
 
   -- Consumer is identified by ip address or authenticated_credential id
   local identifier = get_identifier(conf)

--- a/kong/plugins/rate-limiting/schema.lua
+++ b/kong/plugins/rate-limiting/schema.lua
@@ -91,6 +91,7 @@ return {
           { redis_timeout = { type = "number", default = 2000, }, },
           { redis_database = { type = "integer", default = 0 }, },
           { hide_client_headers = { type = "boolean", required = true, default = false }, },
+          { local_timezone = { type = "boolean", required = false, default = false }, },
         },
         custom_validator = validate_periods_order,
       },

--- a/spec/01-unit/06-timestamp_spec.lua
+++ b/spec/01-unit/06-timestamp_spec.lua
@@ -85,7 +85,7 @@ describe("Timestamp", function()
   it("should get correct local timestamp when local timezone is UTC", function()
     local localtime_symlink = pl_path.exists("/etc/localtime")
     if localtime_symlink then
-      os.execute("mv /etc/localtime /etc/localtime_backup")
+      os.execute("sudo mv /etc/localtime /etc/localtime_backup")
     end
     local utc_timestamp = timestamp.get_utc()
     local local_timestamp = timestamp.get_tz_time()
@@ -94,7 +94,7 @@ describe("Timestamp", function()
     assert.is_true(time_offset > 0)
     assert.is_true(time_offset < 1000)
     if localtime_symlink then
-      os.execute("mv /etc/localtime_backup /etc/localtime")
+      os.execute("sudo mv /etc/localtime_backup /etc/localtime")
     end
   end)
 
@@ -110,17 +110,17 @@ describe("Timestamp", function()
   it("should get correct local timestamp when local timezone is set to UTC+1", function ()
     local localtime_symlink = pl_path.exists("/etc/localtime")
     if localtime_symlink then
-      os.execute("mv /etc/localtime /etc/localtime_backup")
+      os.execute("sudo mv /etc/localtime /etc/localtime_backup")
     end
-    os.execute("ln -sf /usr/share/zoneinfo/Europe/London /etc/localtime")
+    os.execute("sudo ln -sf /usr/share/zoneinfo/Europe/London /etc/localtime")
     local utc_timestamp = timestamp.get_utc()
     local local_timestamp = timestamp.get_tz_time()
     local time_offset = local_timestamp - utc_timestamp - 60 * 60 * 1000
     assert.is_true(time_offset < 1000)
     assert.is_true(time_offset > 0)
-    os.execute("rm /etc/localtime")
+    os.execute("sudo rm /etc/localtime")
     if localtime_symlink then
-      os.execute("mv /etc/localtime_backup /etc/localtime")
+      os.execute("sudo mv /etc/localtime_backup /etc/localtime")
     end
   end)
 end)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

This PR adds support for the rate-limiting plugin to be aware of the local timezone.

Currently, the rate-limiting plugin is working on UTC time, and there have been issues from users complaining about the accuracy problem working in their own timezone(like https://github.com/Kong/kong/issues/8894, and [FTI-4105](https://konghq.atlassian.net/browse/FTI-4105)).

This PR adds an additional param `local_timezone` for the rate-limiting plugin to let the rate-limiting take effect based on the local timezone so that rate-limiting on days/months/years will be based on the local timestamp.


The side-effect of this PR, however, is causing some ambiguity on the SQL generated by rate-limiting cluster policies:

https://github.com/Kong/kong/blob/5d721ac9ae1df36049013599d0253bd39cb6f758/kong/plugins/rate-limiting/policies/cluster.lua#L79-L91

After the change, `TO_TIMESTAMP(%s) AT TIME ZONE 'UTC'` with the period date will not mean that this value is a UTC timestamp, it is actually a local timestamp but we just stored it as a 'fake UTC' timestamp so that it will not be drifted.

Note that this change does not have an influence on the TTL of Postgres records because TTLs are calculated on the Postgres side.

I made this PR a draft to leave some space for checking & commenting so that I can make sure the change is meaningful, ~~and I'll add related tests and do other checks if this PR is considered a proper way to solve the timezone problem.~~

<!--- Why is this change required? What problem does it solve? -->

### Full changelog

* Add `get_tz_time` function(can be used to get milliseconds since unix epoch in the given timezone) in `kong.tools.timestamp`
* Add `local_timezone` param for `rate-limiting` plugin

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #8894 and [FTI-4105](https://konghq.atlassian.net/browse/FTI-4105).
