### PR TITLE
fix(clustering) event for config sync is generated 2 times

### DIFF
--- a/kong-2.8.1-0.rockspec
+++ b/kong-2.8.1-0.rockspec
@@ -74,6 +74,7 @@ build = {
     ["kong.clustering.config_helper"] = "kong/clustering/config_helper.lua",
     ["kong.clustering.services.negotiation"] = "kong/clustering/services/negotiation.lua",
     ["kong.clustering.services.supported"] = "kong/clustering/services/supported.lua",
+    ["kong.clustering.services.config"] = "kong/clustering/services/config.lua",
 
     ["kong.cluster_events"] = "kong/cluster_events/init.lua",
     ["kong.cluster_events.strategies.cassandra"] = "kong/cluster_events/strategies/cassandra.lua",

--- a/kong/clustering/init.lua
+++ b/kong/clustering/init.lua
@@ -6,6 +6,7 @@ local pl_file = require("pl.file")
 local pl_tablex = require("pl.tablex")
 local ssl = require("ngx.ssl")
 local openssl_x509 = require("resty.openssl.x509")
+local config_service = require("kong.clustering.services.config")
 local ngx_log = ngx.log
 local assert = assert
 local sort = table.sort
@@ -60,8 +61,9 @@ function _M:handle_wrpc_websocket()
 end
 
 function _M:init_cp_worker(plugins_list)
-  self.json_handler:init_worker(plugins_list)
-  self.wrpc_handler:init_worker(plugins_list)
+  config_service.init_worker()
+  config_service.init_control_plane(self.json_handler, plugins_list)
+  config_service.init_control_plane(self.wrpc_handler, plugins_list)
 end
 
 function _M:init_dp_worker(plugins_list)

--- a/kong/clustering/services/config.lua
+++ b/kong/clustering/services/config.lua
@@ -1,0 +1,125 @@
+local _M = {}
+local cjson = require("cjson.safe")
+local semaphore = require("ngx.semaphore")
+local declarative = require("kong.db.declarative")
+local clustering_utils = require("kong.clustering.utils")
+local calculate_config_hash = require("kong.clustering.config_helper").calculate_config_hash
+
+local kong_dict = ngx.shared.kong
+local cjson_encode = cjson.encode
+local plugins_list_to_map = clustering_utils.plugins_list_to_map
+
+
+local type = type
+local ngx = ngx
+local ngx_ERR = ngx.ERR
+local ngx_DEBUG = ngx.DEBUG
+local ngx_log = ngx.log
+local _log_prefix = "[config sync] "
+local kong = kong
+local timer_at = ngx.timer.at
+
+
+-- Sends "clustering", "push_config" to all workers in the same node, including self
+local function post_push_config_event()
+  local res, err = kong.worker_events.post("clustering", "push_config")
+  if not res then
+    ngx_log(ngx_ERR, _log_prefix, "unable to broadcast event: ", err)
+  end
+end
+
+local function handle_dao_crud_event(data)
+  if type(data) ~= "table" or data.schema == nil or data.schema.db_export == false then
+    return
+  end
+
+  kong.cluster_events:broadcast("clustering:push_config", data.schema.name .. ":" .. data.operation)
+
+  -- we have to re-broadcast event using `post` because the dao
+  -- events were sent using `post_local` which means not all workers
+  -- can receive it
+  post_push_config_event()
+end
+
+-- Handles "clustering:push_config" cluster event
+local function handle_clustering_push_config_event(data)
+  ngx_log(ngx_DEBUG, _log_prefix, "received clustering:push_config event for ", data)
+  post_push_config_event()
+end
+
+function _M.init_worker()
+  -- The "dao:crud" event is triggered using post_local, which eventually generates an
+  -- ""clustering:push_config" cluster event. It is assumed that the workers in the
+  -- same node where the dao:crud event originated will "know" about the update mostly via
+  -- changes in the cache shared dict. Since data planes don't use the cache, nodes in the same
+  -- kong node where the event originated will need to be notified so they push config to
+  -- their data planes
+  kong.worker_events.register(handle_dao_crud_event, "dao:crud")
+
+  -- The "clustering:push_config" cluster event gets inserted in the cluster when there's
+  -- a crud change (like an insertion or deletion). Only one worker per kong node receives
+  -- this callback. This makes such node post push_config events to all the cp workers on
+  -- its node
+  kong.cluster_events:subscribe("clustering:push_config", handle_clustering_push_config_event)
+end
+
+function _M.init_control_plane(control_plane, plugins_list)
+  control_plane.plugins_list = plugins_list
+
+  control_plane.plugins_map = plugins_list_to_map(plugins_list)
+
+  control_plane.plugins_configured = {}
+  control_plane.plugin_versions = {}
+
+  for i = 1, #plugins_list do
+    local plugin = plugins_list[i]
+    control_plane.plugin_versions[plugin.name] = plugin.version
+  end
+
+  -- each control_plane must have its own semaphore,
+  -- otherwise only 1 kind of dataplanes recieve configs
+  local push_config_semaphore = semaphore.new()
+
+  -- When "clustering", "push_config" worker event is received by a worker,
+  -- it loads and pushes the config to its the connected data planes
+  kong.worker_events.register(function(_)
+    if push_config_semaphore:count() <= 0 then
+      -- the following line always executes immediately after the `if` check
+      -- because `:count` will never yield, end result is that the semaphore
+      -- count is guaranteed to not exceed 1
+      push_config_semaphore:post()
+    end
+  end, "clustering", "push_config")
+
+  timer_at(0, control_plane.push_config_loop, control_plane, push_config_semaphore,
+               control_plane.conf.db_update_frequency)
+end
+
+local config_version = 0
+
+function _M:get_config()
+  local config_table, err = declarative.export_config()
+  if not config_table then
+    return nil, err
+  end
+
+  -- update plugins map
+  local plugins_configured = {}
+  if config_table.plugins then
+    for _, plugin in pairs(config_table.plugins) do
+      plugins_configured[plugin.name] = true
+    end
+  end
+
+  -- store serialized plugins map for troubleshooting purposes
+  local shm_key_name = "clustering:cp_plugins_configured:worker_" .. ngx.worker.id()
+  kong_dict:set(shm_key_name, cjson_encode(plugins_configured))
+  ngx_log(ngx_DEBUG, "plugin configuration map key: " .. shm_key_name .. " configuration: ", kong_dict:get(shm_key_name))
+
+  local config_hash, hashes = calculate_config_hash(config_table)
+  config_version = config_version + 1
+
+  return config_table, config_hash, hashes, plugins_configured
+end
+
+return _M

--- a/kong/clustering/services/config.lua
+++ b/kong/clustering/services/config.lua
@@ -95,7 +95,6 @@ function _M.init_control_plane(control_plane, plugins_list)
                control_plane.conf.db_update_frequency)
 end
 
-local config_version = 0
 
 function _M:get_config()
   local config_table, err = declarative.export_config()
@@ -117,7 +116,6 @@ function _M:get_config()
   ngx_log(ngx_DEBUG, "plugin configuration map key: " .. shm_key_name .. " configuration: ", kong_dict:get(shm_key_name))
 
   local config_hash, hashes = calculate_config_hash(config_table)
-  config_version = config_version + 1
 
   return config_table, config_hash, hashes, plugins_configured
 end

--- a/kong/clustering/wrpc_control_plane.lua
+++ b/kong/clustering/wrpc_control_plane.lua
@@ -104,6 +104,7 @@ function _M:export_deflated_reconfigure_payload()
     return nil, config_hash -- config_hash is err in this case
   end
 
+  config_version = config_version + 1
   self.plugins_configured = plugins_configured
 
   local service = get_wrpc_service(self)

--- a/kong/clustering/wrpc_control_plane.lua
+++ b/kong/clustering/wrpc_control_plane.lua
@@ -4,17 +4,15 @@ local _MT = { __index = _M, }
 
 local semaphore = require("ngx.semaphore")
 local cjson = require("cjson.safe")
-local declarative = require("kong.db.declarative")
+local config_service = require("kong.clustering.services.config")
 local constants = require("kong.constants")
 local clustering_utils = require("kong.clustering.utils")
 local wrpc = require("kong.tools.wrpc")
 local wrpc_proto = require("kong.tools.wrpc.proto")
 local utils = require("kong.tools.utils")
 local init_negotiation_server = require("kong.clustering.services.negotiation").init_negotiation_server
-local calculate_config_hash = require("kong.clustering.config_helper").calculate_config_hash
 local string = string
 local setmetatable = setmetatable
-local type = type
 local pcall = pcall
 local pairs = pairs
 local ngx = ngx
@@ -25,13 +23,12 @@ local ngx_exit = ngx.exit
 local exiting = ngx.worker.exiting
 local ngx_time = ngx.time
 local ngx_var = ngx.var
-local timer_at = ngx.timer.at
 
 local plugins_list_to_map = clustering_utils.plugins_list_to_map
 local deflate_gzip = utils.deflate_gzip
 local yield = utils.yield
 
-local kong_dict = ngx.shared.kong
+local get_config = config_service.get_config
 local ngx_DEBUG = ngx.DEBUG
 local ngx_INFO = ngx.INFO
 local ngx_NOTICE = ngx.NOTICE
@@ -101,25 +98,13 @@ end
 local config_version = 0
 
 function _M:export_deflated_reconfigure_payload()
-  local config_table, err = declarative.export_config()
+  local config_table, config_hash, hashes, plugins_configured = get_config()
+
   if not config_table then
-    return nil, err
+    return nil, config_hash -- config_hash is err in this case
   end
 
-  -- update plugins map
-  self.plugins_configured = {}
-  if config_table.plugins then
-    for _, plugin in pairs(config_table.plugins) do
-      self.plugins_configured[plugin.name] = true
-    end
-  end
-
-  local config_hash, hashes = calculate_config_hash(config_table)
-  config_version = config_version + 1
-
-  -- store serialized plugins map for troubleshooting purposes
-  local shm_key_name = "clustering:cp_plugins_configured:worker_" .. ngx.worker.id()
-  kong_dict:set(shm_key_name, cjson_encode(self.plugins_configured))
+  self.plugins_configured = plugins_configured
 
   local service = get_wrpc_service(self)
 
@@ -257,7 +242,7 @@ function _M:handle_cp_websocket()
 end
 
 
-local function push_config_loop(premature, self, push_config_semaphore, delay)
+function _M.push_config_loop(premature, self, push_config_semaphore, delay)
   if premature then
     return
   end
@@ -302,84 +287,5 @@ local function push_config_loop(premature, self, push_config_semaphore, delay)
     end
   end
 end
-
-
-function _M:init_worker(plugins_list)
-  -- ROLE = "control_plane"
-
-  self.plugins_list = plugins_list
-
-  self.plugins_map = plugins_list_to_map(plugins_list)
-
-  self.deflated_reconfigure_payload = nil
-  self.reconfigure_payload = nil
-  self.plugins_configured = {}
-  self.plugin_versions = {}
-
-  for i = 1, #plugins_list do
-    local plugin = plugins_list[i]
-    self.plugin_versions[plugin.name] = plugin.version
-  end
-
-  local push_config_semaphore = semaphore.new()
-
-  -- Sends "clustering", "push_config" to all workers in the same node, including self
-  local function post_push_config_event()
-    local res, err = kong.worker_events.post("clustering", "push_config")
-    if not res then
-      ngx_log(ngx_ERR, _log_prefix, "unable to broadcast event: ", err)
-    end
-  end
-
-  -- Handles "clustering:push_config" cluster event
-  local function handle_clustering_push_config_event(data)
-    ngx_log(ngx_DEBUG, _log_prefix, "received clustering:push_config event for ", data)
-    post_push_config_event()
-  end
-
-
-  -- Handles "dao:crud" worker event and broadcasts "clustering:push_config" cluster event
-  local function handle_dao_crud_event(data)
-    if type(data) ~= "table" or data.schema == nil or data.schema.db_export == false then
-      return
-    end
-
-    kong.cluster_events:broadcast("clustering:push_config", data.schema.name .. ":" .. data.operation)
-
-    -- we have to re-broadcast event using `post` because the dao
-    -- events were sent using `post_local` which means not all workers
-    -- can receive it
-    post_push_config_event()
-  end
-
-  -- The "clustering:push_config" cluster event gets inserted in the cluster when there's
-  -- a crud change (like an insertion or deletion). Only one worker per kong node receives
-  -- this callback. This makes such node post push_config events to all the cp workers on
-  -- its node
-  kong.cluster_events:subscribe("clustering:push_config", handle_clustering_push_config_event)
-
-  -- The "dao:crud" event is triggered using post_local, which eventually generates an
-  -- ""clustering:push_config" cluster event. It is assumed that the workers in the
-  -- same node where the dao:crud event originated will "know" about the update mostly via
-  -- changes in the cache shared dict. Since data planes don't use the cache, nodes in the same
-  -- kong node where the event originated will need to be notified so they push config to
-  -- their data planes
-  kong.worker_events.register(handle_dao_crud_event, "dao:crud")
-
-  -- When "clustering", "push_config" worker event is received by a worker,
-  -- it loads and pushes the config to its the connected data planes
-  kong.worker_events.register(function(_)
-    if push_config_semaphore:count() <= 0 then
-      -- the following line always executes immediately after the `if` check
-      -- because `:count` will never yield, end result is that the semaphore
-      -- count is guaranteed to not exceed 1
-      push_config_semaphore:post()
-    end
-  end, "clustering", "push_config")
-
-  timer_at(0, push_config_loop, self, push_config_semaphore,
-               self.conf.db_update_frequency)
-end
-
 
 return _M

--- a/kong/clustering/wrpc_data_plane.lua
+++ b/kong/clustering/wrpc_data_plane.lua
@@ -153,7 +153,7 @@ local function communicate_impl(dp)
 
         local data = dp.next_data
         if data then
-          local config_version = tonumber(data.version)
+          local config_version = tonumber(data.version or 0)
           if config_version > last_config_version then
             local config_table = assert(inflate_gzip(data.config))
             yield()


### PR DESCRIPTION
This problem is because we register events 2 times, each for 1 implementation of a control plane.

I also refactored a little bit. They cannot share 1 copy of the config cache because they have different handling of the message.

For wRPC, it's `protobuf(gzip(json_encode(config)) + other_fields)`, and for webSocket it's `gzip(json_encode(config + other_fields))`.