### PR TITLE
feat(acme): debug log details

### DIFF
--- a/kong/plugins/acme/handler.lua
+++ b/kong/plugins/acme/handler.lua
@@ -105,7 +105,7 @@ function ACMEHandler:certificate(conf)
   host = string.lower(host)
 
   if not check_domains(conf, host) then
-    kong.log.debug("ignoring because domain is not in whitelist")
+    kong.log.debug("ignoring because domain is not in whitelist:", host)
     return
   end
 

--- a/kong/plugins/acme/handler.lua
+++ b/kong/plugins/acme/handler.lua
@@ -105,7 +105,7 @@ function ACMEHandler:certificate(conf)
   host = string.lower(host)
 
   if not check_domains(conf, host) then
-    kong.log.debug("ignoring because domain is not in whitelist:", host)
+    kong.log.debug("ignoring because domain is not in allowed-list: ", host)
     return
   end
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Currently the FTI-3300 has not landed and we're using the previous implementation, monitoring the use of it using debug logs. But we're not able to have the granularity of failed domains registration. With this log we would be able to have more insights.

Note: suggesting changing `whitelist` to `allowlist` too.

### Full changelog

* Add host in the debug log for non allowed domain

### Issue reference

Following https://github.com/Kong/kong/pull/9047
