### PR TITLE
fix(release): be more verbose about building and pushing the master branch builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,7 +68,7 @@ pipeline {
                 sh './scripts/setup-ci.sh'
                 sh 'make setup-kong-build-tools'
 
-                sh 'cd $KONG_BUILD_TOOLS_LOCATION && make package-kong'
+                sh 'cd $KONG_BUILD_TOOLS_LOCATION && DOCKER_MACHINE_ARM64_NAME="jenkins-kong-"`cat /proc/sys/kernel/random/uuid` make package-kong'
                 sh 'cd $KONG_BUILD_TOOLS_LOCATION && make build-test-container'
                 sh 'cd $KONG_BUILD_TOOLS_LOCATION && make test'
                 sh 'docker tag $KONG_TEST_IMAGE_NAME kong/kong-gateway-internal:${GIT_BRANCH##*/}'


### PR DESCRIPTION
The "nightly" release logic currently is
```
RELEASE_DOCKER_ONLY=true kong make release
kong-build-tools make package-kong
kong-build-tools make test
kong-build-tools make build-test-container
kong-build-tools make release #which exits early after pushing the docker container
```
This leads to release naming and destination logic is burried behind many layers of abstraction including two Makefile's and kong-build-tools release.sh.

Instead let's make our CI more verbose / explicit about what exactly it's doing. Explicitly call package, build the test container, test it and rename / push

related: https://github.com/Kong/kong-ee/pull/3432