### PR TITLE
chore(atc_router) add LRU cache support just like the traditional router

### DIFF
--- a/kong/router/atc_compat.lua
+++ b/kong/router/atc_compat.lua
@@ -570,8 +570,8 @@ function _M:exec(ctx)
       local name = name:gsub("-", "_"):lower()
 
       if type(value) == "table" then
-        for i = 1, #value do
-          value[i] = value[i]:lower()
+        for i, v in ipairs(value) do
+          value[i] = v:lower()
         end
         tb_sort(value)
         value = tb_concat(value, ", ")
@@ -584,10 +584,10 @@ function _M:exec(ctx)
         headers_key = { "|", name, "=", value }
 
       else
-        headers_key[headers_count+1] = "|"
-        headers_key[headers_count+2] = name
-        headers_key[headers_count+3] = "="
-        headers_key[headers_count+4] = value
+        headers_key[headers_count + 1] = "|"
+        headers_key[headers_count + 2] = name
+        headers_key[headers_count + 3] = "="
+        headers_key[headers_count + 4] = value
       end
 
       headers_count = headers_count + 4

--- a/kong/router/atc_compat.lua
+++ b/kong/router/atc_compat.lua
@@ -612,7 +612,7 @@ function _M:exec(ctx)
                           sni, headers)
     if not match_t then
       self.cache_neg:set(cache_key, true)
-      return
+      return nil
     end
 
     self.cache:set(cache_key, match_t)

--- a/kong/router/atc_compat.lua
+++ b/kong/router/atc_compat.lua
@@ -290,7 +290,7 @@ local function route_priority(r)
 end
 
 
-function _M.new(routes)
+function _M.new(routes, cache, cache_neg)
   if type(routes) ~= "table" then
     return error("expected arg #1 routes to be a table")
   end
@@ -298,14 +298,22 @@ function _M.new(routes)
   local s = get_schema()
   local inst = router.new(s)
 
+  if not cache then
+    cache = lrucache.new(MATCH_LRUCACHE_SIZE)
+  end
+
+  if not cache_neg then
+    cache_neg = lrucache.new(MATCH_LRUCACHE_SIZE)
+  end
+
   local router = setmetatable({
     schema = s,
     router = inst,
     routes = {},
     services = {},
     fields = {},
-    cache = lrucache.new(MATCH_LRUCACHE_SIZE),
-    cache_neg = lrucache.new(MATCH_LRUCACHE_SIZE),
+    cache = cache,
+    cache_neg = cache_neg,
   }, _MT)
 
   for _, r in ipairs(routes) do

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -154,7 +154,7 @@ dns_no_sync = off
 worker_consistency = eventual
 worker_state_update_frequency = 5
 
-router_flavor = traditional
+router_flavor = traditional_compatible
 
 lua_socket_pool_size = 30
 lua_ssl_trusted_certificate = system

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -154,7 +154,7 @@ dns_no_sync = off
 worker_consistency = eventual
 worker_state_update_frequency = 5
 
-router_flavor = traditional_compatible
+router_flavor = traditional
 
 lua_socket_pool_size = 30
 lua_ssl_trusted_certificate = system


### PR DESCRIPTION
This code is copied from the traditional router, we just keep the same logic/behavior as old router. 

Maybe we will change it in the future.