### PR TITLE
fix(release): be more explicit about building and pushing the master branch builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,7 +46,7 @@ pipeline {
             when {
                 beforeAgent true
                 anyOf { 
-                    branch 'fix/master-builds';
+                    branch 'master';
                 }
             }
             environment {


### PR DESCRIPTION
The "nightly" release logic currently is
```
RELEASE_DOCKER_ONLY=true kong make release
kong-build-tools make package-kong
kong-build-tools make test
kong-build-tools make build-test-container
kong-build-tools make release #which exits early after pushing the docker container
```
This leads to release naming and destination logic is burried behind many layers of abstraction including two Makefile's and kong-build-tools release.sh.

Instead let's make our CI more verbose / explicit about what exactly it's doing. Explicitly call package, build the test container, test it and rename / push

related: https://github.com/Kong/kong-ee/pull/3432
test run: https://internal.builds.konghq.com/blue/organizations/jenkins/kong/detail/fix%2Fmaster-builds/9/pipeline