### PR TITLE
fix(tests) more requests to wait for router update

### DIFF
--- a/spec/02-integration/03-db/11-postgres-ro_spec.lua
+++ b/spec/02-integration/03-db/11-postgres-ro_spec.lua
@@ -97,6 +97,7 @@ for _, strategy in helpers.each_strategy() do
       }) -- runs migrations
 
       assert(helpers.start_kong({
+        worker_consistency = "strict",
         database = strategy,
         pg_ro_host = helpers.test_conf.pg_host,
         pg_ro_port = 9090, -- connection refused
@@ -139,15 +140,12 @@ for _, strategy in helpers.each_strategy() do
 
           return pcall(function()
             assert.res_status(404, res)
+            assert.logfile().has.line("get_updated_router(): could not rebuild router: " ..
+                                  "could not load routes: [postgres] connection " ..
+                                  "refused (stale router will be used)", true)
           end)
         end, 10)
 
-        helpers.wait_until(function ()
-          return pcall(function ()
-            assert.logfile().has.line("could not rebuild router.*: could not load routes.*" ..
-                                      "postgres.*connection refused", false)
-          end) -- pcall
-        end, 20) -- helpers.wait_until
       end)
     end)
   end)


### PR DESCRIPTION
This test is flaky because we may send the request before the router takes effect.
We need to wait not only for log emitting but also for the router update to take effect.