### PR TITLE
fix(cmd) confusing prompt

### DIFF
--- a/kong/cmd/migrations.lua
+++ b/kong/cmd/migrations.lua
@@ -64,7 +64,7 @@ local function confirm_prompt(q)
   }
 
   while MAX > 0 do
-    io.write("> " .. q .. " [Y/n] ")
+    io.write("> " .. q .. " [y/n] ")
     local a = io.read("*l")
     if ANSWERS[a] ~= nil then
       return ANSWERS[a]


### PR DESCRIPTION
It says `[Y/n]`, but doesn't take Y as the default choice.
