### PR TITLE
fix(templates) use `atc_compatiable` as default for `router_flavor`

### DIFF
--- a/kong/router/atc_compat.lua
+++ b/kong/router/atc_compat.lua
@@ -37,6 +37,8 @@ local get_headers   = ngx.req.get_headers
 local ngx_WARN      = ngx.WARN
 
 
+local protocol_subsystem = constants.PROTOCOLS_WITH_SUBSYSTEM
+
 
 local SLASH            = byte("/")
 local TILDE            = byte("~")
@@ -100,9 +102,6 @@ function _M._set_ngx(mock_ngx)
     end
   end
 end
-
-
-local protocol_subsystem = constants.PROTOCOLS_WITH_SUBSYSTEM
 
 
 local function gen_for_field(name, op, vals, vals_transform)

--- a/kong/router/atc_compat.lua
+++ b/kong/router/atc_compat.lua
@@ -359,8 +359,9 @@ function _M.new(routes, cache, cache_neg)
       assert(inst:add_matcher(route.priority, route_id, atc))
     end
 
-    router.fields = inst:get_fields()
   end
+
+  router.fields = inst:get_fields()
 
   return router
 end

--- a/kong/router/atc_compat.lua
+++ b/kong/router/atc_compat.lua
@@ -11,8 +11,8 @@ local ffi = require("ffi")
 local server_name = require("ngx.ssl").server_name
 local normalize = require("kong.tools.uri").normalize
 local hostname_type = require("kong.tools.utils").hostname_type
-local tb_nkeys = require("table.nkeys")
 local tb_new = require("table.new")
+local tb_nkeys = require("table.nkeys")
 
 
 local ngx = ngx

--- a/kong/router/atc_compat.lua
+++ b/kong/router/atc_compat.lua
@@ -319,13 +319,17 @@ function _M.new(routes, cache, cache_neg)
     cache_neg = cache_neg,
   }, _MT)
 
+  local is_traditional_compatible =
+          kong and kong.configuration and
+          kong.configuration.router_flavor == "traditional_compatible"
+
   for _, r in ipairs(routes) do
     local route = r.route
     local route_id = route.id
     router.routes[route_id] = route
     router.services[route_id] = r.service
 
-    if kong.configuration.router_flavor == "traditional_compatible" then
+    if is_traditional_compatible then
       assert(inst:add_matcher(route_priority(route), route_id, get_atc(route)))
 
     else

--- a/kong/router/atc_compat.lua
+++ b/kong/router/atc_compat.lua
@@ -33,13 +33,13 @@ local var           = ngx.var
 local ngx_log       = ngx.log
 local get_method    = ngx.req.get_method
 local get_headers   = ngx.req.get_headers
-local ngx_WARN = ngx.WARN
+local ngx_WARN      = ngx.WARN
 
 
 
-local SLASH         = byte("/")
+local SLASH            = byte("/")
 local MAX_HEADER_COUNT = 255
-local MAX_REQ_HEADERS = 100
+local MAX_REQ_HEADERS  = 100
 
 
 --[[

--- a/kong/router/atc_compat.lua
+++ b/kong/router/atc_compat.lua
@@ -60,6 +60,13 @@ local function is_regex_magic(path)
 end
 
 
+local function regex_partation(paths)
+  tb_sort(paths, function(a, b)
+      return is_regex_magic(a) and not is_regex_magic(b)
+    end)
+end
+
+
 function _M._set_ngx(mock_ngx)
   if type(mock_ngx) ~= "table" then
     return
@@ -166,6 +173,9 @@ local function get_atc(route)
   if gen then
     tb_insert(out, gen)
   end
+
+  -- move regex paths to the front
+  regex_partation(route.paths)
 
   local gen = gen_for_field("http.path", function(path)
     return is_regex_magic(path) and OP_REGEX or OP_PREFIX

--- a/kong/router/atc_compat.lua
+++ b/kong/router/atc_compat.lua
@@ -122,10 +122,10 @@ local OP_REGEX = "~"
 local function get_atc(route)
   local out = {}
 
-  local gen = gen_for_field("net.protocol", OP_EQUAL, route.protocols)
-  if gen then
-    tb_insert(out, gen)
-  end
+  --local gen = gen_for_field("net.protocol", OP_EQUAL, route.protocols)
+  --if gen then
+  --  tb_insert(out, gen)
+  --end
 
   local gen = gen_for_field("http.method", OP_EQUAL, route.methods)
   if gen then

--- a/kong/router/atc_compat.lua
+++ b/kong/router/atc_compat.lua
@@ -38,6 +38,7 @@ local ngx_WARN      = ngx.WARN
 
 
 local SLASH            = byte("/")
+local TILDE            = byte("~")
 local MAX_HEADER_COUNT = 255
 local MAX_REQ_HEADERS  = 100
 
@@ -56,7 +57,7 @@ local MATCH_LRUCACHE_SIZE = 5e3
 
 
 local function is_regex_magic(path)
-  return sub(path, 1, 1) == "~"
+  return byte(path) == TILDE
 end
 
 

--- a/kong/router/atc_compat.lua
+++ b/kong/router/atc_compat.lua
@@ -62,6 +62,10 @@ end
 
 
 local function regex_partation(paths)
+  if not paths then
+    return
+  end
+
   tb_sort(paths, function(a, b)
       return is_regex_magic(a) and not is_regex_magic(b)
     end)

--- a/kong/router/atc_compat.lua
+++ b/kong/router/atc_compat.lua
@@ -134,6 +134,9 @@ local function get_atc(route)
 
   local gen = gen_for_field("tls.sni", OP_EQUAL, route.snis)
   if gen then
+    -- See #6425, if `net.protocol` is not `https`
+    -- then SNI matching should simply not be considered
+    gen = "net.protocol != \"https\" || " .. gen
     tb_insert(out, gen)
   end
 

--- a/kong/router/atc_compat.lua
+++ b/kong/router/atc_compat.lua
@@ -171,7 +171,8 @@ local function get_atc(route)
     return is_regex_magic(path) and OP_REGEX or OP_PREFIX
   end, route.paths, function(op, p)
     if op == OP_REGEX then
-      return sub(p, 2):gsub("\\", "\\\\")
+      -- Rust only recognize form '?P<>'
+      return sub(p, 2):gsub("?<", "?P<"):gsub("\\", "\\\\")
     end
 
     return normalize(p, true)

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -154,7 +154,7 @@ dns_no_sync = off
 worker_consistency = eventual
 worker_state_update_frequency = 5
 
-router_flavor = traditional
+router_flavor = traditional_compatible
 
 lua_socket_pool_size = 30
 lua_ssl_trusted_certificate = system

--- a/spec/fixtures/balancer_utils.lua
+++ b/spec/fixtures/balancer_utils.lua
@@ -326,8 +326,8 @@ do
     local rproto = opts.route_protocol or "http"
 
     local rpaths = {
-      "/",
       "~/(?<namespace>[^/]+)/(?<id>[0-9]+)/?", -- uri capture hash value
+      "/",
     }
 
     bp.services:insert({

--- a/spec/fixtures/balancer_utils.lua
+++ b/spec/fixtures/balancer_utils.lua
@@ -327,8 +327,7 @@ do
 
     local rpaths = {
       "/",
-      "~/([^/]+)/([0-9]+)/?", -- uri capture hash value
-      --"~/(?<namespace>[^/]+)/(?<id>[0-9]+)/?", -- uri capture hash value
+      "~/(?P<namespace>[^/]+)/(?P<id>[0-9]+)/?", -- uri capture hash value
     }
 
     bp.services:insert({

--- a/spec/fixtures/balancer_utils.lua
+++ b/spec/fixtures/balancer_utils.lua
@@ -326,8 +326,8 @@ do
     local rproto = opts.route_protocol or "http"
 
     local rpaths = {
-      "~/(?<namespace>[^/]+)/(?<id>[0-9]+)/?", -- uri capture hash value
       "/",
+      "~/(?<namespace>[^/]+)/(?<id>[0-9]+)/?", -- uri capture hash value
     }
 
     bp.services:insert({

--- a/spec/fixtures/balancer_utils.lua
+++ b/spec/fixtures/balancer_utils.lua
@@ -327,7 +327,7 @@ do
 
     local rpaths = {
       "/",
-      "~/(?P<namespace>[^/]+)/(?P<id>[0-9]+)/?", -- uri capture hash value
+      "~/(?<namespace>[^/]+)/(?<id>[0-9]+)/?", -- uri capture hash value
     }
 
     bp.services:insert({

--- a/spec/fixtures/balancer_utils.lua
+++ b/spec/fixtures/balancer_utils.lua
@@ -327,7 +327,8 @@ do
 
     local rpaths = {
       "/",
-      "~/(?<namespace>[^/]+)/(?<id>[0-9]+)/?", -- uri capture hash value
+      "~/([^/]+)/([0-9]+)/?", -- uri capture hash value
+      --"~/(?<namespace>[^/]+)/(?<id>[0-9]+)/?", -- uri capture hash value
     }
 
     bp.services:insert({


### PR DESCRIPTION
* enable `traditional_compatible` in kong_defaults.lua
* replace regex `?<` to `?P<` to work with Rust regex
* sort `route.paths`, move regex uri to the front
* use `table.new` to pre-allocate table object