### PR TITLE
fix(wrpc) error handling when sending message

### DIFF
--- a/kong/tools/wrpc/threads.lua
+++ b/kong/tools/wrpc/threads.lua
@@ -69,7 +69,7 @@ local function step(wrpc_peer)
     msg, err = wrpc_peer:receive()
   end
 
-  if err ~= nil and not endswith(err, "timeout") then
+  if err ~= nil and not endswith(err, ": timeout") then
     ngx_log(NOTICE, "[wRPC] WebSocket frame: ", err)
     wrpc_peer.closing = true
     return false, err


### PR DESCRIPTION
### Summary

We miss handling of message sending error (over WebSocket), and the future times out when an error happens.

This problem is found when I tried to send a payload larger than `payload_limit`.