### PR TITLE
fix(aws-lambda) fix 500 error in serviceless route

### DIFF
--- a/kong/plugins/aws-lambda/aws-serializer.lua
+++ b/kong/plugins/aws-lambda/aws-serializer.lua
@@ -78,7 +78,8 @@ return function(ctx, config)
   end
 
   -- prepare path
-  local path = var.upstream_uri:match("^([^%?]+)")  -- strip any query args
+  local uri = var.upstream_uri and var.upstream_uri or var.request_uri
+  local path = uri:match("^([^%?]+)")  -- strip any query args
 
   local request = {
     resource                        = ctx.router_matches.uri,

--- a/kong/plugins/aws-lambda/aws-serializer.lua
+++ b/kong/plugins/aws-lambda/aws-serializer.lua
@@ -78,7 +78,7 @@ return function(ctx, config)
   end
 
   -- prepare path
-  local uri = var.upstream_uri and var.upstream_uri or var.request_uri
+  local uri = var.upstream_uri or var.request_uri
   local path = uri:match("^([^%?]+)")  -- strip any query args
 
   local request = {


### PR DESCRIPTION
### Summary

fix plugin `aws-lambda` 500 error in serviceless route and config enable awsgateway_compatible

### Full changelog

* fix plugin `aws-lambda` 500 in serviceless route and config enable awsgateway_compatible
* add serviceless `db.route` spec to cover this case


