### PR TITLE
fix(*) router now has different path scheme

### DIFF
--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -86,7 +86,7 @@ else
                          }, },
       { methods        = typedefs.methods },
       { hosts          = typedefs.hosts },
-      { paths          = typedefs.paths },
+      { paths          = typedefs.router_paths },
       { headers = typedefs.headers {
         keys = typedefs.header_name {
           match_none = {

--- a/kong/db/schema/typedefs.lua
+++ b/kong/db/schema/typedefs.lua
@@ -304,19 +304,6 @@ typedefs.path = Schema.define {
   custom_validator = validate_path,
 }
 
-typedefs.router_path = Schema.define {
-  type = "string",
-  match_any = {
-    patterns = {"^/", "^~/"},
-    err = "should start with: / (fixed path) or ~/ (regex path)",
-  },
-  match_none = {
-    { pattern = "//",
-      err = "must not have empty segments"
-    },
-  },
-  custom_validator = validate_path,
-}
 
 typedefs.url = Schema.define {
   type = "string",
@@ -538,20 +525,26 @@ typedefs.hosts = Schema.define {
 
 typedefs.no_hosts = Schema.define(typedefs.hosts { eq = null })
 
-typedefs.paths = Schema.define {
-  type = "array",
-  elements = typedefs.router_path {
-    custom_validator = validate_path_with_regexes,
-    match_none = {
-      {
-        pattern = "//",
-        err = "must not have empty segments"
-      },
+typedefs.router_path = Schema.define {
+  type = "string",
+  match_any = {
+    patterns = {"^/", "^~/"},
+    err = "should start with: / (fixed path) or ~/ (regex path)",
+  },
+  match_none = {
+    { pattern = "//",
+      err = "must not have empty segments"
     },
-  }
+  },
+  custom_validator = validate_path_with_regexes,
 }
 
-typedefs.no_paths = Schema.define(typedefs.paths { eq = null })
+typedefs.router_paths = Schema.define {
+  type = "array",
+  elements = typedefs.router_path
+}
+
+typedefs.no_paths = Schema.define(typedefs.router_paths { eq = null })
 
 typedefs.headers = Schema.define {
   type = "map",

--- a/kong/db/schema/typedefs.lua
+++ b/kong/db/schema/typedefs.lua
@@ -295,6 +295,17 @@ typedefs.port = Schema.define {
 
 typedefs.path = Schema.define {
   type = "string",
+  starts_with = "/",
+  match_none = {
+    { pattern = "//",
+      err = "must not have empty segments"
+    },
+  },
+  custom_validator = validate_path,
+}
+
+typedefs.router_path = Schema.define {
+  type = "string",
   match_any = {
     patterns = {"^/", "^~/"},
     err = "should start with: / (fixed path) or ~/ (regex path)",
@@ -529,7 +540,7 @@ typedefs.no_hosts = Schema.define(typedefs.hosts { eq = null })
 
 typedefs.paths = Schema.define {
   type = "array",
-  elements = typedefs.path {
+  elements = typedefs.router_path {
     custom_validator = validate_path_with_regexes,
     match_none = {
       {

--- a/spec/01-unit/01-db/01-schema/05-services_spec.lua
+++ b/spec/01-unit/01-db/01-schema/05-services_spec.lua
@@ -168,7 +168,7 @@ describe("services", function()
 
       local ok, err = Services:validate(service)
       assert.falsy(ok)
-      assert.equal("should start with: / (fixed path) or ~/ (regex path)", err.path)
+      assert.equal("should start with: /", err.path)
     end)
 
     it("must not have empty segments (/foo//bar)", function()

--- a/spec/01-unit/01-db/01-schema/09-upstreams_spec.lua
+++ b/spec/01-unit/01-db/01-schema/09-upstreams_spec.lua
@@ -376,7 +376,7 @@ describe("load upstreams", function()
         {{ active = { concurrency = 0 }}, pos_integer },
         {{ active = { concurrency = -10 }}, pos_integer },
         {{ active = { http_path = "" }}, len_min_default },
-        {{ active = { http_path = "ovo" }}, "should start with: / (fixed path) or ~/ (regex path)" },
+        {{ active = { http_path = "ovo" }}, "should start with: /" },
         {{ active = { https_sni = "127.0.0.1", }}, invalid_ip },
         {{ active = { https_sni = "127.0.0.1:8080", }}, invalid_ip },
         {{ active = { https_sni = "/example", }}, invalid_host },

--- a/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/07-upstreams_routes_spec.lua
@@ -421,7 +421,7 @@ describe("Admin API: #" .. strategy, function()
             })
             body = assert.res_status(400, res)
             local json = cjson.decode(body)
-            assert.same({ hash_on_cookie_path = "should start with: / (fixed path) or ~/ (regex path)" }, json.fields)
+            assert.same({ hash_on_cookie_path = "should start with: /" }, json.fields)
 
             -- Invalid cookie in hash fallback
             res = assert(client:send {
@@ -455,7 +455,7 @@ describe("Admin API: #" .. strategy, function()
             })
             body = assert.res_status(400, res)
             local json = cjson.decode(body)
-            assert.same({ hash_on_cookie_path = "should start with: / (fixed path) or ~/ (regex path)" }, json.fields)
+            assert.same({ hash_on_cookie_path = "should start with: /" }, json.fields)
 
           end
         end)

--- a/spec/02-integration/04-admin_api/10-services_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/10-services_routes_spec.lua
@@ -843,11 +843,11 @@ for _, strategy in helpers.each_strategy() do
                 message  = unindent([[
                   2 schema violations
                   (host: required field missing;
-                  path: should start with: / (fixed path) or ~/ (regex path))
+                  path: should start with: /)
                 ]], true, true),
                 fields = {
                   host = "required field missing",
-                  path = "should start with: / (fixed path) or ~/ (regex path)",
+                  path = "should start with: /",
                 },
               }, json
             )


### PR DESCRIPTION
This scheme change was not done right and causes a lot of tests to fail.

And, `typedef.path` is also used in places like service.
