### PR TITLE
fix(clustering) wRPC bugs fix

### DIFF
--- a/kong/clustering/wrpc_data_plane.lua
+++ b/kong/clustering/wrpc_data_plane.lua
@@ -116,7 +116,7 @@ local function communicate_impl(dp)
   if peer and not peer.closing then
     peer:close()
   end
-  peer = wrpc.new_peer(c, get_services(), { channel = dp.DPCP_CHANNEL_NAME })
+  peer = wrpc.new_peer(c, get_services())
 
   peer.config_semaphore = config_semaphore
   peer.config_obj = dp

--- a/kong/include/wrpc/wrpc.proto
+++ b/kong/include/wrpc/wrpc.proto
@@ -36,6 +36,8 @@ enum ErrorType {
   ERROR_TYPE_UNSPECIFIED = 0;
   // GENERIC signals a general error with the protocol.
   ERROR_TYPE_GENERIC = 1;
+  ERROR_TYPE_INVALID_SERVICE = 2;
+  ERROR_TYPE_INVALID_RPC = 3;
 }
 
 // Error represents a protocol error.

--- a/kong/tools/wrpc/future.lua
+++ b/kong/tools/wrpc/future.lua
@@ -62,7 +62,7 @@ end
 -- Call to tell what to do with the result of the future.
 -- Named `then_do` because `then` is reserved.
 --- @param handler function what to do with result. Parameter:
---- @param error_handler function what to do when error happens
+--- @param error_handler function|nil what to do when error happens
 --- @return boolean ok, string err
 function _M:then_do(handler, error_handler)
   return new_timer(0, then_do_handle_result, self, handler, error_handler)

--- a/kong/tools/wrpc/init.lua
+++ b/kong/tools/wrpc/init.lua
@@ -28,7 +28,7 @@ end
 --- a `peer` object holds a (websocket) connection and a service.
 --- @param conn table WebSocket connection to use.
 --- @param service table Proto object that holds Serivces the connection supports.
-function _M.new_peer(conn, service)
+function _M.new_peer(conn, service, timeout)
   return setmetatable({
     conn = conn,
     service = service,
@@ -37,6 +37,7 @@ function _M.new_peer(conn, service)
     responses = {},
     closing = false,
     _receiving_thread = nil,
+    timeout = timeout or DEFAULT_EXPIRATION_DELAY,
   }, _MT)
 end
 
@@ -95,7 +96,7 @@ end
 --- @param payloads(string) payloads to send
 --- @return kong.tools.wrpc.future|nil future, string|nil err
 function _M:send_encoded_call(rpc, payloads)
-  local response_future = future_new(self, DEFAULT_EXPIRATION_DELAY)
+  local response_future = future_new(self, self.timeout)
   local ok, err = self:send_payload({
     mtype = "MESSAGE_TYPE_RPC",
     svc_id = rpc.svc_id,
@@ -160,7 +161,7 @@ function _M:send_payload(payload)
   -- protobuf may confuse with 0 value and nil(undefined) under some set up
   -- so we will just handle 0 as nil
   if not payload.ack or payload.ack == 0 then
-    payload.deadline = ngx_now() + DEFAULT_EXPIRATION_DELAY
+    payload.deadline = ngx_now() + self.timeout
   end
 
   return self:send(pb_encode("wrpc.WebsocketPayload", {

--- a/kong/tools/wrpc/message.lua
+++ b/kong/tools/wrpc/message.lua
@@ -30,6 +30,8 @@ local function send_error(wrpc_peer, payload, error)
   return nil, error.description or "unspecified error"
 end
 
+_M.send_error = send_error
+
 local empty_table = {}
 
 local function handle_request(wrpc_peer, rpc, payload)
@@ -136,7 +138,11 @@ function _M.handle_error(wrpc_peer, payload)
   end
 
   if ack == 0 then
-    error("unreachable: Handling error response message with type of request")
+    local err = "malformed wRPC message"
+    ngx_log(ERR,
+      err, " Service ID: ", payload.svc_id, " RPC ID: ", payload.rpc_id)
+
+    return nil, err
   end
 
   -- response to a previous call
@@ -144,7 +150,7 @@ function _M.handle_error(wrpc_peer, payload)
 
   if not response_future then
     local err = "receiving error message for a call" ..
-      "expired or not initiated by this peer."
+      " expired or not initiated by this peer."
     ngx_log(ERR, 
       err, " Service ID: ", payload.svc_id, " RPC ID: ", payload.rpc_id)
 

--- a/kong/tools/wrpc/proto.lua
+++ b/kong/tools/wrpc/proto.lua
@@ -63,7 +63,7 @@ local function parse_annotations(proto_obj, proto_file)
 
     annotations[name] = parse_annotation(annotation)
     local id = assert(annotations[name][id_tag_name],
-      keyword .. "with no id assigned")
+      keyword .. " with no id assigned")
     ids[name] = assert(tonumber(id), keyword .. "'s id should be a number")
 
     ::continue::
@@ -136,7 +136,7 @@ end
 -- Sets a service handler for the given rpc method.
 --- @param rpc_name string Full name of the rpc method
 --- @param handler function Function called to handle the rpc method.
---- @param response_handler function Fallback function for responses.
+--- @param response_handler function|nil Fallback function for responses.
 function _M:set_handler(rpc_name, handler, response_handler)
   local rpc = self:get_rpc(rpc_name)
   if not rpc then
@@ -161,5 +161,8 @@ function _M:encode_args(name, arg)
 
   return rpc, assert(pb_encode(rpc.input_type, arg))
 end
+
+-- this is just for unit tests
+_M.__parse_annotations = parse_annotations
 
 return _M

--- a/kong/tools/wrpc/threads.lua
+++ b/kong/tools/wrpc/threads.lua
@@ -15,6 +15,7 @@ local thread_wait = ngx.thread.wait
 
 local process_message = message.process_message
 local handle_error = message.handle_error
+local send_error = message.send_error
 
 -- utility functions
 
@@ -64,6 +65,12 @@ local function step(wrpc_peer)
       else
         process_message(wrpc_peer, payload)
       end
+
+    else
+      send_error(wrpc_peer, payload, {
+        etype = "ERROR_TYPE_GENERIC",
+        description = "Unsupported message type",
+      })
     end
 
     msg, err = wrpc_peer:receive()

--- a/spec/01-unit/19-hybrid/05-wrpc/future_spec.lua
+++ b/spec/01-unit/19-hybrid/05-wrpc/future_spec.lua
@@ -1,0 +1,131 @@
+local semaphore = require "ngx.semaphore"
+local match = require "luassert.match"
+local helpers = require "spec.helpers"
+local semaphore_new = semaphore.new
+
+
+describe("kong.tools.wrpc.future", function()
+  local wrpc_future
+  local log_spy = spy.new()
+  local ngx_log = ngx.log
+  lazy_setup(function()
+    ngx.log = log_spy -- luacheck: ignore
+    package.loaded["kong.tools.wrpc.future"] = nil
+    wrpc_future = require "kong.tools.wrpc.future"
+  end)
+  lazy_teardown(function()
+    ngx.log = ngx_log -- luacheck: ignore
+  end)
+
+  local fake_peer
+  before_each(function()
+    fake_peer = {
+      responses = {},
+      seq = 1,
+    }
+  end)
+
+  it("then_do", function()
+    local smph1 = semaphore_new()
+    local smph2 = semaphore_new()
+
+    local future1 = wrpc_future.new(fake_peer, 1)
+    fake_peer.seq = fake_peer.seq + 1
+    local future2 = wrpc_future.new(fake_peer, 1)
+    assert.same(2, #fake_peer.responses)
+
+    future1:then_do(function(data)
+      assert.same("test1", data)
+      smph1:post()
+    end)
+    future2:then_do(function(data)
+      assert.same("test2", data)
+      smph2:post()
+    end)
+
+    future2:done("test2")
+    future1:done("test1")
+
+
+    assert(smph1:wait(1))
+    assert(smph2:wait(1))
+
+
+    future2:then_do(function(_)
+      assert.fail("future2 should not recieve data")
+    end, function()
+      smph2:post()
+    end)
+
+    assert(smph2:wait(5))
+    assert.is_same({}, fake_peer.responses)
+  end)
+
+  it("wait", function()
+    local smph = semaphore_new()
+
+    local future1 = wrpc_future.new(fake_peer, 1)
+    fake_peer.seq = fake_peer.seq + 1
+    local future2 = wrpc_future.new(fake_peer, 1)
+    fake_peer.seq = fake_peer.seq + 1
+    local future3 = wrpc_future.new(fake_peer, 1)
+    assert.same(3, #fake_peer.responses)
+
+    ngx.thread.spawn(function()
+      assert.same({ 1 }, future1:wait())
+      assert.same({ 2 }, future2:wait())
+      assert.same({ 3 }, future3:wait())
+      assert.same({ nil, "timeout" }, { future3:wait() })
+      smph:post()
+    end)
+
+    future2:done({ 2 })
+    future1:done({ 1 })
+    future3:done({ 3 })
+
+
+    assert(smph:wait(5))
+    assert.is_same({}, fake_peer.responses)
+  end)
+
+  it("drop", function()
+    local smph = semaphore_new()
+
+    local future1 = wrpc_future.new(fake_peer, 1)
+    fake_peer.seq = fake_peer.seq + 1
+    local future2 = wrpc_future.new(fake_peer, 1)
+    fake_peer.seq = fake_peer.seq + 1
+    local future3 = wrpc_future.new(fake_peer, 1)
+    assert.same(3, #fake_peer.responses)
+
+    ngx.thread.spawn(function()
+      assert(future1:drop())
+      assert(future2:drop())
+      assert(future3:drop())
+      smph:post()
+    end)
+
+    future2:done({ 2 })
+    future1:done({ 1 })
+    future3:done({ 3 })
+
+    assert(smph:wait(1))
+    assert.spy(log_spy).was_not_called_with(ngx.ERR, match._, match._)
+    assert.is_same({}, fake_peer.responses)
+
+    ngx.thread.spawn(function()
+      assert(future1:drop())
+      assert(future2:drop())
+      assert(future3:drop())
+      smph:post()
+    end)
+
+    future2:done({ 2 })
+    future1:done({ 1 })
+
+    smph:wait(1)
+    helpers.wait_until(function()
+      return pcall(assert.spy(log_spy).was_called_with, ngx.ERR, match._, match._)
+    end, 5)
+  end)
+end)

--- a/spec/01-unit/19-hybrid/05-wrpc/proto_spec.lua
+++ b/spec/01-unit/19-hybrid/05-wrpc/proto_spec.lua
@@ -1,0 +1,156 @@
+local wrpc_proto = require "kong.tools.wrpc.proto"
+local pl_dir = require "pl.dir"
+local pl_path = require "pl.path"
+
+local parse_annotations = wrpc_proto.__parse_annotations
+
+local function mock_file(str)
+  return {
+    str = str,
+    lines = function(self)
+      self.iter = self.str:gmatch("[^\r\n]+")
+      return self.iter
+    end,
+    -- only used to read a line
+    read = function(self, _)
+      return self.iter()
+    end
+  }
+end
+
+
+local test_path = "/tmp/lua_test_proto"
+describe("kong.tools.wrpc.proto", function()
+  local wrpc_service
+
+  before_each(function()
+    wrpc_service = wrpc_proto.new()
+    wrpc_service:addpath(test_path)
+  end)
+
+  describe("parse annotation", function()
+    it("works", function()
+      local module
+      module = mock_file [[
+        // +wrpc:service-id=1
+        service TestService {
+          //+wrpc:rpc-id=4; comment=test
+          rpc A(EmptyMsg) returns (EmptyMsg);
+        }
+      ]]
+      parse_annotations(wrpc_service, module)
+      assert.same({
+        TestService = {
+          ["service-id"] = '1'
+        },
+        ["TestService.A"] = {
+          comment = 'test',
+          ["rpc-id"] = '4'
+        },
+      }, wrpc_service.annotations)
+    end)
+
+    it("errors", function()
+      local module
+      module = mock_file [[
+        // +wrpc:rpc-id=1
+        service TestService {
+          
+        }
+      ]]
+      assert.error(function()
+        parse_annotations(wrpc_service, module)
+      end, "service with no id assigned")
+
+      module = mock_file [[
+        // +wrpc:service-id=1
+        service TestService {
+          //+wrpc:service-id=4
+          rpc A(EmptyMsg) returns (EmptyMsg);
+        }
+      ]]
+      assert.error(function()
+        parse_annotations(wrpc_service, module)
+      end, "rpc with no id assigned")
+
+      module = mock_file [[
+        // +wrpc:service-id=1
+        service TestService {
+          //+wrpc:rpc-id=4
+        }
+      ]]
+      -- ignoring, as plain comment
+      assert.has.no.error(function()
+        parse_annotations(wrpc_service, module)
+      end)
+
+    end)
+  end)
+
+  describe("import test", function ()
+
+    local function tmp_file(str, module_name)
+      module_name = module_name or "default"
+      local filename = test_path .. "/" .. module_name .. ".proto"
+      local file = assert(io.open(filename, "w"))
+      assert(file:write(str))
+      file:close()
+      return module_name, file, filename
+    end
+
+    lazy_setup(function ()
+      pl_path.mkdir(test_path)
+    end)
+    lazy_teardown(function ()
+      pl_dir.rmtree(test_path)
+    end)
+
+    it("works", function()
+      local module
+      module = tmp_file [[
+        message EmptyMsg {}
+        // +wrpc:service-id=1
+        service TestService {
+          //+wrpc:rpc-id=4; comment=test
+          rpc A(EmptyMsg) returns (EmptyMsg);
+        }
+      ]]
+      wrpc_service:import(module)
+      assert.same({
+        TestService = {
+          ["service-id"] = '1'
+        },
+        ["TestService.A"] = {
+          comment = 'test',
+          ["rpc-id"] = '4'
+        },
+      }, wrpc_service.annotations)
+    end)
+
+    it("errors", function()
+      local module
+      module = tmp_file [[
+        // +wrpc:service-id=1
+        service TestService {
+          //+wrpc:rpc-id=4; comment=test
+          rpc A(EmptyMsg) returns (EmptyMsg);
+        }
+      ]]
+      assert.error_matches(function()
+        wrpc_service:import(module)
+      end, "unknown type 'EmptyMsg'")
+      
+      module = tmp_file ([[
+        // +wrpc:service-id=1
+        service TestService {
+          //+wrpc:rpc-id=4; comment=test
+          rpc A() returns ();
+        }
+      ]], "test2")
+      assert.error_matches(function()
+        wrpc_service:import(module)
+      end, "type name expected")
+    end)
+  end)
+
+end)

--- a/spec/01-unit/19-hybrid/05-wrpc/queue_spec.lua
+++ b/spec/01-unit/19-hybrid/05-wrpc/queue_spec.lua
@@ -1,0 +1,58 @@
+local wrpc_queue = require "kong.tools.wrpc.queue"
+local semaphore = require "ngx.semaphore"
+
+describe("kong.tools.wrpc.queue", function()
+  local queue
+
+  before_each(function()
+    queue = wrpc_queue.new()
+  end)
+
+  it("simple", function()
+    assert.same({ nil, "timeout" }, { queue:pop(0) })
+    queue:push("test0")
+    queue:push("test1")
+    queue:push("test2")
+    assert.same("test0", queue:pop())
+    assert.same("test1", queue:pop())
+    assert.same("test2", queue:pop(0.5))
+    assert.same({ nil, "timeout" }, { queue:pop(0) })
+  end)
+
+  it("simple2", function()
+    queue:push("test0")
+    queue:push("test1")
+    assert.same("test0", queue:pop())
+    queue:push("test2")
+    assert.same("test1", queue:pop())
+    assert.same("test2", queue:pop())
+    assert.same({ nil, "timeout" }, { queue:pop(0) })
+  end)
+
+  it("thread", function()
+    local smph = semaphore.new()
+    ngx.thread.spawn(function()
+      -- wait for no time so it will timed out
+      assert.same({ nil, "timeout" }, { queue:pop(0) })
+      assert.same({}, queue:pop())
+      assert.same({1}, queue:pop())
+      assert.same({2}, queue:pop())
+      assert.same({ nil, "timeout" }, { queue:pop(0) })
+      smph:post()
+    end)
+    -- yield
+    ngx.sleep(0)
+    queue:push({})
+    queue:push({1})
+    queue:push({2})
+    -- yield to allow thread to finish
+    ngx.sleep(0)
+
+    -- should be empty again
+    assert.same({ nil, "timeout" }, { queue:pop(0) })
+    queue:push({2, {}})
+    assert.same({2, {}}, queue:pop())
+
+    assert(smph:wait(0), "thread is not resumed")
+  end)
+end)

--- a/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
@@ -17,7 +17,7 @@ local confs = helpers.get_clustering_protocols()
 
 for _, strategy in helpers.each_strategy() do
   for cluster_protocol, conf in pairs(confs) do
-    describe("CP/DP sync works with #" .. strategy .. " backend, protocol " .. cluster_protocol, function()
+    describe("CP/DP sync works with #" .. strategy .. " backend, protocol #" .. cluster_protocol, function()
 
       lazy_setup(function()
         helpers.get_db_utils(strategy, {
@@ -353,7 +353,8 @@ for _, strategy in helpers.each_strategy() do
     end)
   end
 
-  describe("CP/DP version check works with #" .. strategy, function()
+  for _, cluster_protocol in ipairs{"wrpc", "json"} do
+  describe("CP/DP #version check works with #" .. strategy .. " backend, protocol #" .. cluster_protocol, function()
     -- for these tests, we do not need a real DP, but rather use the fake DP
     -- client so we can mock various values (e.g. node_version)
     describe("relaxed compatibility check:", function()
@@ -373,6 +374,7 @@ for _, strategy in helpers.each_strategy() do
       lazy_setup(function()
 
         assert(helpers.start_kong({
+          legacy_hybrid_protocol = (cluster_protocol == "json"),
           role = "control_plane",
           cluster_cert = "spec/fixtures/kong_clustering.crt",
           cluster_cert_key = "spec/fixtures/kong_clustering.key",
@@ -456,9 +458,9 @@ for _, strategy in helpers.each_strategy() do
         -- we hardcode `dummy` plugin to be 9.9.9 so there must be at least one
         if minor and tonumber(minor) and tonumber(minor) > 2 then
           pl2[i].version = string.format("%d.%d.%d",
-                                         tonumber(v:match("(%d+)")),
-                                         tonumber(minor - 2),
-                                         tonumber(v:match("%d+%.%d+%.(%d+)"))
+                                        tonumber(v:match("(%d+)")),
+                                        tonumber(minor - 2),
+                                        tonumber(v:match("%d+%.%d+%.(%d+)"))
 
           )
           break
@@ -476,9 +478,9 @@ for _, strategy in helpers.each_strategy() do
         -- we hardcode `dummy` plugin to be 9.9.9 so there must be at least one
         if patch and tonumber(patch) and tonumber(patch) > 2 then
           pl3[i].version = string.format("%d.%d.%d",
-                                         tonumber(v:match("(%d+)")),
-                                         tonumber(v:match("%d+%.(%d+)")),
-                                         tonumber(patch - 2)
+                                        tonumber(v:match("(%d+)")),
+                                        tonumber(v:match("%d+%.(%d+)")),
+                                        tonumber(patch - 2)
           )
           break
         end
@@ -492,6 +494,7 @@ for _, strategy in helpers.each_strategy() do
           local uuid = utils.uuid()
 
           local res = assert(helpers.clustering_client({
+            cluster_protocol = cluster_protocol,
             host = "127.0.0.1",
             port = 9005,
             cert = "spec/fixtures/kong_clustering.crt",
@@ -501,8 +504,14 @@ for _, strategy in helpers.each_strategy() do
             node_plugins_list = harness.plugins_list,
           }))
 
-          assert.equals("reconfigure", res.type)
-          assert.is_table(res.config_table)
+          if cluster_protocol == "wrpc" then
+            assert.is_table(res)
+            assert(res.version)
+            assert(res.config)
+          else
+            assert.equals("reconfigure", res.type)
+            assert.is_table(res.config_table)
+          end
 
           -- needs wait_until for C* convergence
           helpers.wait_until(function()
@@ -522,7 +531,7 @@ for _, strategy in helpers.each_strategy() do
                 end
               end
             end
-          end, 5)
+          end, 500)
         end)
       end
       -- ENDS allowed cases
@@ -543,7 +552,7 @@ for _, strategy in helpers.each_strategy() do
             {  name="key-auth", version="1.0.0" }
           }
         },
-        ["CP has configured plugin with newer minor version than in DP enabled plugins"] = {
+        ["CP has configured plugin with newer minor version than in DP enabled plugins newer"] = {
           dp_version = string.format("%d.%d.%d", MAJOR, MINOR, PATCH),
           expected = CLUSTERING_SYNC_STATUS.PLUGIN_VERSION_INCOMPATIBLE,
           plugins_list = {
@@ -577,6 +586,7 @@ for _, strategy in helpers.each_strategy() do
           local uuid = utils.uuid()
 
           local res, err = helpers.clustering_client({
+            cluster_protocol = cluster_protocol,
             host = "127.0.0.1",
             port = 9005,
             cert = "spec/fixtures/kong_clustering.crt",
@@ -592,7 +602,12 @@ for _, strategy in helpers.each_strategy() do
             end
 
           else
-            assert.equals("PONG", res)
+            if cluster_protocol == "wrpc" then
+              -- is not config result
+              assert((res.error or res.ok) and not res.config)
+            else
+              assert.equals("PONG", res)
+            end
           end
 
           -- needs wait_until for c* convergence
@@ -619,6 +634,7 @@ for _, strategy in helpers.each_strategy() do
       -- ENDS blocked cases
     end)
   end)
+  end
 
   for cluster_protocol, conf in pairs(confs) do
     describe("CP/DP sync works with #" .. strategy .. " backend, protocol " .. cluster_protocol, function()

--- a/spec/02-integration/09-hybrid_mode/07-wrpc_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/07-wrpc_spec.lua
@@ -1,0 +1,296 @@
+local match = require "luassert.match"
+local ws_client, ws_server, wrpc, wrpc_proto
+local wait_for_log
+local ngx_log = ngx.log
+
+local timeout = 200 -- for perf test
+local max_payload_len = 1024 * 1024 * 200
+
+local default_ws_opt = {
+  timeout = timeout,
+  max_payload_len = max_payload_len,
+}
+
+local echo_service = "TestService.Echo"
+
+
+local function contain(state, arguments)
+  local expected = arguments[1]
+  return function(value)
+    return type(value) == "string" and value:find(expected) and true
+  end
+end
+
+assert:register("matcher", "contain", contain)
+
+local function new_server(ws_peer)
+  local proto = wrpc_proto.new()
+  proto:addpath("spec/fixtures/wrpc")
+  proto:import("test")
+  proto:set_handler("TestService.Echo", function(_, msg)
+    if msg.message == "log" then
+      ngx.log(ngx.NOTICE, "log test!")
+    end
+    return msg
+  end)
+  local peer = assert(wrpc.new_peer(ws_peer, proto, timeout))
+  peer:spawn_threads()
+  return peer
+end
+
+local function new_client(ws_peer)
+  local proto = wrpc_proto.new()
+  proto:addpath("spec/fixtures/wrpc")
+  proto:import("test")
+  local peer = assert(wrpc.new_peer(ws_peer, proto, timeout))
+  peer:spawn_threads()
+  return peer
+end
+
+local to_close = {}
+
+local function new_pair(ws_opt)
+  local client_ws = ws_client:new(ws_opt or default_ws_opt)
+  local server_ws = ws_server:new(ws_opt or default_ws_opt)
+  server_ws.peer = client_ws
+  client_ws.peer = server_ws
+
+  local client, server = new_client(client_ws), new_server(server_ws)
+
+  table.insert(to_close, client)
+  table.insert(to_close, server)
+
+  return client, server
+end
+
+insulate("wRPC protocol implementation", function()
+  lazy_setup(function ()
+    -- mock
+    -- we don't use mock() or spy() because it fails to mock somehow
+    local inspect = require "inspect"
+    local log_spy = spy.new(function () end)
+    ngx.log = function(level, ...) -- luacheck: ignore
+      return log_spy(level, inspect{...}) -- to make sure msg
+    end
+    -- require here. otherwise mock will fail
+    local wait_until = require "spec.helpers".wait_until
+    function wait_for_log(...)
+      local logs = {...}
+      wait_until(function ()
+        for _, log in ipairs(logs) do
+          if not pcall(assert.spy(log_spy).was_called_with, match._, match.contain(log)) then
+            return
+          end
+        end
+        return true
+      end, 5)
+    end
+
+    package.loaded["kong.tools.wrpc"] = nil
+    package.loaded["kong.tools.wrpc.message"] = nil
+    require "kong.tools.wrpc"
+    require "kong.tools.wrpc.message"
+
+    -- if we require at outer scope, the mock would be too late
+    ws_client = require("spec.fixtures.mocks.lua-resty-websocket.resty.websocket.peer")
+    ws_server = require("spec.fixtures.mocks.lua-resty-websocket.resty.websocket.peer")
+
+    wrpc = require("kong.tools.wrpc")
+    wrpc_proto = require("kong.tools.wrpc.proto")
+  end)
+
+  lazy_teardown(function ()
+    ngx.log = ngx_log -- luacheck: ignore
+  end)
+
+  describe("simple echo tests", function()
+
+    after_each(function ()
+      for i = 1, #to_close do
+        to_close[i]:close()
+        to_close[i] = nil
+      end
+    end)
+
+    it("multiple client, multiple call waiting", function ()
+      local client_n = 30
+      local message_n = 1000
+
+      local expecting = {}
+
+      local clients = {}
+      for i = 1, client_n do
+        clients[i] = new_pair()
+      end
+
+      for i = 1, message_n do
+        local client = math.random(1, client_n)
+        local message = client .. ":" .. math.random(1, 160)
+        local future = clients[client]:call(echo_service, { message = message, })
+        expecting[i] = {future = future, message = message, }
+      end
+
+      for i = 1, message_n do
+        local message = assert(expecting[i].future:wait())
+        assert(message.message == expecting[i].message)
+      end
+
+    end)
+
+    it("API test", function ()
+      local client = new_pair()
+      local param = { message = "log", }
+
+      assert.same(param, client:call_async(echo_service, param))
+      wait_for_log("log test!")
+
+      assert(client:call_no_return(echo_service, param))
+      wait_for_log("log test!")
+
+      
+      local rpc, payloads = assert(client.service:encode_args(echo_service, param))
+      local future = assert(client:send_encoded_call(rpc, payloads))
+      assert.same(param, future:wait())
+      wait_for_log("log test!")
+    end)
+
+    it("errors", function ()
+      local future = require "kong.tools.wrpc.future"
+      local client = new_pair()
+      local param = { message = "log", }
+      local rpc, payloads = assert(client.service:encode_args(echo_service, param))
+
+      local response_future = future.new(client, client.timeout)
+      client:send_payload({
+        mtype = "MESSAGE_TYPE_RPC",
+        svc_id = rpc.svc_id,
+        rpc_id = rpc.rpc_id + 1,
+        payload_encoding = "ENCODING_PROTO3",
+        payloads = payloads,
+      })
+      assert.same({
+        nil, "Invalid service (or rpc)"
+      },{response_future:wait()})
+
+      response_future = future.new(client, client.timeout)
+      client:send_payload({
+        mtype = "MESSAGE_TYPE_RPC",
+        svc_id = rpc.svc_id + 1,
+        rpc_id = rpc.rpc_id,
+        payload_encoding = "ENCODING_PROTO3",
+        payloads = payloads,
+      })
+      assert.same({
+        nil, "Invalid service (or rpc)"
+      },{response_future:wait()})
+
+      local client2 = new_pair({
+        max_payload_len = 25,
+      })
+
+      assert(
+        {
+          nil, "payload too large"
+        },
+        client2:send_payload({
+          mtype = "MESSAGE_TYPE_RPC",
+          svc_id = rpc.svc_id,
+          rpc_id = rpc.rpc_id,
+          payload_encoding = "ENCODING_PROTO3",
+          payloads = string.rep("t", 26),
+        })
+      )
+
+      local other_types = {
+        "MESSAGE_TYPE_UNSPECIFIED",
+        "MESSAGE_TYPE_STREAM_BEGIN",
+        "MESSAGE_TYPE_STREAM_MESSAGE",
+        "MESSAGE_TYPE_STREAM_END",
+      }
+
+      for _, typ in ipairs(other_types) do
+        response_future = future.new(client, client.timeout)
+        client:send_payload({
+          mtype = typ,
+          svc_id = rpc.svc_id,
+          rpc_id = rpc.rpc_id,
+          payload_encoding = "ENCODING_PROTO3",
+          payloads = payloads,
+        })
+
+        assert.same({
+          nil, "Unsupported message type"
+        },{response_future:wait()})
+      end
+
+      -- those will mess up seq so must be put at the last
+      client:send_payload({
+        mtype = "MESSAGE_TYPE_ERROR",
+        svc_id = rpc.svc_id,
+        rpc_id = rpc.rpc_id,
+        payload_encoding = "ENCODING_PROTO3",
+        payloads = payloads,
+      })
+      wait_for_log("malformed wRPC message")
+      
+      client:send_payload({
+        ack = 11,
+        mtype = "MESSAGE_TYPE_ERROR",
+        svc_id = rpc.svc_id,
+        rpc_id = rpc.rpc_id,
+        payload_encoding = "ENCODING_PROTO3",
+        payloads = payloads,
+      })
+      wait_for_log("receiving error message for a call expired or not initiated by this peer.")
+      
+      client:send_payload({
+        ack = 11,
+        mtype = "MESSAGE_TYPE_ERROR",
+        svc_id = rpc.svc_id,
+        rpc_id = rpc.rpc_id + 1,
+        payload_encoding = "ENCODING_PROTO3",
+        payloads = payloads,
+      })
+      wait_for_log("receiving error message for a call expired or not initiated by this peer.", "receiving error message for unkonwn RPC")
+    end)
+    
+    it("#perf", function ()
+      local semaphore = require "ngx.semaphore"
+      local smph = semaphore.new()
+
+      local client_n = 8
+      local message_n = 160
+
+      local m = 16 -- ?m
+      local message = string.rep("testbyte\x00\xff\xab\xcd\xef\xc0\xff\xee", 1024*64*m)
+
+      local done = 0
+      local t = ngx.now()
+      local time
+      local function counter(premature, future)
+        assert(future:wait(200))
+        done = done + 1
+        if done == message_n then
+          local t2 = ngx.now()
+          time = t2 - t
+          smph:post()
+        end
+      end
+
+      local clients = {}
+      for i = 1, client_n do
+        clients[i] = new_pair()
+      end
+
+      for i = 0, message_n - 1 do
+        local client = (i % client_n) + 1
+        local future = assert(clients[client]:call(echo_service, { message = message, }))
+        ngx.timer.at(0, counter, future)
+      end
+
+      -- in my env(i7-1165G7) it takes less than 3.7s
+      assert(smph:wait(10) and time < 10, "wrpc spent too much time")
+    end)
+  
+  end)
+end)

--- a/spec/03-plugins/37-opentelemetry/01-otlp_spec.lua
+++ b/spec/03-plugins/37-opentelemetry/01-otlp_spec.lua
@@ -47,11 +47,13 @@ describe("Plugin: opentelemetry (otlp)", function()
   lazy_setup(function ()
     -- overwrite for testing
     pb.option("enum_as_value")
+    pb.option("auto_default_values")
   end)
 
   lazy_teardown(function()
     -- revert it back
     pb.option("enum_as_name")
+    pb.option("no_default_values")
   end)
 
   after_each(function ()

--- a/spec/03-plugins/37-opentelemetry/04-exporter_spec.lua
+++ b/spec/03-plugins/37-opentelemetry/04-exporter_spec.lua
@@ -12,11 +12,13 @@ for _, strategy in helpers.each_strategy() do
     lazy_setup(function ()
       -- overwrite for testing
       pb.option("enum_as_value")
+      pb.option("auto_default_values")
     end)
 
     lazy_teardown(function()
       -- revert it back
       pb.option("enum_as_name")
+      pb.option("no_default_values")
     end)
 
     -- helpers

--- a/spec/fixtures/mocks/lua-resty-websocket/resty/websocket/peer.lua
+++ b/spec/fixtures/mocks/lua-resty-websocket/resty/websocket/peer.lua
@@ -1,0 +1,143 @@
+local semaphore = require "ngx.semaphore"
+local semaphore_new = semaphore.new
+
+local remove = table.remove
+local insert = table.insert
+
+-- buffer
+local recv_buf = {}
+local recv_buf_mt = { __index = recv_buf }
+
+local default_timeout = 5
+
+function recv_buf.new()
+  return setmetatable({ smph = semaphore_new() }, recv_buf_mt)
+end
+
+function recv_buf:push(obj)
+  insert(self, obj)
+  if #self == 1 then
+    self.smph:post()
+  end
+
+  return true
+end
+
+function recv_buf:pop_no_wait()
+  return remove(self)
+end
+
+function recv_buf:pop(timeout)
+  if #self == 0 then
+    local ok, err = self.smph:wait(timeout or default_timeout)
+    if not ok then
+      return nil, err
+    end
+  end
+
+  return remove(self)
+end
+
+-- end buffer
+
+local unpack = unpack
+
+local _M = {}
+local mt = { __index = _M }
+
+local empty = {}
+
+-- we ignore mask problems and most of error handling
+
+function _M:new(opts)
+  opts = opts or empty
+
+  local new_peer = setmetatable({
+    timeout = opts.timeout,
+    buf = recv_buf.new(),
+  }, mt)
+
+  return new_peer
+end
+
+function _M:set_timeout(time)
+  self.timeout = time
+  return true
+end
+
+local types = {
+  [0x0] = "continuation",
+  [0x1] = "text",
+  [0x2] = "binary",
+  [0x8] = "close",
+  [0x9] = "ping",
+  [0xa] = "pong",
+}
+
+function _M:translate_frame(fin, op, payload)
+  payload = payload or ""
+  local payload_len = #payload
+  op = types[op]
+  if op == "close" then
+    -- being a close frame
+    if payload_len > 0 then
+      return payload[2], "close", payload[1]
+    end
+
+    return "", "close", nil
+  end
+
+  return payload, op, not fin and "again" or nil
+end
+
+function _M:recv_frame()
+  local buf = self.buf
+  local obj, err = buf:pop(self.timeout)
+  if not obj then
+    return nil, nil, err
+  end
+
+  return self:translate_frame(unpack(obj)) -- data, typ, err
+end
+
+local function send_frame(self, fin, op, payload)
+  local message = { fin, op, payload }
+
+  return self.peer.buf:push(message)
+end
+
+_M.send_frame = send_frame
+
+function _M:send_text(data)
+  return self:send_frame(true, 0x1, data)
+end
+
+function _M:send_binary(data)
+  return self:send_frame(true, 0x2, data)
+end
+
+function _M:send_close(code, msg)
+  local payload
+  if code then
+    payload = {code, msg}
+  end
+  return self:send_frame(true, 0x8, payload)
+end
+
+function _M:send_ping(data)
+  return self:send_frame(true, 0x9, data)
+end
+
+function _M:send_pong(data)
+  return self:send_frame(true, 0xa, data)
+end
+
+-- for clients
+function _M.connect()
+end
+function _M.set_keepalive()
+end
+function _M.close()
+end
+
+return _M

--- a/spec/fixtures/wrpc/test.proto
+++ b/spec/fixtures/wrpc/test.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+option go_package = "github.com/kong/koko/internal/gen/wrpc/kong/model;model";
+
+package kong.model;
+
+
+// +wrpc:service-id=1
+service TestService {
+  // +wrpc:rpc-id=1
+  rpc Echo(TestMsg) returns (TestMsg);
+}
+
+message TestMsg {
+  bytes message = 1;
+}

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -2971,15 +2971,7 @@ local function reload_kong(strategy, ...)
   return ok, err
 end
 
---- Simulate a Hybrid mode DP and connect to the CP specified in `opts`.
--- @function clustering_client
--- @param opts Options to use, the `host`, `port`, `cert` and `cert_key` fields
--- are required.
--- Other fields that can be overwritten are:
--- `node_hostname`, `node_id`, `node_version`, `node_plugins_list`. If absent,
--- they are automatically filled.
--- @return msg if handshake succeeded and initial message received from CP or nil, err
-local function clustering_client(opts)
+local function clustering_client_json(opts)
   assert(opts.host)
   assert(opts.port)
   assert(opts.cert)
@@ -3026,6 +3018,95 @@ local function clustering_client(opts)
   return nil, "unknown frame from CP: " .. (typ or err)
 end
 
+local clustering_client_wrpc
+do 
+  local wrpc = require("kong.tools.wrpc")
+  local wrpc_proto = require("kong.tools.wrpc.proto")
+  local semaphore = require("ngx.semaphore")
+
+  local wrpc_services
+  local function get_services()
+    if not wrpc_services then
+      wrpc_services = wrpc_proto.new()
+      -- init_negotiation_client(wrpc_services)
+      wrpc_services:import("kong.services.config.v1.config")
+      wrpc_services:set_handler("ConfigService.SyncConfig", function(peer, data)
+        peer.data = data
+        peer.smph:post()
+        return { accepted = true }
+      end)
+    end
+
+    return wrpc_services
+  end
+  function clustering_client_wrpc(opts)
+    assert(opts.host)
+    assert(opts.port)
+    assert(opts.cert)
+    assert(opts.cert_key)
+
+    local WS_OPTS = {
+      timeout = opts.clustering_timeout,
+      max_payload_len = opts.cluster_max_payload,
+    }
+
+    local c = assert(ws_client:new(WS_OPTS))
+    local uri = "wss://" .. opts.host .. ":" .. opts.port .. "/v1/wrpc?node_id=" ..
+                (opts.node_id or utils.uuid()) ..
+                "&node_hostname=" .. (opts.node_hostname or kong.node.get_hostname()) ..
+                "&node_version=" .. (opts.node_version or KONG_VERSION)
+
+    local conn_opts = {
+      ssl_verify = false, -- needed for busted tests as CP certs are not trusted by the CLI
+      client_cert = assert(ssl.parse_pem_cert(assert(pl_file.read(opts.cert)))),
+      client_priv_key = assert(ssl.parse_pem_priv_key(assert(pl_file.read(opts.cert_key)))),
+      protocols = "wrpc.konghq.com",
+    }
+
+    conn_opts.server_name = "kong_clustering"
+
+    local ok, err = c:connect(uri, conn_opts)
+    if not ok then
+      return nil, err
+    end
+
+    local peer = wrpc.new_peer(c, get_services())
+
+    peer.smph = semaphore.new(0)
+
+    peer:spawn_threads()
+
+    local resp = assert(peer:call_async("ConfigService.ReportMetadata", {
+      plugins = opts.node_plugins_list or PLUGINS_LIST }))
+
+    if resp.ok then
+      peer.smph:wait(2)
+
+      if peer.data then
+        peer:close()
+        return peer.data
+      end
+    end
+
+    return resp
+  end
+end
+
+--- Simulate a Hybrid mode DP and connect to the CP specified in `opts`.
+-- @function clustering_client
+-- @param opts Options to use, the `host`, `port`, `cert` and `cert_key` fields
+-- are required.
+-- Other fields that can be overwritten are:
+-- `node_hostname`, `node_id`, `node_version`, `node_plugins_list`. If absent,
+-- they are automatically filled.
+-- @return msg if handshake succeeded and initial message received from CP or nil, err
+local function clustering_client(opts)
+  if opts.cluster_protocol == "wrpc" then
+    return clustering_client_wrpc(opts)
+  else
+    return clustering_client_json(opts)
+  end
+end
 
 --- Return a table of clustering_protocols and
 -- create the appropriate Nginx template file if needed.


### PR DESCRIPTION
1. CP crashes if DP report meta data with empty plugin list
2. the client is inserted to the list before it reported "basic info", therefore it's possible for an incompatible client to receive config pushs.
3. If no error happens, and no ping is sent yet, update_sync_status is not called and thus we cannot query that DP
4. CP does not return result of compatibility check ReportMetadata
5. Unnessary argument when dp creates connection(refactory leftover)

FT-3030