### PR TITLE
fix(tracing) add `request` type to only create request-level span

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -110,6 +110,7 @@
                                  # Valid values to this setting are:
                                  #
                                  # - `off`: do not enable instrumentations.
+                                 # - `request`: only enable request-level instrumentations.
                                  # - `all`: enable all the following instrumentations.
                                  # - `db_query`: trace database query, including
                                  #   Postgres and Cassandra.

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -1026,6 +1026,7 @@ local function check_and_infer(conf, opts)
     local available_types_map = tablex.deepcopy(instrumentation.available_types)
     available_types_map["all"] = true
     available_types_map["off"] = true
+    available_types_map["request"] = true
 
     for _, trace_type in ipairs(conf.opentelemetry_tracing) do
       if not available_types_map[trace_type] then
@@ -1033,10 +1034,10 @@ local function check_and_infer(conf, opts)
       end
     end
 
-    if tablex.find(conf.opentelemetry_tracing, "off")
-      and tablex.find(conf.opentelemetry_tracing, "all")
+    if #conf.opentelemetry_tracing > 1
+      and tablex.find(conf.opentelemetry_tracing, "off")
     then
-      errors[#errors + 1] = "invalid opentelemetry tracing types: off, all are mutually exclusive"
+      errors[#errors + 1] = "invalid opentelemetry tracing types: off, other types are mutually exclusive"
     end
 
     if conf.opentelemetry_tracing_sampling_rate < 0 or conf.opentelemetry_tracing_sampling_rate > 1 then

--- a/spec/02-integration/14-tracing/01-instrumentations_spec.lua
+++ b/spec/02-integration/14-tracing/01-instrumentations_spec.lua
@@ -296,7 +296,7 @@ for _, strategy in helpers.each_strategy() do
 
     describe("request", function ()
       lazy_setup(function()
-        setup_instrumentations("request", true)
+        setup_instrumentations("request", false)
       end)
 
       lazy_teardown(function()

--- a/spec/02-integration/14-tracing/01-instrumentations_spec.lua
+++ b/spec/02-integration/14-tracing/01-instrumentations_spec.lua
@@ -293,5 +293,33 @@ for _, strategy in helpers.each_strategy() do
         assert.is_same(expected_span_num, #spans, res)
       end)
     end)
+
+    describe("request", function ()
+      lazy_setup(function()
+        setup_instrumentations("request", true)
+      end)
+
+      lazy_teardown(function()
+        helpers.stop_kong()
+      end)
+
+      it("works", function ()
+        local thread = helpers.tcp_server(TCP_PORT)
+        local r = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/",
+        })
+        assert.res_status(200, r)
+
+        -- Getting back the TCP server input
+        local ok, res = thread:join()
+        assert.True(ok)
+        assert.is_string(res)
+
+        -- Making sure it's alright
+        local spans = cjson.decode(res)
+        assert.is_same(1, #spans, res)
+      end)
+    end)
   end)
 end


### PR DESCRIPTION
### Summary

Add `request` type to tracing instrumentation.
This allows only to create the top-level span.