### PR TITLE
feat(clustering): improve wRPC protocol detection

### DIFF
--- a/kong/clustering/utils.lua
+++ b/kong/clustering/utils.lua
@@ -349,11 +349,16 @@ function _M.check_protocol_support(conf, cert, cert_key)
     return nil, err
   end
 
-  if res.status == 404 then
+  local status = res.status
+
+  if status == 200 then
+    return "v1" -- wrpc
+
+  elseif status == 404 then
     return "v0"
   end
 
-  return "v1"   -- wrpc
+  return nil, "bad response code: " .. tostring(status)
 end
 
 

--- a/kong/clustering/wrpc_control_plane.lua
+++ b/kong/clustering/wrpc_control_plane.lua
@@ -28,6 +28,7 @@ local ngx_var = ngx.var
 local timer_at = ngx.timer.at
 local isempty = require("table.isempty")
 local sleep = ngx.sleep
+local get_method = ngx.req.get_method
 
 local plugins_list_to_map = clustering_utils.plugins_list_to_map
 local deflate_gzip = utils.deflate_gzip
@@ -216,6 +217,11 @@ _M.check_configuration_compatibility = clustering_utils.check_configuration_comp
 
 
 function _M:handle_cp_websocket()
+  if get_method() == "HEAD" then
+    -- feature detection request from a DP node
+    return ngx_exit(200)
+  end
+
   local dp_id = ngx_var.arg_node_id
   local dp_hostname = ngx_var.arg_node_hostname
   local dp_ip = ngx_var.remote_addr

--- a/spec/02-integration/09-hybrid_mode/06-legacy_switch_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/06-legacy_switch_spec.lua
@@ -1,0 +1,104 @@
+local helpers = require "spec.helpers"
+local ssl = require "ngx.ssl"
+local http = require "resty.http"
+local read_file = require("pl.file").read
+
+local function new_conf(extra)
+  local t = {
+    cluster_cert          = "spec/fixtures/ocsp_certs/kong_data_plane.crt",
+    cluster_cert_key      = "spec/fixtures/ocsp_certs/kong_data_plane.key",
+    cluster_mtls          = "pki",
+    cluster_listen        = "127.0.0.1:9005",
+    cluster_control_plane = "127.0.0.1:9005",
+    cluster_ca_cert       = "spec/fixtures/ocsp_certs/ca.crt",
+    cluster_server_name   = "kong_clustering",
+
+    nginx_conf = "spec/fixtures/custom_nginx.template",
+  }
+
+  for k, v in pairs(extra or {}) do
+    t[k] = v
+  end
+
+  return t
+end
+
+local dp_cert, dp_key
+do
+  local conf = new_conf()
+  dp_cert = assert(ssl.parse_pem_cert(assert(read_file(conf.cluster_cert))))
+  dp_key = assert(ssl.parse_pem_priv_key(assert(read_file(conf.cluster_cert_key))))
+end
+
+for _, proto in ipairs({ "json", "wrpc" }) do
+
+  for _, strategy in helpers.each_strategy() do
+
+    local is_legacy = proto == "json"
+    local exp_status = is_legacy and 404 or 200
+    local enabled = is_legacy and "enabled" or "disabled"
+
+    describe("legacy_hybrid_protocol (" .. enabled .. ")", function()
+      lazy_setup(function()
+        assert(helpers.start_kong(new_conf({
+          role = "control_plane",
+          database = strategy,
+
+          legacy_hybrid_protocol = is_legacy,
+          cluster_cert = "spec/fixtures/ocsp_certs/kong_clustering.crt",
+          cluster_cert_key = "spec/fixtures/ocsp_certs/kong_clustering.key",
+        })))
+
+        assert(helpers.start_kong(new_conf({
+          role = "data_plane",
+          database = "off",
+          prefix = "servroot2",
+
+          legacy_hybrid_protocol = is_legacy,
+          proxy_listen = "0.0.0.0:9002",
+        })))
+      end)
+
+      lazy_teardown(function()
+        helpers.stop_kong("servroot2", true)
+        helpers.stop_kong(nil, true)
+      end)
+
+      it("data-plane nodes connect using the correct endpoint/protocol", function()
+        if is_legacy then
+          -- ensure that the data-plane has connected _before_ asserting that
+          -- no `[wrpc-clustering]` log line exists
+          assert.logfile().has_line("[clustering] data plane connected", true)
+          assert.logfile().has_no_line("[wrpc-clustering] ", true)
+        else
+          assert.logfile().has_line("[wrpc-clustering] ", true)
+        end
+      end)
+
+      it("wRPC endpoint returns HTTP " .. tostring(exp_status), function()
+        local conf = new_conf()
+
+        local httpc = assert(http.new())
+
+        assert.not_nil(httpc:connect({
+          host = conf.cluster_control_plane:match("[^:]+"),
+          port = conf.cluster_control_plane:match("[0-9]+$"),
+          scheme = "https",
+          ssl_client_cert = dp_cert,
+          ssl_client_priv_key = dp_key,
+          ssl_verify = false,
+        }))
+
+        finally(function() http:close() end)
+
+        local res, err = httpc:request({
+          path = "/v1/wrpc",
+          method = "HEAD",
+        })
+
+        assert.not_nil(res, err)
+        assert.res_status(exp_status, res)
+      end)
+    end)
+  end
+end

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -3318,12 +3318,14 @@ local function get_clustering_protocols()
     ["json (by switch)"] = "spec/fixtures/custom_nginx.template",
   }
 
-  -- disable wrpc in CP
-  os.execute(string.format("cat %s | sed 's/wrpc/foobar/g' > %s", confs.wrpc, confs.json))
+  do
+    -- disable wrpc in CP
+    local tmpl = assert(pl_file.read(confs.wrpc)):gsub("wrpc", "foobar")
+    assert(pl_file.write(confs.json, tmpl))
+  end
 
   return confs
 end
-
 
 ----------------
 -- Variables/constants


### PR DESCRIPTION
### Summary

The data-plane clustering code optimistically makes a request to the control-plane (`HEAD /v1/wrpc`) to determine if it can use wRPC or not. If the request did not return a 404, it would assume wRPC.

We gate the presence of the `/v1/wrpc` block based on the `legacy_hybrid_protocol` config param and rely on NGINX to return a 404.

This is all behaving kinda finnicky in EE land (for reasons I spent an hour debugging and couldn't figure out). Needless to say, I think a more explicit form of feature detection is warranted.

### Full changelog

* `/v1/wrpc` returns 200 immediately for `HEAD` requests
* `kong.clustering.utils.check_protocol_support` checks response codes more strictly now:
  - `404` => legacy
  - `200` => wrpc
  - anything else is an error
 * renamed `06-lagacy_switch_spec.lua` => `06-legacy_switch_spec.lua`