### PR TITLE
chore(rockspec) bump lua-resty-healthcheck to 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,7 +228,6 @@
   migrations, designating a function to call.  The `up_f` part is
   invoked after the `up` part has been executed against the database
   for both Postgres and Cassandra.
-  
 - A new CLI command, `kong migrations status`, generates the status on a JSON file.
 
 ### Dependencies
@@ -255,9 +254,10 @@
   [#8700](https://github.com/Kong/kong/pull/8700)
 - Bumped luasec from 1.0.2 to 1.1.0
   [#8754](https://github.com/Kong/kong/pull/8754)
-- Bumped resty.healthcheck from 1.5.0 to 1.6.0
+- Bumped resty.healthcheck from 1.5.0 to 1.6.1
   [#8755](https://github.com/Kong/kong/pull/8755)
   [#9018](https://github.com/Kong/kong/pull/9018)
+  [#9150](https://github.com/Kong/kong/pull/9150)
 - Bumped resty.cassandra from 1.5.1 to 1.5.2
   [#8845](https://github.com/Kong/kong/pull/8845)
 

--- a/kong-3.0.0-0.rockspec
+++ b/kong-3.0.0-0.rockspec
@@ -33,7 +33,7 @@ dependencies = {
   "luaxxhash >= 1.0",
   "lua-protobuf == 0.3.3",
   "lua-resty-worker-events == 1.0.0",
-  "lua-resty-healthcheck == 1.6.0",
+  "lua-resty-healthcheck == 1.6.1",
   "lua-resty-mlcache == 2.5.0",
   "lua-messagepack == 0.5.2",
   "lua-resty-openssl == 0.8.10",


### PR DESCRIPTION
### Summary

Bump lua-resty-healthcheck to latest 1.6.x release. This is needed to use any lua-resty-events 0.1.x release.

### Full changelog

* [lua-resty-healthcheck 1.6.1](https://github.com/Kong/lua-resty-healthcheck/tree/1.6.1#161-25-jul-2022)
