### PR TITLE
fix(runloop) typo fix for kong.log.err

### DIFF
--- a/kong/runloop/plugin_servers/init.lua
+++ b/kong/runloop/plugin_servers/init.lua
@@ -125,7 +125,7 @@ local function get_server_rpc(server_def)
 
     local rpc_modname = protocol_implementations[server_def.protocol]
     if not rpc_modname then
-      kong.log.error("Unknown protocol implementation: ", server_def.protocol)
+      kong.log.err("Unknown protocol implementation: ", server_def.protocol)
       return nil, "Unknown protocol implementation"
     end
 


### PR DESCRIPTION
### Summary

- fix(runloop) typo fix for kong.log.err