### PR TITLE
fix(http-log) properly migrate headers when multiple values are provided

### DIFF
--- a/kong/plugins/http-log/migrations/001_280_to_300.lua
+++ b/kong/plugins/http-log/migrations/001_280_to_300.lua
@@ -11,9 +11,26 @@ local function ws_migration_teardown(ops)
           for header_name, value_array in pairs(headers) do
             if type(value_array) == "table" then
               -- only update if it's still a table, so it is reentrant
-              headers[header_name] = value_array[1] or "empty header value"
+              if not next(value_array) then
+                -- In <=2.8, while it is possible to set a header with an empty
+                -- array of values, the gateway won't send the header with no
+                -- value to the defined HTTP endpoint. To match this behavior,
+                -- we'll remove the header.
+                headers[header_name] = nil
+              else
+                -- When multiple header values were provided, the gateway would
+                -- send all values, deliminated by a comma & space characters.
+                headers[header_name] = table.concat(value_array, ", ")
+              end
               updated = true
             end
+          end
+
+          -- When there are no headers set after the modifications, set to null
+          -- in order to avoid setting to an empty object.
+          if updated and not next(headers) then
+            local cjson = require "cjson"
+            config.headers = cjson.null
           end
         end
       end


### PR DESCRIPTION
In Kong <=2.8, the `http-log` plugin supports providing multiple header values in the array, and will automatically concatenate them (delimited by `, `) when sent over the wire to the defined HTTP log endpoint.

Prior to these code changes, if someone has `{"some-header": ["test1", "test2"]}` set as the headers on their plugin config, when migrating from 2.8 to 3.0, it’d re-write the headers config to `{"some-header": "test1"}`. These code changes allow to retain the same behavior as prior versions.

Given the example headers config above, the headers sent by the gateway in a manual integration test are below:
```
Content-Length: 1556
User-Agent: lua-resty-http/0.16.1 (Lua) ngx_lua/10020
Content-Type: application/json
some-header: test1, test2
```

The DB migration was manually tested from 2.8 -> 3.0. Below is the state of the plugin in 2.8 (before the migration) and in 3.0 (after the migration):

```
// One header defined with two values.
//
// v2.8 plugin config:
{
    "method": "POST",
    "headers": {
        "some-header": [
            "test1",
            "test2"
        ]
    },
    "timeout": 10000,
    "keepalive": 60000,
    "queue_size": 1,
    "retry_count": 10,
    "content_type": "application/json",
    "flush_timeout": 2,
    "http_endpoint": "http://127.0.0.1:8081",
    "custom_fields_by_lua": null
}
// v3.0 plugin config:
{
    "method": "POST",
    "headers": {
        "some-header": "test1, test2"
    },
    "timeout": 10000,
    "keepalive": 60000,
    "queue_size": 1,
    "retry_count": 10,
    "content_type": "application/json",
    "flush_timeout": 2,
    "http_endpoint": "http://127.0.0.1:8081",
    "custom_fields_by_lua": null
}

// One header defined with one value.
//
// v2.8 plugin config:
{
    "method": "POST",
    "headers": {
        "some-header": [
            "test1"
        ]
    },
    "timeout": 10000,
    "keepalive": 60000,
    "queue_size": 1,
    "retry_count": 10,
    "content_type": "application/json",
    "flush_timeout": 2,
    "http_endpoint": "http://127.0.0.1:8081",
    "custom_fields_by_lua": null
}
// v3.0 plugin config:
{
    "method": "POST",
    "headers": {
        "some-header": "test1"
    },
    "timeout": 10000,
    "keepalive": 60000,
    "queue_size": 1,
    "retry_count": 10,
    "content_type": "application/json",
    "flush_timeout": 2,
    "http_endpoint": "http://127.0.0.1:8081",
    "custom_fields_by_lua": null
}

// One header defined with no value.
//
// v2.8 plugin config:
{
    "method": "POST",
    "headers": {
        "some-header": {}
    },
    "timeout": 10000,
    "keepalive": 60000,
    "queue_size": 1,
    "retry_count": 10,
    "content_type": "application/json",
    "flush_timeout": 2,
    "http_endpoint": "http://127.0.0.1:8081",
    "custom_fields_by_lua": null
}
// v3.0 plugin config:
{
    "method": "POST",
    "headers": null,
    "timeout": 10000,
    "keepalive": 60000,
    "queue_size": 1,
    "retry_count": 10,
    "content_type": "application/json",
    "flush_timeout": 2,
    "http_endpoint": "http://127.0.0.1:8081",
    "custom_fields_by_lua": null
}

// One header defined with one value, another with no value.
//
// v2.8 plugin config:
{
    "method": "POST",
    "headers": {
        "some-header": {},
        "another-header": [
            "test1"
        ]
    },
    "timeout": 10000,
    "keepalive": 60000,
    "queue_size": 1,
    "retry_count": 10,
    "content_type": "application/json",
    "flush_timeout": 2,
    "http_endpoint": "http://127.0.0.1:8081",
    "custom_fields_by_lua": null
}
// v3.0 plugin config:
{
    "method": "POST",
    "headers": {
        "another-header": "test1"
    },
    "timeout": 10000,
    "keepalive": 60000,
    "queue_size": 1,
    "retry_count": 10,
    "content_type": "application/json",
    "flush_timeout": 2,
    "http_endpoint": "http://127.0.0.1:8081",
    "custom_fields_by_lua": null
}

// No headers defined.
//
// v2.8 plugin config:
{
    "method": "POST",
    "headers": null,
    "timeout": 10000,
    "keepalive": 60000,
    "queue_size": 1,
    "retry_count": 10,
    "content_type": "application/json",
    "flush_timeout": 2,
    "http_endpoint": "http://127.0.0.1:8081",
    "custom_fields_by_lua": null
}
// v3.0 plugin config:
{
    "method": "POST",
    "headers": null,
    "timeout": 10000,
    "keepalive": 60000,
    "queue_size": 1,
    "retry_count": 10,
    "content_type": "application/json",
    "flush_timeout": 2,
    "http_endpoint": "http://127.0.0.1:8081",
    "custom_fields_by_lua": null
}
```