### PR TITLE
chore(deps) bump resty.acme from 0.8.0 to 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -249,7 +249,7 @@
   [#9023](https://github.com/Kong/kong/pull/9023)
 - Bumped inspect from 3.1.2 to 3.1.3
   [#8589](https://github.com/Kong/kong/pull/8589)
-- Bumped resty.acme from 0.7.2 to 0.8.0
+- Bumped resty.acme from 0.7.2 to 0.8.1
   [#8680](https://github.com/Kong/kong/pull/8680)
   [#9165](https://github.com/Kong/kong/pull/9165)
 - Bumped luarocks from 3.8.0 to 3.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -251,6 +251,7 @@
   [#8589](https://github.com/Kong/kong/pull/8589)
 - Bumped resty.acme from 0.7.2 to 0.8.0
   [#8680](https://github.com/Kong/kong/pull/8680)
+  [#9165](https://github.com/Kong/kong/pull/9165)
 - Bumped luarocks from 3.8.0 to 3.9.0
   [#8700](https://github.com/Kong/kong/pull/8700)
 - Bumped luasec from 1.0.2 to 1.1.0

--- a/kong-3.0.0-0.rockspec
+++ b/kong-3.0.0-0.rockspec
@@ -39,7 +39,7 @@ dependencies = {
   "lua-resty-openssl == 0.8.10",
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6.1",
-  "lua-resty-acme == 0.8.0",
+  "lua-resty-acme == 0.8.1",
   "lua-resty-session == 3.10",
   "lua-resty-timer-ng == 0.2.0",
 }


### PR DESCRIPTION
## [0.8.1] - 2022-07-26
### bug fixes
- **client:** skip checking eab_handler if eab_kid and eab_hmac_key is set ([#71](https://github.com/fffonion/lua-resty-acme/issues/71)) [6004738](https://github.com/fffonion/lua-resty-acme/commit/6004738222718c678d612afb61a0a428ee25fdb4)

### features
- **storage:** add Vault namespace ([#63](https://github.com/fffonion/lua-resty-acme/issues/63)) [e241933](https://github.com/fffonion/lua-resty-acme/commit/e24193396af96900f3436dc55c5b0be98bc2ccca)
