### PR TITLE
fix(atc-router) router is not inited properly

### DIFF
--- a/kong/router/init.lua
+++ b/kong/router/init.lua
@@ -44,7 +44,7 @@ function _M.new(routes, cache, cache_neg)
     }, _MT)
   end
 
-  return atc_compat.new(routes)
+  return atc_compat.new(routes, cache, cache_neg)
 end
 
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

 `atc_compat.new` should use `cache` and `cache_neg`.

See #9096 


