### PR TITLE
feat(db): disconnect table_name from entity name

### DIFF
--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -617,6 +617,12 @@ local MetaSchema = Schema.new({
       },
     },
     {
+      table_name = {
+        type = "string",
+        nilable = true,
+      },
+    },
+    {
       admin_api_nested_name = {
         type = "string",
         nilable = true,
@@ -655,6 +661,10 @@ local MetaSchema = Schema.new({
     if not fields then
       errors["fields"] = meta_errors.TABLE:format("fields")
       return nil, errors
+    end
+
+    if not schema.table_name then
+      schema.table_name = schema.name
     end
 
     if schema.endpoint_key then

--- a/kong/db/strategies/cassandra/init.lua
+++ b/kong/db/strategies/cassandra/init.lua
@@ -60,7 +60,7 @@ local function is_partitioned(self)
       WHERE keyspace_name = '%s'
       AND table_name = '%s'
       AND column_name = 'partition';
-    ]], self.connector.keyspace, self.schema.name)
+    ]], self.connector.keyspace, self.schema.table_name)
 
   else
     cql = format_cql([[
@@ -68,7 +68,7 @@ local function is_partitioned(self)
       WHERE keyspace_name = '%s'
       AND columnfamily_name = '%s'
       AND column_name = 'partition';
-    ]], self.connector.keyspace, self.schema.name)
+    ]], self.connector.keyspace, self.schema.table_name)
   end
 
   local rows, err = self.connector:query(cql, {}, nil, "read")
@@ -143,129 +143,129 @@ local function build_queries(self)
     return {
       insert = format_cql([[
         INSERT INTO %s (partition, %s) VALUES ('%s', %s) IF NOT EXISTS
-      ]], schema.name, insert_columns, schema.name, insert_bind_args),
+      ]], schema.table_name, insert_columns, schema.name, insert_bind_args),
 
       insert_ttl = format_cql([[
         INSERT INTO %s (partition, %s) VALUES ('%s', %s) IF NOT EXISTS USING TTL %s
-      ]], schema.name, insert_columns, schema.name, insert_bind_args, "%u"),
+      ]], schema.table_name, insert_columns, schema.name, insert_bind_args, "%u"),
 
       insert_no_transaction = format_cql([[
         INSERT INTO %s (partition, %s) VALUES ('%s', %s)
-      ]], schema.name, insert_columns, schema.name, insert_bind_args),
+      ]], schema.table_name, insert_columns, schema.name, insert_bind_args),
 
       insert_no_transaction_ttl = format_cql([[
         INSERT INTO %s (partition, %s) VALUES ('%s', %s) USING TTL %s
-      ]], schema.name, insert_columns, schema.name, insert_bind_args, "%u"),
+      ]], schema.table_name, insert_columns, schema.name, insert_bind_args, "%u"),
 
       select = format_cql([[
         SELECT %s FROM %s WHERE partition = '%s' AND %s
-      ]], select_columns, schema.name, schema.name, select_bind_args),
+      ]], select_columns, schema.table_name, schema.name, select_bind_args),
 
       select_page = format_cql([[
         SELECT %s FROM %s WHERE partition = '%s'
-      ]], select_columns, schema.name, schema.name),
+      ]], select_columns, schema.table_name, schema.name),
 
       select_with_filter = format_cql([[
         SELECT %s FROM %s WHERE partition = '%s' AND %s
-      ]], select_columns, schema.name, schema.name, "%s"),
+      ]], select_columns, schema.table_name, schema.name, "%s"),
 
       select_tags_cond_and_first_tag = format_cql([[
         SELECT entity_id FROM tags WHERE entity_name = '%s' AND tag = ?
-      ]], schema.name),
+      ]], schema.table_name),
 
       select_tags_cond_and_next_tags = format_cql([[
         SELECT entity_id FROM tags WHERE entity_name = '%s' AND tag = ? AND entity_id IN ?
-      ]], schema.name),
+      ]], schema.table_name),
 
       select_tags_cond_or = format_cql([[
         SELECT tag, entity_id, other_tags FROM tags WHERE entity_name = '%s' AND tag IN ?
-      ]], schema.name),
+      ]], schema.table_name),
 
       update = format_cql([[
         UPDATE %s SET %s WHERE partition = '%s' AND %s IF EXISTS
-      ]], schema.name, "%s", schema.name, select_bind_args),
+      ]], schema.table_name, "%s", schema.name, select_bind_args),
 
       update_ttl = format_cql([[
         UPDATE %s USING TTL %s SET %s WHERE partition = '%s' AND %s IF EXISTS
-      ]], schema.name, "%u", "%s", schema.name, select_bind_args),
+      ]], schema.table_name, "%u", "%s", schema.name, select_bind_args),
 
       upsert = format_cql([[
         UPDATE %s SET %s WHERE partition = '%s' AND %s
-      ]], schema.name, "%s", schema.name, select_bind_args),
+      ]], schema.table_name, "%s", schema.name, select_bind_args),
 
       upsert_ttl = format_cql([[
         UPDATE %s USING TTL %s SET %s WHERE partition = '%s' AND %s
-      ]], schema.name, "%u", "%s", schema.name, select_bind_args),
+      ]], schema.table_name, "%u", "%s", schema.name, select_bind_args),
 
       delete = format_cql([[
         DELETE FROM %s WHERE partition = '%s' AND %s
-      ]], schema.name, schema.name, select_bind_args),
+      ]], schema.table_name, schema.name, select_bind_args),
     }
   end
 
   return {
     insert = format_cql([[
       INSERT INTO %s (%s) VALUES (%s) IF NOT EXISTS
-    ]], schema.name, insert_columns, insert_bind_args),
+    ]], schema.table_name, insert_columns, insert_bind_args),
 
     insert_ttl = format_cql([[
       INSERT INTO %s (%s) VALUES (%s) IF NOT EXISTS USING TTL %s
-    ]], schema.name, insert_columns, insert_bind_args, "%u"),
+    ]], schema.table_name, insert_columns, insert_bind_args, "%u"),
 
     insert_no_transaction = format_cql([[
       INSERT INTO %s (%s) VALUES (%s)
-    ]], schema.name, insert_columns, insert_bind_args),
+    ]], schema.table_name, insert_columns, insert_bind_args),
 
     insert_no_transaction_ttl = format_cql([[
       INSERT INTO %s ( %s) VALUES (%s) USING TTL %s
-    ]], schema.name, insert_columns, insert_bind_args, "%u"),
+    ]], schema.table_name, insert_columns, insert_bind_args, "%u"),
 
     -- might raise a "you must enable ALLOW FILTERING" error
     select = format_cql([[
       SELECT %s FROM %s WHERE %s
-    ]], select_columns, schema.name, select_bind_args),
+    ]], select_columns, schema.table_name, select_bind_args),
 
     -- might raise a "you must enable ALLOW FILTERING" error
     select_page = format_cql([[
       SELECT %s FROM %s
-    ]], select_columns, schema.name),
+    ]], select_columns, schema.table_name),
 
     -- might raise a "you must enable ALLOW FILTERING" error
     select_with_filter = format_cql([[
       SELECT %s FROM %s WHERE %s
-    ]], select_columns, schema.name, "%s"),
+    ]], select_columns, schema.table_name, "%s"),
 
     select_tags_cond_and_first_tag = format_cql([[
       SELECT entity_id FROM tags WHERE entity_name = '%s' AND tag = ?
-    ]], schema.name),
+    ]], schema.table_name),
 
     select_tags_cond_and_next_tags = format_cql([[
       SELECT entity_id FROM tags WHERE entity_name = '%s' AND tag = ? AND entity_id IN ?
-    ]], schema.name),
+    ]], schema.table_name),
 
     select_tags_cond_or = format_cql([[
       SELECT tag, entity_id, other_tags FROM tags WHERE entity_name = '%s' AND tag IN ?
-    ]], schema.name),
+    ]], schema.table_name),
 
     update = format_cql([[
       UPDATE %s SET %s WHERE %s IF EXISTS
-    ]], schema.name, "%s", select_bind_args),
+    ]], schema.table_name, "%s", select_bind_args),
 
     update_ttl = format_cql([[
       UPDATE %s USING TTL %s SET %s WHERE %s IF EXISTS
-    ]], schema.name, "%u", "%s", select_bind_args),
+    ]], schema.table_name, "%u", "%s", select_bind_args),
 
     upsert = format_cql([[
       UPDATE %s SET %s WHERE %s
-    ]], schema.name, "%s", select_bind_args),
+    ]], schema.table_name, "%s", select_bind_args),
 
     upsert_ttl = format_cql([[
       UPDATE %s USING TTL %s SET %s WHERE %s
-    ]], schema.name, "%u", "%s", select_bind_args),
+    ]], schema.table_name, "%u", "%s", select_bind_args),
 
     delete = format_cql([[
       DELETE FROM %s WHERE %s
-    ]], schema.name, select_bind_args),
+    ]], schema.table_name, select_bind_args),
   }
 end
 

--- a/kong/db/strategies/postgres/init.lua
+++ b/kong/db/strategies/postgres/init.lua
@@ -810,7 +810,7 @@ function _M.new(connector, schema, errors)
   local fields                        = {}
   local fields_hash                   = {}
 
-  local table_name                    = schema.name
+  local table_name                    = schema.table_name
   local table_name_escaped            = escape_identifier(connector, table_name)
 
   local foreign_key_list              = {}

--- a/spec/01-unit/01-db/01-schema/02-metaschema_spec.lua
+++ b/spec/01-unit/01-db/01-schema/02-metaschema_spec.lua
@@ -439,6 +439,32 @@ describe("metaschema", function()
     assert.truthy(MetaSchema:validate(s))
   end)
 
+  it("populates the 'table_name' field from 'name' if not supplied", function()
+    local s = {
+      name = "testing",
+      primary_key = { "id" },
+      fields = {
+        { id = { type = "string", }, },
+        { foo = { type = "string" }, },
+      },
+    }
+
+    assert.truthy(MetaSchema:validate(s))
+    local schema = Schema.new(s)
+
+    assert.not_nil(schema.table_name)
+    assert.equals("testing", schema.name)
+    assert.equals("testing", schema.table_name)
+
+    s.table_name = "explicit_table_name"
+    assert.truthy(MetaSchema:validate(s))
+    schema = Schema.new(s)
+
+    assert.not_nil(schema.table_name)
+    assert.equals("testing", schema.name)
+    assert.equals("explicit_table_name", schema.table_name)
+  end)
+
   describe("subschemas", function()
 
     it("supports declaring subschemas", function()

--- a/spec/02-integration/03-db/07-tags_spec.lua
+++ b/spec/02-integration/03-db/07-tags_spec.lua
@@ -447,8 +447,8 @@ for _, strategy in helpers.each_strategy() do
       func = describe
     end
     func("trigger defined for table", function()
-      for entity_name, dao in pairs(db.daos) do
-        entity_name = dao.schema.table_name
+      for _, dao in pairs(db.daos) do
+        local entity_name = dao.schema.table_name
         if dao.schema.fields.tags then
           it(entity_name, function()
             -- note: in Postgres 13, EXECUTE FUNCTION sync_tags()

--- a/spec/02-integration/03-db/07-tags_spec.lua
+++ b/spec/02-integration/03-db/07-tags_spec.lua
@@ -448,6 +448,7 @@ for _, strategy in helpers.each_strategy() do
     end
     func("trigger defined for table", function()
       for entity_name, dao in pairs(db.daos) do
+        entity_name = dao.schema.table_name
         if dao.schema.fields.tags then
           it(entity_name, function()
             -- note: in Postgres 13, EXECUTE FUNCTION sync_tags()


### PR DESCRIPTION

### Summary

Allows to define table_name field in a schema. Before the table name was deduced from the entity name.

### Full changelog

* Add `table_name` schema field

