### PR TITLE
feat(acme): add enable_ipv4_common_name option

### DIFF
--- a/kong/plugins/acme/handler.lua
+++ b/kong/plugins/acme/handler.lua
@@ -79,6 +79,10 @@ function ACMEHandler:init_worker()
 end
 
 local function check_domains(conf, host)
+  if not conf.enable_ipv4_common_name and string.find(host, "^(%d+)%.(%d+)%.(%d+)%.(%d+)$") then
+    return false
+  end
+
   if conf.allow_any_domain then
     return true
   end

--- a/kong/plugins/acme/schema.lua
+++ b/kong/plugins/acme/schema.lua
@@ -128,7 +128,7 @@ local schema = {
         }, },
         { enable_ipv4_common_name = {
           type = "boolean",
-          defailt = true,
+          default = true,
         }, },
       },
     }, },

--- a/kong/plugins/acme/schema.lua
+++ b/kong/plugins/acme/schema.lua
@@ -126,6 +126,10 @@ local schema = {
         { preferred_chain = {
           type = "string",
         }, },
+        { enable_ipv4_common_name = {
+          type = "boolean",
+          defailt = true,
+        }, },
       },
     }, },
   },

--- a/spec/03-plugins/29-acme/03-access_spec.lua
+++ b/spec/03-plugins/29-acme/03-access_spec.lua
@@ -247,6 +247,7 @@ for _, strategy in helpers.each_strategy() do
       assert(bp.plugins:insert {
         name = "acme",
         config = {
+          allow_any_domain = true,
           enable_ipv4_common_name = false,
           account_email = "test@test.com",
           api_uri = "https://api.acme.org",
@@ -313,7 +314,7 @@ for _, strategy in helpers.each_strategy() do
         headers =  { host = ip_v4_domain }
       })
       -- key-auth should take over
-      assert.response(res).has.status(404)
+      assert.response(res).has.status(401)
     end)
 
   end)

--- a/spec/03-plugins/29-acme/03-access_spec.lua
+++ b/spec/03-plugins/29-acme/03-access_spec.lua
@@ -4,6 +4,7 @@ local dummy_id = "ZR02iVO6PFywzFLj6igWHd6fnK2R07C-97dkQKC7vJo"
 
 local do_domain = "acme.noatld"
 local skip_domain = "notacme.noatld"
+local ip_v4_domain = "10.42.0.42"
 
 for _, strategy in helpers.each_strategy() do
   describe("Plugin: acme (handler.access) [#" .. strategy .. "]", function()
@@ -221,6 +222,98 @@ for _, strategy in helpers.each_strategy() do
       local body = assert.response(res).has.status(200)
       assert.equal("isme", body)
 
+    end)
+
+  end)
+
+  describe("Plugin: acme (handler.access) deny IPv4 [#" .. strategy .. "]", function()
+    local bp, db
+    local proxy_client
+
+    lazy_setup(function()
+      bp, db = helpers.get_db_utils(strategy, {
+        "certificates",
+        "snis",
+        "services",
+        "routes",
+        "plugins",
+        "acme_storage",
+      }, { "acme", })
+
+      assert(bp.routes:insert {
+        paths = { "/" },
+      })
+
+      assert(bp.plugins:insert {
+        name = "acme",
+        config = {
+          enable_ipv4_common_name = false,
+          account_email = "test@test.com",
+          api_uri = "https://api.acme.org",
+          storage = "kong",
+          domains = { do_domain, "*.subdomain." .. do_domain },
+        },
+      })
+
+      assert(bp.plugins:insert {
+        name = "key-auth",
+      })
+
+      assert(db.acme_storage:insert {
+        key = dummy_id .. "#http-01",
+        value = "isme",
+      })
+
+      assert(helpers.start_kong({
+        plugins = "bundled,acme",
+        database = strategy,
+      }))
+
+      proxy_client = helpers.proxy_client()
+    end)
+
+    lazy_teardown(function()
+      if proxy_client then
+        proxy_client:close()
+      end
+
+      helpers.stop_kong()
+    end)
+
+    it("terminates validation path", function()
+      local body
+      local res = assert( proxy_client:send {
+        method  = "GET",
+        path    = "/.well-known/acme-challenge/yay",
+        headers =  { host = do_domain }
+      })
+
+      -- key-auth should not run
+      assert.response(res).has.status(404)
+      body = res:read_body()
+      assert.match("Not found", body)
+
+      res = assert( proxy_client:send {
+        method  = "GET",
+        path    = "/.well-known/acme-challenge/" .. dummy_id,
+        headers =  { host = do_domain }
+      })
+
+      -- key-auth should not run
+      assert.response(res).has.status(200)
+      body = res:read_body()
+      assert.equal("isme\n", body)
+
+    end)
+
+    it("doesn't terminate validation path with host is an ipv4", function()
+      local res = assert( proxy_client:send {
+        method  = "GET",
+        path    = "/.well-known/acme-challenge/yay",
+        headers =  { host = ip_v4_domain }
+      })
+      -- key-auth should take over
+      assert.response(res).has.status(404)
     end)
 
   end)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Add `enable_ipv4_common_name` option to allow or deny ipv4 common names certificates. On `certificate` or `access` if the option is disabled the request is rejected, so the ACME challenge is not triggered.

This has been done on a custom plugin in Konnect to fix some gateway listening with wildcard host.
<!--- Why is this change required? What problem does it solve? -->

### Full changelog

* Add `enable_ipv4_common_name` in schema
* Add check_domains logic
* Add ip v4 access challenge test

cc @fffonion 