### PR TITLE
refactor(atc-router) use ipairs to init schema

### DIFF
--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -6,14 +6,16 @@ local CACHED_SCHEMA
 
 
 do
+  local fields = {"net.protocol", "tls.sni",
+                  "http.method", "http.host", "http.path",
+                  "http.raw_path", "http.headers.*",
+  }
+
   CACHED_SCHEMA = schema.new()
-  assert(CACHED_SCHEMA:add_field("net.protocol", "String"))
-  assert(CACHED_SCHEMA:add_field("tls.sni", "String"))
-  assert(CACHED_SCHEMA:add_field("http.method", "String"))
-  assert(CACHED_SCHEMA:add_field("http.host", "String"))
-  assert(CACHED_SCHEMA:add_field("http.path", "String"))
-  assert(CACHED_SCHEMA:add_field("http.raw_path", "String"))
-  assert(CACHED_SCHEMA:add_field("http.headers.*", "String"))
+
+  for _, v in ipairs(fields) do
+    assert(CACHED_SCHEMA:add_field(v, "String"))
+  end
 end
 
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

use `ipairs` to init schema, simplify the code.


