### PR TITLE
feat(acme): add host on certificate update log

### DIFF
--- a/kong/plugins/acme/client.lua
+++ b/kong/plugins/acme/client.lua
@@ -148,7 +148,7 @@ local function order(acme_client, host, key, cert_type, rsa_key_size)
 
   local cert, err = acme_client:order_certificate(key, host)
   if err then
-    return nil, nil, "could not create certificate: " .. err
+    return nil, nil, "could not create certificate for host: ", host, " err: " .. err
   end
 
   return cert, key, nil

--- a/kong/plugins/acme/handler.lua
+++ b/kong/plugins/acme/handler.lua
@@ -146,14 +146,14 @@ function ACMEHandler:certificate(conf)
     ngx.timer.at(0, function()
       local ok, err = client.update_certificate(conf, host, nil)
       if err then
-        kong.log.err("failed to update certificate: ", err)
+        kong.log.err("failed to update certificate for host: ", host, " err:", err)
         return
       end
       -- if not ok and err is nil, meaning the update is running by another worker
       if ok then
         err = client.store_renew_config(conf, host)
         if err then
-          kong.log.err("failed to store renew config: ", err)
+          kong.log.err("failed to store renew config for host: ", host, " err:", err)
           return
         end
       end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

When having several certs, when it fails to update there is no way to know which one is failing.

### Full changelog

* adding log entry