### PR TITLE
fix(promtheus-plugin): emit missing node_info guage stat

### DIFF
--- a/kong/plugins/prometheus/exporter.lua
+++ b/kong/plugins/prometheus/exporter.lua
@@ -61,6 +61,7 @@ local function init()
                                        "Kong Node metadata information",
                                        {"node_id", "version"},
                                        prometheus.LOCAL_STORAGE)
+  metrics.node_info:set(1, {node_id, kong.version})
   -- only export upstream health metrics in traditional mode and data plane
   if role ~= "control_plane" then
     metrics.upstream_target_health = prometheus:gauge("upstream_target_health",

--- a/spec/03-plugins/26-prometheus/04-status_api_spec.lua
+++ b/spec/03-plugins/26-prometheus/04-status_api_spec.lua
@@ -415,6 +415,7 @@ describe("Plugin: prometheus (access via status API)", function()
     assert.matches('kong_memory_workers_lua_vms_bytes{node_id="' .. UUID_PATTERN .. '",pid="%d+",kong_subsystem="stream"}', body)
 
     assert.matches('kong_nginx_metric_errors_total 0', body, nil, true)
+    assert.matches('kong_node_info{node_id="' .. UUID_PATTERN .. '",version="%S+"} 1', body)
   end)
 
   it("exposes lua_shared_dict metrics", function()


### PR DESCRIPTION
### Summary

This emits the missing initialized stat `node_info` which outputs the node_id and the current kong gateway version for prometheus to scrape using the info pattern.

### Full changelog

Adds this extra metric in the `/metrics` Prometheus endpoint
```
# HELP kong_node_info Kong Node metadata information
# TYPE kong_node_info gauge
kong_node_info{node_id="c0ba8250-7a6e-44dc-b146-b9ca9a22e47b",version="3.0.0"} 1
```