### PR TITLE
fix(clustering) fix rpc id of negotiation

### DIFF
--- a/kong/include/kong/services/negotiation/v1/negotiation.proto
+++ b/kong/include/kong/services/negotiation/v1/negotiation.proto
@@ -12,7 +12,7 @@ service NegotiationService {
   // to get which services does the DP handle.
   //
   // Call direction: DP to CP
-  // +wrpc:rpc-id=4
+  // +wrpc:rpc-id=1
   rpc NegotiateServices(kong.model.NegotiateServicesRequest) returns (kong.model.NegotiateServicesResponse);
 }
 


### PR DESCRIPTION
Should we also change the id of the service? This service is more fundamental than config.