### PR TITLE
chore(deps) bump penlight from 1.12.0 to 1.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -263,6 +263,8 @@
   [#9150](https://github.com/Kong/kong/pull/9150)
 - Bumped resty.cassandra from 1.5.1 to 1.5.2
   [#8845](https://github.com/Kong/kong/pull/8845)
+- Bumped penlight from 1.12.0 to 1.13.1
+  [#9206](https://github.com/Kong/kong/pull/9206)
 
 ### Additions
 

--- a/kong-3.0.0-0.rockspec
+++ b/kong-3.0.0-0.rockspec
@@ -15,7 +15,7 @@ dependencies = {
   "inspect == 3.1.3",
   "luasec == 1.2.0",
   "luasocket == 3.0-rc1",
-  "penlight == 1.12.0",
+  "penlight == 1.13.1",
   "lua-resty-http ~> 0.17",
   "lua-resty-jit-uuid == 0.0.7",
   "lua-ffi-zlib == 0.5",


### PR DESCRIPTION
### Summary

#### 1.13.1 (2022-Jul-22)
 - fix: `warn` unquoted argument
   [#439](https://github.com/lunarmodules/Penlight/pull/439)

#### 1.13.0 (2022-Jul-22)
 - fix: `xml.parse` returned nonsense when given a file name
   [#431](https://github.com/lunarmodules/Penlight/pull/431)
 - feat: `app.require_here` now follows symlink'd main modules to their directory
   [#423](https://github.com/lunarmodules/Penlight/pull/423)
 - fix: `pretty.write` invalid order function for sorting
   [#430](https://github.com/lunarmodules/Penlight/pull/430)
 - fix: `compat.warn` raised write guard warning in OpenResty
   [#414](https://github.com/lunarmodules/Penlight/pull/414)
 - feat: `utils.enum` now accepts hash tables, to enable better error handling
   [#413](https://github.com/lunarmodules/Penlight/pull/413)
 - feat: `utils.kpairs` new iterator over all non-integer keys
   [#413](https://github.com/lunarmodules/Penlight/pull/413)
 - fix: `warn` use rawget to not trigger strict-checkers
   [#437](https://github.com/lunarmodules/Penlight/pull/437)
 - fix: `lapp` provides the file name when using the default argument
   [#427](https://github.com/lunarmodules/Penlight/pull/427)
 - fix: `lapp` positional arguments now allow digits after the first character
   [#428](https://github.com/lunarmodules/Penlight/pull/428)
 - fix: `path.isdir` windows root directories (including drive letter) were not considered valid
   [#436](https://github.com/lunarmodules/Penlight/pull/436)