### PR TITLE
chore(deps) bump lua-protobuf from 0.3.3 to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -265,6 +265,8 @@
   [#8845](https://github.com/Kong/kong/pull/8845)
 - Bumped penlight from 1.12.0 to 1.13.1
   [#9206](https://github.com/Kong/kong/pull/9206)
+- Bumped protobuf from 0.3.3 to 0.4.0
+  [#9207](https://github.com/Kong/kong/pull/9207)
 
 ### Additions
 

--- a/kong-3.0.0-0.rockspec
+++ b/kong-3.0.0-0.rockspec
@@ -31,7 +31,7 @@ dependencies = {
   "lua_pack == 2.0.0",
   "binaryheap >= 0.4",
   "luaxxhash >= 1.0",
-  "lua-protobuf == 0.3.3",
+  "lua-protobuf == 0.4.0",
   "lua-resty-worker-events == 1.0.0",
   "lua-resty-healthcheck == 1.6.1",
   "lua-resty-mlcache == 2.5.0",


### PR DESCRIPTION
### Summary

#### 0.4.0

* add encode_default_values
* add encode_order
* add oneof name field for which field is decoded
* check stack before push default values
* refactor the logic for setting default value
* fix option support in protoc.lua
* fix wrong error message when use varint as map
* fix decode hooks check
* fix msvc warnings

#### 0.3.4

* fix memory leak in pb.load
* fix bugs in "protoc.lua"
* fix memory usage in messages contains oneof
* code improved