### PR TITLE
fix(db) use a checksum to limit unique key length

### DIFF
--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -10,6 +10,8 @@ local constants = require "kong.constants"
 local txn = require "resty.lmdb.transaction"
 local lmdb = require "resty.lmdb"
 local on_the_fly_migration = require "kong.db.declarative.migrations"
+local to_hex = require("resty.string").to_hex
+local sha1 = require "resty.sha1"
 
 local setmetatable = setmetatable
 local tostring = tostring
@@ -633,6 +635,32 @@ local function find_default_ws(entities)
   end
 end
 
+local sha1sum
+do
+  local sum = sha1:new()
+
+  function sha1sum(s)
+    sum:reset()
+    sum:update(s)
+    return to_hex(sum:final())
+  end
+end
+
+local function unique_field_key(schema_name, ws_id, field, value, unique_across_ws)
+  if unique_across_ws then
+    ws_id = ""
+  end
+
+  -- LMDB imposes a default limit of 511 for keys, but the length of our unique
+  -- value might be unbounded, so we'll use a checksum instead of the raw value
+  value = sha1sum(tostring(value))
+
+  return schema_name .. "|" .. ws_id .. "|" .. field .. ":" .. value
+end
+
+declarative.unique_field_key = unique_field_key
+
+
 
 -- entities format:
 --   {
@@ -785,13 +813,10 @@ function declarative.load_into_cache(entities, meta, hash)
             _, unique_key = next(unique_key)
           end
 
-          local prefix = entity_name .. "|" .. ws_id
-          if schema.fields[unique].unique_across_ws then
-            prefix = entity_name .. "|"
-          end
+          local key = unique_field_key(entity_name, ws_id, unique, unique_key,
+                                       schema.fields[unique].unique_across_ws)
 
-          local unique_cache_key = prefix .. "|" .. unique .. ":" .. unique_key
-          t:set(unique_cache_key, item_marshalled)
+          t:set(key, item_marshalled)
         end
       end
 

--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -11,7 +11,7 @@ local txn = require "resty.lmdb.transaction"
 local lmdb = require "resty.lmdb"
 local on_the_fly_migration = require "kong.db.declarative.migrations"
 local to_hex = require("resty.string").to_hex
-local sha1 = require "resty.sha1"
+local resty_sha256 = require "resty.sha256"
 
 local setmetatable = setmetatable
 local tostring = tostring
@@ -635,13 +635,13 @@ local function find_default_ws(entities)
   end
 end
 
-local sha1sum
+local sha256
 do
-  local sum = sha1:new()
+  local sum = resty_sha256:new()
 
-  function sha1sum(s)
+  function sha256(s)
     sum:reset()
-    sum:update(s)
+    sum:update(tostring(s))
     return to_hex(sum:final())
   end
 end
@@ -653,7 +653,7 @@ local function unique_field_key(schema_name, ws_id, field, value, unique_across_
 
   -- LMDB imposes a default limit of 511 for keys, but the length of our unique
   -- value might be unbounded, so we'll use a checksum instead of the raw value
-  value = sha1sum(tostring(value))
+  value = sha256(value)
 
   return schema_name .. "|" .. ws_id .. "|" .. field .. ":" .. value
 end

--- a/spec/01-unit/01-db/10-declarative_spec.lua
+++ b/spec/01-unit/01-db/10-declarative_spec.lua
@@ -2,8 +2,17 @@ require("spec.helpers") -- for kong.log
 local declarative = require "kong.db.declarative"
 local conf_loader = require "kong.conf_loader"
 
+local to_hex = require("resty.string").to_hex
+local resty_sha1 = require "resty.sha1"
 
 local null = ngx.null
+
+
+local function sha1(s)
+  local sha = resty_sha1:new()
+  sha:update(s)
+  return to_hex(sha:final())
+end
 
 
 describe("declarative", function()
@@ -46,4 +55,20 @@ keyauth_credentials:
 
     assert.is_nil(entities.keyauth_credentials['3f9066ef-b91b-4d1d-a05a-28619401c1ad'].ttl)
   end)
+
+  describe("unique_field_key()", function()
+    local unique_field_key = declarative.unique_field_key
+
+    it("utilizes the schema name, workspace id, field name, and checksum of the field value", function()
+      local key = unique_field_key("services", "123", "fieldname", "test", false)
+      assert.is_string(key)
+      assert.equals("services|123|fieldname:" .. sha1("test"), key)
+    end)
+
+    it("omits the workspace id when 'unique_across_ws' is 'true'", function()
+      local key = unique_field_key("services", "123", "fieldname", "test", true)
+      assert.equals("services||fieldname:" .. sha1("test"), key)
+    end)
+  end)
+
 end)

--- a/spec/01-unit/01-db/10-declarative_spec.lua
+++ b/spec/01-unit/01-db/10-declarative_spec.lua
@@ -3,17 +3,16 @@ local declarative = require "kong.db.declarative"
 local conf_loader = require "kong.conf_loader"
 
 local to_hex = require("resty.string").to_hex
-local resty_sha1 = require "resty.sha1"
+local resty_sha256 = require "resty.sha256"
 
 local null = ngx.null
 
 
-local function sha1(s)
-  local sha = resty_sha1:new()
+local function sha256(s)
+  local sha = resty_sha256:new()
   sha:update(s)
   return to_hex(sha:final())
 end
-
 
 describe("declarative", function()
   describe("parse_string", function()
@@ -62,12 +61,12 @@ keyauth_credentials:
     it("utilizes the schema name, workspace id, field name, and checksum of the field value", function()
       local key = unique_field_key("services", "123", "fieldname", "test", false)
       assert.is_string(key)
-      assert.equals("services|123|fieldname:" .. sha1("test"), key)
+      assert.equals("services|123|fieldname:" .. sha256("test"), key)
     end)
 
     it("omits the workspace id when 'unique_across_ws' is 'true'", function()
       local key = unique_field_key("services", "123", "fieldname", "test", true)
-      assert.equals("services||fieldname:" .. sha1("test"), key)
+      assert.equals("services||fieldname:" .. sha256("test"), key)
     end)
   end)
 


### PR DESCRIPTION
### Summary

LMDB has a (compile-time) max key length limitation of 511. It's easy to exceed this limit when generating unique field indexes in dbless, since they use the [potentially unbounded] field value as part of the key.

With this update, we use a sha1 checksum of the field value instead of just the raw value itself in order to limit the key length.

There is definitely a non-zero performance cost to this, but I don't see any way around that. And we can't easily get much cheaper than sha1.