### PR TITLE
fix(router) atc-router ignores default port

### DIFF
--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -6,15 +6,23 @@ local CACHED_SCHEMA
 
 
 do
-  local fields = {"net.protocol", "tls.sni",
-                  "http.method", "http.host", "http.path",
-                  "http.raw_path", "http.headers.*",
+  local str_fields = {"net.protocol", "tls.sni",
+                      "http.method", "http.host",
+                      "http.path", "http.raw_path",
+                      "http.headers.*",
+  }
+
+  local int_fields = {"net.port",
   }
 
   CACHED_SCHEMA = schema.new()
 
-  for _, v in ipairs(fields) do
+  for _, v in ipairs(str_fields) do
     assert(CACHED_SCHEMA:add_field(v, "String"))
+  end
+
+  for _, v in ipairs(int_fields) do
+    assert(CACHED_SCHEMA:add_field(v, "Int"))
   end
 end
 

--- a/kong/router/atc_compat.lua
+++ b/kong/router/atc_compat.lua
@@ -228,10 +228,10 @@ local function get_atc(route)
   end, route.paths, function(op, p)
     if op == OP_REGEX then
       -- Rust only recognize form '?P<>'
-      return sub(p, 2):gsub("?<", "?P<"):gsub("\\", "\\\\")
+      return (sub(p, 2):gsub("?<", "?P<"):gsub("\\", "\\\\"))
     end
 
-    return normalize(p, true)
+    return (normalize(p, true))
   end)
   if gen then
     tb_insert(out, gen)
@@ -444,16 +444,7 @@ function _M:select(req_method, req_uri, req_host, req_scheme,
       assert(c:add_value("http.path", req_uri))
 
     elseif req_host and field == "http.host" then
-      assert(c:add_value("http.host", req_host))
-      --local host = req_host
-
-      ---- ignores default port
-      --local default_port = req_scheme == "https" and ":443" or ":80"
-      --if sub(req_host, -#default_port) == default_port then
-      --  host = sub(req_host, 1, -#default_port - 1)
-      --end
-
-      --assert(c:add_value("http.host", host))
+      assert(c:add_value("http.host", split_host_port(req_host)))
 
     elseif field == "net.protocol" then
       assert(c:add_value("net.protocol", req_scheme))

--- a/kong/router/atc_compat.lua
+++ b/kong/router/atc_compat.lua
@@ -388,6 +388,11 @@ function _M.new(routes, cache, cache_neg)
   for _, r in ipairs(routes) do
     local route = r.route
     local route_id = route.id
+
+    if not route_id then
+      return nil, "could not categorize route"
+    end
+
     routes_t[route_id] = route
     services_t[route_id] = r.service
 

--- a/kong/router/atc_compat.lua
+++ b/kong/router/atc_compat.lua
@@ -442,6 +442,12 @@ function _M:select(req_method, req_uri, req_host, req_scheme,
       assert(c:add_value("http.path", req_uri))
 
     elseif host and field == "http.host" then
+      -- ignores default port
+      local default_port = req_scheme == "https" and ":443" or ":80"
+      if sub(host, -#default_port) == default_port then
+        host = sub(host, 1, -#default_port - 1)
+      end
+
       assert(c:add_value("http.host", host))
 
     elseif port and field == "net.port" then

--- a/kong/router/atc_compat.lua
+++ b/kong/router/atc_compat.lua
@@ -142,9 +142,9 @@ local function gen_for_field(name, op, vals, val_transform)
 
     if val then
       values_n = values_n + 1
-      values[values_n] = name .. " " .. op ..
+      values[values_n] = name .. " " .. op .. " " ..
                          (type(val) == "number" and val or
-                                      (" \"" .. val .. "\""))
+                                      ("\"" .. val .. "\""))
     end
   end
 

--- a/kong/router/atc_compat.lua
+++ b/kong/router/atc_compat.lua
@@ -409,7 +409,7 @@ function _M:select(req_method, req_uri, req_host, req_scheme,
       local host = req_host
 
       -- ignores default port
-      local default_port = ":" .. (req_scheme == "https" and 443 or 80)
+      local default_port = req_scheme == "https" and ":443" or ":80"
       if sub(req_host, -#default_port) == default_port then
         host = sub(req_host, 1, -#default_port - 1)
       end

--- a/kong/router/atc_compat.lua
+++ b/kong/router/atc_compat.lua
@@ -46,7 +46,7 @@ local get_upstream_uri_v0  = utils.get_upstream_uri_v0
 
 
 local TILDE            = byte("~")
-local ASTER            = byte("*")
+local ASTERISK         = byte("*")
 local MAX_HEADER_COUNT = 255
 local MAX_REQ_HEADERS  = 100
 
@@ -192,12 +192,12 @@ local function get_atc(route)
       local host, port = split_host_port(h)
 
       local op = OP_EQUAL
-      if byte(host) == ASTER then
+      if byte(host) == ASTERISK then
         -- postfix matching
         op = OP_POSTFIX
         host = host:sub(2)
 
-      elseif byte(host, -1) == ASTER then
+      elseif byte(host, -1) == ASTERISK then
         -- prefix matching
         op = OP_PREFIX
         host = host:sub(1, -2)
@@ -397,7 +397,6 @@ function _M.new(routes, cache, cache_neg)
     services_t[route_id] = r.service
 
     if is_traditional_compatible then
-      --print("atc:", get_atc(route))
       assert(inst:add_matcher(route_priority(route), route_id, get_atc(route)))
 
     else

--- a/kong/router/atc_compat.lua
+++ b/kong/router/atc_compat.lua
@@ -446,12 +446,6 @@ function _M:select(req_method, req_uri, req_host, req_scheme,
       assert(c:add_value("http.path", req_uri))
 
     elseif host and field == "http.host" then
-      -- ignores default port
-      local default_port = req_scheme == "https" and ":443" or ":80"
-      if sub(host, -#default_port) == default_port then
-        host = sub(host, 1, -#default_port - 1)
-      end
-
       assert(c:add_value("http.host", host))
 
     elseif port and field == "net.port" then

--- a/kong/router/atc_compat.lua
+++ b/kong/router/atc_compat.lua
@@ -405,8 +405,16 @@ function _M:select(req_method, req_uri, req_host, req_scheme,
     elseif field == "http.path" then
       assert(c:add_value("http.path", req_uri))
 
-    elseif field == "http.host" then
-      assert(c:add_value("http.host", req_host))
+    elseif field == "http.host" and req_host then
+      local host = req_host
+
+      -- ignores default port
+      local default_port = ":" .. (req_scheme == "https" and 443 or 80)
+      if sub(req_host, -#default_port) == default_port then
+        host = sub(req_host, 1, -#default_port - 1)
+      end
+
+      assert(c:add_value("http.host", host))
 
     elseif field == "net.protocol" then
       assert(c:add_value("net.protocol", req_scheme))

--- a/kong/router/atc_compat.lua
+++ b/kong/router/atc_compat.lua
@@ -46,6 +46,7 @@ local get_upstream_uri_v0  = utils.get_upstream_uri_v0
 
 
 local TILDE            = byte("~")
+local ASTER            = byte("*")
 local MAX_HEADER_COUNT = 255
 local MAX_REQ_HEADERS  = 100
 
@@ -191,12 +192,12 @@ local function get_atc(route)
       local host, port = split_host_port(h)
 
       local op = OP_EQUAL
-      if host:sub(1, 1) == "*" then
+      if byte(host) == ASTER then
         -- postfix matching
         op = OP_POSTFIX
         host = host:sub(2)
 
-      elseif host:sub(-1) == "*" then
+      elseif byte(host, -1) == ASTER then
         -- prefix matching
         op = OP_PREFIX
         host = host:sub(1, -2)

--- a/kong/router/atc_compat.lua
+++ b/kong/router/atc_compat.lua
@@ -158,6 +158,24 @@ local function get_atc(route)
     tb_insert(out, gen)
   end
 
+  -- split port in host, ignore form '[...]'
+  local gen = gen_for_field("net.port", OP_EQUAL, route.hosts, function(host)
+    local p = find(host, ":", 1, true)
+    if not p then
+      return nil
+    end
+
+    local port = tonumber(host:sub(p + 1))
+    if not port then
+      return nil
+    end
+
+    return port
+  end)
+  if gen then
+    tb_insert(out, gen)
+  end
+
   local gen = gen_for_field("http.host", function(host)
     if host:sub(1, 1) == "*" then
       -- postfix matching

--- a/kong/router/atc_compat.lua
+++ b/kong/router/atc_compat.lua
@@ -132,7 +132,6 @@ local function gen_for_field(name, op, vals, val_transform)
   local values   = gen_values_t
 
   for _, p in ipairs(vals) do
-    values_n = values_n + 1
 
     local op = (type(op) == "string") and op or op(p)
 
@@ -142,7 +141,10 @@ local function gen_for_field(name, op, vals, val_transform)
     end
 
     if val then
-      values[values_n] = name .. " " .. op ..  " \"" .. val .. "\""
+      values_n = values_n + 1
+      values[values_n] = name .. " " .. op ..
+                         (type(val) == "number" and val or
+                                      (" \"" .. val .. "\""))
     end
   end
 
@@ -182,7 +184,9 @@ local function get_atc(route)
     tb_insert(out, gen)
   end
 
-  local gen = gen_for_field("net.port", OP_EQUAL, route.hosts, get_host_port)
+  local gen = gen_for_field("net.port", OP_EQUAL, route.hosts, function(op, p)
+    return get_host_port(p)
+  end)
   if gen then
     tb_insert(out, gen)
   end
@@ -390,6 +394,7 @@ function _M.new(routes, cache, cache_neg)
     services_t[route_id] = r.service
 
     if is_traditional_compatible then
+      --print("atc:", get_atc(route))
       assert(inst:add_matcher(route_priority(route), route_id, get_atc(route)))
 
     else

--- a/kong/router/atc_compat.lua
+++ b/kong/router/atc_compat.lua
@@ -78,7 +78,7 @@ end
 
 -- split port in host, ignore form '[...]'
 local function get_host_port(host)
-  local p = find(host, ":", 1, true)
+  local p = host:find(":", nil, true)
   if not p then
     return nil
   end
@@ -436,7 +436,7 @@ function _M:select(req_method, req_uri, req_host, req_scheme,
     elseif field == "http.path" then
       assert(c:add_value("http.path", req_uri))
 
-    elseif field == "http.host" and req_host then
+    elseif req_host and field == "http.host" then
       assert(c:add_value("http.host", req_host))
       --local host = req_host
 
@@ -451,10 +451,13 @@ function _M:select(req_method, req_uri, req_host, req_scheme,
     elseif field == "net.protocol" then
       assert(c:add_value("net.protocol", req_scheme))
 
-    elseif field == "net.port" then
-      assert(c:add_value("net.port", req_scheme))
+    elseif req_host and field == "net.port" then
+      local port = get_host_port(req_host)
+      if port then
+        assert(c:add_value("net.port", port))
+      end
 
-    elseif field == "tls.sni" then
+    elseif sni and field == "tls.sni" then
       assert(c:add_value("tls.sni", sni))
 
     elseif req_headers and field:sub(1, 13) == "http.headers." then

--- a/kong/router/atc_compat.lua
+++ b/kong/router/atc_compat.lua
@@ -445,16 +445,16 @@ function _M:select(req_method, req_uri, req_host, req_scheme,
     elseif field == "http.path" then
       assert(c:add_value("http.path", req_uri))
 
-    elseif host and field == "http.host" then
+    elseif field == "http.host" then
       assert(c:add_value("http.host", host))
 
-    elseif port and field == "net.port" then
+    elseif field == "net.port" then
      assert(c:add_value("net.port", port))
 
     elseif field == "net.protocol" then
       assert(c:add_value("net.protocol", req_scheme))
 
-    elseif sni and field == "tls.sni" then
+    elseif field == "tls.sni" then
       assert(c:add_value("tls.sni", sni))
 
     elseif req_headers and field:sub(1, 13) == "http.headers." then

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -347,23 +347,27 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible" }) do
         assert.same(nil, match_t.matches.uri_captures)
       end)
 
-      it_trad_only("[host] matches specific port", function()
+      it("[host] matches specific port", function()
         -- host
         local match_t = router:select("GET", "/", "domain-1.org:321")
         assert.truthy(match_t)
         assert.same(use_case[13].route, match_t.route)
-        assert.same(use_case[13].route.hosts[1], match_t.matches.host)
+        if flavor == "traditional" then
+          assert.same(use_case[13].route.hosts[1], match_t.matches.host)
+        end
         assert.same(nil, match_t.matches.method)
         assert.same(nil, match_t.matches.uri)
         assert.same(nil, match_t.matches.uri_captures)
       end)
 
-      it_trad_only("[host] matches specific port on port-only route", function()
+      it("[host] matches specific port on port-only route", function()
         -- host
         local match_t = router:select("GET", "/", "domain-3.org:321")
         assert.truthy(match_t)
         assert.same(use_case[14].route, match_t.route)
-        assert.same(use_case[14].route.hosts[1], match_t.matches.host)
+        if flavor == "traditional" then
+          assert.same(use_case[14].route.hosts[1], match_t.matches.host)
+        end
         assert.same(nil, match_t.matches.method)
         assert.same(nil, match_t.matches.uri)
         assert.same(nil, match_t.matches.uri_captures)

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -1186,10 +1186,11 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible" }) do
           assert.same(use_case[4].route, match_t.route)
         end)
 
-        it_trad_only("prefers port-specific even for http default port", function()
+        it("prefers port-specific even for http default port", function()
           table.insert(use_case, {
             service = service,
             route   = {
+              id = "e8fb37f1-102d-461e-9c51-6608a6bb8103",
               hosts = { "route.*:80" },    -- same as [2] but port-specific
             },
           })
@@ -1209,8 +1210,10 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible" }) do
           assert.same(use_case[3].route, match_t.route)
 
           -- even if it's implicit port 80
-          local match_t = assert(router:select("GET", "/", "route.org"))
-          assert.same(use_case[3].route, match_t.route)
+          if flavor == "traditional" then
+            local match_t = assert(router:select("GET", "/", "route.org"))
+            assert.same(use_case[3].route, match_t.route)
+          end
         end)
 
         it_trad_only("prefers port-specific even for https default port", function()

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -369,7 +369,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible" }) do
         assert.same(nil, match_t.matches.uri_captures)
       end)
 
-      it_trad_only("[host] fails just because of port on port-only route", function()
+      it("[host] fails just because of port on port-only route", function()
         -- host
         local match_t = router:select("GET", "/", "domain-3.org:123")
         assert.falsy(match_t)

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -324,7 +324,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible" }) do
         assert.same(nil, match_t.matches.uri_captures)
       end)
 
-      it("[host] ignores default port", function()
+      it("#only [host] ignores default port", function()
         -- host
         local match_t = router:select("GET", "/", "domain-1.org:80")
         assert.truthy(match_t)

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -633,7 +633,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible" }) do
         end
       end)
 
-      it_trad_only("[serviceless]", function()
+      it("[serviceless]", function()
         local match_t = router:select("GET", "/serviceless")
         assert.truthy(match_t)
         assert.is_nil(match_t.service)

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -1149,16 +1149,18 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible" }) do
           assert.same(use_case[1].route, match_t.route)
         end)
 
-        it_trad_only("matches port-specific routes", function()
+        it("matches port-specific routes", function()
           table.insert(use_case, {
             service = service,
             route   = {
+              id = "e8fb37f1-102d-461e-9c51-6608a6bb8103",
               hosts = { "*.route.net:123" },
             },
           })
           table.insert(use_case, {
             service = service,
             route   = {
+              id = "e8fb37f1-102d-461e-9c51-6608a6bb8104",
               hosts = { "route.*:123" },    -- same as [2] but port-specific
             },
           })

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -1378,7 +1378,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible" }) do
           assert.same(nil, match_t.matches.uri_captures)
         end)
 
-        it_trad_only("submatch_weight [wildcard host port] > [wildcard host] ", function()
+        it("submatch_weight [wildcard host port] > [wildcard host] ", function()
           local use_case = {
             {
               service = service,
@@ -1401,7 +1401,9 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible" }) do
           local match_t = router:select("GET", "/", "route.org:80")
           assert.truthy(match_t)
           assert.same(use_case[2].route, match_t.route)
-          assert.same("route.*:80", match_t.matches.host)
+          if flavor == "traditional" then
+            assert.same("route.*:80", match_t.matches.host)
+          end
           assert.same(nil, match_t.matches.method)
           assert.same(nil, match_t.matches.uri)
           assert.same(nil, match_t.matches.uri_captures)

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -324,7 +324,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible" }) do
         assert.same(nil, match_t.matches.uri_captures)
       end)
 
-      it_trad_only("[host] ignores default port", function()
+      it("[host] ignores default port", function()
         -- host
         local match_t = router:select("GET", "/", "domain-1.org:80")
         assert.truthy(match_t)

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -1216,10 +1216,11 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible" }) do
           end
         end)
 
-        it_trad_only("prefers port-specific even for https default port", function()
+        it("prefers port-specific even for https default port", function()
           table.insert(use_case, {
             service = service,
             route   = {
+              id = "e8fb37f1-102d-461e-9c51-6608a6bb8103",
               hosts = { "route.*:443" },    -- same as [2] but port-specific
             },
           })
@@ -1234,13 +1235,15 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible" }) do
           local match_t = assert(router:select("GET", "/", "route.org:123"))
           assert.same(use_case[2].route, match_t.route)
 
-          -- port 80 goes to port-specific route
+          -- port 443 goes to port-specific route
           local match_t = assert(router:select("GET", "/", "route.org:443"))
           assert.same(use_case[3].route, match_t.route)
 
-          -- even if it's implicit port 80
-          local match_t = assert(router:select("GET", "/", "route.org", "https"))
-          assert.same(use_case[3].route, match_t.route)
+          -- even if it's implicit port 443
+          if flavor == "traditional" then
+            local match_t = assert(router:select("GET", "/", "route.org", "https"))
+            assert.same(use_case[3].route, match_t.route)
+          end
         end)
 
         it("does not take precedence over a plain host", function()

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -324,12 +324,14 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible" }) do
         assert.same(nil, match_t.matches.uri_captures)
       end)
 
-      it_trad_only("[host] ignores default port", function()
+      it("[host] ignores default port", function()
         -- host
         local match_t = router:select("GET", "/", "domain-1.org:80")
         assert.truthy(match_t)
         assert.same(use_case[1].route, match_t.route)
-        assert.same(use_case[1].route.hosts[1], match_t.matches.host)
+        if flavor == "traditional" then
+          assert.same(use_case[1].route.hosts[1], match_t.matches.host)
+        end
         assert.same(nil, match_t.matches.method)
         assert.same(nil, match_t.matches.uri)
         assert.same(nil, match_t.matches.uri_captures)

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -1447,7 +1447,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible" }) do
 
           -- implicit port
           if flavor == "traditional" then
-          local match_t = router:select("GET", "/", "route.org")
+            local match_t = router:select("GET", "/", "route.org")
             assert.truthy(match_t)
             assert.same(use_case[3].route, match_t.route)
             assert.same("route.*:80", match_t.matches.host)

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -76,7 +76,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible" }) do
           end, "expected arg #1 routes to be a table", nil, true)
         end)
 
-        it_trad_only("enforces routes fields types", function()
+        it("enforces routes fields types", function()
           local router, err = Router.new {
             {
               route   = {

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -324,7 +324,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible" }) do
         assert.same(nil, match_t.matches.uri_captures)
       end)
 
-      it("#only [host] ignores default port", function()
+      it_trad_only("[host] ignores default port", function()
         -- host
         local match_t = router:select("GET", "/", "domain-1.org:80")
         assert.truthy(match_t)

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -1139,7 +1139,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible" }) do
           assert.same(use_case[2].route, match_t.route)
         end)
 
-        it_trad_only("matches any port in request", function()
+        it("matches any port in request", function()
           local match_t = router:select("GET", "/", "route.org:123")
           assert.truthy(match_t)
           assert.same(use_case[2].route, match_t.route)

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -1409,7 +1409,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible" }) do
           assert.same(nil, match_t.matches.uri_captures)
         end)
 
-        it_trad_only("matches a [wildcard host + port] even if a [wildcard host] matched", function()
+        it("matches a [wildcard host + port] even if a [wildcard host] matched", function()
           local use_case = {
             {
               service = service,
@@ -1440,19 +1440,23 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible" }) do
           local match_t = router:select("GET", "/", "route.org:123")
           assert.truthy(match_t)
           assert.same(use_case[2].route, match_t.route)
-          assert.same("route.*:123", match_t.matches.host)
+          if flavor == "traditional" then
+            assert.same("route.*:123", match_t.matches.host)
+          end
           assert.same(nil, match_t.matches.method)
           assert.same(nil, match_t.matches.uri)
           assert.same(nil, match_t.matches.uri_captures)
 
           -- implicit port
+          if flavor == "traditional" then
           local match_t = router:select("GET", "/", "route.org")
-          assert.truthy(match_t)
-          assert.same(use_case[3].route, match_t.route)
-          assert.same("route.*:80", match_t.matches.host)
-          assert.same(nil, match_t.matches.method)
-          assert.same(nil, match_t.matches.uri)
-          assert.same(nil, match_t.matches.uri_captures)
+            assert.truthy(match_t)
+            assert.same(use_case[3].route, match_t.route)
+            assert.same("route.*:80", match_t.matches.host)
+            assert.same(nil, match_t.matches.method)
+            assert.same(nil, match_t.matches.uri)
+            assert.same(nil, match_t.matches.uri_captures)
+          end
         end)
 
         it("matches [wildcard/plain + uri + method]", function()

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -3219,7 +3219,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible" }) do
             assert.equal(host, match_t.upstream_host)
           end)
 
-          it_trad_only("uses the request's Host header incl. port", function()
+          it("uses the request's Host header incl. port", function()
             local _ngx = mock_ngx("GET", "/", { host = host .. ":123" })
             router._set_ngx(_ngx)
             local match_t = router:exec()
@@ -3359,7 +3359,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible" }) do
             assert.equal("grpc", match_t.service.protocol)
           end)
 
-          it_trad_only("uses the request's Host header incl. port", function()
+          it("uses the request's Host header incl. port", function()
             local _ngx = mock_ngx("GET", "/", { host = host .. ":123" })
             router._set_ngx(_ngx)
             local match_t = router:exec()

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -500,15 +500,15 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible" }) do
           assert.same({ location = "my-location-2" }, match_t.matches.headers)
         end
 
+        local match_t = router:select("GET", "/", nil, "http", nil, nil, nil, nil, nil, {
+          location = { "my-location-3", "my-location-2" }
+        })
+        assert.truthy(match_t)
+        assert.same(use_case[9].route, match_t.route)
+        assert.same(nil, match_t.matches.method)
+        assert.same(nil, match_t.matches.uri)
+        assert.same(nil, match_t.matches.uri_captures)
         if flavor == "traditional" then
-          local match_t = router:select("GET", "/", nil, "http", nil, nil, nil, nil, nil, {
-            location = { "my-location-3", "my-location-2" }
-          })
-          assert.truthy(match_t)
-          assert.same(use_case[9].route, match_t.route)
-          assert.same(nil, match_t.matches.method)
-          assert.same(nil, match_t.matches.uri)
-          assert.same(nil, match_t.matches.uri_captures)
           assert.same({ location = "my-location-2" }, match_t.matches.headers)
         end
 
@@ -517,12 +517,10 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible" }) do
         })
         assert.is_nil(match_t)
 
-        if flavor == "traditional" then
-          local match_t = router:select("GET", "/", nil, "http", nil, nil, nil, nil, nil, {
-            location = { "my-location-3", "foo" }
-          })
-          assert.is_nil(match_t)
-        end
+        local match_t = router:select("GET", "/", nil, "http", nil, nil, nil, nil, nil, {
+          location = { "my-location-3", "foo" }
+        })
+        assert.is_nil(match_t)
 
         local match_t = router:select("GET", "/", nil, "http", nil, nil, nil, nil, nil, {
           user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36"
@@ -567,31 +565,31 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible" }) do
                         match_t.matches.headers)
         end
 
+        local match_t = router:select("GET", "/", nil, "http", nil, nil, nil, nil, nil, {
+          location = { "my-location-3", "my-location-1" },
+          version = "v2",
+        })
+        assert.truthy(match_t)
+        assert.same(use_case[10].route, match_t.route)
+        assert.same(nil, match_t.matches.method)
+        assert.same(nil, match_t.matches.uri)
+        assert.same(nil, match_t.matches.uri_captures)
         if flavor == "traditional" then
-          local match_t = router:select("GET", "/", nil, "http", nil, nil, nil, nil, nil, {
-            location = { "my-location-3", "my-location-1" },
-            version = "v2",
-          })
-          assert.truthy(match_t)
-          assert.same(use_case[10].route, match_t.route)
-          assert.same(nil, match_t.matches.method)
-          assert.same(nil, match_t.matches.uri)
-          assert.same(nil, match_t.matches.uri_captures)
           assert.same({ location = "my-location-1", version = "v2", },
                         match_t.matches.headers)
         end
 
+        local match_t = router:select("GET", "/", nil, "http", nil, nil, nil, nil, nil, {
+          location = { "my-location-3", "my-location-2" },
+          version = "v2",
+        })
+        -- fallback to Route 9
+        assert.truthy(match_t)
+        assert.same(use_case[9].route, match_t.route)
+        assert.same(nil, match_t.matches.method)
+        assert.same(nil, match_t.matches.uri)
+        assert.same(nil, match_t.matches.uri_captures)
         if flavor == "traditional" then
-          local match_t = router:select("GET", "/", nil, "http", nil, nil, nil, nil, nil, {
-            location = { "my-location-3", "my-location-2" },
-            version = "v2",
-          })
-          -- fallback to Route 9
-          assert.truthy(match_t)
-          assert.same(use_case[9].route, match_t.route)
-          assert.same(nil, match_t.matches.method)
-          assert.same(nil, match_t.matches.uri)
-          assert.same(nil, match_t.matches.uri_captures)
           assert.same({ location = "my-location-2" }, match_t.matches.headers)
         end
       end)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

* Strip default port in http.host, then pass it to atc-router, 
so atc-router can match host with default port.
* Add a `net.port` and split host:port
* Enable some test cases.




