### PR TITLE
chore(conf) remove warning on experimental `AAAA` in `dns_order` configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,6 +221,7 @@
 
 - Change the default of `lua_ssl_trusted_certificate` to `system`
   [#8602](https://github.com/Kong/kong/pull/8602) to automatically load trusted CA list from system CA store.
+- Remove a warning of `AAAA` being experimental with `dns_order`.
 
 #### Migrations
 

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -876,18 +876,13 @@ local function check_and_infer(conf, opts)
   end
 
   if conf.dns_order then
-    local allowed = { LAST = true, A = true, CNAME = true,
-                      SRV = true, AAAA = true }
+    local allowed = { LAST = true, A = true, AAAA = true,
+                      CNAME = true, SRV = true }
 
     for _, name in ipairs(conf.dns_order) do
       if not allowed[upper(name)] then
         errors[#errors + 1] = fmt("dns_order: invalid entry '%s'",
                                   tostring(name))
-      end
-      if upper(name) == "AAAA" then
-        log.warn("the 'dns_order' configuration property specifies the " ..
-                 "experimental IPv6 entry 'AAAA'")
-
       end
     end
   end


### PR DESCRIPTION
### Summary

We added the feature and warning on 8 Sep 2021 (see #7819), and we have not heard reports on it (perhaps because it was not turned on by default). Thus I removed the warning of the feature being experimental, and now it is considered a fully supported one (though I didn't enable it yet by default).