### PR TITLE
fix(cli) add support for `-c`/`--conf` and `-p`/`--prefix` options to `kong vault` commands

### DIFF
--- a/kong/cmd/vault.lua
+++ b/kong/cmd/vault.lua
@@ -95,6 +95,8 @@ The available commands are:
   get <reference>  Retrieves a value for <reference>
 
 Options:
+ -c,--conf  (optional string)  configuration file
+
 ]]
 
 

--- a/kong/cmd/vault.lua
+++ b/kong/cmd/vault.lua
@@ -95,8 +95,8 @@ The available commands are:
   get <reference>  Retrieves a value for <reference>
 
 Options:
- -c,--conf  (optional string)  configuration file
-
+ -c,--conf    (optional string)  configuration file
+ -p,--prefix  (optional string)  override prefix directory
 ]]
 
 


### PR DESCRIPTION
### Summary

- Adds support for `-c` and `--conf` options to `kong vault` commands.
- Adds support for `-p` and `--prefix` options to `kong vault` commands.