### PR TITLE
refactor(router/atc) optimize get_headers_key

### DIFF
--- a/kong/router/atc_compat.lua
+++ b/kong/router/atc_compat.lua
@@ -523,12 +523,7 @@ function _M:exec(ctx)
 
   headers["host"] = nil
 
-  local idx = find(req_uri, "?", 2, true)
-  if idx then
-    req_uri = sub(req_uri, 1, idx - 1)
-  end
-
-  req_uri = normalize(req_uri, true)
+  req_uri = strip_uri_args(req_uri)
 
   -- cache lookup
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

use `table.new` and reuse table object when we calculate headers cache key

