### PR TITLE
fix(db) keep the $refs for the existing fields when process auto fields is called

### DIFF
--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1659,6 +1659,7 @@ function Schema:process_auto_fields(data, context, nulls, opts)
   end
 
   local refs
+  local prev_refs = resolve_references and data["$refs"]
 
   for key, field in self:each_field(data) do
     local ftype = field.type
@@ -1729,6 +1730,13 @@ function Schema:process_auto_fields(data, context, nulls, opts)
 
               value = nil
             end
+
+          elseif prev_refs and prev_refs[key] then
+            if refs then
+              refs[key] = prev_refs[key]
+            else
+              refs = { [key] = prev_refs[key] }
+            end
           end
 
         elseif vtype == "table" and (ftype == "array" or ftype == "set") then
@@ -1762,6 +1770,17 @@ function Schema:process_auto_fields(data, context, nulls, opts)
                     value[i] = nil
                   end
                 end
+              end
+            end
+
+            if prev_refs and prev_refs[key] then
+              if refs then
+                if not refs[key] then
+                  refs[key] = prev_refs[key]
+                end
+
+              else
+                refs = { [key] = prev_refs[key] }
               end
             end
           end

--- a/spec/02-integration/13-vaults/01-vault_spec.lua
+++ b/spec/02-integration/13-vaults/01-vault_spec.lua
@@ -96,6 +96,10 @@ for _, strategy in helpers.each_strategy() do
       assert.is_nil(certificate.cert_alt)
       assert.is_nil(certificate.key_alt)
 
+      -- process auto fields keeps the existing $refs
+      local certificate_b = db.certificates.schema:process_auto_fields(certificate, "select")
+      assert.same(certificate_b, certificate)
+
       -- TODO: this is unexpected but schema.process_auto_fields uses currently
       -- the `nulls` parameter to detect if the call comes from Admin API
       -- for performance reasons


### PR DESCRIPTION
### Summary

If you call `schema:process_auto_fields` multiple times with `select` context, it turned out that it removes the existing `$refs` and then you would loose the references. This commnit fixes it so that `$refs` are kept on the fields that are `referenceable`.