### PR TITLE
feat(cmd) clean dangling unix sockets on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -367,6 +367,9 @@
   [#8497](https://github.com/Kong/kong/pull/8497) [9265](https://github.com/Kong/kong/pull/9265)
 - Improved error handling and debugging info in the DNS code
   [#8902](https://github.com/Kong/kong/pull/8902)
+- Kong will now attempt to recover from an unclean shutdown by detecting and
+  removing dangling unix sockets in the prefix directory
+  [#9254](https://github.com/Kong/kong/pull/9254)
 
 #### Admin API
 
@@ -500,6 +503,8 @@
   [#9255](https://github.com/Kong/kong/pull/9255)
 - Fixed an issue where cache entries of some entities were not being properly invalidated after a cascade delete
   [#9261](https://github.com/Kong/kong/pull/9261)
+- Running `kong start` when Kong is already running will no longer clobber
+  the existing `.kong_env` file [#9254](https://github.com/Kong/kong/pull/9254)
 
 
 #### Admin API

--- a/kong/cmd/start.lua
+++ b/kong/cmd/start.lua
@@ -6,7 +6,42 @@ local kong_global = require "kong.global"
 local kill = require "kong.cmd.utils.kill"
 local log = require "kong.cmd.utils.log"
 local DB = require "kong.db"
+local lfs = require "lfs"
 
+
+local function is_socket(path)
+  return lfs.attributes(path, "mode") == "socket"
+end
+
+local function cleanup_dangling_unix_sockets(prefix)
+  local found = {}
+
+  for child in lfs.dir(prefix) do
+    local path = prefix .. "/" .. child
+    if is_socket(path) then
+      table.insert(found, path)
+    end
+  end
+
+  if #found < 1 then
+    return
+  end
+
+  log.warn("Found dangling unix sockets in the prefix directory (%q) while " ..
+           "preparing to start Kong. This may be a sign that Kong was " ..
+           "previously shut down uncleanly or is in an unknown state and " ..
+           "could require further investigation.",
+           prefix)
+
+  log.warn("Attempting to remove dangling sockets before starting Kong...")
+
+  for _, sock in ipairs(found) do
+    if is_socket(sock) then
+      log.warn("removing unix socket: %s", sock)
+      assert(os.remove(sock))
+    end
+  end
+end
 
 local function execute(args)
   args.db_timeout = args.db_timeout * 1000
@@ -25,6 +60,9 @@ local function execute(args)
 
   assert(not kill.is_running(conf.nginx_pid),
          "Kong is already running in " .. conf.prefix)
+
+
+  cleanup_dangling_unix_sockets(conf.prefix)
 
   _G.kong = kong_global.new()
   kong_global.init_pdk(_G.kong, conf)

--- a/kong/cmd/start.lua
+++ b/kong/cmd/start.lua
@@ -56,11 +56,10 @@ local function execute(args)
   conf.cassandra_timeout = args.db_timeout -- connect + send + read
   conf.cassandra_schema_consensus_timeout = args.db_timeout
 
-  assert(prefix_handler.prepare_prefix(conf, args.nginx_conf))
-
   assert(not kill.is_running(conf.nginx_pid),
          "Kong is already running in " .. conf.prefix)
 
+  assert(prefix_handler.prepare_prefix(conf, args.nginx_conf))
 
   cleanup_dangling_unix_sockets(conf.prefix)
 

--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -772,7 +772,7 @@ describe("kong start/stop #" .. strategy, function()
       assert.matches("Kong started", stdout)
       assert.not_matches("prefix directory .*not found", stdout)
 
-      assert.not_matches("[warn]", stderr, nil, true)
+      assert.not_matches("[warn] Found dangling unix sockets in the prefix directory", stderr, nil, true)
       assert.not_matches("unix socket", stderr)
     end)
 


### PR DESCRIPTION
## Summary

This change set makes Kong more likely to recover from an unclean shutdown.

It also includes a bugfix for `kong start` wherein the `.kong_env` file could be rewritten (among other things) if Kong is already running.

## Background

When Nginx suffers an unclean shutdown (HW issue, OS issue, `SIGKILL`, etc), it may fail to clean up any listening unix sockets from the filesystem. The presence of these will cause Kong to fail to start back up again:

> [emerg] 2127#0: bind() to unix:/usr/local/kong/worker_events.sock failed (98: Address in use)


## Solution

Kong will search for any existing unix sockets within the prefix directory and remove them before attempting to start nginx. If Kong/nginx is already running, no action is taken.

## Limits

The search for dangling sockets is performed only in the top-level prefix directory (no recursion), so this will become less effective if at some point we add a unix socket in a nested directory. The integration tests I've added would _likely_ catch this condition, unless said socket is not created by default.