### PR TITLE
fix(db) failed to query 2nd page for fields use foreign keys as the primary key

### DIFF
--- a/kong/db/strategies/postgres/init.lua
+++ b/kong/db/strategies/postgres/init.lua
@@ -987,7 +987,7 @@ function _M.new(connector, schema, errors)
   for i, key in ipairs(primary_key) do
     local primary_key_field = primary_key_fields[key]
 
-    insert(page_next_names,          key)
+    insert(page_next_names,          primary_key_field.name)
     insert(primary_key_names,        primary_key_field.name)
     insert(primary_key_escaped,      primary_key_field.name_escaped)
     insert(update_args_names,        primary_key_field.name)


### PR DESCRIPTION
When a field uses the foreign key as the primary key, it uses the name of that item instead of its field name for page_next, thus failing to find the value of the field.

fix FTI-4253
