### PR TITLE
datadog-plugin: Set metrics.required to be false

### DIFF
--- a/kong/plugins/datadog/schema.lua
+++ b/kong/plugins/datadog/schema.lua
@@ -81,7 +81,7 @@ return {
           { consumer_tag = { type = "string", default = "consumer" }, },
           { metrics = {
               type     = "array",
-              required = true,
+              required = false,
               default  = DEFAULT_METRICS,
               elements = {
                 type = "record",


### PR DESCRIPTION
### Summary

The Datadog plugin is configured to set `DEFAULT_METRICS`; meaning you don't have to manually configure any metrics to send to Datadog (which is great!). However, when the schema sets `required = true` alongside a default value, the Admissions Controller will fail with the following error if no metrics are provided: 

```
Error: UPGRADE FAILED: cannot patch "global-datadog" with kind KongClusterPlugin: admission webhook "validations.kong.konghq.com" denied the request: plugin failed schema validation: schema violation (config.metrics: required field missing)
```

In order to use the default Datadog metrics values and the Admissions Controller in parallel, this value needs to be false.

### Full changelog

* [Datadog Plugin] Update Datadog schema, to set the config for metrics.required to false

### Issue reference

Instead of creating a new issue, I've raised this PR to address the issue myself.
