### PR TITLE
fix(dao) add recursion over entities that need to be cascade-deleted

### DIFF
--- a/spec/01-unit/01-db/04-dao_spec.lua
+++ b/spec/01-unit/01-db/04-dao_spec.lua
@@ -500,6 +500,124 @@ describe("DAO", function()
       local _, err = parent_dao:delete({ a = 42 })
       assert.falsy(err)
     end)
+
+
+    it("find_cascade_delete_entities()", function()
+      local parent_schema = assert(Schema.new({
+        name = "Foo",
+        primary_key = { "a" },
+        fields = {
+          { a = { type = "number" }, },
+        }
+      }))
+
+      local child_schema = assert(Schema.new({
+        name = "Bar",
+        primary_key = { "b" },
+        fields = {
+          { b = { type = "number" }, },
+          { c = { type = "foreign", reference = "Foo", on_delete = "cascade" }, },
+        }
+      }))
+
+      local parent_strategy = setmetatable({}, {__index = function() return function() end end})
+      local child_strategy = parent_strategy
+      local child_dao = DAO.new(mock_db, child_schema, child_strategy, errors)
+
+      child_dao.each_for_c = function()
+        local i = 0
+        return function()
+          i = i + 1
+          if i == 1 then
+            return { c = 40 }
+          end
+        end
+      end
+
+
+      -- Create grandchild schema
+      local grandchild_schema = assert(Schema.new({
+        name = "Dar",
+        primary_key = { "d" },
+        fields = {
+          { d = { type = "number" }, },
+          { e = { type = "foreign", reference = "Bar", on_delete = "cascade" }, },
+        }
+      }))
+
+      local parent_strategy = setmetatable({}, {__index = function() return function() end end})
+      local grandchild_strategy = parent_strategy
+      local grandchild_dao = DAO.new(mock_db, grandchild_schema, grandchild_strategy, errors)
+
+      grandchild_dao.each_for_e = function()
+        local i = 0
+        return function()
+          i = i + 1
+          -- We have 3 grand child entities
+          if i <= 3 then
+            return { e = 50 + i }
+          end
+        end
+      end
+
+      -- Create great_grandchild schema
+      local great_grandchild_schema = assert(Schema.new({
+        name = "Far",
+        primary_key = { "f" },
+        fields = {
+          { f = { type = "number" }, },
+          { g = { type = "foreign", reference = "Dar", on_delete = "cascade" }, },
+        }
+      }))
+
+      local parent_strategy = setmetatable({}, {__index = function() return function() end end})
+      local great_grandchild_strategy = parent_strategy
+      local great_grandchild_dao = DAO.new(mock_db, great_grandchild_schema, great_grandchild_strategy, errors)
+
+      great_grandchild_dao.each_for_g = function()
+        local i = 0
+        return function()
+          i = i + 1
+          -- We have 3 great grand child entities
+          if i <= 3 then
+            return { g = 60 + i }
+          end
+        end
+      end
+
+      mock_db = {
+        daos = {
+          Bar = child_dao,
+          Dar = grandchild_dao,
+          Far = great_grandchild_dao,
+        }
+      }
+
+      local parent_dao = DAO.new(mock_db, parent_schema, parent_strategy, errors)
+      local parent_entity = {}
+      local entries = DAO._find_cascade_delete_entities(parent_dao, parent_entity, { show_ws_id = true })
+      assert.equal(#entries, 13)
+      -- Entry 1 should be the child `c` entity which references the parent `Foo` DAO
+      assert.equal(40, entries[1].entity.c)
+      -- Entry 2 should be the grandchild `e` entity which references the child `Bar` DAO
+      assert.equal(51, entries[2].entity.e)
+      -- Entries 3 to 5 should be the great grandchild `g` entity which references the grandchild `Dar` DAO
+      assert.equal(61, entries[3].entity.g)
+      assert.equal(62, entries[4].entity.g)
+      assert.equal(63, entries[5].entity.g)
+      -- Entry 6 should be the grandchild `e` entity which references the child `Bar` DAO
+      assert.equal(52, entries[6].entity.e)
+      -- Entries 7 to 9 should be the great grandchild `g` entity which references the grandchild `Dar` DAO
+      assert.equal(61, entries[7].entity.g)
+      assert.equal(62, entries[8].entity.g)
+      assert.equal(63, entries[9].entity.g)
+      -- Entry 10 should be the grandchild `e` entity which references the child `Bar` DAO
+      assert.equal(53, entries[10].entity.e)
+      -- Entries 11 to 13 should be the great grandchild `g` entity which references the grandchild `Dar` DAO
+      assert.equal(61, entries[11].entity.g)
+      assert.equal(62, entries[12].entity.g)
+      assert.equal(63, entries[13].entity.g)
+    end)
   end)
 
   describe("cache_key", function()


### PR DESCRIPTION
In a scenario where `consumer` entities were deleted, the
`oauth2_tokens` entities didn't have their caches invalidated. This is
because the `find_cascade_delete_entities` function was only finding
entities up to a maximum of two levels. So in this case where
`consumer` is referenced by `oauth2_credentials` and
`oauth2_credentials` is referenced by `oauth2_tokens` (consumer ->
oauth2_credentials -> oauth2_tokens), only the `consumer` and
`oauth2_credentials` had their cache invalidated, the `oauth2_tokens`
caches had their cache still valid after a /consumers DELETE operation. The
`find_cascade_delete_entities` function of the DAO module needs to be
recursive because of this issue. So this PR is doing that, plus it's
adding unit tests along with integration tests for the `oauth2` plugin.

Fix FTI-2023