### PR TITLE
fix(auto-doc) change targets healthy/unhealthy endpoints http method `POST` to `PUT`

### DIFF
--- a/autodoc/admin-api/data/admin-api.lua
+++ b/autodoc/admin-api/data/admin-api.lua
@@ -1809,7 +1809,7 @@ return {
         }
       },
       ["/upstreams/:upstreams/targets/:targets/healthy"] = {
-        POST = {
+        PUT = {
           title = [[Set target as healthy]],
           description = [[
             Set the current health status of a target in the load balancer to "healthy"
@@ -1826,7 +1826,7 @@ return {
             status is propagated to the whole Kong cluster.
           ]],
           endpoint = [[
-            <div class="endpoint post indent">/upstreams/{upstream name or id}/targets/{target or id}/healthy</div>
+            <div class="endpoint put indent">/upstreams/{upstream name or id}/targets/{target or id}/healthy</div>
 
             {:.indent}
             Attributes | Description
@@ -1842,7 +1842,7 @@ return {
         }
       },
       ["/upstreams/:upstreams/targets/:targets/unhealthy"] = {
-        POST = {
+        PUT = {
           title = [[Set target as unhealthy]],
           description = [[
             Set the current health status of a target in the load balancer to "unhealthy"
@@ -1864,7 +1864,7 @@ return {
             target](#delete-target) instead.
           ]],
           endpoint = [[
-            <div class="endpoint post indent">/upstreams/{upstream name or id}/targets/{target or id}/unhealthy</div>
+            <div class="endpoint put indent">/upstreams/{upstream name or id}/targets/{target or id}/unhealthy</div>
 
             {:.indent}
             Attributes | Description
@@ -1880,7 +1880,7 @@ return {
         }
       },
       ["/upstreams/:upstreams/targets/:targets/:address/healthy"] = {
-        POST = {
+        PUT = {
           title = [[Set target address as healthy]],
           description = [[
             Set the current health status of an individual address resolved by a target
@@ -1896,7 +1896,7 @@ return {
             status is propagated to the whole Kong cluster.
           ]],
           endpoint = [[
-            <div class="endpoint post indent">/upstreams/{upstream name or id}/targets/{target or id}/{address}/healthy</div>
+            <div class="endpoint put indent">/upstreams/{upstream name or id}/targets/{target or id}/{address}/healthy</div>
 
             {:.indent}
             Attributes | Description
@@ -1913,7 +1913,7 @@ return {
         }
       },
       ["/upstreams/:upstreams/targets/:targets/:address/unhealthy"] = {
-        POST = {
+        PUT = {
           title = [[Set target address as unhealthy]],
           description = [[
             Set the current health status of an individual address resolved by a target
@@ -1934,7 +1934,7 @@ return {
             target](#delete-target) instead.
           ]],
           endpoint = [[
-            <div class="endpoint post indent">/upstreams/{upstream name or id}/targets/{target or id}/unhealthy</div>
+            <div class="endpoint put indent">/upstreams/{upstream name or id}/targets/{target or id}/unhealthy</div>
 
             {:.indent}
             Attributes | Description
@@ -2338,10 +2338,10 @@ return {
     ["DELETE"] = false,
     -- exceptions for the healthcheck endpoints:
     ["/upstreams/:upstreams/targets/:targets/healthy"] = {
-      ["POST"] = true,
+      ["PUT"] = true,
     },
     ["/upstreams/:upstreams/targets/:targets/unhealthy"] = {
-      ["POST"] = true,
+      ["PUT"] = true,
     },
   },
 


### PR DESCRIPTION
According to this PR commit [fix(api) upsert of targets now require the PUT HTTP method](https://github.com/Kong/kong/pull/8596)
Change set targets healthy/unhealthy endpoints the POST HTTP method to the PUT HTTP method

FT-2544
