### PR TITLE
fix(balancer) stop DNS renewal on target event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -309,6 +309,10 @@
   [#9182](https://github.com/Kong/kong/pull/9182)
 - Added `headers` on active healthcheck for upstreams.
   [#8255](https://github.com/Kong/kong/pull/8255)
+- Target entities using hostnames were resolved when they were not needed. Now
+  when a target is removed or updated, the DNS record associated with it is
+  removed from the list of hostnames to be resolved.
+  [#8497](https://github.com/Kong/kong/pull/8497) [9265](https://github.com/Kong/kong/pull/9265)
 
 #### Hybrid Mode
 

--- a/kong/runloop/balancer/targets.lua
+++ b/kong/runloop/balancer/targets.lua
@@ -35,8 +35,8 @@ local GLOBAL_QUERY_OPTS = { workspace = null, show_ws_id = true }
 
 -- global binary heap for all balancers to share as a single update timer for
 -- renewing DNS records
-local renewal_heap
-local renewal_weak_cache
+local renewal_heap = require("binaryheap").minUnique()
+local renewal_weak_cache = setmetatable({}, { __mode = "v" })
 
 local targets_M = {}
 
@@ -47,9 +47,11 @@ local queryDns
 
 function targets_M.init()
   dns_client = require("kong.tools.dns")(kong.configuration)    -- configure DNS client
+  if renewal_heap:size() > 0 then
+    renewal_heap = require("binaryheap").minUnique()
+    renewal_weak_cache = setmetatable({}, { __mode = "v" })    
+  end
 
-  renewal_heap = require("binaryheap").minUnique()
-  renewal_weak_cache = setmetatable({}, { __mode = "v" })
 
   if not resolve_timer_running then
     resolve_timer_running = assert(ngx.timer.at(1, resolve_timer_callback))


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary
import from https://github.com/Kong/kong/pull/8497
This bug fix pr was not merged to master,  this PR can add this.

But the difference is this PR fixes two bug

1. Because the worker event trigger callback is async, so one scenario upstream was deleted before `on_target_event`  , So this [get_upstream_by_id](https://github.com/Kong/kong/pull/8497/files#diff-993f49a97425ba1092a07a8b7ce88d501a4a2c3b26e00adb675b6939c003b6f2R157)  can return unexpectly.
2. if `target_M.init()` was called multiple times(in hybrid mode), `renewal_heap` and `renewal_weak_cache ` have some Residual data, So we must delete this.

<!--- Why is this change required? What problem does it solve? -->

### Full changelog

* When a target event different from `"create"` is received, remove the hostname from the heap containing the hostnames that must be resolved.
* As the heap is not exposed outside of `targets.lua`, no tests were added.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix FTI-2927 FTI-4219
