### PR TITLE
fix(handler) reverted logic to old one in var.upstream_uri concatenation logic

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1444,7 +1444,7 @@ return {
       if byte(ctx.request_uri or var.request_uri, -1) == QUESTION_MARK then
         var.upstream_uri = var.upstream_uri .. "?"
       elseif var.is_args == "?" then
-        var.upstream_uri = var.upstream_uri .. "?" .. var.args or ""
+        var.upstream_uri = var.upstream_uri .. "?" .. (var.args or "")
       end
 
       local upstream_scheme = var.upstream_scheme


### PR DESCRIPTION
### Summary

It was reported by @joshkping in #9246 that your handler may runtime crash in certain cases. This started to happen after this commit was merged: https://github.com/Kong/kong/commit/44d24a216cfa17926d0c0b2781587d1200bf35e7

It looks like this affects a lot of versions:
- 2.8.1
- 2.8.0
- 2.7.2
- 2.7.1
- 2.7.0
- 2.6.1
- 2.6.0

### Issues Resolved

Fix #9246