### PR TITLE
fix: allow grpcs and tls for client_certificate

### DIFF
--- a/kong/db/schema/entities/services.lua
+++ b/kong/db/schema/entities/services.lua
@@ -53,7 +53,7 @@ return {
                       then_field = "path",
                       then_match = { eq = null }}},
     { conditional = { if_field = "protocol",
-                      if_match = { ne = "https" },
+                      if_match = { not_one_of = { "https", "grpcs", "tls" }},
                       then_field = "client_certificate",
                       then_match = { eq = null }}},
     { conditional = { if_field = "protocol",


### PR DESCRIPTION
### Summary

A [discussion in kong/kubernetes-ingress-controller](https://github.com/Kong/kubernetes-ingress-controller/discussions/2831) wherein a user was trying to use mTLS with gRPC indicated a bug in the Kong Gateway where `grpcs` wasn't allowed to have a `client_certificate`, this PR attempts to fix that (and also add `tls` while we're at it for similar reasons).

### Full changelog

* Fixed a bug where `grpcs` and `tls` could not be used with `client_certificate` in services

### Issue reference

Fix for https://github.com/Kong/kubernetes-ingress-controller/discussions/2831
