### PR TITLE
chore(*) increase events queue len to 1024*50

### DIFF
--- a/kong/global.lua
+++ b/kong/global.lua
@@ -196,6 +196,7 @@ function _GLOBAL.init_worker_events()
       broker_id = 0,          -- broker server runs in nginx worker #0
       listening = "unix:" ..  -- unix socket for broker listening
                   ngx.config.prefix() .. sock_name,
+      max_queue_len = 1024 * 50,  -- max queue len for events buffering
     }
 
     worker_events = require "resty.events.compat"


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

increase events queue len to 1024*50, it may reduce the probability of queue overflow.

See FT-3214. 

