### PR TITLE
chore(conf) lower bound to worker_connections and worker_rlimit_nofile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -362,6 +362,10 @@
 - Add LMDB dbless config persistence and removed the JSON based
   config cache for faster startup time
   [#8670](https://github.com/Kong/kong/pull/8670)
+- `nginx_events_worker_connections=auto` has a lower bound of 1024
+  [#9276](https://github.com/Kong/kong/pull/9276)
+- `nginx_main_worker_rlimit_nofile=auto` has a lower bound of 1024
+  [#9276](https://github.com/Kong/kong/pull/9276)
 
 #### PDK
 - Added new PDK function: `kong.request.get_start_time()`

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -932,7 +932,8 @@
                                  #
                                  # The special and default value of `auto` sets this
                                  # value to `ulimit -n` with the upper bound limited to
-                                 # 16384 as a measure to protect against excess memory use.
+                                 # 16384 as a measure to protect against excess memory use,
+                                 # and the lower bound of 1024 as a good default.
                                  #
                                  # See http://nginx.org/en/docs/ngx_core_module.html#worker_rlimit_nofile
 
@@ -942,7 +943,8 @@
                                  #
                                  # The special and default value of `auto` sets this
                                  # value to `ulimit -n` with the upper bound limited to
-                                 # 16384 as a measure to protect against excess memory use.
+                                 # 16384 as a measure to protect against excess memory use,
+                                 # and the lower bound of 1024 as a good default.
                                  #
                                  # See http://nginx.org/en/docs/ngx_core_module.html#worker_connections
 

--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -253,6 +253,7 @@ local function compile_conf(kong_config, conf_template)
       end
 
       value = math.min(value, 16384)
+      value = math.max(value, 1024)
 
       if worker_rlimit_nofile_auto then
         worker_rlimit_nofile_auto.value = value

--- a/spec/01-unit/04-prefix_handler_spec.lua
+++ b/spec/01-unit/04-prefix_handler_spec.lua
@@ -753,6 +753,7 @@ describe("NGINX conf compiler", function()
 
       local ulimit = prefix_handler.get_ulimit()
       ulimit = math.min(ulimit, 16384)
+      ulimit = math.max(ulimit, 1024)
 
       local nginx_conf = prefix_handler.compile_nginx_conf(conf)
       assert.matches("worker_rlimit_nofile%s+" .. ulimit .. ";", nginx_conf)


### PR DESCRIPTION
### Summary

Adds lower bound of 1024 to:

- `nginx_events_worker_connections=auto`
- `nginx_main_worker_rlimit_nofile=auto`