### PR TITLE
fix(tracing) handling tracestate header correctly

### DIFF
--- a/kong/tracing/propagation.lua
+++ b/kong/tracing/propagation.lua
@@ -343,6 +343,15 @@ local function find_header_type(headers)
   local b3_single_header = headers["b3"]
   if not b3_single_header then
     local tracestate_header = headers["tracestate"]
+
+    -- handling tracestate header if it is multi valued
+    if tracestate_header and type(tracestate_header) == "table" then
+      -- https://www.w3.org/TR/trace-context/#tracestate-header
+      -- Handling multi value header : https://httpwg.org/specs/rfc7230.html#field.order
+      tracestate_header = table.concat(tracestate_header, ',')
+      kong.log.warn("Trace state header is table : " .. tracestate_header)
+    end
+
     if tracestate_header then
       b3_single_header = match(tracestate_header, "^b3=(.+)$")
     end

--- a/kong/tracing/propagation.lua
+++ b/kong/tracing/propagation.lua
@@ -5,6 +5,7 @@ local char = string.char
 local match = string.match
 local gsub = string.gsub
 local fmt = string.format
+local concat = table.concat
 
 
 local baggage_mt = {
@@ -345,11 +346,11 @@ local function find_header_type(headers)
     local tracestate_header = headers["tracestate"]
 
     -- handling tracestate header if it is multi valued
-    if tracestate_header and type(tracestate_header) == "table" then
+    if type(tracestate_header) == "table" then
       -- https://www.w3.org/TR/trace-context/#tracestate-header
       -- Handling multi value header : https://httpwg.org/specs/rfc7230.html#field.order
-      tracestate_header = table.concat(tracestate_header, ',')
-      kong.log.warn("Trace state header is table : " .. tracestate_header)
+      tracestate_header = concat(tracestate_header, ',')
+      kong.log.debug("header `tracestate` is a table :" .. tracestate_header)
     end
 
     if tracestate_header then

--- a/spec/01-unit/26-tracing/02-propagation_spec.lua
+++ b/spec/01-unit/26-tracing/02-propagation_spec.lua
@@ -149,6 +149,13 @@ describe("propagation.parse", function()
       assert.spy(warn).not_called()
     end)
 
+    it("multi value tracestate header", function()
+      local tracestate_header = { "test", trace_id, span_id }
+      local t = { parse({ tracestate =  tracestate_header }) }
+      assert.same({ }, to_hex_ids(t))
+      assert.spy(warn).called(1)
+    end)
+
     describe("errors", function()
       it("requires trace id", function()
         local t = { parse({ b3 = "" }) }

--- a/spec/01-unit/26-tracing/02-propagation_spec.lua
+++ b/spec/01-unit/26-tracing/02-propagation_spec.lua
@@ -40,15 +40,18 @@ describe("propagation.parse", function()
   }
 
   describe("b3 single header parsing", function()
-    local warn
+    local warn, debug
     setup(function()
       warn = spy.on(kong.log, "warn")
+      debug = spy.on(kong.log, "debug")
     end)
     before_each(function()
       warn:clear()
+      debug:clear()
     end)
     teardown(function()
       warn:revert()
+      debug:clear()
     end)
 
     it("does not parse headers with ignore type", function()
@@ -153,7 +156,7 @@ describe("propagation.parse", function()
       local tracestate_header = { "test", trace_id, span_id }
       local t = { parse({ tracestate =  tracestate_header }) }
       assert.same({ }, to_hex_ids(t))
-      assert.spy(warn).called(1)
+      assert.spy(debug).called(1)
     end)
 
     describe("errors", function()


### PR DESCRIPTION
### Summary

When `tracestate` header is multi valued ( it is allowed by the spec ) zipkin plugin was failing with error ```bad argument #1 to 'match' (string expected, got table)```

### Full changelog

* [zipkin] handling multi value tracestate header correctly
