### PR TITLE
fix(tracing) balancer span_kind fix

### DIFF
--- a/kong/tracing/instrumentation.lua
+++ b/kong/tracing/instrumentation.lua
@@ -78,7 +78,7 @@ function _M.balancer(ctx)
   for i = 1, try_count do
     local try = balancer_tries[i]
     span = tracer.start_span("balancer try #" .. i, {
-      kind = 3, -- client
+      span_kind = 3, -- client
       start_time_ns = try.balancer_start * 1e6,
       attributes = {
         ["net.peer.ip"] = try.ip,


### PR DESCRIPTION
### Summary

Balancer span creation was using the incorrect param name for span kind.

### Full changelog

* [tracing] fixed balancer span kind