### PR TITLE
chore(test) Actually test upgrade path with cassandra

### DIFF
--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -46,4 +46,4 @@ jobs:
         run: |
           export GOJIRA_KONG_REPO_URL=$GITHUB_WORKSPACE
           gojira nuke
-          bash -x ./scripts/test-upgrade-path.sh -d postgres 2.8.0 $GITHUB_REF_NAME
+          bash -x ./scripts/test-upgrade-path.sh -d cassandra 2.8.0 $GITHUB_REF_NAME


### PR DESCRIPTION
Previously, upgrades were tested with PostgreSQL twice due to copy&paste error.