### PR TITLE
deps(*) bump lua-resty-mlcache to 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -288,6 +288,8 @@
   [#8845](https://github.com/Kong/kong/pull/8845)
 - Bumped penlight from 1.12.0 to 1.13.1
   [#9206](https://github.com/Kong/kong/pull/9206)
+- Bumped lua-resty-mlcache from 2.5.0 to 2.6.0
+  [#9287](https://github.com/Kong/kong/pull/9287)
 
 ### Additions
 

--- a/kong-3.0.0-0.rockspec
+++ b/kong-3.0.0-0.rockspec
@@ -34,7 +34,7 @@ dependencies = {
   "lua-protobuf == 0.3.3",
   "lua-resty-worker-events == 1.0.0",
   "lua-resty-healthcheck == 1.6.1",
-  "lua-resty-mlcache == 2.5.0",
+  "lua-resty-mlcache == 2.6.0",
   "lua-messagepack == 0.5.2",
   "lua-resty-openssl == 0.8.10",
   "lua-resty-counter == 0.2.1",

--- a/kong/cache/marshall.lua
+++ b/kong/cache/marshall.lua
@@ -1,15 +1,23 @@
 -------------------------------------------------------------------------------
 -- NOTE: the following is copied from lua-resty-mlcache:                     --
 ------------------------------------------------------------------------ cut --
-local cjson = require "cjson.safe"
+local codec
+do
+    local pok
+    pok, codec = pcall(require, "string.buffer")
+    if not pok then
+        codec = require "cjson"
+    end
+end
 
 
 local type = type
+local pcall = pcall
 local error = error
 local tostring = tostring
 local fmt = string.format
 local now = ngx.now
-local cjson_encode = cjson.encode
+local encode = codec.encode
 
 
 local TYPES_LOOKUP = {
@@ -42,12 +50,12 @@ local marshallers = {
   end,
 
   [4] = function(t)      -- table
-      local json, err = cjson_encode(t)
-      if not json then
-          return nil, "could not encode table value: " .. err
+      local pok, str = pcall(encode, t)
+      if not pok then
+          return nil, "could not encode table value: " .. str
       end
 
-      return json
+      return str
   end,
 }
 

--- a/kong/cache/marshall.lua
+++ b/kong/cache/marshall.lua
@@ -3,11 +3,11 @@
 ------------------------------------------------------------------------ cut --
 local codec
 do
-    local pok
-    pok, codec = pcall(require, "string.buffer")
-    if not pok then
-        codec = require "cjson"
-    end
+  local pok
+  pok, codec = pcall(require, "string.buffer")
+  if not pok then
+    codec = require "cjson"
+  end
 end
 
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

lua-resty-mlcache 2.6.0 add support for new api `string.buffer` in OpenResty 1.21.4.1

