### PR TITLE
chore(router) deprecate setting path handling v1 when router_flavor is traditional_compatible

### DIFF
--- a/autodoc/admin-api/data/admin-api.lua
+++ b/autodoc/admin-api/data/admin-api.lua
@@ -971,7 +971,14 @@ return {
 
         #### Path handling algorithms
 
-        `"v0"` is the behavior used in Kong 0.x and 2.x. It treats `service.path`, `route.path` and request path as
+        {:.note}
+        > **Note**: Path handling algorithms v1 was deprecated in Kong 3.0. From Kong 3.0, when `router_flavor`
+        > is set to `expressions`, `route.path_handling` will be unconfigurable and the path handling behavior
+        > will be v0; when `router_flavor` is set to `traditional_compatible`, the path handling behavior
+        > will be v0 regardless of the value of `route.path_handling`. Only `router_flavor` = `traditional`
+        > will support path_handling v1 behavior.
+
+        `"v0"` is the behavior used in Kong 0.x, 2.x and 3.x. It treats `service.path`, `route.path` and request path as
         *segments* of a URL. It will always join them via slashes. Given a service path `/s`, route path `/r`
         and request path `/re`, the concatenated path will be `/s/re`. If the resulting path is a single slash,
         no further transformation is done to it. If it's longer, then the trailing slash is removed.

--- a/autodoc/admin-api/data/admin-api.lua
+++ b/autodoc/admin-api/data/admin-api.lua
@@ -976,7 +976,7 @@ return {
         > is set to `expressions`, `route.path_handling` will be unconfigurable and the path handling behavior
         > will be v0; when `router_flavor` is set to `traditional_compatible`, the path handling behavior
         > will be v0 regardless of the value of `route.path_handling`. Only `router_flavor` = `traditional`
-        > will support path_handling v1 behavior.
+        > will support path_handling `"v1'` behavior.
 
         `"v0"` is the behavior used in Kong 0.x, 2.x and 3.x. It treats `service.path`, `route.path` and request path as
         *segments* of a URL. It will always join them via slashes. Given a service path `/s`, route path `/r`

--- a/autodoc/admin-api/data/admin-api.lua
+++ b/autodoc/admin-api/data/admin-api.lua
@@ -974,7 +974,7 @@ return {
         {:.note}
         > **Note**: Path handling algorithms v1 was deprecated in Kong 3.0. From Kong 3.0, when `router_flavor`
         > is set to `expressions`, `route.path_handling` will be unconfigurable and the path handling behavior
-        > will be v0; when `router_flavor` is set to `traditional_compatible`, the path handling behavior
+        > will be `"v0"`; when `router_flavor` is set to `traditional_compatible`, the path handling behavior
         > will be v0 regardless of the value of `route.path_handling`. Only `router_flavor` = `traditional`
         > will support path_handling `"v1'` behavior.
 

--- a/autodoc/admin-api/data/admin-api.lua
+++ b/autodoc/admin-api/data/admin-api.lua
@@ -975,7 +975,7 @@ return {
         > **Note**: Path handling algorithms v1 was deprecated in Kong 3.0. From Kong 3.0, when `router_flavor`
         > is set to `expressions`, `route.path_handling` will be unconfigurable and the path handling behavior
         > will be `"v0"`; when `router_flavor` is set to `traditional_compatible`, the path handling behavior
-        > will be v0 regardless of the value of `route.path_handling`. Only `router_flavor` = `traditional`
+        > will be `"v0"` regardless of the value of `route.path_handling`. Only `router_flavor` = `traditional`
         > will support path_handling `"v1'` behavior.
 
         `"v0"` is the behavior used in Kong 0.x, 2.x and 3.x. It treats `service.path`, `route.path` and request path as

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -118,17 +118,6 @@ else
       { service = { type = "foreign", reference = "services" }, },
     },
 
-    transformations = {
-      {
-        input = { "path_handling" },
-        on_read = function(path_handling)
-          if kong_router_flavor == "traditional_compatible" then
-            return { path_handling = ngx.null }
-          end
-        end,
-      },
-    },
-
     entity_checks = {
       { conditional = { if_field = "protocols",
                         if_match = { elements = { type = "string", not_one_of = { "grpcs", "https", "tls", "tls_passthrough" }}},

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -125,7 +125,7 @@ else
       { custom_entity_check = {
         field_sources = { "path_handling" },
         fn = function(entity)
-          if entity.path_handling == "v1" and kong.configuration.router_flavor == "traditional_compatible" then
+          if entity.path_handling == "v1" and kong.configuration.router_flavor ~= "traditional" then
             return nil, "path_handling = 'v1' is deprecated and not supported with router_flavor = 'traditional_compatible'"
           end
           return true

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -126,7 +126,7 @@ else
         field_sources = { "path_handling" },
         fn = function(entity)
           if entity.path_handling == "v1" and kong.configuration.router_flavor ~= "traditional" then
-            return nil, "path_handling = 'v1' is deprecated and not supported when router_flavor is not 'traditional'"
+            return nil, "path_handling = 'v1' is deprecated and only supported in 'traditional' router flavor"
           end
           return true
         end,

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -122,6 +122,15 @@ else
                         then_match = { len_eq = 0 },
                         then_err = "'snis' can only be set when 'protocols' is 'grpcs', 'https', 'tls' or 'tls_passthrough'",
                       }},
+      { custom_entity_check = {
+        field_sources = { "path_handling" },
+        fn = function(entity)
+          if entity.path_handling == "v1" and kong.configuration.router_flavor == "traditional_compatible" then
+            return nil, "path_handling = 'v1' is deprecated and not supported with router_flavor = 'traditional_compatible'"
+          end
+          return true
+        end,
+      }},
                     },
   }
 end

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -128,6 +128,7 @@ else
           if entity.path_handling == "v1" and kong.configuration.router_flavor ~= "traditional" then
             return nil, "path_handling = 'v1' is deprecated and only supported in 'traditional' router flavor"
           end
+
           return true
         end,
       }},

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -131,11 +131,11 @@ else
           if entity.path_handling == "v1" then
             if kong_router_flavor == "traditional" then
               deprecation("path_handling='v1' is deprecated and will be removed in future version, " ..
-                          "please use path_handling='v0' instead")
+                          "please use path_handling='v0' instead", { after = "3.0", })
 
             elseif kong_router_flavor == "traditional_compatible" then
               deprecation("path_handling='v1' is deprecated and will not work under traditional_compatible " ..
-                          "router_flavor, please use path_handling='v0' instead")
+                          "router_flavor, please use path_handling='v0' instead", { after = "3.0", })
             end
           end
 

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -1,6 +1,7 @@
 local typedefs = require("kong.db.schema.typedefs")
 local atc = require("kong.router.atc")
 local router = require("resty.router.router")
+local deprecation = require("kong.deprecation")
 
 local kong_router_flavor = kong and kong.configuration and kong.configuration.router_flavor
 

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -126,7 +126,7 @@ else
         field_sources = { "path_handling" },
         fn = function(entity)
           if entity.path_handling == "v1" and kong.configuration.router_flavor ~= "traditional" then
-            return nil, "path_handling = 'v1' is deprecated and not supported with router_flavor = 'traditional_compatible'"
+            return nil, "path_handling = 'v1' is deprecated and not supported when router_flavor is not 'traditional'"
           end
           return true
         end,

--- a/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
+++ b/spec/01-unit/01-db/01-schema/11-declarative_config/03-flatten_spec.lua
@@ -167,11 +167,12 @@ describe("declarative config: flatten", function()
       end)
 
       it("accepts field names with the same name as entities", function()
+        -- "snis" is also an entity
         local config = assert(lyaml.load([[
           _format_version: "1.1"
           routes:
           - name: foo
-            path_handling: v1
+            path_handling: v0
             protocols: ["tls"]
             snis:
             - "example.com"
@@ -197,7 +198,7 @@ describe("declarative config: flatten", function()
               snis = { "example.com" },
               sources = null,
               strip_path = true,
-              path_handling = "v1",
+              path_handling = "v0",
               updated_at = 1234567890,
               request_buffering = true,
               response_buffering = true,
@@ -346,7 +347,7 @@ describe("declarative config: flatten", function()
               host: example.com
           routes:
             - name: r1
-              path_handling: v1
+              path_handling: v0
               paths: [/]
               service: svc1
           consumers:
@@ -443,7 +444,7 @@ describe("declarative config: flatten", function()
               snis = null,
               sources = null,
               strip_path = true,
-              path_handling = "v1",
+              path_handling = "v0",
               updated_at = 1234567890,
               request_buffering = true,
               response_buffering = true,
@@ -712,7 +713,7 @@ describe("declarative config: flatten", function()
               host: example.com
               protocol: https
               routes:
-                - path_handling: v1
+                - path_handling: v0
                   paths:
                   - /path
           ]]))
@@ -737,7 +738,7 @@ describe("declarative config: flatten", function()
                 snis = null,
                 sources = null,
                 strip_path = true,
-                path_handling = "v1",
+                path_handling = "v0",
                 tags = null,
                 updated_at = 1234567890,
                 request_buffering = true,
@@ -774,22 +775,22 @@ describe("declarative config: flatten", function()
               host: example.com
               protocol: https
               routes:
-                - path_handling: v1
+                - path_handling: v0
                   paths:
                   - /path
                   name: r1
-                - path_handling: v1
+                - path_handling: v0
                   hosts:
                   - example.com
                   name: r2
-                - path_handling: v1
+                - path_handling: v0
                   methods: ["GET", "POST"]
                   name: r3
             - name: bar
               host: example.test
               port: 3000
               routes:
-                - path_handling: v1
+                - path_handling: v0
                   paths:
                   - /path
                   hosts:
@@ -818,7 +819,7 @@ describe("declarative config: flatten", function()
                 snis = null,
                 sources = null,
                 strip_path = true,
-                path_handling = "v1",
+                path_handling = "v0",
                 tags = null,
                 updated_at = 1234567890,
                 request_buffering = true,
@@ -842,7 +843,7 @@ describe("declarative config: flatten", function()
                 snis = null,
                 sources = null,
                 strip_path = true,
-                path_handling = "v1",
+                path_handling = "v0",
                 tags = null,
                 updated_at = 1234567890,
                 request_buffering = true,
@@ -866,7 +867,7 @@ describe("declarative config: flatten", function()
                 snis = null,
                 sources = null,
                 strip_path = true,
-                path_handling = "v1",
+                path_handling = "v0",
                 tags = null,
                 updated_at = 1234567890,
                 request_buffering = true,
@@ -890,7 +891,7 @@ describe("declarative config: flatten", function()
                 snis = null,
                 sources = null,
                 strip_path = true,
-                path_handling = "v1",
+                path_handling = "v0",
                 tags = null,
                 updated_at = 1234567890,
                 request_buffering = true,
@@ -949,7 +950,7 @@ describe("declarative config: flatten", function()
               protocol: https
               routes:
               - name: foo
-                path_handling: v1
+                path_handling: v0
                 methods: ["GET"]
                 plugins:
           ]]))
@@ -976,7 +977,7 @@ describe("declarative config: flatten", function()
                 snis = null,
                 sources = null,
                 strip_path = true,
-                path_handling = "v1",
+                path_handling = "v0",
                 updated_at = 1234567890,
                 request_buffering = true,
                 response_buffering = true,
@@ -1016,7 +1017,7 @@ describe("declarative config: flatten", function()
               protocol: https
               routes:
               - name: foo
-                path_handling: v1
+                path_handling: v0
                 methods: ["GET"]
                 plugins:
                   - name: key-auth
@@ -1028,7 +1029,7 @@ describe("declarative config: flatten", function()
               port: 3000
               routes:
               - name: bar
-                path_handling: v1
+                path_handling: v0
                 paths:
                 - /
                 plugins:
@@ -1142,7 +1143,7 @@ describe("declarative config: flatten", function()
                 snis = null,
                 sources = null,
                 strip_path = true,
-                path_handling = "v1",
+                path_handling = "v0",
                 tags = null,
                 updated_at = 1234567890,
                 request_buffering = true,
@@ -1166,7 +1167,7 @@ describe("declarative config: flatten", function()
                 snis = null,
                 sources = null,
                 strip_path = true,
-                path_handling = "v1",
+                path_handling = "v0",
                 tags = null,
                 updated_at = 1234567890,
                 request_buffering = true,

--- a/spec/01-unit/01-db/01-schema/11-declarative_config/04-on-the-fly-migration_spec.lua
+++ b/spec/01-unit/01-db/01-schema/11-declarative_config/04-on-the-fly-migration_spec.lua
@@ -92,7 +92,7 @@ describe("declarative config: on the fly migration", function()
           tags: [hello, world]
         routes:
         - name: foo
-          path_handling: v1
+          path_handling: v0
           protocols: ["https"]
           paths: ["/regex.+", "/prefix" ]
           snis:

--- a/spec/02-integration/03-db/02-db_core_entities_spec.lua
+++ b/spec/02-integration/03-db/02-db_core_entities_spec.lua
@@ -520,7 +520,7 @@ for _, strategy in helpers.each_strategy() do
             protocols = { "http" },
             hosts = { "example.com" },
             service = assert(db.services:insert({ host = "service.com" })),
-            path_handling = "v1",
+            path_handling = "v0",
           }, { nulls = true, workspace = "8a139c70-49a1-4ba2-98a6-bb36f534269d", })
           assert.is_nil(route)
           assert.is_string(err)

--- a/spec/02-integration/03-db/02-db_core_entities_spec.lua
+++ b/spec/02-integration/03-db/02-db_core_entities_spec.lua
@@ -685,7 +685,7 @@ for _, strategy in helpers.each_strategy() do
             protocols = { "http" },
             hosts = { "example.com" },
             service = assert(db.services:insert({ host = "service.com" })),
-            path_handling = "v1",
+            path_handling = "v0",
           }, { nulls = true })
           assert.is_nil(err_t)
           assert.is_nil(err)
@@ -711,7 +711,7 @@ for _, strategy in helpers.each_strategy() do
             regex_priority  = 0,
             preserve_host   = false,
             strip_path      = true,
-            path_handling   = "v1",
+            path_handling   = "v0",
             tags            = ngx.null,
             service         = route.service,
             https_redirect_status_code = 426,
@@ -728,7 +728,7 @@ for _, strategy in helpers.each_strategy() do
             paths           = { "/example" },
             regex_priority  = 3,
             strip_path      = true,
-            path_handling   = "v1",
+            path_handling   = "v0",
             service         = bp.services:insert(),
           }, { nulls = true })
           assert.is_nil(err_t)
@@ -754,7 +754,7 @@ for _, strategy in helpers.each_strategy() do
             destinations    = ngx.null,
             regex_priority  = 3,
             strip_path      = true,
-            path_handling   = "v1",
+            path_handling   = "v0",
             tags            = ngx.null,
             preserve_host   = false,
             service         = route.service,
@@ -771,7 +771,7 @@ for _, strategy in helpers.each_strategy() do
             paths           = { "/example" },
             regex_priority  = 3,
             strip_path      = true,
-            path_handling   = "v1",
+            path_handling   = "v0",
           }, { nulls = true })
           assert.is_nil(err_t)
           assert.is_nil(err)
@@ -797,7 +797,7 @@ for _, strategy in helpers.each_strategy() do
             tags            = ngx.null,
             regex_priority  = 3,
             strip_path      = true,
-            path_handling   = "v1",
+            path_handling   = "v0",
             preserve_host   = false,
             service         = ngx.null,
             https_redirect_status_code = 426,

--- a/spec/02-integration/03-db/02-db_core_entities_spec.lua
+++ b/spec/02-integration/03-db/02-db_core_entities_spec.lua
@@ -1102,7 +1102,7 @@ for _, strategy in helpers.each_strategy() do
             protocols = { "https" },
             hosts = { "example.com" },
             regex_priority = 5,
-            path_handling = "v1"
+            path_handling = "v0"
           })
           assert.is_nil(err_t)
           assert.is_nil(err)
@@ -1116,7 +1116,7 @@ for _, strategy in helpers.each_strategy() do
             paths           = route.paths,
             regex_priority  = 5,
             strip_path      = route.strip_path,
-            path_handling   = "v1",
+            path_handling   = "v0",
             preserve_host   = route.preserve_host,
             tags            = route.tags,
             service         = route.service,
@@ -1135,7 +1135,7 @@ for _, strategy in helpers.each_strategy() do
             local route = bp.routes:insert({
               hosts   = { "example.com" },
               methods = { "GET" },
-              path_handling = "v1",
+              path_handling = "v0",
             })
 
             local new_route, err, err_t = db.routes:update({ id = route.id }, {
@@ -1151,7 +1151,7 @@ for _, strategy in helpers.each_strategy() do
               hosts           = route.hosts,
               regex_priority  = route.regex_priority,
               strip_path      = route.strip_path,
-              path_handling   = "v1",
+              path_handling   = "v0",
               preserve_host   = route.preserve_host,
               tags            = route.tags,
               service         = route.service,
@@ -1978,7 +1978,7 @@ for _, strategy in helpers.each_strategy() do
           protocols = { "http" },
           hosts     = { "example.com" },
           service   = service,
-          path_handling = "v1",
+          path_handling = "v0",
         }, { nulls = true })
         assert.is_nil(err_t)
         assert.is_nil(err)
@@ -1997,7 +1997,7 @@ for _, strategy in helpers.each_strategy() do
           destinations     = ngx.null,
           regex_priority   = 0,
           strip_path       = true,
-          path_handling    = "v1",
+          path_handling    = "v0",
           preserve_host    = false,
           tags             = ngx.null,
           service          = {

--- a/spec/02-integration/05-proxy/02-router_spec.lua
+++ b/spec/02-integration/05-proxy/02-router_spec.lua
@@ -2095,16 +2095,18 @@ for _, strategy in helpers.each_strategy() do
 
           for i, line in ipairs(path_handling_tests) do
             for j, test in ipairs(line:expand()) do
-              routes[#routes + 1] = {
-                strip_path   = test.strip_path,
-                path_handling = test.path_handling,
-                paths        = test.route_path and { test.route_path } or nil,
-                hosts        = { "localbin-" .. i .. "-" .. j .. ".com" },
-                service = {
-                  name = "plain_" .. i .. "-" .. j,
-                  path = test.service_path,
+              if flavor == "traditional" or test.path_handling == "v0" then
+                routes[#routes + 1] = {
+                  strip_path   = test.strip_path,
+                  path_handling = test.path_handling,
+                  paths        = test.route_path and { test.route_path } or nil,
+                  hosts        = { "localbin-" .. i .. "-" .. j .. ".com" },
+                  service = {
+                    name = "plain_" .. i .. "-" .. j,
+                    path = test.service_path,
+                  }
                 }
-              }
+              end
             end
           end
 


### PR DESCRIPTION

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

This PR ~~denies~~ users from setting `path_handling=v1` when the Kong gateway is running with `router_flavor=traditional_compatible`, as the `path_handling` feature is stepping into deprecation and path_handling v0 will be the default behaviour when composing upstream_uri.

Discussed with the team and decide to only print deprecation log in the current version.

### Full changelog

* Add custom entity check function to deny setting `path_handling=v1` when `router_flavor` is `traditional_compatible`
