### PR TITLE
chore(rockspec) use git+https as a luarocks url

### DIFF
--- a/kong-3.0.0-0.rockspec
+++ b/kong-3.0.0-0.rockspec
@@ -3,7 +3,7 @@ version = "3.0.0-0"
 rockspec_format = "3.0"
 supported_platforms = {"linux", "macosx"}
 source = {
-  url = "git://github.com/Kong/kong",
+  url = "git+https://github.com/Kong/kong.git",
   tag = "3.0.0"
 }
 description = {


### PR DESCRIPTION
### Summary

@jeremyjpj0916 reported on #9282 about a problem in our `2.8.1` `.rock` file in luarocks:
https://luarocks.org/manifests/kong/kong-2.8.1-0.src.rock

That has now been fixed. I used:
```
source = {
  url = "git+https://github.com/Kong/kong.git",
  tag = "2.8.1"
}
```

To upload and generate a new `.rock` file.

Here I will fix the url in our `master` branch to also contain `git+https` and
the `.git` at the end. This should be right according to:
https://github.com/luarocks/luarocks/wiki/Rockspec-format#build-rules

And Github proposed URLs when cloning:
https://github.com/Kong/kong.git

<img width="445" alt="image" src="https://user-images.githubusercontent.com/983257/186203046-b8cc04cf-7431-4f72-a68c-fe95dcedbe9f.png">
