### PR TITLE
fix(log-serializer) ensure upstream_uri includes query args

### DIFF
--- a/kong/pdk/log.lua
+++ b/kong/pdk/log.lua
@@ -32,6 +32,7 @@ local ngx = ngx
 local kong = kong
 local check_phase = phase_checker.check
 local split = utils.split
+local byte = string.byte
 
 
 local _PREFIX = "[kong] "
@@ -39,6 +40,7 @@ local _DEFAULT_FORMAT = "%file_src:%line_src %message"
 local _DEFAULT_NAMESPACED_FORMAT = "%file_src:%line_src [%namespace] %message"
 local PHASES = phase_checker.phases
 local PHASES_LOG = PHASES.log
+local QUESTION_MARK = byte("?")
 
 local phases_with_ctx =
     phase_checker.new(PHASES.rewrite,
@@ -780,6 +782,15 @@ do
         response_size = tonumber(response_size, 10)
       end
 
+      local upstream_uri = var.upstream_uri or ""
+      if upstream_uri ~= "" and not find(upstream_uri, "?", nil, true) then
+        if byte(ctx.request_uri or var.request_uri, -1) == QUESTION_MARK then
+          upstream_uri = upstream_uri .. "?"
+        elseif var.is_args == "?" then
+          upstream_uri = upstream_uri .. "?" .. (var.args or "")
+        end
+      end
+
       return edit_result(ctx, {
         request = {
           uri = request_uri,
@@ -790,7 +801,7 @@ do
           size = request_size,
           tls = request_tls
         },
-        upstream_uri = var.upstream_uri,
+        upstream_uri = upstream_uri,
         response = {
           status = ongx.status,
           headers = ongx.resp.get_headers(),

--- a/spec/01-unit/10-log_serializer_spec.lua
+++ b/spec/01-unit/10-log_serializer_spec.lua
@@ -170,6 +170,18 @@ describe("kong.log.serialize", function()
 
         assert.is_nil(res.tries)
       end)
+
+      it("includes query args in upstream_uri when they are not found in " ..
+         "var.upstream_uri and exist in var.args", function()
+        local args = "arg1=foo&arg2=bar"
+        ngx.var.is_args = "?"
+        ngx.var.args = args
+
+        local res = kong.log.serialize({ngx = ngx, kong = kong, })
+        assert.is_table(res)
+
+        assert.equal("/upstream_uri" .. "?" .. args, res.upstream_uri)
+      end)
     end)
   end)
 


### PR DESCRIPTION
### Summary

Ensure the log parameter `upstream_uri` contains any query args that are sent with the upstream request. 

When there is a cache hit in the `proxy-cache` plugin, the flow is interrupted without executing [access/after() in the runloop](https://github.com/Kong/kong/blob/442df3e2860b85498d8f9ba41c22f6c7d111a2ee/kong/runloop/handler.lua#L1444-L1448) so the value of `upstream_uri` in the logs becomes inconsistent when the `proxy-cache` plugin is enabled.