### PR TITLE
chore(router) router expression name

### DIFF
--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -436,7 +436,7 @@ local CONF_INFERENCES = {
     }
   },
   router_flavor = {
-    enum = { "traditional", "traditional_compatible", "expressions" },
+    enum = { "traditional", "traditional_compatible", "expression" },
   },
   worker_state_update_frequency = { typ = "number" },
 

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -3,7 +3,7 @@ local atc = require("kong.router.atc")
 local router = require("resty.router.router")
 
 
-if kong and kong.configuration and kong.configuration.router_flavor == "expressions" then
+if kong and kong.configuration and kong.configuration.router_flavor == "expression" then
   return {
     name         = "routes",
     primary_key  = { "id" },

--- a/kong/db/schema/entities/routes_subschemas.lua
+++ b/kong/db/schema/entities/routes_subschemas.lua
@@ -66,7 +66,7 @@ local grpc_subschema = {
 }
 
 
-if kong and kong.configuration and  kong.configuration.router_flavor == "expressions" then
+if kong and kong.configuration and  kong.configuration.router_flavor == "expression" then
   return {}
 
 else

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -42,7 +42,7 @@ local service = {
     end
   }
 
-for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions" }) do
+for _, flavor in ipairs({ "traditional", "traditional_compatible", "expression" }) do
   describe("Router (flavor = " .. flavor .. ")", function()
     reload_router(flavor)
     local it_trad_only = (flavor == "traditional") and it or pending


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

`expressions` make a little confused, we rename it to `expression`. or `expressional `?

We should have more discussion of it.
