### PR TITLE
chore(vaults) set env vault version to kong version

### DIFF
--- a/kong/vaults/env/init.lua
+++ b/kong/vaults/env/init.lua
@@ -1,4 +1,6 @@
+local kong_meta = require "kong.meta"
 local ffi = require "ffi"
+
 
 local type = type
 local gsub = string.gsub
@@ -53,7 +55,7 @@ end
 
 
 return {
-  VERSION = "1.0.0",
+  VERSION = kong_meta.version,
   init = init,
   get = get,
 }


### PR DESCRIPTION
### Summary

Follows the same logic that we now have on plugins, e.g. see:
https://github.com/Kong/kong/blob/master/kong/plugins/acl/handler.lua#L44