### PR TITLE
perf(router) dynamic router lru cache size based on number of routes

### DIFF
--- a/kong/router/atc_compat.lua
+++ b/kong/router/atc_compat.lua
@@ -52,7 +52,7 @@ local MAX_HEADER_COUNT = 255
 local MAX_REQ_HEADERS  = 100
 
 
-local MATCH_LRUCACHE_SIZE = utils.MATCH_LRUCACHE_SIZE
+local DEFAULT_MATCH_LRUCACHE_SIZE = utils.DEFAULT_MATCH_LRUCACHE_SIZE
 
 
 -- reuse table objects
@@ -381,11 +381,11 @@ function _M.new(routes, cache, cache_neg)
   local inst = router.new(s)
 
   if not cache then
-    cache = lrucache.new(MATCH_LRUCACHE_SIZE)
+    cache = lrucache.new(DEFAULT_MATCH_LRUCACHE_SIZE)
   end
 
   if not cache_neg then
-    cache_neg = lrucache.new(MATCH_LRUCACHE_SIZE)
+    cache_neg = lrucache.new(DEFAULT_MATCH_LRUCACHE_SIZE)
   end
 
   local routes_n   = #routes

--- a/kong/router/init.lua
+++ b/kong/router/init.lua
@@ -11,7 +11,7 @@ local utils = require("kong.router.utils")
 local is_http = ngx.config.subsystem == "http"
 
 
-_M.MATCH_LRUCACHE_SIZE = utils.MATCH_LRUCACHE_SIZE
+_M.DEFAULT_MATCH_LRUCACHE_SIZE = utils.DEFAULT_MATCH_LRUCACHE_SIZE
 
 
 function _M:exec(ctx)

--- a/kong/router/traditional.lua
+++ b/kong/router/traditional.lua
@@ -166,7 +166,7 @@ do
 end
 
 
-local MATCH_LRUCACHE_SIZE = utils.MATCH_LRUCACHE_SIZE
+local DEFAULT_MATCH_LRUCACHE_SIZE = utils.DEFAULT_MATCH_LRUCACHE_SIZE
 
 
 local MATCH_RULES = {
@@ -1276,7 +1276,7 @@ local function find_match(ctx)
 end
 
 
-local _M = { MATCH_LRUCACHE_SIZE = MATCH_LRUCACHE_SIZE }
+local _M = { DEFAULT_MATCH_LRUCACHE_SIZE = DEFAULT_MATCH_LRUCACHE_SIZE }
 
 
 -- for unit-testing purposes only
@@ -1321,11 +1321,11 @@ function _M.new(routes, cache, cache_neg)
   local routes_by_id = {}
 
   if not cache then
-    cache = lrucache.new(MATCH_LRUCACHE_SIZE)
+    cache = lrucache.new(DEFAULT_MATCH_LRUCACHE_SIZE)
   end
 
   if not cache_neg then
-    cache_neg = lrucache.new(MATCH_LRUCACHE_SIZE)
+    cache_neg = lrucache.new(DEFAULT_MATCH_LRUCACHE_SIZE)
   end
 
   -- index routes

--- a/kong/router/utils.lua
+++ b/kong/router/utils.lua
@@ -28,7 +28,7 @@ Max memory limit: 5 MiBs
 LRU size must be: (5 * 2^20) / 1024 = 5120
 Floored: 5000 items should be a good default
 --]]
-local MATCH_LRUCACHE_SIZE = 5e3
+local DEFAULT_MATCH_LRUCACHE_SIZE = 5000
 
 
 local function sanitize_uri_postfix(uri_postfix)
@@ -236,7 +236,7 @@ end
 
 
 return {
-  MATCH_LRUCACHE_SIZE  = MATCH_LRUCACHE_SIZE,
+  DEFAULT_MATCH_LRUCACHE_SIZE  = DEFAULT_MATCH_LRUCACHE_SIZE,
 
   sanitize_uri_postfix = sanitize_uri_postfix,
   check_select_params  = check_select_params,

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -28,9 +28,6 @@ local gsub              = string.gsub
 local find              = string.find
 local lower             = string.lower
 local fmt               = string.format
-local max               = math.max
-local min               = math.min
-local ceil              = math.ceil
 local ngx               = ngx
 local var               = ngx.var
 local log               = ngx.log
@@ -624,9 +621,15 @@ end
 
 
 do
+  local max  = math.max
+  local min  = math.min
+  local ceil = math.ceil
+
+  local DEFAULT_MATCH_LRUCACHE_SIZE = Router.DEFAULT_MATCH_LRUCACHE_SIZE
+
   local router
   local router_version
-  local router_cache_size = Router.DEFAULT_MATCH_LRUCACHE_SIZE
+  local router_cache_size = DEFAULT_MATCH_LRUCACHE_SIZE
   local router_cache = lrucache.new(router_cache_size)
   local router_cache_neg = lrucache.new(router_cache_size)
 
@@ -787,7 +790,7 @@ do
       end
     end
 
-    local n = Router.DEFAULT_MATCH_LRUCACHE_SIZE
+    local n = DEFAULT_MATCH_LRUCACHE_SIZE
     local cache_size = min(ceil(max(i / n, 1)) * n, n * 20)
 
     local reinitialize_cache = cache_size ~= router_cache_size


### PR DESCRIPTION
### Summary

Implements dynamic router LRU cache size based on number of routes.

- By default we initialize positive router LRU cache of 5000 items.
- If there is more than 5000 routes we reinitialize cache to closest 5000, e.g. if there is 5001 routes, we re-initialize cache to 10000 items and keep the size 10000 until number of routes reaches either over 10000 or less than 5001.
- The maximum size of cache is limited to 100000 items.

This should improve our routing performance with high number of routes when routes are found in cache. This will increase memory usage though, but it is expected for users to have beefier systems when number of routes is high (again we limit this to 100000). If previous LRU of 5000 items took around 5 MB, the dynamic is expected to take 100 MB at most (per worker).