### PR TITLE
tests(clustering) add missing wrpc handler gate

### DIFF
--- a/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
@@ -20,15 +20,7 @@ for _, strategy in helpers.each_strategy() do
     describe("CP/DP sync works with #" .. strategy .. " backend, protocol #" .. cluster_protocol, function()
 
       lazy_setup(function()
-        helpers.get_db_utils(strategy, {
-          "routes",
-          "services",
-          "plugins",
-          "upstreams",
-          "targets",
-          "certificates",
-          "clustering_data_planes",
-        }) -- runs migrations
+        helpers.get_db_utils(strategy) -- runs migrations
 
         assert(helpers.start_kong({
           role = "control_plane",
@@ -358,15 +350,7 @@ for _, strategy in helpers.each_strategy() do
     -- for these tests, we do not need a real DP, but rather use the fake DP
     -- client so we can mock various values (e.g. node_version)
     describe("relaxed compatibility check:", function()
-      local bp = helpers.get_db_utils(strategy, {
-        "routes",
-        "services",
-        "plugins",
-        "upstreams",
-        "targets",
-        "certificates",
-        "clustering_data_planes",
-      }) -- runs migrations
+      local bp = helpers.get_db_utils(strategy) -- runs migrations
 
       bp.plugins:insert {
         name = "key-auth",
@@ -639,15 +623,7 @@ for _, strategy in helpers.each_strategy() do
   for cluster_protocol, conf in pairs(confs) do
     describe("CP/DP sync works with #" .. strategy .. " backend, protocol " .. cluster_protocol, function()
       lazy_setup(function()
-        helpers.get_db_utils(strategy, {
-          "routes",
-          "services",
-          "plugins",
-          "upstreams",
-          "targets",
-          "certificates",
-          "clustering_data_planes",
-        }) -- runs migrations
+        helpers.get_db_utils(strategy) -- runs migrations
 
         assert(helpers.start_kong({
           role = "control_plane",
@@ -761,15 +737,7 @@ for _, strategy in helpers.each_strategy() do
 
   describe("CP/DP sync works with #" .. strategy .. " backend, two DPs via different protocols on the same CP", function()
     lazy_setup(function()
-      helpers.get_db_utils(strategy, {
-        "routes",
-        "services",
-        "plugins",
-        "upstreams",
-        "targets",
-        "certificates",
-        "clustering_data_planes",
-      }) -- runs migrations
+      helpers.get_db_utils(strategy) -- runs migrations
 
       assert(helpers.start_kong({
         role = "control_plane",

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -451,11 +451,13 @@ http {
             }
         }
 
+> if not legacy_hybrid_protocol then
         location = /v1/wrpc {
             content_by_lua_block {
                 Kong.serve_wrpc_listener()
             }
         }
+> end
     }
 > end -- role == "control_plane"
 


### PR DESCRIPTION
This updates the `custom_nginx.template` (commonly used in our integration tests) with the `legacy_hybrid_protocol` gate, bringing it into parity with the production template:
https://github.com/Kong/kong/blob/9af18e1b02c1740e5a541198cd48af719cb5cee8/kong/templates/nginx_kong.lua#L442-L448

See #9145