### PR TITLE
chore(api) Unify the version we return on the '/' endpoint

### DIFF
--- a/kong/api/routes/kong.lua
+++ b/kong/api/routes/kong.lua
@@ -5,13 +5,14 @@ local Errors = require "kong.db.errors"
 local process = require "ngx.process"
 
 local kong = kong
+local meta = require "kong.meta"
 local knode  = (kong and kong.node) and kong.node or
                require "kong.pdk.node".new()
 local errors = Errors.new()
 
 
 local tagline = "Welcome to " .. _KONG._NAME
-local version = _KONG._VERSION
+local version = meta.version
 local lua_version = jit and jit.version or _VERSION
 
 


### PR DESCRIPTION
### Summary

This doesn't actually change anything about this field in Kong OSS,
but in EE the `_VERSION` field includes `-enterprise-edition`. We don't
want to include the edition information as part of our kong version
information on the '/' endpoint because that is machine parseable.

