### PR TITLE
chore(deps) bump dev dependency of luacheck and busted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ $(info starting make in kong)
 OS := $(shell uname | awk '{print tolower($$0)}')
 MACHINE := $(shell uname -m)
 
-DEV_ROCKS = "busted 2.0.0" "busted-htest 1.0.0" "luacheck 1.0.0" "lua-llthreads2 0.1.6" "http 0.4" "ldoc 1.4.6"
+DEV_ROCKS = "busted 2.1.1" "busted-htest 1.0.0" "luacheck 1.0.0" "lua-llthreads2 0.1.6" "http 0.4" "ldoc 1.4.6"
 WIN_SCRIPTS = "bin/busted" "bin/kong"
 BUSTED_ARGS ?= -v
 TEST_CMD ?= bin/busted $(BUSTED_ARGS)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ $(info starting make in kong)
 OS := $(shell uname | awk '{print tolower($$0)}')
 MACHINE := $(shell uname -m)
 
-DEV_ROCKS = "busted 2.0.0" "busted-htest 1.0.0" "luacheck 0.26.1" "lua-llthreads2 0.1.6" "http 0.4" "ldoc 1.4.6"
+DEV_ROCKS = "busted 2.0.0" "busted-htest 1.0.0" "luacheck 1.0.0" "lua-llthreads2 0.1.6" "http 0.4" "ldoc 1.4.6"
 WIN_SCRIPTS = "bin/busted" "bin/kong"
 BUSTED_ARGS ?= -v
 TEST_CMD ?= bin/busted $(BUSTED_ARGS)
@@ -51,7 +51,7 @@ ifneq ($(TAG),)
 	# if we're building a tag the tag name is the KONG_VERSION (allows for environment var to override)
 	ISTAG = true
 	KONG_VERSION ?= $TAG
-	
+
 	POSSIBLE_PRERELEASE_NAME = $(shell git describe --tags --abbrev=0 | awk -F"-" '{print $$2}')
 	ifneq ($(POSSIBLE_PRERELEASE_NAME),)
 		# it's a pre-release if the tag has a - in which case it's an internal release only


### PR DESCRIPTION
### Summary

####  bump dev dependency of luacheck from 0.26.1 to 1.0.0

##### Documentation

- [**breaking**] Follow semver guidelines, next release will be v1.x.y

##### Features

- Overhaul docker container to run on Lua 5.4
- Store cached luacheck values per-version in case of changes
- Set_default_std for ldoc
- Add builtin std option for Ldoc globals
- Add builtin std option for the Playdate SDK

#### chore(deps) bump dev dependency of busted from 2.0.0 to 2.1.1

##### Bug Fixes
- Refactor rockspec to dodge luarocks 3.1.3 bug
- Fix caching the ffi.typeof function on luajit — @Tieske
- Fix 'metatype' as a patched method on luajit — @Tieske
- Report pending without function argument — @Tieske
- Cache all outputter functions, use io.write not print — @Tieske
- Exit when CLI specified helper fails — @Tieske
- Restore globals set to nil in insulate block — @Henkoglobin
- Change rockspec URL to git+https — @Frenzie
- Fix error in gtest and utfhandlers if color was set — @Tieske
- Avoid GitHub marketplace namespace conflict

##### Features
- Add tooling so repository can be used as a GitHub action — @alerque
- Add Dockefile and publish to GHCR — @alerque
- Add function to locate relative fixtures — @Tieske
- Add CLI support for setting luacov config path — @nicholaschiasson
- Add helpers to read/load fixtures — @Tieske
- Add Romanian translation — @1337M0nst3r
- Enable color overrides for utf+gtest handlers — @Tieske
- Miscellaneous Tasks
- Overhaul CI & add automatic publishing from rockspecs — @alerque
- Bump luassert/say deps
- Update terra loader to use the global-injection of current Terra — @Tieske