### PR TITLE
fix(db) blue/green migration for route regex path

### DIFF
--- a/kong/db/migrations/core/016_280_to_300.lua
+++ b/kong/db/migrations/core/016_280_to_300.lua
@@ -143,7 +143,7 @@ local function c_copy_vaults_beta_to_sm_vaults(coordinator)
 end
 
 
-local function c_normalize_regex_path(coordinator)
+local function c_migrate_regex_path(coordinator)
   for rows, err in coordinator:iterate("SELECT id, paths FROM routes") do
     if err then
       return nil, err
@@ -320,6 +320,8 @@ return {
       $$;
     ]],
 
+    up_f = p_migrate_regex_path,
+
     teardown = function(connector)
       local _, err = connector:query([[
         DROP TABLE IF EXISTS vaults_beta;
@@ -331,11 +333,6 @@ return {
       end
 
       local _, err = p_update_cache_key(connector)
-      if err then
-        return nil, err
-      end
-
-      _, err = p_migrate_regex_path(connector)
       if err then
         return nil, err
       end
@@ -406,6 +403,11 @@ return {
       if err then
         return nil, err
       end
+
+      _, err = c_migrate_regex_path(coordinator)
+      if err then
+        return nil, err
+      end
     end,
 
     teardown = function(connector)
@@ -434,11 +436,6 @@ return {
       local ok
       ok, err = connector:wait_for_schema_consensus()
       if not ok then
-        return nil, err
-      end
-
-      _, err = c_normalize_regex_path(coordinator)
-      if err then
         return nil, err
       end
 


### PR DESCRIPTION
The migration steps should happen in the up phase, not the teardown phase.

Notice this PR needs cooperation from 2.8.x.x.

fix FT-3293
