### PR TITLE
fix(core): ensure absolute path is used for event sock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,8 +103,9 @@
 - Fix issue in router rebuilding where when paths field is invalid,
   the router's mutex is not released properly.
   [#9480](https://github.com/Kong/kong/pull/9480)
-- Fixed an issue where `kong docker-start` would fail if KONG_PREFIX was set to
-  a relative path. [#9337](https://github.com/Kong/kong/pull/9337)
+- Fixed an issue where `kong docker-start` would fail if `KONG_PREFIX` was set to
+  a relative path.
+  [#9337](https://github.com/Kong/kong/pull/9337)
 - Fixed an issue with error-handling and process cleanup in `kong start`.
   [#9337](https://github.com/Kong/kong/pull/9337)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,10 @@
 - Fix issue in router rebuilding where when paths field is invalid,
   the router's mutex is not released properly.
   [#9480](https://github.com/Kong/kong/pull/9480)
+- Fixed an issue where `kong docker-start` would fail if KONG_PREFIX was set to
+  a relative path. [#9337](https://github.com/Kong/kong/pull/9337)
+- Fixed an issue with error-handling and process cleanup in `kong start`.
+  [#9337](https://github.com/Kong/kong/pull/9337)
 
 #### CLI
 

--- a/kong/cmd/start.lua
+++ b/kong/cmd/start.lua
@@ -107,7 +107,7 @@ local function execute(args)
 
   if err then
     log.verbose("could not start Kong, stopping services")
-    pcall(nginx_signals.stop(conf))
+    pcall(nginx_signals.stop, conf)
     log.verbose("stopped services")
     error(err) -- report to main error handler
   end

--- a/kong/global.lua
+++ b/kong/global.lua
@@ -186,16 +186,22 @@ function _GLOBAL.init_worker_events()
     worker_events = require "resty.worker.events"
 
   else
-    local sock_name = "worker_events.sock"
-    if ngx.config.subsystem == "stream" then
-      sock_name = "stream_" .. sock_name
-    end
+    -- `kong.configuration.prefix` is already normalized to an absolute path,
+    -- but `ngx.config.prefix()` is not
+    local prefix = configuration
+                   and configuration.prefix
+                   or require("pl.path").abspath(ngx.config.prefix())
+
+    local sock = ngx.config.subsystem == "stream"
+                 and "stream_worker_events.sock"
+                 or "worker_events.sock"
+
+    local listening = "unix:" .. prefix .. "/" .. sock
 
     opts = {
       unique_timeout = 5,     -- life time of unique event data in lrucache
       broker_id = 0,          -- broker server runs in nginx worker #0
-      listening = "unix:" ..  -- unix socket for broker listening
-                  ngx.config.prefix() .. sock_name,
+      listening = listening,  -- unix socket for broker listening
       max_queue_len = 1024 * 50,  -- max queue len for events buffering
     }
 

--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -817,7 +817,7 @@ describe("kong start/stop #" .. strategy, function()
       end)
 
       assert(helpers.kong_exec(string.format("prepare -p %q", prefix), {
-        db = strategy,
+        database = strategy,
         proxy_listen = "127.0.0.1:8000",
         stream_listen = "127.0.0.1:9000",
         admin_listen  = "127.0.0.1:8001",


### PR DESCRIPTION
### Summary

This fixes an issue with how Kong initializes resty.events. The code was
previously using `ngx.config.prefix()` to determine the listening socket
path to provide to the resty.events module. This causes breakage when
NGINX is started with a relative path prefix:

> failed to instantiate 'kong.worker_events' module: failed to disable listening: unix:my-prefix/worker_events.sock

Instead of using `ngx.config.prefix()`, Kong will now prefer
`kong.configuration.prefix` when available, as it is already normalized
to an absolute path. If `kong.configuration.prefix` is not defined, the
result of `ngx.config.prefix()` will be used after resolving it to an
absolute path.

Also contains an unrelated fix in `kong/cmd/start.lua`.

### Full changelog

* prefer `kong.configuration.prefix` to `ngx.config.prefix()`
* convert `ngx.config.prefix()` to an absolute path before using it
* fix pcall usage in `kong.cmd.start`