### PR TITLE
chore(gha): don't unit test .md file changes

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,5 +1,10 @@
 name: Build & Test
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    paths-ignore:
+    # ignore top-level markdown files (CHANGELOG.md, README.md, etc.)
+    - '*.md'
 
 jobs:
   build:


### PR DESCRIPTION
### Summary

This change is desired because it eliminates the need for builds/unit tests to pass on PRs that exclusively include only markdown file changes.
Hopefully, this will reduce the time it takes for markdown-only PRs to get approved and merged.

This is a sister PR to https://github.com/Kong/kong-ee/pull/3692

### Full changelog

* [Implement changes to skip builds/unit tests for markdown file PRs]