### PR TITLE
fix(router/atc) detect and return error for concurrent rebuilds durin…

### DIFF
--- a/kong/router/atc_compat.lua
+++ b/kong/router/atc_compat.lua
@@ -443,11 +443,18 @@ local function new_from_scratch(routes, is_traditional_compatible)
       services = services_t,
       fields = inst:get_fields(),
       updated_at = new_updated_at,
+      rebuilding = false,
     }, _MT)
 end
 
 
 local function new_from_previous(routes, is_traditional_compatible, old_router)
+  if old_router.rebuilding then
+    return nil, "concurrent incremental router rebuild without mutex, this is unsafe"
+  end
+
+  old_router.rebuilding = true
+
   local inst = old_router.router
   local old_routes = old_router.routes
   local old_services = old_router.services
@@ -503,6 +510,7 @@ local function new_from_previous(routes, is_traditional_compatible, old_router)
   end
 
   old_router.fields = inst:get_fields()
+  old_router.rebuilding = false
 
   return old_router
 end

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -793,9 +793,7 @@ do
     local n = DEFAULT_MATCH_LRUCACHE_SIZE
     local cache_size = min(ceil(max(i / n, 1)) * n, n * 20)
 
-    local reinitialize_cache = cache_size ~= router_cache_size
-    if reinitialize_cache then
-      router_cache:flush_all()
+    if cache_size ~= router_cache_size then
       router_cache = lrucache.new(cache_size)
       router_cache_size = cache_size
     end
@@ -811,10 +809,7 @@ do
       router_version = version
     end
 
-    if not reinitialize_cache then
-      router_cache:flush_all()
-    end
-
+    router_cache:flush_all()
     router_cache_neg:flush_all()
 
     return true

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -14,7 +14,7 @@ local function reload_router(flavor)
   Router = require "kong.router"
 end
 
-local function new_router(cases)
+local function new_router(cases, old_router)
   -- add fields expression/priority
   for _, v in ipairs(cases) do
     local r = v.route
@@ -23,7 +23,7 @@ local function new_router(cases)
     r.priority = r.priority or atc_compat._route_priority(r)
   end
 
-  return Router.new(cases)
+  return Router.new(cases, nil, nil, old_router)
 end
 
 local service = {
@@ -1666,6 +1666,198 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
           end
         end)
       end)
+
+      if flavor ~= "traditional" then
+        describe("incremental rebuild", function()
+          local router
+          local use_case = {
+            {
+              service = service,
+              route = {
+                id = "e8fb37f1-102d-461e-9c51-6608a6bb8101",
+                paths = { "/foo", },
+                updated_at = 100,
+              },
+            },
+            {
+              service = service,
+              route = {
+                id = "e8fb37f1-102d-461e-9c51-6608a6bb8102",
+                paths = { "/bar", },
+                updated_at = 90,
+              },
+            }
+          }
+
+          before_each(function()
+            router = assert(new_router(use_case))
+          end)
+
+          it("matches initially", function()
+            local match_t = router:select("GET", "/foo")
+            assert.truthy(match_t)
+            assert.same(use_case[1].route, match_t.route)
+
+            match_t = router:select("GET", "/bar")
+            assert.truthy(match_t)
+            assert.same(use_case[2].route, match_t.route)
+          end)
+
+          it("update/remove works", function()
+            local use_case = {
+              {
+                service = service,
+                route = {
+                  id = "e8fb37f1-102d-461e-9c51-6608a6bb8101",
+                  paths = { "/foo1", },
+                  updated_at = 100,
+                },
+              },
+            }
+
+            local nrouter = assert(new_router(use_case, router))
+
+            assert.equal(nrouter, router)
+
+            local match_t = nrouter:select("GET", "/foo1")
+            assert.truthy(match_t)
+            assert.same(use_case[1].route, match_t.route)
+
+            match_t = nrouter:select("GET", "/bar")
+            assert.falsy(match_t)
+          end)
+
+          it("update skips routes if updated_at is unchanged", function()
+            local use_case = {
+              {
+                service = service,
+                route = {
+                  id = "e8fb37f1-102d-461e-9c51-6608a6bb8101",
+                  paths = { "/foo", },
+                  updated_at = 100,
+                },
+              },
+              {
+                service = service,
+                route = {
+                  id = "e8fb37f1-102d-461e-9c51-6608a6bb8102",
+                  paths = { "/baz", },
+                  updated_at = 90,
+                },
+              }
+            }
+
+            local nrouter = assert(new_router(use_case, router))
+
+            assert.equal(nrouter, router)
+
+            local match_t = nrouter:select("GET", "/baz")
+            assert.falsy(match_t)
+
+            match_t = nrouter:select("GET", "/bar")
+            assert.truthy(match_t)
+            assert.same(use_case[2].route, match_t.route)
+          end)
+
+          it("clears match and negative cache after rebuild", function()
+            local match_t = router:select("GET", "/baz")
+            assert.falsy(match_t)
+
+            match_t = router:select("GET", "/foo")
+            assert.truthy(match_t)
+            assert.same(use_case[1].route, match_t.route)
+
+            local use_case = {
+              {
+                service = service,
+                route = {
+                  id = "e8fb37f1-102d-461e-9c51-6608a6bb8101",
+                  paths = { "/foz", },
+                  updated_at = 100,
+                },
+              },
+              {
+                service = service,
+                route = {
+                  id = "e8fb37f1-102d-461e-9c51-6608a6bb8102",
+                  paths = { "/baz", },
+                  updated_at = 100,
+                },
+              }
+            }
+
+
+            local nrouter = assert(new_router(use_case, router))
+
+            assert.equal(nrouter, router)
+
+            local match_t = nrouter:select("GET", "/foo")
+            assert.falsy(match_t)
+
+            match_t = nrouter:select("GET", "/baz")
+            assert.truthy(match_t)
+            assert.same(use_case[2].route, match_t.route)
+          end)
+
+          it("detects concurrent incremental builds", function()
+            local use_cases = {
+              {
+                service = service,
+                route = {
+                  id = "e8fb37f1-102d-461e-9c51-6608a6bb8101",
+                  paths = { "/foz", },
+                  updated_at = 100,
+                },
+              },
+              {
+                service = service,
+                route = {
+                  id = "e8fb37f1-102d-461e-9c51-6608a6bb8102",
+                  paths = { "/baz", },
+                  updated_at = 100,
+                },
+              }
+            }
+
+            -- needs to be larger than YIELD_ITERATIONS
+            for i = 1, 1000 do
+              use_cases[i] = {
+                service = service,
+                route = {
+                  id = "e8fb37f1-102d-461e-9c51-6608a6bb" .. string.format("%04d", i),
+                  paths = { "/" .. i, },
+                  updated_at = 100,
+                },
+              }
+            end
+
+            local threads = {}
+
+            -- make sure yield() actually works
+            ngx.IS_CLI = false
+
+            for i = 1, 10 do
+              threads[i] = ngx.thread.spawn(function()
+                return new_router(use_cases, router)
+              end)
+            end
+
+            local error_detected = false
+
+            for i = 1, 10 do
+              local _, _, err = ngx.thread.wait(threads[i])
+              if err == "concurrent incremental router rebuild without mutex, this is unsafe" then
+                error_detected = true
+                break
+              end
+            end
+
+            ngx.IS_CLI = true
+
+            assert.truthy(error_detected)
+          end)
+        end)
+      end
 
       describe("normalization stopgap measurements", function()
         local use_case, router


### PR DESCRIPTION
…g incremental updates

Ensure incremental router builds that are not guarded by
concurrency mutexes are caught and add incremental router rebuild tests

This is a cherry-pick from `master`.