### PR TITLE
RateLimiting/ResponseRateLimiting: change the default policy to local (FT-3295)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,10 @@
   `ngx.ctx.proxy_cache_hit` anymore. Logging plugins that need the response data
   must read it from `kong.ctx.shared.proxy_cache_hit` from Kong 3.0 on.
   [#8607](https://github.com/Kong/kong/pull/8607)
+- **Rate-limiting**: The default policy is now `local` for all deployment modes.
+  [#9344](https://github.com/Kong/kong/pull/9344)
+- **Response-rate-limiting**: The default policy is now `local` for all deployment modes.
+  [#9344](https://github.com/Kong/kong/pull/9344)
 
 ### Deprecations
 

--- a/kong/plugins/rate-limiting/schema.lua
+++ b/kong/plugins/rate-limiting/schema.lua
@@ -48,7 +48,7 @@ if is_dbless() then
 else
   policy = {
     type = "string",
-    default = "cluster",
+    default = "local",
     len_min = 0,
     one_of = {
       "local",

--- a/kong/plugins/response-ratelimiting/schema.lua
+++ b/kong/plugins/response-ratelimiting/schema.lua
@@ -47,7 +47,7 @@ if is_dbless() then
 else
   policy = {
     type = "string",
-    default = "cluster",
+    default = "local",
     one_of = {
       "local",
       "cluster",

--- a/spec/03-plugins/24-response-rate-limiting/03-api_spec.lua
+++ b/spec/03-plugins/24-response-rate-limiting/03-api_spec.lua
@@ -65,7 +65,7 @@ for _, strategy in helpers.each_strategy() do
           message = "schema violation (config.limits: required field missing)",
         }, json)
       end)
-      it("accepts proper config", function()
+      it("accepts proper config and sets local policy by default", function()
         local route = bp.routes:insert {
           hosts = { "test1.test" },
         }
@@ -87,6 +87,7 @@ for _, strategy in helpers.each_strategy() do
         })
         local body = cjson.decode(assert.res_status(201, res))
         assert.equal(10, body.config.limits.video.second)
+        assert.equal("local", body.config.policy)
       end)
     end)
   end)


### PR DESCRIPTION
This will only affect new plugin configuration, so no cp/dp compat fix is required. docs PR to be done when merged.