### PR TITLE
fix(router) old_route has wrong assignment order

### DIFF
--- a/kong/router/atc_compat.lua
+++ b/kong/router/atc_compat.lua
@@ -26,6 +26,7 @@ local setmetatable = setmetatable
 local pairs = pairs
 local ipairs = ipairs
 local type = type
+local assert = assert
 local tonumber = tonumber
 local get_schema = atc.get_schema
 local max = math.max
@@ -412,7 +413,7 @@ local function add_atc_matcher(inst, route, route_id,
   end
 
   if remove_existing then
-    inst:remove_matcher(route_id)
+    assert(inst:remove_matcher(route_id))
   end
 
   assert(inst:add_matcher(priority, route_id, atc))
@@ -486,13 +487,13 @@ local function new_from_previous(routes, is_traditional_compatible, old_router)
       return nil, "could not categorize route"
     end
 
+    local old_route = old_routes[route_id]
+    local route_updated_at = route.updated_at
+
     route.seen = true
 
     old_routes[route_id] = route
     old_services[route_id] = r.service
-
-    local old_route = old_routes[route_id]
-    local route_updated_at = route.updated_at
 
     if not old_route then
       -- route is new

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -72,7 +72,7 @@ char *strerror(int errnum);
 ]]
 
 local _M = {}
-local YIELD_ITERATIONS = 500
+local YIELD_ITERATIONS = 1000
 
 --- splits a string.
 -- just a placeholder to the penlight `pl.stringx.split` function

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -1858,6 +1858,53 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
 
             assert.truthy(error_detected)
           end)
+
+          it("generates the correct diff", function()
+            local old_router = atc_compat.new({
+              {
+                route = {
+                  id = "e8fb37f1-102d-461e-9c51-6608a6bb8101",
+                  paths = {
+                    "/a"
+                  },
+                  expression = 'http.path ^= "/a"',
+                  priority = 1,
+                  updated_at = 100,
+                },
+              },
+            })
+
+            local add_matcher = spy.on(old_router.router, "add_matcher")
+            local remove_matcher = spy.on(old_router.router, "remove_matcher")
+
+            atc_compat.new({
+              {
+                route = {
+                  id = "e8fb37f1-102d-461e-9c51-6608a6bb8101",
+                  paths = {
+                    "/b",
+                  },
+                  expression = 'http.path ^= "/b"',
+                  priority = 1,
+                  updated_at = 101,
+                }
+              },
+              {
+                route = {
+                  id = "e8fb37f1-102d-461e-9c51-6608a6bb8102",
+                  paths = {
+                    "/c",
+                  },
+                  expression = 'http.path ^= "/c"',
+                  priority = 1,
+                  updated_at = 102,
+                },
+              },
+            }, nil, nil, old_router)
+
+            assert.spy(add_matcher).was_called(2)
+            assert.spy(remove_matcher).was_called(1)
+          end)
         end)
       end
 
@@ -4250,4 +4297,3 @@ describe("[both regex and prefix with regex_priority]", function()
   end)
 
 end)
-


### PR DESCRIPTION
### Summary

The assignment of `old_route` is wrong, it should happen before `old_routes[route_id] = route`.

And in the previous code, the rebuild is actually a complete build, not an incremental build.

