### PR TITLE
fix(request-transformer) properly catch errors of cjson.encode as we changed to cjson.safe now

### DIFF
--- a/kong/plugins/request-transformer/access.lua
+++ b/kong/plugins/request-transformer/access.lua
@@ -343,7 +343,7 @@ local function transform_json_body(conf, body, content_length)
   end
 
   if removed or renamed or replaced or added or appended then
-    return true, cjson.encode(parameters)
+    return true, assert(cjson.encode(parameters))
   end
 end
 


### PR DESCRIPTION
fix issue introduced by [#9186](https://github.com/Kong/kong/pull/9186)

FTI-4205
