### PR TITLE
feat(conf) add support for remaining variables

### DIFF
--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -752,7 +752,7 @@ local function check_and_infer(conf, opts)
           if not exists(cert) then
             local _, err = openssl_x509.new(cert)
             if err then
-              errors[#errors + 1] = prefix .. "ssl_cert: no such file at " .. cert
+              errors[#errors + 1] = prefix .. "ssl_cert: failed loading certificate from " .. cert
             end
           end
         end
@@ -763,7 +763,7 @@ local function check_and_infer(conf, opts)
           if not exists(cert_key) then
             local _, err = openssl_pkey.new(cert_key)
             if err then
-              errors[#errors + 1] = prefix .. "ssl_cert_key: no such file at " .. cert_key
+              errors[#errors + 1] = prefix .. "ssl_cert_key: failed loading key from " .. cert_key
             end
           end
         end
@@ -785,14 +785,14 @@ local function check_and_infer(conf, opts)
     if client_ssl_cert and not exists(client_ssl_cert) then
       local _, err = openssl_x509.new(client_ssl_cert)
       if err then
-        errors[#errors + 1] = "client_ssl_cert: no such file at " .. client_ssl_cert
+        errors[#errors + 1] = "client_ssl_cert: failed loading certificate from " .. client_ssl_cert
       end
     end
 
     if client_ssl_cert_key and not exists(client_ssl_cert_key) then
       local _, err = openssl_pkey.new(client_ssl_cert_key)
       if err then
-        errors[#errors + 1] = "client_ssl_cert_key: no such file at " ..
+        errors[#errors + 1] = "client_ssl_cert_key: failed loading key from " ..
                                client_ssl_cert_key
       end
     end
@@ -1013,14 +1013,14 @@ local function check_and_infer(conf, opts)
       if not exists(cluster_cert) then
         local _, err = openssl_x509.new(cluster_cert)
         if err then
-          errors[#errors + 1] = "cluster_cert: no such file at " .. cluster_cert
+          errors[#errors + 1] = "cluster_cert: failed loading certificate from " .. cluster_cert
         end
       end
 
       if not exists(cluster_cert_key) then
         local _, err = openssl_pkey.new(cluster_cert_key)
         if err then
-          errors[#errors + 1] = "cluster_cert_key: no such file at " .. cluster_cert_key
+          errors[#errors + 1] = "cluster_cert_key: failed loading key from " .. cluster_cert_key
         end
       end
     end

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -770,8 +770,8 @@ describe("Configuration loader", function()
             ssl_cert_key = "/path/cert_key.pem"
           })
           assert.equal(2, #errors)
-          assert.contains("ssl_cert: no such file at /path/cert.pem", errors)
-          assert.contains("ssl_cert_key: no such file at /path/cert_key.pem", errors)
+          assert.contains("ssl_cert: failed loading certificate from /path/cert.pem", errors)
+          assert.contains("ssl_cert_key: failed loading key from /path/cert_key.pem", errors)
           assert.is_nil(conf)
 
           conf, _, errors = conf_loader(nil, {
@@ -779,7 +779,7 @@ describe("Configuration loader", function()
             ssl_cert_key = "/path/cert_key.pem"
           })
           assert.equal(1, #errors)
-          assert.contains("ssl_cert_key: no such file at /path/cert_key.pem", errors)
+          assert.contains("ssl_cert_key: failed loading key from /path/cert_key.pem", errors)
           assert.is_nil(conf)
         end)
         it("requires SSL DH param file to exist", function()
@@ -1050,8 +1050,8 @@ describe("Configuration loader", function()
             client_ssl_cert_key = "/path/cert_key.pem"
           })
           assert.equal(2, #errors)
-          assert.contains("client_ssl_cert: no such file at /path/cert.pem", errors)
-          assert.contains("client_ssl_cert_key: no such file at /path/cert_key.pem", errors)
+          assert.contains("client_ssl_cert: failed loading certificate from /path/cert.pem", errors)
+          assert.contains("client_ssl_cert_key: failed loading key from /path/cert_key.pem", errors)
           assert.is_nil(conf)
 
           conf, _, errors = conf_loader(nil, {
@@ -1060,7 +1060,7 @@ describe("Configuration loader", function()
             client_ssl_cert_key = "/path/cert_key.pem"
           })
           assert.equal(1, #errors)
-          assert.contains("client_ssl_cert_key: no such file at /path/cert_key.pem", errors)
+          assert.contains("client_ssl_cert_key: failed loading key from /path/cert_key.pem", errors)
           assert.is_nil(conf)
         end)
         it("resolves SSL cert/key to absolute path", function()
@@ -1117,8 +1117,8 @@ describe("Configuration loader", function()
             admin_ssl_cert_key = "/path/cert_key.pem"
           })
           assert.equal(2, #errors)
-          assert.contains("admin_ssl_cert: no such file at /path/cert.pem", errors)
-          assert.contains("admin_ssl_cert_key: no such file at /path/cert_key.pem", errors)
+          assert.contains("admin_ssl_cert: failed loading certificate from /path/cert.pem", errors)
+          assert.contains("admin_ssl_cert_key: failed loading key from /path/cert_key.pem", errors)
           assert.is_nil(conf)
 
           conf, _, errors = conf_loader(nil, {
@@ -1126,7 +1126,7 @@ describe("Configuration loader", function()
             admin_ssl_cert_key = "/path/cert_key.pem"
           })
           assert.equal(1, #errors)
-          assert.contains("admin_ssl_cert_key: no such file at /path/cert_key.pem", errors)
+          assert.contains("admin_ssl_cert_key: failed loading key from /path/cert_key.pem", errors)
           assert.is_nil(conf)
         end)
         it("resolves SSL cert/key to absolute path", function()
@@ -1188,8 +1188,8 @@ describe("Configuration loader", function()
             status_ssl_cert_key = "/path/cert_key.pem"
           })
           assert.equal(2, #errors)
-          assert.contains("status_ssl_cert: no such file at /path/cert.pem", errors)
-          assert.contains("status_ssl_cert_key: no such file at /path/cert_key.pem", errors)
+          assert.contains("status_ssl_cert: failed loading certificate from /path/cert.pem", errors)
+          assert.contains("status_ssl_cert_key: failed loading key from /path/cert_key.pem", errors)
           assert.is_nil(conf)
 
           conf, _, errors = conf_loader(nil, {
@@ -1198,7 +1198,7 @@ describe("Configuration loader", function()
             status_ssl_cert_key = "/path/cert_key.pem"
           })
           assert.equal(1, #errors)
-          assert.contains("status_ssl_cert_key: no such file at /path/cert_key.pem", errors)
+          assert.contains("status_ssl_cert_key: failed loading key from /path/cert_key.pem", errors)
           assert.is_nil(conf)
         end)
         it("resolves SSL cert/key to absolute path", function()


### PR DESCRIPTION
### Summary

* move creation of certificate and key files in a separate block
* write certs and keys files for the remaining values: cluster_* and client_*
* update configuration with generated path for cluster_* and client_*