### PR TITLE
chore(clustering) old cp switch

### DIFF
--- a/kong/clustering/init.lua
+++ b/kong/clustering/init.lua
@@ -108,7 +108,9 @@ function _M:init_cp_worker(plugins_list)
   -- their data planes
   kong.worker_events.register(handle_dao_crud_event, "dao:crud")
 
-  self.json_handler:init_worker(plugins_list)
+  if kong.configuration.legacy_hybrid_compatibility then
+    self.json_handler:init_worker(plugins_list)
+  end
   if not kong.configuration.legacy_hybrid_protocol then
       self.wrpc_handler:init_worker(plugins_list)
   end

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -532,6 +532,7 @@ local CONF_INFERENCES = {
 
   legacy_worker_events = { typ = "boolean" },
   legacy_hybrid_protocol = { typ = "boolean" },
+  legacy_hybrid_compatibility = { typ = "boolean" },
 
   lmdb_environment_path = { typ = "string" },
   lmdb_map_size = { typ = "string" },

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -173,6 +173,7 @@ untrusted_lua_sandbox_environment =
 
 legacy_worker_events = off
 legacy_hybrid_protocol = off
+legacy_hybrid_compatibility = on
 
 openresty_path =
 

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -433,11 +433,13 @@ server {
     ssl_certificate_key ${{CLUSTER_CERT_KEY}};
     ssl_session_cache   shared:ClusterSSL:10m;
 
+> if legacy_hybrid_compatibility then
     location = /v1/outlet {
         content_by_lua_block {
             Kong.serve_cluster_listener()
         }
     }
+> end
 
 > if not legacy_hybrid_protocol then
     location = /v1/wrpc {

--- a/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
@@ -25,6 +25,7 @@ for _, strategy in helpers.each_strategy() do
         assert(helpers.start_kong({
           role = "control_plane",
           legacy_hybrid_protocol = (cluster_protocol == "json (by switch)"),
+          legacy_hybrid_compatibility = (cluster_protocol ~= "wrpc_only"),
           cluster_cert = "spec/fixtures/kong_clustering.crt",
           cluster_cert_key = "spec/fixtures/kong_clustering.key",
           database = strategy,
@@ -36,6 +37,7 @@ for _, strategy in helpers.each_strategy() do
         assert(helpers.start_kong({
           role = "data_plane",
           legacy_hybrid_protocol = (cluster_protocol == "json (by switch)"),
+          legacy_hybrid_compatibility = (cluster_protocol ~= "wrpc_only"),
           cluster_protocol = cluster_protocol,
           database = "off",
           prefix = "servroot2",
@@ -359,6 +361,7 @@ for _, strategy in helpers.each_strategy() do
 
         assert(helpers.start_kong({
           legacy_hybrid_protocol = (cluster_protocol == "json"),
+          legacy_hybrid_compatibility = (cluster_protocol ~= "wrpc_only"),
           role = "control_plane",
           cluster_cert = "spec/fixtures/kong_clustering.crt",
           cluster_cert_key = "spec/fixtures/kong_clustering.key",
@@ -638,6 +641,7 @@ for _, strategy in helpers.each_strategy() do
         assert(helpers.start_kong({
           role = "data_plane",
           legacy_hybrid_protocol = (cluster_protocol == "json (by switch)"),
+          legacy_hybrid_compatibility = (cluster_protocol ~= "wrpc_only"),
           cluster_protocol = cluster_protocol,
           database = "off",
           prefix = "servroot2",

--- a/spec/02-integration/09-hybrid_mode/02-start_stop_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/02-start_stop_spec.lua
@@ -11,6 +11,7 @@ for cluster_protocol, conf in pairs(confs) do
         local ok, err = helpers.start_kong({
           role = "control_plane",
           legacy_hybrid_protocol = (cluster_protocol == "json (by switch)"),
+          legacy_hybrid_compatibility = (cluster_protocol ~= "wrpc_only"),
           nginx_conf = conf,
           prefix = "servroot2",
           cluster_cert = "spec/fixtures/kong_clustering.crt",
@@ -26,6 +27,7 @@ for cluster_protocol, conf in pairs(confs) do
         local ok, err = helpers.start_kong({
           role = "control_plane",
           legacy_hybrid_protocol = (cluster_protocol == "json (by switch)"),
+          legacy_hybrid_compatibility = (cluster_protocol ~= "wrpc_only"),
           nginx_conf = conf,
           prefix = "servroot2",
           cluster_cert = "spec/fixtures/kong_clustering.crt",
@@ -41,6 +43,7 @@ for cluster_protocol, conf in pairs(confs) do
         local ok, err = helpers.start_kong({
           role = "control_plane",
           legacy_hybrid_protocol = (cluster_protocol == "json (by switch)"),
+          legacy_hybrid_compatibility = (cluster_protocol ~= "wrpc_only"),
           nginx_conf = conf,
           prefix = "servroot2",
           cluster_cert = "spec/fixtures/kong_clustering.crt",
@@ -56,6 +59,7 @@ for cluster_protocol, conf in pairs(confs) do
         local ok, err = helpers.start_kong({
           role = "control_plane",
           legacy_hybrid_protocol = (cluster_protocol == "json (by switch)"),
+          legacy_hybrid_compatibility = (cluster_protocol ~= "wrpc_only"),
           nginx_conf = conf,
           prefix = "servroot2",
           cluster_cert = "spec/fixtures/kong_clustering.crt",
@@ -73,6 +77,7 @@ for cluster_protocol, conf in pairs(confs) do
         local ok, err = helpers.start_kong({
           role = "data_plane",
           legacy_hybrid_protocol = (cluster_protocol == "json (by switch)"),
+          legacy_hybrid_compatibility = (cluster_protocol ~= "wrpc_only"),
           nginx_conf = conf,
           prefix = "servroot2",
           cluster_cert = "spec/fixtures/kong_clustering.crt",
@@ -88,6 +93,7 @@ for cluster_protocol, conf in pairs(confs) do
         local ok, err = helpers.start_kong({
           role = "data_plane",
           legacy_hybrid_protocol = (cluster_protocol == "json (by switch)"),
+          legacy_hybrid_compatibility = (cluster_protocol ~= "wrpc_only"),
           nginx_conf = conf,
           prefix = "servroot2",
           cluster_cert = "spec/fixtures/kong_clustering.crt",
@@ -106,6 +112,7 @@ for cluster_protocol, conf in pairs(confs) do
           local ok, err = helpers.start_kong({
             role = param[1],
             legacy_hybrid_protocol = (cluster_protocol == "json (by switch)"),
+            legacy_hybrid_compatibility = (cluster_protocol ~= "wrpc_only"),
             nginx_conf = conf,
             database = param[2],
             prefix = "servroot2",
@@ -119,6 +126,7 @@ for cluster_protocol, conf in pairs(confs) do
           local ok, err = helpers.start_kong({
             role = param[1],
             legacy_hybrid_protocol = (cluster_protocol == "json (by switch)"),
+            legacy_hybrid_compatibility = (cluster_protocol ~= "wrpc_only"),
             nginx_conf = conf,
             database = param[2],
             prefix = "servroot2",

--- a/spec/02-integration/09-hybrid_mode/03-pki_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/03-pki_spec.lua
@@ -18,6 +18,7 @@ for cluster_protocol, conf in pairs(confs) do
         assert(helpers.start_kong({
           role = "control_plane",
           legacy_hybrid_protocol = (cluster_protocol == "json (by switch)"),
+          legacy_hybrid_compatibility = (cluster_protocol ~= "wrpc_only"),
           cluster_cert = "spec/fixtures/kong_clustering.crt",
           cluster_cert_key = "spec/fixtures/kong_clustering.key",
           db_update_frequency = 0.1,
@@ -32,6 +33,7 @@ for cluster_protocol, conf in pairs(confs) do
         assert(helpers.start_kong({
           role = "data_plane",
           legacy_hybrid_protocol = (cluster_protocol == "json (by switch)"),
+          legacy_hybrid_compatibility = (cluster_protocol ~= "wrpc_only"),
           nginx_conf = conf,
           database = "off",
           prefix = "servroot2",

--- a/spec/02-integration/09-hybrid_mode/05-ocsp_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/05-ocsp_spec.lua
@@ -51,6 +51,7 @@ for cluster_protocol, conf in pairs(confs) do
           assert(helpers.start_kong({
             role = "data_plane",
             legacy_hybrid_protocol = (cluster_protocol == "json (by switch)"),
+            legacy_hybrid_compatibility = (cluster_protocol ~= "wrpc_only"),
             cluster_protocol = cluster_protocol,
             database = "off",
             prefix = "servroot2",
@@ -106,6 +107,7 @@ for cluster_protocol, conf in pairs(confs) do
           assert(helpers.start_kong({
             role = "control_plane",
             legacy_hybrid_protocol = (cluster_protocol == "json (by switch)"),
+            legacy_hybrid_compatibility = (cluster_protocol ~= "wrpc_only"),
             cluster_protocol = cluster_protocol,
             cluster_cert = "spec/fixtures/ocsp_certs/kong_clustering.crt",
             cluster_cert_key = "spec/fixtures/ocsp_certs/kong_clustering.key",
@@ -124,6 +126,7 @@ for cluster_protocol, conf in pairs(confs) do
           assert(helpers.start_kong({
             role = "data_plane",
             legacy_hybrid_protocol = (cluster_protocol == "json (by switch)"),
+            legacy_hybrid_compatibility = (cluster_protocol ~= "wrpc_only"),
             cluster_protocol = cluster_protocol,
             database = "off",
             prefix = "servroot2",
@@ -177,6 +180,7 @@ for cluster_protocol, conf in pairs(confs) do
           assert(helpers.start_kong({
             role = "control_plane",
             legacy_hybrid_protocol = (cluster_protocol == "json (by switch)"),
+            legacy_hybrid_compatibility = (cluster_protocol ~= "wrpc_only"),
             cluster_protocol = cluster_protocol,
             cluster_cert = "spec/fixtures/ocsp_certs/kong_clustering.crt",
             cluster_cert_key = "spec/fixtures/ocsp_certs/kong_clustering.key",
@@ -195,6 +199,7 @@ for cluster_protocol, conf in pairs(confs) do
           assert(helpers.start_kong({
             role = "data_plane",
             legacy_hybrid_protocol = (cluster_protocol == "json (by switch)"),
+            legacy_hybrid_compatibility = (cluster_protocol ~= "wrpc_only"),
             cluster_protocol = cluster_protocol,
             database = "off",
             prefix = "servroot2",
@@ -251,6 +256,7 @@ for cluster_protocol, conf in pairs(confs) do
           assert(helpers.start_kong({
             role = "control_plane",
             legacy_hybrid_protocol = (cluster_protocol == "json (by switch)"),
+            legacy_hybrid_compatibility = (cluster_protocol ~= "wrpc_only"),
             cluster_protocol = cluster_protocol,
             cluster_cert = "spec/fixtures/ocsp_certs/kong_clustering.crt",
             cluster_cert_key = "spec/fixtures/ocsp_certs/kong_clustering.key",
@@ -269,6 +275,7 @@ for cluster_protocol, conf in pairs(confs) do
           assert(helpers.start_kong({
             role = "data_plane",
             legacy_hybrid_protocol = (cluster_protocol == "json (by switch)"),
+            legacy_hybrid_compatibility = (cluster_protocol ~= "wrpc_only"),
             cluster_protocol = cluster_protocol,
             database = "off",
             prefix = "servroot2",
@@ -343,6 +350,7 @@ for cluster_protocol, conf in pairs(confs) do
           assert(helpers.start_kong({
             role = "data_plane",
             legacy_hybrid_protocol = (cluster_protocol == "json (by switch)"),
+            legacy_hybrid_compatibility = (cluster_protocol ~= "wrpc_only"),
             cluster_protocol = cluster_protocol,
             database = "off",
             prefix = "servroot2",
@@ -413,6 +421,7 @@ for cluster_protocol, conf in pairs(confs) do
           assert(helpers.start_kong({
             role = "data_plane",
             legacy_hybrid_protocol = (cluster_protocol == "json (by switch)"),
+            legacy_hybrid_compatibility = (cluster_protocol ~= "wrpc_only"),
             cluster_protocol = cluster_protocol,
             database = "off",
             prefix = "servroot2",

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -3232,6 +3232,7 @@ local function get_clustering_protocols()
     wrpc = "spec/fixtures/custom_nginx.template",
     json = "/tmp/custom_nginx_no_wrpc.template",
     ["json (by switch)"] = "spec/fixtures/custom_nginx.template",
+    wrpc_only = "spec/fixtures/custom_nginx.template",
   }
 
   -- disable wrpc in CP


### PR DESCRIPTION
Turn off `legacy_hybrid_compatibility` to avoid serializing twice

Fix FT-3308