### PR TITLE
docs: embrace conventional-commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -241,10 +241,13 @@ messages as follows:
 - A blank line should be included between the header and the body
 - The body of your message should not contain lines longer than 72 characters
 
+We strive to adapt the [conventional-commits](https://www.conventionalcommits.org/en/v1.0.0/)
+format.
+
 Here is a template of what your commit message should look like:
 
 ```
-<type>(<scope>) <subject>
+<type>(<scope>): <subject>
 <BLANK LINE>
 <body>
 <BLANK LINE>


### PR DESCRIPTION
### Summary

Kong's commit message format was similar to [conventional-commits](https://github.com/Kong/kong/pull/new/conventional-commits), but deviated in not requiring a colon after the type and optional scope.  As other repositories in the Kong organization have adopted conventional-commits and external tools begin to rely on the format, we're switching `Kong/kong` to this format as well.
