### PR TITLE
fix(auth-plugins): auth plugins cache inconsistency while anonymous was configured as username

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -540,7 +540,7 @@ local function register_events()
     if old_entity then
       old_username = old_entity.username
       if old_username and old_username ~= null and old_username ~= "" then
-        kong.cache:invalidate(kong.db.consumers:cache_key(old_entity.username))
+        kong.cache:invalidate(kong.db.consumers:cache_key(old_username))
       end
     end
 
@@ -548,7 +548,7 @@ local function register_events()
     if entity then
       local username = entity.username
       if username and username ~= null and username ~= "" and username ~= old_username then
-        kong.cache:invalidate(kong.db.consumers:cache_key(entity.username))
+        kong.cache:invalidate(kong.db.consumers:cache_key(username))
       end
     end
   end, "crud", "consumers")

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -40,6 +40,7 @@ local clear_header      = ngx.req.clear_header
 local http_version      = ngx.req.http_version
 local unpack            = unpack
 local escape            = require("kong.tools.uri").escape
+local null              = ngx.null
 
 
 local is_http_module   = subsystem == "http"
@@ -526,6 +527,32 @@ local function register_events()
   end, "crud", "snis")
 
   register_balancer_events(core_cache, worker_events, cluster_events)
+
+
+  -- Consumers invalidations
+  -- As we support conifg.anonymous to be configured as Consumer.username,
+  -- so add an event handler to invalidate the extra cache in case of data inconsistency
+  worker_events.register(function(data)
+    workspaces.set_workspace(data.workspace)
+
+    local old_entity = data.old_entity
+    local old_username
+    if old_entity then
+      old_username = old_entity.username
+      if old_username and old_username ~= null and old_username ~= "" then
+        kong.cache:invalidate(kong.db.consumers:cache_key(old_entity.username))
+      end
+    end
+
+    local entity = data.entity
+    if entity then
+      local username = entity.username
+      if username and username ~= null and username ~= "" and username ~= old_username then
+        kong.cache:invalidate(kong.db.consumers:cache_key(entity.username))
+      end
+    end
+  end, "crud", "consumers")
+
 end
 
 

--- a/spec/03-plugins/10-basic-auth/03-access_spec.lua
+++ b/spec/03-plugins/10-basic-auth/03-access_spec.lua
@@ -640,4 +640,94 @@ for _, strategy in helpers.each_strategy() do
 
     end)
   end)
+
+  describe("Plugin: basic-auth (access) [#" .. strategy .. "]", function()
+    local proxy_client
+    local admin_client
+    local anonymous
+
+    lazy_setup(function()
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+        "consumers",
+        "basicauth_credentials",
+        "keyauth_credentials",
+      })
+
+      anonymous = bp.consumers:insert {
+        username = "Anonymous",
+      }
+
+      local service = bp.services:insert {
+        path = "/request",
+      }
+
+      local route = bp.routes:insert {
+        hosts   = { "anonymous-with-username.com" },
+        service = service,
+      }
+
+      bp.plugins:insert {
+        name     = "basic-auth",
+        route = { id = route.id },
+        config = {
+          anonymous = anonymous.username,
+        },
+      }
+
+      assert(helpers.start_kong({
+        database   = strategy,
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+      }))
+
+      proxy_client = helpers.proxy_client()
+      admin_client = helpers.admin_client()
+    end)
+
+    lazy_teardown(function()
+      if proxy_client then
+        proxy_client:close()
+      end
+      if admin_client then
+        admin_client:close()
+      end
+
+      helpers.stop_kong()
+    end)
+
+    it("consumer cache consistency", function()
+      local res = assert(proxy_client:send {
+        method = "GET",
+        path = "/request",
+        headers = {
+          ["Host"] = "anonymous-with-username.com",
+        },
+      })
+      assert.response(res).has.status(200)
+      local body = assert.response(res).has.jsonbody()
+      assert.are.equal("true", body.headers["x-anonymous-consumer"])
+      assert.are.equal(anonymous.id, body.headers["x-consumer-id"])
+      assert.are.equal(anonymous.username, body.headers["x-consumer-username"])
+
+      local res = assert(admin_client:send {
+        method = "DELETE",
+        path = "/consumers/" .. anonymous.username,
+      })
+      assert.res_status(204, res)
+
+      ngx.sleep(1) -- wait for cache invalidation
+
+      local res = assert(proxy_client:send {
+        method = "GET",
+        path = "/request",
+        headers = {
+          ["Host"] = "anonymous-with-username.com",
+        }
+      })
+      assert.res_status(500, res)
+    end)
+
+  end)
 end


### PR DESCRIPTION

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

As Kong auth plugins support `conifg.anonymous` to be configured as the username of consumer, once a consumer has been cached with the username as part of the cache key, this consumer cache won't be invalidated by the default cache invalidation event handler after the consumer has been deleted.

Considers of the conifg.anonymous exists in several auth plugins, so I added a common event handler to invalidate the extra cache rather than in each plugin.

<!--- Why is this change required? What problem does it solve? -->


### Issue reference
FTI-4287
