### PR TITLE
fix(core) support route migration

### DIFF
--- a/kong/router.lua
+++ b/kong/router.lua
@@ -504,6 +504,11 @@ local function marshall_route(r)
       for i = 1, count do
         local path = paths[i]
 
+        -- we are supporting boths 2.x route path and 3.0 route paths
+        -- for a path not starting with ~, we assume it is a 2.x route path
+        -- it's safe because even if it's a 3.0 prefix path, we can normalize a prefix path
+        -- more than once and get the same result
+        -- and for a path start with ~ we just do what 3.0 do
         local is_not_regex
         local need_normalize = true
         if path:sub(1, 1) == "~" then

--- a/kong/router.lua
+++ b/kong/router.lua
@@ -509,6 +509,7 @@ local function marshall_route(r)
         if path:sub(1, 1) == "~" then
           is_not_regex, need_normalize = false, false
           path = normalize_regex(path:sub(2))
+
         else
           is_not_regex = not not re_find(path, [[[a-zA-Z0-9\.\-_~/%]*$]], "ajo")
         end

--- a/kong/router.lua
+++ b/kong/router.lua
@@ -509,18 +509,18 @@ local function marshall_route(r)
         -- it's safe because even if it's a 3.0 prefix path, we can normalize a prefix path
         -- more than once and get the same result
         -- and for a path start with ~ we just do what 3.0 do
-        local is_not_regex
+        local is_prefix
         local need_normalize = true
         if path:sub(1, 1) == "~" then
-          is_not_regex, need_normalize = false, false
+          is_prefix, need_normalize = false, false
           path = normalize_regex(path:sub(2))
 
 
         else
-          is_not_regex = not not re_find(path, [[[a-zA-Z0-9\.\-_~/%]*$]], "ajo")
+          is_prefix = not not re_find(path, [[[a-zA-Z0-9\.\-_~/%]*$]], "ajo")
         end
 
-        if is_not_regex then
+        if is_prefix then
           -- plain URI or URI prefix
 
           local uri_t = {
@@ -533,10 +533,10 @@ local function marshall_route(r)
           max_uri_length = max(max_uri_length, #path)
 
         else
+          -- regex URI
           if need_normalize then
             path = normalize_regex(path)
           end
-          -- regex URI
           local strip_regex  = REGEX_PREFIX .. path .. [[(?<uri_postfix>.*)]]
 
           local uri_t    = {

--- a/kong/router.lua
+++ b/kong/router.lua
@@ -510,6 +510,7 @@ local function marshall_route(r)
           is_not_regex, need_normalize = false, false
           path = normalize_regex(path:sub(2))
 
+
         else
           is_not_regex = not not re_find(path, [[[a-zA-Z0-9\.\-_~/%]*$]], "ajo")
         end

--- a/kong/router.lua
+++ b/kong/router.lua
@@ -504,7 +504,16 @@ local function marshall_route(r)
       for i = 1, count do
         local path = paths[i]
 
-        if re_find(path, [[[a-zA-Z0-9\.\-_~/%]*$]], "ajo") then
+        local is_not_regex
+        local need_normalize = true
+        if path:sub(1, 1) == "~" then
+          is_not_regex, need_normalize = false, false
+          path = normalize_regex(path:sub(2))
+        else
+          is_not_regex = not not re_find(path, [[[a-zA-Z0-9\.\-_~/%]*$]], "ajo")
+        end
+
+        if is_not_regex then
           -- plain URI or URI prefix
 
           local uri_t = {
@@ -517,8 +526,9 @@ local function marshall_route(r)
           max_uri_length = max(max_uri_length, #path)
 
         else
-          local path = normalize_regex(path)
-
+          if need_normalize then
+            path = normalize_regex(path)
+          end
           -- regex URI
           local strip_regex  = REGEX_PREFIX .. path .. [[(?<uri_postfix>.*)]]
 

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -3627,7 +3627,7 @@ describe("[both regex and prefix with regex_priority]", function()
 
 end)
 
-describe("support 3.0 #migration #only", function ()
+describe("support 3.0 #migration", function ()
   it("works for 3.0 path", function()
     local use_case = {
       -- regex

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -3626,3 +3626,43 @@ describe("[both regex and prefix with regex_priority]", function()
   end)
 
 end)
+
+describe("support 3.0 #migration #only", function ()
+  it("works for 3.0 path", function()
+    local use_case = {
+      -- regex
+      {
+        service = service,
+        route   = {
+          paths = {
+            [[~/v\d+]]
+          },
+          hosts = {
+            "domain-1.org",
+          },
+        },
+      },
+      -- normalized prefix
+      {
+        service = service,
+        route   = {
+          paths = {
+            [[/中文]]
+          },
+        },
+      },
+    }
+    local router = assert(Router.new(use_case))
+    local match_t = router.select("GET", "/v1", "domain-1.org")
+    assert.truthy(match_t)
+    assert.same(use_case[1].route, match_t.route)
+
+    match_t = router.select("GET", "/v12", "domain-1.org")
+    assert.truthy(match_t)
+    assert.same(use_case[1].route, match_t.route)
+
+    match_t = router.select("GET", "/中文", "domain-2.org")
+    assert.truthy(match_t)
+    assert.same(use_case[2].route, match_t.route)
+  end)
+end)


### PR DESCRIPTION
This PR is to support blue/green migration from 2.8.x to 3.0.x.

This PR needs https://github.com/Kong/kong/pull/9334 to cooperate.

Fix FT-3293