### PR TITLE
feat(aws-lambda): add requestContext field into aws-gateway-compatible input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,14 @@
   [#9558](https://github.com/Kong/kong/pull/9558)
 
 
+### Additions
+
+#### Plugins
+
+- **AWS Lambda**: add `requestContext` field into `awsgateway_compatible` input data
+  [#9380](https://github.com/Kong/kong/pull/9380)
+
+
 ## [3.0.0]
 
 > Released 2022/09/12

--- a/kong/plugins/aws-lambda/aws-serializer.lua
+++ b/kong/plugins/aws-lambda/aws-serializer.lua
@@ -94,7 +94,7 @@ return function(ctx, config)
     local domainName = var.host
     local domainPrefix = split(domainName, ".")[1]
     local identity = {
-      sourceIp = var.remote_addr,
+      sourceIp = var.realip_remote_addr or var.remote_addr,
       userAgent = headers["user-agent"],
     }
     local requestId = var.request_id

--- a/kong/plugins/aws-lambda/aws-serializer.lua
+++ b/kong/plugins/aws-lambda/aws-serializer.lua
@@ -3,11 +3,16 @@
 -- https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
 
 local request_util = require "kong.plugins.aws-lambda.request-util"
+local pl_stringx = require("pl.stringx")
+local date = require "date"
 
 local EMPTY = {}
 
+local split = pl_stringx.split
 local ngx_req_get_headers  = ngx.req.get_headers
 local ngx_req_get_uri_args = ngx.req.get_uri_args
+local ngx_get_http_version = ngx.req.http_version
+local ngx_req_start_time = ngx.req.start_time
 local ngx_encode_base64    = ngx.encode_base64
 
 return function(ctx, config)
@@ -81,6 +86,39 @@ return function(ctx, config)
   local uri = var.upstream_uri or var.request_uri
   local path = uri:match("^([^%?]+)")  -- strip any query args
 
+  local requestContext
+  do
+    local http_version = ngx_get_http_version()
+    local protocol = http_version and 'HTTP/'..http_version or nil
+    local httpMethod = var.request_method
+    local domainName = var.host
+    local domainPrefix = split(domainName, ".")[1]
+    local identity = {
+      sourceIp = var.remote_addr,
+      userAgent = headers["user-agent"],
+    }
+    local requestId = var.request_id
+    local start_time = ngx_req_start_time()
+    local requestTime = date(start_time):fmt("${iso}")
+    local requestTimeEpoch = start_time * 1000
+
+    -- Kong does not have the concept of stage, so we just let resource path be the same as path
+    local resourcePath = path
+
+    requestContext = {
+      path = path,
+      protocol = protocol,
+      httpMethod = httpMethod,
+      domainName = domainName,
+      domainPrefix = domainPrefix,
+      identity = identity,
+      requestId = requestId,
+      requestTime = requestTime,
+      requestTimeEpoch = requestTimeEpoch,
+      resourcePath = resourcePath,
+    }
+  end
+
   local request = {
     resource                        = ctx.router_matches.uri,
     path                            = path,
@@ -92,6 +130,7 @@ return function(ctx, config)
     multiValueQueryStringParameters = multiValueQueryStringParameters,
     body                            = body,
     isBase64Encoded                 = isBase64Encoded,
+    requestContext                  = requestContext,
   }
 
   return request

--- a/kong/plugins/aws-lambda/aws-serializer.lua
+++ b/kong/plugins/aws-lambda/aws-serializer.lua
@@ -99,7 +99,8 @@ return function(ctx, config)
     }
     local requestId = var.request_id
     local start_time = ngx_req_start_time()
-    local requestTime = date(start_time):fmt("${iso}")
+    -- The CLF-formatted request time (dd/MMM/yyyy:HH:mm:ss +-hhmm).
+    local requestTime = date(start_time):fmt("%d/%b/%Y:%H:%M:%S %z")
     local requestTimeEpoch = start_time * 1000
 
     -- Kong does not have the concept of stage, so we just let resource path be the same as path

--- a/spec/03-plugins/27-aws-lambda/05-aws-serializer_spec.lua
+++ b/spec/03-plugins/27-aws-lambda/05-aws-serializer_spec.lua
@@ -115,7 +115,7 @@ describe("[AWS Lambda] aws-gateway input", function()
           domainPrefix = "abc",
           identity = { sourceIp = "123.123.123.123", userAgent = "curl/7.54.0" },
           requestId = "1234567890",
-          requestTime = date(1662436514):fmt("${iso}"),
+          requestTime = date(1662436514):fmt("%d/%b/%Y:%H:%M:%S %z"),
           requestTimeEpoch = 1662436514 * 1000,
           resourcePath = "/123/strip/more",
         }
@@ -188,7 +188,7 @@ describe("[AWS Lambda] aws-gateway input", function()
           domainPrefix = "def",
           identity = { sourceIp = "123.123.123.123", userAgent = "curl/7.54.0" },
           requestId = "1234567890",
-          requestTime = date(1662436514):fmt("${iso}"),
+          requestTime = date(1662436514):fmt("%d/%b/%Y:%H:%M:%S %z"),
           requestTimeEpoch = 1662436514 * 1000,
           resourcePath = "/plain/strip/more",
         }
@@ -273,7 +273,7 @@ describe("[AWS Lambda] aws-gateway input", function()
             domainPrefix = "def",
             identity = { sourceIp = "123.123.123.123", userAgent = "curl/7.54.0" },
             requestId = "1234567890",
-            requestTime = date(1662436514):fmt("${iso}"),
+            requestTime = date(1662436514):fmt("%d/%b/%Y:%H:%M:%S %z"),
             requestTimeEpoch = 1662436514 * 1000,
             resourcePath = "/plain/strip/more",
           }

--- a/spec/03-plugins/27-aws-lambda/05-aws-serializer_spec.lua
+++ b/spec/03-plugins/27-aws-lambda/05-aws-serializer_spec.lua
@@ -1,4 +1,5 @@
 local deepcopy = require "pl.tablex".deepcopy
+local date = require "date"
 
 describe("[AWS Lambda] aws-gateway input", function()
 
@@ -15,6 +16,8 @@ describe("[AWS Lambda] aws-gateway input", function()
         get_uri_args = function() return deepcopy(mock_request.query) end,
         read_body = function() body_data = mock_request.body end,
         get_body_data = function() return body_data end,
+        http_version = function() return mock_request.http_version end,
+        start_time = function() return mock_request.start_time end,
       },
       log = function() end,
       encode_base64 = old_ngx.encode_base64
@@ -41,9 +44,12 @@ describe("[AWS Lambda] aws-gateway input", function()
 
   it("serializes a request regex", function()
     mock_request = {
+      http_version = "1.1",
+      start_time = 1662436514,
       headers = {
         ["single-header"] = "hello world",
         ["multi-header"] = { "first", "second" },
+        ["user-agent"] = "curl/7.54.0",
       },
       query = {
         ["single-query"] = "hello world",
@@ -53,7 +59,10 @@ describe("[AWS Lambda] aws-gateway input", function()
       body = "text",
       var = {
         request_method = "GET",
-        upstream_uri = "/123/strip/more?boolean=;multi-query=first;single-query=hello%20world;multi-query=second"
+        upstream_uri = "/123/strip/more?boolean=;multi-query=first;single-query=hello%20world;multi-query=second",
+        request_id = "1234567890",
+        host = "abc.myhost.com",
+        remote_addr = "123.123.123.123"
       },
       ctx = {
         router_matches = {
@@ -81,10 +90,12 @@ describe("[AWS Lambda] aws-gateway input", function()
         headers = {
           ["multi-header"] = "first",
           ["single-header"] = "hello world",
+          ["user-agent"] = "curl/7.54.0",
         },
         multiValueHeaders = {
           ["multi-header"] = { "first", "second" },
           ["single-header"] = { "hello world" },
+          ["user-agent"] = { "curl/7.54.0" },
         },
         queryStringParameters = {
           boolean = true,
@@ -96,14 +107,29 @@ describe("[AWS Lambda] aws-gateway input", function()
           ["multi-query"] = { "first", "second" },
           ["single-query"] = { "hello world" },
         },
+        requestContext = {
+          path = "/123/strip/more",
+          protocol = "HTTP/1.1",
+          httpMethod = "GET",
+          domainName = "abc.myhost.com",
+          domainPrefix = "abc",
+          identity = { sourceIp = "123.123.123.123", userAgent = "curl/7.54.0" },
+          requestId = "1234567890",
+          requestTime = date(1662436514):fmt("${iso}"),
+          requestTimeEpoch = 1662436514 * 1000,
+          resourcePath = "/123/strip/more",
+        }
       }, out)
   end)
 
   it("serializes a request no-regex", function()
     mock_request = {
+      http_version = "1.0",
+      start_time = 1662436514,
       headers = {
         ["single-header"] = "hello world",
         ["multi-header"] = { "first", "second" },
+        ["user-agent"] = "curl/7.54.0",
       },
       query = {
         ["single-query"] = "hello world",
@@ -113,7 +139,10 @@ describe("[AWS Lambda] aws-gateway input", function()
       body = "text",
       var = {
         request_method = "GET",
-        upstream_uri = "/plain/strip/more?boolean=;multi-query=first;single-query=hello%20world;multi-query=second"
+        upstream_uri = "/plain/strip/more?boolean=;multi-query=first;single-query=hello%20world;multi-query=second",
+        request_id = "1234567890",
+        host = "def.myhost.com",
+        remote_addr = "123.123.123.123"
       },
       ctx = {
         router_matches = {
@@ -134,10 +163,12 @@ describe("[AWS Lambda] aws-gateway input", function()
         headers = {
           ["multi-header"] = "first",
           ["single-header"] = "hello world",
+          ["user-agent"] = "curl/7.54.0",
         },
         multiValueHeaders = {
           ["multi-header"] = { "first", "second" },
           ["single-header"] = { "hello world" },
+          ["user-agent"] = { "curl/7.54.0" },
         },
         queryStringParameters = {
           boolean = true,
@@ -149,6 +180,18 @@ describe("[AWS Lambda] aws-gateway input", function()
           ["multi-query"] = { "first", "second" },
           ["single-query"] = { "hello world" },
         },
+        requestContext = {
+          path = "/plain/strip/more",
+          protocol = "HTTP/1.0",
+          httpMethod = "GET",
+          domainName = "def.myhost.com",
+          domainPrefix = "def",
+          identity = { sourceIp = "123.123.123.123", userAgent = "curl/7.54.0" },
+          requestId = "1234567890",
+          requestTime = date(1662436514):fmt("${iso}"),
+          requestTimeEpoch = 1662436514 * 1000,
+          resourcePath = "/plain/strip/more",
+        }
       }, out)
   end)
 
@@ -180,15 +223,21 @@ describe("[AWS Lambda] aws-gateway input", function()
 
       it("serializes a request with body type: " .. tdata.description, function()
         mock_request = {
+          http_version = "1.0",
+          start_time = 1662436514,
           body = tdata.body_in,
           headers = {
             ["Content-Type"] = tdata.ct,
+            ["user-agent"] = "curl/7.54.0",
           },
           query = {},
           var = {
             request_method = "GET",
             upstream_uri = "/plain/strip/more",
             http_content_type = tdata.ct,
+            request_id = "1234567890",
+            host = "def.myhost.com",
+            remote_addr = "123.123.123.123"
           },
           ctx = {
             router_matches = {
@@ -203,9 +252,11 @@ describe("[AWS Lambda] aws-gateway input", function()
           body = tdata.body_out,
           headers = {
             ["Content-Type"] = tdata.ct,
+            ["user-agent"] = "curl/7.54.0",
           },
           multiValueHeaders = {
             ["Content-Type"] = tdata.ct and { tdata.ct } or nil,
+            ["user-agent"] = { "curl/7.54.0" },
           },
           httpMethod = "GET",
           queryStringParameters = {},
@@ -214,6 +265,18 @@ describe("[AWS Lambda] aws-gateway input", function()
           resource = "/plain/strip",
           path = "/plain/strip/more",
           isBase64Encoded = tdata.base64,
+          requestContext = {
+            path = "/plain/strip/more",
+            protocol = "HTTP/1.0",
+            httpMethod = "GET",
+            domainName = "def.myhost.com",
+            domainPrefix = "def",
+            identity = { sourceIp = "123.123.123.123", userAgent = "curl/7.54.0" },
+            requestId = "1234567890",
+            requestTime = date(1662436514):fmt("${iso}"),
+            requestTimeEpoch = 1662436514 * 1000,
+            resourcePath = "/plain/strip/more",
+          }
         }, out)
       end)
     end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

This PR adds a new field `requestContext` into the lambda input data when the aws-lambda plugin is working in `awsgateway_compatible` mode.

The `requestContext` is part of the input data in lambda proxy integration, according to [this AWS document page](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format), and it contains many fields containing request related information on AWS API Gateway. 

The aws-lambda plugin in Kong provides an AWS API Gateway compatible mode that can generate an input data similar with 
[the example provided in this doc](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format), but it does not contain the `requestContext` field. When users are writing their lambda functions with some libraries like [aws-serverless-java-container](https://github.com/awslabs/aws-serverless-java-container), it will check if the input data have the `requestContext` field, and if it does not exist, the request will be regarded as malformed.(For example, see [this code snippet](https://github.com/awslabs/aws-serverless-java-container/blob/98482d485dadaf7212141f162e7e35f4ea6c7b6f/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequestReader.java#L47-L49))

To make the input data sound more "compatible", this PR adds the `requestContext` field into the input data. Note that many fields in the formal `requestContext` cannot be fetched by Kong(like IAM-related information or Cognito-related auth info), so we're just providing a **best-effort delivery** here. We cannot make assurance that the `requestContext` provided by Kong has every information that the lambda function needs, and it is decided by the lambda function whether the whole payload containing `requestContext` can work normally or not. So the feature is just a good-to-have one.


### Full changelog

* Add `requestContext` field into `awsgateway_compatible` input data
* Add related tests

### Issue reference

This should fix [FTI-2620](https://konghq.atlassian.net/browse/FTI-2620), and #7641, in some cases.