### PR TITLE
fix(external-plugins): handle failing instance creation

### DIFF
--- a/kong/runloop/plugin_servers/mp_rpc.lua
+++ b/kong/runloop/plugin_servers/mp_rpc.lua
@@ -255,7 +255,7 @@ function Rpc:call_start_instance(plugin_name, conf)
   })
 
   if status == nil then
-    return err
+    return nil, err
   end
 
   return {

--- a/kong/runloop/plugin_servers/pb_rpc.lua
+++ b/kong/runloop/plugin_servers/pb_rpc.lua
@@ -298,7 +298,11 @@ end
 function Rpc:call(method, data, do_bridge_loop)
   self.msg_id = self.msg_id + 1
   local msg_id = self.msg_id
-  local c = assert(ngx.socket.connect("unix:" .. self.socket_path))
+  local c, err = ngx.socket.connect("unix:" .. self.socket_path)
+  if not c then
+    kong.log.err("trying to connect: ", err)
+    return nil, err
+  end
 
   msg_id = msg_id + 1
   --kong.log.debug("will encode: ", pp{sequence = msg_id, [method] = data})
@@ -361,7 +365,7 @@ function Rpc:call_start_instance(plugin_name, conf)
   })
 
   if status == nil then
-    return err
+    return nil, err
   end
 
   return {


### PR DESCRIPTION
### Summary

This is a fix for https://github.com/Kong/kong/issues/9301 / FT-3319: when a request made the plugin fail, the creation of a new instance was not handling a failed connection properly.
Upon failure to connect to the socket, it was possible to end up in a state where the instance existed without an instance id,
causing an infinite loop and high CPU utilization.