### PR TITLE
fix(router) prefix match no longer normalize input

### DIFF
--- a/kong-3.0.0-0.rockspec
+++ b/kong-3.0.0-0.rockspec
@@ -245,9 +245,9 @@ build = {
     ["kong.db.migrations.operations.210_to_211"] = "kong/db/migrations/operations/210_to_211.lua",
     ["kong.db.migrations.operations.212_to_213"] = "kong/db/migrations/operations/212_to_213.lua",
     ["kong.db.migrations.operations.280_to_300"] = "kong/db/migrations/operations/280_to_300.lua",
-    ["kong.db.migrations.migrate_regex_280_300"] = "kong/db/migrations/migrate_regex_280_300.lua",
+    ["kong.db.migrations.migrate_path_280_300"] = "kong/db/migrations/migrate_path_280_300.lua",
     ["kong.db.declarative.migrations"] = "kong/db/declarative/migrations/init.lua",
-    ["kong.db.declarative.migrations.regex_route_path"] = "kong/db/declarative/migrations/regex_route_path.lua",
+    ["kong.db.declarative.migrations.route_path"] = "kong/db/declarative/migrations/route_path.lua",
 
     ["kong.pdk"] = "kong/pdk/init.lua",
     ["kong.pdk.private.checks"] = "kong/pdk/private/checks.lua",

--- a/kong/db/declarative/migrations/init.lua
+++ b/kong/db/declarative/migrations/init.lua
@@ -1,4 +1,4 @@
-local regex_route_path = require "kong.db.declarative.migrations.regex_route_path"
+local route_path = require "kong.db.declarative.migrations.route_path"
 
 return function(tbl)
   if not tbl then
@@ -6,7 +6,7 @@ return function(tbl)
     return
   end
 
-  regex_route_path(tbl)
+  route_path(tbl)
 
   tbl._format_version = "3.0"
 end

--- a/kong/db/declarative/migrations/route_path.lua
+++ b/kong/db/declarative/migrations/route_path.lua
@@ -1,4 +1,4 @@
-local migrate_regex = require "kong.db.migrations.migrate_regex_280_300"
+local migrate_path = require "kong.db.migrations.migrate_path_280_300"
 
 return function(tbl)
   local version = tbl._format_version
@@ -21,7 +21,7 @@ return function(tbl)
     end
 
     for idx, path in ipairs(paths) do
-      paths[idx] = migrate_regex(path)
+      paths[idx] = migrate_path(path)
     end
 
     ::continue::

--- a/kong/db/migrations/core/016_280_to_300.lua
+++ b/kong/db/migrations/core/016_280_to_300.lua
@@ -6,7 +6,7 @@ local assert = assert
 local ipairs = ipairs
 local cassandra = require "cassandra"
 local encode_array  = arrays.encode_array
-local migrate_regex = require "kong.db.migrations.migrate_regex_280_300"
+local migrate_path = require "kong.db.migrations.migrate_path_280_300"
 
 
 -- remove repeated targets, the older ones are not useful anymore. targets with
@@ -158,7 +158,7 @@ local function c_migrate_regex_path(coordinator)
 
       local changed = false
       for idx, path in ipairs(route.paths) do
-        local normalized_path, current_changed = migrate_regex(path)
+        local normalized_path, current_changed = migrate_path(path)
         if current_changed then
           changed = true
           route.paths[idx] = normalized_path
@@ -192,7 +192,7 @@ local function p_migrate_regex_path(connector)
 
     local changed = false
     for idx, path in ipairs(route.paths) do
-      local normalized_path, current_changed = migrate_regex(path)
+      local normalized_path, current_changed = migrate_path(path)
       if current_changed then
         changed = true
         route.paths[idx] = normalized_path

--- a/kong/db/migrations/migrate_path_280_300.lua
+++ b/kong/db/migrations/migrate_path_280_300.lua
@@ -2,6 +2,8 @@ local find = string.find
 local upper = string.upper
 local re_find = ngx.re.find
 
+local normalize = require("kong.tools.uri").normalize
+
 -- We do not percent decode route.path after 3.0, so here we do 1 last time for them
 local normalize_regex
 do
@@ -74,13 +76,14 @@ local function is_not_regex(path)
   return (re_find(path, [[[a-zA-Z0-9\.\-_~/%]*$]], "ajo"))
 end
 
-local function migrate_regex(reg)
-  if is_not_regex(reg) then
-    return reg, false
+local function migrate_path(path)
+  if is_not_regex(path) then
+    local normalized = normalize(path, true)
+    return normalized, normalized ~= path
   end
 
-  local migrated = "~" .. normalize_regex(reg)
+  local migrated = "~" .. normalize_regex(path)
   return migrated, true
 end
 
-return migrate_regex
+return migrate_path

--- a/kong/router/atc_compat.lua
+++ b/kong/router/atc_compat.lua
@@ -8,7 +8,6 @@ local context = require("resty.router.context")
 local bit = require("bit")
 local lrucache = require("resty.lrucache")
 local server_name = require("ngx.ssl").server_name
-local normalize = require("kong.tools.uri").normalize
 local tb_new = require("table.new")
 local tb_clear = require("table.clear")
 local tb_nkeys = require("table.nkeys")
@@ -232,7 +231,7 @@ local function get_atc(route)
       return sub(p, 2):gsub("?<", "?P<")
     end
 
-    return normalize(p, true)
+    return p
   end)
   if gen then
     tb_insert(out, gen)

--- a/kong/router/traditional.lua
+++ b/kong/router/traditional.lua
@@ -7,7 +7,6 @@ local bit           = require "bit"
 local utils         = require "kong.router.utils"
 
 
-local normalize     = require("kong.tools.uri").normalize
 local setmetatable  = setmetatable
 local is_http       = ngx.config.subsystem == "http"
 local get_method    = ngx.req.get_method
@@ -424,7 +423,7 @@ local function marshall_route(r)
 
           local uri_t = {
             is_prefix = true,
-            value     = normalize(path, true),
+            value     = path,
           }
 
           append(uris_t, uri_t)

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -2055,6 +2055,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
                 id = "e8fb37f1-102d-461e-9c51-6608a6bb8101",
                 paths = {
                   "/plain/a.b.c", -- /plain/a.b.c
+                  "/plain/a.b%25c", -- /plain/a.b.c
                 },
               },
             },
@@ -2092,6 +2093,13 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
 
         it("matches against plain text paths", function()
           local match_t = router:select("GET", "/plain/a.b.c", "example.com")
+          assert.truthy(match_t)
+          assert.same(use_case[1].route, match_t.route)
+
+          -- route no longer normalize user configured path
+          match_t = router:select("GET", "/plain/a.b c", "example.com")
+          assert.falsy(match_t)
+          match_t = router:select("GET", "/plain/a.b%25c", "example.com")
           assert.truthy(match_t)
           assert.same(use_case[1].route, match_t.route)
 

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -2054,7 +2054,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
               route   = {
                 id = "e8fb37f1-102d-461e-9c51-6608a6bb8101",
                 paths = {
-                  "/plain/a.b%2Ec", -- /plain/a.b.c
+                  "/plain/a.b.c", -- /plain/a.b.c
                 },
               },
             },


### PR DESCRIPTION
We should make it consistent with regex paths, so we do not normalize user input paths.

This PR also includes migration.

Remember to add downgrade support for this to EE.