### PR TITLE
fix(router) anchor regex paths in traditional_compatible mode

### DIFF
--- a/kong/router/atc_compat.lua
+++ b/kong/router/atc_compat.lua
@@ -227,8 +227,12 @@ local function get_atc(route)
     return is_regex_magic(path) and OP_REGEX or OP_PREFIX
   end, route.paths, function(op, p)
     if op == OP_REGEX then
-      -- Rust only recognize form '?P<>'
-      return sub(p, 2):gsub("?<", "?P<")
+      -- 1. strip leading `~`
+      p = sub(p, 2)
+      -- 2. prefix with `^` to match the anchored behavior of the traditional router
+      p = "^" .. p
+      -- 3. update named capture opening tag for rust regex::Regex compatibility
+      return p:gsub("?<", "?P<")
     end
 
     return p

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -1108,6 +1108,30 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
           end
           assert.same(nil, match_t.matches.method)
         end)
+
+        it("matches from the beginning of the request URI [uri regex]", function()
+          local use_case = {
+            {
+              service = service,
+              route   = {
+                id = "e8fb37f1-102d-461e-9c51-6608a6bb8101",
+                paths = { [[~/prefix/[0-9]+]] }
+              },
+            },
+          }
+
+          local router = assert(new_router(use_case))
+
+          -- sanity
+          local match_t = router:select("GET", "/prefix/123", "domain.org")
+          assert.truthy(match_t)
+          assert.same(use_case[1].route, match_t.route)
+          assert.same(nil, match_t.matches.host)
+          assert.same(nil, match_t.matches.method)
+
+          match_t = router:select("GET", "/extra/prefix/123", "domain.org")
+          assert.is_nil(match_t)
+        end)
       end)
 
       describe("[wildcard host]", function()


### PR DESCRIPTION
This is a cherry-pick of #9394.