### PR TITLE
fix(request-termination): status_code cannot be set as null

### DIFF
--- a/kong/plugins/request-termination/schema.lua
+++ b/kong/plugins/request-termination/schema.lua
@@ -15,6 +15,7 @@ return {
         fields = {
           { status_code = {
             type = "integer",
+            required = true,
             default = 503,
             between = { 100, 599 },
           }, },

--- a/spec/03-plugins/14-request-termination/01-schema_spec.lua
+++ b/spec/03-plugins/14-request-termination/01-schema_spec.lua
@@ -1,5 +1,6 @@
 local schema_def = require "kong.plugins.request-termination.schema"
 local v = require("spec.helpers").validate_plugin_config_schema
+local null = ngx.null
 
 describe("Plugin: request-termination (schema)", function()
   it("should accept a valid status_code", function()
@@ -23,6 +24,11 @@ describe("Plugin: request-termination (schema)", function()
       local ok, err = v({status_code = "abcd"}, schema_def)
       assert.falsy(ok)
       assert.same("expected an integer", err.config.status_code)
+    end)
+    it("status_code can not be set as null", function()
+      local ok, err = v({status_code = null}, schema_def)
+      assert.falsy(ok)
+      assert.same("required field missing", err.config.status_code)
     end)
     it("status_code < 100", function()
       local ok, err = v({status_code = 99}, schema_def)


### PR DESCRIPTION
### Summary

`status_code` should not be allowed to be set to null, otherwise a 500 error will be returned.

### Full changelog

* Do not allow set `status_code` as null

FTI-4291