### PR TITLE
fix(runloop) do not reset `*:version` to `init` when worker respawns,

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -580,6 +580,12 @@ function Kong.init()
 
     if config.role ~= "control_plane" then
       assert(runloop.build_router("init"))
+
+      ok, err = runloop.set_init_versions_in_cache()
+      if not ok then
+        error("error setting initial versions for router and plugins iterator in cache: " ..
+              tostring(err))
+      end
     end
   end
 
@@ -658,12 +664,6 @@ function Kong.init_worker()
     return
   end
   kong.core_cache = core_cache
-
-  ok, err = runloop.set_init_versions_in_cache()
-  if not ok then
-    stash_init_worker_error(err) -- 'err' fully formatted
-    return
-  end
 
   kong.db:set_events_handler(worker_events)
 

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -10,6 +10,7 @@ local certificate  = require "kong.runloop.certificate"
 local concurrency  = require "kong.concurrency"
 local workspaces   = require "kong.workspaces"
 local lrucache     = require "resty.lrucache"
+local marshall     = require "kong.cache.marshall"
 
 
 local PluginsIterator = require "kong.runloop.plugins_iterator"
@@ -1017,17 +1018,24 @@ end
 
 
 local function set_init_versions_in_cache()
-  if kong.configuration.role ~= "control_plane" then
-    local ok, err = kong.core_cache:safe_set("router:version", "init")
-    if not ok then
-      return nil, "failed to set router version in cache: " .. tostring(err)
-    end
+  -- because of worker events, kong.cache can not be initialized in `init` phase
+  -- therefore, we need to use the shdict API directly to set the initial value
+  assert(kong.configuration.role ~= "control_plane")
+  assert(ngx.get_phase() == "init")
+  local core_cache_shm = ngx.shared["kong_core_db_cache"]
+
+  -- ttl = forever is okay as "*:versions" keys are always manually invalidated
+  local marshalled_value = marshall("init", 0, 0)
+
+  -- see kong.cache.safe_set function
+  local ok, err = core_cache_shm:safe_set("kong_core_db_cacherouter:version", marshalled_value)
+  if not ok then
+    return nil, "failed to set initial router version in cache: " .. tostring(err)
   end
 
-  local ok, err = kong.core_cache:safe_set("plugins_iterator:version", "init")
+  ok, err = core_cache_shm:safe_set("kong_core_db_cacheplugins_iterator:version", marshalled_value)
   if not ok then
-    return nil, "failed to set plugins iterator version in cache: " ..
-                tostring(err)
+    return nil, "failed to set initial plugins iterator version in cache: " .. tostring(err)
   end
 
   return true

--- a/spec/02-integration/05-proxy/02-router_spec.lua
+++ b/spec/02-integration/05-proxy/02-router_spec.lua
@@ -2243,7 +2243,7 @@ for _, strategy in helpers.each_strategy() do
     end)
   end)
 
-  describe("Router at startup [#" .. strategy .. "]" , function()
+  describe("Router [#" .. strategy .. ", flavor = " .. flavor .. "] at startup" , function()
     local proxy_client
     local route
 
@@ -2308,6 +2308,33 @@ for _, strategy in helpers.each_strategy() do
       end
     end)
 
+    it("#db worker respawn correctly rebuilds router", function()
+      local admin_client = helpers.admin_client()
+
+      local res = assert(admin_client:post("/routes", {
+        headers = { ["Content-Type"] = "application/json" },
+        body = {
+          paths = { "/foo" },
+        },
+      }))
+      assert.res_status(201, res)
+      admin_client:close()
+
+      assert(helpers.signal_workers(nil, "-TERM"))
+
+      proxy_client:close()
+      proxy_client = helpers.proxy_client()
+
+      local res = assert(proxy_client:send {
+        method  = "GET",
+        path    = "/foo",
+        headers = { ["kong-debug"] = 1 },
+      })
+
+      local body = assert.response(res).has_status(503)
+      local json = cjson.decode(body)
+      assert.equal("no Service found with those values", json.message)
+    end)
   end)
 end
 end


### PR DESCRIPTION
fixes FT-3328

Previously, when worker respawns, the `router:version` and `plugins_iterator:version` keys in the cache is incorrectly set to `init`, this causes the newly spawned worker to not rebuild the router/iterator and always use the router/iterator from when master process was created.