### PR TITLE
fix (statsd) fix hostname_in_prefix flag bug and request_size/respons type bug

### DIFF
--- a/kong/plugins/statsd/schema.lua
+++ b/kong/plugins/statsd/schema.lua
@@ -43,7 +43,8 @@ local DEFAULT_METRICS = {
   },
   {
     name               = "request_size",
-    stat_type          = "timer",
+    stat_type          = "counter",
+    sample_rate        = 1,
     service_identifier = nil,
   },
   {
@@ -54,7 +55,8 @@ local DEFAULT_METRICS = {
   },
   {
     name               = "response_size",
-    stat_type          = "timer",
+    stat_type          = "counter",
+    sample_rate        = 1,
     service_identifier = nil,
   },
   {


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary
1. `hostname_in_prefix` in shdict metrics have an error formate `kong.node.dd38ef0eed4d.node.dd38ef0eed4d.shdict.kong_core_db_cache.free_space:133341184|g`
2. `request_size` and `response_size` using counter is best

<!--- Why is this change required? What problem does it solve? -->

### Full changelog

* `request_size` and `response_size` using counter type and change test
*  change shdict formate in `hostname_in_prefix`
