### PR TITLE
fix(tests): remove the _G write guard log in busted CLI

### DIFF
--- a/bin/busted
+++ b/bin/busted
@@ -1,5 +1,7 @@
 #!/usr/bin/env resty
 
+setmetatable(_G, nil)
+
 local pl_path = require("pl.path")
 
 local cert_path = pl_path.abspath("spec/fixtures/kong_spec.crt")
@@ -48,8 +50,6 @@ if not os.getenv("KONG_BUSTED_RESPAWNED") then
   local _, _, rc = os.execute(table.concat(script, "; "))
   os.exit(rc)
 end
-
-setmetatable(_G, nil)
 
 pcall(require, "luarocks.loader")
 


### PR DESCRIPTION
### Summary

Move `setmetatable(_G, nil)` to the top-level scope of source files, this will reduce `stderr` output as below when running tests.

```
[kong-master:/kong]# bin/busted spec/03-plugins/14-request-termination/01-schema_spec.lua
2022/09/08 07:55:07 [warn] 24090#0: *2 [lua] _G write guard:12: writing a global Lua variable ('lfs') which may lead to race conditions between concurrent requests, so prefer the use of 'local' variables
stack traceback:
        [C]: at 0x7ff81736ea20
        [C]: at 0x7ff8193d5210
        [C]: in function 'pcall'
        /build/luarocks/share/lua/5.1/pl/path.lua:24: in main chunk
        [C]: in function 'require'
        bin/busted:3: in function 'file_gen'
        init_worker_by_lua:46: in function <init_worker_by_lua:44>
        [C]: in function 'xpcall'
        init_worker_by_lua:53: in function <init_worker_by_lua:51>, context: ngx.timer
```
