### PR TITLE
chore(release) bump kong-release-tools version requirement (#9323)

### DIFF
--- a/scripts/make-release
+++ b/scripts/make-release
@@ -74,7 +74,7 @@ fi
 version="$1"
 step="$2"
 
-if ! [[ "$version" =~ ^([0-9]+)\.([0-9]+)\.([0-9])-?(|alpha|beta|rc)\.[0-9]+)$ ]]
+if ! [[ "$version" =~ ^([0-9]+)\.([0-9]+)\.([0-9])-?((alpha|beta|rc)\.[0-9]+)?$ ]]
 then
     die "first argument must be a version in x.y.z format with optional -(alpha|beta|rc).\d suffix"
 fi
@@ -165,7 +165,7 @@ case "$step" in
       ;;
 
    #---------------------------------------------------------------------------
-   submit_release_pr) submit_release_pr "$branch" "$version" ;;
+   submit_release_pr) submit_release_pr "$base" "$branch" "$version" "$prerelease" ;;
 
    #---------------------------------------------------------------------------
    merge)

--- a/scripts/release-lib.sh
+++ b/scripts/release-lib.sh
@@ -469,8 +469,9 @@ function docs_pr() {
 #-------------------------------------------------------------------------------
 function submit_release_pr() {
   base=$1
-  version=$2
-  prerelease=$3
+  branch=$2
+  version=$3
+  prerelease=$4
 
   if ! git log -n 1 | grep -q "release: $version"
   then
@@ -483,8 +484,8 @@ function submit_release_pr() {
     "or Ctrl-C to cancel."
 
   set -e
-  git push --set-upstream origin "$base"
-  hub pull-request -b "master" -h "$base" -m "Release: $version" -l "pr/please review,pr/do not merge"
+  git push --set-upstream origin "$branch"
+  hub pull-request -b "$base" -h "$branch" -m "Release: $version" -l "pr/please review,pr/do not merge"
 
   if [ "$prerelease" != "" ]
   then


### PR DESCRIPTION
### Summary

Cherry-pick of #9406 for 3.0

* This fixes a couple small issues with the release script which were detected on a test run today in preparation for the 3.0 release

### Reason for the exception to the Code Freeze.

Our current release process requires the release script to be up-to-date on the branch that is going to be released (the script can't release a different branch).

The change doesn't affect Kong's functionality in any way, the modified script is only executed when cutting the release.

Exception approved by myself (Enrique Garcia).



