### PR TITLE
fix(conf) typo fix, flavor should be `expressions`

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1465,7 +1465,7 @@
                                  #   automatically generated at router build time.
                                  #   The `expression` field on the `Route` object
                                  #   is not visible.
-                                 # - `expression`: the DSL based expression router engine
+                                 # - `expressions`: the DSL based expression router engine
                                  #   will be used under the hood. Traditional router
                                  #   config interface is not visible and you must write
                                  #   Router Expression manually and provide them in the


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

typofix, flavor should be `expressions`

