### PR TITLE
chore(scripts): make make-release release better

### DIFF
--- a/scripts/make-release
+++ b/scripts/make-release
@@ -253,7 +253,7 @@ case "$step" in
 
      set -e
      git add Formula/kong.rb
-     git commit -m "chore(kong) bump kong to $version"
+     git commit -m "chore(kong): bump kong to $version"
 
      git push --set-upstream origin "$branch"
      hub pull-request -b master -h "$branch" -m "Release: $version"
@@ -302,7 +302,7 @@ case "$step" in
 
       set -e
       git add README.md Vagrantfile
-      git commit -m "chore(*) bump Kong to $version"
+      git commit -m "chore(*): bump Kong to $version"
 
       git push --set-upstream origin "$branch"
       hub pull-request -b master -h "$branch" -m "Release: $version"

--- a/scripts/release-lib.sh
+++ b/scripts/release-lib.sh
@@ -108,7 +108,7 @@ function commit_changelog() {
 
   set -e
   git add CHANGELOG.md
-  git commit -m "docs(changelog) add $version changes"
+  git commit -m "docs(changelog): add $version changes"
   git log -n 1
 
   SUCCESS "The changelog is now committed locally." \
@@ -127,7 +127,7 @@ function update_copyright() {
 
   git add COPYRIGHT
 
-  git commit -m "docs(COPYRIGHT) update copyright for $version"
+  git commit -m "docs(COPYRIGHT): update copyright for $version"
   git log -n 1
 
   SUCCESS "The COPYRIGHT file is updated locally." \
@@ -146,7 +146,7 @@ function update_admin_api_def() {
 
   git add kong-admin-api.yml
 
-  git commit -m "docs(kong-admin-api.yml) update Admin API definition for $1"
+  git commit -m "docs(kong-admin-api.yml): update Admin API definition for $1"
   git log -n 1
 
   SUCCESS "The kong-admin-api.yml file is updated locally." \
@@ -455,7 +455,7 @@ function docs_pr() {
 
   set -e
   git add app/_data/kong_versions.yml
-  git commit --allow-empty -m "chore(*) update release metadata for $version"
+  git commit --allow-empty -m "chore(*): update release metadata for $version"
 
   git push --set-upstream origin "$branch"
   hub pull-request -b main -h "$branch" -m "Release: $version" -l "pr/please review,pr/do not merge"


### PR DESCRIPTION
By giving it proper semantic commit messages.

Previously: https://github.com/Kong/homebrew-kong/commit/ca40b01ee8f4cbca8ff70e5d000035ceb94e6984

### Summary

We've been known to use https://semantic-release.gitbook.io in a couple places for automation. This PR updates the commit messages for some of the commits it generates to conform to that (the addition of `:`).