### PR TITLE
perf(clustering): use privileged worker for control plane connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,11 @@
   or base64 encoded content.
   [#9253](https://github.com/Kong/kong/pull/9253)
 
+#### Performance
+
+- Data plane's connection to control plane is moved to a privileged worker process
+  [#9432](https://github.com/Kong/kong/pull/9432)
+
 ### Fixes
 
 #### Core

--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -60,7 +60,7 @@ function _M:init_worker(plugins_list)
 
   self.plugins_list = plugins_list
 
-  if ngx.worker.id() == 0 then
+  if clustering_utils.is_dp_worker_process() then
     assert(ngx.timer.at(0, function(premature)
       self:communicate(premature)
     end))

--- a/kong/clustering/init.lua
+++ b/kong/clustering/init.lua
@@ -6,14 +6,15 @@ local pl_file = require("pl.file")
 local pl_tablex = require("pl.tablex")
 local ssl = require("ngx.ssl")
 local openssl_x509 = require("resty.openssl.x509")
+local clustering_utils = require("kong.clustering.utils")
 local ngx_log = ngx.log
 local assert = assert
 local sort = table.sort
 local type = type
 
 
-local check_protocol_support =
-  require("kong.clustering.utils").check_protocol_support
+local check_protocol_support = clustering_utils.check_protocol_support
+local is_dp_worker_process = clustering_utils.is_dp_worker_process
 
 
 local ngx_ERR = ngx.ERR
@@ -171,7 +172,7 @@ function _M:init_worker()
     return
   end
 
-  if role == "data_plane" and ngx.worker.id() == 0 then
+  if role == "data_plane" and is_dp_worker_process() then
     self:init_dp_worker(plugins_list)
   end
 end

--- a/kong/clustering/utils.lua
+++ b/kong/clustering/utils.lua
@@ -13,6 +13,7 @@ local tonumber = tonumber
 local ipairs = ipairs
 local table_insert = table.insert
 local table_concat = table.concat
+local process_type = require("ngx.process").type
 
 local kong = kong
 
@@ -447,6 +448,11 @@ function _M.connect_dp(conf, cert_digest,
   end
 
   return wb, log_suffix
+end
+
+
+function _M.is_dp_worker_process()
+  return process_type() == "privileged agent"
 end
 
 

--- a/kong/clustering/wrpc_data_plane.lua
+++ b/kong/clustering/wrpc_data_plane.lua
@@ -12,6 +12,7 @@ local init_negotiation_client = negotiation.init_negotiation_client
 local negotiate = negotiation.negotiate
 local get_negotiated_service = negotiation.get_negotiated_service
 
+
 local assert = assert
 local setmetatable = setmetatable
 local tonumber = tonumber
@@ -59,7 +60,7 @@ function _M:init_worker(plugins_list)
 
   self.plugins_list = plugins_list
 
-  if ngx.worker.id() == 0 then
+  if clustering_utils.is_dp_worker_process() then
     communicate(self)
   end
 end

--- a/kong/globalpatches.lua
+++ b/kong/globalpatches.lua
@@ -284,7 +284,7 @@ return function(options)
         is_seeded = seeded.master
 
       else
-        id = ngx.worker.id()
+        id = ngx.worker.id() or -1
         is_seeded = seeded[pid]
       end
 


### PR DESCRIPTION
### Summary

Data plane's connection to control plane is moved to a privileged worker process, including:
- maintaining websocket (wrpc) connection and data transfer
- decompression of received data
- json decoding of the received data
- validation and flattening of received data
- inserting data to lmdb

(so that these won't affect latencies / rps on proxy workers)