### PR TITLE
fix(request-transformer): unpredictable overriding result from rename header to existing header caused by pairs disorder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,9 @@
 - **AWS Lambda**: Fix an issue that is causing inability to
   read environment variables in ECS environment.
   [#9460](https://github.com/Kong/kong/pull/9460)
+- **Request-Transformer**: fix a bug when header renaming will override
+  existing header and cause unpredictable result.
+  [#9442](https://github.com/Kong/kong/pull/9442)
 
 ### Dependencies
 

--- a/kong/plugins/request-transformer/access.lua
+++ b/kong/plugins/request-transformer/access.lua
@@ -200,11 +200,9 @@ local function transform_headers(conf)
   -- Rename headers(s)
   for _, old_name, new_name in iter(conf.rename.headers) do
     old_name = old_name:lower()
-    -- Normalize new header name so that it can be successfully overridden
-    new_name = new_name:lower()
-    if headers[old_name] then
-      local value = headers[old_name]
-      headers[new_name] = value
+    local value = headers[old_name]
+    if value then
+      headers[new_name:lower()] = value
       headers[old_name] = nil
       headers_to_remove[old_name] = true
     end

--- a/kong/plugins/request-transformer/access.lua
+++ b/kong/plugins/request-transformer/access.lua
@@ -200,6 +200,8 @@ local function transform_headers(conf)
   -- Rename headers(s)
   for _, old_name, new_name in iter(conf.rename.headers) do
     old_name = old_name:lower()
+    -- Normalize new header name so that it can be successfully overridden
+    new_name = new_name:lower()
     if headers[old_name] then
       local value = headers[old_name]
       headers[new_name] = value

--- a/spec/03-plugins/36-request-transformer/02-access_spec.lua
+++ b/spec/03-plugins/36-request-transformer/02-access_spec.lua
@@ -739,7 +739,7 @@ describe("Plugin: request-transformer(access) [#" .. strategy .. "]", function()
           headers = {
             host = "test9.test",
             ["x-to-rename"] = "new-result",
-            ["x-is-renamed"] = "old-result"
+            ["x-is-renamed"] = "old-result",
           }
         })
         assert.response(r).has.status(200)

--- a/spec/03-plugins/36-request-transformer/02-access_spec.lua
+++ b/spec/03-plugins/36-request-transformer/02-access_spec.lua
@@ -3,6 +3,8 @@ local helpers = require "spec.helpers"
 local cjson   = require "cjson"
 local pl_file = require "pl.file"
 
+local fmt = string.format
+
 
 local function count_log_lines(pattern)
   local cfg = helpers.test_conf
@@ -729,6 +731,24 @@ describe("Plugin: request-transformer(access) [#" .. strategy .. "]", function()
       local h_a_header = assert.request(r).has.header("x-a-header")
       assert.equals("true", h_a_header)
     end)
+    for _, seq in ipairs({ 1, 2, 3, 4, 5, 6}) do
+      it(fmt("override value if target header already exist: #%s", seq), function ()
+        local r = assert(client:send {
+          method = "GET",
+          path = "/request",
+          headers = {
+            host = "test9.test",
+            ["x-to-rename"] = "new-result",
+            ["x-is-renamed"] = "old-result"
+          }
+        })
+        assert.response(r).has.status(200)
+        assert.response(r).has.jsonbody()
+        assert.request(r).has.no.header("x-to-rename")
+        local h_is_renamed = assert.request(r).has.header("x-is-renamed")
+        assert.equals("new-result", h_is_renamed)
+      end)
+    end
     it("specified parameters in url encoded body on POST", function()
       local r = assert(client:send {
         method = "POST",
@@ -856,154 +876,6 @@ describe("Plugin: request-transformer(access) [#" .. strategy .. "]", function()
       assert.response(r).has.jsonbody()
       local json = assert.request(r).has.jsonbody()
       assert.equals("{\"emptyarray\":[]}", json.data)
-    end)
-  end)
-
-  describe("rename", function()
-    it("specified header", function()
-      local r = assert(client:send {
-        method = "GET",
-        path = "/request",
-        headers = {
-          host = "test9.test",
-          ["x-to-rename"] = "true",
-          ["x-another-header"] = "true"
-        }
-      })
-      assert.response(r).has.status(200)
-      assert.response(r).has.jsonbody()
-      assert.request(r).has.no.header("x-to-rename")
-      assert.request(r).has.header("x-is-renamed")
-      assert.request(r).has.header("x-another-header")
-    end)
-    it("does not add as new header if header does not exist", function()
-      local r = assert( client:send {
-        method = "GET",
-        path = "/request",
-        body = {},
-        headers = {
-          host = "test9.test",
-          ["x-a-header"] = "true",
-        }
-      })
-      assert.response(r).has.status(200)
-      assert.response(r).has.jsonbody()
-      assert.request(r).has.no.header("renamedparam")
-      local h_a_header = assert.request(r).has.header("x-a-header")
-      assert.equals("true", h_a_header)
-    end)
-    it("specified parameters in url encoded body on POST", function()
-      local r = assert(client:send {
-        method = "POST",
-        path = "/request",
-        body = {
-          originalparam = "yes",
-        },
-        headers = {
-          ["Content-Type"] = "application/x-www-form-urlencoded",
-          host = "test9.test"
-        }
-      })
-      assert.response(r).has.status(200)
-      assert.response(r).has.jsonbody()
-      assert.request(r).has.no.formparam("originalparam")
-      local value = assert.request(r).has.formparam("renamedparam")
-      assert.equals("yes", value)
-    end)
-    it("does not add as new parameter in url encoded body if parameter does not exist on POST", function()
-      local r = assert(client:send {
-        method = "POST",
-        path = "/request",
-        body = {
-          ["x-a-header"] = "true",
-        },
-        headers = {
-          ["Content-Type"] = "application/x-www-form-urlencoded",
-          host = "test9.test"
-        }
-      })
-      assert.response(r).has.status(200)
-      assert.request(r).has.no.formparam("renamedparam")
-      local value = assert.request(r).has.formparam("x-a-header")
-      assert.equals("true", value)
-    end)
-    it("parameters from JSON body in POST", function()
-      local r = assert(client:send {
-        method = "POST",
-        path = "/request",
-        body = {
-          ["originalparam"] = "yes",
-          ["nottorename"] = "yes"
-        },
-        headers = {
-          host = "test9.test",
-          ["content-type"] = "application/json"
-        }
-      })
-      assert.response(r).has.status(200)
-      assert.response(r).has.jsonbody()
-      local json = assert.request(r).has.jsonbody()
-      assert.is_nil(json.params["originalparam"])
-      assert.is_not_nil(json.params["renamedparam"])
-      assert.equals("yes", json.params["renamedparam"])
-      assert.equals("yes", json.params["nottorename"])
-    end)
-    it("does not fail if JSON body is malformed in POST", function()
-      local r = assert(client:send {
-        method = "POST",
-        path = "/request",
-        body = "malformed json body",
-        headers = {
-          host = "test9.test",
-          ["content-type"] = "application/json"
-        }
-      })
-      assert.response(r).has.status(200)
-      local json = assert.response(r).has.jsonbody()
-      assert.equals("json (error)", json.post_data.kind)
-      assert.is_not_nil(json.post_data.error)
-    end)
-    it("parameters on multipart POST", function()
-      local r = assert(client:send {
-        method = "POST",
-        path = "/request",
-        body = {
-          ["originalparam"] = "yes",
-          ["nottorename"] = "yes"
-        },
-        headers = {
-          ["Content-Type"] = "multipart/form-data",
-          host = "test9.test"
-        }
-      })
-      assert.response(r).has.status(200)
-      assert.response(r).has.jsonbody()
-      assert.request(r).has.no.formparam("originalparam")
-      local value = assert.request(r).has.formparam("renamedparam")
-      assert.equals("yes", value)
-      local value2 = assert.request(r).has.formparam("nottorename")
-      assert.equals("yes", value2)
-    end)
-    it("args on GET if it exists", function()
-      local r = assert( client:send {
-        method = "GET",
-        path = "/request",
-        query = {
-          originalparam = "true",
-          nottorename = "true",
-        },
-        headers = {
-          ["Content-Type"] = "application/x-www-form-urlencoded",
-          host = "test9.test"
-        }
-      })
-      assert.response(r).has.status(200)
-      assert.response(r).has.jsonbody()
-      assert.request(r).has.no.queryparam("originalparam")
-      local value1 = assert.request(r).has.queryparam("renamedparam")
-      assert.equals("true", value1)
-      local value2 = assert.request(r).has.queryparam("nottorename")
-      assert.equals("true", value2)
     end)
   end)
 

--- a/spec/03-plugins/36-request-transformer/02-access_spec.lua
+++ b/spec/03-plugins/36-request-transformer/02-access_spec.lua
@@ -731,15 +731,31 @@ describe("Plugin: request-transformer(access) [#" .. strategy .. "]", function()
       local h_a_header = assert.request(r).has.header("x-a-header")
       assert.equals("true", h_a_header)
     end)
+    it("override value if target header already exist: #%s", function ()
+      local r = assert(client:send {
+        method = "GET",
+        path = "/request",
+        headers = {
+          host = "test9.test",
+          ["x-to-rename"] = "new-result",
+          ["x-is-renamed"] = "old-result",
+        }
+      })
+      assert.response(r).has.status(200)
+      assert.response(r).has.jsonbody()
+      assert.request(r).has.no.header("x-to-rename")
+      local h_is_renamed = assert.request(r).has.header("x-is-renamed")
+      assert.equals("new-result", h_is_renamed)
+    end)
     for _, seq in ipairs({ 1, 2, 3, 4, 5, 6}) do
-      it(fmt("override value if target header already exist: #%s", seq), function ()
+      it(fmt("override value if target header already exist with different format: #%s", seq), function ()
         local r = assert(client:send {
           method = "GET",
           path = "/request",
           headers = {
             host = "test9.test",
             ["x-to-rename"] = "new-result",
-            ["x-is-renamed"] = "old-result",
+            ["X-Is-Renamed"] = "old-result",
           }
         })
         assert.response(r).has.status(200)


### PR DESCRIPTION


<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

This PR fixes a bug in the `request-transformer` plugin, where the rename header cannot override an already existing header steadily.

If a header `A-header` already exists with a value `A-value` in the request, and the `request-transformer` plugin is configured to rename `B-header`(with a value `B-value`) to `A-header`(with different format, like all chars are capitalized), then the upstream request will contain an `A-header` with possibly `A-value` or `B-value`. This unpredictable behaviour may caused by `pairs` function disorder behaviour(Again!).

The code flow is as follows:

A `header` table is fetched by `ngx.req.get_headers` and used later for storing upstream request headers
https://github.com/Kong/kong/blob/c33d745793b454ab27d9681562fadbccbc454a1b/kong/plugins/request-transformer/access.lua#L186

Then the rename header list will be iterated
https://github.com/Kong/kong/blob/c33d745793b454ab27d9681562fadbccbc454a1b/kong/plugins/request-transformer/access.lua#L200-L209

Note that in this code block, the `new_name` will be directly used for setting value in the table, and the headers fetched by `ngx.req.get_headers()` are in lower case, so if `new_name` is an upper-case, then two keys with different format will exist in the `header` table.

And that will lead to the unpredictable iterating sequence in setting headers:
https://github.com/Kong/kong/blob/c33d745793b454ab27d9681562fadbccbc454a1b/kong/plugins/request-transformer/access.lua#L247

https://github.com/Kong/kong/blob/c33d745793b454ab27d9681562fadbccbc454a1b/kong/pdk/service/request.lua#L422-L427

### Full changelog

* Fix unpredictable overriding result from rename header to existing header in request-transformer plugin, by normalizing the header name(set to lower case)
* Cleanup duplicate tests and add related test

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix [FTI-4319] and #9418 


[FTI-4319]: https://konghq.atlassian.net/browse/FTI-4319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ