### PR TITLE
feat(jwt) Add configuration for JWT token claims error response

### DIFF
--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -187,7 +187,7 @@ local function do_authentication(conf)
   -- Verify the JWT registered claims
   local ok_claims, errors = jwt:verify_registered_claims(conf.claims_to_verify)
   if not ok_claims then
-    return false, { status = 401, errors = errors }
+    return false, { status = 401, errors = conf.error_response_claims or errors }
   end
 
   -- Verify the JWT registered claims

--- a/kong/plugins/jwt/schema.lua
+++ b/kong/plugins/jwt/schema.lua
@@ -39,6 +39,7 @@ return {
             elements = { type = "string" },
             default = { "authorization" },
           }, },
+          { error_response_claims = { type = "string", required = false} }
         },
       },
     },


### PR DESCRIPTION
### Summary

This will create a new configuration('error_response_claims') to override the JWT signature expired error