### PR TITLE
chore(error_handlers): define response message for trace method 405 error status code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,16 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+#### Core
+
+- Change the reponse body for a TRACE method from `The upstream server responded with 405`
+  to `Method not allowed`, make the reponse to show more clearly that Kong do not support 
+  TRACE method.
+  [#9448](https://github.com/Kong/kong/pull/9448)
+
+
 ### Additions
 
 #### Core

--- a/kong/error_handlers.lua
+++ b/kong/error_handlers.lua
@@ -12,6 +12,7 @@ local TYPE_GRPC       = "application/grpc"
 local BODIES = {
   [400] = "Bad request",
   [404] = "Not found",
+  [405] = "Method not allowed",
   [408] = "Request timeout",
   [411] = "Length required",
   [412] = "Precondition failed",

--- a/spec/02-integration/05-proxy/13-error_handlers_spec.lua
+++ b/spec/02-integration/05-proxy/13-error_handlers_spec.lua
@@ -1,8 +1,9 @@
 local helpers = require "spec.helpers"
 
-
+for _, strategy in helpers.each_strategy() do
 describe("Proxy error handlers", function()
   local proxy_client
+  helpers.get_db_utils(strategy, {})
 
   lazy_setup(function()
     assert(helpers.start_kong {
@@ -38,15 +39,15 @@ describe("Proxy error handlers", function()
     assert.equal("Bad request\n", body)
   end)
 
-  it("does not expose OpenResty version", function()
+  it("Request For Routers With Trace Method Not Allowed", function ()
     local res = assert(proxy_client:send {
       method = "TRACE",
       path = "/",
     })
-
     assert.res_status(405, res)
     local body = res:read_body()
     assert.matches("kong/", res.headers.server, nil, true)
-    assert.not_matches("openresty/", body, nil, true)
+    assert.equal("Method not allowed\n", body)
   end)
 end)
+end

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -98,7 +98,7 @@ http {
         listen $(entry.listener);
 > end
 
-        error_page 400 404 408 411 412 413 414 417 494 /kong_error_handler;
+        error_page 400 404 405 408 411 412 413 414 417 494 /kong_error_handler;
         error_page 500 502 503 504                     /kong_error_handler;
 
         access_log ${{PROXY_ACCESS_LOG}};


### PR DESCRIPTION
### Summary

When nginx blocks request with trace method from client, it hits the default error message in kong which is "The upstream server responded with 405", it is a little ambiguous. Actually the request doesn't reach upstream. 
Define  a detail message "Method not allowed" for 405 status code.