### PR TITLE
chore(release): setup per-commit releases for past releases

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,6 +41,7 @@ pipeline {
                 beforeAgent true
                 allOf {
                     branch 'master';
+                    branch 'next/*';
                     not { triggeredBy 'TimerTrigger' }
                 }
             }
@@ -100,7 +101,7 @@ pipeline {
                     steps {
                         sh 'echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin || true'
                         sh 'make setup-kong-build-tools'
-                        sh 'make RESTY_IMAGE_BASE=alpine RESTY_IMAGE_TAG=3 KONG_TEST_CONTAINER_TAG="${GIT_BRANCH##*/}-alpine" ADDITIONAL_TAG_LIST="${GIT_BRANCH##*/}-nightly-alpine latest" DOCKER_MACHINE_ARM64_NAME="kong-"`cat /proc/sys/kernel/random/uuid` release-docker-images'
+                        sh 'make RESTY_IMAGE_BASE=alpine RESTY_IMAGE_TAG=3 KONG_TEST_CONTAINER_TAG="${GIT_BRANCH##*/}-alpine" DOCKER_MACHINE_ARM64_NAME="kong-"`cat /proc/sys/kernel/random/uuid` release-docker-images'
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
                 beforeAgent true
                 allOf {
                     branch 'master';
-                    branch 'next/*';
+                    branch 'release/*';
                     not { triggeredBy 'TimerTrigger' }
                 }
             }


### PR DESCRIPTION
Trigger per-commit releases to our unofficial docker repository `kong/kong` for past releases.

This will result in for example a commit to `next/2.4.2` making the docker images
```
GITCOMMITSHA # equivalent to 2.4.2-debian
kong/kong:2.4.2 # equivalent to 2.4.2-debian
kong/kong:2.4.2-alpine # the only multi-arch
kong/kong:2.4.2-amazonlinux
kong/kong:2.4.2-debian
kong/kong:2.4.2-ubuntu