### PR TITLE
fix(opentelemetry): set default propagation type to w3c

### DIFF
--- a/kong/plugins/opentelemetry/handler.lua
+++ b/kong/plugins/opentelemetry/handler.lua
@@ -178,7 +178,7 @@ function OpenTelemetryHandler:rewrite()
     root_span.parent_id = span_id
   end
 
-  propagation_set("w3c", header_type, root_span)
+  propagation_set("w3c", header_type, root_span, "w3c")
 end
 
 function OpenTelemetryHandler:log(conf)

--- a/kong/plugins/opentelemetry/handler.lua
+++ b/kong/plugins/opentelemetry/handler.lua
@@ -178,7 +178,7 @@ function OpenTelemetryHandler:rewrite()
     root_span.parent_id = span_id
   end
 
-  propagation_set("w3c", header_type, root_span, "w3c")
+  propagation_set("preserve", header_type, root_span, "w3c")
 end
 
 function OpenTelemetryHandler:log(conf)


### PR DESCRIPTION
According to the original design, the default propagation header type should be `w3c`, described in https://docs.konghq.com/hub/kong-inc/opentelemetry/#propagation.

> The plugin detects the propagation format from the headers and will use the appropriate format to propagate the span context. If no appropriate format is found, the plugin will fail back to the default format, which is w3c.

The previous implementation didn't specify the default header type successfully, it was failback to the `b3` default.