### PR TITLE
feat(report): route statistics

### DIFF
--- a/kong/router/atc_compat.lua
+++ b/kong/router/atc_compat.lua
@@ -644,6 +644,7 @@ function _M:select(req_method, req_uri, req_host, req_scheme,
     service         = service,
     prefix          = request_prefix,
     matches = {
+      type = captures and "regex" or "prefix",
       uri_captures = (captures and captures[1]) and captures or nil,
     },
     upstream_url_t = {

--- a/kong/router/init.lua
+++ b/kong/router/init.lua
@@ -11,6 +11,131 @@ local utils = require("kong.router.utils")
 local is_http = ngx.config.subsystem == "http"
 
 
+local phonehome_statistics
+do
+  local reports = require("kong.reports")
+  local nkeys = require("table.nkeys")
+  local empty_table = {}
+  -- reuse tables to avoid cost of creating tables and garbage collection
+  local protocol_counts = {
+    http = 0, -- { "http", "https" },
+    stream = 0, -- { "tcp", "tls", "udp" },
+    tls_passthrough = 0, -- { "tls_passthrough" },
+    grpc = 0, -- { "grpc", "grpcs" },
+  }
+  local path_handling_counts = {
+    v0 = 0,
+    v1 = 0,
+  }
+  local route_report = {
+    flavor = "unknown",
+    paths_count = 0,
+    headers_count = 0,
+    total = 0,
+    regex_paths_count = 0,
+    protocols = protocol_counts,
+    path_handling = path_handling_counts,
+  }
+
+  local function send_report()
+    reports.send("routes", route_report)
+  end
+
+  local function traditional_statistics(routes)
+    local paths_count = 0
+    local headers_count = 0
+    local regex_paths_count = 0
+    local http = 0
+    local stream = 0
+    local tls_passthrough = 0
+    local grpc = 0
+    local v0 = 0
+    local v1 = 0
+  
+    for _, route in ipairs(routes) do
+      route = route.route
+      local paths = route.paths or empty_table
+      local headers = route.headers or empty_table
+
+      paths_count = paths_count + #paths
+      headers_count = headers_count + nkeys(headers)
+      for _, path in ipairs(paths) do
+        if path:sub(1, 1) == "~" then
+          regex_paths_count = regex_paths_count + 1
+          break
+        end
+      end
+
+      for _, protocol in ipairs(route.protocols or empty_table) do -- luacheck: ignore 512
+        if protocol == "http" or protocol == "https" then
+          http = http + 1
+
+        elseif protocol == "tcp" or protocol == "tls" or protocol == "udp" then
+
+          stream = stream + 1
+
+        elseif protocol == "tls_passthrough" then
+          tls_passthrough = tls_passthrough + 1
+
+        elseif protocol == "grpc" or protocol == "grpcs" then
+          grpc = grpc + 1
+        end
+        break
+      end
+
+      local path_handling = route.path_handling or "v0"
+      if path_handling == "v0" then
+        v0 = v0 + 1
+
+      elseif path_handling == "v1" then
+        v1 = v1 + 1
+      end
+    end
+
+    route_report.paths_count = paths_count
+    route_report.headers_count = headers_count
+    route_report.regex_paths_count = regex_paths_count
+    protocol_counts.http = http
+    protocol_counts.stream = stream
+    protocol_counts.tls_passthrough = tls_passthrough
+    protocol_counts.grpc = grpc
+    path_handling_counts.v0 = v0
+    path_handling_counts.v1 = v1
+  end
+
+  function phonehome_statistics(routes)
+    if not kong.configuration.anonymous_reports or ngx.worker.id() ~= 0 or
+      ngx.get_phase() == "init" then
+      return
+    end
+
+    -- reset the report table
+    route_report.flavor = kong.configuration.router_flavor
+    route_report.total = #routes
+
+    if route_report.flavor ~= "expressions" then
+      traditional_statistics(routes)
+
+    else
+      route_report.paths_count = 0
+      route_report.regex_paths_count = 0
+      route_report.headers_count = 0
+      protocol_counts.http = 0
+      protocol_counts.stream = 0
+      protocol_counts.tls_passthrough = 0
+      protocol_counts.grpc = 0
+      path_handling_counts.v0 = 0
+      path_handling_counts.v1 = 0
+    end
+
+    -- do not localize timer.at or we will be using vanilla Lua's timer
+    ngx.timer.at(0, send_report)
+    -- ngx.log(ngx.ERR, require "inspect"(route_report))
+  end
+end
+
+_M.phonehome_statistics = phonehome_statistics
+
 _M.DEFAULT_MATCH_LRUCACHE_SIZE = utils.DEFAULT_MATCH_LRUCACHE_SIZE
 
 
@@ -31,6 +156,8 @@ end
 
 
 function _M.new(routes, cache, cache_neg, old_router)
+  phonehome_statistics(routes)
+
   if not is_http or
      not kong or
      not kong.configuration or

--- a/kong/router/traditional.lua
+++ b/kong/router/traditional.lua
@@ -950,6 +950,7 @@ do
           if uri_t.is_regex then
             local is_match, err = match_regex_uri(uri_t, req_uri, matches)
             if is_match then
+              matches.type = "regex"
               return true
             end
 
@@ -963,6 +964,7 @@ do
           matches.uri_prefix = sub(req_uri, 1, #uri_t.value)
           matches.uri_postfix = sanitize_uri_postfix(sub(req_uri, #uri_t.value + 1))
           matches.uri = uri_t.value
+          matches.type = "prefix"
           return true
         end
       end
@@ -973,6 +975,7 @@ do
         if uri_t.is_regex then
           local is_match, err = match_regex_uri(uri_t, req_uri, matches)
           if is_match then
+            matches.type = "regex"
             return true
           end
 
@@ -988,6 +991,7 @@ do
             matches.uri_prefix = sub(req_uri, 1, to)
             matches.uri_postfix = sanitize_uri_postfix(sub(req_uri, to + 1))
             matches.uri = uri_t.value
+            matches.type = "prefix"
             return true
           end
         end
@@ -1254,6 +1258,7 @@ local function find_match(ctx)
           upstream_host   = upstream_host,
           prefix          = request_prefix,
           matches         = {
+            type          = matches.type,
             uri_captures  = matches.uri_captures,
             uri           = matches.uri,
             host          = matches.host,

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1101,6 +1101,7 @@ return {
         reports.add_ping_value("database_version", kong.db.infos.db_ver)
         reports.toggle(true)
         reports.init_worker()
+        -- TODO: trigger a report when start up. We cannot do this in init phase
       end
 
       update_lua_mem(true)

--- a/spec/02-integration/04-admin_api/11-reports_spec.lua
+++ b/spec/02-integration/04-admin_api/11-reports_spec.lua
@@ -242,6 +242,73 @@ for _, strategy in helpers.each_strategy() do
       assert.match("e=r", reports_data)
       assert.match("name=tcp%-log", reports_data)
     end)
+    
+    it("reports route", function()
+      local status, service
+      status, service = assert(admin_send({
+        method = "POST",
+        path = "/services",
+        body = {
+          protocol = "http",
+          host = "example.com",
+        },
+      }))
+      assert.same(201, status)
+      assert.string(service.id)
+
+      local route
+      status, route = assert(admin_send({
+        method = "POST",
+        path = "/routes",
+        body = {
+          protocols = { "http" },
+          hosts = { "dummy" },
+          service = { id = service.id },
+          paths = { "~/" },
+        },
+      }))
+      assert.same(201, status)
+      assert.string(route.id)
+
+      status, route = assert(admin_send({
+        method = "POST",
+        path = "/routes",
+        body = {
+          protocols = { "http" },
+          hosts = { "dummy" },
+          service = { id = service.id },
+          paths = { "/" },
+        },
+      }))
+      assert.same(201, status)
+      assert.string(route.id)
+
+      status, route = assert(admin_send({
+        method = "POST",
+        path = "/routes",
+        body = {
+          protocols = { "http" },
+          hosts = { "dummy" },
+          service = { id = service.id },
+          paths = { "/foo", "~/foo" },
+          path_handling = "v1",
+          headers = { foo = { "bar" } },
+        },
+      }))
+      assert.same(201, status)
+      assert.string(route.id)
+
+      local _, reports_data = assert(reports_server:join())
+
+      assert.match([[signal=routes]], reports_data)
+      assert.match([[total=3]], reports_data)
+      assert.match([[paths_count=4]], reports_data)
+      assert.match([["http":3]], reports_data)
+      assert.match("regex_paths_count=2", reports_data)
+      assert.match([["v0":2]], reports_data)
+      assert.match([["v1":1]], reports_data)
+      assert.match([[headers_count=1]], reports_data)
+    end)
 
     if strategy == "off" then
       it("reports declarative reconfigure via /config", function()

--- a/spec/02-integration/05-proxy/10-balancer/01-healthchecks_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer/01-healthchecks_spec.lua
@@ -1891,7 +1891,7 @@ for _, strategy in helpers.each_strategy() do
 
             end)
 
-            it("perform passive health checks -- manual recovery #only", function()
+            it("perform passive health checks -- manual recovery", function()
                 -- configure healthchecks
                 bu.begin_testcase_setup(strategy, bp)
                 local upstream_name, upstream_id = bu.add_upstream(bp, {


### PR DESCRIPTION
Collect statistics of configured routers and runtime usage including:
1. How many routes are configured;
2. How many paths are configured for routes;
3. How many headers are configured for routes;
4. The used router flavor;
5. How many routes are configured for different kinds of protocols;
6. How many routes are configured with different path handling;
7. How many regex paths matched

Configured routes statistics are collected when every time the router is rebuilt, and are sent at a limited frequency.
Runtime usage is sent along with the ping.

TODO:
- [x] See if we could avoid calculating on every route rebuild
- [x] cherry-pick to EE master
- [x] cherry-pick to release/2.8.x
- [x] cherry-pick to next/2.8.x.x

Fix FT-3217
