### PR TITLE
fix(aws-lambda): fetch ecs environment variable failure caused by the phase change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,11 @@
   correctly created.
   [#9434](https://github.com/Kong/kong/pull/9434)
 
+#### Plugins
+
+- **AWS Lambda**: Fix issue on fetching environment variables in ECS environment.
+  [#9460](https://github.com/Kong/kong/pull/9460)
+
 ## [3.0.0]
 
 > Released 2022/09/12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@
 
 #### Plugins
 
-- **AWS Lambda**: Fix issue on fetching environment variables in ECS environment.
+- **AWS Lambda**: Fix an issue that is causing inability to read environment variables in ECS environment.
   [#9460](https://github.com/Kong/kong/pull/9460)
 
 ## [3.0.0]

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -2,6 +2,8 @@
 
 local aws_v4 = require "kong.plugins.aws-lambda.v4"
 local aws_serializer = require "kong.plugins.aws-lambda.aws-serializer"
+local aws_ecs_cred_provider = require "kong.plugins.aws-lambda.iam-ecs-credentials"
+local aws_ec2_cred_provider = require "kong.plugins.aws-lambda.iam-ec2-credentials"
 local http = require "resty.http"
 local cjson = require "cjson.safe"
 local meta = require "kong.meta"
@@ -21,9 +23,9 @@ end
 local function fetch_aws_credentials(aws_conf)
   local fetch_metadata_credentials do
     local metadata_credentials_source = {
-      require "kong.plugins.aws-lambda.iam-ecs-credentials",
+      aws_ecs_cred_provider,
       -- The EC2 one will always return `configured == true`, so must be the last!
-      require "kong.plugins.aws-lambda.iam-ec2-credentials",
+      aws_ec2_cred_provider,
     }
 
     for _, credential_source in ipairs(metadata_credentials_source) do

--- a/kong/plugins/aws-lambda/iam-ecs-credentials.lua
+++ b/kong/plugins/aws-lambda/iam-ecs-credentials.lua
@@ -117,6 +117,7 @@ local function fetchCredentialsLogged()
 end
 
 return {
+  _ECS_URI = ECS_URI, -- exposed for test
   configured = not not ECS_URI, -- force to boolean
   fetchCredentials = fetchCredentialsLogged,
 }

--- a/spec/03-plugins/27-aws-lambda/04-iam-ecs-credentials_spec.lua
+++ b/spec/03-plugins/27-aws-lambda/04-iam-ecs-credentials_spec.lua
@@ -1,6 +1,100 @@
-require "spec.helpers"
+local helpers = require "spec.helpers"
 
-describe("[AWS Lambda] iam-ecs", function()
+for _, strategy in helpers.each_strategy() do
+  describe("[AWS Lambda] iam-ecs module environment variable fetch in Kong startup [#" .. strategy .. "]", function ()
+    local proxy_client
+
+    lazy_setup(function ()
+      helpers.setenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "/v2/credentials/unique-string-match-12344321")
+
+      local bp = helpers.get_db_utils(strategy, {
+        "routes",
+        "services",
+        "plugins",
+      }, { "aws-lambda", "file-log" })
+
+      local service1 = bp.services:insert {
+        host = "mockbin.org",
+        port = 80,
+      }
+
+      local route1 = bp.routes:insert {
+        hosts = { "lambda.com" },
+        service = service1,
+      }
+
+      -- Add lambda plugin so that the module is loaded
+      bp.plugins:insert {
+        name     = "aws-lambda",
+        route    = { id = route1.id },
+        config   = {
+          port          = 10001,
+          aws_key       = "mock-key",
+          aws_secret    = "mock-secret",
+          aws_region    = "us-east-1",
+          function_name = "kongLambdaTest",
+        },
+      }
+
+      local service2 = bp.services:insert {
+        host = "mockbin.org",
+        port = 80,
+      }
+
+      local route2 = bp.routes:insert {
+        hosts = { "lambda2.com" },
+        service = service2,
+      }
+
+
+      bp.plugins:insert {
+        name     = "file-log",
+        route    = { id = route2.id },
+        config   = {
+          path = "test-aws-ecs-file.log",
+          custom_fields_by_lua = {
+            ecs_uri = "return package.loaded[\"kong.plugins.aws-lambda.iam-ecs-credentials\"]._ECS_URI"
+          }
+        },
+      }
+
+      assert(helpers.start_kong({
+        database   = strategy,
+        untrusted_lua = "on",
+        plugins = "aws-lambda, file-log",
+      }, nil, nil, nil))
+    end)
+
+    before_each(function()
+      proxy_client = helpers.proxy_client()
+    end)
+
+    after_each(function ()
+      proxy_client:close()
+    end)
+
+    lazy_teardown(function()
+      helpers.stop_kong()
+      helpers.unsetenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
+    end)
+
+    it("should find ECS uri in the file log", function()
+      helpers.clean_logfile("test-aws-ecs-file.log")
+
+      assert(proxy_client:send {
+        method = "GET",
+        path = "/",
+        headers = {
+          host = "lambda2.com",
+        }
+      })
+
+      assert.logfile("test-aws-ecs-file.log").has.line("unique-string-match-12344321", true, 20)
+    end)
+  end)
+end
+
+describe("[AWS Lambda] iam-ecs credential fetch test", function()
 
   local fetch_ecs, http_responses, env_vars
   local old_getenv = os.getenv


### PR DESCRIPTION

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

This PR fixes a bug that the aws-lambda plugin failed to get environment variables in ECS which leads to unable to fetch ECS task role credentials.

This bug is introduced since #8900, in which the moment of the step `require "kong.plugins.aws-lambda.iam-ecs-credentials"` is changed from happening in package load(init phase) to only in function call(access phase). Since in the Nginx process environment, only those environment variables exposed through the `env` Nginx config directory can be fetched by `os.getenv` in Lua code(with an exception that env vars can all be fetched in the init phase, and most of the Kong code that using `os.getenv` relies on this). So after #8900, fetching ECS environment variables will fail.

Sorry for bringing this bug in, and this also shows that a full integration test with the AWS environment is really needed for this plugin.


### Full changelog

* Fix fetch ECS environment variable failure caused by the phase change

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix [FTI-4340]


[FTI-4340]: https://konghq.atlassian.net/browse/FTI-4340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ