### PR TITLE
feat(report): route statistics 

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1082,6 +1082,7 @@ return {
         reports.add_ping_value("database_version", kong.db.infos.db_ver)
         reports.toggle(true)
         reports.init_worker()
+        -- TODO: trigger a report when start up. We cannot do this in init phase
       end
 
       update_lua_mem(true)


### PR DESCRIPTION
Collect statistics of configured routers and runtime usage including:
1. How many routes are configured;
2. How many paths are configured for routes;
3. How many headers are configured for routes;
4. The used router flavor;
5. How many routes are configured for different kinds of protocols;
6. How many routes are configured with different path handling;
7. How many regex paths matched

Configured routes statistics are collected when every time the router is rebuilt, and are sent at a limited frequency.
Runtime usage is sent along with the ping.

Fix FT-3217

This is a cherry-pick of https://github.com/Kong/kong/pull/9459
