### PR TITLE
Refactor datadog hostname/port env vars

### DIFF
--- a/kong/plugins/datadog/statsd_logger.lua
+++ b/kong/plugins/datadog/statsd_logger.lua
@@ -21,12 +21,12 @@ local statsd_mt = {}
 statsd_mt.__index = statsd_mt
 
 local env_datadog_agent_host = os.getenv 'KONG_DATADOG_AGENT_HOST'
-local env_datadog_agent_port = tonumber(os.getenv 'KONG_DATADOG_AGENT_PORT' or "")
+local env_datadog_agent_port = os.getenv 'KONG_DATADOG_AGENT_PORT'
 
 function statsd_mt:new(conf)
   local sock   = udp()
-  local host = conf.host or env_datadog_agent_host
-  local port = conf.port or env_datadog_agent_port
+  local host = env_datadog_agent_host or conf.host
+  local port = tonumber(env_datadog_agent_port or conf.port)
 
   local _, err = sock:setpeername(host, port)
   if err then

--- a/spec/03-plugins/08-datadog/01-log_spec.lua
+++ b/spec/03-plugins/08-datadog/01-log_spec.lua
@@ -64,6 +64,11 @@ for _, strategy in helpers.each_strategy() do
         service = bp.services:insert { name = "dd6" }
       }
 
+      local route7 = bp.routes:insert {
+        hosts   = { "datadog7.com" },
+        service = bp.services:insert { name = "dd7" }
+      }
+
       bp.plugins:insert {
         name     = "key-auth",
         route = { id = route1.id },
@@ -149,8 +154,8 @@ for _, strategy in helpers.each_strategy() do
         name     = "datadog",
         route = { id = route5.id },
         config   = {
-          host = ngx.null, -- plugin takes above env var value, if set to null
-          port = ngx.null, -- plugin takes above env var value, if set to null
+          host = "no-such-config.com", -- plugin takes above env var value, if env var is set
+          port = 8125, -- plugin takes above env var value, if env var is set
         },
       }
 
@@ -182,6 +187,21 @@ for _, strategy in helpers.each_strategy() do
           service_name_tag = "upstream",
           status_tag       = "http_status",
           consumer_tag     = "user",
+        },
+      }
+
+      bp.plugins:insert {
+        name     = "key-auth",
+        route = { id = route7.id },
+      }
+
+      helpers.setenv('KONG_DATADOG_AGENT_HOST', 'localhost')
+      bp.plugins:insert {
+        name     = "datadog",
+        route = { id = route7.id },
+        config   = {
+          host = "no-such-config.com", -- plugin takes above env var value, if env var is set
+          port = 9999, -- plugin takes this value, as the env var for port is not set
         },
       }
 
@@ -355,6 +375,30 @@ for _, strategy in helpers.each_strategy() do
       assert.contains("kong.upstream_latency:%d+|ms|#name:dd5,status:200,consumer:bar,app:kong", gauges, true)
       assert.contains("kong.kong_latency:%d*|ms|#name:dd5,status:200,consumer:bar,app:kong", gauges, true)
     end)
+
+    it("logs metrics to host when it is the only thing defined via environment variables", function()
+      local thread = helpers.udp_server(9999, 6)
+
+      local res = assert(proxy_client:send {
+        method  = "GET",
+        path    = "/status/200?apikey=kong",
+        headers = {
+          ["Host"] = "datadog7.com"
+        }
+      })
+      assert.res_status(200, res)
+
+      local ok, gauges = thread:join()
+      assert.True(ok)
+      assert.equal(6, #gauges)
+      assert.contains("kong.request.count:1|c|#name:dd7,status:200,consumer:bar,app:kong" , gauges)
+      assert.contains("kong.latency:%d+|ms|#name:dd7,status:200,consumer:bar,app:kong", gauges, true)
+      assert.contains("kong.request.size:%d+|ms|#name:dd7,status:200,consumer:bar,app:kong", gauges, true)
+      assert.contains("kong.response.size:%d+|ms|#name:dd7,status:200,consumer:bar,app:kong", gauges, true)
+      assert.contains("kong.upstream_latency:%d+|ms|#name:dd7,status:200,consumer:bar,app:kong", gauges, true)
+      assert.contains("kong.kong_latency:%d*|ms|#name:dd7,status:200,consumer:bar,app:kong", gauges, true)
+    end)
+
 
     it("should not return a runtime error (regression)", function()
       local thread = helpers.udp_server(9999, 1, 1)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

This addresses an issue reported here:
https://github.com/Kong/kong/issues/7954

While the tests set a null value to instead inherit the environment variables, this does not work in a Kubernetes context. For example, if I have this config:

```
config:
  host: null
  port: 8125
```

The hostname still resolves to `localhost` once it gets through the schema.lua defaults.

This approach reverses the order of ENV var evaluation, so that environment variables are used if set, and config if not.

### Full changelog

* reverses order of logic determining if env vars or config is used for host/port
* adds test to ensure config is used if env var is not set

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #7954
