### PR TITLE
fix(router/atc): properly handle empty fields on the `Route` object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,12 +72,6 @@
 
 #### Core
 
-- Fix issue where external plugins crashing with unhandled exceptions
-  would cause high CPU utilization after the automatic restart.
-  [#9384](https://github.com/Kong/kong/pull/9384)
-- Fix issue in `header_filter` instrumentation where the span was not
-  correctly created.
-  [#9434](https://github.com/Kong/kong/pull/9434)
 - Fix issue in router building where when field contains an empty table,
   the generated expression is invalid.
   [#9451](https://github.com/Kong/kong/pull/9451)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,19 @@
 
 ## [3.0.1]
 
+### Fixes
+
+#### Core
+
+- Fix issue where external plugins crashing with unhandled exceptions
+  would cause high CPU utilization after the automatic restart.
+  [#9384](https://github.com/Kong/kong/pull/9384)
+- Fix issue in `header_filter` instrumentation where the span was not
+  correctly created.
+  [#9434](https://github.com/Kong/kong/pull/9434)
+- Fix issue in router building where when field contains an empty table,
+  the generated expression is invalid.
+  [#9451](https://github.com/Kong/kong/pull/9451)
 
 ## [3.0.0]
 

--- a/kong/router/atc_compat.lua
+++ b/kong/router/atc_compat.lua
@@ -11,6 +11,7 @@ local server_name = require("ngx.ssl").server_name
 local tb_new = require("table.new")
 local tb_clear = require("table.clear")
 local tb_nkeys = require("table.nkeys")
+local isempty = require("table.isempty")
 local yield = require("kong.tools.utils").yield
 
 
@@ -65,6 +66,11 @@ local atc_single_header_t = tb_new(10, 0)
 
 local function is_regex_magic(path)
   return byte(path) == TILDE
+end
+
+
+local function is_empty_field(f)
+  return f == nil or f == null or isempty(f)
 end
 
 
@@ -139,7 +145,7 @@ end
 
 
 local function gen_for_field(name, op, vals, val_transform)
-  if not vals or vals == null then
+  if is_empty_field(vals) then
     return nil
   end
 
@@ -186,7 +192,7 @@ local function get_atc(route)
     tb_insert(out, gen)
   end
 
-  if route.hosts and route.hosts ~= null then
+  if not is_empty_field(route.hosts) then
     tb_clear(atc_hosts_t)
     local hosts = atc_hosts_t
 
@@ -241,7 +247,7 @@ local function get_atc(route)
     tb_insert(out, gen)
   end
 
-  if route.headers and route.headers ~= null then
+  if not is_empty_field(route.headers) then
     tb_clear(atc_headers_t)
     local headers = atc_headers_t
 

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -1932,6 +1932,59 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
         end)
       end
 
+      describe("check empty route fields", function()
+        local use_case
+        local _get_atc = atc_compat._get_atc
+
+        before_each(function()
+          use_case = {
+            {
+              service = service,
+              route = {
+                id = "e8fb37f1-102d-461e-9c51-6608a6bb8101",
+                methods = { "GET" },
+                paths = { "/foo", },
+              },
+            },
+          }
+        end)
+
+        it("empty methods", function()
+          use_case[1].route.methods = {}
+
+          assert.equal(_get_atc(use_case[1].route), [[(http.path ^= "/foo")]])
+          assert(new_router(use_case))
+        end)
+
+        it("empty hosts", function()
+          use_case[1].route.hosts = {}
+
+          assert.equal(_get_atc(use_case[1].route), [[(http.method == "GET") && (http.path ^= "/foo")]])
+          assert(new_router(use_case))
+        end)
+
+        it("empty headers", function()
+          use_case[1].route.headers = {}
+
+          assert.equal(_get_atc(use_case[1].route), [[(http.method == "GET") && (http.path ^= "/foo")]])
+          assert(new_router(use_case))
+        end)
+
+        it("empty paths", function()
+          use_case[1].route.paths = {}
+
+          assert.equal(_get_atc(use_case[1].route), [[(http.method == "GET")]])
+          assert(new_router(use_case))
+        end)
+
+        it("empty snis", function()
+          use_case[1].route.snis = {}
+
+          assert.equal(_get_atc(use_case[1].route), [[(http.method == "GET") && (http.path ^= "/foo")]])
+          assert(new_router(use_case))
+        end)
+      end)
+
       describe("normalization stopgap measurements", function()
         local use_case, router
 


### PR DESCRIPTION

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

cherry-pick PR #9451 
