### PR TITLE
fix(cmd): kong prepare to write out .kong_process_secrets

### DIFF
--- a/kong/cmd/prepare.lua
+++ b/kong/cmd/prepare.lua
@@ -7,7 +7,7 @@ local function execute(args)
     prefix = args.prefix
   }))
 
-  local ok, err = prefix_handler.prepare_prefix(conf, args.nginx_conf)
+  local ok, err = prefix_handler.prepare_prefix(conf, args.nginx_conf, nil, true)
   if not ok then
     error("could not prepare Kong prefix at " .. conf.prefix .. ": " .. err)
   end

--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -570,6 +570,9 @@ local function prepare_prefix(kong_config, nginx_custom_template_path, skip_writ
     if not ok then
       return nil, err
     end
+
+  elseif not write_process_secrets then
+    os.remove(kong_config.kong_process_secrets)
   end
 
   return true

--- a/spec/02-integration/02-cmd/09-prepare_spec.lua
+++ b/spec/02-integration/02-cmd/09-prepare_spec.lua
@@ -1,4 +1,9 @@
 local helpers = require "spec.helpers"
+local signals = require "kong.cmd.utils.nginx_signals"
+local pl_utils = require "pl.utils"
+
+
+local fmt = string.format
 
 
 local TEST_PREFIX = "servroot_prepared_test"
@@ -19,9 +24,31 @@ describe("kong prepare", function()
     }))
     assert.truthy(helpers.path.exists(TEST_PREFIX))
 
+    local process_secrets = helpers.path.join(TEST_PREFIX, ".kong_process_secrets")
     local admin_access_log_path = helpers.path.join(TEST_PREFIX, helpers.test_conf.admin_access_log)
     local admin_error_log_path = helpers.path.join(TEST_PREFIX, helpers.test_conf.admin_error_log)
 
+    assert.falsy(helpers.path.exists(process_secrets))
+    assert.truthy(helpers.path.exists(admin_access_log_path))
+    assert.truthy(helpers.path.exists(admin_error_log_path))
+  end)
+
+  it("prepares a prefix and creates a process secrets file", function()
+    helpers.setenv("PG_USER", "test-user")
+    finally(function()
+      helpers.unsetenv("PG_USER")
+    end)
+    assert(helpers.kong_exec("prepare -c " .. helpers.test_conf_path, {
+      prefix = TEST_PREFIX,
+      pg_user = "{vault://env/pg-user}",
+    }))
+    assert.truthy(helpers.path.exists(TEST_PREFIX))
+
+    local process_secrets = helpers.path.join(TEST_PREFIX, ".kong_process_secrets")
+    local admin_access_log_path = helpers.path.join(TEST_PREFIX, helpers.test_conf.admin_access_log)
+    local admin_error_log_path = helpers.path.join(TEST_PREFIX, helpers.test_conf.admin_error_log)
+
+    assert.truthy(helpers.path.exists(process_secrets))
     assert.truthy(helpers.path.exists(admin_access_log_path))
     assert.truthy(helpers.path.exists(admin_error_log_path))
   end)
@@ -55,4 +82,78 @@ describe("kong prepare", function()
                      nil, true)
     end)
   end)
+
+  for _, strategy in helpers.each_strategy({ "postgres" }) do
+    describe("and start", function()
+      lazy_setup(function()
+        helpers.get_db_utils(strategy, { "routes" })
+      end)
+      after_each(function()
+        helpers.stop_kong(TEST_PREFIX)
+      end)
+      it("prepares a prefix and starts kong correctly [#" .. strategy .. "]", function()
+        helpers.setenv("PG_DATABASE", "kong")
+        finally(function()
+          helpers.unsetenv("PG_DATABASE")
+        end)
+        assert(helpers.kong_exec("prepare -c " .. helpers.test_conf_path, {
+          prefix = TEST_PREFIX,
+          database = strategy,
+          pg_database = "{vault://env/pg-database}",
+        }))
+        assert.truthy(helpers.path.exists(TEST_PREFIX))
+
+        local process_secrets = helpers.path.join(TEST_PREFIX, ".kong_process_secrets")
+        local admin_access_log_path = helpers.path.join(TEST_PREFIX, helpers.test_conf.admin_access_log)
+        local admin_error_log_path = helpers.path.join(TEST_PREFIX, helpers.test_conf.admin_error_log)
+
+        assert.truthy(helpers.path.exists(process_secrets))
+        assert.truthy(helpers.path.exists(admin_access_log_path))
+        assert.truthy(helpers.path.exists(admin_error_log_path))
+
+        local nginx_bin, err = signals.find_nginx_bin()
+        assert.is_nil(err)
+
+        local cmd = fmt("%s -p %s -c %s", nginx_bin, TEST_PREFIX, "nginx.conf")
+        local ok, _, _, stderr = pl_utils.executeex(cmd)
+
+        assert.equal("", stderr)
+        assert.truthy(ok)
+        local admin_client = helpers.admin_client()
+        local res = admin_client:get("/routes")
+        assert.res_status(200, res)
+        admin_client:close()
+      end)
+
+      it("prepares a prefix and fails to start kong correctly [#" .. strategy .. "]", function()
+        helpers.setenv("PG_DATABASE", "kong_tests_unknown")
+        finally(function()
+          helpers.unsetenv("PG_DATABASE")
+        end)
+        assert(helpers.kong_exec("prepare -c " .. helpers.test_conf_path, {
+          prefix = TEST_PREFIX,
+          database = strategy,
+          pg_database = "{vault://env/pg-database}",
+        }))
+        assert.truthy(helpers.path.exists(TEST_PREFIX))
+
+        local process_secrets = helpers.path.join(TEST_PREFIX, ".kong_process_secrets")
+        local admin_access_log_path = helpers.path.join(TEST_PREFIX, helpers.test_conf.admin_access_log)
+        local admin_error_log_path = helpers.path.join(TEST_PREFIX, helpers.test_conf.admin_error_log)
+
+        assert.truthy(helpers.path.exists(process_secrets))
+        assert.truthy(helpers.path.exists(admin_access_log_path))
+        assert.truthy(helpers.path.exists(admin_error_log_path))
+
+        local nginx_bin, err = signals.find_nginx_bin()
+        assert.is_nil(err)
+
+        local cmd = fmt("%s -p %s -c %s", nginx_bin, TEST_PREFIX, "nginx.conf")
+        local ok, _, _, stderr = pl_utils.executeex(cmd)
+
+        assert.matches("kong_tests_unknown", stderr)
+        assert.falsy(ok)
+      end)
+    end)
+  end
 end)


### PR DESCRIPTION
### Summary

Kong Docker image for example starts Kong by running `kong prepare` and then executes `nginx -c ... -p ...` as seen in:
https://github.com/Kong/docker-kong/blob/master/alpine/docker-entrypoint.sh

This causes issues with Kong secret management references. By default, Kong passes secrets to nginx using environment variable when using `kong start`, but here the `nginx` is started directly without calling `kong start` and thus the secrets are not available for Kong init. This commit fixes that.