### PR TITLE
fix(*): do not use stale router data if workers are respawned

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -716,22 +716,31 @@ function Kong.init_worker()
     end
   end
 
-  if kong.configuration.role ~= "control_plane" then
+  local is_not_control_plane = kong.configuration.role ~= "control_plane"
+  if is_not_control_plane then
     ok, err = execute_cache_warmup(kong.configuration)
     if not ok then
       ngx_log(ngx_ERR, "failed to warm up the DB cache: " .. err)
     end
   end
 
-  runloop.init_worker.before()
-
-  -- run plugins init_worker context
   ok, err = runloop.update_plugins_iterator()
   if not ok then
     stash_init_worker_error("failed to build the plugins iterator: " .. err)
     return
   end
 
+  if is_not_control_plane then
+    ok, err = runloop.update_router()
+    if not ok then
+      stash_init_worker_error("failed to build the router: " .. err)
+      return
+    end
+  end
+
+  runloop.init_worker.before()
+
+  -- run plugins init_worker context
   local plugins_iterator = runloop.get_plugins_iterator()
   local errors = execute_init_worker_plugins_iterator(plugins_iterator, ctx)
   if errors then
@@ -744,7 +753,7 @@ function Kong.init_worker()
 
   runloop.init_worker.after()
 
-  if kong.configuration.role ~= "control_plane" and ngx.worker.id() == 0 then
+  if is_not_control_plane and ngx.worker.id() == 0 then
     plugin_servers.start()
   end
 

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1073,7 +1073,7 @@ end
 -- before or after the plugins
 return {
   build_router = build_router,
-
+  update_router = update_router,
   build_plugins_iterator = build_plugins_iterator,
   update_plugins_iterator = update_plugins_iterator,
   get_plugins_iterator = get_plugins_iterator,

--- a/spec/02-integration/05-proxy/02-router_spec.lua
+++ b/spec/02-integration/05-proxy/02-router_spec.lua
@@ -2243,99 +2243,105 @@ for _, strategy in helpers.each_strategy() do
     end)
   end)
 
-  describe("Router [#" .. strategy .. ", flavor = " .. flavor .. "] at startup" , function()
-    local proxy_client
-    local route
+  for _, consistency in ipairs({ "strict", "eventual" }) do
+    describe("Router [#" .. strategy .. ", flavor = " .. flavor ..
+      ", consistency = " .. consistency .. "] at startup" , function()
+      local proxy_client
+      local route
 
-    lazy_setup(function()
-      local bp = helpers.get_db_utils(strategy, {
-        "routes",
-        "services",
-        "plugins",
-      }, {
-        "enable-buffering",
-      })
+      lazy_setup(function()
+        local bp = helpers.get_db_utils(strategy, {
+          "routes",
+          "services",
+          "plugins",
+        }, {
+          "enable-buffering",
+        })
 
-      route = bp.routes:insert({
-        methods    = { "GET" },
-        protocols  = { "http" },
-        strip_path = false,
-      })
+        route = bp.routes:insert({
+          methods    = { "GET" },
+          protocols  = { "http" },
+          strip_path = false,
+        })
 
-      if enable_buffering then
-        bp.plugins:insert {
-          name = "enable-buffering",
-          protocols = { "http", "https", "grpc", "grpcs" },
-        }
-      end
+        if enable_buffering then
+          bp.plugins:insert {
+            name = "enable-buffering",
+            protocols = { "http", "https", "grpc", "grpcs" },
+          }
+        end
 
-      assert(helpers.start_kong({
-        router_flavor = flavor,
-        database = strategy,
-        nginx_worker_processes = 4,
-        plugins = "bundled,enable-buffering",
-        nginx_conf = "spec/fixtures/custom_nginx.template",
-      }))
-    end)
+        assert(helpers.start_kong({
+          router_flavor = flavor,
+          worker_consistency = consistency,
+          database = strategy,
+          nginx_worker_processes = 4,
+          plugins = "bundled,enable-buffering",
+          nginx_conf = "spec/fixtures/custom_nginx.template",
+        }))
+      end)
 
-    lazy_teardown(function()
-      helpers.stop_kong()
-    end)
+      lazy_teardown(function()
+        helpers.stop_kong()
+      end)
 
-    before_each(function()
-      proxy_client = helpers.proxy_client()
-    end)
-
-    after_each(function()
-      if proxy_client then
-        proxy_client:close()
-      end
-    end)
-
-    it("uses configuration from datastore or declarative_config", function()
-      for _ = 1, 1000 do
+      before_each(function()
         proxy_client = helpers.proxy_client()
+      end)
+
+      after_each(function()
+        if proxy_client then
+          proxy_client:close()
+        end
+      end)
+
+      it("uses configuration from datastore or declarative_config", function()
+        for _ = 1, 1000 do
+          proxy_client = helpers.proxy_client()
+          local res = assert(proxy_client:send {
+            method  = "GET",
+            path    = "/get",
+            headers = { ["kong-debug"] = 1 },
+          })
+
+          assert.response(res).has_status(200)
+
+          assert.equal(route.service.name, res.headers["kong-service-name"])
+          proxy_client:close()
+        end
+      end)
+
+      it("#db worker respawn correctly rebuilds router", function()
+        local admin_client = helpers.admin_client()
+
+        local res = assert(admin_client:post("/routes", {
+          headers = { ["Content-Type"] = "application/json" },
+          body = {
+            paths = { "/foo" },
+          },
+        }))
+        assert.res_status(201, res)
+        admin_client:close()
+
+        local workers_before = helpers.get_kong_workers()
+        assert(helpers.signal_workers(nil, "-TERM"))
+        helpers.wait_until_no_common_workers(workers_before, 1) -- respawned
+
+        proxy_client:close()
+        proxy_client = helpers.proxy_client()
+
         local res = assert(proxy_client:send {
           method  = "GET",
-          path    = "/get",
+          path    = "/foo",
           headers = { ["kong-debug"] = 1 },
         })
 
-        assert.response(res).has_status(200)
-
-        assert.equal(route.service.name, res.headers["kong-service-name"])
-        proxy_client:close()
-      end
+        local body = assert.response(res).has_status(503)
+        local json = cjson.decode(body)
+        assert.equal("no Service found with those values", json.message)
+      end)
     end)
-
-    it("#db worker respawn correctly rebuilds router", function()
-      local admin_client = helpers.admin_client()
-
-      local res = assert(admin_client:post("/routes", {
-        headers = { ["Content-Type"] = "application/json" },
-        body = {
-          paths = { "/foo" },
-        },
-      }))
-      assert.res_status(201, res)
-      admin_client:close()
-
-      assert(helpers.signal_workers(nil, "-TERM"))
-
-      proxy_client:close()
-      proxy_client = helpers.proxy_client()
-
-      local res = assert(proxy_client:send {
-        method  = "GET",
-        path    = "/foo",
-        headers = { ["kong-debug"] = 1 },
-      })
-
-      local body = assert.response(res).has_status(503)
-      local json = cjson.decode(body)
-      assert.equal("no Service found with those values", json.message)
-    end)
-  end)
+  end
 end
 end
 end


### PR DESCRIPTION
### Summary

@Benny-Git reported on #9090 about issue of stale data picked up for router in case the worker was restarted.

Some insights:

There are several ways to restart workers:
1. you reload them with e.g. kong reload or similar nginx signal
2. worker crashes
3. worker is killed

On case 1 the `init` phase will be re-executed, on 2 and 3 it will not.

This commit ensures that the router is rebuild on init worker if it is not current (by default all workers are spawned from master process LuaJIT VM and that is not reintialized on cases 2 and 3).

FT-3432