### PR TITLE
chore(ci): run upgrade tests in PR, not daily

### DIFF
--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -1,9 +1,11 @@
 name: Upgrade Tests
 
 on:
-  schedule:
-    - cron: '0 4 * * *'
-  workflow_dispatch:
+  pull_request:
+  push:
+    paths-ignore:
+    # ignore top-level markdown files (CHANGELOG.md, README.md, etc.)
+    - '*.md'
 
 jobs:
   upgrade-test:


### PR DESCRIPTION
As we've tested the upgrade tests for a good while now, we can make them run in Pull Requests to ensure that new migrations also have a corresponding test.