### PR TITLE
refactor(handler): trying to make reconfigure more atomic

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -23,6 +23,9 @@ local ipairs            = ipairs
 local tostring          = tostring
 local tonumber          = tonumber
 local setmetatable      = setmetatable
+local max               = math.max
+local min               = math.min
+local ceil              = math.ceil
 local sub               = string.sub
 local byte              = string.byte
 local gsub              = string.gsub
@@ -48,6 +51,14 @@ local is_http_module   = subsystem == "http"
 local is_stream_module = subsystem == "stream"
 
 
+local DEFAULT_MATCH_LRUCACHE_SIZE = Router.DEFAULT_MATCH_LRUCACHE_SIZE
+
+
+local ROUTER_CACHE_SIZE = DEFAULT_MATCH_LRUCACHE_SIZE
+local ROUTER_CACHE = lrucache.new(ROUTER_CACHE_SIZE)
+local ROUTER_CACHE_NEG = lrucache.new(ROUTER_CACHE_SIZE)
+
+
 local NOOP = function() end
 
 
@@ -70,30 +81,21 @@ local CLEAR_HEALTH_STATUS_DELAY = constants.CLEAR_HEALTH_STATUS_DELAY
 local TTL_ZERO = { ttl = 0 }
 
 
+local ROUTER
+local ROUTER_VERSION
 local ROUTER_SYNC_OPTS
+
+local PLUGINS_ITERATOR
 local PLUGINS_ITERATOR_SYNC_OPTS
+
 local RECONFIGURE_OPTS
 local GLOBAL_QUERY_OPTS = { workspace = ngx.null, show_ws_id = true }
 
+local SERVER_HEADER = meta._SERVER_TOKENS
 
-local get_plugins_iterator, get_updated_plugins_iterator
-local build_plugins_iterator, update_plugins_iterator
-local rebuild_plugins_iterator
 
-local get_updated_router, build_router, update_router
-local server_header = meta._SERVER_TOKENS
-local rebuild_router
-
-local stream_tls_terminate_sock = "unix:" .. ngx.config.prefix() .. "/stream_tls_terminate.sock"
-local stream_tls_passthrough_sock = "unix:" .. ngx.config.prefix() .. "/stream_tls_passthrough.sock"
-
--- for tests
-local _set_update_plugins_iterator
-local _set_update_router
-local _set_build_router
-local _set_router
-local _set_router_version
-local _register_balancer_events
+local STREAM_TLS_TERMINATE_SOCK
+local STREAM_TLS_PASSTHROUGH_SOCK
 
 
 local set_upstream_cert_and_key
@@ -206,10 +208,345 @@ local function csv(s)
 end
 
 
+-- @param name "router" or "plugins_iterator"
+-- @param callback A function that will update the router or plugins_iterator
+-- @param version target version
+-- @param opts concurrency options, including lock name and timeout.
+-- @returns true if callback was either successfully executed synchronously,
+-- enqueued via async timer, or not needed (because current_version == target).
+-- nil otherwise (callback was neither called successfully nor enqueued,
+-- or an error happened).
+-- @returns error message as a second return value in case of failure/error
+local function rebuild(name, callback, version, opts)
+  local current_version, err = kong.core_cache:get(name .. ":version", TTL_ZERO, utils.uuid)
+  if err then
+    return nil, "failed to retrieve " .. name .. " version: " .. err
+  end
+
+  if current_version == version then
+    return true
+  end
+
+  return concurrency.with_coroutine_mutex(opts, callback)
+end
+
+
+-- Given a protocol, return the subsystem that handles it
+local function should_process_route(route)
+  for _, protocol in ipairs(route.protocols) do
+    if SUBSYSTEMS[protocol] == subsystem then
+      return true
+    end
+  end
+
+  return false
+end
+
+
+local function load_service_from_db(service_pk)
+  local service, err = kong.db.services:select(service_pk, GLOBAL_QUERY_OPTS)
+  if service == nil then
+    -- the third value means "do not cache"
+    return nil, err, -1
+  end
+  return service
+end
+
+
+local function build_services_init_cache(db)
+  local services_init_cache = {}
+  local services = db.services
+  local page_size
+  if services.pagination then
+    page_size = services.pagination.max_page_size
+  end
+
+  for service, err in services:each(page_size, GLOBAL_QUERY_OPTS) do
+    if err then
+      return nil, err
+    end
+
+    services_init_cache[service.id] = service
+  end
+
+  return services_init_cache
+end
+
+
+local function get_service_for_route(db, route, services_init_cache)
+  local service_pk = route.service
+  if not service_pk then
+    return nil
+  end
+
+  local id = service_pk.id
+  local service = services_init_cache[id]
+  if service then
+    return service
+  end
+
+  local err
+
+  -- kong.core_cache is available, not in init phase
+  if kong.core_cache and db.strategy ~= "off" then
+    local cache_key = db.services:cache_key(service_pk.id, nil, nil, nil, nil,
+                                            route.ws_id)
+    service, err = kong.core_cache:get(cache_key, TTL_ZERO,
+                                       load_service_from_db, service_pk)
+
+  else -- dbless or init phase, kong.core_cache not needed/available
+
+    -- A new service/route has been inserted while the initial route
+    -- was being created, on init (perhaps by a different Kong node).
+    -- Load the service individually and update services_init_cache with it
+    service, err = load_service_from_db(service_pk)
+    services_init_cache[id] = service
+  end
+
+  if err then
+    return nil, "error raised while finding service for route (" .. route.id .. "): " ..
+                err
+
+  elseif not service then
+    return nil, "could not find service for route (" .. route.id .. ")"
+  end
+
+
+  -- TODO: this should not be needed as the schema should check it already
+  if SUBSYSTEMS[service.protocol] ~= subsystem then
+    log(WARN, "service with protocol '", service.protocol,
+              "' cannot be used with '", subsystem, "' subsystem")
+
+    return nil
+  end
+
+  return service
+end
+
+
+local function get_router_version()
+  return kong.core_cache:get("router:version", TTL_ZERO, utils.uuid)
+end
+
+
+local function new_router(version)
+  local db = kong.db
+  local routes, i = {}, 0
+
+  local err
+  -- The router is initially created on init phase, where kong.core_cache is
+  -- still not ready. For those cases, use a plain Lua table as a cache
+  -- instead
+  local services_init_cache = {}
+  if not kong.core_cache and db.strategy ~= "off" then
+    services_init_cache, err = build_services_init_cache(db)
+    if err then
+      services_init_cache = {}
+      log(WARN, "could not build services init cache: ", err)
+    end
+  end
+
+  local detect_changes = db.strategy ~= "off" and kong.core_cache
+  local counter = 0
+  local page_size = db.routes.pagination.max_page_size
+  for route, err in db.routes:each(page_size, GLOBAL_QUERY_OPTS) do
+    if err then
+      return nil, "could not load routes: " .. err
+    end
+
+    if detect_changes then
+      if counter > 0 and counter % page_size == 0 then
+        local new_version, err = get_router_version()
+        if err then
+          return nil, "failed to retrieve router version: " .. err
+        end
+
+        if new_version ~= version then
+          return nil, "router was changed while rebuilding it"
+        end
+      end
+      counter = counter + 1
+    end
+
+    if should_process_route(route) then
+      local service, err = get_service_for_route(db, route, services_init_cache)
+      if err then
+        return nil, err
+      end
+
+      -- routes with no services are added to router
+      -- but routes where the services.enabled == false are not put in router
+      if service == nil or service.enabled ~= false then
+        local r = {
+          route   = route,
+          service = service,
+        }
+
+        i = i + 1
+        routes[i] = r
+      end
+    end
+  end
+
+  local n = DEFAULT_MATCH_LRUCACHE_SIZE
+  local cache_size = min(ceil(max(i / n, 1)) * n, n * 20)
+
+  if cache_size ~= ROUTER_CACHE_SIZE then
+    ROUTER_CACHE = lrucache.new(cache_size)
+    ROUTER_CACHE_SIZE = cache_size
+  end
+
+  local new_router, err = Router.new(routes, ROUTER_CACHE, ROUTER_CACHE_NEG, ROUTER)
+  if not new_router then
+    return nil, "could not create router: " .. err
+  end
+
+  return new_router
+end
+
+
+local function build_router(version)
+  local router, err = new_router(version)
+  if not router then
+    return nil, err
+  end
+
+  ROUTER = router
+
+  if version then
+    ROUTER_VERSION = version
+  end
+
+  ROUTER_CACHE:flush_all()
+  ROUTER_CACHE_NEG:flush_all()
+
+  return true
+end
+
+
+local function update_router()
+  -- we might not need to rebuild the router (if we were not
+  -- the first request in this process to enter this code path)
+  -- check again and rebuild only if necessary
+  local version, err = get_router_version()
+  if err then
+    return nil, "failed to retrieve router version: " .. err
+  end
+
+  if version == ROUTER_VERSION then
+    return true
+  end
+
+  local ok, err = build_router(version)
+  if not ok then
+    return nil, --[[ 'err' fully formatted ]] err
+  end
+
+  return true
+end
+
+
+local function rebuild_router(opts)
+  return rebuild("router", update_router, ROUTER_VERSION, opts)
+end
+
+
+local function get_updated_router()
+  if kong.db.strategy ~= "off" and kong.configuration.worker_consistency == "strict" then
+    local ok, err = rebuild_router(ROUTER_SYNC_OPTS)
+    if not ok then
+      -- If an error happens while updating, log it and return non-updated
+      -- version.
+      log(ERR, "could not rebuild router: ", err, " (stale router will be used)")
+    end
+  end
+  return ROUTER
+end
+
+
+-- for tests only
+local function _set_update_router(f)
+  update_router = f
+end
+
+local function _set_build_router(f)
+  build_router = f
+end
+
+local function _set_router(r)
+  ROUTER = r
+end
+
+local function _set_router_version(v)
+  ROUTER_VERSION = v
+end
+
+
+local new_plugins_iterator = PluginsIterator.new
+
+
+local function build_plugins_iterator(version)
+  local plugins_iterator, err = new_plugins_iterator(version)
+  if not plugins_iterator then
+    return nil, err
+  end
+  PLUGINS_ITERATOR = plugins_iterator
+  return true
+end
+
+
+local function update_plugins_iterator()
+  local version, err = kong.core_cache:get("plugins_iterator:version", TTL_ZERO, utils.uuid)
+  if err then
+    return nil, "failed to retrieve plugins iterator version: " .. err
+  end
+
+  if PLUGINS_ITERATOR and PLUGINS_ITERATOR.version == version then
+    return true
+  end
+
+  local ok, err = build_plugins_iterator(version)
+  if not ok then
+    return nil, --[[ 'err' fully formatted ]] err
+  end
+
+  return true
+end
+
+
+local function rebuild_plugins_iterator(opts)
+  local plugins_iterator_version = PLUGINS_ITERATOR and PLUGINS_ITERATOR.version
+  return rebuild("plugins_iterator", update_plugins_iterator, plugins_iterator_version, opts)
+end
+
+
+local function get_updated_plugins_iterator()
+  if kong.db.strategy ~= "off" and kong.configuration.worker_consistency == "strict" then
+    local ok, err = rebuild_plugins_iterator(PLUGINS_ITERATOR_SYNC_OPTS)
+    if not ok then
+      -- If an error happens while updating, log it and return non-updated
+      -- version
+      log(ERR, "could not rebuild plugins iterator: ", err,
+               " (stale plugins iterator will be used)")
+    end
+  end
+  return PLUGINS_ITERATOR
+end
+
+
+local function get_plugins_iterator()
+  return PLUGINS_ITERATOR
+end
+
+
+-- for tests only
+local function _set_update_plugins_iterator(f)
+  update_plugins_iterator = f
+end
+
+
 local function register_balancer_events(core_cache, worker_events, cluster_events)
   -- target updates
-
-
   -- worker_events local handler: event received from DAO
   worker_events.register(function(data)
     local operation = data.operation
@@ -281,8 +618,6 @@ local function register_balancer_events(core_cache, worker_events, cluster_event
 
 
   -- upstream updates
-
-
   -- worker_events local handler: event received from DAO
   worker_events.register(function(data)
     local operation = data.operation
@@ -349,6 +684,11 @@ local function register_balancer_events(core_cache, worker_events, cluster_event
 end
 
 
+local function _register_balancer_events(f)
+  register_balancer_events = f
+end
+
+
 local function register_events()
   -- initialize local local_events hooks
   local db             = kong.db
@@ -364,9 +704,17 @@ local function register_events()
     local current_plugins_hash
     local current_balancer_hash
 
+    local exiting = ngx.worker.exiting
+    local function is_exiting()
+      if not exiting() then
+        return false
+      end
+      log(NOTICE, "declarative reconfigure canceled: process exiting")
+      return true
+    end
+
     worker_events.register(function(data)
-      if ngx.worker.exiting() then
-        log(NOTICE, "declarative reconfigure canceled: process exiting")
+      if is_exiting() then
         return true
       end
 
@@ -383,28 +731,53 @@ local function register_events()
       end
 
       local ok, err = concurrency.with_coroutine_mutex(RECONFIGURE_OPTS, function()
+        -- below you are encouraged to yield for cooperative threading
+
         local rebuild_balancer = balancer_hash == nil or balancer_hash ~= current_balancer_hash
         if rebuild_balancer then
           balancer.stop_healthcheckers(CLEAR_HEALTH_STATUS_DELAY)
         end
 
+        kong.default_workspace = default_ws
+        ngx.ctx.workspace = default_ws
+
+        local router, err
+        if router_hash == nil or router_hash ~= current_router_hash then
+          router, err = new_router()
+          if not router then
+            return nil, err
+          end
+        end
+
+        local plugins_iterator
+        if plugins_hash == nil or plugins_hash ~= current_plugins_hash then
+          plugins_iterator, err = new_plugins_iterator()
+          if not plugins_iterator then
+            return nil, err
+          end
+        end
+
+        -- below you are not supposed to yield and this should be fast and atomic
+
+        -- TODO: we should perhaps only purge the configuration related cache.
         kong.core_cache:purge()
         kong.cache:purge()
 
-        kong.default_workspace = default_ws
-        ngx.ctx.workspace = kong.default_workspace
-
-        if plugins_hash == nil or plugins_hash ~= current_plugins_hash then
-          rebuild_plugins_iterator(PLUGINS_ITERATOR_SYNC_OPTS)
-          current_plugins_hash = plugins_hash
-        end
-
-        if router_hash == nil or router_hash ~= current_router_hash then
-          rebuild_router(ROUTER_SYNC_OPTS)
+        if router then
+          ROUTER = router
+          ROUTER_CACHE:flush_all()
+          ROUTER_CACHE_NEG:flush_all()
           current_router_hash = router_hash
         end
 
+        if plugins_iterator then
+          PLUGINS_ITERATOR = plugins_iterator
+          current_plugins_hash = plugins_hash
+        end
+
         if rebuild_balancer then
+          -- TODO: balancer is a big blob of global state and you cannot easily
+          --       initialize new balancer and then atomically flip it.
           balancer.init()
           current_balancer_hash = balancer_hash
         end
@@ -554,364 +927,6 @@ local function register_events()
     end
   end, "crud", "consumers")
 
-end
-
-
--- @param name "router" or "plugins_iterator"
--- @param callback A function that will update the router or plugins_iterator
--- @param version target version
--- @param opts concurrency options, including lock name and timeout.
--- @returns true if callback was either successfully executed synchronously,
--- enqueued via async timer, or not needed (because current_version == target).
--- nil otherwise (callback was neither called successfully nor enqueued,
--- or an error happened).
--- @returns error message as a second return value in case of failure/error
-local function rebuild(name, callback, version, opts)
-  local current_version, err = kong.core_cache:get(name .. ":version", TTL_ZERO,
-                                                   utils.uuid)
-  if err then
-    return nil, "failed to retrieve " .. name .. " version: " .. err
-  end
-
-  if current_version == version then
-    return true
-  end
-
-  return concurrency.with_coroutine_mutex(opts, callback)
-end
-
-
-do
-  local plugins_iterator
-
-
-  build_plugins_iterator = function(version)
-    local new_iterator, err = PluginsIterator.new(version)
-    if not new_iterator then
-      return nil, err
-    end
-    plugins_iterator = new_iterator
-    return true
-  end
-
-
-  update_plugins_iterator = function()
-    local version, err = kong.core_cache:get("plugins_iterator:version", TTL_ZERO,
-                                             utils.uuid)
-    if err then
-      return nil, "failed to retrieve plugins iterator version: " .. err
-    end
-
-    if plugins_iterator and plugins_iterator.version == version then
-      return true
-    end
-
-    local ok, err = build_plugins_iterator(version)
-    if not ok then
-      return nil, --[[ 'err' fully formatted ]] err
-    end
-
-    return true
-  end
-
-
-  rebuild_plugins_iterator = function(timeout)
-    local plugins_iterator_version = plugins_iterator and plugins_iterator.version
-    return rebuild("plugins_iterator", update_plugins_iterator,
-                   plugins_iterator_version, timeout)
-  end
-
-
-  get_updated_plugins_iterator = function()
-    if kong.db.strategy ~= "off" and kong.configuration.worker_consistency == "strict" then
-      local ok, err = rebuild_plugins_iterator(PLUGINS_ITERATOR_SYNC_OPTS)
-      if not ok then
-        -- If an error happens while updating, log it and return non-updated
-        -- version
-        log(ERR, "could not rebuild plugins iterator: ", err,
-                 " (stale plugins iterator will be used)")
-      end
-    end
-    return plugins_iterator
-  end
-
-
-  get_plugins_iterator = function()
-    return plugins_iterator
-  end
-
-
-  -- for tests only
-  _set_update_plugins_iterator = function(f)
-    update_plugins_iterator = f
-  end
-end
-
-
-do
-  local max  = math.max
-  local min  = math.min
-  local ceil = math.ceil
-
-  local DEFAULT_MATCH_LRUCACHE_SIZE = Router.DEFAULT_MATCH_LRUCACHE_SIZE
-
-  local router
-  local router_version
-  local router_cache_size = DEFAULT_MATCH_LRUCACHE_SIZE
-  local router_cache = lrucache.new(router_cache_size)
-  local router_cache_neg = lrucache.new(router_cache_size)
-
-
-  -- Given a protocol, return the subsystem that handles it
-  local function should_process_route(route)
-    for _, protocol in ipairs(route.protocols) do
-      if SUBSYSTEMS[protocol] == subsystem then
-        return true
-      end
-    end
-
-    return false
-  end
-
-
-  local function load_service_from_db(service_pk)
-    local service, err = kong.db.services:select(service_pk, GLOBAL_QUERY_OPTS)
-    if service == nil then
-      -- the third value means "do not cache"
-      return nil, err, -1
-    end
-    return service
-  end
-
-
-  local function build_services_init_cache(db)
-    local services_init_cache = {}
-    local services = db.services
-    local page_size
-    if services.pagination then
-      page_size = services.pagination.max_page_size
-    end
-
-    for service, err in services:each(page_size, GLOBAL_QUERY_OPTS) do
-      if err then
-        return nil, err
-      end
-
-      services_init_cache[service.id] = service
-    end
-
-    return services_init_cache
-  end
-
-
-  local function get_service_for_route(db, route, services_init_cache)
-    local service_pk = route.service
-    if not service_pk then
-      return nil
-    end
-
-    local id = service_pk.id
-    local service = services_init_cache[id]
-    if service then
-      return service
-    end
-
-    local err
-
-    -- kong.core_cache is available, not in init phase
-    if kong.core_cache and db.strategy ~= "off" then
-      local cache_key = db.services:cache_key(service_pk.id, nil, nil, nil, nil,
-                                              route.ws_id)
-      service, err = kong.core_cache:get(cache_key, TTL_ZERO,
-                                    load_service_from_db, service_pk)
-
-    else -- dbless or init phase: kong.core_cache not needed/available
-
-      -- A new service/route has been inserted while the initial route
-      -- was being created, on init (perhaps by a different Kong node).
-      -- Load the service individually and update services_init_cache with it
-      service, err = load_service_from_db(service_pk)
-      services_init_cache[id] = service
-    end
-
-    if err then
-      return nil, "error raised while finding service for route (" .. route.id .. "): " ..
-                  err
-
-    elseif not service then
-      return nil, "could not find service for route (" .. route.id .. ")"
-    end
-
-
-    -- TODO: this should not be needed as the schema should check it already
-    if SUBSYSTEMS[service.protocol] ~= subsystem then
-      log(WARN, "service with protocol '", service.protocol,
-                "' cannot be used with '", subsystem, "' subsystem")
-
-      return nil
-    end
-
-    return service
-  end
-
-
-  local function get_router_version()
-    return kong.core_cache:get("router:version", TTL_ZERO, utils.uuid)
-  end
-
-
-  build_router = function(version)
-    local db = kong.db
-    local routes, i = {}, 0
-
-    local err
-    -- The router is initially created on init phase, where kong.core_cache is
-    -- still not ready. For those cases, use a plain Lua table as a cache
-    -- instead
-    local services_init_cache = {}
-    if not kong.core_cache and db.strategy ~= "off" then
-      services_init_cache, err = build_services_init_cache(db)
-      if err then
-        services_init_cache = {}
-        log(WARN, "could not build services init cache: ", err)
-      end
-    end
-
-    local counter = 0
-    local page_size = db.routes.pagination.max_page_size
-    for route, err in db.routes:each(page_size, GLOBAL_QUERY_OPTS) do
-      if err then
-        return nil, "could not load routes: " .. err
-      end
-
-      if db.strategy ~= "off" and kong.core_cache then
-        if counter > 0 and counter % page_size == 0 then
-          local new_version, err = get_router_version()
-          if err then
-            return nil, "failed to retrieve router version: " .. err
-          end
-
-          if new_version ~= version then
-            return nil, "router was changed while rebuilding it"
-          end
-        end
-        counter = counter + 1
-      end
-
-      if should_process_route(route) then
-        local service, err = get_service_for_route(db, route, services_init_cache)
-        if err then
-          return nil, err
-        end
-
-        -- routes with no services are added to router
-        -- but routes where the services.enabled == false are not put in router
-        if service == nil or service.enabled ~= false then
-          local r = {
-            route   = route,
-            service = service,
-          }
-
-          i = i + 1
-          routes[i] = r
-        end
-      end
-    end
-
-    local n = DEFAULT_MATCH_LRUCACHE_SIZE
-    local cache_size = min(ceil(max(i / n, 1)) * n, n * 20)
-
-    if cache_size ~= router_cache_size then
-      router_cache = lrucache.new(cache_size)
-      router_cache_size = cache_size
-    end
-
-    local new_router, err = Router.new(routes, router_cache, router_cache_neg, router)
-    if not new_router then
-      return nil, "could not create router: " .. err
-    end
-
-    router = new_router
-
-    if version then
-      router_version = version
-    end
-
-    router_cache:flush_all()
-    router_cache_neg:flush_all()
-
-    return true
-  end
-
-
-  update_router = function()
-    -- we might not need to rebuild the router (if we were not
-    -- the first request in this process to enter this code path)
-    -- check again and rebuild only if necessary
-    local version, err = get_router_version()
-    if err then
-      return nil, "failed to retrieve router version: " .. err
-    end
-
-    if version == router_version then
-      return true
-    end
-
-    local ok, err = build_router(version)
-    if not ok then
-      return nil, --[[ 'err' fully formatted ]] err
-    end
-
-    return true
-  end
-
-
-  rebuild_router = function(opts)
-    return rebuild("router", update_router, router_version, opts)
-  end
-
-
-  get_updated_router = function()
-    if kong.db.strategy ~= "off" and kong.configuration.worker_consistency == "strict" then
-      local ok, err = rebuild_router(ROUTER_SYNC_OPTS)
-      if not ok then
-        -- If an error happens while updating, log it and return non-updated
-        -- version.
-        log(ERR, "could not rebuild router: ", err,
-                 " (stale router will be used)")
-      end
-    end
-    return router
-  end
-
-
-  -- for tests only
-  _set_update_router = function(f)
-    update_router = f
-  end
-
-
-  -- for tests only
-  _set_build_router = function(f)
-    build_router = f
-  end
-
-
-  -- for tests only
-  _set_router = function(r)
-    router = r
-  end
-
-
-  -- for tests only
-  _set_router_version = function(v)
-    router_version = v
-  end
-
-  -- for tests only
-  _register_balancer_events = function(f)
-    register_balancer_events = f
-  end
 end
 
 
@@ -1092,6 +1107,12 @@ return {
 
   init_worker = {
     before = function()
+      -- TODO: PR #9337 may affect the following line
+      local prefix = kong.configuration.prefix or ngx.config.prefix()
+
+      STREAM_TLS_TERMINATE_SOCK = fmt("unix:%s/stream_tls_terminate.sock", prefix)
+      STREAM_TLS_PASSTHROUGH_SOCK = fmt("unix:%s/stream_tls_passthrough.sock", prefix)
+
       if kong.configuration.host_ports then
         HOST_PORTS = kong.configuration.host_ports
       end
@@ -1134,9 +1155,8 @@ return {
             name = "reconfigure",
             timeout = rebuild_timeout,
           }
-        end
 
-        if strategy == "off" or kong.configuration.worker_consistency == "strict" then
+        elseif kong.configuration.worker_consistency == "strict" then
           ROUTER_SYNC_OPTS = {
             name = "router",
             timeout = rebuild_timeout,
@@ -1237,10 +1257,10 @@ return {
         local protocols = route.protocols
         if protocols and protocols.tls then
           log(DEBUG, "TLS termination required, return to second layer proxying")
-          var.kong_tls_preread_block_upstream = stream_tls_terminate_sock
+          var.kong_tls_preread_block_upstream = STREAM_TLS_TERMINATE_SOCK
 
         elseif protocols and protocols.tls_passthrough then
-          var.kong_tls_preread_block_upstream = stream_tls_passthrough_sock
+          var.kong_tls_preread_block_upstream = STREAM_TLS_PASSTHROUGH_SOCK
 
         else
           log(ERR, "unexpected protocols in matched Route")
@@ -1529,7 +1549,7 @@ return {
         return kong.response.exit(errcode, body)
       end
 
-      local ok, err = balancer.set_host_header(balancer_data, upstream_scheme, upstream_host)
+      local ok, err = balancer.set_host_header(balancer_data, upstream_scheme, "upstream_host")
       if not ok then
         log(ERR, "failed to set balancer Host header: ", err)
         return exit(500)
@@ -1653,7 +1673,7 @@ return {
         end
 
         if enabled_headers[headers.VIA] then
-          header[headers.VIA] = server_header
+          header[headers.VIA] = SERVER_HEADER
         end
 
       else
@@ -1664,9 +1684,9 @@ return {
         -- Some plugins short-circuit the request with Via-header, and in those cases
         -- we don't want to set the Server-header, if the Via-header matches with
         -- the Kong server header.
-        if not (enabled_headers[headers.VIA] and header[headers.VIA] == server_header) then
+        if not (enabled_headers[headers.VIA] and header[headers.VIA] == SERVER_HEADER) then
           if enabled_headers[headers.SERVER] then
-            header[headers.SERVER] = server_header
+            header[headers.SERVER] = SERVER_HEADER
 
           else
             header[headers.SERVER] = nil

--- a/kong/runloop/plugins_iterator.lua
+++ b/kong/runloop/plugins_iterator.lua
@@ -471,8 +471,10 @@ end
 
 
 function PluginsIterator.new(version)
-  if not version then
-    error("version must be given", 2)
+  if kong.db.strategy ~= "off" then
+    if not version then
+      error("version must be given", 2)
+    end
   end
 
   loaded_plugins = loaded_plugins or get_loaded_plugins()


### PR DESCRIPTION
### Summary

Originally the `reconfigure` event was `atomic` and it was not yielding. But this caused huge spikes in latencies when new configurations where applied.

We started to add yielding in different places that happen in `reconfigure` event. It may now lead to nasty things like: new router, and old plugins iterator gets used etc. (router from new configuration and plugin iterator from old configuration).

I needed to refactor the handler so that it could at least support more atomic flip of `router` and `plugins iterator`. The balancer is still problematic as it is shared global state and a new balancer cannot currently be build behind the scenes cooperatively, and then flip it atomically together with router and plugins iterator. I asked @locao to research if that could be doable. I leave that to other PR.

### Issue reference

Fix FTI-4369