### PR TITLE
fix(balancer): use local target cache

### DIFF
--- a/kong/runloop/balancer/balancers.lua
+++ b/kong/runloop/balancer/balancers.lua
@@ -102,6 +102,7 @@ local function create_balancer_exclusive(upstream)
   local health_threshold = upstream.healthchecks and
     upstream.healthchecks.threshold or nil
 
+  targets.clean_targets_cache(upstream)
   local targets_list, err = targets.fetch_targets(upstream)
   if not targets_list then
     return nil, "failed fetching targets:" .. err

--- a/kong/runloop/balancer/upstreams.lua
+++ b/kong/runloop/balancer/upstreams.lua
@@ -191,11 +191,6 @@ local function do_upstream_event(operation, upstream_data)
     end
 
   elseif operation == "delete" or operation == "update" then
-    local target_cache_key = "balancer:targets:" .. upstream_id
-    if singletons.db.strategy ~= "off" then
-      singletons.core_cache:invalidate_local(target_cache_key)
-    end
-
     local balancer = balancers.get_balancer_by_id(upstream_id)
     if balancer then
       healthcheckers.stop_healthchecker(balancer, CLEAR_HEALTH_STATUS_DELAY)


### PR DESCRIPTION
### Summary

The target's global cache was caching more data than it should: it kept data retrieved from the database and DNS name resolution, which has its own cache.

As a result, when config reloads were done, some processes were skipped (such as setting the upstream as healthy) because the load-balancer never identified the data as new if it was the same as cached (highly probable with DNS name resolution).

This change makes the target cache local to the worker. 

### Full changelog

* Removed global target cache.
* Added local target cache in `kong/runloop/balancer/targets.lua`.
