### PR TITLE
fix(otel): use `BatchQueue` to avoid worker-level table data race

### DIFF
--- a/kong/pdk/tracing.lua
+++ b/kong/pdk/tracing.lua
@@ -438,7 +438,7 @@ local function new_tracer(name, options)
   -- @function kong.tracing.process_span
   -- @phases log
   -- @tparam function processor a function that accecpt a span as the parameter
-  function self.process_span(processor)
+  function self.process_span(processor, ...)
     check_phase(PHASES.log)
 
     if type(processor) ~= "function" then
@@ -452,7 +452,7 @@ local function new_tracer(name, options)
 
     for _, span in ipairs(ctx.KONG_SPANS) do
       if span.tracer.name == self.name then
-        processor(span)
+        processor(span, ...)
       end
     end
   end

--- a/kong/plugins/opentelemetry/handler.lua
+++ b/kong/plugins/opentelemetry/handler.lua
@@ -1,9 +1,8 @@
-local new_tab = require "table.new"
+local BatchQueue = require "kong.tools.batch_queue"
 local http = require "resty.http"
 local clone = require "table.clone"
 local otlp = require "kong.plugins.opentelemetry.otlp"
 local propagation = require "kong.tracing.propagation"
-local tablepool = require "tablepool"
 
 local ngx = ngx
 local kong = kong
@@ -14,17 +13,12 @@ local ngx_now = ngx.now
 local ngx_update_time = ngx.update_time
 local ngx_req = ngx.req
 local ngx_get_headers = ngx_req.get_headers
-local timer_at = ngx.timer.at
-local clear = table.clear
 local propagation_parse = propagation.parse
 local propagation_set = propagation.set
-local tablepool_release = tablepool.release
-local tablepool_fetch = tablepool.fetch
 local null = ngx.null
 local encode_traces = otlp.encode_traces
 local transform_span = otlp.transform_span
 
-local POOL_BATCH_SPANS = "KONG_OTLP_BATCH_SPANS"
 local _log_prefix = "[otel] "
 
 local OpenTelemetryHandler = {
@@ -37,9 +31,8 @@ local default_headers = {
 }
 
 -- worker-level spans queue
-local spans_queue = new_tab(5000, 0)
+local queues = {} -- one queue per unique plugin config
 local headers_cache = setmetatable({}, { __mode = "k" })
-local last_run_cache = setmetatable({}, { __mode = "k" })
 
 local function get_cached_headers(conf_headers)
   -- cache http headers
@@ -80,56 +73,21 @@ local function http_export_request(conf, pb_data, headers)
   end
 end
 
-local function http_export(premature, conf)
-  if premature then
-    return
-  end
-
-  local spans_n = #spans_queue
-  if spans_n == 0 then
-    return
-  end
-
+local function http_export(conf, spans)
   local start = ngx_now()
   local headers = conf.headers and get_cached_headers(conf.headers) or default_headers
+  local payload = encode_traces(spans, conf.resource_attributes)
 
-  -- batch send spans
-  local spans_buffer = tablepool_fetch(POOL_BATCH_SPANS, conf.batch_span_count, 0)
-
-  for i = 1, spans_n do
-    local len = (spans_buffer.n or 0) + 1
-    spans_buffer[len] = spans_queue[i]
-    spans_buffer.n = len
-
-    if len >= conf.batch_span_count then
-      local pb_data = encode_traces(spans_buffer, conf.resource_attributes)
-      clear(spans_buffer)
-
-      http_export_request(conf, pb_data, headers)
-    end
-  end
-
-  -- remain spans
-  if spans_queue.n and spans_queue.n > 0 then
-    local pb_data = encode_traces(spans_buffer, conf.resource_attributes)
-    http_export_request(conf, pb_data, headers)
-  end
-
-  -- clear the queue
-  clear(spans_queue)
-
-  tablepool_release(POOL_BATCH_SPANS, spans_buffer)
+  http_export_request(conf, payload, headers)
 
   ngx_update_time()
   local duration = ngx_now() - start
-  ngx_log(ngx_DEBUG, _log_prefix, "opentelemetry exporter sent " .. spans_n ..
+  ngx_log(ngx_DEBUG, _log_prefix, "exporter sent " .. #spans ..
     " traces to " .. conf.endpoint .. " in " .. duration .. " seconds")
 end
 
-local function process_span(span)
-  if span.should_sample == false
-      or kong.ctx.plugin.should_sample == false
-  then
+local function process_span(span, queue)
+  if span.should_sample == false or kong.ctx.plugin.should_sample == false then
     -- ignore
     return
   end
@@ -142,11 +100,7 @@ local function process_span(span)
 
   local pb_span = transform_span(span)
 
-  local len = spans_queue.n or 0
-  len = len + 1
-
-  spans_queue[len] = pb_span
-  spans_queue.n = len
+  queue:add(pb_span)
 end
 
 function OpenTelemetryHandler:rewrite()
@@ -184,16 +138,28 @@ end
 function OpenTelemetryHandler:log(conf)
   ngx_log(ngx_DEBUG, _log_prefix, "total spans in current request: ", ngx.ctx.KONG_SPANS and #ngx.ctx.KONG_SPANS)
 
-  -- transform spans
-  kong.tracing.process_span(process_span)
+  local queue_id = conf.__key__
+  local q = queues[queue_id]
+  if not q then
+    local process = function(entries)
+      return http_export(conf, entries)
+    end
 
-  local cache_key = conf.__key__
-  local last = last_run_cache[cache_key] or 0
-  local now = ngx_now()
-  if now - last >= conf.batch_flush_delay then
-    last_run_cache[cache_key] = now
-    timer_at(0, http_export, conf)
+    local opts = {
+      batch_max_size = conf.batch_span_count,
+      process_delay  = conf.batch_flush_delay,
+    }
+
+    local err
+    q, err = BatchQueue.new(process, opts)
+    if not q then
+      kong.log.err("could not create queue: ", err)
+      return
+    end
+    queues[queue_id] = q
   end
+
+  kong.tracing.process_span(process_span, q)
 end
 
 return OpenTelemetryHandler

--- a/spec/03-plugins/37-opentelemetry/04-exporter_spec.lua
+++ b/spec/03-plugins/37-opentelemetry/04-exporter_spec.lua
@@ -71,8 +71,8 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       lazy_teardown(function()
-        helpers.kill_http_server(HTTP_SERVER_PORT)
         helpers.stop_kong()
+        helpers.kill_http_server(HTTP_SERVER_PORT)
       end)
 
       it("works", function ()
@@ -141,8 +141,8 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       lazy_teardown(function()
-        helpers.kill_http_server(HTTP_SERVER_PORT)
         helpers.stop_kong()
+        helpers.kill_http_server(HTTP_SERVER_PORT)
       end)
 
       it("works", function ()
@@ -245,9 +245,8 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       lazy_teardown(function()
-        -- pl_file.delete("/tmp/kong_opentelemetry_data")
-        helpers.kill_http_server(HTTP_SERVER_PORT)
         helpers.stop_kong()
+        helpers.kill_http_server(HTTP_SERVER_PORT)
       end)
 
       it("send enough spans", function ()
@@ -276,7 +275,6 @@ for _, strategy in helpers.each_strategy() do
           for _, pb_data in ipairs(pb_set) do
             local decoded = assert(pb.decode("opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest", ngx.decode_base64(pb_data)))
             assert.not_nil(decoded)
-            -- print(require("inspect")(decoded))
 
             local scope_spans = decoded.resource_spans[1].scope_spans
             if scope_spans then

--- a/spec/03-plugins/37-opentelemetry/04-exporter_spec.lua
+++ b/spec/03-plugins/37-opentelemetry/04-exporter_spec.lua
@@ -42,7 +42,7 @@ for _, strategy in helpers.each_strategy() do
         name = "opentelemetry",
         config = table_merge({
           endpoint = "http://127.0.0.1:" .. HTTP_SERVER_PORT,
-          batch_flush_delay = -1, -- report immediately
+          batch_flush_delay = 0, -- report immediately
         }, config)
       })
 

--- a/spec/03-plugins/37-opentelemetry/04-exporter_spec.lua
+++ b/spec/03-plugins/37-opentelemetry/04-exporter_spec.lua
@@ -3,12 +3,17 @@ local helpers = require "spec.helpers"
 local utils = require "kong.tools.utils"
 local tablex = require "pl.tablex"
 local pb = require "pb"
+local pl_file = require "pl.file"
+local ngx_re = require "ngx.re"
 
 local table_merge = utils.table_merge
-local HTTP_PORT = 35000
+local HTTP_SERVER_PORT = 35000
+local PROXY_PORT = 9000
 
 for _, strategy in helpers.each_strategy() do
   describe("opentelemetry exporter #" .. strategy, function()
+    local bp
+
     lazy_setup(function ()
       -- overwrite for testing
       pb.option("enum_as_value")
@@ -22,13 +27,7 @@ for _, strategy in helpers.each_strategy() do
     end)
 
     -- helpers
-    local function setup_instrumentations(types, config)
-      local bp, _ = assert(helpers.get_db_utils(strategy, {
-        "services",
-        "routes",
-        "plugins",
-      }, { "opentelemetry" }))
-
+    local function setup_instrumentations(types, config, fixtures)
       local http_srv = assert(bp.services:insert {
         name = "mock-service",
         host = helpers.mock_upstream_host,
@@ -42,21 +41,28 @@ for _, strategy in helpers.each_strategy() do
       bp.plugins:insert({
         name = "opentelemetry",
         config = table_merge({
-          endpoint = "http://127.0.0.1:" .. HTTP_PORT,
+          endpoint = "http://127.0.0.1:" .. HTTP_SERVER_PORT,
           batch_flush_delay = -1, -- report immediately
         }, config)
       })
 
-      assert(helpers.start_kong {
+      assert(helpers.start_kong({
+        proxy_listen = "0.0.0.0:" .. PROXY_PORT,
         database = strategy,
         nginx_conf = "spec/fixtures/custom_nginx.template",
         plugins = "opentelemetry",
         opentelemetry_tracing = types,
-      })
+      }, nil, nil, fixtures))
     end
 
     describe("valid #http request", function ()
       lazy_setup(function()
+        bp, _ = assert(helpers.get_db_utils(strategy, {
+          "services",
+          "routes",
+          "plugins",
+        }, { "opentelemetry" }))
+
         setup_instrumentations("all", {
           headers = {
             ["X-Access-Token"] = "token",
@@ -65,15 +71,15 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       lazy_teardown(function()
-        helpers.kill_http_server(HTTP_PORT)
+        helpers.kill_http_server(HTTP_SERVER_PORT)
         helpers.stop_kong()
       end)
 
       it("works", function ()
         local headers, body
         helpers.wait_until(function()
-          local thread = helpers.http_server(HTTP_PORT, { timeout = 10 })
-          local cli = helpers.proxy_client(7000)
+          local thread = helpers.http_server(HTTP_SERVER_PORT, { timeout = 10 })
+          local cli = helpers.proxy_client(7000, PROXY_PORT)
           local r = assert(cli:send {
             method  = "GET",
             path    = "/",
@@ -87,7 +93,7 @@ for _, strategy in helpers.each_strategy() do
           ok, headers, body = thread:join()
 
           return ok
-        end, 60)
+        end, 10)
 
         assert.is_string(body)
 
@@ -120,6 +126,12 @@ for _, strategy in helpers.each_strategy() do
 
     describe("overwrite resource attributes #http", function ()
       lazy_setup(function()
+        bp, _ = assert(helpers.get_db_utils(strategy, {
+          "services",
+          "routes",
+          "plugins",
+        }, { "opentelemetry" }))
+
         setup_instrumentations("all", {
           resource_attributes = {
             ["service.name"] = "kong_oss",
@@ -129,15 +141,15 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       lazy_teardown(function()
-        helpers.kill_http_server(HTTP_PORT)
+        helpers.kill_http_server(HTTP_SERVER_PORT)
         helpers.stop_kong()
       end)
 
       it("works", function ()
         local headers, body
         helpers.wait_until(function()
-          local thread = helpers.http_server(HTTP_PORT, { timeout = 10 })
-          local cli = helpers.proxy_client(7000)
+          local thread = helpers.http_server(HTTP_SERVER_PORT, { timeout = 10 })
+          local cli = helpers.proxy_client(7000, PROXY_PORT)
           local r = assert(cli:send {
             method  = "GET",
             path    = "/",
@@ -151,7 +163,7 @@ for _, strategy in helpers.each_strategy() do
           ok, headers, body = thread:join()
 
           return ok
-        end, 60)
+        end, 10)
 
         assert.is_string(body)
 
@@ -177,6 +189,109 @@ for _, strategy in helpers.each_strategy() do
 
         local scope_spans = decoded.resource_spans[1].scope_spans
         assert.is_true(#scope_spans > 0, scope_spans)
+      end)
+    end)
+
+    describe("data #race with cascaded multiple spans", function ()
+      lazy_setup(function()
+        bp, _ = assert(helpers.get_db_utils(strategy, {
+          "services",
+          "routes",
+          "plugins",
+        }, { "opentelemetry" }))
+
+        pl_file.delete("/tmp/kong_opentelemetry_data")
+
+        local fixtures = {
+          http_mock = {}
+        }
+
+        fixtures.http_mock.my_server_block = [[
+          server {
+            server_name myserver;
+            listen ]] .. HTTP_SERVER_PORT .. [[;
+            client_body_buffer_size 1024k;
+
+            location / {
+              content_by_lua_block {
+                ngx.req.read_body()
+                local data = ngx.req.get_body_data()
+
+                local fd = assert(io.open("/tmp/kong_opentelemetry_data", "a"))
+                assert(fd:write(ngx.encode_base64(data)))
+                assert(fd:write("\n")) -- ensure last line ends in newline
+                assert(fd:close())
+
+                return 200;
+              }
+            }
+          }
+        ]]
+
+        for i = 1, 5 do
+          local svc = assert(bp.services:insert {
+            host = "127.0.0.1",
+            port = PROXY_PORT,
+            path = i == 1 and "/" or ("/cascade-" .. (i - 1)),
+          })
+
+          bp.routes:insert({ service = svc,
+                             protocols = { "http" },
+                             paths = { "/cascade-" .. i },
+                             strip_path = true })
+        end
+
+        setup_instrumentations("request", {}, fixtures)
+      end)
+
+      lazy_teardown(function()
+        -- pl_file.delete("/tmp/kong_opentelemetry_data")
+        helpers.kill_http_server(HTTP_SERVER_PORT)
+        helpers.stop_kong()
+      end)
+
+      it("send enough spans", function ()
+        local pb_set = {}
+        local cli = helpers.proxy_client(7000, PROXY_PORT)
+        local r = assert(cli:send {
+          method  = "GET",
+          path    = "/cascade-5",
+        })
+        assert.res_status(200, r)
+
+        -- close client connection
+        cli:close()
+
+        helpers.wait_until(function()
+          local fd, err = io.open("/tmp/kong_opentelemetry_data", "r")
+          if err then
+            return false, "failed to open file: " .. err
+          end
+
+          local body = fd:read("*a")
+          pb_set = ngx_re.split(body, "\n")
+
+          print("pb set length: ", #pb_set)
+          local count = 0
+          for _, pb_data in ipairs(pb_set) do
+            local decoded = assert(pb.decode("opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest", ngx.decode_base64(pb_data)))
+            assert.not_nil(decoded)
+            -- print(require("inspect")(decoded))
+
+            local scope_spans = decoded.resource_spans[1].scope_spans
+            if scope_spans then
+              for _, scope_span in ipairs(scope_spans) do
+                count = count + #scope_span.spans
+              end
+            end
+          end
+
+          if count < 6 then
+            return false, "not enough spans: " .. count
+          end
+
+          return true
+        end, 10)
       end)
     end)
 

--- a/spec/03-plugins/37-opentelemetry/05-otelcol_spec.lua
+++ b/spec/03-plugins/37-opentelemetry/05-otelcol_spec.lua
@@ -39,7 +39,7 @@ for _, strategy in helpers.each_strategy() do
         name = "opentelemetry",
         config = table_merge({
           endpoint = fmt("http://%s:%s/v1/traces", OTELCOL_HOST, OTELCOL_HTTP_PORT),
-          batch_flush_delay = -1, -- report immediately
+          batch_flush_delay = 0, -- report immediately
         }, config)
       })
 
@@ -76,13 +76,14 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       it("valid traces", function()
-        ngx.sleep(3)
-        local f = assert(io.open(OTELCOL_FILE_EXPORTER_PATH, "rb"))
-        local raw_content = f:read("*all")
-        f:close()
+        helpers.wait_until(function()
+          local f = assert(io.open(OTELCOL_FILE_EXPORTER_PATH, "rb"))
+          local raw_content = f:read("*all")
+          f:close()
 
-        local parts = split(raw_content, "\n", "jo")
-        assert.is_true(#parts > 0)
+          local parts = split(raw_content, "\n", "jo")
+          return #parts > 0
+        end, 10)
       end)
     end)
 


### PR DESCRIPTION
### Summary

Fix an issue where OpenTelemetry spans are randomly stripped and not sent to the backend.