### PR TITLE
fix(pluginserver): error if req come before ready

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -802,10 +802,7 @@ function Kong.init_worker()
   runloop.init_worker.after()
 
   if is_not_control_plane then
-    if worker_id() == 0 then
-      plugin_servers.start()
-    end
-    plugin_servers.check()
+    plugin_servers.start()
   end
 
   if kong.clustering then

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -802,7 +802,10 @@ function Kong.init_worker()
   runloop.init_worker.after()
 
   if is_not_control_plane then
-    plugin_servers.start()
+    if worker_id() == 0 then
+      plugin_servers.start()
+    end
+    plugin_servers.check()
   end
 
   if kong.clustering then

--- a/kong/runloop/plugin_servers/init.lua
+++ b/kong/runloop/plugin_servers/init.lua
@@ -368,7 +368,7 @@ function plugin_servers.start()
 
   for _, server_def in ipairs(proc_mgmt.get_server_defs()) do
     if server_def.start_command then
-      if ngx.worker.id() == 0 then
+      if worker_id() == 0 then
         native_timer_at(0, pluginserver_timer, server_def)
       end
       native_timer_at(0, pluginserver_connection_check_timer, server_def)

--- a/kong/runloop/plugin_servers/init.lua
+++ b/kong/runloop/plugin_servers/init.lua
@@ -372,7 +372,7 @@ function plugin_servers.start()
     end
   end
 
-  local connection_check_timer = proc_mgmt.pluginserver_connection_check_timer
+  local connection_check_timer = proc_mgmt.connection_check_timer
 
   for _, server_def in ipairs(proc_mgmt.get_server_defs()) do
     if server_def.start_command then

--- a/kong/runloop/plugin_servers/init.lua
+++ b/kong/runloop/plugin_servers/init.lua
@@ -362,16 +362,18 @@ end
 
 
 function plugin_servers.start()
-  local pluginserver_timer = proc_mgmt.pluginserver_timer
-  for _, server_def in ipairs(proc_mgmt.get_server_defs()) do
-    if server_def.start_command then
-      native_timer_at(0, pluginserver_timer, server_def)
+  if worker_id() == 0 then
+    local pluginserver_timer = proc_mgmt.pluginserver_timer
+
+    for _, server_def in ipairs(proc_mgmt.get_server_defs()) do
+      if server_def.start_command then
+        native_timer_at(0, pluginserver_timer, server_def)
+      end
     end
   end
-end
 
-function plugin_servers.check()
   local connection_check_timer = proc_mgmt.pluginserver_connection_check_timer
+
   for _, server_def in ipairs(proc_mgmt.get_server_defs()) do
     if server_def.start_command then
       native_timer_at(0, connection_check_timer, server_def)

--- a/kong/runloop/plugin_servers/init.lua
+++ b/kong/runloop/plugin_servers/init.lua
@@ -364,7 +364,6 @@ end
 function plugin_servers.start()
   local pluginserver_timer = proc_mgmt.pluginserver_timer
   local pluginserver_connection_check_timer = proc_mgmt.connection_check_timer
-  local native_timer_at = _G.native_timer_at
   local handler = worker_id() == 0 and pluginserver_timer or pluginserver_connection_check_timer
 
   for _, server_def in ipairs(proc_mgmt.get_server_defs()) do

--- a/kong/runloop/plugin_servers/init.lua
+++ b/kong/runloop/plugin_servers/init.lua
@@ -364,13 +364,14 @@ end
 function plugin_servers.start()
   local pluginserver_timer = proc_mgmt.pluginserver_timer
   local pluginserver_connection_check_timer = proc_mgmt.connection_check_timer
+  local native_timer_at = _G.native_timer_at
 
   for _, server_def in ipairs(proc_mgmt.get_server_defs()) do
     if server_def.start_command then
       if ngx.worker.id() == 0 then
-        _G.native_timer_at(0, pluginserver_timer, server_def)
+        native_timer_at(0, pluginserver_timer, server_def)
       end
-      _G.native_timer_at(0, pluginserver_connection_check_timer, server_def)
+      native_timer_at(0, pluginserver_connection_check_timer, server_def)
     end
   end
 end

--- a/kong/runloop/plugin_servers/init.lua
+++ b/kong/runloop/plugin_servers/init.lua
@@ -362,12 +362,19 @@ end
 
 
 function plugin_servers.start()
-  local handler = worker_id() == 0 and proc_mgmt.pluginserver_timer
-                  or proc_mgmt.pluginserver_connection_check_timer
-
+  local pluginserver_timer = proc_mgmt.pluginserver_timer
   for _, server_def in ipairs(proc_mgmt.get_server_defs()) do
     if server_def.start_command then
-      native_timer_at(0, handler, server_def)
+      native_timer_at(0, pluginserver_timer, server_def)
+    end
+  end
+end
+
+function plugin_servers.check()
+  local connection_check_timer = proc_mgmt.pluginserver_connection_check_timer
+  for _, server_def in ipairs(proc_mgmt.get_server_defs()) do
+    if server_def.start_command then
+      native_timer_at(0, connection_check_timer, server_def)
     end
   end
 end

--- a/kong/runloop/plugin_servers/init.lua
+++ b/kong/runloop/plugin_servers/init.lua
@@ -362,9 +362,8 @@ end
 
 
 function plugin_servers.start()
-  local pluginserver_timer = proc_mgmt.pluginserver_timer
-  local pluginserver_connection_check_timer = proc_mgmt.connection_check_timer
-  local handler = worker_id() == 0 and pluginserver_timer or pluginserver_connection_check_timer
+  local handler = worker_id() == 0 and proc_mgmt.pluginserver_timer
+                  or proc_mgmt.pluginserver_connection_check_timer
 
   for _, server_def in ipairs(proc_mgmt.get_server_defs()) do
     if server_def.start_command then

--- a/kong/runloop/plugin_servers/init.lua
+++ b/kong/runloop/plugin_servers/init.lua
@@ -365,13 +365,11 @@ function plugin_servers.start()
   local pluginserver_timer = proc_mgmt.pluginserver_timer
   local pluginserver_connection_check_timer = proc_mgmt.connection_check_timer
   local native_timer_at = _G.native_timer_at
+  local handler = worker_id() == 0 and pluginserver_timer or pluginserver_connection_check_timer
 
   for _, server_def in ipairs(proc_mgmt.get_server_defs()) do
     if server_def.start_command then
-      if worker_id() == 0 then
-        native_timer_at(0, pluginserver_timer, server_def)
-      end
-      native_timer_at(0, pluginserver_connection_check_timer, server_def)
+      native_timer_at(0, handler, server_def)
     end
   end
 end

--- a/kong/runloop/plugin_servers/init.lua
+++ b/kong/runloop/plugin_servers/init.lua
@@ -221,6 +221,16 @@ function get_instance_id(plugin_name, conf)
   end
 
   local plugin_info = get_plugin_info(plugin_name)
+  local server_def = plugin_info.server_def
+
+  if server_def.socket_err then
+    return nil, server_def.socket_err
+  end
+
+  if not server_def.ready then
+    return nil, "not ready"
+  end
+
   local server_rpc  = get_server_rpc(plugin_info.server_def)
 
   local new_instance_info, err = server_rpc:call_start_instance(plugin_name, conf)
@@ -352,15 +362,15 @@ end
 
 
 function plugin_servers.start()
-  if worker_id() ~= 0 then
-    return
-  end
-
   local pluginserver_timer = proc_mgmt.pluginserver_timer
+  local pluginserver_connection_check_timer = proc_mgmt.connection_check_timer
 
   for _, server_def in ipairs(proc_mgmt.get_server_defs()) do
     if server_def.start_command then
-      native_timer_at(0, pluginserver_timer, server_def)
+      if ngx.worker.id() == 0 then
+        _G.native_timer_at(0, pluginserver_timer, server_def)
+      end
+      _G.native_timer_at(0, pluginserver_connection_check_timer, server_def)
     end
   end
 end

--- a/kong/runloop/plugin_servers/mp_rpc.lua
+++ b/kong/runloop/plugin_servers/mp_rpc.lua
@@ -325,10 +325,17 @@ end
 
 
 function Rpc:handle_event(plugin_name, conf, phase)
-  local instance_id = self.get_instance_id(plugin_name, conf)
-  local _, err = bridge_loop(self, instance_id, phase)
+  local instance_id, err = self.get_instance_id(plugin_name, conf)
+  local _
+  if not err then
+    _, err = bridge_loop(self, instance_id, phase)
+  end
 
   if err then
+    if err == "not ready" then
+      ngx.sleep(0.1)
+      return self:handle_event(plugin_name, conf, phase)
+    end
     if string.match(err:lower(), "no plugin instance") then
       kong.log.warn(err)
       self.reset_instance(plugin_name, conf)

--- a/kong/runloop/plugin_servers/mp_rpc.lua
+++ b/kong/runloop/plugin_servers/mp_rpc.lua
@@ -1,5 +1,7 @@
 local kong_global = require "kong.global"
 local cjson = require "cjson.safe"
+local handle_not_ready = require("kong.runloop.plugin_servers.process").handle_not_ready
+
 local msgpack do
   msgpack = require "MessagePack"
   local nil_pack = msgpack.packers["nil"]
@@ -333,8 +335,7 @@ function Rpc:handle_event(plugin_name, conf, phase)
 
   if err then
     if err == "not ready" then
-      ngx.sleep(0.1)
-      return self:handle_event(plugin_name, conf, phase)
+      return handle_not_ready(plugin_name)
     end
     if string.match(err:lower(), "no plugin instance") then
       kong.log.warn(err)

--- a/kong/runloop/plugin_servers/mp_rpc.lua
+++ b/kong/runloop/plugin_servers/mp_rpc.lua
@@ -327,8 +327,8 @@ end
 
 
 function Rpc:handle_event(plugin_name, conf, phase)
-  local instance_id, err = self.get_instance_id(plugin_name, conf)
-  local _
+  local instance_id, _, err
+  instance_id, err = self.get_instance_id(plugin_name, conf)
   if not err then
     _, err = bridge_loop(self, instance_id, phase)
   end

--- a/kong/runloop/plugin_servers/mp_rpc.lua
+++ b/kong/runloop/plugin_servers/mp_rpc.lua
@@ -1,6 +1,7 @@
 local kong_global = require "kong.global"
 local cjson = require "cjson.safe"
 local handle_not_ready = require("kong.runloop.plugin_servers.process").handle_not_ready
+local str_find = string.find
 
 local msgpack do
   msgpack = require "MessagePack"
@@ -337,7 +338,7 @@ function Rpc:handle_event(plugin_name, conf, phase)
     if err == "not ready" then
       return handle_not_ready(plugin_name)
     end
-    if string.match(err:lower(), "no plugin instance") then
+    if str_find(err:lower(), "no plugin instance") then
       kong.log.warn(err)
       self.reset_instance(plugin_name, conf)
       return self:handle_event(plugin_name, conf, phase)

--- a/kong/runloop/plugin_servers/mp_rpc.lua
+++ b/kong/runloop/plugin_servers/mp_rpc.lua
@@ -338,7 +338,7 @@ function Rpc:handle_event(plugin_name, conf, phase)
     if err == "not ready" then
       return handle_not_ready(plugin_name)
     end
-    if str_find(err:lower(), "no plugin instance") then
+    if str_find(err:lower(), "no plugin instance", 1, true) then
       kong.log.warn(err)
       self.reset_instance(plugin_name, conf)
       return self:handle_event(plugin_name, conf, phase)

--- a/kong/runloop/plugin_servers/mp_rpc.lua
+++ b/kong/runloop/plugin_servers/mp_rpc.lua
@@ -338,7 +338,7 @@ function Rpc:handle_event(plugin_name, conf, phase)
     if err == "not ready" then
       return handle_not_ready(plugin_name)
     end
-    if str_find(err:lower(), "no plugin instance", 1, true) then
+    if err and str_find(err:lower(), "no plugin instance", 1, true) then
       kong.log.warn(err)
       self.reset_instance(plugin_name, conf)
       return self:handle_event(plugin_name, conf, phase)

--- a/kong/runloop/plugin_servers/pb_rpc.lua
+++ b/kong/runloop/plugin_servers/pb_rpc.lua
@@ -3,6 +3,7 @@ local cjson = require "cjson.safe"
 local grpc_tools = require "kong.tools.grpc"
 local pb = require "pb"
 local lpack = require "lua_pack"
+local handle_not_ready = require("kong.runloop.plugin_servers.process").handle_not_ready
 
 local ngx = ngx
 local kong = kong
@@ -397,8 +398,7 @@ function Rpc:handle_event(plugin_name, conf, phase)
 
   if not res or res == "" then
     if err == "not ready" then
-      ngx.sleep(0.1)
-      return self:handle_event(plugin_name, conf, phase)
+      return handle_not_ready(plugin_name)
     end
     if string.match(err:lower(), "no plugin instance")
       or string.match(err:lower(), "closed")  then

--- a/kong/runloop/plugin_servers/pb_rpc.lua
+++ b/kong/runloop/plugin_servers/pb_rpc.lua
@@ -387,8 +387,8 @@ end
 
 
 function Rpc:handle_event(plugin_name, conf, phase)
-  local instance_id, err = self.get_instance_id(plugin_name, conf)
-  local res
+  local instance_id, res, err
+  instance_id, err = self.get_instance_id(plugin_name, conf)
   if not err then
     res, err = self:call("cmd_handle_event", {
       instance_id = instance_id,

--- a/kong/runloop/plugin_servers/pb_rpc.lua
+++ b/kong/runloop/plugin_servers/pb_rpc.lua
@@ -4,6 +4,7 @@ local grpc_tools = require "kong.tools.grpc"
 local pb = require "pb"
 local lpack = require "lua_pack"
 local handle_not_ready = require("kong.runloop.plugin_servers.process").handle_not_ready
+local str_find = string.find
 
 local ngx = ngx
 local kong = kong
@@ -400,8 +401,8 @@ function Rpc:handle_event(plugin_name, conf, phase)
     if err == "not ready" then
       return handle_not_ready(plugin_name)
     end
-    if string.match(err:lower(), "no plugin instance")
-      or string.match(err:lower(), "closed")  then
+    if str_find(err:lower(), "no plugin instance", 1, true)
+      or str_find(err:lower(), "closed", 1, true)  then
       kong.log.warn(err)
       self.reset_instance(plugin_name, conf)
       return self:handle_event(plugin_name, conf, phase)

--- a/kong/runloop/plugin_servers/pb_rpc.lua
+++ b/kong/runloop/plugin_servers/pb_rpc.lua
@@ -401,8 +401,8 @@ function Rpc:handle_event(plugin_name, conf, phase)
     if err == "not ready" then
       return handle_not_ready(plugin_name)
     end
-    if str_find(err:lower(), "no plugin instance", 1, true)
-      or str_find(err:lower(), "closed", 1, true)  then
+    if err and (str_find(err:lower(), "no plugin instance", 1, true)
+      or str_find(err:lower(), "closed", 1, true)) then
       kong.log.warn(err)
       self.reset_instance(plugin_name, conf)
       return self:handle_event(plugin_name, conf, phase)

--- a/kong/runloop/plugin_servers/process.lua
+++ b/kong/runloop/plugin_servers/process.lua
@@ -12,7 +12,6 @@ local kong = kong
 local log = ngx.log
 local ngx_INFO = ngx.INFO
 local ngx_WARN = ngx.WARN
-local ngx_ERR = ngx.ERR
 local cjson_decode = cjson.decode
 
 local proc_mgmt = {}

--- a/kong/runloop/plugin_servers/process.lua
+++ b/kong/runloop/plugin_servers/process.lua
@@ -262,7 +262,6 @@ function proc_mgmt.connection_check_timer(premature, server_def)
   local c, err
   while time < pluginserver_start_timeout do
     c, err = connect(uri)
-    log(ngx_ERR, err)
     if c then
       server_def.ready = true
       c:close()

--- a/kong/runloop/plugin_servers/process.lua
+++ b/kong/runloop/plugin_servers/process.lua
@@ -245,6 +245,8 @@ function proc_mgmt.pluginserver_timer(premature, server_def)
 
   local next_spawn = 0
 
+  _G.native_timer_at(0, connection_check_timer, server_def)
+
   while not ngx.worker.exiting() do
     if ngx.now() < next_spawn then
       ngx.sleep(next_spawn - ngx.now())
@@ -273,7 +275,6 @@ function proc_mgmt.pluginserver_timer(premature, server_def)
   end
   kong.log.notice("Exiting: pluginserver '", server_def.name, "' not respawned.")
 
-  connection_check_timer()
 end
 
 -- limit the number of warning messages

--- a/kong/runloop/plugin_servers/process.lua
+++ b/kong/runloop/plugin_servers/process.lua
@@ -4,6 +4,8 @@ local raw_log = require "ngx.errlog".raw_log
 local ngx = ngx
 local sleep = ngx.sleep
 local connect = ngx.socket.connect
+local is_http_subsystem = ngx.config.subsystem ~= "http"
+local native_timer_at = _G.native_timer_at or ngx.timer.at
 
 local _, ngx_pipe = pcall(require, "ngx.pipe")
 
@@ -210,7 +212,7 @@ function proc_mgmt.connection_check_timer(premature, server_def)
     return
   end
 
-  if ngx.config.subsystem ~= "http" then
+  if is_http_subsystem then
     return
   end
 
@@ -239,13 +241,13 @@ function proc_mgmt.pluginserver_timer(premature, server_def)
     return
   end
 
-  if ngx.config.subsystem ~= "http" then
+  if is_http_subsystem then
     return
   end
 
   local next_spawn = 0
 
-  _G.native_timer_at(0, connection_check_timer, server_def)
+  native_timer_at(0, connection_check_timer, server_def)
 
   while not ngx.worker.exiting() do
     if ngx.now() < next_spawn then

--- a/kong/runloop/plugin_servers/process.lua
+++ b/kong/runloop/plugin_servers/process.lua
@@ -5,7 +5,6 @@ local ngx = ngx
 local sleep = ngx.sleep
 local connect = ngx.socket.connect
 local is_not_http_subsystem = ngx.config.subsystem ~= "http"
-local native_timer_at = _G.native_timer_at or ngx.timer.at
 
 local _, ngx_pipe = pcall(require, "ngx.pipe")
 
@@ -233,8 +232,6 @@ function proc_mgmt.connection_check_timer(premature, server_def)
   end
   server_def.socket_err = err
 end
-
-local connection_check_timer = proc_mgmt.connection_check_timer
 
 function proc_mgmt.pluginserver_timer(premature, server_def)
   if premature then

--- a/kong/runloop/plugin_servers/process.lua
+++ b/kong/runloop/plugin_servers/process.lua
@@ -4,7 +4,7 @@ local raw_log = require "ngx.errlog".raw_log
 local ngx = ngx
 local sleep = ngx.sleep
 local connect = ngx.socket.connect
-local is_http_subsystem = ngx.config.subsystem ~= "http"
+local is_not_http_subsystem = ngx.config.subsystem ~= "http"
 local native_timer_at = _G.native_timer_at or ngx.timer.at
 
 local _, ngx_pipe = pcall(require, "ngx.pipe")
@@ -212,7 +212,7 @@ function proc_mgmt.connection_check_timer(premature, server_def)
     return
   end
 
-  if is_http_subsystem then
+  if is_not_http_subsystem then
     return
   end
 
@@ -241,7 +241,7 @@ function proc_mgmt.pluginserver_timer(premature, server_def)
     return
   end
 
-  if is_http_subsystem then
+  if is_not_http_subsystem then
     return
   end
 

--- a/kong/runloop/plugin_servers/process.lua
+++ b/kong/runloop/plugin_servers/process.lua
@@ -287,8 +287,8 @@ function proc_mgmt.handle_not_ready(plugin_name)
   end
 
   plugin_already_warned[plugin_name] = true
-  log(ngx_WARN, "plugin server is not ready when ",
-      plugin_name, " is required for request")
+  log(ngx_WARN, "plugin server is not ready, ",
+      plugin_name, " will not be executed in this request")
 end
 
 

--- a/kong/runloop/plugin_servers/process.lua
+++ b/kong/runloop/plugin_servers/process.lua
@@ -247,8 +247,6 @@ function proc_mgmt.pluginserver_timer(premature, server_def)
 
   local next_spawn = 0
 
-  native_timer_at(0, connection_check_timer, server_def)
-
   while not ngx.worker.exiting() do
     if ngx.now() < next_spawn then
       ngx.sleep(next_spawn - ngx.now())

--- a/spec/02-integration/05-proxy/10-balancer/01-healthchecks_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer/01-healthchecks_spec.lua
@@ -1891,7 +1891,7 @@ for _, strategy in helpers.each_strategy() do
 
             end)
 
-            it("perform passive health checks -- manual recovery #only", function()
+            it("perform passive health checks -- manual recovery", function()
                 -- configure healthchecks
                 bu.begin_testcase_setup(strategy, bp)
                 local upstream_name, upstream_id = bu.add_upstream(bp, {


### PR DESCRIPTION
We start plugin servers asynchronously while requests try to send RPC calls to the server. When the sock file is not deleted, the server may start a bit slower and the requests hit before it listen to the newly created sock file.

fix FTI-4282
