### PR TITLE
fix(admin): fix potentially truncate arguments

### DIFF
--- a/kong/api/arguments.lua
+++ b/kong/api/arguments.lua
@@ -632,10 +632,8 @@ local function load(opts)
     post = {},
   }, arguments_mt)
 
-  local uargs, err
-  uargs, err = get_uri_args(options.max_uri_args)
+  local uargs, err = get_uri_args(options.max_uri_args)
   if err == "truncated" then
-    kong.log.err("Too many arguments")
     return kong.response.exit(400, { message = "Too many arguments" })
   end
 
@@ -655,8 +653,7 @@ local function load(opts)
 
   if find(content_type_lower, "application/x-www-form-urlencoded", 1, true) == 1 then
     req_read_body()
-    local pargs
-    pargs, err = get_post_args(options.max_post_args)
+    local pargs, err = get_post_args(options.max_post_args)
     if err == "truncated" then
       return kong.response.exit(400, { message = "Too many arguments" })
     end

--- a/kong/api/arguments.lua
+++ b/kong/api/arguments.lua
@@ -25,6 +25,7 @@ local get_uri_args  = req.get_uri_args
 local get_body_data = req.get_body_data
 local get_post_args = req.get_post_args
 local json_decode   = cjson.decode
+local kong          = kong
 
 
 local NOTICE        = ngx.NOTICE
@@ -60,8 +61,8 @@ local defaults = {
   multipart     = true,
   timeout       = 1000,
   chunk_size    = 4096,
-  max_uri_args  = 100,
-  max_post_args = 100,
+  max_uri_args  = 1000,
+  max_post_args = 1000,
   max_line_size = nil,
   max_part_size = nil,
 }
@@ -631,7 +632,12 @@ local function load(opts)
     post = {},
   }, arguments_mt)
 
-  local uargs = get_uri_args(options.max_uri_args)
+  local uargs, err
+  uargs, err = get_uri_args(options.max_uri_args)
+  if err == "truncated" then
+    kong.log.err("Too many arguments")
+    return kong.response.exit(400, { message = "Too many arguments" })
+  end
 
   if options.decode then
     args.uri = decode(uargs, options.schema)
@@ -649,7 +655,11 @@ local function load(opts)
 
   if find(content_type_lower, "application/x-www-form-urlencoded", 1, true) == 1 then
     req_read_body()
-    local pargs, err = get_post_args(options.max_post_args)
+    local pargs
+    pargs, err = get_post_args(options.max_post_args)
+    if err == "truncated" then
+      return kong.response.exit(400, { message = "Too many arguments" })
+    end
     if pargs then
       if options.decode then
         args.post = decode(pargs, options.schema)

--- a/spec/02-integration/04-admin_api/21-truncated_arguments_spec.lua
+++ b/spec/02-integration/04-admin_api/21-truncated_arguments_spec.lua
@@ -3,8 +3,8 @@ local helpers = require "spec.helpers"
 for _, strategy in helpers.each_strategy() do
 
   describe("Admin API - truncated arguments #" .. strategy, function()
-    local max_uri_args = 1000
-    local max_post_args = 1000
+    local max_uri_args_overflow = 1000 + 1
+    local max_post_args_overflow = 1000 + 1
 
     local client
 
@@ -33,7 +33,7 @@ for _, strategy in helpers.each_strategy() do
 
     it("return 400 if reach maxinum post arguments number", function()
       local items = {}
-      for i = 1, max_post_args + 1 do
+      for i = 1, max_post_args_overflow do
         table.insert(items, "config.allow=" .. i)
       end
       local body = "name=ip-restriction&" .. table.concat(items, "&")
@@ -52,7 +52,7 @@ for _, strategy in helpers.each_strategy() do
 
     it("return 400 if reach maxinum uri arguments number", function()
       local items = {}
-      for i = 1, max_uri_args + 1 do
+      for i = 1, max_uri_args_overflow do
         table.insert(items, "a=" .. i)
       end
       local querystring = table.concat(items, "&")

--- a/spec/02-integration/04-admin_api/21-truncated_arguments_spec.lua
+++ b/spec/02-integration/04-admin_api/21-truncated_arguments_spec.lua
@@ -31,7 +31,7 @@ for _, strategy in helpers.each_strategy() do
       end
     end)
 
-    it("return 400 if reach maxinum post arguments number", function()
+    it("return 400 if reach maximum post arguments number", function()
       local items = {}
       for i = 1, max_post_args_overflow do
         table.insert(items, "config.allow=" .. i)
@@ -50,7 +50,7 @@ for _, strategy in helpers.each_strategy() do
       assert.same({ message = "Too many arguments" }, json)
     end)
 
-    it("return 400 if reach maxinum uri arguments number", function()
+    it("return 400 if reach maximum uri arguments number", function()
       local items = {}
       for i = 1, max_uri_args_overflow do
         table.insert(items, "a=" .. i)

--- a/spec/02-integration/04-admin_api/21-truncated_arguments_spec.lua
+++ b/spec/02-integration/04-admin_api/21-truncated_arguments_spec.lua
@@ -1,0 +1,70 @@
+local helpers = require "spec.helpers"
+
+for _, strategy in helpers.each_strategy() do
+
+  describe("Admin API - truncated arguments #" .. strategy, function()
+    local max_uri_args = 1000
+    local max_post_args = 1000
+
+    local client
+
+    lazy_setup(function()
+      helpers.get_db_utils(strategy)
+      assert(helpers.start_kong({
+        database = strategy,
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+        plugins = "bundled",
+      }))
+    end)
+
+    lazy_teardown(function()
+      helpers.stop_kong(nil, true)
+    end)
+
+    before_each(function()
+      client = helpers.admin_client()
+    end)
+
+    after_each(function()
+      if client then
+        client:close()
+      end
+    end)
+
+    it("return 400 if reach maxinum post arguments number", function()
+      local items = {}
+      for i = 1, max_post_args + 1 do
+        table.insert(items, "config.allow=" .. i)
+      end
+      local body = "name=ip-restriction&" .. table.concat(items, "&")
+      local res = assert(client:send {
+        method = "POST",
+        path = "/plugins",
+        headers = {
+          ["Content-Type"] =  "application/x-www-form-urlencoded",
+        },
+        body = body,
+      })
+      assert.response(res).has.status(400)
+      local json = assert.response(res).has.jsonbody()
+      assert.same({ message = "Too many arguments" }, json)
+    end)
+
+    it("return 400 if reach maxinum uri arguments number", function()
+      local items = {}
+      for i = 1, max_uri_args + 1 do
+        table.insert(items, "a=" .. i)
+      end
+      local querystring = table.concat(items, "&")
+      local res = assert(client:send {
+        method = "GET",
+        path = "/plugins?" .. querystring,
+      })
+      assert.response(res).has.status(400)
+      local json = assert.response(res).has.jsonbody()
+      assert.same({ message = "Too many arguments" }, json)
+    end)
+
+  end)
+
+end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Admin API will quietly truncate the request post arguments if reach the limit(100), which might cause data inconsistency issues.

<!--- Why is this change required? What problem does it solve? -->

### Full changelog

1. Increase max_uri_args and max_post_args to 1000
2. Return 400 while reach the maximum argument number

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

[FTI-4407]

[FTI-4407]: https://konghq.atlassian.net/browse/FTI-4407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ