### PR TITLE
refactor(error_handlers):simplify error handlers

### DIFF
--- a/kong/error_handlers.lua
+++ b/kong/error_handlers.lua
@@ -10,29 +10,29 @@ local TYPE_GRPC       = "application/grpc"
 
 
 local BODIES = {
-  [400]   = "Bad request",
-  [404]   = "Not found",
-  [408]   = "Request timeout",
-  [411]   = "Length required",
-  [412]   = "Precondition failed",
-  [413]   = "Payload too large",
-  [414]   = "URI too long",
-  [417]   = "Expectation failed",
-  [494]   = "Request header or cookie too large",
-  [500]   = "An unexpected error occurred",
-  [502]   = "An invalid response was received from the upstream server",
-  [503]   = "The upstream server is currently unavailable",
-  [504]   = "The upstream server is timing out",
+  [400] = "Bad request",
+  [404] = "Not found",
+  [408] = "Request timeout",
+  [411] = "Length required",
+  [412] = "Precondition failed",
+  [413] = "Payload too large",
+  [414] = "URI too long",
+  [417] = "Expectation failed",
+  [494] = "Request header or cookie too large",
+  [500] = "An unexpected error occurred",
+  [502] = "An invalid response was received from the upstream server",
+  [503] = "The upstream server is currently unavailable",
+  [504] = "The upstream server is timing out",
 }
 
 
 local get_body
 do
-  local default_fmt = "The upstream server responded with %d"
+  local DEFAULT_FMT = "The upstream server responded with %d"
 
   get_body = function(status)
     if not BODIES[status] then
-      BODIES[status] = fmt(default_fmt, status)
+      BODIES[status] = fmt(DEFAULT_FMT, status)
     end
 
     return BODIES[status]

--- a/kong/error_handlers.lua
+++ b/kong/error_handlers.lua
@@ -23,8 +23,21 @@ local BODIES = {
   [502]   = "An invalid response was received from the upstream server",
   [503]   = "The upstream server is currently unavailable",
   [504]   = "The upstream server is timing out",
-  default = "The upstream server responded with %d"
 }
+
+
+local get_body
+do
+  local default_fmt = "The upstream server responded with %d"
+
+  get_body = function(status)
+    if not BODIES[status] then
+      BODIES[status] = fmt(default_fmt, status)
+    end
+
+    return BODIES[status]
+  end
+end
 
 
 return function(ctx)
@@ -37,7 +50,7 @@ return function(ctx)
   end
 
   local status = kong.response.get_status()
-  local message = BODIES[status] or fmt(BODIES.default, status)
+  local message = get_body(status)
 
   local headers
   if find(accept_header, TYPE_GRPC, nil, true) == 1 then

--- a/kong/error_handlers.lua
+++ b/kong/error_handlers.lua
@@ -31,11 +31,16 @@ do
   local DEFAULT_FMT = "The upstream server responded with %d"
 
   get_body = function(status)
-    if not BODIES[status] then
-      BODIES[status] = fmt(DEFAULT_FMT, status)
+    local body = BODIES[status]
+
+    if body then
+      return body
     end
 
-    return BODIES[status]
+    body = fmt(DEFAULT_FMT, status)
+    BODIES[status] = body
+
+    return body
   end
 end
 

--- a/kong/error_handlers.lua
+++ b/kong/error_handlers.lua
@@ -10,19 +10,19 @@ local TYPE_GRPC       = "application/grpc"
 
 
 local BODIES = {
-  s400 = "Bad request",
-  s404 = "Not found",
-  s408 = "Request timeout",
-  s411 = "Length required",
-  s412 = "Precondition failed",
-  s413 = "Payload too large",
-  s414 = "URI too long",
-  s417 = "Expectation failed",
-  s494 = "Request header or cookie too large",
-  s500 = "An unexpected error occurred",
-  s502 = "An invalid response was received from the upstream server",
-  s503 = "The upstream server is currently unavailable",
-  s504 = "The upstream server is timing out",
+  [400]   = "Bad request",
+  [404]   = "Not found",
+  [408]   = "Request timeout",
+  [411]   = "Length required",
+  [412]   = "Precondition failed",
+  [413]   = "Payload too large",
+  [414]   = "URI too long",
+  [417]   = "Expectation failed",
+  [494]   = "Request header or cookie too large",
+  [500]   = "An unexpected error occurred",
+  [502]   = "An invalid response was received from the upstream server",
+  [503]   = "The upstream server is currently unavailable",
+  [504]   = "The upstream server is timing out",
   default = "The upstream server responded with %d"
 }
 
@@ -37,7 +37,7 @@ return function(ctx)
   end
 
   local status = kong.response.get_status()
-  local message = BODIES["s" .. status] or fmt(BODIES.default, status)
+  local message = BODIES[status] or fmt(BODIES.default, status)
 
   local headers
   if find(accept_header, TYPE_GRPC, nil, true) == 1 then


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Use number index to simplify error message processing.

### Full changelog

* use number index instead of string index
* add function `get_body` and cache other messages.

