### PR TITLE
fix(clustering): DP friendly msg when CP offline

### DIFF
--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -9,6 +9,7 @@ local clustering_utils = require("kong.clustering.utils")
 local declarative = require("kong.db.declarative")
 local constants = require("kong.constants")
 local utils = require("kong.tools.utils")
+local pl_stringx = require("pl.stringx")
 
 
 local assert = assert
@@ -38,7 +39,7 @@ local PING_WAIT = PING_INTERVAL * 1.5
 local _log_prefix = "[clustering] "
 local DECLARATIVE_EMPTY_CONFIG_HASH = constants.DECLARATIVE_EMPTY_CONFIG_HASH
 
-local endswith = utils.endswith
+local endswith = pl_stringx.endswith
 
 local function is_timeout(err)
   return err and sub(err, -7) == "timeout"
@@ -264,17 +265,18 @@ function _M:communicate(premature)
   ngx.thread.kill(write_thread)
   c:close()
 
-  local true_err
+  local err_msg
   
   if not ok then
-    true_err = err
+    err_msg = err
+
   else
-    true_err = perr
+    err_msg = perr
   end
   
-  if endswith(true_err, ": closed") then
+  if endswith(err_msg, ": closed") then
     ngx_log(ngx_INFO, _log_prefix, "connection to control plane closed", log_suffix)
-  elseif true_err then
+  elseif err_msg then
     ngx_log(ngx_ERR, _log_prefix, err, log_suffix)
   end
 

--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -274,8 +274,9 @@ function _M:communicate(premature)
     err_msg = perr
   end
   
-  if endswith(err_msg, ": closed") then
+  if endswith(err_msg, ": closed") or endswith(err_msg, "(104: Connection reset by peer)") then
     ngx_log(ngx_INFO, _log_prefix, "connection to control plane closed", log_suffix)
+
   elseif err_msg then
     ngx_log(ngx_ERR, _log_prefix, err, log_suffix)
   end

--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -274,7 +274,7 @@ function _M:communicate(premature)
     err_msg = perr
   end
   
-  if err_msg and (endswith(err_msg, ": closed") or endswith(err_msg, "(104: Connection reset by peer)")) then
+  if err_msg and endswith(err_msg, ": closed") then
     ngx_log(ngx_INFO, _log_prefix, "connection to control plane closed", log_suffix)
 
   elseif err_msg then

--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -274,7 +274,7 @@ function _M:communicate(premature)
     err_msg = perr
   end
   
-  if endswith(err_msg, ": closed") or endswith(err_msg, "(104: Connection reset by peer)") then
+  if err_msg and (endswith(err_msg, ": closed") or endswith(err_msg, "(104: Connection reset by peer)")) then
     ngx_log(ngx_INFO, _log_prefix, "connection to control plane closed", log_suffix)
 
   elseif err_msg then

--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -265,14 +265,7 @@ function _M:communicate(premature)
   ngx.thread.kill(write_thread)
   c:close()
 
-  local err_msg
-  
-  if not ok then
-    err_msg = err
-
-  else
-    err_msg = perr
-  end
+  local err_msg = ok and err or perr
   
   if err_msg and endswith(err_msg, ": closed") then
     ngx_log(ngx_INFO, _log_prefix, "connection to control plane closed", log_suffix)

--- a/kong/clustering/wrpc_data_plane.lua
+++ b/kong/clustering/wrpc_data_plane.lua
@@ -232,9 +232,10 @@ local function communicate_impl(dp)
     err_msg = perr
   end
   
-  if endswith(err_msg, ": closed") then
+  if endswith(err_msg, ": closed") or endswith(err_msg, "(104: Connection reset by peer)") then
     ngx_log(ngx_INFO, _log_prefix, "connection to control plane closed", log_suffix)
     return
+
   elseif err_msg then
     ngx_log(ngx_ERR, _log_prefix, err_msg, log_suffix)
   end

--- a/kong/clustering/wrpc_data_plane.lua
+++ b/kong/clustering/wrpc_data_plane.lua
@@ -232,7 +232,7 @@ local function communicate_impl(dp)
     err_msg = perr
   end
   
-  if endswith(err_msg, ": closed") or endswith(err_msg, "(104: Connection reset by peer)") then
+  if err_msg and (endswith(err_msg, ": closed") or endswith(err_msg, "(104: Connection reset by peer)")) then
     ngx_log(ngx_INFO, _log_prefix, "connection to control plane closed", log_suffix)
     return
 

--- a/kong/clustering/wrpc_data_plane.lua
+++ b/kong/clustering/wrpc_data_plane.lua
@@ -232,7 +232,7 @@ local function communicate_impl(dp)
     err_msg = perr
   end
   
-  if err_msg and (endswith(err_msg, ": closed") or endswith(err_msg, "(104: Connection reset by peer)")) then
+  if err_msg and endswith(err_msg, ": closed") then
     ngx_log(ngx_INFO, _log_prefix, "connection to control plane closed", log_suffix)
     return
 

--- a/kong/clustering/wrpc_data_plane.lua
+++ b/kong/clustering/wrpc_data_plane.lua
@@ -223,15 +223,7 @@ local function communicate_impl(dp)
   ngx.thread.kill(ping_thread)
   peer:close()
 
-  local err_msg
-  
-  if not ok then
-    err_msg = err
-
-  else
-    err_msg = perr
-  end
-  
+  local err_msg = ok and err or perr  
   if err_msg and endswith(err_msg, ": closed") then
     ngx_log(ngx_INFO, _log_prefix, "connection to control plane closed", log_suffix)
     return

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -1468,7 +1468,6 @@ do
 end
 _M.time_ns = time_ns
 
-
 local sha256_bin
 do
   local digest = require "resty.openssl.digest"
@@ -1530,8 +1529,5 @@ end
 _M.sha256_hex       = sha256_hex
 _M.sha256_base64    = sha256_base64
 _M.sha256_base64url = sha256_base64url
-function _M.endswith(s, e)
-  return s and e and e ~= "" and s:sub(#s - #e + 1, #s) == e
-end
 
 return _M

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -1530,5 +1530,8 @@ end
 _M.sha256_hex       = sha256_hex
 _M.sha256_base64    = sha256_base64
 _M.sha256_base64url = sha256_base64url
+function _M.endswith(s, e)
+  return s and e and e ~= "" and s:sub(#s - #e + 1, #s) == e
+end
 
 return _M

--- a/spec/02-integration/09-hybrid_mode/02-start_stop_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/02-start_stop_spec.lua
@@ -136,6 +136,7 @@ end
 -- note that lagacy modes still error when CP exits
 describe("when CP exits before DP", function()
   local need_exit = true
+
   setup(function()
     assert(helpers.start_kong({
       role = "control_plane",
@@ -154,12 +155,14 @@ describe("when CP exits before DP", function()
       database = "off",
     }))
   end)
+
   teardown(function()
     if need_exit then
       helpers.stop_kong("servroot1")
     end
     helpers.stop_kong("servroot2")
   end)
+
   it("DP should not emit error message", function ()
     helpers.clean_logfile("servroot2/logs/error.log")
     assert(helpers.stop_kong("servroot1"))

--- a/spec/02-integration/09-hybrid_mode/02-start_stop_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/02-start_stop_spec.lua
@@ -167,6 +167,6 @@ describe("when CP exits before DP", function()
     helpers.clean_logfile("servroot2/logs/error.log")
     assert(helpers.stop_kong("servroot1"))
     need_exit = false
-    assert.logfile("servroot2/logs/error.log").has.no.line("[error]", true)
+    assert.logfile("servroot2/logs/error.log").has.no.line("error while receiving frame from peer", true)
   end)
 end)


### PR DESCRIPTION
Translate the log to a more user-friendly form, and lower the log level.

Also correcting some of the log formats.

Fix FT-3204
