### PR TITLE
style(router/atc): check fields with `is_empty_field` when we calc priority

### DIFF
--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -211,10 +211,6 @@ local function get_priority(route)
     match_weight = match_weight + 1
   end
 
-  if not is_empty_field(hosts) then
-    match_weight = match_weight + 1
-  end
-
   if not is_empty_field(paths) then
     match_weight = match_weight + 1
   end
@@ -235,9 +231,11 @@ local function get_priority(route)
     match_weight = match_weight + 1
   end
 
-  local plain_host_only = not not hosts
+  local plain_host_only = not is_empty_field(hosts)
 
-  if hosts then
+  if plain_host_only then
+    match_weight = match_weight + 1
+
     for _, h in ipairs(hosts) do
       if h:find("*", nil, true) then
         plain_host_only = false

--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -211,10 +211,6 @@ local function get_priority(route)
     match_weight = match_weight + 1
   end
 
-  if not is_empty_field(paths) then
-    match_weight = match_weight + 1
-  end
-
   local headers_count = is_empty_field(headers) and 0 or tb_nkeys(headers)
 
   if headers_count > 0 then
@@ -247,7 +243,9 @@ local function get_priority(route)
   local max_uri_length = 0
   local regex_url = false
 
-  if paths then
+  if not is_empty_field(paths) then
+    match_weight = match_weight + 1
+
     for _, p in ipairs(paths) do
       if is_regex_magic(p) then
         regex_url = true

--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -212,6 +212,10 @@ local function get_priority(route)
     match_weight = match_weight + 1
   end
 
+  if not is_empty_field(hosts) then
+    match_weight = match_weight + 1
+  end
+
   local headers_count = is_empty_field(headers) and 0 or tb_nkeys(headers)
 
   if headers_count > 0 then
@@ -231,8 +235,6 @@ local function get_priority(route)
   local plain_host_only = type(hosts) == "table"
 
   if plain_host_only then
-    match_weight = match_weight + 1
-
     for _, h in ipairs(hosts) do
       if h:find("*", nil, true) then
         plain_host_only = false

--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -14,6 +14,7 @@ local gen_for_field   = atc.gen_for_field
 local split_host_port = atc.split_host_port
 
 
+local type = type
 local pairs = pairs
 local ipairs = ipairs
 local tb_concat = table.concat
@@ -227,7 +228,7 @@ local function get_priority(route)
     match_weight = match_weight + 1
   end
 
-  local plain_host_only = not is_empty_field(hosts)
+  local plain_host_only = type(hosts) == "table"
 
   if plain_host_only then
     match_weight = match_weight + 1

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -2083,60 +2083,65 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
             assert.spy(remove_matcher).was_called(2)
           end)
         end)
-      end
 
-      describe("check empty route fields", function()
-        local use_case
-        local _get_expression = atc_compat._get_expression
+        describe("check empty route fields", function()
+          local use_case
+          local _get_expression = atc_compat._get_expression
 
-        before_each(function()
-          use_case = {
-            {
-              service = service,
-              route = {
-                id = "e8fb37f1-102d-461e-9c51-6608a6bb8101",
-                methods = { "GET" },
-                paths = { "/foo", },
+          before_each(function()
+            use_case = {
+              {
+                service = service,
+                route = {
+                  id = "e8fb37f1-102d-461e-9c51-6608a6bb8101",
+                  methods = { "GET" },
+                  paths = { "/foo", },
+                },
               },
-            },
-          }
+            }
+          end)
+
+          local empty_values = { {}, ngx.null, nil }
+          for i = 1, 3 do
+            local v = empty_values[i]
+
+            it("empty methods", function()
+              use_case[1].route.methods = v
+
+              assert.equal(_get_expression(use_case[1].route), [[(http.path ^= "/foo")]])
+              assert(new_router(use_case))
+            end)
+
+            it("empty hosts", function()
+              use_case[1].route.hosts = v
+
+              assert.equal(_get_expression(use_case[1].route), [[(http.method == "GET") && (http.path ^= "/foo")]])
+              assert(new_router(use_case))
+            end)
+
+            it("empty headers", function()
+              use_case[1].route.headers = v
+
+              assert.equal(_get_expression(use_case[1].route), [[(http.method == "GET") && (http.path ^= "/foo")]])
+              assert(new_router(use_case))
+            end)
+
+            it("empty paths", function()
+              use_case[1].route.paths = v
+
+              assert.equal(_get_expression(use_case[1].route), [[(http.method == "GET")]])
+              assert(new_router(use_case))
+            end)
+
+            it("empty snis", function()
+              use_case[1].route.snis = v
+
+              assert.equal(_get_expression(use_case[1].route), [[(http.method == "GET") && (http.path ^= "/foo")]])
+              assert(new_router(use_case))
+            end)
+          end
         end)
-
-        it("empty methods", function()
-          use_case[1].route.methods = {}
-
-          assert.equal(_get_expression(use_case[1].route), [[(http.path ^= "/foo")]])
-          assert(new_router(use_case))
-        end)
-
-        it("empty hosts", function()
-          use_case[1].route.hosts = {}
-
-          assert.equal(_get_expression(use_case[1].route), [[(http.method == "GET") && (http.path ^= "/foo")]])
-          assert(new_router(use_case))
-        end)
-
-        it("empty headers", function()
-          use_case[1].route.headers = {}
-
-          assert.equal(_get_expression(use_case[1].route), [[(http.method == "GET") && (http.path ^= "/foo")]])
-          assert(new_router(use_case))
-        end)
-
-        it("empty paths", function()
-          use_case[1].route.paths = {}
-
-          assert.equal(_get_expression(use_case[1].route), [[(http.method == "GET")]])
-          assert(new_router(use_case))
-        end)
-
-        it("empty snis", function()
-          use_case[1].route.snis = {}
-
-          assert.equal(_get_expression(use_case[1].route), [[(http.method == "GET") && (http.path ^= "/foo")]])
-          assert(new_router(use_case))
-        end)
-      end)
+      end
 
       describe("normalization stopgap measurements", function()
         local use_case, router


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Fields in route (paths/hosts) may be `nil` or `ngx.null`, so we use `is_empty_field` to check them more carefully.


