### PR TITLE
chore(router/atc): cache split host port results

### DIFF
--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -18,7 +18,6 @@ local assert = assert
 local setmetatable = setmetatable
 local pairs = pairs
 local ipairs = ipairs
-local tonumber = tonumber
 
 
 local max = math.max
@@ -324,6 +323,8 @@ end
 -- example.*:123 => example.*, 123
 local split_host_port
 do
+  local tonumber = tonumber
+
   local memo_h = setmetatable({}, { __mode = "k" })
   local memo_p = setmetatable({}, { __mode = "k" })
 

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -328,12 +328,10 @@ do
 
   local memo_hp = lrucache.new(DEFAULT_HOSTS_LRUCACHE_SIZE)
 
-  split_host_port = function(h)
-    if not h then
+  split_host_port = function(key)
+    if not key then
       return nil, nil
     end
-
-    local key = h
 
     local m = memo_hp:get(key)
 
@@ -341,20 +339,20 @@ do
       return m[1], m[2]
     end
 
-    local p = h:find(":", nil, true)
+    local p = key:find(":", nil, true)
     if not p then
-      memo_hp:set(key, { h, nil })
-      return h, nil
+      memo_hp:set(key, { key, nil })
+      return key, nil
     end
 
-    local port = tonumber(h:sub(p + 1))
+    local port = tonumber(key:sub(p + 1))
 
     if not port then
-      memo_hp:set(key, { h, nil })
-      return h, nil
+      memo_hp:set(key, { key, nil })
+      return key, nil
     end
 
-    local host = h:sub(1, p - 1)
+    local host = key:sub(1, p - 1)
 
     memo_hp:set(key, { host, port })
 

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -324,35 +324,37 @@ end
 -- example.*:123 => example.*, 123
 local split_host_port
 do
-  local memo_hp = setmetatable({}, { __mode = "k" })
+  local memo_h = setmetatable({}, { __mode = "k" })
+  local memo_p = setmetatable({}, { __mode = "k" })
 
   split_host_port = function(h)
     if not h then
       return nil, nil
     end
 
-    local p = h:find(":", nil, true)
-    if not p then
-      return h, nil
+    local mh, mp = memo_h[h], memo_p[h]
+
+    if mh then
+      return mh, mp
     end
 
-    local hp = memo_hp[h]
-
-    -- hit
-    if hp then
-      return hp[1], hp[2]
+    local p = h:find(":", nil, true)
+    if not p then
+      memo_h[h] = h
+      return h, nil
     end
 
     local port = tonumber(h:sub(p + 1))
 
     if not port then
-      memo_hp[h] = { h, nil }
+      memo_h[h] = h
       return h, nil
     end
 
     local host = h:sub(1, p - 1)
 
-    memo_hp[h] = { host, port }
+    memo_h[h] = host
+    memo_p[h] = port
 
     return host, port
   end

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -322,25 +322,40 @@ end
 -- split port in host, ignore form '[...]'
 -- example.com:123 => example.com, 123
 -- example.*:123 => example.*, 123
-local function split_host_port(h)
-  if not h then
-    return nil, nil
+local split_host_port
+do
+  local memo_hp = setmetatable({}, { __mode = "k" })
+
+  split_host_port = function(h)
+    if not h then
+      return nil, nil
+    end
+
+    local p = h:find(":", nil, true)
+    if not p then
+      return h, nil
+    end
+
+    local hp = memo_hp[h]
+
+    -- hit
+    if hp then
+      return hp[1], hp[2]
+    end
+
+    local port = tonumber(h:sub(p + 1))
+
+    if not port then
+      memo_hp[h] = { h, nil }
+      return h, nil
+    end
+
+    local host = h:sub(1, p - 1)
+
+    memo_hp[h] = { host, port }
+
+    return host, port
   end
-
-  local p = h:find(":", nil, true)
-  if not p then
-    return h, nil
-  end
-
-  local port = tonumber(h:sub(p + 1))
-
-  if not port then
-    return h, nil
-  end
-
-  local host = h:sub(1, p - 1)
-
-  return host, port
 end
 
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Cache host-port split results to speed up router building and matching.

This logic is a mimic of traditional flavor router.

