### PR TITLE
chore(tools): use native ngx.sleep in yield

### DIFF
--- a/kong/globalpatches.lua
+++ b/kong/globalpatches.lua
@@ -69,6 +69,8 @@ return function(options)
       return ngx_sleep(s)
     end
 
+    _G.native_ngx_sleep = ngx_sleep
+
   end
 
 

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -1433,7 +1433,7 @@ end
 
 do
   local get_phase = ngx.get_phase
-  local ngx_sleep = ngx.sleep
+  local ngx_sleep = _G.native_ngx_sleep or ngx.sleep
 
   local counter = YIELD_ITERATIONS
   function _M.yield(in_loop, phase)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

In `globalpatches.lua` we re-implement `ngx.sleep`, 
which will check nginx phase then call `socket.sleep` or original `ngx.sleep`.

But in function `yield`, we already have phase check logic
and don't need blocking sleep.

In this case, the re-implemented `ngx.sleep` introduces unnecessary cost,
we should call original `ngx.sleep`.

This PR add a new global function `_G.native_ngx_sleep` like `_G.native_timer_at`,
and use `_G.native_ngx_sleep`  in `yield`.


