### PR TITLE
fix: add missing protocols field to plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,8 @@
 
 #### Plugins
 
+- Add missing `protocols` field to various plugin schemas.
+  [#9525](https://github.com/Kong/kong/pull/9525)
 - **AWS Lambda**: Fix an issue that is causing inability to
   read environment variables in ECS environment.
   [#9460](https://github.com/Kong/kong/pull/9460)

--- a/kong/plugins/azure-functions/schema.lua
+++ b/kong/plugins/azure-functions/schema.lua
@@ -1,6 +1,9 @@
+local typedefs = require "kong.db.schema.typedefs"
+
 return {
   name = "azure-functions",
   fields = {
+    { protocols = typedefs.protocols },
     { config = {
         type = "record",
         fields = {

--- a/kong/plugins/grpc-gateway/schema.lua
+++ b/kong/plugins/grpc-gateway/schema.lua
@@ -1,6 +1,9 @@
+local typedefs = require "kong.db.schema.typedefs"
+
 return {
   name = "grpc-gateway",
   fields = {
+    { protocols = typedefs.protocols },
     { config = {
       type = "record",
       fields = {

--- a/kong/plugins/grpc-web/schema.lua
+++ b/kong/plugins/grpc-web/schema.lua
@@ -1,6 +1,9 @@
+local typedefs = require "kong.db.schema.typedefs"
+
 return {
   name = "grpc-web",
   fields = {
+    { protocols = typedefs.protocols },
     { config = {
       type = "record",
       fields = {

--- a/kong/plugins/pre-function/_schema.lua
+++ b/kong/plugins/pre-function/_schema.lua
@@ -32,6 +32,7 @@ return function(plugin_name)
     name = plugin_name,
     fields = {
       { consumer = typedefs.no_consumer },
+      { protocols = typedefs.protocols },
       {
         config = {
           type = "record",

--- a/kong/plugins/prometheus/schema.lua
+++ b/kong/plugins/prometheus/schema.lua
@@ -1,3 +1,5 @@
+local typedefs = require "kong.db.schema.typedefs"
+
 local function validate_shared_dict()
   if not ngx.shared.prometheus_metrics then
     return nil,
@@ -10,6 +12,7 @@ end
 return {
   name = "prometheus",
   fields = {
+    { protocols = typedefs.protocols },
     { config = {
         type = "record",
         fields = {

--- a/kong/plugins/proxy-cache/schema.lua
+++ b/kong/plugins/proxy-cache/schema.lua
@@ -1,4 +1,5 @@
 local strategies = require "kong.plugins.proxy-cache.strategies"
+local typedefs = require "kong.db.schema.typedefs"
 
 
 local ngx = ngx
@@ -16,6 +17,7 @@ end
 return {
   name = "proxy-cache",
   fields = {
+    { protocols = typedefs.protocols },
     { config = {
         type = "record",
         fields = {

--- a/kong/plugins/request-transformer/schema.lua
+++ b/kong/plugins/request-transformer/schema.lua
@@ -124,6 +124,7 @@ table.insert(colon_strings_array_record_plus_uri.fields, uri)
 return {
   name = "request-transformer",
   fields = {
+    { protocols = typedefs.protocols },
     { config = {
         type = "record",
         fields = {

--- a/kong/plugins/session/schema.lua
+++ b/kong/plugins/session/schema.lua
@@ -33,6 +33,7 @@ return {
   name = "session",
   fields = {
     { consumer = typedefs.no_consumer },
+    { protocols = typedefs.protocols },
     { config = {
         type = "record",
         fields = {

--- a/kong/plugins/zipkin/schema.lua
+++ b/kong/plugins/zipkin/schema.lua
@@ -43,6 +43,7 @@ end
 return {
   name = "zipkin",
   fields = {
+    { protocols = typedefs.protocols },
     { config = {
         type = "record",
         fields = {


### PR DESCRIPTION
### Summary

All plugin entities are expected to have a `protocols` schema field, but some plugin schemas are missing it. From a functional point of view, this doesn't have any impact, since the `protocols` field is still injected in the overall schema. But when plugin schemas are retrieved via the Admin API using the `/schemas/plugins/<name>` endpoint, then the "original" schema is returned. For example:

```
$ http :8001/schemas/plugins/prometheus
HTTP/1.1 200 OK
Access-Control-Allow-Origin: *
Connection: keep-alive
Content-Length: 354
Content-Type: application/json; charset=utf-8
Date: Tue, 11 Oct 2022 06:42:47 GMT
Server: kong/3.0.0
X-Kong-Admin-Latency: 6

{
    "fields": [
        {
            "config": {
                "fields": [
                    {
                        "per_consumer": {
                            "default": false,
                            "type": "boolean"
                        }
                    },
                    {
                        "status_code_metrics": {
                            "default": false,
                            "type": "boolean"
                        }
                    },
                    {
                        "latency_metrics": {
                            "default": false,
                            "type": "boolean"
                        }
                    },
                    {
                        "bandwidth_metrics": {
                            "default": false,
                            "type": "boolean"
                        }
                    },
                    {
                        "upstream_health_metrics": {
                            "default": false,
                            "type": "boolean"
                        }
                    }
                ],
                "required": true,
                "type": "record"
            }
        }
    ]
}
```

This is problematic for decK, which uses this endpoint to inject schema defaults before doing a deployment, which can cause unnecessary/misleading diffs:

```
$ cat kong.yaml
_format_version: "3.0"
plugins:
  - name: prometheus

$ deck sync
updating plugin prometheus (global)  {
   "config": {
     "bandwidth_metrics": false,
     "latency_metrics": false,
     "per_consumer": false,
     "status_code_metrics": false,
     "upstream_health_metrics": false
   },
   "enabled": true,
   "id": "93aece4b-b813-4d9b-af28-f4c1c874f128",
   "name": "prometheus",
-  "protocols": [
-    "grpc",
-    "grpcs",
-    "http",
-    "https"
-  ]
 }

Summary:
  Created: 0
  Updated: 1
  Deleted: 0
```

### Full changelog

* add missing `protocols` field to plugin schemas

