### PR TITLE
feat(hash): replace md5 with sha256 on proxy-cache plugin

### DIFF
--- a/kong/plugins/proxy-cache/cache_key.lua
+++ b/kong/plugins/proxy-cache/cache_key.lua
@@ -1,12 +1,12 @@
 local fmt = string.format
 local ipairs = ipairs
-local md5 = ngx.md5
 local type = type
 local pairs = pairs
 local sort = table.sort
 local insert = table.insert
 local concat = table.concat
 
+local sha256_hex = require "kong.tools.utils".sha256_hex
 
 local _M = {}
 
@@ -108,8 +108,8 @@ function _M.build_cache_key(consumer_id, route_id, method, uri,
   local params_digest  = params_key(params_table, conf)
   local headers_digest = headers_key(headers_table, conf)
 
-  return md5(fmt("%s|%s|%s|%s|%s", prefix_digest, method, uri, params_digest,
-                                   headers_digest))
+  return sha256_hex(fmt("%s|%s|%s|%s|%s", prefix_digest, method, uri,
+                                          params_digest, headers_digest))
 end
 
 

--- a/kong/plugins/proxy-cache/handler.lua
+++ b/kong/plugins/proxy-cache/handler.lua
@@ -268,13 +268,17 @@ function ProxyCacheHandler:access(conf)
   local consumer = kong.client.get_consumer()
   local route = kong.router.get_route()
   local uri = ngx_re_sub(ngx.var.request, "\\?.*", "", "oj")
-  local cache_key = cache_key.build_cache_key(consumer and consumer.id,
-                                              route    and route.id,
-                                              kong.request.get_method(),
-                                              uri,
-                                              kong.request.get_query(),
-                                              kong.request.get_headers(),
-                                              conf)
+  local cache_key, err = cache_key.build_cache_key(consumer and consumer.id,
+                                                   route    and route.id,
+                                                   kong.request.get_method(),
+                                                   uri,
+                                                   kong.request.get_query(),
+                                                   kong.request.get_headers(),
+                                                   conf)
+  if err then
+    kong.log.err(err)
+    return
+  end
 
   kong.response.set_header("X-Cache-Key", cache_key)
 

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -1468,4 +1468,66 @@ do
 end
 _M.time_ns = time_ns
 
+
+local sha256_bin
+do
+  local digest = require "resty.openssl.digest"
+  local sha256_digest
+
+  function sha256_bin(key)
+    local _, bin, err
+    if not sha256_digest then
+      sha256_digest, err = digest.new("sha256")
+      if err then
+        return nil, err
+      end
+    end
+
+    bin, err = sha256_digest:final(key)
+    if err then
+      return nil, err
+    end
+
+    _, err = sha256_digest:reset()
+    if err then
+      sha256_digest = nil
+    end
+
+    return bin
+  end
+end
+_M.sha256_bin = sha256_bin
+
+
+local sha256_hex, sha256_base64, sha256_base64url
+do
+  local to_hex       = require "resty.string".to_hex
+  local to_base64    = ngx.encode_base64
+  local to_base64url = require "ngx.base64".encode_base64url
+
+  local function sha256_encode(encode_alg, key)
+    local bin, err = sha256_bin(key)
+    if err then
+      return nil, err
+    end
+
+    return encode_alg(bin)
+  end
+
+  function sha256_hex(key)
+    return sha256_encode(to_hex, key)
+  end
+
+  function sha256_base64(key)
+    return sha256_encode(to_base64, key)
+  end
+
+  function sha256_base64url(key)
+    return sha256_encode(to_base64url, key)
+  end
+end
+_M.sha256_hex       = sha256_hex
+_M.sha256_base64    = sha256_base64
+_M.sha256_base64url = sha256_base64url
+
 return _M

--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -1485,6 +1485,7 @@ do
 
     bin, err = sha256_digest:final(key)
     if err then
+      sha256_digest = nil
       return nil, err
     end
 

--- a/spec/03-plugins/31-proxy-cache/02-access_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/02-access_spec.lua
@@ -285,10 +285,10 @@ do
       local body1 = assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
 
-      -- cache key is an md5sum of the prefix uuid, method, and $request
+      -- cache key is a sha256sum of the prefix uuid, method, and $request
       local cache_key1 = res.headers["X-Cache-Key"]
       assert.matches("^[%w%d]+$", cache_key1)
-      assert.equals(32, #cache_key1)
+      assert.equals(64, #cache_key1)
 
       -- wait until the underlying strategy converges
       --strategy_wait_until(policy, function()
@@ -822,7 +822,7 @@ do
 
       local cache_key1 = res.headers["X-Cache-Key"]
       assert.matches("^[%w%d]+$", cache_key1)
-      assert.equals(32, #cache_key1)
+      assert.equals(64, #cache_key1)
 
       res = assert(client:send {
         method = "GET",
@@ -853,7 +853,7 @@ do
 
       local cache_key1 = res.headers["X-Cache-Key"]
       assert.matches("^[%w%d]+$", cache_key1)
-      assert.equals(32, #cache_key1)
+      assert.equals(64, #cache_key1)
 
       -- wait until the underlying strategy converges
       --strategy_wait_until(policy, function()

--- a/spec/03-plugins/31-proxy-cache/03-api_spec.lua
+++ b/spec/03-plugins/31-proxy-cache/03-api_spec.lua
@@ -216,10 +216,10 @@ describe("Plugin: proxy-cache", function()
         assert.res_status(200, res)
         assert.same("Miss", res.headers["X-Cache-Status"])
 
-        -- cache key is an md5sum of the prefix uuid, method, and $request
+        -- cache key is a sha256sum of the prefix uuid, method, and $request
         local cache_key1 = res.headers["X-Cache-Key"]
         assert.matches("^[%w%d]+$", cache_key1)
-        assert.equals(32, #cache_key1)
+        assert.equals(64, #cache_key1)
         cache_key = cache_key1
 
         res = assert(proxy_client:send {
@@ -295,10 +295,10 @@ describe("Plugin: proxy-cache", function()
         assert.res_status(200, res)
         assert.same("Miss", res.headers["X-Cache-Status"])
 
-        -- cache key is an md5sum of the prefix uuid, method, and $request
+        -- cache key is a sha256sum of the prefix uuid, method, and $request
         local cache_key1 = res.headers["X-Cache-Key"]
         assert.matches("^[%w%d]+$", cache_key1)
-        assert.equals(32, #cache_key1)
+        assert.equals(64, #cache_key1)
 
         -- make a `Hit` request to `route-1`
         res = assert(proxy_client:send {


### PR DESCRIPTION
Replace md5 hashing algorithm with sha256 on the proxy-cache plugin
Add utils functions for sha256 hashing

[FT-2418](https://konghq.atlassian.net/browse/FT-2418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)