### PR TITLE
fix(cli): shut down timers at the end of execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,11 @@
   the router's mutex is not released properly.
   [#9480](https://github.com/Kong/kong/pull/9480)
 
+#### CLI
+
+- Fix poor CLI performance due to pending timer jobs
+  [#9536](https://github.com/Kong/kong/pull/9536)
+
 #### Admin API
 
 - Increase the maximum request argument number from `100` to `1000`, and return 400 error if request parameters reach the limitation to avoid being truncated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,7 +96,7 @@
 
 #### CLI
 
-- Fix poor CLI performance due to pending timer jobs
+- Fix slow CLI performance due to pending timer jobs
   [#9536](https://github.com/Kong/kong/pull/9536)
 
 #### Admin API

--- a/kong/cmd/init.lua
+++ b/kong/cmd/init.lua
@@ -5,12 +5,10 @@ math.randomseed() -- Generate PRNG seed
 local pl_app = require "pl.lapp"
 local log = require "kong.cmd.utils.log"
 
-local timerng = _G.timerng
-
 local function stop_timers()
   -- shutdown lua-resty-timer-ng to allow the nginx worker to stop quickly
-  if timerng then
-    timerng:destroy()
+  if _G.timerng then
+    _G.timerng:destroy()
   end
 end
 

--- a/kong/cmd/init.lua
+++ b/kong/cmd/init.lua
@@ -5,6 +5,15 @@ math.randomseed() -- Generate PRNG seed
 local pl_app = require "pl.lapp"
 local log = require "kong.cmd.utils.log"
 
+local timerng = _G.timerng
+
+local function stop_timers()
+  -- shutdown lua-resty-timer-ng to allow the nginx worker to stop quickly
+  if timerng then
+    timerng:destroy()
+  end
+end
+
 local options = [[
  --v              verbose
  --vv             debug
@@ -99,4 +108,6 @@ return function(args)
 
     pl_app.quit(nil, true)
   end)
+
+  stop_timers()
 end


### PR DESCRIPTION
### Summary

With timer-ng, the CLI has become slow to terminate as nginx attempts to wait for all pending timers to stop before exiting:



```
$ time kong roar >/dev/null

real    0m1.033s
user    0m0.024s
sys     0m0.016s
```

This commit explicitly shuts down the timer-ng instance so that the CLI can quickly exit:

```
$ time kong roar >/dev/null

real    0m0.132s
user    0m0.027s
sys     0m0.013s
```

### Full changelog

* explicitly stop timer-ng instance on completion of CLI commands