### PR TITLE
perf(rate-limiting): sync to redis periodically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -614,6 +614,9 @@ now encoded as `"[]"` to comply with standard.
   [#9611](https://github.com/Kong/kong/pull/9611)
 - **HTTP-Log**: Support `http_endpoint` field to be referenceable
   [#9714](https://github.com/Kong/kong/pull/9714)
+- **rate-limiting**: Add a new configuration `sync_rate` to the `redis` policy,
+  which synchronizes metrics to redis periodically instead of on every request.
+  [#9538](https://github.com/Kong/kong/pull/9538)
 
 
 #### Hybrid Mode
@@ -638,12 +641,6 @@ now encoded as `"[]"` to comply with standard.
 - Extend `kong.client.tls.request_client_certificate` to support setting
   the Distinguished Name (DN) list hints of the accepted CA certificates.
   [#9768](https://github.com/Kong/kong/pull/9768)
-
-#### Plugins
-
-- **rate-limiting**: Add a new configuration `sync_rate` to the `redis` policy,
-  which synchronizes metrics to redis periodically instead of on every request.
-  [#9538](https://github.com/Kong/kong/pull/9538)
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -639,6 +639,12 @@ now encoded as `"[]"` to comply with standard.
   the Distinguished Name (DN) list hints of the accepted CA certificates.
   [#9768](https://github.com/Kong/kong/pull/9768)
 
+#### Plugins
+
+- **rate-limiting**: Add a new configuration `sync_rate` to the `redis` policy,
+  which synchronizes metrics to redis periodically instead of on every request.
+  [#9538](https://github.com/Kong/kong/pull/9538)
+
 ### Fixes
 
 #### Core

--- a/kong/clustering/compat/removed_fields.lua
+++ b/kong/clustering/compat/removed_fields.lua
@@ -55,6 +55,7 @@ return {
       "phase_duration_flavor",
     }
   },
+
   -- Any dataplane older than 3.3.0
   [3003000000] = {
     acme = {
@@ -83,6 +84,9 @@ return {
     },
     zipkin = {
       "queue",
+    },
+    rate_limiting = {
+      "sync_rate",
     },
   },
 }

--- a/kong/plugins/rate-limiting/handler.lua
+++ b/kong/plugins/rate-limiting/handler.lua
@@ -13,6 +13,7 @@ local pairs = pairs
 local error = error
 local tostring = tostring
 local timer_at = ngx.timer.at
+local SYNC_RATE_REALTIME = -1
 
 
 local EMPTY = {}
@@ -198,9 +199,14 @@ function RateLimitingHandler:access(conf)
     end
   end
 
-  local ok, err = timer_at(0, increment, conf, limits, identifier, current_timestamp, 1)
-  if not ok then
-    kong.log.err("failed to create timer: ", err)
+  if conf.sync_rate ~= SYNC_RATE_REALTIME and conf.policy == "redis" then
+    increment(false, conf, limits, identifier, current_timestamp, 1)
+
+  else
+    local ok, err = timer_at(0, increment, conf, limits, identifier, current_timestamp, 1)
+    if not ok then
+      kong.log.err("failed to create timer: ", err)
+    end
   end
 end
 

--- a/kong/plugins/rate-limiting/policies/init.lua
+++ b/kong/plugins/rate-limiting/policies/init.lua
@@ -2,16 +2,39 @@ local policy_cluster = require "kong.plugins.rate-limiting.policies.cluster"
 local timestamp = require "kong.tools.timestamp"
 local reports = require "kong.reports"
 local redis = require "resty.redis"
-
+local table_clear = require "table.clear"
 
 local kong = kong
 local pairs = pairs
 local null = ngx.null
+local ngx_time= ngx.time
 local shm = ngx.shared.kong_rate_limiting_counters
 local fmt = string.format
 
+local SYNC_RATE_REALTIME = -1
 
 local EMPTY_UUID = "00000000-0000-0000-0000-000000000000"
+
+-- for `conf.sync_rate > 0`
+local auto_sync_timer
+
+local cur_usage = {
+  --[[
+    [cache_key] = <integer>
+  --]]
+}
+
+local cur_usage_expire_at = {
+  --[[
+    [cache_key] = <integer>
+  --]]
+}
+
+local cur_delta = {
+  --[[
+    [cache_key] = <integer>
+  --]]
+}
 
 
 local function is_present(str)
@@ -20,7 +43,7 @@ end
 
 
 local function get_service_and_route_ids(conf)
-  conf = conf or {}
+  conf             = conf or {}
 
   local service_id = conf.service_id
   local route_id   = conf.route_id
@@ -37,7 +60,7 @@ local function get_service_and_route_ids(conf)
 end
 
 
-local get_local_key = function(conf, identifier, period, period_date)
+local function get_local_key(conf, identifier, period, period_date)
   local service_id, route_id = get_service_and_route_ids(conf)
 
   return fmt("ratelimit:%s:%s:%s:%s:%s", route_id, service_id, identifier,
@@ -67,7 +90,7 @@ local function get_redis_connection(conf)
                           conf.redis_port,
                           conf.redis_database)
   end
-  
+
   local ok, err = red:connect(conf.redis_host, conf.redis_port,
                               sock_opts)
   if not ok then
@@ -111,6 +134,84 @@ local function get_redis_connection(conf)
   return red
 end
 
+local function clear_local_counter()
+  table_clear(cur_usage)
+  table_clear(cur_usage_expire_at)
+  table_clear(cur_delta)
+end
+
+local function sync_to_redis(premature, conf)
+  if premature then
+    return
+  end
+
+  local red, err = get_redis_connection(conf)
+  if not red then
+    kong.log.err("[rate-limiting] failed to connect to Redis: ", err)
+    clear_local_counter()
+    return
+  end
+
+  red:init_pipeline()
+
+  for cache_key, delta in pairs(cur_delta) do
+    red:eval([[
+      local key, value, expiration = KEYS[1], tonumber(ARGV[1]), ARGV[2]
+      local exists = redis.call("exists", key)
+      redis.call("incrby", key, value)
+      if not exists or exists == 0 then
+        redis.call("expireat", key, expiration)
+      end
+    ]], 1, cache_key, delta, cur_usage_expire_at[cache_key])
+  end
+
+  local _, err = red:commit_pipeline()
+  if err then
+    kong.log.err("[rate-limiting] failed to commit increment pipeline in Redis: ", err)
+    clear_local_counter()
+    return
+  end
+
+  local ok, err = red:set_keepalive(10000, 100)
+  if not ok then
+    kong.log.err("[rate-limiting] failed to set Redis keepalive: ", err)
+    clear_local_counter()
+    return
+  end
+
+  -- just clear these tables and avoid creating three new tables
+  clear_local_counter()
+end
+
+local function periodical_sync(conf, sync_func)
+  if not auto_sync_timer then
+    local err
+    -- timer may be initialized after the module's loaded so we need to update the reference
+    auto_sync_timer, err = kong.timer:named_every("rate-limiting-auto-sync", conf.sync_rate, sync_func, conf)
+
+    if not auto_sync_timer then
+      kong.log.err("failed to create timer: ", err)
+      return nil, err
+    end
+  end
+
+  return true
+end
+
+local function update_local_counters(conf, periods, limits, identifier, value)
+  for period, period_date in pairs(periods) do
+    if limits[period] then
+      local cache_key = get_local_key(conf, identifier, period, period_date)
+
+      if cur_delta[cache_key] then
+        cur_delta[cache_key] = cur_delta[cache_key] + value
+      else
+        cur_delta[cache_key] = value
+      end
+    end
+  end
+  
+end
 
 return {
   ["local"] = {
@@ -139,7 +240,7 @@ return {
       end
 
       return current_metric or 0
-    end
+    end,
   },
   ["cluster"] = {
     increment = function(conf, limits, identifier, current_timestamp, value)
@@ -175,25 +276,45 @@ return {
       end
 
       return 0
-    end
+    end,
   },
   ["redis"] = {
     increment = function(conf, limits, identifier, current_timestamp, value)
-            -- the usage function already incremented the value of redis key to avoid race condition in concurrent calls
+      local periods = timestamp.get_timestamps(current_timestamp)
 
-      -- because of that we don't need to increment here
-      return true
+      if conf.sync_rate == SYNC_RATE_REALTIME then
+        -- we already incremented the counter at usage()
+        return true
+
+      else
+        update_local_counters(conf, periods, limits, identifier, value)
+        return periodical_sync(conf, sync_to_redis)
+      end
     end,
     usage = function(conf, identifier, period, current_timestamp)
+      local periods = timestamp.get_timestamps(current_timestamp)
+      local cache_key = get_local_key(conf, identifier, period, periods[period])
+
+      -- use local cache to reduce the number of redis calls
+      -- also by pass the logic of incrementing the counter
+      if conf.sync_rate ~= SYNC_RATE_REALTIME and cur_usage[cache_key] then
+        if cur_usage_expire_at[cache_key] > ngx_time() then
+          return cur_usage[cache_key] + (cur_delta[cache_key] or 0)
+        end
+
+        cur_usage[cache_key] = 0
+        cur_usage_expire_at[cache_key] = periods[period] + EXPIRATION[period]
+        cur_delta[cache_key] = 0
+
+        return 0
+      end
+
       local red, err = get_redis_connection(conf)
       if not red then
         return nil, err
       end
 
       reports.retrieve_redis_version(red)
-
-      local periods = timestamp.get_timestamps(current_timestamp)
-      local cache_key = get_local_key(conf, identifier, period, periods[period])
 
       -- the usage of redis command incr instead of get is to avoid race conditions in concurrent calls
       local current_metric, err = red:eval([[
@@ -217,6 +338,12 @@ return {
       local ok, err = red:set_keepalive(10000, 100)
       if not ok then
         kong.log.err("failed to set Redis keepalive: ", err)
+      end
+
+      if conf.sync_rate ~= SYNC_RATE_REALTIME then
+        cur_usage[cache_key] = current_metric or 0
+        cur_usage_expire_at[cache_key] = periods[period] + EXPIRATION[period]
+        cur_delta[cache_key] = 0
       end
 
       return current_metric or 0

--- a/kong/plugins/rate-limiting/schema.lua
+++ b/kong/plugins/rate-limiting/schema.lua
@@ -1,6 +1,9 @@
 local typedefs = require "kong.db.schema.typedefs"
 
 
+local SYNC_RATE_REALTIME = -1
+
+
 local ORDERED_PERIODS = { "second", "minute", "hour", "day", "month", "year"}
 
 
@@ -16,6 +19,16 @@ local function validate_periods_order(config)
                                     upper_period, v2, lower_period, v1)
         end
       end
+    end
+  end
+
+  if config.policy ~= "redis" and config.sync_rate ~= SYNC_RATE_REALTIME then
+    return nil, "sync_rate can only be used with the redis policy"
+  end
+
+  if config.policy == "redis" then
+    if config.sync_rate ~= SYNC_RATE_REALTIME and config.sync_rate < 0.02 then
+      return nil, "sync_rate must be greater than 0.02, or -1 to disable"
     end
   end
 
@@ -90,6 +103,7 @@ return {
           { hide_client_headers = { description = "Optionally hide informative response headers.", type = "boolean", required = true, default = false }, },
           { error_code = { description = "Set a custom error code to return when the rate limit is exceeded.", type = "number", default = 429, gt = 0 }, },
           { error_message = { description = "Set a custom error message to return when the rate limit is exceeded.", type = "string", default = "API rate limit exceeded" }, },
+          { sync_rate = { description = "How often to sync counter data to the central data store. A value of -1 results in synchronous behavior.", type = "number", required = true, default = -1 }, },
         },
         custom_validator = validate_periods_order,
       },

--- a/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
@@ -121,6 +121,7 @@ describe("CP/DP config compat transformations #" .. strategy, function()
           -- [[ new fields
           error_code = 403,
           error_message = "go away!",
+          sync_rate = -1,
           -- ]]
         },
       }
@@ -137,20 +138,21 @@ describe("CP/DP config compat transformations #" .. strategy, function()
       local expected = utils.deep_copy(rate_limit.config)
       expected.error_code = nil
       expected.error_message = nil
+      expected.sync_rate = nil
 
       assert.same(expected, plugin.config)
       assert.equals(CLUSTERING_SYNC_STATUS.NORMAL, get_sync_status(id))
 
 
       id = utils.uuid()
-      plugin = get_plugin(id, "3.1.0", rate_limit.name)
+      plugin = get_plugin(id, "3.3.0", rate_limit.name)
       assert.same(rate_limit.config, plugin.config)
       assert.equals(CLUSTERING_SYNC_STATUS.NORMAL, get_sync_status(id))
     end)
 
     it("does not remove fields from DP nodes that are already compatible", function()
       local id = utils.uuid()
-      local plugin = get_plugin(id, "3.1.0", rate_limit.name)
+      local plugin = get_plugin(id, "3.3.0", rate_limit.name)
       assert.same(rate_limit.config, plugin.config)
       assert.equals(CLUSTERING_SYNC_STATUS.NORMAL, get_sync_status(id))
     end)

--- a/spec/03-plugins/23-rate-limiting/02-policies_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/02-policies_spec.lua
@@ -2,13 +2,36 @@ local uuid      = require("kong.tools.utils").uuid
 local helpers   = require "spec.helpers"
 local timestamp = require "kong.tools.timestamp"
 
+local SYNC_RATE_REALTIME = -1
+
 --[[
   basically a copy of `get_local_key()` 
   in `kong/plugins/rate-limiting/policies/init.lua`
 --]]
-local get_local_key = function(conf, identifier, period, period_date)
-  return string.format("ratelimit:%s:%s:%s:%s:%s",
-    conf.route_id, conf.service_id, identifier, period_date, period)
+local EMPTY_UUID = "00000000-0000-0000-0000-000000000000"
+local null = ngx.null
+local function get_service_and_route_ids(conf)
+  conf             = conf or {}
+
+  local service_id = conf.service_id
+  local route_id   = conf.route_id
+
+  if not service_id or service_id == null then
+    service_id = EMPTY_UUID
+  end
+
+  if not route_id or route_id == null then
+    route_id = EMPTY_UUID
+  end
+
+  return service_id, route_id
+end
+
+local function get_local_key(conf, identifier, period, period_date)
+  local service_id, route_id = get_service_and_route_ids(conf)
+
+  return string.format("ratelimit:%s:%s:%s:%s:%s", route_id, service_id, identifier,
+    period_date, period)
 end
 
 describe("Plugin: rate-limiting (policies)", function()
@@ -18,11 +41,18 @@ describe("Plugin: rate-limiting (policies)", function()
   lazy_setup(function()
     package.loaded["kong.plugins.rate-limiting.policies"] = nil
     policies = require "kong.plugins.rate-limiting.policies"
+    
+    if not _G.kong then
+      _G.kong.db = {}
+    end
+
+    _G.kong.timer = require("resty.timerng").new()
+    _G.kong.timer:start()
   end)
 
   describe("local", function()
     local identifier = uuid()
-    local conf       = { route_id = uuid(), service_id = uuid() }
+    local conf       = { route_id = uuid(), service_id = uuid(), sync_rate = SYNC_RATE_REALTIME }
 
     local shm = ngx.shared.kong_rate_limiting_counters
 
@@ -53,8 +83,8 @@ describe("Plugin: rate-limiting (policies)", function()
       local timestamp = 569000048000
 
       assert(policies['local'].increment(conf, {second=100}, identifier, timestamp+20, 1))
-      local v = shm:ttl(get_local_key(conf, identifier, 'second', timestamp))
-      assert(v and v > 0, "wrong value")
+      local v = assert(shm:ttl(get_local_key(conf, identifier, 'second', timestamp)))
+      assert(v > 0, "wrong value")
       ngx.sleep(1.020)
 
       v = shm:ttl(get_local_key(conf, identifier, 'second', timestamp))
@@ -146,51 +176,53 @@ describe("Plugin: rate-limiting (policies)", function()
     end)
   end
 
-  describe("redis", function()
-    local identifier = uuid()
-    local conf       = {
-      route_id = uuid(),
-      service_id = uuid(),
-      redis_host = helpers.redis_host,
-      redis_port = helpers.redis_port,
-      redis_database = 0,
-    }
+  for _, sync_rate in ipairs{1, SYNC_RATE_REALTIME} do
+    describe("redis with sync rate: " .. sync_rate, function()
+      local identifier = uuid()
+      local conf       = {
+        route_id = uuid(),
+        service_id = uuid(),
+        redis_host = helpers.redis_host,
+        redis_port = helpers.redis_port,
+        redis_database = 0,
+        sync_rate = sync_rate,
+      }
 
-    before_each(function()
-      local red = require "resty.redis"
-      local redis = assert(red:new())
-      redis:set_timeout(1000)
-      assert(redis:connect(conf.redis_host, conf.redis_port))
-      redis:flushall()
-      redis:close()
-    end)
+      before_each(function()
+        local red = require "resty.redis"
+        local redis = assert(red:new())
+        redis:set_timeout(1000)
+        assert(redis:connect(conf.redis_host, conf.redis_port))
+        redis:flushall()
+        redis:close()
+      end)
 
-    it("increase & usage", function()
-      --[[
-        Just a simple test:
-        - increase 1
-        - check usage == 1
-        - increase 1
-        - check usage == 2
-        - increase 1 (beyond the limit)
-        - check usage == 3
-      --]]
+      it("increase & usage", function()
+        --[[
+          Just a simple test:
+          - increase 1
+          - check usage == 1
+          - increase 1
+          - check usage == 2
+          - increase 1 (beyond the limit)
+          - check usage == 3
+        --]]
 
-      local current_timestamp = 1424217600
-      local periods = timestamp.get_timestamps(current_timestamp)
+        local current_timestamp = 1424217600
+        local periods = timestamp.get_timestamps(current_timestamp)
 
-      for period in pairs(periods) do
+        for period in pairs(periods) do
 
-        local metric = assert(policies.redis.usage(conf, identifier, period, current_timestamp))
-        assert.equal(0, metric)
+          local metric = assert(policies.redis.usage(conf, identifier, period, current_timestamp))
+          assert.equal(0, metric)
 
-        for i = 1, 3 do
-          assert(policies.redis.increment(conf, { [period] = 2 }, identifier, current_timestamp, 1))
-          metric = assert(policies.redis.usage(conf, identifier, period, current_timestamp))
-          assert.equal(i, metric)
+          for i = 1, 3 do
+            assert(policies.redis.increment(conf, { [period] = 2 }, identifier, current_timestamp, 1))
+            metric = assert(policies.redis.usage(conf, identifier, period, current_timestamp))
+            assert.equal(i, metric)
+          end
         end
-      end
+      end)
     end)
-  end)
-
+  end
 end)

--- a/spec/03-plugins/23-rate-limiting/04-access_spec.lua
+++ b/spec/03-plugins/23-rate-limiting/04-access_spec.lua
@@ -1,5 +1,7 @@
 local helpers           = require "spec.helpers"
 local cjson             = require "cjson"
+local redis             = require "resty.redis"
+local version           = require "version"
 
 
 local REDIS_HOST        = helpers.redis_host
@@ -51,6 +53,15 @@ local function GET(url, opt)
   client:close()
 
   return res
+end
+
+
+local function redis_connect()
+  local red = assert(redis:new())
+  red:set_timeout(2000)
+  assert(red:connect(REDIS_HOST, REDIS_PORT))
+  local red_version = string.match(red:info(), 'redis_version:([%g]+)\r\n')
+  return red, assert(version(red_version))
 end
 
 
@@ -1218,6 +1229,111 @@ if policy == "redis" then
 end     -- if policy == "redis" then
 
 end)
+
+if policy == "redis" then
+
+desc = fmt("Plugin: rate-limiting with sync_rate #db (access) [strategy: %s]", strategy)
+
+describe(desc, function ()
+  local https_server, admin_client
+
+  lazy_setup(function()
+    helpers.get_db_utils(strategy, nil, {
+      "rate-limiting",
+    })
+
+    https_server = helpers.https_server.new(UPSTREAM_PORT)
+    https_server:start()
+
+    assert(helpers.start_kong({
+      database   = strategy,
+      nginx_conf = "spec/fixtures/custom_nginx.template",
+      plugins = "bundled,rate-limiting,key-auth",
+      trusted_ips = "0.0.0.0/0,::/0",
+      lua_ssl_trusted_certificate = "spec/fixtures/redis/ca.crt",
+      log_level = "error"
+    }))
+
+  end)
+
+  lazy_teardown(function()
+    https_server:shutdown()
+    assert(helpers.stop_kong())
+  end)
+
+  before_each(function()
+    flush_redis()
+    admin_client = helpers.admin_client()
+  end)
+
+  after_each(function()
+    admin_client:close()
+  end)
+
+  it("blocks if exceeding limit", function ()
+    local test_path = "/test"
+
+    local service = setup_service(admin_client, UPSTREAM_URL)
+    local route = setup_route(admin_client, service, { test_path })
+    local rl_plugin = setup_rl_plugin(admin_client, {
+      minute              = 6,
+      policy              = "redis",
+      limit_by            = "ip",
+      redis_host          = REDIS_HOST,
+      redis_port          = REDIS_PORT,
+      redis_password      = REDIS_PASSWORD,
+      redis_database      = REDIS_DATABASE,
+      redis_ssl           = false,
+      sync_rate           = 10,
+    }, service)
+    local red = redis_connect()
+    local ok, err = red:select(REDIS_DATABASE)
+    if not ok then
+      error("failed to change Redis database: " .. err)
+    end
+
+    finally(function()
+      delete_plugin(admin_client, rl_plugin)
+      delete_route(admin_client, route)
+      delete_service(admin_client, service)
+      red:close()
+      os.execute("cat servroot/logs/error.log")
+    end)
+
+    helpers.wait_for_all_config_update({
+      override_global_rate_limiting_plugin = true,
+    })
+
+    -- initially, the metrics are not written to the redis
+    assert(red:dbsize() == 0, "redis db should be empty, but got " .. red:dbsize())
+
+    retry(function ()
+      -- exceed the limit
+      for _i = 0, 7 do
+        GET(test_path)
+      end
+
+      -- exceed the limit locally
+      assert.res_status(429, GET(test_path))
+
+      -- wait for the metrics to be written to the redis
+      helpers.pwait_until(function()
+        GET(test_path)
+        assert(red:dbsize() == 1, "redis db should have 1 key, but got " .. red:dbsize())
+      end, 15)
+
+      -- wait for the metrics expire
+      helpers.pwait_until(function()
+        assert.res_status(200, GET(test_path))
+      end, 61)
+
+    end)
+
+  end)  -- it("blocks if exceeding limit", function ()
+
+end)
+
+end     -- if policy == "redis" then
 
 end     -- for __, policy in ipairs({ "local", "cluster", "redis" }) do
 


### PR DESCRIPTION
### Summary

<del>**BLOCKED BY https://github.com/Kong/kong/pull/9764**</del> :white_check_mark:

Adds a new configuration `sync_rate` to the `redis` policy, which synchronizes metrics to redis periodically instead of on every request.

### Checklist

- [x] changelog
- [x] tests
- [ ] cherry-pick to EE

### Issue reference

Fix _FT-3464_
Fix #8729
