### PR TITLE
style(plugin_server): small code clean for plugin server 

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -801,7 +801,7 @@ function Kong.init_worker()
 
   runloop.init_worker.after()
 
-  if is_not_control_plane and worker_id() == 0 then
+  if is_not_control_plane then
     plugin_servers.start()
   end
 
@@ -812,7 +812,7 @@ end
 
 
 function Kong.exit_worker()
-  if process.type() ~= "privileged agent" and kong.configuration.role ~= "control_plane" and worker_id() == 0 then
+  if process.type() ~= "privileged agent" and kong.configuration.role ~= "control_plane" then
     plugin_servers.stop()
   end
 end

--- a/kong/runloop/plugin_servers/init.lua
+++ b/kong/runloop/plugin_servers/init.lua
@@ -335,7 +335,6 @@ end
 
 function plugin_servers.start()
   if worker_id() ~= 0 then
-    kong.log.notice("only worker #0 can manage")
     return
   end
 
@@ -350,7 +349,6 @@ end
 
 function plugin_servers.stop()
   if worker_id() ~= 0 then
-    kong.log.notice("only worker #0 can manage")
     return
   end
 

--- a/kong/runloop/plugin_servers/init.lua
+++ b/kong/runloop/plugin_servers/init.lua
@@ -15,9 +15,6 @@ local kong = kong
 local ngx_var = ngx.var
 local ngx_sleep = ngx.sleep
 local worker_id = ngx.worker.id
-local req_get_headers = ngx.req.get_headers
-local resp_get_headers = ngx.resp.get_headers
-local req_start_time = ngx.req.start_time
 
 local coroutine_running = coroutine.running
 local get_plugin_info = proc_mgmt.get_plugin_info
@@ -130,7 +127,7 @@ local exposed_api = {
 
   ["kong.nginx.req_start_time"] = function()
     local saved = get_saved()
-    return saved and saved.req_start_time or req_start_time()
+    return saved and saved.req_start_time or ngx.req.start_time()
   end,
 }
 
@@ -279,10 +276,10 @@ local function build_phases(plugin)
           serialize_data = kong.log.serialize(),
           ngx_ctx = clone(ngx.ctx),
           ctx_shared = kong.ctx.shared,
-          request_headers = is_http and req_get_headers(100) or nil,
-          response_headers = is_http and resp_get_headers(100) or nil,
+          request_headers = is_http and ngx.req.get_headers(100) or nil,
+          response_headers = is_http and ngx.resp.get_headers(100) or nil,
           response_status = ngx.status,
-          req_start_time = req_start_time(),
+          req_start_time = ngx.req.start_time(),
         })
       end
 

--- a/kong/runloop/plugin_servers/init.lua
+++ b/kong/runloop/plugin_servers/init.lua
@@ -15,6 +15,7 @@ local kong = kong
 local ngx_var = ngx.var
 local ngx_sleep = ngx.sleep
 local worker_id = ngx.worker.id
+local req_start_time = ngx.req.start_time
 
 local coroutine_running = coroutine.running
 local get_plugin_info = proc_mgmt.get_plugin_info
@@ -24,6 +25,14 @@ local is_http = ngx.config.subsystem == "http"
 
 local cjson_encode = cjson.encode
 local native_timer_at = _G.native_timer_at or ngx.timer.at
+
+local req_get_headers
+local resp_get_headers
+
+if is_http then
+  req_get_headers  = ngx.req.get_headers
+  resp_get_headers = ngx.resp.get_headers
+end
 
 
 --- keep request data a bit longer, into the log timer
@@ -127,7 +136,7 @@ local exposed_api = {
 
   ["kong.nginx.req_start_time"] = function()
     local saved = get_saved()
-    return saved and saved.req_start_time or ngx.req.start_time()
+    return saved and saved.req_start_time or req_start_time()
   end,
 }
 
@@ -276,10 +285,10 @@ local function build_phases(plugin)
           serialize_data = kong.log.serialize(),
           ngx_ctx = clone(ngx.ctx),
           ctx_shared = kong.ctx.shared,
-          request_headers = is_http and ngx.req.get_headers(100) or nil,
-          response_headers = is_http and ngx.resp.get_headers(100) or nil,
+          request_headers = is_http and req_get_headers(100) or nil,
+          response_headers = is_http and resp_get_headers(100) or nil,
           response_status = ngx.status,
-          req_start_time = ngx.req.start_time(),
+          req_start_time = req_start_time(),
         })
       end
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Due to PR #9342 #9546 #9547, 
We should do some code clean to fit these changes.

### Full changelog

* use `get_saved()` in  `kong.nginx.req_start_time`
* check `ngx.config.subsystem == "http"` in module scope
* remove 'log.notice' when `worker_id() ~= 0`
* remove check of worker id in `init.lua`, because plugin server did the same thing.
* if it is http subsystem then we localize `ngx.req.get_headers` `ngx.resp.get_headers`
* if it is stream subsystem then `req_get_headers` will do nothing


