### PR TITLE
fix(url): adjust the pulp admin api links

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,9 +11,9 @@ pipeline {
         DOCKER_PASSWORD = "${env.DOCKER_CREDENTIALS_PSW}"
         KONG_PACKAGE_NAME = "kong"
         DOCKER_CLI_EXPERIMENTAL = "enabled"
-        PULP_HOST_PROD = "https://api.pulp.konnect-prod.konghq.com"
+        PULP_HOST_PROD = "https://api.download.konghq.com"
         PULP_PROD = credentials('PULP')
-        PULP_HOST_STAGE = "https://api.pulp.konnect-stage.konghq.com"
+        PULP_HOST_STAGE = "https://api.download-dev.konghq.com"
         PULP_STAGE = credentials('PULP_STAGE')
         GITHUB_TOKEN = credentials('github_bot_access_token')
         DEBUG = 0


### PR DESCRIPTION
We changed the pulp admin api domain. Recreating the previous one is going to require some additional effort. For the purposes of the 2.8.2 release this should get us over the finish line