### PR TITLE
style(router/atc): define constant LOGICAL_AND/OR

### DIFF
--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -49,6 +49,10 @@ local MAX_REQ_HEADERS  = 100
 local DEFAULT_MATCH_LRUCACHE_SIZE = utils.DEFAULT_MATCH_LRUCACHE_SIZE
 
 
+local LOGICAL_OR  = " || "
+local LOGICAL_AND = " && "
+
+
 -- reuse table objects
 local gen_values_t = tb_new(10, 0)
 
@@ -110,7 +114,7 @@ local function gen_for_field(name, op, vals, val_transform)
   end
 
   if values_n > 0 then
-    return "(" .. tb_concat(values, " || ") .. ")"
+    return "(" .. tb_concat(values, LOGICAL_OR) .. ")"
   end
 
   return nil
@@ -556,6 +560,9 @@ function _M._set_ngx(mock_ngx)
   end
 end
 
+
+_M.LOGICAL_OR      = LOGICAL_OR
+_M.LOGICAL_AND     = LOGICAL_AND
 
 _M.escape_str      = escape_str
 _M.is_empty_field  = is_empty_field

--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -55,8 +55,8 @@ local OP_POSTFIX  = "=^"
 local OP_REGEX    = "~"
 
 
-local LOGICAL_OR  = " || "
-local LOGICAL_AND = " && "
+local LOGICAL_OR  = atc.LOGICAL_OR
+local LOGICAL_AND = atc.LOGICAL_AND
 
 
 local function get_expression(route)

--- a/kong/router/expressions.lua
+++ b/kong/router/expressions.lua
@@ -5,7 +5,8 @@ local atc = require("kong.router.atc")
 local gen_for_field = atc.gen_for_field
 
 
-local OP_EQUAL = "=="
+local OP_EQUAL    = "=="
+local LOGICAL_AND = atc.LOGICAL_AND
 
 
 local function get_exp_and_priority(route)
@@ -16,7 +17,7 @@ local function get_exp_and_priority(route)
 
   local gen = gen_for_field("net.protocol", OP_EQUAL, route.protocols)
   if gen then
-    exp = exp .. " && " .. gen
+    exp = exp .. LOGICAL_AND .. gen
   end
 
   return exp, route.priority


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Define constant `LOGICAL_AND` `LOGICAL_OR` in `atc.lua`,
then use them in other Lua modules.


