### PR TITLE
fix(request-transformer): preserves empty json arrays after decoding and re-encoding

### DIFF
--- a/kong/plugins/request-transformer/access.lua
+++ b/kong/plugins/request-transformer/access.lua
@@ -1,5 +1,5 @@
 local multipart = require "multipart"
-local cjson = require "cjson"
+local cjson = require("cjson.safe").new()
 local pl_template = require "pl.template"
 local pl_tablex = require "pl.tablex"
 
@@ -19,7 +19,6 @@ local encode_args = ngx.encode_args
 local ngx_decode_args = ngx.decode_args
 local type = type
 local str_find = string.find
-local pcall = pcall
 local pairs = pairs
 local error = error
 local rawset = rawset
@@ -42,12 +41,12 @@ local compile_opts = {
 }
 
 
+cjson.decode_array_with_array_mt(true)
+
+
 local function parse_json(body)
   if body then
-    local status, res = pcall(cjson.decode, body)
-    if status then
-      return res
-    end
+    return cjson.decode(body)
   end
 end
 
@@ -344,7 +343,7 @@ local function transform_json_body(conf, body, content_length)
   end
 
   if removed or renamed or replaced or added or appended then
-    return true, cjson.encode(parameters)
+    return true, assert(cjson.encode(parameters))
   end
 end
 

--- a/spec/03-plugins/36-request-transformer/02-access_spec.lua
+++ b/spec/03-plugins/36-request-transformer/02-access_spec.lua
@@ -679,6 +679,21 @@ describe("Plugin: request-transformer(access) [#" .. strategy .. "]", function()
       local value = assert.request(r).has.queryparam("q2")
       assert.equals("v2", value)
     end)
+    it("preserves empty json array", function()
+      local r = assert(client:send {
+        method = "POST",
+        path = "/request",
+        body = [[{"emptyarray":[]}]],
+        headers = {
+          host = "test4.test",
+          ["content-type"] = "application/json"
+        }
+      })
+      assert.response(r).has.status(200)
+      assert.response(r).has.jsonbody()
+      local json = assert.request(r).has.jsonbody()
+      assert.equals("{\"emptyarray\":[]}", json.data)
+    end)
   end)
 
   describe("rename", function()
@@ -826,6 +841,21 @@ describe("Plugin: request-transformer(access) [#" .. strategy .. "]", function()
       assert.equals("true", value1)
       local value2 = assert.request(r).has.queryparam("nottorename")
       assert.equals("true", value2)
+    end)
+    it("preserves empty json array", function()
+      local r = assert(client:send {
+        method = "POST",
+        path = "/request",
+        body = [[{"emptyarray":[]}]],
+        headers = {
+          host = "test9.test",
+          ["content-type"] = "application/json"
+        }
+      })
+      assert.response(r).has.status(200)
+      assert.response(r).has.jsonbody()
+      local json = assert.request(r).has.jsonbody()
+      assert.equals("{\"emptyarray\":[]}", json.data)
     end)
   end)
 
@@ -1180,6 +1210,21 @@ describe("Plugin: request-transformer(access) [#" .. strategy .. "]", function()
       local value = assert.request(r).has.queryparam("q2")
       assert.equals("v2", value)
     end)
+    it("preserves empty json array", function()
+      local r = assert(client:send {
+        method = "POST",
+        path = "/request",
+        body = [[{"emptyarray":[], "p1":"v"}]],
+        headers = {
+          host = "test5.test",
+          ["content-type"] = "application/json"
+        }
+      })
+      assert.response(r).has.status(200)
+      assert.response(r).has.jsonbody()
+      local json = assert.request(r).has.jsonbody()
+      assert.is_truthy(string.find(json.data, "\"emptyarray\":[]", 1, true))
+    end)
 
     pending("escape UTF-8 characters when replacing upstream path - enable after Kong 2.4", function()
       local r = assert(client:send {
@@ -1399,6 +1444,21 @@ describe("Plugin: request-transformer(access) [#" .. strategy .. "]", function()
       local value = assert.has.header("host", json)
       assert.equals("test2.test", value)
     end)
+    it("preserves empty json array", function()
+      local r = assert(client:send {
+        method = "POST",
+        path = "/request",
+        body = [[{"emptyarray":[]}]],
+        headers = {
+          host = "test1.test",
+          ["content-type"] = "application/json"
+        }
+      })
+      assert.response(r).has.status(200)
+      assert.response(r).has.jsonbody()
+      local json = assert.request(r).has.jsonbody()
+      assert.is_truthy(string.find(json.data, "\"emptyarray\":[]", 1, true))
+    end)
   end)
 
   describe("append ", function()
@@ -1554,6 +1614,21 @@ describe("Plugin: request-transformer(access) [#" .. strategy .. "]", function()
       assert.response(r).has.jsonbody()
       local value = assert.request(r).has.formparam("p1")
       assert.equals("This should not change", value)
+    end)
+    it("preserves empty json array", function()
+      local r = assert(client:send {
+        method = "POST",
+        path = "/request",
+        body = [[{"emptyarray":[]}]],
+        headers = {
+          host = "test6.test",
+          ["content-type"] = "application/json"
+        }
+      })
+      assert.response(r).has.status(200)
+      assert.response(r).has.jsonbody()
+      local json = assert.request(r).has.jsonbody()
+      assert.is_truthy(string.find(json.data, "\"emptyarray\":[]", 1, true))
     end)
   end)
 
@@ -1958,6 +2033,21 @@ describe("Plugin: request-transformer(access) [#" .. strategy .. "]", function()
       assert.equals("a2", value[2])
       local value = assert.request(r).has.queryparam("q1")
       assert.equals("20", value)
+    end)
+    it("preserves empty json array", function()
+      local r = assert(client:send {
+        method = "POST",
+        path = "/request",
+        body = [[{"emptyarray":[]}]],
+        headers = {
+          host = "test3.test",
+          ["content-type"] = "application/json"
+        }
+      })
+      assert.response(r).has.status(200)
+      assert.response(r).has.jsonbody()
+      local json = assert.request(r).has.jsonbody()
+      assert.is_truthy(string.find(json.data, "\"emptyarray\":[]", 1, true))
     end)
   end)
 


### PR DESCRIPTION
backport FTI-4205

[The original PR](https://github.com/Kong/kong/pull/9186)
