### PR TITLE
fix(http-log): internal error during validating the schema if http_endpoint contains userinfo but headers is empty (backport FTI-4173)

### DIFF
--- a/kong/plugins/http-log/schema.lua
+++ b/kong/plugins/http-log/schema.lua
@@ -40,7 +40,7 @@ return {
         custom_validator = function(config)
           -- check no double userinfo + authorization header
           local parsed_url = url.parse(config.http_endpoint)
-          if parsed_url.userinfo and config.headers then
+          if parsed_url.userinfo and config.headers and config.headers ~= ngx.null then
             for hname, hvalue in pairs(config.headers) do
               if hname:lower() == "authorization" then
                 return false, "specifying both an 'Authorization' header and user info in 'http_endpoint' is not allowed"

--- a/spec/03-plugins/03-http-log/02-schema_spec.lua
+++ b/spec/03-plugins/03-http-log/02-schema_spec.lua
@@ -23,6 +23,14 @@ describe(PLUGIN_NAME .. ": (schema)", function()
     assert.is_truthy(ok)
   end)
 
+  it("accepts empty headers with username/password in the http_endpoint", function()
+    local ok, err = validate({
+        http_endpoint = "http://bob:password@myservice.com/path",
+      })
+    assert.is_nil(err)
+    assert.is_truthy(ok)
+  end)
+
   it("accepts custom fields by lua", function()
     local ok, err = validate({
         http_endpoint = "http://myservice.com/path",


### PR DESCRIPTION
[The original PR](https://github.com/Kong/kong/pull/9257)

fix(http-log): internal error during validating the schema if `http_endpoint` contains userinfo but `headers` is empty

The missing field will be filled with an appropriate default value
in function `handle_missing_field`. When no explicit defualt value
is set and the field isn't nilable and required, then its default
value will be ngx.null, which is a lightuserdata with the point NULL.

FTI-4173