### PR TITLE
fix(core): ensure absolute path is used for event sock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,10 @@
 - Fix issue in router rebuilding where when paths field is invalid,
   the router's mutex is not released properly.
   [#9480](https://github.com/Kong/kong/pull/9480)
+- Fixed an issue where `kong docker-start` would fail if KONG_PREFIX was set to
+  a relative path. [#9337](https://github.com/Kong/kong/pull/9337)
+- Fixed an issue with error-handling and process cleanup in `kong start`.
+  [#9337](https://github.com/Kong/kong/pull/9337)
 
 ## [3.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,8 +81,9 @@
 - Fix issue in router rebuilding where when paths field is invalid,
   the router's mutex is not released properly.
   [#9480](https://github.com/Kong/kong/pull/9480)
-- Fixed an issue where `kong docker-start` would fail if KONG_PREFIX was set to
-  a relative path. [#9337](https://github.com/Kong/kong/pull/9337)
+- Fixed an issue where `kong docker-start` would fail if `KONG_PREFIX` was set to
+  a relative path.
+  [#9337](https://github.com/Kong/kong/pull/9337)
 - Fixed an issue with error-handling and process cleanup in `kong start`.
   [#9337](https://github.com/Kong/kong/pull/9337)
 

--- a/kong/cmd/start.lua
+++ b/kong/cmd/start.lua
@@ -107,7 +107,7 @@ local function execute(args)
 
   if err then
     log.verbose("could not start Kong, stopping services")
-    pcall(nginx_signals.stop(conf))
+    pcall(nginx_signals.stop, conf)
     log.verbose("stopped services")
     error(err) -- report to main error handler
   end

--- a/kong/global.lua
+++ b/kong/global.lua
@@ -186,16 +186,22 @@ function _GLOBAL.init_worker_events()
     worker_events = require "resty.worker.events"
 
   else
-    local sock_name = "worker_events.sock"
-    if ngx.config.subsystem == "stream" then
-      sock_name = "stream_" .. sock_name
-    end
+    -- `kong.configuration.prefix` is already normalized to an absolute path,
+    -- but `ngx.config.prefix()` is not
+    local prefix = configuration
+                   and configuration.prefix
+                   or require("pl.path").abspath(ngx.config.prefix())
+
+    local sock = ngx.config.subsystem == "stream"
+                 and "stream_worker_events.sock"
+                 or "worker_events.sock"
+
+    local listening = "unix:" .. prefix .. "/" .. sock
 
     opts = {
       unique_timeout = 5,     -- life time of unique event data in lrucache
       broker_id = 0,          -- broker server runs in nginx worker #0
-      listening = "unix:" ..  -- unix socket for broker listening
-                  ngx.config.prefix() .. sock_name,
+      listening = listening,  -- unix socket for broker listening
       max_queue_len = 1024 * 50,  -- max queue len for events buffering
     }
 

--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -795,5 +795,65 @@ describe("kong start/stop #" .. strategy, function()
     end)
   end)
 
+  describe("docker-start", function()
+    -- tests here are meant to emulate the behavior of `kong docker-start`, which
+    -- is a fake CLI command found in our default docker entrypoint:
+    --
+    -- https://github.com/Kong/docker-kong/blob/d588854aaeeab7ac39a0e801e9e6a1ded2f65963/docker-entrypoint.sh
+    --
+    -- this is the only(?) context where nginx is typically invoked directly
+    -- instead of first going through `kong.cmd.start`, so it has some subtle
+    -- differences
+
+    it("works with resty.events when KONG_PREFIX is a relative path", function()
+      local prefix = "relpath"
+
+      finally(function()
+        helpers.kill_all(prefix)
+        pcall(helpers.dir.rmtree, prefix)
+      end)
+
+      assert(helpers.kong_exec(string.format("prepare -p %q", prefix), {
+        db = strategy,
+        proxy_listen = "127.0.0.1:8000",
+        stream_listen = "127.0.0.1:9000",
+        admin_listen  = "127.0.0.1:8001",
+      }))
+
+      local nginx, err = require("kong.cmd.utils.nginx_signals").find_nginx_bin()
+      assert.is_string(nginx, err)
+
+      local started
+      started, err = helpers.execute(string.format("%s -p %q -c nginx.conf",
+                                    nginx, prefix))
+
+      assert.truthy(started, "starting Kong failed: " .. tostring(err))
+
+      -- wait until everything is running
+      helpers.wait_until(function()
+        local client = helpers.admin_client(5000, 8001)
+        local res, rerr = client:send({
+          method = "GET",
+          path = "/",
+        })
+
+        if res then res:read_body() end
+        client:close()
+
+        assert.is_table(res, rerr)
+
+        return res.status == 200
+      end)
+
+      assert.truthy(helpers.path.exists(prefix .. "/worker_events.sock"))
+      assert.truthy(helpers.path.exists(prefix .. "/stream_worker_events.sock"))
+
+      assert.logfile(prefix .. "/logs/error.log").has.no.line("[error]", true)
+      assert.logfile(prefix .. "/logs/error.log").has.no.line("[alert]", true)
+      assert.logfile(prefix .. "/logs/error.log").has.no.line("[crit]", true)
+      assert.logfile(prefix .. "/logs/error.log").has.no.line("[emerg]", true)
+    end)
+  end)
+
 end)
 end

--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -814,7 +814,7 @@ describe("kong start/stop #" .. strategy, function()
       end)
 
       assert(helpers.kong_exec(string.format("prepare -p %q", prefix), {
-        db = strategy,
+        database = strategy,
         proxy_listen = "127.0.0.1:8000",
         stream_listen = "127.0.0.1:9000",
         admin_listen  = "127.0.0.1:8001",


### PR DESCRIPTION
Cherry-pick of #9337 for kong 3.0.1
