### PR TITLE
fix(plugins/zipkin): correctly parse `ot` baggage headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,13 @@
 
 #### Core
 
+- Fix issue where external plugins crashing with unhandled exceptions
+  would cause high CPU utilization after the automatic restart.
+  [#9384](https://github.com/Kong/kong/pull/9384)
+- Fix issue where Zipkin plugin cannot parse OT baggage headers
+  due to invalid OT baggage pattern. [#9280](https://github.com/Kong/kong/pull/9280)
+- Add `use_srv_name` options to upstream for balancer.
+  [#9430](https://github.com/Kong/kong/pull/9430)
 - Fix issue in `header_filter` instrumentation where the span was not
   correctly created.
   [#9434](https://github.com/Kong/kong/pull/9434)

--- a/kong/tracing/propagation.lua
+++ b/kong/tracing/propagation.lua
@@ -19,7 +19,7 @@ local B3_SINGLE_PATTERN =
 local W3C_TRACECONTEXT_PATTERN = "^(%x+)%-(%x+)%-(%x+)%-(%x+)$"
 local JAEGER_TRACECONTEXT_PATTERN = "^(%x+):(%x+):(%x+):(%x+)$"
 local JAEGER_BAGGAGE_PATTERN = "^uberctx%-(.*)$"
-local OT_BAGGAGE_PATTERN = "^ot-baggage%-(.*)$"
+local OT_BAGGAGE_PATTERN = "^ot%-baggage%-(.*)$"
 
 local function hex_to_char(c)
   return char(tonumber(c, 16))

--- a/spec/01-unit/26-tracing/02-propagation_spec.lua
+++ b/spec/01-unit/26-tracing/02-propagation_spec.lua
@@ -559,6 +559,34 @@ describe("propagation.parse", function()
       assert.same({ "ot", big_trace_id_32, nil, big_span_id }, to_hex_ids(t))
       assert.spy(warn).not_called()
     end)
+
+    it("valid trace_id, valid span_id, sampled, valid baggage added", function()
+      local mock_key = "mock_key"
+      local mock_value = "mock_value"
+      local t = { parse({
+        ["ot-tracer-traceid"] = trace_id,
+        ["ot-tracer-spanid"] = span_id,
+        ["ot-tracer-sampled"] = "1",
+        ["ot-baggage-"..mock_key] = mock_value
+      })}
+      local mock_baggage_index = t[6]
+      assert.same({ "ot", trace_id, nil, span_id, true }, to_hex_ids(t))
+      assert.same(mock_baggage_index.mock_key, mock_value)
+      assert.spy(warn).not_called()
+    end)
+
+    it("valid trace_id, valid span_id, sampled, invalid baggage added", function()
+      local t = { parse({
+        ["ot-tracer-traceid"] = trace_id,
+        ["ot-tracer-spanid"] = span_id,
+        ["ot-tracer-sampled"] = "1",
+        ["ottttttttbaggage-foo"] = "invalid header"
+      })}
+      local mock_baggage_index = t[6]
+      assert.same({ "ot", trace_id, nil, span_id, true }, to_hex_ids(t))
+      assert.same(mock_baggage_index, nil)
+      assert.spy(warn).not_called()
+    end)
   end)
 end)
 


### PR DESCRIPTION
cherry-pick of #9280

Co-authored-by: Mayo <mayocream39@yahoo.co.jp>
Co-authored-by: Wangchong Zhou <fffonion@gmail.com>
