### PR TITLE
fix(aws-lambda): accept only true|false|nil for isBase64Encode

### DIFF
--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -145,9 +145,12 @@ local function extract_proxy_response(content)
 
   local headers = serialized_content.headers or {}
   local body = serialized_content.body or ""
-  local isBase64Encoded = serialized_content.isBase64Encoded or false
-  if isBase64Encoded then
+  local isBase64Encoded = serialized_content.isBase64Encoded
+  if isBase64Encoded == true then
     body = ngx_decode_base64(body)
+
+  elseif isBase64Encoded ~= false and isBase64Encoded ~= nil then
+    return nil, "isBase64Encoded must be a boolean"
   end
 
   local multiValueHeaders = serialized_content.multiValueHeaders

--- a/spec/03-plugins/27-aws-lambda/99-access_spec.lua
+++ b/spec/03-plugins/27-aws-lambda/99-access_spec.lua
@@ -141,6 +141,17 @@ for _, strategy in helpers.each_strategy() do
         service     = null,
       }
 
+      local route22 = bp.routes:insert {
+        hosts       = { "lambda22.com" },
+        protocols   = { "http", "https" },
+        service     = null,
+      }
+
+      local route23 = bp.routes:insert {
+        hosts       = { "lambda23.com" },
+        protocols   = { "http", "https" },
+        service     = null,
+      }
 
       bp.plugins:insert {
         name     = "aws-lambda",
@@ -426,6 +437,32 @@ for _, strategy in helpers.each_strategy() do
           function_name        = "functionEcho",
           proxy_url            = "http://127.0.0.1:13128",
           keepalive            = 1,
+        }
+      }
+
+      bp.plugins:insert {
+        name     = "aws-lambda",
+        route    = { id = route22.id },
+        config                 = {
+          port                 = 10001,
+          aws_key              = "mock-key",
+          aws_secret           = "mock-secret",
+          aws_region           = "us-east-1",
+          function_name        = "functionWithIllegalBase64EncodedResponse",
+          is_proxy_integration = true,
+        }
+      }
+
+      bp.plugins:insert {
+        name     = "aws-lambda",
+        route    = { id = route23.id },
+        config                 = {
+          port                 = 10001,
+          aws_key              = "mock-key",
+          aws_secret           = "mock-secret",
+          aws_region           = "us-east-1",
+          function_name        = "functionWithNotBase64EncodedResponse",
+          is_proxy_integration = true,
         }
       }
 
@@ -1019,6 +1056,30 @@ for _, strategy in helpers.each_strategy() do
           })
           assert.res_status(200, res)
           assert.equal("test", res:read_body())
+        end)
+
+        it("returns error response when isBase64Encoded is illegal from a Lambda function", function()
+          local res = assert(proxy_client:send {
+            method  = "GET",
+            path    = "/get?key1=some_value1&key2=some_value2&key3=some_value3",
+            headers = {
+              ["Host"] = "lambda22.com"
+            }
+          })
+          assert.res_status(502, res)
+          assert.is_true(not not string.find(res:read_body(), "isBase64Encoded must be a boolean"))
+        end)
+
+        it("returns raw body when isBase64Encoded is set to false from a Lambda function", function()
+          local res = assert(proxy_client:send {
+            method  = "GET",
+            path    = "/get?key1=some_value1&key2=some_value2&key3=some_value3",
+            headers = {
+              ["Host"] = "lambda23.com"
+            }
+          })
+          assert.res_status(200, res)
+          assert.equal("dGVzdA=", res:read_body())
         end)
 
         it("returns multivalueheaders response from a Lambda function", function()

--- a/spec/fixtures/aws-lambda.lua
+++ b/spec/fixtures/aws-lambda.lua
@@ -42,6 +42,12 @@ local fixtures = {
                     elseif string.match(ngx.var.uri, "functionWithBase64EncodedResponse") then
                       ngx.say("{\"statusCode\": 200, \"body\": \"dGVzdA==\", \"isBase64Encoded\": true}")
 
+                    elseif string.match(ngx.var.uri, "functionWithNotBase64EncodedResponse") then
+                      ngx.say("{\"statusCode\": 200, \"body\": \"dGVzdA=\", \"isBase64Encoded\": false}")
+
+                    elseif string.match(ngx.var.uri, "functionWithIllegalBase64EncodedResponse") then
+                      ngx.say("{\"statusCode\": 200, \"body\": \"dGVzdA=\", \"isBase64Encoded\": \"abc\"}")
+
                     elseif string.match(ngx.var.uri, "functionWithMultiValueHeadersResponse") then
                       ngx.say("{\"statusCode\": 200, \"headers\": { \"Age\": \"3600\"}, \"multiValueHeaders\": {\"Access-Control-Allow-Origin\": [\"site1.com\", \"site2.com\"]}}")
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

This PR changes the behaviour of extracting lambda response in the AWS-Lambda plugin. There will be 3 situations that are considered valid for the field `isBase64Encode`: true, false or not defined. Values that are not booleans or not nil are considered invalid and the plugin will return a 502 response.

Note that if a lambda response contains `"isBase64Encode": null`, then the value(turned into userdata `cjson.null` in Lua) will also be considered invalid.

### Full changelog

* Fix the behaviour of extracting lambda response that the value of isBase64Encode can only accept true, false or not defined.
* Add related tests

### Issue reference

Fix [FTI-4420]

### Other references

https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-output-format


[FTI-4420]: https://konghq.atlassian.net/browse/FTI-4420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ