### PR TITLE
chore(deps): bump lua-resty-openssl from 0.8.13 to 0.8.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,8 +140,9 @@
 
 - Bumped atc-router from 1.0.0 to 1.0.1
   [#9558](https://github.com/Kong/kong/pull/9558)
-- Bumped lua-resty-openssl from 0.8.10 to 0.8.13
+- Bumped lua-resty-openssl from 0.8.10 to 0.8.14
   [#9583](https://github.com/Kong/kong/pull/9583)
+- [#9600](https://github.com/Kong/kong/pull/9600)
 
 ### Additions
 

--- a/kong-3.1.0-0.rockspec
+++ b/kong-3.1.0-0.rockspec
@@ -36,7 +36,7 @@ dependencies = {
   "lua-resty-healthcheck == 1.6.1",
   "lua-resty-mlcache == 2.6.0",
   "lua-messagepack == 0.5.2",
-  "lua-resty-openssl == 0.8.13",
+  "lua-resty-openssl == 0.8.14",
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6.1",
   "lua-resty-acme == 0.8.1",


### PR DESCRIPTION
### Summary

#### [0.8.14] - 2022-10-21
##### bug fixes
- **x509.crl:** fix metamethods when revoked is empty ([#79](https://github.com/fffonion/lua-resty-openssl/issues/79)) [e65adc7](https://github.com/fffonion/lua-resty-openssl/commit/e65adc7f132628c97e4db69cb5c4b13ff9cf0abf)