### PR TITLE
fix(router/atc): exports atc.schema for entities checking

### DIFF
--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -1,7 +1,8 @@
 local typedefs = require("kong.db.schema.typedefs")
-local atc = require("kong.router.atc")
 local router = require("resty.router.router")
 local deprecation = require("kong.deprecation")
+
+local CACHED_SCHEMA = require("kong.router.atc").get_schema()
 
 local kong_router_flavor = kong and kong.configuration and kong.configuration.router_flavor
 
@@ -47,8 +48,7 @@ if kong_router_flavor == "expressions" then
       { custom_entity_check = {
         field_sources = { "expression", "id", },
         fn = function(entity)
-          local s = atc.get_schema()
-          local r = router.new(s)
+          local r = router.new(CACHED_SCHEMA)
 
           local res, err = r:add_matcher(0, entity.id, entity.expression)
           if not res then

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -2,7 +2,7 @@ local typedefs = require("kong.db.schema.typedefs")
 local router = require("resty.router.router")
 local deprecation = require("kong.deprecation")
 
-local CACHED_SCHEMA = require("kong.router.atc").get_schema()
+local CACHED_SCHEMA = require("kong.router.atc").schema
 
 local kong_router_flavor = kong and kong.configuration and kong.configuration.router_flavor
 

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -554,11 +554,6 @@ function _M:exec(ctx)
 end
 
 
-function _M.get_schema()
-  return CACHED_SCHEMA
-end
-
-
 function _M._set_ngx(mock_ngx)
   if type(mock_ngx) ~= "table" then
     return
@@ -587,6 +582,8 @@ function _M._set_ngx(mock_ngx)
   end
 end
 
+
+_M.schema          = CACHED_SCHEMA
 
 _M.LOGICAL_OR      = LOGICAL_OR
 _M.LOGICAL_AND     = LOGICAL_AND

--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -554,6 +554,11 @@ function _M:exec(ctx)
 end
 
 
+function _M.get_schema()
+  return CACHED_SCHEMA
+end
+
+
 function _M._set_ngx(mock_ngx)
   if type(mock_ngx) ~= "table" then
     return

--- a/spec/01-unit/01-db/01-schema/06-routes_spec.lua
+++ b/spec/01-unit/01-db/01-schema/06-routes_spec.lua
@@ -1,25 +1,41 @@
-local routes = require "kong.db.schema.entities.routes"
-local routes_subschemas = require "kong.db.schema.entities.routes_subschemas"
 local services = require "kong.db.schema.entities.services"
 local Schema = require "kong.db.schema"
 local certificates = require "kong.db.schema.entities.certificates"
 local Entity       = require "kong.db.schema.entity"
 
-assert(Schema.new(certificates))
-assert(Schema.new(services))
-local Routes = assert(Entity.new(routes))
+local Routes
 
-for name, subschema in pairs(routes_subschemas) do
-  Routes:new_subschema(name, subschema)
+local function reload_flavor(flavor)
+  _G.kong = {
+    configuration = {
+      router_flavor = flavor,
+    },
+  }
+
+  package.loaded["kong.db.schema.entities.routes"] = nil
+  package.loaded["kong.db.schema.entities.routes_subschemas"] = nil
+
+  local routes = require "kong.db.schema.entities.routes"
+  local routes_subschemas = require "kong.db.schema.entities.routes_subschemas"
+
+  assert(Schema.new(certificates))
+  assert(Schema.new(services))
+  Routes = assert(Entity.new(routes))
+
+  for name, subschema in pairs(routes_subschemas) do
+    Routes:new_subschema(name, subschema)
+  end
 end
 
 
-describe("routes schema", function()
+describe("routes schema (flavor = traditional/traditional_compatible)", function()
   local a_valid_uuid = "cbb297c0-a956-486d-ad1d-f9b42df9465a"
   local another_uuid = "64a8670b-900f-44e7-a900-6ec7ef5aa4d3"
   local uuid_pattern = "^" .. ("%x"):rep(8) .. "%-" .. ("%x"):rep(4) .. "%-"
                            .. ("%x"):rep(4) .. "%-" .. ("%x"):rep(4) .. "%-"
                            .. ("%x"):rep(12) .. "$"
+
+  reload_flavor("traditional")
 
   it("validates a valid route", function()
     local route = {
@@ -1206,5 +1222,60 @@ describe("routes schema", function()
     assert.same({
       ["@entity"] =  { "must set snis when 'protocols' is 'tls_passthrough'" },
     }, errs)
+  end)
+end)
+
+
+describe("routes schema (flavor = expressions)", function()
+  local a_valid_uuid = "cbb297c0-a956-486d-ad1d-f9b42df9465a"
+  local another_uuid = "64a8670b-900f-44e7-a900-6ec7ef5aa4d3"
+
+  reload_flavor("expressions")
+
+  it("validates a valid route", function()
+    local route = {
+      id             = a_valid_uuid,
+      name           = "my_route",
+      protocols      = { "http" },
+      expression     = [[(http.method == "GET")]],
+      priority       = 100,
+      strip_path     = false,
+      preserve_host  = true,
+      service        = { id = another_uuid },
+    }
+    route = Routes:process_auto_fields(route, "insert")
+    assert.truthy(route.created_at)
+    assert.truthy(route.updated_at)
+    assert.same(route.created_at, route.updated_at)
+    assert.truthy(Routes:validate(route))
+    assert.falsy(route.strip_path)
+  end)
+
+  it("fails when priority is missing", function()
+    local route = { priority = ngx.null }
+    route = Routes:process_auto_fields(route, "insert")
+    local ok, errs = Routes:validate_insert(route)
+    assert.falsy(ok)
+    assert.truthy(errs["priority"])
+  end)
+
+  it("fails when expression is missing", function()
+    local route = { expression = ngx.null }
+    route = Routes:process_auto_fields(route, "insert")
+    local ok, errs = Routes:validate_insert(route)
+    assert.falsy(ok)
+    assert.truthy(errs["expression"])
+  end)
+
+  it("fails given an invalid expression", function()
+    local route = {
+      protocols  = { "http" },
+      priority   = 100,
+      expression = [[(http.method == "GET") &&]],
+    }
+    route = Routes:process_auto_fields(route, "insert")
+    local ok, errs = Routes:validate(route)
+    assert.falsy(ok)
+    assert.truthy(errs["@entity"])
   end)
 end)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

When we did code clean for atc-router(#9331), we removed function `get_schema()` unwisely,
which is used in DB schema entity checking.

See [`schema/entities/routes.lua`](https://github.com/Kong/kong/blob/e7b6963f8c01c11232828d2709de08743708bf56/kong/db/schema/entities/routes.lua#L50).


