### PR TITLE
chore(deps): bump lyaml from 6.2.7 to 6.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,7 +149,10 @@
   [#9558](https://github.com/Kong/kong/pull/9558)
 - Bumped lua-resty-openssl from 0.8.10 to 0.8.14
   [#9583](https://github.com/Kong/kong/pull/9583)
-- [#9600](https://github.com/Kong/kong/pull/9600)
+  [#9600](https://github.com/Kong/kong/pull/9600)
+- Bumped lyaml from 6.2.7 to 6.2.8
+  [#9607](https://github.com/Kong/kong/pull/9607)
+
 
 ### Additions
 

--- a/kong-3.1.0-0.rockspec
+++ b/kong-3.1.0-0.rockspec
@@ -26,7 +26,7 @@ dependencies = {
   "pgmoon == 1.15.0",
   "luatz == 0.4",
   "lua_system_constants == 0.1.4",
-  "lyaml == 6.2.7",
+  "lyaml == 6.2.8",
   "luasyslog == 2.0.1",
   "lua_pack == 2.0.0",
   "binaryheap >= 0.4",


### PR DESCRIPTION
### Summary

#### Bug fixes

- luke no longer crashes in std.normalize require loops occasionally in Lua 5.4.
- lyaml emitter no longer leaks at least six bytes for every map, sequence and scalar emitted.