### PR TITLE
fix(clustering): race cond for new DP and new cfg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,13 @@
 - Fixed an issue with error-handling and process cleanup in `kong start`.
   [#9337](https://github.com/Kong/kong/pull/9337)
 
+#### Hybrid Mode
+
+- Fixed a race condition that can cause configuration push events to be dropped
+  when the first data-plane connection is established with a control-plane
+  worker.
+  [#9616](https://github.com/Kong/kong/pull/9616)
+
 #### CLI
 
 - Fix slow CLI performance due to pending timer jobs

--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -553,7 +553,7 @@ local function push_config_loop(premature, self, push_config_semaphore, delay)
       if isempty(self.clients) then
         ngx_log(ngx_DEBUG, _log_prefix, "skipping config push (no connected clients)")
         sleep(1)
-        -- re-queue the task, wait util we have clients connected
+        -- re-queue the task. wait until we have clients connected
         if push_config_semaphore:count() <= 0 then
           push_config_semaphore:post()
         end

--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -551,6 +551,11 @@ local function push_config_loop(premature, self, push_config_semaphore, delay)
     if ok then
       if isempty(self.clients) then
         ngx_log(ngx_DEBUG, _log_prefix, "skipping config push (no connected clients)")
+        sleep(1)
+        -- re-queue the task, wait util we have clients connected
+        if push_config_semaphore:count() <= 0 then
+          push_config_semaphore:post()
+        end
 
       else
         ok, err = pcall(self.push_config, self)

--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -35,6 +35,7 @@ local sub = string.sub
 local gsub = string.gsub
 local deflate_gzip = utils.deflate_gzip
 local isempty = require("table.isempty")
+local sleep = ngx.sleep
 
 local calculate_config_hash = require("kong.clustering.config_helper").calculate_config_hash
 

--- a/kong/clustering/wrpc_control_plane.lua
+++ b/kong/clustering/wrpc_control_plane.lua
@@ -318,7 +318,7 @@ local function push_config_loop(premature, self, push_config_semaphore, delay)
       if isempty(self.clients) then
         ngx_log(ngx_DEBUG, _log_prefix, "skipping config push (no connected clients)")
         sleep(1)
-        -- re-queue the task, wait util we have clients connected
+        -- re-queue the task. wait until we have clients connected
         if push_config_semaphore:count() <= 0 then
           push_config_semaphore:post()
         end

--- a/kong/clustering/wrpc_control_plane.lua
+++ b/kong/clustering/wrpc_control_plane.lua
@@ -321,6 +321,7 @@ local function push_config_loop(premature, self, push_config_semaphore, delay)
         if push_config_semaphore:count() <= 0 then
           push_config_semaphore:post()
         end
+
       else
         ok, err = pcall(self.push_config, self)
         if ok then

--- a/kong/clustering/wrpc_control_plane.lua
+++ b/kong/clustering/wrpc_control_plane.lua
@@ -27,6 +27,7 @@ local ngx_time = ngx.time
 local ngx_var = ngx.var
 local timer_at = ngx.timer.at
 local isempty = require("table.isempty")
+local sleep = ngx.sleep
 
 local plugins_list_to_map = clustering_utils.plugins_list_to_map
 local deflate_gzip = utils.deflate_gzip

--- a/kong/clustering/wrpc_control_plane.lua
+++ b/kong/clustering/wrpc_control_plane.lua
@@ -316,7 +316,11 @@ local function push_config_loop(premature, self, push_config_semaphore, delay)
     if ok then
       if isempty(self.clients) then
         ngx_log(ngx_DEBUG, _log_prefix, "skipping config push (no connected clients)")
-
+        sleep(1)
+        -- re-queue the task, wait util we have clients connected
+        if push_config_semaphore:count() <= 0 then
+          push_config_semaphore:post()
+        end
       else
         ok, err = pcall(self.push_config, self)
         if ok then


### PR DESCRIPTION
1. When new DP connects, it first pushes config, then adds the DP to client lists;
1. When the client list is empty, `push_config_loop` skips handling of the new config signal, expect the config to be sent by logic no.1

This causes races when a new config comes in while the first DP is receiving its first config, and the config will be skipped as the list is empty. The new config won't be seen by that DP or any new DPs.

We fix that by re-posting the semaphore, so no config will be missed.

Co-authored-by: @flrgh for his diagnosis(don't forget to add this to the commit message)

fix FT-3496