### PR TITLE
chore(Github Action) fix job `lint-doc-and-unit-tests`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -116,7 +116,7 @@ jobs:
     - name: Lint Lua code
       run: |
           eval `luarocks path`
-          luacheck -q .
+          make lint
 
     - name: Validate rockspec file
       run: |


### PR DESCRIPTION
Now, CI don't check the `#o` or `#only` tag in busted tests, this PR fixed it.

_FT-3502_