### PR TITLE
chore(ci): fail on do-not-merge label

### DIFF
--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -1,0 +1,13 @@
+name: Pull Request Label Checker
+on:
+  pull_request:
+    types: [synchronize, opened, reopened, labeled, unlabeled]
+jobs:
+  check-labels:
+    name: prevent merge labels
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: do-not-merge label found
+      run: exit 1
+      if: ${{ contains(github.event.*.labels.*.name, 'do not merge') || contains(github.event.*.labels.*.name, 'do-not-merge') }}


### PR DESCRIPTION
### Summary

Add CI to prevent merging when `do-not-merge` or `do not merge` labels exist.

related: https://github.com/Kong/koko/pull/170