### PR TITLE
chore(ci): automatic rebasing on labeling `pr/rebase` or `pr/autosquash`

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -1,0 +1,32 @@
+name: Rebase Pull Request
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  main:
+    if: ${{ github.event.label.name == 'pr/rebase' || github.event.label.name == 'pr/autosquash' }}
+    name: Rebase
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the latest code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.PAT }}
+          fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
+
+      - name: Automatic Rebase
+        uses: cirrus-actions/rebase@1.7
+        with:
+          autosquash: ${{ github.event.label.name == 'pr/autosquash' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+
+      - name: remove label
+        if: always()
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: |
+            pr/rebase
+            pr/autosquash


### PR DESCRIPTION
This workflow is triggered by adding a label called rebase to your pull request. It uses the [automatic-rebase action](https://github.com/marketplace/actions/automatic-rebase) to perform the rebase, and [actions-ecosystem-remove-labels action](https://github.com/marketplace/actions/actions-ecosystem-remove-labels) to remove the label when complete. To use this, you’ll need to add the rebase label to your PR.