### PR TITLE
perf(router): increase `lua_regex_cache_max_entries` and show warning if too small

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,9 @@
 
 - Data plane's connection to control plane is moved to a privileged worker process
   [#9432](https://github.com/Kong/kong/pull/9432)
+- Increase the default value of `lua_regex_cache_max_entries`, a warning will be thrown
+  when there are too many regex routes and `router_flavor` is `traditional`.
+  [#9624](https://github.com/Kong/kong/pull/9624)
 
 ### Fixes
 

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1035,6 +1035,11 @@
                                             # at worst any regex Kong executes could finish within
                                             # roughly 2 seconds.
 
+#nginx_http_lua_regex_cache_max_entries = 8192  # Specifies the maximum number of entries allowed
+                                                # in the worker process level compiled regex cache.
+                                                # It is recommended to set it to at least (number of regex paths * 2)
+                                                # to avoid high CPU usages.
+
 #------------------------------------------------------------------------------
 # DATASTORE
 #------------------------------------------------------------------------------

--- a/kong/router/traditional.lua
+++ b/kong/router/traditional.lua
@@ -1452,7 +1452,8 @@ function _M.new(routes, cache, cache_neg)
 
   -- warning about the regex cache size being too small
   if not lua_regex_cache_max_entries then
-    lua_regex_cache_max_entries = kong.configuration.nginx_http_lua_regex_cache_max_entries or 1024
+    lua_regex_cache_max_entries = kong.configuration.nginx_http_lua_regex_cache_max_entries
+      and tonumber(kong.configuration.nginx_http_lua_regex_cache_max_entries) or 1024
   end
 
   if worker_id() == 0 and regex_uris[0] > lua_regex_cache_max_entries then

--- a/kong/router/traditional.lua
+++ b/kong/router/traditional.lua
@@ -1456,7 +1456,7 @@ function _M.new(routes, cache, cache_neg)
                               and tonumber(kong.configuration.nginx_http_lua_regex_cache_max_entries) or 1024
   end
 
-  if worker_id() == 0 and regex_uris[0] > lua_regex_cache_max_entries then
+  if worker_id() == 0 and regex_uris[0] * 2 > lua_regex_cache_max_entries then
     ngx_log(WARN, "the 'nginx_http_lua_regex_cache_max_entries' setting is set to ",
                    lua_regex_cache_max_entries,
                    " but there are ", regex_uris[0], " regex URIs in use. ",

--- a/kong/router/traditional.lua
+++ b/kong/router/traditional.lua
@@ -1453,7 +1453,7 @@ function _M.new(routes, cache, cache_neg)
   -- warning about the regex cache size being too small
   if not lua_regex_cache_max_entries then
     lua_regex_cache_max_entries = kong.configuration.nginx_http_lua_regex_cache_max_entries
-      and tonumber(kong.configuration.nginx_http_lua_regex_cache_max_entries) or 1024
+                              and tonumber(kong.configuration.nginx_http_lua_regex_cache_max_entries) or 1024
   end
 
   if worker_id() == 0 and regex_uris[0] > lua_regex_cache_max_entries then

--- a/kong/router/traditional.lua
+++ b/kong/router/traditional.lua
@@ -16,6 +16,7 @@ local re_find       = ngx.re.find
 local header        = ngx.header
 local var           = ngx.var
 local ngx_log       = ngx.log
+local worker_id     = ngx.worker.id
 local concat        = table.concat
 local sort          = table.sort
 local byte          = string.byte
@@ -208,6 +209,7 @@ local MAX_REQ_HEADERS = 100
 
 local match_route
 local reduce
+local lua_regex_cache_max_entries
 
 
 local function _set_ngx(mock_ngx)
@@ -1447,6 +1449,20 @@ function _M.new(routes, cache, cache_neg)
   local match_snis           = not isempty(plain_indexes.snis)
   local match_sources        = not isempty(plain_indexes.sources)
   local match_destinations   = not isempty(plain_indexes.destinations)
+
+  -- warning about the regex cache size being too small
+  if not lua_regex_cache_max_entries then
+    lua_regex_cache_max_entries = kong.configuration.nginx_http_lua_regex_cache_max_entries or 1024
+  end
+
+  if worker_id() == 0 and regex_uris[0] > lua_regex_cache_max_entries then
+    ngx_log(WARN, "the 'nginx_http_lua_regex_cache_max_entries' setting is set to ",
+                   lua_regex_cache_max_entries,
+                   " but there are ", regex_uris[0], " regex URIs in use. ",
+                   "This may lead to performance issue due to regex trashing. ",
+                   "Consider increasing the 'nginx_http_lua_regex_cache_max_entries' ",
+                   "to at least ", regex_uris[0] * 2, ".")
+  end
 
   local function find_route(req_method, req_uri, req_host, req_scheme,
                             src_ip, src_port,

--- a/kong/router/traditional.lua
+++ b/kong/router/traditional.lua
@@ -1452,15 +1452,14 @@ function _M.new(routes, cache, cache_neg)
 
   -- warning about the regex cache size being too small
   if not lua_regex_cache_max_entries then
-    lua_regex_cache_max_entries = kong.configuration.nginx_http_lua_regex_cache_max_entries
-                              and tonumber(kong.configuration.nginx_http_lua_regex_cache_max_entries) or 1024
+    lua_regex_cache_max_entries = tonumber(kong.configuration.nginx_http_lua_regex_cache_max_entries) or 1024
   end
 
   if worker_id() == 0 and regex_uris[0] * 2 > lua_regex_cache_max_entries then
     ngx_log(WARN, "the 'nginx_http_lua_regex_cache_max_entries' setting is set to ",
                    lua_regex_cache_max_entries,
-                   " but there are ", regex_uris[0], " regex URIs in use. ",
-                   "This may lead to performance issue due to regex trashing. ",
+                   " but there are ", regex_uris[0], " regex paths configured. ",
+                   "This may lead to performance issue due to regex cache trashing. ",
                    "Consider increasing the 'nginx_http_lua_regex_cache_max_entries' ",
                    "to at least ", regex_uris[0] * 2, ".")
   end

--- a/kong/router/traditional.lua
+++ b/kong/router/traditional.lua
@@ -1457,11 +1457,11 @@ function _M.new(routes, cache, cache_neg)
 
   if worker_id() == 0 and regex_uris[0] * 2 > lua_regex_cache_max_entries then
     ngx_log(WARN, "the 'nginx_http_lua_regex_cache_max_entries' setting is set to ",
-                   lua_regex_cache_max_entries,
-                   " but there are ", regex_uris[0], " regex paths configured. ",
-                   "This may lead to performance issue due to regex cache trashing. ",
-                   "Consider increasing the 'nginx_http_lua_regex_cache_max_entries' ",
-                   "to at least ", regex_uris[0] * 2, ".")
+                  lua_regex_cache_max_entries,
+                  " but there are ", regex_uris[0], " regex paths configured. ",
+                  "This may lead to performance issue due to regex cache trashing. ",
+                  "Consider increasing the 'nginx_http_lua_regex_cache_max_entries' ",
+                  "to at least ", regex_uris[0] * 2)
   end
 
   local function find_route(req_method, req_uri, req_host, req_scheme,

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -82,6 +82,7 @@ nginx_proxy_real_ip_recursive = off
 nginx_admin_client_max_body_size = 10m
 nginx_admin_client_body_buffer_size = 10m
 nginx_http_lua_regex_match_limit = 100000
+nginx_http_lua_regex_cache_max_entries = 8192
 
 client_body_buffer_size = 8k
 real_ip_header = X-Real-IP


### PR DESCRIPTION
### Summary

When a user sets too many regex routes and `lua_regex_cache_max_entries` is set too low (or kept at default 1024), a performance issue might occur due to regex trashing. 

OpenResty [claims](https://github.com/openresty/lua-nginx-module/blob/master/README.markdown#lua_regex_cache_max_entries) that it will emit a warning when the limit has been exceeded, but it doesn't.

Fix FTI-4455