### PR TITLE
fix(opentelemetry): fix parent_id reporting from w3c header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,9 @@
   - Replace the worker-level table cache with
     `BatchQueue` to avoid data race.
     [#9504](https://github.com/Kong/kong/pull/9504)
+  - Fix an issue that the `parent_id` is not set
+    on the span when propagating w3c traceparent.
+    [#9628](https://github.com/Kong/kong/pull/9628)
 
 ### Dependencies
 

--- a/kong/plugins/opentelemetry/handler.lua
+++ b/kong/plugins/opentelemetry/handler.lua
@@ -116,7 +116,7 @@ function OpenTelemetryHandler:rewrite()
     kong.ctx.plugin.should_sample = false
   end
 
-  local header_type, trace_id, span_id, _, should_sample, _ = propagation_parse(headers)
+  local header_type, trace_id, span_id, parent_id, should_sample, _ = propagation_parse(headers)
   if should_sample == false then
     root_span.should_sample = should_sample
   end
@@ -130,6 +130,9 @@ function OpenTelemetryHandler:rewrite()
   -- overwrite root span's parent_id
   if span_id then
     root_span.parent_id = span_id
+
+  elseif parent_id then
+    root_span.parent_id = parent_id
   end
 
   propagation_set("preserve", header_type, root_span, "w3c")

--- a/spec/03-plugins/37-opentelemetry/04-exporter_spec.lua
+++ b/spec/03-plugins/37-opentelemetry/04-exporter_spec.lua
@@ -5,6 +5,17 @@ local tablex = require "pl.tablex"
 local pb = require "pb"
 local pl_file = require "pl.file"
 local ngx_re = require "ngx.re"
+local to_hex = require "resty.string".to_hex
+
+local fmt = string.format
+
+local function gen_trace_id()
+  return to_hex(utils.get_rand_bytes(16))
+end
+
+local function gen_span_id()
+  return to_hex(utils.get_rand_bytes(8))
+end
 
 local table_merge = utils.table_merge
 local HTTP_SERVER_PORT = 35000
@@ -293,5 +304,61 @@ for _, strategy in helpers.each_strategy() do
       end)
     end)
 
+    describe("#propagation", function ()
+      lazy_setup(function()
+        bp, _ = assert(helpers.get_db_utils(strategy, {
+          "services",
+          "routes",
+          "plugins",
+        }, { "opentelemetry" }))
+
+        setup_instrumentations("request")
+      end)
+
+      lazy_teardown(function()
+        helpers.stop_kong()
+        helpers.kill_http_server(HTTP_SERVER_PORT)
+      end)
+
+      it("#propagate w3c traceparent", function ()
+        local trace_id = gen_trace_id()
+        local parent_id = gen_span_id()
+
+        local headers, body
+        helpers.wait_until(function()
+          local thread = helpers.http_server(HTTP_SERVER_PORT, { timeout = 10 })
+          local cli = helpers.proxy_client(7000, PROXY_PORT)
+          local r = assert(cli:send {
+            method  = "GET",
+            path    = "/",
+            headers = {
+              ["traceparent"] = fmt("00-%s-%s-01", trace_id, parent_id),
+            }
+          })
+          assert.res_status(200, r)
+
+          -- close client connection
+          cli:close()
+
+          local ok
+          ok, headers, body = thread:join()
+
+          return ok
+        end, 10)
+
+        assert.is_string(body)
+
+        local idx = tablex.find(headers, "Content-Type: application/x-protobuf")
+        assert.not_nil(idx, headers)
+
+        local decoded = assert(pb.decode("opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest", body))
+        assert.not_nil(decoded)
+
+        local scope_span = decoded.resource_spans[1].scope_spans[1]
+        local span = scope_span.spans[1]
+        assert.same(trace_id, to_hex(span.trace_id), "trace_id")
+        assert.same(parent_id, to_hex(span.parent_span_id), "parent_id")
+      end)
+    end)
   end)
 end


### PR DESCRIPTION
### Summary

When trace context is propagated in w3c format header, the parent_id is not set on the root span and not reported to the collector. I could not come up with a way to cover it in the tests.

### Full changelog

* Fix `parent_id` reporting in traces propagating through w3c headers

### Issue reference

Fix #9627
