### PR TITLE
fix(clustering): log the correct error message var

### DIFF
--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -266,12 +266,12 @@ function _M:communicate(premature)
   c:close()
 
   local err_msg = ok and err or perr
-  
+
   if err_msg and endswith(err_msg, ": closed") then
     ngx_log(ngx_INFO, _log_prefix, "connection to control plane closed", log_suffix)
 
   elseif err_msg then
-    ngx_log(ngx_ERR, _log_prefix, err, log_suffix)
+    ngx_log(ngx_ERR, _log_prefix, err_msg, log_suffix)
   end
 
   -- the config thread might be holding a lock if it's in the middle of an


### PR DESCRIPTION
s/err/err_msg/

This matches the behavior of the wRPC data plane code:

https://github.com/Kong/kong/blob/1a110469bd2513e69a15ca2161816c24354ce273/kong/clustering/wrpc_data_plane.lua#L226-L233