### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/autodocs.yml
+++ b/.github/workflows/autodocs.yml
@@ -16,6 +16,10 @@ on:
         description: "Ignore the build cache and build dependencies from scratch"
         type: boolean
         default: false
+
+permissions:
+  contents: read  #  to fetch code (actions/checkout)
+
 jobs:
   build:
     name: Build dependencies
@@ -70,6 +74,8 @@ jobs:
           source .ci/setup_env_github.sh
           make dev
   autodoc:
+    permissions:
+      contents: write  #  to push code in repo (stefanzweifel/git-auto-commit-action)
     runs-on: ubuntu-latest
     needs: [build]
     steps:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -10,6 +10,9 @@ on:
     - release/*
     - test-please/*
 
+permissions:
+  contents: read  #  to fetch code (actions/checkout)
+
 jobs:
   build:
     name: Build dependencies

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -12,6 +12,9 @@ env:
   terraform_version: '1.2.4'
   DOWNLOAD_ROOT: $HOME/download-root
 
+permissions:
+  contents: read  #  to fetch code (actions/checkout)
+
 jobs:
   build:
     name: Build dependencies
@@ -76,6 +79,11 @@ jobs:
   # the above should be same as build_and_test.yml expect that perf.yml is used in cache_key
 
   perf:
+    permissions:
+      contents: read  #  to fetch code (actions/checkout)
+      pull-requests: write  #  to comment on pull-request
+      issues: write  #  to comment on issue
+
     name: RPS, latency and flamegraphs
     runs-on: ubuntu-20.04
     needs: build

--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -7,6 +7,9 @@ on:
     # ignore top-level markdown files (CHANGELOG.md, README.md, etc.)
     - '*.md'
 
+permissions:
+  contents: read  #  to fetch code (actions/checkout)
+
 jobs:
   upgrade-test:
     name: Run migration tests


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.