### PR TITLE
tests(*): remove httpbin.org from integration tests

### DIFF
--- a/spec/02-integration/04-admin_api/09-routes_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/09-routes_routes_spec.lua
@@ -1543,12 +1543,12 @@ for _, strategy in helpers.each_strategy() do
                 ["Content-Type"] = content_type
               },
               body = {
-                url = "http://httpbin.org",
+                url = "http://konghq.com",
               },
             })
             local body = assert.res_status(200, res)
             local json = cjson.decode(body)
-            assert.same("httpbin.org", json.host)
+            assert.same("konghq.com", json.host)
 
             local in_db = assert(db.services:select({ id = json.id }, { nulls = true }))
             assert.same(json, in_db)

--- a/spec/02-integration/05-proxy/07-upstream_timeouts_spec.lua
+++ b/spec/02-integration/05-proxy/07-upstream_timeouts_spec.lua
@@ -54,7 +54,7 @@ for _, strategy in helpers.each_strategy() do
           service = {
             name            = "api-1",
             protocol        = "http",
-            host            = "httpbin.org",
+            host            = "konghq.com",
             port            = 81,
             connect_timeout = 1, -- ms
           },

--- a/spec/03-plugins/27-aws-lambda/99-access_spec.lua
+++ b/spec/03-plugins/27-aws-lambda/99-access_spec.lua
@@ -27,12 +27,8 @@ for _, strategy in helpers.each_strategy() do
       }
 
       local route1_1 = bp.routes:insert {
-        hosts = { "lambda_ignore_service.com" },
-        service    = bp.services:insert({
-          protocol = "http",
-          host     = "httpbin.org",
-          port     = 80,
-        })
+        hosts   = { "lambda_ignore_service.com" },
+        service = assert(bp.services:insert()),
       }
 
       local route2 = bp.routes:insert {

--- a/spec/03-plugins/30-session/01-access_spec.lua
+++ b/spec/03-plugins/30-session/01-access_spec.lua
@@ -20,17 +20,17 @@ for _, strategy in helpers.each_strategy() do
 
       local route1 = bp.routes:insert {
         paths    = {"/test1"},
-        hosts = {"httpbin.org"},
+        hosts = {"konghq.com"},
       }
 
       local route2 = bp.routes:insert {
         paths    = {"/test2"},
-        hosts = {"httpbin.org"},
+        hosts = {"konghq.com"},
       }
 
       local route3 = bp.routes:insert {
         paths    = {"/headers"},
-        hosts = {"httpbin.org"},
+        hosts = {"konghq.com"},
       }
 
       local route4 = bp.routes:insert {
@@ -161,7 +161,7 @@ for _, strategy in helpers.each_strategy() do
           method = "GET",
           path = "/test1/status/200",
           headers = {
-            host = "httpbin.org",
+            host = "konghq.com",
             apikey = "kong",
           },
         })
@@ -187,7 +187,7 @@ for _, strategy in helpers.each_strategy() do
         local request = {
           method = "GET",
           path = "/test2/status/200",
-          headers = { host = "httpbin.org", },
+          headers = { host = "konghq.com", },
         }
 
         -- make sure the anonymous consumer can't get in (request termination)
@@ -225,7 +225,7 @@ for _, strategy in helpers.each_strategy() do
         local request = {
           method = "GET",
           path = "/headers",
-          headers = { host = "httpbin.org", },
+          headers = { host = "konghq.com", },
         }
 
         -- make a request with a valid key, grab the cookie for later

--- a/spec/03-plugins/30-session/02-kong_storage_adapter_spec.lua
+++ b/spec/03-plugins/30-session/02-kong_storage_adapter_spec.lua
@@ -25,17 +25,17 @@ for _, strategy in helpers.each_strategy() do
 
       local route1 = bp.routes:insert {
         paths    = {"/test1"},
-        hosts = {"httpbin.org"}
+        hosts = {"konghq.com"}
       }
 
       local route2 = bp.routes:insert {
         paths    = {"/test2"},
-        hosts = {"httpbin.org"}
+        hosts = {"konghq.com"}
       }
 
       local route3 = bp.routes:insert {
         paths    = {"/headers"},
-        hosts = {"httpbin.org"},
+        hosts = {"konghq.com"},
       }
 
       assert(bp.plugins:insert {
@@ -150,7 +150,7 @@ for _, strategy in helpers.each_strategy() do
         local request = {
           method = "GET",
           path = "/test1/status/200",
-          headers = { host = "httpbin.org", },
+          headers = { host = "konghq.com", },
         }
 
         -- make sure the anonymous consumer can't get in (request termination)
@@ -193,7 +193,7 @@ for _, strategy in helpers.each_strategy() do
         local request = {
           method = "GET",
           path = "/test2/status/200",
-          headers = { host = "httpbin.org", },
+          headers = { host = "konghq.com", },
         }
 
         local function send_requests(request, number, step)
@@ -250,7 +250,7 @@ for _, strategy in helpers.each_strategy() do
         local request = {
           method = "GET",
           path = "/test2/status/200",
-          headers = { host = "httpbin.org", },
+          headers = { host = "konghq.com", },
         }
 
         -- make sure the anonymous consumer can't get in (request termination)
@@ -288,7 +288,7 @@ for _, strategy in helpers.each_strategy() do
           path = "/test2/status/200?session_logout=true",
           headers = {
             cookie = cookie,
-            host = "httpbin.org",
+            host = "konghq.com",
           }
         }))
         assert.response(res).has.status(200)
@@ -306,7 +306,7 @@ for _, strategy in helpers.each_strategy() do
         local request = {
           method = "GET",
           path = "/headers",
-          headers = { host = "httpbin.org", },
+          headers = { host = "konghq.com", },
         }
 
         client = helpers.proxy_ssl_client()

--- a/spec/03-plugins/34-zipkin/zipkin_spec.lua
+++ b/spec/03-plugins/34-zipkin/zipkin_spec.lua
@@ -333,7 +333,7 @@ for _, strategy in helpers.each_strategy() do
         name = "zipkin",
         config = {
           sample_ratio = 1,
-          http_endpoint = "http://httpbin.org:1337/status/200",
+          http_endpoint = "http://konghq.com:1337/status/200",
           default_header_type = "b3-single",
           connect_timeout = 10,
           send_timeout = 0,

--- a/spec/03-plugins/35-azure-functions/01-access_spec.lua
+++ b/spec/03-plugins/35-azure-functions/01-access_spec.lua
@@ -22,16 +22,16 @@ for _, strategy in helpers.each_strategy() do
       }
 
       -- this plugin definition results in an upstream url to
-      -- http://httpbin.org/anything
+      -- http://mockbin.org/request
       -- which will echo the request for inspection
       db.plugins:insert {
         name     = "azure-functions",
         route    = { id = route2.id },
         config   = {
           https           = true,
-          appname         = "httpbin",
+          appname         = "mockbin",
           hostdomain      = "org",
-          routeprefix     = "anything",
+          routeprefix     = "request",
           functionname    = "test-func-name",
           apikey          = "anything_but_an_API_key",
           clientid        = "and_no_clientid",
@@ -70,7 +70,7 @@ for _, strategy in helpers.each_strategy() do
 
       assert.response(res).has.status(200)
       local json = assert.response(res).has.jsonbody()
-      assert.same({ hello ="world" }, json.args)
+      assert.same({ hello ="world" }, json.queryString)
     end)
 
     it("passes request body", function()
@@ -87,7 +87,7 @@ for _, strategy in helpers.each_strategy() do
 
       assert.response(res).has.status(200)
       local json = assert.response(res).has.jsonbody()
-      assert.same(body, json.data)
+      assert.same(body, json.postData.text)
     end)
 
     it("passes the path parameters", function()
@@ -101,7 +101,7 @@ for _, strategy in helpers.each_strategy() do
 
       assert.response(res).has.status(200)
       local json = assert.response(res).has.jsonbody()
-      assert.matches("httpbin.org/anything/test%-func%-name/and/then/some", json.url)
+      assert.matches("mockbin.org/request/test%-func%-name/and/then/some", json.url)
     end)
 
     it("passes the method", function()
@@ -130,7 +130,7 @@ for _, strategy in helpers.each_strategy() do
 
       assert.response(res).has.status(200)
       local json = assert.response(res).has.jsonbody()
-      assert.same("just a value", json.headers["Just-A-Header"])
+      assert.same("just a value", json.headers["just-a-header"])
     end)
 
     it("injects the apikey and clientid", function()
@@ -145,8 +145,8 @@ for _, strategy in helpers.each_strategy() do
       assert.response(res).has.status(200)
       local json = assert.response(res).has.jsonbody()
       --assert.same({}, json.headers)
-      assert.same("anything_but_an_API_key", json.headers["X-Functions-Key"])
-      assert.same("and_no_clientid", json.headers["X-Functions-Clientid"])
+      assert.same("anything_but_an_API_key", json.headers["x-functions-key"])
+      assert.same("and_no_clientid", json.headers["x-functions-clientid"])
     end)
 
     it("returns server tokens with Via header", function()

--- a/t/03-dns-client/02-timer-usage.t
+++ b/t/03-dns-client/02-timer-usage.t
@@ -20,7 +20,7 @@ qq {
             resolvConf = {}, -- and resolv.conf files
             order = { "A" },
         }))
-        local host = "httpbin.org"
+        local host = "konghq.com"
         local typ = client.TYPE_A
         for i = 1, 10 do
             client.resolve(host, { qtype = typ })
@@ -40,7 +40,7 @@ qq {
         access_by_lua_block {
             local client = require("kong.resty.dns.client")
             assert(client.init())
-            local host = "httpbin.org"
+            local host = "konghq.com"
             local typ = client.TYPE_A
             local answers, err = client.resolve(host, { qtype = typ })
 
@@ -68,7 +68,7 @@ qq {
 --- request
 GET /t
 --- response_body
-first address name: httpbin.org
+first address name: konghq.com
 second address name: mockbin.org
 workers: 6
 timers: 2


### PR DESCRIPTION
Some of these don't actually try to make requests out to `httpbin.org`, but hopefully it saves future us some work to have them not show up in `git grep`.