### PR TITLE
fix(cmd): don't load full conf when running the health check

### DIFF
--- a/kong/cmd/health.lua
+++ b/kong/cmd/health.lua
@@ -1,5 +1,6 @@
 local log = require "kong.cmd.utils.log"
 local kill = require "kong.cmd.utils.kill"
+local kong_default_conf = require "kong.templates.kong_defaults"
 local pl_config = require "pl.config"
 local pl_file = require "pl.file"
 local pl_path = require "pl.path"
@@ -36,6 +37,19 @@ local function get_kong_prefix(args)
         prefix = conf.prefix
       end
     end
+  end
+
+  if not prefix then
+    local s = pl_stringio.open(kong_default_conf)
+    local defaults = pl_config.read(s, {
+      smart = false,
+      list_delim = "_blank_" -- mandatory but we want to ignore it
+    })
+    s:close()
+    if defaults then
+      prefix = defaults.prefix
+    end
+
   end
 
   return prefix

--- a/kong/cmd/health.lua
+++ b/kong/cmd/health.lua
@@ -1,28 +1,65 @@
 local log = require "kong.cmd.utils.log"
 local kill = require "kong.cmd.utils.kill"
+local pl_config = require "pl.config"
+local pl_file = require "pl.file"
 local pl_path = require "pl.path"
 local pl_tablex = require "pl.tablex"
+local pl_stringio = require "pl.stringio"
 local pl_stringx = require "pl.stringx"
 local conf_loader = require "kong.conf_loader"
 
+
+local function get_kong_prefix(args)
+  local prefix = args.prefix or os.getenv("KONG_PREFIX")
+
+  if not prefix then
+    local default_paths = conf_loader.get_default_paths()
+    local path
+    for _, default_path in ipairs(default_paths) do
+      if pl_path.exists(default_path) then
+        path = default_path
+        break
+      end
+    end
+
+    if path then
+      local f = pl_file.read(path)
+      assert(f, "could not load config file at " .. path)
+
+      local s = pl_stringio.open(f)
+      local conf = pl_config.read(s, {
+        smart = false,
+        list_delim = "_blank_" -- mandatory but we want to ignore it
+      })
+      s:close()
+      if conf then
+        prefix = conf.prefix
+      end
+    end
+  end
+
+  return prefix
+end
+
+
+local function get_node_pids(prefix)
+  local pids = {}
+  local prefix_paths = conf_loader.get_prefix_paths()
+  local kong_env = pl_path.join(prefix, unpack(prefix_paths["kong_env"]))
+  assert(pl_path.exists(kong_env), "Kong is not running at " .. prefix)
+
+  pids["nginx"] = pl_path.join(prefix, unpack(prefix_paths["nginx_pid"]))
+
+  return pids
+end
+
 local function execute(args)
-  log.disable()
-  -- retrieve default prefix or use given one
-  local default_conf = assert(conf_loader(nil, {
-    prefix = args.prefix
-  }))
-  log.enable()
-  assert(pl_path.exists(default_conf.prefix),
-         "no such prefix: " .. default_conf.prefix)
-  assert(pl_path.exists(default_conf.kong_env),
-         "Kong is not running at " .. default_conf.prefix)
+  local prefix = get_kong_prefix(args)
+  assert(prefix, "could not get Kong prefix")
+  assert(pl_path.exists(prefix),
+         "no such prefix: " .. prefix)
 
-  -- load <PREFIX>/kong.conf containing running node's config
-  local conf = assert(conf_loader(default_conf.kong_env))
-
-  local pids = {
-    nginx = conf.nginx_pid,
-  }
+  local pids = get_node_pids(prefix)
 
   local count = 0
   for k, v in pairs(pids) do
@@ -36,10 +73,10 @@ local function execute(args)
 
   log("") -- line jump
 
-  assert(count > 0, "Kong is not running at " .. conf.prefix)
-  assert(count == pl_tablex.size(pids), "some services are not running at " .. conf.prefix)
+  assert(count > 0, "Kong is not running at " .. prefix)
+  assert(count == pl_tablex.size(pids), "some services are not running at " .. prefix)
 
-  log("Kong is healthy at %s", conf.prefix)
+  log("Kong is healthy at %s", prefix)
 end
 
 local lapp = [[

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -1847,6 +1847,14 @@ return setmetatable({
     DEFAULT_PATHS[#DEFAULT_PATHS+1] = path
   end,
 
+  get_default_paths = function()
+    return DEFAULT_PATHS
+  end,
+
+  get_prefix_paths = function()
+    return PREFIX_PATHS
+  end,
+
   remove_sensitive = function(conf)
     local purged_conf = tablex.deepcopy(conf)
 


### PR DESCRIPTION
### Summary

When the Kong node has a large config, the health-check CLI tool can use a lot of CPU just to load a config that will be dismissed. This change avoids most of the conf loading.

Kong containers use the `kong health` CLI tool to check if the Gateway is up.

### Full changelog

* Load only the needed parts from the conf file.
* Allow external access to a couple of internal constants from `conf_loader`.
* No tests were added, the `kong health` behavior is the same as before.

FTI-4452
