### PR TITLE
refactor(core/runloop): code clean for reconfigure event processing

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -829,8 +829,8 @@ local function register_events()
   local worker_events  = kong.worker_events
   local cluster_events = kong.cluster_events
 
-  -- declarative config updates
   if db.strategy == "off" then
+    -- declarative config updates
     worker_events.register(reconfigure_handler, "declarative", "reconfigure")
   end
 

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -692,6 +692,143 @@ local function _register_balancer_events(f)
 end
 
 
+local register_reconfigure_event
+do
+  local now = ngx.now
+  local update_time = ngx.update_time
+  local ngx_worker_id = ngx.worker.id
+  local exiting = ngx.worker.exiting
+
+  local current_router_hash
+  local current_plugins_hash
+  local current_balancer_hash
+
+  local function is_exiting(worker_id)
+    if not exiting() then
+      return false
+    end
+    log(NOTICE, "declarative reconfigure was canceled on worker #", worker_id,
+                ": process exiting")
+    return true
+  end
+
+  local function get_now_ms()
+    update_time()
+    return now() * 1000
+  end
+
+  local function reconfigure_handler(data)
+    local worker_id = ngx_worker_id()
+
+    if is_exiting(worker_id) then
+      return true
+    end
+
+    local reconfigure_started_at = get_now_ms()
+
+    log(INFO, "declarative reconfigure was started on worker #", worker_id)
+
+    local default_ws
+    local router_hash
+    local plugins_hash
+    local balancer_hash
+
+    if type(data) == "table" then
+      default_ws    = data[1]
+      router_hash   = data[2]
+      plugins_hash  = data[3]
+      balancer_hash = data[4]
+    end
+
+    local ok, err = concurrency.with_coroutine_mutex(RECONFIGURE_OPTS, function()
+      -- below you are encouraged to yield for cooperative threading
+
+      local rebuild_balancer = balancer_hash == nil or balancer_hash ~= current_balancer_hash
+      if rebuild_balancer then
+        log(DEBUG, "stopping previously started health checkers on worker #", worker_id)
+        balancer.stop_healthcheckers(CLEAR_HEALTH_STATUS_DELAY)
+      end
+
+      kong.default_workspace = default_ws
+      ngx.ctx.workspace = default_ws
+
+      local router, err
+      if router_hash == nil or router_hash ~= current_router_hash then
+        local start = get_now_ms()
+
+        router, err = new_router()
+        if not router then
+          return nil, err
+        end
+
+        log(INFO, "building a new router took ",  get_now_ms() - start,
+                  " ms on worker #", worker_id)
+      end
+
+      local plugins_iterator
+      if plugins_hash == nil or plugins_hash ~= current_plugins_hash then
+        local start = get_now_ms()
+
+        plugins_iterator, err = new_plugins_iterator()
+        if not plugins_iterator then
+          return nil, err
+        end
+
+        log(INFO, "building a new plugins iterator took ", get_now_ms() - start,
+                  " ms on worker #", worker_id)
+      end
+
+      -- below you are not supposed to yield and this should be fast and atomic
+
+      -- TODO: we should perhaps only purge the configuration related cache.
+
+      log(DEBUG, "flushing caches as part of the reconfiguration on worker #", worker_id)
+
+      kong.core_cache:purge()
+      kong.cache:purge()
+
+      if router then
+        ROUTER = router
+        ROUTER_CACHE:flush_all()
+        ROUTER_CACHE_NEG:flush_all()
+        current_router_hash = router_hash
+      end
+
+      if plugins_iterator then
+        PLUGINS_ITERATOR = plugins_iterator
+        current_plugins_hash = plugins_hash
+      end
+
+      if rebuild_balancer then
+        -- TODO: balancer is a big blob of global state and you cannot easily
+        --       initialize new balancer and then atomically flip it.
+        log(DEBUG, "reinitializing balancer with a new configuration on worker #", worker_id)
+        balancer.init()
+        current_balancer_hash = balancer_hash
+      end
+
+      log(INFO, "declarative reconfigure took ", get_now_ms() - reconfigure_started_at,
+                " ms on worker #", worker_id)
+
+      return true
+    end)  -- concurrency.with_coroutine_mutex
+
+    if not ok then
+      log(ERR, "declarative reconfigure failed after ", get_now_ms() - reconfigure_started_at,
+               " ms on worker #", worker_id, ": ", err)
+    end
+  end -- reconfigure_handler
+
+  register_reconfigure_event = function()
+    if db.strategy ~= "off" then
+      return
+    end
+
+    worker_events.register(reconfigure_handler, "declarative", "reconfigure")
+  end
+end
+
+
 local function register_events()
   -- initialize local local_events hooks
   local db             = kong.db
@@ -699,137 +836,8 @@ local function register_events()
   local worker_events  = kong.worker_events
   local cluster_events = kong.cluster_events
 
-  if db.strategy == "off" then
-
-    -- declarative config updates
-
-    local current_router_hash
-    local current_plugins_hash
-    local current_balancer_hash
-
-    local now = ngx.now
-    local update_time = ngx.update_time
-    local worker_id = ngx.worker.id()
-
-    local exiting = ngx.worker.exiting
-    local function is_exiting()
-      if not exiting() then
-        return false
-      end
-      log(NOTICE, "declarative reconfigure was canceled on worker #", worker_id,
-                  ": process exiting")
-      return true
-    end
-
-    worker_events.register(function(data)
-      if is_exiting() then
-        return true
-      end
-
-      update_time()
-      local reconfigure_started_at = now() * 1000
-
-      log(INFO, "declarative reconfigure was started on worker #", worker_id)
-
-      local default_ws
-      local router_hash
-      local plugins_hash
-      local balancer_hash
-
-      if type(data) == "table" then
-        default_ws = data[1]
-        router_hash = data[2]
-        plugins_hash = data[3]
-        balancer_hash = data[4]
-      end
-
-      local ok, err = concurrency.with_coroutine_mutex(RECONFIGURE_OPTS, function()
-        -- below you are encouraged to yield for cooperative threading
-
-        local rebuild_balancer = balancer_hash == nil or balancer_hash ~= current_balancer_hash
-        if rebuild_balancer then
-          log(DEBUG, "stopping previously started health checkers on worker #", worker_id)
-          balancer.stop_healthcheckers(CLEAR_HEALTH_STATUS_DELAY)
-        end
-
-        kong.default_workspace = default_ws
-        ngx.ctx.workspace = default_ws
-
-        local router, err
-        if router_hash == nil or router_hash ~= current_router_hash then
-          update_time()
-          local start = now() * 1000
-
-          router, err = new_router()
-          if not router then
-            return nil, err
-          end
-
-          update_time()
-          log(INFO, "building a new router took ",  now() * 1000 - start,
-                    " ms on worker #", worker_id)
-        end
-
-        local plugins_iterator
-        if plugins_hash == nil or plugins_hash ~= current_plugins_hash then
-          update_time()
-          local start = now() * 1000
-
-          plugins_iterator, err = new_plugins_iterator()
-          if not plugins_iterator then
-            return nil, err
-          end
-
-          update_time()
-          log(INFO, "building a new plugins iterator took ", now() * 1000 - start,
-                    " ms on worker #", worker_id)
-        end
-
-        -- below you are not supposed to yield and this should be fast and atomic
-
-        -- TODO: we should perhaps only purge the configuration related cache.
-
-        log(DEBUG, "flushing caches as part of the reconfiguration on worker #", worker_id)
-
-        kong.core_cache:purge()
-        kong.cache:purge()
-
-        if router then
-          ROUTER = router
-          ROUTER_CACHE:flush_all()
-          ROUTER_CACHE_NEG:flush_all()
-          current_router_hash = router_hash
-        end
-
-        if plugins_iterator then
-          PLUGINS_ITERATOR = plugins_iterator
-          current_plugins_hash = plugins_hash
-        end
-
-        if rebuild_balancer then
-          -- TODO: balancer is a big blob of global state and you cannot easily
-          --       initialize new balancer and then atomically flip it.
-          log(DEBUG, "reinitializing balancer with a new configuration on worker #", worker_id)
-          balancer.init()
-          current_balancer_hash = balancer_hash
-        end
-
-        update_time()
-        log(INFO, "declarative reconfigure took ", now() * 1000 - reconfigure_started_at,
-                  " ms on worker #", worker_id)
-
-        return true
-      end)
-
-      if not ok then
-        update_time()
-        log(ERR, "declarative reconfigure failed after ", now() * 1000 - reconfigure_started_at,
-                 " ms on worker #", worker_id, ": ", err)
-      end
-    end, "declarative", "reconfigure")
-
-    return
-  end
+  -- declarative config updates
+  register_reconfigure_event()
 
   -- events dispatcher
 

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -704,15 +704,6 @@ do
   local current_plugins_hash  = 0
   local current_balancer_hash = 0
 
-  local function is_exiting(worker_id)
-    if not exiting() then
-      return false
-    end
-    log(NOTICE, "declarative reconfigure was canceled on worker #", worker_id,
-                ": process exiting")
-    return true
-  end
-
   local function get_now_ms()
     update_time()
     return now() * 1000
@@ -721,7 +712,9 @@ do
   reconfigure_handler = function(data)
     local worker_id = ngx_worker_id()
 
-    if is_exiting(worker_id) then
+    if exiting() then
+      log(NOTICE, "declarative reconfigure was canceled on worker #", worker_id,
+                  ": process exiting")
       return true
     end
 

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -828,6 +828,7 @@ local function register_events()
   if db.strategy == "off" then
     -- declarative config updates
     worker_events.register(reconfigure_handler, "declarative", "reconfigure")
+    return
   end
 
   -- events dispatcher

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -78,7 +78,6 @@ local HOST_PORTS = {}
 
 
 local SUBSYSTEMS = constants.PROTOCOLS_WITH_SUBSYSTEM
-local CLEAR_HEALTH_STATUS_DELAY = constants.CLEAR_HEALTH_STATUS_DELAY
 local TTL_ZERO = { ttl = 0 }
 
 
@@ -698,6 +697,8 @@ do
   local update_time = ngx.update_time
   local ngx_worker_id = ngx.worker.id
   local exiting = ngx.worker.exiting
+
+  local CLEAR_HEALTH_STATUS_DELAY = constants.CLEAR_HEALTH_STATUS_DELAY
 
   -- '0' for compare with nil
   local CURRENT_ROUTER_HASH   = 0

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -808,14 +808,17 @@ do
         current_balancer_hash = balancer_hash or 0
       end
 
-      log(INFO, "declarative reconfigure took ", get_now_ms() - reconfigure_started_at,
-                " ms on worker #", worker_id)
-
       return true
     end)  -- concurrency.with_coroutine_mutex
 
-    if not ok then
-      log(ERR, "declarative reconfigure failed after ", get_now_ms() - reconfigure_started_at,
+    local reconfigure_time = get_now_ms() - reconfigure_started_at
+
+    if ok then
+      log(INFO, "declarative reconfigure took ", reconfigure_time,
+                " ms on worker #", worker_id)
+
+    else
+      log(ERR, "declarative reconfigure failed after ", reconfigure_time,
                " ms on worker #", worker_id, ": ", err)
     end
   end -- reconfigure_handler


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

In reconfigure event handler, we use `current_router_hash` and others
to compare with new hashes, but they are function local vars.
It is not a common used pattern.

This PR puts these hash vars into `do block` scope and did some style cleaning,
Now the code is more readable and maintainable.

### Full changelog

* move `current_router_hash` `current_plugins_hash` `current_balancer_hash` to `do block` level
* move logic into function `reconfigure_handler()`
* use `get_now_ms()` to calculate delta time
* remove unnecessary `is_exiting()`
* change the hash's default value to `0`, so we can compare them with `nil` directly
* style fix


