### PR TITLE
tests(perf): add "bring-your-own" provider

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -176,23 +176,25 @@ jobs:
     - name: Run Tests
       env:
         PERF_TEST_VERSIONS: ${{ steps.compare_versions.outputs.vers }}
+        PERF_TEST_DRIVER: terraform
         PERF_TEST_TERRAFORM_PROVIDER: bring-your-own
         PERF_TEST_BYO_KONG_IP: ${{ secrets.PERF_TEST_BYO_KONG_IP }}
         PERF_TEST_BYO_WORKER_IP: ${{ secrets.PERF_TEST_BYO_WORKER_IP }}
-        PERF_TEST_BYO_SSH_KEY_PATH: ssh_key
         PERF_TEST_BYO_SSH_USER: gha
         PERF_TEST_USE_DAILY_IMAGE: true
         PERF_TEST_DISABLE_EXEC_OUTPUT: true
       timeout-minutes: 120
       run: |
+        export PERF_TEST_BYO_SSH_KEY_PATH=$(pwd)/ssh_key
         echo "${{ secrets.PERF_TEST_BYO_SSH_KEY }}" > ${PERF_TEST_BYO_SSH_KEY_PATH}
 
+        chmod 600 ${PERF_TEST_BYO_SSH_KEY_PATH}
         # setup tunnel for psql and admin port
         ssh -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveInterval=10 \
             -o ExitOnForwardFailure=yes -o ConnectTimeout=5 \
             -L 15432:localhost:5432 -L 39001:localhost:39001 \
             -i ${PERF_TEST_BYO_SSH_KEY_PATH} \
-            ${PERF_TEST_BYO_SSH_USER}@${{ secrets.PERreF_TEST_BYO_KONG_IP }} tail -f /dev/null &
+            ${PERF_TEST_BYO_SSH_USER}@${PERF_TEST_BYO_KONG_IP} tail -f /dev/null &
         sleep 5
 
         sudo iptables -t nat -I OUTPUT -p tcp --dport 5432  -d ${PERF_TEST_BYO_KONG_IP} -j DNAT --to 127.0.0.1:15432
@@ -213,12 +215,16 @@ jobs:
       if: always()
       env:
         PERF_TEST_VERSIONS: git:${{ github.sha }}
+        PERF_TEST_DRIVER: terraform
         PERF_TEST_TERRAFORM_PROVIDER: bring-your-own
         PERF_TEST_BYO_KONG_IP: ${{ secrets.PERF_TEST_BYO_KONG_IP }}
         PERF_TEST_BYO_WORKER_IP: ${{ secrets.PERF_TEST_BYO_WORKER_IP }}
-        PERF_TEST_BYO_SSH_KEY_PATH: ssh_key
+        PERF_TEST_BYO_SSH_USER: gha
         PERF_TEST_TEARDOWN_ALL: true
       run: |
+        export PERF_TEST_BYO_SSH_KEY_PATH=$(pwd)/ssh_key
+        echo "${{ secrets.PERF_TEST_BYO_SSH_KEY }}" > ${PERF_TEST_BYO_SSH_KEY_PATH}
+
         eval `luarocks path`
         bin/busted -o gtest spec/04-perf/99-teardown/
 

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -145,8 +145,12 @@ jobs:
           fi
         fi
 
-        echo ::set-output name=suites::"$suites"
-        echo ::set-output name=tags::"$tags"
+        # XXX just for test
+        suites=01-rps
+        tags=single_route
+
+        echo "suites=$suites" >> $GITHUB_OUTPUT
+        echo "tags=$tags" >> $GITHUB_OUTPUT
 
     - uses: xt0rted/pull-request-comment-branch@v1
       id: comment-branch
@@ -170,7 +174,7 @@ jobs:
 
         echo $vers
 
-        echo ::set-output name=vers::"$vers"
+        echo "vers=$vers" >> $GITHUB_OUTPUT
 
 
     - name: Run Tests
@@ -289,7 +293,7 @@ jobs:
         result="${result//$'\n'/'%0A'}"
         result="${result//$'\r'/'%0D'}"
 
-        echo ::set-output name=result::"$result"
+        echo "result=$results" >> $GITHUB_OUTPUT
 
     - name: Upload charts
       if: always()

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -147,7 +147,7 @@ jobs:
 
         # XXX just for test
         suites=01-rps
-        tags=single_route
+        tags=simple
 
         echo "suites=$suites" >> $GITHUB_OUTPUT
         echo "tags=$tags" >> $GITHUB_OUTPUT

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -180,6 +180,7 @@ jobs:
         PERF_TEST_BYO_KONG_IP: ${{ secrets.PERF_TEST_BYO_KONG_IP }}
         PERF_TEST_BYO_WORKER_IP: ${{ secrets.PERF_TEST_BYO_WORKER_IP }}
         PERF_TEST_BYO_SSH_KEY_PATH: ssh_key
+        PERF_TEST_BYO_SSH_USER: gha
         PERF_TEST_USE_DAILY_IMAGE: true
         PERF_TEST_DISABLE_EXEC_OUTPUT: true
       timeout-minutes: 120
@@ -191,7 +192,7 @@ jobs:
             -o ExitOnForwardFailure=yes -o ConnectTimeout=5 \
             -L 15432:localhost:5432 -L 39001:localhost:39001 \
             -i ${PERF_TEST_BYO_SSH_KEY_PATH} \
-            root@${{ secrets.PERF_TEST_BYO_KONG_IP }} tail -f /dev/null &
+            ${PERF_TEST_BYO_SSH_USER}@${{ secrets.PERreF_TEST_BYO_KONG_IP }} tail -f /dev/null &
         sleep 5
 
         sudo iptables -t nat -I OUTPUT -p tcp --dport 5432  -d ${PERF_TEST_BYO_KONG_IP} -j DNAT --to 127.0.0.1:15432

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -145,10 +145,6 @@ jobs:
           fi
         fi
 
-        # XXX just for test
-        suites=01-rps
-        tags=simple
-
         echo "suites=$suites" >> $GITHUB_OUTPUT
         echo "tags=$tags" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -172,16 +172,31 @@ jobs:
 
         echo ::set-output name=vers::"$vers"
 
+
     - name: Run Tests
       env:
         PERF_TEST_VERSIONS: ${{ steps.compare_versions.outputs.vers }}
-        PERF_TEST_METAL_PROJECT_ID: ${{ secrets.PERF_TEST_METAL_PROJECT_ID }}
-        PERF_TEST_METAL_AUTH_TOKEN: ${{ secrets.PERF_TEST_METAL_AUTH_TOKEN }}
-        PERF_TEST_DRIVER: terraform
+        PERF_TEST_TERRAFORM_PROVIDER: bring-your-own
+        PERF_TEST_BYO_KONG_IP: ${{ secrets.PERF_TEST_BYO_KONG_IP }}
+        PERF_TEST_BYO_WORKER_IP: ${{ secrets.PERF_TEST_BYO_WORKER_IP }}
+        PERF_TEST_BYO_SSH_KEY_PATH: ssh_key
         PERF_TEST_USE_DAILY_IMAGE: true
         PERF_TEST_DISABLE_EXEC_OUTPUT: true
       timeout-minutes: 120
       run: |
+        echo "${{ secrets.PERF_TEST_BYO_SSH_KEY }}" > ${PERF_TEST_BYO_SSH_KEY_PATH}
+
+        # setup tunnel for psql and admin port
+        ssh -o StrictHostKeyChecking=no -o TCPKeepAlive=yes -o ServerAliveInterval=10 \
+            -o ExitOnForwardFailure=yes -o ConnectTimeout=5 \
+            -L 15432:localhost:5432 -L 39001:localhost:39001 \
+            -i ${PERF_TEST_BYO_SSH_KEY_PATH} \
+            root@${{ secrets.PERF_TEST_BYO_KONG_IP }} tail -f /dev/null &
+        sleep 5
+
+        sudo iptables -t nat -I OUTPUT -p tcp --dport 5432  -d ${PERF_TEST_BYO_KONG_IP} -j DNAT --to 127.0.0.1:15432
+        sudo iptables -t nat -I OUTPUT -p tcp --dport 39001 -d ${PERF_TEST_BYO_KONG_IP} -j DNAT --to 127.0.0.1:39001
+
         eval `luarocks path`
         for suite in ${{ steps.choose_perf.outputs.suites }}; do
           # Run each test individually, ngx.pipe doesn't like to be imported twice
@@ -191,19 +206,22 @@ jobs:
               -t "${{ steps.choose_perf.outputs.tags }}"
           done
         done
-        
+
     - name: Teardown
       # Note: by default each job has if: ${{ success() }}
       if: always()
       env:
         PERF_TEST_VERSIONS: git:${{ github.sha }}
-        PERF_TEST_METAL_PROJECT_ID: ${{ secrets.PERF_TEST_METAL_PROJECT_ID }}
-        PERF_TEST_METAL_AUTH_TOKEN: ${{ secrets.PERF_TEST_METAL_AUTH_TOKEN }}
-        PERF_TEST_DRIVER: terraform
-        PERF_TEST_TEARDOWN_ALL: "true"
+        PERF_TEST_TERRAFORM_PROVIDER: bring-your-own
+        PERF_TEST_BYO_KONG_IP: ${{ secrets.PERF_TEST_BYO_KONG_IP }}
+        PERF_TEST_BYO_WORKER_IP: ${{ secrets.PERF_TEST_BYO_WORKER_IP }}
+        PERF_TEST_BYO_SSH_KEY_PATH: ssh_key
+        PERF_TEST_TEARDOWN_ALL: true
       run: |
         eval `luarocks path`
         bin/busted -o gtest spec/04-perf/99-teardown/
+
+        rm -f ${PERF_TEST_BYO_SSH_KEY_PATH}
 
     - name: Generate high DPI graphs
       if: always()

--- a/spec/fixtures/perf/terraform/bring-your-own/main.tf
+++ b/spec/fixtures/perf/terraform/bring-your-own/main.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.2"
+
+  required_providers {
+    local = {
+      version = "~> 2.2"
+    }
+  }
+}
+

--- a/spec/fixtures/perf/terraform/bring-your-own/output.tf
+++ b/spec/fixtures/perf/terraform/bring-your-own/output.tf
@@ -1,0 +1,23 @@
+output "kong-ip" {
+  value = var.kong_ip
+}
+
+output "kong-internal-ip" {
+  value =  local.kong_internal_ip_fallback
+}
+
+output "db-ip" {
+  value = var.db_ip
+}
+
+output "db-internal-ip" {
+  value = var.db_internal_ip
+}
+
+output "worker-ip" {
+  value = var.worker_ip
+}
+
+output "worker-internal-ip" {
+  value = local.worker_internal_ip_fallback
+}

--- a/spec/fixtures/perf/terraform/bring-your-own/ssh.tf
+++ b/spec/fixtures/perf/terraform/bring-your-own/ssh.tf
@@ -1,0 +1,6 @@
+# copy the file to current directory to be loaded by framework
+resource "local_sensitive_file" "key_priv" {
+  source  = var.ssh_key_path
+  filename = "./id_rsa"
+  file_permission = "0600"
+}

--- a/spec/fixtures/perf/terraform/bring-your-own/variables.tf
+++ b/spec/fixtures/perf/terraform/bring-your-own/variables.tf
@@ -1,0 +1,43 @@
+variable "kong_ip" {
+  type = string
+}
+
+variable "kong_internal_ip" {
+  type = string
+  default = ""
+}
+
+variable "worker_ip" {
+  type = string
+}
+
+variable "worker_internal_ip" {
+  type = string
+  default = ""
+}
+
+locals {
+  kong_internal_ip_fallback = var.kong_internal_ip != "" ? var.kong_internal_ip : var.kong_ip
+  worker_internal_ip_fallback = var.worker_internal_ip != "" ? var.worker_internal_ip : var.worker_ip
+}
+
+# db IP fallback is done in the lua part
+variable "db_ip" {
+  type = string
+  default = ""
+}
+
+variable "db_internal_ip" {
+  type = string
+  default = ""
+}
+
+variable "ssh_key_path" {
+  type = string
+}
+
+variable "seperate_db_node" {
+  type        = bool
+  description = "Whether to create a separate db instance"
+  default     = false
+}

--- a/spec/helpers/perf.lua
+++ b/spec/helpers/perf.lua
@@ -89,6 +89,7 @@ local function use_defaults()
 
   local driver = os.getenv("PERF_TEST_DRIVER") or "docker"
   local use_daily_image = os.getenv("PERF_TEST_USE_DAILY_IMAGE")
+  local ssh_user
 
   if driver == "terraform" then
     local seperate_db_node = not not os.getenv("PERF_TEST_SEPERATE_DB_NODE")
@@ -119,6 +120,7 @@ local function use_defaults()
         ec2_instance_type = os.getenv("PERF_TEST_EC2_INSTANCE_TYPE"), -- "c5a.2xlarge",
         ec2_os = os.getenv("PERF_TEST_EC2_OS"), -- "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*",
       }
+      ssh_user = "ubuntu"
     elseif tf_provider == "bring-your-own" then
       tfvars =  {
         kong_ip = os.getenv("PERF_TEST_BYO_KONG_IP"),
@@ -127,8 +129,9 @@ local function use_defaults()
         db_internal_ip = os.getenv("PERF_TEST_BYO_DB_INTERNAL_IP"), -- fallback to db_ip
         worker_ip = os.getenv("PERF_TEST_BYO_WORKER_IP"),
         worker_internal_ip = os.getenv("PERF_TEST_BYO_WORKER_INTERNAL_IP"), -- fallback to worker_ip
-        ssh_key_path = os.getenv("PERF_TEST_BYO_SSH_KEY_PATH"),
+        ssh_key_path = os.getenv("PERF_TEST_BYO_SSH_USER") or "root",
       }
+      ssh_user = os.getenv("PERF_TEST_BYO_SSH_USER")
     end
 
     tfvars.seperate_db_node = seperate_db_node
@@ -138,6 +141,7 @@ local function use_defaults()
       tfvars = tfvars,
       use_daily_image = use_daily_image,
       seperate_db_node = seperate_db_node,
+      ssh_user = ssh_user,
     })
   else
     use_driver(driver, {

--- a/spec/helpers/perf.lua
+++ b/spec/helpers/perf.lua
@@ -104,7 +104,6 @@ local function use_defaults()
         metal_plan = os.getenv("PERF_TEST_METAL_PLAN"), -- "c3.small.x86"
         -- metal_region = ["sv15", "sv16", "la4"], -- not support setting from lua for now
         metal_os = os.getenv("PERF_TEST_METAL_OS"), -- "ubuntu_20_04",
-        seperate_db_node = seperate_db_node,
       }
     elseif tf_provider == "digitalocean" then
       tfvars =  {
@@ -113,16 +112,26 @@ local function use_defaults()
         do_size = os.getenv("PERF_TEST_DIGITALOCEAN_SIZE"), -- "c2-8vpcu-16gb",
         do_region = os.getenv("PERF_TEST_DIGITALOCEAN_REGION"), --"sfo3",
         do_os = os.getenv("PERF_TEST_DIGITALOCEAN_OS"), -- "ubuntu-20-04-x64",
-        seperate_db_node = seperate_db_node,
       }
     elseif tf_provider == "aws-ec2" then
       tfvars =  {
         aws_region = os.getenv("PERF_TEST_AWS_REGION"), -- "us-east-2",
         ec2_instance_type = os.getenv("PERF_TEST_EC2_INSTANCE_TYPE"), -- "c5a.2xlarge",
         ec2_os = os.getenv("PERF_TEST_EC2_OS"), -- "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*",
-        seperate_db_node = seperate_db_node,
+      }
+    elseif tf_provider == "bring-your-own" then
+      tfvars =  {
+        kong_ip = os.getenv("PERF_TEST_BYO_KONG_IP"),
+        kong_internal_ip = os.getenv("PERF_TEST_BYO_KONG_INTERNAL_IP"), -- fallback to kong_ip
+        db_ip = os.getenv("PERF_TEST_BYO_DB_IP"),
+        db_internal_ip = os.getenv("PERF_TEST_BYO_DB_INTERNAL_IP"), -- fallback to db_ip
+        worker_ip = os.getenv("PERF_TEST_BYO_WORKER_IP"),
+        worker_internal_ip = os.getenv("PERF_TEST_BYO_WORKER_INTERNAL_IP"), -- fallback to worker_ip
+        ssh_key_path = os.getenv("PERF_TEST_BYO_SSH_KEY_PATH"),
       }
     end
+
+    tfvars.seperate_db_node = seperate_db_node
 
     use_driver("terraform", {
       provider = tf_provider,

--- a/spec/helpers/perf.lua
+++ b/spec/helpers/perf.lua
@@ -129,7 +129,7 @@ local function use_defaults()
         db_internal_ip = os.getenv("PERF_TEST_BYO_DB_INTERNAL_IP"), -- fallback to db_ip
         worker_ip = os.getenv("PERF_TEST_BYO_WORKER_IP"),
         worker_internal_ip = os.getenv("PERF_TEST_BYO_WORKER_INTERNAL_IP"), -- fallback to worker_ip
-        ssh_key_path = os.getenv("PERF_TEST_BYO_SSH_USER") or "root",
+        ssh_key_path = os.getenv("PERF_TEST_BYO_SSH_KEY_PATH") or "root",
       }
       ssh_user = os.getenv("PERF_TEST_BYO_SSH_USER")
     end

--- a/spec/helpers/perf/drivers/terraform.lua
+++ b/spec/helpers/perf/drivers/terraform.lua
@@ -550,14 +550,13 @@ function _M:get_start_load_cmd(stub, script, uri)
   script_path = script_path and ("-s " .. script_path) or ""
 
   local nproc, err
-  -- find the physical cores count, instead of counting hyperthreading
-  nproc, err = perf.execute(ssh_execute_wrap(self, self.kong_ip, [[grep '^cpu\\scores' /proc/cpuinfo | uniq |  awk '{print $4}']]))
+  nproc, err = perf.execute(ssh_execute_wrap(self, self.kong_ip, "nproc"))
   if not nproc or err then
-    return false, "failed to get core count: " .. (err or "")
+    return false, "failed to get nproc: " .. (err or "")
   end
 
   if not tonumber(nproc) then
-    return false, "failed to get core count: " .. (nproc or "")
+    return false, "failed to get nproc: " .. (nproc or "")
   end
   nproc = tonumber(nproc)
 

--- a/spec/helpers/perf/drivers/terraform.lua
+++ b/spec/helpers/perf/drivers/terraform.lua
@@ -550,13 +550,14 @@ function _M:get_start_load_cmd(stub, script, uri)
   script_path = script_path and ("-s " .. script_path) or ""
 
   local nproc, err
-  nproc, err = perf.execute(ssh_execute_wrap(self, self.kong_ip, "nproc"))
+  -- find the physical cores count, instead of counting hyperthreading
+  nproc, err = perf.execute(ssh_execute_wrap(self, self.kong_ip, [[grep '^cpu\scores' /proc/cpuinfo | uniq |  awk '{print $4}']]))
   if not nproc or err then
-    return false, "failed to get nproc: " .. (err or "")
+    return false, "failed to get core count: " .. (err or "")
   end
 
   if not tonumber(nproc) then
-    return false, "failed to get nproc: " .. (nproc or "")
+    return false, "failed to get core count: " .. (nproc or "")
   end
   nproc = tonumber(nproc)
 

--- a/spec/helpers/perf/drivers/terraform.lua
+++ b/spec/helpers/perf/drivers/terraform.lua
@@ -391,7 +391,8 @@ function _M:setup_kong(version)
     "sudo pkill -F /usr/local/kong/pids/nginx.pid || true",
     -- remove all lua files, not only those installed by package
     "sudo rm -rf /usr/local/share/lua/5.1/kong",
-    "wget -nv " .. download_path ..
+    "dpkg -I kong-" .. version .. ".deb || " .. -- check if already downloaded and valid
+        "wget -nv " .. download_path ..
         " --user " .. download_user .. " --password " .. download_pass .. " -O kong-" .. version .. ".deb",
     "sudo dpkg -i kong-" .. version .. ".deb || sudo apt-get -f -y install",
     -- generate hybrid cert

--- a/spec/helpers/perf/drivers/terraform.lua
+++ b/spec/helpers/perf/drivers/terraform.lua
@@ -31,10 +31,7 @@ function _M.new(opts)
     end
   end
 
-  local ssh_user = "root"
-  if opts.provider == "aws-ec2" then
-    ssh_user = "ubuntu"
-  end
+  local ssh_user = opts.ssh_user or "root"
 
   return setmetatable({
     opts = opts,

--- a/spec/helpers/perf/drivers/terraform.lua
+++ b/spec/helpers/perf/drivers/terraform.lua
@@ -168,13 +168,16 @@ end
 function _M:teardown(full)
   self.setup_kong_called = false
 
-  local _, err = execute_batch(self, self.kong_ip, {
-    "sudo rm -rf /usr/local/kong_* /usr/local/kong || true",
-    "sudo pkill -kill nginx || true",
-    "sudo dpkg -r kong || true",
-  })
-  if err then
-    return false, err
+  -- only run remote execute when terraform provisioned
+  if self.kong_ip then
+    local _, err = execute_batch(self, self.kong_ip, {
+      "sudo rm -rf /usr/local/kong_* /usr/local/kong || true",
+      "sudo pkill -kill nginx || true",
+      "sudo dpkg -r kong || true",
+    })
+    if err then
+      return false, err
+    end
   end
 
   if full then

--- a/spec/helpers/perf/drivers/terraform.lua
+++ b/spec/helpers/perf/drivers/terraform.lua
@@ -549,7 +549,8 @@ function _M:get_start_load_cmd(stub, script, uri)
   script_path = script_path and ("-s " .. script_path) or ""
 
   local nproc, err
-  nproc, err = perf.execute(ssh_execute_wrap(self, self.kong_ip, "nproc"))
+  -- find the physical cores count, instead of counting hyperthreading
+  nproc, err = perf.execute(ssh_execute_wrap(self, self.kong_ip, "grep ^cpu\\scores /proc/cpuinfo | uniq |  awk '{print $4}'"))
   if not nproc or err then
     return false, "failed to get nproc: " .. (err or "")
   end

--- a/spec/helpers/perf/drivers/terraform.lua
+++ b/spec/helpers/perf/drivers/terraform.lua
@@ -391,7 +391,7 @@ function _M:setup_kong(version)
     "sudo pkill -F /usr/local/kong/pids/nginx.pid || true",
     -- remove all lua files, not only those installed by package
     "sudo rm -rf /usr/local/share/lua/5.1/kong",
-    "dpkg -I kong-" .. version .. ".deb || " .. -- check if already downloaded and valid
+    "dpkg -I kong-" .. version .. ".deb || " .. -- check if already downloaded and valid because pulp flaky
         "wget -nv " .. download_path ..
         " --user " .. download_user .. " --password " .. download_pass .. " -O kong-" .. version .. ".deb",
     "sudo dpkg -i kong-" .. version .. ".deb || sudo apt-get -f -y install",
@@ -551,13 +551,13 @@ function _M:get_start_load_cmd(stub, script, uri)
 
   local nproc, err
   -- find the physical cores count, instead of counting hyperthreading
-  nproc, err = perf.execute(ssh_execute_wrap(self, self.kong_ip, "grep ^cpu\\scores /proc/cpuinfo | uniq |  awk '{print $4}'"))
+  nproc, err = perf.execute(ssh_execute_wrap(self, self.kong_ip, [[grep '^cpu\\scores' /proc/cpuinfo | uniq |  awk '{print $4}']]))
   if not nproc or err then
-    return false, "failed to get nproc: " .. (err or "")
+    return false, "failed to get core count: " .. (err or "")
   end
 
   if not tonumber(nproc) then
-    return false, "failed to get nproc: " .. (nproc or "")
+    return false, "failed to get core count: " .. (nproc or "")
   end
   nproc = tonumber(nproc)
 


### PR DESCRIPTION
This PR moves the perf test in CI off equinix and to a pre-provisioned provider.