### PR TITLE
fix(statsd) remove must type limitation

### DIFF
--- a/kong/plugins/statsd/schema.lua
+++ b/kong/plugins/statsd/schema.lua
@@ -116,15 +116,6 @@ local MUST_TYPE = {}
 local MUST_IDENTIFIER = {}
 
 for _, metric in ipairs(DEFAULT_METRICS) do
-  local typ = metric.stat_type
-  if typ == "counter" or typ == "set" or typ == "gauge" then
-    if not MUST_TYPE[typ] then
-      MUST_TYPE[typ] = { metric.name }
-    else
-      MUST_TYPE[typ][#MUST_TYPE[typ]+1] = metric.name
-    end
-  end
-
   for _, id in ipairs({ "service", "consumer", "workspace"}) do
     if metric[id .. "_identifier"] then
       if not MUST_IDENTIFIER[id] then
@@ -160,24 +151,6 @@ return {
                   { workspace_identifier = { type = "string", one_of = WORKSPACE_IDENTIFIERS }, },
                 },
                 entity_checks = {
-                  { conditional = {
-                    if_field = "name",
-                    if_match = { one_of = MUST_TYPE["set"] },
-                    then_field = "stat_type",
-                    then_match = { eq = "set" },
-                  }, },
-                  { conditional = {
-                    if_field = "name",
-                    if_match = { one_of = MUST_TYPE["counter"] },
-                    then_field = "stat_type",
-                    then_match = { eq = "counter" },
-                  }, },
-                  { conditional = {
-                    if_field = "name",
-                    if_match = { one_of = MUST_TYPE["gauge"] },
-                    then_field = "stat_type",
-                    then_match = { eq = "gauge" },
-                  }, },
                   { conditional = {
                     if_field = "stat_type",
                     if_match = { one_of = { "counter", "gauge" }, },

--- a/kong/plugins/statsd/schema.lua
+++ b/kong/plugins/statsd/schema.lua
@@ -111,8 +111,6 @@ local DEFAULT_METRICS = {
 }
 
 
-local MUST_TYPE = {}
-
 local MUST_IDENTIFIER = {}
 
 for _, metric in ipairs(DEFAULT_METRICS) do

--- a/spec/03-plugins/06-statsd/02-schema_spec.lua
+++ b/spec/03-plugins/06-statsd/02-schema_spec.lua
@@ -43,7 +43,7 @@ describe("Plugin: statsd (schema)", function()
     }
     _, err = validate_entity({ metrics = metrics_input}, statsd_schema)
     assert.not_nil(err)
-    assert.equal("field required for entity check", err.config.metrics[1].name)
+    assert.equal("required field missing", err.config.metrics[1].name)
   end)
   it("rejects counters without sample rate", function()
     local metrics_input = {
@@ -76,7 +76,7 @@ describe("Plugin: statsd (schema)", function()
     }
     local _, err = validate_entity({ metrics = metrics_input}, statsd_schema)
     assert.not_nil(err)
-    assert.equal("value must be counter", err.config.metrics[1].stat_type)
+    assert.equal("expected one of: counter, gauge, histogram, meter, set, timer", err.config.metrics[1].stat_type)
   end)
   it("rejects invalid service identifier", function()
     local metrics_input = {
@@ -141,27 +141,6 @@ describe("Plugin: statsd (schema)", function()
     local ok, err = validate_entity({ metrics = metrics_input}, statsd_schema)
     assert.is_nil(err)
     assert.is_truthy(ok)
-  end)
-  it("rejects if metric has wrong stat type", function()
-    local metrics_input = {
-      {
-        name = "unique_users",
-        stat_type = "counter"
-      }
-    }
-    local _, err = validate_entity({ metrics = metrics_input}, statsd_schema)
-    assert.not_nil(err)
-    assert.equal("value must be set", err.config.metrics[1].stat_type)
-    metrics_input = {
-      {
-        name = "status_count",
-        stat_type = "set",
-        sample_rate = 1
-      }
-    }
-    _, err = validate_entity({ metrics = metrics_input}, statsd_schema)
-    assert.not_nil(err)
-    assert.equal("value must be counter", err.config.metrics[1].stat_type)
   end)
   it("accepts empty allow status codes configuration parameter", function()
     local allow_status_codes_input = {}


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary
remove stated metric must type limitation
<!--- Why is this change required? What problem does it solve? -->

### Full changelog

* remove the constraint to disallow user configure different metrics types, to align with the previous statsd plugin behaviour

### Issue reference
#9659 
FT-3518