### PR TITLE
chore(deps) bump resty.openssl from 0.8.14 to 0.8.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,9 +188,10 @@
 
 - Bumped atc-router from 1.0.0 to 1.0.1
   [#9558](https://github.com/Kong/kong/pull/9558)
-- Bumped lua-resty-openssl from 0.8.10 to 0.8.14
+- Bumped lua-resty-openssl from 0.8.10 to 0.8.15
   [#9583](https://github.com/Kong/kong/pull/9583)
   [#9600](https://github.com/Kong/kong/pull/9600)
+  [#9675](https://github.com/Kong/kong/pull/9675)
 - Bumped lyaml from 6.2.7 to 6.2.8
   [#9607](https://github.com/Kong/kong/pull/9607)
 - Bumped lua-resty-acme from 0.8.1 to 0.9.0

--- a/kong-3.1.0-0.rockspec
+++ b/kong-3.1.0-0.rockspec
@@ -36,7 +36,7 @@ dependencies = {
   "lua-resty-healthcheck == 1.6.1",
   "lua-resty-mlcache == 2.6.0",
   "lua-messagepack == 0.5.2",
-  "lua-resty-openssl == 0.8.14",
+  "lua-resty-openssl == 0.8.15",
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6.1",
   "lua-resty-acme == 0.9.0",


### PR DESCRIPTION
### Summary

#### [0.8.15] - 2022-10-27
##### bug fixes
- **pkey:** check private key existence before doing sign ([#83](https://github.com/fffonion/lua-resty-openssl/issues/83)) [eefcd2a](https://github.com/fffonion/lua-resty-openssl/commit/eefcd2a80b240f44be0bdadd1c2ccc28612004c0)