### PR TITLE
tests(helpers): retry all safe admin client requests

### DIFF
--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -731,7 +731,7 @@ function resty_http_proxy_mt:send(opts, is_reopen)
       return self._cached_body, self._cached_error
     end
 
-  elseif err == "closed"
+  elseif (err == "closed" or err == "connection reset by peer")
      and not is_reopen
      and self.reopen
      and can_reopen(opts.method)

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -932,7 +932,8 @@ local function admin_client(timeout, forced_port)
     scheme = "http",
     host = admin_ip,
     port = forced_port or admin_port,
-    timeout = timeout or 60000
+    timeout = timeout or 60000,
+    reopen = true,
   })
 end
 
@@ -953,6 +954,7 @@ local function admin_ssl_client(timeout)
     host = admin_ip,
     port = admin_port,
     timeout = timeout or 60000,
+    reopen = true,
   })
   return client
 end


### PR DESCRIPTION
This sets the `reopen` flag for the admin client in `spec.helpers`, meaning all `GET`, `HEAD`, `OPTIONS`, and `TRACE` requests with the admin client will be retried with a new connection when there is a TCP level error. This should make our tests a little more resilient to transient problems that can occur in CI.

Requests are only retried once per connection, so there is no risk of getting stuck in a loop if something is actually down.

Integration tests for this functionality were added in #8932; all this PR does is turn it on by default.