### PR TITLE
Fixed #9692 missing yaml-dev dependency in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,4 +6,5 @@ RUN apk add --update \
         alpine-sdk \
         build-base \
         bsd-compat-headers \
-        m4
+        m4 \
+        yaml-dev


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Fixed missing yaml-dev dependency in devcontainer

### Full changelog

* Add yaml-dev dependency to devcontainer

### Issue reference

Fix #9692 
