### PR TITLE
test(healthcheck): add test cases for healthcheck status reported by admin api

### DIFF
--- a/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -598,6 +598,9 @@ describe("Admin API #" .. strategy, function()
           })
           assert.same(200, status)
 
+          -- Give time for weight modification to kick in
+          ngx.sleep(0.3)
+
           local status, body = client_send({
             method = "GET",
             path = "/upstreams/" .. upstream.name .. "/health",


### PR DESCRIPTION
add test cases for healthcheck status reported by Admin API endpoint '/upstream/health'.

The health status of targets with weight 0 reported by Admin API was changed from HEALTHY to HEALTHCHECK_OFF in [#9065](https://github.com/Kong/kong/pull/9065). The test cases added in this PR want to cover those changes.
