### PR TITLE
chore(tests) add concurrency control

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -13,6 +13,11 @@ on:
     - release/*
     - test-please/*
 
+# cancel previous runs if new commits are pushed to the PR, but run for each commit on master
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build dependencies

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -12,6 +12,11 @@ env:
   terraform_version: '1.2.4'
   DOWNLOAD_ROOT: $HOME/download-root
 
+
+# perf test can only run one at a time per repo for now
+concurrency:
+  group: perf-ce
+
 jobs:
   build:
     name: Build dependencies

--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -13,6 +13,10 @@ on:
     - master
     - release/*
     - test-please/*
+# cancel previous runs if new commits are pushed to the PR, but run for each commit on master
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   upgrade-test:


### PR DESCRIPTION
Cancel previous runs if new commits are pushed to the PR, but run for each commit on master.

Ensure only one perf test run at a time, as we move to shared machines.