### PR TITLE
chore(autodocs): use `ubuntu-22.04` for autodoc as well

### DIFF
--- a/.github/workflows/autodocs.yml
+++ b/.github/workflows/autodocs.yml
@@ -70,7 +70,7 @@ jobs:
           source .ci/setup_env_github.sh
           make dev
   autodoc:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [build]
     steps:
       - name: Set environment variables


### PR DESCRIPTION
The labelers are intentionally left on `ubuntu-latest` as they are very simple workflows that should be able to run on any version of OS.

`ubuntu-latest` is currently still pointing at `ubuntu-20.04`, change `autodoc` jobs to make it consistent.