### PR TITLE
chore(declarative) add some additional documentation

### DIFF
--- a/kong/templates/kong_yml.lua
+++ b/kong/templates/kong_yml.lua
@@ -21,6 +21,16 @@ _format_version: "3.0"
 
 _transform: true
 
+# Custom annotations can be added via _comment and _ignore fields. The comments
+# must be strings, and the ignored fields must be an array, carrying any type as
+# values. These two can appear on the top-level of the file and on the top-level
+# of any entity.
+
+_comment: This is a top level comment, and must be a string
+_ignore:
+- This array entry will be ignored
+- as well as this one
+
 # Each Kong entity (core entity or custom entity introduced by a plugin)
 # can be listed in the top-level as an array of objects:
 


### PR DESCRIPTION
Documents the _comment and _ignore fields in the declarative format. The diocumentation is added to the template that is used to create a base file when running `kong config init` in the cli.
