### PR TITLE
chore(ci): remove CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-*   @Kong/gateway


### PR DESCRIPTION
### Summary

CODEOWNERS file was originally added in
Kong/kong#8691.
The rationale at the time was to make sure all PRs are approved and merged only after maintainers have reviewed the change. Since then, we have come a long way.
PRs now are merged only after a moderator
on the team has taken a look at the PR and only moderators have permission to perform a merge.

This commit removes the CODEOWNERS file. My rationale is that the number of Kong maintainers is large and every change to every PR results in a notification to all members. This results in a very signal-to-noise ratio and a lot of members deal with a very high notification volume. My hypothesis here is that lowering the notification volume will help most members and they can deal with a smaller set of PRs on a daily basis.

A select few members like myself are going to load-balance PR reviews across maintainers. This along with a lower notification volume should help us become a bit more productive and happy.

After this change is merged in, you are welcome to add CODEOWNERS file to specific directories within the repository to ensure that the subject matter expert gets notified of changes and is requested a review. A good example of a targeted CODEOWNERS is a plugin or a sub-system like DAO.

### Full changelog

* Remove the CODEOWNERS file.

### Issue reference

None
