### PR TITLE
tests(router/atc): escape '\' in regex path properly

### DIFF
--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -134,7 +134,8 @@ local function get_expression(route)
       -- 1. strip leading `~`
       -- 2. prefix with `^` to match the anchored behavior of the traditional router
       -- 3. update named capture opening tag for rust regex::Regex compatibility
-      return "^" .. p:sub(2):gsub("?<", "?P<")
+      -- 4. transform '\' to '\\'
+      return "^" .. p:sub(2):gsub("?<", "?P<"):gsub([[\]], [[\\]])
     end
 
     return p

--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -134,8 +134,7 @@ local function get_expression(route)
       -- 1. strip leading `~`
       -- 2. prefix with `^` to match the anchored behavior of the traditional router
       -- 3. update named capture opening tag for rust regex::Regex compatibility
-      -- 4. transform '\' to '\\'
-      return "^" .. p:sub(2):gsub("?<", "?P<"):gsub([[\]], [[\\]])
+      return "^" .. p:sub(2):gsub("?<", "?P<")
     end
 
     return p

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -2158,7 +2158,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
             }
           end)
 
-          it("regex path has '\\'", function()
+          it("regex path has double '\\'", function()
             use_case[1].route.paths = { [[~/\\/*$]], }
 
             assert.equal([[(http.method == "GET") && (http.path ~ "^/\\\\/*$")]],

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -2142,7 +2142,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
           end
         end)
 
-        describe("check regex with '\\'", function()
+        describe("#only check regex with '\\'", function()
           local use_case
           local _get_expression = atc_compat._get_expression
 
@@ -2161,8 +2161,16 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
           it("regex path has '\\'", function()
             use_case[1].route.paths = { "~/\\/*$", }
 
-            assert.equal(_get_expression(use_case[1].route),
-                         [[(http.method == "GET") && (http.path ~ "^/\\\\/*$")]])
+            assert.equal([[(http.method == "GET") && (http.path ~ "^/\\\\/*$")]],
+                         _get_expression(use_case[1].route))
+            assert(new_router(use_case))
+          end)
+
+          it("regex path has '\\d'", function()
+            use_case[1].route.paths = { "~/\\d+", }
+
+            assert.equal([[(http.method == "GET") && (http.path ~ "^/\\\\d+")]],
+                         _get_expression(use_case[1].route))
             assert(new_router(use_case))
           end)
         end)

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -2141,6 +2141,32 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
             end)
           end
         end)
+
+        describe("check regex with '\\'", function()
+          local use_case
+          local _get_expression = atc_compat._get_expression
+
+          before_each(function()
+            use_case = {
+              {
+                service = service,
+                route = {
+                  id = "e8fb37f1-102d-461e-9c51-6608a6bb8101",
+                  methods = { "GET" },
+                  paths = { "/foo", },
+                },
+              },
+            }
+          end)
+
+          it("regex path has '\\'", function()
+            use_case[1].route.paths = { "~/\\/*$", }
+
+            assert.equal(_get_expression(use_case[1].route),
+                         [[(http.method == "GET") && (http.path ~ "^/\\\\/*$")]])
+            assert(new_router(use_case))
+          end)
+        end)
       end
 
       describe("normalization stopgap measurements", function()

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -2142,7 +2142,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
           end
         end)
 
-        describe("#only check regex with '\\'", function()
+        describe("check regex with '\\'", function()
           local use_case
           local _get_expression = atc_compat._get_expression
 
@@ -2159,7 +2159,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
           end)
 
           it("regex path has '\\'", function()
-            use_case[1].route.paths = { "~/\\/*$", }
+            use_case[1].route.paths = { [[~/\\/*$]], }
 
             assert.equal([[(http.method == "GET") && (http.path ~ "^/\\\\/*$")]],
                          _get_expression(use_case[1].route))
@@ -2167,9 +2167,9 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
           end)
 
           it("regex path has '\\d'", function()
-            use_case[1].route.paths = { "~/\\d+", }
+            use_case[1].route.paths = { [[~/\d+]], }
 
-            assert.equal([[(http.method == "GET") && (http.path ~ "^/\\\\d+")]],
+            assert.equal([[(http.method == "GET") && (http.path ~ "^/\\d+")]],
                          _get_expression(use_case[1].route))
             assert(new_router(use_case))
           end)

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -2153,7 +2153,6 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
                 route = {
                   id = "e8fb37f1-102d-461e-9c51-6608a6bb8101",
                   methods = { "GET" },
-                  paths = { "/foo", },
                 },
               },
             }


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

We already transform '\\' to '\\\\' in regex path with function `atc.escape_str()`,
now we add more test cases to make sure it works well.

See FTI-4444.


