### PR TITLE
fix(dns): cache by fqdn, return fqdn

### DIFF
--- a/kong/resty/dns/client.lua
+++ b/kong/resty/dns/client.lua
@@ -521,7 +521,7 @@ _M.init = function(options)
     name = string_lower(name)
     if address.ipv4 then
       cacheinsert({{  -- NOTE: nested list! cache is a list of lists
-          name = name..".",
+          name = name .. ".",
           address = address.ipv4,
           type = _M.TYPE_A,
           class = 1,
@@ -535,7 +535,7 @@ _M.init = function(options)
     end
     if address.ipv6 then
       cacheinsert({{  -- NOTE: nested list! cache is a list of lists
-          name = name..".",
+          name = name .. ".",
           address = address.ipv6,
           type = _M.TYPE_AAAA,
           class = 1,
@@ -650,13 +650,6 @@ _M.init = function(options)
       searchOrder[#searchOrder + 1] = search
     end
   end
-  -- check if there is special domain like "."
-  -- for i = #options.search, 1, -1 do
-  --   if options.search[i] == "." then
-  --     table_remove(options.search, i)
-  --   end
-  -- end
-
 
   -- other options
 
@@ -696,20 +689,10 @@ end
 -- Parameter `answers` is updated in-place.
 -- @return `true`
 local function parseAnswer(qname, qtype, answers, try_list)
---print("title: ", require("pl.pretty").write(answers))
   -- check the answers and store them in the cache
   -- eg. A, AAAA, SRV records may be accompanied by CNAME records
   -- store them all, leaving only the requested type in so we can return that set
   local others = {}
-
-  -- remove last '.' from FQDNs as the answer does not contain it
-  local check_qname do
-    -- if string_byte(qname, -1) == DOT then
-    --   check_qname = qname:sub(1, -2) -- FQDN, drop the last dot
-    -- else
-      check_qname = qname
-    -- end
-  end
 
   for i = #answers, 1, -1 do -- we're deleting entries, so reverse the traversal
     local answer = answers[i]
@@ -723,7 +706,7 @@ local function parseAnswer(qname, qtype, answers, try_list)
       answer.target = fqdn(answer.target)
     end
 
-    if (answer.type ~= qtype) or (answer.name ~= check_qname) then
+    if (answer.type ~= qtype) or (answer.name ~= qname) then
       local key = answer.type..":"..answer.name
       try_status(try_list, key .. " removed")
       local lst = others[key]

--- a/kong/runloop/balancer/balancers.lua
+++ b/kong/runloop/balancer/balancers.lua
@@ -337,8 +337,14 @@ local function setHostHeader(addr)
     else
       -- the address itself is a nested name (SRV)
       if addr.useSRVname then
-        addr.hostHeader = addr.ip
+        local host = addr.ip
+        if host:sub(-1,-1) == "." then
+          -- for host header strip fqdn . at the end (originates from DNS)
+          host = host:sub(1,-2)
+        end
+        addr.hostHeader = host
       else
+        -- no need to strip trailing '.' since this name is user provided
         addr.hostHeader = target.name
       end
     end

--- a/kong/runloop/balancer/targets.lua
+++ b/kong/runloop/balancer/targets.lua
@@ -49,7 +49,7 @@ function targets_M.init()
   dns_client = require("kong.tools.dns")(kong.configuration)    -- configure DNS client
   if renewal_heap:size() > 0 then
     renewal_heap = require("binaryheap").minUnique()
-    renewal_weak_cache = setmetatable({}, { __mode = "v" })    
+    renewal_weak_cache = setmetatable({}, { __mode = "v" })
   end
 
 

--- a/spec/01-unit/09-balancer/01-generic_spec.lua
+++ b/spec/01-unit/09-balancer/01-generic_spec.lua
@@ -1757,7 +1757,7 @@ for _, algorithm in ipairs{ "consistent-hashing", "least-connections", "round-ro
             { name = "getkong.test.", address = "5.6.7.8", ttl = 0 },
           })
           add_target(b, "getkong.test.", 5678, 1000)
-          add_target(b, "notachanceinhell.this.name.exists.konghq.com.", 4321, 100)
+          add_target(b, "notevenoneinamillionchance.this.name.exists.konghq.test.", 4321, 100)
 
           local status = b:getStatus()
           table.sort(status.hosts, function(hostA, hostB) return hostA.host < hostB.host end)
@@ -1828,7 +1828,7 @@ for _, algorithm in ipairs{ "consistent-hashing", "least-connections", "round-ro
                 },
               },
               {
-                host = "notachanceinhell.this.name.exists.konghq.com.",
+                host = "notevenoneinamillionchance.this.name.exists.konghq.test.",
                 port = 4321,
                 dns = "dns server error: 3 name error",
                 nodeWeight = 100,

--- a/spec/01-unit/09-balancer/01-generic_spec.lua
+++ b/spec/01-unit/09-balancer/01-generic_spec.lua
@@ -308,8 +308,8 @@ for _, algorithm in ipairs{ "consistent-hashing", "least-connections", "round-ro
 
         it("adding a host",function()
           dnsA({
-            { name = "arecord.tst", address = "1.2.3.4" },
-            { name = "arecord.tst", address = "5.6.7.8" },
+            { name = "arecord.tst.", address = "1.2.3.4" },
+            { name = "arecord.tst.", address = "5.6.7.8" },
           })
 
           assert.same({
@@ -401,8 +401,8 @@ for _, algorithm in ipairs{ "consistent-hashing", "least-connections", "round-ro
 
         it("switching address availability",function()
           dnsA({
-            { name = "arecord.tst", address = "1.2.3.4" },
-            { name = "arecord.tst", address = "5.6.7.8" },
+            { name = "arecord.tst.", address = "1.2.3.4" },
+            { name = "arecord.tst.", address = "5.6.7.8" },
           })
 
           assert.same({
@@ -609,8 +609,8 @@ for _, algorithm in ipairs{ "consistent-hashing", "least-connections", "round-ro
 
         it("changing weight of an available address",function()
           dnsA({
-            { name = "arecord.tst", address = "1.2.3.4" },
-            { name = "arecord.tst", address = "5.6.7.8" },
+            { name = "arecord.tst.", address = "1.2.3.4" },
+            { name = "arecord.tst.", address = "5.6.7.8" },
           })
 
           add_target(b, "arecord.tst", 8001, 25)
@@ -728,8 +728,8 @@ for _, algorithm in ipairs{ "consistent-hashing", "least-connections", "round-ro
 
         it("changing weight of an unavailable address",function()
           dnsA({
-            { name = "arecord.tst", address = "1.2.3.4" },
-            { name = "arecord.tst", address = "5.6.7.8" },
+            { name = "arecord.tst.", address = "1.2.3.4" },
+            { name = "arecord.tst.", address = "5.6.7.8" },
           })
 
           add_target(b, "arecord.tst", 8001, 25)
@@ -908,8 +908,8 @@ for _, algorithm in ipairs{ "consistent-hashing", "least-connections", "round-ro
 
         it("adding a host",function()
           dnsSRV({
-            { name = "srvrecord.tst", target = "1.1.1.1", port = 9000, weight = 10 },
-            { name = "srvrecord.tst", target = "2.2.2.2", port = 9001, weight = 10 },
+            { name = "srvrecord.tst.", target = "1.1.1.1", port = 9000, weight = 10 },
+            { name = "srvrecord.tst.", target = "2.2.2.2", port = 9001, weight = 10 },
           })
 
           add_target(b, "srvrecord.tst", 8001, 25)
@@ -971,8 +971,8 @@ for _, algorithm in ipairs{ "consistent-hashing", "least-connections", "round-ro
 
         it("switching address availability",function()
           dnsSRV({
-            { name = "srvrecord.tst", target = "1.1.1.1", port = 9000, weight = 10 },
-            { name = "srvrecord.tst", target = "2.2.2.2", port = 9001, weight = 10 },
+            { name = "srvrecord.tst.", target = "1.1.1.1", port = 9000, weight = 10 },
+            { name = "srvrecord.tst.", target = "2.2.2.2", port = 9001, weight = 10 },
           })
 
           add_target(b, "srvrecord.tst", 8001, 25)
@@ -1148,8 +1148,8 @@ for _, algorithm in ipairs{ "consistent-hashing", "least-connections", "round-ro
 
         it("changing weight of an available address (dns update)",function()
           local record = dnsSRV({
-            { name = "srvrecord.tst", target = "1.1.1.1", port = 9000, weight = 10 },
-            { name = "srvrecord.tst", target = "2.2.2.2", port = 9001, weight = 10 },
+            { name = "srvrecord.tst.", target = "1.1.1.1", port = 9000, weight = 10 },
+            { name = "srvrecord.tst.", target = "2.2.2.2", port = 9001, weight = 10 },
           })
 
           add_target(b, "srvrecord.tst", 8001, 10)
@@ -1210,8 +1210,8 @@ for _, algorithm in ipairs{ "consistent-hashing", "least-connections", "round-ro
 
           dnsExpire(record)
           dnsSRV({
-            { name = "srvrecord.tst", target = "1.1.1.1", port = 9000, weight = 20 },
-            { name = "srvrecord.tst", target = "2.2.2.2", port = 9001, weight = 20 },
+            { name = "srvrecord.tst.", target = "1.1.1.1", port = 9000, weight = 20 },
+            { name = "srvrecord.tst.", target = "2.2.2.2", port = 9001, weight = 20 },
           })
           targets.resolve_targets(b.targets)  -- touch all adresses to force dns renewal
           add_target(b, "srvrecord.tst", 8001, 99) -- add again to update nodeWeight
@@ -1274,8 +1274,8 @@ for _, algorithm in ipairs{ "consistent-hashing", "least-connections", "round-ro
 
         it("changing weight of an unavailable address (dns update)",function()
           local record = dnsSRV({
-            { name = "srvrecord.tst", target = "1.1.1.1", port = 9000, weight = 10 },
-            { name = "srvrecord.tst", target = "2.2.2.2", port = 9001, weight = 10 },
+            { name = "srvrecord.tst.", target = "1.1.1.1", port = 9000, weight = 10 },
+            { name = "srvrecord.tst.", target = "2.2.2.2", port = 9001, weight = 10 },
           })
 
           add_target(b, "srvrecord.tst", 8001, 25)
@@ -1394,8 +1394,8 @@ for _, algorithm in ipairs{ "consistent-hashing", "least-connections", "round-ro
           -- update weight, through dns renewal
           dnsExpire(record)
           dnsSRV({
-            { name = "srvrecord.tst", target = "1.1.1.1", port = 9000, weight = 20 },
-            { name = "srvrecord.tst", target = "2.2.2.2", port = 9001, weight = 20 },
+            { name = "srvrecord.tst.", target = "1.1.1.1", port = 9000, weight = 20 },
+            { name = "srvrecord.tst.", target = "2.2.2.2", port = 9001, weight = 20 },
           })
           targets.resolve_targets(b.targets)  -- touch all adresses to force dns renewal
           add_target(b, "srvrecord.tst", 8001, 99) -- add again to update nodeWeight
@@ -1545,7 +1545,7 @@ for _, algorithm in ipairs{ "consistent-hashing", "least-connections", "round-ro
 
       it("returns expected results/types when using SRV with IP", function()
         dnsSRV({
-          { name = "konghq.com", target = "1.1.1.1", port = 2, weight = 3 },
+          { name = "konghq.com.", target = "1.1.1.1", port = 2, weight = 3 },
         })
         add_target(b, "konghq.com", 8000, 50)
         local ip, port, hostname, handle = b:getPeer(true, nil, "a string")
@@ -1558,10 +1558,10 @@ for _, algorithm in ipairs{ "consistent-hashing", "least-connections", "round-ro
 
       it("returns expected results/types when using SRV with name ('useSRVname=false')", function()
         dnsA({
-          { name = "getkong.org", address = "1.2.3.4" },
+          { name = "getkong.org.", address = "1.2.3.4" },
         })
         dnsSRV({
-          { name = "konghq.com", target = "getkong.org", port = 2, weight = 3 },
+          { name = "konghq.com.", target = "getkong.org.", port = 2, weight = 3 },
         })
         add_target(b, "konghq.com", 8000, 50)
         local ip, port, hostname, handle = b:getPeer(true, nil, "a string")
@@ -1576,10 +1576,10 @@ for _, algorithm in ipairs{ "consistent-hashing", "least-connections", "round-ro
         b.useSRVname = true -- override setting specified when creating
 
         dnsA({
-          { name = "getkong.org", address = "1.2.3.4" },
+          { name = "getkong.org.", address = "1.2.3.4" },
         })
         dnsSRV({
-          { name = "konghq.com", target = "getkong.org", port = 2, weight = 3 },
+          { name = "konghq.com.", target = "getkong.org.", port = 2, weight = 3 },
         })
         add_target(b, "konghq.com", 8000, 50)
         local ip, port, hostname, handle = b:getPeer(true, nil, "a string")
@@ -1592,7 +1592,7 @@ for _, algorithm in ipairs{ "consistent-hashing", "least-connections", "round-ro
 
       it("returns expected results/types when using A", function()
         dnsA({
-          { name = "getkong.org", address = "1.2.3.4" },
+          { name = "getkong.org.", address = "1.2.3.4" },
         })
         add_target(b, "getkong.org", 8000, 50)
         local ip, port, hostname, handle = b:getPeer(true, nil, "another string")
@@ -1688,7 +1688,7 @@ for _, algorithm in ipairs{ "consistent-hashing", "least-connections", "round-ro
 
       it("recovers when dns entries are replaced by healthy ones", function()
         local record = dnsA({
-          { name = "getkong.org", address = "1.2.3.4", ttl = 2 },
+          { name = "getkong.org.", address = "1.2.3.4", ttl = 2 },
         })
         add_target(b, "getkong.org", 8000, 50)
         assert.not_nil(b:getPeer(true, nil, "from the client"))
@@ -1706,7 +1706,7 @@ for _, algorithm in ipairs{ "consistent-hashing", "least-connections", "round-ro
         -- balancer should now recover since a new healthy backend is available
         record.expire = 0
         dnsA({
-          { name = "getkong.org", address = "5.6.7.8", ttl = 60 },
+          { name = "getkong.org.", address = "5.6.7.8", ttl = 60 },
         })
         targets.resolve_targets(b.targets)
 
@@ -1749,12 +1749,12 @@ for _, algorithm in ipairs{ "consistent-hashing", "least-connections", "round-ro
           add_target(b, "127.0.0.1", 8000, 100)
           add_target(b, "0::1", 8080, 50)
           dnsSRV({
-            { name = "srvrecord.tst", target = "1.1.1.1", port = 9000, weight = 10 },
-            { name = "srvrecord.tst", target = "2.2.2.2", port = 9001, weight = 10 },
+            { name = "srvrecord.tst.", target = "1.1.1.1", port = 9000, weight = 10 },
+            { name = "srvrecord.tst.", target = "2.2.2.2", port = 9001, weight = 10 },
           })
           add_target(b, "srvrecord.tst", 1234, 9999)
           dnsA({
-            { name = "getkong.org", address = "5.6.7.8", ttl = 0 },
+            { name = "getkong.org.", address = "5.6.7.8", ttl = 0 },
           })
           add_target(b, "getkong.org", 5678, 1000)
           add_target(b, "notachanceinhell.this.name.exists.konghq.com", 4321, 100)

--- a/spec/01-unit/09-balancer/01-generic_spec.lua
+++ b/spec/01-unit/09-balancer/01-generic_spec.lua
@@ -1480,10 +1480,10 @@ for _, algorithm in ipairs{ "consistent-hashing", "least-connections", "round-ro
 
       it("returns expected results/types when using SRV with name ('useSRVname=false')", function()
         dnsA({
-          { name = "getkong.org", address = "1.2.3.4" },
+          { name = "getkong.org.", address = "1.2.3.4" },
         })
         dnsSRV({
-          { name = "konghq.com", target = "getkong.org", port = 2, weight = 3 },
+          { name = "konghq.com.", target = "getkong.org.", port = 2, weight = 3 },
         })
         add_target(b, "konghq.com", 8000, 50)
         local ip, port, hostname, handle = b:getPeer(true, nil, "a string")
@@ -1513,10 +1513,10 @@ for _, algorithm in ipairs{ "consistent-hashing", "least-connections", "round-ro
 
       it("returns expected results/types when using SRV with name ('useSRVname=true')", function()
         dnsA({
-          { name = "getkong.org", address = "1.2.3.4" },
+          { name = "getkong.org.", address = "1.2.3.4" },
         })
         dnsSRV({
-          { name = "konghq.com", target = "getkong.org", port = 2, weight = 3 },
+          { name = "konghq.com.", target = "getkong.org.", port = 2, weight = 3 },
         })
         add_target(b, "konghq.com", 8000, 50)
         local ip, port, hostname, handle = b:getPeer(true, nil, "a string")
@@ -1545,29 +1545,29 @@ for _, algorithm in ipairs{ "consistent-hashing", "least-connections", "round-ro
 
       it("returns expected results/types when using SRV with IP", function()
         dnsSRV({
-          { name = "konghq.com.", target = "1.1.1.1", port = 2, weight = 3 },
+          { name = "konghq.test.", target = "1.1.1.1", port = 2, weight = 3 },
         })
-        add_target(b, "konghq.com", 8000, 50)
+        add_target(b, "konghq.test", 8000, 50)
         local ip, port, hostname, handle = b:getPeer(true, nil, "a string")
         assert.equal("1.1.1.1", ip)
         assert.equal(2, port)
-        assert.equal("konghq.com", hostname)
+        assert.equal("konghq.test", hostname)
         assert.not_nil(handle)
       end)
 
 
       it("returns expected results/types when using SRV with name ('useSRVname=false')", function()
         dnsA({
-          { name = "getkong.org.", address = "1.2.3.4" },
+          { name = "getkong.test.", address = "1.2.3.4" },
         })
         dnsSRV({
-          { name = "konghq.com.", target = "getkong.org.", port = 2, weight = 3 },
+          { name = "konghq.test.", target = "getkong.test.", port = 2, weight = 3 },
         })
-        add_target(b, "konghq.com", 8000, 50)
+        add_target(b, "konghq.test", 8000, 50)
         local ip, port, hostname, handle = b:getPeer(true, nil, "a string")
         assert.equal("1.2.3.4", ip)
         assert.equal(2, port)
-        assert.equal("konghq.com", hostname)
+        assert.equal("konghq.test", hostname)
         assert.not_nil(handle)
       end)
 
@@ -1576,29 +1576,29 @@ for _, algorithm in ipairs{ "consistent-hashing", "least-connections", "round-ro
         b.useSRVname = true -- override setting specified when creating
 
         dnsA({
-          { name = "getkong.org.", address = "1.2.3.4" },
+          { name = "getkong.test.", address = "1.2.3.4" },
         })
         dnsSRV({
-          { name = "konghq.com.", target = "getkong.org.", port = 2, weight = 3 },
+          { name = "konghq.test.", target = "getkong.test.", port = 2, weight = 3 },
         })
-        add_target(b, "konghq.com", 8000, 50)
+        add_target(b, "konghq.test", 8000, 50)
         local ip, port, hostname, handle = b:getPeer(true, nil, "a string")
         assert.equal("1.2.3.4", ip)
         assert.equal(2, port)
-        assert.equal("getkong.org", hostname)
+        assert.equal("getkong.test", hostname)
         assert.not_nil(handle)
       end)
 
 
       it("returns expected results/types when using A", function()
         dnsA({
-          { name = "getkong.org.", address = "1.2.3.4" },
+          { name = "getkong.test.", address = "1.2.3.4" },
         })
-        add_target(b, "getkong.org", 8000, 50)
+        add_target(b, "getkong.test", 8000, 50)
         local ip, port, hostname, handle = b:getPeer(true, nil, "another string")
         assert.equal("1.2.3.4", ip)
         assert.equal(8000, port)
-        assert.equal("getkong.org", hostname)
+        assert.equal("getkong.test", hostname)
         assert.not_nil(handle)
       end)
 
@@ -1688,13 +1688,13 @@ for _, algorithm in ipairs{ "consistent-hashing", "least-connections", "round-ro
 
       it("recovers when dns entries are replaced by healthy ones", function()
         local record = dnsA({
-          { name = "getkong.org.", address = "1.2.3.4", ttl = 2 },
+          { name = "getkong.test.", address = "1.2.3.4", ttl = 2 },
         })
-        add_target(b, "getkong.org", 8000, 50)
+        add_target(b, "getkong.test", 8000, 50)
         assert.not_nil(b:getPeer(true, nil, "from the client"))
 
         -- mark it as unhealthy
-        assert(b:setAddressStatus(b:findAddress("1.2.3.4", 8000, "getkong.org", false)))
+        assert(b:setAddressStatus(b:findAddress("1.2.3.4", 8000, "getkong.test", false)))
         assert.same({
             nil, "Balancer is unhealthy", nil, nil,
           }, {
@@ -1706,7 +1706,7 @@ for _, algorithm in ipairs{ "consistent-hashing", "least-connections", "round-ro
         -- balancer should now recover since a new healthy backend is available
         record.expire = 0
         dnsA({
-          { name = "getkong.org.", address = "5.6.7.8", ttl = 60 },
+          { name = "getkong.test.", address = "5.6.7.8", ttl = 60 },
         })
         targets.resolve_targets(b.targets)
 
@@ -1754,9 +1754,9 @@ for _, algorithm in ipairs{ "consistent-hashing", "least-connections", "round-ro
           })
           add_target(b, "srvrecord.tst.", 1234, 9999)
           dnsA({
-            { name = "getkong.org.", address = "5.6.7.8", ttl = 0 },
+            { name = "getkong.test.", address = "5.6.7.8", ttl = 0 },
           })
-          add_target(b, "getkong.org.", 5678, 1000)
+          add_target(b, "getkong.test.", 5678, 1000)
           add_target(b, "notachanceinhell.this.name.exists.konghq.com.", 4321, 100)
 
           local status = b:getStatus()
@@ -1809,7 +1809,7 @@ for _, algorithm in ipairs{ "consistent-hashing", "least-connections", "round-ro
                 },
               },
               {
-                host = "getkong.org.",
+                host = "getkong.test.",
                 port = 5678,
                 dns = "ttl=0, virtual SRV",
                 nodeWeight = 1000,
@@ -1821,7 +1821,7 @@ for _, algorithm in ipairs{ "consistent-hashing", "least-connections", "round-ro
                 addresses = {
                   {
                     healthy = true,
-                    ip = "getkong.org.",
+                    ip = "getkong.test.",
                     port = 5678,
                     weight = 1000
                   },

--- a/spec/01-unit/09-balancer/01-generic_spec.lua
+++ b/spec/01-unit/09-balancer/01-generic_spec.lua
@@ -1752,12 +1752,12 @@ for _, algorithm in ipairs{ "consistent-hashing", "least-connections", "round-ro
             { name = "srvrecord.tst.", target = "1.1.1.1", port = 9000, weight = 10 },
             { name = "srvrecord.tst.", target = "2.2.2.2", port = 9001, weight = 10 },
           })
-          add_target(b, "srvrecord.tst", 1234, 9999)
+          add_target(b, "srvrecord.tst.", 1234, 9999)
           dnsA({
             { name = "getkong.org.", address = "5.6.7.8", ttl = 0 },
           })
-          add_target(b, "getkong.org", 5678, 1000)
-          add_target(b, "notachanceinhell.this.name.exists.konghq.com", 4321, 100)
+          add_target(b, "getkong.org.", 5678, 1000)
+          add_target(b, "notachanceinhell.this.name.exists.konghq.com.", 4321, 100)
 
           local status = b:getStatus()
           table.sort(status.hosts, function(hostA, hostB) return hostA.host < hostB.host end)
@@ -1809,7 +1809,7 @@ for _, algorithm in ipairs{ "consistent-hashing", "least-connections", "round-ro
                 },
               },
               {
-                host = "getkong.org",
+                host = "getkong.org.",
                 port = 5678,
                 dns = "ttl=0, virtual SRV",
                 nodeWeight = 1000,
@@ -1821,14 +1821,14 @@ for _, algorithm in ipairs{ "consistent-hashing", "least-connections", "round-ro
                 addresses = {
                   {
                     healthy = true,
-                    ip = "getkong.org",
+                    ip = "getkong.org.",
                     port = 5678,
                     weight = 1000
                   },
                 },
               },
               {
-                host = "notachanceinhell.this.name.exists.konghq.com",
+                host = "notachanceinhell.this.name.exists.konghq.com.",
                 port = 4321,
                 dns = "dns server error: 3 name error",
                 nodeWeight = 100,
@@ -1840,7 +1840,7 @@ for _, algorithm in ipairs{ "consistent-hashing", "least-connections", "round-ro
                 addresses = {},
               },
               {
-                host = "srvrecord.tst",
+                host = "srvrecord.tst.",
                 port = 1234,
                 dns = "SRV",
                 nodeWeight = 9999,

--- a/spec/01-unit/09-balancer/02-least_connections_spec.lua
+++ b/spec/01-unit/09-balancer/02-least_connections_spec.lua
@@ -247,16 +247,16 @@ describe("[least-connections]", function()
         { name = "github.com.", address = "1.2.3.4" },
       })
       dnsA({
-        { name = "getkong.org.", address = "1.2.3.4" },
+        { name = "getkong.test.", address = "1.2.3.4" },
       })
       local b = validate_lcb(new_balancer({
         "konghq.com",                                      -- name only, as string
         { name = "github.com" },                           -- name only, as table
-        { name = "getkong.org", port = 80, weight = 25 },  -- fully specified, as table
+        { name = "getkong.test", port = 80, weight = 25 },  -- fully specified, as table
       }))
       assert.equal("konghq.com", b.targets[1].name)
       assert.equal("github.com", b.targets[2].name)
-      assert.equal("getkong.org", b.targets[3].name)
+      assert.equal("getkong.test", b.targets[3].name)
     end)
   end)
 

--- a/spec/01-unit/09-balancer/02-least_connections_spec.lua
+++ b/spec/01-unit/09-balancer/02-least_connections_spec.lua
@@ -241,13 +241,13 @@ describe("[least-connections]", function()
 
     it("inserts provided hosts", function()
       dnsA({
-        { name = "konghq.com", address = "1.2.3.4" },
+        { name = "konghq.com.", address = "1.2.3.4" },
       })
       dnsA({
-        { name = "github.com", address = "1.2.3.4" },
+        { name = "github.com.", address = "1.2.3.4" },
       })
       dnsA({
-        { name = "getkong.org", address = "1.2.3.4" },
+        { name = "getkong.org.", address = "1.2.3.4" },
       })
       local b = validate_lcb(new_balancer({
         "konghq.com",                                      -- name only, as string
@@ -265,8 +265,8 @@ describe("[least-connections]", function()
 
     it("honours weights", function()
       dnsSRV({
-        { name = "konghq.com", target = "20.20.20.20", port = 80, weight = 20 },
-        { name = "konghq.com", target = "50.50.50.50", port = 80, weight = 50 },
+        { name = "konghq.com.", target = "20.20.20.20", port = 80, weight = 20 },
+        { name = "konghq.com.", target = "50.50.50.50", port = 80, weight = 50 },
       })
       local b = validate_lcb(new_balancer({ "konghq.com" }))
 
@@ -289,8 +289,8 @@ describe("[least-connections]", function()
 
     it("first returns top weights, on a 0-connection balancer", function()
       dnsSRV({
-        { name = "konghq.com", target = "20.20.20.20", port = 80, weight = 20 },
-        { name = "konghq.com", target = "50.50.50.50", port = 80, weight = 50 },
+        { name = "konghq.com.", target = "20.20.20.20", port = 80, weight = 20 },
+        { name = "konghq.com.", target = "50.50.50.50", port = 80, weight = 50 },
       })
       local b = validate_lcb(new_balancer({ "konghq.com" }))
 
@@ -319,8 +319,8 @@ describe("[least-connections]", function()
 
     it("doesn't use unavailable addresses", function()
       dnsSRV({
-        { name = "konghq.com", target = "20.20.20.20", port = 80, weight = 20 },
-        { name = "konghq.com", target = "50.50.50.50", port = 80, weight = 50 },
+        { name = "konghq.com.", target = "20.20.20.20", port = 80, weight = 20 },
+        { name = "konghq.com.", target = "50.50.50.50", port = 80, weight = 50 },
       })
       local b = validate_lcb(new_balancer({ "konghq.com" }))
 
@@ -345,8 +345,8 @@ describe("[least-connections]", function()
 
     it("uses reenabled (available) addresses again", function()
       dnsSRV({
-        { name = "konghq.com", target = "20.20.20.20", port = 80, weight = 20 },
-        { name = "konghq.com", target = "50.50.50.50", port = 80, weight = 50 },
+        { name = "konghq.com.", target = "20.20.20.20", port = 80, weight = 20 },
+        { name = "konghq.com.", target = "50.50.50.50", port = 80, weight = 50 },
       })
       local b = validate_lcb(new_balancer({ "konghq.com" }))
 
@@ -391,9 +391,9 @@ describe("[least-connections]", function()
 
     it("does not return already failed addresses", function()
       dnsSRV({
-        { name = "konghq.com", target = "20.20.20.20", port = 80, weight = 20 },
-        { name = "konghq.com", target = "50.50.50.50", port = 80, weight = 50 },
-        { name = "konghq.com", target = "70.70.70.70", port = 80, weight = 70 },
+        { name = "konghq.com.", target = "20.20.20.20", port = 80, weight = 20 },
+        { name = "konghq.com.", target = "50.50.50.50", port = 80, weight = 50 },
+        { name = "konghq.com.", target = "70.70.70.70", port = 80, weight = 70 },
       })
       local b = validate_lcb(new_balancer({ "konghq.com" }))
 
@@ -427,9 +427,9 @@ describe("[least-connections]", function()
 
     it("retries, after all adresses failed, restarts with previously failed ones", function()
       dnsSRV({
-        { name = "konghq.com", target = "20.20.20.20", port = 80, weight = 20 },
-        { name = "konghq.com", target = "50.50.50.50", port = 80, weight = 50 },
-        { name = "konghq.com", target = "70.70.70.70", port = 80, weight = 70 },
+        { name = "konghq.com.", target = "20.20.20.20", port = 80, weight = 20 },
+        { name = "konghq.com.", target = "50.50.50.50", port = 80, weight = 50 },
+        { name = "konghq.com.", target = "70.70.70.70", port = 80, weight = 70 },
       })
       local b = validate_lcb(new_balancer({ "konghq.com" }))
 
@@ -452,8 +452,8 @@ describe("[least-connections]", function()
 
     it("releases the previous connection", function()
       dnsSRV({
-        { name = "konghq.com", target = "20.20.20.20", port = 80, weight = 20 },
-        { name = "konghq.com", target = "50.50.50.50", port = 80, weight = 50 },
+        { name = "konghq.com.", target = "20.20.20.20", port = 80, weight = 20 },
+        { name = "konghq.com.", target = "50.50.50.50", port = 80, weight = 50 },
       })
       local b = validate_lcb(new_balancer({ "konghq.com" }))
 
@@ -481,7 +481,7 @@ describe("[least-connections]", function()
 
     it("releases a connection", function()
       dnsSRV({
-        { name = "konghq.com", target = "20.20.20.20", port = 80, weight = 20 },
+        { name = "konghq.com.", target = "20.20.20.20", port = 80, weight = 20 },
       })
       local b = validate_lcb(new_balancer({ "konghq.com" }))
 
@@ -496,7 +496,7 @@ describe("[least-connections]", function()
 
     it("releases connection of already disabled/removed address", function()
       dnsSRV({
-        { name = "konghq.com", target = "20.20.20.20", port = 80, weight = 20 },
+        { name = "konghq.com.", target = "20.20.20.20", port = 80, weight = 20 },
       })
       local b = validate_lcb(new_balancer({ "konghq.com" }))
 

--- a/spec/01-unit/09-balancer/03-consistent_hashing_spec.lua
+++ b/spec/01-unit/09-balancer/03-consistent_hashing_spec.lua
@@ -285,12 +285,12 @@ describe("[consistent_hashing]", function()
         { name = "mashape.com.", address = "1.2.3.4" },
       })
       dnsA({
-        { name = "getkong.org.", address = "5.6.7.8" },
+        { name = "getkong.test.", address = "5.6.7.8" },
       })
       local b = new_balancer({
         hosts = {
           {name = "mashape.com", port = 123, weight = 10},
-          {name = "getkong.org", port = 321, weight = 5},
+          {name = "getkong.test", port = 321, weight = 5},
         },
         dns = client,
         wheelSize = (1000),
@@ -318,7 +318,7 @@ describe("[consistent_hashing]", function()
       assert(15 == res["1.2.3.4:123"] or nil == res["1.2.3.4:123"], "mismatch")
       assert(15 == res["mashape.com:123"] or nil == res["mashape.com:123"], "mismatch")
       assert(15 == res["5.6.7.8:321"] or nil == res["5.6.7.8:321"], "mismatch")
-      assert(15 == res["getkong.org:321"] or nil == res["getkong.org:321"], "mismatch")
+      assert(15 == res["getkong.test:321"] or nil == res["getkong.test:321"], "mismatch")
     end)
     it("evaluate the change in the continuum", function()
       local res1 = {}
@@ -390,12 +390,12 @@ describe("[consistent_hashing]", function()
         { name = "mashape.com.", address = "1.2.3.4" },
       })
       dnsA({
-        { name = "getkong.org.", address = "5.6.7.8" },
+        { name = "getkong.test.", address = "5.6.7.8" },
       })
       local b = new_balancer({
         hosts = {
           {name = "mashape.com", port = 123, weight = 100},
-          {name = "getkong.org", port = 321, weight = 50},
+          {name = "getkong.test", port = 321, weight = 50},
         },
         dns = client,
         wheelSize = 1000,
@@ -412,7 +412,7 @@ describe("[consistent_hashing]", function()
       assert.equal(nil, res["1.2.3.4:123"])     -- address got no hits, key never gets initialized
       assert.equal(nil, res["mashape.com:123"]) -- host got no hits, key never gets initialized
       assert.equal(160, res["5.6.7.8:321"])
-      assert.equal(160, res["getkong.org:321"])
+      assert.equal(160, res["getkong.test:321"])
     end)
     it("does not hit the resolver when 'cache_only' is set", function()
       local record = dnsA({
@@ -681,16 +681,16 @@ describe("[consistent_hashing]", function()
         { name = "mashape.com.", address = "1.2.3.1" },
       })
       dnsA({
-        { name = "getkong.org.", address = "1.2.3.2" },
+        { name = "getkong.test.", address = "1.2.3.2" },
       })
       local b = new_balancer {
-        hosts = {"mashape.com", "getkong.org"},
+        hosts = {"mashape.com", "getkong.test"},
         dns = client,
         wheelSize = 1000,
       }
       local expected = count_indices(b)
       b = new_balancer({
-        hosts = {"getkong.org", "mashape.com"},  -- changed host order
+        hosts = {"getkong.test", "mashape.com"},  -- changed host order
         dns = client,
         wheelSize = 1000,
       })
@@ -702,14 +702,14 @@ describe("[consistent_hashing]", function()
         { name = "mashape.com.", address = "1.2.3.5" },
       })
       dnsAAAA({
-        { name = "getkong.org.", address = "::1" },
+        { name = "getkong.test.", address = "::1" },
       })
       local b = new_balancer({
         hosts = { { name = "mashape.com.", port = 80, weight = 5 } },
         dns = client,
         wheelSize = 2000,
       })
-      add_target(b, "getkong.org.", 8080, 10 )
+      add_target(b, "getkong.test.", 8080, 10 )
       local expected = {
         ["1.2.3.4:80"] = 80,
         ["1.2.3.5:80"] = 80,
@@ -723,15 +723,15 @@ describe("[consistent_hashing]", function()
         { name = "mashape.com.", address = "1.2.3.5" },
       })
       dnsAAAA({
-        { name = "getkong.org.", address = "::1" },
+        { name = "getkong.test.", address = "::1" },
       })
       local b = new_balancer({
         dns = client,
         wheelSize = 1000,
       })
       add_target(b, "mashape.com", 80, 5)
-      add_target(b, "getkong.org", 8080, 10)
-      --b:removeHost("getkong.org", 8080)
+      add_target(b, "getkong.test", 8080, 10)
+      --b:removeHost("getkong.test", 8080)
       --b:removeHost("mashape.com", 80)
     end)
     it("weight change updates properly", function()
@@ -740,14 +740,14 @@ describe("[consistent_hashing]", function()
         { name = "mashape.com.", address = "1.2.3.5" },
       })
       dnsAAAA({
-        { name = "getkong.org.", address = "::1" },
+        { name = "getkong.test.", address = "::1" },
       })
       local b = new_balancer({
         dns = client,
         wheelSize = 1000,
       })
       add_target(b, "mashape.com.", 80, 10)
-      add_target(b, "getkong.org.", 80, 10)
+      add_target(b, "getkong.test.", 80, 10)
       local count = count_indices(b)
       -- 2 hosts -> 320 points
       -- resolved to 3 addresses with same weight -> 106 points each
@@ -796,13 +796,13 @@ describe("[consistent_hashing]", function()
 
       -- insert 2nd address
       dnsA({
-        { name = "getkong.org.", address = "9.9.9.9", ttl = 60*60 },
+        { name = "getkong.test.", address = "9.9.9.9", ttl = 60*60 },
       })
 
       local b = new_balancer({
         hosts = {
           { name = "mashape.com", port = 80, weight = 50 },
-          { name = "getkong.org", port = 123, weight = 50 },
+          { name = "getkong.test", port = 123, weight = 50 },
         },
         dns = client,
         wheelSize = 100,
@@ -832,7 +832,7 @@ describe("[consistent_hashing]", function()
         { name = "really.really.really.does.not.exist.host.test.", address = "1.2.3.4" },
       })
       dnsAAAA({
-        { name = "getkong.org.", address = "::1" },
+        { name = "getkong.test.", address = "::1" },
       })
       local b = new_balancer({
         dns = client,
@@ -840,7 +840,7 @@ describe("[consistent_hashing]", function()
         requery = 1,
       })
       add_target(b, "really.really.really.does.not.exist.host.test.", 80, 10)
-      add_target(b, "getkong.org.", 80, 10)
+      add_target(b, "getkong.test.", 80, 10)
       local count = count_indices(b)
       assert.same({
         ["1.2.3.4:80"] = 160,
@@ -922,12 +922,12 @@ describe("[consistent_hashing]", function()
         { name = "mashape.com.", address = "1.2.3.5" },
       })
       dnsA({
-        { name = "getkong.org.", address = "9.9.9.9" },
+        { name = "getkong.test.", address = "9.9.9.9" },
       })
       local b = new_balancer({
         hosts = {
           { name = "mashape.com", port = 80, weight = 5 },
-          { name = "getkong.org", port = 123, weight = 10 },
+          { name = "getkong.test", port = 123, weight = 10 },
         },
         dns = client,
         wheelSize = 100,
@@ -954,12 +954,12 @@ describe("[consistent_hashing]", function()
         { name = "mashape.com.", address = "::2" },
       })
       dnsA({
-        { name = "getkong.org.", address = "9.9.9.9" },
+        { name = "getkong.test.", address = "9.9.9.9" },
       })
       local b = new_balancer({
         hosts = {
           { name = "mashape.com", port = 80, weight = 5 },
-          { name = "getkong.org", port = 123, weight = 10 },
+          { name = "getkong.test", port = 123, weight = 10 },
         },
         dns = client,
         wheelSize = 100,
@@ -986,12 +986,12 @@ describe("[consistent_hashing]", function()
         { name = "gelato.io.", target = "1.2.3.6", port = 8003, weight = 5 },
       })
       dnsA({
-        { name = "getkong.org.", address = "9.9.9.9" },
+        { name = "getkong.test.", address = "9.9.9.9" },
       })
       local b = new_balancer({
         hosts = {
           { name = "gelato.io" },
-          { name = "getkong.org", port = 123, weight = 10 },
+          { name = "getkong.test", port = 123, weight = 10 },
         },
         dns = client,
         wheelSize = 100,
@@ -1019,12 +1019,12 @@ describe("[consistent_hashing]", function()
         { name = "mashape.com.", address = "1.2.3.4" },
       })
       dnsA({
-        { name = "getkong.org.", address = "9.9.9.9" },
+        { name = "getkong.test.", address = "9.9.9.9" },
       })
       new_balancer({
         hosts = {
           { name = "mashape.com", port = 80, weight = 99999 },
-          { name = "getkong.org", port = 123, weight = 1 },
+          { name = "getkong.test", port = 123, weight = 1 },
         },
         dns = client,
         wheelSize = 1000,
@@ -1034,12 +1034,12 @@ describe("[consistent_hashing]", function()
         { name = "mashape.com.", address = "1.2.3.4" },
       })
       dnsA({
-        { name = "getkong.org.", address = "9.9.9.9" },
+        { name = "getkong.test.", address = "9.9.9.9" },
       })
       new_balancer({
         hosts = {
           { name = "mashape.com", port = 80, weight = 1 },
-          { name = "getkong.org", port = 123, weight = 99999 },
+          { name = "getkong.test", port = 123, weight = 99999 },
         },
         dns = client,
         wheelSize = 1000,

--- a/spec/01-unit/09-balancer/04-round_robin_spec.lua
+++ b/spec/01-unit/09-balancer/04-round_robin_spec.lua
@@ -321,16 +321,16 @@ describe("[round robin balancer]", function()
   describe("unit tests", function()
     it("addressIter", function()
       dnsA({
-        { name = "mashape.test", address = "1.2.3.4" },
-        { name = "mashape.test", address = "1.2.3.5" },
+        { name = "mashape.test.", address = "1.2.3.4" },
+        { name = "mashape.test.", address = "1.2.3.5" },
       })
       dnsAAAA({
-        { name = "getkong.test", address = "::1" },
+        { name = "getkong.test.", address = "::1" },
       })
       dnsSRV({
-        { name = "gelato.test", target = "1.2.3.6", port = 8001 },
-        { name = "gelato.test", target = "1.2.3.6", port = 8002 },
-        { name = "gelato.test", target = "1.2.3.6", port = 8003 },
+        { name = "gelato.test.", target = "1.2.3.6", port = 8001 },
+        { name = "gelato.test.", target = "1.2.3.6", port = 8002 },
+        { name = "gelato.test.", target = "1.2.3.6", port = 8003 },
       })
       local b = new_balancer{
         hosts = {"mashape.test", "getkong.test", "gelato.test" },
@@ -346,8 +346,8 @@ describe("[round robin balancer]", function()
     describe("create", function()
       it("succeeds with proper options", function()
         dnsA({
-          { name = "mashape.test", address = "1.2.3.4" },
-          { name = "mashape.test", address = "1.2.3.5" },
+          { name = "mashape.test.", address = "1.2.3.4" },
+          { name = "mashape.test.", address = "1.2.3.5" },
         })
         check_balancer(new_balancer{
           hosts = {"mashape.test"},
@@ -371,13 +371,13 @@ describe("[round robin balancer]", function()
       end)
       it("succeeds with multiple hosts", function()
         dnsA({
-          { name = "mashape.test", address = "1.2.3.4" },
+          { name = "mashape.test.", address = "1.2.3.4" },
         })
         dnsAAAA({
-          { name = "getkong.test", address = "::1" },
+          { name = "getkong.test.", address = "::1" },
         })
         dnsSRV({
-          { name = "gelato.test", target = "1.2.3.4", port = 8001 },
+          { name = "gelato.test.", target = "1.2.3.4", port = 8001 },
         })
         local b = new_balancer{
           hosts = {"mashape.test", "getkong.test", "gelato.test" },
@@ -399,7 +399,7 @@ describe("[round robin balancer]", function()
         check_balancer(b)
         assert.equals(0, b.totalWeight) -- has one failed host, so weight must be 0
         dnsA({
-          { name = "mashape.test", address = "1.2.3.4" },
+          { name = "mashape.test.", address = "1.2.3.4" },
         })
         add_target(b, "mashape.test", 80, 10)
         check_balancer(b)
@@ -433,7 +433,7 @@ describe("[round robin balancer]", function()
           wheelSize = 15,
         })
         dnsA({
-          { name = "mashape.test", address = "1.2.3.4" },
+          { name = "mashape.test.", address = "1.2.3.4" },
         })
         add_target(b, "mashape.test", 80, 10)
         check_balancer(b)
@@ -453,7 +453,7 @@ describe("[round robin balancer]", function()
       it("valid target is accepted", function()
         local b = check_balancer(new_balancer { dns = client })
         dnsA({
-          { name = "kong.inc", address = "4.3.2.1" },
+          { name = "kong.inc.", address = "4.3.2.1" },
         })
         add_target(b, "1.2.3.4", 80, 10)
         add_target(b, "kong.inc", 80, 10)
@@ -468,7 +468,7 @@ describe("[round robin balancer]", function()
       it("valid address accepted", function()
         local b = check_balancer(new_balancer { dns = client })
         dnsA({
-          { name = "kong.inc", address = "4.3.2.1" },
+          { name = "kong.inc.", address = "4.3.2.1" },
         })
         add_target(b, "kong.inc", 80, 10)
         local _, _, _, handle = b:getPeer()
@@ -479,7 +479,7 @@ describe("[round robin balancer]", function()
       it("invalid target returns an error", function()
         local b = check_balancer(new_balancer { dns = client })
         dnsA({
-          { name = "kong.inc", address = "4.3.2.1" },
+          { name = "kong.inc.", address = "4.3.2.1" },
         })
         add_target(b, "1.2.3.4", 80, 10)
         add_target(b, "kong.inc", 80, 10)
@@ -497,14 +497,14 @@ describe("[round robin balancer]", function()
       it("SRV target with A record targets can be changed with a handle", function()
         local b = check_balancer(new_balancer { dns = client })
         dnsA({
-          { name = "mashape1.test", address = "12.34.56.1" },
+          { name = "mashape1.test.", address = "12.34.56.1" },
         })
         dnsA({
-          { name = "mashape2.test", address = "12.34.56.2" },
+          { name = "mashape2.test.", address = "12.34.56.2" },
         })
         dnsSRV({
-          { name = "mashape.test", target = "mashape1.test", port = 8001, weight = 5 },
-          { name = "mashape.test", target = "mashape2.test", port = 8002, weight = 5 },
+          { name = "mashape.test.", target = "mashape1.test.", port = 8001, weight = 5 },
+          { name = "mashape.test.", target = "mashape2.test.", port = 8002, weight = 5 },
         })
         add_target(b, "mashape.test", 80, 10)
 
@@ -527,10 +527,10 @@ describe("[round robin balancer]", function()
       it("SRV target with port=0 returns the default port", function()
         local b = check_balancer(new_balancer { dns = client })
         dnsA({
-          { name = "mashape1.test", address = "12.34.56.78" },
+          { name = "mashape1.test.", address = "12.34.56.78" },
         })
         dnsSRV({
-          { name = "mashape.test", target = "mashape1.test", port = 0, weight = 5 },
+          { name = "mashape.test.", target = "mashape1.test.", port = 0, weight = 5 },
         })
         add_target(b, "mashape.test", 80, 10)
         local ip, port = b:getPeer()
@@ -547,10 +547,10 @@ describe("[round robin balancer]", function()
       -- uses a different code branch
       -- See issue #17
       dnsA({
-        { name = "mashape.test", address = "1.2.3.4" },
+        { name = "mashape.test.", address = "1.2.3.4" },
       })
       dnsSRV({
-        { name = "gelato.test", target = "mashape.test", port = 8001 },
+        { name = "gelato.test.", target = "mashape.test.", port = 8001 },
       })
       local b = check_balancer(new_balancer {
         hosts = {
@@ -565,10 +565,10 @@ describe("[round robin balancer]", function()
     end)
     it("gets an IP address and port number; round-robin", function()
       dnsA({
-        { name = "mashape.test", address = "1.2.3.4" },
+        { name = "mashape.test.", address = "1.2.3.4" },
       })
       dnsA({
-        { name = "getkong.test", address = "5.6.7.8" },
+        { name = "getkong.test.", address = "5.6.7.8" },
       })
       local b = check_balancer(new_balancer {
         hosts = {
@@ -591,10 +591,10 @@ describe("[round robin balancer]", function()
     end)
     it("gets an IP address and port number; round-robin skips unhealthy addresses", function()
       dnsA({
-        { name = "mashape.test", address = "1.2.3.4" },
+        { name = "mashape.test.", address = "1.2.3.4" },
       })
       dnsA({
-        { name = "getkong.test", address = "5.6.7.8" },
+        { name = "getkong.test.", address = "5.6.7.8" },
       })
       local b = check_balancer(new_balancer {
         hosts = {
@@ -620,7 +620,7 @@ describe("[round robin balancer]", function()
     end)
     it("does not hit the resolver when 'cache_only' is set", function()
       local record = dnsA({
-        { name = "mashape.test", address = "1.2.3.4" },
+        { name = "mashape.test.", address = "1.2.3.4" },
       })
       local b = check_balancer(new_balancer {
         hosts = { { name = "mashape.test", port = 80, weight = 5 } },
@@ -629,7 +629,7 @@ describe("[round robin balancer]", function()
       })
       record.expire = gettime() - 1 -- expire current dns cache record
       dnsA({   -- create a new record
-        { name = "mashape.test", address = "5.6.7.8" },
+        { name = "mashape.test.", address = "5.6.7.8" },
       })
       -- create a spy to check whether dns was queried
       spy.on(client, "resolve")
@@ -709,8 +709,8 @@ describe("[round robin balancer]", function()
         end
       })
       dnsA({
-        { name = "mashape.test", address = "12.34.56.78" },
-        { name = "mashape.test", address = "12.34.56.78" },
+        { name = "mashape.test.", address = "12.34.56.78" },
+        { name = "mashape.test.", address = "12.34.56.78" },
       })
       add_target(b, "mashape.test", 123, 100)
       ngx.sleep(0)
@@ -744,21 +744,21 @@ describe("[round robin balancer]", function()
             error("unknown action received: "..tostring(action))
           end
           if action ~= "health" then
-            assert(ip == "mashape1.test" or ip == "mashape2.test")
+            assert(ip == "mashape1.test." or ip == "mashape2.test.")
             assert(port == 8001 or port == 8002)
             assert.equals("mashape.test", hostname)
           end
         end
       })
       dnsA({
-        { name = "mashape1.test", address = "12.34.56.1" },
+        { name = "mashape1.test.", address = "12.34.56.1" },
       })
       dnsA({
-        { name = "mashape2.test", address = "12.34.56.2" },
+        { name = "mashape2.test.", address = "12.34.56.2" },
       })
       dnsSRV({
-        { name = "mashape.test", target = "mashape1.test", port = 8001, weight = 5 },
-        { name = "mashape.test", target = "mashape2.test", port = 8002, weight = 5 },
+        { name = "mashape.test.", target = "mashape1.test.", port = 8001, weight = 5 },
+        { name = "mashape.test.", target = "mashape2.test.", port = 8002, weight = 5 },
       })
       add_target(b, "mashape.test", 123, 100)
       ngx.sleep(0)
@@ -785,7 +785,7 @@ describe("[round robin balancer]", function()
         hosts = {},  -- no hosts, so balancer is empty
         dns = client,
         wheelSize = 10,
-        callback = function(balancer, action, ip, port, hostname)
+        callback = function(balancer, action, addr, ip, port, hostname, hostheader)
           table.insert(order_of_events, "callback")
           -- this callback is called when updating. So yield here and
           -- verify that the second thread does not interfere with
@@ -794,25 +794,28 @@ describe("[round robin balancer]", function()
         end
       })
       dnsA({
-        { name = "mashape1.test", address = "12.34.56.78" },
+        { name = "mashape1.test.", address = "12.34.56.78" },
       })
       dnsA({
-        { name = "mashape2.test", address = "123.45.67.89" },
+        { name = "mashape2.test.", address = "123.45.67.89" },
       })
       local t1 = ngx.thread.spawn(function()
         table.insert(order_of_events, "thread1 start")
-        add_target(b, "mashape1.test")
+        add_target(b, "mashape1.test.")
         table.insert(order_of_events, "thread1 end")
       end)
       local t2 = ngx.thread.spawn(function()
         table.insert(order_of_events, "thread2 start")
-        add_target(b, "mashape2.test")
+        add_target(b, "mashape2.test.")
         table.insert(order_of_events, "thread2 end")
       end)
       ngx.thread.wait(t1)
       ngx.thread.wait(t2)
       ngx.sleep(0)
       assert.same({
+        -- The callbacks generated during "add_target" are wrapped in "timer at 0"
+        -- the names are in the cache (set above) so no actual lookup should be done, no socket yielding
+        -- all in all; there should be no yielding between thread "start" and "end" above
         [1] = 'thread1 start',
         [2] = 'thread1 end',
         [3] = 'thread2 start',
@@ -824,8 +827,8 @@ describe("[round robin balancer]", function()
     end)
     it("equal weights and 'fitting' indices", function()
       dnsA({
-        { name = "mashape.test", address = "1.2.3.4" },
-        { name = "mashape.test", address = "1.2.3.5" },
+        { name = "mashape.test.", address = "1.2.3.4" },
+        { name = "mashape.test.", address = "1.2.3.5" },
       })
       local b = check_balancer(new_balancer {
         hosts = {"mashape.test"},
@@ -839,16 +842,16 @@ describe("[round robin balancer]", function()
     end)
     it("DNS record order has no effect", function()
       dnsA({
-        { name = "mashape.test", address = "1.2.3.1" },
-        { name = "mashape.test", address = "1.2.3.2" },
-        { name = "mashape.test", address = "1.2.3.3" },
-        { name = "mashape.test", address = "1.2.3.4" },
-        { name = "mashape.test", address = "1.2.3.5" },
-        { name = "mashape.test", address = "1.2.3.6" },
-        { name = "mashape.test", address = "1.2.3.7" },
-        { name = "mashape.test", address = "1.2.3.8" },
-        { name = "mashape.test", address = "1.2.3.9" },
-        { name = "mashape.test", address = "1.2.3.10" },
+        { name = "mashape.test.", address = "1.2.3.1" },
+        { name = "mashape.test.", address = "1.2.3.2" },
+        { name = "mashape.test.", address = "1.2.3.3" },
+        { name = "mashape.test.", address = "1.2.3.4" },
+        { name = "mashape.test.", address = "1.2.3.5" },
+        { name = "mashape.test.", address = "1.2.3.6" },
+        { name = "mashape.test.", address = "1.2.3.7" },
+        { name = "mashape.test.", address = "1.2.3.8" },
+        { name = "mashape.test.", address = "1.2.3.9" },
+        { name = "mashape.test.", address = "1.2.3.10" },
       })
       local b = check_balancer(new_balancer {
         hosts = {"mashape.test"},
@@ -857,16 +860,16 @@ describe("[round robin balancer]", function()
       })
       local expected = count_indices(b)
       dnsA({
-        { name = "mashape.test", address = "1.2.3.8" },
-        { name = "mashape.test", address = "1.2.3.3" },
-        { name = "mashape.test", address = "1.2.3.1" },
-        { name = "mashape.test", address = "1.2.3.2" },
-        { name = "mashape.test", address = "1.2.3.4" },
-        { name = "mashape.test", address = "1.2.3.5" },
-        { name = "mashape.test", address = "1.2.3.6" },
-        { name = "mashape.test", address = "1.2.3.9" },
-        { name = "mashape.test", address = "1.2.3.10" },
-        { name = "mashape.test", address = "1.2.3.7" },
+        { name = "mashape.test.", address = "1.2.3.8" },
+        { name = "mashape.test.", address = "1.2.3.3" },
+        { name = "mashape.test.", address = "1.2.3.1" },
+        { name = "mashape.test.", address = "1.2.3.2" },
+        { name = "mashape.test.", address = "1.2.3.4" },
+        { name = "mashape.test.", address = "1.2.3.5" },
+        { name = "mashape.test.", address = "1.2.3.6" },
+        { name = "mashape.test.", address = "1.2.3.9" },
+        { name = "mashape.test.", address = "1.2.3.10" },
+        { name = "mashape.test.", address = "1.2.3.7" },
       })
       b = check_balancer(new_balancer {
         hosts = {"mashape.test"},
@@ -878,10 +881,10 @@ describe("[round robin balancer]", function()
     end)
     it("changing hostname order has no effect", function()
       dnsA({
-        { name = "mashape.test", address = "1.2.3.1" },
+        { name = "mashape.test.", address = "1.2.3.1" },
       })
       dnsA({
-        { name = "getkong.test", address = "1.2.3.2" },
+        { name = "getkong.test.", address = "1.2.3.2" },
       })
       local b = new_balancer {
         hosts = {"mashape.test", "getkong.test"},
@@ -898,11 +901,11 @@ describe("[round robin balancer]", function()
     end)
     it("adding a host (fitting indices)", function()
       dnsA({
-        { name = "mashape.test", address = "1.2.3.4" },
-        { name = "mashape.test", address = "1.2.3.5" },
+        { name = "mashape.test.", address = "1.2.3.4" },
+        { name = "mashape.test.", address = "1.2.3.5" },
       })
       dnsAAAA({
-        { name = "getkong.test", address = "::1" },
+        { name = "getkong.test.", address = "::1" },
       })
       local b = check_balancer(new_balancer {
         hosts = { { name = "mashape.test", port = 80, weight = 5 } },
@@ -919,11 +922,11 @@ describe("[round robin balancer]", function()
     end)
     it("removing the last host", function()
       dnsA({
-        { name = "mashape.test", address = "1.2.3.4" },
-        { name = "mashape.test", address = "1.2.3.5" },
+        { name = "mashape.test.", address = "1.2.3.4" },
+        { name = "mashape.test.", address = "1.2.3.5" },
       })
       dnsAAAA({
-        { name = "getkong.test", address = "::1" },
+        { name = "getkong.test.", address = "::1" },
       })
       local b = check_balancer(new_balancer {
         dns = client,
@@ -936,11 +939,11 @@ describe("[round robin balancer]", function()
     end)
     it("weight change updates properly", function()
       dnsA({
-        { name = "mashape.test", address = "1.2.3.4" },
-        { name = "mashape.test", address = "1.2.3.5" },
+        { name = "mashape.test.", address = "1.2.3.4" },
+        { name = "mashape.test.", address = "1.2.3.5" },
       })
       dnsAAAA({
-        { name = "getkong.test", address = "::1" },
+        { name = "getkong.test.", address = "::1" },
       })
       local b = check_balancer(new_balancer {
         dns = client,
@@ -974,7 +977,7 @@ describe("[round robin balancer]", function()
       client.resolve = function(name, ...)
         if name == "mashape.test" then
           local record = dnsA({
-            { name = "mashape.test", address = "1.2.3.4", ttl = 0 },
+            { name = "mashape.test.", address = "1.2.3.4", ttl = 0 },
           })
           return record
         else
@@ -991,7 +994,7 @@ describe("[round robin balancer]", function()
 
       -- insert 2nd address
       dnsA({
-        { name = "getkong.test", address = "9.9.9.9", ttl = 60*60 },
+        { name = "getkong.test.", address = "9.9.9.9", ttl = 60*60 },
       })
 
       local b = check_balancer(new_balancer {
@@ -1021,10 +1024,10 @@ describe("[round robin balancer]", function()
     end)
     it("weight change for unresolved record, updates properly", function()
       local record = dnsA({
-        { name = "really.really.really.does.not.exist.hostname.test", address = "1.2.3.4" },
+        { name = "really.really.really.does.not.exist.hostname.test.", address = "1.2.3.4" },
       })
       dnsAAAA({
-        { name = "getkong.test", address = "::1" },
+        { name = "getkong.test.", address = "::1" },
       })
       local b = check_balancer(new_balancer {
         dns = client,
@@ -1058,7 +1061,7 @@ describe("[round robin balancer]", function()
       add_target(b, "really.really.really.does.not.exist.hostname.test", 80, 20)
       -- reinsert a cache entry
       dnsA({
-        { name = "really.really.really.does.not.exist.hostname.test", address = "1.2.3.4" },
+        { name = "really.really.really.does.not.exist.hostname.test.", address = "1.2.3.4" },
       })
       sleep(2)  -- wait for timer to re-resolve the record
       targets.resolve_targets(b.targets)
@@ -1071,12 +1074,12 @@ describe("[round robin balancer]", function()
     end)
     it("weight change SRV record, has no effect", function()
       dnsA({
-        { name = "mashape.test", address = "1.2.3.4" },
-        { name = "mashape.test", address = "1.2.3.5" },
+        { name = "mashape.test.", address = "1.2.3.4" },
+        { name = "mashape.test.", address = "1.2.3.5" },
       })
       dnsSRV({
-        { name = "gelato.test", target = "1.2.3.6", port = 8001, weight = 5 },
-        { name = "gelato.test", target = "1.2.3.6", port = 8002, weight = 5 },
+        { name = "gelato.test.", target = "1.2.3.6", port = 8001, weight = 5 },
+        { name = "gelato.test.", target = "1.2.3.6", port = 8002, weight = 5 },
       })
       local b = check_balancer(new_balancer {
         dns = client,
@@ -1105,11 +1108,11 @@ describe("[round robin balancer]", function()
     end)
     it("renewed DNS A record; no changes", function()
       local record = dnsA({
-        { name = "mashape.test", address = "1.2.3.4" },
-        { name = "mashape.test", address = "1.2.3.5" },
+        { name = "mashape.test.", address = "1.2.3.4" },
+        { name = "mashape.test.", address = "1.2.3.5" },
       })
       dnsA({
-        { name = "getkong.test", address = "9.9.9.9" },
+        { name = "getkong.test.", address = "9.9.9.9" },
       })
       local b = check_balancer(new_balancer {
         hosts = {
@@ -1122,8 +1125,8 @@ describe("[round robin balancer]", function()
       local state = copyWheel(b)
       record.expire = gettime() -1 -- expire current dns cache record
       dnsA({   -- create a new record (identical)
-        { name = "mashape.test", address = "1.2.3.4" },
-        { name = "mashape.test", address = "1.2.3.5" },
+        { name = "mashape.test.", address = "1.2.3.4" },
+        { name = "mashape.test.", address = "1.2.3.5" },
       })
       -- create a spy to check whether dns was queried
       spy.on(client, "resolve")
@@ -1136,11 +1139,11 @@ describe("[round robin balancer]", function()
 
     it("renewed DNS AAAA record; no changes", function()
       local record = dnsAAAA({
-        { name = "mashape.test", address = "::1" },
-        { name = "mashape.test", address = "::2" },
+        { name = "mashape.test.", address = "::1" },
+        { name = "mashape.test.", address = "::2" },
       })
       dnsA({
-        { name = "getkong.test", address = "9.9.9.9" },
+        { name = "getkong.test.", address = "9.9.9.9" },
       })
       local b = check_balancer(new_balancer {
         hosts = {
@@ -1153,8 +1156,8 @@ describe("[round robin balancer]", function()
       local state = copyWheel(b)
       record.expire = gettime() -1 -- expire current dns cache record
       dnsAAAA({   -- create a new record (identical)
-        { name = "mashape.test", address = "::1" },
-        { name = "mashape.test", address = "::2" },
+        { name = "mashape.test.", address = "::1" },
+        { name = "mashape.test.", address = "::2" },
       })
       -- create a spy to check whether dns was queried
       spy.on(client, "resolve")
@@ -1166,12 +1169,12 @@ describe("[round robin balancer]", function()
     end)
     it("renewed DNS SRV record; no changes", function()
       local record = dnsSRV({
-        { name = "gelato.test", target = "1.2.3.6", port = 8001, weight = 5 },
-        { name = "gelato.test", target = "1.2.3.6", port = 8002, weight = 5 },
-        { name = "gelato.test", target = "1.2.3.6", port = 8003, weight = 5 },
+        { name = "gelato.test.", target = "1.2.3.6", port = 8001, weight = 5 },
+        { name = "gelato.test.", target = "1.2.3.6", port = 8002, weight = 5 },
+        { name = "gelato.test.", target = "1.2.3.6", port = 8003, weight = 5 },
       })
       dnsA({
-        { name = "getkong.test", address = "9.9.9.9" },
+        { name = "getkong.test.", address = "9.9.9.9" },
       })
       local b = check_balancer(new_balancer {
         hosts = {
@@ -1184,9 +1187,9 @@ describe("[round robin balancer]", function()
       local state = copyWheel(b)
       record.expire = gettime() -1 -- expire current dns cache record
       dnsSRV({    -- create a new record (identical)
-        { name = "gelato.test", target = "1.2.3.6", port = 8001, weight = 5 },
-        { name = "gelato.test", target = "1.2.3.6", port = 8002, weight = 5 },
-        { name = "gelato.test", target = "1.2.3.6", port = 8003, weight = 5 },
+        { name = "gelato.test.", target = "1.2.3.6", port = 8001, weight = 5 },
+        { name = "gelato.test.", target = "1.2.3.6", port = 8002, weight = 5 },
+        { name = "gelato.test.", target = "1.2.3.6", port = 8003, weight = 5 },
       })
       -- create a spy to check whether dns was queried
       spy.on(client, "resolve")
@@ -1198,12 +1201,12 @@ describe("[round robin balancer]", function()
     end)
     it("renewed DNS A record; address changes", function()
       local record = dnsA({
-        { name = "mashape.test", address = "1.2.3.4" },
-        { name = "mashape.test", address = "1.2.3.5" },
+        { name = "mashape.test.", address = "1.2.3.4" },
+        { name = "mashape.test.", address = "1.2.3.5" },
       })
       dnsA({
-        { name = "getkong.test", address = "9.9.9.9" },
-        { name = "getkong.test", address = "8.8.8.8" },
+        { name = "getkong.test.", address = "9.9.9.9" },
+        { name = "getkong.test.", address = "8.8.8.8" },
       })
       local b = check_balancer(new_balancer {
         hosts = {
@@ -1216,8 +1219,8 @@ describe("[round robin balancer]", function()
       local state = copyWheel(b)
       record.expire = gettime() -1 -- expire current dns cache record
       dnsA({                       -- insert an updated record
-        { name = "mashape.test", address = "1.2.3.4" },
-        { name = "mashape.test", address = "1.2.3.6" },  -- target updated
+        { name = "mashape.test.", address = "1.2.3.4" },
+        { name = "mashape.test.", address = "1.2.3.6" },  -- target updated
       })
       -- run entire wheel to make sure the expired one is requested, and updated
       for _ = 1, b.wheelSize do b:getPeer() end
@@ -1232,10 +1235,10 @@ describe("[round robin balancer]", function()
       -- 2016/11/07 16:48:33 [error] 81932#0: *2 recv() failed (61: Connection refused), context: ngx.timer
 
       local record = dnsA({
-        { name = "mashape.test", address = "1.2.3.4" },
+        { name = "mashape.test.", address = "1.2.3.4" },
       })
       dnsA({
-        { name = "getkong.test", address = "9.9.9.9" },
+        { name = "getkong.test.", address = "9.9.9.9" },
       })
       local b = check_balancer(new_balancer {
         hosts = {
@@ -1270,7 +1273,7 @@ describe("[round robin balancer]", function()
         search = {},
       })
       dnsA({
-        { name = "mashape.test", address = "1.2.3.4" },
+        { name = "mashape.test.", address = "1.2.3.4" },
       })
       sleep(b.requeryInterval + 2) --requery timer runs, so should be fixed after this
 
@@ -1282,7 +1285,7 @@ describe("[round robin balancer]", function()
       -- This test might show some error output similar to the lines below. This is expected and ok.
       -- 2017/11/06 15:52:49 [warn] 5123#0: *2 [lua] balancer.lua:320: queryDns(): [ringbalancer] querying dns for really.really.really.does.not.exist.hostname.test failed: dns server error: 3 name error, context: ngx.timer
 
-      local test_name = "really.really.really.does.not.exist.hostname.test"
+      local test_name = "really.really.really.does.not.exist.hostname.test."
       local ttl = 0.1
       local staleTtl = 0   -- stale ttl = 0, force lookup upon expiring
       local record = dnsA({
@@ -1295,26 +1298,27 @@ describe("[round robin balancer]", function()
         dns = client,
       })
       for _ = 1, b.wheelSize do
-        local ip = b:getPeer()
-        assert.equal(record[1].address, ip)
+        local ip = assert(b:getPeer())
+        assert.equal(ip, record[1].address)
       end
       -- wait for ttl to expire
       sleep(ttl + 0.1)
       targets.resolve_targets(b.targets)
+      sleep(0.1) -- for updates to catch up with async callbacks
       -- run entire wheel to make sure the expired one is requested, so it can fail
       for _ = 1, b.wheelSize do
         local ip, port = b:getPeer()
         assert.is_nil(ip)
-        assert.equal(port, "Balancer is unhealthy")
+        assert.equal("Balancer is unhealthy", port)
       end
     end)
     it("renewed DNS A record; unhealthy entries remain unhealthy after renewal", function()
       local record = dnsA({
-        { name = "mashape.test", address = "1.2.3.4" },
-        { name = "mashape.test", address = "1.2.3.5" },
+        { name = "mashape.test.", address = "1.2.3.4" },
+        { name = "mashape.test.", address = "1.2.3.5" },
       })
       dnsA({
-        { name = "getkong.test", address = "9.9.9.9" },
+        { name = "getkong.test.", address = "9.9.9.9" },
       })
       local b = check_balancer(new_balancer {
         hosts = {
@@ -1346,8 +1350,8 @@ describe("[round robin balancer]", function()
 
       record.expire = gettime() -1 -- expire current dns cache record
       dnsA({   -- create a new record (identical)
-        { name = "mashape.test", address = "1.2.3.4" },
-        { name = "mashape.test", address = "1.2.3.5" },
+        { name = "mashape.test.", address = "1.2.3.4" },
+        { name = "mashape.test.", address = "1.2.3.5" },
       })
       -- create a spy to check whether dns was queried
       spy.on(client, "resolve")
@@ -1373,10 +1377,10 @@ describe("[round robin balancer]", function()
       -- depending on order of insertion it is either 1 or 0 indices
       -- but it may never error.
       dnsA({
-        { name = "mashape.test", address = "1.2.3.4" },
+        { name = "mashape.test.", address = "1.2.3.4" },
       })
       dnsA({
-        { name = "getkong.test", address = "9.9.9.9" },
+        { name = "getkong.test.", address = "9.9.9.9" },
       })
       check_balancer(new_balancer {
         hosts = {
@@ -1388,10 +1392,10 @@ describe("[round robin balancer]", function()
       })
       -- Now the order reversed (weights exchanged)
       dnsA({
-        { name = "mashape.test", address = "1.2.3.4" },
+        { name = "mashape.test.", address = "1.2.3.4" },
       })
       dnsA({
-        { name = "getkong.test", address = "9.9.9.9" },
+        { name = "getkong.test.", address = "9.9.9.9" },
       })
       check_balancer(new_balancer {
         hosts = {
@@ -1406,8 +1410,8 @@ describe("[round robin balancer]", function()
       -- depending on order of insertion it is either 1 or 0 indices
       -- but it may never error.
       dnsSRV({
-        { name = "gelato.test", target = "1.2.3.6", port = 8001, weight = 0 },
-        { name = "gelato.test", target = "1.2.3.6", port = 8002, weight = 0 },
+        { name = "gelato.test.", target = "1.2.3.6", port = 8001, weight = 0 },
+        { name = "gelato.test.", target = "1.2.3.6", port = 8002, weight = 0 },
       })
       local b = check_balancer(new_balancer {
         hosts = {
@@ -1436,7 +1440,7 @@ describe("[round robin balancer]", function()
       client.resolve = function(name, ...)
         if name == "mashape.test" then
           local record = dnsA({
-            { name = "mashape.test", address = "1.2.3.4", ttl = ttl },
+            { name = "mashape.test.", address = "1.2.3.4", ttl = ttl },
           })
           resolve_count = resolve_count + 1
           return record
@@ -1455,7 +1459,7 @@ describe("[round robin balancer]", function()
 
       -- insert 2nd address
       dnsA({
-        { name = "getkong.test", address = "9.9.9.9", ttl = 60*60 },
+        { name = "getkong.test.", address = "9.9.9.9", ttl = 60*60 },
       })
 
       local b = check_balancer(new_balancer {
@@ -1510,7 +1514,7 @@ describe("[round robin balancer]", function()
       client.resolve = function(name, ...)
         if name == hostname then
           record = dnsA({
-            { name = hostname, address = "1.2.3.4", ttl = ttl },
+            { name = hostname..".", address = "1.2.3.4", ttl = ttl },
           })
           return record
         else

--- a/spec/01-unit/14-dns_spec.lua
+++ b/spec/01-unit/14-dns_spec.lua
@@ -102,10 +102,10 @@ describe("DNS", function()
   it("returns an error and 503 on a Name Error (3)", function()
     setup_it_block()
     mock_records = {
-      ["konghq.com:" .. resolver.TYPE_A] = { errcode = 3, errstr = "name error" },
-      ["konghq.com:" .. resolver.TYPE_AAAA] = { errcode = 3, errstr = "name error" },
-      ["konghq.com:" .. resolver.TYPE_CNAME] = { errcode = 3, errstr = "name error" },
-      ["konghq.com:" .. resolver.TYPE_SRV] = { errcode = 3, errstr = "name error" },
+      ["konghq.com.:" .. resolver.TYPE_A] = { errcode = 3, errstr = "name error" },
+      ["konghq.com.:" .. resolver.TYPE_AAAA] = { errcode = 3, errstr = "name error" },
+      ["konghq.com.:" .. resolver.TYPE_CNAME] = { errcode = 3, errstr = "name error" },
+      ["konghq.com.:" .. resolver.TYPE_SRV] = { errcode = 3, errstr = "name error" },
     }
 
     local ip, port, code = balancer.execute({
@@ -123,10 +123,10 @@ describe("DNS", function()
     it("returns an error and 503 on an empty record", function()
       setup_it_block(consistency)
       mock_records = {
-        ["konghq.com:" .. resolver.TYPE_A] = {},
-        ["konghq.com:" .. resolver.TYPE_AAAA] = {},
-        ["konghq.com:" .. resolver.TYPE_CNAME] = {},
-        ["konghq.com:" .. resolver.TYPE_SRV] = {},
+        ["konghq.com.:" .. resolver.TYPE_A] = {},
+        ["konghq.com.:" .. resolver.TYPE_AAAA] = {},
+        ["konghq.com.:" .. resolver.TYPE_CNAME] = {},
+        ["konghq.com.:" .. resolver.TYPE_SRV] = {},
       }
 
       local ip, port, code = balancer.execute({

--- a/spec/01-unit/21-dns-client/02-client_spec.lua
+++ b/spec/01-unit/21-dns-client/02-client_spec.lua
@@ -129,9 +129,9 @@ describe("[DNS client]", function()
           }))
         assert.is.True(result)
         assert.is.Nil(err)
-        record = client.getcache():get("28:localhost")
+        record = client.getcache():get("28:localhost.")
         assert.equal("[::1]", record[1].address)
-        record = client.getcache():get("1:localhost")
+        record = client.getcache():get("1:localhost.")
         assert.equal("127.0.0.1", record[1].address)
       end)
 
@@ -146,11 +146,11 @@ describe("[DNS client]", function()
         assert.is.Nil(err)
 
         -- IPv6 is not defined
-        record = client.getcache():get("28:localhost")
+        record = client.getcache():get("28:localhost.")
         assert.is_nil(record)
 
         -- IPv4 is not overwritten
-        record = client.getcache():get("1:localhost")
+        record = client.getcache():get("1:localhost.")
         assert.equal("1.2.3.4", record[1].address)
       end)
 
@@ -165,11 +165,11 @@ describe("[DNS client]", function()
         assert.is.Nil(err)
 
         -- IPv6 is not overwritten
-        record = client.getcache():get("28:localhost")
+        record = client.getcache():get("28:localhost.")
         assert.equal("[::1:2:3:4]", record[1].address)
 
         -- IPv4 is not defined
-        record = client.getcache():get("1:localhost")
+        record = client.getcache():get("1:localhost.")
         assert.is_nil(record)
       end)
 
@@ -194,18 +194,18 @@ describe("[DNS client]", function()
           table.insert(list, tostring(qname)..":"..tostring(qtype))
         end
         assert.same({
-            'host.one.com:33',
-            'host.two.com:33',
-            'host:33',
-            'host.one.com:1',
-            'host.two.com:1',
-            'host:1',
-            'host.one.com:28',
-            'host.two.com:28',
-            'host:28',
-            'host.one.com:5',
-            'host.two.com:5',
-            'host:5',
+            'host.one.com.:33',
+            'host.two.com.:33',
+            'host.:33',
+            'host.one.com.:1',
+            'host.two.com.:1',
+            'host.:1',
+            'host.one.com.:28',
+            'host.two.com.:28',
+            'host.:28',
+            'host.one.com.:5',
+            'host.two.com.:5',
+            'host.:5',
           }, list)
       end)
 
@@ -222,10 +222,10 @@ describe("[DNS client]", function()
           table.insert(list, tostring(qname)..":"..tostring(qtype))
         end
         assert.same({
-            'host:33',
-            'host:1',
-            'host:28',
-            'host:5',
+            'host.:33',
+            'host.:1',
+            'host.:28',
+            'host.:5',
           }, list)
       end)
 
@@ -242,14 +242,14 @@ describe("[DNS client]", function()
           table.insert(list, tostring(qname)..":"..tostring(qtype))
         end
         assert.same({
-          'host.local.domain.com:33',
-          'host:33',
-          'host.local.domain.com:1',
-          'host:1',
-          'host.local.domain.com:28',
-          'host:28',
-          'host.local.domain.com:5',
-          'host:5',
+          'host.local.domain.com.:33',
+          'host.:33',
+          'host.local.domain.com.:1',
+          'host.:1',
+          'host.local.domain.com.:28',
+          'host.:28',
+          'host.local.domain.com.:5',
+          'host.:5',
         }, list)
       end)
 
@@ -270,18 +270,18 @@ describe("[DNS client]", function()
           table.insert(list, tostring(qname)..":"..tostring(qtype))
         end
         assert.same({
-            'host.one.com:5',
-            'host.two.com:5',
-            'host:5',
-            'host.one.com:33',
-            'host.two.com:33',
-            'host:33',
-            'host.one.com:1',
-            'host.two.com:1',
-            'host:1',
-            'host.one.com:28',
-            'host.two.com:28',
-            'host:28',
+            'host.one.com.:5',
+            'host.two.com.:5',
+            'host.:5',
+            'host.one.com.:33',
+            'host.two.com.:33',
+            'host.:33',
+            'host.one.com.:1',
+            'host.two.com.:1',
+            'host.:1',
+            'host.one.com.:28',
+            'host.two.com.:28',
+            'host.:28',
           }, list)
       end)
 
@@ -389,9 +389,9 @@ describe("[DNS client]", function()
           table.insert(list, tostring(qname)..":"..tostring(qtype))
         end
         assert.same({
-            'host.one.com:28',
-            'host.two.com:28',
-            'host:28',
+            'host.one.com.:28',
+            'host.two.com.:28',
+            'host.:28',
           }, list)
       end)
 
@@ -409,8 +409,8 @@ describe("[DNS client]", function()
           table.insert(list, tostring(qname)..":"..tostring(qtype))
         end
         assert.same({
-          'host.local.domain.com:28',
-          'host:28',
+          'host.local.domain.com.:28',
+          'host.:28',
         }, list)
       end)
 
@@ -430,9 +430,9 @@ describe("[DNS client]", function()
           table.insert(list, tostring(qname)..":"..tostring(qtype))
         end
         assert.same({
-            'host.one.com:28',
-            'host.two.com:28',
-            'host:28',
+            'host.one.com.:28',
+            'host.two.com.:28',
+            'host.:28',
           }, list)
       end)
 
@@ -511,18 +511,18 @@ describe("[DNS client]", function()
         table.insert(list, tostring(qname)..":"..tostring(qtype))
       end
       assert.same({
-          'local.host:33',
-          'local.host.one.com:33',
-          'local.host.two.com:33',
-          'local.host:1',
-          'local.host.one.com:1',
-          'local.host.two.com:1',
-          'local.host:28',
-          'local.host.one.com:28',
-          'local.host.two.com:28',
-          'local.host:5',
-          'local.host.one.com:5',
-          'local.host.two.com:5',
+          'local.host.:33',
+          'local.host.one.com.:33',
+          'local.host.two.com.:33',
+          'local.host.:1',
+          'local.host.one.com.:1',
+          'local.host.two.com.:1',
+          'local.host.:28',
+          'local.host.one.com.:28',
+          'local.host.two.com.:28',
+          'local.host.:5',
+          'local.host.one.com.:5',
+          'local.host.two.com.:5',
         }, list)
     end)
 
@@ -544,18 +544,18 @@ describe("[DNS client]", function()
         table.insert(list, tostring(qname)..":"..tostring(qtype))
       end
       assert.same({
-          'host:1',
-          'host.one.com:1',
-          'host.two.com:1',
-          'host.one.com:33',
-          'host.two.com:33',
-          'host:33',
-          'host:28',
-          'host.one.com:28',
-          'host.two.com:28',
-          'host.one.com:5',
-          'host.two.com:5',
-          'host:5',
+          'host.:1',
+          'host.one.com.:1',
+          'host.two.com.:1',
+          'host.one.com.:33',
+          'host.two.com.:33',
+          'host.:33',
+          'host.:28',
+          'host.one.com.:28',
+          'host.two.com.:28',
+          'host.one.com.:5',
+          'host.two.com.:5',
+          'host.:5',
         }, list)
     end)
 
@@ -581,7 +581,7 @@ describe("[DNS client]", function()
 
     local answers, err, try_list = client.resolve(host, { qtype = typ })
     assert(answers, (err or "") .. tostring(try_list))
-    assert.are.equal(host, answers[1].name)
+    assert.are.equal(host..".", answers[1].name)
     assert.are.equal(typ, answers[1].type)
     assert.are.equal(#answers, 1)
   end)
@@ -593,7 +593,7 @@ describe("[DNS client]", function()
     local typ = client.TYPE_CNAME
 
     local answers = assert(client.resolve(host, { qtype = typ }))
-    assert.are.equal(host, answers[1].name)
+    assert.are.equal(host..".", answers[1].name)
     assert.are.equal(typ, answers[1].type)
     assert.are.equal(#answers, 1)
   end)
@@ -605,7 +605,7 @@ describe("[DNS client]", function()
     local typ = client.TYPE_CNAME
 
     local answers = assert(client.resolve(host .. ".", { qtype = typ }))
-    assert.are.equal(host, answers[1].name)
+    assert.are.equal(host..".", answers[1].name)
     assert.are.equal(typ, answers[1].type)
     assert.are.equal(#answers, 1)
   end)
@@ -663,7 +663,7 @@ describe("[DNS client]", function()
       { qtype = client.TYPE_A },
       false)
     assert.equal(1, #res)
-    assert.equal("some.upper.case", res[1].name)
+    assert.equal("some.upper.case"..".", res[1].name)
   end)
 
   it("fetching multiple A records", function()
@@ -674,9 +674,9 @@ describe("[DNS client]", function()
 
     local answers = assert(client.resolve(host, { qtype = typ }))
     assert.are.equal(#answers, 2)
-    assert.are.equal(host, answers[1].name)
+    assert.are.equal(host..".", answers[1].name)
     assert.are.equal(typ, answers[1].type)
-    assert.are.equal(host, answers[2].name)
+    assert.are.equal(host..".", answers[2].name)
     assert.are.equal(typ, answers[2].type)
   end)
 
@@ -688,9 +688,9 @@ describe("[DNS client]", function()
 
     local answers = assert(client.resolve(host .. ".", { qtype = typ }))
     assert.are.equal(#answers, 2)
-    assert.are.equal(host, answers[1].name)
+    assert.are.equal(host..".", answers[1].name)
     assert.are.equal(typ, answers[1].type)
-    assert.are.equal(host, answers[2].name)
+    assert.are.equal(host..".", answers[2].name)
     assert.are.equal(typ, answers[2].type)
   end)
 
@@ -717,9 +717,9 @@ describe("[DNS client]", function()
     local answers, _, _ = assert(client.resolve(host))
 
     -- check first CNAME
-    local key1 = client.TYPE_CNAME..":"..host
+    local key1 = client.TYPE_CNAME..":"..host.."."
     local entry1 = lrucache:get(key1)
-    assert.are.equal(host, entry1[1].name)       -- the 1st record is the original 'smtp.thijsschreijer.nl'
+    assert.are.equal(host..".", entry1[1].name)       -- the 1st record is the original 'smtp.thijsschreijer.nl'
     assert.are.equal(client.TYPE_CNAME, entry1[1].type) -- and that is a CNAME
 
     -- check second CNAME
@@ -752,11 +752,11 @@ describe("[DNS client]", function()
 
     -- un-typed lookup
     local answers = assert(client.resolve(host))
-    assert.are.equal(host, answers[1].name)
+    assert.are.equal(host..".", answers[1].name)
     assert.are.equal(typ, answers[1].type)
-    assert.are.equal(host, answers[2].name)
+    assert.are.equal(host..".", answers[2].name)
     assert.are.equal(typ, answers[2].type)
-    assert.are.equal(host, answers[3].name)
+    assert.are.equal(host..".", answers[3].name)
     assert.are.equal(typ, answers[3].type)
     assert.are.equal(#answers, 3)
   end)
@@ -772,9 +772,9 @@ describe("[DNS client]", function()
     local answers = assert(client.resolve(host))
 
     -- first check CNAME
-    local key = client.TYPE_CNAME..":"..host
+    local key = client.TYPE_CNAME..":"..host.."."
     local entry = lrucache:get(key)
-    assert.are.equal(host, entry[1].name)
+    assert.are.equal(host..".", entry[1].name)
     assert.are.equal(client.TYPE_CNAME, entry[1].type)
 
     -- check final target
@@ -916,7 +916,7 @@ describe("[DNS client]", function()
 
   it("fetching IPv6 in an SRV record adds brackets",function()
     assert(client.init())
-    local host = "hello.world"
+    local host = "hello.world."
     local address = "::1"
     local entry = {
       {
@@ -955,7 +955,7 @@ describe("[DNS client]", function()
           },
         }))
     query_func = function(self, original_query_func, name, opts)
-      if name ~= "hello.world" and (opts or {}).qtype ~= client.TYPE_CNAME then
+      if name ~= "hello.world." and (opts or {}).qtype ~= client.TYPE_CNAME then
         return original_query_func(self, name, opts)
       end
       return {
@@ -985,9 +985,9 @@ describe("[DNS client]", function()
     local entry1 = {
       {
         type = client.TYPE_CNAME,
-        cname = "hello.world",
+        cname = "hello.world.",
         class = 1,
-        name = "hello.world",
+        name = "hello.world.",
         ttl = 0,
       },
       touch = 0,
@@ -1013,9 +1013,9 @@ describe("[DNS client]", function()
     local entry1 = {
       {
         type = client.TYPE_CNAME,
-        cname = "bye.bye.world",
+        cname = "bye.bye.world.",
         class = 1,
-        name = "hello.world",
+        name = "hello.world.",
         ttl = 0,
       },
       touch = 0,
@@ -1024,9 +1024,9 @@ describe("[DNS client]", function()
     local entry2 = {
       {
         type = client.TYPE_CNAME,
-        cname = "hello.world",
+        cname = "hello.world.",
         class = 1,
-        name = "bye.bye.world",
+        name = "bye.bye.world.",
         ttl = 0,
       },
       touch = 0,
@@ -1083,19 +1083,19 @@ describe("[DNS client]", function()
 
     local answers, err = client.resolve("localhost", {qtype = client.TYPE_A})
     assert.is.Nil(err)
-    assert.are.equal(answers[1].address, "127.3.2.1")
+    assert.are.equal("127.3.2.1", answers[1].address)
 
     answers, err = client.resolve("localhost", {qtype = client.TYPE_AAAA})
     assert.is.Nil(err)
-    assert.are.equal(answers[1].address, "[1::2]")
+    assert.are.equal("[1::2]", answers[1].address)
 
     answers, err = client.resolve("mashape", {qtype = client.TYPE_A})
     assert.is.Nil(err)
-    assert.are.equal(answers[1].address, "123.123.123.123")
+    assert.are.equal("123.123.123.123", answers[1].address)
 
     answers, err = client.resolve("kong.for.president", {qtype = client.TYPE_AAAA})
     assert.is.Nil(err)
-    assert.are.equal(answers[1].address, "[1234::1234]")
+    assert.are.equal("[1234::1234]", answers[1].address)
   end)
 
   describe("toip() function", function()
@@ -1132,7 +1132,7 @@ describe("[DNS client]", function()
           weight = 5,
           priority = 10,
           class = 1,
-          name = host,
+          name = host..".",
           ttl = 10,
         },
         {
@@ -1142,7 +1142,7 @@ describe("[DNS client]", function()
           weight = 5,
           priority = 20,
           class = 1,
-          name = host,
+          name = host..".",
           ttl = 10,
         },
         {
@@ -1152,7 +1152,7 @@ describe("[DNS client]", function()
           weight = 5,
           priority = 10,
           class = 1,
-          name = host,
+          name = host..".",
           ttl = 10,
         },
         touch = 0,
@@ -1184,7 +1184,7 @@ describe("[DNS client]", function()
           weight = 10,
           priority = 10,
           class = 1,
-          name = host,
+          name = host..".",
           ttl = 10,
         },
         touch = 0,
@@ -1214,7 +1214,7 @@ describe("[DNS client]", function()
           weight = 0,   --> weight 0
           priority = 10,
           class = 1,
-          name = host,
+          name = host..".",
           ttl = 10,
         },
         {
@@ -1224,7 +1224,7 @@ describe("[DNS client]", function()
           weight = 50,   --> weight 50
           priority = 10,
           class = 1,
-          name = host,
+          name = host..".",
           ttl = 10,
         },
         {
@@ -1234,7 +1234,7 @@ describe("[DNS client]", function()
           weight = 50,   --> weight 50
           priority = 10,
           class = 1,
-          name = host,
+          name = host..".",
           ttl = 10,
         },
         touch = 0,
@@ -1262,7 +1262,7 @@ describe("[DNS client]", function()
           type = client.TYPE_A,
           address = "1.2.3.4",
           class = 1,
-          name = "a.record.test",
+          name = "a.record.test.",
           ttl = 10,
         },
         touch = 0,
@@ -1271,12 +1271,12 @@ describe("[DNS client]", function()
       local entry_srv = {
         {
           type = client.TYPE_SRV,
-          target = "a.record.test",
+          target = "a.record.test.",
           port = 8001,
           weight = 5,
           priority = 20,
           class = 1,
-          name = "srv.record.test",
+          name = "srv.record.test.",
           ttl = 10,
         },
         touch = 0,
@@ -1329,8 +1329,8 @@ describe("[DNS client]", function()
       record, err, _ = client.resolve(host, { qtype = client.TYPE_SRV })
       assert.is_table(record)
       assert.equal(1, #record)
-      assert.equal(host, record[1].target)
-      assert.equal(host, record[1].name)
+      assert.equal(host..".", record[1].target)
+      assert.equal(host..".", record[1].name)
       assert.is_nil(err)
 
       -- default order, SRV, A; the recursive SRV record fails, and it falls
@@ -1348,7 +1348,7 @@ describe("[DNS client]", function()
             type = client.TYPE_A,
             address = "5.6.7.8",
             class = 1,
-            name = "hello.world",
+            name = "hello.world.",
             ttl = 10,
           },
           touch = 0,
@@ -1359,7 +1359,7 @@ describe("[DNS client]", function()
             type = client.TYPE_AAAA,
             address = "::1",
             class = 1,
-            name = "hello.world",
+            name = "hello.world.",
             ttl = 10,
           },
           touch = 0,
@@ -1386,7 +1386,7 @@ describe("[DNS client]", function()
         expire = 0,
       }
       -- insert in the cache
-      client.getcache()[client.TYPE_A..":".."hello.world"] = empty_entry
+      client.getcache()[client.TYPE_A..":".."hello.world."] = empty_entry
 
       -- Note: the bad case would be that the below lookup would hang due to round-robin on an empty table
       local ip, port = client.toip("hello.world", 123, true)
@@ -1404,9 +1404,9 @@ describe("[DNS client]", function()
       local entry1 = {
         {
           type = client.TYPE_CNAME,
-          cname = "bye.bye.world",
+          cname = "bye.bye.world.",
           class = 1,
-          name = "hello.world",
+          name = "hello.world.",
           ttl = 10,
         },
         touch = 0,
@@ -1415,9 +1415,9 @@ describe("[DNS client]", function()
       local entry2 = {
         {
           type = client.TYPE_CNAME,
-          cname = "hello.world",
+          cname = "hello.world.",
           class = 1,
-          name = "bye.bye.world",
+          name = "bye.bye.world.",
           ttl = 10,
         },
         touch = 0,
@@ -1504,7 +1504,7 @@ describe("[DNS client]", function()
     assert.is_nil(res1)
     assert.are.equal(1, call_count)
     assert.are.equal(NOT_FOUND_ERROR, err1)
-    res1 = assert(client.getcache():get(client.TYPE_A..":"..qname))
+    res1 = assert(client.getcache():get(client.TYPE_A..":"..qname.."."))
 
 
     -- make a second request, result from cache, still called only once
@@ -1515,7 +1515,7 @@ describe("[DNS client]", function()
     assert.is_nil(res2)
     assert.are.equal(1, call_count)
     assert.are.equal(NOT_FOUND_ERROR, err2)
-    res2 = assert(client.getcache():get(client.TYPE_A..":"..qname))
+    res2 = assert(client.getcache():get(client.TYPE_A..":"..qname.."."))
     assert.equal(res1, res2)
     assert.falsy(res2.expired)
 
@@ -1529,7 +1529,7 @@ describe("[DNS client]", function()
     assert.is_nil(res2)
     assert.are.equal(1, call_count)
     assert.are.equal(NOT_FOUND_ERROR, err2)
-    res2 = assert(client.getcache():get(client.TYPE_A..":"..qname))
+    res2 = assert(client.getcache():get(client.TYPE_A..":"..qname.."."))
     assert.equal(res1, res2)
     assert.is_true(res2.expired)  -- by now, record is marked as expired
 
@@ -1543,7 +1543,7 @@ describe("[DNS client]", function()
     assert.is_nil(res2)
     assert.are.equal(2, call_count)
     assert.are.equal(NOT_FOUND_ERROR, err2)
-    res2 = assert(client.getcache():get(client.TYPE_A..":"..qname))
+    res2 = assert(client.getcache():get(client.TYPE_A..":"..qname.."."))
     assert.not_equal(res1, res2)
     assert.falsy(res2.expired)  -- new record, not expired
   end)
@@ -1579,7 +1579,7 @@ describe("[DNS client]", function()
     assert.is_nil(res1)
     assert.are.equal(1, call_count)
     assert.are.equal("dns server error: 5 refused", err1)
-    res1 = assert(client.getcache():get(client.TYPE_A..":"..qname))
+    res1 = assert(client.getcache():get(client.TYPE_A..":"..qname.."."))
 
 
     -- try again, from cache, should still be called only once
@@ -1590,7 +1590,7 @@ describe("[DNS client]", function()
     assert.is_nil(res2)
     assert.are.equal(call_count, 1)
     assert.are.equal(err1, err2)
-    res2 = assert(client.getcache():get(client.TYPE_A..":"..qname))
+    res2 = assert(client.getcache():get(client.TYPE_A..":"..qname.."."))
     assert.are.equal(res1, res2)
     assert.falsy(res1.expired)
 
@@ -1604,7 +1604,7 @@ describe("[DNS client]", function()
     assert.is_nil(res2)
     assert.are.equal(call_count, 1)
     assert.are.equal(err1, err2)
-    res2 = assert(client.getcache():get(client.TYPE_A..":"..qname))
+    res2 = assert(client.getcache():get(client.TYPE_A..":"..qname.."."))
     assert.are.equal(res1, res2)
     assert.is_true(res2.expired)
 
@@ -1617,7 +1617,7 @@ describe("[DNS client]", function()
     assert.is_nil(res2)
     assert.are.equal(call_count, 2)  -- 2 calls now
     assert.are.equal(err1, err2)
-    res2 = assert(client.getcache():get(client.TYPE_A..":"..qname))
+    res2 = assert(client.getcache():get(client.TYPE_A..":"..qname.."."))
     assert.are_not.equal(res1, res2)  -- a new record
     assert.falsy(res2.expired)
   end)

--- a/spec/01-unit/21-dns-client/02-client_spec.lua
+++ b/spec/01-unit/21-dns-client/02-client_spec.lua
@@ -581,7 +581,7 @@ describe("[DNS client]", function()
 
     local answers, err, try_list = client.resolve(host, { qtype = typ })
     assert(answers, (err or "") .. tostring(try_list))
-    assert.are.equal(host..".", answers[1].name)
+    assert.are.equal(host .. ".", answers[1].name)
     assert.are.equal(typ, answers[1].type)
     assert.are.equal(#answers, 1)
   end)
@@ -593,7 +593,7 @@ describe("[DNS client]", function()
     local typ = client.TYPE_CNAME
 
     local answers = assert(client.resolve(host, { qtype = typ }))
-    assert.are.equal(host..".", answers[1].name)
+    assert.are.equal(host .. ".", answers[1].name)
     assert.are.equal(typ, answers[1].type)
     assert.are.equal(#answers, 1)
   end)
@@ -605,7 +605,7 @@ describe("[DNS client]", function()
     local typ = client.TYPE_CNAME
 
     local answers = assert(client.resolve(host .. ".", { qtype = typ }))
-    assert.are.equal(host..".", answers[1].name)
+    assert.are.equal(host .. ".", answers[1].name)
     assert.are.equal(typ, answers[1].type)
     assert.are.equal(#answers, 1)
   end)
@@ -663,7 +663,7 @@ describe("[DNS client]", function()
       { qtype = client.TYPE_A },
       false)
     assert.equal(1, #res)
-    assert.equal("some.upper.case"..".", res[1].name)
+    assert.equal("some.upper.case" .. ".", res[1].name)
   end)
 
   it("fetching multiple A records", function()
@@ -674,9 +674,9 @@ describe("[DNS client]", function()
 
     local answers = assert(client.resolve(host, { qtype = typ }))
     assert.are.equal(#answers, 2)
-    assert.are.equal(host..".", answers[1].name)
+    assert.are.equal(host .. ".", answers[1].name)
     assert.are.equal(typ, answers[1].type)
-    assert.are.equal(host..".", answers[2].name)
+    assert.are.equal(host .. ".", answers[2].name)
     assert.are.equal(typ, answers[2].type)
   end)
 
@@ -688,9 +688,9 @@ describe("[DNS client]", function()
 
     local answers = assert(client.resolve(host .. ".", { qtype = typ }))
     assert.are.equal(#answers, 2)
-    assert.are.equal(host..".", answers[1].name)
+    assert.are.equal(host .. ".", answers[1].name)
     assert.are.equal(typ, answers[1].type)
-    assert.are.equal(host..".", answers[2].name)
+    assert.are.equal(host .. ".", answers[2].name)
     assert.are.equal(typ, answers[2].type)
   end)
 
@@ -717,9 +717,9 @@ describe("[DNS client]", function()
     local answers, _, _ = assert(client.resolve(host))
 
     -- check first CNAME
-    local key1 = client.TYPE_CNAME..":"..host.."."
+    local key1 = client.TYPE_CNAME..":"..host .. "."
     local entry1 = lrucache:get(key1)
-    assert.are.equal(host..".", entry1[1].name)       -- the 1st record is the original 'smtp.thijsschreijer.nl'
+    assert.are.equal(host .. ".", entry1[1].name)       -- the 1st record is the original 'smtp.thijsschreijer.nl'
     assert.are.equal(client.TYPE_CNAME, entry1[1].type) -- and that is a CNAME
 
     -- check second CNAME
@@ -752,11 +752,11 @@ describe("[DNS client]", function()
 
     -- un-typed lookup
     local answers = assert(client.resolve(host))
-    assert.are.equal(host..".", answers[1].name)
+    assert.are.equal(host .. ".", answers[1].name)
     assert.are.equal(typ, answers[1].type)
-    assert.are.equal(host..".", answers[2].name)
+    assert.are.equal(host .. ".", answers[2].name)
     assert.are.equal(typ, answers[2].type)
-    assert.are.equal(host..".", answers[3].name)
+    assert.are.equal(host .. ".", answers[3].name)
     assert.are.equal(typ, answers[3].type)
     assert.are.equal(#answers, 3)
   end)
@@ -772,9 +772,9 @@ describe("[DNS client]", function()
     local answers = assert(client.resolve(host))
 
     -- first check CNAME
-    local key = client.TYPE_CNAME..":"..host.."."
+    local key = client.TYPE_CNAME..":"..host .. "."
     local entry = lrucache:get(key)
-    assert.are.equal(host..".", entry[1].name)
+    assert.are.equal(host .. ".", entry[1].name)
     assert.are.equal(client.TYPE_CNAME, entry[1].type)
 
     -- check final target
@@ -1132,7 +1132,7 @@ describe("[DNS client]", function()
           weight = 5,
           priority = 10,
           class = 1,
-          name = host..".",
+          name = host .. ".",
           ttl = 10,
         },
         {
@@ -1142,7 +1142,7 @@ describe("[DNS client]", function()
           weight = 5,
           priority = 20,
           class = 1,
-          name = host..".",
+          name = host .. ".",
           ttl = 10,
         },
         {
@@ -1152,7 +1152,7 @@ describe("[DNS client]", function()
           weight = 5,
           priority = 10,
           class = 1,
-          name = host..".",
+          name = host .. ".",
           ttl = 10,
         },
         touch = 0,
@@ -1184,7 +1184,7 @@ describe("[DNS client]", function()
           weight = 10,
           priority = 10,
           class = 1,
-          name = host..".",
+          name = host .. ".",
           ttl = 10,
         },
         touch = 0,
@@ -1214,7 +1214,7 @@ describe("[DNS client]", function()
           weight = 0,   --> weight 0
           priority = 10,
           class = 1,
-          name = host..".",
+          name = host .. ".",
           ttl = 10,
         },
         {
@@ -1224,7 +1224,7 @@ describe("[DNS client]", function()
           weight = 50,   --> weight 50
           priority = 10,
           class = 1,
-          name = host..".",
+          name = host .. ".",
           ttl = 10,
         },
         {
@@ -1234,7 +1234,7 @@ describe("[DNS client]", function()
           weight = 50,   --> weight 50
           priority = 10,
           class = 1,
-          name = host..".",
+          name = host .. ".",
           ttl = 10,
         },
         touch = 0,
@@ -1329,8 +1329,8 @@ describe("[DNS client]", function()
       record, err, _ = client.resolve(host, { qtype = client.TYPE_SRV })
       assert.is_table(record)
       assert.equal(1, #record)
-      assert.equal(host..".", record[1].target)
-      assert.equal(host..".", record[1].name)
+      assert.equal(host .. ".", record[1].target)
+      assert.equal(host .. ".", record[1].name)
       assert.is_nil(err)
 
       -- default order, SRV, A; the recursive SRV record fails, and it falls

--- a/spec/01-unit/21-dns-client/03-client_cache_spec.lua
+++ b/spec/01-unit/21-dns-client/03-client_cache_spec.lua
@@ -37,7 +37,7 @@ describe("[DNS client cache]", function()
     resolver.new = function(...)
       local r = old_new(...)
       local original_query_func = function(self, name, options)
-        error("Shouldn't be doing real lookups; requested name: "..tostring(name))
+        error("Shouldn't be doing real lookups; requested name: " .. tostring(name))
       end
       r.query = function(self, ...)
         if not query_func then
@@ -84,7 +84,6 @@ describe("[DNS client cache]", function()
       lrucache = client.getcache()
 
       query_func = function(self, original_query_func, qname, opts)
-        -- print("looking for: ",qname..":"..opts.qtype)
         return mock_records[qname..":"..opts.qtype] or { errcode = 3, errstr = "name error" }
       end
     end)

--- a/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/08-targets_routes_spec.lua
@@ -36,7 +36,7 @@ describe("Admin API #" .. strategy, function()
       })
     }
     fixtures.dns_mock:A {
-      name = "custom_localhost",
+      name = "custom_localhost.",
       address = "127.0.0.1",
     }
 
@@ -400,7 +400,7 @@ describe("Admin API #" .. strategy, function()
       describe("with healthchecks off", function()
         it("returns HEALTHCHECKS_OFF for targets that resolve", function()
           add_targets("127.0.0.1:8%d")
-          local targets = add_targets("custom_localhost:8%d")
+          local targets = add_targets("custom_localhost.:8%d")
           check_health_endpoint(targets, 8, "HEALTHCHECKS_OFF")
         end)
 
@@ -447,7 +447,7 @@ describe("Admin API #" .. strategy, function()
 
         it("returns HEALTHY if failure not detected", function()
 
-          local targets = add_targets("custom_localhost:222%d")
+          local targets = add_targets("custom_localhost.:222%d")
 
           check_health_endpoint(targets, 4, "HEALTHY")
 
@@ -455,7 +455,7 @@ describe("Admin API #" .. strategy, function()
 
         it("returns UNHEALTHY if failure detected", function()
 
-          local targets = add_targets("custom_localhost:222%d")
+          local targets = add_targets("custom_localhost.:222%d")
 
           local status = client_send({
             method = "PUT",
@@ -493,7 +493,7 @@ describe("Admin API #" .. strategy, function()
               ["Content-Type"] = "application/json",
             },
             body = {
-              target = "custom_localhost:2221",
+              target = "custom_localhost.:2221",
               weight = 0,
             }
           })

--- a/spec/02-integration/05-proxy/10-balancer/01-healthchecks_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer/01-healthchecks_spec.lua
@@ -327,7 +327,7 @@ for _, strategy in helpers.each_strategy() do
         assert.equals("UNHEALTHY", health.data[1].health)
         assert.equals("UNHEALTHY", health.data[1].data.addresses[1].health)
 
-        local status = bu.put_target_address_health(upstream_id, "srv-changes-port.test.:80", "a-changes-port.test.:90", "healthy")
+        local status = bu.put_target_address_health(upstream_id, "multiple-ips.test.srv-changes-port.test.:80", "a-changes-port.test.:90", "healthy")
         assert.same(204, status)
       end, 15)
 

--- a/spec/02-integration/05-proxy/10-balancer/01-healthchecks_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer/01-healthchecks_spec.lua
@@ -531,7 +531,7 @@ for _, strategy in helpers.each_strategy() do
       }
 
       fixtures.dns_mock:A {
-        name = "notlocalhost.test",
+        name = "notlocalhost.test.",
         address = "127.0.0.1",
       }
 
@@ -572,7 +572,7 @@ for _, strategy in helpers.each_strategy() do
           }
         }
       })
-      bu.add_target(bp, upstream_id, "notlocalhost.test", 15555)
+      bu.add_target(bp, upstream_id, "notlocalhost.test.", 15555)
       bu.end_testcase_setup(strategy, bp)
 
       helpers.pwait_until(function ()
@@ -582,8 +582,7 @@ for _, strategy in helpers.each_strategy() do
         assert.is.table(health)
         assert.is.table(health.data)
       end, 15)
-
-      bu.poll_wait_health(upstream_id, "notlocalhost.test", "15555", "UNHEALTHY")
+      bu.poll_wait_health(upstream_id, "notlocalhost.test.", "15555", "UNHEALTHY")
 
     end)
 
@@ -620,7 +619,7 @@ for _, strategy in helpers.each_strategy() do
         },
         client_certificate = certificate,
       })
-      bu.add_target(bp, upstream_id, "notlocalhost.test", 15555)
+      bu.add_target(bp, upstream_id, "notlocalhost.test.", 15555)
       bu.end_testcase_setup(strategy, bp)
 
       helpers.pwait_until(function ()
@@ -631,7 +630,7 @@ for _, strategy in helpers.each_strategy() do
         assert.is.table(health.data)
       end, 15)
 
-      bu.poll_wait_health(upstream_id, "notlocalhost.test", "15555", "UNHEALTHY")
+      bu.poll_wait_health(upstream_id, "notlocalhost.test.", "15555", "UNHEALTHY")
 
     end)
   end)
@@ -1714,11 +1713,11 @@ for _, strategy in helpers.each_strategy() do
                 }
 
                 fixtures.dns_mock:A {
-                  name = "target1.test",
+                  name = "target1.test.",
                   address = "127.0.0.1",
                 }
                 fixtures.dns_mock:A {
-                  name = "target2.test",
+                  name = "target2.test.",
                   address = "127.0.0.1",
                 }
 
@@ -1743,7 +1742,7 @@ for _, strategy in helpers.each_strategy() do
                   -- setup target servers:
                   -- server2 will only respond for part of the test,
                   -- then server1 will take over.
-                  local server1 = https_server.new(port1, {"target1.test", "target2.test"}, protocol)
+                  local server1 = https_server.new(port1, {"target1.test.", "target2.test."}, protocol)
                   server1:start()
 
                   -- configure healthchecks
@@ -1765,8 +1764,8 @@ for _, strategy in helpers.each_strategy() do
                       }
                     }
                   })
-                  bu.add_target(bp, upstream_id, "target1.test", port1)
-                  bu.add_target(bp, upstream_id, "target2.test", port1)
+                  bu.add_target(bp, upstream_id, "target1.test.", port1)
+                  bu.add_target(bp, upstream_id, "target2.test.", port1)
                   local api_host = bu.add_api(bp, upstream_name, {
                     service_protocol = protocol
                   })
@@ -1777,9 +1776,9 @@ for _, strategy in helpers.each_strategy() do
                   local oks, fails = bu.client_requests(bu.SLOTS, api_host)
 
                   -- target2 goes unhealthy
-                  assert(bu.direct_request(localhost, port1, "/unhealthy", protocol, "target2.test"))
+                  assert(bu.direct_request(localhost, port1, "/unhealthy", protocol, "target2.test."))
                   -- Wait until healthchecker detects
-                  bu.poll_wait_health(upstream_id, "target2.test", port1, "UNHEALTHY")
+                  bu.poll_wait_health(upstream_id, "target2.test.", port1, "UNHEALTHY")
 
                   -- 2) target1 takes all requests
                   do
@@ -1789,9 +1788,9 @@ for _, strategy in helpers.each_strategy() do
                   end
 
                   -- target2 goes healthy again
-                  assert(bu.direct_request(localhost, port1, "/healthy", protocol, "target2.test"))
+                  assert(bu.direct_request(localhost, port1, "/healthy", protocol, "target2.test."))
                   -- Give time for healthchecker to detect
-                  bu.poll_wait_health(upstream_id, "target2.test", port1, "HEALTHY")
+                  bu.poll_wait_health(upstream_id, "target2.test.", port1, "HEALTHY")
 
                   -- 3) server1 and server2 take requests again
                   do
@@ -1803,10 +1802,10 @@ for _, strategy in helpers.each_strategy() do
                   -- collect server results; hitcount
                   local results = server1:shutdown()
                   ---- verify
-                  assert.are.equal(bu.SLOTS * 2, results["target1.test"].ok)
-                  assert.are.equal(bu.SLOTS, results["target2.test"].ok)
-                  assert.are.equal(0, results["target1.test"].fail)
-                  assert.are.equal(0, results["target1.test"].fail)
+                  assert.are.equal(bu.SLOTS * 2, results["target1.test."].ok)
+                  assert.are.equal(bu.SLOTS, results["target2.test."].ok)
+                  assert.are.equal(0, results["target1.test."].fail)
+                  assert.are.equal(0, results["target1.test."].fail)
                   assert.are.equal(bu.SLOTS * 3, oks)
                   assert.are.equal(0, fails)
                 end

--- a/spec/02-integration/05-proxy/10-balancer/01-healthchecks_spec.lua
+++ b/spec/02-integration/05-proxy/10-balancer/01-healthchecks_spec.lua
@@ -36,40 +36,40 @@ for _, strategy in helpers.each_strategy() do
       }
 
       fixtures.dns_mock:SRV {
-        name = "my.srv.test.com",
-        target = "a.my.srv.test.com",
+        name = "my.srv.test.com.",
+        target = "a.my.srv.test.com.",
         port = 80,  -- port should fail to connect
       }
       fixtures.dns_mock:A {
-        name = "a.my.srv.test.com",
+        name = "a.my.srv.test.com.",
         address = "127.0.0.1",
       }
 
       fixtures.dns_mock:A {
-        name = "multiple-ips.test",
+        name = "multiple-ips.test.",
         address = "127.0.0.1",
       }
       fixtures.dns_mock:A {
-        name = "multiple-ips.test",
+        name = "multiple-ips.test.",
         address = "127.0.0.2",
       }
 
       fixtures.dns_mock:SRV {
-        name = "srv-changes-port.test",
-        target = "a-changes-port.test",
+        name = "multiple-ips.test.srv-changes-port.test.",
+        target = "a-changes-port.test.",
         port = 90,  -- port should fail to connect
       }
 
       fixtures.dns_mock:A {
-        name = "a-changes-port.test",
+        name = "a-changes-port.test.",
         address = "127.0.0.3",
       }
       fixtures.dns_mock:A {
-        name = "another.multiple-ips.test",
+        name = "another.multiple-ips.test.",
         address = "127.0.0.1",
       }
       fixtures.dns_mock:A {
-        name = "another.multiple-ips.test",
+        name = "another.multiple-ips.test.",
         address = "127.0.0.2",
       }
 
@@ -113,7 +113,7 @@ for _, strategy in helpers.each_strategy() do
       })
       -- the following port will not be used, will be overwritten by
       -- the mocked SRV record.
-      bu.add_target(bp, upstream_id, "my.srv.test.com", 80)
+      bu.add_target(bp, upstream_id, "my.srv.test.com.", 80)
       local api_host = bu.add_api(bp, upstream_name)
       bu.end_testcase_setup(strategy, bp)
 
@@ -150,7 +150,7 @@ for _, strategy in helpers.each_strategy() do
       })
       -- the following port will not be used, will be overwritten by
       -- the mocked SRV record.
-      bu.add_target(bp, upstream_id, "multiple-ips.test", 80)
+      bu.add_target(bp, upstream_id, "multiple-ips.test.", 80)
       local api_host = bu.add_api(bp, upstream_name, { connect_timeout = 100, })
       bu.end_testcase_setup(strategy, bp)
 
@@ -177,7 +177,7 @@ for _, strategy in helpers.each_strategy() do
         assert.equals("UNHEALTHY", health.data[1].data.addresses[2].health)
       end, 15)
 
-      local status = bu.put_target_address_health(upstream_id, "multiple-ips.test:80", "127.0.0.2:80", "healthy")
+      local status = bu.put_target_address_health(upstream_id, "multiple-ips.test.:80", "127.0.0.2:80", "healthy")
       assert.same(204, status)
 
       helpers.pwait_until(function ()
@@ -192,7 +192,7 @@ for _, strategy in helpers.each_strategy() do
         assert.equals("HEALTHY", health.data[1].data.addresses[2].health)
       end, 15)
 
-      local status = bu.put_target_address_health(upstream_id, "multiple-ips.test:80", "127.0.0.2:80", "unhealthy")
+      local status = bu.put_target_address_health(upstream_id, "multiple-ips.test.:80", "127.0.0.2:80", "unhealthy")
       assert.same(204, status)
 
       helpers.pwait_until(function ()
@@ -214,7 +214,7 @@ for _, strategy in helpers.each_strategy() do
       -- configure healthchecks
       bu.begin_testcase_setup(strategy, bp)
       local upstream_name, upstream_id = bu.add_upstream(bp, {
-        host_header = "another.multiple-ips.test",
+        host_header = "another.multiple-ips.test.",
         healthchecks = bu.healthchecks_config {
           passive = {
             unhealthy = {
@@ -225,7 +225,7 @@ for _, strategy in helpers.each_strategy() do
       })
       -- the following port will not be used, will be overwritten by
       -- the mocked SRV record.
-      bu.add_target(bp, upstream_id, "multiple-ips.test", 80)
+      bu.add_target(bp, upstream_id, "multiple-ips.test.", 80)
       local api_host = bu.add_api(bp, upstream_name, { connect_timeout = 100, })
       bu.end_testcase_setup(strategy, bp)
 
@@ -253,7 +253,7 @@ for _, strategy in helpers.each_strategy() do
         assert.equals("UNHEALTHY", health.data[1].data.addresses[2].health)
       end, 15)
 
-      local status = bu.put_target_address_health(upstream_id, "multiple-ips.test:80", "127.0.0.2:80", "healthy")
+      local status = bu.put_target_address_health(upstream_id, "multiple-ips.test.:80", "127.0.0.2:80", "healthy")
       assert.same(204, status)
 
       helpers.pwait_until(function ()
@@ -268,7 +268,7 @@ for _, strategy in helpers.each_strategy() do
         assert.equals("HEALTHY", health.data[1].data.addresses[2].health)
       end, 15)
 
-      local status = bu.put_target_address_health(upstream_id, "multiple-ips.test:80", "127.0.0.2:80", "unhealthy")
+      local status = bu.put_target_address_health(upstream_id, "multiple-ips.test.:80", "127.0.0.2:80", "unhealthy")
       assert.same(204, status)
 
       helpers.pwait_until(function ()
@@ -300,7 +300,7 @@ for _, strategy in helpers.each_strategy() do
       })
       -- the following port will not be used, will be overwritten by
       -- the mocked SRV record.
-      bu.add_target(bp, upstream_id, "srv-changes-port.test", 80)
+      bu.add_target(bp, upstream_id, "multiple-ips.test.srv-changes-port.test.", 80)
       local api_host = bu.add_api(bp, upstream_name, { connect_timeout = 100, })
       bu.end_testcase_setup(strategy, bp)
 
@@ -321,13 +321,13 @@ for _, strategy in helpers.each_strategy() do
         assert.is.table(health.data)
         assert.is.table(health.data[1])
 
-        assert.same("a-changes-port.test", health.data[1].data.addresses[1].ip)
+        assert.same("a-changes-port.test.", health.data[1].data.addresses[1].ip)
         assert.same(90, health.data[1].data.addresses[1].port)
 
         assert.equals("UNHEALTHY", health.data[1].health)
         assert.equals("UNHEALTHY", health.data[1].data.addresses[1].health)
 
-        local status = bu.put_target_address_health(upstream_id, "srv-changes-port.test:80", "a-changes-port.test:90", "healthy")
+        local status = bu.put_target_address_health(upstream_id, "srv-changes-port.test.:80", "a-changes-port.test.:90", "healthy")
         assert.same(204, status)
       end, 15)
 
@@ -337,7 +337,7 @@ for _, strategy in helpers.each_strategy() do
         assert.is.table(health.data)
         assert.is.table(health.data[1])
 
-        assert.same("a-changes-port.test", health.data[1].data.addresses[1].ip)
+        assert.same("a-changes-port.test.", health.data[1].data.addresses[1].ip)
         assert.same(90, health.data[1].data.addresses[1].port)
 
         assert.equals("HEALTHY", health.data[1].health)
@@ -368,7 +368,7 @@ for _, strategy in helpers.each_strategy() do
           },
         }
       })
-      bu.add_target(bp, upstream_id, "multiple-ips.test", 80)
+      bu.add_target(bp, upstream_id, "multiple-ips.test.", 80)
       bu.add_api(bp, upstream_name)
       bu.end_testcase_setup(strategy, bp)
 
@@ -399,7 +399,7 @@ for _, strategy in helpers.each_strategy() do
       })
       -- the following port will not be used, will be overwritten by
       -- the mocked SRV record.
-      bu.add_target(bp, upstream_id, "multiple-ips.test", 80)
+      bu.add_target(bp, upstream_id, "multiple-ips.test.", 80)
       local api_host = bu.add_api(bp, upstream_name, { connect_timeout = 100, })
       bu.end_testcase_setup(strategy, bp)
 
@@ -426,7 +426,7 @@ for _, strategy in helpers.each_strategy() do
         assert.equals("UNHEALTHY", health.data[1].data.addresses[2].health)
       end, 15)
 
-      local status = bu.put_target_address_health(upstream_id, "multiple-ips.test:80", "127.0.0.2:80", "healthy")
+      local status = bu.put_target_address_health(upstream_id, "multiple-ips.test.:80", "127.0.0.2:80", "healthy")
       assert.same(204, status)
 
       helpers.pwait_until(function ()
@@ -441,7 +441,7 @@ for _, strategy in helpers.each_strategy() do
         assert.equals("HEALTHY", health.data[1].data.addresses[2].health)
       end, 15)
 
-      local status = bu.put_target_address_health(upstream_id, "multiple-ips.test:80", "127.0.0.2:80", "unhealthy")
+      local status = bu.put_target_address_health(upstream_id, "multiple-ips.test.:80", "127.0.0.2:80", "unhealthy")
       assert.same(204, status)
 
       helpers.pwait_until(function ()
@@ -482,7 +482,7 @@ for _, strategy in helpers.each_strategy() do
       assert.are.equals(upstream_name, new_upstream_name)
 
       -- also the target is the same
-      bu.add_target(bp, new_upstream_id, "multiple-ips.test", 80)
+      bu.add_target(bp, new_upstream_id, "multiple-ips.test.", 80)
       bu.add_api(bp, new_upstream_name, { connect_timeout = 100, })
       bu.end_testcase_setup(strategy, bp)
 
@@ -1188,19 +1188,19 @@ for _, strategy in helpers.each_strategy() do
                 dns_mock = helpers.dns_mock.new()
               }
               fixtures.dns_mock:A {
-                name = "health-threshold.test",
+                name = "health-threshold.test.",
                 address = "127.0.0.1",
               }
               fixtures.dns_mock:A {
-                name = "health-threshold.test",
+                name = "health-threshold.test.",
                 address = "127.0.0.2",
               }
               fixtures.dns_mock:A {
-                name = "health-threshold.test",
+                name = "health-threshold.test.",
                 address = "127.0.0.3",
               }
               fixtures.dns_mock:A {
-                name = "health-threshold.test",
+                name = "health-threshold.test.",
                 address = "127.0.0.4",
               }
 
@@ -1233,14 +1233,14 @@ for _, strategy in helpers.each_strategy() do
                   }
                 })
 
-                bu.add_target(bp, upstream_id, "health-threshold.test", 80, { weight = 25 })
+                bu.add_target(bp, upstream_id, "health-threshold.test.", 80, { weight = 25 })
                 bu.end_testcase_setup(strategy, bp)
 
                 -- 100% healthy
-                bu.put_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.1:80", "healthy")
-                bu.put_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.2:80", "healthy")
-                bu.put_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.3:80", "healthy")
-                bu.put_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.4:80", "healthy")
+                bu.put_target_address_health(upstream_id, "health-threshold.test.:80", "127.0.0.1:80", "healthy")
+                bu.put_target_address_health(upstream_id, "health-threshold.test.:80", "127.0.0.2:80", "healthy")
+                bu.put_target_address_health(upstream_id, "health-threshold.test.:80", "127.0.0.3:80", "healthy")
+                bu.put_target_address_health(upstream_id, "health-threshold.test.:80", "127.0.0.4:80", "healthy")
 
                 local health
 
@@ -1266,7 +1266,7 @@ for _, strategy in helpers.each_strategy() do
                 end
 
                 -- 75% healthy
-                bu.put_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.1:80", "unhealthy")
+                bu.put_target_address_health(upstream_id, "health-threshold.test.:80", "127.0.0.1:80", "unhealthy")
 
                 helpers.pwait_until(function ()
                   health = bu.get_balancer_health(upstream_name)
@@ -1285,7 +1285,7 @@ for _, strategy in helpers.each_strategy() do
                 end
 
                 -- 50% healthy
-                bu.put_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.2:80", "unhealthy")
+                bu.put_target_address_health(upstream_id, "health-threshold.test.:80", "127.0.0.2:80", "unhealthy")
 
                 helpers.pwait_until(function ()
                   health = bu.get_balancer_health(upstream_name)
@@ -1304,7 +1304,7 @@ for _, strategy in helpers.each_strategy() do
                 end
 
                 -- 25% healthy
-                bu.put_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.3:80", "unhealthy")
+                bu.put_target_address_health(upstream_id, "health-threshold.test.:80", "127.0.0.3:80", "unhealthy")
 
                 helpers.pwait_until(function ()
                   health = bu.get_balancer_health(upstream_name)
@@ -1323,7 +1323,7 @@ for _, strategy in helpers.each_strategy() do
                 end
 
                 -- 0% healthy
-                bu.put_target_address_health(upstream_id, "health-threshold.test:80", "127.0.0.4:80", "unhealthy")
+                bu.put_target_address_health(upstream_id, "health-threshold.test.:80", "127.0.0.4:80", "unhealthy")
 
                 helpers.pwait_until(function ()
                   health = bu.get_balancer_health(upstream_name)
@@ -1421,7 +1421,7 @@ for _, strategy in helpers.each_strategy() do
                   local requests = bu.SLOTS * 2 -- go round the balancer twice
                   local port1 = helpers.get_available_port()
                   local port2 = helpers.get_available_port()
-  
+
                   -- setup target servers:
                   -- server2 will only respond for part of the test,
                   -- then server1 will take over.
@@ -1430,7 +1430,7 @@ for _, strategy in helpers.each_strategy() do
                   local server2 = https_server.new(port2, "localhost", "http", true)
                   server1:start()
                   server2:start()
-  
+
                   -- configure healthchecks
                   bu.begin_testcase_setup(strategy, bp)
                   local upstream_name, upstream_id = bu.add_upstream(bp, {

--- a/spec/fixtures/balancer_utils.lua
+++ b/spec/fixtures/balancer_utils.lua
@@ -274,7 +274,7 @@ do
     local host_num = 0
     gen_multi_host = function()
       host_num = host_num + 1
-      return "multiple-hosts-" .. tostring(host_num) .. ".test"
+      return "multiple-hosts-" .. tostring(host_num) .. ".test."
     end
   end
 

--- a/spec/helpers/dns.lua
+++ b/spec/helpers/dns.lua
@@ -32,7 +32,7 @@ function _M.assert_fqdn(name)
   assert(#name > 1, "name cannot be an empty string")
   local t = hostname_type(name)
   assert(t ~= "name" or name:sub(-1,-1) == ".", "expected name to be an ip address or fully "..
-                                                "qualified name with a trailing '.'. Got: "..name)
+                                                "qualified name with a trailing '.'. Got: " .. name)
   return name
 end
 local assert_fqdn = _M.assert_fqdn


### PR DESCRIPTION
### Summary

Avoiding mixing up FQDNs and non-FQDNs.

FTI-2800