### PR TITLE
tests(perf): bump max test run duration from 2h to 3h

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -198,7 +198,7 @@ jobs:
         PERF_TEST_BYO_SSH_USER: gha
         PERF_TEST_USE_DAILY_IMAGE: true
         PERF_TEST_DISABLE_EXEC_OUTPUT: true
-      timeout-minutes: 120
+      timeout-minutes: 180
       run: |
         export PERF_TEST_BYO_SSH_KEY_PATH=$(pwd)/ssh_key
         echo "${{ secrets.PERF_TEST_BYO_SSH_KEY }}" > ${PERF_TEST_BYO_SSH_KEY_PATH}


### PR DESCRIPTION
Past 2 test runs were killed by timeout (for example https://github.com/Kong/kong/actions/runs/3426004985).
Bump it up and test if it will solve the issue.
