### PR TITLE
feat(acme): make account_key configurable

### DIFF
--- a/kong/clustering/compat/removed_fields.lua
+++ b/kong/clustering/compat/removed_fields.lua
@@ -49,4 +49,10 @@ return {
       "request_headers",
     },
   },
+  -- Any dataplane older than 3.3.0
+  [3003000000] = {
+    acme = {
+      "account_key",
+    }
+  },
 }

--- a/kong/plugins/acme/client.lua
+++ b/kong/plugins/acme/client.lua
@@ -236,8 +236,14 @@ local function create_account(conf)
   elseif account then
     return
   end
-  -- no account yet, create one now
-  local pkey = util.create_pkey(4096, "RSA")
+
+  local pkey
+  if conf.account_key then
+    pkey = conf.account_key
+  else
+    -- no account yet, create one now
+    pkey = util.create_pkey(4096, "RSA")
+  end
 
   local err = st:set(account_name, cjson_encode({
     key = pkey,
@@ -512,4 +518,5 @@ return {
   _renew_certificate_storage = renew_certificate_storage,
   _check_expire = check_expire,
   _set_is_dbless = function(d) dbless = d end,
+  _create_account = create_account,
 }

--- a/kong/plugins/acme/client.lua
+++ b/kong/plugins/acme/client.lua
@@ -224,6 +224,42 @@ local function store_renew_config(conf, host)
   return err
 end
 
+local function get_account_key(conf)
+  local kid = conf.key_id
+  local lookup = {kid = kid}
+
+  if conf.key_set then
+    local key_set, key_set_err = kong.db.key_sets:select_by_name(conf.key_set)
+
+    if key_set_err then
+      kong.log.warn("error loading keyset ", conf.key_set, " : ", key_set_err)
+      return nil, key_set_err
+    end
+
+    if not key_set then
+      kong.log.warn("could not load keyset nil value was returned")
+      return nil, error("nil returned by key_sets:select_by_name for key_set ", conf.key_set)
+    end
+
+    lookup.set = {id = key_set.id}
+  end
+
+  local cache_key = kong.db.keys:cache_key(lookup)
+  local key, key_err = kong.db.keys:select_by_cache_key(cache_key)
+
+  if key_err then
+    kong.log.warn("error loading key ", kid, " : ", key_err)
+    return nil, key_err
+  end
+
+  if not key then
+    kong.log.warn("could not load key nil value was returned")
+    return nil, error("nil returned by keys:select_by_cache_key for key ", conf.key_id)
+  end
+
+  return kong.db.keys:get_privkey(key)
+end
+
 local function create_account(conf)
   local _, st, err = new_storage_adapter(conf)
   if err then
@@ -239,7 +275,12 @@ local function create_account(conf)
 
   local pkey
   if conf.account_key then
-    pkey = conf.account_key
+    local account_key, err = get_account_key(conf.account_key)
+    if err then
+      return err
+    end
+
+    pkey = account_key
   else
     -- no account yet, create one now
     pkey = util.create_pkey(4096, "RSA")

--- a/kong/plugins/acme/schema.lua
+++ b/kong/plugins/acme/schema.lua
@@ -71,6 +71,11 @@ local schema = {
           encrypted = true, -- Kong Enterprise-exclusive feature, does nothing in Kong CE
           referenceable = true,
         }, },
+        { account_key = {
+          type = "string",
+          encrypted = true, -- Kong Enterprise-exclusive feature, does nothing in Kong CE
+          referenceable = true,
+        }, },
         { api_uri = typedefs.url({ default = "https://acme-v02.api.letsencrypt.org/directory" }),
         },
         { tos_accepted = {

--- a/kong/plugins/acme/schema.lua
+++ b/kong/plugins/acme/schema.lua
@@ -71,8 +71,7 @@ local schema = {
           encrypted = true, -- Kong Enterprise-exclusive feature, does nothing in Kong CE
           referenceable = true,
         }, },
-        { account_key = {
-          type = "string",
+        { account_key = typedefs.key {
           encrypted = true, -- Kong Enterprise-exclusive feature, does nothing in Kong CE
           referenceable = true,
         }, },

--- a/kong/plugins/acme/schema.lua
+++ b/kong/plugins/acme/schema.lua
@@ -52,6 +52,11 @@ local VAULT_STORAGE_SCHEMA = {
   { jwt_path =  { type = "string" }, },
 }
 
+local ACCOUNT_KEY_SCHEMA = {
+  { key_id = { type = "string", required = true }},
+  { key_set = { type = "string" }}
+}
+
 local schema = {
   name = "acme",
   fields = {
@@ -71,9 +76,10 @@ local schema = {
           encrypted = true, -- Kong Enterprise-exclusive feature, does nothing in Kong CE
           referenceable = true,
         }, },
-        { account_key = typedefs.key {
-          encrypted = true, -- Kong Enterprise-exclusive feature, does nothing in Kong CE
-          referenceable = true,
+        { account_key = {
+          type = "record",
+          required = false,
+          fields = ACCOUNT_KEY_SCHEMA,
         }, },
         { api_uri = typedefs.url({ default = "https://acme-v02.api.letsencrypt.org/directory" }),
         },

--- a/spec/03-plugins/29-acme/01-client_spec.lua
+++ b/spec/03-plugins/29-acme/01-client_spec.lua
@@ -104,7 +104,7 @@ for _, strategy in ipairs(strategies) do
   describe("Plugin: acme (client.create_account) [#" .. strategy .. "]", function()
     describe("create with preconfigured account_key", function()
       lazy_setup(function()
-        account_key = "fake-account-key"
+        account_key = util.create_pkey()
         config = tablex.deepcopy(proper_config)
         config.account_key = account_key
         c = client.new(config)
@@ -143,14 +143,18 @@ for _, strategy in ipairs(strategies) do
     end)
 
     describe("create with generated account_key", function()
-      local i = 0
+      local i = 1
+      local account_keys = {}
 
       lazy_setup(function()
         config = tablex.deepcopy(proper_config)
         c = client.new(config)
 
+        account_keys[1] = util.create_pkey()
+        account_keys[2] = util.create_pkey()
+
         util.create_pkey = function(size, type)
-          local key = "fake-generated-key-" .. i
+          local key = account_keys[i]
           i = i + 1
           return key
         end
@@ -171,7 +175,7 @@ for _, strategy in ipairs(strategies) do
         assert.not_nil(account)
 
         local account_data = cjson.decode(account)
-        assert.equal(account_data.key, "fake-generated-key-0")
+        assert.equal(account_data.key, account_keys[1])
       end)
 
       -- The second call should be a nop because the key is found in the db.
@@ -184,7 +188,7 @@ for _, strategy in ipairs(strategies) do
         assert.not_nil(account)
 
         local account_data = cjson.decode(account)
-        assert.equal(account_data.key, "fake-generated-key-0")
+        assert.equal(account_data.key, account_keys[1])
       end)
     end)
   end)

--- a/spec/03-plugins/29-acme/04-schema_spec.lua
+++ b/spec/03-plugins/29-acme/04-schema_spec.lua
@@ -69,11 +69,25 @@ describe("Plugin: acme (schema)", function()
       },
     ----------------------------------------
     {
-        name = "accepts valid account_key",
+        name = "accepts valid account_key with key_set",
         input = {
           account_email = "example@example.com",
           api_uri = "https://api.acme.org",
-          account_key = ssl_fixtures.key
+          account_key = {
+            key_id = "123",
+            key_set = "my-key-set",
+          }
+        },
+    },
+    ----------------------------------------
+    {
+        name = "accepts valid account_key without key_set",
+        input = {
+          account_email = "example@example.com",
+          api_uri = "https://api.acme.org",
+          account_key = {
+            key_id = "123",
+          }
         },
     },
   }
@@ -89,31 +103,4 @@ describe("Plugin: acme (schema)", function()
       end
     end)
   end
-
-  -- This needs to be a separate test because validating the error cannot be done by
-  -- comparing the expected and actual error. The error message returned by openssl
-  -- is not stable because it includes values that may change like line number. To
-  -- avoid potential test failures in the future, this test checks the error message
-  -- for the prefix that we add.
-  it("rejects invalid account_key", function()
-    local input = {
-      account_email = "example@example.com",
-      api_uri = "https://api.acme.org",
-      account_key = "fake-account-key"
-    }
-
-    local output, err = v(input, acme_schema)
-
-    assert.not_nil(err)
-    assert.not_nil(err.config)
-
-    local s = err.config.account_key
-    assert.equal("invalid key: pkey.new:load_key", string.sub(s, string.find(s, "invalid key: pkey.new:load_key")))
-
-    if err then
-      assert.is_falsy(output)
-    else
-      assert.is_truthy(output)
-    end
-  end)
 end)

--- a/spec/03-plugins/29-acme/04-schema_spec.lua
+++ b/spec/03-plugins/29-acme/04-schema_spec.lua
@@ -1,5 +1,4 @@
 local acme_schema = require "kong.plugins.acme.schema"
-local ssl_fixtures = require "spec.fixtures.ssl"
 local v = require("spec.helpers").validate_plugin_config_schema
 
 describe("Plugin: acme (schema)", function()


### PR DESCRIPTION
### Summary

There is currently no way to configure an existing private key to be used for the acme plugin. If the account does not have a key in storage, then a new one is created. This is a problem when external account binding credentials have already been associated with a key elsewhere (e.g. cert-manager or cert-bot). Some issuers like ZeroSSL allow for EAB credentials to be reused and multiple accounts can be created with different private keys. Others like GCP Public CA only allow for EAB credentials to be associated with one key so when the plugin tries to create a new account with a new key it fails.

The current workaround for this has been to manually insert the key in storage so a new key is not created.

This PR exposes `account_key` and will use that if the account was not found in storage and the value of `account_key` is not nil. Otherwise, it will generate a key on the fly as it does currently.

### Full changelog

* Add `account_key` in acme plugin schema
* Add tests for when `account_key` is present and when it is absent in the configuration

cc @fffonion 
