### PR TITLE
tests(helpers): use io.open to truncate file

### DIFF
--- a/spec/02-integration/01-helpers/01-helpers_spec.lua
+++ b/spec/02-integration/01-helpers/01-helpers_spec.lua
@@ -221,40 +221,6 @@ for _, strategy in helpers.each_strategy() do
       end)
     end)
 
-    describe("get_version()", function()
-      it("gets the version of Kong running", function()
-        local meta = require 'kong.meta'
-        local version = require 'version'
-        assert.equal(version(meta._VERSION), helpers.get_version())
-      end)
-    end)
-
-    describe("wait_until()", function()
-      it("does not errors out if thing happens", function()
-        assert.has_no_error(function()
-          local i = 0
-          helpers.wait_until(function()
-            i = i + 1
-            return i > 1
-          end, 3)
-        end)
-      end)
-      it("errors out after delay", function()
-        assert.error_matches(function()
-          helpers.wait_until(function()
-            return false, "thing still not done"
-          end, 1)
-        end, "timeout: thing still not done")
-      end)
-      it("reports errors in test function", function()
-        assert.error_matches(function()
-          helpers.wait_until(function()
-            assert.equal("foo", "bar")
-          end, 1)
-        end, "Expected objects to be equal.", nil, true)
-      end)
-    end)
-
     describe("response modifier", function()
       it("fails with bad input", function()
         assert.error(function() assert.response().True(true) end)
@@ -623,102 +589,212 @@ for _, strategy in helpers.each_strategy() do
 
     end)
 
-    describe("wait_for_file_contents()", function()
-      local function time()
-        ngx.update_time()
-        return ngx.now()
+  end)
+end
+
+describe("helpers: utilities", function()
+  describe("get_version()", function()
+    it("gets the version of Kong running", function()
+      local meta = require 'kong.meta'
+      local version = require 'version'
+      assert.equal(version(meta._VERSION), helpers.get_version())
+    end)
+  end)
+
+  describe("wait_until()", function()
+    it("does not errors out if thing happens", function()
+      assert.has_no_error(function()
+        local i = 0
+        helpers.wait_until(function()
+          i = i + 1
+          return i > 1
+        end, 3)
+      end)
+    end)
+    it("errors out after delay", function()
+      assert.error_matches(function()
+        helpers.wait_until(function()
+          return false, "thing still not done"
+        end, 1)
+      end, "timeout: thing still not done")
+    end)
+    it("reports errors in test function", function()
+      assert.error_matches(function()
+        helpers.wait_until(function()
+          assert.equal("foo", "bar")
+        end, 1)
+      end, "Expected objects to be equal.", nil, true)
+    end)
+  end)
+
+  describe("wait_for_file_contents()", function()
+    local function time()
+      ngx.update_time()
+      return ngx.now()
+    end
+
+    it("returns the file contents when the file is readable and non-empty", function()
+      local fname = assert(helpers.path.tmpname())
+      assert(helpers.file.write(fname, "test"))
+
+      assert.equals("test", helpers.wait_for_file_contents(fname))
+    end)
+
+    it("waits for the file if need be", function()
+      local fname = assert(helpers.path.tmpname())
+      assert(os.remove(fname))
+
+      local timeout = 1
+      local delay = 0.25
+      local start, duration
+
+      local sema = require("ngx.semaphore").new()
+
+      local ok, res
+      ngx.timer.at(0, function()
+        start = time()
+
+        ok, res = pcall(helpers.wait_for_file_contents, fname, timeout)
+
+        duration = time() - start
+        sema:post(1)
+      end)
+
+      ngx.sleep(delay)
+      assert(helpers.file.write(fname, "test"))
+
+      assert.truthy(sema:wait(timeout),
+                    "timed out waiting for timer to finish")
+
+      assert.truthy(ok, "timer raised an error: " .. tostring(res))
+      assert.equals("test", res)
+
+      assert.truthy(duration <= timeout,
+                    "expected to finish in <" .. tostring(timeout) .. "s" ..
+                    " but took " .. tostring(duration) ..  "s")
+
+      assert.truthy(duration > delay,
+                    "expected to finish in >=" .. tostring(delay) .. "s" ..
+                    " but took " .. tostring(duration) ..  "s")
+    end)
+
+    it("doesn't wait longer than the timeout in the failure case", function()
+      local fname = assert(helpers.path.tmpname())
+
+      local timeout = 1
+      local start, duration
+
+      local sema = require("ngx.semaphore").new()
+
+      local ok, err
+      ngx.timer.at(0, function()
+        start = time()
+
+        ok, err = pcall(helpers.wait_for_file_contents, fname, timeout)
+
+        duration = time() - start
+        sema:post(1)
+      end)
+
+      assert.truthy(sema:wait(timeout * 1.5),
+                    "timed out waiting for timer to finish")
+
+      assert.falsy(ok, "expected wait_for_file_contents to fail")
+      assert.not_nil(err)
+
+      local diff = math.abs(duration - timeout)
+      assert.truthy(diff < 0.5,
+                    "expected to finish in about " .. tostring(timeout) .. "s" ..
+                    " but took " .. tostring(duration) ..  "s")
+    end)
+
+
+    it("raises an assertion error if the file does not exist", function()
+      assert.error_matches(function()
+        helpers.wait_for_file_contents("/i/do/not/exist", 0)
+      end, "does not exist or is not readable")
+    end)
+
+    it("raises an assertion error if the file is empty", function()
+      local fname = assert(helpers.path.tmpname())
+
+      assert.error_matches(function()
+        helpers.wait_for_file_contents(fname, 0)
+      end, "exists but is empty")
+    end)
+  end)
+
+  describe("clean_logfile()", function()
+    it("truncates a file", function()
+      local fname = assert(os.tmpname())
+      assert(helpers.file.write(fname, "some data\nand some more data\n"))
+      assert(helpers.path.getsize(fname) > 0)
+
+      finally(function()
+        os.remove(fname)
+      end)
+
+      helpers.clean_logfile(fname)
+      assert(helpers.path.getsize(fname) == 0)
+    end)
+
+    it("truncates the test conf error.log file if no input is given", function()
+      local log_dir = helpers.path.join(helpers.test_conf.prefix, "logs")
+      if not helpers.path.exists(log_dir) then
+        assert(helpers.dir.makepath(log_dir))
+        finally(function()
+          finally(function()
+            helpers.dir.rmtree(log_dir)
+          end)
+        end)
       end
 
-      it("returns the file contents when the file is readable and non-empty", function()
-        local fname = assert(helpers.path.tmpname())
-        assert(helpers.file.write(fname, "test"))
+      local fname = helpers.path.join(log_dir, "error.log")
+      assert(helpers.file.write(fname, "some data\nand some more data\n"))
+      assert(helpers.path.getsize(fname) > 0)
 
-        assert.equals("test", helpers.wait_for_file_contents(fname))
+      helpers.clean_logfile(fname)
+      assert(helpers.path.getsize(fname) == 0)
+    end)
+
+    it("creates an empty file if one does not exist", function()
+      local fname = assert(os.tmpname())
+      assert(os.remove(fname))
+      assert(not helpers.path.exists(fname))
+
+      helpers.clean_logfile(fname)
+
+      finally(function()
+        os.remove(fname)
       end)
 
-      it("waits for the file if need be", function()
-        local fname = assert(helpers.path.tmpname())
-        assert(os.remove(fname))
-
-        local timeout = 1
-        local delay = 0.25
-        local start, duration
-
-        local sema = require("ngx.semaphore").new()
-
-        local ok, res
-        ngx.timer.at(0, function()
-          start = time()
-
-          ok, res = pcall(helpers.wait_for_file_contents, fname, timeout)
-
-          duration = time() - start
-          sema:post(1)
-        end)
-
-        ngx.sleep(delay)
-        assert(helpers.file.write(fname, "test"))
-
-        assert.truthy(sema:wait(timeout),
-                      "timed out waiting for timer to finish")
-
-        assert.truthy(ok, "timer raised an error: " .. tostring(res))
-        assert.equals("test", res)
-
-        assert.truthy(duration <= timeout,
-                      "expected to finish in <" .. tostring(timeout) .. "s" ..
-                      " but took " .. tostring(duration) ..  "s")
-
-        assert.truthy(duration > delay,
-                      "expected to finish in >=" .. tostring(delay) .. "s" ..
-                      " but took " .. tostring(duration) ..  "s")
-      end)
-
-      it("doesn't wait longer than the timeout in the failure case", function()
-        local fname = assert(helpers.path.tmpname())
-
-        local timeout = 1
-        local start, duration
-
-        local sema = require("ngx.semaphore").new()
-
-        local ok, err
-        ngx.timer.at(0, function()
-          start = time()
-
-          ok, err = pcall(helpers.wait_for_file_contents, fname, timeout)
-
-          duration = time() - start
-          sema:post(1)
-        end)
-
-        assert.truthy(sema:wait(timeout * 1.5),
-                      "timed out waiting for timer to finish")
-
-        assert.falsy(ok, "expected wait_for_file_contents to fail")
-        assert.not_nil(err)
-
-        local diff = math.abs(duration - timeout)
-        assert.truthy(diff < 0.5,
-                      "expected to finish in about " .. tostring(timeout) .. "s" ..
-                      " but took " .. tostring(duration) ..  "s")
-      end)
+      assert(helpers.path.isfile(fname))
+      assert(helpers.path.getsize(fname) == 0)
+    end)
 
 
-      it("raises an assertion error if the file does not exist", function()
-        assert.error_matches(function()
-          helpers.wait_for_file_contents("/i/do/not/exist", 0)
-        end, "does not exist or is not readable")
-      end)
+    it("doesn't raise an error if the parent directory does not exist", function()
+      local fname = "/tmp/i-definitely/do-not-exist." .. ngx.worker.pid()
+      assert(not helpers.path.exists(fname))
 
-      it("raises an assertion error if the file is empty", function()
-        local fname = assert(helpers.path.tmpname())
-
-        assert.error_matches(function()
-          helpers.wait_for_file_contents(fname, 0)
-        end, "exists but is empty")
+      assert.has_no_error(function()
+        helpers.clean_logfile(fname)
       end)
     end)
 
+    it("raises an error if the path is not a file", function()
+      local path = os.tmpname()
+      os.remove(path)
+      assert(helpers.dir.makepath(path))
+      assert(helpers.path.isdir(path))
+
+      finally(function()
+        helpers.dir.rmtree(path)
+      end)
+
+      assert.error_matches(function()
+        helpers.clean_logfile(path)
+      end, "Is a directory")
+    end)
   end)
-end
+end)

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -2892,7 +2892,20 @@ end
 -- @see line
 local function clean_logfile(logfile)
   logfile = logfile or (get_running_conf() or conf).nginx_err_logs
-  os.execute(":> " .. logfile)
+
+  assert(type(logfile) == "string", "'logfile' must be a string")
+
+  local fh, err, errno = io.open(logfile, "w+")
+
+  if fh then
+    fh:close()
+    return
+
+  elseif errno == 2 then -- ENOENT
+    return
+  end
+
+  error("failed to truncate logfile: " .. tostring(err))
 end
 
 


### PR DESCRIPTION
The old implementation of clean_logfile() exec()-ed out to /bin/sh with redirection to truncate the file. This yields an annoying error message if the file does not exist and cannot be created because its parent directory also doesn't exist:

> sh: 1: cannot create /home/runner/work/kong-ee/kong-ee/servroot/logs/error.log: Directory nonexistent

This implementation tries to be a little smarter. It uses `io.open()` instead of `os.execute()` and will throw an error for any errors except ENOENT.

When adding integration tests for this I noticed that the Kong instance that was running within the test suite was interfering with things a bit, so I moved all of the tests that _don't_ require a running Kong instance to a separate `describe(...)` block.