### PR TITLE
fix(core): prefix path must be normalized

### DIFF
--- a/kong/db/schema/typedefs.lua
+++ b/kong/db/schema/typedefs.lua
@@ -452,7 +452,7 @@ local function validate_path_with_regexes(path)
     -- prefix matching. let's check if it's normalized form
     local normalized = normalize(path, true)
     if path ~= normalized then
-      return nil, "not normalized path. Suggest: '" .. normalized .. "'"
+      return nil, "non-normalized path, consider use '" .. normalized .. "' instead"
     end
 
     return true

--- a/kong/db/schema/typedefs.lua
+++ b/kong/db/schema/typedefs.lua
@@ -8,6 +8,7 @@ local socket_url = require "socket.url"
 local constants = require "kong.constants"
 
 
+local normalize = require("kong.tools.uri").normalize
 local pairs = pairs
 local match = string.match
 local gsub = string.gsub
@@ -448,6 +449,12 @@ local function validate_path_with_regexes(path)
   end
 
   if path:sub(1, 1) ~= "~" then
+    -- prefix matching. let's check if it's normalized form
+    local normalized = normalize(path, true)
+    if path ~= normalized then
+      return nil, "not normalized path. Suggest: '" .. normalized .. "'"
+    end
+
     return true
   end
 


### PR DESCRIPTION
Example:

```json
{
	"paths": ["/%c3%A4"]
}
```

```json
{
	"fields": {
		"paths": [
			"not normalized path. Suggest: '/ä'"
		]
	},
	"code": 2,
	"name": "schema violation",
	"message": "schema violation (paths.1: not normalized path. Suggest: '/ä')"
}
```

fix FT-3359