### PR TITLE
fix(cmd): use correct format to log message

### DIFF
--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -48,7 +48,7 @@ local function pre_create_private_file(file)
 
   local fd = ffi.C.open(file, flags, mode)
   if fd == -1 then
-    log.warn("unable to pre-create '", file ,"' file: ",
+    log.warn("unable to pre-create '%s' file: %s", file,
              ffi.string(ffi.C.strerror(ffi.errno())))
 
   else


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

`log.warn()` is not `ngx.log`, we should use `string.format` style, not string concat or array style.

