### PR TITLE
feat(clustering): add config compat transformations to wRPC

### DIFF
--- a/kong/clustering/utils.lua
+++ b/kong/clustering/utils.lua
@@ -500,19 +500,19 @@ local function invalidate_keys_from_config(config_plugins, keys)
   return has_update
 end
 
-local function dp_version_num(dp_version)
+local function version_num(dp_version)
   local base = 1000000000
-  local version_num = 0
+  local num = 0
   for _, v in ipairs(utils.split(dp_version, ".", 4)) do
     v = v:match("^(%d+)")
-    version_num = version_num + base * tonumber(v, 10) or 0
+    num = num + base * (tonumber(v, 10) or 0)
     base = base / 1000
   end
 
-  return version_num
+  return num
 end
--- for test
-_M._dp_version_num = dp_version_num
+
+_M.version_num = version_num
 
 
 local function get_removed_fields(dp_version_number)
@@ -542,7 +542,7 @@ _M._get_removed_fields = get_removed_fields
 
 -- returns has_update, modified_deflated_payload, err
 function _M.update_compatible_payload(payload, dp_version)
-  local fields = get_removed_fields(dp_version_num(dp_version))
+  local fields = get_removed_fields(version_num(dp_version))
   if fields then
     payload = utils.deep_copy(payload, false)
     local config_table = payload["config_table"]

--- a/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
@@ -1,0 +1,160 @@
+local helpers = require "spec.helpers"
+local utils = require "kong.tools.utils"
+local cjson = require "cjson"
+local CLUSTERING_SYNC_STATUS = require("kong.constants").CLUSTERING_SYNC_STATUS
+
+local admin = require "spec.fixtures.admin_api"
+
+local CP_HOST = "127.0.0.1"
+local CP_PORT = 9005
+
+local PLUGIN_LIST
+
+
+local function cluster_client(opts)
+  opts = opts or {}
+  local res = helpers.clustering_client({
+    host = CP_HOST,
+    port = CP_PORT,
+    cert = "spec/fixtures/kong_clustering.crt",
+    cert_key = "spec/fixtures/kong_clustering.key",
+    node_hostname = opts.hostname or "test",
+    node_id = opts.id or utils.uuid(),
+    node_version = opts.version,
+    node_plugins_list = PLUGIN_LIST,
+  })
+
+  if res and res.config then
+    local inflated = assert(utils.inflate_gzip(res.config))
+    res.config = cjson.decode(inflated)
+  end
+
+  return res
+end
+
+local function get_plugin(node_id, node_version, name)
+  local res, err = cluster_client({ id = node_id, version = node_version })
+  assert.is_nil(err)
+  assert.is_table(res and res.config and res.config.plugins,
+                  "invalid response from clustering client")
+
+  local plugin
+  for _, p in ipairs(res.config.plugins) do
+    if p.name == name then
+      plugin = p
+      break
+    end
+  end
+
+  assert.not_nil(plugin, "plugin " .. name .. " not found in config")
+  return plugin
+end
+
+
+local function get_sync_status(id)
+  local status
+  local admin_client = helpers.admin_client()
+
+  helpers.wait_until(function()
+    local res = admin_client:get("/clustering/data-planes")
+    local body = assert.res_status(200, res)
+
+    local json = cjson.decode(body)
+
+    for _, v in pairs(json.data) do
+      if v.id == id then
+        status = v.sync_status
+        return true
+      end
+    end
+  end, 5, 0.5)
+
+  admin_client:close()
+
+  return status
+end
+
+
+for _, strategy in helpers.each_strategy() do
+
+describe("CP/DP config compat transformations #" .. strategy, function()
+  lazy_setup(function()
+    local bp = helpers.get_db_utils(strategy)
+
+    PLUGIN_LIST = helpers.get_plugins_list()
+
+    bp.routes:insert {
+      name = "compat.test",
+      hosts = { "compat.test" },
+      service = bp.services:insert {
+        name = "compat.test",
+      }
+    }
+
+    assert(helpers.start_kong({
+      role = "control_plane",
+      cluster_cert = "spec/fixtures/kong_clustering.crt",
+      cluster_cert_key = "spec/fixtures/kong_clustering.key",
+      database = strategy,
+      db_update_frequency = 0.1,
+      cluster_listen = CP_HOST .. ":" .. CP_PORT,
+      nginx_conf = "spec/fixtures/custom_nginx.template",
+      plugins = "bundled",
+    }))
+  end)
+
+  lazy_teardown(function()
+    helpers.stop_kong()
+  end)
+
+  describe("plugin config fields", function()
+    local rate_limit
+
+    lazy_setup(function()
+      rate_limit = admin.plugins:insert {
+        name = "rate-limiting",
+        enabled = true,
+        config = {
+          second = 1,
+          policy = "local",
+
+          -- [[ new fields
+          error_code = 403,
+          error_message = "go away!",
+          -- ]]
+        },
+      }
+    end)
+
+    lazy_teardown(function()
+      admin.plugins:remove({ id = rate_limit.id })
+    end)
+
+    it("removes new fields before sending them to older DP nodes", function()
+      local id = utils.uuid()
+      local plugin = get_plugin(id, "3.0.0", rate_limit.name)
+
+      local expected = utils.deep_copy(rate_limit.config)
+      expected.error_code = nil
+      expected.error_message = nil
+
+      assert.same(expected, plugin.config)
+      assert.equals(CLUSTERING_SYNC_STATUS.NORMAL, get_sync_status(id))
+
+
+      id = utils.uuid()
+      plugin = get_plugin(id, "3.1.0", rate_limit.name)
+      assert.same(rate_limit.config, plugin.config)
+      assert.equals(CLUSTERING_SYNC_STATUS.NORMAL, get_sync_status(id))
+    end)
+
+    it("does not remove fields from DP nodes that are already compatible", function()
+      local id = utils.uuid()
+      local plugin = get_plugin(id, "3.1.0", rate_limit.name)
+      assert.same(rate_limit.config, plugin.config)
+      assert.equals(CLUSTERING_SYNC_STATUS.NORMAL, get_sync_status(id))
+    end)
+  end)
+end)
+
+end -- each strategy


### PR DESCRIPTION
~_This depends upon #9740 and will be tough to review until it's merged._~

The goal of these changes is to take the cluster compatibility functionality from the legacy control plane code and wire it into the wRPC control plane.

In the interest of time/ease of review, there is very little refactoring here. As such, the code is not very elegant. The changes themselves are pretty minimal though, and to be honest I think most everything in `kong.clustering.*` could use a follow-up refactor for cleanliness and ease of maintenance with EE in the next release or two.

Tests for this are pretty minimal as the `update_compatible_payload` functionality is nothing new and has been fairly well-tested via the legacy cluster protocol. If any issues are discovered, bugfix/additional tests can be implemented post feature-freeze.