### PR TITLE
Revert "fix(db/lmdb): create lmdb directory with proper permission (#…

### DIFF
--- a/kong/cmd/utils/prefix_handler.lua
+++ b/kong/cmd/utils/prefix_handler.lua
@@ -378,54 +378,6 @@ local function write_process_secrets_file(path, data)
   return true
 end
 
-local function pre_create_lmdb(conf)
-  local prefix = conf.prefix
-  local lmdb_path = conf.lmdb_environment_path or "dbless.lmdb"
-  local user = string.match(conf.nginx_user or "", "%w+") or "$USER"
-
-  local dir_name
-  if lmdb_path:sub(1, 1) == "/" then
-    dir_name = lmdb_path
-
-  else
-    dir_name = prefix .. "/" .. lmdb_path
-  end
-
-  if pl_path.isdir(dir_name) then
-    return true
-  end
-
-  log.debug("LMDB directory '%s' does not exist, " ..
-            "pre-creating with the correct permissions",
-            dir_name)
-
-  local ok, err = pl_path.mkdir(dir_name)
-  if not ok then
-    return nil, "can not create directory for LMDB " .. dir_name ..
-                ", err: " .. err
-  end
-
-  local cmds = {
-    string.format("chown %s %s && chmod 0700 %s",
-                  user, dir_name, dir_name),
-
-    string.format("touch %s && chmod 0600 %s",
-                  dir_name .. "/data.mdb", dir_name .. "/data.mdb"),
-
-    string.format("touch %s && chmod 0600 %s",
-                  dir_name .. "/lock.mdb", dir_name .. "/lock.mdb"),
-  }
-
-  for _, cmd in ipairs(cmds) do
-    local ok, _, _, stderr = pl_utils.executeex(cmd)
-    if not ok then
-      return nil, stderr
-    end
-  end
-
-  return true
-end
-
 local function compile_kong_conf(kong_config)
   return compile_conf(kong_config, kong_nginx_template)
 end
@@ -655,12 +607,6 @@ local function prepare_prefix(kong_config, nginx_custom_template_path, skip_writ
 
   if skip_write then
     return true
-  end
-
-  -- check lmdb directory
-  local ok, err = pre_create_lmdb(kong_config)
-  if not ok then
-    return nil, "check LMDB failed: " .. err
   end
 
   -- compile Nginx configurations

--- a/spec/02-integration/02-cmd/09-prepare_spec.lua
+++ b/spec/02-integration/02-cmd/09-prepare_spec.lua
@@ -65,33 +65,6 @@ describe("kong prepare", function()
     assert.truthy(helpers.path.exists(admin_error_log_path))
   end)
 
-  it("prepares a directory for LMDB", function()
-    assert(helpers.kong_exec("prepare -c " .. helpers.test_conf_path ..
-                             " -p " .. TEST_PREFIX))
-    assert.truthy(helpers.path.exists(TEST_PREFIX))
-
-    local lmdb_data_path = helpers.path.join(TEST_PREFIX, "dbless.lmdb/data.mdb")
-    local lmdb_lock_path = helpers.path.join(TEST_PREFIX, "dbless.lmdb/lock.mdb")
-
-    assert.truthy(helpers.path.exists(lmdb_data_path))
-    assert.truthy(helpers.path.exists(lmdb_lock_path))
-
-    local handle = io.popen("ls -l " .. TEST_PREFIX .. " | grep dbless.lmdb")
-    local result = handle:read("*a")
-    handle:close()
-    assert.matches("drwx------", result, nil, true)
-
-    local handle = io.popen("ls -l " .. lmdb_data_path)
-    local result = handle:read("*a")
-    handle:close()
-    assert.matches("-rw-------", result, nil, true)
-
-    local handle = io.popen("ls -l " .. lmdb_lock_path)
-    local result = handle:read("*a")
-    handle:close()
-    assert.matches("-rw-------", result, nil, true)
-  end)
-
   describe("errors", function()
     it("on inexistent Kong conf file", function()
       local ok, stderr = helpers.kong_exec "prepare --conf foobar.conf"


### PR DESCRIPTION
…9755)"

This reverts commit f95b12165687fcdfc8309cec77460d0931a033f6.

It is causing upgrade test failures on `master`.