### PR TITLE
chore(rockspec): bump lua-resty-healthcheck to 1.6.2

### DIFF
--- a/kong-3.1.0-0.rockspec
+++ b/kong-3.1.0-0.rockspec
@@ -33,7 +33,7 @@ dependencies = {
   "luaxxhash >= 1.0",
   "lua-protobuf == 0.3.3",
   "lua-resty-worker-events == 1.0.0",
-  "lua-resty-healthcheck == 1.6.1",
+  "lua-resty-healthcheck == 1.6.2",
   "lua-resty-mlcache == 2.6.0",
   "lua-messagepack == 0.5.2",
   "lua-resty-openssl == 0.8.15",


### PR DESCRIPTION
### Summary

The lua-resty-healthcheck feature used to keep the health status when an existent target is updated was raising more events than needed. The issue was fixed in the healthcheck module and bumped here.

### Full changelog

* lua-resty-healthcheck bump.
* Same behavior as before, no new tests.

FTI-4353