### PR TITLE
docs(autodoc): correct example response data

### DIFF
--- a/autodoc/admin-api/data/admin-api.lua
+++ b/autodoc/admin-api/data/admin-api.lua
@@ -439,7 +439,7 @@ return {
             {
                 "fields": {
                     "hide_credentials": {
-                        "default": true,
+                        "default": false,
                         "type": "boolean"
                     },
                     "key_names": {

--- a/autodoc/admin-api/data/admin-api.lua
+++ b/autodoc/admin-api/data/admin-api.lua
@@ -439,11 +439,11 @@ return {
             {
                 "fields": {
                     "hide_credentials": {
-                        "default": false,
+                        "default": true,
                         "type": "boolean"
                     },
                     "key_names": {
-                        "default": "function",
+                        "default": ["apikey"],
                         "required": true,
                         "type": "array"
                     }


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

Correct JSON response data of autodoc example.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE
