### PR TITLE
fix(http-log): queue id serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,6 +226,9 @@
 - **Response-Transformer**: Fix the bug that Response-Transformer plugin
   breaks when receiving an unexcepted body.
   [#9463](https://github.com/Kong/kong/pull/9463)
+- **HTTP-Log**: Fix an issue where queue id serialization
+  does not include `queue_size` and `flush_timeout`.
+  [#9789](https://github.com/Kong/kong/pull/9789)
 
 ### Dependencies
 

--- a/kong/plugins/http-log/handler.lua
+++ b/kong/plugins/http-log/handler.lua
@@ -123,7 +123,7 @@ end
 
 
 local function get_queue_id(conf)
-  return fmt("%s:%s:%s:%s:%s:%s",
+  return fmt("%s:%s:%s:%s:%s:%s:%s:%s",
              conf.http_endpoint,
              conf.method,
              conf.content_type,
@@ -182,5 +182,7 @@ function HttpLogHandler:log(conf)
   q:add(entry)
 end
 
+-- for testing
+HttpLogHandler.__get_queue_id = get_queue_id
 
 return HttpLogHandler

--- a/spec/03-plugins/03-http-log/03-queue_spec.lua
+++ b/spec/03-plugins/03-http-log/03-queue_spec.lua
@@ -1,0 +1,22 @@
+local helpers = require "spec.helpers"
+
+for _, strategy in helpers.each_strategy() do
+  describe("Plugin: http-log (queue) [#" .. strategy .. "]", function()
+    it("Queue id serialization", function()
+      local get_queue_id = require("kong.plugins.http-log.handler").__get_queue_id
+      local conf = {
+        http_endpoint = "http://example.com",
+        method = "POST",
+        content_type = "application/json",
+        timeout = 1000,
+        keepalive = 1000,
+        retry_count = 10,
+        queue_size = 100,
+        flush_timeout = 1000,
+      }
+
+      local queue_id = get_queue_id(conf)
+      assert.equal("http://example.com:POST:application/json:1000:1000:10:100:1000", queue_id)
+    end)
+  end)
+end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

Fix an issue where queue id serialization does not include `queue_size` and `flush_timeout`.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #9272
