### PR TITLE
fix(clustering): override node id while it contains an invalid uuid

### DIFF
--- a/kong/pdk/private/node.lua
+++ b/kong/pdk/private/node.lua
@@ -30,6 +30,7 @@ local function initialize_node_id(prefix)
     if err then
       return nil, fmt("failed to access file %s: %s", filename, err)
     end
+
     if not utils.is_valid_uuid(id) then
       log.debug("file %s contains invalid uuid: %s", filename, id)
       -- set false to override it when it contains an invalid uuid.

--- a/kong/pdk/private/node.lua
+++ b/kong/pdk/private/node.lua
@@ -1,9 +1,9 @@
+local log = require "kong.cmd.utils.log"
 local utils = require "kong.tools.utils"
 local pl_file = require "pl.file"
 local pl_path = require "pl.path"
 local pl_dir = require "pl.dir"
 
-local ngx = ngx
 local fmt = string.format
 
 local cached_node_id
@@ -23,9 +23,23 @@ local function initialize_node_id(prefix)
 
   local filename = node_id_filename(prefix)
 
-  if not pl_path.exists(filename) then
+  local file_exists = pl_path.exists(filename)
+
+  if file_exists then
+    local id, err = pl_file.read(filename)
+    if err then
+      return nil, fmt("failed to access file %s: %s", filename, err)
+    end
+    if not utils.is_valid_uuid(id) then
+      log.debug("file %s contains invalid uuid: %s", filename, id)
+      -- set false to override it when it contains an invalid uuid.
+      file_exists = false
+    end
+  end
+
+  if not file_exists then
     local id = utils.uuid()
-    ngx.log(ngx.DEBUG, "persisting node_id (", id, ") to ", filename)
+    log.debug("persisting node_id (%s) to %s", id, filename)
 
     local ok, write_err = pl_file.write(filename, id)
     if not ok then
@@ -49,7 +63,7 @@ local function init_node_id(config)
 
   local ok, err = initialize_node_id(config.prefix)
   if not ok then
-    ngx.log(ngx.WARN, err)
+    log.warn(err)
   end
 end
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

- Uses `kong.cmd.utils.log` instead of `ngx.log` as the latter is unavailable in cmd context.
- Fixes the existing node id file with an invalid uuid won't be rewritten after Kong start.
- Enables the `pending` test

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG (This is a fix for the original PR)
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE (This is a fix and does not require user-facing docs update)

