### PR TITLE
fix(api): various minor fixes and optimizations for dynamic log levels

### DIFF
--- a/kong/api/routes/debug.lua
+++ b/kong/api/routes/debug.lua
@@ -26,7 +26,7 @@ local function handle_put_log_level(self, broadcast)
 
   local sys_filter_level = get_sys_filter_level()
 
-  if sys_filter_level and sys_filter_level == log_level then
+  if sys_filter_level == log_level then
     local message = "log level is already " .. self.params.log_level
     return kong.response.exit(200, { message = message })
   end
@@ -34,7 +34,7 @@ local function handle_put_log_level(self, broadcast)
   local ok, err = pcall(set_log_level, log_level)
 
   if not ok then
-    local message = "failed setting log level: " .. tostring(err)
+    local message = "failed setting log level: " .. err
     return kong.response.exit(500, { message = message })
   end
 
@@ -57,10 +57,10 @@ local function handle_put_log_level(self, broadcast)
   end
 
   -- store in shm so that newly spawned workers can update their log levels
-  ok, err = ngx.shared.kong_log_level:set("level", log_level)
+  ok, err = ngx.shared.kong:set("kong:log_level", log_level)
 
   if not ok then
-    local message = "failed storing log level in shm: " .. tostring(err)
+    local message = "failed storing log level in shm: " .. err
     return kong.response.exit(500, { message = message })
   end
 

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -183,6 +183,7 @@ local reset_kong_shm
 do
   local preserve_keys = {
     "kong:node_id",
+    "kong:log_level",
     "events:requests",
     "events:requests:http",
     "events:requests:https",

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -25,7 +25,6 @@ lua_shared_dict kong_core_db_cache          ${{MEM_CACHE_SIZE}};
 lua_shared_dict kong_core_db_cache_miss     12m;
 lua_shared_dict kong_db_cache               ${{MEM_CACHE_SIZE}};
 lua_shared_dict kong_db_cache_miss          12m;
-lua_shared_dict kong_log_level              1m;
 > if role == "data_plane" then
 lua_shared_dict wrpc_channel_dict           5m;
 > end

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -48,7 +48,6 @@ http {
     lua_shared_dict kong_core_db_cache_miss     12m;
     lua_shared_dict kong_db_cache               ${{MEM_CACHE_SIZE}};
     lua_shared_dict kong_db_cache_miss          12m;
-    lua_shared_dict kong_log_level              1m;
 > if database == "cassandra" then
     lua_shared_dict kong_cassandra              5m;
 > end


### PR DESCRIPTION
Use `kong` shm instead of its own dedicated `kong_log_level`.