### PR TITLE
fix(router): emit error for route flavor misconfig

### DIFF
--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -28,6 +28,7 @@ local bor, band, lshift = bit.bor, bit.band, bit.lshift
 local ngx       = ngx
 local ngx_log   = ngx.log
 local ngx_WARN  = ngx.WARN
+local ngx_ERR  = ngx.ERR
 
 
 local DOT              = byte(".")
@@ -282,6 +283,11 @@ end
 
 
 local function get_exp_and_priority(route)
+  if route.expression then
+    ngx_log(ngx_ERR, "expecting a traditional route while expression is given.",
+                 "Likely it's a misconfiguration, please check router_flavor.")
+  end
+
   local exp      = get_expression(route)
   local priority = get_priority(route)
 

--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -285,7 +285,7 @@ end
 local function get_exp_and_priority(route)
   if route.expression then
     ngx_log(ngx_ERR, "expecting a traditional route while expression is given. ",
-                 "Likely it's a misconfiguration, please check router_flavor")
+                 "Likely it's a misconfiguration. Please check router_flavor")
   end
 
   local exp      = get_expression(route)

--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -284,8 +284,8 @@ end
 
 local function get_exp_and_priority(route)
   if route.expression then
-    ngx_log(ngx_ERR, "expecting a traditional route while expression is given.",
-                 "Likely it's a misconfiguration, please check router_flavor.")
+    ngx_log(ngx_ERR, "expecting a traditional route while expression is given. ",
+                 "Likely it's a misconfiguration, please check router_flavor")
   end
 
   local exp      = get_expression(route)

--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -28,7 +28,7 @@ local bor, band, lshift = bit.bor, bit.band, bit.lshift
 local ngx       = ngx
 local ngx_log   = ngx.log
 local ngx_WARN  = ngx.WARN
-local ngx_ERR  = ngx.ERR
+local ngx_ERR   = ngx.ERR
 
 
 local DOT              = byte(".")

--- a/kong/router/expressions.lua
+++ b/kong/router/expressions.lua
@@ -14,8 +14,8 @@ local ngx_ERR = ngx.ERR
 local function get_exp_and_priority(route)
   local exp = route.expression
   if not exp then
-    ngx_log(ngx_ERR, "expecting an expression route while it's not (probably a traditional route).",
-                 "Likely it's a misconfiguration, please check router_flavor.")
+    ngx_log(ngx_ERR, "expecting an expression route while it's not (probably a traditional route). ",
+                 "Likely it's a misconfiguration, please check router_flavor")
     return
   end
 

--- a/kong/router/expressions.lua
+++ b/kong/router/expressions.lua
@@ -15,7 +15,7 @@ local function get_exp_and_priority(route)
   local exp = route.expression
   if not exp then
     ngx_log(ngx_ERR, "expecting an expression route while it's not (probably a traditional route). ",
-                 "Likely it's a misconfiguration, please check router_flavor")
+                 "Likely it's a misconfiguration. Please check router_flavor")
     return
   end
 

--- a/kong/router/expressions.lua
+++ b/kong/router/expressions.lua
@@ -7,11 +7,15 @@ local gen_for_field = atc.gen_for_field
 
 local OP_EQUAL    = "=="
 local LOGICAL_AND = atc.LOGICAL_AND
+local ngx_log = ngx.log
+local ngx_ERR = ngx.ERR
 
 
 local function get_exp_and_priority(route)
   local exp = route.expression
   if not exp then
+    ngx_log(ngx_ERR, "expecting an expression route while it's not (probably a traditional route).",
+                 "Likely it's a misconfiguration, please check router_flavor.")
     return
   end
 

--- a/kong/router/traditional.lua
+++ b/kong/router/traditional.lua
@@ -1342,8 +1342,8 @@ function _M.new(routes, cache, cache_neg)
       local route = routes[i]
       local r = routes[i].route
       if r.expression then
-        ngx_log(ngx_ERR, "expecting a traditional route while expression is given.",
-                    "Likely it's a misconfiguration, please check router_flavor.")
+        ngx_log(ngx_ERR, "expecting a traditional route while expression is given. ",
+                    "Likely it's a misconfiguration, please check router_flavor")
       end
 
       if r.id ~= nil then

--- a/kong/router/traditional.lua
+++ b/kong/router/traditional.lua
@@ -16,6 +16,7 @@ local re_find       = ngx.re.find
 local header        = ngx.header
 local var           = ngx.var
 local ngx_log       = ngx.log
+local ngx_ERR       = ngx.ERR
 local worker_id     = ngx.worker.id
 local concat        = table.concat
 local sort          = table.sort
@@ -1340,6 +1341,11 @@ function _M.new(routes, cache, cache_neg)
 
       local route = routes[i]
       local r = routes[i].route
+      if r.expression then
+        ngx_log(ngx_ERR, "expecting a traditional route while expression is given.",
+                    "Likely it's a misconfiguration, please check router_flavor.")
+      end
+
       if r.id ~= nil then
         routes_by_id[r.id] = route
       end

--- a/kong/router/traditional.lua
+++ b/kong/router/traditional.lua
@@ -1343,7 +1343,7 @@ function _M.new(routes, cache, cache_neg)
       local r = routes[i].route
       if r.expression then
         ngx_log(ngx_ERR, "expecting a traditional route while expression is given. ",
-                    "Likely it's a misconfiguration, please check router_flavor")
+                    "Likely it's a misconfiguration. Please check router_flavor")
       end
 
       if r.id ~= nil then


### PR DESCRIPTION
It will print error logs when users configured the gateway with atc routers and change the flavor to traditional(\_compatible) or verse visa.

Fix FT-3253
