### PR TITLE
fix(key-auth) expire keys in L1/L2 caches when ttl is in [0, 1)

### DIFF
--- a/kong/cache/init.lua
+++ b/kong/cache/init.lua
@@ -155,12 +155,12 @@ function _M:get(key, opts, cb, ...)
     error("key must be a string", 2)
   end
 
-  local v, err = self.mlcache:get(key, opts, cb, ...)
+  local v, err, hit_lvl = self.mlcache:get(key, opts, cb, ...)
   if err then
     return nil, "failed to get from node cache: " .. err
   end
 
-  return v
+  return v, nil, hit_lvl
 end
 
 

--- a/kong/db/strategies/postgres/init.lua
+++ b/kong/db/strategies/postgres/init.lua
@@ -1032,9 +1032,9 @@ function _M.new(connector, schema, errors)
 
     select_expressions = concat {
       select_expressions, ",",
-      "FLOOR(EXTRACT(EPOCH FROM (",
+      "EXTRACT(EPOCH FROM (",
         ttl_escaped, " AT TIME ZONE 'UTC' - CURRENT_TIMESTAMP AT TIME ZONE 'UTC'",
-      "))) AS ", ttl_escaped
+      ")) AS ", ttl_escaped
     }
 
     ttl_select_where = concat {

--- a/kong/pdk/cluster.lua
+++ b/kong/pdk/cluster.lua
@@ -46,9 +46,13 @@ local function new(self)
   --
   -- -- use id here
   function _CLUSTER.get_id()
-    return kong.core_cache:get(CLUSTER_ID_PARAM_KEY, nil, fetch_cluster_id)
-  end
+    local cluster_id, err = kong.core_cache:get(CLUSTER_ID_PARAM_KEY, nil, fetch_cluster_id)
+    if err then
+      return nil, err
+    end
 
+    return cluster_id
+  end
 
   return _CLUSTER
 end

--- a/spec/03-plugins/09-key-auth/02-access_spec.lua
+++ b/spec/03-plugins/09-key-auth/02-access_spec.lua
@@ -967,7 +967,7 @@ for _, strategy in helpers.each_strategy() do
         helpers.stop_kong()
       end)
 
-      it("authenticate for up to 'ttl' #test", function()
+      it("authenticate for up to 'ttl'", function()
         proxy_client = helpers.proxy_client()
         local res = assert(proxy_client:send {
           method  = "GET",

--- a/spec/03-plugins/09-key-auth/02-access_spec.lua
+++ b/spec/03-plugins/09-key-auth/02-access_spec.lua
@@ -919,6 +919,7 @@ for _, strategy in helpers.each_strategy() do
       -- Give a bit of time to reduce test flakyness on slow setups
       local ttl = 10
       local inserted_at
+      local proxy_client
 
       lazy_setup(function()
         helpers.stop_kong()
@@ -956,8 +957,6 @@ for _, strategy in helpers.each_strategy() do
           database   = strategy,
           nginx_conf = "spec/fixtures/custom_nginx.template",
         }))
-
-        proxy_client = helpers.proxy_client()
       end)
 
       lazy_teardown(function()
@@ -968,7 +967,8 @@ for _, strategy in helpers.each_strategy() do
         helpers.stop_kong()
       end)
 
-      it("authenticate for up to 'ttl'", function()
+      it("authenticate for up to 'ttl' #test", function()
+        proxy_client = helpers.proxy_client()
         local res = assert(proxy_client:send {
           method  = "GET",
           path    = "/status/200",
@@ -978,20 +978,25 @@ for _, strategy in helpers.each_strategy() do
           }
         })
         assert.res_status(200, res)
+        proxy_client:close()
 
         ngx.update_time()
         local elapsed = ngx.now() - inserted_at
-        ngx.sleep(ttl - elapsed + 1) -- 1: jitter
 
-        res = assert(proxy_client:send {
-          method  = "GET",
-          path    = "/status/200",
-          headers = {
-            ["Host"] = "key-ttl.com",
-            ["apikey"] = "kong",
-          }
-        })
-        assert.res_status(401, res)
+        helpers.wait_until(function()
+          proxy_client = helpers.proxy_client()
+          res = assert(proxy_client:send {
+            method  = "GET",
+            path    = "/status/200",
+            headers = {
+              ["Host"] = "key-ttl.com",
+              ["apikey"] = "kong",
+            }
+          })
+
+          proxy_client:close()
+          return res and res.status == 401
+        end, ttl - elapsed + 1)
       end)
     end)
   end)


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

The postgres DAO return 0 when key ttl falls between `[0, 1)`, which would make the key never expires in L1/L2 cache.

This fix will check if the returned ttl is 0. If it is, then make it `nil`.

<https://konghq.atlassian.net/browse/FTI-4066>

### Checklist

- [ y ] The Pull Request has tests

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix [FTI-4066](https://konghq.atlassian.net/browse/FTI-4066)
