### PR TITLE
feat(schema) add entity info to errors

### DIFF
--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -237,6 +237,12 @@ local constants = {
     [ngx.ALERT] = "alert",
     [ngx.EMERG] = "emerg",
   },
+
+  ENTITY_ERROR_METADATA_FIELDS = {
+    "id",
+    "name",
+    "tags",
+  },
 }
 
 for _, v in ipairs(constants.CLUSTERING_SYNC_STATUS) do

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -5,6 +5,7 @@ local cjson        = require "cjson"
 local new_tab      = require "table.new"
 local nkeys        = require "table.nkeys"
 local is_reference = require "kong.pdk.vault".new().is_reference
+local constants    = require "kong.constants"
 
 
 local setmetatable = setmetatable
@@ -1987,6 +1988,17 @@ function Schema:validate(input, full_check, original_input, rbw_entity)
   run_transformation_checks(self, input, original_input, rbw_entity, errors)
 
   if next(errors) then
+    local meta = {}
+    local has_meta = false
+    for _, field in ipairs(constants.ENTITY_ERROR_METADATA_FIELDS) do
+      if type(input[field]) ~= "userdata" and input[field] ~= nil then
+        meta[field] = input[field]
+        has_meta = true
+      end
+    end
+    if has_meta then
+      errors["entity_metadata"] = meta
+    end
     return nil, errors
   end
   return true


### PR DESCRIPTION
### Summary

Adds a designated list of entity fields to error responses when those fields are present. This seeks to make DB-less error responses more clearly indicate which entities are responsible for a rejected configuration.

In particular, the inclusion of tags will allow the ingress controller to add information about the source Kubernetes resource and receive it back in error reports for any entity.

Name and ID are included also as good human-friendly fields for non-controller updates.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* Add a constant table of fields to include with errors.
* Include an `entity_metadata` field in `Schema:validate()` errors. If fields from the constant are present, `entity_metadata` is populated and included. If no fields are present, `entity_metadata` is omitted. 

### Issue reference

FTI-4366
