### PR TITLE
feat(cmd): stand-alone script to check kong health

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ OS := $(shell uname | awk '{print tolower($$0)}')
 MACHINE := $(shell uname -m)
 
 DEV_ROCKS = "busted 2.1.1" "busted-htest 1.0.0" "luacheck 1.0.0" "lua-llthreads2 0.1.6" "http 0.4" "ldoc 1.4.6"
-WIN_SCRIPTS = "bin/busted" "bin/kong"
+WIN_SCRIPTS = "bin/busted" "bin/kong" "bin/kong-health"
 BUSTED_ARGS ?= -v
 TEST_CMD ?= bin/busted $(BUSTED_ARGS)
 

--- a/bin/kong-health
+++ b/bin/kong-health
@@ -1,0 +1,77 @@
+#!/usr/bin/env resty
+
+setmetatable(_G, nil)
+package.path = (os.getenv("KONG_LUA_PATH_OVERRIDE") or "") .. "./?.lua;./?/init.lua;" .. package.path
+
+local kill = require "kong.cmd.utils.kill"
+local kong_default_conf = require "kong.templates.kong_defaults"
+local pl_app = require "pl.lapp"
+local pl_config = require "pl.config"
+local pl_path = require "pl.path"
+local pl_stringio = require "pl.stringio"
+
+local KONG_DEFAULT_PREFIX = "/usr/local/kong"
+
+
+local function get_kong_prefix()
+  local prefix = os.getenv("KONG_PREFIX")
+
+  if not prefix then
+    local s = pl_stringio.open(kong_default_conf)
+    local defaults = pl_config.read(s, {
+      smart = false,
+      list_delim = "_blank_" -- mandatory but we want to ignore it
+    })
+    s:close()
+    if defaults then
+      prefix = defaults.prefix
+    end
+
+  end
+
+  return prefix or KONG_DEFAULT_PREFIX
+end
+
+
+local function execute(args)
+  local prefix = args.prefix or get_kong_prefix(args)
+  assert(pl_path.exists(prefix), "no such prefix: " .. prefix)
+
+  local kong_env = pl_path.join(prefix, ".kong_env")
+  assert(pl_path.exists(kong_env), "Kong is not running at " .. prefix)
+
+  print("")
+  local pid_file = pl_path.join(prefix, unpack({"pids", "nginx.pid"}))
+  local x = kill.is_running(pid_file)
+  assert(kill.is_running(pid_file), "Kong is not running at " .. prefix)
+  print("Kong is healthy at ", prefix)
+end
+
+
+local lapp = [[
+Usage: kong health [OPTIONS]
+Check if the necessary services are running for this node.
+Options:
+ -p,--prefix      (optional string) prefix at which Kong should be running
+ --v              verbose
+ --vv             debug
+]]
+
+local function run(args)
+  args = pl_app(lapp)
+  xpcall(function() execute(args) end, function(err)
+    if not (args.v or args.vv) then
+      err = err:match "^.-:.-:.(.*)$"
+      io.stderr:write("Error: " .. err .. "\n")
+      io.stderr:write("\n  Run with --v (verbose) or --vv (debug) for more details\n")
+    else
+      local trace = debug.traceback(err, 2)
+      io.stderr:write("Error: \n")
+      io.stderr:write(trace .. "\n")
+    end
+    pl_app.quit(nil, true)
+  end)
+end
+
+
+run(arg)

--- a/bin/kong-health
+++ b/bin/kong-health
@@ -41,8 +41,8 @@ local function execute(args)
   assert(pl_path.exists(kong_env), "Kong is not running at " .. prefix)
 
   print("")
-  local pid_file = pl_path.join(prefix, unpack({"pids", "nginx.pid"}))
-  local x = kill.is_running(pid_file)
+  local pid_file = pl_path.join(prefix, "pids", "nginx.pid")
+  kill.is_running(pid_file)
   assert(kill.is_running(pid_file), "Kong is not running at " .. prefix)
   print("Kong is healthy at ", prefix)
 end

--- a/spec/02-integration/02-cmd/07-health_spec.lua
+++ b/spec/02-integration/02-cmd/07-health_spec.lua
@@ -1,38 +1,52 @@
 local helpers = require "spec.helpers"
 
-describe("kong health", function()
-  lazy_setup(function()
-    helpers.prepare_prefix()
-  end)
-  lazy_teardown(function()
-    helpers.clean_prefix()
-  end)
-  after_each(function()
-    helpers.kill_all()
-  end)
+local function run_health(script, params)
+  local cmd = script .. " " .. params
+  if script == "health" then
+    return helpers.kong_exec(cmd)
+  end
+  return helpers.execute(cmd)
+end
 
-  it("health help", function()
-    local _, stderr = helpers.kong_exec "health --help"
-    assert.not_equal("", stderr)
-  end)
-  it("succeeds when Kong is running with custom --prefix", function()
-    assert(helpers.kong_exec("start --conf " .. helpers.test_conf_path))
 
-    local _, _, stdout = assert(helpers.kong_exec("health --prefix " .. helpers.test_conf.prefix))
-    assert.matches("nginx%.-running", stdout)
-    assert.matches("Kong is healthy at " .. helpers.test_conf.prefix, stdout, nil, true)
-  end)
-  it("fails when Kong is not running", function()
-    local ok, stderr = helpers.kong_exec("health --prefix " .. helpers.test_conf.prefix)
-    assert.False(ok)
-    assert.matches("Kong is not running at " .. helpers.test_conf.prefix, stderr, nil, true)
-  end)
+for _, health_cmd in ipairs({"health", "bin/kong-health"}) do
+  describe("kong health-check: " .. health_cmd, function()
+    lazy_setup(function()
+      helpers.prepare_prefix()
+    end)
+    lazy_teardown(function()
+      helpers.clean_prefix()
+    end)
+    after_each(function()
+      helpers.kill_all()
+    end)
 
-  describe("errors", function()
-    it("errors on inexisting prefix", function()
-      local ok, stderr = helpers.kong_exec("health --prefix inexistant")
+    it("health help", function()
+      local _, stderr = run_health(health_cmd, "--help")
+      assert.not_equal("", stderr)
+    end)
+    it("succeeds when Kong is running with custom --prefix", function()
+      assert(helpers.kong_exec("start --conf " .. helpers.test_conf_path))
+
+      local _, _, stdout = assert(run_health(health_cmd,  "--prefix " .. helpers.test_conf.prefix))
+
+      if health_cmd == "health" then
+        assert.matches("nginx%.-running", stdout)
+      end
+      assert.matches("Kong is healthy at " .. helpers.test_conf.prefix, stdout, nil, true)
+    end)
+    it("fails when Kong is not running", function()
+      local ok, stderr = run_health(health_cmd, "--prefix " .. helpers.test_conf.prefix)
       assert.False(ok)
-      assert.matches("no such prefix: ", stderr, nil, true)
+      assert.matches("Kong is not running at " .. helpers.test_conf.prefix, stderr, nil, true)
+    end)
+
+    describe("errors", function()
+      it("errors on inexisting prefix", function()
+        local ok, stderr = run_health(health_cmd, "--prefix inexistant")
+        assert.False(ok)
+        assert.matches("no such prefix: ", stderr, nil, true)
+      end)
     end)
   end)
-end)
+end


### PR DESCRIPTION
### Summary

This resty script checks if the Nginx master process needed by Kong is running. It provides the same functionality as `kong health`, but does not start a second Nginx for that. 

### Full changelog

* New resty script.
* Adapted current `kong health` tests.
* To do: obsolete `kong health`.

FTI-4452