### PR TITLE
docs(README): fix markdown order list manner

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Whether you’re running in the cloud, on bare metal, or using containers, you c
   $ cd docker-kong/compose/
 ```
 
-1) Start the Gateway stack using:
+2) Start the Gateway stack using:
 ```cmd
   $ KONG_DATABASE=postgres docker-compose --profile database up
 ```


### PR DESCRIPTION
Fixed the typo on the numbered bullet.

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

The second bullet point of the getting-started section is not correctly numbered.

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
