### PR TITLE
fix(ci): make sure docker tag is valid

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -88,12 +88,12 @@ jobs:
       run: |
         grep -v '^#' ${{ env.KONG_SOURCE_LOCATION}}/.requirements >> $GITHUB_ENV
         echo "DOCKER_RELEASE_REPOSITORY=kong/kong" >> $GITHUB_ENV
-        echo "KONG_TEST_CONTAINER_TAG=$GITHUB_REF_NAME-${{ matrix.package_type }}" >> $GITHUB_ENV
+        echo "KONG_TEST_CONTAINER_TAG=${GITHUB_REF_NAME##*/}-${{ matrix.package_type }}" >> $GITHUB_ENV
         if [[ ${{matrix.package_type }} == "apk" ]]; then
-          echo "ADDITIONAL_TAG_LIST=$GITHUB_REF_NAME-alpine" >> $GITHUB_ENV
+          echo "ADDITIONAL_TAG_LIST=${GITHUB_REF_NAME##*/}-alpine" >> $GITHUB_ENV
         fi
         if [[ ${{matrix.package_type }} == "deb" ]]; then
-          echo "ADDITIONAL_TAG_LIST=$GITHUB_REF_NAME-debian $GITHUB_REF_NAME $GITHUB_SHA" >> $GITHUB_ENV
+          echo "ADDITIONAL_TAG_LIST=${GITHUB_REF_NAME##*/}-debian ${GITHUB_REF_NAME##*/} $GITHUB_SHA" >> $GITHUB_ENV
         fi
 
     - name: Package & Test

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -104,6 +104,7 @@ jobs:
           make package/test/${{ matrix.package_type }}
 
     - name: Push Docker Image
+      continue-on-error: true
       env:
         SKIP_TESTS: true
       run: |
@@ -111,6 +112,7 @@ jobs:
           make release/docker/${{ matrix.package_type }}
 
     - name: Store the package artifacts
+      continue-on-error: true
       uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.package_type }}


### PR DESCRIPTION
required for the release branches so
```
GITHUB_REF=release/3.0.x
```
becomes the docker tag
```
3.0.x
```
and not
```
release/3.0.x
```

Additionally if we successfully package, and test the package don't mark the build a failed because of a storage problem (for now)

Tested on my fork to verify the result:
![image](https://user-images.githubusercontent.com/697188/203868078-3ef5f8fe-139f-4d09-9204-011786971d49.png)
