### PR TITLE
feat (conf) set non root user to run in devcontainer docker containers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,3 +10,6 @@ RUN apt-get install -y \
         git \
         m4 \
         libyaml-dev
+RUN addgroup -S kong && adduser -S kong -G kong
+RUN chown -R kong:kong /home/kong/
+USER kong


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary
This sets a non root user in the devcontainer dockerfile to replace operations as root user

<!--- Why is this change required? What problem does it solve? -->
To ensure non root user is set as root user has high privileges 
### Full changelog
* add non user in devcontainer dockerfile

 ...

### Issue reference #8748 

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #8748 

Continuation of PR #8817 
