### PR TITLE
fix(pdk/vault): do not call sema:wait in init phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,6 +208,8 @@
   and body parameter type of `kong.response.exit` to bytes. Note that old
   version of go PDK is incompatible after this change.
   [#9526](https://github.com/Kong/kong/pull/9526)
+- Vault will not call `semaphore:wait` in `init` or `init_worker` phase.
+  [#9851](https://github.com/Kong/kong/pull/9851)
 
 #### Plugins
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Fix issue #9839

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG


### Full changelog

* check nginx phase
* if it is `init` or `init_worker`, set `wait_ok` to `false`

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[9839]_
