### PR TITLE
revert(clustering): use privileged worker for control plane connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,8 +135,6 @@
 
 #### Performance
 
-- Data plane's connection to control plane is moved to a privileged worker process
-  [#9432](https://github.com/Kong/kong/pull/9432)
 - Increase the default value of `lua_regex_cache_max_entries`, a warning will be thrown
   when there are too many regex routes and `router_flavor` is `traditional`.
   [#9624](https://github.com/Kong/kong/pull/9624)

--- a/kong/clustering/utils.lua
+++ b/kong/clustering/utils.lua
@@ -10,8 +10,8 @@ local parse_url = require("socket.url").parse
 local type = type
 local table_insert = table.insert
 local table_concat = table.concat
-local process_type = require("ngx.process").type
 local encode_base64 = ngx.encode_base64
+local worker_id = ngx.worker.id
 local fmt = string.format
 
 local kong = kong
@@ -292,7 +292,7 @@ end
 
 
 function _M.is_dp_worker_process()
-  return process_type() == "privileged agent"
+  return worker_id() == 0
 end
 
 

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -86,7 +86,6 @@ local migrations_utils = require "kong.cmd.utils.migrations"
 local plugin_servers = require "kong.runloop.plugin_servers"
 local lmdb_txn = require "resty.lmdb.transaction"
 local instrumentation = require "kong.tracing.instrumentation"
-local process = require "ngx.process"
 local tablepool = require "tablepool"
 local get_ctx_table = require("resty.core.ctx").get_ctx_table
 
@@ -633,13 +632,6 @@ function Kong.init()
   db:close()
 
   require("resty.kong.var").patch_metatable()
-
-  if config.role == "data_plane" then
-    local ok, err = process.enable_privileged_agent(2048)
-    if not ok then
-      error(err)
-    end
-  end
 end
 
 
@@ -714,13 +706,6 @@ function Kong.init_worker()
   kong.core_cache = core_cache
 
   kong.db:set_events_handler(worker_events)
-
-  if process.type() == "privileged agent" then
-    if kong.clustering then
-      kong.clustering:init_worker()
-    end
-    return
-  end
 
   if kong.configuration.database == "off" then
     -- databases in LMDB need to be explicitly created, otherwise `get`
@@ -813,7 +798,7 @@ end
 
 
 function Kong.exit_worker()
-  if process.type() ~= "privileged agent" and kong.configuration.role ~= "control_plane" then
+  if kong.configuration.role ~= "control_plane" then
     plugin_servers.stop()
   end
 end


### PR DESCRIPTION
### Summary

Because of increased memory usage, despite the benefits with large configurations on hybrid mode data plane latency, we decided to remove the use of privileged worker for data plane to control plane connection.

This commit removes the use of privileged worker.