### PR TITLE
chore(zipkin): add log namespace in timers

### DIFF
--- a/kong/plugins/zipkin/handler.lua
+++ b/kong/plugins/zipkin/handler.lua
@@ -47,7 +47,8 @@ local function get_reporter(conf)
                                                conf.local_service_name,
                                                conf.connect_timeout,
                                                conf.send_timeout,
-                                               conf.read_timeout)
+                                               conf.read_timeout,
+                                               kong.log)
   end
   return reporter_cache[conf]
 end
@@ -96,7 +97,7 @@ local function timer_log(premature, reporter)
 
   local ok, err = reporter:flush()
   if not ok then
-    kong.log.err("reporter flush ", err)
+    reporter.logger.err("reporter flush ", err)
     return
   end
 end

--- a/kong/plugins/zipkin/reporter.lua
+++ b/kong/plugins/zipkin/reporter.lua
@@ -21,7 +21,7 @@ local function ip_kind(addr)
 end
 
 
-local function new(http_endpoint, default_service_name, local_service_name, connect_timeout, send_timeout, read_timeout)
+local function new(http_endpoint, default_service_name, local_service_name, connect_timeout, send_timeout, read_timeout, logger)
   return setmetatable({
     default_service_name = default_service_name,
     local_service_name = local_service_name,
@@ -31,6 +31,7 @@ local function new(http_endpoint, default_service_name, local_service_name, conn
     read_timeout = read_timeout,
     pending_spans = {},
     pending_spans_n = 0,
+    logger = logger,
   }, zipkin_reporter_mt)
 end
 

--- a/spec/03-plugins/34-zipkin/zipkin_spec.lua
+++ b/spec/03-plugins/34-zipkin/zipkin_spec.lua
@@ -386,7 +386,7 @@ for _, strategy in helpers.each_strategy() do
       -- wait for zero-delay timer
       helpers.wait_timer("zipkin", true, "any-finish")
 
-      assert.logfile().has.line("reporter flush failed to request: timeout", false, 2)
+      assert.logfile().has.line("[zipkin] reporter flush failed to request: timeout", true, 2)
     end)
 
     it("times out if upstream zipkin server takes too long to respond", function()
@@ -402,7 +402,7 @@ for _, strategy in helpers.each_strategy() do
       -- wait for zero-delay timer
       helpers.wait_timer("zipkin", true, "any-finish")
 
-      assert.logfile().has.line("reporter flush failed to request: timeout", false, 2)
+      assert.logfile().has.line("[zipkin] reporter flush failed to request: timeout", true, 2)
     end)
 
     it("connection refused if upstream zipkin server is not listening", function()
@@ -418,7 +418,7 @@ for _, strategy in helpers.each_strategy() do
       -- wait for zero-delay timer
       helpers.wait_timer("zipkin", true, "any-finish")
 
-      assert.logfile().has.line("reporter flush failed to request: connection refused", false, 2)
+      assert.logfile().has.line("[zipkin] reporter flush failed to request: connection refused", true, 2)
     end)
   end)
 end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

The Zipkin plugin error log prefix was lost in the timers.

### Checklist

- [x] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Reimplement #8770
