### PR TITLE
fix(zipkin): global plugin always executes in rewrite phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+- [3.1.0](#310)
 - [3.0.0](#300)
 - [2.8.1](#281)
 - [2.8.0](#280)
@@ -66,6 +67,16 @@
 
 
 ## Unreleased
+
+### Fixes
+
+#### Plugins
+
+- **Zipkin**: Fix an issue where the global plugin's sample ratio overrides route-specific.
+  [#9877](https://github.com/Kong/kong/pull/9877)
+
+
+## 3.1.0 (Unreleased)
 
 ### Breaking Changes
 

--- a/kong/plugins/zipkin/handler.lua
+++ b/kong/plugins/zipkin/handler.lua
@@ -193,17 +193,6 @@ if subsystem == "http" then
   end
 
 
-  function ZipkinLogHandler:rewrite(conf) -- luacheck: ignore 212
-    local zipkin = get_context(conf, kong.ctx.plugin)
-    local ngx_ctx = ngx.ctx
-    -- note: rewrite is logged on the request_span, not on the proxy span
-    local rewrite_start_mu =
-      ngx_ctx.KONG_REWRITE_START and ngx_ctx.KONG_REWRITE_START * 1000
-      or ngx_now_mu()
-    zipkin.request_span:annotate("krs", rewrite_start_mu)
-  end
-
-
   function ZipkinLogHandler:access(conf) -- luacheck: ignore 212
     local zipkin = get_context(conf, kong.ctx.plugin)
     local ngx_ctx = ngx.ctx
@@ -303,10 +292,16 @@ function ZipkinLogHandler:log(conf) -- luacheck: ignore 212
   if ngx_ctx.KONG_REWRITE_START and ngx_ctx.KONG_REWRITE_TIME then
     -- note: rewrite is logged on the request span, not on the proxy span
     local rewrite_finish_mu = (ngx_ctx.KONG_REWRITE_START + ngx_ctx.KONG_REWRITE_TIME) * 1000
-    zipkin.request_span:annotate("krf", rewrite_finish_mu)
+    request_span:annotate("krf", rewrite_finish_mu)
   end
 
   if subsystem == "http" then
+    -- note: rewrite is logged on the request_span, not on the proxy span
+    local rewrite_start_mu =
+      ngx_ctx.KONG_REWRITE_START and ngx_ctx.KONG_REWRITE_START * 1000
+      or request_span.timestamp
+    request_span:annotate("krs", rewrite_start_mu)
+
     -- annotate access_start here instead of in the access phase
     -- because the plugin access phase is skipped when dealing with
     -- requests which are not matched by any route


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
The global Zipkin plugin always executes in the rewrite phase whenever a route/service-specific plugin enables, since the router only executes after the `rewrite` phase.
This cause an issue where route/service-specific plugin inherits the context written by the global plugin in the `access` phase.

According to [plugin precedence](https://docs.konghq.com/gateway/latest/admin-api/#precedence), a plugin will always be run once and only once per request, and route/service-specific plugins have higher priority than global plugins.

This PR moves the logic inside the `rewrite` phase handler to the `log` phase, and it sets the span annotation lazily with no side-effects.

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #9812
