### PR TITLE
feat(schema) add new config error array

### DIFF
--- a/kong/api/routes/config.lua
+++ b/kong/api/routes/config.lua
@@ -66,9 +66,9 @@ return {
 
       local dc = declarative.new_config(kong.configuration)
 
-      local entities, _, err_t, meta, new_hash, entity_errors
+      local entities, _, err_t, meta, new_hash
       if self.params._format_version then
-        entities, _, err_t, meta, new_hash, entity_errors = dc:parse_table(self.params)
+        entities, _, err_t, meta, new_hash = dc:parse_table(self.params)
       else
         local config = self.params.config
         if not config then

--- a/kong/api/routes/config.lua
+++ b/kong/api/routes/config.lua
@@ -66,9 +66,9 @@ return {
 
       local dc = declarative.new_config(kong.configuration)
 
-      local entities, _, err_t, meta, new_hash
+      local entities, _, err_t, meta, new_hash, entity_errors
       if self.params._format_version then
-        entities, _, err_t, meta, new_hash = dc:parse_table(self.params)
+        entities, _, err_t, meta, new_hash, entity_errors = dc:parse_table(self.params)
       else
         local config = self.params.config
         if not config then
@@ -89,7 +89,7 @@ return {
         if check_hash and err_t and err_t.error == "configuration is identical" then
           return kong.response.exit(304)
         end
-        return kong.response.exit(400, errors:declarative_config(err_t))
+        return kong.response.exit(400, errors:declarative_config(err_t, ngx.ctx.entity_alloc))
       end
 
       local ok, err, ttl = declarative.load_into_cache_with_events(entities, meta, new_hash)

--- a/kong/constants.lua
+++ b/kong/constants.lua
@@ -237,6 +237,12 @@ local constants = {
     [ngx.ALERT] = "alert",
     [ngx.EMERG] = "emerg",
   },
+
+  ENTITY_ERROR_METADATA_FIELDS = {
+    "id",
+    "name",
+    "tags",
+  },
 }
 
 for _, v in ipairs(constants.CLUSTERING_SYNC_STATUS) do

--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -11,6 +11,7 @@ local utils = require "kong.tools.utils"
 local txn = require "resty.lmdb.transaction"
 local lmdb = require "resty.lmdb"
 local on_the_fly_migration = require "kong.db.declarative.migrations.route_path"
+local inspect = require "inspect" -- TRR
 
 local setmetatable = setmetatable
 local tostring = tostring
@@ -241,7 +242,8 @@ function Config:parse_table(dc_table, hash)
     error("expected a table as input", 2)
   end
 
-  local entities, err_t, meta = self.schema:flatten(dc_table)
+  local entities, err_t, meta, entity_errors = self.schema:flatten(dc_table)
+  --ngx.log(ngx.NOTICE, "TRR parse err: ", inspect(ngx.ctx.entity_alloc))
   if err_t then
     return nil, pretty_print_error(err_t), err_t
   end
@@ -258,7 +260,7 @@ function Config:parse_table(dc_table, hash)
     hash = md5(cjson_encode({ entities, meta }))
   end
 
-  return entities, nil, nil, meta, hash
+  return entities, nil, nil, meta, hash, entity_errors
 end
 
 

--- a/kong/db/declarative/init.lua
+++ b/kong/db/declarative/init.lua
@@ -242,8 +242,7 @@ function Config:parse_table(dc_table, hash)
     error("expected a table as input", 2)
   end
 
-  local entities, err_t, meta, entity_errors = self.schema:flatten(dc_table)
-  --ngx.log(ngx.NOTICE, "TRR parse err: ", inspect(ngx.ctx.entity_alloc))
+  local entities, err_t, meta = self.schema:flatten(dc_table)
   if err_t then
     return nil, pretty_print_error(err_t), err_t
   end
@@ -260,7 +259,7 @@ function Config:parse_table(dc_table, hash)
     hash = md5(cjson_encode({ entities, meta }))
   end
 
-  return entities, nil, nil, meta, hash, entity_errors
+  return entities, nil, nil, meta, hash
 end
 
 

--- a/kong/db/errors.lua
+++ b/kong/db/errors.lua
@@ -477,7 +477,7 @@ function _M:operation_unsupported(err)
 end
 
 
-function _M:declarative_config(err_t)
+function _M:declarative_config(err_t, entity_errors)
   if type(err_t) ~= "table" then
     error("err_t must be a table", 2)
   end
@@ -485,6 +485,7 @@ function _M:declarative_config(err_t)
   local message = fmt("declarative config is invalid: %s",
                       pl_pretty(err_t, ""))
 
+  err_t["flattened"] = entity_errors
   return new_err_t(self, ERRORS.DECLARATIVE_CONFIG, message, err_t)
 end
 

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -2002,7 +2002,13 @@ function Schema:validate(input, full_check, original_input, rbw_entity)
     ngx.log(ngx.NOTICE, "TRR rich err: ", inspect(rich_err))
     if self.entity_error_alloc ~= nil and has_rich_err then
     pcall(function ()
-      rich_err["errors"] = errors
+      rich_err["errors"] = {}
+      for field, message in pairs(errors) do
+        table.insert(rich_err["errors"], {
+          ["field"] = field,
+          ["message"] = message,
+        })
+      end
       table.insert(ngx.ctx.entity_alloc, rich_err)
       ngx.log(ngx.NOTICE, "TRR alloc err: ", inspect(ngx.ctx.entity_alloc))
     end)

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -5,6 +5,7 @@ local cjson        = require "cjson"
 local new_tab      = require "table.new"
 local nkeys        = require "table.nkeys"
 local is_reference = require "kong.pdk.vault".new().is_reference
+local constants    = require "kong.constants"
 
 
 local setmetatable = setmetatable
@@ -1987,6 +1988,17 @@ function Schema:validate(input, full_check, original_input, rbw_entity)
   run_transformation_checks(self, input, original_input, rbw_entity, errors)
 
   if next(errors) then
+    local meta = {}
+    local has_meta = false
+    for _, field in ipairs(constants.ENTITY_ERROR_METADATA_FIELDS) do
+      if type(input[field]) ~= "userdata" and input[field] ~= nil then
+        meta[field] = input[field]
+        has_meta = true
+      end
+    end
+    if has_meta then
+      errors["entity_metadata"] = meta
+    end
     return nil, errors
   end
   return true

--- a/kong/db/schema/others/declarative_config.lua
+++ b/kong/db/schema/others/declarative_config.lua
@@ -698,6 +698,9 @@ local function flatten(self, input)
 
     local input_copy = utils.deep_copy(input, false)
     populate_ids_for_validation(input_copy, self.known_entities)
+    pcall(function ()
+      ngx.ctx.entity_alloc = {} -- TRR garbage fix for garbage ctx method: since this runs validate twice, clear it here to avoid duplicates
+    end)
     local ok2, err2 = self.full_schema:validate(input_copy)
     if not ok2 then
       local err3 = utils.deep_merge(err2, extract_null_errors(err))
@@ -723,7 +726,7 @@ local function flatten(self, input)
 
   local by_id, by_key = validate_references(self, processed)
   if not by_id then
-    return nil, by_key, nil, Entity_error_alloc
+    return nil, by_key, nil
   end
 
   yield()
@@ -759,7 +762,7 @@ local function flatten(self, input)
     end
   end
 
-  return entities, nil, meta, Entity_error_alloc
+  return entities, nil, meta
 end
 
 


### PR DESCRIPTION
### Summary

A variant of https://github.com/Kong/kong/pull/9806. Whereas #9806 adds its additional error metadata as a new field inside the existing error objects, this variant adds a new `fields.flattened` section, containing an array of error objects ([example](https://gist.github.com/rainest/d1640ce60a8b3c2d0bb99a8fd77d5f3f)). The new error objects store entity type and field names as values, rather than keys, allowing them to unmarshal into a Go struct.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* Add an error accumulator table to schema validation and return it when `POST /config` encounters errors
* Add a field to track whether errors have been processed and added to the error accumulator already. Strip this field before returning errors.

### Issue reference

FTI-4366