### PR TITLE
chore(deps): bump lua-resty-acme from 0.9.0 to 0.10.1

### DIFF
--- a/kong-3.1.0-0.rockspec
+++ b/kong-3.1.0-0.rockspec
@@ -39,7 +39,7 @@ dependencies = {
   "lua-resty-openssl == 0.8.15",
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6.1",
-  "lua-resty-acme == 0.9.0",
+  "lua-resty-acme == 0.10.1",
   "lua-resty-session == 3.10",
   "lua-resty-timer-ng == 0.2.0",
 }


### PR DESCRIPTION
<a name="0.10.1"></a>
## [0.10.1] - 2022-12-06
### bug fixes
- **zerossl:** concatenate response body as string instead of table ([#98](https://github.com/fffonion/lua-resty-acme/issues/98)) [986b1db](https://github.com/fffonion/lua-resty-acme/commit/986b1dbde6c7cc8261d10d5e8c65942e72eb9a32)


<a name="0.10.0"></a>
## [0.10.0] - 2022-11-18
### features
- **autossl:** expose function to get cert from LRU cache ([#96](https://github.com/fffonion/lua-resty-acme/issues/96)) [6135d0e](https://github.com/fffonion/lua-resty-acme/commit/6135d0e3ccc31f58193af1f49ec6fcdd9f45d6da)
- **autossl:** better cache handling in blocking mode [40f5d2d](https://github.com/fffonion/lua-resty-acme/commit/40f5d2d679a684eab81ccb4fcd1282a4255d8c37)
- **autossl:** fix behavior change in non blocking mode [aa484cc](https://github.com/fffonion/lua-resty-acme/commit/aa484ccc0ecd7ee1db4162c46feb9617776e0907)
- **autossl:** move chains set condition back inside the main loop [b83a535](https://github.com/fffonion/lua-resty-acme/commit/b83a53521d967d9c0f7f2e990ba920734eb27b0f)
- **autossl:** add blocking mode [5a623a5](https://github.com/fffonion/lua-resty-acme/commit/5a623a5d975341aadbf8d09d23cca24156178374)

