### PR TITLE
chore(tests) add yaml lint and ensure actions pinned to SHA

### DIFF
--- a/.github/workflows/actions-lint.yml
+++ b/.github/workflows/actions-lint.yml
@@ -1,0 +1,31 @@
+name: Actions Lint
+
+on:
+  pull_request:
+    paths:
+    - '.github/**.yml'
+
+jobs:
+  build:
+    name: Run Lint
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout Kong source code
+        uses: actions/checkout@v3
+
+      - name: Lint actions YAML file
+        # uses: ibiqlik/action-yamllint@v3
+        uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c
+        with:
+          file_or_dir: '.github'
+          strict: false
+
+      - name: Ensure SHA pinned actions
+        # uses: zgosalvez/github-actions-ensure-sha-pinned-actions@v2
+        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@af2eb3226618e2494e3d9084f515ad6dcf16e229
+        with:
+          allowlist: |
+            actions/
+            bazelbuild/
+            docker/login-action

--- a/.github/workflows/autodocs.yml
+++ b/.github/workflows/autodocs.yml
@@ -123,7 +123,8 @@ jobs:
           git checkout -b "autodocs-${{ steps.kong-branch.outputs.name }}"
 
       - name: Commit autodoc changes
-        uses: stefanzweifel/git-auto-commit-action@v4
+        # uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a
         with:
           repository: "./docs.konghq.com"
           commit_message: "Autodocs update"


### PR DESCRIPTION
### Summary

Based on the triggering event, github may use what's on master to run actions for current PR, this means
in some cases we will only know an action has error after it's merged to master. This PR adds a workflow
to run on every change to actions related yml files, so that we can validate their syntax before merging.

This PR also ensures every not-well-known third party actions are pinned to SHA instead of tag.
[This blogpost](https://michaelheap.com/ensure-github-actions-pinned-sha/) is good reading for the
reason why we enforce this.

### Checklist

- [N/A] The Pull Request has tests
- [N/A] There's an entry in the CHANGELOG
- [N/A] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

- add yaml lint to github actions files and pin actions to SHA

