### PR TITLE
feat(pdk): allow plugin to fetch its id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,7 +98,7 @@
 
 #### PDK
 
-- PDK now support getting plugins' ID with `kong.plugin.get_id`.
+- PDK now supports getting plugins' ID with `kong.plugin.get_id`.
   [#9903](https://github.com/Kong/kong/pull/9903)
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,8 +157,6 @@
 
 ## 3.2.0
 
-### Addition
-
 ### Breaking Changes
 
 #### Plugins

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,11 @@
 - **Proxy-Cache**: add `ignore_uri_case` to configuring cache-key uri to be handled as lowercase
   [#10453](https://github.com/Kong/kong/pull/10453)
 
+#### PDK
+
+- PDK now support getting plugins' ID with `kong.plugin.get_id`.
+  [#9903](https://github.com/Kong/kong/pull/9903)
+
 ### Fixes
 
 #### Core
@@ -151,6 +156,8 @@
   [#10476](https://github.com/Kong/kong/pull/10476)
 
 ## 3.2.0
+
+### Addition
 
 ### Breaking Changes
 

--- a/kong-3.2.1-0.rockspec
+++ b/kong-3.2.1-0.rockspec
@@ -277,6 +277,7 @@ build = {
     ["kong.pdk.cluster"] = "kong/pdk/cluster.lua",
     ["kong.pdk.vault"] = "kong/pdk/vault.lua",
     ["kong.pdk.tracing"] = "kong/pdk/tracing.lua",
+    ["kong.pdk.plugin"] = "kong/pdk/plugin.lua",
 
     ["kong.plugins.basic-auth.migrations"] = "kong/plugins/basic-auth/migrations/init.lua",
     ["kong.plugins.basic-auth.migrations.000_base_basic_auth"] = "kong/plugins/basic-auth/migrations/000_base_basic_auth.lua",

--- a/kong/init.lua
+++ b/kong/init.lua
@@ -244,13 +244,14 @@ do
 end
 
 
-local function setup_plugin_context(ctx, plugin)
+local function setup_plugin_context(ctx, plugin, conf)
   if plugin.handler._go then
     ctx.ran_go_plugin = true
   end
 
   kong_global.set_named_ctx(kong, "plugin", plugin.handler, ctx)
   kong_global.set_namespaced_log(kong, plugin.name, ctx)
+  ctx.plugin_id = conf.__plugin_id
 end
 
 
@@ -309,7 +310,7 @@ local function execute_global_plugins_iterator(plugins_iterator, phase, ctx)
       span = instrumentation.plugin_rewrite(plugin)
     end
 
-    setup_plugin_context(ctx, plugin)
+    setup_plugin_context(ctx, plugin, configuration)
     plugin.handler[phase](plugin.handler, configuration)
     reset_plugin_context(ctx, old_ws)
 
@@ -340,7 +341,7 @@ local function execute_collecting_plugins_iterator(plugins_iterator, phase, ctx)
         span = instrumentation.plugin_access(plugin)
       end
 
-      setup_plugin_context(ctx, plugin)
+      setup_plugin_context(ctx, plugin, configuration)
 
       local co = coroutine.create(plugin.handler[phase])
       local cok, cerr = coroutine.resume(co, plugin.handler, configuration)
@@ -391,7 +392,7 @@ local function execute_collected_plugins_iterator(plugins_iterator, phase, ctx)
       span = instrumentation.plugin_header_filter(plugin)
     end
 
-    setup_plugin_context(ctx, plugin)
+    setup_plugin_context(ctx, plugin, configuration)
     plugin.handler[phase](plugin.handler, configuration)
     reset_plugin_context(ctx, old_ws)
 

--- a/kong/pdk/init.lua
+++ b/kong/pdk/init.lua
@@ -211,6 +211,7 @@ local MAJOR_MODULES = {
       "cluster",
       "vault",
       "tracing",
+      "plugin",
 }
 
 if ngx.config.subsystem == 'http' then

--- a/kong/pdk/plugin.lua
+++ b/kong/pdk/plugin.lua
@@ -1,0 +1,20 @@
+--- Plugin related APIs
+--
+-- @module kong.plugin
+
+
+local _plugin = {}
+
+
+function _plugin.get_id(self)
+  return ngx.ctx.plugin_id
+end
+
+local function new()
+  return _plugin
+end
+
+
+return {
+  new = new,
+}

--- a/kong/plugins/datadog/handler.lua
+++ b/kong/plugins/datadog/handler.lua
@@ -48,12 +48,6 @@ local function compose_tags(service_name, status, consumer_id, tags, conf)
 end
 
 
--- we use plugin instance ID as the queue ID
-local function get_queue_id()
-  return kong.plugin.get_id()
-end
-
-
 local function log(conf, messages)
   local logger, err = statsd_logger:new(conf)
   if err then
@@ -119,7 +113,7 @@ function DatadogHandler:log(conf)
     return
   end
 
-  local queue_id = get_queue_id(conf)
+  local queue_id = kong.plugin.get_id()
   local q = queues[queue_id]
   if not q then
     local batch_max_size = conf.queue_size or 1

--- a/kong/plugins/datadog/handler.lua
+++ b/kong/plugins/datadog/handler.lua
@@ -48,8 +48,9 @@ local function compose_tags(service_name, status, consumer_id, tags, conf)
 end
 
 
-local function get_queue_id(conf)
-  return conf.__key__
+-- we use plugin instance ID as the queue ID
+local function get_queue_id()
+  return kong.plugin.get_id()
 end
 
 

--- a/kong/plugins/opentelemetry/handler.lua
+++ b/kong/plugins/opentelemetry/handler.lua
@@ -37,6 +37,11 @@ local default_headers = {
 local queues = {} -- one queue per unique plugin config
 local headers_cache = setmetatable({}, { __mode = "k" })
 
+-- we use plugin instance ID as the queue ID
+local function get_queue_id()
+  return kong.plugin.get_id()
+end
+
 local function get_cached_headers(conf_headers)
   if not conf_headers then
     return default_headers
@@ -153,7 +158,7 @@ end
 function OpenTelemetryHandler:log(conf)
   ngx_log(ngx_DEBUG, _log_prefix, "total spans in current request: ", ngx.ctx.KONG_SPANS and #ngx.ctx.KONG_SPANS)
 
-  local queue_id = conf.__key__
+  local queue_id = get_queue_id()
   local q = queues[queue_id]
   if not q then
     local process = function(entries)

--- a/kong/plugins/opentelemetry/handler.lua
+++ b/kong/plugins/opentelemetry/handler.lua
@@ -37,10 +37,6 @@ local default_headers = {
 local queues = {} -- one queue per unique plugin config
 local headers_cache = setmetatable({}, { __mode = "k" })
 
--- we use plugin instance ID as the queue ID
-local function get_queue_id()
-  return kong.plugin.get_id()
-end
 
 local function get_cached_headers(conf_headers)
   if not conf_headers then
@@ -158,7 +154,7 @@ end
 function OpenTelemetryHandler:log(conf)
   ngx_log(ngx_DEBUG, _log_prefix, "total spans in current request: ", ngx.ctx.KONG_SPANS and #ngx.ctx.KONG_SPANS)
 
-  local queue_id = get_queue_id()
+  local queue_id = kong.plugin.get_id()
   local q = queues[queue_id]
   if not q then
     local process = function(entries)

--- a/kong/plugins/statsd/log.lua
+++ b/kong/plugins/statsd/log.lua
@@ -27,8 +27,9 @@ local range_cache  = setmetatable({}, { __mode = "k" })
 local _M = {}
 
 
-local function get_queue_id(conf)
-  return conf.__key__
+-- we use plugin instance ID as the queue ID
+local function get_queue_id()
+  return kong.plugin.get_id()
 end
 
 local function get_cache_value(cache, cache_key)

--- a/kong/plugins/statsd/log.lua
+++ b/kong/plugins/statsd/log.lua
@@ -27,11 +27,6 @@ local range_cache  = setmetatable({}, { __mode = "k" })
 local _M = {}
 
 
--- we use plugin instance ID as the queue ID
-local function get_queue_id()
-  return kong.plugin.get_id()
-end
-
 local function get_cache_value(cache, cache_key)
   local cache_value = cache[cache_key]
   if not cache_value then
@@ -461,7 +456,7 @@ function _M.execute(conf)
   local message = kong.log.serialize({ngx = ngx, kong = kong, })
   message.cache_metrics = ngx.ctx.cache_metrics
 
-  local queue_id = get_queue_id(conf)
+  local queue_id = kong.plugin.get_id()
   local q = queues[queue_id]
   if not q then
     local batch_max_size = conf.queue_size or 1

--- a/kong/runloop/plugin_servers/init.lua
+++ b/kong/runloop/plugin_servers/init.lua
@@ -189,7 +189,7 @@ end
 --- instance.  Biggest complexity here is due to the remote (and thus non-atomic
 --- and fallible) operation of starting the instance at the server.
 function get_instance_id(plugin_name, conf)
-  local key = type(conf) == "table" and conf.__key__ or plugin_name
+  local key = type(conf) == "table" and kong.plugin.get_id() or plugin_name
   local instance_info = running_instances[key]
 
   while instance_info and not instance_info.id do
@@ -258,7 +258,7 @@ end
 
 --- reset_instance: removes an instance from the table.
 function reset_instance(plugin_name, conf)
-  local key = type(conf) == "table" and conf.__key__ or plugin_name
+  local key = type(conf) == "table" and kong.plugin.get_id() or plugin_name
   running_instances[key] = nil
 end
 

--- a/kong/runloop/plugins_iterator.lua
+++ b/kong/runloop/plugins_iterator.lua
@@ -150,6 +150,7 @@ local function get_plugin_config(plugin, name, ws_id)
   cfg.service_id  = plugin.service  and plugin.service.id
   cfg.consumer_id = plugin.consumer and plugin.consumer.id
   cfg.plugin_instance_name = plugin.instance_name
+  cfg.__plugin_id = plugin.id
 
   local key = kong.db.plugins:cache_key(name,
     cfg.route_id,
@@ -158,6 +159,7 @@ local function get_plugin_config(plugin, name, ws_id)
     nil,
     ws_id)
 
+  -- TODO: deprecate usage of __key__ as id of plugin
   if not cfg.__key__ then
     cfg.__key__ = key
     cfg.__seq__ = next_seq

--- a/spec/02-integration/07-sdk/05-pdk_spec.lua
+++ b/spec/02-integration/07-sdk/05-pdk_spec.lua
@@ -1,0 +1,56 @@
+local helpers = require "spec.helpers"
+
+
+local uuid_pattern = "^" .. ("%x"):rep(8) .. "%-" .. ("%x"):rep(4) .. "%-"
+.. ("%x"):rep(4) .. "%-" .. ("%x"):rep(4) .. "%-"
+.. ("%x"):rep(12) .. "$"
+
+
+describe("kong.plugin.get_id()", function()
+  local proxy_client
+
+  lazy_setup(function()
+    local bp = helpers.get_db_utils(nil, {
+      "plugins",
+    }, {
+      "get-plugin-id",
+    })
+
+    local route = bp.routes:insert({ hosts = { "test.com" } })
+
+    bp.plugins:insert({
+      name = "get-plugin-id",
+      instance_name = "test",
+      route = { id = route.id },
+      config = {},
+    })
+
+    assert(helpers.start_kong({
+      plugins = "bundled,get-plugin-id",
+      nginx_conf = "spec/fixtures/custom_nginx.template",
+    }))
+  end)
+
+  lazy_teardown(function()
+    helpers.stop_kong()
+  end)
+
+  before_each(function()
+    proxy_client = helpers.proxy_client()
+  end)
+
+  after_each(function()
+    if proxy_client then
+      proxy_client:close()
+    end
+  end)
+
+  it("conf", function()
+    local res = proxy_client:get("/request", {
+      headers = { Host = "test.com" }
+    })
+
+    local body = assert.status(200, res)
+    assert.match(uuid_pattern, body)
+  end)
+end)

--- a/spec/fixtures/custom_plugins/kong/plugins/get-plugin-id/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/get-plugin-id/handler.lua
@@ -1,0 +1,10 @@
+local PluginConfigDumpHandler =  {
+  VERSION = "1.0.0",
+  PRIORITY = 1,
+}
+
+function PluginConfigDumpHandler:access(conf)
+  kong.response.exit(200, kong.plugin.get_id())
+end
+
+return PluginConfigDumpHandler

--- a/spec/fixtures/custom_plugins/kong/plugins/get-plugin-id/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/get-plugin-id/schema.lua
@@ -1,0 +1,12 @@
+return {
+  name = "get-plugin-id",
+  fields = {
+    {
+      config = {
+        type = "record",
+        fields = {
+        },
+      },
+    },
+  },
+}


### PR DESCRIPTION
### Summary

Exposing plugins' UUID as fields `id` of plugin config objects.

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

- New PDK function `kong.plugin.get_id()`
  - plugin.lua 
  - new file's entry in rockspec
- Test
  - 05-pdk_spec.lua
  - spec/fixtures/custom_plugins/kong/plugins/get-plugin-id/*
- Change existing usage of `conf.__key__`
  - kong/plugins/*

### Issue reference

Implement FTI-4019
