### PR TITLE
fix: informative error message for invalid jwk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,11 @@
 - **Zipkin**: Fix an issue where the global plugin's sample ratio overrides route-specific.
   [#9877](https://github.com/Kong/kong/pull/9877)
 
+#### Core
+
+- Improve error message for invalid jwk entries
+
+
 
 ## 3.1.0 (Unreleased)
 

--- a/kong/db/schema/entities/keys.lua
+++ b/kong/db/schema/entities/keys.lua
@@ -104,7 +104,7 @@ return {
           -- running customer_validator
           local ok, val_err = typedefs.jwk.custom_validator(entity.jwk)
           if not ok or val_err then
-            return nil, "could not load JWK"
+            return nil, val_err or "could not load JWK"
           end
           -- FIXME: this does not execute the `custom_validator` part.
           --        how to do that without loading that manually as seen above

--- a/kong/db/schema/typedefs.lua
+++ b/kong/db/schema/typedefs.lua
@@ -588,7 +588,7 @@ local function validate_jwk(key)
 
   local pk, err = openssl_pkey.new(key, { format = "JWK" })
   if not pk or err then
-    return false, "could not load JWK" .. (err or "")
+    return false, "could not load JWK, likely not a valid key"
   end
   return true
 end

--- a/spec/02-integration/04-admin_api/21-admin-api-keys_spec.lua
+++ b/spec/02-integration/04-admin_api/21-admin-api-keys_spec.lua
@@ -128,8 +128,8 @@ for _, strategy in helpers.all_strategies() do
             }
           })
           local key_body = assert.res_status(400, j_key)
-          test_jwk_key = cjson.decode(key_body)
-          assert.equal('schema violation (could not load JWK, likely not a valid key)', test_jwk_key.message)
+          local jwk_key = cjson.decode(key_body)
+          assert.equal('schema violation (could not load JWK, likely not a valid key)', jwk_key.message)
         end)
       end)
 

--- a/spec/02-integration/04-admin_api/21-admin-api-keys_spec.lua
+++ b/spec/02-integration/04-admin_api/21-admin-api-keys_spec.lua
@@ -117,6 +117,20 @@ for _, strategy in helpers.all_strategies() do
           local key_body = assert.res_status(201, j_key)
           test_jwk_key = cjson.decode(key_body)
         end)
+
+        it("create invalid JWK", function()
+          local j_key = helpers.admin_client():post("/keys", {
+            headers = HEADERS,
+            body = {
+              name = "jwk invalid",
+              jwk = '{"kid": "36"}',
+              kid = "36"
+            }
+          })
+          local key_body = assert.res_status(400, j_key)
+          test_jwk_key = cjson.decode(key_body)
+          assert.equal('schema violation (could not load JWK, likely not a valid key)', test_jwk_key.message)
+        end)
       end)
 
 


### PR DESCRIPTION
### Summary

Improve error message for invalid jwk entries

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG

### Full changelog

* Improve error message for invalid jwk entries

