### PR TITLE
fix(templates): not add default charset when upstream response doesn't contain it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,7 +96,7 @@
   [#9960](https://github.com/Kong/kong/pull/9960)
 - Expose postgres connection pool configuration
   [#9603](https://github.com/Kong/kong/pull/9603)
-- **Template**: not add default charset when upstream response doesn't contain it.
+- **Template**: Do not add default charset to the `Content-Type` response header when upstream response doesn't contain it.
   [#9905](https://github.com/Kong/kong/pull/9905)
 
 #### Plugins

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,8 @@
   [#9960](https://github.com/Kong/kong/pull/9960)
 - Expose postgres connection pool configuration
   [#9603](https://github.com/Kong/kong/pull/9603)
+- **Template**: not add default charset when upstream response doesn't contain it.
+  [#9905](https://github.com/Kong/kong/pull/9905)
 
 #### Plugins
 

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -1,5 +1,5 @@
 return [[
-charset UTF-8;
+charset off;
 server_tokens off;
 
 error_log ${{PROXY_ERROR_LOG}} ${{LOG_LEVEL}};

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -1,5 +1,4 @@
 return [[
-charset off;
 server_tokens off;
 
 error_log ${{PROXY_ERROR_LOG}} ${{LOG_LEVEL}};

--- a/spec/02-integration/05-proxy/03-upstream_headers_spec.lua
+++ b/spec/02-integration/05-proxy/03-upstream_headers_spec.lua
@@ -266,7 +266,6 @@ for _, strategy in helpers.each_strategy() do
           server {
             server_name myserver;
             listen localhost:12345;
-            charset off;
 
             location = /nocharset {
               content_by_lua_block {

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -22,7 +22,7 @@ events {
 
 > if role == "control_plane" or #proxy_listeners > 0 or #admin_listeners > 0 or #status_listeners > 0 then
 http {
-    charset UTF-8;
+    charset off;
     server_tokens off;
 
     error_log ${{PROXY_ERROR_LOG}} ${{LOG_LEVEL}};

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -22,7 +22,6 @@ events {
 
 > if role == "control_plane" or #proxy_listeners > 0 or #admin_listeners > 0 or #status_listeners > 0 then
 http {
-    charset off;
     server_tokens off;
 
     error_log ${{PROXY_ERROR_LOG}} ${{LOG_LEVEL}};


### PR DESCRIPTION
Currently, Kong adds `charset=UTF-8` to `Content-Type` header of response if the content-type is one of `charset_types` and contains no charset.

Kong doesn't know the charset of upstream response and can't assume it is UTF-8. Also we shouldn't change the response unless explicitly required e.g. by the response transformer plugin.

FTI-4551

[FTI-4551]: https://konghq.atlassian.net/browse/FTI-4551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ