### PR TITLE
fix(declarative-config): set hash when config is loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,12 @@
 - **Zipkin**: Fix an issue where the global plugin's sample ratio overrides route-specific.
   [#9877](https://github.com/Kong/kong/pull/9877)
 
+#### Core
+
+- Fix an issue where after a valid declarative configuration is loaded,
+  the configuration hash is incorrectly set to the value: `00000000000000000000000000000000`.
+  [#9911](https://github.com/Kong/kong/pull/9911)
+
 ### Dependencies
 
 - Bumped luarocks from 3.9.1 to 3.9.2

--- a/kong/db/declarative/import.lua
+++ b/kong/db/declarative/import.lua
@@ -10,7 +10,7 @@ local cjson_encode = require("cjson.safe").encode
 local deepcopy = require("pl.tablex").deepcopy
 local marshall = require("kong.db.declarative.marshaller").marshall
 local schema_topological_sort = require("kong.db.schema.topological_sort")
-
+local nkeys = require("table.nkeys")
 
 local assert = assert
 local sort = table.sort
@@ -148,6 +148,12 @@ local function unique_field_key(schema_name, ws_id, field, value, unique_across_
 end
 
 
+local function config_is_empty(entities)
+  -- empty configuration has no entries other than workspaces
+  return entities.workspaces and nkeys(entities) == 1
+end
+
+
 -- entities format:
 --   {
 --     services: {
@@ -174,7 +180,7 @@ local function load_into_cache(entities, meta, hash)
 
   assert(type(fallback_workspace) == "string")
 
-  if not hash or hash == "" then
+  if not hash or hash == "" or config_is_empty(entities) then
     hash = DECLARATIVE_EMPTY_CONFIG_HASH
   end
 

--- a/spec/02-integration/02-cmd/02-start_stop_spec.lua
+++ b/spec/02-integration/02-cmd/02-start_stop_spec.lua
@@ -1,5 +1,6 @@
-local helpers = require "spec.helpers"
-
+local helpers   = require "spec.helpers"
+local constants = require "kong.constants"
+local cjson     = require "cjson"
 
 for _, strategy in helpers.each_strategy() do
 
@@ -471,6 +472,64 @@ describe("kong start/stop #" .. strategy, function()
 
           return ok
         end, 10)
+      end)
+
+      it("configuration hash is set correctly", function()
+        local yaml_file = helpers.make_yaml_file [[
+          _format_version: "1.1"
+          services:
+          - name: my-service
+            url: http://127.0.0.1:15555
+            routes:
+            - name: example-route
+              hosts:
+              - example.test
+        ]]
+
+        local admin_client, json_body
+
+        finally(function()
+          os.remove(yaml_file)
+          helpers.stop_kong(helpers.test_conf.prefix)
+          if admin_client then
+            admin_client:close()
+          end
+        end)
+
+        assert(helpers.start_kong({
+          database = "off",
+          declarative_config = yaml_file,
+          nginx_conf = "spec/fixtures/custom_nginx.template",
+        }))
+
+        helpers.wait_until(function()
+          helpers.wait_until(function()
+            local pok
+            pok, admin_client = pcall(helpers.admin_client)
+            return pok
+          end, 10)
+
+          local res = assert(admin_client:send {
+            method = "GET",
+            path = "/status"
+          })
+          if res.status ~= 200 then
+            return false
+          end
+          local body = assert.res_status(200, res)
+          json_body = cjson.decode(body)
+
+          if admin_client then
+            admin_client:close()
+            admin_client = nil
+          end
+
+          return true
+        end, 10)
+
+        assert.is_string(json_body.configuration_hash)
+        assert.equals(32, #json_body.configuration_hash)
+        assert.not_equal(constants.DECLARATIVE_EMPTY_CONFIG_HASH, json_body.configuration_hash)
       end)
     end)
   end

--- a/spec/02-integration/04-admin_api/02-kong_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/02-kong_routes_spec.lua
@@ -1,5 +1,6 @@
 local helpers = require "spec.helpers"
 local cjson = require "cjson"
+local constants = require "kong.constants"
 
 local UUID_PATTERN = "%x%x%x%x%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%x%x%x%x%x%x%x%x"
 
@@ -188,6 +189,8 @@ describe("Admin API - Kong routes with strategy #" .. strategy, function()
   end)
 
   describe("/status", function()
+    local empty_config_hash = constants.DECLARATIVE_EMPTY_CONFIG_HASH
+
     it("returns status info", function()
       local res = assert(client:send {
         method = "GET",
@@ -208,7 +211,9 @@ describe("Admin API - Kong routes with strategy #" .. strategy, function()
       assert.is_number(json.server.connections_waiting)
       assert.is_number(json.server.total_requests)
       if strategy == "off" then
-        assert.is_equal(string.rep("0", 32), json.configuration_hash) -- all 0 in DBLESS mode until configuration is applied
+        assert.is_string(json.configuration_hash)
+        assert.equal(32, #json.configuration_hash)
+        assert.is_not_equal(empty_config_hash, json.configuration_hash)
       else
         assert.is_nil(json.configuration_hash) -- not present in DB mode
       end
@@ -251,7 +256,7 @@ describe("Admin API - Kong routes with strategy #" .. strategy, function()
       assert.is_number(json.server.total_requests)
       assert.is_string(json.configuration_hash)
       assert.equal(32, #json.configuration_hash)
-
+      assert.is_not_equal(empty_config_hash, json.configuration_hash)
     end)
 
     it("database.reachable is `true` when DB connection is healthy", function()

--- a/spec/02-integration/04-admin_api/02-kong_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/02-kong_routes_spec.lua
@@ -211,9 +211,7 @@ describe("Admin API - Kong routes with strategy #" .. strategy, function()
       assert.is_number(json.server.connections_waiting)
       assert.is_number(json.server.total_requests)
       if strategy == "off" then
-        assert.is_string(json.configuration_hash)
-        assert.equal(32, #json.configuration_hash)
-        assert.is_not_equal(empty_config_hash, json.configuration_hash)
+        assert.is_equal(empty_config_hash, json.configuration_hash) -- all 0 in DBLESS mode until configuration is applied
       else
         assert.is_nil(json.configuration_hash) -- not present in DB mode
       end


### PR DESCRIPTION
Ensure the `hash` field is correctly configured when the declarative configuration is loaded.