### PR TITLE
test(bundled-plugin): test all plugin sub-modules installed in luarocks kong module are in bundle list

### DIFF
--- a/spec/02-integration/04-admin_api/12-plugins-conf_spec.lua
+++ b/spec/02-integration/04-admin_api/12-plugins-conf_spec.lua
@@ -48,7 +48,7 @@ describe("Plugins conf property" , function()
       local rocks_installed_plugins_list = stringx.split(rocks_installed_plugins, "\n")
       for _, plugin in ipairs(rocks_installed_plugins_list) do
         if not not_bundled_plugins[plugin] then
-          assert.contains(plugin, bundled_plugins_list)
+          assert.truthy(bundled_plugins_list[plugin])
         end
       end
     end)

--- a/spec/02-integration/04-admin_api/12-plugins-conf_spec.lua
+++ b/spec/02-integration/04-admin_api/12-plugins-conf_spec.lua
@@ -5,7 +5,7 @@ local stringx = require "pl.stringx"
 local constants = require "kong.constants"
 local utils = require "spec.helpers.perf.utils"
 
-local not_bundled_plugins = {}
+local NON_BUDLED_PLUGINS = {}
 
 describe("Plugins conf property" , function()
 
@@ -47,7 +47,7 @@ describe("Plugins conf property" , function()
       assert.is_nil(err)
       local rocks_installed_plugins_list = stringx.split(rocks_installed_plugins, "\n")
       for _, plugin in ipairs(rocks_installed_plugins_list) do
-        if not not_bundled_plugins[plugin] then
+        if not NON_BUDLED_PLUGINS[plugin] then
           assert.truthy(bundled_plugins_list[plugin])
         end
       end

--- a/spec/02-integration/04-admin_api/12-plugins-conf_spec.lua
+++ b/spec/02-integration/04-admin_api/12-plugins-conf_spec.lua
@@ -43,7 +43,7 @@ describe("Plugins conf property" , function()
       local body = assert.res_status(200 , res)
       local json = assert(cjson.decode(body))
       local bundled_plugins_list = json.plugins.available_on_server
-      local rocks_installed_plugins, err = utils.execute("ls -1 $(luarocks show kong | grep 'kong.plugins' | grep -E '/.+/kong/plugins/' -o | uniq)")
+      local rocks_installed_plugins, err = utils.execute([[luarocks show kong | grep -oP 'kong\.plugins\.\K([\w-]+)' | uniq]])
       assert.is_nil(err)
       local rocks_installed_plugins_list = stringx.split(rocks_installed_plugins, "\n")
       for _, plugin in ipairs(rocks_installed_plugins_list) do

--- a/spec/02-integration/04-admin_api/12-plugins-conf_spec.lua
+++ b/spec/02-integration/04-admin_api/12-plugins-conf_spec.lua
@@ -48,7 +48,11 @@ describe("Plugins conf property" , function()
       local rocks_installed_plugins_list = stringx.split(rocks_installed_plugins, "\n")
       for _, plugin in ipairs(rocks_installed_plugins_list) do
         if not NON_BUDLED_PLUGINS[plugin] then
-          assert.truthy(bundled_plugins_list[plugin])
+          assert(bundled_plugins_list[plugin] ~= nil,
+                 "Found installed plugin not in bundled list: " ..
+                 "'" .. plugin .. "'" ..
+                 ", please add it to the bundled list or NON_BUDLED_PLUGINS accordingly."
+                 )
         end
       end
     end)

--- a/spec/02-integration/04-admin_api/12-plugins-conf_spec.lua
+++ b/spec/02-integration/04-admin_api/12-plugins-conf_spec.lua
@@ -51,7 +51,7 @@ describe("Plugins conf property" , function()
           assert(bundled_plugins_list[plugin] ~= nil,
                  "Found installed plugin not in bundled list: " ..
                  "'" .. plugin .. "'" ..
-                 ", please add it to the bundled list or NON_BUDLED_PLUGINS accordingly."
+                 ", please add it to the bundled list"
                  )
         end
       end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

This PR adds a test to fetch all the plugins sub-module installed under Luarocks `kong` module and test if it is already in the bundle list, to ensure that we will not forget to add new plugins into the bundle list according to our needs. Plugins that do not need to be bundled have to be added to `not_bundled_plugins` whitelist.

I haven't come up with some better solutions yet so if you're looking at this PR and have a better idea, please let me know, thanks!

### Checklist

- [x] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* add a test to check all plugin sub-modules installed in Luarocks kong module are in bundle list

### Issue reference

[FTI-4599](https://konghq.atlassian.net/browse/FTI-4599)

[FTI-4599]: https://konghq.atlassian.net/browse/FTI-4599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ