### PR TITLE
feat(status_listen) support HTTP/2

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -609,11 +609,13 @@
                          # - `ssl` will require that all connections made
                          #   through a particular address/port be made with TLS
                          #   enabled.
+                         # - `http2` will allow for clients to open HTTP/2
+                         #   connections to Kong's proxy server.
                          #
                          # This value can be set to `off`, disabling
                          # the Status API for this node.
                          #
-                         # Example: `status_listen = 0.0.0.0:8100`
+                         # Example: `status_listen = 0.0.0.0:8100 ssl http2`
 
 
 #nginx_user = kong kong          # Defines user and group credentials used by

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -1739,7 +1739,7 @@ local function load(path, custom_conf, opts)
     { name = "proxy_listen",   subsystem = "http",   ssl_flag = "proxy_ssl_enabled" },
     { name = "stream_listen",  subsystem = "stream", ssl_flag = "stream_proxy_ssl_enabled" },
     { name = "admin_listen",   subsystem = "http",   ssl_flag = "admin_ssl_enabled" },
-    { name = "status_listen",  flags = { "ssl" },    ssl_flag = "status_ssl_enabled" },
+    { name = "status_listen",  subsystem = "http",   ssl_flag = "status_ssl_enabled" },
     { name = "cluster_listen", subsystem = "http" },
   })
   if not ok then

--- a/spec/01-unit/03-conf_loader_spec.lua
+++ b/spec/01-unit/03-conf_loader_spec.lua
@@ -1356,6 +1356,14 @@ describe("Configuration loader", function()
             assert.True(helpers.path.isabs(conf.status_ssl_cert_key[i]))
           end
         end)
+        it("supports HTTP/2", function()
+          local conf, err = conf_loader(nil, {
+            status_listen = "127.0.0.1:123 ssl http2",
+          })
+          assert.is_nil(err)
+          assert.is_table(conf)
+          assert.same({ "127.0.0.1:123 ssl http2" }, conf.status_listen)
+        end)
       end)
 
       describe("lua_ssl_protocls", function()


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

Previously, only support HTTP/1.1 TLS

### Checklist

- [ y ] The Pull Request has tests

### Full changelog

* [Support HTTP2]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[FTI-4582]_


[FTI-4582]: https://konghq.atlassian.net/browse/FTI-4582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ