### PR TITLE
fix(router): add better error handling for ATC router when invalid field

### DIFF
--- a/kong/router/atc_compat.lua
+++ b/kong/router/atc_compat.lua
@@ -598,10 +598,16 @@ function _M:select(req_method, req_uri, req_host, req_scheme,
       assert(c:add_value("http.method", req_method))
 
     elseif field == "http.path" then
-      assert(c:add_value("http.path", req_uri))
+      local res, err = c:add_value("http.path", req_uri)
+      if not res then
+        return nil, err
+      end
 
     elseif field == "http.host" then
-      assert(c:add_value("http.host", host))
+      local res, err = c:add_value("http.host", host)
+      if not res then
+        return nil, err
+      end
 
     elseif field == "net.port" then
      assert(c:add_value("net.port", port))
@@ -610,7 +616,10 @@ function _M:select(req_method, req_uri, req_host, req_scheme,
       assert(c:add_value("net.protocol", req_scheme))
 
     elseif field == "tls.sni" then
-      assert(c:add_value("tls.sni", sni))
+      local res, err = c:add_value("tls.sni", sni)
+      if not res then
+        return nil, err
+      end
 
     elseif req_headers and field:sub(1, 13) == "http.headers." then
       local h = field:sub(14)
@@ -618,11 +627,17 @@ function _M:select(req_method, req_uri, req_host, req_scheme,
 
       if v then
         if type(v) == "string" then
-          assert(c:add_value(field, v:lower()))
+          local res, err = c:add_value(field, v:lower())
+          if not res then
+            return nil, err
+          end
 
         else
           for _, v in ipairs(v) do
-            assert(c:add_value(field, v:lower()))
+            local res, err = c:add_value(field, v:lower())
+            if not res then
+              return nil, err
+            end
           end
         end
       end
@@ -735,10 +750,16 @@ function _M:exec(ctx)
       return nil
     end
 
-    match_t = self:select(req_method, req_uri, req_host, req_scheme,
-                          nil, nil, nil, nil,
-                          sni, headers)
+    local err
+    match_t, err = self:select(req_method, req_uri, req_host, req_scheme,
+                               nil, nil, nil, nil,
+                               sni, headers)
     if not match_t then
+      if err then
+        ngx_log(ngx_ERR, "router returned an error: ", err,
+                         ", 404 Not Found will be returned for the current request")
+      end
+
       self.cache_neg:set(cache_key, true)
       return nil
     end

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -2927,6 +2927,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
       local function mock_ngx(method, request_uri, headers)
         local _ngx
         _ngx = {
+          log = ngx.log,
           re = ngx.re,
           var = setmetatable({
             request_uri = request_uri,
@@ -3974,6 +3975,37 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
         assert.is_nil(match_t.upstream_host) -- only when `preserve_host = true`
         assert.equal([[/123"]], match_t.upstream_uri)
       end)
+
+      if flavor == "traditional_compatible" or flavor == "expressions" then
+        it("gracefully handles invalid utf-8 sequences", function()
+          local use_case_routes = {
+            {
+              service    = {
+                name     = "service-invalid",
+                host     = "example.org",
+                protocol = "http"
+              },
+              route      = {
+                id = "e8fb37f1-102d-461e-9c51-6608a6bb8101",
+                paths    = { [[/hello]] },
+              },
+            },
+          }
+
+          local router = assert(new_router(use_case_routes))
+          local _ngx = mock_ngx("GET", "\xfc\x80\x80\x80\x80\xaf", { host = "example.org" })
+          local log_spy = spy.on(_ngx, "log")
+
+          router._set_ngx(_ngx)
+
+          local match_t = router:exec()
+          assert.is_nil(match_t)
+
+          assert.spy(log_spy).was.called_with(ngx.ERR, "router returned an error: ",
+                                              "invalid utf-8 sequence of 1 bytes from index 0",
+                                              ", 404 Not Found will be returned for the current request")
+        end)
+      end
     end)
 
 


### PR DESCRIPTION
name is provided. fixes KAG-209
