### PR TITLE
fix(jwt): deny requests that have different tokens in the jwt token search locations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,7 @@
 
 - **Zipkin**: Fix an issue where the global plugin's sample ratio overrides route-specific.
   [#9877](https://github.com/Kong/kong/pull/9877)
-- **JWT**: Deny requests that have different tokens in the jwt token search locations. Thanks, Jackson 'Che-Chun' Kuo from Latacora.
+- **JWT**: Deny requests that have different tokens in the jwt token search locations. Thanks Jackson 'Che-Chun' Kuo from Latacora for reporting this issue.
   [#9946](https://github.com/Kong/kong/pull/9946)
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,9 +69,16 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+#### Plugins
+
+- **JWT**: JWT plugin now denies a request that has different tokens in the jwt token search locations.
+  [#9946](https://github.com/Kong/kong/pull/9946)
+
 ### Additions
 
-### Plugins
+#### Plugins
 
 - **Zipkin**: Add support to set the durations of Kong phases as span tags
   through configuration property `config.phase_duration_flavor`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,8 @@
 
 - **Zipkin**: Fix an issue where the global plugin's sample ratio overrides route-specific.
   [#9877](https://github.com/Kong/kong/pull/9877)
+- **JWT**: Deny requests that have different tokens in the jwt token search locations. Thanks, Jackson 'Che-Chun' Kuo from Latacora.
+  [#9946](https://github.com/Kong/kong/pull/9946)
 
 ### Dependencies
 

--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -11,7 +11,6 @@ local ipairs = ipairs
 local pairs = pairs
 local tostring = tostring
 local re_gmatch = ngx.re.gmatch
-local table_insert = table.insert
 
 
 local JwtHandler = {

--- a/kong/plugins/jwt/handler.lua
+++ b/kong/plugins/jwt/handler.lua
@@ -80,16 +80,18 @@ local function retrieve_tokens(conf)
     end
   end
 
+  local tokens_n = 0
   local tokens = {}
   for token, _ in pairs(token_set) do
-    table_insert(tokens, token)
+    tokens_n = tokens_n + 1
+    tokens[tokens_n] = token
   end
 
-  if #tokens == 0 then
+  if tokens_n == 0 then
     return nil
   end
 
-  if #tokens == 1 then
+  if tokens_n == 1 then
     return tokens[1]
   end
 

--- a/spec/03-plugins/16-jwt/03-access_spec.lua
+++ b/spec/03-plugins/16-jwt/03-access_spec.lua
@@ -396,6 +396,21 @@ for _, strategy in helpers.each_strategy() do
         assert.falsy(ok)
         assert.match("Code: Unauthenticated", err)
       end)
+
+      it("reject if multiple different tokens found", function()
+        PAYLOAD.iss = jwt_secret.key
+        local jwt = jwt_encoder.encode(PAYLOAD, jwt_secret.secret)
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/request?jwt=" .. jwt,
+          headers = {
+            ["Authorization"] = "Bearer invalid.jwt.token",
+            ["Host"]          = "jwt1.com",
+          }
+        })
+        local body = cjson.decode(assert.res_status(401, res))
+        assert.same({ message = "Multiple tokens provided" }, body)
+      end)
     end)
 
     describe("HS256", function()


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Deny requests that have different tokens in the jwt token search locations.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE


### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
[FTI-4580]


[FTI-4580]: https://konghq.atlassian.net/browse/FTI-4580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ