### PR TITLE
perf(prometheus): switch high cardinality metrics in kong.conf

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1347,6 +1347,31 @@
                                  # it might take more time to propagate changes
                                  # to each individual worker.
 
+# The following switches enable or disable Prometheus plugin high-cardinality
+# metrics. When enabled, these metrics can negatively impact the Gateway
+# performance depending on the number of entities configured.
+
+#prometheus_plugin_status_code_metrics =
+                                 # Enables or disables reporting the HTTP/Stream
+                                 # status codes per service/route by the
+                                 # Prometheus plugin. Default `on`.
+
+#prometheus_plugin_latency_metrics =
+                                 # Enables or disables reporting the latency
+                                 # added by Kong, request time and upstream
+                                 # latency by the Prometheus plugin. Default `on`.
+
+#prometheus_plugin_bandwidth_metrics =
+                                 # Enables or disables the bandwith consumed by
+                                 # service/route reporting by the Prometheus
+                                 # plugin. Default `on`.
+
+#prometheus_plugin_upstream_health_metrics =
+                                 # Enables or disables the upstream health status
+                                 # reporting by the Prometheus plugin.
+                                 # Default `on`.
+
+
 #------------------------------------------------------------------------------
 # MISCELLANEOUS
 #------------------------------------------------------------------------------

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -639,6 +639,11 @@ local CONF_INFERENCES = {
   untrusted_lua = { enum = { "on", "off", "sandbox" } },
   untrusted_lua_sandbox_requires = { typ = "array" },
   untrusted_lua_sandbox_environment = { typ = "array" },
+
+  prometheus_plugin_status_code_metrics = { typ = "boolean", },
+  prometheus_plugin_latency_metrics = { typ = "boolean", },
+  prometheus_plugin_bandwidth_metrics = { typ = "boolean", },
+  prometheus_plugin_upstream_health_metrics = { typ = "boolean", },
 }
 
 

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -176,4 +176,9 @@ pluginserver_names = NONE
 untrusted_lua = sandbox
 untrusted_lua_sandbox_requires =
 untrusted_lua_sandbox_environment =
+
+prometheus_plugin_status_code_metrics = on
+prometheus_plugin_latency_metrics = on
+prometheus_plugin_bandwidth_metrics = on
+prometheus_plugin_upstream_health_metrics = on
 ]]

--- a/spec/01-unit/09-balancer/04-round_robin_spec.lua
+++ b/spec/01-unit/09-balancer/04-round_robin_spec.lua
@@ -1068,7 +1068,7 @@ describe("[round robin balancer]", function()
       record.expired = true
       -- do a lookup to trigger the async lookup
       client.resolve("really.really.really.does.not.exist.thijsschreijer.nl", {qtype = client.TYPE_A})
-      sleep(0.5) -- provide time for async lookup to complete
+      sleep(1) -- provide time for async lookup to complete
 
       for _ = 1, b.wheelSize do b:getPeer() end -- hit them all to force renewal
 


### PR DESCRIPTION
### Summary

New switches to enable/disable Prometheus plugin high cardinality metrics.

### Checklist

- [x] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* Added config entries in `kong.conf`.
* Prometheus plugin behaves according to entries in `kong.conf`.
* New test to check if entries are missing from the plugin output when disabled. 

### Issue reference

FTI-4460
