### PR TITLE
chore(ci): fix packaging running on forks

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -71,6 +71,7 @@ jobs:
           bazel-out/
 
     - name: Login to Docker Hub
+      if: github.event_name == 'push'
       uses: docker/login-action@v2
       with:
         username: ${{ secrets.GHA_DOCKERHUB_PUSH_USER }}


### PR DESCRIPTION
### Summary

Due to the dangers inherent to automatic processing of PRs, GitHub’s standard pull_request workflow trigger by default prevents write permissions and secrets access to the target repository.
Removed login step to Docker Hub.