### PR TITLE
fix(db): add back `FLOOR` so ttl returns integer instead of float

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@
 
 ## Unreleased
 
-## Additions
+### Additions
 
 ### Plugins
 
@@ -78,6 +78,12 @@
   [#9891](https://github.com/Kong/kong/pull/9891)
 
 ### Fixes
+
+#### Core
+
+- Add back Postgres `FLOOR` function when calculating `ttl`, so it is always returned
+  as `int` instead of `float`.
+  [#9960](https://github.com/Kong/kong/pull/9960)
 
 #### Plugins
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,8 +81,7 @@
 
 #### Core
 
-- Add back Postgres `FLOOR` function when calculating `ttl`, so it is always returned
-  as `int` instead of `float`.
+- Add back Postgres `FLOOR` function when calculating `ttl`, so the returned `ttl` is always a whole integer.
   [#9960](https://github.com/Kong/kong/pull/9960)
 
 #### Plugins

--- a/kong/db/strategies/postgres/init.lua
+++ b/kong/db/strategies/postgres/init.lua
@@ -1032,9 +1032,9 @@ function _M.new(connector, schema, errors)
 
     select_expressions = concat {
       select_expressions, ",",
-      "EXTRACT(EPOCH FROM (",
+      "FLOOR(EXTRACT(EPOCH FROM (",
         ttl_escaped, " AT TIME ZONE 'UTC' - CURRENT_TIMESTAMP AT TIME ZONE 'UTC'",
-      ")) AS ", ttl_escaped
+      "))) AS ", ttl_escaped
     }
 
     ttl_select_where = concat {


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

Add back `FLOOR` so that `ttl` is returned as integer instead of float.

PR <https://github.com/Kong/kong/pull/9801> remove `FLOOR` part to reflect the real `ttl` value, but may return a `float` value instead of `int`, which would break some downstream clients as depicted in issue <https://github.com/Kong/kong/issues/9944>.

This PR add back `FLOOR` as in the `handler.lua`, we have double-check on `cred.ttl == 0`. So it is **safe** to add back.

Also check [FTI-4066].

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[9944]_


[FTI-4066]: https://konghq.atlassian.net/browse/FTI-4066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ