### PR TITLE
Remove info telling users information about what the tool is to minimize targetting of exploits

### DIFF
--- a/kong/tools/utils.lua
+++ b/kong/tools/utils.lua
@@ -1273,10 +1273,8 @@ do
 <html>
   <head>
     <meta charset="utf-8">
-    <title>Kong Error</title>
   </head>
   <body>
-    <h1>Kong Error</h1>
     <p>%s.</p>
   </body>
 </html>


### PR DESCRIPTION
### Summary

Kong is exposing information about itself which helps attackers target CVEs, etc. against Kong more readily as they know what to target.  None of the other response methods other than HTML include this information.

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

Support case 31515


