### PR TITLE
docs(DEVELOPER): Fedora dependencies

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -411,7 +411,9 @@ dnf install \
     pcre-devel \
     unzip \
     zlib-devel \
-    valgrind
+    valgrind \
+    valgrind-devel \
+    perl
 ```
 
 #### OpenResty


### PR DESCRIPTION
On Fedora 36 I had to install:
```
valgrind-devel
perl
```
in addition to the listed dependencies, in order to successfully build OpenResty & OpenSSL.
