### PR TITLE
fix(core/runloop): return true in reconfigure handler

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -815,6 +815,8 @@ do
       log(ERR, "declarative reconfigure failed after ", reconfigure_time,
                " ms on worker #", worker_id, ": ", err)
     end
+
+    return true
   end -- reconfigure_handler
 end
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

worker_events requires handler must return `true` to tell it function exec ok, in PR #9653, we missed it.

I think this bug has existed for a long time, untill #9653's refactoring find it.

### Checklist

- [x] The Pull Request has tests
- [x] There's not an entry in the CHANGELOG
- [x] There is not a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE


