### PR TITLE
docs(admin-api): fix a typo in key set description

### DIFF
--- a/autodoc/admin-api/data/admin-api.lua
+++ b/autodoc/admin-api/data/admin-api.lua
@@ -2262,7 +2262,7 @@ return {
       entity_title = "Key Set",
       entity_title_plural = "Key Sets",
       description = [[
-        An Key Set object holds a collection of asymmetric key objects.
+        A Key Set object holds a collection of asymmetric key objects.
         This entity allows to logically group keys by their purpose.
       ]],
       fields = {


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

This PR fixes an article mistake in the key set description docs.

### Checklist

- [x] The Pull Request does not need tests
- [x] There's not an entry in the CHANGELOG
- [x] There is not a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
