### PR TITLE
docs(admin-api): add db-less mode restrictions for the debug routes

### DIFF
--- a/autodoc/admin-api/data/admin-api.lua
+++ b/autodoc/admin-api/data/admin-api.lua
@@ -2707,6 +2707,18 @@ return {
     ["/upstreams/:upstreams/targets/:targets/unhealthy"] = {
       ["PUT"] = true,
     },
+    ["/debug/node/log-level"] = {
+      ["GET"] = true,
+    },
+    ["/debug/node/log-level/:log_level"] = {
+      ["PUT"] = true,
+    },
+    ["/debug/cluster/log-level/:log_level"] = {
+      ["PUT"] = true,
+    },
+    ["/debug/cluster/control-planes-nodes/log-level/:log_level"] = {
+      ["PUT"] = true,
+    }
   },
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
None of the debug routes are db-less compatible, but the "DB-LESS COMPATIBLE" green text still shows up next to each route: https://docs.konghq.com/gateway/latest/admin-api/#debug-routes