### PR TITLE
chore(db/migrate): check route atc compatiblity

### DIFF
--- a/kong/db/migrations/core/016_280_to_300.lua
+++ b/kong/db/migrations/core/016_280_to_300.lua
@@ -196,7 +196,7 @@ local function c_migrate_regex_path(coordinator)
         goto continue
       end
 
-      if changed then
+      if changed and validate_ok then
         tb_insert(changed_routes, route)
       end
 
@@ -248,7 +248,7 @@ local function p_migrate_regex_path(connector)
       goto continue
     end
 
-    if changed then
+    if changed and validate_ok then
       tb_insert(changed_routes, route)
     end
 

--- a/kong/db/migrations/core/016_280_to_300.lua
+++ b/kong/db/migrations/core/016_280_to_300.lua
@@ -174,7 +174,7 @@ local function c_migrate_regex_path(coordinator)
 
       local res, err = r:add_matcher(0, route.id, exp)
       if not res then
-        return nil, err
+        log.error("Regex compatibility, route id: %s, err: %s", route.id, err)
       end
 
       if changed then
@@ -216,7 +216,7 @@ local function p_migrate_regex_path(connector)
 
     local res, err = r:add_matcher(0, route.id, exp)
     if not res then
-      return nil, err
+      log.error("Regex compatibility, route id: %s, err: %s", route.id, err)
     end
 
     if changed then

--- a/kong/db/migrations/core/016_280_to_300.lua
+++ b/kong/db/migrations/core/016_280_to_300.lua
@@ -193,7 +193,6 @@ local function c_migrate_regex_path(coordinator)
 
       if not validate_atc_expression(route) then
         validate_ok = false
-        goto continue
       end
 
       if changed and validate_ok then
@@ -245,14 +244,11 @@ local function p_migrate_regex_path(connector)
 
     if not validate_atc_expression(route) then
       validate_ok = false
-      goto continue
     end
 
     if changed and validate_ok then
       tb_insert(changed_routes, route)
     end
-
-    ::continue::
   end
 
   if not validate_ok then

--- a/kong/db/migrations/core/016_280_to_300.lua
+++ b/kong/db/migrations/core/016_280_to_300.lua
@@ -21,7 +21,8 @@ do
 
     local res, err = r:add_matcher(0, route.id, exp)
     if not res then
-      log.error("Regex compatibility, route id: %s, err: %s", route.id, err)
+      log.error("Regex path may not work with router flavor 'traditional_compatible', " ..
+                "route id: %s, err: %s", route.id, err)
     end
   end
 end


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary


In `kong migrations up`, it will print an error log to notify the user if there is an incompatible regex path route:

```
2022/12/30 09:27:37 [error] Regex path may not work with router flavor 'traditional_compatible', route id: 0950d523-aa5e-4d05-a1af-928ea5c3aa99, err:  --> 1:2
  |
1 | (http.path ~ "^/\\/*/user$")
  |  ^------------------------^
  |
  = regex parse error:
    ^/\/*/user$
      ^^
error: unrecognized escape sequence
```

Related PR #9987 

Notice, #9987 changes `compat._get_expressioin` to  `compat.get_expressioin`, we must rebase this PR.
