### PR TITLE
chore(db/routes): add custom dao for route validation

### DIFF
--- a/kong-3.1.0-0.rockspec
+++ b/kong-3.1.0-0.rockspec
@@ -183,6 +183,7 @@ build = {
     ["kong.db.dao"] = "kong/db/dao/init.lua",
     ["kong.db.dao.certificates"] = "kong/db/dao/certificates.lua",
     ["kong.db.dao.snis"] = "kong/db/dao/snis.lua",
+    ["kong.db.dao.routes"] = "kong/db/dao/routes.lua",
     ["kong.db.dao.targets"] = "kong/db/dao/targets.lua",
     ["kong.db.dao.plugins"] = "kong/db/dao/plugins.lua",
     ["kong.db.dao.tags"] = "kong/db/dao/tags.lua",

--- a/kong/db/dao/routes.lua
+++ b/kong/db/dao/routes.lua
@@ -1,6 +1,8 @@
+--[[
 local router = require("resty.router.router")
 local CACHED_SCHEMA = require("kong.router.atc").schema
 local _get_expression = require("kong.router.compat")._get_expression
+--]]
 
 
 local kong = kong
@@ -16,6 +18,7 @@ local function check_route(route)
 
   -- router_flavor == "traditional_compatible"
 
+  --[[
   local r = router.new(CACHED_SCHEMA)
   local exp = _get_expression(route)
 
@@ -23,6 +26,7 @@ local function check_route(route)
   if not res then
     return nil, err
   end
+  --]]
 
   return true
 end

--- a/kong/db/dao/routes.lua
+++ b/kong/db/dao/routes.lua
@@ -1,0 +1,61 @@
+local router = require("resty.router.router")
+local CACHED_SCHEMA = require("kong.router.atc").schema
+local _get_expression = require("kong.router.compat")._get_expression
+
+
+local kong = kong
+
+
+local _Routes = {}
+
+
+local function check_route(route)
+  if kong.configuration.router_flavor ~= "traditional_compatible" then
+    return true
+  end
+
+  -- router_flavor == "traditional_compatible"
+
+  local r = router.new(CACHED_SCHEMA)
+  local exp = _get_expression(route)
+
+  local res, err = r:add_matcher(0, route.id, exp)
+  if not res then
+    return nil, err
+  end
+
+  return true
+end
+
+
+function _Routes:insert(entity, options)
+  local ok, err = check_route(entity)
+  if not ok then
+    return nil, err
+  end
+
+  return self.super.insert(self, entity, options)
+end
+
+
+function _Routes:upsert(pk, entity, options)
+  local ok, err = check_route(entity)
+  if not ok then
+    return nil, err
+  end
+
+  return self.super.upsert(self, pk, entity, options)
+end
+
+
+function _Routes:update(pk, entity, options)
+  local ok, err = check_route(entity)
+  if not ok then
+    return nil, err
+  end
+
+  return self.super.update(self, pk, entity, options)
+end
+
+
+return _Routes

--- a/kong/db/dao/routes.lua
+++ b/kong/db/dao/routes.lua
@@ -31,7 +31,7 @@ end
 function _Routes:insert(entity, options)
   local ok, err = check_route(entity)
   if not ok then
-    return nil, err
+    return nil, err, self.errors:transformation_error()
   end
 
   return self.super.insert(self, entity, options)
@@ -41,7 +41,7 @@ end
 function _Routes:upsert(pk, entity, options)
   local ok, err = check_route(entity)
   if not ok then
-    return nil, err
+    return nil, err, self.errors:transformation_error()
   end
 
   return self.super.upsert(self, pk, entity, options)
@@ -51,7 +51,7 @@ end
 function _Routes:update(pk, entity, options)
   local ok, err = check_route(entity)
   if not ok then
-    return nil, err
+    return nil, err, self.errors:transformation_error()
   end
 
   return self.super.update(self, pk, entity, options)

--- a/kong/db/schema/entities/routes.lua
+++ b/kong/db/schema/entities/routes.lua
@@ -67,6 +67,7 @@ else
     name         = "routes",
     primary_key  = { "id" },
     endpoint_key = "name",
+    dao          = "kong.db.dao.routes",
     workspaceable = true,
     subschema_key = "protocols",
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Add a custom DAO object to validate route fields, only works for flavor `traditional_compatible`.

