### PR TITLE
fix(runloop): `set_host_header` pass the wrong upstream_host

### DIFF
--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1637,7 +1637,7 @@ return {
         return kong.response.exit(errcode, body)
       end
 
-      local ok, err = balancer.set_host_header(balancer_data, upstream_scheme, "upstream_host")
+      local ok, err = balancer.set_host_header(balancer_data, upstream_scheme, upstream_host)
       if not ok then
         log(ERR, "failed to set balancer Host header: ", err)
         return exit(500)


### PR DESCRIPTION
In the vast majority cases, this change has no effect, except when the host of balancer is exactly equal to "upstream_host" and `preserve_host` is `false`.

This was introduced by https://github.com/Kong/kong/pull/9494