### PR TITLE
fix(aws-lambda): use matched route expression as resource field in gateway compatible input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,9 @@
   [#9877](https://github.com/Kong/kong/pull/9877)
 - **JWT**: Deny requests that have different tokens in the jwt token search locations. Thanks Jackson 'Che-Chun' Kuo from Latacora for reporting this issue.
   [#9946](https://github.com/Kong/kong/pull/9946)
+- **AWS Lambda**: Fix an issue that `resource` field is missing when using the aws-lambda plugin
+  under `awsgateway_compatible` mode with the new ATC router.
+  [#10006](https://github.com/Kong/kong/pull/10006)
 
 #### Core
 

--- a/kong/plugins/aws-lambda/aws-serializer.lua
+++ b/kong/plugins/aws-lambda/aws-serializer.lua
@@ -114,8 +114,8 @@ return function(ctx, config)
     local requestTime = date(start_time):fmt("%d/%b/%Y:%H:%M:%S %z")
     local requestTimeEpoch = start_time * 1000
 
-    -- Kong does not have the concept of stage, so we just let resource path be the same as path
-    local resourcePath = path
+    local resourceId = route and route.id
+    local resourcePath = resource
 
     requestContext = {
       path = path,
@@ -127,6 +127,7 @@ return function(ctx, config)
       requestId = requestId,
       requestTime = requestTime,
       requestTimeEpoch = requestTimeEpoch,
+      resouceId = resourceId,
       resourcePath = resourcePath,
     }
   end

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -174,8 +174,6 @@ local AWSLambdaHandler = {}
 
 
 function AWSLambdaHandler:access(conf)
-  kong.log.inspect("ROUTER_MATCHES:", ngx.ctx.router_matches)
-  kong.log.inspect("ROUTE:", kong.router.get_route())
   local upstream_body = kong.table.new(0, 6)
   local ctx = ngx.ctx
 

--- a/kong/plugins/aws-lambda/handler.lua
+++ b/kong/plugins/aws-lambda/handler.lua
@@ -174,6 +174,8 @@ local AWSLambdaHandler = {}
 
 
 function AWSLambdaHandler:access(conf)
+  kong.log.inspect("ROUTER_MATCHES:", ngx.ctx.router_matches)
+  kong.log.inspect("ROUTE:", kong.router.get_route())
   local upstream_body = kong.table.new(0, 6)
   local ctx = ngx.ctx
 

--- a/spec/03-plugins/27-aws-lambda/05-aws-serializer_spec.lua
+++ b/spec/03-plugins/27-aws-lambda/05-aws-serializer_spec.lua
@@ -123,7 +123,7 @@ describe("[AWS Lambda] aws-gateway input", function()
           requestId = "1234567890",
           requestTime = date(1662436514):fmt("%d/%b/%Y:%H:%M:%S %z"),
           requestTimeEpoch = 1662436514 * 1000,
-          resourcePath = "/123/strip/more",
+          resourcePath = "/(?<version>\\d+)/strip",
         }
       }, out)
   end)
@@ -196,7 +196,7 @@ describe("[AWS Lambda] aws-gateway input", function()
           requestId = "1234567890",
           requestTime = date(1662436514):fmt("%d/%b/%Y:%H:%M:%S %z"),
           requestTimeEpoch = 1662436514 * 1000,
-          resourcePath = "/plain/strip/more",
+          resourcePath = "/plain/strip",
         }
       }, out)
   end)
@@ -273,7 +273,7 @@ describe("[AWS Lambda] aws-gateway input", function()
           requestId = "1234567890",
           requestTime = date(1662436514):fmt("%d/%b/%Y:%H:%M:%S %z"),
           requestTimeEpoch = 1662436514 * 1000,
-          resourcePath = "/plain/strip/more",
+          resourcePath = [[http.method == "GET" && http.path ~ "^/plain/strip/.*"]],
         }
       }, out)
   end)
@@ -357,7 +357,7 @@ describe("[AWS Lambda] aws-gateway input", function()
             requestId = "1234567890",
             requestTime = date(1662436514):fmt("%d/%b/%Y:%H:%M:%S %z"),
             requestTimeEpoch = 1662436514 * 1000,
-            resourcePath = "/plain/strip/more",
+            resourcePath = "/plain/strip",
           }
         }, out)
       end)

--- a/spec/03-plugins/27-aws-lambda/99-access_spec.lua
+++ b/spec/03-plugins/27-aws-lambda/99-access_spec.lua
@@ -1188,30 +1188,6 @@ for _, strategy in helpers.each_strategy() do
     local admin_client
 
     lazy_setup(function()
-      -- local bp = helpers.get_db_utils(strategy, {
-      --   "routes",
-      --   "services",
-      --   "plugins",
-      -- }, { "aws-lambda" })
-
-      -- local route24 = bp.routes:insert {
-      --   expression = [[http.host == "lambda24.com" && http.path == "/"]],
-      --   protocols   = { "http", "https" },
-      --   service     = null,
-      -- }
-
-      -- bp.plugins:insert {
-      --   name     = "aws-lambda",
-      --   route    = { id = route24.id },
-      --   config   = {
-      --     port          = 10001,
-      --     aws_key       = "mock-key",
-      --     aws_secret    = "mock-secret",
-      --     aws_region    = "us-east-1",
-      --     function_name = "kongLambdaTest",
-      --     awsgateway_compatible = true,
-      --   },
-      -- }
       fixtures.dns_mock:A({
         name = "custom.lambda.endpoint",
         address = "127.0.0.1",


### PR DESCRIPTION
This PR fixes the problem that the `resource` field is missing when using the aws-lambda plugin with 3.0's new ATC router.

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

The `awsgateway_compatible` config field in the aws-lambda plugin provides a way to wrap lambda request content to make it looks like AWS API gateway request. One field in this "compatible" request content, named `resource`, is used to store the resource identifier content. Currently, the value of the `resource` field equals to `ngx.ctx.router_matches.uri`, which is the value of the matched route entity's path/path regex.

When using the ATC router, the `ngx.ctx.router_matches.uri` is not set(and of course, cannot be provided by the new router because it uses expression grammars instead of simple path or path regex), which causes the absence of this `resource` field in the Lambda's request input.

This PR fixes this issue by checking the presence of `ctx.route.expression` and taking it as the resource identifier if it exists. If not then the resource identifier value falls back to `ctx.router_matches.uri`.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

Fix [FTI-4598](https://konghq.atlassian.net/browse/FTI-4598)


[FTI-4598]: https://konghq.atlassian.net/browse/FTI-4598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ