### PR TITLE
build(release): cache only for pull_request

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ env:
   FULL_RELEASE: ${{ github.event_name == 'schedule' || github.event.inputs.official == true }}
 
   # only for pr and push
-  GHA_CACHE: ${{ github.event_name == 'push' || github.event_name == 'pull_request' }}
+  GHA_CACHE: false
 
   HAS_ACCESS_TO_GITHUB_TOKEN: ${{ github.repository_owner == 'Kong' }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,8 @@ env:
   # FULL_RELEASE: true
   FULL_RELEASE: ${{ github.event_name == 'schedule' || github.event.inputs.official == true }}
 
-  # only for pr and push
-  GHA_CACHE: false
+  # only for pr
+  GHA_CACHE: ${{ github.event_name == 'pull_request' }}
 
   HAS_ACCESS_TO_GITHUB_TOKEN: ${{ github.repository_owner == 'Kong' }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
 
     - name: Cache OpenResty
       id: cache-deps
-      if: env.GHA_CACHE == true
+      if: env.GHA_CACHE == 'true'
       uses: actions/cache@v3
       with:
         path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
 
     - name: Cache OpenResty
       id: cache-deps
-      if: env.GHA_CACHE
+      if: env.GHA_CACHE == true
       uses: actions/cache@v3
       with:
         path: |


### PR DESCRIPTION
### Summary

Only enable the GitHub Actions cache for OpenResty when the trigger event is `pull_request`, otherwise Kong Manager artifact will always be cached since the `nightly` tag is used and never updated in the `.requirements` file.