### PR TITLE
chore(deps): remove `luasec`

### DIFF
--- a/kong-3.2.0-0.rockspec
+++ b/kong-3.2.0-0.rockspec
@@ -13,7 +13,6 @@ description = {
 }
 dependencies = {
   "inspect == 3.1.3",
-  "luasec == 1.2.0",
   "luasocket == 3.0-rc1",
   "penlight == 1.13.1",
   "lua-resty-http ~> 0.17",


### PR DESCRIPTION
### Summary

`luasec` library was being used in the CI tests to serve HTTPS requests, but it was replaced by FFI-based SSL helper via #8534. 

It's remained because of KBT #8587. However, `luasec` is no longer not needed in the new build workflow.