### PR TITLE
fix(plugins/datadog):  add return value for log function in batch queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,8 @@
   the configuration hash is incorrectly set to the value: `00000000000000000000000000000000`.
   [#9911](https://github.com/Kong/kong/pull/9911)
 
+- **Datadog**: Fix a bug that the batch queue in datadog can't get the right result when processing batch entries produced by datadog.
+
 ### Dependencies
 
 - Bumped luarocks from 3.9.1 to 3.9.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,14 +103,14 @@
   [#9877](https://github.com/Kong/kong/pull/9877)
 - **JWT**: Deny requests that have different tokens in the jwt token search locations. Thanks Jackson 'Che-Chun' Kuo from Latacora for reporting this issue.
   [#9946](https://github.com/Kong/kong/pull/9946)
+- **Datadog**: Fix a bug that the batch queue in datadog can't get the right result when processing batch entries produced by datadog.
+  [#10044](https://github.com/Kong/kong/pull/10044)
 
 #### Core
 
 - Fix an issue where after a valid declarative configuration is loaded,
   the configuration hash is incorrectly set to the value: `00000000000000000000000000000000`.
   [#9911](https://github.com/Kong/kong/pull/9911)
-
-- **Datadog**: Fix a bug that the batch queue in datadog can't get the right result when processing batch entries produced by datadog.
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,7 @@
   [#9877](https://github.com/Kong/kong/pull/9877)
 - **JWT**: Deny requests that have different tokens in the jwt token search locations. Thanks Jackson 'Che-Chun' Kuo from Latacora for reporting this issue.
   [#9946](https://github.com/Kong/kong/pull/9946)
-- **Datadog**: Fix a bug that the batch queue in datadog can't get the right result when processing batch entries produced by datadog.
+- **Datadog**: Fix a bug in the Datadog plugin batch queue processing where metrics are published multiple times.
   [#10044](https://github.com/Kong/kong/pull/10044)
 
 #### Core

--- a/kong/plugins/datadog/handler.lua
+++ b/kong/plugins/datadog/handler.lua
@@ -57,7 +57,7 @@ local function log(conf, messages)
   local logger, err = statsd_logger:new(conf)
   if err then
     kong.log.err("failed to create Statsd logger: ", err)
-    return
+    return false, err
   end
 
   for _, message in ipairs(messages) do
@@ -103,6 +103,7 @@ local function log(conf, messages)
   end
 
   logger:close_socket()
+  return true
 end
 
 

--- a/spec/03-plugins/08-datadog/01-log_spec.lua
+++ b/spec/03-plugins/08-datadog/01-log_spec.lua
@@ -399,6 +399,25 @@ for _, strategy in helpers.each_strategy() do
       assert.contains("kong.kong_latency:%d*|ms|#name:dd7,status:200,consumer:bar,app:kong", gauges, true)
     end)
 
+    -- the purpose of this test case is to test the batch queue 
+    -- finish processing messages in one time(no retries)
+    it("no more messages than expected", function()
+      local thread = helpers.udp_server(9999, 10, 10)
+
+      local res = assert(proxy_client:send {
+        method  = "GET",
+        path    = "/status/200?apikey=kong",
+        headers = {
+          ["Host"] = "datadog7.com"
+        }
+      })
+      assert.res_status(200, res)
+
+      local ok, gauges = thread:join()
+      assert.True(ok)
+      assert.equal(6, #gauges)
+    end)
+
     it("should not return a runtime error (regression)", function()
       local thread = helpers.udp_server(9999, 1, 1)
 
@@ -423,25 +442,6 @@ for _, strategy in helpers.each_strategy() do
       })
 
       thread:join()
-    end)
-
-    -- the purpose of this test case is to test the batch queue 
-    -- finish processing messages in one time(no retries)
-    it("no more messages than expected", function()
-      local thread = helpers.udp_server(9999, 10, 10)
-
-      local res = assert(proxy_client:send {
-        method  = "GET",
-        path    = "/status/200?apikey=kong",
-        headers = {
-          ["Host"] = "datadog7.com"
-        }
-      })
-      assert.res_status(200, res)
-
-      local ok, gauges = thread:join()
-      assert.True(ok)
-      assert.equal(6, #gauges)
     end)
   end)
 end

--- a/spec/03-plugins/08-datadog/01-log_spec.lua
+++ b/spec/03-plugins/08-datadog/01-log_spec.lua
@@ -424,5 +424,24 @@ for _, strategy in helpers.each_strategy() do
 
       thread:join()
     end)
+
+    -- the purpose of this test case is to test the batch queue 
+    -- finish processing messages in one time(no retries)
+    it("no more messages than expected", function()
+      local thread = helpers.udp_server(9999, 10, 10)
+
+      local res = assert(proxy_client:send {
+        method  = "GET",
+        path    = "/status/200?apikey=kong",
+        headers = {
+          ["Host"] = "datadog7.com"
+        }
+      })
+      assert.res_status(200, res)
+
+      local ok, gauges = thread:join()
+      assert.True(ok)
+      assert.equal(6, #gauges)
+    end)
   end)
 end


### PR DESCRIPTION
### Summary

fix(plugins/datadog): The log function in datadog is called in batch queue when a batch is scheduled to be processed, and batch queue relys on the return value of the process it holds. The return value of log function in datadog always return nil, this makes batch queue consider the result of processing is failed. In this pr, a return value is added to fix this bug.

### Checklist

- [ ] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Issue reference

FTI-4645


[FTI-4645]: https://konghq.atlassian.net/browse/FTI-4645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ