### PR TITLE
style(core/balancer): use `table.new` to pre-create try table

### DIFF
--- a/kong/init.lua
+++ b/kong/init.lua
@@ -87,6 +87,7 @@ local plugin_servers = require "kong.runloop.plugin_servers"
 local lmdb_txn = require "resty.lmdb.transaction"
 local instrumentation = require "kong.tracing.instrumentation"
 local tablepool = require "tablepool"
+local table_new = require "table.new"
 local get_ctx_table = require("resty.core.ctx").get_ctx_table
 
 
@@ -1061,7 +1062,7 @@ function Kong.balancer()
   local balancer_data = ctx.balancer_data
   local tries = balancer_data.tries
   local try_count = balancer_data.try_count
-  local current_try = {}
+  local current_try = table_new(0, 4)
 
   try_count = try_count + 1
   balancer_data.try_count = try_count


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

`current_try` is a small table, which has four fields:

* `balancer_start`
* `balancer_latency`
* `ip`
* `port`

But if the balancer retries, it will have another two fields: `state` and `code`.

In this PR I create a table with 4 fields, should we change it to 6？

