### PR TITLE
fix(core): response phase skips header.before

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,8 @@
   the configuration hash is incorrectly set to the value: `00000000000000000000000000000000`.
   [#9911](https://github.com/Kong/kong/pull/9911)
   [#10046](https://github.com/Kong/kong/pull/10046)
+- Fix an issue where 'X-Kong-Upstream-Status' cannot be emitted when response is buffered.
+  [#10056](https://github.com/Kong/kong/pull/10056)
 
 #### Plugins
 

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1430,7 +1430,8 @@ return {
 
       local upstream_status_header = constants.HEADERS.UPSTREAM_STATUS
       if kong.configuration.enabled_headers[upstream_status_header] then
-        header[upstream_status_header] = tonumber(sub(var.upstream_status or "", -3))
+        local upstream_status = ctx.buffered_status or tonumber(sub(var.upstream_status or "", -3))
+        header[upstream_status_header] = tostring(upstream_status)
         if not header[upstream_status_header] then
           log(ERR, "failed to set ", upstream_status_header, " header")
         end

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1431,7 +1431,7 @@ return {
       local upstream_status_header = constants.HEADERS.UPSTREAM_STATUS
       if kong.configuration.enabled_headers[upstream_status_header] then
         local upstream_status = ctx.buffered_status or tonumber(sub(var.upstream_status or "", -3))
-        header[upstream_status_header] = tostring(upstream_status)
+        header[upstream_status_header] = upstream_status
         if not header[upstream_status_header] then
           log(ERR, "failed to set ", upstream_status_header, " header")
         end

--- a/spec/02-integration/05-proxy/15-upstream-status-header_spec.lua
+++ b/spec/02-integration/05-proxy/15-upstream-status-header_spec.lua
@@ -130,13 +130,17 @@ describe(constants.HEADERS.UPSTREAM_STATUS .. " header", function()
     end)
   end)
 
-  describe("is injected with configuration [headers=X-Kong-Upstream-Status]", function()
+  for _, buffered in ipairs{false, true} do
+  describe("is injected with configuration [headers=X-Kong-Upstream-Status]" ..
+           (buffered and "(buffered)" or ""), function()
     lazy_setup(function()
       setup_db()
 
       assert(helpers.start_kong {
         nginx_conf = "spec/fixtures/custom_nginx.template",
         headers = "X-Kong-Upstream-Status",
+        -- to see if the header is injected when response is buffered
+        plugins = buffered and "bundled,response-phase,dummy,key-auth",
       })
     end)
 
@@ -161,6 +165,7 @@ describe(constants.HEADERS.UPSTREAM_STATUS .. " header", function()
       assert("200", res.headers[constants.HEADERS.UPSTREAM_STATUS])
     end)
   end)
+  end
 
   describe("short-circuited requests", function()
     lazy_setup(function()

--- a/spec/02-integration/05-proxy/15-upstream-status-header_spec.lua
+++ b/spec/02-integration/05-proxy/15-upstream-status-header_spec.lua
@@ -46,6 +46,8 @@ local function setup_db()
     name = "key-auth",
     route = { id = route3.id },
   }
+
+  return bp
 end
 
 
@@ -134,7 +136,13 @@ describe(constants.HEADERS.UPSTREAM_STATUS .. " header", function()
   describe("is injected with configuration [headers=X-Kong-Upstream-Status]" ..
            (buffered and "(buffered)" or ""), function()
     lazy_setup(function()
-      setup_db()
+      local db = setup_db()
+
+      db.plugins:insert {
+        name = "response-phase",
+        config = {
+        }
+      }
 
       assert(helpers.start_kong {
         nginx_conf = "spec/fixtures/custom_nginx.template",

--- a/spec/02-integration/05-proxy/15-upstream-status-header_spec.lua
+++ b/spec/02-integration/05-proxy/15-upstream-status-header_spec.lua
@@ -8,6 +8,8 @@ local function setup_db()
     "services",
     "plugins",
     "keyauth_credentials",
+  }, {
+    "response-phase",
   })
 
   local service = bp.services:insert {

--- a/spec/02-integration/05-proxy/15-upstream-status-header_spec.lua
+++ b/spec/02-integration/05-proxy/15-upstream-status-header_spec.lua
@@ -138,11 +138,13 @@ describe(constants.HEADERS.UPSTREAM_STATUS .. " header", function()
     lazy_setup(function()
       local db = setup_db()
 
-      db.plugins:insert {
-        name = "response-phase",
-        config = {
+      if buffered then
+        db.plugins:insert {
+          name = "response-phase",
+          config = {
+          }
         }
-      }
+      end
 
       assert(helpers.start_kong {
         nginx_conf = "spec/fixtures/custom_nginx.template",

--- a/spec/fixtures/custom_plugins/kong/plugins/response-phase/handler.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/response-phase/handler.lua
@@ -1,0 +1,16 @@
+local kong_meta = require "kong.meta"
+
+local resp_phase = {}
+
+
+resp_phase.PRIORITY = 950
+resp_phase.VERSION = kong_meta.version
+
+
+function resp_phase:access()
+end
+
+function resp_phase:response()
+end
+
+return resp_phase

--- a/spec/fixtures/custom_plugins/kong/plugins/response-phase/schema.lua
+++ b/spec/fixtures/custom_plugins/kong/plugins/response-phase/schema.lua
@@ -1,0 +1,11 @@
+return {
+  name = "response-phase",
+  fields = {
+    { config = {
+        type = "record",
+        fields = {
+        },
+      }
+    }
+  },
+}


### PR DESCRIPTION
This causes some of the header handlings to be skipped.

Full changelog:

`runloop.lua`: moving the header phase before and after handlers and changing the way to get status in before handler
`init.lua`: adjust the ordering of handlers and set status (send headers).

Fix #10031

