### PR TITLE
chore(release): skip login to docker if no access to github token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,7 @@ env:
   # only for pr
   GHA_CACHE: ${{ github.event_name == 'pull_request' }}
 
-  HAS_ACCESS_TO_GITHUB_TOKEN: 'false'
-  # HAS_ACCESS_TO_GITHUB_TOKEN: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
+  HAS_ACCESS_TO_GITHUB_TOKEN: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
 
 jobs:
   metadata:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,8 @@ env:
   # only for pr
   GHA_CACHE: ${{ github.event_name == 'pull_request' }}
 
-  HAS_ACCESS_TO_GITHUB_TOKEN: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
+  HAS_ACCESS_TO_GITHUB_TOKEN: 'false'
+  # HAS_ACCESS_TO_GITHUB_TOKEN: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
 
 jobs:
   metadata:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,7 +230,7 @@ jobs:
         path: bazel-bin/pkg
 
     - name: Login to Docker Hub
-      if: ${{ env.HAS_ACCESS_TO_GITHUB_TOKEN }}
+      if: ${{ env.HAS_ACCESS_TO_GITHUB_TOKEN == 'true' }}
       uses: docker/login-action@bc135a1993a1d0db3e9debefa0cfcb70443cc94c
       with:
         username: ${{ secrets.GHA_DOCKERHUB_PUSH_USER }}
@@ -250,7 +250,7 @@ jobs:
       with:
         file: build/dockerfiles/${{ matrix.package }}.Dockerfile
         context: .
-        push: ${{ env.HAS_ACCESS_TO_GITHUB_TOKEN }}
+        push: ${{ env.HAS_ACCESS_TO_GITHUB_TOKEN == 'true' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |


### PR DESCRIPTION
Skip login to Docker Hub in GitHub Actions if the author has no access to GitHub Token.
Follow-up PR for https://github.com/Kong/kong/pull/10029.

Fix failing CI: https://github.com/Kong/kong/actions/runs/3835570305/jobs/6528976375