### PR TITLE
fix(clustering): restore json websocket protocol (#9921)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,16 @@
 - [0.9.9 and prior](#099---20170202)
 
 
+## Unreleased
+
+### Fixed
+
+#### Hybrid Mode
+
+- Revert the removal of WebSocket protocol support for configuration sync.
+  [#9921](https://github.com/Kong/kong/pull/9921)
+
+
 ## [3.1.1]
 
 > Released 2022/12/09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,16 +67,6 @@
 - [0.9.9 and prior](#099---20170202)
 
 
-## Unreleased
-
-### Fixes
-
-#### Hybrid Mode
-
-- Revert the removal of WebSocket protocol support for configuration sync.
-  [#10067](https://github.com/Kong/kong/pull/10067)
-
-
 ## [3.1.1]
 
 > Released 2022/12/09
@@ -90,6 +80,12 @@ under certain circumstances.
 
 - Bumped `atc-router` to `1.0.2` to address the potential worker crash issue.
   [#9927](https://github.com/Kong/kong/pull/9927)
+
+#### Hybrid Mode
+
+- Revert the removal of WebSocket protocol support for configuration sync.
+  [#10067](https://github.com/Kong/kong/pull/10067)
+
 
 [Back to TOC](#table-of-contents)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,12 +69,12 @@
 
 ## Unreleased
 
-### Fixed
+### Fixes
 
 #### Hybrid Mode
 
 - Revert the removal of WebSocket protocol support for configuration sync.
-  [#9921](https://github.com/Kong/kong/pull/9921)
+  [#10067](https://github.com/Kong/kong/pull/10067)
 
 
 ## [3.1.1]

--- a/kong-3.1.1-0.rockspec
+++ b/kong-3.1.1-0.rockspec
@@ -70,6 +70,8 @@ build = {
     ["kong.conf_loader.listeners"] = "kong/conf_loader/listeners.lua",
 
     ["kong.clustering"] = "kong/clustering/init.lua",
+    ["kong.clustering.data_plane"] = "kong/clustering/data_plane.lua",
+    ["kong.clustering.control_plane"] = "kong/clustering/control_plane.lua",
     ["kong.clustering.wrpc_data_plane"] = "kong/clustering/wrpc_data_plane.lua",
     ["kong.clustering.wrpc_control_plane"] = "kong/clustering/wrpc_control_plane.lua",
     ["kong.clustering.utils"] = "kong/clustering/utils.lua",

--- a/kong/clustering/compat/init.lua
+++ b/kong/clustering/compat/init.lua
@@ -1,3 +1,4 @@
+local cjson = require("cjson.safe")
 local constants = require("kong.constants")
 local meta = require("kong.meta")
 local version = require("kong.clustering.compat.version")
@@ -10,6 +11,8 @@ local table_sort = table.sort
 local gsub = string.gsub
 local deep_copy = utils.deep_copy
 local split = utils.split
+local deflate_gzip = utils.deflate_gzip
+local cjson_encode = cjson.encode
 
 local ngx = ngx
 local ngx_log = ngx.log
@@ -310,8 +313,8 @@ end
 
 
 -- returns has_update, modified_config_table
-function _M.update_compatible_payload(config_table, dp_version, log_suffix)
-  local cp_version_num = version_num(meta.version)
+function _M.wrpc_update_compatible_payload(config_table, dp_version, log_suffix)
+  local cp_version_num = version_num(KONG_VERSION)
   local dp_version_num = version_num(dp_version)
   local has_update
 
@@ -350,6 +353,58 @@ function _M.update_compatible_payload(config_table, dp_version, log_suffix)
   end
 
   return false
+end
+
+
+-- returns has_update, modified_deflated_payload, err
+function _M.update_compatible_payload(payload, dp_version, log_suffix)
+  local cp_version_num = version_num(KONG_VERSION)
+  local dp_version_num = version_num(dp_version)
+
+  -- if the CP and DP have the same version, avoid the payload
+  -- copy and compatibility updates
+  if cp_version_num == dp_version_num then
+    return false
+  end
+
+  local has_update
+  payload = deep_copy(payload, false)
+  local config_table = payload["config_table"]
+
+  local fields = get_removed_fields(dp_version_num)
+  if fields then
+    if invalidate_keys_from_config(config_table["plugins"], fields, log_suffix) then
+      has_update = true
+    end
+  end
+
+  if dp_version_num < 3001000000 --[[ 3.1.0.0 ]] then
+    local config_upstream = config_table["upstreams"]
+    if config_upstream then
+      for _, t in ipairs(config_upstream) do
+        if t["use_srv_name"] ~= nil then
+          ngx_log(ngx_WARN, _log_prefix, "Kong Gateway v" .. KONG_VERSION ..
+                  " contains configuration 'upstream.use_srv_name'",
+                  " which is incompatible with dataplane version " .. dp_version .. " and will",
+                  " be removed.", log_suffix)
+          t["use_srv_name"] = nil
+          has_update = true
+        end
+      end
+    end
+  end
+
+  if has_update then
+    local deflated_payload, err = deflate_gzip(cjson_encode(payload))
+    if deflated_payload then
+      return true, deflated_payload
+
+    else
+      return true, nil, err
+    end
+  end
+
+  return false, nil, nil
 end
 
 

--- a/kong/clustering/compat/version.lua
+++ b/kong/clustering/compat/version.lua
@@ -1,5 +1,6 @@
 local utils = require("kong.tools.utils")
 
+local type = type
 local tonumber = tonumber
 local split = utils.split
 

--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -1,0 +1,534 @@
+local _M = {}
+local _MT = { __index = _M, }
+
+
+local semaphore = require("ngx.semaphore")
+local cjson = require("cjson.safe")
+local declarative = require("kong.db.declarative")
+local utils = require("kong.tools.utils")
+local clustering_utils = require("kong.clustering.utils")
+local compat = require("kong.clustering.compat")
+local constants = require("kong.constants")
+local events = require("kong.clustering.events")
+local calculate_config_hash = require("kong.clustering.config_helper").calculate_config_hash
+
+
+local string = string
+local setmetatable = setmetatable
+local type = type
+local pcall = pcall
+local pairs = pairs
+local ngx = ngx
+local ngx_log = ngx.log
+local timer_at = ngx.timer.at
+local cjson_decode = cjson.decode
+local cjson_encode = cjson.encode
+local kong = kong
+local ngx_exit = ngx.exit
+local exiting = ngx.worker.exiting
+local worker_id = ngx.worker.id
+local ngx_time = ngx.time
+local ngx_now = ngx.now
+local ngx_update_time = ngx.update_time
+local ngx_var = ngx.var
+local table_insert = table.insert
+local table_remove = table.remove
+local sub = string.sub
+local isempty = require("table.isempty")
+local sleep = ngx.sleep
+
+
+local plugins_list_to_map = compat.plugins_list_to_map
+local update_compatible_payload = compat.update_compatible_payload
+local deflate_gzip = utils.deflate_gzip
+local yield = utils.yield
+
+
+local kong_dict = ngx.shared.kong
+local ngx_DEBUG = ngx.DEBUG
+local ngx_NOTICE = ngx.NOTICE
+local ngx_WARN = ngx.WARN
+local ngx_ERR = ngx.ERR
+local ngx_OK = ngx.OK
+local ngx_ERROR = ngx.ERROR
+local ngx_CLOSE = ngx.HTTP_CLOSE
+local PING_INTERVAL = constants.CLUSTERING_PING_INTERVAL
+local PING_WAIT = PING_INTERVAL * 1.5
+local CLUSTERING_SYNC_STATUS = constants.CLUSTERING_SYNC_STATUS
+local DECLARATIVE_EMPTY_CONFIG_HASH = constants.DECLARATIVE_EMPTY_CONFIG_HASH
+local PONG_TYPE = "PONG"
+local RECONFIGURE_TYPE = "RECONFIGURE"
+local _log_prefix = "[clustering] "
+
+
+local function handle_export_deflated_reconfigure_payload(self)
+  ngx_log(ngx_DEBUG, _log_prefix, "exporting config")
+
+  local ok, p_err, err = pcall(self.export_deflated_reconfigure_payload, self)
+  return ok, p_err or err
+end
+
+
+local function is_timeout(err)
+  return err and sub(err, -7) == "timeout"
+end
+
+
+function _M.new(conf, cert_digest)
+  local self = {
+    clients = setmetatable({}, { __mode = "k", }),
+    plugins_map = {},
+
+    conf = conf,
+    cert_digest = cert_digest,
+  }
+
+  return setmetatable(self, _MT)
+end
+
+
+function _M:export_deflated_reconfigure_payload()
+  local config_table, err = declarative.export_config()
+  if not config_table then
+    return nil, err
+  end
+
+  -- update plugins map
+  self.plugins_configured = {}
+  if config_table.plugins then
+    for _, plugin in pairs(config_table.plugins) do
+      self.plugins_configured[plugin.name] = true
+    end
+  end
+
+  -- store serialized plugins map for troubleshooting purposes
+  local shm_key_name = "clustering:cp_plugins_configured:worker_" .. worker_id()
+  kong_dict:set(shm_key_name, cjson_encode(self.plugins_configured))
+  ngx_log(ngx_DEBUG, "plugin configuration map key: " .. shm_key_name .. " configuration: ", kong_dict:get(shm_key_name))
+
+  local config_hash, hashes = calculate_config_hash(config_table)
+
+  local payload = {
+    type = "reconfigure",
+    timestamp = ngx_now(),
+    config_table = config_table,
+    config_hash = config_hash,
+    hashes = hashes,
+  }
+
+  self.reconfigure_payload = payload
+
+  payload, err = cjson_encode(payload)
+  if not payload then
+    return nil, err
+  end
+
+  yield()
+
+  payload, err = deflate_gzip(payload)
+  if not payload then
+    return nil, err
+  end
+
+  yield()
+
+  self.current_hashes = hashes
+  self.current_config_hash = config_hash
+  self.deflated_reconfigure_payload = payload
+
+  return payload, nil, config_hash
+end
+
+
+function _M:push_config()
+  local start = ngx_now()
+
+  local payload, err = self:export_deflated_reconfigure_payload()
+  if not payload then
+    ngx_log(ngx_ERR, _log_prefix, "unable to export config from database: ", err)
+    return
+  end
+
+  local n = 0
+  for _, queue in pairs(self.clients) do
+    table_insert(queue, RECONFIGURE_TYPE)
+    queue.post()
+    n = n + 1
+  end
+
+  ngx_update_time()
+  local duration = ngx_now() - start
+  ngx_log(ngx_DEBUG, _log_prefix, "config pushed to ", n, " data-plane nodes in " .. duration .. " seconds")
+end
+
+
+_M.check_version_compatibility = compat.check_version_compatibility
+_M.check_configuration_compatibility = compat.check_configuration_compatibility
+
+
+function _M:handle_cp_websocket()
+  local dp_id = ngx_var.arg_node_id
+  local dp_hostname = ngx_var.arg_node_hostname
+  local dp_ip = ngx_var.remote_addr
+  local dp_version = ngx_var.arg_node_version
+
+  local wb, log_suffix, ec = clustering_utils.connect_dp(
+                                self.conf, self.cert_digest,
+                                dp_id, dp_hostname, dp_ip, dp_version)
+  if not wb then
+    return ngx_exit(ec)
+  end
+
+  -- connection established
+  -- receive basic info
+  local data, typ, err
+  data, typ, err = wb:recv_frame()
+  if err then
+    err = "failed to receive websocket basic info frame: " .. err
+
+  elseif typ == "binary" then
+    if not data then
+      err = "failed to receive websocket basic info data"
+
+    else
+      data, err = cjson_decode(data)
+      if type(data) ~= "table" then
+        if err then
+          err = "failed to decode websocket basic info data: " .. err
+        else
+          err = "failed to decode websocket basic info data"
+        end
+
+      else
+        if data.type ~= "basic_info" then
+          err =  "invalid basic info data type: " .. (data.type  or "unknown")
+
+        else
+          if type(data.plugins) ~= "table" then
+            err =  "missing plugins in basic info data"
+          end
+        end
+      end
+    end
+  end
+
+  if err then
+    ngx_log(ngx_ERR, _log_prefix, err, log_suffix)
+    wb:send_close()
+    return ngx_exit(ngx_CLOSE)
+  end
+
+  local dp_plugins_map = plugins_list_to_map(data.plugins)
+  local config_hash = DECLARATIVE_EMPTY_CONFIG_HASH -- initial hash
+  local last_seen = ngx_time()
+  local sync_status = CLUSTERING_SYNC_STATUS.UNKNOWN
+  local purge_delay = self.conf.cluster_data_plane_purge_delay
+  local update_sync_status = function()
+    local ok
+    ok, err = kong.db.clustering_data_planes:upsert({ id = dp_id, }, {
+      last_seen = last_seen,
+      config_hash = config_hash ~= "" and config_hash or nil,
+      hostname = dp_hostname,
+      ip = dp_ip,
+      version = dp_version,
+      sync_status = sync_status, -- TODO: import may have been failed though
+    }, { ttl = purge_delay })
+    if not ok then
+      ngx_log(ngx_ERR, _log_prefix, "unable to update clustering data plane status: ", err, log_suffix)
+    end
+  end
+
+  local _
+  _, err, sync_status = self:check_version_compatibility({
+    dp_version = dp_version,
+    dp_plugins_map = dp_plugins_map,
+    log_suffix = log_suffix,
+  })
+  if err then
+    ngx_log(ngx_ERR, _log_prefix, err, log_suffix)
+    wb:send_close()
+    update_sync_status()
+    return ngx_exit(ngx_CLOSE)
+  end
+
+  ngx_log(ngx_DEBUG, _log_prefix, "data plane connected", log_suffix)
+
+  local queue
+  do
+    local queue_semaphore = semaphore.new()
+    queue = {
+      wait = function(...)
+        return queue_semaphore:wait(...)
+      end,
+      post = function(...)
+        return queue_semaphore:post(...)
+      end
+    }
+  end
+
+  -- if clients table is empty, we might have skipped some config
+  -- push event in `push_config_loop`, which means the cached config
+  -- might be stale, so we always export the latest config again in this case
+  if isempty(self.clients) or not self.deflated_reconfigure_payload then
+    _, err = handle_export_deflated_reconfigure_payload(self)
+  end
+
+  self.clients[wb] = queue
+
+  if self.deflated_reconfigure_payload then
+    local _
+    -- initial configuration compatibility for sync status variable
+    _, _, sync_status = self:check_configuration_compatibility(
+                              { dp_plugins_map = dp_plugins_map, })
+
+    table_insert(queue, RECONFIGURE_TYPE)
+    queue.post()
+
+  else
+    ngx_log(ngx_ERR, _log_prefix, "unable to send initial configuration to data plane: ", err, log_suffix)
+  end
+
+  -- how control plane connection management works:
+  -- two threads are spawned, when any of these threads exits,
+  -- it means a fatal error has occurred on the connection,
+  -- and the other thread is also killed
+  --
+  -- * read_thread: it is the only thread that receives websocket frames from the
+  --                data plane and records the current data plane status in the
+  --                database, and is also responsible for handling timeout detection
+  -- * write_thread: it is the only thread that sends websocket frames to the data plane
+  --                 by grabbing any messages currently in the send queue and
+  --                 send them to the data plane in a FIFO order. Notice that the
+  --                 PONG frames are also sent by this thread after they are
+  --                 queued by the read_thread
+
+  local read_thread = ngx.thread.spawn(function()
+    while not exiting() do
+      local data, typ, err = wb:recv_frame()
+
+      if exiting() then
+        return
+      end
+
+      if err then
+        if not is_timeout(err) then
+          return nil, err
+        end
+
+        local waited = ngx_time() - last_seen
+        if waited > PING_WAIT then
+          return nil, "did not receive ping frame from data plane within " ..
+                      PING_WAIT .. " seconds"
+        end
+
+      else
+        if typ == "close" then
+          ngx_log(ngx_DEBUG, _log_prefix, "received close frame from data plane", log_suffix)
+          return
+        end
+
+        if not data then
+          return nil, "did not receive ping frame from data plane"
+        end
+
+        -- dps only send pings
+        if typ ~= "ping" then
+          return nil, "invalid websocket frame received from data plane: " .. typ
+        end
+
+        ngx_log(ngx_DEBUG, _log_prefix, "received ping frame from data plane", log_suffix)
+
+        config_hash = data
+        last_seen = ngx_time()
+        update_sync_status()
+
+        -- queue PONG to avoid races
+        table_insert(queue, PONG_TYPE)
+        queue.post()
+      end
+    end
+  end)
+
+  local write_thread = ngx.thread.spawn(function()
+    while not exiting() do
+      local ok, err = queue.wait(5)
+      if exiting() then
+        return
+      end
+      if ok then
+        local payload = table_remove(queue, 1)
+        if not payload then
+          return nil, "config queue can not be empty after semaphore returns"
+        end
+
+        if payload == PONG_TYPE then
+          local _, err = wb:send_pong()
+          if err then
+            if not is_timeout(err) then
+              return nil, "failed to send pong frame to data plane: " .. err
+            end
+
+            ngx_log(ngx_NOTICE, _log_prefix, "failed to send pong frame to data plane: ", err, log_suffix)
+
+          else
+            ngx_log(ngx_DEBUG, _log_prefix, "sent pong frame to data plane", log_suffix)
+          end
+
+        else -- is reconfigure
+          local previous_sync_status = sync_status
+          ok, err, sync_status = self:check_configuration_compatibility(
+                                    { dp_plugins_map = dp_plugins_map, })
+          if ok then
+            local has_update, deflated_payload, err = update_compatible_payload(self.reconfigure_payload, dp_version, log_suffix)
+            if not has_update then -- no modification, use the cached payload
+              deflated_payload = self.deflated_reconfigure_payload
+            elseif err then
+              ngx_log(ngx_WARN, "unable to update compatible payload: ", err, ", the unmodified config ",
+                                "is returned", log_suffix)
+              deflated_payload = self.deflated_reconfigure_payload
+            end
+
+            -- config update
+            local _, err = wb:send_binary(deflated_payload)
+            if err then
+              if not is_timeout(err) then
+                return nil, "unable to send updated configuration to data plane: " .. err
+              end
+
+              ngx_log(ngx_NOTICE, _log_prefix, "unable to send updated configuration to data plane: ", err, log_suffix)
+
+            else
+              ngx_log(ngx_DEBUG, _log_prefix, "sent config update to data plane", log_suffix)
+            end
+
+          else
+            ngx_log(ngx_WARN, _log_prefix, "unable to send updated configuration to data plane: ", err, log_suffix)
+            if sync_status ~= previous_sync_status then
+              update_sync_status()
+            end
+          end
+        end
+
+      elseif err ~= "timeout" then
+        return nil, "semaphore wait error: " .. err
+      end
+    end
+  end)
+
+  local ok, err, perr = ngx.thread.wait(write_thread, read_thread)
+
+  self.clients[wb] = nil
+
+  ngx.thread.kill(write_thread)
+  ngx.thread.kill(read_thread)
+
+  wb:send_close()
+
+  --TODO: should we update disconnect data plane status?
+  --sync_status = CLUSTERING_SYNC_STATUS.UNKNOWN
+  --update_sync_status()
+
+  if not ok then
+    ngx_log(ngx_ERR, _log_prefix, err, log_suffix)
+    return ngx_exit(ngx_ERROR)
+  end
+
+  if perr then
+    ngx_log(ngx_ERR, _log_prefix, perr, log_suffix)
+    return ngx_exit(ngx_ERROR)
+  end
+
+  return ngx_exit(ngx_OK)
+end
+
+
+local function push_config_loop(premature, self, push_config_semaphore, delay)
+  if premature then
+    return
+  end
+
+  local ok, err = handle_export_deflated_reconfigure_payload(self)
+  if not ok then
+    ngx_log(ngx_ERR, _log_prefix, "unable to export initial config from database: ", err)
+  end
+
+  while not exiting() do
+    local ok, err = push_config_semaphore:wait(1)
+    if exiting() then
+      return
+    end
+
+    if ok then
+      if isempty(self.clients) then
+        ngx_log(ngx_DEBUG, _log_prefix, "skipping config push (no connected clients)")
+        sleep(1)
+        -- re-queue the task. wait until we have clients connected
+        if push_config_semaphore:count() <= 0 then
+          push_config_semaphore:post()
+        end
+
+      else
+        ok, err = pcall(self.push_config, self)
+        if ok then
+          local sleep_left = delay
+          while sleep_left > 0 do
+            if sleep_left <= 1 then
+              ngx.sleep(sleep_left)
+              break
+            end
+
+            ngx.sleep(1)
+
+            if exiting() then
+              return
+            end
+
+            sleep_left = sleep_left - 1
+          end
+
+        else
+          ngx_log(ngx_ERR, _log_prefix, "export and pushing config failed: ", err)
+        end
+      end
+
+    elseif err ~= "timeout" then
+      ngx_log(ngx_ERR, _log_prefix, "semaphore wait error: ", err)
+    end
+  end
+end
+
+
+function _M:init_worker(plugins_list)
+  -- ROLE = "control_plane"
+  self.plugins_list = plugins_list
+  self.plugins_map = plugins_list_to_map(plugins_list)
+
+  self.deflated_reconfigure_payload = nil
+  self.reconfigure_payload = nil
+  self.plugins_configured = {}
+  self.plugin_versions = {}
+
+  for i = 1, #plugins_list do
+    local plugin = plugins_list[i]
+    self.plugin_versions[plugin.name] = plugin.version
+  end
+
+  local push_config_semaphore = semaphore.new()
+
+  -- When "clustering", "push_config" worker event is received by a worker,
+  -- it loads and pushes the config to its the connected data planes
+  events.clustering_push_config(function(_)
+    if push_config_semaphore:count() <= 0 then
+      -- the following line always executes immediately after the `if` check
+      -- because `:count` will never yield, end result is that the semaphore
+      -- count is guaranteed to not exceed 1
+      push_config_semaphore:post()
+    end
+  end)
+
+  timer_at(0, push_config_loop, self, push_config_semaphore,
+               self.conf.db_update_frequency)
+end
+
+
+return _M

--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -1,0 +1,296 @@
+local _M = {}
+local _MT = { __index = _M, }
+
+
+local semaphore = require("ngx.semaphore")
+local cjson = require("cjson.safe")
+local config_helper = require("kong.clustering.config_helper")
+local clustering_utils = require("kong.clustering.utils")
+local declarative = require("kong.db.declarative")
+local constants = require("kong.constants")
+local utils = require("kong.tools.utils")
+local pl_stringx = require("pl.stringx")
+
+
+local assert = assert
+local setmetatable = setmetatable
+local math = math
+local pcall = pcall
+local tostring = tostring
+local sub = string.sub
+local ngx = ngx
+local ngx_log = ngx.log
+local ngx_sleep = ngx.sleep
+local cjson_decode = cjson.decode
+local cjson_encode = cjson.encode
+local exiting = ngx.worker.exiting
+local ngx_time = ngx.time
+local inflate_gzip = utils.inflate_gzip
+local yield = utils.yield
+
+
+local ngx_ERR = ngx.ERR
+local ngx_INFO = ngx.INFO
+local ngx_DEBUG = ngx.DEBUG
+local ngx_WARN = ngx.WARN
+local ngx_NOTICE = ngx.NOTICE
+local PING_INTERVAL = constants.CLUSTERING_PING_INTERVAL
+local PING_WAIT = PING_INTERVAL * 1.5
+local _log_prefix = "[clustering] "
+local DECLARATIVE_EMPTY_CONFIG_HASH = constants.DECLARATIVE_EMPTY_CONFIG_HASH
+
+local endswith = pl_stringx.endswith
+
+local function is_timeout(err)
+  return err and sub(err, -7) == "timeout"
+end
+
+
+function _M.new(conf, cert, cert_key)
+  local self = {
+    declarative_config = declarative.new_config(conf),
+    conf = conf,
+    cert = cert,
+    cert_key = cert_key,
+  }
+
+  return setmetatable(self, _MT)
+end
+
+
+function _M:init_worker(plugins_list)
+  -- ROLE = "data_plane"
+
+  self.plugins_list = plugins_list
+
+  if clustering_utils.is_dp_worker_process() then
+    assert(ngx.timer.at(0, function(premature)
+      self:communicate(premature)
+    end))
+  end
+end
+
+
+local function send_ping(c, log_suffix)
+  log_suffix = log_suffix or ""
+
+  local hash = declarative.get_current_hash()
+
+  if hash == true then
+    hash = DECLARATIVE_EMPTY_CONFIG_HASH
+  end
+
+  local _, err = c:send_ping(hash)
+  if err then
+    ngx_log(is_timeout(err) and ngx_NOTICE or ngx_WARN, _log_prefix,
+            "unable to send ping frame to control plane: ", err, log_suffix)
+
+  else
+    ngx_log(ngx_DEBUG, _log_prefix, "sent ping frame to control plane", log_suffix)
+  end
+end
+
+
+function _M:communicate(premature)
+  if premature then
+    -- worker wants to exit
+    return
+  end
+
+  local conf = self.conf
+
+  local log_suffix = " [" .. conf.cluster_control_plane .. "]"
+  local reconnection_delay = math.random(5, 10)
+
+  local c, uri, err = clustering_utils.connect_cp(
+                        "/v1/outlet", conf, self.cert, self.cert_key)
+  if not c then
+    ngx_log(ngx_ERR, _log_prefix, "connection to control plane ", uri, " broken: ", err,
+                 " (retrying after ", reconnection_delay, " seconds)", log_suffix)
+
+    assert(ngx.timer.at(reconnection_delay, function(premature)
+      self:communicate(premature)
+    end))
+    return
+  end
+
+  -- connection established
+  -- first, send out the plugin list to CP so it can make decision on whether
+  -- sync will be allowed later
+  local _
+  _, err = c:send_binary(cjson_encode({ type = "basic_info",
+                                        plugins = self.plugins_list, }))
+  if err then
+    ngx_log(ngx_ERR, _log_prefix, "unable to send basic information to control plane: ", uri,
+                     " err: ", err, " (retrying after ", reconnection_delay, " seconds)", log_suffix)
+
+    c:close()
+    assert(ngx.timer.at(reconnection_delay, function(premature)
+      self:communicate(premature)
+    end))
+    return
+  end
+
+  local config_semaphore = semaphore.new(0)
+
+  -- how DP connection management works:
+  -- three threads are spawned, when any of these threads exits,
+  -- it means a fatal error has occurred on the connection,
+  -- and the other threads are also killed
+  --
+  -- * config_thread: it grabs a received declarative config and apply it
+  --                  locally. In addition, this thread also persists the
+  --                  config onto the local file system
+  -- * read_thread: it is the only thread that sends WS frames to the CP
+  --                by sending out periodic PING frames to CP that checks
+  --                for the healthiness of the WS connection. In addition,
+  --                PING messages also contains the current config hash
+  --                applied on the local Kong DP
+  -- * write_thread: it is the only thread that receives WS frames from the CP,
+  --                 and is also responsible for handling timeout detection
+
+  local ping_immediately
+  local config_exit
+  local next_data
+
+  local config_thread = ngx.thread.spawn(function()
+    while not exiting() and not config_exit do
+      local ok, err = config_semaphore:wait(1)
+      if ok then
+        local data = next_data
+        if data then
+          local msg = assert(inflate_gzip(data))
+          yield()
+          msg = assert(cjson_decode(msg))
+          yield()
+
+          if msg.type == "reconfigure" then
+            if msg.timestamp then
+              ngx_log(ngx_DEBUG, _log_prefix, "received reconfigure frame from control plane with timestamp: ",
+                                 msg.timestamp, log_suffix)
+
+            else
+              ngx_log(ngx_DEBUG, _log_prefix, "received reconfigure frame from control plane", log_suffix)
+            end
+
+            local config_table = assert(msg.config_table)
+            local pok, res
+            pok, res, err = pcall(config_helper.update, self.declarative_config,
+                                  config_table, msg.config_hash, msg.hashes)
+            if pok then
+              if not res then
+                ngx_log(ngx_ERR, _log_prefix, "unable to update running config: ", err)
+              end
+
+              ping_immediately = true
+
+            else
+              ngx_log(ngx_ERR, _log_prefix, "unable to update running config: ", res)
+            end
+
+            if next_data == data then
+              next_data = nil
+            end
+          end
+        end
+
+      elseif err ~= "timeout" then
+        ngx_log(ngx_ERR, _log_prefix, "semaphore wait error: ", err)
+      end
+    end
+  end)
+
+  local write_thread = ngx.thread.spawn(function()
+    while not exiting() do
+      send_ping(c, log_suffix)
+
+      for _ = 1, PING_INTERVAL do
+        ngx_sleep(1)
+        if exiting() then
+          return
+        end
+        if ping_immediately then
+          ping_immediately = nil
+          break
+        end
+      end
+    end
+  end)
+
+  local read_thread = ngx.thread.spawn(function()
+    local last_seen = ngx_time()
+    while not exiting() do
+      local data, typ, err = c:recv_frame()
+      if err then
+        if not is_timeout(err) then
+          return nil, "error while receiving frame from control plane: " .. err
+        end
+
+        local waited = ngx_time() - last_seen
+        if waited > PING_WAIT then
+          return nil, "did not receive pong frame from control plane within " .. PING_WAIT .. " seconds"
+        end
+
+      else
+        if typ == "close" then
+          ngx_log(ngx_DEBUG, _log_prefix, "received close frame from control plane", log_suffix)
+          return
+        end
+
+        last_seen = ngx_time()
+
+        if typ == "binary" then
+          next_data = data
+          if config_semaphore:count() <= 0 then
+            -- the following line always executes immediately after the `if` check
+            -- because `:count` will never yield, end result is that the semaphore
+            -- count is guaranteed to not exceed 1
+            config_semaphore:post()
+          end
+
+        elseif typ == "pong" then
+          ngx_log(ngx_DEBUG, _log_prefix, "received pong frame from control plane", log_suffix)
+
+        else
+          ngx_log(ngx_NOTICE, _log_prefix, "received unknown (", tostring(typ), ") frame from control plane",
+                              log_suffix)
+        end
+      end
+    end
+  end)
+
+  local ok, err, perr = ngx.thread.wait(read_thread, write_thread, config_thread)
+
+  ngx.thread.kill(read_thread)
+  ngx.thread.kill(write_thread)
+  c:close()
+
+  local err_msg = ok and err or perr
+
+  if err_msg and endswith(err_msg, ": closed") then
+    ngx_log(ngx_INFO, _log_prefix, "connection to control plane closed", log_suffix)
+
+  elseif err_msg then
+    ngx_log(ngx_ERR, _log_prefix, err_msg, log_suffix)
+  end
+
+  -- the config thread might be holding a lock if it's in the middle of an
+  -- update, so we need to give it a chance to terminate gracefully
+  config_exit = true
+
+  ok, err, perr = ngx.thread.wait(config_thread)
+  if not ok then
+    ngx_log(ngx_ERR, _log_prefix, err, log_suffix)
+
+  elseif perr then
+    ngx_log(ngx_ERR, _log_prefix, perr, log_suffix)
+  end
+
+  if not exiting() then
+    assert(ngx.timer.at(reconnection_delay, function(premature)
+      self:communicate(premature)
+    end))
+  end
+end
+
+return _M

--- a/kong/clustering/wrpc_control_plane.lua
+++ b/kong/clustering/wrpc_control_plane.lua
@@ -32,7 +32,7 @@ local isempty = require("table.isempty")
 local sleep = ngx.sleep
 
 local plugins_list_to_map = compat.plugins_list_to_map
-local update_compatible_payload = compat.update_compatible_payload
+local update_compatible_payload = compat.wrpc_update_compatible_payload
 local deflate_gzip = utils.deflate_gzip
 local yield = utils.yield
 

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -535,6 +535,7 @@ local CONF_INFERENCES = {
   untrusted_lua_sandbox_environment = { typ = "array" },
 
   legacy_worker_events = { typ = "boolean" },
+  wrpc_hybrid_protocol = { typ = "boolean" },
 
   lmdb_environment_path = { typ = "string" },
   lmdb_map_size = { typ = "string" },

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -176,6 +176,7 @@ untrusted_lua_sandbox_requires =
 untrusted_lua_sandbox_environment =
 
 legacy_worker_events = off
+wrpc_hybrid_protocol = off
 
 openresty_path =
 

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -433,12 +433,17 @@ server {
     ssl_certificate_key ${{CLUSTER_CERT_KEY}};
     ssl_session_cache   shared:ClusterSSL:10m;
 
+    location = /v1/outlet {
+        content_by_lua_block {
+            Kong.serve_cluster_listener()
+        }
+    }
+
     location = /v1/wrpc {
         content_by_lua_block {
             Kong.serve_wrpc_listener()
         }
     }
-
 }
 > end -- role == "control_plane"
 

--- a/spec/01-unit/19-hybrid/03-compat_spec.lua
+++ b/spec/01-unit/19-hybrid/03-compat_spec.lua
@@ -2,6 +2,8 @@ local compat = require("kong.clustering.compat")
 -- local ssl_fixtures = require "spec.fixtures.ssl"
 local helpers = require "spec.helpers"
 local declarative = require("kong.db.declarative")
+local inflate_gzip = require("kong.tools.utils").inflate_gzip
+local cjson_decode = require("cjson.safe").decode
 
 local function reset_fields()
   compat._set_removed_fields(require("kong.clustering.compat.removed_fields"))
@@ -130,11 +132,12 @@ describe("kong.clustering.compat", function()
     lazy_setup(function()
       test_with = function(plugins, dp_version)
         local has_update, new_conf = compat.update_compatible_payload(
-          { plugins = plugins }, dp_version, ""
+          { config_table = { plugins = plugins } }, dp_version, ""
         )
 
         if has_update then
-          return new_conf.plugins
+          new_conf = cjson_decode(inflate_gzip(new_conf))
+          return new_conf.config_table.plugins
         end
 
         return plugins
@@ -340,11 +343,13 @@ describe("kong.clustering.compat", function()
         }
       }, { _transform = true }))
 
-      config = declarative.export_config()
+      config = { config_table = declarative.export_config() }
     end)
     it(function()
       local has_update, result = compat.update_compatible_payload(config, "3.0.0", "test_")
       assert.truthy(has_update)
+      result = cjson_decode(inflate_gzip(result)).config_table
+
       local upstreams = assert(assert(assert(result).upstreams))
       assert.is_nil(assert(upstreams[1]).use_srv_name)
       assert.is_nil(assert(upstreams[2]).use_srv_name)

--- a/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/01-sync_spec.lua
@@ -12,9 +12,10 @@ local CLUSTERING_SYNC_STATUS = require("kong.constants").CLUSTERING_SYNC_STATUS
 local KEY_AUTH_PLUGIN
 
 
+for wrpc_protocol in ipairs{ true, false } do
 for _, strategy in helpers.each_strategy() do
 
-describe("CP/DP communication #" .. strategy, function()
+describe("CP/DP communication #" .. strategy .. ", wrpc=" .. tostring(wrpc_protocol), function()
 
   lazy_setup(function()
     helpers.get_db_utils(strategy) -- runs migrations
@@ -31,6 +32,7 @@ describe("CP/DP communication #" .. strategy, function()
 
     assert(helpers.start_kong({
       role = "data_plane",
+      wrpc_hybrid_protocol = wrpc_protocol,
       database = "off",
       prefix = "servroot2",
       cluster_cert = "spec/fixtures/kong_clustering.crt",
@@ -339,7 +341,7 @@ describe("CP/DP communication #" .. strategy, function()
   end)
 end)
 
-describe("CP/DP #version check #" .. strategy, function()
+describe("CP/DP #version check #" .. strategy .. ", wrpc=" .. tostring(wrpc_protocol), function()
   -- for these tests, we do not need a real DP, but rather use the fake DP
   -- client so we can mock various values (e.g. node_version)
   describe("relaxed compatibility check:", function()
@@ -476,7 +478,7 @@ describe("CP/DP #version check #" .. strategy, function()
         local uuid = utils.uuid()
 
         local res = assert(helpers.clustering_client({
-          cluster_protocol = "wrpc",
+          wrpc_protocol = wrpc_protocol,
           host = "127.0.0.1",
           port = 9005,
           cert = "spec/fixtures/kong_clustering.crt",
@@ -486,9 +488,15 @@ describe("CP/DP #version check #" .. strategy, function()
           node_plugins_list = harness.plugins_list,
         }))
 
-        assert.is_table(res)
-        assert(res.version)
-        assert(res.config)
+        if wrpc_protocol then
+          assert.is_table(res)
+          assert(res.version)
+          assert(res.config)
+
+        else
+          assert.equals("reconfigure", res.type)
+          assert.is_table(res.config_table)
+        end
 
         -- needs wait_until for C* convergence
         helpers.wait_until(function()
@@ -563,7 +571,7 @@ describe("CP/DP #version check #" .. strategy, function()
         local uuid = utils.uuid()
 
         local res, err = helpers.clustering_client({
-          cluster_protocol = "wrpc",
+          wrpc_protocol = wrpc_protocol,
           host = "127.0.0.1",
           port = 9005,
           cert = "spec/fixtures/kong_clustering.crt",
@@ -579,8 +587,12 @@ describe("CP/DP #version check #" .. strategy, function()
           end
 
         else
-          -- is not config result
-          assert((res.error or res.ok) and not res.config)
+          if wrpc_protocol then  -- wrpc
+            -- is not config result
+            assert((res.error or res.ok) and not res.config)
+          else
+            assert.equals("PONG", res)
+          end
         end
 
         -- needs wait_until for c* convergence
@@ -608,7 +620,7 @@ describe("CP/DP #version check #" .. strategy, function()
   end)
 end)
 
-describe("CP/DP config sync #" .. strategy, function()
+describe("CP/DP config sync #" .. strategy .. ", wrpc=" .. tostring(wrpc_protocol), function()
   lazy_setup(function()
     helpers.get_db_utils(strategy) -- runs migrations
 
@@ -623,6 +635,7 @@ describe("CP/DP config sync #" .. strategy, function()
 
     assert(helpers.start_kong({
       role = "data_plane",
+      wrpc_hybrid_protocol = wrpc_protocol,
       database = "off",
       prefix = "servroot2",
       cluster_cert = "spec/fixtures/kong_clustering.crt",
@@ -718,4 +731,5 @@ describe("CP/DP config sync #" .. strategy, function()
   end)
 end)
 
+end
 end

--- a/spec/02-integration/09-hybrid_mode/02-start_stop_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/02-start_stop_spec.lua
@@ -1,7 +1,9 @@
 local helpers = require "spec.helpers"
 
 
-describe("invalid config are rejected", function()
+for wrpc_protocol in ipairs{ true, false } do
+
+describe("invalid config are rejected, ".. "wrpc=" .. tostring(wrpc_protocol), function()
   describe("role is control_plane", function()
     it("can not disable admin_listen", function()
       local ok, err = helpers.start_kong({
@@ -64,6 +66,7 @@ describe("invalid config are rejected", function()
     it("can not disable proxy_listen", function()
       local ok, err = helpers.start_kong({
         role = "data_plane",
+        wrpc_hybrid_protocol = wrpc_protocol,
         nginx_conf = "spec/fixtures/custom_nginx.template",
         prefix = "servroot2",
         cluster_cert = "spec/fixtures/kong_clustering.crt",
@@ -78,6 +81,7 @@ describe("invalid config are rejected", function()
     it("can not use DB mode", function()
       local ok, err = helpers.start_kong({
         role = "data_plane",
+        wrpc_hybrid_protocol = wrpc_protocol,
         nginx_conf = "spec/fixtures/custom_nginx.template",
         prefix = "servroot2",
         cluster_cert = "spec/fixtures/kong_clustering.crt",
@@ -95,6 +99,7 @@ describe("invalid config are rejected", function()
       it("errors if cluster certificate is not found", function()
         local ok, err = helpers.start_kong({
           role = param[1],
+          wrpc_hybrid_protocol = wrpc_protocol,
           nginx_conf = "spec/fixtures/custom_nginx.template",
           database = param[2],
           prefix = "servroot2",
@@ -107,6 +112,7 @@ describe("invalid config are rejected", function()
       it("errors if cluster certificate key is not found", function()
         local ok, err = helpers.start_kong({
           role = param[1],
+          wrpc_hybrid_protocol = wrpc_protocol,
           nginx_conf = "spec/fixtures/custom_nginx.template",
           database = param[2],
           prefix = "servroot2",
@@ -134,6 +140,7 @@ describe("when CP exits before DP", function()
     }))
     assert(helpers.start_kong({
       role = "data_plane",
+      wrpc_hybrid_protocol = wrpc_protocol,
       prefix = "servroot2",
       cluster_cert = "spec/fixtures/kong_clustering.crt",
       cluster_cert_key = "spec/fixtures/kong_clustering.key",
@@ -163,3 +170,5 @@ describe("when CP exits before DP", function()
     assert.logfile("servroot2/logs/error.log").has.no.line("error while receiving frame from peer", true)
   end)
 end)
+
+end

--- a/spec/02-integration/09-hybrid_mode/03-pki_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/03-pki_spec.lua
@@ -2,9 +2,10 @@ local helpers = require "spec.helpers"
 local cjson = require "cjson.safe"
 
 
+for wrpc_protocol in ipairs{ true, false } do
 for _, strategy in helpers.each_strategy() do
 
-describe("CP/DP PKI sync #" .. strategy, function()
+describe("CP/DP PKI sync #" .. strategy .. "wrpc=" .. tostring(wrpc_protocol), function()
 
   lazy_setup(function()
     helpers.get_db_utils(strategy, {
@@ -27,6 +28,7 @@ describe("CP/DP PKI sync #" .. strategy, function()
 
     assert(helpers.start_kong({
       role = "data_plane",
+      wrpc_hybrid_protocol = wrpc_protocol,
       nginx_conf = "spec/fixtures/custom_nginx.template",
       database = "off",
       prefix = "servroot2",
@@ -156,4 +158,5 @@ describe("CP/DP PKI sync #" .. strategy, function()
   end)
 end)
 
+end
 end

--- a/spec/02-integration/09-hybrid_mode/05-ocsp_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/05-ocsp_spec.lua
@@ -14,9 +14,10 @@ local function set_ocsp_status(status)
 end
 
 
+for wrpc_protocol in ipairs{ true, false } do
 for _, strategy in helpers.each_strategy() do
 
-describe("cluster_ocsp = on works #" .. strategy, function()
+describe("cluster_ocsp = on works #" .. strategy .. "wrpc=" .. tostring(wrpc_protocol), function()
   describe("DP certificate good", function()
     lazy_setup(function()
       helpers.get_db_utils(strategy, {
@@ -46,6 +47,7 @@ describe("cluster_ocsp = on works #" .. strategy, function()
 
       assert(helpers.start_kong({
         role = "data_plane",
+        wrpc_hybrid_protocol = wrpc_protocol,
         nginx_conf = "spec/fixtures/custom_nginx.template",
         database = "off",
         prefix = "servroot2",
@@ -116,6 +118,7 @@ describe("cluster_ocsp = on works #" .. strategy, function()
 
       assert(helpers.start_kong({
         role = "data_plane",
+        wrpc_hybrid_protocol = wrpc_protocol,
         database = "off",
         prefix = "servroot2",
         cluster_cert = "spec/fixtures/ocsp_certs/kong_data_plane.crt",
@@ -184,6 +187,7 @@ describe("cluster_ocsp = on works #" .. strategy, function()
 
       assert(helpers.start_kong({
         role = "data_plane",
+        wrpc_hybrid_protocol = wrpc_protocol,
         database = "off",
         prefix = "servroot2",
         cluster_cert = "spec/fixtures/ocsp_certs/kong_data_plane.crt",
@@ -255,6 +259,7 @@ describe("cluster_ocsp = off works with #" .. strategy .. " backend", function()
 
       assert(helpers.start_kong({
         role = "data_plane",
+        wrpc_hybrid_protocol = wrpc_protocol,
         nginx_conf = "spec/fixtures/custom_nginx.template",
         database = "off",
         prefix = "servroot2",
@@ -327,6 +332,7 @@ describe("cluster_ocsp = optional works with #" .. strategy .. " backend", funct
 
       assert(helpers.start_kong({
         role = "data_plane",
+        wrpc_hybrid_protocol = wrpc_protocol,
         database = "off",
         prefix = "servroot2",
         cluster_cert = "spec/fixtures/ocsp_certs/kong_data_plane.crt",
@@ -395,6 +401,7 @@ describe("cluster_ocsp = optional works with #" .. strategy .. " backend", funct
 
       assert(helpers.start_kong({
         role = "data_plane",
+        wrpc_hybrid_protocol = wrpc_protocol,
         database = "off",
         prefix = "servroot2",
         cluster_cert = "spec/fixtures/ocsp_certs/kong_data_plane.crt",
@@ -440,4 +447,5 @@ describe("cluster_ocsp = optional works with #" .. strategy .. " backend", funct
   end)
 end)
 
+end
 end

--- a/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/09-config-compat_spec.lua
@@ -24,9 +24,8 @@ local function cluster_client(opts)
     node_plugins_list = PLUGIN_LIST,
   })
 
-  if res and res.config then
-    local inflated = assert(utils.inflate_gzip(res.config))
-    res.config = cjson.decode(inflated)
+  if res and res.config_table then
+    res.config = res.config_table
   end
 
   return res

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -445,6 +445,12 @@ http {
         ssl_certificate_key ${{CLUSTER_CERT_KEY}};
         ssl_session_cache   shared:ClusterSSL:10m;
 
+        location = /v1/outlet {
+            content_by_lua_block {
+                Kong.serve_cluster_listener()
+            }
+        }
+
         location = /v1/wrpc {
             content_by_lua_block {
                 Kong.serve_wrpc_listener()


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Try to restore WebSocket protocol and keep wRPC protocol.

Revert PR #9740, update to PR #9823  #9769 , #9616 #9671 #9774.

This is the cherry-pick of #9921, and didn't remove wRPC protocol.

See KAG-371.

Related PRs: #8926 #8357

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG


### Full changelog

* revert PR #9740
* update `control_plane.lua` with new `compat.*`
* change `compat.update_compatible_payload` to fit json+gzip
* add config item `wrpc_hybrid_protocol ` only for test


[KAG-371]: https://konghq.atlassian.net/browse/KAG-371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ