### PR TITLE
docs(autodocs) Fix db-less badges on log level PUT endpoints

### DIFF
--- a/autodoc/admin-api/data/admin-api.lua
+++ b/autodoc/admin-api/data/admin-api.lua
@@ -2706,18 +2706,6 @@ return {
     },
     ["/upstreams/:upstreams/targets/:targets/unhealthy"] = {
       ["PUT"] = true,
-    },
-    ["/debug/node/log-level"] = {
-      ["GET"] = true,
-    },
-    ["/debug/node/log-level/:log_level"] = {
-      ["PUT"] = true,
-    },
-    ["/debug/cluster/log-level/:log_level"] = {
-      ["PUT"] = true,
-    },
-    ["/debug/cluster/control-planes-nodes/log-level/:log_level"] = {
-      ["PUT"] = true,
     }
   },
 


### PR DESCRIPTION
Reverting changes made in https://github.com/Kong/kong/pull/9990. 

`true` means supported in db-less mode. The original PR got the settings backwards, setting `true` when it should be `false`. 

The `GET` endpoint _is_ true, but this is already covered by the rule on line 2698.

### Summary

Bug reported to the docs team on Slack: https://kongstrong.slack.com/archives/CDSTDSG9J/p1672965868058589

### Checklist

- ~[ ] The Pull Request has tests~ - Not applicable
- ~[ ] There's an entry in the CHANGELOG~ - Not applicable
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - https://github.com/Kong/docs.konghq.com/pull/4995

### Full changelog
N/A

### Issue reference
N/A