### PR TITLE
chore(ci): pin kbt version (3.0.x branch)

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -8,16 +8,17 @@ jobs:
 
     env:
       DOWNLOAD_ROOT: $HOME/download-root
-      KONG_NGINX_MODULE_BRANCH: 0.2.1
 
     steps:
+    - name: Checkout Kong source code
+      uses: actions/checkout@v3
+
     - name: Set environment variables
       run: |
+          grep -v '^#' .requirements >> $GITHUB_ENV
           echo "INSTALL_ROOT=$HOME/install-root" >> $GITHUB_ENV
           echo "DOWNLOAD_ROOT=$HOME/download-root" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=$INSTALL_ROOT/openssl/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-    - name: Checkout Kong source code
-      uses: actions/checkout@v3
 
     - name: Lookup build cache
       uses: actions/cache@v3
@@ -32,7 +33,7 @@ jobs:
       with:
         repository: Kong/kong-build-tools
         path: kong-build-tools
-        ref: master
+        ref: ${{ env.KONG_BUILD_TOOLS_VERSION }}
 
     - name: Checkout go-pluginserver
       if: steps.cache-deps.outputs.cache-hit != 'true'

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-*   @Kong/gateway

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1665,13 +1665,3 @@
                                   # Setting this attribute disables the search
                                   # behavior and explicitly instructs Kong which
                                   # OpenResty installation to use.
-
-#max_queued_batches = 100         # Maximum number of batches to keep on an internal
-                                  # plugin queue before dropping old batches.  This is
-                                  # meant as a global, last-resort control to prevent
-                                  # queues from consuming infinite memory.  When batches
-                                  # are being dropped, an error message
-                                  # "exceeded max_queued_batches (%d), dropping oldest"
-                                  # will be logged.  The error message will also include
-                                  # a string that identifies the plugin causing the
-                                  # problem.

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -178,6 +178,4 @@ openresty_path =
 
 opentelemetry_tracing = off
 opentelemetry_tracing_sampling_rate = 1.0
-
-max_queued_batches = 100
 ]]


### PR DESCRIPTION
- Pin KBT version correctly with `.requirements`
- Revert https://github.com/Kong/kong/commit/58294b45e33ed2490b284870ad9c4b7036255bb1 as it does not intend to be cherry-picked into `3.0.x` branch
- Cherrypick https://github.com/Kong/kong/commit/fae7caa131f3922a6e1425461c0458f9cd319f67