### PR TITLE
doc(changelog): bump atc-router to 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,8 @@
 
 - Bumped luarocks from 3.9.1 to 3.9.2
   [#9942](https://github.com/Kong/kong/pull/9942)
+- Bumped atc-router from 1.0.1 to 1.0.2
+  [#9925](https://github.com/Kong/kong/pull/9925)
 
 
 ## 3.1.0


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Add changelog for #9925, which appears in 3.1.x but not in master.
