### PR TITLE
feat(prometheus): expose tags as labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@
 
 ## Unreleased
 
+- **Prometheus**: Prometheus plugin now allows exposing Service, Route and/or Consumer tags as metric labels. [#10082](https://github.com/Kong/kong/pull/10082)
+
 ### Breaking Changes
 
 #### Plugins

--- a/kong/plugins/prometheus/handler.lua
+++ b/kong/plugins/prometheus/handler.lua
@@ -2,6 +2,9 @@ local exporter = require "kong.plugins.prometheus.exporter"
 local kong = kong
 local kong_meta = require "kong.meta"
 
+local keys = require('pl.tablex').keys
+local sort = table.sort
+local concat = table.concat
 
 exporter.init()
 
@@ -33,6 +36,26 @@ function PrometheusHandler.log(self, conf)
       serialized.status_code = message.session.status
     end
   end
+
+  local tags = {}
+  if conf.expose_tags.from_service and message.service and message.service.tags then
+    for i = 1, #message.service.tags do
+      tags[message.service.tags[i]] = true
+    end
+  end
+  if conf.expose_tags.from_route and message.route and message.route.tags then
+    for i = 1, #message.route.tags do
+      tags[message.route.tags[i]] = true
+    end
+  end
+  if conf.expose_tags.from_consumer and message.consumer and message.consumer.tags then
+    for i = 1, #message.consumer.tags do
+      tags[message.consumer.tags[i]] = true
+    end
+  end
+  tags = keys(tags)
+  sort(tags)
+  serialized.tags = concat(tags, ",")
 
   if conf.bandwidth_metrics then
     if http_subsystem then

--- a/kong/plugins/prometheus/schema.lua
+++ b/kong/plugins/prometheus/schema.lua
@@ -21,6 +21,14 @@ return {
           { latency_metrics = { type = "boolean", default = false }, },
           { bandwidth_metrics = { type = "boolean", default = false }, },
           { upstream_health_metrics = { type = "boolean", default = false }, },
+          { expose_tags = {
+            type = "record",
+            fields = {
+              { from_service = { type = "boolean", default = false }, },
+              { from_route = { type = "boolean", default = false }, },
+              { from_consumer = { type = "boolean", default = false }, },
+            },
+          }, },
         },
         custom_validator = validate_shared_dict,
     }, },

--- a/spec/03-plugins/26-prometheus/03-custom-serve_spec.lua
+++ b/spec/03-plugins/26-prometheus/03-custom-serve_spec.lua
@@ -63,7 +63,7 @@ describe("Plugin: prometheus (custom server)",function()
         path    = "/metrics",
       })
       local body = assert.res_status(200, res)
-      assert.matches('http_requests_total{service="mock-service",route="http-route",code="200",source="service",consumer=""} 1', body, nil, true)
+      assert.matches('http_requests_total{service="mock-service",route="http-route",code="200",source="service",tags="",consumer=""} 1', body, nil, true)
     end)
     it("custom port returns 404 for anything other than /metrics", function()
       local client = helpers.http_client("127.0.0.1", 9542)

--- a/spec/03-plugins/26-prometheus/04-status_api_spec.lua
+++ b/spec/03-plugins/26-prometheus/04-status_api_spec.lua
@@ -99,6 +99,7 @@ describe("Plugin: prometheus (access via status API)", function()
       host = upstream.name,
       port = helpers.mock_upstream_port,
       protocol = helpers.mock_upstream_protocol,
+      tags = { "foo" },
     }
 
     bp.routes:insert {
@@ -107,6 +108,7 @@ describe("Plugin: prometheus (access via status API)", function()
       paths = { "/" },
       methods = { "GET" },
       service = service,
+      tags = { "bar" },
     }
 
     local grpc_service = bp.services:insert {
@@ -199,7 +201,7 @@ describe("Plugin: prometheus (access via status API)", function()
 
     helpers.wait_until(function()
       local body = get_metrics()
-      return body:find('http_requests_total{service="mock-service",route="http-route",code="200",source="service",consumer=""} 1', nil, true)
+      return body:find('http_requests_total{service="mock-service",route="http-route",code="200",source="service",tags="",consumer=""} 1', nil, true)
     end)
 
     res = assert(proxy_client:send {
@@ -212,14 +214,14 @@ describe("Plugin: prometheus (access via status API)", function()
     assert.res_status(400, res)
     local body = get_metrics()
 
-    assert.matches('kong_kong_latency_ms_bucket{service="mock%-service",route="http%-route",le="%+Inf"} +%d', body)
-    assert.matches('kong_upstream_latency_ms_bucket{service="mock%-service",route="http%-route",le="%+Inf"} +%d', body)
-    assert.matches('kong_request_latency_ms_bucket{service="mock%-service",route="http%-route",le="%+Inf"} +%d', body)
+    assert.matches('kong_kong_latency_ms_bucket{service="mock%-service",route="http%-route",tags="",le="%+Inf"} +%d', body)
+    assert.matches('kong_upstream_latency_ms_bucket{service="mock%-service",route="http%-route",tags="",le="%+Inf"} +%d', body)
+    assert.matches('kong_request_latency_ms_bucket{service="mock%-service",route="http%-route",tags="",le="%+Inf"} +%d', body)
 
-    assert.matches('http_requests_total{service="mock-service",route="http-route",code="400",source="service",consumer=""} 1', body, nil, true)
-    assert.matches('kong_bandwidth_bytes{service="mock%-service",route="http%-route",direction="ingress",consumer=""} %d+', body)
+    assert.matches('http_requests_total{service="mock-service",route="http-route",code="400",source="service",tags="",consumer=""} 1', body, nil, true)
+    assert.matches('kong_bandwidth_bytes{service="mock%-service",route="http%-route",direction="ingress",tags="",consumer=""} %d+', body)
 
-    assert.matches('kong_bandwidth_bytes{service="mock%-service",route="http%-route",direction="egress",consumer=""} %d+', body)
+    assert.matches('kong_bandwidth_bytes{service="mock%-service",route="http%-route",direction="egress",tags="",consumer=""} %d+', body)
   end)
 
   it("increments the count for proxied grpc requests", function()
@@ -237,7 +239,7 @@ describe("Plugin: prometheus (access via status API)", function()
 
     helpers.wait_until(function()
       local body = get_metrics()
-      return body:find('http_requests_total{service="mock-grpc-service",route="grpc-route",code="200",source="service",consumer=""} 1', nil, true)
+      return body:find('http_requests_total{service="mock-grpc-service",route="grpc-route",code="200",source="service",tags="",consumer=""} 1', nil, true)
     end)
 
     ok, resp = proxy_client_grpcs({
@@ -254,7 +256,7 @@ describe("Plugin: prometheus (access via status API)", function()
 
     helpers.wait_until(function()
       local body = get_metrics()
-      return body:find('http_requests_total{service="mock-grpcs-service",route="grpcs-route",code="200",source="service",consumer=""} 1', nil, true)
+      return body:find('http_requests_total{service="mock-grpcs-service",route="grpcs-route",code="200",source="service",tags="",consumer=""} 1', nil, true)
     end)
   end)
 

--- a/spec/03-plugins/26-prometheus/05-metrics_spec.lua
+++ b/spec/03-plugins/26-prometheus/05-metrics_spec.lua
@@ -139,7 +139,7 @@ for _, strategy in helpers.each_strategy() do
 
         assert.matches('kong_nginx_metric_errors_total 0', body, nil, true)
 
-        return body:find('http_requests_total{service="mock-ssl-service",route="mock-ssl-route",code="400",source="service",consumer=""} 1',
+        return body:find('http_requests_total{service="mock-ssl-service",route="mock-ssl-route",code="400",source="service",tags="",consumer=""} 1',
           nil, true)
       end)
     end)

--- a/spec/03-plugins/26-prometheus/07-optional_fields_spec.lua
+++ b/spec/03-plugins/26-prometheus/07-optional_fields_spec.lua
@@ -77,6 +77,11 @@ for _, strategy in helpers.each_strategy() do
           latency_metrics         = true,
           bandwidth_metrics       = true,
           upstream_health_metrics = true,
+          expose_tags = {
+            from_consumer = true,
+            from_service  = true,
+            from_route    = true,
+          },
         }
       }).id
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [x] [There is a user-facing docs PR against](https://github.com/Kong/docs.konghq.com/pull/5120) https://github.com/Kong/docs.konghq.com

### Full changelog

* Prometheus plugin now allows exposing Service, Route and/or Consumer tags as metric labels.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here.
Fix #_[issue number]_ -->
