### PR TITLE
fix(db): use ATC router for route validation when `router_flavor = traditional_compatible`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@ under certain circumstances.
 - When `router_flavor` is `traditional_compatible`, verify routes created using the
   Expression router instead of the traditional router to ensure created routes
   are actually compatible.
-  [#9987](https://github.com/Kong/kong/pull/9987)
+  [#10088](https://github.com/Kong/kong/pull/10088)
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,15 @@
 This patch release fixes a bug that might cause Kong workers to crash
 under certain circumstances.
 
+### Additions
+
+#### Core
+
+- When `router_flavor` is `traditional_compatible`, verify routes created using the
+  Expression router instead of the traditional router to ensure created routes
+  are actually compatible.
+  [#9987](https://github.com/Kong/kong/pull/9987)
+
 ### Fixes
 
 ##### Core

--- a/kong/db/schema/init.lua
+++ b/kong/db/schema/init.lua
@@ -1201,6 +1201,7 @@ local function run_entity_check(self, name, input, arg, full_check, errors)
     local value = get_field(input, fname)
     if value == nil then
       if (not checker.run_with_missing_fields) and
+         (not arg.run_with_missing_fields) and
          (required_fields and required_fields[fname]) and
          (not get_schema_field(self, fname).nilable) then
         missing = missing or {}

--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -222,6 +222,7 @@ local entity_checkers = {
       fields = {
         { field_sources = { type = "array", elements = { type = "string" } } },
         { fn = { type = "function" } },
+        { run_with_missing_fields = { type = "boolean" } },
       }
     }
   },

--- a/kong/router/compat.lua
+++ b/kong/router/compat.lua
@@ -294,9 +294,12 @@ function _M.new(routes, cache, cache_neg, old_router)
 end
 
 
+-- for schema validation and unit-testing
+_M.get_expression = get_expression
+
+
 -- for unit-testing purposes only
 _M._set_ngx = atc._set_ngx
-_M._get_expression = get_expression
 _M._get_priority = get_priority
 
 

--- a/spec/01-unit/08-router_spec.lua
+++ b/spec/01-unit/08-router_spec.lua
@@ -20,7 +20,7 @@ local function new_router(cases, old_router)
     for _, v in ipairs(cases) do
       local r = v.route
 
-      r.expression = r.expression or atc_compat._get_expression(r)
+      r.expression = r.expression or atc_compat.get_expression(r)
       r.priority = r.priority or atc_compat._get_priority(r)
     end
   end
@@ -2086,7 +2086,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
 
         describe("check empty route fields", function()
           local use_case
-          local _get_expression = atc_compat._get_expression
+          local get_expression = atc_compat.get_expression
 
           before_each(function()
             use_case = {
@@ -2108,35 +2108,35 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
             it("empty methods", function()
               use_case[1].route.methods = v
 
-              assert.equal(_get_expression(use_case[1].route), [[(http.path ^= "/foo")]])
+              assert.equal(get_expression(use_case[1].route), [[(http.path ^= "/foo")]])
               assert(new_router(use_case))
             end)
 
             it("empty hosts", function()
               use_case[1].route.hosts = v
 
-              assert.equal(_get_expression(use_case[1].route), [[(http.method == "GET") && (http.path ^= "/foo")]])
+              assert.equal(get_expression(use_case[1].route), [[(http.method == "GET") && (http.path ^= "/foo")]])
               assert(new_router(use_case))
             end)
 
             it("empty headers", function()
               use_case[1].route.headers = v
 
-              assert.equal(_get_expression(use_case[1].route), [[(http.method == "GET") && (http.path ^= "/foo")]])
+              assert.equal(get_expression(use_case[1].route), [[(http.method == "GET") && (http.path ^= "/foo")]])
               assert(new_router(use_case))
             end)
 
             it("empty paths", function()
               use_case[1].route.paths = v
 
-              assert.equal(_get_expression(use_case[1].route), [[(http.method == "GET")]])
+              assert.equal(get_expression(use_case[1].route), [[(http.method == "GET")]])
               assert(new_router(use_case))
             end)
 
             it("empty snis", function()
               use_case[1].route.snis = v
 
-              assert.equal(_get_expression(use_case[1].route), [[(http.method == "GET") && (http.path ^= "/foo")]])
+              assert.equal(get_expression(use_case[1].route), [[(http.method == "GET") && (http.path ^= "/foo")]])
               assert(new_router(use_case))
             end)
           end
@@ -2144,7 +2144,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
 
         describe("check regex with '\\'", function()
           local use_case
-          local _get_expression = atc_compat._get_expression
+          local get_expression = atc_compat.get_expression
 
           before_each(function()
             use_case = {
@@ -2162,7 +2162,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
             use_case[1].route.paths = { [[~/\\/*$]], }
 
             assert.equal([[(http.method == "GET") && (http.path ~ "^/\\\\/*$")]],
-                         _get_expression(use_case[1].route))
+                         get_expression(use_case[1].route))
             assert(new_router(use_case))
           end)
 
@@ -2170,7 +2170,7 @@ for _, flavor in ipairs({ "traditional", "traditional_compatible", "expressions"
             use_case[1].route.paths = { [[~/\d+]], }
 
             assert.equal([[(http.method == "GET") && (http.path ~ "^/\\d+")]],
-                         _get_expression(use_case[1].route))
+                         get_expression(use_case[1].route))
             assert(new_router(use_case))
           end)
         end)

--- a/spec/02-integration/05-proxy/02-router_spec.lua
+++ b/spec/02-integration/05-proxy/02-router_spec.lua
@@ -2351,7 +2351,12 @@ for _, strategy in helpers.each_strategy() do
             paths = { "~/delay/(?<delay>[^\\/]+)$", },
           },
         }))
-        assert.res_status(201, res)
+        if flavor == "traditional" then
+          assert.res_status(201, res)
+
+        else
+          assert.res_status(400, res)
+        end
 
         helpers.wait_for_all_config_update()
 


### PR DESCRIPTION

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

cherry-pick #9987
