### PR TITLE
chore(db/migration): check migration regex path before db changes

### DIFF
--- a/kong/db/init.lua
+++ b/kong/db/init.lua
@@ -544,6 +544,15 @@ do
         if run_up then
           -- kong migrations bootstrap
           -- kong migrations up
+          if strategy_migration.up_t then
+            local pok, perr, err = xpcall(strategy_migration.up_t, debug.traceback, self.connector)
+            if not pok or err then
+              self.connector:close()
+              return nil, fmt_err(self, "failed to run migration '%s' up_t: %s",
+                                         mig.name, perr or err)
+            end
+          end
+
           if strategy_migration.up and strategy_migration.up ~= "" then
             ok, err = self.connector:run_up_migration(mig.name,
                                                       strategy_migration.up)

--- a/kong/db/migrations/core/016_280_to_300.lua
+++ b/kong/db/migrations/core/016_280_to_300.lua
@@ -485,17 +485,7 @@ return {
 
     up_t = function(connector)
       local coordinator = assert(connector:get_stored_connection())
-      local _, err = c_copy_vaults_to_vault_auth_vaults(coordinator)
-      if err then
-        return nil, err
-      end
-
-      _, err = c_copy_vaults_beta_to_sm_vaults(coordinator)
-      if err then
-        return nil, err
-      end
-
-      _, err = c_validate_regex_path(coordinator)
+      local _, err = c_validate_regex_path(coordinator)
       if err then
         return nil, err
       end

--- a/kong/db/migrations/core/016_280_to_300.lua
+++ b/kong/db/migrations/core/016_280_to_300.lua
@@ -9,6 +9,28 @@ local encode_array  = arrays.encode_array
 local migrate_path = require "kong.db.migrations.migrate_path_280_300"
 
 
+local validate_atc_expression
+do
+  local router = require("resty.router.router")
+  local CACHED_SCHEMA = require("kong.router.atc").schema
+  local get_expression = require("kong.router.compat").get_expression
+
+  validate_atc_expression = function(route)
+    local r = router.new(CACHED_SCHEMA)
+    local exp = get_expression(route)
+
+    local res, err = r:add_matcher(0, route.id, exp)
+    if not res then
+      log.error("Regex path may not work with router flavor 'traditional_compatible', " ..
+                "route id: %s, err: %s", route.id, err)
+      return false
+    end
+
+    return true
+  end
+end
+
+
 -- remove repeated targets, the older ones are not useful anymore. targets with
 -- weight 0 will be kept, as we cannot tell which were deleted and which were
 -- explicitly set as 0.
@@ -140,6 +162,40 @@ local function c_copy_vaults_beta_to_sm_vaults(coordinator)
   end
 
   return true
+end
+
+
+local function c_validate_regex_path(coordinator)
+  local validate_ok = true
+
+  for rows, err in coordinator:iterate("SELECT id, paths FROM routes") do
+    if err then
+      return nil, err
+    end
+
+    for i = 1, #rows do
+      local route = rows[i]
+
+      if not route.paths then
+        goto continue
+      end
+
+      for idx, path in ipairs(route.paths) do
+        local normalized_path, current_changed = migrate_path(path)
+        if current_changed then
+          route.paths[idx] = normalized_path
+        end
+      end
+
+      if not validate_atc_expression(route) then
+        validate_ok = false
+      end
+
+      ::continue::
+    end
+  end
+
+  return validate_ok
 end
 
 

--- a/kong/db/migrations/core/016_280_to_300.lua
+++ b/kong/db/migrations/core/016_280_to_300.lua
@@ -195,12 +195,11 @@ local function c_validate_regex_path(coordinator)
     end
   end
 
-  if validate_ok then
-    return true
-
-  else
+  if not validate_ok then
     return nil, "Regex path validatioin failed."
   end
+
+  return true
 end
 
 
@@ -265,12 +264,11 @@ local function p_validate_regex_path(connector)
     end
   end
 
-  if validate_ok then
-    return true
-
-  else
+  if not validate_ok then
     return nil, "Regex path validatioin failed."
   end
+
+  return true
 end
 
 local function p_migrate_regex_path(connector)

--- a/kong/db/migrations/core/016_280_to_300.lua
+++ b/kong/db/migrations/core/016_280_to_300.lua
@@ -195,7 +195,12 @@ local function c_validate_regex_path(coordinator)
     end
   end
 
-  return validate_ok
+  if validate_ok then
+    return true
+
+  else
+    return nil, "Regex path validatioin failed."
+  end
 end
 
 
@@ -260,7 +265,12 @@ local function p_validate_regex_path(connector)
     end
   end
 
-  return validate_ok
+  if validate_ok then
+    return true
+
+  else
+    return nil, "Regex path validatioin failed."
+  end
 end
 
 local function p_migrate_regex_path(connector)

--- a/kong/db/migrations/core/016_280_to_300.lua
+++ b/kong/db/migrations/core/016_280_to_300.lua
@@ -409,6 +409,8 @@ return {
       $$;
     ]],
 
+    up_t = p_validate_regex_path,
+
     up_f = p_migrate_regex_path,
 
     teardown = function(connector)
@@ -480,6 +482,24 @@ return {
       ALTER TABLE routes ADD expression text;
       ALTER TABLE routes ADD priority int;
     ]],
+
+    up_t = function(connector)
+      local coordinator = assert(connector:get_stored_connection())
+      local _, err = c_copy_vaults_to_vault_auth_vaults(coordinator)
+      if err then
+        return nil, err
+      end
+
+      _, err = c_copy_vaults_beta_to_sm_vaults(coordinator)
+      if err then
+        return nil, err
+      end
+
+      _, err = c_validate_regex_path(coordinator)
+      if err then
+        return nil, err
+      end
+    end,
 
     up_f = function(connector)
       local coordinator = assert(connector:get_stored_connection())

--- a/kong/db/schema/others/migrations.lua
+++ b/kong/db/schema/others/migrations.lua
@@ -6,6 +6,7 @@ return {
       postgres  = {
         type = "record", required = true,
         fields = {
+          { up_t = { type = "function" } },
           { up = { type = "string", len_min = 0 } },
           { up_f = { type = "function" } },
           { teardown = { type = "function" } },
@@ -16,6 +17,7 @@ return {
       cassandra = {
         type = "record", required = true,
         fields = {
+          { up_t = { type = "function" } },
           { up = { type = "string", len_min = 0 } },
           { up_f = { type = "function" } },
           { teardown = { type = "function" } },
@@ -26,8 +28,8 @@ return {
   entity_checks = {
     {
       at_least_one_of = {
-        "postgres.up", "postgres.up_f", "postgres.teardown",
-        "cassandra.up", "cassandra.up_f", "cassandra.teardown"
+        "postgres.up_t", "postgres.up", "postgres.up_f", "postgres.teardown",
+        "postgres.up_t", "cassandra.up", "cassandra.up_f", "cassandra.teardown",
       },
     },
   },

--- a/kong/db/schema/others/migrations.lua
+++ b/kong/db/schema/others/migrations.lua
@@ -28,8 +28,8 @@ return {
   entity_checks = {
     {
       at_least_one_of = {
-        "postgres.up_t", "postgres.up", "postgres.up_f", "postgres.teardown",
-        "postgres.up_t", "cassandra.up", "cassandra.up_f", "cassandra.teardown",
+        "postgres.up", "postgres.up_f", "postgres.teardown",
+        "cassandra.up", "cassandra.up_f", "cassandra.teardown",
       },
     },
   },


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

In `kong migrations up`, it will print an error log to notify the user if there is an incompatible regex path route:

```
2022/12/30 09:27:37 [error] Regex path may not work with router flavor 'traditional_compatible', route id: 0950d523-aa5e-4d05-a1af-928ea5c3aa99, err:  --> 1:2
  |
1 | (http.path ~ "^/\\/*/user$")
  |  ^------------------------^
  |
  = regex parse error:
    ^/\/*/user$
      ^^
error: unrecognized escape sequence
```

It will replace #9992.

See KAG-329.