### PR TITLE
fix(template) keep UTF-8 as default for charset directive but make it configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,9 @@
   Expression router instead of the traditional router to ensure created routes
   are actually compatible.
   [#9987](https://github.com/Kong/kong/pull/9987)
+- Nginx charset directive can now be configured with Nginx directive injections
+  [#10111](https://github.com/Kong/kong/pull/10111)
+
 
 #### Plugins
 
@@ -105,8 +108,6 @@
   [#9960](https://github.com/Kong/kong/pull/9960)
 - Expose postgres connection pool configuration
   [#9603](https://github.com/Kong/kong/pull/9603)
-- **Template**: Do not add default charset to the `Content-Type` response header when upstream response doesn't contain it.
-  [#9905](https://github.com/Kong/kong/pull/9905)
 - Fix an issue where after a valid declarative configuration is loaded,
   the configuration hash is incorrectly set to the value: `00000000000000000000000000000000`.
   [#9911](https://github.com/Kong/kong/pull/9911)

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1024,6 +1024,15 @@
 #nginx_admin_client_max_body_size = 10m  # Defines the maximum request body size for
                                          # Admin API.
 
+#nginx_http_charset = UTF-8  # Adds the specified charset to the “Content-Type”
+                             # response header field. If this charset is different
+                             # from the charset specified in the source_charset
+                             # directive, a conversion is performed.
+                             #
+                             # The parameter `off` cancels the addition of
+                             # charset to the “Content-Type” response header field.
+                             # See http://nginx.org/en/docs/http/ngx_http_charset_module.html#charset
+
 #nginx_http_client_body_buffer_size = 8k  # Defines the buffer size for reading
                                           # the request body. If the client
                                           # request body is larger than this

--- a/kong/templates/kong_defaults.lua
+++ b/kong/templates/kong_defaults.lua
@@ -68,6 +68,7 @@ nginx_main_worker_processes = auto
 nginx_main_worker_rlimit_nofile = auto
 nginx_events_worker_connections = auto
 nginx_events_multi_accept = on
+nginx_http_charset = UTF-8
 nginx_http_client_max_body_size = 0
 nginx_http_client_body_buffer_size = 8k
 nginx_http_ssl_protocols = NONE

--- a/kong/templates/nginx_kong.lua
+++ b/kong/templates/nginx_kong.lua
@@ -332,6 +332,7 @@ server {
 
 > if (role == "control_plane" or role == "traditional") and #admin_listeners > 0 then
 server {
+    charset UTF-8;
     server_name kong_admin;
 > for _, entry in ipairs(admin_listeners) do
     listen $(entry.listener);
@@ -371,6 +372,7 @@ server {
 
 > if #status_listeners > 0 then
 server {
+    charset UTF-8;
     server_name kong_status;
 > for _, entry in ipairs(status_listeners) do
     listen $(entry.listener);
@@ -410,6 +412,7 @@ server {
 
 > if role == "control_plane" then
 server {
+    charset UTF-8;
     server_name kong_cluster_listener;
 > for _, entry in ipairs(cluster_listeners) do
     listen $(entry.listener) ssl;
@@ -439,6 +442,7 @@ server {
 
 > if not legacy_worker_events then
 server {
+    charset UTF-8;
     server_name kong_worker_events;
     listen unix:${{PREFIX}}/worker_events.sock;
     access_log off;

--- a/spec/02-integration/05-proxy/03-upstream_headers_spec.lua
+++ b/spec/02-integration/05-proxy/03-upstream_headers_spec.lua
@@ -284,16 +284,17 @@ for _, strategy in helpers.each_strategy() do
         ]]
 
         assert(helpers.start_kong({
-          database         = strategy,
-          nginx_conf       = "spec/fixtures/custom_nginx.template",
-          lua_package_path = "?/init.lua;./kong/?.lua;./spec/fixtures/?.lua",
+          database           = strategy,
+          nginx_conf         = "spec/fixtures/custom_nginx.template",
+          lua_package_path   = "?/init.lua;./kong/?.lua;./spec/fixtures/?.lua",
+          nginx_http_charset = "off",
         }, nil, nil, fixtures))
       end)
 
       lazy_teardown(stop_kong)
 
       describe("Content-Type", function()
-        it("does not add charset if the response from upstream contains no charset", function()
+        it("does not add charset if the response from upstream contains no charset when charset is turned off", function()
           local res = assert(proxy_client:send {
             method  = "GET",
             path    = "/nocharset",
@@ -306,7 +307,7 @@ for _, strategy in helpers.each_strategy() do
           assert.equal("text/plain", res.headers["Content-Type"])
         end)
 
-        it("charset remain unchanged if the response from upstream contains charset", function()
+        it("charset remain unchanged if the response from upstream contains charset when charset is turned off", function()
           local res = assert(proxy_client:send {
             method  = "GET",
             path    = "/charset",

--- a/spec/fixtures/1.2_custom_nginx.template
+++ b/spec/fixtures/1.2_custom_nginx.template
@@ -14,8 +14,6 @@ events {}
 
 http {
 > if #proxy_listeners > 0 or #admin_listeners > 0 then
-    charset UTF-8;
-
     error_log logs/error.log ${{LOG_LEVEL}};
 
 > if nginx_optimizations then
@@ -192,6 +190,7 @@ http {
 
 > if #admin_listeners > 0 then
     server {
+        charset UTF-8;
         server_name kong_admin;
 > for i = 1, #admin_listeners do
         listen $(admin_listeners[i].listener);

--- a/spec/fixtures/custom_nginx.template
+++ b/spec/fixtures/custom_nginx.template
@@ -353,6 +353,7 @@ http {
 
 > if (role == "control_plane" or role == "traditional") and #admin_listeners > 0 then
     server {
+        charset UTF-8;
         server_name kong_admin;
 > for _, entry in ipairs(admin_listeners) do
         listen $(entry.listener);
@@ -392,6 +393,7 @@ http {
 
 > if #status_listeners > 0 then
     server {
+        charset UTF-8;
         server_name kong_status;
 > for _, entry in ipairs(status_listeners) do
         listen $(entry.listener);
@@ -431,6 +433,7 @@ http {
 
 > if role == "control_plane" then
     server {
+        charset UTF-8;
         server_name kong_cluster_listener;
 > for _, entry in ipairs(cluster_listeners) do
         listen $(entry.listener) ssl;
@@ -709,6 +712,7 @@ http {
 
 > if not legacy_worker_events then
     server {
+        charset UTF-8;
         server_name kong_worker_events;
         listen unix:${{PREFIX}}/worker_events.sock;
         access_log off;


### PR DESCRIPTION
### Summary

`charset` directive that was previously hard coded in template with a value of `UTF-8` was removed completely with this PR:
https://github.com/Kong/kong/pull/9905

Previous discussion from 3 years ago pointed that this is breaking change (not a fix): https://github.com/Kong/kong/pull/5045

So here is another fix to make the directive still default to `UTF-8`. which is a quite fine default, but allow users to configure it. E.g.:

```
KONG_NGINX_HTTP_CHARSET=off kong start
```