### PR TITLE
style(core/runloop):  style clean for certificate.lua

### DIFF
--- a/kong/runloop/certificate.lua
+++ b/kong/runloop/certificate.lua
@@ -19,9 +19,14 @@ local set_cert = ngx_ssl.set_cert
 local set_priv_key = ngx_ssl.set_priv_key
 local tb_concat   = table.concat
 local tb_sort   = table.sort
+local type = type
+local error = error
+local assert = assert
 local tostring = tostring
 local ipairs = ipairs
 local ngx_md5 = ngx.md5
+local ngx_exit = ngx.exit
+local ngx_ERROR = ngx.ERROR
 
 
 local default_cert_and_key
@@ -244,13 +249,13 @@ local function execute()
   local sn, err = server_name()
   if err then
     log(ERR, "could not retrieve SNI: ", err)
-    return ngx.exit(ngx.ERROR)
+    return ngx_exit(ngx_ERROR)
   end
 
   local cert_and_key, err = find_certificate(sn)
   if err then
     log(ERR, err)
-    return ngx.exit(ngx.ERROR)
+    return ngx_exit(ngx_ERROR)
   end
 
   if cert_and_key == default_cert_and_key then
@@ -263,32 +268,32 @@ local function execute()
   local ok, err = clear_certs()
   if not ok then
     log(ERR, "could not clear existing (default) certificates: ", err)
-    return ngx.exit(ngx.ERROR)
+    return ngx_exit(ngx_ERROR)
   end
 
   ok, err = set_cert(cert_and_key.cert)
   if not ok then
     log(ERR, "could not set configured certificate: ", err)
-    return ngx.exit(ngx.ERROR)
+    return ngx_exit(ngx_ERROR)
   end
 
   ok, err = set_priv_key(cert_and_key.key)
   if not ok then
     log(ERR, "could not set configured private key: ", err)
-    return ngx.exit(ngx.ERROR)
+    return ngx_exit(ngx_ERROR)
   end
 
   if cert_and_key.cert_alt and cert_and_key.key_alt then
     ok, err = set_cert(cert_and_key.cert_alt)
     if not ok then
       log(ERR, "could not set alternate configured certificate: ", err)
-      return ngx.exit(ngx.ERROR)
+      return ngx_exit(ngx_ERROR)
     end
 
     ok, err = set_priv_key(cert_and_key.key_alt)
     if not ok then
       log(ERR, "could not set alternate configured private key: ", err)
-      return ngx.exit(ngx.ERROR)
+      return ngx_exit(ngx_ERROR)
     end
   end
 end

--- a/kong/runloop/certificate.lua
+++ b/kong/runloop/certificate.lua
@@ -34,6 +34,11 @@ local default_cert_and_key
 
 local DEFAULT_SNI = "*"
 
+local CA_KEY = {
+  id = "",
+}
+
+
 local function log(lvl, ...)
   ngx_log(lvl, "[ssl] ", ...)
 end
@@ -308,12 +313,11 @@ end
 
 local function fetch_ca_certificates(ca_ids)
   local cas = new_tab(#ca_ids, 0)
-  local key = new_tab(0, 1)
 
   for i, ca_id in ipairs(ca_ids) do
-    key.id = ca_id
+    CA_KEY.id = ca_id
 
-    local obj, err = kong.db.ca_certificates:select(key)
+    local obj, err = kong.db.ca_certificates:select(CA_KEY)
     if not obj then
       if err then
         return nil, err

--- a/kong/runloop/certificate.lua
+++ b/kong/runloop/certificate.lua
@@ -19,6 +19,7 @@ local set_cert = ngx_ssl.set_cert
 local set_priv_key = ngx_ssl.set_priv_key
 local tb_concat   = table.concat
 local tb_sort   = table.sort
+local kong = kong
 local type = type
 local error = error
 local assert = assert
@@ -307,7 +308,7 @@ end
 
 local function fetch_ca_certificates(ca_ids)
   local cas = new_tab(#ca_ids, 0)
-  local key = new_tab(1, 0)
+  local key = new_tab(0, 1)
 
   for i, ca_id in ipairs(ca_ids) do
     key.id = ca_id


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* localize some functions
* change `new_tab(1, 0)` to `new_tab(0, 1)` in `fetch_ca_certificates`


