### PR TITLE
fix(ca_certificates) prevent CA to be deleted that utilized by other entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,8 @@
 - Fix an issue where sorting function for traditional router sources/destinations lead to "invalid order
   function for sorting" error.
   [#10514](https://github.com/Kong/kong/pull/10514)
+- Prevent CA certificate to be deleted that utilized by other entities.
+  [#10120](https://github.com/Kong/kong/pull/10120)
 
 #### Admin API
 

--- a/kong-3.2.1-0.rockspec
+++ b/kong-3.2.1-0.rockspec
@@ -137,6 +137,7 @@ build = {
     ["kong.api.routes.tags"] = "kong/api/routes/tags.lua",
     ["kong.api.routes.clustering"] = "kong/api/routes/clustering.lua",
     ["kong.api.routes.debug"] = "kong/api/routes/debug.lua",
+    ["kong.api.routes.ca_certificates"] = "kong/api/routes/ca_certificates.lua",
 
     ["kong.status"] = "kong/status/init.lua",
 

--- a/kong/api/routes/ca_certificates.lua
+++ b/kong/api/routes/ca_certificates.lua
@@ -1,0 +1,56 @@
+local ngx = ngx
+local kong = kong
+local ipairs = ipairs
+local null = ngx.null
+local string_format = string.format
+
+
+local function each_service(entity)
+  local options = {
+    workspace = null,
+  }
+
+  local iter = entity:each(1000, options)
+  local function iterator()
+    local element, err = iter()
+    if err then return nil, err end
+    if element == nil then return end
+    if element.ca_certificates and #element.ca_certificates > 0 then return element, nil end
+    return iterator()
+  end
+
+  return iterator
+end
+
+
+local function verify_references(id)
+  -- services
+  for service, err in each_service(kong.db.services) do
+    if err then
+      kong.log.err("could not load services: ", err)
+      return
+    end
+
+    for _, v in ipairs(service.ca_certificates) do
+      if v == id then
+        kong.log.notice(string_format("ca_certificate: %s is still referenced from service: %s", id, service.id))
+
+        return kong.response.exit(400, {
+          name = "foreign key violation",
+          fields = { ["@referenced_by"] = "services" },
+          message = "an existing 'services' entity references this 'ca_certificates' entity"
+        })
+      end
+    end
+  end
+end
+
+return {
+  ["/ca_certificates/:ca_certificates"] = {
+    DELETE = function(self, db, helpers, parent)
+      verify_references(self.params.ca_certificates)
+
+      return parent()
+    end,
+  },
+}

--- a/spec/02-integration/04-admin_api/16-ca_certificates_routes_spec.lua
+++ b/spec/02-integration/04-admin_api/16-ca_certificates_routes_spec.lua
@@ -157,6 +157,19 @@ for _, strategy in helpers.each_strategy() do
         local json = cjson.decode(body)
         assert.equal(0, #json.data)
       end)
+
+      it("not allowed if it is referenced by services", function()
+        assert(bp.services:insert {
+          protocol = "https",
+          ca_certificates = { ca.id },
+        })
+        local res = client:delete("/ca_certificates/" .. ca.id)
+
+        local body = assert.res_status(400, res)
+        local json = cjson.decode(body)
+
+        assert.equal("an existing 'services' entity references this 'ca_certificates' entity", json.message)
+      end)
     end)
 
     describe("PATCH", function()


### PR DESCRIPTION
### Summary

Prevent CA to be deleted that utilized by other entities. Currently, Postgres does not support creating foreign keys on fields of type array, so we can't do this by schema constraint.

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* prevent CA to be deleted that utilized by other entities

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix FTI-4343 FTI-2060
