### PR TITLE
fix(pdk/request): support overriding the limit for get_query()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,9 @@
   Expression router instead of the traditional router to ensure created routes
   are actually compatible.
   [#9987](https://github.com/Kong/kong/pull/9987)
+- Support getting all the current request URL query arguments via pdk.request by
+  setting max_args=0.
+  [#10121](https://github.com/Kong/kong/pull/10121)
 
 #### Plugins
 

--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -39,7 +39,7 @@ local function new(self)
   local MIN_HEADERS            = 1
   local MAX_HEADERS_DEFAULT    = 100
   local MAX_HEADERS            = 1000
-  local MIN_QUERY_ARGS         = 1
+  local MIN_QUERY_ARGS         = 0
   local MAX_QUERY_ARGS_DEFAULT = 100
   local MAX_QUERY_ARGS         = 1000
   local MIN_POST_ARGS          = 1
@@ -532,6 +532,9 @@ local function new(self)
 
     if max_args == nil then
       max_args = MAX_QUERY_ARGS_DEFAULT
+
+    elseif max_args == 0 then
+      ngx.log(ngx.WARN, "max_args is set to 0 which may cause potential problems such as denial of service attacks.")
 
     else
       if type(max_args) ~= "number" then

--- a/t/01-pdk/04-request/11-get_query_arg.t
+++ b/t/01-pdk/04-request/11-get_query_arg.t
@@ -165,3 +165,27 @@ GET /t
 error: query argument name must be a string
 --- no_error_log
 [error]
+
+=== TEST 8: request.get_query_arg() can accept 0 as input argument to remove the query limit
+--- http_config eval: $t::Util::HttpConfig
+--- config
+    location = /t {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            local args, err = pdk.request.get_query(0)
+            local count = 0
+            for _, _ in pairs(args) do
+                count = count + 1
+            end
+
+            ngx.say("args_count: ", count, ", error: '", tostring(err), "'")
+        }
+    }
+--- request
+GET /t?a0=0&a1=1&a2=2&a3=3&a4=4&a5=5&a6=6&a7=7&a8=8&a9=9&a10=10&a11=11&a12=12&a13=13&a14=14&a15=15&a16=16&a17=17&a18=18&a19=19&a20=20&a21=21&a22=22&a23=23&a24=24&a25=25&a26=26&a27=27&a28=28&a29=29&a30=30&a31=31&a32=32&a33=33&a34=34&a35=35&a36=36&a37=37&a38=38&a39=39&a40=40&a41=41&a42=42&a43=43&a44=44&a45=45&a46=46&a47=47&a48=48&a49=49&a50=50&a51=51&a52=52&a53=53&a54=54&a55=55&a56=56&a57=57&a58=58&a59=59&a60=60&a61=61&a62=62&a63=63&a64=64&a65=65&a66=66&a67=67&a68=68&a69=69&a70=70&a71=71&a72=72&a73=73&a74=74&a75=75&a76=76&a77=77&a78=78&a79=79&a80=80&a81=81&a82=82&a83=83&a84=84&a85=85&a86=86&a87=87&a88=88&a89=89&a90=90&a91=91&a92=92&a93=93&a94=94&a95=95&a96=96&a97=97&a98=98&a99=99&a100=100
+--- response_body
+args_count: 101, error: 'nil'
+--- no_error_log
+[error]


### PR DESCRIPTION
### Summary

Currently, get_query() method in pdk.request can't support to override the limitation for getting all query parameter. This pr is to support it by allowing max_args=0 to be passed to `ngx.req.get_uri_args` for some special cases. 

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

FTI-2525
