### PR TITLE
doc(developer): remove pcre requirements from developer doc

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -384,7 +384,6 @@ sudo apt update \
     docker \
     docker-compose \
     git \
-    libpcre3 \
     libyaml-dev \
     m4 \
     openssl \
@@ -408,7 +407,6 @@ dnf install \
     libyaml-devel \
     make \
     patch \
-    pcre-devel \
     unzip \
     zlib-devel \
     valgrind \


### PR DESCRIPTION
pcre is buit by ourselves, so user are not required to install pcre

