### PR TITLE
chore(*): lmdb config options in kong.conf.default

### DIFF
--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1375,7 +1375,7 @@
                                       # This path this relative under the Kong
                                       # `prefix`.
 
-#lmdb_map_size = 128m                 # Size of the LMDB memory map, used to store the
+#lmdb_map_size = 128m                 # Maximum size of the LMDB memory map, used to store the
                                       # DB-less and Hybird mode configurations. Default is 128m.
 
 #------------------------------------------------------------------------------

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1368,10 +1368,10 @@
 
 #declarative_config_string =    # The declarative configuration as a string
 
-#lmdb_environment_path =        # Directory where the LMDB database files reside.
+#lmdb_environment_path = dbless.lmdb  # Directory where the LMDB database files reside.
 
-#lmdb_map_size =                # Size of the LMDB memory map, used to store the
-                                # DB-less configuration. Default is 128m.
+#lmdb_map_size = 128m                 # Size of the LMDB memory map, used to store the
+                                      # DB-less configuration. Default is 128m.
 
 #------------------------------------------------------------------------------
 # DATASTORE CACHE

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1368,6 +1368,11 @@
 
 #declarative_config_string =    # The declarative configuration as a string
 
+#lmdb_environment_path =        # Directory where the LMDB database files reside.
+
+#lmdb_map_size =                # Size of the LMDB memory map, used to store the
+                                # DB-less configuration. Default is 128m.
+
 #------------------------------------------------------------------------------
 # DATASTORE CACHE
 #------------------------------------------------------------------------------

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1368,10 +1368,14 @@
 
 #declarative_config_string =    # The declarative configuration as a string
 
-#lmdb_environment_path = dbless.lmdb  # Directory where the LMDB database files reside.
+#lmdb_environment_path = dbless.lmdb  # Directory where the LMDB database files used by
+                                      # DB-less and Hybrid mode to store Kong
+                                      # configurations reside.
+                                      # This path this relative under the Kong
+                                      # `prefix`.
 
 #lmdb_map_size = 128m                 # Size of the LMDB memory map, used to store the
-                                      # DB-less configuration. Default is 128m.
+                                      # DB-less and Hybird mode configurations. Default is 128m.
 
 #------------------------------------------------------------------------------
 # DATASTORE CACHE

--- a/kong.conf.default
+++ b/kong.conf.default
@@ -1371,6 +1371,7 @@
 #lmdb_environment_path = dbless.lmdb  # Directory where the LMDB database files used by
                                       # DB-less and Hybrid mode to store Kong
                                       # configurations reside.
+                                      #
                                       # This path this relative under the Kong
                                       # `prefix`.
 


### PR DESCRIPTION
### Summary

Add missing lmdb configuration options to kong.conf.default

### Issue reference

Fix #10109
