### PR TITLE
fix(api): dynamically sets log level for timers pre-created by timer-ng

### DIFF
--- a/kong-3.2.0-0.rockspec
+++ b/kong-3.2.0-0.rockspec
@@ -41,7 +41,7 @@ dependencies = {
   "lua-resty-ipmatcher == 0.6.1",
   "lua-resty-acme == 0.10.1",
   "lua-resty-session == 4.0.0",
-  "lua-resty-timer-ng == 0.2.0",
+  "lua-resty-timer-ng == 0.2.2",
 }
 build = {
   type = "builtin",

--- a/kong/api/routes/debug.lua
+++ b/kong/api/routes/debug.lua
@@ -64,6 +64,10 @@ local function handle_put_log_level(self, broadcast)
     return kong.response.exit(500, { message = message })
   end
 
+  -- store in global _G table for timers pre-created by lua-resty-timer-ng
+  -- KAG-457 - find a better way to make this work with lua-resty-timer-ng
+  _G.log_level = log_level
+
   return kong.response.exit(200, { message = "log level changed" })
 end
 


### PR DESCRIPTION
If the log level was dynamically set, we must also change the log level for all timers pre-created by the timer-ng library.

We're going to use the global _G table and not a shared dictionary due to performance reasons.