### PR TITLE
chore(deps) bump lua-protobuf from 0.3.3 to 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,8 @@
   [#9942](https://github.com/Kong/kong/pull/9942)
 - Bumped atc-router from 1.0.1 to 1.0.2
   [#9925](https://github.com/Kong/kong/pull/9925)
+- Bumped lua-protobuf from 0.3.3 to 0.4.1
+  [#10137](https://github.com/Kong/kong/pull/10137)
 
 
 ## 3.1.0

--- a/kong-3.2.0-0.rockspec
+++ b/kong-3.2.0-0.rockspec
@@ -31,7 +31,7 @@ dependencies = {
   "lua_pack == 2.0.0",
   "binaryheap >= 0.4",
   "luaxxhash >= 1.0",
-  "lua-protobuf == 0.3.3",
+  "lua-protobuf == 0.4.1",
   "lua-resty-worker-events == 1.0.0",
   "lua-resty-healthcheck == 1.6.2",
   "lua-resty-mlcache == 2.6.0",


### PR DESCRIPTION
### Summary

See: https://github.com/starwing/lua-protobuf/compare/0.3.3...0.4.1