### PR TITLE
chore(deps) bump resty-timer-ng from 0.2.0 to 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,8 @@
   [#9942](https://github.com/Kong/kong/pull/9942)
 - Bumped atc-router from 1.0.1 to 1.0.2
   [#9925](https://github.com/Kong/kong/pull/9925)
+- Bumped resty-timer-ng from 0.2.0 to 0.2.1
+  [#10138](https://github.com/Kong/kong/pull/10138)
 
 
 ## 3.1.0

--- a/kong-3.2.0-0.rockspec
+++ b/kong-3.2.0-0.rockspec
@@ -41,7 +41,7 @@ dependencies = {
   "lua-resty-ipmatcher == 0.6.1",
   "lua-resty-acme == 0.10.1",
   "lua-resty-session == 3.10",
-  "lua-resty-timer-ng == 0.2.0",
+  "lua-resty-timer-ng == 0.2.1",
 }
 build = {
   type = "builtin",


### PR DESCRIPTION
# Summary

- chore(tests): pin third party actions to sha by @ADD-SP
- fix(loop) dynamically sets log level for timers if needed (KAG-326) by @gruceo
- fix: too many scaling logs by @ADD-SP
- chore(rockspec) release 0.2.1 by @gruceo

Full Changelog: https://github.com/Kong/lua-resty-timer-ng/compare/0.2.0...0.2.1