### PR TITLE
chore(deps) bump dev dependency of luacheck from 1.0.0 to 1.1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ $(info starting make in kong)
 OS := $(shell uname | awk '{print tolower($$0)}')
 MACHINE := $(shell uname -m)
 
-DEV_ROCKS = "busted 2.1.1" "busted-htest 1.0.0" "luacheck 1.0.0" "lua-llthreads2 0.1.6" "http 0.4" "ldoc 1.4.6"
+DEV_ROCKS = "busted 2.1.1" "busted-htest 1.0.0" "luacheck 1.1.0" "lua-llthreads2 0.1.6" "http 0.4" "ldoc 1.4.6"
 WIN_SCRIPTS = "bin/busted" "bin/kong" "bin/kong-health"
 BUSTED_ARGS ?= -v
 TEST_CMD ?= bin/busted $(BUSTED_ARGS)


### PR DESCRIPTION
### Summary

#### Features

- Add builtin rule set for SILE globals — @alerque
- Implement support for compound operators — @a2 & @arichard4

#### Bug Fixes

- Correct circular reference detection visavis OpSet — @arichard4
- Remove unnecessary symbol from Playdate std — @DidierMalenfant