### PR TITLE
chore(router/atc): pass routes count to `router.new()`

### DIFF
--- a/kong/router/atc.lua
+++ b/kong/router/atc.lua
@@ -165,9 +165,11 @@ end
 
 local function new_from_scratch(routes, get_exp_and_priority)
   local phase = get_phase()
-  local inst = router.new(CACHED_SCHEMA)
 
-  local routes_n   = #routes
+  local routes_n = #routes
+
+  local inst = router.new(CACHED_SCHEMA, routes_n)
+
   local routes_t   = tb_new(0, routes_n)
   local services_t = tb_new(0, routes_n)
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->
In atc-router 1.04, we can pass the routes count param to `new()` function.

See https://github.com/Kong/atc-router/pull/9

### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE


