### PR TITLE
feat(db): add `description` to metaschema fields

### DIFF
--- a/kong/db/schema/metaschema.lua
+++ b/kong/db/schema/metaschema.lua
@@ -72,6 +72,7 @@ local field_schema = {
   { type = { type = "string", one_of = keys(Schema.valid_types), required = true }, },
   { required = { type = "boolean" }, },
   { reference = { type = "string" }, },
+  { description = { type = "string" }, },
   { auto = { type = "boolean" }, },
   { unique = { type = "boolean" }, },
   { unique_across_ws = { type = "boolean" }, },


### PR DESCRIPTION
### Summary

This allows for in-place documentation of fields.
If we agree to follow this more meticulously we could generate documentation from code.

Signed-off-by: Joshua Schmid <jaiks@posteo.de>

