### PR TITLE
refactor(clustering/compat): using array to store compatible checker functions

### DIFF
--- a/kong-3.2.1-0.rockspec
+++ b/kong-3.2.1-0.rockspec
@@ -78,6 +78,7 @@ build = {
     ["kong.clustering.compat"] = "kong/clustering/compat/init.lua",
     ["kong.clustering.compat.version"] = "kong/clustering/compat/version.lua",
     ["kong.clustering.compat.removed_fields"] = "kong/clustering/compat/removed_fields.lua",
+    ["kong.clustering.compat.checkers"] = "kong/clustering/compat/checkers.lua",
     ["kong.clustering.config_helper"] = "kong/clustering/config_helper.lua",
     ["kong.clustering.tls"] = "kong/clustering/tls.lua",
 

--- a/kong/clustering/compat/checkers.lua
+++ b/kong/clustering/compat/checkers.lua
@@ -1,8 +1,6 @@
 local ipairs = ipairs
 
 
-
-
 local KONG_VERSION = require("kong.meta").version
 
 

--- a/kong/clustering/compat/checkers.lua
+++ b/kong/clustering/compat/checkers.lua
@@ -35,13 +35,16 @@ local compatible_checkers = {
 
       for _, name in ipairs(entity_names) do
         for _, config_entity in ipairs(config_table[name] or {}) do
-          ngx_log(ngx_WARN, _log_prefix, "Kong Gateway v" .. KONG_VERSION ..
-            " contains configuration '" .. name .. ".updated_at'",
-            " which is incompatible with dataplane version " .. dp_version .. " and will",
-            " be removed.", log_suffix)
+          log_warn_message("contains configuration '" .. name .. ".updated_at'",
+                           "be removed",
+                           dp_version,
+                           log_suffix)
           config_entity.updated_at = nil
+          has_update = true
         end
       end
+
+      return has_update
     end
   },
 
@@ -70,7 +73,7 @@ local compatible_checkers = {
       end
 
       if has_update then
-        log_warn_message("tls protocol service contains configuration 'service.client_certificate' " ..
+        log_warn_message("tls protocol service contains configuration 'service.client_certificate'" ..
                          "or 'service.tls_verify' or 'service.tls_verify_depth' or 'service.ca_certificates'",
                          "be removed",
                          dp_version,

--- a/kong/clustering/compat/checkers.lua
+++ b/kong/clustering/compat/checkers.lua
@@ -1,13 +1,27 @@
 local ipairs = ipairs
 
 
-local ngx = ngx
-local ngx_log = ngx.log
-local ngx_WARN = ngx.WARN
 
 
-local _log_prefix = "[clustering] "
 local KONG_VERSION = require("kong.meta").version
+
+
+local log_warn_message
+do
+  local ngx_log = ngx.log
+  local ngx_WARN = ngx.WARN
+  local fmt = string.format
+
+  local _log_prefix = "[clustering] "
+
+  log_warn_message = function(hint, action, dp_version, log_suffix)
+    local msg = fmt("Kong Gateway v%s %s " ..
+                    "which is incompatible with dataplane version %s " ..
+                    "and will %s.",
+                    KONG_VERSION, hint, dp_version, action)
+    ngx_log(ngx_WARN, _log_prefix, msg, log_suffix)
+  end
+end
 
 
 local compatible_checkers = {
@@ -58,11 +72,11 @@ local compatible_checkers = {
       end
 
       if has_update then
-        ngx_log(ngx_WARN, _log_prefix, "Kong Gateway v" .. KONG_VERSION ..
-                " tls protocol service contains configuration 'service.client_certificate'",
-                " or 'service.tls_verify' or 'service.tls_verify_depth' or 'service.ca_certificates'",
-                " which is incompatible with dataplane version " .. dp_version .. " and will",
-                " be removed.", log_suffix)
+        log_warn_message("tls protocol service contains configuration 'service.client_certificate' " ..
+                         "or 'service.tls_verify' or 'service.tls_verify_depth' or 'service.ca_certificates'",
+                         "be removed",
+                         dp_version,
+                         log_suffix)
       end
 
       return has_update
@@ -85,10 +99,10 @@ local compatible_checkers = {
       end
 
       if has_update then
-        ngx_log(ngx_WARN, _log_prefix, "Kong Gateway v" .. KONG_VERSION ..
-                " configuration 'upstream.algorithm' contain 'latency' option",
-                " which is incompatible with dataplane version " .. dp_version .. " and will",
-                " be fall back to 'round-robin'.", log_suffix)
+        log_warn_message("configuration 'upstream.algorithm' contains 'latency' option",
+                         "fall back to 'round-robin'",
+                         dp_version,
+                         log_suffix)
       end
 
       return has_update
@@ -111,10 +125,10 @@ local compatible_checkers = {
       end
 
       if has_update then
-        ngx_log(ngx_WARN, _log_prefix, "Kong Gateway v" .. KONG_VERSION ..
-                " contains configuration 'plugin.instance_name'",
-                " which is incompatible with dataplane version " .. dp_version,
-                " and will be removed.", log_suffix)
+        log_warn_message("contains configuration 'plugin.instance_name'",
+                         "be removed",
+                         dp_version,
+                         log_suffix)
       end
 
       return has_update
@@ -137,10 +151,10 @@ local compatible_checkers = {
       end
 
       if has_update then
-        ngx_log(ngx_WARN, _log_prefix, "Kong Gateway v" .. KONG_VERSION ..
-                " contains configuration 'upstream.use_srv_name'",
-                " which is incompatible with dataplane version " .. dp_version,
-                " and will be removed.", log_suffix)
+        log_warn_message("contains configuration 'upstream.use_srv_name'",
+                         "be removed",
+                         dp_version,
+                         log_suffix)
       end
 
       return has_update

--- a/kong/clustering/compat/checkers.lua
+++ b/kong/clustering/compat/checkers.lua
@@ -32,15 +32,23 @@ local compatible_checkers = {
         }
 
       local has_update
+      local updated_entities = {}
 
       for _, name in ipairs(entity_names) do
         for _, config_entity in ipairs(config_table[name] or {}) do
+          config_entity.updated_at = nil
+
+          updated_entities[name] = true
+          has_update = true
+        end
+      end
+
+      if has_update then
+        for name, _ in pairs(updated_entities) do
           log_warn_message("contains configuration '" .. name .. ".updated_at'",
                            "be removed",
                            dp_version,
                            log_suffix)
-          config_entity.updated_at = nil
-          has_update = true
         end
       end
 

--- a/kong/clustering/compat/checkers.lua
+++ b/kong/clustering/compat/checkers.lua
@@ -56,7 +56,8 @@ local compatible_checkers = {
       for _, t in ipairs(config_services) do
         if t["protocol"] == "tls" then
           if t["client_certificate"] or t["tls_verify"] or
-             t["tls_verify_depth"]   or t["ca_certificates"] then
+             t["tls_verify_depth"]   or t["ca_certificates"]
+          then
 
             t["client_certificate"] = nil
             t["tls_verify"] = nil

--- a/kong/clustering/compat/checkers.lua
+++ b/kong/clustering/compat/checkers.lua
@@ -37,10 +37,13 @@ local compatible_checkers = {
 
       for _, name in ipairs(entity_names) do
         for _, config_entity in ipairs(config_table[name] or {}) do
-          config_entity["updated_at"] = nil
+          if config_entity["updated_at"] then
 
-          updated_entities[name] = true
-          has_update = true
+            config_entity["updated_at"] = nil
+
+            updated_entities[name] = true
+            has_update = true
+          end
         end
       end
 

--- a/kong/clustering/compat/checkers.lua
+++ b/kong/clustering/compat/checkers.lua
@@ -41,18 +41,17 @@ local compatible_checkers = {
 
             config_entity["updated_at"] = nil
 
-            updated_entities[name] = true
             has_update = true
-          end
-        end
-      end
 
-      if has_update then
-        for name, _ in pairs(updated_entities) do
-          log_warn_message("contains configuration '" .. name .. ".updated_at'",
-                           "be removed",
-                           dp_version,
-                           log_suffix)
+            if not updated_entities[name] then
+              log_warn_message("contains configuration '" .. name .. ".updated_at'",
+                               "be removed",
+                               dp_version,
+                               log_suffix)
+
+              updated_entities[name] = true
+            end
+          end
         end
       end
 

--- a/kong/clustering/compat/checkers.lua
+++ b/kong/clustering/compat/checkers.lua
@@ -1,0 +1,152 @@
+local ipairs = ipairs
+
+
+local ngx = ngx
+local ngx_log = ngx.log
+local ngx_WARN = ngx.WARN
+
+
+local _log_prefix = "[clustering] "
+local KONG_VERSION = require("kong.meta").version
+
+
+local compatible_checkers = {
+  { 3003000000, --[[ 3.3.0.0 ]]
+    function(config_table, dp_version, log_suffix)
+      -- remove updated_at field for core entities ca_certificates, certificates, consumers,
+      -- targets, upstreams, plugins, workspaces, clustering_data_planes and snis
+      local entity_names = {
+        "ca_certificates", "certificates", "consumers", "targets", "upstreams",
+        "plugins", "workspaces", "clustering_data_planes", "snis",
+        }
+
+      local has_update
+
+      for _, name in ipairs(entity_names) do
+        for _, config_entity in ipairs(config_table[name] or {}) do
+          ngx_log(ngx_WARN, _log_prefix, "Kong Gateway v" .. KONG_VERSION ..
+            " contains configuration '" .. name .. ".updated_at'",
+            " which is incompatible with dataplane version " .. dp_version .. " and will",
+            " be removed.", log_suffix)
+          config_entity.updated_at = nil
+        end
+      end
+    end
+  },
+
+  { 3002000000, --[[ 3.2.0.0 ]]
+    function(config_table, dp_version, log_suffix)
+      local config_services = config_table["services"]
+      if not config_services  then
+        return nil
+      end
+
+      local has_update
+      for _, t in ipairs(config_services) do
+        if t["protocol"] == "tls" then
+          if t["client_certificate"] or t["tls_verify"] or
+             t["tls_verify_depth"]   or t["ca_certificates"] then
+
+            t["client_certificate"] = nil
+            t["tls_verify"] = nil
+            t["tls_verify_depth"] = nil
+            t["ca_certificates"] = nil
+
+            has_update = true
+          end
+        end
+      end
+
+      if has_update then
+        ngx_log(ngx_WARN, _log_prefix, "Kong Gateway v" .. KONG_VERSION ..
+                " tls protocol service contains configuration 'service.client_certificate'",
+                " or 'service.tls_verify' or 'service.tls_verify_depth' or 'service.ca_certificates'",
+                " which is incompatible with dataplane version " .. dp_version .. " and will",
+                " be removed.", log_suffix)
+      end
+
+      return has_update
+    end
+  },
+
+  { 3002000000, --[[ 3.2.0.0 ]]
+    function(config_table, dp_version, log_suffix)
+      local config_upstreams = config_table["upstreams"]
+      if not config_upstreams  then
+        return nil
+      end
+
+      local has_update
+      for _, t in ipairs(config_upstreams) do
+        if t["algorithm"] == "latency" then
+          t["algorithm"] = "round-robin"
+          has_update = true
+        end
+      end
+
+      if has_update then
+        ngx_log(ngx_WARN, _log_prefix, "Kong Gateway v" .. KONG_VERSION ..
+                " configuration 'upstream.algorithm' contain 'latency' option",
+                " which is incompatible with dataplane version " .. dp_version .. " and will",
+                " be fall back to 'round-robin'.", log_suffix)
+      end
+
+      return has_update
+    end
+  },
+
+  { 3002000000, --[[ 3.2.0.0 ]]
+    function(config_table, dp_version, log_suffix)
+      local config_plugins = config_table["plugins"]
+      if not config_plugins then
+        return nil
+      end
+
+      local has_update
+      for _, plugin in ipairs(config_plugins) do
+        if plugin["instance_name"] ~= nil then
+          plugin["instance_name"] = nil
+          has_update = true
+        end
+      end
+
+      if has_update then
+        ngx_log(ngx_WARN, _log_prefix, "Kong Gateway v" .. KONG_VERSION ..
+                " contains configuration 'plugin.instance_name'",
+                " which is incompatible with dataplane version " .. dp_version,
+                " and will be removed.", log_suffix)
+      end
+
+      return has_update
+    end
+  },
+
+  { 3001000000, --[[ 3.1.0.0 ]]
+    function(config_table, dp_version, log_suffix)
+      local config_upstreams = config_table["upstreams"]
+      if not config_upstreams then
+        return nil
+      end
+
+      local has_update
+      for _, t in ipairs(config_upstreams) do
+        if t["use_srv_name"] ~= nil then
+          t["use_srv_name"] = nil
+          has_update = true
+        end
+      end
+
+      if has_update then
+        ngx_log(ngx_WARN, _log_prefix, "Kong Gateway v" .. KONG_VERSION ..
+                " contains configuration 'upstream.use_srv_name'",
+                " which is incompatible with dataplane version " .. dp_version,
+                " and will be removed.", log_suffix)
+      end
+
+      return has_update
+    end
+  },
+}
+
+
+return compatible_checkers

--- a/kong/clustering/compat/checkers.lua
+++ b/kong/clustering/compat/checkers.lua
@@ -1,3 +1,4 @@
+local pairs  = pairs
 local ipairs = ipairs
 
 
@@ -36,7 +37,7 @@ local compatible_checkers = {
 
       for _, name in ipairs(entity_names) do
         for _, config_entity in ipairs(config_table[name] or {}) do
-          config_entity.updated_at = nil
+          config_entity["updated_at"] = nil
 
           updated_entities[name] = true
           has_update = true

--- a/kong/clustering/compat/checkers.lua
+++ b/kong/clustering/compat/checkers.lua
@@ -1,14 +1,13 @@
 local ipairs = ipairs
 
 
-local KONG_VERSION = require("kong.meta").version
-
-
 local log_warn_message
 do
   local ngx_log = ngx.log
   local ngx_WARN = ngx.WARN
   local fmt = string.format
+
+  local KONG_VERSION = require("kong.meta").version
 
   local _log_prefix = "[clustering] "
 

--- a/kong/clustering/compat/checkers.lua
+++ b/kong/clustering/compat/checkers.lua
@@ -1,4 +1,3 @@
-local pairs  = pairs
 local ipairs = ipairs
 
 

--- a/kong/clustering/compat/init.lua
+++ b/kong/clustering/compat/init.lua
@@ -26,7 +26,7 @@ local extract_major_minor = version.extract_major_minor
 local _log_prefix = "[clustering] "
 
 local REMOVED_FIELDS = require("kong.clustering.compat.removed_fields")
-local COMPATIBLE_CHECKERS = require("kong.clustering.compat.checkers")
+local COMPATIBILITY_CHECKERS = require("kong.clustering.compat.checkers")
 local CLUSTERING_SYNC_STATUS = constants.CLUSTERING_SYNC_STATUS
 local KONG_VERSION = meta.version
 
@@ -361,7 +361,7 @@ function _M.update_compatible_payload(payload, dp_version, log_suffix)
     end
   end
 
-  for _, checker in ipairs(COMPATIBLE_CHECKERS) do
+  for _, checker in ipairs(COMPATIBILITY_CHECKERS) do
     local ver = checker[1]
     local fn  = checker[2]
     if dp_version_num < ver and fn(config_table, dp_version, log_suffix) then

--- a/kong/clustering/compat/init.lua
+++ b/kong/clustering/compat/init.lua
@@ -26,6 +26,7 @@ local extract_major_minor = version.extract_major_minor
 local _log_prefix = "[clustering] "
 
 local REMOVED_FIELDS = require("kong.clustering.compat.removed_fields")
+local COMPATIBLE_CHECKERS = require("kong.clustering.compat.checkers")
 local CLUSTERING_SYNC_STATUS = constants.CLUSTERING_SYNC_STATUS
 local KONG_VERSION = meta.version
 
@@ -360,91 +361,11 @@ function _M.update_compatible_payload(payload, dp_version, log_suffix)
     end
   end
 
-  if dp_version_num < 3003000000 --[[ 3.3.0.0 ]] then
-    -- remove updated_at field for core entities ca_certificates, certificates, consumers,
-    -- targets, upstreams, plugins, workspaces, clustering_data_planes and snis
-    local entity_names = {'ca_certificates', 'certificates', 'consumers', 'targets', 'upstreams',
-      'plugins', 'workspaces', 'clustering_data_planes', 'snis'}
-
-    for _, name in ipairs(entity_names) do
-      for _, config_entity in ipairs(config_table[name] or {}) do
-        if config_entity["updated_at"] ~= nil then
-          ngx_log(ngx_WARN, _log_prefix, "Kong Gateway v" .. KONG_VERSION ..
-            " contains configuration '" .. name .. ".updated_at'",
-            " which is incompatible with dataplane version " .. dp_version .. " and will",
-            " be removed.", log_suffix)
-          config_entity["updated_at"] = nil
-          has_update = true
-        end
-      end
-    end
-  end
-
-  if dp_version_num < 3002000000 --[[ 3.2.0.0 ]] then
-    local config_plugins = config_table["plugins"]
-    if config_plugins then
-      for _, plugin in ipairs(config_plugins) do
-        if plugin["instance_name"] ~= nil then
-          ngx_log(ngx_WARN, _log_prefix, "Kong Gateway v" .. KONG_VERSION ..
-            " contains configuration 'plugin.instance_name'",
-            " which is incompatible with dataplane version " .. dp_version .. " and will",
-            " be removed.", log_suffix)
-          plugin["instance_name"] = nil
-          has_update = true
-        end
-      end
-    end
-
-    local config_services = config_table["services"]
-    if config_services then
-      for _, t in ipairs(config_services) do
-        if t["protocol"] == "tls" then
-          if t["client_certificate"] or t["tls_verify"]
-              or t["tls_verify_depth"] or t["ca_certificates"] then
-            ngx_log(ngx_WARN, _log_prefix, "Kong Gateway v" .. KONG_VERSION ..
-                      " tls protocol service contains configuration 'service.client_certificate'",
-                      " or 'service.tls_verify' or 'service.tls_verify_depth' or 'service.ca_certificates'",
-                      " which is incompatible with dataplane version " .. dp_version .. " and will",
-                      " be removed.", log_suffix)
-            t["client_certificate"] = nil
-            t["tls_verify"] = nil
-            t["tls_verify_depth"] = nil
-            t["ca_certificates"] = nil
-            has_update = true
-          end
-        end
-      end
-    end
-
-    local config_upstreams = config_table["upstreams"]
-    if config_upstreams then
-      for _, t in ipairs(config_upstreams) do
-        if t["algorithm"] == "latency" then
-          ngx_log(ngx_WARN, _log_prefix, "Kong Gateway v" .. KONG_VERSION ..
-                  " configuration 'upstream.algorithm' contain 'latency' option",
-                  " which is incompatible with dataplane version " .. dp_version .. " and will",
-                  " be fall back to 'round-robin'.", log_suffix)
-          t["algorithm"] = "round-robin"
-          has_update = true
-        end
-      end
-    end
-  end
-
-
-  if dp_version_num < 3001000000 --[[ 3.1.0.0 ]] then
-    local config_upstream = config_table["upstreams"]
-    if config_upstream then
-      for _, t in ipairs(config_upstream) do
-        if t["use_srv_name"] ~= nil then
-          ngx_log(ngx_WARN, _log_prefix, "Kong Gateway v" .. KONG_VERSION ..
-                  " contains configuration 'upstream.use_srv_name'",
-                  " which is incompatible with dataplane version " .. dp_version .. " and will",
-                  " be removed.", log_suffix)
-          t["use_srv_name"] = nil
-          has_update = true
-        end
-      end
+  for _, checker in ipairs(COMPATIBLE_CHECKERS) do
+    local ver = checker[1]
+    local fn  = checker[2]
+    if dp_version_num < ver and fn(config_table, dp_version, log_suffix) then
+      has_update = true
     end
   end
 


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

<!--- Why is this change required? What problem does it solve? -->

Move compatible config-checking logic into a hash table, making code more readable.

Need special cherry-pick action to EE.


### Checklist

- [ ] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE


