### PR TITLE
refactor(clustering): reorganize cert validation code

### DIFF
--- a/kong-3.2.0-0.rockspec
+++ b/kong-3.2.0-0.rockspec
@@ -78,6 +78,7 @@ build = {
     ["kong.clustering.compat.version"] = "kong/clustering/compat/version.lua",
     ["kong.clustering.compat.removed_fields"] = "kong/clustering/compat/removed_fields.lua",
     ["kong.clustering.config_helper"] = "kong/clustering/config_helper.lua",
+    ["kong.clustering.tls"] = "kong/clustering/tls.lua",
 
     ["kong.cluster_events"] = "kong/cluster_events/init.lua",
     ["kong.cluster_events.strategies.cassandra"] = "kong/cluster_events/strategies/cassandra.lua",

--- a/kong/clustering/control_plane.lua
+++ b/kong/clustering/control_plane.lua
@@ -42,6 +42,7 @@ local plugins_list_to_map = compat.plugins_list_to_map
 local update_compatible_payload = compat.update_compatible_payload
 local deflate_gzip = utils.deflate_gzip
 local yield = utils.yield
+local connect_dp = clustering_utils.connect_dp
 
 
 local kong_dict = ngx.shared.kong
@@ -74,13 +75,17 @@ local function is_timeout(err)
 end
 
 
-function _M.new(conf, cert_digest)
+function _M.new(clustering)
+  assert(type(clustering) == "table",
+         "kong.clustering is not instantiated")
+
+  assert(type(clustering.conf) == "table",
+         "kong.clustering did not provide configuration")
+
   local self = {
     clients = setmetatable({}, { __mode = "k", }),
     plugins_map = {},
-
-    conf = conf,
-    cert_digest = cert_digest,
+    conf = clustering.conf,
   }
 
   return setmetatable(self, _MT)
@@ -172,9 +177,7 @@ function _M:handle_cp_websocket()
   local dp_ip = ngx_var.remote_addr
   local dp_version = ngx_var.arg_node_version
 
-  local wb, log_suffix, ec = clustering_utils.connect_dp(
-                                self.conf, self.cert_digest,
-                                dp_id, dp_hostname, dp_ip, dp_version)
+  local wb, log_suffix, ec = connect_dp(dp_id, dp_hostname, dp_ip, dp_version)
   if not wb then
     return ngx_exit(ec)
   end

--- a/kong/clustering/data_plane.lua
+++ b/kong/clustering/data_plane.lua
@@ -46,12 +46,24 @@ local function is_timeout(err)
 end
 
 
-function _M.new(conf, cert, cert_key)
+function _M.new(clustering)
+  assert(type(clustering) == "table",
+         "kong.clustering is not instantiated")
+
+  assert(type(clustering.conf) == "table",
+         "kong.clustering did not provide configuration")
+
+  assert(type(clustering.cert) == "table",
+         "kong.clustering did not provide the cluster certificate")
+
+  assert(type(clustering.cert_key) == "cdata",
+         "kong.clustering did not provide the cluster certificate private key")
+
   local self = {
-    declarative_config = declarative.new_config(conf),
-    conf = conf,
-    cert = cert,
-    cert_key = cert_key,
+    declarative_config = assert(declarative.new_config(clustering.conf)),
+    conf = clustering.conf,
+    cert = clustering.cert,
+    cert_key = clustering.cert_key,
   }
 
   return setmetatable(self, _MT)
@@ -102,8 +114,7 @@ function _M:communicate(premature)
   local log_suffix = " [" .. conf.cluster_control_plane .. "]"
   local reconnection_delay = math.random(5, 10)
 
-  local c, uri, err = clustering_utils.connect_cp(
-                        "/v1/outlet", conf, self.cert, self.cert_key)
+  local c, uri, err = clustering_utils.connect_cp(self, "/v1/outlet")
   if not c then
     ngx_log(ngx_ERR, _log_prefix, "connection to control plane ", uri, " broken: ", err,
                  " (retrying after ", reconnection_delay, " seconds)", log_suffix)

--- a/kong/clustering/init.lua
+++ b/kong/clustering/init.lua
@@ -2,12 +2,10 @@ local _M = {}
 local _MT = { __index = _M, }
 
 
-local pl_file = require("pl.file")
 local pl_tablex = require("pl.tablex")
-local ssl = require("ngx.ssl")
-local openssl_x509 = require("resty.openssl.x509")
 local clustering_utils = require("kong.clustering.utils")
 local events = require("kong.clustering.events")
+local clustering_tls = require("kong.clustering.tls")
 
 
 local assert = assert
@@ -15,6 +13,20 @@ local sort = table.sort
 
 
 local is_dp_worker_process = clustering_utils.is_dp_worker_process
+local validate_client_cert = clustering_tls.validate_client_cert
+local get_cluster_cert = clustering_tls.get_cluster_cert
+local get_cluster_cert_key = clustering_tls.get_cluster_cert_key
+
+local setmetatable = setmetatable
+local ngx = ngx
+local ngx_log = ngx.log
+local ngx_var = ngx.var
+local kong = kong
+local ngx_exit = ngx.exit
+local ngx_ERR = ngx.ERR
+
+
+local _log_prefix = "[clustering] "
 
 
 function _M.new(conf)
@@ -22,29 +34,45 @@ function _M.new(conf)
 
   local self = {
     conf = conf,
+    cert = assert(get_cluster_cert(conf)),
+    cert_key = assert(get_cluster_cert_key(conf)),
   }
 
   setmetatable(self, _MT)
 
-  local cert = assert(pl_file.read(conf.cluster_cert))
-  self.cert = assert(ssl.parse_pem_cert(cert))
-
-  cert = openssl_x509.new(cert, "PEM")
-  self.cert_digest = cert:digest("sha256")
-
-  local key = assert(pl_file.read(conf.cluster_cert_key))
-  self.cert_key = assert(ssl.parse_pem_priv_key(key))
-
   if conf.role == "control_plane" then
     self.json_handler =
-      require("kong.clustering.control_plane").new(self.conf, self.cert_digest)
+      require("kong.clustering.control_plane").new(self)
   end
 
   return self
 end
 
 
+--- Validate the client certificate presented by the data plane.
+---
+--- If no certificate is passed in by the caller, it will be read from
+--- ngx.var.ssl_client_raw_cert.
+---
+---@param cert_pem? string # data plane cert text
+---
+---@return boolean? success
+---@return string?  error
+function _M:validate_client_cert(cert_pem)
+  -- XXX: do not refactor or change the call signature of this function without
+  -- reviewing the EE codebase first to sanity-check your changes
+  cert_pem = cert_pem or ngx_var.ssl_client_raw_cert
+  return validate_client_cert(self.conf, self.cert, cert_pem)
+end
+
+
 function _M:handle_cp_websocket()
+  local ok, err = self:validate_client_cert()
+  if not ok then
+    ngx_log(ngx_ERR, _log_prefix, err)
+    return ngx_exit(444)
+  end
+
   return self.json_handler:handle_cp_websocket()
 end
 
@@ -63,7 +91,7 @@ function _M:init_dp_worker(plugins_list)
       return
     end
 
-    self.child = require("kong.clustering.data_plane").new(self.conf, self.cert, self.cert_key)
+    self.child = require("kong.clustering.data_plane").new(self)
     self.child:init_worker(plugins_list)
   end
 

--- a/kong/clustering/tls.lua
+++ b/kong/clustering/tls.lua
@@ -1,0 +1,232 @@
+-- TLS helpers for kong.clustering
+local tls = {}
+
+
+local openssl_x509 = require("resty.openssl.x509")
+local pl_file = require("pl.file")
+local ssl = require("ngx.ssl")
+local http = require("resty.http")
+local ocsp = require("ngx.ocsp")
+
+local constants = require("kong.constants")
+
+
+local ngx_log = ngx.log
+local WARN = ngx.WARN
+
+local OCSP_TIMEOUT = constants.CLUSTERING_OCSP_TIMEOUT
+
+
+
+local function log(lvl, ...)
+  ngx_log(lvl, "[clustering] ", ...)
+end
+
+
+local function validate_shared_cert(cert, cert_digest)
+  local digest, err = cert:digest("sha256")
+  if not digest then
+    return nil, "unable to retrieve data plane client certificate digest " ..
+                "during handshake: " .. err
+  end
+
+  if digest ~= cert_digest then
+    return nil, "data plane presented incorrect client certificate during " ..
+                "handshake (digest does not match the control plane certifiate)"
+  end
+
+  return true
+end
+
+local check_for_revocation_status
+do
+  local get_full_client_certificate_chain = require("resty.kong.tls").get_full_client_certificate_chain
+  check_for_revocation_status = function()
+    local cert, err = get_full_client_certificate_chain()
+    if not cert then
+      return nil, err or "no client certificate"
+    end
+
+    local der_cert
+    der_cert, err = ssl.cert_pem_to_der(cert)
+    if not der_cert then
+      return nil, "failed to convert certificate chain from PEM to DER: " .. err
+    end
+
+    local ocsp_url
+    ocsp_url, err = ocsp.get_ocsp_responder_from_der_chain(der_cert)
+    if not ocsp_url then
+      return nil, err or ("OCSP responder endpoint can not be determined, " ..
+                          "maybe the client certificate is missing the " ..
+                          "required extensions")
+    end
+
+    local ocsp_req
+    ocsp_req, err = ocsp.create_ocsp_request(der_cert)
+    if not ocsp_req then
+      return nil, "failed to create OCSP request: " .. err
+    end
+
+    local c = http.new()
+    local res
+    res, err = c:request_uri(ocsp_url, {
+      headers = {
+        ["Content-Type"] = "application/ocsp-request",
+      },
+      timeout = OCSP_TIMEOUT,
+      method = "POST",
+      body = ocsp_req,
+    })
+
+    if not res then
+      return nil, "failed sending request to OCSP responder: " .. tostring(err)
+    end
+    if res.status ~= 200 then
+      return nil, "OCSP responder returns bad HTTP status code: " .. res.status
+    end
+
+    local ocsp_resp = res.body
+    if not ocsp_resp or #ocsp_resp == 0 then
+      return nil, "unexpected response from OCSP responder: empty body"
+    end
+
+    res, err = ocsp.validate_ocsp_response(ocsp_resp, der_cert)
+    if not res then
+      return false, "failed to validate OCSP response: " .. err
+    end
+
+    return true
+  end
+end
+
+
+---@class kong.clustering.certinfo : table
+---
+---@field raw                 string      # raw, PEM-encoded certificate string
+---@field cdata               ffi.cdata*  # cdata pointer returned by ngx.ssl.parse_pem_cert()
+---@field x509                table       # resty.openssl.x509 object
+---@field digest              string      # sha256 certificate digest
+---@field common_name?        string      # CN field of the certificate
+---@field parent_common_name? string      # parent domain of the certificate CN
+
+
+--- Read and parse the cluster certificate from disk.
+---
+---@param  kong_config               table
+---@return kong.clustering.certinfo? cert
+---@return string|nil                error
+function tls.get_cluster_cert(kong_config)
+  local raw, cdata, x509, digest
+  -- `cn` and `parent_cn` are populated and used in EE. They are included here
+  -- to keep the shared code more consistent between repositories.
+  local cn, parent_cn = nil, nil
+  local err
+
+  raw, err = pl_file.read(kong_config.cluster_cert)
+  if not raw then
+    return nil, "failed reading the cluster certificate file: "
+                .. tostring(err)
+  end
+
+  cdata, err = ssl.parse_pem_cert(raw)
+  if not cdata then
+    return nil, "failed parsing the cluster certificate PEM data: "
+                .. tostring(err)
+  end
+
+  x509, err = openssl_x509.new(raw, "PEM")
+  if not x509 then
+    return nil, "failed creating x509 object for the cluster certificate: "
+                .. tostring(err)
+  end
+
+  digest, err = x509:digest("sha256")
+  if not digest then
+    return nil, "failed calculating the cluster certificate digest: "
+                .. tostring(err)
+  end
+
+  return {
+    cdata                  = cdata,
+    common_name            = cn,
+    digest                 = digest,
+    parent_common_name     = parent_cn,
+    raw                    = raw,
+    x509                   = x509,
+  }
+end
+
+
+--- Read and parse the cluster certificate private key from disk.
+---
+---@param  kong_config    table
+---@return ffi.cdata*|nil private_key
+---@return string|nil     error
+function tls.get_cluster_cert_key(kong_config)
+  local key_pem, key, err
+
+  key_pem, err = pl_file.read(kong_config.cluster_cert_key)
+  if not key_pem then
+    return nil, "failed reading the cluster certificate private key file: "
+                .. tostring(err)
+  end
+
+  key, err = ssl.parse_pem_priv_key(key_pem)
+  if not key then
+    return nil, "failed parsing the cluster certificate private key PEM data: "
+                .. tostring(err)
+  end
+
+  return key
+end
+
+
+--- Validate the client certificate presented by the data plane.
+---
+---@param kong_config  table                    # kong.configuration table
+---@param cp_cert      kong.clustering.certinfo # clustering certinfo table
+---@param dp_cert_pem  string                   # data plane cert text
+---
+---@return boolean? success
+---@return string?  error
+function tls.validate_client_cert(kong_config, cp_cert, dp_cert_pem)
+  if not dp_cert_pem then
+    return nil, "data plane failed to present client certificate during handshake"
+  end
+
+  local cert, err = openssl_x509.new(dp_cert_pem, "PEM")
+  if not cert then
+    return nil, "unable to load data plane client certificate during handshake: " .. err
+  end
+
+  local ok, _
+
+  -- use mutual TLS authentication
+  if kong_config.cluster_mtls == "shared" then
+    _, err = validate_shared_cert(cert, cp_cert.digest)
+
+  elseif kong_config.cluster_ocsp ~= "off" then
+    ok, err = check_for_revocation_status()
+    if ok == false then
+      err = "data plane client certificate was revoked: " ..  err
+
+    elseif not ok then
+      if kong_config.cluster_ocsp == "on" then
+        err = "data plane client certificate revocation check failed: " .. err
+
+      else
+        log(WARN, "data plane client certificate revocation check failed: ", err)
+        err = nil
+      end
+    end
+  end
+
+  if err then
+    return nil, err
+  end
+
+  return true
+end
+
+
+return tls

--- a/kong/clustering/utils.lua
+++ b/kong/clustering/utils.lua
@@ -1,8 +1,4 @@
 local constants = require("kong.constants")
-local openssl_x509 = require("resty.openssl.x509")
-local ssl = require("ngx.ssl")
-local ocsp = require("ngx.ocsp")
-local http = require("resty.http")
 local ws_client = require("resty.websocket.client")
 local ws_server = require("resty.websocket.server")
 local parse_url = require("socket.url").parse
@@ -17,7 +13,6 @@ local fmt = string.format
 local kong = kong
 
 local ngx = ngx
-local ngx_var = ngx.var
 local ngx_log = ngx.log
 local ngx_DEBUG = ngx.DEBUG
 local ngx_WARN = ngx.WARN
@@ -26,137 +21,12 @@ local ngx_CLOSE = ngx.HTTP_CLOSE
 
 local _log_prefix = "[clustering] "
 
-local OCSP_TIMEOUT = constants.CLUSTERING_OCSP_TIMEOUT
-
 local KONG_VERSION = kong.version
 
 local prefix = kong.configuration.prefix or require("pl.path").abspath(ngx.config.prefix())
 local CLUSTER_PROXY_SSL_TERMINATOR_SOCK = fmt("unix:%s/cluster_proxy_ssl_terminator.sock", prefix)
 
 local _M = {}
-
-
-local function validate_shared_cert(cert_digest)
-  local cert = ngx_var.ssl_client_raw_cert
-
-  if not cert then
-    return nil, "data plane failed to present client certificate during handshake"
-  end
-
-  local err
-  cert, err = openssl_x509.new(cert, "PEM")
-  if not cert then
-    return nil, "unable to load data plane client certificate during handshake: " .. err
-  end
-
-  local digest
-  digest, err = cert:digest("sha256")
-  if not digest then
-    return nil, "unable to retrieve data plane client certificate digest during handshake: " .. err
-  end
-
-  if digest ~= cert_digest then
-    return nil, "data plane presented incorrect client certificate during handshake (expected: " ..
-      cert_digest .. ", got: " .. digest .. ")"
-  end
-
-  return true
-end
-
-local check_for_revocation_status
-do
-  local get_full_client_certificate_chain = require("resty.kong.tls").get_full_client_certificate_chain
-  check_for_revocation_status = function()
-
-    local cert, err = get_full_client_certificate_chain()
-    if not cert then
-      return nil, err or "no client certificate"
-    end
-
-    local der_cert
-    der_cert, err = ssl.cert_pem_to_der(cert)
-    if not der_cert then
-      return nil, "failed to convert certificate chain from PEM to DER: " .. err
-    end
-
-    local ocsp_url
-    ocsp_url, err = ocsp.get_ocsp_responder_from_der_chain(der_cert)
-    if not ocsp_url then
-      return nil, err or "OCSP responder endpoint can not be determined, " ..
-        "maybe the client certificate is missing the " ..
-        "required extensions"
-    end
-
-    local ocsp_req
-    ocsp_req, err = ocsp.create_ocsp_request(der_cert)
-    if not ocsp_req then
-      return nil, "failed to create OCSP request: " .. err
-    end
-
-    local c = http.new()
-    local res
-    res, err = c:request_uri(ocsp_url, {
-      headers = {
-        ["Content-Type"] = "application/ocsp-request",
-      },
-      timeout = OCSP_TIMEOUT,
-      method = "POST",
-      body = ocsp_req,
-    })
-
-    if not res then
-      return nil, "failed sending request to OCSP responder: " .. tostring(err)
-    end
-    if res.status ~= 200 then
-      return nil, "OCSP responder returns bad HTTP status code: " .. res.status
-    end
-
-    local ocsp_resp = res.body
-    if not ocsp_resp or #ocsp_resp == 0 then
-      return nil, "unexpected response from OCSP responder: empty body"
-    end
-
-    res, err = ocsp.validate_ocsp_response(ocsp_resp, der_cert)
-    if not res then
-      return false, "failed to validate OCSP response: " .. err
-    end
-
-    return true
-  end
-end
-
-_M.check_for_revocation_status = check_for_revocation_status
-
-local function validate_connection_certs(conf, cert_digest)
-  local _, err
-
-  -- use mutual TLS authentication
-  if conf.cluster_mtls == "shared" then
-    _, err = validate_shared_cert(cert_digest)
-
-  elseif conf.cluster_ocsp ~= "off" then
-    local ok
-    ok, err = check_for_revocation_status()
-    if ok == false then
-      err = "data plane client certificate was revoked: " ..  err
-
-    elseif not ok then
-      if conf.cluster_ocsp == "on" then
-        err = "data plane client certificate revocation check failed: " .. err
-
-      else
-        ngx_log(ngx_WARN, _log_prefix, "data plane client certificate revocation check failed: ", err)
-        err = nil
-      end
-    end
-  end
-
-  if err then
-    return nil, err
-  end
-
-  return true
-end
 
 
 local function parse_proxy_url(conf)
@@ -192,7 +62,8 @@ local WS_OPTS = {
 }
 
 -- TODO: pick one random CP
-function _M.connect_cp(endpoint, conf, cert, cert_key, protocols)
+function _M.connect_cp(dp, endpoint, protocols)
+  local conf = dp.conf
   local address = conf.cluster_control_plane .. endpoint
 
   local c = assert(ws_client:new(WS_OPTS))
@@ -203,8 +74,8 @@ function _M.connect_cp(endpoint, conf, cert, cert_key, protocols)
 
   local opts = {
     ssl_verify = true,
-    client_cert = cert,
-    client_priv_key = cert_key,
+    client_cert = dp.cert.cdata,
+    client_priv_key = dp.cert_key,
     protocols = protocols,
   }
 
@@ -238,8 +109,7 @@ function _M.connect_cp(endpoint, conf, cert, cert_key, protocols)
 end
 
 
-function _M.connect_dp(conf, cert_digest,
-                       dp_id, dp_hostname, dp_ip, dp_version)
+function _M.connect_dp(dp_id, dp_hostname, dp_ip, dp_version)
   local log_suffix = {}
 
   if type(dp_id) == "string" then
@@ -262,12 +132,6 @@ function _M.connect_dp(conf, cert_digest,
     log_suffix = " [" .. table_concat(log_suffix, ", ") .. "]"
   else
     log_suffix = ""
-  end
-
-  local ok, err = validate_connection_certs(conf, cert_digest)
-  if not ok then
-    ngx_log(ngx_ERR, _log_prefix, err)
-    return nil, nil, ngx.HTTP_CLOSE
   end
 
   if not dp_id then

--- a/kong/conf_loader/init.lua
+++ b/kong/conf_loader/init.lua
@@ -1106,7 +1106,7 @@ local function check_and_parse(conf, opts)
     if conf.cluster_mtls == "shared" then
       insert(conf.lua_ssl_trusted_certificate, conf.cluster_cert)
 
-    elseif conf.cluster_mtls == "pki" then
+    elseif conf.cluster_mtls == "pki" or conf.cluster_mtls == "pki_check_cn" then
       insert(conf.lua_ssl_trusted_certificate, conf.cluster_ca_cert)
     end
 

--- a/spec/02-integration/09-hybrid_mode/03-pki_spec.lua
+++ b/spec/02-integration/09-hybrid_mode/03-pki_spec.lua
@@ -10,6 +10,8 @@ describe("CP/DP PKI sync #" .. strategy, function()
     helpers.get_db_utils(strategy, {
       "routes",
       "services",
+      -- ensure we have no stale data plane info before testing
+      "clustering_data_planes",
     }) -- runs migrations
 
     assert(helpers.start_kong({

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -3444,7 +3444,7 @@ local function clustering_client(opts)
     ssl_verify = false, -- needed for busted tests as CP certs are not trusted by the CLI
     client_cert = assert(ssl.parse_pem_cert(assert(pl_file.read(opts.cert)))),
     client_priv_key = assert(ssl.parse_pem_priv_key(assert(pl_file.read(opts.cert_key)))),
-    server_name = "kong_clustering",
+    server_name = opts.server_name or "kong_clustering",
   }
 
   local res, err = c:connect(uri, conn_opts)


### PR DESCRIPTION
## background

This is a backport of refactoring that was performed in [Kong/kong-ee#4375](https://github.com/Kong/kong-ee/pull/4375). I am aware it's far from ideal to merge code in EE first and backport it into OSS, but the refactor was required in order to merge some bugfix code for an EE-specific clustering feature, so here we are. In any case, keep all of this in mind when reviewing, as I'm sure the context will help.


## summary
This moves most all of the code that handles certificates for clustering into a new, discrete module: kong.clustering.tls.

### changes

  - The control_plane and utils modules no longer handle certificate validation--this is done at the root level via the `kong.clustering:validate_client_cert()` function.

### notes

  - In order to untangle all the tightly-coupled code, call signatures for several functions were changed:
    * `kong.clustering.data_plane.new()`
    * `kong.clustering.control_plane.new()`
    * `kong.clustering.utils.connect_cp()`
    * `kong.clustering.utils.connect_dp()`

  - There are some some references here to EE-specific features such as the `pki_check_cn` setting for `cluster_mtls`. Until we organize the code better, I feel this is helpful in preventing OSS changes from mistakenly causing breakage when merged by EE.

KAG-455