### PR TITLE
fix(tracing) add http.status_code, fix http.flavor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,8 @@
   [#10044](https://github.com/Kong/kong/pull/10044)
 - **OpenTelemetry**: Fix non-compliance to specification for `http.uri` in spans. The field should be full HTTP URI.
   [#10036](https://github.com/Kong/kong/pull/10036)
+- **OpenTelemetry**: Fix non-compliance to specification by setting `http.status_code` on spans for requests that have a status code.
+  [#10036](https://github.com/Kong/kong/pull/10160)
 - **OAuth2**: `refresh_token_ttl` is now limited between `0` and `100000000` by schema validator. Previously numbers that are too large causes requests to fail.
   [#10068](https://github.com/Kong/kong/pull/10068)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,10 +135,13 @@
   [#10052](https://github.com/Kong/kong/pull/10052)
 - **Datadog**: Fix a bug in the Datadog plugin batch queue processing where metrics are published multiple times.
   [#10044](https://github.com/Kong/kong/pull/10044)
-- **OpenTelemetry**: Fix non-compliance to specification for `http.uri` in spans. The field should be full HTTP URI.
-  [#10036](https://github.com/Kong/kong/pull/10036)
-- **OpenTelemetry**: Fix non-compliance to specification by setting `http.status_code` on spans for requests that have a status code.
-  [#10036](https://github.com/Kong/kong/pull/10160)
+- **OpenTelemetry**: Fix non-compliances to specification:
+  - For `http.uri` in spans. The field should be full HTTP URI.
+    [#10036](https://github.com/Kong/kong/pull/10036)
+  - For `http.status_code`. It should be present on spans for requests that have a status code.
+    [#10160](https://github.com/Kong/kong/pull/10160)
+  - For `http.flavor`. It should be a string value, not a double.
+    [#10160](https://github.com/Kong/kong/pull/10160)
 - **OAuth2**: `refresh_token_ttl` is now limited between `0` and `100000000` by schema validator. Previously numbers that are too large causes requests to fail.
   [#10068](https://github.com/Kong/kong/pull/10068)
 

--- a/kong/plugins/opentelemetry/otlp.lua
+++ b/kong/plugins/opentelemetry/otlp.lua
@@ -20,6 +20,16 @@ for i = 0, 2 do
   PB_STATUS[i] = { code = i }
 end
 
+local KEY_TO_ATTRIBUTE_TYPES = {
+  ["http.status_code"] = "int_value",
+}
+
+local TYPE_TO_ATTRIBUTE_TYPES = {
+  string = "string_value",
+  number = "double_value",
+  boolean = "bool_value",
+}
+
 local function transform_attributes(attr)
   if type(attr) ~= "table" then
     error("invalid attributes", 2)
@@ -27,25 +37,12 @@ local function transform_attributes(attr)
 
   local pb_attributes = new_tab(nkeys(attr), 0)
   for k, v in pairs(attr) do
-    local typ = type(v)
-    local pb_val
 
-    if typ == "string" then
-      pb_val = { string_value = v }
-
-    elseif typ == "number" then
-      pb_val = { double_value = v }
-
-    elseif typ == "boolean" then
-      pb_val = { bool_value = v }
-
-    else
-      pb_val = EMPTY_TAB -- considered empty
-    end
+    local attribute_type = KEY_TO_ATTRIBUTE_TYPES[k] or TYPE_TO_ATTRIBUTE_TYPES[type(v)]
 
     insert(pb_attributes, {
       key = k,
-      value = pb_val,
+      value = attribute_type and { [attribute_type] = v } or EMPTY_TAB
     })
   end
 

--- a/kong/runloop/handler.lua
+++ b/kong/runloop/handler.lua
@@ -1450,6 +1450,8 @@ return {
         end
       end
 
+      instrumentation.runloop_before_header_filter(status)
+
       local hash_cookie = ctx.balancer_data.hash_cookie
       if hash_cookie then
         balancer.set_cookie(hash_cookie)

--- a/kong/tracing/instrumentation.lua
+++ b/kong/tracing/instrumentation.lua
@@ -196,6 +196,11 @@ function _M.request(ctx)
                  and ctx.KONG_PROCESSING_START * 1e6
                   or time_ns()
 
+  local http_flavor = ngx.req.http_version()
+  if type(http_flavor) == "number" then
+    http_flavor = string.format("%.1f", http_flavor)
+  end
+
   local active_span = tracer.start_span(span_name, {
     span_kind = 2, -- server
     start_time_ns = start_time,
@@ -204,7 +209,7 @@ function _M.request(ctx)
       ["http.url"] = req_uri,
       ["http.host"] = host,
       ["http.scheme"] = scheme,
-      ["http.flavor"] = ngx.req.http_version(),
+      ["http.flavor"] = http_flavor,
       ["net.peer.ip"] = client.get_ip(),
     },
   })

--- a/kong/tracing/instrumentation.lua
+++ b/kong/tracing/instrumentation.lua
@@ -170,7 +170,7 @@ function _M.http_client()
   http.request_uri = wrap
 end
 
---- Regsiter vailable_types
+--- Register available_types
 -- functions in this list will be replaced with NOOP
 -- if tracing module is NOT enabled.
 for k, _ in pairs(_M) do
@@ -261,7 +261,16 @@ do
   available_types.dns_query = true
 end
 
+
 -- runloop
+function _M.runloop_before_header_filter()
+  local root_span = ngx.ctx.KONG_SPANS and ngx.ctx.KONG_SPANS[1]
+  if root_span then
+    root_span:set_attribute("http.status_code", ngx.status)
+  end
+end
+
+
 function _M.runloop_log_before(ctx)
   -- add balancer
   _M.balancer(ctx)

--- a/spec/03-plugins/37-opentelemetry/04-exporter_spec.lua
+++ b/spec/03-plugins/37-opentelemetry/04-exporter_spec.lua
@@ -441,7 +441,7 @@ for _, strategy in helpers.each_strategy() do
         local attr = span.attributes
         sort_by_key(attr)
         assert.same({
-          { key = "http.flavor", value = { double_value = 1.1 } },
+          { key = "http.flavor", value = { string_value = "1.1" } },
           { key = "http.host", value = { string_value = "0.0.0.0" } },
           { key = "http.method", value = { string_value = "GET" } },
           { key = "http.scheme", value = { string_value = "http" } },

--- a/spec/03-plugins/37-opentelemetry/04-exporter_spec.lua
+++ b/spec/03-plugins/37-opentelemetry/04-exporter_spec.lua
@@ -445,6 +445,7 @@ for _, strategy in helpers.each_strategy() do
           { key = "http.host", value = { string_value = "0.0.0.0" } },
           { key = "http.method", value = { string_value = "GET" } },
           { key = "http.scheme", value = { string_value = "http" } },
+          { key = "http.status_code", value = { int_value = 200 } },
           { key = "http.url", value = { string_value = "http://0.0.0.0/" } },
           { key = "net.peer.ip", value = { string_value = "127.0.0.1" } },
         }, attr)


### PR DESCRIPTION
### Summary

According to the opentracing spec, the `http.status_code` attribute is:

> Conditionally Required: If and only if one was received/sent.

Also, the `http.flavor` attribute is supposed to be a string, not a double.

Ref: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md

This change sets `http.status_code` on the root span once it is available (at the beginning of the `header_filter` phase) and also modifies the `http.flavor` attribute type so they both follow the spec.

### Checklist

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- <del>[ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE</del>

### Full changelog

* Fix(tracing) add http.status_code attribute to root span, if available

### Issue reference

FTI-4644 / KAG-463

