### PR TITLE
fix(pdk): request.get_raw_query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,12 @@
 - **OAuth2**: `refresh_token_ttl` is now limited between `0` and `100000000` by schema validator. Previously numbers that are too large causes requests to fail.
   [#10068](https://github.com/Kong/kong/pull/10068)
 
+#### PDK
+
+- Fix an issue where service.request.set_raw_query fails when called after
+  request.get_raw_query
+  [#10164](https://github.com/Kong/kong/pull/10164)
+
 ### Changed
 
 #### Hybrid Mode

--- a/kong/pdk/request.lua
+++ b/kong/pdk/request.lua
@@ -454,7 +454,9 @@ local function new(self)
   function _REQUEST.get_raw_query()
     check_phase(PHASES.request)
 
-    return var.args or ""
+    local uri = var.request_uri or ""
+    local q = find(uri, "?", 2, true)
+    return q and sub(uri, q + 1, -1) or ""
   end
 
 

--- a/t/01-pdk/04-request/22-get_set_raw_query.t
+++ b/t/01-pdk/04-request/22-get_set_raw_query.t
@@ -1,0 +1,32 @@
+use Test::Nginx::Socket::Lua;
+
+repeat_each(2);
+plan tests => repeat_each() * (blocks() * 2);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: service.request.set_raw_query() works if preceded by
+request.get_raw_query() github issue #10080
+--- http_config
+    lua_package_path "../lua-resty-core/lib/?.lua;lualib/?.lua;;";
+    lua_kong_load_var_index $args;
+    init_by_lua_block {
+        require("resty.kong.var").patch_metatable()
+    }
+--- config
+    location = /t {
+        access_by_lua_block {
+            local PDK = require "kong.pdk"
+            local pdk = PDK.new()
+
+            local q = pdk.request.get_raw_query()
+            pdk.service.request.set_raw_query("test=val")
+            ngx.say("args: ", ngx.var.args)
+        }
+    }
+--- request
+GET /t
+--- response_body
+args: test=val


### PR DESCRIPTION
### Summary

Avoid accessing `ngx.var.args` and fetch the raw query string from the request_uri instead.

Alternatives could be restricting access to happen only via ngx.var.* or implementing some index clearing logic in [lua-kong-nginx-module](https://github.com/Kong/lua-kong-nginx-module/blob/fec73310688b16da974a97e52bf27aa9c698bfaa/lualib/resty/kong/var.lua#L153-L187) by patching set_uri_args(). 

Possibly going to close this in favor of: https://github.com/Kong/lua-kong-nginx-module/pull/59


Fix #10080

[KAG-410]


[KAG-410]: https://konghq.atlassian.net/browse/KAG-410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ