### PR TITLE
style(bug_report): Allow reproduce formatting

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -40,7 +40,6 @@ body:
       2. With this config...
       3. Run '...'
       4. See error...
-    render: markdown
   validations:
     required: false
 - type: textarea


### PR DESCRIPTION
### Summary

Allow the "steps to reproduce" section to be formatted and previewed as Markdown like the other sections. It's currently not clear how it will be formatted when you're writing an issue. Everything gets put inside a single code fence and I frequently find that I need to reformat it after first submitting an issue.

### Checklist

I don't think that any of these were applicable. I've ticked them to indicate that they aren't "outstanding":

- [x] The Pull Request has tests
- [x] There's an entry in the CHANGELOG
- [x] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

N/A

### Issue reference

N/A
