### PR TITLE
fix(key-auth): return unauthorized if api key includes symbols that are not allowed

### DIFF
--- a/kong/plugins/key-auth/handler.lua
+++ b/kong/plugins/key-auth/handler.lua
@@ -30,6 +30,7 @@ local _realm = 'Key realm="' .. _KONG._NAME .. '"'
 
 local ERR_DUPLICATE_API_KEY   = { status = 401, message = "Duplicate API key found" }
 local ERR_NO_API_KEY          = { status = 401, message = "No API key found in request" }
+local ERR_INVALID_API_KEY     = { status = 401, message = "Invalid symbol(s) found in API key" }
 local ERR_INVALID_AUTH_CRED   = { status = 401, message = "Invalid authentication credentials" }
 local ERR_INVALID_PLUGIN_CONF = { status = 500, message = "Invalid plugin configuration" }
 local ERR_UNEXPECTED          = { status = 500, message = "An unexpected error occurred" }
@@ -168,6 +169,12 @@ local function do_authentication(conf)
   if not key or key == "" then
     kong.response.set_header("WWW-Authenticate", _realm)
     return nil, ERR_NO_API_KEY
+  end
+
+  -- this request contains invalid symbol in API key, HTTP 401
+  if not key:find("^[%w%-%_]+$") then
+    kong.response.set_header("WWW-Authenticate", _realm)
+    return nil, ERR_INVALID_API_KEY
   end
 
   -- retrieve our consumer linked to this API key

--- a/spec/03-plugins/09-key-auth/02-access_spec.lua
+++ b/spec/03-plugins/09-key-auth/02-access_spec.lua
@@ -245,6 +245,19 @@ for _, strategy in helpers.each_strategy() do
         local json = cjson.decode(body)
         assert.same({ message = "No API key found in request" }, json)
       end)
+      it("returns Unauthorized on invalid symbol in key header", function()
+        local res = assert(proxy_client:send {
+          method  = "GET",
+          path    = "/status/200",
+          headers = {
+            ["Host"] = "key-auth1.com",
+            ["apikey"] = "5SRmk6gý",
+          }
+        })
+        local body = assert.res_status(401, res)
+        local json = cjson.decode(body)
+        assert.same({ message = "Invalid symbol(s) found in API key" }, json)
+      end)
       it("returns WWW-Authenticate header on missing credentials", function()
         local res = assert(proxy_client:send {
           method  = "GET",


### PR DESCRIPTION
Currently the key-auth plugin returns HTTP 500 (Internal Server Error) status code if the api key includes non-ascii symbols. This is not appropriate .This updates the key-auth plugin to send HTTP 401 (Unauthorized) status code on such cases.

* return 401 when the api key includes non-ascii symbols
* add a new test case in key-auth plugin

Fix #5627

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Currently the key-auth plugin returns HTTP 500 (Internal Server Error) status code if the api key includes non-ascii symbols. This is not appropriate .This updates the key-auth plugin to send HTTP 401 (Unauthorized) status code on such cases.

### Checklist

- [x] The Pull Request has tests
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/Kong/docs.konghq.com - PUT DOCS PR HERE

### Full changelog

* [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #5627 
