### PR TITLE
fix(build): make ca-certificates an explicit dependency

### DIFF
--- a/build/package/nfpm.yaml
+++ b/build/package/nfpm.yaml
@@ -45,6 +45,8 @@ replaces:
 conflicts:
 - kong-community-edition
 - kong-enterprise-edition-fips
+depends:
+- ca-certificates
 overrides:
   deb:
     depends:


### PR DESCRIPTION
nfpm docs for reference: https://nfpm.goreleaser.com/configuration/