### PR TITLE
chore(development): add vim modelines to bin/*

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,3 +20,15 @@ indent_size              = 4
 
 [Makefile]
 indent_style             = tab
+
+[bin/kong]
+indent_style             = space
+indent_size              = 2
+
+[bin/busted]
+indent_style             = space
+indent_size              = 2
+
+[bin/kong-health]
+indent_style             = space
+indent_size              = 2

--- a/bin/busted
+++ b/bin/busted
@@ -60,3 +60,5 @@ require("kong.globalpatches")({
 
 -- Busted command-line runner
 require 'busted.runner'({ standalone = false })
+
+-- vim: set ft=lua ts=2 sw=2 sts=2 et :

--- a/bin/kong
+++ b/bin/kong
@@ -7,3 +7,5 @@ pcall(require, "luarocks.loader")
 package.path = (os.getenv("KONG_LUA_PATH_OVERRIDE") or "") .. "./?.lua;./?/init.lua;" .. package.path
 
 require("kong.cmd.init")(arg)
+
+-- vim: set ft=lua ts=2 sw=2 sts=2 et :

--- a/bin/kong-health
+++ b/bin/kong-health
@@ -75,3 +75,5 @@ end
 
 
 run(arg)
+
+-- vim: set ft=lua ts=2 sw=2 sts=2 et :


### PR DESCRIPTION
This adds vim [modelines](https://vim.fandom.com/wiki/Modeline_magic) to our lua scripts in bin/ to identify their filetypes and set the proper indentation settings.

I wish this could be done without cluttering up files with comment strings, but .editorconfig does not have any notion of "treat this file as $filetype." I have updated .editorconfig with the proper settings for these files, however.