### PR TITLE
chore(deps) bump resty-timer-ng from 0.2.0 to 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,8 @@
   [#10144](https://github.com/Kong/kong/pull/10144)
 - Bumped lua-kong-nginx-module from 0.5.0 to 0.5.1
   [#10181](https://github.com/Kong/kong/pull/10181)
+- Bumped resty-timer-ng from 0.2.0 to 0.2.2
+  [#10138](https://github.com/Kong/kong/pull/10193)
 
 
 ## 3.1.0

--- a/kong-3.2.0-0.rockspec
+++ b/kong-3.2.0-0.rockspec
@@ -41,7 +41,7 @@ dependencies = {
   "lua-resty-ipmatcher == 0.6.1",
   "lua-resty-acme == 0.10.1",
   "lua-resty-session == 3.10",
-  "lua-resty-timer-ng == 0.2.0",
+  "lua-resty-timer-ng == 0.2.2",
 }
 build = {
   type = "builtin",


### PR DESCRIPTION
# Summary

- chore(tests): pin third party actions to sha by @ADD-SP
- fix(loop) dynamically sets log level for timers if needed (KAG-326) by @gruceo
- fix: too many scaling logs by @ADD-SP
- chore(rockspec) release 0.2.1 by @gruceo
- fix(loop) only use set_log_level API on http subsystem

Full Changelog: https://github.com/Kong/lua-resty-timer-ng/compare/0.2.0...0.2.2