### PR TITLE
chore(deps) bump resty.session from 3.10 to 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,11 @@
 
 - **JWT**: JWT plugin now denies a request that has different tokens in the jwt token search locations.
   [#9946](https://github.com/Kong/kong/pull/9946)
+- **Session**: for sessions to work as expected it is required that all nodes run Kong >= 3.2.x.
+  For that reason it is advisable that during upgrades mixed versions of proxy nodes run for
+  as little as possible. During that time, the invalid sessions could cause failures and partial downtime.
+  All existing sessions are invalidated when upgrading to this version.
+  [#10199](https://github.com/Kong/kong/pull/10199)
 
 ### Additions
 
@@ -121,6 +126,8 @@
   Defaults to `nil` which means do not add any tags
   to the metrics.
   [#10118](https://github.com/Kong/kong/pull/10118)
+- **Session**: now uses lua-resty-session v4.0.0
+  [#10199](https://github.com/Kong/kong/pull/10199)
 
 #### Admin API
 
@@ -183,6 +190,8 @@
   [#10144](https://github.com/Kong/kong/pull/10144)
 - Bumped lua-kong-nginx-module from 0.5.0 to 0.5.1
   [#10181](https://github.com/Kong/kong/pull/10181)
+- Bumped lua-resty-session from 3.10 to 4.0.0
+  [#10199](https://github.com/Kong/kong/pull/10199)
 
 #### Core
 

--- a/kong-3.2.0-0.rockspec
+++ b/kong-3.2.0-0.rockspec
@@ -40,7 +40,7 @@ dependencies = {
   "lua-resty-counter == 0.2.1",
   "lua-resty-ipmatcher == 0.6.1",
   "lua-resty-acme == 0.10.1",
-  "lua-resty-session == 3.10",
+  "lua-resty-session == 4.0.0",
   "lua-resty-timer-ng == 0.2.0",
 }
 build = {

--- a/kong/clustering/compat/init.lua
+++ b/kong/clustering/compat/init.lua
@@ -235,7 +235,16 @@ local function delete_at(t, key)
 end
 
 
-local function invalidate_keys_from_config(config_plugins, keys, log_suffix)
+local function rename_field(config, name_from, name_to, has_update)
+  if config[name_from] ~= nil then
+    config[name_to] = config[name_from]
+    return true
+  end
+  return has_update
+end
+
+
+local function invalidate_keys_from_config(config_plugins, keys, log_suffix, dp_version_num)
   if not config_plugins then
     return false
   end
@@ -246,8 +255,24 @@ local function invalidate_keys_from_config(config_plugins, keys, log_suffix)
     local config = t and t["config"]
     if config then
       local name = gsub(t["name"], "-", "_")
-
       if keys[name] ~= nil then
+        -- Any dataplane older than 3.2.0
+        if dp_version_num < 3002000000 then
+          -- OSS
+          if name == "session" then
+            has_update = rename_field(config, "idling_timeout", "cookie_idletime", has_update)
+            has_update = rename_field(config, "rolling_timeout", "cookie_lifetime", has_update)
+            has_update = rename_field(config, "stale_ttl", "cookie_discard", has_update)
+            has_update = rename_field(config, "cookie_same_site", "cookie_samesite", has_update)
+            has_update = rename_field(config, "cookie_http_only", "cookie_httponly", has_update)
+            has_update = rename_field(config, "remember", "cookie_persistent", has_update)
+
+            if config["cookie_samesite"] == "Default" then
+              config["cookie_samesite"] = "Lax"
+            end
+          end
+        end
+
         for _, key in ipairs(keys[name]) do
           if delete_at(config, key) then
             ngx_log(ngx_WARN, _log_prefix, name, " plugin contains configuration '", key,
@@ -329,7 +354,7 @@ function _M.update_compatible_payload(payload, dp_version, log_suffix)
 
   local fields = get_removed_fields(dp_version_num)
   if fields then
-    if invalidate_keys_from_config(config_table["plugins"], fields, log_suffix) then
+    if invalidate_keys_from_config(config_table["plugins"], fields, log_suffix, dp_version_num) then
       has_update = true
     end
   end
@@ -385,7 +410,7 @@ function _M.update_compatible_payload(payload, dp_version, log_suffix)
     end
   end
 
-  
+
   if dp_version_num < 3001000000 --[[ 3.1.0.0 ]] then
     local config_upstream = config_table["upstreams"]
     if config_upstream then

--- a/kong/clustering/compat/removed_fields.lua
+++ b/kong/clustering/compat/removed_fields.lua
@@ -34,10 +34,19 @@ return {
       "http_response_header_for_traceid",
     },
   },
-  -- Any dataplane older than 3.1.0
+  -- Any dataplane older than 3.2.0
   [3002000000] = {
     statsd = {
       "tag_style",
     },
-  }
+    session = {
+      "audience",
+      "absolute_timeout",
+      "remember_cookie_name",
+      "remember_rolling_timeout",
+      "remember_absolute_timeout",
+      "response_headers",
+      "request_headers",
+    },
+  },
 }

--- a/kong/plugins/session/daos.lua
+++ b/kong/plugins/session/daos.lua
@@ -1,5 +1,6 @@
 local typedefs = require "kong.db.schema.typedefs"
 
+
 return {
   {
     primary_key = { "id" },

--- a/kong/plugins/session/handler.lua
+++ b/kong/plugins/session/handler.lua
@@ -9,12 +9,12 @@ local KongSessionHandler = {
 }
 
 
-function KongSessionHandler.header_filter(_, conf)
+function KongSessionHandler:header_filter(conf)
   header_filter.execute(conf)
 end
 
 
-function KongSessionHandler.access(_, conf)
+function KongSessionHandler:access(conf)
   access.execute(conf)
 end
 

--- a/kong/plugins/session/header_filter.lua
+++ b/kong/plugins/session/header_filter.lua
@@ -10,7 +10,7 @@ local assert = assert
 local function get_authenticated_groups()
   local authenticated_groups = ngx.ctx.authenticated_groups
   if authenticated_groups == nil then
-    return nil
+    return
   end
 
   assert(type(authenticated_groups) == "table",
@@ -29,19 +29,26 @@ function _M.execute(conf)
 
   if not credential then
     -- don't open sessions for anonymous users
-    kong.log.debug("anonymous: no credential.")
+    kong.log.debug("anonymous: no credential")
     return
   end
 
   local credential_id = credential.id
-  local consumer_id = consumer and consumer.id
+
+  local subject
+  local consumer_id
+  if consumer then
+    consumer_id = consumer.id
+    subject = consumer.username or consumer.custom_id or consumer_id
+  end
 
   -- if session exists and the data in the session matches the ctx then
   -- don't worry about saving the session data or sending cookie
-  local s = kong.ctx.shared.authenticated_session
-  if s and s.present then
-    local cid, cred_id = kong_session.retrieve_session_data(s)
-    if cred_id == credential_id and cid == consumer_id
+  local session = kong.ctx.shared.authenticated_session
+  if session then
+    local session_consumer_id, session_credential_id = kong_session.get_session_data(session)
+    if session_credential_id == credential_id and
+       session_consumer_id   == consumer_id
     then
       return
     end
@@ -51,12 +58,27 @@ function _M.execute(conf)
   -- create new session and save the data / send the Set-Cookie header
   if consumer_id then
     local groups = get_authenticated_groups()
-    s = s or kong_session.open_session(conf)
-    kong_session.store_session_data(s,
-                                    consumer_id,
-                                    credential_id or consumer_id,
-                                    groups)
-    s:save()
+    if not session then
+      session = kong_session.open_session(conf)
+    end
+
+    kong_session.set_session_data(session,
+                                  consumer_id,
+                                  credential_id or consumer_id,
+                                  groups)
+
+    session:set_subject(subject)
+
+    local ok, err = session:save()
+    if not ok then
+      if err then
+        kong.log.err("session save failed (", err, ")")
+      else
+        kong.log.err("session save failed")
+      end
+    end
+
+    session:set_response_headers()
   end
 end
 

--- a/spec/03-plugins/30-session/02-kong_storage_adapter_spec.lua
+++ b/spec/03-plugins/30-session/02-kong_storage_adapter_spec.lua
@@ -1,12 +1,5 @@
 local helpers = require "spec.helpers"
-local utils = require "kong.tools.utils"
 local cjson = require "cjson"
-
-
-local function get_sid_from_cookie(cookie)
-  local cookie_parts = utils.split(cookie, "; ")
-  return utils.split(utils.split(cookie_parts[1], "|")[1], "=")[2]
-end
 
 
 for _, strategy in helpers.each_strategy() do
@@ -24,17 +17,17 @@ for _, strategy in helpers.each_strategy() do
       }, { "ctx-checker" })
 
       local route1 = bp.routes:insert {
-        paths    = {"/test1"},
+        paths = {"/test1"},
         hosts = {"konghq.com"}
       }
 
       local route2 = bp.routes:insert {
-        paths    = {"/test2"},
+        paths = {"/test2"},
         hosts = {"konghq.com"}
       }
 
       local route3 = bp.routes:insert {
-        paths    = {"/headers"},
+        paths = {"/headers"},
         hosts = {"konghq.com"},
       }
 
@@ -46,6 +39,7 @@ for _, strategy in helpers.each_strategy() do
         config = {
           storage = "kong",
           secret = "ultra top secret session",
+          response_headers = { "id", "timeout", "audience", "subject" }
         }
       })
 
@@ -57,8 +51,8 @@ for _, strategy in helpers.each_strategy() do
         config = {
           secret = "super secret session secret",
           storage = "kong",
-          cookie_renew = 600,
-          cookie_lifetime = 604,
+          rolling_timeout = 4,
+          response_headers = { "id", "timeout", "audience", "subject" }
         }
       })
 
@@ -70,6 +64,7 @@ for _, strategy in helpers.each_strategy() do
         config = {
           storage = "kong",
           secret = "ultra top secret session",
+          response_headers = { "id", "timeout", "audience", "subject" }
         }
       })
 
@@ -144,7 +139,7 @@ for _, strategy in helpers.each_strategy() do
       helpers.stop_kong()
     end)
 
-    describe("kong adapter - ", function()
+    describe("kong adapter -", function()
       it("kong adapter stores consumer", function()
         local res, cookie
         local request = {
@@ -167,6 +162,8 @@ for _, strategy in helpers.each_strategy() do
         cookie = assert.response(res).has.header("Set-Cookie")
         client:close()
 
+        local sid = res.headers["Session-Id"]
+
         ngx.sleep(2)
 
         -- use the cookie without the key to ensure cookie still lets them in
@@ -183,8 +180,6 @@ for _, strategy in helpers.each_strategy() do
         assert.response(res).has.status(200)
         client:close()
 
-        -- make sure it's in the db
-        local sid = get_sid_from_cookie(cookie)
         assert.equal(sid, db.sessions:select_by_session_id(sid).session_id)
       end)
 
@@ -267,6 +262,8 @@ for _, strategy in helpers.each_strategy() do
         cookie = assert.response(res).has.header("Set-Cookie")
         client:close()
 
+        local sid = res.headers["Session-Id"]
+
         ngx.sleep(2)
 
         -- use the cookie without the key to ensure cookie still lets them in
@@ -278,7 +275,6 @@ for _, strategy in helpers.each_strategy() do
         client:close()
 
         -- session should be in the table initially
-        local sid = get_sid_from_cookie(cookie)
         assert.equal(sid, db.sessions:select_by_session_id(sid).session_id)
 
         -- logout request


### PR DESCRIPTION
### Summary

Bumps resty.session session from 3.10 to 4.0.0.

This is huge change as the session library was basically rewritten. The session plugin was modified accordingly.

And the clustering compatibility was added.