### PR TITLE
fix(*): reduce bazel memory usage on messy local state and fix bin/busted

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,12 +3,6 @@ load("//build/nfpm:rules.bzl", "nfpm_pkg")
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
 filegroup(
-    name = "srcs",
-    srcs = glob(["**"]),
-    visibility = ["//visibility:public"],
-)
-
-filegroup(
     name = "distribution_srcs",
     srcs = glob(["distribution/**"]),
     visibility = ["//visibility:public"],
@@ -16,7 +10,10 @@ filegroup(
 
 filegroup(
     name = "rockspec_srcs",
-    srcs = glob(["*.rockspec"]),
+    srcs = glob([
+        "kong/**",
+        "*.rockspec",
+    ]),
     visibility = ["//visibility:public"],
 )
 

--- a/bin/busted
+++ b/bin/busted
@@ -30,8 +30,9 @@ if not os.getenv("KONG_BUSTED_RESPAWNED") then
 
   -- rebuild the invoked commandline, while inserting extra resty-flags
   local resty_flags = DEFAULT_RESTY_FLAGS
-  local cmd = { "exec" }
-  for i = -1, #arg do
+  local cmd = { "exec", "/usr/bin/env", "resty" }
+  local cmd_prefix_count = #cmd
+  for i = 0, #arg do
     if arg[i]:sub(1, 12) == "RESTY_FLAGS=" then
       resty_flags = arg[i]:sub(13, -1)
 
@@ -41,7 +42,7 @@ if not os.getenv("KONG_BUSTED_RESPAWNED") then
   end
 
   if resty_flags then
-    table.insert(cmd, 3, resty_flags)
+    table.insert(cmd, cmd_prefix_count+1, resty_flags)
   end
 
   table.insert(script, table.concat(cmd, " "))


### PR DESCRIPTION
<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

This patch remove watch of dangeling local files so that bazel memory usage can remain small.

This patch also makes `bin/busted` be able to run with `resty-cli` with args. Consider this
```
/path/to/resty -I lualib_path --nginx nginx_path bin/busted x
```
the current logic will be broken because arg will be
```
{
 [-5] = "/path/to/resty",
 [0] = "bin/busted",
 [1] = "x",
}
```

In this patch, `$0` (resty-cli path) is not read from `arg[-1]` but using `/usr/bin/env resty` instead.

### Full changelog

* [fix(busted): allow busted to be called with resty with extra args](https://github.com/Kong/kong/commit/973f2674efe6424b1a9628fe46944dcd3a49776c)
* [chore(build): reduce memory usage by removing unused filegroup](https://github.com/Kong/kong/commit/25bf4ecf6bfddcd115c16d432c7565abfd11f76e)

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_
